### PR TITLE
improve(android): show provider-configured model details

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -171,7 +171,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 355,
+      "line": 358,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -179,7 +179,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 369,
+      "line": 372,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -259,7 +259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3188,
+      "line": 3194,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
@@ -267,7 +267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3190,
+      "line": 3196,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -275,7 +275,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3192,
+      "line": 3198,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -2715,7 +2715,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 241,
+      "line": 240,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Loading",
       "surface": "android",
@@ -2723,7 +2723,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 241,
+      "line": 240,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "No providers",
       "surface": "android",
@@ -2731,7 +2731,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 278,
+      "line": 277,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Ready",
       "surface": "android",
@@ -2739,7 +2739,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 279,
+      "line": 278,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Needs",
       "surface": "android",
@@ -2747,7 +2747,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 280,
+      "line": 279,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Unknown",
       "surface": "android",
@@ -2755,7 +2755,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 283,
+      "line": 282,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "$modelCount configured models. Refresh to recheck availability.",
       "surface": "android",
@@ -2763,7 +2763,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 283,
+      "line": 282,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Connect your Gateway to view provider readiness.",
       "surface": "android",
@@ -2771,7 +2771,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 287,
+      "line": 286,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Refresh",
       "surface": "android",
@@ -2779,7 +2779,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 287,
+      "line": 286,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
@@ -2787,7 +2787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 319,
+      "line": 318,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "${row.modelCount} configured models",
       "surface": "android",
@@ -2795,7 +2795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 319,
+      "line": 318,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "No configured models",
       "surface": "android",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -219,7 +219,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 666,
+      "line": 667,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -227,7 +227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1529,
+      "line": 1547,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron job started.",
       "surface": "android",
@@ -235,7 +235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1529,
+      "line": 1547,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron run queued.",
       "surface": "android",
@@ -243,7 +243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1573,
+      "line": 1591,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron job disabled.",
       "surface": "android",
@@ -251,7 +251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1573,
+      "line": 1591,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron job enabled.",
       "surface": "android",
@@ -259,7 +259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3175,
+      "line": 3188,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
@@ -267,7 +267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3177,
+      "line": 3190,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -275,7 +275,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3179,
+      "line": 3192,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -795,7 +795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 306,
+      "line": 307,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "$readyProviderCount providers ready",
       "surface": "android",
@@ -803,7 +803,15 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 307,
+      "line": 308,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
+      "source": "Provider availability unknown",
+      "surface": "android",
+      "id": "native.android.625b4d9f7e893047"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 309,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "No ready providers",
       "surface": "android",
@@ -811,7 +819,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 311,
+      "line": 313,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Main session",
       "surface": "android",
@@ -2685,9 +2693,9 @@
       "kind": "ui-named-argument",
       "line": 110,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
-      "source": "Connected providers",
+      "source": "Providers and configured models",
       "surface": "android",
-      "id": "native.android.0a5b541f486e6760"
+      "id": "native.android.ca79d0de89bfa25a"
     },
     {
       "kind": "ui-named-argument",
@@ -2707,15 +2715,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 154,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
-      "source": "Needs attention",
-      "surface": "android",
-      "id": "native.android.b21d6b8b2a1bf1c2"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 210,
+      "line": 241,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Loading",
       "surface": "android",
@@ -2723,7 +2723,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 210,
+      "line": 241,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "No providers",
       "surface": "android",
@@ -2731,7 +2731,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 241,
+      "line": 278,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Ready",
       "surface": "android",
@@ -2739,23 +2739,31 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 242,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
-      "source": "Models",
-      "surface": "android",
-      "id": "native.android.bbe270b421ba7ee0"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 243,
+      "line": 279,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Needs",
       "surface": "android",
       "id": "native.android.b36b0c2003a82b53"
     },
     {
+      "kind": "ui-named-argument",
+      "line": 280,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
+      "source": "Unknown",
+      "surface": "android",
+      "id": "native.android.35fbba1d22e775ac"
+    },
+    {
       "kind": "conditional-branch",
-      "line": 246,
+      "line": 283,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
+      "source": "$modelCount configured models. Refresh to recheck availability.",
+      "surface": "android",
+      "id": "native.android.62fdb673c946ccf0"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 283,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Connect your Gateway to view provider readiness.",
       "surface": "android",
@@ -2763,15 +2771,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 246,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
-      "source": "Refresh to recheck provider readiness from your Gateway.",
-      "surface": "android",
-      "id": "native.android.0bf3fd4d988ecdd9"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 250,
+      "line": 287,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Refresh",
       "surface": "android",
@@ -2779,7 +2779,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 250,
+      "line": 287,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
@@ -2787,15 +2787,15 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 281,
+      "line": 319,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
-      "source": "${row.modelCount} models",
+      "source": "${row.modelCount} configured models",
       "surface": "android",
-      "id": "native.android.80393d587b549b8e"
+      "id": "native.android.c11f2727dd9a93f7"
     },
     {
       "kind": "conditional-branch",
-      "line": 281,
+      "line": 319,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "No configured models",
       "surface": "android",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -4419,7 +4419,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 492,
+      "line": 496,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Overview",
       "surface": "android",
@@ -4427,7 +4427,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 538,
+      "line": 542,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No recent sessions",
       "surface": "android",
@@ -4435,7 +4435,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 539,
+      "line": 543,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Start a chat and your active OpenClaw conversations will appear here.",
       "surface": "android",
@@ -4443,7 +4443,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 540,
+      "line": 544,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Start Chat",
       "surface": "android",
@@ -4451,7 +4451,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 586,
+      "line": 590,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -4459,7 +4459,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 594,
+      "line": 598,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Search",
       "surface": "android",
@@ -4467,7 +4467,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 647,
+      "line": 651,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "ACTIVE AGENT",
       "surface": "android",
@@ -4475,7 +4475,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 656,
+      "line": 660,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "View",
       "surface": "android",
@@ -4483,7 +4483,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 659,
+      "line": 663,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$pendingRunCount active",
       "surface": "android",
@@ -4491,7 +4491,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 659,
+      "line": 663,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Idle",
       "surface": "android",
@@ -4499,7 +4499,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 659,
+      "line": 663,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Runs",
       "surface": "android",
@@ -4507,7 +4507,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 660,
+      "line": 664,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$sessionCount recent",
       "surface": "android",
@@ -4515,7 +4515,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 660,
+      "line": 664,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Sessions",
       "surface": "android",
@@ -4523,7 +4523,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 661,
+      "line": 665,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Cron",
       "surface": "android",
@@ -4531,7 +4531,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 664,
+      "line": 668,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -4539,7 +4539,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 668,
+      "line": 672,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Reconnect gateway",
       "surface": "android",
@@ -4547,7 +4547,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 819,
+      "line": 823,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open ${card.title}",
       "surface": "android",
@@ -4555,7 +4555,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 887,
+      "line": 891,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Talk",
       "surface": "android",
@@ -4563,7 +4563,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 888,
+      "line": 892,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open Talk",
       "surface": "android",
@@ -4571,7 +4571,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 890,
+      "line": 894,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Talk settings",
       "surface": "android",
@@ -4579,7 +4579,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 898,
+      "line": 902,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Recent Sessions",
       "surface": "android",
@@ -4587,7 +4587,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 908,
+      "line": 912,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "View all",
       "surface": "android",
@@ -4595,7 +4595,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1047,
+      "line": 1051,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$onlineNodes/$nodeCount",
       "surface": "android",
@@ -4603,7 +4603,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1047,
+      "line": 1051,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "None",
       "surface": "android",
@@ -4611,7 +4611,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1079,
+      "line": 1083,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Recent conversations",
       "surface": "android",
@@ -4619,7 +4619,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1086,
+      "line": 1090,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Browse",
       "surface": "android",
@@ -4627,7 +4627,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1086,
+      "line": 1090,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -4635,7 +4635,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1143,
+      "line": 1147,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Working · $pendingRunCount active ${pluralize(\"run\", pendingRunCount)}",
       "surface": "android",
@@ -4643,7 +4643,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1264,
+      "line": 1269,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -4651,7 +4651,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1329,
+      "line": 1334,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open ${row.title}",
       "surface": "android",
@@ -4659,7 +4659,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1437,
+      "line": 1442,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open session",
       "surface": "android",
@@ -4667,7 +4667,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1552,
+      "line": 1560,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Back",
       "surface": "android",
@@ -4675,7 +4675,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1555,
+      "line": 1563,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Settings",
       "surface": "android",
@@ -4683,7 +4683,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1558,
+      "line": 1566,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Search settings",
       "surface": "android",
@@ -4691,23 +4691,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1582,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
-      "source": "$readyProviderCount ready",
-      "surface": "android",
-      "id": "native.android.07ee62163aebc378"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 1582,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
-      "source": "Review readiness",
-      "surface": "android",
-      "id": "native.android.fc155dcf9db1d39c"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 1600,
+      "line": 1618,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Speaker muted",
       "surface": "android",
@@ -4715,7 +4699,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1600,
+      "line": 1618,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Speaker on",
       "surface": "android",
@@ -4723,7 +4707,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1602,
+      "line": 1620,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -4731,7 +4715,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1602,
+      "line": 1620,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Smart delivery",
       "surface": "android",
@@ -4739,7 +4723,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1603,
+      "line": 1621,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Camera enabled",
       "surface": "android",
@@ -4747,7 +4731,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1603,
+      "line": 1621,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Locked",
       "surface": "android",
@@ -4755,7 +4739,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1650,
+      "line": 1668,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "surface": "android",
@@ -4763,7 +4747,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1653,
+      "line": 1671,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "All systems operational",
       "surface": "android",
@@ -4771,7 +4755,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1653,
+      "line": 1671,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Gateway not connected",
       "surface": "android",
@@ -4779,7 +4763,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1685,
+      "line": 1703,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No provider usage",
       "surface": "android",
@@ -4787,7 +4771,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1686,
+      "line": 1704,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 provider",
       "surface": "android",
@@ -4795,7 +4779,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1687,
+      "line": 1705,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$count providers",
       "surface": "android",
@@ -4803,7 +4787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1693,
+      "line": 1711,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$ready/${skills.size} ready",
       "surface": "android",
@@ -4811,7 +4795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1693,
+      "line": 1711,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No skills",
       "surface": "android",
@@ -4819,7 +4803,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1707,
+      "line": 1725,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$pending pending",
       "surface": "android",
@@ -4827,7 +4811,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1707,
+      "line": 1725,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 pending",
       "surface": "android",
@@ -4835,7 +4819,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1712,
+      "line": 1730,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$held held",
       "surface": "android",
@@ -4843,7 +4827,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1712,
+      "line": 1730,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 held",
       "surface": "android",
@@ -4851,7 +4835,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1713,
+      "line": 1731,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$applied applied",
       "surface": "android",
@@ -4859,7 +4843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1713,
+      "line": 1731,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 applied",
       "surface": "android",
@@ -4867,7 +4851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1894,
+      "line": 1912,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw mobile",
       "surface": "android",
@@ -4875,7 +4859,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1898,
+      "line": 1916,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open profile",
       "surface": "android",
@@ -4883,7 +4867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1983,
+      "line": 2001,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Main session",
       "surface": "android",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -219,7 +219,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 667,
+      "line": 666,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -227,7 +227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1547,
+      "line": 1548,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron job started.",
       "surface": "android",
@@ -235,7 +235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1547,
+      "line": 1548,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron run queued.",
       "surface": "android",
@@ -243,7 +243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1591,
+      "line": 1592,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron job disabled.",
       "surface": "android",
@@ -251,7 +251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1591,
+      "line": 1592,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron job enabled.",
       "surface": "android",
@@ -259,7 +259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3194,
+      "line": 3195,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
@@ -267,7 +267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3196,
+      "line": 3197,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -275,7 +275,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3198,
+      "line": 3199,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",

--- a/apps/android/CHANGELOG.md
+++ b/apps/android/CHANGELOG.md
@@ -12,6 +12,8 @@ Adds an Android system share target that stages bounded text and image shares fo
 
 Displays configured agent avatars across Android overview, settings, and chat, with bounded data and public remote image loading. Thanks @guarismo.
 
+Shows source-configured provider model inventory, capabilities, and route-aware availability in Android without exposing runtime route details. Thanks @snowzlmbot.
+
 ## 2026.7.1 - 2026-07-08
 
 Adds multi-gateway switching with isolated credentials, history, queues, and notification routing.

--- a/apps/android/app/src/main/java/ai/openclaw/app/AndroidScreenshotFixture.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/AndroidScreenshotFixture.kt
@@ -29,6 +29,7 @@ internal object AndroidScreenshotFixture {
         available = true,
         supportsVision = true,
         supportsAudio = true,
+        supportsVideo = true,
         supportsDocuments = true,
         supportsReasoning = true,
         contextTokens = 200_000,

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -278,6 +278,9 @@ class MainViewModel(
   val gatewayVersion: StateFlow<String?> = runtimeState(initial = null) { it.gatewayVersion }
   val gatewayUpdateAvailable: StateFlow<GatewayUpdateAvailableSummary?> = runtimeState(initial = null) { it.gatewayUpdateAvailable }
   val modelCatalog: StateFlow<List<GatewayModelSummary>> = runtimeState(initial = emptyList()) { it.modelCatalog }
+  val providerModelCatalog: StateFlow<List<GatewayModelSummary>> = runtimeState(initial = emptyList()) { it.providerModelCatalog }
+  val providerModelCatalogRefreshing: StateFlow<Boolean> = runtimeState(initial = false) { it.providerModelCatalogRefreshing }
+  val providerModelCatalogErrorText: StateFlow<String?> = runtimeState(initial = null) { it.providerModelCatalogErrorText }
   val modelAuthProviders: StateFlow<List<GatewayModelProviderSummary>> = runtimeState(initial = emptyList()) { it.modelAuthProviders }
   val modelCatalogRefreshing: StateFlow<Boolean> = runtimeState(initial = false) { it.modelCatalogRefreshing }
   val modelCatalogErrorText: StateFlow<String?> = runtimeState(initial = null) { it.modelCatalogErrorText }
@@ -860,6 +863,10 @@ class MainViewModel(
 
   fun refreshModelCatalog() {
     ensureRuntime().refreshModelCatalog()
+  }
+
+  fun refreshProviderModels() {
+    ensureRuntime().refreshProviderModels()
   }
 
   fun refreshTalkSetupReadiness() {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -87,6 +87,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
@@ -716,6 +717,12 @@ class NodeRuntime private constructor(
   val seamColorArgb: StateFlow<Long> = _seamColorArgb.asStateFlow()
   private val _modelCatalog = MutableStateFlow<List<GatewayModelSummary>>(emptyList())
   val modelCatalog: StateFlow<List<GatewayModelSummary>> = _modelCatalog.asStateFlow()
+  private val _providerModelCatalog = MutableStateFlow<List<GatewayModelSummary>>(emptyList())
+  val providerModelCatalog: StateFlow<List<GatewayModelSummary>> = _providerModelCatalog.asStateFlow()
+  private val _providerModelCatalogRefreshing = MutableStateFlow(false)
+  val providerModelCatalogRefreshing: StateFlow<Boolean> = _providerModelCatalogRefreshing.asStateFlow()
+  private val _providerModelCatalogErrorText = MutableStateFlow<String?>(null)
+  val providerModelCatalogErrorText: StateFlow<String?> = _providerModelCatalogErrorText.asStateFlow()
   private val _modelAuthProviders = MutableStateFlow<List<GatewayModelProviderSummary>>(emptyList())
   val modelAuthProviders: StateFlow<List<GatewayModelProviderSummary>> = _modelAuthProviders.asStateFlow()
   private val _modelCatalogRefreshing = MutableStateFlow(false)
@@ -918,6 +925,9 @@ class NodeRuntime private constructor(
     _gatewayAgents.value = emptyList()
     selectedChatAgentId = null
     _modelCatalog.value = emptyList()
+    _providerModelCatalog.value = emptyList()
+    _providerModelCatalogRefreshing.value = false
+    _providerModelCatalogErrorText.value = null
     _modelAuthProviders.value = emptyList()
     _modelCatalogRefreshing.value = false
     _modelCatalogErrorText.value = null
@@ -1413,6 +1423,7 @@ class NodeRuntime private constructor(
       refreshBrandingFromGateway()
       refreshAgentsFromGateway()
       refreshModelCatalogFromGateway()
+      refreshProviderModelsFromGateway()
       refreshTalkSetupReadinessFromGateway()
       refreshCronFromGateway()
       refreshUsageFromGateway()
@@ -1428,6 +1439,13 @@ class NodeRuntime private constructor(
     if (mode == NodeRuntimeMode.ScreenshotFixture) return
     scope.launch {
       refreshModelCatalogFromGateway()
+    }
+  }
+
+  fun refreshProviderModels() {
+    if (mode == NodeRuntimeMode.ScreenshotFixture) return
+    scope.launch {
+      refreshProviderModelsFromGateway()
     }
   }
 
@@ -1921,6 +1939,7 @@ class NodeRuntime private constructor(
     _gatewayDefaultAgentId.value = "main"
     _gatewayAgents.value = AndroidScreenshotFixture.agents
     _modelCatalog.value = AndroidScreenshotFixture.models
+    _providerModelCatalog.value = AndroidScreenshotFixture.models
     _modelAuthProviders.value = AndroidScreenshotFixture.providers
     _talkSetupReadiness.value =
       GatewayTalkSetupReadiness(
@@ -3821,18 +3840,61 @@ class NodeRuntime private constructor(
       val modelsRes = requestGatewayData(gatewayScope, "models.list", "{}")
       val modelsRoot = json.parseToJsonElement(modelsRes).asObjectOrNull()
       val models = parseGatewayModels(modelsRoot?.get("models") as? JsonArray)
-      val authRes = requestGatewayData(gatewayScope, "models.authStatus", "{}")
-      val authRoot = json.parseToJsonElement(authRes).asObjectOrNull()
-      val providers = parseGatewayModelProviders(authRoot?.get("providers") as? JsonArray)
       publishGatewayData(gatewayScope) {
         _modelCatalog.value = models
-        _modelAuthProviders.value = providers
       }
     } catch (_: Throwable) {
       publishGatewayData(gatewayScope) { _modelCatalogErrorText.value = "Could not load provider catalog." }
     } finally {
       publishGatewayData(gatewayScope) { _modelCatalogRefreshing.value = false }
     }
+  }
+
+  private suspend fun refreshProviderModelsFromGateway() {
+    val gatewayScope = captureGatewayDataScope() ?: return
+    publishGatewayData(gatewayScope) {
+      _providerModelCatalogRefreshing.value = true
+      _providerModelCatalogErrorText.value = null
+    }
+    if (!operatorConnected) {
+      _providerModelCatalog.value = emptyList()
+      _modelAuthProviders.value = emptyList()
+      _providerModelCatalogRefreshing.value = false
+      return
+    }
+    try {
+      val (models, providers) =
+        coroutineScope {
+          val models = async { requestProviderModelCatalog(gatewayScope) }
+          val providers = async { requestModelAuthProviders(gatewayScope) }
+          models.await() to providers.await()
+        }
+      publishGatewayData(gatewayScope) {
+        _providerModelCatalog.value = models
+        _modelAuthProviders.value = providers
+      }
+    } catch (_: Throwable) {
+      publishGatewayData(gatewayScope) {
+        _providerModelCatalogErrorText.value = "Could not load provider model config."
+      }
+    } finally {
+      publishGatewayData(gatewayScope) { _providerModelCatalogRefreshing.value = false }
+    }
+  }
+
+  private suspend fun requestProviderModelCatalog(gatewayScope: GatewayDataScope): List<GatewayModelSummary> {
+    val modelsRes =
+      requestProviderModelConfig { paramsJson ->
+        requestGatewayData(gatewayScope, "models.list", paramsJson)
+      }
+    val modelsRoot = json.parseToJsonElement(modelsRes).asObjectOrNull()
+    return parseGatewayModels(modelsRoot?.get("models") as? JsonArray)
+  }
+
+  private suspend fun requestModelAuthProviders(gatewayScope: GatewayDataScope): List<GatewayModelProviderSummary> {
+    val authRes = requestGatewayData(gatewayScope, "models.authStatus", "{}")
+    val authRoot = json.parseToJsonElement(authRes).asObjectOrNull()
+    return parseGatewayModelProviders(authRoot?.get("providers") as? JsonArray)
   }
 
   private suspend fun refreshTalkSetupReadinessFromGateway() {
@@ -5640,6 +5702,7 @@ data class GatewayModelSummary(
   val available: Boolean?,
   val supportsVision: Boolean,
   val supportsAudio: Boolean,
+  val supportsVideo: Boolean,
   val supportsDocuments: Boolean,
   val supportsReasoning: Boolean,
   val contextTokens: Long?,
@@ -5660,11 +5723,22 @@ internal fun parseGatewayModels(models: JsonArray?): List<GatewayModelSummary> =
         available = obj.optionalBoolean("available"),
         supportsVision = "image" in inputTypes,
         supportsAudio = "audio" in inputTypes,
+        supportsVideo = "video" in inputTypes,
         supportsDocuments = "document" in inputTypes,
         supportsReasoning = obj["reasoning"].toString().trim() == "true",
         contextTokens = obj["contextWindow"].toString().toLongOrNull() ?: obj["contextTokens"].toString().toLongOrNull(),
       )
     }.orEmpty()
+
+internal suspend fun requestProviderModelConfig(request: suspend (String) -> String): String =
+  try {
+    request("""{"view":"provider-config"}""")
+  } catch (err: GatewayRequestRejected) {
+    if (err.gatewayError.code != "INVALID_REQUEST") throw err
+    // Released Gateways without the inventory view still provide the closest
+    // read-only catalog through the configured picker contract.
+    request("""{"view":"configured"}""")
+  }
 
 data class GatewayModelProviderSummary(
   val id: String,

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -87,7 +87,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
@@ -723,6 +722,7 @@ class NodeRuntime private constructor(
   val providerModelCatalogRefreshing: StateFlow<Boolean> = _providerModelCatalogRefreshing.asStateFlow()
   private val _providerModelCatalogErrorText = MutableStateFlow<String?>(null)
   val providerModelCatalogErrorText: StateFlow<String?> = _providerModelCatalogErrorText.asStateFlow()
+  private val providerModelCatalogRefreshGuard = LatestGatewayRefreshGuard()
   private val _modelAuthProviders = MutableStateFlow<List<GatewayModelProviderSummary>>(emptyList())
   val modelAuthProviders: StateFlow<List<GatewayModelProviderSummary>> = _modelAuthProviders.asStateFlow()
   private val _modelCatalogRefreshing = MutableStateFlow(false)
@@ -925,6 +925,7 @@ class NodeRuntime private constructor(
     _gatewayAgents.value = emptyList()
     selectedChatAgentId = null
     _modelCatalog.value = emptyList()
+    providerModelCatalogRefreshGuard.invalidate()
     _providerModelCatalog.value = emptyList()
     _providerModelCatalogRefreshing.value = false
     _providerModelCatalogErrorText.value = null
@@ -3752,6 +3753,15 @@ class NodeRuntime private constructor(
       cronRefreshGuard.publishIfCurrent(refreshGeneration) { publish() }
     }
 
+  private inline fun publishProviderModelRefresh(
+    gatewayScope: GatewayDataScope,
+    refreshGeneration: Long,
+    crossinline publish: () -> Unit,
+  ): Boolean =
+    publishGatewayData(gatewayScope) {
+      providerModelCatalogRefreshGuard.publishIfCurrent(refreshGeneration) { publish() }
+    }
+
   private suspend fun refreshBrandingFromGateway() {
     val gatewayScope = captureGatewayDataScope() ?: return
     if (!gatewayConnectionDisplay.value.isConnected) return
@@ -3851,34 +3861,56 @@ class NodeRuntime private constructor(
   }
 
   private suspend fun refreshProviderModelsFromGateway() {
+    val refreshGeneration = providerModelCatalogRefreshGuard.begin()
     val gatewayScope = captureGatewayDataScope() ?: return
-    publishGatewayData(gatewayScope) {
+    publishProviderModelRefresh(gatewayScope, refreshGeneration) {
       _providerModelCatalogRefreshing.value = true
       _providerModelCatalogErrorText.value = null
     }
     if (!operatorConnected) {
-      _providerModelCatalog.value = emptyList()
-      _modelAuthProviders.value = emptyList()
-      _providerModelCatalogRefreshing.value = false
+      publishProviderModelRefresh(gatewayScope, refreshGeneration) {
+        _providerModelCatalog.value = emptyList()
+        _modelAuthProviders.value = emptyList()
+        _providerModelCatalogRefreshing.value = false
+      }
       return
     }
     try {
-      val (models, providers) =
-        coroutineScope {
-          val models = async { requestProviderModelCatalog(gatewayScope) }
-          val providers = async { requestModelAuthProviders(gatewayScope) }
-          models.await() to providers.await()
+      try {
+        val models = requestProviderModelCatalog(gatewayScope)
+        publishProviderModelRefresh(gatewayScope, refreshGeneration) {
+          _providerModelCatalog.value = models
         }
-      publishGatewayData(gatewayScope) {
-        _providerModelCatalog.value = models
-        _modelAuthProviders.value = providers
+      } catch (err: Throwable) {
+        publishProviderModelRefresh(gatewayScope, refreshGeneration) {
+          _providerModelCatalogErrorText.value =
+            if (err is ProviderModelConfigUnsupported) {
+              "Update your Gateway to view provider model config."
+            } else {
+              "Could not load provider model config."
+            }
+        }
       }
-    } catch (_: Throwable) {
-      publishGatewayData(gatewayScope) {
-        _providerModelCatalogErrorText.value = "Could not load provider model config."
+
+      // Keep readiness independent from the additive provider-config view so
+      // older Gateways still populate provider status while prompting an upgrade.
+      try {
+        val providers = requestModelAuthProviders(gatewayScope)
+        publishProviderModelRefresh(gatewayScope, refreshGeneration) {
+          _modelAuthProviders.value = providers
+        }
+      } catch (_: Throwable) {
+        publishProviderModelRefresh(gatewayScope, refreshGeneration) {
+          if (_providerModelCatalogErrorText.value == null) {
+            _providerModelCatalogErrorText.value =
+              "Provider models loaded, but readiness is unavailable."
+          }
+        }
       }
     } finally {
-      publishGatewayData(gatewayScope) { _providerModelCatalogRefreshing.value = false }
+      publishProviderModelRefresh(gatewayScope, refreshGeneration) {
+        _providerModelCatalogRefreshing.value = false
+      }
     }
   }
 
@@ -5726,18 +5758,18 @@ internal fun parseGatewayModels(models: JsonArray?): List<GatewayModelSummary> =
         supportsVideo = "video" in inputTypes,
         supportsDocuments = "document" in inputTypes,
         supportsReasoning = obj["reasoning"].toString().trim() == "true",
-        contextTokens = obj["contextWindow"].toString().toLongOrNull() ?: obj["contextTokens"].toString().toLongOrNull(),
+        contextTokens = obj["contextTokens"].toString().toLongOrNull() ?: obj["contextWindow"].toString().toLongOrNull(),
       )
     }.orEmpty()
+
+internal class ProviderModelConfigUnsupported : Exception()
 
 internal suspend fun requestProviderModelConfig(request: suspend (String) -> String): String =
   try {
     request("""{"view":"provider-config"}""")
   } catch (err: GatewayRequestRejected) {
     if (err.gatewayError.code != "INVALID_REQUEST") throw err
-    // Released Gateways without the inventory view still provide the closest
-    // read-only catalog through the configured picker contract.
-    request("""{"view":"configured"}""")
+    throw ProviderModelConfigUnsupported()
   }
 
 data class GatewayModelProviderSummary(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt
@@ -65,7 +65,7 @@ internal fun CommandPalette(
 ) {
   val isConnected by viewModel.isConnected.collectAsState()
   val sessions by viewModel.chatSessions.collectAsState()
-  val models by viewModel.modelCatalog.collectAsState()
+  val models by viewModel.providerModelCatalog.collectAsState()
   val providers by viewModel.modelAuthProviders.collectAsState()
   val pendingRunCount by viewModel.pendingRunCount.collectAsState()
   var query by rememberSaveable { mutableStateOf("") }
@@ -302,8 +302,10 @@ internal fun providerCommandSubtitle(
   models: List<GatewayModelSummary>,
 ): String {
   if (!isConnected) return "Connect Gateway to view providers"
-  val readyProviderCount = providerRows(providers = providers, models = models).count { it.ready }
+  val rows = providerRows(providers = providers, models = models)
+  val readyProviderCount = rows.count { it.ready }
   if (readyProviderCount > 0) return "$readyProviderCount providers ready"
+  if (rows.any { it.availability == ProviderAvailability.Unknown }) return "Provider availability unknown"
   return "No ready providers"
 }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt
@@ -173,8 +173,7 @@ internal fun providerRows(
         modelCount = providerModels.size,
         models = providerModels,
       )
-    }
-    .sortedWith(compareBy(::providerPriority, { it.name.lowercase() }))
+    }.sortedWith(compareBy(::providerPriority, { it.name.lowercase() }))
 }
 
 private val ProviderAvailability.label: String

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt
@@ -20,17 +20,16 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -44,6 +43,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
@@ -54,15 +54,15 @@ internal fun ProvidersModelsScreen(
   onBack: () -> Unit,
 ) {
   val isConnected by viewModel.isConnected.collectAsState()
-  val models by viewModel.modelCatalog.collectAsState()
+  val models by viewModel.providerModelCatalog.collectAsState()
   val providers by viewModel.modelAuthProviders.collectAsState()
-  val refreshing by viewModel.modelCatalogRefreshing.collectAsState()
-  val errorText by viewModel.modelCatalogErrorText.collectAsState()
+  val refreshing by viewModel.providerModelCatalogRefreshing.collectAsState()
+  val errorText by viewModel.providerModelCatalogErrorText.collectAsState()
   val providerRows = providerRows(providers = providers, models = models)
 
   LaunchedEffect(isConnected) {
     if (isConnected) {
-      viewModel.refreshModelCatalog()
+      viewModel.refreshProviderModels()
     }
   }
 
@@ -101,21 +101,21 @@ internal fun ProvidersModelsScreen(
             isConnected = isConnected,
             providerRows = providerRows,
             modelCount = models.size,
-            onRefresh = viewModel::refreshModelCatalog,
+            onRefresh = viewModel::refreshProviderModels,
             refreshing = refreshing,
           )
         }
 
         item {
-          ProviderSectionLabel(title = "Connected providers")
+          ProviderSectionLabel(title = "Providers and configured models")
         }
 
-        item {
-          if (!isConnected && providerRows.isEmpty()) {
+        if (!isConnected && providerRows.isEmpty()) {
+          item {
             ClawEmptyState(title = "Gateway offline", body = "Connect your Gateway to load provider readiness.")
-          } else {
-            ProviderList(rows = providerRows, refreshing = refreshing)
           }
+        } else {
+          providerListItems(rows = providerRows, refreshing = refreshing)
         }
 
         errorText?.let { message ->
@@ -134,43 +134,73 @@ internal data class ProviderRow(
   val id: String,
   val name: String,
   val status: String,
-  val ready: Boolean,
+  val availability: ProviderAvailability,
   val modelCount: Int,
-)
+  val models: List<GatewayModelSummary> = emptyList(),
+) {
+  val ready: Boolean
+    get() = availability == ProviderAvailability.Available
+}
+
+internal enum class ProviderAvailability {
+  Available,
+  Unavailable,
+  Unknown,
+}
 
 /** Combines gateway auth-provider readiness with configured model providers. */
 internal fun providerRows(
   providers: List<GatewayModelProviderSummary>,
   models: List<GatewayModelSummary>,
 ): List<ProviderRow> {
-  val modelCounts = models.groupingBy { it.provider }.eachCount()
-  val authRows =
-    providers
-      .map { provider ->
-        val ready = modelProviderReady(provider.status)
-        ProviderRow(
-          id = provider.id,
-          name = provider.displayName,
-          status = if (ready) "Ready" else "Needs attention",
-          ready = ready,
-          modelCount = modelCounts[provider.id] ?: 0,
-        )
-      }
-  val authProviderIds = authRows.mapTo(mutableSetOf()) { it.id.trim().lowercase() }
-  val configuredModelRows =
-    modelCounts.keys
-      .filter { provider -> provider.trim().lowercase() !in authProviderIds }
-      .map { provider ->
-        ProviderRow(
-          id = provider,
-          name = providerDisplayName(provider),
-          status = "Ready",
-          ready = true,
-          modelCount = modelCounts[provider] ?: 0,
-        )
-      }
-  return (authRows + configuredModelRows).sortedWith(compareBy(::providerPriority, { it.name.lowercase() }))
+  val providersById = providers.associateBy { it.id.normalizedProviderId() }
+  val modelsByProvider =
+    models
+      .groupBy { it.provider.normalizedProviderId() }
+      .mapValues { (_, providerModels) -> providerModels.sortedWith(modelComparator) }
+  val providerIds = providersById.keys + modelsByProvider.keys
+  return providerIds
+    .map { providerId ->
+      val providerModels = modelsByProvider[providerId].orEmpty()
+      val authProvider = providersById[providerId]
+      val availability = providerAvailability(authProvider = authProvider, models = providerModels)
+      val displayId = providerModels.firstOrNull()?.provider?.takeIf { it.isNotBlank() } ?: authProvider?.id ?: providerId
+      ProviderRow(
+        id = displayId,
+        name = authProvider?.displayName ?: providerDisplayName(displayId),
+        status = availability.label,
+        availability = availability,
+        modelCount = providerModels.size,
+        models = providerModels,
+      )
+    }
+    .sortedWith(compareBy(::providerPriority, { it.name.lowercase() }))
 }
+
+private val ProviderAvailability.label: String
+  get() =
+    when (this) {
+      ProviderAvailability.Available -> "Ready"
+      ProviderAvailability.Unavailable -> "Needs attention"
+      ProviderAvailability.Unknown -> "Unknown"
+    }
+
+private fun providerAvailability(
+  authProvider: GatewayModelProviderSummary?,
+  models: List<GatewayModelSummary>,
+): ProviderAvailability {
+  if (models.any { it.available == true }) return ProviderAvailability.Available
+  if (models.isNotEmpty()) {
+    return if (models.all { it.available == false }) ProviderAvailability.Unavailable else ProviderAvailability.Unknown
+  }
+  return if (authProvider != null && modelProviderReady(authProvider.status)) {
+    ProviderAvailability.Available
+  } else {
+    ProviderAvailability.Unavailable
+  }
+}
+
+private fun String.normalizedProviderId(): String = trim().lowercase()
 
 /** Normalizes gateway provider status strings into a ready/not-ready boolean. */
 internal fun modelProviderReady(status: String): Boolean {
@@ -181,6 +211,8 @@ internal fun modelProviderReady(status: String): Boolean {
     normalized == "configured" ||
     normalized == "static"
 }
+
+private val modelComparator = compareBy<GatewayModelSummary>({ it.name.lowercase() }, { it.id.lowercase() })
 
 private fun providerPriority(row: ProviderRow): Int = providerPriority(row.id)
 
@@ -195,31 +227,35 @@ private fun providerPriority(provider: String): Int =
     else -> 100
   }
 
-@Composable
-private fun ProviderList(
+private fun LazyListScope.providerListItems(
   rows: List<ProviderRow>,
   refreshing: Boolean,
 ) {
-  ClawPanel(contentPadding = PaddingValues(horizontal = 0.dp, vertical = 0.dp)) {
-    Column {
-      if (rows.isEmpty()) {
-        ProviderListRow(
+  if (rows.isEmpty()) {
+    item(key = "provider-catalog-empty") {
+      ProviderListRow(
+        row =
           ProviderRow(
             id = "loading",
             name = "Provider catalog",
             status = if (refreshing) "Loading" else "No providers",
-            ready = false,
+            availability = ProviderAvailability.Unknown,
             modelCount = 0,
           ),
-        )
-      } else {
-        val visibleRows = rows.take(5)
-        visibleRows.forEachIndexed { index, row ->
-          ProviderListRow(row)
-          if (index != visibleRows.lastIndex) {
-            HorizontalDivider(color = ClawTheme.colors.border, thickness = 1.dp)
-          }
-        }
+      )
+    }
+    return
+  }
+  rows.forEach { row ->
+    item(key = "provider:${row.id}") {
+      ProviderListRow(row = row)
+    }
+    items(
+      count = row.models.size,
+      key = { index -> "model:${row.id}:$index:${row.models[index].id}" },
+    ) { index ->
+      Box(modifier = Modifier.padding(horizontal = 10.dp)) {
+        ProviderModelRow(model = row.models[index])
       }
     }
   }
@@ -234,16 +270,17 @@ private fun ProviderOverviewPanel(
   onRefresh: () -> Unit,
 ) {
   val readyCount = providerRows.count { it.ready }
-  val needsSetupCount = providerRows.count { !it.ready }
+  val needsSetupCount = providerRows.count { it.availability == ProviderAvailability.Unavailable }
+  val unknownCount = providerRows.count { it.availability == ProviderAvailability.Unknown }
   ClawPanel(contentPadding = PaddingValues(horizontal = 12.dp, vertical = 12.dp)) {
     Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
       Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
         ProviderMetricTile(label = "Ready", value = readyCount.toString(), modifier = Modifier.weight(1f))
-        ProviderMetricTile(label = "Models", value = modelCount.toString(), modifier = Modifier.weight(1f))
         ProviderMetricTile(label = "Needs", value = needsSetupCount.toString(), modifier = Modifier.weight(1f))
+        ProviderMetricTile(label = "Unknown", value = unknownCount.toString(), modifier = Modifier.weight(1f))
       }
       Text(
-        text = if (isConnected) "Refresh to recheck provider readiness from your Gateway." else "Connect your Gateway to view provider readiness.",
+        text = if (isConnected) "$modelCount configured models. Refresh to recheck availability." else "Connect your Gateway to view provider readiness.",
         style = ClawTheme.type.body,
         color = ClawTheme.colors.textMuted,
       )
@@ -274,18 +311,82 @@ private fun ProviderMetricTile(
 
 @Composable
 private fun ProviderListRow(row: ProviderRow) {
-  Row(modifier = Modifier.fillMaxWidth().heightIn(min = 58.dp).padding(horizontal = 10.dp, vertical = 6.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-    ProviderBadge(text = row.name)
-    Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(1.dp)) {
-      Text(text = row.name, style = ClawTheme.type.body, color = ClawTheme.colors.text, maxLines = 1)
-      Text(text = if (row.modelCount > 0) "${row.modelCount} models" else "No configured models", style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp), color = ClawTheme.colors.textMuted, maxLines = 1)
-    }
-    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(5.dp)) {
-      Box(modifier = Modifier.size(4.5.dp).clip(CircleShape).background(if (row.ready) ClawTheme.colors.success else ClawTheme.colors.warning))
-      Text(text = row.status, style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp), color = ClawTheme.colors.textMuted, maxLines = 1)
+  ClawPanel(contentPadding = PaddingValues(horizontal = 10.dp, vertical = 8.dp)) {
+    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+      ProviderBadge(text = row.name)
+      Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(1.dp)) {
+        Text(text = row.name, style = ClawTheme.type.body, color = ClawTheme.colors.text, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Text(text = if (row.modelCount > 0) "${row.modelCount} configured models" else "No configured models", style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp), color = ClawTheme.colors.textMuted, maxLines = 1)
+      }
+      AvailabilityPill(availability = row.availability, label = row.status)
     }
   }
 }
+
+@Composable
+private fun ProviderModelRow(model: GatewayModelSummary) {
+  Surface(shape = RoundedCornerShape(ClawTheme.radii.row), color = ClawTheme.colors.surface, border = BorderStroke(1.dp, ClawTheme.colors.border)) {
+    Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 9.dp, vertical = 8.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+      Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.Top) {
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+          Text(text = model.name, style = ClawTheme.type.body, color = ClawTheme.colors.text, maxLines = 1, overflow = TextOverflow.Ellipsis)
+          Text(text = model.id, style = ClawTheme.type.caption.copy(fontSize = 12.2.sp, lineHeight = 15.sp), color = ClawTheme.colors.textMuted, maxLines = 2, overflow = TextOverflow.Ellipsis)
+        }
+        val availability = model.available.toProviderAvailability()
+        AvailabilityPill(availability = availability, label = availability.modelLabel)
+      }
+      modelCapabilities(model).takeIf { it.isNotEmpty() }?.let { capabilities ->
+        Text(text = capabilities, style = ClawTheme.type.caption.copy(fontSize = 12.sp, lineHeight = 15.sp), color = ClawTheme.colors.textSubtle, maxLines = 2, overflow = TextOverflow.Ellipsis)
+      }
+    }
+  }
+}
+
+@Composable
+private fun AvailabilityPill(
+  availability: ProviderAvailability,
+  label: String,
+) {
+  Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(5.dp)) {
+    Box(modifier = Modifier.size(4.5.dp).clip(CircleShape).background(availability.color()))
+    Text(text = label, style = ClawTheme.type.caption.copy(fontSize = 12.2.sp, lineHeight = 15.sp), color = ClawTheme.colors.textMuted, maxLines = 1)
+  }
+}
+
+@Composable
+private fun ProviderAvailability.color(): Color =
+  when (this) {
+    ProviderAvailability.Available -> ClawTheme.colors.success
+    ProviderAvailability.Unavailable -> ClawTheme.colors.warning
+    ProviderAvailability.Unknown -> ClawTheme.colors.textSubtle
+  }
+
+private val ProviderAvailability.modelLabel: String
+  get() =
+    when (this) {
+      ProviderAvailability.Available -> "Available"
+      ProviderAvailability.Unavailable -> "Unavailable"
+      ProviderAvailability.Unknown -> "Unknown"
+    }
+
+private fun Boolean?.toProviderAvailability(): ProviderAvailability =
+  when (this) {
+    true -> ProviderAvailability.Available
+    false -> ProviderAvailability.Unavailable
+    null -> ProviderAvailability.Unknown
+  }
+
+internal fun modelCapabilities(model: GatewayModelSummary): String =
+  buildList {
+    if (model.supportsReasoning) add("reasoning")
+    if (model.supportsVision) add("image")
+    if (model.supportsAudio) add("audio")
+    if (model.supportsVideo) add("video")
+    if (model.supportsDocuments) add("document")
+    model.contextTokens?.let { add("${formatContextTokens(it)} context") }
+  }.joinToString(" / ")
+
+private fun formatContextTokens(tokens: Long): String = if (tokens >= 1_000) "${tokens / 1_000}k" else tokens.toString()
 
 @Composable
 private fun ProviderBadge(text: String) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -410,7 +410,7 @@ private fun OverviewScreen(
   val pendingRunCount by viewModel.pendingRunCount.collectAsState()
   val gatewayConnectionDisplay by viewModel.gatewayConnectionDisplay.collectAsState()
   val isConnected = gatewayConnectionDisplay.isConnected
-  val models by viewModel.modelCatalog.collectAsState()
+  val models by viewModel.providerModelCatalog.collectAsState()
   val providers by viewModel.modelAuthProviders.collectAsState()
   val execApprovals by viewModel.execApprovals.collectAsState()
   val pendingToolCalls by viewModel.chatPendingToolCalls.collectAsState()
@@ -419,7 +419,9 @@ private fun OverviewScreen(
   val channelsSummary by viewModel.channelsSummary.collectAsState()
   val agents by viewModel.gatewayAgents.collectAsState()
   val defaultAgentId by viewModel.gatewayDefaultAgentId.collectAsState()
-  val readyProviderCount = providerRows(providers = providers, models = models).count { it.ready }
+  val providerRows = providerRows(providers = providers, models = models)
+  val readyProviderCount = providerRows.count { it.ready }
+  val unknownProviderCount = providerRows.count { it.availability == ProviderAvailability.Unknown }
   val pendingApprovalsCount = execApprovals.size + pendingToolCalls.size
   val attentionRows =
     homeAttentionRows(
@@ -428,6 +430,7 @@ private fun OverviewScreen(
       channelsSummary = channelsSummary,
       nodesDevicesSummary = nodesDevicesSummary,
       readyProviderCount = readyProviderCount,
+      unknownProviderCount = unknownProviderCount,
     )
   val secondaryAttentionRows =
     if (nodesDevicesSummary.hasNodeCapabilityApprovalPending()) {
@@ -470,6 +473,7 @@ private fun OverviewScreen(
       viewModel.refreshChatSessions(limit = 20)
       viewModel.refreshAgents()
       viewModel.refreshModelCatalog()
+      viewModel.refreshProviderModels()
       viewModel.refreshCronJobs()
       viewModel.refreshNodesDevices()
       viewModel.refreshChannels()
@@ -1224,6 +1228,7 @@ internal fun homeAttentionRows(
   channelsSummary: GatewayChannelsSummary,
   nodesDevicesSummary: GatewayNodesDevicesSummary,
   readyProviderCount: Int,
+  unknownProviderCount: Int = 0,
 ): List<HomeAttentionRow> =
   listOfNotNull(
     if (!isConnected) {
@@ -1246,7 +1251,7 @@ internal fun homeAttentionRows(
     } else {
       null
     },
-    if (isConnected && readyProviderCount == 0) {
+    if (isConnected && readyProviderCount == 0 && unknownProviderCount == 0) {
       HomeAttentionRow("Providers", "No ready providers", Icons.Outlined.Inventory2, Tab.Settings, SettingsRoute.ProvidersModels)
     } else {
       null
@@ -1493,7 +1498,7 @@ private fun SettingsShellScreen(
   val displayName by viewModel.displayName.collectAsState()
   val gatewayConnectionDisplay by viewModel.gatewayConnectionDisplay.collectAsState()
   val isConnected = gatewayConnectionDisplay.isConnected
-  val models by viewModel.modelCatalog.collectAsState()
+  val models by viewModel.providerModelCatalog.collectAsState()
   val providers by viewModel.modelAuthProviders.collectAsState()
   val cameraEnabled by viewModel.cameraEnabled.collectAsState()
   val notificationForwardingEnabled by viewModel.notificationForwardingEnabled.collectAsState()
@@ -1509,13 +1514,16 @@ private fun SettingsShellScreen(
   val channelsSummary by viewModel.channelsSummary.collectAsState()
   val dreamingSummary by viewModel.dreamingSummary.collectAsState()
   val appearanceThemeMode by viewModel.appearanceThemeMode.collectAsState()
-  val readyProviderCount = providerRows(providers = providers, models = models).count { it.ready }
+  val providerRows = providerRows(providers = providers, models = models)
+  val readyProviderCount = providerRows.count { it.ready }
+  val unknownProviderCount = providerRows.count { it.availability == ProviderAvailability.Unknown }
   val pendingApprovalsCount = execApprovals.size + pendingToolCalls.size
 
   LaunchedEffect(isConnected) {
     if (isConnected) {
       viewModel.refreshAgents()
       viewModel.refreshModelCatalog()
+      viewModel.refreshProviderModels()
       viewModel.refreshCronJobs()
       viewModel.refreshUsage()
       viewModel.refreshSkills()
@@ -1579,9 +1587,19 @@ private fun SettingsShellScreen(
           SettingsRow("Agents", if (agents.isEmpty()) "Load from gateway" else "${agents.size} available", Icons.Default.Person, status = agents.isNotEmpty(), route = SettingsRoute.Agents),
           SettingsRow(
             "Providers & Models",
-            if (readyProviderCount > 0) "$readyProviderCount ready" else "Review readiness",
+            when {
+              readyProviderCount > 0 -> "$readyProviderCount ready"
+              unknownProviderCount > 0 -> "Availability unknown"
+              else -> "Review readiness"
+            },
             Icons.Outlined.Inventory2,
-            status = if (isConnected) readyProviderCount > 0 else false,
+            status =
+              when {
+                !isConnected -> false
+                readyProviderCount > 0 -> true
+                unknownProviderCount > 0 -> null
+                else -> false
+              },
             route = SettingsRoute.ProvidersModels,
           ),
           SettingsRow("Approvals", approvalsSummary(pendingApprovalsCount), Icons.Default.Lock, status = approvalsStatus(pendingApprovalsCount), route = SettingsRoute.Approvals),

--- a/apps/android/app/src/test/java/ai/openclaw/app/ProviderModelCatalogRequestTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ProviderModelCatalogRequestTest.kt
@@ -1,0 +1,46 @@
+package ai.openclaw.app
+
+import ai.openclaw.app.gateway.GatewayRequestRejected
+import ai.openclaw.app.gateway.GatewaySession
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class ProviderModelCatalogRequestTest {
+  @Test
+  fun fallsBackToConfiguredViewWhenGatewayRejectsProviderConfigView() =
+    runBlocking {
+      val requests = mutableListOf<String>()
+
+      val response =
+        requestProviderModelConfig { paramsJson ->
+          requests += paramsJson
+          if (requests.size == 1) {
+            throw GatewayRequestRejected(GatewaySession.ErrorShape("INVALID_REQUEST", "unsupported view"))
+          }
+          "configured-response"
+        }
+
+      assertEquals("configured-response", response)
+      assertEquals(
+        listOf("""{"view":"provider-config"}""", """{"view":"configured"}"""),
+        requests,
+      )
+    }
+
+  @Test
+  fun preservesNonCompatibilityGatewayFailures() =
+    runBlocking {
+      val expected = GatewayRequestRejected(GatewaySession.ErrorShape("UNAVAILABLE", "gateway busy"))
+      var actual: Throwable? = null
+
+      try {
+        requestProviderModelConfig { throw expected }
+      } catch (err: Throwable) {
+        actual = err
+      }
+
+      assertSame(expected, actual)
+    }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/ProviderModelCatalogRequestTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ProviderModelCatalogRequestTest.kt
@@ -3,30 +3,44 @@ package ai.openclaw.app
 import ai.openclaw.app.gateway.GatewayRequestRejected
 import ai.openclaw.app.gateway.GatewaySession
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ProviderModelCatalogRequestTest {
   @Test
-  fun fallsBackToConfiguredViewWhenGatewayRejectsProviderConfigView() =
+  fun prefersEffectiveContextCapOverNativeWindow() {
+    val models =
+      parseGatewayModels(
+        Json
+          .parseToJsonElement(
+            """[{"id":"model","name":"Model","provider":"example","contextWindow":128000,"contextTokens":96000}]""",
+          ).jsonArray,
+      )
+
+    assertEquals(96_000L, models.single().contextTokens)
+  }
+
+  @Test
+  fun reportsProviderConfigUnsupportedWithoutSubstitutingConfiguredView() =
     runBlocking {
       val requests = mutableListOf<String>()
+      var actual: Throwable? = null
 
-      val response =
+      try {
         requestProviderModelConfig { paramsJson ->
           requests += paramsJson
-          if (requests.size == 1) {
-            throw GatewayRequestRejected(GatewaySession.ErrorShape("INVALID_REQUEST", "unsupported view"))
-          }
-          "configured-response"
+          throw GatewayRequestRejected(GatewaySession.ErrorShape("INVALID_REQUEST", "unsupported view"))
         }
+      } catch (err: Throwable) {
+        actual = err
+      }
 
-      assertEquals("configured-response", response)
-      assertEquals(
-        listOf("""{"view":"provider-config"}""", """{"view":"configured"}"""),
-        requests,
-      )
+      assertTrue(actual is ProviderModelConfigUnsupported)
+      assertEquals(listOf("""{"view":"provider-config"}"""), requests)
     }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/ProviderModelStatusTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/ProviderModelStatusTest.kt
@@ -2,6 +2,9 @@ package ai.openclaw.app.ui
 
 import ai.openclaw.app.GatewayModelProviderSummary
 import ai.openclaw.app.GatewayModelSummary
+import ai.openclaw.app.parseGatewayModels
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -46,22 +49,143 @@ class ProviderModelStatusTest {
     assertEquals(listOf("openai", "byteplus"), rows.map { it.id })
     assertEquals(1, rows.first { it.id == "openai" }.modelCount)
     assertEquals(1, rows.first { it.id == "byteplus" }.modelCount)
-    assertTrue(rows.first { it.id == "byteplus" }.ready)
+    assertEquals(listOf("gpt-5.5"), rows.first { it.id == "openai" }.models.map { it.id })
+    assertEquals(listOf("seed-1-8-251228"), rows.first { it.id == "byteplus" }.models.map { it.id })
+    assertEquals(ProviderAvailability.Unknown, rows.first { it.id == "byteplus" }.availability)
+    assertFalse(rows.first { it.id == "byteplus" }.ready)
+  }
+
+  @Test
+  fun providerRowsPreserveReadyAuthProvidersWithoutConfiguredModels() {
+    val rows =
+      providerRows(
+        providers =
+          listOf(
+            GatewayModelProviderSummary(
+              id = "openai",
+              displayName = "OpenAI",
+              status = "ok",
+              profileCount = 1,
+            ),
+          ),
+        models = emptyList(),
+      )
+
+    assertEquals(ProviderAvailability.Available, rows.single().availability)
+    assertTrue(rows.single().ready)
+    assertTrue(rows.single().models.isEmpty())
+  }
+
+  @Test
+  fun unknownModelAvailabilityIsNotUpgradedByProviderAuth() {
+    val rows =
+      providerRows(
+        providers =
+          listOf(
+            GatewayModelProviderSummary(
+              id = "openai",
+              displayName = "OpenAI",
+              status = "ok",
+              profileCount = 1,
+            ),
+          ),
+        models = listOf(model(provider = "openai", id = "gpt-5.5")),
+      )
+
+    assertEquals(ProviderAvailability.Unknown, rows.single().availability)
+    assertEquals("Unknown", rows.single().status)
+    assertFalse(rows.single().ready)
+  }
+
+  @Test
+  fun unavailableModelsOverrideReadyProviderAuth() {
+    val rows =
+      providerRows(
+        providers =
+          listOf(
+            GatewayModelProviderSummary(
+              id = "custom",
+              displayName = "Custom",
+              status = "ok",
+              profileCount = 1,
+            ),
+          ),
+        models = listOf(model(provider = "custom", id = "offline-model", available = false)),
+      )
+
+    assertEquals(ProviderAvailability.Unavailable, rows.single().availability)
+    assertEquals("Needs attention", rows.single().status)
+    assertFalse(rows.single().ready)
+  }
+
+  @Test
+  fun oneAvailableRouteMakesProviderReadyAndModelsSortByName() {
+    val rows =
+      providerRows(
+        providers = emptyList(),
+        models =
+          listOf(
+            model(provider = "custom", id = "zeta", name = "Zeta", available = null),
+            model(provider = "custom", id = "alpha", name = "Alpha", available = true),
+          ),
+      )
+
+    assertEquals(ProviderAvailability.Available, rows.single().availability)
+    assertEquals(listOf("alpha", "zeta"), rows.single().models.map { it.id })
+    assertTrue(rows.single().ready)
+  }
+
+  @Test
+  fun commandSubtitleDoesNotReportUnknownModelsAsReady() {
+    val providers =
+      listOf(
+        GatewayModelProviderSummary(
+          id = "openai",
+          displayName = "OpenAI",
+          status = "ok",
+          profileCount = 1,
+        ),
+      )
+
+    assertEquals(
+      "Provider availability unknown",
+      providerCommandSubtitle(
+        isConnected = true,
+        providers = providers,
+        models = listOf(model(provider = "openai", id = "gpt-5.5")),
+      ),
+    )
+  }
+
+  @Test
+  fun videoCapabilitySurvivesGatewayParsingAndRendering() {
+    val payload =
+      Json.parseToJsonElement(
+          """[{"id":"video-model","name":"Video Model","provider":"openai","input":["text","video"]}]""",
+        )
+        .jsonArray
+    val model = parseGatewayModels(payload).single()
+
+    assertTrue(model.supportsVideo)
+    assertEquals("video", modelCapabilities(model))
   }
 
   private fun model(
     provider: String,
     id: String,
+    name: String = id,
+    available: Boolean? = null,
   ): GatewayModelSummary =
     GatewayModelSummary(
       id = id,
-      name = id,
+      name = name,
       provider = provider,
       supportsVision = false,
       supportsAudio = false,
+      supportsVideo = false,
       supportsDocuments = false,
       supportsReasoning = false,
       contextTokens = null,
-      available = null,
+      available = available,
     )
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/ProviderModelStatusTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/ProviderModelStatusTest.kt
@@ -160,7 +160,8 @@ class ProviderModelStatusTest {
   @Test
   fun videoCapabilitySurvivesGatewayParsingAndRendering() {
     val payload =
-      Json.parseToJsonElement(
+      Json
+        .parseToJsonElement(
           """[{"id":"video-model","name":"Video Model","provider":"openai","input":["text","video"]}]""",
         )
         .jsonArray

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/ProviderModelStatusTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/ProviderModelStatusTest.kt
@@ -163,8 +163,7 @@ class ProviderModelStatusTest {
       Json
         .parseToJsonElement(
           """[{"id":"video-model","name":"Video Model","provider":"openai","input":["text","video"]}]""",
-        )
-        .jsonArray
+        ).jsonArray
     val model = parseGatewayModels(payload).single()
 
     assertTrue(model.supportsVideo)

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
@@ -224,6 +224,21 @@ class ShellScreenLogicTest {
   }
 
   @Test
+  fun homeAttentionRowsDoNotClaimUnknownProvidersAreUnavailable() {
+    val rows =
+      homeAttentionRows(
+        isConnected = true,
+        pendingApprovals = 0,
+        channelsSummary = emptyChannels(),
+        nodesDevicesSummary = emptyNodesDevices(),
+        readyProviderCount = 0,
+        unknownProviderCount = 1,
+      )
+
+    assertEquals(emptyList<String>(), rows.map { it.title })
+  }
+
+  @Test
   fun skillWorkshopSummaryPrioritizesPendingAndHeldProposals() {
     assertEquals(
       "2 pending",

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatModelPickerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatModelPickerTest.kt
@@ -61,6 +61,7 @@ class ChatModelPickerTest {
       available = true,
       supportsVision = false,
       supportsAudio = false,
+      supportsVideo = false,
       supportsDocuments = false,
       supportsReasoning = supportsReasoning,
       contextTokens = null,

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -7347,6 +7347,7 @@ public struct ModelChoice: Codable, Sendable {
     public let available: Bool?
     public let contextwindow: Int?
     public let reasoning: Bool?
+    public let input: [AnyCodable]?
 
     public init(
         id: String,
@@ -7355,7 +7356,8 @@ public struct ModelChoice: Codable, Sendable {
         alias: String? = nil,
         available: Bool? = nil,
         contextwindow: Int? = nil,
-        reasoning: Bool? = nil)
+        reasoning: Bool? = nil,
+        input: [AnyCodable]? = nil)
     {
         self.id = id
         self.name = name
@@ -7364,6 +7366,7 @@ public struct ModelChoice: Codable, Sendable {
         self.available = available
         self.contextwindow = contextwindow
         self.reasoning = reasoning
+        self.input = input
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -7374,6 +7377,7 @@ public struct ModelChoice: Codable, Sendable {
         case available
         case contextwindow = "contextWindow"
         case reasoning
+        case input
     }
 }
 

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -80,6 +80,7 @@ Other selection rules:
 - Changing `agents.defaults.model.primary` does not rewrite existing session pins. If status reports `This session is pinned to X; config primary Y will apply to new/unpinned sessions.`, run `/model default` to clear the pin.
 - CLI default-model and allowlist pickers respect `models.mode: "replace"` by listing only `models.providers.*.models` instead of the full built-in catalog.
 - The Control UI model picker asks the Gateway for its configured model view: `agents.defaults.models` when set (including `provider/*` wildcard entries), otherwise `models.providers.*.models` plus providers with usable auth. The full built-in catalog is reserved for explicit browse views (`models.list` with `view: "all"`, or `openclaw models list --all`).
+- Provider inventory UIs use `models.list` with `view: "provider-config"` to show source-authored `models.providers.*.models` rows without applying picker allowlists.
 
 Full mechanics: [Model failover](/concepts/model-failover).
 

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -846,6 +846,10 @@ context.
   `provider/*` entries. Without an allowlist, the response uses explicit
   `models.providers.<provider>.models` entries, falling back to the full
   catalog only when no configured model rows exist.
+- `"provider-config"`: source-authored `models.providers.*.models` inventory,
+  independent of picker allowlists. Rows include public model capabilities and
+  route-aware availability, but omit provider endpoints, auth material, and
+  runtime request configuration.
 - `"all"`: full gateway catalog, bypassing `agents.defaults.models`. Use for
   diagnostics/discovery UIs, not normal model pickers.
 

--- a/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
@@ -3,6 +3,8 @@ import { Value } from "typebox/value";
 import { describe, expect, it } from "vitest";
 import {
   AgentsListResultSchema,
+  ModelsListParamsSchema,
+  ModelsListResultSchema,
   SkillsDetailResultSchema,
   SkillsProposalInspectResultSchema,
   SkillsProposalRequestRevisionResultSchema,
@@ -63,6 +65,31 @@ describe("AgentsListResultSchema", () => {
     };
 
     expect(Value.Check(AgentsListResultSchema, result)).toBe(true);
+  });
+});
+
+describe("ModelsListParamsSchema", () => {
+  it("accepts the provider-config inventory view", () => {
+    expect(Value.Check(ModelsListParamsSchema, { view: "provider-config" })).toBe(true);
+    expect(Value.Check(ModelsListParamsSchema, { view: "provider-route" })).toBe(false);
+  });
+});
+
+describe("ModelsListResultSchema", () => {
+  it("accepts stable public input capabilities", () => {
+    const model = {
+      id: "gpt-image",
+      name: "GPT Image",
+      provider: "openai",
+      input: ["text", "image", "audio", "video", "document"],
+    };
+
+    expect(Value.Check(ModelsListResultSchema, { models: [model] })).toBe(true);
+    expect(
+      Value.Check(ModelsListResultSchema, {
+        models: [{ ...model, input: ["text", "binary"] }],
+      }),
+    ).toBe(false);
   });
 });
 

--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -21,6 +21,17 @@ export const ModelChoiceSchema = Type.Object(
     available: Type.Optional(Type.Boolean()),
     contextWindow: Type.Optional(Type.Integer({ minimum: 1 })),
     reasoning: Type.Optional(Type.Boolean()),
+    input: Type.Optional(
+      Type.Array(
+        Type.Union([
+          Type.Literal("text"),
+          Type.Literal("image"),
+          Type.Literal("audio"),
+          Type.Literal("video"),
+          Type.Literal("document"),
+        ]),
+      ),
+    ),
   },
   { additionalProperties: false },
 );
@@ -241,7 +252,12 @@ export const AgentsFilesSetResultSchema = Type.Object(
 export const ModelsListParamsSchema = Type.Object(
   {
     view: Type.Optional(
-      Type.Union([Type.Literal("default"), Type.Literal("configured"), Type.Literal("all")]),
+      Type.Union([
+        Type.Literal("default"),
+        Type.Literal("configured"),
+        Type.Literal("provider-config"),
+        Type.Literal("all"),
+      ]),
     ),
   },
   { additionalProperties: false },

--- a/src/agents/model-catalog-browse.test.ts
+++ b/src/agents/model-catalog-browse.test.ts
@@ -5,7 +5,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
-import { loadModelCatalogSnapshotForBrowse } from "./model-catalog-browse.js";
+import {
+  buildProviderConfigModelCatalogForBrowse,
+  loadModelCatalogSnapshotForBrowse,
+} from "./model-catalog-browse.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 
 const DEFAULT_MODEL_CATALOG_BROWSE_TIMEOUT_MS = 750;
@@ -93,6 +96,33 @@ describe("loadModelCatalogSnapshotForBrowse", () => {
     ).resolves.toBe(fullCatalog);
 
     expect(loadCatalog).toHaveBeenCalledExactlyOnceWith({ readOnly: false });
+  });
+
+  it("builds provider-config inventory independently of picker allowlists", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/allowlisted": {},
+          },
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            models: [
+              { id: "two", name: "Two" },
+              { id: "one", name: "One" },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(buildProviderConfigModelCatalogForBrowse({ cfg })).toMatchObject([
+      { provider: "openai", id: "one", name: "One" },
+      { provider: "openai", id: "two", name: "Two" },
+    ]);
   });
 
   it("returns an empty catalog when read-only catalog loading times out with provider wildcards", async () => {

--- a/src/agents/model-catalog-browse.test.ts
+++ b/src/agents/model-catalog-browse.test.ts
@@ -98,6 +98,21 @@ describe("loadModelCatalogSnapshotForBrowse", () => {
     expect(loadCatalog).toHaveBeenCalledExactlyOnceWith({ readOnly: false });
   });
 
+  it.each([
+    ["without picker allowlists", config()],
+    ["with provider wildcards", config({ providerWildcard: true })],
+  ])("uses the read-only catalog for provider-config views %s", async (_label, cfg) => {
+    const loadCatalog = vi.fn(async ({ readOnly }: { readOnly: boolean }) =>
+      readOnly ? readOnlyCatalog : fullCatalog,
+    );
+
+    await expect(
+      loadModelCatalogSnapshotForBrowse({ cfg, view: "provider-config", loadCatalog }),
+    ).resolves.toBe(readOnlyCatalog);
+
+    expect(loadCatalog).toHaveBeenCalledExactlyOnceWith({ readOnly: true });
+  });
+
   it("builds provider-config inventory independently of picker allowlists", () => {
     const cfg = {
       agents: {

--- a/src/agents/model-catalog-browse.ts
+++ b/src/agents/model-catalog-browse.ts
@@ -6,8 +6,11 @@ import {
   resolveTimerTimeoutMs,
 } from "@openclaw/normalization-core/number-coercion";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
-import { parseConfiguredModelVisibilityEntries } from "./model-selection-shared.js";
+import type { ModelCatalogEntry, ModelCatalogSnapshot } from "./model-catalog.types.js";
+import {
+  buildConfiguredModelCatalog,
+  parseConfiguredModelVisibilityEntries,
+} from "./model-selection-shared.js";
 
 /**
  * Loads the model catalog shape used by browse/list commands without letting optional
@@ -16,7 +19,20 @@ import { parseConfiguredModelVisibilityEntries } from "./model-selection-shared.
 const DEFAULT_MODEL_CATALOG_BROWSE_TIMEOUT_MS = 750;
 
 /** Visible model subset requested by model browse callers. */
-export type ModelCatalogBrowseView = "default" | "configured" | "all";
+export type ModelCatalogBrowseView = "default" | "configured" | "provider-config" | "all";
+
+/** Source-authored provider rows for inventory UIs, independent of picker allowlists. */
+export function buildProviderConfigModelCatalogForBrowse(params: {
+  cfg: OpenClawConfig;
+  workspaceDir?: string;
+}): ModelCatalogEntry[] {
+  return buildConfiguredModelCatalog(params).toSorted(
+    (a, b) =>
+      a.provider.localeCompare(b.provider) ||
+      a.name.localeCompare(b.name) ||
+      a.id.localeCompare(b.id),
+  );
+}
 
 /** True when a browse view cannot be answered from read-only cached catalog entries. */
 export function modelCatalogBrowseRequiresFullDiscovery(params: {

--- a/src/gateway/server-methods/models-list-result.openai-routes.test.ts
+++ b/src/gateway/server-methods/models-list-result.openai-routes.test.ts
@@ -289,8 +289,6 @@ describe("models.list OpenAI routes", () => {
             models: {
               providers: {
                 openai: {
-                  api: "openai-responses",
-                  baseUrl: "https://api.openai.com/v1",
                   models: [{ id: "gpt-5.5", name: "GPT-5.5" }],
                 },
               },

--- a/src/gateway/server-methods/models-list-result.openai-routes.test.ts
+++ b/src/gateway/server-methods/models-list-result.openai-routes.test.ts
@@ -24,7 +24,7 @@ async function listModels(params: {
   catalog: ModelCatalogEntry[];
   cfg?: OpenClawConfig;
   routeResolverFactory?: typeof createOpenAIModelRoutesResolver;
-  view?: "all" | "configured" | "default";
+  view?: "all" | "configured" | "provider-config" | "default";
 }) {
   const context = {
     getRuntimeConfig: () => params.cfg ?? ({} as OpenClawConfig),
@@ -283,6 +283,41 @@ describe("models.list OpenAI routes", () => {
           await expect(listModels({ catalog: [chatGPTRow, row], cfg })).resolves.toEqual(
             subscriptionProjection,
           );
+
+          const inventoryConfig = {
+            ...cfg,
+            models: {
+              providers: {
+                openai: {
+                  api: "openai-responses",
+                  baseUrl: "https://api.openai.com/v1",
+                  models: [{ id: "gpt-5.5", name: "GPT-5.5" }],
+                },
+              },
+            },
+          } as unknown as OpenClawConfig;
+          await expect(
+            listModels({
+              catalog: [
+                { ...row, input: ["text", "image"] },
+                { ...chatGPTRow, input: ["text", "video"] },
+              ],
+              cfg: inventoryConfig,
+              view: "provider-config",
+            }),
+          ).resolves.toEqual({
+            models: [
+              {
+                id: "gpt-5.5",
+                name: "GPT-5.5",
+                provider: "openai",
+                contextWindow: 400_000,
+                reasoning: true,
+                input: ["text", "video"],
+                available: true,
+              },
+            ],
+          });
 
           await expect(
             listModels({ catalog: [row, chatGPTRow], cfg, view: "default" }),

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -17,6 +17,7 @@ import {
 } from "../../agents/model-auth-availability.js";
 import { hasSyntheticLocalProviderAuthConfig } from "../../agents/model-auth.js";
 import {
+  buildProviderConfigModelCatalogForBrowse,
   loadModelCatalogSnapshotForBrowse,
   type ModelCatalogBrowseView,
 } from "../../agents/model-catalog-browse.js";
@@ -41,6 +42,7 @@ import {
   openAIModelCatalogRoutePolicy,
 } from "../../agents/openai-model-routes.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
+import { getRuntimeConfigSourceSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { loadPluginRegistrySnapshotWithMetadata } from "../../plugins/plugin-registry.js";
 import type { GatewayRequestContext } from "./types.js";
@@ -48,7 +50,7 @@ import type { GatewayRequestContext } from "./types.js";
 type ModelsListView = ModelCatalogBrowseView;
 type ModelsListEntry = Pick<
   ModelCatalogEntry,
-  "alias" | "contextWindow" | "id" | "name" | "provider" | "reasoning"
+  "alias" | "contextWindow" | "id" | "input" | "name" | "provider" | "reasoning"
 > & { available?: boolean };
 type ModelsListAvailability = ModelAuthAvailability;
 type ModelsListEntryEvaluation = ModelAuthAvailabilityEvaluation;
@@ -314,6 +316,8 @@ async function buildPublicModelsListEntries(params: {
   catalog: ModelCatalogEntry[];
   cfg: OpenClawConfig;
   evaluateEntry(entry: ModelCatalogEntry): Promise<ModelsListEntryEvaluation>;
+  includeInput?: boolean;
+  preserveUnknownAvailability?: boolean;
 }): Promise<ModelsListEntry[]> {
   return await Promise.all(
     params.catalog.map(async (entry): Promise<ModelsListEntry> => {
@@ -324,11 +328,15 @@ async function buildPublicModelsListEntries(params: {
         evaluation.routeResolution === null &&
         normalizeProviderId(entry.provider) !== "openai" &&
         hasSyntheticLocalProviderAuthConfig({ cfg: params.cfg, provider: entry.provider });
-      // Optionality remains for older Gateway compatibility. Current producers
-      // emit a boolean because existing clients treat omission as selectable.
+      const available = evaluation.availability ?? (syntheticLocalAvailable ? true : undefined);
+      // Legacy views keep emitting a boolean because existing clients treat
+      // omission as selectable. Inventory consumers preserve unknown state.
       return {
         ...publicEntry,
-        available: evaluation.availability ?? syntheticLocalAvailable,
+        ...(params.includeInput && entry.input?.length ? { input: entry.input } : {}),
+        ...(params.preserveUnknownAvailability && available === undefined
+          ? {}
+          : { available: available ?? false }),
       };
     }),
   );
@@ -368,6 +376,31 @@ export async function buildModelsListResult(params: {
   });
   const catalog = snapshot.entries;
   const routeVariants = snapshot.routeVariants;
+  if (view === "provider-config") {
+    const sourceConfig = getRuntimeConfigSourceSnapshot() ?? cfg;
+    const inventorySnapshot = {
+      entries: buildProviderConfigModelCatalogForBrowse({ cfg: sourceConfig, workspaceDir }),
+      routeVariants,
+    };
+    const inventoryProjector = createGatewayAgentModelCatalogProjector({
+      cfg,
+      agentId,
+      snapshot: inventorySnapshot,
+      ...(params.routeResolverFactory
+        ? { routeResolverFactory: params.routeResolverFactory }
+        : {}),
+    });
+    const inventory = await inventoryProjector.projectCatalog();
+    return {
+      models: await buildPublicModelsListEntries({
+        catalog: inventory,
+        cfg,
+        evaluateEntry: inventoryProjector.evaluateEntry,
+        includeInput: true,
+        preserveUnknownAvailability: true,
+      }),
+    };
+  }
   const defaultModel = resolveAgentEffectiveModelPrimary(cfg, agentId);
   const visibilityPolicy = createModelVisibilityPolicy({
     cfg,

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -209,6 +209,32 @@ function resolveGatewayModelCatalogRouteKey(entry: ModelCatalogEntry): string {
   );
 }
 
+function resolveProviderConfigInventoryEntries(params: {
+  authoredEntries: readonly ModelCatalogEntry[];
+  canonicalEntries: readonly ModelCatalogEntry[];
+}): ModelCatalogEntry[] {
+  const canonicalByKey = new Map<string, ModelCatalogEntry>();
+  for (const entry of params.canonicalEntries) {
+    const key = resolveGatewayModelCatalogRouteKey(entry);
+    if (!canonicalByKey.has(key)) {
+      canonicalByKey.set(key, entry);
+    }
+  }
+  const seen = new Set<string>();
+  const inventory: ModelCatalogEntry[] = [];
+  for (const authoredEntry of params.authoredEntries) {
+    const key = resolveGatewayModelCatalogRouteKey(authoredEntry);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    // Authored config owns inventory membership. Canonical catalog rows own
+    // route metadata; configured logical overrides are applied by the projector.
+    inventory.push(canonicalByKey.get(key) ?? authoredEntry);
+  }
+  return inventory;
+}
+
 /** Builds one per-agent, snapshot-scoped route projection for Gateway thinking metadata. */
 export function createGatewayAgentModelCatalogProjector(params: {
   cfg: OpenClawConfig;
@@ -378,8 +404,15 @@ export async function buildModelsListResult(params: {
   const routeVariants = snapshot.routeVariants;
   if (view === "provider-config") {
     const sourceConfig = getRuntimeConfigSourceSnapshot() ?? cfg;
+    const authoredEntries = buildProviderConfigModelCatalogForBrowse({
+      cfg: sourceConfig,
+      workspaceDir,
+    });
     const inventorySnapshot = {
-      entries: buildProviderConfigModelCatalogForBrowse({ cfg: sourceConfig, workspaceDir }),
+      entries: resolveProviderConfigInventoryEntries({
+        authoredEntries,
+        canonicalEntries: catalog,
+      }),
       routeVariants,
     };
     const inventoryProjector = createGatewayAgentModelCatalogProjector({

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -60,7 +60,8 @@ let loggedSlowModelsListCatalog = false;
 // Unknown views are rejected by protocol validation first; this helper keeps the
 // handler default explicit for older clients that omit the field.
 function resolveModelsListView(params: Record<string, unknown>): ModelsListView {
-  return typeof params.view === "string" ? (params.view as ModelsListView) : "default";
+  const view = params.view;
+  return view === "configured" || view === "provider-config" || view === "all" ? view : "default";
 }
 
 function resolvePositiveSafeInteger(value: unknown): number | undefined {
@@ -419,9 +420,7 @@ export async function buildModelsListResult(params: {
       cfg,
       agentId,
       snapshot: inventorySnapshot,
-      ...(params.routeResolverFactory
-        ? { routeResolverFactory: params.routeResolverFactory }
-        : {}),
+      ...(params.routeResolverFactory ? { routeResolverFactory: params.routeResolverFactory } : {}),
     });
     const inventory = await inventoryProjector.projectCatalog();
     return {

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -82,7 +82,7 @@ function requestModelsList(params: {
 }
 
 describe("models.list", () => {
-  it("projects source-authored provider inventory through canonical auth state", async () => {
+  it("keeps source-authored provider inventory when the canonical catalog is missing", async () => {
     const sourceConfig = {
       agents: {
         defaults: {

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -44,7 +44,7 @@ function createDemoOAuthStore(params: { access: string; expires: number }) {
 }
 
 function requestModelsList(params: {
-  view: "default" | "configured" | "all";
+  view: "default" | "configured" | "provider-config" | "all";
   respond?: ReturnType<typeof vi.fn>;
   runtimeConfig?: OpenClawConfig;
   loadGatewayModelCatalog: (params?: {
@@ -82,6 +82,154 @@ function requestModelsList(params: {
 }
 
 describe("models.list", () => {
+  it("projects source-authored provider inventory through canonical auth state", async () => {
+    const sourceConfig = {
+      agents: {
+        defaults: {
+          models: {
+            "vllm/allowlisted": {},
+          },
+        },
+      },
+      secrets: {
+        providers: {
+          "mounted-json": {
+            source: "file",
+            path: "/tmp/openclaw-test-secrets.json",
+            mode: "json",
+          },
+        },
+      },
+      models: {
+        providers: {
+          vllm: {
+            baseUrl: "https://vllm.example/v1",
+            apiKey: {
+              source: "file",
+              provider: "mounted-json",
+              id: "/providers/vllm/apiKey",
+            },
+            models: [
+              {
+                id: "source-model",
+                name: "Source Model",
+                contextWindow: 128_000,
+                reasoning: true,
+                input: ["text", "image"],
+                params: { temperature: 0.2 },
+                compat: { supportsDeveloperRole: false },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const runtimeConfig = {
+      ...sourceConfig,
+      models: {
+        providers: {
+          vllm: {
+            ...sourceConfig.models.providers.vllm,
+            apiKey: "test-key",
+            models: [{ id: "runtime-only", name: "Runtime Only" }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const loadGatewayModelCatalog = vi.fn(() => Promise.resolve([]));
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+    try {
+      const { request, respond } = requestModelsList({
+        view: "provider-config",
+        runtimeConfig,
+        loadGatewayModelCatalog,
+        reqId: "req-models-list-provider-config-source",
+      });
+      await request;
+
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        {
+          models: [
+            {
+              id: "source-model",
+              name: "Source Model",
+              provider: "vllm",
+              contextWindow: 128_000,
+              reasoning: true,
+              input: ["text", "image"],
+              available: true,
+            },
+          ],
+        },
+        undefined,
+      );
+      expect(loadGatewayModelCatalog).toHaveBeenCalledExactlyOnceWith({ readOnly: true });
+    } finally {
+      clearRuntimeConfigSnapshot();
+    }
+  });
+
+  it("omits unknown provider-config availability", async () => {
+    const config = {
+      secrets: {
+        providers: {
+          "mounted-json": {
+            source: "file",
+            path: "/tmp/openclaw-test-secrets.json",
+            mode: "json",
+          },
+        },
+      },
+      models: {
+        providers: {
+          vllm: {
+            baseUrl: "https://vllm.example/v1",
+            apiKey: {
+              source: "file",
+              provider: "mounted-json",
+              id: "/providers/vllm/apiKey",
+            },
+            models: [
+              {
+                id: "llama-secure",
+                name: "Llama Secure",
+                input: ["text", "image", "document"],
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    setRuntimeConfigSnapshot(config, config);
+    try {
+      const { request, respond } = requestModelsList({
+        view: "provider-config",
+        runtimeConfig: config,
+        loadGatewayModelCatalog: vi.fn(() => Promise.resolve([])),
+        reqId: "req-models-list-provider-config-unknown",
+      });
+      await request;
+
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        {
+          models: [
+            {
+              id: "llama-secure",
+              name: "Llama Secure",
+              provider: "vllm",
+              input: ["text", "image", "document"],
+            },
+          ],
+        },
+        undefined,
+      );
+    } finally {
+      clearRuntimeConfigSnapshot();
+    }
+  });
+
   it("does not block the configured view on slow model catalog discovery", async () => {
     await withoutOpenAIEnvAuth(async () => {
       const catalog = createDeferred<never>();

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -83,6 +83,25 @@ function requestModelsList(params: {
 
 describe("models.list", () => {
   it("keeps source-authored provider inventory when the canonical catalog is missing", async () => {
+    const sourceProvider = {
+      baseUrl: "https://vllm.example/v1",
+      apiKey: {
+        source: "file",
+        provider: "mounted-json",
+        id: "/providers/vllm/apiKey",
+      },
+      models: [
+        {
+          id: "source-model",
+          name: "Source Model",
+          contextWindow: 128_000,
+          reasoning: true,
+          input: ["text", "image"],
+          params: { temperature: 0.2 },
+          compat: { supportsDeveloperRole: false },
+        },
+      ],
+    };
     const sourceConfig = {
       agents: {
         defaults: {
@@ -102,25 +121,7 @@ describe("models.list", () => {
       },
       models: {
         providers: {
-          vllm: {
-            baseUrl: "https://vllm.example/v1",
-            apiKey: {
-              source: "file",
-              provider: "mounted-json",
-              id: "/providers/vllm/apiKey",
-            },
-            models: [
-              {
-                id: "source-model",
-                name: "Source Model",
-                contextWindow: 128_000,
-                reasoning: true,
-                input: ["text", "image"],
-                params: { temperature: 0.2 },
-                compat: { supportsDeveloperRole: false },
-              },
-            ],
-          },
+          vllm: sourceProvider,
         },
       },
     } as unknown as OpenClawConfig;
@@ -129,7 +130,7 @@ describe("models.list", () => {
       models: {
         providers: {
           vllm: {
-            ...sourceConfig.models.providers.vllm,
+            ...sourceProvider,
             apiKey: "test-key",
             models: [{ id: "runtime-only", name: "Runtime Only" }],
           },


### PR DESCRIPTION
## What Problem This Solves

Android Settings > Providers & Models showed provider readiness but not the model IDs authored under `models.providers.*.models`. Reusing the normal configured picker view was also incorrect for this surface because `agents.defaults.models` allowlists can replace or filter those provider-authored rows.

## Why This Change Was Made

This adds an additive, read-only `models.list` view named `provider-config`. The Gateway builds it from the active source-config snapshot, excludes allowlist-only rows, and returns capability and availability metadata without exposing runtime-only model parameters.

Android keeps this source catalog separate from the normal picker catalog, uses it consistently in the detailed screen and sibling readiness summaries, refreshes it on connection and screen entry, and shows explicit upgrade guidance when an older Gateway rejects the additive view. Auth readiness still refreshes independently. Configuration writes are intentionally out of scope.

## User Impact

Android users can review provider-configured model IDs, capabilities, and availability without editing configuration. Existing model pickers keep their allowlist-aware behavior. Older released Gateways show an upgrade requirement instead of silently substituting picker rows.

## Evidence

- Fresh maintainer review covered the Gateway entry point, source-config owner boundary, auth availability callee, configured/all sibling views, Android callers, protocol schema/generator, tests, and docs.
- Maintainer fixes aligned Overview, Settings, and Command Palette readiness with the source catalog, preserved tri-state availability, made catalog/auth failures independent, guarded overlapping refreshes, and removed non-public provider runtime fields from the response.
- Repeated Codex AutoReview cycles found and fixed route, readiness, old-Gateway, and stale-refresh edge cases; fresh branch AutoReview after the current-main rebase was clean.
- Native i18n inventory regenerated at each rebase conflict and checked without drift on the final tree.
- Sanitized AWS run `run_083bd2d7d2f8` built and tested both Android flavors, both lint lanes, benchmark assembly, and app/benchmark ktlint with Android SDK 37.0 and JDK 17: https://crabbox.openclaw.ai/portal/runs/run_083bd2d7d2f8
- Sanitized AWS run `run_9405fb23595b` passed 125 focused Gateway/protocol tests and both protocol generators with zero drift: https://crabbox.openclaw.ai/portal/runs/run_9405fb23595b
- Exact head `20090844301cba5db3d87c0e6b7c9c79541b14a8` CI: https://github.com/openclaw/openclaw/actions/runs/29173106655
- Repository guard `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 101912` is required before merge.

## Real behavior proof

The contributor's emulator artifact on head `47bc07434b1275d53555d7c96b4a91b507d0cc89` proves the real Android `GatewaySession` path, `models.list` with `view: "provider-config"`, and provider/model row rendering: https://github.com/snowzlmbot/openclaw/actions/runs/28918884394

The final patch narrows that earlier UI to read-only review and preserves the proven list/render path. No exact-final-head emulator capture was produced; exact-head Android CI and focused request/UI tests cover the final read-only code.
