### PR TITLE
fix(infra): bound three warning dedupe caches with createDedupeCache

### DIFF
--- a/src/config/io.clobber-snapshot.test.ts
+++ b/src/config/io.clobber-snapshot.test.ts
@@ -289,38 +289,4 @@ describe("config clobber snapshots", () => {
       expect(contents).toContain(`polluted-${CONFIG_CLOBBER_SNAPSHOT_LIMIT + 2}\n`);
     });
   });
-
-  it("deduplicates clobber-cap warnings on the same config path via the bounded cache", async () => {
-    await withCase(async (configPath) => {
-      const warn = vi.fn();
-      const observedAt = "2026-05-04T00:00:00.000Z";
-
-      await Promise.all(
-        Array.from({ length: CONFIG_CLOBBER_SNAPSHOT_LIMIT + 10 }, async (_, index) => {
-          await persistBoundedClobberedConfigSnapshot({
-            deps: { fs, logger: { warn } },
-            configPath,
-            raw: `dedupe-${index}\n`,
-            observedAt,
-          });
-        }),
-      );
-
-      const capWarnings = warn.mock.calls.filter(
-        ([message]) =>
-          typeof message === "string" && message.includes("Config clobber snapshot cap reached"),
-      );
-      // warnClobberCapReached → clobberCapWarnedPaths.check(configPath)
-      // suppresses duplicates: only 1 warning per unique configPath.
-      expect(capWarnings.length).toBe(1);
-    });
-  });
-});
-
-describe("clobberCapWarnedPaths", () => {
-  it("loads the module with a bounded dedupe cache", async () => {
-    vi.resetModules();
-    const mod = await import("./io.clobber-snapshot.js");
-    expect(mod.persistBoundedClobberedConfigSnapshot).toBeDefined();
-  });
 });

--- a/src/config/io.clobber-snapshot.test.ts
+++ b/src/config/io.clobber-snapshot.test.ts
@@ -290,3 +290,11 @@ describe("config clobber snapshots", () => {
     });
   });
 });
+
+describe("clobberCapWarnedPaths", () => {
+  it("loads the module with a bounded dedupe cache", async () => {
+    vi.resetModules();
+    const mod = await import("./io.clobber-snapshot.js");
+    expect(mod.persistBoundedClobberedConfigSnapshot).toBeDefined();
+  });
+});

--- a/src/config/io.clobber-snapshot.test.ts
+++ b/src/config/io.clobber-snapshot.test.ts
@@ -289,6 +289,32 @@ describe("config clobber snapshots", () => {
       expect(contents).toContain(`polluted-${CONFIG_CLOBBER_SNAPSHOT_LIMIT + 2}\n`);
     });
   });
+
+  it("deduplicates clobber-cap warnings on the same config path via the bounded cache", async () => {
+    await withCase(async (configPath) => {
+      const warn = vi.fn();
+      const observedAt = "2026-05-04T00:00:00.000Z";
+
+      await Promise.all(
+        Array.from({ length: CONFIG_CLOBBER_SNAPSHOT_LIMIT + 10 }, async (_, index) => {
+          await persistBoundedClobberedConfigSnapshot({
+            deps: { fs, logger: { warn } },
+            configPath,
+            raw: `dedupe-${index}\n`,
+            observedAt,
+          });
+        }),
+      );
+
+      const capWarnings = warn.mock.calls.filter(
+        ([message]) =>
+          typeof message === "string" && message.includes("Config clobber snapshot cap reached"),
+      );
+      // warnClobberCapReached → clobberCapWarnedPaths.check(configPath)
+      // suppresses duplicates: only 1 warning per unique configPath.
+      expect(capWarnings.length).toBe(1);
+    });
+  });
 });
 
 describe("clobberCapWarnedPaths", () => {

--- a/src/config/io.clobber-snapshot.ts
+++ b/src/config/io.clobber-snapshot.ts
@@ -1,5 +1,6 @@
 // Detects suspicious config clobbers and finds recovery snapshots.
 import path from "node:path";
+import { createDedupeCache } from "../infra/dedupe.js";
 import { sleep } from "../utils/sleep.js";
 
 /** Maximum retained clobbered-config snapshots per config file. */
@@ -8,7 +9,10 @@ const CONFIG_CLOBBER_SNAPSHOT_LIMIT = 32;
 const CONFIG_CLOBBER_LOCK_STALE_MS = 30_000;
 const CONFIG_CLOBBER_LOCK_RETRY_MS = 10;
 const CONFIG_CLOBBER_LOCK_TIMEOUT_MS = 2_000;
-const clobberCapWarnedPaths = new Set<string>();
+const clobberCapWarnedPaths = createDedupeCache({
+  ttlMs: 0,
+  maxSize: 4096,
+});
 
 type ConfigClobberSnapshotFs = {
   promises: {
@@ -210,10 +214,9 @@ function warnClobberCapReached(
   configPath: string,
   existing: number,
 ): void {
-  if (clobberCapWarnedPaths.has(configPath)) {
+  if (clobberCapWarnedPaths.check(configPath)) {
     return;
   }
-  clobberCapWarnedPaths.add(configPath);
   deps.logger.warn(
     `Config clobber snapshot cap reached for ${configPath}: ${existing} existing .clobbered.* files; rotating oldest snapshots to preserve the latest forensic copy.`,
   );

--- a/src/infra/dedupe.test.ts
+++ b/src/infra/dedupe.test.ts
@@ -33,6 +33,11 @@ describe("createDedupeCache", () => {
     expect(cache.peek("a", 500)).toBe(true);
     expect(cache.peek("b", 500)).toBe(false);
     expect(cache.peek("c", 500)).toBe(true);
+
+    expect(cache.check("b", 600)).toBe(false);
+    expect(cache.peek("a", 700)).toBe(false);
+    expect(cache.peek("b", 700)).toBe(true);
+    expect(cache.peek("c", 700)).toBe(true);
   });
 
   it("clears itself when maxSize floors to zero", () => {

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -7,6 +7,7 @@ import {
   type InterpreterInlineEvalHit,
 } from "../infra/command-analysis/inline-eval.js";
 import { detectPolicyInlineEval } from "../infra/command-analysis/policy.js";
+import { createDedupeCache } from "../infra/dedupe.js";
 import {
   commitExecAuthorizationLocked,
   commandRequiresSecurityAuditSuppressionApproval,
@@ -145,7 +146,10 @@ type SystemRunPolicyPhase = SystemRunParsePhase & {
   approvedCwdSnapshot: ApprovedCwdSnapshot | undefined;
 };
 
-const safeBinTrustedDirWarningCache = new Set<string>();
+const safeBinTrustedDirWarningCache = createDedupeCache({
+  ttlMs: 0,
+  maxSize: 4096,
+});
 const APPROVAL_CWD_DRIFT_DENIED_MESSAGE =
   "SYSTEM_RUN_DENIED: approval cwd changed before execution";
 const APPROVAL_SCRIPT_OPERAND_BINDING_DENIED_MESSAGE =
@@ -166,10 +170,9 @@ type EffectiveSystemRunExecPolicy = {
 };
 
 function warnWritableTrustedDirOnce(message: string): void {
-  if (safeBinTrustedDirWarningCache.has(message)) {
+  if (safeBinTrustedDirWarningCache.check(message)) {
     return;
   }
-  safeBinTrustedDirWarningCache.add(message);
   logWarn(message);
 }
 

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { buildApprovalResolutionRef } from "../infra/approval-resolution-ref.js";
+import { createDedupeCache } from "../infra/dedupe.js";
 import {
   clearNodeSqliteKyselyCacheForDatabase,
   executeSqliteQuerySync,
@@ -180,7 +181,10 @@ export function assertOpenClawStateDatabaseForMaintenance(
 const stateDbLog = createSubsystemLogger("state/db");
 
 /** Targets already warned about, so chmod-less filesystems warn once per path. */
-const chmodWarnedTargets = new Set<string>();
+const chmodWarnedTargets = createDedupeCache({
+  ttlMs: 0,
+  maxSize: 4096,
+});
 
 // Permission hardening is best-effort only on filesystems that cannot apply
 // it: the database stays usable without the chmod, and crashing at open would
@@ -188,10 +192,9 @@ const chmodWarnedTargets = new Set<string>();
 // chmod failures still throw so credentials-adjacent hardening stays loud.
 function bestEffortChmodSync(target: string, mode: number): void {
   const result = applyPrivateModeSync(target, mode);
-  if (result.applied || chmodWarnedTargets.has(target)) {
+  if (result.applied || chmodWarnedTargets.check(target)) {
     return;
   }
-  chmodWarnedTargets.add(target);
   stateDbLog.warn(`skipped permission hardening for ${target}: ${String(result.error)}`);
 }
 


### PR DESCRIPTION
## What Problem This Solves

Three process-lifetime warning dedupe sets accept path- or message-derived keys and never evict them. Long-running gateways that encounter many state paths, config paths, or writable trusted directories can grow those sets without a bound.

## Why This Change Was Made

Replace each set with the shared `createDedupeCache({ ttlMs: 0, maxSize: 4096 })`. This preserves warn-once behavior below the cap, promotes repeated hot keys, and admits cold keys again after eviction. The config-clobber, system-run, and state-DB owners keep their existing warning text and failure handling.

## User Impact

Normal warning behavior is unchanged. After more than 4096 distinct warning keys in one process, an evicted cold key can warn again instead of consuming memory forever.

## Evidence

- `node scripts/run-vitest.mjs src/infra/dedupe.test.ts src/config/io.clobber-snapshot.test.ts` — 2 files, 11 tests passed.
- `node scripts/run-vitest.mjs src/node-host/invoke-system-run.test.ts` — 1 file, 72 tests passed.
- `node scripts/run-vitest.mjs src/state/openclaw-state-db.test.ts` — 77 passed, 1 skipped.
- `node scripts/check-changed.mjs -- src/infra/dedupe.test.ts src/config/io.clobber-snapshot.ts src/node-host/invoke-system-run.ts src/state/openclaw-state-db.ts` — conflict, max-lines, attribution, export, duplicate-coverage, dependency-pin, and formatting checks passed on Testbox. The run stopped only at the known current-main Plugin SDK baseline drift: https://github.com/openclaw/openclaw/actions/runs/29527725576
- Fresh full-branch autoreview: clean, 0.98 confidence.

AI-assisted maintainer revision. Contributor credit preserved.
