### PR TITLE
fix(memory): keep memory_get errors structured when wiki fallback fails

### DIFF
--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -630,6 +630,31 @@ describe("memory tools", () => {
     });
   });
 
+  it("returns the memory_get error when a corpus=all supplement fallback throws", async () => {
+    setMemoryReadFileImpl(async () => {
+      throw new Error("path required");
+    });
+    registerMemoryCorpusSupplement("memory-wiki", {
+      search: async () => [],
+      get: async () => {
+        throw new Error("wiki unavailable");
+      },
+    });
+
+    const tool = createMemoryGetToolOrThrow();
+    const result = await tool.execute("call_get_all_fallback_throws", {
+      path: "entities/alpha.md",
+      corpus: "all",
+    });
+
+    expect(result.details).toEqual({
+      path: "entities/alpha.md",
+      text: "",
+      disabled: true,
+      error: "path required",
+    });
+  });
+
   it("falls back to a wiki corpus supplement when memory_get corpus=all misses memory without throwing", async () => {
     setMemoryReadFileImpl(async (params: MemoryReadParams) => ({
       text: "",

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -348,13 +348,19 @@ async function resolveMemoryReadFailureResult(params: {
   agentSessionKey?: string;
 }) {
   if (params.requestedCorpus === "all") {
-    const supplement = await getSupplementMemoryReadResult({
-      relPath: params.relPath,
-      from: params.from,
-      lines: params.lines,
-      agentSessionKey: params.agentSessionKey,
-      corpus: params.requestedCorpus,
-    });
+    let supplement: Awaited<ReturnType<typeof getSupplementMemoryReadResult>> | null = null;
+    try {
+      supplement = await getSupplementMemoryReadResult({
+        relPath: params.relPath,
+        from: params.from,
+        lines: params.lines,
+        agentSessionKey: params.agentSessionKey,
+        corpus: params.requestedCorpus,
+      });
+    } catch {
+      // Supplement lookup is best-effort after the primary memory read failed.
+      // Preserve the original structured memory_get error instead of rejecting.
+    }
     if (supplement) {
       return jsonResult(supplement);
     }


### PR DESCRIPTION
Closes #101809

## What Problem This Solves

Fixes an issue where `memory_get` with `corpus=all` could reject instead of returning a structured disabled memory result when the primary memory read failed and the wiki supplement fallback also threw.

This PR is AI-assisted. I understand the change: it only makes the optional supplement lookup best-effort after the primary memory read has already failed, preserving the original structured `memory_get` error.

## Why This Change Was Made

The `corpus=all` supplement fallback is useful when the primary memory read misses or fails, but it should not be able to hide the original memory read failure by throwing from inside the failure resolver. The fix catches supplement lookup failures only in that resolver path, then falls back to the existing disabled result built from the original memory error.

## User Impact

Users and agents now get a predictable `memory_get` response with `disabled: true` and the original memory error instead of an unhandled tool rejection when a wiki supplement lookup fails during fallback.

## Evidence

Before the fix, the new focused regression failed with `wiki unavailable` escaping from `resolveMemoryReadFailureResult`.

After the fix:

- `/Users/harjothk/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/run-vitest.mjs extensions/memory-core/src/tools.citations.test.ts -- -t "returns the memory_get error when a corpus=all supplement fallback throws" --reporter=verbose` passed.
- `/Users/harjothk/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/run-vitest.mjs extensions/memory-core/src/tools.citations.test.ts extensions/memory-core/src/tools.test.ts -- --reporter=verbose` passed: 2 files, 45 tests.
- `git diff --check` passed.
- `/Users/harjothk/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 .agents/skills/autoreview/scripts/autoreview --mode local` passed clean with no accepted/actionable findings.
