### PR TITLE
fix(thread-ownership): cap mention cache and bound forwarder JSON reads

### DIFF
--- a/extensions/thread-ownership/index.test.ts
+++ b/extensions/thread-ownership/index.test.ts
@@ -1,7 +1,7 @@
 // Thread Ownership tests cover index plugin behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawPluginApi } from "./api.js";
-import register from "./index.js";
+import register, { resetMentionedThreadsForTests } from "./index.js";
 
 describe("thread-ownership plugin", () => {
   const hooks: Record<string, Function> = {};
@@ -50,6 +50,7 @@ describe("thread-ownership plugin", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    resetMentionedThreadsForTests();
     for (const key of Object.keys(hooks)) {
       delete hooks[key];
     }
@@ -501,6 +502,44 @@ describe("thread-ownership plugin", () => {
       );
 
       expect(globalThis.fetch).toHaveBeenCalled();
+    });
+
+    it("evicts oldest mention cache entries once the cache exceeds its cap", async () => {
+      await hooks.message_received(
+        {
+          content: "hey @TestBot help",
+          threadId: "1111.0001",
+          metadata: { channelId: "C000" },
+        },
+        { channelId: "slack", conversationId: "C000" },
+      );
+
+      for (let i = 1; i <= 1000; i += 1) {
+        await hooks.message_received(
+          {
+            content: "hey @TestBot help",
+            threadId: `2222.${i.toString().padStart(4, "0")}`,
+            metadata: { channelId: `C${i.toString().padStart(3, "0")}` },
+          },
+          { channelId: "slack", conversationId: `C${i.toString().padStart(3, "0")}` },
+        );
+      }
+
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ owner: "test-agent" }), { status: 200 }),
+      );
+
+      await hooks.message_sending(
+        {
+          content: "On it!",
+          replyToId: "1111.0001",
+          metadata: { channelId: "C000" },
+          to: "C000",
+        },
+        { channelId: "slack", conversationId: "C000" },
+      );
+
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/extensions/thread-ownership/index.ts
+++ b/extensions/thread-ownership/index.ts
@@ -1,5 +1,7 @@
 // Thread Ownership plugin entrypoint registers its OpenClaw integration.
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import { resolveLivePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { escapeRegExp } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
@@ -22,6 +24,7 @@ type ThreadOwnershipMessageSendingResult = { cancel: true } | undefined;
 // Entries expire after 5 minutes.
 const mentionedThreads = new Map<string, number>();
 const MENTION_TTL_MS = 5 * 60 * 1000;
+const MENTIONED_THREADS_MAX_ENTRIES = 1000;
 
 function isThreadOwnershipConfig(value: unknown): value is ThreadOwnershipConfig {
   return value !== null && typeof value === "object";
@@ -49,6 +52,15 @@ function cleanExpiredMentions(): void {
       mentionedThreads.delete(key);
     }
   }
+}
+
+function trackMentionedThread(key: string): void {
+  cleanExpiredMentions();
+  if (mentionedThreads.has(key)) {
+    mentionedThreads.delete(key);
+  }
+  mentionedThreads.set(key, Date.now());
+  pruneMapToMaxSize(mentionedThreads, MENTIONED_THREADS_MAX_ENTRIES);
 }
 
 function containsAgentNameMention(text: string, agentName: string): boolean {
@@ -136,8 +148,7 @@ export default definePluginEntry({
         containsAgentNameMention(text, agent.name) ||
         (botUserId && text.includes(`<@${botUserId}>`));
       if (mentioned) {
-        cleanExpiredMentions();
-        mentionedThreads.set(`${channelId}:${threadTs}`, Date.now());
+        trackMentionedThread(`${channelId}:${threadTs}`);
       }
     });
 
@@ -189,7 +200,10 @@ export default definePluginEntry({
             return undefined;
           }
           if (resp.status === 409) {
-            const body = (await resp.json()) as { owner?: string };
+            const body = await readProviderJsonResponse<{ owner?: string }>(
+              resp,
+              "thread-ownership.ownership-conflict",
+            );
             api.logger.info?.(
               `thread-ownership: cancelled send to ${channelId}:${threadTs} — owned by ${body.owner}`,
             );
@@ -208,3 +222,7 @@ export default definePluginEntry({
     });
   },
 });
+
+export function resetMentionedThreadsForTests(): void {
+  mentionedThreads.clear();
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes two thread-ownership resource bounds in the Slack multi-agent plugin:

1. **`mentionedThreads`** — in-memory mention cache with no size cap under sustained @-mention traffic.
2. **409 ownership-conflict JSON reads** — forwarder conflict responses used unbounded `resp.json()` instead of the shared bounded provider JSON reader.

## Why This Change Was Made

Routes mention tracking through `pruneMapToMaxSize` (cap **1 000** entries) and replaces the 409 handler's `resp.json()` call with `readProviderJsonResponse` from `openclaw/plugin-sdk/provider-http`.

## User Impact

Long-lived gateways with high Slack @-mention volume get bounded mention-cache memory. Oversized ownership-conflict JSON bodies fail closed instead of buffering unbounded data.

## Evidence

- `extensions/thread-ownership/index.ts:25–27,59–63` — `mentionedThreads` Map, `MENTIONED_THREADS_MAX_ENTRIES = 1000`, prune after each track
- `extensions/thread-ownership/index.ts:203` — `readProviderJsonResponse` on ownership-conflict responses
- `src/infra/map-size.ts` — shared `pruneMapToMaxSize` helper
- Diff: production changes in `index.ts`; regressions in `index.test.ts`

### Behavior proof

#### 1) Node runtime (production cap + `pruneMapToMaxSize`, no Vitest)

Replays the same key shapes and cap wired in `index.ts`:

```text
=== thread-ownership mention cache cap (production constants + pruneMapToMaxSize) ===
Node: v22.22.0
size after 1001 inserts: 1000
oldest C000:1111.0001 evicted: true
newest retained: true
```

#### 2) Call-site regression tests

```text
$ pnpm test extensions/thread-ownership/index.test.ts --reporter=verbose

 ✓ thread-ownership plugin > message_received @-mention tracking > evicts oldest mention cache entries once the cache exceeds its cap 8ms

 Test Files  1 passed (1)
      Tests  22 passed (22)
   Duration  774ms (transform 274ms, setup 128ms, import 522ms, tests 50ms, environment 0ms)

[test] passed 1 Vitest shard in 4.24s
```

After 1 001 tracked mentions the oldest `{channel}:{thread}` key is evicted; ownership claim / 409 conflict tests still pass with bounded JSON parsing on the production path.

**Proof gap:** No redacted live Slack forwarder or production gateway logs in this validation environment.
