### PR TITLE
fix: reject zero cron failure alert cooldowns

### DIFF
--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -1659,6 +1659,16 @@ describe("cron cli", () => {
     );
   });
 
+  it("rejects failure alert cooldowns that floor to zero on cron edit", async () => {
+    await expectCronCommandExit(["cron", "edit", "job-1", "--failure-alert-cooldown", "0.1ms"]);
+    expectRuntimeErrorContaining("Invalid --failure-alert-cooldown");
+    expect(callGatewayFromCli).not.toHaveBeenCalledWith(
+      "cron.update",
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
   it("supports --no-failure-alert on cron edit", async () => {
     callGatewayFromCli.mockClear();
 

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -585,7 +585,7 @@ export function registerCronEditCommand(cron: Command) {
             }
             if (hasFailureAlertCooldown) {
               const cooldownMs = parseDurationMs(String(opts.failureAlertCooldown));
-              if (!cooldownMs && cooldownMs !== 0) {
+              if (!cooldownMs) {
                 throw new Error("Invalid --failure-alert-cooldown.");
               }
               failureAlert.cooldownMs = cooldownMs;


### PR DESCRIPTION
Closes #101770

## What Problem This Solves

Fixes an issue where `openclaw cron edit --failure-alert-cooldown 0.1ms` could save a `0ms` failure-alert cooldown even though the user entered a positive-looking duration.

## Why This Change Was Made

The cron edit path now rejects parsed cooldown values that are falsy, matching the duration parser's invalid result for tiny durations that floor to `0ms`.

## User Impact

Users configuring cron failure alerts get a clear validation error instead of accidentally disabling cooldown throttling.

## Evidence

Head SHA: `ebf57fadad370ad297867443a5d6dd425218c026`

Changed files:
- `src/cli/cron-cli/register.cron-edit.ts`
- `src/cli/cron-cli.test.ts`

Claim proved:
- `cron edit --failure-alert-cooldown 0.1ms` is rejected before `cron.update`, so tiny positive durations that floor to `0ms` are not saved.

Commands / observed results:
- `PNPM_CONFIG_MODULES_DIR=E:\code\openclaw\node_modules node scripts/run-node.mjs cron edit job-1 --failure-alert-cooldown 0.1ms; Write-Host "EXIT_CODE=$LASTEXITCODE"`
  - Output included `Error: Invalid --failure-alert-cooldown.` and `EXIT_CODE=1` on head `ebf57fadad370ad297867443a5d6dd425218c026`.
- `PNPM_CONFIG_MODULES_DIR=E:\code\openclaw\node_modules CI=1 node scripts/run-vitest.mjs src/cli/cron-cli.test.ts`
  - Passed: 1 file / 104 tests.
- Focused CLI-shard proof also passed for `rejects failure alert cooldowns that floor to zero on cron edit`; that regression runs `cron edit job-1 --failure-alert-cooldown 0.1ms`, asserts `Invalid --failure-alert-cooldown`, and asserts `cron.update` is not called.
- `git diff --check`
  - Passed with no output.

Autoreview:
- Current follow-up run used the configured `pixel_api` relay and returned `no local changes to review`; no new diff was added in this proof refresh.