### PR TITLE
feat(android): add app language switcher

### DIFF
--- a/.github/workflows/android-language-proof.yml
+++ b/.github/workflows/android-language-proof.yml
@@ -1,0 +1,179 @@
+name: Android language proof
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_ref:
+        description: Branch, tag, or SHA to test
+        required: true
+        default: main
+      app_language:
+        description: OpenClaw app language mode for screenshot proof
+        required: true
+        default: zh-CN
+      screenshot_locale:
+        description: Fastlane screenshot output locale folder
+        required: true
+        default: zh-CN
+      screenshot_scene:
+        description: Android screenshot scene to capture
+        required: true
+        default: language
+
+concurrency:
+  group: android-language-proof-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  android-language-proof:
+    name: Android language proof
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      ANDROID_AVD_HOME: ${{ github.workspace }}/.android/avd
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ inputs.target_ref }}
+          fetch-depth: 1
+          fetch-tags: false
+          persist-credentials: false
+          submodules: false
+
+      - name: Setup Java
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+          cache-dependency-path: |
+            apps/android/**/*.gradle*
+            apps/android/**/gradle-wrapper.properties
+            apps/android/gradle/libs.versions.toml
+
+      - name: Cache Android SDK
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.android-sdk
+          key: ${{ runner.os }}-android-language-proof-sdk-v1-cmdline-14742923-api35-api37-buildtools-36.0.0
+          restore-keys: |
+            ${{ runner.os }}-android-language-proof-sdk-v1-
+
+      - name: Setup Android SDK cmdline-tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          ANDROID_SDK_ROOT="$HOME/.android-sdk"
+          CMDLINE_TOOLS_VERSION="14742923"
+          ARCHIVE="commandlinetools-linux-${CMDLINE_TOOLS_VERSION}_latest.zip"
+          URL="https://dl.google.com/android/repository/${ARCHIVE}"
+
+          if [ ! -x "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" ]; then
+            mkdir -p "$ANDROID_SDK_ROOT/cmdline-tools"
+            curl -fsSL "$URL" -o "/tmp/${ARCHIVE}"
+            rm -rf "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+            unzip -q "/tmp/${ARCHIVE}" -d "$ANDROID_SDK_ROOT/cmdline-tools"
+            mv "$ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools" "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+          fi
+
+          echo "ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT" >> "$GITHUB_ENV"
+          echo "ANDROID_HOME=$ANDROID_SDK_ROOT" >> "$GITHUB_ENV"
+          echo "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin" >> "$GITHUB_PATH"
+          echo "$ANDROID_SDK_ROOT/platform-tools" >> "$GITHUB_PATH"
+          echo "$ANDROID_SDK_ROOT/emulator" >> "$GITHUB_PATH"
+
+      - name: Install Android SDK packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          yes | sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --licenses >/dev/null || true
+          sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --install \
+            "platform-tools" \
+            "emulator" \
+            "platforms;android-37.0" \
+            "build-tools;36.0.0" \
+            "system-images;android-35;google_apis;x86_64"
+
+      - name: Create Android proof AVD
+        shell: bash
+        env:
+          AVD_NAME: OpenClaw_Language_API35
+        run: |
+          set -euo pipefail
+          mkdir -p "$ANDROID_AVD_HOME"
+          echo "no" | avdmanager create avd \
+            --force \
+            --name "$AVD_NAME" \
+            --package "system-images;android-35;google_apis;x86_64" \
+            --device "pixel_6"
+          find "$ANDROID_AVD_HOME" -maxdepth 2 -type f -print | sort
+
+      - name: Enable Android emulator KVM access
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -e /dev/kvm ]; then
+            sudo sh -c 'echo KERNEL==\"kvm\", GROUP=\"kvm\", MODE=\"0666\", OPTIONS+=\"static_node=kvm\" > /etc/udev/rules.d/99-kvm4all.rules'
+            sudo udevadm control --reload-rules
+            sudo udevadm trigger --name-match=kvm
+            ls -l /dev/kvm
+          else
+            echo "KVM is not available on this runner; the emulator will use its default fallback."
+          fi
+
+      - name: Build app and capture language screenshot
+        shell: bash
+        env:
+          ANDROID_SCREENSHOT_AVD: OpenClaw_Language_API35
+          ANDROID_SCREENSHOT_EMULATOR_ARGS: -no-snapshot -no-snapshot-save -gpu swiftshader_indirect -memory 2048 -cores 2
+          ANDROID_SCREENSHOT_EMULATOR_TIMEOUT_SECONDS: "360"
+          ANDROID_SCREENSHOT_SETTLE_SECONDS: "2.0"
+          APP_LANGUAGE: ${{ inputs.app_language }}
+          SCREENSHOT_LOCALE: ${{ inputs.screenshot_locale }}
+          SCREENSHOT_SCENE: ${{ inputs.screenshot_scene }}
+        run: |
+          set -euo pipefail
+          bash scripts/android-screenshots.sh \
+            --avd "$ANDROID_SCREENSHOT_AVD" \
+            --locale "$SCREENSHOT_LOCALE" \
+            --scene "$SCREENSHOT_SCENE" \
+            --app-language "$APP_LANGUAGE"
+
+      - name: Summarize proof
+        shell: bash
+        env:
+          TARGET_REF: ${{ inputs.target_ref }}
+          APP_LANGUAGE: ${{ inputs.app_language }}
+          SCREENSHOT_LOCALE: ${{ inputs.screenshot_locale }}
+          SCREENSHOT_SCENE: ${{ inputs.screenshot_scene }}
+        run: |
+          set -euo pipefail
+          screenshot_dir="apps/android/fastlane/metadata/android/${SCREENSHOT_LOCALE}/images/phoneScreenshots"
+          {
+            echo "## Android language proof"
+            echo
+            echo "- Target ref: \`${TARGET_REF}\`"
+            echo "- App language mode: \`${APP_LANGUAGE}\`"
+            echo "- Screenshot scene: \`${SCREENSHOT_SCENE}\`"
+            echo "- Screenshot artifact path: \`openclaw-${SCREENSHOT_SCENE}.png\`"
+            echo
+            echo "### Captured files"
+            find "$screenshot_dir" -maxdepth 1 -type f -name '*.png' -printf '- `%f`\n' | sort
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Android language proof artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: android-language-proof-${{ inputs.app_language }}
+          path: |
+            apps/android/fastlane/metadata/android/${{ inputs.screenshot_locale }}/images/phoneScreenshots/*.png
+            apps/android/app/build/outputs/apk/play/debug/*.apk
+          if-no-files-found: error
+          retention-days: 14

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -131,7 +131,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 203,
+      "line": 219,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt",
       "source": "OPENCLAW",
       "surface": "android",
@@ -147,7 +147,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 217,
+      "line": 218,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -155,7 +155,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 227,
+      "line": 228,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -443,7 +443,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 75,
+      "line": 98,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -451,7 +451,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 82,
+      "line": 105,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Connected",
       "surface": "android",
@@ -459,7 +459,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 107,
+      "line": 132,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Gateway paired",
       "surface": "android",
@@ -467,7 +467,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 107,
+      "line": 132,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Mac Studio - Tailnet",
       "surface": "android",
@@ -475,7 +475,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 108,
+      "line": 133,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Node",
       "surface": "android",
@@ -483,7 +483,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 109,
+      "line": 134,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Transport",
       "surface": "android",
@@ -491,7 +491,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 110,
+      "line": 135,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Capabilities",
       "surface": "android",
@@ -499,7 +499,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 113,
+      "line": 138,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Ready",
       "surface": "android",
@@ -507,7 +507,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 125,
+      "line": 150,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Hi Molty, are you there?",
       "surface": "android",
@@ -515,7 +515,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 125,
+      "line": 150,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "You",
       "surface": "android",
@@ -523,7 +523,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 127,
+      "line": 152,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Molty",
       "surface": "android",
@@ -531,7 +531,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 128,
+      "line": 153,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Always. Lurking in the shadows, exfoliating.",
       "surface": "android",
@@ -539,7 +539,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 156,
+      "line": 181,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Listening on device",
       "surface": "android",
@@ -547,7 +547,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 156,
+      "line": 181,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Talk mode",
       "surface": "android",
@@ -555,7 +555,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 157,
+      "line": 182,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Wake phrase",
       "surface": "android",
@@ -563,7 +563,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 158,
+      "line": 183,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Latency",
       "surface": "android",
@@ -571,7 +571,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 164,
+      "line": 189,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Screen tools",
       "surface": "android",
@@ -579,7 +579,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 164,
+      "line": 189,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Shared with your gateway",
       "surface": "android",
@@ -587,7 +587,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 165,
+      "line": 190,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Canvas",
       "surface": "android",
@@ -595,7 +595,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 176,
+      "line": 201,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Live context",
       "surface": "android",
@@ -603,7 +603,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 177,
+      "line": 202,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Camera",
       "surface": "android",
@@ -611,7 +611,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 178,
+      "line": 203,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Screen",
       "surface": "android",
@@ -619,7 +619,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 179,
+      "line": 204,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Location",
       "surface": "android",
@@ -627,7 +627,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 187,
+      "line": 212,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Security",
       "surface": "android",
@@ -635,15 +635,55 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 191,
+      "line": 216,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Notifications",
       "surface": "android",
       "id": "native.android.1a74a732a75fbd60"
     },
     {
+      "kind": "ui-named-argument",
+      "line": 225,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
+      "source": "Language switch",
+      "surface": "android",
+      "id": "native.android.e2b3203c4f6194b3"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 228,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
+      "source": "Mode",
+      "surface": "android",
+      "id": "native.android.ea52c02b73d34991"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 229,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
+      "source": "Resource",
+      "surface": "android",
+      "id": "native.android.7ee401c1385a8deb"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 230,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
+      "source": "Action",
+      "surface": "android",
+      "id": "native.android.815eedcdbf98f28a"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 233,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
+      "source": "Localized resources",
+      "surface": "android",
+      "id": "native.android.3181522bb3170033"
+    },
+    {
       "kind": "conditional-branch",
-      "line": 397,
+      "line": 444,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Connect",
       "surface": "android",
@@ -651,7 +691,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 398,
+      "line": 445,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -659,7 +699,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 399,
+      "line": 446,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Talk",
       "surface": "android",
@@ -667,7 +707,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 400,
+      "line": 447,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Device tools",
       "surface": "android",
@@ -675,11 +715,19 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 401,
+      "line": 448,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Settings",
       "surface": "android",
       "id": "native.android.523d4a53f3d257a5"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 449,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
+      "source": "Language",
+      "surface": "android",
+      "id": "native.android.0171f43151bbc229"
     },
     {
       "kind": "conditional-branch",
@@ -2827,7 +2875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 220,
+      "line": 226,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Provider limits and quota health.",
       "surface": "android",
@@ -2835,7 +2883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 220,
+      "line": 226,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Usage",
       "surface": "android",
@@ -2843,7 +2891,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 240,
+      "line": 246,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load usage.",
       "surface": "android",
@@ -2851,7 +2899,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 245,
+      "line": 251,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No usage data yet.",
       "surface": "android",
@@ -2859,7 +2907,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 246,
+      "line": 252,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Provider limits will appear here when your gateway reports them.",
       "surface": "android",
@@ -2867,7 +2915,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 281,
+      "line": 287,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cron Jobs",
       "surface": "android",
@@ -2875,7 +2923,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 281,
+      "line": 287,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scheduled OpenClaw work from your gateway.",
       "surface": "android",
@@ -2883,7 +2931,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 292,
+      "line": 298,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Android shows scheduled work status. Create and edit schedules from the desktop app.",
       "surface": "android",
@@ -2891,7 +2939,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 302,
+      "line": 308,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load cron jobs.",
       "surface": "android",
@@ -2899,7 +2947,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 307,
+      "line": 313,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No scheduled jobs.",
       "surface": "android",
@@ -2907,7 +2955,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 308,
+      "line": 314,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Create recurring OpenClaw work from the desktop app.",
       "surface": "android",
@@ -2915,7 +2963,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 343,
+      "line": 349,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Inspect scheduled gateway work.",
       "surface": "android",
@@ -2923,7 +2971,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 357,
+      "line": 363,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to inspect cron jobs.",
       "surface": "android",
@@ -2931,7 +2979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 365,
+      "line": 371,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cron job not loaded.",
       "surface": "android",
@@ -2939,7 +2987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 365,
+      "line": 371,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Loading cron job…",
       "surface": "android",
@@ -2947,7 +2995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 387,
+      "line": 393,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agents",
       "surface": "android",
@@ -2955,7 +3003,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 387,
+      "line": 393,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose and inspect the assistants available on this gateway.",
       "surface": "android",
@@ -2963,7 +3011,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 398,
+      "line": 404,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load agents.",
       "surface": "android",
@@ -2971,7 +3019,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 402,
+      "line": 408,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No agents loaded yet.",
       "surface": "android",
@@ -2979,7 +3027,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 428,
+      "line": 434,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Approvals",
       "surface": "android",
@@ -2987,7 +3035,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 428,
+      "line": 434,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review actions that need your attention.",
       "surface": "android",
@@ -2995,7 +3043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 439,
+      "line": 445,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refresh",
       "surface": "android",
@@ -3003,7 +3051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 439,
+      "line": 445,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refreshing",
       "surface": "android",
@@ -3011,7 +3059,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 452,
+      "line": 458,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway disconnected.",
       "surface": "android",
@@ -3019,7 +3067,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 453,
+      "line": 459,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load approval requests in the app.",
       "surface": "android",
@@ -3027,7 +3075,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 459,
+      "line": 465,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No gateway approvals.",
       "surface": "android",
@@ -3035,7 +3083,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 460,
+      "line": 466,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Exec approval requests will appear here while this phone is connected.",
       "surface": "android",
@@ -3043,7 +3091,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 467,
+      "line": 473,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Session activity",
       "surface": "android",
@@ -3051,7 +3099,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 468,
+      "line": 474,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Chat tool calls waiting in the active session remain visible here.",
       "surface": "android",
@@ -3059,7 +3107,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 482,
+      "line": 488,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "How this phone appears to OpenClaw.",
       "surface": "android",
@@ -3067,7 +3115,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 482,
+      "line": 488,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Profile",
       "surface": "android",
@@ -3075,7 +3123,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 485,
+      "line": 491,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Device name",
       "surface": "android",
@@ -3083,7 +3131,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 486,
+      "line": 492,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save Profile",
       "surface": "android",
@@ -3091,7 +3139,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 505,
+      "line": 511,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Configure voice, transport, and playback.",
       "surface": "android",
@@ -3099,7 +3147,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 505,
+      "line": 511,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Talk Provider Setup",
       "surface": "android",
@@ -3107,7 +3155,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 508,
+      "line": 514,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Audio Test",
       "surface": "android",
@@ -3115,7 +3163,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 509,
+      "line": 515,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check that OpenClaw can speak clearly on this phone.",
       "surface": "android",
@@ -3123,7 +3171,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 512,
+      "line": 518,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enable speaker",
       "surface": "android",
@@ -3131,7 +3179,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 512,
+      "line": 518,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Mute speaker",
       "surface": "android",
@@ -3139,7 +3187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 513,
+      "line": 519,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Assistant speech muted",
       "surface": "android",
@@ -3147,7 +3195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 513,
+      "line": 519,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replies play aloud",
       "surface": "android",
@@ -3155,7 +3203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 515,
+      "line": 521,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Muted",
       "surface": "android",
@@ -3163,7 +3211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 515,
+      "line": 521,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "On",
       "surface": "android",
@@ -3171,7 +3219,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 519,
+      "line": 525,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Done",
       "surface": "android",
@@ -3179,7 +3227,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 529,
+      "line": 535,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Realtime Talk",
       "surface": "android",
@@ -3187,7 +3235,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 530,
+      "line": 536,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Dictation",
       "surface": "android",
@@ -3195,7 +3243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 658,
+      "line": 664,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allowlist",
       "surface": "android",
@@ -3203,7 +3251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 658,
+      "line": 664,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Blocklist",
       "surface": "android",
@@ -3211,7 +3259,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 691,
+      "line": 697,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose what reaches OpenClaw.",
       "surface": "android",
@@ -3219,7 +3267,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 691,
+      "line": 697,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Notifications",
       "surface": "android",
@@ -3227,7 +3275,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 695,
+      "line": 701,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Alerts stay on this phone.",
       "surface": "android",
@@ -3235,7 +3283,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 695,
+      "line": 701,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can receive selected alerts.",
       "surface": "android",
@@ -3243,7 +3291,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 707,
+      "line": 713,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Granted",
       "surface": "android",
@@ -3251,7 +3299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 707,
+      "line": 713,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup",
       "surface": "android",
@@ -3259,7 +3307,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 712,
+      "line": 718,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check Access",
       "surface": "android",
@@ -3267,7 +3315,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 712,
+      "line": 718,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open System Access",
       "surface": "android",
@@ -3275,7 +3323,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 722,
+      "line": 728,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forwarding Mode",
       "surface": "android",
@@ -3283,7 +3331,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 771,
+      "line": 777,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App Filter",
       "surface": "android",
@@ -3291,7 +3339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 778,
+      "line": 784,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Close App Picker",
       "surface": "android",
@@ -3299,7 +3347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 778,
+      "line": 784,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open App Picker",
       "surface": "android",
@@ -3307,7 +3355,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 783,
+      "line": 789,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Search apps",
       "surface": "android",
@@ -3315,7 +3363,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 786,
+      "line": 792,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Show System Apps",
       "surface": "android",
@@ -3323,7 +3371,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 787,
+      "line": 793,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Include Android and background packages.",
       "surface": "android",
@@ -3331,7 +3379,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 794,
+      "line": 800,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No matching apps.",
       "surface": "android",
@@ -3339,7 +3387,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 805,
+      "line": 811,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Showing ${visibleApps.size} of ${apps.size}. Refine search for more.",
       "surface": "android",
@@ -3347,7 +3395,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1044,
+      "line": 1050,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose what this phone can share.",
       "surface": "android",
@@ -3355,7 +3403,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1044,
+      "line": 1050,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Phone Capabilities",
       "surface": "android",
@@ -3363,7 +3411,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1053,
+      "line": 1059,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow photo library access.",
       "surface": "android",
@@ -3371,7 +3419,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1053,
+      "line": 1059,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected or full photo access granted.",
       "surface": "android",
@@ -3379,7 +3427,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1063,
+      "line": 1069,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App list stays on this phone.",
       "surface": "android",
@@ -3387,7 +3435,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1063,
+      "line": 1069,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can list launcher-visible apps.",
       "surface": "android",
@@ -3395,7 +3443,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1074,
+      "line": 1080,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Location",
       "surface": "android",
@@ -3403,7 +3451,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1082,
+      "line": 1088,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always allows requested location checks while OpenClaw is in the background; Android shows this in the persistent node notification.",
       "surface": "android",
@@ -3411,7 +3459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1107,
+      "line": 1113,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow background location?",
       "surface": "android",
@@ -3419,7 +3467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1109,
+      "line": 1115,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw only checks location when your paired Gateway requests it. ",
       "surface": "android",
@@ -3427,7 +3475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1122,
+      "line": 1128,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open Settings",
       "surface": "android",
@@ -3435,7 +3483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1127,
+      "line": 1133,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not Now",
       "surface": "android",
@@ -3443,7 +3491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1175,
+      "line": 1181,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace gateway setup?",
       "surface": "android",
@@ -3451,7 +3499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1190,
+      "line": 1196,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace setup",
       "surface": "android",
@@ -3459,7 +3507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1206,
+      "line": 1212,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forget gateway?",
       "surface": "android",
@@ -3467,7 +3515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1219,
+      "line": 1225,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cancel",
       "surface": "android",
@@ -3475,7 +3523,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1225,
+      "line": 1231,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection between this phone and OpenClaw.",
       "surface": "android",
@@ -3483,7 +3531,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1229,
+      "line": 1235,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connected",
       "surface": "android",
@@ -3491,7 +3539,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1229,
+      "line": 1235,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Offline",
       "surface": "android",
@@ -3499,7 +3547,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1230,
+      "line": 1236,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not paired",
       "surface": "android",
@@ -3507,7 +3555,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1230,
+      "line": 1236,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Online",
       "surface": "android",
@@ -3515,7 +3563,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1240,
+      "line": 1246,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Reconnect",
       "surface": "android",
@@ -3523,7 +3571,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1241,
+      "line": 1247,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Disconnect",
       "surface": "android",
@@ -3531,7 +3579,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1245,
+      "line": 1251,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateways",
       "surface": "android",
@@ -3539,7 +3587,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1247,
+      "line": 1253,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No paired gateways.",
       "surface": "android",
@@ -3547,7 +3595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1267,
+      "line": 1273,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forget",
       "surface": "android",
@@ -3555,7 +3603,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1289,
+      "line": 1295,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway setup",
       "surface": "android",
@@ -3563,7 +3611,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1291,
+      "line": 1297,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scan or paste a setup code to add another gateway.",
       "surface": "android",
@@ -3571,7 +3619,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1298,
+      "line": 1304,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Add gateway",
       "surface": "android",
@@ -3579,7 +3627,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1299,
+      "line": 1305,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup Code",
       "surface": "android",
@@ -3587,7 +3635,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1303,
+      "line": 1309,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Android can scan or paste an existing setup code, but this gateway does not expose setup-code generation to the app yet. Generate the QR/code on the gateway host with openclaw qr, then scan it here or paste the setup code below.",
       "surface": "android",
@@ -3595,7 +3643,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1312,
+      "line": 1318,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection Setup",
       "surface": "android",
@@ -3603,7 +3651,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1313,
+      "line": 1319,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup code",
       "surface": "android",
@@ -3611,7 +3659,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1315,
+      "line": 1321,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Host",
       "surface": "android",
@@ -3619,7 +3667,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1316,
+      "line": 1322,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Port",
       "surface": "android",
@@ -3627,7 +3675,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1318,
+      "line": 1324,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection security",
       "surface": "android",
@@ -3635,7 +3683,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1322,
+      "line": 1328,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Secure (TLS)",
       "surface": "android",
@@ -3643,7 +3691,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1322,
+      "line": 1328,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Unencrypted",
       "surface": "android",
@@ -3651,7 +3699,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1339,
+      "line": 1345,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Token",
       "surface": "android",
@@ -3659,7 +3707,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1340,
+      "line": 1346,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Bootstrap",
       "surface": "android",
@@ -3667,7 +3715,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1342,
+      "line": 1348,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Password",
       "surface": "android",
@@ -3675,7 +3723,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1347,
+      "line": 1353,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save & Connect",
       "surface": "android",
@@ -3683,7 +3731,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1364,
+      "line": 1370,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enter a valid setup code or gateway address.",
       "surface": "android",
@@ -3691,7 +3739,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1387,
+      "line": 1395,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "A calm, high-contrast OpenClaw interface.",
       "surface": "android",
@@ -3699,7 +3747,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1387,
+      "line": 1395,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Appearance",
       "surface": "android",
@@ -3707,15 +3755,31 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1398,
+      "line": 1410,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme",
       "surface": "android",
       "id": "native.android.0e5de6796bc8d8f9"
     },
     {
+      "kind": "ui-named-argument",
+      "line": 1420,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Language",
+      "surface": "android",
+      "id": "native.android.1633ade91e141120"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 1422,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "System follows this device language ($deviceLanguage). ",
+      "surface": "android",
+      "id": "native.android.f65909934ec8439e"
+    },
+    {
       "kind": "conditional-branch",
-      "line": 1443,
+      "line": 1502,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Ready",
       "surface": "android",
@@ -3723,7 +3787,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1472,
+      "line": 1531,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "About",
       "surface": "android",
@@ -3731,7 +3795,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1472,
+      "line": 1531,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw for Android.",
       "surface": "android",
@@ -3739,7 +3803,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1485,
+      "line": 1544,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway",
       "surface": "android",
@@ -3747,7 +3811,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1487,
+      "line": 1546,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Runtime",
       "surface": "android",
@@ -3755,7 +3819,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1490,
+      "line": 1549,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Update",
       "surface": "android",
@@ -3763,7 +3827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1501,
+      "line": 1560,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "© 2026 OpenClaw Foundation — MIT License.",
       "surface": "android",
@@ -3771,7 +3835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1518,
+      "line": 1577,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw logo",
       "surface": "android",
@@ -3779,7 +3843,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1520,
+      "line": 1579,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -3787,7 +3851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1521,
+      "line": 1580,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Personal AI on your devices",
       "surface": "android",
@@ -3795,7 +3859,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1580,
+      "line": 1639,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Licenses",
       "surface": "android",
@@ -3803,7 +3867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1581,
+      "line": 1640,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw appreciates its partners in the open-source community.",
       "surface": "android",
@@ -3811,7 +3875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1590,
+      "line": 1649,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No license notices are packaged in this build.",
       "surface": "android",
@@ -3819,7 +3883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1616,
+      "line": 1675,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open ${license.title}",
       "surface": "android",
@@ -3827,7 +3891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1651,
+      "line": 1710,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check",
       "surface": "android",
@@ -3835,7 +3899,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1684,
+      "line": 1743,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Back",
       "surface": "android",
@@ -3843,7 +3907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1758,
+      "line": 1817,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Sending",
       "surface": "android",
@@ -3851,7 +3915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1767,
+      "line": 1826,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow Once",
       "surface": "android",
@@ -3859,7 +3923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1767,
+      "line": 1826,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allowing",
       "surface": "android",
@@ -3867,7 +3931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1775,
+      "line": 1834,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always",
       "surface": "android",
@@ -3875,7 +3939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1775,
+      "line": 1834,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Saving",
       "surface": "android",
@@ -3883,7 +3947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1783,
+      "line": 1842,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Deny",
       "surface": "android",
@@ -3891,7 +3955,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1783,
+      "line": 1842,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Denying",
       "surface": "android",
@@ -3899,7 +3963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1808,
+      "line": 1867,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review",
       "surface": "android",
@@ -3907,7 +3971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1836,
+      "line": 1895,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Issue",
       "surface": "android",
@@ -3915,7 +3979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1866,
+      "line": 1925,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enabled",
       "surface": "android",
@@ -3923,7 +3987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1880,
+      "line": 1939,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No",
       "surface": "android",
@@ -3931,7 +3995,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1880,
+      "line": 1939,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Yes",
       "surface": "android",
@@ -3939,7 +4003,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1898,
+      "line": 1957,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Error",
       "surface": "android",
@@ -3947,7 +4011,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1901,
+      "line": 1960,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery Error",
       "surface": "android",
@@ -3955,7 +4019,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1940,
+      "line": 1999,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Tap to copy",
       "surface": "android",
@@ -3963,7 +4027,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 1955,
+      "line": 2014,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$title copied",
       "surface": "android",
@@ -3971,7 +4035,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1993,
+      "line": 2052,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default assistant",
       "surface": "android",
@@ -3979,7 +4043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1995,
+      "line": 2054,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default",
       "surface": "android",
@@ -3987,7 +4051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2051,
+      "line": 2110,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -3995,7 +4059,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2054,
+      "line": 2113,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting ${minutes}m",
       "surface": "android",
@@ -4003,7 +4067,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2054,
+      "line": 2113,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting for review",
       "surface": "android",
@@ -4011,7 +4075,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2082,
+      "line": 2141,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}",
       "surface": "android",
@@ -4019,7 +4083,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2089,
+      "line": 2148,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No limits reported",
       "surface": "android",
@@ -4027,7 +4091,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2120,
+      "line": 2179,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Off",
       "surface": "android",
@@ -4035,7 +4099,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2141,
+      "line": 2200,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "System Event Text",
       "surface": "android",
@@ -4043,7 +4107,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2142,
+      "line": 2201,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agent Prompt",
       "surface": "android",
@@ -4051,7 +4115,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2143,
+      "line": 2202,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Command",
       "surface": "android",
@@ -4059,7 +4123,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2144,
+      "line": 2203,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Payload Text",
       "surface": "android",
@@ -4587,7 +4651,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 436,
+      "line": 437,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Overview",
       "surface": "android",
@@ -4595,7 +4659,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 481,
+      "line": 482,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No recent sessions",
       "surface": "android",
@@ -4603,7 +4667,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 482,
+      "line": 483,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Start a chat and your active OpenClaw conversations will appear here.",
       "surface": "android",
@@ -4611,7 +4675,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 483,
+      "line": 484,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Start Chat",
       "surface": "android",
@@ -4619,7 +4683,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 529,
+      "line": 530,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -4627,7 +4691,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 537,
+      "line": 538,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Search",
       "surface": "android",
@@ -4635,7 +4699,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 589,
+      "line": 590,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "ACTIVE AGENT",
       "surface": "android",
@@ -4643,7 +4707,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 598,
+      "line": 599,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "View",
       "surface": "android",
@@ -4651,7 +4715,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 601,
+      "line": 602,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$pendingRunCount active",
       "surface": "android",
@@ -4659,7 +4723,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 601,
+      "line": 602,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Idle",
       "surface": "android",
@@ -4667,7 +4731,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 601,
+      "line": 602,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Runs",
       "surface": "android",
@@ -4675,7 +4739,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 602,
+      "line": 603,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$sessionCount recent",
       "surface": "android",
@@ -4683,7 +4747,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 602,
+      "line": 603,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Sessions",
       "surface": "android",
@@ -4691,7 +4755,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 603,
+      "line": 604,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Cron",
       "surface": "android",
@@ -4699,7 +4763,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 606,
+      "line": 607,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -4707,7 +4771,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 610,
+      "line": 611,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Reconnect gateway",
       "surface": "android",
@@ -4715,7 +4779,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 758,
+      "line": 759,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open ${card.title}",
       "surface": "android",
@@ -4723,7 +4787,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 826,
+      "line": 827,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Talk",
       "surface": "android",
@@ -4731,7 +4795,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 827,
+      "line": 828,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open Talk",
       "surface": "android",
@@ -4739,7 +4803,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 829,
+      "line": 830,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Talk settings",
       "surface": "android",
@@ -4747,7 +4811,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 837,
+      "line": 838,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Recent Sessions",
       "surface": "android",
@@ -4755,7 +4819,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 847,
+      "line": 848,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "View all",
       "surface": "android",
@@ -4763,7 +4827,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 986,
+      "line": 987,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$onlineNodes/$nodeCount",
       "surface": "android",
@@ -4771,7 +4835,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 986,
+      "line": 987,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "None",
       "surface": "android",
@@ -4779,7 +4843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1018,
+      "line": 1019,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Recent conversations",
       "surface": "android",
@@ -4787,7 +4851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1025,
+      "line": 1026,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Browse",
       "surface": "android",
@@ -4795,7 +4859,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1025,
+      "line": 1026,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -4803,7 +4867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1077,
+      "line": 1078,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Working · $pendingRunCount active ${pluralize(\"run\", pendingRunCount)}",
       "surface": "android",
@@ -4811,7 +4875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1198,
+      "line": 1199,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -4819,7 +4883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1263,
+      "line": 1264,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open ${row.title}",
       "surface": "android",
@@ -4827,7 +4891,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1371,
+      "line": 1372,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open session",
       "surface": "android",
@@ -4835,7 +4899,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1483,
+      "line": 1485,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Back",
       "surface": "android",
@@ -4843,7 +4907,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1486,
+      "line": 1488,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Settings",
       "surface": "android",
@@ -4851,7 +4915,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1489,
+      "line": 1491,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Search settings",
       "surface": "android",
@@ -4859,7 +4923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1513,
+      "line": 1515,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$readyProviderCount ready",
       "surface": "android",
@@ -4867,7 +4931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1513,
+      "line": 1515,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Review readiness",
       "surface": "android",
@@ -4875,7 +4939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1524,
+      "line": 1526,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Speaker muted",
       "surface": "android",
@@ -4883,7 +4947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1524,
+      "line": 1526,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Speaker on",
       "surface": "android",
@@ -4891,7 +4955,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1526,
+      "line": 1528,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -4899,7 +4963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1526,
+      "line": 1528,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Smart delivery",
       "surface": "android",
@@ -4907,7 +4971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1527,
+      "line": 1529,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Camera enabled",
       "surface": "android",
@@ -4915,7 +4979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1527,
+      "line": 1529,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Locked",
       "surface": "android",
@@ -4923,7 +4987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1569,
+      "line": 1576,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "surface": "android",
@@ -4931,7 +4995,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1572,
+      "line": 1579,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "All systems operational",
       "surface": "android",
@@ -4939,7 +5003,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1572,
+      "line": 1579,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Gateway not connected",
       "surface": "android",
@@ -4947,7 +5011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1604,
+      "line": 1611,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No provider usage",
       "surface": "android",
@@ -4955,7 +5019,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1605,
+      "line": 1612,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 provider",
       "surface": "android",
@@ -4963,7 +5027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1606,
+      "line": 1613,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$count providers",
       "surface": "android",
@@ -4971,7 +5035,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1612,
+      "line": 1619,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$ready/${skills.size} ready",
       "surface": "android",
@@ -4979,7 +5043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1612,
+      "line": 1619,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No skills",
       "surface": "android",
@@ -4987,7 +5051,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1790,
+      "line": 1797,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw mobile",
       "surface": "android",
@@ -4995,7 +5059,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1794,
+      "line": 1801,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open profile",
       "surface": "android",
@@ -5003,7 +5067,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1879,
+      "line": 1886,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Main session",
       "surface": "android",

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -90,6 +90,10 @@ the screenshots, then shuts down the emulator it started.
 For PR evidence, `.github/workflows/android-language-proof.yml` can build the
 Play debug APK on GitHub Actions, run the same screenshot script against a
 managed AVD, and upload the language screenshot plus debug APK as artifacts.
+The Android App Bundle keeps language resource splitting disabled because the
+app can apply explicit language overrides at runtime; this keeps localized
+string resources available immediately for Play-delivered installs without a
+Play Core language-download step.
 
 `pnpm android:release:archive` builds signed release artifacts into `apps/android/build/release-artifacts/` and writes `.sha256` checksum files:
 

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -18,6 +18,7 @@ OpenClaw Android is the officially released Google Play app. It connects to an O
 - [x] Authenticated background presence beacons
 - [x] Voice tab full functionality
 - [x] Screen tab full functionality
+- [x] App language selector that defaults to the Android device language; explicit language choices override OpenClaw resources per app, and `System` clears the override
 
 ## Open in Android Studio
 
@@ -69,6 +70,12 @@ Generate raw Google Play screenshots:
 pnpm android:screenshots
 ```
 
+Capture only the language-switch proof scene and force an in-app language:
+
+```bash
+pnpm android:screenshots -- --scene language --app-language zh-CN --locale zh-CN
+```
+
 To make screenshot capture own emulator startup, pass a named AVD:
 
 ```bash
@@ -79,6 +86,10 @@ The screenshot script uses one connected ADB device when available. If none is
 connected and `ANDROID_SCREENSHOT_AVD` is set, it boots that emulator
 headlessly, waits for Android to finish booting, disables animations, captures
 the screenshots, then shuts down the emulator it started.
+
+For PR evidence, `.github/workflows/android-language-proof.yml` can build the
+Play debug APK on GitHub Actions, run the same screenshot script against a
+managed AVD, and upload the language screenshot plus debug APK as artifacts.
 
 `pnpm android:release:archive` builds signed release artifacts into `apps/android/build/release-artifacts/` and writes `.sha256` checksum files:
 

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -107,6 +107,15 @@ android {
     }
   }
 
+  // OpenClaw applies explicit app locales at runtime. Keep all localized string
+  // resources installed in App Bundle deliveries so language overrides work
+  // immediately and offline without a Play Core language-download flow.
+  bundle {
+    language {
+      enableSplit = false
+    }
+  }
+
   buildTypes {
     release {
       if (hasAndroidReleaseSigning) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/AndroidScreenshotMode.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/AndroidScreenshotMode.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 
 const val extraAndroidScreenshotMode = "openclaw.screenshotMode"
 const val extraAndroidScreenshotScene = "openclaw.screenshotScene"
+const val extraAndroidScreenshotAppLanguage = "openclaw.screenshotAppLanguage"
 
 enum class AndroidScreenshotScene(
   val rawValue: String,
@@ -13,6 +14,7 @@ enum class AndroidScreenshotScene(
   Voice("voice"),
   Screen("screen"),
   Settings("settings"),
+  Language("language"),
   ;
 
   companion object {
@@ -20,9 +22,17 @@ enum class AndroidScreenshotScene(
   }
 }
 
-fun parseAndroidScreenshotModeIntent(intent: Intent?): AndroidScreenshotScene? {
+data class AndroidScreenshotModeRequest(
+  val scene: AndroidScreenshotScene,
+  val appLanguageMode: AppLanguageMode,
+)
+
+fun parseAndroidScreenshotModeIntent(intent: Intent?): AndroidScreenshotModeRequest? {
   if (intent?.getBooleanExtra(extraAndroidScreenshotMode, false) != true) {
     return null
   }
-  return AndroidScreenshotScene.fromRawValue(intent.getStringExtra(extraAndroidScreenshotScene))
+  return AndroidScreenshotModeRequest(
+    scene = AndroidScreenshotScene.fromRawValue(intent.getStringExtra(extraAndroidScreenshotScene)),
+    appLanguageMode = AppLanguageMode.fromRawValue(intent.getStringExtra(extraAndroidScreenshotAppLanguage)),
+  )
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/AppLanguageMode.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/AppLanguageMode.kt
@@ -1,0 +1,104 @@
+package ai.openclaw.app
+
+import android.content.Context
+import android.content.res.Configuration
+import android.os.LocaleList
+import java.util.Locale
+
+internal const val appLanguageModePreferenceKey = "appearance.languageMode"
+internal const val openClawPlainPrefsName = "openclaw.node"
+
+enum class AppLanguageMode(
+  val rawValue: String,
+  val localeTag: String?,
+  val displayLabel: String,
+  val nativeLabel: String,
+) {
+  System("system", null, "System", "Use device language"),
+  English("en", "en", "English", "English"),
+  ChineseSimplified("zh-CN", "zh-CN", "Chinese (Simplified)", "简体中文"),
+  ChineseTraditional("zh-TW", "zh-TW", "Chinese (Traditional)", "繁體中文"),
+  PortugueseBrazil("pt-BR", "pt-BR", "Portuguese (Brazil)", "Português (Brasil)"),
+  German("de", "de", "German", "Deutsch"),
+  Spanish("es", "es", "Spanish", "Español"),
+  Japanese("ja-JP", "ja-JP", "Japanese", "日本語"),
+  Korean("ko", "ko", "Korean", "한국어"),
+  French("fr", "fr", "French", "Français"),
+  Hindi("hi", "hi", "Hindi", "हिन्दी"),
+  Arabic("ar", "ar", "Arabic", "العربية"),
+  Italian("it", "it", "Italian", "Italiano"),
+  Turkish("tr", "tr", "Turkish", "Türkçe"),
+  Ukrainian("uk", "uk", "Ukrainian", "Українська"),
+  Indonesian("id", "id", "Indonesian", "Bahasa Indonesia"),
+  Polish("pl", "pl", "Polish", "Polski"),
+  Thai("th", "th", "Thai", "ไทย"),
+  Vietnamese("vi", "vi", "Vietnamese", "Tiếng Việt"),
+  Dutch("nl", "nl", "Dutch", "Nederlands"),
+  Persian("fa", "fa", "فارسی", "فارسی"),
+  Russian("ru", "ru", "Russian", "Русский"),
+  Swedish("sv", "sv", "Swedish", "Svenska"),
+  ;
+
+  companion object {
+    fun fromRawValue(raw: String?): AppLanguageMode = entries.firstOrNull { it.rawValue == raw?.trim() } ?: System
+
+    fun fromLocaleTag(localeTag: String?): AppLanguageMode = entries.firstOrNull { it.localeTag == localeTag?.trim() } ?: System
+  }
+}
+
+fun appLanguageOptions(): List<AppLanguageMode> = AppLanguageMode.entries
+
+fun appLanguageModeForLabel(label: String): AppLanguageMode =
+  AppLanguageMode.entries.firstOrNull { mode ->
+    mode.displayLabel == label ||
+      mode.nativeLabel == label ||
+      appLanguageOptionLabel(mode) == label
+  } ?: AppLanguageMode.System
+
+fun appLanguageOptionLabel(mode: AppLanguageMode): String =
+  if (mode == AppLanguageMode.System) {
+    mode.displayLabel
+  } else {
+    "${mode.displayLabel} · ${mode.nativeLabel}"
+  }
+
+fun appLanguageSummary(mode: AppLanguageMode): String = appLanguageOptionLabel(mode)
+
+fun currentDeviceLanguageTag(): String {
+  val locales = LocaleList.getDefault()
+  return if (locales.isEmpty) {
+    Locale.getDefault().toLanguageTag()
+  } else {
+    locales[0].toLanguageTag()
+  }
+}
+
+fun openClawLocalizedContext(
+  base: Context,
+  mode: AppLanguageMode,
+): Context {
+  val localeTag = mode.localeTag
+  if (localeTag == null) {
+    val baseLocales = base.resources.configuration.locales
+    if (!baseLocales.isEmpty) {
+      Locale.setDefault(baseLocales[0])
+    }
+    return base
+  }
+  val localeList = LocaleList.forLanguageTags(localeTag)
+  if (localeList.isEmpty) return base
+  val locale = localeList[0]
+  Locale.setDefault(locale)
+  val config = Configuration(base.resources.configuration)
+  config.setLocales(localeList)
+  config.setLayoutDirection(locale)
+  return base.createConfigurationContext(config)
+}
+
+fun openClawLocalizedContextFromPrefs(base: Context): Context {
+  val prefs = base.getSharedPreferences(openClawPlainPrefsName, Context.MODE_PRIVATE)
+  return openClawLocalizedContext(
+    base = base,
+    mode = AppLanguageMode.fromRawValue(prefs.getString(appLanguageModePreferenceKey, null)),
+  )
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt
@@ -3,6 +3,7 @@ package ai.openclaw.app
 import ai.openclaw.app.ui.AndroidScreenshotModeScreen
 import ai.openclaw.app.ui.OpenClawTheme
 import ai.openclaw.app.ui.RootScreen
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.WindowManager
@@ -49,14 +50,18 @@ class MainActivity : ComponentActivity() {
   private var foreground = false
   private var pendingIntent: Intent? = null
 
+  override fun attachBaseContext(newBase: Context) {
+    super.attachBaseContext(openClawLocalizedContextFromPrefs(newBase))
+  }
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     pendingIntent = intent
     WindowCompat.setDecorFitsSystemWindows(window, false)
     permissionRequester = PermissionRequester(this)
     if (BuildConfig.DEBUG) {
-      parseAndroidScreenshotModeIntent(intent)?.let { scene ->
-        enterScreenshotMode(scene)
+      parseAndroidScreenshotModeIntent(intent)?.let { request ->
+        enterScreenshotMode(request)
         return
       }
     }
@@ -81,6 +86,17 @@ class MainActivity : ComponentActivity() {
         }
       } else {
         val appearanceThemeMode by currentViewModel.appearanceThemeMode.collectAsState()
+        val appLanguageMode by currentViewModel.appLanguageMode.collectAsState()
+        var activeLanguageMode by remember { mutableStateOf<AppLanguageMode?>(null) }
+
+        LaunchedEffect(appLanguageMode) {
+          val previous = activeLanguageMode
+          activeLanguageMode = appLanguageMode
+          if (previous != null && previous != appLanguageMode) {
+            recreate()
+          }
+        }
+
         OpenClawTheme(themeMode = appearanceThemeMode) {
           RootScreen(viewModel = currentViewModel)
         }
@@ -88,10 +104,10 @@ class MainActivity : ComponentActivity() {
     }
   }
 
-  private fun enterScreenshotMode(scene: AndroidScreenshotScene) {
+  private fun enterScreenshotMode(request: AndroidScreenshotModeRequest) {
     hideScreenshotModeStatusBar()
     setContent {
-      AndroidScreenshotModeScreen(scene = scene)
+      AndroidScreenshotModeScreen(scene = request.scene, languageMode = request.appLanguageMode)
     }
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -210,6 +210,7 @@ class MainViewModel(
   val installedAppsSharingEnabled: StateFlow<Boolean> = prefs.installedAppsSharingEnabled
   val speakerEnabled: StateFlow<Boolean> = prefs.speakerEnabled
   val appearanceThemeMode: StateFlow<AppearanceThemeMode> = prefs.appearanceThemeMode
+  val appLanguageMode: StateFlow<AppLanguageMode> = prefs.appLanguageMode
   val voiceCaptureMode: StateFlow<VoiceCaptureMode> = runtimeState(initial = VoiceCaptureMode.Off) { it.voiceCaptureMode }
   val micEnabled: StateFlow<Boolean> = runtimeState(initial = false) { it.micEnabled }
 
@@ -565,6 +566,10 @@ class MainViewModel(
 
   fun setAppearanceThemeMode(mode: AppearanceThemeMode) {
     prefs.setAppearanceThemeMode(mode)
+  }
+
+  fun setAppLanguageMode(mode: AppLanguageMode) {
+    prefs.setAppLanguageMode(mode)
   }
 
   fun refreshGatewayConnection() {

--- a/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
@@ -46,7 +46,6 @@ class SecurePrefs(
     private const val displayNameKey = "node.displayName"
     private const val locationModeKey = "location.enabledMode"
     private const val voiceWakeModeKey = "voiceWake.mode"
-    private const val plainPrefsName = "openclaw.node"
     private const val securePrefsName = "openclaw.node.secure"
     private const val notificationsForwardingEnabledKey = "notifications.forwarding.enabled"
     private const val defaultNotificationForwardingEnabled = false
@@ -75,7 +74,7 @@ class SecurePrefs(
 
   // Non-secret UI/runtime preferences stay readable for migration and backup behavior.
   private val plainPrefs: SharedPreferences =
-    appContext.getSharedPreferences(plainPrefsName, Context.MODE_PRIVATE)
+    appContext.getSharedPreferences(openClawPlainPrefsName, Context.MODE_PRIVATE)
   private val hadPlainPrefsBeforeInit = plainPrefs.all.isNotEmpty()
 
   // Gateway credentials and arbitrary secret strings are isolated behind EncryptedSharedPreferences.
@@ -209,6 +208,10 @@ class SecurePrefs(
   private val _appearanceThemeMode =
     MutableStateFlow(AppearanceThemeMode.fromRawValue(plainPrefs.getString(appearanceThemeModeKey, null)))
   val appearanceThemeMode: StateFlow<AppearanceThemeMode> = _appearanceThemeMode
+
+  private val _appLanguageMode =
+    MutableStateFlow(AppLanguageMode.fromRawValue(plainPrefs.getString(appLanguageModePreferenceKey, null)))
+  val appLanguageMode: StateFlow<AppLanguageMode> = _appLanguageMode
 
   private val _modelFavorites = MutableStateFlow(loadChatModelRefs(chatModelFavoritesKey))
   val modelFavorites: StateFlow<List<String>> = _modelFavorites
@@ -621,6 +624,17 @@ class SecurePrefs(
   fun setAppearanceThemeMode(mode: AppearanceThemeMode) {
     plainPrefs.edit { putString(appearanceThemeModeKey, mode.rawValue) }
     _appearanceThemeMode.value = mode
+  }
+
+  fun setAppLanguageMode(mode: AppLanguageMode) {
+    plainPrefs.edit {
+      if (mode == AppLanguageMode.System) {
+        remove(appLanguageModePreferenceKey)
+      } else {
+        putString(appLanguageModePreferenceKey, mode.rawValue)
+      }
+    }
+    _appLanguageMode.value = mode
   }
 
   fun toggleModelFavorite(ref: String) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt
@@ -1,6 +1,10 @@
 package ai.openclaw.app.ui
 
 import ai.openclaw.app.AndroidScreenshotScene
+import ai.openclaw.app.AppLanguageMode
+import ai.openclaw.app.R
+import ai.openclaw.app.appLanguageOptionLabel
+import ai.openclaw.app.openClawLocalizedContext
 import ai.openclaw.app.ui.design.ClawDesignTheme
 import ai.openclaw.app.ui.design.ClawTheme
 import androidx.compose.foundation.BorderStroke
@@ -25,6 +29,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ScreenShare
 import androidx.compose.material.icons.filled.ChatBubble
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.WifiTethering
@@ -32,11 +37,15 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -44,22 +53,36 @@ import androidx.compose.ui.unit.dp
 private val ScreenshotIconBoxSize = 44.dp
 
 @Composable
-fun AndroidScreenshotModeScreen(scene: AndroidScreenshotScene) {
-  ClawDesignTheme(dark = true) {
-    Column(
-      modifier =
-        Modifier
-          .fillMaxSize()
-          .background(ClawTheme.colors.canvas)
-          .padding(
-            horizontal = ClawTheme.spacing.md,
-            vertical = 26.dp,
-          ),
-      verticalArrangement = Arrangement.SpaceBetween,
-    ) {
-      ScreenshotHeader(scene)
-      ScreenshotSceneBody(scene = scene, modifier = Modifier.weight(1f))
-      ScreenshotTabBar(activeScene = scene)
+fun AndroidScreenshotModeScreen(
+  scene: AndroidScreenshotScene,
+  languageMode: AppLanguageMode = AppLanguageMode.System,
+) {
+  val baseContext = LocalContext.current
+  val localizedContext =
+    remember(baseContext, languageMode) {
+      openClawLocalizedContext(base = baseContext, mode = languageMode)
+    }
+  CompositionLocalProvider(LocalContext provides localizedContext) {
+    ClawDesignTheme(dark = true) {
+      Column(
+        modifier =
+          Modifier
+            .fillMaxSize()
+            .background(ClawTheme.colors.canvas)
+            .padding(
+              horizontal = ClawTheme.spacing.md,
+              vertical = 26.dp,
+            ),
+        verticalArrangement = Arrangement.SpaceBetween,
+      ) {
+        ScreenshotHeader(scene)
+        ScreenshotSceneBody(
+          scene = scene,
+          languageMode = languageMode,
+          modifier = Modifier.weight(1f),
+        )
+        ScreenshotTabBar(activeScene = scene)
+      }
     }
   }
 }
@@ -86,6 +109,7 @@ private fun ScreenshotHeader(scene: AndroidScreenshotScene) {
 @Composable
 private fun ScreenshotSceneBody(
   scene: AndroidScreenshotScene,
+  languageMode: AppLanguageMode,
   modifier: Modifier = Modifier,
 ) {
   Column(
@@ -98,6 +122,7 @@ private fun ScreenshotSceneBody(
       AndroidScreenshotScene.Voice -> VoiceScene()
       AndroidScreenshotScene.Screen -> ScreenScene()
       AndroidScreenshotScene.Settings -> SettingsScene()
+      AndroidScreenshotScene.Language -> LanguageScene(languageMode)
     }
   }
 }
@@ -190,6 +215,27 @@ private fun SettingsScene() {
   CompactList(
     title = "Notifications",
     rows = listOf("Gateway status", "Approval requests", "Background presence"),
+  )
+}
+
+@Composable
+private fun LanguageScene(languageMode: AppLanguageMode) {
+  FeaturePanel(
+    icon = Icons.Default.Language,
+    title = "Language switch",
+    subtitle = appLanguageOptionLabel(languageMode),
+  ) {
+    MetricRow(label = "Mode", value = languageMode.rawValue)
+    MetricRow(label = "Resource", value = stringResource(R.string.trust_this_gateway))
+    MetricRow(label = "Action", value = stringResource(R.string.trust_and_continue))
+  }
+  CompactList(
+    title = "Localized resources",
+    rows =
+      listOf(
+        stringResource(R.string.cancel),
+        stringResource(R.string.new_chat_in_worktree),
+      ),
   )
 }
 
@@ -322,6 +368,7 @@ private fun ScreenshotTabBar(activeScene: AndroidScreenshotScene) {
       TabIcon(icon = Icons.Default.Mic, active = activeScene == AndroidScreenshotScene.Voice)
       TabIcon(icon = Icons.AutoMirrored.Filled.ScreenShare, active = activeScene == AndroidScreenshotScene.Screen)
       TabIcon(icon = Icons.Default.Settings, active = activeScene == AndroidScreenshotScene.Settings)
+      TabIcon(icon = Icons.Default.Language, active = activeScene == AndroidScreenshotScene.Language)
     }
   }
 }
@@ -399,4 +446,5 @@ private fun sceneTitle(scene: AndroidScreenshotScene): String =
     AndroidScreenshotScene.Voice -> "Talk"
     AndroidScreenshotScene.Screen -> "Device tools"
     AndroidScreenshotScene.Settings -> "Settings"
+    AndroidScreenshotScene.Language -> "Language"
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.app.ui
 
 import ai.openclaw.app.AndroidLicenseNotice
+import ai.openclaw.app.AppLanguageMode
 import ai.openclaw.app.AppearanceThemeMode
 import ai.openclaw.app.BuildConfig
 import ai.openclaw.app.GatewayAgentSummary
@@ -17,7 +18,11 @@ import ai.openclaw.app.LocationMode
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.NotificationPackageFilterMode
 import ai.openclaw.app.SensitiveFeatureConfig
+import ai.openclaw.app.appLanguageOptionLabel
+import ai.openclaw.app.appLanguageOptions
+import ai.openclaw.app.appLanguageSummary
 import ai.openclaw.app.chat.ChatPendingToolCall
+import ai.openclaw.app.currentDeviceLanguageTag
 import ai.openclaw.app.gateway.GatewayRegistryEntryKind
 import ai.openclaw.app.gatewayTalkSetupDescription
 import ai.openclaw.app.gatewayTalkSetupStatusText
@@ -96,6 +101,7 @@ import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.GraphicEq
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Mic
@@ -1383,12 +1389,18 @@ private fun AppearanceSettingsScreen(
   onBack: () -> Unit,
 ) {
   val themeMode by viewModel.appearanceThemeMode.collectAsState()
+  val languageMode by viewModel.appLanguageMode.collectAsState()
+  val deviceLanguage = currentDeviceLanguageTag()
 
   SettingsDetailFrame(title = "Appearance", subtitle = "A calm, high-contrast OpenClaw interface.", icon = Icons.Default.Palette, onBack = onBack) {
     SettingsMetricPanel(
       rows =
         listOf(
           SettingsMetric("Theme", appearanceThemeSummary(themeMode)),
+          SettingsMetric(
+            "Language",
+            appLanguageMetric(languageMode = languageMode, deviceLanguage = deviceLanguage),
+          ),
           SettingsMetric("Contrast", "High"),
           SettingsMetric("Typography", "Readable"),
         ),
@@ -1403,6 +1415,33 @@ private fun AppearanceSettingsScreen(
         )
       }
     }
+    ClawPanel {
+      Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        Text(text = "Language", style = ClawTheme.type.section, color = ClawTheme.colors.text)
+        Text(
+          text =
+            "System follows this device language ($deviceLanguage). " +
+              "Choose a language to override OpenClaw without changing Android settings.",
+          style = ClawTheme.type.body,
+          color = ClawTheme.colors.textMuted,
+        )
+        ClawSeparatedColumn(items = appLanguageOptions()) { mode ->
+          val selectedIndicator: (@Composable () -> Unit)? =
+            if (mode == languageMode) {
+              { ClawIconBadge(Icons.Default.Check) }
+            } else {
+              null
+            }
+          ClawListItem(
+            title = appLanguageOptionLabel(mode),
+            subtitle = appLanguageRowSubtitle(mode = mode, deviceLanguage = deviceLanguage),
+            leading = { ClawIconBadge(Icons.Default.Language) },
+            trailing = selectedIndicator,
+            onClick = { viewModel.setAppLanguageMode(mode) },
+          )
+        }
+      }
+    }
   }
 }
 
@@ -1411,6 +1450,26 @@ internal fun appearanceThemeSummary(mode: AppearanceThemeMode): String = mode.di
 internal fun appearanceThemeOptions(): List<String> = AppearanceThemeMode.entries.map { it.displayLabel }
 
 internal fun appearanceThemeModeForLabel(label: String): AppearanceThemeMode = AppearanceThemeMode.fromDisplayLabel(label)
+
+internal fun appLanguageMetric(
+  languageMode: AppLanguageMode,
+  deviceLanguage: String,
+): String =
+  if (languageMode == AppLanguageMode.System) {
+    "System ($deviceLanguage)"
+  } else {
+    appLanguageSummary(languageMode)
+  }
+
+internal fun appLanguageRowSubtitle(
+  mode: AppLanguageMode,
+  deviceLanguage: String,
+): String =
+  if (mode == AppLanguageMode.System) {
+    "Follow Android device language: $deviceLanguage"
+  } else {
+    "Use ${mode.localeTag} inside OpenClaw"
+  }
 
 internal fun locationModeLabels(backgroundLocationAvailable: Boolean): List<String> =
   if (backgroundLocationAvailable) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -13,6 +13,7 @@ import ai.openclaw.app.HomeDestination
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.NodeRuntime
 import ai.openclaw.app.R
+import ai.openclaw.app.appLanguageSummary
 import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.ui.chat.ChatScreen
 import ai.openclaw.app.ui.design.ClawBottomNav
@@ -64,10 +65,10 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.GraphicEq
 import androidx.compose.material.icons.filled.Groups
 import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.Notifications
-import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Security
@@ -1442,6 +1443,7 @@ private fun SettingsShellScreen(
   val channelsSummary by viewModel.channelsSummary.collectAsState()
   val dreamingSummary by viewModel.dreamingSummary.collectAsState()
   val appearanceThemeMode by viewModel.appearanceThemeMode.collectAsState()
+  val appLanguageMode by viewModel.appLanguageMode.collectAsState()
   val readyProviderCount = providerRows(providers = providers, models = models).count { it.ready }
   val pendingApprovalsCount = execApprovals.size + pendingToolCalls.size
 
@@ -1525,7 +1527,12 @@ private fun SettingsShellScreen(
           SettingsRow("Canvas", "Screen surface", Icons.AutoMirrored.Filled.ScreenShare, status = isConnected, route = SettingsRoute.Canvas),
           SettingsRow("Notifications", if (notificationForwardingEnabled) "Smart delivery" else "Off", Icons.Default.Notifications, route = SettingsRoute.Notifications),
           SettingsRow("Phone Capabilities", if (cameraEnabled) "Camera enabled" else "Locked", Icons.Default.Lock, status = !cameraEnabled, route = SettingsRoute.PhoneCapabilities),
-          SettingsRow("Appearance", appearanceThemeSummary(appearanceThemeMode), Icons.Default.Palette, route = SettingsRoute.Appearance),
+          SettingsRow(
+            "Appearance",
+            "${appearanceThemeSummary(appearanceThemeMode)} · ${appLanguageSummary(appLanguageMode)}",
+            Icons.Default.Language,
+            route = SettingsRoute.Appearance,
+          ),
           SettingsRow("About", "Version and update", Icons.Default.Storage, route = SettingsRoute.About),
           SettingsRow("Health", "Diagnostics", Icons.Default.Settings, status = isConnected, route = SettingsRoute.Health),
         )

--- a/apps/android/app/src/test/java/ai/openclaw/app/AndroidScreenshotModeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/AndroidScreenshotModeTest.kt
@@ -22,10 +22,12 @@ class AndroidScreenshotModeTest {
       parseAndroidScreenshotModeIntent(
         Intent(Intent.ACTION_MAIN)
           .putExtra(extraAndroidScreenshotMode, true)
-          .putExtra(extraAndroidScreenshotScene, "voice"),
+          .putExtra(extraAndroidScreenshotScene, "voice")
+          .putExtra(extraAndroidScreenshotAppLanguage, "zh-CN"),
       )
 
-    assertEquals(AndroidScreenshotScene.Voice, parsed)
+    assertEquals(AndroidScreenshotScene.Voice, parsed?.scene)
+    assertEquals(AppLanguageMode.ChineseSimplified, parsed?.appLanguageMode)
   }
 
   @Test
@@ -37,6 +39,7 @@ class AndroidScreenshotModeTest {
           .putExtra(extraAndroidScreenshotScene, "unknown"),
       )
 
-    assertEquals(AndroidScreenshotScene.Connect, parsed)
+    assertEquals(AndroidScreenshotScene.Connect, parsed?.scene)
+    assertEquals(AppLanguageMode.System, parsed?.appLanguageMode)
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/AppLanguageModeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/AppLanguageModeTest.kt
@@ -1,0 +1,40 @@
+package ai.openclaw.app
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AppLanguageModeTest {
+  @Test
+  fun fromRawValue_defaultsToSystemForMissingOrUnknownValue() {
+    assertEquals(AppLanguageMode.System, AppLanguageMode.fromRawValue(null))
+    assertEquals(AppLanguageMode.System, AppLanguageMode.fromRawValue(""))
+    assertEquals(AppLanguageMode.System, AppLanguageMode.fromRawValue("unsupported"))
+  }
+
+  @Test
+  fun localeBackedModesExposeStableLanguageTags() {
+    assertEquals("zh-CN", AppLanguageMode.ChineseSimplified.localeTag)
+    assertEquals("pt-BR", AppLanguageMode.PortugueseBrazil.localeTag)
+    assertEquals("ja-JP", AppLanguageMode.Japanese.localeTag)
+    assertNull(AppLanguageMode.System.localeTag)
+  }
+
+  @Test
+  fun optionLabelsRoundTripToModes() {
+    for (mode in appLanguageOptions()) {
+      assertEquals(mode, appLanguageModeForLabel(appLanguageOptionLabel(mode)))
+    }
+  }
+
+  @Test
+  fun appLanguageOptionsIncludeAllNativeResourceLocales() {
+    val localeTags = appLanguageOptions().mapNotNull { it.localeTag }.toSet()
+
+    assertTrue(localeTags.contains("zh-CN"))
+    assertTrue(localeTags.contains("zh-TW"))
+    assertTrue(localeTags.contains("pt-BR"))
+    assertTrue(localeTags.contains("sv"))
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsTest.kt
@@ -159,6 +159,38 @@ class SecurePrefsTest {
   }
 
   @Test
+  fun appLanguageMode_defaultsToSystemWithoutWritingPreference() {
+    val context = RuntimeEnvironment.getApplication()
+    val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
+    plainPrefs.edit().clear().commit()
+    val prefs = testPrefs(context)
+
+    assertEquals(AppLanguageMode.System, prefs.appLanguageMode.value)
+    assertFalse(plainPrefs.contains("appearance.languageMode"))
+  }
+
+  @Test
+  fun setAppLanguageMode_persistsSelectedMode() {
+    val context = RuntimeEnvironment.getApplication()
+    val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
+    plainPrefs.edit().clear().commit()
+    val securePrefs = context.getSharedPreferences("secure-prefs-test-${UUID.randomUUID()}", Context.MODE_PRIVATE)
+    val prefs = SecurePrefs(context, securePrefs)
+
+    prefs.setAppLanguageMode(AppLanguageMode.ChineseSimplified)
+
+    assertEquals(AppLanguageMode.ChineseSimplified, prefs.appLanguageMode.value)
+    assertEquals("zh-CN", plainPrefs.getString("appearance.languageMode", null))
+    assertEquals(AppLanguageMode.ChineseSimplified, SecurePrefs(context, securePrefs).appLanguageMode.value)
+
+    prefs.setAppLanguageMode(AppLanguageMode.System)
+
+    assertEquals(AppLanguageMode.System, prefs.appLanguageMode.value)
+    assertFalse(plainPrefs.contains("appearance.languageMode"))
+    assertEquals(AppLanguageMode.System, SecurePrefs(context, securePrefs).appLanguageMode.value)
+  }
+
+  @Test
   fun gatewayCredentials_areIndependentAcrossGateways() {
     val context = RuntimeEnvironment.getApplication()
     val securePrefs = context.getSharedPreferences("openclaw.node.secure.test", Context.MODE_PRIVATE)

--- a/scripts/android-screenshots.sh
+++ b/scripts/android-screenshots.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage:
-  scripts/android-screenshots.sh [--device <adb-serial>] [--avd <name>] [--locale en-US] [--skip-build] [--skip-install] [--keep-emulator] [--dry-run]
+  scripts/android-screenshots.sh [--device <adb-serial>] [--avd <name>] [--locale en-US] [--scene <id>] [--app-language <mode>] [--skip-build] [--skip-install] [--keep-emulator] [--dry-run]
 
 Builds and installs the Play debug app, launches deterministic screenshot scenes,
 and writes raw Google Play screenshots under:
@@ -18,13 +18,15 @@ EOF
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ANDROID_DIR="${ROOT_DIR}/apps/android"
 LOCALE="en-US"
+APP_LANGUAGE="system"
 DEVICE="${ANDROID_SCREENSHOT_DEVICE:-}"
 AVD="${ANDROID_SCREENSHOT_AVD:-}"
 KEEP_EMULATOR="${ANDROID_SCREENSHOT_KEEP_EMULATOR:-0}"
 SKIP_BUILD=0
 SKIP_INSTALL=0
 DRY_RUN=0
-SCENES=(connect chat voice screen settings)
+SCENES=(connect chat voice screen settings language)
+CUSTOM_SCENES=0
 EMULATOR_PID=""
 EMULATOR_LOG=""
 STARTED_EMULATOR=0
@@ -44,6 +46,18 @@ while [[ $# -gt 0 ]]; do
       ;;
     --locale)
       LOCALE="${2:-}"
+      shift 2
+      ;;
+    --scene)
+      if [[ "$CUSTOM_SCENES" != "1" ]]; then
+        SCENES=()
+        CUSTOM_SCENES=1
+      fi
+      SCENES+=("${2:-}")
+      shift 2
+      ;;
+    --app-language)
+      APP_LANGUAGE="${2:-}"
       shift 2
       ;;
     --skip-build)
@@ -86,6 +100,35 @@ validate_locale() {
 
 validate_locale "$LOCALE"
 
+validate_scene() {
+  local scene="$1"
+  case "$scene" in
+    connect|chat|voice|screen|settings|language)
+      return 0
+      ;;
+  esac
+  echo "Invalid Android screenshot scene: ${scene}" >&2
+  echo "Expected one of: connect, chat, voice, screen, settings, language." >&2
+  exit 1
+}
+
+validate_app_language() {
+  local mode="$1"
+  case "$mode" in
+    system|en|zh-CN|zh-TW|pt-BR|de|es|ja-JP|ko|fr|hi|ar|it|tr|uk|id|pl|th|vi|nl|fa|ru|sv)
+      return 0
+      ;;
+  esac
+  echo "Invalid Android screenshot app language: ${mode}" >&2
+  echo "Expected system or one of the app locale tags." >&2
+  exit 1
+}
+
+for scene in "${SCENES[@]}"; do
+  validate_scene "$scene"
+done
+validate_app_language "$APP_LANGUAGE"
+
 cleanup_started_emulator() {
   local stopped=0
 
@@ -105,6 +148,14 @@ cleanup_started_emulator() {
 cleanup_emulator_log() {
   if [[ -n "$EMULATOR_LOG" && -f "$EMULATOR_LOG" ]]; then
     rm -f "$EMULATOR_LOG"
+  fi
+}
+
+print_emulator_log_tail() {
+  if [[ -n "$EMULATOR_LOG" && -f "$EMULATOR_LOG" ]]; then
+    echo "--- emulator log tail ---" >&2
+    tail -120 "$EMULATOR_LOG" >&2 || true
+    echo "--- end emulator log tail ---" >&2
   fi
 }
 
@@ -258,8 +309,14 @@ boot_emulator() {
   EMULATOR_PID="$!"
   STARTED_EMULATOR=1
 
-  serial="$(wait_for_single_device "$adb")"
-  wait_for_boot_completed "$adb" "$serial"
+  if ! serial="$(wait_for_single_device "$adb")"; then
+    print_emulator_log_tail
+    return 1
+  fi
+  if ! wait_for_boot_completed "$adb" "$serial"; then
+    print_emulator_log_tail
+    return 1
+  fi
   stabilize_device_for_screenshots "$adb" "$serial"
   ADB_SERIAL="$serial"
 }
@@ -308,6 +365,7 @@ ADB_DISPLAY="${DEVICE:-<auto>}"
 
 echo "Android screenshot output: ${OUTPUT_DIR}"
 echo "Scenes: ${SCENES[*]}"
+echo "App language: ${APP_LANGUAGE}"
 echo "ADB device: ${ADB_DISPLAY}"
 if [[ -n "$AVD" ]]; then
   echo "Fallback AVD: ${AVD}"
@@ -349,7 +407,8 @@ for scene in "${SCENES[@]}"; do
   "$ADB_BIN" -s "$ADB_SERIAL" shell am start -W \
     -n ai.openclaw.app/.MainActivity \
     --ez openclaw.screenshotMode true \
-    --es openclaw.screenshotScene "$scene" >/dev/null
+    --es openclaw.screenshotScene "$scene" \
+    --es openclaw.screenshotAppLanguage "$APP_LANGUAGE" >/dev/null
   sleep "${ANDROID_SCREENSHOT_SETTLE_SECONDS:-1.5}"
   "$ADB_BIN" -s "$ADB_SERIAL" exec-out screencap -p >"$output_path"
   echo "Captured ${output_path}"


### PR DESCRIPTION
## What Problem This Solves

The Android app already ships localized string resources, but users could not choose an app language and first-launch behavior did not explicitly preserve a device-language default. This made multilingual support hard to verify and hard to control without changing the whole Android device language.

This PR adds an Android app language selector that defaults to `System`, follows the Android device language on first install, and lets users override OpenClaw resources per app from Appearance settings.

## Summary

- Add an Android app language mode model with persisted `System` default and per-app language overrides.
- Apply the saved language before `MainActivity` resource inflation, recreate the activity after user changes, and expose the selector from Appearance settings.
- Keep App Bundle language resources installed for runtime language overrides by disabling language resource splitting.
- Extend Android screenshot proof tooling with a `language` scene, `--scene`, and `--app-language` so language-resource behavior can be captured in CI.
- Sync the native app i18n inventory and document the Android language proof path.

## Implementation Notes

- `System` remains the default and follows the Android device language without writing a preference on first install.
- Explicit language modes store the locale tag in the existing app preferences namespace and wrap the activity base context with the selected locale.
- The Android App Bundle disables language resource splitting with `android.bundle.language.enableSplit = false` because OpenClaw applies explicit app locales at runtime. This keeps localized string resources installed for Play-delivered users instead of requiring a Play Core language-download flow.
- The proof screenshot scene renders localized Android string resources (`trust_this_gateway`, `trust_and_continue`, etc.) under the selected app language.
- The Android proof workflow is manual-only and uploads the language screenshot plus the Play debug APK as artifacts.

## Evidence

Current PR head tested: `ce628bfec022838a0481c92dbb6b179038dea566`

Local static checks after the packaging fix:

- `git diff --check`
- `bash -n scripts/android-screenshots.sh`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "ok #{ARGV[0]}"' .github/workflows/android-language-proof.yml`

OpenClaw PR CI on current head:

- CI run: https://github.com/openclaw/openclaw/actions/runs/28915829677
- `android-build-play`: passed — https://github.com/openclaw/openclaw/actions/runs/28915829677/job/85782597868
- `android-ktlint`: passed — https://github.com/openclaw/openclaw/actions/runs/28915829677/job/85782597889
- `android-test-play`: passed — https://github.com/openclaw/openclaw/actions/runs/28915829677/job/85782597870
- `android-test-third-party`: passed — https://github.com/openclaw/openclaw/actions/runs/28915829677/job/85782597879
- `native-i18n`: passed — https://github.com/openclaw/openclaw/actions/runs/28915829677/job/85782597765

Real Android build and media proof from `snowzlmbot/openclaw` Actions:

- Android language proof run: https://github.com/snowzlmbot/openclaw/actions/runs/28916166117
- Result: passed
- Target ref tested: `ce628bfec022838a0481c92dbb6b179038dea566`
- Inputs: `app_language=zh-CN`, `screenshot_locale=zh-CN`, `screenshot_scene=language`
- Artifact: `android-language-proof-zh-CN` — https://github.com/snowzlmbot/openclaw/actions/runs/28916166117/artifacts/8157797111
- Artifact contents:
  - `fastlane/metadata/android/zh-CN/images/phoneScreenshots/openclaw-language.png`
  - `app/build/outputs/apk/play/debug/openclaw-2026.6.11-play-debug.apk`
- Screenshot proof details: `openclaw-language.png` is a 1080x2400 PNG captured from the Android UI. It shows the Language scene with `Mode zh-CN`, `Resource 信任此网关?`, `Action 信任并继续`, and localized resource rows such as `取消`.
- Screenshot SHA-256: `76db9b4a2ea6333788cc01ba0fd2cef8120c0e8d103765bb3c81cb4a396343bf`
- Debug APK SHA-256: `e068026ce261466fa7c28b6c616f2a9e6251d887cccc97602aa237a87f989026`

## Risk / Rollback

- Risk is limited to Android app locale/resource handling, App Bundle language packaging, and the manual screenshot proof path.
- Packaging tradeoff: Play App Bundles keep all localized string resources in the base install, which slightly increases delivered resource size. The current Android localized resources are small; if future localization adds large per-locale assets, OpenClaw can revisit Play Core language downloads.
- Rollback is straightforward by removing the language preference model, settings selector, language split override, and screenshot proof additions.
