### PR TITLE
fix(agents): retry after read-only shell inspection turns

### DIFF
--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -7,6 +7,7 @@ import {
   formatToolAggregate,
   formatToolProgressOutput,
   inferToolMetaFromArgs,
+  isMutatingToolCall,
   normalizeUsage,
   runAgentHarnessAfterCompactionHook,
   runAgentHarnessAfterToolCallHook,
@@ -2538,7 +2539,6 @@ function readNonNegativeInteger(record: JsonObject, key: string): number | undef
   return value !== undefined && Number.isInteger(value) && value >= 0 ? value : undefined;
 }
 
-
 function readCodexErrorNotificationMessage(record: JsonObject): string | undefined {
   const error = record.error;
   return isJsonObject(error) ? readString(error, "message") : undefined;
@@ -2791,9 +2791,9 @@ function shouldRecordNativeToolTranscript(item: CodexThreadItem): boolean {
 
 function isMutatingNativeToolItem(item: CodexThreadItem): boolean {
   if (item.type === "commandExecution") {
-    // Codex commandActions describe presentation, not safety. Upstream may
-    // classify mutating commands as read/search, so native commands fail closed.
-    return true;
+    // Codex commandActions are presentation hints; side-effect evidence follows
+    // OpenClaw's command parser so simple inspection can retry while shell writes fail closed.
+    return isMutatingToolCall("exec", itemToolArgs(item));
   }
   return (
     item.type === "fileChange" ||

--- a/extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts
+++ b/extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts
@@ -461,4 +461,42 @@ describe("Outcome/fallback runtime contract - Codex app-server adapter", () => {
       expect(classifyProjectedAttemptResult(result) !== null).toBe(replaySafe);
     },
   );
+
+  it.each([
+    { command: "rg TODO src/agents", replaySafe: true },
+    { command: "cat package.json > /tmp/package.json", replaySafe: false },
+  ])(
+    "classifies an empty Codex turn after native command from command replay safety",
+    async ({ command, replaySafe }) => {
+      const projector = await createProjector();
+      await projector.handleNotification(
+        forCurrentTurn("turn/completed", {
+          turn: {
+            id: TURN_ID,
+            status: "completed",
+            items: [
+              {
+                type: "commandExecution",
+                id: "cmd-1",
+                command,
+                commandActions: [],
+                cwd: "/tmp/project",
+                status: "completed",
+                aggregatedOutput: "",
+                exitCode: 0,
+                durationMs: 1,
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = projector.buildResult(buildToolTelemetry());
+
+      expect(result.replayMetadata).toEqual({
+        hadPotentialSideEffects: !replaySafe,
+        replaySafe,
+      });
+    },
+  );
 });

--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -50,7 +50,9 @@ describe("tool mutation helpers", () => {
   ])("treats read-only shell command as non-mutating: %s %s", (toolName, command) => {
     expect(isMutatingToolCall(toolName, { command })).toBe(false);
     expect(buildToolMutationState(toolName, { command }).mutatingAction).toBe(false);
-    expect(buildToolMutationState(toolName, { command }, command).actionFingerprint).toBeUndefined();
+    expect(
+      buildToolMutationState(toolName, { command }, command).actionFingerprint,
+    ).toBeUndefined();
   });
 
   it.each([
@@ -211,7 +213,18 @@ describe("tool mutation helpers", () => {
     expect(isReplaySafeToolCall("nodes", { action: "describe" })).toBe(true);
     expect(isReplaySafeToolCall("nodes", { action: "pending" })).toBe(true);
     expect(isReplaySafeToolCall("nodes", { action: "approve" })).toBe(false);
-    expect(isReplaySafeToolCall("exec", { command: "rg TODO src" })).toBe(false);
+    expect(isReplaySafeToolCall("exec", { command: "rg TODO src" })).toBe(true);
+    expect(isReplaySafeToolCall("bash", { command: "sed -n '1,40p' package.json" })).toBe(true);
+    expect(
+      isReplaySafeToolCall("exec", { command: "gh pr view 123 --repo openclaw/openclaw" }),
+    ).toBe(true);
+    expect(isReplaySafeToolCall("exec", { command: "rg TODO src | wc -l" })).toBe(false);
+    expect(isReplaySafeToolCall("bash", { command: "cat package.json > /tmp/package.json" })).toBe(
+      false,
+    );
+    expect(isReplaySafeToolCall("exec", { command: "gh pr create --title fix --body body" })).toBe(
+      false,
+    );
     expect(isReplaySafeToolCall("process", { action: "list" })).toBe(true);
     expect(isReplaySafeToolCall("process", { action: "log", sessionId: "run-1" })).toBe(true);
     expect(isReplaySafeToolCall("process", { action: "poll", sessionId: "run-1" })).toBe(false);

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -415,7 +415,7 @@ export function isReplaySafeToolCall(toolName: string, args: unknown): boolean {
   switch (normalized) {
     case "exec":
     case "bash":
-      return false;
+      return isPlainReadOnlyShellCommand(readShellCommand(record));
     case "process":
       return action != null && PROCESS_REPLAY_SAFE_ACTIONS.has(action);
     case "message":

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -325,7 +325,7 @@ export {
   type BeforeToolCallFailureDisposition,
   type DeferredPluginToolApproval,
 } from "../agents/agent-tools.before-tool-call.js";
-export { isReplaySafeToolCall } from "../agents/tool-mutation.js";
+export { isMutatingToolCall, isReplaySafeToolCall } from "../agents/tool-mutation.js";
 export {
   resolveAgentHarnessBeforePromptBuildResult,
   runAgentHarnessAfterCompactionHook,


### PR DESCRIPTION
Closes #101890

## What Problem This Solves

Fixes an issue where strict-agentic runs that only performed read-only shell inspection could still be treated as unsafe to replay, so a terminal turn with no visible answer would skip the normal retry path.

The same false side-effect signal affected Codex app-server native `commandExecution` items, where simple inspection commands such as `rg` were recorded as side-effecting even when OpenClaw's own shell classifier already considered them read-only.

## Why This Change Was Made

This change reuses the existing read-only shell command classifier for `exec`/`bash` replay safety instead of maintaining a stricter unconditional replay block. Codex native command projection now derives side-effect evidence from that same command parser and still ignores `commandActions` as a safety boundary because those are only best-effort presentation hints.

Shell writes, redirection, compound commands, unsafe `rg` flags, GitHub write operations, file changes, MCP calls, and other native side-effecting items remain fail-closed.

## User Impact

Agents can recover from empty terminal turns after harmless inspection commands without requiring a manual rerun. Users still get the existing verification warning path when a command may have changed state.

## Evidence

Current main before this change returned `false` for `isReplaySafeToolCall("exec", { command: "rg TODO src" })`, which caused the new regression test to fail.

Validation run after the fix:

```text
$ node scripts/run-vitest.mjs src/agents/tool-mutation.test.ts extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts
[test] passed 2 Vitest shards in 6.52s

$ node_modules/.bin/oxfmt --check --threads=1 extensions/codex/src/app-server/event-projector.ts extensions/codex/src/app-server/outcome-fallback-runtime-contract.test.ts src/agents/tool-mutation.test.ts src/agents/tool-mutation.ts src/plugin-sdk/agent-harness-runtime.ts
All matched files use the correct format.

$ git diff --check
<no output>
```

I also checked the current Codex protocol shape before changing the Codex projector: `CommandExecutionThreadItem` carries the concrete `command`/`cwd` fields and describes `commandActions` as best-effort parsing, so this PR bases safety on the actual command string rather than action hints.
