### PR TITLE
refactor: localize internal implementation symbols

### DIFF
--- a/extensions/discord/src/channel.conversation.ts
+++ b/extensions/discord/src/channel.conversation.ts
@@ -119,7 +119,7 @@ export function resolveDiscordCommandConversation(params: {
   return conversationId ? { conversationId } : null;
 }
 
-export function resolveDiscordThreadConversationRef(params: {
+function resolveDiscordThreadConversationRef(params: {
   threadId?: string | number | null;
   threadParentId?: string | number | null;
   parentSessionKey?: string | null;

--- a/extensions/discord/src/monitor/message-handler.reply-typing-policy.ts
+++ b/extensions/discord/src/monitor/message-handler.reply-typing-policy.ts
@@ -19,7 +19,7 @@ export type DiscordAcceptedTypingPrestartDecision = {
     | "defer-to-message";
 };
 
-export function resolveDiscordSourceReplyDeliveryMode(
+function resolveDiscordSourceReplyDeliveryMode(
   ctx: DiscordMessagePreflightContext,
 ): SourceReplyDeliveryMode {
   // Keep prestart policy keyed to the same source-reply mode as dispatch.

--- a/extensions/discord/src/monitor/model-picker.state.ts
+++ b/extensions/discord/src/monitor/model-picker.state.ts
@@ -454,7 +454,7 @@ function chunkBucketsByCount(sortedItems: string[]): DiscordModelPickerBucket[] 
  * "bad customId → reset to defaults" semantics already used for other
  * state fields.
  */
-export function resolveBucket(
+function resolveBucket(
   buckets: DiscordModelPickerBucket[],
   id: string | undefined,
 ): DiscordModelPickerBucket | null {

--- a/extensions/discord/src/monitor/native-command-auth.ts
+++ b/extensions/discord/src/monitor/native-command-auth.ts
@@ -21,7 +21,7 @@ import type { DiscordConfig } from "./native-command.types.js";
 import { resolveDiscordNativeInteractionChannelContext } from "./native-interaction-channel-context.js";
 import { resolveDiscordSenderIdentity } from "./sender-identity.js";
 
-export function resolveDiscordNativeCommandAllowlistAccess(params: {
+function resolveDiscordNativeCommandAllowlistAccess(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
   sender: { id: string; name?: string; tag?: string };

--- a/extensions/discord/src/monitor/provider.deploy-errors.ts
+++ b/extensions/discord/src/monitor/provider.deploy-errors.ts
@@ -187,7 +187,7 @@ export function formatDiscordDeployErrorMessage(err: unknown): string {
   return `Discord REST ${operation} was aborted${timingText}`;
 }
 
-export function resolveDiscordDeployRateLimitDetails(
+function resolveDiscordDeployRateLimitDetails(
   err: unknown,
 ): DiscordDeployRateLimitDetails | undefined {
   if (!err || typeof err !== "object") {

--- a/extensions/discord/src/voice/realtime.ts
+++ b/extensions/discord/src/voice/realtime.ts
@@ -222,7 +222,7 @@ function isDiscordAgentProxyVoiceMode(mode: DiscordVoiceMode): boolean {
   return mode === "agent-proxy";
 }
 
-export function resolveDiscordRealtimeInterruptResponseOnInputAudio(params: {
+function resolveDiscordRealtimeInterruptResponseOnInputAudio(params: {
   realtimeConfig: DiscordRealtimeVoiceConfig;
   providerId: string;
 }): boolean {
@@ -230,7 +230,7 @@ export function resolveDiscordRealtimeInterruptResponseOnInputAudio(params: {
   return readProviderConfigBoolean(providerConfig, "interruptResponseOnInputAudio") ?? true;
 }
 
-export function resolveDiscordRealtimeBargeIn(params: {
+function resolveDiscordRealtimeBargeIn(params: {
   realtimeConfig: DiscordRealtimeVoiceConfig;
   providerId: string;
 }): boolean {
@@ -241,7 +241,7 @@ export function resolveDiscordRealtimeBargeIn(params: {
   return resolveDiscordRealtimeInterruptResponseOnInputAudio(params);
 }
 
-export function buildDiscordSpeakExactUserMessage(text: string): string {
+function buildDiscordSpeakExactUserMessage(text: string): string {
   return [
     "Internal OpenClaw voice playback result.",
     "Do not call openclaw_agent_consult or any other tool for this message.",

--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -23,7 +23,7 @@ type BitableRecordUpdateFields = NonNullable<
   NonNullable<BitableRecordUpdatePayload["data"]>["fields"]
 >;
 
-export class LarkApiError extends Error {
+class LarkApiError extends Error {
   readonly code: number;
   readonly api: string;
   readonly context?: Record<string, unknown>;

--- a/extensions/feishu/src/doctor.ts
+++ b/extensions/feishu/src/doctor.ts
@@ -544,7 +544,7 @@ function collectRepairSessionEntries(
   );
 }
 
-export function inspectFeishuDoctorState(params: {
+function inspectFeishuDoctorState(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
 }): FeishuDoctorInspection {

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -417,7 +417,7 @@ export type SendMediaResult = {
  * Upload an image to Feishu and get an image_key for sending.
  * Supports: JPEG, PNG, WEBP, GIF, TIFF, BMP, ICO
  */
-export async function uploadImageFeishu(params: {
+async function uploadImageFeishu(params: {
   cfg: ClawdbotConfig;
   image: Buffer | string; // Buffer or file path
   imageType?: "message" | "avatar";
@@ -470,7 +470,7 @@ export function sanitizeFileNameForUpload(fileName: string): string {
  * Upload a file to Feishu and get a file_key for sending.
  * Max file size: 30MB
  */
-export async function uploadFileFeishu(params: {
+async function uploadFileFeishu(params: {
   cfg: ClawdbotConfig;
   file: Buffer | string; // Buffer or file path
   fileName: string;
@@ -514,7 +514,7 @@ export async function uploadFileFeishu(params: {
 /**
  * Send an image message using an image_key
  */
-export async function sendImageFeishu(params: {
+async function sendImageFeishu(params: {
   cfg: ClawdbotConfig;
   to: string;
   imageKey: string;
@@ -568,7 +568,7 @@ export async function sendImageFeishu(params: {
 /**
  * Send a file message using a file_key
  */
-export async function sendFileFeishu(params: {
+async function sendFileFeishu(params: {
   cfg: ClawdbotConfig;
   to: string;
   fileKey: string;
@@ -625,7 +625,7 @@ export async function sendFileFeishu(params: {
 /**
  * Helper to detect file type from extension
  */
-export function detectFileType(
+function detectFileType(
   fileName: string,
 ): "opus" | "mp4" | "pdf" | "doc" | "xls" | "ppt" | "stream" {
   const ext = normalizeLowercaseStringOrEmpty(path.extname(fileName));

--- a/extensions/feishu/src/monitor.state.ts
+++ b/extensions/feishu/src/monitor.state.ts
@@ -180,7 +180,7 @@ function isServerNotRunningError(error: Error): boolean {
   return (error as NodeJS.ErrnoException).code === "ERR_SERVER_NOT_RUNNING";
 }
 
-export async function closeFeishuHttpServer(server: http.Server): Promise<void> {
+async function closeFeishuHttpServer(server: http.Server): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     let settled = false;
     const settle = (err?: Error) => {

--- a/extensions/feishu/src/presentation-card.ts
+++ b/extensions/feishu/src/presentation-card.ts
@@ -98,7 +98,7 @@ function buildFeishuPayloadButton(
   return rendered;
 }
 
-export function buildFeishuCardElementsForBlock(
+function buildFeishuCardElementsForBlock(
   block: MessagePresentationBlock,
 ): Record<string, unknown>[] {
   if (block.type === "text") {

--- a/extensions/file-transfer/src/node-host/path-errors.ts
+++ b/extensions/file-transfer/src/node-host/path-errors.ts
@@ -43,7 +43,7 @@ export function readAbsolutePath(input: unknown): string | InvalidPathResult {
   return input;
 }
 
-export function canonicalPathFromFsSafeError(err: unknown): string | undefined {
+function canonicalPathFromFsSafeError(err: unknown): string | undefined {
   if (!(err instanceof FsSafeError) || !err.cause || typeof err.cause !== "object") {
     return undefined;
   }

--- a/extensions/google-meet/src/agent-consult.ts
+++ b/extensions/google-meet/src/agent-consult.ts
@@ -29,7 +29,7 @@ export function resolveGoogleMeetRealtimeTools(policy: GoogleMeetToolPolicy): Re
   return resolveRealtimeVoiceAgentConsultTools(policy);
 }
 
-export function submitGoogleMeetConsultWorkingResponse(
+function submitGoogleMeetConsultWorkingResponse(
   session: RealtimeVoiceBridgeSession,
   callId: string,
 ): void {

--- a/extensions/google/src/gemini-web-search-provider.runtime.ts
+++ b/extensions/google/src/gemini-web-search-provider.runtime.ts
@@ -169,7 +169,7 @@ function resolveGeminiTimeRangeFilter(
   };
 }
 
-export function resolveGeminiRuntimeApiKey(gemini?: GeminiConfig): string | undefined {
+function resolveGeminiRuntimeApiKey(gemini?: GeminiConfig): string | undefined {
   return (
     readConfiguredSecretString(gemini?.apiKey, "tools.web.search.gemini.apiKey") ??
     readProviderEnvValue(["GEMINI_API_KEY"]) ??

--- a/extensions/imessage/src/accounts.ts
+++ b/extensions/imessage/src/accounts.ts
@@ -164,7 +164,7 @@ function normalizeIMessageDbPath(value: string | undefined | null): string {
 // Stable signature for the local Messages backend an iMessage account targets.
 // Two enabled accounts that share a signature watch the same source, which
 // caused duplicate inbound handling in openclaw/openclaw#65141.
-export function resolveIMessageAccountSourceSignature(account: ResolvedIMessageAccount): string {
+function resolveIMessageAccountSourceSignature(account: ResolvedIMessageAccount): string {
   return JSON.stringify([
     normalizeIMessageCliPath(account.config.cliPath),
     normalizeIMessageDbPath(account.config.dbPath),

--- a/extensions/imessage/src/approval-reactions.ts
+++ b/extensions/imessage/src/approval-reactions.ts
@@ -233,7 +233,7 @@ const imessageApprovalReactionTargets =
     readPersistedTarget,
   });
 
-export function listIMessageApprovalReactionBindings(
+function listIMessageApprovalReactionBindings(
   allowedDecisions: readonly ExecApprovalReplyDecision[],
 ): IMessageApprovalReactionBinding[] {
   return listApprovalReactionBindings({ allowedDecisions });

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -51,7 +51,7 @@ function isTestEnv(): boolean {
   return Boolean(vitest);
 }
 
-export function normalizeIMessageFullDiskAccessError(message: string): string | undefined {
+function normalizeIMessageFullDiskAccessError(message: string): string | undefined {
   const normalized = normalizeLowercaseStringOrEmpty(message);
   if (!normalized.includes("full disk access") || !normalized.includes("chat.db")) {
     return undefined;

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -329,7 +329,7 @@ function isKnownFromMeIMessageReactionTarget(params: {
  * 2. Otherwise, return the wildcard `groups["*"].systemPrompt` (trimmed; empty
  *    after trim → `undefined`).
  */
-export function resolveIMessageGroupSystemPrompt(params: {
+function resolveIMessageGroupSystemPrompt(params: {
   groupConfig: unknown;
   defaultConfig: unknown;
 }): string | undefined {

--- a/extensions/imessage/src/probe.ts
+++ b/extensions/imessage/src/probe.ts
@@ -100,7 +100,7 @@ function isDefaultLocalIMessageCliPath(cliPath: string): boolean {
   return trimmed === "imsg" || (!trimmed.includes("/") && path.basename(trimmed) === "imsg");
 }
 
-export function resolveIMessageNonMacHostError(
+function resolveIMessageNonMacHostError(
   cliPath: string,
   platform: NodeJS.Platform = process.platform,
 ): string | undefined {

--- a/extensions/kilocode/stream.ts
+++ b/extensions/kilocode/stream.ts
@@ -56,7 +56,7 @@ function resolveKilocodeThinkingLevel(ctx: ProviderWrapStreamFnContext): ThinkLe
   return ctx.thinkingLevel;
 }
 
-export function createKilocodeStreamWrapper(
+function createKilocodeStreamWrapper(
   baseStreamFn: ProviderWrapStreamFnContext["streamFn"],
   thinkingLevel?: ThinkLevel,
 ): ProviderWrapStreamFnContext["streamFn"] {

--- a/extensions/kimi-coding/stream.ts
+++ b/extensions/kimi-coding/stream.ts
@@ -168,7 +168,7 @@ function resolveKimiAnthropicThinkingBudgetTokens(
   return KIMI_ANTHROPIC_THINKING_BUDGETS[thinkingLevel];
 }
 
-export function resolveKimiThinkingConfig(params: {
+function resolveKimiThinkingConfig(params: {
   configuredThinking: unknown;
   thinkingLevel?: KimiThinkingLevel;
 }): KimiThinkingConfig {

--- a/extensions/line/src/actions.ts
+++ b/extensions/line/src/actions.ts
@@ -10,7 +10,7 @@ export function truncateLineActionLabel(label: string, limit = LINE_ACTION_LABEL
   return truncateUtf16Safe(label, limit);
 }
 
-export function truncateLineActionData(data: string): string {
+function truncateLineActionData(data: string): string {
   return truncateUtf16Safe(data, LINE_ACTION_DATA_LIMIT);
 }
 

--- a/extensions/matrix/src/matrix/client-bootstrap.ts
+++ b/extensions/matrix/src/matrix/client-bootstrap.ts
@@ -123,7 +123,7 @@ export async function resolveRuntimeMatrixClientWithReadiness(opts: {
   });
 }
 
-export async function stopResolvedRuntimeMatrixClient(
+async function stopResolvedRuntimeMatrixClient(
   resolved: ResolvedRuntimeMatrixClient,
   mode: ResolvedRuntimeMatrixClientStopMode = "stop",
 ): Promise<void> {

--- a/extensions/matrix/src/matrix/crypto-state-store.ts
+++ b/extensions/matrix/src/matrix/crypto-state-store.ts
@@ -219,7 +219,7 @@ export function readMatrixIdbSnapshotJson(storageRootDir: string): string | null
   );
 }
 
-export function hasMatrixIdbSnapshotState(storageRootDir: string): boolean {
+function hasMatrixIdbSnapshotState(storageRootDir: string): boolean {
   return isIdbSnapshotMeta(
     openSyncStore<MatrixIdbSnapshotRecord>(
       openMatrixIdbSnapshotStoreOptions(storageRootDir),
@@ -352,7 +352,7 @@ function resolveRecoveryKeyStateKeyForPath(recoveryKeyPath: string): string {
   return `file:${createHash("sha256").update(basename, "utf8").digest("hex").slice(0, 32)}`;
 }
 
-export function normalizeMatrixStoredRecoveryKey(value: unknown): MatrixStoredRecoveryKey | null {
+function normalizeMatrixStoredRecoveryKey(value: unknown): MatrixStoredRecoveryKey | null {
   if (
     !isRecord(value) ||
     value.version !== 1 ||
@@ -383,7 +383,7 @@ export function normalizeMatrixStoredRecoveryKey(value: unknown): MatrixStoredRe
   };
 }
 
-export function normalizeMatrixLegacyCryptoMigrationState(
+function normalizeMatrixLegacyCryptoMigrationState(
   value: unknown,
 ): MatrixLegacyCryptoMigrationState | null {
   if (!isRecord(value) || value.version !== 1 || typeof value.accountId !== "string") {

--- a/extensions/matrix/src/matrix/direct-room.ts
+++ b/extensions/matrix/src/matrix/direct-room.ts
@@ -9,7 +9,7 @@ function trimMaybeString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
-export function normalizeJoinedMatrixMembers(joinedMembers: unknown): string[] {
+function normalizeJoinedMatrixMembers(joinedMembers: unknown): string[] {
   if (!Array.isArray(joinedMembers)) {
     return [];
   }

--- a/extensions/matrix/src/matrix/monitor/reaction-events.ts
+++ b/extensions/matrix/src/matrix/monitor/reaction-events.ts
@@ -24,7 +24,7 @@ const loadExecApprovalResolver = createLazyRuntimeModule(
 
 export type MatrixReactionNotificationMode = "off" | "own";
 
-export function resolveMatrixReactionNotificationMode(params: {
+function resolveMatrixReactionNotificationMode(params: {
   cfg: CoreConfig;
   accountId: string;
 }): MatrixReactionNotificationMode {

--- a/extensions/matrix/src/matrix/profile.ts
+++ b/extensions/matrix/src/matrix/profile.ts
@@ -27,11 +27,11 @@ export type MatrixProfileSyncResult = {
   convertedAvatarFromHttp: boolean;
 };
 
-export function isMatrixMxcUri(value: string): boolean {
+function isMatrixMxcUri(value: string): boolean {
   return normalizeLowercaseStringOrEmpty(normalizeOptionalString(value)).startsWith("mxc://");
 }
 
-export function isMatrixHttpAvatarUri(value: string): boolean {
+function isMatrixHttpAvatarUri(value: string): boolean {
   const normalized = normalizeLowercaseStringOrEmpty(normalizeOptionalString(value));
   return normalized.startsWith("https://") || normalized.startsWith("http://");
 }

--- a/extensions/memory-core/src/memory/manager-reindex-lock.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-lock.ts
@@ -6,7 +6,7 @@ export type MemoryReindexLockHandle = {
   release: () => void;
 };
 
-export function resolveMemoryReindexLockPath(dbPath: string): string {
+function resolveMemoryReindexLockPath(dbPath: string): string {
   return `${dbPath}.reindex-lock.sqlite`;
 }
 

--- a/extensions/memory-core/src/memory/manager-sync-control.ts
+++ b/extensions/memory-core/src/memory/manager-sync-control.ts
@@ -34,7 +34,7 @@ export type MemoryReadonlyRecoveryState = {
   readMeta: () => { vectorDims?: number } | undefined;
 };
 
-export function isMemoryReadonlyDbError(err: unknown): boolean {
+function isMemoryReadonlyDbError(err: unknown): boolean {
   const readonlyPattern =
     /attempt to write a readonly database|database is read-only|SQLITE_READONLY/i;
   const messages = new Set<string>();
@@ -67,7 +67,7 @@ export function isMemoryReadonlyDbError(err: unknown): boolean {
   return [...messages].some((value) => readonlyPattern.test(value));
 }
 
-export function extractMemoryErrorReason(err: unknown): string {
+function extractMemoryErrorReason(err: unknown): string {
   if (err instanceof Error && err.message.trim()) {
     return err.message;
   }

--- a/extensions/memory-core/src/memory/qmd-runtime-cache.ts
+++ b/extensions/memory-core/src/memory/qmd-runtime-cache.ts
@@ -142,7 +142,7 @@ function buildMultiCollectionProbeCacheContextInput(
   return JSON.stringify(buildRuntimeCacheContextRecord(params));
 }
 
-export function buildQmdCollectionValidationCacheContextHash(
+function buildQmdCollectionValidationCacheContextHash(
   params: QmdRuntimeCollectionValidationCacheContext,
 ): string {
   return hashText(buildCollectionValidationCacheContextInput(params));

--- a/extensions/memory-wiki/src/import-runs-state.ts
+++ b/extensions/memory-wiki/src/import-runs-state.ts
@@ -117,7 +117,7 @@ function asNonNegativeInteger(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
 }
 
-export function normalizeMemoryWikiImportRunRecord(raw: unknown): ChatGptImportRunRecord | null {
+function normalizeMemoryWikiImportRunRecord(raw: unknown): ChatGptImportRunRecord | null {
   const record = asRecord(raw);
   if (!record) {
     return null;

--- a/extensions/memory-wiki/src/markdown.ts
+++ b/extensions/memory-wiki/src/markdown.ts
@@ -644,7 +644,7 @@ export function renderMarkdownFence(content: string, infoString = "text"): strin
   return `${fence}${infoString}\n${content}\n${fence}`;
 }
 
-export function inferWikiPageKind(relativePath: string): WikiPageKind | null {
+function inferWikiPageKind(relativePath: string): WikiPageKind | null {
   const normalized = relativePath.split(path.sep).join("/");
   if (normalized.startsWith("entities/")) {
     return "entity";

--- a/extensions/minimax/provider-registration.ts
+++ b/extensions/minimax/provider-registration.ts
@@ -288,7 +288,7 @@ function createMinimaxOAuthMethod(region: MiniMaxRegion) {
   };
 }
 
-export function buildMinimaxApiProviderPlugin(): ProviderPlugin {
+function buildMinimaxApiProviderPlugin(): ProviderPlugin {
   return {
     id: API_PROVIDER_ID,
     label: PROVIDER_LABEL,
@@ -325,7 +325,7 @@ export function buildMinimaxApiProviderPlugin(): ProviderPlugin {
   };
 }
 
-export function buildMinimaxPortalProviderPlugin(): ProviderPlugin {
+function buildMinimaxPortalProviderPlugin(): ProviderPlugin {
   return {
     id: PORTAL_PROVIDER_ID,
     label: PROVIDER_LABEL,

--- a/extensions/msteams/src/sqlite-state.ts
+++ b/extensions/msteams/src/sqlite-state.ts
@@ -47,9 +47,7 @@ export function toPluginJsonValue<T>(value: T): T {
   return JSON.parse(serialized) as T;
 }
 
-export function resolveMSTeamsSqliteStateDir(
-  options: MSTeamsSqliteStateOptions | undefined,
-): string {
+function resolveMSTeamsSqliteStateDir(options: MSTeamsSqliteStateOptions | undefined): string {
   return (
     resolveStateDirOverride(options) ??
     getMSTeamsRuntime().state.resolveStateDir(options?.env ?? process.env, options?.homedir)

--- a/extensions/ollama/src/config-compat.ts
+++ b/extensions/ollama/src/config-compat.ts
@@ -48,7 +48,7 @@ export const legacyConfigRules: LegacyConfigRule[] = [
   },
 ];
 
-export function migrateOllamaCloudRetiredBaseUrl(config: OpenClawConfig): {
+function migrateOllamaCloudRetiredBaseUrl(config: OpenClawConfig): {
   config: OpenClawConfig;
   changes: string[];
 } | null {

--- a/extensions/ollama/src/node-inference.ts
+++ b/extensions/ollama/src/node-inference.ts
@@ -179,7 +179,7 @@ async function fetchLoadedModelNames(baseUrl: string): Promise<Set<string>> {
   }
 }
 
-export async function discoverOllamaNodeModels(
+async function discoverOllamaNodeModels(
   baseUrl = OLLAMA_DEFAULT_BASE_URL,
 ): Promise<OllamaModelsPayload> {
   const apiBase = resolveOllamaApiBase(baseUrl);

--- a/extensions/qqbot/src/engine/messaging/outbound-media-path.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-media-path.ts
@@ -28,7 +28,7 @@ export function isPathWithinRoot(candidatePath: string, rootPath: string): boole
   );
 }
 
-export function resolvePathInsideWorkspace(
+function resolvePathInsideWorkspace(
   workspaceDir: string,
   pathWithinWorkspace: string,
 ): string | null {

--- a/extensions/signal/src/approval-reactions.ts
+++ b/extensions/signal/src/approval-reactions.ts
@@ -352,7 +352,7 @@ function readPersistedTarget(target: unknown): SignalApprovalReactionTarget | nu
   };
 }
 
-export function listSignalApprovalReactionBindings(
+function listSignalApprovalReactionBindings(
   allowedDecisions: readonly ExecApprovalReplyDecision[],
 ): SignalApprovalReactionBinding[] {
   return listApprovalReactionBindings({ allowedDecisions });
@@ -404,7 +404,7 @@ const APPROVAL_ID_LINE_RE = /^\s*ID:\s*([A-Za-z0-9][A-Za-z0-9._:-]*)\s*$/i;
 const APPROVE_REPLY_COMMAND_LINE_RE =
   /^\s*Reply with:\s*\/approve(?:@[^\s]+)?\s+([A-Za-z0-9][A-Za-z0-9._:-]*)\s+(.+)$/i;
 
-export function extractSignalApprovalPromptBinding(text: string): {
+function extractSignalApprovalPromptBinding(text: string): {
   approvalId: string;
   approvalKind: ApprovalKind;
   allowedDecisions: ExecApprovalReplyDecision[];
@@ -476,7 +476,7 @@ function buildTargetRoute(params: {
     : null;
 }
 
-export function shouldAppendSignalApprovalReactionHintForOutboundMessage(params: {
+function shouldAppendSignalApprovalReactionHintForOutboundMessage(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
   to: string;

--- a/extensions/slack/src/approval-native-gates.ts
+++ b/extensions/slack/src/approval-native-gates.ts
@@ -369,7 +369,7 @@ export function shouldHandleSlackPluginViaForwardingSession(params: {
   });
 }
 
-export function isSlackNativeApprovalClientEnabled(params: {
+function isSlackNativeApprovalClientEnabled(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
   approvalKind: SlackApprovalKind;

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -177,7 +177,7 @@ export function setSlackDefaultSendIdentity(accountId: string, identity?: SlackS
   }
 }
 
-export function getSlackDefaultSendIdentity(accountId: string): SlackSendIdentity | undefined {
+function getSlackDefaultSendIdentity(accountId: string): SlackSendIdentity | undefined {
   const normalizedAccountId = normalizeOptionalString(accountId);
   return normalizedAccountId ? slackDefaultSendIdentities.get(normalizedAccountId) : undefined;
 }

--- a/extensions/vllm/thinking-policy.ts
+++ b/extensions/vllm/thinking-policy.ts
@@ -12,9 +12,7 @@ const VLLM_BINARY_THINKING_PROFILE = {
   defaultLevel: "off",
 } satisfies ProviderThinkingProfile;
 
-export function normalizeVllmQwenThinkingFormat(
-  value: unknown,
-): VllmQwenThinkingFormat | undefined {
+function normalizeVllmQwenThinkingFormat(value: unknown): VllmQwenThinkingFormat | undefined {
   if (typeof value !== "string") {
     return undefined;
   }

--- a/extensions/voice-call/src/providers/twilio-region.ts
+++ b/extensions/voice-call/src/providers/twilio-region.ts
@@ -10,7 +10,7 @@ const TWILIO_API_HOSTNAME_BY_REGION = {
 
 const TWILIO_API_HOSTNAMES = new Set(Object.values(TWILIO_API_HOSTNAME_BY_REGION));
 
-export function resolveTwilioApiHostname(region?: TwilioRegion): string {
+function resolveTwilioApiHostname(region?: TwilioRegion): string {
   return TWILIO_API_HOSTNAME_BY_REGION[region ?? "us1"];
 }
 

--- a/extensions/whatsapp/src/approval-auth.ts
+++ b/extensions/whatsapp/src/approval-auth.ts
@@ -8,7 +8,7 @@ import { normalizeWhatsAppTarget } from "./normalize.js";
 
 type ApprovalKind = "exec" | "plugin";
 
-export function normalizeWhatsAppApproverId(value: string | number): string | undefined {
+function normalizeWhatsAppApproverId(value: string | number): string | undefined {
   const normalized = normalizeWhatsAppTarget(String(value));
   if (!normalized || normalized.endsWith("@g.us")) {
     return undefined;

--- a/extensions/whatsapp/src/approval-reactions.ts
+++ b/extensions/whatsapp/src/approval-reactions.ts
@@ -96,7 +96,7 @@ function readPersistedTarget(target: unknown): WhatsAppApprovalReactionTarget | 
   };
 }
 
-export function listWhatsAppApprovalReactionBindings(
+function listWhatsAppApprovalReactionBindings(
   allowedDecisions: readonly ExecApprovalReplyDecision[],
 ): WhatsAppApprovalReactionBinding[] {
   return listApprovalReactionBindings({ allowedDecisions });

--- a/extensions/whatsapp/src/channel-outbound.ts
+++ b/extensions/whatsapp/src/channel-outbound.ts
@@ -11,7 +11,7 @@ import { resolveWhatsAppOutboundTarget } from "./resolve-outbound-target.js";
 import { getWhatsAppRuntime } from "./runtime.js";
 import { sendMessageWhatsApp, sendPollWhatsApp } from "./send.js";
 
-export function normalizeWhatsAppChannelPayloadText(text: string | undefined): string {
+function normalizeWhatsAppChannelPayloadText(text: string | undefined): string {
   return normalizeWhatsAppPayloadTextPreservingIndentation(text);
 }
 

--- a/extensions/whatsapp/src/document-filename.ts
+++ b/extensions/whatsapp/src/document-filename.ts
@@ -3,7 +3,7 @@ import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 
 const WHATSAPP_DEFAULT_DOCUMENT_FILE_NAME = "file";
 
-export function resolveWhatsAppDefaultDocumentFileName(mimetype?: string): string {
+function resolveWhatsAppDefaultDocumentFileName(mimetype?: string): string {
   const extension = extensionForMime(mimetype);
   return extension
     ? `${WHATSAPP_DEFAULT_DOCUMENT_FILE_NAME}${extension}`

--- a/extensions/whatsapp/src/inbound/media.ts
+++ b/extensions/whatsapp/src/inbound/media.ts
@@ -6,7 +6,7 @@ import { extractContextInfo } from "./extract.js";
 import { resolveInboundMediaMimetype } from "./media-mimetype.js";
 import { downloadMediaMessage, normalizeMessageContent } from "./runtime-api.js";
 
-export class WhatsAppInboundMediaLimitExceededError extends Error {
+class WhatsAppInboundMediaLimitExceededError extends Error {
   constructor(maxBytes: number) {
     super(`Media exceeds ${Math.round(maxBytes / (1024 * 1024))}MB limit`);
     this.name = "WhatsAppInboundMediaLimitExceededError";

--- a/extensions/xiaomi/thinking.ts
+++ b/extensions/xiaomi/thinking.ts
@@ -10,7 +10,7 @@ const MIMO_REASONING_MODEL_IDS = new Set([
   "mimo-v2.6-pro",
 ]);
 
-export function isMiMoReasoningModelId(modelId: string): boolean {
+function isMiMoReasoningModelId(modelId: string): boolean {
   return MIMO_REASONING_MODEL_IDS.has(modelId.toLowerCase());
 }
 

--- a/extensions/zalo/src/monitor.webhook.ts
+++ b/extensions/zalo/src/monitor.webhook.ts
@@ -99,7 +99,7 @@ export class ZaloRetryableWebhookError extends Error {
   }
 }
 
-export async function processZaloReplayGuardedUpdate(params: {
+async function processZaloReplayGuardedUpdate(params: {
   target: ZaloWebhookTarget;
   update: ZaloUpdate;
   processUpdate: ZaloWebhookProcessUpdate;

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -268,7 +268,7 @@ const pendingTerminalPresentationByToolCall = new Map<
   }
 >();
 
-export function resolveToolTerminalPresentation(params: {
+function resolveToolTerminalPresentation(params: {
   tool: AnyAgentTool;
   toolParams: unknown;
   result: Awaited<ReturnType<AnyAgentTool["execute"]>>;

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -1024,7 +1024,7 @@ export function addClientToolsToToolSearchCatalog(params: {
 }
 
 /** Register catalog entries under run/session keys and optional direct refs. */
-export function registerToolSearchCatalog(params: {
+function registerToolSearchCatalog(params: {
   sessionId?: string;
   sessionKey?: string;
   agentId?: string;

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -540,7 +540,7 @@ async function findRecentWorkspaceAttestationPath(
   return null;
 }
 
-export async function hasRecentWorkspaceAttestation(
+async function hasRecentWorkspaceAttestation(
   attestationPath: string,
   opts?: { trustUnknown?: boolean },
 ): Promise<boolean> {

--- a/src/channels/plugins/bundled-ids.ts
+++ b/src/channels/plugins/bundled-ids.ts
@@ -27,7 +27,7 @@ export function listBundledChannelPluginIdsForRoot(
 /**
  * Lists bundled channel ids for a package root/cache scope.
  */
-export function listBundledChannelIdsForRoot(
+function listBundledChannelIdsForRoot(
   _packageRoot: string,
   env: NodeJS.ProcessEnv = process.env,
   discovery?: PluginDiscoveryResult,

--- a/src/channels/plugins/pairing.ts
+++ b/src/channels/plugins/pairing.ts
@@ -21,7 +21,7 @@ export function getPairingAdapter(channelId: ChannelId): ChannelPairingAdapter |
   return plugin?.pairing ?? null;
 }
 
-export function requirePairingAdapter(channelId: ChannelId): ChannelPairingAdapter {
+function requirePairingAdapter(channelId: ChannelId): ChannelPairingAdapter {
   const adapter = getPairingAdapter(channelId);
   if (!adapter) {
     throw new Error(`Channel ${channelId} does not support pairing`);

--- a/src/channels/plugins/setup-wizard-helpers.ts
+++ b/src/channels/plugins/setup-wizard-helpers.ts
@@ -570,7 +570,7 @@ export function setChannelDmPolicyWithAllowFrom(params: {
   };
 }
 
-export function setCompatChannelDmPolicyWithAllowFrom(params: {
+function setCompatChannelDmPolicyWithAllowFrom(params: {
   cfg: OpenClawConfig;
   channel: string;
   dmPolicy: DmPolicy;
@@ -599,7 +599,7 @@ export function setCompatChannelDmPolicyWithAllowFrom(params: {
   });
 }
 
-export function setCompatChannelAllowFrom(params: {
+function setCompatChannelAllowFrom(params: {
   cfg: OpenClawConfig;
   channel: string;
   allowFrom: string[];
@@ -639,7 +639,7 @@ export function setAccountDmAllowFromForChannel(params: {
   });
 }
 
-export function createCompatChannelDmPolicy(params: {
+function createCompatChannelDmPolicy(params: {
   label: string;
   channel: string;
   promptAllowFrom?: ChannelSetupDmPolicy["promptAllowFrom"];
@@ -837,7 +837,7 @@ export function createAccountScopedGroupAccessSection<TResolved>(params: {
 type AccountScopedChannel = string;
 type CompatDmChannel = string;
 
-export function patchCompatDmChannelConfig(params: {
+function patchCompatDmChannelConfig(params: {
   cfg: OpenClawConfig;
   channel: string;
   patch: Record<string, unknown>;

--- a/src/channels/plugins/target-parsing-loaded.ts
+++ b/src/channels/plugins/target-parsing-loaded.ts
@@ -25,7 +25,7 @@ export type ParsedChannelExplicitTarget = {
   chatType?: "direct" | "group" | "channel";
 };
 
-export function resolveCompatParsedRouteTarget(params: {
+function resolveCompatParsedRouteTarget(params: {
   channel: string;
   rawTarget?: string | null;
   fallbackThreadId?: string | number | null;

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -2555,7 +2555,7 @@ export async function runConfigUnset(opts: {
   }
 }
 
-export async function runConfigFile(opts: { runtime?: RuntimeEnv }) {
+async function runConfigFile(opts: { runtime?: RuntimeEnv }) {
   const runtime = opts.runtime ?? defaultRuntime;
   try {
     const snapshot = await readConfigFileSnapshot();
@@ -2580,7 +2580,7 @@ async function buildCliConfigSchema(): Promise<Record<string, unknown>> {
   return schema;
 }
 
-export async function runConfigSchema(opts: { runtime?: RuntimeEnv } = {}) {
+async function runConfigSchema(opts: { runtime?: RuntimeEnv } = {}) {
   const runtime = opts.runtime ?? defaultRuntime;
   try {
     writeRuntimeJson(runtime, await buildCliConfigSchema());
@@ -2590,7 +2590,7 @@ export async function runConfigSchema(opts: { runtime?: RuntimeEnv } = {}) {
   }
 }
 
-export async function runConfigValidate(opts: { json?: boolean; runtime?: RuntimeEnv } = {}) {
+async function runConfigValidate(opts: { json?: boolean; runtime?: RuntimeEnv } = {}) {
   const runtime = opts.runtime ?? defaultRuntime;
   let outputPath = CONFIG_PATH ?? "openclaw.json";
 

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -45,7 +45,7 @@ export const OPENCLAW_MODEL_ID = "openclaw";
 /** Default OpenAI-compatible model alias that targets the default OpenClaw agent. */
 export const OPENCLAW_DEFAULT_MODEL_ID = "openclaw/default";
 
-export class UnknownGatewayAgentError extends Error {
+class UnknownGatewayAgentError extends Error {
   constructor(readonly agentId: string) {
     super(`Unknown agent '${agentId}'.`);
     this.name = "UnknownGatewayAgentError";

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -68,11 +68,6 @@ export function isNodeRoleMethod(method: string): boolean {
   return isCoreNodeGatewayMethod(method);
 }
 
-/** Returns true when a method requires admin operator scope. */
-export function isAdminOnlyMethod(method: string): boolean {
-  return resolveScopedMethod(method) === ADMIN_SCOPE;
-}
-
 /** Resolves the required static operator scope for a gateway method, if one exists. */
 export function resolveRequiredOperatorScopeForMethod(method: string): OperatorScope | undefined {
   return resolveScopedMethod(method);

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -348,7 +348,7 @@ function matchesScopedPluginOrDreamingSidecar(params: {
   );
 }
 
-export class PluginLoadFailureError extends Error {
+class PluginLoadFailureError extends Error {
   readonly pluginIds: string[];
   readonly registry: PluginRegistry;
 

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -78,7 +78,7 @@ type ProviderResolutionOutput = Map<string, unknown>;
 
 /** Error for failures that affect an entire configured secret provider. */
 /** Error emitted when a configured secret provider cannot resolve a ref. */
-export class SecretProviderResolutionError extends Error {
+class SecretProviderResolutionError extends Error {
   readonly scope = "provider" as const;
   readonly source: SecretRefSource;
   readonly provider: string;
@@ -97,7 +97,7 @@ export class SecretProviderResolutionError extends Error {
 }
 
 /** Error for failures limited to one SecretRef id under a provider. */
-export class SecretRefResolutionError extends Error {
+class SecretRefResolutionError extends Error {
   readonly scope = "ref" as const;
   readonly source: SecretRefSource;
   readonly provider: string;

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -126,7 +126,7 @@ export type ParentFlowLinkErrorCode =
   | "cancel_requested"
   | "terminal";
 
-export class ParentFlowLinkError extends Error {
+class ParentFlowLinkError extends Error {
   constructor(
     public readonly code: ParentFlowLinkErrorCode,
     message: string,


### PR DESCRIPTION
## What Problem This Solves

Internal implementation helpers were exported across core and plugin modules even though no repository caller consumed those exports. That inflated the apparent public surface and kept deadcode reports noisy.

## Why This Change Was Made

Localize 80 file-private functions and classes while preserving their existing in-module use, and remove one unreferenced gateway scope helper. Public barrels, plugin SDK contracts, generated types, package APIs, and Codex protocol/runtime surfaces are unchanged.

## User Impact

No user-visible behavior changes. Maintainers get a smaller internal API surface and more useful unused-export results.

## Evidence

- AWS Crabbox `cbx_a0c80231b0b5` (`harbor-crayfish`), run `run_b0dc060be2eb`: `pnpm check:changed` passed on the exact rebased commit, including core/core-test/extension/extension-test typechecks, core and extension lint, import-cycle checks, and repository guards.
- AWS Crabbox run `run_b523fff2c493`: 13 targeted Vitest shards passed, 884 assertions total.
- AWS Crabbox run `run_e613ee674391`: `ts-unused-exports` report dropped from 3,576 to 3,550 flagged modules; none of the 80 localized symbols remain in the report.
- Full duplicate scan: zero clones across production, test, and mixed lanes.
- Fresh GPT-5.5 branch autoreview: no actionable findings; patch correct at 0.84 confidence.
- `git diff --check` passed; 62 files, +80/-89, net -9 lines.
