### PR TITLE
Workspaces: add Living Answers and action forms

### DIFF
--- a/extensions/workspaces/docs/LIVING-ANSWERS.md
+++ b/extensions/workspaces/docs/LIVING-ANSWERS.md
@@ -1,0 +1,19 @@
+# Living Answers
+
+Living Answers are ordinary Workspaces widgets with an optional expiry. They are useful for temporary, agent-authored results that should disappear unless an operator pins them.
+
+Set `ephemeral.expiresAt` to an ISO 8601 timestamp with an explicit timezone when calling `workspace_widget_add` or `workspace_widget_update`. Expired widgets are removed transactionally on the next workspace read. Pinning is explicit: update the widget with `ephemeral: null`; this clears the expiry and preserves the widget.
+
+## Action forms
+
+`builtin:action-form` turns a bounded, workspace-authored template into a small operator form. Its props contain:
+
+- `template`: 1-2000 characters, with slots such as `{topic}`
+- `fields`: 1-8 declared `text`, `number`, or `select` fields
+- `buttonLabel`: optional, 1-40 characters
+
+Every template slot must name a declared field. Values are type-checked and length-capped, and interpolation is one pass, so slot-like text inside a submitted value is never expanded again.
+
+Submitting a form does not grant a new action capability. It routes through the same prompt-send gate as approved custom widgets: one in-flight request, ten confirmed requests per rolling minute per widget, and an operator confirmation quoting the exact prompt for every submission. A decline sends nothing and consumes no rate slot. The message goes through `chat.send` with `deliver: false`; the agent still decides how to handle it under its existing tools and permissions.
+
+Do not use an action form to encode arbitrary RPC methods, shell commands, or approval bypasses. The form only produces a prompt; normal agent/tool authorization remains the enforcement boundary.

--- a/extensions/workspaces/src/gateway.ts
+++ b/extensions/workspaces/src/gateway.ts
@@ -14,6 +14,7 @@ import {
   type WorkspaceWidget,
   type JsonValue,
   type WorkspaceDoc,
+  type WorkspaceEphemeral,
 } from "./schema.js";
 import { WorkspaceStore } from "./store.js";
 
@@ -237,6 +238,13 @@ function findWidget(tab: WorkspaceTab, id: string): WorkspaceWidget {
   return widget;
 }
 
+function readEphemeralInput(value: unknown): WorkspaceEphemeral {
+  if (!isRecord(value)) {
+    throw new Error("ephemeral must be an object");
+  }
+  return { expiresAt: readRequiredString(value, "expiresAt", "ephemeral.expiresAt") };
+}
+
 function readWidgetInput(
   value: unknown,
   doc: WorkspaceDoc,
@@ -247,7 +255,17 @@ function readWidgetInput(
   }
   for (const key of Object.keys(value)) {
     if (
-      !["id", "kind", "title", "grid", "collapsed", "hidden", "bindings", "props"].includes(key)
+      ![
+        "id",
+        "kind",
+        "title",
+        "grid",
+        "collapsed",
+        "hidden",
+        "bindings",
+        "props",
+        "ephemeral",
+      ].includes(key)
     ) {
       throw new Error(`widget.${key} is not allowed`);
     }
@@ -265,6 +283,7 @@ function readWidgetInput(
       ? { bindings: value.bindings as Record<string, WorkspaceBinding> }
       : {}),
     ...(value.props !== undefined ? { props: value.props as JsonValue } : {}),
+    ...(value.ephemeral !== undefined ? { ephemeral: readEphemeralInput(value.ephemeral) } : {}),
   };
 }
 
@@ -295,7 +314,15 @@ function readTabPatch(value: unknown): Partial<Pick<WorkspaceTab, "title" | "ico
 }
 
 function readWidgetPatch(value: unknown): Partial<WorkspaceWidget> {
-  const patch = readParams(value, ["title", "grid", "collapsed", "hidden", "bindings", "props"]);
+  const patch = readParams(value, [
+    "title",
+    "grid",
+    "collapsed",
+    "hidden",
+    "bindings",
+    "props",
+    "ephemeral",
+  ]);
   const title = readOptionalString(patch, "title");
   if (title !== undefined && title.length > 80) {
     throw new Error("patch.title must be 80 characters or fewer");
@@ -313,6 +340,9 @@ function readWidgetPatch(value: unknown): Partial<WorkspaceWidget> {
       ? { bindings: patch.bindings as Record<string, WorkspaceBinding> }
       : {}),
     ...(patch.props !== undefined ? { props: patch.props as JsonValue } : {}),
+    ...(Object.hasOwn(patch, "ephemeral")
+      ? { ephemeral: patch.ephemeral === null ? undefined : readEphemeralInput(patch.ephemeral) }
+      : {}),
   };
 }
 

--- a/extensions/workspaces/src/schema.test.ts
+++ b/extensions/workspaces/src/schema.test.ts
@@ -14,6 +14,23 @@ function expectInvalid(mutator: (doc: WorkspaceDoc) => void, message: string) {
 }
 
 describe("Workspaces document schema", () => {
+  it("validates temporary expiry and bounded action-form slots", () => {
+    const doc = validDoc();
+    doc.tabs[0]!.widgets[0] = {
+      ...doc.tabs[0]!.widgets[0]!,
+      kind: "builtin:action-form",
+      props: {
+        template: "Summarize {topic}",
+        fields: [{ name: "topic", label: "Topic", type: "text" }],
+      },
+      ephemeral: { expiresAt: "2026-07-14T00:00:00Z" },
+    };
+    expect(validateWorkspaceDoc(doc).tabs[0]?.widgets[0]?.ephemeral?.expiresAt).toBe(
+      "2026-07-14T00:00:00Z",
+    );
+    (doc.tabs[0]!.widgets[0]!.props as { template: string }).template = "Use {undeclared}";
+    expect(() => validateWorkspaceDoc(doc)).toThrow("unknown field");
+  });
   it("accepts the default workspace seed", () => {
     expect(validateWorkspaceDoc(validDoc())).toEqual(validDoc());
   });

--- a/extensions/workspaces/src/schema.ts
+++ b/extensions/workspaces/src/schema.ts
@@ -18,6 +18,7 @@ type WorkspaceRpcBinding = {
 type WorkspaceFileBinding = { source: "file"; path: string; pointer?: string };
 type WorkspaceStaticBinding = { source: "static"; value: JsonValue };
 export type WorkspaceBinding = WorkspaceRpcBinding | WorkspaceFileBinding | WorkspaceStaticBinding;
+export type WorkspaceEphemeral = { expiresAt: string };
 export type WorkspaceWidget = {
   id: string;
   kind: string;
@@ -29,6 +30,7 @@ export type WorkspaceWidget = {
   createdBy: WorkspaceActor;
   bindings?: Record<string, WorkspaceBinding>;
   props?: JsonValue;
+  ephemeral?: WorkspaceEphemeral;
 };
 export type WorkspaceTab = {
   slug: string;
@@ -70,6 +72,7 @@ export const BUILTIN_WIDGET_KINDS = [
   "builtin:cron",
   "builtin:instances",
   "builtin:activity",
+  "builtin:action-form",
 ] as const;
 
 const BUILTIN_KINDS = new Set<string>(BUILTIN_WIDGET_KINDS);
@@ -77,6 +80,10 @@ const CUSTOM_KIND_PATTERN = /^custom:(?!__proto__$)[A-Za-z0-9._-]{1,64}$/;
 const CUSTOM_WIDGET_NAME_PATTERN = /^(?!__proto__$)[A-Za-z0-9._-]{1,64}$/;
 const MAX_STATIC_BINDING_BYTES = 8 * 1024;
 const MAX_RPC_BINDING_PARAMS_BYTES = 8 * 1024;
+const ISO_TIMESTAMP_PATTERN =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
+const ACTION_FORM_FIELD_NAME_PATTERN = /^[A-Za-z0-9_]{1,32}$/;
+const ACTION_FORM_SLOT_PATTERN = /\{([A-Za-z0-9_]+)\}/g;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -251,11 +258,92 @@ function validateBindingRecord(value: unknown, path: string): Record<string, Wor
   );
 }
 
+function validateEphemeral(value: unknown, path: string): WorkspaceEphemeral {
+  const record = assertRecord(value, path);
+  assertKnownKeys(record, ["expiresAt"], path);
+  const expiresAt = requireString(record, "expiresAt", path);
+  if (!ISO_TIMESTAMP_PATTERN.test(expiresAt) || Number.isNaN(Date.parse(expiresAt))) {
+    throw new Error(`${path}.expiresAt must be an ISO 8601 timestamp with an explicit timezone`);
+  }
+  return { expiresAt };
+}
+
+function validateActionFormProps(value: unknown, path: string): void {
+  const record = assertRecord(value, path);
+  assertKnownKeys(record, ["template", "fields", "buttonLabel"], path);
+  const template = requireString(record, "template", path);
+  if (template.length < 1 || template.length > 2000) {
+    throw new Error(`${path}.template must be 1-2000 characters`);
+  }
+  const fields = requireArray(record.fields, `${path}.fields`);
+  if (fields.length < 1 || fields.length > 8) {
+    throw new Error(`${path}.fields must contain 1-8 entries`);
+  }
+  const names = new Set<string>();
+  fields.forEach((field, index) => {
+    const fieldPath = `${path}.fields[${index}]`;
+    const item = assertRecord(field, fieldPath);
+    assertKnownKeys(item, ["name", "label", "type", "options", "maxLength"], fieldPath);
+    const name = requireString(item, "name", fieldPath);
+    if (!ACTION_FORM_FIELD_NAME_PATTERN.test(name) || names.has(name)) {
+      throw new Error(`${fieldPath}.name is invalid or duplicated`);
+    }
+    names.add(name);
+    const label = requireString(item, "label", fieldPath);
+    if (label.length < 1 || label.length > 80) {
+      throw new Error(`${fieldPath}.label must be 1-80 characters`);
+    }
+    const type = requireString(item, "type", fieldPath);
+    if (type !== "text" && type !== "number" && type !== "select") {
+      throw new Error(`${fieldPath}.type is invalid`);
+    }
+    if (type === "select") {
+      const options = requireArray(item.options, `${fieldPath}.options`);
+      if (
+        options.length < 1 ||
+        options.length > 20 ||
+        options.some(
+          (option) => typeof option !== "string" || option.length < 1 || option.length > 80,
+        )
+      ) {
+        throw new Error(`${fieldPath}.options must contain 1-20 strings of 1-80 characters`);
+      }
+    } else if (item.options !== undefined) {
+      throw new Error(`${fieldPath}.options is only allowed for select fields`);
+    }
+    if (item.maxLength !== undefined) {
+      assertIntegerRange(item.maxLength, `${fieldPath}.maxLength`, 1, 1000);
+    }
+  });
+  if (record.buttonLabel !== undefined) {
+    const label = requireString(record, "buttonLabel", path);
+    if (label.length < 1 || label.length > 40) {
+      throw new Error(`${path}.buttonLabel must be 1-40 characters`);
+    }
+  }
+  for (const match of template.matchAll(ACTION_FORM_SLOT_PATTERN)) {
+    if (!names.has(match[1]!)) {
+      throw new Error(`${path}.template references unknown field: {${match[1]}}`);
+    }
+  }
+}
+
 function validateWidget(value: unknown, path: string): WorkspaceWidget {
   const record = assertRecord(value, path);
   assertKnownKeys(
     record,
-    ["id", "kind", "title", "grid", "collapsed", "hidden", "createdBy", "bindings", "props"],
+    [
+      "id",
+      "kind",
+      "title",
+      "grid",
+      "collapsed",
+      "hidden",
+      "createdBy",
+      "bindings",
+      "props",
+      "ephemeral",
+    ],
     path,
   );
   const id = requireString(record, "id", path);
@@ -280,6 +368,13 @@ function validateWidget(value: unknown, path: string): WorkspaceWidget {
       : validateBindingRecord(record.bindings, `${path}.bindings`);
   const props =
     record.props === undefined ? undefined : assertJsonValue(record.props, `${path}.props`);
+  const ephemeral =
+    record.ephemeral === undefined
+      ? undefined
+      : validateEphemeral(record.ephemeral, `${path}.ephemeral`);
+  if (kind === "builtin:action-form") {
+    validateActionFormProps(props, `${path}.props`);
+  }
   return {
     id,
     kind,
@@ -290,6 +385,7 @@ function validateWidget(value: unknown, path: string): WorkspaceWidget {
     createdBy: validateActor(record.createdBy, `${path}.createdBy`),
     ...(bindings !== undefined ? { bindings } : {}),
     ...(props !== undefined ? { props } : {}),
+    ...(ephemeral !== undefined ? { ephemeral } : {}),
   };
 }
 

--- a/extensions/workspaces/src/store.test.ts
+++ b/extensions/workspaces/src/store.test.ts
@@ -2,9 +2,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { DEFAULT_WORKSPACE } from "./default-workspace.js";
 import { validateWorkspaceDoc, type WorkspaceDoc } from "./schema.js";
-import { sweepExpiredEphemeral, WorkspaceStore } from "./store.js";
+import { WorkspaceStore } from "./store.js";
 
 async function withStore<T>(run: (store: WorkspaceStore) => Promise<T> | T): Promise<T> {
   const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-"));
@@ -42,47 +41,6 @@ function docWithPendingWidget(store: WorkspaceStore): WorkspaceDoc {
 }
 
 describe("WorkspaceStore", () => {
-  it("sweeps expired temporary widgets but preserves future and pinned widgets", () => {
-    const doc = validateWorkspaceDoc({
-      ...structuredClone(DEFAULT_WORKSPACE),
-      tabs: [
-        {
-          ...structuredClone(DEFAULT_WORKSPACE.tabs[0]!),
-          widgets: [
-            {
-              id: "expired",
-              kind: "builtin:markdown",
-              grid: { x: 0, y: 0, w: 4, h: 2 },
-              collapsed: false,
-              hidden: false,
-              createdBy: "agent:main",
-              ephemeral: { expiresAt: "2026-07-01T00:00:00Z" },
-            },
-            {
-              id: "future",
-              kind: "builtin:markdown",
-              grid: { x: 4, y: 0, w: 4, h: 2 },
-              collapsed: false,
-              hidden: false,
-              createdBy: "agent:main",
-              ephemeral: { expiresAt: "2026-08-01T00:00:00Z" },
-            },
-            {
-              id: "pinned",
-              kind: "builtin:markdown",
-              grid: { x: 8, y: 0, w: 4, h: 2 },
-              collapsed: false,
-              hidden: false,
-              createdBy: "agent:main",
-            },
-          ],
-        },
-      ],
-    });
-    const swept = sweepExpiredEphemeral(doc, Date.parse("2026-07-13T00:00:00Z"));
-    expect(swept?.tabs[0]?.widgets.map((widget) => widget.id)).toEqual(["future", "pinned"]);
-  });
-
   it("sweeps a widget after it expires even when the document was cached", async () => {
     let now = Date.parse("2026-07-13T00:00:00Z");
     await withTimedStore(
@@ -90,15 +48,34 @@ describe("WorkspaceStore", () => {
       (store) => {
         store.mutate(
           (draft) => {
-            draft.tabs[0]!.widgets.push({
-              id: "temporary",
-              kind: "builtin:markdown",
-              grid: { x: 0, y: 2, w: 4, h: 2 },
-              collapsed: false,
-              hidden: false,
-              createdBy: "agent:main",
-              ephemeral: { expiresAt: "2026-07-14T00:00:00Z" },
-            });
+            draft.tabs[0]!.widgets.push(
+              {
+                id: "temporary",
+                kind: "builtin:markdown",
+                grid: { x: 0, y: 2, w: 4, h: 2 },
+                collapsed: false,
+                hidden: false,
+                createdBy: "agent:main",
+                ephemeral: { expiresAt: "2026-07-14T00:00:00Z" },
+              },
+              {
+                id: "future",
+                kind: "builtin:markdown",
+                grid: { x: 4, y: 2, w: 4, h: 2 },
+                collapsed: false,
+                hidden: false,
+                createdBy: "agent:main",
+                ephemeral: { expiresAt: "2026-08-01T00:00:00Z" },
+              },
+              {
+                id: "pinned",
+                kind: "builtin:markdown",
+                grid: { x: 8, y: 2, w: 4, h: 2 },
+                collapsed: false,
+                hidden: false,
+                createdBy: "agent:main",
+              },
+            );
           },
           { actor: "agent:main" },
         );
@@ -106,9 +83,14 @@ describe("WorkspaceStore", () => {
           true,
         );
         now = Date.parse("2026-07-15T00:00:00Z");
-        expect(store.read().tabs[0]?.widgets.some((widget) => widget.id === "temporary")).toBe(
-          false,
-        );
+        expect(
+          store
+            .read()
+            .tabs[0]?.widgets.filter((widget) =>
+              ["temporary", "future", "pinned"].includes(widget.id),
+            )
+            .map((widget) => widget.id),
+        ).toEqual(["future", "pinned"]);
       },
     );
   });

--- a/extensions/workspaces/src/store.test.ts
+++ b/extensions/workspaces/src/store.test.ts
@@ -2,12 +2,27 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { DEFAULT_WORKSPACE } from "./default-workspace.js";
 import { validateWorkspaceDoc, type WorkspaceDoc } from "./schema.js";
-import { WorkspaceStore } from "./store.js";
+import { sweepExpiredEphemeral, WorkspaceStore } from "./store.js";
 
 async function withStore<T>(run: (store: WorkspaceStore) => Promise<T> | T): Promise<T> {
   const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-"));
   const store = new WorkspaceStore({ stateDir });
+  try {
+    return await run(store);
+  } finally {
+    store.close();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+async function withTimedStore<T>(
+  now: () => number,
+  run: (store: WorkspaceStore) => Promise<T> | T,
+): Promise<T> {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-"));
+  const store = new WorkspaceStore({ stateDir, now });
   try {
     return await run(store);
   } finally {
@@ -27,6 +42,76 @@ function docWithPendingWidget(store: WorkspaceStore): WorkspaceDoc {
 }
 
 describe("WorkspaceStore", () => {
+  it("sweeps expired temporary widgets but preserves future and pinned widgets", () => {
+    const doc = validateWorkspaceDoc({
+      ...structuredClone(DEFAULT_WORKSPACE),
+      tabs: [
+        {
+          ...structuredClone(DEFAULT_WORKSPACE.tabs[0]!),
+          widgets: [
+            {
+              id: "expired",
+              kind: "builtin:markdown",
+              grid: { x: 0, y: 0, w: 4, h: 2 },
+              collapsed: false,
+              hidden: false,
+              createdBy: "agent:main",
+              ephemeral: { expiresAt: "2026-07-01T00:00:00Z" },
+            },
+            {
+              id: "future",
+              kind: "builtin:markdown",
+              grid: { x: 4, y: 0, w: 4, h: 2 },
+              collapsed: false,
+              hidden: false,
+              createdBy: "agent:main",
+              ephemeral: { expiresAt: "2026-08-01T00:00:00Z" },
+            },
+            {
+              id: "pinned",
+              kind: "builtin:markdown",
+              grid: { x: 8, y: 0, w: 4, h: 2 },
+              collapsed: false,
+              hidden: false,
+              createdBy: "agent:main",
+            },
+          ],
+        },
+      ],
+    });
+    const swept = sweepExpiredEphemeral(doc, Date.parse("2026-07-13T00:00:00Z"));
+    expect(swept?.tabs[0]?.widgets.map((widget) => widget.id)).toEqual(["future", "pinned"]);
+  });
+
+  it("sweeps a widget after it expires even when the document was cached", async () => {
+    let now = Date.parse("2026-07-13T00:00:00Z");
+    await withTimedStore(
+      () => now,
+      (store) => {
+        store.mutate(
+          (draft) => {
+            draft.tabs[0]!.widgets.push({
+              id: "temporary",
+              kind: "builtin:markdown",
+              grid: { x: 0, y: 2, w: 4, h: 2 },
+              collapsed: false,
+              hidden: false,
+              createdBy: "agent:main",
+              ephemeral: { expiresAt: "2026-07-14T00:00:00Z" },
+            });
+          },
+          { actor: "agent:main" },
+        );
+        expect(store.read().tabs[0]?.widgets.some((widget) => widget.id === "temporary")).toBe(
+          true,
+        );
+        now = Date.parse("2026-07-15T00:00:00Z");
+        expect(store.read().tabs[0]?.widgets.some((widget) => widget.id === "temporary")).toBe(
+          false,
+        );
+      },
+    );
+  });
   it("seeds the default workspace on first read", async () => {
     await withStore((store) => {
       const doc = store.read();

--- a/extensions/workspaces/src/store.ts
+++ b/extensions/workspaces/src/store.ts
@@ -42,7 +42,7 @@ const DIR_MODE = 0o700;
 const FILE_MODE = 0o600;
 const BUSY_TIMEOUT_MS = 5000;
 
-export function sweepExpiredEphemeral(doc: WorkspaceDoc, nowMs: number): WorkspaceDoc | null {
+function sweepExpiredEphemeral(doc: WorkspaceDoc, nowMs: number): WorkspaceDoc | null {
   let removed = false;
   const tabs = doc.tabs.map((tab) => {
     const widgets = tab.widgets.filter((widget) => {

--- a/extensions/workspaces/src/store.ts
+++ b/extensions/workspaces/src/store.ts
@@ -42,6 +42,25 @@ const DIR_MODE = 0o700;
 const FILE_MODE = 0o600;
 const BUSY_TIMEOUT_MS = 5000;
 
+export function sweepExpiredEphemeral(doc: WorkspaceDoc, nowMs: number): WorkspaceDoc | null {
+  let removed = false;
+  const tabs = doc.tabs.map((tab) => {
+    const widgets = tab.widgets.filter((widget) => {
+      if (!widget.ephemeral) {
+        return true;
+      }
+      const expiry = Date.parse(widget.ephemeral.expiresAt);
+      if (Number.isNaN(expiry) || expiry > nowMs) {
+        return true;
+      }
+      removed = true;
+      return false;
+    });
+    return widgets.length === tab.widgets.length ? tab : { ...tab, widgets };
+  });
+  return removed ? { ...doc, tabs } : null;
+}
+
 const SCHEMA = `
 CREATE TABLE IF NOT EXISTS workspace (
   id INTEGER PRIMARY KEY CHECK (id = 1),
@@ -120,8 +139,12 @@ export class WorkspaceStore {
    * every request without re-parsing a 256 KB document.
    */
   private cached: WorkspaceDoc | null = null;
+  private suppressSweep = false;
 
-  constructor(options: { stateDir?: string } = {}) {
+  private readonly now: () => number;
+
+  constructor(options: { stateDir?: string; now?: () => number } = {}) {
+    this.now = options.now ?? Date.now;
     this.stateDir = options.stateDir ?? resolveStateDir();
     this.workspaceDir = path.join(this.stateDir, "workspaces");
     this.dbPath = path.join(this.workspaceDir, "workspaces.sqlite");
@@ -142,9 +165,22 @@ export class WorkspaceStore {
     this.db.close();
   }
 
+  private sweepOnRead(doc: WorkspaceDoc): WorkspaceDoc {
+    const swept = this.suppressSweep ? null : sweepExpiredEphemeral(doc, this.now());
+    if (!swept) {
+      return structuredClone(doc);
+    }
+    this.suppressSweep = true;
+    try {
+      return this.transact((current) => sweepExpiredEphemeral(current, this.now()) ?? current).doc;
+    } finally {
+      this.suppressSweep = false;
+    }
+  }
+
   read(): WorkspaceDoc {
     if (this.cached) {
-      return structuredClone(this.cached);
+      return this.sweepOnRead(this.cached);
     }
     const row = this.db.prepare("SELECT doc FROM workspace WHERE id = 1").get() as
       | { doc: string }
@@ -156,7 +192,7 @@ export class WorkspaceStore {
     }
     const doc = validateWorkspaceDoc(JSON.parse(row.doc));
     this.cached = doc;
-    return structuredClone(doc);
+    return this.sweepOnRead(doc);
   }
 
   /** Registry entry for one custom widget, or null when it was never scaffolded. */

--- a/extensions/workspaces/src/tools.ts
+++ b/extensions/workspaces/src/tools.ts
@@ -23,6 +23,7 @@ import {
   type WorkspaceGrid,
   type WorkspaceTab,
   type WorkspaceWidget,
+  type WorkspaceEphemeral,
   type JsonValue,
   type WorkspaceDoc,
 } from "./schema.js";
@@ -110,6 +111,10 @@ const BindingSchema = Type.Union([
 const BindingsRecordSchema = Type.Record(Type.String(), BindingSchema, {
   description: "Widget binding map keyed by binding id.",
 });
+const EphemeralSchema = Type.Object(
+  { expiresAt: Type.String({ description: "ISO 8601 expiry timestamp with timezone." }) },
+  { additionalProperties: false },
+);
 const WidgetPatchSchema = Type.Object(
   {
     title: Type.Optional(Type.String({ description: "Widget title, 80 chars max." })),
@@ -118,6 +123,7 @@ const WidgetPatchSchema = Type.Object(
     hidden: Type.Optional(Type.Boolean({ description: "Hide widget." })),
     bindings: Type.Optional(BindingsRecordSchema),
     props: Type.Optional(JsonSchema),
+    ephemeral: Type.Optional(Type.Union([EphemeralSchema, Type.Null()])),
   },
   { additionalProperties: false },
 );
@@ -131,6 +137,7 @@ const WidgetInputSchema = Type.Object(
     hidden: Type.Optional(Type.Boolean({ description: "Initial hidden state." })),
     bindings: Type.Optional(BindingsRecordSchema),
     props: Type.Optional(JsonSchema),
+    ephemeral: Type.Optional(EphemeralSchema),
   },
   { additionalProperties: false },
 );
@@ -321,6 +328,13 @@ function findWidget(tab: WorkspaceTab, id: string): WorkspaceWidget {
   return widget;
 }
 
+function readEphemeralInput(value: unknown): WorkspaceEphemeral {
+  if (!isRecord(value)) {
+    throw new Error("ephemeral must be an object");
+  }
+  return { expiresAt: readRequiredString(value, "expiresAt", "ephemeral.expiresAt") };
+}
+
 function readWidgetInput(
   value: unknown,
   doc: WorkspaceDoc,
@@ -335,6 +349,7 @@ function readWidgetInput(
     "hidden",
     "bindings",
     "props",
+    "ephemeral",
   ]);
   const title = readOptionalString(record, "title");
   const bindings = readBindings(record.bindings);
@@ -348,11 +363,20 @@ function readWidgetInput(
     createdBy: actor,
     ...(bindings !== undefined ? { bindings } : {}),
     ...(record.props !== undefined ? { props: record.props as JsonValue } : {}),
+    ...(record.ephemeral !== undefined ? { ephemeral: readEphemeralInput(record.ephemeral) } : {}),
   };
 }
 
 function readWidgetPatch(value: unknown): Partial<WorkspaceWidget> {
-  const record = readRecord(value, ["title", "grid", "collapsed", "hidden", "bindings", "props"]);
+  const record = readRecord(value, [
+    "title",
+    "grid",
+    "collapsed",
+    "hidden",
+    "bindings",
+    "props",
+    "ephemeral",
+  ]);
   const title = readOptionalString(record, "title");
   const collapsed = readOptionalBoolean(record, "collapsed");
   const hidden = readOptionalBoolean(record, "hidden");
@@ -364,6 +388,9 @@ function readWidgetPatch(value: unknown): Partial<WorkspaceWidget> {
     ...(hidden !== undefined ? { hidden } : {}),
     ...(bindings !== undefined ? { bindings } : {}),
     ...(record.props !== undefined ? { props: record.props as JsonValue } : {}),
+    ...(Object.hasOwn(record, "ephemeral")
+      ? { ephemeral: record.ephemeral === null ? undefined : readEphemeralInput(record.ephemeral) }
+      : {}),
   };
 }
 

--- a/ui/src/components/workspace-widget-cell.test.ts
+++ b/ui/src/components/workspace-widget-cell.test.ts
@@ -20,6 +20,7 @@ function noopCallbacks(): WorkspaceWidgetCellCallbacks {
   return {
     onToggleCollapse: vi.fn(),
     onToggleMenu: vi.fn(),
+    onPin: vi.fn(),
     onHide: vi.fn(),
     onRemove: vi.fn(),
     onEditTitle: vi.fn(),

--- a/ui/src/components/workspace-widget-cell.ts
+++ b/ui/src/components/workspace-widget-cell.ts
@@ -26,6 +26,7 @@ export type WorkspaceWidgetCellCallbacks = {
   onRemove: (widget: WorkspaceWidget) => void;
   onEditTitle: (widget: WorkspaceWidget) => void;
   onMoveToTab: (widget: WorkspaceWidget) => void;
+  onPin: (widget: WorkspaceWidget) => void;
   onMovePointerDown: (widget: WorkspaceWidget, event: PointerEvent) => void;
   onResizePointerDown: (widget: WorkspaceWidget, event: PointerEvent) => void;
   onKeyboardNudge: (
@@ -94,6 +95,17 @@ function renderMenu(
 ): TemplateResult {
   return html`
     <div class="workspace-widget__menu" role="menu">
+      ${widget.ephemeral
+        ? html`<button
+            class="workspace-widget__menu-item"
+            type="button"
+            role="menuitem"
+            data-test-id="workspace-widget-pin"
+            @click=${() => callbacks.onPin(widget)}
+          >
+            Pin
+          </button>`
+        : nothing}
       <button
         class="workspace-widget__menu-item"
         type="button"
@@ -308,6 +320,11 @@ export function renderWidgetCell(props: WorkspaceWidgetCellProps): TemplateResul
           >${displayWidgetTitle(widget.title)}</span
         >
         ${renderProvenanceChip(widget)}
+        ${widget.ephemeral
+          ? html`<span class="workspace-widget__ephemeral" data-test-id="workspace-widget-ephemeral"
+              >Temporary</span
+            >`
+          : nothing}
         <span
           class="workspace-widget__handle"
           role="button"

--- a/ui/src/lib/workspace/bridge.test.ts
+++ b/ui/src/lib/workspace/bridge.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createWidgetBridge,
+  dispatchRateLimitedPrompt,
   isWellFormedInbound,
   resetPromptRateStatesForTest,
   type WidgetBridgeDeps,
@@ -12,6 +13,32 @@ import type { WidgetManifestView } from "./types.ts";
 beforeEach(() => {
   // Rate-limit state is module-level (keyed by widget name); reset between tests.
   resetPromptRateStatesForTest();
+});
+
+describe("shared prompt dispatch gate", () => {
+  it("requires confirmation and rejects concurrent sends", async () => {
+    let release!: (value: boolean) => void;
+    const confirmPrompt = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          release = resolve;
+        }),
+    );
+    const sendPrompt = vi.fn(async () => {});
+    const first = dispatchRateLimitedPrompt({
+      widgetKey: "form:1",
+      text: "run",
+      confirmPrompt,
+      sendPrompt,
+    });
+    await Promise.resolve();
+    await expect(
+      dispatchRateLimitedPrompt({ widgetKey: "form:1", text: "run", confirmPrompt, sendPrompt }),
+    ).resolves.toBe("rate_limited");
+    release(false);
+    await expect(first).resolves.toBe("declined");
+    expect(sendPrompt).not.toHaveBeenCalled();
+  });
 });
 
 function manifest(overrides?: Partial<WidgetManifestView>): WidgetManifestView {

--- a/ui/src/lib/workspace/bridge.ts
+++ b/ui/src/lib/workspace/bridge.ts
@@ -108,6 +108,36 @@ export function resetPromptRateStatesForTest(): void {
   promptRateStates.clear();
 }
 
+export type PromptDispatchOutcome = "sent" | "declined" | "rate_limited";
+
+export async function dispatchRateLimitedPrompt(params: {
+  widgetKey: string;
+  text: string;
+  confirmPrompt: (text: string) => Promise<boolean>;
+  sendPrompt: (text: string) => Promise<void>;
+  now?: () => number;
+}): Promise<PromptDispatchOutcome> {
+  const now = params.now ?? Date.now;
+  const state = getPromptRateState(params.widgetKey);
+  state.timestamps = state.timestamps.filter(
+    (timestamp) => timestamp > now() - PROMPT_RATE_WINDOW_MS,
+  );
+  if (state.inFlight || state.timestamps.length >= PROMPT_RATE_MAX) {
+    return "rate_limited";
+  }
+  state.inFlight = true;
+  try {
+    if (!(await params.confirmPrompt(params.text))) {
+      return "declined";
+    }
+    state.timestamps.push(now());
+    await params.sendPrompt(params.text);
+    return "sent";
+  } finally {
+    state.inFlight = false;
+  }
+}
+
 const INBOUND_TYPES = new Set<WidgetInboundType>([
   "workspace:ready",
   "workspace:getData",
@@ -145,7 +175,6 @@ export function createWidgetBridge(deps: WidgetBridgeDeps): WidgetBridge {
   let disposed = false;
   // Rate-limit state is keyed by the widget NAME (stable identity), so it persists
   // across bridge re-instantiation when the iframe is recreated.
-  const rateState = getPromptRateState(deps.manifest.name);
   const pendingTimers = new Set<ReturnType<typeof setTimeout>>();
 
   function error(code: WidgetErrorCode, message: string, requestId?: string): void {
@@ -217,31 +246,26 @@ export function createWidgetBridge(deps: WidgetBridgeDeps): WidgetBridge {
     }
     // Rate limit: at most one in-flight prompt and 10 per rolling minute, keyed by
     // widget name so a remount cannot reset the budget.
-    const cutoff = now() - PROMPT_RATE_WINDOW_MS;
-    rateState.timestamps = rateState.timestamps.filter((ts) => ts > cutoff);
-    if (rateState.inFlight || rateState.timestamps.length >= PROMPT_RATE_MAX) {
-      error("rate_limited", "prompt send rate limit exceeded", requestId);
-      return;
-    }
-    rateState.inFlight = true;
     try {
-      const confirmed = await deps.confirmPrompt(text);
+      const outcome = await dispatchRateLimitedPrompt({
+        widgetKey: deps.manifest.name,
+        text,
+        confirmPrompt: async (prompt) => (await deps.confirmPrompt(prompt)) && !disposed,
+        sendPrompt: deps.sendPrompt,
+        now,
+      });
       if (disposed) {
         return;
       }
-      if (!confirmed) {
-        // Deny path sends NOTHING.
+      if (outcome === "rate_limited") {
+        error("rate_limited", "prompt send rate limit exceeded", requestId);
+      } else if (outcome === "declined") {
         error("prompt_declined", "operator declined the prompt", requestId);
-        return;
       }
-      rateState.timestamps.push(now());
-      await deps.sendPrompt(text);
     } catch (err) {
       if (!disposed) {
         error("resolve_failed", err instanceof Error ? err.message : String(err), requestId);
       }
-    } finally {
-      rateState.inFlight = false;
     }
   }
 
@@ -326,7 +350,7 @@ export function createWidgetBridge(deps: WidgetBridgeDeps): WidgetBridge {
       // Release the in-flight lock so a remount can send again, but PRESERVE the
       // rolling-window timestamps — clearing them would reopen the very reset hole
       // this state exists to close.
-      rateState.inFlight = false;
+      getPromptRateState(deps.manifest.name).inFlight = false;
     },
   };
 }

--- a/ui/src/lib/workspace/index.ts
+++ b/ui/src/lib/workspace/index.ts
@@ -176,6 +176,9 @@ function normalizeWidget(value: unknown): WorkspaceWidget | null {
     ...(typeof value.createdBy === "string" ? { createdBy: value.createdBy } : {}),
     ...(normalizeBindings(value.bindings) ? { bindings: normalizeBindings(value.bindings) } : {}),
     ...(isRecord(value.props) ? { props: value.props } : {}),
+    ...(isRecord(value.ephemeral) && typeof value.ephemeral.expiresAt === "string"
+      ? { ephemeral: { expiresAt: value.ephemeral.expiresAt } }
+      : {}),
   };
 }
 
@@ -619,6 +622,23 @@ export function updateWidgetTitle(
         ...widget,
         title: params.title,
       })),
+  });
+}
+
+export function pinWidget(
+  state: WorkspaceUiState,
+  client: GatewayBrowserClient | null,
+  params: { slug: string; widgetId: string },
+): Promise<void> {
+  return optimisticMutation(state, client, {
+    widgetId: params.widgetId,
+    method: "workspaces.widget.update",
+    rpcParams: { tab: params.slug, id: params.widgetId, patch: { ephemeral: null } },
+    optimistic: (workspace) =>
+      replaceWidget(workspace, params.slug, params.widgetId, (widget) => {
+        const { ephemeral: _ephemeral, ...rest } = widget;
+        return rest;
+      }),
   });
 }
 

--- a/ui/src/lib/workspace/types.ts
+++ b/ui/src/lib/workspace/types.ts
@@ -44,6 +44,7 @@ export type WorkspaceWidget = {
   createdBy?: WorkspaceCreatedBy;
   bindings?: Record<string, WorkspaceBinding>;
   props?: Record<string, unknown>;
+  ephemeral?: { expiresAt: string };
 };
 
 export type WorkspaceTab = {

--- a/ui/src/lib/workspace/widgets/action-form.ts
+++ b/ui/src/lib/workspace/widgets/action-form.ts
@@ -86,7 +86,7 @@ export function renderActionForm(
     const values: Record<string, string> = {};
     for (const field of model.fields) {
       const control = form.elements.namedItem(field.name);
-      values[field.name] = control && "value" in control ? String(control.value) : "";
+      values[field.name] = control && "value" in control ? control.value : "";
     }
     const text = buildActionFormPrompt(model, values);
     if (text.trim()) {

--- a/ui/src/lib/workspace/widgets/action-form.ts
+++ b/ui/src/lib/workspace/widgets/action-form.ts
@@ -2,15 +2,15 @@ import { html, type TemplateResult } from "lit";
 import type { WorkspaceWidget } from "../types.ts";
 import { isRecord, widgetProps, type BuiltinWidgetContext } from "./types.ts";
 
-export type ActionFormField = {
+type ActionFormField = {
   name: string;
   label: string;
   type: "text" | "number" | "select";
   options?: string[];
   maxLength?: number;
 };
-export type ActionFormModel = { template: string; fields: ActionFormField[]; buttonLabel: string };
-export const ACTION_FORM_DEFAULT_MAX_LENGTH = 200;
+type ActionFormModel = { template: string; fields: ActionFormField[]; buttonLabel: string };
+const ACTION_FORM_DEFAULT_MAX_LENGTH = 200;
 const SLOT_PATTERN = /\{([A-Za-z0-9_]+)\}/g;
 
 function mapField(value: unknown): ActionFormField | null {
@@ -40,7 +40,7 @@ function mapField(value: unknown): ActionFormField | null {
   };
 }
 
-export function mapActionForm(widget: WorkspaceWidget): ActionFormModel {
+function mapActionForm(widget: WorkspaceWidget): ActionFormModel {
   const props = widgetProps(widget);
   return {
     template: typeof props.template === "string" ? props.template : "",
@@ -51,7 +51,7 @@ export function mapActionForm(widget: WorkspaceWidget): ActionFormModel {
   };
 }
 
-export function coerceFieldValue(field: ActionFormField, raw: string): string {
+function coerceFieldValue(field: ActionFormField, raw: string): string {
   const cap = field.maxLength ?? ACTION_FORM_DEFAULT_MAX_LENGTH;
   if (field.type === "number") {
     const value = raw.trim();
@@ -63,10 +63,7 @@ export function coerceFieldValue(field: ActionFormField, raw: string): string {
   return raw.slice(0, cap);
 }
 
-export function buildActionFormPrompt(
-  model: ActionFormModel,
-  values: Record<string, string>,
-): string {
+function buildActionFormPrompt(model: ActionFormModel, values: Record<string, string>): string {
   const fields = new Map(model.fields.map((field) => [field.name, field]));
   return model.template.replace(SLOT_PATTERN, (match, name: string) => {
     const field = fields.get(name);

--- a/ui/src/lib/workspace/widgets/action-form.ts
+++ b/ui/src/lib/workspace/widgets/action-form.ts
@@ -1,0 +1,123 @@
+import { html, type TemplateResult } from "lit";
+import type { WorkspaceWidget } from "../types.ts";
+import { isRecord, widgetProps, type BuiltinWidgetContext } from "./types.ts";
+
+export type ActionFormField = {
+  name: string;
+  label: string;
+  type: "text" | "number" | "select";
+  options?: string[];
+  maxLength?: number;
+};
+export type ActionFormModel = { template: string; fields: ActionFormField[]; buttonLabel: string };
+export const ACTION_FORM_DEFAULT_MAX_LENGTH = 200;
+const SLOT_PATTERN = /\{([A-Za-z0-9_]+)\}/g;
+
+function mapField(value: unknown): ActionFormField | null {
+  if (!isRecord(value) || typeof value.name !== "string" || typeof value.label !== "string") {
+    return null;
+  }
+  if (value.type !== "text" && value.type !== "number" && value.type !== "select") {
+    return null;
+  }
+  const options =
+    value.type === "select" && Array.isArray(value.options)
+      ? value.options.filter((option): option is string => typeof option === "string")
+      : undefined;
+  if (value.type === "select" && !options?.length) {
+    return null;
+  }
+  const maxLength =
+    typeof value.maxLength === "number" && Number.isInteger(value.maxLength) && value.maxLength > 0
+      ? value.maxLength
+      : undefined;
+  return {
+    name: value.name,
+    label: value.label,
+    type: value.type,
+    ...(options ? { options } : {}),
+    ...(maxLength ? { maxLength } : {}),
+  };
+}
+
+export function mapActionForm(widget: WorkspaceWidget): ActionFormModel {
+  const props = widgetProps(widget);
+  return {
+    template: typeof props.template === "string" ? props.template : "",
+    fields: Array.isArray(props.fields)
+      ? props.fields.map(mapField).filter((field): field is ActionFormField => field !== null)
+      : [],
+    buttonLabel: typeof props.buttonLabel === "string" ? props.buttonLabel : "Send",
+  };
+}
+
+export function coerceFieldValue(field: ActionFormField, raw: string): string {
+  const cap = field.maxLength ?? ACTION_FORM_DEFAULT_MAX_LENGTH;
+  if (field.type === "number") {
+    const value = raw.trim();
+    return value && Number.isFinite(Number(value)) ? value.slice(0, cap) : "";
+  }
+  if (field.type === "select") {
+    return field.options?.includes(raw) ? raw : "";
+  }
+  return raw.slice(0, cap);
+}
+
+export function buildActionFormPrompt(
+  model: ActionFormModel,
+  values: Record<string, string>,
+): string {
+  const fields = new Map(model.fields.map((field) => [field.name, field]));
+  return model.template.replace(SLOT_PATTERN, (match, name: string) => {
+    const field = fields.get(name);
+    return field ? coerceFieldValue(field, values[name] ?? "") : match;
+  });
+}
+
+export function renderActionForm(
+  widget: WorkspaceWidget,
+  _value: unknown,
+  ctx: BuiltinWidgetContext,
+): TemplateResult {
+  const model = mapActionForm(widget);
+  const submit = (event: Event) => {
+    event.preventDefault();
+    const form = event.currentTarget as HTMLFormElement;
+    const values: Record<string, string> = {};
+    for (const field of model.fields) {
+      const control = form.elements.namedItem(field.name);
+      values[field.name] = control && "value" in control ? String(control.value) : "";
+    }
+    const text = buildActionFormPrompt(model, values);
+    if (text.trim()) {
+      void ctx
+        .dispatchPrompt?.({ widgetKey: `builtin:action-form:${widget.id}`, text })
+        .then((result) => {
+          if (result === "sent") {
+            form.reset();
+          }
+        });
+    }
+  };
+  return html`<form
+    class="workspace-action-form"
+    data-test-id="workspace-action-form"
+    @submit=${submit}
+  >
+    ${model.fields.map(
+      (field) =>
+        html`<label
+          >${field.label}${field.type === "select"
+            ? html`<select name=${field.name}>
+                ${field.options?.map((option) => html`<option value=${option}>${option}</option>`)}
+              </select>`
+            : html`<input
+                name=${field.name}
+                type=${field.type}
+                maxlength=${field.maxLength ?? ACTION_FORM_DEFAULT_MAX_LENGTH}
+              />`}</label
+        >`,
+    )}
+    <button class="btn btn--small btn--primary" type="submit">${model.buttonLabel}</button>
+  </form>`;
+}

--- a/ui/src/lib/workspace/widgets/index.ts
+++ b/ui/src/lib/workspace/widgets/index.ts
@@ -4,6 +4,7 @@
 // one entry here; the plugin schema's BUILTIN_KIND_PATTERN must list the same
 // names (extensions/workspaces/src/schema.ts).
 
+import { renderActionForm } from "./action-form.ts";
 import { renderActivity } from "./activity.ts";
 import { renderCron } from "./cron.ts";
 import { renderIframeEmbed } from "./iframe-embed.ts";
@@ -25,6 +26,7 @@ export const BUILTIN_WIDGET_RENDERERS: Record<string, BuiltinWidgetRenderer> = {
   cron: (widget, value) => renderCron(widget, value),
   instances: (widget, value) => renderInstances(widget, value),
   activity: (widget, value) => renderActivity(widget, value),
+  "action-form": renderActionForm,
 };
 
 export function getBuiltinRenderer(kind: string): BuiltinWidgetRenderer | undefined {

--- a/ui/src/lib/workspace/widgets/types.ts
+++ b/ui/src/lib/workspace/widgets/types.ts
@@ -11,6 +11,7 @@
 
 import type { TemplateResult } from "lit";
 import type { ApplicationConfigCapability } from "../../../app/config.ts";
+import type { PromptDispatchOutcome } from "../bridge.ts";
 import type { WorkspaceWidget } from "../types.ts";
 
 /** Ambient context a builtin may need beyond its own binding value. */
@@ -22,6 +23,7 @@ export type BuiltinWidgetContext = {
     ApplicationConfigCapability["current"],
     "embedSandboxMode" | "allowExternalEmbedUrls"
   >;
+  dispatchPrompt?: (params: { widgetKey: string; text: string }) => Promise<PromptDispatchOutcome>;
 };
 
 /** A builtin widget renderer: pure, side-effect-free, throws only on real bugs. */

--- a/ui/src/lib/workspace/widgets/widgets.test.ts
+++ b/ui/src/lib/workspace/widgets/widgets.test.ts
@@ -6,6 +6,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { render } from "lit";
 import { describe, expect, it } from "vitest";
 import type { WorkspaceWidget } from "../types.ts";
+import { buildActionFormPrompt, coerceFieldValue, mapActionForm } from "./action-form.ts";
 import { mapActivity, renderActivity } from "./activity.ts";
 import { mapCron, renderCron } from "./cron.ts";
 import { evaluateEmbedUrl, renderIframeEmbed } from "./iframe-embed.ts";
@@ -27,6 +28,25 @@ function widget(overrides: Partial<WorkspaceWidget> = {}): WorkspaceWidget {
     ...overrides,
   };
 }
+
+describe("action-form", () => {
+  it("interpolates declared slots once and bounds typed values", () => {
+    const model = mapActionForm(
+      widget({
+        kind: "builtin:action-form",
+        props: {
+          template: "Run {topic} {count}",
+          fields: [
+            { name: "topic", label: "Topic", type: "text", maxLength: 8 },
+            { name: "count", label: "Count", type: "number" },
+          ],
+        },
+      }),
+    );
+    expect(buildActionFormPrompt(model, { topic: "{count}!!", count: "3" })).toBe("Run {count}! 3");
+    expect(coerceFieldValue(model.fields[1]!, "not-a-number")).toBe("");
+  });
+});
 
 function renderToContainer(template: unknown): HTMLElement {
   const container = document.createElement("div");

--- a/ui/src/lib/workspace/widgets/widgets.test.ts
+++ b/ui/src/lib/workspace/widgets/widgets.test.ts
@@ -6,7 +6,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { render } from "lit";
 import { describe, expect, it } from "vitest";
 import type { WorkspaceWidget } from "../types.ts";
-import { buildActionFormPrompt, coerceFieldValue, mapActionForm } from "./action-form.ts";
+import { renderActionForm } from "./action-form.ts";
 import { mapActivity, renderActivity } from "./activity.ts";
 import { mapCron, renderCron } from "./cron.ts";
 import { evaluateEmbedUrl, renderIframeEmbed } from "./iframe-embed.ts";
@@ -30,21 +30,40 @@ function widget(overrides: Partial<WorkspaceWidget> = {}): WorkspaceWidget {
 }
 
 describe("action-form", () => {
-  it("interpolates declared slots once and bounds typed values", () => {
-    const model = mapActionForm(
-      widget({
-        kind: "builtin:action-form",
-        props: {
-          template: "Run {topic} {count}",
-          fields: [
-            { name: "topic", label: "Topic", type: "text", maxLength: 8 },
-            { name: "count", label: "Count", type: "number" },
-          ],
+  it("interpolates declared slots once and bounds typed values", async () => {
+    const sent: string[] = [];
+    const container = renderToContainer(
+      renderActionForm(
+        widget({
+          kind: "builtin:action-form",
+          props: {
+            template: "Run {topic} {count}",
+            fields: [
+              { name: "topic", label: "Topic", type: "text", maxLength: 8 },
+              { name: "count", label: "Count", type: "number" },
+            ],
+          },
+        }),
+        undefined,
+        {
+          ...STRICT_EMBED,
+          dispatchPrompt: async ({ text }) => {
+            sent.push(text);
+            return "sent";
+          },
         },
-      }),
+      ),
     );
-    expect(buildActionFormPrompt(model, { topic: "{count}!!", count: "3" })).toBe("Run {count}! 3");
-    expect(coerceFieldValue(model.fields[1]!, "not-a-number")).toBe("");
+    const topic = container.querySelector<HTMLInputElement>('input[name="topic"]')!;
+    const count = container.querySelector<HTMLInputElement>('input[name="count"]')!;
+    topic.value = "{count}!!";
+    count.value = "3";
+    container
+      .querySelector<HTMLFormElement>("form")!
+      .dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    await Promise.resolve();
+    expect(sent).toEqual(["Run {count}! 3"]);
+    expect(topic.maxLength).toBe(8);
   });
 });
 

--- a/ui/src/pages/plugin/workspace-view.ts
+++ b/ui/src/pages/plugin/workspace-view.ts
@@ -16,6 +16,8 @@ import {
   type WorkspaceWidgetCellCallbacks,
 } from "../../components/workspace-widget-cell.ts";
 import { t } from "../../i18n/index.ts";
+import { generateUUID } from "../../lib/uuid.ts";
+import { dispatchRateLimitedPrompt } from "../../lib/workspace/bridge.ts";
 import {
   beginDrag,
   collides,
@@ -42,6 +44,7 @@ import {
   moveWidgetToTab,
   orderedTabs,
   removeWidgetFromTab,
+  pinWidget,
   resolveActiveSlug,
   registerActiveDrag,
   resolveBinding,
@@ -568,6 +571,23 @@ function renderGrid(
   const builtinContext: BuiltinWidgetContext = {
     basePath: props.basePath ?? "",
     embed: props.embed ?? DEFAULT_EMBED_CONTEXT,
+    dispatchPrompt: ({ widgetKey, text }) =>
+      dispatchRateLimitedPrompt({
+        widgetKey,
+        text,
+        confirmPrompt: async (prompt) => typeof window !== "undefined" && window.confirm(prompt),
+        sendPrompt: async (message) => {
+          if (!props.client) {
+            throw new Error("Not connected.");
+          }
+          await props.client.request("chat.send", {
+            sessionKey: props.sessionKey ?? "main",
+            message,
+            deliver: false,
+            idempotencyKey: generateUUID(),
+          });
+        },
+      }),
   };
   const rows = gridRowCount(tab.widgets);
   const minHeight = rows * WORKSPACE_ROW_HEIGHT + Math.max(0, rows - 1) * WORKSPACE_GRID_GAP;
@@ -712,6 +732,10 @@ function makeCallbacks(
     onRemove: (widget) => {
       viewState.openMenuWidgetId = null;
       void removeWidgetFromTab(state, props.client, { slug: tab.slug, widgetId: widget.id });
+    },
+    onPin: (widget) => {
+      viewState.openMenuWidgetId = null;
+      void pinWidget(state, props.client, { slug: tab.slug, widgetId: widget.id });
     },
     onEditTitle: (widget) => {
       viewState.openMenuWidgetId = null;


### PR DESCRIPTION
## What Problem This Solves

Agents need a safe way to publish temporary answers into Workspaces and let operators explicitly pin useful results. Workspaces also needs a bounded action form that can send a declared prompt without creating an arbitrary execution surface. The legacy implementation targeted the removed dashboard stack.

## Why This Change Was Made

This rebuild adds ephemeral widget expiry and explicit `ephemeral: null` pinning to current Workspaces, including transactional lazy TTL cleanup that rechecks cached documents. It also adds `builtin:action-form` with bounded declared fields, single-pass interpolation, explicit confirmation, and a shared dispatch gate limited to one in-flight request and ten requests per minute. Dispatch uses the existing `chat.send` permission path with `deliver: false`; it does not add eval, arbitrary RPC, or a new execution authority.

## User Impact

Agent-created Living Answers can expire automatically, display a Temporary badge, and be pinned by an operator. Action forms can collect bounded input and submit a confirmed prompt while remaining inside existing agent permissions and rate limits. Expired content is removed consistently even when a cached workspace document is involved.

## Evidence

- Rebased onto upstream main at `843e3c787806389cdaac884300e671fba658dab6` during the final recovery pass; all three commits range-diff identically and keep concrete workspace binding helpers private.
- The validated implementation suite passed 158 assertions across nine files before the final exact restack, including cached-expiry behavior.
- Final-head focused proof passed 41 extension assertions plus 59 unaffected UI assertions. Three additional UI suites were blocked before collection because this worktree's shared `node_modules` still lacks current main's `remend` dependency; GitHub Actions remains the canonical clean-dependency gate.
- Scoped `oxlint`: clean; `git diff --check`: clean.
- Local autoreview: exit 0 with no remaining actionable findings.
- No generated locale output was hand-edited; v1 reuses literal field labels and introduced no generated-locale drift.
