### PR TITLE
fix(heartbeat): bound HEARTBEAT.md file read size

### DIFF
--- a/src/infra/heartbeat-runner.oversized-heartbeat-file.test.ts
+++ b/src/infra/heartbeat-runner.oversized-heartbeat-file.test.ts
@@ -10,6 +10,51 @@ import { seedMainSessionStore, withTempHeartbeatSandbox } from "./heartbeat-runn
 installHeartbeatRunnerTestRuntime({ includeSlack: true });
 
 describe("runHeartbeatOnce oversized HEARTBEAT.md", () => {
+  it("follows a symlinked HEARTBEAT.md to a regular file", async () => {
+    if (process.platform === "win32") {
+      // Symlink support in unit tests is not guaranteed on Windows CI runners.
+      return;
+    }
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "slack", to: "channel:C123" },
+          },
+        },
+        channels: { slack: { heartbeat: { showOk: false } } },
+        session: { store: storePath },
+      };
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "slack",
+        lastProvider: "slack",
+        lastTo: "channel:C123",
+      });
+      const heartbeatPath = path.join(tmpDir, "HEARTBEAT.md");
+      const targetPath = path.join(tmpDir, "real-HEARTBEAT.md");
+      await fs.writeFile(targetPath, "- Check status\n", "utf-8");
+      await fs.rm(heartbeatPath, { force: true });
+      await fs.symlink(targetPath, heartbeatPath);
+
+      replySpy.mockResolvedValue({ text: "ok" });
+      const sendSlack = vi.fn().mockResolvedValue({ messageId: "m1", channelId: "C123" });
+
+      const res = await runHeartbeatOnce({
+        cfg,
+        deps: {
+          getReplyFromConfig: replySpy,
+          slack: sendSlack,
+          getQueueSize: () => 0,
+          nowMs: () => 0,
+        },
+      });
+
+      expect(res.status).toBe("ran");
+      expect(sendSlack).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("treats an oversized HEARTBEAT.md like a missing file and continues the run", async () => {
     await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg: OpenClawConfig = {

--- a/src/infra/heartbeat-runner.oversized-heartbeat-file.test.ts
+++ b/src/infra/heartbeat-runner.oversized-heartbeat-file.test.ts
@@ -1,13 +1,21 @@
 // Regression test for bounded HEARTBEAT.md reads.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resetLogger, setLoggerOverride } from "../logging/logger.js";
+import { loggingState } from "../logging/state.js";
 import { runHeartbeatOnce } from "./heartbeat-runner.js";
 import { installHeartbeatRunnerTestRuntime } from "./heartbeat-runner.test-harness.js";
 import { seedMainSessionStore, withTempHeartbeatSandbox } from "./heartbeat-runner.test-utils.js";
 
 installHeartbeatRunnerTestRuntime({ includeSlack: true });
+
+afterEach(() => {
+  loggingState.rawConsole = null;
+  setLoggerOverride(null);
+  resetLogger();
+});
 
 describe("runHeartbeatOnce oversized HEARTBEAT.md", () => {
   it("follows a symlinked HEARTBEAT.md to a regular file", async () => {
@@ -76,6 +84,10 @@ describe("runHeartbeatOnce oversized HEARTBEAT.md", () => {
       const oversizedContent = Buffer.alloc(16 * 1024 * 1024 + 1, "x");
       await fs.writeFile(path.join(tmpDir, "HEARTBEAT.md"), oversizedContent);
 
+      const warn = vi.fn();
+      loggingState.rawConsole = { log: vi.fn(), info: vi.fn(), warn, error: vi.fn() };
+      setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+
       replySpy.mockResolvedValue({ text: "needs attention" });
       const sendSlack = vi.fn().mockResolvedValue({ messageId: "m1", channelId: "C123" });
 
@@ -91,6 +103,10 @@ describe("runHeartbeatOnce oversized HEARTBEAT.md", () => {
 
       expect(res.status).toBe("ran");
       expect(sendSlack).toHaveBeenCalledTimes(1);
+      // Operators must see why their oversized heartbeat file no longer applies.
+      expect(
+        warn.mock.calls.some((call) => String(call[0]).includes("skipping oversized HEARTBEAT.md")),
+      ).toBe(true);
     });
   });
 });

--- a/src/infra/heartbeat-runner.oversized-heartbeat-file.test.ts
+++ b/src/infra/heartbeat-runner.oversized-heartbeat-file.test.ts
@@ -1,0 +1,51 @@
+// Regression test for bounded HEARTBEAT.md reads.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { runHeartbeatOnce } from "./heartbeat-runner.js";
+import { installHeartbeatRunnerTestRuntime } from "./heartbeat-runner.test-harness.js";
+import { seedMainSessionStore, withTempHeartbeatSandbox } from "./heartbeat-runner.test-utils.js";
+
+installHeartbeatRunnerTestRuntime({ includeSlack: true });
+
+describe("runHeartbeatOnce oversized HEARTBEAT.md", () => {
+  it("treats an oversized HEARTBEAT.md like a missing file and continues the run", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "slack", to: "channel:C123" },
+          },
+        },
+        channels: { slack: { heartbeat: { showOk: false } } },
+        session: { store: storePath },
+      };
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "slack",
+        lastProvider: "slack",
+        lastTo: "channel:C123",
+      });
+      // Overwrite the default heartbeat file with content larger than the 16 MB cap.
+      const oversizedContent = Buffer.alloc(16 * 1024 * 1024 + 1, "x");
+      await fs.writeFile(path.join(tmpDir, "HEARTBEAT.md"), oversizedContent);
+
+      replySpy.mockResolvedValue({ text: "needs attention" });
+      const sendSlack = vi.fn().mockResolvedValue({ messageId: "m1", channelId: "C123" });
+
+      const res = await runHeartbeatOnce({
+        cfg,
+        deps: {
+          getReplyFromConfig: replySpy,
+          slack: sendSlack,
+          getQueueSize: () => 0,
+          nowMs: () => 0,
+        },
+      });
+
+      expect(res.status).toBe("ran");
+      expect(sendSlack).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1,5 +1,6 @@
 // Runs heartbeat checks and emits status updates for configured agents.
 import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
 import path from "node:path";
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import {
@@ -1084,8 +1085,14 @@ async function resolveHeartbeatPreflight(params: {
   const MAX_HEARTBEAT_FILE_BYTES = 16 * 1024 * 1024;
   let heartbeatFileContent: string | undefined;
   try {
+    // Resolve symlinks so a HEARTBEAT.md pointing to a regular file keeps
+    // working; missing/broken symlinks still surface as ENOENT below.
+    const resolvedHeartbeatFilePath = await fs.realpath(heartbeatFilePath);
     heartbeatFileContent = (
-      await readRegularFile({ filePath: heartbeatFilePath, maxBytes: MAX_HEARTBEAT_FILE_BYTES })
+      await readRegularFile({
+        filePath: resolvedHeartbeatFilePath,
+        maxBytes: MAX_HEARTBEAT_FILE_BYTES,
+      })
     ).buffer.toString("utf-8");
     const tasks = parseHeartbeatTasks(heartbeatFileContent);
     if (

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1,6 +1,5 @@
 // Runs heartbeat checks and emits status updates for configured agents.
 import { createHash } from "node:crypto";
-import fs from "node:fs/promises";
 import path from "node:path";
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import {
@@ -165,6 +164,7 @@ import {
   resolveHeartbeatDeliveryTargetWithSessionRoute,
   resolveHeartbeatSenderContext,
 } from "./outbound/targets.js";
+import { readRegularFile } from "./regular-file.js";
 import {
   consumeSelectedSystemEventEntries,
   peekSystemEventEntries,
@@ -1081,9 +1081,12 @@ async function resolveHeartbeatPreflight(params: {
 
   const workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
   const heartbeatFilePath = path.join(workspaceDir, DEFAULT_HEARTBEAT_FILENAME);
+  const MAX_HEARTBEAT_FILE_BYTES = 16 * 1024 * 1024;
   let heartbeatFileContent: string | undefined;
   try {
-    heartbeatFileContent = await fs.readFile(heartbeatFilePath, "utf-8");
+    heartbeatFileContent = (
+      await readRegularFile({ filePath: heartbeatFilePath, maxBytes: MAX_HEARTBEAT_FILE_BYTES })
+    ).buffer.toString("utf-8");
     const tasks = parseHeartbeatTasks(heartbeatFileContent);
     if (
       isHeartbeatContentEffectivelyEmpty(heartbeatFileContent) &&

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1120,6 +1120,12 @@ async function resolveHeartbeatPreflight(params: {
       // The heartbeat prompt already says "if it exists".
       return basePreflight;
     }
+    // Oversized files loaded in full before the cap existed, so tell the
+    // operator why their heartbeat instructions no longer apply instead of
+    // dropping them silently. Other read errors keep proceeding as before.
+    if (err instanceof Error && err.message.startsWith("File exceeds")) {
+      log.warn(`heartbeat: skipping oversized ${DEFAULT_HEARTBEAT_FILENAME}: ${err.message}`);
+    }
     // For other read errors, proceed with heartbeat as before.
   }
 


### PR DESCRIPTION
## What Problem This Solves

`resolveHeartbeatPreflight` in `src/infra/heartbeat-runner.ts` read the workspace `HEARTBEAT.md` with an unbounded `fs.readFile`, allowing an arbitrarily large file to be loaded into memory and processed by the heartbeat pipeline.

## Why This Change Was Made

Switch to `readRegularFile` with a 16 MiB cap so the read is bounded and rejects non-regular files. Symlinks are resolved via `fs.realpath` first, so a `HEARTBEAT.md` symlinked to a valid regular file keeps working while dangling symlinks still surface as `ENOENT` (treated as missing, by design). This aligns with other bounded-read fixes in the repo and prevents accidental or malicious oversized heartbeat files from causing memory pressure.

## User Impact

Oversized `HEARTBEAT.md` files are now skipped: the heartbeat run continues without the file content, and the operator sees a `gateway/heartbeat` warning (`skipping oversized HEARTBEAT.md: File exceeds 16777216 bytes: ...`) explaining why the file no longer applies. Normal-sized and symlinked heartbeat files behave exactly as before.

## Evidence

- `src/infra/heartbeat-runner.oversized-heartbeat-file.test.ts`: regression tests for (a) a symlinked `HEARTBEAT.md` loading through `realpath` and (b) a `16 MiB + 1` byte file being skipped while the run continues and the operator-visible warning fires.
- Final-head runtime proof (`a6074aaceeafc379434e5207500a3e46f52c5f6f`, rebased onto `upstream/main` `851f76cb0d0`): standalone driver invoking the real exported `runHeartbeatOnce` path against `/tmp` fixtures with an isolated `HOME`, model reply and Slack delivery stubbed via `HeartbeatDeps`. Transcript in the comments.
- Focused tests on the final head: `node scripts/run-vitest.mjs src/infra/heartbeat-runner.oversized-heartbeat-file.test.ts --run` passes (2/2).

## Real behavior proof

Final head `a6074aaceeafc379434e5207500a3e46f52c5f6f`. Fixture paths are throwaway `/tmp` dirs.

```text
--- case: symlink ---
HEARTBEAT.md lstat: isSymbolicLink=true size=58 (cap=16777216)
runHeartbeatOnce status: ran
captured prompt contains PROOF-MARKER: true
captured prompt bytes: 626
slack deliveries: 1

[heartbeat] skipping oversized HEARTBEAT.md: File exceeds 16777216 bytes: /tmp/openclaw-hb-proof/oversized/workspace/HEARTBEAT.md
--- case: oversized ---
HEARTBEAT.md lstat: isSymbolicLink=false size=16777246 (cap=16777216)
runHeartbeatOnce status: ran
captured prompt contains PROOF-MARKER: false
captured prompt bytes: 559
slack deliveries: 1
```

```text
$ node scripts/run-vitest.mjs src/infra/heartbeat-runner.oversized-heartbeat-file.test.ts --run
 ✓ |infra| src/infra/heartbeat-runner.oversized-heartbeat-file.test.ts (2 tests) 942ms
     ✓ follows a symlinked HEARTBEAT.md to a regular file  833ms
 Test Files  1 passed (1)
      Tests  2 passed (2)
[test] passed 1 Vitest shard in 14.88s
```
