### PR TITLE
Workspaces: add persistent notes widget

### DIFF
--- a/docs/web/workspaces.md
+++ b/docs/web/workspaces.md
@@ -83,6 +83,12 @@ An agent can author a real HTML widget with `workspace_widget_scaffold` (or you 
 Sending a prompt into chat from a widget additionally requires a manifest capability, a
 per-invocation confirmation quoting the exact text, and passes a rate limit.
 
+Widgets that declare the `state:persist` capability may keep up to 64 KB of JSON state.
+The iframe sends `workspace:getState` or `workspace:setState` over its document-bound
+bridge; the trusted parent supplies the rendered widget's ID, so child code cannot select
+another widget's record. A set may include the version returned by the last read as
+`expectedVersion`; stale writes fail instead of silently overwriting newer state.
+
 ## CLI
 
 ```sh
@@ -97,8 +103,8 @@ the Control UI does not, because the browser already holds it.
 
 ## Storage
 
-The workspace document, the custom-widget registry, and a 20-entry undo ring live in
-`<stateDir>/workspaces/workspaces.sqlite`. Agent-authored widget assets stay on disk under
+The workspace document, the custom-widget registry, widget state, and a 20-entry undo ring
+live in `<stateDir>/workspaces/workspaces.sqlite`. Agent-authored widget assets stay on disk under
 `<stateDir>/workspaces/widgets/<name>/`, and file-binding data under
 `<stateDir>/workspaces/data/`, because an agent authors those with ordinary file tools and
 the widget route serves their bytes.

--- a/extensions/workspaces/src/gateway.test.ts
+++ b/extensions/workspaces/src/gateway.test.ts
@@ -69,6 +69,8 @@ describe("workspace gateway methods", () => {
       "workspaces.widget.setLayout",
       "workspaces.widget.scaffold",
       "workspaces.widget.approve",
+      "workspaces.widget.state.get",
+      "workspaces.widget.state.set",
       "workspaces.replace",
       "workspaces.undo",
       "workspaces.data.read",
@@ -81,13 +83,78 @@ describe("workspace gateway methods", () => {
     expect(methods.get("workspaces.widget.approve")?.opts).toEqual({
       scope: "operator.approvals",
     });
-    const readOnly = new Set(["workspaces.get", "workspaces.widget.frame", "workspaces.data.read"]);
+    const readOnly = new Set([
+      "workspaces.get",
+      "workspaces.widget.frame",
+      "workspaces.widget.state.get",
+      "workspaces.data.read",
+    ]);
     for (const [name, method] of methods) {
       if (readOnly.has(name) || name === "workspaces.widget.approve") {
         continue;
       }
       expect(method.opts).toEqual({ scope: "operator.write" });
     }
+  });
+
+  it("persists only the trusted-parent widget id with optimistic concurrency", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const { api, methods } = createApi();
+      registerWorkspaceGatewayMethods({ api, store: new WorkspaceStore({ stateDir }) });
+      const broadcast = vi.fn();
+
+      const empty = await callMethod(
+        methods.get("workspaces.widget.state.get")!,
+        { widgetId: "cost-today" },
+        broadcast,
+      );
+      expect(empty.response?.[1]).toEqual({ state: null, version: 0 });
+
+      const first = await callMethod(
+        methods.get("workspaces.widget.state.set")!,
+        { widgetId: "cost-today", state: { text: "a" }, expectedVersion: 0 },
+        broadcast,
+      );
+      expect(first.response?.[0]).toBe(true);
+      expect(first.response?.[1]).toEqual({ widgetId: "cost-today", version: 1 });
+      expect(broadcast).toHaveBeenCalledWith("plugin.workspaces.widget-state.changed", {
+        widgetId: "cost-today",
+        version: 1,
+      });
+
+      const read = await callMethod(
+        methods.get("workspaces.widget.state.get")!,
+        { widgetId: "cost-today" },
+        broadcast,
+      );
+      expect(read.response?.[1]).toMatchObject({ state: { text: "a" }, version: 1 });
+
+      broadcast.mockClear();
+      const stale = await callMethod(
+        methods.get("workspaces.widget.state.set")!,
+        { widgetId: "cost-today", state: { text: "clobber" }, expectedVersion: 0 },
+        broadcast,
+      );
+      expect(stale.response?.[0]).toBe(false);
+      expect(stale.response?.[2]?.message).toContain("version conflict");
+      expect(broadcast).not.toHaveBeenCalled();
+
+      const malformed = await callMethod(
+        methods.get("workspaces.widget.state.set")!,
+        { widgetId: "cost-today", state: null, expectedVersion: -1 },
+        broadcast,
+      );
+      expect(malformed.response?.[0]).toBe(false);
+      expect(malformed.response?.[2]?.message).toContain("non-negative integer");
+
+      const smuggled = await callMethod(
+        methods.get("workspaces.widget.state.set")!,
+        { widgetId: "cost-today", state: {}, targetWidgetId: "other" },
+        broadcast,
+      );
+      expect(smuggled.response?.[0]).toBe(false);
+      expect(smuggled.response?.[2]?.message).toContain("unexpected param");
+    });
   });
 
   it("returns the workspace without broadcasting and broadcasts successful writes", async () => {

--- a/extensions/workspaces/src/gateway.ts
+++ b/extensions/workspaces/src/gateway.ts
@@ -765,6 +765,56 @@ export function registerWorkspaceGatewayMethods(options: WorkspaceGatewayMethodO
     { scope: APPROVE_SCOPE },
   );
 
+  // The browser parent calls these on behalf of a sandboxed custom widget. The
+  // parent supplies the widget id from its trusted render context; iframe input
+  // is never allowed to select another widget's state record.
+  api.registerGatewayMethod(
+    "workspaces.widget.state.get",
+    async ({ params: requestParams, respond }) => {
+      try {
+        const params = readParams(requestParams, ["widgetId"]);
+        const widgetId = readWidgetId(params, "widgetId");
+        const record = store.readWidgetState(widgetId);
+        respond(true, record ?? { state: null, version: 0 });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: READ_SCOPE },
+  );
+
+  api.registerGatewayMethod(
+    "workspaces.widget.state.set",
+    async (opts) => {
+      try {
+        const params = readParams(opts.params, ["widgetId", "state", "expectedVersion"]);
+        const widgetId = readWidgetId(params, "widgetId");
+        if (!Object.hasOwn(params, "state")) {
+          throw new Error("state is required");
+        }
+        let expectedVersion: number | undefined;
+        if (params.expectedVersion !== undefined) {
+          if (
+            typeof params.expectedVersion !== "number" ||
+            !Number.isInteger(params.expectedVersion) ||
+            params.expectedVersion < 0
+          ) {
+            throw new Error("expectedVersion must be a non-negative integer");
+          }
+          expectedVersion = params.expectedVersion;
+        }
+        const { version } = store.writeWidgetState(widgetId, params.state as JsonValue, {
+          expectedVersion,
+        });
+        opts.context.broadcast("plugin.workspaces.widget-state.changed", { widgetId, version });
+        opts.respond(true, { widgetId, version });
+      } catch (error) {
+        respondError(opts.respond, error);
+      }
+    },
+    { scope: WRITE_SCOPE },
+  );
+
   api.registerGatewayMethod(
     "workspaces.replace",
     async (opts) => {

--- a/extensions/workspaces/src/manifest.test.ts
+++ b/extensions/workspaces/src/manifest.test.ts
@@ -36,6 +36,21 @@ const VALID_MANIFEST = {
 };
 
 describe("validateWidgetManifest", () => {
+  it("accepts the state:persist capability", () => {
+    expect(
+      validateWidgetManifest(
+        {
+          schemaVersion: 1,
+          name: "chart",
+          title: "Chart",
+          entrypoint: "index.html",
+          bindings: [],
+          capabilities: ["state:persist"],
+        },
+        "chart",
+      ).capabilities,
+    ).toEqual(["state:persist"]);
+  });
   it("accepts a well-formed manifest", () => {
     expect(validateWidgetManifest(VALID_MANIFEST)).toEqual(VALID_MANIFEST);
   });

--- a/extensions/workspaces/src/manifest.ts
+++ b/extensions/workspaces/src/manifest.ts
@@ -200,7 +200,7 @@ export function matchesApprovedFile(
   return expected !== undefined && expected === hashBytes(bytes);
 }
 const BINDING_ID_PATTERN = /^(?!__proto__$)[A-Za-z0-9._-]{1,64}$/;
-const WIDGET_CAPABILITIES = ["data:read", "prompt:send"] as const;
+const WIDGET_CAPABILITIES = ["data:read", "prompt:send", "state:persist"] as const;
 
 type WidgetCapability = (typeof WIDGET_CAPABILITIES)[number];
 

--- a/extensions/workspaces/src/schema.test.ts
+++ b/extensions/workspaces/src/schema.test.ts
@@ -42,6 +42,13 @@ describe("Workspaces document schema", () => {
     }, "widgets[0].kind");
   });
 
+  it("accepts the trusted notes builtin", () => {
+    const doc = validDoc();
+    doc.tabs[0]!.widgets[0]!.kind = "builtin:notes";
+
+    expect(validateWorkspaceDoc(doc).tabs[0]?.widgets[0]?.kind).toBe("builtin:notes");
+  });
+
   it("rejects a prototype-setter custom widget kind", () => {
     expectInvalid((doc) => {
       doc.tabs[0]!.widgets[0]!.kind = "custom:__proto__";

--- a/extensions/workspaces/src/schema.ts
+++ b/extensions/workspaces/src/schema.ts
@@ -70,6 +70,7 @@ export const BUILTIN_WIDGET_KINDS = [
   "builtin:cron",
   "builtin:instances",
   "builtin:activity",
+  "builtin:notes",
 ] as const;
 
 const BUILTIN_KINDS = new Set<string>(BUILTIN_WIDGET_KINDS);

--- a/extensions/workspaces/src/store.test.ts
+++ b/extensions/workspaces/src/store.test.ts
@@ -27,6 +27,111 @@ function docWithPendingWidget(store: WorkspaceStore): WorkspaceDoc {
 }
 
 describe("WorkspaceStore", () => {
+  it("persists size-capped widget state in SQLite with monotonic versions", async () => {
+    await withStore((store) => {
+      expect(store.readWidgetState("cost-today")).toBeNull();
+
+      expect(store.writeWidgetState("cost-today", { text: "hello" })).toMatchObject({ version: 1 });
+      expect(store.readWidgetState("cost-today")).toMatchObject({
+        state: { text: "hello" },
+        version: 1,
+        updatedAt: expect.any(String),
+      });
+
+      expect(
+        store.writeWidgetState("cost-today", { text: "updated" }, { expectedVersion: 1 }),
+      ).toMatchObject({ version: 2 });
+      expect(store.readWidgetState("cost-today")).toMatchObject({
+        state: { text: "updated" },
+        version: 2,
+      });
+    });
+  });
+
+  it("keeps widget state after the store is reopened", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-reopen-"));
+    try {
+      const first = new WorkspaceStore({ stateDir });
+      first.writeWidgetState("cost-today", { text: "durable" });
+      first.close();
+
+      const reopened = new WorkspaceStore({ stateDir });
+      try {
+        expect(reopened.readWidgetState("cost-today")).toMatchObject({
+          state: { text: "durable" },
+          version: 1,
+        });
+      } finally {
+        reopened.close();
+      }
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects stale, invalid, and oversized widget state without changing prior state", async () => {
+    await withStore((store) => {
+      store.writeWidgetState("cost-today", { text: "safe" }, { expectedVersion: 0 });
+
+      expect(() =>
+        store.writeWidgetState("cost-today", { text: "stale" }, { expectedVersion: 0 }),
+      ).toThrow("widget state version conflict: expected 0, found 1");
+      expect(() => store.writeWidgetState("../escape", { nope: true })).toThrow(
+        "widget id is invalid",
+      );
+      expect(() => store.writeWidgetState("cost-today", { text: "x".repeat(70 * 1024) })).toThrow(
+        "widget state exceeds 64 KB",
+      );
+      expect(() => store.writeWidgetState("cost-today", { bad: undefined } as never)).toThrow(
+        "widget state must be valid JSON",
+      );
+
+      expect(store.readWidgetState("cost-today")).toMatchObject({
+        state: { text: "safe" },
+        version: 1,
+      });
+    });
+  });
+
+  it("deletes state when a widget is removed or replaced with a different kind", async () => {
+    await withStore((store) => {
+      store.writeWidgetState("cost-today", { text: "private" });
+      store.mutate(
+        (draft) => {
+          draft.tabs[0]!.widgets = draft.tabs[0]!.widgets.filter(
+            (widget) => widget.id !== "cost-today",
+          );
+        },
+        { actor: "user" },
+      );
+      expect(store.readWidgetState("cost-today")).toBeNull();
+      expect(() => store.writeWidgetState("cost-today", { text: "orphan" })).toThrow(
+        "workspace widget not found",
+      );
+
+      store.mutate(
+        (draft) => {
+          draft.tabs[0]!.widgets.push({
+            id: "cost-today",
+            kind: "builtin:markdown",
+            title: "Replacement",
+            grid: { x: 0, y: 0, w: 4, h: 2 },
+            collapsed: false,
+            hidden: false,
+            createdBy: "user",
+          });
+        },
+        { actor: "user" },
+      );
+      expect(store.readWidgetState("cost-today")).toBeNull();
+      expect(
+        store.writeWidgetState("cost-today", { text: "fresh" }, { expectedVersion: 0 }),
+      ).toEqual({
+        version: 1,
+      });
+    });
+  });
+
   it("seeds the default workspace on first read", async () => {
     await withStore((store) => {
       const doc = store.read();

--- a/extensions/workspaces/src/store.ts
+++ b/extensions/workspaces/src/store.ts
@@ -28,6 +28,7 @@ import { WidgetAssetTokens } from "./asset-tokens.js";
 import { DEFAULT_WORKSPACE } from "./default-workspace.js";
 import {
   validateWorkspaceDoc,
+  type JsonValue,
   type WorkspaceActor,
   type WorkspaceWidgetRegistryEntry,
   type WorkspaceDoc,
@@ -35,12 +36,21 @@ import {
 
 type WorkspaceMutationOptions = { actor: WorkspaceActor };
 type WorkspaceMutationResult = { doc: WorkspaceDoc; changed: boolean };
+type WidgetStateRecord = {
+  state: JsonValue;
+  version: number;
+  updatedAt: string;
+};
+type WidgetStateWriteOptions = { expectedVersion?: number };
+type WidgetStateWriteResult = { version: number };
 
 const MAX_WORKSPACE_BYTES = 256 * 1024;
+const MAX_WIDGET_STATE_BYTES = 64 * 1024;
 const UNDO_RING_SIZE = 20;
 const DIR_MODE = 0o700;
 const FILE_MODE = 0o600;
 const BUSY_TIMEOUT_MS = 5000;
+const WIDGET_ID_PATTERN = /^[A-Za-z0-9_-]{1,48}$/;
 
 const SCHEMA = `
 CREATE TABLE IF NOT EXISTS workspace (
@@ -54,6 +64,13 @@ CREATE TABLE IF NOT EXISTS undo (
   doc TEXT NOT NULL,
   created_ms INTEGER NOT NULL
 );
+CREATE TABLE IF NOT EXISTS widget_state (
+  widget_id TEXT PRIMARY KEY,
+  widget_kind TEXT NOT NULL,
+  version INTEGER NOT NULL CHECK (version >= 1),
+  state TEXT NOT NULL,
+  updated_ms INTEGER NOT NULL
+);
 `;
 
 function serializeWorkspaceDoc(doc: WorkspaceDoc): string {
@@ -64,6 +81,66 @@ function assertWorkspaceSize(serialized: string): void {
   if (Buffer.byteLength(serialized, "utf8") > MAX_WORKSPACE_BYTES) {
     throw new Error("workspace document exceeds 256 KB");
   }
+}
+
+function assertWidgetId(widgetId: string): void {
+  if (!WIDGET_ID_PATTERN.test(widgetId)) {
+    throw new Error("widget id is invalid");
+  }
+}
+
+function assertJsonValue(value: unknown, seen = new Set<object>()): asserts value is JsonValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean" ||
+    (typeof value === "number" && Number.isFinite(value))
+  ) {
+    return;
+  }
+  if (typeof value !== "object") {
+    throw new Error("widget state must be valid JSON");
+  }
+  if (seen.has(value)) {
+    throw new Error("widget state must be valid JSON");
+  }
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        assertJsonValue(entry, seen);
+      }
+      return;
+    }
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new Error("widget state must be valid JSON");
+    }
+    for (const entry of Object.values(value as Record<string, unknown>)) {
+      assertJsonValue(entry, seen);
+    }
+  } finally {
+    seen.delete(value);
+  }
+}
+
+function serializeWidgetState(value: unknown): string {
+  assertJsonValue(value);
+  const serialized = JSON.stringify(value);
+  if (Buffer.byteLength(serialized, "utf8") > MAX_WIDGET_STATE_BYTES) {
+    throw new Error("widget state exceeds 64 KB");
+  }
+  return serialized;
+}
+
+function widgetKind(doc: WorkspaceDoc, widgetId: string): string | null {
+  for (const tab of doc.tabs) {
+    const widget = tab.widgets.find((entry) => entry.id === widgetId);
+    if (widget) {
+      return widget.kind;
+    }
+  }
+  return null;
 }
 
 /**
@@ -169,6 +246,78 @@ export class WorkspaceStore {
     return this.widgetEntry(name)?.status ?? null;
   }
 
+  /** Reads one widget's opaque state blob without mixing it into the workspace document. */
+  readWidgetState(widgetId: string): WidgetStateRecord | null {
+    assertWidgetId(widgetId);
+    const row = this.db
+      .prepare("SELECT version, state, updated_ms FROM widget_state WHERE widget_id = ?")
+      .get(widgetId) as { version: number; state: string; updated_ms: number } | undefined;
+    if (!row) {
+      return null;
+    }
+    const state: unknown = JSON.parse(row.state);
+    assertJsonValue(state);
+    return {
+      state,
+      version: row.version,
+      updatedAt: new Date(row.updated_ms).toISOString(),
+    };
+  }
+
+  /**
+   * Atomically writes one widget's state. `expectedVersion: 0` means the widget
+   * has never written state; omitting it preserves last-write-wins behavior.
+   */
+  writeWidgetState(
+    widgetId: string,
+    state: JsonValue,
+    options: WidgetStateWriteOptions = {},
+  ): WidgetStateWriteResult {
+    assertWidgetId(widgetId);
+    if (
+      options.expectedVersion !== undefined &&
+      (!Number.isInteger(options.expectedVersion) || options.expectedVersion < 0)
+    ) {
+      throw new Error("expectedVersion must be a non-negative integer");
+    }
+    const serialized = serializeWidgetState(state);
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      // Bind persistence to the current widget identity inside the same write
+      // transaction. Arbitrary IDs cannot create orphan rows, and a removed or
+      // replaced widget cannot inherit another widget's opaque state.
+      this.cached = null;
+      const kind = widgetKind(this.read(), widgetId);
+      if (kind === null) {
+        throw new Error(`workspace widget not found: ${widgetId}`);
+      }
+      const previous = this.db
+        .prepare("SELECT version, widget_kind FROM widget_state WHERE widget_id = ?")
+        .get(widgetId) as { version: number; widget_kind: string } | undefined;
+      if (previous && previous.widget_kind !== kind) {
+        this.db.prepare("DELETE FROM widget_state WHERE widget_id = ?").run(widgetId);
+      }
+      const currentVersion = previous?.widget_kind === kind ? previous.version : 0;
+      if (options.expectedVersion !== undefined && options.expectedVersion !== currentVersion) {
+        throw new Error(
+          `widget state version conflict: expected ${options.expectedVersion}, found ${currentVersion}`,
+        );
+      }
+      const version = currentVersion + 1;
+      this.db
+        .prepare(
+          "INSERT INTO widget_state (widget_id, widget_kind, version, state, updated_ms) VALUES (?, ?, ?, ?, ?) " +
+            "ON CONFLICT(widget_id) DO UPDATE SET widget_kind = excluded.widget_kind, version = excluded.version, state = excluded.state, updated_ms = excluded.updated_ms",
+        )
+        .run(widgetId, kind, version, serialized, Date.now());
+      this.db.exec("COMMIT");
+      return { version };
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
   /**
    * Applies `fn` to a draft of the current document and persists the result.
    * `fn` must be synchronous: it runs inside the write transaction, which is what
@@ -244,6 +393,21 @@ export class WorkspaceStore {
         ...derive(current),
         workspaceVersion: current.workspaceVersion + 1,
       });
+      const nextKinds = new Map(
+        next.tabs.flatMap((tab) => tab.widgets.map((widget) => [widget.id, widget.kind] as const)),
+      );
+      const stateRows = this.db
+        .prepare("SELECT widget_id, widget_kind FROM widget_state")
+        .all() as Array<{
+        widget_id: string;
+        widget_kind: string;
+      }>;
+      const deleteState = this.db.prepare("DELETE FROM widget_state WHERE widget_id = ?");
+      for (const row of stateRows) {
+        if (nextKinds.get(row.widget_id) !== row.widget_kind) {
+          deleteState.run(row.widget_id);
+        }
+      }
       this.commit(next, { snapshot: options.snapshot === false ? null : current });
       this.db.exec("COMMIT");
       return { doc: next, changed: true };

--- a/extensions/workspaces/src/tools.ts
+++ b/extensions/workspaces/src/tools.ts
@@ -59,7 +59,7 @@ const WIDGET_KIND_DESCRIPTION = [
   "builtin:markdown (props {markdown} or {text}, or a file binding of a .md file),",
   "builtin:table (binding id `rows`; props {columns: string[]}),",
   "builtin:iframe-embed (props {url}),",
-  "builtin:sessions, builtin:usage, builtin:cron, builtin:instances, builtin:activity",
+  "builtin:sessions, builtin:usage, builtin:cron, builtin:instances, builtin:activity, builtin:notes",
   "(each reads its own rpc binding; see workspace_get for a worked example).",
   "Charts are not builtins — author one with workspace_widget_scaffold and use custom:<name>.",
 ].join(" ");

--- a/ui/src/components/workspace-custom-widget.test.ts
+++ b/ui/src/components/workspace-custom-widget.test.ts
@@ -70,7 +70,7 @@ describe("loadWidgetManifestView", () => {
       manifest: {
         entrypoint: "index.html",
         bindings: [{ id: "value", source: "static", value: 1 }],
-        capabilities: ["data:read", "prompt:send"],
+        capabilities: ["data:read", "prompt:send", "state:persist"],
       },
     }));
     const view = await loadWidgetManifestView({ request } as never, "revenue-chart");
@@ -80,7 +80,7 @@ describe("loadWidgetManifestView", () => {
       frameExpiresAt: FRAME_EXPIRES_AT,
       entrypoint: "index.html",
       bindings: { value: { source: "static", value: 1 } },
-      capabilities: ["data:read", "prompt:send"],
+      capabilities: ["data:read", "prompt:send", "state:persist"],
     });
   });
 
@@ -168,6 +168,48 @@ function connectWidgetBridge(params: {
 }
 
 describe("attachWidgetBridge document-bound channel", () => {
+  it("binds state RPCs to the host widget id, never a child-provided id", async () => {
+    const iframe = document.createElement("iframe");
+    document.body.appendChild(iframe);
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ state: { text: "old" }, version: 2 })
+      .mockResolvedValueOnce({ widgetId: "w_custom", version: 3 });
+    const { childPort, detach, posts } = connectWidgetBridge({
+      iframe,
+      manifest: manifest({ capabilities: ["state:persist"] }),
+      context: host({ client: { request } as never }),
+    });
+
+    childPort.postMessage(
+      { v: 1, type: "workspace:getState", requestId: "g1", widgetId: "other" },
+      [],
+    );
+    await vi.waitFor(() => expect(posts).toHaveLength(1));
+    childPort.postMessage(
+      {
+        v: 1,
+        type: "workspace:setState",
+        requestId: "s1",
+        widgetId: "other",
+        state: { text: "new" },
+        expectedVersion: 2,
+      },
+      [],
+    );
+    await vi.waitFor(() => expect(posts).toHaveLength(2));
+
+    expect(request).toHaveBeenNthCalledWith(1, "workspaces.widget.state.get", {
+      widgetId: "w_custom",
+    });
+    expect(request).toHaveBeenNthCalledWith(2, "workspaces.widget.state.set", {
+      widgetId: "w_custom",
+      state: { text: "new" },
+      expectedVersion: 2,
+    });
+    detach();
+  });
+
   it("drops a foreign bootstrap and accepts the iframe's token-bound port", async () => {
     const iframe = document.createElement("iframe");
     const foreign = document.createElement("iframe");

--- a/ui/src/components/workspace-custom-widget.ts
+++ b/ui/src/components/workspace-custom-widget.ts
@@ -160,7 +160,8 @@ export async function loadWidgetManifestView(
       bindings[parsedBinding.id] = parsedBinding.binding;
     }
     const capabilities = (Array.isArray(record.capabilities) ? record.capabilities : []).filter(
-      (cap): cap is WorkspaceWidgetCapability => cap === "data:read" || cap === "prompt:send",
+      (cap): cap is WorkspaceWidgetCapability =>
+        cap === "data:read" || cap === "prompt:send" || cap === "state:persist",
     );
     // The approval gate hashes the manifest's declared entrypoint. Loading a
     // different file would mount code the operator never approved.
@@ -236,6 +237,39 @@ export function attachWidgetBridge(params: {
           deliver: false,
           idempotencyKey: generateUUID(),
         });
+      },
+      getWidgetState: async () => {
+        if (!context.client) {
+          throw new Error("Not connected.");
+        }
+        const payload = (await context.client.request("workspaces.widget.state.get", {
+          widgetId: widget.id,
+        })) as { state?: unknown; version?: unknown } | null;
+        const version = payload?.version;
+        return {
+          state: payload?.state ?? null,
+          ...(typeof version === "number" && Number.isInteger(version) && version >= 0
+            ? { version }
+            : {}),
+        };
+      },
+      setWidgetState: async (state, expectedVersion) => {
+        if (!context.client) {
+          throw new Error("Not connected.");
+        }
+        const payload = (await context.client.request("workspaces.widget.state.set", {
+          widgetId: widget.id,
+          state,
+          ...(expectedVersion !== undefined ? { expectedVersion } : {}),
+        })) as { version?: unknown } | null;
+        if (
+          typeof payload?.version !== "number" ||
+          !Number.isInteger(payload.version) ||
+          payload.version < 1
+        ) {
+          throw new Error("Invalid widget state response.");
+        }
+        return { version: payload.version };
       },
     });
 

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2190,6 +2190,12 @@ export const en: TranslationMap = {
       activity: {
         empty: "No recent activity.",
       },
+      notes: {
+        placeholder: "Write a note…",
+        readonlyHint: "Connect to the gateway to edit and save notes.",
+        saveError: "Your note couldn’t be saved. Keep editing and try again.",
+        conflict: "This note changed somewhere else. Copy your edits before reloading.",
+      },
       embed: {
         missing: "This embed has no URL yet.",
         blockedExternal: "External embeds are disabled by your gateway policy.",

--- a/ui/src/lib/workspace/bridge.test.ts
+++ b/ui/src/lib/workspace/bridge.test.ts
@@ -148,6 +148,87 @@ describe("getTheme", () => {
   });
 });
 
+describe("widget state capability", () => {
+  it("denies state access before invoking host dependencies when capability is absent", async () => {
+    const getWidgetState = vi.fn(async () => ({ state: { secret: true }, version: 1 }));
+    const setWidgetState = vi.fn(async () => ({ version: 2 }));
+    const { bridge, posted } = makeBridge({ getWidgetState, setWidgetState });
+
+    bridge.handleMessage({ v: 1, type: "workspace:getState", requestId: "g1" });
+    bridge.handleMessage({
+      v: 1,
+      type: "workspace:setState",
+      requestId: "s1",
+      state: { text: "nope" },
+    });
+
+    await vi.waitFor(() => expect(posted).toHaveLength(2));
+    expect(posted).toEqual([
+      expect.objectContaining({
+        type: "workspace:error",
+        code: "capability_denied",
+        requestId: "g1",
+      }),
+      expect.objectContaining({
+        type: "workspace:error",
+        code: "capability_denied",
+        requestId: "s1",
+      }),
+    ]);
+    expect(getWidgetState).not.toHaveBeenCalled();
+    expect(setWidgetState).not.toHaveBeenCalled();
+  });
+
+  it("gets and sets state while forwarding an optional expectedVersion", async () => {
+    const getWidgetState = vi.fn(async () => ({ state: { text: "old" }, version: 3 }));
+    const setWidgetState = vi.fn(async (_state: unknown, _expectedVersion?: number) => ({
+      version: 4,
+    }));
+    const { bridge, posted } = makeBridge({
+      manifest: manifest({ capabilities: ["state:persist"] }),
+      getWidgetState,
+      setWidgetState,
+    });
+
+    bridge.handleMessage({ v: 1, type: "workspace:getState", requestId: "g1" });
+    bridge.handleMessage({
+      v: 1,
+      type: "workspace:setState",
+      requestId: "s1",
+      state: { text: "new" },
+      expectedVersion: 3,
+      widgetId: "ignored-child-id",
+    });
+
+    await vi.waitFor(() => expect(posted).toHaveLength(2));
+    expect(getWidgetState).toHaveBeenCalledOnce();
+    expect(setWidgetState).toHaveBeenCalledWith({ text: "new" }, 3);
+    expect(posted).toEqual([
+      { v: 1, type: "workspace:state", requestId: "g1", state: { text: "old" }, version: 3 },
+      { v: 1, type: "workspace:state", requestId: "s1", state: { text: "new" }, version: 4 },
+    ]);
+  });
+
+  it("drops malformed expectedVersion without invoking the state writer", () => {
+    const setWidgetState = vi.fn(async () => ({ version: 1 }));
+    const { bridge } = makeBridge({
+      manifest: manifest({ capabilities: ["state:persist"] }),
+      setWidgetState,
+    });
+
+    expect(
+      bridge.handleMessage({
+        v: 1,
+        type: "workspace:setState",
+        requestId: "s1",
+        state: {},
+        expectedVersion: -1,
+      }),
+    ).toBe(false);
+    expect(setWidgetState).not.toHaveBeenCalled();
+  });
+});
+
 describe("sendPrompt capability + confirm + rate limit", () => {
   it("denies without a dialog when the capability is absent", async () => {
     const confirmPrompt = vi.fn(async () => true);

--- a/ui/src/lib/workspace/bridge.ts
+++ b/ui/src/lib/workspace/bridge.ts
@@ -26,7 +26,9 @@ export type WidgetInboundType =
   | "workspace:ready"
   | "workspace:getData"
   | "workspace:getTheme"
-  | "workspace:sendPrompt";
+  | "workspace:sendPrompt"
+  | "workspace:getState"
+  | "workspace:setState";
 
 export type WidgetErrorCode =
   | "binding_denied"
@@ -41,6 +43,7 @@ export type WidgetOutboundMessage =
   | { v: 1; type: "workspace:data"; requestId: string; bindingId: string; data: unknown }
   | { v: 1; type: "workspace:push"; bindingId: string; data: unknown }
   | { v: 1; type: "workspace:theme"; requestId: string; tokens: Record<string, string> }
+  | { v: 1; type: "workspace:state"; requestId: string; state: unknown; version?: number }
   | { v: 1; type: "workspace:error"; requestId?: string; code: WidgetErrorCode; message: string };
 
 /** Injected side effects — real implementations live in the browser host. */
@@ -60,6 +63,10 @@ export type WidgetBridgeDeps = {
   confirmPrompt: (text: string) => Promise<boolean>;
   /** Dispatch the prompt through the existing chat-send path. */
   sendPrompt: (text: string) => Promise<void>;
+  /** Read state for the parent-bound widget identity. */
+  getWidgetState?: () => Promise<{ state: unknown; version?: number }>;
+  /** Write state for the parent-bound widget identity. */
+  setWidgetState?: (state: unknown, expectedVersion?: number) => Promise<{ version: number }>;
   /** Post a message to the child (host wires targetOrigin "*"). */
   post: (message: WidgetOutboundMessage) => void;
   /** getData answer deadline; posts a timeout error if the resolver overruns. Default 10s. */
@@ -113,6 +120,8 @@ const INBOUND_TYPES = new Set<WidgetInboundType>([
   "workspace:getData",
   "workspace:getTheme",
   "workspace:sendPrompt",
+  "workspace:getState",
+  "workspace:setState",
 ]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -245,6 +254,50 @@ export function createWidgetBridge(deps: WidgetBridgeDeps): WidgetBridge {
     }
   }
 
+  async function handleGetState(requestId: string): Promise<void> {
+    if (!capabilities.has("state:persist") || !deps.getWidgetState) {
+      error("capability_denied", "widget lacks the state:persist capability", requestId);
+      return;
+    }
+    try {
+      const result = await deps.getWidgetState();
+      if (!disposed) {
+        deps.post({
+          v: 1,
+          type: "workspace:state",
+          requestId,
+          state: result.state,
+          ...(result.version !== undefined ? { version: result.version } : {}),
+        });
+      }
+    } catch (err) {
+      if (!disposed) {
+        error("resolve_failed", err instanceof Error ? err.message : String(err), requestId);
+      }
+    }
+  }
+
+  async function handleSetState(
+    requestId: string,
+    state: unknown,
+    expectedVersion?: number,
+  ): Promise<void> {
+    if (!capabilities.has("state:persist") || !deps.setWidgetState) {
+      error("capability_denied", "widget lacks the state:persist capability", requestId);
+      return;
+    }
+    try {
+      const { version } = await deps.setWidgetState(state, expectedVersion);
+      if (!disposed) {
+        deps.post({ v: 1, type: "workspace:state", requestId, state, version });
+      }
+    } catch (err) {
+      if (!disposed) {
+        error("resolve_failed", err instanceof Error ? err.message : String(err), requestId);
+      }
+    }
+  }
+
   function handleMessage(data: unknown): boolean {
     if (disposed) {
       return false;
@@ -283,6 +336,38 @@ export function createWidgetBridge(deps: WidgetBridgeDeps): WidgetBridge {
           return false;
         }
         void handleSendPrompt(requestId, text);
+        return true;
+      }
+      case "workspace:getState": {
+        const requestId = typeof data.requestId === "string" ? data.requestId : null;
+        if (requestId === null) {
+          dropped += 1;
+          return false;
+        }
+        void handleGetState(requestId);
+        return true;
+      }
+      case "workspace:setState": {
+        const requestId = typeof data.requestId === "string" ? data.requestId : null;
+        const hasState = Object.hasOwn(data, "state");
+        const hasExpectedVersion = Object.hasOwn(data, "expectedVersion");
+        const expectedVersion = data.expectedVersion;
+        if (
+          requestId === null ||
+          !hasState ||
+          (hasExpectedVersion &&
+            (typeof expectedVersion !== "number" ||
+              !Number.isInteger(expectedVersion) ||
+              expectedVersion < 0))
+        ) {
+          dropped += 1;
+          return false;
+        }
+        void handleSetState(
+          requestId,
+          data.state,
+          hasExpectedVersion ? (expectedVersion as number) : undefined,
+        );
         return true;
       }
       default:

--- a/ui/src/lib/workspace/types.ts
+++ b/ui/src/lib/workspace/types.ts
@@ -80,7 +80,7 @@ export type WorkspaceDocument = {
 };
 
 /** Capability names a custom widget may hold (00 §2). */
-export type WorkspaceWidgetCapability = "data:read" | "prompt:send";
+export type WorkspaceWidgetCapability = "data:read" | "prompt:send" | "state:persist";
 
 /**
  * The subset of a custom widget's `widget.json` manifest the parent bridge needs

--- a/ui/src/lib/workspace/widgets/context.ts
+++ b/ui/src/lib/workspace/widgets/context.ts
@@ -1,0 +1,85 @@
+import type { GatewayBrowserClient } from "../../../api/gateway.ts";
+import type { WorkspaceWidget } from "../types.ts";
+import type { BuiltinWidgetContext } from "./types.ts";
+
+type BuiltinContextProps = {
+  client: GatewayBrowserClient | null;
+  connected: boolean;
+  basePath?: string;
+  embed?: BuiltinWidgetContext["embed"];
+};
+
+const DEFAULT_EMBED_CONTEXT: BuiltinWidgetContext["embed"] = {
+  embedSandboxMode: "strict",
+  allowExternalEmbedUrls: false,
+};
+
+const builtinStateByClient = new WeakMap<
+  GatewayBrowserClient,
+  Map<string, NonNullable<BuiltinWidgetContext["state"]>>
+>();
+
+function getBuiltinState(
+  client: GatewayBrowserClient,
+  widgetId: string,
+): NonNullable<BuiltinWidgetContext["state"]> {
+  let states = builtinStateByClient.get(client);
+  if (!states) {
+    states = new Map();
+    builtinStateByClient.set(client, states);
+  }
+  const existing = states.get(widgetId);
+  if (existing) {
+    return existing;
+  }
+  const state: NonNullable<BuiltinWidgetContext["state"]> = {
+    get: async () => {
+      const payload = (await client.request("workspaces.widget.state.get", {
+        widgetId,
+      })) as { state?: unknown; version?: unknown } | null;
+      if (
+        typeof payload?.version !== "number" ||
+        !Number.isInteger(payload.version) ||
+        payload.version < 0
+      ) {
+        throw new Error("Invalid widget state response.");
+      }
+      return { state: payload.state ?? null, version: payload.version };
+    },
+    set: async (value, expectedVersion) => {
+      const payload = (await client.request("workspaces.widget.state.set", {
+        widgetId,
+        state: value,
+        expectedVersion,
+      })) as { version?: unknown } | null;
+      if (
+        typeof payload?.version !== "number" ||
+        !Number.isInteger(payload.version) ||
+        payload.version < 1
+      ) {
+        throw new Error("Invalid widget state response.");
+      }
+      return { version: payload.version };
+    },
+  };
+  states.set(widgetId, state);
+  return state;
+}
+
+/** Bind trusted builtin persistence to the host-owned widget id. */
+export function buildBuiltinContext(
+  props: BuiltinContextProps,
+  widget: WorkspaceWidget,
+): BuiltinWidgetContext {
+  const context: BuiltinWidgetContext = {
+    basePath: props.basePath ?? "",
+    embed: props.embed ?? DEFAULT_EMBED_CONTEXT,
+  };
+  if (!props.client || !props.connected) {
+    return context;
+  }
+  return {
+    ...context,
+    state: getBuiltinState(props.client, widget.id),
+  };
+}

--- a/ui/src/lib/workspace/widgets/index.ts
+++ b/ui/src/lib/workspace/widgets/index.ts
@@ -9,6 +9,7 @@ import { renderCron } from "./cron.ts";
 import { renderIframeEmbed } from "./iframe-embed.ts";
 import { renderInstances } from "./instances.ts";
 import { renderMarkdown } from "./markdown.ts";
+import { renderNotes } from "./notes.ts";
 import { renderSessions } from "./sessions.ts";
 import { renderStatCard } from "./stat-card.ts";
 import { renderTable } from "./table.ts";
@@ -25,6 +26,7 @@ export const BUILTIN_WIDGET_RENDERERS: Record<string, BuiltinWidgetRenderer> = {
   cron: (widget, value) => renderCron(widget, value),
   instances: (widget, value) => renderInstances(widget, value),
   activity: (widget, value) => renderActivity(widget, value),
+  notes: renderNotes,
 };
 
 export function getBuiltinRenderer(kind: string): BuiltinWidgetRenderer | undefined {

--- a/ui/src/lib/workspace/widgets/notes.ts
+++ b/ui/src/lib/workspace/widgets/notes.ts
@@ -1,0 +1,203 @@
+import { html, type TemplateResult } from "lit";
+import { ref } from "lit/directives/ref.js";
+import { t } from "../../../i18n/index.ts";
+import type { WorkspaceWidget } from "../types.ts";
+import type { BuiltinWidgetContext, BuiltinWidgetState } from "./types.ts";
+import { widgetProps } from "./types.ts";
+
+const NOTES_PERSIST_DEBOUNCE_MS = 500;
+
+function seedText(widget: WorkspaceWidget): string {
+  const text = widgetProps(widget).text;
+  return typeof text === "string" ? text : "";
+}
+
+function isConflict(error: unknown): boolean {
+  return error instanceof Error && /version conflict/i.test(error.message);
+}
+
+const editorBindings = new WeakMap<BuiltinWidgetState, (element: Element | undefined) => void>();
+
+function bindEditor(state: BuiltinWidgetState): (element: Element | undefined) => void {
+  const existing = editorBindings.get(state);
+  if (existing) {
+    return existing;
+  }
+  let textarea: HTMLTextAreaElement | null = null;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let dirty = false;
+  let disconnected = false;
+  let disconnectRevision = 0;
+  let saving = false;
+  let queued = false;
+  let latest = "";
+  let version: number | undefined;
+  let hydrationPending = true;
+  let hydrationStarted = false;
+
+  const showStatus = (key: "saveError" | "conflict" | null): void => {
+    const status = textarea?.parentElement?.querySelector<HTMLElement>(
+      "[data-test-id='workspace-notes-status']",
+    );
+    if (!status) {
+      return;
+    }
+    status.dataset.state = key ? "error" : "idle";
+    status.textContent =
+      key === "conflict"
+        ? t("workspaces.widget.notes.conflict")
+        : key === "saveError"
+          ? t("workspaces.widget.notes.saveError")
+          : "";
+  };
+
+  const persist = async (): Promise<void> => {
+    timer = undefined;
+    if (disconnected) {
+      return;
+    }
+    if (saving) {
+      queued = true;
+      return;
+    }
+    if (version === undefined) {
+      if (hydrationPending) {
+        queued = true;
+        return;
+      }
+      showStatus("saveError");
+      return;
+    }
+    saving = true;
+    queued = false;
+    const value = latest;
+    try {
+      const result = await state.set(value, version);
+      version = result.version;
+      if (latest === value) {
+        dirty = false;
+      }
+      showStatus(null);
+    } catch (error) {
+      showStatus(isConflict(error) ? "conflict" : "saveError");
+    } finally {
+      saving = false;
+      if (!disconnected && queued && latest !== value) {
+        void persist();
+      }
+    }
+  };
+
+  const onInput = (): void => {
+    if (!textarea) {
+      return;
+    }
+    dirty = true;
+    latest = textarea.value;
+    showStatus(null);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+    timer = setTimeout(() => void persist(), NOTES_PERSIST_DEBOUNCE_MS);
+  };
+
+  const binding = (element: Element | undefined): void => {
+    if (!(element instanceof HTMLTextAreaElement)) {
+      disconnected = true;
+      const revision = ++disconnectRevision;
+      queueMicrotask(() => {
+        if (!disconnected || revision !== disconnectRevision) {
+          return;
+        }
+        if (timer !== undefined) {
+          clearTimeout(timer);
+          timer = undefined;
+        }
+        queued ||= dirty;
+        textarea?.removeEventListener("input", onInput);
+        textarea = null;
+      });
+      return;
+    }
+    disconnected = false;
+    disconnectRevision += 1;
+    if (textarea === element) {
+      return;
+    }
+    textarea?.removeEventListener("input", onInput);
+    textarea = element;
+    if (dirty) {
+      element.value = latest;
+    } else {
+      latest = element.value;
+    }
+    element.addEventListener("input", onInput);
+    if (version !== undefined) {
+      if (dirty && queued && timer === undefined && !saving) {
+        timer = setTimeout(() => void persist(), NOTES_PERSIST_DEBOUNCE_MS);
+      }
+      return;
+    }
+    if (hydrationStarted) {
+      return;
+    }
+    hydrationStarted = true;
+    hydrationPending = true;
+    void state
+      .get()
+      .then((result) => {
+        hydrationPending = false;
+        if (disconnected) {
+          hydrationStarted = false;
+          return;
+        }
+        version = result.version;
+        if (!dirty && typeof result.state === "string" && textarea) {
+          textarea.value = result.state;
+          latest = result.state;
+        }
+        if (dirty && queued) {
+          void persist();
+        }
+      })
+      .catch(() => {
+        hydrationPending = false;
+        hydrationStarted = false;
+        if (dirty) {
+          showStatus("saveError");
+        }
+      });
+  };
+  editorBindings.set(state, binding);
+  return binding;
+}
+
+export function renderNotes(
+  widget: WorkspaceWidget,
+  _value: unknown,
+  context: BuiltinWidgetContext,
+): TemplateResult {
+  const seed = seedText(widget);
+  const status = context.state ? "" : t("workspaces.widget.notes.readonlyHint");
+  return html`
+    <div class="workspace-notes" data-test-id="workspace-notes">
+      <textarea
+        class="workspace-notes__pad"
+        data-test-id="workspace-notes-pad"
+        aria-label=${widget.title ?? t("workspaces.widget.notes.placeholder")}
+        placeholder=${t("workspaces.widget.notes.placeholder")}
+        ?readonly=${!context.state}
+        .value=${seed}
+        ${context.state ? ref(bindEditor(context.state)) : null}
+      ></textarea>
+      <div
+        class="workspace-notes__status"
+        data-test-id="workspace-notes-status"
+        data-state=${context.state ? "idle" : "readonly"}
+        role=${context.state ? "alert" : "status"}
+      >
+        ${status}
+      </div>
+    </div>
+  `;
+}

--- a/ui/src/lib/workspace/widgets/types.ts
+++ b/ui/src/lib/workspace/widgets/types.ts
@@ -13,6 +13,11 @@ import type { TemplateResult } from "lit";
 import type { ApplicationConfigCapability } from "../../../app/config.ts";
 import type { WorkspaceWidget } from "../types.ts";
 
+export type BuiltinWidgetState = {
+  get(): Promise<{ state: unknown; version: number }>;
+  set(state: unknown, expectedVersion: number): Promise<{ version: number }>;
+};
+
 /** Ambient context a builtin may need beyond its own binding value. */
 export type BuiltinWidgetContext = {
   /** Control UI mount path used by builtins that link to another app route. */
@@ -22,6 +27,8 @@ export type BuiltinWidgetContext = {
     ApplicationConfigCapability["current"],
     "embedSandboxMode" | "allowExternalEmbedUrls"
   >;
+  /** Host-bound persistence for trusted builtins; absent without a gateway client. */
+  state?: BuiltinWidgetState;
 };
 
 /** A builtin widget renderer: pure, side-effect-free, throws only on real bugs. */

--- a/ui/src/lib/workspace/widgets/widgets.test.ts
+++ b/ui/src/lib/workspace/widgets/widgets.test.ts
@@ -3,19 +3,24 @@
 // separately (empty/populated) to lock the empty/loading/error affordances.
 
 import { expectDefined } from "@openclaw/normalization-core";
-import { render } from "lit";
-import { describe, expect, it } from "vitest";
+import { html, nothing, render } from "lit";
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../../api/gateway.ts";
 import type { WorkspaceWidget } from "../types.ts";
 import { mapActivity, renderActivity } from "./activity.ts";
+import { buildBuiltinContext } from "./context.ts";
 import { mapCron, renderCron } from "./cron.ts";
 import { evaluateEmbedUrl, renderIframeEmbed } from "./iframe-embed.ts";
 import { mapInstances, renderInstances } from "./instances.ts";
 import { mapMarkdownSource, renderMarkdown } from "./markdown.ts";
+import { renderNotes } from "./notes.ts";
 import { mapSessions, renderSessions } from "./sessions.ts";
 import { mapStatCard, renderStatCard } from "./stat-card.ts";
 import { mapTable, renderTable } from "./table.ts";
-import type { BuiltinWidgetContext } from "./types.ts";
+import type { BuiltinWidgetContext, BuiltinWidgetState } from "./types.ts";
 import { mapUsage, renderUsage } from "./usage.ts";
+
+const NOTES_PERSIST_DEBOUNCE_MS = 500;
 
 function widget(overrides: Partial<WorkspaceWidget> = {}): WorkspaceWidget {
   return {
@@ -322,5 +327,330 @@ describe("iframe-embed render × sandbox mode", () => {
     );
     expect(container.querySelector('[data-test-id="workspace-embed-blocked"]')).not.toBeNull();
     expect(container.querySelector('[data-test-id="workspace-embed-frame"]')).toBeNull();
+  });
+});
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("notes builtin", () => {
+  it("hydrates persisted text without overwriting an early user edit", async () => {
+    const load = deferred<{ state: unknown; version: number }>();
+    const state: BuiltinWidgetState = {
+      get: () => load.promise,
+      set: async () => ({ version: 2 }),
+    };
+    const container = renderToContainer(
+      renderNotes(widget({ kind: "builtin:notes", props: { text: "seed" } }), null, {
+        ...STRICT_EMBED,
+        state,
+      }),
+    );
+    const pad = container.querySelector<HTMLTextAreaElement>(
+      "[data-test-id='workspace-notes-pad']",
+    )!;
+    expect(pad.value).toBe("seed");
+
+    pad.value = "typed before load";
+    pad.dispatchEvent(new Event("input"));
+    load.resolve({ state: "persisted", version: 7 });
+    await flushMicrotasks();
+
+    expect(pad.value).toBe("typed before load");
+  });
+
+  it("persists an early edit after the version finishes loading", async () => {
+    vi.useFakeTimers();
+    try {
+      const load = deferred<{ state: unknown; version: number }>();
+      const set = vi.fn<BuiltinWidgetState["set"]>(async () => ({ version: 8 }));
+      const container = renderToContainer(
+        renderNotes(widget({ kind: "builtin:notes" }), null, {
+          ...STRICT_EMBED,
+          state: { get: () => load.promise, set },
+        }),
+      );
+      const pad = container.querySelector<HTMLTextAreaElement>(
+        "[data-test-id='workspace-notes-pad']",
+      )!;
+      pad.value = "typed while loading";
+      pad.dispatchEvent(new Event("input"));
+      vi.advanceTimersByTime(NOTES_PERSIST_DEBOUNCE_MS);
+      await flushMicrotasks();
+      expect(set).not.toHaveBeenCalled();
+
+      load.resolve({ state: "old", version: 7 });
+      await flushMicrotasks();
+      expect(set).toHaveBeenCalledWith("typed while loading", 7);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("debounces edits, coalesces an in-flight save, and forwards versions", async () => {
+    vi.useFakeTimers();
+    try {
+      const firstSave = deferred<{ version: number }>();
+      const set = vi
+        .fn<BuiltinWidgetState["set"]>()
+        .mockImplementationOnce(() => firstSave.promise)
+        .mockResolvedValueOnce({ version: 6 });
+      const state: BuiltinWidgetState = {
+        get: async () => ({ state: "old", version: 4 }),
+        set,
+      };
+      const container = renderToContainer(
+        renderNotes(widget({ kind: "builtin:notes" }), null, { ...STRICT_EMBED, state }),
+      );
+      const pad = container.querySelector<HTMLTextAreaElement>(
+        "[data-test-id='workspace-notes-pad']",
+      )!;
+      await flushMicrotasks();
+
+      pad.value = "first";
+      pad.dispatchEvent(new Event("input"));
+      pad.value = "coalesced";
+      pad.dispatchEvent(new Event("input"));
+      vi.advanceTimersByTime(NOTES_PERSIST_DEBOUNCE_MS);
+      await flushMicrotasks();
+      expect(set).toHaveBeenCalledTimes(1);
+      expect(set).toHaveBeenNthCalledWith(1, "coalesced", 4);
+
+      pad.value = "latest";
+      pad.dispatchEvent(new Event("input"));
+      vi.advanceTimersByTime(NOTES_PERSIST_DEBOUNCE_MS);
+      await flushMicrotasks();
+      expect(set).toHaveBeenCalledTimes(1);
+
+      firstSave.resolve({ version: 5 });
+      await flushMicrotasks();
+      expect(set).toHaveBeenNthCalledWith(2, "latest", 5);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("shows save failures and version conflicts", async () => {
+    vi.useFakeTimers();
+    try {
+      const state: BuiltinWidgetState = {
+        get: async () => ({ state: null, version: 2 }),
+        set: vi
+          .fn<BuiltinWidgetState["set"]>()
+          .mockRejectedValueOnce(new Error("disk unavailable"))
+          .mockRejectedValueOnce(new Error("widget state version conflict")),
+      };
+      const container = renderToContainer(
+        renderNotes(widget({ kind: "builtin:notes" }), null, { ...STRICT_EMBED, state }),
+      );
+      const pad = container.querySelector<HTMLTextAreaElement>(
+        "[data-test-id='workspace-notes-pad']",
+      )!;
+      await flushMicrotasks();
+
+      pad.value = "one";
+      pad.dispatchEvent(new Event("input"));
+      vi.advanceTimersByTime(NOTES_PERSIST_DEBOUNCE_MS);
+      await flushMicrotasks();
+      expect(
+        container.querySelector("[data-test-id='workspace-notes-status']")?.textContent,
+      ).toContain("couldn’t be saved");
+
+      pad.value = "two";
+      pad.dispatchEvent(new Event("input"));
+      vi.advanceTimersByTime(NOTES_PERSIST_DEBOUNCE_MS);
+      await flushMicrotasks();
+      expect(
+        container.querySelector("[data-test-id='workspace-notes-status']")?.textContent,
+      ).toContain("changed somewhere else");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels pending persistence while disconnected and retries it after reconnect", async () => {
+    vi.useFakeTimers();
+    try {
+      const set = vi.fn<BuiltinWidgetState["set"]>(async () => ({ version: 1 }));
+      const state: BuiltinWidgetState = {
+        get: async () => ({ state: null, version: 0 }),
+        set,
+      };
+      const container = document.createElement("div");
+      render(
+        renderNotes(widget({ kind: "builtin:notes" }), null, {
+          ...STRICT_EMBED,
+          state,
+        }),
+        container,
+      );
+      const pad = container.querySelector<HTMLTextAreaElement>(
+        "[data-test-id='workspace-notes-pad']",
+      )!;
+      pad.value = "do not save";
+      pad.dispatchEvent(new Event("input"));
+      render(nothing, container);
+      vi.advanceTimersByTime(NOTES_PERSIST_DEBOUNCE_MS);
+      await flushMicrotasks();
+
+      expect(set).not.toHaveBeenCalled();
+
+      render(
+        renderNotes(widget({ kind: "builtin:notes" }), null, {
+          ...STRICT_EMBED,
+          state,
+        }),
+        container,
+      );
+      vi.advanceTimersByTime(NOTES_PERSIST_DEBOUNCE_MS);
+      await flushMicrotasks();
+      expect(set).toHaveBeenCalledWith("do not save", 0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a pending persistence timer across an unrelated rerender", async () => {
+    vi.useFakeTimers();
+    try {
+      const set = vi.fn<BuiltinWidgetState["set"]>(async () => ({ version: 2 }));
+      const state: BuiltinWidgetState = {
+        get: async () => ({ state: null, version: 1 }),
+        set,
+      };
+      const container = document.createElement("div");
+      const note = widget({ kind: "builtin:notes" });
+      render(html`${renderNotes(note, null, { ...STRICT_EMBED, state })}`, container);
+      await flushMicrotasks();
+      const pad = container.querySelector<HTMLTextAreaElement>(
+        "[data-test-id='workspace-notes-pad']",
+      )!;
+      pad.value = "survives rerender";
+      pad.dispatchEvent(new Event("input"));
+
+      render(html`${renderNotes(note, null, { ...STRICT_EMBED, state })}`, container);
+      vi.advanceTimersByTime(NOTES_PERSIST_DEBOUNCE_MS);
+      await flushMicrotasks();
+
+      expect(set).toHaveBeenCalledWith("survives rerender", 1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fails closed instead of writing without a loaded version", async () => {
+    vi.useFakeTimers();
+    try {
+      const set = vi.fn<BuiltinWidgetState["set"]>(async () => ({ version: 1 }));
+      const container = renderToContainer(
+        renderNotes(widget({ kind: "builtin:notes" }), null, {
+          ...STRICT_EMBED,
+          state: {
+            get: async () => {
+              throw new Error("invalid version");
+            },
+            set,
+          },
+        }),
+      );
+      const pad = container.querySelector<HTMLTextAreaElement>(
+        "[data-test-id='workspace-notes-pad']",
+      )!;
+      pad.value = "must not overwrite";
+      pad.dispatchEvent(new Event("input"));
+      await vi.advanceTimersByTimeAsync(NOTES_PERSIST_DEBOUNCE_MS);
+
+      expect(set).not.toHaveBeenCalled();
+      expect(
+        container.querySelector("[data-test-id='workspace-notes-status']")?.textContent,
+      ).toContain("couldn’t be saved");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retries hydration after a failed mount", async () => {
+    const get = vi
+      .fn<BuiltinWidgetState["get"]>()
+      .mockRejectedValueOnce(new Error("gateway interrupted"))
+      .mockResolvedValueOnce({ state: "recovered", version: 3 });
+    const state: BuiltinWidgetState = {
+      get,
+      set: async () => ({ version: 4 }),
+    };
+    const container = document.createElement("div");
+    const note = widget({ kind: "builtin:notes" });
+    render(renderNotes(note, null, { ...STRICT_EMBED, state }), container);
+    await flushMicrotasks();
+    render(nothing, container);
+    await flushMicrotasks();
+    render(renderNotes(note, null, { ...STRICT_EMBED, state }), container);
+    await flushMicrotasks();
+
+    expect(get).toHaveBeenCalledTimes(2);
+    expect(
+      container.querySelector<HTMLInputElement>("[data-test-id='workspace-notes-pad']")?.value,
+    ).toBe("recovered");
+  });
+
+  it("renders a read-only seeded pad without a gateway state client", () => {
+    const container = renderToContainer(
+      renderNotes(
+        widget({ kind: "builtin:notes", props: { text: "seed note" } }),
+        null,
+        STRICT_EMBED,
+      ),
+    );
+    const pad = container.querySelector<HTMLTextAreaElement>(
+      "[data-test-id='workspace-notes-pad']",
+    )!;
+    expect(pad.readOnly).toBe(true);
+    expect(pad.value).toBe("seed note");
+    expect(
+      container.querySelector("[data-test-id='workspace-notes-status']")?.textContent,
+    ).toContain("Connect to the gateway");
+  });
+
+  it("binds state RPCs to the host widget id and forwards expectedVersion", async () => {
+    const requests: Array<{ method: string; params: unknown }> = [];
+    const client = {
+      request: async (method: string, params: unknown) => {
+        requests.push({ method, params });
+        return method.endsWith(".get") ? { state: "note", version: 3 } : { version: 4 };
+      },
+    } as unknown as GatewayBrowserClient;
+    const props = { client, connected: true };
+    const context = buildBuiltinContext(props, widget({ id: "trusted-notes-id" }));
+
+    await context.state?.get();
+    await context.state?.set("next", 3);
+
+    expect(requests).toEqual([
+      { method: "workspaces.widget.state.get", params: { widgetId: "trusted-notes-id" } },
+      {
+        method: "workspaces.widget.state.set",
+        params: { widgetId: "trusted-notes-id", state: "next", expectedVersion: 3 },
+      },
+    ]);
+    expect(buildBuiltinContext(props, widget({ id: "trusted-notes-id" })).state).toBe(
+      context.state,
+    );
+    expect(buildBuiltinContext({ ...props, connected: false }, widget()).state).toBeUndefined();
   });
 });

--- a/ui/src/pages/plugin/workspace-view.ts
+++ b/ui/src/pages/plugin/workspace-view.ts
@@ -60,6 +60,7 @@ import type {
   WorkspaceDocument,
   WidgetManifestView,
 } from "../../lib/workspace/types.ts";
+import { buildBuiltinContext } from "../../lib/workspace/widgets/context.ts";
 import type { BuiltinWidgetContext } from "../../lib/workspace/widgets/index.ts";
 import { getSafeLocalStorage } from "../../local-storage.ts";
 import "../../styles/workspace.css";
@@ -76,11 +77,6 @@ export type WorkspaceProps = {
   basePath?: string;
   /** Session key for custom-widget prompt dispatch (L5). */
   sessionKey?: string;
-};
-
-const DEFAULT_EMBED_CONTEXT: BuiltinWidgetContext["embed"] = {
-  embedSandboxMode: "strict",
-  allowExternalEmbedUrls: false,
 };
 
 // Per-host transient view state (menu, live drag) kept outside the data model so a
@@ -565,10 +561,6 @@ function renderGrid(
     `;
   }
   const callbacks = makeCallbacks(props, state, viewState, tab);
-  const builtinContext: BuiltinWidgetContext = {
-    basePath: props.basePath ?? "",
-    embed: props.embed ?? DEFAULT_EMBED_CONTEXT,
-  };
   const rows = gridRowCount(tab.widgets);
   const minHeight = rows * WORKSPACE_ROW_HEIGHT + Math.max(0, rows - 1) * WORKSPACE_GRID_GAP;
   return html`
@@ -581,7 +573,7 @@ function renderGrid(
           menuOpen: viewState.openMenuWidgetId === widget.id,
           pending: state.pendingWidgetIds.has(widget.id),
           dragging: viewState.drag?.widgetId === widget.id,
-          builtinContext,
+          builtinContext: buildBuiltinContext(props, widget),
           callbacks,
           ...(custom ? { custom } : {}),
         });

--- a/ui/src/styles/workspace.css
+++ b/ui/src/styles/workspace.css
@@ -383,6 +383,49 @@
   font-size: 0.85em;
 }
 
+.workspace-notes {
+  display: flex;
+  min-height: 120px;
+  height: 100%;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.workspace-notes__pad {
+  flex: 1;
+  width: 100%;
+  min-height: 112px;
+  resize: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+  background: color-mix(in srgb, var(--card) 86%, var(--bg));
+  color: var(--text);
+  font: inherit;
+  line-height: 1.5;
+}
+
+.workspace-notes__pad:focus-visible {
+  border-color: var(--accent);
+  outline: 2px solid color-mix(in srgb, var(--accent) 28%, transparent);
+  outline-offset: 1px;
+}
+
+.workspace-notes__pad:read-only {
+  color: var(--text-muted, var(--text));
+  cursor: default;
+}
+
+.workspace-notes__status {
+  min-height: 1.25em;
+  color: var(--text-muted, var(--text));
+  font-size: 0.78em;
+}
+
+.workspace-notes__status[data-state="error"] {
+  color: var(--danger);
+}
+
 .workspace-widget__error {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## What Problem This Solves

Workspaces had persistent per-widget state after #101329, but no trusted built-in editor that used the contract safely. The legacy Notes implementation targeted the removed dashboard stack and could overwrite edits during hydration or write without a loaded concurrency version.

## Why This Change Was Made

This stacked rebuild adds `builtin:notes` to the current Workspaces registry and consumes the recovered widget-state contract through a trusted per-widget accessor. Every save uses optimistic concurrency, missing versions never degrade to unguarded writes, early edits queue until hydration completes, and conflicts surface visibly. Debounced writes are canceled on disconnect/unmount; reconnect retries hydration without performing network work while unmounted.

## User Impact

Workspace users can keep persistent notes inside a widget without losing early input to a late load. Concurrent edits are detected instead of silently overwritten, read-only/offline views cannot mutate state, and transient hydration failures can recover after reconnect.

Generated locale synchronization remains intentionally separate: four new English keys require authenticated translation sync for the repository's 20 generated locales. No generated locale was hand-edited or filled with fallback-only output.

## Evidence

- Stacked on the recovered Workspaces widget-state contract and rebased onto upstream main at `843e3c787806389cdaac884300e671fba658dab6` during the final recovery pass; the Notes commit range-diffs identically and its companion differs only in current-main import context.
- Final-head focused Vitest: 61 extension + 83 UI tests passed.
- Scoped extension/UI `oxfmt` and `oxlint`: clean.
- Final-head extension/UI/UI-test TypeScript checks passed.
- Autoreview found two lifecycle defects (unmount-stranded debounce and non-retryable hydration); both were fixed with expanded tests.
- Test-only state helpers were removed from the public export surface; the remaining pairing-store dead-export findings originate from current upstream `main`.
- `git diff --check`: clean.
- Known external gate: `pnpm ui:i18n:check` reports 12 pending keys across 20 generated locales: four introduced here plus eight already present on the frozen main snapshot. Authenticated translation sync remains required; no fallback-only locale output was committed.
