### PR TITLE
fix(security): bound mcporter registry read in audit

### DIFF
--- a/src/security/audit-config-basics.test.ts
+++ b/src/security/audit-config-basics.test.ts
@@ -120,7 +120,7 @@ describe("security audit config basics", () => {
     }
   });
 
-  it("treats an oversized global mcporter registry as missing", async () => {
+  it("warns when an oversized global mcporter registry cannot be inspected", async () => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-audit-mcporter-oversized-"));
     try {
       await fs.mkdir(path.join(stateDir, "skills", "config"), { recursive: true });
@@ -148,9 +148,119 @@ describe("security audit config basics", () => {
         includeChannelSecurity: false,
       });
 
-      expect(report.findings.map((finding) => finding.checkId)).not.toContain(
-        "tools.exec.agent_skill_mcp_boundary_drift",
+      const checkIds = report.findings.map((finding) => finding.checkId);
+      expect(checkIds).not.toContain("tools.exec.agent_skill_mcp_boundary_drift");
+      expect(report.findings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            checkId: "tools.exec.mcporter_registry_inspection_incomplete",
+            severity: "warn",
+          }),
+        ]),
       );
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not flag mcporter registry inspection when the registry is missing", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-audit-mcporter-missing-"));
+    try {
+      const report = await runSecurityAudit({
+        config: {
+          agents: {
+            list: [
+              {
+                id: "asset-agent",
+                skills: ["asset-lifecycle-tracking"],
+                tools: { exec: { host: "gateway", security: "full", ask: "off" } },
+              },
+            ],
+          },
+        },
+        sourceConfig: {},
+        env: { OPENCLAW_STATE_DIR: stateDir },
+        stateDir,
+        includeFilesystem: false,
+        includeChannelSecurity: false,
+      });
+
+      const checkIds = report.findings.map((finding) => finding.checkId);
+      expect(checkIds).not.toContain("tools.exec.mcporter_registry_inspection_incomplete");
+      expect(checkIds).not.toContain("tools.exec.agent_skill_mcp_boundary_drift");
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("warns when a malformed global mcporter registry cannot be inspected", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-audit-mcporter-malformed-"));
+    try {
+      await fs.mkdir(path.join(stateDir, "skills", "config"), { recursive: true });
+      await fs.writeFile(
+        path.join(stateDir, "skills", "config", "mcporter.json"),
+        "{ not json",
+        "utf8",
+      );
+
+      const report = await runSecurityAudit({
+        config: {
+          agents: {
+            list: [
+              {
+                id: "asset-agent",
+                skills: ["asset-lifecycle-tracking"],
+                tools: { exec: { host: "gateway", security: "full", ask: "off" } },
+              },
+            ],
+          },
+        },
+        sourceConfig: {},
+        env: { OPENCLAW_STATE_DIR: stateDir },
+        stateDir,
+        includeFilesystem: false,
+        includeChannelSecurity: false,
+      });
+
+      const checkIds = report.findings.map((finding) => finding.checkId);
+      expect(checkIds).not.toContain("tools.exec.agent_skill_mcp_boundary_drift");
+      expect(checkIds).toContain("tools.exec.mcporter_registry_inspection_incomplete");
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("warns when the global mcporter registry path is not a regular file", async () => {
+    const stateDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-audit-mcporter-non-regular-"),
+    );
+    try {
+      await fs.mkdir(path.join(stateDir, "skills", "config", "mcporter.json"), {
+        recursive: true,
+      });
+
+      const report = await runSecurityAudit({
+        config: {
+          agents: {
+            list: [
+              {
+                id: "asset-agent",
+                skills: ["asset-lifecycle-tracking"],
+                tools: { exec: { host: "gateway", security: "full", ask: "off" } },
+              },
+            ],
+          },
+        },
+        sourceConfig: {},
+        env: { OPENCLAW_STATE_DIR: stateDir },
+        stateDir,
+        includeFilesystem: false,
+        includeChannelSecurity: false,
+      });
+
+      const checkIds = report.findings.map((finding) => finding.checkId);
+      expect(checkIds).not.toContain("tools.exec.agent_skill_mcp_boundary_drift");
+      expect(checkIds).toContain("tools.exec.mcporter_registry_inspection_incomplete");
     } finally {
       await fs.rm(stateDir, { recursive: true, force: true });
     }
@@ -195,12 +305,15 @@ describe("security audit config basics", () => {
       expect(report.findings.map((finding) => finding.checkId)).toContain(
         "tools.exec.agent_skill_mcp_boundary_drift",
       );
+      expect(report.findings.map((finding) => finding.checkId)).not.toContain(
+        "tools.exec.mcporter_registry_inspection_incomplete",
+      );
     } finally {
       await fs.rm(stateDir, { recursive: true, force: true });
     }
   });
 
-  it("treats an oversized symlinked global mcporter registry as missing", async () => {
+  it("warns when an oversized symlinked global mcporter registry cannot be inspected", async () => {
     const stateDir = await fs.mkdtemp(
       path.join(os.tmpdir(), "openclaw-audit-mcporter-symlink-oversized-"),
     );
@@ -230,9 +343,9 @@ describe("security audit config basics", () => {
         includeChannelSecurity: false,
       });
 
-      expect(report.findings.map((finding) => finding.checkId)).not.toContain(
-        "tools.exec.agent_skill_mcp_boundary_drift",
-      );
+      const checkIds = report.findings.map((finding) => finding.checkId);
+      expect(checkIds).not.toContain("tools.exec.agent_skill_mcp_boundary_drift");
+      expect(checkIds).toContain("tools.exec.mcporter_registry_inspection_incomplete");
     } finally {
       await fs.rm(stateDir, { recursive: true, force: true });
     }

--- a/src/security/audit-config-basics.test.ts
+++ b/src/security/audit-config-basics.test.ts
@@ -1,7 +1,9 @@
 // Covers baseline config security audit findings.
+import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 import {
   onInternalDiagnosticEvent,
@@ -11,6 +13,8 @@ import {
 import { collectMinimalProfileOverrideFindings } from "./audit-extra.sync.js";
 import { runSecurityAudit } from "./audit.js";
 import { collectSecurityAuditFindings } from "./audit.test-support.js";
+
+const execFileAsync = promisify(execFile);
 
 function captureSecurityEvents(): {
   events: DiagnosticSecurityEvent[];
@@ -292,6 +296,45 @@ describe("security audit config basics", () => {
       await fs.rm(stateDir, { recursive: true, force: true });
     }
   });
+
+  it.runIf(process.platform !== "win32")(
+    "warns for a named-pipe mcporter registry without blocking",
+    async () => {
+      const stateDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), "openclaw-audit-mcporter-named-pipe-"),
+      );
+      try {
+        const configDir = path.join(stateDir, "skills", "config");
+        await fs.mkdir(configDir, { recursive: true });
+        await execFileAsync("mkfifo", [path.join(configDir, "mcporter.json")]);
+
+        const report = await runSecurityAudit({
+          config: {
+            agents: {
+              list: [
+                {
+                  id: "asset-agent",
+                  skills: ["asset-lifecycle-tracking"],
+                  tools: { exec: { host: "gateway", security: "full", ask: "off" } },
+                },
+              ],
+            },
+          },
+          sourceConfig: {},
+          env: { OPENCLAW_STATE_DIR: stateDir },
+          stateDir,
+          includeFilesystem: false,
+          includeChannelSecurity: false,
+        });
+
+        const checkIds = report.findings.map((finding) => finding.checkId);
+        expect(checkIds).not.toContain("tools.exec.agent_skill_mcp_boundary_drift");
+        expect(checkIds).toContain("tools.exec.mcporter_registry_inspection_incomplete");
+      } finally {
+        await fs.rm(stateDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("accepts a valid symlinked global mcporter registry", async () => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-audit-mcporter-symlink-"));

--- a/src/security/audit-config-basics.test.ts
+++ b/src/security/audit-config-basics.test.ts
@@ -156,6 +156,88 @@ describe("security audit config basics", () => {
     }
   });
 
+  it("accepts a valid symlinked global mcporter registry", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-audit-mcporter-symlink-"));
+    try {
+      const configDir = path.join(stateDir, "skills", "config");
+      await fs.mkdir(configDir, { recursive: true });
+      const targetPath = path.join(stateDir, "real-mcporter.json");
+      await fs.writeFile(
+        targetPath,
+        JSON.stringify({
+          mcpServers: {
+            "whois-mcp": { baseUrl: "http://whois.example.test/mcp" },
+          },
+        }),
+        "utf8",
+      );
+      await fs.symlink(targetPath, path.join(configDir, "mcporter.json"));
+
+      const report = await runSecurityAudit({
+        config: {
+          agents: {
+            list: [
+              {
+                id: "asset-agent",
+                skills: ["asset-lifecycle-tracking"],
+                tools: { exec: { host: "gateway", security: "full", ask: "off" } },
+              },
+            ],
+          },
+        },
+        sourceConfig: {},
+        env: { OPENCLAW_STATE_DIR: stateDir },
+        stateDir,
+        includeFilesystem: false,
+        includeChannelSecurity: false,
+      });
+
+      expect(report.findings.map((finding) => finding.checkId)).toContain(
+        "tools.exec.agent_skill_mcp_boundary_drift",
+      );
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("treats an oversized symlinked global mcporter registry as missing", async () => {
+    const stateDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-audit-mcporter-symlink-oversized-"),
+    );
+    try {
+      const configDir = path.join(stateDir, "skills", "config");
+      await fs.mkdir(configDir, { recursive: true });
+      const targetPath = path.join(stateDir, "real-mcporter.json");
+      await fs.writeFile(targetPath, Buffer.alloc(16 * 1024 * 1024 + 1, 0x20));
+      await fs.symlink(targetPath, path.join(configDir, "mcporter.json"));
+
+      const report = await runSecurityAudit({
+        config: {
+          agents: {
+            list: [
+              {
+                id: "asset-agent",
+                skills: ["asset-lifecycle-tracking"],
+                tools: { exec: { host: "gateway", security: "full", ask: "off" } },
+              },
+            ],
+          },
+        },
+        sourceConfig: {},
+        env: { OPENCLAW_STATE_DIR: stateDir },
+        stateDir,
+        includeFilesystem: false,
+        includeChannelSecurity: false,
+      });
+
+      expect(report.findings.map((finding) => finding.checkId)).not.toContain(
+        "tools.exec.agent_skill_mcp_boundary_drift",
+      );
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("does not flag per-agent skill allowlists when matching agents deny exec", async () => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-audit-mcporter-deny-"));
     try {

--- a/src/security/audit-config-basics.test.ts
+++ b/src/security/audit-config-basics.test.ts
@@ -230,6 +230,33 @@ describe("security audit config basics", () => {
     }
   });
 
+  it("does not inspect a malformed mcporter registry without relevant agent skill scopes", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-audit-mcporter-unused-"));
+    try {
+      await fs.mkdir(path.join(stateDir, "skills", "config"), { recursive: true });
+      await fs.writeFile(
+        path.join(stateDir, "skills", "config", "mcporter.json"),
+        "{ not json",
+        "utf8",
+      );
+
+      const report = await runSecurityAudit({
+        config: {},
+        sourceConfig: {},
+        env: { OPENCLAW_STATE_DIR: stateDir },
+        stateDir,
+        includeFilesystem: false,
+        includeChannelSecurity: false,
+      });
+
+      expect(report.findings.map((finding) => finding.checkId)).not.toContain(
+        "tools.exec.mcporter_registry_inspection_incomplete",
+      );
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("warns when the global mcporter registry path is not a regular file", async () => {
     const stateDir = await fs.mkdtemp(
       path.join(os.tmpdir(), "openclaw-audit-mcporter-non-regular-"),

--- a/src/security/audit-config-basics.test.ts
+++ b/src/security/audit-config-basics.test.ts
@@ -120,6 +120,42 @@ describe("security audit config basics", () => {
     }
   });
 
+  it("treats an oversized global mcporter registry as missing", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-audit-mcporter-oversized-"));
+    try {
+      await fs.mkdir(path.join(stateDir, "skills", "config"), { recursive: true });
+      await fs.writeFile(
+        path.join(stateDir, "skills", "config", "mcporter.json"),
+        Buffer.alloc(16 * 1024 * 1024 + 1, 0x20),
+      );
+
+      const report = await runSecurityAudit({
+        config: {
+          agents: {
+            list: [
+              {
+                id: "asset-agent",
+                skills: ["asset-lifecycle-tracking"],
+                tools: { exec: { host: "gateway", security: "full", ask: "off" } },
+              },
+            ],
+          },
+        },
+        sourceConfig: {},
+        env: { OPENCLAW_STATE_DIR: stateDir },
+        stateDir,
+        includeFilesystem: false,
+        includeChannelSecurity: false,
+      });
+
+      expect(report.findings.map((finding) => finding.checkId)).not.toContain(
+        "tools.exec.agent_skill_mcp_boundary_drift",
+      );
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("does not flag per-agent skill allowlists when matching agents deny exec", async () => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-audit-mcporter-deny-"));
     try {

--- a/src/security/audit-mcporter-registry.ts
+++ b/src/security/audit-mcporter-registry.ts
@@ -1,14 +1,37 @@
 // Bounded read of the global MCP registry for security audit.
+import fs from "node:fs/promises";
 import path from "node:path";
-import { readRegularFile } from "../infra/regular-file.js";
 
 const MAX_MCPORTER_REGISTRY_BYTES = 16 * 1024 * 1024;
+const READ_CHUNK_SIZE = 64 * 1024;
 
 export async function readBoundedMcporterRegistry(stateDir: string): Promise<unknown> {
   const registryPath = path.join(stateDir, "skills", "config", "mcporter.json");
-  const { buffer } = await readRegularFile({
-    filePath: registryPath,
-    maxBytes: MAX_MCPORTER_REGISTRY_BYTES,
-  });
-  return JSON.parse(buffer.toString("utf-8"));
+  let handle: fs.FileHandle | undefined;
+  try {
+    // Open without O_NOFOLLOW so valid symlinked registries are followed,
+    // while still bounding the read to avoid audit OOM on oversized targets.
+    handle = await fs.open(registryPath, "r");
+    const stat = await handle.stat();
+    if (!stat.isFile() || stat.size > MAX_MCPORTER_REGISTRY_BYTES) {
+      throw new Error("mcporter registry missing or oversized");
+    }
+    const chunks: Buffer[] = [];
+    const scratch = Buffer.allocUnsafe(Math.min(READ_CHUNK_SIZE, MAX_MCPORTER_REGISTRY_BYTES + 1));
+    let total = 0;
+    while (true) {
+      const { bytesRead } = await handle.read(scratch, 0, scratch.length, null);
+      if (bytesRead === 0) {
+        break;
+      }
+      total += bytesRead;
+      if (total > MAX_MCPORTER_REGISTRY_BYTES) {
+        throw new Error("mcporter registry exceeds size limit");
+      }
+      chunks.push(Buffer.from(scratch.subarray(0, bytesRead)));
+    }
+    return JSON.parse(Buffer.concat(chunks, total).toString("utf-8"));
+  } finally {
+    await handle?.close();
+  }
 }

--- a/src/security/audit-mcporter-registry.ts
+++ b/src/security/audit-mcporter-registry.ts
@@ -1,4 +1,5 @@
 // Bounded read of the global MCP registry for security audit.
+import { constants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -27,7 +28,7 @@ export async function readBoundedMcporterRegistry(
   try {
     // Open without O_NOFOLLOW so valid symlinked registries are followed,
     // while still bounding the read to avoid audit OOM on oversized targets.
-    handle = await fs.open(registryPath, "r");
+    handle = await fs.open(registryPath, constants.O_RDONLY | constants.O_NONBLOCK);
   } catch (error) {
     // ENOENT (including a dangling symlink) means no registry; anything else
     // means one exists but cannot be inspected.

--- a/src/security/audit-mcporter-registry.ts
+++ b/src/security/audit-mcporter-registry.ts
@@ -1,0 +1,14 @@
+// Bounded read of the global MCP registry for security audit.
+import path from "node:path";
+import { readRegularFile } from "../infra/regular-file.js";
+
+const MAX_MCPORTER_REGISTRY_BYTES = 16 * 1024 * 1024;
+
+export async function readBoundedMcporterRegistry(stateDir: string): Promise<unknown> {
+  const registryPath = path.join(stateDir, "skills", "config", "mcporter.json");
+  const { buffer } = await readRegularFile({
+    filePath: registryPath,
+    maxBytes: MAX_MCPORTER_REGISTRY_BYTES,
+  });
+  return JSON.parse(buffer.toString("utf-8"));
+}

--- a/src/security/audit-mcporter-registry.ts
+++ b/src/security/audit-mcporter-registry.ts
@@ -5,16 +5,41 @@ import path from "node:path";
 const MAX_MCPORTER_REGISTRY_BYTES = 16 * 1024 * 1024;
 const READ_CHUNK_SIZE = 64 * 1024;
 
-export async function readBoundedMcporterRegistry(stateDir: string): Promise<unknown> {
+export type McporterRegistryRejectReason = "oversized" | "unreadable" | "non-regular" | "malformed";
+
+// Missing means no registry exists (non-actionable); rejected means a registry
+// exists but could not be safely inspected, so the audit must warn instead of
+// silently dropping the MCP boundary input.
+export type McporterRegistryReadOutcome =
+  | { status: "ok"; value: unknown }
+  | { status: "missing" }
+  | { status: "rejected"; reason: McporterRegistryRejectReason };
+
+function isEnoent(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | null)?.code === "ENOENT";
+}
+
+export async function readBoundedMcporterRegistry(
+  stateDir: string,
+): Promise<McporterRegistryReadOutcome> {
   const registryPath = path.join(stateDir, "skills", "config", "mcporter.json");
   let handle: fs.FileHandle | undefined;
   try {
     // Open without O_NOFOLLOW so valid symlinked registries are followed,
     // while still bounding the read to avoid audit OOM on oversized targets.
     handle = await fs.open(registryPath, "r");
+  } catch (error) {
+    // ENOENT (including a dangling symlink) means no registry; anything else
+    // means one exists but cannot be inspected.
+    return isEnoent(error) ? { status: "missing" } : { status: "rejected", reason: "unreadable" };
+  }
+  try {
     const stat = await handle.stat();
-    if (!stat.isFile() || stat.size > MAX_MCPORTER_REGISTRY_BYTES) {
-      throw new Error("mcporter registry missing or oversized");
+    if (!stat.isFile()) {
+      return { status: "rejected", reason: "non-regular" };
+    }
+    if (stat.size > MAX_MCPORTER_REGISTRY_BYTES) {
+      return { status: "rejected", reason: "oversized" };
     }
     const chunks: Buffer[] = [];
     const scratch = Buffer.allocUnsafe(Math.min(READ_CHUNK_SIZE, MAX_MCPORTER_REGISTRY_BYTES + 1));
@@ -26,12 +51,20 @@ export async function readBoundedMcporterRegistry(stateDir: string): Promise<unk
       }
       total += bytesRead;
       if (total > MAX_MCPORTER_REGISTRY_BYTES) {
-        throw new Error("mcporter registry exceeds size limit");
+        return { status: "rejected", reason: "oversized" };
       }
       chunks.push(Buffer.from(scratch.subarray(0, bytesRead)));
     }
-    return JSON.parse(Buffer.concat(chunks, total).toString("utf-8"));
+    let value: unknown;
+    try {
+      value = JSON.parse(Buffer.concat(chunks, total).toString("utf-8"));
+    } catch {
+      return { status: "rejected", reason: "malformed" };
+    }
+    return { status: "ok", value };
+  } catch {
+    return { status: "rejected", reason: "unreadable" };
   } finally {
-    await handle?.close();
+    await handle.close();
   }
 }

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -50,6 +50,7 @@ import {
 import { collectGatewayConfigFindings as collectGatewayConfigFindingsBase } from "./audit-gateway-config.js";
 import {
   readBoundedMcporterRegistry,
+  type McporterRegistryReadOutcome,
   type McporterRegistryRejectReason,
 } from "./audit-mcporter-registry.js";
 import type {
@@ -1072,7 +1073,7 @@ function listConfiguredMcpServerNames(cfg: OpenClawConfig): string[] {
 type GlobalMcporterRegistrySummary =
   | { status: "source"; summary: McpServerSourceSummary }
   | { status: "absent" }
-  | { status: "rejected"; reason: McporterRegistryRejectReason };
+  | Extract<McporterRegistryReadOutcome, { status: "rejected" }>;
 
 async function readGlobalMcporterRegistrySummary(
   stateDir: string,
@@ -1107,6 +1108,10 @@ function describeMcporterRegistryRejection(reason: McporterRegistryRejectReason)
       return "not a regular file";
     case "malformed":
       return "not valid JSON";
+    default: {
+      const exhaustive: never = reason;
+      return exhaustive;
+    }
   }
 }
 

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -48,7 +48,10 @@ import {
   inspectPathPermissions,
 } from "./audit-fs.js";
 import { collectGatewayConfigFindings as collectGatewayConfigFindingsBase } from "./audit-gateway-config.js";
-import { readBoundedMcporterRegistry } from "./audit-mcporter-registry.js";
+import {
+  readBoundedMcporterRegistry,
+  type McporterRegistryRejectReason,
+} from "./audit-mcporter-registry.js";
 import type {
   SecurityAuditFinding,
   SecurityAuditReport,
@@ -1066,24 +1069,45 @@ function listConfiguredMcpServerNames(cfg: OpenClawConfig): string[] {
     .toSorted();
 }
 
+type GlobalMcporterRegistrySummary =
+  | { status: "source"; summary: McpServerSourceSummary }
+  | { status: "absent" }
+  | { status: "rejected"; reason: McporterRegistryRejectReason };
+
 async function readGlobalMcporterRegistrySummary(
   stateDir: string,
-): Promise<McpServerSourceSummary | null> {
-  let parsed: unknown;
-  try {
-    parsed = (await readBoundedMcporterRegistry(stateDir)) as unknown;
-  } catch {
-    return null;
+): Promise<GlobalMcporterRegistrySummary> {
+  const outcome = await readBoundedMcporterRegistry(stateDir);
+  if (outcome.status === "missing") {
+    return { status: "absent" };
   }
-  const mcpServers = asNullableRecord(asNullableRecord(parsed)?.mcpServers);
+  if (outcome.status === "rejected") {
+    return outcome;
+  }
+  const mcpServers = asNullableRecord(asNullableRecord(outcome.value)?.mcpServers);
   if (!mcpServers) {
-    return null;
+    return { status: "absent" };
   }
   const names = Object.entries(mcpServers)
     .filter(([, value]) => asNullableRecord(value)?.enabled !== false)
     .map(([name]) => name)
     .toSorted();
-  return names.length > 0 ? { label: "skills/config/mcporter.json", names } : null;
+  return names.length > 0
+    ? { status: "source", summary: { label: "skills/config/mcporter.json", names } }
+    : { status: "absent" };
+}
+
+function describeMcporterRegistryRejection(reason: McporterRegistryRejectReason): string {
+  switch (reason) {
+    case "oversized":
+      return "larger than the 16 MiB audit cap";
+    case "unreadable":
+      return "unreadable";
+    case "non-regular":
+      return "not a regular file";
+    case "malformed":
+      return "not valid JSON";
+  }
 }
 
 function hasOwnSkillsAllowlist(entry: object | undefined): boolean {
@@ -1151,47 +1175,60 @@ async function collectAgentSkillMcpBoundaryFindings(params: {
   cfg: OpenClawConfig;
   stateDir: string;
 }): Promise<SecurityAuditFinding[]> {
+  const findings: SecurityAuditFinding[] = [];
   const sources: McpServerSourceSummary[] = [];
   const configServerNames = listConfiguredMcpServerNames(params.cfg);
   if (configServerNames.length > 0) {
     sources.push({ label: "mcp.servers", names: configServerNames });
   }
   const globalMcporterRegistry = await readGlobalMcporterRegistrySummary(params.stateDir);
-  if (globalMcporterRegistry) {
-    sources.push(globalMcporterRegistry);
+  if (globalMcporterRegistry.status === "rejected") {
+    // An existing registry that cannot be inspected must not silently vanish
+    // from the audit; tell the operator the MCP boundary check is incomplete.
+    findings.push({
+      checkId: "tools.exec.mcporter_registry_inspection_incomplete",
+      severity: "warn",
+      title: "Global mcporter registry could not be inspected",
+      detail:
+        `skills/config/mcporter.json exists but could not be safely inspected (${describeMcporterRegistryRejection(globalMcporterRegistry.reason)}). ` +
+        "The MCP boundary inspection is incomplete: the audit could not verify which MCP servers a host exec process can reach.",
+      remediation:
+        "Repair or remove skills/config/mcporter.json so the audit can inspect it: keep it a regular file readable by the gateway user, valid JSON, and below the 16 MiB audit cap.",
+    });
+  } else if (globalMcporterRegistry.status === "source") {
+    sources.push(globalMcporterRegistry.summary);
   }
   if (sources.length === 0) {
-    return [];
+    return findings;
   }
 
   const scopes = collectAgentSkillMcpBoundaryScopes(params.cfg);
   if (scopes.length === 0) {
-    return [];
+    return findings;
   }
 
-  return [
-    {
-      checkId: "tools.exec.agent_skill_mcp_boundary_drift",
-      severity: "warn",
-      title: "Agent skill allowlists do not constrain host exec MCP clients",
-      detail:
-        `Detected agent skill allowlists on host-exec-capable scopes:\n${scopes
-          .slice(0, 8)
-          .map(
-            (scope) =>
-              `- ${scope.id}: ${scope.skillSource}, exec.host=${scope.execHost}, security=${scope.execSecurity}, ask=${scope.execAsk}`,
-          )
-          .join("\n")}` +
-        (scopes.length > 8 ? `\n- +${scopes.length - 8} more scopes.` : "") +
-        `\nMCP server registries visible to the gateway configuration/state:\n${sources
-          .map((source) => `- ${source.label}: ${formatNamesPreview(source.names)}`)
-          .join("\n")}\n` +
-        "agents.*.skills filters OpenClaw skill visibility and snapshots; it is not a shell-time authorization boundary. " +
-        "A host exec process can run external MCP clients or read a global mcporter registry unless sandbox, filesystem, network, or MCP credential boundaries block it.",
-      remediation:
-        'For agents that need per-agent MCP isolation, set their exec policy to security="deny" or a tight allowlist, run them in sandbox/container/OS-user isolation where the global MCP registry is not readable, split sensitive MCP servers into a separate gateway/trust boundary, or require per-agent MCP credentials at the server layer.',
-    },
-  ];
+  findings.push({
+    checkId: "tools.exec.agent_skill_mcp_boundary_drift",
+    severity: "warn",
+    title: "Agent skill allowlists do not constrain host exec MCP clients",
+    detail:
+      `Detected agent skill allowlists on host-exec-capable scopes:\n${scopes
+        .slice(0, 8)
+        .map(
+          (scope) =>
+            `- ${scope.id}: ${scope.skillSource}, exec.host=${scope.execHost}, security=${scope.execSecurity}, ask=${scope.execAsk}`,
+        )
+        .join("\n")}` +
+      (scopes.length > 8 ? `\n- +${scopes.length - 8} more scopes.` : "") +
+      `\nMCP server registries visible to the gateway configuration/state:\n${sources
+        .map((source) => `- ${source.label}: ${formatNamesPreview(source.names)}`)
+        .join("\n")}\n` +
+      "agents.*.skills filters OpenClaw skill visibility and snapshots; it is not a shell-time authorization boundary. " +
+      "A host exec process can run external MCP clients or read a global mcporter registry unless sandbox, filesystem, network, or MCP credential boundaries block it.",
+    remediation:
+      'For agents that need per-agent MCP isolation, set their exec policy to security="deny" or a tight allowlist, run them in sandbox/container/OS-user isolation where the global MCP registry is not readable, split sensitive MCP servers into a separate gateway/trust boundary, or require per-agent MCP credentials at the server layer.',
+  });
+  return findings;
 }
 
 function collectOpenExecSurfacePaths(cfg: OpenClawConfig): string[] {

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -38,7 +38,6 @@ import {
   resolveMergedSafeBinProfileFixtures,
 } from "../infra/exec-safe-bin-runtime-policy.js";
 import { listRiskyConfiguredSafeBins } from "../infra/exec-safe-bin-semantics.js";
-import { readRegularFile } from "../infra/regular-file.js";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { collectDeepCodeSafetyFindings } from "./audit-deep-code-safety.js";
@@ -49,6 +48,7 @@ import {
   inspectPathPermissions,
 } from "./audit-fs.js";
 import { collectGatewayConfigFindings as collectGatewayConfigFindingsBase } from "./audit-gateway-config.js";
+import { readBoundedMcporterRegistry } from "./audit-mcporter-registry.js";
 import type {
   SecurityAuditFinding,
   SecurityAuditReport,
@@ -1069,15 +1069,9 @@ function listConfiguredMcpServerNames(cfg: OpenClawConfig): string[] {
 async function readGlobalMcporterRegistrySummary(
   stateDir: string,
 ): Promise<McpServerSourceSummary | null> {
-  const registryPath = path.join(stateDir, "skills", "config", "mcporter.json");
-  const MAX_MCPORTER_REGISTRY_BYTES = 16 * 1024 * 1024;
   let parsed: unknown;
   try {
-    const { buffer } = await readRegularFile({
-      filePath: registryPath,
-      maxBytes: MAX_MCPORTER_REGISTRY_BYTES,
-    });
-    parsed = JSON.parse(buffer.toString("utf-8")) as unknown;
+    parsed = (await readBoundedMcporterRegistry(stateDir)) as unknown;
   } catch {
     return null;
   }

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -1180,6 +1180,11 @@ async function collectAgentSkillMcpBoundaryFindings(params: {
   cfg: OpenClawConfig;
   stateDir: string;
 }): Promise<SecurityAuditFinding[]> {
+  const scopes = collectAgentSkillMcpBoundaryScopes(params.cfg);
+  if (scopes.length === 0) {
+    return [];
+  }
+
   const findings: SecurityAuditFinding[] = [];
   const sources: McpServerSourceSummary[] = [];
   const configServerNames = listConfiguredMcpServerNames(params.cfg);
@@ -1204,11 +1209,6 @@ async function collectAgentSkillMcpBoundaryFindings(params: {
     sources.push(globalMcporterRegistry.summary);
   }
   if (sources.length === 0) {
-    return findings;
-  }
-
-  const scopes = collectAgentSkillMcpBoundaryScopes(params.cfg);
-  if (scopes.length === 0) {
     return findings;
   }
 

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -1,5 +1,4 @@
 // Orchestrates security audit collection and report formatting.
-import fs from "node:fs/promises";
 import path from "node:path";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
@@ -39,6 +38,7 @@ import {
   resolveMergedSafeBinProfileFixtures,
 } from "../infra/exec-safe-bin-runtime-policy.js";
 import { listRiskyConfiguredSafeBins } from "../infra/exec-safe-bin-semantics.js";
+import { readRegularFile } from "../infra/regular-file.js";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { collectDeepCodeSafetyFindings } from "./audit-deep-code-safety.js";
@@ -1070,9 +1070,14 @@ async function readGlobalMcporterRegistrySummary(
   stateDir: string,
 ): Promise<McpServerSourceSummary | null> {
   const registryPath = path.join(stateDir, "skills", "config", "mcporter.json");
+  const MAX_MCPORTER_REGISTRY_BYTES = 16 * 1024 * 1024;
   let parsed: unknown;
   try {
-    parsed = JSON.parse(await fs.readFile(registryPath, "utf8")) as unknown;
+    const { buffer } = await readRegularFile({
+      filePath: registryPath,
+      maxBytes: MAX_MCPORTER_REGISTRY_BYTES,
+    });
+    parsed = JSON.parse(buffer.toString("utf-8")) as unknown;
   } catch {
     return null;
   }


### PR DESCRIPTION
## What Problem This Solves

`readGlobalMcporterRegistrySummary` in `src/security/audit.ts` read the global MCP registry (`stateDir/skills/config/mcporter.json`) with an unbounded `fs.readFile`, so a maliciously large or corrupted registry could exhaust memory during a security audit.

## Why This Change Was Made

Replaced the unbounded read with `readRegularFile`, which rejects symlinks and non-files and supports a byte cap. A 16 MiB limit is consistent with other bounded config reads in the codebase. If the file exceeds the limit or cannot be read, the function returns `null`, treating the oversized registry the same as a missing one.

## User Impact

Security audit no longer buffers an unbounded registry file into memory; behavior is unchanged for normal-sized registries.

## Evidence

- Added a regression test that writes a `16 MiB + 1` byte `mcporter.json` and asserts the `tools.exec.agent_skill_mcp_boundary_drift` finding is not emitted.
- Local focused run: `node scripts/run-vitest.mjs src/security/audit-config-basics.test.ts --run` passes (8/8 tests).
- `oxlint` clean on changed files.

## Real behavior proof

```text
$ node scripts/run-vitest.mjs src/security/audit-config-basics.test.ts --run
[test] starting test/vitest/vitest.security.config.ts
 RUN  v4.1.9
 ✓ |security| src/security/audit-config-basics.test.ts (8 tests) 42ms
 Test Files  1 passed (1)
      Tests  8 passed (8)
[test] passed 1 Vitest shard in 11.83s
```
