### PR TITLE
fix(android): keep cold-start gateway auto-connect from overriding explicit intents

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -203,7 +203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2706,
+      "line": 2714,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
       "surface": "android",
@@ -211,7 +211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2708,
+      "line": 2716,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -219,7 +219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2710,
+      "line": 2718,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -387,7 +387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1286,
+      "line": 1293,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -395,7 +395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1286,
+      "line": 1293,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Reconnecting…",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1742,7 +1742,11 @@ class NodeRuntime private constructor(
     // Only attempt the stored preferred gateway once per runtime lifetime; users
     // can still reconnect explicitly from the UI after a failed auto attempt.
     didAutoConnect = true
-    connect(endpoint)
+    // Cold-start fallback only: discovery can emit late, so atomically claim the very first
+    // lifecycle intent. If any explicit connect/disconnect/switch intent already exists, stand
+    // down permanently instead of overriding the user's decision with a stale auto-connect.
+    if (!gatewayLifecycleIntentSeq.compareAndSet(0L, 1L)) return
+    launchConnect(endpoint, explicitAuth = null)
   }
 
   private fun reconnectPreferredGatewayOnForeground() {
@@ -2631,10 +2635,7 @@ class NodeRuntime private constructor(
 
   fun connect(endpoint: GatewayEndpoint) {
     gatewayLifecycleIntentSeq.incrementAndGet()
-    launchGatewayLifecycle {
-      prepareGatewayTarget(endpoint)
-      beginConnect(endpoint = endpoint, auth = resolveGatewayConnectAuth(endpoint))
-    }
+    launchConnect(endpoint, explicitAuth = null)
   }
 
   fun connect(
@@ -2642,9 +2643,16 @@ class NodeRuntime private constructor(
     auth: GatewayConnectAuth,
   ) {
     gatewayLifecycleIntentSeq.incrementAndGet()
+    launchConnect(endpoint, explicitAuth = auth)
+  }
+
+  private fun launchConnect(
+    endpoint: GatewayEndpoint,
+    explicitAuth: GatewayConnectAuth?,
+  ) {
     launchGatewayLifecycle {
       prepareGatewayTarget(endpoint)
-      beginConnect(endpoint = endpoint, auth = resolveGatewayConnectAuth(endpoint, auth))
+      beginConnect(endpoint = endpoint, auth = resolveGatewayConnectAuth(endpoint, explicitAuth))
     }
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
@@ -611,6 +612,7 @@ class GatewaySession(
       }
     }
 
+    @OptIn(DelicateCoroutinesApi::class)
     suspend fun sendRequestFrame(
       method: String,
       params: JsonElement?,
@@ -625,7 +627,12 @@ class GatewaySession(
         pending.remove(id)
         throw err
       }
-      connectionScope.launch(Dispatchers.IO) {
+      // ATOMIC start: joinOwnedWork() cancels connectionJob right after failPending(); a
+      // DEFAULT-start watcher still queued for dispatch would be cancelled without ever running
+      // and silently drop the terminal onError owed to fire-and-forget callers. ATOMIC
+      // guarantees this block runs; await() on the already-failed deferred then surfaces the
+      // disconnect outcome without suspending.
+      connectionScope.launch(Dispatchers.IO, start = CoroutineStart.ATOMIC) {
         try {
           val response =
             try {

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
@@ -589,34 +590,13 @@ class GatewayBootstrapAuthTest {
 
   @Test
   fun refreshGatewayConnection_reconnectsSavedManualEndpointAfterDisconnect() {
-    val app = RuntimeEnvironment.getApplication()
-    val securePrefs =
-      app.getSharedPreferences(
-        "openclaw.node.secure.test.${UUID.randomUUID()}",
-        android.content.Context.MODE_PRIVATE,
-      )
-    val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
-    prefs.setManualEnabled(true)
-    prefs.setManualHost("127.0.0.1")
-    prefs.setManualPort(18789)
-    prefs.setManualTls(false)
-    val savedEndpoint = GatewayEndpoint.manual(host = "127.0.0.1", port = 18789)
-    prefs.gatewayRegistry.upsert(
-      GatewayRegistryEntry(
-        stableId = savedEndpoint.stableId,
-        kind = GatewayRegistryEntryKind.MANUAL,
-        name = savedEndpoint.name,
-        host = savedEndpoint.host,
-        port = savedEndpoint.port,
-        tls = false,
-      ),
-    )
-    prefs.gatewayRegistry.setActive(savedEndpoint.stableId)
-    prefs.saveGatewayCredentials(savedEndpoint.stableId, token = "initial-token")
-    val runtime = NodeRuntime(app, prefs)
+    val (runtime, prefs) = createNeutralizedRuntime()
+    armSavedActiveManualGateway(prefs)
 
-    waitForDesiredConnection(runtime, "nodeSession")
-    prefs.saveGatewayCredentials(savedEndpoint.stableId, token = "shared-token")
+    runtime.connect(
+      GatewayEndpoint.manual(host = "127.0.0.1", port = 18789),
+      NodeRuntime.GatewayConnectAuth(token = "initial-token", bootstrapToken = null, password = null),
+    )
     runtime.disconnect()
     assertNull(desiredConnection(runtime, "nodeSession"))
 
@@ -721,6 +701,7 @@ class GatewayBootstrapAuthTest {
       )
     val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
     val runtime = NodeRuntime(app, prefs)
+    neutralizeColdStartAutoConnect(runtime)
     val current = GatewayEndpoint.manual("127.0.0.1", 18789)
     val missingStableId = "bonjour-missing"
     prefs.gatewayRegistry.upsert(
@@ -1147,6 +1128,78 @@ class GatewayBootstrapAuthTest {
     assertNull(readField<String?>(talkMode, "activePttCaptureId"))
     assertEquals(VoiceCaptureMode.Off, runtime.voiceCaptureMode.value)
     assertFalse(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)
+  }
+
+  @Test
+  fun coldStartAutoConnectConnectsSavedActiveGatewayWhenNoExplicitIntentExists() {
+    val (runtime, prefs) = createNeutralizedRuntime()
+    armSavedActiveManualGateway(prefs)
+
+    invokeAutoConnectIfNeeded(runtime)
+
+    val desired = desiredConnection(runtime, "nodeSession") ?: error("Expected desired node connection")
+    assertEquals("127.0.0.1", readField<GatewayEndpoint>(desired, "endpoint").host)
+    assertEquals("shared-token", readField<String?>(desired, "token"))
+  }
+
+  @Test
+  fun coldStartAutoConnectStandsDownAfterExplicitLifecycleIntent() {
+    val (runtime, prefs) = createNeutralizedRuntime()
+    armSavedActiveManualGateway(prefs)
+    runtime.disconnect()
+
+    invokeAutoConnectIfNeeded(runtime)
+
+    assertNull(desiredConnection(runtime, "nodeSession"))
+  }
+
+  // Arms the registry only after the runtime's background work is neutralized, so the real
+  // discovery collector can never observe an auto-connectable active gateway.
+  private fun createNeutralizedRuntime(): Pair<NodeRuntime, SecurePrefs> {
+    val app = RuntimeEnvironment.getApplication()
+    val securePrefs =
+      app.getSharedPreferences(
+        "openclaw.node.secure.test.${UUID.randomUUID()}",
+        android.content.Context.MODE_PRIVATE,
+      )
+    val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
+    val runtime = NodeRuntime(app, prefs)
+    neutralizeColdStartAutoConnect(runtime)
+    return runtime to prefs
+  }
+
+  private fun armSavedActiveManualGateway(prefs: SecurePrefs) {
+    prefs.setManualEnabled(true)
+    prefs.setManualHost("127.0.0.1")
+    prefs.setManualPort(18789)
+    prefs.setManualTls(false)
+    val savedEndpoint = GatewayEndpoint.manual(host = "127.0.0.1", port = 18789)
+    prefs.gatewayRegistry.upsert(
+      GatewayRegistryEntry(
+        stableId = savedEndpoint.stableId,
+        kind = GatewayRegistryEntryKind.MANUAL,
+        name = savedEndpoint.name,
+        host = savedEndpoint.host,
+        port = savedEndpoint.port,
+        tls = false,
+      ),
+    )
+    prefs.gatewayRegistry.setActive(savedEndpoint.stableId)
+    prefs.saveGatewayCredentials(savedEndpoint.stableId, token = "shared-token")
+  }
+
+  private fun invokeAutoConnectIfNeeded(runtime: NodeRuntime) {
+    val method = runtime.javaClass.getDeclaredMethod("autoConnectIfNeeded")
+    method.isAccessible = true
+    method.invoke(runtime)
+  }
+
+  // NodeRuntime's init collects gateway discovery on a background dispatcher and auto-connects
+  // the saved active gateway whenever that collector happens to run, racing scripted lifecycle
+  // steps (observed as CI-only flakes on loaded Linux runners). Cancel and join all runtime-scope
+  // work so nothing runs in the background; arm the registry only afterwards.
+  private fun neutralizeColdStartAutoConnect(runtime: NodeRuntime) {
+    runBlocking { readField<CoroutineScope>(runtime, "scope").coroutineContext[Job]?.cancelAndJoin() }
   }
 
   private fun waitForGatewayTrustPrompt(runtime: NodeRuntime): NodeRuntime.GatewayTrustPrompt {


### PR DESCRIPTION
## What Problem This Solves

Two Android JVM unit tests flaked repeatedly on Linux CI (`android-test-play`) across unrelated PRs (#101002, #101387, #101396, observed 2026-07-06/07) while passing locally on macOS:

1. `GatewayBootstrapAuthTest.refreshGatewayConnection_reconnectsSavedManualEndpointAfterDisconnect` — `IllegalStateException` at the `desiredConnection(runtime, "nodeSession") ?: error(...)` assertion (plus a sibling failure in `switchToUndiscoveredGatewayKeepsCurrentConnectionAndActiveGateway` in run 28830800141).
2. `GatewaySessionInvokeTest.disconnectReportsUnknownOutcomeForFireAndForgetRpc` — `TimeoutCancellationException` awaiting the fire-and-forget `onError` (attempt-1 log of run 28847716276).

Root causes:

1. `NodeRuntime.init` collects gateway discovery on a background dispatcher and auto-connects the saved active gateway whenever that collector happens to run. On loaded CI runners it lands mid-test and races explicit connect/disconnect/refresh through `gatewayLifecycleIntentSeq` (silent guarded-block drop) and `gatewaySwitchMutex` (async defer). This is also a real product hole: a late discovery emission could reconnect over an explicit user disconnect.
2. `GatewaySession.Connection.joinOwnedWork()` cancels `connectionJob` right after `failPending()`. The fire-and-forget error watcher launched by `sendRequestFrame` is a `DEFAULT`-start child of that job; if still queued for dispatch it is cancelled without ever running, silently dropping the terminal `UNAVAILABLE` "Gateway disconnected before response" callback.

## Why This Change Was Made

- `autoConnectIfNeeded()` now atomically claims the very first lifecycle intent (`gatewayLifecycleIntentSeq.compareAndSet(0, 1)`) and stands down permanently when any explicit connect/disconnect/switch intent already exists. Both `connect()` overloads share a new `launchConnect` helper.
- `sendRequestFrame` starts its watcher with `CoroutineStart.ATOMIC` (stable `@DelicateCoroutinesApi` in kotlinx-coroutines 1.11.0, documented to start even when its job is already cancelled). Since `failPending()` always precedes the cancel, `await()` surfaces the disconnect outcome without suspending.
- The two racy tests now cancel-and-join the runtime scope before arming the registry (`neutralizeColdStartAutoConnect`), making the scripted sequences fully synchronous; two new regression tests pin the auto-connect intent-claim contract. Supersedes the poll-based stabilization from #101519 with a deterministic setup (its bounded `waitForDesiredConnection` remains for the final assert).

## User Impact

- Android app no longer auto-connects over an explicit disconnect/connect/switch issued before gateway discovery settles.
- Fire-and-forget gateway RPC callers (e.g. talk-mode audio append) reliably receive the terminal error on disconnect instead of silently losing it.
- The `android-test-play` CI lane stops flaking on these two tests.

## Evidence

- Reproduced flake (1) on a Blacksmith Linux box at iteration 1 of a 120x loop under `taskset -c 0,1`, with a seq probe proving the auto-connect interloper (`seqBefore=3` after only connect+disconnect).
- Proved mechanism (2) with a deterministic manual-dispatcher demo on kotlinx-coroutines 1.11.0: `DEFAULT` start drops the terminal error when cancelled before first dispatch; `ATOMIC` delivers it. Verified `DispatchedTask` exceptional-resume dominance and `JobSupport` final-cause selection in the 1.11.0 sources.
- Post-fix on the same box: 3 pinned stress rounds (120/150 looped iterations plus both real classes, 0 failures), full `:app:testPlayDebugUnitTest` (109 classes, 0 failures), `:app:ktlintCheck` green; revalidated after rebasing onto latest `main`.
- Codex autoreview on the diff: clean, no actionable findings.
