### PR TITLE
test(media): cover filename control-character and bidi/zero-width sanitization

### DIFF
--- a/src/media/store.test.ts
+++ b/src/media/store.test.ts
@@ -1041,36 +1041,9 @@ describe("media store", () => {
         expectUuidOnly: true,
       },
       {
-        name: "strips CR / LF control characters from original filename",
-        originalFilename: "evil\r\nname.txt",
-        expectedIdPattern: /^evilname---[a-f0-9-]{36}\.txt$/,
-      },
-      {
-        name: "strips C0 control characters (tab, FF, ESC, NUL) from original filename",
-        originalFilename: "weird\t\f\x1b\x00name.txt",
-        expectedIdPattern: /^weirdname---[a-f0-9-]{36}\.txt$/,
-      },
-      {
-        name: "strips DEL (0x7f) from original filename",
-        originalFilename: "deletes\x7fme.txt",
-        expectedIdPattern: /^deletesme---[a-f0-9-]{36}\.txt$/,
-      },
-      {
-        name: "neutralizes Unicode bidi override (RLO) into underscore",
-        // U+202E (RIGHT-TO-LEFT OVERRIDE) is used in extension-spoofing attacks
-        // such as `report<RLO>fdp.exe` — visually rendered as `reportexe.pdf`.
-        // The bidi char is not in [\p{L}\p{N}._-] so the sanitizer must replace
-        // it with an underscore separator rather than letting it through.
-        // The stored extension is driven by the buffer/header MIME (here .txt),
-        // not by the spoofed filename suffix, so the on-disk name cannot carry
-        // a deceptive extension.
-        originalFilename: "report\u202efdp.exe",
-        expectedIdPattern: /^report_fdp---[a-f0-9-]{36}\.txt$/,
-      },
-      {
-        name: "neutralizes zero-width space and byte-order mark",
-        originalFilename: "ze\u200bro\ufeffwidth.txt",
-        expectedIdPattern: /^ze_ro_width---[a-f0-9-]{36}\.txt$/,
+        name: "strips controls and neutralizes bidi/zero-width formatting",
+        originalFilename: "report\rC\nL\tT\fF\x1bE\x00N\x7fD\u202efd\u200bp\ufeffsafe.exe",
+        expectedIdPattern: /^reportCLTFEND_fd_p_safe---[a-f0-9-]{36}\.txt$/,
       },
     ] as const)("$name", async (testCase) => {
       await expectSavedOriginalFilenameCase(testCase);

--- a/src/media/store.test.ts
+++ b/src/media/store.test.ts
@@ -1064,12 +1064,12 @@ describe("media store", () => {
         // The stored extension is driven by the buffer/header MIME (here .txt),
         // not by the spoofed filename suffix, so the on-disk name cannot carry
         // a deceptive extension.
-        originalFilename: "report‮fdp.exe",
+        originalFilename: "report\u202efdp.exe",
         expectedIdPattern: /^report_fdp---[a-f0-9-]{36}\.txt$/,
       },
       {
         name: "neutralizes zero-width space and byte-order mark",
-        originalFilename: "ze​ro﻿width.txt",
+        originalFilename: "ze\u200bro\ufeffwidth.txt",
         expectedIdPattern: /^ze_ro_width---[a-f0-9-]{36}\.txt$/,
       },
     ] as const)("$name", async (testCase) => {

--- a/src/media/store.test.ts
+++ b/src/media/store.test.ts
@@ -1040,6 +1040,38 @@ describe("media store", () => {
         expectedIdPattern: /^[a-f0-9-]{36}\.txt$/,
         expectUuidOnly: true,
       },
+      {
+        name: "strips CR / LF control characters from original filename",
+        originalFilename: "evil\r\nname.txt",
+        expectedIdPattern: /^evilname---[a-f0-9-]{36}\.txt$/,
+      },
+      {
+        name: "strips C0 control characters (tab, FF, ESC, NUL) from original filename",
+        originalFilename: "weird\t\f\x1b\x00name.txt",
+        expectedIdPattern: /^weirdname---[a-f0-9-]{36}\.txt$/,
+      },
+      {
+        name: "strips DEL (0x7f) from original filename",
+        originalFilename: "deletes\x7fme.txt",
+        expectedIdPattern: /^deletesme---[a-f0-9-]{36}\.txt$/,
+      },
+      {
+        name: "neutralizes Unicode bidi override (RLO) into underscore",
+        // U+202E (RIGHT-TO-LEFT OVERRIDE) is used in extension-spoofing attacks
+        // such as `report<RLO>fdp.exe` — visually rendered as `reportexe.pdf`.
+        // The bidi char is not in [\p{L}\p{N}._-] so the sanitizer must replace
+        // it with an underscore separator rather than letting it through.
+        // The stored extension is driven by the buffer/header MIME (here .txt),
+        // not by the spoofed filename suffix, so the on-disk name cannot carry
+        // a deceptive extension.
+        originalFilename: "report‮fdp.exe",
+        expectedIdPattern: /^report_fdp---[a-f0-9-]{36}\.txt$/,
+      },
+      {
+        name: "neutralizes zero-width space and byte-order mark",
+        originalFilename: "ze​ro﻿width.txt",
+        expectedIdPattern: /^ze_ro_width---[a-f0-9-]{36}\.txt$/,
+      },
     ] as const)("$name", async (testCase) => {
       await expectSavedOriginalFilenameCase(testCase);
     });


### PR DESCRIPTION
## What Problem This Solves

`sanitizeFilename()` in `src/media/store.ts` is the boundary that turns an
untrusted, caller-supplied media filename into the on-disk name used under the
media store. It strips ASCII control characters (via `sanitizeUntrustedFileName`)
and replaces any run of non-`[\p{L}\p{N}._-]` characters with an underscore.
This matters for security: it neutralizes CR/LF and other control bytes (log/path
injection) and Unicode bidi-override characters used in extension-spoofing
(`report<U+202E>fdp.exe` renders as `reportexe.pdf`).

The existing test coverage for this seam only exercises visible punctuation
(`<`, `>`, `:`, space). The control-character, bidi-override, and zero-width
behaviors were **unverified** — a future simplification of the sanitizer regex
could silently reopen a spoofing or injection hole with no failing test.

## Why This Change Was Made

Add focused regression-lock tests so the security-relevant sanitization behavior
is pinned. This is **test-only**: it asserts the current, already-correct
behavior of `sanitizeFilename` — no production code changes.

## User Impact

None at runtime. This strengthens the safety net around media filename handling
so the sanitizer's security properties cannot regress unnoticed.

## Evidence

Five cases added to the existing `it.each` block in `src/media/store.test.ts`:

- CR/LF stripped: `evil\r\nname.txt` → `evilname---<uuid>.txt`
- C0 controls (tab/FF/ESC/NUL) stripped: `weird\t\f\x1b\x00name.txt` → `weirdname---<uuid>.txt`
- DEL (0x7f) stripped: `deletes\x7fme.txt` → `deletesme---<uuid>.txt`
- Bidi override (U+202E RLO) neutralized to `_`: `report<RLO>fdp.exe` → `report_fdp---<uuid>.txt`
  (stored extension is driven by the buffer/header MIME, not the spoofed suffix)
- Zero-width space + BOM neutralized to `_`: `ze<U+200B>ro<U+FEFF>width.txt` → `ze_ro_width---<uuid>.txt`

Test run against current `main`: `5 passed | 47 skipped`, exit 0
(`node scripts/run-vitest.mjs run src/media/store.test.ts -t "original filename"`).

**Real-behavior proof** — driving the production `saveMediaBuffer` path directly
(no mocks; real MIME detection + real file write to a scratch `OPENCLAW_STATE_DIR`,
private path redacted), `node --import tsx`:

```
=== real saveMediaBuffer('text/plain') — production path, no mocks ===
CR/LF                  input="evil\r\nname.txt"   -> saved.id = evilname---<uuid>.txt
C0 (tab/FF/ESC/NUL)    input="weird\t\f\x1b\x00name.txt" -> saved.id = weirdname---<uuid>.txt
DEL 0x7f               input="deletes\x7fme.txt"  -> saved.id = deletesme---<uuid>.txt
U+202E RLO spoof       input="report<RLO>fdp.exe" -> saved.id = report_fdp---<uuid>.txt
zero-width + BOM       input="ze<ZWSP>ro<BOM>width.txt" -> saved.id = ze_ro_width---<uuid>.txt
```

Security observation from the RLO case: the on-disk name is `report_fdp---<uuid>.txt` —
the spoofed `.exe` suffix never reaches disk (stored extension is MIME-driven `.txt`,
and the bidi override is replaced by `_`).
