### PR TITLE
refactor(deadcode): localize release tooling declarations

### DIFF
--- a/scripts/android-pin-version.ts
+++ b/scripts/android-pin-version.ts
@@ -18,7 +18,7 @@ type CliOptions = {
   sync: boolean;
 };
 
-export type PinAndroidVersionResult = {
+type PinAndroidVersionResult = {
   previousVersion: string | null;
   previousVersionCode: number | null;
   nextVersion: string;

--- a/scripts/control-ui-i18n-report.ts
+++ b/scripts/control-ui-i18n-report.ts
@@ -82,13 +82,13 @@ type ReportArgs = {
   top: number;
 };
 
-export type RawCopySummary = {
+type RawCopySummary = {
   entries: number;
   occurrences: number;
   topPaths: Array<{ count: number; path: string }>;
 };
 
-export type LocaleSummary = {
+type LocaleSummary = {
   fallbackKeysInScope: string[];
   meta: LocaleMeta;
 };

--- a/scripts/control-ui-i18n.ts
+++ b/scripts/control-ui-i18n.ts
@@ -426,7 +426,7 @@ function compareStringArrays(left: string[], right: string[]) {
   return left.every((value, index) => value === right[index]);
 }
 
-export type PlaceholderMismatch = {
+type PlaceholderMismatch = {
   key: string;
   locale: string;
   sourcePlaceholders: string[];
@@ -1497,7 +1497,7 @@ async function translateBatch(
   throw lastError ?? new Error("translation failed");
 }
 
-export type NativeTranslationEntry = {
+type NativeTranslationEntry = {
   id: string;
   source: string;
   sourcePath: string;

--- a/scripts/e2e/parallels/guest-transports.ts
+++ b/scripts/e2e/parallels/guest-transports.ts
@@ -6,13 +6,13 @@ import type { PhaseRunner } from "./phase-runner.ts";
 import { encodePowerShell, psSingleQuote } from "./powershell.ts";
 import type { CommandResult } from "./types.ts";
 
-export interface GuestExecOptions {
+interface GuestExecOptions {
   check?: boolean;
   input?: string;
   timeoutMs?: number;
 }
 
-export interface WindowsBackgroundPowerShellOptions {
+interface WindowsBackgroundPowerShellOptions {
   append?: (chunk: string | Uint8Array) => void;
   beforeLaunchAttempt?: () => void;
   completedLogDrainGraceMs?: number;
@@ -475,7 +475,7 @@ export class LinuxGuest {
   }
 }
 
-export interface MacosGuestOptions extends GuestExecOptions {
+interface MacosGuestOptions extends GuestExecOptions {
   env?: Record<string, string>;
 }
 

--- a/scripts/e2e/parallels/macos-discord.ts
+++ b/scripts/e2e/parallels/macos-discord.ts
@@ -5,9 +5,9 @@ import path from "node:path";
 import type { MacosGuest } from "./guest-transports.ts";
 import { run, say, shellQuote, warn } from "./host-command.ts";
 
-export type DiscordSmokePhase = "fresh" | "upgrade";
+type DiscordSmokePhase = "fresh" | "upgrade";
 
-export interface MacosDiscordConfig {
+interface MacosDiscordConfig {
   channelId: string;
   guildId: string;
   token: string;

--- a/scripts/e2e/parallels/npm-update-scripts.ts
+++ b/scripts/e2e/parallels/npm-update-scripts.ts
@@ -18,7 +18,7 @@ import {
 } from "./provider-auth.ts";
 import type { Platform, ProviderAuth } from "./types.ts";
 
-export interface NpmUpdateScriptInput {
+interface NpmUpdateScriptInput {
   auth: ProviderAuth;
   expectedNeedle: string;
   updateTarget: string;

--- a/scripts/e2e/parallels/parallels-vm.ts
+++ b/scripts/e2e/parallels/parallels-vm.ts
@@ -9,11 +9,11 @@ interface PrlctlVmListItem {
   status?: string;
 }
 
-export interface WaitForVmStatusOptions {
+interface WaitForVmStatusOptions {
   probeTimeoutMs?: () => number | undefined;
 }
 
-export interface EnsureVmRunningOptions extends WaitForVmStatusOptions {
+interface EnsureVmRunningOptions extends WaitForVmStatusOptions {
   transitionTimeoutMs?: () => number | undefined;
 }
 

--- a/scripts/e2e/parallels/smoke-common.ts
+++ b/scripts/e2e/parallels/smoke-common.ts
@@ -29,7 +29,7 @@ export interface SmokeRunOptions {
   targetPackageSpec?: string;
 }
 
-export interface SmokeLaneStatuses {
+interface SmokeLaneStatuses {
   freshAgent: string;
   freshGateway: string;
   freshMain: string;
@@ -41,7 +41,7 @@ export interface SmokeLaneStatuses {
   upgradeVersion: string;
 }
 
-export interface CommonSmokeSummary {
+interface CommonSmokeSummary {
   currentHead: string;
   freshMain: {
     agent: string;

--- a/scripts/mobile-release-ref.ts
+++ b/scripts/mobile-release-ref.ts
@@ -4,8 +4,8 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
-export type MobileReleasePlatform = "ios" | "android";
-export type MobileReleaseCommand = "preflight" | "record" | "resolve";
+type MobileReleasePlatform = "ios" | "android";
+type MobileReleaseCommand = "preflight" | "record" | "resolve";
 
 type GitDeps = {
   execFileSync?: typeof execFileSync;

--- a/scripts/native-app-i18n.ts
+++ b/scripts/native-app-i18n.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { translateNativeEntries } from "./control-ui-i18n.ts";
 
-export type NativeI18nSurface = "android" | "apple";
+type NativeI18nSurface = "android" | "apple";
 
 export const NATIVE_I18N_LOCALES = [
   "zh-CN",

--- a/scripts/openclaw-npm-postpublish-verify.ts
+++ b/scripts/openclaw-npm-postpublish-verify.ts
@@ -94,13 +94,13 @@ type DistJavaScriptFileListResult =
   | { files: string[]; limitExceeded: false }
   | { files: string[]; limit: number; limitExceeded: true };
 
-export type PublishedInstallScenario = {
+type PublishedInstallScenario = {
   name: string;
   installSpecs: string[];
   expectedVersion: string;
 };
 
-export type OpenClawNpmPostpublishVerifyArgs =
+type OpenClawNpmPostpublishVerifyArgs =
   | {
       help: false;
       version: string;

--- a/scripts/openclaw-npm-prepublish-verify.ts
+++ b/scripts/openclaw-npm-prepublish-verify.ts
@@ -19,7 +19,7 @@ type InstalledPackageJson = {
   version?: string;
 };
 
-export type OpenClawNpmPrepublishVerifyArgs =
+type OpenClawNpmPrepublishVerifyArgs =
   | {
       expectedVersion?: string;
       dependencyTarballPaths: string[];

--- a/scripts/openclaw-npm-release-check.ts
+++ b/scripts/openclaw-npm-release-check.ts
@@ -32,7 +32,7 @@ type PackageJson = {
   peerDependenciesMeta?: Record<string, { optional?: boolean }>;
 };
 
-export type ParsedReleaseVersion = {
+type ParsedReleaseVersion = {
   version: string;
   baseVersion: string;
   channel: "stable" | "alpha" | "beta";
@@ -44,7 +44,7 @@ export type ParsedReleaseVersion = {
   correctionNumber?: number;
 };
 
-export type ParsedReleaseTag = {
+type ParsedReleaseTag = {
   version: string;
   packageVersion: string;
   baseVersion: string;
@@ -52,13 +52,13 @@ export type ParsedReleaseTag = {
   correctionNumber?: number;
 };
 
-export type NpmPublishPlan = {
+type NpmPublishPlan = {
   channel: "stable" | "alpha" | "beta";
   publishTag: "latest" | "alpha" | "beta";
   mirrorDistTags: ("latest" | "alpha" | "beta")[];
 };
 
-export type NpmDistTagMirrorAuth = {
+type NpmDistTagMirrorAuth = {
   hasAuth: boolean;
   source: "node-auth-token" | "npm-token" | "none";
 };

--- a/scripts/plugin-release-pretag-pack-check.ts
+++ b/scripts/plugin-release-pretag-pack-check.ts
@@ -10,7 +10,7 @@ import { collectPublishablePluginPackages } from "./lib/plugin-npm-release.ts";
 
 const DEFAULT_CLAWHUB_CLI_PACKAGE = "clawhub@0.23.1";
 
-export type PluginReleasePretagPackTarget = {
+type PluginReleasePretagPackTarget = {
   packageDir: string;
   packageName: string;
   packClawHub: boolean;

--- a/scripts/release-beta-smoke.ts
+++ b/scripts/release-beta-smoke.ts
@@ -20,14 +20,14 @@ export type RunOptions = {
   timeoutMs?: number;
 };
 
-export type WorkflowRunInfo = {
+type WorkflowRunInfo = {
   conclusion: string | null;
   html_url: string;
   status: string;
   updated_at: string;
 };
 
-export type PollRunOptions = {
+type PollRunOptions = {
   pollIntervalMs?: number;
   readRun?: (repo: string, runId: string) => WorkflowRunInfo;
   sleep?: (ms: number) => Promise<void>;

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -149,12 +149,12 @@ const SAFE_UNIX_SMOKE_PATH = "/usr/bin:/bin";
 const DEFAULT_RELEASE_CHECK_COMMAND_TIMEOUT_MS = 5 * 60 * 1000;
 const DEFAULT_RELEASE_CHECK_COMMAND_MAX_BUFFER_BYTES = 100 * 1024 * 1024;
 export const MAX_CRITICAL_PLUGIN_SDK_ENTRYPOINT_BYTES = 2 * 1024 * 1024;
-export const CRITICAL_PLUGIN_SDK_SIZE_CHECK_SPECIFIERS = [
+const CRITICAL_PLUGIN_SDK_SIZE_CHECK_SPECIFIERS = [
   "openclaw/plugin-sdk/core",
   "openclaw/plugin-sdk/provider-entry",
   "openclaw/plugin-sdk/runtime",
 ] as const;
-export const CRITICAL_PLUGIN_SDK_IMPORT_SMOKE_SPECIFIERS = ["openclaw/plugin-sdk/core"] as const;
+const CRITICAL_PLUGIN_SDK_IMPORT_SMOKE_SPECIFIERS = ["openclaw/plugin-sdk/core"] as const;
 export const PACKED_CLI_SMOKE_COMMANDS = [
   ["--help"],
   ["onboard", "--help"],


### PR DESCRIPTION
## What Problem This Solves

Thirty script-local declarations were still exported even though no other repository module imports them. This leaves dead public surface across mobile release, native localization, Parallels smoke, and npm release tooling.

## Why This Change Was Made

Localize only declarations proven to be referenced inside their defining module. Keep CLI entrypoints, test-imported helpers, and intentionally shared script APIs exported.

## User Impact

No runtime or CLI behavior changes. The script module surfaces are narrower and better match their actual consumers.

## Evidence

- `git diff --check`
- corrected repository-wide TypeScript/JavaScript identifier scan: all 30 selected export candidates disappeared after the edit
- codebase-memory MCP clean full rebuild: 21,043 files, 281,315 nodes, 1,134,314 edges, zero extraction errors; graph snippets return the current localized source
- `check:changed` passed on Blacksmith Testbox `tbx_01kwzdbc5xms2y5j6rcpqb5bcn`
- focused Testbox validation: 16 test files, 348 tests passed across 2 Vitest shards
- local autoreview: clean, confidence 0.88
- branch autoreview: clean, confidence 0.88
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/28904921727
