### PR TITLE
fix: preserve zero sequence ids in sdk events

### DIFF
--- a/packages/sdk/src/normalize.test.ts
+++ b/packages/sdk/src/normalize.test.ts
@@ -8,6 +8,23 @@ function agentItemEvent(data: Record<string, unknown>) {
 }
 
 describe("normalizeGatewayEvent terminal tool item status", () => {
+  it("preserves zero sequence values in event ids and zero timestamps", () => {
+    const event = normalizeGatewayEvent({
+      event: "agent",
+      seq: 0,
+      payload: {
+        runId: "r1",
+        sessionKey: "main",
+        ts: 0,
+        stream: "lifecycle",
+        data: { phase: "start" },
+      },
+    });
+
+    expect(event.id).toBe("0:agent:r1:main:0");
+    expect(event.ts).toBe(0);
+  });
+
   it("classifies a failed terminal tool item as tool.call.failed", () => {
     expect(normalizeGatewayEvent(agentItemEvent({ phase: "end", status: "failed" })).type).toBe(
       "tool.call.failed",

--- a/packages/sdk/src/normalize.ts
+++ b/packages/sdk/src/normalize.ts
@@ -177,7 +177,9 @@ export function normalizeGatewayEvent(event: GatewayEvent): OpenClawEvent {
   const taskId = readString(payload.taskId);
   const agentId = readString(payload.agentId);
   const ts = readNumber(payload.ts) ?? Date.now();
-  const idParts = [event.seq ?? "local", event.event, runId, sessionKey, ts].filter(Boolean);
+  const idParts = [event.seq ?? "local", event.event, runId, sessionKey, ts].filter(
+    (part) => part !== undefined && part !== null && part !== "",
+  );
 
   return {
     version: 1,


### PR DESCRIPTION
Closes #101768

## What Problem This Solves

Fixes an issue where SDK consumers could receive normalized gateway event IDs that omit a valid zero sequence value when the gateway event has `seq: 0`.

## Why This Change Was Made

The SDK now filters only absent ID parts instead of filtering all falsy values, so `0` remains a valid event ID component while missing optional metadata still stays out of the ID.

## User Impact

SDK event replay and dedupe keys now preserve the gateway sequence value for zero-sequence events.

## Evidence

Head SHA: `c20c991520346132c2f3f0358294c833de887640`

Changed files:
- `packages/sdk/src/normalize.ts`
- `packages/sdk/src/normalize.test.ts`

Claim proved:
- The public SDK normalization path preserves a valid `seq: 0` in the normalized event ID and keeps a valid `ts: 0` timestamp.

Commands / observed results:
- `node -e "import { normalizeGatewayEvent } from './packages/sdk/src/normalize.ts'; const normalized = normalizeGatewayEvent({ event: 'agent', seq: 0, payload: { runId: 'r1', sessionKey: 'main', ts: 0, stream: 'lifecycle', data: { phase: 'start' } } }); console.log(JSON.stringify({ head: (await import('node:child_process')).execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim(), inputSeq: normalized.raw.seq, normalizedId: normalized.id, normalizedTs: normalized.ts, normalizedType: normalized.type }, null, 2));"`
  - Output included `"head": "c20c991520346132c2f3f0358294c833de887640"`, `"inputSeq": 0`, `"normalizedId": "0:agent:r1:main:0"`, `"normalizedTs": 0`, and `"normalizedType": "run.started"`.
- `git diff --check 600ff3acb437b87410bfe39de8a5f83aa1d408b2...HEAD`
  - Passed with no output.
- GitHub CI on head `c20c991520346132c2f3f0358294c833de887640`
  - `check-test-types` passed after the rebase refresh.