### PR TITLE
fix(web): avoid exact-limit fetch truncation warnings

### DIFF
--- a/src/agents/tools/web-shared.test.ts
+++ b/src/agents/tools/web-shared.test.ts
@@ -129,6 +129,24 @@ describe("readResponseText", () => {
     expect(releaseLock).toHaveBeenCalledTimes(1);
   });
 
+  it("does not mark exact-limit bounded response reads as truncated", async () => {
+    const cancel = vi.fn(async () => undefined);
+    const releaseLock = vi.fn();
+    const response = responseFromReader({
+      chunks: ["hello", " world"],
+      cancel,
+      releaseLock,
+    });
+
+    await expect(readResponseText(response, { maxBytes: 11 })).resolves.toEqual({
+      text: "hello world",
+      truncated: false,
+      bytesRead: 11,
+    });
+    expect(cancel).not.toHaveBeenCalled();
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
   it("cancels and releases bounded response readers after truncation", async () => {
     const cancel = vi.fn(async () => undefined);
     const releaseLock = vi.fn();

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -272,8 +272,7 @@ export async function readResponseText(
         bytesRead += chunk.byteLength;
         parts.push(chunk);
 
-        if (truncated || bytesRead >= maxBytes) {
-          truncated = true;
+        if (truncated) {
           break;
         }
       }


### PR DESCRIPTION
﻿Closes #101837

## What Problem This Solves

Fixes an issue where users running `web_fetch` could see a response reported as truncated when the streamed response body was exactly `maxResponseBytes` bytes, even though no bytes were omitted.

## Why This Change Was Made

`readResponseText` now treats truncation as proven only when a chunk exceeds the remaining byte budget. Reaching the byte budget exactly no longer flips the truncation flag by itself, so exact-limit responses can complete normally while true overflow still cancels the reader.

## User Impact

Users no longer get misleading `Response body truncated after ... bytes.` warnings for complete responses that happen to land exactly on the byte cap. Oversized responses are still bounded and marked truncated.

## Evidence

- Claim proved: Current head `18b610b93e7e0a96de0eb891de3bab0e43f2c74b` lets an exact-limit `readResponseText` helper run complete without setting `truncated`, while still reporting the exact byte count.
- Real helper proof for the requested boundary, constructing a real `Response` from streamed chunks `"hello"` + `" world"` and reading it with `maxBytes: 11`:
  ```text
  node --import ../openclaw/node_modules/tsx/dist/esm/index.mjs --input-type=module -e "import { readResponseText } from './src/agents/tools/web-shared.ts'; const encoder = new TextEncoder(); let cancelCount = 0; const response = new Response(new ReadableStream({ start(controller) { controller.enqueue(encoder.encode('hello')); controller.enqueue(encoder.encode(' world')); controller.close(); }, cancel() { cancelCount += 1; } })); const result = await readResponseText(response, { maxBytes: 11 }); console.log(JSON.stringify({ text: result.text, truncated: result.truncated, bytesRead: result.bytesRead, cancelCount }));"
  {"text":"hello world","truncated":false,"bytesRead":11,"cancelCount":0}
  ```
- Focused regression: `PNPM_CONFIG_MODULES_DIR='../openclaw/node_modules' node scripts/run-vitest.mjs src/agents/tools/web-shared.test.ts` passed (`1` file, `12` tests).
- Whitespace check: `git diff --check` passed.
- GitHub current-head checks: `gh pr checks 101845 --repo openclaw/openclaw --json name,bucket,state,completedAt,link` showed no failed buckets; current checks are pass/skip/neutral.
- Duplicate search before issue creation: no open issue or PR found for `web_fetch truncated maxBytes exact limit` or `readResponseText truncated maxBytes`.

Observed result: exact-limit helper output is `truncated:false`, `bytesRead:11`, and `cancelCount:0`, so the shared helper no longer feeds a false truncation warning to `web_fetch` for complete exact-cap responses.
