### PR TITLE
refactor(deadcode): localize core helpers

### DIFF
--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -147,7 +147,7 @@ export function createExecApprovalPendingState(params: {
 }
 
 /** Builds pending approval state plus rounded notice duration. */
-export function createExecApprovalRequestState(params: {
+function createExecApprovalRequestState(params: {
   warnings: string[];
   timeoutMs: number;
   approvalRunningNoticeMs: number;
@@ -163,7 +163,7 @@ export function createExecApprovalRequestState(params: {
 }
 
 /** Creates a fresh approval id/slug/context key for a pending request. */
-export function createExecApprovalRequestContext(params: {
+function createExecApprovalRequestContext(params: {
   warnings: string[];
   timeoutMs: number;
   approvalRunningNoticeMs: number;
@@ -188,7 +188,7 @@ export function createExecApprovalRequestContext(params: {
 }
 
 /** Creates a pending approval context using the default approval timeout. */
-export function createDefaultExecApprovalRequestContext(params: {
+function createDefaultExecApprovalRequestContext(params: {
   warnings: string[];
   approvalRunningNoticeMs: number;
   createApprovalSlug: (approvalId: string) => string;

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -440,7 +440,7 @@ export function formatHooksCheck(report: HookStatusReport, opts: HooksCheckOptio
   return lines.join("\n");
 }
 
-export async function enableHook(hookName: string): Promise<void> {
+async function enableHook(hookName: string): Promise<void> {
   const snapshot = await readConfigFileSnapshot();
   const config = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
   const hook = resolveHookForToggle(buildHooksReport(config), hookName, { requireEligible: true });
@@ -460,7 +460,7 @@ export async function enableHook(hookName: string): Promise<void> {
   );
 }
 
-export async function disableHook(hookName: string): Promise<void> {
+async function disableHook(hookName: string): Promise<void> {
   const snapshot = await readConfigFileSnapshot();
   const config = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
   const hook = resolveHookForToggle(buildHooksReport(config), hookName);

--- a/src/cli/update-cli/plugin-payload-validation.ts
+++ b/src/cli/update-cli/plugin-payload-validation.ts
@@ -244,7 +244,7 @@ async function validatePackagePayload(params: {
   return failures;
 }
 
-export function isBundleInstallRecord(record: PluginInstallRecord): boolean {
+function isBundleInstallRecord(record: PluginInstallRecord): boolean {
   return (
     (record as { format?: unknown }).format === "bundle" || record.clawhubFamily === "bundle-plugin"
   );

--- a/src/commands/doctor-plugin-registry.ts
+++ b/src/commands/doctor-plugin-registry.ts
@@ -321,7 +321,7 @@ export function maybeRepairStaleManagedNpmBundledPlugins(
 }
 
 /** Removes local install records that shadow current bundled plugin sources. */
-export async function maybeRepairStaleLocalBundledPluginInstallRecords(
+async function maybeRepairStaleLocalBundledPluginInstallRecords(
   params: PluginRegistryDoctorRepairParams,
 ): Promise<string[]> {
   const stale = await listStaleLocalBundledPluginInstallRecordShadows(params);

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -41,7 +41,7 @@ const CONVERSATIONAL_SAFE_ONBOARD_KEYS = new Set([
   "classic",
 ]);
 
-export function wantsClassicInteractiveSetup(opts: OnboardOptions): boolean {
+function wantsClassicInteractiveSetup(opts: OnboardOptions): boolean {
   if (opts.classic === true) {
     return true;
   }

--- a/src/commands/runtime-plugin-install.ts
+++ b/src/commands/runtime-plugin-install.ts
@@ -69,7 +69,7 @@ function isInstalledRecordPresentOnDisk(
 }
 
 /** Ensures the runtime plugin required by the selected model is installed and enabled. */
-export async function ensureRuntimePluginForModelSelection(params: {
+async function ensureRuntimePluginForModelSelection(params: {
   cfg: OpenClawConfig;
   model?: string;
   prompter: WizardPrompter;
@@ -140,7 +140,7 @@ export async function ensureRuntimePluginForModelSelection(params: {
 }
 
 /** Repairs missing install records for runtime plugins required by model selection. */
-export async function repairRuntimePluginInstallForModelSelection(params: {
+async function repairRuntimePluginInstallForModelSelection(params: {
   cfg: OpenClawConfig;
   model?: string;
   env?: NodeJS.ProcessEnv;

--- a/src/config/codex-plugin-diagnostics.ts
+++ b/src/config/codex-plugin-diagnostics.ts
@@ -185,7 +185,7 @@ function openAiDefaultRouteKeepsCodexUnavailable(cfg: OpenClawConfig): boolean {
  * Route-specific Codex selections still win; this only answers the missing-plugin
  * diagnostic question for OpenAI defaults and OpenAI-compatible proxy configs.
  */
-export function configExplicitlyKeepsCodexUnavailableForOpenAi(cfg: OpenClawConfig): boolean {
+function configExplicitlyKeepsCodexUnavailableForOpenAi(cfg: OpenClawConfig): boolean {
   if (openAiHasCodexDefaultRuntimePolicy(cfg)) {
     return false;
   }

--- a/src/config/nix-mode-write-guard.ts
+++ b/src/config/nix-mode-write-guard.ts
@@ -17,7 +17,7 @@ export class NixModeConfigMutationError extends Error {
 }
 
 /** Build the operator-facing immutable-config message for Nix-managed installs. */
-export function formatNixModeConfigMutationMessage(params: { configPath?: string } = {}): string {
+function formatNixModeConfigMutationMessage(params: { configPath?: string } = {}): string {
   return [
     "Config is managed by Nix (`OPENCLAW_NIX_MODE=1`), so OpenClaw treats openclaw.json as immutable.",
     "This usually means nix-openclaw, the first-party Nix distribution, or another Nix-managed package set this mode.",

--- a/src/config/sessions/store-cache.ts
+++ b/src/config/sessions/store-cache.ts
@@ -119,7 +119,7 @@ export function internSessionEntryLargeStrings(entry: SessionEntry): void {
   snapshot.prompt = internLargeSessionStoreString(snapshot.prompt);
 }
 
-export function internSessionStoreLargeStrings(store: Record<string, SessionEntry>): void {
+function internSessionStoreLargeStrings(store: Record<string, SessionEntry>): void {
   for (const entry of Object.values(store)) {
     internSessionEntryLargeStrings(entry);
   }
@@ -252,7 +252,7 @@ export function cloneSessionStoreSnapshotEntry(entry: SessionEntry): SessionStor
   return deepFreeze(cloneSessionStoreRecord({ entry }).entry);
 }
 
-export function getSessionStoreTtl(): number {
+function getSessionStoreTtl(): number {
   return resolveCacheTtlMs({
     envValue: process.env.OPENCLAW_SESSION_CACHE_TTL_MS,
     defaultTtlMs: DEFAULT_SESSION_STORE_TTL_MS,

--- a/src/config/sessions/transcript-jsonl.ts
+++ b/src/config/sessions/transcript-jsonl.ts
@@ -28,7 +28,7 @@ export function serializeJsonlLine(entry: unknown): string {
   return serialized;
 }
 
-export function serializeJsonlEntries(entries: readonly unknown[]): string {
+function serializeJsonlEntries(entries: readonly unknown[]): string {
   return serializeJsonlLines(entries.map(serializeJsonlLine));
 }
 

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -63,7 +63,7 @@ function truncateChatHistoryText(
 }
 
 /** Return true for known tool-call/tool-result block type spellings in transcripts. */
-export function isToolHistoryBlockType(type: unknown): boolean {
+function isToolHistoryBlockType(type: unknown): boolean {
   if (typeof type !== "string") {
     return false;
   }

--- a/src/gateway/local-request-context.ts
+++ b/src/gateway/local-request-context.ts
@@ -47,7 +47,7 @@ const unavailableCron: CronServiceContract = {
 };
 
 /** Creates the minimal gateway context used by embedded local agent execution. */
-export function createLocalGatewayRequestContext(
+function createLocalGatewayRequestContext(
   params: LocalGatewayRequestContextParams,
 ): GatewayRequestContext {
   const logGateway = createSubsystemLogger("gateway/local");

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -69,7 +69,7 @@ export function isNodeRoleMethod(method: string): boolean {
 }
 
 /** Resolves the required static operator scope for a gateway method, if one exists. */
-export function resolveRequiredOperatorScopeForMethod(method: string): OperatorScope | undefined {
+function resolveRequiredOperatorScopeForMethod(method: string): OperatorScope | undefined {
   return resolveScopedMethod(method);
 }
 

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -293,7 +293,7 @@ export function listCoreGatewayMethodNames(): string[] {
 }
 
 /** Looks up the raw core method scope, including node and dynamic sentinel scopes. */
-export function resolveCoreGatewayMethodScope(method: string): GatewayMethodScope | undefined {
+function resolveCoreGatewayMethodScope(method: string): GatewayMethodScope | undefined {
   return CORE_GATEWAY_METHOD_SPEC_BY_NAME.get(method)?.scope;
 }
 

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -11,7 +11,7 @@ type GatewayMethodChannelPlugin = {
 };
 
 /** Lists core methods intentionally advertised to gateway clients. */
-export function listCoreGatewayMethods(): string[] {
+function listCoreGatewayMethods(): string[] {
   return listCoreAdvertisedGatewayMethodNames();
 }
 

--- a/src/gateway/server-methods/approval-shared.ts
+++ b/src/gateway/server-methods/approval-shared.ts
@@ -86,7 +86,7 @@ function isPromiseLike<T>(value: T | Promise<T>): value is Promise<T> {
   return typeof value === "object" && value !== null && "then" in value;
 }
 
-export function isApprovalDecision(value: string): value is ExecApprovalDecision {
+function isApprovalDecision(value: string): value is ExecApprovalDecision {
   return value === "allow-once" || value === "allow-always" || value === "deny";
 }
 

--- a/src/gateway/server-methods/channels.ts
+++ b/src/gateway/server-methods/channels.ts
@@ -247,7 +247,7 @@ function resolveChannelGatewayAccountId(params: {
 }
 
 /** Log out one channel account through its owning channel plugin. */
-export async function logoutChannelAccount(params: {
+async function logoutChannelAccount(params: {
   channelId: ChannelId;
   accountId?: string | null;
   cfg: OpenClawConfig;
@@ -282,7 +282,7 @@ export async function logoutChannelAccount(params: {
 }
 
 /** Start one channel account through its owning channel plugin. */
-export async function startChannelAccount(params: {
+async function startChannelAccount(params: {
   channelId: ChannelId;
   accountId?: string | null;
   cfg: OpenClawConfig;
@@ -309,7 +309,7 @@ export async function startChannelAccount(params: {
 }
 
 /** Stop one channel account through its owning channel plugin. */
-export async function stopChannelAccount(params: {
+async function stopChannelAccount(params: {
   channelId: ChannelId;
   accountId?: string | null;
   cfg: OpenClawConfig;

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1595,7 +1595,7 @@ function buildChatSendUserTurnMedia(savedMedia: SavedMedia[]): NonNullable<UserT
   }));
 }
 
-export function buildOversizedHistoryPlaceholder(message?: unknown): Record<string, unknown> {
+function buildOversizedHistoryPlaceholder(message?: unknown): Record<string, unknown> {
   const role =
     message &&
     typeof message === "object" &&

--- a/src/gateway/server-methods/talk-shared.ts
+++ b/src/gateway/server-methods/talk-shared.ts
@@ -123,7 +123,7 @@ function getVoiceCallRealtimeConfig(config: OpenClawConfig): {
   return getVoiceCallProviderConfig(config, "realtime");
 }
 
-export function getVoiceCallStreamingConfig(config: OpenClawConfig): {
+function getVoiceCallStreamingConfig(config: OpenClawConfig): {
   provider?: string;
   providers?: Record<string, RealtimeTranscriptionProviderConfig>;
 } {

--- a/src/gateway/server-methods/tools-catalog.ts
+++ b/src/gateway/server-methods/tools-catalog.ts
@@ -194,7 +194,7 @@ function buildPluginGroups(params: {
 }
 
 /** Build the merged core/plugin tool catalog for one agent. */
-export function buildToolsCatalogResult(params: {
+function buildToolsCatalogResult(params: {
   cfg: OpenClawConfig;
   agentId?: string;
   includePlugins?: boolean;

--- a/src/gateway/server-methods/workspace-fs.ts
+++ b/src/gateway/server-methods/workspace-fs.ts
@@ -11,7 +11,7 @@ export type WorkspaceDirEntry = WorkspacePathStat & { name: string };
 /** Shared preview cap: keeps file payloads comfortably under client WS limits. */
 export const WORKSPACE_PREVIEW_MAX_BYTES = 256 * 1024;
 
-export async function openWorkspaceRoot(rootDir: string): Promise<WorkspaceRoot | undefined> {
+async function openWorkspaceRoot(rootDir: string): Promise<WorkspaceRoot | undefined> {
   try {
     return await fsSafeRoot(rootDir, {
       hardlinks: "reject",

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -408,7 +408,7 @@ export function createRuntimeSecretsActivator(params: {
 }
 
 /** Throw a formatted startup error when the loaded config snapshot is invalid. */
-export function assertValidGatewayStartupConfigSnapshot(
+function assertValidGatewayStartupConfigSnapshot(
   snapshot: ConfigFileSnapshot,
   options: { includeDoctorHint?: boolean } = {},
 ): void {

--- a/src/gateway/server/plugins-http/route-capability.ts
+++ b/src/gateway/server/plugins-http/route-capability.ts
@@ -34,7 +34,7 @@ function resolvePluginNodeCapabilityRouteSurface(
 }
 
 /** Lists all node-capability routes matching the already canonicalized path context. */
-export function findMatchingPluginNodeCapabilityRoutes(
+function findMatchingPluginNodeCapabilityRoutes(
   registry: PluginRegistry,
   context: PluginRoutePathContext,
 ): PluginNodeCapabilityRoute[] {

--- a/src/gateway/server/plugins-http/route-match.ts
+++ b/src/gateway/server/plugins-http/route-match.ts
@@ -13,7 +13,7 @@ import {
 type PluginHttpRouteEntry = NonNullable<PluginRegistry["httpRoutes"]>[number];
 
 /** Returns true when a registered route matches any canonical request candidate. */
-export function doesPluginRouteMatchPath(
+function doesPluginRouteMatchPath(
   route: PluginHttpRouteEntry,
   context: PluginRoutePathContext,
 ): boolean {

--- a/src/gateway/session-child-sessions.ts
+++ b/src/gateway/session-child-sessions.ts
@@ -14,7 +14,7 @@ export type DirectChildSessionEntry = {
 };
 
 /** Returns true when a session store row is a direct child of the parent key. */
-export function isDirectChildSessionEntry(params: {
+function isDirectChildSessionEntry(params: {
   sessionKey: string;
   entry: SessionEntry | undefined;
   parentKey: string;

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1045,7 +1045,7 @@ export function loadSessionEntry(sessionKey: string, opts?: { agentId?: string; 
   };
 }
 
-export function resolveFreshestSessionStoreMatchFromStoreKeys(
+function resolveFreshestSessionStoreMatchFromStoreKeys(
   store: Record<string, SessionEntry>,
   storeKeys: string[],
 ): { key: string; entry: SessionEntry } | undefined {
@@ -1570,7 +1570,7 @@ export function resolveGatewaySessionStoreTarget(params: {
 
 export { loadCombinedSessionStoreForGateway } from "../config/sessions/combined-store-gateway.js";
 
-export function resolveGatewaySessionThinkingDefault(params: {
+function resolveGatewaySessionThinkingDefault(params: {
   cfg: OpenClawConfig;
   provider: string;
   model: string;

--- a/src/infra/command-carriers.ts
+++ b/src/infra/command-carriers.ts
@@ -295,7 +295,7 @@ export function unwrapEnvInvocation(argv: string[]): string[] | null {
 }
 
 /** Resolve the command argv behind an `env` carrier, honoring bounded `env -S` recursion. */
-export function resolveEnvCarriedArgv(argv: string[], depth = 0): string[] | null {
+function resolveEnvCarriedArgv(argv: string[], depth = 0): string[] | null {
   const parsed = parseEnvInvocationPrelude(argv, depth);
   return parsed ? (parsed.splitArgv ?? argv.slice(parsed.commandIndex)) : null;
 }

--- a/src/infra/event-session-routing.ts
+++ b/src/infra/event-session-routing.ts
@@ -93,7 +93,7 @@ export function parseDirectAgentSessionTarget(
 }
 
 /** Resolve the configured DM allowlist that applies to an event session. */
-export function resolveEventSessionAllowFrom(params: {
+function resolveEventSessionAllowFrom(params: {
   cfg?: OpenClawConfig;
   sessionKey?: string | null;
   channel?: string | null;

--- a/src/infra/exec-control-command-guard.ts
+++ b/src/infra/exec-control-command-guard.ts
@@ -11,7 +11,7 @@ type ParsedExecApprovalCommand = {
 
 export type UnsafeExecControlShellCommandKind = "approve" | "channel-login";
 
-export function parseExecApprovalShellCommand(raw: string): ParsedExecApprovalCommand | null {
+function parseExecApprovalShellCommand(raw: string): ParsedExecApprovalCommand | null {
   const normalized = raw.trimStart();
   const match = normalized.match(
     /^\/approve(?:@[^\s]+)?\s+([A-Za-z0-9][A-Za-z0-9._:-]*)\s+(allow-once|allow-always|always|deny)\b/i,

--- a/src/infra/host-env-security.ts
+++ b/src/infra/host-env-security.ts
@@ -178,10 +178,7 @@ function sanitizeInheritedGitAllowProtocolValue(value: string): string {
   return safeProtocols.join(":");
 }
 
-export function sanitizeHostInheritedEnvEntry(
-  rawKey: string,
-  value: string,
-): [string, string] | null {
+function sanitizeHostInheritedEnvEntry(rawKey: string, value: string): [string, string] | null {
   const key = normalizeEnvVarKey(rawKey);
   if (!key) {
     return null;

--- a/src/infra/kysely-sync.ts
+++ b/src/infra/kysely-sync.ts
@@ -32,7 +32,7 @@ export function getNodeSqliteKysely<Database>(db: DatabaseSync): Kysely<Database
 }
 
 /** Execute a compiled Kysely query synchronously against node:sqlite. */
-export function executeCompiledSqliteQuerySync<Row>(
+function executeCompiledSqliteQuerySync<Row>(
   db: DatabaseSync,
   compiledQuery: CompiledQuery<Row>,
 ): QueryResult<Row> {

--- a/src/infra/net/proxy/proxy-tls.ts
+++ b/src/infra/net/proxy/proxy-tls.ts
@@ -30,7 +30,7 @@ function isHttpsProxyUrl(value: string | undefined): boolean {
 }
 
 /** Resolves the configured managed proxy CA file, with env/CLI override first. */
-export function resolveManagedProxyCaFile(params: {
+function resolveManagedProxyCaFile(params: {
   config?: ProxyConfig;
   caFileOverride?: string;
 }): string | undefined {

--- a/src/infra/outbound/message-action-tts.ts
+++ b/src/infra/outbound/message-action-tts.ts
@@ -14,7 +14,7 @@ const loadMessageActionTtsRuntime = createLazyRuntimeModule(
 );
 
 /** Reads the session-level TTS auto mode for a message-action send. */
-export function resolveMessageActionSessionTtsAuto(params: {
+function resolveMessageActionSessionTtsAuto(params: {
   cfg: OpenClawConfig;
   sessionKey?: string;
   agentId?: string;

--- a/src/infra/outbound/target-errors.ts
+++ b/src/infra/outbound/target-errors.ts
@@ -40,7 +40,7 @@ export function unknownTargetError(provider: string, raw: string, hint?: string)
   return new Error(unknownTargetMessage(provider, raw, hint));
 }
 
-export function reservedTargetLiteralMessage(provider: string, raw: string, hint?: string): string {
+function reservedTargetLiteralMessage(provider: string, raw: string, hint?: string): string {
   return `Reserved target "${raw}" for ${provider} cannot be used as a literal destination. Provide an explicit id or handle.${formatTargetHint(hint, true)}`;
 }
 

--- a/src/infra/promotions-feed.ts
+++ b/src/infra/promotions-feed.ts
@@ -194,7 +194,7 @@ export function markPromotionSlugsNotified(slugs: Iterable<string>): void {
   }
 }
 
-export function isPromotionWindowLive(
+function isPromotionWindowLive(
   entry: Pick<ClawHubPromotionsFeedEntry, "startsAt" | "endsAt">,
   nowMs: number,
 ): boolean {

--- a/src/infra/stale-lock-file.ts
+++ b/src/infra/stale-lock-file.ts
@@ -10,7 +10,7 @@ export type LockFileOwnerPayload = {
   starttime?: number;
 };
 
-export function readLockFileOwnerPayload(
+function readLockFileOwnerPayload(
   payload: Record<string, unknown> | null,
 ): LockFileOwnerPayload | null {
   if (!payload) {

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -473,7 +473,7 @@ export function registerUnhandledRejectionHandler(handler: UnhandledRejectionHan
   };
 }
 
-export function isUnhandledRejectionHandled(reason: unknown): boolean {
+function isUnhandledRejectionHandled(reason: unknown): boolean {
   for (const handler of handlers) {
     try {
       if (handler(reason)) {

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -302,7 +302,7 @@ async function detectGitRoot(root: string): Promise<string | null> {
   return top ? path.resolve(top) : null;
 }
 
-export async function checkGitUpdateStatus(params: {
+async function checkGitUpdateStatus(params: {
   root: string;
   timeoutMs?: number;
   fetch?: boolean;

--- a/src/logging/diagnostic-stability-bundle.ts
+++ b/src/logging/diagnostic-stability-bundle.ts
@@ -225,7 +225,7 @@ function readSafeErrorMetadata(error: unknown): DiagnosticStabilityBundle["error
   };
 }
 
-export function resolveDiagnosticStabilityBundleDir(
+function resolveDiagnosticStabilityBundleDir(
   options: DiagnosticStabilityBundleLocationOptions = {},
 ): string {
   return path.join(

--- a/src/logging/diagnostic-support-export.ts
+++ b/src/logging/diagnostic-support-export.ts
@@ -670,7 +670,7 @@ function resolveOutputPath(options: {
   return resolved;
 }
 
-export async function buildDiagnosticSupportExport(
+async function buildDiagnosticSupportExport(
   options: DiagnosticSupportExportOptions = {},
 ): Promise<DiagnosticSupportExportArtifact> {
   const env = options.env ?? process.env;

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -161,7 +161,7 @@ export function normalizeMimeType(value: string | undefined): string | undefined
 }
 
 /** Parses a Content-Type header into normalized MIME and optional charset values. */
-export function parseContentType(value: string | undefined): {
+function parseContentType(value: string | undefined): {
   mimeType?: string;
   charset?: string;
 } {

--- a/src/plugins/activation-context.ts
+++ b/src/plugins/activation-context.ts
@@ -114,7 +114,7 @@ export function withActivatedPluginIds(params: {
   };
 }
 
-export function applyPluginCompatibilityOverrides(params: {
+function applyPluginCompatibilityOverrides(params: {
   config?: OpenClawConfig;
   compat?: PluginActivationCompatConfig;
   env: NodeJS.ProcessEnv;
@@ -183,7 +183,7 @@ function applyPluginAutoEnableForActivation(params: {
   });
 }
 
-export function resolvePluginActivationSnapshot(params: {
+function resolvePluginActivationSnapshot(params: {
   rawConfig?: OpenClawConfig;
   resolvedConfig?: OpenClawConfig;
   autoEnabledReasons?: Record<string, string[]>;
@@ -220,7 +220,7 @@ export function resolvePluginActivationSnapshot(params: {
   };
 }
 
-export function resolvePluginActivationInputs(params: {
+function resolvePluginActivationInputs(params: {
   rawConfig?: OpenClawConfig;
   resolvedConfig?: OpenClawConfig;
   autoEnabledReasons?: Record<string, string[]>;

--- a/src/plugins/api-lifecycle.ts
+++ b/src/plugins/api-lifecycle.ts
@@ -25,7 +25,7 @@ const PLUGIN_API_METHOD_POLICIES: Partial<Record<PluginApiMethodName, PluginApiL
 };
 
 /** Returns lifecycle policy for one plugin API method name. */
-export function getPluginApiMethodLifecyclePolicy(
+function getPluginApiMethodLifecyclePolicy(
   methodName: string,
 ): PluginApiLifecyclePolicy | undefined {
   return PLUGIN_API_METHOD_POLICIES[methodName as PluginApiMethodName];

--- a/src/plugins/bundled-capability-runtime.ts
+++ b/src/plugins/bundled-capability-runtime.ts
@@ -95,7 +95,7 @@ function shouldApplyVitestCapabilityAliasOverrides(params: {
   return Boolean(params.env?.VITEST && params.pluginSdkResolution === "dist");
 }
 
-export function buildBundledCapabilityRuntimeConfig(
+function buildBundledCapabilityRuntimeConfig(
   pluginIds: readonly string[],
   env?: PluginLoadOptions["env"],
 ): PluginLoadOptions["config"] {

--- a/src/plugins/bundled-load-path-aliases.ts
+++ b/src/plugins/bundled-load-path-aliases.ts
@@ -83,7 +83,7 @@ export function parsePackagedBundledPluginPath(
 }
 
 /** Builds the legacy extensions-root alias for a packaged bundled plugin path. */
-export function buildLegacyBundledPath(localPath: string): string | null {
+function buildLegacyBundledPath(localPath: string): string | null {
   const packaged = parsePackagedBundledPluginPath(localPath);
   if (!packaged) {
     return null;

--- a/src/plugins/bundled-manifest-contract-plugins.ts
+++ b/src/plugins/bundled-manifest-contract-plugins.ts
@@ -18,7 +18,7 @@ function createPluginIdSet(pluginIds: readonly string[] | undefined): Set<string
 }
 
 /** Lists bundled plugin ids with a non-empty contract contribution in a manifest snapshot. */
-export function listBundledManifestContractPluginIds(params: {
+function listBundledManifestContractPluginIds(params: {
   plugins: readonly PluginManifestRecord[];
   contract: PluginManifestContractListKey;
   onlyPluginIds?: readonly string[];

--- a/src/plugins/bundled-source-overlays.ts
+++ b/src/plugins/bundled-source-overlays.ts
@@ -11,7 +11,7 @@ function decodeMountInfoPath(value: string): string {
 }
 
 /** Parses Linux mountinfo content into absolute mount points. */
-export function parseLinuxMountInfoMountPoints(mountInfo: string): Set<string> {
+function parseLinuxMountInfoMountPoints(mountInfo: string): Set<string> {
   const mountPoints = new Set<string>();
   for (const line of mountInfo.split(/\r?\n/u)) {
     const trimmed = line.trim();

--- a/src/plugins/cli-registry-loader.ts
+++ b/src/plugins/cli-registry-loader.ts
@@ -131,7 +131,7 @@ async function resolvePrimaryCommandPluginIds(
 }
 
 /** Builds the runtime load context used for CLI-only plugin registry loading. */
-export function resolvePluginCliLoadContext(params: {
+function resolvePluginCliLoadContext(params: {
   cfg?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   logger: PluginLogger;
@@ -143,7 +143,7 @@ export function resolvePluginCliLoadContext(params: {
   });
 }
 
-export async function loadPluginCliMetadataRegistryWithContext(
+async function loadPluginCliMetadataRegistryWithContext(
   context: PluginCliLoadContext,
   params?: { primaryCommand?: string },
   loaderOptions?: PluginCliLoaderOptions,
@@ -156,7 +156,7 @@ export async function loadPluginCliMetadataRegistryWithContext(
   };
 }
 
-export async function loadPluginCliCommandRegistryWithContext(params: {
+async function loadPluginCliCommandRegistryWithContext(params: {
   context: PluginCliLoadContext;
   primaryCommand?: string;
   loaderOptions?: PluginCliLoaderOptions;
@@ -242,7 +242,7 @@ export async function loadPluginCliDescriptors(
   }
 }
 
-export async function loadPluginCliRegistrationEntries(params: {
+async function loadPluginCliRegistrationEntries(params: {
   cfg?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   loaderOptions?: PluginCliLoaderOptions;

--- a/src/plugins/config-activation-shared.ts
+++ b/src/plugins/config-activation-shared.ts
@@ -72,7 +72,7 @@ const PLUGIN_ACTIVATION_REASON_BY_CAUSE: Record<PluginActivationCause, string> =
   "bundled-disabled-by-default": "bundled (disabled by default)",
 };
 
-export function resolvePluginActivationReason(
+function resolvePluginActivationReason(
   cause?: PluginActivationCause,
   reason?: string,
 ): string | undefined {
@@ -298,11 +298,11 @@ export function resolvePluginActivationDecisionShared<TRootConfig>(params: {
   };
 }
 
-export function toEnableStateResult(state: EnableStateLike): { enabled: boolean; reason?: string } {
+function toEnableStateResult(state: EnableStateLike): { enabled: boolean; reason?: string } {
   return state.enabled ? { enabled: true } : { enabled: false, reason: state.reason };
 }
 
-export function resolveEnableStateResult<TParams>(
+function resolveEnableStateResult<TParams>(
   params: TParams,
   resolveState: (params: TParams) => EnableStateLike,
 ): { enabled: boolean; reason?: string } {

--- a/src/plugins/embedding-provider-runtime.ts
+++ b/src/plugins/embedding-provider-runtime.ts
@@ -15,7 +15,7 @@ import {
 export { listRegisteredEmbeddingProviders };
 
 /** Lists embedding provider adapters registered directly with the process registry. */
-export function listRegisteredEmbeddingProviderAdapters(): EmbeddingProviderAdapter[] {
+function listRegisteredEmbeddingProviderAdapters(): EmbeddingProviderAdapter[] {
   return listRegisteredEmbeddingProviders().map((entry) => entry.adapter);
 }
 
@@ -28,7 +28,7 @@ export function listEmbeddingProviders(cfg?: OpenClawConfig): EmbeddingProviderA
   });
 }
 
-export function resolveConfiguredEmbeddingProviderId(
+function resolveConfiguredEmbeddingProviderId(
   providerId: string,
   cfg?: OpenClawConfig,
 ): string | undefined {

--- a/src/plugins/install-paths.ts
+++ b/src/plugins/install-paths.ts
@@ -96,7 +96,7 @@ export function resolveDefaultPluginNpmDir(
 }
 
 /** Encodes an npm package name into a managed npm project directory name. */
-export function encodePluginNpmProjectDirName(packageName: string): string {
+function encodePluginNpmProjectDirName(packageName: string): string {
   const trimmed = packageName.trim();
   if (!trimmed) {
     throw new Error("invalid npm package name: missing");
@@ -130,7 +130,7 @@ export function resolvePluginNpmGenerationProjectDirPrefix(packageName: string):
 }
 
 /** Encodes a package generation fingerprint into a compact project directory suffix. */
-export function encodePluginNpmGenerationKeyDirName(generationKey: string): string {
+function encodePluginNpmGenerationKeyDirName(generationKey: string): string {
   const digest = createHash("sha256").update(generationKey).digest("hex");
   return `g-${digest.slice(0, PLUGIN_NPM_GENERATION_KEY_HASH_CHARS)}`;
 }

--- a/src/plugins/manifest-registry-installed.ts
+++ b/src/plugins/manifest-registry-installed.ts
@@ -45,7 +45,7 @@ type InstalledPackageMetadata = {
   packageOptionalDependencies?: PluginDependencySpecMap;
 };
 
-export function clearInstalledManifestRegistryProcessCaches(): void {
+function clearInstalledManifestRegistryProcessCaches(): void {
   installedPackageJsonPathCache.clear();
   installedPackageMetadataCache.clear();
   installedManifestRegistryRealpathCache.clear();

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -1627,7 +1627,7 @@ export function normalizeManifestChannelCommandDefaults(
     : undefined;
 }
 
-export function resolvePluginManifestPath(rootDir: string): string {
+function resolvePluginManifestPath(rootDir: string): string {
   for (const filename of PLUGIN_MANIFEST_FILENAMES) {
     const candidate = path.join(rootDir, filename);
     if (fs.existsSync(candidate)) {

--- a/src/plugins/native-module-require.ts
+++ b/src/plugins/native-module-require.ts
@@ -151,7 +151,7 @@ function requireWithOptionalAliases(
 }
 
 /** Runs a native require block with temporary CJS/ESM alias hooks and restores both afterward. */
-export function withNativeRequireAliases<T>(
+function withNativeRequireAliases<T>(
   aliasMap: Record<string, string> | undefined,
   run: () => T,
 ): T {

--- a/src/plugins/npm-project-roots.ts
+++ b/src/plugins/npm-project-roots.ts
@@ -31,7 +31,7 @@ export function listManagedPluginNpmProjectRootsSync(npmRoot: string): string[] 
 }
 
 /** Async variant of project-level managed npm root discovery. */
-export async function listManagedPluginNpmProjectRoots(npmRoot: string): Promise<string[]> {
+async function listManagedPluginNpmProjectRoots(npmRoot: string): Promise<string[]> {
   const projectsDir = resolvePluginNpmProjectsDir(npmRoot);
   try {
     return sortPaths(

--- a/src/plugins/openai-compatible-embedding-provider.ts
+++ b/src/plugins/openai-compatible-embedding-provider.ts
@@ -392,7 +392,7 @@ async function postEmbeddingRequest(params: {
 }
 
 /** Creates a normalized OpenAI-compatible embedding client from runtime config. */
-export async function createOpenAICompatibleEmbeddingClient(
+async function createOpenAICompatibleEmbeddingClient(
   options: EmbeddingProviderCreateOptions,
 ): Promise<OpenAICompatibleEmbeddingClient> {
   const configuredProvider = resolveConfiguredProvider(options);

--- a/src/plugins/provider-catalog-result.ts
+++ b/src/plugins/provider-catalog-result.ts
@@ -115,7 +115,7 @@ function copyProviderCatalogModel(model: unknown): ModelDefinitionConfig | undef
 }
 
 /** Copies the supported provider config fields from a provider catalog result. */
-export function copyProviderCatalogProviderConfig(
+function copyProviderCatalogProviderConfig(
   providerConfig: unknown,
 ): ModelProviderConfig | undefined {
   if (!isRecord(providerConfig)) {

--- a/src/plugins/provider-discovery.runtime.ts
+++ b/src/plugins/provider-discovery.runtime.ts
@@ -52,7 +52,7 @@ function resolveProviderDiscoveryDependencyRoot(rootDir: string): string {
   return rootDir;
 }
 
-export function clearProviderDiscoveryModuleLoaders(): void {
+function clearProviderDiscoveryModuleLoaders(): void {
   providerDiscoveryModuleLoaders.clear();
   for (const [modulePath, rootDir] of providerDiscoveryModuleRoots) {
     clearNativeRequireJavaScriptModuleCache(modulePath, { dependencyRoot: rootDir });

--- a/src/plugins/runtime/runtime-plugin-boundary.ts
+++ b/src/plugins/runtime/runtime-plugin-boundary.ts
@@ -19,7 +19,7 @@ type PluginRuntimeRecord = {
   source: string;
 };
 
-export function readPluginBoundaryConfigSafely() {
+function readPluginBoundaryConfigSafely() {
   try {
     return getRuntimeConfig();
   } catch {

--- a/src/plugins/web-provider-public-artifacts.explicit.ts
+++ b/src/plugins/web-provider-public-artifacts.explicit.ts
@@ -153,7 +153,7 @@ export function loadBundledWebFetchProviderEntriesFromDir(params: {
   });
 }
 
-export function loadBundledRuntimeWebFetchProviderEntriesFromDir(params: {
+function loadBundledRuntimeWebFetchProviderEntriesFromDir(params: {
   dirName: string;
   pluginId: string;
 }): PluginWebFetchProviderEntry[] | null {

--- a/src/proxy-capture/coverage.ts
+++ b/src/proxy-capture/coverage.ts
@@ -125,7 +125,7 @@ const DEBUG_PROXY_COVERAGE_ENTRIES: readonly DebugProxyCoverageEntry[] = [
 
 let warnedCoverageSessionKey: string | null = null;
 
-export function listDebugProxyCoverageEntries(): DebugProxyCoverageEntry[] {
+function listDebugProxyCoverageEntries(): DebugProxyCoverageEntry[] {
   // Return copies because callers may render/sort/filter entries for CLI output.
   return DEBUG_PROXY_COVERAGE_ENTRIES.map((entry) => ({
     ...entry,
@@ -133,7 +133,7 @@ export function listDebugProxyCoverageEntries(): DebugProxyCoverageEntry[] {
   }));
 }
 
-export function summarizeDebugProxyCoverage(
+function summarizeDebugProxyCoverage(
   entries: readonly DebugProxyCoverageEntry[] = DEBUG_PROXY_COVERAGE_ENTRIES,
 ): DebugProxyCoverageSummary {
   let captured = 0;

--- a/src/secrets/auth-profiles-scan.ts
+++ b/src/secrets/auth-profiles-scan.ts
@@ -82,7 +82,7 @@ const AUTH_PROFILE_FIELD_SPEC_BY_TYPE = (() => {
 })();
 
 /** Returns the value/ref field names for one auth-profile credential type. */
-export function getAuthProfileFieldSpec(type: AuthProfileCredentialType): AuthProfileFieldSpec {
+function getAuthProfileFieldSpec(type: AuthProfileCredentialType): AuthProfileFieldSpec {
   return AUTH_PROFILE_FIELD_SPEC_BY_TYPE[type];
 }
 

--- a/src/secrets/channel-env-vars.ts
+++ b/src/secrets/channel-env-vars.ts
@@ -18,7 +18,7 @@ type ChannelEnvVarLookupParams = {
  * Resolves plugin-declared channel environment variable names keyed by channel id.
  * The result is deterministic so env-shell docs and prompt snapshots stay stable.
  */
-export function resolveChannelEnvVars(
+function resolveChannelEnvVars(
   params?: ChannelEnvVarLookupParams,
 ): Record<string, readonly string[]> {
   const snapshot = loadPluginMetadataSnapshot({

--- a/src/secrets/legacy-secretref-env-marker.ts
+++ b/src/secrets/legacy-secretref-env-marker.ts
@@ -41,7 +41,7 @@ function toCandidate(
 /**
  * Finds legacy env marker strings on registered secret targets without mutating config.
  */
-export function collectLegacySecretRefEnvMarkerCandidates(
+function collectLegacySecretRefEnvMarkerCandidates(
   config: OpenClawConfig,
 ): LegacySecretRefEnvMarkerCandidate[] {
   const defaults = config.secrets?.defaults;

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -345,7 +345,7 @@ export function resolveProviderAuthLookupMaps(
 }
 
 /** Resolves env vars used by setup, default SecretRefs, and broad secret scrubbing. */
-export function resolveProviderEnvVars(
+function resolveProviderEnvVars(
   params?: ProviderEnvVarLookupParams,
 ): Record<string, readonly string[]> {
   return {

--- a/src/secrets/runtime-fast-path.ts
+++ b/src/secrets/runtime-fast-path.ts
@@ -110,7 +110,7 @@ function hasCandidateAuthProfileStoreSource(agentDir: string): boolean {
 /**
  * Returns whether auth profile files or OAuth state exist for candidate agent dirs.
  */
-export function hasCandidateAuthProfileStoreSources(params: {
+function hasCandidateAuthProfileStoreSources(params: {
   config: OpenClawConfig;
   env: NodeJS.ProcessEnv | Record<string, string | undefined>;
   agentDirs?: string[];

--- a/src/secrets/runtime-state.ts
+++ b/src/secrets/runtime-state.ts
@@ -51,7 +51,7 @@ const preparedSnapshotRefreshContext = new WeakMap<
 /**
  * Clones refresh context while preserving callback identity and isolating mutable maps/config.
  */
-export function cloneSecretsRuntimeRefreshContext(
+function cloneSecretsRuntimeRefreshContext(
   context: SecretsRuntimeRefreshContext,
 ): SecretsRuntimeRefreshContext {
   const cloned: SecretsRuntimeRefreshContext = {

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -306,7 +306,7 @@ function buildSecurityAuditSuppressionsActiveFinding(params: {
   };
 }
 
-export function applySecurityAuditSuppressions(
+function applySecurityAuditSuppressions(
   findings: SecurityAuditFinding[],
   suppressions: SecurityAuditSuppression[] | undefined,
 ): { findings: SecurityAuditFinding[]; suppressedFindings: SecurityAuditSuppressedFinding[] } {
@@ -1153,7 +1153,7 @@ function collectAgentSkillMcpBoundaryScopes(cfg: OpenClawConfig): AgentSkillMcpB
   });
 }
 
-export async function collectAgentSkillMcpBoundaryFindings(params: {
+async function collectAgentSkillMcpBoundaryFindings(params: {
   cfg: OpenClawConfig;
   stateDir: string;
 }): Promise<SecurityAuditFinding[]> {

--- a/src/security/installed-plugin-dirs.ts
+++ b/src/security/installed-plugin-dirs.ts
@@ -9,7 +9,7 @@ const IGNORED_INSTALLED_PLUGIN_DIR_NAMES = new Set(["node_modules", ".openclaw-i
  * Decide whether an installed-plugin directory should be skipped by security audits.
  * This filters generated install debris while keeping real plugin roots visible to scans.
  */
-export function shouldIgnoreInstalledPluginDirName(name: string): boolean {
+function shouldIgnoreInstalledPluginDirName(name: string): boolean {
   const normalized = normalizeOptionalLowercaseString(name);
   if (!normalized) {
     return true;

--- a/src/sessions/input-provenance.ts
+++ b/src/sessions/input-provenance.ts
@@ -114,9 +114,7 @@ export function hasInterSessionUserProvenance(
 // Prefix text is model-facing safety context for inter-session handoffs. It
 // states source metadata and explicitly prevents treating the payload as direct
 // end-user instruction.
-export function buildInterSessionPromptPrefix(
-  inputProvenance: InputProvenance | undefined,
-): string {
+function buildInterSessionPromptPrefix(inputProvenance: InputProvenance | undefined): string {
   const provenance = inputProvenance?.kind === "inter_session" ? inputProvenance : undefined;
   const details = [
     provenance?.sourceSessionKey ? `sourceSession=${provenance.sourceSessionKey}` : undefined,

--- a/src/sessions/session-chat-type-shared.ts
+++ b/src/sessions/session-chat-type-shared.ts
@@ -93,7 +93,7 @@ function deriveBuiltInLegacySessionChatType(
   return undefined;
 }
 
-export function deriveSessionChatTypeFromScopedKey(
+function deriveSessionChatTypeFromScopedKey(
   scopedSessionKey: string,
   deriveLegacySessionChatTypes: Array<
     (scopedSessionKey: string) => SessionKeyChatType | undefined

--- a/src/shared/device-pairing-access.ts
+++ b/src/shared/device-pairing-access.ts
@@ -66,7 +66,7 @@ function includesAll(allowed: readonly string[], requested: readonly string[]): 
 }
 
 /** Normalizes requested roles/scopes from pending pairing records, including legacy singular role. */
-export function summarizePendingDeviceAccess(request: PendingLike): DevicePairingAccessSummary {
+function summarizePendingDeviceAccess(request: PendingLike): DevicePairingAccessSummary {
   return {
     roles: normalizeRoleList(request.roles, request.role),
     scopes: normalizeDeviceAuthScopes(request.scopes),
@@ -74,7 +74,7 @@ export function summarizePendingDeviceAccess(request: PendingLike): DevicePairin
 }
 
 /** Summarizes currently approved device access, excluding roles whose tokens are revoked. */
-export function summarizeApprovedDeviceAccess(device: PairedLike): DevicePairingAccessSummary {
+function summarizeApprovedDeviceAccess(device: PairedLike): DevicePairingAccessSummary {
   const approvedRoles = normalizeRoleList(device.roles, device.role);
   const tokenList = Array.isArray(device.tokens)
     ? device.tokens

--- a/src/skills/config/mutations.ts
+++ b/src/skills/config/mutations.ts
@@ -4,7 +4,7 @@ import { REDACTED_SENTINEL } from "../../config/redact-snapshot.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 
-export function patchSkillConfigEntry(
+function patchSkillConfigEntry(
   cfg: OpenClawConfig,
   skillKey: string,
   patch: { enabled?: boolean; apiKey?: string; env?: Record<string, string> },

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -530,7 +530,7 @@ function resolveContainedSkillPath(params: {
   return null;
 }
 
-export function resolveNestedSkillsRoot(
+function resolveNestedSkillsRoot(
   dir: string,
   opts?: {
     maxEntriesToScan?: number;

--- a/src/tasks/task-flow-registry.ts
+++ b/src/tasks/task-flow-registry.ts
@@ -202,7 +202,7 @@ function resolveFlowBlockedSummary(
   );
 }
 
-export function deriveTaskFlowStatusFromTask(
+function deriveTaskFlowStatusFromTask(
   task: Pick<TaskRecord, "status" | "terminalOutcome">,
 ): TaskFlowStatus {
   if (task.status === "queued") {

--- a/src/tasks/task-registry.audit.ts
+++ b/src/tasks/task-registry.audit.ts
@@ -187,10 +187,7 @@ export function listTaskAuditFindings(options: TaskAuditOptions = {}): TaskAudit
   return findings.toSorted(compareFindings);
 }
 
-export function isRetainedLostTaskAuditFinding(
-  finding: TaskAuditFinding,
-  now = Date.now(),
-): boolean {
+function isRetainedLostTaskAuditFinding(finding: TaskAuditFinding, now = Date.now()): boolean {
   const cleanupAfter = resolveEffectiveTaskCleanupAfter(finding.task);
   return (
     finding.code === "lost" &&

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -883,7 +883,7 @@ function reconcileTaskRecordForOperatorInspectionWithContexts(
   return projectTaskLost(task, now, backingSessionContext);
 }
 
-export function reconcileTaskRecordForOperatorInspection(
+function reconcileTaskRecordForOperatorInspection(
   task: TaskRecord,
   context: CronRecoveryContext = createCronRecoveryContext(),
 ): TaskRecord {

--- a/src/trajectory/command-export.ts
+++ b/src/trajectory/command-export.ts
@@ -69,7 +69,7 @@ async function resolveTrajectoryExportBaseDir(workspaceDir: string): Promise<{
   return { baseDir: path.resolve(baseDir), realBase };
 }
 
-export async function resolveTrajectoryCommandOutputDir(params: {
+async function resolveTrajectoryCommandOutputDir(params: {
   outputPath?: string;
   workspaceDir: string;
   sessionId: string;

--- a/src/utils/delivery-context.shared.ts
+++ b/src/utils/delivery-context.shared.ts
@@ -84,9 +84,7 @@ export function deliveryContextFromChannelRoute(
 }
 
 /** Converts delivery context fields into the SDK channel route reference shape. */
-export function channelRouteFromDeliveryContext(
-  context?: DeliveryContext,
-): ChannelRouteRef | undefined {
+function channelRouteFromDeliveryContext(context?: DeliveryContext): ChannelRouteRef | undefined {
   return normalizeChannelRouteTarget(normalizeDeliveryContext(context));
 }
 


### PR DESCRIPTION
## What Problem This Solves

Internal core helpers remained exported even though no code outside their defining modules referenced them. Those unnecessary exports expand module APIs and make dead-code analysis less precise.

## Why This Change Was Made

Localize 99 functions across 79 core modules after a fresh codebase-memory graph index and repository-wide reference audit.

Each changed symbol:

- still has at least one local caller
- has zero external JavaScript or TypeScript references
- is not exposed through a wildcard re-export
- is not part of a package entry surface

The formatter also compacted ten declarations, leaving the production diff at net -10 lines.

## User Impact

None. Runtime behavior is unchanged; this only narrows internal module surfaces.

## Evidence

- codebase-memory graph: 21,039 files, 281,257 nodes, 1,133,831 edges, zero extraction errors
- exact committed-state audit: 99 private functions across 79 files, local callers, zero external code references
- `git diff --check`
- Testbox `tbx_01kwz049syz11bmqsfhw9gx148`: `pnpm check:changed` passed
- 31 direct non-gateway test files: 419 tests passed across 10 Vitest shards
- 9 direct gateway test files: 1,007 tests passed across 23 project files
- `src/gateway/model-pricing-cache.test.ts`: 75 tests passed twice in isolated reruns
- broad `pnpm test:changed` completed its earlier shards but the gateway shard hit the repository's 15-minute no-output retry path; the retry exposed one project-order-sensitive pricing-cache assertion and then repeated the teardown stall. The affected test passed twice in isolation.
- autoreview local: clean, confidence 0.93
- autoreview branch: clean, confidence 0.82

No transcript is attached.
