### PR TITLE
refactor(deadcode): localize UI and script symbols

### DIFF
--- a/scripts/build-diffs-viewer-runtime.mjs
+++ b/scripts/build-diffs-viewer-runtime.mjs
@@ -64,7 +64,7 @@ export function createPierreDiffsSideEffectImportPlugin() {
 /**
  * Builds one configured diffs viewer runtime target.
  */
-export async function buildDiffsViewerRuntime(targetName) {
+async function buildDiffsViewerRuntime(targetName) {
   const target = targets[targetName];
   if (!target) {
     throw new Error(

--- a/scripts/changed-lanes.mjs
+++ b/scripts/changed-lanes.mjs
@@ -357,7 +357,7 @@ export function listStagedChangedPaths(cwd = process.cwd()) {
 /**
  * Classifies package.json script-only changes from git content.
  */
-export function classifyPackageJsonChangeFromGit(params) {
+function classifyPackageJsonChangeFromGit(params) {
   try {
     const { before, after } = readPackageJsonBeforeAfter(params);
     if (isLiveDockerPackageScriptOnlyChange(before, after)) {
@@ -482,7 +482,7 @@ function stableJson(value) {
 /**
  * Writes changed-lane booleans to the GitHub Actions output file.
  */
-export function writeChangedLaneGitHubOutput(result, outputPath = process.env.GITHUB_OUTPUT) {
+function writeChangedLaneGitHubOutput(result, outputPath = process.env.GITHUB_OUTPUT) {
   if (!outputPath) {
     throw new Error("GITHUB_OUTPUT is required");
   }

--- a/scripts/check-changed.mjs
+++ b/scripts/check-changed.mjs
@@ -120,7 +120,7 @@ function executableExistsOnPath(command, env = process.env) {
   return false;
 }
 
-export function shouldSkipAppLintForMissingSwiftlint(options = {}) {
+function shouldSkipAppLintForMissingSwiftlint(options = {}) {
   const env = options.env ?? process.env;
   const platform = options.platform ?? process.platform;
   const swiftlintAvailable = options.swiftlintAvailable ?? executableExistsOnPath("swiftlint", env);
@@ -244,7 +244,7 @@ export function createShrinkwrapGuardCommand(paths) {
   };
 }
 
-export async function runChangedCheckViaCrabbox(argv = [], env = process.env) {
+async function runChangedCheckViaCrabbox(argv = [], env = process.env) {
   console.error("[check:changed] delegating to Blacksmith Testbox via `pnpm crabbox:run`.");
   return await runManagedCommand({
     bin: "pnpm",
@@ -567,7 +567,7 @@ function createTargetedOxlintCommand({
   };
 }
 
-export async function runChangedCheck(result, options = {}) {
+async function runChangedCheck(result, options = {}) {
   const baseEnv = resolveLocalHeavyCheckEnv(options.env ?? process.env);
   const childEnv = createChangedCheckChildEnv(baseEnv);
   const plan = createChangedCheckPlan(result, {

--- a/scripts/check-deadcode-unused-files.mjs
+++ b/scripts/check-deadcode-unused-files.mjs
@@ -114,7 +114,7 @@ export function compareUnusedFilesToAllowlist(
 /**
  * Formats unused-file allowlist drift for CLI output.
  */
-export function formatUnusedFileComparison(comparison) {
+function formatUnusedFileComparison(comparison) {
   const lines = [];
   if (!comparison.allowlistIsSorted) {
     lines.push("deadcode unused-file allowlist is not sorted.");

--- a/scripts/check-dependency-pins.mjs
+++ b/scripts/check-dependency-pins.mjs
@@ -117,7 +117,7 @@ export function collectDependencyPinViolations(cwd = process.cwd()) {
 /**
  * Builds the full dependency pin audit payload.
  */
-export function collectDependencyPinAudit(cwd = process.cwd()) {
+function collectDependencyPinAudit(cwd = process.cwd()) {
   const packageJsonFiles = listTrackedPackageJsonFiles(cwd);
   let packageSpecCount = 0;
   for (const relativePath of packageJsonFiles) {

--- a/scripts/check-dynamic-import-warts.mjs
+++ b/scripts/check-dynamic-import-warts.mjs
@@ -178,7 +178,7 @@ export function findDynamicImportAdvisories(content, fileName = "source.ts") {
 /**
  * Collects dynamic import advisories across configured source roots.
  */
-export async function collectDynamicImportAdvisories(options = {}) {
+async function collectDynamicImportAdvisories(options = {}) {
   const roots = options.roots ?? defaultRoots;
   const files = await collectTypeScriptFilesFromRoots(roots, {
     extraTestSuffixes: [".suite.ts"],

--- a/scripts/check-extension-package-tsc-boundary.mjs
+++ b/scripts/check-extension-package-tsc-boundary.mjs
@@ -674,7 +674,7 @@ export function resolveCanaryArtifactPaths(extensionId, rootDir = repoRoot) {
 /**
  * Removes canary artifacts for one extension.
  */
-export function cleanupCanaryArtifacts(extensionId, rootDir = repoRoot) {
+function cleanupCanaryArtifacts(extensionId, rootDir = repoRoot) {
   const { canaryPath, tsconfigPath } = resolveCanaryArtifactPaths(extensionId, rootDir);
   rmSync(canaryPath, { force: true });
   rmSync(tsconfigPath, { force: true });

--- a/scripts/check-extension-plugin-sdk-boundary.mjs
+++ b/scripts/check-extension-plugin-sdk-boundary.mjs
@@ -229,7 +229,7 @@ function collectEntriesByModeFromModuleReferences(filePath, references) {
 /**
  * Collects the current extension plugin SDK boundary inventory.
  */
-export async function collectExtensionPluginSdkBoundaryInventory(mode) {
+async function collectExtensionPluginSdkBoundaryInventory(mode) {
   if (!MODES.has(mode)) {
     throw new Error(`Unknown mode: ${mode}`);
   }
@@ -307,7 +307,7 @@ function formatInventoryHuman(mode, inventory) {
 /**
  * Runs the boundary inventory check with CLI-style inputs and outputs.
  */
-export async function runExtensionPluginSdkBoundaryCheck(argv, io) {
+async function runExtensionPluginSdkBoundaryCheck(argv, io) {
   const args = argv ?? process.argv.slice(2);
   const streams = io ?? { stdout: process.stdout, stderr: process.stderr };
   const json = args.includes("--json");

--- a/scripts/check-extension-wildcard-reexports.mjs
+++ b/scripts/check-extension-wildcard-reexports.mjs
@@ -52,7 +52,7 @@ export function findLocalWildcardReexports(source) {
 /**
  * Collects guarded extension API/runtime barrels that use wildcard re-exports.
  */
-export async function collectExtensionWildcardReexports(rootDir = repoRoot) {
+async function collectExtensionWildcardReexports(rootDir = repoRoot) {
   const files = await listGuardedFiles(rootDir);
   const violations = [];
   for (const filePath of files) {

--- a/scripts/check-ingress-agent-owner-context.mjs
+++ b/scripts/check-ingress-agent-owner-context.mjs
@@ -23,7 +23,7 @@ const enforcedFiles = new Set([
 /**
  * Finds legacy `agentCommand(...)` call lines in ingress-owned source.
  */
-export function findLegacyAgentCommandCallLines(content, fileName = "source.ts") {
+function findLegacyAgentCommandCallLines(content, fileName = "source.ts") {
   const sourceFile = ts.createSourceFile(fileName, content, ts.ScriptTarget.Latest, true);
   return collectCallExpressionLines(ts, sourceFile, (node) => {
     const callee = unwrapExpression(node.expression);

--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -228,7 +228,7 @@ function isPersistedStringCastType(typeText) {
 /**
  * Collects Kysely/raw SQLite violations from one source file.
  */
-export function collectKyselyGuardrailViolations(content, relativePath) {
+function collectKyselyGuardrailViolations(content, relativePath) {
   const sourceFile = ts.createSourceFile(relativePath, content, ts.ScriptTarget.Latest, true);
   const imports = collectImports(sourceFile);
   const violations = [];
@@ -352,7 +352,7 @@ export function collectKyselyGuardrailViolations(content, relativePath) {
 /**
  * Collects Kysely guardrail violations across configured source roots.
  */
-export async function collectKyselyGuardrails() {
+async function collectKyselyGuardrails() {
   const files = await collectTypeScriptFilesFromRoots(sourceRoots, { includeTests: true });
   const violations = [];
   for (const filePath of files) {

--- a/scripts/check-no-conflict-markers.mjs
+++ b/scripts/check-no-conflict-markers.mjs
@@ -77,7 +77,7 @@ export function findConflictMarkersInFiles(filePaths, readFile = fs.readFileSync
 /**
  * Uses git grep to list tracked files that may contain conflict markers.
  */
-export function listTrackedFilesWithConflictMarkerCandidates(cwd = process.cwd(), run = spawnSync) {
+function listTrackedFilesWithConflictMarkerCandidates(cwd = process.cwd(), run = spawnSync) {
   const result = run(
     "git",
     ["grep", "-l", "-z", "-I", "-E", CONFLICT_MARKER_GREP_PATTERN, "--", "."],

--- a/scripts/check-no-raw-channel-fetch.mjs
+++ b/scripts/check-no-raw-channel-fetch.mjs
@@ -83,7 +83,7 @@ function isRawFetchCall(expression) {
 /**
  * Finds raw `fetch(...)` and `globalThis.fetch(...)` call lines.
  */
-export function findRawFetchCallLines(content, fileName = "source.ts") {
+function findRawFetchCallLines(content, fileName = "source.ts") {
   const sourceFile = ts.createSourceFile(fileName, content, ts.ScriptTarget.Latest, true);
   return collectCallExpressionLines(ts, sourceFile, (node) =>
     isRawFetchCall(node.expression) ? node.expression : null,

--- a/scripts/check-no-register-http-handler.mjs
+++ b/scripts/check-no-register-http-handler.mjs
@@ -19,7 +19,7 @@ function isDeprecatedRegisterHttpHandlerCall(expression) {
 /**
  * Finds deprecated `registerHttpHandler(...)` call lines.
  */
-export function findDeprecatedRegisterHttpHandlerLines(content, fileName = "source.ts") {
+function findDeprecatedRegisterHttpHandlerLines(content, fileName = "source.ts") {
   const sourceFile = ts.createSourceFile(fileName, content, ts.ScriptTarget.Latest, true);
   return collectCallExpressionLines(ts, sourceFile, (node) =>
     isDeprecatedRegisterHttpHandlerCall(node.expression) ? node.expression : null,

--- a/scripts/check-plugin-extension-import-boundary.mjs
+++ b/scripts/check-plugin-extension-import-boundary.mjs
@@ -212,7 +212,7 @@ function formatEntry(entry) {
 /**
  * Runs the plugin-extension import boundary baseline check.
  */
-export async function runPluginExtensionImportBoundaryCheck(argv, io) {
+async function runPluginExtensionImportBoundaryCheck(argv, io) {
   return await runBaselineInventoryCheck({
     argv: argv ?? process.argv.slice(2),
     io,

--- a/scripts/check-plugin-sdk-wildcard-reexports.mjs
+++ b/scripts/check-plugin-sdk-wildcard-reexports.mjs
@@ -48,7 +48,7 @@ export function findPluginSdkWildcardReexports(source) {
 /**
  * Collects extension API barrels that wildcard re-export plugin SDK subpaths.
  */
-export async function collectPluginSdkWildcardReexports(rootDir = repoRoot) {
+async function collectPluginSdkWildcardReexports(rootDir = repoRoot) {
   const files = await listExtensionApiFiles(path.join(rootDir, "extensions"));
   const violations = [];
   for (const filePath of files) {

--- a/scripts/check-protocol-event-coverage.mjs
+++ b/scripts/check-protocol-event-coverage.mjs
@@ -420,7 +420,7 @@ function collectSwiftStaticStringConstants(sources) {
  * Runs the full coverage check against a repo checkout and returns error
  * strings plus a summary for logging.
  */
-export function collectProtocolEventCoverageErrors(params = {}) {
+function collectProtocolEventCoverageErrors(params = {}) {
   const rootDir = params.rootDir ?? process.cwd();
   const fsImpl = params.fs ?? fs;
 

--- a/scripts/check-runtime-sidecar-loaders.mjs
+++ b/scripts/check-runtime-sidecar-loaders.mjs
@@ -230,7 +230,7 @@ export function findRuntimeSidecarLoaderViolations(content, importerPath, explic
 /**
  * Collects runtime sidecar loader violations across configured roots.
  */
-export async function collectRuntimeSidecarLoaderViolations(params) {
+async function collectRuntimeSidecarLoaderViolations(params) {
   const files = await collectTypeScriptFilesFromRoots(params.sourceRoots, {
     extraTestSuffixes: [".test-support.ts", ".test-helpers.ts"],
   });

--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -734,7 +734,7 @@ function sortRecordByKey(record) {
 }
 
 /** Counts legacy call sites per unmigrated file for every debt concern. */
-export async function collectSessionAccessorDebtCounts(repoRoot) {
+async function collectSessionAccessorDebtCounts(repoRoot) {
   const counts = {};
   for (const concern of sessionAccessorDebtConcerns) {
     const violations = await collectFileViolations({

--- a/scripts/check-web-search-provider-boundaries.mjs
+++ b/scripts/check-web-search-provider-boundaries.mjs
@@ -232,7 +232,7 @@ function formatEntry(entry) {
 /**
  * Runs the web-search provider boundary baseline check.
  */
-export async function runWebSearchProviderBoundaryCheck(argv, io) {
+async function runWebSearchProviderBoundaryCheck(argv, io) {
   return await runBaselineInventoryCheck({
     argv: argv ?? process.argv.slice(2),
     io,

--- a/scripts/check-webhook-auth-body-order.mjs
+++ b/scripts/check-webhook-auth-body-order.mjs
@@ -33,7 +33,7 @@ function getCalleeName(expression) {
 /**
  * Finds request body reads that occur before webhook auth validation.
  */
-export function findBlockedWebhookBodyReadLines(content, fileName = "source.ts") {
+function findBlockedWebhookBodyReadLines(content, fileName = "source.ts") {
   const sourceFile = ts.createSourceFile(fileName, content, ts.ScriptTarget.Latest, true);
   const lines = [];
   const visit = (node) => {

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -23,7 +23,7 @@ export function usage() {
 /**
  * Parses aggregate check runner arguments.
  */
-export function parseCheckArgs(argv) {
+function parseCheckArgs(argv) {
   const args = {
     help: false,
     includeArchitecture: false,

--- a/scripts/close-duplicate-prs-after-merge.mjs
+++ b/scripts/close-duplicate-prs-after-merge.mjs
@@ -149,7 +149,7 @@ export function parseUnifiedDiffRanges(diffText) {
 /**
  * Reports whether two PR diffs touch overlapping hunks.
  */
-export function hasOverlappingHunks(leftRanges, rightRanges) {
+function hasOverlappingHunks(leftRanges, rightRanges) {
   for (const [path, left] of leftRanges) {
     const right = rightRanges.get(path) ?? [];
     for (const leftRange of left) {

--- a/scripts/dependency-changes-report.mjs
+++ b/scripts/dependency-changes-report.mjs
@@ -314,7 +314,7 @@ async function writeArtifact(filePath, content) {
 /**
  * Generates and writes dependency change report artifacts.
  */
-export async function runDependencyChangesReport(options) {
+async function runDependencyChangesReport(options) {
   const headLockfileText = await readFile(path.join(options.rootDir, options.headLockfile), "utf8");
   const baseLockfileText = options.baseRef
     ? readGitFile(options.baseRef, "pnpm-lock.yaml", options.rootDir)

--- a/scripts/e2e/kitchen-sink-rpc-walk.mjs
+++ b/scripts/e2e/kitchen-sink-rpc-walk.mjs
@@ -150,7 +150,7 @@ export function readPositiveInt(raw, fallback, label = "value") {
   return parsed;
 }
 
-export function clampKitchenSinkTimerTimeoutMs(value) {
+function clampKitchenSinkTimerTimeoutMs(value) {
   if (!Number.isFinite(value)) {
     return 1;
   }
@@ -212,7 +212,7 @@ export function resolveKitchenSinkRpcConfig(env = process.env) {
   };
 }
 
-export async function findAvailableLoopbackPort(options = {}) {
+async function findAvailableLoopbackPort(options = {}) {
   const createServer = options.createServer ?? (() => net.createServer());
   const server = createServer();
   return await new Promise((resolve, reject) => {
@@ -718,7 +718,7 @@ export function parseGatewayCliRequestFailure(error) {
   return payload?.ok === false ? createGatewayClientRequestError(payload.error) : null;
 }
 
-export function createGatewayClientRequestError(requestError) {
+function createGatewayClientRequestError(requestError) {
   if (
     requestError?.type !== "gateway_request_error" ||
     !isNonEmptyString(requestError.code) ||
@@ -1540,7 +1540,7 @@ export function extractPluginCommandNames(payload) {
     .toSorted((left, right) => left.localeCompare(right));
 }
 
-export function extractToolEntries(payload) {
+function extractToolEntries(payload) {
   return (Array.isArray(payload?.groups) ? payload.groups : []).flatMap((group) =>
     Array.isArray(group?.tools) ? group.tools : [],
   );

--- a/scripts/e2e/lib/config-reload/log-scanner.mjs
+++ b/scripts/e2e/lib/config-reload/log-scanner.mjs
@@ -9,7 +9,7 @@ const DEFAULT_TAIL_LINE_LIMIT = 160;
 const RELOAD_NEEDLE = "config change detected; evaluating reload";
 const RESTART_NEEDLE = "config change requires gateway restart";
 
-export function inspectConfigReloadLogLine(line) {
+function inspectConfigReloadLogLine(line) {
   return {
     reload: line.includes(RELOAD_NEEDLE),
     restart: line.includes(RESTART_NEEDLE),

--- a/scripts/e2e/lib/gateway-network/client.mjs
+++ b/scripts/e2e/lib/gateway-network/client.mjs
@@ -20,7 +20,7 @@ function isRecord(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-export function hasGatewayHealthSummaryPayload(response) {
+function hasGatewayHealthSummaryPayload(response) {
   if (!isRecord(response) || !isRecord(response.payload)) {
     return false;
   }
@@ -43,7 +43,7 @@ export function responseError(method, response) {
   return new Error(`${method} failed: ${message}`);
 }
 
-export function isRetryableStartupError(message) {
+function isRetryableStartupError(message) {
   return (
     message.includes("gateway starting") ||
     message.includes("closed before frame") ||

--- a/scripts/e2e/parallels/smoke-common.ts
+++ b/scripts/e2e/parallels/smoke-common.ts
@@ -120,7 +120,7 @@ export abstract class SmokeRunController<TOptions extends SmokeRunOptions & Smok
   }
 }
 
-export async function resolveSmokeHostConfig(
+async function resolveSmokeHostConfig(
   options: SmokeHostOptions,
   defaultPort: number,
 ): Promise<{ hostIp: string; hostPort: number }> {
@@ -130,7 +130,7 @@ export async function resolveSmokeHostConfig(
   };
 }
 
-export async function prepareSmokeRunHost(
+async function prepareSmokeRunHost(
   options: SmokeHostOptions,
   defaultPort: number,
   latestVersion: string,
@@ -150,7 +150,7 @@ export async function prepareSmokeRunHost(
   return [host.hostIp, host.hostPort];
 }
 
-export function logSmokeRunStart(input: {
+function logSmokeRunStart(input: {
   latestVersion: string;
   runDir: string;
   snapshot: SnapshotInfo;
@@ -165,7 +165,7 @@ export function logSmokeRunStart(input: {
   say(`Run logs: ${input.runDir}`);
 }
 
-export async function startSmokeArtifactServer(input: {
+async function startSmokeArtifactServer(input: {
   artifact: PackageArtifact;
   dir: string;
   hostIp: string;
@@ -205,7 +205,7 @@ export async function packAndServeSmokeArtifact(
   return [artifact, server.server, server.hostPort];
 }
 
-export async function runRequestedSmokeLanes(input: {
+async function runRequestedSmokeLanes(input: {
   mode: Mode;
   runFresh: () => Promise<void>;
   runLane: (name: "fresh" | "upgrade", fn: () => Promise<void>) => Promise<void>;
@@ -219,7 +219,7 @@ export async function runRequestedSmokeLanes(input: {
   }
 }
 
-export async function runSmokeLaneWithStatus(
+async function runSmokeLaneWithStatus(
   name: "fresh" | "upgrade",
   fn: () => Promise<void>,
   statuses: Pick<SmokeLaneStatuses, "freshMain" | "upgrade">,
@@ -227,7 +227,7 @@ export async function runSmokeLaneWithStatus(
   await runSmokeLane(name, fn, (lane, status) => setSmokeLaneStatus(statuses, lane, status));
 }
 
-export function setSmokeLaneStatus(
+function setSmokeLaneStatus(
   statuses: Pick<SmokeLaneStatuses, "freshMain" | "upgrade">,
   name: SmokeLane,
   status: SmokeLaneStatus,
@@ -239,7 +239,7 @@ export function setSmokeLaneStatus(
   }
 }
 
-export async function finishSmokeRun(input: {
+async function finishSmokeRun(input: {
   json: boolean;
   printSummary: (summaryPath: string) => void;
   status: Pick<SmokeLaneStatuses, "freshMain" | "upgrade">;
@@ -255,7 +255,7 @@ export async function finishSmokeRun(input: {
   }
 }
 
-export async function runSmokeLanesAndFinish(
+async function runSmokeLanesAndFinish(
   mode: Mode,
   json: boolean,
   status: Pick<SmokeLaneStatuses, "freshMain" | "upgrade">,
@@ -278,7 +278,7 @@ export async function runSmokeLanesAndFinish(
   });
 }
 
-export async function cleanupSmokeArtifacts(input: {
+async function cleanupSmokeArtifacts(input: {
   keepServer: boolean;
   server: HostServer | null;
   tgzDir: string;

--- a/scripts/e2e/telegram-user-crabbox-proof.ts
+++ b/scripts/e2e/telegram-user-crabbox-proof.ts
@@ -577,12 +577,12 @@ function appendCommandText(current: string, chunk: Buffer): string {
   return current + chunk.toString("utf8");
 }
 
-export function appendCommandTextTail(current: string, chunk: Buffer, maxChars: number): string {
+function appendCommandTextTail(current: string, chunk: Buffer, maxChars: number): string {
   const next = appendCommandText(current, chunk);
   return next.length > maxChars ? next.slice(-maxChars) : next;
 }
 
-export function appendCommandStdout(
+function appendCommandStdout(
   current: string,
   chunk: Buffer,
   maxChars = COMMAND_STDOUT_MAX_CHARS,
@@ -594,7 +594,7 @@ export function appendCommandStdout(
   return { ok: true, value: next };
 }
 
-export function appendCommandStderrTail(
+function appendCommandStderrTail(
   current: string,
   chunk: Buffer,
   maxChars = COMMAND_STDERR_TAIL_CHARS,

--- a/scripts/format-docs.mjs
+++ b/scripts/format-docs.mjs
@@ -183,7 +183,7 @@ export function runOxfmt(files, params = {}, deps = {}) {
   }
 }
 
-export function repairFiles(root, files) {
+function repairFiles(root, files) {
   const changed = [];
   for (const relativePath of files) {
     const absolutePath = path.join(root, relativePath);

--- a/scripts/generate-base-config-schema.ts
+++ b/scripts/generate-base-config-schema.ts
@@ -3,7 +3,7 @@
 import { pathToFileURL } from "node:url";
 import { computeBaseConfigSchemaResponse } from "../src/config/schema-base.js";
 
-export function checkBaseConfigSchema(): void {
+function checkBaseConfigSchema(): void {
   computeBaseConfigSchemaResponse({
     generatedAt: "2026-05-05T00:00:00.000Z",
   });

--- a/scripts/generate-bundled-channel-config-metadata.ts
+++ b/scripts/generate-bundled-channel-config-metadata.ts
@@ -235,7 +235,7 @@ function resolveChannelUnsupportedSecretRefSurfacePatterns(
   }
 }
 
-export async function collectBundledChannelConfigMetadata(params?: { repoRoot?: string }) {
+async function collectBundledChannelConfigMetadata(params?: { repoRoot?: string }) {
   const repoRoot = path.resolve(params?.repoRoot ?? process.cwd());
   const sources = collectBundledPluginSources({ repoRoot, requirePackageJson: true });
   const entries: BundledChannelConfigMetadata[] = [];
@@ -289,7 +289,7 @@ export async function collectBundledChannelConfigMetadata(params?: { repoRoot?: 
   return entries.toSorted((left, right) => left.channelId.localeCompare(right.channelId));
 }
 
-export async function writeBundledChannelConfigMetadataModule(params?: {
+async function writeBundledChannelConfigMetadataModule(params?: {
   repoRoot?: string;
   outputPath?: string;
   check?: boolean;

--- a/scripts/generate-dependency-release-evidence.mjs
+++ b/scripts/generate-dependency-release-evidence.mjs
@@ -292,7 +292,7 @@ function runEvidenceReports({ rootDir, outputDir, baseRef, execFileSyncImpl }) {
 /**
  * Generates dependency evidence reports, manifest, and summaries for a release.
  */
-export async function generateDependencyReleaseEvidence({
+async function generateDependencyReleaseEvidence({
   rootDir = process.cwd(),
   outputDir,
   releaseRef,

--- a/scripts/generate-prompt-snapshots.ts
+++ b/scripts/generate-prompt-snapshots.ts
@@ -116,7 +116,7 @@ async function checkSnapshots() {
   console.log(`Prompt snapshots are current (${files.length} files).`);
 }
 
-export async function runPromptSnapshotGenerator(argv = process.argv.slice(2)) {
+async function runPromptSnapshotGenerator(argv = process.argv.slice(2)) {
   const mode = argv.includes("--write") ? "write" : argv.includes("--check") ? "check" : undefined;
 
   if (!mode) {

--- a/scripts/mobile-release-ref.ts
+++ b/scripts/mobile-release-ref.ts
@@ -218,11 +218,11 @@ function assertRootDir(rootDir: string): void {
   }
 }
 
-export function resolveCommitSha(sha: string, rootDir: string, deps: GitDeps = {}): string {
+function resolveCommitSha(sha: string, rootDir: string, deps: GitDeps = {}): string {
   return git(["rev-parse", "--verify", `${sha}^{commit}`], rootDir, deps).trim();
 }
 
-export function readRemoteRef(
+function readRemoteRef(
   remote: string,
   ref: string,
   rootDir: string,

--- a/scripts/native-app-i18n.ts
+++ b/scripts/native-app-i18n.ts
@@ -1000,7 +1000,7 @@ function render(entries: NativeI18nEntry[]): string {
   return `${JSON.stringify({ version: 1, entries }, null, 2)}\n`;
 }
 
-export async function syncNativeI18n(options: { checkOnly: boolean; write: boolean }) {
+async function syncNativeI18n(options: { checkOnly: boolean; write: boolean }) {
   const expected = render(await collectNativeI18nEntries());
   let current = "";
   try {

--- a/scripts/openclaw-npm-postpublish-verify.ts
+++ b/scripts/openclaw-npm-postpublish-verify.ts
@@ -644,7 +644,7 @@ export function collectInstalledPluginSdkZodArtifactErrors(packageRoot: string):
   return [];
 }
 
-export function collectInstalledPluginSdkDeclarationErrors(packageRoot: string): string[] {
+function collectInstalledPluginSdkDeclarationErrors(packageRoot: string): string[] {
   const pluginSdkDistRoot = join(packageRoot, "dist", "plugin-sdk");
   const errors: string[] = [];
   const forbiddenPrivateWorkspaceSpecifiers = ["@openclaw/llm-core"];

--- a/scripts/plugin-clawhub-release-plan.ts
+++ b/scripts/plugin-clawhub-release-plan.ts
@@ -7,7 +7,7 @@ import {
   parsePluginReleaseArgs,
 } from "./lib/plugin-clawhub-release.ts";
 
-export async function collectPluginReleasePlanForClawHub(argv: string[]) {
+async function collectPluginReleasePlanForClawHub(argv: string[]) {
   const { selection, selectionMode, baseRef, headRef } = parsePluginReleaseArgs(argv);
   return await collectPluginClawHubReleasePlan({
     selection,

--- a/scripts/plugin-npm-release-check.ts
+++ b/scripts/plugin-npm-release-check.ts
@@ -12,7 +12,7 @@ import {
   resolveSelectedPublishablePluginPackages,
 } from "./lib/plugin-npm-release.ts";
 
-export function runPluginNpmReleaseCheck(argv: string[]) {
+function runPluginNpmReleaseCheck(argv: string[]) {
   const { selection, selectionMode, npmDistTag, baseRef, headRef } =
     parsePluginNpmReleaseArgs(argv);
   const changedExtensionIds =

--- a/scripts/plugin-npm-release-plan.ts
+++ b/scripts/plugin-npm-release-plan.ts
@@ -4,7 +4,7 @@
 import { pathToFileURL } from "node:url";
 import { collectPluginReleasePlan, parsePluginNpmReleaseArgs } from "./lib/plugin-npm-release.ts";
 
-export function collectPluginNpmReleasePlan(argv: string[]) {
+function collectPluginNpmReleasePlan(argv: string[]) {
   const { selection, selectionMode, npmDistTag, baseRef, headRef } =
     parsePluginNpmReleaseArgs(argv);
   return collectPluginReleasePlan({

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -28,7 +28,7 @@ Options:
 `;
 }
 
-export function parsePluginSdkSurfaceReportArgs(argv) {
+function parsePluginSdkSurfaceReportArgs(argv) {
   const args = { check: false, help: false };
   for (const arg of argv) {
     if (arg === "--check") {
@@ -49,7 +49,7 @@ const deprecatedPublicEntrypointSet = new Set(deprecatedPublicPluginSdkEntrypoin
 const deprecatedBarrelEntrypointSet = new Set(deprecatedBarrelPluginSdkEntrypoints);
 const forbiddenPublicSubpaths = new Set(["test-utils"]);
 
-export function readPluginSdkSurfaceBudgetEnv(name, fallback, env = process.env) {
+function readPluginSdkSurfaceBudgetEnv(name, fallback, env = process.env) {
   const raw = env[name];
   if (raw === undefined) {
     return fallback;
@@ -65,7 +65,7 @@ export function readPluginSdkSurfaceBudgetEnv(name, fallback, env = process.env)
   return parsed;
 }
 
-export function readPluginSdkEntrypointBudgetEnv(name, fallback, env = process.env) {
+function readPluginSdkEntrypointBudgetEnv(name, fallback, env = process.env) {
   const raw = env[name];
   if (raw === undefined) {
     return fallback;

--- a/scripts/pre-commit/pnpm-audit-prod.mjs
+++ b/scripts/pre-commit/pnpm-audit-prod.mjs
@@ -41,7 +41,7 @@ const AUDIT_ADVISORY_VERSION_OVERRIDES = [
   },
 ];
 
-export function normalizeAuditLevel(level) {
+function normalizeAuditLevel(level) {
   const normalized = String(level ?? "").toLowerCase();
   if (normalized in SEVERITY_RANK) {
     return normalized;

--- a/scripts/qa/ux-matrix-evidence-producer.ts
+++ b/scripts/qa/ux-matrix-evidence-producer.ts
@@ -647,7 +647,7 @@ async function writeProducerMetadata(params: {
   );
 }
 
-export async function runUxMatrixEvidenceProducer(options: ProducerOptions) {
+async function runUxMatrixEvidenceProducer(options: ProducerOptions) {
   await fs.mkdir(options.artifactBase, { recursive: true });
   await writePreflight(options.artifactBase);
 

--- a/scripts/resolve-upgrade-survivor-baselines.mjs
+++ b/scripts/resolve-upgrade-survivor-baselines.mjs
@@ -109,7 +109,7 @@ function readStableReleases(file, publishedVersions) {
 /**
  * Expands the release-history token into recent stable plus pinned historical baselines.
  */
-export function resolveReleaseHistory(args) {
+function resolveReleaseHistory(args) {
   const releasesJson = args.get("releases-json");
   if (!releasesJson) {
     throw new Error("--releases-json is required when requested baselines include release-history");
@@ -136,7 +136,7 @@ export function resolveReleaseHistory(args) {
 /**
  * Resolves the last N stable release versions from release metadata.
  */
-export function resolveLastStable(args, count) {
+function resolveLastStable(args, count) {
   const releasesJson = args.get("releases-json");
   if (!releasesJson) {
     throw new Error("--releases-json is required when requested baselines include last-stable-*");
@@ -152,7 +152,7 @@ export function resolveLastStable(args, count) {
 /**
  * Resolves all stable release versions at or after the requested minimum.
  */
-export function resolveAllSince(args, minimumVersion) {
+function resolveAllSince(args, minimumVersion) {
   const releasesJson = args.get("releases-json");
   if (!releasesJson) {
     throw new Error("--releases-json is required when requested baselines include all-since-*");

--- a/scripts/run-oxlint-shards.mjs
+++ b/scripts/run-oxlint-shards.mjs
@@ -62,7 +62,7 @@ export function createOxlintShards({
 /**
  * Splits core oxlint targets into smaller source/package/UI shards.
  */
-export function createCoreOxlintShards({ cwd = process.cwd(), readDir = fs.readdirSync } = {}) {
+function createCoreOxlintShards({ cwd = process.cwd(), readDir = fs.readdirSync } = {}) {
   const sourceShards = listSourceRootTargetGroups({ cwd, readDir }).map((targets) => ({
     name: targets.length === 1 ? `core:${targets[0].replaceAll("/", ":")}` : "core:src:root",
     args: ["--tsconfig", CORE_TS_CONFIG, ...targets],

--- a/scripts/run-vitest.mjs
+++ b/scripts/run-vitest.mjs
@@ -423,7 +423,7 @@ export function resolveVitestSpawnParams(env = process.env, platform = process.p
 /**
  * Applies local Vitest scheduling and native worker budget env.
  */
-export function resolveVitestSpawnEnv(env = process.env) {
+function resolveVitestSpawnEnv(env = process.env) {
   const baseEnv = resolveLocalVitestEnv(env);
   if (!shouldApplyNativeWorkerBudget(baseEnv)) {
     return baseEnv;
@@ -892,7 +892,7 @@ export function installVitestNoOutputWatchdog(params) {
 /**
  * Forwards child output while optionally suppressing complete stderr lines.
  */
-export function forwardVitestOutput(stream, target, shouldSuppressLine = () => false) {
+function forwardVitestOutput(stream, target, shouldSuppressLine = () => false) {
   if (!stream) {
     return;
   }

--- a/scripts/runtime-postbuild.mjs
+++ b/scripts/runtime-postbuild.mjs
@@ -149,14 +149,14 @@ export const LEGACY_CLI_EXIT_COMPAT_CHUNKS = [
 /**
  * Lists generated plugin SDK root-alias outputs.
  */
-export function listPluginSdkRootAliasOutputs() {
+function listPluginSdkRootAliasOutputs() {
   return [PLUGIN_SDK_ROOT_ALIAS_OUTPUT];
 }
 
 /**
  * Lists generated official channel catalog outputs.
  */
-export function listOfficialChannelCatalogOutputs() {
+function listOfficialChannelCatalogOutputs() {
   return [OFFICIAL_CHANNEL_CATALOG_OUTPUT];
 }
 
@@ -232,7 +232,7 @@ function resolveStableRootRuntimeAliasCandidate(params) {
 /**
  * Lists stable aliases for hashed root runtime/contract chunks.
  */
-export function listStableRootRuntimeAliasOutputs(params = {}) {
+function listStableRootRuntimeAliasOutputs(params = {}) {
   const rootDir = params.rootDir ?? ROOT;
   const distDir = path.join(rootDir, "dist");
   const fsImpl = params.fs ?? fs;
@@ -252,7 +252,7 @@ export function listStableRootRuntimeAliasOutputs(params = {}) {
 /**
  * Lists compatibility chunk outputs required for old CLI exit paths.
  */
-export function listLegacyCliExitCompatOutputs(params = {}) {
+function listLegacyCliExitCompatOutputs(params = {}) {
   const chunks = params.chunks ?? LEGACY_CLI_EXIT_COMPAT_CHUNKS;
   return chunks
     .map(({ dest }) => dest.replace(/\\/g, "/"))
@@ -262,7 +262,7 @@ export function listLegacyCliExitCompatOutputs(params = {}) {
 /**
  * Lists legacy hashed runtime aliases that may be needed during live upgrades.
  */
-export function listLegacyRootRuntimeCompatOutputs(params = {}) {
+function listLegacyRootRuntimeCompatOutputs(params = {}) {
   const rootDir = params.rootDir ?? ROOT;
   const distDir = path.join(rootDir, "dist");
   const fsImpl = params.fs ?? fs;

--- a/scripts/sync-codex-model-prompt-fixture.ts
+++ b/scripts/sync-codex-model-prompt-fixture.ts
@@ -109,7 +109,7 @@ export function renderCodexModelInstructions(params: {
   throw new Error(`Codex model ${params.model.slug} has no renderable instructions.`);
 }
 
-export async function createCodexModelPromptFixture(params: {
+async function createCodexModelPromptFixture(params: {
   catalogPath: string;
   catalogLabel?: string;
   model: string;

--- a/scripts/test-docker-all.mjs
+++ b/scripts/test-docker-all.mjs
@@ -54,7 +54,7 @@ const IS_MAIN = process.argv[1]
   ? path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
   : false;
 
-export function dockerAllUsage() {
+function dockerAllUsage() {
   return [
     "Usage: node scripts/test-docker-all.mjs [--plan-json]",
     "",

--- a/scripts/test-group-report.mjs
+++ b/scripts/test-group-report.mjs
@@ -641,7 +641,7 @@ function readReportInput(entry) {
   };
 }
 
-export function readReportInputs(entries) {
+function readReportInputs(entries) {
   const invalid = [];
   const missing = [];
   const reports = [];

--- a/scripts/test-live-shard.mjs
+++ b/scripts/test-live-shard.mjs
@@ -586,7 +586,7 @@ export function validateLiveShardReportPayload(
 /**
  * Reads and validates the live-shard Vitest JSON report.
  */
-export function validateLiveShardReport(reportPath, expectedFiles = []) {
+function validateLiveShardReport(reportPath, expectedFiles = []) {
   let payload;
   try {
     payload = JSON.parse(fs.readFileSync(reportPath, "utf8"));

--- a/scripts/test-live.mjs
+++ b/scripts/test-live.mjs
@@ -9,7 +9,7 @@ import {
 /**
  * Renders CLI usage for the live-test wrapper.
  */
-export function testLiveUsage() {
+function testLiveUsage() {
   return [
     "Usage: node scripts/test-live.mjs [options] [--] [vitest targets/args...]",
     "",

--- a/scripts/transitive-manifest-risk-report.mjs
+++ b/scripts/transitive-manifest-risk-report.mjs
@@ -603,7 +603,7 @@ export function renderTransitiveManifestRiskMarkdownReport(report) {
   return `${lines.join("\n")}\n`;
 }
 
-export async function runTransitiveManifestRiskReport({
+async function runTransitiveManifestRiskReport({
   rootDir = process.cwd(),
   fetchImpl = fetch,
   now = new Date(),

--- a/scripts/tsdown-build.mjs
+++ b/scripts/tsdown-build.mjs
@@ -486,7 +486,7 @@ function resolveTsdownEnv(env, params = {}) {
   };
 }
 
-export function tsdownBuildUsage() {
+function tsdownBuildUsage() {
   return [
     "Usage: node scripts/tsdown-build.mjs [tsdown args...]",
     "",

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -333,7 +333,7 @@ export function main(argv = process.argv.slice(2)) {
   runPnpm(["run", script, ...rest]);
 }
 
-export function resolveDirectExecutionPath(entry, realpath = fs.realpathSync.native) {
+function resolveDirectExecutionPath(entry, realpath = fs.realpathSync.native) {
   const resolved = path.resolve(entry);
   try {
     return realpath(resolved);

--- a/scripts/verify-plugin-npm-published-runtime.mjs
+++ b/scripts/verify-plugin-npm-published-runtime.mjs
@@ -379,7 +379,7 @@ export function parseVerifyPublishedPluginRuntimeArgs(argv) {
   return { help: false, spec: first };
 }
 
-export async function verifyPublishedPluginRuntime(spec) {
+async function verifyPublishedPluginRuntime(spec) {
   const workingDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-npm-runtime."));
   try {
     const tarballPath = await packPublishedPackage(spec, workingDir);

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -25,7 +25,7 @@ export function usage() {
 /**
  * Parses verify wrapper CLI args.
  */
-export function parseVerifyArgs(argv) {
+function parseVerifyArgs(argv) {
   const args = { help: false };
   for (const arg of argv) {
     if (arg === "--help" || arg === "-h") {

--- a/scripts/write-cli-startup-metadata.ts
+++ b/scripts/write-cli-startup-metadata.ts
@@ -270,7 +270,7 @@ function resolveSubcommandHelpSourceSignature(sourceRootDir: string = rootDir): 
   return hash.digest("hex");
 }
 
-export function readBundledChannelCatalog(
+function readBundledChannelCatalog(
   extensionsDirOverride: string = extensionsDir,
 ): BundledChannelCatalog {
   const entries: ExtensionChannelEntry[] = [];

--- a/scripts/write-package-dist-inventory.ts
+++ b/scripts/write-package-dist-inventory.ts
@@ -4,7 +4,7 @@
 import { pathToFileURL } from "node:url";
 import { writePackageDistInventory } from "../src/infra/package-dist-inventory.ts";
 
-export async function writeCurrentPackageDistInventory(): Promise<void> {
+async function writeCurrentPackageDistInventory(): Promise<void> {
   await writePackageDistInventory(process.cwd());
 }
 

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -127,7 +127,7 @@ function isTerminalAvailable(
   );
 }
 
-export class OpenClawApp extends LitElement {
+class OpenClawApp extends LitElement {
   @state() private gatewayConnected = false;
   @state() private gatewayReconnecting = false;
   @state() private gatewayLastError: string | null = null;

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -124,7 +124,7 @@ function shouldHandleNavigationClick(event: MouseEvent): boolean {
   );
 }
 
-export class AppSidebar extends LitElement {
+class AppSidebar extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/components/app-topbar.ts
+++ b/ui/src/components/app-topbar.ts
@@ -10,7 +10,7 @@ import { icons } from "./icons.ts";
 // slide-over drawer; the one topbar toggle switches behavior there.
 const NAV_DRAWER_MEDIA_QUERY = "(max-width: 1100px)";
 
-export class AppTopbar extends LitElement {
+class AppTopbar extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/components/connection-banner.ts
+++ b/ui/src/components/connection-banner.ts
@@ -28,7 +28,7 @@ function renderConnectionBanner(props: ConnectionBannerProps) {
   `;
 }
 
-export class ConnectionBanner extends LitElement {
+class ConnectionBanner extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/components/dashboard-header.ts
+++ b/ui/src/components/dashboard-header.ts
@@ -3,7 +3,7 @@ import { LitElement, html, nothing } from "lit";
 import { property } from "lit/decorators.js";
 import { titleForRoute, type NavigationRouteId } from "../app-navigation.ts";
 
-export class DashboardHeader extends LitElement {
+class DashboardHeader extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/components/exec-approval.ts
+++ b/ui/src/components/exec-approval.ts
@@ -224,7 +224,7 @@ function renderExecApprovalPrompt(props: ExecApprovalProps) {
   `;
 }
 
-export class ExecApproval extends LitElement {
+class ExecApproval extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/components/gateway-url-confirmation.ts
+++ b/ui/src/components/gateway-url-confirmation.ts
@@ -45,7 +45,7 @@ function renderGatewayUrlConfirmation(props: GatewayUrlConfirmationProps) {
   `;
 }
 
-export class GatewayUrlConfirmation extends LitElement {
+class GatewayUrlConfirmation extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/components/login-gate.ts
+++ b/ui/src/components/login-gate.ts
@@ -108,7 +108,7 @@ function buildFeedback(params: {
   };
 }
 
-export function resolveLoginFailureFeedback(
+function resolveLoginFailureFeedback(
   params: LoginFailureFeedbackParams,
 ): LoginFailureFeedback | null {
   if (params.connected || !params.lastError) {
@@ -431,7 +431,7 @@ function renderLoginGate(props: LoginGateProps) {
   `;
 }
 
-export class LoginGate extends LitElement {
+class LoginGate extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/components/theme-mode-toggle.ts
+++ b/ui/src/components/theme-mode-toggle.ts
@@ -10,7 +10,7 @@ export type ThemeModeChangeDetail = {
   element: HTMLElement;
 };
 
-export class ThemeModeToggle extends LitElement {
+class ThemeModeToggle extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/components/tooltip.ts
+++ b/ui/src/components/tooltip.ts
@@ -16,7 +16,7 @@ function createTooltipId() {
   return `openclaw-tooltip-${nextTooltipId}`;
 }
 
-export class TooltipProvider extends LitElement {
+class TooltipProvider extends LitElement {
   @property({ type: Number }) delay = HOVER_DELAY;
   @property({ type: Number }) skipDelay = SKIP_DELAY;
   @property({ type: Number }) touchDelay = TOUCH_DELAY;
@@ -99,7 +99,7 @@ export class TooltipProvider extends LitElement {
   }
 }
 
-export class Tooltip extends LitElement {
+class Tooltip extends LitElement {
   @property() content = "";
 
   private trigger: HTMLElement | null = null;

--- a/ui/src/components/update-banner.ts
+++ b/ui/src/components/update-banner.ts
@@ -67,7 +67,7 @@ export type UpdateBannerProps = {
   onDismiss: () => void;
 };
 
-export class UpdateBanner extends LitElement {
+class UpdateBanner extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -95,7 +95,7 @@ const NEW_SESSION_LIST_LOADING_MESSAGE =
 const NEW_SESSION_CREATE_FAILED_MESSAGE =
   "New Chat could not create a new session. Try again in a moment.";
 
-export class ChatPane extends LitElement {
+class ChatPane extends LitElement {
   @consume({ context: applicationContext, subscribe: false })
   private context!: ChatPageContext;
   @property({ attribute: false }) paneId = "single";

--- a/ui/src/pages/chat/components/chat-sidebar.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.ts
@@ -592,7 +592,7 @@ export function renderMarkdownSidebar(props: MarkdownSidebarProps) {
   `;
 }
 
-export class ChatDetailPanel extends LitElement {
+class ChatDetailPanel extends LitElement {
   @property({ attribute: false }) content: SidebarContent | null = null;
   @property({ attribute: false }) loadFullMessage?:
     | ((request: SidebarFullMessageRequest) => Promise<DetailFullMessageResult | null | undefined>)


### PR DESCRIPTION
## What Problem This Solves

The maintainer deadcode sweep still reported implementation-only Control UI components and repository scripts as public module exports. Those exports had no in-repo consumers, inflated the apparent API surface, and made unused-export reports noisier.

## Why This Change Was Made

Localize 105 functions and classes across 72 UI and script files by removing only their unnecessary `export` modifiers. Reusable script libraries, GitHub policy modules, test helpers, config barrels, and wildcard-reexported Parallels helpers remain exported.

This is an AI-assisted maintainer-requested deadcode sweep. The resulting diff was reviewed repeatedly against current `main`.

## User Impact

No runtime or visual behavior changes. Maintainers get a smaller, more accurate internal module surface and clearer deadcode reports.

## Evidence

- Exact whole-repo reference validation: all 105 symbols remain file-private with no external code references.
- Exact-diff validation: all 72 files differ from current `main` only by removing the selected `export` modifiers; net LOC change is zero.
- AWS Crabbox `cbx_c5124c0abe6a` (`amber-prawn`):
  - `run_a645ca66e513`: exact-base `pnpm check:changed` passed against `a6768d9de56`, covering core/core-tests/tooling/live-Docker lanes, both typechecks, core/UI/script lint, import cycles, policy guards, prompt snapshots, and Docker scheduler validation.
  - `run_c1d893703921`: 39 focused UI component tests and 8 Playwright UI e2e tests passed after rebasing onto `62353440068`, including login recovery, mobile sizing, safe-area handling, and stored-credential splash behavior.
- Fresh branch autoreview after the final rebase: no findings; patch correct at 0.89 confidence.
