### PR TITLE
Workspaces: add stream and computed bindings

### DIFF
--- a/docs/web/workspaces.md
+++ b/docs/web/workspaces.md
@@ -45,14 +45,27 @@ Nine trusted widgets ship with the plugin and render as first-party UI:
 
 Widgets declare data through **bindings**, they never fetch on their own:
 
-| Binding  | Resolves to                                                                                               |
-| -------- | --------------------------------------------------------------------------------------------------------- |
-| `static` | A literal value stored in the document (8 KB max).                                                        |
-| `file`   | A JSON, Markdown, or CSV file under `<stateDir>/workspaces/data/`, optionally narrowed by a JSON pointer. |
-| `rpc`    | One of a fixed allowlist of read-only gateway methods, resolved by the trusted Control UI.                |
+| Binding    | Resolves to                                                                                               |
+| ---------- | --------------------------------------------------------------------------------------------------------- |
+| `static`   | A literal value stored in the document (8 KB max).                                                        |
+| `file`     | A JSON, Markdown, or CSV file under `<stateDir>/workspaces/data/`, optionally narrowed by a JSON pointer. |
+| `rpc`      | One of a fixed allowlist of read-only gateway methods, resolved by the trusted Control UI.                |
+| `stream`   | The latest observed payload from `presence` or `sessions.changed`, optionally narrowed by a JSON pointer. |
+| `computed` | A fixed `sum`, `avg`, `min`, `max`, `last`, `count`, `pick`, or `format` operation over sibling bindings. |
 
 The `file` binding is the simplest way to put your own numbers in a workspace: write a
 JSON file into the data directory and point a `stat-card` at it.
+
+When a widget has more than one binding, set `outputBinding` to the binding id the
+widget renders. This is an explicit contract, not object-key order. Computed inputs can
+reference static, file, or RPC siblings, but not another computed or stream binding.
+OpenClaw never evaluates expressions from a workspace document.
+
+Stream bindings use only events visible to a read-scoped Control UI connection.
+`plugin.workspaces.changed` still tells the shell to refetch the document after an edit,
+but it is write-scoped and therefore is not a valid stream binding event. An unchanged
+stream binding retains its last value across that document refetch. A newly mounted stream
+starts empty until its first event; it does not replay events sent before subscription.
 
 ## Provenance
 
@@ -88,9 +101,20 @@ per-invocation confirmation quoting the exact text, and passes a rate limit.
 ```sh
 openclaw workspaces tabs list
 openclaw workspaces tabs create --title Financials
+openclaw workspaces widgets add --tab financials --kind builtin:stat-card \
+  --binding subtotal=static:40 \
+  --binding tax=static:2 \
+  --binding 'value=computed:{"op":"sum","inputs":["subtotal","tax"]}' \
+  --output-binding value
+openclaw workspaces widgets add --tab financials --kind builtin:stat-card \
+  --binding 'value=stream:presence#/presence/0' \
+  --output-binding value
 openclaw workspaces widget-scaffold revenue-chart --title "Revenue Chart"
 openclaw workspaces widget-approve revenue-chart
 ```
+
+The `workspace_widget_add` and `workspace_widget_update` agent tools expose the same
+`stream` and `computed` binding objects plus `outputBinding` in their schemas.
 
 `widget-approve` needs a device paired with the `operator.approvals` scope; approving from
 the Control UI does not, because the browser already holds it.

--- a/extensions/workspaces/src/binding-contract.ts
+++ b/extensions/workspaces/src/binding-contract.ts
@@ -22,6 +22,29 @@ export const DATA_READ_RPC_ALLOWLIST = [
   "cron.runs",
 ] as const;
 
+/** Gateway events that stream bindings may consume over the existing UI socket. */
+export const STREAM_EVENT_ALLOWLIST = ["presence", "sessions.changed"] as const;
+
+/** Fixed client-side operations available to computed bindings. */
+export const COMPUTED_OPS = [
+  "sum",
+  "avg",
+  "min",
+  "max",
+  "last",
+  "count",
+  "pick",
+  "format",
+] as const;
+
+export type ComputedOp = (typeof COMPUTED_OPS)[number];
+
+/** Server-owned capabilities returned with `workspaces.get` for fail-closed UI use. */
+export const WORKSPACE_BINDING_CONTRACT = {
+  streamEvents: STREAM_EVENT_ALLOWLIST,
+  computedOps: COMPUTED_OPS,
+} as const;
+
 type WorkspaceBindingErrorCode =
   | "binding_denied"
   | "binding_not_found"

--- a/extensions/workspaces/src/cli.test.ts
+++ b/extensions/workspaces/src/cli.test.ts
@@ -108,10 +108,21 @@ describe("workspace CLI", () => {
       "value",
       { source: "static", value: { ok: true } },
     ]);
+    expect(parseWorkspaceBindingShorthand("live=stream:presence#/presence/0")).toEqual([
+      "live",
+      { source: "stream", event: "presence", pointer: "/presence/0" },
+    ]);
+    expect(
+      parseWorkspaceBindingShorthand('total=computed:{"op":"sum","inputs":["subtotal","tax"]}'),
+    ).toEqual(["total", { source: "computed", op: "sum", inputs: ["subtotal", "tax"] }]);
 
     expect(() => parseWorkspaceBindingShorthand("file:q3.json")).toThrow("binding must be");
     expect(() => parseWorkspaceBindingShorthand("value=static:{bad")).toThrow("invalid static");
     expect(() => parseWorkspaceBindingShorthand("value=command:date")).toThrow("binding source");
+    expect(() => parseWorkspaceBindingShorthand("live=stream:")).toThrow(
+      "stream binding event is required",
+    );
+    expect(() => parseWorkspaceBindingShorthand("total=computed:{bad")).toThrow("invalid computed");
   });
 
   it("round-trips tabs and widgets through the L1 gateway methods", async () => {
@@ -139,7 +150,13 @@ describe("workspace CLI", () => {
             "--title",
             "Q3 Revenue",
             "--binding",
-            "value=file:q3.json#/revenue",
+            "subtotal=static:40",
+            "--binding",
+            "tax=static:2",
+            "--binding",
+            'value=computed:{"op":"sum","inputs":["subtotal","tax"]}',
+            "--output-binding",
+            "value",
             "--props",
             '{"format":"usd"}',
           ],
@@ -157,7 +174,12 @@ describe("workspace CLI", () => {
           {
             title: "Q3 Revenue",
             grid: { x: 0, y: 0, w: 4, h: 2 },
-            bindings: { value: { source: "file", path: "q3.json", pointer: "/revenue" } },
+            outputBinding: "value",
+            bindings: {
+              subtotal: { source: "static", value: 40 },
+              tax: { source: "static", value: 2 },
+              value: { source: "computed", op: "sum", inputs: ["subtotal", "tax"] },
+            },
             props: { format: "usd" },
           },
         ],
@@ -168,8 +190,30 @@ describe("workspace CLI", () => {
         expect.objectContaining({ tab: "finance" }),
         expect.objectContaining({ mode: "cli", scopes: ["operator.write", "operator.read"] }),
       );
+      await captureStdout(async () => {
+        await program.parseAsync(
+          [
+            "workspaces",
+            "widgets",
+            "update",
+            "--tab",
+            "finance",
+            "--id",
+            "q3-revenue",
+            "--binding",
+            "value=stream:presence#/presence/0",
+            "--output-binding",
+            "value",
+          ],
+          { from: "user" },
+        );
+      });
+      expect(store.read().tabs[1]?.widgets[0]).toMatchObject({
+        outputBinding: "value",
+        bindings: { value: { source: "stream", event: "presence", pointer: "/presence/0" } },
+      });
       expect(broadcast).toHaveBeenCalledWith("plugin.workspaces.changed", {
-        workspaceVersion: 3,
+        workspaceVersion: 4,
         changedTabSlug: "finance",
         actor: "user",
       });

--- a/extensions/workspaces/src/cli.ts
+++ b/extensions/workspaces/src/cli.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import type { Command } from "commander";
 import { addGatewayClientOptions, callGatewayFromCli } from "openclaw/plugin-sdk/gateway-runtime";
+import { COMPUTED_OPS, STREAM_EVENT_ALLOWLIST, type ComputedOp } from "./binding-contract.js";
 import {
   validateWorkspaceDoc,
   type WorkspaceBinding,
@@ -70,7 +71,10 @@ function parseWorkspaceGrid(value: string): WorkspaceGrid {
 export function parseWorkspaceBindingShorthand(value: string): [string, WorkspaceBinding] {
   const eqIndex = value.indexOf("=");
   if (eqIndex <= 0) {
-    throw new Error("binding must be id=file:<path>, id=rpc:<method>, or id=static:<json>");
+    throw new Error(
+      "binding must be id=file:<path>, id=rpc:<method>, id=static:<json>, " +
+        "id=stream:<event>, or id=computed:<json>",
+    );
   }
   const id = value.slice(0, eqIndex).trim();
   const body = value.slice(eqIndex + 1).trim();
@@ -104,7 +108,48 @@ export function parseWorkspaceBindingShorthand(value: string): [string, Workspac
   if (body.startsWith("static:")) {
     return [id, { source: "static", value: parseJson(body.slice("static:".length), "static") }];
   }
-  throw new Error("binding source must be file, rpc, or static");
+  if (body.startsWith("stream:")) {
+    const streamSpec = body.slice("stream:".length);
+    const hashIndex = streamSpec.indexOf("#");
+    const event = (hashIndex >= 0 ? streamSpec.slice(0, hashIndex) : streamSpec).trim();
+    const pointer = hashIndex >= 0 ? streamSpec.slice(hashIndex + 1) : undefined;
+    if (!event) {
+      throw new Error("stream binding event is required");
+    }
+    if (!STREAM_EVENT_ALLOWLIST.includes(event as (typeof STREAM_EVENT_ALLOWLIST)[number])) {
+      throw new Error(`stream binding event is not allowlisted: ${event}`);
+    }
+    return [id, { source: "stream", event, ...(pointer !== undefined ? { pointer } : {}) }];
+  }
+  if (body.startsWith("computed:")) {
+    const value = parseJson(body.slice("computed:".length), "computed");
+    if (!isRecord(value)) {
+      throw new Error("computed binding must be a JSON object");
+    }
+    const op = value.op;
+    const inputs = value.inputs;
+    const arg = value.arg;
+    if (typeof op !== "string" || !COMPUTED_OPS.includes(op as ComputedOp)) {
+      throw new Error("computed binding op is invalid");
+    }
+    if (!Array.isArray(inputs) || inputs.some((input) => typeof input !== "string")) {
+      throw new Error("computed binding inputs must be an array of binding ids");
+    }
+    const stringInputs = inputs.filter((input): input is string => typeof input === "string");
+    if (arg !== undefined && typeof arg !== "string") {
+      throw new Error("computed binding arg must be a string");
+    }
+    return [
+      id,
+      {
+        source: "computed",
+        op: op as ComputedOp,
+        inputs: stringInputs,
+        ...(arg !== undefined ? { arg } : {}),
+      },
+    ];
+  }
+  throw new Error("binding source must be file, rpc, static, stream, or computed");
 }
 
 function collectBinding(value: string, previous: string[] = []): string[] {
@@ -306,6 +351,7 @@ export function registerWorkspaceCli(options: RegisterWorkspaceCliOptions): void
       .option("--title <title>", "Widget title")
       .option("--grid <x,y,w,h>", "Widget grid", "0,0,4,2")
       .option("--binding <id=source>", "Binding shorthand", collectBinding, [])
+      .option("--output-binding <id>", "Binding id rendered by the widget")
       .option("--props <json>", "Widget props JSON"),
   ).action(
     async (
@@ -316,6 +362,7 @@ export function registerWorkspaceCli(options: RegisterWorkspaceCliOptions): void
         title?: string;
         grid?: string;
         binding?: string[];
+        outputBinding?: string;
         props?: string;
       },
     ) => {
@@ -328,6 +375,7 @@ export function registerWorkspaceCli(options: RegisterWorkspaceCliOptions): void
           ...(commandOptions.title ? { title: commandOptions.title } : {}),
           grid: parseWorkspaceGrid(commandOptions.grid ?? "0,0,4,2"),
           ...(bindings ? { bindings } : {}),
+          ...(commandOptions.outputBinding ? { outputBinding: commandOptions.outputBinding } : {}),
           ...(commandOptions.props ? { props: parseJson(commandOptions.props, "props") } : {}),
         },
       });
@@ -343,7 +391,10 @@ export function registerWorkspaceCli(options: RegisterWorkspaceCliOptions): void
       .requiredOption("--id <id>", "Widget id")
       .option("--title <title>", "Widget title")
       .option("--collapsed <bool>", "Collapsed state", parseOptionalBoolean)
-      .option("--hidden <bool>", "Hidden state", parseOptionalBoolean),
+      .option("--hidden <bool>", "Hidden state", parseOptionalBoolean)
+      .option("--binding <id=source>", "Replacement binding shorthand", collectBinding, [])
+      .option("--output-binding <id>", "Binding id rendered by the widget")
+      .option("--props <json>", "Replacement widget props JSON"),
   ).action(
     async (
       commandOptions: GatewayOptions & {
@@ -352,12 +403,19 @@ export function registerWorkspaceCli(options: RegisterWorkspaceCliOptions): void
         title?: string;
         collapsed?: boolean;
         hidden?: boolean;
+        binding?: string[];
+        outputBinding?: string;
+        props?: string;
       },
     ) => {
+      const bindings = parseBindings(commandOptions.binding);
       const patch = {
         ...(commandOptions.title !== undefined ? { title: commandOptions.title } : {}),
         ...(commandOptions.collapsed !== undefined ? { collapsed: commandOptions.collapsed } : {}),
         ...(commandOptions.hidden !== undefined ? { hidden: commandOptions.hidden } : {}),
+        ...(bindings ? { bindings } : {}),
+        ...(commandOptions.outputBinding ? { outputBinding: commandOptions.outputBinding } : {}),
+        ...(commandOptions.props ? { props: parseJson(commandOptions.props, "props") } : {}),
       };
       requirePatch(patch);
       const result = await callWorkspaceGateway("workspaces.widget.update", commandOptions, {

--- a/extensions/workspaces/src/cli.ts
+++ b/extensions/workspaces/src/cli.ts
@@ -122,13 +122,13 @@ export function parseWorkspaceBindingShorthand(value: string): [string, Workspac
     return [id, { source: "stream", event, ...(pointer !== undefined ? { pointer } : {}) }];
   }
   if (body.startsWith("computed:")) {
-    const value = parseJson(body.slice("computed:".length), "computed");
-    if (!isRecord(value)) {
+    const computed = parseJson(body.slice("computed:".length), "computed");
+    if (!isRecord(computed)) {
       throw new Error("computed binding must be a JSON object");
     }
-    const op = value.op;
-    const inputs = value.inputs;
-    const arg = value.arg;
+    const op = computed.op;
+    const inputs = computed.inputs;
+    const arg = computed.arg;
     if (typeof op !== "string" || !COMPUTED_OPS.includes(op as ComputedOp)) {
       throw new Error("computed binding op is invalid");
     }

--- a/extensions/workspaces/src/data-read.test.ts
+++ b/extensions/workspaces/src/data-read.test.ts
@@ -28,6 +28,21 @@ describe("workspace data binding resolver", () => {
     });
   });
 
+  it("returns the client-resolution signal for stream and computed bindings", async () => {
+    await expect(resolveBinding({ source: "stream", event: "presence" })).rejects.toMatchObject({
+      code: "binding_client_resolved",
+    });
+    await expect(
+      resolveBinding({ source: "computed", op: "sum", inputs: ["a"] }),
+    ).rejects.toMatchObject({ code: "binding_client_resolved" });
+  });
+
+  it("rejects stream events that read-only workspace clients cannot receive", async () => {
+    await expect(
+      resolveBinding({ source: "stream", event: "plugin.workspaces.changed" }),
+    ).rejects.toMatchObject({ code: "binding_invalid" });
+  });
+
   it("allowlists the read methods the L4 builtin data widgets bind", () => {
     // Frozen so a builtin can never reference a method the write-time schema
     // would reject. system-presence backs builtin:instances; cron.runs backs

--- a/extensions/workspaces/src/data-read.ts
+++ b/extensions/workspaces/src/data-read.ts
@@ -2,6 +2,9 @@ import path from "node:path";
 import { FsSafeError, root as fsRoot } from "openclaw/plugin-sdk/security-runtime";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import {
+  COMPUTED_OPS,
+  type ComputedOp,
+  STREAM_EVENT_ALLOWLIST,
   WorkspaceBindingResolutionError,
   normalizeWorkspaceDataLogicalPath,
 } from "./binding-contract.js";
@@ -50,6 +53,61 @@ function readBinding(value: unknown): WorkspaceBinding {
       source: "file",
       path: value.path,
       ...(value.pointer !== undefined ? { pointer: value.pointer } : {}),
+    };
+  }
+  if (value.source === "stream") {
+    if (typeof value.event !== "string" || !value.event.trim()) {
+      throw new WorkspaceBindingResolutionError(
+        "binding_invalid",
+        "stream binding event is required",
+      );
+    }
+    if (!STREAM_EVENT_ALLOWLIST.includes(value.event as (typeof STREAM_EVENT_ALLOWLIST)[number])) {
+      throw new WorkspaceBindingResolutionError(
+        "binding_invalid",
+        "stream binding event is not allowlisted",
+      );
+    }
+    return {
+      source: "stream",
+      event: value.event,
+      ...(typeof value.pointer === "string" ? { pointer: value.pointer } : {}),
+    };
+  }
+  if (value.source === "computed") {
+    if (typeof value.op !== "string") {
+      throw new WorkspaceBindingResolutionError(
+        "binding_invalid",
+        "computed binding op is required",
+      );
+    }
+    if (!COMPUTED_OPS.includes(value.op as ComputedOp)) {
+      throw new WorkspaceBindingResolutionError(
+        "binding_invalid",
+        "computed binding op is invalid",
+      );
+    }
+    if (!Array.isArray(value.inputs)) {
+      throw new WorkspaceBindingResolutionError(
+        "binding_invalid",
+        "computed binding inputs are required",
+      );
+    }
+    if (
+      value.inputs.length < 1 ||
+      value.inputs.length > 32 ||
+      value.inputs.some((input) => typeof input !== "string")
+    ) {
+      throw new WorkspaceBindingResolutionError(
+        "binding_invalid",
+        "computed binding inputs are invalid",
+      );
+    }
+    return {
+      source: "computed",
+      op: value.op as ComputedOp,
+      inputs: value.inputs,
+      ...(typeof value.arg === "string" ? { arg: value.arg } : {}),
     };
   }
   throw new WorkspaceBindingResolutionError("binding_invalid", "binding source is invalid");
@@ -151,6 +209,12 @@ export async function resolveBinding(
     throw new WorkspaceBindingResolutionError(
       "binding_client_resolved",
       "rpc workspace bindings are resolved by the Control UI gateway client",
+    );
+  }
+  if (binding.source === "stream" || binding.source === "computed") {
+    throw new WorkspaceBindingResolutionError(
+      "binding_client_resolved",
+      `${binding.source} workspace bindings are resolved by the Control UI client`,
     );
   }
   return await resolveFileBinding(binding, options);

--- a/extensions/workspaces/src/gateway.test.ts
+++ b/extensions/workspaces/src/gateway.test.ts
@@ -99,6 +99,12 @@ describe("workspace gateway methods", () => {
       const read = await callMethod(methods.get("workspaces.get")!, {}, broadcast);
       expect(read.response?.[0]).toBe(true);
       expect(read.response?.[1]).toMatchObject({ workspaceVersion: 1 });
+      expect(read.response?.[1]).toMatchObject({
+        bindingContract: {
+          streamEvents: ["presence", "sessions.changed"],
+          computedOps: ["sum", "avg", "min", "max", "last", "count", "pick", "format"],
+        },
+      });
       expect(broadcast).not.toHaveBeenCalled();
 
       // Provenance is derived from the caller. An RPC client must not be able to

--- a/extensions/workspaces/src/gateway.ts
+++ b/extensions/workspaces/src/gateway.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { WORKSPACE_BINDING_CONTRACT } from "./binding-contract.js";
 import { rememberWorkspaceBroadcast } from "./broadcast.js";
 import { resolveBinding, type ResolveBindingOptions } from "./data-read.js";
 import { snapshotApprovedWidget } from "./manifest.js";
@@ -247,12 +248,23 @@ function readWidgetInput(
   }
   for (const key of Object.keys(value)) {
     if (
-      !["id", "kind", "title", "grid", "collapsed", "hidden", "bindings", "props"].includes(key)
+      ![
+        "id",
+        "kind",
+        "title",
+        "grid",
+        "collapsed",
+        "hidden",
+        "bindings",
+        "outputBinding",
+        "props",
+      ].includes(key)
     ) {
       throw new Error(`widget.${key} is not allowed`);
     }
   }
   const title = readOptionalString(value, "title");
+  const outputBinding = readOptionalString(value, "outputBinding");
   return {
     id: makeUniqueWidgetId(value, doc),
     kind: readRequiredString(value, "kind", "widget.kind"),
@@ -264,6 +276,7 @@ function readWidgetInput(
     ...(value.bindings !== undefined
       ? { bindings: value.bindings as Record<string, WorkspaceBinding> }
       : {}),
+    ...(outputBinding !== undefined ? { outputBinding } : {}),
     ...(value.props !== undefined ? { props: value.props as JsonValue } : {}),
   };
 }
@@ -295,8 +308,17 @@ function readTabPatch(value: unknown): Partial<Pick<WorkspaceTab, "title" | "ico
 }
 
 function readWidgetPatch(value: unknown): Partial<WorkspaceWidget> {
-  const patch = readParams(value, ["title", "grid", "collapsed", "hidden", "bindings", "props"]);
+  const patch = readParams(value, [
+    "title",
+    "grid",
+    "collapsed",
+    "hidden",
+    "bindings",
+    "outputBinding",
+    "props",
+  ]);
   const title = readOptionalString(patch, "title");
+  const outputBinding = readOptionalString(patch, "outputBinding");
   if (title !== undefined && title.length > 80) {
     throw new Error("patch.title must be 80 characters or fewer");
   }
@@ -312,6 +334,7 @@ function readWidgetPatch(value: unknown): Partial<WorkspaceWidget> {
     ...(patch.bindings !== undefined
       ? { bindings: patch.bindings as Record<string, WorkspaceBinding> }
       : {}),
+    ...(outputBinding !== undefined ? { outputBinding } : {}),
     ...(patch.props !== undefined ? { props: patch.props as JsonValue } : {}),
   };
 }
@@ -372,7 +395,11 @@ export function registerWorkspaceGatewayMethods(options: WorkspaceGatewayMethodO
       try {
         rememberWorkspaceBroadcast(context.broadcast);
         const doc = store.read();
-        respond(true, { doc, workspaceVersion: doc.workspaceVersion });
+        respond(true, {
+          doc,
+          workspaceVersion: doc.workspaceVersion,
+          bindingContract: WORKSPACE_BINDING_CONTRACT,
+        });
       } catch (error) {
         respondError(respond, error);
       }
@@ -562,7 +589,11 @@ export function registerWorkspaceGatewayMethods(options: WorkspaceGatewayMethodO
         await respondWrite(opts, RPC_ACTOR, slug, async () =>
           store.mutate(
             (draft) => {
-              Object.assign(findWidget(findTab(draft, slug), id), patch);
+              const widget = findWidget(findTab(draft, slug), id);
+              if (patch.bindings !== undefined && patch.outputBinding === undefined) {
+                delete widget.outputBinding;
+              }
+              Object.assign(widget, patch);
             },
             { actor: RPC_ACTOR },
           ),

--- a/extensions/workspaces/src/schema.test.ts
+++ b/extensions/workspaces/src/schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { DEFAULT_WORKSPACE } from "./default-workspace.js";
-import { validateWorkspaceDoc, type WorkspaceDoc } from "./schema.js";
+import { migrateWorkspaceDoc, validateWorkspaceDoc, type WorkspaceDoc } from "./schema.js";
 
 function validDoc(): WorkspaceDoc {
   return structuredClone(DEFAULT_WORKSPACE);
@@ -124,5 +124,165 @@ describe("Workspaces document schema", () => {
     expectInvalid((doc) => {
       doc.tabs[0]!.createdBy = "robot" as never;
     }, "createdBy");
+  });
+
+  it("accepts stream bindings on readable event channels", () => {
+    const doc = validDoc();
+    doc.tabs[0]!.widgets[0]!.bindings = {
+      live: { source: "stream", event: "presence", pointer: "/online" },
+    } as never;
+
+    expect(() => validateWorkspaceDoc(doc)).not.toThrow();
+  });
+
+  it("rejects stream bindings on non-allowlisted event channels", () => {
+    expectInvalid((doc) => {
+      doc.tabs[0]!.widgets[0]!.bindings = {
+        live: { source: "stream", event: "evil.channel" },
+      } as never;
+    }, "bindings.live.event is not allowlisted");
+  });
+
+  it("does not advertise the write-scoped workspace change event as stream-readable", () => {
+    expectInvalid((doc) => {
+      doc.tabs[0]!.widgets[0]!.bindings = {
+        live: { source: "stream", event: "plugin.workspaces.changed" },
+      } as never;
+    }, "bindings.live.event is not allowlisted");
+  });
+
+  it("requires an explicit output binding when a widget has multiple bindings", () => {
+    expectInvalid((doc) => {
+      doc.tabs[0]!.widgets[0]!.bindings = {
+        a: { source: "static", value: 1 },
+        b: { source: "static", value: 2 },
+      } as never;
+    }, "outputBinding is required when bindings contains more than one entry");
+  });
+
+  it("accepts a validated non-first output binding", () => {
+    const doc = validDoc();
+    doc.tabs[0]!.widgets[0]!.bindings = {
+      a: { source: "static", value: 2 },
+      b: { source: "static", value: 3 },
+      total: { source: "computed", op: "sum", inputs: ["a", "b"] },
+    } as never;
+    doc.tabs[0]!.widgets[0]!.outputBinding = "total";
+
+    expect(validateWorkspaceDoc(doc).tabs[0]!.widgets[0]).toMatchObject({
+      outputBinding: "total",
+    });
+  });
+
+  it("migrates the legacy first-binding choice into an explicit outputBinding", () => {
+    const doc = validDoc();
+    doc.tabs[0]!.widgets[0]!.bindings = {
+      first: { source: "static", value: 1 },
+      second: { source: "static", value: 2 },
+    };
+
+    const migrated = migrateWorkspaceDoc(doc);
+    expect(migrated.changed).toBe(true);
+    expect(migrated.doc.tabs[0]!.widgets[0]!.outputBinding).toBe("first");
+  });
+
+  it("rejects prototype-chain names as computed inputs and output bindings", () => {
+    expectInvalid((doc) => {
+      doc.tabs[0]!.widgets[0]!.bindings = {
+        total: { source: "computed", op: "sum", inputs: ["constructor"] },
+      } as never;
+    }, "references unknown binding: constructor");
+
+    expectInvalid((doc) => {
+      doc.tabs[0]!.widgets[0]!.bindings = { value: { source: "static", value: 1 } };
+      doc.tabs[0]!.widgets[0]!.outputBinding = "constructor";
+    }, "references unknown binding: constructor");
+  });
+
+  it("rejects an output binding that is absent from the widget binding map", () => {
+    expectInvalid((doc) => {
+      doc.tabs[0]!.widgets[0]!.bindings = {
+        value: { source: "static", value: 1 },
+      } as never;
+      doc.tabs[0]!.widgets[0]!.outputBinding = "missing";
+    }, "outputBinding references unknown binding: missing");
+  });
+
+  it("accepts every computed operation with valid sibling inputs", () => {
+    for (const op of ["sum", "avg", "min", "max", "last", "count"]) {
+      const doc = validDoc();
+      doc.tabs[0]!.widgets[0]!.bindings = {
+        total: { source: "computed", op, inputs: ["a", "b"] },
+        a: { source: "static", value: 1 },
+        b: { source: "static", value: 2 },
+      } as never;
+      doc.tabs[0]!.widgets[0]!.outputBinding = "total";
+      expect(() => validateWorkspaceDoc(doc)).not.toThrow();
+    }
+
+    for (const [op, arg] of [
+      ["pick", "/nested/value"],
+      ["format", "{0} of {1}"],
+    ]) {
+      const doc = validDoc();
+      doc.tabs[0]!.widgets[0]!.bindings = {
+        derived: { source: "computed", op, inputs: ["a"], arg },
+        a: { source: "static", value: 1 },
+      } as never;
+      doc.tabs[0]!.widgets[0]!.outputBinding = "derived";
+      expect(() => validateWorkspaceDoc(doc)).not.toThrow();
+    }
+  });
+
+  it("rejects invalid computed operations, inputs, and arguments", () => {
+    expectInvalid((doc) => {
+      doc.tabs[0]!.widgets[0]!.bindings = {
+        total: { source: "computed", op: "eval", inputs: ["a"] },
+        a: { source: "static", value: 1 },
+      } as never;
+    }, "bindings.total.op is not a valid computed op");
+
+    expectInvalid((doc) => {
+      doc.tabs[0]!.widgets[0]!.bindings = {
+        total: { source: "computed", op: "sum", inputs: [] },
+      } as never;
+    }, "bindings.total.inputs must contain 1 to 32 entries");
+
+    expectInvalid((doc) => {
+      doc.tabs[0]!.widgets[0]!.bindings = {
+        derived: { source: "computed", op: "pick", inputs: ["a"] },
+        a: { source: "static", value: 1 },
+      } as never;
+    }, "bindings.derived.arg is required for the pick op");
+
+    expectInvalid((doc) => {
+      doc.tabs[0]!.widgets[0]!.bindings = {
+        total: { source: "computed", op: "sum", inputs: ["a"], arg: "unused" },
+        a: { source: "static", value: 1 },
+      } as never;
+    }, "bindings.total.arg is not allowed for the sum op");
+  });
+
+  it("rejects computed inputs that reference missing or computed siblings", () => {
+    expectInvalid((doc) => {
+      doc.tabs[0]!.widgets[0]!.bindings = {
+        total: { source: "computed", op: "sum", inputs: ["missing"] },
+      } as never;
+    }, "references unknown binding: missing");
+
+    expectInvalid((doc) => {
+      doc.tabs[0]!.widgets[0]!.bindings = {
+        total: { source: "computed", op: "sum", inputs: ["mid"] },
+        mid: { source: "computed", op: "sum", inputs: ["a"] },
+        a: { source: "static", value: 1 },
+      } as never;
+    }, "may not reference another computed binding: mid");
+
+    expectInvalid((doc) => {
+      doc.tabs[0]!.widgets[0]!.bindings = {
+        total: { source: "computed", op: "sum", inputs: ["live"] },
+        live: { source: "stream", event: "presence" },
+      } as never;
+    }, "may not reference a stream binding: live");
   });
 });

--- a/extensions/workspaces/src/schema.ts
+++ b/extensions/workspaces/src/schema.ts
@@ -1,4 +1,10 @@
-import { DATA_READ_RPC_ALLOWLIST, normalizeWorkspaceDataLogicalPath } from "./binding-contract.js";
+import {
+  COMPUTED_OPS,
+  type ComputedOp,
+  DATA_READ_RPC_ALLOWLIST,
+  normalizeWorkspaceDataLogicalPath,
+  STREAM_EVENT_ALLOWLIST,
+} from "./binding-contract.js";
 
 export type JsonValue =
   | null
@@ -17,7 +23,19 @@ type WorkspaceRpcBinding = {
 };
 type WorkspaceFileBinding = { source: "file"; path: string; pointer?: string };
 type WorkspaceStaticBinding = { source: "static"; value: JsonValue };
-export type WorkspaceBinding = WorkspaceRpcBinding | WorkspaceFileBinding | WorkspaceStaticBinding;
+type WorkspaceStreamBinding = { source: "stream"; event: string; pointer?: string };
+type WorkspaceComputedBinding = {
+  source: "computed";
+  op: ComputedOp;
+  inputs: string[];
+  arg?: string;
+};
+export type WorkspaceBinding =
+  | WorkspaceRpcBinding
+  | WorkspaceFileBinding
+  | WorkspaceStaticBinding
+  | WorkspaceStreamBinding
+  | WorkspaceComputedBinding;
 export type WorkspaceWidget = {
   id: string;
   kind: string;
@@ -28,6 +46,8 @@ export type WorkspaceWidget = {
   /** Provenance stamp; the Control UI renders an "AI" chip for `agent:<id>`. */
   createdBy: WorkspaceActor;
   bindings?: Record<string, WorkspaceBinding>;
+  /** Binding rendered by the widget; required when the binding map is ambiguous. */
+  outputBinding?: string;
   props?: JsonValue;
 };
 export type WorkspaceTab = {
@@ -75,8 +95,10 @@ export const BUILTIN_WIDGET_KINDS = [
 const BUILTIN_KINDS = new Set<string>(BUILTIN_WIDGET_KINDS);
 const CUSTOM_KIND_PATTERN = /^custom:(?!__proto__$)[A-Za-z0-9._-]{1,64}$/;
 const CUSTOM_WIDGET_NAME_PATTERN = /^(?!__proto__$)[A-Za-z0-9._-]{1,64}$/;
+const BINDING_ID_PATTERN = /^(?!__proto__$)[A-Za-z0-9._-]{1,64}$/;
 const MAX_STATIC_BINDING_BYTES = 8 * 1024;
 const MAX_RPC_BINDING_PARAMS_BYTES = 8 * 1024;
+const MAX_COMPUTED_INPUTS = 32;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -236,26 +258,100 @@ function validateBinding(value: unknown, path: string): WorkspaceBinding {
     }
     return { source, value: jsonValue };
   }
+  if (source === "stream") {
+    assertKnownKeys(record, ["source", "event", "pointer"], path);
+    const event = requireString(record, "event", path);
+    if (!STREAM_EVENT_ALLOWLIST.includes(event as (typeof STREAM_EVENT_ALLOWLIST)[number])) {
+      throw new Error(`${path}.event is not allowlisted`);
+    }
+    const pointer = optionalString(record, "pointer", path);
+    if (pointer !== undefined && !pointer.startsWith("/")) {
+      throw new Error(`${path}.pointer must be a JSON pointer`);
+    }
+    return { source, event, ...(pointer !== undefined ? { pointer } : {}) };
+  }
+  if (source === "computed") {
+    assertKnownKeys(record, ["source", "op", "inputs", "arg"], path);
+    const op = requireString(record, "op", path);
+    if (!COMPUTED_OPS.includes(op as ComputedOp)) {
+      throw new Error(`${path}.op is not a valid computed op`);
+    }
+    const rawInputs = requireArray(record.inputs, `${path}.inputs`);
+    if (rawInputs.length < 1 || rawInputs.length > MAX_COMPUTED_INPUTS) {
+      throw new Error(`${path}.inputs must contain 1 to ${MAX_COMPUTED_INPUTS} entries`);
+    }
+    const inputs = rawInputs.map((entry, index) => {
+      if (typeof entry !== "string" || !BINDING_ID_PATTERN.test(entry)) {
+        throw new Error(`${path}.inputs[${index}] is invalid`);
+      }
+      return entry;
+    });
+    const needsArg = op === "pick" || op === "format";
+    const arg = optionalString(record, "arg", path);
+    if (needsArg && !arg) {
+      throw new Error(`${path}.arg is required for the ${op} op`);
+    }
+    if (!needsArg && arg !== undefined) {
+      throw new Error(`${path}.arg is not allowed for the ${op} op`);
+    }
+    if (op === "pick" && arg !== undefined && !arg.startsWith("/")) {
+      throw new Error(`${path}.arg must be a JSON pointer for the pick op`);
+    }
+    return { source, op: op as ComputedOp, inputs, ...(arg !== undefined ? { arg } : {}) };
+  }
   throw new Error(`${path}.source is invalid`);
 }
 
 function validateBindingRecord(value: unknown, path: string): Record<string, WorkspaceBinding> {
   const record = assertRecord(value, path);
-  return Object.fromEntries(
+  const bindings = Object.fromEntries(
     Object.entries(record).map(([key, entry]) => {
-      if (key === "__proto__" || !/^[A-Za-z0-9._-]{1,64}$/.test(key)) {
+      if (!BINDING_ID_PATTERN.test(key)) {
         throw new Error(`${path}.${key} binding id is invalid`);
       }
       return [key, validateBinding(entry, `${path}.${key}`)];
     }),
   );
+  // Computed bindings depend only on leaf siblings. This makes cycles
+  // structurally impossible without maintaining a second dependency graph.
+  for (const [key, binding] of Object.entries(bindings)) {
+    if (binding.source !== "computed") {
+      continue;
+    }
+    for (const input of binding.inputs) {
+      if (!Object.hasOwn(bindings, input)) {
+        throw new Error(`${path}.${key}.inputs references unknown binding: ${input}`);
+      }
+      const target = bindings[input]!;
+      if (target.source === "computed") {
+        throw new Error(
+          `${path}.${key}.inputs may not reference another computed binding: ${input}`,
+        );
+      }
+      if (target.source === "stream") {
+        throw new Error(`${path}.${key}.inputs may not reference a stream binding: ${input}`);
+      }
+    }
+  }
+  return bindings;
 }
 
 function validateWidget(value: unknown, path: string): WorkspaceWidget {
   const record = assertRecord(value, path);
   assertKnownKeys(
     record,
-    ["id", "kind", "title", "grid", "collapsed", "hidden", "createdBy", "bindings", "props"],
+    [
+      "id",
+      "kind",
+      "title",
+      "grid",
+      "collapsed",
+      "hidden",
+      "createdBy",
+      "bindings",
+      "outputBinding",
+      "props",
+    ],
     path,
   );
   const id = requireString(record, "id", path);
@@ -278,6 +374,16 @@ function validateWidget(value: unknown, path: string): WorkspaceWidget {
     record.bindings === undefined
       ? undefined
       : validateBindingRecord(record.bindings, `${path}.bindings`);
+  const outputBinding = optionalString(record, "outputBinding", path);
+  if (outputBinding !== undefined && !BINDING_ID_PATTERN.test(outputBinding)) {
+    throw new Error(`${path}.outputBinding is invalid`);
+  }
+  if (outputBinding !== undefined && (!bindings || !Object.hasOwn(bindings, outputBinding))) {
+    throw new Error(`${path}.outputBinding references unknown binding: ${outputBinding}`);
+  }
+  if (bindings && Object.keys(bindings).length > 1 && outputBinding === undefined) {
+    throw new Error(`${path}.outputBinding is required when bindings contains more than one entry`);
+  }
   const props =
     record.props === undefined ? undefined : assertJsonValue(record.props, `${path}.props`);
   return {
@@ -289,6 +395,7 @@ function validateWidget(value: unknown, path: string): WorkspaceWidget {
     hidden: requireBoolean(record, "hidden", path),
     createdBy: validateActor(record.createdBy, `${path}.createdBy`),
     ...(bindings !== undefined ? { bindings } : {}),
+    ...(outputBinding !== undefined ? { outputBinding } : {}),
     ...(props !== undefined ? { props } : {}),
   };
 }
@@ -455,4 +562,37 @@ export function validateWorkspaceDoc(value: unknown): WorkspaceDoc {
     widgetsRegistry: validateWidgetsRegistry(record.widgetsRegistry),
     prefs: validatePrefs(record.prefs, tabSlugs),
   };
+}
+export function migrateWorkspaceDoc(value: unknown): { doc: WorkspaceDoc; changed: boolean } {
+  const record = assertRecord(value, "workspaces");
+  const schemaVersion = record.schemaVersion;
+  if (typeof schemaVersion !== "number" || !Number.isInteger(schemaVersion)) {
+    throw new Error("schemaVersion must be an integer");
+  }
+  if (schemaVersion > CURRENT_WORKSPACE_SCHEMA_VERSION) {
+    throw new Error(`unsupported future workspace schemaVersion: ${schemaVersion}`);
+  }
+  if (schemaVersion < CURRENT_WORKSPACE_SCHEMA_VERSION) {
+    throw new Error(`unsupported old workspace schemaVersion: ${schemaVersion}`);
+  }
+  const migrated = structuredClone(record);
+  let changed = false;
+  if (Array.isArray(migrated.tabs)) {
+    for (const tab of migrated.tabs) {
+      if (!isRecord(tab) || !Array.isArray(tab.widgets)) {
+        continue;
+      }
+      for (const widget of tab.widgets) {
+        if (!isRecord(widget) || widget.outputBinding !== undefined || !isRecord(widget.bindings)) {
+          continue;
+        }
+        const bindingIds = Object.keys(widget.bindings);
+        if (bindingIds.length > 1) {
+          widget.outputBinding = bindingIds[0];
+          changed = true;
+        }
+      }
+    }
+  }
+  return { doc: validateWorkspaceDoc(migrated), changed };
 }

--- a/extensions/workspaces/src/store.ts
+++ b/extensions/workspaces/src/store.ts
@@ -27,6 +27,7 @@ import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import { WidgetAssetTokens } from "./asset-tokens.js";
 import { DEFAULT_WORKSPACE } from "./default-workspace.js";
 import {
+  migrateWorkspaceDoc,
   validateWorkspaceDoc,
   type WorkspaceActor,
   type WorkspaceWidgetRegistryEntry,
@@ -154,7 +155,15 @@ export class WorkspaceStore {
       this.commit(seeded, { snapshot: null });
       return structuredClone(seeded);
     }
-    const doc = validateWorkspaceDoc(JSON.parse(row.doc));
+    const migrated = migrateWorkspaceDoc(JSON.parse(row.doc));
+    const doc = migrated.doc;
+    if (migrated.changed) {
+      const serialized = serializeWorkspaceDoc(doc);
+      assertWorkspaceSize(serialized);
+      this.db
+        .prepare("UPDATE workspace SET doc = ?, updated_ms = ? WHERE id = 1")
+        .run(serialized, Date.now());
+    }
     this.cached = doc;
     return structuredClone(doc);
   }
@@ -213,7 +222,7 @@ export class WorkspaceStore {
         this.db.prepare("DELETE FROM undo WHERE version = ?").run(row.version);
         // transact() stamps the next version, so the restored document lands as a
         // forward write rather than a rewind.
-        const snapshot = validateWorkspaceDoc(JSON.parse(row.doc));
+        const snapshot = migrateWorkspaceDoc(JSON.parse(row.doc)).doc;
         // Approval state is a separate operator decision, not layout history.
         // Undo may restore tabs/widgets, but it must never revive a revoked
         // approval or discard a registry decision made after the snapshot.

--- a/extensions/workspaces/src/tools.test.ts
+++ b/extensions/workspaces/src/tools.test.ts
@@ -7,6 +7,7 @@ import { Value } from "typebox/value";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { registerWorkspaceCli } from "./cli.js";
 import { registerWorkspaceGatewayMethods } from "./gateway.js";
+import type { WorkspaceDoc } from "./schema.js";
 import { WorkspaceStore } from "./store.js";
 import { createWorkspaceTools } from "./tools.js";
 
@@ -98,6 +99,11 @@ describe("workspace tools", () => {
         tab: "main",
         kind: "builtin:markdown",
         grid: { x: 0, y: 0, w: 4, h: 2 },
+        outputBinding: "value",
+        bindings: {
+          base: { source: "static", value: 40 },
+          value: { source: "computed", op: "sum", inputs: ["base"] },
+        },
       },
       workspace_widget_update: { tab: "main", id: "cost-today", collapsed: true },
       workspace_widget_move: { tab: "main", id: "cost-today", grid: { x: 4, y: 0, w: 4, h: 2 } },
@@ -133,6 +139,15 @@ describe("workspace tools", () => {
         false,
       );
     }
+    expect(
+      Value.Check(tools.get("workspace_widget_add")!.parameters, {
+        tab: "main",
+        kind: "builtin:stat-card",
+        grid: { x: 0, y: 0, w: 4, h: 2 },
+        outputBinding: "live",
+        bindings: { live: { source: "stream", event: "presence", pointer: "/presence/0" } },
+      }),
+    ).toBe(true);
   });
 
   it("stamps tool provenance from context and rejects createdBy override params", async () => {
@@ -262,6 +277,7 @@ describe("workspace tools", () => {
           title: "Notes",
           grid: { x: 0, y: 0, w: 4, h: 2 },
           bindings: { value: { source: "static", value: "hello" } },
+          outputBinding: "value",
         }),
       );
       expect(addResult.doc).toMatchObject({
@@ -269,22 +285,58 @@ describe("workspace tools", () => {
           expect.any(Object),
           expect.objectContaining({
             slug: "ops",
-            widgets: [expect.objectContaining({ id: "notes", title: "Notes" })],
+            widgets: [
+              expect.objectContaining({ id: "notes", title: "Notes", outputBinding: "value" }),
+            ],
           }),
         ],
       });
-      await tools.get("workspace_widget_move")?.execute("call-3", {
+      const updateResult = details(
+        await tools.get("workspace_widget_update")?.execute("call-3", {
+          tab: "ops",
+          id: "notes",
+          bindings: { live: { source: "stream", event: "presence" } },
+          outputBinding: "live",
+        }),
+      );
+      expect(updateResult.doc).toMatchObject({
+        tabs: expect.arrayContaining([
+          expect.objectContaining({
+            slug: "ops",
+            widgets: [
+              expect.objectContaining({
+                id: "notes",
+                outputBinding: "live",
+                bindings: { live: { source: "stream", event: "presence" } },
+              }),
+            ],
+          }),
+        ]),
+      });
+      const clearResult = details(
+        await tools.get("workspace_widget_update")?.execute("call-3b", {
+          tab: "ops",
+          id: "notes",
+          bindings: {},
+        }),
+      );
+      const clearedWidget = (clearResult.doc as WorkspaceDoc).tabs
+        .find((tab) => tab.slug === "ops")
+        ?.widgets.find((widget) => widget.id === "notes");
+      expect(clearedWidget?.bindings).toEqual({});
+      expect(clearedWidget).not.toHaveProperty("outputBinding");
+      await tools.get("workspace_widget_move")?.execute("call-4", {
         tab: "ops",
         id: "notes",
         grid: { x: 4, y: 0, w: 4, h: 2 },
       });
       const data = details(
-        await tools.get("workspace_data_read")?.execute("call-4", {
+        await tools.get("workspace_data_read")?.execute("call-5", {
           binding: { source: "static", value: { ok: true } },
         }),
       );
       expect(data).toEqual({ data: { ok: true } });
-      expect(broadcast).toHaveBeenCalledTimes(3);
+      expect(broadcast).toHaveBeenCalledTimes(5);
     });
   });
 

--- a/extensions/workspaces/src/tools.ts
+++ b/extensions/workspaces/src/tools.ts
@@ -6,6 +6,7 @@ import type {
 } from "openclaw/plugin-sdk/plugin-entry";
 import { getPluginRuntimeGatewayRequestScope } from "openclaw/plugin-sdk/plugin-runtime";
 import { Type } from "typebox";
+import { COMPUTED_OPS, STREAM_EVENT_ALLOWLIST } from "./binding-contract.js";
 import { workspaceBroadcast, type WorkspaceBroadcast } from "./broadcast.js";
 import {
   WorkspaceBindingResolutionError,
@@ -106,6 +107,35 @@ const BindingSchema = Type.Union([
     },
     { additionalProperties: false },
   ),
+  Type.Object(
+    {
+      source: Type.Literal("stream"),
+      event: Type.String({
+        enum: [...STREAM_EVENT_ALLOWLIST],
+        description: "Readable gateway event delivered on the Control UI connection.",
+      }),
+      pointer: Type.Optional(Type.String({ description: "Optional JSON pointer." })),
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      source: Type.Literal("computed"),
+      op: Type.String({
+        enum: [...COMPUTED_OPS],
+        description: "Fixed operation; arbitrary expressions are never evaluated.",
+      }),
+      inputs: Type.Array(Type.String(), {
+        minItems: 1,
+        maxItems: 32,
+        description: "Sibling binding ids used as operation inputs.",
+      }),
+      arg: Type.Optional(
+        Type.String({ description: "Required JSON pointer for pick or template for format." }),
+      ),
+    },
+    { additionalProperties: false },
+  ),
 ]);
 const BindingsRecordSchema = Type.Record(Type.String(), BindingSchema, {
   description: "Widget binding map keyed by binding id.",
@@ -117,6 +147,9 @@ const WidgetPatchSchema = Type.Object(
     collapsed: Type.Optional(Type.Boolean({ description: "Collapse widget body." })),
     hidden: Type.Optional(Type.Boolean({ description: "Hide widget." })),
     bindings: Type.Optional(BindingsRecordSchema),
+    outputBinding: Type.Optional(
+      Type.String({ description: "Binding id rendered by the widget; required for 2+ bindings." }),
+    ),
     props: Type.Optional(JsonSchema),
   },
   { additionalProperties: false },
@@ -130,6 +163,9 @@ const WidgetInputSchema = Type.Object(
     collapsed: Type.Optional(Type.Boolean({ description: "Initial collapsed state." })),
     hidden: Type.Optional(Type.Boolean({ description: "Initial hidden state." })),
     bindings: Type.Optional(BindingsRecordSchema),
+    outputBinding: Type.Optional(
+      Type.String({ description: "Binding id rendered by the widget; required for 2+ bindings." }),
+    ),
     props: Type.Optional(JsonSchema),
   },
   { additionalProperties: false },
@@ -334,10 +370,12 @@ function readWidgetInput(
     "collapsed",
     "hidden",
     "bindings",
+    "outputBinding",
     "props",
   ]);
   const title = readOptionalString(record, "title");
   const bindings = readBindings(record.bindings);
+  const outputBinding = readOptionalString(record, "outputBinding");
   return {
     id: makeUniqueWidgetId(record, doc),
     kind: readRequiredString(record, "kind", "kind"),
@@ -347,22 +385,33 @@ function readWidgetInput(
     hidden: readOptionalBoolean(record, "hidden") ?? false,
     createdBy: actor,
     ...(bindings !== undefined ? { bindings } : {}),
+    ...(outputBinding !== undefined ? { outputBinding } : {}),
     ...(record.props !== undefined ? { props: record.props as JsonValue } : {}),
   };
 }
 
 function readWidgetPatch(value: unknown): Partial<WorkspaceWidget> {
-  const record = readRecord(value, ["title", "grid", "collapsed", "hidden", "bindings", "props"]);
+  const record = readRecord(value, [
+    "title",
+    "grid",
+    "collapsed",
+    "hidden",
+    "bindings",
+    "outputBinding",
+    "props",
+  ]);
   const title = readOptionalString(record, "title");
   const collapsed = readOptionalBoolean(record, "collapsed");
   const hidden = readOptionalBoolean(record, "hidden");
   const bindings = readBindings(record.bindings);
+  const outputBinding = readOptionalString(record, "outputBinding");
   return {
     ...(title !== undefined ? { title } : {}),
     ...(record.grid !== undefined ? { grid: readGrid(record.grid) } : {}),
     ...(collapsed !== undefined ? { collapsed } : {}),
     ...(hidden !== undefined ? { hidden } : {}),
     ...(bindings !== undefined ? { bindings } : {}),
+    ...(outputBinding !== undefined ? { outputBinding } : {}),
     ...(record.props !== undefined ? { props: record.props as JsonValue } : {}),
   };
 }
@@ -639,6 +688,7 @@ export function createWorkspaceTools(params: WorkspaceToolParams): AnyAgentTool[
           "collapsed",
           "hidden",
           "bindings",
+          "outputBinding",
           "props",
         ]);
         const tabSlug = readSlug(record, "tab");
@@ -674,6 +724,7 @@ export function createWorkspaceTools(params: WorkspaceToolParams): AnyAgentTool[
           "collapsed",
           "hidden",
           "bindings",
+          "outputBinding",
           "props",
         ]);
         const tabSlug = readSlug(record, "tab");
@@ -687,7 +738,11 @@ export function createWorkspaceTools(params: WorkspaceToolParams): AnyAgentTool[
           ...mutationBase,
           changedTabSlug: tabSlug,
           mutate: (draft) => {
-            Object.assign(findWidget(findTab(draft, tabSlug), id), patch);
+            const widget = findWidget(findTab(draft, tabSlug), id);
+            if (patch.bindings !== undefined && patch.outputBinding === undefined) {
+              delete widget.outputBinding;
+            }
+            Object.assign(widget, patch);
           },
         });
       },
@@ -880,17 +935,18 @@ export function createWorkspaceTools(params: WorkspaceToolParams): AnyAgentTool[
       label: "Workspace Data Read",
       description:
         "Resolve a workspace binding exactly as a widget sees it. `file` and `static` bindings " +
-        'return their data; an `rpc` binding returns { status: "binding_client_resolved" } ' +
-        "because only the trusted Control UI may call the gateway on a widget's behalf.",
+        "return their data; `rpc`, `stream`, and `computed` bindings return " +
+        '{ status: "binding_client_resolved" } because the trusted Control UI owns their ' +
+        "gateway subscription or sibling-value context.",
       parameters: Type.Object({ binding: BindingSchema }, { additionalProperties: false }),
       execute: async (_toolCallId, rawParams) => {
         const record = readRecord(rawParams, ["binding"]);
         try {
           return jsonResult({ data: await resolveBinding(record.binding, params.dataRead) });
         } catch (error) {
-          // `rpc` bindings are resolved by the trusted Control UI over its own
-          // authenticated socket. That is the documented answer, not an error, so
-          // return it as a result the model can act on.
+          // Client-owned bindings need the authenticated socket or sibling values.
+          // That is the documented answer, not an error, so return it as a result
+          // the model can act on.
           if (
             error instanceof WorkspaceBindingResolutionError &&
             error.code === "binding_client_resolved"

--- a/extensions/workspaces/src/ui-gateway-integration.test.ts
+++ b/extensions/workspaces/src/ui-gateway-integration.test.ts
@@ -165,6 +165,12 @@ describe("workspace UI <-> gateway integration seam", () => {
       await loadWorkspace(state, client);
       expect(state.loaded).toBe(true);
       expect(state.error).toBeNull();
+      // Keep capability negotiation on the real UI <-> gateway seam: split unit
+      // tests on either side would both stay green if the wire field drifted.
+      expect(state.bindingContract).toEqual({
+        streamEvents: ["presence", "sessions.changed"],
+        computedOps: ["sum", "avg", "min", "max", "last", "count", "pick", "format"],
+      });
       // Direct real-routing assertion on the get payload (independent of the UI's
       // defensive normalize): the seeded tab/widget survive the round-trip.
       const got = (await client.request("workspaces.get", {})) as { doc: WorkspaceDoc };

--- a/ui/src/lib/workspace/index.test.ts
+++ b/ui/src/lib/workspace/index.test.ts
@@ -18,12 +18,14 @@ import {
   removeWidgetFromTab,
   resolveActiveSlug,
   resolveBinding,
+  resolveComputedBinding,
   setWidgetCollapsed,
   updateWidgetTitle,
   startBindingPolling,
   stopBindingPolling,
   stopWorkspace,
   subscribeToWorkspaceEvents,
+  subscribeToStreamBinding,
   visibleTabs,
 } from "./index.ts";
 
@@ -130,7 +132,14 @@ describe("loadWorkspace", () => {
     const state = getWorkspaceState(host);
     const client = mockClient({
       // Real gateway shape: workspaces.get returns { doc, workspaceVersion }.
-      request: vi.fn(async () => ({ doc: sampleDoc, workspaceVersion: 3 })) as never,
+      request: vi.fn(async () => ({
+        doc: sampleDoc,
+        workspaceVersion: 3,
+        bindingContract: {
+          streamEvents: ["presence", "sessions.changed"],
+          computedOps: ["sum", "count"],
+        },
+      })) as never,
     });
     await loadWorkspace(state, client, { requestedSlug: "archive" });
     expect(state.loaded).toBe(true);
@@ -138,6 +147,10 @@ describe("loadWorkspace", () => {
     expect(state.workspace?.workspaceVersion).toBe(3);
     expect(state.workspace?.tabs).toHaveLength(2);
     expect(state.activeSlug).toBe("archive");
+    expect(state.bindingContract).toEqual({
+      streamEvents: ["presence", "sessions.changed"],
+      computedOps: ["sum", "count"],
+    });
   });
 
   it("records an error on failure", async () => {
@@ -453,6 +466,80 @@ describe("binding resolution", () => {
     });
     const result = await resolveBinding(client, { source: "rpc", method: "x" });
     expect(result).toEqual({ error: "no data" });
+  });
+});
+
+describe("computed binding resolution", () => {
+  it("reduces finite numeric inputs and handles empty reductions", () => {
+    expect(resolveComputedBinding("sum", [[1, 2], 3])).toEqual({ value: 6 });
+    expect(resolveComputedBinding("avg", [1, 2, 3])).toEqual({ value: 2 });
+    expect(resolveComputedBinding("min", [3, 1, 2])).toEqual({ value: 1 });
+    expect(resolveComputedBinding("max", [3, 1, 2])).toEqual({ value: 3 });
+    expect(resolveComputedBinding("sum", [])).toEqual({ value: 0 });
+    expect(resolveComputedBinding("avg", [])).toEqual({ value: null });
+  });
+
+  it("reduces large min/max inputs without spreading them into function arguments", () => {
+    const values = Array.from({ length: 1_000_000 }, (_, index) => index);
+
+    expect(resolveComputedBinding("min", [values])).toEqual({ value: 0 });
+    expect(resolveComputedBinding("max", [values])).toEqual({ value: 999_999 });
+  });
+
+  it("supports count, last, pick, and format without evaluating expressions", () => {
+    expect(resolveComputedBinding("count", [[1, 2, 3], 4])).toEqual({ value: 4 });
+    expect(resolveComputedBinding("last", [1, "final"])).toEqual({ value: "final" });
+    expect(resolveComputedBinding("pick", [{ a: { b: 7 } }], "/a/b")).toEqual({ value: 7 });
+    expect(resolveComputedBinding("format", [42, { unit: "USD" }], "{0} {1}")).toEqual({
+      value: '42 {"unit":"USD"}',
+    });
+  });
+
+  it("returns an error for unknown operations", () => {
+    expect(resolveComputedBinding("eval", [1])).toEqual({
+      error: expect.stringContaining("Unknown computed op"),
+    });
+  });
+});
+
+describe("stream binding subscription", () => {
+  it("pushes matching event payloads with the pointer applied and unsubscribes", () => {
+    let listener: GatewayEventListener | null = null;
+    const unsubscribe = vi.fn();
+    const client = mockClient({
+      addEventListener: vi.fn((next: GatewayEventListener) => {
+        listener = next;
+        return unsubscribe;
+      }) as never,
+    });
+    const results: unknown[] = [];
+    const dispose = subscribeToStreamBinding(
+      client,
+      { source: "stream", event: "presence", pointer: "/online" } as never,
+      ["presence", "sessions.changed"],
+      (result) => results.push(result),
+    );
+
+    listener!({ type: "event", event: "presence", payload: { online: 5 } });
+    listener!({ type: "event", event: "sessions.changed", payload: { online: 9 } });
+    expect(results).toEqual([{ value: 5 }]);
+
+    dispose();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it("refuses a non-allowlisted event without subscribing", () => {
+    const addEventListener = vi.fn(() => () => {});
+    const client = mockClient({ addEventListener: addEventListener as never });
+
+    subscribeToStreamBinding(
+      client,
+      { source: "stream", event: "plugin.workspaces.changed" } as never,
+      ["presence", "sessions.changed"],
+      () => {},
+    );
+
+    expect(addEventListener).not.toHaveBeenCalled();
   });
 });
 

--- a/ui/src/lib/workspace/index.ts
+++ b/ui/src/lib/workspace/index.ts
@@ -11,6 +11,7 @@ import {
   WORKSPACE_GRID_COLUMNS,
   workspaceAgentProvenance,
   type WorkspaceBinding,
+  type WorkspaceBindingContract,
   type WorkspaceChangedEvent,
   type WorkspaceGridRect,
   type WorkspaceTab,
@@ -27,6 +28,8 @@ export type WorkspaceUiState = {
   loaded: boolean;
   error: string | null;
   workspace: WorkspaceDocument | null;
+  /** Plugin-owned capabilities from `workspaces.get`; empty means fail closed. */
+  bindingContract: WorkspaceBindingContract;
   /** Slug of the workspace tab in view; null until the doc resolves a default. */
   activeSlug: string | null;
   /** Whether the hidden-tabs overflow menu is open. */
@@ -90,6 +93,7 @@ export function getWorkspaceState(host: WorkspaceHost): WorkspaceUiState {
       loaded: false,
       error: null,
       workspace: null,
+      bindingContract: { streamEvents: [], computedOps: [] },
       activeSlug: null,
       hiddenMenuOpen: false,
       pendingWidgetIds: new Set(),
@@ -131,7 +135,13 @@ function normalizeBinding(value: unknown): WorkspaceBinding | null {
     return null;
   }
   const source = value.source;
-  if (source !== "rpc" && source !== "file" && source !== "static") {
+  if (
+    source !== "rpc" &&
+    source !== "file" &&
+    source !== "static" &&
+    source !== "stream" &&
+    source !== "computed"
+  ) {
     return null;
   }
   return {
@@ -141,6 +151,12 @@ function normalizeBinding(value: unknown): WorkspaceBinding | null {
     ...(typeof value.pointer === "string" ? { pointer: value.pointer } : {}),
     ...(isRecord(value.params) ? { params: value.params } : {}),
     ...("value" in value ? { value: value.value } : {}),
+    ...(typeof value.event === "string" ? { event: value.event } : {}),
+    ...(typeof value.op === "string" ? { op: value.op } : {}),
+    ...(Array.isArray(value.inputs)
+      ? { inputs: value.inputs.filter((input): input is string => typeof input === "string") }
+      : {}),
+    ...(typeof value.arg === "string" ? { arg: value.arg } : {}),
   };
 }
 
@@ -175,7 +191,22 @@ function normalizeWidget(value: unknown): WorkspaceWidget | null {
     collapsed: value.collapsed === true,
     ...(typeof value.createdBy === "string" ? { createdBy: value.createdBy } : {}),
     ...(normalizeBindings(value.bindings) ? { bindings: normalizeBindings(value.bindings) } : {}),
+    ...(typeof value.outputBinding === "string" ? { outputBinding: value.outputBinding } : {}),
     ...(isRecord(value.props) ? { props: value.props } : {}),
+  };
+}
+
+function normalizeStringList(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}
+
+function normalizeBindingContract(value: unknown): WorkspaceBindingContract {
+  const record = isRecord(value) ? value : {};
+  return {
+    streamEvents: normalizeStringList(record.streamEvents),
+    computedOps: normalizeStringList(record.computedOps),
   };
 }
 
@@ -366,6 +397,9 @@ export async function loadWorkspace(
       // workspaces.get responds { doc, workspaceVersion } — read `doc`
       // (a bare payload is tolerated for forward-compat).
       isRecord(payload) && "doc" in payload ? payload.doc : payload,
+    );
+    state.bindingContract = normalizeBindingContract(
+      isRecord(payload) ? payload.bindingContract : undefined,
     );
     state.workspace = workspace;
     state.activeSlug = resolveActiveSlug(workspace, opts?.requestedSlug ?? state.activeSlug);
@@ -741,6 +775,12 @@ export async function resolveBinding(
       const value = await client.request(binding.method, params);
       return { value: applyPointer(value, binding.pointer) };
     }
+    if (binding.source === "stream") {
+      return { error: "Stream bindings resolve via subscription, not a one-shot read." };
+    }
+    if (binding.source === "computed") {
+      return { error: "Computed bindings resolve from sibling values, not a one-shot read." };
+    }
     // file: `workspaces.data.read` accepts ONLY a `binding` param (its readParams
     // whitelist rejects anything else), and it resolves the file AND applies the
     // JSON pointer server-side, returning the final value under `data`. So we send
@@ -774,6 +814,106 @@ export function applyPointer(value: unknown, pointer: string | undefined): unkno
     }
   }
   return current;
+}
+
+function collectNumbers(value: unknown, numbers: number[]): void {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    numbers.push(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      collectNumbers(entry, numbers);
+    }
+  }
+}
+
+function countElements(value: unknown): number {
+  if (Array.isArray(value)) {
+    return value.length;
+  }
+  return value === undefined || value === null ? 0 : 1;
+}
+
+function formatComputed(template: string, values: unknown[]): string {
+  return template.replace(/\{(\d+)\}/g, (_match, digits: string) => {
+    const value = values[Number(digits)];
+    if (typeof value === "string") {
+      return value;
+    }
+    if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+      return String(value);
+    }
+    return value === undefined || value === null ? "" : (JSON.stringify(value) ?? "");
+  });
+}
+
+/** Derive a computed value through a fixed operation switch; no expressions are evaluated. */
+export function resolveComputedBinding(
+  op: string,
+  inputValues: unknown[],
+  arg?: string,
+): WorkspaceBindingResult {
+  switch (op) {
+    case "sum":
+    case "avg":
+    case "min":
+    case "max": {
+      const numbers: number[] = [];
+      for (const value of inputValues) {
+        collectNumbers(value, numbers);
+      }
+      if (op === "sum") {
+        return { value: numbers.reduce((total, value) => total + value, 0) };
+      }
+      if (numbers.length === 0) {
+        return { value: null };
+      }
+      if (op === "avg") {
+        return { value: numbers.reduce((total, value) => total + value, 0) / numbers.length };
+      }
+      return {
+        value: numbers.reduce((result, value) =>
+          op === "min" ? Math.min(result, value) : Math.max(result, value),
+        ),
+      };
+    }
+    case "count":
+      return {
+        value: inputValues.reduce<number>((total, value) => total + countElements(value), 0),
+      };
+    case "last":
+      return { value: inputValues.length ? inputValues[inputValues.length - 1] : null };
+    case "pick":
+      return { value: applyPointer(inputValues[0], arg) };
+    case "format":
+      return { value: formatComputed(arg ?? "", inputValues) };
+    default:
+      return { error: `Unknown computed op: ${op}` };
+  }
+}
+
+/** Subscribe to an allowlisted event on the Control UI's existing gateway connection. */
+export function subscribeToStreamBinding(
+  client: GatewayBrowserClient | null,
+  binding: WorkspaceBinding,
+  allowedEvents: readonly string[],
+  onValue: (result: WorkspaceBindingResult) => void,
+): () => void {
+  const event = binding.event;
+  if (!client || !event || !allowedEvents.includes(event)) {
+    return () => {};
+  }
+  return client.addEventListener((frame: GatewayEventFrame) => {
+    if (frame.event !== event) {
+      return;
+    }
+    try {
+      onValue({ value: applyPointer(frame.payload, binding.pointer) });
+    } catch (error) {
+      onValue({ error: formatError(error) });
+    }
+  });
 }
 
 export { workspaceAgentProvenance };

--- a/ui/src/lib/workspace/types.ts
+++ b/ui/src/lib/workspace/types.ts
@@ -13,7 +13,7 @@ export type WorkspaceCreatedBy = string;
 
 export type WorkspaceWidgetKind = string;
 
-export type WorkspaceBindingSource = "rpc" | "file" | "static";
+export type WorkspaceBindingSource = "rpc" | "file" | "static" | "stream" | "computed";
 
 export type WorkspaceBinding = {
   source: WorkspaceBindingSource;
@@ -26,6 +26,13 @@ export type WorkspaceBinding = {
   params?: Record<string, unknown>;
   /** `static` bindings carry their value inline. */
   value?: unknown;
+  /** `stream` bindings consume an allowlisted gateway broadcast. */
+  event?: string;
+  /** `computed` bindings derive a value from sibling binding ids. */
+  op?: string;
+  inputs?: string[];
+  /** Argument for the `pick` and `format` computed operations. */
+  arg?: string;
 };
 
 export type WorkspaceGridRect = {
@@ -43,7 +50,14 @@ export type WorkspaceWidget = {
   collapsed: boolean;
   createdBy?: WorkspaceCreatedBy;
   bindings?: Record<string, WorkspaceBinding>;
+  outputBinding?: string;
   props?: Record<string, unknown>;
+};
+
+/** Server-owned binding capabilities returned alongside the persisted document. */
+export type WorkspaceBindingContract = {
+  streamEvents: string[];
+  computedOps: string[];
 };
 
 export type WorkspaceTab = {

--- a/ui/src/pages/plugin/workspace-view.test.ts
+++ b/ui/src/pages/plugin/workspace-view.test.ts
@@ -1,6 +1,6 @@
 import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { GatewayBrowserClient, GatewayEventListener } from "../../api/gateway.ts";
 import { getWorkspaceState } from "../../lib/workspace/index.ts";
 import { stopWorkspace } from "./workspace-controller.ts";
 import {
@@ -147,6 +147,10 @@ describe("renderWorkspace", () => {
     const state = getWorkspaceState(host);
     state.loaded = true;
     state.activeSlug = "main";
+    state.bindingContract = {
+      streamEvents: ["presence", "sessions.changed"],
+      computedOps: ["sum", "avg", "min", "max", "last", "count", "pick", "format"],
+    };
     state.workspace = {
       schemaVersion: 1,
       workspaceVersion: 1,
@@ -192,6 +196,147 @@ describe("renderWorkspace", () => {
       expect(host.querySelector(".workspace-stat__value")?.textContent).toBe("2");
     } finally {
       stopWorkspace(host);
+      host.remove();
+    }
+  });
+
+  it("renders a computed primary binding from static sibling bindings", async () => {
+    const host = document.createElement("div");
+    document.body.append(host);
+    const state = getWorkspaceState(host);
+    state.loaded = true;
+    state.activeSlug = "main";
+    state.bindingContract = {
+      streamEvents: ["presence", "sessions.changed"],
+      computedOps: ["sum", "avg", "min", "max", "last", "count", "pick", "format"],
+    };
+    state.workspace = {
+      schemaVersion: 1,
+      workspaceVersion: 1,
+      tabs: [
+        {
+          slug: "main",
+          title: "Main",
+          hidden: false,
+          widgets: [
+            {
+              id: "total",
+              kind: "builtin:stat-card",
+              title: "Total",
+              grid: { x: 0, y: 0, w: 4, h: 2 },
+              collapsed: false,
+              bindings: {
+                a: { source: "static", value: 2 },
+                b: { source: "static", value: 3 },
+                value: { source: "computed", op: "sum", inputs: ["a", "b"] },
+              },
+              outputBinding: "value",
+            },
+          ],
+        },
+      ],
+      widgetsRegistry: {},
+      prefs: { tabOrder: ["main"] },
+    } as never;
+
+    try {
+      render(renderWorkspace({ host, client: null, connected: true }), host);
+      await vi.waitFor(() => {
+        render(renderWorkspace({ host, client: null, connected: true }), host);
+        expect(host.querySelector(".workspace-stat__value")?.textContent).toBe("5");
+      });
+    } finally {
+      stopWorkspace(host);
+      host.remove();
+    }
+  });
+
+  it("renders pushed stream values without resubscribing on a polling refresh", async () => {
+    const host = document.createElement("div");
+    document.body.append(host);
+    const listeners: GatewayEventListener[] = [];
+    const unsubscribers: Array<ReturnType<typeof vi.fn>> = [];
+    let nextWorkspace: unknown;
+    const addEventListener = vi.fn((next: GatewayEventListener) => {
+      listeners.push(next);
+      const unsubscribe = vi.fn();
+      unsubscribers.push(unsubscribe);
+      return unsubscribe;
+    });
+    const client = {
+      request: vi.fn(async () => ({
+        doc: nextWorkspace,
+        bindingContract: {
+          streamEvents: ["presence", "sessions.changed"],
+          computedOps: ["sum", "avg", "min", "max", "last", "count", "pick", "format"],
+        },
+      })),
+      addEventListener,
+    } as unknown as GatewayBrowserClient;
+    const state = getWorkspaceState(host);
+    state.loaded = true;
+    state.activeSlug = "main";
+    state.bindingContract = {
+      streamEvents: ["presence", "sessions.changed"],
+      computedOps: ["sum", "avg", "min", "max", "last", "count", "pick", "format"],
+    };
+    state.workspace = {
+      schemaVersion: 1,
+      workspaceVersion: 1,
+      tabs: [
+        {
+          slug: "main",
+          title: "Main",
+          hidden: false,
+          widgets: [
+            {
+              id: "online",
+              kind: "builtin:stat-card",
+              title: "Online",
+              grid: { x: 0, y: 0, w: 4, h: 2 },
+              collapsed: false,
+              bindings: {
+                value: { source: "stream", event: "presence", pointer: "/online" },
+              },
+            },
+          ],
+        },
+      ],
+      widgetsRegistry: {},
+      prefs: { tabOrder: ["main"] },
+    } as never;
+
+    try {
+      render(renderWorkspace({ host, client, connected: true }), host);
+      // One document-change listener plus one stream listener.
+      expect(addEventListener).toHaveBeenCalledTimes(2);
+      for (const listener of listeners) {
+        listener({ type: "event", event: "presence", payload: { online: 8 } });
+      }
+      render(renderWorkspace({ host, client, connected: true }), host);
+      expect(host.querySelector(".workspace-stat__value")?.textContent).toBe("8");
+
+      bumpWorkspaceDataVersion(host);
+      render(renderWorkspace({ host, client, connected: true }), host);
+      expect(addEventListener).toHaveBeenCalledTimes(2);
+
+      nextWorkspace = { ...(state.workspace as object), workspaceVersion: 2 };
+      for (const listener of listeners) {
+        listener({
+          type: "event",
+          event: "plugin.workspaces.changed",
+          payload: { workspaceVersion: 2 },
+        });
+      }
+      await vi.waitFor(() => expect(state.workspace?.workspaceVersion).toBe(2));
+      render(renderWorkspace({ host, client, connected: true }), host);
+      expect(host.querySelector(".workspace-stat__value")?.textContent).toBe("8");
+      expect(addEventListener).toHaveBeenCalledTimes(2);
+    } finally {
+      stopWorkspace(host);
+      for (const unsubscribe of unsubscribers) {
+        expect(unsubscribe).toHaveBeenCalledOnce();
+      }
       host.remove();
     }
   });

--- a/ui/src/pages/plugin/workspace-view.ts
+++ b/ui/src/pages/plugin/workspace-view.ts
@@ -45,9 +45,11 @@ import {
   resolveActiveSlug,
   registerActiveDrag,
   resolveBinding,
+  resolveComputedBinding,
   setWidgetCollapsed,
   startBindingPolling,
   subscribeToWorkspaceEvents,
+  subscribeToStreamBinding,
   updateWidgetTitle,
   visibleTabs,
   type WorkspaceBindingResult,
@@ -92,6 +94,10 @@ type WorkspaceViewState = {
   bindingResults: Map<string, WorkspaceBindingResult>;
   bindingLoads: Set<string>;
   bindingVersion: number;
+  /** Live stream subscriptions are versioned by the document, not polling ticks. */
+  streamSubscriptions: Map<string, StreamSubscription>;
+  /** Latest pushed value, retained when polling clears one-shot binding results. */
+  streamValues: Map<string, WorkspaceBindingResult>;
   /** Loaded custom-widget manifests keyed by widget name for one workspace version. */
   manifestCache: Map<string, WidgetManifestView>;
   manifestLoads: Set<string>;
@@ -108,6 +114,12 @@ type WorkspaceViewState = {
   dialog: WorkspaceDialogState | null;
   /** First-visit onboarding banner dismissed this session (#5); mirrors localStorage. */
   onboardingDismissed: boolean;
+};
+
+type StreamSubscription = {
+  event: string;
+  pointer?: string;
+  unsubscribe: () => void;
 };
 
 /** localStorage flag so the first-visit onboarding banner (#5) stays dismissed across reloads. */
@@ -205,9 +217,21 @@ function syncMenuDismiss(
   workspaceMenuDismiss.set(host, { onPointerDown, onKeyDown });
 }
 
-/** View-level teardown: drop any menu-dismiss listeners. Called from the controller's stop. */
+/** View-level teardown for document listeners and live data subscriptions. */
 export function stopWorkspaceView(host: object): void {
   teardownMenuDismiss(host);
+  teardownStreamSubscriptions(host);
+}
+
+function teardownStreamSubscriptions(host: object): void {
+  const state = workspaceViewStates.get(host);
+  if (!state) {
+    return;
+  }
+  for (const subscription of state.streamSubscriptions.values()) {
+    subscription.unsubscribe();
+  }
+  state.streamSubscriptions.clear();
 }
 
 function getViewState(host: object): WorkspaceViewState {
@@ -219,6 +243,8 @@ function getViewState(host: object): WorkspaceViewState {
       bindingResults: new Map(),
       bindingLoads: new Set(),
       bindingVersion: -1,
+      streamSubscriptions: new Map(),
+      streamValues: new Map(),
       manifestCache: new Map(),
       manifestLoads: new Set(),
       manifestVersion: -1,
@@ -256,14 +282,17 @@ export function navigateToWorkspaceTab(slug: string): void {
   window.dispatchEvent(new PopStateEvent("popstate"));
 }
 
-/** Primary binding for a widget (first declared), if any. */
+/** Resolve the server-validated output contract without relying on object insertion order. */
 function primaryBinding(widget: WorkspaceWidget): WorkspaceBinding | null {
   const bindings = widget.bindings;
   if (!bindings) {
     return null;
   }
-  const first = Object.values(bindings)[0];
-  return first ?? null;
+  if (widget.outputBinding) {
+    return bindings[widget.outputBinding] ?? null;
+  }
+  const values = Object.values(bindings);
+  return values.length === 1 ? (values[0] ?? null) : null;
 }
 
 /**
@@ -275,12 +304,91 @@ function bindingCacheKey(workspace: WorkspaceDocument, viewState: WorkspaceViewS
   return workspace.workspaceVersion * 1_000_003 + viewState.dataVersion;
 }
 
+function reconcileStreamSubscriptions(
+  viewState: WorkspaceViewState,
+  client: GatewayBrowserClient | null,
+  tab: WorkspaceTab,
+  allowedEvents: readonly string[],
+  requestUpdate: (() => void) | null,
+): void {
+  if (!client) {
+    for (const subscription of viewState.streamSubscriptions.values()) {
+      subscription.unsubscribe();
+    }
+    viewState.streamSubscriptions.clear();
+    return;
+  }
+
+  const wanted = new Map<string, WorkspaceBinding>();
+  for (const widget of tab.widgets) {
+    const binding = primaryBinding(widget);
+    if (binding?.source === "stream" && binding.event && allowedEvents.includes(binding.event)) {
+      wanted.set(widget.id, binding);
+    }
+  }
+
+  for (const [widgetId, subscription] of viewState.streamSubscriptions) {
+    const binding = wanted.get(widgetId);
+    if (
+      !binding ||
+      subscription.event !== binding.event ||
+      subscription.pointer !== binding.pointer
+    ) {
+      subscription.unsubscribe();
+      viewState.streamSubscriptions.delete(widgetId);
+      viewState.streamValues.delete(widgetId);
+    }
+  }
+
+  for (const [widgetId, binding] of wanted) {
+    if (viewState.streamSubscriptions.has(widgetId)) {
+      continue;
+    }
+    const unsubscribe = subscribeToStreamBinding(client, binding, allowedEvents, (result) => {
+      viewState.streamValues.set(widgetId, result);
+      viewState.bindingResults.set(widgetId, result);
+      requestUpdate?.();
+    });
+    viewState.streamSubscriptions.set(widgetId, {
+      event: binding.event as string,
+      ...(binding.pointer !== undefined ? { pointer: binding.pointer } : {}),
+      unsubscribe,
+    });
+  }
+}
+
+async function resolveComputedForWidget(
+  client: GatewayBrowserClient | null,
+  widget: WorkspaceWidget,
+  binding: WorkspaceBinding,
+  allowedOps: readonly string[],
+): Promise<WorkspaceBindingResult> {
+  if (!binding.op || !allowedOps.includes(binding.op)) {
+    return { error: `Computed op is not advertised by the workspace server: ${binding.op ?? ""}` };
+  }
+  const siblings = widget.bindings ?? {};
+  const values: unknown[] = [];
+  for (const inputId of binding.inputs ?? []) {
+    const input = siblings[inputId];
+    if (!input) {
+      return { error: `Computed input not found: ${inputId}` };
+    }
+    const result = await resolveBinding(client, input);
+    if ("error" in result) {
+      return result;
+    }
+    values.push(result.value);
+  }
+  return resolveComputedBinding(binding.op ?? "", values, binding.arg);
+}
+
 /** Kick off binding resolution for widgets on the active tab; cache per version. */
 function ensureBindings(
   viewState: WorkspaceViewState,
   client: GatewayBrowserClient | null,
   workspace: WorkspaceDocument,
   tab: WorkspaceTab,
+  bindingContract: WorkspaceUiState["bindingContract"],
   requestUpdate: (() => void) | null,
 ): void {
   const key = bindingCacheKey(workspace, viewState);
@@ -289,6 +397,7 @@ function ensureBindings(
     viewState.bindingLoads.clear();
     viewState.bindingVersion = key;
   }
+  reconcileStreamSubscriptions(viewState, client, tab, bindingContract.streamEvents, requestUpdate);
   for (const widget of tab.widgets) {
     const binding = primaryBinding(widget);
     if (
@@ -298,8 +407,19 @@ function ensureBindings(
     ) {
       continue;
     }
+    if (binding.source === "stream") {
+      const streamed = viewState.streamValues.get(widget.id);
+      if (streamed) {
+        viewState.bindingResults.set(widget.id, streamed);
+      }
+      continue;
+    }
     viewState.bindingLoads.add(widget.id);
-    void resolveBinding(client, binding).then((result) => {
+    const pending =
+      binding.source === "computed"
+        ? resolveComputedForWidget(client, widget, binding, bindingContract.computedOps)
+        : resolveBinding(client, binding);
+    void pending.then((result) => {
       if (viewState.bindingVersion !== key) {
         return;
       }
@@ -551,7 +671,14 @@ function renderGrid(
   workspace: WorkspaceDocument,
   tab: WorkspaceTab,
 ): TemplateResult {
-  ensureBindings(viewState, props.client, workspace, tab, props.onRequestUpdate ?? null);
+  ensureBindings(
+    viewState,
+    props.client,
+    workspace,
+    tab,
+    state.bindingContract,
+    props.onRequestUpdate ?? null,
+  );
   ensureManifests(viewState, props, workspace, tab);
   if (tab.widgets.length === 0) {
     // #15: dashed placeholder card with an icon so an empty tab reads as an


### PR DESCRIPTION
## What Problem This Solves

Workspaces could read one-shot RPC, file, and static values, but could not express live socket-backed values or safe client-side derivations. The original #101878 implementation was tied to the superseded Dashboard stack and left its new kinds inaccessible or ambiguous on current authoring surfaces.

## Why This Change Was Made

This rebuild ports only the binding-kind delta onto the Workspaces architecture landed by #104139. It adds allowlisted `stream` bindings, fixed-operation `computed` bindings, and an explicit `outputBinding` so rendering never depends on object insertion order.

The server returns the binding contract consumed by the UI, while the gateway seam has a real integration test to prevent drift. CLI and agent tools can author both kinds. Stream events are limited to channels visible to read-scoped clients (`presence` and `sessions.changed`); write-scoped workspace-change broadcasts are not advertised. Computed expressions use a closed operation switch and may reference only validated non-computed, non-stream sibling inputs.

## User Impact

- Workspace widgets can update from approved live events without polling when a readable event exists.
- Widgets can derive sums, averages, minimums, maximums, counts, last values, JSON-pointer picks, and fixed-format output without `eval` or arbitrary code.
- Multiple bindings require an explicit output, and existing multi-binding documents migrate their prior first-binding choice once.
- Poll and refetch cycles preserve current stream values instead of blanking the widget.

## Evidence

- Rebased onto upstream main at `a03df5fd5898e24facd38c07d9d9e60a047f0111`; the second commit is patch-equivalent and the first differs only by preserving current main's private `WorkspaceBindingErrorCode` while retaining the stream/computed contracts.
- Final-head focused Vitest: 8 files / 107 tests passed across schema, data reads, CLI, tools, gateway contract, UI normalization, and workspace rendering.
- Extension and UI typechecks, scoped formatting, scoped lint with warnings denied, and `git diff --check` passed.
- Repository-wide validation remains GitHub Actions' responsibility.
- Repository autoreview: clean, no accepted/actionable findings.
- No GitNexus refresh or reset was performed.

Closes #101150.
