### PR TITLE
docs: remove device-specific node wording

### DIFF
--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -11,7 +11,7 @@ A **node** is a companion device (macOS/iOS/Android/headless) that connects to t
 
 Legacy transport: [Bridge protocol](/gateway/bridge-protocol) (TCP JSONL; historical only for current nodes).
 
-macOS can also run in **node mode**: the menubar app connects to the Gateway's WS server and exposes its local canvas/camera commands as a node (so `openclaw nodes …` works against this Mac). In remote gateway mode, browser automation is handled by the CLI node host (`openclaw node run` or the installed node service), not by the native app node.
+macOS can also run in **node mode**: the menubar app connects to the Gateway's WS server and exposes its local canvas/camera commands as a node. In remote gateway mode, browser automation is handled by the CLI node host (`openclaw node run` or the installed node service), not by the native app node.
 
 Nodes are **peripherals**, not gateways: they don't run the gateway service, and channel messages (Telegram, WhatsApp, etc.) land on the gateway, not on nodes.
 
@@ -490,5 +490,5 @@ Notes:
 
 ## Mac node mode
 
-- The macOS menubar app connects to the Gateway WS server as a node (so `openclaw nodes …` works against this Mac).
+- The macOS menubar app connects to the Gateway WS server as a node.
 - In remote mode, the app opens an SSH tunnel for the Gateway port and connects to `localhost`.


### PR DESCRIPTION
## What Problem This Solves

The nodes documentation twice says `openclaw nodes …` works “against this Mac.” This device-specific phrasing can read as referring to a particular machine (the one the mantainer was using) instead of a generic macOS node.

## Why This Change Was Made

Remove both redundant parentheticals while preserving the explanation that the macOS menubar app connects to the Gateway as a node. No runtime behavior or command documentation changes.

## User Impact

Readers get a clearer, device-neutral description of macOS node mode.

## Evidence

- Before: `openclaw nodes …` works `against this Mac`.
- After: both sentences end after explaining that the menubar app connects as a node.