### PR TITLE
fix(slack): keep inbound message preview truncation UTF-16 safe

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -187,6 +187,15 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(prepared.ctxPayload.BodyForAgent).toContain(body);
   });
 
+  it("truncates inbound preview on a surrogate boundary", async () => {
+    const body = `${"a".repeat(159)}🐱`;
+    const prepared = await prepareWithDefaultCtx(createSlackMessage({ text: body }));
+
+    assertPrepared(prepared);
+    expect(prepared.preview).toBe("a".repeat(159));
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(prepared.preview)).toBe(false);
+  });
+
   it("logs inbound metadata without logging message content", async () => {
     const body = "confidential acquisition target: northstar; do not include this text in logs";
     shouldLogVerboseMock.mockReturnValue(true);

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -35,6 +35,7 @@ import {
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveSlackReplyToMode } from "../../account-reply-mode.js";
 import type { ResolvedSlackAccount } from "../../accounts.js";
 import { reactSlackMessage } from "../../actions.js";
@@ -1178,7 +1179,7 @@ export async function prepareSlackMessage(params: {
 
   const roomLabel = channelName ? `#${channelName}` : `#${message.channel}`;
   const senderName = await resolveSenderName();
-  const preview = rawBody.replace(/\s+/g, " ").slice(0, 160);
+  const preview = truncateUtf16Safe(rawBody.replace(/\s+/g, " "), 160);
   const inboundLabel = isDirectMessage
     ? `Slack DM from ${senderName}`
     : `Slack message in ${roomLabel} from ${senderName}`;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Slack messages containing emoji near the 160-character boundary produce an invalid `preview` string in the `PreparedSlackMessage` shape returned by `prepareSlackMessage`.

When an inbound Slack message is prepared for dispatch, a 160-character preview is built from the raw message body by collapsing whitespace and calling `.slice(0, 160)`. Emoji and supplementary-plane characters use two UTF-16 code units (a surrogate pair). A cut that lands between the two halves of a surrogate pair produces a lone high surrogate — invalid Unicode — in the `preview` field that is stored on the `PreparedSlackMessage` object and passed to the dispatch pipeline.

**Concrete example:** Inbound body `"a".repeat(159) + "🐱"` (161 code units). Old path: `preview` length 160, ends on `U+D83D` (unpaired high surrogate). Consumers of `PreparedSlackMessage.preview` — system event labels, monitoring, debug output — receive malformed Unicode.

## Why This Change Was Made

Replace `.slice(0, 160)` with `truncateUtf16Safe(..., 160)`, which detects and avoids splitting surrogate pairs. The preceding `.replace(/\s+/g, " ")` is unchanged. `truncateUtf16Safe` from `openclaw/plugin-sdk/text-utility-runtime` is the established helper for this class of fix throughout the codebase.

## User Impact

**Before:** Long Slack messages with emoji straddling the 160-character preview boundary leave `PreparedSlackMessage.preview` with invalid Unicode.

**After:** `preview` is always a valid Unicode string; boundary emoji are dropped whole instead of split.

## Evidence

- `extensions/slack/src/monitor/message-handler/prepare.ts:1182` — `const preview = truncateUtf16Safe(rawBody.replace(/\s+/g, " "), 160);`
- `PreparedSlackMessage.preview` typed in `types.ts:38` and returned from `prepareSlackMessage`
- `packages/normalization-core/src/utf16-slice.ts` — `truncateUtf16Safe` / `sliceUtf16Safe` surrogate backoff
- Diff: one new import, one call-site replacement in `prepare.ts`; surrogate-boundary regression in `prepare.test.ts`

### Behavior proof

#### 1) Node runtime — before/after on exact `prepare.ts` expression (no Vitest)

Replays the shipped preview pipeline on the surrogate boundary input (`159 × 'a' + 🐱`):

```text
=== Slack inbound preview UTF-16 reproduction (Node runtime, prepare.ts logic, no mocks) ===
Node: v22.22.0
rawBody code units: 161
collapsed code units: 161
old .slice(0, 160) code units: 160
old preview has unpaired surrogate: true
old preview last char: U+D83D
truncateUtf16Safe(collapsed, 160) code units: 159
fixed preview has unpaired surrogate: false
fixed preview equals 159 ASCII a's: true
```

#### 2) Node runtime — production `prepareSlackMessage` (no Vitest, no vi.mock)

Imports PR-head `prepareSlackMessage` and calls it with the same boundary input via `createInboundSlackTestContext` (real monitor context shape, no Vitest mocks):

```text
$ node --import tsx/esm
=== prepareSlackMessage no-mock Node proof (PR-head production path) ===
Node: v22.22.0
input body code units: 161
prepared: non-null PreparedSlackMessage
preview length: 159
preview equals 159 ASCII a's: true
preview has dangling surrogate: false
PreparedSlackMessage.preview field valid Unicode: true
```

This exercises the full changed production path — not just the helper expression — and shows `PreparedSlackMessage.preview` is surrogate-safe at the 160 code-unit cap.

#### 3) Call-site regression through production `prepareSlackMessage`

```text
$ pnpm test extensions/slack/src/monitor/message-handler/prepare.test.ts -t "truncates inbound preview" --reporter=verbose

 ✓ slack prepareSlackMessage inbound contract > truncates inbound preview on a surrogate boundary 51ms

 Test Files  1 passed (1)
      Tests  1 passed | 112 skipped (113)
   Duration  4.55s (transform 2.47s, setup 28ms, import 4.39s, tests 51ms, environment 0ms)

[test] passed 1 Vitest shard in 8.66s
```

Regression flow:

1. Inbound `message.text` = `"a".repeat(159) + "🐱"`.
2. `prepareSlackMessage` returns non-null `PreparedSlackMessage`.
3. `prepared.preview` === `"a".repeat(159)` (159 code units).
4. No dangling high surrogate: `/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(prepared.preview)` === false.

**Proof gap:** No redacted live Slack workspace transcript in this validation environment. Node `prepareSlackMessage` proof + regression cover the production preview builder; optional supplemental proof is a redacted inbound Slack message log showing a long emoji-near-boundary preview stays well-formed.

- [x] AI-assisted (Cursor / Claude Sonnet 4.6)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
