### PR TITLE
fix(ui): sync native approvals i18n baseline

### DIFF
--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -3926,6 +3926,13 @@
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/pages/nodes/view-exec-approvals.ts",
+      "text": "Default action"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/pages/nodes/view-exec-approvals.ts",
       "text": "Defaults"
     },
     {
@@ -3982,6 +3989,13 @@
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/pages/nodes/view-exec-approvals.ts",
+      "text": "Host-native policy"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/pages/nodes/view-exec-approvals.ts",
       "text": "Load exec approvals to edit allowlists."
     },
     {
@@ -3990,6 +4004,13 @@
       "name": "text",
       "path": "ui/src/pages/nodes/view-exec-approvals.ts",
       "text": "Mode"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/pages/nodes/view-exec-approvals.ts",
+      "text": "Native"
     },
     {
       "count": 1,
@@ -4018,6 +4039,13 @@
       "name": "text",
       "path": "ui/src/pages/nodes/view-exec-approvals.ts",
       "text": "Pattern"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/pages/nodes/view-exec-approvals.ts",
+      "text": "Read-only here. Edit from the companion app or CLI."
     },
     {
       "count": 1,


### PR DESCRIPTION
## What Problem This Solves

Restores the Control UI i18n gate after #101669 added four intentional raw strings to the native exec-approvals view without synchronizing the tracked raw-copy baseline.

## Why This Change Was Made

`view-exec-approvals.ts` already uses the raw-copy baseline for this legacy, untranslated surface. This change runs the repository-owned baseline sync and records only the four new strings; it does not alter runtime behavior or broaden localization scope.

## User Impact

No runtime behavior change. CI and release-gate artifact builds can validate the Control UI again.

## Evidence

- `node --import tsx scripts/control-ui-i18n.ts check` — passed for all 20 locales with zero fallbacks.
- `git diff --check` — passed.
- Reproduced failure: release-gate build-artifacts job 85659750801 reported exactly these four missing baseline entries.

Agent transcript omitted; no transcript publication was approved for this tiny mechanical sync.
