### PR TITLE
fix: keep Gemini thinking disabled after clamp

### DIFF
--- a/packages/ai/src/providers/google-shared.test.ts
+++ b/packages/ai/src/providers/google-shared.test.ts
@@ -55,6 +55,14 @@ function createOutput(): AssistantMessage {
 }
 
 describe("buildGoogleSimpleThinking", () => {
+  it("keeps thinking disabled when a non-reasoning model clamps low to off", () => {
+    const nonReasoningModel = { ...model, reasoning: false };
+
+    expect(buildGoogleSimpleThinking(nonReasoningModel, { reasoning: "low" })).toEqual({
+      enabled: false,
+    });
+  });
+
   it.each(["xhigh", "max"] as const)(
     "keeps thinking disabled when reasoning=%s clamps to off",
     (reasoning) => {

--- a/packages/ai/src/providers/google-shared.test.ts
+++ b/packages/ai/src/providers/google-shared.test.ts
@@ -6,6 +6,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../utils/system-prompt-cache-boundary.js";
 import {
   buildGoogleGenerateContentParams,
+  buildGoogleSimpleThinking,
   consumeGoogleGenerateContentStream,
 } from "./google-shared.js";
 
@@ -52,6 +53,30 @@ function createOutput(): AssistantMessage {
     timestamp: 0,
   };
 }
+
+describe("buildGoogleSimpleThinking", () => {
+  it.each(["xhigh", "max"] as const)(
+    "keeps thinking disabled when reasoning=%s clamps to off",
+    (reasoning) => {
+      const offOnlyThinkingModel = {
+        ...model,
+        id: "gemini-3-flash-preview",
+        thinkingLevelMap: {
+          minimal: null,
+          low: null,
+          medium: null,
+          high: null,
+          xhigh: null,
+          max: null,
+        },
+      } satisfies Model<"google-generative-ai">;
+
+      expect(buildGoogleSimpleThinking(offOnlyThinkingModel, { reasoning })).toEqual({
+        enabled: false,
+      });
+    },
+  );
+});
 
 async function* chunks(items: GenerateContentResponse[]) {
   yield* items;

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -557,8 +557,11 @@ export function buildGoogleSimpleThinking<T extends GoogleApiType>(
   }
 
   const clampedReasoning = clampThinkingLevel(model, options.reasoning);
+  if (clampedReasoning === "off") {
+    return { enabled: false };
+  }
   const effort = (
-    clampedReasoning === "off" || clampedReasoning === "max" ? "high" : clampedReasoning
+    clampedReasoning === "max" ? "high" : clampedReasoning
   ) as ClampedGoogleThinkingLevel;
 
   if (

--- a/src/agents/google-simple-completion-stream.test.ts
+++ b/src/agents/google-simple-completion-stream.test.ts
@@ -24,15 +24,16 @@ vi.mock("./custom-api-registry.js", () => ({
   ensureCustomApiRegistered,
 }));
 
-const { prepareGoogleSimpleCompletionModel } = await import(
-  "./google-simple-completion-stream.js"
-);
+const { prepareGoogleSimpleCompletionModel } = await import("./google-simple-completion-stream.js");
 
 const GOOGLE_SIMPLE_COMPLETION_API = "openclaw-google-generative-ai-simple";
 
 // Mirrors the provider catalog shape closely enough for wrapper registration
 // without pulling live Google model discovery into unit tests.
-function makeGoogleModel(id = "gemini-flash-latest"): Model<"google-generative-ai"> {
+function makeGoogleModel(
+  id = "gemini-flash-latest",
+  overrides: Partial<Model<"google-generative-ai">> = {},
+): Model<"google-generative-ai"> {
   return {
     id,
     name: id,
@@ -45,6 +46,7 @@ function makeGoogleModel(id = "gemini-flash-latest"): Model<"google-generative-a
     contextWindow: 1_000_000,
     maxTokens: 8192,
     headers: {},
+    ...overrides,
   };
 }
 
@@ -152,4 +154,63 @@ describe("prepareGoogleSimpleCompletionModel", () => {
       ).payload.generationConfig.thinkingConfig,
     ).not.toHaveProperty("thinkingBudget");
   });
+
+  it.each(["xhigh", "max"] as const)(
+    "preserves clamped-off intent in the final Gemini 3 payload for reasoning=%s",
+    async (reasoning) => {
+      const actual = await vi.importActual<
+        typeof import("../plugin-sdk/provider-stream-shared.js")
+      >("../plugin-sdk/provider-stream-shared.js");
+      sanitizeGoogleThinkingPayload.mockImplementationOnce(actual.sanitizeGoogleThinkingPayload);
+      streamSimple.mockImplementationOnce((_model, _context, options) => {
+        const payload = {
+          generationConfig: {
+            thinkingConfig: { thinkingLevel: "MINIMAL" },
+          },
+        };
+        options?.onPayload?.(payload, _model);
+        return { content: [{ type: "text", text: "ok" }], payload };
+      });
+      const model = makeGoogleModel("gemini-3-flash-preview", {
+        thinkingLevelMap: {
+          minimal: null,
+          low: null,
+          medium: null,
+          high: null,
+          xhigh: null,
+          max: null,
+        },
+      });
+      const wrapped = prepareGoogleSimpleCompletionModel(model);
+      const streamFn = ensureCustomApiRegistered.mock.calls[0]?.[1] as (
+        ...args: unknown[]
+      ) => unknown;
+
+      const result = await streamFn(wrapped, { messages: [] }, { apiKey: "key", reasoning });
+
+      expect(sanitizeGoogleThinkingPayload).toHaveBeenCalledWith({
+        payload: {
+          generationConfig: {
+            thinkingConfig: { thinkingLevel: "MINIMAL" },
+          },
+        },
+        modelId: "gemini-3-flash-preview",
+        thinkingLevel: "off",
+      });
+      expect(result).toMatchObject({
+        payload: {
+          generationConfig: {
+            thinkingConfig: { thinkingLevel: "MINIMAL" },
+          },
+        },
+      });
+      expect(
+        (
+          result as {
+            payload: { generationConfig: { thinkingConfig: Record<string, unknown> } };
+          }
+        ).payload.generationConfig.thinkingConfig,
+      ).not.toHaveProperty("includeThoughts");
+    },
+  );
 });

--- a/src/agents/google-simple-completion-stream.ts
+++ b/src/agents/google-simple-completion-stream.ts
@@ -4,8 +4,9 @@
  * This registers a patched Google stream API that keeps the normal Google
  * backend but sanitizes unsupported thinking payload options for simple models.
  */
+import { clampThinkingLevel } from "@openclaw/ai/internal/runtime";
 import { streamSimple } from "../llm/stream.js";
-import type { Api, Model } from "../llm/types.js";
+import type { Api, Model, ModelThinkingLevel } from "../llm/types.js";
 import {
   sanitizeGoogleThinkingPayload,
   streamWithPayloadPatch,
@@ -20,18 +21,20 @@ const GOOGLE_SIMPLE_COMPLETION_API: Api = "openclaw-google-generative-ai-simple"
 const SOURCE_API: Api = "google-generative-ai";
 
 function resolveGoogleSimpleThinkingLevel(
+  model: Model,
   reasoning: unknown,
 ): GoogleThinkingInputLevel | undefined {
   switch (reasoning) {
+    case "adaptive":
+      return reasoning;
     case "off":
     case "minimal":
     case "low":
     case "medium":
-    case "adaptive":
     case "high":
     case "max":
     case "xhigh":
-      return reasoning;
+      return clampThinkingLevel(model, reasoning as ModelThinkingLevel);
     default:
       return undefined;
   }
@@ -39,7 +42,7 @@ function resolveGoogleSimpleThinkingLevel(
 
 function buildGoogleSimpleCompletionStreamFn(): StreamFn {
   return (model, context, options) => {
-    const googleModel = { ...model, api: SOURCE_API };
+    const googleModel: Model = { ...model, api: SOURCE_API };
     return streamWithPayloadPatch(
       streamSimple as unknown as StreamFn,
       googleModel,
@@ -50,6 +53,7 @@ function buildGoogleSimpleCompletionStreamFn(): StreamFn {
           payload,
           modelId: model.id,
           thinkingLevel: resolveGoogleSimpleThinkingLevel(
+            googleModel,
             (options as { reasoning?: unknown } | undefined)?.reasoning,
           ),
         });


### PR DESCRIPTION
Closes #101785

## What Problem This Solves

Fixes an issue where users requesting a Google/Gemini reasoning level that the selected model clamps down to `off` could still get thinking enabled at the provider's high effort level.

AI-assisted: yes, created with Codex.

## Why This Change Was Made

The Google shared provider now treats `clampThinkingLevel()` returning `off` as a disabled-thinking result before mapping provider efforts. The Google simple-completion wrapper also passes the clamped effective reasoning level into the final thinking-payload sanitizer, so an unsupported `max`/`xhigh` request cannot be restored to Gemini 3 `HIGH` after the shared builder already disabled it. The existing `max` to `high` normalization remains in place for supported non-off Google thinking requests.

## User Impact

Gemini requests whose catalog/model constraints resolve reasoning to `off` no longer unexpectedly send high thinking settings, avoiding unwanted token overhead and provider errors on models that should have thinking disabled.

## Evidence

- Follow-up for ClawSweeper P1 was committed and pushed at `d4f31fb354f`.
- `git diff --check` passed after the wrapper fix.
- `/Users/fallmonkey/Developer/openclaw/node_modules/.bin/oxfmt --check --threads=1 packages/ai/src/providers/google-shared.ts packages/ai/src/providers/google-shared.test.ts src/agents/google-simple-completion-stream.ts src/agents/google-simple-completion-stream.test.ts src/llm/providers/stream-wrappers/google.test.ts` passed.
- `node scripts/run-vitest.mjs packages/ai/src/providers/google-shared.test.ts src/agents/google-simple-completion-stream.test.ts src/llm/providers/stream-wrappers/google.test.ts` passed as a narrow local fallback after temporarily symlinking this linked worktree to the main checkout's existing `node_modules`: 3 test files, 28 tests, 2 Vitest shards in 5.23s. The symlink was removed after the run.
- Non-mock runtime payload trace on head `d4f31fb354f` passed. This used the actual `prepareGoogleSimpleCompletionModel()` and `streamSimple()` runtime modules with the real Google simple-completion custom API wrapper, captured the final provider payload in `onPayload`, then threw `OPENCLAW_PAYLOAD_CAPTURED_BEFORE_NETWORK` to stop before any Google network request. The redacted terminal output was:

```json
{
  "model": "gemini-3-flash-preview",
  "wrappedApi": "openclaw-google-generative-ai-simple",
  "requestedReasoning": "xhigh",
  "capturedFinalThinkingConfig": { "thinkingLevel": "MINIMAL" },
  "stoppedBeforeNetwork": true,
  "proofChecks": {
    "noHighThinkingLevel": true,
    "noThoughtsRequested": true,
    "finalPayloadUsesMinimal": true
  }
}
{
  "model": "gemini-3-flash-preview",
  "wrappedApi": "openclaw-google-generative-ai-simple",
  "requestedReasoning": "max",
  "capturedFinalThinkingConfig": { "thinkingLevel": "MINIMAL" },
  "stoppedBeforeNetwork": true,
  "proofChecks": {
    "noHighThinkingLevel": true,
    "noThoughtsRequested": true,
    "finalPayloadUsesMinimal": true
  }
}
```
- The new wrapper-level regression `preserves clamped-off intent in the final Gemini 3 payload for reasoning=xhigh|max` runs the actual `sanitizeGoogleThinkingPayload()` through the Google simple-completion wrapper payload hook. For an off-only `gemini-3-flash-preview`, the wrapper now calls the sanitizer with `thinkingLevel: "off"`, and the final outbound payload remains `{ "thinkingConfig": { "thinkingLevel": "MINIMAL" } }` with no `includeThoughts` and no `HIGH`.
- Existing shared-builder proof still applies: `buildGoogleSimpleThinking()` plus `buildGoogleGenerateContentParams()` with off-only `thinkingLevelMap` emits disabled simple thinking for Gemini 2.5 and Gemini 3 clamp-to-off requests without sending `HIGH` or `includeThoughts`.
- Remote agent proof is still blocked in this environment: `blacksmith` is not installed on PATH for Blacksmith Testbox, and brokered AWS Crabbox reports missing coordinator/broker auth. No secrets were printed.
- One bounded local autoreview pass was run with `/Users/fallmonkey/Developer/openclaw/.agents/skills/autoreview/scripts/autoreview --mode local`; it reported clean with no accepted/actionable findings.

