### PR TITLE
refactor(deadcode): localize browser plugin declarations

### DIFF
--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -318,7 +318,7 @@ export type AriaSnapshotNode = {
 };
 
 /** Prefix assigned to generated accessibility-node refs. */
-export const AX_REF_PREFIX = "ax";
+const AX_REF_PREFIX = "ax";
 export const AX_REF_PATTERN = new RegExp(`^${AX_REF_PREFIX}\\d+$`);
 
 /** Raw accessibility node subset read from CDP Accessibility.getFullAXTree. */
@@ -437,7 +437,7 @@ export async function snapshotAria(opts: {
 }
 
 /** Role snapshot ref metadata used by agent-facing snapshots. */
-export type CdpRoleRef = {
+type CdpRoleRef = {
   role: string;
   name?: string;
   nth?: number;
@@ -446,7 +446,7 @@ export type CdpRoleRef = {
 };
 
 /** Options for CDP role snapshot extraction and compaction. */
-export type CdpRoleSnapshotOptions = {
+type CdpRoleSnapshotOptions = {
   interactive?: boolean;
   compact?: boolean;
   maxDepth?: number;

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -117,13 +117,13 @@ type PendingChromeMcpSessionLease = {
 };
 
 /** Minimal process info used when cleaning up MCP child process trees. */
-export type ChromeMcpProcessInfo = {
+type ChromeMcpProcessInfo = {
   pid: number;
   ppid: number;
 };
 
 /** Injectable process cleanup dependencies for platform-specific tests. */
-export type ChromeMcpProcessCleanupDeps = {
+type ChromeMcpProcessCleanupDeps = {
   listProcesses?: () => Promise<ChromeMcpProcessInfo[]>;
   killProcess?: (pid: number, signal: NodeJS.Signals) => void;
   sleep?: (ms: number) => Promise<void>;

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -68,7 +68,7 @@ type AuxiliaryTabSession = {
 };
 
 /** Browser identity reported by the paired extension. */
-export type ExtensionIdentity = {
+type ExtensionIdentity = {
   userAgent: string;
   browserVersion: string;
   extensionVersion: string;

--- a/extensions/browser/src/browser/navigation-guard.ts
+++ b/extensions/browser/src/browser/navigation-guard.ts
@@ -43,7 +43,7 @@ export type BrowserNavigationPolicyOptions = {
 export type BrowserNavigationProxyMode = "direct" | "explicit-browser-proxy";
 
 /** Minimal request shape used to walk browser redirect chains. */
-export type BrowserNavigationRequestLike = {
+type BrowserNavigationRequestLike = {
   url(): string;
   redirectedFrom(): BrowserNavigationRequestLike | null;
 };

--- a/extensions/browser/src/browser/paths.ts
+++ b/extensions/browser/src/browser/paths.ts
@@ -48,7 +48,7 @@ export const DEFAULT_DOWNLOAD_DIR = path.join(DEFAULT_BROWSER_TMP_DIR, "download
 /** Default root directory for browser upload inputs. */
 export const DEFAULT_UPLOAD_DIR = path.join(DEFAULT_BROWSER_TMP_DIR, "uploads");
 /** Default root directory for managed inbound media references. */
-export const DEFAULT_INBOUND_MEDIA_DIR = path.join(CONFIG_DIR, "media", "inbound");
+const DEFAULT_INBOUND_MEDIA_DIR = path.join(CONFIG_DIR, "media", "inbound");
 
 type ExistingPathsResult = Awaited<ReturnType<typeof resolveExistingPathsWithinRoot>>;
 type StrictExistingPathsResult = Awaited<ReturnType<typeof resolveStrictExistingPathsWithinRoot>>;

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -84,7 +84,7 @@ export type BrowserNetworkRequest = {
 };
 
 /** Observed browser dialog record tracked for agent-visible state. */
-export type BrowserObservedDialogRecord = {
+type BrowserObservedDialogRecord = {
   id: string;
   type: string;
   message: string;
@@ -101,7 +101,7 @@ type BrowserObservedDialogState = {
 };
 
 /** Browser state currently observable by agent responses. */
-export type BrowserObservedState = {
+type BrowserObservedState = {
   dialogs: BrowserObservedDialogState;
 };
 

--- a/extensions/browser/src/browser/screenshot-annotate.ts
+++ b/extensions/browser/src/browser/screenshot-annotate.ts
@@ -25,7 +25,7 @@ export interface RawAnnotationInput {
   doc: { x: number; y: number; width: number; height: number };
 }
 
-export interface AnnotationBox {
+interface AnnotationBox {
   x: number;
   y: number;
   width: number;
@@ -40,7 +40,7 @@ export interface AnnotationItem {
   box: AnnotationBox;
 }
 
-export interface OverlayItem {
+interface OverlayItem {
   ref: string;
   x: number;
   y: number;
@@ -57,7 +57,7 @@ interface AnnotationPlan {
   skipped: number;
 }
 
-export interface PlanAnnotationsParams {
+interface PlanAnnotationsParams {
   inputs: RawAnnotationInput[];
   space: CoordinateSpace;
   /** Required when space === "viewport". */

--- a/extensions/browser/src/browser/vision.ts
+++ b/extensions/browser/src/browser/vision.ts
@@ -14,7 +14,7 @@ export const DEFAULT_BROWSER_SCREENSHOT_DESCRIPTION_PROMPT =
   "Describe what is visible in this browser screenshot. Capture page layout, headings, primary content blocks, visible text, and notable interactive elements so a text-only assistant can reason about the page.";
 
 /** Input context for browser screenshot image understanding. */
-export type BrowserScreenshotDescriptionContext = {
+type BrowserScreenshotDescriptionContext = {
   cfg: OpenClawConfig;
   filePath: string;
   agentDir?: string;
@@ -35,7 +35,7 @@ export type BrowserScreenshotDescriptionContext = {
 };
 
 /** Dependencies injected so Browser tests can avoid loading media runtimes. */
-export type BrowserScreenshotDescriptionDeps = {
+type BrowserScreenshotDescriptionDeps = {
   describeImageFile: typeof DescribeImageFileFn;
   normalizeBrowserScreenshot: typeof NormalizeBrowserScreenshotFn;
   saveMediaBuffer: typeof SaveMediaBufferFn;


### PR DESCRIPTION
## What Problem This Solves

The private browser plugin implementation still exported 15 declarations that have no consumers outside their defining modules. Those exports expanded the apparent internal API without providing a supported package surface.

## Why This Change Was Made

Localize the unused declarations at their ownership sites across eight browser implementation modules. The browser plugin's package barrels and runtime API continue to expose the same supported surface.

This is an export-only cleanup: 15 declarations changed from exported to module-local, with 15 insertions and 15 deletions.

## User Impact

None expected. Runtime behavior, public browser plugin APIs, and package exports are unchanged.

## Evidence

- Base: `9dbb1ed3d24655a144be1fe58a652f13ebe9f311`
- Head: `e260600c10667a9c302dd959b0db0ba69813a4b7`
- Codebase graph after the change: 21,043 files, 281,319 nodes, 1,138,868 edges, zero extraction errors.
- Repository-wide AST and text searches found no consumers for the 15 removed exports.
- `OPENCLAW_TESTBOX=1 pnpm check:changed`: passed for `extensions` and `extensionTests`, including extension typechecks, changed-file lint, guards, and import-cycle checks.
- Targeted browser Testbox lane: 11 files passed, 358 tests passed.
- Full browser shard on this branch: 5 files and 13 tests failed, with 128 files and 1,522 tests passing and 1 skipped.
- The identical full browser shard on a clean detached checkout of the current base failed in the same 5 files and 13 tests, including stale SSRF expectations and `Response.arrayBuffer` mock gaps. These failures are current-main drift and unrelated to this export-only diff.
- Fresh local autoreview: clean, 0.91 confidence.
- Fresh committed-branch autoreview: clean, 0.90 confidence.
- `git diff --check`: passed.

## AI Assistance

AI-assisted code search, editing, review, and validation were used. No agent transcript is attached.
