### PR TITLE
refactor(deadcode): localize canvas declarations

### DIFF
--- a/extensions/canvas/src/capability.ts
+++ b/extensions/canvas/src/capability.ts
@@ -16,7 +16,7 @@ export const CANVAS_CAPABILITY_PATH_PREFIX = PLUGIN_NODE_CAPABILITY_PATH_PREFIX;
 export const CANVAS_CAPABILITY_TTL_MS = DEFAULT_PLUGIN_NODE_CAPABILITY_TTL_MS;
 
 /** Normalized Canvas capability-scoped URL shape. */
-export type NormalizedCanvasScopedUrl = NormalizedPluginNodeCapabilityUrl;
+type NormalizedCanvasScopedUrl = NormalizedPluginNodeCapabilityUrl;
 
 /** Creates a new opaque Canvas capability token. */
 export function mintCanvasCapabilityToken(): string {

--- a/extensions/canvas/src/cli.ts
+++ b/extensions/canvas/src/cli.ts
@@ -25,7 +25,7 @@ import { buildA2UITextJsonl, validateA2UIJsonl } from "./a2ui-jsonl.js";
 import { canvasSnapshotTempPath, parseCanvasSnapshotPayload } from "./cli-helpers.js";
 
 /** Runtime output surface used by Canvas CLI commands. */
-export type CanvasCliRuntime = {
+type CanvasCliRuntime = {
   log: (message: string) => void;
   error: (message: string) => void;
   exit: (code: number) => void;

--- a/extensions/canvas/src/host/server.ts
+++ b/extensions/canvas/src/host/server.ts
@@ -35,7 +35,7 @@ export const CANVAS_LIVE_RELOAD_MAX_INBOUND_MESSAGE_BYTES = 64 * 1024;
 type ChokidarWatch = typeof import("chokidar").watch;
 
 /** Options for Canvas host creation. */
-export type CanvasHostOpts = {
+type CanvasHostOpts = {
   runtime: RuntimeEnv;
   rootDir?: string;
   port?: number;
@@ -47,7 +47,7 @@ export type CanvasHostOpts = {
 };
 
 /** Options for starting a standalone Canvas host HTTP server. */
-export type CanvasHostServerOpts = CanvasHostOpts & {
+type CanvasHostServerOpts = CanvasHostOpts & {
   handler?: CanvasHostHandler;
   ownsHandler?: boolean;
 };
@@ -60,7 +60,7 @@ export type CanvasHostServer = {
 };
 
 /** Options for creating only the Canvas host request handler. */
-export type CanvasHostHandlerOpts = {
+type CanvasHostHandlerOpts = {
   runtime: RuntimeEnv;
   rootDir?: string;
   basePath?: string;

--- a/extensions/canvas/src/http-route.ts
+++ b/extensions/canvas/src/http-route.ts
@@ -11,7 +11,7 @@ import { A2UI_PATH, CANVAS_HOST_PATH, CANVAS_WS_PATH, handleA2uiHttpRequest } fr
 import { createCanvasHostHandler, type CanvasHostHandler } from "./host/server.js";
 
 /** Canvas route handler shape registered with the plugin HTTP router. */
-export type CanvasHttpRouteHandler = {
+type CanvasHttpRouteHandler = {
   handleHttpRequest: (req: IncomingMessage, res: ServerResponse) => Promise<boolean>;
   handleUpgrade: (req: IncomingMessage, socket: Duplex, head: Buffer) => Promise<boolean>;
   close: () => Promise<void>;

--- a/extensions/canvas/src/tool-schema.ts
+++ b/extensions/canvas/src/tool-schema.ts
@@ -10,7 +10,7 @@ import {
 import { Type } from "typebox";
 
 /** Agent tool actions supported by the Canvas plugin. */
-export const CANVAS_ACTIONS = [
+const CANVAS_ACTIONS = [
   "present",
   "hide",
   "navigate",
@@ -21,7 +21,7 @@ export const CANVAS_ACTIONS = [
 ] as const;
 
 /** Snapshot formats accepted by the Canvas tool. */
-export const CANVAS_SNAPSHOT_FORMATS = ["png", "jpg", "jpeg"] as const;
+const CANVAS_SNAPSHOT_FORMATS = ["png", "jpg", "jpeg"] as const;
 
 /** TypeBox schema for the model-facing Canvas tool arguments. */
 export const CanvasToolSchema = Type.Object({


### PR DESCRIPTION
## What Problem This Solves

Eight Canvas implementation declarations were exported even though they have no repository consumers and are not exposed by the plugin's explicit runtime API barrel.

## Why This Change Was Made

Localize the unused option, handler, runtime, URL, action, and snapshot-format declarations to their owning modules. This narrows the private plugin implementation surface without changing runtime behavior or supported Canvas API exports.

## User Impact

None. This is export-surface deadcode cleanup with no runtime behavior change.

## Evidence

- Repository-wide export-consumer scan confirmed all eight declarations have no external consumers.
- `extensions/canvas/runtime-api.ts` continues to expose the supported host, CLI, document, and capability APIs.
- Clean codebase-memory MCP rebuild on current main indexed 21,043 files, 281,316 nodes, and 1,133,691 edges with zero extraction errors.
- `OPENCLAW_TESTBOX=1 pnpm check:changed` passed after rebasing onto current `origin/main`.
- Complete Canvas extension suite passed: 12 files, 84 tests, one Vitest shard.
- Full `pnpm build` passed after the rebase.
- Local autoreview passed with no findings at 0.91 confidence.
- Branch autoreview passed with no findings at 0.90 confidence.
- Testbox: `tbx_01kwzejx516kztxfaewgfw183c`
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/28905879016
