### PR TITLE
fix(msteams): bound user token response parsing [AI]

### DIFF
--- a/extensions/msteams/src/monitor-handler.sso.test.ts
+++ b/extensions/msteams/src/monitor-handler.sso.test.ts
@@ -141,6 +141,58 @@ describe("handleSigninTokenExchangeInvoke", () => {
     expect(stored).toBeNull();
   });
 
+  it("bounds successful User Token service JSON reads and cancels the stream", async () => {
+    const state = { canceled: false, enqueued: 0 };
+    const chunkBytes = 1024 * 1024;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (state.enqueued >= 64) {
+          controller.close();
+          return;
+        }
+        state.enqueued += 1;
+        controller.enqueue(new Uint8Array(chunkBytes).fill(0x61));
+      },
+      cancel() {
+        state.canceled = true;
+      },
+    });
+    const jsonSpy = vi.spyOn(Response.prototype, "json").mockImplementation(async () => {
+      throw new Error("raw response.json() should not be used");
+    });
+    const fetchImpl: MSTeamsSsoFetch = vi.fn(async () => {
+      return new Response(stream, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const { sso, tokenStore } = createSsoDeps({ fetchImpl });
+
+    try {
+      const result = await handleSigninTokenExchangeInvoke({
+        value: { id: "flow-1", connectionName: "GraphConnection", token: "exchangeable-token" },
+        user: { userId: "aad-user-guid", channelId: "msteams" },
+        deps: sso,
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe("unexpected_response");
+        expect(result.message).toMatch(/JSON response exceeds 16777216 bytes/);
+      }
+      expect(jsonSpy).not.toHaveBeenCalled();
+      expect(state.enqueued).toBeLessThan(32);
+      expect(state.canceled).toBe(true);
+      const stored = await tokenStore.get({
+        connectionName: "GraphConnection",
+        userId: "aad-user-guid",
+      });
+      expect(stored).toBeNull();
+    } finally {
+      jsonSpy.mockRestore();
+    }
+  });
+
   it("refuses to exchange without a user id", async () => {
     const { fetchImpl, calls } = createFakeFetch([]);
     const { sso } = createSsoDeps({ fetchImpl });

--- a/extensions/msteams/src/sso.ts
+++ b/extensions/msteams/src/sso.ts
@@ -24,6 +24,7 @@
  * that ack; these helpers encapsulate token exchange and persistence.
  */
 
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import type { MSTeamsAccessTokenProvider } from "./attachments/types.js";
 import { readMSTeamsHttpErrorDetail } from "./http-error.js";
 import type { MSTeamsSsoTokenStore } from "./sso-token-store.js";
@@ -130,9 +131,15 @@ async function callUserTokenService(
   }
   let parsed: unknown;
   try {
-    parsed = await response.json();
-  } catch {
-    return { error: "invalid JSON from User Token service", status: response.status };
+    parsed = await readProviderJsonResponse<unknown>(
+      response,
+      "invalid JSON from User Token service",
+    );
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : "invalid JSON from User Token service",
+      status: response.status,
+    };
   }
   if (!parsed || typeof parsed !== "object") {
     return { error: "empty response from User Token service", status: response.status };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Microsoft Teams SSO token exchange could fail poorly when the Bot Framework User Token service returned a very large or malformed JSON response.

## Why This Change Was Made

The Microsoft Teams SSO success path now uses the shared provider JSON response reader, matching the bounded parsing behavior already used by the plugin's Graph and attachment paths. The regression test verifies the stream is cancelled at the JSON response limit and that raw `Response.json()` parsing is not used.

AI-assisted.

## User Impact

Microsoft Teams SSO token exchange now handles oversized or malformed User Token service responses with bounded parsing. Normal token responses keep the same behavior, and invalid responses do not persist a delegated token.

## Evidence

- `pnpm format -- extensions/msteams/src/sso.ts extensions/msteams/src/monitor-handler.sso.test.ts`
- `git diff --check`
- `node scripts/run-vitest.mjs extensions/msteams/src/monitor-handler.sso.test.ts` - 1 file, 6 tests passed
- `rg -n "await [A-Za-z0-9_]+\\.json\\(|\\.json\\(\\)" extensions/msteams/src extensions/msteams/*.ts` - remaining Microsoft Teams matches are regression-test spies only

Known limitation: remote Testbox/Crabbox proof was not available in this environment because neither `crabbox` nor `../crabbox/bin/crabbox` is installed.
