### PR TITLE
fix: plugin tests fail on hosts with a usable /tmp/openclaw or a source checkout

### DIFF
--- a/src/plugins/git-install.test.ts
+++ b/src/plugins/git-install.test.ts
@@ -7,6 +7,7 @@ import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensit
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { DiagnosticSecurityEvent } from "../infra/diagnostic-events.js";
+import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 
 const runCommandWithTimeoutMock = vi.fn();
 const installPluginFromInstalledPackageDirMock = vi.fn();
@@ -531,7 +532,7 @@ describe("installPluginFromGitSpec", () => {
     }
   });
 
-  it("falls back to OS temp when target workspace creation fails", async () => {
+  it("falls back to the OpenClaw temp root when target workspace creation fails", async () => {
     const gitDir = trackedTempDirs.make("openclaw-git-install-stage-fallback-");
     runCommandWithTimeoutMock
       .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
@@ -568,7 +569,12 @@ describe("installPluginFromGitSpec", () => {
         normalizedSpec: "git:https://github.com/acme/demo.git",
       });
       expect(path.dirname(targetPrefix)).toBe(await fs.realpath(path.dirname(persistentRepoDir)));
-      expect(path.dirname(fallbackPrefix)).toBe(await fs.realpath(os.tmpdir()));
+      // withTempDir roots fallback staging at resolvePreferredOpenClawTmpDir(), which
+      // prefers /tmp/openclaw and only degrades to a uid-scoped os.tmpdir path when
+      // that is unsafe. Recompute it here so the assertion holds on every host.
+      expect(path.dirname(fallbackPrefix)).toBe(
+        await fs.realpath(resolvePreferredOpenClawTmpDir()),
+      );
       expect(runCommandWithTimeoutMock).toHaveBeenCalledTimes(3);
     } finally {
       mkdtempSpy.mockRestore();

--- a/src/plugins/manifest-model-id-normalization.test.ts
+++ b/src/plugins/manifest-model-id-normalization.test.ts
@@ -338,8 +338,14 @@ describe("manifest model id normalization", () => {
 
     const readFileSyncSpy = vi.spyOn(fs, "readFileSync");
 
-    expect(listOpenClawPluginManifestMetadata(process.env)).toHaveLength(1);
-    expect(listOpenClawPluginManifestMetadata(process.env)).toHaveLength(1);
+    // The scan also lists source-checkout extensions/ manifests when tests run
+    // from a repo checkout, so only pin the record for the plugin under test.
+    const listNormalizerRecords = () =>
+      listOpenClawPluginManifestMetadata(process.env).filter(
+        (record) => record.pluginDir === pluginDir,
+      );
+    expect(listNormalizerRecords()).toHaveLength(1);
+    expect(listNormalizerRecords()).toHaveLength(1);
 
     const manifestReads = readFileSyncSpy.mock.calls.filter(
       ([filePath]) => String(filePath) === manifestPath,

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -4,6 +4,7 @@ import { DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY } from "../agents/tool-policy.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { loggingState } from "../logging/state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
 
 type MockRegistryToolEntry = {
   pluginId: string;
@@ -2861,15 +2862,9 @@ describe("resolvePluginTools optional tools", () => {
   });
 
   it("reloads when gateway binding would otherwise reuse a default-mode active registry", () => {
-    setActivePluginRegistry(
-      {
-        plugins: [],
-        tools: [],
-        diagnostics: [],
-      } as never,
-      "default-registry",
-      "default",
-    );
+    // Retiring an active registry walks all cleanup collections, so the
+    // default-mode stand-in must be a fully initialized registry shape.
+    setActivePluginRegistry(createEmptyPluginRegistry(), "default-registry", "default");
     setOptionalDemoRegistry();
 
     resolvePluginTools({


### PR DESCRIPTION
Closes #101876

## What Problem This Solves

Fixes an issue where three plugin test cases fail on any POSIX host with a normal `/tmp/openclaw` state or a source checkout (developer laptops, warm CI boxes), blocking green local runs of the plugins shard:

- `src/plugins/git-install.test.ts > falls back to OS temp when target workspace creation fails`
- `src/plugins/manifest-model-id-normalization.test.ts > reuses manifest metadata while file fingerprints are unchanged`
- `src/plugins/tools.optional.test.ts > reloads when gateway binding would otherwise reuse a default-mode active registry`

## Why This Change Was Made

The three failures have three distinct causes — recent prod changes landed with stale test expectations; this PR updates only the tests to the current prod contracts (no prod behavior changes):

1. **git-install**: #101246 made `withTempDir` root fallback staging at `resolvePreferredOpenClawTmpDir()` (prefers `/tmp/openclaw`, degrades to a uid-scoped `os.tmpdir()` path when unsafe), but the test still asserted bare `os.tmpdir()`. The test now recomputes the resolver output, so the assertion holds in every resolver state.
2. **manifest scan**: 26c0285812b added the source-checkout manifest metadata fallback, so `listOpenClawPluginManifestMetadata` legitimately lists all repo `extensions/` manifests when tests run from a checkout (140 records, not 1). The test now pins exactly one record for the plugin under test and keeps the fingerprint-reuse assertion (manifest file read exactly once across two scans).
3. **tools.optional**: #100990 requires initialized registry collections (`registryHasPluginHostCleanupWork` no longer optional-chains), and updated most test registries but missed this hand-rolled `{plugins, tools, diagnostics} as never` fake, which crashes when retired. The test now uses `createEmptyPluginRegistry()`, which also drops the `as never` cast.

Note: the issue attributes all three failures to the temp-root mechanism; investigation showed only the git-install test is temp-root-coupled. The other two are stale expectations from the July 6–7 prod changes above.

## User Impact

No user-visible behavior change. Developers and CI hosts get deterministic plugin-shard test results regardless of `/tmp/openclaw` state (present, absent, or unsafe) and regardless of running from a source checkout.

## Evidence

`node scripts/run-vitest.mjs src/plugins/git-install.test.ts src/plugins/manifest-model-id-normalization.test.ts src/plugins/tools.optional.test.ts` (macOS, worktree of e7365d41d35):

- Before: `Tests 3 failed | 95 passed (98)` — reproducing the issue exactly.
- After, with `/tmp/openclaw` present and safe: `Tests 98 passed (98)`.
- After, with `/tmp/openclaw` absent (resolver creates it): `Tests 98 passed (98)`.
- After, with `/tmp/openclaw` unsafe (symlink → uid-scoped `os.tmpdir()` fallback): `git-install.test.ts 23 passed (23)` (the only resolver-coupled file).
- Full plugins shard (`node scripts/run-vitest.mjs src/plugins`): pass (see CI for the hosted run).

`oxfmt --check` and `scripts/run-oxlint.mjs` clean on the three changed files.
