### PR TITLE
refactor(deadcode): localize control ui declarations

### DIFF
--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -330,7 +330,7 @@ type GatewayConnectTimingPhase =
   | "hello"
   | "failed";
 
-export type GatewayConnectTiming = {
+type GatewayConnectTiming = {
   generation: number;
   phase: GatewayConnectTimingPhase;
   durationMs: number;

--- a/ui/src/app-route-paths.ts
+++ b/ui/src/app-route-paths.ts
@@ -1,7 +1,7 @@
 import { normalizeRouteBasePath, normalizeRoutePath } from "@openclaw/uirouter";
 import type { RouteLocation } from "@openclaw/uirouter";
 
-export const APP_ROUTE_DEFINITIONS = {
+const APP_ROUTE_DEFINITIONS = {
   chat: { path: "/chat" },
   overview: { path: "/overview" },
   activity: { path: "/activity" },

--- a/ui/src/components/connection-banner.ts
+++ b/ui/src/components/connection-banner.ts
@@ -5,7 +5,7 @@ import { property } from "lit/decorators.js";
 import { t } from "../i18n/index.ts";
 import { redactLoginFailureError } from "./login-gate.ts";
 
-export type ConnectionBannerProps = {
+type ConnectionBannerProps = {
   lastError: string | null;
   onRetry: () => void;
 };

--- a/ui/src/components/exec-approval.ts
+++ b/ui/src/components/exec-approval.ts
@@ -16,7 +16,7 @@ const DEFAULT_EXEC_APPROVAL_DECISIONS = [
   "deny",
 ] as const satisfies readonly ExecApprovalDecision[];
 
-export type ExecApprovalProps = {
+type ExecApprovalProps = {
   queue: readonly ExecApprovalRequest[];
   busy: boolean;
   error: string | null;

--- a/ui/src/components/file-preview-modal.ts
+++ b/ui/src/components/file-preview-modal.ts
@@ -4,7 +4,7 @@ import { property, query } from "lit/decorators.js";
 import { renderCopyButton } from "./copy-button.ts";
 import { icons } from "./icons.ts";
 
-export type FilePreviewModalFile = {
+type FilePreviewModalFile = {
   path: string;
   size: string;
   contents: string;

--- a/ui/src/components/gateway-url-confirmation.ts
+++ b/ui/src/components/gateway-url-confirmation.ts
@@ -4,7 +4,7 @@ import { property } from "lit/decorators.js";
 import { t } from "../i18n/index.ts";
 import "./modal-dialog.ts";
 
-export type GatewayUrlConfirmationProps = {
+type GatewayUrlConfirmationProps = {
   pendingGatewayUrl: string | null;
   onConfirm: () => void;
   onCancel: () => void;

--- a/ui/src/components/login-gate.ts
+++ b/ui/src/components/login-gate.ts
@@ -25,7 +25,7 @@ type LoginFailureKind =
   | "protocol-mismatch"
   | "network";
 
-export type LoginFailureFeedback = {
+type LoginFailureFeedback = {
   kind: LoginFailureKind;
   title: string;
   summary: string;
@@ -35,7 +35,7 @@ export type LoginFailureFeedback = {
   rawError: string;
 };
 
-export type LoginGateProps = {
+type LoginGateProps = {
   basePath: string;
   connected: boolean;
   lastError: string | null;

--- a/ui/src/components/update-banner.ts
+++ b/ui/src/components/update-banner.ts
@@ -58,7 +58,7 @@ function dismiss(updateAvailable: UpdateAvailable) {
   }
 }
 
-export type UpdateBannerProps = {
+type UpdateBannerProps = {
   statusBanner: { tone: "danger" | "warn" | "info"; text: string } | null;
   updateAvailable: UpdateAvailable | null;
   updateRunning: boolean;

--- a/ui/src/lib/config/index.ts
+++ b/ui/src/lib/config/index.ts
@@ -167,7 +167,7 @@ export async function loadConfig(state: ConfigState, options: LoadConfigOptions 
   }
 }
 
-export async function loadConfigSchema(state: ConfigState) {
+async function loadConfigSchema(state: ConfigState) {
   const client = state.client;
   if (!client || !state.connected) {
     return;

--- a/ui/src/lib/nodes/index.ts
+++ b/ui/src/lib/nodes/index.ts
@@ -118,7 +118,7 @@ export type ExecApprovalsSnapshot = FileExecApprovalsSnapshot | NativeExecApprov
 
 export type ExecApprovalsTarget = { kind: "gateway" } | { kind: "node"; nodeId: string };
 
-export type NodesState = {
+type NodesState = {
   client: GatewayRequestClient | null;
   connected: boolean;
   nodesLoading: boolean;
@@ -127,7 +127,7 @@ export type NodesState = {
   chatError?: string | null;
 };
 
-export type DevicesState = {
+type DevicesState = {
   client: GatewayRequestClient | null;
   connected: boolean;
   devicesLoading: boolean;

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -63,7 +63,7 @@ export type SessionListOptions = {
   append?: boolean;
 };
 
-export type SessionRefreshOptions = SessionListOptions & {
+type SessionRefreshOptions = SessionListOptions & {
   force?: boolean;
   // Sidebar startup hydration must not block session creation or drop the open session.
   backgroundHydrate?: boolean;
@@ -89,29 +89,29 @@ export type SessionPatch = {
   unread?: boolean;
 };
 
-export type SessionDeleteOptions = {
+type SessionDeleteOptions = {
   agentId?: string;
   deleteTranscript?: boolean;
 };
 
-export type SessionDeleteTarget = {
+type SessionDeleteTarget = {
   key: string;
   agentId?: string;
 };
 
-export type SessionDeleteBatchResult = {
+type SessionDeleteBatchResult = {
   deleted: string[];
   errors: string[];
 };
 
-export type SessionCompactResult = {
+type SessionCompactResult = {
   ok?: boolean;
   compacted?: boolean;
   reason?: string;
   result?: { tokensBefore?: number; tokensAfter?: number };
 };
 
-export type SessionSteerResult = {
+type SessionSteerResult = {
   runId?: string;
   status?: unknown;
 };
@@ -120,7 +120,7 @@ export type SessionResetOptions = {
   agentId?: string | null;
 };
 
-export type SessionGateway = {
+type SessionGateway = {
   readonly snapshot: {
     client: GatewayBrowserClient | null;
     connected: boolean;
@@ -134,7 +134,7 @@ export type SessionGateway = {
 
 type SessionRequestClient = Pick<GatewayBrowserClient, "request">;
 
-export type SessionMessageSubscription = {
+type SessionMessageSubscription = {
   key: string;
   agentId?: string | null;
 };

--- a/ui/src/lib/workboard/index.ts
+++ b/ui/src/lib/workboard/index.ts
@@ -290,7 +290,7 @@ export type WorkboardLifecycle = {
   sourceUpdatedAt?: number;
 };
 
-export type WorkboardTaskStatus =
+type WorkboardTaskStatus =
   | "queued"
   | "running"
   | "completed"
@@ -315,7 +315,7 @@ export type WorkboardTaskSummary = {
   error?: string;
 };
 
-export type WorkboardDependencyParent = {
+type WorkboardDependencyParent = {
   id: string;
   title: string;
   status?: WorkboardStatus;
@@ -328,7 +328,7 @@ export type WorkboardDependencyState = {
   blockedParents: WorkboardDependencyParent[];
 };
 
-export type WorkboardDispatchSummary = {
+type WorkboardDispatchSummary = {
   started: number;
   failures: number;
   promoted: number;
@@ -339,9 +339,9 @@ export type WorkboardDispatchSummary = {
 
 export type WorkboardAutoRefreshIntervalMs = 0 | 5000 | 15000 | 30000 | 60000;
 
-export type WorkboardRefreshSource = "initial" | "manual" | "poll";
+type WorkboardRefreshSource = "initial" | "manual" | "poll";
 
-export type WorkboardViewPresetId =
+type WorkboardViewPresetId =
   | "all"
   | "default_agent"
   | "ready"

--- a/ui/src/pages/chat/components/chat-sidebar.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.ts
@@ -35,7 +35,7 @@ export type SidebarFullMessageRequest = {
   kind: "assistant_message" | "tool_output";
 };
 
-export type MarkdownSidebarContent = {
+type MarkdownSidebarContent = {
   kind: "markdown";
   content: string;
   rawText?: string | null;
@@ -43,7 +43,7 @@ export type MarkdownSidebarContent = {
   unavailableReason?: DetailUnavailableReason | null;
 };
 
-export type CanvasSidebarContent = {
+type CanvasSidebarContent = {
   kind: "canvas";
   docId: string;
   title?: string;
@@ -54,7 +54,7 @@ export type CanvasSidebarContent = {
   unavailableReason?: DetailUnavailableReason | null;
 };
 
-export type ImageSidebarContent = {
+type ImageSidebarContent = {
   kind: "image";
   title: string;
   src: string;
@@ -64,7 +64,7 @@ export type ImageSidebarContent = {
   unavailableReason?: DetailUnavailableReason | null;
 };
 
-export type FileSidebarContent = {
+type FileSidebarContent = {
   kind: "file";
   path: string;
   name: string;
@@ -436,7 +436,7 @@ function resolveSidebarCanvasSandbox(
   return content.kind === "canvas" ? resolveEmbedSandbox(embedSandboxMode) : "allow-scripts";
 }
 
-export type MarkdownSidebarProps = {
+type MarkdownSidebarProps = {
   content: SidebarContent | null;
   error: string | null;
   fileView?: FileViewControls;

--- a/ui/src/test-helpers/chat-model.ts
+++ b/ui/src/test-helpers/chat-model.ts
@@ -6,7 +6,7 @@ import type {
   SessionsPatchResult,
 } from "../api/types.ts";
 
-export const OPENAI_GPT5_MODEL: ModelCatalogEntry = {
+const OPENAI_GPT5_MODEL: ModelCatalogEntry = {
   id: "gpt-5",
   name: "GPT-5",
   provider: "openai",


### PR DESCRIPTION
## What Problem This Solves

The Control UI exposes 31 declarations that have no consumers outside their defining modules. Those unnecessary exports enlarge internal module APIs and make dead-code ownership less precise.

## Why This Change Was Made

Localize the 31 same-file-only declarations across 14 Control UI modules. The change removes only `export` modifiers; names, values, types, and runtime behavior are unchanged.

## User Impact

No user-visible or visual behavior changes. Maintainers get narrower Control UI module boundaries with fewer accidental APIs.

## Evidence

- Exact baseline: `ba7af36306733978104e28b780b08305b8452fbf`.
- Exact head: `36070eddd2ee4749747c0987491020de0a700da7`.
- Repository-wide AST and exact-symbol scans found all 31 declarations only in their defining files; the post-edit scan reports 31 localized and zero remaining.
- Refreshed code graph: 21,043 files, 281,314 nodes, 1,138,313 edges, zero extraction errors.
- `pnpm deadcode:unused-files` passed on Testbox `tbx_01kwzamevnwjqc6kvt0qkt8jdz`; all 27 intentional allowlist entries matched.
- `pnpm check:changed` passed on the same Testbox.
- Changed Control UI tests passed: 142 files, 2,320 tests.
- Fresh local autoreview: no findings, confidence 0.87.
- Fresh branch autoreview: no findings, confidence 0.90.
- `git diff --check` passed.

AI assistance: yes. No agent transcript attached.
