### PR TITLE
refactor(deadcode): localize extension helpers

### DIFF
--- a/extensions/memory-wiki/src/cli.ts
+++ b/extensions/memory-wiki/src/cli.ts
@@ -526,7 +526,7 @@ export async function runWikiDoctor(params: {
   return report;
 }
 
-export async function runWikiInit(params: {
+async function runWikiInit(params: {
   config: ResolvedMemoryWikiConfig;
   json?: boolean;
   stdout?: Pick<NodeJS.WriteStream, "write">;
@@ -540,7 +540,7 @@ export async function runWikiInit(params: {
   });
 }
 
-export async function runWikiCompile(params: {
+async function runWikiCompile(params: {
   config: ResolvedMemoryWikiConfig;
   appConfig?: OpenClawConfig;
   json?: boolean;
@@ -557,7 +557,7 @@ export async function runWikiCompile(params: {
   });
 }
 
-export async function runWikiLint(params: {
+async function runWikiLint(params: {
   config: ResolvedMemoryWikiConfig;
   appConfig?: OpenClawConfig;
   json?: boolean;
@@ -574,7 +574,7 @@ export async function runWikiLint(params: {
   });
 }
 
-export async function runWikiIngest(params: {
+async function runWikiIngest(params: {
   config: ResolvedMemoryWikiConfig;
   inputPath: string;
   title?: string;
@@ -613,7 +613,7 @@ export async function runWikiOkfImport(params: {
   });
 }
 
-export async function runWikiSearch(params: {
+async function runWikiSearch(params: {
   config: ResolvedMemoryWikiConfig;
   appConfig?: OpenClawConfig;
   query: string;
@@ -651,7 +651,7 @@ export async function runWikiSearch(params: {
   return results;
 }
 
-export async function runWikiGet(params: {
+async function runWikiGet(params: {
   config: ResolvedMemoryWikiConfig;
   appConfig?: OpenClawConfig;
   lookup: string;
@@ -679,7 +679,7 @@ export async function runWikiGet(params: {
   return result;
 }
 
-export async function runWikiApplySynthesis(params: {
+async function runWikiApplySynthesis(params: {
   config: ResolvedMemoryWikiConfig;
   appConfig?: OpenClawConfig;
   title: string;
@@ -720,7 +720,7 @@ export async function runWikiApplySynthesis(params: {
   return result;
 }
 
-export async function runWikiApplyMetadata(params: {
+async function runWikiApplyMetadata(params: {
   config: ResolvedMemoryWikiConfig;
   appConfig?: OpenClawConfig;
   lookup: string;
@@ -785,7 +785,7 @@ export async function runWikiBridgeImport(params: {
   });
 }
 
-export async function runWikiUnsafeLocalImport(params: {
+async function runWikiUnsafeLocalImport(params: {
   config: ResolvedMemoryWikiConfig;
   appConfig?: OpenClawConfig;
   json?: boolean;
@@ -804,7 +804,7 @@ export async function runWikiUnsafeLocalImport(params: {
   });
 }
 
-export async function runWikiObsidianStatus(params: {
+async function runWikiObsidianStatus(params: {
   config: ResolvedMemoryWikiConfig;
   json?: boolean;
   stdout?: Pick<NodeJS.WriteStream, "write">;
@@ -820,7 +820,7 @@ export async function runWikiObsidianStatus(params: {
   });
 }
 
-export async function runWikiObsidianSearch(params: {
+async function runWikiObsidianSearch(params: {
   config: ResolvedMemoryWikiConfig;
   query: string;
   json?: boolean;
@@ -834,7 +834,7 @@ export async function runWikiObsidianSearch(params: {
   });
 }
 
-export async function runWikiObsidianOpenCli(params: {
+async function runWikiObsidianOpenCli(params: {
   config: ResolvedMemoryWikiConfig;
   vaultPath: string;
   json?: boolean;
@@ -848,7 +848,7 @@ export async function runWikiObsidianOpenCli(params: {
   });
 }
 
-export async function runWikiObsidianCommandCli(params: {
+async function runWikiObsidianCommandCli(params: {
   config: ResolvedMemoryWikiConfig;
   id: string;
   json?: boolean;
@@ -862,7 +862,7 @@ export async function runWikiObsidianCommandCli(params: {
   });
 }
 
-export async function runWikiObsidianDailyCli(params: {
+async function runWikiObsidianDailyCli(params: {
   config: ResolvedMemoryWikiConfig;
   json?: boolean;
   stdout?: Pick<NodeJS.WriteStream, "write">;

--- a/extensions/oc-path/src/cli.ts
+++ b/extensions/oc-path/src/cli.ts
@@ -66,7 +66,7 @@ const defaultRuntime: OutputRuntimeEnv = {
 
 // Defense-in-depth: replace the redaction sentinel with `[REDACTED]`
 // before writing, even if upstream emits it.
-export function scrubSentinel(s: string): string {
+function scrubSentinel(s: string): string {
   if (!s.includes(REDACTED_SENTINEL)) {
     return s;
   }

--- a/extensions/oc-path/src/oc-path/oc-path.ts
+++ b/extensions/oc-path/src/oc-path/oc-path.ts
@@ -625,7 +625,7 @@ function scanBracketAware(s: string, onChar: ScanCallback, onUnbalanced: () => n
 }
 
 /** First top-level occurrence of `ch` in `s`; -1 when absent. */
-export function indexOfTopLevel(s: string, ch: string): number {
+function indexOfTopLevel(s: string, ch: string): number {
   let result = -1;
   const failLocal = (): never => {
     throw new OcPathError(`Unbalanced bracket/brace in oc:// path: ${s}`, s, "OC_PATH_UNBALANCED");

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -716,7 +716,7 @@ export function scanPolicyMcpServers(
     });
 }
 
-export function scanPolicyModelProviders(
+function scanPolicyModelProviders(
   cfg: Record<string, unknown>,
 ): readonly PolicyModelProviderEvidence[] {
   return Object.keys(configuredModelProviders(cfg))
@@ -727,9 +727,7 @@ export function scanPolicyModelProviders(
     }));
 }
 
-export function scanPolicyModelRefs(
-  cfg: Record<string, unknown>,
-): readonly PolicyModelRefEvidence[] {
+function scanPolicyModelRefs(cfg: Record<string, unknown>): readonly PolicyModelRefEvidence[] {
   const refs: PolicyModelRefEvidence[] = [];
   if (isRecord(cfg.agents)) {
     collectModelRefsFromRecord(refs, cfg.agents, "oc://openclaw.config/agents");
@@ -740,7 +738,7 @@ export function scanPolicyModelRefs(
   );
 }
 
-export function scanPolicyNetwork(cfg: Record<string, unknown>): readonly PolicyNetworkEvidence[] {
+function scanPolicyNetwork(cfg: Record<string, unknown>): readonly PolicyNetworkEvidence[] {
   return [
     networkBooleanEvidence(
       cfg,
@@ -835,7 +833,7 @@ export function scanPolicyIngress(cfg: Record<string, unknown>): readonly Policy
   return entries.toSorted((a, b) => a.source.localeCompare(b.source) || a.id.localeCompare(b.id));
 }
 
-export function scanPolicyGatewayExposure(
+function scanPolicyGatewayExposure(
   cfg: Record<string, unknown>,
 ): readonly PolicyGatewayExposureEvidence[] {
   const gateway = isRecord(cfg.gateway) ? cfg.gateway : {};
@@ -959,7 +957,7 @@ export function scanPolicyGatewayExposure(
   return entries.toSorted((a, b) => a.source.localeCompare(b.source));
 }
 
-export function scanPolicyAgentWorkspace(
+function scanPolicyAgentWorkspace(
   cfg: Record<string, unknown>,
 ): readonly PolicyAgentWorkspaceEvidence[] {
   const agents = isRecord(cfg.agents) ? cfg.agents : {};
@@ -1006,7 +1004,7 @@ export function scanPolicyAgentWorkspace(
   return entries.toSorted((a, b) => a.source.localeCompare(b.source) || a.id.localeCompare(b.id));
 }
 
-export function scanPolicySandboxPosture(
+function scanPolicySandboxPosture(
   cfg: Record<string, unknown>,
 ): readonly PolicySandboxPostureEvidence[] {
   const agents = isRecord(cfg.agents) ? cfg.agents : {};
@@ -1045,9 +1043,7 @@ export function scanPolicySandboxPosture(
   return entries.toSorted((a, b) => a.source.localeCompare(b.source) || a.id.localeCompare(b.id));
 }
 
-export function scanPolicyToolPosture(
-  cfg: Record<string, unknown>,
-): readonly PolicyToolPostureEvidence[] {
+function scanPolicyToolPosture(cfg: Record<string, unknown>): readonly PolicyToolPostureEvidence[] {
   const globalTools = isRecord(cfg.tools) ? cfg.tools : {};
   const agents = isRecord(cfg.agents) ? cfg.agents : {};
   const defaults = isRecord(agents.defaults) ? agents.defaults : {};
@@ -1087,13 +1083,13 @@ export function scanPolicyToolPosture(
   return entries.toSorted((a, b) => a.source.localeCompare(b.source) || a.id.localeCompare(b.id));
 }
 
-export function scanPolicySecrets(cfg: Record<string, unknown>): readonly PolicySecretEvidence[] {
+function scanPolicySecrets(cfg: Record<string, unknown>): readonly PolicySecretEvidence[] {
   return [...scanPolicySecretProviders(cfg), ...scanPolicySecretInputs(cfg)].toSorted((a, b) =>
     a.source.localeCompare(b.source),
   );
 }
 
-export function scanPolicyAuthProfiles(
+function scanPolicyAuthProfiles(
   cfg: Record<string, unknown>,
 ): readonly PolicyAuthProfileEvidence[] {
   const auth = isRecord(cfg.auth) ? cfg.auth : {};
@@ -1124,7 +1120,7 @@ export function scanPolicyAuthProfiles(
     });
 }
 
-export function scanPolicyDataHandling(
+function scanPolicyDataHandling(
   cfg: Record<string, unknown>,
 ): readonly PolicyDataHandlingEvidence[] {
   const entries: PolicyDataHandlingEvidence[] = [];

--- a/extensions/qa-lab/src/confidence-report.ts
+++ b/extensions/qa-lab/src/confidence-report.ts
@@ -293,7 +293,7 @@ function normalizeManifestLane(value: unknown): QaConfidenceManifestLane {
   };
 }
 
-export function normalizeQaConfidenceManifest(value: unknown): QaConfidenceManifest {
+function normalizeQaConfidenceManifest(value: unknown): QaConfidenceManifest {
   if (!isRecord(value)) {
     throw new Error("confidence manifest must be an object");
   }
@@ -1269,9 +1269,7 @@ export async function buildQaConfidenceSelfTestSummary(
   };
 }
 
-export function renderQaConfidenceSelfTestMarkdownReport(
-  summary: QaConfidenceSelfTestSummary,
-): string {
+function renderQaConfidenceSelfTestMarkdownReport(summary: QaConfidenceSelfTestSummary): string {
   const lines = [
     "# OpenClaw QA Confidence Self-Test",
     "",

--- a/extensions/qa-lab/src/scorecard-taxonomy.ts
+++ b/extensions/qa-lab/src/scorecard-taxonomy.ts
@@ -456,7 +456,7 @@ function formatZodIssuePath(pathLocal: PropertyKey[]) {
   return pathLocal.length ? pathLocal.map(String).join(".") : "<root>";
 }
 
-export function parseQaMaturityTaxonomy(value: unknown, label = QA_MATURITY_TAXONOMY_PATH) {
+function parseQaMaturityTaxonomy(value: unknown, label = QA_MATURITY_TAXONOMY_PATH) {
   const parsed = qaMaturityTaxonomySchema.safeParse(value);
   if (parsed.success) {
     return parsed.data;
@@ -467,7 +467,7 @@ export function parseQaMaturityTaxonomy(value: unknown, label = QA_MATURITY_TAXO
   throw new Error(`${label}: ${issues}`);
 }
 
-export function parseQaMaturityScores(value: unknown, label = QA_MATURITY_SCORES_PATH) {
+function parseQaMaturityScores(value: unknown, label = QA_MATURITY_SCORES_PATH) {
   const parsed = qaMaturityScoresSchema.safeParse(value);
   if (parsed.success) {
     return parsed.data;
@@ -574,7 +574,7 @@ export function activeQaMaturityTaxonomySurfaces(taxonomy: QaMaturityTaxonomy) {
   return taxonomy.surfaces.filter((surface) => !surface.archived);
 }
 
-export function buildQaMaturityTaxonomyCategoryIndex(
+function buildQaMaturityTaxonomyCategoryIndex(
   taxonomy: QaMaturityTaxonomy,
 ): QaMaturityTaxonomyCategoryIndex {
   const active = activeQaMaturityTaxonomySurfaces(taxonomy);
@@ -639,7 +639,7 @@ function expectedMaturitySurfaceLtsStatus(supportedCategories: number, totalCate
   return supportedCategories === totalCategories ? "full" : "partial";
 }
 
-export function validateQaMaturityScoresAgainstTaxonomy(params: {
+function validateQaMaturityScoresAgainstTaxonomy(params: {
   coverageScores?: QaMaturityCoverageScores;
   scores: QaMaturityScores;
   taxonomy: QaMaturityTaxonomy;

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-shared.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-shared.ts
@@ -419,7 +419,7 @@ export async function assertNoSutReplyWindow(params: {
   };
 }
 
-export async function runConfigurableTopLevelScenario(params: {
+async function runConfigurableTopLevelScenario(params: {
   accessToken: string;
   actorId: MatrixQaActorId;
   baseUrl: string;

--- a/extensions/telegram/src/monitor.ts
+++ b/extensions/telegram/src/monitor.ts
@@ -31,7 +31,7 @@ import type {
 
 export type { MonitorTelegramOpts } from "./monitor.types.js";
 
-export function createTelegramRunnerOptions(cfg: OpenClawConfig): RunOptions<unknown> {
+function createTelegramRunnerOptions(cfg: OpenClawConfig): RunOptions<unknown> {
   return {
     sink: {
       concurrency: resolveAgentMaxConcurrent(cfg),


### PR DESCRIPTION
## What Problem This Solves

Removes 34 unnecessary public module symbols from bundled plugin implementation files. These helpers are only called inside their defining modules, so exporting them enlarges internal API surfaces without providing a consumer.

## Why This Change Was Made

Localizes the helpers to their owning modules across memory-wiki, policy, QA Lab, QA Matrix, oc-path, and Telegram. Repository-wide reference checks found local callers and zero external code consumers; no plugin API barrel or package export exposes these symbols.

## User Impact

No user-visible behavior changes. The extension implementation surface is smaller and more accurately reflects the supported plugin boundaries.

## Evidence

- Exact-transform verification: 34 helpers remain locally referenced and have zero external JavaScript/TypeScript references.
- Testbox `tbx_01kwyz85j4mdcq34kq68g89s56`: `pnpm check:changed` passed for the `extensions` and `extensionTests` lanes.
- Same Testbox: 8 focused files passed across 4 Vitest shards, 131 tests total.
- Fresh local autoreview: clean, confidence 0.89.
- Fresh branch autoreview: clean, confidence 0.88.
- `git diff --check` passed.

AI-assisted. I reviewed the diff and validation results. No agent transcript is attached.
