### PR TITLE
fix: require exact markdown frontmatter delimiters

### DIFF
--- a/packages/markdown-core/src/frontmatter.test.ts
+++ b/packages/markdown-core/src/frontmatter.test.ts
@@ -1,7 +1,7 @@
 // Markdown Core tests cover frontmatter behavior.
 import JSON5 from "json5";
 import { describe, expect, it } from "vitest";
-import { parseFrontmatterBlock } from "./frontmatter.js";
+import { parseFrontmatterBlock, stripFrontmatterBlock } from "./frontmatter.js";
 
 describe("parseFrontmatterBlock", () => {
   it("parses YAML block scalars", () => {
@@ -101,6 +101,23 @@ metadata:
   it("returns empty when frontmatter is missing", () => {
     const content = "# No frontmatter";
     expect(parseFrontmatterBlock(content)).toStrictEqual({});
+  });
+
+  it("requires exact opening frontmatter delimiter lines", () => {
+    expect(parseFrontmatterBlock("---not\nname: nope\n---not\nbody")).toStrictEqual({});
+    expect(parseFrontmatterBlock("----\nname: nope\n----\nbody")).toStrictEqual({});
+  });
+
+  it("requires exact closing frontmatter delimiter lines", () => {
+    expect(parseFrontmatterBlock("---\nname: nope\n---not\nbody")).toStrictEqual({});
+    expect(parseFrontmatterBlock("---\nname: nope\n----\nbody")).toStrictEqual({});
+  });
+
+  it("strips only exact frontmatter delimiter blocks", () => {
+    expect(stripFrontmatterBlock("---\nname: valid\n---\nBody text")).toBe("Body text");
+    expect(stripFrontmatterBlock("---not\nname: nope\n---not\nBody text")).toBe(
+      "---not\nname: nope\n---not\nBody text",
+    );
   });
 
   it("preserves prototype-named keys when YAML value is null", () => {

--- a/packages/markdown-core/src/frontmatter.ts
+++ b/packages/markdown-core/src/frontmatter.ts
@@ -181,30 +181,51 @@ function shouldPreferInlineLineValue(params: {
   return lineEntry.value.includes(":");
 }
 
-function extractFrontmatterBlock(content: string): string | undefined {
-  const normalized = content
+type ExtractedFrontmatterBlock = {
+  block: string;
+  body: string;
+};
+
+const FRONTMATTER_DELIMITER_LINE = /(?:^|\n)---(?:\n|$)/u;
+
+function normalizeFrontmatterContent(content: string): string {
+  return content
     .replace(/^\uFEFF/, "")
     .replace(/\r\n/g, "\n")
     .replace(/\r/g, "\n");
-  if (!normalized.startsWith("---")) {
+}
+
+function extractFrontmatterBlock(content: string): ExtractedFrontmatterBlock | undefined {
+  const normalized = normalizeFrontmatterContent(content);
+  if (!normalized.startsWith("---\n")) {
     return undefined;
   }
-  const endIndex = normalized.indexOf("\n---", 3);
-  if (endIndex === -1) {
+  const blockAndBody = normalized.slice(4);
+  const closingDelimiter = FRONTMATTER_DELIMITER_LINE.exec(blockAndBody);
+  if (!closingDelimiter) {
     return undefined;
   }
-  return normalized.slice(4, endIndex);
+  return {
+    block: blockAndBody.slice(0, closingDelimiter.index),
+    body: blockAndBody.slice(closingDelimiter.index + closingDelimiter[0].length),
+  };
+}
+
+/** Removes a leading YAML frontmatter block and returns the remaining Markdown body. */
+export function stripFrontmatterBlock(content: string): string {
+  const normalized = normalizeFrontmatterContent(content);
+  return (extractFrontmatterBlock(normalized)?.body ?? normalized).trim();
 }
 
 /** Parses leading YAML frontmatter into string values used by skill and metadata loaders. */
 export function parseFrontmatterBlock(content: string): ParsedFrontmatter {
-  const block = extractFrontmatterBlock(content);
-  if (!block) {
+  const extracted = extractFrontmatterBlock(content);
+  if (!extracted?.block) {
     return {};
   }
 
-  const lineParsed = parseLineFrontmatter(block);
-  const yamlParsed = parseYamlFrontmatter(block);
+  const lineParsed = parseLineFrontmatter(extracted.block);
+  const yamlParsed = parseYamlFrontmatter(extracted.block);
   if (yamlParsed === null) {
     return lineFrontmatterToPlain(lineParsed);
   }

--- a/packages/markdown-core/src/frontmatter.ts
+++ b/packages/markdown-core/src/frontmatter.ts
@@ -181,7 +181,7 @@ function shouldPreferInlineLineValue(params: {
   return lineEntry.value.includes(":");
 }
 
-type ExtractedFrontmatterBlock = {
+export type ExtractedFrontmatterBlock = {
   block: string;
   body: string;
 };
@@ -195,7 +195,7 @@ function normalizeFrontmatterContent(content: string): string {
     .replace(/\r/g, "\n");
 }
 
-function extractFrontmatterBlock(content: string): ExtractedFrontmatterBlock | undefined {
+export function extractFrontmatterBlock(content: string): ExtractedFrontmatterBlock | undefined {
   const normalized = normalizeFrontmatterContent(content);
   if (!normalized.startsWith("---\n")) {
     return undefined;

--- a/src/plugins/bundle-commands.test.ts
+++ b/src/plugins/bundle-commands.test.ts
@@ -174,4 +174,52 @@ describe("loadEnabledClaudeBundleCommands", () => {
       },
     );
   });
+
+  it("does not treat dash-prefixed markdown text as command frontmatter", async () => {
+    const homeDir = await createTempDir("openclaw-bundle-commands-home-");
+    const workspaceDir = await createTempDir("openclaw-bundle-commands-workspace-");
+    await withEnvAsync(
+      {
+        HOME: homeDir,
+        USERPROFILE: homeDir,
+        OPENCLAW_HOME: undefined,
+        OPENCLAW_STATE_DIR: undefined,
+      },
+      async () => {
+        await writeClaudeBundleCommandFixture({
+          homeDir,
+          pluginId: "dash-prefix-bundle",
+          commands: [
+            {
+              relativePath: "commands/dash-prefix.md",
+              contents: ["---not", "name: nope", "---not", "Actual prompt body."],
+            },
+          ],
+        });
+
+        const commands = loadEnabledClaudeBundleCommands({
+          workspaceDir,
+          cfg: {
+            plugins: {
+              entries: { "dash-prefix-bundle": { enabled: true } },
+            },
+          },
+        });
+
+        expectEnabledClaudeBundleCommands(commands, [
+          {
+            pluginId: "dash-prefix-bundle",
+            rawName: "dash-prefix",
+            description: "---not",
+            promptTemplate: "---not\nname: nope\n---not\nActual prompt body.",
+            sourceFilePath: path.join(
+              resolveBundlePluginRoot(homeDir, "dash-prefix-bundle"),
+              "commands",
+              "dash-prefix.md",
+            ),
+          },
+        ]);
+      },
+    );
+  });
 });

--- a/src/plugins/bundle-commands.ts
+++ b/src/plugins/bundle-commands.ts
@@ -5,7 +5,10 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { parseFrontmatterBlock } from "../../packages/markdown-core/src/frontmatter.js";
+import {
+  parseFrontmatterBlock,
+  stripFrontmatterBlock,
+} from "../../packages/markdown-core/src/frontmatter.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { readRootJsonObjectSync } from "../infra/json-files.js";
 import { isPathInsideWithRealpath } from "../security/scan-paths.js";
@@ -41,18 +44,6 @@ function parseFrontmatterBool(value: string | undefined, fallback: boolean): boo
     return false;
   }
   return fallback;
-}
-
-function stripFrontmatter(content: string): string {
-  const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
-  if (!normalized.startsWith("---")) {
-    return normalized.trim();
-  }
-  const endIndex = normalized.indexOf("\n---", 3);
-  if (endIndex === -1) {
-    return normalized.trim();
-  }
-  return normalized.slice(endIndex + 4).trim();
 }
 
 function readClaudeBundleManifest(rootDir: string): Record<string, unknown> {
@@ -133,7 +124,7 @@ function loadBundleCommandsFromRoot(params: {
     if (parseFrontmatterBool(frontmatter["disable-model-invocation"], false)) {
       continue;
     }
-    const promptTemplate = stripFrontmatter(raw);
+    const promptTemplate = stripFrontmatterBlock(raw);
     if (!promptTemplate) {
       continue;
     }

--- a/src/skills/workshop/frontmatter.ts
+++ b/src/skills/workshop/frontmatter.ts
@@ -1,4 +1,5 @@
 // Workshop frontmatter helpers parse generated skill metadata before saving drafts.
+import { extractFrontmatterBlock } from "../../../packages/markdown-core/src/frontmatter.js";
 import { parseFrontmatter } from "../loading/frontmatter.js";
 
 type ProposalFrontmatter = {
@@ -21,9 +22,9 @@ export function renderProposalMarkdown(params: {
   date?: string;
 }): string {
   const originalFrontmatter =
-    extractFrontmatterBlock(params.content) ??
+    extractFrontmatterBlock(params.content)?.block ??
     (params.fallbackFrontmatterContent
-      ? extractFrontmatterBlock(params.fallbackFrontmatterContent)
+      ? extractFrontmatterBlock(params.fallbackFrontmatterContent)?.block
       : undefined);
   const keptFrontmatter = originalFrontmatter
     ? filterFrontmatterBlock(originalFrontmatter, [
@@ -64,18 +65,13 @@ export function readProposalFrontmatter(content: string): ProposalFrontmatter | 
 
 export function stripProposalFrontmatterForSkill(content: string): string {
   const normalized = normalizeNewlines(content);
-  if (!normalized.startsWith("---")) {
-    return normalized.endsWith("\n") ? normalized : `${normalized}\n`;
-  }
-  const endIndex = normalized.indexOf("\n---", 3);
-  if (endIndex === -1) {
+  const extracted = extractFrontmatterBlock(normalized);
+  if (!extracted) {
     return normalized.endsWith("\n") ? normalized : `${normalized}\n`;
   }
 
-  const rawBlock = normalized.slice(4, endIndex);
-  const bodyStart = endIndex + "\n---".length;
-  const body = normalized.slice(bodyStart).replace(/^\n+/, "");
-  const keptLines = rawBlock
+  const body = extracted.body.replace(/^\n+/, "");
+  const keptLines = extracted.block
     .split("\n")
     .filter((line) => {
       const key = line.match(/^([\w-]+):/)?.[1]?.toLowerCase();
@@ -88,26 +84,9 @@ export function stripProposalFrontmatterForSkill(content: string): string {
   return result.endsWith("\n") ? result : `${result}\n`;
 }
 
-function extractFrontmatterBlock(content: string): string | undefined {
-  const normalized = normalizeNewlines(content);
-  if (!normalized.startsWith("---")) {
-    return undefined;
-  }
-  const endIndex = normalized.indexOf("\n---", 3);
-  if (endIndex === -1) {
-    return undefined;
-  }
-  return normalized.slice(4, endIndex);
-}
-
 function stripFrontmatterBlock(content: string): string {
   const normalized = normalizeNewlines(content);
-  const block = extractFrontmatterBlock(normalized);
-  if (block === undefined) {
-    return normalized;
-  }
-  const endIndex = normalized.indexOf("\n---", 3);
-  return normalized.slice(endIndex + "\n---".length).replace(/^\n+/, "");
+  return extractFrontmatterBlock(normalized)?.body.replace(/^\n+/, "") ?? normalized;
 }
 
 function filterFrontmatterBlock(block: string, keysToDrop: readonly string[]): string {

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -148,6 +148,27 @@ describe("skill workshop proposals", () => {
     expect((await inspectSkillProposal(proposal.record.id))?.record.status).toBe("applied");
   });
 
+  it("preserves dash-prefixed markdown text when applying proposals", async () => {
+    const workspaceDir = await makeWorkspace();
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      name: "Dash Prefix",
+      description: "Preserve dash-prefixed content",
+      content: "---not\nname: nope\n---not\nActual prompt body.\n",
+    });
+
+    expect(proposal.content).toContain("---not\nname: nope\n---not\nActual prompt body.");
+
+    const applied = await applySkillProposal({
+      workspaceDir,
+      proposalId: proposal.record.id,
+    });
+
+    await expect(fs.readFile(applied.targetSkillFile, "utf8")).resolves.toBe(
+      '---\nname: "dash-prefix"\ndescription: "Preserve dash-prefixed content"\n---\n\n---not\nname: nope\n---not\nActual prompt body.\n',
+    );
+  });
+
   it.runIf(process.platform !== "win32")(
     "applies updates through opted-in trusted workspace skills symlink targets",
     async () => {


### PR DESCRIPTION
Closes #101769

## What Problem This Solves

Fixes an issue where users writing Markdown command, hook, skill, workshop proposal, or metadata files could have content that starts with non-delimiter text like `---not` or `----` interpreted as YAML frontmatter.

That could make OpenClaw read unexpected metadata and strip or alter body text even though the Markdown did not begin with a whole `---` delimiter line.

## Why This Change Was Made

The shared markdown-core frontmatter parser now requires exact `---` delimiter lines for both opening and closing fences. Bundled Claude command body extraction and skill workshop proposal stripping now reuse the same shared delimiter extractor instead of keeping separate prefix-based logic.

This keeps metadata parsing and body stripping aligned without adding config, compatibility shims, or plugin-specific policy.

## User Impact

Markdown files can now safely begin with dash-prefixed text that is not a frontmatter delimiter. Valid `---` frontmatter blocks still parse normally, while `---not` and `----` remain part of the Markdown body.

## Evidence

Before the fix, the reported source-level case parsed unexpected metadata:

```text
node --import tsx --input-type=module - <<'EOF'
import { parseFrontmatterBlock } from './packages/markdown-core/src/frontmatter.ts';
const content = '---not\nname: nope\n---not\nbody';
console.log(JSON.stringify(parseFrontmatterBlock(content)));
EOF
{"name":"nope"}
```

After the fix, the final source-level proof keeps invalid delimiter text as Markdown and still accepts a valid block:

```text
node --import tsx --input-type=module - <<'EOF'
import { parseFrontmatterBlock, stripFrontmatterBlock } from './packages/markdown-core/src/frontmatter.ts';
const invalid = '---not\nname: nope\n---not\nbody';
const valid = '---\nname: valid\n---\nbody';
console.log('invalid', JSON.stringify(parseFrontmatterBlock(invalid)), JSON.stringify(stripFrontmatterBlock(invalid)));
console.log('valid', JSON.stringify(parseFrontmatterBlock(valid)), JSON.stringify(stripFrontmatterBlock(valid)));
EOF
invalid {} "---not\nname: nope\n---not\nbody"
valid {"name":"valid"} "body"
```

Validation run:

```text
./node_modules/.bin/oxfmt --write --threads=1 packages/markdown-core/src/frontmatter.ts packages/markdown-core/src/frontmatter.test.ts src/plugins/bundle-commands.ts src/plugins/bundle-commands.test.ts src/skills/workshop/frontmatter.ts src/skills/workshop/service.test.ts
# passed

node scripts/run-vitest.mjs packages/markdown-core/src/frontmatter.test.ts src/plugins/bundle-commands.test.ts src/hooks/frontmatter.test.ts src/skills/loading/frontmatter.test.ts src/skills/workshop/service.test.ts
[test] passed 3 Vitest shards in 14.87s

pnpm tsgo:test:packages
# passed

pnpm tsgo:test:src
# passed

pnpm build
[build-all] phase timings: total 114.9s; slowest tsdown 110.9s; ui:build 1.39s

.agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
```

Real behavior proof with the configured local DeepSeek profile:

```text
node scripts/run-node.mjs agent --local --agent main --model deepseek/deepseek-v4-pro --message 'Reply exactly: frontmatter delimiter proof ok' --json --timeout 180
[provider-transport-fetch] response provider=deepseek api=openai-completions model=deepseek-v4-pro status=200
"finalAssistantVisibleText": "frontmatter delimiter proof ok"
"executionTrace": { "winnerProvider": "deepseek", "winnerModel": "deepseek-v4-pro" }
```

I did not run local `pnpm check*` or full local `pnpm test` in this linked checkout; the focused node harness, tsgo lanes, build, and PR CI cover the changed surfaces.

AI-assisted: implementation and validation were prepared with AI assistance; proof commands were run manually in this checkout.
