### PR TITLE
fix(matrix): recognize mm: and antml: reasoning tags in reply suppression

### DIFF
--- a/extensions/matrix/src/matrix/monitor/replies.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.test.ts
@@ -198,6 +198,29 @@ describe("deliverMatrixReplies", () => {
     expect(sendOptions(0).cfg).toBe(cfg);
   });
 
+  it("suppresses namespaced reasoning tags (mm: and antml: prefixes) before Matrix sends", async () => {
+    // Construct tag strings to prevent tool from interpreting them as XML
+    const mm = "mm";
+    const ant = "antml";
+    await deliverMatrixReplies({
+      cfg,
+      replies: [
+        { text: `<${mm}:think>MiniMax reasoning</${mm}:think>` },
+        { text: `<${ant}:thinking>Anthropic reasoning</${ant}:thinking>` },
+        { text: "Visible answer" },
+      ],
+      roomId: "room:6",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      textLimit: 4000,
+      replyToMode: "off",
+    });
+
+    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(1);
+    expect(sendCall(0)[0]).toBe("room:6");
+    expect(sendCall(0)[1]).toBe("Visible answer");
+  });
+
   it("uses supplied cfg for chunking and send delivery without reloading runtime config", async () => {
     const explicitCfg = {
       channels: {
@@ -244,14 +267,14 @@ describe("deliverMatrixReplies", () => {
     await deliverMatrixReplies({
       cfg,
       replies: [{ text: "caption", mediaUrl: "https://example.com/a.jpg" }],
-      roomId: "room:6",
+      roomId: "room:7",
       client: {} as MatrixClient,
       runtime: runtimeEnv,
       textLimit: 4000,
       replyToMode: "off",
     });
 
-    expect(sendCall(0)[0]).toBe("room:6");
+    expect(sendCall(0)[0]).toBe("room:7");
     expect(sendCall(0)[1]).toBe("caption");
     expect(sendOptions(0).mediaUrl).toBe("https://example.com/a.jpg");
   });

--- a/extensions/matrix/src/matrix/monitor/replies.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.ts
@@ -5,9 +5,10 @@ import type { MatrixClient } from "../sdk.js";
 import { chunkMatrixText, sendMessageMatrix } from "../send.js";
 import type { MarkdownTableMode, OpenClawConfig, ReplyPayload, RuntimeEnv } from "./runtime-api.js";
 
-const THINKING_TAG_RE = /<\s*\/?\s*(?:think(?:ing)?|thought|antthinking)\b[^<>]*>/gi;
+const THINKING_TAG_RE =
+  /<\s*\/?\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/gi;
 const THINKING_BLOCK_RE =
-  /<\s*(?:think(?:ing)?|thought|antthinking)\b[^<>]*>[\s\S]*?<\s*\/\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
+  /<\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>[\s\S]*?<\s*\/\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)\s*>/gi;
 
 function shouldSuppressReasoningReplyText(text?: string): boolean {
   if (typeof text !== "string") {


### PR DESCRIPTION
<!--
AI-assisted: generated with Cursor / Claude Sonnet 4.6
-->

## What Problem This Solves

Fixes an issue where Matrix users receiving responses from MiniMax or Anthropic models would see raw reasoning tag blocks leaked as visible chat messages instead of being silently suppressed.

The Matrix reply suppression function (`shouldSuppressReasoningReplyText`) uses two local regexes to decide whether a reply is reasoning-only. These regexes recognised bare `<think>`, `<thinking>`, `<thought>`, and `<antthinking>` tags but did **not** recognise the namespace-prefixed forms that MiniMax and Anthropic emit: `<mm:think>`, `<antml:thinking>`, and their closing counterparts. A reply containing only `<mm:think>...</mm:think>` would pass suppression and be sent to the Matrix room as a visible (garbled) message.

The shared contract in `src/shared/text/reasoning-tags.ts` already handles both `antml:` and `mm:` prefixes via `(?:antml:|mm:)?` in its regexes. The Matrix plugin's local copies had drifted.

## Why This Change Was Made

Update both `THINKING_TAG_RE` and `THINKING_BLOCK_RE` in `replies.ts` to include the `(?:antml:|mm:)?` prefix group, aligning them with `src/shared/text/reasoning-tags.ts:12`. No logic changes — only the regex patterns.

Extend the existing reasoning-suppression test to cover the `<mm:think>` and `<antml:thinking>` tag variants.

## User Impact

Matrix users talking to a MiniMax- or Anthropic-backed agent (Claude models, or any provider emitting namespaced think tags) would previously see the model's reasoning content leak into the chat as a raw XML-looking message. After this fix, namespaced reasoning blocks are suppressed the same way bare `<think>` blocks are.

## Evidence

- **Protocol drift source:** `src/shared/text/reasoning-tags.ts:11` — `QUICK_TAG_RE` already includes `(?:antml:|mm:)?`; `THINKING_TAG_RE` at line 12 includes `(?:antml:|mm:)?`. The Matrix local copy at `extensions/matrix/src/matrix/monitor/replies.ts:8` did not.
- **Failing example (pre-fix):** a reply of `<mm:think>reasoning</mm:think>` would return `false` from `shouldSuppressReasoningReplyText` and be sent to Matrix.
- **Fix:** added `(?:antml:|mm:)?` before `(?:think(?:ing)?|thought)` in both local regexes.
- **Test added:** `extensions/matrix/src/matrix/monitor/replies.test.ts` — new `it` block sends two namespaced-tag-only replies plus one visible reply; asserts only one send call with the visible text.
- **Diff:** 4-line regex change + 20-line test addition; no logic or API change.

- [x] AI-assisted (Cursor / Claude Sonnet 4.6)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
