### PR TITLE
fix(googlechat): cap approval binding registries

### DIFF
--- a/extensions/googlechat/src/approval-card-actions.test.ts
+++ b/extensions/googlechat/src/approval-card-actions.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   clearGoogleChatApprovalCardBindingsForTest,
+  getGoogleChatApprovalCardBinding,
   registerGoogleChatManualApprovalFollowupSuppression,
   registerGoogleChatApprovalCardBinding,
   shouldSuppressGoogleChatManualExecApprovalFollowupPayload,
@@ -109,5 +110,73 @@ describe("Google Chat approval card action registry", () => {
         presentation: { blocks: [] },
       }),
     ).toBe(false);
+  });
+
+  it("evicts oldest approval card bindings once the cache exceeds its cap", () => {
+    const firstToken = "token-first";
+    registerGoogleChatApprovalCardBinding({
+      token: firstToken,
+      accountId: "default",
+      approvalId: "approval-first",
+      approvalKind: "exec",
+      decision: "allow-once",
+      allowedDecisions: ["allow-once", "deny"],
+      spaceName: "spaces/AAA",
+      messageName: "spaces/AAA/messages/msg-1",
+      expiresAtMs: Date.now() + 60_000,
+    });
+    expect(getGoogleChatApprovalCardBinding(firstToken)).not.toBeNull();
+
+    for (let i = 1; i <= 1024; i += 1) {
+      registerGoogleChatApprovalCardBinding({
+        token: `token-fill-${i}`,
+        accountId: "default",
+        approvalId: `approval-fill-${i}`,
+        approvalKind: "exec",
+        decision: "allow-once",
+        allowedDecisions: ["allow-once", "deny"],
+        spaceName: "spaces/AAA",
+        messageName: `spaces/AAA/messages/msg-${i}`,
+        expiresAtMs: Date.now() + 60_000,
+      });
+    }
+
+    expect(getGoogleChatApprovalCardBinding(firstToken)).toBeNull();
+    expect(getGoogleChatApprovalCardBinding("token-fill-1024")).not.toBeNull();
+  });
+
+  it("evicts oldest manual approval follow-up suppressions once the cache exceeds its cap", () => {
+    const firstApprovalId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    registerGoogleChatManualApprovalFollowupSuppression({
+      approvalId: firstApprovalId,
+      approvalKind: "exec",
+      allowedDecisions: ["allow-once", "deny"],
+      expiresAtMs: Date.now() + 60_000,
+    });
+    expect(
+      shouldSuppressGoogleChatManualExecApprovalFollowupText(
+        `/approve ${firstApprovalId.slice(0, 8)} allow-once`,
+      ),
+    ).toBe(true);
+
+    for (let i = 1; i <= 1024; i += 1) {
+      registerGoogleChatManualApprovalFollowupSuppression({
+        approvalId: `${i.toString().padStart(8, "0")}-aaaa-aaaa-aaaa-aaaaaaaaaaaa`,
+        approvalKind: "exec",
+        allowedDecisions: ["allow-once", "deny"],
+        expiresAtMs: Date.now() + 60_000,
+      });
+    }
+
+    expect(
+      shouldSuppressGoogleChatManualExecApprovalFollowupText(
+        `/approve ${firstApprovalId.slice(0, 8)} allow-once`,
+      ),
+    ).toBe(false);
+    expect(
+      shouldSuppressGoogleChatManualExecApprovalFollowupText(
+        `/approve ${"1024".padStart(8, "0")} allow-once`,
+      ),
+    ).toBe(true);
   });
 });

--- a/extensions/googlechat/src/approval-card-actions.ts
+++ b/extensions/googlechat/src/approval-card-actions.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import type { ExecApprovalDecision } from "openclaw/plugin-sdk/approval-runtime";
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { GoogleChatActionParameter, GoogleChatEvent } from "./types.js";
 
@@ -25,6 +26,8 @@ export type GoogleChatApprovalCardBinding = {
 
 const approvalCardBindings = new Map<string, GoogleChatApprovalCardBinding>();
 const approvalCardResolvingTokens = new Set<string>();
+const GOOGLECHAT_APPROVAL_CARD_BINDING_MAX_ENTRIES = 1024;
+const GOOGLECHAT_MANUAL_APPROVAL_SUPPRESSION_MAX_ENTRIES = 1024;
 
 type GoogleChatManualApprovalSuppressionPayload = {
   text?: string;
@@ -113,7 +116,11 @@ export function registerGoogleChatApprovalCardBinding(
   if (binding.expiresAtMs <= Date.now()) {
     return false;
   }
+  if (approvalCardBindings.has(binding.token)) {
+    approvalCardBindings.delete(binding.token);
+  }
   approvalCardBindings.set(binding.token, binding);
+  pruneMapToMaxSize(approvalCardBindings, GOOGLECHAT_APPROVAL_CARD_BINDING_MAX_ENTRIES);
   registerGoogleChatManualApprovalFollowupSuppression({
     approvalId: binding.approvalId,
     approvalKind: binding.approvalKind,
@@ -156,7 +163,14 @@ export function registerGoogleChatManualApprovalFollowupSuppression(
   if (!key) {
     return false;
   }
+  if (manualApprovalFollowupSuppressions.has(key)) {
+    manualApprovalFollowupSuppressions.delete(key);
+  }
   manualApprovalFollowupSuppressions.set(key, suppression);
+  pruneMapToMaxSize(
+    manualApprovalFollowupSuppressions,
+    GOOGLECHAT_MANUAL_APPROVAL_SUPPRESSION_MAX_ENTRIES,
+  );
   return true;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes two unbounded in-process Maps in the Google Chat approval flow:

1. **`approvalCardBindings`** — maps approval tokens to in-flight native Google Chat interactive card state. No eviction path; on a long-lived gateway with high approval-card throughput this Map grows without limit.
2. **`manualApprovalFollowupSuppressions`** — tracks approval IDs to suppress duplicate follow-up text after native card delivery. Same unbounded growth pattern.

## Why This Change Was Made

Applies `pruneMapToMaxSize` from `openclaw/plugin-sdk/collection-runtime` immediately after every `.set` call on both Maps, each capped at **1 024 entries** with LRU eviction. An evicted binding simply cannot be resolved — the same behavior as a gateway restart.

## User Impact

Operators running Google Chat channels with high approval-card volume on long-lived gateways get bounded memory for both registries. Behavior is unchanged for the first 1 024 simultaneous in-flight approval cards.

## Evidence

- `extensions/googlechat/src/approval-card-actions.ts:27–30` — module-level `approvalCardBindings` and `manualApprovalFollowupSuppressions` Maps
- `extensions/googlechat/src/approval-card-actions.ts:123,170–173` — `pruneMapToMaxSize` after each `.set`
- `src/infra/map-size.ts` — shared `pruneMapToMaxSize` helper re-exported via `openclaw/plugin-sdk/collection-runtime`
- Diff: production changes in `approval-card-actions.ts`; regressions in `approval-card-actions.test.ts`

### Behavior proof

#### 1) Node runtime through production registry exports (no Vitest mocks)

Imports and exercises the real `registerGoogleChatApprovalCardBinding`, `getGoogleChatApprovalCardBinding`, `registerGoogleChatManualApprovalFollowupSuppression`, and `shouldSuppressGoogleChatManualExecApprovalFollowupText` helpers from `approval-card-actions.ts`:

```text
=== Google Chat approval registry cap proof (Node runtime, production exports, no Vitest) ===
Node: v22.22.0

[approvalCardBindings] after first register: resolvable=true
after 1025 total registers:
  oldest token-first evicted: true
  newest token-fill-1024 retained: true

[manualApprovalFollowupSuppressions] after 1025 registers:
  oldest first approval suppressed before fill: true
  oldest first approval suppressed after fill: false
  newest 1024-padded approval suppressed: true
```

Space names redacted. This shows both registries stay bounded at 1024 entries and evict oldest insertion-order records once the cap is exceeded.

#### 2) Call-site regression tests

```text
$ pnpm test extensions/googlechat/src/approval-card-actions.test.ts --reporter=verbose

 ✓ evicts oldest approval card bindings once the cache exceeds its cap
 ✓ evicts oldest manual approval follow-up suppressions once the cache exceeds its cap

 Test Files  1 passed (1)
      Tests  6 passed (6)
```

Regressions register 1 025 entries and confirm:
- oldest approval-card token `token-first` becomes unresolvable while `token-fill-1024` remains resolvable
- oldest manual follow-up suppression stops matching while the newest padded approval ID still suppresses

**Proof gap:** No redacted live Google Chat native approval-card delivery or button-click transcript in this validation environment. Node runtime plus registry regressions cover the production in-process Maps; optional supplemental proof is a redacted gateway log showing approval-card registration under sustained throughput with stable memory.
