### PR TITLE
fix(browser): keep Playwright truncation UTF-16 safe

### DIFF
--- a/extensions/browser/src/browser/chrome-mcp.snapshot.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.snapshot.test.ts
@@ -66,4 +66,18 @@ describe("chrome MCP snapshot conversion", () => {
     });
     expect(result.stats.refs).toBe(2);
   });
+
+  it("does not split a surrogate pair when truncating AI snapshots", () => {
+    const prefix = `- button "${"A".repeat(18)}`;
+    const result = buildAiSnapshotFromChromeMcpSnapshot({
+      root: {
+        role: "button",
+        name: `${"A".repeat(18)}🙂`,
+      },
+      maxChars: prefix.length + 1,
+    });
+
+    expect(result.snapshot).toBe(`${prefix}\n\n[...TRUNCATED - page too large]`);
+    expect(result.truncated).toBe(true);
+  });
 });

--- a/extensions/browser/src/browser/chrome-mcp.snapshot.ts
+++ b/extensions/browser/src/browser/chrome-mcp.snapshot.ts
@@ -5,6 +5,7 @@
  * and compact AI snapshots with stable refs and duplicate tracking.
  */
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { normalizeString } from "../record-shared.js";
 import type { SnapshotAriaNode } from "./client.types.js";
 import {
@@ -184,7 +185,7 @@ export function buildAiSnapshotFromChromeMcpSnapshot(params: {
       ? Math.floor(params.maxChars)
       : undefined;
   if (maxChars && snapshot.length > maxChars) {
-    snapshot = `${snapshot.slice(0, maxChars)}\n\n[...TRUNCATED - page too large]`;
+    snapshot = `${truncateUtf16Safe(snapshot, maxChars)}\n\n[...TRUNCATED - page too large]`;
     truncated = true;
   }
 

--- a/extensions/browser/src/browser/pw-tools-core.responses.ts
+++ b/extensions/browser/src/browser/pw-tools-core.responses.ts
@@ -2,6 +2,7 @@
  * Response-body retrieval for Playwright-backed browser tools.
  */
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { ensurePageState, getPageForTargetId } from "./pw-session.js";
 import { normalizeTimeoutMs } from "./pw-tools-core.shared.js";
 import { matchBrowserUrlPattern } from "./url-pattern.js";
@@ -103,7 +104,7 @@ export async function responseBodyViaPlaywright(opts: {
     throw new Error(`Failed to read response body for "${url}": ${String(err)}`, { cause: err });
   }
 
-  const trimmed = bodyText.length > maxChars ? bodyText.slice(0, maxChars) : bodyText;
+  const trimmed = bodyText.length > maxChars ? truncateUtf16Safe(bodyText, maxChars) : bodyText;
   return {
     url,
     status,

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.test.ts
@@ -194,6 +194,23 @@ describe("pw-tools-core aria snapshot storage", () => {
     expect(ariaSnapshotMock).toHaveBeenCalledWith({ mode: "ai", timeout: 5000 });
   });
 
+  it("does not split a surrogate pair when truncating ai snapshots", async () => {
+    const prefix = `- button "${"A".repeat(18)}`;
+    const ariaSnapshotMock = vi.fn().mockResolvedValue(`${prefix}🙂"`);
+    const page = { ariaSnapshot: ariaSnapshotMock };
+    getPageForTargetId.mockResolvedValue(page);
+
+    const mod = await import("./pw-tools-core.snapshot.js");
+    const result = await mod.snapshotAiViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      targetId: "tab-1",
+      maxChars: prefix.length + 1,
+    });
+
+    expect(result.snapshot).toBe(`${prefix}\n\n[...TRUNCATED - page too large]`);
+    expect(result.truncated).toBe(true);
+  });
+
   it("uses the default navigation timeout for non-finite timeouts", async () => {
     const page = { url: vi.fn(() => "http://127.0.0.1:31337/after") };
     getPageForTargetId.mockResolvedValue(page);

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -281,7 +281,7 @@ export async function snapshotAiViaPlaywright(opts: {
       : undefined;
   let truncated = false;
   if (limit && snapshot.length > limit) {
-    snapshot = `${snapshot.slice(0, limit)}\n\n[...TRUNCATED - page too large]`;
+    snapshot = `${truncateUtf16Safe(snapshot, limit)}\n\n[...TRUNCATED - page too large]`;
     truncated = true;
   }
 

--- a/extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
@@ -532,6 +532,38 @@ describe("pw-tools-core", () => {
     expect(res.truncated).toBe(true);
   });
 
+  it("does not split a surrogate pair when truncating response body text", async () => {
+    let responseHandler: ((resp: unknown) => void) | undefined;
+    const on = vi.fn((event: string, handler: (resp: unknown) => void) => {
+      if (event === "response") {
+        responseHandler = handler;
+      }
+    });
+    const off = vi.fn();
+    setPwToolsCoreCurrentPage({ on, off });
+
+    const p = mod.responseBodyViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "T1",
+      url: "**/emoji",
+      timeoutMs: 1000,
+      maxChars: 1,
+    });
+
+    await Promise.resolve();
+    if (!responseHandler) {
+      throw new Error("expected Playwright response handler");
+    }
+    responseHandler({
+      url: () => "https://example.com/emoji",
+      status: () => 200,
+      headers: () => ({ "content-type": "text/plain" }),
+      body: async () => Buffer.from("🙂B"),
+    });
+
+    await expect(p).resolves.toMatchObject({ body: "", truncated: true });
+  });
+
   it("preserves the prefix while bounding decode for a large response", async () => {
     let responseHandler: ((resp: unknown) => void) | undefined;
     const on = vi.fn((event: string, handler: (resp: unknown) => void) => {


### PR DESCRIPTION
## Summary

- Keep Playwright browser response-body truncation UTF-16 safe.
- Keep Playwright AI snapshot truncation UTF-16 safe before appending the page-too-large marker.
- Keep Chrome MCP AI snapshot truncation UTF-16 safe for the same `maxChars` route contract.
- Add regression coverage for all three truncation paths.

## What Problem This Solves

Browser tool output can be truncated at a raw JavaScript string index. When the limit lands between the two code units of an emoji or other surrogate pair, OpenClaw can return a dangling surrogate in the browser response body or AI snapshot text.

## User Impact

Users inspecting browser response bodies or page snapshots can see malformed Unicode output when content is truncated near an emoji boundary. The fix preserves the existing size limits and truncation markers while avoiding invalid UTF-16 in returned browser tool text.

- **Why it matters / User impact:** Browser response body and AI snapshot output are directly shown to the agent/user; malformed UTF-16 can make truncated browser evidence confusing or lossy when page text or response bodies contain emoji.
- **What did NOT change:** Only the Playwright response-body truncation boundary and the two browser AI snapshot truncation boundaries changed. Routing, navigation, network matching, byte limits, provider behavior, channel behavior, config, and unrelated browser tool paths are unchanged and out of scope.
- **Architecture / source-of-truth check:** The source-of-truth contract is that browser helper output must remain bounded and valid UTF-16. The canonical helper for that contract is `truncateUtf16Safe` from `openclaw/plugin-sdk/text-utility-runtime`, which the browser extension already imports, so this patch stays inside the existing plugin architecture boundary.

## Origin / follow-up

Follows #101591, which fixed another user-visible UI truncation path by making emoji / surrogate-pair clipping UTF-16 safe.

Gap this fills: the browser Playwright response-body, Playwright AI snapshot, and Chrome MCP AI snapshot helpers still used direct `.slice(0, maxChars)` / `.slice(0, limit)` truncation in user-visible browser tool output.

Consistency: this patch reuses the existing `truncateUtf16Safe` helper already used in the browser extension instead of introducing a new truncation implementation.

## Competition / linked PR analysis

- Related open PR scan / competition scan: checked open PRs touching `extensions/browser/src/browser/pw-tools-core.responses.ts`, `extensions/browser/src/browser/pw-tools-core.snapshot.ts`, and `extensions/browser/src/browser/chrome-mcp.snapshot.ts`; no matching open PR found.
- This is a focused follow-up, not a broad Unicode sweep. It only changes the Playwright response-body boundary plus the two browser AI snapshot output paths covered below.

## Real behavior proof

- **Behavior or issue addressed:** Browser Playwright response-body, Playwright AI snapshot, and Chrome MCP AI snapshot truncation no longer returns dangling surrogate halves when `maxChars` cuts through an emoji.
- **Canonical reachability path:** user browser command/input supplies response or snapshot options including `maxChars` → browser route/type layer passes typed options into the Playwright or Chrome MCP runtime helper → helper normalizes the limit with `Math.floor` / bounded option handling → runtime object reads a Playwright response, calls `page.ariaSnapshot({ mode: "ai" })`, or converts a Chrome MCP structured snapshot into browser AI snapshot text → helper truncates returned body/snapshot → agent/user receives browser tool output.
- **Boundary crossed:** local-runtime; the Playwright proof starts a real local Google Chrome process, connects over CDP, uses Playwright page APIs, serves a local HTTP response, and calls the production browser helpers. The Chrome MCP sibling path is covered by a focused regression test for the same public AI snapshot `maxChars` contract requested in review.
- **Shared helper / provider constraint check:** Reused `truncateUtf16Safe` from `openclaw/plugin-sdk/text-utility-runtime` in both Playwright and Chrome MCP browser snapshot helpers. Provider constraints are N/A because this does not change provider-owned API contracts.
- **Real environment tested:** Linux worktree `/media/vdb/code/ai/aispace/openclaw-worktrees/pr-101761`, Node 22.22.0, local `/usr/bin/google-chrome` headless CDP, local HTTP server on `127.0.0.1`.
- **Exact steps or command run after this patch:** `cd /media/vdb/code/ai/aispace/openclaw-worktrees/pr-101761 && node --import tsx /media/vdb/code/ai/aispace/openclaw-followup-101591-evidence/browser-playwright-unicode-proof.mjs > /media/vdb/code/ai/aispace/openclaw-pr-101761-evidence/after-pr-review-fix-browser-proof.json`
- **Evidence after fix:** `/media/vdb/code/ai/aispace/openclaw-pr-101761-evidence/after-pr-review-fix-browser-proof.json` shows `responseBodyViaPlaywright.body` is `""`, `responseBodyViaPlaywright.hasLoneSurrogate` is `false`, `snapshotAiViaPlaywright.hasLoneSurrogate` is `false`, and both Playwright paths remain `truncated: true`. `/media/vdb/code/ai/aispace/openclaw-pr-101761-evidence/vitest-browser-review-fix.txt` shows the requested Chrome MCP snapshot regression passed with the two existing browser test files.
- **Observed result after fix:** The same local Chrome/CDP path that produced dangling surrogates on `origin/main` now returns UTF-16-safe truncated text for Playwright response body and AI snapshot output. The Chrome MCP sibling AI snapshot test now verifies the same surrogate-boundary truncation case uses the shared safe helper.
- **What was not tested:** No external website, remote browser, or third-party service was used; the bug is in local browser output truncation, so the proof uses a local Chrome instance and local HTTP response.
- **Fix classification:** Root cause fix

## Review findings addressed

- RF-001 (`status: ⏳ waiting on author`): addressed by the code/test update below and ready for a fresh review after push.
- Reviewer proof request / local evidence judgment: the reviewer accepted the original local Chrome/CDP proof for the Playwright paths as sufficient, and this update attaches current-PR-head local Chrome/CDP proof plus the requested Chrome MCP regression test. No third-party provider, channel, transport, account, or external-service live boundary is part of this browser truncation fix.
- RF-002 / RF-005 (`chrome-mcp.snapshot.ts` sibling path): fixed by applying `truncateUtf16Safe` in `buildAiSnapshotFromChromeMcpSnapshot`.
- RF-003 / RF-004 (same-route Chrome MCP existing-session gap): addressed by covering the Chrome MCP AI snapshot `maxChars` branch instead of leaving the Playwright-only fix.
- RF-006 (requested test command): addressed with `node scripts/run-vitest.mjs extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts extensions/browser/src/browser/pw-tools-core.snapshot.test.ts extensions/browser/src/browser/chrome-mcp.snapshot.test.ts`.

## Regression Test Plan

- `node scripts/run-vitest.mjs extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts extensions/browser/src/browser/pw-tools-core.snapshot.test.ts extensions/browser/src/browser/chrome-mcp.snapshot.test.ts`
- Evidence: `/media/vdb/code/ai/aispace/openclaw-pr-101761-evidence/vitest-browser-review-fix.txt` reports 3 test files passed and 27 tests passed.
- **Target test file:** `extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts`, `extensions/browser/src/browser/pw-tools-core.snapshot.test.ts`, and `extensions/browser/src/browser/chrome-mcp.snapshot.test.ts`.
- **Scenario locked in:** Each regression test places the truncation limit between the high and low surrogate of `🙂`, then verifies the returned browser output does not include the dangling half.
- **Why this is the smallest reliable guardrail:** The tests cover the exact three helper-level truncation boundaries changed by the patch, while the real Chrome/CDP proof covers the local-runtime Playwright browser path.

## Merge risk

- **Risk labels considered:** `merge-risk: compatibility` and `merge-risk: availability` considered; neither should be required because this patch does not change limits, protocol shape, routing, process lifecycle, or external service behavior.
- **Risk explanation:** The only output difference occurs when a truncation boundary would split a surrogate pair; the safe helper returns a valid shorter prefix instead of malformed UTF-16.
- **Why acceptable:** Existing truncation semantics are preserved for ordinary text, and the maximum returned text length remains bounded by the caller's limit plus the existing snapshot marker where applicable.

## Patch quality notes

- **Maintainer-ready confidence:** High. The diff is six files, reuses an existing helper, has before/after real Chrome/CDP proof for the Playwright paths, and adds focused regression tests for all three changed truncation boundaries.
- **Patch quality notes:** No new helper, no broad Unicode sweep, no unrelated formatting, and no dependency or lockfile changes. The public-output contract stays compatible because returned strings remain bounded and valid.

## Risk / Compatibility

Low. The response body byte cap, `maxChars` option, truncation flag, and snapshot truncation marker behavior stay the same across Playwright and Chrome MCP snapshot output. The only behavior change is that a truncation boundary may move back by one UTF-16 code unit when it would otherwise split a surrogate pair.

## What was not changed

- No browser routing, CDP connection, navigation, or network matching behavior changed.
- No response byte limit changed.
- No snapshot URL collection, Chrome MCP structured snapshot conversion, or role-ref storage behavior changed.
- No provider/channel contracts changed.

## Root Cause

- **Root cause:** The source truncation invariant for browser helper output is bounded text that remains valid UTF-16, but the Playwright response-body, Playwright AI snapshot, and Chrome MCP AI snapshot helpers bypassed that contract with direct `.slice(0, maxChars)` / `.slice(0, limit)`. That caused the runtime browser output path to split surrogate pairs when the caller's limit landed between the emoji code units.
- **Why this is root-cause fix:** The fix moves all three proven truncation sites back onto the repository's existing UTF-16-safe text helper, so the source-of-truth contract is enforced at the boundary that returns browser tool output rather than masked downstream. Because the same Chrome/CDP response, `page.ariaSnapshot({ mode: "ai" })`, and Chrome MCP AI snapshot conversion paths now call `truncateUtf16Safe` before returning text, they no longer emit dangling surrogate halves while preserving the existing truncation semantics.
