### PR TITLE
fix(browser): bind wait predicates to allowed documents

### DIFF
--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -6,6 +6,7 @@ import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  ChromeMcpDocumentUnavailableError,
   clickChromeMcpCoords,
   clickChromeMcpElement,
   closeChromeMcpTab,
@@ -29,6 +30,7 @@ import {
   takeChromeMcpScreenshot,
   takeChromeMcpSnapshot,
   uploadChromeMcpFile,
+  withChromeMcpDocument,
 } from "./chrome-mcp.js";
 
 type ToolCall = {
@@ -233,6 +235,106 @@ describe("chrome MCP page parsing", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllEnvs();
+  });
+
+  it("keeps document-bound evaluations on one pinned target and raw snapshot uid", async () => {
+    const session = createPageSession({
+      pid: 139,
+      pages: [{ id: 1, url: "https://example.com" }],
+      onTool: (call) => {
+        if (call.name === "take_snapshot") {
+          return {
+            structuredContent: {
+              snapshot: { id: "7_0", role: "RootWebArea", name: "Example" },
+            },
+          };
+        }
+        if (call.name === "evaluate_script") {
+          return { content: [{ type: "text", text: '```json\n"ok"\n```' }] };
+        }
+        return undefined;
+      },
+    });
+    setChromeMcpSessionFactoryForTest(async () => session);
+    const targetId = (await listChromeMcpTabs("chrome-live"))[0]?.targetId ?? "";
+
+    await expect(
+      withChromeMcpDocument({ profileName: "chrome-live", targetId }, async (document) => [
+        await document.evaluate("(root) => root.ownerDocument.location.href"),
+        await document.evaluate("(root) => root.textContent"),
+      ]),
+    ).resolves.toEqual(["ok", "ok"]);
+
+    const calls = (session.client.callTool as unknown as ToolCallMock).mock.calls.map(
+      ([call]) => call,
+    );
+    expect(calls.map((call) => call.name)).toEqual([
+      "list_pages",
+      "take_snapshot",
+      "evaluate_script",
+      "evaluate_script",
+    ]);
+    expect(calls.at(-1)?.arguments).toMatchObject({ pageId: 1, args: ["7_0"] });
+  });
+
+  it("brands a stale document uid so waits can recapture after navigation", async () => {
+    const session = createPageSession({
+      pid: 139,
+      pages: [{ id: 1, url: "https://example.com" }],
+      onTool: (call) => {
+        if (call.name === "take_snapshot") {
+          return {
+            structuredContent: { snapshot: { id: "8_0", role: "RootWebArea" } },
+          };
+        }
+        if (call.name === "evaluate_script") {
+          return {
+            isError: true,
+            content: [
+              { type: "text", text: 'Element with uid "8_0" no longer exists on the page.' },
+            ],
+          };
+        }
+        return undefined;
+      },
+    });
+    setChromeMcpSessionFactoryForTest(async () => session);
+    const targetId = (await listChromeMcpTabs("chrome-live"))[0]?.targetId ?? "";
+
+    await expect(
+      withChromeMcpDocument({ profileName: "chrome-live", targetId }, (document) =>
+        document.evaluate("(root) => root.ownerDocument.location.href"),
+      ),
+    ).rejects.toBeInstanceOf(ChromeMcpDocumentUnavailableError);
+  });
+
+  it.each([
+    ["take_snapshot", "Execution context was destroyed, most likely because of a navigation."],
+    ["evaluate_script", "Protocol error: Frame was detached."],
+  ])("brands navigation failure from %s for document recapture", async (failedTool, message) => {
+    const session = createPageSession({
+      pid: 139,
+      pages: [{ id: 1, url: "https://example.com" }],
+      onTool: (call) => {
+        if (call.name === failedTool) {
+          return { isError: true, content: [{ type: "text", text: message }] };
+        }
+        if (call.name === "take_snapshot") {
+          return {
+            structuredContent: { snapshot: { id: "9_0", role: "RootWebArea" } },
+          };
+        }
+        return undefined;
+      },
+    });
+    setChromeMcpSessionFactoryForTest(async () => session);
+    const targetId = (await listChromeMcpTabs("chrome-live"))[0]?.targetId ?? "";
+
+    await expect(
+      withChromeMcpDocument({ profileName: "chrome-live", targetId }, (document) =>
+        document.evaluate("(root) => root.ownerDocument.location.href"),
+      ),
+    ).rejects.toBeInstanceOf(ChromeMcpDocumentUnavailableError);
   });
 
   it("binds macOS ancestry, start time, and executable command in one snapshot row", () => {

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -2270,7 +2270,7 @@ export async function withChromeMcpDocument<T>(
             ),
           );
         } catch (error) {
-          rethrowChromeMcpDocumentError(error);
+          return rethrowChromeMcpDocumentError(error);
         }
       },
     });

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -78,6 +78,25 @@ type ChromeMcpTargetOperation = ChromeMcpOperationOptions & {
   targetId: string;
 };
 
+export class ChromeMcpDocumentUnavailableError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "ChromeMcpDocumentUnavailableError";
+  }
+}
+
+function rethrowChromeMcpDocumentError(error: unknown): never {
+  const message = error instanceof Error ? error.message : String(error);
+  if (
+    /Element (?:with )?uid .* (?:not found|no longer exists) on (?:the )?page|Execution context was destroyed|Cannot find context with specified id|Frame (?:was |is )?detached|detached Frame|Node is detached from document/i.test(
+      message,
+    )
+  ) {
+    throw new ChromeMcpDocumentUnavailableError(message, { cause: error });
+  }
+  throw error;
+}
+
 type ChromeMcpCallOptions = ChromeMcpOperationOptions & {
   ephemeral?: boolean;
 };
@@ -2209,6 +2228,52 @@ export async function takeChromeMcpSnapshot(
       params.targetId,
       extractSnapshot(result),
     );
+  });
+}
+
+/** Run document-bound evaluations without releasing the target/session lock. */
+export async function withChromeMcpDocument<T>(
+  params: ChromeMcpTargetOperation,
+  task: (document: { evaluate: (fn: string) => Promise<unknown> }) => Promise<T>,
+): Promise<T> {
+  return await withChromeMcpTarget(params, async (target) => {
+    let snapshot: ChromeMcpSnapshotNode;
+    try {
+      snapshot = extractSnapshot(
+        await callTool(
+          params.profileName,
+          target.profileOptions,
+          "take_snapshot",
+          { pageId: target.pageId, verbose: true },
+          params,
+          target.lease,
+        ),
+      );
+    } catch (error) {
+      rethrowChromeMcpDocumentError(error);
+    }
+    const uid = normalizeOptionalString(snapshot.id);
+    if (!uid || snapshot.role?.trim().toLowerCase() !== "rootwebarea") {
+      throw new Error("Chrome MCP snapshot did not contain a top-level document uid");
+    }
+    return await task({
+      evaluate: async (fn) => {
+        try {
+          return extractJsonMessage(
+            await callTool(
+              params.profileName,
+              target.profileOptions,
+              "evaluate_script",
+              { pageId: target.pageId, function: fn, args: [uid] },
+              params,
+              target.lease,
+            ),
+          );
+        } catch (error) {
+          rethrowChromeMcpDocumentError(error);
+        }
+      },
+    });
   });
 }
 

--- a/extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts
@@ -289,6 +289,7 @@ describe("pw-tools-core browser SSRF guards", () => {
       mouse: { click: navigate },
       keyboard: { press: navigate },
       evaluate: navigate,
+      evaluateHandle: vi.fn(async () => ({ dispose: vi.fn(async () => {}) })),
       waitForFunction: navigate,
     };
     pageState.locator = {
@@ -320,21 +321,202 @@ describe("pw-tools-core browser SSRF guards", () => {
     });
   });
 
-  it("keeps wait operations outside the action-owned request guard", async () => {
-    const waitForFunction = vi.fn(async () => {});
+  it("guards executable wait predicates and preserves proxy policy", async () => {
+    let currentUrl = "https://example.com";
+    const order: string[] = [];
+    sessionMocks.withPageNavigationRequestGuard.mockImplementationOnce(
+      async ({
+        action,
+        page,
+      }: {
+        action: (url: string) => Promise<unknown>;
+        page: { url: () => string };
+      }) => {
+        order.push("guard");
+        return await action(page.url());
+      },
+    );
+    const documentHandle = { dispose: vi.fn(async () => {}) };
+    const waitForFunction = vi.fn(
+      async (
+        predicate: (state: { document: unknown }) => boolean,
+        state: { document: unknown },
+      ) => {
+        order.push("predicate");
+        expect(predicate({ ...state, document: globalThis.document })).toBe(true);
+        currentUrl = "https://93.184.216.34/target";
+      },
+    );
     pageState.page = {
-      url: vi.fn(() => "https://example.com"),
+      url: vi.fn(() => currentUrl),
+      evaluateHandle: vi.fn(async () => documentHandle),
+      waitForTimeout: vi.fn(async () => {
+        order.push("passive");
+      }),
       waitForFunction,
     };
 
     await interactions.waitForViaPlaywright({
       cdpUrl: "http://127.0.0.1:18792",
       targetId: "tab-1",
+      timeMs: 1,
       fn: "() => true",
+      ssrfPolicy: { allowPrivateNetwork: false },
+      browserProxyMode: "explicit-browser-proxy",
     });
 
-    expect(waitForFunction).toHaveBeenCalledWith("() => true", { timeout: expect.any(Number) });
-    expect(sessionMocks.withPageNavigationRequestGuard).not.toHaveBeenCalled();
+    expect(waitForFunction).toHaveBeenCalledWith(
+      expect.any(Function),
+      { document: documentHandle },
+      { timeout: expect.any(Number) },
+    );
+    expect(order).toEqual(["guard", "passive", "predicate"]);
+    expect(sessionMocks.withPageNavigationRequestGuard).toHaveBeenCalledWith({
+      action: expect.any(Function),
+      onPolicyCheckStarted: expect.any(Function),
+      onPolicyDenied: expect.any(Function),
+      page: pageState.page,
+      ssrfPolicy: { allowPrivateNetwork: false },
+      browserProxyMode: "explicit-browser-proxy",
+    });
+    expect(sessionMocks.assertPageNavigationCompletedSafely).toHaveBeenLastCalledWith({
+      cdpUrl: "http://127.0.0.1:18792",
+      page: pageState.page,
+      response: null,
+      ssrfPolicy: { allowPrivateNetwork: false },
+      browserProxyMode: "explicit-browser-proxy",
+      targetId: "tab-1",
+    });
+  });
+
+  it("preserves declared async wait predicates", async () => {
+    const documentHandle = { dispose: vi.fn(async () => {}) };
+    const waitForFunction = vi.fn(async () => {});
+    pageState.page = {
+      url: vi.fn(() => "https://example.com"),
+      evaluateHandle: vi.fn(async () => documentHandle),
+      waitForFunction,
+    };
+
+    await interactions.waitForViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "tab-1",
+      fn: "async () => true",
+      ssrfPolicy: { allowPrivateNetwork: false },
+    });
+
+    expect(waitForFunction).toHaveBeenCalledOnce();
+    expect(documentHandle.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("preserves synchronous wait predicates that return a promise", async () => {
+    const documentHandle = { dispose: vi.fn(async () => {}) };
+    pageState.page = {
+      url: vi.fn(() => "https://example.com"),
+      evaluateHandle: vi.fn(async () => documentHandle),
+      waitForFunction: vi.fn(
+        async (
+          predicate: (state: { document: unknown }) => boolean,
+          state: { document: unknown },
+        ) => {
+          const browserState = { ...state, document: globalThis.document };
+          expect(predicate(browserState)).toBe(false);
+          await Promise.resolve();
+          expect(predicate(browserState)).toBe(true);
+        },
+      ),
+    };
+
+    await interactions.waitForViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "tab-1",
+      fn: "() => Promise.resolve(true)",
+      ssrfPolicy: { allowPrivateNetwork: false },
+    });
+
+    expect(sessionMocks.closeBlockedNavigationTarget).not.toHaveBeenCalled();
+    expect(documentHandle.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("does not recreate a wait predicate in a replacement document", async () => {
+    const documentHandle = { dispose: vi.fn(async () => {}) };
+    pageState.page = {
+      url: vi.fn(() => "https://example.com/next"),
+      evaluateHandle: vi.fn(async () => documentHandle),
+      waitForFunction: vi.fn(
+        async (
+          predicate: (state: { document: unknown }) => boolean,
+          state: { document: unknown },
+        ) => predicate({ ...state, document: {} }),
+      ),
+    };
+
+    await expect(
+      interactions.waitForViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "tab-1",
+        fn: "() => document.cookie",
+        ssrfPolicy: { allowPrivateNetwork: false },
+      }),
+    ).rejects.toThrow("Wait predicate document changed");
+
+    expect(documentHandle.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("does not start a predicate after aborting an earlier wait condition", async () => {
+    const ctrl = new AbortController();
+    sessionMocks.isBrowserObservedDialogBlockedError.mockReturnValueOnce(true);
+    const waitForFunction = vi.fn(async () => {});
+    pageState.page = {
+      url: vi.fn(() => "https://example.com"),
+      waitForTimeout: vi.fn(async () => {
+        ctrl.abort(new Error("aborted during passive wait"));
+      }),
+      waitForFunction,
+    };
+
+    await expect(
+      interactions.waitForViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "tab-1",
+        timeMs: 1,
+        fn: "() => true",
+        signal: ctrl.signal,
+        ssrfPolicy: { allowPrivateNetwork: false },
+      }),
+    ).rejects.toThrow("aborted during passive wait");
+    await Promise.resolve();
+    expect(waitForFunction).not.toHaveBeenCalled();
+    expect(sessionMocks.markObservedDialogsHandledRemotelyForPage).toHaveBeenCalledWith(
+      pageState.page,
+    );
+  });
+
+  it("does not start a predicate when document capture finishes after abort", async () => {
+    const ctrl = new AbortController();
+    const documentHandle = { dispose: vi.fn(async () => {}) };
+    const waitForFunction = vi.fn(async () => {});
+    pageState.page = {
+      url: vi.fn(() => "https://example.com"),
+      evaluateHandle: vi.fn(async () => {
+        ctrl.abort(new Error("aborted during document capture"));
+        return documentHandle;
+      }),
+      waitForFunction,
+    };
+
+    await expect(
+      interactions.waitForViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "tab-1",
+        fn: "() => true",
+        signal: ctrl.signal,
+        ssrfPolicy: { allowPrivateNetwork: false },
+      }),
+    ).rejects.toThrow("aborted during document capture");
+
+    expect(waitForFunction).not.toHaveBeenCalled();
+    expect(documentHandle.dispose).toHaveBeenCalledOnce();
   });
 
   it("keeps the request guard alive until an aborted hover actually settles", async () => {

--- a/extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts
@@ -1466,6 +1466,40 @@ describe("pw-tools-core interaction navigation guard", () => {
     releaseHover();
   });
 
+  it("retains the download grace when an executable wait aborts", async () => {
+    const ctrl = new AbortController();
+    ctrl.abort(new Error("aborted by test"));
+    const page = {
+      url: vi.fn(() => "https://example.com"),
+      waitForFunction: vi.fn(async () => {}),
+    };
+    const drain = vi.fn(async () => undefined);
+    const dispose = vi.fn();
+    getPwToolsCoreSessionMocks().beginActionDownloadCaptureOnPage.mockReturnValueOnce({
+      drain,
+      dispose,
+    });
+    setPwToolsCoreCurrentPage(page);
+
+    const task = mod.executeActViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "T1",
+      action: { kind: "wait", fn: "() => false" },
+      evaluateEnabled: true,
+      ssrfPolicy: { allowPrivateNetwork: false },
+      signal: ctrl.signal,
+    });
+
+    await expect(task).rejects.toThrow("aborted by test");
+    expect(drain).toHaveBeenCalledWith({
+      firstEventGraceMs: 250,
+      maxWaitMs: 1_000,
+      quietMs: 250,
+    });
+    expect(dispose).toHaveBeenCalledOnce();
+    expect(page.waitForFunction).not.toHaveBeenCalled();
+  });
+
   it("does not add a second download grace after a settled guarded failure", async () => {
     vi.useFakeTimers();
     try {

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -1306,41 +1306,90 @@ export async function scrollIntoViewViaPlaywright(
   }
 }
 
+type BrowserWaitPredicateState = {
+  document: unknown;
+  pending?: boolean;
+  predicate?: () => unknown;
+  settled?: { kind: "value"; value: unknown } | { error: unknown; kind: "error" };
+};
+
+function createBrowserWaitPredicate(source: string): (state: BrowserWaitPredicateState) => boolean {
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval -- compile only; Playwright runs it in-page
+  return new Function(
+    "state",
+    `
+      if (state.document !== this.document) throw "Wait predicate document changed";
+      state.predicate ??= (${source});
+      var settled = state.settled;
+      if (settled) {
+        delete state.settled;
+        if (settled.kind === "error") throw settled.error;
+        if (!!settled.value) return true;
+      }
+      if (state.pending) return false;
+      var predicate = state.predicate;
+      var value = predicate();
+      if (!value || typeof value.then !== "function") return !!value;
+      state.pending = true;
+      value.then(
+        function(resolved) {
+          state.settled = { kind: "value", value: resolved };
+          delete state.pending;
+        },
+        function(error) {
+          state.settled = { error: error, kind: "error" };
+          delete state.pending;
+        }
+      );
+      return false;
+    `,
+  ) as (state: BrowserWaitPredicateState) => boolean;
+}
+
 /** Waits for load state, timeout, URL, text, ref, or selector conditions. */
-export async function waitForViaPlaywright(opts: {
-  cdpUrl: string;
-  targetId?: string;
-  timeMs?: number;
-  text?: string;
-  textGone?: string;
-  selector?: string;
-  url?: string;
-  loadState?: "load" | "domcontentloaded" | "networkidle";
-  fn?: string;
-  timeoutMs?: number;
-  signal?: AbortSignal;
-}): Promise<void> {
+export async function waitForViaPlaywright(
+  opts: {
+    cdpUrl: string;
+    targetId?: string;
+    timeMs?: number;
+    text?: string;
+    textGone?: string;
+    selector?: string;
+    url?: string;
+    loadState?: "load" | "domcontentloaded" | "networkidle";
+    fn?: string;
+    timeoutMs?: number;
+    signal?: AbortSignal;
+  } & BrowserNavigationPolicyOptions,
+): Promise<void> {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
   const timeout = resolveActWaitTimeoutMs(opts.timeoutMs);
+  const fn = normalizeOptionalString(opts.fn) ?? "";
+  const predicateSource = fn ? normalizeBrowserEvaluateFunctionSource(fn) : "";
+  const predicate = fn ? createBrowserWaitPredicate(predicateSource) : undefined;
   const { abortPromise, cleanup } = createAbortPromise(opts.signal);
   const reconcileRemoteDialog = () => reconcileRemoteDialogAfterActionSettled(page, opts.signal);
   const waitForStep = async <T>(stepPromise: Promise<T>) => {
     await awaitActionWithAbort(stepPromise, abortPromise, reconcileRemoteDialog);
   };
-
-  try {
-    // Playwright exposes no per-wait cancellation; retiring the shared
-    // connection would disrupt sibling tabs. Keep waits outside this guard.
+  const waitForSettledStep = async <T>(stepPromise: Promise<T>) => {
+    await stepPromise;
+    reconcileRemoteDialog();
+    throwIfInteractionAborted(opts.signal);
+  };
+  const runWaitSequence = async (
+    waitFor: <T>(stepPromise: Promise<T>) => Promise<void>,
+  ): Promise<void> => {
     if (typeof opts.timeMs === "number" && Number.isFinite(opts.timeMs)) {
-      await waitForStep(
+      await waitFor(
         page.waitForTimeout(
           resolveBoundedDelayMs(opts.timeMs, "wait timeMs", ACT_MAX_WAIT_TIME_MS),
         ),
       );
     }
     if (opts.text) {
-      await waitForStep(
+      await waitFor(
         page.getByText(opts.text).first().waitFor({
           state: "visible",
           timeout,
@@ -1348,7 +1397,7 @@ export async function waitForViaPlaywright(opts: {
       );
     }
     if (opts.textGone) {
-      await waitForStep(
+      await waitFor(
         page.getByText(opts.textGone).first().waitFor({
           state: "hidden",
           timeout,
@@ -1358,24 +1407,61 @@ export async function waitForViaPlaywright(opts: {
     if (opts.selector) {
       const selector = normalizeOptionalString(opts.selector) ?? "";
       if (selector) {
-        await waitForStep(page.locator(selector).first().waitFor({ state: "visible", timeout }));
+        await waitFor(page.locator(selector).first().waitFor({ state: "visible", timeout }));
       }
     }
     if (opts.url) {
       const url = normalizeOptionalString(opts.url) ?? "";
       if (url) {
-        await waitForStep(page.waitForURL(url, { timeout }));
+        await waitFor(page.waitForURL(url, { timeout }));
       }
     }
     if (opts.loadState) {
-      await waitForStep(page.waitForLoadState(opts.loadState, { timeout }));
+      await waitFor(page.waitForLoadState(opts.loadState, { timeout }));
     }
-    if (opts.fn) {
-      const fn = normalizeOptionalString(opts.fn) ?? "";
-      if (fn) {
-        await waitForStep(page.waitForFunction(fn, { timeout }));
+    if (fn) {
+      // Passing the live document handle makes Playwright fail instead of
+      // recreating this predicate in a replacement execution context.
+      const documentHandle = await page.evaluateHandle(() => globalThis.document);
+      try {
+        throwIfInteractionAborted(opts.signal);
+        await waitFor(
+          page.waitForFunction(
+            predicate!,
+            {
+              document: documentHandle,
+            } satisfies BrowserWaitPredicateState,
+            { timeout },
+          ),
+        );
+      } finally {
+        await documentHandle.dispose();
       }
     }
+  };
+
+  try {
+    // Playwright exposes no per-wait cancellation; retiring the shared
+    // connection would disrupt sibling tabs. Only executable waits need the
+    // request guard, which must own the full sequence before their predicate.
+    // `fn` shares the explicit evaluateEnabled trust contract with evaluate;
+    // this guard owns navigation during the action, not jobs trusted JS schedules later.
+    if (!fn) {
+      await runWaitSequence(waitForStep);
+      return;
+    }
+    await awaitNavigationGuardedInteraction(
+      {
+        action: async () => await runWaitSequence(waitForSettledStep),
+        cdpUrl: opts.cdpUrl,
+        page,
+        ...interactionNavigationPolicy(opts),
+        targetId: opts.targetId,
+      },
+      abortPromise,
+      opts.signal,
+      reconcileRemoteDialog,
+    );
   } finally {
     cleanup();
   }
@@ -1809,6 +1895,7 @@ async function executeSingleAction(
         loadState: action.loadState,
         fn: action.fn,
         timeoutMs: action.timeoutMs,
+        ...navigationPolicy,
         signal,
       });
       break;
@@ -1853,8 +1940,9 @@ function actionUsesNavigationRequestGuard(action: BrowserActRequest): boolean {
   switch (action.kind) {
     case "close":
     case "resize":
-    case "wait":
       return false;
+    case "wait":
+      return Boolean(action.fn);
     case "batch":
       return action.actions.some(actionUsesNavigationRequestGuard);
     default:

--- a/extensions/browser/src/browser/pw-tools-core.last-file-chooser-arm-wins.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.last-file-chooser-arm-wins.test.ts
@@ -117,7 +117,9 @@ describe("pw-tools-core", () => {
     const waitForSelector = vi.fn(async () => {});
     const waitForURL = vi.fn(async () => {});
     const waitForLoadState = vi.fn(async () => {});
-    const waitForFunction = vi.fn(async () => {});
+    const waitForFunction = vi.fn(
+      async (_predicate: unknown, _state: unknown, _options: unknown) => {},
+    );
     const waitForTimeout = vi.fn(async () => {});
     const documentHandle = { dispose: vi.fn(async () => {}) };
 

--- a/extensions/browser/src/browser/pw-tools-core.last-file-chooser-arm-wins.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.last-file-chooser-arm-wins.test.ts
@@ -119,8 +119,10 @@ describe("pw-tools-core", () => {
     const waitForLoadState = vi.fn(async () => {});
     const waitForFunction = vi.fn(async () => {});
     const waitForTimeout = vi.fn(async () => {});
+    const documentHandle = { dispose: vi.fn(async () => {}) };
 
     const page = {
+      evaluateHandle: vi.fn(async () => documentHandle),
       locator: vi.fn(() => ({
         first: () => ({ waitFor: waitForSelector }),
       })),
@@ -152,9 +154,13 @@ describe("pw-tools-core", () => {
     expect(waitForLoadState).toHaveBeenCalledWith("networkidle", {
       timeout: 1234,
     });
-    expect(waitForFunction).toHaveBeenCalledWith("window.ready===true", {
-      timeout: 1234,
-    });
+    expect(waitForFunction).toHaveBeenCalledWith(
+      expect.any(Function),
+      { document: documentHandle },
+      { timeout: 1234 },
+    );
+    expect(String(waitForFunction.mock.calls[0]?.[0])).toContain("window.ready===true");
+    expect(documentHandle.dispose).toHaveBeenCalledOnce();
   });
 
   it("clamps wait timeoutMs to 120000 for wait steps", async () => {

--- a/extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts
+++ b/extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts
@@ -113,6 +113,8 @@ describe("existing-session interaction navigation guard", () => {
         }),
     );
     routeState.tab.url = "https://example.com";
+    routeState.profileCtx.closeTab.mockReset();
+    routeState.profileCtx.closeTab.mockResolvedValue(undefined);
     routeState.profileCtx.listTabs.mockReset();
     routeState.profileCtx.listTabs.mockResolvedValue([
       {
@@ -201,6 +203,23 @@ describe("existing-session interaction navigation guard", () => {
       "https://example.com",
     );
     expect(String(evaluate.mock.calls[1]?.[0])).toContain("document.title === 'ready'");
+  });
+
+  it("preserves promise-returning predicates inside the bound document", async () => {
+    const evaluate = vi
+      .fn()
+      .mockResolvedValueOnce("https://example.com")
+      .mockResolvedValueOnce({ kind: "result", ready: true });
+    chromeMcpMocks.withChromeMcpDocument.mockImplementationOnce(
+      async (_params, task) => await task({ evaluate }),
+    );
+
+    const response = await runAction({ kind: "wait", fn: "() => Promise.resolve(true)" });
+
+    expect(response.statusCode).toBe(200);
+    const script = String(evaluate.mock.calls[1]?.[0]);
+    expect(script).toContain("Boolean(await");
+    expect(routeState.profileCtx.closeTab).not.toHaveBeenCalled();
   });
 
   it("does not run a wait predicate in a document rejected by navigation policy", async () => {

--- a/extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts
+++ b/extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts
@@ -7,6 +7,7 @@ import {
 import { createBrowserRouteApp, createBrowserRouteResponse } from "./test-helpers.js";
 
 const chromeMcpMocks = vi.hoisted(() => ({
+  ChromeMcpDocumentUnavailableError: class ChromeMcpDocumentUnavailableError extends Error {},
   clickChromeMcpCoords: vi.fn(async () => {}),
   clickChromeMcpElement: vi.fn(async () => {}),
   dragChromeMcpElement: vi.fn(async () => {}),
@@ -15,6 +16,15 @@ const chromeMcpMocks = vi.hoisted(() => ({
   fillChromeMcpForm: vi.fn(async () => {}),
   hoverChromeMcpElement: vi.fn(async () => {}),
   pressChromeMcpKey: vi.fn(async () => {}),
+  withChromeMcpDocument: vi.fn(
+    async (_params: unknown, task: (document: { evaluate: (fn: string) => unknown }) => unknown) =>
+      await task({
+        evaluate: async (fn) =>
+          fn.includes("globalThis.location.href")
+            ? "https://example.com"
+            : { kind: "result", ready: true },
+      }),
+  ),
 }));
 
 const navigationGuardMocks = vi.hoisted(() => ({
@@ -26,6 +36,7 @@ const navigationGuardMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../chrome-mcp.js", () => ({
+  ChromeMcpDocumentUnavailableError: chromeMcpMocks.ChromeMcpDocumentUnavailableError,
   clickChromeMcpCoords: chromeMcpMocks.clickChromeMcpCoords,
   clickChromeMcpElement: chromeMcpMocks.clickChromeMcpElement,
   closeChromeMcpTab: vi.fn(async () => {}),
@@ -36,6 +47,7 @@ vi.mock("../chrome-mcp.js", () => ({
   hoverChromeMcpElement: chromeMcpMocks.hoverChromeMcpElement,
   pressChromeMcpKey: chromeMcpMocks.pressChromeMcpKey,
   resizeChromeMcpPage: vi.fn(async () => {}),
+  withChromeMcpDocument: chromeMcpMocks.withChromeMcpDocument,
 }));
 
 vi.mock("../navigation-guard.js", () => navigationGuardMocks);
@@ -77,7 +89,9 @@ describe("existing-session interaction navigation guard", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     for (const fn of Object.values(chromeMcpMocks)) {
-      fn.mockClear();
+      if ("mockClear" in fn) {
+        fn.mockClear();
+      }
     }
     for (const fn of Object.values(navigationGuardMocks)) {
       fn.mockClear();
@@ -86,6 +100,18 @@ describe("existing-session interaction navigation guard", () => {
       async (_opts?: { url: string; ssrfPolicy?: unknown }) => {},
     );
     chromeMcpMocks.evaluateChromeMcpScript.mockResolvedValue("https://example.com");
+    chromeMcpMocks.withChromeMcpDocument.mockImplementation(
+      async (
+        _params: unknown,
+        task: (document: { evaluate: (fn: string) => unknown }) => unknown,
+      ) =>
+        await task({
+          evaluate: async (fn) =>
+            fn.includes("globalThis.location.href")
+              ? "https://example.com"
+              : { kind: "result", ready: true },
+        }),
+    );
     routeState.tab.url = "https://example.com";
     routeState.profileCtx.listTabs.mockReset();
     routeState.profileCtx.listTabs.mockResolvedValue([
@@ -156,6 +182,67 @@ describe("existing-session interaction navigation guard", () => {
       expect.objectContaining({ key: "Enter" }),
     );
     expectNavigationProbeUrls(Array.from({ length: 8 }, () => "https://example.com"));
+  });
+
+  it("checks the bound document URL before evaluating a wait predicate", async () => {
+    const evaluate = vi
+      .fn()
+      .mockResolvedValueOnce("https://example.com")
+      .mockResolvedValueOnce({ kind: "result", ready: true });
+    chromeMcpMocks.withChromeMcpDocument.mockImplementationOnce(
+      async (_params, task) => await task({ evaluate }),
+    );
+
+    const response = await runAction({ kind: "wait", fn: "() => document.title === 'ready'" });
+
+    expect(response.statusCode).toBe(200);
+    expect(evaluate).toHaveBeenCalledTimes(2);
+    expect(navigationGuardMocks.assertBrowserNavigationResultAllowed.mock.calls[0]?.[0]?.url).toBe(
+      "https://example.com",
+    );
+    expect(String(evaluate.mock.calls[1]?.[0])).toContain("document.title === 'ready'");
+  });
+
+  it("does not run a wait predicate in a document rejected by navigation policy", async () => {
+    const evaluate = vi.fn().mockResolvedValue("http://169.254.169.254/latest/meta-data");
+    chromeMcpMocks.withChromeMcpDocument.mockImplementationOnce(
+      async (_params, task) => await task({ evaluate }),
+    );
+    navigationGuardMocks.assertBrowserNavigationResultAllowed
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("blocked document"));
+
+    await expectActionToThrow({ kind: "wait", fn: "() => document.cookie" }, "blocked document");
+
+    expect(evaluate).toHaveBeenCalledOnce();
+    expect(String(evaluate.mock.calls[0]?.[0])).not.toContain("document.cookie");
+  });
+
+  it("rechecks a requested URL after a ready predicate mutates same-document history", async () => {
+    chromeMcpMocks.withChromeMcpDocument.mockImplementation(async (_params, task) => {
+      let urlReads = 0;
+      return await task({
+        evaluate: async (fn) => {
+          if (!fn.includes("globalThis.location.href")) {
+            return { kind: "result", ready: true };
+          }
+          urlReads += 1;
+          if (urlReads === 2) {
+            throw new Error("final URL rechecked");
+          }
+          return "https://example.com/ready";
+        },
+      });
+    });
+
+    await expectActionToThrow(
+      {
+        kind: "wait",
+        url: "https://example.com/ready",
+        fn: "() => { history.pushState({}, '', '/changed'); return true; }",
+      },
+      "final URL rechecked",
+    );
   });
 
   it.each(GUARDED_TARGET_REFRESH_ACTIONS)(

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -214,7 +214,10 @@ function buildExistingSessionWaitPredicate(params: {
     checks.push(`document.readyState === "complete"`);
   }
   if (params.fn) {
-    checks.push(`Boolean(await (${params.fn})())`);
+    // `fn` is admitted only by the same evaluateEnabled gate as evaluate.
+    // Preserve its async semantics; document binding guards scheduler rebinding.
+    const source = normalizeBrowserEvaluateFunctionSource(params.fn);
+    checks.push(`Boolean(await (${source})())`);
   }
   if (checks.length === 0) {
     return null;
@@ -281,7 +284,10 @@ async function waitForExistingSessionCondition(
           try {
             return { kind: "result", ready: Boolean(await (${predicate})) };
           } catch (error) {
-            return { kind: "error", message: error instanceof Error ? error.message : String(error) };
+            const message = error && typeof error === "object" && "message" in error
+              ? String(error.message)
+              : String(error);
+            return { kind: "error", message };
           }
         }`);
         if (!outcome || typeof outcome !== "object") {

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -8,6 +8,7 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { formatErrorMessage } from "../../infra/errors.js";
 import {
+  ChromeMcpDocumentUnavailableError,
   clickChromeMcpElement,
   clickChromeMcpCoords,
   dragChromeMcpElement,
@@ -17,6 +18,7 @@ import {
   hoverChromeMcpElement,
   pressChromeMcpKey,
   resizeChromeMcpPage,
+  withChromeMcpDocument,
   type ChromeMcpOperationOptions,
   type ChromeMcpProfileOptions,
 } from "../chrome-mcp.js";
@@ -231,6 +233,8 @@ async function waitForExistingSessionCondition(
     url?: string;
     loadState?: "load" | "domcontentloaded" | "networkidle";
     fn?: string;
+    ssrfPolicy?: BrowserNavigationPolicyOptions["ssrfPolicy"];
+    browserProxyMode?: BrowserNavigationPolicyOptions["browserProxyMode"];
   },
 ): Promise<void> {
   if (params.timeMs && params.timeMs > 0) {
@@ -243,24 +247,71 @@ async function waitForExistingSessionCondition(
   const timeoutMs = Math.max(250, params.timeoutMs ?? 10_000);
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    let ready = true;
-    if (predicate) {
-      ready = Boolean(
-        await evaluateChromeMcpScript({
-          ...params,
-          fn: `async () => ${predicate}`,
-        }),
-      );
-    }
-    if (ready && params.url) {
-      const currentUrl = await evaluateChromeMcpScript({
-        ...params,
-        fn: "() => window.location.href",
+    try {
+      const ready = await withChromeMcpDocument(params, async (document) => {
+        const readAllowedUrl = async () => {
+          const url = await document.evaluate(`(root) => {
+            const boundDocument = root?.nodeType === 9 ? root : root?.ownerDocument;
+            return boundDocument === globalThis.document ? globalThis.location.href : null;
+          }`);
+          if (typeof url !== "string" || !url.trim()) {
+            return null;
+          }
+          await assertBrowserNavigationResultAllowed({
+            url,
+            ...withBrowserNavigationPolicy(params.ssrfPolicy, {
+              browserProxyMode: params.browserProxyMode,
+            }),
+          });
+          return url;
+        };
+        const currentUrl = await readAllowedUrl();
+        if (!currentUrl) {
+          return false;
+        }
+        if (params.url && !matchBrowserUrlPattern(params.url, currentUrl)) {
+          return false;
+        }
+        if (!predicate) {
+          return true;
+        }
+        const outcome = await document.evaluate(`async (root) => {
+          const boundDocument = root?.nodeType === 9 ? root : root?.ownerDocument;
+          if (boundDocument !== globalThis.document) return { kind: "navigation" };
+          try {
+            return { kind: "result", ready: Boolean(await (${predicate})) };
+          } catch (error) {
+            return { kind: "error", message: error instanceof Error ? error.message : String(error) };
+          }
+        }`);
+        if (!outcome || typeof outcome !== "object") {
+          throw new Error("Document-bound wait returned an invalid result");
+        }
+        if ("kind" in outcome && outcome.kind === "error") {
+          throw new Error(
+            "message" in outcome && typeof outcome.message === "string"
+              ? outcome.message
+              : "Wait predicate failed",
+          );
+        }
+        const predicateReady =
+          "kind" in outcome &&
+          outcome.kind === "result" &&
+          "ready" in outcome &&
+          outcome.ready === true;
+        if (!predicateReady || !params.url) {
+          return predicateReady;
+        }
+        const finalUrl = await readAllowedUrl();
+        return finalUrl !== null && matchBrowserUrlPattern(params.url, finalUrl);
       });
-      ready = typeof currentUrl === "string" && matchBrowserUrlPattern(params.url, currentUrl);
-    }
-    if (ready) {
-      return;
+      if (ready) {
+        return;
+      }
+    } catch (error) {
+      if (!(error instanceof ChromeMcpDocumentUnavailableError)) {
+        throw error;
+      }
     }
     await sleep(250, undefined, { signal: params.signal });
   }
@@ -600,15 +651,20 @@ export function registerBrowserAgentActRoutes(
                 });
                 return await jsonOk();
               case "wait":
-                await waitForExistingSessionCondition({
-                  ...existingSessionTarget,
-                  timeMs: action.timeMs,
-                  text: action.text,
-                  textGone: action.textGone,
-                  selector: action.selector,
-                  url: action.url,
-                  loadState: action.loadState,
-                  fn: action.fn,
+                await runExistingSessionActionWithNavigationGuard({
+                  execute: () =>
+                    waitForExistingSessionCondition({
+                      ...existingSessionTarget,
+                      timeMs: action.timeMs,
+                      text: action.text,
+                      textGone: action.textGone,
+                      selector: action.selector,
+                      url: action.url,
+                      loadState: action.loadState,
+                      fn: action.fn,
+                      ...navigationPolicy,
+                    }),
+                  guard: existingSessionNavigationGuard,
                 });
                 return await jsonOk();
               case "evaluate": {

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -193,7 +193,7 @@ describe("production lint suppressions", () => {
   it("keeps the intentional production suppression tail on an explicit allowlist", () => {
     expect(summarizeSuppressions(collectProductionLintSuppressions())).toEqual(
       filterExpectedSuppressionsForPresentFiles([
-        "extensions/browser/src/browser/pw-tools-core.interactions.ts|@typescript-eslint/no-implied-eval|2",
+        "extensions/browser/src/browser/pw-tools-core.interactions.ts|@typescript-eslint/no-implied-eval|3",
         "extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.ts|typescript/no-unnecessary-type-parameters|1",
         "extensions/browser/src/node-host/invoke-browser.ts|typescript/no-unnecessary-type-parameters|1",
         "extensions/diffs/src/viewer-client.ts|eslint/no-underscore-dangle|1",


### PR DESCRIPTION
## What Problem This Solves

Browser `wait` predicates could be re-created in a replacement document before navigation policy approved that document. Managed Playwright's polling scheduler re-runs across execution-context replacement, while the Chrome-MCP polling loop could attach to a new document between iterations.

## Why This Change Was Made

- Managed Playwright now installs the existing request-level navigation guard before the full wait sequence and pins executable polling to a real `document` handle. A replacement execution context cannot adopt that handle, so user code is never re-created in another document.
- Synchronous and asynchronous predicate semantics are preserved. Promise results are tracked in the persistent Playwright polling state without making the polling callback itself async.
- Chrome-MCP existing-session waits now acquire the top-level `RootWebArea` UID and evaluate URL checks plus predicates through one locked target/session transaction. Only typed stale-document failures retry, and every retry re-checks navigation policy before predicate execution.
- No Chrome-MCP version pin, custom-server compatibility gate, new configuration, or documentation contract was added.
- This rewrite is 215 net production lines and 647 net lines total, versus the submitted design's 551 net production lines and 1,367 net lines total: 61% less production growth and 53% less total growth.

`fn` remains part of the explicit `browser.evaluateEnabled` trusted-JavaScript surface, just like `evaluate`. This change enforces the document/navigation boundary; it does not pretend trusted JavaScript cannot schedule later work.

## User Impact

Allowed waits keep their existing synchronous and asynchronous behavior. A wait predicate cannot silently resume in a policy-denied replacement document, and existing-session waits fail closed if their document/session identity becomes stale. Passive waits remain unchanged.

## Evidence

- Exact head: `92814ac3f20`
- Fresh branch autoreview at exact head: clean, no accepted/actionable findings.
- Blacksmith Testbox lease `tbx_01kxb1xd06xsh809y528512fwr`: focused Browser suite passed 192/192; exact-head `pnpm check:changed` passed formatting, production/test types, lint, dependency pins, API baseline, database-first guard, and import cycles; exact-head `pnpm build` passed. After hosted CI exposed the explicit lint-suppression count drift, the corrected baseline test passed 3/3 on the same Testbox and a fresh autoreview was clean (correctness 0.96). Provisioning run: https://github.com/openclaw/openclaw/actions/runs/29191172358
- Real managed-browser proof: a Dev Gateway and OpenAI agent opened an allowed page, issued an executable wait, attempted delayed navigation to a blocked private destination, observed the policy denial, confirmed the denied document never ran the predicate, preserved the source document, and kept the Gateway healthy.
- Real existing-session proof: a Dev Gateway and OpenAI agent repeated the scenario through Chrome-MCP; the blocked document never ran the predicate and the Gateway stayed healthy.
- Playwright 1.61.1 dependency audit: `waitForFunction(pageFunction, arg, options)` treats the second argument as data and strings as expressions; the server scheduler re-runs polling across execution contexts, while non-element JS handles cannot cross contexts. The rewrite passes a real function, state argument, timeout options, and a document handle accordingly.
- Chrome DevTools MCP 1.5.0 dependency audit: `evaluate_script` resolves supplied UIDs through the current snapshot and owning page/frame; snapshot UIDs include loader/backend-node identity. The rewrite uses the top-level `RootWebArea` UID inside the existing target/session lock.

No known proof gaps remain for the changed behavior.
