### PR TITLE
fix(telegram): keep DM topic auto-rename user message UTF-16 safe

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -6371,6 +6371,36 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(bot.api["editForumTopic"]).not.toHaveBeenCalled();
   });
 
+  it("truncates DM topic auto-rename input on UTF-16 boundaries", async () => {
+    const sessionKey = "agent:default:telegram:direct:123";
+    loadSessionStore.mockReturnValue({
+      [sessionKey]: { sessionId: "s1", updatedAt: 1 },
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({ queuedFinal: true });
+    const bot = createBot();
+    const base = "a".repeat(499);
+    const rawBody = `${base}😀tail`;
+
+    await dispatchWithContext({
+      bot,
+      context: createContext({
+        ctxPayload: {
+          SessionKey: sessionKey,
+          RawBody: rawBody,
+        } as TelegramMessageContext["ctxPayload"],
+      }),
+      telegramCfg: { autoTopicLabel: true },
+    });
+
+    await vi.waitFor(() => {
+      expect(generateTopicLabel).toHaveBeenCalled();
+    });
+    const call = generateTopicLabel.mock.calls[0]?.[0] as { userMessage: string };
+    expect(call.userMessage.length).toBeLessThanOrEqual(500);
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(call.userMessage)).toBe(false);
+    expect(call.userMessage).toBe(base);
+  });
+
   it("does not emit a silent-reply fallback when the dispatcher reports a queued final reply", async () => {
     dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
       queuedFinal: true,

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -6396,8 +6396,6 @@ describe("dispatchTelegramMessage draft streaming", () => {
       expect(generateTopicLabel).toHaveBeenCalled();
     });
     const call = generateTopicLabel.mock.calls[0]?.[0] as { userMessage: string };
-    expect(call.userMessage.length).toBeLessThanOrEqual(500);
-    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(call.userMessage)).toBe(false);
     expect(call.userMessage).toBe(base);
   });
 

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -55,6 +55,7 @@ import {
   readLatestAssistantTextByIdentity,
 } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { stripInlineDirectiveTagsForDelivery } from "openclaw/plugin-sdk/text-chunking";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveTelegramConfigReasoningDefault } from "./agent-config.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
@@ -3074,7 +3075,7 @@ export const dispatchTelegramMessage = async ({
 
   // Fire-and-forget: auto-rename DM topic on first message.
   if (isDmTopic && isFirstTurnInSession) {
-    const userMessage = (ctxPayload.RawBody ?? ctxPayload.Body ?? "").slice(0, 500);
+    const userMessage = truncateUtf16Safe(ctxPayload.RawBody ?? ctxPayload.Body ?? "", 500);
     if (userMessage.trim()) {
       const agentDir = resolveAgentDir(cfg, route.agentId);
       const directAutoTopicLabel =


### PR DESCRIPTION
## What Problem This Solves

Telegram DM-topic auto-labeling caps the first user message at 500 UTF-16 code units before sending it to the label model. A raw `slice(0, 500)` can stop after the high surrogate of an astral character and make OpenClaw pass malformed text into topic-label generation.

## Why This Change Was Made

The Telegram-owned boundary now uses the existing `truncateUtf16Safe` helper from `openclaw/plugin-sdk/text-utility-runtime`. The 500-unit cap, raw-body preference, first-turn condition, configuration resolution, fire-and-forget behavior, and Telegram topic edit remain unchanged.

## User Impact

A long first message in a Telegram DM topic no longer acquires a surrogate half when an emoji crosses the auto-label input boundary. Short messages and messages not crossing an astral-character boundary remain unchanged.

## Evidence

- The production `dispatchTelegramMessage` regression places an emoji's high surrogate exactly at code-unit index 499 and asserts that `generateTopicLabel` receives the exact 499-character prefix.
- Blacksmith Testbox run [28996475282](https://github.com/openclaw/openclaw/actions/runs/28996475282): the full `bot-message-dispatch.test.ts` shard passed, 172/172.
- `git diff --check`: passed.
- Fresh structured autoreview: clean, no accepted/actionable findings; confidence 0.99.

## Live proof status

The required real-user Telegram harness was attempted. It stopped before leasing a credential or creating a Crabbox because the configured Convex burner credential file was absent and no environment override was available. The current harness also exercises an ordinary burner user/group, not a Telegram Business DM-topic update, so it cannot directly force this owner branch. No personal account was used and no live-behavior claim is made.
