### PR TITLE
docs: add product one-liner to AGENTS.md Start

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ Skills own workflows; root owns hard policy and routing.
 ## Start
 
 - Repo: `https://github.com/openclaw/openclaw`
+- Product: OpenClaw = personal AI assistant on your own devices. Gateway = control plane, assistant = product; channels (WhatsApp/Telegram/Slack/Discord/...) are transports; plugins extend channels, providers, skills.
 - Replies: repo-root refs only: `extensions/telegram/src/index.ts:80`. No absolute paths, no `~/`.
 - Docs/user-visible work: `pnpm docs:list`, then read relevant docs only.
 - Existing-solutions preflight: before proposing or building a custom system, feature, workflow, tool, integration, or automation, do a lightweight check for open-source projects, maintained libraries, existing OpenClaw plugins, or free platforms that already solve it well enough. Prefer those when adequate. Build custom only when existing options are unsuitable, too expensive, unmaintained, unsafe, non-compliant, or the user explicitly asks for custom. Avoid paid-service recommendations unless the user explicitly approves spend. Keep this to a brief preflight gate, not a broad research assignment.


### PR DESCRIPTION
## What Problem This Solves

Root `AGENTS.md` opens with policy and routing but never states what OpenClaw is. Agents and new contributors bootstrapping from it must round-trip to `README.md` for basic product framing before rules like the Gateway/channel/plugin ownership boundaries make sense.

## Why This Change Was Made

Adds one telegraph-style line to `## Start` naming the product (personal AI assistant on your own devices), the Gateway's control-plane role, channels as transports, and plugins as the extension surface. Docs-only; no policy or behavior change.

## User Impact

No runtime or user-visible impact. Contributor/agent docs only: anyone reading root `AGENTS.md` first gets immediate product context without opening the README.

## Evidence

Docs-only, single insertion (`AGENTS.md:9`):

```
- Product: OpenClaw = personal AI assistant on your own devices. Gateway = control plane, assistant = product; channels (WhatsApp/Telegram/Slack/Discord/...) are transports; plugins extend channels, providers, skills.
```

`git diff --check` clean; 1 file changed, 1 insertion, 0 deletions. Wording follows the repo naming rules (OpenClaw product casing, "plugins" wording).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TorWGLPaUpEHNn7AVoothc
