### PR TITLE
fix(control-ui): show unavailable sizes for negative byte counts

### DIFF
--- a/ui/src/lib/agents/display.test.ts
+++ b/ui/src/lib/agents/display.test.ts
@@ -17,6 +17,7 @@ import {
 describe("formatBytes", () => {
   it("preserves the Control UI byte-size display contract", () => {
     expect(formatBytes(undefined)).toBe("-");
+    expect(formatBytes(-1)).toBe("-");
     expect(formatBytes(512)).toBe("512 B");
     expect(formatBytes(1536)).toBe("1.5 KB");
     expect(formatBytes(12 * 1024)).toBe("12 KB");

--- a/ui/src/lib/agents/display.ts
+++ b/ui/src/lib/agents/display.ts
@@ -325,7 +325,7 @@ export function agentBadgeText(agentId: string, defaultId: string | null) {
 }
 
 export function formatBytes(bytes?: number) {
-  if (bytes == null || !Number.isFinite(bytes)) {
+  if (bytes == null || !Number.isFinite(bytes) || bytes < 0) {
     return "-";
   }
   return formatByteSize(bytes, {


### PR DESCRIPTION
## What Problem This Solves

Fixes a narrow Control UI display bug where a finite negative byte metric was formatted as a real size instead of using the existing unavailable marker.

`formatBytes()` already treats missing and non-finite values as unavailable, but values such as `-1` previously reached `formatByteSize()` and rendered as `-1 B`.

## Why This Change Was Made

The fix stays at the Control UI display boundary. The shared byte formatter remains unchanged; the UI wrapper now rejects negative cardinal values alongside nullish and non-finite inputs.

```diff
 export function formatBytes(bytes?: number) {
-  if (bytes == null || !Number.isFinite(bytes)) {
+  if (bytes == null || !Number.isFinite(bytes) || bytes < 0) {
     return "-";
   }
```

## User Impact

Malformed or sentinel-like negative byte counts now display as `-`. Zero and positive sizes keep their existing formatting.

```text
undefined -> -
-1        -> -
0         -> 0 B
512       -> 512 B
1536      -> 1.5 KB
```

## Evidence

Current-branch behavior proof against the real shared formatter:

```text
base main:
formatBytes(-1): -1 B
formatBytes(0): 0 B
formatBytes(512): 512 B
formatBytes(1536): 1.5 KB

PR head:
formatBytes(-1): -
formatBytes(0): 0 B
formatBytes(512): 512 B
formatBytes(1536): 1.5 KB
```

Possible call chain:

```text
Control UI status/detail data
  -> formatBytes(bytes)
  -> unavailable guard for nullish, non-finite, or negative values
  -> formatByteSize(...) for valid zero/positive values
  -> rendered byte-size label
```

Validation on current head `1d68a5fb71d`:

- focused UI Vitest: 17 tests passed
- `oxfmt` passed on the touched files
- `oxlint` passed on the touched files
- `git diff --check` passed
- GitHub CI is green with no failed or pending checks

AI-assisted: drafted and validated with Codex; I reviewed the change and understand the behavior.
