### PR TITLE
fix(plugins): persist binding approval before trusting it in memory

### DIFF
--- a/src/plugins/conversation-binding.test.ts
+++ b/src/plugins/conversation-binding.test.ts
@@ -7,6 +7,7 @@ import type {
   SessionBindingRecord,
 } from "../infra/outbound/session-binding-service.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import * as openClawStateDb from "../state/openclaw-state-db.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -16,7 +17,6 @@ import {
   resetPluginConversationBindingStateForTest,
   seedPluginConversationBindingApprovalForTest,
 } from "./conversation-binding.test-fixtures.js";
-import * as openClawStateDb from "../state/openclaw-state-db.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import type { PluginRegistry } from "./registry.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";

--- a/src/plugins/conversation-binding.test.ts
+++ b/src/plugins/conversation-binding.test.ts
@@ -16,6 +16,7 @@ import {
   resetPluginConversationBindingStateForTest,
   seedPluginConversationBindingApprovalForTest,
 } from "./conversation-binding.test-fixtures.js";
+import * as openClawStateDb from "../state/openclaw-state-db.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import type { PluginRegistry } from "./registry.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
@@ -606,6 +607,36 @@ describe("plugin conversation binding approvals", () => {
     expect(differentAccount.status).toBe("pending");
   });
 
+  it("does not leak an in-memory auto-approval when persisting an allow-always grant fails", async () => {
+    const pendingRequest = await requestPendingBinding(
+      createDiscordCodexBindRequest("channel:persist-fail-1", "Bind Codex thread persist-fail-1."),
+    );
+
+    const writeSpy = vi
+      .spyOn(openClawStateDb, "runOpenClawStateWriteTransaction")
+      .mockImplementationOnce(() => {
+        throw new Error("SQLITE_BUSY: database is locked");
+      });
+
+    // A failed persist must propagate; the grant was never durably recorded.
+    await expect(approveBindingRequest(pendingRequest.approvalId, "allow-always")).rejects.toThrow(
+      "SQLITE_BUSY",
+    );
+
+    writeSpy.mockRestore();
+
+    // Nothing reached disk.
+    expect(readPluginBindingApprovalRows()).toEqual([]);
+
+    // No in-memory grant leaked: the next same-scope request still prompts instead of
+    // silently auto-approving from a cache entry that was never persisted.
+    const sameScope = await requestPluginConversationBinding(
+      createDiscordCodexBindRequest("channel:persist-fail-2", "Bind Codex thread persist-fail-2."),
+    );
+
+    expect(sameScope.status).toBe("pending");
+  });
+
   it("persists overlapping always-allow approvals", async () => {
     const firstRequest = await requestPendingBinding(
       createDiscordCodexBindRequest(
@@ -651,6 +682,19 @@ describe("plugin conversation binding approvals", () => {
         plugin_root: "/plugins/codex-a",
       },
     ]);
+
+    // Both grants must stay live in the in-memory cache: publishing the cache only after
+    // the persist await must recompute from the latest cache, not clobber a concurrently
+    // approved scope with a stale pre-await snapshot. Follow-up binds auto-approve from cache.
+    const firstFollowUp = await requestPluginConversationBinding(
+      createDiscordCodexBindRequest("channel:race-1b", "Rebind Codex thread race-1.", "default"),
+    );
+    const secondFollowUp = await requestPluginConversationBinding(
+      createDiscordCodexBindRequest("channel:race-2b", "Rebind Codex thread race-2.", "work"),
+    );
+
+    expect(firstFollowUp.status).toBe("bound");
+    expect(secondFollowUp.status).toBe("bound");
   });
 
   it("does not remove approval rows written outside the process cache", async () => {

--- a/src/plugins/conversation-binding.ts
+++ b/src/plugins/conversation-binding.ts
@@ -404,9 +404,15 @@ function hasPersistentApproval(params: {
 }
 
 async function addPersistentApproval(entry: PluginBindingApprovalEntry): Promise<void> {
-  const file = getApprovals();
+  // Persist before publishing the grant into the in-memory cache. hasPersistentApproval
+  // auto-approves later binds from this cache, so a failed SQLite write must not leave the
+  // runtime more permissive than disk: on throw the cache stays untouched and the user is
+  // re-prompted, instead of silently auto-approving a grant that never persisted.
+  await persistApprovalEntry(entry);
+  // Recompute from the current cache after the await so a concurrent allow-always persisted
+  // during the write is not dropped by a stale pre-await snapshot.
   const key = buildApprovalScopeKey(entry);
-  const approvals = file.approvals.filter(
+  const approvals = getApprovals().approvals.filter(
     (existing) =>
       buildApprovalScopeKey({
         pluginRoot: existing.pluginRoot,
@@ -418,7 +424,6 @@ async function addPersistentApproval(entry: PluginBindingApprovalEntry): Promise
   const state = getPluginBindingGlobalState();
   state.approvalsCache = { approvals };
   state.approvalsLoaded = true;
-  await persistApprovalEntry(entry);
 }
 
 function buildBindingMetadata(params: {


### PR DESCRIPTION
## What Problem This Solves

When a user picks **Allow always** on a plugin conversation-binding prompt, `addPersistentApproval` (`src/plugins/conversation-binding.ts`) published the grant into the in-memory approvals cache **before** the SQLite write that persists it. If that write throws — `SQLITE_BUSY` under concurrent writers, a full disk, a read-only or permission-denied state directory — the cache already held the grant while nothing was durably recorded, and there is no rollback.

The consequence is a silent, session-scoped over-approval: `hasPersistentApproval()` reads that cache and **auto-approves later binds for the same plugin/channel/account without prompting the user**, even though the triggering approval actually rejected (no binding was created, no "approved" event fired) and the grant is gone on the next restart. The user never durably granted a standing approval, yet the running gateway behaves as if they did until it restarts.

This is a default-path surface: plugin conversation-binding approvals are reached through the bundled Telegram, Slack, and Discord interaction handlers.

## Why This Change Was Made

Runtime state must not end up more permissive than the durable store when a write fails. `addPersistentApproval` now **persists first** and only publishes the grant into the cache after the write succeeds, then recomputes the merged set from the current cache so a concurrently-approved grant is not dropped:

- On a write failure the cache is left untouched, so `hasPersistentApproval` stays `false` and the user is re-prompted — fail-safe, instead of a silent standing approval that was never saved.
- Publishing after the `await` recomputes from `getApprovals()` (not a stale pre-await snapshot), so two concurrent `Allow always` approvals both stay live in the cache. The `onConflict` upsert keeps the write idempotent.

The mutate-before-persist ordering pre-dated the JSON→SQLite move and the save-chain serialization change; neither added rollback. Scope is limited to `addPersistentApproval`; the save-chain serialization semantics and the separate before-tool-call plugin-permission approvals are unchanged.

## User Impact

A failed approvals write no longer leaves the gateway silently auto-approving plugin conversation binds that were never persisted. "Allow always" either persists and takes effect, or fails leaving no standing grant, so a later same-scope bind prompts again — the in-memory state matches disk in both cases. Successful and concurrent approvals are unchanged.

## Evidence

- Focused regression test (`src/plugins/conversation-binding.test.ts`): injects a write failure during an `Allow always` approval and asserts the approval rejects, nothing is persisted, and the next same-scope request stays `pending` (no auto-approval leak). Negative control: with the fix reverted the test fails with `bound != pending`.
- The existing concurrent "persists overlapping always-allow approvals" test was extended to assert both grants stay live in the in-memory cache (follow-up binds return `bound`). Negative control: a stale-snapshot variant fails this test.
- Local run against the real Vitest runner: `conversation-binding.test.ts` 19/19 pass with the fix; the two negative controls fail as expected with the fix reverted.
- **Real-behavior run** — a script drives the unmodified production functions (`requestPluginConversationBinding` / `resolvePluginConversationBindingApproval`) against a real `node:sqlite` state database, injecting a genuine `SQLITE_READONLY` write failure (`PRAGMA query_only=ON`, representative of a read-only / permission-denied / non-writable state database). No OpenClaw code is mocked — SQLite itself rejects the write:

  ```
  [setup] real state DB opened; PRAGMA query_only=ON -> writes raise SQLITE_READONLY

  == FAILURE PATH (approvals write fails) ==
  [fail] initial allow-always request -> pending  (expect: pending)
  [fail] allow-always resolve rejected -> true  (attempt to write a readonly database)
  [fail] persisted approval rows -> 0  (expect: 0)
  [fail] next same-scope bind -> pending  (expect: pending == NO in-memory auto-approval leak)

  == SUCCESS PATH (writes enabled) ==
  [ok]   allow-always resolve -> approved  (expect: approved)
  [ok]   persisted approval rows -> 1  (expect: 1)
  [ok]   next same-scope bind -> bound  (expect: bound == durable auto-approval)
  ```

  The failed write leaves no persisted row and, with the fix, no in-memory grant — the next same-scope bind stays `pending`. With writes enabled the same path persists the grant and auto-approves.
- `check:changed` / typecheck / lint delegated to hosted CI for this commit.
