### PR TITLE
Add Claw artifact provenance preview

### DIFF
--- a/src/claws/artifacts.ts
+++ b/src/claws/artifacts.ts
@@ -1,0 +1,124 @@
+// Read-only Claw artifact selector and provenance preview helpers.
+import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
+import { isImmutableGitCommitRef, parseGitPluginSpec } from "../infra/git-plugin-spec.js";
+import { isExactSemverVersion, parseRegistryNpmSpec } from "../infra/npm-registry-spec.js";
+import {
+  parseNpmPackPrefixPath,
+  resolveFileNpmSpecToLocalPath,
+} from "../infra/plugin-install-specs.js";
+import type {
+  ClawArtifactInstallSurface,
+  ClawArtifactPreview,
+  ClawArtifactProvenanceRecord,
+  ClawArtifactSource,
+  ClawPackageEntry,
+} from "./types.js";
+
+type ParsedSelector = {
+  source: ClawArtifactSource;
+  packageName?: string;
+  version?: string;
+  pinned?: boolean;
+  supported: boolean;
+};
+
+const INSTALL_SURFACE_BY_KIND: Record<ClawPackageEntry["kind"], ClawArtifactInstallSurface> = {
+  skill: "skills",
+  plugin: "plugins",
+  mcpServer: "mcpServers",
+  connector: "connectors",
+};
+
+const PROVENANCE_RECORD_BY_KIND: Record<ClawPackageEntry["kind"], ClawArtifactProvenanceRecord> = {
+  skill: "skill.clawhubOrigin",
+  plugin: "plugin.installRecord",
+  mcpServer: "mcpServer.installRecord",
+  connector: "connector.installRecord",
+};
+
+function isAbsoluteLocalPath(selector: string): boolean {
+  return (
+    selector.startsWith("/") || /^[A-Za-z]:[\\/]/.test(selector) || selector.startsWith("\\\\")
+  );
+}
+
+function parseArtifactSelector(selector: string): ParsedSelector {
+  const clawHub = parseClawHubPluginSpec(selector);
+  if (clawHub) {
+    return {
+      source: "clawhub",
+      packageName: clawHub.name,
+      ...(clawHub.version ? { version: clawHub.version } : {}),
+      pinned: clawHub.version ? isExactSemverVersion(clawHub.version) : false,
+      supported: true,
+    };
+  }
+  if (selector.trim().toLowerCase().startsWith("clawhub:")) {
+    return { source: "clawhub", supported: false };
+  }
+
+  if (selector.trim().toLowerCase().startsWith("npm:")) {
+    const spec = selector.trim().slice("npm:".length).trim();
+    const npm = parseRegistryNpmSpec(spec);
+    return npm
+      ? {
+          source: "npm",
+          packageName: npm.name,
+          ...(npm.selector ? { version: npm.selector } : {}),
+          pinned: npm.selectorKind === "exact-version",
+          supported: true,
+        }
+      : { source: "npm", supported: false };
+  }
+
+  const npmPackPath = parseNpmPackPrefixPath(selector);
+  if (npmPackPath !== null) {
+    return { source: "npmPack", supported: npmPackPath.length > 0 };
+  }
+
+  if (selector.trim().toLowerCase().startsWith("git:")) {
+    const git = parseGitPluginSpec(selector);
+    return {
+      source: "git",
+      ...(git?.ref ? { version: git.ref } : {}),
+      pinned: git?.ref ? isImmutableGitCommitRef(git.ref) : false,
+      supported: git !== null,
+    };
+  }
+  if (selector.trim().toLowerCase().startsWith("git+")) {
+    return { source: "git", supported: false };
+  }
+
+  const fileSpec = resolveFileNpmSpecToLocalPath(selector);
+  if (fileSpec !== null) {
+    return { source: "path", supported: fileSpec.ok };
+  }
+  if (selector.startsWith("./") || selector.startsWith("../") || isAbsoluteLocalPath(selector)) {
+    return { source: "path", supported: true };
+  }
+  return { source: "unknown", supported: false };
+}
+
+function pinningFor(parsed: ParsedSelector): ClawArtifactPreview["provenance"]["pinning"] {
+  if (!parsed.supported) {
+    return "unknown";
+  }
+  return parsed.pinned ? "pinned" : "floating";
+}
+
+export function buildClawArtifactPreview(entry: ClawPackageEntry): ClawArtifactPreview {
+  const parsed = parseArtifactSelector(entry.selector);
+  return {
+    source: parsed.source,
+    selector: entry.selector,
+    installSurface: INSTALL_SURFACE_BY_KIND[entry.kind],
+    ...(parsed.packageName ? { packageName: parsed.packageName } : {}),
+    ...(parsed.version ? { version: parsed.version } : {}),
+    provenance: {
+      record: PROVENANCE_RECORD_BY_KIND[entry.kind],
+      requestedSpecifier: entry.selector,
+      pinning: pinningFor(parsed),
+    },
+    supported: parsed.supported,
+  };
+}

--- a/src/claws/plan.ts
+++ b/src/claws/plan.ts
@@ -1,4 +1,5 @@
 // Builds the first read-only claw lifecycle plan.
+import { buildClawArtifactPreview } from "./artifacts.js";
 import {
   CLAW_PLAN_SCHEMA_VERSION,
   type ClawDiagnostic,
@@ -27,11 +28,28 @@ function entrySource(entry: ClawManifest["entries"][number]): string | undefined
 }
 
 function planKnownEntry(entry: ClawManifest["entries"][number]): ClawPlanEntry {
+  const required = entry.required ?? true;
+
+  if ("selector" in entry) {
+    const artifact = buildClawArtifactPreview(entry);
+    return {
+      id: entry.id,
+      kind: entry.kind,
+      required,
+      decision: artifact.supported ? "inspectOnly" : "blockedUnsupported",
+      target: entryTarget(entry),
+      artifact,
+      reason: artifact.supported
+        ? `This entry can be resolved by a future installer through the ${artifact.installSurface} install surface; this PR previews artifact and provenance metadata only.`
+        : "This package selector is not supported by the artifact preview and would block a future installer until rewritten.",
+    };
+  }
+
   const requiresConsent = CONSENT_KINDS.has(entry.kind);
   return {
     id: entry.id,
     kind: entry.kind,
-    required: entry.required ?? true,
+    required,
     decision: requiresConsent ? "requiresConsent" : "inspectOnly",
     target: entryTarget(entry),
     source: entrySource(entry),
@@ -60,6 +78,7 @@ export function buildClawPlan(params: {
   const entries = [...knownEntries, ...unknownEntries];
   const optionalEntries = entries.filter((entry) => !entry.required).length;
   const requiresConsent = entries.filter((entry) => entry.decision === "requiresConsent").length;
+  const unsupportedEntries = entries.filter((entry) => entry.decision === "blockedUnsupported");
 
   return {
     schemaVersion: CLAW_PLAN_SCHEMA_VERSION,
@@ -75,7 +94,8 @@ export function buildClawPlan(params: {
       requiredEntries: entries.length - optionalEntries,
       optionalEntries,
       requiresConsent,
-      unsupportedOptionalEntries: unknownEntries.length,
+      unsupportedRequiredEntries: unsupportedEntries.filter((entry) => entry.required).length,
+      unsupportedOptionalEntries: unsupportedEntries.filter((entry) => !entry.required).length,
     },
     entries,
     diagnostics: params.diagnostics ?? [],

--- a/src/claws/schema.test.ts
+++ b/src/claws/schema.test.ts
@@ -68,7 +68,6 @@ describe("parseClawManifest", () => {
     ]);
   });
 
-
   it("fails unknown top-level manifest keys", () => {
     const result = parseClawManifest({
       ...baseManifest,
@@ -165,6 +164,254 @@ describe("parseClawManifest", () => {
 });
 
 describe("buildClawPlan", () => {
+  it("adds package artifact and provenance previews", () => {
+    const parsed = parseClawManifest({
+      ...baseManifest,
+      entries: [
+        {
+          kind: "skill",
+          id: "sec-filings",
+          selector: "clawhub:sec-filings@1.0.0",
+        },
+        {
+          kind: "plugin",
+          id: "terminal-plugin",
+          selector: "npm:@openclaw/plugin-terminal@2.0.0+build.5",
+        },
+        {
+          kind: "plugin",
+          id: "packed-plugin",
+          selector: "npm-pack:dist/plugin.tgz",
+        },
+        {
+          kind: "plugin",
+          id: "tagged-plugin",
+          selector: "npm:tagged-plugin@beta",
+        },
+        {
+          kind: "plugin",
+          id: "git-plugin",
+          selector: "git:github.com/acme/demo#0123456789abcdef0123456789abcdef01234567",
+        },
+        {
+          kind: "plugin",
+          id: "file-plugin",
+          selector: "file:///tmp/openclaw-plugin",
+        },
+      ],
+    });
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) {
+      throw new Error("expected manifest to parse");
+    }
+
+    const plan = buildClawPlan({ manifest: parsed.manifest, sourcePath: "/tmp/claw.json" });
+
+    expect(plan.summary).toMatchObject({
+      totalEntries: 6,
+      unsupportedRequiredEntries: 0,
+      unsupportedOptionalEntries: 0,
+    });
+    expect(plan.entries[0]).toMatchObject({
+      id: "sec-filings",
+      decision: "inspectOnly",
+      artifact: {
+        source: "clawhub",
+        installSurface: "skills",
+        packageName: "sec-filings",
+        version: "1.0.0",
+        provenance: {
+          record: "skill.clawhubOrigin",
+          requestedSpecifier: "clawhub:sec-filings@1.0.0",
+          pinning: "pinned",
+        },
+        supported: true,
+      },
+    });
+    expect(plan.entries[1]).toMatchObject({
+      id: "terminal-plugin",
+      artifact: {
+        source: "npm",
+        installSurface: "plugins",
+        packageName: "@openclaw/plugin-terminal",
+        version: "2.0.0+build.5",
+        provenance: { record: "plugin.installRecord" },
+      },
+    });
+    expect(plan.entries[2]).toMatchObject({
+      id: "packed-plugin",
+      decision: "inspectOnly",
+      artifact: {
+        source: "npmPack",
+        selector: "npm-pack:dist/plugin.tgz",
+        installSurface: "plugins",
+        supported: true,
+      },
+    });
+    expect(plan.entries[3]).toMatchObject({
+      id: "tagged-plugin",
+      artifact: {
+        source: "npm",
+        packageName: "tagged-plugin",
+        version: "beta",
+        provenance: { pinning: "floating" },
+        supported: true,
+      },
+    });
+    expect(plan.entries[4]).toMatchObject({
+      id: "git-plugin",
+      artifact: {
+        source: "git",
+        version: "0123456789abcdef0123456789abcdef01234567",
+        provenance: { pinning: "pinned" },
+        supported: true,
+      },
+    });
+    expect(plan.entries[5]).toMatchObject({
+      id: "file-plugin",
+      artifact: {
+        source: "path",
+        selector: "file:///tmp/openclaw-plugin",
+        supported: true,
+      },
+    });
+  });
+
+  it("previews absolute local package selectors as path artifacts", () => {
+    const parsed = parseClawManifest({
+      ...baseManifest,
+      entries: [
+        {
+          kind: "plugin",
+          id: "absolute-posix-plugin",
+          selector: "/tmp/openclaw-plugin",
+        },
+        {
+          kind: "plugin",
+          id: "absolute-windows-plugin",
+          selector: "C:/tmp/openclaw-plugin",
+        },
+      ],
+    });
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) {
+      throw new Error("expected manifest to parse");
+    }
+
+    const plan = buildClawPlan({ manifest: parsed.manifest });
+
+    expect(plan.summary).toMatchObject({
+      totalEntries: 2,
+      unsupportedRequiredEntries: 0,
+    });
+    expect(plan.entries.map((entry) => entry.artifact)).toEqual([
+      expect.objectContaining({
+        source: "path",
+        selector: "/tmp/openclaw-plugin",
+        installSurface: "plugins",
+        supported: true,
+      }),
+      expect.objectContaining({
+        source: "path",
+        selector: "C:/tmp/openclaw-plugin",
+        installSurface: "plugins",
+        supported: true,
+      }),
+    ]);
+  });
+
+  it("blocks trailing-at package selectors in the read-only plan", () => {
+    const parsed = parseClawManifest({
+      ...baseManifest,
+      entries: [
+        {
+          kind: "skill",
+          id: "bad-skill",
+          selector: "clawhub:demo@",
+        },
+        {
+          kind: "plugin",
+          id: "bad-plugin",
+          selector: "npm:demo@",
+        },
+        {
+          kind: "plugin",
+          id: "bad-git",
+          selector: "git:",
+        },
+        {
+          kind: "plugin",
+          id: "bad-git-plus",
+          selector: "git+",
+        },
+        {
+          kind: "plugin",
+          id: "bad-git-plus-url",
+          selector: "git+ssh://github.com/acme/demo.git",
+        },
+        {
+          kind: "plugin",
+          id: "bad-file",
+          selector: "file:",
+        },
+        {
+          kind: "plugin",
+          id: "bad-hosted-file",
+          selector: "file://example.com/demo.tgz",
+        },
+      ],
+    });
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) {
+      throw new Error("expected manifest to parse");
+    }
+
+    const plan = buildClawPlan({ manifest: parsed.manifest });
+
+    expect(plan.summary).toMatchObject({ unsupportedRequiredEntries: 7 });
+    expect(plan.entries.map((entry) => entry.artifact?.supported)).toEqual([
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+    ]);
+  });
+
+  it("blocks unsupported package selectors in the read-only plan", () => {
+    const parsed = parseClawManifest({
+      ...baseManifest,
+      entries: [
+        {
+          kind: "plugin",
+          id: "bad-plugin",
+          selector: "registry.example.com/plugin.tgz",
+        },
+      ],
+    });
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) {
+      throw new Error("expected manifest to parse");
+    }
+
+    const plan = buildClawPlan({ manifest: parsed.manifest });
+
+    expect(plan.summary).toMatchObject({
+      unsupportedRequiredEntries: 1,
+      unsupportedOptionalEntries: 0,
+    });
+    expect(plan.entries[0]).toMatchObject({
+      decision: "blockedUnsupported",
+      artifact: { source: "unknown", supported: false },
+    });
+  });
+
   it("marks workspace and automation entries as future consent points", () => {
     const parsed = parseClawManifest({
       ...baseManifest,

--- a/src/claws/types.ts
+++ b/src/claws/types.ts
@@ -145,10 +145,31 @@ export type ClawReadResult =
       diagnostics: ClawDiagnostic[];
     };
 
-export type ClawPlanEntryDecision =
-  | "inspectOnly"
-  | "requiresConsent"
-  | "blockedUnsupported";
+export type ClawPlanEntryDecision = "inspectOnly" | "requiresConsent" | "blockedUnsupported";
+
+export type ClawArtifactSource = "clawhub" | "npm" | "npmPack" | "git" | "path" | "unknown";
+
+export type ClawArtifactInstallSurface = "skills" | "plugins" | "mcpServers" | "connectors";
+
+export type ClawArtifactProvenanceRecord =
+  | "skill.clawhubOrigin"
+  | "plugin.installRecord"
+  | "mcpServer.installRecord"
+  | "connector.installRecord";
+
+export type ClawArtifactPreview = {
+  source: ClawArtifactSource;
+  selector: string;
+  installSurface: ClawArtifactInstallSurface;
+  packageName?: string;
+  version?: string;
+  provenance: {
+    record: ClawArtifactProvenanceRecord;
+    requestedSpecifier: string;
+    pinning: "pinned" | "floating" | "unknown";
+  };
+  supported: boolean;
+};
 
 export type ClawPlanEntry = {
   id: string;
@@ -157,6 +178,7 @@ export type ClawPlanEntry = {
   decision: ClawPlanEntryDecision;
   target?: string;
   source?: string;
+  artifact?: ClawArtifactPreview;
   reason: string;
 };
 
@@ -174,6 +196,7 @@ export type ClawPlan = {
     requiredEntries: number;
     optionalEntries: number;
     requiresConsent: number;
+    unsupportedRequiredEntries: number;
     unsupportedOptionalEntries: number;
   };
   entries: ClawPlanEntry[];

--- a/src/cli/claws-cli.runtime.ts
+++ b/src/cli/claws-cli.runtime.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { readClawFeedFile, readClawManifestFromFeed } from "../claws/feed.js";
 import { buildClawPlan } from "../claws/plan.js";
 import { readClawManifestFile } from "../claws/reader.js";
+import type { ClawPlan } from "../claws/types.js";
 import { defaultRuntime, writeRuntimeJson, type RuntimeEnv } from "../runtime.js";
 import type {
   ClawsFeedInspectOptions,
@@ -20,6 +21,18 @@ function formatDiagnostics(diagnostics: DiagnosticLike[]): string {
         `${diagnostic.level.toUpperCase()} ${diagnostic.code} ${diagnostic.path}: ${diagnostic.message}`,
     )
     .join("\n");
+}
+
+function logClawPlanSummary(plan: ClawPlan, runtime: RuntimeEnv): void {
+  runtime.log("Read-only: true");
+  runtime.log(`Entries: ${plan.summary.totalEntries}`);
+  runtime.log(`Requires consent later: ${plan.summary.requiresConsent}`);
+  if (plan.summary.unsupportedRequiredEntries > 0) {
+    runtime.log(`Unsupported required entries: ${plan.summary.unsupportedRequiredEntries}`);
+  }
+  if (plan.summary.unsupportedOptionalEntries > 0) {
+    runtime.log(`Unsupported optional entries: ${plan.summary.unsupportedOptionalEntries}`);
+  }
 }
 
 export async function runClawsInspectCommand(
@@ -88,12 +101,7 @@ export async function runClawsPlanCommand(
   }
 
   runtime.log(`Claw plan: ${plan.claw.name} (${plan.claw.id}@${plan.claw.version})`);
-  runtime.log("Read-only: true");
-  runtime.log(`Entries: ${plan.summary.totalEntries}`);
-  runtime.log(`Requires consent later: ${plan.summary.requiresConsent}`);
-  if (plan.summary.unsupportedOptionalEntries > 0) {
-    runtime.log(`Unsupported optional entries: ${plan.summary.unsupportedOptionalEntries}`);
-  }
+  logClawPlanSummary(plan, runtime);
 }
 
 export async function runClawsFeedInspectCommand(
@@ -170,12 +178,7 @@ export async function runClawsFeedPlanCommand(
 
   runtime.log(`Claw plan: ${plan.claw.name} (${plan.claw.id}@${plan.claw.version})`);
   runtime.log(`Feed: ${result.feed.name} (${result.feed.id})`);
-  runtime.log("Read-only: true");
-  runtime.log(`Entries: ${plan.summary.totalEntries}`);
-  runtime.log(`Requires consent later: ${plan.summary.requiresConsent}`);
-  if (plan.summary.unsupportedOptionalEntries > 0) {
-    runtime.log(`Unsupported optional entries: ${plan.summary.unsupportedOptionalEntries}`);
-  }
+  logClawPlanSummary(plan, runtime);
   if (result.diagnostics.length > 0) {
     runtime.log(formatDiagnostics(result.diagnostics));
   }

--- a/src/cli/claws-cli.test.ts
+++ b/src/cli/claws-cli.test.ts
@@ -45,38 +45,34 @@ async function writeFeedWorkspace(params?: {
   manifest?: unknown;
 }): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), "openclaw-claws-cli-feed-"));
-  const manifest =
-    params?.manifest ??
-    {
-      schemaVersion: "openclaw.claw.v1",
-      id: "starter",
-      name: "Starter",
-      version: "1.0.0",
-      entries: [
-        {
-          kind: "workspaceFile",
-          id: "soul",
-          path: "SOUL.md",
-          source: "files/SOUL.md",
-        },
-      ],
-    };
-  const feed =
-    params?.feed ??
-    {
-      schemaVersion: "openclaw.clawFeed.v1",
-      id: "local-starters",
-      name: "Local Starters",
-      entries: [
-        {
-          id: "starter",
-          name: "Starter",
-          version: "1.0.0",
-          source: "starter.claw.json",
-          owner: { type: "publisher", id: "openclaw.examples" },
-        },
-      ],
-    };
+  const manifest = params?.manifest ?? {
+    schemaVersion: "openclaw.claw.v1",
+    id: "starter",
+    name: "Starter",
+    version: "1.0.0",
+    entries: [
+      {
+        kind: "workspaceFile",
+        id: "soul",
+        path: "SOUL.md",
+        source: "files/SOUL.md",
+      },
+    ],
+  };
+  const feed = params?.feed ?? {
+    schemaVersion: "openclaw.clawFeed.v1",
+    id: "local-starters",
+    name: "Local Starters",
+    entries: [
+      {
+        id: "starter",
+        name: "Starter",
+        version: "1.0.0",
+        source: "starter.claw.json",
+        owner: { type: "publisher", id: "openclaw.examples" },
+      },
+    ],
+  };
   await writeFile(join(dir, "starter.claw.json"), JSON.stringify(manifest), "utf8");
   const feedPath = join(dir, "claws.feed.json");
   await writeFile(feedPath, JSON.stringify(feed), "utf8");
@@ -158,6 +154,48 @@ describe("claws cli", () => {
       summary: { totalEntries: 1, requiresConsent: 1 },
       entries: [{ id: "soul", decision: "requiresConsent" }],
     });
+  });
+
+  it("prints unsupported required entries in local text plans", async () => {
+    const manifestPath = await writeManifest({
+      schemaVersion: "openclaw.claw.v1",
+      id: "starter",
+      name: "Starter",
+      version: "1.0.0",
+      entries: [
+        {
+          kind: "plugin",
+          id: "bad-plugin",
+          selector: "registry.example.com/plugin.tgz",
+        },
+      ],
+    });
+
+    await runCli(["claws", "plan", manifestPath]);
+
+    expect(mocks.logs).toContain("Unsupported required entries: 1");
+  });
+
+  it("prints unsupported required entries in feed text plans", async () => {
+    const feedPath = await writeFeedWorkspace({
+      manifest: {
+        schemaVersion: "openclaw.claw.v1",
+        id: "starter",
+        name: "Starter",
+        version: "1.0.0",
+        entries: [
+          {
+            kind: "plugin",
+            id: "bad-plugin",
+            selector: "registry.example.com/plugin.tgz",
+          },
+        ],
+      },
+    });
+
+    await runCli(["claws", "feed", "plan", feedPath, "starter"]);
+
+    expect(mocks.logs).toContain("Unsupported required entries: 1");
   });
 
   it("prints JSON inspection for a local claw feed", async () => {

--- a/src/cli/plugins-command-helpers.ts
+++ b/src/cli/plugins-command-helpers.ts
@@ -3,6 +3,11 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { theme } from "../../packages/terminal-core/src/theme.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { HOOK_INSTALL_ERROR_CODE } from "../hooks/install.js";
+import {
+  parseNpmPackPrefixPath,
+  parseNpmPrefixSpec,
+  resolveFileNpmSpecToLocalPath,
+} from "../infra/plugin-install-specs.js";
 import type { PluginKind } from "../plugins/plugin-kind.types.js";
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { applyExclusiveSlotSelection } from "../plugins/slots.js";
@@ -64,31 +69,7 @@ function buildSlotSelectionRegistry(
   };
 }
 
-export function resolveFileNpmSpecToLocalPath(
-  raw: string,
-): { ok: true; path: string } | { ok: false; error: string } | null {
-  const trimmed = raw.trim();
-  if (!normalizeLowercaseStringOrEmpty(trimmed).startsWith("file:")) {
-    return null;
-  }
-  const rest = trimmed.slice("file:".length);
-  if (!rest) {
-    return { ok: false, error: "unsupported file: spec: missing path" };
-  }
-  if (rest.startsWith("///")) {
-    return { ok: true, path: rest.slice(2) };
-  }
-  if (rest.startsWith("//localhost/")) {
-    return { ok: true, path: rest.slice("//localhost".length) };
-  }
-  if (rest.startsWith("//")) {
-    return {
-      ok: false,
-      error: 'unsupported file: URL host (expected "file:<path>" or "file:///abs/path")',
-    };
-  }
-  return { ok: true, path: rest };
-}
+export { parseNpmPackPrefixPath, parseNpmPrefixSpec, resolveFileNpmSpecToLocalPath };
 
 export function applySlotSelectionForPlugin(
   config: OpenClawConfig,
@@ -218,20 +199,4 @@ export function logSlotWarnings(warnings: string[], runtime: RuntimeEnv = defaul
   for (const warning of warnings) {
     runtime.log(theme.warn(warning));
   }
-}
-
-export function parseNpmPrefixSpec(raw: string): string | null {
-  const trimmed = raw.trim();
-  if (!normalizeLowercaseStringOrEmpty(trimmed).startsWith("npm:")) {
-    return null;
-  }
-  return trimmed.slice("npm:".length).trim();
-}
-
-export function parseNpmPackPrefixPath(raw: string): string | null {
-  const trimmed = raw.trim();
-  if (!normalizeLowercaseStringOrEmpty(trimmed).startsWith("npm-pack:")) {
-    return null;
-  }
-  return trimmed.slice("npm-pack:".length).trim();
 }

--- a/src/infra/git-plugin-spec.ts
+++ b/src/infra/git-plugin-spec.ts
@@ -1,0 +1,178 @@
+// Shared Git plugin install spec parser.
+import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { resolveHomeRelativePath } from "./home-dir.js";
+
+const GIT_SPEC_PREFIX = "git:";
+const FULL_GIT_COMMIT_PATTERN = /^[0-9a-f]{40}$/i;
+
+/** Resolved Git source metadata persisted into plugin install records. */
+export type GitPluginResolution = {
+  url: string;
+  ref?: string;
+  commit?: string;
+  resolvedAt: string;
+};
+
+/** Normalized Git plugin install spec accepted by the Git installer. */
+export type ParsedGitPluginSpec = {
+  input: string;
+  url: string;
+  ref?: string;
+  label: string;
+  normalizedSpec: string;
+};
+
+/** Returns true for full commit SHAs that do not require branch/tag drift checks. */
+export function isImmutableGitCommitRef(ref: string | undefined): boolean {
+  return FULL_GIT_COMMIT_PATTERN.test(ref ?? "");
+}
+
+function splitGitSpecRef(input: string): { base: string; ref?: string } {
+  const hashIndex = input.lastIndexOf("#");
+  if (hashIndex > 0) {
+    return {
+      base: input.slice(0, hashIndex),
+      ref: normalizeOptionalString(input.slice(hashIndex + 1)),
+    };
+  }
+
+  for (
+    let atIndex = input.lastIndexOf("@");
+    atIndex > 0;
+    atIndex = input.lastIndexOf("@", atIndex - 1)
+  ) {
+    const base = input.slice(0, atIndex);
+    const ref = normalizeOptionalString(input.slice(atIndex + 1));
+    if (ref && isGitSpecBase(base)) {
+      return { base, ref };
+    }
+  }
+
+  return { base: input };
+}
+
+function isGitSpecBase(value: string): boolean {
+  return (
+    looksLikeGitHubRepoShorthand(value) ||
+    looksLikeGitHubHostPath(value) ||
+    looksLikeUrlGitSpecBase(value) ||
+    looksLikeScpGitUrl(value) ||
+    value.endsWith(".git") ||
+    value.startsWith("./") ||
+    value.startsWith("../") ||
+    value.startsWith("~/")
+  );
+}
+
+function looksLikeGitHubRepoShorthand(value: string): boolean {
+  return /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\.git)?$/.test(value);
+}
+
+function looksLikeGitHubHostPath(value: string): boolean {
+  return /^github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\.git)?$/i.test(value);
+}
+
+function isGitUrl(value: string): boolean {
+  return (
+    /^(?:ssh|git|file):\/\//i.test(value) || looksLikeScpGitUrl(value) || value.endsWith(".git")
+  );
+}
+
+function looksLikeScpGitUrl(value: string): boolean {
+  return /^[^@\s]+@[^:\s]+:.+/.test(value);
+}
+
+function looksLikeUrlGitSpecBase(value: string): boolean {
+  try {
+    const url = new URL(value);
+    if (!["http:", "https:", "ssh:", "git:", "file:"].includes(url.protocol)) {
+      return false;
+    }
+    if (url.protocol === "file:") {
+      return url.pathname.length > 1;
+    }
+    return Boolean(url.hostname) && url.pathname.length > 1;
+  } catch {
+    return false;
+  }
+}
+
+function stripGitSuffix(value: string): string {
+  return value.replace(/\.git$/i, "");
+}
+
+function normalizeGitHubRepo(value: string): { url: string; label: string } {
+  const repo = stripGitSuffix(value.replace(/^github\.com\//i, ""));
+  return {
+    url: `https://github.com/${repo}.git`,
+    label: repo,
+  };
+}
+
+function resolveLocalGitPath(value: string): string {
+  return resolveHomeRelativePath(value);
+}
+
+function normalizeGitLabel(value: string): string {
+  if (hasHttpUrlPrefix(value) || /^(?:ssh|git|file):\/\//i.test(value)) {
+    try {
+      const url = new URL(value);
+      return stripGitSuffix(`${url.hostname}${url.pathname}`).replace(/^\/+/, "");
+    } catch {
+      return stripGitSuffix(value);
+    }
+  }
+  return stripGitSuffix(value);
+}
+
+export function parseGitPluginSpec(raw: string): ParsedGitPluginSpec | null {
+  const trimmed = raw.trim();
+  if (!trimmed.toLowerCase().startsWith(GIT_SPEC_PREFIX)) {
+    return null;
+  }
+
+  const body = trimmed.slice(GIT_SPEC_PREFIX.length).trim();
+  if (!body) {
+    return null;
+  }
+
+  const split = splitGitSpecRef(body);
+  const base = split.base.trim();
+  if (!base) {
+    return null;
+  }
+
+  if (looksLikeGitHubRepoShorthand(base) || looksLikeGitHubHostPath(base)) {
+    const normalized = normalizeGitHubRepo(base);
+    return {
+      input: trimmed,
+      url: normalized.url,
+      ref: split.ref,
+      label: normalized.label,
+      normalizedSpec: `${GIT_SPEC_PREFIX}${normalized.url}${split.ref ? `@${split.ref}` : ""}`,
+    };
+  }
+
+  if (
+    hasHttpUrlPrefix(base) ||
+    isGitUrl(base) ||
+    base.startsWith("./") ||
+    base.startsWith("../") ||
+    base.startsWith("~/")
+  ) {
+    const url =
+      base.startsWith("./") || base.startsWith("../") || base.startsWith("~/")
+        ? resolveLocalGitPath(base)
+        : base;
+    return {
+      input: trimmed,
+      url,
+      ref: split.ref,
+      label: normalizeGitLabel(url),
+      normalizedSpec: `${GIT_SPEC_PREFIX}${url}${split.ref ? `@${split.ref}` : ""}`,
+    };
+  }
+
+  return null;
+}

--- a/src/infra/plugin-install-specs.ts
+++ b/src/infra/plugin-install-specs.ts
@@ -1,0 +1,44 @@
+// Shared plugin install selector parsing helpers.
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+
+export function resolveFileNpmSpecToLocalPath(
+  raw: string,
+): { ok: true; path: string } | { ok: false; error: string } | null {
+  const trimmed = raw.trim();
+  if (!normalizeLowercaseStringOrEmpty(trimmed).startsWith("file:")) {
+    return null;
+  }
+  const rest = trimmed.slice("file:".length);
+  if (!rest) {
+    return { ok: false, error: "unsupported file: spec: missing path" };
+  }
+  if (rest.startsWith("///")) {
+    return { ok: true, path: rest.slice(2) };
+  }
+  if (rest.startsWith("//localhost/")) {
+    return { ok: true, path: rest.slice("//localhost".length) };
+  }
+  if (rest.startsWith("//")) {
+    return {
+      ok: false,
+      error: 'unsupported file: URL host (expected "file:<path>" or "file:///abs/path")',
+    };
+  }
+  return { ok: true, path: rest };
+}
+
+export function parseNpmPrefixSpec(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!normalizeLowercaseStringOrEmpty(trimmed).startsWith("npm:")) {
+    return null;
+  }
+  return trimmed.slice("npm:".length).trim();
+}
+
+export function parseNpmPackPrefixPath(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!normalizeLowercaseStringOrEmpty(trimmed).startsWith("npm-pack:")) {
+    return null;
+  }
+  return trimmed.slice("npm-pack:".length).trim();
+}

--- a/src/plugins/git-install.test.ts
+++ b/src/plugins/git-install.test.ts
@@ -129,6 +129,21 @@ describe("parseGitPluginSpec", () => {
     expect(parsed.ref).toBe("feature/foo");
     expect(parsed.label).toBe("git@github.com:acme/demo");
   });
+
+  it("resolves home-relative local specs against OPENCLAW_HOME", () => {
+    const previous = process.env.OPENCLAW_HOME;
+    process.env.OPENCLAW_HOME = "/tmp/openclaw-home";
+    try {
+      const parsed = expectParsedGitSpec("git:~/plugins/demo.git");
+      expect(parsed.url).toBe(path.resolve("/tmp/openclaw-home/plugins/demo.git"));
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCLAW_HOME;
+      } else {
+        process.env.OPENCLAW_HOME = previous;
+      }
+    }
+  });
 });
 
 describe("isImmutableGitCommitRef", () => {

--- a/src/plugins/git-install.ts
+++ b/src/plugins/git-install.ts
@@ -3,7 +3,6 @@ import "../infra/fs-safe-defaults.js";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
-import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { sha256HexPrefix } from "../infra/crypto-digest.js";
@@ -33,185 +32,29 @@ import {
   pluginAuditOutcomeForReason,
 } from "./security-events.js";
 
-const GIT_SPEC_PREFIX = "git:";
 const DEFAULT_GIT_TIMEOUT_MS = 120_000;
-const FULL_GIT_COMMIT_PATTERN = /^[0-9a-f]{40}$/i;
+
+export {
+  isImmutableGitCommitRef,
+  parseGitPluginSpec,
+  type GitPluginResolution,
+  type ParsedGitPluginSpec,
+} from "../infra/git-plugin-spec.js";
+import {
+  isImmutableGitCommitRef,
+  parseGitPluginSpec,
+  type GitPluginResolution,
+  type ParsedGitPluginSpec,
+} from "../infra/git-plugin-spec.js";
 
 type PluginInstallLogger = {
   info?: (message: string) => void;
   warn?: (message: string) => void;
 };
 
-/** Resolved Git source metadata persisted into plugin install records. */
-export type GitPluginResolution = {
-  url: string;
-  ref?: string;
-  commit?: string;
-  resolvedAt: string;
-};
-
 export type GitPluginInstallResult =
   | (Extract<InstallPluginResult, { ok: true }> & { git: GitPluginResolution })
   | Extract<InstallPluginResult, { ok: false }>;
-
-/** Normalized Git plugin install spec accepted by the Git installer. */
-export type ParsedGitPluginSpec = {
-  input: string;
-  url: string;
-  ref?: string;
-  label: string;
-  normalizedSpec: string;
-};
-
-/** Returns true for full commit SHAs that do not require branch/tag drift checks. */
-export function isImmutableGitCommitRef(ref: string | undefined): boolean {
-  return FULL_GIT_COMMIT_PATTERN.test(ref ?? "");
-}
-
-function splitGitSpecRef(input: string): { base: string; ref?: string } {
-  const hashIndex = input.lastIndexOf("#");
-  if (hashIndex > 0) {
-    return {
-      base: input.slice(0, hashIndex),
-      ref: normalizeOptionalString(input.slice(hashIndex + 1)),
-    };
-  }
-
-  for (
-    let atIndex = input.lastIndexOf("@");
-    atIndex > 0;
-    atIndex = input.lastIndexOf("@", atIndex - 1)
-  ) {
-    const base = input.slice(0, atIndex);
-    const ref = normalizeOptionalString(input.slice(atIndex + 1));
-    if (ref && isGitSpecBase(base)) {
-      return { base, ref };
-    }
-  }
-
-  return { base: input };
-}
-
-function isGitSpecBase(value: string): boolean {
-  return (
-    looksLikeGitHubRepoShorthand(value) ||
-    looksLikeGitHubHostPath(value) ||
-    looksLikeUrlGitSpecBase(value) ||
-    looksLikeScpGitUrl(value) ||
-    value.endsWith(".git") ||
-    value.startsWith("./") ||
-    value.startsWith("../") ||
-    value.startsWith("~/")
-  );
-}
-
-function looksLikeGitHubRepoShorthand(value: string): boolean {
-  return /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\.git)?$/.test(value);
-}
-
-function looksLikeGitHubHostPath(value: string): boolean {
-  return /^github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\.git)?$/i.test(value);
-}
-
-function isGitUrl(value: string): boolean {
-  return (
-    /^(?:ssh|git|file):\/\//i.test(value) || looksLikeScpGitUrl(value) || value.endsWith(".git")
-  );
-}
-
-function looksLikeScpGitUrl(value: string): boolean {
-  return /^[^@\s]+@[^:\s]+:.+/.test(value);
-}
-
-function looksLikeUrlGitSpecBase(value: string): boolean {
-  try {
-    const url = new URL(value);
-    if (!["http:", "https:", "ssh:", "git:", "file:"].includes(url.protocol)) {
-      return false;
-    }
-    if (url.protocol === "file:") {
-      return url.pathname.length > 1;
-    }
-    return Boolean(url.hostname) && url.pathname.length > 1;
-  } catch {
-    return false;
-  }
-}
-
-function stripGitSuffix(value: string): string {
-  return value.replace(/\.git$/i, "");
-}
-
-function normalizeGitHubRepo(value: string): { url: string; label: string } {
-  const repo = stripGitSuffix(value.replace(/^github\.com\//i, ""));
-  return {
-    url: `https://github.com/${repo}.git`,
-    label: repo,
-  };
-}
-
-function normalizeGitLabel(value: string): string {
-  if (hasHttpUrlPrefix(value) || /^(?:ssh|git|file):\/\//i.test(value)) {
-    try {
-      const url = new URL(value);
-      return stripGitSuffix(`${url.hostname}${url.pathname}`).replace(/^\/+/, "");
-    } catch {
-      return stripGitSuffix(value);
-    }
-  }
-  return stripGitSuffix(value);
-}
-
-export function parseGitPluginSpec(raw: string): ParsedGitPluginSpec | null {
-  const trimmed = raw.trim();
-  if (!trimmed.toLowerCase().startsWith(GIT_SPEC_PREFIX)) {
-    return null;
-  }
-
-  const body = trimmed.slice(GIT_SPEC_PREFIX.length).trim();
-  if (!body) {
-    return null;
-  }
-
-  const split = splitGitSpecRef(body);
-  const base = split.base.trim();
-  if (!base) {
-    return null;
-  }
-
-  if (looksLikeGitHubRepoShorthand(base) || looksLikeGitHubHostPath(base)) {
-    const normalized = normalizeGitHubRepo(base);
-    return {
-      input: trimmed,
-      url: normalized.url,
-      ref: split.ref,
-      label: normalized.label,
-      normalizedSpec: `${GIT_SPEC_PREFIX}${normalized.url}${split.ref ? `@${split.ref}` : ""}`,
-    };
-  }
-
-  if (
-    hasHttpUrlPrefix(base) ||
-    isGitUrl(base) ||
-    base.startsWith("./") ||
-    base.startsWith("../") ||
-    base.startsWith("~/")
-  ) {
-    const url =
-      base.startsWith("./") || base.startsWith("../") || base.startsWith("~/")
-        ? resolveUserPath(base)
-        : base;
-    return {
-      input: trimmed,
-      url,
-      ref: split.ref,
-      label: normalizeGitLabel(url),
-      normalizedSpec: `${GIT_SPEC_PREFIX}${url}${split.ref ? `@${split.ref}` : ""}`,
-    };
-  }
-
-  return null;
-}
 
 function createGitCommandEnv(): NodeJS.ProcessEnv {
   return {


### PR DESCRIPTION
## Summary

Stacked after #101755. This adds the next read-only Claws lifecycle slice: artifact and provenance preview inside the existing Claw plan output.

Design reference: RFC PR https://github.com/openclaw/rfcs/pull/27

- adds package-entry artifact previews for Claw plan entries
- reuses the canonical OpenClaw selector parsers for `clawhub:`, `npm:`, git, file/local, and npm-pack preview support
- records the expected install surface and provenance record family for skills, plugins, MCP servers, and connectors
- marks unsupported package selector shapes as `blockedUnsupported` in the read-only plan
- prints required unsupported entries in text-mode plan output
- keeps PR4 read-only: no artifact fetch, install, workspace mutation, automation enablement, provenance writes, or Gateway state changes

## Stack

- RFC: https://github.com/openclaw/rfcs/pull/27
- PR2: https://github.com/openclaw/openclaw/pull/101328
- PR3: https://github.com/openclaw/openclaw/pull/101755
- This PR: artifact/provenance preview only

## Verification

- `node scripts/run-vitest.mjs src/claws/schema.test.ts src/claws/feed.test.ts src/cli/claws-cli.test.ts src/cli/plugins-install-config.test.ts src/plugins/git-install.test.ts src/cli/program/command-registry.test.ts src/cli/program/root-command-descriptions.test.ts`
- `node scripts/run-vitest.mjs src/claws/schema.test.ts src/cli/plugins-install-config.test.ts src/plugins/git-install.test.ts`
- `git diff --check`
- `node scripts/check-no-conflict-markers.mjs`
- `OPENCLAW_DISABLE_BUNDLED_PLUGINS=1 OPENCLAW_STATE_DIR=/tmp/openclaw-claws-pr4-proof-state node --import tsx src/entry.ts claws feed plan src/claws/fixtures/local-claws.feed.json incident-response --json`
- `codex review -c model=gpt-5.5 --base origin/user/giodl/claws-pr3-feed-plan` returned no actionable correctness issues after fixing parser-reuse, OPENCLAW_HOME, and unused-import findings.

Note: ad hoc direct `tsc --ignoreConfig` over changed files is not useful for this slice because it does not load the repo path mappings for `@openclaw/normalization-core/*` and `@openclaw/net-policy/*`; the focused Vitest suites above cover the changed Claws, plugin install config, and git parser/installer paths.

## Real behavior proof

Behavior or issue addressed:
This PR enriches the read-only Claw lifecycle plan with artifact and provenance preview metadata for package entries, so a future installer can be reviewed against explicit install surfaces and expected provenance record families before mutation exists.

Real environment tested:
WSL Ubuntu checkout at `/root/src/openclaw-claws-pr4`, branch `user/giodl/claws-pr4-artifact-plan`, commit `8eeef1c91a73`. Runtime used the source harness with `node --import tsx src/entry.ts`, `OPENCLAW_DISABLE_BUNDLED_PLUGINS=1`, and isolated `OPENCLAW_STATE_DIR=/tmp/openclaw-claws-pr4-proof-state`.

Exact steps or command run after this patch:
1. `OPENCLAW_DISABLE_BUNDLED_PLUGINS=1 OPENCLAW_STATE_DIR=/tmp/openclaw-claws-pr4-proof-state node --import tsx src/entry.ts claws feed plan src/claws/fixtures/local-claws.feed.json incident-response --json`

Evidence after fix:
`claws feed plan` emitted this current-head JSON:

```json
{
  "schemaVersion": "openclaw.clawPlan.v1",
  "readOnly": true,
  "claw": {
    "id": "incident-response",
    "name": "Incident Response",
    "version": "1.0.0",
    "sourcePath": "/root/src/openclaw-claws-pr4/src/claws/fixtures/incident-response.claw.json"
  },
  "summary": {
    "totalEntries": 5,
    "requiredEntries": 4,
    "optionalEntries": 1,
    "requiresConsent": 2,
    "unsupportedRequiredEntries": 0,
    "unsupportedOptionalEntries": 0
  },
  "entries": [
    {
      "id": "incident-triage-skill",
      "kind": "skill",
      "required": true,
      "decision": "inspectOnly",
      "target": "clawhub:incident-triage@1.0.0",
      "artifact": {
        "source": "clawhub",
        "selector": "clawhub:incident-triage@1.0.0",
        "installSurface": "skills",
        "packageName": "incident-triage",
        "version": "1.0.0",
        "provenance": {
          "record": "skill.clawhubOrigin",
          "requestedSpecifier": "clawhub:incident-triage@1.0.0",
          "pinning": "pinned"
        },
        "supported": true
      },
      "reason": "This entry can be resolved by a future installer through the skills install surface; this PR previews artifact and provenance metadata only."
    },
    {
      "id": "pager-duty-plugin",
      "kind": "plugin",
      "required": true,
      "decision": "inspectOnly",
      "target": "npm:@openclaw/plugin-pager-duty@2.4.0",
      "artifact": {
        "source": "npm",
        "selector": "npm:@openclaw/plugin-pager-duty@2.4.0",
        "installSurface": "plugins",
        "packageName": "@openclaw/plugin-pager-duty",
        "version": "2.4.0",
        "provenance": {
          "record": "plugin.installRecord",
          "requestedSpecifier": "npm:@openclaw/plugin-pager-duty@2.4.0",
          "pinning": "pinned"
        },
        "supported": true
      },
      "reason": "This entry can be resolved by a future installer through the plugins install surface; this PR previews artifact and provenance metadata only."
    },
    {
      "id": "statuspage-mcp",
      "kind": "mcpServer",
      "required": false,
      "decision": "inspectOnly",
      "target": "clawhub:statuspage-mcp@1.1.0",
      "artifact": {
        "source": "clawhub",
        "selector": "clawhub:statuspage-mcp@1.1.0",
        "installSurface": "mcpServers",
        "packageName": "statuspage-mcp",
        "version": "1.1.0",
        "provenance": {
          "record": "mcpServer.installRecord",
          "requestedSpecifier": "clawhub:statuspage-mcp@1.1.0",
          "pinning": "pinned"
        },
        "supported": true
      },
      "reason": "This entry can be resolved by a future installer through the mcpServers install surface; this PR previews artifact and provenance metadata only."
    },
    {
      "id": "runbook",
      "kind": "workspaceFile",
      "required": true,
      "decision": "requiresConsent",
      "target": "SOUL.md",
      "source": "files/SOUL.md",
      "reason": "This entry would require explicit user consent before a future install command mutates workspace files or automation state."
    },
    {
      "id": "heartbeat-summary",
      "kind": "schedule",
      "required": true,
      "decision": "requiresConsent",
      "target": "heartbeat-summary",
      "source": "automations/heartbeat-summary.json",
      "reason": "This entry would require explicit user consent before a future install command mutates workspace files or automation state."
    }
  ],
  "diagnostics": [],
  "feed": {
    "id": "local-starter-claws",
    "name": "Local Starter Claws",
    "sourcePath": "/root/src/openclaw-claws-pr4/src/claws/fixtures/local-claws.feed.json",
    "entry": {
      "id": "incident-response",
      "name": "Incident Response",
      "version": "1.0.0",
      "source": "incident-response.claw.json",
      "publisher": "openclaw.examples",
      "description": "Starter claw for triage, workspace context, and response automation.",
      "owner": {
        "type": "publisher",
        "id": "openclaw.examples"
      },
      "trust": {
        "level": "source"
      }
    }
  }
}
```

Observed result after fix:
The read-only feed plan returned five entries. The package entries include `artifact` preview metadata with selector source, install surface, parsed package/version where available, expected provenance record, requested specifier, pinning mode, and supported status. Workspace and schedule entries remain `requiresConsent` without artifact mutation.

What was not tested:
Remote feed fetch, ClawHub publish/search, artifact fetch, artifact install, workspace mutation, automation enablement, provenance writes, Gateway state changes, lifecycle/update flows, and full-project typecheck remain out of scope for PR4.
