### PR TITLE
test(gateway): cover unloaded channel restart

### DIFF
--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -560,6 +560,12 @@ describe("buildGatewayReloadPlan", () => {
     ]);
 
     setActivePluginRegistry(emptyRegistry);
+    expect(buildGatewayReloadPlan(["channels.whatsapp.enabled"])).toMatchObject({
+      restartGateway: true,
+      restartReasons: ["channels.whatsapp.enabled"],
+      restartChannels: new Set(),
+      noopPaths: [],
+    });
     expect(buildGatewayReloadPlan(["channels.telegram.botToken"])).toMatchObject({
       restartGateway: true,
       restartChannels: new Set(),


### PR DESCRIPTION
## What Problem This Solves

An unloaded channel plugin contributes no active reload metadata. Enabling its channel config must therefore fall back to a full Gateway restart; otherwise a future broad WhatsApp no-op fallback could silently accept the change while the plugin remains unavailable.

## Why This Change Was Made

Extend the existing active-registry transition test with the specific `channels.whatsapp.enabled` case. The assertion verifies the exact restart reason and empty channel-restart/no-op outputs at the owner boundary, without duplicating the Gateway reload test setup or changing runtime behavior.

The latest ClawSweeper rank-up move asked for a clean current-main transplant and refreshed focused proof. This head is rewritten from current `origin/main`, and the assertion now lives in the existing registry-transition test.

## User Impact

No runtime behavior changes. The regression test protects the restart fallback required to make newly enabled, previously unloaded channels available after Gateway startup.

## Evidence

- Regression sensitivity: with a temporary leaked base `channels.whatsapp` no-op rule, `node scripts/run-vitest.mjs src/gateway/config-reload.test.ts -t 'refreshes channel rules when the tracked channel registry changes'` failed in all three routed Gateway projects. The observed plan had `restartGateway: false`, no restart reasons, and `noopPaths: ["channels.whatsapp.enabled"]`.
- Repaired owner boundary: after removing that temporary mutation, the same focused command passed 3/3 tests with 519 skipped.
- Full focused file: `node scripts/run-vitest.mjs src/gateway/config-reload.test.ts` passed 174/174 tests in the Gateway shard.
- Changed-file gate: `node scripts/check-changed.mjs` passed on Blacksmith Testbox `tbx_01kzjnynb47jrjhnfgbz2wabks` (core test typecheck, formatting, lint, dead-code scan, and repository guards): https://github.com/openclaw/openclaw/actions/runs/31300686133
- Codex-backed autoreview: clean after one round, no accepted/actionable findings; correctness 0.99.
- `git diff --check` passed.
