### PR TITLE
Add Claw dry-run apply lifecycle plan

### DIFF
--- a/src/claws/lifecycle.ts
+++ b/src/claws/lifecycle.ts
@@ -1,0 +1,116 @@
+// Builds dry-run Claw apply plans without mutating user state.
+import {
+  CLAW_APPLY_PLAN_SCHEMA_VERSION,
+  type ClawApplyPlan,
+  type ClawApplyPlanEntry,
+  type ClawPlan,
+  type ClawPlanEntry,
+} from "./types.js";
+
+function artifactAction(entry: ClawPlanEntry): ClawApplyPlanEntry {
+  const unsupported =
+    entry.decision === "blockedUnsupported" || entry.artifact?.supported === false;
+  const blocked = unsupported && entry.required;
+  return {
+    id: entry.id,
+    kind: entry.kind,
+    required: entry.required,
+    phase: unsupported ? "unsupported" : "artifact",
+    action: unsupported ? "skipUnsupported" : "installArtifact",
+    ...(entry.target ? { target: entry.target } : {}),
+    consentRequired: false,
+    blocked,
+    ...(entry.artifact && !unsupported
+      ? { provenanceRecord: entry.artifact.provenance.record }
+      : {}),
+    rollback: unsupported
+      ? { action: "none" }
+      : { action: "uninstallArtifact", ...(entry.target ? { target: entry.target } : {}) },
+    reason: unsupported
+      ? entry.required
+        ? "This required artifact selector is unsupported and blocks apply until the Claw is rewritten."
+        : "This optional artifact selector is unsupported and would be skipped during apply."
+      : "Dry-run would install the artifact and record provenance for rollback/update.",
+  };
+}
+
+function workspaceAction(entry: ClawPlanEntry): ClawApplyPlanEntry {
+  return {
+    id: entry.id,
+    kind: entry.kind,
+    required: entry.required,
+    phase: "workspace",
+    action: entry.kind === "persona" ? "writePersonaFile" : "writeWorkspaceFile",
+    ...(entry.target ? { target: entry.target } : {}),
+    ...(entry.source ? { source: entry.source } : {}),
+    consentRequired: true,
+    blocked: false,
+    provenanceRecord: "workspaceFile.installRecord",
+    rollback: { action: "removeWorkspaceFile", ...(entry.target ? { target: entry.target } : {}) },
+    reason: "Dry-run would require explicit consent before writing workspace-owned files.",
+  };
+}
+
+function automationAction(entry: ClawPlanEntry): ClawApplyPlanEntry {
+  return {
+    id: entry.id,
+    kind: entry.kind,
+    required: entry.required,
+    phase: "automation",
+    action: "registerAutomation",
+    ...(entry.target ? { target: entry.target } : {}),
+    ...(entry.source ? { source: entry.source } : {}),
+    consentRequired: true,
+    blocked: false,
+    provenanceRecord: "automation.installRecord",
+    rollback: { action: "disableAutomation", ...(entry.target ? { target: entry.target } : {}) },
+    reason: "Dry-run would require explicit consent before registering or enabling automation state.",
+  };
+}
+
+function applyEntry(entry: ClawPlanEntry): ClawApplyPlanEntry {
+  if (entry.artifact) {
+    return artifactAction(entry);
+  }
+  if (entry.kind === "workspaceFile" || entry.kind === "persona") {
+    return workspaceAction(entry);
+  }
+  if (entry.kind === "heartbeat" || entry.kind === "schedule" || entry.kind === "automation") {
+    return automationAction(entry);
+  }
+  return {
+    id: entry.id,
+    kind: entry.kind,
+    required: entry.required,
+    phase: "unsupported",
+    action: "skipUnsupported",
+    consentRequired: false,
+    blocked: entry.required,
+    rollback: { action: "none" },
+    reason: entry.required
+      ? "This required entry kind is not supported by the dry-run apply planner."
+      : "This optional entry kind is not supported and would be skipped during apply.",
+  };
+}
+
+export function buildClawApplyPlan(plan: ClawPlan): ClawApplyPlan {
+  const entries = plan.entries.map(applyEntry);
+  return {
+    schemaVersion: CLAW_APPLY_PLAN_SCHEMA_VERSION,
+    dryRun: true,
+    mutationAllowed: false,
+    claw: plan.claw,
+    summary: {
+      totalEntries: entries.length,
+      installActions: entries.filter(
+        (entry) => !entry.blocked && entry.action !== "skipUnsupported",
+      ).length,
+      consentRequired: entries.filter((entry) => entry.consentRequired).length,
+      blockedEntries: entries.filter((entry) => entry.blocked).length,
+      provenanceRecords: entries.filter((entry) => entry.provenanceRecord).length,
+      rollbackActions: entries.filter((entry) => entry.rollback.action !== "none").length,
+    },
+    entries,
+    diagnostics: plan.diagnostics,
+  };
+}

--- a/src/claws/schema.test.ts
+++ b/src/claws/schema.test.ts
@@ -1,5 +1,6 @@
 // Tests for openclaw.claw.v1 manifest parsing.
 import { describe, expect, it } from "vitest";
+import { buildClawApplyPlan } from "./lifecycle.js";
 import { buildClawPlan } from "./plan.js";
 import { parseClawManifest } from "./schema.js";
 
@@ -444,5 +445,155 @@ describe("buildClawPlan", () => {
       "requiresConsent",
       "requiresConsent",
     ]);
+  });
+});
+
+describe("buildClawApplyPlan", () => {
+  it("builds a dry-run lifecycle plan with provenance and rollback actions", () => {
+    const parsed = parseClawManifest({
+      ...baseManifest,
+      entries: [
+        {
+          kind: "plugin",
+          id: "terminal-plugin",
+          selector: "npm:@openclaw/plugin-terminal@2.0.0",
+        },
+        {
+          kind: "workspaceFile",
+          id: "soul",
+          path: "SOUL.md",
+          source: "files/SOUL.md",
+        },
+        {
+          kind: "schedule",
+          id: "morning-brief",
+          source: "automations/morning-brief.json",
+        },
+      ],
+    });
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) {
+      throw new Error("expected manifest to parse");
+    }
+
+    const applyPlan = buildClawApplyPlan(buildClawPlan({ manifest: parsed.manifest }));
+
+    expect(applyPlan).toMatchObject({
+      schemaVersion: "openclaw.clawApplyPlan.v1",
+      dryRun: true,
+      mutationAllowed: false,
+      summary: {
+        totalEntries: 3,
+        installActions: 3,
+        consentRequired: 2,
+        blockedEntries: 0,
+        provenanceRecords: 3,
+        rollbackActions: 3,
+      },
+    });
+    expect(applyPlan.entries).toEqual([
+      expect.objectContaining({
+        id: "terminal-plugin",
+        phase: "artifact",
+        action: "installArtifact",
+        consentRequired: false,
+        provenanceRecord: "plugin.installRecord",
+        rollback: { action: "uninstallArtifact", target: "npm:@openclaw/plugin-terminal@2.0.0" },
+      }),
+      expect.objectContaining({
+        id: "soul",
+        phase: "workspace",
+        action: "writeWorkspaceFile",
+        consentRequired: true,
+        provenanceRecord: "workspaceFile.installRecord",
+        rollback: { action: "removeWorkspaceFile", target: "SOUL.md" },
+      }),
+      expect.objectContaining({
+        id: "morning-brief",
+        phase: "automation",
+        action: "registerAutomation",
+        consentRequired: true,
+        provenanceRecord: "automation.installRecord",
+        rollback: { action: "disableAutomation", target: "morning-brief" },
+      }),
+    ]);
+  });
+
+  it("skips optional unsupported entries without blocking apply", () => {
+    const parsed = parseClawManifest({
+      ...baseManifest,
+      entries: [
+        {
+          kind: "plugin",
+          id: "bad-optional-plugin",
+          selector: "registry.example.com/plugin.tgz",
+          required: false,
+        },
+        {
+          kind: "futureThing",
+          id: "future-optional",
+          required: false,
+        },
+      ],
+    });
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) {
+      throw new Error("expected manifest to parse");
+    }
+
+    const applyPlan = buildClawApplyPlan(buildClawPlan({ manifest: parsed.manifest }));
+
+    expect(applyPlan.summary).toMatchObject({
+      installActions: 0,
+      blockedEntries: 0,
+      rollbackActions: 0,
+    });
+    expect(applyPlan.entries).toEqual([
+      expect.objectContaining({
+        id: "bad-optional-plugin",
+        action: "skipUnsupported",
+        blocked: false,
+      }),
+      expect.objectContaining({
+        id: "future-optional",
+        action: "skipUnsupported",
+        blocked: false,
+      }),
+    ]);
+  });
+
+  it("carries unsupported required artifacts into blocked apply actions", () => {
+    const parsed = parseClawManifest({
+      ...baseManifest,
+      entries: [
+        {
+          kind: "plugin",
+          id: "bad-plugin",
+          selector: "registry.example.com/plugin.tgz",
+        },
+      ],
+    });
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) {
+      throw new Error("expected manifest to parse");
+    }
+
+    const applyPlan = buildClawApplyPlan(buildClawPlan({ manifest: parsed.manifest }));
+
+    expect(applyPlan.summary).toMatchObject({
+      installActions: 0,
+      blockedEntries: 1,
+      rollbackActions: 0,
+    });
+    expect(applyPlan.entries[0]).toMatchObject({
+      id: "bad-plugin",
+      phase: "unsupported",
+      action: "skipUnsupported",
+      blocked: true,
+      rollback: { action: "none" },
+    });
   });
 });

--- a/src/claws/types.ts
+++ b/src/claws/types.ts
@@ -2,10 +2,12 @@
 
 export const CLAW_SCHEMA_VERSION = "openclaw.claw.v1" as const;
 export const CLAW_PLAN_SCHEMA_VERSION = "openclaw.clawPlan.v1" as const;
+export const CLAW_APPLY_PLAN_SCHEMA_VERSION = "openclaw.clawApplyPlan.v1" as const;
 export const CLAW_FEED_SCHEMA_VERSION = "openclaw.clawFeed.v1" as const;
 
 export type ClawSchemaVersion = typeof CLAW_SCHEMA_VERSION;
 export type ClawPlanSchemaVersion = typeof CLAW_PLAN_SCHEMA_VERSION;
+export type ClawApplyPlanSchemaVersion = typeof CLAW_APPLY_PLAN_SCHEMA_VERSION;
 export type ClawFeedSchemaVersion = typeof CLAW_FEED_SCHEMA_VERSION;
 
 export type ClawDiagnosticLevel = "error" | "warning";
@@ -200,5 +202,52 @@ export type ClawPlan = {
     unsupportedOptionalEntries: number;
   };
   entries: ClawPlanEntry[];
+  diagnostics: ClawDiagnostic[];
+};
+
+export type ClawApplyPlanEntryAction =
+  | "installArtifact"
+  | "writeWorkspaceFile"
+  | "writePersonaFile"
+  | "registerAutomation"
+  | "skipUnsupported";
+
+export type ClawApplyPlanEntryPhase = "artifact" | "workspace" | "automation" | "unsupported";
+
+export type ClawApplyPlanEntry = {
+  id: string;
+  kind: ClawEntryKind | string;
+  required: boolean;
+  phase: ClawApplyPlanEntryPhase;
+  action: ClawApplyPlanEntryAction;
+  target?: string;
+  source?: string;
+  consentRequired: boolean;
+  blocked: boolean;
+  provenanceRecord?:
+    | ClawArtifactProvenanceRecord
+    | "workspaceFile.installRecord"
+    | "automation.installRecord";
+  rollback: {
+    action: "uninstallArtifact" | "removeWorkspaceFile" | "disableAutomation" | "none";
+    target?: string;
+  };
+  reason: string;
+};
+
+export type ClawApplyPlan = {
+  schemaVersion: ClawApplyPlanSchemaVersion;
+  dryRun: true;
+  mutationAllowed: false;
+  claw: ClawPlan["claw"];
+  summary: {
+    totalEntries: number;
+    installActions: number;
+    consentRequired: number;
+    blockedEntries: number;
+    provenanceRecords: number;
+    rollbackActions: number;
+  };
+  entries: ClawApplyPlanEntry[];
   diagnostics: ClawDiagnostic[];
 };

--- a/src/cli/claws-cli.runtime.ts
+++ b/src/cli/claws-cli.runtime.ts
@@ -1,11 +1,14 @@
 // Runtime handlers for local Claws CLI commands.
 import { resolve } from "node:path";
 import { readClawFeedFile, readClawManifestFromFeed } from "../claws/feed.js";
+import { buildClawApplyPlan } from "../claws/lifecycle.js";
 import { buildClawPlan } from "../claws/plan.js";
 import { readClawManifestFile } from "../claws/reader.js";
-import type { ClawPlan } from "../claws/types.js";
+import type { ClawApplyPlan, ClawPlan } from "../claws/types.js";
 import { defaultRuntime, writeRuntimeJson, type RuntimeEnv } from "../runtime.js";
 import type {
+  ClawsApplyOptions,
+  ClawsFeedApplyOptions,
   ClawsFeedInspectOptions,
   ClawsFeedPlanOptions,
   ClawsInspectOptions,
@@ -33,6 +36,34 @@ function logClawPlanSummary(plan: ClawPlan, runtime: RuntimeEnv): void {
   if (plan.summary.unsupportedOptionalEntries > 0) {
     runtime.log(`Unsupported optional entries: ${plan.summary.unsupportedOptionalEntries}`);
   }
+}
+
+function logClawApplyPlanSummary(plan: ClawApplyPlan, runtime: RuntimeEnv): void {
+  runtime.log("Dry-run: true");
+  runtime.log("Mutation allowed: false");
+  runtime.log(`Entries: ${plan.summary.totalEntries}`);
+  runtime.log(`Install actions: ${plan.summary.installActions}`);
+  runtime.log(`Consent required: ${plan.summary.consentRequired}`);
+  runtime.log(`Provenance records: ${plan.summary.provenanceRecords}`);
+  runtime.log(`Rollback actions: ${plan.summary.rollbackActions}`);
+  if (plan.summary.blockedEntries > 0) {
+    runtime.log(`Blocked entries: ${plan.summary.blockedEntries}`);
+  }
+}
+
+function failNonDryRun(opts: { dryRun?: boolean; json?: boolean }, runtime: RuntimeEnv): boolean {
+  if (opts.dryRun) {
+    return false;
+  }
+  const message =
+    "Claw apply is dry-run only in this OpenClaw build; pass --dry-run to preview lifecycle actions.";
+  if (opts.json) {
+    writeRuntimeJson(runtime, { ok: false, error: { code: "dry_run_required", message } });
+  } else {
+    runtime.error(message);
+  }
+  runtime.exit(1);
+  return true;
 }
 
 export async function runClawsInspectCommand(
@@ -102,6 +133,43 @@ export async function runClawsPlanCommand(
 
   runtime.log(`Claw plan: ${plan.claw.name} (${plan.claw.id}@${plan.claw.version})`);
   logClawPlanSummary(plan, runtime);
+}
+
+export async function runClawsApplyCommand(
+  manifestPath: string,
+  opts: ClawsApplyOptions,
+  runtime: RuntimeEnv = defaultRuntime,
+): Promise<void> {
+  if (failNonDryRun(opts, runtime)) {
+    return;
+  }
+
+  const result = await readClawManifestFile(manifestPath);
+  if (!result.ok) {
+    if (opts.json) {
+      writeRuntimeJson(runtime, { valid: false, diagnostics: result.diagnostics });
+    } else {
+      runtime.error(formatDiagnostics(result.diagnostics));
+    }
+    runtime.exit(1);
+    return;
+  }
+
+  const plan = buildClawApplyPlan(
+    buildClawPlan({
+      manifest: result.manifest,
+      diagnostics: result.diagnostics,
+      sourcePath: resolve(manifestPath),
+    }),
+  );
+
+  if (opts.json) {
+    writeRuntimeJson(runtime, plan);
+    return;
+  }
+
+  runtime.log(`Claw apply plan: ${plan.claw.name} (${plan.claw.id}@${plan.claw.version})`);
+  logClawApplyPlanSummary(plan, runtime);
 }
 
 export async function runClawsFeedInspectCommand(
@@ -179,6 +247,57 @@ export async function runClawsFeedPlanCommand(
   runtime.log(`Claw plan: ${plan.claw.name} (${plan.claw.id}@${plan.claw.version})`);
   runtime.log(`Feed: ${result.feed.name} (${result.feed.id})`);
   logClawPlanSummary(plan, runtime);
+  if (result.diagnostics.length > 0) {
+    runtime.log(formatDiagnostics(result.diagnostics));
+  }
+}
+
+export async function runClawsFeedApplyCommand(
+  feedPath: string,
+  clawId: string,
+  opts: ClawsFeedApplyOptions,
+  runtime: RuntimeEnv = defaultRuntime,
+): Promise<void> {
+  if (failNonDryRun(opts, runtime)) {
+    return;
+  }
+
+  const result = await readClawManifestFromFeed({ feedPath, entryId: clawId });
+  if (!result.ok) {
+    if (opts.json) {
+      writeRuntimeJson(runtime, { valid: false, diagnostics: result.diagnostics });
+    } else {
+      runtime.error(formatDiagnostics(result.diagnostics));
+    }
+    runtime.exit(1);
+    return;
+  }
+
+  const plan = buildClawApplyPlan(
+    buildClawPlan({
+      manifest: result.manifest,
+      diagnostics: result.diagnostics,
+      sourcePath: result.manifestPath,
+    }),
+  );
+  const payload = {
+    ...plan,
+    feed: {
+      id: result.feed.id,
+      name: result.feed.name,
+      sourcePath: resolve(feedPath),
+      entry: result.entry,
+    },
+  };
+
+  if (opts.json) {
+    writeRuntimeJson(runtime, payload);
+    return;
+  }
+
+  runtime.log(`Claw apply plan: ${plan.claw.name} (${plan.claw.id}@${plan.claw.version})`);
+  runtime.log(`Feed: ${result.feed.name} (${result.feed.id})`);
+  logClawApplyPlanSummary(plan, runtime);
   if (result.diagnostics.length > 0) {
     runtime.log(formatDiagnostics(result.diagnostics));
   }

--- a/src/cli/claws-cli.test.ts
+++ b/src/cli/claws-cli.test.ts
@@ -198,6 +198,78 @@ describe("claws cli", () => {
     expect(mocks.logs).toContain("Unsupported required entries: 1");
   });
 
+  it("builds a dry-run JSON apply plan", async () => {
+    const manifestPath = await writeManifest({
+      schemaVersion: "openclaw.claw.v1",
+      id: "starter",
+      name: "Starter",
+      version: "1.0.0",
+      entries: [
+        {
+          kind: "plugin",
+          id: "example-plugin",
+          selector: "npm:@openclaw/plugin-example@1.0.0",
+        },
+        {
+          kind: "workspaceFile",
+          id: "soul",
+          path: "SOUL.md",
+          source: "files/SOUL.md",
+        },
+      ],
+    });
+
+    await runCli(["claws", "apply", manifestPath, "--dry-run", "--json"]);
+
+    expect(mocks.runtime.writeJson).toHaveBeenCalledOnce();
+    expect(mocks.runtime.writeJson.mock.calls[0][0]).toMatchObject({
+      schemaVersion: "openclaw.clawApplyPlan.v1",
+      dryRun: true,
+      mutationAllowed: false,
+      summary: { totalEntries: 2, installActions: 2, consentRequired: 1 },
+      entries: [
+        {
+          id: "example-plugin",
+          action: "installArtifact",
+          rollback: { action: "uninstallArtifact" },
+        },
+        { id: "soul", action: "writeWorkspaceFile", consentRequired: true },
+      ],
+    });
+  });
+
+  it("requires --dry-run before apply can preview lifecycle actions", async () => {
+    const manifestPath = await writeManifest({
+      schemaVersion: "openclaw.claw.v1",
+      id: "starter",
+      name: "Starter",
+      version: "1.0.0",
+      entries: [],
+    });
+
+    await runCli(["claws", "apply", manifestPath]);
+
+    expect(mocks.runtime.error).toHaveBeenCalledWith(
+      "Claw apply is dry-run only in this OpenClaw build; pass --dry-run to preview lifecycle actions.",
+    );
+    expect(mocks.runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("builds a dry-run JSON apply plan from a feed entry", async () => {
+    const feedPath = await writeFeedWorkspace();
+
+    await runCli(["claws", "feed", "apply", feedPath, "starter", "--dry-run", "--json"]);
+
+    expect(mocks.runtime.writeJson).toHaveBeenCalledOnce();
+    expect(mocks.runtime.writeJson.mock.calls[0][0]).toMatchObject({
+      schemaVersion: "openclaw.clawApplyPlan.v1",
+      dryRun: true,
+      mutationAllowed: false,
+      feed: { id: "local-starters", entry: { id: "starter" } },
+      summary: { totalEntries: 1, consentRequired: 1, rollbackActions: 1 },
+    });
+  });
+
   it("prints JSON inspection for a local claw feed", async () => {
     const feedPath = await writeFeedWorkspace();
 

--- a/src/cli/claws-cli.ts
+++ b/src/cli/claws-cli.ts
@@ -10,11 +10,21 @@ export type ClawsPlanOptions = {
   json?: boolean;
 };
 
+export type ClawsApplyOptions = {
+  dryRun?: boolean;
+  json?: boolean;
+};
+
 export type ClawsFeedInspectOptions = {
   json?: boolean;
 };
 
 export type ClawsFeedPlanOptions = {
+  json?: boolean;
+};
+
+export type ClawsFeedApplyOptions = {
+  dryRun?: boolean;
   json?: boolean;
 };
 
@@ -41,6 +51,17 @@ export function registerClawsCli(program: Command) {
       await runClawsPlanCommand(manifest, opts);
     });
 
+  claws
+    .command("apply")
+    .description("Preview the Claw apply lifecycle without mutating state")
+    .argument("<manifest>", "Path to an openclaw.claw.v1 JSON manifest")
+    .option("--dry-run", "Preview apply actions without installing or writing files", false)
+    .option("--json", "Print JSON", false)
+    .action(async (manifest: string, opts: ClawsApplyOptions) => {
+      const { runClawsApplyCommand } = await import("./claws-cli.runtime.js");
+      await runClawsApplyCommand(manifest, opts);
+    });
+
   const feed = claws.command("feed").description("Inspect and plan Claws from a local feed");
 
   feed
@@ -62,6 +83,18 @@ export function registerClawsCli(program: Command) {
     .action(async (feedPath: string, claw: string, opts: ClawsFeedPlanOptions) => {
       const { runClawsFeedPlanCommand } = await import("./claws-cli.runtime.js");
       await runClawsFeedPlanCommand(feedPath, claw, opts);
+    });
+
+  feed
+    .command("apply")
+    .description("Preview a feed Claw apply lifecycle without mutating state")
+    .argument("<feed>", "Path to an openclaw.clawFeed.v1 JSON feed")
+    .argument("<claw>", "Claw feed entry id")
+    .option("--dry-run", "Preview apply actions without installing or writing files", false)
+    .option("--json", "Print JSON", false)
+    .action(async (feedPath: string, claw: string, opts: ClawsFeedApplyOptions) => {
+      const { runClawsFeedApplyCommand } = await import("./claws-cli.runtime.js");
+      await runClawsFeedApplyCommand(feedPath, claw, opts);
     });
 
   applyParentDefaultHelpAction(feed);


### PR DESCRIPTION
## Summary
- adds `openclaw.clawApplyPlan.v1`, a dry-run Claw apply lifecycle plan derived from the existing read-only Claw plan
- adds `openclaw claws apply <manifest> --dry-run` and `openclaw claws feed apply <feed> <claw> --dry-run`
- models install actions, consent-required workspace/automation actions, provenance records, rollback actions, and required-entry blockers without mutating user state

Stack/RFC:
- RFC: https://github.com/openclaw/rfcs/pull/27
- Depends on PR4: https://github.com/openclaw/openclaw/pull/101842
- Follows PR3: https://github.com/openclaw/openclaw/pull/101755
- Follows PR2: https://github.com/openclaw/openclaw/pull/101328

## Intentional boundaries
- dry-run only; apply exits non-zero unless `--dry-run` is provided
- no artifact install, workspace file writes, automation enablement, provenance persistence, rollback execution, remote fetch, or Gateway state changes
- optional unsupported entries are skipped in the apply plan; only required unsupported entries block apply

## Validation
- `node scripts/run-vitest.mjs src/claws/schema.test.ts src/claws/feed.test.ts src/cli/claws-cli.test.ts src/cli/program/command-registry.test.ts src/cli/program/root-command-descriptions.test.ts`
- `node scripts/run-vitest.mjs src/claws/schema.test.ts src/cli/claws-cli.test.ts`
- `git diff --check`
- `node scripts/check-no-conflict-markers.mjs`
- `codex review -c model=gpt-5.5 --base origin/user/giodl/claws-pr4-artifact-plan` - clean after fixing optional unsupported apply blockers

## Real behavior proof
Environment:
- branch: `user/giodl/claws-pr5-lifecycle-plan`
- commit: `a2b32d18e04`
- `OPENCLAW_DISABLE_BUNDLED_PLUGINS=1`
- `OPENCLAW_STATE_DIR=/tmp/openclaw-claws-pr5-proof-state`

Commands:
```bash
OPENCLAW_DISABLE_BUNDLED_PLUGINS=1 OPENCLAW_STATE_DIR=/tmp/openclaw-claws-pr5-proof-state node --import tsx src/entry.ts claws apply src/claws/fixtures/incident-response.claw.json --dry-run --json
OPENCLAW_DISABLE_BUNDLED_PLUGINS=1 OPENCLAW_STATE_DIR=/tmp/openclaw-claws-pr5-proof-state node --import tsx src/entry.ts claws feed apply src/claws/fixtures/local-claws.feed.json incident-response --dry-run --json
```

Observed summaries:
```json
{"schemaVersion":"openclaw.clawApplyPlan.v1","dryRun":true,"mutationAllowed":false,"summary":{"totalEntries":5,"installActions":5,"consentRequired":2,"blockedEntries":0,"provenanceRecords":5,"rollbackActions":5}}
{"schemaVersion":"openclaw.clawApplyPlan.v1","dryRun":true,"mutationAllowed":false,"summary":{"totalEntries":5,"installActions":5,"consentRequired":2,"blockedEntries":0,"provenanceRecords":5,"rollbackActions":5},"feed":{"id":"local-starter-claws","entry":"incident-response"}}
```
