### PR TITLE
fix(memory-core): guard supplement lookup in resolveMemoryReadFailureResult with try-catch (fixes #101809)

### DIFF
--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -705,12 +705,10 @@ describe("memory tools", () => {
     expect(getSupplement).not.toHaveBeenCalled();
   });
 
-  it("returns structured error when supplement lookup throws in memory_get corpus=all fallback", async () => {
-    // Primary memory read → throw → enters catch → resolveMemoryReadFailureResult
+  it("returns the primary error when a corpus=all supplement fallback throws", async () => {
     setMemoryReadFileImpl(async () => {
       throw new Error("primary read failed");
     });
-    // Supplement get → throw → would be uncaught without the fix
     registerMemoryCorpusSupplement("memory-wiki", {
       search: async () => [],
       get: async () => {
@@ -724,21 +722,11 @@ describe("memory tools", () => {
       corpus: "all",
     });
 
-    // Must receive the PRIMARY structured error result, NOT an unhandled rejection
-    // from the supplement's thrown error. The error message must reference the
-    // original primary read failure, not the supplement failure.
-    const details = result.details as {
-      path: string;
-      text: string;
-      disabled: boolean;
-      error: string;
-    };
-    expect(details).toEqual({
+    expect(result.details).toEqual({
       path: "entities/alpha.md",
       text: "",
       disabled: true,
-      error: expect.stringContaining("primary read failed"),
+      error: "primary read failed",
     });
-    expect(details.error).not.toContain("supplement lookup failed");
   });
 });

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -704,4 +704,41 @@ describe("memory tools", () => {
     });
     expect(getSupplement).not.toHaveBeenCalled();
   });
+
+  it("returns structured error when supplement lookup throws in memory_get corpus=all fallback", async () => {
+    // Primary memory read → throw → enters catch → resolveMemoryReadFailureResult
+    setMemoryReadFileImpl(async () => {
+      throw new Error("primary read failed");
+    });
+    // Supplement get → throw → would be uncaught without the fix
+    registerMemoryCorpusSupplement("memory-wiki", {
+      search: async () => [],
+      get: async () => {
+        throw new Error("supplement lookup failed");
+      },
+    });
+
+    const tool = createMemoryGetToolOrThrow();
+    const result = await tool.execute("call_get_all_supplement_throws", {
+      path: "entities/alpha.md",
+      corpus: "all",
+    });
+
+    // Must receive the PRIMARY structured error result, NOT an unhandled rejection
+    // from the supplement's thrown error. The error message must reference the
+    // original primary read failure, not the supplement failure.
+    const details = result.details as {
+      path: string;
+      text: string;
+      disabled: boolean;
+      error: string;
+    };
+    expect(details).toEqual({
+      path: "entities/alpha.md",
+      text: "",
+      disabled: true,
+      error: expect.stringContaining("primary read failed"),
+    });
+    expect(details.error).not.toContain("supplement lookup failed");
+  });
 });

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -360,7 +360,8 @@ async function resolveMemoryReadFailureResult(params: {
         return jsonResult(supplement);
       }
     } catch {
-      // Supplement lookup failed; fall through to return the primary error result.
+      // Supplement lookup is best-effort after the primary memory read failed.
+      // Preserve the original structured error instead of rejecting the tool call.
     }
   }
   const message = formatErrorMessage(params.error);

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -348,15 +348,19 @@ async function resolveMemoryReadFailureResult(params: {
   agentSessionKey?: string;
 }) {
   if (params.requestedCorpus === "all") {
-    const supplement = await getSupplementMemoryReadResult({
-      relPath: params.relPath,
-      from: params.from,
-      lines: params.lines,
-      agentSessionKey: params.agentSessionKey,
-      corpus: params.requestedCorpus,
-    });
-    if (supplement) {
-      return jsonResult(supplement);
+    try {
+      const supplement = await getSupplementMemoryReadResult({
+        relPath: params.relPath,
+        from: params.from,
+        lines: params.lines,
+        agentSessionKey: params.agentSessionKey,
+        corpus: params.requestedCorpus,
+      });
+      if (supplement) {
+        return jsonResult(supplement);
+      }
+    } catch {
+      // Supplement lookup failed; fall through to return the primary error result.
     }
   }
   const message = formatErrorMessage(params.error);


### PR DESCRIPTION
## What Problem This Solves

When `memory_get corpus=all` primary read fails, the tool calls `resolveMemoryReadFailureResult` which attempts supplement lookup via `getSupplementMemoryReadResult()`. If the supplement lookup throws (e.g., config loading or database issue), the error propagates as an unhandled rejection because:

1. `resolveMemoryReadFailureResult` is **already inside the outer `catch` block** of `executeMemoryReadResult`
2. The supplement call inside it **has no try-catch guard**
3. The error escapes as an unhandled rejection instead of returning the structured `{disabled: true}` error result

Fixes #101809.

## Changes

### `extensions/memory-core/src/tools.ts`

Wrap the supplement lookup call in `resolveMemoryReadFailureResult` with try-catch. When supplement lookup fails, fall through to return the original primary memory-read structured error (`{path, text: "", disabled: true, error: "..."}`) instead of crashing.

### `extensions/memory-core/src/tools.citations.test.ts`

Add proof test `"returns structured error when supplement lookup throws in memory_get corpus=all fallback"`:
1. Primary memory read throws
2. Registered corpus supplement `get()` throws
3. Asserts the result is the **original primary disabled result** (`error` contains "primary read failed", does NOT contain "supplement lookup failed")

## Evidence

**Unit tests (23/23 passed):**
```
 RUN  v4.1.9 /home/0668001248/IdeaProjects/zw-openclaw/openclaw

 Test Files  1 passed (1)
      Tests  23 passed (23)
   Start at  06:47:49
   Duration  134.44s
```

**Real behavior proof — before fix (test fails, uncaught exception):**
```
 FAIL  |extension-memory| ... > returns structured error when supplement lookup throws in memory_get corpus=all fallback
Error: supplement lookup failed
 ❯ Object.get tools.citations.test.ts:717:15
 ❯ getMemoryCorpusSupplementResult tools.shared.ts:193:50
 ❯ getSupplementMemoryReadResult tools.ts:325:28
 ❯ resolveMemoryReadFailureResult tools.ts:351:30   ← THE BUG: no try-catch
 ❯ executeMemoryReadResult tools.ts:394:18

 Test Files  1 failed (1)
      Tests  1 failed | 22 skipped (23)
```

**Real behavior proof — after fix (test passes, structured error returned):**

Vitest output:
```
 RUN  v4.1.9 /home/0668001248/IdeaProjects/zw-openclaw/openclaw

 Test Files  1 passed (1)
      Tests  1 passed | 22 skipped (23)
   Start at  07:05:13
   Duration  70.78s
```

The test validates that when primary read fails with `"primary read failed"` and supplement `get()` throws `"supplement lookup failed"`, the returned result is:

```typescript
{
  path: "entities/alpha.md",
  text: "",
  disabled: true,
  error: expect.stringContaining("primary read failed"),   // original primary error preserved
  // error does NOT contain "supplement lookup failed"       // supplement error caught & discarded
}
```

**Verification summary:**
| Assertion | Result | Meaning |
|-----------|--------|---------|
| `details.disabled === true` | ✅ | Structured error, not a crash |
| `details.error` contains "primary read failed" | ✅ | Original primary error preserved |
| `details.error` does NOT contain "supplement lookup failed" | ✅ | Supplement error was caught and discarded |

## Review
- Manually reviewed and verified
- AI-assisted: Yes
- Fixes #101809