### PR TITLE
fix(nostr): strip internal tool-trace banners from outbound text

### DIFF
--- a/extensions/nostr/src/channel.inbound.test.ts
+++ b/extensions/nostr/src/channel.inbound.test.ts
@@ -254,14 +254,28 @@ describe("nostr inbound gateway path", () => {
         text: string,
         reply: (text: string) => Promise<void>,
         meta: { eventId: string; createdAt: number },
+        lifecycle: NostrIngressLifecycle,
       ) => Promise<void>;
     };
     const sendReply = vi.fn(async (_text: string) => {});
+    const lifecycle: NostrIngressLifecycle = {
+      abortSignal: new AbortController().signal,
+      onAdopted: vi.fn(async () => {}),
+      onDeferred: vi.fn(),
+      onAdoptionFinalizing: vi.fn(),
+      onAbandoned: vi.fn(async () => {}),
+    };
 
-    await options.onMessage("sender-pubkey", "hello from nostr", sendReply, {
-      eventId: "event-456",
-      createdAt: 1_710_000_001,
-    });
+    await options.onMessage(
+      "sender-pubkey",
+      "hello from nostr",
+      sendReply,
+      {
+        eventId: "event-456",
+        createdAt: 1_710_000_001,
+      },
+      lifecycle,
+    );
 
     expect(sendReply).toHaveBeenCalledWith("converted:Done.");
     expect(mockCallArg(sendReply)).not.toContain("⚠️");
@@ -294,14 +308,28 @@ describe("nostr inbound gateway path", () => {
         text: string,
         reply: (text: string) => Promise<void>,
         meta: { eventId: string; createdAt: number },
+        lifecycle: NostrIngressLifecycle,
       ) => Promise<void>;
     };
     const sendReply = vi.fn(async (_text: string) => {});
+    const lifecycle: NostrIngressLifecycle = {
+      abortSignal: new AbortController().signal,
+      onAdopted: vi.fn(async () => {}),
+      onDeferred: vi.fn(),
+      onAdoptionFinalizing: vi.fn(),
+      onAbandoned: vi.fn(async () => {}),
+    };
 
-    await options.onMessage("sender-pubkey", "hello from nostr", sendReply, {
-      eventId: "event-789",
-      createdAt: 1_710_000_002,
-    });
+    await options.onMessage(
+      "sender-pubkey",
+      "hello from nostr",
+      sendReply,
+      {
+        eventId: "event-789",
+        createdAt: 1_710_000_002,
+      },
+      lifecycle,
+    );
 
     expect(sendReply).not.toHaveBeenCalled();
 

--- a/extensions/nostr/src/channel.inbound.test.ts
+++ b/extensions/nostr/src/channel.inbound.test.ts
@@ -228,4 +228,44 @@ describe("nostr inbound gateway path", () => {
 
     await cleanup.stop();
   });
+
+  it("strips internal tool-trace banners before inbound DM replies", async () => {
+    const toolTraceText = "Done.\n⚠️ 🛠️ `search repos (agent)` failed";
+    const { harness, cleanup } = await startGatewayHarness({
+      account: buildResolvedNostrAccount({
+        publicKey: "bot-pubkey",
+        config: { dmPolicy: "allowlist", allowFrom: ["nostr:sender-pubkey"] },
+      }),
+      cfg: {
+        session: { store: { type: "jsonl" } },
+        commands: { useAccessGroups: true },
+      } as never,
+    });
+
+    harness.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions }) => {
+        await dispatcherOptions.deliver({ text: toolTraceText });
+      },
+    );
+
+    const options = mockCallArg(mocks.startNostrBus) as {
+      onMessage: (
+        senderPubkey: string,
+        text: string,
+        reply: (text: string) => Promise<void>,
+        meta: { eventId: string; createdAt: number },
+      ) => Promise<void>;
+    };
+    const sendReply = vi.fn(async (_text: string) => {});
+
+    await options.onMessage("sender-pubkey", "hello from nostr", sendReply, {
+      eventId: "event-456",
+      createdAt: 1_710_000_001,
+    });
+
+    expect(sendReply).toHaveBeenCalledWith("converted:Done.");
+    expect(mockCallArg(sendReply)).not.toContain("⚠️");
+
+    await cleanup.stop();
+  });
 });

--- a/extensions/nostr/src/channel.inbound.test.ts
+++ b/extensions/nostr/src/channel.inbound.test.ts
@@ -231,7 +231,12 @@ describe("nostr inbound gateway path", () => {
 
   it("strips internal tool-trace banners before inbound DM replies", async () => {
     const toolTraceText = "Done.\n⚠️ 🛠️ `search repos (agent)` failed";
-    const { harness, cleanup } = await startGatewayHarness({
+    mocks.dispatchInboundDirectDm.mockImplementationOnce(
+      async (params: Parameters<typeof DispatchInboundDirectDm>[0]) => {
+        await params.deliver({ text: toolTraceText });
+      },
+    );
+    const { cleanup } = await startGatewayHarness({
       account: buildResolvedNostrAccount({
         publicKey: "bot-pubkey",
         config: { dmPolicy: "allowlist", allowFrom: ["nostr:sender-pubkey"] },
@@ -241,12 +246,6 @@ describe("nostr inbound gateway path", () => {
         commands: { useAccessGroups: true },
       } as never,
     });
-
-    harness.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
-      async ({ dispatcherOptions }) => {
-        await dispatcherOptions.deliver({ text: toolTraceText });
-      },
-    );
 
     const options = mockCallArg(mocks.startNostrBus) as {
       onMessage: (
@@ -285,7 +284,12 @@ describe("nostr inbound gateway path", () => {
 
   it("drops inbound DM replies that contain only internal tool-trace banners", async () => {
     const toolTraceOnlyText = "⚠️ 🛠️ `search repos (agent)` failed";
-    const { harness, cleanup } = await startGatewayHarness({
+    mocks.dispatchInboundDirectDm.mockImplementationOnce(
+      async (params: Parameters<typeof DispatchInboundDirectDm>[0]) => {
+        await params.deliver({ text: toolTraceOnlyText });
+      },
+    );
+    const { cleanup } = await startGatewayHarness({
       account: buildResolvedNostrAccount({
         publicKey: "bot-pubkey",
         config: { dmPolicy: "allowlist", allowFrom: ["nostr:sender-pubkey"] },
@@ -295,12 +299,6 @@ describe("nostr inbound gateway path", () => {
         commands: { useAccessGroups: true },
       } as never,
     });
-
-    harness.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
-      async ({ dispatcherOptions }) => {
-        await dispatcherOptions.deliver({ text: toolTraceOnlyText });
-      },
-    );
 
     const options = mockCallArg(mocks.startNostrBus) as {
       onMessage: (

--- a/extensions/nostr/src/channel.inbound.test.ts
+++ b/extensions/nostr/src/channel.inbound.test.ts
@@ -268,4 +268,43 @@ describe("nostr inbound gateway path", () => {
 
     await cleanup.stop();
   });
+
+  it("drops inbound DM replies that contain only internal tool-trace banners", async () => {
+    const toolTraceOnlyText = "⚠️ 🛠️ `search repos (agent)` failed";
+    const { harness, cleanup } = await startGatewayHarness({
+      account: buildResolvedNostrAccount({
+        publicKey: "bot-pubkey",
+        config: { dmPolicy: "allowlist", allowFrom: ["nostr:sender-pubkey"] },
+      }),
+      cfg: {
+        session: { store: { type: "jsonl" } },
+        commands: { useAccessGroups: true },
+      } as never,
+    });
+
+    harness.dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions }) => {
+        await dispatcherOptions.deliver({ text: toolTraceOnlyText });
+      },
+    );
+
+    const options = mockCallArg(mocks.startNostrBus) as {
+      onMessage: (
+        senderPubkey: string,
+        text: string,
+        reply: (text: string) => Promise<void>,
+        meta: { eventId: string; createdAt: number },
+      ) => Promise<void>;
+    };
+    const sendReply = vi.fn(async (_text: string) => {});
+
+    await options.onMessage("sender-pubkey", "hello from nostr", sendReply, {
+      eventId: "event-789",
+      createdAt: 1_710_000_002,
+    });
+
+    expect(sendReply).not.toHaveBeenCalled();
+
+    await cleanup.stop();
+  });
 });

--- a/extensions/nostr/src/gateway.ts
+++ b/extensions/nostr/src/gateway.ts
@@ -27,6 +27,7 @@ type NostrOutboundAdapter = Pick<
   "deliveryCapabilities" | "deliveryMode" | "textChunkLimit" | "sanitizeText" | "sendText"
 > & {
   sendText: NonNullable<ChannelOutboundAdapter["sendText"]>;
+  sanitizeText: NonNullable<ChannelOutboundAdapter["sanitizeText"]>;
 };
 
 const activeBuses = new Map<string, NostrBusHandle>();

--- a/extensions/nostr/src/gateway.ts
+++ b/extensions/nostr/src/gateway.ts
@@ -198,12 +198,13 @@ export const startNostrGatewayAccount: NostrGatewayStart = async (ctx) => {
               if (!outboundText.trim()) {
                 return;
               }
+              const sanitizedText = sanitizeAssistantVisibleText(outboundText);
               const tableMode = runtime.channel.text.resolveMarkdownTableMode({
                 cfg: ctx.cfg,
                 channel: "nostr",
                 accountId: account.accountId,
               });
-              await reply(runtime.channel.text.convertMarkdownTables(outboundText, tableMode));
+              await reply(runtime.channel.text.convertMarkdownTables(sanitizedText, tableMode));
             },
             onRecordError: (err) => {
               ctx.log?.error?.(

--- a/extensions/nostr/src/gateway.ts
+++ b/extensions/nostr/src/gateway.ts
@@ -199,6 +199,9 @@ export const startNostrGatewayAccount: NostrGatewayStart = async (ctx) => {
                 return;
               }
               const sanitizedText = sanitizeAssistantVisibleText(outboundText);
+              if (!sanitizedText.trim()) {
+                return;
+              }
               const tableMode = runtime.channel.text.resolveMarkdownTableMode({
                 cfg: ctx.cfg,
                 channel: "nostr",

--- a/extensions/nostr/src/gateway.ts
+++ b/extensions/nostr/src/gateway.ts
@@ -10,7 +10,6 @@ import {
 import { createChannelPairingController } from "openclaw/plugin-sdk/channel-pairing";
 import { attachChannelToResult } from "openclaw/plugin-sdk/channel-send-result";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { runStoppablePassiveMonitor } from "openclaw/plugin-sdk/extension-shared";
 import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import type { ChannelOutboundAdapter, ChannelPlugin } from "./channel-api.js";
 import type { MetricEvent, MetricsSnapshot } from "./metrics.js";

--- a/extensions/nostr/src/gateway.ts
+++ b/extensions/nostr/src/gateway.ts
@@ -10,6 +10,8 @@ import {
 import { createChannelPairingController } from "openclaw/plugin-sdk/channel-pairing";
 import { attachChannelToResult } from "openclaw/plugin-sdk/channel-send-result";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { runStoppablePassiveMonitor } from "openclaw/plugin-sdk/extension-shared";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import type { ChannelOutboundAdapter, ChannelPlugin } from "./channel-api.js";
 import type { MetricEvent, MetricsSnapshot } from "./metrics.js";
 import { startNostrBus, type NostrBusHandle } from "./nostr-bus.js";
@@ -22,7 +24,7 @@ type NostrGatewayStart = NonNullable<
 >;
 type NostrOutboundAdapter = Pick<
   ChannelOutboundAdapter,
-  "deliveryCapabilities" | "deliveryMode" | "textChunkLimit" | "sendText"
+  "deliveryCapabilities" | "deliveryMode" | "textChunkLimit" | "sanitizeText" | "sendText"
 > & {
   sendText: NonNullable<ChannelOutboundAdapter["sendText"]>;
 };
@@ -306,6 +308,7 @@ export const nostrPairingTextAdapter = {
 export const nostrOutboundAdapter: NostrOutboundAdapter = {
   deliveryMode: "direct",
   textChunkLimit: 4000,
+  sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
   deliveryCapabilities: {
     durableFinal: {
       text: true,

--- a/extensions/nostr/src/gateway.ts
+++ b/extensions/nostr/src/gateway.ts
@@ -24,7 +24,7 @@ type NostrGatewayStart = NonNullable<
 >;
 type NostrOutboundAdapter = Pick<
   ChannelOutboundAdapter,
-  "deliveryCapabilities" | "deliveryMode" | "textChunkLimit" | "sanitizeText" | "sendText"
+  "deliveryCapabilities" | "deliveryMode" | "textChunkLimit" | "sendText"
 > & {
   sendText: NonNullable<ChannelOutboundAdapter["sendText"]>;
   sanitizeText: NonNullable<ChannelOutboundAdapter["sanitizeText"]>;

--- a/extensions/nostr/src/outbound-tool-trace-sanitize.test.ts
+++ b/extensions/nostr/src/outbound-tool-trace-sanitize.test.ts
@@ -2,18 +2,18 @@
 // the sibling channel fixes tracked under #90684 (Slack / Signal / Matrix /
 // Telegram / Google Chat / QQBot / IRC / SMS / Feishu / LINE / Nextcloud Talk).
 import { describe, expect, it } from "vitest";
-import { nostrPlugin } from "./channel.js";
+import { nostrOutboundAdapter } from "./gateway.js";
 
 describe("nostr outbound sanitizeText", () => {
   it("strips internal tool-trace banners before outbound delivery", () => {
     const text = "Done.\n⚠️ 🛠️ `search repos (agent)` failed";
 
-    expect(nostrPlugin.outbound?.sanitizeText({ text, payload: { text } })).toBe("Done.");
+    expect(nostrOutboundAdapter.sanitizeText({ text, payload: { text } })).toBe("Done.");
   });
 
   it("preserves ordinary assistant prose while sanitizing", () => {
     const text = "The pipeline has 3 open deals.";
 
-    expect(nostrPlugin.outbound?.sanitizeText({ text, payload: { text } })).toBe(text);
+    expect(nostrOutboundAdapter.sanitizeText({ text, payload: { text } })).toBe(text);
   });
 });

--- a/extensions/nostr/src/outbound-tool-trace-sanitize.test.ts
+++ b/extensions/nostr/src/outbound-tool-trace-sanitize.test.ts
@@ -1,0 +1,19 @@
+// Nostr outbound must strip assistant internal tool-trace scaffolding, matching
+// the sibling channel fixes tracked under #90684 (Slack / Signal / Matrix /
+// Telegram / Google Chat / QQBot / IRC / SMS / Feishu / LINE / Nextcloud Talk).
+import { describe, expect, it } from "vitest";
+import { nostrPlugin } from "./channel.js";
+
+describe("nostr outbound sanitizeText", () => {
+  it("strips internal tool-trace banners before outbound delivery", () => {
+    const text = "Done.\n⚠️ 🛠️ `search repos (agent)` failed";
+
+    expect(nostrPlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe("Done.");
+  });
+
+  it("preserves ordinary assistant prose while sanitizing", () => {
+    const text = "The pipeline has 3 open deals.";
+
+    expect(nostrPlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe(text);
+  });
+});

--- a/extensions/nostr/src/outbound-tool-trace-sanitize.test.ts
+++ b/extensions/nostr/src/outbound-tool-trace-sanitize.test.ts
@@ -8,12 +8,12 @@ describe("nostr outbound sanitizeText", () => {
   it("strips internal tool-trace banners before outbound delivery", () => {
     const text = "Done.\n⚠️ 🛠️ `search repos (agent)` failed";
 
-    expect(nostrPlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe("Done.");
+    expect(nostrPlugin.outbound?.sanitizeText({ text, payload: { text } })).toBe("Done.");
   });
 
   it("preserves ordinary assistant prose while sanitizing", () => {
     const text = "The pipeline has 3 open deals.";
 
-    expect(nostrPlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe(text);
+    expect(nostrPlugin.outbound?.sanitizeText({ text, payload: { text } })).toBe(text);
   });
 });


### PR DESCRIPTION
Part of #90684

## What Problem This Solves

Fixes an issue where Nostr users receiving bot replies would see internal assistant tool-trace scaffolding lines (e.g. `⚠️ 🛠️ `search repos (agent)` failed`) leaked into outbound messages. These banners are internal runtime diagnostics that should not reach end users.

Nostr has two user-visible reply paths: the shared outbound adapter and the gateway inbound DM `deliver` callback. Both could forward raw assistant text before this change.

## Why This Change Was Made

Add `sanitizeAssistantVisibleText` on:
1. `nostrOutboundAdapter.sanitizeText` (shared outbound delivery path)
2. the inbound DM `deliver` callback before markdown table conversion (the main bot-reply path for incoming Nostr DMs)

Also drop inbound replies that become empty after sanitization so blank encrypted DMs are not published.

Matches the accepted sibling pattern already shipped for Slack, Signal, Matrix, Feishu, Mattermost, Telegram, Google Chat, QQBot, IRC, SMS, Discord, WhatsApp, LINE, and Nextcloud Talk.

Non-goals: no relay protocol redesign; no committed proof harness in this PR.

Collision check: searched open/closed PRs for nostr tool-trace / `sanitizeAssistantVisibleText` / #90684 — this is the Nostr channel candidate under the cross-channel sanitizer issue. Siblings: merged [#101708](https://github.com/openclaw/openclaw/pull/101708) (LINE), [#101712](https://github.com/openclaw/openclaw/pull/101712) (Nextcloud Talk), [#98705](https://github.com/openclaw/openclaw/pull/98705) (Feishu).

## User Impact

- **Before:** Tool-trace failure banners could appear in Nostr bot replies on outbound delivery and inbound DM replies; trace-only replies could publish empty encrypted DMs.
- **After:** Banners are stripped on both paths; fully stripped inbound replies are dropped. Normal assistant prose and markdown table conversion are preserved.

## Evidence

Exact head: `0193ff493de8d5f99452aa5eb95ab2d5e74e0960`

### current-`main` negative (core strip keeps banner)

Core `stripInternalRuntimeScaffolding` does not remove tool-trace failure banners (same pre-fix leak class as sibling channel PRs).

### Non-mocked loopback relay delivery (local harness — not shipped)

Local WebSocket Nostr relay + real `startNostrBus.sendDm` encrypt/publish, applying production `nostrOutboundAdapter.sanitizeText` / inbound `sanitizeAssistantVisibleText`, then decrypting captured kind-4 EVENTs. No third-party relay and no personal nsec. Harness kept local (not committed).

```text
node=v22.22.0
head=555b997a4793c43a71c527b2bb27e5f9c4ba5596 (proof captured pre-drop of local harness; behavior unchanged)
PASS raw_wire_has_banner plain="Done.\n⚠️ 🛠️ `search repos (agent)` failed"
PASS outbound_adapter_wire_clean plain="Done."
PASS outbound_trace_only_no_event
PASS inbound_deliver_wire_clean plain="Done."
PASS inbound_trace_only_dropped
{
  "scenario": "nostr loopback relay tool-trace sanitize",
  "relay": "ws://127.0.0.1:34059",
  "assertions": 5,
  "capturedEvents": 3,
  "paths": [
    "outbound.sanitizeText+sendDm",
    "inbound.sanitizeAssistantVisibleText+reply"
  ]
}
ALL PROOF ASSERTIONS: 5 passed, 0 failed
```

### Focused tests

```bash
node scripts/run-vitest.mjs extensions/nostr/src/channel.inbound.test.ts extensions/nostr/src/outbound-tool-trace-sanitize.test.ts
```

```text
 Test Files  2 passed (2)
      Tests  6 passed (6)
[test] passed 1 Vitest shard
```

## Verification

- Exact head: `0193ff493de8d5f99452aa5eb95ab2d5e74e0960`
- Rebased onto recent `origin/main`
- Focused tests: 6 passed
- Loopback relay proof: 5/5 assertions (local harness, not in diff)
- No proof script in PR diff (avoids extension boundary / lint gates)

## Real behavior proof

- **Behavior addressed:** tool-trace banners stripped before Nostr DM encrypt/publish on outbound + inbound deliver; trace-only dropped.
- **Environment:** local Linux WSL2; loopback `ws://127.0.0.1:<ephemeral>` relay; real `nostr-tools` encrypt/publish/decrypt.
- **Observed output after fix:** (proof paste above)
- **What was not tested:** credentialed round-trip against a public third-party relay / personal nsec.

## Risk / Compatibility

**Low/Med (message-delivery).** Only changes assistant-visible text shaping on Nostr outbound/inbound deliver. Mitigation: sibling-channel pattern + loopback decrypt proof + focused gateway/outbound tests.

## Review

- Manually reviewed and verified
- AI-assisted: Yes

