### PR TITLE
fix(cli): proxy run signal handling + clone into existing-empty git checkout dir

### DIFF
--- a/src/cli/proxy-cli.runtime.test.ts
+++ b/src/cli/proxy-cli.runtime.test.ts
@@ -508,4 +508,46 @@ describe("proxy cli runtime", () => {
     expect(session?.mode).toBe("proxy-run");
     expect(session?.endedAt).toBeGreaterThanOrEqual(beforeRun);
   });
+
+  it("forwards SIGTERM to the child and ends the session before exiting", async () => {
+    const child = Object.assign(new EventEmitter(), {
+      killed: false,
+      kill: vi.fn((signal: NodeJS.Signals) => {
+        child.killed = true;
+        queueMicrotask(() => {
+          child.emit("exit", null, signal);
+        });
+        return true;
+      }),
+    });
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+
+    spawnMock.mockImplementation(() => child);
+
+    const { runDebugProxyRunCommand } = await import("./proxy-cli.runtime.js");
+    const { getDebugProxyCaptureStore } = await import("../proxy-capture/store.sqlite.js");
+
+    const beforeRun = Date.now();
+    const runPromise = runDebugProxyRunCommand({
+      commandArgs: ["long-lived"],
+    });
+
+    const sigtermListener = process.listeners("SIGTERM").at(-1);
+    expect(sigtermListener).toBeTypeOf("function");
+    (sigtermListener as () => void)();
+
+    await runPromise;
+
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(serverStopSpy).toHaveBeenCalledTimes(1);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    const store = getDebugProxyCaptureStore();
+    const [session] = store.listSessions(5);
+    expect(session?.mode).toBe("proxy-run");
+    expect(session?.endedAt).toBeGreaterThanOrEqual(beforeRun);
+
+    exitSpy.mockRestore();
+    process.exitCode = undefined;
+  });
 });

--- a/src/cli/proxy-cli.runtime.ts
+++ b/src/cli/proxy-cli.runtime.ts
@@ -79,7 +79,8 @@ export async function runDebugProxyRunCommand(opts: {
     ...baseSettings,
     sessionId,
   };
-  getDebugProxyCaptureStore().upsertSession({
+  const store = getDebugProxyCaptureStore();
+  store.upsertSession({
     id: sessionId,
     startedAt: Date.now(),
     mode: "proxy-run",
@@ -87,33 +88,87 @@ export async function runDebugProxyRunCommand(opts: {
     sourceProcess: "openclaw",
     proxyUrl: undefined,
   });
-  const server = await startDebugProxyServer({
-    host: opts.host,
-    port: opts.port,
-    settings,
-  });
   const [command, ...args] = opts.commandArgs;
+  let child: ReturnType<typeof spawn> | undefined = undefined;
+  let server: Awaited<ReturnType<typeof startDebugProxyServer>> | undefined;
+  // A signal can land while the server is still starting; remember it so the
+  // child spawned afterwards is killed instead of orphaned.
+  let pendingSignal: NodeJS.Signals | undefined;
+  let resolveChildDone: () => void = () => undefined;
+  let rejectChildDone: (error: unknown) => void = () => undefined;
+  const childDone = new Promise<void>((resolve, reject) => {
+    resolveChildDone = resolve;
+    rejectChildDone = reject;
+  });
+  let shutdownPromise: Promise<void> | null = null;
+  const shutdown = async (signal?: NodeJS.Signals) => {
+    if (shutdownPromise) {
+      return await shutdownPromise;
+    }
+    shutdownPromise = (async () => {
+      process.off("SIGINT", onSigint);
+      process.off("SIGTERM", onSigterm);
+      if (signal) {
+        pendingSignal = signal;
+      }
+      if (signal && child && !child.killed) {
+        child.kill(signal);
+      }
+      try {
+        await childDone;
+      } finally {
+        if (server) {
+          await server.stop();
+        }
+        store.endSession(sessionId);
+      }
+      if (signal) {
+        process.exit(process.exitCode ?? 1);
+      }
+    })();
+    return await shutdownPromise;
+  };
+  const onSigint = () => {
+    void shutdown("SIGINT");
+  };
+  const onSigterm = () => {
+    void shutdown("SIGTERM");
+  };
+  // Register before any await so Ctrl+C during startup still cleans up.
+  process.on("SIGINT", onSigint);
+  process.on("SIGTERM", onSigterm);
+  try {
+    server = await startDebugProxyServer({
+      host: opts.host,
+      port: opts.port,
+      settings,
+    });
+  } catch (error) {
+    rejectChildDone(error);
+    throw error;
+  }
   const childEnv = applyDebugProxyEnv(process.env, {
     proxyUrl: server.proxyUrl,
     sessionId,
     certDir: settings.certDir,
   });
+  child = spawn(command, args, {
+    stdio: "inherit",
+    env: childEnv,
+    cwd: process.cwd(),
+  });
+  child.once("error", rejectChildDone);
+  child.once("exit", (code, signal) => {
+    process.exitCode = signal ? 1 : (code ?? 1);
+    resolveChildDone();
+  });
+  if (pendingSignal && !child.killed) {
+    child.kill(pendingSignal);
+  }
   try {
-    await new Promise<void>((resolve, reject) => {
-      const child = spawn(command, args, {
-        stdio: "inherit",
-        env: childEnv,
-        cwd: process.cwd(),
-      });
-      child.once("error", reject);
-      child.once("exit", (code, signal) => {
-        process.exitCode = signal ? 1 : (code ?? 1);
-        resolve();
-      });
-    });
+    await childDone;
   } finally {
-    await server.stop();
-    getDebugProxyCaptureStore().endSession(sessionId);
+    await shutdown();
   }
 }
 

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -5471,6 +5471,37 @@ describe("update-cli", () => {
     expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
   });
 
+  it("clones into an existing empty OPENCLAW_GIT_DIR using dot as the destination", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-empty-git-dir-"));
+    pathExists.mockResolvedValue(true);
+    vi.mocked(runCommandWithTimeout).mockResolvedValue({
+      stdout: "cloned",
+      stderr: "",
+      code: 0,
+      signal: null,
+      killed: false,
+      termination: "exit",
+    });
+
+    try {
+      await ensureGitCheckout({
+        dir: tempDir,
+        timeoutMs: 5_000,
+        env: process.env,
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+
+    expect(runCommandWithTimeout).toHaveBeenCalledWith(
+      ["git", "clone", "https://github.com/openclaw/openclaw.git", "."],
+      expect.objectContaining({
+        cwd: tempDir,
+        timeoutMs: 5_000,
+      }),
+    );
+  });
+
   it("keeps the requested channel when plugin sync writes config after update", async () => {
     const tempDir = createCaseDir("openclaw-update");
     mockPackageInstallStatus(tempDir);

--- a/src/cli/update-cli/shared.ts
+++ b/src/cli/update-cli/shared.ts
@@ -265,7 +265,7 @@ export async function ensureGitCheckout(params: {
 
     return await runUpdateStep({
       name: "git clone",
-      argv: ["git", "clone", OPENCLAW_REPO_URL, params.dir],
+      argv: ["git", "clone", OPENCLAW_REPO_URL, "."],
       cwd: params.dir,
       env: gitEnv,
       timeoutMs: params.timeoutMs,


### PR DESCRIPTION
## Summary

- Problem: `openclaw proxy run -- <cmd>` ignores SIGINT/SIGTERM: the child process is orphaned on Ctrl+C, the proxy server is never stopped, and the capture session is never ended. A signal landing during server startup (before the child spawns) is lost entirely. Separately, `ensureGitCheckout` fails when `OPENCLAW_GIT_DIR` points at an existing empty directory, because `git clone <url> <dir>` runs with `cwd: <dir>`.
- Why it matters: orphaned children keep ports/resources held after the CLI exits, and capture sessions are left dangling in the store; the update path errors out on a perfectly valid empty checkout dir.
- What changed: `runDebugProxyRunCommand` registers SIGINT/SIGTERM handlers before any await, forwards the signal to the child, remembers a signal that lands mid-startup (`pendingSignal`) and applies it to the just-spawned child, and funnels all cleanup through one idempotent `shutdown()` that stops the server, ends the session, and exits with the child's code. `ensureGitCheckout` clones into `"."` with `cwd` set to the target dir.
- What did NOT change (scope boundary): `proxy start` signal handling, the capture store API, proxy validation output, and all other update-cli steps are untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Tests

- `pnpm test src/cli/proxy-cli.runtime.test.ts` — 14 passed, including a new test that fires SIGTERM mid-run and asserts the child is killed, the server stopped, the session ended, and the process exits 1.
- `pnpm test src/cli/update-cli.test.ts` — 182 passed, including a new test asserting the clone into an existing empty `OPENCLAW_GIT_DIR` uses `.` as the destination.
- `pnpm tsgo` green; `pnpm lint` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
