### PR TITLE
fix(agents): mark exec/bash read-only shell calls as replay-safe

### DIFF
--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -50,7 +50,9 @@ describe("tool mutation helpers", () => {
   ])("treats read-only shell command as non-mutating: %s %s", (toolName, command) => {
     expect(isMutatingToolCall(toolName, { command })).toBe(false);
     expect(buildToolMutationState(toolName, { command }).mutatingAction).toBe(false);
-    expect(buildToolMutationState(toolName, { command }, command).actionFingerprint).toBeUndefined();
+    expect(
+      buildToolMutationState(toolName, { command }, command).actionFingerprint,
+    ).toBeUndefined();
   });
 
   it.each([
@@ -211,7 +213,13 @@ describe("tool mutation helpers", () => {
     expect(isReplaySafeToolCall("nodes", { action: "describe" })).toBe(true);
     expect(isReplaySafeToolCall("nodes", { action: "pending" })).toBe(true);
     expect(isReplaySafeToolCall("nodes", { action: "approve" })).toBe(false);
-    expect(isReplaySafeToolCall("exec", { command: "rg TODO src" })).toBe(false);
+    expect(isReplaySafeToolCall("exec", { command: "rg TODO src" })).toBe(true);
+    expect(isReplaySafeToolCall("exec", { command: "ls -la" })).toBe(true);
+    expect(isReplaySafeToolCall("bash", { command: "cat package.json" })).toBe(true);
+    expect(isReplaySafeToolCall("exec", { command: "grep -r foo src" })).toBe(true);
+    expect(isReplaySafeToolCall("exec", { command: "npm start" })).toBe(false);
+    expect(isReplaySafeToolCall("bash", { command: "cat package.json > /tmp/out" })).toBe(false);
+    expect(isReplaySafeToolCall("exec", { command: "rg --pre touch pattern file" })).toBe(false);
     expect(isReplaySafeToolCall("process", { action: "list" })).toBe(true);
     expect(isReplaySafeToolCall("process", { action: "log", sessionId: "run-1" })).toBe(true);
     expect(isReplaySafeToolCall("process", { action: "poll", sessionId: "run-1" })).toBe(false);

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -415,7 +415,7 @@ export function isReplaySafeToolCall(toolName: string, args: unknown): boolean {
   switch (normalized) {
     case "exec":
     case "bash":
-      return false;
+      return isPlainReadOnlyShellCommand(readShellCommand(record));
     case "process":
       return action != null && PROCESS_REPLAY_SAFE_ACTIONS.has(action);
     case "message":


### PR DESCRIPTION
fix(agents): strict-agentic retry blocked after read-only exec/bash inspection turns

isReplaySafeToolCall always returned false for exec/bash, blocking
strict-agentic retry after turns with only read-only inspection commands
like ls, cat, grep, or rg. isMutatingToolCall already uses
isPlainReadOnlyShellCommand for the same tools — align replay-safe
classification to match.

Fixes #101890

## What Problem This Solves

Fixes an issue where GPT-5 agent runs using only read-only shell inspection commands (`exec ls`, `exec cat`, `exec grep`, `exec rg`) would silently produce no output when the model's follow-up turn was reasoning-only or empty. The retry that should recover a visible answer was incorrectly blocked.

## Why This Change Was Made

`isReplaySafeToolCall` blanket-returned `false` for all `exec`/`bash` calls, marking them as having potential side effects even when the underlying command was read-only. `isMutatingToolCall` already uses `isPlainReadOnlyShellCommand` to correctly classify the same commands — this fix aligns `isReplaySafeToolCall` to use the same check, so read-only shell calls no longer block retry.

## User Impact

GPT-5 (strict-agentic) runs that inspect files or search code via `exec`/`bash` before producing an answer now correctly retry when the model's follow-up turn is empty or reasoning-only, instead of silently terminating with no output.

## Evidence

Script simulating the replay-safe classification and retry gate before and after the fix:

<img width="1053" height="478" alt="Screenshot 2026-07-07 at 6 46 00 PM" src="https://github.com/user-attachments/assets/a770b4ac-f657-45da-8d4d-7bf7f187968b" />


Focused regression tests added to `src/agents/tool-mutation.test.ts` covering read-only commands (`ls`, `cat`, `grep`, `rg`) now returning `true` and mutating commands (`npm start`, redirects, unsafe `rg` flags) still returning `false`.
