### PR TITLE
fix(session-fork): skip fork when parent size is unresolved instead of forking (#101718)

### DIFF
--- a/scripts/proof-session-fork-timeout.ts
+++ b/scripts/proof-session-fork-timeout.ts
@@ -1,0 +1,226 @@
+/**
+ * Self-contained real-behavior proof for PR #101767 (fixes #101718).
+ *
+ * Drives the REAL `resolveParentForkDecision` / `forkSessionEntryFromParent`
+ * against REAL transcript files on disk, with injected filesystem latency that
+ * simulates a slow mount (NFS / FUSE / saturated SSD) — the exact scenario in
+ * the issue. No mocks: the production modules and Node's real `fs` do the work.
+ *
+ * It proves the fix's two guarantees:
+ *   1. Bounded: parent-fork token resolution never blocks longer than the 2s
+ *      deadline (+ a 1s stat fallback), even when the transcript read hangs.
+ *   2. Safe: when the size cannot be confirmed in time, the parent is SKIPPED
+ *      (isolated context) instead of forked into the unbounded whole-file read
+ *      flagged by review — an oversized parent is still caught by a fast,
+ *      stat-only byte estimate.
+ *
+ * Usage: npx tsx scripts/proof-session-fork-timeout.ts
+ */
+import { execSync } from "node:child_process";
+import nodeFs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+// ── Inject filesystem latency (simulate a slow mount) ────────────────
+let openDelayMs = 0;
+let statDelayMs = 0;
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+const realOpen = nodeFs.promises.open.bind(nodeFs.promises);
+// The bounded transcript tail read opens the file handle here.
+nodeFs.promises.open = (async (...args: unknown[]) => {
+  if (openDelayMs > 0) {
+    await sleep(openDelayMs);
+  }
+  return (realOpen as (...a: unknown[]) => unknown)(...args);
+}) as typeof nodeFs.promises.open;
+
+// `stat` backs both the byte-estimate fallback (node:fs/promises) and the tail
+// reader (node:fs.promises); patch every distinct object they reference.
+for (const target of new Set<{ stat: unknown }>([fsp, nodeFs.promises])) {
+  const realStat = (target.stat as (...a: unknown[]) => unknown).bind(target);
+  (target as { stat: unknown }).stat = async (...args: unknown[]) => {
+    if (statDelayMs > 0) {
+      await sleep(statDelayMs);
+    }
+    return realStat(...args);
+  };
+}
+
+// Import the REAL production modules only after fs is instrumented.
+const { resolveParentForkDecision, forkSessionEntryFromParent } =
+  await import("../src/auto-reply/reply/session-fork.js");
+const { resolveParentForkTokenCountRuntime } =
+  await import("../src/auto-reply/reply/session-fork.runtime.js");
+
+// ── Fixture: a real on-disk parent transcript of a chosen size ───────
+const roots: string[] = [];
+async function makeParent(targetBytes: number): Promise<{
+  storePath: string;
+  parentEntry: { sessionId: string; sessionFile: string; updatedAt: number };
+  parentSessionKey: string;
+  sessionKey: string;
+}> {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), "openclaw-fork-proof-"));
+  roots.push(root);
+  const parentFile = path.join(root, "parent.jsonl");
+  const line = `${JSON.stringify({
+    type: "message",
+    id: "x",
+    parentId: null,
+    message: { role: "assistant", content: "y".repeat(240) },
+  })}\n`;
+  let buf = `${JSON.stringify({ type: "session", cwd: root, id: "hdr" })}\n`;
+  while (Buffer.byteLength(buf) < targetBytes) {
+    buf += line;
+  }
+  await fsp.writeFile(parentFile, buf, "utf-8");
+  const storePath = path.join(root, "sessions.json");
+  const parentSessionKey = "agent:main:main";
+  const sessionKey = "agent:main:subagent:child";
+  await fsp.writeFile(
+    storePath,
+    JSON.stringify({
+      [parentSessionKey]: { sessionId: "parent-session", sessionFile: parentFile, updatedAt: 1 },
+      [sessionKey]: { sessionId: "", updatedAt: 2 },
+    }),
+    "utf-8",
+  );
+  return {
+    storePath,
+    parentEntry: { sessionId: "parent-session", sessionFile: parentFile, updatedAt: 1 },
+    parentSessionKey,
+    sessionKey,
+  };
+}
+
+// ── Harness plumbing ─────────────────────────────────────────────────
+let passed = 0;
+let failed = 0;
+const check = (name: string, ok: boolean, detail: string): void => {
+  if (ok) {
+    passed += 1;
+    console.log(`  ✅ ${name} — ${detail}`);
+  } else {
+    failed += 1;
+    console.log(`  ❌ ${name} — ${detail}`);
+  }
+};
+
+console.log("PR #101767 real-behavior proof (#101718) — slow-filesystem parent fork\n");
+console.log(`HEAD: ${execSync("git rev-parse --short HEAD").toString().trim()}`);
+console.log(
+  `worktree: ${execSync("git status --porcelain").toString().trim() ? "dirty (fix applied)" : "clean"}\n`,
+);
+
+const KB = 1024;
+const LARGE_BYTES = 600 * KB; // 600KB ⇒ byte estimate ≈ 150K tokens (> 100K cap)
+const SMALL_BYTES = 2 * KB; // 2KB   ⇒ byte estimate ≈ 512 tokens (< cap)
+
+// ── Baseline: the read the deadline must guard is genuinely unbounded ─
+{
+  const { storePath, parentEntry } = await makeParent(LARGE_BYTES);
+  openDelayMs = 3_000;
+  statDelayMs = 0;
+  const t0 = Date.now();
+  await resolveParentForkTokenCountRuntime({ parentEntry, storePath });
+  const dt = Date.now() - t0;
+  check(
+    "Baseline: raw token resolution blocks on a slow transcript read",
+    dt >= 2_800,
+    `unguarded runtime took ${dt}ms (this is what the 2s deadline must bound)`,
+  );
+}
+
+// ── Case 1: slow read + OVERSIZED parent ⇒ bounded SKIP, no fork read ─
+{
+  const fixture = await makeParent(LARGE_BYTES);
+  openDelayMs = 3_000;
+  statDelayMs = 0;
+  const t0 = Date.now();
+  const decision = await resolveParentForkDecision({
+    parentEntry: fixture.parentEntry,
+    agentId: "main",
+    storePath: fixture.storePath,
+  });
+  const dt = Date.now() - t0;
+  check(
+    "Case 1a: oversized parent decision is bounded by the deadline",
+    dt < 2_900,
+    `decided in ${dt}ms (< 2.9s) instead of blocking on the 3s read`,
+  );
+  check(
+    "Case 1b: oversized parent SKIPS the fork via the stat-only estimate",
+    decision.status === "skip" && decision.reason === "parent-too-large",
+    `decision=${decision.status}/${"reason" in decision ? decision.reason : "-"}`,
+  );
+
+  // End-to-end: the storage-boundary entry point must not enter the fork read.
+  const t1 = Date.now();
+  const result = await forkSessionEntryFromParent({
+    agentId: "main",
+    fallbackEntry: { sessionId: "", updatedAt: 2 },
+    parentSessionKey: fixture.parentSessionKey,
+    sessionKey: fixture.sessionKey,
+    storePath: fixture.storePath,
+  });
+  const dt1 = Date.now() - t1;
+  check(
+    "Case 1c: forkSessionEntryFromParent returns skipped (no whole-file read)",
+    result.status === "skipped" && dt1 < 2_900,
+    `status=${result.status} in ${dt1}ms`,
+  );
+}
+
+// ── Case 2: slow read + SMALL parent ⇒ bounded FORK, estimate preserved ─
+{
+  const fixture = await makeParent(SMALL_BYTES);
+  openDelayMs = 3_000;
+  statDelayMs = 0;
+  const t0 = Date.now();
+  const decision = await resolveParentForkDecision({
+    parentEntry: fixture.parentEntry,
+    agentId: "main",
+    storePath: fixture.storePath,
+  });
+  const dt = Date.now() - t0;
+  const parentTokens = decision.status === "fork" ? decision.parentTokens : undefined;
+  check(
+    "Case 2: small parent forks with a preserved conservative estimate",
+    decision.status === "fork" && typeof parentTokens === "number" && dt < 2_900,
+    `decision=${decision.status} parentTokens=${String(parentTokens)} in ${dt}ms`,
+  );
+}
+
+// ── Case 3: slow read AND slow stat ⇒ bounded SKIP (unresolved) ───────
+{
+  const fixture = await makeParent(LARGE_BYTES);
+  openDelayMs = 3_000;
+  statDelayMs = 3_000;
+  const t0 = Date.now();
+  const decision = await resolveParentForkDecision({
+    parentEntry: fixture.parentEntry,
+    agentId: "main",
+    storePath: fixture.storePath,
+  });
+  const dt = Date.now() - t0;
+  check(
+    "Case 3a: unresolvable size is still bounded (deadline + stat fallback)",
+    dt < 3_900,
+    `decided in ${dt}ms even with stat itself hanging`,
+  );
+  check(
+    "Case 3b: unresolvable size SKIPS conservatively instead of forking",
+    decision.status === "skip" && decision.reason === "parent-size-unresolved",
+    `decision=${decision.status}/${"reason" in decision ? decision.reason : "-"}`,
+  );
+}
+
+// ── Cleanup + summary ────────────────────────────────────────────────
+openDelayMs = 0;
+statDelayMs = 0;
+await Promise.all(roots.map((root) => fsp.rm(root, { recursive: true, force: true })));
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/scripts/proof-session-fork-timeout.ts
+++ b/scripts/proof-session-fork-timeout.ts
@@ -25,7 +25,10 @@ import path from "node:path";
 // ── Inject filesystem latency (simulate a slow mount) ────────────────
 let openDelayMs = 0;
 let statDelayMs = 0;
-const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
 
 const realOpen = nodeFs.promises.open.bind(nodeFs.promises);
 // The bounded transcript tail read opens the file handle here.

--- a/src/auto-reply/reply/session-fork.runtime.ts
+++ b/src/auto-reply/reply/session-fork.runtime.ts
@@ -75,6 +75,18 @@ async function estimateParentTranscriptTokensFromBytes(params: {
   }
 }
 
+/**
+ * Fast, stat-only token estimate used as a bounded fallback when the full
+ * token resolution exceeds its deadline. Reads only file metadata, so it stays
+ * bounded even for multi-hundred-MB transcripts and never enters a full read.
+ */
+export async function estimateParentForkTokensFromSizeRuntime(params: {
+  parentEntry: StoreSessionEntry;
+  storePath: string;
+}): Promise<number | undefined> {
+  return estimateParentTranscriptTokensFromBytes(params);
+}
+
 /** Resolves the best available token count for a parent session before forking. */
 export async function resolveParentForkTokenCountRuntime(params: {
   parentEntry: StoreSessionEntry;

--- a/src/auto-reply/reply/session-fork.test.ts
+++ b/src/auto-reply/reply/session-fork.test.ts
@@ -9,6 +9,7 @@ import { forkSessionEntryFromParent, resolveParentForkDecision } from "./session
 const runtimeMocks = vi.hoisted(() => ({
   forkSessionFromParentRuntime: vi.fn(),
   resolveParentForkTokenCountRuntime: vi.fn(),
+  estimateParentForkTokensFromSizeRuntime: vi.fn(),
 }));
 
 vi.mock("./session-fork.runtime.js", () => runtimeMocks);
@@ -21,9 +22,22 @@ async function makeRoot(prefix: string): Promise<string> {
   return root;
 }
 
+/** A promise that never settles, used to model a hung filesystem read. */
+function neverSettles<T>(): Promise<T> {
+  return new Promise<T>(() => {});
+}
+
+const decisionParams = {
+  parentEntry: { sessionId: "parent", updatedAt: 1 },
+  agentId: "main",
+  storePath: "/tmp/sessions.json",
+} as const;
+
 afterEach(async () => {
+  vi.useRealTimers();
   runtimeMocks.forkSessionFromParentRuntime.mockReset();
   runtimeMocks.resolveParentForkTokenCountRuntime.mockReset();
+  runtimeMocks.estimateParentForkTokensFromSizeRuntime.mockReset();
   await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
 });
 
@@ -84,52 +98,129 @@ describe("forkSessionEntryFromParent", () => {
     >;
     expect(stored[sessionKey]?.sessionFile).toBe(path.join(activeStoreDir, "forked-session.jsonl"));
   });
+
+  it("skips the fork read entirely when the parent size cannot be resolved (#101718)", async () => {
+    const root = await makeRoot("openclaw-session-fork-timeout-");
+    const storePath = path.join(root, "sessions.json");
+    const parentSessionKey = "agent:main:main";
+    const sessionKey = "agent:main:subagent:child";
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        [parentSessionKey]: {
+          sessionId: "parent-session",
+          sessionFile: path.join(root, "parent.jsonl"),
+          updatedAt: 1,
+        },
+        [sessionKey]: { sessionId: "", updatedAt: 2 },
+      }),
+      "utf-8",
+    );
+
+    vi.useFakeTimers();
+    // Both the full resolution and the fast size probe hang: the parent size is
+    // unresolvable. The fork must NOT proceed into the unbounded transcript read.
+    runtimeMocks.resolveParentForkTokenCountRuntime.mockReturnValue(neverSettles());
+    runtimeMocks.estimateParentForkTokensFromSizeRuntime.mockReturnValue(neverSettles());
+
+    const resultPromise = forkSessionEntryFromParent({
+      agentId: "main",
+      fallbackEntry: { sessionId: "", updatedAt: 2 },
+      parentSessionKey,
+      sessionKey,
+      storePath,
+    });
+    await vi.advanceTimersByTimeAsync(4_000);
+    const result = await resultPromise;
+
+    expect(result.status).toBe("skipped");
+    expect(runtimeMocks.forkSessionFromParentRuntime).not.toHaveBeenCalled();
+  });
 });
 
 describe("resolveParentForkDecision", () => {
   it("returns fork with token count when the runtime resolves quickly", async () => {
     runtimeMocks.resolveParentForkTokenCountRuntime.mockResolvedValue(50_000);
 
-    const decision = await resolveParentForkDecision({
-      parentEntry: { sessionId: "parent", updatedAt: 1 },
-      agentId: "main",
-      storePath: "/tmp/sessions.json",
-    });
+    const decision = await resolveParentForkDecision({ ...decisionParams });
 
     expect(decision.status).toBe("fork");
+    if (decision.status !== "fork") {
+      throw new Error("expected fork");
+    }
     expect(decision.parentTokens).toBe(50_000);
-  });
-
-  it("returns fork without parentTokens when the runtime hangs (timeout)", async () => {
-    // Simulate a hung filesystem: never resolve
-    runtimeMocks.resolveParentForkTokenCountRuntime.mockReturnValue(
-      new Promise(() => {}), // never settles
-    );
-
-    const decision = await resolveParentForkDecision({
-      parentEntry: { sessionId: "parent", updatedAt: 1 },
-      agentId: "main",
-      storePath: "/tmp/sessions.json",
-    });
-
-    // Must still return a decision (not throw), fork proceeds
-    // without a token estimate rather than blocking indefinitely (#101718).
-    expect(decision.status).toBe("fork");
-    expect(decision.parentTokens).toBeUndefined();
+    expect(runtimeMocks.estimateParentForkTokensFromSizeRuntime).not.toHaveBeenCalled();
   });
 
   it("returns skip when parent is too large", async () => {
     runtimeMocks.resolveParentForkTokenCountRuntime.mockResolvedValue(200_000);
 
-    const decision = await resolveParentForkDecision({
-      parentEntry: { sessionId: "parent", updatedAt: 1 },
-      agentId: "main",
-      storePath: "/tmp/sessions.json",
-    });
+    const decision = await resolveParentForkDecision({ ...decisionParams });
 
     expect(decision.status).toBe("skip");
+    if (decision.status !== "skip") {
+      throw new Error("expected skip");
+    }
     expect(decision.reason).toBe("parent-too-large");
+    if (decision.reason !== "parent-too-large") {
+      throw new Error("expected parent-too-large");
+    }
     expect(decision.parentTokens).toBe(200_000);
     expect(decision.maxTokens).toBe(100_000);
+  });
+
+  it("falls back to the byte estimate and forks a small parent when the runtime hangs", async () => {
+    vi.useFakeTimers();
+    runtimeMocks.resolveParentForkTokenCountRuntime.mockReturnValue(neverSettles());
+    runtimeMocks.estimateParentForkTokensFromSizeRuntime.mockResolvedValue(40_000);
+
+    const decisionPromise = resolveParentForkDecision({ ...decisionParams });
+    await vi.advanceTimersByTimeAsync(2_500);
+    const decision = await decisionPromise;
+
+    expect(decision.status).toBe("fork");
+    if (decision.status !== "fork") {
+      throw new Error("expected fork");
+    }
+    // The conservative estimate is preserved rather than discarded on timeout.
+    expect(decision.parentTokens).toBe(40_000);
+    expect(runtimeMocks.estimateParentForkTokensFromSizeRuntime).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the byte estimate and skips an oversized parent when the runtime hangs", async () => {
+    vi.useFakeTimers();
+    runtimeMocks.resolveParentForkTokenCountRuntime.mockReturnValue(neverSettles());
+    runtimeMocks.estimateParentForkTokensFromSizeRuntime.mockResolvedValue(5_000_000);
+
+    const decisionPromise = resolveParentForkDecision({ ...decisionParams });
+    await vi.advanceTimersByTimeAsync(2_500);
+    const decision = await decisionPromise;
+
+    expect(decision.status).toBe("skip");
+    if (decision.status !== "skip") {
+      throw new Error("expected skip");
+    }
+    expect(decision.reason).toBe("parent-too-large");
+    if (decision.reason !== "parent-too-large") {
+      throw new Error("expected parent-too-large");
+    }
+    expect(decision.parentTokens).toBe(5_000_000);
+  });
+
+  it("skips with an unresolved reason when both the runtime and the size probe hang", async () => {
+    vi.useFakeTimers();
+    runtimeMocks.resolveParentForkTokenCountRuntime.mockReturnValue(neverSettles());
+    runtimeMocks.estimateParentForkTokensFromSizeRuntime.mockReturnValue(neverSettles());
+
+    const decisionPromise = resolveParentForkDecision({ ...decisionParams });
+    await vi.advanceTimersByTimeAsync(4_000);
+    const decision = await decisionPromise;
+
+    expect(decision.status).toBe("skip");
+    if (decision.status !== "skip") {
+      throw new Error("expected skip");
+    }
+    expect(decision.reason).toBe("parent-size-unresolved");
+    expect(decision.message.length).toBeGreaterThan(0);
   });
 });

--- a/src/auto-reply/reply/session-fork.test.ts
+++ b/src/auto-reply/reply/session-fork.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { forkSessionEntryFromParent } from "./session-fork.js";
+import { forkSessionEntryFromParent, resolveParentForkDecision } from "./session-fork.js";
 
 const runtimeMocks = vi.hoisted(() => ({
   forkSessionFromParentRuntime: vi.fn(),
@@ -83,5 +83,53 @@ describe("forkSessionEntryFromParent", () => {
       { sessionFile?: string }
     >;
     expect(stored[sessionKey]?.sessionFile).toBe(path.join(activeStoreDir, "forked-session.jsonl"));
+  });
+});
+
+describe("resolveParentForkDecision", () => {
+  it("returns fork with token count when the runtime resolves quickly", async () => {
+    runtimeMocks.resolveParentForkTokenCountRuntime.mockResolvedValue(50_000);
+
+    const decision = await resolveParentForkDecision({
+      parentEntry: { sessionId: "parent", updatedAt: 1 },
+      agentId: "main",
+      storePath: "/tmp/sessions.json",
+    });
+
+    expect(decision.status).toBe("fork");
+    expect(decision.parentTokens).toBe(50_000);
+  });
+
+  it("returns fork without parentTokens when the runtime hangs (timeout)", async () => {
+    // Simulate a hung filesystem: never resolve
+    runtimeMocks.resolveParentForkTokenCountRuntime.mockReturnValue(
+      new Promise(() => {}), // never settles
+    );
+
+    const decision = await resolveParentForkDecision({
+      parentEntry: { sessionId: "parent", updatedAt: 1 },
+      agentId: "main",
+      storePath: "/tmp/sessions.json",
+    });
+
+    // Must still return a decision (not throw), fork proceeds
+    // without a token estimate rather than blocking indefinitely (#101718).
+    expect(decision.status).toBe("fork");
+    expect(decision.parentTokens).toBeUndefined();
+  });
+
+  it("returns skip when parent is too large", async () => {
+    runtimeMocks.resolveParentForkTokenCountRuntime.mockResolvedValue(200_000);
+
+    const decision = await resolveParentForkDecision({
+      parentEntry: { sessionId: "parent", updatedAt: 1 },
+      agentId: "main",
+      storePath: "/tmp/sessions.json",
+    });
+
+    expect(decision.status).toBe("skip");
+    expect(decision.reason).toBe("parent-too-large");
+    expect(decision.parentTokens).toBe(200_000);
+    expect(decision.maxTokens).toBe(100_000);
   });
 });

--- a/src/auto-reply/reply/session-fork.ts
+++ b/src/auto-reply/reply/session-fork.ts
@@ -25,6 +25,12 @@ export type ParentForkDecision =
       maxTokens: number;
       parentTokens: number;
       message: string;
+    }
+  | {
+      status: "skip";
+      reason: "parent-size-unresolved";
+      maxTokens: number;
+      message: string;
     };
 
 type ParentForkDecisionParams = {
@@ -102,6 +108,13 @@ function formatParentForkTooLargeMessage(params: {
   );
 }
 
+function formatParentForkSizeUnresolvedMessage(): string {
+  return (
+    "Parent context size could not be resolved in time to fork safely; " +
+    "starting with isolated context instead."
+  );
+}
+
 function resolveParentForkStorePath(params: {
   agentId?: string;
   config?: OpenClawConfig;
@@ -124,10 +137,23 @@ export async function resolveParentForkDecision(
   params: ParentForkDecisionParams,
 ): Promise<ParentForkDecision> {
   const maxTokens = DEFAULT_PARENT_FORK_MAX_TOKENS;
-  const parentTokens = await resolveParentForkTokenCount({
+  const resolution = await resolveParentForkTokenCount({
     parentEntry: params.parentEntry,
     storePath: resolveParentForkStorePath(params),
   });
+  if (resolution.status === "unresolved") {
+    // The parent size could not be resolved within the deadline, even from a
+    // fast size probe. Skip the fork and start with isolated context rather
+    // than enter an unbounded parent transcript read that could stall session
+    // creation indefinitely (#101718).
+    return {
+      status: "skip",
+      reason: "parent-size-unresolved",
+      maxTokens,
+      message: formatParentForkSizeUnresolvedMessage(),
+    };
+  }
+  const parentTokens = resolution.tokens;
   if (typeof parentTokens === "number" && parentTokens > maxTokens) {
     return {
       status: "skip",
@@ -291,17 +317,45 @@ export async function forkSessionEntryFromParent(
   );
 }
 
+/**
+ * Parent forking must never block session creation, but it also must not fork a
+ * parent whose size was never confirmed (that would enter an unbounded fork
+ * transcript read). The full resolution can read up to ~1MB of transcript tail
+ * — or the whole transcript index when leaf-control is invalid — so it is raced
+ * against a deadline. On timeout we fall back to a fast, stat-only byte estimate
+ * (bounded even for multi-hundred-MB files) so an oversized parent is still
+ * skipped; only when even that probe cannot answer in time do we treat the
+ * parent as unresolved and skip conservatively (#101718).
+ */
 const PARENT_FORK_TOKEN_TIMEOUT_MS = 2_000;
+const PARENT_FORK_SIZE_PROBE_TIMEOUT_MS = 1_000;
+const PARENT_FORK_TOKEN_TIMEOUT = Symbol("parent-fork-token-timeout");
+
+type ParentForkTokenResolution =
+  | { status: "resolved"; tokens: number | undefined }
+  | { status: "unresolved" };
+
+function resolveAfter<T>(value: T, ms: number): Promise<T> {
+  return new Promise<T>((resolve) => setTimeout(() => resolve(value), ms));
+}
 
 async function resolveParentForkTokenCount(params: {
   parentEntry: SessionEntry;
   storePath: string;
-}): Promise<number | undefined> {
+}): Promise<ParentForkTokenResolution> {
   const runtime = await loadSessionForkRuntime();
-  return Promise.race([
+  const resolved = await Promise.race([
     runtime.resolveParentForkTokenCountRuntime(params),
-    new Promise<undefined>((resolve) =>
-      setTimeout(() => resolve(undefined), PARENT_FORK_TOKEN_TIMEOUT_MS),
-    ),
+    resolveAfter(PARENT_FORK_TOKEN_TIMEOUT, PARENT_FORK_TOKEN_TIMEOUT_MS),
   ]);
+  if (resolved !== PARENT_FORK_TOKEN_TIMEOUT) {
+    return { status: "resolved", tokens: resolved };
+  }
+  const estimate = await Promise.race([
+    runtime.estimateParentForkTokensFromSizeRuntime(params),
+    resolveAfter<number | undefined>(undefined, PARENT_FORK_SIZE_PROBE_TIMEOUT_MS),
+  ]);
+  return typeof estimate === "number"
+    ? { status: "resolved", tokens: estimate }
+    : { status: "unresolved" };
 }

--- a/src/auto-reply/reply/session-fork.ts
+++ b/src/auto-reply/reply/session-fork.ts
@@ -291,10 +291,17 @@ export async function forkSessionEntryFromParent(
   );
 }
 
+const PARENT_FORK_TOKEN_TIMEOUT_MS = 2_000;
+
 async function resolveParentForkTokenCount(params: {
   parentEntry: SessionEntry;
   storePath: string;
 }): Promise<number | undefined> {
   const runtime = await loadSessionForkRuntime();
-  return runtime.resolveParentForkTokenCountRuntime(params);
+  return Promise.race([
+    runtime.resolveParentForkTokenCountRuntime(params),
+    new Promise<undefined>((resolve) =>
+      setTimeout(() => resolve(undefined), PARENT_FORK_TOKEN_TIMEOUT_MS),
+    ),
+  ]);
 }

--- a/src/auto-reply/reply/session-fork.ts
+++ b/src/auto-reply/reply/session-fork.ts
@@ -336,7 +336,9 @@ type ParentForkTokenResolution =
   | { status: "unresolved" };
 
 function resolveAfter<T>(value: T, ms: number): Promise<T> {
-  return new Promise<T>((resolve) => setTimeout(() => resolve(value), ms));
+  return new Promise<T>((resolve) => {
+    setTimeout(() => resolve(value), ms);
+  });
 }
 
 async function resolveParentForkTokenCount(params: {

--- a/src/auto-reply/reply/session-parent-fork-prepare.ts
+++ b/src/auto-reply/reply/session-parent-fork-prepare.ts
@@ -30,11 +30,14 @@ export async function prepareReplySessionParentFork(params: {
     storePath: params.storePath,
   });
   if (decision.status === "skip") {
-    // The parent branch is too large to inherit usefully. Start fresh and
-    // mark as handled so the thread does not retry this decision every turn.
+    // The parent branch is too large (or its size could not be resolved in
+    // time) to inherit usefully. Start fresh and mark as handled so the thread
+    // does not retry this decision every turn.
+    const parentTokensLabel =
+      decision.reason === "parent-too-large" ? decision.parentTokens : "unknown";
     params.warn(
-      `skipping parent fork (parent too large): parentKey=${params.parentSessionKey} → sessionKey=${params.sessionKey} ` +
-        `parentTokens=${decision.parentTokens} maxTokens=${decision.maxTokens}`,
+      `skipping parent fork (${decision.reason}): parentKey=${params.parentSessionKey} → sessionKey=${params.sessionKey} ` +
+        `parentTokens=${parentTokensLabel} maxTokens=${decision.maxTokens}`,
     );
     return { ...params.sessionEntry, forkedFromParent: true };
   }


### PR DESCRIPTION
## What Problem This Solves

`resolveParentForkTokenCount` reads the parent session transcript to estimate token count when forking a session, but had no timeout. On large transcripts (hundreds of MB) or slow filesystems (NFS, FUSE, saturated SSD), this blocks session creation indefinitely, accumulating blocked async contexts that exhaust gateway connection slots (#101718).

## Why This Change Was Made (revised after review)

The first revision added a 2-second `Promise.race` timeout that returned `undefined` on timeout. Review correctly flagged this as **unsafe** (P1): `undefined` makes `resolveParentForkDecision` return `{status: "fork"}`, and the fork runtime (`forkSessionFromParentRuntime` → `readForkSourceTranscript` → `readRegularFile`) then reads the **entire** parent transcript with no bound. So a slow/huge parent could still stall session creation *after* the timeout fired, and an oversized parent that should start with isolated context was forked instead — bypassing the documented 100K-token skip.

This revision fixes the root cause: **never fork after an unresolved size check.**

- The 2s deadline still guards the full token resolution (which can read up to ~1MB of transcript tail, or the whole transcript index when leaf-control is invalid).
- **On timeout, fall back to a fast, stat-only byte estimate** (`estimateParentForkTokensFromSizeRuntime`). A single `fs.stat` is O(1) regardless of file size, so a multi-hundred-MB parent still yields an estimate → **skip** (isolated context), never a whole-file read.
- **If even the stat probe cannot answer within 1s**, the parent size is treated as **unresolved** and the fork is **skipped** conservatively (new `parent-size-unresolved` decision), rather than forked.

Net effect: the fork read is only ever entered for a parent whose size was confirmed small, so it is inherently bounded. Oversized or unresolvable parents skip to isolated context — the safe, documented behavior.

## Evidence

### Layer 1 — Real behavior proof (slow filesystem, real modules, no mocks)

`scripts/proof-session-fork-timeout.ts` drives the **real** `resolveParentForkDecision` / `forkSessionEntryFromParent` against **real** on-disk transcripts, injecting `fs` latency to simulate a slow mount (the exact issue scenario). Elapsed times prove the deadline is enforced and the fork read is never entered for an oversized/unresolvable parent:

```
$ npx tsx scripts/proof-session-fork-timeout.ts
PR #101767 real-behavior proof (#101718) — slow-filesystem parent fork

HEAD: 437b4dd1da
worktree: clean

  ✅ Baseline: raw token resolution blocks on a slow transcript read — unguarded runtime took 3014ms (this is what the 2s deadline must bound)
  ✅ Case 1a: oversized parent decision is bounded by the deadline — decided in 2001ms (< 2.9s) instead of blocking on the 3s read
  ✅ Case 1b: oversized parent SKIPS the fork via the stat-only estimate — decision=skip/parent-too-large
  ✅ Case 1c: forkSessionEntryFromParent returns skipped (no whole-file read) — status=skipped in 2006ms
  ✅ Case 2: small parent forks with a preserved conservative estimate — decision=fork parentTokens=519 in 2004ms
  ✅ Case 3a: unresolvable size is still bounded (deadline + stat fallback) — decided in 3020ms even with stat itself hanging
  ✅ Case 3b: unresolvable size SKIPS conservatively instead of forking — decision=skip/parent-size-unresolved

7 passed, 0 failed
```

The **Baseline** case shows the unguarded runtime blocking 3s on a slow read (what the deadline must bound); **Case 1c** proves the storage-boundary entry point returns `skipped` in ~2s for an oversized parent — it never enters the unbounded fork read that review flagged.

### Layer 2 — Focused unit tests

```
$ vitest run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/session-fork.test.ts

 ✓ forkSessionEntryFromParent > forks transcripts in the directory for the store being mutated
 ✓ forkSessionEntryFromParent > skips the fork read entirely when the parent size cannot be resolved (#101718)
 ✓ resolveParentForkDecision > returns fork with token count when the runtime resolves quickly
 ✓ resolveParentForkDecision > returns skip when parent is too large
 ✓ resolveParentForkDecision > falls back to the byte estimate and forks a small parent when the runtime hangs
 ✓ resolveParentForkDecision > falls back to the byte estimate and skips an oversized parent when the runtime hangs
 ✓ resolveParentForkDecision > skips with an unresolved reason when both the runtime and the size probe hang

 Test Files  1 passed (1)
      Tests  7 passed (7)
```

The prior revision's test asserted the buggy behavior (`fork` with no `parentTokens` on timeout); it is replaced with the fallback/skip coverage above.

### Layer 3 — Static checks

```
$ oxfmt --check <changed files>       → All matched files use the correct format.
$ oxlint <changed files>              → clean (0 warnings)
```

Type checks (`tsgo:core`) run in CI on this branch.

### Changes

| File | + | - |
|------|---|---|
| `src/auto-reply/reply/session-fork.ts` | +66 | -3 |
| `src/auto-reply/reply/session-fork.runtime.ts` | +12 | -0 |
| `src/auto-reply/reply/session-parent-fork-prepare.ts` | +7 | -4 |
| `src/auto-reply/reply/session-fork.test.ts` | +140 | -1 |
| `scripts/proof-session-fork-timeout.ts` (proof only) | +229 | -0 |

Closes #101718.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
