### PR TITLE
fix: cancel Android link preview calls

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatLinkPreview.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatLinkPreview.kt
@@ -4,14 +4,19 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.util.LruCache
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import okhttp3.Authenticator
+import okhttp3.Call
+import okhttp3.Callback
 import okhttp3.CookieJar
 import okhttp3.Dns
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.Response
 import okhttp3.ResponseBody
 import okio.Buffer
 import org.commonmark.node.Code
@@ -28,6 +33,7 @@ import java.net.URI
 import java.net.UnknownHostException
 import java.util.Locale
 import java.util.concurrent.TimeUnit
+import kotlin.coroutines.resume
 import kotlin.math.max
 
 internal const val LINK_PREVIEW_TITLE_MAX_CHARS = 120
@@ -136,7 +142,7 @@ internal class LinkPreviewFetcher(
       fetchImageBlocking(url)
     }
 
-  private fun fetchBlocking(originalUrl: String): LinkPreviewResult {
+  private suspend fun fetchBlocking(originalUrl: String): LinkPreviewResult {
     val response =
       fetchBody(
         originalUrl = originalUrl,
@@ -152,7 +158,7 @@ internal class LinkPreviewFetcher(
     }
   }
 
-  private fun fetchImageBlocking(url: String): LinkPreviewImageResult {
+  private suspend fun fetchImageBlocking(url: String): LinkPreviewImageResult {
     val response =
       fetchBody(
         originalUrl = url,
@@ -169,7 +175,7 @@ internal class LinkPreviewFetcher(
     return LinkPreviewImageResult.Loaded(bitmap)
   }
 
-  private fun fetchBody(
+  private suspend fun fetchBody(
     originalUrl: String,
     accept: String,
     allowedContentTypes: Set<String>,
@@ -198,7 +204,7 @@ internal class LinkPreviewFetcher(
       val call = client.newCall(request)
       call.timeout().timeout(remainingNanos, TimeUnit.NANOSECONDS)
 
-      val response = runCatching { call.execute() }.getOrElse { return null }
+      val response = call.awaitResponse() ?: return null
       response.use {
         if (it.isRedirect) {
           if (redirects >= LINK_PREVIEW_MAX_REDIRECTS) return null
@@ -211,12 +217,7 @@ internal class LinkPreviewFetcher(
         val contentTypeName = "${contentType.type}/${contentType.subtype}".lowercase(Locale.US)
         if (contentTypeName !in allowedContentTypes) return null
 
-        val bytes =
-          try {
-            readBody(it.body, maxBytes, rejectOversizedBody)
-          } catch (_: IOException) {
-            return null
-          } ?: return null
+        val bytes = call.awaitBodyRead { readBody(it.body, maxBytes, rejectOversizedBody) } ?: return null
         return LinkPreviewFetchedBody(
           url = currentUrl,
           bytes = bytes,
@@ -227,6 +228,51 @@ internal class LinkPreviewFetcher(
     }
   }
 }
+
+private suspend fun Call.awaitResponse(): Response? =
+  suspendCancellableCoroutine { continuation ->
+    continuation.invokeOnCancellation { cancel() }
+    enqueue(
+      object : Callback {
+        override fun onFailure(
+          call: Call,
+          e: IOException,
+        ) {
+          if (continuation.isActive) {
+            continuation.resume(null)
+          }
+        }
+
+        override fun onResponse(
+          call: Call,
+          response: Response,
+        ) {
+          if (continuation.isActive) {
+            continuation.resume(response) { _, cancelledResponse, _ ->
+              cancelledResponse.close()
+            }
+          } else {
+            response.close()
+          }
+        }
+      },
+    )
+  }
+
+private suspend fun <T> Call.awaitBodyRead(block: () -> T?): T? =
+  suspendCancellableCoroutine { continuation ->
+    continuation.invokeOnCancellation { cancel() }
+    try {
+      val result = block()
+      if (continuation.isActive) {
+        continuation.resume(result)
+      }
+    } catch (_: IOException) {
+      if (continuation.isActive) {
+        continuation.resume(null)
+      }
+    }
+  }
 
 private data class LinkPreviewFetchedBody(
   val url: HttpUrl,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatLinkPreview.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatLinkPreview.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import okhttp3.Authenticator
 import okhttp3.Call
-import okhttp3.Callback
 import okhttp3.CookieJar
 import okhttp3.Dns
 import okhttp3.HttpUrl
@@ -204,7 +203,7 @@ internal class LinkPreviewFetcher(
       val call = client.newCall(request)
       call.timeout().timeout(remainingNanos, TimeUnit.NANOSECONDS)
 
-      val response = call.awaitResponse() ?: return null
+      val response = call.executeCancellable() ?: return null
       response.use {
         if (it.isRedirect) {
           if (redirects >= LINK_PREVIEW_MAX_REDIRECTS) return null
@@ -229,34 +228,23 @@ internal class LinkPreviewFetcher(
   }
 }
 
-private suspend fun Call.awaitResponse(): Response? =
+private suspend fun Call.executeCancellable(): Response? =
   suspendCancellableCoroutine { continuation ->
+    // execute() blocks this IO worker, so cancellation must close the Call from the cancelling thread.
     continuation.invokeOnCancellation { cancel() }
-    enqueue(
-      object : Callback {
-        override fun onFailure(
-          call: Call,
-          e: IOException,
-        ) {
-          if (continuation.isActive) {
-            continuation.resume(null)
-          }
-        }
-
-        override fun onResponse(
-          call: Call,
-          response: Response,
-        ) {
-          if (continuation.isActive) {
-            continuation.resume(response) { _, cancelledResponse, _ ->
-              cancelledResponse.close()
-            }
-          } else {
-            response.close()
-          }
-        }
-      },
-    )
+    val response =
+      try {
+        execute()
+      } catch (_: IOException) {
+        null
+      }
+    if (response != null) {
+      continuation.resume(response) { _, cancelledResponse, _ ->
+        cancelledResponse.close()
+      }
+    } else if (continuation.isActive) {
+      continuation.resume(null)
+    }
   }
 
 private suspend fun <T> Call.awaitBodyRead(block: () -> T?): T? =

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatLinkPreview.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatLinkPreview.kt
@@ -230,7 +230,7 @@ internal class LinkPreviewFetcher(
 
 private suspend fun Call.executeCancellable(): Response? =
   suspendCancellableCoroutine { continuation ->
-    // execute() blocks this IO worker, so cancellation must close the Call from the cancelling thread.
+    // execute() blocks this IO worker, so cancellation must cancel the Call from the cancelling thread.
     continuation.invokeOnCancellation { cancel() }
     val response =
       try {

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatLinkPreviewTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatLinkPreviewTest.kt
@@ -262,8 +262,9 @@ class ChatLinkPreviewTest {
       coroutineScope {
         server.enqueue(
           MockResponse()
+            // Cancel before OkHttp produces a Response.
             .setHeader("Content-Type", "text/html")
-            .setBodyDelay(30, TimeUnit.SECONDS)
+            .setHeadersDelay(30, TimeUnit.SECONDS)
             .setBody("<title>Never delivered</title>"),
         )
 
@@ -281,6 +282,7 @@ class ChatLinkPreviewTest {
       coroutineScope {
         server.enqueue(
           MockResponse()
+            // Cancel while OkHttp is reading the response body.
             .setHeader("Content-Type", "image/png")
             .setBodyDelay(30, TimeUnit.SECONDS)
             .setBody(Buffer().write(pngBytes(width = 10, height = 10))),

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatLinkPreviewTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatLinkPreviewTest.kt
@@ -2,7 +2,14 @@ package ai.openclaw.app.ui.chat
 
 import android.graphics.Bitmap
 import android.graphics.Color
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import okhttp3.Dns
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
@@ -248,6 +255,47 @@ class ChatLinkPreviewTest {
 
       assertSame(LinkPreviewResult.Failed, fetcher().fetch(server.url("/disconnect").toString()))
     }
+
+  @Test
+  fun cancellationCancelsActiveMetadataAndImageCalls() {
+    withServer { server ->
+      coroutineScope {
+        server.enqueue(
+          MockResponse()
+            .setHeader("Content-Type", "text/html")
+            .setBodyDelay(30, TimeUnit.SECONDS)
+            .setBody("<title>Never delivered</title>"),
+        )
+
+        val metadataFetch = async { fetcher(timeoutMillis = 60_000).fetch(server.url("/slow-page").toString()) }
+        assertTrue(withContext(Dispatchers.IO) { server.takeRequest(1, TimeUnit.SECONDS) } != null)
+        delay(100)
+
+        withTimeout(1_000) {
+          metadataFetch.cancelAndJoin()
+        }
+      }
+    }
+
+    withServer { server ->
+      coroutineScope {
+        server.enqueue(
+          MockResponse()
+            .setHeader("Content-Type", "image/png")
+            .setBodyDelay(30, TimeUnit.SECONDS)
+            .setBody(Buffer().write(pngBytes(width = 10, height = 10))),
+        )
+
+        val imageFetch = async { fetcher(timeoutMillis = 60_000).fetchImage(server.url("/slow-image.png").toString()) }
+        assertTrue(withContext(Dispatchers.IO) { server.takeRequest(1, TimeUnit.SECONDS) } != null)
+        delay(100)
+
+        withTimeout(1_000) {
+          imageFetch.cancelAndJoin()
+        }
+      }
+    }
+  }
 
   @Test
   fun allowsHttpToHttpsRedirectAndRejectsFileRedirect() {


### PR DESCRIPTION
Closes #101810

AI-assisted with Codex.

## What Problem This Solves

Fixes an issue where Android chat link previews could keep background network work alive after the preview coroutine was cancelled, such as when users scroll away from a preview or leave the chat screen while metadata or image fetches are still in flight.

## Why This Change Was Made

The Android link preview fetcher now executes OkHttp calls through a cancellable coroutine bridge that maps coroutine cancellation to `Call.cancel()`. The same cancellation path is kept active through response body reads, so both metadata and image preview fetches stop promptly without changing the existing wall-clock deadline.

## User Impact

Android users can cancel or leave link preview loading without stranding slow preview downloads on background work. Metadata and image preview behavior remains unchanged for successful fetches, redirects, content-type checks, and cache behavior.

## Evidence

- `JAVA_HOME=/Users/nianjiu/.gradle/jdks/eclipse_adoptium-21-aarch64-os_x.2/jdk-21.0.7+6/Contents/Home pnpm android:test --tests ai.openclaw.app.ui.chat.ChatLinkPreviewTest --rerun-tasks` passed: 33 executed tasks, including forced `ChatLinkPreviewTest` execution.
- `cd apps/android && JAVA_HOME=/Users/nianjiu/.gradle/jdks/eclipse_adoptium-21-aarch64-os_x.2/jdk-21.0.7+6/Contents/Home ./gradlew :app:ktlintCheck` passed.
- `git diff --check` passed.
- Initial local Android test attempts exposed a local Gradle daemon using a VS Code extension JRE without `jlink`; stopping the daemon and using the full Gradle-managed JDK 21 above resolved the local toolchain issue.
- The MockWebServer regression covers metadata cancellation while response headers are pending and image cancellation while the response body is delayed.
- Maintainer follow-up retained synchronous `Call.execute()` on `Dispatchers.IO`; OkHttp 5.4.0 source shows that switching to `enqueue()` would start the call timeout only after async-dispatcher promotion and could extend the existing deadline under queue saturation.
- Exact-head GitHub CI run [29002817091](https://github.com/openclaw/openclaw/actions/runs/29002817091) passed Play and third-party Android tests, Android assemble/lint, and ktlint at `d015697c91cfa21a87f1288ba20276dd50fa0da6`.
- Final exact-head autoreview passed with no accepted/actionable findings.
