### PR TITLE
fix(agents): downgrade stop/abort stop reasons from error to correct level

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -141,6 +141,7 @@ import { listOpenAIAuthProfileProvidersForAgentRuntime } from "./openai-routing.
 import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
 import {
   createAgentRunRestartAbortError,
+  isAbortedAgentStopReason,
   isAgentRunDirectAbortReason,
   isAgentRunRestartAbortReason,
   resolveAgentRunAbortLifecycleFields,
@@ -1874,8 +1875,12 @@ async function agentCommandInternal(
         }
         attemptLifecycleState.lifecycleEnded = true;
         const stopReason = runResult.meta.stopReason;
-        if (stopReason && stopReason !== "end_turn") {
-          console.error(`[agent] run ${runId} ended with stopReason=${stopReason}`);
+        if (stopReason && stopReason !== "end_turn" && stopReason !== "stop") {
+          if (isAbortedAgentStopReason(stopReason)) {
+            console.warn(`[agent] run ${runId} ended with stopReason=${stopReason}`);
+          } else {
+            console.error(`[agent] run ${runId} ended with stopReason=${stopReason}`);
+          }
         }
         emitAgentEvent({
           runId,


### PR DESCRIPTION
fix(agents): downgrade stop/abort stop reasons from error to correct level

stopReason=stop is a normal model completion (equivalent to end_turn) but was hitting the console.error branch. Exclude it from error logging. Also downgrade aborted/restart stop reasons to console.warn since those are intentional user/system cancellations, not failures.

Fixes #101678

## What Problem This Solves

Fixes an issue where successful agent run completions (`stopReason=stop`) were logged at `console.error` severity. Operators monitoring error logs would see false alarms on every normal run completion.

## Why This Change Was Made

`stopReason=stop` is a normal model completion, equivalent to `end_turn` which was already silently excluded. The condition only excluded `end_turn`, so `stop` fell through to `console.error`. The fix excludes `stop` from error logging entirely, and also downgrades `aborted`/`restart` stop reasons from `console.error` to `console.warn` since those are intentional user/system cancellations, not failures.

## User Impact

Operators and developers no longer see spurious error-level log entries for successful agent runs. Actual failures (`timeout`, `error`) still log at error level. Intentional cancellations log at warn level.

## Evidence

Script simulating `emitLifecycleEnd` with each stop reason, before and after the fix:

<img width="960" height="304" alt="Screenshot 2026-07-07 at 5 35 41 PM" src="https://github.com/user-attachments/assets/3a0b7999-b35b-42ac-8da9-427ced11c9ea" />
