### PR TITLE
Demo: add lobster sidebar divider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Control UI sidebar divider:** separate the navigation sidebar from the workspace with a bold lobster-red border.
 - **Android chat agent selector:** switch the active agent directly from the live chat screen while keeping chat, Talk mode, and home canvas on the same canonical session. (#80422) Thanks @bcperry.
 - **Gateway host status:** show the connected Gateway's host, network address, OS, runtime, uptime, CPU, memory, and disk details in Control UI Settings. (#100478)
 - **iOS offline chat:** pre-paint recent sessions and canonical transcripts from a protected, bounded per-gateway cache, keep sending disabled offline, and purge cached conversation text when pairing is reset. (#100194)

--- a/apps/macos/Sources/OpenClaw/SettingsRootView.swift
+++ b/apps/macos/Sources/OpenClaw/SettingsRootView.swift
@@ -3,6 +3,8 @@ import Observation
 import SwiftUI
 
 struct SettingsRootView: View {
+    private static let lobsterColor = Color(red: 1, green: 0.29, blue: 0.24)
+
     @Bindable var state: AppState
     private let permissionMonitor = PermissionMonitor.shared
     @State private var monitoringPermissions = false
@@ -29,12 +31,21 @@ struct SettingsRootView: View {
                     Section(group.title) {
                         ForEach(group.tabs) { tab in
                             Label(tab.title, systemImage: tab.systemImage)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 4)
+                                .overlay {
+                                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                                        .stroke(
+                                            tab == self.selectedTab ? Self.lobsterColor : .clear,
+                                            lineWidth: 3)
+                                }
                                 .tag(tab as SettingsTab?)
                         }
                     }
                 }
             }
             .listStyle(.sidebar)
+            .tint(Self.lobsterColor)
             .navigationSplitViewColumnWidth(SettingsLayout.sidebarWidth)
         } detail: {
             self.detailContainer
@@ -201,7 +212,9 @@ struct SettingsRootView: View {
     }
 
     private func validTab(for requested: SettingsTab) -> SettingsTab {
-        if requested == .debug, !self.state.debugPaneEnabled { return .general }
+        if requested == .debug, !self.state.debugPaneEnabled {
+            return .general
+        }
         return requested
     }
 

--- a/apps/macos/Sources/OpenClaw/SettingsRootView.swift
+++ b/apps/macos/Sources/OpenClaw/SettingsRootView.swift
@@ -45,6 +45,7 @@ struct SettingsRootView: View {
                 }
             }
             .listStyle(.sidebar)
+            .accentColor(Self.lobsterColor)
             .tint(Self.lobsterColor)
             .navigationSplitViewColumnWidth(SettingsLayout.sidebarWidth)
         } detail: {

--- a/apps/macos/Sources/OpenClaw/SettingsRootView.swift
+++ b/apps/macos/Sources/OpenClaw/SettingsRootView.swift
@@ -26,20 +26,30 @@ struct SettingsRootView: View {
 
     var body: some View {
         NavigationSplitView(columnVisibility: self.animatedColumnVisibility) {
-            List(selection: self.sidebarSelection) {
+            List {
                 ForEach(self.visibleGroups) { group in
                     Section(group.title) {
                         ForEach(group.tabs) { tab in
-                            Label(tab.title, systemImage: tab.systemImage)
-                                .padding(.horizontal, 6)
-                                .padding(.vertical, 4)
-                                .overlay {
-                                    RoundedRectangle(cornerRadius: 7, style: .continuous)
-                                        .stroke(
-                                            tab == self.selectedTab ? Self.lobsterColor : .clear,
-                                            lineWidth: 3)
-                                }
-                                .tag(tab as SettingsTab?)
+                            Button {
+                                self.selectedTab = self.validTab(for: tab)
+                            } label: {
+                                Label(tab.title, systemImage: tab.systemImage)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(.horizontal, 6)
+                                    .padding(.vertical, 4)
+                                    .foregroundStyle(tab == self.selectedTab ? .white : .primary)
+                                    .background {
+                                        RoundedRectangle(cornerRadius: 7, style: .continuous)
+                                            .fill(tab == self.selectedTab ? Self.lobsterColor : .clear)
+                                    }
+                                    .overlay {
+                                        RoundedRectangle(cornerRadius: 7, style: .continuous)
+                                            .stroke(
+                                                tab == self.selectedTab ? Self.lobsterColor : .clear,
+                                                lineWidth: 3)
+                                    }
+                            }
+                            .buttonStyle(.plain)
                         }
                     }
                 }
@@ -94,15 +104,6 @@ struct SettingsRootView: View {
 
     private var visibleGroups: [SettingsTabGroup] {
         SettingsTabGroup.defaultGroups(showDebug: self.state.debugPaneEnabled)
-    }
-
-    private var sidebarSelection: Binding<SettingsTab?> {
-        Binding(
-            get: { self.selectedTab },
-            set: { tab in
-                guard let tab else { return }
-                self.selectedTab = self.validTab(for: tab)
-            })
     }
 
     private var animatedColumnVisibility: Binding<NavigationSplitViewVisibility> {

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -37,6 +37,26 @@ async function captureUiProof(page: Page, fileName: string) {
   await page.screenshot({ fullPage: true, path: path.join(artifactDir, fileName) });
 }
 
+async function expectLobsterDivider(page: Page) {
+  await expect
+    .poll(() =>
+      page.locator(".shell-nav").evaluate((element) => {
+        const dividerStyle = getComputedStyle(element, "::after");
+        const colorProbe = document.createElement("span");
+        colorProbe.style.color = "var(--accent)";
+        document.body.append(colorProbe);
+        const lobster = getComputedStyle(colorProbe).color;
+        colorProbe.remove();
+        return {
+          colorMatches: dividerStyle.backgroundColor === lobster,
+          display: dividerStyle.display,
+          width: dividerStyle.width,
+        };
+      }),
+    )
+    .toEqual({ colorMatches: true, display: "block", width: "8px" });
+}
+
 describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () => {
   beforeAll(async () => {
     if (!chromiumAvailable) {
@@ -68,6 +88,7 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       await page.goto(`${server.baseUrl}overview`);
 
       const sidebar = page.locator("openclaw-app-sidebar");
+      await expectLobsterDivider(page);
       const pinnedItems = sidebar.locator(".sidebar-nav > .nav-section__items > .nav-item");
       await expect.poll(() => trimmedTextContents(pinnedItems)).toEqual(["Overview"]);
       await expect.poll(() => sidebar.locator(".sidebar-brand").count()).toBe(0);
@@ -153,6 +174,7 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       await expect
         .poll(() => page.locator(".shell").getAttribute("class"))
         .toContain("shell--nav-collapsed");
+      await expectLobsterDivider(page);
       // Rail mode keeps the palette entry reachable as an icon-only control.
       await expect.poll(() => searchButton.isVisible()).toBe(true);
       await page.reload();

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -226,8 +226,20 @@
   display: flex;
   min-height: 100%;
   overflow: visible;
-  border-right: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
   transition: width var(--shell-focus-duration) var(--shell-focus-ease);
+}
+
+/* Paint outside the grid track so the oversized divider does not narrow the
+   collapsed rail or shift its centered controls. */
+.shell-nav::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 100%;
+  width: 8px;
+  background: var(--accent);
+  pointer-events: none;
 }
 
 .shell-nav-backdrop {

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -123,6 +123,10 @@
       opacity var(--shell-focus-duration) var(--shell-focus-ease);
   }
 
+  .shell-nav::after {
+    display: none;
+  }
+
   .shell--nav-drawer-open .shell-nav,
   .shell--nav-collapsed.shell--nav-drawer-open .shell-nav {
     transform: translateX(0);


### PR DESCRIPTION
## What Problem This Solves

Makes the active navigation boundary unmistakable in both the Linux Control UI and macOS Settings for a presentation demo.

## Why This Change Was Made

The Control UI divider uses the existing theme accent as a bold 8px lobster-red stripe. It is painted outside the navigation grid track so expanded and collapsed sidebar widths remain stable, and it stays hidden for the mobile drawer.

The macOS Settings selection uses the same lobster accent with a 3px selected-row border instead of the system blue selection color.

## User Impact

Desktop Control UI users see a large lobster-colored sidebar divider. macOS Settings users see lobster-colored selection styling. This is a presentation-only draft and is not intended to land.

## Evidence

- `corepack pnpm test ui/src/e2e/sidebar-customization.e2e.test.ts`
- Blacksmith Testbox `tbx_01kwz5krw060c6q26rczch22md`: 2 tests passed
- Regression coverage checks the divider in expanded and collapsed desktop states
- AWS Linux Crabbox `cbx_6643d2cdf0e5` (`coral-hermit`): real OpenAI API key returned HTTP 200; live Gateway and modified Control UI launched in VNC
- macOS Tart Crabbox `cbx_90eff477bff3` (`pearl-barnacle-e61d`): Developer-ID-signed app verified, installed at `/Applications/OpenClaw.app`, launched, and Settings visually confirmed with solid lobster selection and no system-blue fill
