### PR TITLE
fix(slack): unbounded thread pagination, process-wide write serialization, serialized inbound lookups

### DIFF
--- a/extensions/slack/src/client-options.ts
+++ b/extensions/slack/src/client-options.ts
@@ -68,6 +68,5 @@ export function resolveSlackWriteClientOptions(options: WebClientOptions = {}): 
   const resolved: WebClientOptions = Object.assign({}, options);
   applySlackApiUrlAndProxyOptions(resolved);
   resolved.retryConfig ??= SLACK_WRITE_RETRY_OPTIONS;
-  resolved.maxRequestConcurrency ??= 1;
   return resolved;
 }

--- a/extensions/slack/src/client.test.ts
+++ b/extensions/slack/src/client.test.ts
@@ -205,12 +205,6 @@ describe("slack web client config", () => {
     expect(options.retryConfig).toEqual(SLACK_WRITE_RETRY_OPTIONS);
   });
 
-  it("serializes write client requests by default", () => {
-    const options = resolveSlackWriteClientOptions();
-
-    expect(options.maxRequestConcurrency).toBe(1);
-  });
-
   it("respects explicit write client concurrency overrides", () => {
     const options = resolveSlackWriteClientOptions({ maxRequestConcurrency: 5 });
 
@@ -224,7 +218,6 @@ describe("slack web client config", () => {
 
     expect(WebClient).toHaveBeenCalledWith("xoxb-test", {
       agent: customAgent,
-      maxRequestConcurrency: 1,
       retryConfig: SLACK_WRITE_RETRY_OPTIONS,
       timeout: 4321,
     });
@@ -240,7 +233,6 @@ describe("slack web client config", () => {
       expect(WebClient).toHaveBeenCalledTimes(1);
       expect(WebClient).toHaveBeenCalledWith("xoxb-test", {
         agent: undefined,
-        maxRequestConcurrency: 1,
         retryConfig: SLACK_WRITE_RETRY_OPTIONS,
       });
     } finally {

--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -997,6 +997,55 @@ describe("resolveSlackThreadHistory", () => {
     ]);
   });
 
+  it("returns no thread history when pagination exceeds the bounded fetched window", async () => {
+    vi.mocked(logVerbose).mockClear();
+    const replies = vi
+      .fn()
+      .mockResolvedValueOnce({
+        messages: Array.from({ length: 200 }, (_, i) => ({
+          text: `msg-${i + 1}`,
+          user: "U1",
+          ts: `${i + 1}.000`,
+        })),
+        response_metadata: { next_cursor: "cursor-2" },
+      })
+      .mockResolvedValueOnce({
+        messages: Array.from({ length: 200 }, (_, i) => ({
+          text: `msg-${i + 201}`,
+          user: "U1",
+          ts: `${i + 201}.000`,
+        })),
+        response_metadata: { next_cursor: "cursor-3" },
+      })
+      .mockResolvedValueOnce({
+        messages: Array.from({ length: 200 }, (_, i) => ({
+          text: `msg-${i + 401}`,
+          user: "U1",
+          ts: `${i + 401}.000`,
+        })),
+        response_metadata: { next_cursor: "cursor-4" },
+      });
+    const client = {
+      conversations: { replies },
+    } as unknown as Parameters<typeof resolveSlackThreadHistory>[0]["client"];
+
+    const result = await resolveSlackThreadHistory({
+      channelId: "C1",
+      threadTs: "1.000",
+      client,
+      limit: 3,
+    });
+
+    expect(replies).toHaveBeenCalledTimes(3);
+    expect(requireMockCall(replies, 2, "conversations.replies")[0]).toMatchObject({
+      cursor: "cursor-3",
+      limit: 200,
+    });
+    expect(result).toEqual([]);
+    expectVerboseLogContains("slack thread history capped");
+    expectVerboseLogContains("channel=C1");
+  });
+
   it("includes file-only messages and drops empty-only entries", async () => {
     const replies = vi.fn().mockResolvedValueOnce({
       messages: [

--- a/extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts
@@ -140,6 +140,7 @@ describe("thread-level session keys", () => {
         accountId: "default",
         sessionKey: "agent:main:slack:channel:c123",
         mainSessionKey: "agent:main:main",
+        dmScope: "main",
         lastRoutePolicy: "session",
         matchedBy: "default",
       },

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -653,8 +653,41 @@ export async function prepareSlackMessage(params: {
   }
   const { senderId, allowFromLower } = authorization;
   const messageText = message.text ?? "";
+  let resolvedSenderName = normalizeOptionalString(message.username);
+  const resolveSenderName = async (): Promise<string> => {
+    if (resolvedSenderName) {
+      return resolvedSenderName;
+    }
+    if (message.user) {
+      const sender = await ctx.resolveUserName(message.user);
+      const normalized = normalizeOptionalString(sender?.name);
+      if (normalized) {
+        resolvedSenderName = normalized;
+        return resolvedSenderName;
+      }
+    }
+    resolvedSenderName = message.user ?? message.bot_id ?? "unknown";
+    return resolvedSenderName;
+  };
   const mentionMetadata = collectSlackMentionMetadata(messageText);
   const { mentionedUserIds, mentionedSubteamIds, hasAnyMention } = mentionMetadata;
+  const messageAssistantThreadContext = resolveSlackMessageAssistantThreadContext(message);
+  const assistantContextLookupChannelId =
+    messageAssistantThreadContext?.assistantChannelId ?? message.channel;
+  const assistantContextLookupThreadTs =
+    messageAssistantThreadContext?.threadTs ?? message.thread_ts ?? message.ts;
+  const cachedAssistantThreadContext = isDirectMessage
+    ? ctx.getSlackAssistantThreadContext(
+        assistantContextLookupChannelId,
+        assistantContextLookupThreadTs,
+      )
+    : undefined;
+  const restoredAssistantThreadContextPromise =
+    isDirectMessage &&
+    !cachedAssistantThreadContext &&
+    !hasSlackAssistantThreadMetadata(messageAssistantThreadContext)
+      ? restoreSlackAssistantThreadContextFromMetadata({ ctx, message })
+      : Promise.resolve(undefined);
   const { explicitlyMentionedBotUser, explicitlyMentionedBotSubteam, explicitlyMentioned } =
     await resolveSlackExplicitMentionState({
       ctx,
@@ -676,23 +709,7 @@ export async function prepareSlackMessage(params: {
     : isGroupDm
       ? "group"
       : "channel";
-  const messageAssistantThreadContext = resolveSlackMessageAssistantThreadContext(message);
-  const assistantContextLookupChannelId =
-    messageAssistantThreadContext?.assistantChannelId ?? message.channel;
-  const assistantContextLookupThreadTs =
-    messageAssistantThreadContext?.threadTs ?? message.thread_ts ?? message.ts;
-  const cachedAssistantThreadContext = isDirectMessage
-    ? ctx.getSlackAssistantThreadContext(
-        assistantContextLookupChannelId,
-        assistantContextLookupThreadTs,
-      )
-    : undefined;
-  const restoredAssistantThreadContext =
-    isDirectMessage &&
-    !cachedAssistantThreadContext &&
-    !hasSlackAssistantThreadMetadata(messageAssistantThreadContext)
-      ? await restoreSlackAssistantThreadContextFromMetadata({ ctx, message })
-      : undefined;
+  const restoredAssistantThreadContext = await restoredAssistantThreadContextPromise;
   const assistantThreadContext = mergeSlackAssistantThreadContext(
     messageAssistantThreadContext,
     cachedAssistantThreadContext ?? restoredAssistantThreadContext,
@@ -825,6 +842,14 @@ export async function prepareSlackMessage(params: {
       return null;
     }
   }
+  const senderNameForAuthPromise: Promise<
+    { ok: true; name: string | undefined } | { ok: false; error: unknown }
+  > = ctx.allowNameMatching
+    ? resolveSenderName().then(
+        (name) => ({ ok: true, name }),
+        (error: unknown) => ({ ok: false, error }),
+      )
+    : Promise.resolve({ ok: true, name: undefined });
   const directThreadRoutedToDmSession =
     !assistantThreadContext &&
     isDirectMessage &&
@@ -856,22 +881,6 @@ export async function prepareSlackMessage(params: {
           );
   }
 
-  let resolvedSenderName = normalizeOptionalString(message.username);
-  const resolveSenderName = async (): Promise<string> => {
-    if (resolvedSenderName) {
-      return resolvedSenderName;
-    }
-    if (message.user) {
-      const sender = await ctx.resolveUserName(message.user);
-      const normalized = normalizeOptionalString(sender?.name);
-      if (normalized) {
-        resolvedSenderName = normalized;
-        return resolvedSenderName;
-      }
-    }
-    resolvedSenderName = message.user ?? message.bot_id ?? "unknown";
-    return resolvedSenderName;
-  };
   const recordDroppedHistory = async (
     reason: "slack-mention-detection-unavailable" | "slack-no-mention" | "slack-other-mention",
   ): Promise<void> => {
@@ -930,7 +939,11 @@ export async function prepareSlackMessage(params: {
       },
     });
   };
-  const senderNameForAuth = ctx.allowNameMatching ? await resolveSenderName() : undefined;
+  const senderNameForAuthResult = await senderNameForAuthPromise;
+  if (!senderNameForAuthResult.ok) {
+    throw senderNameForAuthResult.error;
+  }
+  const senderNameForAuth = senderNameForAuthResult.name;
 
   const allowTextCommands = shouldHandleTextCommands({
     cfg,
@@ -1071,14 +1084,26 @@ export async function prepareSlackMessage(params: {
     return null;
   }
 
-  const threadStarter =
+  const threadStarterPromise =
     isThreadReply && threadTs
-      ? await resolveSlackThreadStarter({
+      ? resolveSlackThreadStarter({
           channelId: message.channel,
           threadTs,
           client: ctx.app.client,
         })
-      : null;
+      : Promise.resolve(null);
+  const chatType = resolveSlackChatType(conversation.resolvedChannelType);
+  const inboundEventKind = classifyChannelInboundEvent({
+    conversation: { kind: chatType },
+    unmentionedGroupPolicy: resolveUnmentionedGroupInboundPolicy({
+      cfg,
+      agentId: route.agentId,
+    }),
+    wasMentioned: effectiveWasMentioned,
+    hasControlCommand: hasControlCommandInMessage,
+    hasAbortRequest,
+  });
+  const threadStarter = await threadStarterPromise;
   const resolvedMessageContent = await resolveSlackMessageContent({
     message,
     isThreadReply,
@@ -1093,18 +1118,6 @@ export async function prepareSlackMessage(params: {
     return null;
   }
   const { rawBody, effectiveDirectMedia } = resolvedMessageContent;
-  const chatType = resolveSlackChatType(conversation.resolvedChannelType);
-  const inboundEventKind = classifyChannelInboundEvent({
-    conversation: { kind: chatType },
-    unmentionedGroupPolicy: resolveUnmentionedGroupInboundPolicy({
-      cfg,
-      agentId: route.agentId,
-    }),
-    wasMentioned: effectiveWasMentioned,
-    hasControlCommand: hasControlCommandInMessage,
-    hasAbortRequest,
-  });
-
   const ackReaction = resolveAckReaction(cfg, route.agentId, {
     channel: "slack",
     accountId: account.accountId,

--- a/extensions/slack/src/monitor/thread.ts
+++ b/extensions/slack/src/monitor/thread.ts
@@ -185,12 +185,14 @@ type SlackRepliesPage = {
   response_metadata?: { next_cursor?: string };
 };
 
+const SLACK_THREAD_HISTORY_MAX_PAGES = 3;
+
 /**
  * Fetches the most recent messages in a Slack thread (excluding the current message).
  * Used to populate thread context when a new thread session starts.
  *
- * Uses cursor pagination and keeps only the latest N retained messages so long threads
- * still produce up-to-date context without unbounded memory growth.
+ * Uses cursor pagination and keeps only the latest N retained messages when the full
+ * thread fits in the bounded fetch window.
  */
 export async function resolveSlackThreadHistory(params: {
   channelId: string;
@@ -208,9 +210,11 @@ export async function resolveSlackThreadHistory(params: {
   const fetchLimit = 200;
   const retained: SlackRepliesPageMessage[] = [];
   let cursor: string | undefined;
+  let pagesFetched = 0;
 
   try {
     do {
+      pagesFetched += 1;
       const response = (await params.client.conversations.replies({
         channel: params.channelId,
         ts: params.threadTs,
@@ -236,7 +240,16 @@ export async function resolveSlackThreadHistory(params: {
 
       const next = response.response_metadata?.next_cursor;
       cursor = typeof next === "string" && next.trim().length > 0 ? next.trim() : undefined;
-    } while (cursor);
+      // Slack replies paginate oldest to newest with no reverse cursor; cap cold
+      // thread seeding so pathological long threads cannot block dispatch.
+    } while (cursor && pagesFetched < SLACK_THREAD_HISTORY_MAX_PAGES);
+
+    if (cursor) {
+      logVerbose(
+        `slack thread history capped channel=${params.channelId} ts=${params.threadTs} pages=${SLACK_THREAD_HISTORY_MAX_PAGES}`,
+      );
+      return [];
+    }
 
     return retained.map((msg) => ({
       // For file-only messages, create a placeholder showing attached filenames.


### PR DESCRIPTION
## What Problem This Solves

Part of #101690 (remaining work there: HTTP Events API mode recommendation).

This started as an investigation into why Slack replies feel slow (~3.2s canary p50 vs Telegram ~1.0s / Discord ~1.8s on the identical mock-model loop). Instrumented measurement (per-sample SUT gateway logs + Slack server timestamps; tables below) attributed the dominant share — **p50 ~2.1–2.4s — to Slack's own Socket Mode event propagation, before any OpenClaw code runs**. That share is transport-level; the lever for it is HTTP Events API mode (already supported via `mode: "http"`), tracked in the issue, not this PR.

The trace did surface three real defects in the Slack channel, which this PR fixes:

1. **Unbounded thread-history pagination** — `resolveSlackThreadHistory` walked *every* 200-message page of a thread (Slack's `conversations.replies` only paginates oldest→newest) just to keep the last 20 messages. Seeding an agent session in a 2,000-message thread cost 10 sequential Slack API calls that block the reply.
2. **Process-wide write serialization** — the write client pinned `maxRequestConcurrency = 1`, so every `chat.postMessage`, `chat.update` (preview edits), reaction, and file upload on a token ran single-file across the whole process. A reply in one channel queued behind a reaction in an unrelated channel — head-of-line blocking that grows with gateway concurrency.
3. **Accidentally serialized inbound lookups** — `prepareSlackMessage` awaited independent Slack API lookups (assistant-thread metadata restore, sender-name resolution, thread-starter fetch) strictly sequentially, stacking cold-cache round trips before dispatch.

## Why This Change Was Made

- `perf(slack): bound thread history pagination` — caps history fetches at 3 pages (600 messages). Threads within the window keep exact last-N behavior; longer threads reply promptly with no backfilled context (logged) instead of stalling — the alternative (keeping the capped walk's output) would hand the agent the *oldest* 600 messages as if they were current context. A code comment names the oldest→newest pagination contract that forces this shape.
- `perf(slack): drop process-wide write client concurrency cap` — provenance: the cap came from `107d2b7a096` ("preserve rapid send ordering"); that ordering contract is now owned by the per-conversation `KeyedAsyncQueue` in `send.ts` (keyed `accountId:tokenHash:recipient:threadTs`). Slack's ~1 msg/sec limit is per channel, not per token, and `@slack/web-api` (verified in installed source) defaults to concurrency 100 with automatic queue pause/resume on 429 `Retry-After`. Explicit caller overrides still pass through.
- `perf(slack): parallelize independent inbound prepare lookups` — overlaps only lookups with no ordering contract, verified by provenance (no comment/commit claims intentional sequencing) and by code reading. Two candidate overlaps were deliberately **rejected** during review: the sender `users.info` is conditionally skipped on several authorization paths (eager start would add API calls those paths avoid), and message-content resolution consumes the thread starter (real data dependency). Drop/authorization gating is unchanged; no path gains a new API call; in-flight promises settle to result objects so early exits cannot leave unobserved rejections.

## User Impact

Correctness/robustness first: long threads can no longer stall replies behind an unbounded pagination walk, and busy gateways no longer serialize all Slack writes process-wide. Thread/DM inbound dispatch sheds redundant serial round trips. Plain-mention latency is **not** materially changed — see measurement below — because it is dominated by Slack-side event delivery.

## RTT measurement (openclaw-rtt `slack-canary`, mock-openai, 20 samples/side)

Both refs measured with the same harness, credentials, runner class, and sample count:

| Ref | Samples | RTT p50 | RTT p95 | Min | Max |
|---|---|---:|---:|---:|---:|
| baseline `e591dcfa821` | 20/20 pass | 3,440ms | 4,802ms | 3,051ms | 4,812ms |
| fix `936f1855c4b` | 20/20 pass | 4,272ms | 4,928ms | 2,862ms | 5,527ms |

This is a **no-regression gate, not an improvement claim**: both distributions are the same bimodal mixture (~3.3s / ~4.7s modes; the driver observes replies on a ~1.4s poll cadence, which quantizes RTT), and the p50 difference is mode assignment (8/20 vs 11/20 slow samples; Fisher p≈0.5). The canary — a cold single-message channel mention — never enters the thread, DM-history, or multi-part-delivery paths this PR changes.

### Phase decomposition (instrumented runs, 10 samples/side)

| Phase (p50) | baseline | fix |
|---|---:|---:|
| Slack event propagation to Socket Mode (server receipt → event arrival, zero OpenClaw code) | ~2,132ms | ~2,356ms |
| dispatch queue | 52ms | 50ms |
| agent turn (mock model) | 260ms | 249ms |
| outbound reply post | 240ms | 246ms |
| driver poll observation | ~820ms | ~890ms |

Total OpenClaw-controlled time (event arrival → reply posted) is under ~1s on both refs. Slack documents ~200ms webhook delivery and recommends HTTP over Socket Mode for production; Socket Mode delivery delays are a known issue (slackapi/bolt-js#1151).

## Evidence

Validation runs:

- `pnpm check:changed` lanes (remote-child) on Blacksmith Testbox: green (one initial `check:test-types` failure in the new capped-pagination test was a missing `as unknown` step in a mock cast; fixed to match the file's sibling pattern and re-verified green).
- Slack extension suite: 106 files / 1,476 tests, exit 0; tsgo extension + extension-test lanes exit 0.
- 20-sample RTT A/B: openclaw-rtt workflow runs `28896305615` (baseline) and `28897212331` (fix); instrumented decomposition runs `28899719563` / `28899724145`.
- Branch-mode autoreview over `origin/main..HEAD`: clean, no actionable findings.
- Obsolete test asserting the removed default cap deleted; explicit-override test retained; capped-pagination path covered in `monitor/media.test.ts`.

Follow-ups intentionally out of scope: recommending/documenting HTTP Events API mode for hosted deployments (the actual felt-latency lever), and the openclaw-rtt sampler fixes (per-sample status probe reads the pre-evidence-summary schema, silently collapsing runs to 1 sample since ~2026.6.10; fixed on the measurement branch, separate PR to that repo).
