### PR TITLE
refactor(deadcode): localize script helper types

### DIFF
--- a/scripts/e2e/lib/session-log-mentions.ts
+++ b/scripts/e2e/lib/session-log-mentions.ts
@@ -3,12 +3,12 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { readPositiveIntEnv } from "./env-limits.mjs";
 
-export type SessionLogMentionLimits = {
+type SessionLogMentionLimits = {
   fileMaxBytes: number;
   totalMaxBytes: number;
 };
 
-export type SessionLogNeedles = Record<string, string>;
+type SessionLogNeedles = Record<string, string>;
 
 const DEFAULT_FILE_MAX_BYTES = 4 * 1024 * 1024;
 const DEFAULT_TOTAL_MAX_BYTES = 16 * 1024 * 1024;

--- a/scripts/e2e/lib/temp-state-dir.ts
+++ b/scripts/e2e/lib/temp-state-dir.ts
@@ -8,7 +8,7 @@ const cleanupSignals = ["SIGINT", "SIGTERM", "SIGHUP"] as const;
 
 type CleanupSignal = (typeof cleanupSignals)[number];
 
-export type E2eStateDir = {
+type E2eStateDir = {
   stateDir: string;
   created: boolean;
   cleanup: () => void;

--- a/scripts/e2e/mcp-channel-limits.ts
+++ b/scripts/e2e/mcp-channel-limits.ts
@@ -1,7 +1,7 @@
 // Mcp Channel Limits script supports OpenClaw repository automation.
 import { readPositiveIntEnv } from "./lib/env-limits.mjs";
 
-export type McpChannelLimits = {
+type McpChannelLimits = {
   connectTimeoutMs: number;
   gatewayEventRetainLimit: number;
   rawMessageRetainLimit: number;

--- a/scripts/e2e/mcp-code-mode-gateway-client.ts
+++ b/scripts/e2e/mcp-code-mode-gateway-client.ts
@@ -16,7 +16,7 @@ type FetchJsonOptions = {
   timeoutMs?: number;
 };
 
-export type McpCodeModeClientFetchLimits = {
+type McpCodeModeClientFetchLimits = {
   bodyMaxBytes: number;
   timeoutMs: number;
 };

--- a/scripts/e2e/telegram-bot-api.ts
+++ b/scripts/e2e/telegram-bot-api.ts
@@ -13,7 +13,7 @@ type TelegramBotApiOptions = {
 
 const DEFAULT_BASE_URL =
   process.env.OPENCLAW_TELEGRAM_USER_BOT_API_BASE_URL ?? "https://api.telegram.org";
-export type TelegramBotApiLimits = {
+type TelegramBotApiLimits = {
   bodyMaxBytes: number;
   timeoutMs: number;
 };

--- a/scripts/lib/android-version.ts
+++ b/scripts/lib/android-version.ts
@@ -14,7 +14,7 @@ type AndroidVersionManifest = {
   versionCode: number;
 };
 
-export type ResolvedAndroidVersion = {
+type ResolvedAndroidVersion = {
   canonicalVersion: string;
   changelogPath: string;
   releaseNotesPath: string;

--- a/scripts/lib/copy-assets.ts
+++ b/scripts/lib/copy-assets.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-export type BuildCopyContext = {
+type BuildCopyContext = {
   prefix: string;
   projectRoot: string;
   verbose: boolean;

--- a/scripts/lib/gateway-bench-child.ts
+++ b/scripts/lib/gateway-bench-child.ts
@@ -18,7 +18,7 @@ export type StopChildResult = ChildExit & {
   exitedBeforeTeardown: boolean;
 };
 
-export type StopChildOptions = {
+type StopChildOptions = {
   killGraceMs?: number;
   platform?: NodeJS.Platform;
   runTaskkill?: typeof spawnSync;

--- a/scripts/lib/gateway-ws-client.ts
+++ b/scripts/lib/gateway-ws-client.ts
@@ -2,8 +2,8 @@
 import { randomUUID } from "node:crypto";
 import WebSocket from "ws";
 
-export type GatewayReqFrame = { type: "req"; id: string; method: string; params?: unknown };
-export type GatewayResFrame = {
+type GatewayReqFrame = { type: "req"; id: string; method: string; params?: unknown };
+type GatewayResFrame = {
   type: "res";
   id: string;
   ok: boolean;

--- a/scripts/lib/npm-verify-exec.ts
+++ b/scripts/lib/npm-verify-exec.ts
@@ -1,7 +1,7 @@
 // Npm Verify Exec script supports OpenClaw repository automation.
 import { execFileSync } from "node:child_process";
 
-export type NpmVerifyCommandInvocation = {
+type NpmVerifyCommandInvocation = {
   command: string;
   args: string[];
   windowsVerbatimArguments?: boolean;

--- a/scripts/lib/openclaw-release-clawhub-plan.ts
+++ b/scripts/lib/openclaw-release-clawhub-plan.ts
@@ -22,7 +22,7 @@ type ClawHubDispatchTarget = {
   inputs: ClawHubDispatchInputs;
 };
 
-export type OpenClawReleaseClawHubPlanArgs = {
+type OpenClawReleaseClawHubPlanArgs = {
   releaseTag: string;
   releasePublishBranch: string;
   releasePublishRunId: string;
@@ -30,7 +30,7 @@ export type OpenClawReleaseClawHubPlanArgs = {
   plugins: string[];
 };
 
-export type OpenClawReleaseClawHubPlan = {
+type OpenClawReleaseClawHubPlan = {
   clawHubWorkflowRef: string;
   releasePublishBranch: string;
   normal: ClawHubDispatchTarget;
@@ -48,7 +48,7 @@ export type OpenClawReleaseClawHubPlan = {
   };
 };
 
-export type OpenClawReleaseClawHubRuntimeStateArgs = {
+type OpenClawReleaseClawHubRuntimeStateArgs = {
   repository: string;
   waitForClawHub: boolean;
   forceSkipClawHub: boolean;
@@ -57,7 +57,7 @@ export type OpenClawReleaseClawHubRuntimeStateArgs = {
   bootstrapCompleted: boolean;
 };
 
-export type OpenClawReleaseClawHubRuntimeState = {
+type OpenClawReleaseClawHubRuntimeState = {
   verifierArgs: string[];
   proofLines: {
     normal: string;

--- a/scripts/lib/plugin-npm-release.ts
+++ b/scripts/lib/plugin-npm-release.ts
@@ -76,7 +76,7 @@ export type GitRangeSelection = {
   headRef: string;
 };
 
-export type ParsedPluginReleaseArgs = {
+type ParsedPluginReleaseArgs = {
   selection: string[];
   selectionMode?: PluginReleaseSelectionMode;
   pluginsFlagProvided: boolean;
@@ -98,14 +98,13 @@ function parsePluginNpmDistTagOverride(value: string | undefined): "extended-sta
   throw new Error(`Unknown npm dist-tag override: ${value}. Expected "extended-stable".`);
 }
 
-export type PublishablePluginPackageCandidate<
-  TPackageJson extends PluginPackageJson = PluginPackageJson,
-> = {
-  extensionId: string;
-  packageDir: string;
-  packageJson: TPackageJson;
-  readmeText?: string;
-};
+type PublishablePluginPackageCandidate<TPackageJson extends PluginPackageJson = PluginPackageJson> =
+  {
+    extensionId: string;
+    packageDir: string;
+    packageJson: TPackageJson;
+    readmeText?: string;
+  };
 
 export const OPENCLAW_PLUGIN_NPM_REPOSITORY_URL = "https://github.com/openclaw/openclaw";
 
@@ -402,7 +401,7 @@ export function collectPublishablePluginPackageErrors(
   return errors;
 }
 
-export type PublishablePluginPackageFilters = {
+type PublishablePluginPackageFilters = {
   extensionIds?: readonly string[];
   packageNames?: readonly string[];
   npmDistTag?: "extended-stable";

--- a/scripts/lib/release-beta-verifier.ts
+++ b/scripts/lib/release-beta-verifier.ts
@@ -11,7 +11,7 @@ import {
 
 type JsonRecord = Record<string, unknown>;
 
-export type ReleaseVerifyBetaArgs = {
+type ReleaseVerifyBetaArgs = {
   version: string;
   tag: string;
   distTag: string;
@@ -35,7 +35,7 @@ export type ReleaseVerifyBetaArgs = {
   };
 };
 
-export type NpmViewFields = {
+type NpmViewFields = {
   version?: string;
   distTagVersion?: string;
   integrity?: string;

--- a/scripts/lib/version-script-args.ts
+++ b/scripts/lib/version-script-args.ts
@@ -1,15 +1,15 @@
 import path from "node:path";
 
-export type VersionScriptFormat = "json" | "shell";
-export type VersionQueryCliOptions = {
+type VersionScriptFormat = "json" | "shell";
+type VersionQueryCliOptions = {
   field: string | null;
   format: VersionScriptFormat;
   help: boolean;
   releaseVersion: string | null;
   rootDir: string;
 };
-export type VersionSyncMode = "check" | "write";
-export type VersionSyncCliOptions = {
+type VersionSyncMode = "check" | "write";
+type VersionSyncCliOptions = {
   help: boolean;
   mode: VersionSyncMode;
   releaseVersion: string | null;

--- a/scripts/test-env-mutation-report.ts
+++ b/scripts/test-env-mutation-report.ts
@@ -10,7 +10,7 @@ import { collectFilesSync, isCodeFile, toPosixPath } from "./check-file-utils.js
 
 type EnvMutationOperation = "assign" | "delete" | "replace" | "stubEnv";
 
-export type TestEnvMutationFinding = {
+type TestEnvMutationFinding = {
   allowed: boolean;
   allowReason?: string;
   excerpt: string;

--- a/scripts/test-skip-inventory.ts
+++ b/scripts/test-skip-inventory.ts
@@ -20,7 +20,7 @@ type SkipInventoryReason =
 
 type SkipInventoryTarget = "describe" | "it" | "test" | "unknown";
 
-export type TestSkipInventoryFinding = {
+type TestSkipInventoryFinding = {
   excerpt: string;
   file: string;
   kind: SkipInventoryKind;


### PR DESCRIPTION
## What Problem This Solves

Twenty-seven internal type aliases were exported from repository-only script and E2E helper modules even though no repository consumer imports them.

## Why This Change Was Made

Localize those helper types while preserving every exported runtime function, value, and intentionally shared type. This narrows the tooling surface without changing script behavior or command contracts.

## User Impact

None. This is type-export deadcode cleanup with no runtime behavior change.

## Evidence

- Repository-wide export-consumer scan confirmed all 27 selected types have no external consumers.
- The post-edit scripts scan leaves only the deliberately excluded Codex protocol type.
- Clean codebase-memory MCP rebuild indexed 21,043 files, 281,321 nodes, and 1,134,385 edges with zero extraction errors.
- `OPENCLAW_TESTBOX=1 pnpm check:changed` passed in the tooling lane.
- Focused tooling proof passed across 21 test files: 474 tests in two Vitest shards.
- Full `pnpm build` passed.
- Local autoreview passed with no findings at 0.93 confidence.
- Branch autoreview passed with no findings at 0.89 confidence.
- Testbox: `tbx_01kwzfvqfxypj8rdhk02s3xc61`
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/28906844253
