### PR TITLE
fix(agents): avoid false unscheduled note after shell cron add

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -520,17 +520,29 @@ describe("handleToolExecutionEnd cron mutation tracking", () => {
     expect(ctx.state.itemActiveIds.size).toBe(0);
   });
 
-  it("increments successfulCronAdds when shell cron add succeeds", async () => {
+  it.each([
+    ["exec", "openclaw cron add --at +1h --message 'follow up' --name reminder"],
+    ["bash", "pnpm openclaw cron add --cron '0 9 * * *' --message 'daily reminder'"],
+    ["exec", "npx openclaw cron add --at=+1h --message 'follow up'"],
+    ["exec", "bunx openclaw cron add --at +1h --message 'follow up'"],
+    ["exec", "/usr/local/bin/openclaw cron add --at +1h --message 'follow up'"],
+    ["bash", "corepack pnpm openclaw cron add --at +1h --message 'follow up'"],
+    ["exec", "env OPENCLAW_PROFILE=test openclaw cron add --at +1h --message 'follow up'"],
+    ["exec", "openclaw cron create --at +1h --message 'follow up'"],
+    ["exec", "openclaw --profile work cron create --at +1h --message 'follow up'"],
+    ["exec", "openclaw --dev cron add --at +1h --message 'follow up'"],
+    ["exec", "openclaw --log-level debug --no-color cron add --at +1h --message 'follow up'"],
+    ["exec", "openclaw --container helper cron add --at +1h --message 'follow up'"],
+    ["exec", "openclaw cron add --at +1h --message 'follow up || wait'"],
+  ] as const)("increments successfulCronAdds when %s runs %s", async (toolName, command) => {
     const { ctx } = createTestContext();
     await handleToolExecutionStart(
       ctx as never,
       {
         type: "tool_execution_start",
-        toolName: "exec",
-        toolCallId: "tool-exec-cron-add",
-        args: {
-          command: "  openclaw cron add --at +1h --message 'follow up' --name reminder",
-        },
+        toolName,
+        toolCallId: "tool-shell-cron-add",
+        args: { command },
       } as never,
     );
 
@@ -538,66 +550,15 @@ describe("handleToolExecutionEnd cron mutation tracking", () => {
       ctx as never,
       {
         type: "tool_execution_end",
-        toolName: "exec",
-        toolCallId: "tool-exec-cron-add",
+        toolName,
+        toolCallId: "tool-shell-cron-add",
         isError: false,
         result: {
           details: {
             status: "completed",
             exitCode: 0,
-            aggregated: JSON.stringify({
-              ok: true,
-              params: {
-                id: "job-shell-cron",
-                schedule: { kind: "once", atMs: 1_713_000_000_000 },
-                payload: { kind: "agentTurn", message: "follow up" },
-              },
-            }),
-          },
-        },
-      } as never,
-    );
-
-    expect(ctx.state.successfulCronAdds).toBe(1);
-  });
-
-  it("increments successfulCronAdds when shell cron add emits warning text with JSON", async () => {
-    const { ctx } = createTestContext();
-    await handleToolExecutionStart(
-      ctx as never,
-      {
-        type: "tool_execution_start",
-        toolName: "bash",
-        toolCallId: "tool-bash-cron-add-warning-json",
-        args: {
-          command: "openclaw cron add --at +1h --message 'follow up' --name reminder",
-        },
-      } as never,
-    );
-
-    await handleToolExecutionEnd(
-      ctx as never,
-      {
-        type: "tool_execution_end",
-        toolName: "bash",
-        toolCallId: "tool-bash-cron-add-warning-json",
-        isError: false,
-        result: {
-          details: {
-            status: "completed",
-            exitCode: 0,
-            aggregated: [
-              "No --agent specified; using configured default agent.",
-              JSON.stringify({
-                ok: true,
-                params: {
-                  id: "job-shell-cron",
-                  schedule: { kind: "once", atMs: 1_713_000_000_000 },
-                  payload: { kind: "agentTurn", message: "follow up" },
-                },
-              }),
-              "Scheduled reminder using the configured default agent.",
-            ].join("\n"),
+            durationMs: 12,
+            aggregated: "warning text and human-readable success output",
           },
         },
       } as never,
@@ -640,15 +601,28 @@ describe("handleToolExecutionEnd cron mutation tracking", () => {
     expect(ctx.state.successfulCronAdds).toBe(0);
   });
 
-  it("does not increment successfulCronAdds for unrelated shell commands", async () => {
+  it.each([
+    ["openclaw cron list --json", "a different cron action"],
+    ["echo openclaw cron add --at +1h", "a command that only mentions cron add"],
+    ["openclaw cron add --at '+1h", "an unterminated shell argument"],
+    ["cd /tmp && openclaw cron add --at +1h", "a compound command"],
+    ["openclaw cron add --help", "the add command help"],
+    ["openclaw cron create -h", "the create alias help"],
+    ["openclaw cron add --bad||true", "a masked cron failure"],
+    ["openclaw cron add --at +1h; true", "a semicolon suffix"],
+    ["openclaw cron add --at +1h | cat", "a pipeline suffix"],
+    ["openclaw cron add --at +1h & true", "a background suffix"],
+    ["openclaw cron add --at +1h\ntrue", "a newline-separated suffix"],
+    ["openclaw cron add --bad # ignored\ntrue", "a comment-masked cron failure"],
+  ])("does not count %s (%s)", async (command) => {
     const { ctx } = createTestContext();
     await handleToolExecutionStart(
       ctx as never,
       {
         type: "tool_execution_start",
         toolName: "exec",
-        toolCallId: "tool-exec-cron-list",
-        args: { command: "openclaw cron list --json" },
+        toolCallId: "tool-exec-not-cron-add",
+        args: { command },
       } as never,
     );
 
@@ -657,13 +631,14 @@ describe("handleToolExecutionEnd cron mutation tracking", () => {
       {
         type: "tool_execution_end",
         toolName: "exec",
-        toolCallId: "tool-exec-cron-list",
+        toolCallId: "tool-exec-not-cron-add",
         isError: false,
         result: {
           details: {
             status: "completed",
             exitCode: 0,
-            aggregated: JSON.stringify({ jobs: [] }),
+            durationMs: 12,
+            aggregated: "completed",
           },
         },
       } as never,

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -522,11 +522,17 @@ describe("handleToolExecutionEnd cron mutation tracking", () => {
 
   it.each([
     ["exec", "openclaw cron add --at +1h --message 'follow up' --name reminder"],
-    ["bash", "pnpm openclaw cron add --cron '0 9 * * *' --message 'daily reminder'"],
     ["exec", "npx openclaw cron add --at=+1h --message 'follow up'"],
     ["exec", "bunx openclaw cron add --at +1h --message 'follow up'"],
+    ["exec", "pnpm exec openclaw cron add --at +1h --message 'follow up'"],
+    ["exec", "pnpm dlx openclaw cron add --at +1h --message 'follow up'"],
+    ["exec", "npx -y openclaw cron add --at +1h --message 'follow up'"],
+    ["exec", "bunx --bun openclaw cron add --at +1h --message 'follow up'"],
+    ["exec", "pnpm dlx openclaw@latest cron add --at +1h --message 'follow up'"],
+    ["exec", "npx openclaw@latest cron add --at +1h --message 'follow up'"],
+    ["exec", "bunx openclaw@latest cron add --at +1h --message 'follow up'"],
     ["exec", "/usr/local/bin/openclaw cron add --at +1h --message 'follow up'"],
-    ["bash", "corepack pnpm openclaw cron add --at +1h --message 'follow up'"],
+    ["bash", "corepack pnpm exec openclaw cron add --at +1h --message 'follow up'"],
     ["exec", "env OPENCLAW_PROFILE=test openclaw cron add --at +1h --message 'follow up'"],
     ["exec", "openclaw cron create --at +1h --message 'follow up'"],
     ["exec", "openclaw --profile work cron create --at +1h --message 'follow up'"],
@@ -534,6 +540,7 @@ describe("handleToolExecutionEnd cron mutation tracking", () => {
     ["exec", "openclaw --log-level debug --no-color cron add --at +1h --message 'follow up'"],
     ["exec", "openclaw --container helper cron add --at +1h --message 'follow up'"],
     ["exec", "openclaw cron add --at +1h --message 'follow up || wait'"],
+    ["exec", "openclaw cron add --at +1h --message 'follow up' 2>&1"],
   ] as const)("increments successfulCronAdds when %s runs %s", async (toolName, command) => {
     const { ctx } = createTestContext();
     await handleToolExecutionStart(
@@ -614,6 +621,13 @@ describe("handleToolExecutionEnd cron mutation tracking", () => {
     ["openclaw cron add --at +1h & true", "a background suffix"],
     ["openclaw cron add --at +1h\ntrue", "a newline-separated suffix"],
     ["openclaw cron add --bad # ignored\ntrue", "a comment-masked cron failure"],
+    ["npx -y echo openclaw cron add --at +1h", "a package runner for another executable"],
+    ["pnpm openclaw cron add --at +1h", "a bare pnpm package script"],
+    ["corepack pnpm openclaw cron add --at +1h", "a corepack pnpm package script"],
+    ["openclaw@latest cron add --at +1h", "a package spec without a package runner"],
+    ["pnpm exec openclaw@latest cron add --at +1h", "a package spec passed to pnpm exec"],
+    ["openclaw cron add --bad &>/tmp/cron.log", "a bash-only combined redirection"],
+    ["openclaw cron add --bad &>>/tmp/cron.log", "a bash-only append redirection"],
   ])("does not count %s (%s)", async (command) => {
     const { ctx } = createTestContext();
     await handleToolExecutionStart(

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -520,6 +520,158 @@ describe("handleToolExecutionEnd cron mutation tracking", () => {
     expect(ctx.state.itemActiveIds.size).toBe(0);
   });
 
+  it("increments successfulCronAdds when shell cron add succeeds", async () => {
+    const { ctx } = createTestContext();
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-cron-add",
+        args: {
+          command: "  openclaw cron add --at +1h --message 'follow up' --name reminder",
+        },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-cron-add",
+        isError: false,
+        result: {
+          details: {
+            status: "completed",
+            exitCode: 0,
+            aggregated: JSON.stringify({
+              ok: true,
+              params: {
+                id: "job-shell-cron",
+                schedule: { kind: "once", atMs: 1_713_000_000_000 },
+                payload: { kind: "agentTurn", message: "follow up" },
+              },
+            }),
+          },
+        },
+      } as never,
+    );
+
+    expect(ctx.state.successfulCronAdds).toBe(1);
+  });
+
+  it("increments successfulCronAdds when shell cron add emits warning text with JSON", async () => {
+    const { ctx } = createTestContext();
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "bash",
+        toolCallId: "tool-bash-cron-add-warning-json",
+        args: {
+          command: "openclaw cron add --at +1h --message 'follow up' --name reminder",
+        },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "bash",
+        toolCallId: "tool-bash-cron-add-warning-json",
+        isError: false,
+        result: {
+          details: {
+            status: "completed",
+            exitCode: 0,
+            aggregated: [
+              "No --agent specified; using configured default agent.",
+              JSON.stringify({
+                ok: true,
+                params: {
+                  id: "job-shell-cron",
+                  schedule: { kind: "once", atMs: 1_713_000_000_000 },
+                  payload: { kind: "agentTurn", message: "follow up" },
+                },
+              }),
+              "Scheduled reminder using the configured default agent.",
+            ].join("\n"),
+          },
+        },
+      } as never,
+    );
+
+    expect(ctx.state.successfulCronAdds).toBe(1);
+  });
+
+  it("does not increment successfulCronAdds when shell cron add fails", async () => {
+    const { ctx } = createTestContext();
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-cron-add-failed",
+        args: {
+          command: "openclaw cron add --at +1h --message 'follow up' --name reminder",
+        },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-cron-add-failed",
+        isError: false,
+        result: {
+          details: {
+            status: "completed",
+            exitCode: 1,
+            aggregated: "Cron job name is required.",
+          },
+        },
+      } as never,
+    );
+
+    expect(ctx.state.successfulCronAdds).toBe(0);
+  });
+
+  it("does not increment successfulCronAdds for unrelated shell commands", async () => {
+    const { ctx } = createTestContext();
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-cron-list",
+        args: { command: "openclaw cron list --json" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-cron-list",
+        isError: false,
+        result: {
+          details: {
+            status: "completed",
+            exitCode: 0,
+            aggregated: JSON.stringify({ jobs: [] }),
+          },
+        },
+      } as never,
+    );
+
+    expect(ctx.state.successfulCronAdds).toBe(0);
+  });
+
   it("keeps pre-execution cron failures replay-safe", async () => {
     const { ctx } = createTestContext();
     await handleToolExecutionStart(

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -276,6 +276,9 @@ function isExecToolName(toolName: string): boolean {
   return toolName === "exec" || toolName === "bash";
 }
 
+const SHELL_CRON_ADD_COMMAND_PATTERN =
+  /(?:^|(?:&&|\|\||;))\s*(?:env\s+)?(?:(?:[A-Za-z_][A-Za-z0-9_]*=\S+)\s+)*(?:(?:corepack\s+)?pnpm\s+)?(?:[\w./-]*openclaw)\s+cron\s+add(?:\s|$)/;
+
 function isPatchToolName(toolName: string): boolean {
   return toolName === "apply_patch";
 }
@@ -451,6 +454,124 @@ function extractExecOutput(result: unknown): string | undefined {
 function extractLiveExecOutput(result: unknown): string | undefined {
   const output = extractExecOutput(result);
   return typeof output === "string" ? truncateLiveExecOutput(output) : undefined;
+}
+
+function readCronAddShellCommand(args: unknown): string | undefined {
+  const record = asOptionalObjectRecord(args);
+  const command = readStringValue(record?.command) ?? readStringValue(record?.cmd);
+  if (!command || !SHELL_CRON_ADD_COMMAND_PATTERN.test(command)) {
+    return undefined;
+  }
+  return command;
+}
+
+function readJsonObjectAt(
+  text: string,
+  startIndex: number,
+): { record: Record<string, unknown>; endIndex: number } | undefined {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let index = startIndex; index < text.length; index += 1) {
+    const char = text[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+    if (char !== "}") {
+      continue;
+    }
+    depth -= 1;
+    if (depth !== 0) {
+      continue;
+    }
+    try {
+      const parsed: unknown = JSON.parse(text.slice(startIndex, index + 1));
+      const record = asOptionalObjectRecord(parsed);
+      return record ? { record, endIndex: index } : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+function readCronAddResultRecords(output: string | undefined): Record<string, unknown>[] {
+  if (!output) {
+    return [];
+  }
+  try {
+    const parsed: unknown = JSON.parse(output);
+    const record = asOptionalObjectRecord(parsed);
+    if (record) {
+      return [record];
+    }
+  } catch {
+    // Exec aggregated output can contain stderr warnings around JSON stdout.
+  }
+  const records: Record<string, unknown>[] = [];
+  for (let index = 0; index < output.length; index += 1) {
+    if (output[index] !== "{") {
+      continue;
+    }
+    const parsed = readJsonObjectAt(output, index);
+    if (!parsed) {
+      continue;
+    }
+    records.push(parsed.record);
+    index = parsed.endIndex;
+  }
+  return records;
+}
+
+function isCronJobRecord(value: unknown): boolean {
+  const record = asOptionalObjectRecord(value);
+  return Boolean(
+    record &&
+    readStringValue(record.id) &&
+    asOptionalObjectRecord(record.schedule) &&
+    asOptionalObjectRecord(record.payload),
+  );
+}
+
+function isCronAddResponseRecord(value: unknown): boolean {
+  const record = asOptionalObjectRecord(value);
+  if (!record) {
+    return false;
+  }
+  if (isCronJobRecord(record) || isCronJobRecord(record.job)) {
+    return true;
+  }
+  if (record.ok === true) {
+    return isCronJobRecord(record.params) || isCronJobRecord(record.result);
+  }
+  return false;
+}
+
+function didShellCronAddSucceed(args: unknown, result: unknown): boolean {
+  if (!readCronAddShellCommand(args)) {
+    return false;
+  }
+  const details = readExecToolDetails(result);
+  if (details?.status !== "completed" || details.exitCode !== 0) {
+    return false;
+  }
+  const output = extractExecOutput(result);
+  return readCronAddResultRecords(output).some(isCronAddResponseRecord);
 }
 
 function readChannelToolProgress(result: unknown): ChannelToolProgress | undefined {
@@ -1352,7 +1473,11 @@ export async function handleToolExecutionEnd(
   }
 
   // Track committed reminders only when cron.add completed successfully.
-  if (!isToolError && toolName === "cron" && isCronAddAction(startArgs)) {
+  if (
+    !isToolError &&
+    ((toolName === "cron" && isCronAddAction(startArgs)) ||
+      (isExecToolName(toolName) && didShellCronAddSucceed(startArgs, result)))
+  ) {
     ctx.state.successfulCronAdds += 1;
   }
   if (!isToolError && toolName === HEARTBEAT_RESPONSE_TOOL_NAME) {

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -460,6 +460,64 @@ function isOpenClawExecutable(token: string | undefined): boolean {
   return executable?.split(/[\\/]/).at(-1) === "openclaw";
 }
 
+function isOpenClawPackageSpec(token: string | undefined): boolean {
+  const packageSpec = normalizeOptionalLowercaseString(token);
+  return packageSpec?.startsWith("openclaw@") === true && packageSpec.length > "openclaw@".length;
+}
+
+function skipOpenClawPackageRunner(
+  tokens: string[],
+  startIndex: number,
+): { commandIndex: number; acceptsPackageSpec: boolean } {
+  let commandIndex = startIndex;
+  let acceptsPackageSpec = false;
+  let runner = normalizeOptionalLowercaseString(tokens[commandIndex]);
+  if (
+    runner === "corepack" &&
+    normalizeOptionalLowercaseString(tokens[commandIndex + 1]) === "pnpm"
+  ) {
+    commandIndex += 1;
+    runner = "pnpm";
+  }
+  if (runner === "pnpm") {
+    const subcommand = normalizeOptionalLowercaseString(tokens[commandIndex + 1]);
+    if (subcommand === "exec" || subcommand === "dlx") {
+      commandIndex += 2;
+      acceptsPackageSpec = subcommand === "dlx";
+    } else {
+      commandIndex = startIndex;
+    }
+  } else if (runner === "npx" || runner === "bunx") {
+    commandIndex += 1;
+    acceptsPackageSpec = true;
+    while (true) {
+      const option = normalizeOptionalLowercaseString(tokens[commandIndex]);
+      if (
+        option === "-y" ||
+        option === "--yes" ||
+        option === "--no-install" ||
+        option === "--bun"
+      ) {
+        commandIndex += 1;
+        continue;
+      }
+      if (option === "-p" || option === "--package") {
+        commandIndex += 2;
+        continue;
+      }
+      if (option?.startsWith("--package=") || option?.startsWith("--yes=")) {
+        commandIndex += 1;
+        continue;
+      }
+      break;
+    }
+  }
+  if (tokens[commandIndex] === "--") {
+    commandIndex += 1;
+  }
+  return { commandIndex, acceptsPackageSpec };
+}
+
 function isOpenClawCronAddShellCommand(args: unknown): boolean {
   const record = asOptionalObjectRecord(args);
   const command = readStringValue(record?.command) ?? readStringValue(record?.cmd);
@@ -479,15 +537,8 @@ function isOpenClawCronAddShellCommand(args: unknown): boolean {
   while (/^[A-Za-z_][A-Za-z0-9_]*=/u.test(tokens[commandIndex] ?? "")) {
     commandIndex += 1;
   }
-  const executable = normalizeOptionalLowercaseString(tokens[commandIndex]);
-  if (
-    executable === "corepack" &&
-    normalizeOptionalLowercaseString(tokens[commandIndex + 1]) === "pnpm"
-  ) {
-    commandIndex += 2;
-  } else if (executable === "pnpm" || executable === "npx" || executable === "bunx") {
-    commandIndex += 1;
-  }
+  const packageRunner = skipOpenClawPackageRunner(tokens, commandIndex);
+  commandIndex = packageRunner.commandIndex;
 
   let cliArgIndex = commandIndex + 1;
   for (
@@ -500,7 +551,8 @@ function isOpenClawCronAddShellCommand(args: unknown): boolean {
   const action = normalizeOptionalLowercaseString(tokens[cliArgIndex + 1]);
   const actionArgs = tokens.slice(cliArgIndex + 2);
   return (
-    isOpenClawExecutable(tokens[commandIndex]) &&
+    (isOpenClawExecutable(tokens[commandIndex]) ||
+      (packageRunner.acceptsPackageSpec && isOpenClawPackageSpec(tokens[commandIndex]))) &&
     normalizeOptionalLowercaseString(tokens[cliArgIndex]) === "cron" &&
     (action === "add" || action === "create") &&
     !actionArgs.some((token) => token === "-h" || token === "--help")

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -29,6 +29,7 @@ import {
   emitAgentItemEvent,
   emitAgentPatchSummaryEvent,
 } from "../infra/agent-events.js";
+import { consumeRootOptionToken } from "../infra/cli-root-options.js";
 import type { ExecApprovalDecision } from "../infra/exec-approvals.js";
 import {
   parseInteractiveParam,
@@ -38,6 +39,7 @@ import { hasReplyPayloadContent } from "../interactive/payload.js";
 import type { PluginHookAfterToolCallEvent } from "../plugins/types.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { truncateUtf16Safe } from "../utils.js";
+import { hasTopLevelShellControlOperator, splitShellArgs } from "../utils/shell-argv.js";
 import { normalizeAcceptedSessionSpawnResult } from "./accepted-session-spawn.js";
 import {
   consumeAdjustedParamsForToolCall,
@@ -276,9 +278,6 @@ function isExecToolName(toolName: string): boolean {
   return toolName === "exec" || toolName === "bash";
 }
 
-const SHELL_CRON_ADD_COMMAND_PATTERN =
-  /(?:^|(?:&&|\|\||;))\s*(?:env\s+)?(?:(?:[A-Za-z_][A-Za-z0-9_]*=\S+)\s+)*(?:(?:corepack\s+)?pnpm\s+)?(?:[\w./-]*openclaw)\s+cron\s+add(?:\s|$)/;
-
 function isPatchToolName(toolName: string): boolean {
   return toolName === "apply_patch";
 }
@@ -456,122 +455,64 @@ function extractLiveExecOutput(result: unknown): string | undefined {
   return typeof output === "string" ? truncateLiveExecOutput(output) : undefined;
 }
 
-function readCronAddShellCommand(args: unknown): string | undefined {
+function isOpenClawExecutable(token: string | undefined): boolean {
+  const executable = normalizeOptionalLowercaseString(token);
+  return executable?.split(/[\\/]/).at(-1) === "openclaw";
+}
+
+function isOpenClawCronAddShellCommand(args: unknown): boolean {
   const record = asOptionalObjectRecord(args);
   const command = readStringValue(record?.command) ?? readStringValue(record?.cmd);
-  if (!command || !SHELL_CRON_ADD_COMMAND_PATTERN.test(command)) {
-    return undefined;
+  if (!command || hasTopLevelShellControlOperator(command)) {
+    return false;
   }
-  return command;
-}
+  const tokens = splitShellArgs(command);
+  if (!tokens || tokens.length < 3) {
+    return false;
+  }
 
-function readJsonObjectAt(
-  text: string,
-  startIndex: number,
-): { record: Record<string, unknown>; endIndex: number } | undefined {
-  let depth = 0;
-  let inString = false;
-  let escaped = false;
-  for (let index = startIndex; index < text.length; index += 1) {
-    const char = text[index];
-    if (inString) {
-      if (escaped) {
-        escaped = false;
-      } else if (char === "\\") {
-        escaped = true;
-      } else if (char === '"') {
-        inString = false;
-      }
-      continue;
-    }
-    if (char === '"') {
-      inString = true;
-      continue;
-    }
-    if (char === "{") {
-      depth += 1;
-      continue;
-    }
-    if (char !== "}") {
-      continue;
-    }
-    depth -= 1;
-    if (depth !== 0) {
-      continue;
-    }
-    try {
-      const parsed: unknown = JSON.parse(text.slice(startIndex, index + 1));
-      const record = asOptionalObjectRecord(parsed);
-      return record ? { record, endIndex: index } : undefined;
-    } catch {
-      return undefined;
-    }
+  // Compound shell programs need a real shell AST; only count direct CLI invocations.
+  let commandIndex = 0;
+  if (normalizeOptionalLowercaseString(tokens[commandIndex]) === "env") {
+    commandIndex += 1;
   }
-  return undefined;
-}
+  while (/^[A-Za-z_][A-Za-z0-9_]*=/u.test(tokens[commandIndex] ?? "")) {
+    commandIndex += 1;
+  }
+  const executable = normalizeOptionalLowercaseString(tokens[commandIndex]);
+  if (
+    executable === "corepack" &&
+    normalizeOptionalLowercaseString(tokens[commandIndex + 1]) === "pnpm"
+  ) {
+    commandIndex += 2;
+  } else if (executable === "pnpm" || executable === "npx" || executable === "bunx") {
+    commandIndex += 1;
+  }
 
-function readCronAddResultRecords(output: string | undefined): Record<string, unknown>[] {
-  if (!output) {
-    return [];
+  let cliArgIndex = commandIndex + 1;
+  for (
+    let consumed = consumeRootOptionToken(tokens, cliArgIndex);
+    consumed > 0;
+    consumed = consumeRootOptionToken(tokens, cliArgIndex)
+  ) {
+    cliArgIndex += consumed;
   }
-  try {
-    const parsed: unknown = JSON.parse(output);
-    const record = asOptionalObjectRecord(parsed);
-    if (record) {
-      return [record];
-    }
-  } catch {
-    // Exec aggregated output can contain stderr warnings around JSON stdout.
-  }
-  const records: Record<string, unknown>[] = [];
-  for (let index = 0; index < output.length; index += 1) {
-    if (output[index] !== "{") {
-      continue;
-    }
-    const parsed = readJsonObjectAt(output, index);
-    if (!parsed) {
-      continue;
-    }
-    records.push(parsed.record);
-    index = parsed.endIndex;
-  }
-  return records;
-}
-
-function isCronJobRecord(value: unknown): boolean {
-  const record = asOptionalObjectRecord(value);
-  return Boolean(
-    record &&
-    readStringValue(record.id) &&
-    asOptionalObjectRecord(record.schedule) &&
-    asOptionalObjectRecord(record.payload),
+  const action = normalizeOptionalLowercaseString(tokens[cliArgIndex + 1]);
+  const actionArgs = tokens.slice(cliArgIndex + 2);
+  return (
+    isOpenClawExecutable(tokens[commandIndex]) &&
+    normalizeOptionalLowercaseString(tokens[cliArgIndex]) === "cron" &&
+    (action === "add" || action === "create") &&
+    !actionArgs.some((token) => token === "-h" || token === "--help")
   );
 }
 
-function isCronAddResponseRecord(value: unknown): boolean {
-  const record = asOptionalObjectRecord(value);
-  if (!record) {
-    return false;
-  }
-  if (isCronJobRecord(record) || isCronJobRecord(record.job)) {
-    return true;
-  }
-  if (record.ok === true) {
-    return isCronJobRecord(record.params) || isCronJobRecord(record.result);
-  }
-  return false;
-}
-
 function didShellCronAddSucceed(args: unknown, result: unknown): boolean {
-  if (!readCronAddShellCommand(args)) {
+  if (!isOpenClawCronAddShellCommand(args)) {
     return false;
   }
   const details = readExecToolDetails(result);
-  if (details?.status !== "completed" || details.exitCode !== 0) {
-    return false;
-  }
-  const output = extractExecOutput(result);
-  return readCronAddResultRecords(output).some(isCronAddResponseRecord);
+  return details?.status === "completed" && details.exitCode === 0;
 }
 
 function readChannelToolProgress(result: unknown): ChannelToolProgress | undefined {

--- a/src/utils/shell-argv.ts
+++ b/src/utils/shell-argv.ts
@@ -40,6 +40,10 @@ export function hasTopLevelShellControlOperator(raw: string): boolean {
     if (ch === "#" && wordStart) {
       return /[\r\n]/u.test(raw.slice(i + 1));
     }
+    if (ch === "&" && (raw[i - 1] === ">" || raw[i - 1] === "<")) {
+      wordStart = false;
+      continue;
+    }
     if (ch === ";" || ch === "&" || ch === "|" || ch === "\n" || ch === "\r") {
       return true;
     }

--- a/src/utils/shell-argv.ts
+++ b/src/utils/shell-argv.ts
@@ -7,6 +7,48 @@ function isDoubleQuoteEscape(next: string | undefined): next is string {
   return Boolean(next && DOUBLE_QUOTE_ESCAPES.has(next));
 }
 
+/** Returns whether a shell string contains an unquoted command separator or pipeline operator. */
+export function hasTopLevelShellControlOperator(raw: string): boolean {
+  let quote: "'" | '"' | undefined;
+  let escaped = false;
+  let wordStart = true;
+
+  for (let i = 0; i < raw.length; i += 1) {
+    const ch = raw[i];
+    if (escaped) {
+      escaped = false;
+      wordStart = false;
+      continue;
+    }
+    if (quote) {
+      if (quote === '"' && ch === "\\" && isDoubleQuoteEscape(raw[i + 1])) {
+        i += 1;
+      } else if (ch === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      wordStart = false;
+      continue;
+    }
+    if (ch === "#" && wordStart) {
+      return /[\r\n]/u.test(raw.slice(i + 1));
+    }
+    if (ch === ";" || ch === "&" || ch === "|" || ch === "\n" || ch === "\r") {
+      return true;
+    }
+    wordStart = /\s/u.test(ch);
+  }
+
+  return false;
+}
+
 /** Splits a shell-like argv string into tokens, returning null for unterminated quotes or escapes. */
 export function splitShellArgs(raw: string): string[] | null {
   const tokens: string[] = [];


### PR DESCRIPTION
Closes #52972

## What Problem This Solves

Shell-driven reminder creation could succeed through `openclaw cron add` while the turn still received the contradictory note that no reminder was scheduled.

## Why This Change Was Made

The reminder guard already records successful structured `cron` tool adds. This extends that producer-side evidence to successful direct OpenClaw CLI invocations made through `exec` or `bash`.

The classifier accepts the canonical `cron add` and `cron create` forms, root CLI options, executable paths, environment assignments, and explicit package executors such as `pnpm exec`, `pnpm dlx`, `npx`, and `bunx`. It uses the existing typed exec result contract and only counts a completed command with exit code 0.

To avoid false success, it rejects help-only calls, malformed shell input, bare pnpm package scripts, unrelated executables, and compound shell programs whose pipelines or control operators could mask the cron command's status. Portable redirections such as `2>&1` remain supported; bash-only `&>` forms are conservatively rejected because the exec shell may be POSIX `sh`.

## User Impact

Users no longer get a false unscheduled-reminder note after a supported shell cron add succeeds. Failed, masked, help-only, and unrelated commands still leave the guard active.

## Evidence

Exact PR head: `2a4fec68622ad7355a9d1883b80f8dd87073f474`

AWS Crabbox focused proof (`cbx_b01769ac2169`, run `run_b413f37aecee`):

```text
pnpm test:serial \
  src/agents/embedded-agent-subscribe.handlers.tools.test.ts \
  src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts

Test Files  2 passed (2)
Tests       178 passed (178)
```

Additional local explicit-file proof after the final bare-pnpm correction:

```text
node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.handlers.tools.test.ts
Test Files  1 passed (1)
Tests       120 passed (120)
```

Formatting and review:

```text
oxfmt --write <touched files>
git diff --check
autoreview: no accepted/actionable findings
```

