### PR TITLE
fix(security): bound plugin manifest reads in audit deep scan

### DIFF
--- a/src/security/audit-extra.async.test.ts
+++ b/src/security/audit-extra.async.test.ts
@@ -246,6 +246,25 @@ description: test skill
     ).toBe(false);
   });
 
+  it("surfaces manifest_parse_error finding when plugin package.json exceeds the size limit", async () => {
+    const tmpDir = await makeTmpDir("audit-manifest-oversized");
+    const pluginDir = path.join(tmpDir, "extensions", "oversized-plugin");
+    await fs.mkdir(pluginDir, { recursive: true });
+    // Oversized manifest — simulates a plugin trying to exhaust the audit reader
+    // by declaring a huge package.json, hiding its declared extension entrypoints.
+    await fs.writeFile(path.join(pluginDir, "package.json"), "x".repeat(1024 * 1024 + 1), "utf-8");
+
+    const findings = await collectPluginsCodeSafetyFindings({ stateDir: tmpDir });
+    const finding = requireFinding(
+      findings,
+      (f) => f.checkId === "plugins.code_safety.manifest_parse_error",
+      "oversized manifest parse error",
+    );
+    expect(finding.severity).toBe("warn");
+    expect(finding.detail).toContain("oversized-plugin");
+    expect(finding.detail).toContain("too large");
+  });
+
   it("reports scan_failed when plugin code scanner throws during deep audit", async () => {
     const scanSpy = vi
       .spyOn(skillScanner, "scanDirectoryWithSummary")

--- a/src/security/audit-extra.async.ts
+++ b/src/security/audit-extra.async.ts
@@ -3,7 +3,6 @@
  *
  * These functions perform I/O (filesystem, config reads) to detect security issues.
  */
-import fs from "node:fs/promises";
 import path from "node:path";
 import { clearTimeout as clearNodeTimeout, setTimeout as setNodeTimeout } from "node:timers";
 import {
@@ -21,6 +20,7 @@ import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import type { OpenClawConfig, ConfigFileSnapshot } from "../config/config.js";
 import { collectIncludePathsRecursive } from "../config/includes-scan.js";
 import { resolveOAuthDir } from "../config/paths.js";
+import { readRegularFile, statRegularFile } from "../infra/fs-safe.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { createLazyRuntimeModule, createLazyRuntimeNamedExport } from "../shared/lazy-runtime.js";
 import type { SkillScanFinding } from "../skills/security/scanner.js";
@@ -96,9 +96,25 @@ function expandTilde(p: string, env: NodeJS.ProcessEnv): string | null {
   return null;
 }
 
+const MAX_PLUGIN_MANIFEST_BYTES = 1024 * 1024;
+
 async function readPluginManifestExtensions(pluginPath: string): Promise<string[]> {
   const manifestPath = path.join(pluginPath, "package.json");
-  const raw = await fs.readFile(manifestPath, "utf-8").catch(() => "");
+  const statResult = await statRegularFile(manifestPath);
+  if (statResult.missing) {
+    return [];
+  }
+  if (statResult.stat.size > MAX_PLUGIN_MANIFEST_BYTES) {
+    throw new Error(
+      `Plugin manifest at ${manifestPath} is too large (${statResult.stat.size} bytes, max ${MAX_PLUGIN_MANIFEST_BYTES})`,
+    );
+  }
+
+  const { buffer } = await readRegularFile({
+    filePath: manifestPath,
+    maxBytes: MAX_PLUGIN_MANIFEST_BYTES,
+  });
+  const raw = buffer.toString("utf-8");
   if (!raw.trim()) {
     return [];
   }


### PR DESCRIPTION
## What Problem This Solves

`readPluginManifestExtensions` in `src/security/audit-extra.async.ts` read each installed plugin's `package.json` with an unbounded `fs.readFile`. A malicious or broken plugin could place an arbitrarily large manifest in the plugin directory and exhaust memory or slow the security audit.

## Why This Change Was Made

The audit deep scan now enforces a hard 1 MiB size limit on plugin `package.json` reads, using the existing `statRegularFile` / `readRegularFile` helpers from `src/infra/regular-file.js`, which also reject symlinks and non-file targets. Oversized manifests throw a clear error that surfaces as a `plugins.code_safety.manifest_parse_error` finding, matching the existing malformed-JSON behavior so the issue is visible instead of silently skipped.

## User Impact

Users will receive a clear security audit warning if any installed plugin manifest exceeds 1 MiB, and the audit will no longer attempt to load unbounded file content during deep scan.

## Evidence

- Added a regression test in `src/security/audit-extra.async.test.ts` that creates a `package.json` of `1 MiB + 1` bytes and asserts a `manifest_parse_error` finding is emitted for the oversized plugin.
- Local focused run: `node scripts/run-vitest.mjs src/security/audit-extra.async.test.ts --run` passes (7/7 tests).
- `oxlint` clean on changed files.

## Real behavior proof

```text
$ node scripts/run-vitest.mjs src/security/audit-extra.async.test.ts --run
[test] starting test/vitest/vitest.unit-fast.config.ts
 RUN  v4.1.9
 ✓ |unit-fast| src/security/audit-extra.async.test.ts (7 tests) 126ms
 Test Files  1 passed (1)
      Tests  7 passed (7)
[test] passed 1 Vitest shard in 71.62s
```
