### PR TITLE
improve: soften the idle voice button ring in the chat composer

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1944,6 +1944,17 @@ openclaw-chat-page {
   cursor: not-allowed;
 }
 
+/* Idle voice ring stays muted so the idle -> hover -> recording progression
+   escalates (40% -> 70% -> full ring via --stop); a full-strength idle ring
+   makes recording state indistinguishable at a glance. */
+.chat-send-btn--voice {
+  border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+}
+
+.chat-send-btn--voice:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--accent) 70%, transparent);
+}
+
 .chat-send-btn--stop {
   border-color: var(--danger);
   background: transparent;


### PR DESCRIPTION
## What Problem This Solves

The idle Talk voice button in the Control UI chat composer draws a full-strength accent ring, which reads harsher than every neighboring control and — more importantly — is visually indistinguishable at a glance from the recording (stop) state, which also uses a full-strength ring.

## Why This Change Was Made

Mute the idle voice ring to 40% accent and ramp hover to 70%, so button emphasis escalates idle → hover → recording (full ring via `.chat-send-btn--stop`). Scoped to `.chat-send-btn--voice` only; the send/stop buttons and disabled state are untouched (disabled precedence verified via selector specificity, recording via source order). Treatment chosen from a four-variant design pass rendered on the real UI.

## User Impact

The composer mic button sits quietly in the control row when idle, brightens on hover, and the recording state now clearly stands out. No behavior, layout, config, or API changes.

## Evidence

- Before/after screenshots (idle + hover) in the PR comment below, captured with the Control UI e2e harness (mock gateway) on Blacksmith Testbox through Crabbox (`tbx_01kwyvx4pbdmb3yhjff6gvzvny`).
- `oxfmt --check` clean on the changed file (same Testbox).
- Autoreview (codex, gpt-5.5): clean, no actionable findings — noted disabled/stop-state precedence is preserved.
