### PR TITLE
fix(ai): disable thinking when clamped to off in buildGoogleSimpleThinking (#101785)

### DIFF
--- a/packages/ai/src/providers/google-shared.test.ts
+++ b/packages/ai/src/providers/google-shared.test.ts
@@ -6,6 +6,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../utils/system-prompt-cache-boundary.js";
 import {
   buildGoogleGenerateContentParams,
+  buildGoogleSimpleThinking,
   consumeGoogleGenerateContentStream,
 } from "./google-shared.js";
 
@@ -248,5 +249,36 @@ describe("buildGoogleGenerateContentParams", () => {
 
     expect(params.config?.systemInstruction).toBe("Stable\nDynamic");
     expect(JSON.stringify(params)).not.toContain("OPENCLAW_CACHE_BOUNDARY");
+  });
+});
+
+describe("buildGoogleSimpleThinking", () => {
+  // Non-reasoning model: clampThinkingLevel clamps any non-"off" level to "off".
+  const nonReasoningModel: Model<"google-generative-ai"> = {
+    ...model,
+    id: "gemini-1.5-pro",
+    name: "Gemini 1.5 Pro",
+    reasoning: false,
+  };
+
+  it("disables thinking when clampThinkingLevel returns off for non-reasoning models", () => {
+    // Before the fix, clamped "off" was mapped to "high" effort and enabled
+    // thinking for models that cannot support it. After the fix, "off" returns
+    // disabled thinking immediately.
+    const result = buildGoogleSimpleThinking(nonReasoningModel, {
+      reasoning: "low",
+    });
+
+    expect(result.enabled).toBe(false);
+    expect(result.budgetTokens).toBeUndefined();
+    expect(result.level).toBeUndefined();
+  });
+
+  it("disables thinking when reasoning is explicitly off", () => {
+    const result = buildGoogleSimpleThinking(model, {
+      reasoning: "off",
+    });
+
+    expect(result.enabled).toBe(false);
   });
 });

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -557,8 +557,16 @@ export function buildGoogleSimpleThinking<T extends GoogleApiType>(
   }
 
   const clampedReasoning = clampThinkingLevel(model, options.reasoning);
+
+  // If the reasoning level was clamped to "off" (model doesn't support the
+  // requested level), disable thinking entirely. Otherwise, "off" would map
+  // to "high" effort and incorrectly enable thinking.
+  if (clampedReasoning === "off") {
+    return { enabled: false };
+  }
+
   const effort = (
-    clampedReasoning === "off" || clampedReasoning === "max" ? "high" : clampedReasoning
+    clampedReasoning === "max" ? "high" : clampedReasoning
   ) as ClampedGoogleThinkingLevel;
 
   if (


### PR DESCRIPTION
## What Problem This Solves

When a user requests a reasoning level (e.g., `low` or `medium`) on a Google model that does not support thinking, the `clampThinkingLevel` function correctly clamps the requested level to `"off"` (indicating the model cannot support the requested reasoning capability). However, the `buildGoogleSimpleThinking` function in `packages/ai/src/providers/google-shared.ts` had a logic bug: it treated `"off"` as a valid reasoning level and mapped it to `"high"` effort, then incorrectly enabled thinking for models that should have it disabled.

This caused unexpected API failures or unnecessary token overhead when using non-thinking-capable models with reasoning settings that get clamped to `"off"`.

## Why This Change Was Made

The bug was in line 560-562 of `packages/ai/src/providers/google-shared.ts`:

```typescript
// BEFORE (buggy):
const effort = (
  clampedReasoning === "off" || clampedReasoning === "max" ? "high" : clampedReasoning
) as ClampedGoogleThinkingLevel;
```

The problem: when `clampThinkingLevel` returns `"off"` (meaning "model doesn't support this level"), the ternary operator mapped `"off"` to `"high"` effort, and the code then enabled thinking with that high effort.

The fix adds an explicit check after clamping: if the reasoning level was clamped to `"off"`, disable thinking entirely. This preserves the intent that only models supporting thinking should have it enabled, and only at supported levels.

## User Impact

- Users requesting reasoning levels on non-thinking-capable Google models (e.g., Gemini 1.5 Pro) will no longer encounter unexpected API failures from incorrectly enabled high-level thinking
- Reduced unnecessary token overhead for deployments that accidentally use thinking settings on incompatible models
- Fixes a P2 bug that could cause crashes or unexpected behavior in agent workflows using Google models with clamped reasoning settings

## Evidence

- **Behavior addressed:** `buildGoogleSimpleThinking()` incorrectly enabled HIGH-level thinking when `clampThinkingLevel()` clamped a requested reasoning level to `"off"` for non-reasoning-capable Google models.
- **Environment tested:** OpenClaw source at commit `827f2c442` (upstream main), Node 22.19+, TypeScript strict mode.
- **Steps run after the patch:**
  1. Added a focused regression case in `packages/ai/src/providers/google-shared.test.ts` that calls `buildGoogleSimpleThinking()` with a non-reasoning model (`reasoning: false`, id `"gemini-1.5-pro"`) and `reasoning: "low"` — exercising the exact clamp-to-off path.
  2. Ran the verification on current `main` (without fix) to confirm the bug reproduces: the function returned `enabled: true` instead of `enabled: false`.
  3. Ran the same verification on the fix branch: the function correctly returns `enabled: false`.
- **Evidence after fix:**
  Focused behavior verification — before fix (main, no patch):
  ```
  × buildGoogleSimpleThinking > disables thinking when clampThinkingLevel returns off for non-reasoning models
    AssertionError: expected true to be false
    - Expected: false
    + Received: true
  ```

  After fix (patch applied):
  ```
  ✓ buildGoogleSimpleThinking > disables thinking when clampThinkingLevel returns off for non-reasoning models
  ```
  The non-reasoning model with `reasoning: "low"` now returns `{ enabled: false }` with no `budgetTokens` and no `level`, confirming thinking is fully disabled when clamped to off.
- **Observed result after fix:** The clamp-to-off path in `buildGoogleSimpleThinking()` now correctly returns `{ enabled: false }`. Before the fix, it returned `{ enabled: true }` with high-effort thinking, causing API errors on non-thinking-capable Google models. The regression case fails on main and passes with the patch.
- **What was not tested:** Google API network round-trips (the fix is in provider request-shaping logic before any network call; the function output is deterministic given model + options).

## Real behavior proof

- **Behavior addressed:** `buildGoogleSimpleThinking()` incorrectly enabled HIGH-level thinking when `clampThinkingLevel()` clamped a requested reasoning level to `"off"` for non-reasoning-capable Google models.
- **Environment tested:** OpenClaw source at commit `827f2c442` (upstream main), Node 22.19+, TypeScript strict mode.
- **Steps run after the patch:**
  1. Added a focused regression case in `packages/ai/src/providers/google-shared.test.ts` that calls `buildGoogleSimpleThinking()` with a non-reasoning model (`reasoning: false`, id `"gemini-1.5-pro"`) and `reasoning: "low"` — exercising the exact clamp-to-off path.
  2. Ran the verification on current `main` (without fix) to confirm the bug reproduces: the function returned `enabled: true` instead of `enabled: false`.
  3. Ran the same verification on the fix branch: the function correctly returns `enabled: false`.
- **Evidence after fix:**
  Focused behavior verification — before fix (main, no patch):
  ```
  × buildGoogleSimpleThinking > disables thinking when clampThinkingLevel returns off for non-reasoning models
    AssertionError: expected true to be false
    - Expected: false
    + Received: true
  ```

  After fix (patch applied):
  ```
  ✓ buildGoogleSimpleThinking > disables thinking when clampThinkingLevel returns off for non-reasoning models
  ```
  The non-reasoning model with `reasoning: "low"` now returns `{ enabled: false }` with no `budgetTokens` and no `level`, confirming thinking is fully disabled when clamped to off.
- **Observed result after fix:** The clamp-to-off path in `buildGoogleSimpleThinking()` now correctly returns `{ enabled: false }`. Before the fix, it returned `{ enabled: true }` with high-effort thinking, causing API errors on non-thinking-capable Google models. The regression case fails on main and passes with the patch.
- **What was not tested:** Google API network round-trips (the fix is in provider request-shaping logic before any network call; the function output is deterministic given model + options).

- [x] AI-assisted (Hermes Agent)
