### PR TITLE
Add Claw lifecycle CLI e2e coverage

### DIFF
--- a/src/claws/lifecycle.e2e.test.ts
+++ b/src/claws/lifecycle.e2e.test.ts
@@ -1,0 +1,143 @@
+// E2E coverage for the staged Claw lifecycle CLI flow.
+import { execFile } from "node:child_process";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+async function runOpenClaw(args: string[], options?: { expectFailure?: boolean }) {
+  const stateDir = await mkdtemp(join(tmpdir(), "openclaw-claws-lifecycle-e2e-"));
+  const env = {
+    ...process.env,
+    HOME: stateDir,
+    USERPROFILE: stateDir,
+    OPENCLAW_CONFIG_PATH: join(stateDir, "openclaw.json"),
+    OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+    OPENCLAW_HOME: stateDir,
+    OPENCLAW_STATE_DIR: stateDir,
+    OPENCLAW_TEST_FAST: "1",
+    OPENCLAW_TEST_RUNTIME_LOG: "1",
+    VITEST: "",
+  };
+  try {
+    const result = await execFileAsync(
+      process.execPath,
+      ["--import", "tsx", "src/entry.ts", ...args],
+      {
+        cwd: process.cwd(),
+        env,
+        maxBuffer: 1024 * 1024,
+      },
+    );
+    if (options?.expectFailure) {
+      throw new Error(`expected command to fail: ${args.join(" ")}`);
+    }
+    return { ok: true as const, stdout: result.stdout, stderr: result.stderr };
+  } catch (error) {
+    if (!options?.expectFailure) {
+      throw error;
+    }
+    const failed = error as Error & { stdout?: string; stderr?: string; code?: number };
+    return {
+      ok: false as const,
+      code: failed.code,
+      stdout: failed.stdout ?? "",
+      stderr: failed.stderr ?? "",
+    };
+  }
+}
+
+function parseJson(stdout: string): unknown {
+  const trimmed = stdout.trim();
+  expect(trimmed.length).toBeGreaterThan(0);
+  return JSON.parse(trimmed);
+}
+
+describe("claws lifecycle cli e2e", () => {
+  it("runs inspect, plan, and dry-run apply for a local Claw manifest", async () => {
+    const manifestPath = "src/claws/fixtures/incident-response.claw.json";
+
+    const inspect = parseJson(
+      (await runOpenClaw(["claws", "inspect", manifestPath, "--json"])).stdout,
+    );
+    expect(inspect).toMatchObject({
+      valid: true,
+      manifest: { id: "incident-response", entries: expect.any(Array) },
+    });
+
+    const plan = parseJson(
+      (await runOpenClaw(["claws", "plan", manifestPath, "--json"])).stdout,
+    );
+    expect(plan).toMatchObject({
+      schemaVersion: "openclaw.clawPlan.v1",
+      readOnly: true,
+      summary: { totalEntries: 5, requiresConsent: 2, unsupportedRequiredEntries: 0 },
+    });
+
+    const apply = parseJson(
+      (await runOpenClaw(["claws", "apply", manifestPath, "--dry-run", "--json"])).stdout,
+    );
+    expect(apply).toMatchObject({
+      schemaVersion: "openclaw.clawApplyPlan.v1",
+      dryRun: true,
+      mutationAllowed: false,
+      summary: {
+        totalEntries: 5,
+        installActions: 5,
+        consentRequired: 2,
+        blockedEntries: 0,
+        provenanceRecords: 5,
+        rollbackActions: 5,
+      },
+    });
+  });
+
+  it("runs feed plan and feed dry-run apply from the local feed fixture", async () => {
+    const feedPath = "src/claws/fixtures/local-claws.feed.json";
+
+    const plan = parseJson(
+      (await runOpenClaw(["claws", "feed", "plan", feedPath, "incident-response", "--json"]))
+        .stdout,
+    );
+    expect(plan).toMatchObject({
+      schemaVersion: "openclaw.clawPlan.v1",
+      feed: { id: "local-starter-claws", entry: { id: "incident-response" } },
+      summary: { totalEntries: 5, requiresConsent: 2 },
+    });
+
+    const apply = parseJson(
+      (
+        await runOpenClaw([
+          "claws",
+          "feed",
+          "apply",
+          feedPath,
+          "incident-response",
+          "--dry-run",
+          "--json",
+        ])
+      ).stdout,
+    );
+    expect(apply).toMatchObject({
+      schemaVersion: "openclaw.clawApplyPlan.v1",
+      dryRun: true,
+      mutationAllowed: false,
+      feed: { id: "local-starter-claws", entry: { id: "incident-response" } },
+      summary: { totalEntries: 5, consentRequired: 2, blockedEntries: 0 },
+    });
+  });
+
+  it("fails closed when apply is invoked without --dry-run", async () => {
+    const result = await runOpenClaw(
+      ["claws", "apply", "src/claws/fixtures/incident-response.claw.json"],
+      { expectFailure: true },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("Claw apply is dry-run only");
+  });
+});


### PR DESCRIPTION
## Summary
- adds an E2E test that runs the staged Claw lifecycle through the real `src/entry.ts` CLI entrypoint
- covers local `claws inspect`, `claws plan`, `claws apply --dry-run`, feed `plan`, feed `apply --dry-run`, and fail-closed non-dry-run `apply`
- isolates child CLI state/config/home paths so the proof does not depend on developer or CI config

Stack/RFC:
- RFC: https://github.com/openclaw/rfcs/pull/27
- Depends on PR5: https://github.com/openclaw/openclaw/pull/101874
- Depends on PR4: https://github.com/openclaw/openclaw/pull/101842
- Follows PR3: https://github.com/openclaw/openclaw/pull/101755
- Follows PR2: https://github.com/openclaw/openclaw/pull/101328

## Intentional boundaries
- proof-only slice for the lifecycle commands added in PR5
- no install/apply mutation, artifact fetch, workspace write, automation enablement, provenance persistence, rollback execution, remote feed fetch, or Gateway state change

## Validation
- `node scripts/run-vitest.mjs src/claws/schema.test.ts src/cli/claws-cli.test.ts src/claws/lifecycle.e2e.test.ts`
- `node scripts/run-vitest.mjs src/claws/lifecycle.e2e.test.ts`
- `git diff --check`
- `node scripts/check-no-conflict-markers.mjs`
- `codex review -c model=gpt-5.5 --base origin/user/giodl/claws-pr5-lifecycle-plan` - clean after fixing inherited config-path isolation in the spawned CLI environment

## Real behavior proof
The E2E test invokes:
```bash
node --import tsx src/entry.ts claws inspect src/claws/fixtures/incident-response.claw.json --json
node --import tsx src/entry.ts claws plan src/claws/fixtures/incident-response.claw.json --json
node --import tsx src/entry.ts claws apply src/claws/fixtures/incident-response.claw.json --dry-run --json
node --import tsx src/entry.ts claws feed plan src/claws/fixtures/local-claws.feed.json incident-response --json
node --import tsx src/entry.ts claws feed apply src/claws/fixtures/local-claws.feed.json incident-response --dry-run --json
node --import tsx src/entry.ts claws apply src/claws/fixtures/incident-response.claw.json
```

The child process environment pins temp `HOME`, `USERPROFILE`, `OPENCLAW_CONFIG_PATH`, `OPENCLAW_HOME`, and `OPENCLAW_STATE_DIR`, disables bundled plugins, and enables `OPENCLAW_TEST_FAST=1`.

Observed test result:
```text
src/claws/lifecycle.e2e.test.ts: 3 tests passed
combined focused run: 29 tests passed across schema, CLI, and lifecycle E2E shards
```
