### PR TITLE
fix(slack): keep thread label snippet truncation UTF-16 safe

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context-root.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context-root.test.ts
@@ -244,4 +244,11 @@ describe("formatSlackBotStarterThreadLabel", () => {
       }),
     ).toBe("Slack thread DM (assistant root): Line one Line two");
   });
+
+  it("drops a surrogate-pair emoji whole when it straddles the 80-char snippet limit", () => {
+    const starterText = `${"a".repeat(79)}🐱tail`;
+    const label = formatSlackBotStarterThreadLabel({ roomLabel: "DM", starterText });
+    expect(label).toBe(`Slack thread DM (assistant root): ${"a".repeat(79)}`);
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(label)).toBe(false);
+  });
 });

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context-root.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context-root.ts
@@ -1,4 +1,6 @@
 // Slack plugin module implements prepare thread context root behavior.
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+
 export type SlackBotAuthorIdentity = {
   botUserId?: string;
   botId?: string;
@@ -107,7 +109,7 @@ export function formatSlackBotStarterThreadLabel(params: {
   if (!params.starterText) {
     return base;
   }
-  const snippet = params.starterText.replace(/\s+/g, " ").slice(0, 80).trim();
+  const snippet = truncateUtf16Safe(params.starterText.replace(/\s+/g, " "), 80).trim();
   if (!snippet) {
     return base;
   }

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
@@ -8,6 +8,7 @@ import {
   filterSupplementalContextItems,
   shouldIncludeSupplementalContext,
 } from "openclaw/plugin-sdk/security-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { ResolvedSlackAccount } from "../../accounts.js";
 import type { SlackMessageEvent } from "../../types.js";
 import { resolveSlackAllowListMatch } from "../allow-list.js";
@@ -224,7 +225,7 @@ export async function resolveSlackThreadContextData(params: {
 
   if (starter?.text && includeStarterContext) {
     threadStarterBody = starter.text;
-    const snippet = starter.text.replace(/\s+/g, " ").slice(0, 80);
+    const snippet = truncateUtf16Safe(starter.text.replace(/\s+/g, " "), 80);
     threadLabel = `Slack thread ${params.roomLabel}${snippet ? `: ${snippet}` : ""}`;
     // Root media seeds a new thread session once. Rehydrating it later makes
     // old files look like current-turn uploads and repeats media processing.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Slack thread labels injected into the agent prompt context could contain invalid Unicode when thread starter messages contain emoji near the 80-character snippet boundary.

When a Slack thread reply arrives, OpenClaw builds a human-readable label for the thread (e.g. `"Slack thread #general: Great idea about the 🚀 launch…"`) and injects it into the LLM's context. The snippet is produced by collapsing whitespace then calling `.slice(0, 80)`. Emoji and supplementary-plane characters are represented as two UTF-16 code units (a surrogate pair). If the cut point lands between the two halves, the result contains an isolated surrogate — invalid Unicode — which is then passed to the model as part of its context string.

This affects two sibling helper functions:
- `prepareSlackThreadContext` in `prepare-thread-context.ts` — builds `threadLabel` for live thread replies
- `resolveSlackAssistantRootThreadLabel` / `formatSlackBotStarterThreadLabel` in `prepare-thread-context-root.ts` — builds the label for assistant-root thread sessions

## Why This Change Was Made

Replace `.slice(0, 80)` with `truncateUtf16Safe(..., 80)` in both helpers. The surrounding `.replace(/\s+/g, " ")` and `.trim()` calls are unchanged; only the final truncation step is made surrogate-safe. `truncateUtf16Safe` from `openclaw/plugin-sdk/text-utility-runtime` is the established helper for this pattern throughout the codebase.

Both sites are fixed in the same PR because they share the identical bug pattern and are tested together.

## User Impact

Slack users who start threads with emoji-rich messages long enough to reach the 80-character boundary (common in practice — a single sentence with a few emoji easily hits this) would cause the agent to receive a malformed thread label in its prompt context. This can produce garbled context, confuse the model about the thread subject, or trigger a rejected API call on providers that validate Unicode input. After this fix, thread labels are always valid Unicode strings.

## Evidence

- **`prepare-thread-context.ts:228`** (post-fix): `const snippet = truncateUtf16Safe(starter.text.replace(/\s+/g, " "), 80);` — `snippet` is used on the next line as `threadLabel = \`Slack thread ${params.roomLabel}: ${snippet}\``.
- **`prepare-thread-context-root.ts:112`** (post-fix): `const snippet = truncateUtf16Safe(params.starterText.replace(/\s+/g, " "), 80).trim();` — `snippet` is returned as part of the label string `\`${base} (assistant root): ${snippet}\``.
- Both labels are consumed by downstream prompt-context builders and reach the LLM.
- **Fix:** `truncateUtf16Safe(..., 80)` — same length cap, surrogate-pair-safe.
- **Diff:** two production files + surrogate-boundary regression in `prepare-thread-context-root.test.ts`.

### Behavior proof

#### 1) Node runtime through production `formatSlackBotStarterThreadLabel` (no Vitest mocks)

Imports and calls the real exported helper from `prepare-thread-context-root.ts` on a surrogate-boundary starter (`79 × 'a' + 🐱tail`):

```text
=== Slack thread label UTF-16 reproduction (Node runtime, production helpers, no mocks) ===
Node: v22.22.0
starterText code units: 85
old .slice(0, 80).trim() code units: 80
old snippet has unpaired surrogate: true
truncateUtf16Safe(..., 80).trim() code units: 79
fixed snippet has unpaired surrogate: false

[formatSlackBotStarterThreadLabel — production export]
label: Slack thread DM (assistant root): aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
label has unpaired surrogate: false
label equals expected 79-a form: true

[prepare-thread-context.ts label shape]
threadLabel: Slack thread #general: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
threadLabel has unpaired surrogate: false
```

This shows both fixed call-site shapes — assistant-root labels and live thread labels — emit surrogate-safe snippets at the 80 code-unit cap.

#### 2) Call-site regression test

```text
$ pnpm test extensions/slack/src/monitor/message-handler/prepare-thread-context-root.test.ts -t "surrogate" --reporter=verbose

 ✓ formatSlackBotStarterThreadLabel > drops a surrogate-pair emoji whole when it straddles the 80-char snippet limit

 Test Files  1 passed (1)
      Tests  1 passed | 23 skipped (24)
```

Regression asserts `formatSlackBotStarterThreadLabel({ roomLabel: "DM", starterText: "a".repeat(79) + "🐱tail" })` drops the boundary emoji whole and leaves no unpaired surrogate in the final label.

**Proof gap:** No redacted live Slack workspace transcript in this validation environment. The Node runtime call and regression cover the production label builders; optional supplemental proof is a redacted thread-reply log showing a long emoji-near-boundary starter produces a well-formed `threadLabel`.

- [x] AI-assisted (Cursor / Claude Sonnet 4.6)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
