### PR TITLE
refactor(deadcode): localize AI provider declarations

### DIFF
--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -56,7 +56,7 @@ function formatAzureOpenAIError(error: unknown): string {
 }
 
 // Azure OpenAI Responses-specific options
-export interface AzureOpenAIResponsesOptions extends StreamOptions {
+interface AzureOpenAIResponsesOptions extends StreamOptions {
   reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh";
   reasoningSummary?: "auto" | "detailed" | "concise" | null;
   azureApiVersion?: string;

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -35,7 +35,7 @@ import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-bou
 import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
-export type GoogleApiType = "google-generative-ai" | "google-vertex";
+type GoogleApiType = "google-generative-ai" | "google-vertex";
 
 /**
  * Thinking level for Gemini 3 models.
@@ -48,9 +48,9 @@ export type GoogleThinkingLevel =
   | "MEDIUM"
   | "HIGH";
 
-export type GoogleToolChoice = "auto" | "none" | "any";
+type GoogleToolChoice = "auto" | "none" | "any";
 
-export type GoogleThinkingOptions = {
+type GoogleThinkingOptions = {
   enabled: boolean;
   budgetTokens?: number;
   level?: GoogleThinkingLevel;

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -19,7 +19,7 @@ import {
 } from "./google-shared.js";
 import { buildBaseOptions } from "./simple-options.js";
 
-export interface GoogleVertexOptions extends GoogleProviderOptions {
+interface GoogleVertexOptions extends GoogleProviderOptions {
   project?: string;
   location?: string;
 }

--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -13,7 +13,7 @@ import {
 } from "./google-shared.js";
 import { buildBaseOptions } from "./simple-options.js";
 
-export type GoogleOptions = GoogleProviderOptions;
+type GoogleOptions = GoogleProviderOptions;
 
 // Counter for generating unique tool call IDs
 let toolCallCounter = 0;

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -98,7 +98,7 @@ export function createBoundedMistralFetcher(
  */
 type MistralReasoningEffort = "none" | "high";
 
-export interface MistralOptions extends StreamOptions {
+interface MistralOptions extends StreamOptions {
   toolChoice?:
     | "auto"
     | "none"

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -95,7 +95,7 @@ const CODEX_RESPONSE_STATUSES = new Set<CodexResponseStatus>([
 // Types
 // ============================================================================
 
-export interface OpenAICodexResponsesOptions extends StreamOptions {
+interface OpenAICodexResponsesOptions extends StreamOptions {
   reasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
   reasoningSummary?: "auto" | "concise" | "detailed" | "off" | "on" | null;
   serviceTier?: ResponseCreateParamsStreaming["service_tier"];
@@ -914,7 +914,7 @@ type WebSocketConstructor = new (
   protocols?: string | string[] | { headers?: Record<string, string> },
 ) => WebSocketLike;
 
-export interface OpenAICodexWebSocketDebugStats {
+interface OpenAICodexWebSocketDebugStats {
   requests: number;
   connectionsCreated: number;
   connectionsReused: number;

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -167,7 +167,7 @@ function resolveReplayableResponsesMessageId(params: {
   return params.previousReplayItemWasReasoning ? params.textSignatureId : undefined;
 }
 
-export interface OpenAIResponsesStreamOptions {
+interface OpenAIResponsesStreamOptions {
   serviceTier?: ResponseCreateParamsStreaming["service_tier"];
   resolveServiceTier?: (
     responseServiceTier: ResponseCreateParamsStreaming["service_tier"] | undefined,
@@ -179,7 +179,7 @@ export interface OpenAIResponsesStreamOptions {
   ) => void;
 }
 
-export interface ConvertResponsesMessagesOptions {
+interface ConvertResponsesMessagesOptions {
   includeSystemPrompt?: boolean;
   replayResponsesItemIds?: boolean;
 }
@@ -217,7 +217,7 @@ type ResponsesLifecycleStreamOptions = Pick<
 type OpenAIResponsesProcessStreamOptions = OpenAIResponsesStreamOptions &
   FirstStreamEventInternalOptions;
 
-export type ResponsesReasoningEffort = "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+type ResponsesReasoningEffort = "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 
 function isResponsesReasoningEffort(
   effort: string | undefined,
@@ -231,7 +231,7 @@ function isResponsesReasoningEffort(
     effort === "max"
   );
 }
-export type ResponsesReasoningSummary = "auto" | "detailed" | "concise" | null;
+type ResponsesReasoningSummary = "auto" | "detailed" | "concise" | null;
 
 type ResponsesCommonParamsOptions = Pick<StreamOptions, "maxTokens" | "temperature"> & {
   reasoningEffort?: ResponsesReasoningEffort;


### PR DESCRIPTION
## What Problem This Solves

Thirteen provider-internal TypeScript declarations were exported from lazy `@openclaw/ai` implementation modules even though no repository consumer imports them and none are exposed through the package entrypoints.

## Why This Change Was Made

Localize those declarations to their owning modules. This narrows the implementation surface without changing runtime code, the public package barrels, or the exported provider stream functions.

## User Impact

None. This is export-surface deadcode cleanup with no runtime behavior change.

## Evidence

- Repository-wide export-consumer scan confirmed the 13 declarations have no external consumers.
- Clean codebase-memory MCP rebuild indexed 21,043 files, 281,315 nodes, and 1,134,113 edges with zero extraction errors.
- MCP source proof shows `GoogleOptions` is module-local while `streamGoogle` and `streamSimpleGoogle` remain exported.
- `OPENCLAW_TESTBOX=1 pnpm check:changed` passed on Testbox `tbx_01kwzdwsfjdhgp7hh0w17ykb28`.
- Eight focused provider test files passed: 94 tests in one Vitest shard.
- Full `pnpm build` passed on the same Testbox.
- Local autoreview passed with no findings at 0.86 confidence.
- Branch autoreview passed with no findings at 0.92 confidence.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/28905346491
