### PR TITLE
refactor(deadcode): localize test and tooling helpers

### DIFF
--- a/scripts/github/dependency-guard.mjs
+++ b/scripts/github/dependency-guard.mjs
@@ -253,7 +253,7 @@ export function isDependencyGuardMarkerComment(comment, marker, trustedAuthors) 
   return Boolean(login && trustedAuthors.has(login) && comment.body?.includes(marker));
 }
 
-export function renderDependencyAwarenessComment(dependencyFiles) {
+function renderDependencyAwarenessComment(dependencyFiles) {
   const listedFiles = dependencyFiles.slice(0, maxListedFiles);
   const omittedCount = dependencyFiles.length - listedFiles.length;
   const fileLines = listedFiles.map((filename) => `- ${markdownCode(filename)}`);

--- a/scripts/github/real-behavior-proof-policy.mjs
+++ b/scripts/github/real-behavior-proof-policy.mjs
@@ -66,7 +66,7 @@ function createTooLargeGitHubApiBodyError(label, maxBytes) {
   return error;
 }
 
-export async function withGitHubApiTimeout(label, timeoutMs, run) {
+async function withGitHubApiTimeout(label, timeoutMs, run) {
   const boundedTimeoutMs = Math.max(1, timeoutMs);
   const controller = new AbortController();
   const timeoutError = createTimeoutError(label, boundedTimeoutMs);
@@ -168,7 +168,7 @@ function isAutomationUser(user = {}, fallbackLogin = "") {
   return user?.type === "Bot" || /\[bot\]$/i.test(login) || login.startsWith("app/");
 }
 
-export function isExternalPullRequest(pullRequest) {
+function isExternalPullRequest(pullRequest) {
   if (!pullRequest) {
     return false;
   }

--- a/scripts/lib/codex-app-server-protocol-source.ts
+++ b/scripts/lib/codex-app-server-protocol-source.ts
@@ -399,7 +399,7 @@ function formatGeneratedTypeScript(repoRoot: string, root: string): void {
   }
 }
 
-export async function rewriteTypeScriptImports(root: string): Promise<void> {
+async function rewriteTypeScriptImports(root: string): Promise<void> {
   const entries = await fs.readdir(root, { withFileTypes: true });
   await Promise.all(
     entries.map(async (entry) => {
@@ -417,7 +417,7 @@ export async function rewriteTypeScriptImports(root: string): Promise<void> {
   );
 }
 
-export function normalizeGeneratedTypeScript(text: string): string {
+function normalizeGeneratedTypeScript(text: string): string {
   return text
     .replace(/(from\s+["'])(\.{1,2}\/[^"']+?)(\.js)?(["'])/g, "$1$2.js$4")
     .replace('export * as v2 from "./v2.js";', 'export * as v2 from "./v2/index.js";')

--- a/scripts/lib/gateway-bench-probes.ts
+++ b/scripts/lib/gateway-bench-probes.ts
@@ -37,7 +37,7 @@ export async function requestProbeStatus(
   }
 }
 
-export function classifyProbeErrorKind(error: unknown): string {
+function classifyProbeErrorKind(error: unknown): string {
   if (typeof error === "object" && error !== null) {
     const code = (error as { code?: unknown }).code;
     if (typeof code === "string" && code.trim()) {

--- a/scripts/lib/openclaw-test-state.mjs
+++ b/scripts/lib/openclaw-test-state.mjs
@@ -336,12 +336,12 @@ export async function createState(options = {}) {
 }
 
 /** Render a dotenv-style env file for a created test state plan. */
-export function renderEnvFile(plan) {
+function renderEnvFile(plan) {
   return `${renderExports(plan.env)}\n`;
 }
 
 /** Render shell commands that create and export an isolated OpenClaw test state. */
-export function renderShellSnippet(options = {}) {
+function renderShellSnippet(options = {}) {
   const label = normalizeLabel(options.label);
   const scenario = requireScenario(options.scenario);
   const config = scenarioConfig(scenario, options);
@@ -374,7 +374,7 @@ export function renderShellSnippet(options = {}) {
 }
 
 /** Render a reusable shell function for creating isolated OpenClaw test state. */
-export function renderShellFunction() {
+function renderShellFunction() {
   return `openclaw_test_state_create() {
   local raw_label="\${1:-state}"
   local label="$raw_label"

--- a/scripts/lib/plugin-npm-release.ts
+++ b/scripts/lib/plugin-npm-release.ts
@@ -654,7 +654,7 @@ function runNpmView(args: string[]): string {
   }
 }
 
-export function resolveNpmLatestVersion(packageName: string): string {
+function resolveNpmLatestVersion(packageName: string): string {
   const raw = runNpmView([packageName, "dist-tags.latest", "--json"]);
   const parsed = JSON.parse(raw) as unknown;
   if (typeof parsed !== "string" || !parsed.trim()) {

--- a/scripts/lib/plugin-npm-runtime-build.mjs
+++ b/scripts/lib/plugin-npm-runtime-build.mjs
@@ -22,7 +22,7 @@ function readJsonFile(filePath) {
 }
 
 /** Return whether a plugin package publishes through an artifact release workflow. */
-export function isPublishablePluginPackage(packageJson) {
+function isPublishablePluginPackage(packageJson) {
   return (
     packageJson.openclaw?.release?.publishToNpm === true ||
     packageJson.openclaw?.release?.publishToClawHub === true
@@ -121,7 +121,7 @@ export function listPluginNpmRuntimeBuildOutputs(plan) {
 }
 
 /** Resolve package `files` entries needed for runtime build outputs and plugin metadata. */
-export function resolvePluginNpmRuntimePackageFiles(plan) {
+function resolvePluginNpmRuntimePackageFiles(plan) {
   const merged = new Set(
     Array.isArray(plan.packageJson.files)
       ? plan.packageJson.files.filter((entry) => typeof entry === "string")
@@ -167,7 +167,7 @@ function resolveOpenClawPeerRange(packageJson, rootPackageJson) {
 }
 
 /** Resolve package peer dependency metadata for the OpenClaw plugin API. */
-export function resolvePluginNpmRuntimePackagePeerMetadata(plan) {
+function resolvePluginNpmRuntimePackagePeerMetadata(plan) {
   const openclawPeerRange = resolveOpenClawPeerRange(plan.packageJson, plan.rootPackageJson);
   if (!openclawPeerRange) {
     throw new Error(

--- a/test/e2e/qa-lab/config/cli-channel-picker.ts
+++ b/test/e2e/qa-lab/config/cli-channel-picker.ts
@@ -244,7 +244,7 @@ function createEvidenceWriter(options: ProducerOptions) {
   });
 }
 
-export async function runCliChannelPickerProducer(options: ProducerOptions) {
+async function runCliChannelPickerProducer(options: ProducerOptions) {
   const startedAt = Date.now();
   const writer = createEvidenceWriter(options);
   const workDir = path.join(options.artifactBase, ".work");

--- a/test/e2e/qa-lab/media/hosted-media-provider-live.ts
+++ b/test/e2e/qa-lab/media/hosted-media-provider-live.ts
@@ -795,7 +795,7 @@ export function buildHostedMediaEvidence(params: {
   return createHostedMediaEvidenceWriter(params.options).build(params.result);
 }
 
-export async function runHostedMediaProviderLiveProducer(
+async function runHostedMediaProviderLiveProducer(
   options: HostedMediaOptions,
 ): Promise<QaEvidenceSummaryJson> {
   const writer = createHostedMediaEvidenceWriter(options);

--- a/test/e2e/qa-lab/plugins/plugin-lifecycle-probe-runtime.ts
+++ b/test/e2e/qa-lab/plugins/plugin-lifecycle-probe-runtime.ts
@@ -492,7 +492,7 @@ async function runMeasured(
   );
 }
 
-export async function runPluginLifecycleMatrix() {
+async function runPluginLifecycleMatrix() {
   const pluginId = "lifecycle-claw";
   const packageName = "@openclaw/lifecycle-claw";
   const resourceDir = tempDirs.make("openclaw-plugin-lifecycle-matrix-");

--- a/test/e2e/qa-lab/runtime/docker-artifact-proof.ts
+++ b/test/e2e/qa-lab/runtime/docker-artifact-proof.ts
@@ -159,7 +159,7 @@ async function runScheduler(options: ProducerOptions, appendLog: (chunk: unknown
   });
 }
 
-export async function runDockerArtifactProofProducer(
+async function runDockerArtifactProofProducer(
   options: ProducerOptions,
 ): Promise<QaEvidenceSummaryJson> {
   const proof = PROOFS[options.lane];

--- a/test/e2e/qa-lab/runtime/gateway-mcp-real-transports.ts
+++ b/test/e2e/qa-lab/runtime/gateway-mcp-real-transports.ts
@@ -713,7 +713,7 @@ async function produceProof(options: ProducerOptions): Promise<ProofResult> {
   }
 }
 
-export async function runGatewayMcpRealTransportProducer(
+async function runGatewayMcpRealTransportProducer(
   options: ProducerOptions,
 ): Promise<QaEvidenceSummaryJson> {
   const scenario = SCENARIOS[options.scenarioId];

--- a/test/e2e/qa-lab/runtime/media-talk-gateway.ts
+++ b/test/e2e/qa-lab/runtime/media-talk-gateway.ts
@@ -570,7 +570,7 @@ async function produceProof(options: ProducerOptions): Promise<ProofResult> {
   }
 }
 
-export async function runMediaTalkGatewayProducer(
+async function runMediaTalkGatewayProducer(
   options: ProducerOptions,
 ): Promise<QaEvidenceSummaryJson> {
   const scenario = SCENARIOS[options.scenarioId];

--- a/test/e2e/qa-lab/runtime/voice-call-gateway.ts
+++ b/test/e2e/qa-lab/runtime/voice-call-gateway.ts
@@ -315,7 +315,7 @@ async function produceProof(options: ProducerOptions): Promise<ProofResult> {
   }
 }
 
-export async function runVoiceCallGatewayProducer(
+async function runVoiceCallGatewayProducer(
   options: ProducerOptions,
 ): Promise<QaEvidenceSummaryJson> {
   const writer = createQaScriptEvidenceWriter({

--- a/test/helpers/agents/prompt-composition-scenarios.ts
+++ b/test/helpers/agents/prompt-composition-scenarios.ts
@@ -738,7 +738,7 @@ async function createMaintenanceScenario(workspaceDir: string): Promise<PromptSc
 }
 
 /** Create a temp workspace with prompt composition context files. */
-export async function createWorkspaceWithPromptCompositionFiles(): Promise<string> {
+async function createWorkspaceWithPromptCompositionFiles(): Promise<string> {
   const workspaceDir = await makeTempWorkspace("openclaw-prompt-cache-");
   await writeWorkspaceFile({
     dir: workspaceDir,

--- a/test/helpers/auto-reply/trigger-handling-test-harness.ts
+++ b/test/helpers/auto-reply/trigger-handling-test-harness.ts
@@ -313,7 +313,7 @@ export function makeCfg(home: string): OpenClawConfig {
   } as OpenClawConfig);
 }
 
-export async function loadGetReplyFromConfig() {
+async function loadGetReplyFromConfig() {
   return (await import("../../../src/auto-reply/reply.js")).getReplyFromConfig;
 }
 
@@ -399,7 +399,7 @@ export async function expectBareNewOrResetAcknowledged(params: {
   expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
 }
 
-export function installTriggerHandlingE2eTestHooks() {
+function installTriggerHandlingE2eTestHooks() {
   afterEach(() => {
     clearRuntimeAuthProfileStoreSnapshots();
     vi.clearAllMocks();
@@ -418,7 +418,7 @@ export function mockRunEmbeddedAgentOk(text = "ok"): AnyMock {
   return runEmbeddedAgentMock;
 }
 
-export function createBlockReplyCollector() {
+function createBlockReplyCollector() {
   const blockReplies: Array<{ text?: string }> = [];
   return {
     blockReplies,

--- a/test/vitest/vitest.boundary.config.ts
+++ b/test/vitest/vitest.boundary.config.ts
@@ -5,7 +5,7 @@ import { resolveVitestIsolation } from "./vitest.scoped-config.ts";
 import { nonIsolatedRunnerPath, sharedVitestConfig } from "./vitest.shared.config.ts";
 import { boundaryTestFiles } from "./vitest.unit-paths.mjs";
 
-export function loadBoundaryIncludePatternsFromEnv(
+function loadBoundaryIncludePatternsFromEnv(
   env: Record<string, string | undefined> = process.env,
 ): string[] | null {
   return loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env);

--- a/test/vitest/vitest.contracts-shared.ts
+++ b/test/vitest/vitest.contracts-shared.ts
@@ -42,7 +42,7 @@ export const channelSessionContractPatterns = [
 
 export const pluginContractPatterns = ["src/plugins/contracts/**/*.test.ts"];
 
-export function loadContractsIncludePatternsFromEnv(
+function loadContractsIncludePatternsFromEnv(
   env: Record<string, string | undefined> = process.env,
 ): string[] | null {
   return loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env);

--- a/test/vitest/vitest.extension-active-memory.config.ts
+++ b/test/vitest/vitest.extension-active-memory.config.ts
@@ -9,7 +9,7 @@ export function loadIncludePatternsFromEnv(
   return loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env);
 }
 
-export function createExtensionActiveMemoryVitestConfig(
+function createExtensionActiveMemoryVitestConfig(
   env: Record<string, string | undefined> = process.env,
 ) {
   return createScopedVitestConfig(

--- a/test/vitest/vitest.extension-clickclack.config.ts
+++ b/test/vitest/vitest.extension-clickclack.config.ts
@@ -1,7 +1,7 @@
 // Vitest extension clickclack config wires the extension clickclack test shard.
 import { createSingleChannelExtensionVitestConfig } from "./vitest.extension-channel-single-config.ts";
 
-export function createExtensionClickClackVitestConfig(
+function createExtensionClickClackVitestConfig(
   env: Record<string, string | undefined> = process.env,
 ) {
   return createSingleChannelExtensionVitestConfig("clickclack", env);

--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -1,7 +1,7 @@
 // Vitest extension codex app server attempt extra config wires the extension codex app server attempt extra test shard.
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
-export function createExtensionCodexAppServerAttemptExtraVitestConfig(
+function createExtensionCodexAppServerAttemptExtraVitestConfig(
   env: Record<string, string | undefined> = process.env,
 ) {
   return createScopedVitestConfig(

--- a/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
@@ -1,7 +1,7 @@
 // Vitest extension codex app server attempt light config wires the extension codex app server attempt light test shard.
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
-export function createExtensionCodexAppServerAttemptLightVitestConfig(
+function createExtensionCodexAppServerAttemptLightVitestConfig(
   env: Record<string, string | undefined> = process.env,
 ) {
   return createScopedVitestConfig(

--- a/test/vitest/vitest.extension-codex-app-server-attempt-support.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-support.config.ts
@@ -1,7 +1,7 @@
 // Vitest extension codex app server attempt support config wires the extension codex app server attempt support test shard.
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
-export function createExtensionCodexAppServerAttemptSupportVitestConfig(
+function createExtensionCodexAppServerAttemptSupportVitestConfig(
   env: Record<string, string | undefined> = process.env,
 ) {
   return createScopedVitestConfig(

--- a/test/vitest/vitest.extension-codex-app-server-attempt.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt.config.ts
@@ -1,7 +1,7 @@
 // Vitest extension codex app server attempt config wires the extension codex app server attempt test shard.
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
-export function createExtensionCodexAppServerAttemptVitestConfig(
+function createExtensionCodexAppServerAttemptVitestConfig(
   env: Record<string, string | undefined> = process.env,
 ) {
   return createScopedVitestConfig(["extensions/codex/src/app-server/run-attempt.test.ts"], {

--- a/test/vitest/vitest.extension-codex-app-server-runtime.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-runtime.config.ts
@@ -1,7 +1,7 @@
 // Vitest extension codex app server runtime config wires the extension codex app server runtime test shard.
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
-export function createExtensionCodexAppServerRuntimeVitestConfig(
+function createExtensionCodexAppServerRuntimeVitestConfig(
   env: Record<string, string | undefined> = process.env,
 ) {
   return createScopedVitestConfig(

--- a/test/vitest/vitest.extension-codex-app-server-support.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-support.config.ts
@@ -35,7 +35,7 @@ const coveredAppServerPatterns = [
   "extensions/codex/src/app-server/user-input-bridge.test.ts",
 ];
 
-export function createExtensionCodexAppServerSupportVitestConfig(
+function createExtensionCodexAppServerSupportVitestConfig(
   env: Record<string, string | undefined> = process.env,
 ) {
   return createScopedVitestConfig(["extensions/codex/src/app-server/**/*.test.ts"], {

--- a/test/vitest/vitest.extension-codex-app-server-tools.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-tools.config.ts
@@ -1,7 +1,7 @@
 // Vitest extension codex app server tools config wires the extension codex app server tools test shard.
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
-export function createExtensionCodexAppServerToolsVitestConfig(
+function createExtensionCodexAppServerToolsVitestConfig(
   env: Record<string, string | undefined> = process.env,
 ) {
   return createScopedVitestConfig(

--- a/test/vitest/vitest.extension-codex-surface.config.ts
+++ b/test/vitest/vitest.extension-codex-surface.config.ts
@@ -2,7 +2,7 @@
 import { codexExtensionTestRoots } from "./vitest.extension-codex-paths.mjs";
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
-export function createExtensionCodexSurfaceVitestConfig(
+function createExtensionCodexSurfaceVitestConfig(
   env: Record<string, string | undefined> = process.env,
 ) {
   return createScopedVitestConfig(

--- a/test/vitest/vitest.extension-codex.config.ts
+++ b/test/vitest/vitest.extension-codex.config.ts
@@ -9,9 +9,7 @@ export function loadIncludePatternsFromEnv(
   return loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env);
 }
 
-export function createExtensionCodexVitestConfig(
-  env: Record<string, string | undefined> = process.env,
-) {
+function createExtensionCodexVitestConfig(env: Record<string, string | undefined> = process.env) {
   return createScopedVitestConfig(
     loadIncludePatternsFromEnv(env) ??
       codexExtensionTestRoots.map((root) => `${root}/**/*.test.ts`),

--- a/test/vitest/vitest.gateway-client.config.ts
+++ b/test/vitest/vitest.gateway-client.config.ts
@@ -1,7 +1,7 @@
 // Vitest gateway client config wires the gateway client test shard.
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
-export function createGatewayClientVitestConfig(env?: Record<string, string | undefined>) {
+function createGatewayClientVitestConfig(env?: Record<string, string | undefined>) {
   return createScopedVitestConfig(
     [
       "packages/gateway-client/src/**/*.test.ts",

--- a/test/vitest/vitest.gateway-core.config.ts
+++ b/test/vitest/vitest.gateway-core.config.ts
@@ -19,7 +19,7 @@ const nonCoreGatewayTestExclude = [
   "src/gateway/sessions-history-http.test.ts",
 ];
 
-export function createGatewayCoreVitestConfig(env?: Record<string, string | undefined>) {
+function createGatewayCoreVitestConfig(env?: Record<string, string | undefined>) {
   return createScopedVitestConfig(["src/gateway/**/*.test.ts"], {
     dir: "src/gateway",
     env,

--- a/test/vitest/vitest.gateway-methods.config.ts
+++ b/test/vitest/vitest.gateway-methods.config.ts
@@ -1,7 +1,7 @@
 // Vitest gateway methods config wires the gateway methods test shard.
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
-export function createGatewayMethodsVitestConfig(env?: Record<string, string | undefined>) {
+function createGatewayMethodsVitestConfig(env?: Record<string, string | undefined>) {
   return createScopedVitestConfig(["src/gateway/server-methods/**/*.test.ts"], {
     dir: "src/gateway",
     env,

--- a/test/vitest/vitest.gateway-server.config.ts
+++ b/test/vitest/vitest.gateway-server.config.ts
@@ -9,7 +9,7 @@ const gatewayServerBackedHttpTests = [
   "src/gateway/probe.auth.integration.test.ts",
 ];
 
-export function createGatewayServerVitestConfig(env?: Record<string, string | undefined>) {
+function createGatewayServerVitestConfig(env?: Record<string, string | undefined>) {
   return createScopedVitestConfig(
     ["src/gateway/**/*server*.test.ts", ...gatewayServerBackedHttpTests],
     {

--- a/test/vitest/vitest.gateway.config.ts
+++ b/test/vitest/vitest.gateway.config.ts
@@ -22,7 +22,7 @@ export function createGatewayVitestConfig(env?: Record<string, string | undefine
   });
 }
 
-export function createGatewayProjectShardVitestConfig() {
+function createGatewayProjectShardVitestConfig() {
   return createProjectShardVitestConfig(gatewayProjectConfigs);
 }
 

--- a/test/vitest/vitest.pattern-file.ts
+++ b/test/vitest/vitest.pattern-file.ts
@@ -124,7 +124,7 @@ function patternsCouldOverlap(value: string, pattern: string): boolean {
   );
 }
 
-export function loadPatternListFile(filePath: string, label: string): string[] {
+function loadPatternListFile(filePath: string, label: string): string[] {
   const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown;
   if (!Array.isArray(parsed)) {
     throw new TypeError(`${label} must point to a JSON array: ${filePath}`);

--- a/test/vitest/vitest.scoped-config.ts
+++ b/test/vitest/vitest.scoped-config.ts
@@ -58,10 +58,7 @@ function directoryPatternCoversInclude(excludePattern: string, includePattern: s
   return candidate === excludeRoot || candidate.startsWith(`${excludeRoot}/`);
 }
 
-export function includePatternIsFullyExcluded(
-  includePattern: string,
-  excludePattern: string,
-): boolean {
+function includePatternIsFullyExcluded(includePattern: string, excludePattern: string): boolean {
   const include = normalizePathPattern(includePattern);
   const exclude = normalizePathPattern(excludePattern);
   return (

--- a/test/vitest/vitest.tui-pty.config.ts
+++ b/test/vitest/vitest.tui-pty.config.ts
@@ -14,7 +14,7 @@ function toTuiPtyIncludePatterns(patterns: string[] | null) {
   return patterns?.map((pattern) => pattern.replace(/^src\//u, "")) ?? null;
 }
 
-export function createTuiPtyVitestConfig(env?: Record<string, string | undefined>) {
+function createTuiPtyVitestConfig(env?: Record<string, string | undefined>) {
   const baseTest = sharedVitestConfig.test ?? {};
   const exclude = (baseTest.exclude ?? []).filter((pattern) => pattern !== "**/*.e2e.test.ts");
   const configEnv = env ?? process.env;

--- a/test/vitest/vitest.ui-e2e.config.ts
+++ b/test/vitest/vitest.ui-e2e.config.ts
@@ -5,7 +5,7 @@ import { sharedVitestConfig } from "./vitest.shared.config.ts";
 
 const uiE2eIncludePatterns = ["ui/src/**/*.e2e.test.ts"];
 
-export function createUiE2eVitestConfig(
+function createUiE2eVitestConfig(
   env: Record<string, string | undefined> = process.env,
   argv: string[] = process.argv,
 ) {

--- a/ui/src/test-helpers/chat-model.ts
+++ b/ui/src/test-helpers/chat-model.ts
@@ -44,9 +44,7 @@ export function createAmbiguousModelCatalog(
   }));
 }
 
-export function createMainSessionRow(
-  overrides: Partial<GatewaySessionRow> = {},
-): GatewaySessionRow {
+function createMainSessionRow(overrides: Partial<GatewaySessionRow> = {}): GatewaySessionRow {
   return {
     key: "main",
     kind: "direct",


### PR DESCRIPTION
## What Problem This Solves

Removes 47 stale named exports from test, tooling, and UI test-helper modules. These helpers are implementation details with local callers, but their exported surface implied unsupported reuse and increased dead-code/search noise.

## Why This Change Was Made

The codebase-memory graph was rebuilt from current `main`, then every candidate was verified to have local callers, no external JavaScript/TypeScript references, no wildcard re-export path, and no package entry-point exposure. Shared Parallels helpers were excluded because their modules are intentionally re-exported through `scripts/e2e/parallels/common.ts`.

## User Impact

No runtime or visual behavior changes. Maintainers get a smaller, more accurate internal API surface across test harnesses, tooling scripts, Vitest configuration, and the Control UI chat-model test helper.

## Evidence

- Fresh full codebase-memory index: 21,039 files, 281,271 nodes, 1,133,750 edges, zero extraction errors.
- Exact committed-state reference audit: 47 functions across 39 files retain local callers and have zero external code references.
- Diff: 47 insertions, 54 deletions, net -7 lines.
- Testbox `tbx_01kwz3xgsc463fq3z2k52kgk1a`: `pnpm check:changed` passed.
- Focused Testbox suite: 17 files, 723 tests passed across unit-fast, tooling, UI, and e2e shards.
- Fresh local and branch autoreview: no findings, 0.90 confidence each.

AI-assisted: yes. The change and proof were reviewed before submission.
