### PR TITLE
refactor(deadcode): trim private helper exports

### DIFF
--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-shared.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-shared.ts
@@ -198,14 +198,6 @@ export function buildMatrixReplyArtifact(
   };
 }
 
-export function buildMatrixNoticeArtifact(event: MatrixQaObservedEvent) {
-  return {
-    bodyPreview: event.body?.trim().slice(0, 200),
-    eventId: event.eventId,
-    sender: event.sender,
-  };
-}
-
 export function buildMatrixReplyDetails(label: string, artifact: MatrixQaReplyArtifact) {
   return [
     `${label} event: ${artifact.eventId}`,

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -511,7 +511,7 @@ const DEFAULT_TELEGRAM_TEST_CONFIG: OpenClawConfig = {
   },
 };
 
-export function makeTelegramMessageCtx(params: {
+function makeTelegramMessageCtx(params: {
   chat: {
     id: number;
     type: string;

--- a/extensions/voice-call/src/manager.test-harness.ts
+++ b/extensions/voice-call/src/manager.test-harness.ts
@@ -82,7 +82,7 @@ export function createTestStorePath(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-voice-call-test-"));
 }
 
-export function createVoiceCallStateRuntimeForTests(): VoiceCallStateRuntime["state"] {
+function createVoiceCallStateRuntimeForTests(): VoiceCallStateRuntime["state"] {
   return {
     resolveStateDir: () => "",
     openKeyedStore: (() => {

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -86,7 +86,7 @@ type ClampedGoogleThinkingLevel = Exclude<AgentThinkingLevel, "xhigh" | "max">;
  *
  * See: https://ai.google.dev/gemini-api/docs/thought-signatures
  */
-export function isThinkingPart(part: Pick<Part, "thought" | "thoughtSignature">): boolean {
+function isThinkingPart(part: Pick<Part, "thought" | "thoughtSignature">): boolean {
   return part.thought === true;
 }
 
@@ -615,11 +615,11 @@ export function isGemma4Model<T extends GoogleApiType>(model: Model<T>): boolean
   return /gemma-?4/.test(model.id.toLowerCase());
 }
 
-export function isGemini3ProModel<T extends GoogleApiType>(model: Model<T>): boolean {
+function isGemini3ProModel<T extends GoogleApiType>(model: Model<T>): boolean {
   return /gemini-3(?:\.\d+)?-pro/.test(model.id.toLowerCase());
 }
 
-export function isGemini3FlashModel<T extends GoogleApiType>(model: Model<T>): boolean {
+function isGemini3FlashModel<T extends GoogleApiType>(model: Model<T>): boolean {
   return /gemini-3(?:\.\d+)?-flash/.test(model.id.toLowerCase());
 }
 

--- a/src/channels/plugins/contracts/test-helpers/runtime-artifacts.ts
+++ b/src/channels/plugins/contracts/test-helpers/runtime-artifacts.ts
@@ -35,10 +35,7 @@ function resolveBundledChannelWorkspaceArtifactPath(
   return null;
 }
 
-export function resolveBundledChannelContractArtifactUrl(
-  pluginId: string,
-  entryBaseName: string,
-): string {
+function resolveBundledChannelContractArtifactUrl(pluginId: string, entryBaseName: string): string {
   const normalizedEntryBaseName = entryBaseName.replace(/\.(?:[cm]?js|ts)$/u, "");
   const record = resolvePluginRuntimeRecord(pluginId, () => {
     throw new Error(`missing bundled channel plugin '${pluginId}'`);

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -149,7 +149,7 @@ export let STATE_DIR = resolveStateDir();
  * Can be overridden via OPENCLAW_CONFIG_PATH.
  * Default: ~/.openclaw/openclaw.json (or $OPENCLAW_STATE_DIR/openclaw.json)
  */
-export function resolveCanonicalConfigPath(
+function resolveCanonicalConfigPath(
   env: NodeJS.ProcessEnv = process.env,
   stateDir: string = resolveStateDir(env, envHomedir(env)),
 ): string {

--- a/src/config/recovery-policy.ts
+++ b/src/config/recovery-policy.ts
@@ -27,7 +27,7 @@ function isPluginPolicyIssue(issue: ConfigValidationIssue): boolean {
 }
 
 /** Return true for plugin validation issues caused by missing compiled runtime output. */
-export function isPluginPackagingRuntimeOutputIssue(issue: ConfigValidationIssue): boolean {
+function isPluginPackagingRuntimeOutputIssue(issue: ConfigValidationIssue): boolean {
   const path = issue.path.trim();
   const message = issue.message.trim().toLowerCase();
   return isPluginsPath(path) && message.includes(COMPILED_RUNTIME_OUTPUT_DIAGNOSTIC);

--- a/src/config/sessions/lifecycle.ts
+++ b/src/config/sessions/lifecycle.ts
@@ -121,7 +121,7 @@ function readFirstLine(filePath: string): string | undefined {
 }
 
 /** Reads session start time from a transcript header when store metadata is missing. */
-export function readSessionHeaderStartedAtMs(params: {
+function readSessionHeaderStartedAtMs(params: {
   entry: SessionLifecycleEntry | undefined;
   agentId?: string;
   storePath?: string;

--- a/src/config/sessions/metadata.ts
+++ b/src/config/sessions/metadata.ts
@@ -86,7 +86,7 @@ const mergeOrigin = (
 };
 
 /** Derives session origin metadata from an inbound message context. */
-export function deriveSessionOrigin(
+function deriveSessionOrigin(
   ctx: MsgContext,
   opts?: { skipSystemEventOrigin?: boolean },
 ): SessionOrigin | undefined {
@@ -152,7 +152,7 @@ export function snapshotSessionOrigin(entry?: SessionEntry): SessionOrigin | und
   return { ...entry.origin };
 }
 
-export function deriveGroupSessionPatch(params: {
+function deriveGroupSessionPatch(params: {
   ctx: MsgContext;
   sessionKey: string;
   existing?: SessionEntry;

--- a/src/logging/test-helpers/diagnostic-log-capture.ts
+++ b/src/logging/test-helpers/diagnostic-log-capture.ts
@@ -9,7 +9,7 @@ import {
 type CapturedDiagnosticLogRecord = Extract<DiagnosticEventPayload, { type: "log.record" }>;
 
 /** Flushes asynchronous diagnostic log record delivery. */
-export async function flushDiagnosticLogRecords(): Promise<void> {
+async function flushDiagnosticLogRecords(): Promise<void> {
   // The dispatcher drains 100 records per turn. A busy shared test process can
   // have several batches ahead of the log under test, so wait for queued log
   // records instead of assuming a fixed small number of turns.


### PR DESCRIPTION
## What Problem This Solves

Removes 13 stale private helper surfaces that made core config/session code, AI provider internals, plugin test harnesses, and QA Matrix look more reusable than they are.

## Why This Change Was Made

A forced codebase-memory graph rebuild plus repository-wide exact-reference checks identified 12 helpers that are only used in their declaring module and one QA Matrix helper with no references. The 12 live helpers are made module-local; the unreferenced helper is deleted. Public package, plugin SDK, and runtime barrel candidates were explicitly excluded.

## User Impact

No runtime or visual behavior changes. Internal API boundaries are smaller and more accurate, reducing false reuse signals for future maintenance.

## Evidence

- Forced graph index: 21,039 files, 281,271 nodes, 1,134,169 edges, 0 extraction errors.
- Exact-reference audit: 12 localized helpers have 0 external named references; the deleted helper has 0 repository references.
- Diff: 13 targets across 10 files, 12 insertions, 23 deletions (net -11).
- Testbox `tbx_01kwz7gm3v517p519cz09k9a3v`: `pnpm check:changed` passed for core, core tests, extensions, and extension tests.
- Exact commit `37b2e53271eff479fe13373476f14d133fe35cbd`: 24 focused files, 368 tests, 7 Vitest shards passed.
- `extensions/telegram/src/bot.test.ts` has one failing assertion on both this branch and pristine `origin/main` (`does not retry plugin-owned callback text skipped by inbound policy`); 94/95 tests pass in that file and the failure is unrelated to this export-only harness change.
- Fresh autoreview after rebasing onto current main: no findings, confidence 0.88.
- `git diff --check` passed; personal-data and secret-pattern scans found no matches.

AI assistance: yes. No transcript attached.
