### PR TITLE
Workspaces: add tab-scoped widget pub/sub

### DIFF
--- a/docs/web/workspaces.md
+++ b/docs/web/workspaces.md
@@ -83,6 +83,11 @@ An agent can author a real HTML widget with `workspace_widget_scaffold` (or you 
 Sending a prompt into chat from a widget additionally requires a manifest capability, a
 per-invocation confirmation quoting the exact text, and passes a rate limit.
 
+Widgets approved for `bus:pubsub` can exchange JSON payloads through the parent broker with
+`workspace:publish`, `workspace:subscribe`, and `workspace:unsubscribe`. Delivery uses
+`workspace:message`, stays within the current tab, excludes the publisher, and stops when the
+widget, tab, or Workspaces view is removed. Publishes are limited to 8 KiB and 60 per minute.
+
 ## CLI
 
 ```sh

--- a/extensions/workspaces/src/manifest.test.ts
+++ b/extensions/workspaces/src/manifest.test.ts
@@ -102,6 +102,14 @@ describe("validateWidgetManifest", () => {
     expect(manifest.capabilities).toEqual(["data:read", "prompt:send"]);
   });
 
+  it("accepts the bus:pubsub capability", () => {
+    const manifest = validateWidgetManifest({
+      ...VALID_MANIFEST,
+      capabilities: ["data:read", "bus:pubsub"],
+    });
+    expect(manifest.capabilities).toEqual(["data:read", "bus:pubsub"]);
+  });
+
   it("rejects duplicate binding ids", () => {
     expect(() =>
       validateWidgetManifest({

--- a/extensions/workspaces/src/manifest.ts
+++ b/extensions/workspaces/src/manifest.ts
@@ -200,7 +200,7 @@ export function matchesApprovedFile(
   return expected !== undefined && expected === hashBytes(bytes);
 }
 const BINDING_ID_PATTERN = /^(?!__proto__$)[A-Za-z0-9._-]{1,64}$/;
-const WIDGET_CAPABILITIES = ["data:read", "prompt:send"] as const;
+const WIDGET_CAPABILITIES = ["data:read", "prompt:send", "bus:pubsub"] as const;
 
 type WidgetCapability = (typeof WIDGET_CAPABILITIES)[number];
 

--- a/ui/src/components/workspace-custom-widget.test.ts
+++ b/ui/src/components/workspace-custom-widget.test.ts
@@ -1,5 +1,6 @@
 import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createWorkspaceWidgetBus } from "../lib/workspace/bus.ts";
 import type { WorkspaceWidget, WidgetManifestView } from "../lib/workspace/types.ts";
 import {
   attachWidgetBridge,
@@ -36,7 +37,14 @@ function manifest(overrides?: Partial<WidgetManifestView>): WidgetManifestView {
 }
 
 function host(overrides?: Partial<CustomWidgetHostContext>): CustomWidgetHostContext {
-  return { client: null, basePath: "", sessionKey: "main", ...overrides };
+  return {
+    client: null,
+    basePath: "",
+    sessionKey: "main",
+    tabSlug: "main",
+    widgetBus: createWorkspaceWidgetBus(),
+    ...overrides,
+  };
 }
 
 function renderToContainer(template: unknown): HTMLElement {
@@ -70,7 +78,7 @@ describe("loadWidgetManifestView", () => {
       manifest: {
         entrypoint: "index.html",
         bindings: [{ id: "value", source: "static", value: 1 }],
-        capabilities: ["data:read", "prompt:send"],
+        capabilities: ["data:read", "prompt:send", "bus:pubsub"],
       },
     }));
     const view = await loadWidgetManifestView({ request } as never, "revenue-chart");
@@ -80,7 +88,7 @@ describe("loadWidgetManifestView", () => {
       frameExpiresAt: FRAME_EXPIRES_AT,
       entrypoint: "index.html",
       bindings: { value: { source: "static", value: 1 } },
-      capabilities: ["data:read", "prompt:send"],
+      capabilities: ["data:read", "prompt:send", "bus:pubsub"],
     });
   });
 
@@ -137,6 +145,29 @@ describe("renderCustomWidgetHost DOM", () => {
     expect(iframe?.getAttribute("src")).toMatch(
       new RegExp(`^/gw/plugins/workspaces/widgets/${BRIDGE_TOKEN}/revenue-chart/index\\.html$`),
     );
+  });
+
+  it("recreates the frame when the host moves a widget to another tab", () => {
+    const bus = createWorkspaceWidgetBus();
+    const container = renderToContainer(
+      renderCustomWidgetHost({
+        widget: widget(),
+        manifest: manifest(),
+        context: host({ tabSlug: "a", widgetBus: bus }),
+      }),
+    );
+    const original = container.querySelector("iframe");
+
+    render(
+      renderCustomWidgetHost({
+        widget: widget(),
+        manifest: manifest(),
+        context: host({ tabSlug: "b", widgetBus: bus }),
+      }),
+      container,
+    );
+
+    expect(container.querySelector("iframe")).not.toBe(original);
   });
 });
 
@@ -304,6 +335,80 @@ describe("attachWidgetBridge document-bound channel", () => {
     childPort.close();
     replacement.port1.close();
     detach();
+  });
+});
+
+describe("attachWidgetBridge parent-brokered pub/sub", () => {
+  function connected(params: {
+    id: string;
+    tabSlug: string;
+    bus: ReturnType<typeof createWorkspaceWidgetBus>;
+  }) {
+    const iframe = document.createElement("iframe");
+    document.body.appendChild(iframe);
+    return connectWidgetBridge({
+      iframe,
+      widget: widget({ id: params.id }),
+      manifest: manifest({ capabilities: ["bus:pubsub"] }),
+      context: host({ tabSlug: params.tabSlug, widgetBus: params.bus }),
+    });
+  }
+
+  it("delivers same-tab messages and isolates an identical channel on another tab", async () => {
+    const bus = createWorkspaceWidgetBus();
+    const filter = connected({ id: "filter", tabSlug: "a", bus });
+    const chart = connected({ id: "chart", tabSlug: "a", bus });
+    const otherTab = connected({ id: "other", tabSlug: "b", bus });
+    chart.childPort.postMessage({ v: 1, type: "workspace:subscribe", channel: "selection" });
+    otherTab.childPort.postMessage({ v: 1, type: "workspace:subscribe", channel: "selection" });
+    // MessagePorts are ordered individually, not across distinct ports. Let both
+    // subscriptions reach the parent before publishing from the third port.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    filter.childPort.postMessage({
+      v: 1,
+      type: "workspace:publish",
+      channel: "selection",
+      payload: { region: "eu" },
+    });
+
+    await vi.waitFor(() => expect(chart.posts).toHaveLength(1));
+    expect(chart.posts[0]).toEqual({
+      v: 1,
+      type: "workspace:message",
+      channel: "selection",
+      payload: { region: "eu" },
+    });
+    expect(otherTab.posts).toHaveLength(0);
+    filter.detach();
+    chart.detach();
+    otherTab.detach();
+    filter.childPort.close();
+    chart.childPort.close();
+    otherTab.childPort.close();
+  });
+
+  it("stops delivery after widget, tab, and workspace teardown", async () => {
+    const bus = createWorkspaceWidgetBus();
+    const publisher = connected({ id: "publisher", tabSlug: "removed", bus });
+    const subscriber = connected({ id: "subscriber", tabSlug: "removed", bus });
+    subscriber.childPort.postMessage({ v: 1, type: "workspace:subscribe", channel: "updates" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    subscriber.detach();
+    publisher.childPort.postMessage({
+      v: 1,
+      type: "workspace:publish",
+      channel: "updates",
+      payload: 1,
+    });
+    bus.retainTabs(new Set());
+    bus.dispose();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(subscriber.posts).toHaveLength(0);
+    publisher.detach();
+    publisher.childPort.close();
+    subscriber.childPort.close();
   });
 });
 

--- a/ui/src/components/workspace-custom-widget.test.ts
+++ b/ui/src/components/workspace-custom-widget.test.ts
@@ -359,17 +359,22 @@ describe("attachWidgetBridge parent-brokered pub/sub", () => {
     const filter = connected({ id: "filter", tabSlug: "a", bus });
     const chart = connected({ id: "chart", tabSlug: "a", bus });
     const otherTab = connected({ id: "other", tabSlug: "b", bus });
-    chart.childPort.postMessage({ v: 1, type: "workspace:subscribe", channel: "selection" });
-    otherTab.childPort.postMessage({ v: 1, type: "workspace:subscribe", channel: "selection" });
+    chart.childPort.postMessage({ v: 1, type: "workspace:subscribe", channel: "selection" }, []);
+    otherTab.childPort.postMessage({ v: 1, type: "workspace:subscribe", channel: "selection" }, []);
     // MessagePorts are ordered individually, not across distinct ports. Let both
     // subscriptions reach the parent before publishing from the third port.
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    filter.childPort.postMessage({
-      v: 1,
-      type: "workspace:publish",
-      channel: "selection",
-      payload: { region: "eu" },
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
     });
+    filter.childPort.postMessage(
+      {
+        v: 1,
+        type: "workspace:publish",
+        channel: "selection",
+        payload: { region: "eu" },
+      },
+      [],
+    );
 
     await vi.waitFor(() => expect(chart.posts).toHaveLength(1));
     expect(chart.posts[0]).toEqual({
@@ -391,19 +396,26 @@ describe("attachWidgetBridge parent-brokered pub/sub", () => {
     const bus = createWorkspaceWidgetBus();
     const publisher = connected({ id: "publisher", tabSlug: "removed", bus });
     const subscriber = connected({ id: "subscriber", tabSlug: "removed", bus });
-    subscriber.childPort.postMessage({ v: 1, type: "workspace:subscribe", channel: "updates" });
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    subscriber.childPort.postMessage({ v: 1, type: "workspace:subscribe", channel: "updates" }, []);
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
 
     subscriber.detach();
-    publisher.childPort.postMessage({
-      v: 1,
-      type: "workspace:publish",
-      channel: "updates",
-      payload: 1,
-    });
+    publisher.childPort.postMessage(
+      {
+        v: 1,
+        type: "workspace:publish",
+        channel: "updates",
+        payload: 1,
+      },
+      [],
+    );
     bus.retainTabs(new Set());
     bus.dispose();
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
 
     expect(subscriber.posts).toHaveLength(0);
     publisher.detach();

--- a/ui/src/components/workspace-custom-widget.ts
+++ b/ui/src/components/workspace-custom-widget.ts
@@ -25,6 +25,7 @@ import {
   type WidgetBridge,
   type WidgetOutboundMessage,
 } from "../lib/workspace/bridge.ts";
+import type { WorkspaceWidgetBus } from "../lib/workspace/bus.ts";
 import type {
   WorkspaceBinding,
   WorkspaceWidget,
@@ -55,6 +56,10 @@ export type CustomWidgetHostContext = {
   basePath: string;
   /** Session key for prompt dispatch via chat.send. */
   sessionKey: string;
+  /** Parent-owned broker scoped to this Workspaces view. */
+  widgetBus: WorkspaceWidgetBus;
+  /** Parent-resolved tab identity; never accepted from child messages. */
+  tabSlug: string;
   /** Operator confirm dialog quoting the prompt text; resolves true to send. */
   confirmPrompt?: (text: string) => Promise<boolean> | boolean;
   /** Read theme tokens; defaults to computed styles of the document root. */
@@ -160,7 +165,8 @@ export async function loadWidgetManifestView(
       bindings[parsedBinding.id] = parsedBinding.binding;
     }
     const capabilities = (Array.isArray(record.capabilities) ? record.capabilities : []).filter(
-      (cap): cap is WorkspaceWidgetCapability => cap === "data:read" || cap === "prompt:send",
+      (cap): cap is WorkspaceWidgetCapability =>
+        cap === "data:read" || cap === "prompt:send" || cap === "bus:pubsub",
     );
     // The approval gate hashes the manifest's declared entrypoint. Loading a
     // different file would mount code the operator never approved.
@@ -193,11 +199,13 @@ export function attachWidgetBridge(params: {
   let bridge: WidgetBridge | null = null;
   let port: MessagePort | null = null;
   let disposed = false;
+  const busConnection = context.widgetBus.connect(context.tabSlug);
 
   const createBridge = (connectedPort: MessagePort): WidgetBridge =>
     createWidgetBridge({
       manifest,
       post: (message: WidgetOutboundMessage): void => connectedPort.postMessage(message, []),
+      bus: busConnection,
       assertBindingAllowed: (bindingId) => {
         // Agent-authored frames can navigate themselves despite their sandbox/CSP.
         // Never place privileged RPC/file data in them; built-in widgets own those
@@ -270,6 +278,7 @@ export function attachWidgetBridge(params: {
     window.removeEventListener("message", onBootstrap);
     port?.close();
     bridge?.dispose();
+    busConnection.dispose();
     port = null;
     bridge = null;
   };
@@ -301,7 +310,9 @@ class CustomWidgetFrameDirective extends AsyncDirective {
       name,
       params.manifest.entrypoint,
     );
-    const nextKey = `${params.widget.id}::${assetUrl}`;
+    // A move between tabs must rebind the frame to a fresh parent-owned bus
+    // connection; retaining the old iframe would retain its previous tab identity.
+    const nextKey = `${params.context.tabSlug}::${params.widget.id}::${assetUrl}`;
     if (this.iframe && this.key === nextKey) {
       return this.iframe;
     }

--- a/ui/src/components/workspace-widget-cell.test.ts
+++ b/ui/src/components/workspace-widget-cell.test.ts
@@ -1,5 +1,6 @@
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
+import { createWorkspaceWidgetBus } from "../lib/workspace/bus.ts";
 import type { WorkspaceWidget, WidgetManifestView } from "../lib/workspace/types.ts";
 import type { BuiltinWidgetContext } from "../lib/workspace/widgets/index.ts";
 import {
@@ -216,7 +217,13 @@ function customContext(
     status: "approved",
     createdBy: "user",
     manifest: customManifest(),
-    host: { client: null, basePath: "", sessionKey: "main" },
+    host: {
+      client: null,
+      basePath: "",
+      sessionKey: "main",
+      tabSlug: "main",
+      widgetBus: createWorkspaceWidgetBus(),
+    },
     onApprove: vi.fn(),
     onReject: vi.fn(),
     ...overrides,

--- a/ui/src/lib/workspace/bridge.test.ts
+++ b/ui/src/lib/workspace/bridge.test.ts
@@ -316,6 +316,26 @@ describe("pub/sub capability + limits + cleanup", () => {
       channel: "c",
       payload: circular,
     });
+    bridge.handleMessage({
+      v: 1,
+      type: "workspace:publish",
+      channel: "c",
+      // Structured clone accepts this, but it is not JSON. JSON.stringify would
+      // misleadingly measure the 1 MiB buffer as `{}` and omit `undefined`.
+      payload: { bytes: new ArrayBuffer(1024 * 1024), omitted: undefined },
+    });
+    let deeplyNested: unknown = null;
+    for (let index = 0; index < 10_000; index += 1) {
+      deeplyNested = { value: deeplyNested };
+    }
+    expect(() =>
+      bridge.handleMessage({
+        v: 1,
+        type: "workspace:publish",
+        channel: "c",
+        payload: deeplyNested,
+      }),
+    ).not.toThrow();
     for (let index = 0; index < 61; index += 1) {
       bridge.handleMessage({ v: 1, type: "workspace:publish", channel: "c", payload: index });
     }
@@ -328,6 +348,10 @@ describe("pub/sub capability + limits + cleanup", () => {
         expect.objectContaining({ type: "workspace:error", code: "rate_limited" }),
       ]),
     );
+    expect(
+      posted.filter((message) => message.type === "workspace:error" && message.code === "malformed")
+        .length,
+    ).toBeGreaterThanOrEqual(2);
   });
 
   it("unsubscribe and dispose sever child delivery", () => {

--- a/ui/src/lib/workspace/bridge.test.ts
+++ b/ui/src/lib/workspace/bridge.test.ts
@@ -2,8 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createWidgetBridge,
   isWellFormedInbound,
+  resetBusRateStatesForTest,
   resetPromptRateStatesForTest,
   type WidgetBridgeDeps,
+  type WidgetBusBridge,
   type WidgetErrorCode,
   type WidgetOutboundMessage,
 } from "./bridge.ts";
@@ -12,6 +14,7 @@ import type { WidgetManifestView } from "./types.ts";
 beforeEach(() => {
   // Rate-limit state is module-level (keyed by widget name); reset between tests.
   resetPromptRateStatesForTest();
+  resetBusRateStatesForTest();
 });
 
 function manifest(overrides?: Partial<WidgetManifestView>): WidgetManifestView {
@@ -235,6 +238,114 @@ describe("sendPrompt capability + confirm + rate limit", () => {
     await vi.waitFor(() => expect(posted).toHaveLength(1));
     expect(posted[0]).toMatchObject({ type: "workspace:error", code: "rate_limited" });
     expect(sent).toBe(10);
+  });
+});
+
+describe("pub/sub capability + limits + cleanup", () => {
+  function fakeBus() {
+    const published: Array<{ channel: string; payload: unknown }> = [];
+    const subscriptions = new Map<string, (channel: string, payload: unknown) => void>();
+    const bus: WidgetBusBridge = {
+      publish: (channel, payload) => published.push({ channel, payload }),
+      subscribe: (channel, deliver) => {
+        subscriptions.set(channel, deliver);
+        return () => subscriptions.delete(channel);
+      },
+    };
+    return { bus, published, subscriptions };
+  }
+
+  it("brokers publish and subscribe only for an approved widget", () => {
+    const gated = fakeBus();
+    const approved = makeBridge({
+      manifest: manifest({ capabilities: ["bus:pubsub"] }),
+      bus: gated.bus,
+    });
+    approved.bridge.handleMessage({ v: 1, type: "workspace:subscribe", channel: "selection" });
+    approved.bridge.handleMessage({
+      v: 1,
+      type: "workspace:publish",
+      channel: "selection",
+      payload: { region: "eu" },
+    });
+    gated.subscriptions.get("selection")?.("selection", { region: "us" });
+    expect(gated.published).toEqual([{ channel: "selection", payload: { region: "eu" } }]);
+    expect(approved.posted).toContainEqual({
+      v: 1,
+      type: "workspace:message",
+      channel: "selection",
+      payload: { region: "us" },
+    });
+
+    const denied = fakeBus();
+    const unapproved = makeBridge({ manifest: manifest({ capabilities: [] }), bus: denied.bus });
+    unapproved.bridge.handleMessage({ v: 1, type: "workspace:subscribe", channel: "selection" });
+    unapproved.bridge.handleMessage({
+      v: 1,
+      type: "workspace:publish",
+      channel: "selection",
+      payload: 1,
+    });
+    expect(denied.subscriptions.size).toBe(0);
+    expect(denied.published).toHaveLength(0);
+    expect(unapproved.posted).toHaveLength(2);
+    expect(unapproved.posted[0]).toMatchObject({
+      type: "workspace:error",
+      code: "capability_denied",
+    });
+  });
+
+  it("rejects oversized, unserializable, and over-rate publishes", () => {
+    const { bus, published } = fakeBus();
+    const { bridge, posted } = makeBridge({
+      manifest: manifest({ name: "limited", capabilities: ["bus:pubsub"] }),
+      bus,
+      now: () => 1_000,
+    });
+    bridge.handleMessage({
+      v: 1,
+      type: "workspace:publish",
+      channel: "c",
+      payload: "x".repeat(8 * 1024 + 1),
+    });
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    bridge.handleMessage({
+      v: 1,
+      type: "workspace:publish",
+      channel: "c",
+      payload: circular,
+    });
+    for (let index = 0; index < 61; index += 1) {
+      bridge.handleMessage({ v: 1, type: "workspace:publish", channel: "c", payload: index });
+    }
+
+    expect(published).toHaveLength(60);
+    expect(posted).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "workspace:error", code: "payload_too_large" }),
+        expect.objectContaining({ type: "workspace:error", code: "malformed" }),
+        expect.objectContaining({ type: "workspace:error", code: "rate_limited" }),
+      ]),
+    );
+  });
+
+  it("unsubscribe and dispose sever child delivery", () => {
+    const { bus, subscriptions } = fakeBus();
+    const { bridge, posted } = makeBridge({
+      manifest: manifest({ capabilities: ["bus:pubsub"] }),
+      bus,
+    });
+    bridge.handleMessage({ v: 1, type: "workspace:subscribe", channel: "a" });
+    bridge.handleMessage({ v: 1, type: "workspace:subscribe", channel: "b" });
+    bridge.handleMessage({ v: 1, type: "workspace:unsubscribe", channel: "a" });
+    expect(subscriptions.has("a")).toBe(false);
+    expect(subscriptions.has("b")).toBe(true);
+
+    bridge.dispose();
+
+    expect(subscriptions.size).toBe(0);
+    expect(posted).toHaveLength(0);
   });
 });
 

--- a/ui/src/lib/workspace/bridge.test.ts
+++ b/ui/src/lib/workspace/bridge.test.ts
@@ -2,10 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createWidgetBridge,
   isWellFormedInbound,
-  resetBusRateStatesForTest,
   resetPromptRateStatesForTest,
   type WidgetBridgeDeps,
-  type WidgetBusBridge,
   type WidgetErrorCode,
   type WidgetOutboundMessage,
 } from "./bridge.ts";
@@ -14,7 +12,6 @@ import type { WidgetManifestView } from "./types.ts";
 beforeEach(() => {
   // Rate-limit state is module-level (keyed by widget name); reset between tests.
   resetPromptRateStatesForTest();
-  resetBusRateStatesForTest();
 });
 
 function manifest(overrides?: Partial<WidgetManifestView>): WidgetManifestView {
@@ -245,7 +242,7 @@ describe("pub/sub capability + limits + cleanup", () => {
   function fakeBus() {
     const published: Array<{ channel: string; payload: unknown }> = [];
     const subscriptions = new Map<string, (channel: string, payload: unknown) => void>();
-    const bus: WidgetBusBridge = {
+    const bus: NonNullable<WidgetBridgeDeps["bus"]> = {
       publish: (channel, payload) => published.push({ channel, payload }),
       subscribe: (channel, deliver) => {
         subscriptions.set(channel, deliver);

--- a/ui/src/lib/workspace/bridge.ts
+++ b/ui/src/lib/workspace/bridge.ts
@@ -50,7 +50,7 @@ export type WidgetOutboundMessage =
   | { v: 1; type: "workspace:message"; channel: string; payload: unknown }
   | { v: 1; type: "workspace:error"; requestId?: string; code: WidgetErrorCode; message: string };
 
-export type WidgetBusBridge = {
+type WidgetBusBridge = {
   publish: (channel: string, payload: unknown) => void;
   subscribe: (channel: string, deliver: (channel: string, payload: unknown) => void) => () => void;
 };
@@ -124,6 +124,7 @@ function getPromptRateState(widgetName: string): PromptRateState {
 /** Test-only: reset all persisted rate-limit budgets. */
 export function resetPromptRateStatesForTest(): void {
   promptRateStates.clear();
+  busRateStates.clear();
 }
 
 type BusRateState = { timestamps: number[] };
@@ -136,11 +137,6 @@ function getBusRateState(widgetName: string): BusRateState {
     busRateStates.set(widgetName, state);
   }
   return state;
-}
-
-/** Test-only: reset all persisted pub/sub rate-limit budgets. */
-export function resetBusRateStatesForTest(): void {
-  busRateStates.clear();
 }
 
 function isStrictJsonValue(root: unknown): boolean {

--- a/ui/src/lib/workspace/bridge.ts
+++ b/ui/src/lib/workspace/bridge.ts
@@ -14,6 +14,8 @@
 //   approved. Undeclared bindingId → `workspace:error {code:"binding_denied"}`.
 // - `sendPrompt` requires the manifest `prompt:send` capability AND an operator
 //   confirm per invocation AND a rate limit (1 in-flight, 10/min).
+// - Inter-widget pub/sub is parent-brokered and requires `bus:pubsub` for both
+//   publishing and subscribing. The host owns tab and connection identity.
 // - Parent→child posts always use targetOrigin "*" (opaque origin), carrying only
 //   binding data / theme tokens the widget is entitled to — never secrets.
 
@@ -26,7 +28,10 @@ export type WidgetInboundType =
   | "workspace:ready"
   | "workspace:getData"
   | "workspace:getTheme"
-  | "workspace:sendPrompt";
+  | "workspace:sendPrompt"
+  | "workspace:publish"
+  | "workspace:subscribe"
+  | "workspace:unsubscribe";
 
 export type WidgetErrorCode =
   | "binding_denied"
@@ -35,13 +40,20 @@ export type WidgetErrorCode =
   | "prompt_declined"
   | "timeout"
   | "resolve_failed"
+  | "payload_too_large"
   | "malformed";
 
 export type WidgetOutboundMessage =
   | { v: 1; type: "workspace:data"; requestId: string; bindingId: string; data: unknown }
   | { v: 1; type: "workspace:push"; bindingId: string; data: unknown }
   | { v: 1; type: "workspace:theme"; requestId: string; tokens: Record<string, string> }
+  | { v: 1; type: "workspace:message"; channel: string; payload: unknown }
   | { v: 1; type: "workspace:error"; requestId?: string; code: WidgetErrorCode; message: string };
+
+export type WidgetBusBridge = {
+  publish: (channel: string, payload: unknown) => void;
+  subscribe: (channel: string, deliver: (channel: string, payload: unknown) => void) => () => void;
+};
 
 /** Injected side effects — real implementations live in the browser host. */
 export type WidgetBridgeDeps = {
@@ -62,6 +74,8 @@ export type WidgetBridgeDeps = {
   sendPrompt: (text: string) => Promise<void>;
   /** Post a message to the child (host wires targetOrigin "*"). */
   post: (message: WidgetOutboundMessage) => void;
+  /** Parent-owned bus connection already bound to this widget's tab and identity. */
+  bus?: WidgetBusBridge;
   /** getData answer deadline; posts a timeout error if the resolver overruns. Default 10s. */
   getDataTimeoutMs?: number;
   /** Injectable clock for tests. */
@@ -81,6 +95,10 @@ export type WidgetBridge = {
 const DEFAULT_GET_DATA_TIMEOUT_MS = 10_000;
 const PROMPT_RATE_WINDOW_MS = 60_000;
 const PROMPT_RATE_MAX = 10;
+const BUS_PUBLISH_RATE_WINDOW_MS = 60_000;
+const BUS_PUBLISH_RATE_MAX = 60;
+const BUS_MAX_PAYLOAD_BYTES = 8 * 1024;
+const BUS_MAX_CHANNEL_LENGTH = 128;
 
 /**
  * sendPrompt rate-limit state, keyed by STABLE widget identity (the custom widget
@@ -108,11 +126,44 @@ export function resetPromptRateStatesForTest(): void {
   promptRateStates.clear();
 }
 
+type BusRateState = { timestamps: number[] };
+const busRateStates = new Map<string, BusRateState>();
+
+function getBusRateState(widgetName: string): BusRateState {
+  let state = busRateStates.get(widgetName);
+  if (!state) {
+    state = { timestamps: [] };
+    busRateStates.set(widgetName, state);
+  }
+  return state;
+}
+
+/** Test-only: reset all persisted pub/sub rate-limit budgets. */
+export function resetBusRateStatesForTest(): void {
+  busRateStates.clear();
+}
+
+function payloadByteLength(payload: unknown): number | null {
+  let json: string | undefined;
+  try {
+    json = JSON.stringify(payload);
+  } catch {
+    return null;
+  }
+  if (json === undefined) {
+    return 0;
+  }
+  return new TextEncoder().encode(json).length;
+}
+
 const INBOUND_TYPES = new Set<WidgetInboundType>([
   "workspace:ready",
   "workspace:getData",
   "workspace:getTheme",
   "workspace:sendPrompt",
+  "workspace:publish",
+  "workspace:subscribe",
+  "workspace:unsubscribe",
 ]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -146,6 +197,8 @@ export function createWidgetBridge(deps: WidgetBridgeDeps): WidgetBridge {
   // Rate-limit state is keyed by the widget NAME (stable identity), so it persists
   // across bridge re-instantiation when the iframe is recreated.
   const rateState = getPromptRateState(deps.manifest.name);
+  const busRateState = getBusRateState(deps.manifest.name);
+  const busSubscriptions = new Map<string, () => void>();
   const pendingTimers = new Set<ReturnType<typeof setTimeout>>();
 
   function error(code: WidgetErrorCode, message: string, requestId?: string): void {
@@ -245,6 +298,62 @@ export function createWidgetBridge(deps: WidgetBridgeDeps): WidgetBridge {
     }
   }
 
+  function handlePublish(channel: string, payload: unknown, requestId?: string): void {
+    if (!capabilities.has("bus:pubsub")) {
+      error("capability_denied", "widget lacks the bus:pubsub capability", requestId);
+      return;
+    }
+    if (!deps.bus) {
+      return;
+    }
+    const byteLength = payloadByteLength(payload);
+    if (byteLength === null) {
+      error("malformed", "publish payload is not serializable", requestId);
+      return;
+    }
+    if (byteLength > BUS_MAX_PAYLOAD_BYTES) {
+      error(
+        "payload_too_large",
+        `publish payload exceeds ${BUS_MAX_PAYLOAD_BYTES} bytes`,
+        requestId,
+      );
+      return;
+    }
+    const cutoff = now() - BUS_PUBLISH_RATE_WINDOW_MS;
+    busRateState.timestamps = busRateState.timestamps.filter((timestamp) => timestamp > cutoff);
+    if (busRateState.timestamps.length >= BUS_PUBLISH_RATE_MAX) {
+      error("rate_limited", "publish rate limit exceeded", requestId);
+      return;
+    }
+    busRateState.timestamps.push(now());
+    deps.bus.publish(channel, payload);
+  }
+
+  function handleSubscribe(channel: string): void {
+    if (!capabilities.has("bus:pubsub")) {
+      error("capability_denied", "widget lacks the bus:pubsub capability");
+      return;
+    }
+    if (!deps.bus || busSubscriptions.has(channel)) {
+      return;
+    }
+    const unsubscribe = deps.bus.subscribe(channel, (deliveredChannel, payload) => {
+      if (!disposed) {
+        deps.post({ v: 1, type: "workspace:message", channel: deliveredChannel, payload });
+      }
+    });
+    busSubscriptions.set(channel, unsubscribe);
+  }
+
+  function handleUnsubscribe(channel: string): void {
+    const unsubscribe = busSubscriptions.get(channel);
+    if (!unsubscribe) {
+      return;
+    }
+    busSubscriptions.delete(channel);
+    unsubscribe();
+  }
+
   function handleMessage(data: unknown): boolean {
     if (disposed) {
       return false;
@@ -285,6 +394,35 @@ export function createWidgetBridge(deps: WidgetBridgeDeps): WidgetBridge {
         void handleSendPrompt(requestId, text);
         return true;
       }
+      case "workspace:publish": {
+        const channel = typeof data.channel === "string" ? data.channel : null;
+        const requestId = typeof data.requestId === "string" ? data.requestId : undefined;
+        if (
+          channel === null ||
+          !channel.trim() ||
+          channel.length > BUS_MAX_CHANNEL_LENGTH ||
+          !Object.hasOwn(data, "payload")
+        ) {
+          dropped += 1;
+          return false;
+        }
+        handlePublish(channel, data.payload, requestId);
+        return true;
+      }
+      case "workspace:subscribe":
+      case "workspace:unsubscribe": {
+        const channel = typeof data.channel === "string" ? data.channel : null;
+        if (channel === null || !channel.trim() || channel.length > BUS_MAX_CHANNEL_LENGTH) {
+          dropped += 1;
+          return false;
+        }
+        if (data.type === "workspace:subscribe") {
+          handleSubscribe(channel);
+        } else {
+          handleUnsubscribe(channel);
+        }
+        return true;
+      }
       default:
         dropped += 1;
         return false;
@@ -323,6 +461,10 @@ export function createWidgetBridge(deps: WidgetBridgeDeps): WidgetBridge {
         clearTimeout(timer);
       }
       pendingTimers.clear();
+      for (const unsubscribe of busSubscriptions.values()) {
+        unsubscribe();
+      }
+      busSubscriptions.clear();
       // Release the in-flight lock so a remount can send again, but PRESERVE the
       // rolling-window timestamps — clearing them would reopen the very reset hole
       // this state exists to close.

--- a/ui/src/lib/workspace/bridge.ts
+++ b/ui/src/lib/workspace/bridge.ts
@@ -143,17 +143,71 @@ export function resetBusRateStatesForTest(): void {
   busRateStates.clear();
 }
 
-function payloadByteLength(payload: unknown): number | null {
+function isStrictJsonValue(root: unknown): boolean {
+  const ancestors = new Set<object>();
+  const stack: Array<{ value: unknown; exit?: boolean }> = [{ value: root }];
+  while (stack.length > 0) {
+    const frame = stack.pop()!;
+    const value = frame.value;
+    if (frame.exit) {
+      ancestors.delete(value as object);
+      continue;
+    }
+    if (
+      value === null ||
+      typeof value === "string" ||
+      typeof value === "boolean" ||
+      (typeof value === "number" && Number.isFinite(value))
+    ) {
+      continue;
+    }
+    if (typeof value !== "object" || ancestors.has(value)) {
+      return false;
+    }
+    ancestors.add(value);
+    stack.push({ value, exit: true });
+    if (Array.isArray(value)) {
+      for (let index = value.length - 1; index >= 0; index -= 1) {
+        if (!Object.hasOwn(value, index)) {
+          return false;
+        }
+        stack.push({ value: value[index] });
+      }
+      continue;
+    }
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      return false;
+    }
+    for (const key of Reflect.ownKeys(value)) {
+      if (typeof key !== "string") {
+        return false;
+      }
+      stack.push({ value: (value as Record<string, unknown>)[key] });
+    }
+  }
+  return true;
+}
+
+function normalizeJsonPayload(payload: unknown): { payload: unknown; byteLength: number } | null {
   let json: string | undefined;
   try {
+    if (!isStrictJsonValue(payload)) {
+      return null;
+    }
     json = JSON.stringify(payload);
   } catch {
     return null;
   }
   if (json === undefined) {
-    return 0;
+    return null;
   }
-  return new TextEncoder().encode(json).length;
+  return {
+    // Forward exactly the JSON value that was measured, never the richer
+    // structured-clone input supplied by hostile iframe code.
+    payload: JSON.parse(json) as unknown,
+    byteLength: new TextEncoder().encode(json).length,
+  };
 }
 
 const INBOUND_TYPES = new Set<WidgetInboundType>([
@@ -306,12 +360,12 @@ export function createWidgetBridge(deps: WidgetBridgeDeps): WidgetBridge {
     if (!deps.bus) {
       return;
     }
-    const byteLength = payloadByteLength(payload);
-    if (byteLength === null) {
+    const normalized = normalizeJsonPayload(payload);
+    if (!normalized) {
       error("malformed", "publish payload is not serializable", requestId);
       return;
     }
-    if (byteLength > BUS_MAX_PAYLOAD_BYTES) {
+    if (normalized.byteLength > BUS_MAX_PAYLOAD_BYTES) {
       error(
         "payload_too_large",
         `publish payload exceeds ${BUS_MAX_PAYLOAD_BYTES} bytes`,
@@ -326,7 +380,7 @@ export function createWidgetBridge(deps: WidgetBridgeDeps): WidgetBridge {
       return;
     }
     busRateState.timestamps.push(now());
-    deps.bus.publish(channel, payload);
+    deps.bus.publish(channel, normalized.payload);
   }
 
   function handleSubscribe(channel: string): void {

--- a/ui/src/lib/workspace/bus.test.ts
+++ b/ui/src/lib/workspace/bus.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { createWorkspaceWidgetBus } from "./bus.ts";
+
+describe("workspace widget bus", () => {
+  it("delivers only to other subscribers on the publisher's tab and channel", () => {
+    const bus = createWorkspaceWidgetBus();
+    const publisher = bus.connect("tab-a");
+    const sameTab = bus.connect("tab-a");
+    const otherTab = bus.connect("tab-b");
+    const publisherDelivery = vi.fn();
+    const sameTabDelivery = vi.fn();
+    const otherTabDelivery = vi.fn();
+
+    publisher.subscribe("selection", publisherDelivery);
+    sameTab.subscribe("selection", sameTabDelivery);
+    otherTab.subscribe("selection", otherTabDelivery);
+
+    expect(publisher.publish("selection", { region: "eu" })).toBe(1);
+    expect(publisherDelivery).not.toHaveBeenCalled();
+    expect(sameTabDelivery).toHaveBeenCalledWith("selection", { region: "eu" });
+    expect(otherTabDelivery).not.toHaveBeenCalled();
+  });
+
+  it("revokes every connection belonging to a removed tab", () => {
+    const bus = createWorkspaceWidgetBus();
+    const removedPublisher = bus.connect("removed");
+    const removedSubscriber = bus.connect("removed");
+    const keptPublisher = bus.connect("kept");
+    const keptSubscriber = bus.connect("kept");
+    const removedDelivery = vi.fn();
+    const keptDelivery = vi.fn();
+
+    removedSubscriber.subscribe("updates", removedDelivery);
+    keptSubscriber.subscribe("updates", keptDelivery);
+    bus.retainTabs(new Set(["kept"]));
+
+    expect(removedPublisher.publish("updates", 1)).toBe(0);
+    removedSubscriber.subscribe("updates", removedDelivery);
+    expect(removedPublisher.publish("updates", 2)).toBe(0);
+    expect(removedDelivery).not.toHaveBeenCalled();
+    expect(keptPublisher.publish("updates", 3)).toBe(1);
+    expect(keptDelivery).toHaveBeenCalledWith("updates", 3);
+  });
+
+  it("revokes all connections when the workspace lifecycle is disposed", () => {
+    const bus = createWorkspaceWidgetBus();
+    const publisher = bus.connect("main");
+    const subscriber = bus.connect("main");
+    const delivery = vi.fn();
+    subscriber.subscribe("updates", delivery);
+
+    bus.dispose();
+
+    expect(publisher.publish("updates", 1)).toBe(0);
+    subscriber.subscribe("updates", delivery);
+    expect(publisher.publish("updates", 2)).toBe(0);
+    expect(delivery).not.toHaveBeenCalled();
+  });
+
+  it("disconnecting a widget removes all of its subscriptions", () => {
+    const bus = createWorkspaceWidgetBus();
+    const publisher = bus.connect("main");
+    const subscriber = bus.connect("main");
+    const delivery = vi.fn();
+    subscriber.subscribe("a", delivery);
+    subscriber.subscribe("b", delivery);
+
+    subscriber.dispose();
+
+    expect(publisher.publish("a", 1)).toBe(0);
+    expect(publisher.publish("b", 2)).toBe(0);
+    expect(delivery).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/lib/workspace/bus.ts
+++ b/ui/src/lib/workspace/bus.ts
@@ -1,6 +1,6 @@
 /** Parent-owned, in-memory pub/sub for custom widgets in one Workspaces view. */
 
-export type WorkspaceWidgetBusConnection = {
+type WorkspaceWidgetBusConnection = {
   publish: (channel: string, payload: unknown) => number;
   subscribe: (channel: string, deliver: (channel: string, payload: unknown) => void) => () => void;
   dispose: () => void;

--- a/ui/src/lib/workspace/bus.ts
+++ b/ui/src/lib/workspace/bus.ts
@@ -1,0 +1,109 @@
+/** Parent-owned, in-memory pub/sub for custom widgets in one Workspaces view. */
+
+export type WorkspaceWidgetBusConnection = {
+  publish: (channel: string, payload: unknown) => number;
+  subscribe: (channel: string, deliver: (channel: string, payload: unknown) => void) => () => void;
+  dispose: () => void;
+};
+
+export type WorkspaceWidgetBus = {
+  connect: (tabSlug: string) => WorkspaceWidgetBusConnection;
+  /** Revoke connections whose tabs no longer exist in the workspace document. */
+  retainTabs: (tabSlugs: ReadonlySet<string>) => void;
+  /** Revoke every connection when the owning Workspaces view stops. */
+  dispose: () => void;
+};
+
+type ConnectionState = {
+  tabSlug: string;
+  active: boolean;
+  subscriptions: Map<string, (channel: string, payload: unknown) => void>;
+};
+
+/**
+ * Create a broker scoped to one Workspaces view. Child messages never supply a
+ * tab or subscriber id: the trusted parent closes over both in each connection.
+ */
+export function createWorkspaceWidgetBus(): WorkspaceWidgetBus {
+  const connections = new Map<number, ConnectionState>();
+  let nextConnectionId = 0;
+  let active = true;
+
+  const revoke = (connectionId: number): void => {
+    const connection = connections.get(connectionId);
+    if (!connection) {
+      return;
+    }
+    connection.active = false;
+    connection.subscriptions.clear();
+    connections.delete(connectionId);
+  };
+
+  const connect = (tabSlug: string): WorkspaceWidgetBusConnection => {
+    nextConnectionId += 1;
+    const connectionId = nextConnectionId;
+    const connection: ConnectionState = {
+      tabSlug,
+      active,
+      subscriptions: new Map(),
+    };
+    if (active) {
+      connections.set(connectionId, connection);
+    }
+
+    return {
+      publish(channel, payload) {
+        if (!active || !connection.active) {
+          return 0;
+        }
+        let delivered = 0;
+        // Snapshot before delivery so a callback can unsubscribe safely.
+        for (const [peerId, peer] of Array.from(connections.entries())) {
+          if (peerId === connectionId || !peer.active || peer.tabSlug !== connection.tabSlug) {
+            continue;
+          }
+          const deliver = peer.subscriptions.get(channel);
+          if (deliver) {
+            deliver(channel, payload);
+            delivered += 1;
+          }
+        }
+        return delivered;
+      },
+      subscribe(channel, deliver) {
+        if (!active || !connection.active) {
+          return () => {};
+        }
+        connection.subscriptions.set(channel, deliver);
+        return () => {
+          if (connection.subscriptions.get(channel) === deliver) {
+            connection.subscriptions.delete(channel);
+          }
+        };
+      },
+      dispose() {
+        revoke(connectionId);
+      },
+    };
+  };
+
+  return {
+    connect,
+    retainTabs(tabSlugs) {
+      for (const [connectionId, connection] of Array.from(connections.entries())) {
+        if (!tabSlugs.has(connection.tabSlug)) {
+          revoke(connectionId);
+        }
+      }
+    },
+    dispose() {
+      if (!active) {
+        return;
+      }
+      active = false;
+      for (const connectionId of Array.from(connections.keys())) {
+        revoke(connectionId);
+      }
+    },
+  };
+}

--- a/ui/src/lib/workspace/types.ts
+++ b/ui/src/lib/workspace/types.ts
@@ -80,7 +80,7 @@ export type WorkspaceDocument = {
 };
 
 /** Capability names a custom widget may hold (00 §2). */
-export type WorkspaceWidgetCapability = "data:read" | "prompt:send";
+export type WorkspaceWidgetCapability = "data:read" | "prompt:send" | "bus:pubsub";
 
 /**
  * The subset of a custom widget's `widget.json` manifest the parent bridge needs

--- a/ui/src/pages/plugin/workspace-view.ts
+++ b/ui/src/pages/plugin/workspace-view.ts
@@ -16,6 +16,7 @@ import {
   type WorkspaceWidgetCellCallbacks,
 } from "../../components/workspace-widget-cell.ts";
 import { t } from "../../i18n/index.ts";
+import { createWorkspaceWidgetBus, type WorkspaceWidgetBus } from "../../lib/workspace/bus.ts";
 import {
   beginDrag,
   collides,
@@ -108,6 +109,8 @@ type WorkspaceViewState = {
   dialog: WorkspaceDialogState | null;
   /** First-visit onboarding banner dismissed this session (#5); mirrors localStorage. */
   onboardingDismissed: boolean;
+  /** Parent broker owned by this view and revoked with its lifecycle. */
+  widgetBus: WorkspaceWidgetBus;
 };
 
 /** localStorage flag so the first-visit onboarding banner (#5) stays dismissed across reloads. */
@@ -208,6 +211,8 @@ function syncMenuDismiss(
 /** View-level teardown: drop any menu-dismiss listeners. Called from the controller's stop. */
 export function stopWorkspaceView(host: object): void {
   teardownMenuDismiss(host);
+  workspaceViewStates.get(host)?.widgetBus.dispose();
+  workspaceViewStates.delete(host);
 }
 
 function getViewState(host: object): WorkspaceViewState {
@@ -227,6 +232,7 @@ function getViewState(host: object): WorkspaceViewState {
       dataVersion: 0,
       dialog: null,
       onboardingDismissed: isOnboardingDismissed(),
+      widgetBus: createWorkspaceWidgetBus(),
     };
     workspaceViewStates.set(host, state);
   }
@@ -523,6 +529,7 @@ function buildCustomContext(
   viewState: WorkspaceViewState,
   workspace: WorkspaceDocument,
   widget: WorkspaceWidget,
+  tabSlug: string,
 ): WorkspaceCustomWidgetContext | null {
   const name = customWidgetName(widget.kind);
   if (!name) {
@@ -532,6 +539,8 @@ function buildCustomContext(
     client: props.client,
     basePath: props.basePath ?? "",
     sessionKey: props.sessionKey ?? "main",
+    widgetBus: viewState.widgetBus,
+    tabSlug,
   };
   const createdBy = workspace.widgetsRegistry[name]?.createdBy;
   return {
@@ -574,7 +583,7 @@ function renderGrid(
   return html`
     <div class="workspace-grid" style="min-height: ${minHeight}px" data-test-id="workspace-grid">
       ${tab.widgets.map((widget) => {
-        const custom = buildCustomContext(props, state, viewState, workspace, widget);
+        const custom = buildCustomContext(props, state, viewState, workspace, widget, tab.slug);
         return renderWidgetCell({
           widget,
           binding: viewState.bindingResults.get(widget.id) ?? null,
@@ -951,6 +960,9 @@ function renderBody(
       </div>
     `;
   }
+  // Revoke every connection from a tab removed by a document replacement before
+  // the corresponding iframe directive completes its disconnect callback.
+  viewState.widgetBus.retainTabs(new Set(workspace.tabs.map((tab) => tab.slug)));
   if (workspace.tabs.length === 0) {
     return html`
       <div class="workspace-empty workspace-empty--onboarding" data-test-id="workspace-empty">


### PR DESCRIPTION
## What Problem This Solves

Approved custom widgets could not coordinate within a workspace tab. A filter widget could not drive a chart or table without introducing gateway persistence or cross-tab reach.

## Why This Change Was Made

This rebuild ports the original #101841 feature delta onto the Workspaces architecture landed by #104139. It adds a parent-owned, in-memory broker and a `bus:pubsub` manifest capability. The host binds every connection to the rendered tab and widget identity; iframe messages can provide only a channel and strict JSON payload.

The rebuild also closes the old payload-limit bypass: values are validated as strict JSON, normalized before fanout, capped at 8 KiB on the exact forwarded representation, and rate-limited to 60 publishes per minute. Structured-clone-only values such as `ArrayBuffer`, cycles, and unsupported JSON values are rejected.

## User Impact

- Widgets on the same tab can publish and subscribe to shared channels.
- Messages never cross tabs and never echo to the publisher.
- Removing a widget or tab, moving a widget, or closing Workspaces tears down or rebinds its broker connection.
- No gateway method, persistent store, dependency, or network permission is added.

## Evidence

- Rebased onto upstream main at `843e3c787806389cdaac884300e671fba658dab6` during the final recovery pass; all three commits range-diff identically while preserving current main's private capability constant and adding `bus:pubsub`.
- Final-head focused Vitest: 26 extension + 65 UI tests passed (manifest, bridge, bus, iframe host, and workspace view).
- Final-head extension/UI/UI-test TypeScript checks, scoped formatting, oxlint, and `git diff --check` passed.
- Independent adversarial review found the structured-clone size bypass; the regression was fixed and covered.
- Repository autoreview rerun after the fix: clean, no accepted/actionable findings.

Closes #101147.
