### PR TITLE
fix(shared): skip app-group identity migration when OPENCLAW_STATE_DIR is overridden

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentity.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentity.swift
@@ -151,17 +151,22 @@ enum DeviceIdentityPaths {
         self.appGroupMigrationSource(
             appGroupStateDirURL: self.appGroupStateDirURL(),
             appGroupStateDirAvailable: self.appGroupStateDirAvailable,
+            stateDirOverridden: self.stateDirOverrideURL() != nil,
             profile: profile)
     }
 
     /// Non-nil only for unentitled builds whose store selection fell back to legacy storage;
     /// entitled builds keep using the App Group container and must never migrate out of it.
+    /// An explicit OPENCLAW_STATE_DIR override selects a caller-chosen store, not the legacy
+    /// fallback; importing container identity/tokens there would leak the machine's real
+    /// pairing into unrelated stores (test dirs, relocated installs).
     static func appGroupMigrationSource(
         appGroupStateDirURL: URL?,
         appGroupStateDirAvailable: Bool,
+        stateDirOverridden: Bool,
         profile: GatewayDeviceIdentityProfile) -> AppGroupMigrationSource?
     {
-        guard !appGroupStateDirAvailable, let appGroupStateDirURL else {
+        guard !stateDirOverridden, !appGroupStateDirAvailable, let appGroupStateDirURL else {
             return nil
         }
         let identityDirURL = appGroupStateDirURL.appendingPathComponent("identity", isDirectory: true)

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityStoreTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityStoreTests.swift
@@ -12,16 +12,10 @@ struct DeviceIdentityStoreTests {
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         let blocker = tempDir.appendingPathComponent("not-a-directory", isDirectory: false)
         try Data().write(to: blocker)
-        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
+        // Repoint the pinned state dir at a plain file to force write failures;
+        // the isolation trait restores the env var after the test.
         setenv("OPENCLAW_STATE_DIR", blocker.path, 1)
-        defer {
-            if let previousStateDir {
-                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
-            } else {
-                unsetenv("OPENCLAW_STATE_DIR")
-            }
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let compatibleEntry: DeviceAuthEntry = DeviceAuthStore.storeToken(
             deviceId: "unwritable-device",
@@ -39,20 +33,6 @@ struct DeviceIdentityStoreTests {
 
     @Test(.stateDirectoryIsolated)
     func `device auth tokens are isolated by gateway owner`() throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
-        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
-        defer {
-            if let previousStateDir {
-                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
-            } else {
-                unsetenv("OPENCLAW_STATE_DIR")
-            }
-            try? FileManager.default.removeItem(at: tempDir)
-        }
-
         let deviceID = "test-device"
         _ = DeviceAuthStore.storeToken(deviceId: deviceID, role: "node", token: "legacy-token")
         #expect(DeviceAuthStore.loadToken(deviceId: deviceID, role: "node", gatewayID: "gateway-a") == nil)
@@ -92,20 +72,6 @@ struct DeviceIdentityStoreTests {
 
     @Test(.stateDirectoryIsolated)
     func `legacy device auth migration claims only the proven role`() throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
-        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
-        defer {
-            if let previousStateDir {
-                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
-            } else {
-                unsetenv("OPENCLAW_STATE_DIR")
-            }
-            try? FileManager.default.removeItem(at: tempDir)
-        }
-
         let deviceID = "legacy-device"
         _ = DeviceAuthStore.storeToken(
             deviceId: deviceID,
@@ -216,20 +182,6 @@ struct DeviceIdentityStoreTests {
 
     @Test(.stateDirectoryIsolated)
     func `secondary profiles use separate identity and auth files`() throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
-        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
-        defer {
-            if let previousStateDir {
-                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
-            } else {
-                unsetenv("OPENCLAW_STATE_DIR")
-            }
-            try? FileManager.default.removeItem(at: tempDir)
-        }
-
         let primaryIdentity = DeviceIdentityStore.loadOrCreate()
         let nodeIdentity = DeviceIdentityStore.loadOrCreate(profile: .node)
         let shareIdentity = DeviceIdentityStore.loadOrCreate(profile: .shareExtension)
@@ -248,7 +200,11 @@ struct DeviceIdentityStoreTests {
             token: "share-token",
             profile: .shareExtension)
 
-        let identityDir = tempDir.appendingPathComponent("identity", isDirectory: true)
+        // getenv, not ProcessInfo: the trait pins OPENCLAW_STATE_DIR via setenv and
+        // ProcessInfo.environment can serve a stale snapshot on Darwin.
+        let stateDirPath = try #require(getenv("OPENCLAW_STATE_DIR").map { String(cString: $0) })
+        let identityDir = URL(fileURLWithPath: stateDirPath, isDirectory: true)
+            .appendingPathComponent("identity", isDirectory: true)
         #expect(primaryIdentity.deviceId != nodeIdentity.deviceId)
         #expect(primaryIdentity.deviceId != shareIdentity.deviceId)
         #expect(FileManager.default.fileExists(atPath: identityDir.appendingPathComponent("device.json").path))
@@ -407,6 +363,7 @@ struct DeviceIdentityStoreTests {
         let migrationSource = DeviceIdentityPaths.appGroupMigrationSource(
             appGroupStateDirURL: appGroupURL,
             appGroupStateDirAvailable: false,
+            stateDirOverridden: false,
             profile: .primary)
         let identity = DeviceIdentityStore.loadOrCreate(
             fileURL: legacyIdentityURL,
@@ -458,6 +415,7 @@ struct DeviceIdentityStoreTests {
             migrationSource: DeviceIdentityPaths.appGroupMigrationSource(
                 appGroupStateDirURL: tempDir.appendingPathComponent("shared", isDirectory: true),
                 appGroupStateDirAvailable: false,
+                stateDirOverridden: false,
                 profile: .primary))
 
         #expect(identity.deviceId == "56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c")
@@ -493,6 +451,7 @@ struct DeviceIdentityStoreTests {
         let migrationSource = DeviceIdentityPaths.appGroupMigrationSource(
             appGroupStateDirURL: appGroupURL,
             appGroupStateDirAvailable: false,
+            stateDirOverridden: false,
             profile: .primary)
         let identity = DeviceIdentityStore.loadOrCreate(
             fileURL: legacyIdentityURL,
@@ -509,6 +468,21 @@ struct DeviceIdentityStoreTests {
         #expect(DeviceIdentityPaths.appGroupMigrationSource(
             appGroupStateDirURL: appGroupURL,
             appGroupStateDirAvailable: true,
+            stateDirOverridden: false,
+            profile: .primary) == nil)
+    }
+
+    // Regression: an explicit OPENCLAW_STATE_DIR override must never import the
+    // machine's app-group identity/tokens; developer-Mac pairing state leaked
+    // into isolated test state dirs through this migration path.
+    @Test
+    func `provides no app group migration source when the state dir is overridden`() {
+        let appGroupURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        #expect(DeviceIdentityPaths.appGroupMigrationSource(
+            appGroupStateDirURL: appGroupURL,
+            appGroupStateDirAvailable: false,
+            stateDirOverridden: true,
             profile: .primary) == nil)
     }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityStoreTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityStoreTests.swift
@@ -32,7 +32,7 @@ struct DeviceIdentityStoreTests {
     }
 
     @Test(.stateDirectoryIsolated)
-    func `device auth tokens are isolated by gateway owner`() throws {
+    func `device auth tokens are isolated by gateway owner`() {
         let deviceID = "test-device"
         _ = DeviceAuthStore.storeToken(deviceId: deviceID, role: "node", token: "legacy-token")
         #expect(DeviceAuthStore.loadToken(deviceId: deviceID, role: "node", gatewayID: "gateway-a") == nil)
@@ -71,7 +71,7 @@ struct DeviceIdentityStoreTests {
     }
 
     @Test(.stateDirectoryIsolated)
-    func `legacy device auth migration claims only the proven role`() throws {
+    func `legacy device auth migration claims only the proven role`() {
         let deviceID = "legacy-device"
         _ = DeviceAuthStore.storeToken(
             deviceId: deviceID,

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -862,20 +862,6 @@ struct GatewayNodeSessionTests {
 
     @Test(.stateDirectoryIsolated)
     func `scanned setup code prefers bootstrap auth over stored device token`() async throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
-        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
-        defer {
-            if let previousStateDir {
-                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
-            } else {
-                unsetenv("OPENCLAW_STATE_DIR")
-            }
-            try? FileManager.default.removeItem(at: tempDir)
-        }
-
         let identity = DeviceIdentityStore.loadOrCreate()
         _ = DeviceAuthStore.storeToken(
             deviceId: identity.deviceId,
@@ -918,20 +904,6 @@ struct GatewayNodeSessionTests {
 
     @Test(.stateDirectoryIsolated)
     func `credentialless setup handoff does not send a stored device token`() async throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
-        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
-        defer {
-            if let previousStateDir {
-                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
-            } else {
-                unsetenv("OPENCLAW_STATE_DIR")
-            }
-            try? FileManager.default.removeItem(at: tempDir)
-        }
-
         let identity = DeviceIdentityStore.loadOrCreate()
         _ = DeviceAuthStore.storeToken(
             deviceId: identity.deviceId,
@@ -978,20 +950,6 @@ struct GatewayNodeSessionTests {
 
     @Test(.stateDirectoryIsolated)
     func `stored device token cannot cross gateway owner`() async throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
-        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
-        defer {
-            if let previousStateDir {
-                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
-            } else {
-                unsetenv("OPENCLAW_STATE_DIR")
-            }
-            try? FileManager.default.removeItem(at: tempDir)
-        }
-
         let identity = DeviceIdentityStore.loadOrCreate()
         _ = DeviceAuthStore.storeToken(
             deviceId: identity.deviceId,
@@ -1040,20 +998,6 @@ struct GatewayNodeSessionTests {
 
     @Test(.stateDirectoryIsolated)
     func `share extension identity profile uses separate node identity and token store`() async throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
-        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
-        defer {
-            if let previousStateDir {
-                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
-            } else {
-                unsetenv("OPENCLAW_STATE_DIR")
-            }
-            try? FileManager.default.removeItem(at: tempDir)
-        }
-
         let primaryIdentity = DeviceIdentityStore.loadOrCreate()
         _ = DeviceAuthStore.storeToken(
             deviceId: primaryIdentity.deviceId,
@@ -1251,20 +1195,6 @@ struct GatewayNodeSessionTests {
 
     @Test(.stateDirectoryIsolated)
     func `bootstrap hello stores additional device tokens`() async throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
-        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
-        defer {
-            if let previousStateDir {
-                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
-            } else {
-                unsetenv("OPENCLAW_STATE_DIR")
-            }
-            try? FileManager.default.removeItem(at: tempDir)
-        }
-
         let identity = DeviceIdentityStore.loadOrCreate()
         let session = FakeGatewayWebSocketSession(helloAuth: [
             "deviceToken": "node-device-token",
@@ -1336,16 +1266,10 @@ struct GatewayNodeSessionTests {
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         let blocker = tempDir.appendingPathComponent("not-a-directory", isDirectory: false)
         try Data().write(to: blocker)
-        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
+        // Repoint the pinned state dir at a plain file to force write failures;
+        // the isolation trait restores the env var after the test.
         setenv("OPENCLAW_STATE_DIR", blocker.path, 1)
-        defer {
-            if let previousStateDir {
-                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
-            } else {
-                unsetenv("OPENCLAW_STATE_DIR")
-            }
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let session = FakeGatewayWebSocketSession(helloAuth: [
             "deviceToken": "node-device-token",
@@ -1383,20 +1307,6 @@ struct GatewayNodeSessionTests {
 
     @Test(.stateDirectoryIsolated)
     func `non bootstrap hello stores primary device token but not additional bootstrap tokens`() async throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
-        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
-        defer {
-            if let previousStateDir {
-                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
-            } else {
-                unsetenv("OPENCLAW_STATE_DIR")
-            }
-            try? FileManager.default.removeItem(at: tempDir)
-        }
-
         let identity = DeviceIdentityStore.loadOrCreate()
         let session = FakeGatewayWebSocketSession(helloAuth: [
             "deviceToken": "server-node-token",
@@ -1445,20 +1355,6 @@ struct GatewayNodeSessionTests {
 
     @Test(.stateDirectoryIsolated)
     func `untrusted bootstrap hello does not persist bootstrap handoff tokens`() async throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
-        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
-        defer {
-            if let previousStateDir {
-                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
-            } else {
-                unsetenv("OPENCLAW_STATE_DIR")
-            }
-            try? FileManager.default.removeItem(at: tempDir)
-        }
-
         let identity = DeviceIdentityStore.loadOrCreate()
         let session = FakeGatewayWebSocketSession(helloAuth: [
             "deviceToken": "untrusted-node-token",
@@ -1508,20 +1404,6 @@ struct GatewayNodeSessionTests {
 
     @Test(.stateDirectoryIsolated)
     func `private lan bootstrap persists handoff tokens for reconnect`() async throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
-        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
-        defer {
-            if let previousStateDir {
-                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
-            } else {
-                unsetenv("OPENCLAW_STATE_DIR")
-            }
-            try? FileManager.default.removeItem(at: tempDir)
-        }
-
         let identity = DeviceIdentityStore.loadOrCreate()
         let url = try #require(URL(string: "ws://192.168.50.164:18889"))
         let bootstrapSession = FakeGatewayWebSocketSession(helloAuth: [
@@ -1599,20 +1481,6 @@ struct GatewayNodeSessionTests {
 
     @Test(.stateDirectoryIsolated)
     func `token mismatch retries stored device token only for trusted loopback hosts`() async throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
-        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
-        defer {
-            if let previousStateDir {
-                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
-            } else {
-                unsetenv("OPENCLAW_STATE_DIR")
-            }
-            try? FileManager.default.removeItem(at: tempDir)
-        }
-
         let identity = DeviceIdentityStore.loadOrCreate()
         _ = DeviceAuthStore.storeToken(
             deviceId: identity.deviceId,

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/StateDirectoryIsolationTrait.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/StateDirectoryIsolationTrait.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 
 private actor StateDirectoryTestGate {
@@ -23,9 +24,32 @@ private actor StateDirectoryTestGate {
     }
 }
 
-/// Prevents process-wide state-directory overrides from crossing suite boundaries.
+/// Serializes state-directory tests and pins `OPENCLAW_STATE_DIR` to a fresh
+/// per-test temp dir. Device identity/auth stores resolve that env var on every
+/// call; without the pin they fall back to the developer's real store
+/// (app group container or ~/Library/Application Support/OpenClaw), so real
+/// device tokens leak into nil-token assertions on machines that ran the app.
+/// Tests needing a custom dir (for example an unwritable path) may still set
+/// the env var themselves and restore the previous value.
 struct StateDirectoryIsolationTrait: TestTrait, TestScoping {
     private static let gate = StateDirectoryTestGate()
+
+    /// Value restored between gated tests: the operator-provided launch value
+    /// when present, else a run-scoped quarantine dir. Never restore to unset —
+    /// leaked background tasks (reconnect watchdogs from failed tests) would
+    /// then write fake tokens into the developer's real store.
+    private static let restoreStateDirPath: String = {
+        if let raw = getenv("OPENCLAW_STATE_DIR") {
+            let value = String(cString: raw).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !value.isEmpty {
+                return value
+            }
+        }
+        let quarantine = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openclaw-test-state-quarantine-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: quarantine, withIntermediateDirectories: true)
+        return quarantine.path
+    }()
 
     func provideScope(
         for test: Test,
@@ -33,13 +57,27 @@ struct StateDirectoryIsolationTrait: TestTrait, TestScoping {
         performing function: @Sendable () async throws -> Void) async throws
     {
         await Self.gate.acquire()
+        // Resolve the restore value before the first setenv so it captures the
+        // launch environment, not a prior test's temp dir.
+        let restorePath = Self.restoreStateDirPath
+        let stateDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openclaw-test-state-\(UUID().uuidString)", isDirectory: true)
+        var thrown: (any Error)?
         do {
+            try FileManager.default.createDirectory(at: stateDir, withIntermediateDirectories: true)
+            setenv("OPENCLAW_STATE_DIR", stateDir.path, 1)
             try await function()
         } catch {
-            await Self.gate.release()
-            throw error
+            thrown = error
         }
+        // Restore env before releasing the gate; the next gated test sets its
+        // own dir immediately after acquire and must not be clobbered.
+        setenv("OPENCLAW_STATE_DIR", restorePath, 1)
+        try? FileManager.default.removeItem(at: stateDir)
         await Self.gate.release()
+        if let thrown {
+            throw thrown
+        }
     }
 }
 

--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -193,6 +193,7 @@ export const migratedSessionAccessorWriteFiles = new Set([
   "src/config/sessions/cleanup-service.ts",
   "src/config/sessions/goals.ts",
   "src/gateway/boot.ts",
+  "src/gateway/server-methods/chat.ts",
   "src/gateway/server-methods/sessions.ts",
   "src/gateway/server-node-events.ts",
   "src/gateway/session-compaction-checkpoints.ts",

--- a/scripts/lib/session-accessor-debt-baseline.json
+++ b/scripts/lib/session-accessor-debt-baseline.json
@@ -58,7 +58,6 @@
     "src/config/sessions/session-file.ts": 2,
     "src/config/sessions/session-registry-maintenance.ts": 2,
     "src/gateway/server-methods/agent.ts": 2,
-    "src/gateway/server-methods/chat.ts": 2,
     "src/gateway/session-lifecycle-state.ts": 2,
     "src/gateway/test-helpers.mocks.ts": 1,
     "src/infra/heartbeat-runner.ts": 5,

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -18,9 +18,11 @@ import {
   cleanupSessionLifecycleArtifacts,
   commitReplySessionInitialization,
   createSessionEntryWithTranscript,
+  findTranscriptEvent,
   listSessionEntries,
   loadReplySessionInitializationSnapshot,
   loadSessionEntry,
+  loadTranscriptEvents,
   markSessionAbortTarget,
   openSessionEntryReadView,
   patchSessionEntry,
@@ -99,6 +101,68 @@ describe("session accessor file-backed seam", () => {
       sessionId: "session-1",
       updatedAt: expect.any(Number),
     });
+  });
+
+  it("loads parsed transcript events from explicit and store-derived targets", async () => {
+    const header = { type: "session", id: "session-events", timestamp: 1 };
+    const message = { type: "message", id: "m1", message: { role: "assistant" } };
+    fs.writeFileSync(
+      transcriptPath,
+      `${JSON.stringify(header)}\n${JSON.stringify(message)}\nnot-json\n`,
+      "utf-8",
+    );
+    await upsertSessionEntry(
+      { sessionKey: "agent:main:main", storePath },
+      { sessionId: "session-events", sessionFile: transcriptPath, updatedAt: 10 },
+    );
+
+    const explicit = await loadTranscriptEvents({
+      sessionFile: transcriptPath,
+      sessionId: "session-events",
+    });
+    expect(explicit).toEqual([header, message]);
+
+    const derived = await loadTranscriptEvents({
+      sessionId: "session-events",
+      sessionKey: "agent:main:main",
+      storePath,
+    });
+    expect(derived).toEqual([header, message]);
+
+    const missing = await loadTranscriptEvents({
+      sessionFile: path.join(tempDir, "missing.jsonl"),
+      sessionId: "session-events",
+    });
+    expect(missing).toEqual([]);
+  });
+
+  it("finds the newest matching transcript event without loading the whole file", async () => {
+    const header = { type: "session", id: "session-find", timestamp: 1 };
+    const older = { type: "message", id: "m1", message: { role: "assistant", tag: "old" } };
+    const newer = { type: "message", id: "m2", message: { role: "assistant", tag: "new" } };
+    fs.writeFileSync(
+      transcriptPath,
+      `${JSON.stringify(header)}\n${JSON.stringify(older)}\n${JSON.stringify(newer)}\n`,
+      "utf-8",
+    );
+
+    const seen: unknown[] = [];
+    const found = await findTranscriptEvent(
+      { sessionFile: transcriptPath, sessionId: "session-find" },
+      (event) => {
+        seen.push(event);
+        return (event as { type?: string }).type === "message";
+      },
+    );
+    // Newest-first with early exit: the older message is never visited.
+    expect(found).toEqual({ event: newer });
+    expect(seen).toEqual([newer]);
+
+    const missing = await findTranscriptEvent(
+      { sessionFile: path.join(tempDir, "missing.jsonl"), sessionId: "session-find" },
+      () => true,
+    );
+    expect(missing).toBeUndefined();
   });
 
   it("opens a borrowed read view with raw exact-key probes and deferred enumeration", async () => {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -96,7 +96,10 @@ import { resolveSessionTranscriptFile } from "./transcript-file-resolve.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
 import { serializeJsonlLine, writeJsonlLines } from "./transcript-jsonl.js";
 import { replayRecentUserAssistantMessages } from "./transcript-replay.js";
-import { streamSessionTranscriptLines } from "./transcript-stream.js";
+import {
+  streamSessionTranscriptLines,
+  streamSessionTranscriptLinesReverse,
+} from "./transcript-stream.js";
 import {
   scanSessionTranscriptTree,
   selectSessionTranscriptTreePathNodes,
@@ -2087,6 +2090,48 @@ export async function appendTranscriptMessage<TMessage>(
       ? { useRawWhenLinear: options.useRawWhenLinear }
       : {}),
   });
+}
+
+/**
+ * Finds the newest transcript record accepted by the matcher. Reads newest-first
+ * with early exit so hot append-path lookups never materialize the whole
+ * transcript; missing transcripts match nothing. The match is wrapped so parsed
+ * falsy records stay distinguishable from "no match".
+ */
+export async function findTranscriptEvent(
+  scope: SessionTranscriptReadScope,
+  match: (event: TranscriptEvent) => boolean,
+): Promise<{ event: TranscriptEvent } | undefined> {
+  const target = resolveSessionTranscriptReadTarget(scope);
+  for await (const line of streamSessionTranscriptLinesReverse(target.sessionFile)) {
+    try {
+      const event = JSON.parse(line) as TranscriptEvent;
+      if (match(event)) {
+        return { event };
+      }
+    } catch {
+      // Malformed lines are skipped, matching transcript index tolerance.
+    }
+  }
+  return undefined;
+}
+
+/** Reads parsed transcript records from an explicit or derived transcript target. */
+export async function loadTranscriptEvents(
+  scope: SessionTranscriptReadScope,
+): Promise<TranscriptEvent[]> {
+  const target = resolveSessionTranscriptReadTarget(scope);
+  const events: TranscriptEvent[] = [];
+  // Missing transcripts stream zero lines, so readers get an empty event list
+  // instead of a filesystem error; that keeps the read contract storage-neutral.
+  for await (const line of streamSessionTranscriptLines(target.sessionFile)) {
+    try {
+      events.push(JSON.parse(line) as TranscriptEvent);
+    } catch {
+      // Malformed lines are skipped, matching transcript index tolerance.
+    }
+  }
+  return events;
 }
 
 /** Emits a transcript update after resolving the current transcript target. */

--- a/src/gateway/server-methods/chat-transcript-inject.ts
+++ b/src/gateway/server-methods/chat-transcript-inject.ts
@@ -1,7 +1,11 @@
 // Chat transcript injection appends gateway-authored assistant rows while
 // preserving agent-session parent links and transcript update notifications.
 import type { SessionManager } from "../../agents/sessions/session-manager.js";
-import { persistSessionTranscriptTurn } from "../../config/sessions/session-accessor.js";
+import {
+  findTranscriptEvent,
+  persistSessionTranscriptTurn,
+  type TranscriptEvent,
+} from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 
@@ -53,9 +57,71 @@ function resolveInjectedAssistantContent(params: {
   return [{ type: "text", text: `${labelPrefix}${params.message}` }];
 }
 
+function transcriptEventRecord(event: TranscriptEvent): Record<string, unknown> | undefined {
+  return event && typeof event === "object" && !Array.isArray(event)
+    ? (event as Record<string, unknown>)
+    : undefined;
+}
+
+function transcriptEventMessage(event: TranscriptEvent): Record<string, unknown> | undefined {
+  const message = transcriptEventRecord(event)?.message;
+  return message && typeof message === "object" && !Array.isArray(message)
+    ? (message as Record<string, unknown>)
+    : undefined;
+}
+
+function transcriptEventId(event: TranscriptEvent): string | undefined {
+  const id = transcriptEventRecord(event)?.id;
+  return typeof id === "string" && id.trim().length > 0 ? id : undefined;
+}
+
+type InjectedAssistantIdempotencyTarget = {
+  agentId?: string;
+  sessionFile?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  storePath?: string;
+};
+
+async function findInjectedAssistantMessageByIdempotencyKey(params: {
+  idempotencyKey: string;
+  target: InjectedAssistantIdempotencyTarget;
+}): Promise<{ messageId: string; message: Record<string, unknown> } | undefined> {
+  if (!params.target.sessionId || !params.target.sessionKey) {
+    return undefined;
+  }
+  // The in-lock duplicate check resolves through the already-resolved
+  // sessionFile when present so the lookup reads the file being appended to.
+  // findTranscriptEvent scans newest-first with early exit, keeping the hot
+  // idempotent append path from materializing the whole transcript.
+  const found = await findTranscriptEvent(
+    {
+      ...(params.target.agentId ? { agentId: params.target.agentId } : {}),
+      ...(params.target.sessionFile ? { sessionFile: params.target.sessionFile } : {}),
+      sessionId: params.target.sessionId,
+      sessionKey: params.target.sessionKey,
+      ...(params.target.storePath ? { storePath: params.target.storePath } : {}),
+    },
+    (candidate) => {
+      const message = transcriptEventMessage(candidate);
+      return message?.role === "assistant" && message.idempotencyKey === params.idempotencyKey;
+    },
+  );
+  const message = found ? transcriptEventMessage(found.event) : undefined;
+  if (!message) {
+    return undefined;
+  }
+  // Legacy shipped transcripts can carry assistant rows without top-level ids;
+  // fall back to the idempotency key so re-issued aborts still dedupe there.
+  const messageId = (found ? transcriptEventId(found.event) : undefined) ?? params.idempotencyKey;
+  return { messageId, message };
+}
+
 /** Append a gateway-authored assistant message while preserving transcript parent links. */
 export async function appendInjectedAssistantMessageToTranscript(params: {
-  transcriptPath: string;
+  transcriptPath?: string;
+  storePath?: string;
+  sessionId?: string;
   sessionKey?: string;
   agentId?: string;
   message: string;
@@ -118,26 +184,60 @@ export async function appendInjectedAssistantMessageToTranscript(params: {
   };
 
   try {
+    if (!params.transcriptPath && (!params.storePath || !params.sessionId || !params.sessionKey)) {
+      return { ok: false, error: "transcript identity not resolved" };
+    }
+    const assistantScopedIdempotency =
+      params.idempotencyKey && params.storePath && params.sessionId && params.sessionKey
+        ? {
+            idempotencyKey: params.idempotencyKey,
+            target: {
+              ...(params.agentId ? { agentId: params.agentId } : {}),
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+              storePath: params.storePath,
+            },
+          }
+        : undefined;
     const turn = await persistSessionTranscriptTurn(
       {
-        sessionFile: params.transcriptPath,
         sessionKey: params.sessionKey ?? "",
+        ...(params.transcriptPath ? { sessionFile: params.transcriptPath } : {}),
+        ...(params.storePath ? { storePath: params.storePath } : {}),
+        ...(params.sessionId ? { sessionId: params.sessionId } : {}),
         ...(params.agentId ? { agentId: params.agentId } : {}),
       },
       {
         updateMode: "inline",
+        touchSessionEntry: Boolean(params.storePath && params.sessionId && params.sessionKey),
         ...(params.config ? { config: params.config } : {}),
         messages: [
           {
             message: messageBody,
+            idempotencyLookup: assistantScopedIdempotency ? "caller-checked" : "scan",
             now,
             useRawWhenLinear: true,
+            shouldAppend: assistantScopedIdempotency
+              ? async (target) =>
+                  !(await findInjectedAssistantMessageByIdempotencyKey({
+                    idempotencyKey: assistantScopedIdempotency.idempotencyKey,
+                    target,
+                  }))
+              : undefined,
           },
         ],
       },
     );
     const appended = turn.messages[0];
     if (!appended) {
+      if (assistantScopedIdempotency) {
+        const existing = await findInjectedAssistantMessageByIdempotencyKey(
+          assistantScopedIdempotency,
+        );
+        if (existing) {
+          return { ok: true, messageId: existing.messageId, message: existing.message };
+        }
+      }
       return { ok: false, error: "gateway-injected assistant message was not appended" };
     }
     return {

--- a/src/gateway/server-methods/chat.abort-persistence.test.ts
+++ b/src/gateway/server-methods/chat.abort-persistence.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { CURRENT_SESSION_VERSION } from "openclaw/plugin-sdk/agent-sessions";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
+import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
 import { onAgentEvent, resetAgentEventsForTest } from "../../infra/agent-events.js";
 import {
   createActiveRun,
@@ -171,6 +172,12 @@ async function createTranscriptFixture(prefix: string) {
   const sessionId = "sess-main";
   const transcriptPath = path.join(dir, `${sessionId}.jsonl`);
   await writeTranscriptHeader(transcriptPath, sessionId);
+  // The accessor resolves transcript targets from the persisted store, so the
+  // fixture seeds a real entry instead of relying on the mocked gateway wrapper.
+  await replaceSessionEntry(
+    { agentId: "main", sessionKey: "main", storePath: path.join(dir, "sessions.json") },
+    { sessionId, sessionFile: transcriptPath, updatedAt: Date.now() },
+  );
   setMockSessionEntry(transcriptPath, sessionId);
   return { transcriptPath, sessionId };
 }

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -19,6 +19,7 @@ import {
   setReplyPayloadMetadata,
 } from "../../auto-reply/reply-payload.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
+import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
 import { appendSessionTranscriptMessage } from "../../config/sessions/transcript-append.js";
 import { resolveMirroredTranscriptText } from "../../config/sessions/transcript-mirror.js";
 import { getAgentRunContext } from "../../infra/agent-events.js";
@@ -444,7 +445,7 @@ async function waitForAssertion(assertion: () => void, timeoutMs = 1000, stepMs 
   await vi.waitFor(assertion, { interval: stepMs, timeout: timeoutMs });
 }
 
-function createTranscriptFixture(prefix: string) {
+async function createTranscriptFixture(prefix: string) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   const transcriptPath = path.join(dir, "sess.jsonl");
   fs.writeFileSync(
@@ -459,6 +460,12 @@ function createTranscriptFixture(prefix: string) {
     "utf-8",
   );
   mockState.transcriptPath = transcriptPath;
+  // The accessor resolves transcript targets from the persisted store, so the
+  // fixture seeds a real entry instead of relying on the mocked gateway wrapper.
+  await replaceSessionEntry(
+    { agentId: "main", sessionKey: "main", storePath: path.join(dir, "sessions.json") },
+    { sessionId: mockState.sessionId, sessionFile: transcriptPath, updatedAt: Date.now() },
+  );
   return dir;
 }
 
@@ -466,7 +473,7 @@ async function withTranscriptFixtureState(
   prefix: string,
   run: (fixtureDir: string) => Promise<void>,
 ): Promise<void> {
-  const fixtureDir = createTranscriptFixture(prefix);
+  const fixtureDir = await createTranscriptFixture(prefix);
   await withEnvAsync({ OPENCLAW_STATE_DIR: fixtureDir }, async () => await run(fixtureDir));
 }
 
@@ -863,7 +870,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("broadcasts session metadata changes reported by chat command dispatch", async () => {
-    createTranscriptFixture("openclaw-chat-send-session-metadata-");
+    await createTranscriptFixture("openclaw-chat-send-session-metadata-");
     mockState.sessionEntry = {
       goal: {
         status: "active",
@@ -908,7 +915,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("broadcasts session metadata changes before later command dispatch failure", async () => {
-    createTranscriptFixture("openclaw-chat-send-session-metadata-error-");
+    await createTranscriptFixture("openclaw-chat-send-session-metadata-error-");
     mockState.sessionMetadataChanges = [
       {
         sessionKey: "agent:main:main",
@@ -939,7 +946,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("persists non-agent delivery mirrors with the chat send idempotency key", async () => {
-    createTranscriptFixture("openclaw-chat-send-final-idem-");
+    await createTranscriptFixture("openclaw-chat-send-final-idem-");
     mockState.finalText = "mirror text";
     const respond = vi.fn();
     const context = createChatContext();
@@ -963,7 +970,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("registers tool-event recipients for clients advertising tool-events capability", async () => {
-    createTranscriptFixture("openclaw-chat-send-tool-events-");
+    await createTranscriptFixture("openclaw-chat-send-tool-events-");
     mockState.finalText = "ok";
     mockState.triggerAgentRunStart = true;
     mockState.agentRunId = "run-current";
@@ -1002,7 +1009,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("registers default global tool-event recipients for unscoped global sends", async () => {
-    createTranscriptFixture("openclaw-chat-send-global-tool-events-");
+    await createTranscriptFixture("openclaw-chat-send-global-tool-events-");
     mockState.config = {
       agents: { list: [{ id: "main", default: true }, { id: "work" }] },
       session: { scope: "global" },
@@ -1047,7 +1054,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("registers selected global alias tool-event recipients against the canonical run key", async () => {
-    createTranscriptFixture("openclaw-chat-send-global-alias-tool-events-");
+    await createTranscriptFixture("openclaw-chat-send-global-alias-tool-events-");
     mockState.config = {
       agents: { list: [{ id: "main", default: true }, { id: "work" }] },
       session: { scope: "global" },
@@ -1093,7 +1100,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("scopes selected-agent global aliases before loading chat session state", async () => {
-    createTranscriptFixture("openclaw-chat-send-global-alias-load-");
+    await createTranscriptFixture("openclaw-chat-send-global-alias-load-");
     mockState.config = {
       agents: { list: [{ id: "main", default: true }, { id: "work" }] },
       session: { scope: "global" },
@@ -1117,7 +1124,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("accepts selected-agent global main aliases before loading chat session state", async () => {
-    createTranscriptFixture("openclaw-chat-send-global-main-alias-load-");
+    await createTranscriptFixture("openclaw-chat-send-global-main-alias-load-");
     mockState.config = {
       agents: { list: [{ id: "main", default: true }, { id: "work" }] },
       session: { scope: "global" },
@@ -1148,7 +1155,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("registers selected-agent global aliases under the canonical abort key", async () => {
-    createTranscriptFixture("openclaw-chat-send-global-alias-abort-key-");
+    await createTranscriptFixture("openclaw-chat-send-global-alias-abort-key-");
     mockState.config = {
       agents: { list: [{ id: "main", default: true }, { id: "work" }] },
       session: { scope: "global" },
@@ -1180,7 +1187,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("scopes chat history global aliases before loading session state", async () => {
-    createTranscriptFixture("openclaw-chat-history-global-alias-load-");
+    await createTranscriptFixture("openclaw-chat-history-global-alias-load-");
     mockState.config = {
       agents: { list: [{ id: "main", default: true }, { id: "work" }] },
       session: { scope: "global" },
@@ -1206,7 +1213,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("does not register tool-event recipients without tool-events capability", async () => {
-    createTranscriptFixture("openclaw-chat-send-tool-events-off-");
+    await createTranscriptFixture("openclaw-chat-send-tool-events-off-");
     mockState.finalText = "ok";
     mockState.triggerAgentRunStart = true;
     mockState.agentRunId = "run-no-cap";
@@ -1229,7 +1236,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("persists agent-run audio replies emitted as media-bearing block payloads", async () => {
-    createTranscriptFixture("openclaw-chat-send-agent-audio-");
+    await createTranscriptFixture("openclaw-chat-send-agent-audio-");
     const transcriptDir = path.dirname(mockState.transcriptPath);
     const audioPath = path.join(transcriptDir, "reply.mp3");
     fs.writeFileSync(audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
@@ -1284,7 +1291,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("persists auto-TTS final media as audio-only so webchat does not duplicate assistant text", async () => {
-    const transcriptDir = createTranscriptFixture("openclaw-chat-send-agent-tts-final-");
+    const transcriptDir = await createTranscriptFixture("openclaw-chat-send-agent-tts-final-");
     const audioPath = path.join(transcriptDir, "tts.mp3");
     fs.writeFileSync(audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
     mockState.config = {
@@ -1350,7 +1357,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("does not mirror agent-run stale media final text from live delivery", async () => {
-    const transcriptDir = createTranscriptFixture("openclaw-chat-send-agent-stale-tts-");
+    const transcriptDir = await createTranscriptFixture("openclaw-chat-send-agent-stale-tts-");
     const staleAudioPath = path.join(transcriptDir, "stale.mp3");
     mockState.config = {
       agents: {
@@ -1401,7 +1408,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("does not mirror normal agent-run final text from live delivery", async () => {
-    const transcriptDir = createTranscriptFixture("openclaw-chat-send-agent-text-only-");
+    const transcriptDir = await createTranscriptFixture("openclaw-chat-send-agent-text-only-");
     mockState.config = {
       agents: {
         defaults: {
@@ -1448,7 +1455,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("broadcasts agent-run internal-ui source replies without duplicating transcript", async () => {
-    createTranscriptFixture("openclaw-chat-send-agent-source-reply-");
+    await createTranscriptFixture("openclaw-chat-send-agent-source-reply-");
     const mirrorIdempotencyKey = "idem-agent-source-reply:internal-source-reply:0";
     await appendSourceReplyMirrorEntry({
       idempotencyKey: mirrorIdempotencyKey,
@@ -1507,7 +1514,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("broadcasts agent-run status notices without source reply mirrors", async () => {
-    createTranscriptFixture("openclaw-chat-send-agent-status-notice-");
+    await createTranscriptFixture("openclaw-chat-send-agent-status-notice-");
     mockState.triggerAgentRunStart = true;
     mockState.dispatchedReplies = [
       {
@@ -2175,7 +2182,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("does not broadcast an error terminal after an internal-ui source reply final", async () => {
-    createTranscriptFixture("openclaw-chat-send-agent-source-reply-error-");
+    await createTranscriptFixture("openclaw-chat-send-agent-source-reply-error-");
     mockState.triggerAgentRunStart = true;
     const sourceReply = setReplyPayloadMetadata(
       {
@@ -2231,7 +2238,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("broadcasts returned agent errors after status notices", async () => {
-    createTranscriptFixture("openclaw-chat-send-agent-status-notice-error-");
+    await createTranscriptFixture("openclaw-chat-send-agent-status-notice-error-");
     const errorMessage = "LLM idle timeout (120s): no response from model";
     mockState.triggerAgentRunStart = true;
     mockState.dispatchedReplies = [
@@ -2273,7 +2280,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("broadcasts returned agent-run error payloads after an agent starts", async () => {
-    createTranscriptFixture("openclaw-chat-send-agent-returned-error-");
+    await createTranscriptFixture("openclaw-chat-send-agent-returned-error-");
     const errorMessage = "LLM idle timeout (120s): no response from model";
     mockState.triggerAgentRunStart = true;
     mockState.dispatchedReplies = [
@@ -2319,7 +2326,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("keeps visible text on non-agent TTS final media because no model transcript exists", async () => {
-    const transcriptDir = createTranscriptFixture("openclaw-chat-send-command-tts-final-");
+    const transcriptDir = await createTranscriptFixture("openclaw-chat-send-command-tts-final-");
     const audioPath = path.join(transcriptDir, "tts.mp3");
     fs.writeFileSync(audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
     mockState.config = {
@@ -2370,7 +2377,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("folds block-only non-agent command replies into the final WebChat message", async () => {
-    createTranscriptFixture("openclaw-chat-send-command-block-final-");
+    await createTranscriptFixture("openclaw-chat-send-command-block-final-");
     mockState.dispatchedReplies = [
       {
         kind: "block",
@@ -2412,7 +2419,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("keeps slash-command block text when the final payload only adds media", async () => {
-    const transcriptDir = createTranscriptFixture("openclaw-chat-send-command-block-media-final-");
+    const transcriptDir = await createTranscriptFixture(
+      "openclaw-chat-send-command-block-media-final-",
+    );
     const audioPath = path.join(transcriptDir, "tts.mp3");
     fs.writeFileSync(audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
     mockState.config = {
@@ -2468,7 +2477,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("broadcasts sensitive pairing QR display without persisting QR content", async () => {
-    createTranscriptFixture("openclaw-chat-send-command-pair-qr-");
+    await createTranscriptFixture("openclaw-chat-send-command-pair-qr-");
     const setupCode = "openclaw-test-pairing-setup-code";
     mockState.dispatchedReplies = [
       {
@@ -2516,7 +2525,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("keeps visible slash-command finals alongside earlier block text", async () => {
-    createTranscriptFixture("openclaw-chat-send-command-block-text-final-");
+    await createTranscriptFixture("openclaw-chat-send-command-block-text-final-");
     mockState.dispatchedReplies = [
       {
         kind: "block",
@@ -2546,7 +2555,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("deduplicates exact slash-command final text echoes", async () => {
-    createTranscriptFixture("openclaw-chat-send-command-block-duplicate-text-final-");
+    await createTranscriptFixture("openclaw-chat-send-command-block-duplicate-text-final-");
     mockState.dispatchedReplies = [
       {
         kind: "block",
@@ -2584,7 +2593,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("keeps slash-command block text when the final payload only carries a reply directive", async () => {
-    createTranscriptFixture("openclaw-chat-send-command-block-reply-directive-final-");
+    await createTranscriptFixture("openclaw-chat-send-command-block-reply-directive-final-");
     mockState.dispatchedReplies = [
       {
         kind: "block",
@@ -2619,7 +2628,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("keeps media from duplicate slash-command finals without duplicating block text", async () => {
-    const transcriptDir = createTranscriptFixture("openclaw-chat-send-command-block-media-dupe-");
+    const transcriptDir = await createTranscriptFixture(
+      "openclaw-chat-send-command-block-media-dupe-",
+    );
     const audioPath = path.join(transcriptDir, "tts.mp3");
     fs.writeFileSync(audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
     mockState.config = {
@@ -2675,7 +2686,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("deduplicates slash-command media when file URLs and paths reference the same attachment", async () => {
-    const transcriptDir = createTranscriptFixture(
+    const transcriptDir = await createTranscriptFixture(
       "openclaw-chat-send-command-block-media-file-url-",
     );
     const audioPath = path.join(transcriptDir, "voice.mp3");
@@ -2728,7 +2739,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("does not downgrade a voice-note block when a duplicate final has normalized false flags", async () => {
-    const transcriptDir = createTranscriptFixture("openclaw-chat-send-command-block-voice-sticky-");
+    const transcriptDir = await createTranscriptFixture(
+      "openclaw-chat-send-command-block-voice-sticky-",
+    );
     const audioPath = path.join(transcriptDir, "voice.mp3");
     fs.writeFileSync(audioPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
     mockState.config = {
@@ -2778,7 +2791,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("keeps final text when only the slash-command media is duplicated", async () => {
-    const transcriptDir = createTranscriptFixture(
+    const transcriptDir = await createTranscriptFixture(
       "openclaw-chat-send-command-block-media-different-final-text-",
     );
     const audioPath = path.join(transcriptDir, "voice.mp3");
@@ -2838,7 +2851,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("keeps same-caption slash-command finals when media differs", async () => {
-    const transcriptDir = createTranscriptFixture(
+    const transcriptDir = await createTranscriptFixture(
       "openclaw-chat-send-command-block-same-caption-different-media-",
     );
     const blockAudioPath = path.join(transcriptDir, "block.mp3");
@@ -2900,7 +2913,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("deduplicates slash-command final echoes against the same text and media block", async () => {
-    const transcriptDir = createTranscriptFixture(
+    const transcriptDir = await createTranscriptFixture(
       "openclaw-chat-send-command-block-same-caption-same-media-",
     );
     const firstAudioPath = path.join(transcriptDir, "first.mp3");
@@ -2973,7 +2986,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("uses canonical mediaUrls when deduplicating slash-command block media", async () => {
-    const transcriptDir = createTranscriptFixture(
+    const transcriptDir = await createTranscriptFixture(
       "openclaw-chat-send-command-block-media-canonical-",
     );
     const blockAudioPath = path.join(transcriptDir, "block.mp3");
@@ -3041,7 +3054,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("does not spread duplicate final media flags across multi-media command blocks", async () => {
-    const transcriptDir = createTranscriptFixture(
+    const transcriptDir = await createTranscriptFixture(
       "openclaw-chat-send-command-block-media-partial-",
     );
     const firstAudioPath = path.join(transcriptDir, "first.mp3");
@@ -3106,7 +3119,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("keeps sensitive overlapping slash-command media out of transcripts", async () => {
-    const transcriptDir = createTranscriptFixture(
+    const transcriptDir = await createTranscriptFixture(
       "openclaw-chat-send-command-block-media-sensitive-overlap-",
     );
     const secretAudioPath = path.join(transcriptDir, "secret.mp3");
@@ -3158,7 +3171,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("keeps reordered slash-command final media instead of treating it as duplicate", async () => {
-    const transcriptDir = createTranscriptFixture(
+    const transcriptDir = await createTranscriptFixture(
       "openclaw-chat-send-command-block-media-reordered-",
     );
     const firstAudioPath = path.join(transcriptDir, "first.mp3");
@@ -3216,7 +3229,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("renders image reply payloads as assistant image content instead of MEDIA text", async () => {
-    createTranscriptFixture("openclaw-chat-send-agent-image-");
+    await createTranscriptFixture("openclaw-chat-send-agent-image-");
     mockState.finalPayload = {
       text: "Scan this QR code with the OpenClaw iOS app:",
       mediaUrl: "data:image/png;base64,cG5n",
@@ -3241,7 +3254,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("suppresses reasoning payloads from webchat transcript replies", async () => {
-    createTranscriptFixture("openclaw-chat-send-reasoning-hidden-");
+    await createTranscriptFixture("openclaw-chat-send-reasoning-hidden-");
     mockState.dispatchedReplies = [
       {
         kind: "final",
@@ -3266,7 +3279,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.inject keeps message defined when directive tag is the only content", async () => {
-    createTranscriptFixture("openclaw-chat-inject-directive-only-");
+    await createTranscriptFixture("openclaw-chat-inject-directive-only-");
     const respond = vi.fn();
     const context = createChatContext();
 
@@ -3292,7 +3305,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.inject rejects archived sessions without appending", async () => {
-    createTranscriptFixture("openclaw-chat-inject-archived-");
+    await createTranscriptFixture("openclaw-chat-inject-archived-");
     mockState.sessionEntry = { archivedAt: Date.now() };
     const respond = vi.fn();
     const context = createChatContext();
@@ -3314,7 +3327,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.inject rechecks archive state after lifecycle admission waits", async () => {
-    createTranscriptFixture("openclaw-chat-inject-archive-race-");
+    await createTranscriptFixture("openclaw-chat-inject-archive-race-");
     const storePath = path.join(path.dirname(mockState.transcriptPath), "sessions.json");
     const mutationStarted = createDeferred();
     const releaseMutation = createDeferred();
@@ -3357,7 +3370,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.send non-streaming final keeps message defined for directive-only assistant text", async () => {
-    createTranscriptFixture("openclaw-chat-send-directive-only-");
+    await createTranscriptFixture("openclaw-chat-send-directive-only-");
     mockState.finalText = "[[reply_to_current]]";
     const respond = vi.fn();
     const context = createChatContext();
@@ -3377,7 +3390,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("preserves inline reply directives in transcript text while stripping them from display", async () => {
-    createTranscriptFixture("openclaw-chat-send-inline-reply-transcript-");
+    await createTranscriptFixture("openclaw-chat-send-inline-reply-transcript-");
     mockState.finalText = "see[[reply_to_current]]now  with  spacing";
     const respond = vi.fn();
     const context = createChatContext();
@@ -3400,7 +3413,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("rejects oversized chat.send session keys before dispatch", async () => {
-    createTranscriptFixture("openclaw-chat-send-session-key-too-long-");
+    await createTranscriptFixture("openclaw-chat-send-session-key-too-long-");
     const respond = vi.fn();
     const context = createChatContext();
 
@@ -3425,7 +3438,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.inject strips external untrusted wrapper metadata from final payload text", async () => {
-    createTranscriptFixture("openclaw-chat-inject-untrusted-meta-");
+    await createTranscriptFixture("openclaw-chat-inject-untrusted-meta-");
     const respond = vi.fn();
     const context = createChatContext();
 
@@ -3448,7 +3461,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.inject broadcasts and routes on the canonical session key", async () => {
-    createTranscriptFixture("openclaw-chat-inject-canonical-key-");
+    await createTranscriptFixture("openclaw-chat-inject-canonical-key-");
     mockState.sessionEntry = {
       canonicalKey: "agent:main:canon",
     };
@@ -3478,7 +3491,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.inject advances the session registry marker after transcript append", async () => {
-    const fixtureDir = createTranscriptFixture("openclaw-chat-inject-registry-marker-");
+    const fixtureDir = await createTranscriptFixture("openclaw-chat-inject-registry-marker-");
     const updatedAt = Date.parse("2026-05-18T11:00:00.000Z");
     const appendedAt = Date.parse("2026-05-18T11:05:00.000Z");
     const storePath = path.join(path.dirname(mockState.transcriptPath), "sessions.json");
@@ -3526,7 +3539,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.inject scopes selected-agent global sessions before appending", async () => {
-    createTranscriptFixture("openclaw-chat-inject-selected-global-");
+    await createTranscriptFixture("openclaw-chat-inject-selected-global-");
     mockState.config = {
       agents: { list: [{ id: "main", default: true }, { id: "work" }] },
       session: { scope: "global" },
@@ -3566,7 +3579,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.send non-streaming final strips external untrusted wrapper metadata from final payload text", async () => {
-    createTranscriptFixture("openclaw-chat-send-untrusted-meta-");
+    await createTranscriptFixture("openclaw-chat-send-untrusted-meta-");
     mockState.finalText = `hello\n\n${UNTRUSTED_CONTEXT_SUFFIX}`;
     const respond = vi.fn();
     const context = createChatContext();
@@ -3580,7 +3593,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.send non-streaming final broadcasts and routes on the canonical session key", async () => {
-    createTranscriptFixture("openclaw-chat-send-canonical-key-");
+    await createTranscriptFixture("openclaw-chat-send-canonical-key-");
     mockState.sessionEntry = {
       canonicalKey: "agent:main:canon",
     };
@@ -3603,7 +3616,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.send broadcasts final replies for telegram-shaped session keys", async () => {
-    createTranscriptFixture("openclaw-chat-send-telegram-final-");
+    await createTranscriptFixture("openclaw-chat-send-telegram-final-");
     mockState.finalText = "telegram ok";
     const respond = vi.fn();
     const context = createChatContext();
@@ -3631,7 +3644,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.send keeps explicit delivery routes for channel-scoped sessions", async () => {
-    createTranscriptFixture("openclaw-chat-send-origin-routing-");
+    await createTranscriptFixture("openclaw-chat-send-origin-routing-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       deliveryContext: {
@@ -3667,7 +3680,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.send marks user slash commands as text command sources", async () => {
-    createTranscriptFixture("openclaw-chat-send-text-command-source-");
+    await createTranscriptFixture("openclaw-chat-send-text-command-source-");
     mockState.finalText = "ok";
     const respond = vi.fn();
     const context = createChatContext();
@@ -3687,7 +3700,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.send keeps thinking metadata out of command text for normal messages", async () => {
-    createTranscriptFixture("openclaw-chat-send-thinking-normal-message-");
+    await createTranscriptFixture("openclaw-chat-send-thinking-normal-message-");
     mockState.finalText = "ok";
     const respond = vi.fn();
     const context = createChatContext();
@@ -3721,7 +3734,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.send keeps explicit delivery routes for Feishu channel-scoped sessions", async () => {
-    createTranscriptFixture("openclaw-chat-send-feishu-origin-routing-");
+    await createTranscriptFixture("openclaw-chat-send-feishu-origin-routing-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       deliveryContext: {
@@ -3754,7 +3767,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.send keeps explicit delivery routes for per-account channel-peer sessions", async () => {
-    createTranscriptFixture("openclaw-chat-send-per-account-channel-peer-routing-");
+    await createTranscriptFixture("openclaw-chat-send-per-account-channel-peer-routing-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       deliveryContext: {
@@ -3787,7 +3800,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.send keeps explicit delivery routes for legacy channel-peer sessions", async () => {
-    createTranscriptFixture("openclaw-chat-send-legacy-channel-peer-routing-");
+    await createTranscriptFixture("openclaw-chat-send-legacy-channel-peer-routing-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       deliveryContext: {
@@ -3820,7 +3833,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.send keeps explicit delivery routes for legacy thread sessions", async () => {
-    createTranscriptFixture("openclaw-chat-send-legacy-thread-channel-peer-routing-");
+    await createTranscriptFixture("openclaw-chat-send-legacy-thread-channel-peer-routing-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       deliveryContext: {
@@ -3856,7 +3869,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.send does not inherit external delivery context for shared main sessions", async () => {
-    createTranscriptFixture("openclaw-chat-send-main-no-cross-route-");
+    await createTranscriptFixture("openclaw-chat-send-main-no-cross-route-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       deliveryContext: {
@@ -3888,7 +3901,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.send does not inherit external delivery context for UI clients on main sessions", async () => {
-    createTranscriptFixture("openclaw-chat-send-main-ui-routes-");
+    await createTranscriptFixture("openclaw-chat-send-main-ui-routes-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       deliveryContext: {
@@ -3927,7 +3940,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.send does not inherit external delivery context for UI clients on main sessions when deliver is enabled", async () => {
-    createTranscriptFixture("openclaw-chat-send-main-ui-deliver-no-route-");
+    await createTranscriptFixture("openclaw-chat-send-main-ui-deliver-no-route-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       deliveryContext: {
@@ -3968,7 +3981,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.send inherits external delivery context for CLI clients on configured main sessions", async () => {
-    createTranscriptFixture("openclaw-chat-send-config-main-cli-routes-");
+    await createTranscriptFixture("openclaw-chat-send-config-main-cli-routes-");
     mockState.mainSessionKey = "work";
     mockState.finalText = "ok";
     mockState.sessionEntry = {
@@ -4009,7 +4022,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.send falls back to origin provider metadata for configured main CLI delivery inheritance", async () => {
-    createTranscriptFixture("openclaw-chat-send-config-main-origin-provider-routes-");
+    await createTranscriptFixture("openclaw-chat-send-config-main-origin-provider-routes-");
     mockState.mainSessionKey = "work";
     mockState.finalText = "ok";
     mockState.sessionEntry = {
@@ -4047,7 +4060,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.send falls back to origin thread metadata for configured main CLI delivery inheritance", async () => {
-    createTranscriptFixture("openclaw-chat-send-config-main-origin-thread-routes-");
+    await createTranscriptFixture("openclaw-chat-send-config-main-origin-thread-routes-");
     mockState.mainSessionKey = "work";
     mockState.finalText = "ok";
     mockState.sessionEntry = {
@@ -4088,7 +4101,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.send keeps configured main delivery inheritance when connect metadata omits client details", async () => {
-    createTranscriptFixture("openclaw-chat-send-config-main-connect-no-client-");
+    await createTranscriptFixture("openclaw-chat-send-config-main-connect-no-client-");
     mockState.mainSessionKey = "work";
     mockState.finalText = "ok";
     mockState.sessionEntry = {
@@ -4124,7 +4137,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.send does not inherit external delivery context for non-channel custom sessions", async () => {
-    createTranscriptFixture("openclaw-chat-send-custom-no-cross-route-");
+    await createTranscriptFixture("openclaw-chat-send-custom-no-cross-route-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       deliveryContext: {
@@ -4157,7 +4170,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.send keeps replies on the internal surface when deliver is not enabled", async () => {
-    createTranscriptFixture("openclaw-chat-send-no-deliver-internal-surface-");
+    await createTranscriptFixture("openclaw-chat-send-no-deliver-internal-surface-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       deliveryContext: {
@@ -4189,7 +4202,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.send does not inherit external routes for webchat clients on channel-scoped sessions", async () => {
-    createTranscriptFixture("openclaw-chat-send-webchat-channel-scoped-no-inherit-");
+    await createTranscriptFixture("openclaw-chat-send-webchat-channel-scoped-no-inherit-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       deliveryContext: {
@@ -4232,7 +4245,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.send still inherits external routes for UI clients on channel-scoped sessions", async () => {
-    createTranscriptFixture("openclaw-chat-send-ui-channel-scoped-inherit-");
+    await createTranscriptFixture("openclaw-chat-send-ui-channel-scoped-inherit-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       deliveryContext: {
@@ -4273,7 +4286,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("chat.send accepts admin-scoped synthetic originating routes without external delivery", async () => {
-    createTranscriptFixture("openclaw-chat-send-synthetic-origin-admin-");
+    await createTranscriptFixture("openclaw-chat-send-synthetic-origin-admin-");
     mockState.finalText = "ok";
     const respond = vi.fn();
     const context = createChatContext();
@@ -4303,7 +4316,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("rejects synthetic originating routes when the caller lacks admin scope", async () => {
-    createTranscriptFixture("openclaw-chat-send-synthetic-origin-reject-");
+    await createTranscriptFixture("openclaw-chat-send-synthetic-origin-reject-");
     mockState.finalText = "ok";
     const respond = vi.fn();
     const context = createChatContext();
@@ -4328,7 +4341,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("rejects reserved system provenance fields for non-ACP clients", async () => {
-    createTranscriptFixture("openclaw-chat-send-system-provenance-reject-");
+    await createTranscriptFixture("openclaw-chat-send-system-provenance-reject-");
     mockState.finalText = "ok";
     const respond = vi.fn();
     const context = createChatContext();
@@ -4352,7 +4365,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("rejects forged ACP metadata when the caller lacks admin scope", async () => {
-    createTranscriptFixture("openclaw-chat-send-system-provenance-spoof-reject-");
+    await createTranscriptFixture("openclaw-chat-send-system-provenance-spoof-reject-");
     mockState.finalText = "ok";
     const respond = vi.fn();
     const context = createChatContext();
@@ -4387,7 +4400,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("allows admin-scoped clients to inject system provenance without ACP metadata", async () => {
-    createTranscriptFixture("openclaw-chat-send-system-provenance-admin-");
+    await createTranscriptFixture("openclaw-chat-send-system-provenance-admin-");
     mockState.finalText = "ok";
     const respond = vi.fn();
     const context = createChatContext();
@@ -4427,7 +4440,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("forwards gateway caller scopes into the dispatch context", async () => {
-    createTranscriptFixture("openclaw-chat-send-gateway-client-scopes-");
+    await createTranscriptFixture("openclaw-chat-send-gateway-client-scopes-");
     mockState.finalText = "ok";
     const respond = vi.fn();
     const context = createChatContext();
@@ -4449,7 +4462,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("normalizes missing gateway caller scopes to an empty array before dispatch", async () => {
-    createTranscriptFixture("openclaw-chat-send-missing-gateway-client-scopes-");
+    await createTranscriptFixture("openclaw-chat-send-missing-gateway-client-scopes-");
     mockState.finalText = "ok";
     const respond = vi.fn();
     const context = createChatContext();
@@ -4468,7 +4481,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("injects ACP system provenance into the agent-visible body", async () => {
-    createTranscriptFixture("openclaw-chat-send-system-provenance-acp-");
+    await createTranscriptFixture("openclaw-chat-send-system-provenance-acp-");
     mockState.finalText = "ok";
     const respond = vi.fn();
     const context = createChatContext();
@@ -4517,7 +4530,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("prepares clean text-only chat.send user turns for Pi persistence", async () => {
-    createTranscriptFixture("openclaw-chat-send-user-transcript-agent-run-");
+    await createTranscriptFixture("openclaw-chat-send-user-transcript-agent-run-");
     mockState.finalText = "ok";
     mockState.triggerAgentRunStart = true;
     const respond = vi.fn();
@@ -4545,7 +4558,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("does not emit pre-gate user transcript content when before_agent_run hooks are registered", async () => {
-    createTranscriptFixture("openclaw-chat-send-user-transcript-before-run-gate-");
+    await createTranscriptFixture("openclaw-chat-send-user-transcript-before-run-gate-");
     mockState.finalText = "ok";
     mockState.triggerAgentRunStart = true;
     mockState.hasBeforeAgentRunHooks = true;
@@ -4580,7 +4593,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("does not persist raw user transcript content when a delivered before_agent_run block is followed by a dispatch error", async () => {
-    createTranscriptFixture("openclaw-chat-send-user-transcript-blocked-delivery-error-");
+    await createTranscriptFixture("openclaw-chat-send-user-transcript-blocked-delivery-error-");
     mockState.triggerAgentRunStart = true;
     mockState.hasBeforeAgentRunHooks = true;
     mockState.dispatchBlockedByBeforeAgentRun = true;
@@ -4615,7 +4628,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("emits a user transcript update when hooks pass and the started agent throws before runtime persistence", async () => {
-    createTranscriptFixture("openclaw-chat-send-user-transcript-gate-pass-error-");
+    await createTranscriptFixture("openclaw-chat-send-user-transcript-gate-pass-error-");
     mockState.triggerAgentRunStart = true;
     mockState.hasBeforeAgentRunHooks = true;
     mockState.dispatchErrorAfterAgentRunStart = new Error("model unavailable");
@@ -4642,7 +4655,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("prepares persisted media paths for Pi user-turn persistence", async () => {
-    createTranscriptFixture("openclaw-chat-send-user-transcript-images-");
+    await createTranscriptFixture("openclaw-chat-send-user-transcript-images-");
     mockState.finalText = "ok";
     mockState.triggerAgentRunStart = true;
     mockState.savedMediaResults = [
@@ -4714,7 +4727,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("prepares non-image chat.send attachments as media refs without dispatch images", async () => {
-    createTranscriptFixture("openclaw-chat-send-user-transcript-file-");
+    await createTranscriptFixture("openclaw-chat-send-user-transcript-file-");
     mockState.finalText = "ok";
     mockState.triggerAgentRunStart = true;
     mockState.savedMediaResults = [
@@ -4764,7 +4777,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("preserves offloaded attachment media paths in transcript order", async () => {
-    createTranscriptFixture("openclaw-chat-send-user-transcript-offloaded-");
+    await createTranscriptFixture("openclaw-chat-send-user-transcript-offloaded-");
     mockState.finalText = "ok";
     mockState.triggerAgentRunStart = true;
     mockState.sessionEntry = {
@@ -4828,7 +4841,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("leaves ACP bridge user persistence to the agent runtime", async () => {
-    createTranscriptFixture("openclaw-chat-send-user-transcript-acp-images-");
+    await createTranscriptFixture("openclaw-chat-send-user-transcript-acp-images-");
     mockState.finalText = "ok";
     mockState.triggerAgentRunStart = true;
     mockState.savedMediaResults = [
@@ -4877,7 +4890,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("waits for the user transcript update before final broadcast on non-agent attachment sends", async () => {
-    createTranscriptFixture("openclaw-chat-send-no-agent-images-order-");
+    await createTranscriptFixture("openclaw-chat-send-no-agent-images-order-");
     mockState.finalText = "ok";
     mockState.savedMediaResults = [
       { path: "/tmp/chat-send-image-a.png", contentType: "image/png" },
@@ -4919,7 +4932,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("preserves media-only final replies in the final broadcast message", async () => {
-    createTranscriptFixture("openclaw-chat-send-media-only-final-");
+    await createTranscriptFixture("openclaw-chat-send-media-only-final-");
     mockState.finalPayload = { mediaUrl: "data:image/png;base64,cG5n" };
     const respond = vi.fn();
     const context = createChatContext();
@@ -4937,7 +4950,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("strips NO_REPLY from transcript text when final replies only carry media", async () => {
-    createTranscriptFixture("openclaw-chat-send-media-only-silent-final-");
+    await createTranscriptFixture("openclaw-chat-send-media-only-silent-final-");
     mockState.finalPayload = {
       text: "NO_REPLY",
       mediaUrl: "data:image/png;base64,cG5n",
@@ -4958,7 +4971,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("preserves reply tags in transcript updates for media replies while stripping them from the broadcast", async () => {
-    createTranscriptFixture("openclaw-chat-send-media-reply-tags-");
+    await createTranscriptFixture("openclaw-chat-send-media-reply-tags-");
     mockState.finalPayload = {
       replyToCurrent: true,
       mediaUrl: "data:image/png;base64,cG5n",
@@ -4997,7 +5010,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("does not persist sensitive image media into transcript updates", async () => {
-    createTranscriptFixture("openclaw-chat-send-sensitive-media-final-");
+    await createTranscriptFixture("openclaw-chat-send-sensitive-media-final-");
     mockState.finalPayload = {
       text: "Scan this QR code with the OpenClaw iOS app:",
       mediaUrl: "data:image/png;base64,cG5n",
@@ -5037,7 +5050,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("sanitizes replyToId before emitting inline reply directives", async () => {
-    createTranscriptFixture("openclaw-chat-send-sanitized-reply-id-");
+    await createTranscriptFixture("openclaw-chat-send-sanitized-reply-id-");
     mockState.finalPayload = {
       text: "hello",
       replyToId: "abc]]\n[[audio_as_voice]]",
@@ -5063,7 +5076,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("falls back to inline reply id when structured replyToId sanitizes empty", async () => {
-    createTranscriptFixture("openclaw-chat-send-inline-reply-id-fallback-");
+    await createTranscriptFixture("openclaw-chat-send-inline-reply-id-fallback-");
     mockState.finalPayload = {
       text: "hello[[reply_to:inline-id]]",
       replyToId: "]]\n[[",
@@ -5088,7 +5101,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("routes text-only image offloads into media-understanding fields", async () => {
-    createTranscriptFixture("openclaw-chat-send-text-only-attachments-");
+    await createTranscriptFixture("openclaw-chat-send-text-only-attachments-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       modelProvider: "test-provider",
@@ -5145,7 +5158,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("keeps image attachments inline for configured custom vision models", async () => {
-    createTranscriptFixture("openclaw-chat-send-configured-custom-vision-");
+    await createTranscriptFixture("openclaw-chat-send-configured-custom-vision-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       modelProvider: "modelscope",
@@ -5193,7 +5206,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("keeps image attachments for text-only sessions bound to ACP", async () => {
-    createTranscriptFixture("openclaw-chat-send-text-only-acp-bound-attachments-");
+    await createTranscriptFixture("openclaw-chat-send-text-only-acp-bound-attachments-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       modelProvider: "test-provider",
@@ -5244,7 +5257,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("resolves attachment image support from the session agent model", async () => {
-    createTranscriptFixture("openclaw-chat-send-agent-scoped-text-only-attachments-");
+    await createTranscriptFixture("openclaw-chat-send-agent-scoped-text-only-attachments-");
     mockState.finalText = "ok";
     mockState.config = {
       agents: {
@@ -5319,7 +5332,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("routes non-image offloaded refs into ctx.MediaPaths + MediaTypes for chat.send", async () => {
-    createTranscriptFixture("openclaw-chat-send-non-image-ctx-media-paths-");
+    await createTranscriptFixture("openclaw-chat-send-non-image-ctx-media-paths-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       modelProvider: "test-provider",
@@ -5378,7 +5391,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("routes image-named generic container bytes as non-image media paths for chat.send", async () => {
-    createTranscriptFixture("openclaw-chat-send-spoofed-image-container-");
+    await createTranscriptFixture("openclaw-chat-send-spoofed-image-container-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       modelProvider: "test-provider",
@@ -5434,7 +5447,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("preserves sandbox-relative MediaPaths and stores workspace context for media-understanding", async () => {
-    createTranscriptFixture("openclaw-chat-send-non-image-absolutize-");
+    await createTranscriptFixture("openclaw-chat-send-non-image-absolutize-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       modelProvider: "test-provider",
@@ -5482,7 +5495,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("preserves staged non-image paths when plugin-bound sessions also carry inline images", async () => {
-    createTranscriptFixture("openclaw-chat-send-plugin-bound-mixed-media-staging-");
+    await createTranscriptFixture("openclaw-chat-send-plugin-bound-mixed-media-staging-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       modelProvider: "test-provider",
@@ -5560,7 +5573,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     // A non-PDF managed offload cannot fall back to a managed path, so an infra
     // staging error stays a retryable 5xx. (Managed PDFs fall back instead — see
     // the staging-throw fallback test below.) #90097
-    createTranscriptFixture("openclaw-chat-send-stage-unavailable-");
+    await createTranscriptFixture("openclaw-chat-send-stage-unavailable-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       modelProvider: "test-provider",
@@ -5636,7 +5649,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("logs chat.send attachment parse failures with stack details", async () => {
-    createTranscriptFixture("openclaw-chat-send-attachment-parse-stack-");
+    await createTranscriptFixture("openclaw-chat-send-attachment-parse-stack-");
     const respond = vi.fn();
     const context = createChatContext();
 
@@ -5688,7 +5701,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     // the returned `staged` map against the input refs. Non-PDF refs cannot fall
     // back to a managed path, so an incomplete stage stays a 5xx. (Managed PDFs
     // fall back instead — see the staging-skip fallback test below.) #90097
-    createTranscriptFixture("openclaw-chat-send-partial-stage-");
+    await createTranscriptFixture("openclaw-chat-send-partial-stage-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       modelProvider: "test-provider",
@@ -5762,7 +5775,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     // #90097: a managed inbound PDF above the sandbox staging cap is read
     // host-side (media-understanding) rather than copied into the sandbox, so
     // it must reach dispatch with its managed media path instead of a 4xx.
-    createTranscriptFixture("openclaw-chat-send-managed-pdf-pass-through-");
+    await createTranscriptFixture("openclaw-chat-send-managed-pdf-pass-through-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       modelProvider: "test-provider",
@@ -5825,7 +5838,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     // ENOSPC) the PDF must still reach the agent via its managed media path
     // instead of failing the send — host-side media-understanding reads it from
     // the media-store root.
-    createTranscriptFixture("openclaw-chat-send-managed-pdf-stage-throw-");
+    await createTranscriptFixture("openclaw-chat-send-managed-pdf-stage-throw-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       modelProvider: "test-provider",
@@ -5884,7 +5897,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     // path) and return it absent from the staged map. An already-managed PDF in
     // that state falls back to its managed media path rather than failing the
     // send; the staged workspace dir is still carried for any files that landed.
-    createTranscriptFixture("openclaw-chat-send-managed-pdf-stage-skip-");
+    await createTranscriptFixture("openclaw-chat-send-managed-pdf-stage-skip-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       modelProvider: "test-provider",
@@ -5937,7 +5950,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     // #90097: the PDF fallback is per-ref. A managed PDF that stages does not
     // rescue a sibling non-PDF that silently fell out of staging; that batch must
     // still surface a retryable 5xx and clean up every offloaded entry.
-    createTranscriptFixture("openclaw-chat-send-mixed-stage-skip-");
+    await createTranscriptFixture("openclaw-chat-send-mixed-stage-skip-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       modelProvider: "test-provider",
@@ -6009,7 +6022,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     // retryable 5xx UNAVAILABLE, misleading clients into retrying a
     // deterministically broken request. Managed PDFs pass through (see above);
     // other oversized non-image files must still be rejected.
-    createTranscriptFixture("openclaw-chat-send-sandbox-oversize-");
+    await createTranscriptFixture("openclaw-chat-send-sandbox-oversize-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       modelProvider: "test-provider",
@@ -6070,7 +6083,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("passes imageOrder for mixed inline and offloaded chat.send attachments", async () => {
-    createTranscriptFixture("openclaw-chat-send-image-order-");
+    await createTranscriptFixture("openclaw-chat-send-image-order-");
     mockState.finalText = "ok";
     mockState.sessionEntry = {
       modelProvider: "test-provider",
@@ -6116,7 +6129,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("maps media offload failures to UNAVAILABLE in chat.send", async () => {
-    createTranscriptFixture("openclaw-chat-send-media-offload-error-");
+    await createTranscriptFixture("openclaw-chat-send-media-offload-error-");
     mockState.sessionEntry = {
       modelProvider: "test-provider",
       model: "vision-model",
@@ -6158,7 +6171,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("persists chat.send attachments one at a time", async () => {
-    createTranscriptFixture("openclaw-chat-send-image-serial-save-");
+    await createTranscriptFixture("openclaw-chat-send-image-serial-save-");
     mockState.finalText = "ok";
     mockState.savedMediaResults = [
       { path: "/tmp/chat-send-image-a.png", contentType: "image/png" },
@@ -6207,7 +6220,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("does not parse or offload attachments for stop commands", async () => {
-    createTranscriptFixture("openclaw-chat-send-stop-command-attachments-");
+    await createTranscriptFixture("openclaw-chat-send-stop-command-attachments-");
     mockState.savedMediaResults = [{ path: "/tmp/should-not-exist.png", contentType: "image/png" }];
     const respond = vi.fn();
     const context = createChatContext();
@@ -6247,7 +6260,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("emits a user transcript update when chat.send completes without an agent run", async () => {
-    createTranscriptFixture("openclaw-chat-send-user-transcript-no-run-");
+    await createTranscriptFixture("openclaw-chat-send-user-transcript-no-run-");
     mockState.finalText = "ok";
     const respond = vi.fn();
     const context = createChatContext();
@@ -6272,7 +6285,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("emits a user transcript update when chat.send fails before an agent run starts", async () => {
-    createTranscriptFixture("openclaw-chat-send-user-transcript-error-no-run-");
+    await createTranscriptFixture("openclaw-chat-send-user-transcript-error-no-run-");
     mockState.dispatchError = new Error("upstream unavailable");
     const respond = vi.fn();
     const context = createChatContext();
@@ -6300,7 +6313,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("emits a user transcript update when a slash-prefixed turn fails before command delivery", async () => {
-    createTranscriptFixture("openclaw-chat-send-user-transcript-slash-error-no-run-");
+    await createTranscriptFixture("openclaw-chat-send-user-transcript-slash-error-no-run-");
     mockState.dispatchError = new Error("slash command continued into unavailable runtime");
     const respond = vi.fn();
     const context = createChatContext();
@@ -6327,7 +6340,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("does not duplicate fallback user transcript rows when chat.send is replayed", async () => {
-    createTranscriptFixture("openclaw-chat-send-user-transcript-error-replay-");
+    await createTranscriptFixture("openclaw-chat-send-user-transcript-error-replay-");
     mockState.dispatchError = new Error("upstream unavailable");
 
     await runNonStreamingChatSend({
@@ -6361,7 +6374,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("emits a user transcript update on pre-start failures even when before_agent_run hooks exist", async () => {
-    createTranscriptFixture("openclaw-chat-send-user-transcript-error-hook-pre-start-");
+    await createTranscriptFixture("openclaw-chat-send-user-transcript-error-hook-pre-start-");
     mockState.hasBeforeAgentRunHooks = true;
     mockState.dispatchError = new Error("resolver unavailable");
     const respond = vi.fn();
@@ -6387,7 +6400,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("emits a user transcript update when chat.send fails after agent start but before runtime persistence", async () => {
-    createTranscriptFixture("openclaw-chat-send-user-transcript-error-before-runtime-persist-");
+    await createTranscriptFixture(
+      "openclaw-chat-send-user-transcript-error-before-runtime-persist-",
+    );
     mockState.triggerAgentRunStart = true;
     mockState.dispatchErrorAfterAgentRunStart = new Error("cli backend unavailable");
     const respond = vi.fn();
@@ -6417,7 +6432,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("applies before_message_write redaction to gateway fallback user transcript persistence", async () => {
-    createTranscriptFixture("openclaw-chat-send-user-transcript-error-before-write-redact-");
+    await createTranscriptFixture("openclaw-chat-send-user-transcript-error-before-write-redact-");
     mockState.triggerAgentRunStart = true;
     mockState.dispatchErrorAfterAgentRunStart = new Error("cli backend unavailable");
     mockState.beforeMessageWriteContent = "[redacted by hook]";
@@ -6444,7 +6459,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("does not persist gateway fallback user transcripts blocked by before_message_write", async () => {
-    createTranscriptFixture("openclaw-chat-send-user-transcript-error-before-write-block-");
+    await createTranscriptFixture("openclaw-chat-send-user-transcript-error-before-write-block-");
     mockState.triggerAgentRunStart = true;
     mockState.dispatchErrorAfterAgentRunStart = new Error("cli backend unavailable");
     mockState.beforeMessageWriteBlock = true;
@@ -6470,7 +6485,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("emits a user transcript update when a started agent returns an error before runtime persistence", async () => {
-    createTranscriptFixture("openclaw-chat-send-user-transcript-agent-error-no-runtime-persist-");
+    await createTranscriptFixture(
+      "openclaw-chat-send-user-transcript-agent-error-no-runtime-persist-",
+    );
     mockState.triggerAgentRunStart = true;
     mockState.finalPayload = { text: "agent failed before prompt append", isError: true };
     const respond = vi.fn();
@@ -6498,7 +6515,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("falls back to gateway user persistence when successful runtime persistence fails", async () => {
-    createTranscriptFixture("openclaw-chat-send-user-transcript-success-runtime-persist-failed-");
+    await createTranscriptFixture(
+      "openclaw-chat-send-user-transcript-success-runtime-persist-failed-",
+    );
     mockState.triggerAgentRunStart = true;
     mockState.runtimeUserMessagePersistencePending = new Promise((_, reject) => {
       setTimeout(() => reject(new Error("runtime prompt mirror failed")), 0);
@@ -6530,7 +6549,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it("emits a user transcript update when hooks pass and a started agent returns an error", async () => {
-    createTranscriptFixture("openclaw-chat-send-user-transcript-agent-error-hook-pass-");
+    await createTranscriptFixture("openclaw-chat-send-user-transcript-agent-error-hook-pass-");
     mockState.triggerAgentRunStart = true;
     mockState.hasBeforeAgentRunHooks = true;
     mockState.finalPayload = { text: "agent failed before prompt append", isError: true };

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1,7 +1,6 @@
 // Chat gateway methods implement chat.send/history/abort/inject/metadata and
 // bridge UI RPCs to agent dispatch, transcripts, media, and streaming state.
 import { createHash, randomUUID } from "node:crypto";
-import fs from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
@@ -64,17 +63,19 @@ import {
   type StageSandboxMediaResult,
 } from "../../auto-reply/reply/stage-sandbox-media.js";
 import type { MsgContext, TemplateContext } from "../../auto-reply/templating.js";
-import {
-  resolveSessionFilePath,
-  resolveSessionWorkStartError,
-  updateSessionStoreEntry,
-} from "../../config/sessions.js";
+import { resolveSessionWorkStartError } from "../../config/sessions.js";
 import {
   resolveSessionRoutingContract,
   SESSION_ROUTING_CHANGED_ERROR_REASON,
 } from "../../config/sessions/main-session.js";
+import {
+  findTranscriptEvent,
+  loadTranscriptEvents,
+  patchSessionEntry,
+  type SessionTranscriptWriteScope,
+  type TranscriptEvent,
+} from "../../config/sessions/session-accessor.js";
 import { resolveMirroredTranscriptText } from "../../config/sessions/transcript-mirror.js";
-import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   claimAgentRunContext,
@@ -192,7 +193,6 @@ import {
 } from "../server-shared.js";
 import { resolveSessionHistoryTailReadOptions } from "../session-history-state.js";
 import { persistGatewaySessionLifecycleEvent } from "../session-lifecycle-state.js";
-import { readSessionTranscriptIndex } from "../session-transcript-index.fs.js";
 import {
   capArrayByJsonBytes,
   readRecentSessionMessagesWithStatsAsync,
@@ -1722,82 +1722,82 @@ export function reportOmittedChatHistory(params: {
   return omittedCount;
 }
 
-function resolveTranscriptPath(params: {
+type AssistantTranscriptScopeParams = {
   sessionId: string;
   storePath: string | undefined;
-  sessionFile?: string;
+  sessionKey: string;
   agentId?: string;
-}): string | null {
-  const { sessionId, storePath, sessionFile, agentId } = params;
-  if (!storePath && !sessionFile) {
+};
+
+type SourceReplyTranscriptMirrorMetadata = NonNullable<
+  ReturnType<typeof getReplyPayloadMetadata>
+>["sourceReplyTranscriptMirror"];
+
+type SourceReplyContentState = {
+  broadcastContent: AssistantDisplayContentBlock[];
+  persistedContent: AssistantDisplayContentBlock[];
+  hasManagedOutgoingContent: boolean;
+  backedManagedOutgoingContent: boolean;
+};
+
+function assistantTranscriptScope(
+  params: AssistantTranscriptScopeParams,
+): SessionTranscriptWriteScope | null {
+  const sessionKey = params.sessionKey.trim();
+  if (!sessionKey || !params.sessionId.trim()) {
     return null;
   }
-  try {
-    const sessionsDir = storePath ? path.dirname(storePath) : undefined;
-    return resolveSessionFilePath(
-      sessionId,
-      sessionFile ? { sessionFile } : undefined,
-      sessionsDir || agentId ? { sessionsDir, agentId } : undefined,
-    );
-  } catch {
-    return null;
-  }
+  return {
+    sessionKey,
+    sessionId: params.sessionId,
+    ...(params.storePath ? { storePath: params.storePath } : {}),
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+  };
 }
 
-function ensureTranscriptFile(params: { transcriptPath: string; sessionId: string }): {
-  ok: boolean;
-  error?: string;
-} {
-  if (fs.existsSync(params.transcriptPath)) {
-    return { ok: true };
-  }
-  try {
-    fs.mkdirSync(path.dirname(params.transcriptPath), { recursive: true });
-    const header = {
-      type: "session",
-      version: CURRENT_SESSION_VERSION,
-      id: params.sessionId,
-      timestamp: new Date().toISOString(),
-      cwd: process.cwd(),
-    };
-    fs.writeFileSync(params.transcriptPath, `${JSON.stringify(header)}\n`, {
-      encoding: "utf-8",
-      mode: 0o600,
-    });
-    return { ok: true };
-  } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err) };
-  }
+function transcriptEventRecord(event: TranscriptEvent): Record<string, unknown> | undefined {
+  return event && typeof event === "object" && !Array.isArray(event)
+    ? (event as Record<string, unknown>)
+    : undefined;
 }
 
-async function findAssistantTranscriptMessageByIdempotencyKey(
-  transcriptPath: string,
+function transcriptEventId(event: TranscriptEvent): string | undefined {
+  const id = transcriptEventRecord(event)?.id;
+  return typeof id === "string" && id.trim().length > 0 ? id : undefined;
+}
+
+function transcriptEventMessage(event: TranscriptEvent): Record<string, unknown> | undefined {
+  const message = transcriptEventRecord(event)?.message;
+  return message && typeof message === "object" && !Array.isArray(message)
+    ? (message as Record<string, unknown>)
+    : undefined;
+}
+
+function findAssistantTranscriptMessageByIdempotencyKeyInEvents(
+  events: readonly TranscriptEvent[],
   idempotencyKey: string,
-): Promise<{ messageId: string; message: Record<string, unknown> } | null> {
+): { messageId: string; message: Record<string, unknown> } | null {
   const trimmedIdempotencyKey = idempotencyKey.trim();
   if (!trimmedIdempotencyKey) {
     return null;
   }
-  const index = await readSessionTranscriptIndex(transcriptPath, { view: "all" });
-  const target = index?.entries.toReversed().find((entry) => {
-    const message = entry.record.message as Record<string, unknown> | undefined;
+  const target = events.toReversed().find((event) => {
+    const message = transcriptEventMessage(event);
     return message?.role === "assistant" && message.idempotencyKey === trimmedIdempotencyKey;
   });
-  const message = target?.record.message as Record<string, unknown> | undefined;
-  if (!target || !message) {
+  const message = target ? transcriptEventMessage(target) : undefined;
+  const messageId = target ? transcriptEventId(target) : undefined;
+  if (!messageId || !message) {
     return null;
   }
-  return { messageId: target.id ?? trimmedIdempotencyKey, message };
+  return { messageId, message };
 }
 
-async function findSourceReplyTranscriptMirrorByIdempotencyKey(
-  transcriptPath: string,
+function findSourceReplyTranscriptMirrorByIdempotencyKeyInEvents(
+  events: readonly TranscriptEvent[],
   idempotencyKey: string,
-): Promise<{ messageId: string; message: Record<string, unknown> } | null> {
-  const found = await findAssistantTranscriptMessageByIdempotencyKey(
-    transcriptPath,
-    idempotencyKey,
-  );
+): { messageId: string; message: Record<string, unknown> } | null {
+  const found = findAssistantTranscriptMessageByIdempotencyKeyInEvents(events, idempotencyKey);
   if (found?.message.provider !== "openclaw" || found.message.model !== "delivery-mirror") {
     return null;
   }
@@ -1824,13 +1824,13 @@ function extractAssistantTranscriptText(message: Record<string, unknown>): strin
   return text || undefined;
 }
 
-async function findSourceReplyTranscriptMirrorByMetadata(params: {
-  transcriptPath: string;
+function findSourceReplyTranscriptMirrorByMetadataInEvents(params: {
+  events: readonly TranscriptEvent[];
   idempotencyKey: string;
-  metadata: NonNullable<ReturnType<typeof getReplyPayloadMetadata>>["sourceReplyTranscriptMirror"];
-}): Promise<{ messageId: string; message: Record<string, unknown> } | null> {
-  const byIdempotencyKey = await findSourceReplyTranscriptMirrorByIdempotencyKey(
-    params.transcriptPath,
+  metadata: SourceReplyTranscriptMirrorMetadata;
+}): { messageId: string; message: Record<string, unknown> } | null {
+  const byIdempotencyKey = findSourceReplyTranscriptMirrorByIdempotencyKeyInEvents(
+    params.events,
     params.idempotencyKey,
   );
   if (byIdempotencyKey) {
@@ -1843,23 +1843,35 @@ async function findSourceReplyTranscriptMirrorByMetadata(params: {
   if (!expectedText) {
     return null;
   }
-  const index = await readSessionTranscriptIndex(params.transcriptPath, { view: "all" });
-  const target = index?.entries.toReversed().find((entry) => {
-    const message = entry.record.message as Record<string, unknown> | undefined;
+  const target = params.events.toReversed().find((event) => {
+    const message = transcriptEventMessage(event);
     return (
-      typeof entry.id === "string" &&
-      entry.id.trim().length > 0 &&
+      typeof transcriptEventId(event) === "string" &&
       message?.role === "assistant" &&
       message.provider === "openclaw" &&
       message.model === "delivery-mirror" &&
       extractAssistantTranscriptText(message) === expectedText
     );
   });
-  const message = target?.record.message as Record<string, unknown> | undefined;
-  if (!target?.id || !message) {
+  const message = target ? transcriptEventMessage(target) : undefined;
+  const messageId = target ? transcriptEventId(target) : undefined;
+  if (!messageId || !message) {
     return null;
   }
-  return { messageId: target.id, message };
+  return { messageId, message };
+}
+
+async function transcriptExists(scope: SessionTranscriptWriteScope): Promise<boolean> {
+  const sessionId = scope.sessionId;
+  if (!sessionId) {
+    return false;
+  }
+  // Existence probe: the newest-first matcher returns on the first record, so
+  // this reads one transcript line instead of materializing the whole file.
+  const found = await findTranscriptEvent({ ...scope, sessionId }, () => true).catch(
+    () => undefined,
+  );
+  return found !== undefined;
 }
 
 async function appendAssistantTranscriptMessage(params: {
@@ -1881,42 +1893,18 @@ async function appendAssistantTranscriptMessage(params: {
   ttsSupplement?: GatewayInjectedTtsSupplementMarker;
   cfg?: OpenClawConfig;
 }): Promise<TranscriptAppendResult> {
-  const transcriptPath = resolveTranscriptPath({
-    sessionId: params.sessionId,
-    storePath: params.storePath,
-    sessionFile: params.sessionFile,
-    agentId: params.agentId,
-  });
-  if (!transcriptPath) {
-    return { ok: false, error: "transcript path not resolved" };
+  const scope = assistantTranscriptScope(params);
+  if (!scope) {
+    return { ok: false, error: "transcript identity not resolved" };
   }
-
-  if (!fs.existsSync(transcriptPath)) {
-    if (!params.createIfMissing) {
-      return { ok: false, error: "transcript file not found" };
-    }
-    const ensured = ensureTranscriptFile({
-      transcriptPath,
-      sessionId: params.sessionId,
-    });
-    if (!ensured.ok) {
-      return { ok: false, error: ensured.error ?? "failed to create transcript file" };
-    }
-  }
-
-  if (params.idempotencyKey) {
-    const existing = await findAssistantTranscriptMessageByIdempotencyKey(
-      transcriptPath,
-      params.idempotencyKey,
-    );
-    if (existing) {
-      return { ok: true, messageId: existing.messageId, message: existing.message };
-    }
+  if (!params.createIfMissing && !(await transcriptExists(scope))) {
+    return { ok: false, error: "transcript not found" };
   }
 
   const appended = await appendInjectedAssistantMessageToTranscript({
-    transcriptPath,
     sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+    storePath: params.storePath,
     ...(params.agentId ? { agentId: params.agentId } : {}),
     message: params.message,
     label: params.label,
@@ -1926,32 +1914,158 @@ async function appendAssistantTranscriptMessage(params: {
     ttsSupplement: params.ttsSupplement,
     config: params.cfg,
   });
-  if (appended.ok) {
-    await advanceSessionTranscriptMarker({
-      storePath: params.storePath,
-      sessionKey: params.sessionKey,
-      sessionId: params.sessionId,
-    });
-  }
   return appended;
 }
 
-async function advanceSessionTranscriptMarker(params: {
-  storePath: string | undefined;
-  sessionKey: string;
-  sessionId: string;
-}): Promise<void> {
-  if (!params.storePath) {
+async function touchAssistantTranscriptSessionEntry(
+  scope: SessionTranscriptWriteScope,
+): Promise<void> {
+  if (!scope.storePath || !scope.sessionKey || !scope.sessionId) {
     return;
   }
-
   const transcriptMarkerUpdatedAt = Date.now();
-  await updateSessionStoreEntry({
-    storePath: params.storePath,
-    sessionKey: params.sessionKey,
-    update: (current) =>
-      current.sessionId === params.sessionId ? { updatedAt: transcriptMarkerUpdatedAt } : null,
+  await patchSessionEntry(
+    {
+      storePath: scope.storePath,
+      sessionKey: scope.sessionKey,
+      ...(scope.agentId ? { agentId: scope.agentId } : {}),
+    },
+    (current) =>
+      current.sessionId === scope.sessionId ? { updatedAt: transcriptMarkerUpdatedAt } : null,
+    {
+      skipMaintenance: true,
+    },
+  );
+}
+
+async function rewriteSourceReplyTranscriptMirrors(params: {
+  candidates: readonly {
+    idempotencyKey: string;
+    metadata: SourceReplyTranscriptMirrorMetadata;
+  }[];
+  requests: readonly {
+    idempotencyKey: string;
+    metadata: SourceReplyTranscriptMirrorMetadata;
+    state: SourceReplyContentState;
+  }[];
+  scope: SessionTranscriptWriteScope;
+  config?: OpenClawConfig;
+}): Promise<
+  Array<{
+    messageId?: string;
+    request: {
+      idempotencyKey: string;
+      metadata: SourceReplyTranscriptMirrorMetadata;
+      state: SourceReplyContentState;
+    };
+  }>
+> {
+  const { sessionId, sessionKey } = params.scope;
+  if (!sessionId || !sessionKey || params.requests.length === 0 || params.candidates.length === 0) {
+    return [];
+  }
+
+  const events = await loadTranscriptEvents({ ...params.scope, sessionId });
+  const allowedSourceReplyMirrorIds = new Set<string>();
+  for (const candidate of params.candidates) {
+    const target = findSourceReplyTranscriptMirrorByMetadataInEvents({
+      events,
+      idempotencyKey: candidate.idempotencyKey,
+      metadata: candidate.metadata,
+    });
+    if (target) {
+      allowedSourceReplyMirrorIds.add(target.messageId);
+    }
+  }
+
+  const rewriteTargets: Array<{
+    request: (typeof params.requests)[number];
+    messageId: string;
+    message: Record<string, unknown>;
+  }> = [];
+  for (const request of params.requests) {
+    const target = findSourceReplyTranscriptMirrorByMetadataInEvents({
+      events,
+      idempotencyKey: request.idempotencyKey,
+      metadata: request.metadata,
+    });
+    if (target) {
+      rewriteTargets.push({ request, ...target });
+    }
+  }
+  if (rewriteTargets.length === 0) {
+    return [];
+  }
+
+  const rewriteTargetIds = new Set(rewriteTargets.map((target) => target.messageId));
+  // Guard over visible records (messages/compaction) only: hidden tree records
+  // such as leaf controls may trail the mirrors and must not veto the rewrite.
+  const visibleEvents = events.filter((event) => {
+    const record = transcriptEventRecord(event);
+    return Boolean(record?.message) || record?.type === "compaction";
   });
+  const firstRewriteEntryIndex = visibleEvents.findIndex((event) => {
+    const id = transcriptEventId(event);
+    return id ? rewriteTargetIds.has(id) : false;
+  });
+  const canRewriteSourceReplyMirrors =
+    firstRewriteEntryIndex >= 0 &&
+    visibleEvents.slice(firstRewriteEntryIndex).every((event) => {
+      const id = transcriptEventId(event);
+      return !id || allowedSourceReplyMirrorIds.has(id);
+    });
+  if (!canRewriteSourceReplyMirrors) {
+    return [];
+  }
+
+  const result = await rewriteTranscriptEntriesInRuntimeTranscript({
+    scope: {
+      sessionId,
+      sessionKey,
+      ...(params.scope.agentId ? { agentId: params.scope.agentId } : {}),
+      ...(params.scope.storePath ? { storePath: params.scope.storePath } : {}),
+    },
+    request: {
+      allowedRewriteSuffixEntryIds: [...allowedSourceReplyMirrorIds],
+      replacements: rewriteTargets.map((target) => ({
+        entryId: target.messageId,
+        message: {
+          ...(target.message as unknown as AgentMessage),
+          idempotencyKey: target.request.idempotencyKey,
+          content: target.request.state.persistedContent,
+        } as unknown as AgentMessage,
+      })),
+    },
+    ...(params.config ? { config: params.config } : {}),
+  });
+  if (!result.changed) {
+    return [];
+  }
+
+  // The file-backed rewrite appends replacement entries under fresh ids, so
+  // re-read the transcript to hand callers the persisted mirror ids.
+  const rewrittenEvents = await loadTranscriptEvents({ ...params.scope, sessionId });
+  return rewriteTargets.map((target) => {
+    const rewritten = findSourceReplyTranscriptMirrorByIdempotencyKeyInEvents(
+      rewrittenEvents,
+      target.request.idempotencyKey,
+    );
+    return rewritten?.messageId
+      ? { messageId: rewritten.messageId, request: target.request }
+      : { request: target.request };
+  });
+}
+
+async function publishAssistantTranscriptRewrite(params: {
+  scope: SessionTranscriptWriteScope;
+  rewritten: readonly { messageId?: string }[];
+}): Promise<void> {
+  if (params.rewritten.length === 0) {
+    return;
+  }
+  // The file-backed rewrite emits its own transcript update; only the session
+  // marker touch remains so history readers observe the fresh updatedAt.
+  await touchAssistantTranscriptSessionEntry(params.scope);
 }
 
 function collectSessionAbortPartials(params: {
@@ -4540,15 +4654,9 @@ export const chatHandlers: GatewayRequestHandlers = {
           sessionLoadOptions,
         );
         const sessionId = latestEntry?.sessionId ?? backingSessionId ?? clientRunId;
-        const resolvedTranscriptPath = resolveTranscriptPath({
-          sessionId,
-          storePath: latestStorePath,
-          sessionFile: latestEntry?.sessionFile ?? entry?.sessionFile,
-          agentId,
-        });
         const mediaLocalRoots = appendLocalMediaParentRoots(
           getAgentScopedMediaLocalRoots(cfg, agentId),
-          resolvedTranscriptPath ? [resolvedTranscriptPath] : undefined,
+          latestStorePath ? [latestStorePath] : undefined,
         );
         const assistantContent = await buildAssistantDisplayContentFromReplyPayloads({
           sessionKey,
@@ -5156,15 +5264,9 @@ export const chatHandlers: GatewayRequestHandlers = {
                     sessionLoadOptions,
                   );
                   const sessionId = latestEntry?.sessionId ?? backingSessionId ?? clientRunId;
-                  const resolvedTranscriptPath = resolveTranscriptPath({
-                    sessionId,
-                    storePath: latestStorePath,
-                    sessionFile: latestEntry?.sessionFile ?? entry?.sessionFile,
-                    agentId,
-                  });
                   const mediaLocalRoots = appendLocalMediaParentRoots(
                     getAgentScopedMediaLocalRoots(cfg, agentId),
-                    resolvedTranscriptPath ? [resolvedTranscriptPath] : undefined,
+                    latestStorePath ? [latestStorePath] : undefined,
                   );
                   const assistantContent = await buildAssistantDisplayContentFromReplyPayloads({
                     sessionKey,
@@ -5357,15 +5459,9 @@ export const chatHandlers: GatewayRequestHandlers = {
                     sessionLoadOptions,
                   );
                   const sessionId = latestEntry?.sessionId ?? backingSessionId ?? clientRunId;
-                  const resolvedTranscriptPath = resolveTranscriptPath({
-                    sessionId,
-                    storePath: latestStorePath,
-                    sessionFile: latestEntry?.sessionFile ?? entry?.sessionFile,
-                    agentId,
-                  });
                   const mediaLocalRoots = appendLocalMediaParentRoots(
                     getAgentScopedMediaLocalRoots(cfg, agentId),
-                    resolvedTranscriptPath ? [resolvedTranscriptPath] : undefined,
+                    latestStorePath ? [latestStorePath] : undefined,
                   );
                   const buildReplyAssistantContent = async (
                     payloads: typeof finalPayloads,
@@ -5404,12 +5500,6 @@ export const chatHandlers: GatewayRequestHandlers = {
                     agentRunReplyPayloads.length === 1
                       ? await buildReplyMediaMessage(finalPayloads)
                       : undefined;
-                  type SourceReplyContentState = {
-                    broadcastContent: AssistantDisplayContentBlock[];
-                    persistedContent: AssistantDisplayContentBlock[];
-                    hasManagedOutgoingContent: boolean;
-                    backedManagedOutgoingContent: boolean;
-                  };
                   const sourceReplyContentStates: SourceReplyContentState[] = [];
                   const sourceReplyBroadcastContent: AssistantDisplayContentBlock[] = [];
                   for (const [replyIndex] of agentRunReplyPayloads.entries()) {
@@ -5455,9 +5545,7 @@ export const chatHandlers: GatewayRequestHandlers = {
                   if (sourceReplyBroadcastContent.length || displayReply) {
                     const sourceReplyPersistenceRequests: Array<{
                       idempotencyKey: string;
-                      metadata: NonNullable<
-                        ReturnType<typeof getReplyPayloadMetadata>
-                      >["sourceReplyTranscriptMirror"];
+                      metadata: SourceReplyTranscriptMirrorMetadata;
                       state: SourceReplyContentState;
                     }> = [];
                     for (const [
@@ -5486,6 +5574,32 @@ export const chatHandlers: GatewayRequestHandlers = {
                         state,
                       });
                     }
+                    const sourceReplyMirrorCandidates: Array<{
+                      idempotencyKey: string;
+                      metadata: SourceReplyTranscriptMirrorMetadata;
+                    }> = [];
+                    for (const [
+                      replyIndex,
+                      sourceReplyPayload,
+                    ] of agentRunReplyPayloads.entries()) {
+                      if (!sourceReplyContentStates[replyIndex]) {
+                        continue;
+                      }
+                      const mirrorMetadata =
+                        getReplyPayloadMetadata(sourceReplyPayload)?.sourceReplyTranscriptMirror;
+                      const mirrorIdempotencyKey = mirrorMetadata?.idempotencyKey;
+                      if (
+                        typeof mirrorIdempotencyKey !== "string" ||
+                        mirrorIdempotencyKey.trim().length === 0 ||
+                        !mirrorMetadata
+                      ) {
+                        continue;
+                      }
+                      sourceReplyMirrorCandidates.push({
+                        idempotencyKey: mirrorIdempotencyKey,
+                        metadata: mirrorMetadata,
+                      });
+                    }
 
                     const attachSourceReplyManagedImages = async (paramsLocal: {
                       messageId?: string;
@@ -5505,115 +5619,29 @@ export const chatHandlers: GatewayRequestHandlers = {
                       paramsLocal.request.state.backedManagedOutgoingContent = true;
                     };
 
-                    if (resolvedTranscriptPath && sourceReplyPersistenceRequests.length > 0) {
-                      const allowedSourceReplyMirrorIds = new Set<string>();
-                      for (const [
-                        replyIndex,
-                        sourceReplyPayload,
-                      ] of agentRunReplyPayloads.entries()) {
-                        if (!sourceReplyContentStates[replyIndex]) {
-                          continue;
-                        }
-                        const mirrorIdempotencyKey =
-                          getReplyPayloadMetadata(sourceReplyPayload)?.sourceReplyTranscriptMirror
-                            ?.idempotencyKey;
-                        const mirrorMetadata =
-                          getReplyPayloadMetadata(sourceReplyPayload)?.sourceReplyTranscriptMirror;
-                        if (
-                          typeof mirrorIdempotencyKey !== "string" ||
-                          mirrorIdempotencyKey.trim().length === 0 ||
-                          !mirrorMetadata
-                        ) {
-                          continue;
-                        }
-                        const target = await findSourceReplyTranscriptMirrorByMetadata({
-                          transcriptPath: resolvedTranscriptPath,
-                          idempotencyKey: mirrorIdempotencyKey,
-                          metadata: mirrorMetadata,
+                    const sourceReplyScope = assistantTranscriptScope({
+                      sessionId,
+                      sessionKey,
+                      storePath: latestStorePath,
+                      agentId,
+                    });
+                    if (sourceReplyScope && sourceReplyPersistenceRequests.length > 0) {
+                      const rewritten = await rewriteSourceReplyTranscriptMirrors({
+                        candidates: sourceReplyMirrorCandidates,
+                        requests: sourceReplyPersistenceRequests,
+                        scope: sourceReplyScope,
+                        config: cfg,
+                      });
+                      if (rewritten.length > 0) {
+                        await publishAssistantTranscriptRewrite({
+                          scope: sourceReplyScope,
+                          rewritten,
                         });
-                        if (target) {
-                          allowedSourceReplyMirrorIds.add(target.messageId);
-                        }
-                      }
-                      const rewriteTargets: Array<{
-                        request: (typeof sourceReplyPersistenceRequests)[number];
-                        messageId: string;
-                        message: Record<string, unknown>;
-                      }> = [];
-                      for (const request of sourceReplyPersistenceRequests) {
-                        const target = await findSourceReplyTranscriptMirrorByMetadata({
-                          transcriptPath: resolvedTranscriptPath,
-                          idempotencyKey: request.idempotencyKey,
-                          metadata: request.metadata,
-                        });
-                        if (target) {
-                          rewriteTargets.push({ request, ...target });
-                        }
-                      }
-
-                      if (rewriteTargets.length > 0) {
-                        const rewriteTargetIds = new Set(
-                          rewriteTargets.map((target) => target.messageId),
-                        );
-                        const rewriteIndex = await readSessionTranscriptIndex(
-                          resolvedTranscriptPath,
-                          { view: "all" },
-                        );
-                        const firstRewriteEntryIndex =
-                          rewriteIndex?.entries.findIndex(
-                            (entryValue) =>
-                              typeof entryValue.id === "string" &&
-                              rewriteTargetIds.has(entryValue.id),
-                          ) ?? -1;
-                        const canRewriteSourceReplyMirrors =
-                          firstRewriteEntryIndex >= 0 &&
-                          rewriteIndex?.entries
-                            .slice(firstRewriteEntryIndex)
-                            .every(
-                              (entryLocal) =>
-                                typeof entryLocal.id !== "string" ||
-                                allowedSourceReplyMirrorIds.has(entryLocal.id),
-                            ) === true;
-                        if (canRewriteSourceReplyMirrors) {
-                          const result = await rewriteTranscriptEntriesInRuntimeTranscript({
-                            scope: {
-                              sessionId,
-                              sessionKey,
-                              sessionFile: resolvedTranscriptPath,
-                              agentId,
-                              ...(latestStorePath ? { storePath: latestStorePath } : {}),
-                            },
-                            request: {
-                              allowedRewriteSuffixEntryIds: [...allowedSourceReplyMirrorIds],
-                              replacements: rewriteTargets.map((target) => ({
-                                entryId: target.messageId,
-                                message: {
-                                  ...(target.message as unknown as AgentMessage),
-                                  idempotencyKey: target.request.idempotencyKey,
-                                  content: target.request.state.persistedContent,
-                                } as unknown as AgentMessage,
-                              })),
-                            },
-                            config: cfg,
+                        for (const target of rewritten) {
+                          await attachSourceReplyManagedImages({
+                            messageId: target.messageId,
+                            request: target.request,
                           });
-                          if (result.changed) {
-                            await advanceSessionTranscriptMarker({
-                              storePath: latestStorePath,
-                              sessionKey,
-                              sessionId,
-                            });
-                            for (const target of rewriteTargets) {
-                              const rewritten =
-                                await findSourceReplyTranscriptMirrorByIdempotencyKey(
-                                  resolvedTranscriptPath,
-                                  target.request.idempotencyKey,
-                                );
-                              await attachSourceReplyManagedImages({
-                                messageId: rewritten?.messageId,
-                                request: target.request,
-                              });
-                            }
-                          }
                         }
                       }
                     }

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -153,6 +153,7 @@ describe("session accessor boundary guard", () => {
         "src/config/sessions/cleanup-service.ts",
         "src/config/sessions/goals.ts",
         "src/gateway/boot.ts",
+        "src/gateway/server-methods/chat.ts",
         "src/gateway/server-methods/sessions.ts",
         "src/gateway/server-node-events.ts",
         "src/gateway/session-compaction-checkpoints.ts",


### PR DESCRIPTION
## What Problem This Solves

`swift test --package-path apps/shared/OpenClawKit` fails on any Mac where the OpenClaw app previously paired: `GatewayNodeSessionTests` "non bootstrap hello stores primary device token but not additional bootstrap tokens" and "untrusted bootstrap hello does not persist bootstrap handoff tokens" expect `DeviceAuthStore.loadToken` to return nil, but real operator/node device tokens leak into the per-test state dirs. CI (clean machines) passes, so the breakage only hits local development.

Root cause is in prod code, not the tests: `DeviceIdentityStore.loadOrCreate(profile:)` passes `DeviceIdentityPaths.appGroupMigrationSource(profile:)`, which on unentitled processes (test runners, the shipped mac app) points at the machine's real app-group container. Any fresh state dir has no identity file, so `migratedIdentity` copies the machine's real `device.json` and `device-auth.json` — real device tokens included — into every `OPENCLAW_STATE_DIR`-overridden temp dir. That contradicts the function's own contract comment ("only for builds whose store selection fell back to legacy storage"): an explicit override is not the legacy fallback.

## Why This Change Was Made

- `DeviceIdentityPaths.appGroupMigrationSource` now returns nil when `OPENCLAW_STATE_DIR` is set (new `stateDirOverridden` parameter on the injectable variant), honoring the documented legacy-fallback-only contract. Overridden stores (tests, relocated installs) no longer silently import the machine's real pairing identity and tokens.
- `StateDirectoryIsolationTrait` now owns test state-dir isolation instead of only serializing: it pins `OPENCLAW_STATE_DIR` to a fresh temp dir per gated test and afterwards restores the launch value or a run-scoped quarantine dir — never unset — so stray late writes from leaked reconnect tasks cannot reach the developer's real store. The identical 14-line setenv/defer block is deleted from 12 tests; net diff is +76/-191.

## User Impact

- Local `swift test` runs of OpenClawKit pass regardless of machine pairing state, and tests can no longer read or overwrite a developer's real device-auth store (the old behavior could clobber a real node token with a test literal).
- Product behavior change is narrow: unentitled builds running with an explicit `OPENCLAW_STATE_DIR` override no longer import app-group container identity into the override dir. Default store selection (container/legacy) is unchanged.

## Evidence

- Repro before fix (Mac with real pairing state): both tests fail with the machine's real tokens, `updatedAtMs` matching the app-group container store exactly.
- After fix: `swift test --package-path apps/shared/OpenClawKit --filter "GatewayNodeSessionTests|DeviceIdentityStoreTests"` passes 44/44 on the same polluted Mac, including the new regression test "provides no app group migration source when the state dir is overridden".
- Full package run: 600 tests / 55 suites green except one unrelated pre-existing flake (`ChatStreamReplayTests` reconnect timeout under full parallel load; passes standalone in 1.5s).
- Real machine stores verified byte-checked after runs: real tokens only, no test literals.
- Autoreview (Codex, gpt-5.5): clean, no actionable findings.
