### PR TITLE
refactor(deadcode): localize msteams declarations

### DIFF
--- a/extensions/msteams/src/conversation-store-state.ts
+++ b/extensions/msteams/src/conversation-store-state.ts
@@ -26,9 +26,9 @@ export type MSTeamsLegacyConversationStoreData = {
 
 export const MSTEAMS_CONVERSATIONS_LEGACY_FILENAME = "msteams-conversations.json";
 export const MSTEAMS_CONVERSATIONS_NAMESPACE = "conversations";
-export const MSTEAMS_MAX_CONVERSATIONS = 1000;
+const MSTEAMS_MAX_CONVERSATIONS = 1000;
 export const MSTEAMS_SQLITE_MAX_CONVERSATION_ROWS = MSTEAMS_MAX_CONVERSATIONS + 1000;
-export const MSTEAMS_CONVERSATION_TTL_MS = 365 * 24 * 60 * 60 * 1000;
+const MSTEAMS_CONVERSATION_TTL_MS = 365 * 24 * 60 * 60 * 1000;
 const CONVERSATION_LOCK_FILENAME = "msteams-conversations.sqlite.lock";
 
 type MSTeamsConversationStoreStateOptions = {

--- a/extensions/msteams/src/feedback-reflection.ts
+++ b/extensions/msteams/src/feedback-reflection.ts
@@ -22,7 +22,7 @@ import { getMSTeamsRuntime } from "./runtime.js";
 import { sendMSTeamsActivityWithReference } from "./sdk-proactive.js";
 import type { MSTeamsApp } from "./sdk.js";
 
-export type FeedbackEvent = {
+type FeedbackEvent = {
   type: "custom";
   event: "feedback";
   ts: number;
@@ -56,7 +56,7 @@ export function buildFeedbackEvent(params: {
   };
 }
 
-export type RunFeedbackReflectionParams = {
+type RunFeedbackReflectionParams = {
   cfg: OpenClawConfig;
   app: MSTeamsApp;
   appId: string;

--- a/extensions/msteams/src/graph-messages.ts
+++ b/extensions/msteams/src/graph-messages.ts
@@ -129,13 +129,13 @@ export function resolveConversationPath(to: string): {
   };
 }
 
-export type GetMessageMSTeamsParams = {
+type GetMessageMSTeamsParams = {
   cfg: OpenClawConfig;
   to: string;
   messageId: string;
 };
 
-export type GetMessageMSTeamsResult = {
+type GetMessageMSTeamsResult = {
   id: string;
   text: string | undefined;
   from: GraphMessageFrom | undefined;
@@ -161,7 +161,7 @@ export async function getMessageMSTeams(
   };
 }
 
-export type PinMessageMSTeamsParams = {
+type PinMessageMSTeamsParams = {
   cfg: OpenClawConfig;
   to: string;
   messageId: string;
@@ -206,7 +206,7 @@ export async function pinMessageMSTeams(
   return { ok: true, pinnedMessageId: result.id };
 }
 
-export type UnpinMessageMSTeamsParams = {
+type UnpinMessageMSTeamsParams = {
   cfg: OpenClawConfig;
   to: string;
   /** The pinned-message resource ID returned by pin or list-pins (not the message ID). */
@@ -238,12 +238,12 @@ export async function unpinMessageMSTeams(
   return { ok: true };
 }
 
-export type ListPinsMSTeamsParams = {
+type ListPinsMSTeamsParams = {
   cfg: OpenClawConfig;
   to: string;
 };
 
-export type ListPinsMSTeamsResult = {
+type ListPinsMSTeamsResult = {
   pins: Array<{ id: string; pinnedMessageId: string; messageId?: string; text?: string }>;
 };
 
@@ -317,14 +317,14 @@ type GraphMessageWithReactions = GraphMessage & {
   reactions?: GraphReaction[];
 };
 
-export type ReactMessageMSTeamsParams = {
+type ReactMessageMSTeamsParams = {
   cfg: OpenClawConfig;
   to: string;
   messageId: string;
   reactionType: string;
 };
 
-export type ListReactionsMSTeamsParams = {
+type ListReactionsMSTeamsParams = {
   cfg: OpenClawConfig;
   to: string;
   messageId: string;
@@ -340,7 +340,7 @@ const REACTION_TYPE_EMOJI: Record<string, string> = {
   angry: "\u{1F621}",
 };
 
-export type ReactionSummary = {
+type ReactionSummary = {
   reactionType: string;
   /** Display name for the reaction (matches reactionType for known types). */
   name: string;
@@ -350,7 +350,7 @@ export type ReactionSummary = {
   users: Array<{ id: string; displayName?: string }>;
 };
 
-export type ListReactionsMSTeamsResult = {
+type ListReactionsMSTeamsResult = {
   reactions: ReactionSummary[];
 };
 
@@ -460,7 +460,7 @@ export async function listReactionsMSTeams(
 // Search
 // ---------------------------------------------------------------------------
 
-export type SearchMessagesMSTeamsParams = {
+type SearchMessagesMSTeamsParams = {
   cfg: OpenClawConfig;
   to: string;
   query: string;
@@ -468,7 +468,7 @@ export type SearchMessagesMSTeamsParams = {
   limit?: number;
 };
 
-export type SearchMessagesMSTeamsResult = {
+type SearchMessagesMSTeamsResult = {
   messages: Array<{
     id: string;
     text: string | undefined;

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -45,7 +45,7 @@ import { sendMSTeamsActivityWithReference } from "./sdk-proactive.js";
 import type { MSTeamsActivityLike } from "./sdk-types.js";
 import type { MSTeamsApp } from "./sdk.js";
 
-export type MSTeamsConversationReference = {
+type MSTeamsConversationReference = {
   activityId?: string;
   user?: { id?: string; name?: string; aadObjectId?: string };
   agent?: { id?: string; name?: string; aadObjectId?: string } | null;
@@ -67,7 +67,7 @@ export type MSTeamsConversationReference = {
   aadObjectId?: string;
 };
 
-export type MSTeamsReplyRenderOptions = {
+type MSTeamsReplyRenderOptions = {
   textChunkLimit: number;
   chunkText?: boolean;
   mediaMode?: "split" | "inline";
@@ -84,13 +84,13 @@ export type MSTeamsRenderedMessage = {
   mediaUrl?: string;
 };
 
-export type MSTeamsSendRetryOptions = {
+type MSTeamsSendRetryOptions = {
   maxAttempts?: number;
   baseDelayMs?: number;
   maxDelayMs?: number;
 };
 
-export type MSTeamsSendRetryEvent = {
+type MSTeamsSendRetryEvent = {
   messageIndex: number;
   messageCount: number;
   nextAttempt: number;

--- a/extensions/msteams/src/pending-uploads.ts
+++ b/extensions/msteams/src/pending-uploads.ts
@@ -8,7 +8,7 @@
 
 import crypto from "node:crypto";
 
-export interface PendingUpload {
+interface PendingUpload {
   id: string;
   buffer: Buffer;
   filename: string;

--- a/extensions/msteams/src/polls.ts
+++ b/extensions/msteams/src/polls.ts
@@ -67,10 +67,10 @@ export type StoredMSTeamsPollVoteBucket = {
 export const MSTEAMS_POLLS_LEGACY_FILENAME = "msteams-polls.json";
 export const MSTEAMS_POLLS_NAMESPACE = "polls";
 export const MSTEAMS_POLL_VOTE_BUCKETS_NAMESPACE = "poll-vote-buckets";
-export const MSTEAMS_MAX_POLLS = 1000;
+const MSTEAMS_MAX_POLLS = 1000;
 export const MSTEAMS_SQLITE_MAX_POLL_ROWS = MSTEAMS_MAX_POLLS + 1000;
 // Keep worst-case retained vote buckets below plugin-state's per-plugin live row cap.
-export const MSTEAMS_POLL_VOTE_BUCKET_COUNT = 32;
+const MSTEAMS_POLL_VOTE_BUCKET_COUNT = 32;
 export const MSTEAMS_MAX_POLL_VOTE_BUCKET_ROWS =
   (MSTEAMS_MAX_POLLS + 1) * MSTEAMS_POLL_VOTE_BUCKET_COUNT;
 const MSTEAMS_POLL_TTL_MS = 30 * 24 * 60 * 60 * 1000;

--- a/extensions/msteams/src/sdk-proactive.ts
+++ b/extensions/msteams/src/sdk-proactive.ts
@@ -14,7 +14,7 @@ type MSTeamsAccountRef = {
   aadObjectId?: string;
 };
 
-export type MSTeamsSdkReferenceSource = {
+type MSTeamsSdkReferenceSource = {
   activityId?: string;
   user?: MSTeamsAccountRef;
   agent?: MSTeamsAccountRef | null;

--- a/extensions/msteams/src/sdk-types.ts
+++ b/extensions/msteams/src/sdk-types.ts
@@ -49,11 +49,11 @@ type MSTeamsActivity = {
 };
 
 /** Structural alias for ActivityParams — avoids tsgo resolution bugs with the bundled @microsoft/teams.api package. */
-export type MSTeamsActivityParams = { type?: string; [key: string]: unknown };
+type MSTeamsActivityParams = { type?: string; [key: string]: unknown };
 /** Structural alias for ActivityLike. */
 export type MSTeamsActivityLike = MSTeamsActivityParams | string;
 
-export type MSTeamsStreamer = {
+type MSTeamsStreamer = {
   emit(activity: MSTeamsActivityParams | string): void;
   update(text: string): void;
   close(): Promise<unknown>;

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -178,7 +178,7 @@ export type MSTeamsApp = {
  * Token provider compatible with the existing codebase, wrapping the Teams
  * SDK App's public tokenManager.
  */
-export type MSTeamsTokenProvider = {
+type MSTeamsTokenProvider = {
   getAccessToken: (scope: string) => Promise<string>;
 };
 
@@ -235,7 +235,7 @@ export async function createMSTeamsExpressAdapter(
 /**
  * Options for creating a Teams SDK App instance.
  */
-export type CreateMSTeamsAppOptions = {
+type CreateMSTeamsAppOptions = {
   /**
    * HTTP server adapter to use. When an Express app is available (monitor
    * mode), pass an ExpressAdapter so the SDK registers routes and handles

--- a/extensions/msteams/src/send-context.ts
+++ b/extensions/msteams/src/send-context.ts
@@ -31,7 +31,7 @@ import type { MSTeamsApp } from "./sdk.js";
 import { createMSTeamsTokenProvider, loadMSTeamsSdkWithAuth } from "./sdk.js";
 import { resolveMSTeamsCredentials } from "./token.js";
 
-export type MSTeamsConversationType = "personal" | "groupChat" | "channel";
+type MSTeamsConversationType = "personal" | "groupChat" | "channel";
 
 export type MSTeamsProactiveContext = {
   appId: string;

--- a/extensions/msteams/src/sqlite-state.ts
+++ b/extensions/msteams/src/sqlite-state.ts
@@ -4,7 +4,7 @@ import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import { getMSTeamsRuntime } from "./runtime.js";
 import { withFileLock } from "./store-fs.js";
 
-export type MSTeamsSqliteStateOptions = {
+type MSTeamsSqliteStateOptions = {
   env?: NodeJS.ProcessEnv;
   homedir?: () => string;
   stateDir?: string;

--- a/extensions/msteams/src/sso-token-store.ts
+++ b/extensions/msteams/src/sso-token-store.ts
@@ -45,7 +45,7 @@ type SsoStoreData = {
   tokens: Record<string, MSTeamsSsoStoredToken>;
 };
 
-export type MSTeamsSsoStoreData = SsoStoreData;
+type MSTeamsSsoStoreData = SsoStoreData;
 
 export const MSTEAMS_SSO_TOKENS_LEGACY_FILENAME = "msteams-sso-tokens.json";
 export const MSTEAMS_SSO_TOKENS_NAMESPACE = "sso-tokens";

--- a/extensions/msteams/src/token.ts
+++ b/extensions/msteams/src/token.ts
@@ -15,7 +15,7 @@ import { resolveMSTeamsStorePath } from "./storage.js";
 
 // ── Credential types ───────────────────────────────────────────────────────
 
-export type MSTeamsSecretCredentials = {
+type MSTeamsSecretCredentials = {
   type: "secret";
   appId: string;
   appPassword: string;


### PR DESCRIPTION
## What Problem This Solves

The Microsoft Teams plugin still exported 32 declarations that have no consumers outside their defining `src` modules. Those exports expanded the apparent implementation API without belonging to the plugin's supported `api.ts`, runtime barrel, or `src/index.ts` contract.

## Why This Change Was Made

Localize the unused declarations at their ownership sites across 13 Microsoft Teams implementation modules. Every declaration and use remains in place; only the `export` modifiers are removed.

This is an export-only cleanup with 32 insertions and 32 deletions.

## User Impact

None expected. Runtime behavior, supported Microsoft Teams plugin APIs, setup surfaces, and channel operations are unchanged.

## Evidence

- Base: `f2c6a0eda6f1e626f6b7fc7a6beb1be6ff02b22c`
- Head: `39fe05ccaa25d112485abc11dbc79893dcb4df51`
- Codebase graph after rebasing and refreshing: 21,043 files, 281,323 nodes, 1,130,486 edges, zero extraction, call, usage, or semantic errors.
- Repository-wide AST and text searches, including tests, found no consumers for the 32 removed exports.
- `OPENCLAW_TESTBOX=1 pnpm check:changed`: passed for `extensions` and `extensionTests`, including production/test typechecks, extension lint, database-first guards, runtime sidecar guards, and import-cycle checks.
- Full Microsoft Teams Testbox shard: 70 files passed, 1,003 tests passed.
- Fresh local autoreview: clean, 0.87 confidence.
- Fresh committed-branch autoreview: clean, 0.89 confidence.
- `git diff --check`: passed.

## AI Assistance

AI-assisted code search, editing, review, and validation were used. No agent transcript is attached.
