### PR TITLE
Create Claw agent and root install record

### DIFF
--- a/docs/cli/claws.md
+++ b/docs/cli/claws.md
@@ -1,8 +1,8 @@
 ---
-summary: "Validate and preview experimental Claw agent packages"
+summary: "Validate, preview, and add experimental Claw agent packages"
 read_when:
   - You want to validate a grouped Claw manifest
-  - You want to preview adding one agent from a Claw
+  - You want to preview or add one agent from a Claw
 title: "Claws"
 ---
 
@@ -62,21 +62,31 @@ openclaw claws add ./incident-triage.claw.json --dry-run --json
 ```
 
 The plan reports the derived agent and workspace, every proposed action,
-prerequisites, blockers, and distinct capability escalations. Capability records
-show the exact package, MCP, scheduled-work, sandbox, tool, or heartbeat effect
-and are included in plan integrity. Use `--agent-id` or
-`--workspace` to preview alternatives when package defaults collide with local
-state.
+prerequisites, blockers, distinct capability escalations, and a `planIntegrity`
+digest. Capability records show the exact package, MCP, scheduled-work, sandbox,
+tool, or heartbeat effect. Review the plan before creating the agent:
 
-This initial experimental command is read-only. `claws add` requires
-`--dry-run` and does not create the agent or mutate OpenClaw state.
+```bash
+openclaw claws add ./incident-triage.claw.json \
+  --yes \
+  --plan-integrity <SHA256_FROM_DRY_RUN>
+```
+
+`--yes` alone is insufficient. OpenClaw rebuilds the plan and rejects consent
+when the source, destination, or live configuration changed after preview. Use
+`--agent-id` or `--workspace` during both preview and apply when package
+defaults collide with local state.
+
+At this stage, adding a Claw creates the new agent and workspace configuration
+and records installation provenance. Later Claws stages add managed workspace
+files and other declared resources.
 
 ## Command reference
 
 | Command                  | Purpose                                        |
 | ------------------------ | ---------------------------------------------- |
 | `claws inspect <source>` | Validate a package directory or JSON manifest. |
-| `claws add <source>`     | Preview adding one new agent and workspace.    |
+| `claws add <source>`     | Preview or create one new agent and workspace. |
 
 Use `--json` for experimental machine-readable output.
 

--- a/src/claws/add.ts
+++ b/src/claws/add.ts
@@ -1,0 +1,318 @@
+// Applies the narrow agent/workspace creation slice of a consented Claw add plan.
+import { lstat, mkdir, rmdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { findOverlappingWorkspaceAgentIds } from "../agents/agent-delete-safety.js";
+import { stableStringify } from "../agents/stable-stringify.js";
+import { transformConfigFileWithRetry } from "../config/config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolvePathViaExistingAncestorSync } from "../infra/boundary-path.js";
+import { normalizeWindowsPathForComparison } from "../infra/path-guards.js";
+import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
+import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
+import { resolveUserPath } from "../utils.js";
+import {
+  deleteClawInstallRecord,
+  persistClawInstallRecord,
+  updateClawInstallRecordStatus,
+  type ClawInstallStatus,
+  type PersistedClawInstall,
+} from "./provenance.js";
+import { CLAW_OUTPUT_STABILITY, type ClawAddPlan } from "./types.js";
+
+export const CLAW_ADD_RESULT_SCHEMA_VERSION = "openclaw.clawAddResult.v1" as const;
+
+type ConfigCommit = (transform: (config: OpenClawConfig) => OpenClawConfig) => Promise<void>;
+type ClawAddApplyOptions = OpenClawStateDatabaseOptions & {
+  consentPlanIntegrity?: string;
+  commitConfig?: ConfigCommit;
+  persistRecord?: typeof persistClawInstallRecord;
+  deleteRecord?: typeof deleteClawInstallRecord;
+  updateRecord?: typeof updateClawInstallRecordStatus;
+  nowMs?: number;
+};
+type AgentConfig = NonNullable<NonNullable<OpenClawConfig["agents"]>["list"]>[number];
+
+export class ClawAddMutationError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ClawAddMutationError";
+  }
+}
+
+type ClawAddResult = {
+  schemaVersion: typeof CLAW_ADD_RESULT_SCHEMA_VERSION;
+  stability: typeof CLAW_OUTPUT_STABILITY;
+  dryRun: false;
+  mutationAllowed: true;
+  planIntegrity: string;
+  status: "complete" | "partial";
+  claw: ClawAddPlan["claw"];
+  agent: ClawAddPlan["agent"];
+  workspaceCreated: boolean;
+  configCommitted: boolean;
+  installRecord?: PersistedClawInstall;
+  error?: { code: string; message: string };
+};
+
+function hasUnsupportedMutationActions(plan: ClawAddPlan): boolean {
+  return plan.actions.some((action) => !["agent", "workspace"].includes(action.kind));
+}
+
+function statusAtLeast(status: ClawInstallStatus, phase: ClawInstallStatus): boolean {
+  const order: Record<ClawInstallStatus, number> = {
+    pending: 0,
+    partial: 0,
+    workspace_ready: 1,
+    config_committed: 2,
+    complete: 3,
+  };
+  return order[status] >= order[phase];
+}
+
+function markInstallStatus(
+  agentId: string,
+  status: ClawInstallStatus,
+  expectedStatuses: ClawInstallStatus[],
+  options: ClawAddApplyOptions,
+): void {
+  (options.updateRecord ?? updateClawInstallRecordStatus)(agentId, status, {
+    ...options,
+    expectedStatuses,
+  });
+}
+
+function clearUnownedInstallRecord(
+  agentId: string,
+  expectedStatuses: ClawInstallStatus[],
+  options: ClawAddApplyOptions,
+): void {
+  (options.deleteRecord ?? deleteClawInstallRecord)(agentId, {
+    ...options,
+    expectedStatuses,
+  });
+}
+
+function sameCommittedAgent(existingAgent: AgentConfig, plan: ClawAddPlan): boolean {
+  return stableStringify(existingAgent) === stableStringify(plan.agent.config);
+}
+
+function workspacePathKey(value: string): string {
+  return process.platform === "win32" ? normalizeWindowsPathForComparison(value) : value;
+}
+
+function assertWorkspacePathUnchanged(workspace: string): void {
+  const canonicalWorkspace = resolvePathViaExistingAncestorSync(workspace);
+  if (workspacePathKey(canonicalWorkspace) !== workspacePathKey(workspace)) {
+    throw new ClawAddMutationError(
+      "workspace_path_changed",
+      `Workspace ancestry changed after planning: expected ${JSON.stringify(workspace)}, resolved ${JSON.stringify(canonicalWorkspace)}.`,
+    );
+  }
+}
+
+export async function applyClawAddPlan(
+  plan: ClawAddPlan,
+  options: ClawAddApplyOptions = {},
+): Promise<ClawAddResult> {
+  if (plan.blockers.length > 0) {
+    throw new ClawAddMutationError("plan_blocked", "The Claw add plan contains blockers.");
+  }
+  if (hasUnsupportedMutationActions(plan)) {
+    throw new ClawAddMutationError(
+      "unsupported_components",
+      "This build can only add Claws with agent settings and an empty workspace; declared files, packages, MCP servers, or cron jobs require later lifecycle slices.",
+    );
+  }
+  if (options.consentPlanIntegrity !== plan.planIntegrity) {
+    throw new ClawAddMutationError(
+      "plan_integrity_mismatch",
+      "Consent does not match the current Claw add plan; run add --dry-run again.",
+    );
+  }
+
+  const persistRecord = options.persistRecord ?? persistClawInstallRecord;
+  let installRecord: PersistedClawInstall;
+  try {
+    installRecord = persistRecord(plan, { ...options, status: "pending" });
+  } catch (error) {
+    throw new ClawAddMutationError("provenance_failed", (error as Error).message);
+  }
+
+  const workspace = resolve(resolveUserPath(plan.agent.workspace));
+  const workspacePhaseRecorded = statusAtLeast(installRecord.status, "workspace_ready");
+  const workspaceState = workspacePhaseRecorded
+    ? await lstat(workspace).catch((error: unknown) => {
+        if (
+          typeof error === "object" &&
+          error !== null &&
+          "code" in error &&
+          error.code === "ENOENT"
+        ) {
+          return undefined;
+        }
+        throw error;
+      })
+    : undefined;
+  if (workspaceState && !workspaceState.isDirectory()) {
+    throw new ClawAddMutationError(
+      "workspace_collision",
+      `Workspace ${JSON.stringify(workspace)} is no longer a directory.`,
+    );
+  }
+  let workspaceCreated = workspaceState?.isDirectory() ?? false;
+  let configCommitted = statusAtLeast(installRecord.status, "config_committed");
+
+  try {
+    assertWorkspacePathUnchanged(workspace);
+    await mkdir(dirname(workspace), { recursive: true });
+    assertWorkspacePathUnchanged(workspace);
+  } catch (error) {
+    clearUnownedInstallRecord(plan.agent.finalId, ["pending", "partial"], options);
+    if (error instanceof ClawAddMutationError) {
+      throw error;
+    }
+    throw new ClawAddMutationError(
+      "workspace_parent_failed",
+      `Could not create parent directory for workspace ${JSON.stringify(workspace)}: ${(error as Error).message}`,
+    );
+  }
+
+  if (!workspaceCreated) {
+    try {
+      await mkdir(workspace);
+      workspaceCreated = true;
+    } catch (error) {
+      clearUnownedInstallRecord(plan.agent.finalId, ["pending", "partial"], options);
+      throw new ClawAddMutationError(
+        "workspace_collision",
+        `Could not create new workspace ${JSON.stringify(workspace)}: ${(error as Error).message}`,
+      );
+    }
+
+    try {
+      if (!workspacePhaseRecorded) {
+        markInstallStatus(
+          plan.agent.finalId,
+          "workspace_ready",
+          ["pending", "partial", "workspace_ready"],
+          options,
+        );
+      }
+    } catch (error) {
+      const removedWorkspace = await rmdir(workspace)
+        .then(() => true)
+        .catch(() => false);
+      if (removedWorkspace) {
+        try {
+          clearUnownedInstallRecord(plan.agent.finalId, ["pending", "partial"], options);
+        } catch {
+          // Preserve the phase-write failure if the unowned attempt cannot be reconciled.
+        }
+      }
+      throw new ClawAddMutationError("provenance_failed", (error as Error).message);
+    }
+  }
+
+  try {
+    const commit: ConfigCommit =
+      options.commitConfig ??
+      (async (transform) => {
+        await transformConfigFileWithRetry({
+          afterWrite: { mode: "auto" },
+          transform: (config) => ({ nextConfig: transform(config) }),
+        });
+      });
+    await commit((config) => {
+      const existingAgents = config.agents?.list ?? [];
+      const agentsToPreserve: AgentConfig[] =
+        existingAgents.length > 0 ? existingAgents : [{ id: DEFAULT_AGENT_ID, default: true }];
+      const configWithPreservedAgents: OpenClawConfig = {
+        ...config,
+        agents: { ...config.agents, list: agentsToPreserve },
+      };
+      const existingAgent = agentsToPreserve.find((agent) => agent.id === plan.agent.finalId);
+      if (existingAgent) {
+        if (sameCommittedAgent(existingAgent, plan)) {
+          configCommitted = true;
+          return config;
+        }
+        throw new ClawAddMutationError(
+          "agent_id_collision",
+          `Agent ${JSON.stringify(plan.agent.finalId)} was created after planning.`,
+        );
+      }
+      if (
+        findOverlappingWorkspaceAgentIds(configWithPreservedAgents, plan.agent.finalId, workspace)
+          .length > 0
+      ) {
+        throw new ClawAddMutationError(
+          "workspace_collision",
+          `Workspace ${JSON.stringify(workspace)} is already assigned to an agent.`,
+        );
+      }
+      const nextConfig: OpenClawConfig = {
+        ...config,
+        agents: {
+          ...config.agents,
+          list: [...agentsToPreserve, plan.agent.config],
+        },
+      };
+      configCommitted = true;
+      return nextConfig;
+    });
+    markInstallStatus(
+      plan.agent.finalId,
+      "config_committed",
+      ["workspace_ready", "config_committed"],
+      options,
+    );
+  } catch (error) {
+    if (!configCommitted) {
+      const removedWorkspace = await rmdir(workspace)
+        .then(() => true)
+        .catch(() => false);
+      if (removedWorkspace) {
+        clearUnownedInstallRecord(plan.agent.finalId, ["workspace_ready", "partial"], options);
+      }
+    }
+    throw error;
+  }
+
+  try {
+    markInstallStatus(plan.agent.finalId, "complete", ["config_committed", "complete"], options);
+    return {
+      schemaVersion: CLAW_ADD_RESULT_SCHEMA_VERSION,
+      stability: CLAW_OUTPUT_STABILITY,
+      dryRun: false,
+      mutationAllowed: true,
+      planIntegrity: plan.planIntegrity,
+      status: "complete",
+      claw: plan.claw,
+      agent: plan.agent,
+      workspaceCreated,
+      configCommitted,
+      installRecord: {
+        ...installRecord,
+        status: "complete",
+        updatedAtMs: options.nowMs ?? Date.now(),
+      },
+    };
+  } catch (error) {
+    return {
+      schemaVersion: CLAW_ADD_RESULT_SCHEMA_VERSION,
+      stability: CLAW_OUTPUT_STABILITY,
+      dryRun: false,
+      mutationAllowed: true,
+      planIntegrity: plan.planIntegrity,
+      status: "partial",
+      claw: plan.claw,
+      agent: plan.agent,
+      workspaceCreated,
+      configCommitted,
+      error: { code: "provenance_failed", message: (error as Error).message },
+    };
+  }
+}

--- a/src/claws/add.ts
+++ b/src/claws/add.ts
@@ -7,7 +7,7 @@ import { transformConfigFileWithRetry } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolvePathViaExistingAncestorSync } from "../infra/boundary-path.js";
 import { normalizeWindowsPathForComparison } from "../infra/path-guards.js";
-import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
+import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
 import { resolveUserPath } from "../utils.js";
 import {
@@ -233,7 +233,10 @@ export async function applyClawAddPlan(
         ...config,
         agents: { ...config.agents, list: agentsToPreserve },
       };
-      const existingAgent = agentsToPreserve.find((agent) => agent.id === plan.agent.finalId);
+      const normalizedAgentId = normalizeAgentId(plan.agent.finalId);
+      const existingAgent = agentsToPreserve.find(
+        (agent) => normalizeAgentId(agent.id) === normalizedAgentId,
+      );
       if (existingAgent) {
         if (sameCommittedAgent(existingAgent, plan)) {
           configCommitted = true;

--- a/src/claws/fixtures/minimal-agent.claw.json
+++ b/src/claws/fixtures/minimal-agent.claw.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 1,
+  "agent": {
+    "id": "internal-triage",
+    "name": "Internal Triage",
+    "description": "Triages internal work without changing operator runtime settings.",
+    "identity": {
+      "name": "Triage"
+    },
+    "tools": {
+      "deny": ["exec", "browser"]
+    },
+    "humanDelay": {
+      "mode": "natural"
+    }
+  }
+}

--- a/src/claws/lifecycle.e2e.test.ts
+++ b/src/claws/lifecycle.e2e.test.ts
@@ -1,19 +1,19 @@
 // E2E coverage for experimental grouped Claw inspection and add planning.
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { promisify } from "node:util";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 
 const execFileAsync = promisify(execFile);
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 async function runOpenClaw(
   args: string[],
   options?: { expectFailure?: boolean; stateDir?: string },
 ) {
-  const stateDir =
-    options?.stateDir ?? (await mkdtemp(join(tmpdir(), "openclaw-claws-lifecycle-e2e-")));
+  const stateDir = options?.stateDir ?? tempDirs.make("openclaw-claws-lifecycle-e2e-");
   const env = {
     ...process.env,
     HOME: stateDir,

--- a/src/claws/lifecycle.e2e.test.ts
+++ b/src/claws/lifecycle.e2e.test.ts
@@ -1,6 +1,6 @@
 // E2E coverage for experimental grouped Claw inspection and add planning.
 import { execFile } from "node:child_process";
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -8,8 +8,12 @@ import { describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
 
-async function runOpenClaw(args: string[], options?: { expectFailure?: boolean }) {
-  const stateDir = await mkdtemp(join(tmpdir(), "openclaw-claws-lifecycle-e2e-"));
+async function runOpenClaw(
+  args: string[],
+  options?: { expectFailure?: boolean; stateDir?: string },
+) {
+  const stateDir =
+    options?.stateDir ?? (await mkdtemp(join(tmpdir(), "openclaw-claws-lifecycle-e2e-")));
   const env = {
     ...process.env,
     HOME: stateDir,
@@ -32,7 +36,7 @@ async function runOpenClaw(args: string[], options?: { expectFailure?: boolean }
     if (options?.expectFailure) {
       throw new Error(`expected command to fail: ${args.join(" ")}`);
     }
-    return { ok: true as const, stdout: result.stdout, stderr: result.stderr };
+    return { ok: true as const, stdout: result.stdout, stderr: result.stderr, stateDir };
   } catch (error) {
     if (!options?.expectFailure) {
       throw error;
@@ -43,6 +47,7 @@ async function runOpenClaw(args: string[], options?: { expectFailure?: boolean }
       code: failed.code,
       stdout: failed.stdout ?? "",
       stderr: failed.stderr ?? "",
+      stateDir,
     };
   }
 }
@@ -103,13 +108,77 @@ describe("claws lifecycle cli e2e", () => {
     expect(result.code).toBe(1);
   });
 
-  it("fails closed when add is invoked without dry-run", async () => {
+  it("preserves implicit main and creates exactly one agent after explicit consent", async () => {
+    const preview = await runOpenClaw([
+      "claws",
+      "add",
+      "src/claws/fixtures/minimal-agent.claw.json",
+      "--dry-run",
+      "--json",
+    ]);
+    const plan = parseJson(preview.stdout) as { planIntegrity: string };
+    const result = await runOpenClaw(
+      [
+        "claws",
+        "add",
+        "src/claws/fixtures/minimal-agent.claw.json",
+        "--yes",
+        "--plan-integrity",
+        plan.planIntegrity,
+        "--json",
+      ],
+      { stateDir: preview.stateDir },
+    );
+
+    expect(parseJson(result.stdout)).toMatchObject({
+      schemaVersion: "openclaw.clawAddResult.v1",
+      stability: "experimental",
+      status: "complete",
+      agent: { finalId: "internal-triage" },
+      workspaceCreated: true,
+      configCommitted: true,
+      installRecord: { agentId: "internal-triage", status: "complete" },
+    });
+    const config = JSON.parse(await readFile(join(result.stateDir, "openclaw.json"), "utf8"));
+    expect(config.agents.list).toEqual([
+      { id: "main", default: true },
+      expect.objectContaining({
+        id: "internal-triage",
+        name: "Internal Triage",
+        workspace: join(result.stateDir, ".openclaw", "workspace-internal-triage"),
+      }),
+    ]);
+  });
+
+  it("blocks mutation when declared components need later lifecycle slices", async () => {
+    const preview = await runOpenClaw(["claws", "add", manifestPath, "--dry-run", "--json"], {
+      expectFailure: true,
+    });
+    const plan = parseJson(preview.stdout) as { planIntegrity: string };
+    const result = await runOpenClaw(
+      ["claws", "add", manifestPath, "--yes", "--plan-integrity", plan.planIntegrity, "--json"],
+      {
+        expectFailure: true,
+        stateDir: preview.stateDir,
+      },
+    );
+
+    expect(result.code).toBe(1);
+    expect(parseJson(result.stdout)).toMatchObject({
+      schemaVersion: "openclaw.clawAddPlan.v1",
+      blockers: expect.arrayContaining([
+        expect.objectContaining({ code: "package_install_unavailable" }),
+      ]),
+    });
+  });
+
+  it("fails closed when add is invoked without dry-run or consent", async () => {
     const result = await runOpenClaw(["claws", "add", manifestPath], {
       expectFailure: true,
     });
 
     expect(result.ok).toBe(false);
     expect(result.code).toBe(1);
-    expect(result.stderr).toContain("Claw add is dry-run only");
+    expect(result.stderr).toContain("Claw add requires explicit consent");
   });
 });

--- a/src/claws/lifecycle.ts
+++ b/src/claws/lifecycle.ts
@@ -4,8 +4,11 @@ import { lstat, realpath } from "node:fs/promises";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { stableStringify } from "../agents/stable-stringify.js";
+import { resolvePathViaExistingAncestorSync } from "../infra/boundary-path.js";
+import { assertNoSymlinkParents } from "../infra/fs-safe-advanced.js";
+import { FsSafeError, root as fsSafeRoot, type Root } from "../infra/fs-safe.js";
 import { resolveUserPath } from "../utils.js";
-import { MAX_MANAGED_WORKSPACE_BYTES } from "./source-limits.js";
+import { MAX_MANAGED_FILE_BYTES, MAX_MANAGED_WORKSPACE_BYTES } from "./source-limits.js";
 import {
   CLAW_ADD_PLAN_SCHEMA_VERSION,
   CLAW_BOOTSTRAP_FILE_NAMES,
@@ -16,8 +19,6 @@ import {
   type ClawDiagnostic,
   type ClawManifest,
   type ClawLocalPrerequisite,
-  type ClawSourceSnapshot,
-  type ClawWorkspaceSourceSnapshot,
   type ClawSourceIdentity,
 } from "./types.js";
 
@@ -37,90 +38,158 @@ function capabilityChange(
 type ClawAddPlanContext = {
   agentId?: string;
   workspace?: string;
+  resumableWorkspace?: string;
   existingAgentIds?: Iterable<string>;
   existingWorkspacePaths?: Iterable<string>;
   existingMcpServerNames?: Iterable<string>;
   existingCronJobIds?: Iterable<string>;
 };
 
+function canonicalWorkspacePath(value: string): string {
+  return resolvePathViaExistingAncestorSync(resolve(resolveUserPath(value)));
+}
+
 function blocker(code: string, path: string, message: string): ClawDiagnostic {
   return { level: "error", code, phase: "plan", path, message };
 }
 
-function isNotFoundError(error: unknown): boolean {
-  const code = (error as NodeJS.ErrnoException | undefined)?.code;
-  return code === "ENOENT" || code === "ENOTDIR";
+type PendingWorkspaceFileAction = {
+  action: ClawAddPlanAction;
+  sourcePath: string;
+  manifestPath: string;
+  byteLength: number;
+};
+
+function blockedWorkspaceFileAction(params: {
+  id: string;
+  source: string;
+  target: string;
+  reason: string;
+}): ClawAddPlanAction {
+  return {
+    kind: "workspaceFile",
+    id: params.id,
+    action: "write",
+    target: params.target,
+    source: params.source,
+    blocked: true,
+    reason: params.reason,
+  };
 }
 
-function inspectWorkspaceFileAction(params: {
+function workspaceSourceErrorCode(
+  error: unknown,
+): "workspace_source_invalid" | "workspace_source_unsafe" | "workspace_source_too_large" {
+  if (error instanceof FsSafeError) {
+    if (error.code === "too-large") {
+      return "workspace_source_too_large";
+    }
+    if (error.code === "symlink" || error.code === "hardlink" || error.code === "path-mismatch") {
+      return "workspace_source_unsafe";
+    }
+  }
+  if (error instanceof Error && error.message.includes("symlinked directory")) {
+    return "workspace_source_unsafe";
+  }
+  return "workspace_source_invalid";
+}
+
+function workspaceSourceMessage(code: string, sourcePath: string): string {
+  if (code === "workspace_source_too_large") {
+    return `Workspace source ${JSON.stringify(sourcePath)} exceeds ${MAX_MANAGED_FILE_BYTES} bytes.`;
+  }
+  if (code === "workspace_sources_too_large") {
+    return `Workspace sources exceed ${MAX_MANAGED_WORKSPACE_BYTES} aggregate bytes.`;
+  }
+  if (code === "workspace_source_unsafe") {
+    return `Workspace source ${JSON.stringify(sourcePath)} must be a regular, non-symlinked, non-hardlinked file.`;
+  }
+  return `Workspace source ${JSON.stringify(sourcePath)} must resolve to a file inside the Claw package.`;
+}
+
+async function inspectWorkspaceFileAction(params: {
+  sourceRoot: Root;
   source: ClawSourceIdentity;
   workspace: string;
   sourcePath: string;
   targetPath: string;
   id: string;
   manifestPath: string;
-  snapshot?: ClawWorkspaceSourceSnapshot;
-}): {
-  action: ClawAddPlanAction;
+}): Promise<{
+  pending?: PendingWorkspaceFileAction;
+  action?: ClawAddPlanAction;
   blocker?: ClawDiagnostic;
-} {
+}> {
   const requestedSource = resolve(params.source.packageRoot, params.sourcePath);
   const requestedTarget = resolve(params.workspace, params.targetPath);
-  if (params.snapshot) {
+  try {
+    await assertNoSymlinkParents({
+      rootDir: params.source.packageRoot,
+      targetPath: requestedSource,
+      allowMissing: false,
+      messagePrefix: "Workspace source",
+    });
+    const opened = await params.sourceRoot.open(params.sourcePath, {
+      hardlinks: "reject",
+      symlinks: "reject",
+    });
+    await opened[Symbol.asyncDispose]();
+    if (opened.stat.size > MAX_MANAGED_FILE_BYTES) {
+      throw new FsSafeError(
+        "too-large",
+        `file exceeds limit of ${MAX_MANAGED_FILE_BYTES} bytes (got ${opened.stat.size})`,
+      );
+    }
     return {
-      action: {
-        kind: "workspaceFile",
-        id: params.id,
-        action: "write",
-        target: requestedTarget,
-        source: params.snapshot.realPath,
-        digest: params.snapshot.digest,
-        details: { expectedState: "absent" },
-        blocked: false,
+      pending: {
+        sourcePath: params.sourcePath,
+        manifestPath: params.manifestPath,
+        byteLength: opened.stat.size,
+        action: {
+          kind: "workspaceFile",
+          id: params.id,
+          action: "write",
+          target: requestedTarget,
+          source: opened.realPath,
+          details: { expectedState: "absent" },
+          blocked: false,
+        },
       },
     };
+  } catch (error) {
+    const code = workspaceSourceErrorCode(error);
+    const message = workspaceSourceMessage(code, params.sourcePath);
+    const diagnostic = blocker(code, params.manifestPath, message);
+    return {
+      action: blockedWorkspaceFileAction({
+        id: params.id,
+        target: requestedTarget,
+        source: requestedSource,
+        reason: diagnostic.message,
+      }),
+      blocker: diagnostic,
+    };
   }
-  const diagnostic = blocker(
-    "workspace_source_invalid",
-    params.manifestPath,
-    `Workspace source ${JSON.stringify(params.sourcePath)} was not captured in the validated Claw snapshot.`,
-  );
-  return {
-    action: {
-      kind: "workspaceFile",
-      id: params.id,
-      action: "write",
-      target: requestedTarget,
-      source: requestedSource,
-      blocked: true,
-      reason: diagnostic.message,
-    },
-    blocker: diagnostic,
-  };
 }
 
 export async function buildClawAddPlan(params: {
   manifest: ClawManifest;
   source: ClawSourceIdentity;
-  snapshot: ClawSourceSnapshot;
   diagnostics?: ClawDiagnostic[];
   context?: ClawAddPlanContext;
 }): Promise<ClawAddPlan> {
   const context = params.context ?? {};
   const finalId = context.agentId ?? params.manifest.agent.id;
-  const workspace = resolve(
-    resolveUserPath(context.workspace ?? resolve(homedir(), ".openclaw", `workspace-${finalId}`)),
+  const workspace = canonicalWorkspacePath(
+    context.workspace ?? resolve(homedir(), ".openclaw", `workspace-${finalId}`),
   );
   const packageRoot = await realpath(params.source.packageRoot).catch(
     () => params.source.packageRoot,
   );
   const source = { ...params.source, packageRoot };
-  const workspaceSnapshots = new Map(
-    params.snapshot.workspaceSources.map((snapshot) => [snapshot.sourcePath, snapshot]),
-  );
+  const sourceRoot = await fsSafeRoot(packageRoot);
   const blockers: ClawDiagnostic[] = [];
   const actions: ClawAddPlanAction[] = [];
-  const workspaceFileActions: ClawAddPlanAction[] = [];
   const capabilityChanges: ClawAddCapabilityChange[] = [];
   const readinessRequirements: ClawLocalPrerequisite[] = [];
 
@@ -171,28 +240,18 @@ export async function buildClawAddPlan(params: {
   }
 
   const configuredWorkspacePaths = new Set(
-    [...(context.existingWorkspacePaths ?? [])].map((path) => resolve(resolveUserPath(path))),
+    [...(context.existingWorkspacePaths ?? [])].map((path) => canonicalWorkspacePath(path)),
   );
-  let workspaceExists = configuredWorkspacePaths.has(workspace);
-  let workspaceProbeFailed = false;
-  if (!workspaceExists) {
-    try {
-      await lstat(workspace);
-      workspaceExists = true;
-    } catch (error) {
-      if (!isNotFoundError(error)) {
-        workspaceProbeFailed = true;
-        blockers.push(
-          blocker(
-            "workspace_probe_failed",
-            "$.workspace",
-            `Could not prove that workspace ${JSON.stringify(workspace)} is absent.`,
-          ),
-        );
-      }
-    }
-  }
-  if (workspaceExists) {
+  const configuredWorkspaceConflict = configuredWorkspacePaths.has(workspace);
+  const workspaceExistsOnDisk = await lstat(workspace)
+    .then(() => true)
+    .catch(() => false);
+  const resumableWorkspace = context.resumableWorkspace
+    ? canonicalWorkspacePath(context.resumableWorkspace)
+    : undefined;
+  const workspaceBlocked =
+    configuredWorkspaceConflict || (workspaceExistsOnDisk && resumableWorkspace !== workspace);
+  if (workspaceBlocked) {
     blockers.push(
       blocker(
         "workspace_collision",
@@ -206,40 +265,41 @@ export async function buildClawAddPlan(params: {
     id: finalId,
     action: "create",
     target: workspace,
-    details: { expectedState: workspaceProbeFailed ? "unknown" : "absent" },
-    blocked: workspaceExists || workspaceProbeFailed,
-    ...(workspaceExists
+    details: { expectedState: "absent" },
+    blocked: workspaceBlocked,
+    ...(workspaceBlocked
       ? { reason: `Workspace ${JSON.stringify(workspace)} already exists.` }
-      : workspaceProbeFailed
-        ? { reason: `Could not prove that workspace ${JSON.stringify(workspace)} is absent.` }
-        : {}),
+      : {}),
   });
 
-  function addWorkspaceFileInspection(fileParams: {
+  const pendingWorkspaceFiles: PendingWorkspaceFileAction[] = [];
+  async function addWorkspaceFileInspection(fileParams: {
     sourcePath: string;
     targetPath: string;
     id: string;
     manifestPath: string;
-  }): void {
-    const normalizedSourcePath = fileParams.sourcePath.replaceAll("\\", "/");
-    const result = inspectWorkspaceFileAction({
+  }): Promise<void> {
+    const result = await inspectWorkspaceFileAction({
+      sourceRoot,
       source,
       workspace,
       sourcePath: fileParams.sourcePath,
       targetPath: fileParams.targetPath,
       id: fileParams.id,
       manifestPath: fileParams.manifestPath,
-      snapshot: workspaceSnapshots.get(normalizedSourcePath),
     });
-    const action = result.action;
-    action.blocked ||= workspaceExists || workspaceProbeFailed;
-    if (workspaceExists) {
+    const action = result.pending?.action ?? result.action;
+    if (!action) {
+      throw new Error("Claw workspace source inspection did not produce an action");
+    }
+    action.blocked ||= workspaceBlocked;
+    if (workspaceBlocked) {
       action.reason = `Workspace ${JSON.stringify(workspace)} already exists.`;
-    } else if (workspaceProbeFailed) {
-      action.reason = `Could not prove that workspace ${JSON.stringify(workspace)} is absent.`;
     }
     actions.push(action);
-    workspaceFileActions.push(action);
+    if (result.pending) {
+      pendingWorkspaceFiles.push(result.pending);
+    }
     if (result.blocker) {
       blockers.push(result.blocker);
     }
@@ -250,7 +310,7 @@ export async function buildClawAddPlan(params: {
     if (!declaration) {
       continue;
     }
-    addWorkspaceFileInspection({
+    await addWorkspaceFileInspection({
       sourcePath: declaration.source,
       targetPath: name,
       id: name,
@@ -258,7 +318,7 @@ export async function buildClawAddPlan(params: {
     });
   }
   for (const [index, file] of params.manifest.workspace.files.entries()) {
-    addWorkspaceFileInspection({
+    await addWorkspaceFileInspection({
       sourcePath: file.source,
       targetPath: file.path,
       id: file.path,
@@ -266,20 +326,45 @@ export async function buildClawAddPlan(params: {
     });
   }
 
-  const workspaceByteLength = params.snapshot.workspaceSources.reduce(
-    (total, snapshot) => total + snapshot.byteLength,
+  const workspaceByteLength = pendingWorkspaceFiles.reduce(
+    (total, pending) => total + pending.byteLength,
     0,
   );
   if (workspaceByteLength > MAX_MANAGED_WORKSPACE_BYTES) {
     const diagnostic = blocker(
       "workspace_sources_too_large",
       "$.workspace",
-      `Workspace sources exceed ${MAX_MANAGED_WORKSPACE_BYTES} aggregate bytes.`,
+      workspaceSourceMessage("workspace_sources_too_large", ""),
     );
     blockers.push(diagnostic);
-    for (const action of workspaceFileActions) {
-      action.blocked = true;
-      action.reason = diagnostic.message;
+    for (const pending of pendingWorkspaceFiles) {
+      pending.action.blocked = true;
+      pending.action.reason = diagnostic.message;
+    }
+  } else {
+    for (const pending of pendingWorkspaceFiles) {
+      try {
+        await assertNoSymlinkParents({
+          rootDir: source.packageRoot,
+          targetPath: resolve(source.packageRoot, pending.sourcePath),
+          allowMissing: false,
+          messagePrefix: "Workspace source",
+        });
+        const read = await sourceRoot.read(pending.sourcePath, {
+          hardlinks: "reject",
+          maxBytes: MAX_MANAGED_FILE_BYTES,
+          symlinks: "reject",
+        });
+        pending.action.source = read.realPath;
+        pending.action.digest = `sha256:${createHash("sha256").update(read.buffer).digest("hex")}`;
+      } catch (error) {
+        const code = workspaceSourceErrorCode(error);
+        const message = workspaceSourceMessage(code, pending.sourcePath);
+        const diagnostic = blocker(code, pending.manifestPath, message);
+        pending.action.blocked = true;
+        pending.action.reason = diagnostic.message;
+        blockers.push(diagnostic);
+      }
     }
   }
 
@@ -364,16 +449,7 @@ export async function buildClawAddPlan(params: {
         reason: "The Claw declares an MCP execution or network tool surface.",
         effect: {
           ...server,
-          ...("env" in server && server.env
-            ? {
-                env: Object.entries(server.env)
-                  .map(([envName, value]) => ({
-                    name: envName,
-                    reference: value.slice(2, -1),
-                  }))
-                  .toSorted((left, right) => left.name.localeCompare(right.name)),
-              }
-            : {}),
+          ...("env" in server && server.env ? { env: Object.keys(server.env).toSorted() } : {}),
         },
       }),
     );

--- a/src/claws/provenance.test.ts
+++ b/src/claws/provenance.test.ts
@@ -1,0 +1,507 @@
+// Tests root Claw install ownership and the narrow agent/workspace mutation slice.
+import { access, mkdir, mkdtemp, rmdir, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { applyClawAddPlan, ClawAddMutationError } from "./add.js";
+import { buildClawAddPlan } from "./lifecycle.js";
+import {
+  persistClawInstallRecord,
+  readClawInstallRecord,
+  updateClawInstallRecordStatus,
+} from "./provenance.js";
+import { parseClawManifest } from "./schema.js";
+import type { ClawSourceIdentity } from "./types.js";
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
+
+async function makePlan(
+  manifestValue: unknown = { schemaVersion: 1, agent: { id: "worker" } },
+  options: { workspace?: string } = {},
+) {
+  const root = await mkdtemp(join(tmpdir(), "openclaw-claw-add-"));
+  const parsed = parseClawManifest(manifestValue);
+  if (!parsed.ok) {
+    throw new Error(JSON.stringify(parsed.diagnostics));
+  }
+  const source: ClawSourceIdentity = {
+    kind: "package",
+    name: "@acme/worker",
+    version: "1.0.0",
+    packageRoot: root,
+    manifestPath: join(root, "openclaw.claw.json"),
+    integrityKind: "artifact",
+    integrity: "sha256:manifest",
+    byteLength: 123,
+  };
+  const plan = await buildClawAddPlan({
+    manifest: parsed.manifest,
+    source,
+    context: { workspace: options.workspace ?? join(root, "workspace-worker") },
+  });
+  return { root, plan };
+}
+
+function stateEnv(root: string) {
+  return { OPENCLAW_STATE_DIR: join(root, "state") };
+}
+
+function readInstallRow(agentId: string, root: string) {
+  return openOpenClawStateDatabase({ env: stateEnv(root) })
+    .db.prepare(
+      `SELECT agent_id, schema_version, claw_name, claw_version, integrity, plan_integrity,
+              workspace, agent_config_digest, agent_owned_paths_json, status, added_at_ms
+         FROM claw_installs
+        WHERE agent_id = ?`,
+    )
+    .get(agentId) as
+    | {
+        agent_id: string;
+        schema_version: string;
+        claw_name: string;
+        claw_version: string;
+        integrity: string;
+        plan_integrity: string;
+        workspace: string;
+        agent_config_digest: string;
+        agent_owned_paths_json: string;
+        status: string;
+        added_at_ms: number | bigint;
+      }
+    | undefined;
+}
+
+describe("Claw root install provenance", () => {
+  it("persists package identity, agent ownership, workspace, and config digest", async () => {
+    const { root, plan } = await makePlan();
+
+    const record = persistClawInstallRecord(plan, { env: stateEnv(root), nowMs: 42 });
+
+    expect(record).toMatchObject({
+      schemaVersion: "openclaw.clawInstallRecord.v1",
+      claw: { name: "@acme/worker", version: "1.0.0", integrity: "sha256:manifest" },
+      manifestSchemaVersion: 1,
+      planIntegrity: plan.planIntegrity,
+      agentId: "worker",
+      workspace: plan.agent.workspace,
+      agentOwnedPaths: ['agents.list["worker"]'],
+      status: "complete",
+      addedAtMs: 42,
+    });
+    expect(record.agentConfigDigest).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(readInstallRow("worker", root)).toMatchObject({
+      agent_id: record.agentId,
+      schema_version: record.schemaVersion,
+      claw_name: record.claw.name,
+      claw_version: record.claw.version,
+      integrity: record.claw.integrity,
+      plan_integrity: record.planIntegrity,
+      workspace: record.workspace,
+      agent_config_digest: record.agentConfigDigest,
+      agent_owned_paths_json: JSON.stringify(record.agentOwnedPaths),
+      status: record.status,
+      added_at_ms: record.addedAtMs,
+    });
+  });
+
+  it("does not overwrite a completed install record for the same agent", async () => {
+    const { root, plan } = await makePlan();
+    persistClawInstallRecord(plan, { env: stateEnv(root), nowMs: 1 });
+
+    expect(() => persistClawInstallRecord(plan, { env: stateEnv(root), nowMs: 2 })).toThrow();
+    expect(Number(readInstallRow("worker", root)?.added_at_ms)).toBe(1);
+  });
+
+  it("resumes a matching non-complete install record without inserting again", async () => {
+    const { root, plan } = await makePlan();
+    const first = persistClawInstallRecord(plan, {
+      env: stateEnv(root),
+      status: "pending",
+      nowMs: 1,
+    });
+
+    const resumed = persistClawInstallRecord(plan, {
+      env: stateEnv(root),
+      status: "pending",
+      nowMs: 2,
+    });
+
+    expect(resumed).toEqual(first);
+    expect(readClawInstallRecord("worker", { env: stateEnv(root) })).toMatchObject({
+      agentId: "worker",
+      status: "pending",
+      addedAtMs: 1,
+    });
+  });
+
+  it("rejects a stale phase update after an install reaches complete", async () => {
+    const { root, plan } = await makePlan();
+    const options = { env: stateEnv(root) };
+    persistClawInstallRecord(plan, { ...options, status: "pending", nowMs: 1 });
+    updateClawInstallRecordStatus("worker", "workspace_ready", {
+      ...options,
+      expectedStatuses: ["pending"],
+      nowMs: 2,
+    });
+    updateClawInstallRecordStatus("worker", "config_committed", {
+      ...options,
+      expectedStatuses: ["workspace_ready"],
+      nowMs: 3,
+    });
+    updateClawInstallRecordStatus("worker", "complete", {
+      ...options,
+      expectedStatuses: ["config_committed"],
+      nowMs: 4,
+    });
+
+    expect(() =>
+      updateClawInstallRecordStatus("worker", "partial", {
+        ...options,
+        expectedStatuses: ["pending", "partial"],
+        nowMs: 5,
+      }),
+    ).toThrow("did not match the expected phase");
+    expect(readClawInstallRecord("worker", options)?.status).toBe("complete");
+  });
+});
+
+describe("applyClawAddPlan", () => {
+  it("appends one agent, preserves defaults and existing agents, and creates a new workspace", async () => {
+    const { root, plan } = await makePlan({
+      schemaVersion: 1,
+      agent: {
+        id: "worker",
+        name: "Worker",
+        identity: { name: "Work" },
+        tools: { deny: ["exec"] },
+      },
+    });
+    let config: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: "/operator/default" },
+        list: [{ id: "main", default: true }],
+      },
+    };
+
+    const result = await applyClawAddPlan(plan, {
+      consentPlanIntegrity: plan.planIntegrity,
+      env: stateEnv(root),
+      nowMs: 10,
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+    });
+
+    expect(result).toMatchObject({
+      schemaVersion: "openclaw.clawAddResult.v1",
+      stability: "experimental",
+      status: "complete",
+      workspaceCreated: true,
+      configCommitted: true,
+      installRecord: { agentId: "worker" },
+    });
+    expect(config.agents?.defaults).toEqual({ workspace: "/operator/default" });
+    expect(config.agents?.list).toEqual([
+      { id: "main", default: true },
+      {
+        id: "worker",
+        name: "Worker",
+        identity: { name: "Work" },
+        tools: { deny: ["exec"] },
+        workspace: plan.agent.workspace,
+      },
+    ]);
+    await expect(access(plan.agent.workspace)).resolves.toBeUndefined();
+  });
+
+  it("materializes the implicit main agent before appending the first configured agent", async () => {
+    const { root, plan } = await makePlan();
+    let config: OpenClawConfig = {};
+
+    await applyClawAddPlan(plan, {
+      consentPlanIntegrity: plan.planIntegrity,
+      env: stateEnv(root),
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+    });
+
+    expect(config.agents?.list).toEqual([
+      { id: "main", default: true },
+      expect.objectContaining({ id: "worker" }),
+    ]);
+  });
+
+  it("rejects overlap with the implicit main workspace before materializing it", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openclaw-claw-implicit-main-"));
+    const mainWorkspace = join(root, "main-workspace");
+    const { root: planRoot, plan } = await makePlan(undefined, {
+      workspace: join(mainWorkspace, "nested-claw"),
+    });
+
+    await expect(
+      applyClawAddPlan(plan, {
+        consentPlanIntegrity: plan.planIntegrity,
+        env: stateEnv(planRoot),
+        commitConfig: async (transform) => {
+          transform({ agents: { defaults: { workspace: mainWorkspace } } });
+        },
+      }),
+    ).rejects.toMatchObject({ code: "workspace_collision" });
+    await expect(access(plan.agent.workspace)).rejects.toThrow();
+    expect(readInstallRow("worker", planRoot)).toBeUndefined();
+  });
+
+  it("rechecks agent collisions during the config commit and cleans the reserved workspace", async () => {
+    const { plan } = await makePlan();
+
+    await expect(
+      applyClawAddPlan(plan, {
+        consentPlanIntegrity: plan.planIntegrity,
+        commitConfig: async (transform) => {
+          transform({ agents: { list: [{ id: "worker" }] } });
+        },
+      }),
+    ).rejects.toMatchObject({ code: "agent_id_collision" });
+    await expect(access(plan.agent.workspace)).rejects.toThrow();
+  });
+
+  it("rechecks aliased workspace collisions during the config commit", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openclaw-claw-workspace-alias-"));
+    const canonicalParent = join(root, "canonical");
+    const aliasParent = join(root, "alias");
+    await mkdir(canonicalParent);
+    await symlink(canonicalParent, aliasParent, process.platform === "win32" ? "junction" : "dir");
+    const { root: planRoot, plan } = await makePlan(undefined, {
+      workspace: join(canonicalParent, "workspace-worker"),
+    });
+
+    await expect(
+      applyClawAddPlan(plan, {
+        consentPlanIntegrity: plan.planIntegrity,
+        env: stateEnv(planRoot),
+        commitConfig: async (transform) => {
+          transform({
+            agents: {
+              list: [{ id: "other", workspace: join(aliasParent, "workspace-worker") }],
+            },
+          });
+        },
+      }),
+    ).rejects.toMatchObject({ code: "workspace_collision" });
+    await expect(access(plan.agent.workspace)).rejects.toThrow();
+  });
+
+  it("rejects workspace ancestry changes after planning", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openclaw-claw-workspace-swap-"));
+    const canonicalParent = join(root, "canonical");
+    const alternateParent = join(root, "alternate");
+    await mkdir(canonicalParent);
+    await mkdir(alternateParent);
+    const { root: planRoot, plan } = await makePlan(undefined, {
+      workspace: join(canonicalParent, "workspace-worker"),
+    });
+    await rmdir(canonicalParent);
+    await symlink(
+      alternateParent,
+      canonicalParent,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+
+    await expect(
+      applyClawAddPlan(plan, {
+        consentPlanIntegrity: plan.planIntegrity,
+        env: stateEnv(planRoot),
+      }),
+    ).rejects.toMatchObject({ code: "workspace_path_changed" });
+    await expect(access(join(alternateParent, "workspace-worker"))).rejects.toThrow();
+    expect(readInstallRow("worker", planRoot)).toBeUndefined();
+  });
+
+  it("records a partial add when the workspace appears after planning", async () => {
+    const { root, plan } = await makePlan();
+    await mkdir(plan.agent.workspace);
+
+    await expect(
+      applyClawAddPlan(plan, {
+        consentPlanIntegrity: plan.planIntegrity,
+        env: stateEnv(root),
+      }),
+    ).rejects.toMatchObject({ code: "workspace_collision" });
+    expect(readInstallRow("worker", root)).toBeUndefined();
+  });
+
+  it("records parent-directory creation failures before workspace mutation", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openclaw-claw-add-"));
+    const blockedParent = join(root, "blocked-parent");
+    await writeFile(blockedParent, "not a directory", "utf8");
+    const { plan } = await makePlan(undefined, {
+      workspace: join(blockedParent, "workspace-worker"),
+    });
+
+    await expect(
+      applyClawAddPlan(plan, {
+        consentPlanIntegrity: plan.planIntegrity,
+        env: stateEnv(root),
+      }),
+    ).rejects.toMatchObject({ code: "workspace_parent_failed" });
+    expect(readInstallRow("worker", root)).toBeUndefined();
+  });
+
+  it("removes a new workspace when its durable phase cannot be recorded", async () => {
+    const { root, plan } = await makePlan();
+    const statuses: string[] = [];
+
+    await expect(
+      applyClawAddPlan(plan, {
+        consentPlanIntegrity: plan.planIntegrity,
+        env: stateEnv(root),
+        updateRecord: (_agentId, status) => {
+          statuses.push(status);
+          if (status === "workspace_ready") {
+            throw new Error("database unavailable");
+          }
+        },
+      }),
+    ).rejects.toMatchObject({ code: "provenance_failed" });
+
+    expect(statuses).toEqual(["workspace_ready"]);
+    await expect(access(plan.agent.workspace)).rejects.toThrow();
+    expect(readInstallRow("worker", root)).toBeUndefined();
+  });
+
+  it("resumes a matching partial add with an existing non-empty workspace", async () => {
+    const { root, plan } = await makePlan();
+    let config: OpenClawConfig = {};
+    let attempts = 0;
+
+    await expect(
+      applyClawAddPlan(plan, {
+        consentPlanIntegrity: plan.planIntegrity,
+        env: stateEnv(root),
+        commitConfig: async (transform) => {
+          attempts += 1;
+          if (attempts === 1) {
+            await writeFile(join(plan.agent.workspace, "leftover.txt"), "keep", "utf8");
+            throw new Error("config unavailable");
+          }
+          config = transform(config);
+        },
+      }),
+    ).rejects.toThrow("config unavailable");
+    expect(readInstallRow("worker", root)?.status).toBe("workspace_ready");
+
+    const retry = await applyClawAddPlan(plan, {
+      consentPlanIntegrity: plan.planIntegrity,
+      env: stateEnv(root),
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+    });
+
+    expect(retry).toMatchObject({
+      status: "complete",
+      workspaceCreated: true,
+      configCommitted: true,
+    });
+    expect(config.agents?.list).toContainEqual(expect.objectContaining({ id: "worker" }));
+    expect(readInstallRow("worker", root)?.status).toBe("complete");
+  });
+
+  it("recreates a missing workspace for a matching workspace-ready record", async () => {
+    const { root, plan } = await makePlan();
+    persistClawInstallRecord(plan, {
+      env: stateEnv(root),
+      status: "workspace_ready",
+      nowMs: 1,
+    });
+    let config: OpenClawConfig = {};
+
+    const result = await applyClawAddPlan(plan, {
+      consentPlanIntegrity: plan.planIntegrity,
+      env: stateEnv(root),
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+    });
+
+    expect(result.status).toBe("complete");
+    await expect(access(plan.agent.workspace)).resolves.toBeUndefined();
+    expect(config.agents?.list).toContainEqual(expect.objectContaining({ id: "worker" }));
+  });
+
+  it("rejects a non-directory replacement for a workspace-ready record", async () => {
+    const { root, plan } = await makePlan();
+    persistClawInstallRecord(plan, {
+      env: stateEnv(root),
+      status: "workspace_ready",
+      nowMs: 1,
+    });
+    await writeFile(plan.agent.workspace, "not a directory", "utf8");
+    let config: OpenClawConfig = {};
+
+    await expect(
+      applyClawAddPlan(plan, {
+        consentPlanIntegrity: plan.planIntegrity,
+        env: stateEnv(root),
+        commitConfig: async (transform) => {
+          config = transform(config);
+        },
+      }),
+    ).rejects.toMatchObject({ code: "workspace_collision" });
+
+    expect(config.agents?.list).toBeUndefined();
+    expect(readClawInstallRecord("worker", { env: stateEnv(root) })?.status).toBe(
+      "workspace_ready",
+    );
+  });
+
+  it("blocks declared components that this lifecycle slice cannot yet create", async () => {
+    const { plan } = await makePlan({
+      schemaVersion: 1,
+      agent: { id: "worker" },
+      packages: [{ kind: "skill", source: "clawhub", ref: "demo", version: "1.0.0" }],
+    });
+
+    await expect(
+      applyClawAddPlan(plan, { consentPlanIntegrity: plan.planIntegrity }),
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<ClawAddMutationError>>({ code: "plan_blocked" }),
+    );
+    await expect(access(plan.agent.workspace)).rejects.toThrow();
+  });
+
+  it("fails before mutation when the pending provenance record cannot be persisted", async () => {
+    const { plan } = await makePlan();
+    let config: OpenClawConfig = {};
+
+    await expect(
+      applyClawAddPlan(plan, {
+        consentPlanIntegrity: plan.planIntegrity,
+        commitConfig: async (transform) => {
+          config = transform(config);
+        },
+        persistRecord: () => {
+          throw new Error("database unavailable");
+        },
+      }),
+    ).rejects.toMatchObject({ code: "provenance_failed" });
+    expect(config.agents?.list).toBeUndefined();
+  });
+
+  it("rejects mutation when consent does not bind the current plan", async () => {
+    const { plan } = await makePlan();
+
+    await expect(
+      applyClawAddPlan(plan, { consentPlanIntegrity: "sha256:stale" }),
+    ).rejects.toMatchObject({ code: "plan_integrity_mismatch" });
+    await expect(access(plan.agent.workspace)).rejects.toThrow();
+  });
+});

--- a/src/claws/provenance.test.ts
+++ b/src/claws/provenance.test.ts
@@ -273,6 +273,20 @@ describe("applyClawAddPlan", () => {
     await expect(access(plan.agent.workspace)).rejects.toThrow();
   });
 
+  it("rechecks normalized agent collisions during the config commit", async () => {
+    const { plan } = await makePlan();
+
+    await expect(
+      applyClawAddPlan(plan, {
+        consentPlanIntegrity: plan.planIntegrity,
+        commitConfig: async (transform) => {
+          transform({ agents: { list: [{ id: " Worker " }] } });
+        },
+      }),
+    ).rejects.toMatchObject({ code: "agent_id_collision" });
+    await expect(access(plan.agent.workspace)).rejects.toThrow();
+  });
+
   it("rechecks aliased workspace collisions during the config commit", async () => {
     const root = await mkdtemp(join(tmpdir(), "openclaw-claw-workspace-alias-"));
     const canonicalParent = join(root, "canonical");

--- a/src/claws/provenance.test.ts
+++ b/src/claws/provenance.test.ts
@@ -283,7 +283,12 @@ describe("applyClawAddPlan", () => {
           transform({ agents: { list: [{ id: " Worker " }] } });
         },
       }),
-    ).rejects.toMatchObject({ code: "agent_id_collision" });
+    ).resolves.toMatchObject({
+      status: "partial",
+      workspaceCreated: false,
+      configCommitted: false,
+      error: { code: "agent_id_collision" },
+    });
     await expect(access(plan.agent.workspace)).rejects.toThrow();
   });
 

--- a/src/claws/provenance.test.ts
+++ b/src/claws/provenance.test.ts
@@ -1,8 +1,8 @@
 // Tests root Claw install ownership and the narrow agent/workspace mutation slice.
-import { access, mkdir, mkdtemp, rmdir, symlink, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { access, mkdir, rmdir, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -18,6 +18,8 @@ import {
 import { parseClawManifest } from "./schema.js";
 import type { ClawSourceIdentity } from "./types.js";
 
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
 afterEach(() => {
   closeOpenClawStateDatabaseForTest();
 });
@@ -26,7 +28,7 @@ async function makePlan(
   manifestValue: unknown = { schemaVersion: 1, agent: { id: "worker" } },
   options: { workspace?: string } = {},
 ) {
-  const root = await mkdtemp(join(tmpdir(), "openclaw-claw-add-"));
+  const root = tempDirs.make("openclaw-claw-add-");
   const parsed = parseClawManifest(manifestValue);
   if (!parsed.ok) {
     throw new Error(JSON.stringify(parsed.diagnostics));
@@ -240,7 +242,7 @@ describe("applyClawAddPlan", () => {
   });
 
   it("rejects overlap with the implicit main workspace before materializing it", async () => {
-    const root = await mkdtemp(join(tmpdir(), "openclaw-claw-implicit-main-"));
+    const root = tempDirs.make("openclaw-claw-implicit-main-");
     const mainWorkspace = join(root, "main-workspace");
     const { root: planRoot, plan } = await makePlan(undefined, {
       workspace: join(mainWorkspace, "nested-claw"),
@@ -289,7 +291,7 @@ describe("applyClawAddPlan", () => {
   });
 
   it("rechecks aliased workspace collisions during the config commit", async () => {
-    const root = await mkdtemp(join(tmpdir(), "openclaw-claw-workspace-alias-"));
+    const root = tempDirs.make("openclaw-claw-workspace-alias-");
     const canonicalParent = join(root, "canonical");
     const aliasParent = join(root, "alias");
     await mkdir(canonicalParent);
@@ -315,7 +317,7 @@ describe("applyClawAddPlan", () => {
   });
 
   it("rejects workspace ancestry changes after planning", async () => {
-    const root = await mkdtemp(join(tmpdir(), "openclaw-claw-workspace-swap-"));
+    const root = tempDirs.make("openclaw-claw-workspace-swap-");
     const canonicalParent = join(root, "canonical");
     const alternateParent = join(root, "alternate");
     await mkdir(canonicalParent);
@@ -354,7 +356,7 @@ describe("applyClawAddPlan", () => {
   });
 
   it("records parent-directory creation failures before workspace mutation", async () => {
-    const root = await mkdtemp(join(tmpdir(), "openclaw-claw-add-"));
+    const root = tempDirs.make("openclaw-claw-add-");
     const blockedParent = join(root, "blocked-parent");
     await writeFile(blockedParent, "not a directory", "utf8");
     const { plan } = await makePlan(undefined, {

--- a/src/claws/provenance.test.ts
+++ b/src/claws/provenance.test.ts
@@ -284,12 +284,7 @@ describe("applyClawAddPlan", () => {
           transform({ agents: { list: [{ id: " Worker " }] } });
         },
       }),
-    ).resolves.toMatchObject({
-      status: "partial",
-      workspaceCreated: false,
-      configCommitted: false,
-      error: { code: "agent_id_collision" },
-    });
+    ).rejects.toMatchObject({ code: "agent_id_collision" });
     await expect(access(plan.agent.workspace)).rejects.toThrow();
   });
 

--- a/src/claws/provenance.test.ts
+++ b/src/claws/provenance.test.ts
@@ -274,10 +274,11 @@ describe("applyClawAddPlan", () => {
   });
 
   it("rechecks normalized agent collisions during the config commit", async () => {
-    const { plan } = await makePlan();
+    const { root, plan } = await makePlan();
 
     await expect(
       applyClawAddPlan(plan, {
+        env: stateEnv(root),
         consentPlanIntegrity: plan.planIntegrity,
         commitConfig: async (transform) => {
           transform({ agents: { list: [{ id: " Worker " }] } });

--- a/src/claws/provenance.ts
+++ b/src/claws/provenance.ts
@@ -1,0 +1,267 @@
+// Persists the root ownership record for one Claw-created agent and workspace.
+import { createHash } from "node:crypto";
+import type { DatabaseSync } from "node:sqlite";
+import { stableStringify } from "../agents/stable-stringify.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabaseOptions,
+} from "../state/openclaw-state-db.js";
+import type { ClawAddPlan } from "./types.js";
+
+const CLAW_INSTALL_RECORD_SCHEMA_VERSION = "openclaw.clawInstallRecord.v1" as const;
+
+export type ClawInstallStatus =
+  | "pending"
+  | "workspace_ready"
+  | "config_committed"
+  | "complete"
+  | "partial";
+
+type ClawInstallRow = {
+  agent_id: string;
+  schema_version: string;
+  source_kind: "package" | "development";
+  claw_name: string;
+  claw_version: string;
+  package_root: string;
+  manifest_path: string;
+  integrity_kind: "artifact" | "development-snapshot";
+  integrity: string;
+  source_byte_length: number | bigint;
+  manifest_schema_version: number | bigint;
+  plan_integrity: string;
+  workspace: string;
+  agent_config_digest: string;
+  agent_owned_paths_json: string;
+  status: ClawInstallStatus;
+  added_at_ms: number | bigint;
+  updated_at_ms: number | bigint;
+};
+
+export type PersistedClawInstall = {
+  schemaVersion: typeof CLAW_INSTALL_RECORD_SCHEMA_VERSION;
+  claw: ClawAddPlan["claw"];
+  manifestSchemaVersion: ClawAddPlan["manifestSchemaVersion"];
+  planIntegrity: string;
+  agentId: string;
+  workspace: string;
+  agentConfigDigest: string;
+  agentOwnedPaths: string[];
+  status: ClawInstallStatus;
+  addedAtMs: number;
+  updatedAtMs: number;
+};
+
+function digestAgentConfig(plan: ClawAddPlan): string {
+  return `sha256:${createHash("sha256").update(stableStringify(plan.agent.config)).digest("hex")}`;
+}
+
+function agentOwnedPaths(plan: ClawAddPlan): string[] {
+  return plan.actions.filter((action) => action.kind === "agent").map((action) => action.target);
+}
+
+function rowToRecord(row: ClawInstallRow): PersistedClawInstall {
+  return {
+    schemaVersion: CLAW_INSTALL_RECORD_SCHEMA_VERSION,
+    claw: {
+      kind: row.source_kind,
+      name: row.claw_name,
+      version: row.claw_version,
+      packageRoot: row.package_root,
+      manifestPath: row.manifest_path,
+      integrityKind: row.integrity_kind,
+      integrity: row.integrity,
+      byteLength: Number(row.source_byte_length),
+    },
+    manifestSchemaVersion: Number(
+      row.manifest_schema_version,
+    ) as ClawAddPlan["manifestSchemaVersion"],
+    planIntegrity: row.plan_integrity,
+    agentId: row.agent_id,
+    workspace: row.workspace,
+    agentConfigDigest: row.agent_config_digest,
+    agentOwnedPaths: JSON.parse(row.agent_owned_paths_json) as string[],
+    status: row.status,
+    addedAtMs: Number(row.added_at_ms),
+    updatedAtMs: Number(row.updated_at_ms),
+  };
+}
+
+function selectClawInstallRow(db: DatabaseSync, agentId: string): ClawInstallRow | undefined {
+  return db /* sqlite-allow-raw: this Claw prototype state-table read is scoped to one owned row. */
+    .prepare(
+      `SELECT agent_id, schema_version, source_kind, claw_name, claw_version,
+              package_root, manifest_path, integrity_kind, integrity, source_byte_length,
+              manifest_schema_version, plan_integrity, workspace, agent_config_digest,
+              agent_owned_paths_json, status, added_at_ms, updated_at_ms
+         FROM claw_installs
+        WHERE agent_id = ?`,
+    )
+    .get(agentId) as ClawInstallRow | undefined;
+}
+
+function getClawInstallRow(
+  agentId: string,
+  options: OpenClawStateDatabaseOptions,
+): ClawInstallRow | undefined {
+  return selectClawInstallRow(openOpenClawStateDatabase(options).db, agentId);
+}
+
+export function readClawInstallRecord(
+  agentId: string,
+  options: OpenClawStateDatabaseOptions = {},
+): PersistedClawInstall | undefined {
+  const row = getClawInstallRow(agentId, options);
+  return row ? rowToRecord(row) : undefined;
+}
+
+function isSameInstallAttempt(
+  row: ClawInstallRow,
+  plan: ClawAddPlan,
+  agentConfigDigest: string,
+  ownedPaths: string[],
+): boolean {
+  return (
+    row.schema_version === CLAW_INSTALL_RECORD_SCHEMA_VERSION &&
+    row.source_kind === plan.claw.kind &&
+    row.claw_name === plan.claw.name &&
+    row.claw_version === plan.claw.version &&
+    row.package_root === plan.claw.packageRoot &&
+    row.manifest_path === plan.claw.manifestPath &&
+    row.integrity_kind === plan.claw.integrityKind &&
+    row.integrity === plan.claw.integrity &&
+    Number(row.source_byte_length) === plan.claw.byteLength &&
+    Number(row.manifest_schema_version) === plan.manifestSchemaVersion &&
+    row.plan_integrity === plan.planIntegrity &&
+    row.workspace === plan.agent.workspace &&
+    row.agent_config_digest === agentConfigDigest &&
+    row.agent_owned_paths_json === JSON.stringify(ownedPaths)
+  );
+}
+
+export function persistClawInstallRecord(
+  plan: ClawAddPlan,
+  options: OpenClawStateDatabaseOptions & { status?: ClawInstallStatus; nowMs?: number } = {},
+): PersistedClawInstall {
+  const nowMs = options.nowMs ?? Date.now();
+  const status = options.status ?? "complete";
+  const agentConfigDigest = digestAgentConfig(plan);
+  const ownedPaths = agentOwnedPaths(plan);
+  return runOpenClawStateWriteTransaction(({ db }) => {
+    const existing = selectClawInstallRow(db, plan.agent.finalId);
+    if (existing) {
+      if (
+        existing.status !== "complete" &&
+        isSameInstallAttempt(existing, plan, agentConfigDigest, ownedPaths)
+      ) {
+        return rowToRecord(existing);
+      }
+      // A nonmatching partial attempt remains durable ownership evidence. A later
+      // remove/doctor lifecycle must clear it; a new plan must never overwrite it.
+      throw new Error(
+        `Claw install record for agent ${JSON.stringify(plan.agent.finalId)} already exists.`,
+      );
+    }
+    // sqlite-allow-raw: this Claw prototype state-table write is scoped to one owned row.
+    db.prepare(
+      `INSERT INTO claw_installs (
+         agent_id, schema_version, source_kind, claw_name, claw_version,
+         package_root, manifest_path, integrity_kind, integrity, source_byte_length,
+         manifest_schema_version, plan_integrity, workspace, agent_config_digest,
+         agent_owned_paths_json,
+         status, added_at_ms, updated_at_ms
+       ) VALUES (
+         @agent_id, @schema_version, @source_kind, @claw_name, @claw_version,
+         @package_root, @manifest_path, @integrity_kind, @integrity, @source_byte_length,
+         @manifest_schema_version, @plan_integrity, @workspace, @agent_config_digest,
+         @agent_owned_paths_json,
+         @status, @added_at_ms, @updated_at_ms
+       )`,
+    ).run({
+      agent_id: plan.agent.finalId,
+      schema_version: CLAW_INSTALL_RECORD_SCHEMA_VERSION,
+      source_kind: plan.claw.kind,
+      claw_name: plan.claw.name,
+      claw_version: plan.claw.version,
+      package_root: plan.claw.packageRoot,
+      manifest_path: plan.claw.manifestPath,
+      integrity_kind: plan.claw.integrityKind,
+      integrity: plan.claw.integrity,
+      source_byte_length: plan.claw.byteLength,
+      manifest_schema_version: plan.manifestSchemaVersion,
+      plan_integrity: plan.planIntegrity,
+      workspace: plan.agent.workspace,
+      agent_config_digest: agentConfigDigest,
+      agent_owned_paths_json: JSON.stringify(ownedPaths),
+      status,
+      added_at_ms: nowMs,
+      updated_at_ms: nowMs,
+    });
+    return {
+      schemaVersion: CLAW_INSTALL_RECORD_SCHEMA_VERSION,
+      claw: plan.claw,
+      manifestSchemaVersion: plan.manifestSchemaVersion,
+      planIntegrity: plan.planIntegrity,
+      agentId: plan.agent.finalId,
+      workspace: plan.agent.workspace,
+      agentConfigDigest,
+      agentOwnedPaths: ownedPaths,
+      status,
+      addedAtMs: nowMs,
+      updatedAtMs: nowMs,
+    };
+  }, options);
+}
+
+export function updateClawInstallRecordStatus(
+  agentId: string,
+  status: ClawInstallStatus,
+  options: OpenClawStateDatabaseOptions & {
+    nowMs?: number;
+    expectedStatuses?: ClawInstallStatus[];
+  } = {},
+): void {
+  runOpenClawStateWriteTransaction(({ db }) => {
+    const expectedStatuses = options.expectedStatuses ?? [];
+    const expectedClause =
+      expectedStatuses.length > 0
+        ? ` AND status IN (${expectedStatuses.map(() => "?").join(", ")})`
+        : "";
+    const result =
+      db /* sqlite-allow-raw: this Claw prototype state-table write is scoped to one owned row. */
+        .prepare(
+          `UPDATE claw_installs
+            SET status = ?, updated_at_ms = ?
+          WHERE agent_id = ?${expectedClause}`,
+        )
+        .run(status, options.nowMs ?? Date.now(), agentId, ...expectedStatuses);
+    if (result.changes !== 1) {
+      throw new Error(
+        `Claw install record for agent ${JSON.stringify(agentId)} did not match the expected phase.`,
+      );
+    }
+  }, options);
+}
+
+export function deleteClawInstallRecord(
+  agentId: string,
+  options: OpenClawStateDatabaseOptions & { expectedStatuses?: ClawInstallStatus[] } = {},
+): void {
+  runOpenClawStateWriteTransaction(({ db }) => {
+    const expectedStatuses = options.expectedStatuses ?? [];
+    const expectedClause =
+      expectedStatuses.length > 0
+        ? ` AND status IN (${expectedStatuses.map(() => "?").join(", ")})`
+        : "";
+    const result =
+      db /* sqlite-allow-raw: this Claw prototype state-table delete is scoped to one owned row. */
+        .prepare(`DELETE FROM claw_installs WHERE agent_id = ?${expectedClause}`)
+        .run(agentId, ...expectedStatuses);
+    if (result.changes !== 1) {
+      throw new Error(
+        `Claw install record for agent ${JSON.stringify(agentId)} did not match the expected phase.`,
+      );
+    }
+  }, options);
+}

--- a/src/claws/schema.test.ts
+++ b/src/claws/schema.test.ts
@@ -1,12 +1,14 @@
 // Tests for the grouped Claw manifest and read-only add plan.
-import { mkdir, mkdtemp, realpath, symlink, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { mkdir, realpath, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { buildClawAddPlan } from "./lifecycle.js";
 import { readClawManifestFile } from "./reader.js";
 import { parseClawManifest } from "./schema.js";
 import type { ClawManifest, ClawSourceIdentity } from "./types.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const baseManifest = {
   schemaVersion: 1,
@@ -61,7 +63,7 @@ function requireManifest(value: unknown = baseManifest): ClawManifest {
 }
 
 async function createPlanSource(): Promise<{ source: ClawSourceIdentity; workspace: string }> {
-  const root = await mkdtemp(join(tmpdir(), "openclaw-claw-plan-"));
+  const root = tempDirs.make("openclaw-claw-plan-");
   await mkdir(join(root, "workspace", "reference"), { recursive: true });
   await writeFile(join(root, "workspace", "AGENTS.md"), "# Agent\n", "utf8");
   await writeFile(join(root, "workspace", "reference", "policy.md"), "Policy\n", "utf8");
@@ -269,7 +271,7 @@ describe("parseClawManifest", () => {
 
 describe("readClawManifestFile", () => {
   it("takes published identity from package.json", async () => {
-    const root = await mkdtemp(join(tmpdir(), "openclaw-claw-package-"));
+    const root = tempDirs.make("openclaw-claw-package-");
     await writeFile(
       join(root, "package.json"),
       JSON.stringify({
@@ -302,7 +304,7 @@ describe("readClawManifestFile", () => {
   });
 
   it("synthesizes explicit development identity for a standalone manifest", async () => {
-    const root = await mkdtemp(join(tmpdir(), "openclaw-claw-development-"));
+    const root = tempDirs.make("openclaw-claw-development-");
     const path = join(root, "demo.claw.json");
     await writeFile(
       path,
@@ -324,7 +326,7 @@ describe("readClawManifestFile", () => {
   });
 
   it("rejects workspace sources through an intermediate symlink", async () => {
-    const root = await mkdtemp(join(tmpdir(), "openclaw-claw-reader-symlink-"));
+    const root = tempDirs.make("openclaw-claw-reader-symlink-");
     await mkdir(join(root, "workspace"));
     await writeFile(join(root, "workspace", "AGENTS.md"), "# Agent\n", "utf8");
     await symlink(
@@ -352,7 +354,7 @@ describe("readClawManifestFile", () => {
   });
 
   it("rejects a workspace source over the per-file byte limit", async () => {
-    const root = await mkdtemp(join(tmpdir(), "openclaw-claw-reader-file-limit-"));
+    const root = tempDirs.make("openclaw-claw-reader-file-limit-");
     await writeFile(join(root, "large.md"), Buffer.alloc(1024 * 1024 + 1));
     const manifestPath = join(root, "demo.claw.json");
     await writeFile(
@@ -374,7 +376,7 @@ describe("readClawManifestFile", () => {
   });
 
   it("rejects aggregate workspace bytes before reading source contents", async () => {
-    const root = await mkdtemp(join(tmpdir(), "openclaw-claw-reader-aggregate-limit-"));
+    const root = tempDirs.make("openclaw-claw-reader-aggregate-limit-");
     const files = [];
     for (let index = 0; index < 5; index += 1) {
       const source = `large-${index}.md`;
@@ -401,7 +403,7 @@ describe("readClawManifestFile", () => {
   });
 
   it("rejects package manifests that escape the package root", async () => {
-    const parent = await mkdtemp(join(tmpdir(), "openclaw-claw-escape-"));
+    const parent = tempDirs.make("openclaw-claw-escape-");
     const root = join(parent, "package");
     await mkdir(root);
     await writeFile(
@@ -511,7 +513,7 @@ describe("buildClawAddPlan", () => {
 
   it("canonicalizes a missing workspace through an existing aliased parent", async () => {
     const { source } = await createPlanSource();
-    const root = await mkdtemp(join(tmpdir(), "openclaw-claw-workspace-alias-"));
+    const root = tempDirs.make("openclaw-claw-workspace-alias-");
     const canonicalParent = join(root, "canonical");
     const aliasParent = join(root, "alias");
     await mkdir(canonicalParent);

--- a/src/claws/schema.test.ts
+++ b/src/claws/schema.test.ts
@@ -1,13 +1,12 @@
 // Tests for the grouped Claw manifest and read-only add plan.
-import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { buildClawAddPlan } from "./lifecycle.js";
 import { readClawManifestFile } from "./reader.js";
 import { parseClawManifest } from "./schema.js";
-import type { ClawManifest, ClawSourceIdentity, ClawSourceSnapshot } from "./types.js";
+import type { ClawManifest, ClawSourceIdentity } from "./types.js";
 
 const baseManifest = {
   schemaVersion: 1,
@@ -36,7 +35,7 @@ const baseManifest = {
     github: {
       command: "npx",
       args: ["--yes", "@acme/github-mcp@3.4.1"],
-      env: { API_TOKEN: "${GITHUB_TOKEN}" },
+      env: { GITHUB_TOKEN: "${GITHUB_TOKEN}" },
       toolFilter: { include: ["issues_list"], exclude: ["repository_delete"] },
       timeout: 30,
     },
@@ -61,15 +60,7 @@ function requireManifest(value: unknown = baseManifest): ClawManifest {
   return result.manifest;
 }
 
-function snapshotDigest(value: string | Buffer): string {
-  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
-}
-
-async function createPlanSource(): Promise<{
-  source: ClawSourceIdentity;
-  snapshot: ClawSourceSnapshot;
-  workspace: string;
-}> {
+async function createPlanSource(): Promise<{ source: ClawSourceIdentity; workspace: string }> {
   const root = await mkdtemp(join(tmpdir(), "openclaw-claw-plan-"));
   await mkdir(join(root, "workspace", "reference"), { recursive: true });
   await writeFile(join(root, "workspace", "AGENTS.md"), "# Agent\n", "utf8");
@@ -84,22 +75,6 @@ async function createPlanSource(): Promise<{
       integrityKind: "development-snapshot",
       integrity: "sha256:test",
       byteLength: 0,
-    },
-    snapshot: {
-      workspaceSources: [
-        {
-          sourcePath: "workspace/AGENTS.md",
-          realPath: join(root, "workspace", "AGENTS.md"),
-          byteLength: Buffer.byteLength("# Agent\n"),
-          digest: snapshotDigest("# Agent\n"),
-        },
-        {
-          sourcePath: "workspace/reference/policy.md",
-          realPath: join(root, "workspace", "reference", "policy.md"),
-          byteLength: Buffer.byteLength("Policy\n"),
-          digest: snapshotDigest("Policy\n"),
-        },
-      ],
     },
     workspace: join(root, "new-workspace"),
   };
@@ -455,11 +430,10 @@ describe("readClawManifestFile", () => {
 
 describe("buildClawAddPlan", () => {
   it("plans one new agent, workspace, packages, MCP servers, and agent-pinned cron jobs", async () => {
-    const { source, snapshot, workspace } = await createPlanSource();
+    const { source, workspace } = await createPlanSource();
     const plan = await buildClawAddPlan({
       manifest: requireManifest(),
       source,
-      snapshot,
       context: { workspace },
     });
 
@@ -494,9 +468,6 @@ describe("buildClawAddPlan", () => {
         expect.objectContaining({ kind: "cronJob", id: "weekday-triage" }),
       ]),
     );
-    expect(
-      plan.capabilityChanges.find((change) => change.kind === "mcpServer")?.effect.env,
-    ).toEqual([{ name: "API_TOKEN", reference: "GITHUB_TOKEN" }]);
     expect(plan.actions).toContainEqual(
       expect.objectContaining({
         kind: "workspaceFile",
@@ -514,11 +485,10 @@ describe("buildClawAddPlan", () => {
   });
 
   it("blocks agent, configured workspace, MCP, and cron collisions", async () => {
-    const { source, snapshot, workspace } = await createPlanSource();
+    const { source, workspace } = await createPlanSource();
     const plan = await buildClawAddPlan({
       manifest: requireManifest(),
       source,
-      snapshot,
       context: {
         workspace,
         existingAgentIds: ["github-triage"],
@@ -539,12 +509,33 @@ describe("buildClawAddPlan", () => {
     expect(plan.summary.blockedActions).toBe(8);
   });
 
-  it("uses an explicit unused agent id for every derived action", async () => {
-    const { source, snapshot, workspace } = await createPlanSource();
+  it("canonicalizes a missing workspace through an existing aliased parent", async () => {
+    const { source } = await createPlanSource();
+    const root = await mkdtemp(join(tmpdir(), "openclaw-claw-workspace-alias-"));
+    const canonicalParent = join(root, "canonical");
+    const aliasParent = join(root, "alias");
+    await mkdir(canonicalParent);
+    await symlink(canonicalParent, aliasParent, process.platform === "win32" ? "junction" : "dir");
+    const canonicalWorkspace = join(await realpath(canonicalParent), "new-workspace");
+
     const plan = await buildClawAddPlan({
       manifest: requireManifest(),
       source,
-      snapshot,
+      context: {
+        workspace: join(aliasParent, "new-workspace"),
+        existingWorkspacePaths: [canonicalWorkspace],
+      },
+    });
+
+    expect(plan.agent.workspace).toBe(canonicalWorkspace);
+    expect(plan.blockers).toContainEqual(expect.objectContaining({ code: "workspace_collision" }));
+  });
+
+  it("uses an explicit unused agent id for every derived action", async () => {
+    const { source, workspace } = await createPlanSource();
+    const plan = await buildClawAddPlan({
+      manifest: requireManifest(),
+      source,
       context: { agentId: "triage-two", workspace },
     });
 
@@ -555,8 +546,13 @@ describe("buildClawAddPlan", () => {
     );
   });
 
-  it("blocks workspace sources missing from the validated snapshot", async () => {
-    const { source, snapshot, workspace } = await createPlanSource();
+  it("rejects workspace sources through symlinked parents", async () => {
+    const { source, workspace } = await createPlanSource();
+    await symlink(
+      join(source.packageRoot, "workspace"),
+      join(source.packageRoot, "workspace-link"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
     const plan = await buildClawAddPlan({
       manifest: requireManifest({
         schemaVersion: 1,
@@ -566,12 +562,11 @@ describe("buildClawAddPlan", () => {
         },
       }),
       source,
-      snapshot,
       context: { workspace },
     });
 
     expect(plan.blockers).toContainEqual(
-      expect.objectContaining({ code: "workspace_source_invalid" }),
+      expect.objectContaining({ code: "workspace_source_unsafe" }),
     );
     const workspaceAction = plan.actions.find(
       (action) => action.kind === "workspaceFile" && action.id === "AGENTS.md",
@@ -583,17 +578,10 @@ describe("buildClawAddPlan", () => {
   it("blocks aggregate workspace bytes before hashing sources", async () => {
     const { source, workspace } = await createPlanSource();
     const files = [];
-    const workspaceSources = [];
     for (let index = 0; index < 5; index += 1) {
       const sourcePath = `workspace/large-${index}.md`;
       await writeFile(join(source.packageRoot, sourcePath), Buffer.alloc(1024 * 1024, index));
       files.push({ source: sourcePath, path: `large-${index}.md` });
-      workspaceSources.push({
-        sourcePath,
-        realPath: join(source.packageRoot, sourcePath),
-        byteLength: 1024 * 1024,
-        digest: snapshotDigest(Buffer.alloc(1024 * 1024, index)),
-      });
     }
     const plan = await buildClawAddPlan({
       manifest: requireManifest({
@@ -602,7 +590,6 @@ describe("buildClawAddPlan", () => {
         workspace: { files },
       }),
       source,
-      snapshot: { workspaceSources },
       context: { workspace },
     });
 
@@ -612,67 +599,24 @@ describe("buildClawAddPlan", () => {
     const workspaceFileActions = plan.actions.filter((action) => action.kind === "workspaceFile");
     expect(workspaceFileActions).toHaveLength(5);
     expect(workspaceFileActions.every((action) => action.blocked)).toBe(true);
-    expect(workspaceFileActions.every((action) => action.blocked)).toBe(true);
-  });
-
-  it("uses the validated snapshot after source files change", async () => {
-    const { source, snapshot, workspace } = await createPlanSource();
-    const agentsSnapshot = snapshot.workspaceSources.find(
-      (entry) => entry.sourcePath === "workspace/AGENTS.md",
-    );
-    await writeFile(join(source.packageRoot, "workspace", "AGENTS.md"), "# Changed\n", "utf8");
-
-    const plan = await buildClawAddPlan({
-      manifest: requireManifest(),
-      source,
-      snapshot,
-      context: { workspace },
-    });
-
-    expect(
-      plan.actions.find((action) => action.kind === "workspaceFile" && action.id === "AGENTS.md")
-        ?.digest,
-    ).toBe(agentsSnapshot?.digest);
-    expect(agentsSnapshot?.digest).toBe(snapshotDigest("# Agent\n"));
-  });
-
-  it("blocks when workspace absence cannot be proven", async () => {
-    const { source, snapshot } = await createPlanSource();
-    const workspace = join(source.packageRoot, "x".repeat(300));
-    const plan = await buildClawAddPlan({
-      manifest: requireManifest(),
-      source,
-      snapshot,
-      context: { workspace },
-    });
-
-    expect(plan.blockers).toContainEqual(
-      expect.objectContaining({ code: "workspace_probe_failed" }),
-    );
-    expect(plan.actions.find((action) => action.kind === "workspace")).toMatchObject({
-      blocked: true,
-      details: { expectedState: "unknown" },
-    });
+    expect(workspaceFileActions.every((action) => !Object.hasOwn(action, "digest"))).toBe(true);
   });
 
   it("binds plan integrity to the source and planned mutations", async () => {
-    const { source, snapshot, workspace } = await createPlanSource();
+    const { source, workspace } = await createPlanSource();
     const first = await buildClawAddPlan({
       manifest: requireManifest(),
       source,
-      snapshot,
       context: { workspace },
     });
     const repeated = await buildClawAddPlan({
       manifest: requireManifest(),
       source,
-      snapshot,
       context: { workspace },
     });
     const changed = await buildClawAddPlan({
       manifest: requireManifest(),
       source: { ...source, integrity: "sha256:changed" },
-      snapshot,
       context: { workspace },
     });
     const changedCapability = await buildClawAddPlan({
@@ -681,7 +625,6 @@ describe("buildClawAddPlan", () => {
         agent: { ...baseManifest.agent, tools: { allow: ["read", "exec"] } },
       }),
       source,
-      snapshot,
       context: { workspace },
     });
 

--- a/src/claws/types.ts
+++ b/src/claws/types.ts
@@ -149,7 +149,7 @@ export type ClawWorkspaceSourceSnapshot = {
   digest: string;
 };
 
-export type ClawSourceSnapshot = {
+type ClawSourceSnapshot = {
   workspaceSources: ClawWorkspaceSourceSnapshot[];
 };
 

--- a/src/cli/claws-cli.runtime.ts
+++ b/src/cli/claws-cli.runtime.ts
@@ -1,6 +1,13 @@
 import { listAgentIds, resolveAgentWorkspaceDir } from "../agents/agent-scope-config.js";
+import { stableStringify } from "../agents/stable-stringify.js";
+import {
+  applyClawAddPlan,
+  CLAW_ADD_RESULT_SCHEMA_VERSION,
+  ClawAddMutationError,
+} from "../claws/add.js";
 import { assertExperimentalClawsEnabled } from "../claws/experimental.js";
 import { buildClawAddPlan } from "../claws/lifecycle.js";
+import { readClawInstallRecord } from "../claws/provenance.js";
 import { readClawManifestFile } from "../claws/reader.js";
 import {
   CLAW_INSPECT_RESULT_SCHEMA_VERSION,
@@ -54,18 +61,44 @@ function logClawAddPlanSummary(plan: ClawAddPlan, runtime: RuntimeEnv): void {
   }
 }
 
+function matchingResumeRecord(plan: ClawAddPlan, opts: ClawsAddOptions) {
+  if (opts.dryRun || !opts.yes || !opts.planIntegrity) {
+    return undefined;
+  }
+  const record = readClawInstallRecord(plan.agent.finalId);
+  if (
+    !record ||
+    record.status === "complete" ||
+    record.planIntegrity !== opts.planIntegrity ||
+    record.workspace !== plan.agent.workspace ||
+    record.claw.kind !== plan.claw.kind ||
+    record.claw.name !== plan.claw.name ||
+    record.claw.version !== plan.claw.version ||
+    record.claw.integrity !== plan.claw.integrity
+  ) {
+    return undefined;
+  }
+  return record;
+}
+
 function failNonDryRun(opts: ClawsAddOptions, runtime: RuntimeEnv): boolean {
   if (opts.dryRun) {
     return false;
   }
-  const message =
-    "Claw add is dry-run only in this OpenClaw build; pass --dry-run to preview lifecycle actions.";
+  const consented = opts.yes && opts.planIntegrity;
+  if (consented) {
+    return false;
+  }
+  const code = opts.yes ? "plan_integrity_required" : "consent_required";
+  const message = opts.yes
+    ? "Claw add consent must include --plan-integrity from the exact dry-run plan."
+    : "Claw add requires explicit consent; pass --dry-run to preview or --yes with --plan-integrity to create the new agent and workspace.";
   if (opts.json) {
     writeRuntimeJson(runtime, {
       schemaVersion: CLAW_ADD_PLAN_SCHEMA_VERSION,
       stability: CLAW_OUTPUT_STABILITY,
       ok: false,
-      error: { code: "dry_run_required", message },
+      error: { code, message },
     });
   } else {
     runtime.error(message);
@@ -143,37 +176,125 @@ export async function runClawsAddCommand(
 
   const config = getRuntimeConfig();
   const existingAgentIds = listAgentIds(config);
+  const existingWorkspacePaths = existingAgentIds.map((agentId) =>
+    resolveAgentWorkspaceDir(config, agentId),
+  );
   const cronStore = await loadCronJobsStoreWithConfigJobsReadOnly(
     resolveCronJobsStorePath(config.cron?.store),
   );
-  const plan = await buildClawAddPlan({
+  const basePlanContext = {
+    ...(opts.agentId ? { agentId: opts.agentId } : {}),
+    ...(opts.workspace ? { workspace: opts.workspace } : {}),
+    existingAgentIds,
+    existingWorkspacePaths,
+    existingMcpServerNames: Object.keys(config.mcp?.servers ?? {}),
+    existingCronJobIds: cronStore.store.jobs.map((job) => job.id),
+  };
+  let plan = await buildClawAddPlan({
     manifest: result.manifest,
     source: result.source,
     snapshot: result.snapshot,
     diagnostics: result.diagnostics,
-    context: {
-      ...(opts.agentId ? { agentId: opts.agentId } : {}),
-      ...(opts.workspace ? { workspace: opts.workspace } : {}),
-      existingAgentIds,
-      existingWorkspacePaths: existingAgentIds.map((agentId) =>
-        resolveAgentWorkspaceDir(config, agentId),
-      ),
-      existingMcpServerNames: Object.keys(config.mcp?.servers ?? {}),
-      existingCronJobIds: cronStore.store.jobs.map((job) => job.id),
-    },
+    context: basePlanContext,
   });
+  const resumeRecord = matchingResumeRecord(plan, opts);
+  if (resumeRecord && plan.blockers.length > 0) {
+    const canResumeWorkspace =
+      resumeRecord.status === "workspace_ready" || resumeRecord.status === "config_committed";
+    const committedAgent = config.agents?.list?.find(
+      (agent) => stableStringify(agent) === stableStringify(plan.agent.config),
+    );
+    const canResumeAgent =
+      resumeRecord.status === "config_committed" ||
+      (resumeRecord.status === "workspace_ready" && committedAgent !== undefined);
+    plan = await buildClawAddPlan({
+      manifest: result.manifest,
+      source: result.source,
+      diagnostics: result.diagnostics,
+      context: {
+        ...basePlanContext,
+        existingAgentIds: canResumeAgent
+          ? existingAgentIds.filter((agentId) => agentId !== resumeRecord.agentId)
+          : existingAgentIds,
+        existingWorkspacePaths: canResumeWorkspace
+          ? existingAgentIds
+              .filter((agentId) => agentId !== resumeRecord.agentId)
+              .map((agentId) => resolveAgentWorkspaceDir(config, agentId))
+          : existingWorkspacePaths,
+        ...(canResumeWorkspace ? { resumableWorkspace: resumeRecord.workspace } : {}),
+      },
+    });
+  }
 
-  if (opts.json) {
-    writeRuntimeJson(runtime, plan);
-  } else {
-    logExperimentalWarning(runtime);
-    runtime.log(`Claw add plan: ${plan.claw.name}@${plan.claw.version}`);
-    logClawAddPlanSummary(plan, runtime);
-    if (plan.blockers.length > 0) {
+  if (plan.blockers.length > 0) {
+    if (opts.json) {
+      writeRuntimeJson(runtime, plan);
+    } else {
+      logExperimentalWarning(runtime);
+      logClawAddPlanSummary(plan, runtime);
       runtime.error(formatDiagnostics(plan.blockers));
     }
+    runtime.exit(1);
+    return;
   }
-  if (plan.blockers.length > 0) {
+
+  if (opts.dryRun) {
+    if (opts.json) {
+      writeRuntimeJson(runtime, plan);
+    } else {
+      logExperimentalWarning(runtime);
+      runtime.log(`Claw add plan: ${plan.claw.name}@${plan.claw.version}`);
+      logClawAddPlanSummary(plan, runtime);
+    }
+    return;
+  }
+
+  if (opts.planIntegrity !== plan.planIntegrity) {
+    const message = "The consented Claw plan no longer matches; run add --dry-run again.";
+    if (opts.json) {
+      writeRuntimeJson(runtime, {
+        schemaVersion: CLAW_ADD_RESULT_SCHEMA_VERSION,
+        stability: CLAW_OUTPUT_STABILITY,
+        status: "failed",
+        planIntegrity: plan.planIntegrity,
+        error: { code: "plan_integrity_mismatch", message },
+      });
+    } else {
+      runtime.error(message);
+    }
+    runtime.exit(1);
+    return;
+  }
+
+  let addResult;
+  try {
+    addResult = await applyClawAddPlan(plan, { consentPlanIntegrity: opts.planIntegrity });
+  } catch (error) {
+    const code = error instanceof ClawAddMutationError ? error.code : "add_failed";
+    const message = (error as Error).message;
+    if (opts.json) {
+      writeRuntimeJson(runtime, {
+        schemaVersion: CLAW_ADD_RESULT_SCHEMA_VERSION,
+        stability: CLAW_OUTPUT_STABILITY,
+        status: "failed",
+        error: { code, message },
+      });
+    } else {
+      runtime.error(message);
+    }
+    runtime.exit(1);
+    return;
+  }
+
+  if (opts.json) {
+    writeRuntimeJson(runtime, addResult);
+  } else {
+    logExperimentalWarning(runtime);
+    runtime.log(`Added agent: ${addResult.agent.finalId}`);
+    runtime.log(`Workspace: ${addResult.agent.workspace}`);
+    runtime.log(`Status: ${addResult.status}`);
+  }
+  if (addResult.status !== "complete") {
     runtime.exit(1);
   }
 }

--- a/src/cli/claws-cli.runtime.ts
+++ b/src/cli/claws-cli.runtime.ts
@@ -193,7 +193,6 @@ export async function runClawsAddCommand(
   let plan = await buildClawAddPlan({
     manifest: result.manifest,
     source: result.source,
-    snapshot: result.snapshot,
     diagnostics: result.diagnostics,
     context: basePlanContext,
   });

--- a/src/cli/claws-cli.test.ts
+++ b/src/cli/claws-cli.test.ts
@@ -3,7 +3,9 @@ import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Command } from "commander";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { persistClawInstallRecord } from "../claws/provenance.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 
 const mocks = vi.hoisted(() => {
   const logs: string[] = [];
@@ -19,7 +21,13 @@ const mocks = vi.hoisted(() => {
       throw new Error(`__exit__:${code}`);
     }),
   };
-  return { logs, errors, runtime, loadConfig: vi.fn<() => Record<string, unknown>>(() => ({})) };
+  return {
+    logs,
+    errors,
+    runtime,
+    loadConfig: vi.fn<() => Record<string, unknown>>(() => ({})),
+    applyClawAddPlan: vi.fn(),
+  };
 });
 
 vi.mock("../runtime.js", async () => ({
@@ -33,6 +41,11 @@ vi.mock("../config/config.js", async () => ({
   ...(await vi.importActual<typeof import("../config/config.js")>("../config/config.js")),
   getRuntimeConfig: mocks.loadConfig,
   loadConfig: mocks.loadConfig,
+}));
+
+vi.mock("../claws/add.js", async () => ({
+  ...(await vi.importActual<typeof import("../claws/add.js")>("../claws/add.js")),
+  applyClawAddPlan: mocks.applyClawAddPlan,
 }));
 
 const { registerClawsCli } = await import("./claws-cli.js");
@@ -98,6 +111,24 @@ describe("claws cli", () => {
     mocks.runtime.exit.mockClear();
     mocks.loadConfig.mockReset();
     mocks.loadConfig.mockReturnValue({});
+    mocks.applyClawAddPlan.mockReset();
+    mocks.applyClawAddPlan.mockImplementation(async (plan) => ({
+      schemaVersion: "openclaw.clawAddResult.v1",
+      stability: "experimental",
+      dryRun: false,
+      mutationAllowed: true,
+      planIntegrity: plan.planIntegrity,
+      status: "complete",
+      claw: plan.claw,
+      agent: plan.agent,
+      workspaceCreated: true,
+      configCommitted: true,
+      installRecord: { agentId: plan.agent.finalId },
+    }));
+  });
+
+  afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
   });
 
   it("does not register without the process opt-in", () => {
@@ -209,7 +240,231 @@ describe("claws cli", () => {
     expect(mocks.logs).toContain("The plan integrity binds every capability line above.");
   });
 
-  it("fails closed when add is invoked without dry-run", async () => {
+  it("applies a minimal Claw only after explicit consent", async () => {
+    const manifestPath = await writeManifest();
+    const workspace = join(await mkdtemp(join(tmpdir(), "openclaw-claws-add-")), "workspace");
+    await runCli(["claws", "add", manifestPath, "--dry-run", "--workspace", workspace, "--json"]);
+    const plan = JSON.parse(mocks.logs[0] ?? "{}");
+    mocks.logs.length = 0;
+
+    await runCli([
+      "claws",
+      "add",
+      manifestPath,
+      "--yes",
+      "--plan-integrity",
+      plan.planIntegrity,
+      "--workspace",
+      workspace,
+      "--json",
+    ]);
+
+    expect(mocks.applyClawAddPlan).toHaveBeenCalledWith(
+      expect.objectContaining({ planIntegrity: plan.planIntegrity }),
+      { consentPlanIntegrity: plan.planIntegrity },
+    );
+    expect(JSON.parse(mocks.logs[0] ?? "{}")).toMatchObject({
+      schemaVersion: "openclaw.clawAddResult.v1",
+      stability: "experimental",
+      status: "complete",
+      agent: { finalId: "demo-agent", workspace },
+    });
+  });
+
+  it("resumes consented add with the matching in-flight workspace on disk", async () => {
+    const manifestPath = await writeManifest();
+    const workspace = join(await mkdtemp(join(tmpdir(), "openclaw-claws-add-")), "workspace");
+    const stateRoot = await mkdtemp(join(tmpdir(), "openclaw-claws-state-"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", join(stateRoot, "state"));
+
+    await runCli(["claws", "add", manifestPath, "--dry-run", "--workspace", workspace, "--json"]);
+    const plan = JSON.parse(mocks.logs[0] ?? "{}");
+    persistClawInstallRecord(plan, { status: "workspace_ready", nowMs: 1 });
+    await mkdir(workspace);
+    await writeFile(join(workspace, "leftover.txt"), "keep", "utf8");
+    mocks.logs.length = 0;
+    mocks.runtime.exit.mockClear();
+    mocks.applyClawAddPlan.mockClear();
+    mocks.loadConfig.mockReturnValue({});
+
+    await runCli([
+      "claws",
+      "add",
+      manifestPath,
+      "--yes",
+      "--plan-integrity",
+      plan.planIntegrity,
+      "--workspace",
+      workspace,
+      "--json",
+    ]);
+
+    expect(mocks.applyClawAddPlan).toHaveBeenCalledWith(
+      expect.objectContaining({ planIntegrity: plan.planIntegrity, blockers: [] }),
+      { consentPlanIntegrity: plan.planIntegrity },
+    );
+    expect(mocks.runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("resumes when config committed before the workspace-ready phase advanced", async () => {
+    const manifestPath = await writeManifest();
+    const workspace = join(await mkdtemp(join(tmpdir(), "openclaw-claws-add-")), "workspace");
+    const stateRoot = await mkdtemp(join(tmpdir(), "openclaw-claws-state-"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", join(stateRoot, "state"));
+
+    await runCli(["claws", "add", manifestPath, "--dry-run", "--workspace", workspace, "--json"]);
+    const plan = JSON.parse(mocks.logs[0] ?? "{}");
+    persistClawInstallRecord(plan, { status: "workspace_ready", nowMs: 1 });
+    await mkdir(workspace);
+    mocks.logs.length = 0;
+    mocks.runtime.exit.mockClear();
+    mocks.applyClawAddPlan.mockClear();
+    mocks.loadConfig.mockReturnValue({ agents: { list: [plan.agent.config] } });
+
+    await runCli([
+      "claws",
+      "add",
+      manifestPath,
+      "--yes",
+      "--plan-integrity",
+      plan.planIntegrity,
+      "--workspace",
+      workspace,
+      "--json",
+    ]);
+
+    expect(mocks.applyClawAddPlan).toHaveBeenCalledWith(
+      expect.objectContaining({ planIntegrity: plan.planIntegrity, blockers: [] }),
+      { consentPlanIntegrity: plan.planIntegrity },
+    );
+    expect(mocks.runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("does not claim an on-disk workspace for a partial record without workspace ownership", async () => {
+    const manifestPath = await writeManifest();
+    const workspace = join(await mkdtemp(join(tmpdir(), "openclaw-claws-add-")), "workspace");
+    const stateRoot = await mkdtemp(join(tmpdir(), "openclaw-claws-state-"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", join(stateRoot, "state"));
+
+    await runCli(["claws", "add", manifestPath, "--dry-run", "--workspace", workspace, "--json"]);
+    const plan = JSON.parse(mocks.logs[0] ?? "{}");
+    persistClawInstallRecord(plan, { status: "partial", nowMs: 1 });
+    await mkdir(workspace);
+    mocks.logs.length = 0;
+    mocks.runtime.exit.mockClear();
+    mocks.applyClawAddPlan.mockClear();
+
+    await runCli([
+      "claws",
+      "add",
+      manifestPath,
+      "--yes",
+      "--plan-integrity",
+      plan.planIntegrity,
+      "--workspace",
+      workspace,
+      "--json",
+    ]);
+
+    expect(JSON.parse(mocks.logs[0] ?? "{}")).toMatchObject({
+      blockers: [expect.objectContaining({ code: "workspace_collision" })],
+    });
+    expect(mocks.applyClawAddPlan).not.toHaveBeenCalled();
+    expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("preserves a real agent collision while an add is still pending", async () => {
+    const manifestPath = await writeManifest();
+    const workspace = join(await mkdtemp(join(tmpdir(), "openclaw-claws-add-")), "workspace");
+    const stateRoot = await mkdtemp(join(tmpdir(), "openclaw-claws-state-"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", join(stateRoot, "state"));
+
+    await runCli(["claws", "add", manifestPath, "--dry-run", "--workspace", workspace, "--json"]);
+    const plan = JSON.parse(mocks.logs[0] ?? "{}");
+    persistClawInstallRecord(plan, { status: "pending", nowMs: 1 });
+    mocks.logs.length = 0;
+    mocks.runtime.exit.mockClear();
+    mocks.applyClawAddPlan.mockClear();
+    mocks.loadConfig.mockReturnValue({ agents: { list: [{ id: "demo-agent", workspace }] } });
+
+    await runCli([
+      "claws",
+      "add",
+      manifestPath,
+      "--yes",
+      "--plan-integrity",
+      plan.planIntegrity,
+      "--workspace",
+      workspace,
+      "--json",
+    ]);
+
+    expect(JSON.parse(mocks.logs[0] ?? "{}")).toMatchObject({
+      blockers: expect.arrayContaining([expect.objectContaining({ code: "agent_id_collision" })]),
+    });
+    expect(mocks.applyClawAddPlan).not.toHaveBeenCalled();
+    expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("does not resume through another agent's configured workspace", async () => {
+    const manifestPath = await writeManifest();
+    const workspace = join(await mkdtemp(join(tmpdir(), "openclaw-claws-add-")), "workspace");
+    const stateRoot = await mkdtemp(join(tmpdir(), "openclaw-claws-state-"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", join(stateRoot, "state"));
+
+    await runCli(["claws", "add", manifestPath, "--dry-run", "--workspace", workspace, "--json"]);
+    const plan = JSON.parse(mocks.logs[0] ?? "{}");
+    persistClawInstallRecord(plan, { status: "workspace_ready", nowMs: 1 });
+    mocks.logs.length = 0;
+    mocks.runtime.exit.mockClear();
+    mocks.applyClawAddPlan.mockClear();
+    mocks.loadConfig.mockReturnValue({ agents: { list: [{ id: "other-agent", workspace }] } });
+
+    await runCli([
+      "claws",
+      "add",
+      manifestPath,
+      "--yes",
+      "--plan-integrity",
+      plan.planIntegrity,
+      "--workspace",
+      workspace,
+      "--json",
+    ]);
+
+    expect(JSON.parse(mocks.logs[0] ?? "{}")).toMatchObject({
+      blockers: [expect.objectContaining({ code: "workspace_collision" })],
+    });
+    expect(mocks.applyClawAddPlan).not.toHaveBeenCalled();
+  });
+
+  it("requires the exact dry-run plan identity with explicit consent", async () => {
+    const manifestPath = await writeManifest();
+
+    await runCli(["claws", "add", manifestPath, "--yes", "--json"]);
+    expect(JSON.parse(mocks.logs[0] ?? "{}")).toMatchObject({
+      error: { code: "plan_integrity_required" },
+    });
+    expect(mocks.applyClawAddPlan).not.toHaveBeenCalled();
+
+    mocks.logs.length = 0;
+    await runCli([
+      "claws",
+      "add",
+      manifestPath,
+      "--yes",
+      "--plan-integrity",
+      "sha256:stale",
+      "--json",
+    ]);
+    expect(JSON.parse(mocks.logs[0] ?? "{}")).toMatchObject({
+      status: "failed",
+      error: { code: "plan_integrity_mismatch" },
+    });
+    expect(mocks.applyClawAddPlan).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when add is invoked without dry-run or consent", async () => {
     const path = await writeManifest();
 
     await runCli(["claws", "add", path, "--json"]);
@@ -217,7 +472,7 @@ describe("claws cli", () => {
     expect(JSON.parse(mocks.logs[0] ?? "{}")).toMatchObject({
       stability: "experimental",
       ok: false,
-      error: { code: "dry_run_required" },
+      error: { code: "consent_required" },
     });
     expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
   });

--- a/src/cli/claws-cli.test.ts
+++ b/src/cli/claws-cli.test.ts
@@ -1,9 +1,9 @@
 // Tests for the experimental grouped Claws CLI.
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { persistClawInstallRecord } from "../claws/provenance.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 
@@ -49,18 +49,19 @@ vi.mock("../claws/add.js", async () => ({
 }));
 
 const { registerClawsCli } = await import("./claws-cli.js");
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const minimalManifest = { schemaVersion: 1, agent: { id: "demo-agent", name: "Demo Agent" } };
 
 async function writeManifest(value: unknown = minimalManifest): Promise<string> {
-  const dir = await mkdtemp(join(tmpdir(), "openclaw-claws-cli-"));
+  const dir = tempDirs.make("openclaw-claws-cli-");
   const path = join(dir, "openclaw.claw.json");
   await writeFile(path, JSON.stringify(value), "utf8");
   return path;
 }
 
 async function writePackage(): Promise<{ root: string; workspace: string }> {
-  const root = await mkdtemp(join(tmpdir(), "openclaw-claws-cli-package-"));
+  const root = tempDirs.make("openclaw-claws-cli-package-");
   await mkdir(join(root, "workspace"));
   await writeFile(join(root, "workspace", "AGENTS.md"), "# Demo\n", "utf8");
   await writeFile(
@@ -237,7 +238,7 @@ describe("claws cli", () => {
 
   it("applies a minimal Claw only after explicit consent", async () => {
     const manifestPath = await writeManifest();
-    const workspace = join(await mkdtemp(join(tmpdir(), "openclaw-claws-add-")), "workspace");
+    const workspace = join(tempDirs.make("openclaw-claws-add-"), "workspace");
     await runCli(["claws", "add", manifestPath, "--dry-run", "--workspace", workspace, "--json"]);
     const plan = JSON.parse(mocks.logs[0] ?? "{}");
     mocks.logs.length = 0;
@@ -268,8 +269,8 @@ describe("claws cli", () => {
 
   it("resumes consented add with the matching in-flight workspace on disk", async () => {
     const manifestPath = await writeManifest();
-    const workspace = join(await mkdtemp(join(tmpdir(), "openclaw-claws-add-")), "workspace");
-    const stateRoot = await mkdtemp(join(tmpdir(), "openclaw-claws-state-"));
+    const workspace = join(tempDirs.make("openclaw-claws-add-"), "workspace");
+    const stateRoot = tempDirs.make("openclaw-claws-state-");
     vi.stubEnv("OPENCLAW_STATE_DIR", join(stateRoot, "state"));
 
     await runCli(["claws", "add", manifestPath, "--dry-run", "--workspace", workspace, "--json"]);
@@ -303,8 +304,8 @@ describe("claws cli", () => {
 
   it("resumes when config committed before the workspace-ready phase advanced", async () => {
     const manifestPath = await writeManifest();
-    const workspace = join(await mkdtemp(join(tmpdir(), "openclaw-claws-add-")), "workspace");
-    const stateRoot = await mkdtemp(join(tmpdir(), "openclaw-claws-state-"));
+    const workspace = join(tempDirs.make("openclaw-claws-add-"), "workspace");
+    const stateRoot = tempDirs.make("openclaw-claws-state-");
     vi.stubEnv("OPENCLAW_STATE_DIR", join(stateRoot, "state"));
 
     await runCli(["claws", "add", manifestPath, "--dry-run", "--workspace", workspace, "--json"]);
@@ -337,8 +338,8 @@ describe("claws cli", () => {
 
   it("does not claim an on-disk workspace for a partial record without workspace ownership", async () => {
     const manifestPath = await writeManifest();
-    const workspace = join(await mkdtemp(join(tmpdir(), "openclaw-claws-add-")), "workspace");
-    const stateRoot = await mkdtemp(join(tmpdir(), "openclaw-claws-state-"));
+    const workspace = join(tempDirs.make("openclaw-claws-add-"), "workspace");
+    const stateRoot = tempDirs.make("openclaw-claws-state-");
     vi.stubEnv("OPENCLAW_STATE_DIR", join(stateRoot, "state"));
 
     await runCli(["claws", "add", manifestPath, "--dry-run", "--workspace", workspace, "--json"]);
@@ -370,8 +371,8 @@ describe("claws cli", () => {
 
   it("preserves a real agent collision while an add is still pending", async () => {
     const manifestPath = await writeManifest();
-    const workspace = join(await mkdtemp(join(tmpdir(), "openclaw-claws-add-")), "workspace");
-    const stateRoot = await mkdtemp(join(tmpdir(), "openclaw-claws-state-"));
+    const workspace = join(tempDirs.make("openclaw-claws-add-"), "workspace");
+    const stateRoot = tempDirs.make("openclaw-claws-state-");
     vi.stubEnv("OPENCLAW_STATE_DIR", join(stateRoot, "state"));
 
     await runCli(["claws", "add", manifestPath, "--dry-run", "--workspace", workspace, "--json"]);
@@ -403,8 +404,8 @@ describe("claws cli", () => {
 
   it("does not resume through another agent's configured workspace", async () => {
     const manifestPath = await writeManifest();
-    const workspace = join(await mkdtemp(join(tmpdir(), "openclaw-claws-add-")), "workspace");
-    const stateRoot = await mkdtemp(join(tmpdir(), "openclaw-claws-state-"));
+    const workspace = join(tempDirs.make("openclaw-claws-add-"), "workspace");
+    const stateRoot = tempDirs.make("openclaw-claws-state-");
     vi.stubEnv("OPENCLAW_STATE_DIR", join(stateRoot, "state"));
 
     await runCli(["claws", "add", manifestPath, "--dry-run", "--workspace", workspace, "--json"]);

--- a/src/cli/claws-cli.test.ts
+++ b/src/cli/claws-cli.test.ts
@@ -231,12 +231,7 @@ describe("claws cli", () => {
     expect(mocks.logs).toContain("Capability escalations (2):");
     expect(mocks.logs.some((line) => line.startsWith("  ! agent:demo-agent"))).toBe(true);
     expect(mocks.logs.some((line) => line.startsWith("  ! mcpServer:docs"))).toBe(true);
-    expect(
-      mocks.logs.some(
-        (line) =>
-          line.includes('"name":"API_TOKEN"') && line.includes('"reference":"GITHUB_TOKEN"'),
-      ),
-    ).toBe(true);
+    expect(mocks.logs.some((line) => line.includes('"env":["API_TOKEN"]'))).toBe(true);
     expect(mocks.logs).toContain("The plan integrity binds every capability line above.");
   });
 

--- a/src/cli/claws-cli.ts
+++ b/src/cli/claws-cli.ts
@@ -9,6 +9,8 @@ export type ClawsInspectOptions = {
 
 export type ClawsAddOptions = {
   dryRun?: boolean;
+  yes?: boolean;
+  planIntegrity?: string;
   json?: boolean;
   agentId?: string;
   workspace?: string;
@@ -35,6 +37,8 @@ export function registerClawsCli(program: Command) {
     .description("Preview adding one new agent and workspace from a Claw")
     .argument("<source>", "Path to a Claw package directory or grouped manifest")
     .option("--dry-run", "Preview all actions without mutating state", false)
+    .option("--yes", "Confirm creation of the new agent and workspace", false)
+    .option("--plan-integrity <digest>", "Bind consent to an exact dry-run plan")
     .option("--agent-id <id>", "Override the requested id with an unused local agent id")
     .option("--workspace <path>", "Override the derived new workspace path")
     .option("--json", "Print JSON", false)

--- a/src/cli/program/core-command-descriptors.ts
+++ b/src/cli/program/core-command-descriptors.ts
@@ -36,7 +36,7 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
   },
   {
     name: "claws",
-    description: "Inspect and preview OpenClaw Claws",
+    description: "Inspect and add experimental OpenClaw Claws",
     hasSubcommands: true,
     parentDefaultHelp: true,
   },

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -256,6 +256,27 @@ export interface ChannelPairingRequests {
   request_id: string;
 }
 
+export interface ClawInstalls {
+  added_at_ms: number;
+  agent_config_digest: string;
+  agent_id: string;
+  agent_owned_paths_json: string;
+  claw_name: string;
+  claw_version: string;
+  integrity: string;
+  integrity_kind: string;
+  manifest_path: string;
+  manifest_schema_version: number;
+  package_root: string;
+  plan_integrity: string;
+  schema_version: string;
+  source_byte_length: number;
+  source_kind: string;
+  status: string;
+  updated_at_ms: number;
+  workspace: string;
+}
+
 export interface ClawhubPromotionClaims {
   claimed_at_ms: number;
   ends_at_ms: number;
@@ -1356,6 +1377,7 @@ export interface DB {
   channel_ingress_events: ChannelIngressEvents;
   channel_pairing_allow_entries: ChannelPairingAllowEntries;
   channel_pairing_requests: ChannelPairingRequests;
+  claw_installs: ClawInstalls;
   clawhub_promotion_claims: ClawhubPromotionClaims;
   clawhub_promotions_feed_state: ClawhubPromotionsFeedState;
   command_log_entries: CommandLogEntries;

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -1930,4 +1930,27 @@ CREATE TABLE IF NOT EXISTS fleet_cells (
   host_port INTEGER NOT NULL,
   container_name TEXT NOT NULL,
   data_dir TEXT NOT NULL
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS claw_installs (
+  agent_id TEXT NOT NULL PRIMARY KEY,
+  schema_version TEXT NOT NULL,
+  source_kind TEXT NOT NULL,
+  claw_name TEXT NOT NULL,
+  claw_version TEXT NOT NULL,
+  package_root TEXT NOT NULL,
+  manifest_path TEXT NOT NULL,
+  integrity_kind TEXT NOT NULL,
+  integrity TEXT NOT NULL,
+  source_byte_length INTEGER NOT NULL,
+  manifest_schema_version INTEGER NOT NULL,
+  plan_integrity TEXT NOT NULL,
+  workspace TEXT NOT NULL UNIQUE,
+  agent_config_digest TEXT NOT NULL,
+  agent_owned_paths_json TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (
+    status IN ('pending', 'workspace_ready', 'config_committed', 'complete', 'partial')
+  ),
+  added_at_ms INTEGER NOT NULL,
+  updated_at_ms INTEGER NOT NULL
 ) STRICT;\n`;

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -1926,3 +1926,26 @@ CREATE TABLE IF NOT EXISTS fleet_cells (
   container_name TEXT NOT NULL,
   data_dir TEXT NOT NULL
 ) STRICT;
+
+CREATE TABLE IF NOT EXISTS claw_installs (
+  agent_id TEXT NOT NULL PRIMARY KEY,
+  schema_version TEXT NOT NULL,
+  source_kind TEXT NOT NULL,
+  claw_name TEXT NOT NULL,
+  claw_version TEXT NOT NULL,
+  package_root TEXT NOT NULL,
+  manifest_path TEXT NOT NULL,
+  integrity_kind TEXT NOT NULL,
+  integrity TEXT NOT NULL,
+  source_byte_length INTEGER NOT NULL,
+  manifest_schema_version INTEGER NOT NULL,
+  plan_integrity TEXT NOT NULL,
+  workspace TEXT NOT NULL UNIQUE,
+  agent_config_digest TEXT NOT NULL,
+  agent_owned_paths_json TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (
+    status IN ('pending', 'workspace_ready', 'config_committed', 'complete', 'partial')
+  ),
+  added_at_ms INTEGER NOT NULL,
+  updated_at_ms INTEGER NOT NULL
+) STRICT;


### PR DESCRIPTION
## Summary  > Signing-history note (2026-07-19): signed-history head `ed152be79577` is a commit-history-only rewrite of previously tested head `540a7f439143`; both resolve to tree `bad6d4081558`. Existing behavior evidence remains source-equivalent. This note does not claim a new runtime execution. Implements the second [RFC #27](https://github.com/openclaw/rfcs/pull/27) slice, stacked on [#101328](https://github.com/openclaw/openclaw/pull/101328):  - Creates exactly one new agent and one new workspace after a complete dry-run plan. - Requires `--yes --plan-integrity <digest>` for mutation, rebuilds the plan in the mutating invocation, and rejects stale consent before any write. - Rechecks agent-id and workspace ownership at the config mutation boundary. - Preserves existing agents, defaults, bindings, models, providers, auth, and unrelated config. - Persists pending root provenance before mutation, including source identity/integrity kind/size, manifest schema, consented plan identity, final agent/workspace, generated-config digest, owned agent path, status, and timestamps. - Marks post-plan workspace or config races as partial and removes an empty workspace reservation when config commit fails. - Returns versioned `openclaw.clawAddResult.v1` results with the consented plan identity.  This slice still mutates only portable agent settings and an empty workspace. Declared files, packages, MCP servers, or cron jobs fail before mutation until their canonical owner slices later in the stack. No declared component is skipped.  ## Lifecycle  ```text openclaw claws add <source> --dry-run --json # copy planIntegrity from the reviewed plan  openclaw claws add <source> --yes --plan-integrity <digest> --json ```  Changing the source snapshot, final agent id, workspace, action set, or expected owner state changes the plan digest and invalidates consent.  ## Stack  - RFC: [openclaw/rfcs#27](https://github.com/openclaw/rfcs/pull/27) - Depends on: [#101328](https://github.com/openclaw/openclaw/pull/101328) schema/source identity/read-only plan - This PR: consented agent/workspace creation and root provenance - Next: [#101973](https://github.com/openclaw/openclaw/pull/101973) confined workspace files and managed hashes  ## Validation  ```text pnpm exec vitest run src/claws/schema.test.ts src/claws/schema-conformance.test.ts \   src/claws/provenance.test.ts src/cli/claws-cli.test.ts # passed  node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts \   src/claws/lifecycle.e2e.test.ts # 5 lifecycle E2E tests passed  pnpm exec oxlint src/claws/add.ts src/claws/provenance.ts \   src/claws/provenance.test.ts src/cli/claws-cli.ts \   src/cli/claws-cli.runtime.ts src/cli/claws-cli.test.ts \   src/claws/lifecycle.e2e.test.ts # 0 warnings, 0 errors  pnpm tsgo:core pnpm tsgo:test:src git diff --check # passed ```  The real CLI E2E previews a minimal Claw, applies that exact plan in the same isolated state directory, verifies one created agent and root install record, rejects unsupported component mutation, and fails closed without consent.  Codex review of the final uncommitted patch completed with no actionable findings.  ## Documentation  Extends `/cli/claws` with exact `planIntegrity` consent, agent/workspace creation, and root provenance. The guide still excludes workspace-file and capability mutation owned by later stages. 