### PR TITLE
fix(agent-core): skip handleRunFailure error forwarding for control-flow signals

### DIFF
--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -154,11 +154,10 @@ describe("agentLoop continuation guards", () => {
     });
   });
 
-  it("suppresses failure events for control-flow errors carrying the sentinel", async () => {
-    // Control-flow signals like MidTurnPrecheckSignal should not produce
-    // visible error events. handleRunFailure emits clean turn_end + agent_end
-    // lifecycle settlement but skips error-message forwarding for errors
-    // carrying the agent-core.controlFlowError sentinel.
+  it("settles control-flow runs cleanly — no error, no stale tool state, no abandoned stream", async () => {
+    // Control-flow signals like MidTurnPrecheckSignal must settle cleanly:
+    // no error messages, no abandoned streaming state, no stale tool calls,
+    // and a clean terminal lifecycle so callers see coherent event pairs.
     const signalError = new Error(
       "Context overflow: prompt too large for the model (mid-turn precheck).",
     );
@@ -166,6 +165,8 @@ describe("agentLoop continuation guards", () => {
     (signalError as unknown as Record<symbol, unknown>)[Symbol.for("agent-core.controlFlowError")] =
       true;
 
+    // Subscribe to capture the terminal settlement events.
+    const events: Array<{ type: string; stopReason?: string; errorMessage?: string }> = [];
     const agent = new Agent({
       initialState: {
         messages: [{ role: "user", content: "test", timestamp: 1 }],
@@ -175,13 +176,39 @@ describe("agentLoop continuation guards", () => {
         throw signalError;
       },
     });
+    agent.subscribe((event) => {
+      if (event.type === "turn_end") {
+        const msg = event.message as unknown as {
+          stopReason?: string;
+          errorMessage?: string;
+        };
+        events.push({ type: "turn_end", stopReason: msg.stopReason, errorMessage: msg.errorMessage });
+      }
+      if (event.type === "agent_end") {
+        events.push({ type: "agent_end" });
+      }
+    });
 
-    // Must not throw — handleRunFailure settles cleanly for sentinel errors.
+    // Must not throw — handleRunFailure settles via settleControlFlowRun.
     await agent.continue();
-    // No error message leaked to UI-visible state.
-    // Lifecycle events (turn_end + agent_end) are still emitted for callers
-    // that depend on consistent terminal settlement.
+
+    // No error state leaked.
     expect(agent.state.errorMessage).toBeUndefined();
+    // Streaming state cleaned up (no abandoned stream).
+    expect(agent.state.isStreaming).toBe(false);
+    // No stale tool call state.
+    expect(agent.state.pendingToolCalls.size).toBe(0);
+
+    // Terminal lifecycle events emitted with clean settlement.
+    const turnEnds = events.filter((e) => e.type === "turn_end");
+    const agentEnds = events.filter((e) => e.type === "agent_end");
+    expect(turnEnds.length).toBeGreaterThanOrEqual(1);
+    expect(agentEnds.length).toBeGreaterThanOrEqual(1);
+    // Settlement uses stopReason "stop" — not "error" or "toolUse".
+    for (const te of turnEnds) {
+      expect(te.stopReason).toBe("stop");
+      expect(te.errorMessage).toBeUndefined();
+    }
   });
 
   it("still forwards real errors through handleRunFailure", async () => {

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -154,10 +154,13 @@ describe("agentLoop continuation guards", () => {
     });
   });
 
-  it("settles control-flow runs cleanly — no error, no stale tool state, no abandoned stream", async () => {
+  it("settles control-flow runs cleanly — no error, no stale tool state, no stale metadata", async () => {
     // Control-flow signals like MidTurnPrecheckSignal must settle cleanly:
     // no error messages, no abandoned streaming state, no stale tool calls,
     // and a clean terminal lifecycle so callers see coherent event pairs.
+    // The settlement must NOT carry stale model/api/provider/usage metadata
+    // from the toolUse turn, which would confuse session replay or liveness
+    // observers during the retry path.
     const signalError = new Error(
       "Context overflow: prompt too large for the model (mid-turn precheck).",
     );
@@ -166,7 +169,13 @@ describe("agentLoop continuation guards", () => {
       true;
 
     // Subscribe to capture the terminal settlement events.
-    const events: Array<{ type: string; stopReason?: string; errorMessage?: string }> = [];
+    const events: Array<{
+      type: string;
+      stopReason?: string;
+      errorMessage?: string;
+      hasModelMeta?: boolean;
+      agentEndMessages?: number;
+    }> = [];
     const agent = new Agent({
       initialState: {
         messages: [{ role: "user", content: "test", timestamp: 1 }],
@@ -181,11 +190,19 @@ describe("agentLoop continuation guards", () => {
         const msg = event.message as unknown as {
           stopReason?: string;
           errorMessage?: string;
+          api?: unknown;
+          provider?: unknown;
+          model?: unknown;
         };
-        events.push({ type: "turn_end", stopReason: msg.stopReason, errorMessage: msg.errorMessage });
+        events.push({
+          type: "turn_end",
+          stopReason: msg.stopReason,
+          errorMessage: msg.errorMessage,
+          hasModelMeta: msg.api !== undefined || msg.provider !== undefined || msg.model !== undefined,
+        });
       }
       if (event.type === "agent_end") {
-        events.push({ type: "agent_end" });
+        events.push({ type: "agent_end", agentEndMessages: event.messages.length });
       }
     });
 
@@ -199,15 +216,22 @@ describe("agentLoop continuation guards", () => {
     // No stale tool call state.
     expect(agent.state.pendingToolCalls.size).toBe(0);
 
-    // Terminal lifecycle events emitted with clean settlement.
+    // Terminal lifecycle events emitted.
     const turnEnds = events.filter((e) => e.type === "turn_end");
     const agentEnds = events.filter((e) => e.type === "agent_end");
     expect(turnEnds.length).toBeGreaterThanOrEqual(1);
     expect(agentEnds.length).toBeGreaterThanOrEqual(1);
+
     // Settlement uses stopReason "stop" — not "error" or "toolUse".
     for (const te of turnEnds) {
       expect(te.stopReason).toBe("stop");
       expect(te.errorMessage).toBeUndefined();
+      // Settlement must NOT carry stale model metadata from the toolUse turn.
+      expect(te.hasModelMeta).toBe(false);
+    }
+    // agent_end carries empty messages — no stale data persisted.
+    for (const ae of agentEnds) {
+      expect(ae.agentEndMessages).toBe(0);
     }
   });
 

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -154,13 +154,10 @@ describe("agentLoop continuation guards", () => {
     });
   });
 
-  it("settles control-flow runs cleanly — no error, no stale tool state, no stale metadata", async () => {
-    // Control-flow signals like MidTurnPrecheckSignal must settle cleanly:
-    // no error messages, no abandoned streaming state, no stale tool calls,
-    // and a clean terminal lifecycle so callers see coherent event pairs.
-    // The settlement must NOT carry stale model/api/provider/usage metadata
-    // from the toolUse turn, which would confuse session replay or liveness
-    // observers during the retry path.
+  it("settles control-flow runs cleanly — no error, no stale tool state, valid settlement", async () => {
+    // Control-flow signals like MidTurnPrecheckSignal must settle with a
+    // valid AgentMessage so AgentSession extensions and subscriber surfaces
+    // receive a well-formed turn_end payload without stale tool-use state.
     const signalError = new Error(
       "Context overflow: prompt too large for the model (mid-turn precheck).",
     );
@@ -173,7 +170,6 @@ describe("agentLoop continuation guards", () => {
       type: string;
       stopReason?: string;
       errorMessage?: string;
-      hasModelMeta?: boolean;
       agentEndMessages?: number;
     }> = [];
     const agent = new Agent({
@@ -190,15 +186,11 @@ describe("agentLoop continuation guards", () => {
         const msg = event.message as unknown as {
           stopReason?: string;
           errorMessage?: string;
-          api?: unknown;
-          provider?: unknown;
-          model?: unknown;
         };
         events.push({
           type: "turn_end",
           stopReason: msg.stopReason,
           errorMessage: msg.errorMessage,
-          hasModelMeta: msg.api !== undefined || msg.provider !== undefined || msg.model !== undefined,
         });
       }
       if (event.type === "agent_end") {
@@ -226,10 +218,8 @@ describe("agentLoop continuation guards", () => {
     for (const te of turnEnds) {
       expect(te.stopReason).toBe("stop");
       expect(te.errorMessage).toBeUndefined();
-      // Settlement must NOT carry stale model metadata from the toolUse turn.
-      expect(te.hasModelMeta).toBe(false);
     }
-    // agent_end carries empty messages — no stale data persisted.
+    // agent_end carries empty messages — no stale data persisted into session.
     for (const ae of agentEnds) {
       expect(ae.agentEndMessages).toBe(0);
     }

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -153,6 +153,53 @@ describe("agentLoop continuation guards", () => {
       role: "assistant",
     });
   });
+
+  it("suppresses failure events for control-flow errors carrying the sentinel", async () => {
+    // Control-flow signals like MidTurnPrecheckSignal should not produce
+    // visible error events. handleRunFailure emits clean turn_end + agent_end
+    // lifecycle settlement but skips error-message forwarding for errors
+    // carrying the agent-core.controlFlowError sentinel.
+    const signalError = new Error(
+      "Context overflow: prompt too large for the model (mid-turn precheck).",
+    );
+    signalError.name = "MidTurnPrecheckSignal";
+    (signalError as unknown as Record<symbol, unknown>)[Symbol.for("agent-core.controlFlowError")] =
+      true;
+
+    const agent = new Agent({
+      initialState: {
+        messages: [{ role: "user", content: "test", timestamp: 1 }],
+        model,
+      },
+      streamFn: () => {
+        throw signalError;
+      },
+    });
+
+    // Must not throw — handleRunFailure settles cleanly for sentinel errors.
+    await agent.continue();
+    // No error message leaked to UI-visible state.
+    // Lifecycle events (turn_end + agent_end) are still emitted for callers
+    // that depend on consistent terminal settlement.
+    expect(agent.state.errorMessage).toBeUndefined();
+  });
+
+  it("still forwards real errors through handleRunFailure", async () => {
+    const agent = new Agent({
+      initialState: {
+        messages: [{ role: "user", content: "test2", timestamp: 1 }],
+        model,
+      },
+      streamFn: () => {
+        throw new Error("provider exploded");
+      },
+    });
+
+    // Real errors are swallowed by handleRunFailure (existing behavior).
+    await agent.continue();
+    // Error message must be visible in agent state.
+    expect(agent.state.errorMessage).toBe("provider exploded");
+  });
 });
 
 describe("agentLoop streaming updates", () => {

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -31,6 +31,13 @@ import type {
 
 export type { QueueMode } from "./types.js";
 
+/**
+ * Errors carrying this sentinel are control-flow signals (not user-facing
+ * failures). HandleRunFailure skips error-event forwarding for them so the
+ * caller's dedicated recovery path can run without a visible error flash.
+ */
+export const CONTROL_FLOW_ERROR = Symbol.for("agent-core.controlFlowError");
+
 function defaultConvertToLlm(messages: AgentMessage[]): Message[] {
   return messages.filter(
     (message) =>
@@ -534,6 +541,33 @@ export class Agent {
   }
 
   private async handleRunFailure(error: unknown, aborted: boolean): Promise<void> {
+    // Control-flow signals (e.g. MidTurnPrecheckSignal) are not user-facing
+    // errors. Skip error-event forwarding so the caller's dedicated recovery
+    // path can handle truncation + retry without a visible error flash.
+    // Still emit a clean turn_end + agent_end settlement so terminal lifecycle
+    // stays consistent for callers that depend on those events.
+    if (
+      !aborted &&
+      error instanceof Error &&
+      (error as Error & { [CONTROL_FLOW_ERROR]?: unknown })[CONTROL_FLOW_ERROR]
+    ) {
+      // Emit clean lifecycle settlement so subscribers see matching pairs
+      // of turn_start/turn_end and agent_start/agent_end events.
+      const settlementMessage = {
+        role: "assistant" as const,
+        content: [{ type: "text" as const, text: "" }],
+        api: this.mutableState.model.api,
+        provider: this.mutableState.model.provider,
+        model: this.mutableState.model.id,
+        usage: EMPTY_USAGE,
+        stopReason: "stop" as const,
+        timestamp: Date.now(),
+      } satisfies AgentMessage;
+      await this.processEvents({ type: "turn_end", message: settlementMessage, toolResults: [] });
+      await this.processEvents({ type: "agent_end", messages: [settlementMessage] });
+      return;
+    }
+
     const failureMessage = {
       role: "assistant",
       content: [{ type: "text", text: "" }],

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -548,19 +548,29 @@ export class Agent {
    * it only emits turn_end + agent_end so subscribers receive coherent
    * terminal pairs without stale tool-use or abandoned lifecycle state.
    */
+  /**
+   * Emits a clean terminal lifecycle settlement for control-flow signals.
+   * Unlike handleRunFailure this does NOT push a synthetic error message —
+   * it only emits turn_end + agent_end so subscribers receive coherent
+   * terminal pairs without stale tool-use or abandoned lifecycle state.
+   *
+   * The settlement message intentionally omits model/api/provider/usage
+   * metadata to avoid carrying stale toolUse-turn state into session
+   * replay or liveness observers during the retry path.
+   */
   private async settleControlFlowRun(): Promise<void> {
     const settlementMessage = {
       role: "assistant" as const,
       content: [{ type: "text" as const, text: "" }],
-      api: this.mutableState.model.api,
-      provider: this.mutableState.model.provider,
-      model: this.mutableState.model.id,
-      usage: EMPTY_USAGE,
       stopReason: "stop" as const,
       timestamp: Date.now(),
-    } satisfies AgentMessage;
-    await this.processEvents({ type: "turn_end", message: settlementMessage, toolResults: [] });
-    await this.processEvents({ type: "agent_end", messages: [settlementMessage] });
+    };
+    await this.processEvents({
+      type: "turn_end",
+      message: settlementMessage as AgentMessage,
+      toolResults: [],
+    });
+    await this.processEvents({ type: "agent_end", messages: [] });
   }
 
   private async handleRunFailure(error: unknown, aborted: boolean): Promise<void> {

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -540,31 +540,38 @@ export class Agent {
     }
   }
 
+  /**
+   * Emits a clean terminal lifecycle settlement for control-flow signals.
+   * Unlike handleRunFailure this does NOT push a synthetic error message —
+   * it only emits turn_end + agent_end so subscribers receive coherent
+   * terminal pairs without stale tool-use or abandoned lifecycle state.
+   */
+  private async settleControlFlowRun(): Promise<void> {
+    const settlementMessage = {
+      role: "assistant" as const,
+      content: [{ type: "text" as const, text: "" }],
+      api: this.mutableState.model.api,
+      provider: this.mutableState.model.provider,
+      model: this.mutableState.model.id,
+      usage: EMPTY_USAGE,
+      stopReason: "stop" as const,
+      timestamp: Date.now(),
+    } satisfies AgentMessage;
+    await this.processEvents({ type: "turn_end", message: settlementMessage, toolResults: [] });
+    await this.processEvents({ type: "agent_end", messages: [settlementMessage] });
+  }
+
   private async handleRunFailure(error: unknown, aborted: boolean): Promise<void> {
     // Control-flow signals (e.g. MidTurnPrecheckSignal) are not user-facing
-    // errors. Skip error-event forwarding so the caller's dedicated recovery
-    // path can handle truncation + retry without a visible error flash.
-    // Still emit a clean turn_end + agent_end settlement so terminal lifecycle
-    // stays consistent for callers that depend on those events.
+    // errors. Emit a clean lifecycle settlement so subscribers see matching
+    // turn_start/turn_end and agent_start/agent_end pairs, then let the
+    // caller's dedicated recovery path handle truncation + retry.
     if (
       !aborted &&
       error instanceof Error &&
       (error as Error & { [CONTROL_FLOW_ERROR]?: unknown })[CONTROL_FLOW_ERROR]
     ) {
-      // Emit clean lifecycle settlement so subscribers see matching pairs
-      // of turn_start/turn_end and agent_start/agent_end events.
-      const settlementMessage = {
-        role: "assistant" as const,
-        content: [{ type: "text" as const, text: "" }],
-        api: this.mutableState.model.api,
-        provider: this.mutableState.model.provider,
-        model: this.mutableState.model.id,
-        usage: EMPTY_USAGE,
-        stopReason: "stop" as const,
-        timestamp: Date.now(),
-      } satisfies AgentMessage;
-      await this.processEvents({ type: "turn_end", message: settlementMessage, toolResults: [] });
-      await this.processEvents({ type: "agent_end", messages: [settlementMessage] });
+      await this.settleControlFlowRun();
       return;
     }
 

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -35,8 +35,10 @@ export type { QueueMode } from "./types.js";
  * Errors carrying this sentinel are control-flow signals (not user-facing
  * failures). HandleRunFailure skips error-event forwarding for them so the
  * caller's dedicated recovery path can run without a visible error flash.
+ *
+ * Not exported — callers access it via Symbol.for("agent-core.controlFlowError").
  */
-export const CONTROL_FLOW_ERROR = Symbol.for("agent-core.controlFlowError");
+const CONTROL_FLOW_ERROR = Symbol.for("agent-core.controlFlowError");
 
 function defaultConvertToLlm(messages: AgentMessage[]): Message[] {
   return messages.filter(

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -554,22 +554,21 @@ export class Agent {
    * it only emits turn_end + agent_end so subscribers receive coherent
    * terminal pairs without stale tool-use or abandoned lifecycle state.
    *
-   * The settlement message intentionally omits model/api/provider/usage
-   * metadata to avoid carrying stale toolUse-turn state into session
-   * replay or liveness observers during the retry path.
+   * The settlement message is a valid AssistantMessage so AgentSession
+   * extensions and subscriber surfaces receive a well-formed payload.
    */
   private async settleControlFlowRun(): Promise<void> {
     const settlementMessage = {
       role: "assistant" as const,
       content: [{ type: "text" as const, text: "" }],
+      api: this.mutableState.model.api,
+      provider: this.mutableState.model.provider,
+      model: this.mutableState.model.id,
+      usage: EMPTY_USAGE,
       stopReason: "stop" as const,
       timestamp: Date.now(),
-    };
-    await this.processEvents({
-      type: "turn_end",
-      message: settlementMessage as AgentMessage,
-      toolResults: [],
-    });
+    } satisfies AgentMessage;
+    await this.processEvents({ type: "turn_end", message: settlementMessage, toolResults: [] });
     await this.processEvents({ type: "agent_end", messages: [] });
   }
 

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -195,7 +195,7 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
     ),
     publicExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS",
-      10464,
+      10463,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -195,7 +195,7 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
     ),
     publicExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS",
-      10463,
+      10464,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/embedded-agent-runner/run/midturn-precheck.ts
+++ b/src/agents/embedded-agent-runner/run/midturn-precheck.ts
@@ -32,6 +32,10 @@ export class MidTurnPrecheckSignal extends Error {
     super(MID_TURN_PRECHECK_ERROR_MESSAGE);
     this.name = "MidTurnPrecheckSignal";
     this.request = request;
+    // Mark as a control-flow signal so Agent.handleRunFailure skips
+    // failure-event forwarding. The attempt runner's dedicated recovery
+    // path handles truncation + retry without a visible error flash.
+    (this as Record<symbol, unknown>)[Symbol.for("agent-core.controlFlowError")] = true;
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

When a tool result makes the next prompt exceed the context budget during a tool loop, `transformContext` throws `MidTurnPrecheckSignal` — a **control-flow mechanism** to trigger tool-result truncation and retry, not a terminal error.

However, `Agent.handleRunFailure` was treating this signal as a real error and pushing a synthetic failure event (`stopReason: "error"`) into the stream. Users see "Context overflow: prompt too large for the model (mid-turn precheck)." immediately, even though the retry succeeds via the `pendingMidTurnPrecheckRequest` side-channel callback.

Fixes [#101621](https://github.com/openclaw/openclaw/issues/101621).

## Why This Change Was Made

Mark `MidTurnPrecheckSignal` with a `Symbol.for("agent-core.controlFlowError")` sentinel so `Agent.handleRunFailure` can recognize control-flow signals. Instead of pushing a synthetic error event, the fix emits a clean lifecycle settlement via a dedicated `settleControlFlowRun` helper — emitting `turn_end` (`stopReason: "stop"`) + `agent_end` so subscribers receive coherent terminal pairs without stale tool-use or abandoned lifecycle state.

### Production call path (root cause)

```
transformContext() throws MidTurnPrecheckSignal
  → streamAssistantResponse() → runLoop() → runAgentLoop()
  → Agent.runPromptMessages()
  → Agent.runWithLifecycle() catch
    → handleRunFailure(error)  ← was pushing synthetic error to stream
```

### Design decisions

- **Symbol sentinel**: Uses `Symbol.for("agent-core.controlFlowError")` owned by agent-core — a generic contract, not OpenClaw-specific. Discoverable across packages via the symbol key string without importing. The constant is internal only (not exported from the public API surface).
- **settleControlFlowRun helper**: Dedicated private method for clean lifecycle settlement, distinct from `handleRunFailure`. Emits a valid `AgentMessage` (satisfies the full type contract) so `AgentSession` extensions and subscriber surfaces receive a well-formed payload.
- **Scope**: The fix is scoped to `Agent.handleRunFailure` only (production path); not applied to the `agent-loop.ts` EventStream API which is unused in production.

### Files changed

| File | Change |
|------|--------|
| `packages/agent-core/src/agent.ts` | Internal `CONTROL_FLOW_ERROR` sentinel; `settleControlFlowRun` helper; `handleRunFailure` early-return for sentinel errors |
| `src/agents/embedded-agent-runner/run/midturn-precheck.ts` | Mark `MidTurnPrecheckSignal` with the sentinel in constructor |
| `packages/agent-core/src/agent-loop.test.ts` | 2 new tests with lifecycle settlement coverage |

## User Impact

- **Before**: Users see a premature "Context overflow" error flash during tool loops, even though the truncation+retry succeeds silently.
- **After**: No visible error for control-flow signals. Clean lifecycle settlement emitted with a valid AgentMessage. Real errors still produce error events normally.

## Evidence

### 1. Real machine verification (Node v22.19.0, Linux x86_64)

```
=== Verification ===
Node: v22.19.0 Host: LIN-DF11F9C3F26.zte.intra

[Test 1] Control-flow signal → clean settlement
  errorMessage:      undefined ✅
  isStreaming:       false ✅
  pendingToolCalls:  0 ✅
  turn_end (stop, valid msg): true ✅
  agent_end (empty): true ✅
  => PASS

[Test 2] Real error → handleRunFailure
  errorMessage: provider down ✅
  => PASS
```

### 2. Lifecycle settlement test coverage (agent-loop.test.ts)

```
 ✓ settles control-flow runs cleanly —
     no error, no stale tool state, valid settlement
 ✓ still forwards real errors through handleRunFailure
```

### 3. MCP gateway verification

```
Gateway: live ✅
midTurnPrecheck enabled: true
MCP overflow-test server: ready ✅
```

## Risk checklist

merge-risk: Low

- Only errors carrying `Symbol.for("agent-core.controlFlowError")` are suppressed (currently only `MidTurnPrecheckSignal`)
- Real errors still trigger normal `handleRunFailure` — regression test included
- Settlement message is a valid complete `AgentMessage` — no casts, satisfies the type contract
- `CONTROL_FLOW_ERROR` is internal only, not exported from the public API surface
- Check scoped to `Agent.handleRunFailure` only (production path); no breaking API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>