### PR TITLE
fix(codex): cap compaction override warning cache via createDedupeCache

### DIFF
--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -1712,6 +1712,59 @@ describe("maybeCompactCodexAppServerSession", () => {
     warn.mockRestore();
   });
 
+  it("bounds ignored compaction override warnings through the compact entry point", async () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const info = vi.spyOn(embeddedAgentLog, "info").mockImplementation(() => undefined);
+
+    async function runWithIgnoredOverrides(index: number): Promise<void> {
+      const agentId = `cap-${index}`;
+      await maybeCompactCodexAppServerSession({
+        sessionId: `session-${index}`,
+        sessionKey: `agent:${agentId}:session-${index}`,
+        sessionFile: path.join(tempDir, `${agentId}.jsonl`),
+        workspaceDir: tempDir,
+        trigger: "auto",
+        config: {
+          agents: {
+            list: [
+              {
+                id: agentId,
+                compaction: {
+                  model: "openai/gpt-5.4-mini",
+                  provider: "custom-summary",
+                },
+              },
+            ],
+          },
+        },
+      });
+    }
+
+    for (let index = 0; index < 4_097; index += 1) {
+      await runWithIgnoredOverrides(index);
+    }
+
+    expect(warn).toHaveBeenCalledTimes(4_097);
+    await runWithIgnoredOverrides(4_096);
+    expect(warn).toHaveBeenCalledTimes(4_097);
+
+    await runWithIgnoredOverrides(0);
+    expect(warn).toHaveBeenCalledTimes(4_098);
+    expect(warn.mock.calls.at(-1)).toEqual([
+      "ignoring OpenClaw compaction overrides for Codex app-server compaction; Codex uses native server-side compaction",
+      {
+        sessionId: "session-0",
+        sessionKey: "agent:cap-0:session-0",
+        ignoredConfig: [
+          "agents.list.cap-0.compaction.model",
+          "agents.list.cap-0.compaction.provider",
+        ],
+      },
+    ]);
+    info.mockRestore();
+    warn.mockRestore();
+  });
+
   it("warns when active agent compaction overrides are ignored", async () => {
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
     const fake = createFakeCodexClient();

--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -1723,7 +1723,7 @@ describe("maybeCompactCodexAppServerSession", () => {
         sessionKey: `agent:${agentId}:session-${index}`,
         sessionFile: path.join(tempDir, `${agentId}.jsonl`),
         workspaceDir: tempDir,
-        trigger: "auto",
+        trigger: "budget",
         config: {
           agents: {
             list: [

--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -1740,24 +1740,36 @@ describe("maybeCompactCodexAppServerSession", () => {
       });
     }
 
-    for (let index = 0; index < 4_097; index += 1) {
+    // Fill exactly the advertised 4,096-entry cap: every distinct key warns once.
+    for (let index = 0; index < 4_096; index += 1) {
       await runWithIgnoredOverrides(index);
     }
+    expect(warn).toHaveBeenCalledTimes(4_096);
 
-    expect(warn).toHaveBeenCalledTimes(4_097);
+    // At exactly 4,096 entries the oldest key is still retained, so a duplicate stays suppressed.
+    await runWithIgnoredOverrides(0);
+    expect(warn).toHaveBeenCalledTimes(4_096);
+
+    // The 4,097th distinct key pushes past the cap and evicts the LRU entry. The duplicate
+    // check on key 0 refreshed its recency, so the evicted key is 1.
     await runWithIgnoredOverrides(4_096);
     expect(warn).toHaveBeenCalledTimes(4_097);
 
-    await runWithIgnoredOverrides(0);
+    // The evicted key warns again on reappearance.
+    await runWithIgnoredOverrides(1);
+    expect(warn).toHaveBeenCalledTimes(4_098);
+
+    // A recent duplicate stays suppressed.
+    await runWithIgnoredOverrides(4_096);
     expect(warn).toHaveBeenCalledTimes(4_098);
     expect(warn.mock.calls.at(-1)).toEqual([
       "ignoring OpenClaw compaction overrides for Codex app-server compaction; Codex uses native server-side compaction",
       {
-        sessionId: "session-0",
-        sessionKey: "agent:cap-0:session-0",
+        sessionId: "session-1",
+        sessionKey: "agent:cap-1:session-1",
         ignoredConfig: [
-          "agents.list.cap-0.compaction.model",
-          "agents.list.cap-0.compaction.provider",
+          "agents.list.cap-1.compaction.model",
+          "agents.list.cap-1.compaction.provider",
         ],
       },
     ]);

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -8,6 +8,7 @@ import {
   type EmbeddedAgentCompactResult,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resolveAgentDir, resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
+import { createDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { isIncognitoSessionKey } from "../incognito-session.js";
@@ -42,7 +43,9 @@ import {
 } from "./shared-client.js";
 import { resumeCodexAppServerThread } from "./thread-resume.js";
 
-const warnedIgnoredCompactionOverrides = new Set<string>();
+// ttlMs: 0 retains keys until the 4,096-entry LRU cap evicts them, after which a
+// previously suppressed warning can intentionally emit again.
+const warnedIgnoredCompactionOverrides = createDedupeCache({ ttlMs: 0, maxSize: 4096 });
 const codexNativeCompactionQueue = new KeyedAsyncQueue();
 const CODEX_NATIVE_COMPACTION_INTERRUPT_GRACE_MS = 30_000;
 type CodexAppServerCompactOptions = {
@@ -350,10 +353,9 @@ function warnIfIgnoringOpenClawCompactionOverrides(
     return;
   }
   const warningKey = ignoredConfig.join("\0");
-  if (warnedIgnoredCompactionOverrides.has(warningKey)) {
+  if (warnedIgnoredCompactionOverrides.check(warningKey)) {
     return;
   }
-  warnedIgnoredCompactionOverrides.add(warningKey);
   embeddedAgentLog.warn(
     "ignoring OpenClaw compaction overrides for Codex app-server compaction; Codex uses native server-side compaction",
     {


### PR DESCRIPTION
## What Problem This Solves

The Codex app-server ignored-compaction-override warning used a process-lifetime
`Set<string>`. Every distinct ignored override key remained in memory until the
gateway exited.

## Why This Change Was Made

The warning owner now uses the existing public SDK helper:
`createDedupeCache({ ttlMs: 0, maxSize: 4096 })`.

This preserves ordinary warn-once behavior while bounding retained keys. A key
can warn again only after it is evicted from the 4,096-entry LRU cache.

The change does not alter configuration, persistence, provider routing, or the
Codex RPC.

## User Impact

Gateways with ordinary ignored-override cardinality keep the same warning
behavior. High-cardinality configurations no longer grow this warning cache
without bound.

## Evidence

- Exact reviewed head: `36605735babdbd4ebc8d6733eb6b817fb6acf78a`.
- Current `main` still contains the unbounded module-level `Set`.
- Direct upstream contract inspection at `openai/codex`
  `414782450952a196bbb64b1605a458c2531c47b6`:
  - `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:924-926` defines
    `ThreadCompactStartParams` with only `thread_id`.
  - `codex-rs/app-server/src/request_processors/thread_processor.rs:1755-1766`
    loads that thread and submits `Op::Compact`.
  - `codex-rs/core/src/tasks/compact.rs:17-75` selects native compaction from
    the Codex turn context.
  - OpenClaw model/provider/thinking overrides therefore cannot enter
    `thread/compact/start`; the warning remains accurate.
- Boundary test passed three consecutive runs:
  `node scripts/run-vitest.mjs extensions/codex/src/app-server/compact.test.ts -t "bounds ignored compaction override warnings"`.
- Full focused file passed: 46/46 tests.
- `git diff --check` passed.
- Exact-head CI passed, including `openclaw/ci-gate`:
  https://github.com/openclaw/openclaw/actions/runs/30884809067
- Exact-head ClawSweeper found no actionable code findings:
  https://github.com/openclaw/openclaw/pull/101745#issuecomment-4905330328
- Autoreview was attempted twice; its helper completed secret scanning but hung
  before returning model output, so no autoreview result was available.

Production delta: `+5/-3` (net `+2`). Tests: `+65/-0`.

AI-assisted: built with Codex
