### PR TITLE
fix(tests): pin plugin temp-dir assertions to resolvePreferredOpenClawTmpDir() (#101876)

### DIFF
--- a/src/plugins/git-install.test.ts
+++ b/src/plugins/git-install.test.ts
@@ -7,6 +7,7 @@ import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensit
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { DiagnosticSecurityEvent } from "../infra/diagnostic-events.js";
+import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 
 const runCommandWithTimeoutMock = vi.fn();
 const installPluginFromInstalledPackageDirMock = vi.fn();
@@ -568,7 +569,9 @@ describe("installPluginFromGitSpec", () => {
         normalizedSpec: "git:https://github.com/acme/demo.git",
       });
       expect(path.dirname(targetPrefix)).toBe(await fs.realpath(path.dirname(persistentRepoDir)));
-      expect(path.dirname(fallbackPrefix)).toBe(await fs.realpath(os.tmpdir()));
+      expect(path.dirname(fallbackPrefix)).toBe(
+        await fs.realpath(resolvePreferredOpenClawTmpDir()),
+      );
       expect(runCommandWithTimeoutMock).toHaveBeenCalledTimes(3);
     } finally {
       mkdtempSpy.mockRestore();


### PR DESCRIPTION
Refs #101876

## Scope

The issue lumps three separate test failures together, but only **one** of them is actually the `os.tmpdir()` assertion mismatch described in the title. This PR fixes that one. The other two failures have unrelated root causes (details below) and I recommend splitting them into their own issues.

## What this PR fixes

`src/plugins/git-install.test.ts > installPluginFromGitSpec > falls back to OS temp when target workspace creation fails` hard-coded `os.tmpdir()` in its assertion:

```ts
expect(path.dirname(fallbackPrefix)).toBe(await fs.realpath(os.tmpdir()));
```

`withTempDir` (`src/infra/install-source-utils.ts`) actually defaults its root to `resolvePreferredOpenClawTmpDir()` (`src/infra/tmp-openclaw-dir.ts`), which on POSIX prefers `/tmp/openclaw` whenever ownership/permissions are safe and only falls back to `os.tmpdir()` when unsafe. The assertion therefore only holds on hosts where `/tmp/openclaw` resolves *unsafe*, i.e. it encodes the environment rather than the contract.

Fix: pin the assertion (and add the import) to the same resolver the production code uses:

```ts
import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
// ...
expect(path.dirname(fallbackPrefix)).toBe(
  await fs.realpath(resolvePreferredOpenClawTmpDir()),
);
```

## Verification

```
node scripts/run-vitest.mjs src/plugins/git-install.test.ts
# Test Files  1 passed (1)
#      Tests  23 passed (23)
```

Repro'd the original failure on macOS with `/tmp/openclaw` present, applied the fix, all 23 tests pass.

## What this PR does NOT fix (please split into separate issues)

Both of these fail on the same host but are **not** `os.tmpdir()` assertion errors — they surface only because vitest keeps running past the git-install failure:

### 1. `src/plugins/manifest-model-id-normalization.test.ts > manifest model id normalization > reuses manifest metadata while file fingerprints are unchanged`

```
AssertionError: expected [ Array(140) ] to have a length of 1 but got 140
  at src/plugins/manifest-model-id-normalization.test.ts:341
      expect(listOpenClawPluginManifestMetadata(process.env)).toHaveLength(1);
```

Root cause: the test seeds a per-test `OPENCLAW_STATE_DIR` and disables bundled plugins, but `listOpenClawPluginManifestMetadata` also calls `listSourceCheckoutPluginDirs`, which uses `import.meta.url` / `process.argv[1]` to find the OpenClaw package root and enumerates every child of its `extensions/` dir (140 on a source checkout). Nothing to do with `/tmp/openclaw`. Fix would need to either mock `resolvePackageRootsForSourceManifestMetadata` (or the fs of `openclaw-root`) or add an env/option to opt out of source-checkout scanning during tests.

### 2. `src/plugins/tools.optional.test.ts > resolvePluginTools optional tools > reloads when gateway binding would otherwise reuse a default-mode active registry` (line 2863)

```
TypeError: Cannot read properties of undefined (reading 'length')
  at registryHasPluginHostCleanupWork src/plugins/runtime.ts:66:32
      registry.sessionExtensions.length > 0 ||
  at cleanupRetiredPluginHostRegistry ← setActivePluginRegistry ← setRegistry ← setOptionalDemoRegistry
```

Root cause: the test's mock registry is `{ plugins: [], tools: [], diagnostics: [] }` — the retirement/cleanup path in `runtime.ts` reads `sessionExtensions.length`, `runtimeLifecycles.length`, etc. without null-guarding. Either the test should provide those arrays, or the production predicate should tolerate missing fields (arguably both). Also nothing to do with `/tmp/openclaw`.

## Suggestion

Once this PR lands, please close the `os.tmpdir` part of #101876 and open two separate issues for the two failures above so they can be triaged independently.
