### PR TITLE
fix(zalo): keep outbound text and caption truncation UTF-16 safe

### DIFF
--- a/extensions/zalo/src/send.test.ts
+++ b/extensions/zalo/src/send.test.ts
@@ -18,6 +18,9 @@ import { sendMessageZalo, sendPhotoZalo } from "./send.js";
 
 type ZaloSendResult = Awaited<ReturnType<typeof sendMessageZalo>>;
 
+const UNPAIRED_SURROGATE_RE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
+const ZALO_TEXT_LIMIT = 2000;
+
 function requireSuccessfulSend(result: ZaloSendResult, expectedMessageId: string) {
   expect(result.ok).toBe(true);
   if (!result.ok) {
@@ -117,6 +120,39 @@ describe("zalo send", () => {
 
     expect(sendMessageMock).not.toHaveBeenCalled();
     expect(sendPhotoMock).not.toHaveBeenCalled();
+  });
+
+  it("does not leave dangling surrogates when truncating outbound text at the 2000 limit", async () => {
+    sendMessageMock.mockResolvedValueOnce({
+      ok: true,
+      result: { message_id: "z-msg-surrogate" },
+    });
+
+    const text = `${"a".repeat(ZALO_TEXT_LIMIT - 1)}🐱`;
+    await sendMessageZalo("dm-chat-surrogate-text", text, {
+      token: "zalo-token",
+    });
+
+    const sentText = sendMessageMock.mock.calls[0]?.[1]?.text as string;
+    expect(sentText).toBe("a".repeat(ZALO_TEXT_LIMIT - 1));
+    expect(UNPAIRED_SURROGATE_RE.test(sentText)).toBe(false);
+  });
+
+  it("does not leave dangling surrogates when truncating photo captions at the 2000 limit", async () => {
+    sendPhotoMock.mockResolvedValueOnce({
+      ok: true,
+      result: { message_id: "z-photo-surrogate" },
+    });
+
+    const caption = `${"a".repeat(ZALO_TEXT_LIMIT - 1)}🐱`;
+    await sendPhotoZalo("dm-chat-surrogate-caption", "https://example.com/photo.jpg", {
+      token: "zalo-token",
+      caption,
+    });
+
+    const sentCaption = sendPhotoMock.mock.calls[0]?.[1]?.caption as string;
+    expect(sentCaption).toBe("a".repeat(ZALO_TEXT_LIMIT - 1));
+    expect(UNPAIRED_SURROGATE_RE.test(sentCaption)).toBe(false);
   });
 
   it("sends cfg-backed media directly without hosted-media rewrites", async () => {

--- a/extensions/zalo/src/send.ts
+++ b/extensions/zalo/src/send.ts
@@ -6,6 +6,7 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveZaloAccount } from "./accounts.js";
 import type { ZaloFetch } from "./api.js";
 import { sendMessage, sendPhoto } from "./api.js";
@@ -167,7 +168,7 @@ export async function sendMessageZalo(
       context.token,
       {
         chat_id: context.chatId,
-        text: text.slice(0, 2000),
+        text: truncateUtf16Safe(text, 2000),
       },
       context.fetcher,
     ),
@@ -200,7 +201,8 @@ export async function sendPhotoZalo(
         {
           chat_id: context.chatId,
           photo: photoUrl.trim(),
-          caption: options.caption?.slice(0, 2000),
+          caption:
+            options.caption !== undefined ? truncateUtf16Safe(options.caption, 2000) : undefined,
         },
         context.fetcher,
       ))(),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where outbound Zalo messages containing emoji near the 2 000-character limit could be delivered with a corrupted final character. Zalo's API enforces a 2 000-character message limit, and the previous code used JavaScript's `.slice(0, 2000)` to enforce it. `String.slice` splits at UTF-16 code-unit boundaries, so an emoji that encodes as a surrogate pair (e.g. 🐱 = `\uD83D\uDC31`) positioned at index 1999–2000 would be split in two, leaving an unpaired surrogate sent to the Zalo API.

**Concrete example:** A Zalo message of 1999 ASCII characters followed by 🐱 — the old code passes `…text\uD83D` (an unpaired high surrogate) to the API; the new code backs off to 1999 characters and sends the message cleanly.

## Why This Change Was Made

Replace both `.slice(0, 2000)` calls with `truncateUtf16Safe(…, 2000)`, the shared helper from `openclaw/plugin-sdk/text-utility-runtime` that backs off from any incomplete surrogate pair before returning. Two call sites are fixed:

- `sendMessageZalo` — the plain text body (`text: text.slice(0, 2000)`)
- `sendPhotoZalo` — the photo caption (`caption: options.caption?.slice(0, 2000)`)

## User Impact

**Before:** Zalo messages or photo captions that are exactly 2 000 characters long and end with an emoji may be delivered with a broken character, causing a malformed payload to the Zalo API and potentially a send error or garbled message.

**After:** Both text and caption are truncated on a clean code-point boundary; emoji at the cap are either included whole or dropped, never split.

## Evidence

- **Broken call sites:** `extensions/zalo/src/send.ts:170` (text) and `:203` (caption) on current `upstream/main` — both use raw `.slice(0, 2000)`.
- **Fix:** `truncateUtf16Safe` from `openclaw/plugin-sdk/text-utility-runtime`, defined in `packages/normalization-core/src/utf16-slice.ts`.
- **Precedent:** identical fix applied in #101781 (Telegram DM topic), #101782 (Slack thread label), #101784 (Slack inbound preview).
- **Diff:** production change is +4/−2 in `extensions/zalo/src/send.ts`; call-site regressions added in `extensions/zalo/src/send.test.ts`.
- **No open PR** for this surface (confirmed via `gh pr list --search "zalo truncat utf16 slice"`).

### Behavior proof

#### 1) Node runtime boundary reproduction (no mocks, no Vitest)

Reproduces the shipped bug vs fix on the exact Zalo 2000-limit boundary input (`1999 × 'a' + 🐱`):

```text
$ node --import tsx/esm -e "
import { truncateUtf16Safe } from './packages/normalization-core/src/utf16-slice.ts';
const ZALO_TEXT_LIMIT = 2000;
const input = 'a'.repeat(ZALO_TEXT_LIMIT - 1) + '🐱';
const oldSlice = input.slice(0, ZALO_TEXT_LIMIT);
const fixed = truncateUtf16Safe(input, ZALO_TEXT_LIMIT);
const unpaired = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test.bind(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
console.log('input code units:', input.length);
console.log('old .slice(0,2000) code units:', oldSlice.length);
console.log('old payload has unpaired surrogate:', unpaired(oldSlice));
console.log('old payload last char code: U+' + oldSlice.charCodeAt(oldSlice.length - 1).toString(16).toUpperCase());
console.log('truncateUtf16Safe(...,2000) code units:', fixed.length);
console.log('fixed payload has unpaired surrogate:', unpaired(fixed));
"

input code units: 2001
old .slice(0,2000) code units: 2000
old payload has unpaired surrogate: true
old payload last char code: U+D83D
truncateUtf16Safe(...,2000) code units: 1999
fixed payload has unpaired surrogate: false
```

#### 2) Loopback HTTP proof through production `send.ts` + `api.ts` (no Vitest mocks)

Uses a local `node:http` server as `ZALO_API_URL` so the real outbound path serializes JSON and POSTs through `callZaloApi`. Token and chat ids are redacted; photo URL uses `https://example.com/photo.jpg` only to satisfy SSRF hostname policy — the request still goes to the local loopback API.

```text
=== Zalo loopback HTTP proof (production send.ts + api.ts, no Vitest mocks) ===
Node: v22.22.0
ZALO_API_URL=http://127.0.0.1:55742
boundary input code units: 2001
old .slice(0,2000) would leave unpaired surrogate: true

[sendMessageZalo → POST /botREDACTED-TOKEN/sendMessage]
send ok: true
message_id: loopback-1
API JSON text code units: 1999
API JSON text has unpaired surrogate: false

[sendPhotoZalo → POST /botREDACTED-TOKEN/sendPhoto]
send ok: true
message_id: loopback-2
API JSON caption code units: 1999
API JSON caption has unpaired surrogate: false
```

This shows the after-fix production path emits surrogate-safe JSON for both outbound text and photo captions at the 2000 cap.

#### 3) Call-site regression tests

```text
$ pnpm test extensions/zalo/src/send.test.ts --reporter=verbose

 ✓ extensions/zalo/src/send.test.ts > zalo send > does not leave dangling surrogates when truncating outbound text at the 2000 limit
 ✓ extensions/zalo/src/send.test.ts > zalo send > does not leave dangling surrogates when truncating photo captions at the 2000 limit

 Test Files  1 passed (1)
      Tests  6 passed (6)
```

**Proof gap:** No redacted traffic to the live `bot-api.zaloplatforms.com` endpoint (no Zalo bot token in this validation environment). Loopback proof exercises the same production serialization and HTTP client path with a local stand-in API.

---

> **AI-assisted PR** — Generated with Cursor/Claude. Logic verified against `packages/normalization-core/src/utf16-slice.ts` and upstream `main` state. Change is narrow and non-breaking.

Made with [Cursor](https://cursor.com)
