### PR TITLE
refactor(deadcode): localize Parallels helpers

### DIFF
--- a/scripts/e2e/parallels/host-server.ts
+++ b/scripts/e2e/parallels/host-server.ts
@@ -23,7 +23,7 @@ export function resolveHostIp(explicit = ""): string {
   return output;
 }
 
-export function allocateHostPort(): number {
+function allocateHostPort(): number {
   return Number(
     run(
       "python3",
@@ -36,7 +36,7 @@ export function allocateHostPort(): number {
   );
 }
 
-export async function isHostPortFree(port: number): Promise<boolean> {
+async function isHostPortFree(port: number): Promise<boolean> {
   return await new Promise((resolve) => {
     const server = createServer();
     server.once("error", () => resolve(false));

--- a/scripts/e2e/parallels/parallels-vm.ts
+++ b/scripts/e2e/parallels/parallels-vm.ts
@@ -17,13 +17,13 @@ export interface EnsureVmRunningOptions extends WaitForVmStatusOptions {
   transitionTimeoutMs?: () => number | undefined;
 }
 
-export function listVmNames(): string[] {
+function listVmNames(): string[] {
   return listVms()
     .map((item) => (item.name ?? "").trim())
     .filter(Boolean);
 }
 
-export function vmStatus(vmName: string, timeoutMs?: number): string {
+function vmStatus(vmName: string, timeoutMs?: number): string {
   return listVms(timeoutMs).find((vm) => vm.name === vmName)?.status || "missing";
 }
 

--- a/scripts/e2e/parallels/plugin-isolation.ts
+++ b/scripts/e2e/parallels/plugin-isolation.ts
@@ -87,7 +87,7 @@ export function windowsCodexPlatformPackageRepairFunction(): string {
 }`;
 }
 
-export function providerOnlyPluginId(modelId: string, fallbackPluginId: string): string {
+function providerOnlyPluginId(modelId: string, fallbackPluginId: string): string {
   return providerIdFromModelId(modelId) || fallbackPluginId;
 }
 

--- a/scripts/e2e/parallels/provider-auth.ts
+++ b/scripts/e2e/parallels/provider-auth.ts
@@ -100,7 +100,7 @@ export function resolveParallelsModelTimeoutSeconds(platform?: Platform): number
   return readPositiveIntEnv("OPENCLAW_PARALLELS_MODEL_TIMEOUT_S", defaultSeconds);
 }
 
-export function providerTimeoutConfigJson(
+function providerTimeoutConfigJson(
   modelId: string,
   platform: Platform,
   timeoutSeconds = resolveParallelsModelTimeoutSeconds(platform),
@@ -128,7 +128,7 @@ export function providerTimeoutConfigJson(
   });
 }
 
-export function modelTransportConfigJson(modelId: string): string {
+function modelTransportConfigJson(modelId: string): string {
   if (providerIdFromModelId(modelId) !== "openai") {
     return "";
   }
@@ -140,7 +140,7 @@ export function modelTransportConfigJson(modelId: string): string {
   });
 }
 
-export function configPathMapKey(key: string): string {
+function configPathMapKey(key: string): string {
   return `[${JSON.stringify(key)}]`;
 }
 

--- a/scripts/e2e/parallels/snapshots.ts
+++ b/scripts/e2e/parallels/snapshots.ts
@@ -88,7 +88,7 @@ export function resolveSnapshot(vmName: string, hint: string): SnapshotInfo {
   return best;
 }
 
-export function stringSimilarity(a: string, b: string): number {
+function stringSimilarity(a: string, b: string): number {
   if (a === b) {
     return 1;
   }


### PR DESCRIPTION
## What Problem This Solves

The Parallels E2E tooling exposed nine implementation helpers through module exports even though every remaining caller is in the declaring file.

## Why This Change Was Made

Repository graph analysis and exact reference searches confirmed that these functions have no external consumers. This keeps their implementations and behavior unchanged while shrinking the internal tooling API.

## User Impact

No user-visible behavior changes. Parallels maintainers have a smaller, more accurate module surface.

## Evidence

- Codebase-memory graph: 21,041 files, 281,312 nodes, 1,138,750 edges, zero extraction errors.
- Diff: five files, nine export modifiers removed, zero net lines.
- `OPENCLAW_TESTBOX=1 pnpm check:changed`: passed on Testbox `tbx_01kwz8vza8cvf2z6f5gfyg8dn9`.
- `pnpm test:serial test/scripts/parallels-smoke-model.test.ts`: 1 file and 80 tests passed on the same Testbox.
- Fresh branch autoreview: clean, confidence 0.88.
- AI assistance: yes. No transcript attached.
