### PR TITLE
fix(acpx): handle target stdout stream errors

### DIFF
--- a/extensions/acpx/src/runtime-internals/mcp-proxy.mjs
+++ b/extensions/acpx/src/runtime-internals/mcp-proxy.mjs
@@ -118,6 +118,7 @@ function main() {
   };
 
   child.stdin.on("error", exitWithError);
+  child.stdout.on("error", exitWithError);
   process.stdout.on("error", exitWithError);
 
   input.on("line", (line) => {

--- a/extensions/acpx/src/runtime-internals/mcp-proxy.test.ts
+++ b/extensions/acpx/src/runtime-internals/mcp-proxy.test.ts
@@ -238,4 +238,53 @@ setTimeout(() => {}, 30_000);
     expect(stderr).toMatch(/EPIPE|write/i);
     expect(stderr).not.toContain("Unhandled 'error' event");
   });
+
+  it("reports target stdout stream failures without an unhandled stream error", async () => {
+    const spawnMockPath = await makeTempScript(
+      "mock-target-stdout-error.cjs",
+      String.raw`const childProcess = require("node:child_process");
+const { EventEmitter } = require("node:events");
+const { syncBuiltinESMExports } = require("node:module");
+const { PassThrough } = require("node:stream");
+
+childProcess.spawn = () => {
+  const child = new EventEmitter();
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.kill = () => {};
+
+  process.nextTick(() => {
+    child.stdout.emit("error", new Error("target stdout failed"));
+  });
+
+  return child;
+};
+syncBuiltinESMExports();
+`,
+    );
+
+    const payload = encodePayload({
+      targetCommand: `${process.execPath} unused-target.cjs`,
+      mcpServers: [],
+    });
+
+    const child = spawn(process.execPath, ["--require", spawnMockPath, proxyPath, "--payload", payload], {
+      stdio: ["pipe", "pipe", "pipe"],
+      cwd: process.cwd(),
+    });
+
+    let stderr = "";
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.stdin.end();
+
+    const exitCode = await new Promise<number | null>((resolve) => {
+      child.once("close", (code) => resolve(code));
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("target stdout failed");
+    expect(stderr).not.toContain("Unhandled 'error' event");
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ACPX-backed MCP proxy sessions could crash with an unhandled stream error when the proxied target stdout stream emits an error.

## Why This Change Was Made

The proxy already routes target stdin, proxy stdout, and child process errors through one controlled failure path. This change applies the same local boundary handling to the target stdout stream before piping it to the proxy stdout, without changing ACPX command rewriting or MCP payload behavior.

## User Impact

ACPX MCP proxy failures from target stdout streams now exit cleanly with the underlying error instead of surfacing as an unhandled Node stream error.

## Evidence

- Maintainer follow-up proof (2026-07-08): exact-head runtime seam comparison for `149cd86b70e5b738945c1905347edcd4c15a2ac1` exercised the same parent-side target stdout stream `error` event against base and PR versions of `extensions/acpx/src/runtime-internals/mcp-proxy.mjs` using only Node built-ins plus a temporary preload. Base result: `exit=1`, `hasTargetMessage=true`, `hasUnhandled=true`, first stderr line `node:events:497`. PR result: `exit=1`, `hasTargetMessage=true`, `hasUnhandled=false`, first stderr line `target stdout failed`. This proves the added `child.stdout.on("error", exitWithError)` converts the target stdout stream failure into the controlled proxy error path instead of Node's unhandled stream error path.
- Maintainer follow-up proof (2026-07-08): GitHub Actions `Real behavior proof` passed for exact head `149cd86b70e5b738945c1905347edcd4c15a2ac1`: run https://github.com/openclaw/openclaw/actions/runs/28890588288, job https://github.com/openclaw/openclaw/actions/runs/28890588288/job/85701964100, completed 2026-07-07T18:50:09Z. The log includes `External PR includes problem context and evidence.`
- Maintainer follow-up proof (2026-07-08): `git diff --check upstream/main...149cd86b70e5b738945c1905347edcd4c15a2ac1 -- extensions/acpx/src/runtime-internals/mcp-proxy.mjs extensions/acpx/src/runtime-internals/mcp-proxy.test.ts` passed.
- Maintainer follow-up proof (2026-07-08): duplicate search stayed clear: PR search for `acpx mcp proxy stdout error` found only #101846, and issue search for the same query returned `[]`.

- Maintainer follow-up proof (2026-07-08): removed the leading UTF-8 BOM from this PR body so `scripts/github/real-behavior-proof-check.mjs` can recognize the existing `## What Problem This Solves` heading. Local policy evaluation changed from `missing: What Problem This Solves` to `passed: External PR includes problem context and evidence`.
- Maintainer follow-up proof (2026-07-08): `git diff --check upstream/main...HEAD` passed for the two-file PR diff.
- Maintainer proof gap: local focused Vitest was not run because this clean worktree has no `node_modules`; the existing PR CI already ran the focused source/tests, and this edit is body-only.
- Claim proved: the current `extensions/acpx/src/runtime-internals/mcp-proxy.mjs` handles a target stdout stream `error` event through the proxy error path.
- Commands / artifacts:
  - `git diff --check` passed.
  - Direct runtime seam proof with a temporary Node preload mocked the target child stdout stream error against this branch's `mcp-proxy.mjs`; observed output: `target stdout stream error handled`.
  - Duplicate search: open issue and PR searches for `acpx mcp proxy stdout error` returned `[]`.
- Observed result: the proxy process exits with code 1, stderr includes `target stdout failed`, and stderr does not include `Unhandled 'error' event`.
- Local environment note: `node scripts/run-vitest.mjs extensions/acpx/src/runtime-internals/mcp-proxy.test.ts` could not run in the clean worktree because `node_modules` was absent; a one-time install attempt in a discarded worktree exposed Windows workspace-link cleanup issues, so this PR leaves full Vitest validation to CI rather than carrying local install side effects.



