### PR TITLE
fix(discord): split encoded video URLs from captions

### DIFF
--- a/extensions/discord/src/media-detection.test.ts
+++ b/extensions/discord/src/media-detection.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { isLikelyDiscordVideoMedia } from "./media-detection.js";
+
+describe("isLikelyDiscordVideoMedia", () => {
+  it.each([
+    ["plain local path", "/tmp/render.MP4?download=1", true],
+    ["encoded extension dot", "https://cdn.example/render%2Emp4?download=1", true],
+    ["encoded extension characters", "https://cdn.example/render%2Em%70%34", true],
+    ["malformed earlier segment", "https://cdn.example/bad%ZZ/render%2Emp4", true],
+    ["encoded suffix after extension", "https://cdn.example/render.mp4%2Fpreview", false],
+    ["double-encoded dot", "https://cdn.example/render%252Emp4", false],
+    ["non-video extension", "https://cdn.example/render%2Ejpg", false],
+  ])("classifies %s", (_name, mediaUrl, expected) => {
+    expect(isLikelyDiscordVideoMedia(mediaUrl)).toBe(expected);
+  });
+});

--- a/extensions/discord/src/media-detection.ts
+++ b/extensions/discord/src/media-detection.ts
@@ -10,10 +10,13 @@ function normalizeMediaPathForExtension(mediaUrl: string): string {
   }
   try {
     const parsed = new URL(trimmed);
+    const fileName = parsed.pathname.slice(parsed.pathname.lastIndexOf("/") + 1);
+    // Mirror media-loader filename decoding without reinterpreting escapes in
+    // earlier URL path segments, which are irrelevant to the file extension.
     try {
-      return normalizeLowercaseStringOrEmpty(decodeURIComponent(parsed.pathname));
+      return normalizeLowercaseStringOrEmpty(decodeURIComponent(fileName));
     } catch {
-      return normalizeLowercaseStringOrEmpty(parsed.pathname);
+      return normalizeLowercaseStringOrEmpty(fileName);
     }
   } catch {
     const withoutHash = trimmed.split("#", 1)[0] ?? trimmed;

--- a/extensions/discord/src/media-detection.ts
+++ b/extensions/discord/src/media-detection.ts
@@ -10,7 +10,11 @@ function normalizeMediaPathForExtension(mediaUrl: string): string {
   }
   try {
     const parsed = new URL(trimmed);
-    return normalizeLowercaseStringOrEmpty(parsed.pathname);
+    try {
+      return normalizeLowercaseStringOrEmpty(decodeURIComponent(parsed.pathname));
+    } catch {
+      return normalizeLowercaseStringOrEmpty(parsed.pathname);
+    }
   } catch {
     const withoutHash = trimmed.split("#", 1)[0] ?? trimmed;
     const withoutQuery = withoutHash.split("?", 1)[0] ?? withoutHash;

--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -588,12 +588,14 @@ describe("discordOutbound", () => {
   it.each([
     {
       name: "implicit first-mode",
+      mediaUrl: "/tmp/render.mp4",
       replyToIdSource: "implicit" as const,
       replyToMode: "first" as const,
       expectedReplies: [{ messageId: "reply-1", scope: "first" }, undefined],
     },
     {
       name: "implicit all-mode",
+      mediaUrl: "/tmp/render.mp4",
       replyToIdSource: "implicit" as const,
       replyToMode: "all" as const,
       expectedReplies: [
@@ -603,6 +605,17 @@ describe("discordOutbound", () => {
     },
     {
       name: "explicit first-mode",
+      mediaUrl: "/tmp/render.mp4",
+      replyToIdSource: "explicit" as const,
+      replyToMode: "first" as const,
+      expectedReplies: [
+        { messageId: "reply-1", scope: "all" },
+        { messageId: "reply-1", scope: "all" },
+      ],
+    },
+    {
+      name: "encoded URL extension",
+      mediaUrl: "https://cdn.discordapp.com/attachments/1/render%2Emp4?ex=1",
       replyToIdSource: "explicit" as const,
       replyToMode: "first" as const,
       expectedReplies: [
@@ -615,7 +628,7 @@ describe("discordOutbound", () => {
       cfg: {},
       to: "channel:123456",
       text: "rendered clip",
-      mediaUrl: "/tmp/render.mp4",
+      mediaUrl: testCase.mediaUrl,
       accountId: "default",
       replyToId: "reply-1",
       replyToIdSource: testCase.replyToIdSource,
@@ -639,7 +652,7 @@ describe("discordOutbound", () => {
     expect(mediaCall[1]).toBe("");
     const mediaOptions = mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 1, 2);
     expect(mediaOptions.accountId).toBe("default");
-    expect(mediaOptions.mediaUrl).toBe("/tmp/render.mp4");
+    expect(mediaOptions.mediaUrl).toBe(testCase.mediaUrl);
     expect(mediaOptions.reply).toEqual(testCase.expectedReplies[1]);
   });
 


### PR DESCRIPTION
## What Problem This Solves

Discord sends captioned video media in two messages so the caption remains visible before the upload. The local video classifier checked the raw URL pathname, so a valid filename such as `render%2Emp4` did not match the `.mp4` suffix and incorrectly took the combined-send path.

## Why This Change Was Made

The classifier now extracts and decodes only the final URL filename before extension matching. That matches the shared media loader's filename semantics while avoiding whole-path decoding: malformed escapes in earlier path segments cannot suppress classification, and encoded path delimiters are not reinterpreted as URL structure.

The original media URL is still passed unchanged into the existing guarded media loader and Discord send path.

## User Impact

Captioned Discord videos whose filename contains percent-encoded extension characters now use the same caption-first/media-second delivery as ordinary `.mp4`, `.mov`, `.webm`, and other supported video URLs.

## Evidence

- Blacksmith Testbox `coral-crab` (`tbx_01kx2dacsrr1z0hjxenejbt9s5`): 55 focused tests passed across the direct media classifier and Discord outbound adapter.
- Direct cases cover encoded dots and extension characters, malformed earlier path segments, encoded suffixes, double encoding, local query strings, and non-video extensions.
- The outbound regression proves two sends and preserves the original encoded media URL.
- Fresh autoreview after the maintainer refactor: no actionable findings, confidence 0.96.
- `git diff --check` passed.

The existing PR runtime transcripts additionally exercise the production outbound adapter and real Discord send-stack body construction without claiming external network delivery.
