### PR TITLE
fix(agents): preserve run-mode subagent bundle MCP runtimes for approved exec follow-up turns

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -2136,6 +2136,38 @@ process.on("SIGINT", shutdown);`,
     }
   });
 
+  it("keeps a run-mode subagent runtime alive for an approved follow-up turn", async () => {
+    const sessionId = "session-subagent-followup";
+    const sessionKey = "agent:test:session-subagent-followup";
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId,
+      sessionKey,
+      workspaceDir: "/workspace",
+      cfg: { mcp: { sessionIdleTtlMs: 0 } },
+    });
+    const materialized = await materializeBundleMcpToolsForRun({ runtime });
+    expect(runtime.activeLeases).toBe(1);
+
+    await expect(
+      retireSessionMcpRuntimeForSessionKey({
+        sessionKey,
+        reason: "subagent-run-cleanup",
+        preserveActiveLeases: true,
+      }),
+    ).resolves.toBe(true);
+    expect(testing.getCachedSessionIds()).toContain(sessionId);
+
+    const followUp = await materializeBundleMcpToolsForRun({ runtime });
+    expect(runtime.activeLeases).toBe(2);
+
+    await materialized.dispose();
+    expect(testing.getCachedSessionIds()).toContain(sessionId);
+
+    await followUp.dispose();
+    expect(runtime.activeLeases).toBe(0);
+    expect(testing.getCachedSessionIds()).not.toContain(sessionId);
+  });
+
   it("cancels deferred retirement when a later run reuses the runtime", async () => {
     const manager = testing.createSessionMcpRuntimeManager({ enableIdleSweepTimer: false });
     const params = {

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -2646,6 +2646,7 @@ describe("subagent registry lifecycle hardening", () => {
     expectFields(retireArg, {
       sessionKey: entry.childSessionKey,
       reason: "subagent-run-cleanup",
+      preserveActiveLeases: true,
     });
     expect(retireArg.onError).toBeTypeOf("function");
   });

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -1237,6 +1237,7 @@ export function createSubagentRegistryLifecycleController(params: {
         await retireSessionMcpRuntimeForSessionKey({
           sessionKey: cleanupParams.entry.childSessionKey,
           reason: "subagent-run-cleanup",
+          preserveActiveLeases: true,
           onError: (error, sessionId) => {
             params.warn("failed to retire subagent bundle MCP runtime", {
               error: buildSafeLifecycleErrorMeta(error),
@@ -1331,6 +1332,7 @@ export function createSubagentRegistryLifecycleController(params: {
     await retireSessionMcpRuntimeForSessionKey({
       sessionKey: cleanupParams.entry.childSessionKey,
       reason: cleanupParams.reason,
+      preserveActiveLeases: true,
       onError: (error, sessionId) => {
         params.warn("failed to retire subagent bundle MCP runtime", {
           error: buildSafeLifecycleErrorMeta(error),


### PR DESCRIPTION
## Summary
Fixes #76233.

An approved exec follow-up turn against a run-mode subagent session could fail with `bundle-mcp runtime disposed for session <id>` (surfacing as `errorCode=UNAVAILABLE`) because run-mode subagent cleanup retired the child session's bundle MCP runtime while the run still held an active materialization lease. Run-mode cleanup now retires with `preserveActiveLeases`, and the materialized run completes the deferred retirement once its lease releases.

Note for anyone who saw the earlier revision of this branch: the fix was re-expressed on top of the deferred-retirement API that main gained in #69039 (sandboxed MCP Apps, `f3971bbd56`), which did not exist at the original merge base. The earlier revision hand-rolled a blocking lease wait inside `runtime.dispose()`. Replaying that now would stack a second, blocking ownership mechanism on top of main's non-blocking `preserveActiveLeases` / `deferRetirement` design, and it would make session-reset, cron, and fingerprint-change disposal paths block on live leases. The current change uses main's mechanism instead.

## Root cause
`src/agents/subagent-registry-lifecycle.ts` retired the child session bundle MCP runtime at run-mode cleanup without preserving active leases:

```before
await retireSessionMcpRuntimeForSessionKey({
  sessionKey: cleanupParams.entry.childSessionKey,
  reason: "subagent-run-cleanup",
  onError: (error, sessionId) => { ... },
});
```

`retireSessionMcpRuntime` disposes the session runtime immediately unless `preserveActiveLeases` is set, so a still-pending approved exec follow-up turn holding that session's runtime handle found it disposed and failed at tool materialization.

The embedded-run path (`src/agents/embedded-agent-runner/run.ts`, reason `embedded-run-end`) already passes `preserveActiveLeases: true` on current main, so that path no longer reproduces. The run-mode subagent path (`subagent-run-cleanup`) was still live, and it is the case #76233 reports.

## Fix
Run-mode retirement now preserves active leases, so retirement starts, stops the runtime from being reused for later runs, and defers final disposal while a lease is held:

```after
await retireSessionMcpRuntimeForSessionKey({
  sessionKey: cleanupParams.entry.childSessionKey,
  reason: cleanupParams.reason,
  preserveActiveLeases: true,
  onError: (error, sessionId) => { ... },
});
```

`src/agents/agent-bundle-mcp-materialize.ts` then completes that deferred retirement when the materialized run releases its lease, instead of leaving it to the idle sweeper:

```after
disposed = true;
releaseLease?.();
await completeDeferredSessionMcpRuntimeRetirement(params.runtime).catch((error: unknown) => {
  logWarn(`bundle-mcp: deferred runtime retirement failed: ${formatErrorMessage(error)}`);
});
await params.disposeRuntime?.();
```

This mirrors the existing precedent for view leases in `src/agents/mcp-ui-resource.ts` and for MCP App sessions in `src/gateway/server-methods/mcp-app.ts`.

Both touched production files are already over the 500-line changed-file LOC ratchet, so a second commit keeps them from growing with no behavior change: run cleanup reuses the existing run-mode retire helper rather than repeating its call, and the MCP argument coercion helpers move into `src/agents/agent-bundle-mcp-args.ts`.

## Why this is the right boundary
The race is at the session MCP runtime ownership boundary, not in the exec follow-up text path. Materialized bundle MCP tools already acquire and release runtime leases, and main already models "retire but honor live leases" through `preserveActiveLeases` plus manager-level `deferRetirement` / `completeDeferredRetirement`. Session-mode subagents keep their warm-runtime behavior, `disposeAll()` still tears runtimes down unconditionally at shutdown, and the idle sweeper remains the backstop for a deferred retirement whose lease holder never disposes.

## Verification
- `node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime.test.ts` passed: 49 passed (49).
- `node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime.test.ts src/agents/subagent-registry-lifecycle.test.ts src/agents/agent-bundle-mcp-tools.materialize.test.ts` reported 151 of 152 passing on a loaded local machine; the single failure was the unrelated pre-existing `retires timed-out shared MCP sessions before later catalog retries` case, which passes when its file is run on its own and passes in CI.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` passed.
- `oxlint` and `oxfmt --check` passed on the changed files.
- `node --import tsx scripts/check-ts-max-loc.ts --base $(git merge-base origin/main HEAD) --head HEAD` passed.
- Regression coverage: `agent-bundle-mcp-runtime.test.ts` keeps a run-mode subagent runtime alive across `subagent-run-cleanup` for an approved follow-up turn and asserts the session is dropped only after the last lease releases; `subagent-registry-lifecycle.test.ts` asserts the run-mode cleanup call site passes `preserveActiveLeases: true`.

## Real behavior proof
Behavior addressed: An approved exec follow-up turn for a run-mode subagent must not fail with `bundle-mcp runtime disposed for session <id>` when run cleanup retires the session bundle MCP runtime while the run still holds an active materialization lease.
Real environment tested: The real source functions `getOrCreateSessionMcpRuntime`, `materializeBundleMcpToolsForRun`, `createSubagentRegistryLifecycleController(...).completeCleanupBookkeeping`, and `retireSessionMcpRuntimeForSessionKey` were driven in one process against the pristine `origin/main` content of the changed production files and against PR head `3f6a9c4d4efc174d0d54de057df10fb818cefe25`, with identical input. No external network service or provider was involved.
Exact steps or command run after this patch: `node --import tsx proof-101830-driver.ts`, a scratch driver that creates the child session runtime, materializes bundle MCP tools for the run so a lease is held, runs the real run-mode subagent cleanup bookkeeping (`reason: "subagent-run-cleanup"`), then has a late approved follow-up turn materialize bundle MCP tools against the same runtime, then releases both leases.
Evidence after fix:
```
# BEFORE (pristine origin/main content of the changed files)
{
  "step1_runHoldsLease": {
    "activeLeases": 1,
    "liveSessionIds": [
      "session-subagent-run-101830"
    ]
  },
  "step2_afterRunModeSubagentCleanup": {
    "activeLeases": 1,
    "liveSessionIds": []
  },
  "step3_approvedFollowUpTurn": "rejected: bundle-mcp runtime disposed for session session-subagent-run-101830",
  "step4_afterAllLeasesReleased": {
    "activeLeases": 0,
    "liveSessionIds": []
  }
}
# AFTER (this patch, head 3f6a9c4d4e, identical input)
{
  "step1_runHoldsLease": {
    "activeLeases": 1,
    "liveSessionIds": [
      "session-subagent-run-101830"
    ]
  },
  "step2_afterRunModeSubagentCleanup": {
    "activeLeases": 1,
    "liveSessionIds": [
      "session-subagent-run-101830"
    ]
  },
  "step3_approvedFollowUpTurn": "ok: approved follow-up turn materialized bundle MCP tools",
  "step4_afterAllLeasesReleased": {
    "activeLeases": 0,
    "liveSessionIds": []
  }
}
```
Observed result after fix: On the pristine base, run-mode cleanup drops the session runtime while its lease is still held and the late approved follow-up turn is rejected with `bundle-mcp runtime disposed for session session-subagent-run-101830`; with this patch the same cleanup keeps the runtime live under the held lease, the follow-up turn materializes its bundle MCP tools, and the session is removed only after the last lease releases.
What was not tested: No live provider request, no real WebSocket approval click, and no full production build; the idle-sweeper backstop and session-mode subagent cleanup were covered only by the shipped regression coverage, not by this driver.
