### PR TITLE
fix: keep emoji intact at remaining text truncation boundaries

### DIFF
--- a/src/gateway/server-methods/restart.test.ts
+++ b/src/gateway/server-methods/restart.test.ts
@@ -95,6 +95,18 @@ describe("gateway.restart.request handler", () => {
     expectRestartRequest(false);
   });
 
+  it("backs off before an emoji that crosses the reason limit", async () => {
+    mockScheduledRestart({ safe: true, summary: "safe to restart now" });
+
+    await invokeRestartRequest({ reason: "x".repeat(199) + "🧠tail" });
+
+    expect(requestSafeGatewayRestart).toHaveBeenCalledWith({
+      reason: "x".repeat(199),
+      delayMs: 0,
+      skipDeferral: false,
+    });
+  });
+
   it("rejects non-object params without scheduling a restart", async () => {
     const respond = await invokeRestartRequest("operator");
 

--- a/src/gateway/server-methods/restart.ts
+++ b/src/gateway/server-methods/restart.ts
@@ -1,4 +1,5 @@
 // Gateway RPC handlers for safe gateway restart requests and preflight state.
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
 import {
   createSafeGatewayRestartPreflight,
@@ -13,7 +14,9 @@ function isRestartRequestParams(value: unknown): value is Record<string, unknown
 function normalizeReason(value: unknown): string | undefined {
   // Restart reasons are operator-visible log context, not payload storage.
   // Trim and cap them before passing through to the coordinator.
-  return typeof value === "string" && value.trim() ? value.trim().slice(0, 200) : undefined;
+  return typeof value === "string" && value.trim()
+    ? truncateUtf16Safe(value.trim(), 200)
+    : undefined;
 }
 
 function normalizeSkipDeferral(value: unknown): boolean {

--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -136,6 +136,15 @@ describe("infra runtime", () => {
       await vi.runAllTimersAsync();
     });
 
+    it("backs off before an emoji that crosses the restart reason limit", () => {
+      const restart = scheduleGatewaySigusr1Restart({
+        delayMs: 0,
+        reason: "x".repeat(199) + "🧠tail",
+      });
+
+      expect(restart.reason).toBe("x".repeat(199));
+    });
+
     it("tracks external restart policy", () => {
       expect(isGatewaySigusr1RestartExternallyAllowed()).toBe(false);
       setGatewaySigusr1RestartPolicy({ allowExternal: true });

--- a/src/infra/restart-intent.test.ts
+++ b/src/infra/restart-intent.test.ts
@@ -141,6 +141,15 @@ describe("gateway restart intent", () => {
     expect(fs.existsSync(legacyIntentPath(env))).toBe(false);
   });
 
+  it("backs off before an emoji that crosses the persisted reason limit", () => {
+    const env = createIntentEnv();
+    insertIntentRow(env, { reason: "x".repeat(199) + "🧠tail" });
+
+    expect(consumeGatewayRestartIntentPayloadSync(env)).toEqual({
+      reason: "x".repeat(199),
+    });
+  });
+
   it("overwrites the previous pending intent row", () => {
     const env = createIntentEnv();
     expect(

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -843,10 +843,7 @@ export function scheduleGatewaySigusr1Restart(opts?: {
       ? Math.floor(opts.delayMs)
       : 2000;
   const delayMs = Math.min(Math.max(delayMsRaw, 0), 60_000);
-  const reason =
-    typeof opts?.reason === "string" && opts.reason.trim()
-      ? truncateUtf16Safe(opts.reason.trim(), 200)
-      : undefined;
+  const reason = normalizeRestartIntentReason(opts?.reason);
   const hasSigusr1Listener = process.listenerCount("SIGUSR1") > 0;
   const mode = hasSigusr1Listener ? "emit" : process.platform === "win32" ? "supervisor" : "signal";
   const nowMs = Date.now();

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -2,6 +2,7 @@
 import { spawnSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { getRuntimeConfig } from "../config/config.js";
 import {
   resolveGatewayLaunchAgentLabel,
@@ -279,7 +280,7 @@ function readGatewayRestartIntentPayloadSync(
 
 function normalizeRestartIntentReason(reason: string | undefined): string | undefined {
   const normalized = reason?.trim();
-  return normalized ? normalized.slice(0, 200) : undefined;
+  return normalized ? truncateUtf16Safe(normalized, 200) : undefined;
 }
 
 export function consumeGatewayRestartIntentPayloadSync(
@@ -844,7 +845,7 @@ export function scheduleGatewaySigusr1Restart(opts?: {
   const delayMs = Math.min(Math.max(delayMsRaw, 0), 60_000);
   const reason =
     typeof opts?.reason === "string" && opts.reason.trim()
-      ? opts.reason.trim().slice(0, 200)
+      ? truncateUtf16Safe(opts.reason.trim(), 200)
       : undefined;
   const hasSigusr1Listener = process.listenerCount("SIGUSR1") > 0;
   const mode = hasSigusr1Listener ? "emit" : process.platform === "win32" ? "supervisor" : "signal";

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -4049,6 +4049,24 @@ describe("right-click Reply", () => {
     expect(target.senderLabel).toBe("User");
   });
 
+  it("backs off before an emoji that crosses the reply target limit", () => {
+    const onSetReply = vi.fn();
+    const container = renderChatView({ onSetReply });
+    const section = container.querySelector<HTMLElement>(".card.chat");
+    const group = document.createElement("div");
+    group.className = "chat-group";
+    const bubble = document.createElement("div");
+    bubble.className = "chat-bubble";
+    bubble.dataset.messageText = "x".repeat(499) + "🧠tail";
+    group.appendChild(bubble);
+    section!.querySelector(".chat-thread-inner")!.appendChild(group);
+
+    bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    document.querySelector<HTMLButtonElement>(".chat-reply-context-menu button")!.click();
+
+    expect(onSetReply.mock.calls[0][0].text).toBe("x".repeat(499));
+  });
+
   it("keeps the native context menu when Reply is unavailable", () => {
     const container = renderChatView();
     const section = container.querySelector<HTMLElement>(".card.chat");
@@ -4127,6 +4145,20 @@ describe("right-click Reply", () => {
 
     const dismiss = preview!.querySelector<HTMLButtonElement>(".chat-reply-preview__dismiss");
     expect(dismiss).not.toBeNull();
+  });
+
+  it("backs off before an emoji that crosses the reply preview limit", () => {
+    const container = renderChatView({
+      replyTarget: {
+        messageId: "msg-emoji",
+        text: "x".repeat(119) + "🧠tail",
+        senderLabel: "User",
+      },
+    });
+
+    expect(container.querySelector(".chat-reply-preview__text")?.textContent).toBe(
+      `${"x".repeat(119)}...`,
+    );
   });
 
   it("calls onClearReply when dismiss button is clicked", () => {

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -1,5 +1,5 @@
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 // Chat-owned composer, queue, status, context, and run controls.
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing, type TemplateResult } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { ref } from "lit/directives/ref.js";

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -1,3 +1,4 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 // Chat-owned composer, queue, status, context, and run controls.
 import { html, nothing, type TemplateResult } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -7,11 +8,11 @@ import type { GatewaySessionRow, SessionGoal, SessionsListResult } from "../../.
 import { normalizeChatSendShortcut, type ChatSendShortcut } from "../../../app/settings.ts";
 import { icons, type IconName } from "../../../components/icons.ts";
 import { toSanitizedMarkdownHtml } from "../../../components/markdown.ts";
+import "../../../components/tooltip.ts";
 import {
   renderProviderQuotaPill,
   type ProviderQuotaPillProps,
 } from "../../../components/provider-quota-pill.ts";
-import "../../../components/tooltip.ts";
 import { t } from "../../../i18n/index.ts";
 import type { ChatAttachment, ChatQueueItem } from "../../../lib/chat/chat-types.ts";
 import {
@@ -2216,7 +2217,8 @@ export function renderChatComposer(props: ChatComposerProps) {
                   >Replying to ${props.replyTarget.senderLabel ?? "message"}</span
                 >
                 <span class="chat-reply-preview__text"
-                  >${props.replyTarget.text.slice(0, 120)}${props.replyTarget.text.length > 120
+                  >${truncateUtf16Safe(props.replyTarget.text, 120)}${props.replyTarget.text
+                    .length > 120
                     ? "..."
                     : ""}</span
                 >

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -1,3 +1,4 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 // Chat-owned message thread presentation and thread-local interaction state.
 import { html, nothing, type TemplateResult } from "lit";
 import { guard } from "lit/directives/guard.js";
@@ -431,7 +432,7 @@ export function renderChatPinnedMessages(
                       >${role === "user" ? userRoleLabel : "Assistant"}</span
                     >
                     <span class="agent-chat__pinned-text"
-                      >${text.slice(0, 100)}${text.length > 100 ? "..." : ""}</span
+                      >${truncateUtf16Safe(text, 100)}${text.length > 100 ? "..." : ""}</span
                     >
                     <openclaw-tooltip content="Unpin">
                       <button
@@ -531,7 +532,7 @@ function handleChatContextMenu(event: MouseEvent, props: ChatThreadProps) {
   }
   const senderEl = group.querySelector(".chat-sender-name");
   const senderLabel = senderEl?.textContent?.trim() ?? undefined;
-  const text = (bubble as HTMLElement).dataset.messageText?.trim().slice(0, 500) ?? "";
+  const text = truncateUtf16Safe((bubble as HTMLElement).dataset.messageText?.trim() ?? "", 500);
   if (!text) {
     return;
   }

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -1,5 +1,5 @@
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 // Chat-owned message thread presentation and thread-local interaction state.
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing, type TemplateResult } from "lit";
 import { guard } from "lit/directives/guard.js";
 import { ref } from "lit/directives/ref.js";


### PR DESCRIPTION
## What Problem This Solves

Restart reasons and Control UI chat previews still had raw UTF-16 slicing boundaries. If an emoji crossed one of those caps, the returned or rendered string could end with a lone surrogate.

## Why This Change Was Made

Use the existing `truncateUtf16Safe` primitive at each user-visible boundary. The maintainer fixup also makes `scheduleGatewaySigusr1Restart` reuse the restart module's existing reason normalizer and covers the equivalent gateway RPC boundary, so restart reasons have one consistent contract from input through persisted intent and scheduling.

## User Impact

- Gateway restart reasons stay valid when supplied through RPC, scheduling, or persisted restart intent.
- Reply targets, reply previews, and pinned-message previews no longer render malformed emoji at their limits.
- Ordinary text and all existing maximum lengths remain unchanged.

## Evidence

- Exact-output regression coverage: gateway RPC reason, scheduler reason, persisted restart reason, reply target, and reply preview.
- Existing Control UI and restart code paths are exercised rather than testing the helper in isolation.
- Fresh maintainer autoreview: clean, confidence 0.97.
- Exact-head CI: [run 28880798105](https://github.com/openclaw/openclaw/actions/runs/28880798105), success at `e5bab02257c814892936aac182fbf8a35cb93994`.
- OpenGrep and CodeQL exact-head checks: success.

## Scope

Eight files; no config, protocol, dependency, migration, or compatibility change. AI-assisted; maintainer-reviewed and expanded to the complete restart boundary.
