### PR TITLE
fix(mattermost): cap outbound target caches to prevent unbounded memory growth

### DIFF
--- a/extensions/mattermost/src/mattermost/send.test.ts
+++ b/extensions/mattermost/src/mattermost/send.test.ts
@@ -744,3 +744,83 @@ describe("sendMessageMattermost user-first resolution", () => {
     expect(retryCall?.[2]?.initialDelayMs).toBe(1000);
   });
 });
+
+describe("sendMessageMattermost outbound cache caps", () => {
+  function makeAccount(token: string) {
+    return {
+      accountId: "default",
+      botToken: token,
+      baseUrl: "https://mattermost.example.com",
+      config: {},
+    };
+  }
+
+  function restoreSendMocks() {
+    mockState.createMattermostClient.mockReturnValue({});
+    mockState.createMattermostPost.mockResolvedValue({ id: "post-id" });
+    mockState.createMattermostDirectChannelWithRetry.mockResolvedValue({ id: "dm-channel-id" });
+    mockState.fetchMattermostMe.mockResolvedValue({ id: "bot-id" });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    restoreSendMocks();
+  });
+
+  it("evicts oldest DM channel cache entries after the configured cap", async () => {
+    const token = "token-dm-cap-test";
+    mockState.resolveMattermostAccount.mockReturnValue(makeAccount(token));
+
+    const firstUserId = `dm${"0".repeat(24)}`;
+    for (let index = 0; index < 1025; index += 1) {
+      const userId = `dm${String(index).padStart(24, "0")}`;
+      mockState.createMattermostDirectChannelWithRetry.mockResolvedValueOnce({
+        id: `dm-channel-${index}`,
+      });
+      await sendMessageMattermost(`user:${userId}`, "hello", { cfg: TEST_CFG });
+    }
+
+    expect(mockState.createMattermostDirectChannelWithRetry).toHaveBeenCalledTimes(1025);
+
+    vi.clearAllMocks();
+    restoreSendMocks();
+    mockState.resolveMattermostAccount.mockReturnValue(makeAccount(token));
+    mockState.createMattermostDirectChannelWithRetry.mockResolvedValueOnce({
+      id: "dm-channel-0-again",
+    });
+
+    await sendMessageMattermost(`user:${firstUserId}`, "hello again", { cfg: TEST_CFG });
+
+    expect(mockState.createMattermostDirectChannelWithRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("evicts oldest user-by-name cache entries after the configured cap", async () => {
+    const token = "token-user-cap-test";
+    mockState.resolveMattermostAccount.mockReturnValue(makeAccount(token));
+
+    const firstUsername = "user0";
+    for (let index = 0; index < 513; index += 1) {
+      const username = `user${index}`;
+      mockState.fetchMattermostUserByUsername.mockResolvedValueOnce({ id: `uid-${index}` });
+      mockState.createMattermostDirectChannelWithRetry.mockResolvedValueOnce({
+        id: `dm-channel-${index}`,
+      });
+      await sendMessageMattermost(`@${username}`, "hello", { cfg: TEST_CFG });
+    }
+
+    expect(mockState.fetchMattermostUserByUsername).toHaveBeenCalledTimes(513);
+
+    vi.clearAllMocks();
+    restoreSendMocks();
+    mockState.resolveMattermostAccount.mockReturnValue(makeAccount(token));
+    mockState.fetchMattermostUserByUsername.mockResolvedValueOnce({ id: "uid-0" });
+    mockState.createMattermostDirectChannelWithRetry.mockResolvedValueOnce({
+      id: "dm-channel-0-again",
+    });
+
+    await sendMessageMattermost(`@${firstUsername}`, "hello again", { cfg: TEST_CFG });
+
+    expect(mockState.fetchMattermostUserByUsername).toHaveBeenCalledTimes(1);
+    expect(mockState.createMattermostDirectChannelWithRetry).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -4,6 +4,7 @@ import {
   type MessageReceipt,
   type MessageReceiptPartKind,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { isPrivateNetworkOptInEnabled } from "openclaw/plugin-sdk/ssrf-runtime";
@@ -66,6 +67,14 @@ type MattermostTarget =
   | { kind: "channel"; id: string }
   | { kind: "channel-name"; name: string }
   | { kind: "user"; id?: string; username?: string };
+
+// Caps match the Slack DM channel cache precedent; bounded by distinct (baseUrl, token, target)
+// triples seen during process lifetime. Without a cap, long-running servers accumulate one entry
+// per unique recipient/channel pair forever.
+const MATTERMOST_BOT_USER_CACHE_MAX = 64;
+const MATTERMOST_USER_BY_NAME_CACHE_MAX = 512;
+const MATTERMOST_CHANNEL_BY_NAME_CACHE_MAX = 512;
+const MATTERMOST_DM_CHANNEL_CACHE_MAX = 1024;
 
 const botUserCache = new Map<string, MattermostUser>();
 const userByNameCache = new Map<string, MattermostUser>();
@@ -204,6 +213,7 @@ async function resolveBotUser(
   const client = createMattermostClient({ baseUrl, botToken: token, allowPrivateNetwork });
   const user = await fetchMattermostMe(client);
   botUserCache.set(key, user);
+  pruneMapToMaxSize(botUserCache, MATTERMOST_BOT_USER_CACHE_MAX);
   return user;
 }
 
@@ -226,6 +236,7 @@ async function resolveUserIdByUsername(params: {
   });
   const user = await fetchMattermostUserByUsername(client, username);
   userByNameCache.set(key, user);
+  pruneMapToMaxSize(userByNameCache, MATTERMOST_USER_BY_NAME_CACHE_MAX);
   return user.id;
 }
 
@@ -253,6 +264,7 @@ async function resolveChannelIdByName(params: {
       const channel = await fetchMattermostChannelByName(client, team.id, name);
       if (channel?.id) {
         channelByNameCache.set(key, channel.id);
+        pruneMapToMaxSize(channelByNameCache, MATTERMOST_CHANNEL_BY_NAME_CACHE_MAX);
         return channel.id;
       }
     } catch {
@@ -345,6 +357,7 @@ async function resolveTargetChannelId(params: ResolveTargetChannelIdParams): Pro
   params.onDmChannelResolution?.(resolution);
   const channel = await resolution;
   dmChannelCache.set(dmKey, channel.id);
+  pruneMapToMaxSize(dmChannelCache, MATTERMOST_DM_CHANNEL_CACHE_MAX);
   return channel.id;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where long-running Mattermost-connected OpenClaw processes gradually accumulate unbounded heap memory proportional to the number of unique users, channel names, and DM pairs they have ever addressed. On active servers with many distinct recipients the four module-level Maps in `send.ts` — `botUserCache`, `userByNameCache`, `channelByNameCache`, `dmChannelCache` — grow without limit and are never evicted.

**Concrete example:** An OpenClaw instance routing messages to 5 000 distinct Mattermost users over a week records 5 000 entries in `userByNameCache` and another 5 000 in `dmChannelCache`. No TTL, no eviction, no bound — every unique `(baseUrl, token, target)` triple stays in memory for the life of the process.

## Why This Change Was Made

Added four named cap constants and one `pruneMapToMaxSize` call after each cache `.set()`. `pruneMapToMaxSize` (from `openclaw/plugin-sdk/collection-runtime`) evicts the oldest insertion-order entry whenever the map exceeds its limit — the same LRU-like strategy used in `src/infra/map-size.ts`.

Cap values follow the existing Slack precedent (`SLACK_DM_CHANNEL_CACHE_MAX = 1024` at `extensions/slack/src/send.ts:49`):

| Cache | Cap |
|---|---|
| `botUserCache` | 64 (bounded by distinct bot accounts) |
| `userByNameCache` | 512 |
| `channelByNameCache` | 512 |
| `dmChannelCache` | 1024 |

## User Impact

**Before:** Memory in the Mattermost send path grows linearly with the number of unique targets seen since process start. Operators on large servers must restart periodically to reclaim memory.

**After:** Each outbound cache is capped; the total overhead per cache is bounded and stable under sustained traffic.

## Evidence

- `extensions/mattermost/src/mattermost/send.ts:70–73` — four unbounded `Map` declarations, no cap or TTL before this PR
- `extensions/slack/src/send.ts:49,572–578` — direct Slack precedent with `SLACK_DM_CHANNEL_CACHE_MAX`
- `src/infra/map-size.ts` — `pruneMapToMaxSize` implementation; `openclaw/plugin-sdk/collection-runtime` re-exports it
- Diff: production change is +13 lines in `extensions/mattermost/src/mattermost/send.ts`; call-site regressions added in `extensions/mattermost/src/mattermost/send.test.ts`

### Behavior proof

```text
$ pnpm test extensions/mattermost/src/mattermost/send.test.ts

 Test Files  1 passed (1)
      Tests  35 passed (35)
```

New regressions in `extensions/mattermost/src/mattermost/send.test.ts` assert outbound caches stay bounded:

- `evicts oldest DM channel cache entries after the configured cap` — 1025 distinct `user:` sends force a cache miss on the first entry after the 1024 cap.
- `evicts oldest user-by-name cache entries after the configured cap` — 513 distinct `@username` sends force a username re-lookup for the first entry after the 512 cap.

This mirrors the Slack DM cache precedent and reuses the shared `pruneMapToMaxSize` helper contract from `src/infra/map-size.ts`.

---

> **AI-assisted PR** — Generated with Cursor/Claude. Logic verified against `src/infra/map-size.ts` and `extensions/slack/src/send.ts` precedent. Diff is minimal and non-breaking: existing callers are unaffected, cache semantics are preserved, only the maximum retained size changes.

Made with [Cursor](https://cursor.com)
