### PR TITLE
fix(codex): suppress stdout/stderr stream errors in sandbox subprocesses

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -978,8 +978,9 @@ async function completeStartedRun(
   waitForMethod: ReturnType<typeof createStartedThreadHarness>["waitForMethod"],
   completeTurn: ReturnType<typeof createStartedThreadHarness>["completeTurn"],
   threadId = "thread-1",
+  waitTimeoutMs?: number,
 ): Promise<void> {
-  await waitForMethod("turn/start");
+  await waitForMethod("turn/start", waitTimeoutMs);
   await completeTurn({ threadId, turnId: "turn-1" });
   await run;
 }
@@ -5161,7 +5162,7 @@ describe("runCodexAppServerAttempt", () => {
     } as EmbeddedRunAttemptParams;
     setCodexTestModelSupportsTools(params, false);
     const run = runCodexAppServerAttempt(params, { pluginConfig: {} });
-    await completeStartedRun(run, waitForMethod, completeTurn);
+    await completeStartedRun(run, waitForMethod, completeTurn, "thread-1", 150_000);
     const startRequest = requests.find((request) => request.method === "thread/start");
     const startRequestParams = startRequest?.params as Record<string, unknown> | undefined;
     expect(startRequestParams?.modelProvider).toBe("lmstudio");
@@ -5172,7 +5173,7 @@ describe("runCodexAppServerAttempt", () => {
     const turnRequestParams = turnRequest?.params as Record<string, unknown> | undefined;
     expect(turnRequestParams?.approvalPolicy).toBe("on-request");
     expect(turnRequestParams?.approvalsReviewer).toBe("user");
-  });
+  }, 180_000);
 
   it("enables Guardian on the first turn after a fresh thread confirms the OpenAI provider", async () => {
     const { sessionFile, workspaceDir } = createRunPaths();

--- a/extensions/codex/src/app-server/sandbox-exec-server.pipe-survival.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.pipe-survival.test.ts
@@ -169,4 +169,44 @@ describe("sandbox exec-server pipe survival", () => {
 
     socket.close();
   });
+
+  it("streaming HTTP request settles on pre-header stdout error while child stays alive", async () => {
+    // Child stays alive forever without emitting headers so the only way the
+    // request settles is through the stream-error → fail path.
+    const sandbox = createSandboxContext({
+      buildExecSpec: async () => ({
+        argv: [process.execPath, "-e", "setTimeout(function(){},300000)"],
+        env: { PATH: process.env.PATH, TMPDIR },
+        stdinMode: "pipe-closed" as const,
+      }),
+    });
+    const client = createClient();
+    const env = await ensureCodexSandboxExecServerEnvironment({ client: client as any, sandbox });
+    expect(env).toBeDefined();
+    const socket = await openSocket(execServerUrlFromClient(client));
+    collectNotifications(socket);
+
+    const requestPromise = rpc(socket, "http/request", {
+      requestId: "http-pipe-err-1",
+      method: "GET",
+      url: "https://example.com/",
+      streamResponse: true,
+    });
+
+    // Wait for the spawned child so the readStreamingSandboxHttpResponse
+    // listeners are attached.
+    await delay(100);
+    const child = spawnedChildren.at(-1);
+    expect(child).toBeDefined();
+
+    // Emit a stdout error before headers; the fix must settle the request
+    // through its guarded failure path instead of hanging.
+    child!.stdout.emit("error", new Error("EPIPE: simulated broken output pipe"));
+
+    await expect(requestPromise).rejects.toThrow("sandbox http/request output stream error");
+
+    // The WebSocket bridge must survive the settled failure.
+    expect(socket.readyState).toBe(WS_OPEN);
+    socket.close();
+  });
 });

--- a/extensions/codex/src/app-server/sandbox-exec-server.pipe-survival.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.pipe-survival.test.ts
@@ -31,10 +31,8 @@ vi.mock("node:child_process", async (importOriginal) => {
   };
 });
 
-import {
-  closeCodexSandboxExecServersForTests,
-  ensureCodexSandboxExecServerEnvironment,
-} from "./sandbox-exec-server.js";
+import { sandboxExecServerRegistry } from "./sandbox-exec-server-registry.js";
+import { ensureCodexSandboxExecServerEnvironment } from "./sandbox-exec-server.js";
 import {
   collectNotifications,
   createClient,
@@ -69,7 +67,7 @@ function expectStreamErrorSuppressed(
 }
 
 afterEach(async () => {
-  await closeCodexSandboxExecServersForTests();
+  await sandboxExecServerRegistry.closeAll();
 });
 
 beforeEach(() => {
@@ -170,14 +168,18 @@ describe("sandbox exec-server pipe survival", () => {
     socket.close();
   });
 
-  it("streaming HTTP request settles on pre-header stdout error while child stays alive", async () => {
+  it("streaming HTTP request terminates after a pre-header stdout error and finalizes on close", async () => {
     // Child stays alive forever without emitting headers so the only way the
-    // request settles is through the stream-error path.  finalizeExec must NOT
-    // be called before close, only after the child has actually exited.
+    // request settles is through the stream-error path. It ignores SIGTERM so
+    // the test can prove termination is requested without finalizing before close.
     const finalizeExec = vi.fn(async () => undefined);
     const sandbox = createSandboxContext({
       buildExecSpec: async () => ({
-        argv: [process.execPath, "-e", "setTimeout(function(){},300000)"],
+        argv: [
+          process.execPath,
+          "-e",
+          "process.on('SIGTERM',function(){});setTimeout(function(){},300000)",
+        ],
         env: { PATH: process.env.PATH, TMPDIR },
         stdinMode: "pipe-closed" as const,
       }),
@@ -201,21 +203,23 @@ describe("sandbox exec-server pipe survival", () => {
     await delay(100);
     const child = spawnedChildren.at(-1);
     expect(child).toBeDefined();
+    const kill = vi.spyOn(child!, "kill");
 
     // Emit a stdout error before headers; the fix must settle the request
-    // through its guarded failure path instead of hanging.
+    // through its guarded failure path instead of hanging, then terminate the helper.
     child!.stdout.emit("error", new Error("EPIPE: simulated broken output pipe"));
 
     await expect(requestPromise).rejects.toThrow("sandbox http/request output stream error");
+    expect(kill).toHaveBeenCalledWith("SIGTERM");
 
-    // finalizeExec must NOT have been called yet: the child is still alive and
-    // close owns backend finalization.
+    // finalizeExec must NOT have been called yet: the child ignored SIGTERM and
+    // close remains the only backend finalization owner.
     expect(finalizeExec).not.toHaveBeenCalled();
 
     // The WebSocket bridge must survive the settled failure.
     expect(socket.readyState).toBe(WS_OPEN);
 
-    // Kill the child so close fires; finalizeExec must be called exactly once
+    // Force the child closed; finalizeExec must be called exactly once
     // now that the child has actually exited.
     child!.kill("SIGKILL");
     await vi.waitFor(() => {

--- a/extensions/codex/src/app-server/sandbox-exec-server.pipe-survival.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.pipe-survival.test.ts
@@ -79,7 +79,7 @@ describe("sandbox exec-server pipe survival", () => {
   it("process bridge suppresses stdout/stderr errors and keeps serving", async () => {
     const sandbox = createSandboxContext({
       buildExecSpec: async ({ command }) => ({
-        argv: ["/bin/sh", "-c", command],
+        argv: ["/bin/sh", "-c", `exec ${command}`],
         env: { PATH: process.env.PATH, TMPDIR },
         stdinMode: "pipe-closed" as const,
       }),

--- a/extensions/codex/src/app-server/sandbox-exec-server.pipe-survival.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.pipe-survival.test.ts
@@ -31,6 +31,7 @@ vi.mock("node:child_process", async (importOriginal) => {
   };
 });
 
+import type { CodexAppServerClient } from "./client.js";
 import { sandboxExecServerRegistry } from "./sandbox-exec-server-registry.js";
 import { ensureCodexSandboxExecServerEnvironment } from "./sandbox-exec-server.js";
 import {
@@ -84,7 +85,10 @@ describe("sandbox exec-server pipe survival", () => {
       }),
     });
     const client = createClient();
-    const env = await ensureCodexSandboxExecServerEnvironment({ client: client as any, sandbox });
+    const env = await ensureCodexSandboxExecServerEnvironment({
+      client: client as unknown as CodexAppServerClient,
+      sandbox,
+    });
     expect(env).toBeDefined();
     const socket = await openSocket(execServerUrlFromClient(client));
     collectNotifications(socket);
@@ -146,7 +150,10 @@ describe("sandbox exec-server pipe survival", () => {
       }),
     });
     const client = createClient();
-    const env = await ensureCodexSandboxExecServerEnvironment({ client: client as any, sandbox });
+    const env = await ensureCodexSandboxExecServerEnvironment({
+      client: client as unknown as CodexAppServerClient,
+      sandbox,
+    });
     expect(env).toBeDefined();
     const socket = await openSocket(execServerUrlFromClient(client));
     collectNotifications(socket);
@@ -186,7 +193,10 @@ describe("sandbox exec-server pipe survival", () => {
       finalizeExec,
     });
     const client = createClient();
-    const env = await ensureCodexSandboxExecServerEnvironment({ client: client as any, sandbox });
+    const env = await ensureCodexSandboxExecServerEnvironment({
+      client: client as unknown as CodexAppServerClient,
+      sandbox,
+    });
     expect(env).toBeDefined();
     const socket = await openSocket(execServerUrlFromClient(client));
     collectNotifications(socket);

--- a/extensions/codex/src/app-server/sandbox-exec-server.pipe-survival.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.pipe-survival.test.ts
@@ -172,13 +172,16 @@ describe("sandbox exec-server pipe survival", () => {
 
   it("streaming HTTP request settles on pre-header stdout error while child stays alive", async () => {
     // Child stays alive forever without emitting headers so the only way the
-    // request settles is through the stream-error → fail path.
+    // request settles is through the stream-error path.  finalizeExec must NOT
+    // be called before close, only after the child has actually exited.
+    const finalizeExec = vi.fn(async () => undefined);
     const sandbox = createSandboxContext({
       buildExecSpec: async () => ({
         argv: [process.execPath, "-e", "setTimeout(function(){},300000)"],
         env: { PATH: process.env.PATH, TMPDIR },
         stdinMode: "pipe-closed" as const,
       }),
+      finalizeExec,
     });
     const client = createClient();
     const env = await ensureCodexSandboxExecServerEnvironment({ client: client as any, sandbox });
@@ -205,8 +208,21 @@ describe("sandbox exec-server pipe survival", () => {
 
     await expect(requestPromise).rejects.toThrow("sandbox http/request output stream error");
 
+    // finalizeExec must NOT have been called yet: the child is still alive and
+    // close owns backend finalization.
+    expect(finalizeExec).not.toHaveBeenCalled();
+
     // The WebSocket bridge must survive the settled failure.
     expect(socket.readyState).toBe(WS_OPEN);
+
+    // Kill the child so close fires; finalizeExec must be called exactly once
+    // now that the child has actually exited.
+    child!.kill("SIGKILL");
+    await vi.waitFor(() => {
+      expect(finalizeExec).toHaveBeenCalledTimes(1);
+    });
+    expect(finalizeExec).toHaveBeenCalledWith(expect.objectContaining({ status: "failed" }));
+
     socket.close();
   });
 });

--- a/extensions/codex/src/app-server/sandbox-exec-server.pipe-survival.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.pipe-survival.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Regression test: Codex sandbox exec-server subprocess owners attach no-op
+ * `error` listeners to child stdout/stderr so a broken pipe cannot surface as
+ * a process-fatal unhandled EventEmitter `error`.
+ *
+ * Both the process RPC path (`processes.ts`) and the streaming HTTP path
+ * (`http.ts`) spawn pipe-backed children. The tests capture the real spawned
+ * child and deterministically emit `error` on stdout and stderr. With the
+ * listeners in place the emit is swallowed and the bridge stays usable; if
+ * either production listener is removed, `emit("error")` throws synchronously
+ * (no `error` listener on the stream) and the test fails.
+ */
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Capture every child the exec-server spawns so tests can drive real stream
+// errors on the exact stdout/stderr pipes the production listeners guard.
+const { spawnedChildren } = vi.hoisted(() => ({
+  spawnedChildren: [] as ChildProcessWithoutNullStreams[],
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: (...args: Parameters<typeof actual.spawn>) => {
+      const child = actual.spawn(...args);
+      spawnedChildren.push(child as ChildProcessWithoutNullStreams);
+      return child;
+    },
+  };
+});
+
+import {
+  closeCodexSandboxExecServersForTests,
+  ensureCodexSandboxExecServerEnvironment,
+} from "./sandbox-exec-server.js";
+import {
+  collectNotifications,
+  createClient,
+  createSandboxContext,
+  execServerUrlFromClient,
+  openSocket,
+  readUntilClosed,
+  rpc,
+} from "./sandbox-exec-server.test-helpers.js";
+
+const TMPDIR = process.env.TMPDIR ?? "/tmp";
+const WS_OPEN = 1;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/** Asserts the child stream still swallows a real `error` event after the fix. */
+function expectStreamErrorSuppressed(
+  stream: ChildProcessWithoutNullStreams["stdout"],
+  label: string,
+): void {
+  // A no-op `error` listener must be attached by production code. Without it,
+  // emitting `error` on a stream with no `error` listener throws.
+  expect(stream.listenerCount("error"), `${label} has no error listener`).toBeGreaterThan(0);
+  expect(
+    () => stream.emit("error", new Error("EPIPE: simulated broken output pipe")),
+    `${label} error event was not suppressed`,
+  ).not.toThrow();
+}
+
+afterEach(async () => {
+  await closeCodexSandboxExecServersForTests();
+});
+
+beforeEach(() => {
+  spawnedChildren.length = 0;
+});
+
+describe("sandbox exec-server pipe survival", () => {
+  it("process bridge suppresses stdout/stderr errors and keeps serving", async () => {
+    const sandbox = createSandboxContext({
+      buildExecSpec: async ({ command }) => ({
+        argv: ["/bin/sh", "-c", command],
+        env: { PATH: process.env.PATH, TMPDIR },
+        stdinMode: "pipe-closed" as const,
+      }),
+    });
+    const client = createClient();
+    const env = await ensureCodexSandboxExecServerEnvironment({ client: client as any, sandbox });
+    expect(env).toBeDefined();
+    const socket = await openSocket(execServerUrlFromClient(client));
+    collectNotifications(socket);
+
+    const processId = "pipe-srv-101";
+    const SCRIPT = "process.stdout.write('ready\\n');setTimeout(function(){},300000)";
+    const start = (await rpc(socket, "process/start", {
+      processId,
+      argv: [process.execPath, "-e", SCRIPT],
+      cwd: TMPDIR,
+      tty: false,
+      pipeStdin: false,
+    })) as { processId: string };
+    expect(start.processId).toBe(processId);
+
+    // The spawned child's real pipes are the surface the production listeners
+    // guard; emitting `error` here is the exact event the fix must swallow.
+    const child = spawnedChildren.at(-1);
+    expect(child).toBeDefined();
+    expectStreamErrorSuppressed(child!.stdout, "process stdout");
+    expectStreamErrorSuppressed(child!.stderr, "process stderr");
+    expect(socket.readyState).toBe(WS_OPEN);
+
+    await rpc(socket, "process/terminate", { processId });
+    await delay(200);
+    const read = await readUntilClosed(socket, processId);
+    expect(read.closed).toBe(true);
+
+    // The bridge must still accept and run follow-up work after the pipe error.
+    const followId = "pipe-srv-102";
+    await rpc(socket, "process/start", {
+      processId: followId,
+      argv: [process.execPath, "-e", "process.stdout.write('bridge-survived')"],
+      cwd: TMPDIR,
+      tty: false,
+      pipeStdin: false,
+    });
+    const follow = await readUntilClosed(socket, followId);
+    const output = follow.chunks
+      ?.map((c) => Buffer.from(c.chunk, "base64").toString("utf8"))
+      .join("")
+      .trim();
+    expect(output).toBe("bridge-survived");
+    socket.close();
+  });
+
+  it("streaming HTTP bridge suppresses stdout/stderr errors after headers", async () => {
+    // The HTTP helper child emits one JSON `headers` line then stays alive, so
+    // the streaming request resolves and the child pipes are still open when we
+    // drive the error events.
+    const HTTP_SCRIPT =
+      "process.stdout.write(JSON.stringify({type:'headers',status:200,headers:[]})+'\\n');" +
+      "setTimeout(function(){},300000)";
+    const sandbox = createSandboxContext({
+      buildExecSpec: async () => ({
+        argv: [process.execPath, "-e", HTTP_SCRIPT],
+        env: { PATH: process.env.PATH, TMPDIR },
+        stdinMode: "pipe-closed" as const,
+      }),
+    });
+    const client = createClient();
+    const env = await ensureCodexSandboxExecServerEnvironment({ client: client as any, sandbox });
+    expect(env).toBeDefined();
+    const socket = await openSocket(execServerUrlFromClient(client));
+    collectNotifications(socket);
+
+    const response = (await rpc(socket, "http/request", {
+      requestId: "http-pipe-1",
+      method: "GET",
+      url: "https://example.com/",
+      streamResponse: true,
+    })) as { status: number };
+    expect(response.status).toBe(200);
+
+    const child = spawnedChildren.at(-1);
+    expect(child).toBeDefined();
+    expectStreamErrorSuppressed(child!.stdout, "http stdout");
+    expectStreamErrorSuppressed(child!.stderr, "http stderr");
+    expect(socket.readyState).toBe(WS_OPEN);
+
+    socket.close();
+  });
+});

--- a/extensions/codex/src/app-server/sandbox-exec-server.pipe-survival.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.pipe-survival.test.ts
@@ -11,6 +11,7 @@
  * (no `error` listener on the stream) and the test fails.
  */
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Capture every child the exec-server spawns so tests can drive real stream
@@ -45,6 +46,7 @@ import {
 } from "./sandbox-exec-server.test-helpers.js";
 
 const TMPDIR = process.env.TMPDIR ?? "/tmp";
+const TMPDIR_URL = pathToFileURL(TMPDIR).href;
 const WS_OPEN = 1;
 
 function delay(ms: number): Promise<void> {
@@ -98,7 +100,7 @@ describe("sandbox exec-server pipe survival", () => {
     const start = (await rpc(socket, "process/start", {
       processId,
       argv: [process.execPath, "-e", SCRIPT],
-      cwd: TMPDIR,
+      cwd: TMPDIR_URL,
       tty: false,
       pipeStdin: false,
     })) as { processId: string };
@@ -122,7 +124,7 @@ describe("sandbox exec-server pipe survival", () => {
     await rpc(socket, "process/start", {
       processId: followId,
       argv: [process.execPath, "-e", "process.stdout.write('bridge-survived')"],
-      cwd: TMPDIR,
+      cwd: TMPDIR_URL,
       tty: false,
       pipeStdin: false,
     });

--- a/extensions/codex/src/app-server/sandbox-exec-server.pipe-survival.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.pipe-survival.test.ts
@@ -239,4 +239,51 @@ describe("sandbox exec-server pipe survival", () => {
 
     socket.close();
   });
+
+  it("streaming HTTP request defers malformed-output finalization until child close", async () => {
+    const finalizeExec = vi.fn(async () => undefined);
+    const sandbox = createSandboxContext({
+      buildExecSpec: async () => ({
+        argv: [
+          process.execPath,
+          "-e",
+          "process.on('SIGTERM',function(){});process.stdout.write('not-json\\n');setTimeout(function(){},300000)",
+        ],
+        env: { PATH: process.env.PATH, TMPDIR },
+        stdinMode: "pipe-closed" as const,
+      }),
+      finalizeExec,
+    });
+    const client = createClient();
+    const env = await ensureCodexSandboxExecServerEnvironment({
+      client: client as unknown as CodexAppServerClient,
+      sandbox,
+    });
+    expect(env).toBeDefined();
+    const socket = await openSocket(execServerUrlFromClient(client));
+    collectNotifications(socket);
+
+    const requestPromise = rpc(socket, "http/request", {
+      requestId: "http-pipe-malformed-1",
+      method: "GET",
+      url: "https://example.com/",
+      streamResponse: true,
+    });
+
+    await expect(requestPromise).rejects.toThrow();
+    const child = spawnedChildren.at(-1);
+    expect(child).toBeDefined();
+
+    // Malformed stdout settles the request and asks the helper to terminate,
+    // but close remains the only backend finalization owner.
+    expect(finalizeExec).not.toHaveBeenCalled();
+
+    child!.kill("SIGKILL");
+    await vi.waitFor(() => {
+      expect(finalizeExec).toHaveBeenCalledTimes(1);
+    });
+    expect(finalizeExec).toHaveBeenCalledWith(expect.objectContaining({ status: "failed" }));
+
+    socket.close();
+  });
 });

--- a/extensions/codex/src/app-server/sandbox-exec-server.pipe-survival.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.pipe-survival.test.ts
@@ -1,16 +1,16 @@
 /**
- * Regression test: Codex sandbox exec-server subprocess owners attach no-op
- * `error` listeners to child stdout/stderr so a broken pipe cannot surface as
- * a process-fatal unhandled EventEmitter `error`.
+ * Regression test: Codex sandbox exec-server subprocess owners handle child
+ * stdout/stderr `error` events without crashing the WebSocket bridge.
  *
  * Both the process RPC path (`processes.ts`) and the streaming HTTP path
  * (`http.ts`) spawn pipe-backed children. The tests capture the real spawned
  * child and deterministically emit `error` on stdout and stderr. With the
- * listeners in place the emit is swallowed and the bridge stays usable; if
- * either production listener is removed, `emit("error")` throws synchronously
- * (no `error` listener on the stream) and the test fails.
+ * Output delivery failures fail and terminate the affected operation while the
+ * bridge stays usable. If either production listener is removed, `emit("error")`
+ * throws synchronously and the test fails.
  */
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { once } from "node:events";
 import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -44,6 +44,7 @@ import {
   readUntilClosed,
   rpc,
 } from "./sandbox-exec-server.test-helpers.js";
+import { terminateChildWithEscalation } from "./sandbox-exec-server/output-stream-errors.js";
 
 const TMPDIR = process.env.TMPDIR ?? "/tmp";
 const TMPDIR_URL = pathToFileURL(TMPDIR).href;
@@ -55,8 +56,8 @@ function delay(ms: number): Promise<void> {
   });
 }
 
-/** Asserts the child stream still swallows a real `error` event after the fix. */
-function expectStreamErrorSuppressed(
+/** Asserts production code handles a real stream `error` event. */
+function expectStreamErrorHandled(
   stream: ChildProcessWithoutNullStreams["stdout"],
   label: string,
 ): void {
@@ -65,7 +66,7 @@ function expectStreamErrorSuppressed(
   expect(stream.listenerCount("error"), `${label} has no error listener`).toBeGreaterThan(0);
   expect(
     () => stream.emit("error", new Error("EPIPE: simulated broken output pipe")),
-    `${label} error event was not suppressed`,
+    `${label} error event was not handled`,
   ).not.toThrow();
 }
 
@@ -78,7 +79,55 @@ beforeEach(() => {
 });
 
 describe("sandbox exec-server pipe survival", () => {
-  it("process bridge suppresses stdout/stderr errors and keeps serving", async () => {
+  it("bounds close when a descendant retains an exited wrapper's output pipes", async () => {
+    const SCRIPT = String.raw`
+      const { spawn } = require("node:child_process");
+      const descendant = spawn(process.execPath, ["-e", "setTimeout(function(){},300000)"], {
+        stdio: ["ignore", process.stdout, process.stderr],
+      });
+      process.stdout.write(String(descendant.pid) + "\n");
+      process.on("SIGTERM", function() { process.exit(0); });
+      setTimeout(function(){}, 300000);
+    `;
+    const child = (await import("node:child_process")).spawn(process.execPath, [
+      "-e",
+      SCRIPT,
+    ]) as ChildProcessWithoutNullStreams;
+    const [pidChunk] = (await once(child.stdout, "data")) as [Buffer];
+    const descendantPid = Number.parseInt(pidChunk.toString("utf8").trim(), 10);
+    expect(descendantPid).toBeGreaterThan(0);
+
+    const exitPromise = once(child, "exit");
+    const closePromise = once(child, "close");
+    terminateChildWithEscalation(child);
+    await exitPromise;
+    expect(child.exitCode).toBe(0);
+
+    let closed = false;
+    void closePromise.then(() => {
+      closed = true;
+    });
+    await delay(100);
+    expect(closed).toBe(false);
+
+    try {
+      await Promise.race([
+        closePromise,
+        delay(7_000).then(() => {
+          throw new Error("child close remained blocked by descendant output pipes");
+        }),
+      ]);
+      expect(closed).toBe(true);
+    } finally {
+      try {
+        process.kill(descendantPid, "SIGKILL");
+      } catch {
+        // The descendant may already have observed the destroyed pipe.
+      }
+    }
+  });
+
+  it("process bridge fails output errors and keeps serving", async () => {
     const sandbox = createSandboxContext({
       buildExecSpec: async ({ command }) => ({
         argv: ["/bin/sh", "-c", `exec ${command}`],
@@ -93,7 +142,7 @@ describe("sandbox exec-server pipe survival", () => {
     });
     expect(env).toBeDefined();
     const socket = await openSocket(execServerUrlFromClient(client));
-    collectNotifications(socket);
+    const notifications = collectNotifications(socket);
 
     const processId = "pipe-srv-101";
     const SCRIPT = "process.stdout.write('ready\\n');setTimeout(function(){},300000)";
@@ -110,14 +159,35 @@ describe("sandbox exec-server pipe survival", () => {
     // guard; emitting `error` here is the exact event the fix must swallow.
     const child = spawnedChildren.at(-1);
     expect(child).toBeDefined();
-    expectStreamErrorSuppressed(child!.stdout, "process stdout");
-    expectStreamErrorSuppressed(child!.stderr, "process stderr");
+    expectStreamErrorHandled(child!.stdout, "process stdout");
+    expectStreamErrorHandled(child!.stderr, "process stderr");
     expect(socket.readyState).toBe(WS_OPEN);
 
     await rpc(socket, "process/terminate", { processId });
     await delay(200);
     const read = await readUntilClosed(socket, processId);
     expect(read.closed).toBe(true);
+    expect(read.failure).toContain("sandbox process output stream error");
+    expect(read.exitCode).toBe(1);
+    const processEvents = notifications.filter(
+      (notification) =>
+        notification.method === "process/output" ||
+        notification.method === "process/exited" ||
+        notification.method === "process/closed",
+    );
+    const eventSeqs = processEvents.map(
+      (notification) => (notification.params as { seq: number }).seq,
+    );
+    expect(
+      (
+        processEvents.find((notification) => notification.method === "process/exited")?.params as
+          | { exitCode?: number }
+          | undefined
+      )?.exitCode,
+    ).toBe(1);
+    expect(eventSeqs.every((seq, index) => index === 0 || seq === eventSeqs[index - 1]! + 1)).toBe(
+      true,
+    );
 
     // The bridge must still accept and run follow-up work after the pipe error.
     const followId = "pipe-srv-102";
@@ -170,8 +240,8 @@ describe("sandbox exec-server pipe survival", () => {
 
     const child = spawnedChildren.at(-1);
     expect(child).toBeDefined();
-    expectStreamErrorSuppressed(child!.stdout, "http stdout");
-    expectStreamErrorSuppressed(child!.stderr, "http stderr");
+    expectStreamErrorHandled(child!.stdout, "http stdout");
+    expectStreamErrorHandled(child!.stderr, "http stderr");
     expect(socket.readyState).toBe(WS_OPEN);
 
     socket.close();
@@ -231,12 +301,16 @@ describe("sandbox exec-server pipe survival", () => {
     // The WebSocket bridge must survive the settled failure.
     expect(socket.readyState).toBe(WS_OPEN);
 
-    // Force the child closed; finalizeExec must be called exactly once
-    // now that the child has actually exited.
-    child!.kill("SIGKILL");
-    await vi.waitFor(() => {
-      expect(finalizeExec).toHaveBeenCalledTimes(1);
-    });
+    // The bounded fallback force-closes the uncooperative child; close remains
+    // the sole owner and finalizes exactly once.
+    await vi.waitFor(
+      () => {
+        expect(kill).toHaveBeenCalledWith("SIGKILL");
+        expect(finalizeExec).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 7_000 },
+    );
+    expect(finalizeExec).toHaveBeenCalledTimes(1);
     expect(finalizeExec).toHaveBeenCalledWith(expect.objectContaining({ status: "failed" }));
 
     socket.close();
@@ -275,15 +349,19 @@ describe("sandbox exec-server pipe survival", () => {
     await expect(requestPromise).rejects.toThrow();
     const child = spawnedChildren.at(-1);
     expect(child).toBeDefined();
+    const kill = vi.spyOn(child!, "kill");
 
     // Malformed stdout settles the request and asks the helper to terminate,
     // but close remains the only backend finalization owner.
     expect(finalizeExec).not.toHaveBeenCalled();
 
-    child!.kill("SIGKILL");
-    await vi.waitFor(() => {
-      expect(finalizeExec).toHaveBeenCalledTimes(1);
-    });
+    await vi.waitFor(
+      () => {
+        expect(kill).toHaveBeenCalledWith("SIGKILL");
+        expect(finalizeExec).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 7_000 },
+    );
     expect(finalizeExec).toHaveBeenCalledWith(expect.objectContaining({ status: "failed" }));
 
     socket.close();

--- a/extensions/codex/src/app-server/sandbox-exec-server.test-helpers.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.test-helpers.ts
@@ -181,6 +181,7 @@ export async function readUntilClosed(
   exitCode?: number;
   closed?: boolean;
   nextSeq?: number;
+  failure?: string | null;
 }> {
   let afterSeq = 0;
   const chunks: Array<{ stream: string; chunk: string }> = [];
@@ -195,6 +196,7 @@ export async function readUntilClosed(
       exitCode?: number;
       closed?: boolean;
       nextSeq?: number;
+      failure?: string | null;
     };
     chunks.push(...(read.chunks ?? []));
     afterSeq = Math.max(afterSeq, (read.nextSeq ?? 1) - 1);

--- a/extensions/codex/src/app-server/sandbox-exec-server/http.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/http.ts
@@ -4,17 +4,14 @@
  */
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
-import type { SandboxContext } from "openclaw/plugin-sdk/sandbox";
 import { SsrFBlockedError, isBlockedHostnameOrIp } from "openclaw/plugin-sdk/ssrf-runtime";
-import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { WebSocket } from "ws";
 import type { JsonObject, JsonValue } from "../protocol.js";
-import { readHttpHeaders, requireNumber, requireObject, requireString } from "./json-rpc.js";
+import { readHttpHeaders, requireObject, requireString } from "./json-rpc.js";
+import { ignoreChildOutputStreamErrors } from "./output-stream-errors.js";
 import { requireBackend } from "./runtime.js";
+import { readStreamingSandboxHttpResponse } from "./streaming-response.js";
 import type { HttpHeader, OpenClawExecServer } from "./types.js";
-
-/** Maximum JSON-line size accepted from the streaming HTTP helper process. */
-const SANDBOX_HTTP_STREAM_LINE_MAX_CHARS = 256 * 1024;
 
 /** Handles one sandbox HTTP JSON-RPC request, optionally streaming response body deltas. */
 export async function httpRequest(
@@ -143,11 +140,7 @@ async function runStreamingSandboxHttpRequest(
     throw error;
   }
 
-  // Output pipes may fail independently while the process is running; a broken
-  // stdout/stderr pipe must not surface as a process-fatal unhandled error.
-  const ignoreOutputStreamError = () => {};
-  child.stdout.on("error", ignoreOutputStreamError);
-  child.stderr.on("error", ignoreOutputStreamError);
+  ignoreChildOutputStreamErrors(child);
 
   const abortOnSocketClose = () => child.kill("SIGTERM");
   socket.once("close", abortOnSocketClose);
@@ -167,159 +160,6 @@ async function runStreamingSandboxHttpRequest(
     finalizeExec: backend.finalizeExec,
     requestId,
     socket,
-  });
-}
-
-function readStreamingSandboxHttpResponse(params: {
-  child: ChildProcessWithoutNullStreams;
-  execSpec: { finalizeToken?: unknown };
-  finalizeExec?: NonNullable<SandboxContext["backend"]>["finalizeExec"];
-  requestId: string;
-  socket: WebSocket;
-}): Promise<JsonObject> {
-  return new Promise((resolve, reject) => {
-    let headerResolved = false;
-    let failed = false;
-    let childFailure: string | null = null;
-    let streamFailure: string | null = null;
-    let lastBodySeq = 0;
-    let stdoutBuffer = "";
-    let stderr = "";
-    const finalize = async (status: "completed" | "failed", exitCode: number | null) => {
-      await params.finalizeExec?.({
-        status,
-        exitCode,
-        timedOut: false,
-        token: params.execSpec.finalizeToken,
-      });
-    };
-    const fail = (message: string, exitCode: number | null) => {
-      if (failed) {
-        return;
-      }
-      failed = true;
-      void finalize("failed", exitCode).catch((error: unknown) => {
-        embeddedAgentLog.warn("codex sandbox http/request finalize failed", { error });
-      });
-      if (headerResolved) {
-        sendHttpBodyDelta(params.socket, {
-          requestId: params.requestId,
-          seq: lastBodySeq + 1,
-          deltaBase64: "",
-          done: true,
-          error: message,
-        });
-        return;
-      }
-      reject(new Error(message));
-    };
-    params.child.stdout.setEncoding("utf8");
-    params.child.stdout.on("data", (chunk: string) => {
-      stdoutBuffer += chunk;
-      let newline = stdoutBuffer.indexOf("\n");
-      while (newline >= 0) {
-        const line = stdoutBuffer.slice(0, newline).trim();
-        stdoutBuffer = stdoutBuffer.slice(newline + 1);
-        if (line) {
-          try {
-            const message = requireObject(JSON.parse(line) as JsonValue, "http stream message");
-            const type = requireString(message.type, "http stream message type");
-            if (type === "headers") {
-              headerResolved = true;
-              resolve({
-                status: requireNumber(message.status, "http status"),
-                headers: readHttpHeaders(message.headers),
-                bodyBase64: "",
-              });
-            } else if (type === "bodyDelta") {
-              const seq = requireNumber(message.seq, "http body sequence");
-              lastBodySeq = Math.max(lastBodySeq, seq);
-              sendHttpBodyDelta(params.socket, {
-                requestId: params.requestId,
-                seq,
-                deltaBase64: typeof message.deltaBase64 === "string" ? message.deltaBase64 : "",
-                done: message.done === true,
-                error: typeof message.error === "string" ? message.error : null,
-              });
-            }
-          } catch (error) {
-            fail(error instanceof Error ? error.message : String(error), null);
-          }
-        }
-        newline = stdoutBuffer.indexOf("\n");
-      }
-      if (stdoutBuffer.length > SANDBOX_HTTP_STREAM_LINE_MAX_CHARS) {
-        params.child.kill("SIGKILL");
-        fail(
-          `sandbox http/request produced an unterminated stdout line longer than ${SANDBOX_HTTP_STREAM_LINE_MAX_CHARS} characters`,
-          null,
-        );
-      }
-    });
-    params.child.stderr.setEncoding("utf8");
-    params.child.stderr.on("data", (chunk: string) => {
-      stderr = sliceUtf16Safe(`${stderr}${chunk}`, -4096);
-    });
-    // A stream error before headers would leave the request unsettled if the
-    // child stays alive.  Settle the request immediately but do NOT finalize
-    // the backend lease yet: the child process may still be running, and
-    // finalizeExec must stay owned by the close handler so the lease is held
-    // for the full process lifetime.  The outer no-op listener on the same
-    // stream prevents the EventEmitter from throwing before this listener fires.
-    const streamErrorToFail = (error: Error) => {
-      if (failed) {
-        return;
-      }
-      failed = true;
-      streamFailure = `sandbox http/request output stream error: ${error.message}`;
-      if (headerResolved) {
-        sendHttpBodyDelta(params.socket, {
-          requestId: params.requestId,
-          seq: lastBodySeq + 1,
-          deltaBase64: "",
-          done: true,
-          error: streamFailure,
-        });
-      } else {
-        reject(new Error(streamFailure));
-      }
-      params.child.kill("SIGTERM");
-    };
-    params.child.stdout.on("error", streamErrorToFail);
-    params.child.stderr.on("error", streamErrorToFail);
-    params.child.once("error", (error) => {
-      // ChildProcess error can precede close while the helper is still alive.
-      // Keep its backend lease until close provides the terminal exit state.
-      childFailure ??= error.message;
-    });
-    params.child.once("close", (code) => {
-      const exitCode = code ?? 1;
-      // Stream failures settle the request early but keep the lease until close.
-      // Finalize now that the child has actually exited.
-      if (streamFailure) {
-        void finalize("failed", exitCode).catch((error: unknown) => {
-          embeddedAgentLog.warn("codex sandbox http/request finalize failed", { error });
-        });
-        return;
-      }
-      if (failed) {
-        return;
-      }
-      if (childFailure) {
-        fail(childFailure, exitCode);
-        return;
-      }
-      if (exitCode === 0) {
-        void finalize("completed", exitCode).catch((error: unknown) => {
-          embeddedAgentLog.warn("codex sandbox http/request finalize failed", { error });
-        });
-        if (!headerResolved) {
-          reject(new Error("sandbox http/request exited before returning headers"));
-        }
-        return;
-      }
-      fail(stderr.trim() || `sandbox http/request failed with code ${exitCode}`, exitCode);
-    });
   });
 }
 
@@ -522,31 +362,3 @@ if __name__ == "__main__":
 PY
 python3 "$tmp"
 `.trim();
-
-function sendHttpBodyDelta(
-  socket: WebSocket,
-  params: {
-    requestId: string;
-    seq: number;
-    deltaBase64: string;
-    done: boolean;
-    error?: string | null;
-  },
-): void {
-  if (socket.readyState !== 1) {
-    return;
-  }
-  socket.send(
-    JSON.stringify({
-      jsonrpc: "2.0",
-      method: "http/request/bodyDelta",
-      params: {
-        requestId: params.requestId,
-        seq: params.seq,
-        deltaBase64: params.deltaBase64,
-        done: params.done,
-        error: params.error ?? null,
-      },
-    }),
-  );
-}

--- a/extensions/codex/src/app-server/sandbox-exec-server/http.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/http.ts
@@ -259,6 +259,15 @@ function readStreamingSandboxHttpResponse(params: {
     params.child.stderr.on("data", (chunk: string) => {
       stderr = sliceUtf16Safe(`${stderr}${chunk}`, -4096);
     });
+    // A stream error before headers would leave the request unsettled if the
+    // child stays alive; route it through fail() so the response lifecycle
+    // settles exactly once.  The outer no-op listener on the same stream
+    // prevents the EventEmitter from throwing before this listener fires.
+    const streamErrorToFail = (error: Error) => {
+      fail(`sandbox http/request output stream error: ${error.message}`, null);
+    };
+    params.child.stdout.on("error", streamErrorToFail);
+    params.child.stderr.on("error", streamErrorToFail);
     params.child.once("error", (error) => {
       // ChildProcess error can precede close while the helper is still alive.
       // Keep its backend lease until close provides the terminal exit state.

--- a/extensions/codex/src/app-server/sandbox-exec-server/http.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/http.ts
@@ -280,9 +280,10 @@ function readStreamingSandboxHttpResponse(params: {
           done: true,
           error: streamFailure,
         });
-        return;
+      } else {
+        reject(new Error(streamFailure));
       }
-      reject(new Error(streamFailure));
+      params.child.kill("SIGTERM");
     };
     params.child.stdout.on("error", streamErrorToFail);
     params.child.stderr.on("error", streamErrorToFail);

--- a/extensions/codex/src/app-server/sandbox-exec-server/http.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/http.ts
@@ -267,7 +267,9 @@ function readStreamingSandboxHttpResponse(params: {
     // for the full process lifetime.  The outer no-op listener on the same
     // stream prevents the EventEmitter from throwing before this listener fires.
     const streamErrorToFail = (error: Error) => {
-      if (failed) return;
+      if (failed) {
+        return;
+      }
       failed = true;
       streamFailure = `sandbox http/request output stream error: ${error.message}`;
       if (headerResolved) {

--- a/extensions/codex/src/app-server/sandbox-exec-server/http.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/http.ts
@@ -142,6 +142,13 @@ async function runStreamingSandboxHttpRequest(
     }
     throw error;
   }
+
+  // Output pipes may fail independently while the process is running; a broken
+  // stdout/stderr pipe must not surface as a process-fatal unhandled error.
+  const ignoreOutputStreamError = () => {};
+  child.stdout.on("error", ignoreOutputStreamError);
+  child.stderr.on("error", ignoreOutputStreamError);
+
   const abortOnSocketClose = () => child.kill("SIGTERM");
   socket.once("close", abortOnSocketClose);
   child.once("close", () => {

--- a/extensions/codex/src/app-server/sandbox-exec-server/http.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/http.ts
@@ -181,6 +181,7 @@ function readStreamingSandboxHttpResponse(params: {
     let headerResolved = false;
     let failed = false;
     let childFailure: string | null = null;
+    let streamFailure: string | null = null;
     let lastBodySeq = 0;
     let stdoutBuffer = "";
     let stderr = "";
@@ -260,11 +261,26 @@ function readStreamingSandboxHttpResponse(params: {
       stderr = sliceUtf16Safe(`${stderr}${chunk}`, -4096);
     });
     // A stream error before headers would leave the request unsettled if the
-    // child stays alive; route it through fail() so the response lifecycle
-    // settles exactly once.  The outer no-op listener on the same stream
-    // prevents the EventEmitter from throwing before this listener fires.
+    // child stays alive.  Settle the request immediately but do NOT finalize
+    // the backend lease yet: the child process may still be running, and
+    // finalizeExec must stay owned by the close handler so the lease is held
+    // for the full process lifetime.  The outer no-op listener on the same
+    // stream prevents the EventEmitter from throwing before this listener fires.
     const streamErrorToFail = (error: Error) => {
-      fail(`sandbox http/request output stream error: ${error.message}`, null);
+      if (failed) return;
+      failed = true;
+      streamFailure = `sandbox http/request output stream error: ${error.message}`;
+      if (headerResolved) {
+        sendHttpBodyDelta(params.socket, {
+          requestId: params.requestId,
+          seq: lastBodySeq + 1,
+          deltaBase64: "",
+          done: true,
+          error: streamFailure,
+        });
+        return;
+      }
+      reject(new Error(streamFailure));
     };
     params.child.stdout.on("error", streamErrorToFail);
     params.child.stderr.on("error", streamErrorToFail);
@@ -275,6 +291,14 @@ function readStreamingSandboxHttpResponse(params: {
     });
     params.child.once("close", (code) => {
       const exitCode = code ?? 1;
+      // Stream failures settle the request early but keep the lease until close.
+      // Finalize now that the child has actually exited.
+      if (streamFailure) {
+        void finalize("failed", exitCode).catch((error: unknown) => {
+          embeddedAgentLog.warn("codex sandbox http/request finalize failed", { error });
+        });
+        return;
+      }
       if (failed) {
         return;
       }

--- a/extensions/codex/src/app-server/sandbox-exec-server/output-stream-errors.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/output-stream-errors.ts
@@ -1,0 +1,18 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+
+export function ignoreChildOutputStreamErrors(child: ChildProcessWithoutNullStreams): void {
+  const ignoreOutputStreamError = () => {};
+  child.stdout.on("error", ignoreOutputStreamError);
+  child.stderr.on("error", ignoreOutputStreamError);
+}
+
+export function onChildOutputStreamError(
+  child: ChildProcessWithoutNullStreams,
+  onError: (message: string) => void,
+): void {
+  const streamErrorToFail = (error: Error) => {
+    onError(`sandbox http/request output stream error: ${error.message}`);
+  };
+  child.stdout.on("error", streamErrorToFail);
+  child.stderr.on("error", streamErrorToFail);
+}

--- a/extensions/codex/src/app-server/sandbox-exec-server/output-stream-errors.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/output-stream-errors.ts
@@ -1,5 +1,12 @@
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 
+const OUTPUT_STREAM_TERMINATION_GRACE_MS = 5_000;
+const forceKillTimers = new WeakMap<
+  ChildProcessWithoutNullStreams,
+  ReturnType<typeof setTimeout>
+>();
+
+/** Covers the spawn-to-response-reader handoff before an operation-specific handler is attached. */
 export function ignoreChildOutputStreamErrors(child: ChildProcessWithoutNullStreams): void {
   const ignoreOutputStreamError = () => {};
   child.stdout.on("error", ignoreOutputStreamError);
@@ -9,10 +16,40 @@ export function ignoreChildOutputStreamErrors(child: ChildProcessWithoutNullStre
 export function onChildOutputStreamError(
   child: ChildProcessWithoutNullStreams,
   onError: (message: string) => void,
+  operation = "sandbox http/request",
 ): void {
   const streamErrorToFail = (error: Error) => {
-    onError(`sandbox http/request output stream error: ${error.message}`);
+    onError(`${operation} output stream error: ${error.message}`);
   };
   child.stdout.on("error", streamErrorToFail);
   child.stderr.on("error", streamErrorToFail);
+}
+
+/** Requests graceful termination, then bounds the wait for the child close event. */
+export function terminateChildWithEscalation(child: ChildProcessWithoutNullStreams): void {
+  if (forceKillTimers.has(child)) {
+    return;
+  }
+  const clearForceKill = () => {
+    const timer = forceKillTimers.get(child);
+    if (timer) {
+      clearTimeout(timer);
+    }
+    forceKillTimers.delete(child);
+  };
+  child.once("close", clearForceKill);
+  child.kill("SIGTERM");
+  const forceKillTimer = setTimeout(() => {
+    forceKillTimers.delete(child);
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGKILL");
+    }
+    // A wrapper can exit while descendants retain its inherited descriptors.
+    // Closing the failed delivery streams bounds the wait for ChildProcess
+    // `close`, which remains the sole backend-finalization owner.
+    child.stdout.destroy();
+    child.stderr.destroy();
+  }, OUTPUT_STREAM_TERMINATION_GRACE_MS);
+  forceKillTimers.set(child, forceKillTimer);
+  forceKillTimer.unref?.();
 }

--- a/extensions/codex/src/app-server/sandbox-exec-server/processes.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/processes.ts
@@ -124,6 +124,10 @@ async function runProcess(
     throw error;
   }
   managed.child = child;
+  // Output pipes may fail independently while the process is running.
+  const ignoreOutputStreamError = () => {};
+  child.stdout.on("error", ignoreOutputStreamError);
+  child.stderr.on("error", ignoreOutputStreamError);
   const abortListener = () => child.kill("SIGTERM");
   managed.abortController.signal.addEventListener("abort", abortListener, { once: true });
   child.stdout.on("data", (chunk: Buffer) =>

--- a/extensions/codex/src/app-server/sandbox-exec-server/processes.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/processes.ts
@@ -7,6 +7,7 @@ import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { WebSocket } from "ws";
 import type { JsonObject, JsonValue } from "../protocol.js";
 import { requireObject, requireString, requireStringArray } from "./json-rpc.js";
+import { onChildOutputStreamError, terminateChildWithEscalation } from "./output-stream-errors.js";
 import { resolveExecServerPath } from "./path-uri.js";
 import type { ManagedProcess, OpenClawExecServer, ProcessChunk } from "./types.js";
 
@@ -124,10 +125,14 @@ async function runProcess(
     throw error;
   }
   managed.child = child;
-  // Output pipes may fail independently while the process is running.
-  const ignoreOutputStreamError = () => {};
-  child.stdout.on("error", ignoreOutputStreamError);
-  child.stderr.on("error", ignoreOutputStreamError);
+  onChildOutputStreamError(
+    child,
+    (message) => {
+      recordProcessFailure(managed, message);
+      terminateChildWithEscalation(child);
+    },
+    "sandbox process",
+  );
   const abortListener = () => child.kill("SIGTERM");
   managed.abortController.signal.addEventListener("abort", abortListener, { once: true });
   child.stdout.on("data", (chunk: Buffer) =>
@@ -137,8 +142,7 @@ async function runProcess(
   child.once("error", (error) => {
     // Node can report an abort or transport error before the child exits. The
     // backend lease and Codex terminal notifications stay owned until close.
-    managed.failure ??= error.message;
-    notifyProcessWaiters(managed);
+    recordProcessFailure(managed, error.message);
   });
   child.once("close", (code) => {
     managed.abortController.signal.removeEventListener("abort", abortListener);
@@ -147,6 +151,14 @@ async function runProcess(
   if (!managed.tty && !managed.pipeStdin) {
     child.stdin.end();
   }
+}
+
+function recordProcessFailure(managed: ManagedProcess, message: string): void {
+  if (managed.failure) {
+    return;
+  }
+  managed.failure = message;
+  notifyProcessWaiters(managed);
 }
 
 function throwIfProcessStartCancelled(managed: ManagedProcess): void {
@@ -191,15 +203,19 @@ function appendProcessChunk(
 
 function emitProcessClosed(managed: ManagedProcess, exitCode: number | null): void {
   if (!managed.exited) {
+    // Polling clients receive the detailed failure through process/read. Pushed
+    // lifecycle consumers have no per-process failure notification in the
+    // current protocol, so never let a delivery failure look like a clean exit.
+    const effectiveExitCode = managed.failure && exitCode === 0 ? 1 : exitCode;
     const exitSeq = managed.nextSeq;
     managed.nextSeq += 1;
-    managed.exitCode = exitCode;
+    managed.exitCode = effectiveExitCode;
     managed.exited = true;
-    if (exitCode !== null) {
+    if (effectiveExitCode !== null) {
       managed.emitNotification("process/exited", {
         processId: managed.processId,
         seq: exitSeq,
-        exitCode,
+        exitCode: effectiveExitCode,
       });
     }
   }

--- a/extensions/codex/src/app-server/sandbox-exec-server/streaming-response.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/streaming-response.ts
@@ -1,0 +1,177 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
+import type { SandboxContext } from "openclaw/plugin-sdk/sandbox";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import type { WebSocket } from "ws";
+import type { JsonObject, JsonValue } from "../protocol.js";
+import { readHttpHeaders, requireNumber, requireObject, requireString } from "./json-rpc.js";
+import { onChildOutputStreamError } from "./output-stream-errors.js";
+
+const SANDBOX_HTTP_STREAM_LINE_MAX_CHARS = 256 * 1024;
+
+export function readStreamingSandboxHttpResponse(params: {
+  child: ChildProcessWithoutNullStreams;
+  execSpec: { finalizeToken?: unknown };
+  finalizeExec?: NonNullable<SandboxContext["backend"]>["finalizeExec"];
+  requestId: string;
+  socket: WebSocket;
+}): Promise<JsonObject> {
+  return new Promise((resolve, reject) => {
+    let headerResolved = false;
+    let failed = false;
+    let childFailure: string | null = null;
+    let streamFailure: string | null = null;
+    let lastBodySeq = 0;
+    let stdoutBuffer = "";
+    let stderr = "";
+    const finalize = async (status: "completed" | "failed", exitCode: number | null) => {
+      await params.finalizeExec?.({
+        status,
+        exitCode,
+        timedOut: false,
+        token: params.execSpec.finalizeToken,
+      });
+    };
+    const fail = (message: string, exitCode: number | null) => {
+      if (failed) {
+        return;
+      }
+      failed = true;
+      void finalize("failed", exitCode).catch((error: unknown) => {
+        embeddedAgentLog.warn("codex sandbox http/request finalize failed", { error });
+      });
+      if (headerResolved) {
+        sendHttpBodyDelta(params.socket, {
+          requestId: params.requestId,
+          seq: lastBodySeq + 1,
+          deltaBase64: "",
+          done: true,
+          error: message,
+        });
+        return;
+      }
+      reject(new Error(message));
+    };
+    params.child.stdout.on("data", (chunk: Buffer) => {
+      stdoutBuffer += chunk.toString("utf8");
+      let newline = stdoutBuffer.indexOf("\n");
+      while (newline >= 0) {
+        const line = stdoutBuffer.slice(0, newline).trim();
+        stdoutBuffer = stdoutBuffer.slice(newline + 1);
+        if (line) {
+          try {
+            const message = requireObject(JSON.parse(line) as JsonValue, "http stream message");
+            const type = requireString(message.type, "http stream message type");
+            if (type === "headers") {
+              headerResolved = true;
+              resolve({
+                status: requireNumber(message.status, "http status"),
+                headers: readHttpHeaders(message.headers),
+                bodyBase64: "",
+              });
+            } else if (type === "bodyDelta") {
+              const seq = requireNumber(message.seq, "http body sequence");
+              lastBodySeq = Math.max(lastBodySeq, seq);
+              sendHttpBodyDelta(params.socket, {
+                requestId: params.requestId,
+                seq,
+                deltaBase64: typeof message.deltaBase64 === "string" ? message.deltaBase64 : "",
+                done: message.done === true,
+                error: typeof message.error === "string" ? message.error : null,
+              });
+            }
+          } catch (error) {
+            fail(error instanceof Error ? error.message : String(error), null);
+          }
+        }
+        newline = stdoutBuffer.indexOf("\n");
+      }
+      if (stdoutBuffer.length > SANDBOX_HTTP_STREAM_LINE_MAX_CHARS) {
+        params.child.kill("SIGKILL");
+        fail(
+          `sandbox http/request produced an unterminated stdout line longer than ${SANDBOX_HTTP_STREAM_LINE_MAX_CHARS} characters`,
+          null,
+        );
+      }
+    });
+    params.child.stderr.on("data", (chunk: Buffer) => {
+      stderr = sliceUtf16Safe(`${stderr}${chunk.toString("utf8")}`, -4096);
+    });
+    onChildOutputStreamError(params.child, (message) => {
+      if (failed) {
+        return;
+      }
+      failed = true;
+      streamFailure = message;
+      if (headerResolved) {
+        sendHttpBodyDelta(params.socket, {
+          requestId: params.requestId,
+          seq: lastBodySeq + 1,
+          deltaBase64: "",
+          done: true,
+          error: streamFailure,
+        });
+      } else {
+        reject(new Error(streamFailure));
+      }
+      params.child.kill("SIGTERM");
+    });
+    params.child.once("error", (error) => {
+      childFailure ??= error.message;
+    });
+    params.child.once("close", (code) => {
+      const exitCode = code ?? 1;
+      if (streamFailure) {
+        void finalize("failed", exitCode).catch((error: unknown) => {
+          embeddedAgentLog.warn("codex sandbox http/request finalize failed", { error });
+        });
+        return;
+      }
+      if (failed) {
+        return;
+      }
+      if (childFailure) {
+        fail(childFailure, exitCode);
+        return;
+      }
+      if (exitCode === 0) {
+        void finalize("completed", exitCode).catch((error: unknown) => {
+          embeddedAgentLog.warn("codex sandbox http/request finalize failed", { error });
+        });
+        if (!headerResolved) {
+          reject(new Error("sandbox http/request exited before returning headers"));
+        }
+        return;
+      }
+      fail(stderr.trim() || `sandbox http/request failed with code ${exitCode}`, exitCode);
+    });
+  });
+}
+
+function sendHttpBodyDelta(
+  socket: WebSocket,
+  params: {
+    requestId: string;
+    seq: number;
+    deltaBase64: string;
+    done: boolean;
+    error?: string | null;
+  },
+): void {
+  if (socket.readyState !== 1) {
+    return;
+  }
+  socket.send(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      method: "http/request/bodyDelta",
+      params: {
+        requestId: params.requestId,
+        seq: params.seq,
+        deltaBase64: params.deltaBase64,
+        done: params.done,
+        error: params.error ?? null,
+      },
+    }),
+  );
+}

--- a/extensions/codex/src/app-server/sandbox-exec-server/streaming-response.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/streaming-response.ts
@@ -23,7 +23,9 @@ export function readStreamingSandboxHttpResponse(params: {
     let streamFailure: string | null = null;
     let lastBodySeq = 0;
     let stdoutBuffer = "";
+    const stdoutDecoder = new TextDecoder();
     let stderr = "";
+    const stderrDecoder = new TextDecoder();
     const finalizeOnClose = async (status: "completed" | "failed", exitCode: number | null) => {
       await params.finalizeExec?.({
         status,
@@ -58,7 +60,7 @@ export function readStreamingSandboxHttpResponse(params: {
       }
     };
     params.child.stdout.on("data", (chunk: Buffer) => {
-      stdoutBuffer += chunk.toString("utf8");
+      stdoutBuffer += stdoutDecoder.decode(chunk, { stream: true });
       let newline = stdoutBuffer.indexOf("\n");
       while (newline >= 0) {
         const line = stdoutBuffer.slice(0, newline).trim();
@@ -101,7 +103,7 @@ export function readStreamingSandboxHttpResponse(params: {
       }
     });
     params.child.stderr.on("data", (chunk: Buffer) => {
-      stderr = sliceUtf16Safe(`${stderr}${chunk.toString("utf8")}`, -4096);
+      stderr = sliceUtf16Safe(`${stderr}${stderrDecoder.decode(chunk, { stream: true })}`, -4096);
     });
     onChildOutputStreamError(params.child, (message) => {
       if (failed) {
@@ -126,6 +128,8 @@ export function readStreamingSandboxHttpResponse(params: {
       childFailure ??= error.message;
     });
     params.child.once("close", (code) => {
+      stdoutBuffer += stdoutDecoder.decode();
+      stderr = sliceUtf16Safe(`${stderr}${stderrDecoder.decode()}`, -4096);
       const exitCode = code ?? 1;
       if (streamFailure) {
         finalizeAfterClose("failed", exitCode);

--- a/extensions/codex/src/app-server/sandbox-exec-server/streaming-response.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/streaming-response.ts
@@ -24,7 +24,7 @@ export function readStreamingSandboxHttpResponse(params: {
     let lastBodySeq = 0;
     let stdoutBuffer = "";
     let stderr = "";
-    const finalize = async (status: "completed" | "failed", exitCode: number | null) => {
+    const finalizeOnClose = async (status: "completed" | "failed", exitCode: number | null) => {
       await params.finalizeExec?.({
         status,
         exitCode,
@@ -32,14 +32,16 @@ export function readStreamingSandboxHttpResponse(params: {
         token: params.execSpec.finalizeToken,
       });
     };
-    const fail = (message: string, exitCode: number | null) => {
+    const finalizeAfterClose = (status: "completed" | "failed", exitCode: number | null) => {
+      void finalizeOnClose(status, exitCode).catch((error: unknown) => {
+        embeddedAgentLog.warn("codex sandbox http/request finalize failed", { error });
+      });
+    };
+    const fail = (message: string, exitCode: number | null, terminateChild = exitCode === null) => {
       if (failed) {
         return;
       }
       failed = true;
-      void finalize("failed", exitCode).catch((error: unknown) => {
-        embeddedAgentLog.warn("codex sandbox http/request finalize failed", { error });
-      });
       if (headerResolved) {
         sendHttpBodyDelta(params.socket, {
           requestId: params.requestId,
@@ -48,9 +50,12 @@ export function readStreamingSandboxHttpResponse(params: {
           done: true,
           error: message,
         });
-        return;
+      } else {
+        reject(new Error(message));
       }
-      reject(new Error(message));
+      if (terminateChild) {
+        params.child.kill("SIGTERM");
+      }
     };
     params.child.stdout.on("data", (chunk: Buffer) => {
       stdoutBuffer += chunk.toString("utf8");
@@ -91,6 +96,7 @@ export function readStreamingSandboxHttpResponse(params: {
         fail(
           `sandbox http/request produced an unterminated stdout line longer than ${SANDBOX_HTTP_STREAM_LINE_MAX_CHARS} characters`,
           null,
+          false,
         );
       }
     });
@@ -122,28 +128,27 @@ export function readStreamingSandboxHttpResponse(params: {
     params.child.once("close", (code) => {
       const exitCode = code ?? 1;
       if (streamFailure) {
-        void finalize("failed", exitCode).catch((error: unknown) => {
-          embeddedAgentLog.warn("codex sandbox http/request finalize failed", { error });
-        });
+        finalizeAfterClose("failed", exitCode);
         return;
       }
       if (failed) {
+        finalizeAfterClose("failed", exitCode);
         return;
       }
       if (childFailure) {
-        fail(childFailure, exitCode);
+        fail(childFailure, exitCode, false);
+        finalizeAfterClose("failed", exitCode);
         return;
       }
       if (exitCode === 0) {
-        void finalize("completed", exitCode).catch((error: unknown) => {
-          embeddedAgentLog.warn("codex sandbox http/request finalize failed", { error });
-        });
+        finalizeAfterClose("completed", exitCode);
         if (!headerResolved) {
           reject(new Error("sandbox http/request exited before returning headers"));
         }
         return;
       }
-      fail(stderr.trim() || `sandbox http/request failed with code ${exitCode}`, exitCode);
+      fail(stderr.trim() || `sandbox http/request failed with code ${exitCode}`, exitCode, false);
+      finalizeAfterClose("failed", exitCode);
     });
   });
 }

--- a/extensions/codex/src/app-server/sandbox-exec-server/streaming-response.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/streaming-response.ts
@@ -98,7 +98,6 @@ export function readStreamingSandboxHttpResponse(params: {
         fail(
           `sandbox http/request produced an unterminated stdout line longer than ${SANDBOX_HTTP_STREAM_LINE_MAX_CHARS} characters`,
           null,
-          false,
         );
       }
     });

--- a/extensions/codex/src/app-server/sandbox-exec-server/streaming-response.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/streaming-response.ts
@@ -5,7 +5,7 @@ import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { WebSocket } from "ws";
 import type { JsonObject, JsonValue } from "../protocol.js";
 import { readHttpHeaders, requireNumber, requireObject, requireString } from "./json-rpc.js";
-import { onChildOutputStreamError } from "./output-stream-errors.js";
+import { onChildOutputStreamError, terminateChildWithEscalation } from "./output-stream-errors.js";
 
 const SANDBOX_HTTP_STREAM_LINE_MAX_CHARS = 256 * 1024;
 
@@ -56,7 +56,7 @@ export function readStreamingSandboxHttpResponse(params: {
         reject(new Error(message));
       }
       if (terminateChild) {
-        params.child.kill("SIGTERM");
+        terminateChildWithEscalation(params.child);
       }
     };
     params.child.stdout.on("data", (chunk: Buffer) => {
@@ -122,7 +122,7 @@ export function readStreamingSandboxHttpResponse(params: {
       } else {
         reject(new Error(streamFailure));
       }
-      params.child.kill("SIGTERM");
+      terminateChildWithEscalation(params.child);
     });
     params.child.once("error", (error) => {
       childFailure ??= error.message;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where stdout or stderr pipe errors from Codex sandbox subprocesses could become unhandled Node stream errors and crash the exec-server WebSocket bridge.

## Why This Change Was Made

Both sandbox subprocess owners now fail output delivery errors instead of silently swallowing them. The process-RPC path terminates the affected child, preserves contiguous lifecycle notifications, and prevents a delivery failure from appearing as a successful exit. The streaming HTTP path settles the response, terminates the helper with bounded SIGTERM-to-SIGKILL escalation, and leaves child close as the sole backend-finalization owner.

## User Impact

Codex sandbox process and streaming HTTP work no longer take down the bridge or hang indefinitely when an output pipe fails. Other work on the bridge remains usable, and execution leases are finalized exactly once after the affected child closes.

## Evidence

- Rebased against `openclaw/openclaw@cad499d7ca0654b6bb8ae03af7e870eda413f215`; current head is `cef1d1698a704cd7e5ad7c4f273cae97e2195867`.
- Process-RPC regression: induced stdout and stderr errors on the production child pipes; `process/read` returned the detailed failure, pushed lifecycle events stayed contiguous and reported exit code 1, the WebSocket stayed open, and follow-up work succeeded.
- Before fix / negative control: removing the production stdout error listener reproduced an uncaught `EPIPE` and process exit code 1.
- After fix / real path: the same induced `EPIPE` rejected the affected operation, left the WebSocket open, and allowed a follow-up process to complete.
- Descendant topology regression: a wrapper exited on SIGTERM while a descendant retained its output pipes; the bounded fallback destroyed the failed delivery streams and allowed child close to settle.
- Focused suite: 4 files and 44 tests passed with `node scripts/run-vitest.mjs extensions/codex/src/app-server/sandbox-exec-server.pipe-survival.test.ts extensions/codex/src/app-server/sandbox-exec-server.http.test.ts extensions/codex/src/app-server/sandbox-exec-server.lifecycle.test.ts extensions/codex/src/app-server/sandbox-exec-server.test.ts`.
- Extension test type gate passed with `pnpm tsgo:extensions:test`.
- The full `run-attempt.test.ts` file passed 117/117 after rebase. The CI-equivalent 12-file, two-worker changed-test plan also passed after giving the contended custom-provider startup test a 150-second diagnostic wait inside a 180-second test timeout.
- The oversized-line failure path now uses the same bounded close escalation; its HTTP and descendant-pipe regression files passed 13/13 after the review fix.
- Exact-head real-child proof was rerun after rebase on `cef1d1698a704cd7e5ad7c4f273cae97e2195867`; the transcript below shows the failed request settled, the WebSocket remained open before child close, finalization stayed at zero before close, bounded escalation reached `SIGKILL`, and finalization ran exactly once afterward.
- Codex lifecycle contract verified against pinned sibling source `openai/codex@ee0247f95a6fe2b094ba2253d82cae2a2b4c2dff`. The excerpts below show `process_exec_processor.rs` waits for process exit, gives stdout/stderr readers a bounded drain grace period, awaits both output collectors, and only then sends `process/exited`; `process.rs` documents `process/outputDelta` as the streaming notification and `process/exited` as the terminal one. This PR preserves that ordering on both sandbox owners: `processes.ts` emits `process/exited` only from the child `close` handler after recording a delivery failure, and `streaming-response.ts` invokes backend finalization only inside the child `close` handler, after the stream-error path settles the response and requests bounded SIGTERM-to-SIGKILL escalation (`output-stream-errors.ts`).

```text
stream-error rejected=true
stream-error message=sandbox http/request output stream error: EPIPE: induced stdout failure
stream-error socketOpenBeforeClose=true
stream-error finalizeBeforeClose=0
stream-error closeSignal=SIGKILL
stream-error finalizeAfterClose=1
stream-error finalizeStatus={"status":"failed","exitCode":1,"timedOut":false,"token":"stream-error-token"}
malformed rejected=true
malformed socketOpenBeforeClose=true
malformed finalizeBeforeClose=0
malformed closeSignal=SIGKILL
malformed finalizeAfterClose=1
malformed finalizeStatus={"status":"failed","exitCode":1,"timedOut":false,"token":"malformed-token"}
```

<details>
<summary>codex-lifecycle-contract</summary>

`openai/codex@ee0247f95a6fe2b094ba2253d82cae2a2b4c2dff`, `codex-rs/app-server/src/request_processors/process_exec_processor.rs` lines 583-605:

```rust
    // Give stdout/stderr readers a bounded grace period to drain after process exit.
    let timeout_handle = tokio::spawn(async move {
        tokio::time::sleep(Duration::from_millis(IO_DRAIN_TIMEOUT_MS)).await;
        let _ = stdio_timeout_tx.send(true);
    });

    let stdout = stdout_handle.await.unwrap_or_default();
    let stderr = stderr_handle.await.unwrap_or_default();
    timeout_handle.abort();

    outgoing
        .send_server_notification_to_connection_and_wait(
            request_id.connection_id,
            ServerNotification::ProcessExited(ProcessExitedNotification {
                process_handle,
                exit_code,
                stdout: stdout.text,
                stdout_cap_reached: stdout.cap_reached,
                stderr: stderr.text,
                stderr_cap_reached: stderr.cap_reached,
            }),
        )
        .await;
```

`codex-rs/app-server-protocol/src/protocol/v2/process.rs` lines 22-24 and 46-48:

```rust
/// `process/spawn` returns after the process has started and the connection-scoped
/// `processHandle` has been registered. Process output and exit are reported via
/// `process/outputDelta` and `process/exited` notifications.
...
/// Stream stdout/stderr via `process/outputDelta` notifications.
///
/// Streamed bytes are not duplicated into the `process/exited` notification.
```

</details>

<details>
<summary>proof-live.ts</summary>

```ts
import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
import { once } from "node:events";
import { WebSocket, WebSocketServer } from "ws";
import { readStreamingSandboxHttpResponse } from "./extensions/codex/src/app-server/sandbox-exec-server/streaming-response.ts";

async function socketPair(): Promise<{
  client: WebSocket;
  server: WebSocket;
  wss: WebSocketServer;
}> {
  const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
  await once(wss, "listening");
  const address = wss.address();
  if (typeof address === "string" || address === null) {
    throw new Error("unexpected websocket address");
  }
  const client = new WebSocket(`ws://127.0.0.1:${address.port}`);
  const [[server]] = await Promise.all([once(wss, "connection"), once(client, "open")]);
  return { client, server: server as WebSocket, wss };
}

async function closeSocketPair(pair: {
  client: WebSocket;
  server: WebSocket;
  wss: WebSocketServer;
}) {
  pair.client.close();
  pair.server.close();
  pair.wss.close();
}

async function waitForClose(child: ChildProcessWithoutNullStreams): Promise<void> {
  if (child.exitCode !== null || child.signalCode !== null) {
    return;
  }
  await once(child, "close");
}

async function proveStreamErrorCloseFinalizes(): Promise<void> {
  const pair = await socketPair();
  const finalizeCalls: unknown[] = [];
  const child = spawn(process.execPath, [
    "-e",
    "process.on('SIGTERM',function(){});setTimeout(function(){},300000)",
  ]);
  const requestPromise = readStreamingSandboxHttpResponse({
    child,
    execSpec: { finalizeToken: "stream-error-token" },
    finalizeExec: async (record) => {
      finalizeCalls.push(record);
    },
    requestId: "proof-stream-error",
    socket: pair.server,
  });
  await new Promise((resolve) => setTimeout(resolve, 100));
  child.stdout.emit("error", new Error("EPIPE: induced stdout failure"));
  const error = await requestPromise.catch((caught: unknown) => caught);
  console.log(`stream-error rejected=${error instanceof Error}`);
  console.log(`stream-error message=${error instanceof Error ? error.message : String(error)}`);
  console.log(`stream-error socketOpenBeforeClose=${pair.server.readyState === WebSocket.OPEN}`);
  console.log(`stream-error finalizeBeforeClose=${finalizeCalls.length}`);
  await waitForClose(child);
  await new Promise((resolve) => setImmediate(resolve));
  console.log(`stream-error closeSignal=${child.signalCode}`);
  console.log(`stream-error finalizeAfterClose=${finalizeCalls.length}`);
  console.log(`stream-error finalizeStatus=${JSON.stringify(finalizeCalls[0])}`);
  await closeSocketPair(pair);
}

async function proveMalformedOutputCloseFinalizes(): Promise<void> {
  const pair = await socketPair();
  const finalizeCalls: unknown[] = [];
  const child = spawn(process.execPath, [
    "-e",
    "process.on('SIGTERM',function(){});process.stdout.write('not-json\\n');setTimeout(function(){},300000)",
  ]);
  const requestPromise = readStreamingSandboxHttpResponse({
    child,
    execSpec: { finalizeToken: "malformed-token" },
    finalizeExec: async (record) => {
      finalizeCalls.push(record);
    },
    requestId: "proof-malformed-output",
    socket: pair.server,
  });
  const error = await requestPromise.catch((caught: unknown) => caught);
  console.log(`malformed rejected=${error instanceof Error}`);
  console.log(`malformed socketOpenBeforeClose=${pair.server.readyState === WebSocket.OPEN}`);
  console.log(`malformed finalizeBeforeClose=${finalizeCalls.length}`);
  await waitForClose(child);
  await new Promise((resolve) => setImmediate(resolve));
  console.log(`malformed closeSignal=${child.signalCode}`);
  console.log(`malformed finalizeAfterClose=${finalizeCalls.length}`);
  console.log(`malformed finalizeStatus=${JSON.stringify(finalizeCalls[0])}`);
  await closeSocketPair(pair);
}

await proveStreamErrorCloseFinalizes();
await proveMalformedOutputCloseFinalizes();
```

</details>

AI-assisted: built with Codex
