### PR TITLE
fix: require exact markdown frontmatter fences

### DIFF
--- a/packages/markdown-core/src/frontmatter.test.ts
+++ b/packages/markdown-core/src/frontmatter.test.ts
@@ -103,6 +103,11 @@ metadata:
     expect(parseFrontmatterBlock(content)).toStrictEqual({});
   });
 
+  it("does not parse dash-prefixed text as frontmatter delimiters", () => {
+    expect(parseFrontmatterBlock("---not\nname: nope\n---not\nbody")).toStrictEqual({});
+    expect(parseFrontmatterBlock("----\nname: nope\n----\nbody")).toStrictEqual({});
+  });
+
   it("preserves prototype-named keys when YAML value is null", () => {
     const content = `---
 title: Hello

--- a/packages/markdown-core/src/frontmatter.ts
+++ b/packages/markdown-core/src/frontmatter.ts
@@ -186,14 +186,17 @@ function extractFrontmatterBlock(content: string): string | undefined {
     .replace(/^\uFEFF/, "")
     .replace(/\r\n/g, "\n")
     .replace(/\r/g, "\n");
-  if (!normalized.startsWith("---")) {
+  const lines = normalized.split("\n");
+  if (lines[0] !== "---") {
     return undefined;
   }
-  const endIndex = normalized.indexOf("\n---", 3);
-  if (endIndex === -1) {
-    return undefined;
+
+  for (let i = 1; i < lines.length; i += 1) {
+    if (lines[i] === "---") {
+      return lines.slice(1, i).join("\n");
+    }
   }
-  return normalized.slice(4, endIndex);
+  return undefined;
 }
 
 /** Parses leading YAML frontmatter into string values used by skill and metadata loaders. */

--- a/src/plugins/bundle-commands.ts
+++ b/src/plugins/bundle-commands.ts
@@ -45,14 +45,20 @@ function parseFrontmatterBool(value: string | undefined, fallback: boolean): boo
 
 function stripFrontmatter(content: string): string {
   const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
-  if (!normalized.startsWith("---")) {
+  const lines = normalized.split("\n");
+  if (lines[0] !== "---") {
     return normalized.trim();
   }
-  const endIndex = normalized.indexOf("\n---", 3);
-  if (endIndex === -1) {
-    return normalized.trim();
+
+  for (let i = 1; i < lines.length; i += 1) {
+    if (lines[i] === "---") {
+      return lines
+        .slice(i + 1)
+        .join("\n")
+        .trim();
+    }
   }
-  return normalized.slice(endIndex + 4).trim();
+  return normalized.trim();
 }
 
 function readClaudeBundleManifest(rootDir: string): Record<string, unknown> {

--- a/src/skills/workshop/frontmatter.ts
+++ b/src/skills/workshop/frontmatter.ts
@@ -64,18 +64,13 @@ export function readProposalFrontmatter(content: string): ProposalFrontmatter | 
 
 export function stripProposalFrontmatterForSkill(content: string): string {
   const normalized = normalizeNewlines(content);
-  if (!normalized.startsWith("---")) {
-    return normalized.endsWith("\n") ? normalized : `${normalized}\n`;
-  }
-  const endIndex = normalized.indexOf("\n---", 3);
-  if (endIndex === -1) {
+  const block = findLeadingFrontmatterBlock(normalized);
+  if (!block) {
     return normalized.endsWith("\n") ? normalized : `${normalized}\n`;
   }
 
-  const rawBlock = normalized.slice(4, endIndex);
-  const bodyStart = endIndex + "\n---".length;
-  const body = normalized.slice(bodyStart).replace(/^\n+/, "");
-  const keptLines = rawBlock
+  const body = block.body.replace(/^\n+/, "");
+  const keptLines = block.raw
     .split("\n")
     .filter((line) => {
       const key = line.match(/^([\w-]+):/)?.[1]?.toLowerCase();
@@ -90,24 +85,16 @@ export function stripProposalFrontmatterForSkill(content: string): string {
 
 function extractFrontmatterBlock(content: string): string | undefined {
   const normalized = normalizeNewlines(content);
-  if (!normalized.startsWith("---")) {
-    return undefined;
-  }
-  const endIndex = normalized.indexOf("\n---", 3);
-  if (endIndex === -1) {
-    return undefined;
-  }
-  return normalized.slice(4, endIndex);
+  return findLeadingFrontmatterBlock(normalized)?.raw;
 }
 
 function stripFrontmatterBlock(content: string): string {
   const normalized = normalizeNewlines(content);
-  const block = extractFrontmatterBlock(normalized);
-  if (block === undefined) {
+  const block = findLeadingFrontmatterBlock(normalized);
+  if (!block) {
     return normalized;
   }
-  const endIndex = normalized.indexOf("\n---", 3);
-  return normalized.slice(endIndex + "\n---".length).replace(/^\n+/, "");
+  return block.body.replace(/^\n+/, "");
 }
 
 function filterFrontmatterBlock(block: string, keysToDrop: readonly string[]): string {
@@ -134,4 +121,21 @@ function normalizeNewlines(content: string): string {
     .replace(/^\uFEFF/, "")
     .replace(/\r\n/g, "\n")
     .replace(/\r/g, "\n");
+}
+
+function findLeadingFrontmatterBlock(content: string): { raw: string; body: string } | undefined {
+  const lines = content.split("\n");
+  if (lines[0] !== "---") {
+    return undefined;
+  }
+
+  for (let i = 1; i < lines.length; i += 1) {
+    if (lines[i] === "---") {
+      return {
+        raw: lines.slice(1, i).join("\n"),
+        body: lines.slice(i + 1).join("\n"),
+      };
+    }
+  }
+  return undefined;
 }

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -358,6 +358,28 @@ describe("skill workshop proposals", () => {
     await expect(fs.readFile(skillFile, "utf8")).resolves.toContain("user-invocable: false");
   });
 
+  it("keeps dash-prefixed proposal body text outside frontmatter", async () => {
+    const workspaceDir = await makeWorkspace();
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      name: "Dash Prefixed Body",
+      description: "Keep body delimiters literal",
+      content: "---not frontmatter\nname: body text\n---not a delimiter\n",
+    });
+
+    expect(proposal.content).toContain(
+      "\n---\n\n---not frontmatter\nname: body text\n---not a delimiter\n",
+    );
+
+    await applySkillProposal({ workspaceDir, proposalId: proposal.record.id });
+
+    await expect(
+      fs.readFile(path.join(workspaceDir, "skills", "dash-prefixed-body", "SKILL.md"), "utf8"),
+    ).resolves.toBe(
+      '---\nname: "dash-prefixed-body"\ndescription: "Keep body delimiters literal"\n---\n\n---not frontmatter\nname: body text\n---not a delimiter\n',
+    );
+  });
+
   it("rejects create proposals when the target skill file already exists", async () => {
     const workspaceDir = await makeWorkspace();
     const skillFile = path.join(workspaceDir, "skills", "empty-skill", "SKILL.md");


### PR DESCRIPTION
Closes #101769

## What Problem This Solves

Fixes an issue where Markdown that starts with dash-prefixed text such as `---not` or `----` could be treated as a frontmatter block.

## Why This Change Was Made

Frontmatter parsing, bundled command body stripping, and skill workshop proposal stripping now require opening and closing fences to be whole `---` lines. This keeps ordinary dash-prefixed Markdown content from being parsed or stripped as metadata.

## User Impact

Plugin command, hook, skill, metadata, and workshop proposal Markdown that begins with non-delimiter dash text is preserved as body content instead of being misread as frontmatter.

## Evidence

Head SHA: `f6451a08c2a0b1452c1b9c1470627ea905733fc7`

Changed files:
- `packages/markdown-core/src/frontmatter.ts`
- `packages/markdown-core/src/frontmatter.test.ts`
- `src/plugins/bundle-commands.ts`
- `src/skills/workshop/frontmatter.ts`
- `src/skills/workshop/service.test.ts`

Claim proved:
- Whole-line `---` fences are required across the parser, bundled command stripper, and workshop proposal render/apply path.
- A workshop proposal body beginning with `---not frontmatter` is preserved in the generated `SKILL.md`.

Commands / observed results:
- `PNPM_CONFIG_MODULES_DIR=E:\code\openclaw\node_modules node scripts/run-vitest.mjs packages/markdown-core/src/frontmatter.test.ts`
  - Passed: 1 file / 11 tests.
- `PNPM_CONFIG_MODULES_DIR=E:\code\openclaw\node_modules node --import tsx -e "import fs from 'node:fs/promises'; import path from 'node:path'; import { execSync } from 'node:child_process'; import { createOpenClawTestState } from './src/test-utils/openclaw-test-state.ts'; import { proposeCreateSkill, applySkillProposal } from './src/skills/workshop/service.ts'; const state = await createOpenClawTestState({ layout: 'state-only', prefix: 'openclaw-frontmatter-proof-' }); try { const workspaceDir = state.workspaceDir; const proposal = await proposeCreateSkill({ workspaceDir, name: 'Dash Prefixed Body', description: 'Keep body delimiters literal', content: '---not frontmatter\nname: body text\n---not a delimiter\n' }); await applySkillProposal({ workspaceDir, proposalId: proposal.record.id }); const skillPath = path.join(workspaceDir, 'skills', 'dash-prefixed-body', 'SKILL.md'); const skill = await fs.readFile(skillPath, 'utf8'); console.log(JSON.stringify({ head: execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim(), proposalPreservedDashBody: proposal.content.includes('\n---\n\n---not frontmatter\nname: body text\n---not a delimiter\n'), skillPreservedDashBody: skill.includes('\n---not frontmatter\nname: body text\n---not a delimiter\n'), skill }, null, 2)); } finally { await state.cleanup(); }"`
  - Output on head `f6451a08c2a0b1452c1b9c1470627ea905733fc7` showed `"proposalPreservedDashBody": true`, `"skillPreservedDashBody": true`, and generated `SKILL.md` body containing `---not frontmatter` as preserved body text.
- `git diff --check`
  - Passed with no output.
- `PYTHONUTF8=1 CODEX_HOME=%USERPROFILE%\.codex-autoreview-pixel python .agents\skills\autoreview\scripts\autoreview --mode local`
  - Passed via the configured `pixel_api` relay: no accepted/actionable findings; overall patch correct.

Proof note:
- Running the whole `src/skills/workshop/service.test.ts` file on this Windows host reached the new regression but reported one unrelated existing executable-bit test failure: `rejects non-text and executable proposal directory support files`. The direct workshop API proof above exercises the changed render/apply path without that Windows chmod limitation.