### PR TITLE
fix(discord): dispose fallback timeout abort listeners

### DIFF
--- a/extensions/discord/src/monitor/message-handler.queue.test.ts
+++ b/extensions/discord/src/monitor/message-handler.queue.test.ts
@@ -55,6 +55,20 @@ function createDeferred<T = void>() {
   return { promise, resolve };
 }
 
+async function withNativeAbortSignalAnyDisabled<T>(run: () => Promise<T>): Promise<T> {
+  const descriptor = Object.getOwnPropertyDescriptor(AbortSignal, "any");
+  Object.defineProperty(AbortSignal, "any", { configurable: true, value: undefined });
+  try {
+    return await run();
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(AbortSignal, "any", descriptor);
+    } else {
+      delete (AbortSignal as { any?: unknown }).any;
+    }
+  }
+}
+
 async function flushQueueWork(): Promise<void> {
   for (let i = 0; i < 40; i += 1) {
     await Promise.resolve();
@@ -618,6 +632,49 @@ describe("createDiscordMessageHandler queue behavior", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("disposes fallback run abort listeners after queued processing settles", async () => {
+    await withNativeAbortSignalAnyDisabled(async () => {
+      preflightDiscordMessageMock.mockReset();
+      processDiscordMessageMock.mockReset();
+
+      const jobAbortController = new AbortController();
+      const lifecycleAbortController = new AbortController();
+      const removeListenerSpy = vi.spyOn(jobAbortController.signal, "removeEventListener");
+      let capturedAbortSignal: AbortSignal | undefined;
+      preflightDiscordMessageMock.mockImplementation(
+        async (params: { data: { channel_id: string } }) => ({
+          ...createPreflightContext(params.data.channel_id),
+          abortSignal: jobAbortController.signal,
+        }),
+      );
+      processDiscordMessageMock.mockImplementation(
+        async (ctx: { abortSignal?: AbortSignal }) => {
+          capturedAbortSignal = ctx.abortSignal;
+        },
+      );
+
+      const handler = createDiscordMessageHandler(
+        createDiscordHandlerParams({ abortSignal: lifecycleAbortController.signal }),
+      );
+
+      await expect(
+        handler(createMessageData("m-dispose") as never, {} as never),
+      ).resolves.toBeUndefined();
+      await flushQueueWork();
+
+      expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+      expect(capturedAbortSignal).toBeDefined();
+      expect(capturedAbortSignal).not.toBe(jobAbortController.signal);
+      expect(capturedAbortSignal?.aborted).toBe(false);
+      expect(removeListenerSpy).toHaveBeenCalledWith("abort", expect.any(Function));
+
+      jobAbortController.abort();
+      lifecycleAbortController.abort();
+
+      expect(capturedAbortSignal?.aborted).toBe(false);
+    });
   });
 
   it("refreshes run activity while active runs are in progress", async () => {

--- a/extensions/discord/src/monitor/message-media.ts
+++ b/extensions/discord/src/monitor/message-media.ts
@@ -18,7 +18,7 @@ import {
   resolveDiscordReferencedReplyMessage,
   resolveDiscordSnapshotStickers,
 } from "./message-forwarded.js";
-import { mergeAbortSignals } from "./timeouts.js";
+import { createDisposableMergedAbortSignal } from "./timeouts.js";
 
 const DISCORD_CDN_HOSTNAMES = [
   "cdn.discordapp.com",
@@ -254,7 +254,10 @@ async function fetchDiscordMedia(params: {
   originalFilename?: string;
 }) {
   const timeoutAbortController = params.totalTimeoutMs ? new AbortController() : undefined;
-  const signal = mergeAbortSignals([params.abortSignal, timeoutAbortController?.signal]);
+  const mergedAbortSignal = createDisposableMergedAbortSignal([
+    params.abortSignal,
+    timeoutAbortController?.signal,
+  ]);
   let timedOut = false;
   let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
 
@@ -267,7 +270,7 @@ async function fetchDiscordMedia(params: {
     readIdleTimeoutMs: params.readIdleTimeoutMs,
     fallbackContentType: params.fallbackContentType,
     originalFilename: params.originalFilename,
-    ...(signal ? { requestInit: { signal } } : {}),
+    ...(mergedAbortSignal.signal ? { requestInit: { signal: mergedAbortSignal.signal } } : {}),
   }).catch((error: unknown) => {
     if (timedOut) {
       return new Promise<never>(() => {});
@@ -292,6 +295,7 @@ async function fetchDiscordMedia(params: {
     if (timeoutHandle) {
       clearTimeout(timeoutHandle);
     }
+    mergedAbortSignal.dispose();
   }
 }
 

--- a/extensions/discord/src/monitor/message-run-queue.ts
+++ b/extensions/discord/src/monitor/message-run-queue.ts
@@ -12,7 +12,7 @@ import {
 import { materializeDiscordInboundJob, type DiscordInboundJob } from "./inbound-job.js";
 import type { RuntimeEnv } from "./message-handler.preflight.types.js";
 import type { DiscordMonitorStatusSink } from "./status.js";
-import { mergeAbortSignals } from "./timeouts.js";
+import { createDisposableMergedAbortSignal } from "./timeouts.js";
 
 type ProcessDiscordMessage = typeof import("./message-handler.process.js").processDiscordMessage;
 
@@ -48,9 +48,14 @@ async function processDiscordQueuedMessage(params: {
   const processDiscordMessageImpl =
     params.testing?.processDiscordMessage ??
     (await loadMessageProcessRuntime()).processDiscordMessage;
-  const abortSignal = mergeAbortSignals([params.job.runtime.abortSignal, params.lifecycleSignal]);
+  const mergedAbortSignal = createDisposableMergedAbortSignal([
+    params.job.runtime.abortSignal,
+    params.lifecycleSignal,
+  ]);
   try {
-    await processDiscordMessageImpl(materializeDiscordInboundJob(params.job, abortSignal));
+    await processDiscordMessageImpl(
+      materializeDiscordInboundJob(params.job, mergedAbortSignal.signal),
+    );
     await commitDiscordInboundReplay({
       replayKeys: params.job.replayKeys,
       replayGuard: params.replayGuard,
@@ -69,6 +74,8 @@ async function processDiscordQueuedMessage(params: {
       });
     }
     throw error;
+  } finally {
+    mergedAbortSignal.dispose();
   }
 }
 

--- a/extensions/discord/src/monitor/message-utils.test.ts
+++ b/extensions/discord/src/monitor/message-utils.test.ts
@@ -70,6 +70,20 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+async function withNativeAbortSignalAnyDisabled<T>(run: () => Promise<T>): Promise<T> {
+  const descriptor = Object.getOwnPropertyDescriptor(AbortSignal, "any");
+  Object.defineProperty(AbortSignal, "any", { configurable: true, value: undefined });
+  try {
+    return await run();
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(AbortSignal, "any", descriptor);
+    } else {
+      delete (AbortSignal as { any?: unknown }).any;
+    }
+  }
+}
+
 function asMessage(payload: Record<string, unknown>): Message {
   return payload as unknown as Message;
 }
@@ -920,6 +934,53 @@ describe("resolveMediaList", () => {
     ]);
     const requestInit = requireRecord(fetchParams().requestInit, "fetch request init");
     expect(requestInit.signal).toBe(abortController.signal);
+  });
+
+  it("disposes fallback attachment abort listeners after downloads settle", async () => {
+    await withNativeAbortSignalAnyDisabled(async () => {
+      const attachment = {
+        id: "att-dispose",
+        url: "https://cdn.discordapp.com/attachments/1/dispose.png",
+        filename: "dispose.png",
+        content_type: "image/png",
+      };
+      const abortController = new AbortController();
+      const removeListenerSpy = vi.spyOn(abortController.signal, "removeEventListener");
+      readRemoteMediaBuffer.mockResolvedValueOnce({
+        buffer: Buffer.from("image"),
+        contentType: "image/png",
+      });
+      saveMediaBuffer.mockResolvedValueOnce({
+        path: "/tmp/dispose.png",
+        contentType: "image/png",
+      });
+
+      await expect(
+        resolveMediaList(
+          asMessage({
+            attachments: [attachment],
+          }),
+          512,
+          { abortSignal: abortController.signal, totalTimeoutMs: 10_000 },
+        ),
+      ).resolves.toEqual([
+        {
+          path: "/tmp/dispose.png",
+          contentType: "image/png",
+          placeholder: "<media:image>",
+        },
+      ]);
+
+      const requestInit = requireRecord(fetchParams().requestInit, "fetch request init");
+      const requestSignal = requestInit.signal as AbortSignal;
+      expect(requestSignal).not.toBe(abortController.signal);
+      expect(requestSignal.aborted).toBe(false);
+      expect(removeListenerSpy).toHaveBeenCalledWith("abort", expect.any(Function));
+
+      abortController.abort();
+
+      expect(requestSignal.aborted).toBe(false);
+    });
   });
 });
 

--- a/extensions/discord/src/monitor/timeouts.test.ts
+++ b/extensions/discord/src/monitor/timeouts.test.ts
@@ -23,6 +23,34 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+async function withNativeAbortSignalAnyDisabled<T>(run: () => Promise<T>): Promise<T> {
+  const descriptor = Object.getOwnPropertyDescriptor(AbortSignal, "any");
+  Object.defineProperty(AbortSignal, "any", { configurable: true, value: undefined });
+  try {
+    return await run();
+  } finally {
+    if (descriptor) {
+      Object.defineProperty(AbortSignal, "any", descriptor);
+    } else {
+      delete (AbortSignal as typeof AbortSignal & { any?: typeof AbortSignal.any }).any;
+    }
+  }
+}
+
+function findRegisteredAbortListener(addListenerSpy: {
+  mock: {
+    calls: ReadonlyArray<
+      readonly [string, EventListenerOrEventListenerObject | null, ...unknown[]]
+    >;
+  };
+}) {
+  const listener = addListenerSpy.mock.calls.find(([type]) => type === "abort")?.[1];
+  if (typeof listener !== "function") {
+    throw new Error("Expected fallback abort listener to be registered");
+  }
+  return listener;
+}
+
 describe("discord monitor timeouts", () => {
   it("keeps deprecated timeout helpers on the runtime api compatibility surface", () => {
     expect(runtimeApiIsAbortError).toBe(isAbortError);
@@ -79,6 +107,76 @@ describe("discord monitor timeouts", () => {
     expect(receivedSignal?.aborted).toBe(true);
     expect(onTimeout).toHaveBeenCalledWith(MAX_TIMER_TIMEOUT_MS);
     expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+  });
+
+  it("disposes fallback merged abort listeners after completed timeout races settle", async () => {
+    await withNativeAbortSignalAnyDisabled(async () => {
+      const parentAbortController = new AbortController();
+      const addListenerSpy = vi.spyOn(parentAbortController.signal, "addEventListener");
+      const removeListenerSpy = vi.spyOn(parentAbortController.signal, "removeEventListener");
+      const mergedAbortSpy = vi.fn();
+      const onTimeout = vi.fn();
+      let receivedSignal: AbortSignal | undefined;
+
+      await expect(
+        runDiscordTaskWithTimeout({
+          timeoutMs: 1_000,
+          abortSignals: [parentAbortController.signal],
+          onTimeout,
+          run: async (signal) => {
+            receivedSignal = signal;
+            signal?.addEventListener("abort", mergedAbortSpy);
+          },
+        }),
+      ).resolves.toBe(false);
+
+      const fallbackAbortListener = findRegisteredAbortListener(addListenerSpy);
+      expect(removeListenerSpy.mock.calls).toContainEqual(["abort", fallbackAbortListener]);
+
+      parentAbortController.abort();
+
+      expect(onTimeout).not.toHaveBeenCalled();
+      expect(receivedSignal?.aborted).toBe(false);
+      expect(mergedAbortSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not refire fallback merged abort listeners after timeout races settle", async () => {
+    await withNativeAbortSignalAnyDisabled(async () => {
+      vi.useFakeTimers();
+      const parentAbortController = new AbortController();
+      const addListenerSpy = vi.spyOn(parentAbortController.signal, "addEventListener");
+      const removeListenerSpy = vi.spyOn(parentAbortController.signal, "removeEventListener");
+      const mergedAbortSpy = vi.fn();
+      const onTimeout = vi.fn();
+      let receivedSignal: AbortSignal | undefined;
+
+      const task = runDiscordTaskWithTimeout({
+        timeoutMs: 10,
+        abortSignals: [parentAbortController.signal],
+        onTimeout,
+        run: async (signal) => {
+          receivedSignal = signal;
+          signal?.addEventListener("abort", mergedAbortSpy);
+          await new Promise<void>((resolve) => {
+            signal?.addEventListener("abort", () => resolve(), { once: true });
+          });
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(10);
+
+      await expect(task).resolves.toBe(true);
+      const fallbackAbortListener = findRegisteredAbortListener(addListenerSpy);
+      expect(removeListenerSpy.mock.calls).toContainEqual(["abort", fallbackAbortListener]);
+      expect(receivedSignal?.aborted).toBe(true);
+      expect(mergedAbortSpy).toHaveBeenCalledTimes(1);
+
+      parentAbortController.abort();
+
+      expect(onTimeout).toHaveBeenCalledTimes(1);
+      expect(mergedAbortSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("caps raceWithTimeout timers before arming the watchdog", async () => {

--- a/extensions/discord/src/monitor/timeouts.test.ts
+++ b/extensions/discord/src/monitor/timeouts.test.ts
@@ -32,7 +32,7 @@ async function withNativeAbortSignalAnyDisabled<T>(run: () => Promise<T>): Promi
     if (descriptor) {
       Object.defineProperty(AbortSignal, "any", descriptor);
     } else {
-      delete (AbortSignal as typeof AbortSignal & { any?: typeof AbortSignal.any }).any;
+      delete (AbortSignal as { any?: unknown }).any;
     }
   }
 }

--- a/extensions/discord/src/monitor/timeouts.ts
+++ b/extensions/discord/src/monitor/timeouts.ts
@@ -44,7 +44,7 @@ export function mergeAbortSignals(
   return createDisposableMergedAbortSignal(signals).signal;
 }
 
-function createDisposableMergedAbortSignal(signals: Array<AbortSignal | undefined>): {
+export function createDisposableMergedAbortSignal(signals: Array<AbortSignal | undefined>): {
   signal: AbortSignal | undefined;
   dispose: () => void;
 } {

--- a/extensions/discord/src/monitor/timeouts.ts
+++ b/extensions/discord/src/monitor/timeouts.ts
@@ -41,25 +41,42 @@ export function isAbortError(error: unknown): boolean {
 export function mergeAbortSignals(
   signals: Array<AbortSignal | undefined>,
 ): AbortSignal | undefined {
+  return createDisposableMergedAbortSignal(signals).signal;
+}
+
+function createDisposableMergedAbortSignal(signals: Array<AbortSignal | undefined>): {
+  signal: AbortSignal | undefined;
+  dispose: () => void;
+} {
   const activeSignals = signals.filter((signal): signal is AbortSignal => Boolean(signal));
+  const dispose = () => undefined;
   if (activeSignals.length === 0) {
-    return undefined;
+    return { signal: undefined, dispose };
   }
   if (activeSignals.length === 1) {
-    return activeSignals[0];
+    return { signal: activeSignals[0], dispose };
   }
   if (typeof AbortSignal.any === "function") {
-    return AbortSignal.any(activeSignals);
+    return { signal: AbortSignal.any(activeSignals), dispose };
   }
   const fallbackController = new AbortController();
   for (const signal of activeSignals) {
     if (signal.aborted) {
       fallbackController.abort();
-      return fallbackController.signal;
+      return { signal: fallbackController.signal, dispose };
     }
   }
+  let disposed = false;
+  let disposeFallbackListeners = () => undefined;
   const abortFallback = () => {
     fallbackController.abort();
+    disposeFallbackListeners();
+  };
+  disposeFallbackListeners = () => {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
     for (const signal of activeSignals) {
       signal.removeEventListener("abort", abortFallback);
     }
@@ -67,7 +84,7 @@ export function mergeAbortSignals(
   for (const signal of activeSignals) {
     signal.addEventListener("abort", abortFallback, { once: true });
   }
-  return fallbackController.signal;
+  return { signal: fallbackController.signal, dispose: disposeFallbackListeners };
 }
 
 /** @deprecated Discord no longer uses this for channel-owned message run timeouts. */
@@ -82,24 +99,25 @@ export async function runDiscordTaskWithTimeout(params: {
   const timeoutMs =
     params.timeoutMs === undefined ? undefined : resolveTimerTimeoutMs(params.timeoutMs, 0, 0);
   const timeoutAbortController = timeoutMs ? new AbortController() : undefined;
-  const mergedAbortSignal = mergeAbortSignals([
+  const mergedAbortSignal = createDisposableMergedAbortSignal([
     ...(params.abortSignals ?? []),
     timeoutAbortController?.signal,
   ]);
   let timedOut = false;
   let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
-  const runPromise = params.run(mergedAbortSignal).catch((error: unknown) => {
-    if (!timedOut) {
-      throw error;
-    }
-    if (timeoutAbortController?.signal.aborted && isAbortError(error)) {
-      params.onAbortAfterTimeout?.();
-      return;
-    }
-    params.onErrorAfterTimeout?.(error);
-  });
 
   try {
+    const runPromise = params.run(mergedAbortSignal.signal).catch((error: unknown) => {
+      if (!timedOut) {
+        throw error;
+      }
+      if (timeoutAbortController?.signal.aborted && isAbortError(error)) {
+        params.onAbortAfterTimeout?.();
+        return;
+      }
+      params.onErrorAfterTimeout?.(error);
+    });
+
     if (!timeoutMs) {
       await runPromise;
       return false;
@@ -123,6 +141,7 @@ export async function runDiscordTaskWithTimeout(params: {
     if (timeoutHandle) {
       clearTimeout(timeoutHandle);
     }
+    mergedAbortSignal.dispose();
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes fallback abort-signal listener cleanup in the active Discord monitor paths. When native `AbortSignal.any` is unavailable, Discord manually attaches abort listeners to parent signals. The queued message runner and media download path were still using the signal-only helper, so successful monitor work could leave parent signals retaining stale fallback listeners.

## Why This Change Was Made

The fallback merged signal now has an explicit disposer, and the active Discord monitor callers use it directly:

- `message-run-queue.ts` disposes the merged job/lifecycle abort signal in `finally` after queued processing settles.
- `message-media.ts` disposes the merged request/timeout abort signal in `finally` after media download settles.
- `runDiscordTaskWithTimeout` keeps the same disposable cleanup for the deprecated timeout compatibility path.

## User Impact

Long-running Discord monitor processes avoid accumulating stale abort listeners across repeated queued message runs and media downloads on runtimes or test environments that take the fallback merge path.

## Evidence

- Collision check before opening: no open PR modified `extensions/discord/src/monitor/timeouts.ts` or `extensions/discord/src/monitor/timeouts.test.ts`.
- ClawSweeper blocker addressed: the two current signal-only monitor callers it identified are now updated to `createDisposableMergedAbortSignal` and dispose in `finally`.
- `git diff --check`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-discord.config.ts extensions/discord/src/monitor/message-handler.queue.test.ts extensions/discord/src/monitor/message-utils.test.ts extensions/discord/src/monitor/timeouts.test.ts --reporter verbose`

Focused test output:

```text
✓ |extension-discord| extensions/discord/src/monitor/message-handler.queue.test.ts > createDiscordMessageHandler queue behavior > disposes fallback run abort listeners after queued processing settles
✓ |extension-discord| extensions/discord/src/monitor/message-utils.test.ts > resolveMediaList > disposes fallback attachment abort listeners after downloads settle
✓ |extension-discord| extensions/discord/src/monitor/timeouts.test.ts > discord monitor timeouts > disposes fallback merged abort listeners after completed timeout races settle
✓ |extension-discord| extensions/discord/src/monitor/timeouts.test.ts > discord monitor timeouts > does not refire fallback merged abort listeners after timeout races settle

Test Files  3 passed (3)
Tests  81 passed (81)
```

Representative runtime proof, run with `pnpm exec tsx` against the PR branch, not through Vitest: the harness disables native `AbortSignal.any`, creates a real `createDiscordMessageRunQueue`, enqueues a Discord monitor-style job, captures the abort signal passed to `processDiscordMessage`, then aborts the parent signals after queued processing settles.

```text
Discord monitor queue fallback cleanup proof
{
  "nativeAbortSignalAny": "disabled for fallback path",
  "processed": true,
  "parentAbortListenersAdded": 1,
  "parentAbortListenersRemoved": 1,
  "mergedSignalIsFallback": true,
  "mergedSignalBeforeParentAbort": false,
  "mergedSignalAfterParentAbort": false,
  "runtimeErrorCount": 0
}
```

The regression tests and the runtime proof both force the fallback path by temporarily disabling native `AbortSignal.any`. The runtime proof shows the monitor queue path removed the parent abort listener on normal completion, and aborting the parent signal after settlement no longer aborts the captured merged signal.
