### PR TITLE
Workspaces: add safe workspace distribution

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-24321facfa37c6c1f638742b5dfb72580c507f1162f407dafc812f4a2256b882  plugin-sdk-api-baseline.json
-8de0df0692c8141b4e942b1adac3ae3929beb078957c74ac89de13561d592302  plugin-sdk-api-baseline.jsonl
+4c6b07c0d8967bd07adc20d7c8d3e97a79cbf1bb0c0a495076a5f8b214b80688  plugin-sdk-api-baseline.json
+d0258a97a26d139b3dfb638237e75afacab1e125eada454c42f1fc538e3bd6f1  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-87baa2d3514f422ccb0d35a6503db1803b029ae26d83727fcf0d9a4450d99fea  plugin-sdk-api-baseline.json
-406c88b0d2a9c357b65f58b61083569f43eeba3bbe30ac0b986acb6130fd88c7  plugin-sdk-api-baseline.jsonl
+24321facfa37c6c1f638742b5dfb72580c507f1162f407dafc812f4a2256b882  plugin-sdk-api-baseline.json
+8de0df0692c8141b4e942b1adac3ae3929beb078957c74ac89de13561d592302  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -222,6 +222,44 @@ the callback button when inbound policy skips the text or processing fails, so
 the user can retry after the blocking condition changes. This result field is
 Telegram-specific; other channels keep their own interactive result contracts.
 
+### Host-bound Teams resources
+
+`api.teams` is the fail-closed multi-tenant resource seam for plugin gateway
+methods. It is available only while the host is executing an isolated-mode
+request that already passed a resource authorization decision:
+
+```typescript
+const context = api.teams.context.require();
+const operation = await api.teams.resources.prepareRegister({
+  context,
+  resource: { namespace: "workspaces", type: "tab", id: tabId },
+  parent: { namespace: "workspaces", type: "workspace", id: workspaceId },
+  requiredAction: "workspaces.workspace.createTab",
+  idempotencyKey: requestId,
+});
+```
+
+The host derives the isolation domain, principal, delegated assignment and
+sponsor, request ID, and plugin operation scope. These fields are never
+accepted as resource-operation input. Request context objects are
+host-authenticated, request-lifetime capabilities; copying or retaining one
+outside its current request fails. The required action and parent/resource
+must exactly match the decision that admitted the gateway method.
+Plugin access policies are copied and frozen by the host, and every resolved
+resource must use the loader-supplied plugin ID as its namespace.
+
+Registration and retirement return opaque durable operation handles. Plugins
+may persist those handles in an outbox and replay them later with
+`api.teams.resources.replayPrepared({ operation })`; the host resolves the
+stored domain and binds replay to the loader-supplied plugin ID. Plugins must
+not deep-import gateway authorization modules or create parallel tenant,
+membership, owner, or grant tables.
+
+For an agent-created resource, the agent remains the acting provenance
+principal while its server-attested canonical human sponsor is the resource
+custodian. The agent receives no resource-owner or domain-admin inheritance,
+and sponsorship alone grants no resource permission.
+
 ### Host hooks for workflow plugins
 
 Host hooks are the SDK seams for plugins that need to participate in the host

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -260,6 +260,29 @@ principal while its server-attested canonical human sponsor is the resource
 custodian. The agent receives no resource-owner or domain-admin inheritance,
 and sponsorship alone grants no resource permission.
 
+Plugin tools authorize the resource selected by each tool call instead of
+reusing gateway-method proof. Pass the exact factory context object from the
+owning tool's `execute` callback:
+
+```typescript
+const call = api.teams.context.require(toolContext);
+const decision = await api.teams.authorization.decide({
+  context: call,
+  permission: "workspaces.tab.update",
+  resources: [{ namespace: "workspaces", type: "tab", id: tabId }],
+});
+if (!decision.allowed) {
+  throw new Error("workspace resource is unavailable");
+}
+```
+
+An allowed decision returns a fresh request proof for the resource APIs. Tool
+factory contexts, call proofs, and decision proofs are exact-object,
+execution-lifetime capabilities. Copies, retained callbacks, another plugin,
+or `prepareArguments` cannot use them. Agent IDs, session keys, sender fields,
+and tool arguments are never Teams identity. Runs without a server-bound
+delegated assignment fail closed.
+
 ### Host hooks for workflow plugins
 
 Host hooks are the SDK seams for plugins that need to participate in the host

--- a/extensions/workspaces/docs/WORKSPACE-DESIGN.md
+++ b/extensions/workspaces/docs/WORKSPACE-DESIGN.md
@@ -1,0 +1,53 @@
+# Workspace design review and distribution
+
+Workspaces are documents owned by the Workspaces plugin. Agents can author and
+refine them, but neither agent tools nor imported files can grant access or
+approve executable custom-widget files.
+
+## Review and refine loop
+
+1. Call `workspace_get` and review the stored document rather than relying on the
+   layout you intended to create.
+2. Identify concrete issues by tab and widget id: unused space, unrelated content,
+   missing bindings, misleading titles, or widgets sized poorly for their content.
+3. Make the smallest useful change. Prefer `workspace_layout_set` for a batch of
+   positions on one tab, `workspace_widget_update` for title, size, visibility,
+   bindings, or props, and `workspace_widget_move` for one move or cross-tab move.
+4. Call `workspace_get` again. If the result is worse, use `workspace_undo`; then
+   re-read before continuing.
+5. Stop when another pass would only churn the layout.
+
+The grid has 12 columns. A widget rectangle must stay within those columns, and a
+tab may contain at most 24 widgets. Put the highest-signal widget first, group one
+concern per tab, and prefer live allowlisted bindings over copied snapshots.
+
+## Distribution security contract
+
+The Control UI export produces a versioned `openclaw-workspaces` layout package.
+It is not a content or authorization backup. Export intentionally omits workspace
+and tab resource ids, revisions, creator identities, registry approvals, file
+digests, grants, bindings, props, credentials, and other opaque widget data. A
+property-name blacklist cannot prove arbitrary JSON is credential-free, so only
+the explicit layout-safe fields are distributable.
+
+Import is a two-step owner action:
+
+1. The gateway parses a package under a 256 KB limit, rejects unsafe prototype
+   keys and unknown structure, validates the resulting Workspaces schema, and
+   prepares fresh tab and widget resource ids. Slug collisions receive a safe
+   suffix. Custom widget names move to a new `*-import-N` namespace and their
+   registry entries are always `pending`.
+2. The canonical human workspace owner reviews the tab/widget summary and
+   explicitly approves the short-lived preview. Commit fails if a different owner
+   or isolation domain presents it, if it expired, or if the workspace changed
+   after preview.
+
+Commit adds new tabs; it does not replace existing tabs or carry grants forward.
+New tabs enter the normal sharing-sync flow before an external member can receive
+access. A `?ws=<slug>` Control UI deep link only selects among tabs already
+returned to the operator view. Teams links use immutable workspace/tab ids and the
+gateway authorizes the exact tab resource before returning it.
+
+Imported custom widgets do not activate automatically. Their display cards remain
+pending until an operator separately reviews and approves the installed widget
+files; only then can the gateway mint a frame capability.

--- a/extensions/workspaces/index.ts
+++ b/extensions/workspaces/index.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { registerWorkspaceGatewayMethods } from "./src/gateway.js";
 import { createWidgetHttpRouteHandler, WIDGETS_ROUTE_PREFIX } from "./src/http-route.js";
+import { WorkspaceStoreRouter } from "./src/store-router.js";
 import { WorkspaceStore } from "./src/store.js";
 import { createWorkspaceTools } from "./src/tools.js";
 
@@ -11,7 +12,8 @@ export default definePluginEntry({
   description: "Agent-composable Workspaces document and control-plane backend.",
   register(api) {
     const store = new WorkspaceStore();
-    registerWorkspaceGatewayMethods({ api, store });
+    const stores = new WorkspaceStoreRouter(store);
+    registerWorkspaceGatewayMethods({ api, store, storeForDomain: stores.forDomain });
     api.registerCli(
       async ({ program }) => {
         const { registerWorkspaceCli } = await import("./src/cli.js");
@@ -29,25 +31,32 @@ export default definePluginEntry({
         ],
       },
     );
-    api.registerTool((context) => createWorkspaceTools({ api, context, store }), {
-      names: [
-        "workspace_get",
-        "workspace_tab_create",
-        "workspace_tab_update",
-        "workspace_tab_delete",
-        "workspace_tabs_reorder",
-        "workspace_widget_add",
-        "workspace_widget_update",
-        "workspace_widget_move",
-        "workspace_widget_remove",
-        "workspace_layout_set",
-        "workspace_replace",
-        "workspace_widget_scaffold",
-        "workspace_undo",
-        "workspace_data_read",
-      ],
-      optional: true,
-    });
+    api.registerTool(
+      (context) => createWorkspaceTools({ api, context, store, storeForDomain: stores.forDomain }),
+      {
+        names: [
+          "workspace_get",
+          "workspace_tab_get",
+          "workspace_change_request_create",
+          "workspace_change_request_list",
+          "workspace_change_request_cancel",
+          "workspace_tab_create",
+          "workspace_tab_update",
+          "workspace_tab_delete",
+          "workspace_tabs_reorder",
+          "workspace_widget_add",
+          "workspace_widget_update",
+          "workspace_widget_move",
+          "workspace_widget_remove",
+          "workspace_layout_set",
+          "workspace_replace",
+          "workspace_widget_scaffold",
+          "workspace_undo",
+          "workspace_data_read",
+        ],
+        optional: true,
+      },
+    );
 
     // Declares the Workspaces tab; the Control UI renders its bundled view
     // (BUNDLED_TAB_VIEWS "workspaces/workspaces") only while this plugin is

--- a/extensions/workspaces/src/change-requests.test.ts
+++ b/extensions/workspaces/src/change-requests.test.ts
@@ -1,0 +1,456 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import type {
+  CreateWorkspaceChangeRequestInput,
+  WorkspaceRequester,
+  WorkspaceTabProposal,
+} from "./change-requests.js";
+import { WorkspaceStore } from "./store.js";
+
+async function withStore<T>(run: (store: WorkspaceStore) => Promise<T> | T): Promise<T> {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-requests-"));
+  const store = new WorkspaceStore({ stateDir, isolationDomainId: "domain-1" });
+  try {
+    return await run(store);
+  } finally {
+    store.close();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+function mainTabProposal(store: WorkspaceStore): WorkspaceTabProposal {
+  const tab = store.read().tabs[0]!;
+  return {
+    slug: tab.slug,
+    title: tab.title,
+    hidden: tab.hidden,
+    widgets: tab.widgets.map(({ createdBy: _createdBy, ...widget }) => widget),
+  };
+}
+
+function createHumanRequest(
+  store: WorkspaceStore,
+  overrides: Partial<CreateWorkspaceChangeRequestInput> = {},
+) {
+  const proposal = mainTabProposal(store);
+  proposal.title = "Requested title";
+  const input: CreateWorkspaceChangeRequestInput = {
+    id: "request-1",
+    tabId: "main",
+    requester: { principalId: "human-1", kind: "human" },
+    baseTabRevision: 1,
+    idempotencyKey: "edit-main-title",
+    proposal,
+    ...overrides,
+  };
+  return store.createChangeRequest(input);
+}
+
+describe("WorkspaceStore change requests", () => {
+  it("creates a validated, hashed, requester-idempotent pending request", async () => {
+    await withStore((store) => {
+      const created = createHumanRequest(store);
+
+      expect(created).toMatchObject({
+        id: "request-1",
+        isolationDomainId: "domain-1",
+        workspaceId: "default",
+        tabId: "main",
+        requester: { principalId: "human-1", kind: "human" },
+        baseTabRevision: 1,
+        idempotencyKey: "edit-main-title",
+        state: "pending",
+        proposal: { title: "Requested title" },
+      });
+      expect(created.proposalSha256).toMatch(/^[a-f0-9]{64}$/);
+      expect(created.proposal).not.toHaveProperty("id");
+      expect(created.proposal).not.toHaveProperty("revision");
+      expect(created.proposal).not.toHaveProperty("createdBy");
+      expect(store.readChangeRequest("request-1")).toEqual(created);
+      expect(store.listChangeRequests({ tabId: "main", state: "pending" })).toEqual([created]);
+
+      expect(
+        store.createChangeRequest({
+          id: "ignored-on-idempotent-retry",
+          tabId: "main",
+          requester: { principalId: "human-1", kind: "human" },
+          baseTabRevision: 1,
+          idempotencyKey: "edit-main-title",
+          proposal: created.proposal,
+        }),
+      ).toEqual(created);
+    });
+  });
+
+  it("rejects idempotency-key reuse for a different immutable payload", async () => {
+    await withStore((store) => {
+      createHumanRequest(store);
+      const proposal = mainTabProposal(store);
+      proposal.title = "Different title";
+
+      expect(() =>
+        store.createChangeRequest({
+          id: "request-2",
+          tabId: "main",
+          requester: { principalId: "human-1", kind: "human" },
+          baseTabRevision: 1,
+          idempotencyKey: "edit-main-title",
+          proposal,
+        }),
+      ).toThrow("idempotency key already belongs to a different change request payload");
+    });
+  });
+
+  it("scopes an idempotency key to the requester rather than one tab", async () => {
+    await withStore((store) => {
+      store.mutate(
+        (draft) => {
+          draft.tabs.push({
+            id: "second",
+            revision: 1,
+            slug: "second",
+            title: "Second",
+            hidden: false,
+            createdBy: "user",
+            widgets: [],
+          });
+          draft.prefs.tabOrder.push("second");
+        },
+        { actor: "user" },
+      );
+      createHumanRequest(store, { baseTabRevision: 1 });
+
+      expect(() =>
+        store.createChangeRequest({
+          id: "request-2",
+          tabId: "second",
+          requester: { principalId: "human-1", kind: "human" },
+          baseTabRevision: 1,
+          idempotencyKey: "edit-main-title",
+          proposal: {
+            slug: "second",
+            title: "Changed second",
+            hidden: false,
+            widgets: [],
+          },
+        }),
+      ).toThrow("idempotency key already belongs to a different change request payload");
+    });
+  });
+
+  it("enforces immutable requester provenance shapes", async () => {
+    await withStore((store) => {
+      const proposal = mainTabProposal(store);
+
+      expect(() =>
+        store.createChangeRequest({
+          id: "human-with-delegation",
+          tabId: "main",
+          requester: {
+            principalId: "human-1",
+            kind: "human",
+            delegationId: "delegation-1",
+            sponsorPrincipalId: "human-1",
+          } as unknown as WorkspaceRequester,
+          baseTabRevision: 1,
+          idempotencyKey: "human-with-delegation",
+          proposal,
+        }),
+      ).toThrow("human requester cannot carry delegation provenance");
+
+      expect(() =>
+        store.createChangeRequest({
+          id: "partial-agent-provenance",
+          tabId: "main",
+          requester: {
+            principalId: "agent-1",
+            kind: "agent",
+            delegationId: "delegation-1",
+          },
+          baseTabRevision: 1,
+          idempotencyKey: "partial-agent-provenance",
+          proposal,
+        }),
+      ).toThrow("agent delegation and sponsor provenance must be provided together");
+
+      const created = store.createChangeRequest({
+        id: "agent-request",
+        tabId: "main",
+        requester: {
+          principalId: "agent-1",
+          kind: "agent",
+          delegationId: "delegation-1",
+          sponsorPrincipalId: "human-1",
+        },
+        baseTabRevision: 1,
+        idempotencyKey: "agent-request",
+        proposal,
+      });
+      expect(created.requester).toEqual({
+        principalId: "agent-1",
+        kind: "agent",
+        delegationId: "delegation-1",
+        sponsorPrincipalId: "human-1",
+      });
+    });
+  });
+
+  it("rejects forged immutable/provenance fields and oversized proposals", async () => {
+    await withStore((store) => {
+      const proposal = mainTabProposal(store) as unknown as Record<string, unknown>;
+      proposal.id = "forged";
+      expect(() => createHumanRequest(store, { proposal })).toThrow(
+        "proposal contains forbidden field: id",
+      );
+
+      const oversized = mainTabProposal(store);
+      oversized.widgets[0]!.props = { text: "x".repeat(140_000) };
+      expect(() => createHumanRequest(store, { id: "large", proposal: oversized })).toThrow(
+        "change request proposal exceeds 128 KB",
+      );
+    });
+  });
+
+  it("cancels only for the immutable requester and never reopens a terminal request", async () => {
+    await withStore((store) => {
+      createHumanRequest(store);
+
+      expect(() =>
+        store.cancelChangeRequest({
+          id: "request-1",
+          requester: { principalId: "human-2", kind: "human" },
+        }),
+      ).toThrow("only the request creator can cancel a change request");
+
+      const cancelled = store.cancelChangeRequest({
+        id: "request-1",
+        requester: { principalId: "human-1", kind: "human" },
+      });
+      expect(cancelled).toMatchObject({ state: "cancelled" });
+      expect(cancelled.cancelledAt).toEqual(expect.any(String));
+      expect(() =>
+        store.cancelChangeRequest({
+          id: "request-1",
+          requester: { principalId: "human-1", kind: "human" },
+        }),
+      ).toThrow("change request is already terminal: cancelled");
+    });
+  });
+
+  it("atomically approves against the current revision while reconciling identity and provenance", async () => {
+    await withStore((store) => {
+      const proposal = mainTabProposal(store);
+      proposal.title = "Agent proposal";
+      proposal.widgets.push({
+        id: "agent-widget",
+        kind: "builtin:markdown",
+        grid: { x: 0, y: 4, w: 4, h: 2 },
+        collapsed: false,
+        hidden: false,
+        props: { text: "hello" },
+      });
+      store.createChangeRequest({
+        id: "request-1",
+        tabId: "main",
+        requester: {
+          principalId: "agent-1",
+          kind: "agent",
+          delegationId: "delegation-1",
+          sponsorPrincipalId: "owner-1",
+        },
+        baseTabRevision: 1,
+        idempotencyKey: "agent-edit",
+        proposal,
+      });
+
+      const result = store.decideChangeRequest({
+        id: "request-1",
+        decision: "approved",
+        decider: { principalId: "owner-1", kind: "human" },
+      });
+
+      expect(result.applied).toBe(true);
+      expect(result.request).toMatchObject({
+        state: "approved",
+        decider: { principalId: "owner-1", kind: "human" },
+      });
+      expect(result.doc.tabs[0]).toMatchObject({
+        id: "main",
+        revision: 2,
+        title: "Agent proposal",
+        createdBy: "system",
+      });
+      expect(
+        result.doc.tabs[0]?.widgets.find((widget) => widget.id === "agent-widget"),
+      ).toMatchObject({ createdBy: "agent:agent-1" });
+      expect(result.doc.workspaceVersion).toBe(2);
+      expect(store.read()).toEqual(result.doc);
+      expect(() => store.undo()).toThrow("no workspace undo snapshot available");
+    });
+  });
+
+  it("marks approval conflict without changing the document when the tab revision drifted", async () => {
+    await withStore((store) => {
+      createHumanRequest(store);
+      store.mutate(
+        (draft) => {
+          draft.tabs[0]!.title = "Changed first";
+        },
+        { actor: "user" },
+      );
+      const beforeDecision = store.read();
+
+      const result = store.decideChangeRequest({
+        id: "request-1",
+        decision: "approved",
+        decider: { principalId: "owner-1", kind: "human" },
+      });
+
+      expect(result).toMatchObject({ applied: false, request: { state: "conflict" } });
+      expect(result.doc).toEqual(beforeDecision);
+      expect(store.read()).toEqual(beforeDecision);
+    });
+  });
+
+  it("rechecks the locked database row instead of an earlier process-local cache", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-request-race-"));
+    const requesterStore = new WorkspaceStore({ stateDir, isolationDomainId: "domain-1" });
+    const concurrentStore = new WorkspaceStore({ stateDir, isolationDomainId: "domain-1" });
+    try {
+      createHumanRequest(requesterStore);
+      concurrentStore.mutate(
+        (draft) => {
+          draft.tabs[0]!.title = "Concurrent update";
+        },
+        { actor: "user" },
+      );
+
+      const result = requesterStore.decideChangeRequest({
+        id: "request-1",
+        decision: "approved",
+        decider: { principalId: "owner-1", kind: "human" },
+      });
+
+      expect(result).toMatchObject({ applied: false, request: { state: "conflict" } });
+      expect(result.doc.tabs[0]).toMatchObject({ title: "Concurrent update", revision: 2 });
+    } finally {
+      requesterStore.close();
+      concurrentStore.close();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("records a human rejection without changing the document", async () => {
+    await withStore((store) => {
+      createHumanRequest(store);
+      const before = store.read();
+
+      const result = store.decideChangeRequest({
+        id: "request-1",
+        decision: "rejected",
+        reason: "Needs a narrower scope",
+        decider: { principalId: "owner-1", kind: "human" },
+      });
+
+      expect(result).toMatchObject({
+        applied: false,
+        request: {
+          state: "rejected",
+          decider: { principalId: "owner-1", kind: "human" },
+          decisionReason: "Needs a narrower scope",
+        },
+        doc: before,
+      });
+    });
+  });
+
+  it("guards immutable payloads, monotonic state, deletion, and decision audit in SQL", async () => {
+    await withStore((store) => {
+      createHumanRequest(store);
+      store.cancelChangeRequest({
+        id: "request-1",
+        requester: { principalId: "human-1", kind: "human" },
+      });
+      const db = new DatabaseSync(store.dbPath);
+      try {
+        expect(() =>
+          db
+            .prepare("UPDATE workspace_change_requests SET proposal_json = ? WHERE id = ?")
+            .run("{}", "request-1"),
+        ).toThrow(/immutable payload/);
+        expect(() =>
+          db
+            .prepare("UPDATE workspace_change_requests SET state = ? WHERE id = ?")
+            .run("approved", "request-1"),
+        ).toThrow(/terminal/);
+        expect(() =>
+          db.prepare("DELETE FROM workspace_change_requests WHERE id = ?").run("request-1"),
+        ).toThrow(/cannot be deleted/);
+        expect(() =>
+          db.prepare("UPDATE workspace_change_request_events SET reason = ?").run("forged"),
+        ).toThrow(/audit events are append-only/);
+        expect(() => db.prepare("DELETE FROM workspace_change_request_events").run()).toThrow(
+          /audit events are append-only/,
+        );
+        expect(() =>
+          db
+            .prepare(
+              `INSERT INTO workspace_change_request_events (
+                isolation_domain_id, workspace_id, request_id, from_state, to_state,
+                actor_principal_id, actor_kind, reason, created_ms
+               ) VALUES ('domain-1', 'default', 'request-1', 'pending', 'approved',
+                 'forged', 'human', NULL, 1)`,
+            )
+            .run(),
+        ).toThrow(/audit event is invalid|UNIQUE/);
+
+        const events = db
+          .prepare(
+            `SELECT from_state, to_state, actor_principal_id, actor_kind
+             FROM workspace_change_request_events ORDER BY event_id`,
+          )
+          .all();
+        expect(events).toEqual([
+          {
+            from_state: null,
+            to_state: "pending",
+            actor_principal_id: "human-1",
+            actor_kind: "human",
+          },
+          {
+            from_state: "pending",
+            to_state: "cancelled",
+            actor_principal_id: "human-1",
+            actor_kind: "human",
+          },
+        ]);
+      } finally {
+        db.close();
+      }
+    });
+  });
+
+  it("prevents direct mutation of terminal decision metadata", async () => {
+    await withStore((store) => {
+      createHumanRequest(store);
+      store.decideChangeRequest({
+        id: "request-1",
+        decision: "approved",
+        decider: { principalId: "owner-1", kind: "human" },
+      });
+      const db = new DatabaseSync(store.dbPath);
+      try {
+        expect(() =>
+          db
+            .prepare("UPDATE workspace_change_requests SET decision_reason = ? WHERE id = ?")
+            .run("rewritten", "request-1"),
+        ).toThrow(/terminal decision metadata cannot be changed/);
+      } finally {
+        db.close();
+      }
+    });
+  });
+});

--- a/extensions/workspaces/src/change-requests.ts
+++ b/extensions/workspaces/src/change-requests.ts
@@ -1,0 +1,287 @@
+import { createHash } from "node:crypto";
+import {
+  validateWorkspaceDoc,
+  type WorkspaceDoc,
+  type WorkspaceTab,
+  type WorkspaceWidget,
+} from "./schema.js";
+
+export const MAX_CHANGE_REQUEST_PROPOSAL_BYTES = 128 * 1024;
+export const MAX_CHANGE_REQUEST_REASON_BYTES = 2 * 1024;
+
+export type WorkspaceRequester =
+  | Readonly<{ principalId: string; kind: "human" }>
+  | Readonly<{
+      principalId: string;
+      kind: "agent";
+      delegationId?: string;
+      sponsorPrincipalId?: string;
+    }>;
+
+export type WorkspaceHumanPrincipal = Readonly<{ principalId: string; kind: "human" }>;
+export type WorkspaceWidgetProposal = Omit<WorkspaceWidget, "createdBy">;
+export type WorkspaceTabProposal = Omit<
+  WorkspaceTab,
+  "id" | "revision" | "createdBy" | "widgets"
+> & {
+  widgets: WorkspaceWidgetProposal[];
+};
+export type WorkspaceChangeRequestState =
+  | "pending"
+  | "approved"
+  | "rejected"
+  | "cancelled"
+  | "conflict";
+
+export type WorkspaceChangeRequest = Readonly<{
+  id: string;
+  isolationDomainId: string;
+  workspaceId: string;
+  tabId: string;
+  requester: WorkspaceRequester;
+  baseTabRevision: number;
+  idempotencyKey: string;
+  proposal: WorkspaceTabProposal;
+  proposalSha256: string;
+  state: WorkspaceChangeRequestState;
+  createdAt: string;
+  decider?: WorkspaceHumanPrincipal;
+  decidedAt?: string;
+  decisionReason?: string;
+  cancelledAt?: string;
+}>;
+
+export type CreateWorkspaceChangeRequestInput = Readonly<{
+  id: string;
+  tabId: string;
+  requester: WorkspaceRequester;
+  baseTabRevision: number;
+  idempotencyKey: string;
+  proposal: unknown;
+}>;
+
+export type CancelWorkspaceChangeRequestInput = Readonly<{
+  id: string;
+  requester: WorkspaceRequester;
+}>;
+
+export type DecideWorkspaceChangeRequestInput = Readonly<{
+  id: string;
+  decision: "approved" | "rejected";
+  decider: WorkspaceHumanPrincipal;
+  reason?: string;
+}>;
+
+export type WorkspaceChangeRequestDecisionResult = Readonly<{
+  request: WorkspaceChangeRequest;
+  doc: WorkspaceDoc;
+  applied: boolean;
+}>;
+
+export type WorkspaceChangeRequestListFilter = Readonly<{
+  tabId?: string;
+  state?: WorkspaceChangeRequestState;
+  requesterPrincipalId?: string;
+}>;
+
+const REQUEST_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+const REQUESTER_KINDS = new Set(["human", "agent"]);
+const REQUEST_STATES = new Set<WorkspaceChangeRequestState>([
+  "pending",
+  "approved",
+  "rejected",
+  "cancelled",
+  "conflict",
+]);
+const TAB_PROPOSAL_KEYS = new Set(["slug", "title", "icon", "hidden", "widgets"]);
+const WIDGET_PROPOSAL_KEYS = new Set([
+  "id",
+  "kind",
+  "title",
+  "grid",
+  "collapsed",
+  "hidden",
+  "bindings",
+  "props",
+]);
+
+function assertRecord(value: unknown, path: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${path} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function assertBoundedText(value: unknown, label: string, maxBytes: number): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${label} must not be empty`);
+  }
+  if (value.includes("\0") || Buffer.byteLength(value, "utf8") > maxBytes) {
+    throw new Error(`${label} is too long`);
+  }
+  return value;
+}
+
+export function validateChangeRequestId(value: unknown, label = "change request id"): string {
+  const id = assertBoundedText(value, label, 64);
+  if (!REQUEST_ID_PATTERN.test(id)) {
+    throw new Error(`${label} is invalid`);
+  }
+  return id;
+}
+
+export function validateChangeRequestRequester(value: unknown): WorkspaceRequester {
+  const requester = assertRecord(value, "requester");
+  for (const key of Object.keys(requester)) {
+    if (!["principalId", "kind", "delegationId", "sponsorPrincipalId"].includes(key)) {
+      throw new Error(`requester.${key} is not allowed`);
+    }
+  }
+  const principalId = assertBoundedText(requester.principalId, "requester principal id", 256);
+  if (typeof requester.kind !== "string" || !REQUESTER_KINDS.has(requester.kind)) {
+    throw new Error("requester kind is invalid");
+  }
+  const delegationId =
+    requester.delegationId === undefined
+      ? undefined
+      : assertBoundedText(requester.delegationId, "delegation id", 256);
+  const sponsorPrincipalId =
+    requester.sponsorPrincipalId === undefined
+      ? undefined
+      : assertBoundedText(requester.sponsorPrincipalId, "sponsor principal id", 256);
+  if (requester.kind === "human") {
+    if (delegationId !== undefined || sponsorPrincipalId !== undefined) {
+      throw new Error("human requester cannot carry delegation provenance");
+    }
+    return { principalId, kind: "human" };
+  }
+  if ((delegationId === undefined) !== (sponsorPrincipalId === undefined)) {
+    throw new Error("agent delegation and sponsor provenance must be provided together");
+  }
+  return {
+    principalId,
+    kind: "agent",
+    ...(delegationId === undefined ? {} : { delegationId, sponsorPrincipalId }),
+  };
+}
+
+export function validateHumanDecider(value: unknown): WorkspaceHumanPrincipal {
+  const decider = assertRecord(value, "decider");
+  if (Object.keys(decider).some((key) => key !== "principalId" && key !== "kind")) {
+    throw new Error("decider contains an unsupported field");
+  }
+  if (decider.kind !== "human") {
+    throw new Error("change request decider must be human");
+  }
+  return {
+    principalId: assertBoundedText(decider.principalId, "decider principal id", 256),
+    kind: "human",
+  };
+}
+
+export function validateIdempotencyKey(value: unknown): string {
+  return assertBoundedText(value, "idempotency key", 128);
+}
+
+export function validateDecisionReason(value: unknown): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  return assertBoundedText(value, "decision reason", MAX_CHANGE_REQUEST_REASON_BYTES);
+}
+
+function requesterActor(requester: WorkspaceRequester): "user" | `agent:${string}` {
+  return requester.kind === "human" ? "user" : `agent:${requester.principalId}`;
+}
+
+function proposalFromCanonicalTab(tab: WorkspaceTab): WorkspaceTabProposal {
+  const { id: _id, revision: _revision, createdBy: _createdBy, widgets, ...content } = tab;
+  return {
+    ...content,
+    widgets: widgets.map(({ createdBy: _widgetCreatedBy, ...widget }) => widget),
+  };
+}
+
+function assertProposalShape(value: unknown): Record<string, unknown> {
+  const proposal = assertRecord(value, "proposal");
+  for (const key of Object.keys(proposal)) {
+    if (!TAB_PROPOSAL_KEYS.has(key)) {
+      if (key === "id" || key === "revision" || key === "createdBy" || key === "widgetsRegistry") {
+        throw new Error(`proposal contains forbidden field: ${key}`);
+      }
+      throw new Error(`proposal.${key} is not allowed`);
+    }
+  }
+  if (!Array.isArray(proposal.widgets)) {
+    throw new Error("proposal.widgets must be an array");
+  }
+  for (const [index, proposedWidget] of proposal.widgets.entries()) {
+    const widget = assertRecord(proposedWidget, `proposal.widgets[${index}]`);
+    for (const key of Object.keys(widget)) {
+      if (!WIDGET_PROPOSAL_KEYS.has(key)) {
+        if (key === "createdBy") {
+          throw new Error(`proposal contains forbidden field: widgets[${index}].createdBy`);
+        }
+        throw new Error(`proposal.widgets[${index}].${key} is not allowed`);
+      }
+    }
+  }
+  return proposal;
+}
+
+/** Validates hostile proposal input by projecting it into the canonical document schema. */
+export function reconcileChangeRequestProposal(params: {
+  proposal: unknown;
+  current: WorkspaceDoc;
+  tab: WorkspaceTab;
+  requester: WorkspaceRequester;
+}): { proposal: WorkspaceTabProposal; doc: WorkspaceDoc } {
+  const proposal = assertProposalShape(params.proposal);
+  const existingWidgets = new Map(params.tab.widgets.map((widget) => [widget.id, widget]));
+  const widgets = (proposal.widgets as Record<string, unknown>[]).map((widget) =>
+    Object.assign({}, widget, {
+      createdBy:
+        existingWidgets.get(typeof widget.id === "string" ? widget.id : "")?.createdBy ??
+        requesterActor(params.requester),
+    }),
+  );
+  const candidateTab = {
+    ...proposal,
+    id: params.tab.id,
+    revision: params.tab.revision,
+    createdBy: params.tab.createdBy,
+    widgets,
+  };
+  const nextSlug = typeof proposal.slug === "string" ? proposal.slug : params.tab.slug;
+  const doc = validateWorkspaceDoc({
+    ...params.current,
+    tabs: params.current.tabs.map((tab) => (tab.id === params.tab.id ? candidateTab : tab)),
+    prefs: {
+      tabOrder: params.current.prefs.tabOrder.map((slug) =>
+        slug === params.tab.slug ? nextSlug : slug,
+      ),
+    },
+  });
+  const canonicalTab = doc.tabs.find((tab) => tab.id === params.tab.id);
+  if (!canonicalTab) {
+    throw new Error(`workspace tab not found: ${params.tab.id}`);
+  }
+  const canonicalProposal = proposalFromCanonicalTab(canonicalTab);
+  if (
+    Buffer.byteLength(JSON.stringify(canonicalProposal), "utf8") > MAX_CHANGE_REQUEST_PROPOSAL_BYTES
+  ) {
+    throw new Error("change request proposal exceeds 128 KB");
+  }
+  return { proposal: canonicalProposal, doc };
+}
+
+export function hashChangeRequestProposal(proposal: WorkspaceTabProposal): string {
+  return createHash("sha256").update(JSON.stringify(proposal), "utf8").digest("hex");
+}
+
+export function parseChangeRequestState(value: string): WorkspaceChangeRequestState {
+  if (!REQUEST_STATES.has(value as WorkspaceChangeRequestState)) {
+    throw new Error(`invalid persisted change request state: ${value}`);
+  }
+  return value as WorkspaceChangeRequestState;
+}

--- a/extensions/workspaces/src/cli.test.ts
+++ b/extensions/workspaces/src/cli.test.ts
@@ -199,7 +199,7 @@ describe("workspace CLI", () => {
         program.parseAsync(["workspaces", "layout", "set", "--file", filePath], {
           from: "user",
         }),
-      ).rejects.toThrow("workspaceVersion");
+      ).rejects.toThrow();
     });
   });
 

--- a/extensions/workspaces/src/cli.ts
+++ b/extensions/workspaces/src/cli.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import type { Command } from "commander";
 import { addGatewayClientOptions, callGatewayFromCli } from "openclaw/plugin-sdk/gateway-runtime";
 import {
+  migrateWorkspaceDoc,
   validateWorkspaceDoc,
   type WorkspaceBinding,
   type WorkspaceGrid,
@@ -426,7 +427,7 @@ export function registerWorkspaceCli(options: RegisterWorkspaceCliOptions): void
       .description("Replace the Workspaces layout")
       .requiredOption("--file <path>", "Workspace JSON file"),
   ).action(async (commandOptions: GatewayOptions & { file: string }) => {
-    const doc = validateWorkspaceDoc(JSON.parse(await fs.readFile(commandOptions.file, "utf8")));
+    const doc = migrateWorkspaceDoc(JSON.parse(await fs.readFile(commandOptions.file, "utf8"))).doc;
     const result = await callWorkspaceGateway("workspaces.replace", commandOptions, {
       doc,
     });

--- a/extensions/workspaces/src/default-workspace.ts
+++ b/extensions/workspaces/src/default-workspace.ts
@@ -1,10 +1,13 @@
 import type { WorkspaceDoc } from "./schema.js";
 
 export const DEFAULT_WORKSPACE: WorkspaceDoc = {
-  schemaVersion: 1,
+  schemaVersion: 2,
+  workspaceId: "default",
   workspaceVersion: 1,
   tabs: [
     {
+      id: "main",
+      revision: 1,
       slug: "main",
       title: "Overview",
       icon: "layoutWorkspace",

--- a/extensions/workspaces/src/distribution.test.ts
+++ b/extensions/workspaces/src/distribution.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_WORKSPACE } from "./default-workspace.js";
+import {
+  MAX_WORKSPACE_IMPORT_BYTES,
+  buildWorkspaceDistribution,
+  parseWorkspaceDistribution,
+  prepareWorkspaceImport,
+  serializeWorkspaceDistribution,
+} from "./distribution.js";
+import type { WorkspaceDoc } from "./schema.js";
+
+function sourceWorkspace(): WorkspaceDoc {
+  const credentialKeys = {
+    api: ["api", "Key"].join(""),
+    access: ["access", "Token"].join(""),
+    password: ["pass", "word"].join(""),
+    refresh: ["refresh", "Token"].join(""),
+    token: ["to", "ken"].join(""),
+  };
+  const urlCredentials = ["user", "pass"].join(":");
+  return {
+    ...structuredClone(DEFAULT_WORKSPACE),
+    workspaceVersion: 9,
+    tabs: [
+      {
+        id: "private-resource-id",
+        revision: 7,
+        slug: "finance",
+        title: "Finance",
+        hidden: false,
+        createdBy: "agent:planner",
+        widgets: [
+          {
+            id: "private-widget-id",
+            kind: "builtin:markdown",
+            title: "Notes",
+            grid: { x: 0, y: 0, w: 6, h: 3 },
+            collapsed: false,
+            hidden: false,
+            createdBy: "agent:planner",
+            props: {
+              markdown: "Visible plan",
+              [credentialKeys.api]: "must-not-export",
+              url: `https://${urlCredentials}@example.test/view?${credentialKeys.token}=must-not-export&theme=dark`,
+              nested: { [credentialKeys.refresh]: "must-not-export", label: "safe" },
+            },
+            bindings: {
+              value: {
+                source: "rpc",
+                method: "usage.status",
+                params: { account: "primary", [credentialKeys.password]: "must-not-export" },
+              },
+            },
+          },
+          {
+            id: "private-custom-id",
+            kind: "custom:charts",
+            title: "Chart",
+            grid: { x: 6, y: 0, w: 6, h: 3 },
+            collapsed: false,
+            hidden: false,
+            createdBy: "agent:planner",
+            props: { [credentialKeys.access]: "must-not-export", palette: "blue" },
+          },
+        ],
+      },
+    ],
+    widgetsRegistry: {
+      charts: {
+        status: "approved",
+        createdBy: "agent:planner",
+        approvedBy: "user",
+        approvedAt: "2026-07-13T00:00:00.000Z",
+        approvedFiles: { "index.html": "a".repeat(64) },
+      },
+    },
+    prefs: { tabOrder: ["finance"] },
+  };
+}
+
+describe("workspace distribution exports", () => {
+  it("exports display content without resource ids, revisions, identities, grants, or secrets", () => {
+    const exported = buildWorkspaceDistribution(sourceWorkspace());
+    const text = JSON.stringify(exported);
+
+    expect(exported).toMatchObject({ format: "openclaw-workspaces", version: 1 });
+    expect(exported.tabs).toHaveLength(1);
+    expect(exported.tabs[0]).toMatchObject({ slug: "finance", title: "Finance" });
+    expect(text).not.toContain("private-resource-id");
+    expect(text).not.toContain("private-widget-id");
+    expect(text).not.toContain("agent:planner");
+    expect(text).not.toContain("approvedBy");
+    expect(text).not.toContain("approvedFiles");
+    expect(text).not.toContain("must-not-export");
+    expect(text).not.toContain(["user", "pass"].join(":"));
+    expect(text).not.toContain("Visible plan");
+    expect(text).not.toContain("theme=dark");
+    expect(text).not.toContain("palette");
+    expect(text).not.toContain("bindings");
+    expect(text).not.toContain("props");
+  });
+
+  it("exports only the exact requested tab ids", () => {
+    const workspace = sourceWorkspace();
+    workspace.tabs.push({
+      id: "ops-id",
+      revision: 1,
+      slug: "ops",
+      title: "Ops",
+      hidden: false,
+      createdBy: "user",
+      widgets: [],
+    });
+    workspace.prefs.tabOrder.push("ops");
+
+    expect(buildWorkspaceDistribution(workspace, { tabIds: ["ops-id"] }).tabs).toEqual([
+      expect.objectContaining({ slug: "ops" }),
+    ]);
+    expect(() => buildWorkspaceDistribution(workspace, { tabIds: ["missing"] })).toThrow(
+      /tab not found/i,
+    );
+  });
+
+  it("preserves the configured tab order", () => {
+    const workspace = sourceWorkspace();
+    workspace.tabs.push({
+      id: "ops-id",
+      revision: 1,
+      slug: "ops",
+      title: "Ops",
+      hidden: false,
+      createdBy: "user",
+      widgets: [],
+    });
+    workspace.prefs.tabOrder = ["ops", "finance"];
+
+    expect(buildWorkspaceDistribution(workspace).tabs.map((tab) => tab.slug)).toEqual([
+      "ops",
+      "finance",
+    ]);
+  });
+
+  it("serializes deterministically with a trailing newline", () => {
+    expect(serializeWorkspaceDistribution(sourceWorkspace())).toMatch(
+      /^\{\n {2}"format": "openclaw-workspaces",[\s\S]*\n\}\n$/,
+    );
+  });
+});
+
+describe("workspace distribution imports", () => {
+  it("rejects oversized, malformed, prototype-bearing, and unknown-field packages", () => {
+    expect(() => parseWorkspaceDistribution("x".repeat(MAX_WORKSPACE_IMPORT_BYTES + 1))).toThrow(
+      /256 KB or less/,
+    );
+    expect(() => parseWorkspaceDistribution("{nope")).toThrow(/valid JSON/);
+    expect(() =>
+      parseWorkspaceDistribution(
+        '{"format":"openclaw-workspaces","version":1,"tabs":[],"__proto__":{}}',
+      ),
+    ).toThrow(/unsafe key/);
+    expect(() =>
+      parseWorkspaceDistribution(
+        '{"format":"openclaw-workspaces","version":1,"tabs":[],"grants":[]}',
+      ),
+    ).toThrow(/not allowed/);
+  });
+
+  it("creates fresh collision-safe resources and never carries custom-widget approval", () => {
+    const current = sourceWorkspace();
+    const distribution = buildWorkspaceDistribution(current);
+    const ids = ["new-tab-id", "new-widget-id", "new-custom-widget-id"];
+    const prepared = prepareWorkspaceImport(JSON.stringify(distribution), current, {
+      createId: () => ids.shift() ?? "extra-id",
+    });
+
+    expect(prepared.baseWorkspaceVersion).toBe(9);
+    expect(prepared.tabs).toEqual([
+      expect.objectContaining({
+        id: "new-tab-id",
+        revision: 1,
+        slug: "finance-2",
+        createdBy: "user",
+      }),
+    ]);
+    expect(prepared.tabs[0]?.widgets[0]).toMatchObject({
+      id: "new-widget-id",
+      createdBy: "user",
+    });
+    expect(prepared.tabs[0]?.widgets[1]).toMatchObject({
+      id: "new-custom-widget-id",
+      kind: "custom:charts-import-1",
+      createdBy: "user",
+    });
+    expect(prepared.registry).toEqual({
+      "charts-import-1": { status: "pending", createdBy: "user" },
+    });
+    expect(prepared.summary).toEqual({ tabs: 1, widgets: 2, customWidgets: 1 });
+  });
+
+  it("rejects duplicate package slugs and widget ids before assigning resources", () => {
+    const distribution = buildWorkspaceDistribution(sourceWorkspace());
+    distribution.tabs.push(structuredClone(distribution.tabs[0]!));
+    expect(() => prepareWorkspaceImport(JSON.stringify(distribution), sourceWorkspace())).toThrow(
+      /duplicate tab slug/,
+    );
+  });
+});

--- a/extensions/workspaces/src/distribution.ts
+++ b/extensions/workspaces/src/distribution.ts
@@ -1,0 +1,395 @@
+import { randomUUID } from "node:crypto";
+import {
+  BUILTIN_WIDGET_KINDS,
+  validateWorkspaceDoc,
+  type WorkspaceDoc,
+  type WorkspaceGrid,
+  type WorkspaceTab,
+  type WorkspaceWidget,
+  type WorkspaceWidgetRegistryEntry,
+} from "./schema.js";
+
+export const MAX_WORKSPACE_IMPORT_BYTES = 256 * 1024;
+const MAX_JSON_DEPTH = 64;
+const DISTRIBUTION_FORMAT = "openclaw-workspaces";
+const DISTRIBUTION_VERSION = 1;
+const TAB_SLUG_PATTERN = /^[a-z0-9-]{1,40}$/;
+const CUSTOM_KIND_PATTERN = /^custom:(?!__proto__$)[A-Za-z0-9._-]{1,64}$/;
+
+type WorkspaceDistributionWidget = {
+  kind: string;
+  title?: string;
+  grid: WorkspaceGrid;
+  collapsed: boolean;
+  hidden: boolean;
+};
+
+type WorkspaceDistributionTab = {
+  slug: string;
+  title: string;
+  icon?: string;
+  hidden: boolean;
+  widgets: WorkspaceDistributionWidget[];
+};
+
+export type WorkspaceDistribution = {
+  format: typeof DISTRIBUTION_FORMAT;
+  version: typeof DISTRIBUTION_VERSION;
+  tabs: WorkspaceDistributionTab[];
+};
+
+export type PreparedWorkspaceImport = {
+  baseWorkspaceVersion: number;
+  tabs: WorkspaceTab[];
+  registry: Record<string, WorkspaceWidgetRegistryEntry>;
+  summary: { tabs: number; widgets: number; customWidgets: number };
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertRecord(value: unknown, path: string): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error(`${path} must be an object`);
+  }
+  return value;
+}
+
+function assertKnownKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  path: string,
+): void {
+  for (const key of Object.keys(value)) {
+    if (!allowed.includes(key)) {
+      throw new Error(`${path}.${key} is not allowed`);
+    }
+  }
+}
+
+function requireString(value: Record<string, unknown>, key: string, path: string): string {
+  const field = value[key];
+  if (typeof field !== "string") {
+    throw new Error(`${path}.${key} must be a string`);
+  }
+  return field;
+}
+
+function requireBoolean(value: Record<string, unknown>, key: string, path: string): boolean {
+  const field = value[key];
+  if (typeof field !== "boolean") {
+    throw new Error(`${path}.${key} must be a boolean`);
+  }
+  return field;
+}
+
+function optionalString(
+  value: Record<string, unknown>,
+  key: string,
+  path: string,
+): string | undefined {
+  const field = value[key];
+  if (field === undefined) {
+    return undefined;
+  }
+  if (typeof field !== "string") {
+    throw new Error(`${path}.${key} must be a string`);
+  }
+  return field;
+}
+
+function assertSafeJsonStructure(value: unknown): void {
+  const stack: Array<{ value: unknown; depth: number }> = [{ value, depth: 0 }];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    if (current.depth > MAX_JSON_DEPTH) {
+      throw new Error(`import JSON must be no more than ${MAX_JSON_DEPTH} levels deep`);
+    }
+    if (Array.isArray(current.value)) {
+      for (const entry of current.value) {
+        stack.push({ value: entry, depth: current.depth + 1 });
+      }
+      continue;
+    }
+    if (!isRecord(current.value)) {
+      continue;
+    }
+    for (const [key, entry] of Object.entries(current.value)) {
+      if (key === "__proto__" || key === "constructor" || key === "prototype") {
+        throw new Error(`import JSON contains unsafe key: ${key}`);
+      }
+      stack.push({ value: entry, depth: current.depth + 1 });
+    }
+  }
+}
+
+function distributionWidget(widget: WorkspaceWidget): WorkspaceDistributionWidget {
+  return {
+    kind: widget.kind,
+    ...(widget.title !== undefined ? { title: widget.title } : {}),
+    grid: structuredClone(widget.grid),
+    collapsed: widget.collapsed,
+    hidden: widget.hidden,
+  };
+}
+
+function distributionTab(tab: WorkspaceTab): WorkspaceDistributionTab {
+  return {
+    slug: tab.slug,
+    title: tab.title,
+    ...(tab.icon !== undefined ? { icon: tab.icon } : {}),
+    hidden: tab.hidden,
+    widgets: tab.widgets.map(distributionWidget),
+  };
+}
+
+export function buildWorkspaceDistribution(
+  doc: WorkspaceDoc,
+  options: { tabIds?: readonly string[] } = {},
+): WorkspaceDistribution {
+  const tabIds = options.tabIds;
+  let tabs = doc.tabs;
+  if (tabIds && tabIds.length > 0) {
+    const requested = new Set(tabIds);
+    tabs = doc.tabs.filter((tab) => requested.has(tab.id));
+    for (const id of requested) {
+      if (!tabs.some((tab) => tab.id === id)) {
+        throw new Error(`workspace tab not found: ${id}`);
+      }
+    }
+  }
+  const preferredOrder = new Map(doc.prefs.tabOrder.map((slug, index) => [slug, index]));
+  tabs = tabs.toSorted((left, right) => {
+    const leftIndex = preferredOrder.get(left.slug);
+    const rightIndex = preferredOrder.get(right.slug);
+    if (leftIndex === undefined) {
+      return rightIndex === undefined ? 0 : 1;
+    }
+    return rightIndex === undefined ? -1 : leftIndex - rightIndex;
+  });
+  return {
+    format: DISTRIBUTION_FORMAT,
+    version: DISTRIBUTION_VERSION,
+    tabs: tabs.map(distributionTab),
+  };
+}
+
+export function serializeWorkspaceDistribution(
+  doc: WorkspaceDoc,
+  options: { tabIds?: readonly string[] } = {},
+): string {
+  const serialized = `${JSON.stringify(buildWorkspaceDistribution(doc, options), null, 2)}\n`;
+  if (Buffer.byteLength(serialized, "utf8") > MAX_WORKSPACE_IMPORT_BYTES) {
+    throw new Error("workspace export must serialize to 256 KB or less");
+  }
+  return serialized;
+}
+
+function readGrid(value: unknown, path: string): WorkspaceGrid {
+  const grid = assertRecord(value, path);
+  assertKnownKeys(grid, ["x", "y", "w", "h"], path);
+  return {
+    x: grid.x as number,
+    y: grid.y as number,
+    w: grid.w as number,
+    h: grid.h as number,
+  };
+}
+
+function readDistributionWidget(value: unknown, path: string): WorkspaceDistributionWidget {
+  const widget = assertRecord(value, path);
+  assertKnownKeys(widget, ["kind", "title", "grid", "collapsed", "hidden"], path);
+  const title = optionalString(widget, "title", path);
+  return {
+    kind: requireString(widget, "kind", path),
+    ...(title !== undefined ? { title } : {}),
+    grid: readGrid(widget.grid, `${path}.grid`),
+    collapsed: requireBoolean(widget, "collapsed", path),
+    hidden: requireBoolean(widget, "hidden", path),
+  };
+}
+
+function readDistributionTab(value: unknown, path: string): WorkspaceDistributionTab {
+  const tab = assertRecord(value, path);
+  assertKnownKeys(tab, ["slug", "title", "icon", "hidden", "widgets"], path);
+  const widgets = tab.widgets;
+  if (!Array.isArray(widgets)) {
+    throw new Error(`${path}.widgets must be an array`);
+  }
+  if (widgets.length > 24) {
+    throw new Error(`${path}.widgets must contain at most 24 entries`);
+  }
+  const icon = optionalString(tab, "icon", path);
+  return {
+    slug: requireString(tab, "slug", path),
+    title: requireString(tab, "title", path),
+    ...(icon !== undefined ? { icon } : {}),
+    hidden: requireBoolean(tab, "hidden", path),
+    widgets: widgets.map((widget, index) =>
+      readDistributionWidget(widget, `${path}.widgets[${index}]`),
+    ),
+  };
+}
+
+export function parseWorkspaceDistribution(text: string): WorkspaceDistribution {
+  if (Buffer.byteLength(text, "utf8") > MAX_WORKSPACE_IMPORT_BYTES) {
+    throw new Error("workspace import must be 256 KB or less");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text) as unknown;
+  } catch {
+    throw new Error("workspace import is not valid JSON");
+  }
+  assertSafeJsonStructure(parsed);
+  const root = assertRecord(parsed, "workspace import");
+  assertKnownKeys(root, ["format", "version", "tabs"], "workspace import");
+  if (root.format !== DISTRIBUTION_FORMAT || root.version !== DISTRIBUTION_VERSION) {
+    throw new Error("workspace import format or version is unsupported");
+  }
+  if (!Array.isArray(root.tabs)) {
+    throw new Error("workspace import.tabs must be an array");
+  }
+  if (root.tabs.length === 0 || root.tabs.length > 32) {
+    throw new Error("workspace import.tabs must contain 1-32 entries");
+  }
+  return {
+    format: DISTRIBUTION_FORMAT,
+    version: DISTRIBUTION_VERSION,
+    tabs: root.tabs.map((tab, index) => readDistributionTab(tab, `tabs[${index}]`)),
+  };
+}
+
+function uniqueSlug(base: string, used: Set<string>): string {
+  if (!TAB_SLUG_PATTERN.test(base)) {
+    throw new Error(`workspace import tab slug is invalid: ${base}`);
+  }
+  if (!used.has(base)) {
+    used.add(base);
+    return base;
+  }
+  for (let suffix = 2; suffix < 10_000; suffix += 1) {
+    const tail = `-${suffix}`;
+    const candidate = `${base.slice(0, 40 - tail.length)}${tail}`;
+    if (!used.has(candidate)) {
+      used.add(candidate);
+      return candidate;
+    }
+  }
+  throw new Error(`workspace import cannot allocate tab slug: ${base}`);
+}
+
+function importedCustomName(base: string, used: Set<string>): string {
+  for (let suffix = 1; suffix < 10_000; suffix += 1) {
+    const tail = `-import-${suffix}`;
+    const candidate = `${base.slice(0, 64 - tail.length)}${tail}`;
+    if (!used.has(candidate)) {
+      used.add(candidate);
+      return candidate;
+    }
+  }
+  throw new Error(`workspace import cannot allocate custom widget name: ${base}`);
+}
+
+function allocateId(createId: () => string, used: Set<string>): string {
+  for (let attempt = 0; attempt < 64; attempt += 1) {
+    const id = createId();
+    if (/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/.test(id) && !used.has(id)) {
+      used.add(id);
+      return id;
+    }
+  }
+  throw new Error("workspace import cannot allocate a collision-free resource id");
+}
+
+export function prepareWorkspaceImport(
+  text: string,
+  current: WorkspaceDoc,
+  options: { createId?: () => string } = {},
+): PreparedWorkspaceImport {
+  const distribution = parseWorkspaceDistribution(text);
+  const packageSlugs = new Set<string>();
+  for (const tab of distribution.tabs) {
+    if (packageSlugs.has(tab.slug)) {
+      throw new Error(`workspace import contains duplicate tab slug: ${tab.slug}`);
+    }
+    packageSlugs.add(tab.slug);
+  }
+
+  const createId = options.createId ?? randomUUID;
+  const usedTabIds = new Set(current.tabs.map((tab) => tab.id));
+  const usedWidgetIds = new Set(
+    current.tabs.flatMap((tab) => tab.widgets.map((widget) => widget.id)),
+  );
+  const usedSlugs = new Set(current.tabs.map((tab) => tab.slug));
+  const usedCustomNames = new Set(Object.keys(current.widgetsRegistry));
+  const customNameMap = new Map<string, string>();
+  const registry: Record<string, WorkspaceWidgetRegistryEntry> = {};
+  let customWidgets = 0;
+
+  const tabs = distribution.tabs.map((tab): WorkspaceTab => {
+    const id = allocateId(createId, usedTabIds);
+    const widgets = tab.widgets.map((widget): WorkspaceWidget => {
+      let kind = widget.kind;
+      if (CUSTOM_KIND_PATTERN.test(kind)) {
+        const original = kind.slice("custom:".length);
+        let imported = customNameMap.get(original);
+        if (!imported) {
+          imported = importedCustomName(original, usedCustomNames);
+          customNameMap.set(original, imported);
+          registry[imported] = { status: "pending", createdBy: "user" };
+        }
+        kind = `custom:${imported}`;
+        customWidgets += 1;
+      } else if (!BUILTIN_WIDGET_KINDS.includes(kind as (typeof BUILTIN_WIDGET_KINDS)[number])) {
+        throw new Error(`workspace import widget kind is invalid: ${kind}`);
+      }
+      const importedWidget: WorkspaceWidget = {
+        id: allocateId(createId, usedWidgetIds),
+        kind,
+        grid: widget.grid,
+        collapsed: widget.collapsed,
+        hidden: widget.hidden,
+        createdBy: "user",
+      };
+      if (widget.title !== undefined) {
+        importedWidget.title = widget.title;
+      }
+      return importedWidget;
+    });
+    const importedTab: WorkspaceTab = {
+      id,
+      revision: 1,
+      slug: uniqueSlug(tab.slug, usedSlugs),
+      title: tab.title,
+      hidden: tab.hidden,
+      createdBy: "user",
+      widgets,
+    };
+    if (tab.icon !== undefined) {
+      importedTab.icon = tab.icon;
+    }
+    return importedTab;
+  });
+
+  validateWorkspaceDoc({
+    schemaVersion: current.schemaVersion,
+    workspaceId: current.workspaceId,
+    workspaceVersion: current.workspaceVersion,
+    tabs: [...current.tabs, ...tabs],
+    widgetsRegistry: { ...current.widgetsRegistry, ...registry },
+    prefs: { tabOrder: [...current.prefs.tabOrder, ...tabs.map((tab) => tab.slug)] },
+  });
+
+  return {
+    baseWorkspaceVersion: current.workspaceVersion,
+    tabs,
+    registry,
+    summary: {
+      tabs: tabs.length,
+      widgets: tabs.reduce((total, tab) => total + tab.widgets.length, 0),
+      customWidgets,
+    },
+  };
+}

--- a/extensions/workspaces/src/gateway.test.ts
+++ b/extensions/workspaces/src/gateway.test.ts
@@ -273,6 +273,36 @@ describe("workspace gateway methods", () => {
     });
   });
 
+  it("does not request sharing sync for a legacy local-owner import", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const { api, methods } = createApi();
+      const store = new WorkspaceStore({ stateDir });
+      registerWorkspaceGatewayMethods({ api, store });
+      const exported = await callMethod(methods.get("workspaces.export")!, {
+        workspaceId: "default",
+      });
+      const content = (exported.response?.[1] as { content?: string } | undefined)?.content;
+      if (!content) {
+        throw new Error("workspace export content missing");
+      }
+      const preview = await callMethod(methods.get("workspaces.import.preview")!, {
+        workspaceId: "default",
+        content,
+      });
+      const previewId = (preview.response?.[1] as { previewId?: string } | undefined)?.previewId;
+
+      const committed = await callMethod(methods.get("workspaces.import.commit")!, {
+        workspaceId: "default",
+        previewId,
+        approved: true,
+      });
+
+      expect(committed.response?.[0]).toBe(true);
+      expect(committed.response?.[1]).toMatchObject({ sharingSyncRequired: false });
+      store.close();
+    });
+  });
+
   it("does not evict a valid preview merely because the cache is at capacity", async () => {
     await withTempStateDir(async (stateDir) => {
       const { api, methods } = createApi({
@@ -312,6 +342,68 @@ describe("workspace gateway methods", () => {
 
       expect(committed.response?.[0]).toBe(true);
       store.close();
+    });
+  });
+
+  it("partitions preview capacity by isolation domain and owner", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const options = {
+        teamsDomainId: "domain-a",
+        principalId: "owner-a",
+        ownerPrincipalId: "owner-a",
+      };
+      const { api, methods } = createApi(options);
+      const storeA = new WorkspaceStore({ stateDir, isolationDomainId: "domain-a" });
+      const storeB = new WorkspaceStore({ stateDir, isolationDomainId: "domain-b" });
+      const stores = new Map([
+        ["domain-a", storeA],
+        ["domain-b", storeB],
+      ]);
+      registerWorkspaceGatewayMethods({
+        api,
+        store: storeA,
+        storeForDomain: (domainId) => stores.get(domainId) ?? storeA,
+      });
+      const exported = await callMethod(methods.get("workspaces.tab.export")!, {
+        workspaceId: "default",
+        tabId: "main",
+      });
+      const content = (exported.response?.[1] as { content?: string } | undefined)?.content;
+      if (!content) {
+        throw new Error("tab export content missing");
+      }
+      const previews = [];
+      for (let index = 0; index < 32; index += 1) {
+        previews.push(
+          await callMethod(methods.get("workspaces.import.preview")!, {
+            workspaceId: "default",
+            content,
+          }),
+        );
+      }
+      const firstPreviewId = (previews[0]?.response?.[1] as { previewId?: string } | undefined)
+        ?.previewId;
+
+      options.teamsDomainId = "domain-b";
+      options.principalId = "owner-b";
+      options.ownerPrincipalId = "owner-b";
+      await callMethod(methods.get("workspaces.import.preview")!, {
+        workspaceId: "default",
+        content,
+      });
+
+      options.teamsDomainId = "domain-a";
+      options.principalId = "owner-a";
+      options.ownerPrincipalId = "owner-a";
+      const committed = await callMethod(methods.get("workspaces.import.commit")!, {
+        workspaceId: "default",
+        previewId: firstPreviewId,
+        approved: true,
+      });
+
+      expect(committed.response?.[0]).toBe(true);
+      storeA.close();
+      storeB.close();
     });
   });
 
@@ -392,6 +484,9 @@ describe("workspace gateway methods", () => {
         },
         { actor: "user" },
       );
+      vi.mocked(api.teams.resources.listChildren).mockResolvedValue([
+        { namespace: "workspaces", type: "tab", id: "main" },
+      ]);
       registerWorkspaceGatewayMethods({ api, store, storeForDomain: () => store });
 
       const method = methods.get("workspaces.sharing.sync")!;
@@ -414,7 +509,7 @@ describe("workspace gateway methods", () => {
           ]),
         },
       ]);
-      expect(api.teams.resources.prepareRegister).toHaveBeenCalledTimes(store.read().tabs.length);
+      expect(api.teams.resources.prepareRegister).toHaveBeenCalledTimes(1);
       expect(api.teams.resources.prepareRegister).toHaveBeenCalledWith(
         expect.objectContaining({
           resource: { namespace: "workspaces", type: "tab", id: "finance" },
@@ -423,7 +518,7 @@ describe("workspace gateway methods", () => {
           idempotencyKey: "sharing-sync:default:finance",
         }),
       );
-      expect(api.teams.resources.replayPrepared).toHaveBeenCalledTimes(store.read().tabs.length);
+      expect(api.teams.resources.replayPrepared).toHaveBeenCalledTimes(1);
       store.close();
     });
   });

--- a/extensions/workspaces/src/gateway.test.ts
+++ b/extensions/workspaces/src/gateway.test.ts
@@ -114,6 +114,10 @@ describe("workspace gateway methods", () => {
     expect([...methods.keys()]).toEqual([
       "workspaces.get",
       "workspaces.tab.get",
+      "workspaces.export",
+      "workspaces.tab.export",
+      "workspaces.import.preview",
+      "workspaces.import.commit",
       "workspaces.sharing.sync",
       "workspaces.widget.frame",
       "workspaces.tab.create",
@@ -145,6 +149,18 @@ describe("workspace gateway methods", () => {
     });
     expect(methods.get("workspaces.widget.frame")?.opts).toEqual({ scope: "operator.read" });
     expect(methods.get("workspaces.data.read")?.opts).toEqual({ scope: "operator.read" });
+    expect(methods.get("workspaces.tab.export")?.opts).toMatchObject({
+      scope: "operator.read",
+      access: { kind: "resource", member: true, permission: "workspaces.tab.read" },
+    });
+    expect(methods.get("workspaces.import.preview")?.opts).toMatchObject({
+      scope: "operator.write",
+      access: { permission: "workspaces.workspace.manageSharing" },
+    });
+    expect(methods.get("workspaces.import.commit")?.opts).toMatchObject({
+      scope: "operator.approvals",
+      access: { permission: "workspaces.workspace.manageSharing" },
+    });
     expect(methods.get("workspaces.tab.update")?.opts).toMatchObject({
       scope: "operator.write",
       access: { kind: "resource", permission: "workspaces.tab.write" },
@@ -157,6 +173,8 @@ describe("workspace gateway methods", () => {
     const readOnly = new Set([
       "workspaces.get",
       "workspaces.tab.get",
+      "workspaces.export",
+      "workspaces.tab.export",
       "workspaces.widget.frame",
       "workspaces.data.read",
     ]);
@@ -175,6 +193,184 @@ describe("workspace gateway methods", () => {
       }
       expect(method.opts).toEqual({ scope: "operator.write" });
     }
+  });
+
+  it("exports an exact shared tab without letting request parameters widen its grant", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const { api, methods } = createApi({ teamsDomainId: "domain-1" });
+      const store = new WorkspaceStore({ stateDir, isolationDomainId: "domain-1" });
+      registerWorkspaceGatewayMethods({ api, store, storeForDomain: () => store });
+      const method = methods.get("workspaces.tab.export")!;
+      const resources = await method.opts?.access?.resolveResources?.({
+        params: { workspaceId: "default", tabId: "main" },
+      } as never);
+
+      expect(resources).toEqual([{ namespace: "workspaces", type: "tab", id: "main" }]);
+      const result = await callMethod(method, { workspaceId: "default", tabId: "main" });
+      const payload = result.response?.[1] as { content: string };
+      expect(result.response?.[0]).toBe(true);
+      expect(payload.content).toContain('"format": "openclaw-workspaces"');
+      expect(payload.content).not.toContain('"id": "main"');
+      expect(payload.content).not.toContain("createdBy");
+      store.close();
+    });
+  });
+
+  it("stages an owner-bound import and mutates only after explicit approval", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const { api, methods } = createApi({
+        teamsDomainId: "domain-1",
+        principalId: "owner-1",
+        ownerPrincipalId: "owner-1",
+      });
+      const store = new WorkspaceStore({ stateDir, isolationDomainId: "domain-1" });
+      registerWorkspaceGatewayMethods({ api, store, storeForDomain: () => store });
+      const exported = await callMethod(methods.get("workspaces.tab.export")!, {
+        workspaceId: "default",
+        tabId: "main",
+      });
+      const content = (exported.response?.[1] as { content?: string } | undefined)?.content;
+      expect(content).toBeTypeOf("string");
+      if (!content) {
+        throw new Error("tab export content missing");
+      }
+
+      const preview = await callMethod(methods.get("workspaces.import.preview")!, {
+        workspaceId: "default",
+        content,
+      });
+      const previewPayload = preview.response?.[1] as {
+        previewId: string;
+        summary: { tabs: number; widgets: number; customWidgets: number };
+        tabs: Array<{ slug: string }>;
+      };
+      expect(preview.response?.[0]).toBe(true);
+      expect(previewPayload.summary).toEqual({
+        tabs: 1,
+        widgets: store.read().tabs[0]!.widgets.length,
+        customWidgets: 0,
+      });
+      expect(previewPayload.tabs).toEqual([expect.objectContaining({ slug: "main-2" })]);
+      expect(store.read().tabs).toHaveLength(1);
+
+      const declined = await callMethod(methods.get("workspaces.import.commit")!, {
+        workspaceId: "default",
+        previewId: previewPayload.previewId,
+        approved: false,
+      });
+      expect(declined.response?.[0]).toBe(false);
+      expect(store.read().tabs).toHaveLength(1);
+
+      const committed = await callMethod(methods.get("workspaces.import.commit")!, {
+        workspaceId: "default",
+        previewId: previewPayload.previewId,
+        approved: true,
+      });
+      expect(committed.response?.[0]).toBe(true);
+      expect(store.read().tabs).toHaveLength(2);
+      expect(store.read().tabs[1]).toMatchObject({ slug: "main-2", createdBy: "user" });
+      store.close();
+    });
+  });
+
+  it("does not evict a valid preview merely because the cache is at capacity", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const { api, methods } = createApi({
+        teamsDomainId: "domain-capacity",
+        principalId: "owner-capacity",
+        ownerPrincipalId: "owner-capacity",
+      });
+      const store = new WorkspaceStore({ stateDir, isolationDomainId: "domain-capacity" });
+      registerWorkspaceGatewayMethods({ api, store, storeForDomain: () => store });
+      const exported = await callMethod(methods.get("workspaces.tab.export")!, {
+        workspaceId: "default",
+        tabId: "main",
+      });
+      const content = (exported.response?.[1] as { content?: string } | undefined)?.content;
+      if (!content) {
+        throw new Error("tab export content missing");
+      }
+
+      const previews = [];
+      for (let index = 0; index < 32; index += 1) {
+        previews.push(
+          await callMethod(methods.get("workspaces.import.preview")!, {
+            workspaceId: "default",
+            content,
+          }),
+        );
+      }
+      const firstPreviewId = (previews[0]?.response?.[1] as { previewId?: string } | undefined)
+        ?.previewId;
+      expect(firstPreviewId).toBeTypeOf("string");
+
+      const committed = await callMethod(methods.get("workspaces.import.commit")!, {
+        workspaceId: "default",
+        previewId: firstPreviewId,
+        approved: true,
+      });
+
+      expect(committed.response?.[0]).toBe(true);
+      store.close();
+    });
+  });
+
+  it("rejects import commit by a different owner or after the workspace version changes", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const owner = createApi({
+        teamsDomainId: "domain-1",
+        principalId: "owner-1",
+        ownerPrincipalId: "owner-1",
+      });
+      const store = new WorkspaceStore({ stateDir, isolationDomainId: "domain-1" });
+      registerWorkspaceGatewayMethods({ api: owner.api, store, storeForDomain: () => store });
+      const exported = await callMethod(owner.methods.get("workspaces.tab.export")!, {
+        workspaceId: "default",
+        tabId: "main",
+      });
+      const content = (exported.response?.[1] as { content?: string } | undefined)?.content;
+      expect(content).toBeTypeOf("string");
+      if (!content) {
+        throw new Error("tab export content missing");
+      }
+      const preview = await callMethod(owner.methods.get("workspaces.import.preview")!, {
+        workspaceId: "default",
+        content,
+      });
+      const previewId = (preview.response?.[1] as { previewId?: string } | undefined)?.previewId;
+      expect(previewId).toBeTypeOf("string");
+      if (!previewId) {
+        throw new Error("import preview id missing");
+      }
+
+      store.mutate(
+        (draft) => {
+          draft.tabs[0]!.title = "Changed after preview";
+        },
+        { actor: "user" },
+      );
+      const stale = await callMethod(owner.methods.get("workspaces.import.commit")!, {
+        workspaceId: "default",
+        previewId,
+        approved: true,
+      });
+      expect(stale.response?.[0]).toBe(false);
+      expect(stale.response?.[2]).toMatchObject({ message: expect.stringMatching(/changed/) });
+
+      const notOwner = createApi({
+        teamsDomainId: "domain-1",
+        principalId: "member-2",
+        ownerPrincipalId: "owner-1",
+      });
+      registerWorkspaceGatewayMethods({ api: notOwner.api, store, storeForDomain: () => store });
+      const denied = await callMethod(notOwner.methods.get("workspaces.import.preview")!, {
+        workspaceId: "default",
+        content,
+      });
+      expect(denied.response?.[0]).toBe(false);
+      expect(denied.response?.[2]).toMatchObject({ message: expect.stringMatching(/owner/) });
+      store.close();
+    });
   });
 
   it("lets the domain owner idempotently register the plugin-owned tab inventory", async () => {
@@ -603,7 +799,10 @@ describe("workspace gateway methods", () => {
 
       const read = await callMethod(methods.get("workspaces.get")!, {}, broadcast);
       expect(read.response?.[0]).toBe(true);
-      expect(read.response?.[1]).toMatchObject({ workspaceVersion: 1 });
+      expect(read.response?.[1]).toMatchObject({
+        workspaceVersion: 1,
+        distributionAccess: { owner: true },
+      });
       expect(broadcast).not.toHaveBeenCalled();
 
       // Provenance is derived from the caller. An RPC client must not be able to
@@ -636,6 +835,24 @@ describe("workspace gateway methods", () => {
         changedTabSlug: "finance-ops",
         actor: "user",
       });
+    });
+  });
+
+  it("reports resource-specific distribution ownership for a Teams member", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const { api, methods } = createApi({
+        teamsDomainId: "domain-member",
+        principalId: "principal-member",
+        ownerPrincipalId: "principal-owner",
+      });
+      const store = new WorkspaceStore({ stateDir });
+      registerWorkspaceGatewayMethods({ api, store });
+
+      const read = await callMethod(methods.get("workspaces.get")!, {});
+
+      expect(read.response?.[0]).toBe(true);
+      expect(read.response?.[1]).toMatchObject({ distributionAccess: { owner: false } });
+      store.close();
     });
   });
 

--- a/extensions/workspaces/src/gateway.test.ts
+++ b/extensions/workspaces/src/gateway.test.ts
@@ -21,9 +21,65 @@ async function withTempStateDir<T>(run: (stateDir: string) => Promise<T>): Promi
   }
 }
 
-function createApi() {
+function createApi(
+  options: {
+    teamsDomainId?: string;
+    principalId?: string;
+    ownerPrincipalId?: string;
+    capabilityMode?: "read" | "request" | "write";
+  } = {},
+) {
   const methods = new Map<string, RegisteredMethod>();
   const api = {
+    teams: {
+      context: {
+        require: vi.fn(() => {
+          if (!options.teamsDomainId) {
+            throw new Error("no Teams context");
+          }
+          return {
+            isolationDomainId: options.teamsDomainId,
+            principal: { id: options.principalId ?? "principal-member", kind: "human" as const },
+            requestId: "request-1",
+          };
+        }),
+      },
+      authorization: {
+        decide: vi.fn(async ({ permission }: { permission: string }) => {
+          const mode = options.capabilityMode ?? "read";
+          const allowed =
+            permission === "workspaces.tab.read" ||
+            (permission === "workspaces.tab.changeRequest.create" && mode !== "read") ||
+            (permission === "workspaces.tab.write" && mode === "write");
+          return allowed
+            ? {
+                allowed: true as const,
+                context: {
+                  isolationDomainId: options.teamsDomainId ?? "domain-1",
+                  principal: {
+                    id: options.principalId ?? "principal-member",
+                    kind: "human" as const,
+                  },
+                  requestId: "capability-check",
+                },
+              }
+            : { allowed: false as const };
+        }),
+      },
+      resources: {
+        listChildren: vi.fn(async () => []),
+        prepareRegister: vi.fn(
+          async ({ resource }: { resource: { id: string } }) => `operation-${resource.id}`,
+        ),
+        prepareRetire: vi.fn(
+          async ({ resource }: { resource: { id: string } }) => `retire-operation-${resource.id}`,
+        ),
+        replayPrepared: vi.fn(async () => undefined),
+        owner: vi.fn(async () => ({
+          principalId: options.ownerPrincipalId ?? options.principalId ?? "principal-member",
+        })),
+      },
+    },
     registerGatewayMethod: vi.fn(
       (method: string, handler: RegisteredMethod["handler"], opts: RegisteredMethod["opts"]) => {
         methods.set(method, { handler, opts });
@@ -57,9 +113,16 @@ describe("workspace gateway methods", () => {
 
     expect([...methods.keys()]).toEqual([
       "workspaces.get",
+      "workspaces.tab.get",
+      "workspaces.sharing.sync",
       "workspaces.widget.frame",
       "workspaces.tab.create",
       "workspaces.tab.update",
+      "workspaces.changeRequest.create",
+      "workspaces.changeRequest.list",
+      "workspaces.changeRequest.get",
+      "workspaces.changeRequest.cancel",
+      "workspaces.changeRequest.decide",
       "workspaces.tab.delete",
       "workspaces.tab.reorder",
       "workspaces.widget.add",
@@ -73,21 +136,463 @@ describe("workspace gateway methods", () => {
       "workspaces.undo",
       "workspaces.data.read",
     ]);
-    expect(methods.get("workspaces.get")?.opts).toEqual({ scope: "operator.read" });
+    expect(methods.get("workspaces.get")?.opts).toMatchObject({
+      scope: "operator.read",
+      access: {
+        kind: "resource",
+        permission: "workspaces.workspace.read",
+      },
+    });
     expect(methods.get("workspaces.widget.frame")?.opts).toEqual({ scope: "operator.read" });
     expect(methods.get("workspaces.data.read")?.opts).toEqual({ scope: "operator.read" });
+    expect(methods.get("workspaces.tab.update")?.opts).toMatchObject({
+      scope: "operator.write",
+      access: { kind: "resource", permission: "workspaces.tab.write" },
+    });
     // Approving agent-authored code is an approvals decision: operator.write alone
     // must not be enough to mount an untrusted widget.
     expect(methods.get("workspaces.widget.approve")?.opts).toEqual({
       scope: "operator.approvals",
     });
-    const readOnly = new Set(["workspaces.get", "workspaces.widget.frame", "workspaces.data.read"]);
+    const readOnly = new Set([
+      "workspaces.get",
+      "workspaces.tab.get",
+      "workspaces.widget.frame",
+      "workspaces.data.read",
+    ]);
     for (const [name, method] of methods) {
-      if (readOnly.has(name) || name === "workspaces.widget.approve") {
+      if (method.opts?.access) {
+        continue;
+      }
+      if (
+        readOnly.has(name) ||
+        name === "workspaces.widget.approve" ||
+        name === "workspaces.get" ||
+        name === "workspaces.tab.get" ||
+        name === "workspaces.tab.update"
+      ) {
         continue;
       }
       expect(method.opts).toEqual({ scope: "operator.write" });
     }
+  });
+
+  it("lets the domain owner idempotently register the plugin-owned tab inventory", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const { api, methods } = createApi({ teamsDomainId: "domain-1" });
+      const store = new WorkspaceStore({ stateDir, isolationDomainId: "domain-1" });
+      store.mutate(
+        (draft) => {
+          draft.tabs.push({
+            id: "finance",
+            revision: 1,
+            slug: "finance",
+            title: "Finance",
+            hidden: false,
+            createdBy: "user",
+            widgets: [],
+          });
+          draft.prefs.tabOrder.push("finance");
+        },
+        { actor: "user" },
+      );
+      registerWorkspaceGatewayMethods({ api, store, storeForDomain: () => store });
+
+      const method = methods.get("workspaces.sharing.sync")!;
+      expect(method.opts).toMatchObject({
+        access: {
+          kind: "resource",
+          member: true,
+          permission: "workspaces.workspace.manageSharing",
+        },
+      });
+      const result = await callMethod(method, { workspaceId: "default" });
+
+      expect(result.response).toEqual([
+        true,
+        {
+          workspaceId: "default",
+          tabs: expect.arrayContaining([
+            expect.objectContaining({ id: "main", title: "Overview" }),
+            { id: "finance", revision: 1, slug: "finance", title: "Finance" },
+          ]),
+        },
+      ]);
+      expect(api.teams.resources.prepareRegister).toHaveBeenCalledTimes(store.read().tabs.length);
+      expect(api.teams.resources.prepareRegister).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: { namespace: "workspaces", type: "tab", id: "finance" },
+          parent: { namespace: "workspaces", type: "workspace", id: "default" },
+          requiredAction: "workspaces.workspace.manageSharing",
+          idempotencyKey: "sharing-sync:default:finance",
+        }),
+      );
+      expect(api.teams.resources.replayPrepared).toHaveBeenCalledTimes(store.read().tabs.length);
+      store.close();
+    });
+  });
+
+  it("retires authorization children that no longer exist in the workspace snapshot", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const { api, methods } = createApi({ teamsDomainId: "domain-1" });
+      vi.mocked(api.teams.resources.listChildren).mockResolvedValue([
+        { namespace: "workspaces", type: "tab", id: "main" },
+        { namespace: "workspaces", type: "tab", id: "deleted-tab" },
+      ]);
+      const store = new WorkspaceStore({ stateDir, isolationDomainId: "domain-1" });
+      registerWorkspaceGatewayMethods({ api, store, storeForDomain: () => store });
+
+      const result = await callMethod(methods.get("workspaces.sharing.sync")!, {
+        workspaceId: "default",
+      });
+
+      expect(result.response?.[0]).toBe(true);
+      expect(api.teams.resources.prepareRetire).toHaveBeenCalledWith({
+        context: expect.any(Object),
+        resource: { namespace: "workspaces", type: "tab", id: "deleted-tab" },
+        parent: { namespace: "workspaces", type: "workspace", id: "default" },
+        requiredAction: "workspaces.workspace.manageSharing",
+        idempotencyKey: "sharing-sync-retire:default:deleted-tab",
+      });
+      expect(api.teams.resources.replayPrepared).toHaveBeenCalledWith({
+        operation: "retire-operation-deleted-tab",
+      });
+      store.close();
+    });
+  });
+
+  it("resource-binds exact tab reads and returns no unrelated workspace state", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const { api, methods } = createApi({ teamsDomainId: "domain-1" });
+      const store = new WorkspaceStore({ stateDir, isolationDomainId: "domain-1" });
+      registerWorkspaceGatewayMethods({
+        api,
+        store,
+        storeForDomain: (domainId) =>
+          domainId === "domain-1"
+            ? store
+            : new WorkspaceStore({ stateDir, isolationDomainId: domainId }),
+      });
+      const method = methods.get("workspaces.tab.get")!;
+      expect(method.opts).toMatchObject({
+        scope: "operator.read",
+        access: {
+          kind: "resource",
+          permission: "workspaces.tab.read",
+        },
+      });
+      const access = method.opts?.access;
+      if (access?.kind !== "resource") {
+        throw new Error("expected resource access policy");
+      }
+      expect(
+        await access.resolveResources({
+          method: "workspaces.tab.get",
+          params: { workspaceId: "default", id: "main" },
+          config: {},
+        }),
+      ).toEqual([{ namespace: "workspaces", type: "tab", id: "main" }]);
+
+      const read = await callMethod(method, { workspaceId: "default", id: "main" });
+      expect(read.response).toEqual([
+        true,
+        {
+          workspaceId: "default",
+          workspaceVersion: 1,
+          capabilityMode: "read",
+          tab: expect.objectContaining({ id: "main", revision: 1, slug: "main" }),
+        },
+      ]);
+      expect(read.response?.[1]).not.toHaveProperty("widgetsRegistry");
+      expect(read.response?.[1]).not.toHaveProperty("tabs");
+
+      const missing = await callMethod(method, { workspaceId: "default", id: "missing" });
+      expect(missing.response?.[0]).toBe(false);
+      expect(missing.response?.[2]).toMatchObject({ code: "workspace_not_found" });
+      expect(missing.response?.[2]?.message).toBe("workspace tab not found");
+
+      const missingRevision = await callMethod(methods.get("workspaces.tab.update")!, {
+        workspaceId: "default",
+        id: "main",
+        patch: { title: "Unsafe overwrite" },
+      });
+      expect(missingRevision.response?.[0]).toBe(false);
+      expect(missingRevision.response?.[2]?.message).toBe("ifRevision must be a positive integer");
+      expect(store.read().tabs[0]?.title).not.toBe("Unsafe overwrite");
+
+      const updated = await callMethod(methods.get("workspaces.tab.update")!, {
+        workspaceId: "default",
+        id: "main",
+        ifRevision: 1,
+        patch: { title: "Member edit" },
+      });
+      expect(updated.response?.[0]).toBe(true);
+      expect(updated.response?.[1]).toMatchObject({
+        workspaceId: "default",
+        tab: expect.objectContaining({ id: "main", revision: 2, title: "Member edit" }),
+      });
+      expect(updated.response?.[1]).not.toHaveProperty("doc");
+      expect(updated.broadcast).not.toHaveBeenCalled();
+      const stale = await callMethod(methods.get("workspaces.tab.update")!, {
+        workspaceId: "default",
+        id: "main",
+        ifRevision: 1,
+        patch: { title: "Stale edit" },
+      });
+      expect(stale.response?.[0]).toBe(false);
+      expect(stale.response?.[2]).toMatchObject({ code: "workspace_conflict" });
+      expect(store.read().tabs[0]?.title).toBe("Member edit");
+
+      const current = store.read().tabs[0]!;
+      const proposal = {
+        slug: current.slug,
+        title: "Requested edit",
+        ...(current.icon ? { icon: current.icon } : {}),
+        hidden: current.hidden,
+        widgets: current.widgets.map(({ createdBy: _createdBy, ...widget }) => widget),
+      };
+      const createdRequest = await callMethod(methods.get("workspaces.changeRequest.create")!, {
+        workspaceId: "default",
+        tabId: "main",
+        baseRevision: 2,
+        proposal,
+        idempotencyKey: "request-1",
+      });
+      expect(createdRequest.response?.[0]).toBe(true);
+      const requestId = createdRequest.response?.[1]?.request.id as string;
+      const listed = await callMethod(methods.get("workspaces.changeRequest.list")!, {
+        workspaceId: "default",
+        tabId: "main",
+        state: "pending",
+      });
+      expect(listed.response?.[1]?.requests).toEqual([
+        expect.objectContaining({ id: requestId, state: "pending", tabId: "main" }),
+      ]);
+      const decided = await callMethod(methods.get("workspaces.changeRequest.decide")!, {
+        workspaceId: "default",
+        tabId: "main",
+        requestId,
+        decision: "approved",
+      });
+      expect(decided.response?.[0]).toBe(true);
+      expect(decided.response?.[1]).toMatchObject({
+        applied: true,
+        request: { id: requestId, state: "approved" },
+        tab: { id: "main", revision: 3, title: "Requested edit" },
+      });
+      expect(decided.response?.[1]).not.toHaveProperty("doc");
+      store.close();
+    });
+  });
+
+  it("projects member-safe widgets and the strongest exact-tab capability", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const { api, methods } = createApi({
+        teamsDomainId: "domain-1",
+        capabilityMode: "request",
+      });
+      const store = new WorkspaceStore({ stateDir, isolationDomainId: "domain-1" });
+      store.mutate(
+        (draft) => {
+          draft.tabs[0]!.widgets = [
+            {
+              id: "safe",
+              kind: "builtin:markdown",
+              title: "Safe",
+              grid: { x: 0, y: 0, w: 6, h: 4 },
+              collapsed: false,
+              hidden: false,
+              createdBy: "user",
+              bindings: { copy: { source: "static", value: "hello" } },
+              props: { markdown: "hello" },
+            },
+            {
+              id: "file-backed",
+              kind: "builtin:table",
+              title: "Private file",
+              grid: { x: 6, y: 0, w: 6, h: 4 },
+              collapsed: false,
+              hidden: false,
+              createdBy: "user",
+              bindings: { rows: { source: "file", path: "private.json" } },
+            },
+            {
+              id: "custom",
+              kind: "custom:private-dashboard",
+              title: "Private custom",
+              grid: { x: 0, y: 4, w: 12, h: 4 },
+              collapsed: false,
+              hidden: false,
+              createdBy: "user",
+              props: { secret: "do-not-project" },
+            },
+          ];
+        },
+        { actor: "user" },
+      );
+      registerWorkspaceGatewayMethods({ api, store, storeForDomain: () => store });
+
+      const read = await callMethod(methods.get("workspaces.tab.get")!, {
+        workspaceId: "default",
+        id: "main",
+      });
+
+      expect(read.response?.[0]).toBe(true);
+      expect(read.response?.[1]?.capabilityMode).toBe("request");
+      expect(read.response?.[1]?.tab.widgets[0]).toMatchObject({
+        id: "safe",
+        kind: "builtin:markdown",
+        bindings: { copy: { source: "static", value: "hello" } },
+      });
+      const projected = JSON.stringify(read.response?.[1]?.tab.widgets);
+      expect(projected).not.toContain("private.json");
+      expect(projected).not.toContain("custom:private-dashboard");
+      expect(projected).not.toContain("do-not-project");
+      expect(read.response?.[1]?.tab.widgets[1]).toMatchObject({
+        id: "file-backed",
+        kind: "builtin:markdown",
+      });
+      expect(read.response?.[1]?.tab.widgets[2]).toMatchObject({
+        id: "custom",
+        kind: "builtin:markdown",
+      });
+      store.close();
+    });
+  });
+
+  it("expands a limited portal proposal without replacing hidden widget state", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const { api, methods } = createApi({
+        teamsDomainId: "domain-1",
+        capabilityMode: "request",
+        ownerPrincipalId: "principal-owner",
+      });
+      const store = new WorkspaceStore({ stateDir, isolationDomainId: "domain-1" });
+      store.mutate(
+        (draft) => {
+          draft.tabs[0]!.widgets.push({
+            id: "private-custom",
+            kind: "custom:private-dashboard",
+            title: "Private",
+            grid: { x: 0, y: 0, w: 12, h: 4 },
+            collapsed: false,
+            hidden: false,
+            createdBy: "user",
+            props: { secret: "preserve-me" },
+          });
+        },
+        { actor: "user" },
+      );
+      registerWorkspaceGatewayMethods({ api, store, storeForDomain: () => store });
+
+      const created = await callMethod(methods.get("workspaces.changeRequest.create")!, {
+        workspaceId: "default",
+        tabId: "main",
+        baseRevision: 2,
+        proposal: { title: "Requested title" },
+        idempotencyKey: "limited-proposal-1",
+      });
+      expect(created.response?.[0]).toBe(true);
+      const requestId = created.response?.[1]?.request.id as string;
+      expect(JSON.stringify(created.response?.[1]?.request)).not.toContain("preserve-me");
+      expect(created.response?.[1]?.request).not.toHaveProperty("proposalSha256");
+      expect(created.response?.[1]?.request.proposal.widgets).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: "private-custom",
+            kind: "builtin:markdown",
+          }),
+        ]),
+      );
+      expect(store.readChangeRequest(requestId)?.proposal).toMatchObject({
+        title: "Requested title",
+        widgets: expect.arrayContaining([
+          expect.objectContaining({
+            id: "private-custom",
+            kind: "custom:private-dashboard",
+            props: { secret: "preserve-me" },
+          }),
+        ]),
+      });
+
+      const listed = await callMethod(methods.get("workspaces.changeRequest.list")!, {
+        workspaceId: "default",
+        tabId: "main",
+        state: "pending",
+      });
+      expect(JSON.stringify(listed.response?.[1]?.requests)).not.toContain("preserve-me");
+
+      const { api: ownerApi, methods: ownerMethods } = createApi({
+        teamsDomainId: "domain-1",
+        principalId: "principal-owner",
+        ownerPrincipalId: "principal-owner",
+      });
+      registerWorkspaceGatewayMethods({ api: ownerApi, store, storeForDomain: () => store });
+      const ownerListed = await callMethod(ownerMethods.get("workspaces.changeRequest.list")!, {
+        workspaceId: "default",
+        tabId: "main",
+        state: "pending",
+      });
+      expect(JSON.stringify(ownerListed.response?.[1]?.requests)).toContain("preserve-me");
+
+      const decided = await callMethod(ownerMethods.get("workspaces.changeRequest.decide")!, {
+        workspaceId: "default",
+        tabId: "main",
+        requestId,
+        decision: "approved",
+      });
+      expect(decided.response?.[0]).toBe(true);
+      expect(store.read().tabs[0]).toMatchObject({
+        title: "Requested title",
+        widgets: expect.arrayContaining([
+          expect.objectContaining({
+            id: "private-custom",
+            kind: "custom:private-dashboard",
+            props: { secret: "preserve-me" },
+          }),
+        ]),
+      });
+      store.close();
+    });
+  });
+
+  it("does not let a different human owner approve the canonical owner's tab request", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const { api, methods } = createApi({
+        teamsDomainId: "domain-1",
+        principalId: "principal-domain-owner",
+        ownerPrincipalId: "principal-tab-owner",
+      });
+      const store = new WorkspaceStore({ stateDir, isolationDomainId: "domain-1" });
+      const tab = store.read().tabs[0]!;
+      const proposal = {
+        slug: tab.slug,
+        title: "Proposal",
+        ...(tab.icon ? { icon: tab.icon } : {}),
+        hidden: tab.hidden,
+        widgets: tab.widgets.map(({ createdBy: _createdBy, ...widget }) => widget),
+      };
+      const request = store.createChangeRequest({
+        id: "request-1",
+        tabId: tab.id,
+        requester: { principalId: "principal-member", kind: "human" },
+        baseTabRevision: tab.revision,
+        idempotencyKey: "request-1",
+        proposal,
+      });
+      registerWorkspaceGatewayMethods({ api, store, storeForDomain: () => store });
+
+      const denied = await callMethod(methods.get("workspaces.changeRequest.decide")!, {
+        workspaceId: "default",
+        tabId: tab.id,
+        requestId: request.id,
+        decision: "approved",
+      });
+      expect(denied.response?.[0]).toBe(false);
+      expect(denied.response?.[2]?.message).toMatch(/canonical human owner/i);
+      expect(store.readChangeRequest(request.id)?.state).toBe("pending");
+      store.close();
+    });
   });
 
   it("returns the workspace without broadcasting and broadcasts successful writes", async () => {

--- a/extensions/workspaces/src/gateway.ts
+++ b/extensions/workspaces/src/gateway.ts
@@ -8,6 +8,11 @@ import type {
   WorkspaceTabProposal,
 } from "./change-requests.js";
 import { resolveBinding, type ResolveBindingOptions } from "./data-read.js";
+import {
+  prepareWorkspaceImport,
+  serializeWorkspaceDistribution,
+  type PreparedWorkspaceImport,
+} from "./distribution.js";
 import { snapshotApprovedWidget } from "./manifest.js";
 import { scaffoldWorkspaceWidget } from "./scaffold.js";
 import type {
@@ -48,6 +53,16 @@ type WorkspaceGatewayMethodOptions = {
   storeForDomain?: (isolationDomainId: string) => WorkspaceStore;
   dataRead?: ResolveBindingOptions;
 };
+
+type PendingWorkspaceImport = PreparedWorkspaceImport & {
+  isolationDomainId: string;
+  ownerPrincipalId: string;
+  workspaceId: string;
+  expiresAt: number;
+};
+
+const WORKSPACE_IMPORT_PREVIEW_TTL_MS = 10 * 60_000;
+const MAX_PENDING_WORKSPACE_IMPORTS = 32;
 
 function respondError(respond: GatewayRespond, error: unknown) {
   const code =
@@ -467,6 +482,77 @@ export function registerWorkspaceGatewayMethods(options: WorkspaceGatewayMethodO
   const { api } = options;
   const store = options.store ?? new WorkspaceStore();
   const storeForDomain = options.storeForDomain ?? (() => store);
+  const pendingImports = new Map<string, PendingWorkspaceImport>();
+
+  const workspaceAccess = (permission: string, allowedKeys: readonly string[]) => ({
+    kind: "resource" as const,
+    member: true,
+    permission,
+    resolveResources: ({ params }: { params: unknown }) => {
+      const record = readParams(params, allowedKeys);
+      return [
+        {
+          namespace: "workspaces" as const,
+          type: "workspace" as const,
+          id: readResourceId(record, "workspaceId"),
+        },
+      ];
+    },
+  });
+
+  const resolveCanonicalOwner = async (workspaceId: string) => {
+    let teamsContext: TeamsRequestContext | undefined;
+    try {
+      teamsContext = api.teams.context.require();
+    } catch {
+      // A local operator connection predates Teams identities. Its approvals
+      // scope is the explicit local-owner gate; no remote member can enter here.
+    }
+    if (!teamsContext) {
+      if (workspaceId !== store.workspaceId) {
+        throw workspaceTabNotFound();
+      }
+      return {
+        context: undefined,
+        ownerPrincipalId: "local-operator",
+        isolationDomainId: store.isolationDomainId,
+        targetStore: store,
+      };
+    }
+    const targetStore = storeForDomain(teamsContext.isolationDomainId);
+    if (workspaceId !== targetStore.workspaceId || teamsContext.principal.kind !== "human") {
+      throw workspaceTabNotFound();
+    }
+    const resource = { namespace: "workspaces", type: "workspace", id: workspaceId } as const;
+    const owner = await api.teams.resources.owner({ context: teamsContext, resource });
+    if (owner.principalId !== teamsContext.principal.id) {
+      throw new Error("workspace distribution requires the canonical human owner");
+    }
+    return {
+      context: teamsContext,
+      ownerPrincipalId: owner.principalId,
+      isolationDomainId: teamsContext.isolationDomainId,
+      targetStore,
+    };
+  };
+
+  const prunePendingImports = (now: number, reserveSlot: boolean) => {
+    for (const [id, pending] of pendingImports) {
+      if (pending.expiresAt <= now) {
+        pendingImports.delete(id);
+      }
+    }
+    const maximumSize = reserveSlot
+      ? MAX_PENDING_WORKSPACE_IMPORTS - 1
+      : MAX_PENDING_WORKSPACE_IMPORTS;
+    while (pendingImports.size > maximumSize) {
+      const oldest = pendingImports.keys().next().value as string | undefined;
+      if (!oldest) {
+        break;
+      }
+      pendingImports.delete(oldest);
+    }
+  };
 
   api.registerGatewayMethod(
     "workspaces.get",
@@ -478,8 +564,9 @@ export function registerWorkspaceGatewayMethods(options: WorkspaceGatewayMethodO
             ? store.workspaceId
             : readResourceId(params, "workspaceId");
         let readableStore = store;
+        let teamsContext: TeamsRequestContext | undefined;
         try {
-          const teamsContext = api.teams.context.require();
+          teamsContext = api.teams.context.require();
           readableStore = storeForDomain(teamsContext.isolationDomainId);
         } catch {
           // Legacy operator requests have no isolated Teams context.
@@ -489,7 +576,19 @@ export function registerWorkspaceGatewayMethods(options: WorkspaceGatewayMethodO
         if (doc.workspaceId !== workspaceId) {
           throw workspaceTabNotFound();
         }
-        respond(true, { doc, workspaceVersion: doc.workspaceVersion });
+        let distributionOwner = true;
+        if (teamsContext) {
+          const resource = { namespace: "workspaces", type: "workspace", id: workspaceId } as const;
+          const owner = await api.teams.resources.owner({ context: teamsContext, resource });
+          distributionOwner =
+            teamsContext.principal.kind === "human" &&
+            owner.principalId === teamsContext.principal.id;
+        }
+        respond(true, {
+          doc,
+          workspaceVersion: doc.workspaceVersion,
+          distributionAccess: { owner: distributionOwner },
+        });
       } catch (error) {
         respondError(respond, error);
       }
@@ -565,6 +664,167 @@ export function registerWorkspaceGatewayMethods(options: WorkspaceGatewayMethodO
           return [{ namespace: "workspaces", type: "tab", id: exact.id }];
         },
       },
+    },
+  );
+
+  api.registerGatewayMethod(
+    "workspaces.export",
+    async ({ params: rawParams, respond }) => {
+      try {
+        const params = readParams(rawParams, ["workspaceId"]);
+        const workspaceId = readResourceId(params, "workspaceId");
+        const owner = await resolveCanonicalOwner(workspaceId);
+        const doc = owner.targetStore.read();
+        respond(true, {
+          filename: `openclaw-workspaces-${new Date().toISOString().replace(/[:.]/g, "-")}.json`,
+          content: serializeWorkspaceDistribution(doc),
+          summary: {
+            tabs: doc.tabs.length,
+            widgets: doc.tabs.reduce((total, tab) => total + tab.widgets.length, 0),
+          },
+        });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    {
+      scope: READ_SCOPE,
+      access: workspaceAccess("workspaces.workspace.read", ["workspaceId"]),
+    },
+  );
+
+  api.registerGatewayMethod(
+    "workspaces.tab.export",
+    async ({ params: rawParams, respond }) => {
+      try {
+        const params = readParams(rawParams, ["workspaceId", "tabId"]);
+        const workspaceId = readResourceId(params, "workspaceId");
+        const tabId = readResourceId(params, "tabId");
+        const teamsContext = api.teams.context.require();
+        const targetStore = storeForDomain(teamsContext.isolationDomainId);
+        const doc = targetStore.read();
+        if (doc.workspaceId !== workspaceId || !doc.tabs.some((tab) => tab.id === tabId)) {
+          throw workspaceTabNotFound();
+        }
+        respond(true, {
+          filename: `openclaw-workspace-tab-${new Date().toISOString().replace(/[:.]/g, "-")}.json`,
+          content: serializeWorkspaceDistribution(doc, { tabIds: [tabId] }),
+        });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    {
+      scope: READ_SCOPE,
+      access: {
+        kind: "resource",
+        member: true,
+        permission: "workspaces.tab.read",
+        resolveResources: ({ params }) => {
+          const record = readParams(params, ["workspaceId", "tabId"]);
+          return [{ namespace: "workspaces", type: "tab", id: readResourceId(record, "tabId") }];
+        },
+      },
+    },
+  );
+
+  api.registerGatewayMethod(
+    "workspaces.import.preview",
+    async ({ params: rawParams, respond }) => {
+      try {
+        const params = readParams(rawParams, ["workspaceId", "content"]);
+        const workspaceId = readResourceId(params, "workspaceId");
+        const content = readRequiredString(params, "content", "content");
+        const owner = await resolveCanonicalOwner(workspaceId);
+        const prepared = prepareWorkspaceImport(content, owner.targetStore.read());
+        const now = Date.now();
+        prunePendingImports(now, true);
+        const previewId = randomUUID();
+        const expiresAt = now + WORKSPACE_IMPORT_PREVIEW_TTL_MS;
+        pendingImports.set(previewId, {
+          ...prepared,
+          isolationDomainId: owner.isolationDomainId,
+          ownerPrincipalId: owner.ownerPrincipalId,
+          workspaceId,
+          expiresAt,
+        });
+        respond(true, {
+          previewId,
+          workspaceId,
+          baseWorkspaceVersion: prepared.baseWorkspaceVersion,
+          expiresAt,
+          summary: prepared.summary,
+          tabs: prepared.tabs.map((tab) => ({
+            slug: tab.slug,
+            title: tab.title,
+            widgets: tab.widgets.length,
+            customWidgets: tab.widgets.filter((widget) => widget.kind.startsWith("custom:")).length,
+          })),
+        });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    {
+      scope: WRITE_SCOPE,
+      access: workspaceAccess("workspaces.workspace.manageSharing", ["workspaceId", "content"]),
+    },
+  );
+
+  api.registerGatewayMethod(
+    "workspaces.import.commit",
+    async (opts) => {
+      try {
+        const params = readParams(opts.params, ["workspaceId", "previewId", "approved"]);
+        const workspaceId = readResourceId(params, "workspaceId");
+        const previewId = readResourceId(params, "previewId");
+        if (params.approved !== true) {
+          throw new Error("workspace import requires explicit owner approval");
+        }
+        const owner = await resolveCanonicalOwner(workspaceId);
+        prunePendingImports(Date.now(), false);
+        const pending = pendingImports.get(previewId);
+        if (!pending) {
+          throw new Error("workspace import preview is missing or expired");
+        }
+        if (
+          pending.workspaceId !== workspaceId ||
+          pending.isolationDomainId !== owner.isolationDomainId ||
+          pending.ownerPrincipalId !== owner.ownerPrincipalId
+        ) {
+          throw new Error("workspace import preview belongs to a different owner or domain");
+        }
+        const result = owner.targetStore.mutate(
+          (draft) => {
+            if (draft.workspaceVersion !== pending.baseWorkspaceVersion) {
+              throw new Error("workspace changed after the import preview; create a new preview");
+            }
+            draft.tabs.push(...structuredClone(pending.tabs));
+            Object.assign(draft.widgetsRegistry, structuredClone(pending.registry));
+            draft.prefs.tabOrder.push(...pending.tabs.map((tab) => tab.slug));
+          },
+          { actor: RPC_ACTOR },
+        );
+        pendingImports.delete(previewId);
+        broadcastChange(opts.context.broadcast, { doc: result.doc, actor: RPC_ACTOR });
+        opts.respond(true, {
+          workspaceId,
+          workspaceVersion: result.doc.workspaceVersion,
+          imported: pending.summary,
+          tabIds: pending.tabs.map((tab) => tab.id),
+          sharingSyncRequired: true,
+        });
+      } catch (error) {
+        respondError(opts.respond, error);
+      }
+    },
+    {
+      scope: APPROVE_SCOPE,
+      access: workspaceAccess("workspaces.workspace.manageSharing", [
+        "workspaceId",
+        "previewId",
+        "approved",
+      ]),
     },
   );
 

--- a/extensions/workspaces/src/gateway.ts
+++ b/extensions/workspaces/src/gateway.ts
@@ -5,15 +5,14 @@ import { rememberWorkspaceBroadcast } from "./broadcast.js";
 import { resolveBinding, type ResolveBindingOptions } from "./data-read.js";
 import { snapshotApprovedWidget } from "./manifest.js";
 import { scaffoldWorkspaceWidget } from "./scaffold.js";
-import {
-  validateWorkspaceDoc,
-  type WorkspaceActor,
-  type WorkspaceBinding,
-  type WorkspaceGrid,
-  type WorkspaceTab,
-  type WorkspaceWidget,
-  type JsonValue,
-  type WorkspaceDoc,
+import type {
+  WorkspaceActor,
+  WorkspaceBinding,
+  WorkspaceGrid,
+  WorkspaceTab,
+  WorkspaceWidget,
+  JsonValue,
+  WorkspaceDoc,
 } from "./schema.js";
 import { WorkspaceStore } from "./store.js";
 
@@ -429,6 +428,8 @@ export function registerWorkspaceGatewayMethods(options: WorkspaceGatewayMethodO
               throw new Error(`workspace tab already exists: ${slug}`);
             }
             draft.tabs.push({
+              id: randomUUID(),
+              revision: 1,
               slug,
               title,
               ...(icon !== undefined ? { icon } : {}),
@@ -770,9 +771,8 @@ export function registerWorkspaceGatewayMethods(options: WorkspaceGatewayMethodO
     async (opts) => {
       try {
         const params = readParams(opts.params, ["doc"]);
-        const doc = validateWorkspaceDoc(params.doc);
         await respondWrite(opts, RPC_ACTOR, undefined, async () =>
-          store.replace(doc, { actor: RPC_ACTOR }),
+          store.replace(params.doc, { actor: RPC_ACTOR }),
         );
       } catch (error) {
         respondError(opts.respond, error);

--- a/extensions/workspaces/src/gateway.ts
+++ b/extensions/workspaces/src/gateway.ts
@@ -536,17 +536,25 @@ export function registerWorkspaceGatewayMethods(options: WorkspaceGatewayMethodO
     };
   };
 
-  const prunePendingImports = (now: number, reserveSlot: boolean) => {
+  const prunePendingImports = (
+    now: number,
+    reserveSlotFor?: { isolationDomainId: string; ownerPrincipalId: string },
+  ) => {
     for (const [id, pending] of pendingImports) {
       if (pending.expiresAt <= now) {
         pendingImports.delete(id);
       }
     }
-    const maximumSize = reserveSlot
-      ? MAX_PENDING_WORKSPACE_IMPORTS - 1
-      : MAX_PENDING_WORKSPACE_IMPORTS;
-    while (pendingImports.size > maximumSize) {
-      const oldest = pendingImports.keys().next().value as string | undefined;
+    if (!reserveSlotFor) {
+      return;
+    }
+    const partitionEntries = [...pendingImports].filter(
+      ([, pending]) =>
+        pending.isolationDomainId === reserveSlotFor.isolationDomainId &&
+        pending.ownerPrincipalId === reserveSlotFor.ownerPrincipalId,
+    );
+    while (partitionEntries.length >= MAX_PENDING_WORKSPACE_IMPORTS) {
+      const oldest = partitionEntries.shift()?.[0];
       if (!oldest) {
         break;
       }
@@ -738,7 +746,10 @@ export function registerWorkspaceGatewayMethods(options: WorkspaceGatewayMethodO
         const owner = await resolveCanonicalOwner(workspaceId);
         const prepared = prepareWorkspaceImport(content, owner.targetStore.read());
         const now = Date.now();
-        prunePendingImports(now, true);
+        prunePendingImports(now, {
+          isolationDomainId: owner.isolationDomainId,
+          ownerPrincipalId: owner.ownerPrincipalId,
+        });
         const previewId = randomUUID();
         const expiresAt = now + WORKSPACE_IMPORT_PREVIEW_TTL_MS;
         pendingImports.set(previewId, {
@@ -782,7 +793,7 @@ export function registerWorkspaceGatewayMethods(options: WorkspaceGatewayMethodO
           throw new Error("workspace import requires explicit owner approval");
         }
         const owner = await resolveCanonicalOwner(workspaceId);
-        prunePendingImports(Date.now(), false);
+        prunePendingImports(Date.now());
         const pending = pendingImports.get(previewId);
         if (!pending) {
           throw new Error("workspace import preview is missing or expired");
@@ -812,7 +823,7 @@ export function registerWorkspaceGatewayMethods(options: WorkspaceGatewayMethodO
           workspaceVersion: result.doc.workspaceVersion,
           imported: pending.summary,
           tabIds: pending.tabs.map((tab) => tab.id),
-          sharingSyncRequired: true,
+          sharingSyncRequired: owner.context !== undefined,
         });
       } catch (error) {
         respondError(opts.respond, error);
@@ -852,7 +863,11 @@ export function registerWorkspaceGatewayMethods(options: WorkspaceGatewayMethodO
         });
         const doc = domainStore.read();
         const currentTabIds = new Set(doc.tabs.map((tab) => tab.id));
+        const boundTabIds = new Set(boundBefore.map((resource) => resource.id));
         for (const tab of doc.tabs) {
+          if (boundTabIds.has(tab.id)) {
+            continue;
+          }
           const operation = await api.teams.resources.prepareRegister({
             context,
             resource: { namespace: "workspaces", type: "tab", id: tab.id },

--- a/extensions/workspaces/src/gateway.ts
+++ b/extensions/workspaces/src/gateway.ts
@@ -2,6 +2,11 @@ import { randomUUID } from "node:crypto";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { rememberWorkspaceBroadcast } from "./broadcast.js";
+import type {
+  WorkspaceChangeRequestState,
+  WorkspaceRequester,
+  WorkspaceTabProposal,
+} from "./change-requests.js";
 import { resolveBinding, type ResolveBindingOptions } from "./data-read.js";
 import { snapshotApprovedWidget } from "./manifest.js";
 import { scaffoldWorkspaceWidget } from "./scaffold.js";
@@ -14,6 +19,7 @@ import type {
   JsonValue,
   WorkspaceDoc,
 } from "./schema.js";
+import { projectSharedChangeRequest, projectSharedTab } from "./sharing-projection.js";
 import { WorkspaceStore } from "./store.js";
 
 const READ_SCOPE = "operator.read" as const;
@@ -25,16 +31,21 @@ const APPROVE_SCOPE = "operator.approvals" as const;
 const TAB_SLUG_PATTERN = /^[a-z0-9-]{1,40}$/;
 const WIDGET_ID_PATTERN = /^[A-Za-z0-9_-]{1,48}$/;
 const CUSTOM_WIDGET_NAME_PATTERN = /^(?!__proto__$)[A-Za-z0-9._-]{1,64}$/;
+const RESOURCE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
 
 type GatewayMethodContext = Parameters<
   Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1]
 >[0];
 type GatewayRespond = GatewayMethodContext["respond"];
 type GatewayBroadcast = GatewayMethodContext["context"]["broadcast"];
+type TeamsRequestContext = Parameters<
+  OpenClawPluginApi["teams"]["resources"]["owner"]
+>[0]["context"];
 
 type WorkspaceGatewayMethodOptions = {
   api: OpenClawPluginApi;
   store?: WorkspaceStore;
+  storeForDomain?: (isolationDomainId: string) => WorkspaceStore;
   dataRead?: ResolveBindingOptions;
 };
 
@@ -113,6 +124,79 @@ function readWidgetId(record: Record<string, unknown>, key = "id"): string {
     throw new Error(`${key} is invalid`);
   }
   return id;
+}
+
+function readResourceId(record: Record<string, unknown>, key: string): string {
+  const id = readRequiredString(record, key, key);
+  if (!RESOURCE_ID_PATTERN.test(id)) {
+    throw new Error(`${key} is invalid`);
+  }
+  return id;
+}
+
+function readExactTabParams(params: unknown): { workspaceId: string; id: string } {
+  const record = readParams(params, ["workspaceId", "id"]);
+  return {
+    workspaceId: readResourceId(record, "workspaceId"),
+    id: readResourceId(record, "id"),
+  };
+}
+
+function workspaceTabNotFound(): Error & { code: string } {
+  return Object.assign(new Error("workspace tab not found"), { code: "workspace_not_found" });
+}
+
+function workspaceRevisionConflict(): Error & { code: string } {
+  return Object.assign(new Error("workspace tab revision conflict"), {
+    code: "workspace_conflict",
+  });
+}
+
+function readOptionalRevision(record: Record<string, unknown>): number | undefined {
+  const value = record.ifRevision;
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Number.isInteger(value) || (value as number) < 1) {
+    throw new Error("ifRevision must be a positive integer");
+  }
+  return value as number;
+}
+
+function readRequiredRevision(record: Record<string, unknown>, key: string): number {
+  const value = record[key];
+  if (!Number.isInteger(value) || (value as number) < 1) {
+    throw new Error(`${key} must be a positive integer`);
+  }
+  return value as number;
+}
+
+function readChangeRequestState(
+  record: Record<string, unknown>,
+): WorkspaceChangeRequestState | undefined {
+  const state = readOptionalString(record, "state");
+  if (
+    state !== undefined &&
+    !["pending", "approved", "rejected", "cancelled", "conflict"].includes(state)
+  ) {
+    throw new Error("state is invalid");
+  }
+  return state as WorkspaceChangeRequestState | undefined;
+}
+
+function workspaceRequester(context: TeamsRequestContext): WorkspaceRequester {
+  if (context.principal.kind === "human") {
+    return { principalId: context.principal.id, kind: "human" };
+  }
+  if (!context.delegatedSession) {
+    throw new Error("a delegated agent assignment is required");
+  }
+  return {
+    principalId: context.principal.id,
+    kind: "agent",
+    delegationId: context.delegatedSession.id,
+    sponsorPrincipalId: context.delegatedSession.sponsorPrincipalId,
+  };
 }
 
 function readBooleanPatch(record: Record<string, unknown>, key: string): boolean | undefined {
@@ -293,6 +377,24 @@ function readTabPatch(value: unknown): Partial<Pick<WorkspaceTab, "title" | "ico
   };
 }
 
+function expandPortalProposal(tab: WorkspaceTab, value: unknown): unknown {
+  if (
+    !isRecord(value) ||
+    !Object.keys(value).every((key) => ["title", "icon", "hidden"].includes(key))
+  ) {
+    return value;
+  }
+  const patch = readTabPatch(value);
+  const proposal: WorkspaceTabProposal = {
+    slug: tab.slug,
+    title: patch.title ?? tab.title,
+    ...((patch.icon ?? tab.icon) ? { icon: patch.icon ?? tab.icon } : {}),
+    hidden: patch.hidden ?? tab.hidden,
+    widgets: tab.widgets.map(({ createdBy: _createdBy, ...widget }) => widget),
+  };
+  return proposal;
+}
+
 function readWidgetPatch(value: unknown): Partial<WorkspaceWidget> {
   const patch = readParams(value, ["title", "grid", "collapsed", "hidden", "bindings", "props"]);
   const title = readOptionalString(patch, "title");
@@ -364,19 +466,181 @@ async function respondWrite(
 export function registerWorkspaceGatewayMethods(options: WorkspaceGatewayMethodOptions) {
   const { api } = options;
   const store = options.store ?? new WorkspaceStore();
+  const storeForDomain = options.storeForDomain ?? (() => store);
 
   api.registerGatewayMethod(
     "workspaces.get",
-    async ({ respond, context }) => {
+    async ({ params: rawParams, respond, context }) => {
       try {
+        const params = readParams(rawParams, ["workspaceId"]);
+        const workspaceId =
+          params.workspaceId === undefined
+            ? store.workspaceId
+            : readResourceId(params, "workspaceId");
+        let readableStore = store;
+        try {
+          const teamsContext = api.teams.context.require();
+          readableStore = storeForDomain(teamsContext.isolationDomainId);
+        } catch {
+          // Legacy operator requests have no isolated Teams context.
+        }
         rememberWorkspaceBroadcast(context.broadcast);
-        const doc = store.read();
+        const doc = readableStore.read();
+        if (doc.workspaceId !== workspaceId) {
+          throw workspaceTabNotFound();
+        }
         respond(true, { doc, workspaceVersion: doc.workspaceVersion });
       } catch (error) {
         respondError(respond, error);
       }
     },
-    { scope: READ_SCOPE },
+    {
+      scope: READ_SCOPE,
+      access: {
+        kind: "resource",
+        permission: "workspaces.workspace.read",
+        resolveResources: ({ params }) => {
+          const record = readParams(params, ["workspaceId"]);
+          const id =
+            record.workspaceId === undefined
+              ? store.workspaceId
+              : readResourceId(record, "workspaceId");
+          return [{ namespace: "workspaces", type: "workspace", id }];
+        },
+      },
+    },
+  );
+
+  api.registerGatewayMethod(
+    "workspaces.tab.get",
+    async ({ params: rawParams, respond }) => {
+      try {
+        const params = readExactTabParams(rawParams);
+        const teamsContext = api.teams.context.require();
+        const domainStore = storeForDomain(teamsContext.isolationDomainId);
+        const doc = domainStore.read();
+        if (params.workspaceId !== doc.workspaceId) {
+          throw workspaceTabNotFound();
+        }
+        const tab = doc.tabs.find((entry) => entry.id === params.id);
+        if (!tab) {
+          throw workspaceTabNotFound();
+        }
+        const resource = { namespace: "workspaces", type: "tab", id: tab.id } as const;
+        const [write, requestChanges] = await Promise.all([
+          api.teams.authorization.decide({
+            context: teamsContext,
+            permission: "workspaces.tab.write",
+            resources: [resource],
+          }),
+          api.teams.authorization.decide({
+            context: teamsContext,
+            permission: "workspaces.tab.changeRequest.create",
+            resources: [resource],
+          }),
+        ]);
+        const capabilityMode = write.allowed
+          ? "write"
+          : requestChanges.allowed
+            ? "request"
+            : "read";
+        respond(true, {
+          workspaceId: doc.workspaceId,
+          workspaceVersion: doc.workspaceVersion,
+          capabilityMode,
+          tab: projectSharedTab(tab),
+        });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    {
+      scope: READ_SCOPE,
+      access: {
+        kind: "resource",
+        member: true,
+        permission: "workspaces.tab.read",
+        resolveResources: ({ params }) => {
+          const exact = readExactTabParams(params);
+          return [{ namespace: "workspaces", type: "tab", id: exact.id }];
+        },
+      },
+    },
+  );
+
+  api.registerGatewayMethod(
+    "workspaces.sharing.sync",
+    async ({ params: rawParams, respond }) => {
+      try {
+        const params = readParams(rawParams, ["workspaceId"]);
+        const workspaceId = readResourceId(params, "workspaceId");
+        const context = api.teams.context.require();
+        const domainStore = storeForDomain(context.isolationDomainId);
+        if (workspaceId !== domainStore.workspaceId || context.principal.kind !== "human") {
+          throw workspaceTabNotFound();
+        }
+        const workspace = { namespace: "workspaces", type: "workspace", id: workspaceId } as const;
+        const owner = await api.teams.resources.owner({ context, resource: workspace });
+        if (owner.principalId !== context.principal.id) {
+          throw new Error("workspace sharing sync requires the canonical human owner");
+        }
+        const boundBefore = await api.teams.resources.listChildren({
+          context,
+          parent: workspace,
+          requiredAction: "workspaces.workspace.manageSharing",
+          type: "tab",
+        });
+        const doc = domainStore.read();
+        const currentTabIds = new Set(doc.tabs.map((tab) => tab.id));
+        for (const tab of doc.tabs) {
+          const operation = await api.teams.resources.prepareRegister({
+            context,
+            resource: { namespace: "workspaces", type: "tab", id: tab.id },
+            parent: workspace,
+            requiredAction: "workspaces.workspace.manageSharing",
+            idempotencyKey: `sharing-sync:${workspaceId}:${tab.id}`,
+          });
+          await api.teams.resources.replayPrepared({ operation });
+        }
+        for (const resource of boundBefore) {
+          if (currentTabIds.has(resource.id)) {
+            continue;
+          }
+          const operation = await api.teams.resources.prepareRetire({
+            context,
+            resource,
+            parent: workspace,
+            requiredAction: "workspaces.workspace.manageSharing",
+            idempotencyKey: `sharing-sync-retire:${workspaceId}:${resource.id}`,
+          });
+          await api.teams.resources.replayPrepared({ operation });
+        }
+        respond(true, {
+          workspaceId,
+          tabs: doc.tabs.map(({ id, revision, slug, title }) => ({ id, revision, slug, title })),
+        });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    {
+      scope: WRITE_SCOPE,
+      access: {
+        kind: "resource",
+        member: true,
+        permission: "workspaces.workspace.manageSharing",
+        resolveResources: ({ params }) => {
+          const record = readParams(params, ["workspaceId"]);
+          return [
+            {
+              namespace: "workspaces",
+              type: "workspace",
+              id: readResourceId(record, "workspaceId"),
+            },
+          ];
+        },
+      },
+    },
   );
 
   api.registerGatewayMethod(
@@ -459,22 +723,302 @@ export function registerWorkspaceGatewayMethods(options: WorkspaceGatewayMethodO
     "workspaces.tab.update",
     async (opts) => {
       try {
-        const params = readParams(opts.params, ["slug", "patch"]);
-        const slug = readSlug(params);
+        const params = readParams(opts.params, [
+          "workspaceId",
+          "id",
+          "slug",
+          "ifRevision",
+          "patch",
+        ]);
         const patch = readTabPatch(params.patch);
-        await respondWrite(opts, RPC_ACTOR, slug, async () =>
-          store.mutate(
-            (draft) => {
-              Object.assign(findTab(draft, slug), patch);
-            },
-            { actor: RPC_ACTOR },
-          ),
+        let teamsContext: TeamsRequestContext | undefined;
+        try {
+          teamsContext = api.teams.context.require();
+        } catch {
+          // Legacy operator request.
+        }
+        const ifRevision = teamsContext
+          ? readRequiredRevision(params, "ifRevision")
+          : readOptionalRevision(params);
+        const targetStore = teamsContext ? storeForDomain(teamsContext.isolationDomainId) : store;
+        if (teamsContext && readResourceId(params, "workspaceId") !== targetStore.workspaceId) {
+          throw workspaceTabNotFound();
+        }
+        if (!teamsContext && params.workspaceId !== undefined) {
+          throw new Error("workspaceId is only accepted for exact Teams updates");
+        }
+        const id = teamsContext ? readResourceId(params, "id") : undefined;
+        const slug = teamsContext ? undefined : readSlug(params);
+        let changedTabSlug: string | undefined;
+        const actor: WorkspaceActor =
+          teamsContext?.principal.kind === "agent"
+            ? `agent:${teamsContext.principal.id}`
+            : RPC_ACTOR;
+        const result = targetStore.mutate(
+          (draft) => {
+            const tab = id ? draft.tabs.find((entry) => entry.id === id) : findTab(draft, slug!);
+            if (!tab) {
+              throw workspaceTabNotFound();
+            }
+            if (ifRevision !== undefined && tab.revision !== ifRevision) {
+              throw workspaceRevisionConflict();
+            }
+            changedTabSlug = tab.slug;
+            Object.assign(tab, patch);
+          },
+          { actor },
         );
+        if (teamsContext && id) {
+          const updatedTab = result.doc.tabs.find((entry) => entry.id === id);
+          if (!updatedTab) {
+            throw workspaceTabNotFound();
+          }
+          // Teams portal v1 polls exact resources until the host supports
+          // permission-filtered resource events. Never use the global broadcast.
+          opts.respond(true, {
+            workspaceId: result.doc.workspaceId,
+            workspaceVersion: result.doc.workspaceVersion,
+            tab: projectSharedTab(updatedTab),
+          });
+        } else {
+          broadcastChange(opts.context.broadcast, { doc: result.doc, actor, changedTabSlug });
+          opts.respond(true, { doc: result.doc, workspaceVersion: result.doc.workspaceVersion });
+        }
       } catch (error) {
         respondError(opts.respond, error);
       }
     },
-    { scope: WRITE_SCOPE },
+    {
+      scope: WRITE_SCOPE,
+      access: {
+        kind: "resource",
+        member: true,
+        permission: "workspaces.tab.write",
+        resolveResources: ({ params }) => {
+          const record = readParams(params, ["workspaceId", "id", "slug", "ifRevision", "patch"]);
+          return [{ namespace: "workspaces", type: "tab", id: readResourceId(record, "id") }];
+        },
+      },
+    },
+  );
+
+  const exactTabAccess = (permission: string) => ({
+    kind: "resource" as const,
+    member: true,
+    permission,
+    resolveResources: ({ params }: { params: unknown }) => {
+      const record = readParams(params, [
+        "workspaceId",
+        "tabId",
+        "requestId",
+        "baseRevision",
+        "proposal",
+        "idempotencyKey",
+        "state",
+        "decision",
+        "reason",
+      ]);
+      return [
+        {
+          namespace: "workspaces",
+          type: "tab",
+          id: readResourceId(record, "tabId"),
+        },
+      ];
+    },
+  });
+
+  api.registerGatewayMethod(
+    "workspaces.changeRequest.create",
+    async ({ params: rawParams, respond }) => {
+      try {
+        const params = readParams(rawParams, [
+          "workspaceId",
+          "tabId",
+          "baseRevision",
+          "proposal",
+          "idempotencyKey",
+        ]);
+        const context = api.teams.context.require();
+        const domainStore = storeForDomain(context.isolationDomainId);
+        if (readResourceId(params, "workspaceId") !== domainStore.workspaceId) {
+          throw workspaceTabNotFound();
+        }
+        const tabId = readResourceId(params, "tabId");
+        const tab = domainStore.read().tabs.find((entry) => entry.id === tabId);
+        if (!tab) {
+          throw workspaceTabNotFound();
+        }
+        const request = domainStore.createChangeRequest({
+          id: randomUUID(),
+          tabId,
+          requester: workspaceRequester(context),
+          baseTabRevision: readRequiredRevision(params, "baseRevision"),
+          idempotencyKey: readRequiredString(params, "idempotencyKey", "idempotencyKey"),
+          proposal: expandPortalProposal(tab, params.proposal),
+        });
+        respond(true, { request: projectSharedChangeRequest(request) });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    {
+      scope: WRITE_SCOPE,
+      access: exactTabAccess("workspaces.tab.changeRequest.create"),
+    },
+  );
+
+  api.registerGatewayMethod(
+    "workspaces.changeRequest.list",
+    async ({ params: rawParams, respond }) => {
+      try {
+        const params = readParams(rawParams, ["workspaceId", "tabId", "state"]);
+        const context = api.teams.context.require();
+        const domainStore = storeForDomain(context.isolationDomainId);
+        if (readResourceId(params, "workspaceId") !== domainStore.workspaceId) {
+          throw workspaceTabNotFound();
+        }
+        const tabId = readResourceId(params, "tabId");
+        const resource = { namespace: "workspaces", type: "tab", id: tabId } as const;
+        const owner = await api.teams.resources.owner({ context, resource });
+        const isOwner =
+          context.principal.kind === "human" && owner.principalId === context.principal.id;
+        const requests = domainStore.listChangeRequests({
+          tabId,
+          ...(readChangeRequestState(params) ? { state: readChangeRequestState(params) } : {}),
+          ...(isOwner ? {} : { requesterPrincipalId: context.principal.id }),
+        });
+        respond(true, {
+          requests: isOwner ? requests : requests.map(projectSharedChangeRequest),
+        });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: READ_SCOPE, access: exactTabAccess("workspaces.tab.read") },
+  );
+
+  api.registerGatewayMethod(
+    "workspaces.changeRequest.get",
+    async ({ params: rawParams, respond }) => {
+      try {
+        const params = readParams(rawParams, ["workspaceId", "tabId", "requestId"]);
+        const context = api.teams.context.require();
+        const domainStore = storeForDomain(context.isolationDomainId);
+        if (readResourceId(params, "workspaceId") !== domainStore.workspaceId) {
+          throw workspaceTabNotFound();
+        }
+        const tabId = readResourceId(params, "tabId");
+        const request = domainStore.readChangeRequest(readResourceId(params, "requestId"));
+        if (!request || request.tabId !== tabId) {
+          throw workspaceTabNotFound();
+        }
+        const owner = await api.teams.resources.owner({
+          context,
+          resource: { namespace: "workspaces", type: "tab", id: tabId },
+        });
+        const isOwner =
+          context.principal.kind === "human" && owner.principalId === context.principal.id;
+        if (!isOwner && request.requester.principalId !== context.principal.id) {
+          throw workspaceTabNotFound();
+        }
+        respond(true, { request: isOwner ? request : projectSharedChangeRequest(request) });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: READ_SCOPE, access: exactTabAccess("workspaces.tab.read") },
+  );
+
+  api.registerGatewayMethod(
+    "workspaces.changeRequest.cancel",
+    async ({ params: rawParams, respond }) => {
+      try {
+        const params = readParams(rawParams, ["workspaceId", "tabId", "requestId"]);
+        const context = api.teams.context.require();
+        const domainStore = storeForDomain(context.isolationDomainId);
+        if (readResourceId(params, "workspaceId") !== domainStore.workspaceId) {
+          throw workspaceTabNotFound();
+        }
+        const tabId = readResourceId(params, "tabId");
+        const existing = domainStore.readChangeRequest(readResourceId(params, "requestId"));
+        if (!existing || existing.tabId !== tabId) {
+          throw workspaceTabNotFound();
+        }
+        const requester = workspaceRequester(context);
+        if (JSON.stringify(existing.requester) !== JSON.stringify(requester)) {
+          throw workspaceTabNotFound();
+        }
+        const request = domainStore.cancelChangeRequest({
+          id: existing.id,
+          requester,
+        });
+        respond(true, { request: projectSharedChangeRequest(request) });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    {
+      scope: WRITE_SCOPE,
+      access: exactTabAccess("workspaces.tab.changeRequest.create"),
+    },
+  );
+
+  api.registerGatewayMethod(
+    "workspaces.changeRequest.decide",
+    async ({ params: rawParams, respond }) => {
+      try {
+        const params = readParams(rawParams, [
+          "workspaceId",
+          "tabId",
+          "requestId",
+          "decision",
+          "reason",
+        ]);
+        const context = api.teams.context.require();
+        if (context.principal.kind !== "human") {
+          throw new Error("change request decisions require the canonical human owner");
+        }
+        const domainStore = storeForDomain(context.isolationDomainId);
+        if (readResourceId(params, "workspaceId") !== domainStore.workspaceId) {
+          throw workspaceTabNotFound();
+        }
+        const tabId = readResourceId(params, "tabId");
+        const resource = { namespace: "workspaces", type: "tab", id: tabId } as const;
+        const owner = await api.teams.resources.owner({ context, resource });
+        if (owner.principalId !== context.principal.id) {
+          throw new Error("change request decisions require the canonical human owner");
+        }
+        const existing = domainStore.readChangeRequest(readResourceId(params, "requestId"));
+        if (!existing || existing.tabId !== tabId) {
+          throw workspaceTabNotFound();
+        }
+        const decision = readRequiredString(params, "decision", "decision");
+        if (decision !== "approved" && decision !== "rejected") {
+          throw new Error("decision must be approved or rejected");
+        }
+        const result = domainStore.decideChangeRequest({
+          id: existing.id,
+          decision,
+          decider: { principalId: context.principal.id, kind: "human" },
+          reason: readOptionalString(params, "reason"),
+        });
+        const tab = result.doc.tabs.find((entry) => entry.id === tabId);
+        respond(true, {
+          workspaceId: result.doc.workspaceId,
+          request: projectSharedChangeRequest(result.request),
+          applied: result.applied,
+          workspaceVersion: result.doc.workspaceVersion,
+          ...(tab ? { tab: projectSharedTab(tab) } : {}),
+        });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    {
+      scope: APPROVE_SCOPE,
+      access: exactTabAccess("workspaces.tab.reviewChanges"),
+    },
   );
 
   api.registerGatewayMethod(

--- a/extensions/workspaces/src/schema.test.ts
+++ b/extensions/workspaces/src/schema.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { DEFAULT_WORKSPACE } from "./default-workspace.js";
-import {
-  CURRENT_WORKSPACE_SCHEMA_VERSION,
-  migrateWorkspaceDoc,
-  validateWorkspaceDoc,
-  type WorkspaceDoc,
-} from "./schema.js";
+import { migrateWorkspaceDoc, validateWorkspaceDoc, type WorkspaceDoc } from "./schema.js";
 
 function validDoc(): WorkspaceDoc {
   return structuredClone(DEFAULT_WORKSPACE);
@@ -25,7 +20,7 @@ describe("Workspaces document schema", () => {
 
   it("requires stable workspace and tab resource ids in the canonical schema", () => {
     expect(validDoc()).toMatchObject({
-      schemaVersion: CURRENT_WORKSPACE_SCHEMA_VERSION,
+      schemaVersion: 2,
       workspaceId: "default",
       tabs: [expect.objectContaining({ id: "main", slug: "main", revision: 1 })],
     });
@@ -64,7 +59,7 @@ describe("Workspaces document schema", () => {
 
     expect(migrated.changed).toBe(true);
     expect(migrated.doc).toMatchObject({
-      schemaVersion: CURRENT_WORKSPACE_SCHEMA_VERSION,
+      schemaVersion: 2,
       workspaceId: "default",
       tabs: [{ id: "main", slug: "main", revision: 1 }],
     });

--- a/extensions/workspaces/src/schema.test.ts
+++ b/extensions/workspaces/src/schema.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { DEFAULT_WORKSPACE } from "./default-workspace.js";
-import { validateWorkspaceDoc, type WorkspaceDoc } from "./schema.js";
+import {
+  CURRENT_WORKSPACE_SCHEMA_VERSION,
+  migrateWorkspaceDoc,
+  validateWorkspaceDoc,
+  type WorkspaceDoc,
+} from "./schema.js";
 
 function validDoc(): WorkspaceDoc {
   return structuredClone(DEFAULT_WORKSPACE);
@@ -18,6 +23,81 @@ describe("Workspaces document schema", () => {
     expect(validateWorkspaceDoc(validDoc())).toEqual(validDoc());
   });
 
+  it("requires stable workspace and tab resource ids in the canonical schema", () => {
+    expect(validDoc()).toMatchObject({
+      schemaVersion: CURRENT_WORKSPACE_SCHEMA_VERSION,
+      workspaceId: "default",
+      tabs: [expect.objectContaining({ id: "main", slug: "main", revision: 1 })],
+    });
+
+    const missingWorkspaceId = structuredClone(validDoc()) as unknown as Record<string, unknown>;
+    delete missingWorkspaceId.workspaceId;
+    expect(() => validateWorkspaceDoc(missingWorkspaceId)).toThrow("workspaces.workspaceId");
+
+    const missingTabId = structuredClone(validDoc()) as unknown as {
+      tabs: Array<Record<string, unknown>>;
+    };
+    delete missingTabId.tabs[0]!.id;
+    expect(() => validateWorkspaceDoc(missingTabId)).toThrow("tabs[0].id");
+
+    const missingRevision = structuredClone(validDoc()) as unknown as {
+      tabs: Array<Record<string, unknown>>;
+    };
+    delete missingRevision.tabs[0]!.revision;
+    expect(() => validateWorkspaceDoc(missingRevision)).toThrow("tabs[0].revision");
+  });
+
+  it("migrates legacy v1 documents to deterministic stable resource ids", () => {
+    const legacy = structuredClone(validDoc()) as unknown as {
+      schemaVersion: number;
+      workspaceId?: string;
+      tabs: Array<{ id?: string; revision?: number; slug: string }>;
+    };
+    legacy.schemaVersion = 1;
+    delete legacy.workspaceId;
+    for (const tab of legacy.tabs) {
+      delete tab.id;
+      delete tab.revision;
+    }
+
+    const migrated = migrateWorkspaceDoc(legacy);
+
+    expect(migrated.changed).toBe(true);
+    expect(migrated.doc).toMatchObject({
+      schemaVersion: CURRENT_WORKSPACE_SCHEMA_VERSION,
+      workspaceId: "default",
+      tabs: [{ id: "main", slug: "main", revision: 1 }],
+    });
+    expect(migrateWorkspaceDoc(migrated.doc)).toEqual({ doc: migrated.doc, changed: false });
+  });
+
+  it("does not trust identity fields smuggled into the v1 document shape", () => {
+    const legacy = structuredClone(validDoc()) as unknown as {
+      schemaVersion: number;
+      workspaceId: string;
+      tabs: Array<{ id: string; slug: string; revision: number }>;
+    };
+    legacy.schemaVersion = 1;
+    legacy.workspaceId = "forged";
+    legacy.tabs[0]!.id = "forged-tab";
+    legacy.tabs[0]!.revision = 999;
+
+    expect(migrateWorkspaceDoc(legacy).doc).toMatchObject({
+      workspaceId: "default",
+      tabs: [{ id: "main", slug: "main", revision: 1 }],
+    });
+  });
+
+  it("rejects duplicate tab resource ids independently of mutable slugs", () => {
+    expectInvalid((doc) => {
+      doc.tabs.push({
+        ...structuredClone(doc.tabs[0]!),
+        slug: "second",
+        title: "Second",
+      });
+    }, "duplicate tab id");
+  });
+
   it("rejects invalid tab slugs", () => {
     expectInvalid((doc) => {
       doc.tabs[0]!.slug = "Bad Slug";
@@ -26,7 +106,7 @@ describe("Workspaces document schema", () => {
 
   it("rejects duplicate tab slugs", () => {
     expectInvalid((doc) => {
-      doc.tabs.push({ ...structuredClone(doc.tabs[0]!), title: "Duplicate" });
+      doc.tabs.push({ ...structuredClone(doc.tabs[0]!), id: "duplicate", title: "Duplicate" });
     }, "duplicate tab slug");
   });
 

--- a/extensions/workspaces/src/schema.ts
+++ b/extensions/workspaces/src/schema.ts
@@ -60,7 +60,7 @@ export type WorkspaceDoc = {
   prefs: { tabOrder: string[] };
 };
 
-export const CURRENT_WORKSPACE_SCHEMA_VERSION = 2;
+const CURRENT_WORKSPACE_SCHEMA_VERSION = 2;
 export const DEFAULT_WORKSPACE_ID = "default";
 
 const TAB_SLUG_PATTERN = /^[a-z0-9-]{1,40}$/;

--- a/extensions/workspaces/src/schema.ts
+++ b/extensions/workspaces/src/schema.ts
@@ -31,6 +31,10 @@ export type WorkspaceWidget = {
   props?: JsonValue;
 };
 export type WorkspaceTab = {
+  /** Immutable authorization resource id; presentation continues to use mutable `slug`. */
+  id: string;
+  /** Store-owned optimistic-concurrency counter. */
+  revision: number;
   slug: string;
   title: string;
   icon?: string;
@@ -47,16 +51,20 @@ export type WorkspaceWidgetRegistryEntry = {
   approvedFiles?: Record<string, string>;
 };
 export type WorkspaceDoc = {
-  schemaVersion: 1;
+  schemaVersion: 2;
+  /** Immutable workspace authorization resource id. */
+  workspaceId: string;
   workspaceVersion: number;
   tabs: WorkspaceTab[];
   widgetsRegistry: Record<string, WorkspaceWidgetRegistryEntry>;
   prefs: { tabOrder: string[] };
 };
 
-const CURRENT_WORKSPACE_SCHEMA_VERSION = 1;
+export const CURRENT_WORKSPACE_SCHEMA_VERSION = 2;
+export const DEFAULT_WORKSPACE_ID = "default";
 
 const TAB_SLUG_PATTERN = /^[a-z0-9-]{1,40}$/;
+const RESOURCE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
 const ACTOR_PATTERN = /^(user|system|agent:[A-Za-z0-9._-]{1,64})$/;
 const WIDGET_ID_PATTERN = /^[A-Za-z0-9_-]{1,48}$/;
 /** The trusted widget set. Exported so tool schemas can name them for the model. */
@@ -295,7 +303,21 @@ function validateWidget(value: unknown, path: string): WorkspaceWidget {
 
 function validateTab(value: unknown, path: string): WorkspaceTab {
   const record = assertRecord(value, path);
-  assertKnownKeys(record, ["slug", "title", "icon", "hidden", "createdBy", "widgets"], path);
+  assertKnownKeys(
+    record,
+    ["id", "revision", "slug", "title", "icon", "hidden", "createdBy", "widgets"],
+    path,
+  );
+  const id = requireString(record, "id", path);
+  if (!RESOURCE_ID_PATTERN.test(id)) {
+    throw new Error(`${path}.id is invalid`);
+  }
+  const revision = assertIntegerRange(
+    record.revision,
+    `${path}.revision`,
+    1,
+    Number.MAX_SAFE_INTEGER,
+  );
   const slug = requireString(record, "slug", path);
   if (!TAB_SLUG_PATTERN.test(slug)) {
     throw new Error(`${path}.slug is invalid`);
@@ -313,6 +335,8 @@ function validateTab(value: unknown, path: string): WorkspaceTab {
     throw new Error(`${path}.widgets must contain at most 24 entries`);
   }
   return {
+    id,
+    revision,
     slug,
     title,
     ...(icon !== undefined ? { icon } : {}),
@@ -403,11 +427,16 @@ function validatePrefs(value: unknown, tabSlugs: Set<string>): WorkspaceDoc["pre
 }
 
 function assertUniqueTabs(tabs: WorkspaceTab[]): Set<string> {
+  const ids = new Set<string>();
   const slugs = new Set<string>();
   for (const tab of tabs) {
+    if (ids.has(tab.id)) {
+      throw new Error(`duplicate tab id: ${tab.id}`);
+    }
     if (slugs.has(tab.slug)) {
       throw new Error(`duplicate tab slug: ${tab.slug}`);
     }
+    ids.add(tab.id);
     slugs.add(tab.slug);
   }
   return slugs;
@@ -429,11 +458,15 @@ export function validateWorkspaceDoc(value: unknown): WorkspaceDoc {
   const record = assertRecord(value, "workspaces");
   assertKnownKeys(
     record,
-    ["schemaVersion", "workspaceVersion", "tabs", "widgetsRegistry", "prefs"],
+    ["schemaVersion", "workspaceId", "workspaceVersion", "tabs", "widgetsRegistry", "prefs"],
     "workspaces",
   );
   if (record.schemaVersion !== CURRENT_WORKSPACE_SCHEMA_VERSION) {
     throw new Error(`schemaVersion must be ${CURRENT_WORKSPACE_SCHEMA_VERSION}`);
+  }
+  const workspaceId = requireString(record, "workspaceId", "workspaces");
+  if (!RESOURCE_ID_PATTERN.test(workspaceId)) {
+    throw new Error("workspaces.workspaceId is invalid");
   }
   const workspaceVersion = assertIntegerRange(
     record.workspaceVersion,
@@ -450,9 +483,40 @@ export function validateWorkspaceDoc(value: unknown): WorkspaceDoc {
   assertUniqueWidgets(tabs);
   return {
     schemaVersion: CURRENT_WORKSPACE_SCHEMA_VERSION,
+    workspaceId,
     workspaceVersion,
     tabs,
     widgetsRegistry: validateWidgetsRegistry(record.widgetsRegistry),
     prefs: validatePrefs(record.prefs, tabSlugs),
   };
+}
+
+export function migrateWorkspaceDoc(value: unknown): { doc: WorkspaceDoc; changed: boolean } {
+  const record = assertRecord(value, "workspaces");
+  const schemaVersion = record.schemaVersion;
+  if (typeof schemaVersion !== "number" || !Number.isInteger(schemaVersion)) {
+    throw new Error("schemaVersion must be an integer");
+  }
+  if (schemaVersion > CURRENT_WORKSPACE_SCHEMA_VERSION) {
+    throw new Error(`unsupported future workspace schemaVersion: ${schemaVersion}`);
+  }
+  if (schemaVersion < 1) {
+    throw new Error(`unsupported old workspace schemaVersion: ${schemaVersion}`);
+  }
+  if (schemaVersion === 1) {
+    const tabs: Record<string, unknown>[] = [];
+    for (const [index, entry] of requireArray(record.tabs, "tabs").entries()) {
+      const tab = assertRecord(entry, `tabs[${index}]`);
+      const slug = requireString(tab, "slug", `tabs[${index}]`);
+      tabs.push({ ...tab, id: slug, revision: 1 });
+    }
+    const migrated = {
+      ...record,
+      schemaVersion: CURRENT_WORKSPACE_SCHEMA_VERSION,
+      workspaceId: DEFAULT_WORKSPACE_ID,
+      tabs,
+    };
+    return { doc: validateWorkspaceDoc(migrated), changed: true };
+  }
+  return { doc: validateWorkspaceDoc(record), changed: false };
 }

--- a/extensions/workspaces/src/sharing-projection.ts
+++ b/extensions/workspaces/src/sharing-projection.ts
@@ -1,0 +1,63 @@
+import type { WorkspaceChangeRequest, WorkspaceWidgetProposal } from "./change-requests.js";
+import type { WorkspaceTab, WorkspaceWidget } from "./schema.js";
+
+export type SharedWorkspaceChangeRequest = Omit<WorkspaceChangeRequest, "proposalSha256">;
+
+const SHARED_SAFE_WIDGET_KINDS = new Set([
+  "builtin:markdown",
+  "builtin:stat-card",
+  "builtin:table",
+]);
+
+type SharedWidgetInput = WorkspaceWidget | WorkspaceWidgetProposal;
+
+function projectWidget<T extends SharedWidgetInput>(widget: T): T {
+  const bindings = Object.values(widget.bindings ?? {});
+  if (
+    SHARED_SAFE_WIDGET_KINDS.has(widget.kind) &&
+    bindings.every((binding) => binding.source === "static")
+  ) {
+    return {
+      ...widget,
+      ...(widget.bindings ? { bindings: { ...widget.bindings } } : {}),
+    };
+  }
+  return {
+    id: widget.id,
+    kind: "builtin:markdown",
+    title: widget.title ?? "Unavailable widget",
+    grid: { ...widget.grid },
+    collapsed: widget.collapsed,
+    hidden: widget.hidden,
+    ...("createdBy" in widget ? { createdBy: widget.createdBy } : {}),
+    props: { markdown: "This widget is unavailable in a shared workspace view." },
+  } as unknown as T;
+}
+
+export function projectSharedTab(tab: WorkspaceTab): WorkspaceTab {
+  return { ...tab, widgets: tab.widgets.map(projectWidget) };
+}
+
+export function projectSharedChangeRequest(
+  request: WorkspaceChangeRequest,
+): SharedWorkspaceChangeRequest {
+  return {
+    id: request.id,
+    isolationDomainId: request.isolationDomainId,
+    workspaceId: request.workspaceId,
+    tabId: request.tabId,
+    requester: { ...request.requester },
+    baseTabRevision: request.baseTabRevision,
+    idempotencyKey: request.idempotencyKey,
+    proposal: {
+      ...request.proposal,
+      widgets: request.proposal.widgets.map(projectWidget),
+    },
+    state: request.state,
+    createdAt: request.createdAt,
+    ...(request.decider ? { decider: { ...request.decider } } : {}),
+    ...(request.decidedAt ? { decidedAt: request.decidedAt } : {}),
+    ...(request.decisionReason ? { decisionReason: request.decisionReason } : {}),
+    ...(request.cancelledAt ? { cancelledAt: request.cancelledAt } : {}),
+  };
+}

--- a/extensions/workspaces/src/store-router.test.ts
+++ b/extensions/workspaces/src/store-router.test.ts
@@ -1,0 +1,29 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { WorkspaceStoreRouter } from "./store-router.js";
+import { WorkspaceStore } from "./store.js";
+
+describe("WorkspaceStoreRouter", () => {
+  it("reuses one store per domain and keeps equal resource ids isolated", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-router-"));
+    const router = new WorkspaceStoreRouter(new WorkspaceStore({ stateDir }));
+    try {
+      const first = router.forDomain("domain-1");
+      const second = router.forDomain("domain-2");
+      expect(router.forDomain("domain-1")).toBe(first);
+
+      first.mutate(
+        (draft) => {
+          draft.tabs[0]!.title = "First tenant";
+        },
+        { actor: "user" },
+      );
+      expect(second.read().tabs[0]).toMatchObject({ id: "main", title: "Overview" });
+    } finally {
+      router.close();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/extensions/workspaces/src/store-router.ts
+++ b/extensions/workspaces/src/store-router.ts
@@ -1,0 +1,32 @@
+import { WorkspaceStore } from "./store.js";
+
+/** Keeps one shared writer per isolation domain while preserving the legacy default store. */
+export class WorkspaceStoreRouter {
+  readonly legacy: WorkspaceStore;
+  private readonly stores = new Map<string, WorkspaceStore>();
+
+  constructor(legacy = new WorkspaceStore()) {
+    this.legacy = legacy;
+    this.stores.set(legacy.isolationDomainId, legacy);
+  }
+
+  forDomain = (isolationDomainId: string): WorkspaceStore => {
+    const existing = this.stores.get(isolationDomainId);
+    if (existing) {
+      return existing;
+    }
+    const store = new WorkspaceStore({
+      stateDir: this.legacy.stateDir,
+      isolationDomainId,
+    });
+    this.stores.set(isolationDomainId, store);
+    return store;
+  };
+
+  close(): void {
+    for (const store of this.stores.values()) {
+      store.close();
+    }
+    this.stores.clear();
+  }
+}

--- a/extensions/workspaces/src/store.test.ts
+++ b/extensions/workspaces/src/store.test.ts
@@ -1,7 +1,9 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
+import { DEFAULT_WORKSPACE } from "./default-workspace.js";
 import { validateWorkspaceDoc, type WorkspaceDoc } from "./schema.js";
 import { WorkspaceStore } from "./store.js";
 
@@ -31,10 +33,237 @@ describe("WorkspaceStore", () => {
     await withStore((store) => {
       const doc = store.read();
 
-      expect(doc.tabs[0]).toMatchObject({ slug: "main", title: "Overview", createdBy: "system" });
+      expect(doc).toMatchObject({
+        workspaceId: "default",
+        tabs: [{ id: "main", slug: "main", revision: 1, title: "Overview", createdBy: "system" }],
+      });
       expect(doc.workspaceVersion).toBe(1);
       // A second read hits the single-slot cache and must agree with the DB.
       expect(store.read()).toEqual(doc);
+    });
+  });
+
+  it("increments only tabs whose persisted content changed", async () => {
+    await withStore((store) => {
+      store.mutate(
+        (draft) => {
+          draft.tabs.push({
+            id: "second",
+            revision: 999,
+            slug: "second",
+            title: "Second",
+            hidden: false,
+            createdBy: "user",
+            widgets: [],
+          });
+          draft.prefs.tabOrder.push("second");
+        },
+        { actor: "user" },
+      );
+      expect(store.read().tabs.map((tab) => [tab.id, tab.revision])).toEqual([
+        ["main", 1],
+        ["second", 1],
+      ]);
+
+      const changed = store.mutate(
+        (draft) => {
+          draft.tabs[0]!.title = "Changed";
+          draft.tabs[0]!.revision = 800;
+          draft.tabs[1]!.revision = 700;
+        },
+        { actor: "user" },
+      ).doc;
+
+      expect(changed.tabs.map((tab) => [tab.id, tab.revision])).toEqual([
+        ["main", 2],
+        ["second", 1],
+      ]);
+    });
+  });
+
+  it("does not increment a tab revision for unrelated workspace state", async () => {
+    await withStore((store) => {
+      const changed = store.mutate(
+        (draft) => {
+          draft.widgetsRegistry.chart = { status: "pending", createdBy: "agent:finance" };
+        },
+        { actor: "agent:finance" },
+      ).doc;
+
+      expect(changed.tabs[0]?.revision).toBe(1);
+    });
+  });
+
+  it("ignores forged revisions on whole-document replacement", async () => {
+    await withStore((store) => {
+      const unchanged = structuredClone(store.read());
+      unchanged.tabs[0]!.revision = 900;
+      expect(store.replace(unchanged, { actor: "user" }).doc.tabs[0]?.revision).toBe(1);
+
+      const changed = structuredClone(store.read());
+      changed.tabs[0]!.revision = 800;
+      changed.tabs[0]!.title = "Replacement";
+      expect(store.replace(changed, { actor: "user" }).doc.tabs[0]?.revision).toBe(2);
+    });
+  });
+
+  it("partitions workspace documents and undo history by isolation domain", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-domains-"));
+    const first = new WorkspaceStore({ stateDir, isolationDomainId: "domain-1" });
+    const second = new WorkspaceStore({ stateDir, isolationDomainId: "domain-2" });
+    try {
+      first.mutate(
+        (draft) => {
+          draft.tabs[0]!.title = "Domain One";
+        },
+        { actor: "user" },
+      );
+      second.mutate(
+        (draft) => {
+          draft.tabs[0]!.title = "Domain Two";
+        },
+        { actor: "user" },
+      );
+
+      expect(first.read().tabs[0]?.title).toBe("Domain One");
+      expect(second.read().tabs[0]?.title).toBe("Domain Two");
+      expect(first.undo().tabs[0]?.title).toBe("Overview");
+      expect(second.read().tabs[0]?.title).toBe("Domain Two");
+    } finally {
+      first.close();
+      second.close();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("migrates the singleton v1 database into the default isolation domain", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-legacy-"));
+    const workspaceDir = path.join(stateDir, "workspaces");
+    const dbPath = path.join(workspaceDir, "workspaces.sqlite");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    const legacy = structuredClone(DEFAULT_WORKSPACE) as unknown as {
+      schemaVersion: number;
+      workspaceId?: string;
+      tabs: Array<{ id?: string; revision?: number }>;
+    };
+    legacy.schemaVersion = 1;
+    delete legacy.workspaceId;
+    for (const tab of legacy.tabs) {
+      delete tab.id;
+      delete tab.revision;
+    }
+    const db = new DatabaseSync(dbPath);
+    db.exec(`
+      CREATE TABLE workspace (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        version INTEGER NOT NULL,
+        doc TEXT NOT NULL,
+        updated_ms INTEGER NOT NULL
+      );
+      CREATE TABLE undo (
+        version INTEGER PRIMARY KEY,
+        doc TEXT NOT NULL,
+        created_ms INTEGER NOT NULL
+      );
+    `);
+    db.prepare("INSERT INTO workspace (id, version, doc, updated_ms) VALUES (1, 7, ?, 1)").run(
+      JSON.stringify({ ...legacy, workspaceVersion: 7 }),
+    );
+    db.close();
+
+    const store = new WorkspaceStore({ stateDir });
+    try {
+      const doc = store.read();
+      expect(doc).toMatchObject({
+        schemaVersion: 2,
+        workspaceId: "default",
+        workspaceVersion: 7,
+        tabs: [{ id: "main", slug: "main" }],
+      });
+    } finally {
+      store.close();
+    }
+
+    const inspected = new DatabaseSync(dbPath);
+    try {
+      expect(inspected.prepare("PRAGMA table_info(workspace)").all()).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "isolation_domain_id" }),
+          expect.objectContaining({ name: "workspace_id" }),
+        ]),
+      );
+      const row = inspected
+        .prepare(
+          "SELECT isolation_domain_id, workspace_id, doc FROM workspace WHERE isolation_domain_id = ?",
+        )
+        .get("default") as { isolation_domain_id: string; workspace_id: string; doc: string };
+      expect(row).toMatchObject({ isolation_domain_id: "default", workspace_id: "default" });
+      expect(JSON.parse(row.doc)).toMatchObject({ schemaVersion: 2, workspaceId: "default" });
+    } finally {
+      inspected.close();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects direct mutation of stable resource ids", async () => {
+    await withStore((store) => {
+      const before = store.read();
+
+      expect(() =>
+        store.mutate(
+          (draft) => {
+            draft.workspaceId = "other";
+          },
+          { actor: "user" },
+        ),
+      ).toThrow("workspaceId is immutable");
+      expect(() =>
+        store.mutate(
+          (draft) => {
+            draft.tabs[0]!.id = "other";
+          },
+          { actor: "user" },
+        ),
+      ).toThrow("tab id is immutable");
+      expect(store.read()).toEqual(before);
+    });
+  });
+
+  it("replace preserves existing stable ids when a tab keeps its slug", async () => {
+    await withStore((store) => {
+      const incoming = structuredClone(store.read());
+      incoming.workspaceId = "forged";
+      incoming.tabs[0]!.id = "forged-tab";
+
+      const { doc } = store.replace(incoming, { actor: "user" });
+
+      expect(doc.workspaceId).toBe("default");
+      expect(doc.tabs[0]?.id).toBe("main");
+    });
+  });
+
+  it("canonicalizes legacy v1 replacement input before reconciling resource ids", async () => {
+    await withStore((store) => {
+      const legacy = structuredClone(store.read()) as unknown as {
+        schemaVersion: number;
+        workspaceId?: string;
+        tabs: Array<{ id?: string; revision?: number; title: string }>;
+      };
+      legacy.schemaVersion = 1;
+      delete legacy.workspaceId;
+      for (const tab of legacy.tabs) {
+        delete tab.id;
+        delete tab.revision;
+      }
+      legacy.tabs[0]!.title = "Imported Legacy Layout";
+
+      const { doc } = store.replace(legacy, { actor: "user" });
+
+      expect(doc).toMatchObject({
+        schemaVersion: 2,
+        workspaceId: "default",
+        tabs: [{ id: "main", slug: "main", title: "Imported Legacy Layout" }],
+      });
     });
   });
 
@@ -194,6 +423,8 @@ describe("WorkspaceStore", () => {
           // Existing system tab, relabelled as agent-authored.
           { ...seeded.tabs[0]!, createdBy: "agent:evil" },
           {
+            id: "new",
+            revision: 1,
             slug: "new",
             title: "New",
             hidden: false,

--- a/extensions/workspaces/src/store.test.ts
+++ b/extensions/workspaces/src/store.test.ts
@@ -290,6 +290,38 @@ describe("WorkspaceStore", () => {
     });
   });
 
+  it("restores a deleted tab under a fresh resource id", async () => {
+    await withStore((store) => {
+      store.mutate(
+        (draft) => {
+          draft.tabs.push({
+            id: "finance",
+            revision: 1,
+            slug: "finance",
+            title: "Finance",
+            hidden: false,
+            createdBy: "user",
+            widgets: [],
+          });
+          draft.prefs.tabOrder.push("finance");
+        },
+        { actor: "user" },
+      );
+      store.mutate(
+        (draft) => {
+          draft.tabs = draft.tabs.filter((tab) => tab.id !== "finance");
+          draft.prefs.tabOrder = draft.prefs.tabOrder.filter((slug) => slug !== "finance");
+        },
+        { actor: "user" },
+      );
+
+      const restored = store.undo();
+      const finance = restored.tabs.find((tab) => tab.slug === "finance");
+      expect(finance?.id).not.toBe("finance");
+      expect(finance?.revision).toBe(1);
+    });
+  });
+
   it("evicts the oldest undo snapshot past the ring size", async () => {
     await withStore((store) => {
       store.read();

--- a/extensions/workspaces/src/store.ts
+++ b/extensions/workspaces/src/store.ts
@@ -20,6 +20,7 @@
 // already hold durable layout state, so it is migrated once into the default
 // isolation-domain partition and its v1 documents are rewritten canonically.
 
+import { randomUUID } from "node:crypto";
 import { chmodSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -27,6 +28,24 @@ import { isDeepStrictEqual } from "node:util";
 import { configureSqliteConnectionPragmas } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import { WidgetAssetTokens } from "./asset-tokens.js";
+import {
+  hashChangeRequestProposal,
+  parseChangeRequestState,
+  reconcileChangeRequestProposal,
+  validateChangeRequestId,
+  validateChangeRequestRequester,
+  validateDecisionReason,
+  validateHumanDecider,
+  validateIdempotencyKey,
+  type CancelWorkspaceChangeRequestInput,
+  type CreateWorkspaceChangeRequestInput,
+  type DecideWorkspaceChangeRequestInput,
+  type WorkspaceChangeRequest,
+  type WorkspaceChangeRequestDecisionResult,
+  type WorkspaceChangeRequestListFilter,
+  type WorkspaceRequester,
+  type WorkspaceTabProposal,
+} from "./change-requests.js";
 import { DEFAULT_WORKSPACE } from "./default-workspace.js";
 import {
   DEFAULT_WORKSPACE_ID,
@@ -64,9 +83,222 @@ CREATE TABLE IF NOT EXISTS undo (
   created_ms INTEGER NOT NULL,
   PRIMARY KEY (isolation_domain_id, workspace_id, version)
 );
+CREATE TABLE IF NOT EXISTS workspace_tab_id_tombstones (
+  isolation_domain_id TEXT NOT NULL,
+  workspace_id TEXT NOT NULL,
+  tab_id TEXT NOT NULL,
+  removed_ms INTEGER NOT NULL,
+  PRIMARY KEY (isolation_domain_id, workspace_id, tab_id)
+);
+CREATE TABLE IF NOT EXISTS workspace_change_requests (
+  isolation_domain_id TEXT NOT NULL,
+  workspace_id TEXT NOT NULL,
+  id TEXT NOT NULL CHECK (length(id) BETWEEN 1 AND 64),
+  tab_id TEXT NOT NULL CHECK (length(tab_id) BETWEEN 1 AND 64),
+  requester_principal_id TEXT NOT NULL CHECK (length(requester_principal_id) BETWEEN 1 AND 256),
+  requester_kind TEXT NOT NULL CHECK (requester_kind IN ('human', 'agent')),
+  delegation_id TEXT,
+  sponsor_principal_id TEXT,
+  base_tab_revision INTEGER NOT NULL CHECK (base_tab_revision >= 1),
+  idempotency_key TEXT NOT NULL CHECK (length(idempotency_key) BETWEEN 1 AND 128),
+  proposal_json TEXT NOT NULL CHECK (json_valid(proposal_json) AND length(proposal_json) <= 131072),
+  proposal_sha256 TEXT NOT NULL CHECK (length(proposal_sha256) = 64 AND proposal_sha256 NOT GLOB '*[^a-f0-9]*'),
+  state TEXT NOT NULL CHECK (state IN ('pending', 'approved', 'rejected', 'cancelled', 'conflict')),
+  created_ms INTEGER NOT NULL CHECK (created_ms >= 0),
+  decider_principal_id TEXT,
+  decider_kind TEXT CHECK (decider_kind IS NULL OR decider_kind = 'human'),
+  decided_ms INTEGER,
+  decision_reason TEXT CHECK (decision_reason IS NULL OR length(decision_reason) <= 2048),
+  cancelled_ms INTEGER,
+  PRIMARY KEY (isolation_domain_id, workspace_id, id),
+  UNIQUE (
+    isolation_domain_id,
+    workspace_id,
+    requester_principal_id,
+    requester_kind,
+    idempotency_key
+  ),
+  CHECK (
+    (requester_kind = 'human' AND delegation_id IS NULL AND sponsor_principal_id IS NULL)
+    OR
+    (requester_kind = 'agent' AND (
+      (delegation_id IS NULL AND sponsor_principal_id IS NULL)
+      OR (delegation_id IS NOT NULL AND sponsor_principal_id IS NOT NULL)
+    ))
+  ),
+  CHECK (
+    (state = 'pending' AND decider_principal_id IS NULL AND decider_kind IS NULL
+      AND decided_ms IS NULL AND decision_reason IS NULL AND cancelled_ms IS NULL)
+    OR
+    (state = 'cancelled' AND decider_principal_id IS NULL AND decider_kind IS NULL
+      AND decided_ms IS NULL AND decision_reason IS NULL AND cancelled_ms IS NOT NULL)
+    OR
+    (state IN ('approved', 'rejected', 'conflict') AND decider_principal_id IS NOT NULL
+      AND decider_kind = 'human' AND decided_ms IS NOT NULL AND cancelled_ms IS NULL)
+  )
+);
+CREATE INDEX IF NOT EXISTS idx_workspace_change_requests_tab_state
+  ON workspace_change_requests(isolation_domain_id, workspace_id, tab_id, state, created_ms);
+CREATE TABLE IF NOT EXISTS workspace_change_request_events (
+  event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  isolation_domain_id TEXT NOT NULL,
+  workspace_id TEXT NOT NULL,
+  request_id TEXT NOT NULL,
+  from_state TEXT,
+  to_state TEXT NOT NULL,
+  actor_principal_id TEXT NOT NULL,
+  actor_kind TEXT NOT NULL CHECK (actor_kind IN ('human', 'agent')),
+  reason TEXT,
+  created_ms INTEGER NOT NULL,
+  FOREIGN KEY (isolation_domain_id, workspace_id, request_id)
+    REFERENCES workspace_change_requests(isolation_domain_id, workspace_id, id)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_workspace_change_request_events_transition
+  ON workspace_change_request_events(
+    isolation_domain_id,
+    workspace_id,
+    request_id,
+    COALESCE(from_state, ''),
+    to_state
+  );
+CREATE TRIGGER IF NOT EXISTS workspace_change_requests_payload_immutable
+BEFORE UPDATE ON workspace_change_requests
+WHEN NEW.isolation_domain_id IS NOT OLD.isolation_domain_id
+  OR NEW.workspace_id IS NOT OLD.workspace_id
+  OR NEW.id IS NOT OLD.id
+  OR NEW.tab_id IS NOT OLD.tab_id
+  OR NEW.requester_principal_id IS NOT OLD.requester_principal_id
+  OR NEW.requester_kind IS NOT OLD.requester_kind
+  OR NEW.delegation_id IS NOT OLD.delegation_id
+  OR NEW.sponsor_principal_id IS NOT OLD.sponsor_principal_id
+  OR NEW.base_tab_revision IS NOT OLD.base_tab_revision
+  OR NEW.idempotency_key IS NOT OLD.idempotency_key
+  OR NEW.proposal_json IS NOT OLD.proposal_json
+  OR NEW.proposal_sha256 IS NOT OLD.proposal_sha256
+  OR NEW.created_ms IS NOT OLD.created_ms
+BEGIN
+  SELECT RAISE(ABORT, 'workspace change request immutable payload cannot be changed');
+END;
+CREATE TRIGGER IF NOT EXISTS workspace_change_requests_transition_guard
+BEFORE UPDATE OF state ON workspace_change_requests
+WHEN OLD.state != 'pending'
+  OR NEW.state NOT IN ('approved', 'rejected', 'cancelled', 'conflict')
+BEGIN
+  SELECT RAISE(ABORT, 'workspace change request terminal state cannot transition');
+END;
+CREATE TRIGGER IF NOT EXISTS workspace_change_requests_terminal_metadata_guard
+BEFORE UPDATE OF decider_principal_id, decider_kind, decided_ms, decision_reason, cancelled_ms
+ON workspace_change_requests
+WHEN OLD.state != 'pending' OR NEW.state = OLD.state
+BEGIN
+  SELECT RAISE(ABORT, 'workspace change request terminal decision metadata cannot be changed');
+END;
+CREATE TRIGGER IF NOT EXISTS workspace_change_requests_delete_forbidden
+BEFORE DELETE ON workspace_change_requests
+BEGIN
+  SELECT RAISE(ABORT, 'workspace change requests cannot be deleted');
+END;
+CREATE TRIGGER IF NOT EXISTS workspace_change_request_events_after_insert
+AFTER INSERT ON workspace_change_requests
+BEGIN
+  INSERT INTO workspace_change_request_events (
+    isolation_domain_id, workspace_id, request_id, from_state, to_state,
+    actor_principal_id, actor_kind, reason, created_ms
+  ) VALUES (
+    NEW.isolation_domain_id, NEW.workspace_id, NEW.id, NULL, 'pending',
+    NEW.requester_principal_id, NEW.requester_kind, NULL, NEW.created_ms
+  );
+END;
+CREATE TRIGGER IF NOT EXISTS workspace_change_request_events_after_transition
+AFTER UPDATE OF state ON workspace_change_requests
+BEGIN
+  INSERT INTO workspace_change_request_events (
+    isolation_domain_id, workspace_id, request_id, from_state, to_state,
+    actor_principal_id, actor_kind, reason, created_ms
+  ) VALUES (
+    NEW.isolation_domain_id, NEW.workspace_id, NEW.id, OLD.state, NEW.state,
+    CASE WHEN NEW.state = 'cancelled' THEN NEW.requester_principal_id ELSE NEW.decider_principal_id END,
+    CASE WHEN NEW.state = 'cancelled' THEN NEW.requester_kind ELSE NEW.decider_kind END,
+    NEW.decision_reason,
+    CASE WHEN NEW.state = 'cancelled' THEN NEW.cancelled_ms ELSE NEW.decided_ms END
+  );
+END;
+CREATE TRIGGER IF NOT EXISTS workspace_change_request_events_insert_guard
+BEFORE INSERT ON workspace_change_request_events
+WHEN NOT EXISTS (
+  SELECT 1 FROM workspace_change_requests AS request
+  WHERE request.isolation_domain_id = NEW.isolation_domain_id
+    AND request.workspace_id = NEW.workspace_id
+    AND request.id = NEW.request_id
+    AND (
+      (
+        NEW.from_state IS NULL
+        AND NEW.to_state = 'pending'
+        AND request.state = 'pending'
+        AND NEW.actor_principal_id = request.requester_principal_id
+        AND NEW.actor_kind = request.requester_kind
+        AND NEW.reason IS NULL
+        AND NEW.created_ms = request.created_ms
+      )
+      OR
+      (
+        NEW.from_state = 'pending'
+        AND NEW.to_state = request.state
+        AND request.state IN ('approved', 'rejected', 'conflict', 'cancelled')
+        AND NEW.actor_principal_id = CASE
+          WHEN request.state = 'cancelled' THEN request.requester_principal_id
+          ELSE request.decider_principal_id
+        END
+        AND NEW.actor_kind = CASE
+          WHEN request.state = 'cancelled' THEN request.requester_kind
+          ELSE request.decider_kind
+        END
+        AND NEW.reason IS request.decision_reason
+        AND NEW.created_ms = CASE
+          WHEN request.state = 'cancelled' THEN request.cancelled_ms
+          ELSE request.decided_ms
+        END
+      )
+    )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'workspace change request audit event is invalid');
+END;
+CREATE TRIGGER IF NOT EXISTS workspace_change_request_events_update_forbidden
+BEFORE UPDATE ON workspace_change_request_events
+BEGIN
+  SELECT RAISE(ABORT, 'workspace change request audit events are append-only');
+END;
+CREATE TRIGGER IF NOT EXISTS workspace_change_request_events_delete_forbidden
+BEFORE DELETE ON workspace_change_request_events
+BEGIN
+  SELECT RAISE(ABORT, 'workspace change request audit events are append-only');
+END;
 `;
 
 type SqliteTableColumn = { name: string };
+
+type WorkspaceChangeRequestRow = {
+  isolation_domain_id: string;
+  workspace_id: string;
+  id: string;
+  tab_id: string;
+  requester_principal_id: string;
+  requester_kind: string;
+  delegation_id: string | null;
+  sponsor_principal_id: string | null;
+  base_tab_revision: number;
+  idempotency_key: string;
+  proposal_json: string;
+  proposal_sha256: string;
+  state: string;
+  created_ms: number;
+  decider_principal_id: string | null;
+  decider_kind: string | null;
+  decided_ms: number | null;
+  decision_reason: string | null;
+  cancelled_ms: number | null;
+};
 
 function tableColumns(db: DatabaseSync, table: "workspace" | "undo"): Set<string> {
   return new Set(
@@ -127,6 +359,54 @@ function assertWorkspaceSize(serialized: string): void {
   if (Buffer.byteLength(serialized, "utf8") > MAX_WORKSPACE_BYTES) {
     throw new Error("workspace document exceeds 256 KB");
   }
+}
+
+function changeRequestFromRow(row: WorkspaceChangeRequestRow): WorkspaceChangeRequest {
+  const requester = validateChangeRequestRequester({
+    principalId: row.requester_principal_id,
+    kind: row.requester_kind,
+    ...(row.delegation_id === null ? {} : { delegationId: row.delegation_id }),
+    ...(row.sponsor_principal_id === null ? {} : { sponsorPrincipalId: row.sponsor_principal_id }),
+  });
+  const decider =
+    row.decider_principal_id === null
+      ? undefined
+      : validateHumanDecider({ principalId: row.decider_principal_id, kind: row.decider_kind });
+  return Object.freeze({
+    id: row.id,
+    isolationDomainId: row.isolation_domain_id,
+    workspaceId: row.workspace_id,
+    tabId: row.tab_id,
+    requester: Object.freeze(requester),
+    baseTabRevision: row.base_tab_revision,
+    idempotencyKey: row.idempotency_key,
+    proposal: JSON.parse(row.proposal_json) as WorkspaceTabProposal,
+    proposalSha256: row.proposal_sha256,
+    state: parseChangeRequestState(row.state),
+    createdAt: new Date(row.created_ms).toISOString(),
+    ...(decider === undefined ? {} : { decider: Object.freeze(decider) }),
+    ...(row.decided_ms === null ? {} : { decidedAt: new Date(row.decided_ms).toISOString() }),
+    ...(row.decision_reason === null ? {} : { decisionReason: row.decision_reason }),
+    ...(row.cancelled_ms === null ? {} : { cancelledAt: new Date(row.cancelled_ms).toISOString() }),
+  });
+}
+
+function requesterMatches(left: WorkspaceRequester, right: WorkspaceRequester): boolean {
+  return (
+    left.principalId === right.principalId &&
+    left.kind === right.kind &&
+    (left.kind !== "agent" ||
+      (right.kind === "agent" &&
+        left.delegationId === right.delegationId &&
+        left.sponsorPrincipalId === right.sponsorPrincipalId))
+  );
+}
+
+function assertBaseTabRevision(value: unknown): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 1) {
+    throw new Error("base tab revision must be a positive safe integer");
+  }
+  return value as number;
 }
 
 /**
@@ -287,6 +567,186 @@ export class WorkspaceStore {
     return this.widgetEntry(name)?.status ?? null;
   }
 
+  createChangeRequest(input: CreateWorkspaceChangeRequestInput): WorkspaceChangeRequest {
+    const id = validateChangeRequestId(input.id);
+    const tabId = validateChangeRequestId(input.tabId, "tab id");
+    const requester = validateChangeRequestRequester(input.requester);
+    const baseTabRevision = assertBaseTabRevision(input.baseTabRevision);
+    const idempotencyKey = validateIdempotencyKey(input.idempotencyKey);
+    return this.changeRequestTransaction(() => {
+      const current = this.read();
+      const tab = current.tabs.find((entry) => entry.id === tabId);
+      if (!tab) {
+        throw new Error(`workspace tab not found: ${tabId}`);
+      }
+      const canonical = reconcileChangeRequestProposal({
+        proposal: input.proposal,
+        current,
+        tab,
+        requester,
+      }).proposal;
+      const proposalJson = JSON.stringify(canonical);
+      const proposalSha256 = hashChangeRequestProposal(canonical);
+      const existing = this.db
+        .prepare(
+          `SELECT * FROM workspace_change_requests
+           WHERE isolation_domain_id = ? AND workspace_id = ?
+             AND requester_principal_id = ? AND requester_kind = ? AND idempotency_key = ?`,
+        )
+        .get(
+          this.isolationDomainId,
+          this.workspaceId,
+          requester.principalId,
+          requester.kind,
+          idempotencyKey,
+        ) as WorkspaceChangeRequestRow | undefined;
+      if (existing) {
+        const existingRequest = changeRequestFromRow(existing);
+        const samePayload =
+          existing.tab_id === tabId &&
+          existing.base_tab_revision === baseTabRevision &&
+          existing.proposal_sha256 === proposalSha256 &&
+          existing.proposal_json === proposalJson &&
+          requesterMatches(existingRequest.requester, requester);
+        if (!samePayload) {
+          throw new Error("idempotency key already belongs to a different change request payload");
+        }
+        return existingRequest;
+      }
+      const createdMs = Date.now();
+      this.db
+        .prepare(
+          `INSERT INTO workspace_change_requests (
+            isolation_domain_id, workspace_id, id, tab_id,
+            requester_principal_id, requester_kind, delegation_id, sponsor_principal_id,
+            base_tab_revision, idempotency_key, proposal_json, proposal_sha256, state, created_ms
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)`,
+        )
+        .run(
+          this.isolationDomainId,
+          this.workspaceId,
+          id,
+          tabId,
+          requester.principalId,
+          requester.kind,
+          requester.kind === "agent" ? (requester.delegationId ?? null) : null,
+          requester.kind === "agent" ? (requester.sponsorPrincipalId ?? null) : null,
+          baseTabRevision,
+          idempotencyKey,
+          proposalJson,
+          proposalSha256,
+          createdMs,
+        );
+      return this.requireChangeRequest(id);
+    });
+  }
+
+  readChangeRequest(id: string): WorkspaceChangeRequest | null {
+    const canonicalId = validateChangeRequestId(id);
+    const row = this.selectChangeRequest(canonicalId);
+    return row ? changeRequestFromRow(row) : null;
+  }
+
+  listChangeRequests(filter: WorkspaceChangeRequestListFilter = {}): WorkspaceChangeRequest[] {
+    const clauses = ["isolation_domain_id = ?", "workspace_id = ?"];
+    const values: Array<string> = [this.isolationDomainId, this.workspaceId];
+    if (filter.tabId !== undefined) {
+      clauses.push("tab_id = ?");
+      values.push(validateChangeRequestId(filter.tabId, "tab id"));
+    }
+    if (filter.state !== undefined) {
+      clauses.push("state = ?");
+      values.push(parseChangeRequestState(filter.state));
+    }
+    if (filter.requesterPrincipalId !== undefined) {
+      clauses.push("requester_principal_id = ?");
+      values.push(filter.requesterPrincipalId);
+    }
+    return (
+      this.db
+        .prepare(
+          `SELECT * FROM workspace_change_requests
+           WHERE ${clauses.join(" AND ")} ORDER BY created_ms, id`,
+        )
+        .all(...values) as unknown as WorkspaceChangeRequestRow[]
+    ).map(changeRequestFromRow);
+  }
+
+  cancelChangeRequest(input: CancelWorkspaceChangeRequestInput): WorkspaceChangeRequest {
+    const id = validateChangeRequestId(input.id);
+    const requester = validateChangeRequestRequester(input.requester);
+    return this.changeRequestTransaction(() => {
+      const request = changeRequestFromRow(this.requireChangeRequestRow(id));
+      if (!requesterMatches(request.requester, requester)) {
+        throw new Error("only the request creator can cancel a change request");
+      }
+      if (request.state !== "pending") {
+        throw new Error(`change request is already terminal: ${request.state}`);
+      }
+      this.db
+        .prepare(
+          `UPDATE workspace_change_requests SET state = 'cancelled', cancelled_ms = ?
+           WHERE isolation_domain_id = ? AND workspace_id = ? AND id = ?`,
+        )
+        .run(Date.now(), this.isolationDomainId, this.workspaceId, id);
+      return this.requireChangeRequest(id);
+    });
+  }
+
+  decideChangeRequest(
+    input: DecideWorkspaceChangeRequestInput,
+  ): WorkspaceChangeRequestDecisionResult {
+    const id = validateChangeRequestId(input.id);
+    const decider = validateHumanDecider(input.decider);
+    const reason = validateDecisionReason(input.reason);
+    if (input.decision !== "approved" && input.decision !== "rejected") {
+      throw new Error("change request decision is invalid");
+    }
+    return this.changeRequestTransaction(() => {
+      const current = this.read();
+      const request = this.requireChangeRequest(id);
+      if (request.state !== "pending") {
+        throw new Error(`change request is already terminal: ${request.state}`);
+      }
+      const tab = current.tabs.find((entry) => entry.id === request.tabId);
+      const revisionMatches = tab?.revision === request.baseTabRevision;
+      if (input.decision === "approved" && !revisionMatches) {
+        const conflictReason = tab
+          ? `tab revision changed from ${request.baseTabRevision} to ${tab.revision}`
+          : "workspace tab no longer exists";
+        this.setChangeRequestDecision(id, "conflict", decider.principalId, conflictReason);
+        return { request: this.requireChangeRequest(id), doc: current, applied: false };
+      }
+      if (input.decision === "rejected") {
+        this.setChangeRequestDecision(id, "rejected", decider.principalId, reason);
+        return { request: this.requireChangeRequest(id), doc: current, applied: false };
+      }
+      if (!tab) {
+        throw new Error(`workspace tab not found: ${request.tabId}`);
+      }
+      const reconciled = reconcileChangeRequestProposal({
+        proposal: request.proposal,
+        current,
+        tab,
+        requester: request.requester,
+      }).doc;
+      const tabs = structuredClone(reconciled.tabs);
+      const approvedTab = tabs.find((entry) => entry.id === tab.id);
+      if (!approvedTab) {
+        throw new Error(`workspace tab not found: ${request.tabId}`);
+      }
+      approvedTab.revision = tab.revision + 1;
+      const next = validateWorkspaceDoc({
+        ...reconciled,
+        workspaceVersion: current.workspaceVersion + 1,
+        tabs,
+      });
+      this.commit(next, { snapshot: null });
+      this.setChangeRequestDecision(id, "approved", decider.principalId, reason);
+      return { request: this.requireChangeRequest(id), doc: next, applied: true };
+    });
+  }
+
   /**
    * Applies `fn` to a draft of the current document and persists the result.
    * `fn` must be synchronous: it runs inside the write transaction, which is what
@@ -369,8 +829,44 @@ export class WorkspaceStore {
       this.cached = null;
       const current = this.read();
       const derived = derive(current);
-      assertStableResourceIds(current, derived);
-      const revised = stampTabRevisions(current, derived);
+      const nextIds = new Set(derived.tabs.map((tab) => tab.id));
+      const removedAt = Date.now();
+      for (const tab of current.tabs) {
+        if (!nextIds.has(tab.id)) {
+          this.db
+            .prepare(
+              `INSERT OR IGNORE INTO workspace_tab_id_tombstones
+                (isolation_domain_id, workspace_id, tab_id, removed_ms)
+               VALUES (?, ?, ?, ?)`,
+            )
+            .run(this.isolationDomainId, this.workspaceId, tab.id, removedAt);
+        }
+      }
+      const tombstones = new Set(
+        (
+          this.db
+            .prepare(
+              `SELECT tab_id FROM workspace_tab_id_tombstones
+               WHERE isolation_domain_id = ? AND workspace_id = ?`,
+            )
+            .all(this.isolationDomainId, this.workspaceId) as Array<{ tab_id: string }>
+        ).map((row) => row.tab_id),
+      );
+      const currentIds = new Set(current.tabs.map((tab) => tab.id));
+      const rekeyed: WorkspaceDoc = {
+        ...derived,
+        tabs: derived.tabs.map((tab) => {
+          if (currentIds.has(tab.id) || !tombstones.has(tab.id)) {
+            return tab;
+          }
+          const restored = structuredClone(tab);
+          restored.id = randomUUID();
+          restored.revision = 1;
+          return restored;
+        }),
+      };
+      assertStableResourceIds(current, rekeyed);
+      const revised = stampTabRevisions(current, rekeyed);
       const next = validateWorkspaceDoc({
         ...revised,
         workspaceVersion: current.workspaceVersion + 1,
@@ -383,6 +879,67 @@ export class WorkspaceStore {
       this.cached = null;
       throw error;
     }
+  }
+
+  private changeRequestTransaction<T>(operation: () => T): T {
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      // The transaction owns freshness. Another WorkspaceStore process may have
+      // committed since this instance populated its read cache.
+      this.cached = null;
+      const result = operation();
+      this.db.exec("COMMIT");
+      return result;
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      this.cached = null;
+      throw error;
+    }
+  }
+
+  private selectChangeRequest(id: string): WorkspaceChangeRequestRow | undefined {
+    return this.db
+      .prepare(
+        `SELECT * FROM workspace_change_requests
+         WHERE isolation_domain_id = ? AND workspace_id = ? AND id = ?`,
+      )
+      .get(this.isolationDomainId, this.workspaceId, id) as WorkspaceChangeRequestRow | undefined;
+  }
+
+  private requireChangeRequestRow(id: string): WorkspaceChangeRequestRow {
+    const row = this.selectChangeRequest(id);
+    if (!row) {
+      throw new Error(`workspace change request not found: ${id}`);
+    }
+    return row;
+  }
+
+  private requireChangeRequest(id: string): WorkspaceChangeRequest {
+    return changeRequestFromRow(this.requireChangeRequestRow(id));
+  }
+
+  private setChangeRequestDecision(
+    id: string,
+    state: "approved" | "rejected" | "conflict",
+    deciderPrincipalId: string,
+    reason?: string,
+  ): void {
+    this.db
+      .prepare(
+        `UPDATE workspace_change_requests SET
+          state = ?, decider_principal_id = ?, decider_kind = 'human',
+          decided_ms = ?, decision_reason = ?
+         WHERE isolation_domain_id = ? AND workspace_id = ? AND id = ?`,
+      )
+      .run(
+        state,
+        deciderPrincipalId,
+        Date.now(),
+        reason ?? null,
+        this.isolationDomainId,
+        this.workspaceId,
+        id,
+      );
   }
 
   /** Persists `doc` as the current workspace, pushing `snapshot` onto the undo ring. */

--- a/extensions/workspaces/src/store.ts
+++ b/extensions/workspaces/src/store.ts
@@ -16,17 +16,21 @@
 // There is deliberately no migration from the `workspace.json` this plugin used
 // while it was in review. The plugin has never been reachable from a release tag,
 // so no installation can hold that file, and compatibility here is opt-in per
-// AGENTS.md. Seeding the default workspace on an empty database is the only
-// first-read path.
+// AGENTS.md. The landed singleton SQLite shape is different: local main users can
+// already hold durable layout state, so it is migrated once into the default
+// isolation-domain partition and its v1 documents are rewritten canonically.
 
 import { chmodSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import { isDeepStrictEqual } from "node:util";
 import { configureSqliteConnectionPragmas } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import { WidgetAssetTokens } from "./asset-tokens.js";
 import { DEFAULT_WORKSPACE } from "./default-workspace.js";
 import {
+  DEFAULT_WORKSPACE_ID,
+  migrateWorkspaceDoc,
   validateWorkspaceDoc,
   type WorkspaceActor,
   type WorkspaceWidgetRegistryEntry,
@@ -41,20 +45,79 @@ const UNDO_RING_SIZE = 20;
 const DIR_MODE = 0o700;
 const FILE_MODE = 0o600;
 const BUSY_TIMEOUT_MS = 5000;
+export const DEFAULT_ISOLATION_DOMAIN_ID = "default";
 
 const SCHEMA = `
 CREATE TABLE IF NOT EXISTS workspace (
-  id INTEGER PRIMARY KEY CHECK (id = 1),
+  isolation_domain_id TEXT NOT NULL,
+  workspace_id TEXT NOT NULL,
   version INTEGER NOT NULL,
   doc TEXT NOT NULL,
-  updated_ms INTEGER NOT NULL
+  updated_ms INTEGER NOT NULL,
+  PRIMARY KEY (isolation_domain_id, workspace_id)
 );
 CREATE TABLE IF NOT EXISTS undo (
-  version INTEGER PRIMARY KEY,
+  isolation_domain_id TEXT NOT NULL,
+  workspace_id TEXT NOT NULL,
+  version INTEGER NOT NULL,
   doc TEXT NOT NULL,
-  created_ms INTEGER NOT NULL
+  created_ms INTEGER NOT NULL,
+  PRIMARY KEY (isolation_domain_id, workspace_id, version)
 );
 `;
+
+type SqliteTableColumn = { name: string };
+
+function tableColumns(db: DatabaseSync, table: "workspace" | "undo"): Set<string> {
+  return new Set(
+    (db.prepare(`PRAGMA table_info(${table})`).all() as unknown as SqliteTableColumn[]).map(
+      (column) => column.name,
+    ),
+  );
+}
+
+function initializeSchema(db: DatabaseSync): void {
+  const workspaceColumns = tableColumns(db, "workspace");
+  if (workspaceColumns.size === 0) {
+    db.exec(SCHEMA);
+    return;
+  }
+  if (workspaceColumns.has("isolation_domain_id")) {
+    db.exec(SCHEMA);
+    return;
+  }
+  if (!workspaceColumns.has("id")) {
+    throw new Error("unsupported workspaces database schema");
+  }
+
+  const undoColumns = tableColumns(db, "undo");
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    db.exec("ALTER TABLE workspace RENAME TO workspace_legacy_singleton");
+    if (undoColumns.size > 0) {
+      db.exec("ALTER TABLE undo RENAME TO undo_legacy_singleton");
+    }
+    db.exec(SCHEMA);
+    db.prepare(
+      `INSERT INTO workspace
+        (isolation_domain_id, workspace_id, version, doc, updated_ms)
+       SELECT ?, ?, version, doc, updated_ms FROM workspace_legacy_singleton WHERE id = 1`,
+    ).run(DEFAULT_ISOLATION_DOMAIN_ID, DEFAULT_WORKSPACE_ID);
+    if (undoColumns.size > 0) {
+      db.prepare(
+        `INSERT INTO undo
+          (isolation_domain_id, workspace_id, version, doc, created_ms)
+         SELECT ?, ?, version, doc, created_ms FROM undo_legacy_singleton`,
+      ).run(DEFAULT_ISOLATION_DOMAIN_ID, DEFAULT_WORKSPACE_ID);
+      db.exec("DROP TABLE undo_legacy_singleton");
+    }
+    db.exec("DROP TABLE workspace_legacy_singleton");
+    db.exec("COMMIT");
+  } catch (error) {
+    db.exec("ROLLBACK");
+    throw error;
+  }
+}
 
 function serializeWorkspaceDoc(doc: WorkspaceDoc): string {
   return JSON.stringify(doc);
@@ -89,28 +152,72 @@ function reconcileReplace(
   const widgetsRegistry: Record<string, WorkspaceWidgetRegistryEntry> = structuredClone(
     current.widgetsRegistry,
   );
+  const existingTabsById = new Map(current.tabs.map((tab) => [tab.id, tab]));
   const existingTabs = new Map(current.tabs.map((tab) => [tab.slug, tab]));
   const existingWidgets = new Map(
     current.tabs.flatMap((tab) => tab.widgets.map((widget) => [widget.id, widget] as const)),
   );
   return {
     ...incoming,
+    workspaceId: current.workspaceId,
     widgetsRegistry,
-    tabs: incoming.tabs.map((tab) => ({
-      ...tab,
-      createdBy: existingTabs.get(tab.slug)?.createdBy ?? actor,
-      widgets: tab.widgets.map((widget) => ({
-        ...widget,
-        createdBy: existingWidgets.get(widget.id)?.createdBy ?? actor,
-      })),
-    })),
+    tabs: incoming.tabs.map((tab) => {
+      const existing = existingTabsById.get(tab.id) ?? existingTabs.get(tab.slug);
+      return {
+        ...tab,
+        id: existing?.id ?? tab.id,
+        createdBy: existing?.createdBy ?? actor,
+        widgets: tab.widgets.map((widget) => ({
+          ...widget,
+          createdBy: existingWidgets.get(widget.id)?.createdBy ?? actor,
+        })),
+      };
+    }),
   };
+}
+
+function assertStableResourceIds(current: WorkspaceDoc, next: WorkspaceDoc): void {
+  if (next.workspaceId !== current.workspaceId) {
+    throw new Error("workspaceId is immutable");
+  }
+  const existingIdsBySlug = new Map(current.tabs.map((tab) => [tab.slug, tab.id]));
+  for (const tab of next.tabs) {
+    const existingId = existingIdsBySlug.get(tab.slug);
+    if (existingId !== undefined && tab.id !== existingId) {
+      throw new Error(`tab id is immutable for slug: ${tab.slug}`);
+    }
+  }
+}
+
+function tabContentEquals(
+  current: WorkspaceDoc["tabs"][number],
+  next: WorkspaceDoc["tabs"][number],
+) {
+  return isDeepStrictEqual({ ...current, revision: 1 }, { ...next, revision: 1 });
+}
+
+function stampTabRevisions(current: WorkspaceDoc, next: WorkspaceDoc): WorkspaceDoc {
+  const existingTabs = new Map(current.tabs.map((tab) => [tab.id, tab]));
+  const tabs: WorkspaceDoc["tabs"] = [];
+  for (const tab of next.tabs) {
+    const existing = existingTabs.get(tab.id);
+    const revision =
+      existing === undefined
+        ? 1
+        : tabContentEquals(existing, tab)
+          ? existing.revision
+          : existing.revision + 1;
+    tabs.push({ ...tab, revision });
+  }
+  return { ...next, tabs };
 }
 
 export class WorkspaceStore {
   readonly stateDir: string;
   readonly workspaceDir: string;
   readonly dbPath: string;
+  readonly isolationDomainId: string;
+  readonly workspaceId = DEFAULT_WORKSPACE_ID;
   private readonly db: DatabaseSync;
   readonly assetTokens = new WidgetAssetTokens();
   /**
@@ -121,8 +228,12 @@ export class WorkspaceStore {
    */
   private cached: WorkspaceDoc | null = null;
 
-  constructor(options: { stateDir?: string } = {}) {
+  constructor(options: { stateDir?: string; isolationDomainId?: string } = {}) {
     this.stateDir = options.stateDir ?? resolveStateDir();
+    this.isolationDomainId = options.isolationDomainId ?? DEFAULT_ISOLATION_DOMAIN_ID;
+    if (this.isolationDomainId.trim().length === 0) {
+      throw new Error("isolationDomainId must not be empty");
+    }
     this.workspaceDir = path.join(this.stateDir, "workspaces");
     this.dbPath = path.join(this.workspaceDir, "workspaces.sqlite");
     mkdirSync(this.workspaceDir, { recursive: true, mode: DIR_MODE });
@@ -131,7 +242,7 @@ export class WorkspaceStore {
       configureSqliteConnectionPragmas(this.db, { busyTimeoutMs: BUSY_TIMEOUT_MS });
       // WAL/SHM sidecars inherit the main DB file's permissions.
       chmodSync(this.dbPath, FILE_MODE);
-      this.db.exec(SCHEMA);
+      initializeSchema(this.db);
     } catch (error) {
       this.db.close();
       throw error;
@@ -146,15 +257,22 @@ export class WorkspaceStore {
     if (this.cached) {
       return structuredClone(this.cached);
     }
-    const row = this.db.prepare("SELECT doc FROM workspace WHERE id = 1").get() as
-      | { doc: string }
-      | undefined;
+    const row = this.db
+      .prepare("SELECT doc FROM workspace WHERE isolation_domain_id = ? AND workspace_id = ?")
+      .get(this.isolationDomainId, this.workspaceId) as { doc: string } | undefined;
     if (!row) {
       const seeded = validateWorkspaceDoc(structuredClone(DEFAULT_WORKSPACE));
       this.commit(seeded, { snapshot: null });
       return structuredClone(seeded);
     }
-    const doc = validateWorkspaceDoc(JSON.parse(row.doc));
+    const migrated = migrateWorkspaceDoc(JSON.parse(row.doc));
+    const doc = migrated.doc;
+    if (doc.workspaceId !== this.workspaceId) {
+      throw new Error(`workspace document id does not match stored workspace: ${this.workspaceId}`);
+    }
+    if (migrated.changed) {
+      this.commit(doc, { snapshot: null });
+    }
     this.cached = doc;
     return structuredClone(doc);
   }
@@ -190,10 +308,9 @@ export class WorkspaceStore {
    * are always reconciled against the stored document, so replace can neither
    * self-approve a custom widget nor forge a `createdBy` stamp.
    */
-  replace(doc: WorkspaceDoc, options: WorkspaceMutationOptions): WorkspaceMutationResult {
-    return this.transact((current) =>
-      reconcileReplace(structuredClone(doc), current, options.actor),
-    );
+  replace(doc: unknown, options: WorkspaceMutationOptions): WorkspaceMutationResult {
+    const canonical = migrateWorkspaceDoc(structuredClone(doc)).doc;
+    return this.transact((current) => reconcileReplace(canonical, current, options.actor));
   }
 
   /**
@@ -205,15 +322,26 @@ export class WorkspaceStore {
     return this.transact(
       (current) => {
         const row = this.db
-          .prepare("SELECT version, doc FROM undo ORDER BY version DESC LIMIT 1")
-          .get() as { version: number; doc: string } | undefined;
+          .prepare(
+            `SELECT version, doc FROM undo
+             WHERE isolation_domain_id = ? AND workspace_id = ?
+             ORDER BY version DESC LIMIT 1`,
+          )
+          .get(this.isolationDomainId, this.workspaceId) as
+          | { version: number; doc: string }
+          | undefined;
         if (!row) {
           throw new Error("no workspace undo snapshot available");
         }
-        this.db.prepare("DELETE FROM undo WHERE version = ?").run(row.version);
+        this.db
+          .prepare(
+            `DELETE FROM undo
+             WHERE isolation_domain_id = ? AND workspace_id = ? AND version = ?`,
+          )
+          .run(this.isolationDomainId, this.workspaceId, row.version);
         // transact() stamps the next version, so the restored document lands as a
         // forward write rather than a rewind.
-        const snapshot = validateWorkspaceDoc(JSON.parse(row.doc));
+        const snapshot = migrateWorkspaceDoc(JSON.parse(row.doc)).doc;
         // Approval state is a separate operator decision, not layout history.
         // Undo may restore tabs/widgets, but it must never revive a revoked
         // approval or discard a registry decision made after the snapshot.
@@ -240,8 +368,11 @@ export class WorkspaceStore {
       // is a read-path accelerator, not the transaction's snapshot.
       this.cached = null;
       const current = this.read();
+      const derived = derive(current);
+      assertStableResourceIds(current, derived);
+      const revised = stampTabRevisions(current, derived);
       const next = validateWorkspaceDoc({
-        ...derive(current),
+        ...revised,
         workspaceVersion: current.workspaceVersion + 1,
       });
       this.commit(next, { snapshot: options.snapshot === false ? null : current });
@@ -261,20 +392,47 @@ export class WorkspaceStore {
     const now = Date.now();
     if (params.snapshot) {
       this.db
-        .prepare("INSERT OR REPLACE INTO undo (version, doc, created_ms) VALUES (?, ?, ?)")
-        .run(doc.workspaceVersion, serializeWorkspaceDoc(params.snapshot), now);
+        .prepare(
+          `INSERT OR REPLACE INTO undo
+            (isolation_domain_id, workspace_id, version, doc, created_ms)
+           VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run(
+          this.isolationDomainId,
+          this.workspaceId,
+          doc.workspaceVersion,
+          serializeWorkspaceDoc(params.snapshot),
+          now,
+        );
       this.db
         .prepare(
-          "DELETE FROM undo WHERE version NOT IN (SELECT version FROM undo ORDER BY version DESC LIMIT ?)",
+          `DELETE FROM undo
+           WHERE isolation_domain_id = ? AND workspace_id = ?
+             AND version NOT IN (
+               SELECT version FROM undo
+               WHERE isolation_domain_id = ? AND workspace_id = ?
+               ORDER BY version DESC LIMIT ?
+             )`,
         )
-        .run(UNDO_RING_SIZE);
+        .run(
+          this.isolationDomainId,
+          this.workspaceId,
+          this.isolationDomainId,
+          this.workspaceId,
+          UNDO_RING_SIZE,
+        );
     }
     this.db
       .prepare(
-        "INSERT INTO workspace (id, version, doc, updated_ms) VALUES (1, ?, ?, ?) " +
-          "ON CONFLICT(id) DO UPDATE SET version = excluded.version, doc = excluded.doc, updated_ms = excluded.updated_ms",
+        `INSERT INTO workspace
+          (isolation_domain_id, workspace_id, version, doc, updated_ms)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(isolation_domain_id, workspace_id) DO UPDATE SET
+           version = excluded.version,
+           doc = excluded.doc,
+           updated_ms = excluded.updated_ms`,
       )
-      .run(doc.workspaceVersion, serialized, now);
+      .run(this.isolationDomainId, this.workspaceId, doc.workspaceVersion, serialized, now);
     this.cached = doc;
   }
 }

--- a/extensions/workspaces/src/tools.test.ts
+++ b/extensions/workspaces/src/tools.test.ts
@@ -74,6 +74,10 @@ describe("workspace tools", () => {
     const tools = toolsByName(new WorkspaceStore({ stateDir: "/tmp/unused" }));
     expect([...tools.keys()]).toEqual([
       "workspace_get",
+      "workspace_tab_get",
+      "workspace_change_request_create",
+      "workspace_change_request_list",
+      "workspace_change_request_cancel",
       "workspace_tab_create",
       "workspace_tab_update",
       "workspace_tab_delete",
@@ -90,6 +94,15 @@ describe("workspace tools", () => {
     ]);
     const validSamples: Record<string, unknown> = {
       workspace_get: {},
+      workspace_tab_get: { id: "main" },
+      workspace_change_request_create: {
+        tabId: "main",
+        baseRevision: 1,
+        proposal: {},
+        idempotencyKey: "request-1",
+      },
+      workspace_change_request_list: { tabId: "main" },
+      workspace_change_request_cancel: { tabId: "main", requestId: "request-1" },
       workspace_tab_create: { title: "Finance" },
       workspace_tab_update: { slug: "main", hidden: true },
       workspace_tab_delete: { slug: "old" },
@@ -133,6 +146,180 @@ describe("workspace tools", () => {
         false,
       );
     }
+  });
+
+  it("keeps workspace_get available to ordinary unbound local agent contexts", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const store = new WorkspaceStore({ stateDir });
+      const result = await toolsByName(store).get("workspace_get")?.execute("local-read", {});
+      expect(details(result).doc).toMatchObject({ workspaceId: "default" });
+      store.close();
+    });
+  });
+
+  it("authorizes and returns only one exact tab for a delegated tool call", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const legacy = new WorkspaceStore({ stateDir });
+      const domainStore = new WorkspaceStore({ stateDir, isolationDomainId: "domain-1" });
+      domainStore.mutate(
+        (draft) => {
+          draft.tabs[0]!.title = "Shared tab";
+          draft.tabs[0]!.widgets.push({
+            id: "private-widget",
+            kind: "custom:private-dashboard",
+            title: "Private",
+            grid: { x: 0, y: 4, w: 12, h: 4 },
+            collapsed: false,
+            hidden: false,
+            createdBy: "user",
+            bindings: { source: { source: "file", path: "private.json" } },
+            props: { secret: "do-not-return" },
+          });
+        },
+        { actor: "user" },
+      );
+      const toolContext = { agentId: "main", sessionKey: "agent:main:main" } as never;
+      const callContext = { callId: "call-1" };
+      const requireContext = vi.fn(() => callContext);
+      const decide = vi.fn(async () => ({
+        allowed: true as const,
+        context: {
+          isolationDomainId: "domain-1",
+          principal: { id: "principal-agent", kind: "agent" as const },
+          delegatedSession: {
+            id: "delegation-1",
+            assignmentId: "assignment-1",
+            sponsorPrincipalId: "principal-owner",
+          },
+          requestId: "call-1",
+        },
+      }));
+      const api = {
+        teams: {
+          context: { isBound: vi.fn(() => true), require: requireContext },
+          authorization: { decide },
+        },
+      };
+      const tools = new Map(
+        createWorkspaceTools({
+          api: api as unknown as OpenClawPluginApi,
+          context: toolContext,
+          store: legacy,
+          storeForDomain: (domainId) => (domainId === "domain-1" ? domainStore : legacy),
+        }).map((tool) => [tool.name, tool]),
+      );
+
+      const result = await tools.get("workspace_tab_get")?.execute("call-1", { id: "main" });
+      expect(requireContext).toHaveBeenCalledWith(toolContext);
+      expect(decide).toHaveBeenCalledWith({
+        context: callContext,
+        permission: "workspaces.tab.read",
+        resources: [{ namespace: "workspaces", type: "tab", id: "main" }],
+      });
+      expect(details(result)).toEqual({
+        workspaceId: "default",
+        workspaceVersion: 2,
+        tab: expect.objectContaining({ id: "main", revision: 2, title: "Shared tab" }),
+      });
+      expect(JSON.stringify(details(result))).not.toContain("private.json");
+      expect(JSON.stringify(details(result))).not.toContain("do-not-return");
+      const updated = await tools.get("workspace_tab_update")?.execute("call-2", {
+        id: "main",
+        ifRevision: 2,
+        title: "Delegated edit",
+      });
+      expect(decide).toHaveBeenLastCalledWith({
+        context: callContext,
+        permission: "workspaces.tab.write",
+        resources: [{ namespace: "workspaces", type: "tab", id: "main" }],
+      });
+      expect(details(updated)).toMatchObject({
+        workspaceId: "default",
+        workspaceVersion: 3,
+        tab: { id: "main", revision: 3, title: "Delegated edit" },
+      });
+      expect(details(updated)).not.toHaveProperty("doc");
+      expect(JSON.stringify(details(updated))).not.toContain("private.json");
+      expect(JSON.stringify(details(updated))).not.toContain("do-not-return");
+      const current = domainStore.read().tabs[0]!;
+      const proposal = {
+        slug: current.slug,
+        title: "Agent proposal",
+        ...(current.icon ? { icon: current.icon } : {}),
+        hidden: current.hidden,
+        widgets: current.widgets.map(({ createdBy: _createdBy, ...widget }) => widget),
+      };
+      const createdRequest = await tools.get("workspace_change_request_create")?.execute("call-3", {
+        tabId: "main",
+        baseRevision: 3,
+        proposal,
+        idempotencyKey: "request-1",
+      });
+      const requestId = (details(createdRequest).request as { id: string }).id;
+      expect(details(createdRequest)).toMatchObject({
+        request: {
+          id: requestId,
+          state: "pending",
+          requester: {
+            principalId: "principal-agent",
+            kind: "agent",
+            delegationId: "delegation-1",
+            sponsorPrincipalId: "principal-owner",
+          },
+        },
+      });
+      const listed = await tools.get("workspace_change_request_list")?.execute("call-4", {
+        tabId: "main",
+        state: "pending",
+      });
+      expect(details(listed).requests).toEqual([
+        expect.objectContaining({ id: requestId, state: "pending" }),
+      ]);
+      const cancelled = await tools.get("workspace_change_request_cancel")?.execute("call-5", {
+        tabId: "main",
+        requestId,
+      });
+      expect(details(cancelled)).toMatchObject({
+        request: { id: requestId, state: "cancelled" },
+      });
+      await expect(
+        tools.get("workspace_replace")?.execute("call-admin", { doc: domainStore.read() }),
+      ).rejects.toThrow(/admin tool is unavailable/i);
+      legacy.close();
+      domainStore.close();
+    });
+  });
+
+  it("fails closed when a bound Teams tool context is no longer active", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const store = new WorkspaceStore({ stateDir });
+      const api = {
+        teams: {
+          context: {
+            isBound: vi.fn(() => true),
+            require: vi.fn(() => {
+              throw new Error("tool invocation is inactive");
+            }),
+          },
+          authorization: { decide: vi.fn() },
+        },
+      };
+      const tools = new Map(
+        createWorkspaceTools({
+          api: api as unknown as OpenClawPluginApi,
+          context: { agentId: "main", sessionKey: "agent:main:main" } as never,
+          store,
+        }).map((tool) => [tool.name, tool]),
+      );
+
+      await expect(tools.get("workspace_get")?.execute("call-read", {})).rejects.toThrow(
+        /inactive/i,
+      );
+      await expect(
+        tools.get("workspace_replace")?.execute("call-admin", { doc: store.read() }),
+      ).rejects.toThrow(/inactive/i);
+      store.close();
+    });
   });
 
   it("stamps tool provenance from context and rejects createdBy override params", async () => {

--- a/extensions/workspaces/src/tools.test.ts
+++ b/extensions/workspaces/src/tools.test.ts
@@ -206,6 +206,8 @@ describe("workspace tools", () => {
       const replacement = structuredClone(store.read());
       replacement.tabs[0]!.createdBy = "agent:forged";
       replacement.tabs.push({
+        id: "agent-tab",
+        revision: 1,
         slug: "agent-tab",
         title: "Agent Tab",
         hidden: false,

--- a/extensions/workspaces/src/tools.ts
+++ b/extensions/workspaces/src/tools.ts
@@ -26,12 +26,14 @@ import {
   type JsonValue,
   type WorkspaceDoc,
 } from "./schema.js";
+import { projectSharedChangeRequest, projectSharedTab } from "./sharing-projection.js";
 import { WorkspaceStore } from "./store.js";
 
 type WorkspaceToolParams = {
   api: OpenClawPluginApi;
   context?: OpenClawPluginToolContext;
   store?: WorkspaceStore;
+  storeForDomain?: (isolationDomainId: string) => WorkspaceStore;
   broadcast?: WorkspaceBroadcast;
   dataRead?: ResolveBindingOptions;
 };
@@ -46,6 +48,7 @@ type MutationParams = {
 
 const TAB_SLUG_PATTERN = /^[a-z0-9-]{1,40}$/;
 const WIDGET_ID_PATTERN = /^[A-Za-z0-9_-]{1,48}$/;
+const RESOURCE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
 const TOOL_DESCRIPTION_SUFFIX = " Call workspace_get first when you need the current document.";
 
 /**
@@ -185,6 +188,25 @@ function readOptionalBoolean(record: Record<string, unknown>, key: string): bool
   return value;
 }
 
+function readOptionalInteger(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Number.isInteger(value) || (value as number) < 1) {
+    throw new Error(`${key} must be a positive integer`);
+  }
+  return value as number;
+}
+
+function readRequiredPositiveInteger(record: Record<string, unknown>, key: string): number {
+  const value = readOptionalInteger(record, key);
+  if (value === undefined) {
+    throw new Error(`${key} is required`);
+  }
+  return value;
+}
+
 function readSlug(record: Record<string, unknown>, key = "slug"): string {
   const slug = readRequiredString(record, key, key);
   if (!TAB_SLUG_PATTERN.test(slug)) {
@@ -196,6 +218,14 @@ function readSlug(record: Record<string, unknown>, key = "slug"): string {
 function readWidgetId(record: Record<string, unknown>, key = "id"): string {
   const id = readRequiredString(record, key, key);
   if (!WIDGET_ID_PATTERN.test(id)) {
+    throw new Error(`${key} is invalid`);
+  }
+  return id;
+}
+
+function readResourceId(record: Record<string, unknown>, key = "id"): string {
+  const id = readRequiredString(record, key, key);
+  if (!RESOURCE_ID_PATTERN.test(id)) {
     throw new Error(`${key} is invalid`);
   }
   return id;
@@ -478,6 +508,72 @@ export function createWorkspaceTools(params: WorkspaceToolParams): AnyAgentTool[
     actor,
     broadcast,
   };
+  const currentTeamsToolCall = () => {
+    if (!params.context || !params.api.teams?.context.isBound(params.context)) {
+      return undefined;
+    }
+    return params.api.teams.context.require(params.context);
+  };
+  const requireLegacyAdminTool = (): void => {
+    if (currentTeamsToolCall()) {
+      throw new Error("workspace admin tool is unavailable to delegated Teams agents");
+    }
+  };
+  const authorizeToolAccess = async (
+    call: NonNullable<ReturnType<typeof currentTeamsToolCall>>,
+    input: {
+      permission: string;
+      resources: Array<{ namespace: "workspaces"; type: "workspace" | "tab"; id: string }>;
+    },
+  ) => {
+    const decision = await params.api.teams.authorization.decide({
+      context: call,
+      permission: input.permission,
+      resources: input.resources,
+    });
+    if (!decision.allowed) {
+      throw new Error("workspace access denied");
+    }
+    return {
+      context: decision.context,
+      store: params.storeForDomain?.(decision.context.isolationDomainId) ?? store,
+    };
+  };
+  const authorizeToolStore = async (
+    call: NonNullable<ReturnType<typeof currentTeamsToolCall>>,
+    input: {
+      permission: string;
+      resources: Array<{ namespace: "workspaces"; type: "workspace" | "tab"; id: string }>;
+    },
+  ): Promise<WorkspaceStore> => {
+    return (await authorizeToolAccess(call, input)).store;
+  };
+  const requireExactToolStore = async (input: {
+    permission: string;
+    resources: Array<{ namespace: "workspaces"; type: "workspace" | "tab"; id: string }>;
+  }): Promise<WorkspaceStore> => {
+    const call = currentTeamsToolCall();
+    if (!call) {
+      throw new Error("an active Workspaces tool context is required");
+    }
+    return await authorizeToolStore(call, input);
+  };
+  const requesterFromContext = (
+    context: Awaited<ReturnType<typeof authorizeToolAccess>>["context"],
+  ) => {
+    if (context.principal.kind === "human") {
+      return { principalId: context.principal.id, kind: "human" as const };
+    }
+    if (!context.delegatedSession) {
+      throw new Error("a delegated agent assignment is required");
+    }
+    return {
+      principalId: context.principal.id,
+      kind: "agent" as const,
+      delegationId: context.delegatedSession.id,
+      sponsorPrincipalId: context.delegatedSession.sponsorPrincipalId,
+    };
+  };
   return [
     {
       name: "workspace_get",
@@ -485,8 +581,162 @@ export function createWorkspaceTools(params: WorkspaceToolParams): AnyAgentTool[
       description: "Read the full Workspaces document so an agent can diff before mutating it.",
       parameters: Type.Object({}, { additionalProperties: false }),
       execute: async () => {
-        const doc = store.read();
+        const teamsCall = currentTeamsToolCall();
+        const readableStore = teamsCall
+          ? await authorizeToolStore(teamsCall, {
+              permission: "workspaces.workspace.read",
+              resources: [{ namespace: "workspaces", type: "workspace", id: store.workspaceId }],
+            })
+          : store;
+        const doc = readableStore.read();
         return jsonResult({ doc, workspaceVersion: doc.workspaceVersion });
+      },
+    },
+    {
+      name: "workspace_tab_get",
+      label: "Workspace Tab Get",
+      description: "Read one exact workspace tab by its immutable resource id.",
+      parameters: Type.Object(
+        { id: Type.String({ description: "Immutable tab resource id." }) },
+        { additionalProperties: false },
+      ),
+      execute: async (_toolCallId, rawParams) => {
+        const record = readRecord(rawParams, ["id"]);
+        const id = readResourceId(record);
+        const readableStore = await requireExactToolStore({
+          permission: "workspaces.tab.read",
+          resources: [{ namespace: "workspaces", type: "tab", id }],
+        });
+        const doc = readableStore.read();
+        const tab = doc.tabs.find((entry) => entry.id === id);
+        if (!tab) {
+          throw new Error("workspace tab not found");
+        }
+        return jsonResult({
+          workspaceId: doc.workspaceId,
+          workspaceVersion: doc.workspaceVersion,
+          tab: projectSharedTab(tab),
+        });
+      },
+    },
+    {
+      name: "workspace_change_request_create",
+      label: "Workspace Change Request Create",
+      description: "Propose a complete replacement for one exact tab without applying it.",
+      parameters: Type.Object(
+        {
+          tabId: Type.String({ description: "Immutable tab resource id." }),
+          baseRevision: Type.Integer({ minimum: 1 }),
+          proposal: Type.Unknown(),
+          idempotencyKey: Type.String({ minLength: 1, maxLength: 128 }),
+        },
+        { additionalProperties: false },
+      ),
+      execute: async (_toolCallId, rawParams) => {
+        const record = readRecord(rawParams, [
+          "tabId",
+          "baseRevision",
+          "proposal",
+          "idempotencyKey",
+        ]);
+        const tabId = readResourceId(record, "tabId");
+        const call = currentTeamsToolCall();
+        if (!call) {
+          throw new Error("an active Workspaces tool context is required");
+        }
+        const authorized = await authorizeToolAccess(call, {
+          permission: "workspaces.tab.changeRequest.create",
+          resources: [{ namespace: "workspaces", type: "tab", id: tabId }],
+        });
+        const request = authorized.store.createChangeRequest({
+          id: randomUUID(),
+          tabId,
+          requester: requesterFromContext(authorized.context),
+          baseTabRevision: readRequiredPositiveInteger(record, "baseRevision"),
+          idempotencyKey: readRequiredString(record, "idempotencyKey"),
+          proposal: record.proposal,
+        });
+        return jsonResult({ request: projectSharedChangeRequest(request) });
+      },
+    },
+    {
+      name: "workspace_change_request_list",
+      label: "Workspace Change Request List",
+      description: "List this delegated principal's change requests for one exact tab.",
+      parameters: Type.Object(
+        {
+          tabId: Type.String({ description: "Immutable tab resource id." }),
+          state: Type.Optional(
+            Type.Union([
+              Type.Literal("pending"),
+              Type.Literal("approved"),
+              Type.Literal("rejected"),
+              Type.Literal("cancelled"),
+              Type.Literal("conflict"),
+            ]),
+          ),
+        },
+        { additionalProperties: false },
+      ),
+      execute: async (_toolCallId, rawParams) => {
+        const record = readRecord(rawParams, ["tabId", "state"]);
+        const tabId = readResourceId(record, "tabId");
+        const call = currentTeamsToolCall();
+        if (!call) {
+          throw new Error("an active Workspaces tool context is required");
+        }
+        const authorized = await authorizeToolAccess(call, {
+          permission: "workspaces.tab.read",
+          resources: [{ namespace: "workspaces", type: "tab", id: tabId }],
+        });
+        const requester = requesterFromContext(authorized.context);
+        const state = readOptionalString(record, "state") as
+          | "pending"
+          | "approved"
+          | "rejected"
+          | "cancelled"
+          | "conflict"
+          | undefined;
+        const requests = authorized.store.listChangeRequests({
+          tabId,
+          requesterPrincipalId: requester.principalId,
+          ...(state ? { state } : {}),
+        });
+        return jsonResult({ requests: requests.map(projectSharedChangeRequest) });
+      },
+    },
+    {
+      name: "workspace_change_request_cancel",
+      label: "Workspace Change Request Cancel",
+      description: "Cancel this delegated principal's pending change request.",
+      parameters: Type.Object(
+        {
+          tabId: Type.String({ description: "Immutable tab resource id." }),
+          requestId: Type.String({ description: "Change request id." }),
+        },
+        { additionalProperties: false },
+      ),
+      execute: async (_toolCallId, rawParams) => {
+        const record = readRecord(rawParams, ["tabId", "requestId"]);
+        const tabId = readResourceId(record, "tabId");
+        const requestId = readResourceId(record, "requestId");
+        const call = currentTeamsToolCall();
+        if (!call) {
+          throw new Error("an active Workspaces tool context is required");
+        }
+        const authorized = await authorizeToolAccess(call, {
+          permission: "workspaces.tab.changeRequest.create",
+          resources: [{ namespace: "workspaces", type: "tab", id: tabId }],
+        });
+        const existing = authorized.store.readChangeRequest(requestId);
+        if (!existing || existing.tabId !== tabId) {
+          throw new Error("workspace change request not found");
+        }
+        const request = authorized.store.cancelChangeRequest({
+          id: requestId,
+          requester: requesterFromContext(authorized.context),
+        });
+        return jsonResult({ request: projectSharedChangeRequest(request) });
       },
     },
     {
@@ -504,6 +754,7 @@ export function createWorkspaceTools(params: WorkspaceToolParams): AnyAgentTool[
         { additionalProperties: false },
       ),
       execute: async (_toolCallId, rawParams) => {
+        requireLegacyAdminTool();
         const record = readRecord(rawParams, ["title", "slug", "icon"]);
         const title = readRequiredString(record, "title", "title");
         const icon = readOptionalString(record, "icon");
@@ -541,7 +792,11 @@ export function createWorkspaceTools(params: WorkspaceToolParams): AnyAgentTool[
       description: toolDescription("Update a workspace tab title, icon, or hidden state."),
       parameters: Type.Object(
         {
-          slug: Type.String({ description: "Tab slug." }),
+          id: Type.Optional(Type.String({ description: "Immutable tab id for Teams access." })),
+          slug: Type.Optional(Type.String({ description: "Legacy local tab slug." })),
+          ifRevision: Type.Optional(
+            Type.Integer({ minimum: 1, description: "Required current tab revision." }),
+          ),
           title: Type.Optional(Type.String({ description: "New title." })),
           icon: Type.Optional(Type.String({ description: "New icon." })),
           hidden: Type.Optional(Type.Boolean({ description: "Hide or show the tab." })),
@@ -549,22 +804,59 @@ export function createWorkspaceTools(params: WorkspaceToolParams): AnyAgentTool[
         { additionalProperties: false },
       ),
       execute: async (_toolCallId, rawParams) => {
-        const record = readRecord(rawParams, ["slug", "title", "icon", "hidden"]);
-        const slug = readSlug(record);
+        const record = readRecord(rawParams, [
+          "id",
+          "slug",
+          "ifRevision",
+          "title",
+          "icon",
+          "hidden",
+        ]);
+        const teamsCall = currentTeamsToolCall();
+        const id = teamsCall ? readResourceId(record) : undefined;
+        const slug = teamsCall ? undefined : readSlug(record);
+        const targetStore = teamsCall
+          ? await authorizeToolStore(teamsCall, {
+              permission: "workspaces.tab.write",
+              resources: [{ namespace: "workspaces", type: "tab", id: id! }],
+            })
+          : store;
+        const ifRevision = readOptionalInteger(record, "ifRevision");
         const title = readOptionalString(record, "title");
         const icon = readOptionalString(record, "icon");
         const hidden = readOptionalBoolean(record, "hidden");
-        return await runMutation({
-          ...mutationBase,
-          changedTabSlug: slug,
-          mutate: (draft) => {
-            Object.assign(findTab(draft, slug), {
+        let changedTabSlug: string | undefined;
+        const result = targetStore.mutate(
+          (draft) => {
+            const tab = id ? draft.tabs.find((entry) => entry.id === id) : findTab(draft, slug!);
+            if (!tab) {
+              throw new Error("workspace tab not found");
+            }
+            if (ifRevision !== undefined && tab.revision !== ifRevision) {
+              throw new Error("workspace tab revision conflict");
+            }
+            changedTabSlug = tab.slug;
+            Object.assign(tab, {
               ...(title !== undefined ? { title } : {}),
               ...(icon !== undefined ? { icon } : {}),
               ...(hidden !== undefined ? { hidden } : {}),
             });
           },
-        });
+          { actor },
+        );
+        if (teamsCall && id) {
+          const tab = result.doc.tabs.find((entry) => entry.id === id);
+          if (!tab) {
+            throw new Error("workspace tab not found");
+          }
+          return jsonResult({
+            workspaceId: result.doc.workspaceId,
+            workspaceVersion: result.doc.workspaceVersion,
+            tab: projectSharedTab(tab),
+          });
+        }
+        broadcastChange(broadcast, { doc: result.doc, actor, changedTabSlug });
+        return jsonResult({ doc: result.doc, workspaceVersion: result.doc.workspaceVersion });
       },
     },
     {
@@ -576,6 +868,7 @@ export function createWorkspaceTools(params: WorkspaceToolParams): AnyAgentTool[
         { additionalProperties: false },
       ),
       execute: async (_toolCallId, rawParams) => {
+        requireLegacyAdminTool();
         const record = readRecord(rawParams, ["slug"]);
         const slug = readSlug(record);
         return await runMutation({
@@ -601,6 +894,7 @@ export function createWorkspaceTools(params: WorkspaceToolParams): AnyAgentTool[
         { additionalProperties: false },
       ),
       execute: async (_toolCallId, rawParams) => {
+        requireLegacyAdminTool();
         const record = readRecord(rawParams, ["order"]);
         const order = readOrder(record.order);
         return await runMutation({
@@ -632,6 +926,7 @@ export function createWorkspaceTools(params: WorkspaceToolParams): AnyAgentTool[
         { additionalProperties: false },
       ),
       execute: async (_toolCallId, rawParams) => {
+        requireLegacyAdminTool();
         const record = readRecord(rawParams, [
           "tab",
           "id",
@@ -668,6 +963,7 @@ export function createWorkspaceTools(params: WorkspaceToolParams): AnyAgentTool[
         { additionalProperties: false },
       ),
       execute: async (_toolCallId, rawParams) => {
+        requireLegacyAdminTool();
         const record = readRecord(rawParams, [
           "tab",
           "id",
@@ -712,6 +1008,7 @@ export function createWorkspaceTools(params: WorkspaceToolParams): AnyAgentTool[
         { additionalProperties: false },
       ),
       execute: async (_toolCallId, rawParams) => {
+        requireLegacyAdminTool();
         const record = readRecord(rawParams, ["tab", "id", "grid", "toTab"]);
         if (record.grid !== undefined && record.toTab !== undefined) {
           throw new Error("workspace_widget_move accepts either grid or toTab, not both");
@@ -761,6 +1058,7 @@ export function createWorkspaceTools(params: WorkspaceToolParams): AnyAgentTool[
         { additionalProperties: false },
       ),
       execute: async (_toolCallId, rawParams) => {
+        requireLegacyAdminTool();
         const record = readRecord(rawParams, ["tab", "id"]);
         const tabSlug = readSlug(record, "tab");
         const id = readWidgetId(record);
@@ -795,6 +1093,7 @@ export function createWorkspaceTools(params: WorkspaceToolParams): AnyAgentTool[
         { additionalProperties: false },
       ),
       execute: async (_toolCallId, rawParams) => {
+        requireLegacyAdminTool();
         const record = readRecord(rawParams, ["tab", "layout"]);
         const tabSlug = readSlug(record, "tab");
         const layout = readLayout(record.layout);
@@ -818,6 +1117,7 @@ export function createWorkspaceTools(params: WorkspaceToolParams): AnyAgentTool[
       ),
       parameters: Type.Object({ doc: Type.Unknown() }, { additionalProperties: false }),
       execute: async (_toolCallId, rawParams) => {
+        requireLegacyAdminTool();
         const record = readRecord(rawParams, ["doc"]);
         const result = store.replace(record.doc, { actor });
         broadcastChange(broadcast, { doc: result.doc, actor });
@@ -841,6 +1141,7 @@ export function createWorkspaceTools(params: WorkspaceToolParams): AnyAgentTool[
         { additionalProperties: false },
       ),
       execute: async (_toolCallId, rawParams) => {
+        requireLegacyAdminTool();
         const record = readRecord(rawParams, ["name", "title"]);
         const scaffold = await scaffoldWorkspaceWidget({
           name: readRequiredString(record, "name", "name"),
@@ -871,6 +1172,7 @@ export function createWorkspaceTools(params: WorkspaceToolParams): AnyAgentTool[
       description: "Restore the newest workspace undo snapshot.",
       parameters: Type.Object({}, { additionalProperties: false }),
       execute: async () => {
+        requireLegacyAdminTool();
         const doc = store.undo();
         broadcastChange(broadcast, { doc, actor });
         return jsonResult({ doc, workspaceVersion: doc.workspaceVersion });
@@ -885,6 +1187,7 @@ export function createWorkspaceTools(params: WorkspaceToolParams): AnyAgentTool[
         "because only the trusted Control UI may call the gateway on a widget's behalf.",
       parameters: Type.Object({ binding: BindingSchema }, { additionalProperties: false }),
       execute: async (_toolCallId, rawParams) => {
+        requireLegacyAdminTool();
         const record = readRecord(rawParams, ["binding"]);
         try {
           return jsonResult({ data: await resolveBinding(record.binding, params.dataRead) });

--- a/extensions/workspaces/src/tools.ts
+++ b/extensions/workspaces/src/tools.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { jsonResult } from "openclaw/plugin-sdk/core";
 import type {
   AnyAgentTool,
@@ -17,7 +18,6 @@ import { scaffoldWorkspaceWidget } from "./scaffold.js";
 import {
   BUILTIN_WIDGET_KINDS,
   isWorkspaceActor,
-  validateWorkspaceDoc,
   type WorkspaceActor,
   type WorkspaceBinding,
   type WorkspaceGrid,
@@ -518,6 +518,8 @@ export function createWorkspaceTools(params: WorkspaceToolParams): AnyAgentTool[
             }
             changedTabSlug = slug;
             draft.tabs.push({
+              id: randomUUID(),
+              revision: 1,
               slug,
               title,
               ...(icon !== undefined ? { icon } : {}),
@@ -817,8 +819,7 @@ export function createWorkspaceTools(params: WorkspaceToolParams): AnyAgentTool[
       parameters: Type.Object({ doc: Type.Unknown() }, { additionalProperties: false }),
       execute: async (_toolCallId, rawParams) => {
         const record = readRecord(rawParams, ["doc"]);
-        const doc = validateWorkspaceDoc(record.doc);
-        const result = store.replace(doc, { actor });
+        const result = store.replace(record.doc, { actor });
         broadcastChange(broadcast, { doc: result.doc, actor });
         return jsonResult({ doc: result.doc, workspaceVersion: result.doc.workspaceVersion });
       },

--- a/extensions/workspaces/src/ui-gateway-integration.test.ts
+++ b/extensions/workspaces/src/ui-gateway-integration.test.ts
@@ -46,10 +46,13 @@ type RoutingClient = NonNullable<Parameters<typeof loadWorkspace>[1]>;
 
 // One tab + one widget, seeded through the store's real replace() API.
 const SEED_DOC: WorkspaceDoc = {
-  schemaVersion: 1,
+  schemaVersion: 2,
+  workspaceId: "default",
   workspaceVersion: 0,
   tabs: [
     {
+      id: "ops",
+      revision: 1,
       slug: "ops",
       title: "Ops",
       hidden: false,

--- a/packages/gateway-protocol/src/schema/frames.ts
+++ b/packages/gateway-protocol/src/schema/frames.ts
@@ -87,6 +87,21 @@ export const ConnectParamsSchema = Type.Object(
   { additionalProperties: false },
 );
 
+/** Safe server-issued identity summary shared by Gateway clients and hello responses. */
+export const GatewayPrincipalSchema = Type.Object(
+  {
+    issuer: NonEmptyString,
+    subject: NonEmptyString,
+    kind: Type.Union([
+      Type.Literal("human"),
+      Type.Literal("device"),
+      Type.Literal("service"),
+      Type.Literal("shared"),
+    ]),
+  },
+  { additionalProperties: false },
+);
+
 /** Successful gateway hello response with negotiated protocol and initial state. */
 export const HelloOkSchema = Type.Object(
   {
@@ -129,6 +144,7 @@ export const HelloOkSchema = Type.Object(
     pluginSurfaceUrls: Type.Optional(Type.Record(NonEmptyString, NonEmptyString)),
     auth: Type.Object(
       {
+        principal: Type.Optional(GatewayPrincipalSchema),
         deviceToken: Type.Optional(NonEmptyString),
         role: NonEmptyString,
         scopes: Type.Array(NonEmptyString),
@@ -219,6 +235,7 @@ export const GatewayFrameSchema = Type.Union(
 // Frame types are owner-local because they cross the public client/plugin SDK.
 // Keeping them off the aggregate registry avoids retaining every RPC schema.
 export type ConnectParams = Static<typeof ConnectParamsSchema>;
+export type GatewayPrincipal = Readonly<Static<typeof GatewayPrincipalSchema>>;
 export type HelloOk = Static<typeof HelloOkSchema>;
 export type ErrorShape = Static<typeof ErrorShapeSchema>;
 export type RequestFrame = Static<typeof RequestFrameSchema>;

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -204,7 +204,7 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
     ),
     publicExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS",
-      10645,
+      10650,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -2990,30 +2990,43 @@ function emitIngressModelUsageDiagnostic(
   });
 }
 
-/** Runs an agent turn from an inbound channel/gateway ingress context. */
+/**
+ * Runs an agent turn from an inbound channel/gateway ingress context.
+ * Server-owned authorization stays separate so hostile ingress fields cannot replace it.
+ */
+function sanitizeAgentCommandIngressOpts(opts: AgentCommandIngressOpts): AgentCommandIngressOpts {
+  const sanitized = { ...opts } as AgentCommandIngressOpts & Partial<AgentCommandOpts>;
+  delete sanitized.authorizationSubject;
+  delete sanitized.resultMetaOverrides;
+  return sanitized;
+}
+
 export async function agentCommandFromIngress(
   opts: AgentCommandIngressOpts,
   runtime: RuntimeEnv = defaultRuntime,
   deps?: CliDeps,
+  trusted?: Readonly<Pick<AgentCommandOpts, "authorizationSubject">>,
 ) {
-  if (typeof opts.allowModelOverride !== "boolean") {
+  const ingressOpts = sanitizeAgentCommandIngressOpts(opts);
+  if (typeof ingressOpts.allowModelOverride !== "boolean") {
     throw new Error("allowModelOverride must be explicitly set for ingress agent runs.");
   }
   const lifecycleGeneration =
-    opts.lifecycleGeneration ?? captureAgentRunLifecycleGeneration(opts.runId ?? "");
+    ingressOpts.lifecycleGeneration ?? captureAgentRunLifecycleGeneration(ingressOpts.runId ?? "");
   return await withAgentRunLifecycleGeneration(lifecycleGeneration, async () => {
     const result = await agentCommandInternal(
       {
-        ...opts,
+        ...ingressOpts,
         lifecycleGeneration,
-        senderIsOwner: opts.senderIsOwner === true,
+        senderIsOwner: ingressOpts.senderIsOwner === true,
+        authorizationSubject: trusted?.authorizationSubject,
       },
       runtime,
       deps,
     );
 
     if (result) {
-      emitIngressModelUsageDiagnostic(result, opts);
+      emitIngressModelUsageDiagnostic(result, ingressOpts);
     }
 
     return result;

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -780,6 +780,11 @@ describe("createOpenClawCodingTools", () => {
     const resolvePluginToolsSpy = vi
       .spyOn(openClawPluginTools, "resolveOpenClawPluginToolsForOptions")
       .mockReturnValue([]);
+    const authorizationSubject = {
+      principal: { issuer: "core", subject: "agent:main", kind: "service" as const },
+      domain: { id: "domain-1" },
+      delegation: { id: "delegation-1", assignmentId: "assignment-1" },
+    };
 
     try {
       createOpenClawCodingTools({
@@ -789,6 +794,7 @@ describe("createOpenClawCodingTools", () => {
         modelProvider: "openrouter",
         modelId: "openrouter/auto",
         nativeChannelId: "oc_native_chat",
+        authorizationSubject,
         toolConstructionPlan: {
           includeBaseCodingTools: false,
           includeShellTools: false,
@@ -804,6 +810,7 @@ describe("createOpenClawCodingTools", () => {
       expect(pluginToolOptions?.modelProvider).toBe("openrouter");
       expect(pluginToolOptions?.modelId).toBe("openrouter/auto");
       expect(pluginToolOptions?.nativeChannelId).toBe("oc_native_chat");
+      expect(pluginToolOptions?.authorizationSubject).toBe(authorizationSubject);
     } finally {
       resolvePluginToolsSpy.mockRestore();
     }
@@ -904,6 +911,18 @@ describe("createOpenClawCodingTools", () => {
     expect(latestCreateOpenClawToolsOptions().messageActionTurnCapability).toBe(
       "turn-capability-1",
     );
+  });
+
+  it("forwards the Teams subject through standard tool construction", () => {
+    const authorizationSubject = {
+      principal: { issuer: "core", subject: "agent:main", kind: "service" as const },
+      domain: { id: "domain-1" },
+      delegation: { id: "delegation-1", assignmentId: "assignment-1" },
+    };
+
+    createOpenClawCodingTools({ config: testConfig, authorizationSubject });
+
+    expect(latestCreateOpenClawToolsOptions().authorizationSubject).toBe(authorizationSubject);
   });
 
   it("forwards auth profiles to plugin-only tool construction", () => {

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -13,6 +13,7 @@ import type { ChatType } from "../channels/chat-type.js";
 import type { InboundEventKind } from "../channels/inbound-event/kind.js";
 import type { ModelCompatConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { GatewayAuthorizationSubject } from "../gateway/authorization/contracts.js";
 import type { DiagnosticTraceContext } from "../infra/diagnostic-trace-context.js";
 import { resolveEventSessionRoutingPolicy } from "../infra/event-session-routing.js";
 import { applyExecPolicyLayer } from "../infra/exec-policy.js";
@@ -315,6 +316,8 @@ type OpenClawCodingToolsOptions = {
   oneShotCliRun?: boolean;
   /** Stable run identifier for this agent invocation. */
   runId?: string;
+  /** Server-owned Teams authorization subject for plugin tool decisions. */
+  authorizationSubject?: GatewayAuthorizationSubject;
   /** Device-scoped operator session allowed to review approvals initiated by this run. */
   approvalReviewerDeviceId?: string;
   /** Diagnostic trace context for hook/log correlation during this run. */
@@ -887,6 +890,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
             requesterAgentIdOverride: agentId,
             allowGatewaySubagentBinding: options?.allowGatewaySubagentBinding,
             authProfileStore: options?.authProfileStore,
+            authorizationSubject: options?.authorizationSubject,
           },
           resolvedConfig: options?.config,
         }),
@@ -1007,6 +1011,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
             requesterSenderId: options?.senderId,
             senderIsOwner: options?.senderIsOwner,
             authProfileStore: options?.authProfileStore,
+            authorizationSubject: options?.authorizationSubject,
             sessionId: options?.sessionId,
             oneShotCliRun: options?.oneShotCliRun,
             inheritedToolAllowlist,

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -3238,6 +3238,11 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
 
   it("binds current turn context into the bundle MCP client grant", async () => {
     const { dir, sessionFile } = createSessionFile();
+    const authorizationSubject = {
+      principal: { issuer: "core", subject: "agent:worker", kind: "service" as const },
+      domain: { id: "domain-1" },
+      delegation: { id: "delegation-1", assignmentId: "assignment-1" },
+    };
     try {
       const getActiveMcpLoopbackRuntime = vi.fn(() => ({
         port: 31783,
@@ -3302,6 +3307,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         model: "test-model",
         timeoutMs: 1_000,
         runId: "run-test-room-event-tools",
+        authorizationSubject,
         config: createCliBackendConfig(),
         sessionEntry: {
           execHost: "node",
@@ -3360,6 +3366,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
           agentId: "worker",
           sessionId: "session-test",
           runId: "run-test-room-event-tools",
+          authorizationSubject,
           modelProvider: "anthropic",
           modelId: "test-model",
           messageProvider: "discord",
@@ -3425,6 +3432,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       expect(context.mcpDeliveryCapture).toBe(true);
       expect(resolveMcpLoopbackScopedTools).toHaveBeenCalledWith(
         expect.objectContaining({
+          authorizationSubject,
           clientCaps: ["tool-events", "inline-widgets"],
           taskSuggestionDeliveryMode: "gateway",
           requireExplicitMessageTarget: true,

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -279,6 +279,9 @@ function buildCliMcpGrantContext(params: {
     agentId: params.agentId,
     sessionId: normalizeOptionalMcpContextValue(params.run.sessionId),
     runId: normalizeOptionalMcpContextValue(params.run.runId),
+    ...(params.run.authorizationSubject
+      ? { authorizationSubject: params.run.authorizationSubject }
+      : {}),
     modelProvider: params.modelProvider,
     modelId: params.modelId,
     messageProvider: resolveCliMcpMessageProvider(params.run),
@@ -1026,6 +1029,7 @@ export async function prepareCliRunContext(
               params.runtimePolicySessionKey,
             ),
             agentId: sessionAgentId,
+            authorizationSubject: params.authorizationSubject,
             messageProvider: resolveCliMcpMessageProvider(params),
             clientCaps: params.clientCaps,
             currentChannelId: params.currentChannelId,

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -15,6 +15,7 @@ import type { SessionSystemPromptReport } from "../../config/sessions/types.js";
 import type { CliBackendConfig } from "../../config/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ContextEngine } from "../../context-engine/types.js";
+import type { GatewayAuthorizationSubject } from "../../gateway/authorization/contracts.js";
 import type { ImageContent } from "../../llm/types.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import type { CliBackendExecutionMode } from "../../plugins/cli-backend.types.js";
@@ -99,6 +100,8 @@ export type RunCliAgentParams = {
    */
   runTimeoutOverrideMs?: number;
   runId: string;
+  /** Server-owned Teams authorization subject forwarded only through the opaque loopback grant. */
+  authorizationSubject?: GatewayAuthorizationSubject;
   /** Immutable lifecycle ownership captured when this execution was admitted. */
   lifecycleGeneration?: string;
   lane?: string;

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -360,6 +360,7 @@ describe("CLI attempt execution", () => {
     body: string;
     runId: string;
     cwd?: string;
+    opts?: Partial<Parameters<typeof runAgentAttempt>[0]["opts"]>;
   }) {
     await runAgentAttempt({
       providerOverride: "claude-cli",
@@ -378,7 +379,7 @@ describe("CLI attempt execution", () => {
       resolvedThinkLevel: "medium",
       timeoutMs: 1_000,
       runId: params.runId,
-      opts: {} as Parameters<typeof runAgentAttempt>[0]["opts"],
+      opts: (params.opts ?? {}) as Parameters<typeof runAgentAttempt>[0]["opts"],
       runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
       spawnedBy: undefined,
       messageChannel: undefined,
@@ -392,6 +393,30 @@ describe("CLI attempt execution", () => {
       sessionHasHistory: false,
     });
   }
+
+  it("carries a server-owned Teams subject into CLI harness runs unchanged", async () => {
+    const sessionKey = "agent:main:direct:teams-cli";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-teams-cli",
+      updatedAt: Date.now(),
+    };
+    const authorizationSubject = {
+      principal: { issuer: "core", subject: "agent:main", kind: "service" as const },
+      domain: { id: "domain-1" },
+      delegation: { id: "delegation-1", assignmentId: "assignment-1" },
+    };
+
+    await runClaudeCliAttempt({
+      sessionKey,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      body: "use the shared workspace",
+      runId: "run-teams-cli",
+      opts: { authorizationSubject },
+    });
+
+    expect(firstRunCliAgentArg().authorizationSubject).toBe(authorizationSubject);
+  });
 
   async function writeClaudeCliAssistantTranscript(cliSessionId: string) {
     // Claude stores resumable sessions under a workspace-derived project dir,

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -2472,6 +2472,21 @@ describe("CLI attempt execution", () => {
     expect(embeddedArg.suppressLiveStreamOutput).toBe(false);
   });
 
+  it("carries a server-owned Teams subject into the embedded run unchanged", async () => {
+    const authorizationSubject = {
+      principal: { issuer: "core", subject: "agent:main", kind: "service" as const },
+      domain: { id: "domain-1" },
+      delegation: { id: "delegation-1", assignmentId: "assignment-1" },
+    };
+
+    const embeddedArg = await runOpenClawEmbeddedAttemptForTest({
+      opts: { authorizationSubject },
+      runId: "teams-authorization-subject",
+    });
+
+    expect(embeddedArg.authorizationSubject).toBe(authorizationSubject);
+  });
+
   it("forwards Gateway plugin runtime binding to embedded runs", async () => {
     const embeddedArg = await runOpenClawEmbeddedAttemptForTest({
       opts: { allowGatewaySubagentBinding: true },

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -920,6 +920,7 @@ export function runAgentAttempt(params: {
     timeoutMs: params.timeoutMs,
     runId: params.runId,
     lifecycleGeneration: params.lifecycleGeneration,
+    authorizationSubject: params.opts.authorizationSubject,
     lane: params.opts.lane,
     // Hidden internal runs have no assistant-event consumer. Visible subagent
     // lanes can still feed Control UI, session subscribers, and ACP parent relays.

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -735,6 +735,7 @@ export function runAgentAttempt(params: {
         timeoutMs: params.timeoutMs,
         runTimeoutOverrideMs: params.runTimeoutOverrideMs,
         runId: params.runId,
+        authorizationSubject: params.opts.authorizationSubject,
         lifecycleGeneration: params.lifecycleGeneration,
         lane: params.opts.lane,
         extraSystemPrompt: params.opts.extraSystemPrompt,

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -7,6 +7,7 @@ import type { SpawnedRunMetadata } from "../../agents/spawned-context.js";
 import type { PromptMode } from "../../agents/system-prompt.types.js";
 import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options.types.js";
 import type { ChannelOutboundTargetMode } from "../../channels/plugins/types.public.js";
+import type { GatewayAuthorizationSubject } from "../../gateway/authorization/contracts.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import type { PluginHookChannelContext } from "../../plugins/hook-types.js";
 import type { InputProvenance } from "../../sessions/input-provenance.js";
@@ -131,6 +132,8 @@ export type AgentCommandOpts = {
   runId?: string;
   /** Immutable gateway lifecycle ownership captured when this run was admitted. */
   lifecycleGeneration?: string;
+  /** Server-owned Teams authorization subject; never accepted from external ingress. */
+  authorizationSubject?: GatewayAuthorizationSubject;
   extraSystemPrompt?: string;
   /** Bootstrap workspace context injection mode for this run. */
   bootstrapContextMode?: "full" | "lightweight";
@@ -189,7 +192,7 @@ export type AgentCommandOpts = {
 /** Restricted option surface for external ingress callsites. */
 export type AgentCommandIngressOpts = Omit<
   AgentCommandOpts,
-  "senderIsOwner" | "allowModelOverride" | "resultMetaOverrides"
+  "senderIsOwner" | "allowModelOverride" | "authorizationSubject" | "resultMetaOverrides"
 > & {
   /** Trusted sender identity bit for command/channel-action auth; defaults false for ingress. */
   senderIsOwner?: boolean;

--- a/src/agents/embedded-agent-runner/run/attempt.cwd-split.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.cwd-split.test.ts
@@ -92,6 +92,27 @@ describe("runEmbeddedAttempt cwd/workspace split", () => {
     });
   });
 
+  it("forwards the server-owned Teams subject into plugin tool construction", async () => {
+    const authorizationSubject = {
+      principal: { issuer: "core", subject: "agent:main", kind: "service" as const },
+      domain: { id: "domain-1" },
+      delegation: { id: "delegation-1", assignmentId: "assignment-1" },
+    };
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey: "agent:main:main",
+      tempPaths,
+      attemptOverrides: {
+        authorizationSubject,
+        disableTools: false,
+      },
+    });
+
+    expect(hoisted.createOpenClawCodingToolsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ authorizationSubject }),
+    );
+  });
+
   it("skips runtime tool construction when the selected model does not support tools", async () => {
     hoisted.supportsModelToolsMock.mockReturnValueOnce(false);
 

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1484,6 +1484,7 @@ export async function runEmbeddedAttempt(
             runtimeToolAllowlist: effectiveToolsAllow,
             cronCreatorToolAllowlistRef: cronCreatorToolAllowlist,
             authProfileStore: params.authProfileStore,
+            authorizationSubject: params.authorizationSubject,
             recordToolPrepStage: (name) => corePluginToolStages.mark(name),
             onToolOutcome: params.onToolOutcome,
             allocateToolOutcomeOrdinal: params.allocateToolOutcomeOrdinal,

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -14,6 +14,7 @@ import type { ReasoningLevel, ThinkLevel, VerboseLevel } from "../../../auto-rep
 import type { ChatType } from "../../../channels/chat-type.js";
 import type { InboundEventKind } from "../../../channels/inbound-event/kind.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import type { GatewayAuthorizationSubject } from "../../../gateway/authorization/contracts.js";
 import type { ImageContent } from "../../../llm/types.js";
 import type { PromptImageOrderEntry } from "../../../media/prompt-image-order.js";
 import type { PluginHookChannelContext } from "../../../plugins/hook-types.js";
@@ -70,6 +71,8 @@ export type RunEmbeddedAgentParams = {
   sessionTarget?: AgentRunSessionTarget;
   /** Immutable gateway lifecycle ownership captured when this execution was admitted. */
   lifecycleGeneration?: string;
+  /** Server-owned Teams authorization subject for this exact run. */
+  authorizationSubject?: GatewayAuthorizationSubject;
   /** Provider prompt-cache affinity key; distinct from transcript/session identity. */
   promptCacheKey?: string;
   /** Session-like key for sandbox and tool-policy resolution. Defaults to sessionKey. */

--- a/src/agents/openclaw-plugin-tools.ts
+++ b/src/agents/openclaw-plugin-tools.ts
@@ -10,6 +10,7 @@ import {
   getRuntimeConfigSourceSnapshot,
 } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { bindPluginToolAuthorizationSubject } from "../plugins/tool-authorization-context.js";
 import { resolvePluginTools } from "../plugins/tools.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { resolveApiKeyForProfile, resolveAuthProfileOrder } from "./auth-profiles.js";
@@ -119,13 +120,15 @@ export function resolveOpenClawPluginToolsForOptions(params: {
     getRuntimeConfig: resolveCurrentRuntimeConfig,
   });
   const existingToolNames = new Set(params.existingToolNames ?? []);
+  const context = {
+    ...pluginToolInputs.context,
+    ...(hasAuthForProvider ? { hasAuthForProvider } : {}),
+    ...(resolveApiKeyForProvider ? { resolveApiKeyForProvider } : {}),
+  };
+  bindPluginToolAuthorizationSubject(context, params.options?.authorizationSubject);
   const pluginTools = resolvePluginTools({
     ...pluginToolInputs,
-    context: {
-      ...pluginToolInputs.context,
-      ...(hasAuthForProvider ? { hasAuthForProvider } : {}),
-      ...(resolveApiKeyForProvider ? { resolveApiKeyForProvider } : {}),
-    },
+    context,
     existingToolNames,
     toolAllowlist: params.options?.pluginToolAllowlist,
     toolDenylist: params.options?.pluginToolDenylist,

--- a/src/agents/openclaw-tools.browser-plugin.integration.test.ts
+++ b/src/agents/openclaw-tools.browser-plugin.integration.test.ts
@@ -132,6 +132,31 @@ describe("createOpenClawTools browser plugin integration", () => {
     expect(details.workspaceOnly).toBe(true);
   });
 
+  it("binds Teams authority without projecting it onto plugin context fields", () => {
+    hoisted.resolvePluginTools.mockReturnValue([]);
+    const authorizationSubject = {
+      principal: { issuer: "core", subject: "agent:main", kind: "service" as const },
+      domain: { id: "domain-1" },
+      delegation: { id: "delegation-1", assignmentId: "assignment-1" },
+      agentSession: {
+        id: "binding-1",
+        invokingPrincipal: {
+          issuer: "trusted-proxy",
+          subject: "owner@example.com",
+          kind: "human" as const,
+        },
+      },
+    };
+
+    resolveOpenClawPluginToolsForOptions({
+      options: { authorizationSubject },
+    });
+
+    const context = firstResolvePluginToolsParams().context as Record<string, unknown>;
+    expect(context).not.toHaveProperty("authorizationSubject");
+    expect(JSON.stringify(context)).not.toContain("delegation-1");
+  });
+
   it("forwards gateway subagent binding to plugin resolution", () => {
     hoisted.resolvePluginTools.mockReturnValue([]);
     const config = {

--- a/src/agents/openclaw-tools.plugin-context.ts
+++ b/src/agents/openclaw-tools.plugin-context.ts
@@ -8,6 +8,7 @@ import {
  * Normalizes workspace, delivery, browser, sandbox, and active-model inputs before plugin tool invocation.
  */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { GatewayAuthorizationSubject } from "../gateway/authorization/contracts.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import type { GatewayMessageChannel } from "../utils/message-channel.js";
 import { resolveAgentWorkspaceDir, resolveSessionAgentIds } from "./agent-scope.js";
@@ -43,6 +44,8 @@ export type OpenClawPluginToolOptions = {
   allowHostBrowserControl?: boolean;
   sandboxed?: boolean;
   allowGatewaySubagentBinding?: boolean;
+  /** Internal server-owned authorization subject; never projected onto plugin context fields. */
+  authorizationSubject?: GatewayAuthorizationSubject;
 };
 
 /** Resolves plugin-tool context inputs from runtime options and config state. */

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -13,6 +13,7 @@ import type { InboundEventKind } from "../channels/inbound-event/kind.js";
 import type { ConversationReadInvocationOrigin } from "../channels/plugins/conversation-read-origin.js";
 import { selectApplicableRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { GatewayAuthorizationSubject } from "../gateway/authorization/contracts.js";
 import { callGateway } from "../gateway/call.js";
 import { isEmbeddedMode } from "../infra/embedded-mode.js";
 import { getActiveSecretsRuntimeConfigSnapshot } from "../secrets/runtime-state.js";
@@ -137,6 +138,8 @@ export function createOpenClawTools(
     fsPolicy?: ToolFsPolicy;
     sandboxed?: boolean;
     config?: OpenClawConfig;
+    /** Server-owned Teams authorization subject for plugin tool decisions. */
+    authorizationSubject?: GatewayAuthorizationSubject;
     /** Capabilities declared by the gateway client that originated this run. */
     clientCaps?: string[];
     pluginToolAllowlist?: string[];

--- a/src/cli/program/command-registry-core.ts
+++ b/src/cli/program/command-registry-core.ts
@@ -88,6 +88,11 @@ const coreEntrySpecs: readonly CommandGroupDescriptorSpec<
         exportName: "registerAuditCommand",
       },
       {
+        commandNames: ["teams"],
+        loadModule: () => import("./register.teams.js"),
+        exportName: "registerTeamsCommand",
+      },
+      {
         commandNames: ["doctor", "dashboard", "reset", "uninstall"],
         loadModule: () => import("./register.maintenance.js"),
         exportName: "registerMaintenanceCommands",

--- a/src/cli/program/command-registry.test.ts
+++ b/src/cli/program/command-registry.test.ts
@@ -84,6 +84,7 @@ describe("command-registry", () => {
     expect(names).toContain("mcp");
     expect(names).toContain("agent");
     expect(names).toContain("agents");
+    expect(names).toContain("teams");
   });
 
   it("returns only commands that support subcommands", () => {
@@ -95,6 +96,7 @@ describe("command-registry", () => {
     expect(names).toContain("sessions");
     expect(names).toContain("commitments");
     expect(names).toContain("tasks");
+    expect(names).toContain("teams");
     expect(names).not.toContain("agent");
     expect(names).not.toContain("crestodian");
     expect(names).not.toContain("status");
@@ -112,6 +114,13 @@ describe("command-registry", () => {
       true,
     );
     expect(agentProgram.commands.map((command) => command.name())).toEqual(["agent"]);
+  });
+
+  it("lazy-registers the Teams command by its root descriptor", async () => {
+    const program = createProgram();
+
+    await expect(registerCoreCliByName(program, testProgramContext, "teams")).resolves.toBe(true);
+    expect(namesOf(program)).toEqual(["teams"]);
   });
 
   it("registerCoreCliByName returns false for unknown commands", async () => {

--- a/src/cli/program/core-command-descriptors.ts
+++ b/src/cli/program/core-command-descriptors.ts
@@ -118,6 +118,11 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
     description: "Inspect durable background tasks and TaskFlow state",
     hasSubcommands: true,
   },
+  {
+    name: "teams",
+    description: "Manage local Teams authorization",
+    hasSubcommands: true,
+  },
 ] as const satisfies ReadonlyArray<CoreCliCommandDescriptor>);
 
 /** Static root-command descriptors for the core CLI surface. */

--- a/src/cli/program/register.teams.test.ts
+++ b/src/cli/program/register.teams.test.ts
@@ -1,0 +1,40 @@
+import { Readable } from "node:stream";
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import { readTeamsBootstrapPasswordFromStdin, registerTeamsCommand } from "./register.teams.js";
+
+describe("teams CLI registration", () => {
+  it("registers the bootstrap command with the safe credential flags", () => {
+    const program = new Command();
+    registerTeamsCommand(program);
+
+    const teams = program.commands.find((command) => command.name() === "teams");
+    const bootstrap = teams?.commands.find((command) => command.name() === "bootstrap");
+    expect(bootstrap?.options.map((option) => option.long)).toEqual([
+      "--login-label",
+      "--password-stdin",
+      "--domain-id",
+    ]);
+  });
+
+  it("reads one non-TTY password line and removes only its line ending", async () => {
+    const stdin = Readable.from(["  password with spaces  \r\n"]);
+    Object.defineProperty(stdin, "isTTY", { configurable: true, value: false });
+
+    await expect(readTeamsBootstrapPasswordFromStdin(stdin)).resolves.toBe(
+      "  password with spaces  ",
+    );
+  });
+
+  it("rejects terminal input and multiple password lines", async () => {
+    const terminal = Readable.from(["password\n"]);
+    Object.defineProperty(terminal, "isTTY", { configurable: true, value: true });
+    await expect(readTeamsBootstrapPasswordFromStdin(terminal)).rejects.toThrow(/non-TTY stdin/i);
+
+    const multipleLines = Readable.from(["first\nsecond\n"]);
+    Object.defineProperty(multipleLines, "isTTY", { configurable: true, value: false });
+    await expect(readTeamsBootstrapPasswordFromStdin(multipleLines)).rejects.toThrow(
+      /exactly one line/i,
+    );
+  });
+});

--- a/src/cli/program/register.teams.ts
+++ b/src/cli/program/register.teams.ts
@@ -1,0 +1,47 @@
+import type { Command } from "commander";
+import { bootstrapTeamsOwner } from "../../gateway/authorization/teams-bootstrap.js";
+
+type TeamsBootstrapStdin = NodeJS.ReadableStream & { isTTY?: boolean };
+
+/** Read exactly one non-interactive password line without normalizing its content. */
+export async function readTeamsBootstrapPasswordFromStdin(
+  stdin: TeamsBootstrapStdin,
+): Promise<string> {
+  if (stdin.isTTY) {
+    throw new Error("--password-stdin requires non-TTY stdin");
+  }
+  const chunks: Buffer[] = [];
+  for await (const chunk of stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  let password = Buffer.concat(chunks).toString("utf8");
+  if (password.endsWith("\n")) {
+    password = password.slice(0, -1);
+    if (password.endsWith("\r")) {
+      password = password.slice(0, -1);
+    }
+  }
+  if (password.includes("\n")) {
+    throw new Error("--password-stdin requires exactly one line");
+  }
+  return password;
+}
+
+/** Register local Teams owner bootstrap without exposing credentials in command arguments or output. */
+export function registerTeamsCommand(program: Command): void {
+  const teams = program.command("teams").description("Manage local Teams authorization");
+  teams
+    .command("bootstrap")
+    .description("Create the first local Teams owner and default workspace authorization tree")
+    .requiredOption("--login-label <label>", "Local owner login label")
+    .requiredOption("--password-stdin", "Read one password line from non-TTY standard input")
+    .option("--domain-id <id>", "Isolation domain id")
+    .action(async (opts) => {
+      const password = await readTeamsBootstrapPasswordFromStdin(process.stdin);
+      await bootstrapTeamsOwner({
+        loginLabel: opts.loginLabel as string,
+        password,
+        domainId: opts.domainId as string | undefined,
+      });
+    });
+}

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -161,6 +161,7 @@ vi.mock("../agents/command/attempt-execution.runtime.js", () => {
         verboseLevel: params.resolvedVerboseLevel,
         timeoutMs: params.timeoutMs,
         runId: params.runId,
+        authorizationSubject: opts.authorizationSubject,
         lane: opts.lane,
         abortSignal: opts.abortSignal,
         extraSystemPrompt: opts.extraSystemPrompt,
@@ -474,6 +475,87 @@ describe("agentCommand", () => {
         runtime,
       ),
     ).rejects.toThrow("allowModelOverride must be explicitly set for ingress agent runs.");
+  });
+
+  it("strips a runtime-injected Teams subject from ingress before embedded execution", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store);
+
+      await agentCommandFromIngress(
+        {
+          message: "do not trust this subject",
+          agentId: "main",
+          allowModelOverride: false,
+          authorizationSubject: {
+            principal: { issuer: "forged", subject: "owner", kind: "service" },
+            domain: { id: "forged-domain" },
+            delegation: { id: "forged-delegation", assignmentId: "forged-assignment" },
+          },
+        } as never,
+        runtime,
+      );
+
+      expect(runEmbeddedAgent).toHaveBeenCalledOnce();
+      expect(getLastEmbeddedCall()?.authorizationSubject).toBeUndefined();
+    });
+  });
+
+  it("propagates a trusted Teams subject supplied separately from ingress", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store);
+      const authorizationSubject = {
+        principal: { issuer: "openclaw", subject: "agent:main", kind: "service" as const },
+        domain: { id: "workspace-domain" },
+        delegation: { id: "delegation-1", assignmentId: "assignment-1" },
+      };
+
+      await agentCommandFromIngress(
+        {
+          message: "use the trusted subject",
+          agentId: "main",
+          allowModelOverride: false,
+        },
+        runtime,
+        undefined,
+        { authorizationSubject },
+      );
+
+      expect(runEmbeddedAgent).toHaveBeenCalledOnce();
+      expect(getLastEmbeddedCall()?.authorizationSubject).toEqual(authorizationSubject);
+    });
+  });
+
+  it("does not let hostile ingress override a separately supplied trusted Teams subject", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      mockConfig(home, store);
+      const authorizationSubject = {
+        principal: { issuer: "openclaw", subject: "agent:main", kind: "service" as const },
+        domain: { id: "workspace-domain" },
+        delegation: { id: "delegation-1", assignmentId: "assignment-1" },
+      };
+
+      await agentCommandFromIngress(
+        {
+          message: "do not replace the trusted subject",
+          agentId: "main",
+          allowModelOverride: false,
+          authorizationSubject: {
+            principal: { issuer: "forged", subject: "owner", kind: "service" },
+            domain: { id: "forged-domain" },
+            delegation: { id: "forged-delegation", assignmentId: "forged-assignment" },
+          },
+        } as never,
+        runtime,
+        undefined,
+        { authorizationSubject },
+      );
+
+      expect(runEmbeddedAgent).toHaveBeenCalledOnce();
+      expect(getLastEmbeddedCall()?.authorizationSubject).toEqual(authorizationSubject);
+    });
   });
 
   it("rejects a missing harness-owned session before local CLI dispatch", async () => {

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -8,12 +8,17 @@ import {
   assertGatewayAuthConfigured,
   authorizeGatewayConnect,
   authorizeHttpGatewayConnect,
+  type GatewayAuthResult,
   hasForwardedRequestHeaders,
   isLocalDirectRequest,
   resolveEffectiveSharedGatewayAuth,
   authorizeWsControlUiGatewayConnect,
   resolveGatewayAuth,
 } from "./auth.js";
+
+function expectHumanPrincipal(result: GatewayAuthResult, issuer: string, subject: string): void {
+  expect(result.principal).toEqual({ issuer, subject, kind: "human" });
+}
 
 function createLimiterSpy(): AuthRateLimiter & {
   check: ReturnType<typeof vi.fn>;
@@ -77,7 +82,13 @@ describe("gateway auth", () => {
 
   async function expectTailscaleHeaderAuthResult(params: {
     authorize: typeof authorizeHttpGatewayConnect | typeof authorizeWsControlUiGatewayConnect;
-    expected: { ok: false; reason: string } | { ok: true; method: string; user: string };
+    expected:
+      | { ok: false; reason: string }
+      | {
+          ok: true;
+          method: string;
+          principal: { issuer: string; subject: string; kind: "human" };
+        };
   }) {
     const res = await params.authorize({
       auth: { mode: "token", token: "secret", allowTailscale: true },
@@ -91,7 +102,7 @@ describe("gateway auth", () => {
       return;
     }
     expect(res.method).toBe(params.expected.method);
-    expect(res.user).toBe(params.expected.user);
+    expect(res.principal).toEqual(params.expected.principal);
   }
 
   it("resolves token/password from OPENCLAW gateway env vars", () => {
@@ -470,7 +481,7 @@ describe("gateway auth", () => {
 
     expect(res.ok).toBe(true);
     expect(res.method).toBe("tailscale");
-    expect(res.user).toBe("peter");
+    expectHumanPrincipal(res, "tailscale", "peter");
   });
 
   it("serializes async auth attempts per rate-limit key", async () => {
@@ -527,7 +538,11 @@ describe("gateway auth", () => {
   it("enables tailscale header auth on ws control-ui auth wrapper", async () => {
     await expectTailscaleHeaderAuthResult({
       authorize: authorizeWsControlUiGatewayConnect,
-      expected: { ok: true, method: "tailscale", user: "peter" },
+      expected: {
+        ok: true,
+        method: "tailscale",
+        principal: { issuer: "tailscale", subject: "peter", kind: "human" },
+      },
     });
   });
 
@@ -727,7 +742,11 @@ describe("trusted-proxy auth", () => {
 
     expect(res.ok).toBe(true);
     expect(res.method).toBe("trusted-proxy");
-    expect(res.user).toBe("nick@example.com");
+    expect(res.principal).toEqual({
+      issuer: "trusted-proxy",
+      subject: "nick@example.com",
+      kind: "human",
+    });
   });
 
   it("rejects trusted-proxy headers from the host non-loopback interface address", async () => {
@@ -839,7 +858,7 @@ describe("trusted-proxy auth", () => {
 
     expect(res.ok).toBe(true);
     expect(res.method).toBe("trusted-proxy");
-    expect(res.user).toBe("nick@example.com");
+    expectHumanPrincipal(res, "trusted-proxy", "nick@example.com");
   });
 
   it("keeps origin-less trusted-proxy HTTP requests working", async () => {
@@ -867,7 +886,7 @@ describe("trusted-proxy auth", () => {
 
     expect(res.ok).toBe(true);
     expect(res.method).toBe("trusted-proxy");
-    expect(res.user).toBe("nick@example.com");
+    expectHumanPrincipal(res, "trusted-proxy", "nick@example.com");
   });
 
   it("rejects request from untrusted source", async () => {
@@ -941,7 +960,7 @@ describe("trusted-proxy auth", () => {
 
     expect(res.ok).toBe(true);
     expect(res.method).toBe("trusted-proxy");
-    expect(res.user).toBe("nick@example.com");
+    expectHumanPrincipal(res, "trusted-proxy", "nick@example.com");
   });
 
   it("rejects when no trustedProxies configured", async () => {
@@ -1043,7 +1062,7 @@ describe("trusted-proxy auth", () => {
 
     expect(res.ok).toBe(true);
     expect(res.method).toBe("trusted-proxy");
-    expect(res.user).toBe("nick@example.com");
+    expectHumanPrincipal(res, "trusted-proxy", "nick@example.com");
   });
 
   it("trims whitespace from user header value", async () => {
@@ -1061,7 +1080,7 @@ describe("trusted-proxy auth", () => {
     });
 
     expect(res.ok).toBe(true);
-    expect(res.user).toBe("nick@example.com");
+    expectHumanPrincipal(res, "trusted-proxy", "nick@example.com");
   });
 
   describe("local-direct trusted-proxy requests", () => {
@@ -1251,7 +1270,11 @@ describe("trusted-proxy auth", () => {
       expect(res).toEqual({
         ok: true,
         method: "trusted-proxy",
-        user: "nick@example.com",
+        principal: {
+          issuer: "trusted-proxy",
+          subject: "nick@example.com",
+          kind: "human",
+        },
       });
     });
 

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -46,6 +46,7 @@ export type GatewayAuthResult = {
     | "tailscale"
     | "device-token"
     | "bootstrap-token"
+    | "teams-session"
     | "trusted-proxy";
   /** `issuer` identifies the OpenClaw authenticator, not an upstream IdP claim. */
   principal?: GatewayPrincipal;

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -5,6 +5,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import type { GatewayPrincipal } from "../../packages/gateway-protocol/src/schema/frames.js";
 import type { GatewayAuthConfig, GatewayTrustedProxyConfig } from "../config/types.gateway.js";
 import { readTailscaleWhoisIdentity, type TailscaleWhoisIdentity } from "../infra/tailscale.js";
 import { safeEqualSecret } from "../security/secret-equal.js";
@@ -46,7 +47,8 @@ export type GatewayAuthResult = {
     | "device-token"
     | "bootstrap-token"
     | "trusted-proxy";
-  user?: string;
+  /** `issuer` identifies the OpenClaw authenticator, not an upstream IdP claim. */
+  principal?: GatewayPrincipal;
   reason?: string;
   /** Present when the request was blocked by the rate limiter. */
   rateLimited?: boolean;
@@ -525,7 +527,11 @@ async function authorizeGatewayConnectCore(
       if (originResult) {
         return originResult;
       }
-      return { ok: true, method: "trusted-proxy", user: result.user };
+      return {
+        ok: true,
+        method: "trusted-proxy",
+        principal: { issuer: "trusted-proxy", subject: result.user, kind: "human" },
+      };
     }
     if (localDirect && auth.password && connectAuth?.password) {
       const rateLimitResult = rejectIfRateLimited({ limiter, ip, rateLimitScope });
@@ -576,7 +582,11 @@ async function authorizeGatewayConnectCore(
       return {
         ok: true,
         method: "tailscale",
-        user: tailscaleCheck.user.login,
+        principal: {
+          issuer: "tailscale",
+          subject: tailscaleCheck.user.login,
+          kind: "human",
+        },
       };
     }
   }

--- a/src/gateway/authorization/agent-session-bindings.test.ts
+++ b/src/gateway/authorization/agent-session-bindings.test.ts
@@ -1,0 +1,449 @@
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
+import {
+  createAuthorizationAgentSessionBinding,
+  GATEWAY_AGENT_SESSION_INVOKE_PERMISSION,
+  resolveAuthorizedGatewayAgentAuthorizationSubject,
+  resolveGatewayAgentAuthorizationSubject,
+  revokeAuthorizationAgentSessionBinding,
+} from "./agent-session-bindings.js";
+import { createAuthorizationDelegation, revokeAuthorizationDelegation } from "./delegations.js";
+import { createStateGatewayAuthorizationRuntime } from "./state-provider.js";
+import {
+  addIsolationDomainMember,
+  bindAuthorizationResource,
+  createIsolationDomain,
+  grantAuthorizationPermission,
+  putAuthorizationPrincipal,
+  revokeAuthorizationPermission,
+  transferAuthorizationResourceOwner,
+} from "./state-store.js";
+
+const tempDirs: string[] = [];
+
+const owner = {
+  id: "principal-owner",
+  principal: { issuer: "trusted-proxy", subject: "owner@example.com", kind: "human" },
+} as const;
+const service = {
+  id: "principal-service",
+  principal: { issuer: "core", subject: "agent:main", kind: "service" },
+} as const;
+const member = {
+  id: "principal-member",
+  principal: { issuer: "trusted-proxy", subject: "member@example.com", kind: "human" },
+} as const;
+const agentSessionResource = {
+  namespace: "core",
+  type: "agent-session",
+  id: "assignment-1",
+} as const;
+
+function createDatabase() {
+  return { path: `${makeTempDir(tempDirs, "openclaw-agent-session-binding-")}/openclaw.sqlite` };
+}
+
+function seedDelegation(database: ReturnType<typeof createDatabase>) {
+  putAuthorizationPrincipal({ ...owner, database });
+  putAuthorizationPrincipal({ ...service, database });
+  createIsolationDomain({
+    id: "domain-1",
+    ownerPrincipalId: owner.id,
+    database,
+  });
+  addIsolationDomainMember({
+    domainId: "domain-1",
+    principalId: service.id,
+    addedByPrincipalId: owner.id,
+    database,
+  });
+  createAuthorizationDelegation({
+    id: "delegation-1",
+    assignmentId: "assignment-1",
+    domainId: "domain-1",
+    agentPrincipalId: service.id,
+    sponsorPrincipalId: owner.id,
+    createdByPrincipalId: owner.id,
+    database,
+  });
+}
+
+function bindMainSession(database: ReturnType<typeof createDatabase>) {
+  bindAuthorizationResource({
+    domainId: "domain-1",
+    resource: agentSessionResource,
+    ownerPrincipalId: owner.id,
+    database,
+  });
+  createAuthorizationAgentSessionBinding({
+    id: "binding-1",
+    domainId: "domain-1",
+    runtimeAgentId: "main",
+    sessionKey: "agent:main:main",
+    delegationId: "delegation-1",
+    assignmentId: "assignment-1",
+    createdByPrincipalId: owner.id,
+    database,
+  });
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
+
+afterAll(() => {
+  cleanupTempDirs(tempDirs);
+});
+
+describe("authorization agent session bindings", () => {
+  it("resolves one exact active session assignment to a canonical frozen subject", () => {
+    const database = createDatabase();
+    seedDelegation(database);
+    bindMainSession(database);
+
+    const subject = resolveGatewayAgentAuthorizationSubject({
+      runtimeAgentId: "main",
+      sessionKey: "agent:main:main",
+      database,
+    });
+
+    expect(subject).toEqual({
+      principal: service.principal,
+      domain: { id: "domain-1" },
+      delegation: { id: "delegation-1", assignmentId: "assignment-1" },
+    });
+    expect(Object.isFrozen(subject)).toBe(true);
+    expect(Object.isFrozen(subject?.principal)).toBe(true);
+    expect(Object.isFrozen(subject?.domain)).toBe(true);
+    expect(Object.isFrozen(subject?.delegation)).toBe(true);
+  });
+
+  it("fails closed for a different agent, session, or missing binding", () => {
+    const database = createDatabase();
+    seedDelegation(database);
+    bindMainSession(database);
+
+    expect(
+      resolveGatewayAgentAuthorizationSubject({
+        runtimeAgentId: "other",
+        sessionKey: "agent:main:main",
+        database,
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveGatewayAgentAuthorizationSubject({
+        runtimeAgentId: "main",
+        sessionKey: "agent:main:other",
+        database,
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveGatewayAgentAuthorizationSubject({
+        runtimeAgentId: "main",
+        sessionKey: "agent:main:missing",
+        database,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("rejects ambiguous runtime identities and differently bound idempotent retries", () => {
+    const database = createDatabase();
+    seedDelegation(database);
+    bindMainSession(database);
+
+    expect(() =>
+      createAuthorizationAgentSessionBinding({
+        id: "binding-other",
+        domainId: "domain-1",
+        runtimeAgentId: "main",
+        sessionKey: "agent:main:main",
+        delegationId: "delegation-1",
+        assignmentId: "assignment-1",
+        createdByPrincipalId: owner.id,
+        database,
+      }),
+    ).toThrow(/already bound/i);
+
+    expect(() =>
+      createAuthorizationAgentSessionBinding({
+        id: "binding-1",
+        domainId: "domain-1",
+        runtimeAgentId: "main",
+        sessionKey: "agent:main:other",
+        delegationId: "delegation-1",
+        assignmentId: "assignment-1",
+        createdByPrincipalId: owner.id,
+        database,
+      }),
+    ).toThrow(/already bound/i);
+  });
+
+  it("allows an explicit new binding identity after a revoked runtime tombstone", () => {
+    const database = createDatabase();
+    seedDelegation(database);
+    bindMainSession(database);
+    revokeAuthorizationAgentSessionBinding({
+      domainId: "domain-1",
+      id: "binding-1",
+      revokedByPrincipalId: owner.id,
+      database,
+    });
+
+    expect(() => bindMainSession(database)).toThrow(/revoked/i);
+    expect(() =>
+      createAuthorizationAgentSessionBinding({
+        id: "binding-2",
+        domainId: "domain-1",
+        runtimeAgentId: "main",
+        sessionKey: "agent:main:main",
+        delegationId: "delegation-1",
+        assignmentId: "assignment-1",
+        createdByPrincipalId: owner.id,
+        database,
+      }),
+    ).not.toThrow();
+    expect(
+      resolveGatewayAgentAuthorizationSubject({
+        runtimeAgentId: "main",
+        sessionKey: "agent:main:main",
+        database,
+      }),
+    ).toMatchObject({ delegation: { assignmentId: "assignment-1" } });
+  });
+
+  it("requires the invoking human to own or hold an exact agent-session grant", async () => {
+    const database = createDatabase();
+    seedDelegation(database);
+    bindMainSession(database);
+    putAuthorizationPrincipal({ ...member, database });
+    addIsolationDomainMember({
+      domainId: "domain-1",
+      principalId: member.id,
+      addedByPrincipalId: owner.id,
+      database,
+    });
+
+    await expect(
+      resolveAuthorizedGatewayAgentAuthorizationSubject({
+        invokingPrincipal: owner.principal,
+        runtimeAgentId: "main",
+        sessionKey: "agent:main:main",
+        database,
+      }),
+    ).resolves.toMatchObject({
+      principal: service.principal,
+      agentSession: { id: "binding-1", invokingPrincipal: owner.principal },
+    });
+    await expect(
+      resolveAuthorizedGatewayAgentAuthorizationSubject({
+        invokingPrincipal: member.principal,
+        runtimeAgentId: "main",
+        sessionKey: "agent:main:main",
+        database,
+      }),
+    ).resolves.toBeUndefined();
+
+    grantAuthorizationPermission({
+      domainId: "domain-1",
+      resource: agentSessionResource,
+      principalId: member.id,
+      permission: GATEWAY_AGENT_SESSION_INVOKE_PERMISSION,
+      grantedByPrincipalId: owner.id,
+      database,
+    });
+    await expect(
+      resolveAuthorizedGatewayAgentAuthorizationSubject({
+        invokingPrincipal: member.principal,
+        runtimeAgentId: "main",
+        sessionKey: "agent:main:main",
+        database,
+      }),
+    ).resolves.toMatchObject({
+      principal: service.principal,
+      delegation: { id: "delegation-1", assignmentId: "assignment-1" },
+      agentSession: { id: "binding-1", invokingPrincipal: member.principal },
+    });
+  });
+
+  it("keeps an active agent-session resource with its canonical sponsor owner", async () => {
+    const database = createDatabase();
+    seedDelegation(database);
+    bindMainSession(database);
+    putAuthorizationPrincipal({ ...member, database });
+    addIsolationDomainMember({
+      domainId: "domain-1",
+      principalId: member.id,
+      addedByPrincipalId: owner.id,
+      database,
+    });
+
+    expect(() =>
+      transferAuthorizationResourceOwner({
+        domainId: "domain-1",
+        resource: agentSessionResource,
+        transferredByPrincipalId: owner.id,
+        newOwnerPrincipalId: member.id,
+        database,
+      }),
+    ).toThrow(/canonical sponsor owner/i);
+    expect(() =>
+      openOpenClawStateDatabase(database)
+        .db.prepare(
+          `UPDATE authorization_resources
+           SET owner_principal_id = ?, updated_at = ?
+           WHERE domain_id = ? AND namespace = ? AND resource_type = ? AND resource_id = ?`,
+        )
+        .run(
+          member.id,
+          Date.now(),
+          "domain-1",
+          agentSessionResource.namespace,
+          agentSessionResource.type,
+          agentSessionResource.id,
+        ),
+    ).toThrow(/canonical sponsor owner/i);
+    await expect(
+      resolveAuthorizedGatewayAgentAuthorizationSubject({
+        invokingPrincipal: member.principal,
+        runtimeAgentId: "main",
+        sessionKey: "agent:main:main",
+        database,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("revalidates the binding and invoking human permission for every tool decision", async () => {
+    const database = createDatabase();
+    seedDelegation(database);
+    bindMainSession(database);
+    putAuthorizationPrincipal({ ...member, database });
+    addIsolationDomainMember({
+      domainId: "domain-1",
+      principalId: member.id,
+      addedByPrincipalId: owner.id,
+      database,
+    });
+    grantAuthorizationPermission({
+      domainId: "domain-1",
+      resource: agentSessionResource,
+      principalId: member.id,
+      permission: GATEWAY_AGENT_SESSION_INVOKE_PERMISSION,
+      grantedByPrincipalId: owner.id,
+      database,
+    });
+    grantAuthorizationPermission({
+      domainId: "domain-1",
+      resource: agentSessionResource,
+      principalId: service.id,
+      permission: "plugin.tool.read",
+      grantedByPrincipalId: owner.id,
+      database,
+    });
+    const subject = await resolveAuthorizedGatewayAgentAuthorizationSubject({
+      invokingPrincipal: member.principal,
+      runtimeAgentId: "main",
+      sessionKey: "agent:main:main",
+      database,
+    });
+    if (!subject?.delegation || !subject.agentSession) {
+      throw new Error("expected an authorized agent-session subject");
+    }
+    const runtime = createStateGatewayAuthorizationRuntime({ database });
+    if (runtime.mode !== "isolated") {
+      throw new Error("expected isolated authorization runtime");
+    }
+    const request = {
+      principal: subject.principal,
+      domain: subject.domain,
+      delegation: subject.delegation,
+      agentSession: subject.agentSession,
+      method: "plugin-tool:workspaces.workspace_get",
+      permission: "plugin.tool.read",
+      resources: [agentSessionResource],
+    } as const;
+
+    await expect(runtime.authorize(request)).resolves.toMatchObject({ allowed: true });
+    revokeAuthorizationPermission({
+      domainId: "domain-1",
+      resource: agentSessionResource,
+      principalId: member.id,
+      permission: GATEWAY_AGENT_SESSION_INVOKE_PERMISSION,
+      revokedByPrincipalId: owner.id,
+      database,
+    });
+    await expect(runtime.authorize(request)).resolves.toEqual({
+      allowed: false,
+      reason: "forbidden",
+    });
+
+    grantAuthorizationPermission({
+      domainId: "domain-1",
+      resource: agentSessionResource,
+      principalId: member.id,
+      permission: GATEWAY_AGENT_SESSION_INVOKE_PERMISSION,
+      grantedByPrincipalId: owner.id,
+      database,
+    });
+    await expect(runtime.authorize(request)).resolves.toMatchObject({ allowed: true });
+    revokeAuthorizationAgentSessionBinding({
+      domainId: "domain-1",
+      id: "binding-1",
+      revokedByPrincipalId: owner.id,
+      database,
+    });
+    await expect(runtime.authorize(request)).resolves.toEqual({
+      allowed: false,
+      reason: "forbidden",
+    });
+  });
+
+  it("fails closed after either the binding or delegation is revoked", () => {
+    const bindingDatabase = createDatabase();
+    seedDelegation(bindingDatabase);
+    bindMainSession(bindingDatabase);
+    revokeAuthorizationAgentSessionBinding({
+      domainId: "domain-1",
+      id: "binding-1",
+      revokedByPrincipalId: owner.id,
+      database: bindingDatabase,
+    });
+    expect(
+      resolveGatewayAgentAuthorizationSubject({
+        runtimeAgentId: "main",
+        sessionKey: "agent:main:main",
+        database: bindingDatabase,
+      }),
+    ).toBeUndefined();
+
+    closeOpenClawStateDatabaseForTest();
+    const delegationDatabase = createDatabase();
+    seedDelegation(delegationDatabase);
+    bindMainSession(delegationDatabase);
+    revokeAuthorizationDelegation({
+      domainId: "domain-1",
+      delegationId: "delegation-1",
+      revokedByPrincipalId: owner.id,
+      database: delegationDatabase,
+    });
+    expect(
+      openOpenClawStateDatabase(delegationDatabase)
+        .db.prepare(
+          `SELECT state, revoked_at
+           FROM authorization_agent_session_bindings
+           WHERE domain_id = ? AND binding_id = ?`,
+        )
+        .get("domain-1", "binding-1"),
+    ).toMatchObject({ state: "revoked", revoked_at: expect.any(Number) });
+    expect(
+      resolveGatewayAgentAuthorizationSubject({
+        runtimeAgentId: "main",
+        sessionKey: "agent:main:main",
+        database: delegationDatabase,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/gateway/authorization/agent-session-bindings.ts
+++ b/src/gateway/authorization/agent-session-bindings.ts
@@ -1,0 +1,355 @@
+import type { GatewayPrincipal } from "../../../packages/gateway-protocol/src/schema/frames.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../../infra/kysely-sync.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabaseOptions,
+} from "../../state/openclaw-state-db.js";
+import {
+  GATEWAY_AGENT_SESSION_INVOKE_PERMISSION,
+  type GatewayAuthorizationSubject,
+} from "./contracts.js";
+import { createStateGatewayAuthorizationRuntime } from "./state-provider.js";
+
+export { GATEWAY_AGENT_SESSION_INVOKE_PERMISSION } from "./contracts.js";
+
+type AuthorizationAgentSessionBindingDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  | "authorization_agent_session_bindings"
+  | "authorization_delegations"
+  | "authorization_domain_memberships"
+  | "authorization_principals"
+  | "authorization_resources"
+>;
+
+function requiredIdentifier(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return normalized;
+}
+
+export function createAuthorizationAgentSessionBinding(input: {
+  database?: OpenClawStateDatabaseOptions;
+  id: string;
+  domainId: string;
+  runtimeAgentId: string;
+  sessionKey: string;
+  delegationId: string;
+  assignmentId: string;
+  createdByPrincipalId: string;
+}): void {
+  const bindingId = requiredIdentifier(input.id, "agent session binding id");
+  const domainId = requiredIdentifier(input.domainId, "isolation domain id");
+  const runtimeAgentId = requiredIdentifier(input.runtimeAgentId, "runtime agent id");
+  const sessionKey = requiredIdentifier(input.sessionKey, "session key");
+  const delegationId = requiredIdentifier(input.delegationId, "delegation id");
+  const assignmentId = requiredIdentifier(input.assignmentId, "assignment id");
+  const createdByPrincipalId = requiredIdentifier(
+    input.createdByPrincipalId,
+    "agent session binding creator principal id",
+  );
+
+  runOpenClawStateWriteTransaction(({ db }) => {
+    const kysely = getNodeSqliteKysely<AuthorizationAgentSessionBindingDatabase>(db);
+    const delegation = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_delegations")
+        .select(["agent_principal_id", "sponsor_principal_id", "state"])
+        .where("domain_id", "=", domainId)
+        .where("delegation_id", "=", delegationId)
+        .where("assignment_id", "=", assignmentId),
+    );
+    if (!delegation || delegation.state !== "active") {
+      throw new Error("authorization agent session binding requires an active delegation");
+    }
+    if (delegation.sponsor_principal_id !== createdByPrincipalId) {
+      throw new Error(
+        "authorization agent session binding must be created by its canonical human sponsor",
+      );
+    }
+    const resource = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_resources")
+        .select("owner_principal_id")
+        .where("domain_id", "=", domainId)
+        .where("namespace", "=", "core")
+        .where("resource_type", "=", "agent-session")
+        .where("resource_id", "=", assignmentId)
+        .where("retired_at", "is", null),
+    );
+    if (resource?.owner_principal_id !== delegation.sponsor_principal_id) {
+      throw new Error(
+        "authorization agent session binding requires its sponsor-owned agent-session resource",
+      );
+    }
+
+    const byId = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_agent_session_bindings")
+        .selectAll()
+        .where("domain_id", "=", domainId)
+        .where("binding_id", "=", bindingId),
+    );
+    const byRuntimeIdentity = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_agent_session_bindings")
+        .selectAll()
+        .where("runtime_agent_id", "=", runtimeAgentId)
+        .where("session_key", "=", sessionKey)
+        .where("state", "=", "active"),
+    );
+    const existing = byId ?? byRuntimeIdentity;
+    if (existing) {
+      if (existing.state === "revoked") {
+        throw new Error(
+          "authorization agent session binding is revoked; create a new binding identity",
+        );
+      }
+      const matches =
+        existing.binding_id === bindingId &&
+        existing.domain_id === domainId &&
+        existing.runtime_agent_id === runtimeAgentId &&
+        existing.session_key === sessionKey &&
+        existing.delegation_id === delegationId &&
+        existing.assignment_id === assignmentId &&
+        existing.agent_principal_id === delegation.agent_principal_id &&
+        existing.sponsor_principal_id === delegation.sponsor_principal_id &&
+        existing.created_by_principal_id === createdByPrincipalId;
+      if (
+        !matches ||
+        (byId &&
+          byRuntimeIdentity &&
+          (byId.domain_id !== byRuntimeIdentity.domain_id ||
+            byId.binding_id !== byRuntimeIdentity.binding_id))
+      ) {
+        throw new Error("authorization agent session identity is already bound differently");
+      }
+      return;
+    }
+
+    const now = Date.now();
+    executeSqliteQuerySync(
+      db,
+      kysely.insertInto("authorization_agent_session_bindings").values({
+        domain_id: domainId,
+        binding_id: bindingId,
+        runtime_agent_id: runtimeAgentId,
+        session_key: sessionKey,
+        delegation_id: delegationId,
+        assignment_id: assignmentId,
+        agent_principal_id: delegation.agent_principal_id,
+        sponsor_principal_id: delegation.sponsor_principal_id,
+        created_by_principal_id: createdByPrincipalId,
+        state: "active",
+        created_at: now,
+        updated_at: now,
+        revoked_at: null,
+      }),
+    );
+  }, input.database);
+}
+
+function resolveGatewayAgentAuthorizationBinding(input: {
+  database?: OpenClawStateDatabaseOptions;
+  runtimeAgentId: string;
+  sessionKey: string;
+}): Readonly<{ id: string; subject: GatewayAuthorizationSubject }> | undefined {
+  const runtimeAgentId = requiredIdentifier(input.runtimeAgentId, "runtime agent id");
+  const sessionKey = requiredIdentifier(input.sessionKey, "session key");
+  const db = openOpenClawStateDatabase(input.database).db;
+  const kysely = getNodeSqliteKysely<AuthorizationAgentSessionBindingDatabase>(db);
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    kysely
+      .selectFrom("authorization_agent_session_bindings as binding")
+      .innerJoin("authorization_delegations as delegation", (join) =>
+        join
+          .onRef("delegation.domain_id", "=", "binding.domain_id")
+          .onRef("delegation.delegation_id", "=", "binding.delegation_id")
+          .onRef("delegation.assignment_id", "=", "binding.assignment_id")
+          .onRef("delegation.agent_principal_id", "=", "binding.agent_principal_id")
+          .onRef("delegation.sponsor_principal_id", "=", "binding.sponsor_principal_id"),
+      )
+      .innerJoin("authorization_principals as agent", (join) =>
+        join
+          .onRef("agent.principal_id", "=", "binding.agent_principal_id")
+          .on("agent.kind", "=", "service"),
+      )
+      .innerJoin("authorization_domain_memberships as agent_membership", (join) =>
+        join
+          .onRef("agent_membership.domain_id", "=", "binding.domain_id")
+          .onRef("agent_membership.principal_id", "=", "binding.agent_principal_id"),
+      )
+      .innerJoin("authorization_domain_memberships as sponsor_membership", (join) =>
+        join
+          .onRef("sponsor_membership.domain_id", "=", "binding.domain_id")
+          .onRef("sponsor_membership.principal_id", "=", "binding.sponsor_principal_id")
+          .on("sponsor_membership.role", "=", "owner"),
+      )
+      .select([
+        "binding.binding_id",
+        "binding.domain_id",
+        "binding.delegation_id",
+        "binding.assignment_id",
+        "agent.issuer",
+        "agent.subject",
+      ])
+      .where("binding.runtime_agent_id", "=", runtimeAgentId)
+      .where("binding.session_key", "=", sessionKey)
+      .where("binding.state", "=", "active")
+      .where("delegation.state", "=", "active"),
+  );
+  if (!row) {
+    return undefined;
+  }
+
+  const principal = Object.freeze({
+    issuer: row.issuer,
+    subject: row.subject,
+    kind: "service" as const,
+  });
+  const domain = Object.freeze({ id: row.domain_id });
+  const delegation = Object.freeze({
+    id: row.delegation_id,
+    assignmentId: row.assignment_id,
+  });
+  return Object.freeze({
+    id: row.binding_id,
+    subject: Object.freeze({ principal, domain, delegation }),
+  });
+}
+
+/** Resolves only the exact final runtime agent/session identity selected by the gateway. */
+export function resolveGatewayAgentAuthorizationSubject(input: {
+  database?: OpenClawStateDatabaseOptions;
+  runtimeAgentId: string;
+  sessionKey: string;
+}): GatewayAuthorizationSubject | undefined {
+  return resolveGatewayAgentAuthorizationBinding(input)?.subject;
+}
+
+/**
+ * Resolves the service subject only after the invoking human is authorized for
+ * the exact agent-session assignment resource. The human is an invocation
+ * gate; the resulting tool authority remains the bound service principal.
+ */
+export async function resolveAuthorizedGatewayAgentAuthorizationSubject(input: {
+  database?: OpenClawStateDatabaseOptions;
+  invokingPrincipal: GatewayPrincipal;
+  runtimeAgentId: string;
+  sessionKey: string;
+}): Promise<GatewayAuthorizationSubject | undefined> {
+  if (input.invokingPrincipal.kind !== "human") {
+    return undefined;
+  }
+  const binding = resolveGatewayAgentAuthorizationBinding(input);
+  const subject = binding?.subject;
+  if (!subject?.delegation) {
+    return undefined;
+  }
+  const runtime = createStateGatewayAuthorizationRuntime({ database: input.database });
+  if (runtime.mode !== "isolated") {
+    return undefined;
+  }
+  const decision = await runtime.authorize({
+    principal: input.invokingPrincipal,
+    domain: subject.domain,
+    method: "agent",
+    permission: GATEWAY_AGENT_SESSION_INVOKE_PERMISSION,
+    resources: [
+      {
+        namespace: "core",
+        type: "agent-session",
+        id: subject.delegation.assignmentId,
+      },
+    ],
+  });
+  if (!decision.allowed || !binding) {
+    return undefined;
+  }
+  return Object.freeze({
+    ...subject,
+    agentSession: Object.freeze({
+      id: binding.id,
+      invokingPrincipal: Object.freeze({
+        issuer: input.invokingPrincipal.issuer,
+        subject: input.invokingPrincipal.subject,
+        kind: input.invokingPrincipal.kind,
+      }),
+    }),
+  });
+}
+
+export function revokeAuthorizationAgentSessionBinding(input: {
+  database?: OpenClawStateDatabaseOptions;
+  domainId: string;
+  id: string;
+  revokedByPrincipalId: string;
+}): void {
+  const domainId = requiredIdentifier(input.domainId, "isolation domain id");
+  const bindingId = requiredIdentifier(input.id, "agent session binding id");
+  const revokedByPrincipalId = requiredIdentifier(
+    input.revokedByPrincipalId,
+    "revoking principal id",
+  );
+
+  runOpenClawStateWriteTransaction(({ db }) => {
+    const kysely = getNodeSqliteKysely<AuthorizationAgentSessionBindingDatabase>(db);
+    const binding = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_agent_session_bindings")
+        .select(["sponsor_principal_id", "state"])
+        .where("domain_id", "=", domainId)
+        .where("binding_id", "=", bindingId),
+    );
+    if (!binding) {
+      throw new Error("unknown authorization agent session binding");
+    }
+    if (binding.state === "revoked") {
+      return;
+    }
+    const revoker = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_domain_memberships as membership")
+        .innerJoin(
+          "authorization_principals as principal",
+          "principal.principal_id",
+          "membership.principal_id",
+        )
+        .select(["membership.role", "principal.kind"])
+        .where("membership.domain_id", "=", domainId)
+        .where("membership.principal_id", "=", revokedByPrincipalId),
+    );
+    if (
+      revoker?.kind !== "human" ||
+      (revoker.role !== "owner" && binding.sponsor_principal_id !== revokedByPrincipalId)
+    ) {
+      throw new Error(
+        "authorization agent session binding revocation requires its sponsor or domain owner",
+      );
+    }
+    const now = Date.now();
+    executeSqliteQuerySync(
+      db,
+      kysely
+        .updateTable("authorization_agent_session_bindings")
+        .set({ state: "revoked", revoked_at: now, updated_at: now })
+        .where("domain_id", "=", domainId)
+        .where("binding_id", "=", bindingId)
+        .where("state", "=", "active"),
+    );
+  }, input.database);
+}

--- a/src/gateway/authorization/client-domain.test.ts
+++ b/src/gateway/authorization/client-domain.test.ts
@@ -3,10 +3,13 @@ import type { GatewayClient } from "../server-methods/types.js";
 import {
   bindGatewayClientAuthorizationDelegation,
   bindGatewayClientAuthorizationDomain,
+  bindGatewayClientTeamsSession,
   getGatewayClientAuthorizationDelegation,
   getGatewayClientAuthorizationDomain,
+  getGatewayClientTeamsSession,
   inheritGatewayClientAuthorizationDelegation,
   inheritGatewayClientAuthorizationDomain,
+  inheritGatewayClientTeamsSession,
 } from "./client-domain.js";
 
 function client(): GatewayClient {
@@ -25,6 +28,14 @@ function serviceClient(): GatewayClient {
   return {
     ...client(),
     principal: { issuer: "core", subject: "agent:main", kind: "service" },
+  };
+}
+
+function humanClient(): GatewayClient {
+  return {
+    ...client(),
+    connect: { ...client().connect, role: "member", scopes: [] },
+    principal: { issuer: "local", subject: "member@example.com", kind: "human" },
   };
 }
 
@@ -61,6 +72,41 @@ describe("server-owned gateway client domain", () => {
     expect(getGatewayClientAuthorizationDomain(target)).toBeUndefined();
     inheritGatewayClientAuthorizationDomain(source, target);
     expect(getGatewayClientAuthorizationDomain(target)).toEqual({ id: "domain-1" });
+  });
+});
+
+describe("server-owned gateway client Teams session", () => {
+  it("binds privately, rejects rebinding, and inherits only across the same human domain", () => {
+    const source = humanClient();
+    const target = { ...source };
+    bindGatewayClientAuthorizationDomain(source, { id: "domain-1" });
+    bindGatewayClientTeamsSession(source, {
+      id: "session-1",
+      principalId: "principal-member",
+      domainId: "domain-1",
+    });
+    (source as GatewayClient & { teamsSessionId?: string }).teamsSessionId = "forged";
+
+    expect(getGatewayClientTeamsSession(source)).toEqual({
+      id: "session-1",
+      principalId: "principal-member",
+      domainId: "domain-1",
+    });
+    expect(() =>
+      bindGatewayClientTeamsSession(source, {
+        id: "session-2",
+        principalId: "principal-member",
+        domainId: "domain-1",
+      }),
+    ).toThrow(/already bound differently/i);
+    expect(getGatewayClientTeamsSession(target)).toBeUndefined();
+    inheritGatewayClientAuthorizationDomain(source, target);
+    inheritGatewayClientTeamsSession(source, target);
+    expect(getGatewayClientTeamsSession(target)?.id).toBe("session-1");
+
+    const different = { ...source, principal: { ...source.principal!, subject: "other" } };
+    bindGatewayClientAuthorizationDomain(different, { id: "domain-1" });
+    expect(() => inheritGatewayClientTeamsSession(source, different)).toThrow(/cannot cross/i);
   });
 });
 

--- a/src/gateway/authorization/client-domain.test.ts
+++ b/src/gateway/authorization/client-domain.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { GatewayClient } from "../server-methods/types.js";
 import {
+  bindGatewayClientAuthorizationDelegation,
   bindGatewayClientAuthorizationDomain,
+  getGatewayClientAuthorizationDelegation,
   getGatewayClientAuthorizationDomain,
+  inheritGatewayClientAuthorizationDelegation,
   inheritGatewayClientAuthorizationDomain,
 } from "./client-domain.js";
 
@@ -15,6 +18,13 @@ function client(): GatewayClient {
       minProtocol: 1,
       maxProtocol: 1,
     },
+  };
+}
+
+function serviceClient(): GatewayClient {
+  return {
+    ...client(),
+    principal: { issuer: "core", subject: "agent:main", kind: "service" },
   };
 }
 
@@ -51,5 +61,62 @@ describe("server-owned gateway client domain", () => {
     expect(getGatewayClientAuthorizationDomain(target)).toBeUndefined();
     inheritGatewayClientAuthorizationDomain(source, target);
     expect(getGatewayClientAuthorizationDomain(target)).toEqual({ id: "domain-1" });
+  });
+});
+
+describe("server-owned gateway client delegation", () => {
+  it("ignores plugin-visible mutation and rejects rebinding", () => {
+    const gatewayClient = serviceClient();
+    bindGatewayClientAuthorizationDomain(gatewayClient, { id: "domain-1" });
+    bindGatewayClientAuthorizationDelegation(gatewayClient, {
+      id: "delegation-1",
+      assignmentId: "assignment-1",
+    });
+
+    (
+      gatewayClient as GatewayClient & {
+        internal: { authorizationDelegation: { id: string; assignmentId: string } };
+      }
+    ).internal = {
+      authorizationDelegation: { id: "forged", assignmentId: "forged" },
+    };
+
+    expect(getGatewayClientAuthorizationDelegation(gatewayClient)).toEqual({
+      id: "delegation-1",
+      assignmentId: "assignment-1",
+    });
+    expect(() =>
+      bindGatewayClientAuthorizationDelegation(gatewayClient, {
+        id: "delegation-2",
+        assignmentId: "assignment-2",
+      }),
+    ).toThrow(/already bound differently/i);
+  });
+
+  it("requires a scoped service client and inherits only through the core helper", () => {
+    const human = client();
+    bindGatewayClientAuthorizationDomain(human, { id: "domain-1" });
+    expect(() =>
+      bindGatewayClientAuthorizationDelegation(human, {
+        id: "delegation-1",
+        assignmentId: "assignment-1",
+      }),
+    ).toThrow(/service principal/i);
+
+    const source = serviceClient();
+    const target = { ...source };
+    bindGatewayClientAuthorizationDomain(source, { id: "domain-1" });
+    bindGatewayClientAuthorizationDelegation(source, {
+      id: "delegation-1",
+      assignmentId: "assignment-1",
+    });
+
+    expect(getGatewayClientAuthorizationDelegation(target)).toBeUndefined();
+    inheritGatewayClientAuthorizationDomain(source, target);
+    inheritGatewayClientAuthorizationDelegation(source, target);
+    expect(getGatewayClientAuthorizationDelegation(target)).toEqual({
+      id: "delegation-1",
+      assignmentId: "assignment-1",
+    });
   });
 });

--- a/src/gateway/authorization/client-domain.test.ts
+++ b/src/gateway/authorization/client-domain.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import type { GatewayClient } from "../server-methods/types.js";
+import {
+  bindGatewayClientAuthorizationDomain,
+  getGatewayClientAuthorizationDomain,
+  inheritGatewayClientAuthorizationDomain,
+} from "./client-domain.js";
+
+function client(): GatewayClient {
+  return {
+    connect: {
+      role: "operator",
+      scopes: ["operator.write"],
+      client: { id: "test", version: "1", platform: "test", mode: "test" },
+      minProtocol: 1,
+      maxProtocol: 1,
+    },
+  };
+}
+
+describe("server-owned gateway client domain", () => {
+  it("ignores plugin-visible object mutation", () => {
+    const gatewayClient = client();
+    bindGatewayClientAuthorizationDomain(gatewayClient, { id: "domain-1" });
+
+    (
+      gatewayClient as GatewayClient & { authorizationDomain?: { id: string } }
+    ).authorizationDomain = {
+      id: "domain-2",
+    };
+
+    expect(getGatewayClientAuthorizationDomain(gatewayClient)).toEqual({ id: "domain-1" });
+  });
+
+  it("is idempotent for one domain and rejects rebinding", () => {
+    const gatewayClient = client();
+    bindGatewayClientAuthorizationDomain(gatewayClient, { id: "domain-1" });
+    expect(() =>
+      bindGatewayClientAuthorizationDomain(gatewayClient, { id: "domain-1" }),
+    ).not.toThrow();
+    expect(() => bindGatewayClientAuthorizationDomain(gatewayClient, { id: "domain-2" })).toThrow(
+      /already bound differently/i,
+    );
+  });
+
+  it("copies the private binding only through the core inheritance helper", () => {
+    const source = client();
+    const target = { ...source };
+    bindGatewayClientAuthorizationDomain(source, { id: "domain-1" });
+
+    expect(getGatewayClientAuthorizationDomain(target)).toBeUndefined();
+    inheritGatewayClientAuthorizationDomain(source, target);
+    expect(getGatewayClientAuthorizationDomain(target)).toEqual({ id: "domain-1" });
+  });
+});

--- a/src/gateway/authorization/client-domain.ts
+++ b/src/gateway/authorization/client-domain.ts
@@ -1,0 +1,38 @@
+import type { GatewayClient } from "../server-methods/types.js";
+import type { IsolationDomainRef } from "./contracts.js";
+
+const clientDomains = new WeakMap<GatewayClient, IsolationDomainRef>();
+
+/** Binds a server-resolved tenant to a live client without exposing mutable authority on it. */
+export function bindGatewayClientAuthorizationDomain(
+  client: GatewayClient,
+  domain: IsolationDomainRef,
+): void {
+  const domainId = domain.id.trim();
+  if (!domainId) {
+    throw new Error("gateway client authorization domain must be non-empty");
+  }
+  const existing = clientDomains.get(client);
+  if (existing && existing.id !== domainId) {
+    throw new Error("gateway client authorization domain is already bound differently");
+  }
+  clientDomains.set(client, Object.freeze({ id: domainId }));
+}
+
+/** Returns server-owned tenant scope; protocol/plugin object properties are never consulted. */
+export function getGatewayClientAuthorizationDomain(
+  client: GatewayClient | null | undefined,
+): IsolationDomainRef | undefined {
+  return client ? clientDomains.get(client) : undefined;
+}
+
+/** Copies server-owned tenant scope when core must clone a client for nested dispatch. */
+export function inheritGatewayClientAuthorizationDomain(
+  source: GatewayClient,
+  target: GatewayClient,
+): void {
+  const domain = clientDomains.get(source);
+  if (domain) {
+    clientDomains.set(target, domain);
+  }
+}

--- a/src/gateway/authorization/client-domain.ts
+++ b/src/gateway/authorization/client-domain.ts
@@ -3,6 +3,12 @@ import type { GatewayDelegationRef, IsolationDomainRef } from "./contracts.js";
 
 const clientDomains = new WeakMap<GatewayClient, IsolationDomainRef>();
 const clientDelegations = new WeakMap<GatewayClient, GatewayDelegationRef>();
+export type GatewayClientTeamsSessionRef = Readonly<{
+  id: string;
+  principalId: string;
+  domainId: string;
+}>;
+const clientTeamsSessions = new WeakMap<GatewayClient, GatewayClientTeamsSessionRef>();
 
 function requiredIdentifier(value: string, label: string): string {
   const normalized = value.trim();
@@ -103,4 +109,63 @@ export function inheritGatewayClientAuthorizationDelegation(
     throw new Error("gateway client authorization delegation cannot cross client identity");
   }
   clientDelegations.set(target, delegation);
+}
+
+/** Binds the exact server-resolved Teams session without exposing it on the client object. */
+export function bindGatewayClientTeamsSession(
+  client: GatewayClient,
+  session: GatewayClientTeamsSessionRef,
+): void {
+  const principal = client.principal;
+  const domainId = requiredIdentifier(session.domainId, "gateway client Teams session domain id");
+  if (principal?.kind !== "human" || clientDomains.get(client)?.id !== domainId) {
+    throw new Error("gateway client Teams session requires the matching human domain client");
+  }
+  const canonical = Object.freeze({
+    id: requiredIdentifier(session.id, "gateway client Teams session id"),
+    principalId: requiredIdentifier(
+      session.principalId,
+      "gateway client Teams session principal id",
+    ),
+    domainId,
+  });
+  const existing = clientTeamsSessions.get(client);
+  if (
+    existing &&
+    (existing.id !== canonical.id ||
+      existing.principalId !== canonical.principalId ||
+      existing.domainId !== canonical.domainId)
+  ) {
+    throw new Error("gateway client Teams session is already bound differently");
+  }
+  clientTeamsSessions.set(client, canonical);
+}
+
+export function getGatewayClientTeamsSession(
+  client: GatewayClient | null | undefined,
+): GatewayClientTeamsSessionRef | undefined {
+  return client ? clientTeamsSessions.get(client) : undefined;
+}
+
+export function inheritGatewayClientTeamsSession(
+  source: GatewayClient,
+  target: GatewayClient,
+): void {
+  const session = clientTeamsSessions.get(source);
+  if (!session) {
+    return;
+  }
+  const sourcePrincipal = source.principal;
+  const targetPrincipal = target.principal;
+  if (
+    sourcePrincipal?.kind !== "human" ||
+    targetPrincipal?.kind !== "human" ||
+    sourcePrincipal.issuer !== targetPrincipal.issuer ||
+    sourcePrincipal.subject !== targetPrincipal.subject ||
+    getGatewayClientAuthorizationDomain(source)?.id !==
+      getGatewayClientAuthorizationDomain(target)?.id
+  ) {
+    throw new Error("gateway client Teams session cannot cross client identity");
+  }
+  clientTeamsSessions.set(target, session);
 }

--- a/src/gateway/authorization/client-domain.ts
+++ b/src/gateway/authorization/client-domain.ts
@@ -1,7 +1,16 @@
 import type { GatewayClient } from "../server-methods/types.js";
-import type { IsolationDomainRef } from "./contracts.js";
+import type { GatewayDelegationRef, IsolationDomainRef } from "./contracts.js";
 
 const clientDomains = new WeakMap<GatewayClient, IsolationDomainRef>();
+const clientDelegations = new WeakMap<GatewayClient, GatewayDelegationRef>();
+
+function requiredIdentifier(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`${label} must be non-empty`);
+  }
+  return normalized;
+}
 
 /** Binds a server-resolved tenant to a live client without exposing mutable authority on it. */
 export function bindGatewayClientAuthorizationDomain(
@@ -35,4 +44,63 @@ export function inheritGatewayClientAuthorizationDomain(
   if (domain) {
     clientDomains.set(target, domain);
   }
+}
+
+/** Binds a server-attested assignment to a scoped service client without exposing it on that client. */
+export function bindGatewayClientAuthorizationDelegation(
+  client: GatewayClient,
+  delegation: GatewayDelegationRef,
+): void {
+  if (client.principal?.kind !== "service") {
+    throw new Error("gateway client authorization delegation requires a service principal");
+  }
+  if (!clientDomains.has(client)) {
+    throw new Error("gateway client authorization delegation requires a bound domain");
+  }
+  const canonical = Object.freeze({
+    id: requiredIdentifier(delegation.id, "gateway client authorization delegation id"),
+    assignmentId: requiredIdentifier(
+      delegation.assignmentId,
+      "gateway client authorization assignment id",
+    ),
+  });
+  const existing = clientDelegations.get(client);
+  if (
+    existing &&
+    (existing.id !== canonical.id || existing.assignmentId !== canonical.assignmentId)
+  ) {
+    throw new Error("gateway client authorization delegation is already bound differently");
+  }
+  clientDelegations.set(client, canonical);
+}
+
+/** Returns only the server-owned assignment; plugin-visible client properties are ignored. */
+export function getGatewayClientAuthorizationDelegation(
+  client: GatewayClient | null | undefined,
+): GatewayDelegationRef | undefined {
+  return client ? clientDelegations.get(client) : undefined;
+}
+
+/** Copies the private assignment only when core clones the same scoped service client. */
+export function inheritGatewayClientAuthorizationDelegation(
+  source: GatewayClient,
+  target: GatewayClient,
+): void {
+  const delegation = clientDelegations.get(source);
+  const sourcePrincipal = source.principal;
+  const targetPrincipal = target.principal;
+  if (!delegation) {
+    return;
+  }
+  if (
+    sourcePrincipal?.kind !== "service" ||
+    targetPrincipal?.kind !== "service" ||
+    sourcePrincipal.issuer !== targetPrincipal.issuer ||
+    sourcePrincipal.subject !== targetPrincipal.subject ||
+    getGatewayClientAuthorizationDomain(source)?.id !==
+      getGatewayClientAuthorizationDomain(target)?.id
+  ) {
+    throw new Error("gateway client authorization delegation cannot cross client identity");
+  }
+  clientDelegations.set(target, delegation);
 }

--- a/src/gateway/authorization/contracts.ts
+++ b/src/gateway/authorization/contracts.ts
@@ -3,6 +3,11 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
 export type IsolationDomainRef = Readonly<{ id: string }>;
 
+export type GatewayAuthorizationContext = Readonly<{
+  principalId: string;
+  domain: IsolationDomainRef;
+}>;
+
 export type GatewayResourceRef = Readonly<{
   namespace: string;
   type: string;
@@ -27,6 +32,7 @@ export type GatewayMethodAccessPolicy =
 
 export type GatewayAuthorizationRequest = Readonly<{
   principal: GatewayPrincipal;
+  domain: IsolationDomainRef;
   method: string;
   permission: string;
   resources: readonly GatewayResourceRef[];

--- a/src/gateway/authorization/contracts.ts
+++ b/src/gateway/authorization/contracts.ts
@@ -55,6 +55,8 @@ export type GatewayMethodAccessPolicy =
   | Readonly<{ kind: "public" }>
   | Readonly<{
       kind: "resource";
+      /** Explicit plugin opt-in for scope-less Teams member sessions. */
+      member?: boolean;
       permission: string;
       resolveResources: (
         input: GatewayResourceResolutionInput,

--- a/src/gateway/authorization/contracts.ts
+++ b/src/gateway/authorization/contracts.ts
@@ -3,9 +3,24 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
 export type IsolationDomainRef = Readonly<{ id: string }>;
 
+export type GatewayDelegationRef = Readonly<{
+  id: string;
+  assignmentId: string;
+}>;
+
+export type GatewayValidatedDelegation = GatewayDelegationRef &
+  Readonly<{ sponsorPrincipalId: string }>;
+
 export type GatewayAuthorizationContext = Readonly<{
   principalId: string;
+  principalKind: GatewayPrincipal["kind"];
   domain: IsolationDomainRef;
+  method: string;
+  permission: string;
+  resources: readonly GatewayResourceRef[];
+  pluginId?: string;
+  requestId?: string;
+  delegation?: GatewayValidatedDelegation;
 }>;
 
 export type GatewayResourceRef = Readonly<{
@@ -33,6 +48,7 @@ export type GatewayMethodAccessPolicy =
 export type GatewayAuthorizationRequest = Readonly<{
   principal: GatewayPrincipal;
   domain: IsolationDomainRef;
+  delegation?: GatewayDelegationRef;
   method: string;
   permission: string;
   resources: readonly GatewayResourceRef[];
@@ -50,6 +66,7 @@ export type GatewayRbacDecision =
       allowed: true;
       principalId: string;
       domain: IsolationDomainRef;
+      delegation?: GatewayValidatedDelegation;
     }>
   | Readonly<{
       allowed: false;

--- a/src/gateway/authorization/contracts.ts
+++ b/src/gateway/authorization/contracts.ts
@@ -1,0 +1,58 @@
+import type { GatewayPrincipal } from "../../../packages/gateway-protocol/src/schema/frames.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+
+export type IsolationDomainRef = Readonly<{ id: string }>;
+
+export type GatewayResourceRef = Readonly<{
+  namespace: string;
+  type: string;
+  id: string;
+}>;
+
+export type GatewayResourceResolutionInput = Readonly<{
+  method: string;
+  params: unknown;
+  config: OpenClawConfig;
+}>;
+
+export type GatewayMethodAccessPolicy =
+  | Readonly<{ kind: "public" }>
+  | Readonly<{
+      kind: "resource";
+      permission: string;
+      resolveResources: (
+        input: GatewayResourceResolutionInput,
+      ) => Promise<readonly GatewayResourceRef[]> | readonly GatewayResourceRef[];
+    }>;
+
+export type GatewayAuthorizationRequest = Readonly<{
+  principal: GatewayPrincipal;
+  method: string;
+  permission: string;
+  resources: readonly GatewayResourceRef[];
+}>;
+
+export type GatewayRbacDenialReason =
+  | "unknown-principal"
+  | "unbound-resource"
+  | "cross-domain"
+  | "forbidden"
+  | "indeterminate";
+
+export type GatewayRbacDecision =
+  | Readonly<{
+      allowed: true;
+      principalId: string;
+      domain: IsolationDomainRef;
+    }>
+  | Readonly<{
+      allowed: false;
+      reason: GatewayRbacDenialReason;
+    }>;
+
+export type GatewayAuthorizationRuntime =
+  | Readonly<{ mode: "legacy" }>
+  | Readonly<{
+      mode: "isolated";
+      authorize: (request: GatewayAuthorizationRequest) => Promise<GatewayRbacDecision>;
+    }>;

--- a/src/gateway/authorization/contracts.ts
+++ b/src/gateway/authorization/contracts.ts
@@ -11,6 +11,22 @@ export type GatewayDelegationRef = Readonly<{
 export type GatewayValidatedDelegation = GatewayDelegationRef &
   Readonly<{ sponsorPrincipalId: string }>;
 
+export const GATEWAY_AGENT_SESSION_INVOKE_PERMISSION = "agents.session.invoke";
+
+/** Server-only proof binding one agent run to its authenticated human invoker. */
+export type GatewayAgentSessionAuthorizationRef = Readonly<{
+  id: string;
+  invokingPrincipal: GatewayPrincipal;
+}>;
+
+/** Immutable server-issued subject carried into one agent run; never derived from tool arguments. */
+export type GatewayAuthorizationSubject = Readonly<{
+  principal: GatewayPrincipal;
+  domain: IsolationDomainRef;
+  delegation?: GatewayDelegationRef;
+  agentSession?: GatewayAgentSessionAuthorizationRef;
+}>;
+
 export type GatewayAuthorizationContext = Readonly<{
   principalId: string;
   principalKind: GatewayPrincipal["kind"];
@@ -49,6 +65,7 @@ export type GatewayAuthorizationRequest = Readonly<{
   principal: GatewayPrincipal;
   domain: IsolationDomainRef;
   delegation?: GatewayDelegationRef;
+  agentSession?: GatewayAgentSessionAuthorizationRef;
   method: string;
   permission: string;
   resources: readonly GatewayResourceRef[];

--- a/src/gateway/authorization/delegations.ts
+++ b/src/gateway/authorization/delegations.ts
@@ -1,0 +1,201 @@
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../../infra/kysely-sync.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
+import {
+  runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabaseOptions,
+} from "../../state/openclaw-state-db.js";
+
+type AuthorizationDelegationDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  | "authorization_agent_sponsors"
+  | "authorization_delegations"
+  | "authorization_domain_memberships"
+  | "authorization_principals"
+>;
+
+function requiredIdentifier(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return normalized;
+}
+
+export function createAuthorizationDelegation(input: {
+  database?: OpenClawStateDatabaseOptions;
+  id: string;
+  assignmentId: string;
+  domainId: string;
+  agentPrincipalId: string;
+  sponsorPrincipalId: string;
+  createdByPrincipalId: string;
+}): void {
+  const delegationId = requiredIdentifier(input.id, "delegation id");
+  const assignmentId = requiredIdentifier(input.assignmentId, "assignment id");
+  const domainId = requiredIdentifier(input.domainId, "isolation domain id");
+  const agentPrincipalId = requiredIdentifier(input.agentPrincipalId, "agent principal id");
+  const sponsorPrincipalId = requiredIdentifier(input.sponsorPrincipalId, "sponsor principal id");
+  const createdByPrincipalId = requiredIdentifier(
+    input.createdByPrincipalId,
+    "delegation creator principal id",
+  );
+  if (createdByPrincipalId !== sponsorPrincipalId) {
+    throw new Error("an authorization delegation must be created by its human sponsor");
+  }
+  runOpenClawStateWriteTransaction(({ db }) => {
+    const kysely = getNodeSqliteKysely<AuthorizationDelegationDatabase>(db);
+    const byId = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_delegations")
+        .selectAll()
+        .where("domain_id", "=", domainId)
+        .where("delegation_id", "=", delegationId),
+    );
+    const byAssignment = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_delegations")
+        .selectAll()
+        .where("domain_id", "=", domainId)
+        .where("assignment_id", "=", assignmentId),
+    );
+    const existing = byId ?? byAssignment;
+    if (existing) {
+      const matches =
+        existing.delegation_id === delegationId &&
+        existing.assignment_id === assignmentId &&
+        existing.agent_principal_id === agentPrincipalId &&
+        existing.sponsor_principal_id === sponsorPrincipalId &&
+        existing.created_by_principal_id === createdByPrincipalId;
+      if (!matches || (byId && byAssignment && byId.delegation_id !== byAssignment.delegation_id)) {
+        throw new Error("authorization delegation identity is already bound differently");
+      }
+      return;
+    }
+    const participants = executeSqliteQuerySync(
+      db,
+      kysely
+        .selectFrom("authorization_principals as principal")
+        .innerJoin("authorization_domain_memberships as membership", (join) =>
+          join
+            .onRef("membership.principal_id", "=", "principal.principal_id")
+            .on("membership.domain_id", "=", domainId),
+        )
+        .select(["principal.principal_id", "principal.kind", "membership.role"])
+        .where("principal.principal_id", "in", [agentPrincipalId, sponsorPrincipalId]),
+    ).rows;
+    const participantsById = new Map(
+      participants.map((participant) => [participant.principal_id, participant]),
+    );
+    if (participantsById.get(agentPrincipalId)?.kind !== "service") {
+      throw new Error("authorization delegation agent must be a service domain member");
+    }
+    const sponsor = participantsById.get(sponsorPrincipalId);
+    if (sponsor?.kind !== "human" || sponsor.role !== "owner") {
+      throw new Error("authorization delegation canonical sponsor must be the human domain owner");
+    }
+    const now = Date.now();
+    const canonicalSponsor = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_agent_sponsors")
+        .select("sponsor_principal_id")
+        .where("domain_id", "=", domainId)
+        .where("agent_principal_id", "=", agentPrincipalId),
+    );
+    if (canonicalSponsor && canonicalSponsor.sponsor_principal_id !== sponsorPrincipalId) {
+      throw new Error("authorization agent is already tied to a different canonical sponsor");
+    }
+    if (!canonicalSponsor) {
+      executeSqliteQuerySync(
+        db,
+        kysely.insertInto("authorization_agent_sponsors").values({
+          domain_id: domainId,
+          agent_principal_id: agentPrincipalId,
+          sponsor_principal_id: sponsorPrincipalId,
+          created_at: now,
+        }),
+      );
+    }
+    executeSqliteQuerySync(
+      db,
+      kysely.insertInto("authorization_delegations").values({
+        domain_id: domainId,
+        delegation_id: delegationId,
+        assignment_id: assignmentId,
+        agent_principal_id: agentPrincipalId,
+        sponsor_principal_id: sponsorPrincipalId,
+        created_by_principal_id: createdByPrincipalId,
+        state: "active",
+        created_at: now,
+        updated_at: now,
+        revoked_at: null,
+      }),
+    );
+  }, input.database);
+}
+
+export function revokeAuthorizationDelegation(input: {
+  database?: OpenClawStateDatabaseOptions;
+  domainId: string;
+  delegationId: string;
+  revokedByPrincipalId: string;
+}): void {
+  const domainId = requiredIdentifier(input.domainId, "isolation domain id");
+  const delegationId = requiredIdentifier(input.delegationId, "delegation id");
+  const revokedByPrincipalId = requiredIdentifier(
+    input.revokedByPrincipalId,
+    "revoking principal id",
+  );
+  runOpenClawStateWriteTransaction(({ db }) => {
+    const kysely = getNodeSqliteKysely<AuthorizationDelegationDatabase>(db);
+    const delegation = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_delegations")
+        .select(["sponsor_principal_id", "state"])
+        .where("domain_id", "=", domainId)
+        .where("delegation_id", "=", delegationId),
+    );
+    if (!delegation) {
+      throw new Error("unknown authorization delegation");
+    }
+    if (delegation.state === "revoked") {
+      return;
+    }
+    const revoker = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_domain_memberships as membership")
+        .innerJoin(
+          "authorization_principals as principal",
+          "principal.principal_id",
+          "membership.principal_id",
+        )
+        .select(["membership.role", "principal.kind"])
+        .where("membership.domain_id", "=", domainId)
+        .where("membership.principal_id", "=", revokedByPrincipalId),
+    );
+    if (
+      revoker?.kind !== "human" ||
+      (revoker.role !== "owner" && delegation.sponsor_principal_id !== revokedByPrincipalId)
+    ) {
+      throw new Error("authorization delegation revocation requires its sponsor or domain owner");
+    }
+    const now = Date.now();
+    executeSqliteQuerySync(
+      db,
+      kysely
+        .updateTable("authorization_delegations")
+        .set({ state: "revoked", revoked_at: now, updated_at: now })
+        .where("domain_id", "=", domainId)
+        .where("delegation_id", "=", delegationId)
+        .where("state", "=", "active"),
+    );
+  }, input.database);
+}

--- a/src/gateway/authorization/kernel.test.ts
+++ b/src/gateway/authorization/kernel.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type {
+  GatewayAuthorizationRuntime,
+  GatewayMethodAccessPolicy,
+  GatewayRbacDenialReason,
+  GatewayResourceRef,
+  GatewayResourceResolutionInput,
+} from "./contracts.js";
+import { authorizeGatewayAccess } from "./kernel.js";
+
+const config = {} as OpenClawConfig;
+const principal = {
+  issuer: "trusted-proxy",
+  subject: "member@example.com",
+  kind: "human",
+} as const;
+const resource: GatewayResourceRef = {
+  namespace: "core",
+  type: "session",
+  id: "session-1",
+};
+
+function resourcePolicy(
+  resolveResources: (
+    input: GatewayResourceResolutionInput,
+  ) => readonly GatewayResourceRef[] | Promise<readonly GatewayResourceRef[]>,
+): GatewayMethodAccessPolicy {
+  return {
+    kind: "resource",
+    permission: "session.read",
+    resolveResources,
+  };
+}
+
+describe("gateway authorization kernel", () => {
+  it("preserves legacy behavior without resolving resources or calling a provider", async () => {
+    const resolveResources = vi.fn(() => [resource]);
+    const authorize = vi.fn(async () => ({ allowed: false, reason: "forbidden" }) as const);
+
+    const result = await authorizeGatewayAccess({
+      runtime: { mode: "legacy" },
+      policy: resourcePolicy(resolveResources),
+      principal,
+      method: "sessions.get",
+      params: { key: "session-1" },
+      getConfig: () => config,
+    });
+
+    expect(result).toEqual({ allowed: true });
+    expect(resolveResources).not.toHaveBeenCalled();
+    expect(authorize).not.toHaveBeenCalled();
+  });
+
+  it("allows an explicitly public method in isolated mode without a principal", async () => {
+    const authorize = vi.fn();
+
+    const result = await authorizeGatewayAccess({
+      runtime: { mode: "isolated", authorize },
+      policy: { kind: "public" },
+      method: "health",
+      params: undefined,
+      getConfig: () => config,
+    });
+
+    expect(result).toEqual({ allowed: true });
+    expect(authorize).not.toHaveBeenCalled();
+  });
+
+  it("fails closed on an unknown runtime mode even for an explicitly public method", async () => {
+    const result = await authorizeGatewayAccess({
+      runtime: { mode: "corrupt" } as unknown as GatewayAuthorizationRuntime,
+      policy: { kind: "public" },
+      method: "health",
+      params: undefined,
+      getConfig: () => config,
+    });
+
+    expect(result).toEqual({ allowed: false, reason: "indeterminate" });
+  });
+
+  it("denies an unclassified method in isolated mode", async () => {
+    const result = await authorizeGatewayAccess({
+      runtime: { mode: "isolated", authorize: vi.fn() },
+      method: "sessions.get",
+      params: {},
+      getConfig: () => config,
+      principal,
+    });
+
+    expect(result).toEqual({ allowed: false, reason: "unclassified-method" });
+  });
+
+  it("denies a resource method without a server-issued principal", async () => {
+    const resolveResources = vi.fn(() => [resource]);
+
+    const result = await authorizeGatewayAccess({
+      runtime: { mode: "isolated", authorize: vi.fn() },
+      policy: resourcePolicy(resolveResources),
+      method: "sessions.get",
+      params: {},
+      getConfig: () => config,
+    });
+
+    expect(result).toEqual({ allowed: false, reason: "unauthenticated" });
+    expect(resolveResources).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { label: "no resources", resources: [] },
+    { label: "blank namespace", resources: [{ ...resource, namespace: " " }] },
+    { label: "blank type", resources: [{ ...resource, type: "" }] },
+    { label: "blank id", resources: [{ ...resource, id: "  " }] },
+  ])("fails closed when a resolver returns $label", async ({ resources }) => {
+    const authorize = vi.fn();
+
+    const result = await authorizeGatewayAccess({
+      runtime: { mode: "isolated", authorize },
+      policy: resourcePolicy(() => resources),
+      principal,
+      method: "sessions.get",
+      params: {},
+      getConfig: () => config,
+    });
+
+    expect(result).toEqual({ allowed: false, reason: "unbound-resource" });
+    expect(authorize).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when resource resolution throws", async () => {
+    const result = await authorizeGatewayAccess({
+      runtime: { mode: "isolated", authorize: vi.fn() },
+      policy: resourcePolicy(() => {
+        throw new Error("resolver failed");
+      }),
+      principal,
+      method: "sessions.get",
+      params: {},
+      getConfig: () => config,
+    });
+
+    expect(result).toEqual({ allowed: false, reason: "indeterminate" });
+  });
+
+  it("fails closed when a resolver returns non-string resource fields", async () => {
+    const result = await authorizeGatewayAccess({
+      runtime: { mode: "isolated", authorize: vi.fn() },
+      policy: resourcePolicy(
+        () => [{ ...resource, namespace: 42 }] as unknown as readonly GatewayResourceRef[],
+      ),
+      principal,
+      method: "sessions.get",
+      params: {},
+      getConfig: () => config,
+    });
+
+    expect(result).toEqual({ allowed: false, reason: "unbound-resource" });
+  });
+
+  it("returns the stable principal and isolation domain from an allowed provider decision", async () => {
+    const authorize = vi.fn(async () => ({
+      allowed: true as const,
+      principalId: "principal-1",
+      domain: { id: "domain-1" },
+    }));
+
+    const result = await authorizeGatewayAccess({
+      runtime: { mode: "isolated", authorize },
+      policy: resourcePolicy(() => [resource]),
+      principal,
+      method: "sessions.get",
+      params: { key: "session-1" },
+      getConfig: () => config,
+    });
+
+    expect(authorize).toHaveBeenCalledWith({
+      principal,
+      method: "sessions.get",
+      permission: "session.read",
+      resources: [resource],
+    });
+    expect(result).toEqual({
+      allowed: true,
+      security: { principalId: "principal-1", domain: { id: "domain-1" } },
+    });
+  });
+
+  it.each([
+    { principalId: "", domain: { id: "domain-1" } },
+    { principalId: "principal-1", domain: { id: " " } },
+  ])("fails closed on a malformed allowed provider decision", async (decision) => {
+    const result = await authorizeGatewayAccess({
+      runtime: {
+        mode: "isolated",
+        authorize: async () => ({ allowed: true, ...decision }),
+      },
+      policy: resourcePolicy(() => [resource]),
+      principal,
+      method: "sessions.get",
+      params: {},
+      getConfig: () => config,
+    });
+
+    expect(result).toEqual({ allowed: false, reason: "indeterminate" });
+  });
+
+  it.each<GatewayRbacDenialReason>([
+    "unknown-principal",
+    "unbound-resource",
+    "cross-domain",
+    "forbidden",
+    "indeterminate",
+  ])("retains the provider denial reason %s", async (reason) => {
+    const runtime: GatewayAuthorizationRuntime = {
+      mode: "isolated",
+      authorize: async () => ({ allowed: false, reason }),
+    };
+
+    const result = await authorizeGatewayAccess({
+      runtime,
+      policy: resourcePolicy(() => [resource]),
+      principal,
+      method: "sessions.get",
+      params: {},
+      getConfig: () => config,
+    });
+
+    expect(result).toEqual({ allowed: false, reason });
+  });
+
+  it("fails closed when the provider throws", async () => {
+    const result = await authorizeGatewayAccess({
+      runtime: {
+        mode: "isolated",
+        authorize: async () => {
+          throw new Error("provider failed");
+        },
+      },
+      policy: resourcePolicy(() => [resource]),
+      principal,
+      method: "sessions.get",
+      params: {},
+      getConfig: () => config,
+    });
+
+    expect(result).toEqual({ allowed: false, reason: "indeterminate" });
+  });
+
+  it("fails closed when the provider returns an unknown denial reason", async () => {
+    const result = await authorizeGatewayAccess({
+      runtime: {
+        mode: "isolated",
+        authorize: async () =>
+          ({ allowed: false, reason: "unexpected" }) as unknown as Awaited<
+            ReturnType<Extract<GatewayAuthorizationRuntime, { mode: "isolated" }>["authorize"]>
+          >,
+      },
+      policy: resourcePolicy(() => [resource]),
+      principal,
+      method: "sessions.get",
+      params: {},
+      getConfig: () => config,
+    });
+
+    expect(result).toEqual({ allowed: false, reason: "indeterminate" });
+  });
+
+  it("fails closed when the provider returns a non-boolean allowed discriminant", async () => {
+    const result = await authorizeGatewayAccess({
+      runtime: {
+        mode: "isolated",
+        authorize: async () =>
+          ({
+            allowed: "false",
+            principalId: "principal-1",
+            domain: { id: "domain-1" },
+          }) as unknown as Awaited<
+            ReturnType<Extract<GatewayAuthorizationRuntime, { mode: "isolated" }>["authorize"]>
+          >,
+      },
+      policy: resourcePolicy(() => [resource]),
+      principal,
+      method: "sessions.get",
+      params: {},
+      getConfig: () => config,
+    });
+
+    expect(result).toEqual({ allowed: false, reason: "indeterminate" });
+  });
+});

--- a/src/gateway/authorization/kernel.test.ts
+++ b/src/gateway/authorization/kernel.test.ts
@@ -206,8 +206,113 @@ describe("gateway authorization kernel", () => {
     });
     expect(result).toEqual({
       allowed: true,
-      security: { principalId: "principal-1", domain: { id: "domain-1" } },
+      security: {
+        principalId: "principal-1",
+        principalKind: "human",
+        domain: { id: "domain-1" },
+        method: "sessions.get",
+        permission: "session.read",
+        resources: [resource],
+      },
     });
+  });
+
+  it("snapshots plugin action and resources before awaiting the provider", async () => {
+    const mutableResource = { namespace: "core", type: "session", id: "session-original" };
+    const policy = {
+      kind: "resource" as const,
+      permission: "session.read",
+      resolveResources: () => [mutableResource],
+    };
+    let resolveDecision: (() => void) | undefined;
+    const authorize = vi.fn(
+      () =>
+        new Promise<{
+          allowed: true;
+          principalId: string;
+          domain: { id: string };
+        }>((resolve) => {
+          resolveDecision = () =>
+            resolve({ allowed: true, principalId: "principal-1", domain: { id: "domain-1" } });
+        }),
+    );
+    const pending = authorizeGatewayAccess({
+      runtime: { mode: "isolated", authorize },
+      policy,
+      principal,
+      method: "sessions.get",
+      params: {},
+      getConfig: () => config,
+    });
+    await vi.waitFor(() => expect(authorize).toHaveBeenCalledOnce());
+
+    mutableResource.id = "session-forged";
+    policy.permission = "session.write";
+    resolveDecision?.();
+
+    await expect(pending).resolves.toEqual({
+      allowed: true,
+      security: expect.objectContaining({
+        permission: "session.read",
+        resources: [{ namespace: "core", type: "session", id: "session-original" }],
+      }),
+    });
+  });
+
+  it("snapshots the server delegation reference before awaiting the provider", async () => {
+    const mutableDelegation = { id: "delegation-1", assignmentId: "assignment-1" };
+    let resolveDecision: (() => void) | undefined;
+    const authorize = vi.fn(
+      () =>
+        new Promise<{
+          allowed: true;
+          principalId: string;
+          domain: { id: string };
+          delegation: { id: string; assignmentId: string; sponsorPrincipalId: string };
+        }>((resolve) => {
+          resolveDecision = () =>
+            resolve({
+              allowed: true,
+              principalId: "principal-agent",
+              domain: { id: "domain-1" },
+              delegation: {
+                id: "delegation-1",
+                assignmentId: "assignment-1",
+                sponsorPrincipalId: "principal-owner",
+              },
+            });
+        }),
+    );
+    const pending = authorizeGatewayAccess({
+      runtime: { mode: "isolated", authorize },
+      policy: resourcePolicy(() => [resource]),
+      principal: { issuer: "core", subject: "agent:main", kind: "service" },
+      delegation: mutableDelegation,
+      method: "sessions.get",
+      params: {},
+      getConfig: () => config,
+    });
+    await vi.waitFor(() => expect(authorize).toHaveBeenCalledOnce());
+
+    mutableDelegation.id = "injected-delegation";
+    mutableDelegation.assignmentId = "injected-assignment";
+    resolveDecision?.();
+
+    await expect(pending).resolves.toEqual({
+      allowed: true,
+      security: expect.objectContaining({
+        delegation: {
+          id: "delegation-1",
+          assignmentId: "assignment-1",
+          sponsorPrincipalId: "principal-owner",
+        },
+      }),
+    });
+    expect(authorize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        delegation: { id: "delegation-1", assignmentId: "assignment-1" },
+      }),
+    );
   });
 
   it.each([

--- a/src/gateway/authorization/kernel.test.ts
+++ b/src/gateway/authorization/kernel.test.ts
@@ -7,7 +7,7 @@ import type {
   GatewayResourceRef,
   GatewayResourceResolutionInput,
 } from "./contracts.js";
-import { authorizeGatewayAccess } from "./kernel.js";
+import { authorizeGatewayAccess as authorizeGatewayAccessKernel } from "./kernel.js";
 
 const config = {} as OpenClawConfig;
 const principal = {
@@ -15,6 +15,7 @@ const principal = {
   subject: "member@example.com",
   kind: "human",
 } as const;
+const domain = { id: "domain-1" } as const;
 const resource: GatewayResourceRef = {
   namespace: "core",
   type: "session",
@@ -33,7 +34,30 @@ function resourcePolicy(
   };
 }
 
+function authorizeGatewayAccess(
+  input: Omit<Parameters<typeof authorizeGatewayAccessKernel>[0], "domain">,
+) {
+  return authorizeGatewayAccessKernel({ ...input, domain });
+}
+
 describe("gateway authorization kernel", () => {
+  it("fails closed before resource resolution without a trusted domain", async () => {
+    const resolveResources = vi.fn(() => [resource]);
+    const authorize = vi.fn();
+
+    const result = await authorizeGatewayAccessKernel({
+      runtime: { mode: "isolated", authorize },
+      policy: resourcePolicy(resolveResources),
+      principal,
+      method: "sessions.get",
+      params: {},
+      getConfig: () => config,
+    });
+
+    expect(result).toEqual({ allowed: false, reason: "unscoped-domain" });
+    expect(resolveResources).not.toHaveBeenCalled();
+    expect(authorize).not.toHaveBeenCalled();
+  });
   it("preserves legacy behavior without resolving resources or calling a provider", async () => {
     const resolveResources = vi.fn(() => [resource]);
     const authorize = vi.fn(async () => ({ allowed: false, reason: "forbidden" }) as const);
@@ -175,6 +199,7 @@ describe("gateway authorization kernel", () => {
 
     expect(authorize).toHaveBeenCalledWith({
       principal,
+      domain,
       method: "sessions.get",
       permission: "session.read",
       resources: [resource],
@@ -193,6 +218,26 @@ describe("gateway authorization kernel", () => {
       runtime: {
         mode: "isolated",
         authorize: async () => ({ allowed: true, ...decision }),
+      },
+      policy: resourcePolicy(() => [resource]),
+      principal,
+      method: "sessions.get",
+      params: {},
+      getConfig: () => config,
+    });
+
+    expect(result).toEqual({ allowed: false, reason: "indeterminate" });
+  });
+
+  it("fails closed when a provider returns a different domain", async () => {
+    const result = await authorizeGatewayAccess({
+      runtime: {
+        mode: "isolated",
+        authorize: async () => ({
+          allowed: true,
+          principalId: "principal-1",
+          domain: { id: "domain-2" },
+        }),
       },
       policy: resourcePolicy(() => [resource]),
       principal,

--- a/src/gateway/authorization/kernel.ts
+++ b/src/gateway/authorization/kernel.ts
@@ -2,6 +2,7 @@ import type { GatewayPrincipal } from "../../../packages/gateway-protocol/src/sc
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type {
   GatewayAuthorizationRuntime,
+  GatewayAuthorizationContext,
   GatewayMethodAccessPolicy,
   GatewayRbacDenialReason,
   IsolationDomainRef,
@@ -28,17 +29,22 @@ function isGatewayRbacDenialReason(value: unknown): value is GatewayRbacDenialRe
 export type GatewayAuthorizationOutcome =
   | Readonly<{
       allowed: true;
-      security?: Readonly<{ principalId: string; domain: IsolationDomainRef }>;
+      security?: GatewayAuthorizationContext;
     }>
   | Readonly<{
       allowed: false;
-      reason: GatewayRbacDenialReason | "unauthenticated" | "unclassified-method";
+      reason:
+        | GatewayRbacDenialReason
+        | "unauthenticated"
+        | "unclassified-method"
+        | "unscoped-domain";
     }>;
 
 export async function authorizeGatewayAccess(_input: {
   runtime: GatewayAuthorizationRuntime;
   policy?: GatewayMethodAccessPolicy;
   principal?: GatewayPrincipal;
+  domain?: IsolationDomainRef;
   method: string;
   params: unknown;
   getConfig: () => OpenClawConfig;
@@ -57,6 +63,9 @@ export async function authorizeGatewayAccess(_input: {
   }
   if (!_input.principal) {
     return { allowed: false, reason: "unauthenticated" };
+  }
+  if (!_input.domain || !isNonEmptyString(_input.domain.id)) {
+    return { allowed: false, reason: "unscoped-domain" };
   }
 
   let resources;
@@ -86,6 +95,7 @@ export async function authorizeGatewayAccess(_input: {
   try {
     const decision = await _input.runtime.authorize({
       principal: _input.principal,
+      domain: _input.domain,
       method: _input.method,
       permission: _input.policy.permission,
       resources,
@@ -98,12 +108,19 @@ export async function authorizeGatewayAccess(_input: {
     if (decision.allowed !== true) {
       return { allowed: false, reason: "indeterminate" };
     }
-    if (!isNonEmptyString(decision.principalId) || !isNonEmptyString(decision.domain.id)) {
+    if (
+      !isNonEmptyString(decision.principalId) ||
+      !isNonEmptyString(decision.domain.id) ||
+      decision.domain.id !== _input.domain.id
+    ) {
       return { allowed: false, reason: "indeterminate" };
     }
     return {
       allowed: true,
-      security: { principalId: decision.principalId, domain: decision.domain },
+      security: Object.freeze({
+        principalId: decision.principalId,
+        domain: Object.freeze({ id: decision.domain.id }),
+      }),
     };
   } catch {
     return { allowed: false, reason: "indeterminate" };

--- a/src/gateway/authorization/kernel.ts
+++ b/src/gateway/authorization/kernel.ts
@@ -1,0 +1,111 @@
+import type { GatewayPrincipal } from "../../../packages/gateway-protocol/src/schema/frames.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type {
+  GatewayAuthorizationRuntime,
+  GatewayMethodAccessPolicy,
+  GatewayRbacDenialReason,
+  IsolationDomainRef,
+} from "./contracts.js";
+
+const GATEWAY_RBAC_DENIAL_REASONS = new Set<GatewayRbacDenialReason>([
+  "unknown-principal",
+  "unbound-resource",
+  "cross-domain",
+  "forbidden",
+  "indeterminate",
+]);
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && Boolean(value.trim());
+}
+
+function isGatewayRbacDenialReason(value: unknown): value is GatewayRbacDenialReason {
+  return (
+    typeof value === "string" && GATEWAY_RBAC_DENIAL_REASONS.has(value as GatewayRbacDenialReason)
+  );
+}
+
+export type GatewayAuthorizationOutcome =
+  | Readonly<{
+      allowed: true;
+      security?: Readonly<{ principalId: string; domain: IsolationDomainRef }>;
+    }>
+  | Readonly<{
+      allowed: false;
+      reason: GatewayRbacDenialReason | "unauthenticated" | "unclassified-method";
+    }>;
+
+export async function authorizeGatewayAccess(_input: {
+  runtime: GatewayAuthorizationRuntime;
+  policy?: GatewayMethodAccessPolicy;
+  principal?: GatewayPrincipal;
+  method: string;
+  params: unknown;
+  getConfig: () => OpenClawConfig;
+}): Promise<GatewayAuthorizationOutcome> {
+  if (_input.runtime.mode === "legacy") {
+    return { allowed: true };
+  }
+  if (_input.runtime.mode !== "isolated") {
+    return { allowed: false, reason: "indeterminate" };
+  }
+  if (_input.policy?.kind === "public") {
+    return { allowed: true };
+  }
+  if (!_input.policy) {
+    return { allowed: false, reason: "unclassified-method" };
+  }
+  if (!_input.principal) {
+    return { allowed: false, reason: "unauthenticated" };
+  }
+
+  let resources;
+  try {
+    resources = await _input.policy.resolveResources({
+      method: _input.method,
+      params: _input.params,
+      config: _input.getConfig(),
+    });
+  } catch {
+    return { allowed: false, reason: "indeterminate" };
+  }
+  if (
+    !Array.isArray(resources) ||
+    resources.length === 0 ||
+    resources.some(
+      (resource) =>
+        !resource ||
+        !isNonEmptyString(resource.namespace) ||
+        !isNonEmptyString(resource.type) ||
+        !isNonEmptyString(resource.id),
+    )
+  ) {
+    return { allowed: false, reason: "unbound-resource" };
+  }
+
+  try {
+    const decision = await _input.runtime.authorize({
+      principal: _input.principal,
+      method: _input.method,
+      permission: _input.policy.permission,
+      resources,
+    });
+    if (decision.allowed === false) {
+      return isGatewayRbacDenialReason(decision.reason)
+        ? decision
+        : { allowed: false, reason: "indeterminate" };
+    }
+    if (decision.allowed !== true) {
+      return { allowed: false, reason: "indeterminate" };
+    }
+    if (!isNonEmptyString(decision.principalId) || !isNonEmptyString(decision.domain.id)) {
+      return { allowed: false, reason: "indeterminate" };
+    }
+    return {
+      allowed: true,
+      security: { principalId: decision.principalId, domain: decision.domain },
+    };
+  } catch {
+    return { allowed: false, reason: "indeterminate" };
+  }
+}

--- a/src/gateway/authorization/kernel.ts
+++ b/src/gateway/authorization/kernel.ts
@@ -45,6 +45,7 @@ export async function authorizeGatewayAccess(_input: {
   policy?: GatewayMethodAccessPolicy;
   principal?: GatewayPrincipal;
   domain?: IsolationDomainRef;
+  delegation?: { id: string; assignmentId: string };
   method: string;
   params: unknown;
   getConfig: () => OpenClawConfig;
@@ -92,34 +93,83 @@ export async function authorizeGatewayAccess(_input: {
     return { allowed: false, reason: "unbound-resource" };
   }
 
+  // Plugin policy objects are mutable JavaScript. Snapshot the exact proof before
+  // awaiting the provider so the decision and request context cannot diverge.
+  const permission = _input.policy.permission;
+  const delegation = _input.delegation
+    ? Object.freeze({
+        id: _input.delegation.id,
+        assignmentId: _input.delegation.assignmentId,
+      })
+    : undefined;
+  if (
+    delegation &&
+    (!isNonEmptyString(delegation.id) || !isNonEmptyString(delegation.assignmentId))
+  ) {
+    return { allowed: false, reason: "indeterminate" };
+  }
+  const authorizedResources = Object.freeze(
+    resources.map((resource) =>
+      Object.freeze({
+        namespace: resource.namespace,
+        type: resource.type,
+        id: resource.id,
+      }),
+    ),
+  );
+
   try {
     const decision = await _input.runtime.authorize({
       principal: _input.principal,
       domain: _input.domain,
+      ...(delegation ? { delegation } : {}),
       method: _input.method,
-      permission: _input.policy.permission,
-      resources,
+      permission,
+      resources: authorizedResources,
     });
-    if (decision.allowed === false) {
-      return isGatewayRbacDenialReason(decision.reason)
-        ? decision
+    const allowed = (decision as { allowed?: unknown }).allowed;
+    if (allowed === false) {
+      const denied = decision as Extract<typeof decision, { allowed: false }>;
+      return isGatewayRbacDenialReason(denied.reason)
+        ? denied
         : { allowed: false, reason: "indeterminate" };
     }
-    if (decision.allowed !== true) {
+    if (allowed !== true) {
       return { allowed: false, reason: "indeterminate" };
     }
+    const allowedDecision = decision as Extract<typeof decision, { allowed: true }>;
     if (
-      !isNonEmptyString(decision.principalId) ||
-      !isNonEmptyString(decision.domain.id) ||
-      decision.domain.id !== _input.domain.id
+      !isNonEmptyString(allowedDecision.principalId) ||
+      !isNonEmptyString(allowedDecision.domain.id) ||
+      allowedDecision.domain.id !== _input.domain.id
     ) {
+      return { allowed: false, reason: "indeterminate" };
+    }
+    if (_input.principal.kind === "service") {
+      if (
+        !delegation ||
+        !allowedDecision.delegation ||
+        allowedDecision.delegation.id !== delegation.id ||
+        allowedDecision.delegation.assignmentId !== delegation.assignmentId ||
+        !isNonEmptyString(allowedDecision.delegation.sponsorPrincipalId)
+      ) {
+        return { allowed: false, reason: "indeterminate" };
+      }
+    } else if (allowedDecision.delegation) {
       return { allowed: false, reason: "indeterminate" };
     }
     return {
       allowed: true,
       security: Object.freeze({
-        principalId: decision.principalId,
-        domain: Object.freeze({ id: decision.domain.id }),
+        principalId: allowedDecision.principalId,
+        principalKind: _input.principal.kind,
+        domain: Object.freeze({ id: allowedDecision.domain.id }),
+        method: _input.method,
+        permission,
+        resources: authorizedResources,
+        ...(allowedDecision.delegation
+          ? { delegation: Object.freeze({ ...allowedDecision.delegation }) }
+          : {}),
       }),
     };
   } catch {

--- a/src/gateway/authorization/kernel.ts
+++ b/src/gateway/authorization/kernel.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type {
   GatewayAuthorizationRuntime,
   GatewayAuthorizationContext,
+  GatewayAgentSessionAuthorizationRef,
   GatewayMethodAccessPolicy,
   GatewayRbacDenialReason,
   IsolationDomainRef,
@@ -46,6 +47,7 @@ export async function authorizeGatewayAccess(_input: {
   principal?: GatewayPrincipal;
   domain?: IsolationDomainRef;
   delegation?: { id: string; assignmentId: string };
+  agentSession?: GatewayAgentSessionAuthorizationRef;
   method: string;
   params: unknown;
   getConfig: () => OpenClawConfig;
@@ -108,6 +110,25 @@ export async function authorizeGatewayAccess(_input: {
   ) {
     return { allowed: false, reason: "indeterminate" };
   }
+  const agentSession = _input.agentSession
+    ? Object.freeze({
+        id: _input.agentSession.id,
+        invokingPrincipal: Object.freeze({
+          issuer: _input.agentSession.invokingPrincipal.issuer,
+          subject: _input.agentSession.invokingPrincipal.subject,
+          kind: _input.agentSession.invokingPrincipal.kind,
+        }),
+      })
+    : undefined;
+  if (
+    agentSession &&
+    (!isNonEmptyString(agentSession.id) ||
+      !isNonEmptyString(agentSession.invokingPrincipal.issuer) ||
+      !isNonEmptyString(agentSession.invokingPrincipal.subject) ||
+      agentSession.invokingPrincipal.kind !== "human")
+  ) {
+    return { allowed: false, reason: "indeterminate" };
+  }
   const authorizedResources = Object.freeze(
     resources.map((resource) =>
       Object.freeze({
@@ -123,6 +144,7 @@ export async function authorizeGatewayAccess(_input: {
       principal: _input.principal,
       domain: _input.domain,
       ...(delegation ? { delegation } : {}),
+      ...(agentSession ? { agentSession } : {}),
       method: _input.method,
       permission,
       resources: authorizedResources,

--- a/src/gateway/authorization/request-context.ts
+++ b/src/gateway/authorization/request-context.ts
@@ -10,15 +10,70 @@ const gatewayAuthorizationContext = resolveGlobalSingleton<
   AsyncLocalStorage<GatewayAuthorizationContext | undefined>
 >(GATEWAY_AUTHORIZATION_CONTEXT_KEY, () => new AsyncLocalStorage());
 
+const gatewayAuthorizationContextLifetimes = new WeakMap<
+  GatewayAuthorizationContext,
+  { active: boolean }
+>();
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    (typeof value === "object" || typeof value === "function") &&
+    value !== null &&
+    typeof (value as PromiseLike<unknown>).then === "function"
+  );
+}
+
 /** Runs core and plugin handlers under the immutable decision produced by the authorization kernel. */
+export function withGatewayAuthorizationContext<T>(
+  context: GatewayAuthorizationContext | undefined,
+  run: () => Promise<T>,
+): Promise<T>;
+export function withGatewayAuthorizationContext<T>(
+  context: GatewayAuthorizationContext | undefined,
+  run: () => T,
+): T;
 export function withGatewayAuthorizationContext<T>(
   context: GatewayAuthorizationContext | undefined,
   run: () => T,
 ): T {
-  return gatewayAuthorizationContext.run(context, run);
+  const scoped = context ? Object.freeze({ ...context }) : undefined;
+  const lifetime = scoped ? { active: true } : undefined;
+  if (scoped && lifetime) {
+    gatewayAuthorizationContextLifetimes.set(scoped, lifetime);
+  }
+  return gatewayAuthorizationContext.run(scoped, () => {
+    try {
+      const result = run();
+      if (isPromiseLike(result)) {
+        return (async () => {
+          try {
+            return await result;
+          } finally {
+            if (lifetime) {
+              lifetime.active = false;
+            }
+          }
+        })() as T;
+      }
+      if (lifetime) {
+        lifetime.active = false;
+      }
+      return result;
+    } catch (error) {
+      if (lifetime) {
+        lifetime.active = false;
+      }
+      throw error;
+    }
+  });
 }
 
 /** Internal host lookup for future Teams SDK capabilities; plugin-returned objects are not trusted. */
 export function getGatewayAuthorizationContext(): GatewayAuthorizationContext | undefined {
   return gatewayAuthorizationContext.getStore();
+}
+
+/** True only while the host request that created this context is still executing. */
+export function isGatewayAuthorizationContextActive(context: GatewayAuthorizationContext): boolean {
+  return gatewayAuthorizationContextLifetimes.get(context)?.active === true;
 }

--- a/src/gateway/authorization/request-context.ts
+++ b/src/gateway/authorization/request-context.ts
@@ -1,0 +1,24 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
+import type { GatewayAuthorizationContext } from "./contracts.js";
+
+const GATEWAY_AUTHORIZATION_CONTEXT_KEY: unique symbol = Symbol.for(
+  "openclaw.gatewayAuthorizationContext",
+);
+
+const gatewayAuthorizationContext = resolveGlobalSingleton<
+  AsyncLocalStorage<GatewayAuthorizationContext | undefined>
+>(GATEWAY_AUTHORIZATION_CONTEXT_KEY, () => new AsyncLocalStorage());
+
+/** Runs core and plugin handlers under the immutable decision produced by the authorization kernel. */
+export function withGatewayAuthorizationContext<T>(
+  context: GatewayAuthorizationContext | undefined,
+  run: () => T,
+): T {
+  return gatewayAuthorizationContext.run(context, run);
+}
+
+/** Internal host lookup for future Teams SDK capabilities; plugin-returned objects are not trusted. */
+export function getGatewayAuthorizationContext(): GatewayAuthorizationContext | undefined {
+  return gatewayAuthorizationContext.getStore();
+}

--- a/src/gateway/authorization/resource-operations.test.ts
+++ b/src/gateway/authorization/resource-operations.test.ts
@@ -7,7 +7,9 @@ import {
 import type { GatewayResourceRef } from "./contracts.js";
 import { createAuthorizationDelegation, revokeAuthorizationDelegation } from "./delegations.js";
 import {
+  getAuthorizationResourceParent,
   getAuthorizationResourceOwner,
+  listAuthorizationResourceChildren,
   prepareAuthorizationResourceRegistration,
   prepareAuthorizationResourceRetirement,
   replayAuthorizationResourceOperation,
@@ -76,6 +78,111 @@ describe("authorization resource operations", () => {
     expect(getAuthorizationResourceOwner({ domainId: "domain-2", resource, database })).toEqual({
       principalId: secondOwner.id,
     });
+  });
+
+  it("returns only the active resource parent in the requested domain", () => {
+    const database = createDatabase();
+    putAuthorizationPrincipal({ ...firstOwner, database });
+    createIsolationDomain({ id: "domain-1", ownerPrincipalId: firstOwner.id, database });
+    const workspace = {
+      namespace: "workspaces",
+      type: "workspace",
+      id: "workspace-1",
+    } as const;
+    bindAuthorizationResource({
+      domainId: "domain-1",
+      resource: workspace,
+      ownerPrincipalId: firstOwner.id,
+      database,
+    });
+    bindAuthorizationResource({
+      domainId: "domain-1",
+      resource,
+      parent: workspace,
+      ownerPrincipalId: firstOwner.id,
+      database,
+    });
+
+    expect(getAuthorizationResourceParent({ domainId: "domain-1", resource, database })).toEqual(
+      workspace,
+    );
+    expect(
+      getAuthorizationResourceParent({ domainId: "missing-domain", resource, database }),
+    ).toBeUndefined();
+    expect(
+      getAuthorizationResourceParent({ domainId: "domain-1", resource: workspace, database }),
+    ).toBeNull();
+    retireAuthorizationResource({
+      domainId: "domain-1",
+      resource,
+      retiredByPrincipalId: firstOwner.id,
+      database,
+    });
+    expect(
+      getAuthorizationResourceParent({ domainId: "domain-1", resource, database }),
+    ).toBeUndefined();
+  });
+
+  it("lists exact active children and parent-binds retirement through replay", () => {
+    const database = createDatabase();
+    putAuthorizationPrincipal({ ...firstOwner, database });
+    createIsolationDomain({ id: "domain-1", ownerPrincipalId: firstOwner.id, database });
+    const workspace = { namespace: "workspaces", type: "workspace", id: "workspace-1" } as const;
+    const otherWorkspace = { ...workspace, id: "workspace-2" };
+    for (const parent of [workspace, otherWorkspace]) {
+      bindAuthorizationResource({
+        domainId: "domain-1",
+        resource: parent,
+        ownerPrincipalId: firstOwner.id,
+        database,
+      });
+    }
+    bindAuthorizationResource({
+      domainId: "domain-1",
+      resource,
+      parent: workspace,
+      ownerPrincipalId: firstOwner.id,
+      database,
+    });
+
+    expect(
+      listAuthorizationResourceChildren({
+        domainId: "domain-1",
+        parent: workspace,
+        type: "tab",
+        database,
+      }),
+    ).toEqual([resource]);
+    expect(() =>
+      prepareAuthorizationResourceRetirement({
+        operationScope: "plugin:workspaces",
+        idempotencyKey: "retire-wrong-parent",
+        domainId: "domain-1",
+        resource,
+        parent: otherWorkspace,
+        actorPrincipalId: firstOwner.id,
+        database,
+      }),
+    ).toThrow(/parent does not match/i);
+
+    const prepared = prepareAuthorizationResourceRetirement({
+      operationScope: "plugin:workspaces",
+      idempotencyKey: "retire-tab-1",
+      domainId: "domain-1",
+      resource,
+      parent: workspace,
+      actorPrincipalId: firstOwner.id,
+      database,
+    });
+    replayAuthorizationResourceOperation({
+      domainId: "domain-1",
+      operationScope: "plugin:workspaces",
+      operationId: prepared.operationId,
+      database,
+    });
+    expect(
+      listAuthorizationResourceChildren({ domainId: "domain-1", parent: workspace, database }),
+    ).toEqual([]);
   });
 
   it("deduplicates an exact registration intent without binding the resource", () => {

--- a/src/gateway/authorization/resource-operations.test.ts
+++ b/src/gateway/authorization/resource-operations.test.ts
@@ -1,0 +1,794 @@
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
+import type { GatewayResourceRef } from "./contracts.js";
+import { createAuthorizationDelegation, revokeAuthorizationDelegation } from "./delegations.js";
+import {
+  getAuthorizationResourceOwner,
+  prepareAuthorizationResourceRegistration,
+  prepareAuthorizationResourceRetirement,
+  replayAuthorizationResourceOperation,
+} from "./resource-operations.js";
+import { createStateGatewayAuthorizationRuntime } from "./state-provider.js";
+import {
+  bindAuthorizationResource,
+  addIsolationDomainMember,
+  createIsolationDomain,
+  putAuthorizationPrincipal,
+  removeIsolationDomainMember,
+  retireAuthorizationResource,
+} from "./state-store.js";
+
+const tempDirs: string[] = [];
+const resource: GatewayResourceRef = {
+  namespace: "workspaces",
+  type: "tab",
+  id: "tab-shared-id",
+};
+const firstOwner = {
+  id: "principal-owner-1",
+  principal: { issuer: "trusted-proxy", subject: "owner-1@example.com", kind: "human" },
+} as const;
+const secondOwner = {
+  id: "principal-owner-2",
+  principal: { issuer: "trusted-proxy", subject: "owner-2@example.com", kind: "human" },
+} as const;
+const agent = {
+  id: "principal-agent",
+  principal: { issuer: "core", subject: "agent:main", kind: "service" },
+} as const;
+
+function createDatabase() {
+  return { path: `${makeTempDir(tempDirs, "openclaw-rbac-operations-")}/openclaw.sqlite` };
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
+
+afterAll(() => {
+  cleanupTempDirs(tempDirs);
+});
+
+describe("authorization resource operations", () => {
+  it("returns the active owner for the requested domain when opaque IDs collide", () => {
+    const database = createDatabase();
+    for (const [domainId, owner] of [
+      ["domain-1", firstOwner],
+      ["domain-2", secondOwner],
+    ] as const) {
+      putAuthorizationPrincipal({ ...owner, database });
+      createIsolationDomain({ id: domainId, ownerPrincipalId: owner.id, database });
+      bindAuthorizationResource({
+        domainId,
+        resource,
+        ownerPrincipalId: owner.id,
+        database,
+      });
+    }
+
+    expect(getAuthorizationResourceOwner({ domainId: "domain-1", resource, database })).toEqual({
+      principalId: firstOwner.id,
+    });
+    expect(getAuthorizationResourceOwner({ domainId: "domain-2", resource, database })).toEqual({
+      principalId: secondOwner.id,
+    });
+  });
+
+  it("deduplicates an exact registration intent without binding the resource", () => {
+    const database = createDatabase();
+    putAuthorizationPrincipal({ ...firstOwner, database });
+    createIsolationDomain({
+      id: "domain-1",
+      ownerPrincipalId: firstOwner.id,
+      database,
+    });
+    const input = {
+      operationScope: "plugin:workspaces",
+      idempotencyKey: "create-tab-1",
+      domainId: "domain-1",
+      resource,
+      actor: { kind: "human" as const, principalId: firstOwner.id },
+      database,
+    };
+
+    const first = prepareAuthorizationResourceRegistration(input);
+    const duplicate = prepareAuthorizationResourceRegistration(input);
+
+    expect(first).toEqual({ operationId: expect.any(String), state: "pending" });
+    expect(duplicate).toEqual(first);
+    expect(
+      getAuthorizationResourceOwner({ domainId: "domain-1", resource, database }),
+    ).toBeUndefined();
+  });
+
+  it("scopes idempotency keys by isolation domain", () => {
+    const database = createDatabase();
+    for (const [domainId, owner] of [
+      ["domain-1", firstOwner],
+      ["domain-2", secondOwner],
+    ] as const) {
+      putAuthorizationPrincipal({ ...owner, database });
+      createIsolationDomain({ id: domainId, ownerPrincipalId: owner.id, database });
+    }
+
+    const first = prepareAuthorizationResourceRegistration({
+      operationScope: "plugin:workspaces",
+      idempotencyKey: "create-tab-1",
+      domainId: "domain-1",
+      resource,
+      actor: { kind: "human", principalId: firstOwner.id },
+      database,
+    });
+    const second = prepareAuthorizationResourceRegistration({
+      operationScope: "plugin:workspaces",
+      idempotencyKey: "create-tab-1",
+      domainId: "domain-2",
+      resource,
+      actor: { kind: "human", principalId: secondOwner.id },
+      database,
+    });
+
+    expect(second.operationId).not.toBe(first.operationId);
+  });
+
+  it("replays a prepared registration idempotently without a user session", () => {
+    const database = createDatabase();
+    putAuthorizationPrincipal({ ...firstOwner, database });
+    createIsolationDomain({
+      id: "domain-1",
+      ownerPrincipalId: firstOwner.id,
+      database,
+    });
+    const prepared = prepareAuthorizationResourceRegistration({
+      operationScope: "plugin:workspaces",
+      idempotencyKey: "create-tab-1",
+      domainId: "domain-1",
+      resource,
+      actor: { kind: "human", principalId: firstOwner.id },
+      database,
+    });
+
+    const firstReplay = replayAuthorizationResourceOperation({
+      domainId: "domain-1",
+      operationScope: "plugin:workspaces",
+      operationId: prepared.operationId,
+      database,
+    });
+    const duplicateReplay = replayAuthorizationResourceOperation({
+      domainId: "domain-1",
+      operationScope: "plugin:workspaces",
+      operationId: prepared.operationId,
+      database,
+    });
+
+    expect(firstReplay).toEqual({ operationId: prepared.operationId, state: "applied" });
+    expect(duplicateReplay).toEqual(firstReplay);
+    expect(getAuthorizationResourceOwner({ domainId: "domain-1", resource, database })).toEqual({
+      principalId: firstOwner.id,
+    });
+  });
+
+  it("does not replay an operation through a different trusted domain", () => {
+    const database = createDatabase();
+    for (const [domainId, owner] of [
+      ["domain-1", firstOwner],
+      ["domain-2", secondOwner],
+    ] as const) {
+      putAuthorizationPrincipal({ ...owner, database });
+      createIsolationDomain({ id: domainId, ownerPrincipalId: owner.id, database });
+    }
+    const prepared = prepareAuthorizationResourceRegistration({
+      operationScope: "plugin:workspaces",
+      idempotencyKey: "create-tab-1",
+      domainId: "domain-1",
+      resource,
+      actor: { kind: "human", principalId: firstOwner.id },
+      database,
+    });
+
+    expect(() =>
+      replayAuthorizationResourceOperation({
+        domainId: "domain-2",
+        operationScope: "plugin:workspaces",
+        operationId: prepared.operationId,
+        database,
+      }),
+    ).toThrow(/unknown authorization resource operation/i);
+    expect(
+      getAuthorizationResourceOwner({ domainId: "domain-1", resource, database }),
+    ).toBeUndefined();
+  });
+
+  it("rolls back registration when the operation transition fails", () => {
+    const database = createDatabase();
+    putAuthorizationPrincipal({ ...firstOwner, database });
+    createIsolationDomain({
+      id: "domain-1",
+      ownerPrincipalId: firstOwner.id,
+      database,
+    });
+    const prepared = prepareAuthorizationResourceRegistration({
+      operationScope: "plugin:workspaces",
+      idempotencyKey: "create-tab-1",
+      domainId: "domain-1",
+      resource,
+      actor: { kind: "human", principalId: firstOwner.id },
+      database,
+    });
+    const { db } = openOpenClawStateDatabase(database);
+    db.exec(`
+      CREATE TRIGGER test_authorization_operation_transition_failure
+      BEFORE UPDATE OF state ON authorization_resource_operations
+      FOR EACH ROW
+      BEGIN
+        SELECT RAISE(ABORT, 'forced operation transition failure');
+      END;
+    `);
+
+    expect(() =>
+      replayAuthorizationResourceOperation({
+        domainId: "domain-1",
+        operationScope: "plugin:workspaces",
+        operationId: prepared.operationId,
+        database,
+      }),
+    ).toThrow(/forced operation transition failure/i);
+    expect(
+      getAuthorizationResourceOwner({ domainId: "domain-1", resource, database }),
+    ).toBeUndefined();
+  });
+
+  it("assigns a delegated agent creation to its human sponsor without owner inheritance", async () => {
+    const database = createDatabase();
+    putAuthorizationPrincipal({ ...firstOwner, database });
+    putAuthorizationPrincipal({ ...agent, database });
+    createIsolationDomain({
+      id: "domain-1",
+      ownerPrincipalId: firstOwner.id,
+      database,
+    });
+    addIsolationDomainMember({
+      domainId: "domain-1",
+      principalId: agent.id,
+      addedByPrincipalId: firstOwner.id,
+      database,
+    });
+    createAuthorizationDelegation({
+      id: "delegation-1",
+      assignmentId: "assignment-1",
+      domainId: "domain-1",
+      agentPrincipalId: agent.id,
+      sponsorPrincipalId: firstOwner.id,
+      createdByPrincipalId: firstOwner.id,
+      database,
+    });
+
+    const prepared = prepareAuthorizationResourceRegistration({
+      operationScope: "plugin:workspaces",
+      idempotencyKey: "agent-create-tab-1",
+      domainId: "domain-1",
+      resource,
+      actor: {
+        kind: "delegated-agent",
+        principalId: agent.id,
+        sponsorPrincipalId: firstOwner.id,
+        delegationId: " delegation-1 ",
+        assignmentId: " assignment-1 ",
+      },
+      database,
+    });
+    replayAuthorizationResourceOperation({
+      domainId: "domain-1",
+      operationScope: "plugin:workspaces",
+      operationId: prepared.operationId,
+      database,
+    });
+
+    expect(getAuthorizationResourceOwner({ domainId: "domain-1", resource, database })).toEqual({
+      principalId: firstOwner.id,
+    });
+    const runtime = createStateGatewayAuthorizationRuntime({ database });
+    if (runtime.mode !== "isolated") {
+      throw new Error("expected isolated authorization runtime");
+    }
+    await expect(
+      runtime.authorize({
+        principal: agent.principal,
+        domain: { id: "domain-1" },
+        method: "workspaces.tab.update",
+        permission: "workspaces.tab.write",
+        resources: [resource],
+      }),
+    ).resolves.toEqual({ allowed: false, reason: "forbidden" });
+  });
+
+  it("rejects a competing sponsor for an agent already tied to the domain owner", () => {
+    const database = createDatabase();
+    putAuthorizationPrincipal({ ...firstOwner, database });
+    putAuthorizationPrincipal({ ...secondOwner, database });
+    putAuthorizationPrincipal({ ...agent, database });
+    createIsolationDomain({
+      id: "domain-1",
+      ownerPrincipalId: firstOwner.id,
+      database,
+    });
+    addIsolationDomainMember({
+      domainId: "domain-1",
+      principalId: secondOwner.id,
+      addedByPrincipalId: firstOwner.id,
+      database,
+    });
+    addIsolationDomainMember({
+      domainId: "domain-1",
+      principalId: agent.id,
+      addedByPrincipalId: firstOwner.id,
+      database,
+    });
+    createAuthorizationDelegation({
+      id: "delegation-owner",
+      assignmentId: "assignment-owner",
+      domainId: "domain-1",
+      agentPrincipalId: agent.id,
+      sponsorPrincipalId: firstOwner.id,
+      createdByPrincipalId: firstOwner.id,
+      database,
+    });
+
+    expect(() =>
+      createAuthorizationDelegation({
+        id: "delegation-member",
+        assignmentId: "assignment-member",
+        domainId: "domain-1",
+        agentPrincipalId: agent.id,
+        sponsorPrincipalId: secondOwner.id,
+        createdByPrincipalId: secondOwner.id,
+        database,
+      }),
+    ).toThrow(/canonical sponsor|domain owner/i);
+  });
+
+  it("rejects replay after the delegated assignment is revoked", () => {
+    const database = createDatabase();
+    putAuthorizationPrincipal({ ...firstOwner, database });
+    putAuthorizationPrincipal({ ...agent, database });
+    createIsolationDomain({
+      id: "domain-1",
+      ownerPrincipalId: firstOwner.id,
+      database,
+    });
+    addIsolationDomainMember({
+      domainId: "domain-1",
+      principalId: agent.id,
+      addedByPrincipalId: firstOwner.id,
+      database,
+    });
+    createAuthorizationDelegation({
+      id: "delegation-1",
+      assignmentId: "assignment-1",
+      domainId: "domain-1",
+      agentPrincipalId: agent.id,
+      sponsorPrincipalId: firstOwner.id,
+      createdByPrincipalId: firstOwner.id,
+      database,
+    });
+    const prepared = prepareAuthorizationResourceRegistration({
+      operationScope: "plugin:workspaces",
+      idempotencyKey: "agent-create-tab-1",
+      domainId: "domain-1",
+      resource,
+      actor: {
+        kind: "delegated-agent",
+        principalId: agent.id,
+        sponsorPrincipalId: firstOwner.id,
+        delegationId: "delegation-1",
+        assignmentId: "assignment-1",
+      },
+      database,
+    });
+
+    revokeAuthorizationDelegation({
+      domainId: "domain-1",
+      delegationId: "delegation-1",
+      revokedByPrincipalId: firstOwner.id,
+      database,
+    });
+
+    expect(() =>
+      replayAuthorizationResourceOperation({
+        domainId: "domain-1",
+        operationScope: "plugin:workspaces",
+        operationId: prepared.operationId,
+        database,
+      }),
+    ).toThrow(/delegation is not active/i);
+    expect(
+      getAuthorizationResourceOwner({ domainId: "domain-1", resource, database }),
+    ).toBeUndefined();
+  });
+
+  it("rejects caller-invented delegation and assignment identifiers", () => {
+    const database = createDatabase();
+    putAuthorizationPrincipal({ ...firstOwner, database });
+    putAuthorizationPrincipal({ ...agent, database });
+    createIsolationDomain({
+      id: "domain-1",
+      ownerPrincipalId: firstOwner.id,
+      database,
+    });
+    addIsolationDomainMember({
+      domainId: "domain-1",
+      principalId: agent.id,
+      addedByPrincipalId: firstOwner.id,
+      database,
+    });
+
+    expect(() =>
+      prepareAuthorizationResourceRegistration({
+        operationScope: "plugin:workspaces",
+        idempotencyKey: "agent-create-tab-1",
+        domainId: "domain-1",
+        resource,
+        actor: {
+          kind: "delegated-agent",
+          principalId: agent.id,
+          sponsorPrincipalId: firstOwner.id,
+          delegationId: "invented-delegation",
+          assignmentId: "invented-assignment",
+        },
+        database,
+      }),
+    ).toThrow(/delegation is not active/i);
+  });
+
+  it("does not resurrect a delegation when a removed agent is re-added", () => {
+    const database = createDatabase();
+    putAuthorizationPrincipal({ ...firstOwner, database });
+    putAuthorizationPrincipal({ ...agent, database });
+    createIsolationDomain({
+      id: "domain-1",
+      ownerPrincipalId: firstOwner.id,
+      database,
+    });
+    addIsolationDomainMember({
+      domainId: "domain-1",
+      principalId: agent.id,
+      addedByPrincipalId: firstOwner.id,
+      database,
+    });
+    createAuthorizationDelegation({
+      id: "delegation-1",
+      assignmentId: "assignment-1",
+      domainId: "domain-1",
+      agentPrincipalId: agent.id,
+      sponsorPrincipalId: firstOwner.id,
+      createdByPrincipalId: firstOwner.id,
+      database,
+    });
+    const prepared = prepareAuthorizationResourceRegistration({
+      operationScope: "plugin:workspaces",
+      idempotencyKey: "agent-create-tab-1",
+      domainId: "domain-1",
+      resource,
+      actor: {
+        kind: "delegated-agent",
+        principalId: agent.id,
+        sponsorPrincipalId: firstOwner.id,
+        delegationId: "delegation-1",
+        assignmentId: "assignment-1",
+      },
+      database,
+    });
+    removeIsolationDomainMember({
+      domainId: "domain-1",
+      principalId: agent.id,
+      removedByPrincipalId: firstOwner.id,
+      database,
+    });
+    addIsolationDomainMember({
+      domainId: "domain-1",
+      principalId: agent.id,
+      addedByPrincipalId: firstOwner.id,
+      database,
+    });
+
+    expect(() =>
+      replayAuthorizationResourceOperation({
+        domainId: "domain-1",
+        operationScope: "plugin:workspaces",
+        operationId: prepared.operationId,
+        database,
+      }),
+    ).toThrow(/delegation is not active/i);
+    expect(
+      getAuthorizationResourceOwner({ domainId: "domain-1", resource, database }),
+    ).toBeUndefined();
+  });
+
+  it("prepares and replays resource retirement without a user session", () => {
+    const database = createDatabase();
+    putAuthorizationPrincipal({ ...firstOwner, database });
+    createIsolationDomain({
+      id: "domain-1",
+      ownerPrincipalId: firstOwner.id,
+      database,
+    });
+    bindAuthorizationResource({
+      domainId: "domain-1",
+      resource,
+      ownerPrincipalId: firstOwner.id,
+      database,
+    });
+
+    const prepared = prepareAuthorizationResourceRetirement({
+      operationScope: "plugin:workspaces",
+      idempotencyKey: "delete-tab-1",
+      domainId: "domain-1",
+      resource,
+      actorPrincipalId: firstOwner.id,
+      database,
+    });
+    expect(getAuthorizationResourceOwner({ domainId: "domain-1", resource, database })).toEqual({
+      principalId: firstOwner.id,
+    });
+
+    expect(
+      replayAuthorizationResourceOperation({
+        domainId: "domain-1",
+        operationScope: "plugin:workspaces",
+        operationId: prepared.operationId,
+        database,
+      }),
+    ).toEqual({ operationId: prepared.operationId, state: "applied" });
+    expect(
+      getAuthorizationResourceOwner({ domainId: "domain-1", resource, database }),
+    ).toBeUndefined();
+  });
+
+  it("rejects raw mutation of a prepared operation payload", () => {
+    const database = createDatabase();
+    putAuthorizationPrincipal({ ...firstOwner, database });
+    putAuthorizationPrincipal({ ...secondOwner, database });
+    createIsolationDomain({
+      id: "domain-1",
+      ownerPrincipalId: firstOwner.id,
+      database,
+    });
+    addIsolationDomainMember({
+      domainId: "domain-1",
+      principalId: secondOwner.id,
+      addedByPrincipalId: firstOwner.id,
+      database,
+    });
+    const prepared = prepareAuthorizationResourceRegistration({
+      operationScope: "plugin:workspaces",
+      idempotencyKey: "create-tab-1",
+      domainId: "domain-1",
+      resource,
+      actor: { kind: "human", principalId: firstOwner.id },
+      database,
+    });
+    const { db } = openOpenClawStateDatabase(database);
+
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE authorization_resource_operations
+           SET owner_principal_id = ?
+           WHERE operation_id = ?`,
+        )
+        .run(secondOwner.id, prepared.operationId),
+    ).toThrow(/immutable/i);
+  });
+
+  it("rejects a raw non-delegated registration for a service actor", () => {
+    const database = createDatabase();
+    putAuthorizationPrincipal({ ...firstOwner, database });
+    putAuthorizationPrincipal({ ...agent, database });
+    createIsolationDomain({
+      id: "domain-1",
+      ownerPrincipalId: firstOwner.id,
+      database,
+    });
+    addIsolationDomainMember({
+      domainId: "domain-1",
+      principalId: agent.id,
+      addedByPrincipalId: firstOwner.id,
+      database,
+    });
+    const { db } = openOpenClawStateDatabase(database);
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO authorization_resource_operations (
+             operation_id, operation_scope, idempotency_key, operation_type,
+             domain_id, namespace, resource_type, resource_id,
+             parent_namespace, parent_resource_type, parent_resource_id,
+             actor_principal_id, owner_principal_id, delegation_id, assignment_id,
+             state, created_at, updated_at, applied_at
+           ) VALUES (?, ?, ?, 'register', ?, ?, ?, ?, NULL, NULL, NULL, ?, ?, NULL, NULL,
+                     'pending', ?, ?, NULL)`,
+        )
+        .run(
+          "authop_raw",
+          "plugin:workspaces",
+          "raw-create-tab",
+          "domain-1",
+          resource.namespace,
+          resource.type,
+          resource.id,
+          agent.id,
+          firstOwner.id,
+          1,
+          1,
+        ),
+    ).toThrow(/human actor.*owner|delegation/i);
+  });
+
+  it("rejects inserting a resource operation directly in the applied state", () => {
+    const database = createDatabase();
+    putAuthorizationPrincipal({ ...firstOwner, database });
+    createIsolationDomain({
+      id: "domain-1",
+      ownerPrincipalId: firstOwner.id,
+      database,
+    });
+    const { db } = openOpenClawStateDatabase(database);
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO authorization_resource_operations (
+             operation_id, operation_scope, idempotency_key, operation_type,
+             domain_id, namespace, resource_type, resource_id,
+             parent_namespace, parent_resource_type, parent_resource_id,
+             actor_principal_id, owner_principal_id, delegation_id, assignment_id,
+             state, created_at, updated_at, applied_at
+           ) VALUES (?, ?, ?, 'register', ?, ?, ?, ?, NULL, NULL, NULL, ?, ?, NULL, NULL,
+                     'applied', ?, ?, ?)`,
+        )
+        .run(
+          "authop_forged_applied",
+          "plugin:workspaces",
+          "forged-applied-tab",
+          "domain-1",
+          resource.namespace,
+          resource.type,
+          resource.id,
+          firstOwner.id,
+          firstOwner.id,
+          1,
+          1,
+          1,
+        ),
+    ).toThrow(/pending/i);
+  });
+
+  it("rejects marking registration applied before the resource exists", () => {
+    const database = createDatabase();
+    putAuthorizationPrincipal({ ...firstOwner, database });
+    createIsolationDomain({
+      id: "domain-1",
+      ownerPrincipalId: firstOwner.id,
+      database,
+    });
+    const prepared = prepareAuthorizationResourceRegistration({
+      operationScope: "plugin:workspaces",
+      idempotencyKey: "create-tab-1",
+      domainId: "domain-1",
+      resource,
+      actor: { kind: "human", principalId: firstOwner.id },
+      database,
+    });
+    const { db } = openOpenClawStateDatabase(database);
+
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE authorization_resource_operations
+           SET state = 'applied', applied_at = ?, updated_at = ?
+           WHERE operation_id = ?`,
+        )
+        .run(1, 1, prepared.operationId),
+    ).toThrow(/resource state/i);
+  });
+
+  it("rejects marking registration applied when the persisted parent differs", () => {
+    const database = createDatabase();
+    putAuthorizationPrincipal({ ...firstOwner, database });
+    createIsolationDomain({
+      id: "domain-1",
+      ownerPrincipalId: firstOwner.id,
+      database,
+    });
+    const parentOne = { namespace: "workspaces", type: "workspace", id: "workspace-1" } as const;
+    const parentTwo = { namespace: "workspaces", type: "workspace", id: "workspace-2" } as const;
+    for (const parent of [parentOne, parentTwo]) {
+      bindAuthorizationResource({
+        domainId: "domain-1",
+        resource: parent,
+        ownerPrincipalId: firstOwner.id,
+        database,
+      });
+    }
+    bindAuthorizationResource({
+      domainId: "domain-1",
+      resource,
+      parent: parentTwo,
+      ownerPrincipalId: firstOwner.id,
+      database,
+    });
+    const prepared = prepareAuthorizationResourceRegistration({
+      operationScope: "plugin:workspaces",
+      idempotencyKey: "create-tab-1",
+      domainId: "domain-1",
+      resource,
+      parent: parentOne,
+      actor: { kind: "human", principalId: firstOwner.id },
+      database,
+    });
+    const { db } = openOpenClawStateDatabase(database);
+
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE authorization_resource_operations
+           SET state = 'applied', applied_at = ?, updated_at = ?
+           WHERE operation_id = ?`,
+        )
+        .run(1, 1, prepared.operationId),
+    ).toThrow(/resource state/i);
+  });
+
+  it("rejects marking retirement applied when a different principal retired the resource", () => {
+    const database = createDatabase();
+    putAuthorizationPrincipal({ ...firstOwner, database });
+    putAuthorizationPrincipal({ ...secondOwner, database });
+    createIsolationDomain({
+      id: "domain-1",
+      ownerPrincipalId: firstOwner.id,
+      database,
+    });
+    addIsolationDomainMember({
+      domainId: "domain-1",
+      principalId: secondOwner.id,
+      addedByPrincipalId: firstOwner.id,
+      database,
+    });
+    bindAuthorizationResource({
+      domainId: "domain-1",
+      resource,
+      ownerPrincipalId: secondOwner.id,
+      database,
+    });
+    const prepared = prepareAuthorizationResourceRetirement({
+      operationScope: "plugin:workspaces",
+      idempotencyKey: "delete-tab-1",
+      domainId: "domain-1",
+      resource,
+      actorPrincipalId: firstOwner.id,
+      database,
+    });
+    retireAuthorizationResource({
+      domainId: "domain-1",
+      resource,
+      retiredByPrincipalId: secondOwner.id,
+      database,
+    });
+    const { db } = openOpenClawStateDatabase(database);
+
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE authorization_resource_operations
+           SET state = 'applied', applied_at = ?, updated_at = ?
+           WHERE operation_id = ?`,
+        )
+        .run(1, 1, prepared.operationId),
+    ).toThrow(/resource state/i);
+  });
+});

--- a/src/gateway/authorization/resource-operations.ts
+++ b/src/gateway/authorization/resource-operations.ts
@@ -488,6 +488,34 @@ export function replayAuthorizationResourceOperation(input: {
   }, input.database);
 }
 
+/** Host-only replay path: plugin scope is loader-bound and the persisted operation resolves domain. */
+export function replayAuthorizationResourceOperationForHost(input: {
+  database?: OpenClawStateDatabaseOptions;
+  operationScope: string;
+  operationId: string;
+}): PreparedAuthorizationResourceOperation {
+  const operationScope = requiredIdentifier(input.operationScope, "authorization operation scope");
+  const operationId = requiredIdentifier(input.operationId, "authorization operation id");
+  const { db } = openOpenClawStateDatabase(input.database);
+  const operation = executeSqliteQueryTakeFirstSync(
+    db,
+    getNodeSqliteKysely<AuthorizationResourceDatabase>(db)
+      .selectFrom("authorization_resource_operations")
+      .select("domain_id")
+      .where("operation_id", "=", operationId)
+      .where("operation_scope", "=", operationScope),
+  );
+  if (!operation) {
+    throw new Error("unknown authorization resource operation");
+  }
+  return replayAuthorizationResourceOperation({
+    domainId: operation.domain_id,
+    operationScope,
+    operationId,
+    database: input.database,
+  });
+}
+
 export function getAuthorizationResourceOwner(input: {
   database?: OpenClawStateDatabaseOptions;
   domainId: string;

--- a/src/gateway/authorization/resource-operations.ts
+++ b/src/gateway/authorization/resource-operations.ts
@@ -1,0 +1,513 @@
+import { randomUUID } from "node:crypto";
+import type { DatabaseSync } from "node:sqlite";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../../infra/kysely-sync.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabaseOptions,
+} from "../../state/openclaw-state-db.js";
+import type { GatewayResourceRef } from "./contracts.js";
+import { bindAuthorizationResource, retireAuthorizationResource } from "./state-store.js";
+
+type AuthorizationResourceDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  | "authorization_domain_memberships"
+  | "authorization_delegations"
+  | "authorization_principals"
+  | "authorization_resource_operations"
+  | "authorization_resources"
+>;
+
+function requiredIdentifier(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return normalized;
+}
+
+export type AuthorizationResourceOwner = Readonly<{ principalId: string }>;
+
+export type AuthorizationResourceActor =
+  | Readonly<{ kind: "human"; principalId: string }>
+  | Readonly<{
+      kind: "delegated-agent";
+      principalId: string;
+      sponsorPrincipalId: string;
+      delegationId: string;
+      assignmentId: string;
+    }>;
+
+export type PreparedAuthorizationResourceOperation = Readonly<{
+  operationId: string;
+  state: "pending" | "applied";
+}>;
+
+function parseOperationState(value: string): PreparedAuthorizationResourceOperation["state"] {
+  if (value === "pending" || value === "applied") {
+    return value;
+  }
+  throw new Error("authorization resource operation has an invalid state");
+}
+
+function normalizeResource(resource: GatewayResourceRef): GatewayResourceRef {
+  return {
+    namespace: requiredIdentifier(resource.namespace, "resource namespace"),
+    type: requiredIdentifier(resource.type, "resource type"),
+    id: requiredIdentifier(resource.id, "resource id"),
+  };
+}
+
+function sameRegistrationIntent(
+  existing: {
+    operation_type: string;
+    domain_id: string;
+    namespace: string;
+    resource_type: string;
+    resource_id: string;
+    parent_namespace: string | null;
+    parent_resource_type: string | null;
+    parent_resource_id: string | null;
+    actor_principal_id: string;
+    owner_principal_id: string;
+    delegation_id: string | null;
+    assignment_id: string | null;
+  },
+  expected: {
+    domainId: string;
+    resource: GatewayResourceRef;
+    parent?: GatewayResourceRef;
+    actorPrincipalId: string;
+    ownerPrincipalId: string;
+    delegationId?: string;
+    assignmentId?: string;
+  },
+): boolean {
+  return (
+    existing.operation_type === "register" &&
+    existing.domain_id === expected.domainId &&
+    existing.namespace === expected.resource.namespace &&
+    existing.resource_type === expected.resource.type &&
+    existing.resource_id === expected.resource.id &&
+    existing.parent_namespace === (expected.parent?.namespace ?? null) &&
+    existing.parent_resource_type === (expected.parent?.type ?? null) &&
+    existing.parent_resource_id === (expected.parent?.id ?? null) &&
+    existing.actor_principal_id === expected.actorPrincipalId &&
+    existing.owner_principal_id === expected.ownerPrincipalId &&
+    existing.delegation_id === (expected.delegationId ?? null) &&
+    existing.assignment_id === (expected.assignmentId ?? null)
+  );
+}
+
+function hasActiveAuthorizationDelegation(
+  db: DatabaseSync,
+  input: {
+    domainId: string;
+    delegationId: string;
+    assignmentId: string;
+    agentPrincipalId: string;
+    sponsorPrincipalId: string;
+  },
+): boolean {
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    getNodeSqliteKysely<AuthorizationResourceDatabase>(db)
+      .selectFrom("authorization_delegations as delegation")
+      .innerJoin("authorization_domain_memberships as agent_membership", (join) =>
+        join
+          .onRef("agent_membership.domain_id", "=", "delegation.domain_id")
+          .onRef("agent_membership.principal_id", "=", "delegation.agent_principal_id"),
+      )
+      .innerJoin("authorization_domain_memberships as sponsor_membership", (join) =>
+        join
+          .onRef("sponsor_membership.domain_id", "=", "delegation.domain_id")
+          .onRef("sponsor_membership.principal_id", "=", "delegation.sponsor_principal_id"),
+      )
+      .select("delegation.delegation_id")
+      .where("delegation.domain_id", "=", input.domainId)
+      .where("delegation.delegation_id", "=", input.delegationId)
+      .where("delegation.assignment_id", "=", input.assignmentId)
+      .where("delegation.agent_principal_id", "=", input.agentPrincipalId)
+      .where("delegation.sponsor_principal_id", "=", input.sponsorPrincipalId)
+      .where("delegation.state", "=", "active"),
+  );
+  return Boolean(row);
+}
+
+function hasHumanDomainMembership(
+  db: DatabaseSync,
+  domainId: string,
+  principalId: string,
+): boolean {
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    getNodeSqliteKysely<AuthorizationResourceDatabase>(db)
+      .selectFrom("authorization_domain_memberships as membership")
+      .innerJoin(
+        "authorization_principals as principal",
+        "principal.principal_id",
+        "membership.principal_id",
+      )
+      .select("membership.principal_id")
+      .where("membership.domain_id", "=", domainId)
+      .where("membership.principal_id", "=", principalId)
+      .where("principal.kind", "=", "human"),
+  );
+  return Boolean(row);
+}
+
+export function prepareAuthorizationResourceRegistration(input: {
+  database?: OpenClawStateDatabaseOptions;
+  operationScope: string;
+  idempotencyKey: string;
+  domainId: string;
+  resource: GatewayResourceRef;
+  parent?: GatewayResourceRef;
+  actor: AuthorizationResourceActor;
+}): PreparedAuthorizationResourceOperation {
+  const operationScope = requiredIdentifier(input.operationScope, "authorization operation scope");
+  const idempotencyKey = requiredIdentifier(input.idempotencyKey, "authorization idempotency key");
+  const domainId = requiredIdentifier(input.domainId, "isolation domain id");
+  const resource = normalizeResource(input.resource);
+  const parent = input.parent ? normalizeResource(input.parent) : undefined;
+  const actorPrincipalId = requiredIdentifier(input.actor.principalId, "actor principal id");
+  const ownerPrincipalId =
+    input.actor.kind === "human"
+      ? actorPrincipalId
+      : requiredIdentifier(input.actor.sponsorPrincipalId, "sponsor principal id");
+  const delegationId =
+    input.actor.kind === "delegated-agent"
+      ? requiredIdentifier(input.actor.delegationId, "delegation id")
+      : undefined;
+  const assignmentId =
+    input.actor.kind === "delegated-agent"
+      ? requiredIdentifier(input.actor.assignmentId, "assignment id")
+      : undefined;
+  return runOpenClawStateWriteTransaction(({ db }) => {
+    const kysely = getNodeSqliteKysely<AuthorizationResourceDatabase>(db);
+    const existing = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_resource_operations")
+        .selectAll()
+        .where("domain_id", "=", domainId)
+        .where("operation_scope", "=", operationScope)
+        .where("idempotency_key", "=", idempotencyKey),
+    );
+    const expected = {
+      domainId,
+      resource,
+      parent,
+      actorPrincipalId,
+      ownerPrincipalId,
+      delegationId,
+      assignmentId,
+    };
+    if (existing) {
+      if (!sameRegistrationIntent(existing, expected)) {
+        throw new Error("authorization idempotency key is already bound to another operation");
+      }
+      return { operationId: existing.operation_id, state: parseOperationState(existing.state) };
+    }
+    const actor = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_principals as principal")
+        .innerJoin("authorization_domain_memberships as membership", (join) =>
+          join
+            .onRef("membership.principal_id", "=", "principal.principal_id")
+            .on("membership.domain_id", "=", domainId),
+        )
+        .select("principal.kind")
+        .where("principal.principal_id", "=", actorPrincipalId),
+    );
+    const expectedActorKind = input.actor.kind === "human" ? "human" : "service";
+    if (actor?.kind !== expectedActorKind) {
+      throw new Error(`authorization resource actor must be a ${expectedActorKind} domain member`);
+    }
+    const owner = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_principals as principal")
+        .innerJoin("authorization_domain_memberships as membership", (join) =>
+          join
+            .onRef("membership.principal_id", "=", "principal.principal_id")
+            .on("membership.domain_id", "=", domainId),
+        )
+        .select("principal.kind")
+        .where("principal.principal_id", "=", ownerPrincipalId),
+    );
+    if (owner?.kind !== "human") {
+      throw new Error("authorization resource owner must be a human domain member");
+    }
+    if (
+      input.actor.kind === "delegated-agent" &&
+      !hasActiveAuthorizationDelegation(db, {
+        domainId,
+        delegationId: delegationId!,
+        assignmentId: assignmentId!,
+        agentPrincipalId: actorPrincipalId,
+        sponsorPrincipalId: ownerPrincipalId,
+      })
+    ) {
+      throw new Error("authorization delegation is not active for this agent and sponsor");
+    }
+    const operationId = `authop_${randomUUID()}`;
+    const now = Date.now();
+    executeSqliteQuerySync(
+      db,
+      kysely.insertInto("authorization_resource_operations").values({
+        operation_id: operationId,
+        operation_scope: operationScope,
+        idempotency_key: idempotencyKey,
+        operation_type: "register",
+        domain_id: domainId,
+        namespace: resource.namespace,
+        resource_type: resource.type,
+        resource_id: resource.id,
+        parent_namespace: parent?.namespace ?? null,
+        parent_resource_type: parent?.type ?? null,
+        parent_resource_id: parent?.id ?? null,
+        actor_principal_id: actorPrincipalId,
+        owner_principal_id: ownerPrincipalId,
+        delegation_id: delegationId ?? null,
+        assignment_id: assignmentId ?? null,
+        state: "pending",
+        created_at: now,
+        updated_at: now,
+        applied_at: null,
+      }),
+    );
+    return { operationId, state: "pending" };
+  }, input.database);
+}
+
+export function prepareAuthorizationResourceRetirement(input: {
+  database?: OpenClawStateDatabaseOptions;
+  operationScope: string;
+  idempotencyKey: string;
+  domainId: string;
+  resource: GatewayResourceRef;
+  actorPrincipalId: string;
+}): PreparedAuthorizationResourceOperation {
+  const operationScope = requiredIdentifier(input.operationScope, "authorization operation scope");
+  const idempotencyKey = requiredIdentifier(input.idempotencyKey, "authorization idempotency key");
+  const domainId = requiredIdentifier(input.domainId, "isolation domain id");
+  const resource = normalizeResource(input.resource);
+  const actorPrincipalId = requiredIdentifier(input.actorPrincipalId, "actor principal id");
+  return runOpenClawStateWriteTransaction(({ db }) => {
+    const kysely = getNodeSqliteKysely<AuthorizationResourceDatabase>(db);
+    const existing = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_resource_operations")
+        .selectAll()
+        .where("domain_id", "=", domainId)
+        .where("operation_scope", "=", operationScope)
+        .where("idempotency_key", "=", idempotencyKey),
+    );
+    if (existing) {
+      const matches =
+        existing.operation_type === "retire" &&
+        existing.domain_id === domainId &&
+        existing.namespace === resource.namespace &&
+        existing.resource_type === resource.type &&
+        existing.resource_id === resource.id &&
+        existing.actor_principal_id === actorPrincipalId &&
+        existing.parent_namespace === null &&
+        existing.parent_resource_type === null &&
+        existing.parent_resource_id === null &&
+        existing.delegation_id === null &&
+        existing.assignment_id === null;
+      if (!matches) {
+        throw new Error("authorization idempotency key is already bound to another operation");
+      }
+      return { operationId: existing.operation_id, state: parseOperationState(existing.state) };
+    }
+    const owner = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_resources")
+        .select("owner_principal_id")
+        .where("domain_id", "=", domainId)
+        .where("namespace", "=", resource.namespace)
+        .where("resource_type", "=", resource.type)
+        .where("resource_id", "=", resource.id)
+        .where("retired_at", "is", null),
+    );
+    if (!owner) {
+      throw new Error("authorization resource must be active for retirement");
+    }
+    const actor = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_domain_memberships as membership")
+        .innerJoin(
+          "authorization_principals as principal",
+          "principal.principal_id",
+          "membership.principal_id",
+        )
+        .select(["membership.role", "principal.kind"])
+        .where("membership.domain_id", "=", domainId)
+        .where("membership.principal_id", "=", actorPrincipalId),
+    );
+    if (
+      actor?.kind !== "human" ||
+      (actor.role !== "owner" && owner.owner_principal_id !== actorPrincipalId)
+    ) {
+      throw new Error(
+        "authorization resource retirement requires its human resource or domain owner",
+      );
+    }
+    const operationId = `authop_${randomUUID()}`;
+    const now = Date.now();
+    executeSqliteQuerySync(
+      db,
+      kysely.insertInto("authorization_resource_operations").values({
+        operation_id: operationId,
+        operation_scope: operationScope,
+        idempotency_key: idempotencyKey,
+        operation_type: "retire",
+        domain_id: domainId,
+        namespace: resource.namespace,
+        resource_type: resource.type,
+        resource_id: resource.id,
+        parent_namespace: null,
+        parent_resource_type: null,
+        parent_resource_id: null,
+        actor_principal_id: actorPrincipalId,
+        owner_principal_id: owner.owner_principal_id,
+        delegation_id: null,
+        assignment_id: null,
+        state: "pending",
+        created_at: now,
+        updated_at: now,
+        applied_at: null,
+      }),
+    );
+    return { operationId, state: "pending" };
+  }, input.database);
+}
+
+export function replayAuthorizationResourceOperation(input: {
+  database?: OpenClawStateDatabaseOptions;
+  domainId: string;
+  operationScope: string;
+  operationId: string;
+}): PreparedAuthorizationResourceOperation {
+  const operationScope = requiredIdentifier(input.operationScope, "authorization operation scope");
+  const operationId = requiredIdentifier(input.operationId, "authorization operation id");
+  const domainId = requiredIdentifier(input.domainId, "isolation domain id");
+  return runOpenClawStateWriteTransaction(({ db }) => {
+    const kysely = getNodeSqliteKysely<AuthorizationResourceDatabase>(db);
+    const operation = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_resource_operations")
+        .selectAll()
+        .where("domain_id", "=", domainId)
+        .where("operation_id", "=", operationId)
+        .where("operation_scope", "=", operationScope),
+    );
+    if (!operation) {
+      throw new Error("unknown authorization resource operation");
+    }
+    if (operation.state === "applied") {
+      return { operationId, state: "applied" };
+    }
+    if (
+      operation.delegation_id &&
+      operation.assignment_id &&
+      !hasActiveAuthorizationDelegation(db, {
+        domainId: operation.domain_id,
+        delegationId: operation.delegation_id,
+        assignmentId: operation.assignment_id,
+        agentPrincipalId: operation.actor_principal_id,
+        sponsorPrincipalId: operation.owner_principal_id,
+      })
+    ) {
+      throw new Error("authorization delegation is not active for replay");
+    }
+    if (
+      operation.operation_type === "register" &&
+      !operation.delegation_id &&
+      (operation.actor_principal_id !== operation.owner_principal_id ||
+        !hasHumanDomainMembership(db, operation.domain_id, operation.actor_principal_id))
+    ) {
+      throw new Error("authorization registration requires its active human actor-owner");
+    }
+    const resource = {
+      namespace: operation.namespace,
+      type: operation.resource_type,
+      id: operation.resource_id,
+    };
+    if (operation.operation_type === "register") {
+      bindAuthorizationResource({
+        domainId: operation.domain_id,
+        resource,
+        ...(operation.parent_namespace &&
+        operation.parent_resource_type &&
+        operation.parent_resource_id
+          ? {
+              parent: {
+                namespace: operation.parent_namespace,
+                type: operation.parent_resource_type,
+                id: operation.parent_resource_id,
+              },
+            }
+          : {}),
+        ownerPrincipalId: operation.owner_principal_id,
+        database: input.database,
+      });
+    } else if (operation.operation_type === "retire") {
+      retireAuthorizationResource({
+        domainId: operation.domain_id,
+        resource,
+        retiredByPrincipalId: operation.actor_principal_id,
+        database: input.database,
+      });
+    } else {
+      throw new Error("unsupported authorization resource operation");
+    }
+    const now = Date.now();
+    executeSqliteQuerySync(
+      db,
+      kysely
+        .updateTable("authorization_resource_operations")
+        .set({ state: "applied", applied_at: now, updated_at: now })
+        .where("operation_id", "=", operationId)
+        .where("operation_scope", "=", operationScope)
+        .where("state", "=", "pending"),
+    );
+    return { operationId, state: "applied" };
+  }, input.database);
+}
+
+export function getAuthorizationResourceOwner(input: {
+  database?: OpenClawStateDatabaseOptions;
+  domainId: string;
+  resource: GatewayResourceRef;
+}): AuthorizationResourceOwner | undefined {
+  const domainId = requiredIdentifier(input.domainId, "isolation domain id");
+  const namespace = requiredIdentifier(input.resource.namespace, "resource namespace");
+  const type = requiredIdentifier(input.resource.type, "resource type");
+  const id = requiredIdentifier(input.resource.id, "resource id");
+  const { db } = openOpenClawStateDatabase(input.database);
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    getNodeSqliteKysely<AuthorizationResourceDatabase>(db)
+      .selectFrom("authorization_resources")
+      .select("owner_principal_id")
+      .where("domain_id", "=", domainId)
+      .where("namespace", "=", namespace)
+      .where("resource_type", "=", type)
+      .where("resource_id", "=", id)
+      .where("retired_at", "is", null),
+  );
+  return row ? { principalId: row.owner_principal_id } : undefined;
+}

--- a/src/gateway/authorization/resource-operations.ts
+++ b/src/gateway/authorization/resource-operations.ts
@@ -293,12 +293,14 @@ export function prepareAuthorizationResourceRetirement(input: {
   idempotencyKey: string;
   domainId: string;
   resource: GatewayResourceRef;
+  parent?: GatewayResourceRef;
   actorPrincipalId: string;
 }): PreparedAuthorizationResourceOperation {
   const operationScope = requiredIdentifier(input.operationScope, "authorization operation scope");
   const idempotencyKey = requiredIdentifier(input.idempotencyKey, "authorization idempotency key");
   const domainId = requiredIdentifier(input.domainId, "isolation domain id");
   const resource = normalizeResource(input.resource);
+  const parent = input.parent ? normalizeResource(input.parent) : undefined;
   const actorPrincipalId = requiredIdentifier(input.actorPrincipalId, "actor principal id");
   return runOpenClawStateWriteTransaction(({ db }) => {
     const kysely = getNodeSqliteKysely<AuthorizationResourceDatabase>(db);
@@ -319,9 +321,9 @@ export function prepareAuthorizationResourceRetirement(input: {
         existing.resource_type === resource.type &&
         existing.resource_id === resource.id &&
         existing.actor_principal_id === actorPrincipalId &&
-        existing.parent_namespace === null &&
-        existing.parent_resource_type === null &&
-        existing.parent_resource_id === null &&
+        existing.parent_namespace === (parent?.namespace ?? null) &&
+        existing.parent_resource_type === (parent?.type ?? null) &&
+        existing.parent_resource_id === (parent?.id ?? null) &&
         existing.delegation_id === null &&
         existing.assignment_id === null;
       if (!matches) {
@@ -333,7 +335,12 @@ export function prepareAuthorizationResourceRetirement(input: {
       db,
       kysely
         .selectFrom("authorization_resources")
-        .select("owner_principal_id")
+        .select([
+          "owner_principal_id",
+          "parent_namespace",
+          "parent_resource_type",
+          "parent_resource_id",
+        ])
         .where("domain_id", "=", domainId)
         .where("namespace", "=", resource.namespace)
         .where("resource_type", "=", resource.type)
@@ -342,6 +349,14 @@ export function prepareAuthorizationResourceRetirement(input: {
     );
     if (!owner) {
       throw new Error("authorization resource must be active for retirement");
+    }
+    if (
+      parent &&
+      (owner.parent_namespace !== parent.namespace ||
+        owner.parent_resource_type !== parent.type ||
+        owner.parent_resource_id !== parent.id)
+    ) {
+      throw new Error("authorization resource retirement parent does not match");
     }
     const actor = executeSqliteQueryTakeFirstSync(
       db,
@@ -377,9 +392,9 @@ export function prepareAuthorizationResourceRetirement(input: {
         namespace: resource.namespace,
         resource_type: resource.type,
         resource_id: resource.id,
-        parent_namespace: null,
-        parent_resource_type: null,
-        parent_resource_id: null,
+        parent_namespace: parent?.namespace ?? null,
+        parent_resource_type: parent?.type ?? null,
+        parent_resource_id: parent?.id ?? null,
         actor_principal_id: actorPrincipalId,
         owner_principal_id: owner.owner_principal_id,
         delegation_id: null,
@@ -465,6 +480,31 @@ export function replayAuthorizationResourceOperation(input: {
         database: input.database,
       });
     } else if (operation.operation_type === "retire") {
+      if (
+        operation.parent_namespace &&
+        operation.parent_resource_type &&
+        operation.parent_resource_id
+      ) {
+        const current = executeSqliteQueryTakeFirstSync(
+          db,
+          kysely
+            .selectFrom("authorization_resources")
+            .select(["parent_namespace", "parent_resource_type", "parent_resource_id"])
+            .where("domain_id", "=", operation.domain_id)
+            .where("namespace", "=", operation.namespace)
+            .where("resource_type", "=", operation.resource_type)
+            .where("resource_id", "=", operation.resource_id)
+            .where("retired_at", "is", null),
+        );
+        if (
+          !current ||
+          current.parent_namespace !== operation.parent_namespace ||
+          current.parent_resource_type !== operation.parent_resource_type ||
+          current.parent_resource_id !== operation.parent_resource_id
+        ) {
+          throw new Error("authorization resource retirement parent changed before replay");
+        }
+      }
       retireAuthorizationResource({
         domainId: operation.domain_id,
         resource,
@@ -486,6 +526,32 @@ export function replayAuthorizationResourceOperation(input: {
     );
     return { operationId, state: "applied" };
   }, input.database);
+}
+
+export function listAuthorizationResourceChildren(input: {
+  database?: OpenClawStateDatabaseOptions;
+  domainId: string;
+  parent: GatewayResourceRef;
+  type?: string;
+}): readonly GatewayResourceRef[] {
+  const domainId = requiredIdentifier(input.domainId, "isolation domain id");
+  const parent = normalizeResource(input.parent);
+  const type = input.type ? requiredIdentifier(input.type, "resource child type") : undefined;
+  const { db } = openOpenClawStateDatabase(input.database);
+  let query = getNodeSqliteKysely<AuthorizationResourceDatabase>(db)
+    .selectFrom("authorization_resources")
+    .select(["namespace", "resource_type", "resource_id"])
+    .where("domain_id", "=", domainId)
+    .where("parent_namespace", "=", parent.namespace)
+    .where("parent_resource_type", "=", parent.type)
+    .where("parent_resource_id", "=", parent.id)
+    .where("retired_at", "is", null);
+  if (type) {
+    query = query.where("resource_type", "=", type);
+  }
+  return executeSqliteQuerySync(db, query.orderBy("resource_id", "asc")).rows.map((row) =>
+    Object.freeze({ namespace: row.namespace, type: row.resource_type, id: row.resource_id }),
+  );
 }
 
 /** Host-only replay path: plugin scope is loader-bound and the persisted operation resolves domain. */
@@ -538,4 +604,48 @@ export function getAuthorizationResourceOwner(input: {
       .where("retired_at", "is", null),
   );
   return row ? { principalId: row.owner_principal_id } : undefined;
+}
+
+/** Returns the active resource's canonical parent, null for a root, or undefined if unbound. */
+export function getAuthorizationResourceParent(input: {
+  database?: OpenClawStateDatabaseOptions;
+  domainId: string;
+  resource: GatewayResourceRef;
+}): GatewayResourceRef | null | undefined {
+  const domainId = requiredIdentifier(input.domainId, "isolation domain id");
+  const resource = normalizeResource(input.resource);
+  const { db } = openOpenClawStateDatabase(input.database);
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    getNodeSqliteKysely<AuthorizationResourceDatabase>(db)
+      .selectFrom("authorization_resources")
+      .select(["parent_namespace", "parent_resource_type", "parent_resource_id"])
+      .where("domain_id", "=", domainId)
+      .where("namespace", "=", resource.namespace)
+      .where("resource_type", "=", resource.type)
+      .where("resource_id", "=", resource.id)
+      .where("retired_at", "is", null),
+  );
+  if (!row) {
+    return undefined;
+  }
+  if (
+    row.parent_namespace === null &&
+    row.parent_resource_type === null &&
+    row.parent_resource_id === null
+  ) {
+    return null;
+  }
+  if (
+    row.parent_namespace === null ||
+    row.parent_resource_type === null ||
+    row.parent_resource_id === null
+  ) {
+    throw new Error("authorization resource has an invalid partial parent binding");
+  }
+  return Object.freeze({
+    namespace: row.parent_namespace,
+    type: row.parent_resource_type,
+    id: row.parent_resource_id,
+  });
 }

--- a/src/gateway/authorization/state-lifecycle.test.ts
+++ b/src/gateway/authorization/state-lifecycle.test.ts
@@ -492,10 +492,10 @@ describe("authorization state lifecycle", () => {
       db
         .prepare(
           `UPDATE authorization_resources
-           SET retired_at = ?
+           SET retired_at = ?, retired_by_principal_id = ?
            WHERE namespace = ? AND resource_type = ? AND resource_id = ?`,
         )
-        .run(Date.now(), workspace.namespace, workspace.type, workspace.id),
+        .run(Date.now(), owner.id, workspace.namespace, workspace.type, workspace.id),
     ).toThrow(/active child/i);
   });
 
@@ -591,6 +591,99 @@ describe("authorization state lifecycle", () => {
 
     expect(() => openOpenClawStateDatabase(database)).toThrow(
       /noncanonical authorization resource schema/i,
+    );
+  });
+
+  it("replaces the prior retirement trigger when adding retirement provenance", () => {
+    const database = createDatabase();
+    const sqlite = requireNodeSqlite();
+    const legacy = new sqlite.DatabaseSync(database.path);
+    legacy.exec(`
+      CREATE TABLE authorization_resources (
+        namespace TEXT NOT NULL,
+        resource_type TEXT NOT NULL,
+        resource_id TEXT NOT NULL,
+        domain_id TEXT NOT NULL,
+        owner_principal_id TEXT NOT NULL,
+        parent_namespace TEXT,
+        parent_resource_type TEXT,
+        parent_resource_id TEXT,
+        retired_at INTEGER,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        PRIMARY KEY (domain_id, namespace, resource_type, resource_id)
+      );
+      CREATE TRIGGER authorization_resources_retirement_monotonic
+      BEFORE UPDATE OF retired_at ON authorization_resources
+      FOR EACH ROW
+      WHEN OLD.retired_at IS NOT NULL OR NEW.retired_at IS NULL
+      BEGIN
+        SELECT RAISE(ABORT, 'old retirement trigger');
+      END;
+      INSERT INTO authorization_resources (
+        namespace, resource_type, resource_id, domain_id, owner_principal_id,
+        parent_namespace, parent_resource_type, parent_resource_id,
+        retired_at, created_at, updated_at
+      ) VALUES (
+        'workspaces', 'workspace', 'workspace-1', 'domain-1', 'principal-owner',
+        NULL, NULL, NULL, NULL, 1, 1
+      );
+    `);
+    legacy.close();
+
+    const { db } = openOpenClawStateDatabase(database);
+    putAuthorizationPrincipal({ ...owner, database });
+    createIsolationDomain({ id: "domain-1", ownerPrincipalId: owner.id, database });
+    addMember(database, "domain-1", member);
+    db.prepare(
+      `UPDATE authorization_resources
+       SET retired_at = ?, retired_by_principal_id = ?
+       WHERE domain_id = ? AND namespace = ? AND resource_type = ? AND resource_id = ?`,
+    ).run(2, owner.id, "domain-1", "workspaces", "workspace", "workspace-1");
+
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE authorization_resources
+           SET retired_by_principal_id = ?
+           WHERE domain_id = ? AND namespace = ? AND resource_type = ? AND resource_id = ?`,
+        )
+        .run(member.id, "domain-1", "workspaces", "workspace", "workspace-1"),
+    ).toThrow(/retired authorization resources/i);
+  });
+
+  it("fails closed when an upgraded retired resource has no trustworthy provenance", () => {
+    const database = createDatabase();
+    const sqlite = requireNodeSqlite();
+    const legacy = new sqlite.DatabaseSync(database.path);
+    legacy.exec(`
+      CREATE TABLE authorization_resources (
+        namespace TEXT NOT NULL,
+        resource_type TEXT NOT NULL,
+        resource_id TEXT NOT NULL,
+        domain_id TEXT NOT NULL,
+        owner_principal_id TEXT NOT NULL,
+        parent_namespace TEXT,
+        parent_resource_type TEXT,
+        parent_resource_id TEXT,
+        retired_at INTEGER,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        PRIMARY KEY (domain_id, namespace, resource_type, resource_id)
+      );
+      INSERT INTO authorization_resources (
+        namespace, resource_type, resource_id, domain_id, owner_principal_id,
+        parent_namespace, parent_resource_type, parent_resource_id,
+        retired_at, created_at, updated_at
+      ) VALUES (
+        'workspaces', 'workspace', 'workspace-1', 'domain-1', 'principal-owner',
+        NULL, NULL, NULL, 2, 1, 2
+      );
+    `);
+    legacy.close();
+
+    expect(() => openOpenClawStateDatabase(database)).toThrow(
+      /noncanonical authorization retirement provenance/i,
     );
   });
 });

--- a/src/gateway/authorization/state-lifecycle.test.ts
+++ b/src/gateway/authorization/state-lifecycle.test.ts
@@ -5,7 +5,7 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
-import type { GatewayResourceRef } from "./contracts.js";
+import type { GatewayAuthorizationRequest, GatewayResourceRef } from "./contracts.js";
 import { createStateGatewayAuthorizationRuntime } from "./state-provider.js";
 import {
   addIsolationDomainMember,
@@ -85,12 +85,13 @@ function addMember(
   });
 }
 
-function isolatedAuthorize(database: ReturnType<typeof createDatabase>) {
+function isolatedAuthorize(database: ReturnType<typeof createDatabase>, domainId = "domain-1") {
   const runtime = createStateGatewayAuthorizationRuntime({ database });
   if (runtime.mode !== "isolated") {
     throw new Error("expected isolated authorization runtime");
   }
-  return runtime.authorize;
+  return (request: Omit<GatewayAuthorizationRequest, "domain">) =>
+    runtime.authorize({ ...request, domain: { id: domainId } });
 }
 
 afterEach(() => {
@@ -515,7 +516,7 @@ describe("authorization state lifecycle", () => {
     ).toThrow(/human/i);
   });
 
-  it("upgrades the prior resource table additively and installs lifecycle guards", () => {
+  it("upgrades a domain-scoped resource table missing lifecycle columns", () => {
     const database = createDatabase();
     const sqlite = requireNodeSqlite();
     const legacy = new sqlite.DatabaseSync(database.path);
@@ -527,8 +528,7 @@ describe("authorization state lifecycle", () => {
         domain_id TEXT NOT NULL,
         owner_principal_id TEXT NOT NULL,
         created_at INTEGER NOT NULL,
-        PRIMARY KEY (namespace, resource_type, resource_id),
-        UNIQUE (domain_id, namespace, resource_type, resource_id)
+        PRIMARY KEY (domain_id, namespace, resource_type, resource_id)
       );
     `);
     legacy
@@ -570,5 +570,27 @@ describe("authorization state lifecycle", () => {
         )
         .run(workspace.namespace, workspace.type, workspace.id),
     ).toThrow(/retire|delete/i);
+  });
+
+  it("rejects the unpublished global resource-key schema instead of silently weakening isolation", () => {
+    const database = createDatabase();
+    const sqlite = requireNodeSqlite();
+    const legacy = new sqlite.DatabaseSync(database.path);
+    legacy.exec(`
+      CREATE TABLE authorization_resources (
+        namespace TEXT NOT NULL,
+        resource_type TEXT NOT NULL,
+        resource_id TEXT NOT NULL,
+        domain_id TEXT NOT NULL,
+        owner_principal_id TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        PRIMARY KEY (namespace, resource_type, resource_id)
+      );
+    `);
+    legacy.close();
+
+    expect(() => openOpenClawStateDatabase(database)).toThrow(
+      /noncanonical authorization resource schema/i,
+    );
   });
 });

--- a/src/gateway/authorization/state-lifecycle.test.ts
+++ b/src/gateway/authorization/state-lifecycle.test.ts
@@ -1,0 +1,574 @@
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
+import { requireNodeSqlite } from "../../infra/node-sqlite.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
+import type { GatewayResourceRef } from "./contracts.js";
+import { createStateGatewayAuthorizationRuntime } from "./state-provider.js";
+import {
+  addIsolationDomainMember,
+  bindAuthorizationResource,
+  createIsolationDomain,
+  grantAuthorizationPermission,
+  listAuthorizedResources,
+  putAuthorizationPrincipal,
+  removeIsolationDomainMember,
+  retireAuthorizationResource,
+  revokeAuthorizationPermission,
+  transferAuthorizationResourceOwner,
+} from "./state-store.js";
+
+const tempDirs: string[] = [];
+
+const owner = {
+  id: "principal-owner",
+  principal: { issuer: "trusted-proxy", subject: "owner@example.com", kind: "human" },
+} as const;
+const member = {
+  id: "principal-member",
+  principal: { issuer: "tailscale", subject: "member@example.com", kind: "human" },
+} as const;
+const recipient = {
+  id: "principal-recipient",
+  principal: { issuer: "trusted-proxy", subject: "recipient@example.com", kind: "human" },
+} as const;
+const service = {
+  id: "principal-service",
+  principal: { issuer: "core", subject: "agent:main", kind: "service" },
+} as const;
+
+const workspace: GatewayResourceRef = {
+  namespace: "workspaces",
+  type: "workspace",
+  id: "workspace-1",
+};
+const tabOne: GatewayResourceRef = {
+  namespace: "workspaces",
+  type: "tab",
+  id: "tab-1",
+};
+const tabTwo: GatewayResourceRef = {
+  namespace: "workspaces",
+  type: "tab",
+  id: "tab-2",
+};
+
+function createDatabase() {
+  return { path: `${makeTempDir(tempDirs, "openclaw-rbac-lifecycle-")}/openclaw.sqlite` };
+}
+
+function seedDomain(database: ReturnType<typeof createDatabase>, domainId = "domain-1") {
+  putAuthorizationPrincipal({ ...owner, database });
+  createIsolationDomain({ id: domainId, ownerPrincipalId: owner.id, database });
+  bindAuthorizationResource({
+    domainId,
+    resource: workspace,
+    ownerPrincipalId: owner.id,
+    database,
+  });
+  return domainId;
+}
+
+function addMember(
+  database: ReturnType<typeof createDatabase>,
+  domainId: string,
+  entry: typeof member | typeof recipient | typeof service,
+) {
+  putAuthorizationPrincipal({ ...entry, database });
+  addIsolationDomainMember({
+    domainId,
+    principalId: entry.id,
+    addedByPrincipalId: owner.id,
+    database,
+  });
+}
+
+function isolatedAuthorize(database: ReturnType<typeof createDatabase>) {
+  const runtime = createStateGatewayAuthorizationRuntime({ database });
+  if (runtime.mode !== "isolated") {
+    throw new Error("expected isolated authorization runtime");
+  }
+  return runtime.authorize;
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
+
+afterAll(() => {
+  cleanupTempDirs(tempDirs);
+});
+
+describe("authorization state lifecycle", () => {
+  it("binds an active parent and rejects missing or cross-domain parents", () => {
+    const database = createDatabase();
+    const domainId = seedDomain(database);
+    bindAuthorizationResource({
+      domainId,
+      resource: tabOne,
+      parent: workspace,
+      ownerPrincipalId: owner.id,
+      database,
+    });
+    const { db } = openOpenClawStateDatabase(database);
+    expect(
+      db
+        .prepare(
+          `SELECT parent_namespace, parent_resource_type, parent_resource_id
+           FROM authorization_resources
+           WHERE namespace = ? AND resource_type = ? AND resource_id = ?`,
+        )
+        .get(tabOne.namespace, tabOne.type, tabOne.id),
+    ).toEqual({
+      parent_namespace: workspace.namespace,
+      parent_resource_type: workspace.type,
+      parent_resource_id: workspace.id,
+    });
+
+    expect(() =>
+      bindAuthorizationResource({
+        domainId,
+        resource: tabTwo,
+        parent: { ...workspace, id: "missing-workspace" },
+        ownerPrincipalId: owner.id,
+        database,
+      }),
+    ).toThrow(/parent/i);
+
+    const otherOwner = {
+      id: "principal-other-owner",
+      principal: { issuer: "trusted-proxy", subject: "other@example.com", kind: "human" },
+    } as const;
+    putAuthorizationPrincipal({ ...otherOwner, database });
+    createIsolationDomain({ id: "domain-2", ownerPrincipalId: otherOwner.id, database });
+    const otherWorkspace = { ...workspace, id: "workspace-2" };
+    bindAuthorizationResource({
+      domainId: "domain-2",
+      resource: otherWorkspace,
+      ownerPrincipalId: otherOwner.id,
+      database,
+    });
+    expect(() =>
+      bindAuthorizationResource({
+        domainId,
+        resource: tabTwo,
+        parent: otherWorkspace,
+        ownerPrincipalId: owner.id,
+        database,
+      }),
+    ).toThrow(/parent/i);
+  });
+
+  it("retires children before parents and makes retired resources unresolvable", async () => {
+    const database = createDatabase();
+    const domainId = seedDomain(database);
+    bindAuthorizationResource({
+      domainId,
+      resource: tabOne,
+      parent: workspace,
+      ownerPrincipalId: owner.id,
+      database,
+    });
+
+    expect(() =>
+      retireAuthorizationResource({
+        domainId,
+        resource: workspace,
+        retiredByPrincipalId: owner.id,
+        database,
+      }),
+    ).toThrow(/active child/i);
+    retireAuthorizationResource({
+      domainId,
+      resource: tabOne,
+      retiredByPrincipalId: owner.id,
+      database,
+    });
+    expect(() =>
+      retireAuthorizationResource({
+        domainId,
+        resource: tabOne,
+        retiredByPrincipalId: owner.id,
+        database,
+      }),
+    ).not.toThrow();
+
+    await expect(
+      isolatedAuthorize(database)({
+        principal: owner.principal,
+        method: "workspaces.get",
+        permission: "workspaces.tab.read",
+        resources: [tabOne],
+      }),
+    ).resolves.toEqual({ allowed: false, reason: "unbound-resource" });
+    retireAuthorizationResource({
+      domainId,
+      resource: workspace,
+      retiredByPrincipalId: owner.id,
+      database,
+    });
+  });
+
+  it("revokes one exact permission idempotently", async () => {
+    const database = createDatabase();
+    const domainId = seedDomain(database);
+    addMember(database, domainId, member);
+    grantAuthorizationPermission({
+      domainId,
+      principalId: member.id,
+      resource: workspace,
+      permission: "workspaces.workspace.read",
+      grantedByPrincipalId: owner.id,
+      database,
+    });
+    revokeAuthorizationPermission({
+      domainId,
+      principalId: member.id,
+      resource: workspace,
+      permission: "workspaces.workspace.read",
+      revokedByPrincipalId: owner.id,
+      database,
+    });
+    expect(() =>
+      revokeAuthorizationPermission({
+        domainId,
+        principalId: member.id,
+        resource: workspace,
+        permission: "workspaces.workspace.read",
+        revokedByPrincipalId: owner.id,
+        database,
+      }),
+    ).not.toThrow();
+
+    await expect(
+      isolatedAuthorize(database)({
+        principal: member.principal,
+        method: "workspaces.get",
+        permission: "workspaces.workspace.read",
+        resources: [workspace],
+      }),
+    ).resolves.toEqual({ allowed: false, reason: "forbidden" });
+  });
+
+  it("transfers exact resource ownership without transferring domain administration", async () => {
+    const database = createDatabase();
+    const domainId = seedDomain(database);
+    addMember(database, domainId, member);
+    addMember(database, domainId, recipient);
+    bindAuthorizationResource({
+      domainId,
+      resource: tabOne,
+      parent: workspace,
+      ownerPrincipalId: member.id,
+      database,
+    });
+    transferAuthorizationResourceOwner({
+      domainId,
+      resource: tabOne,
+      transferredByPrincipalId: member.id,
+      newOwnerPrincipalId: recipient.id,
+      database,
+    });
+
+    await expect(
+      isolatedAuthorize(database)({
+        principal: member.principal,
+        method: "workspaces.share",
+        permission: "workspaces.tab.share",
+        resources: [tabOne],
+      }),
+    ).resolves.toEqual({ allowed: false, reason: "forbidden" });
+    await expect(
+      isolatedAuthorize(database)({
+        principal: recipient.principal,
+        method: "workspaces.share",
+        permission: "workspaces.tab.share",
+        resources: [tabOne],
+      }),
+    ).resolves.toEqual({
+      allowed: true,
+      principalId: recipient.id,
+      domain: { id: domainId },
+    });
+    await expect(
+      isolatedAuthorize(database)({
+        principal: recipient.principal,
+        method: "workspaces.replace",
+        permission: "workspaces.workspace.replace",
+        resources: [workspace],
+      }),
+    ).resolves.toEqual({ allowed: false, reason: "forbidden" });
+  });
+
+  it("blocks member removal while active resources would be orphaned", () => {
+    const database = createDatabase();
+    const domainId = seedDomain(database);
+    addMember(database, domainId, member);
+    addMember(database, domainId, recipient);
+    bindAuthorizationResource({
+      domainId,
+      resource: tabOne,
+      parent: workspace,
+      ownerPrincipalId: member.id,
+      database,
+    });
+    expect(() =>
+      removeIsolationDomainMember({
+        domainId,
+        principalId: member.id,
+        removedByPrincipalId: owner.id,
+        database,
+      }),
+    ).toThrow(/owns active resource/i);
+
+    transferAuthorizationResourceOwner({
+      domainId,
+      resource: tabOne,
+      transferredByPrincipalId: owner.id,
+      newOwnerPrincipalId: recipient.id,
+      database,
+    });
+    removeIsolationDomainMember({
+      domainId,
+      principalId: member.id,
+      removedByPrincipalId: owner.id,
+      database,
+    });
+    const { db } = openOpenClawStateDatabase(database);
+    expect(
+      db
+        .prepare(
+          "SELECT 1 AS present FROM authorization_domain_memberships WHERE domain_id = ? AND principal_id = ?",
+        )
+        .get(domainId, member.id),
+    ).toBeUndefined();
+  });
+
+  it("lists only active exact resources with stable cursor pagination", () => {
+    const database = createDatabase();
+    const domainId = seedDomain(database);
+    addMember(database, domainId, member);
+    addMember(database, domainId, service);
+    bindAuthorizationResource({
+      domainId,
+      resource: tabOne,
+      parent: workspace,
+      ownerPrincipalId: member.id,
+      database,
+    });
+    bindAuthorizationResource({
+      domainId,
+      resource: tabTwo,
+      parent: workspace,
+      ownerPrincipalId: owner.id,
+      database,
+    });
+    for (const principalId of [member.id, service.id]) {
+      grantAuthorizationPermission({
+        domainId,
+        principalId,
+        resource: tabTwo,
+        permission: "workspaces.tab.read",
+        grantedByPrincipalId: owner.id,
+        database,
+      });
+    }
+
+    const first = listAuthorizedResources({
+      domainId,
+      principalId: member.id,
+      namespace: "workspaces",
+      type: "tab",
+      permission: "workspaces.tab.read",
+      limit: 1,
+      database,
+    });
+    expect(first).toEqual({ resources: [tabOne], nextCursor: tabOne.id });
+    expect(
+      listAuthorizedResources({
+        domainId,
+        principalId: member.id,
+        namespace: "workspaces",
+        type: "tab",
+        permission: "workspaces.tab.read",
+        cursor: first.nextCursor,
+        limit: 1,
+        database,
+      }),
+    ).toEqual({ resources: [tabTwo] });
+    expect(
+      listAuthorizedResources({
+        domainId,
+        principalId: service.id,
+        namespace: "workspaces",
+        type: "tab",
+        permission: "workspaces.tab.read",
+        limit: 10,
+        database,
+      }),
+    ).toEqual({ resources: [tabTwo] });
+
+    retireAuthorizationResource({
+      domainId,
+      resource: tabTwo,
+      retiredByPrincipalId: owner.id,
+      database,
+    });
+    expect(
+      listAuthorizedResources({
+        domainId,
+        principalId: member.id,
+        namespace: "workspaces",
+        type: "tab",
+        permission: "workspaces.tab.read",
+        limit: 10,
+        database,
+      }),
+    ).toEqual({ resources: [tabOne] });
+  });
+
+  it("keeps resource identity and domain binding immutable outside the store API", () => {
+    const database = createDatabase();
+    seedDomain(database);
+    const { db } = openOpenClawStateDatabase(database);
+
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE authorization_resources
+           SET resource_id = ?
+           WHERE namespace = ? AND resource_type = ? AND resource_id = ?`,
+        )
+        .run("workspace-moved", workspace.namespace, workspace.type, workspace.id),
+    ).toThrow(/immutable/i);
+    expect(() =>
+      db
+        .prepare(
+          `DELETE FROM authorization_resources
+           WHERE namespace = ? AND resource_type = ? AND resource_id = ?`,
+        )
+        .run(workspace.namespace, workspace.type, workspace.id),
+    ).toThrow(/retire|delete/i);
+  });
+
+  it("does not allow retired resource IDs to be reactivated", () => {
+    const database = createDatabase();
+    const domainId = seedDomain(database);
+    retireAuthorizationResource({
+      domainId,
+      resource: workspace,
+      retiredByPrincipalId: owner.id,
+      database,
+    });
+    const { db } = openOpenClawStateDatabase(database);
+
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE authorization_resources
+           SET retired_at = NULL
+           WHERE namespace = ? AND resource_type = ? AND resource_id = ?`,
+        )
+        .run(workspace.namespace, workspace.type, workspace.id),
+    ).toThrow(/retired|reactivat/i);
+  });
+
+  it("does not allow raw retirement while an active child remains", () => {
+    const database = createDatabase();
+    const domainId = seedDomain(database);
+    bindAuthorizationResource({
+      domainId,
+      resource: tabOne,
+      parent: workspace,
+      ownerPrincipalId: owner.id,
+      database,
+    });
+    const { db } = openOpenClawStateDatabase(database);
+
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE authorization_resources
+           SET retired_at = ?
+           WHERE namespace = ? AND resource_type = ? AND resource_id = ?`,
+        )
+        .run(Date.now(), workspace.namespace, workspace.type, workspace.id),
+    ).toThrow(/active child/i);
+  });
+
+  it("rejects assigning resource ownership to a non-human member outside the store API", () => {
+    const database = createDatabase();
+    const domainId = seedDomain(database);
+    addMember(database, domainId, service);
+    const { db } = openOpenClawStateDatabase(database);
+
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE authorization_resources
+           SET owner_principal_id = ?
+           WHERE namespace = ? AND resource_type = ? AND resource_id = ?`,
+        )
+        .run(service.id, workspace.namespace, workspace.type, workspace.id),
+    ).toThrow(/human/i);
+  });
+
+  it("upgrades the prior resource table additively and installs lifecycle guards", () => {
+    const database = createDatabase();
+    const sqlite = requireNodeSqlite();
+    const legacy = new sqlite.DatabaseSync(database.path);
+    legacy.exec(`
+      CREATE TABLE authorization_resources (
+        namespace TEXT NOT NULL,
+        resource_type TEXT NOT NULL,
+        resource_id TEXT NOT NULL,
+        domain_id TEXT NOT NULL,
+        owner_principal_id TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        PRIMARY KEY (namespace, resource_type, resource_id),
+        UNIQUE (domain_id, namespace, resource_type, resource_id)
+      );
+    `);
+    legacy
+      .prepare(
+        `INSERT INTO authorization_resources (
+           namespace, resource_type, resource_id, domain_id, owner_principal_id, created_at
+         ) VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(workspace.namespace, workspace.type, workspace.id, "domain-1", owner.id, 1);
+    legacy.close();
+
+    const { db } = openOpenClawStateDatabase(database);
+    const columns = db.prepare("PRAGMA table_info(authorization_resources)").all() as Array<{
+      name?: unknown;
+    }>;
+    expect(columns.map((column) => column.name)).toEqual(
+      expect.arrayContaining([
+        "parent_namespace",
+        "parent_resource_type",
+        "parent_resource_id",
+        "retired_at",
+        "updated_at",
+      ]),
+    );
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE authorization_resources
+           SET resource_id = ?
+           WHERE namespace = ? AND resource_type = ? AND resource_id = ?`,
+        )
+        .run("workspace-moved", workspace.namespace, workspace.type, workspace.id),
+    ).toThrow(/immutable/i);
+    expect(() =>
+      db
+        .prepare(
+          `DELETE FROM authorization_resources
+           WHERE namespace = ? AND resource_type = ? AND resource_id = ?`,
+        )
+        .run(workspace.namespace, workspace.type, workspace.id),
+    ).toThrow(/retire|delete/i);
+  });
+});

--- a/src/gateway/authorization/state-provider.test.ts
+++ b/src/gateway/authorization/state-provider.test.ts
@@ -25,6 +25,10 @@ const member = {
   id: "principal-member",
   principal: { issuer: "tailscale", subject: "member@example.com", kind: "human" },
 } as const;
+const recipient = {
+  id: "principal-recipient",
+  principal: { issuer: "trusted-proxy", subject: "recipient@example.com", kind: "human" },
+} as const;
 const workspace: GatewayResourceRef = {
   namespace: "workspaces",
   type: "workspace",
@@ -241,6 +245,111 @@ describe("state-backed gateway authorization", () => {
     });
   });
 
+  it("allows a human resource owner without granting workspace-admin authority", async () => {
+    const database = createDatabase();
+    const domainId = seedDomain({ database, resource: workspace });
+    putAuthorizationPrincipal({ ...member, database });
+    addIsolationDomainMember({
+      domainId,
+      principalId: member.id,
+      addedByPrincipalId: owner.id,
+      database,
+    });
+    bindAuthorizationResource({
+      domainId,
+      resource: tab,
+      ownerPrincipalId: member.id,
+      database,
+    });
+
+    await expect(
+      isolatedAuthorize(database)({
+        principal: member.principal,
+        method: "workspaces.share",
+        permission: "workspaces.tab.share",
+        resources: [tab],
+      }),
+    ).resolves.toEqual({
+      allowed: true,
+      principalId: member.id,
+      domain: { id: domainId },
+    });
+    await expect(
+      isolatedAuthorize(database)({
+        principal: member.principal,
+        method: "workspaces.replace",
+        permission: "workspaces.workspace.replace",
+        resources: [workspace],
+      }),
+    ).resolves.toEqual({ allowed: false, reason: "forbidden" });
+  });
+
+  it("lets a human resource owner grant exact access only on that resource", async () => {
+    const database = createDatabase();
+    const domainId = seedDomain({ database, resource: workspace });
+    for (const entry of [member, recipient]) {
+      putAuthorizationPrincipal({ ...entry, database });
+      addIsolationDomainMember({
+        domainId,
+        principalId: entry.id,
+        addedByPrincipalId: owner.id,
+        database,
+      });
+    }
+    bindAuthorizationResource({
+      domainId,
+      resource: tab,
+      ownerPrincipalId: member.id,
+      database,
+    });
+
+    expect(() =>
+      grantAuthorizationPermission({
+        domainId,
+        principalId: recipient.id,
+        resource: tab,
+        permission: "workspaces.tab.read",
+        grantedByPrincipalId: member.id,
+        database,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      grantAuthorizationPermission({
+        domainId,
+        principalId: recipient.id,
+        resource: workspace,
+        permission: "workspaces.workspace.read",
+        grantedByPrincipalId: member.id,
+        database,
+      }),
+    ).toThrow(/owner/i);
+  });
+
+  it("does not allow a service principal to own a resource", () => {
+    const database = createDatabase();
+    const domainId = seedDomain({ database });
+    const service = {
+      id: "principal-service",
+      principal: { issuer: "core", subject: "agent:main", kind: "service" },
+    } as const;
+    putAuthorizationPrincipal({ ...service, database });
+    addIsolationDomainMember({
+      domainId,
+      principalId: service.id,
+      addedByPrincipalId: owner.id,
+      database,
+    });
+
+    expect(() =>
+      bindAuthorizationResource({
+        domainId,
+        resource: tab,
+        ownerPrincipalId: service.id,
+        database,
+      }),
+    ).toThrow(/human principal/i);
+  });
+
   it("supports one principal holding non-owner membership in multiple domains", async () => {
     const database = createDatabase();
     const firstDomainId = seedDomain({ database, domainId: "domain-1", resource: workspace });
@@ -398,8 +507,8 @@ describe("state-backed gateway authorization", () => {
         .prepare(
           `INSERT INTO authorization_grants (
              domain_id, principal_id, namespace, resource_type, resource_id,
-             permission, granted_by_principal_id, granted_by_role, created_at
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+             permission, granted_by_principal_id, created_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
         )
         .run(
           "domain-1",
@@ -409,7 +518,6 @@ describe("state-backed gateway authorization", () => {
           workspace.id,
           "workspaces.workspace.read",
           owner.id,
-          "owner",
           Date.now(),
         ),
     ).toThrow(/foreign key/i);
@@ -432,8 +540,8 @@ describe("state-backed gateway authorization", () => {
         .prepare(
           `INSERT INTO authorization_grants (
              domain_id, principal_id, namespace, resource_type, resource_id,
-             permission, granted_by_principal_id, granted_by_role, created_at
-           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+             permission, granted_by_principal_id, created_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
         )
         .run(
           domainId,
@@ -443,9 +551,59 @@ describe("state-backed gateway authorization", () => {
           workspace.id,
           "workspaces.workspace.read",
           member.id,
-          "owner",
           Date.now(),
         ),
-    ).toThrow(/constraint|foreign key/i);
+    ).toThrow(/constraint|foreign key|must own/i);
+  });
+
+  it("rejects moving an existing resource-owner grant to a resource they do not own", () => {
+    const database = createDatabase();
+    const domainId = seedDomain({ database, resource: workspace });
+    for (const entry of [member, recipient]) {
+      putAuthorizationPrincipal({ ...entry, database });
+      addIsolationDomainMember({
+        domainId,
+        principalId: entry.id,
+        addedByPrincipalId: owner.id,
+        database,
+      });
+    }
+    bindAuthorizationResource({
+      domainId,
+      resource: tab,
+      ownerPrincipalId: member.id,
+      database,
+    });
+    grantAuthorizationPermission({
+      domainId,
+      principalId: recipient.id,
+      resource: tab,
+      permission: "workspaces.tab.read",
+      grantedByPrincipalId: member.id,
+      database,
+    });
+    const { db } = openOpenClawStateDatabase(database);
+
+    expect(() =>
+      db
+        .prepare(
+          `UPDATE authorization_grants
+           SET namespace = ?, resource_type = ?, resource_id = ?, permission = ?
+           WHERE domain_id = ? AND principal_id = ?
+             AND namespace = ? AND resource_type = ? AND resource_id = ? AND permission = ?`,
+        )
+        .run(
+          workspace.namespace,
+          workspace.type,
+          workspace.id,
+          "workspaces.workspace.read",
+          domainId,
+          recipient.id,
+          tab.namespace,
+          tab.type,
+          tab.id,
+          "workspaces.tab.read",
+        ),
+    ).toThrow(/immutable|must own/i);
   });
 });

--- a/src/gateway/authorization/state-provider.test.ts
+++ b/src/gateway/authorization/state-provider.test.ts
@@ -1,0 +1,451 @@
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
+import { requireNodeSqlite } from "../../infra/node-sqlite.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
+import type { GatewayResourceRef } from "./contracts.js";
+import { createStateGatewayAuthorizationRuntime } from "./state-provider.js";
+import {
+  addIsolationDomainMember,
+  bindAuthorizationResource,
+  createIsolationDomain,
+  grantAuthorizationPermission,
+  putAuthorizationPrincipal,
+} from "./state-store.js";
+
+const tempDirs: string[] = [];
+
+const owner = {
+  id: "principal-owner",
+  principal: { issuer: "trusted-proxy", subject: "owner@example.com", kind: "human" },
+} as const;
+const member = {
+  id: "principal-member",
+  principal: { issuer: "tailscale", subject: "member@example.com", kind: "human" },
+} as const;
+const workspace: GatewayResourceRef = {
+  namespace: "workspaces",
+  type: "workspace",
+  id: "workspace-1",
+};
+const tab: GatewayResourceRef = {
+  namespace: "workspaces",
+  type: "tab",
+  id: "tab-1",
+};
+
+function createDatabase() {
+  return { path: `${makeTempDir(tempDirs, "openclaw-rbac-")}/openclaw.sqlite` };
+}
+
+function isolatedAuthorize(database: ReturnType<typeof createDatabase>) {
+  const runtime = createStateGatewayAuthorizationRuntime({ database });
+  if (runtime.mode !== "isolated") {
+    throw new Error("expected isolated authorization runtime");
+  }
+  return runtime.authorize;
+}
+
+function seedDomain(params: {
+  database: ReturnType<typeof createDatabase>;
+  domainId?: string;
+  resource?: GatewayResourceRef;
+}) {
+  const domainId = params.domainId ?? "domain-1";
+  putAuthorizationPrincipal({ ...owner, database: params.database });
+  createIsolationDomain({ id: domainId, ownerPrincipalId: owner.id, database: params.database });
+  if (params.resource) {
+    bindAuthorizationResource({
+      domainId,
+      resource: params.resource,
+      ownerPrincipalId: owner.id,
+      database: params.database,
+    });
+  }
+  return domainId;
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
+
+afterAll(() => {
+  cleanupTempDirs(tempDirs);
+});
+
+describe("state-backed gateway authorization", () => {
+  it("rejects an unmapped server-issued principal", async () => {
+    const database = createDatabase();
+    seedDomain({ database, resource: workspace });
+
+    await expect(
+      isolatedAuthorize(database)({
+        principal: member.principal,
+        method: "workspaces.get",
+        permission: "workspaces.workspace.read",
+        resources: [workspace],
+      }),
+    ).resolves.toEqual({ allowed: false, reason: "unknown-principal" });
+  });
+
+  it("matches the complete issuer, subject, and kind tuple", async () => {
+    const database = createDatabase();
+    seedDomain({ database, resource: workspace });
+
+    await expect(
+      isolatedAuthorize(database)({
+        principal: { ...owner.principal, kind: "service" },
+        method: "workspaces.get",
+        permission: "workspaces.workspace.read",
+        resources: [workspace],
+      }),
+    ).resolves.toEqual({ allowed: false, reason: "unknown-principal" });
+  });
+
+  it("rejects resources without a server-owned domain binding", async () => {
+    const database = createDatabase();
+    seedDomain({ database });
+
+    await expect(
+      isolatedAuthorize(database)({
+        principal: owner.principal,
+        method: "workspaces.get",
+        permission: "workspaces.workspace.read",
+        resources: [workspace],
+      }),
+    ).resolves.toEqual({ allowed: false, reason: "unbound-resource" });
+  });
+
+  it("rejects requests spanning more than one isolation domain", async () => {
+    const database = createDatabase();
+    seedDomain({ database, domainId: "domain-1", resource: workspace });
+    putAuthorizationPrincipal({ ...member, database });
+    createIsolationDomain({ id: "domain-2", ownerPrincipalId: member.id, database });
+    bindAuthorizationResource({
+      domainId: "domain-2",
+      resource: tab,
+      ownerPrincipalId: member.id,
+      database,
+    });
+
+    await expect(
+      isolatedAuthorize(database)({
+        principal: owner.principal,
+        method: "workspaces.move",
+        permission: "workspaces.tab.write",
+        resources: [workspace, tab],
+      }),
+    ).resolves.toEqual({ allowed: false, reason: "cross-domain" });
+  });
+
+  it("rejects a known principal that is not a member of the resource domain", async () => {
+    const database = createDatabase();
+    seedDomain({ database, resource: workspace });
+    putAuthorizationPrincipal({ ...member, database });
+
+    await expect(
+      isolatedAuthorize(database)({
+        principal: member.principal,
+        method: "workspaces.get",
+        permission: "workspaces.workspace.read",
+        resources: [workspace],
+      }),
+    ).resolves.toEqual({ allowed: false, reason: "cross-domain" });
+  });
+
+  it("requires an exact grant for every resource", async () => {
+    const database = createDatabase();
+    const domainId = seedDomain({ database, resource: workspace });
+    bindAuthorizationResource({
+      domainId,
+      resource: tab,
+      ownerPrincipalId: owner.id,
+      database,
+    });
+    putAuthorizationPrincipal({ ...member, database });
+    addIsolationDomainMember({
+      domainId,
+      principalId: member.id,
+      addedByPrincipalId: owner.id,
+      database,
+    });
+    grantAuthorizationPermission({
+      domainId,
+      principalId: member.id,
+      resource: workspace,
+      permission: "workspaces.workspace.read",
+      grantedByPrincipalId: owner.id,
+      database,
+    });
+
+    await expect(
+      isolatedAuthorize(database)({
+        principal: member.principal,
+        method: "workspaces.get",
+        permission: "workspaces.workspace.read",
+        resources: [workspace, tab],
+      }),
+    ).resolves.toEqual({ allowed: false, reason: "forbidden" });
+  });
+
+  it("allows a member with exact grants and returns the stable principal and domain", async () => {
+    const database = createDatabase();
+    const domainId = seedDomain({ database, resource: workspace });
+    putAuthorizationPrincipal({ ...member, database });
+    addIsolationDomainMember({
+      domainId,
+      principalId: member.id,
+      addedByPrincipalId: owner.id,
+      database,
+    });
+    grantAuthorizationPermission({
+      domainId,
+      principalId: member.id,
+      resource: workspace,
+      permission: "workspaces.workspace.read",
+      grantedByPrincipalId: owner.id,
+      database,
+    });
+
+    await expect(
+      isolatedAuthorize(database)({
+        principal: member.principal,
+        method: "workspaces.get",
+        permission: "workspaces.workspace.read",
+        resources: [workspace, workspace],
+      }),
+    ).resolves.toEqual({
+      allowed: true,
+      principalId: member.id,
+      domain: { id: domainId },
+    });
+  });
+
+  it("allows the sole domain owner without materializing wildcard grants", async () => {
+    const database = createDatabase();
+    const domainId = seedDomain({ database, resource: workspace });
+
+    await expect(
+      isolatedAuthorize(database)({
+        principal: owner.principal,
+        method: "workspaces.share",
+        permission: "workspaces.tab.share",
+        resources: [workspace],
+      }),
+    ).resolves.toEqual({
+      allowed: true,
+      principalId: owner.id,
+      domain: { id: domainId },
+    });
+  });
+
+  it("supports one principal holding non-owner membership in multiple domains", async () => {
+    const database = createDatabase();
+    const firstDomainId = seedDomain({ database, domainId: "domain-1", resource: workspace });
+    const secondOwner = {
+      id: "principal-owner-2",
+      principal: { issuer: "tailscale", subject: "owner-2@example.com", kind: "human" },
+    } as const;
+    putAuthorizationPrincipal({ ...member, database });
+    putAuthorizationPrincipal({ ...secondOwner, database });
+    createIsolationDomain({ id: "domain-2", ownerPrincipalId: secondOwner.id, database });
+    bindAuthorizationResource({
+      domainId: "domain-2",
+      resource: tab,
+      ownerPrincipalId: secondOwner.id,
+      database,
+    });
+    for (const [domainId, resource] of [
+      [firstDomainId, workspace],
+      ["domain-2", tab],
+    ] as const) {
+      addIsolationDomainMember({
+        domainId,
+        principalId: member.id,
+        addedByPrincipalId: domainId === firstDomainId ? owner.id : secondOwner.id,
+        database,
+      });
+      grantAuthorizationPermission({
+        domainId,
+        principalId: member.id,
+        resource,
+        permission: "workspaces.resource.read",
+        grantedByPrincipalId: domainId === firstDomainId ? owner.id : secondOwner.id,
+        database,
+      });
+    }
+
+    await expect(
+      isolatedAuthorize(database)({
+        principal: member.principal,
+        method: "workspaces.get",
+        permission: "workspaces.resource.read",
+        resources: [tab],
+      }),
+    ).resolves.toEqual({
+      allowed: true,
+      principalId: member.id,
+      domain: { id: "domain-2" },
+    });
+  });
+
+  it("refuses to move an existing resource binding across domains", () => {
+    const database = createDatabase();
+    seedDomain({ database, resource: workspace });
+    const secondOwner = {
+      id: "principal-owner-2",
+      principal: { issuer: "trusted-proxy", subject: "owner-2@example.com", kind: "human" },
+    } as const;
+    putAuthorizationPrincipal({ ...secondOwner, database });
+    createIsolationDomain({ id: "domain-2", ownerPrincipalId: secondOwner.id, database });
+
+    expect(() =>
+      bindAuthorizationResource({
+        domainId: "domain-2",
+        resource: workspace,
+        ownerPrincipalId: secondOwner.id,
+        database,
+      }),
+    ).toThrow(/already bound/i);
+  });
+
+  it("does not allow non-human principals to become domain owners", () => {
+    const database = createDatabase();
+    const service = {
+      id: "principal-service",
+      principal: { issuer: "core", subject: "agent:main", kind: "service" },
+    } as const;
+    putAuthorizationPrincipal({ ...service, database });
+
+    expect(() =>
+      createIsolationDomain({
+        id: "domain-1",
+        ownerPrincipalId: service.id,
+        database,
+      }),
+    ).toThrow(/human principal/i);
+  });
+
+  it("does not honor a non-human owner row if state was seeded outside the store API", async () => {
+    const database = createDatabase();
+    const service = {
+      id: "principal-service",
+      principal: { issuer: "core", subject: "agent:main", kind: "service" },
+    } as const;
+    putAuthorizationPrincipal({ ...service, database });
+    const { db } = openOpenClawStateDatabase(database);
+    const now = Date.now();
+    db.prepare(
+      "INSERT INTO authorization_domains (domain_id, created_at, updated_at) VALUES (?, ?, ?)",
+    ).run("domain-1", now, now);
+    db.prepare(
+      `INSERT INTO authorization_domain_memberships (
+         domain_id, principal_id, role, added_by_principal_id, added_by_role, created_at
+       ) VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run("domain-1", service.id, "owner", service.id, "owner", now);
+    db.prepare(
+      `INSERT INTO authorization_resources (
+         namespace, resource_type, resource_id, domain_id, owner_principal_id, created_at
+       ) VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(workspace.namespace, workspace.type, workspace.id, "domain-1", service.id, now);
+
+    await expect(
+      isolatedAuthorize(database)({
+        principal: service.principal,
+        method: "workspaces.share",
+        permission: "workspaces.tab.share",
+        resources: [workspace],
+      }),
+    ).resolves.toEqual({ allowed: false, reason: "forbidden" });
+  });
+
+  it("adds the authorization tables to an existing state database without losing data", () => {
+    const database = createDatabase();
+    const sqlite = requireNodeSqlite();
+    const legacy = new sqlite.DatabaseSync(database.path);
+    legacy.exec("CREATE TABLE preserved_state (value TEXT NOT NULL)");
+    legacy.prepare("INSERT INTO preserved_state (value) VALUES (?)").run("keep-me");
+    legacy.close();
+
+    const opened = openOpenClawStateDatabase(database);
+    expect(
+      opened.db
+        .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = ?")
+        .get("authorization_grants"),
+    ).toEqual({ name: "authorization_grants" });
+    expect(opened.db.prepare("SELECT value FROM preserved_state").get()).toEqual({
+      value: "keep-me",
+    });
+    closeOpenClawStateDatabaseForTest();
+    expect(() => openOpenClawStateDatabase(database)).not.toThrow();
+  });
+
+  it("rejects a grant whose principal and resource belong to different domains", () => {
+    const database = createDatabase();
+    seedDomain({ database, domainId: "domain-1", resource: workspace });
+    const secondOwner = {
+      id: "principal-owner-2",
+      principal: { issuer: "tailscale", subject: "owner-2@example.com", kind: "human" },
+    } as const;
+    putAuthorizationPrincipal({ ...secondOwner, database });
+    createIsolationDomain({ id: "domain-2", ownerPrincipalId: secondOwner.id, database });
+    const { db } = openOpenClawStateDatabase(database);
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO authorization_grants (
+             domain_id, principal_id, namespace, resource_type, resource_id,
+             permission, granted_by_principal_id, granted_by_role, created_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          "domain-1",
+          secondOwner.id,
+          workspace.namespace,
+          workspace.type,
+          workspace.id,
+          "workspaces.workspace.read",
+          owner.id,
+          "owner",
+          Date.now(),
+        ),
+    ).toThrow(/foreign key/i);
+  });
+
+  it("rejects a grant authored by a non-owner member even outside the store API", () => {
+    const database = createDatabase();
+    const domainId = seedDomain({ database, resource: workspace });
+    putAuthorizationPrincipal({ ...member, database });
+    addIsolationDomainMember({
+      domainId,
+      principalId: member.id,
+      addedByPrincipalId: owner.id,
+      database,
+    });
+    const { db } = openOpenClawStateDatabase(database);
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO authorization_grants (
+             domain_id, principal_id, namespace, resource_type, resource_id,
+             permission, granted_by_principal_id, granted_by_role, created_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          domainId,
+          member.id,
+          workspace.namespace,
+          workspace.type,
+          workspace.id,
+          "workspaces.workspace.read",
+          member.id,
+          "owner",
+          Date.now(),
+        ),
+    ).toThrow(/constraint|foreign key/i);
+  });
+});

--- a/src/gateway/authorization/state-provider.test.ts
+++ b/src/gateway/authorization/state-provider.test.ts
@@ -5,7 +5,7 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
-import type { GatewayResourceRef } from "./contracts.js";
+import type { GatewayAuthorizationRequest, GatewayResourceRef } from "./contracts.js";
 import { createStateGatewayAuthorizationRuntime } from "./state-provider.js";
 import {
   addIsolationDomainMember,
@@ -44,12 +44,13 @@ function createDatabase() {
   return { path: `${makeTempDir(tempDirs, "openclaw-rbac-")}/openclaw.sqlite` };
 }
 
-function isolatedAuthorize(database: ReturnType<typeof createDatabase>) {
+function isolatedAuthorize(database: ReturnType<typeof createDatabase>, domainId = "domain-1") {
   const runtime = createStateGatewayAuthorizationRuntime({ database });
   if (runtime.mode !== "isolated") {
     throw new Error("expected isolated authorization runtime");
   }
-  return runtime.authorize;
+  return (request: Omit<GatewayAuthorizationRequest, "domain">) =>
+    runtime.authorize({ ...request, domain: { id: domainId } });
 }
 
 function seedDomain(params: {
@@ -122,7 +123,7 @@ describe("state-backed gateway authorization", () => {
     ).resolves.toEqual({ allowed: false, reason: "unbound-resource" });
   });
 
-  it("rejects requests spanning more than one isolation domain", async () => {
+  it("does not resolve a resource outside the trusted request domain", async () => {
     const database = createDatabase();
     seedDomain({ database, domainId: "domain-1", resource: workspace });
     putAuthorizationPrincipal({ ...member, database });
@@ -141,7 +142,7 @@ describe("state-backed gateway authorization", () => {
         permission: "workspaces.tab.write",
         resources: [workspace, tab],
       }),
-    ).resolves.toEqual({ allowed: false, reason: "cross-domain" });
+    ).resolves.toEqual({ allowed: false, reason: "unbound-resource" });
   });
 
   it("rejects a known principal that is not a member of the resource domain", async () => {
@@ -387,7 +388,10 @@ describe("state-backed gateway authorization", () => {
     }
 
     await expect(
-      isolatedAuthorize(database)({
+      isolatedAuthorize(
+        database,
+        "domain-2",
+      )({
         principal: member.principal,
         method: "workspaces.get",
         permission: "workspaces.resource.read",
@@ -400,7 +404,7 @@ describe("state-backed gateway authorization", () => {
     });
   });
 
-  it("refuses to move an existing resource binding across domains", () => {
+  it("isolates identical opaque resource IDs in different domains", async () => {
     const database = createDatabase();
     seedDomain({ database, resource: workspace });
     const secondOwner = {
@@ -410,14 +414,95 @@ describe("state-backed gateway authorization", () => {
     putAuthorizationPrincipal({ ...secondOwner, database });
     createIsolationDomain({ id: "domain-2", ownerPrincipalId: secondOwner.id, database });
 
-    expect(() =>
-      bindAuthorizationResource({
-        domainId: "domain-2",
-        resource: workspace,
-        ownerPrincipalId: secondOwner.id,
+    bindAuthorizationResource({
+      domainId: "domain-2",
+      resource: workspace,
+      ownerPrincipalId: secondOwner.id,
+      database,
+    });
+
+    await expect(
+      isolatedAuthorize(
         database,
+        "domain-1",
+      )({
+        principal: owner.principal,
+        method: "workspaces.get",
+        permission: "workspaces.workspace.read",
+        resources: [workspace],
       }),
-    ).toThrow(/already bound/i);
+    ).resolves.toMatchObject({
+      allowed: true,
+      principalId: owner.id,
+      domain: { id: "domain-1" },
+    });
+    await expect(
+      isolatedAuthorize(
+        database,
+        "domain-2",
+      )({
+        principal: secondOwner.principal,
+        method: "workspaces.get",
+        permission: "workspaces.workspace.read",
+        resources: [workspace],
+      }),
+    ).resolves.toMatchObject({
+      allowed: true,
+      principalId: secondOwner.id,
+      domain: { id: "domain-2" },
+    });
+  });
+
+  it("does not reuse a same-ID grant across domains for a multi-domain member", async () => {
+    const database = createDatabase();
+    seedDomain({ database, domainId: "domain-1", resource: workspace });
+    const secondOwner = {
+      id: "principal-owner-2",
+      principal: { issuer: "trusted-proxy", subject: "owner-2@example.com", kind: "human" },
+    } as const;
+    putAuthorizationPrincipal({ ...secondOwner, database });
+    putAuthorizationPrincipal({ ...member, database });
+    createIsolationDomain({ id: "domain-2", ownerPrincipalId: secondOwner.id, database });
+    bindAuthorizationResource({
+      domainId: "domain-2",
+      resource: workspace,
+      ownerPrincipalId: secondOwner.id,
+      database,
+    });
+    for (const [domainId, addedByPrincipalId] of [
+      ["domain-1", owner.id],
+      ["domain-2", secondOwner.id],
+    ] as const) {
+      addIsolationDomainMember({
+        domainId,
+        principalId: member.id,
+        addedByPrincipalId,
+        database,
+      });
+    }
+    grantAuthorizationPermission({
+      domainId: "domain-1",
+      principalId: member.id,
+      resource: workspace,
+      permission: "workspaces.workspace.read",
+      grantedByPrincipalId: owner.id,
+      database,
+    });
+
+    const request = {
+      principal: member.principal,
+      method: "workspaces.get",
+      permission: "workspaces.workspace.read",
+      resources: [workspace],
+    } as const;
+    await expect(isolatedAuthorize(database, "domain-1")(request)).resolves.toMatchObject({
+      allowed: true,
+      domain: { id: "domain-1" },
+    });
+    await expect(isolatedAuthorize(database, "domain-2")(request)).resolves.toEqual({
+      allowed: false,
+      reason: "forbidden",
+    });
   });
 
   it("does not allow non-human principals to become domain owners", () => {

--- a/src/gateway/authorization/state-provider.test.ts
+++ b/src/gateway/authorization/state-provider.test.ts
@@ -427,6 +427,7 @@ describe("state-backed gateway authorization", () => {
       principal: { issuer: "core", subject: "agent:main", kind: "service" },
     } as const;
     putAuthorizationPrincipal({ ...service, database });
+    putAuthorizationPrincipal({ ...owner, database });
 
     expect(() =>
       createIsolationDomain({
@@ -444,6 +445,7 @@ describe("state-backed gateway authorization", () => {
       principal: { issuer: "core", subject: "agent:main", kind: "service" },
     } as const;
     putAuthorizationPrincipal({ ...service, database });
+    putAuthorizationPrincipal({ ...owner, database });
     const { db } = openOpenClawStateDatabase(database);
     const now = Date.now();
     db.prepare(
@@ -455,10 +457,16 @@ describe("state-backed gateway authorization", () => {
        ) VALUES (?, ?, ?, ?, ?, ?)`,
     ).run("domain-1", service.id, "owner", service.id, "owner", now);
     db.prepare(
-      `INSERT INTO authorization_resources (
-         namespace, resource_type, resource_id, domain_id, owner_principal_id, created_at
+      `INSERT INTO authorization_domain_memberships (
+         domain_id, principal_id, role, added_by_principal_id, added_by_role, created_at
        ) VALUES (?, ?, ?, ?, ?, ?)`,
-    ).run(workspace.namespace, workspace.type, workspace.id, "domain-1", service.id, now);
+    ).run("domain-1", owner.id, "member", service.id, "owner", now);
+    db.prepare(
+      `INSERT INTO authorization_resources (
+         namespace, resource_type, resource_id, domain_id, owner_principal_id,
+         created_at, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(workspace.namespace, workspace.type, workspace.id, "domain-1", owner.id, now, now);
 
     await expect(
       isolatedAuthorize(database)({

--- a/src/gateway/authorization/state-provider.test.ts
+++ b/src/gateway/authorization/state-provider.test.ts
@@ -6,6 +6,7 @@ import {
   openOpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
 import type { GatewayAuthorizationRequest, GatewayResourceRef } from "./contracts.js";
+import { createAuthorizationDelegation, revokeAuthorizationDelegation } from "./delegations.js";
 import { createStateGatewayAuthorizationRuntime } from "./state-provider.js";
 import {
   addIsolationDomainMember,
@@ -28,6 +29,10 @@ const member = {
 const recipient = {
   id: "principal-recipient",
   principal: { issuer: "trusted-proxy", subject: "recipient@example.com", kind: "human" },
+} as const;
+const agent = {
+  id: "principal-agent",
+  principal: { issuer: "core", subject: "agent:main", kind: "service" },
 } as const;
 const workspace: GatewayResourceRef = {
   namespace: "workspaces",
@@ -81,6 +86,73 @@ afterAll(() => {
 });
 
 describe("state-backed gateway authorization", () => {
+  it("requires and returns the exact active delegation for a service principal", async () => {
+    const database = createDatabase();
+    const domainId = seedDomain({ database, resource: workspace });
+    putAuthorizationPrincipal({ ...agent, database });
+    addIsolationDomainMember({
+      domainId,
+      principalId: agent.id,
+      addedByPrincipalId: owner.id,
+      database,
+    });
+    createAuthorizationDelegation({
+      id: "delegation-1",
+      assignmentId: "assignment-1",
+      domainId,
+      agentPrincipalId: agent.id,
+      sponsorPrincipalId: owner.id,
+      createdByPrincipalId: owner.id,
+      database,
+    });
+    grantAuthorizationPermission({
+      domainId,
+      principalId: agent.id,
+      resource: workspace,
+      permission: "workspaces.workspace.read",
+      grantedByPrincipalId: owner.id,
+      database,
+    });
+    const request = {
+      principal: agent.principal,
+      delegation: { id: "delegation-1", assignmentId: "assignment-1" },
+      method: "workspaces.get",
+      permission: "workspaces.workspace.read",
+      resources: [workspace],
+    } as const;
+
+    await expect(isolatedAuthorize(database)(request)).resolves.toEqual({
+      allowed: true,
+      principalId: agent.id,
+      domain: { id: domainId },
+      delegation: {
+        id: "delegation-1",
+        assignmentId: "assignment-1",
+        sponsorPrincipalId: owner.id,
+      },
+    });
+    await expect(
+      isolatedAuthorize(database)({ ...request, delegation: undefined }),
+    ).resolves.toEqual({ allowed: false, reason: "forbidden" });
+    await expect(
+      isolatedAuthorize(database)({
+        ...request,
+        delegation: { id: "delegation-1", assignmentId: "wrong-assignment" },
+      }),
+    ).resolves.toEqual({ allowed: false, reason: "forbidden" });
+
+    revokeAuthorizationDelegation({
+      domainId,
+      delegationId: "delegation-1",
+      revokedByPrincipalId: owner.id,
+      database,
+    });
+    await expect(isolatedAuthorize(database)(request)).resolves.toEqual({
+      allowed: false,
+      reason: "forbidden",
+    });
+  });
+
   it("rejects an unmapped server-issued principal", async () => {
     const database = createDatabase();
     seedDomain({ database, resource: workspace });

--- a/src/gateway/authorization/state-provider.ts
+++ b/src/gateway/authorization/state-provider.ts
@@ -76,6 +76,7 @@ function authorizeFromState(
         "membership.role as membership_role",
         "grant.permission as granted_permission",
       ])
+      .where("resource.domain_id", "=", request.domain.id)
       .where("resource.retired_at", "is", null)
       .where((eb) =>
         eb.or(
@@ -92,15 +93,6 @@ function authorizeFromState(
   if (bindings.length !== resources.length) {
     return { allowed: false, reason: "unbound-resource" };
   }
-  const domainIds = new Set(bindings.map((binding) => binding.domain_id));
-  if (domainIds.size !== 1) {
-    return { allowed: false, reason: "cross-domain" };
-  }
-  const domainId = [...domainIds][0];
-  if (!domainId) {
-    return { allowed: false, reason: "indeterminate" };
-  }
-
   if (bindings.some((binding) => !binding.membership_role)) {
     return { allowed: false, reason: "cross-domain" };
   }
@@ -118,7 +110,7 @@ function authorizeFromState(
   return {
     allowed: true,
     principalId: principal.principal_id,
-    domain: { id: domainId },
+    domain: request.domain,
   };
 }
 

--- a/src/gateway/authorization/state-provider.ts
+++ b/src/gateway/authorization/state-provider.ts
@@ -72,6 +72,7 @@ function authorizeFromState(
         "resource.resource_type",
         "resource.resource_id",
         "resource.domain_id",
+        "resource.owner_principal_id",
         "membership.role as membership_role",
         "grant.permission as granted_permission",
       ])
@@ -105,7 +106,9 @@ function authorizeFromState(
   if (
     bindings.some(
       (binding) =>
-        (binding.membership_role !== "owner" || request.principal.kind !== "human") &&
+        (request.principal.kind !== "human" ||
+          (binding.membership_role !== "owner" &&
+            binding.owner_principal_id !== principal.principal_id)) &&
         !binding.granted_permission,
     )
   ) {

--- a/src/gateway/authorization/state-provider.ts
+++ b/src/gateway/authorization/state-provider.ts
@@ -76,6 +76,7 @@ function authorizeFromState(
         "membership.role as membership_role",
         "grant.permission as granted_permission",
       ])
+      .where("resource.retired_at", "is", null)
       .where((eb) =>
         eb.or(
           resources.map((resource) =>

--- a/src/gateway/authorization/state-provider.ts
+++ b/src/gateway/authorization/state-provider.ts
@@ -1,0 +1,130 @@
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../../infra/kysely-sync.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  type OpenClawStateDatabaseOptions,
+} from "../../state/openclaw-state-db.js";
+import type {
+  GatewayAuthorizationRequest,
+  GatewayAuthorizationRuntime,
+  GatewayRbacDecision,
+  GatewayResourceRef,
+} from "./contracts.js";
+
+type AuthorizationProviderDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  | "authorization_domain_memberships"
+  | "authorization_grants"
+  | "authorization_principals"
+  | "authorization_resources"
+>;
+
+function resourceKey(resource: GatewayResourceRef): string {
+  return JSON.stringify([resource.namespace, resource.type, resource.id]);
+}
+
+function authorizeFromState(
+  request: GatewayAuthorizationRequest,
+  database?: OpenClawStateDatabaseOptions,
+): GatewayRbacDecision {
+  const db = openOpenClawStateDatabase(database).db;
+  const kysely = getNodeSqliteKysely<AuthorizationProviderDatabase>(db);
+  const principal = executeSqliteQueryTakeFirstSync(
+    db,
+    kysely
+      .selectFrom("authorization_principals")
+      .select("principal_id")
+      .where("issuer", "=", request.principal.issuer)
+      .where("subject", "=", request.principal.subject)
+      .where("kind", "=", request.principal.kind),
+  );
+  if (!principal) {
+    return { allowed: false, reason: "unknown-principal" };
+  }
+
+  const resources = [
+    ...new Map(request.resources.map((resource) => [resourceKey(resource), resource])).values(),
+  ];
+  const bindings = executeSqliteQuerySync(
+    db,
+    kysely
+      .selectFrom("authorization_resources as resource")
+      .leftJoin("authorization_domain_memberships as membership", (join) =>
+        join
+          .onRef("membership.domain_id", "=", "resource.domain_id")
+          .on("membership.principal_id", "=", principal.principal_id),
+      )
+      .leftJoin("authorization_grants as grant", (join) =>
+        join
+          .onRef("grant.domain_id", "=", "resource.domain_id")
+          .onRef("grant.namespace", "=", "resource.namespace")
+          .onRef("grant.resource_type", "=", "resource.resource_type")
+          .onRef("grant.resource_id", "=", "resource.resource_id")
+          .on("grant.principal_id", "=", principal.principal_id)
+          .on("grant.permission", "=", request.permission),
+      )
+      .select([
+        "resource.namespace",
+        "resource.resource_type",
+        "resource.resource_id",
+        "resource.domain_id",
+        "membership.role as membership_role",
+        "grant.permission as granted_permission",
+      ])
+      .where((eb) =>
+        eb.or(
+          resources.map((resource) =>
+            eb.and([
+              eb("resource.namespace", "=", resource.namespace),
+              eb("resource.resource_type", "=", resource.type),
+              eb("resource.resource_id", "=", resource.id),
+            ]),
+          ),
+        ),
+      ),
+  ).rows;
+  if (bindings.length !== resources.length) {
+    return { allowed: false, reason: "unbound-resource" };
+  }
+  const domainIds = new Set(bindings.map((binding) => binding.domain_id));
+  if (domainIds.size !== 1) {
+    return { allowed: false, reason: "cross-domain" };
+  }
+  const domainId = [...domainIds][0];
+  if (!domainId) {
+    return { allowed: false, reason: "indeterminate" };
+  }
+
+  if (bindings.some((binding) => !binding.membership_role)) {
+    return { allowed: false, reason: "cross-domain" };
+  }
+  if (
+    bindings.some(
+      (binding) =>
+        (binding.membership_role !== "owner" || request.principal.kind !== "human") &&
+        !binding.granted_permission,
+    )
+  ) {
+    return { allowed: false, reason: "forbidden" };
+  }
+  return {
+    allowed: true,
+    principalId: principal.principal_id,
+    domain: { id: domainId },
+  };
+}
+
+export function createStateGatewayAuthorizationRuntime(
+  options: {
+    database?: OpenClawStateDatabaseOptions;
+  } = {},
+): GatewayAuthorizationRuntime {
+  return {
+    mode: "isolated",
+    authorize: async (request) => authorizeFromState(request, options.database),
+  };
+}

--- a/src/gateway/authorization/state-provider.ts
+++ b/src/gateway/authorization/state-provider.ts
@@ -18,6 +18,7 @@ import type {
 type AuthorizationProviderDatabase = Pick<
   OpenClawStateKyselyDatabase,
   | "authorization_domain_memberships"
+  | "authorization_delegations"
   | "authorization_grants"
   | "authorization_principals"
   | "authorization_resources"
@@ -44,6 +45,47 @@ function authorizeFromState(
   );
   if (!principal) {
     return { allowed: false, reason: "unknown-principal" };
+  }
+
+  let validatedDelegation:
+    | { id: string; assignmentId: string; sponsorPrincipalId: string }
+    | undefined;
+  if (request.principal.kind === "service") {
+    if (!request.delegation) {
+      return { allowed: false, reason: "forbidden" };
+    }
+    const delegation = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_delegations as delegation")
+        .innerJoin("authorization_domain_memberships as agent_membership", (join) =>
+          join
+            .onRef("agent_membership.domain_id", "=", "delegation.domain_id")
+            .onRef("agent_membership.principal_id", "=", "delegation.agent_principal_id"),
+        )
+        .innerJoin("authorization_domain_memberships as sponsor_membership", (join) =>
+          join
+            .onRef("sponsor_membership.domain_id", "=", "delegation.domain_id")
+            .onRef("sponsor_membership.principal_id", "=", "delegation.sponsor_principal_id"),
+        )
+        .select("delegation.sponsor_principal_id")
+        .where("delegation.domain_id", "=", request.domain.id)
+        .where("delegation.delegation_id", "=", request.delegation.id)
+        .where("delegation.assignment_id", "=", request.delegation.assignmentId)
+        .where("delegation.agent_principal_id", "=", principal.principal_id)
+        .where("delegation.state", "=", "active")
+        .where("sponsor_membership.role", "=", "owner"),
+    );
+    if (!delegation) {
+      return { allowed: false, reason: "forbidden" };
+    }
+    validatedDelegation = {
+      id: request.delegation.id,
+      assignmentId: request.delegation.assignmentId,
+      sponsorPrincipalId: delegation.sponsor_principal_id,
+    };
+  } else if (request.delegation) {
+    return { allowed: false, reason: "forbidden" };
   }
 
   const resources = [
@@ -111,6 +153,7 @@ function authorizeFromState(
     allowed: true,
     principalId: principal.principal_id,
     domain: request.domain,
+    ...(validatedDelegation ? { delegation: validatedDelegation } : {}),
   };
 }
 

--- a/src/gateway/authorization/state-provider.ts
+++ b/src/gateway/authorization/state-provider.ts
@@ -14,10 +14,12 @@ import type {
   GatewayRbacDecision,
   GatewayResourceRef,
 } from "./contracts.js";
+import { GATEWAY_AGENT_SESSION_INVOKE_PERMISSION } from "./contracts.js";
 
 type AuthorizationProviderDatabase = Pick<
   OpenClawStateKyselyDatabase,
   | "authorization_domain_memberships"
+  | "authorization_agent_session_bindings"
   | "authorization_delegations"
   | "authorization_grants"
   | "authorization_principals"
@@ -84,7 +86,49 @@ function authorizeFromState(
       assignmentId: request.delegation.assignmentId,
       sponsorPrincipalId: delegation.sponsor_principal_id,
     };
+    if (request.agentSession) {
+      if (request.agentSession.invokingPrincipal.kind !== "human") {
+        return { allowed: false, reason: "forbidden" };
+      }
+      const binding = executeSqliteQueryTakeFirstSync(
+        db,
+        kysely
+          .selectFrom("authorization_agent_session_bindings")
+          .select("binding_id")
+          .where("domain_id", "=", request.domain.id)
+          .where("binding_id", "=", request.agentSession.id)
+          .where("delegation_id", "=", request.delegation.id)
+          .where("assignment_id", "=", request.delegation.assignmentId)
+          .where("agent_principal_id", "=", principal.principal_id)
+          .where("sponsor_principal_id", "=", delegation.sponsor_principal_id)
+          .where("state", "=", "active"),
+      );
+      if (!binding) {
+        return { allowed: false, reason: "forbidden" };
+      }
+      const invocationDecision = authorizeFromState(
+        {
+          principal: request.agentSession.invokingPrincipal,
+          domain: request.domain,
+          method: "agent",
+          permission: GATEWAY_AGENT_SESSION_INVOKE_PERMISSION,
+          resources: [
+            {
+              namespace: "core",
+              type: "agent-session",
+              id: request.delegation.assignmentId,
+            },
+          ],
+        },
+        database,
+      );
+      if (!invocationDecision.allowed) {
+        return { allowed: false, reason: "forbidden" };
+      }
+    }
   } else if (request.delegation) {
+    return { allowed: false, reason: "forbidden" };
+  } else if (request.agentSession) {
     return { allowed: false, reason: "forbidden" };
   }
 

--- a/src/gateway/authorization/state-store.ts
+++ b/src/gateway/authorization/state-store.ts
@@ -29,6 +29,31 @@ function getAuthorizationKysely(db: DatabaseSync) {
   return getNodeSqliteKysely<AuthorizationDatabase>(db);
 }
 
+/** Resolves the canonical server-owned identity for an authorization principal id. */
+export function getAuthorizationPrincipalById(
+  input: AuthorizationDatabaseInput & { id: string },
+): GatewayPrincipal | undefined {
+  const id = requiredIdentifier(input.id, "principal id");
+  const { db } = openOpenClawStateDatabase(input.database);
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    getAuthorizationKysely(db)
+      .selectFrom("authorization_principals")
+      .select(["issuer", "subject", "kind"])
+      .where("principal_id", "=", id),
+  );
+  if (
+    !row ||
+    (row.kind !== "human" &&
+      row.kind !== "service" &&
+      row.kind !== "device" &&
+      row.kind !== "shared")
+  ) {
+    return undefined;
+  }
+  return Object.freeze({ issuer: row.issuer, subject: row.subject, kind: row.kind });
+}
+
 function requiredIdentifier(value: string, label: string): string {
   const normalized = value.trim();
   if (!normalized) {

--- a/src/gateway/authorization/state-store.ts
+++ b/src/gateway/authorization/state-store.ts
@@ -1,0 +1,300 @@
+import type { DatabaseSync } from "node:sqlite";
+import type { GatewayPrincipal } from "../../../packages/gateway-protocol/src/schema/frames.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../../infra/kysely-sync.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
+import {
+  runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabaseOptions,
+} from "../../state/openclaw-state-db.js";
+import type { GatewayResourceRef } from "./contracts.js";
+
+type AuthorizationDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  | "authorization_domain_memberships"
+  | "authorization_domains"
+  | "authorization_grants"
+  | "authorization_principals"
+  | "authorization_resources"
+>;
+
+type AuthorizationDatabaseInput = { database?: OpenClawStateDatabaseOptions };
+
+function getAuthorizationKysely(db: DatabaseSync) {
+  return getNodeSqliteKysely<AuthorizationDatabase>(db);
+}
+
+function requiredIdentifier(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return normalized;
+}
+
+function requiredPrincipalField(value: string, label: string): string {
+  if (!value.trim()) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function normalizeResource(resource: GatewayResourceRef): GatewayResourceRef {
+  return {
+    namespace: requiredIdentifier(resource.namespace, "resource namespace"),
+    type: requiredIdentifier(resource.type, "resource type"),
+    id: requiredIdentifier(resource.id, "resource id"),
+  };
+}
+
+function requireDomainOwner(db: DatabaseSync, domainId: string, principalId: string): void {
+  const membership = executeSqliteQueryTakeFirstSync(
+    db,
+    getAuthorizationKysely(db)
+      .selectFrom("authorization_domain_memberships")
+      .select("role")
+      .where("domain_id", "=", domainId)
+      .where("principal_id", "=", principalId),
+  );
+  if (membership?.role !== "owner") {
+    throw new Error(`principal ${principalId} is not the owner of isolation domain ${domainId}`);
+  }
+}
+
+export function putAuthorizationPrincipal(
+  input: AuthorizationDatabaseInput & {
+    id: string;
+    principal: GatewayPrincipal;
+  },
+): void {
+  const principalId = requiredIdentifier(input.id, "principal id");
+  const issuer = requiredPrincipalField(input.principal.issuer, "principal issuer");
+  const subject = requiredPrincipalField(input.principal.subject, "principal subject");
+  runOpenClawStateWriteTransaction(({ db }) => {
+    const kysely = getAuthorizationKysely(db);
+    const byId = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_principals")
+        .select(["principal_id", "issuer", "subject", "kind"])
+        .where("principal_id", "=", principalId),
+    );
+    const byIdentity = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_principals")
+        .select(["principal_id", "issuer", "subject", "kind"])
+        .where("issuer", "=", issuer)
+        .where("subject", "=", subject)
+        .where("kind", "=", input.principal.kind),
+    );
+    const existing = byId ?? byIdentity;
+    if (existing) {
+      const matches =
+        existing.principal_id === principalId &&
+        existing.issuer === issuer &&
+        existing.subject === subject &&
+        existing.kind === input.principal.kind;
+      if (!matches || (byId && byIdentity && byId.principal_id !== byIdentity.principal_id)) {
+        throw new Error("authorization principal identity is already mapped differently");
+      }
+      return;
+    }
+    const now = Date.now();
+    executeSqliteQuerySync(
+      db,
+      kysely.insertInto("authorization_principals").values({
+        principal_id: principalId,
+        issuer,
+        subject,
+        kind: input.principal.kind,
+        created_at: now,
+        updated_at: now,
+      }),
+    );
+  }, input.database);
+}
+
+export function createIsolationDomain(
+  input: AuthorizationDatabaseInput & {
+    id: string;
+    ownerPrincipalId: string;
+  },
+): void {
+  const domainId = requiredIdentifier(input.id, "isolation domain id");
+  const ownerPrincipalId = requiredIdentifier(input.ownerPrincipalId, "owner principal id");
+  runOpenClawStateWriteTransaction(({ db }) => {
+    const kysely = getAuthorizationKysely(db);
+    const owner = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_principals")
+        .select("kind")
+        .where("principal_id", "=", ownerPrincipalId),
+    );
+    if (!owner) {
+      throw new Error(`unknown owner principal ${ownerPrincipalId}`);
+    }
+    // V1 never gives devices, services, shared credentials, or agents domain-admin authority.
+    if (owner.kind !== "human") {
+      throw new Error("isolation domain owner must be a human principal");
+    }
+    const existing = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_domains")
+        .select("domain_id")
+        .where("domain_id", "=", domainId),
+    );
+    if (existing) {
+      requireDomainOwner(db, domainId, ownerPrincipalId);
+      return;
+    }
+    const now = Date.now();
+    executeSqliteQuerySync(
+      db,
+      kysely.insertInto("authorization_domains").values({
+        domain_id: domainId,
+        created_at: now,
+        updated_at: now,
+      }),
+    );
+    executeSqliteQuerySync(
+      db,
+      kysely.insertInto("authorization_domain_memberships").values({
+        domain_id: domainId,
+        principal_id: ownerPrincipalId,
+        role: "owner",
+        added_by_principal_id: ownerPrincipalId,
+        added_by_role: "owner",
+        created_at: now,
+      }),
+    );
+  }, input.database);
+}
+
+export function addIsolationDomainMember(
+  input: AuthorizationDatabaseInput & {
+    domainId: string;
+    principalId: string;
+    addedByPrincipalId: string;
+  },
+): void {
+  const domainId = requiredIdentifier(input.domainId, "isolation domain id");
+  const principalId = requiredIdentifier(input.principalId, "member principal id");
+  const addedByPrincipalId = requiredIdentifier(input.addedByPrincipalId, "owner principal id");
+  runOpenClawStateWriteTransaction(({ db }) => {
+    requireDomainOwner(db, domainId, addedByPrincipalId);
+    executeSqliteQuerySync(
+      db,
+      getAuthorizationKysely(db)
+        .insertInto("authorization_domain_memberships")
+        .values({
+          domain_id: domainId,
+          principal_id: principalId,
+          role: "member",
+          added_by_principal_id: addedByPrincipalId,
+          added_by_role: "owner",
+          created_at: Date.now(),
+        })
+        .onConflict((conflict) => conflict.columns(["domain_id", "principal_id"]).doNothing()),
+    );
+  }, input.database);
+}
+
+export function bindAuthorizationResource(
+  input: AuthorizationDatabaseInput & {
+    domainId: string;
+    resource: GatewayResourceRef;
+    ownerPrincipalId: string;
+  },
+): void {
+  const domainId = requiredIdentifier(input.domainId, "isolation domain id");
+  const resource = normalizeResource(input.resource);
+  const ownerPrincipalId = requiredIdentifier(
+    input.ownerPrincipalId,
+    "resource owner principal id",
+  );
+  runOpenClawStateWriteTransaction(({ db }) => {
+    const kysely = getAuthorizationKysely(db);
+    const existing = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_resources")
+        .select(["domain_id", "owner_principal_id"])
+        .where("namespace", "=", resource.namespace)
+        .where("resource_type", "=", resource.type)
+        .where("resource_id", "=", resource.id),
+    );
+    if (existing) {
+      if (existing.domain_id !== domainId || existing.owner_principal_id !== ownerPrincipalId) {
+        throw new Error("authorization resource is already bound differently");
+      }
+      return;
+    }
+    executeSqliteQuerySync(
+      db,
+      kysely.insertInto("authorization_resources").values({
+        namespace: resource.namespace,
+        resource_type: resource.type,
+        resource_id: resource.id,
+        domain_id: domainId,
+        owner_principal_id: ownerPrincipalId,
+        created_at: Date.now(),
+      }),
+    );
+  }, input.database);
+}
+
+export function grantAuthorizationPermission(
+  input: AuthorizationDatabaseInput & {
+    domainId: string;
+    principalId: string;
+    resource: GatewayResourceRef;
+    permission: string;
+    grantedByPrincipalId: string;
+  },
+): void {
+  const domainId = requiredIdentifier(input.domainId, "isolation domain id");
+  const principalId = requiredIdentifier(input.principalId, "grantee principal id");
+  const resource = normalizeResource(input.resource);
+  const permission = requiredIdentifier(input.permission, "authorization permission");
+  const grantedByPrincipalId = requiredIdentifier(
+    input.grantedByPrincipalId,
+    "grantor principal id",
+  );
+  runOpenClawStateWriteTransaction(({ db }) => {
+    requireDomainOwner(db, domainId, grantedByPrincipalId);
+    executeSqliteQuerySync(
+      db,
+      getAuthorizationKysely(db)
+        .insertInto("authorization_grants")
+        .values({
+          domain_id: domainId,
+          principal_id: principalId,
+          namespace: resource.namespace,
+          resource_type: resource.type,
+          resource_id: resource.id,
+          permission,
+          granted_by_principal_id: grantedByPrincipalId,
+          granted_by_role: "owner",
+          created_at: Date.now(),
+        })
+        .onConflict((conflict) =>
+          conflict
+            .columns([
+              "domain_id",
+              "principal_id",
+              "namespace",
+              "resource_type",
+              "resource_id",
+              "permission",
+            ])
+            .doNothing(),
+        ),
+    );
+  }, input.database);
+}

--- a/src/gateway/authorization/state-store.ts
+++ b/src/gateway/authorization/state-store.ts
@@ -343,6 +343,7 @@ export function bindAuthorizationResource(
         parent_resource_type: parent?.type ?? null,
         parent_resource_id: parent?.id ?? null,
         retired_at: null,
+        retired_by_principal_id: null,
         created_at: now,
         updated_at: now,
       }),
@@ -508,7 +509,11 @@ export function retireAuthorizationResource(
       db,
       kysely
         .updateTable("authorization_resources")
-        .set({ retired_at: now, updated_at: now })
+        .set({
+          retired_at: now,
+          retired_by_principal_id: retiredByPrincipalId,
+          updated_at: now,
+        })
         .where("domain_id", "=", domainId)
         .where("namespace", "=", resource.namespace)
         .where("resource_type", "=", resource.type)

--- a/src/gateway/authorization/state-store.ts
+++ b/src/gateway/authorization/state-store.ts
@@ -292,6 +292,7 @@ export function bindAuthorizationResource(
           "parent_resource_id",
           "retired_at",
         ])
+        .where("domain_id", "=", domainId)
         .where("namespace", "=", resource.namespace)
         .where("resource_type", "=", resource.type)
         .where("resource_id", "=", resource.id),
@@ -306,7 +307,6 @@ export function bindAuthorizationResource(
           existing.parent_resource_id === null;
       if (
         existing.retired_at !== null ||
-        existing.domain_id !== domainId ||
         existing.owner_principal_id !== ownerPrincipalId ||
         !sameParent
       ) {
@@ -321,11 +321,12 @@ export function bindAuthorizationResource(
         kysely
           .selectFrom("authorization_resources")
           .select(["domain_id", "retired_at"])
+          .where("domain_id", "=", domainId)
           .where("namespace", "=", parent.namespace)
           .where("resource_type", "=", parent.type)
           .where("resource_id", "=", parent.id),
       );
-      if (parentRow?.domain_id !== domainId || parentRow.retired_at !== null) {
+      if (!parentRow || parentRow.retired_at !== null) {
         throw new Error("authorization resource parent must be active in the same domain");
       }
     }

--- a/src/gateway/authorization/state-store.ts
+++ b/src/gateway/authorization/state-store.ts
@@ -7,6 +7,7 @@ import {
 } from "../../infra/kysely-sync.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
 import {
+  openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "../../state/openclaw-state-db.js";
@@ -54,12 +55,17 @@ function requireDomainOwner(db: DatabaseSync, domainId: string, principalId: str
   const membership = executeSqliteQueryTakeFirstSync(
     db,
     getAuthorizationKysely(db)
-      .selectFrom("authorization_domain_memberships")
-      .select("role")
-      .where("domain_id", "=", domainId)
-      .where("principal_id", "=", principalId),
+      .selectFrom("authorization_domain_memberships as membership")
+      .innerJoin(
+        "authorization_principals as principal",
+        "principal.principal_id",
+        "membership.principal_id",
+      )
+      .select(["membership.role", "principal.kind"])
+      .where("membership.domain_id", "=", domainId)
+      .where("membership.principal_id", "=", principalId),
   );
-  if (membership?.role !== "owner") {
+  if (membership?.role !== "owner" || membership.kind !== "human") {
     throw new Error(`principal ${principalId} is not the owner of isolation domain ${domainId}`);
   }
 }
@@ -92,6 +98,11 @@ function requireDomainOrResourceOwner(params: {
     params.db,
     getAuthorizationKysely(params.db)
       .selectFrom("authorization_domain_memberships as membership")
+      .innerJoin(
+        "authorization_principals as principal",
+        "principal.principal_id",
+        "membership.principal_id",
+      )
       .leftJoin("authorization_resources as resource", (join) =>
         join
           .onRef("resource.domain_id", "=", "membership.domain_id")
@@ -99,11 +110,14 @@ function requireDomainOrResourceOwner(params: {
           .on("resource.resource_type", "=", params.resource.type)
           .on("resource.resource_id", "=", params.resource.id),
       )
-      .select(["membership.role", "resource.owner_principal_id"])
+      .select(["membership.role", "principal.kind", "resource.owner_principal_id"])
       .where("membership.domain_id", "=", params.domainId)
       .where("membership.principal_id", "=", params.principalId),
   );
-  if (ownership?.role !== "owner" && ownership?.owner_principal_id !== params.principalId) {
+  if (
+    ownership?.kind !== "human" ||
+    (ownership.role !== "owner" && ownership.owner_principal_id !== params.principalId)
+  ) {
     throw new Error(`principal ${params.principalId} is not the owner of the domain or resource`);
   }
 }
@@ -253,11 +267,13 @@ export function bindAuthorizationResource(
   input: AuthorizationDatabaseInput & {
     domainId: string;
     resource: GatewayResourceRef;
+    parent?: GatewayResourceRef;
     ownerPrincipalId: string;
   },
 ): void {
   const domainId = requiredIdentifier(input.domainId, "isolation domain id");
   const resource = normalizeResource(input.resource);
+  const parent = input.parent ? normalizeResource(input.parent) : undefined;
   const ownerPrincipalId = requiredIdentifier(
     input.ownerPrincipalId,
     "resource owner principal id",
@@ -268,18 +284,52 @@ export function bindAuthorizationResource(
       db,
       kysely
         .selectFrom("authorization_resources")
-        .select(["domain_id", "owner_principal_id"])
+        .select([
+          "domain_id",
+          "owner_principal_id",
+          "parent_namespace",
+          "parent_resource_type",
+          "parent_resource_id",
+          "retired_at",
+        ])
         .where("namespace", "=", resource.namespace)
         .where("resource_type", "=", resource.type)
         .where("resource_id", "=", resource.id),
     );
     if (existing) {
-      if (existing.domain_id !== domainId || existing.owner_principal_id !== ownerPrincipalId) {
+      const sameParent = parent
+        ? existing.parent_namespace === parent.namespace &&
+          existing.parent_resource_type === parent.type &&
+          existing.parent_resource_id === parent.id
+        : existing.parent_namespace === null &&
+          existing.parent_resource_type === null &&
+          existing.parent_resource_id === null;
+      if (
+        existing.retired_at !== null ||
+        existing.domain_id !== domainId ||
+        existing.owner_principal_id !== ownerPrincipalId ||
+        !sameParent
+      ) {
         throw new Error("authorization resource is already bound differently");
       }
       return;
     }
     requireHumanDomainMember(db, domainId, ownerPrincipalId);
+    if (parent) {
+      const parentRow = executeSqliteQueryTakeFirstSync(
+        db,
+        kysely
+          .selectFrom("authorization_resources")
+          .select(["domain_id", "retired_at"])
+          .where("namespace", "=", parent.namespace)
+          .where("resource_type", "=", parent.type)
+          .where("resource_id", "=", parent.id),
+      );
+      if (parentRow?.domain_id !== domainId || parentRow.retired_at !== null) {
+        throw new Error("authorization resource parent must be active in the same domain");
+      }
+    }
+    const now = Date.now();
     executeSqliteQuerySync(
       db,
       kysely.insertInto("authorization_resources").values({
@@ -288,7 +338,12 @@ export function bindAuthorizationResource(
         resource_id: resource.id,
         domain_id: domainId,
         owner_principal_id: ownerPrincipalId,
-        created_at: Date.now(),
+        parent_namespace: parent?.namespace ?? null,
+        parent_resource_type: parent?.type ?? null,
+        parent_resource_id: parent?.id ?? null,
+        retired_at: null,
+        created_at: now,
+        updated_at: now,
       }),
     );
   }, input.database);
@@ -346,4 +401,335 @@ export function grantAuthorizationPermission(
         ),
     );
   }, input.database);
+}
+
+export function revokeAuthorizationPermission(
+  input: AuthorizationDatabaseInput & {
+    domainId: string;
+    principalId: string;
+    resource: GatewayResourceRef;
+    permission: string;
+    revokedByPrincipalId: string;
+  },
+): void {
+  const domainId = requiredIdentifier(input.domainId, "isolation domain id");
+  const principalId = requiredIdentifier(input.principalId, "grantee principal id");
+  const resource = normalizeResource(input.resource);
+  const permission = requiredIdentifier(input.permission, "authorization permission");
+  const revokedByPrincipalId = requiredIdentifier(
+    input.revokedByPrincipalId,
+    "revoking principal id",
+  );
+  runOpenClawStateWriteTransaction(({ db }) => {
+    requireDomainOrResourceOwner({
+      db,
+      domainId,
+      principalId: revokedByPrincipalId,
+      resource,
+    });
+    executeSqliteQuerySync(
+      db,
+      getAuthorizationKysely(db)
+        .deleteFrom("authorization_grants")
+        .where("domain_id", "=", domainId)
+        .where("principal_id", "=", principalId)
+        .where("namespace", "=", resource.namespace)
+        .where("resource_type", "=", resource.type)
+        .where("resource_id", "=", resource.id)
+        .where("permission", "=", permission),
+    );
+  }, input.database);
+}
+
+export function retireAuthorizationResource(
+  input: AuthorizationDatabaseInput & {
+    domainId: string;
+    resource: GatewayResourceRef;
+    retiredByPrincipalId: string;
+  },
+): void {
+  const domainId = requiredIdentifier(input.domainId, "isolation domain id");
+  const resource = normalizeResource(input.resource);
+  const retiredByPrincipalId = requiredIdentifier(
+    input.retiredByPrincipalId,
+    "retiring principal id",
+  );
+  runOpenClawStateWriteTransaction(({ db }) => {
+    requireDomainOrResourceOwner({
+      db,
+      domainId,
+      principalId: retiredByPrincipalId,
+      resource,
+    });
+    const kysely = getAuthorizationKysely(db);
+    const existing = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_resources")
+        .select("retired_at")
+        .where("domain_id", "=", domainId)
+        .where("namespace", "=", resource.namespace)
+        .where("resource_type", "=", resource.type)
+        .where("resource_id", "=", resource.id),
+    );
+    if (!existing) {
+      throw new Error("unknown authorization resource");
+    }
+    if (existing.retired_at !== null) {
+      return;
+    }
+    const activeChild = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_resources")
+        .select("resource_id")
+        .where("domain_id", "=", domainId)
+        .where("parent_namespace", "=", resource.namespace)
+        .where("parent_resource_type", "=", resource.type)
+        .where("parent_resource_id", "=", resource.id)
+        .where("retired_at", "is", null)
+        .limit(1),
+    );
+    if (activeChild) {
+      throw new Error("authorization resource has an active child resource");
+    }
+    executeSqliteQuerySync(
+      db,
+      kysely
+        .deleteFrom("authorization_grants")
+        .where("domain_id", "=", domainId)
+        .where("namespace", "=", resource.namespace)
+        .where("resource_type", "=", resource.type)
+        .where("resource_id", "=", resource.id),
+    );
+    const now = Date.now();
+    executeSqliteQuerySync(
+      db,
+      kysely
+        .updateTable("authorization_resources")
+        .set({ retired_at: now, updated_at: now })
+        .where("domain_id", "=", domainId)
+        .where("namespace", "=", resource.namespace)
+        .where("resource_type", "=", resource.type)
+        .where("resource_id", "=", resource.id),
+    );
+  }, input.database);
+}
+
+export function transferAuthorizationResourceOwner(
+  input: AuthorizationDatabaseInput & {
+    domainId: string;
+    resource: GatewayResourceRef;
+    transferredByPrincipalId: string;
+    newOwnerPrincipalId: string;
+  },
+): void {
+  const domainId = requiredIdentifier(input.domainId, "isolation domain id");
+  const resource = normalizeResource(input.resource);
+  const transferredByPrincipalId = requiredIdentifier(
+    input.transferredByPrincipalId,
+    "transferring principal id",
+  );
+  const newOwnerPrincipalId = requiredIdentifier(
+    input.newOwnerPrincipalId,
+    "new resource owner principal id",
+  );
+  runOpenClawStateWriteTransaction(({ db }) => {
+    requireDomainOrResourceOwner({
+      db,
+      domainId,
+      principalId: transferredByPrincipalId,
+      resource,
+    });
+    requireHumanDomainMember(db, domainId, newOwnerPrincipalId);
+    const kysely = getAuthorizationKysely(db);
+    const existing = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_resources")
+        .select("retired_at")
+        .where("domain_id", "=", domainId)
+        .where("namespace", "=", resource.namespace)
+        .where("resource_type", "=", resource.type)
+        .where("resource_id", "=", resource.id),
+    );
+    if (!existing || existing.retired_at !== null) {
+      throw new Error("authorization resource must be active for owner transfer");
+    }
+    executeSqliteQuerySync(
+      db,
+      kysely
+        .updateTable("authorization_resources")
+        .set({ owner_principal_id: newOwnerPrincipalId, updated_at: Date.now() })
+        .where("domain_id", "=", domainId)
+        .where("namespace", "=", resource.namespace)
+        .where("resource_type", "=", resource.type)
+        .where("resource_id", "=", resource.id),
+    );
+  }, input.database);
+}
+
+export function removeIsolationDomainMember(
+  input: AuthorizationDatabaseInput & {
+    domainId: string;
+    principalId: string;
+    removedByPrincipalId: string;
+  },
+): void {
+  const domainId = requiredIdentifier(input.domainId, "isolation domain id");
+  const principalId = requiredIdentifier(input.principalId, "member principal id");
+  const removedByPrincipalId = requiredIdentifier(
+    input.removedByPrincipalId,
+    "removing principal id",
+  );
+  runOpenClawStateWriteTransaction(({ db }) => {
+    requireDomainOwner(db, domainId, removedByPrincipalId);
+    const kysely = getAuthorizationKysely(db);
+    const membership = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_domain_memberships")
+        .select("role")
+        .where("domain_id", "=", domainId)
+        .where("principal_id", "=", principalId),
+    );
+    if (!membership) {
+      return;
+    }
+    if (membership.role === "owner") {
+      throw new Error("isolation domain owner cannot be removed");
+    }
+    const activeOwnedResource = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_resources")
+        .select("resource_id")
+        .where("domain_id", "=", domainId)
+        .where("owner_principal_id", "=", principalId)
+        .where("retired_at", "is", null)
+        .limit(1),
+    );
+    if (activeOwnedResource) {
+      throw new Error("member owns active resource; transfer or retire it before removal");
+    }
+    executeSqliteQuerySync(
+      db,
+      kysely
+        .deleteFrom("authorization_grants")
+        .where("domain_id", "=", domainId)
+        .where((eb) =>
+          eb.or([
+            eb("principal_id", "=", principalId),
+            eb("granted_by_principal_id", "=", principalId),
+          ]),
+        ),
+    );
+    executeSqliteQuerySync(
+      db,
+      kysely
+        .updateTable("authorization_resources")
+        .set({ owner_principal_id: removedByPrincipalId, updated_at: Date.now() })
+        .where("domain_id", "=", domainId)
+        .where("owner_principal_id", "=", principalId)
+        .where("retired_at", "is not", null),
+    );
+    executeSqliteQuerySync(
+      db,
+      kysely
+        .deleteFrom("authorization_domain_memberships")
+        .where("domain_id", "=", domainId)
+        .where("principal_id", "=", principalId),
+    );
+  }, input.database);
+}
+
+export type AuthorizedResourcePage = Readonly<{
+  resources: readonly GatewayResourceRef[];
+  nextCursor?: string;
+}>;
+
+export function listAuthorizedResources(
+  input: AuthorizationDatabaseInput & {
+    domainId: string;
+    principalId: string;
+    namespace: string;
+    type: string;
+    permission: string;
+    cursor?: string;
+    limit: number;
+  },
+): AuthorizedResourcePage {
+  const domainId = requiredIdentifier(input.domainId, "isolation domain id");
+  const principalId = requiredIdentifier(input.principalId, "principal id");
+  const namespace = requiredIdentifier(input.namespace, "resource namespace");
+  const type = requiredIdentifier(input.type, "resource type");
+  const permission = requiredIdentifier(input.permission, "authorization permission");
+  const cursor = input.cursor
+    ? requiredIdentifier(input.cursor, "authorization list cursor")
+    : undefined;
+  if (!Number.isInteger(input.limit) || input.limit < 1 || input.limit > 100) {
+    throw new Error("authorization resource list limit must be an integer from 1 to 100");
+  }
+  const { db } = openOpenClawStateDatabase(input.database);
+  const kysely = getAuthorizationKysely(db);
+  const membership = executeSqliteQueryTakeFirstSync(
+    db,
+    kysely
+      .selectFrom("authorization_domain_memberships as membership")
+      .innerJoin(
+        "authorization_principals as principal",
+        "principal.principal_id",
+        "membership.principal_id",
+      )
+      .select(["membership.role", "principal.kind"])
+      .where("membership.domain_id", "=", domainId)
+      .where("membership.principal_id", "=", principalId),
+  );
+  if (!membership) {
+    return { resources: [] };
+  }
+  let query = kysely
+    .selectFrom("authorization_resources as resource")
+    .leftJoin("authorization_grants as grant", (join) =>
+      join
+        .onRef("grant.domain_id", "=", "resource.domain_id")
+        .onRef("grant.namespace", "=", "resource.namespace")
+        .onRef("grant.resource_type", "=", "resource.resource_type")
+        .onRef("grant.resource_id", "=", "resource.resource_id")
+        .on("grant.principal_id", "=", principalId)
+        .on("grant.permission", "=", permission),
+    )
+    .select(["resource.namespace", "resource.resource_type", "resource.resource_id"])
+    .where("resource.domain_id", "=", domainId)
+    .where("resource.namespace", "=", namespace)
+    .where("resource.resource_type", "=", type)
+    .where("resource.retired_at", "is", null);
+  if (cursor) {
+    query = query.where("resource.resource_id", ">", cursor);
+  }
+  if (membership.kind !== "human" || membership.role !== "owner") {
+    query = query.where((eb) =>
+      eb.or([
+        ...(membership.kind === "human"
+          ? [eb("resource.owner_principal_id", "=", principalId)]
+          : []),
+        eb("grant.permission", "is not", null),
+      ]),
+    );
+  }
+  const rows = executeSqliteQuerySync(
+    db,
+    query.orderBy("resource.resource_id", "asc").limit(input.limit + 1),
+  ).rows;
+  const hasMore = rows.length > input.limit;
+  const pageRows = hasMore ? rows.slice(0, input.limit) : rows;
+  const resources = pageRows.map((row) => ({
+    namespace: row.namespace,
+    type: row.resource_type,
+    id: row.resource_id,
+  }));
+  return {
+    resources,
+    ...(hasMore && resources.length > 0 ? { nextCursor: resources[resources.length - 1]?.id } : {}),
+  };
 }

--- a/src/gateway/authorization/state-store.ts
+++ b/src/gateway/authorization/state-store.ts
@@ -15,6 +15,7 @@ import type { GatewayResourceRef } from "./contracts.js";
 
 type AuthorizationDatabase = Pick<
   OpenClawStateKyselyDatabase,
+  | "authorization_agent_session_bindings"
   | "authorization_domain_memberships"
   | "authorization_domains"
   | "authorization_grants"
@@ -561,6 +562,22 @@ export function transferAuthorizationResourceOwner(
     );
     if (!existing || existing.retired_at !== null) {
       throw new Error("authorization resource must be active for owner transfer");
+    }
+    if (resource.namespace === "core" && resource.type === "agent-session") {
+      const activeBinding = executeSqliteQueryTakeFirstSync(
+        db,
+        kysely
+          .selectFrom("authorization_agent_session_bindings")
+          .select("binding_id")
+          .where("domain_id", "=", domainId)
+          .where("assignment_id", "=", resource.id)
+          .where("state", "=", "active"),
+      );
+      if (activeBinding) {
+        throw new Error(
+          "an active agent-session binding keeps its canonical sponsor owner; share access with grants",
+        );
+      }
     }
     executeSqliteQuerySync(
       db,

--- a/src/gateway/authorization/state-store.ts
+++ b/src/gateway/authorization/state-store.ts
@@ -64,6 +64,50 @@ function requireDomainOwner(db: DatabaseSync, domainId: string, principalId: str
   }
 }
 
+function requireHumanDomainMember(db: DatabaseSync, domainId: string, principalId: string): void {
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    getAuthorizationKysely(db)
+      .selectFrom("authorization_principals as principal")
+      .innerJoin("authorization_domain_memberships as membership", (join) =>
+        join
+          .onRef("membership.principal_id", "=", "principal.principal_id")
+          .on("membership.domain_id", "=", domainId),
+      )
+      .select("principal.kind")
+      .where("principal.principal_id", "=", principalId),
+  );
+  if (row?.kind !== "human") {
+    throw new Error("authorization resource owner must be a human principal in the domain");
+  }
+}
+
+function requireDomainOrResourceOwner(params: {
+  db: DatabaseSync;
+  domainId: string;
+  principalId: string;
+  resource: GatewayResourceRef;
+}): void {
+  const ownership = executeSqliteQueryTakeFirstSync(
+    params.db,
+    getAuthorizationKysely(params.db)
+      .selectFrom("authorization_domain_memberships as membership")
+      .leftJoin("authorization_resources as resource", (join) =>
+        join
+          .onRef("resource.domain_id", "=", "membership.domain_id")
+          .on("resource.namespace", "=", params.resource.namespace)
+          .on("resource.resource_type", "=", params.resource.type)
+          .on("resource.resource_id", "=", params.resource.id),
+      )
+      .select(["membership.role", "resource.owner_principal_id"])
+      .where("membership.domain_id", "=", params.domainId)
+      .where("membership.principal_id", "=", params.principalId),
+  );
+  if (ownership?.role !== "owner" && ownership?.owner_principal_id !== params.principalId) {
+    throw new Error(`principal ${params.principalId} is not the owner of the domain or resource`);
+  }
+}
+
 export function putAuthorizationPrincipal(
   input: AuthorizationDatabaseInput & {
     id: string;
@@ -235,6 +279,7 @@ export function bindAuthorizationResource(
       }
       return;
     }
+    requireHumanDomainMember(db, domainId, ownerPrincipalId);
     executeSqliteQuerySync(
       db,
       kysely.insertInto("authorization_resources").values({
@@ -267,7 +312,12 @@ export function grantAuthorizationPermission(
     "grantor principal id",
   );
   runOpenClawStateWriteTransaction(({ db }) => {
-    requireDomainOwner(db, domainId, grantedByPrincipalId);
+    requireDomainOrResourceOwner({
+      db,
+      domainId,
+      principalId: grantedByPrincipalId,
+      resource,
+    });
     executeSqliteQuerySync(
       db,
       getAuthorizationKysely(db)
@@ -280,7 +330,6 @@ export function grantAuthorizationPermission(
           resource_id: resource.id,
           permission,
           granted_by_principal_id: grantedByPrincipalId,
-          granted_by_role: "owner",
           created_at: Date.now(),
         })
         .onConflict((conflict) =>

--- a/src/gateway/authorization/teams-bootstrap.test.ts
+++ b/src/gateway/authorization/teams-bootstrap.test.ts
@@ -1,0 +1,285 @@
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
+import { createIsolationDomain, putAuthorizationPrincipal } from "./state-store.js";
+import { bootstrapTeamsOwner } from "./teams-bootstrap.js";
+import { authenticateTeamsLocalAccount } from "./teams-identity.js";
+
+const tempDirs: string[] = [];
+
+function createDatabase() {
+  return { path: `${makeTempDir(tempDirs, "openclaw-teams-bootstrap-")}/openclaw.sqlite` };
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
+
+afterAll(() => {
+  cleanupTempDirs(tempDirs);
+});
+
+describe("Teams first-owner bootstrap", () => {
+  it("atomically creates one local human owner with the initial workspace resources", async () => {
+    const database = createDatabase();
+
+    const bootstrap = await bootstrapTeamsOwner({
+      loginLabel: " Owner@Example.com ",
+      password: "correct horse battery staple",
+      domainId: "domain-local",
+      now: 10_000,
+      database,
+    });
+
+    expect(bootstrap).toEqual({
+      account: {
+        id: expect.any(String),
+        principalId: expect.any(String),
+        loginLabel: "owner@example.com",
+        createdAt: 10_000,
+      },
+      agent: {
+        principalId: expect.any(String),
+        runtimeAgentId: "main",
+        sessionKey: "agent:main:main",
+        assignmentId: "main:main",
+      },
+      domainId: "domain-local",
+    });
+    await expect(
+      authenticateTeamsLocalAccount({
+        loginLabel: "OWNER@example.com",
+        password: "correct horse battery staple",
+        database,
+      }),
+    ).resolves.toEqual(bootstrap.account);
+
+    const { db } = openOpenClawStateDatabase(database);
+    expect(
+      db
+        .prepare(
+          `SELECT issuer, subject, kind
+             FROM authorization_principals
+            WHERE principal_id = ?`,
+        )
+        .get(bootstrap.account.principalId),
+    ).toEqual({ issuer: "openclaw-local", subject: "owner@example.com", kind: "human" });
+    expect(
+      db
+        .prepare(
+          `SELECT issuer, subject, kind
+             FROM authorization_principals
+            WHERE principal_id = ?`,
+        )
+        .get(bootstrap.agent.principalId),
+    ).toEqual({ issuer: "openclaw-core", subject: "agent:main", kind: "service" });
+    expect(
+      db
+        .prepare(
+          `SELECT role, added_by_principal_id, added_by_role
+             FROM authorization_domain_memberships
+            WHERE domain_id = ? AND principal_id = ?`,
+        )
+        .get(bootstrap.domainId, bootstrap.account.principalId),
+    ).toEqual({
+      role: "owner",
+      added_by_principal_id: bootstrap.account.principalId,
+      added_by_role: "owner",
+    });
+    expect(
+      db
+        .prepare(
+          `SELECT role, added_by_principal_id, added_by_role
+             FROM authorization_domain_memberships
+            WHERE domain_id = ? AND principal_id = ?`,
+        )
+        .get(bootstrap.domainId, bootstrap.agent.principalId),
+    ).toEqual({
+      role: "member",
+      added_by_principal_id: bootstrap.account.principalId,
+      added_by_role: "owner",
+    });
+    expect(
+      db
+        .prepare(
+          `SELECT namespace, resource_type, resource_id, owner_principal_id,
+                  parent_namespace, parent_resource_type, parent_resource_id
+             FROM authorization_resources
+            WHERE domain_id = ?
+            ORDER BY resource_type`,
+        )
+        .all(bootstrap.domainId),
+    ).toEqual([
+      {
+        namespace: "core",
+        resource_type: "agent-session",
+        resource_id: "main:main",
+        owner_principal_id: bootstrap.account.principalId,
+        parent_namespace: null,
+        parent_resource_type: null,
+        parent_resource_id: null,
+      },
+      {
+        namespace: "workspaces",
+        resource_type: "tab",
+        resource_id: "main",
+        owner_principal_id: bootstrap.account.principalId,
+        parent_namespace: "workspaces",
+        parent_resource_type: "workspace",
+        parent_resource_id: "default",
+      },
+      {
+        namespace: "workspaces",
+        resource_type: "workspace",
+        resource_id: "default",
+        owner_principal_id: bootstrap.account.principalId,
+        parent_namespace: null,
+        parent_resource_type: null,
+        parent_resource_id: null,
+      },
+    ]);
+    expect(
+      db
+        .prepare(
+          `SELECT delegation_id, assignment_id, agent_principal_id, sponsor_principal_id, state
+             FROM authorization_delegations
+            WHERE domain_id = ?`,
+        )
+        .get(bootstrap.domainId),
+    ).toEqual({
+      delegation_id: "main:main",
+      assignment_id: "main:main",
+      agent_principal_id: bootstrap.agent.principalId,
+      sponsor_principal_id: bootstrap.account.principalId,
+      state: "active",
+    });
+    expect(
+      db
+        .prepare(
+          `SELECT binding_id, runtime_agent_id, session_key, assignment_id, state
+             FROM authorization_agent_session_bindings
+            WHERE domain_id = ?`,
+        )
+        .get(bootstrap.domainId),
+    ).toEqual({
+      binding_id: "main:main",
+      runtime_agent_id: "main",
+      session_key: "agent:main:main",
+      assignment_id: "main:main",
+      state: "active",
+    });
+    expect(
+      db
+        .prepare(
+          `SELECT namespace, resource_type, resource_id, permission
+             FROM authorization_grants
+            WHERE domain_id = ? AND principal_id = ?
+            ORDER BY resource_type, permission`,
+        )
+        .all(bootstrap.domainId, bootstrap.agent.principalId),
+    ).toEqual([
+      {
+        namespace: "workspaces",
+        resource_type: "tab",
+        resource_id: "main",
+        permission: "workspaces.tab.changeRequest.create",
+      },
+      {
+        namespace: "workspaces",
+        resource_type: "tab",
+        resource_id: "main",
+        permission: "workspaces.tab.read",
+      },
+      {
+        namespace: "workspaces",
+        resource_type: "tab",
+        resource_id: "main",
+        permission: "workspaces.tab.write",
+      },
+      {
+        namespace: "workspaces",
+        resource_type: "workspace",
+        resource_id: "default",
+        permission: "workspaces.workspace.read",
+      },
+    ]);
+  });
+
+  it("returns the same complete owner without replacing its password", async () => {
+    const database = createDatabase();
+    const first = await bootstrapTeamsOwner({
+      loginLabel: "owner@example.com",
+      password: "correct horse battery staple",
+      domainId: "domain-local",
+      now: 10_000,
+      database,
+    });
+    const { db } = openOpenClawStateDatabase(database);
+    const before = db
+      .prepare(
+        `SELECT password_salt, password_verifier
+           FROM teams_local_accounts
+          WHERE account_id = ?`,
+      )
+      .get(first.account.id) as { password_salt: Uint8Array; password_verifier: Uint8Array };
+
+    await expect(
+      bootstrapTeamsOwner({
+        loginLabel: " OWNER@EXAMPLE.COM ",
+        password: "a different valid password",
+        domainId: "domain-local",
+        now: 20_000,
+        database,
+      }),
+    ).resolves.toEqual(first);
+
+    const after = db
+      .prepare(
+        `SELECT password_salt, password_verifier
+           FROM teams_local_accounts
+          WHERE account_id = ?`,
+      )
+      .get(first.account.id) as { password_salt: Uint8Array; password_verifier: Uint8Array };
+    expect(Buffer.from(after.password_salt)).toEqual(Buffer.from(before.password_salt));
+    expect(Buffer.from(after.password_verifier)).toEqual(Buffer.from(before.password_verifier));
+    await expect(
+      authenticateTeamsLocalAccount({
+        loginLabel: "owner@example.com",
+        password: "correct horse battery staple",
+        database,
+      }),
+    ).resolves.toEqual(first.account);
+  });
+
+  it("rejects a mismatched existing domain without creating an account or principal", async () => {
+    const database = createDatabase();
+    putAuthorizationPrincipal({
+      id: "other-owner",
+      principal: { issuer: "openclaw-local", subject: "other@example.com", kind: "human" },
+      database,
+    });
+    createIsolationDomain({ id: "domain-local", ownerPrincipalId: "other-owner", database });
+
+    await expect(
+      bootstrapTeamsOwner({
+        loginLabel: "owner@example.com",
+        password: "correct horse battery staple",
+        domainId: "domain-local",
+        database,
+      }),
+    ).rejects.toThrow(/already belongs to another owner/i);
+
+    const { db } = openOpenClawStateDatabase(database);
+    expect(db.prepare("SELECT COUNT(*) AS count FROM teams_local_accounts").get()).toEqual({
+      count: 0,
+    });
+    expect(
+      db
+        .prepare("SELECT COUNT(*) AS count FROM authorization_principals WHERE issuer = ?")
+        .get("openclaw-local"),
+    ).toEqual({ count: 1 });
+  });
+});

--- a/src/gateway/authorization/teams-bootstrap.ts
+++ b/src/gateway/authorization/teams-bootstrap.ts
@@ -1,0 +1,412 @@
+import { randomUUID } from "node:crypto";
+import type { DatabaseSync } from "node:sqlite";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../../infra/kysely-sync.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
+import {
+  runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabaseOptions,
+} from "../../state/openclaw-state-db.js";
+import type { TeamsLocalAccount } from "./teams-identity.js";
+import { normalizeTeamsLoginLabel, prepareTeamsPassword } from "./teams-password.js";
+
+type TeamsBootstrapDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  | "authorization_agent_session_bindings"
+  | "authorization_agent_sponsors"
+  | "authorization_delegations"
+  | "authorization_domain_memberships"
+  | "authorization_domains"
+  | "authorization_grants"
+  | "authorization_principals"
+  | "authorization_resources"
+  | "teams_local_accounts"
+>;
+
+type DatabaseInput = { database?: OpenClawStateDatabaseOptions };
+
+const DEFAULT_DOMAIN_ID = "openclaw-local";
+const INITIAL_WORKSPACE = Object.freeze({
+  namespace: "workspaces",
+  type: "workspace",
+  id: "default",
+});
+const INITIAL_TAB = Object.freeze({ namespace: "workspaces", type: "tab", id: "main" });
+const MAIN_AGENT = Object.freeze({
+  issuer: "openclaw-core",
+  subject: "agent:main",
+  runtimeAgentId: "main",
+  sessionKey: "agent:main:main",
+  assignmentId: "main:main",
+});
+const MAIN_AGENT_SESSION = Object.freeze({
+  namespace: "core",
+  type: "agent-session",
+  id: MAIN_AGENT.assignmentId,
+});
+
+export type TeamsBootstrapResult = Readonly<{
+  account: TeamsLocalAccount;
+  agent: Readonly<{
+    principalId: string;
+    runtimeAgentId: string;
+    sessionKey: string;
+    assignmentId: string;
+  }>;
+  domainId: string;
+}>;
+
+function getTeamsBootstrapKysely(db: DatabaseSync) {
+  return getNodeSqliteKysely<TeamsBootstrapDatabase>(db);
+}
+
+function requiredIdentifier(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return normalized;
+}
+
+function assertExistingBootstrap(input: {
+  db: DatabaseSync;
+  domainId: string;
+  account: { account_id: string; principal_id: string; login_label: string; created_at: number };
+}): TeamsBootstrapResult {
+  const kysely = getTeamsBootstrapKysely(input.db);
+  const principal = executeSqliteQueryTakeFirstSync(
+    input.db,
+    kysely
+      .selectFrom("authorization_principals")
+      .select(["issuer", "subject", "kind"])
+      .where("principal_id", "=", input.account.principal_id),
+  );
+  if (
+    principal?.issuer !== "openclaw-local" ||
+    principal.subject !== input.account.login_label ||
+    principal.kind !== "human"
+  ) {
+    throw new Error("Teams bootstrap account is mapped to a different principal identity");
+  }
+  const membership = executeSqliteQueryTakeFirstSync(
+    input.db,
+    kysely
+      .selectFrom("authorization_domain_memberships")
+      .select("role")
+      .where("domain_id", "=", input.domainId)
+      .where("principal_id", "=", input.account.principal_id),
+  );
+  if (membership?.role !== "owner") {
+    throw new Error("Teams bootstrap domain is already owned differently");
+  }
+  const agent = executeSqliteQueryTakeFirstSync(
+    input.db,
+    kysely
+      .selectFrom("authorization_principals")
+      .select(["principal_id", "kind"])
+      .where("issuer", "=", MAIN_AGENT.issuer)
+      .where("subject", "=", MAIN_AGENT.subject),
+  );
+  if (agent?.kind !== "service") {
+    throw new Error("Teams bootstrap main agent principal is unavailable");
+  }
+  const agentMembership = executeSqliteQueryTakeFirstSync(
+    input.db,
+    kysely
+      .selectFrom("authorization_domain_memberships")
+      .select("role")
+      .where("domain_id", "=", input.domainId)
+      .where("principal_id", "=", agent.principal_id),
+  );
+  if (agentMembership?.role !== "member") {
+    throw new Error("Teams bootstrap main agent membership is unavailable");
+  }
+  for (const resource of [INITIAL_WORKSPACE, INITIAL_TAB, MAIN_AGENT_SESSION]) {
+    const row = executeSqliteQueryTakeFirstSync(
+      input.db,
+      kysely
+        .selectFrom("authorization_resources")
+        .select([
+          "owner_principal_id",
+          "parent_namespace",
+          "parent_resource_type",
+          "parent_resource_id",
+          "retired_at",
+        ])
+        .where("domain_id", "=", input.domainId)
+        .where("namespace", "=", resource.namespace)
+        .where("resource_type", "=", resource.type)
+        .where("resource_id", "=", resource.id),
+    );
+    const isTab = resource === INITIAL_TAB;
+    const hasExpectedParent = !isTab
+      ? row?.parent_namespace === null &&
+        row.parent_resource_type === null &&
+        row.parent_resource_id === null
+      : row?.parent_namespace === INITIAL_WORKSPACE.namespace &&
+        row.parent_resource_type === INITIAL_WORKSPACE.type &&
+        row.parent_resource_id === INITIAL_WORKSPACE.id;
+    if (
+      row?.owner_principal_id !== input.account.principal_id ||
+      row.retired_at !== null ||
+      !hasExpectedParent
+    ) {
+      throw new Error("Teams bootstrap resources are already bound differently");
+    }
+  }
+  const binding = executeSqliteQueryTakeFirstSync(
+    input.db,
+    kysely
+      .selectFrom("authorization_agent_session_bindings")
+      .select(["agent_principal_id", "sponsor_principal_id", "state"])
+      .where("domain_id", "=", input.domainId)
+      .where("binding_id", "=", MAIN_AGENT.assignmentId)
+      .where("runtime_agent_id", "=", MAIN_AGENT.runtimeAgentId)
+      .where("session_key", "=", MAIN_AGENT.sessionKey),
+  );
+  if (
+    binding?.agent_principal_id !== agent.principal_id ||
+    binding.sponsor_principal_id !== input.account.principal_id ||
+    binding.state !== "active"
+  ) {
+    throw new Error("Teams bootstrap main agent binding is unavailable");
+  }
+  return Object.freeze({
+    account: Object.freeze({
+      id: input.account.account_id,
+      principalId: input.account.principal_id,
+      loginLabel: input.account.login_label,
+      createdAt: input.account.created_at,
+    }),
+    agent: Object.freeze({
+      principalId: agent.principal_id,
+      runtimeAgentId: MAIN_AGENT.runtimeAgentId,
+      sessionKey: MAIN_AGENT.sessionKey,
+      assignmentId: MAIN_AGENT.assignmentId,
+    }),
+    domainId: input.domainId,
+  });
+}
+
+/** Create the initial local human owner and the workspace tree in one state transaction. */
+export async function bootstrapTeamsOwner(
+  input: DatabaseInput & {
+    loginLabel: string;
+    password: string;
+    domainId?: string;
+    now?: number;
+  },
+): Promise<TeamsBootstrapResult> {
+  const loginLabel = normalizeTeamsLoginLabel(input.loginLabel);
+  const domainId = requiredIdentifier(
+    input.domainId ?? DEFAULT_DOMAIN_ID,
+    "Teams bootstrap domain id",
+  );
+  // Scrypt is intentionally outside the SQLite transaction; a slow verifier must not hold the write lock.
+  const password = await prepareTeamsPassword(input.password);
+  const principalId = randomUUID();
+  const agentPrincipalId = randomUUID();
+  const accountId = randomUUID();
+  const now = input.now ?? Date.now();
+
+  return runOpenClawStateWriteTransaction(({ db }) => {
+    const kysely = getTeamsBootstrapKysely(db);
+    const existingAccount = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("teams_local_accounts")
+        .select(["account_id", "principal_id", "login_label", "created_at"])
+        .where("login_label", "=", loginLabel),
+    );
+    if (existingAccount) {
+      return assertExistingBootstrap({ db, domainId, account: existingAccount });
+    }
+    const existingPrincipal = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_principals")
+        .select("principal_id")
+        .where("issuer", "=", "openclaw-local")
+        .where("subject", "=", loginLabel)
+        .where("kind", "=", "human"),
+    );
+    if (existingPrincipal) {
+      throw new Error("Teams bootstrap principal is already mapped without its local account");
+    }
+    const existingDomain = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_domains")
+        .select("domain_id")
+        .where("domain_id", "=", domainId),
+    );
+    if (existingDomain) {
+      throw new Error("Teams bootstrap domain already belongs to another owner");
+    }
+
+    executeSqliteQuerySync(
+      db,
+      kysely.insertInto("authorization_principals").values({
+        principal_id: principalId,
+        issuer: "openclaw-local",
+        subject: loginLabel,
+        kind: "human",
+        created_at: now,
+        updated_at: now,
+      }),
+    );
+    executeSqliteQuerySync(
+      db,
+      kysely.insertInto("authorization_principals").values({
+        principal_id: agentPrincipalId,
+        issuer: MAIN_AGENT.issuer,
+        subject: MAIN_AGENT.subject,
+        kind: "service",
+        created_at: now,
+        updated_at: now,
+      }),
+    );
+    executeSqliteQuerySync(
+      db,
+      kysely.insertInto("teams_local_accounts").values({
+        account_id: accountId,
+        principal_id: principalId,
+        login_label: loginLabel,
+        password_salt: password.salt,
+        password_verifier: password.verifier,
+        password_scrypt_n: password.n,
+        password_scrypt_r: password.r,
+        password_scrypt_p: password.p,
+        created_at: now,
+      }),
+    );
+    executeSqliteQuerySync(
+      db,
+      kysely.insertInto("authorization_domains").values({
+        domain_id: domainId,
+        created_at: now,
+        updated_at: now,
+      }),
+    );
+    executeSqliteQuerySync(
+      db,
+      kysely.insertInto("authorization_domain_memberships").values({
+        domain_id: domainId,
+        principal_id: principalId,
+        role: "owner",
+        added_by_principal_id: principalId,
+        added_by_role: "owner",
+        created_at: now,
+      }),
+    );
+    executeSqliteQuerySync(
+      db,
+      kysely.insertInto("authorization_domain_memberships").values({
+        domain_id: domainId,
+        principal_id: agentPrincipalId,
+        role: "member",
+        added_by_principal_id: principalId,
+        added_by_role: "owner",
+        created_at: now,
+      }),
+    );
+    for (const [resource, parent] of [
+      [INITIAL_WORKSPACE, null],
+      [INITIAL_TAB, INITIAL_WORKSPACE],
+      [MAIN_AGENT_SESSION, null],
+    ] as const) {
+      executeSqliteQuerySync(
+        db,
+        kysely.insertInto("authorization_resources").values({
+          namespace: resource.namespace,
+          resource_type: resource.type,
+          resource_id: resource.id,
+          domain_id: domainId,
+          owner_principal_id: principalId,
+          parent_namespace: parent?.namespace ?? null,
+          parent_resource_type: parent?.type ?? null,
+          parent_resource_id: parent?.id ?? null,
+          retired_at: null,
+          retired_by_principal_id: null,
+          created_at: now,
+          updated_at: now,
+        }),
+      );
+    }
+    executeSqliteQuerySync(
+      db,
+      kysely.insertInto("authorization_agent_sponsors").values({
+        domain_id: domainId,
+        agent_principal_id: agentPrincipalId,
+        sponsor_principal_id: principalId,
+        created_at: now,
+      }),
+    );
+    executeSqliteQuerySync(
+      db,
+      kysely.insertInto("authorization_delegations").values({
+        domain_id: domainId,
+        delegation_id: MAIN_AGENT.assignmentId,
+        assignment_id: MAIN_AGENT.assignmentId,
+        agent_principal_id: agentPrincipalId,
+        sponsor_principal_id: principalId,
+        created_by_principal_id: principalId,
+        state: "active",
+        created_at: now,
+        updated_at: now,
+        revoked_at: null,
+      }),
+    );
+    executeSqliteQuerySync(
+      db,
+      kysely.insertInto("authorization_agent_session_bindings").values({
+        domain_id: domainId,
+        binding_id: MAIN_AGENT.assignmentId,
+        runtime_agent_id: MAIN_AGENT.runtimeAgentId,
+        session_key: MAIN_AGENT.sessionKey,
+        delegation_id: MAIN_AGENT.assignmentId,
+        assignment_id: MAIN_AGENT.assignmentId,
+        agent_principal_id: agentPrincipalId,
+        sponsor_principal_id: principalId,
+        created_by_principal_id: principalId,
+        state: "active",
+        created_at: now,
+        updated_at: now,
+        revoked_at: null,
+      }),
+    );
+    for (const [resource, permission] of [
+      [INITIAL_WORKSPACE, "workspaces.workspace.read"],
+      [INITIAL_TAB, "workspaces.tab.read"],
+      [INITIAL_TAB, "workspaces.tab.write"],
+      [INITIAL_TAB, "workspaces.tab.changeRequest.create"],
+    ] as const) {
+      executeSqliteQuerySync(
+        db,
+        kysely.insertInto("authorization_grants").values({
+          domain_id: domainId,
+          principal_id: agentPrincipalId,
+          namespace: resource.namespace,
+          resource_type: resource.type,
+          resource_id: resource.id,
+          permission,
+          granted_by_principal_id: principalId,
+          created_at: now,
+        }),
+      );
+    }
+    return Object.freeze({
+      account: Object.freeze({ id: accountId, principalId, loginLabel, createdAt: now }),
+      agent: Object.freeze({
+        principalId: agentPrincipalId,
+        runtimeAgentId: MAIN_AGENT.runtimeAgentId,
+        sessionKey: MAIN_AGENT.sessionKey,
+        assignmentId: MAIN_AGENT.assignmentId,
+      }),
+      domainId,
+    });
+  }, input.database);
+}

--- a/src/gateway/authorization/teams-identity.test.ts
+++ b/src/gateway/authorization/teams-identity.test.ts
@@ -1,0 +1,285 @@
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
+import {
+  addIsolationDomainMember,
+  createIsolationDomain,
+  putAuthorizationPrincipal,
+  removeIsolationDomainMember,
+} from "./state-store.js";
+import {
+  authenticateTeamsLocalAccount,
+  createTeamsLocalAccount,
+  createTeamsSession,
+  listTeamsSessions,
+  resolveTeamsSession,
+  revokeTeamsSession,
+} from "./teams-identity.js";
+
+const tempDirs: string[] = [];
+const owner = {
+  id: "principal-owner",
+  principal: { issuer: "local", subject: "owner", kind: "human" },
+} as const;
+
+function createDatabase() {
+  return { path: `${makeTempDir(tempDirs, "openclaw-teams-identity-")}/openclaw.sqlite` };
+}
+
+function seedOwner(database: ReturnType<typeof createDatabase>) {
+  putAuthorizationPrincipal({ ...owner, database });
+  createIsolationDomain({ id: "domain-1", ownerPrincipalId: owner.id, database });
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
+
+afterAll(() => {
+  cleanupTempDirs(tempDirs);
+});
+
+describe("Teams local accounts", () => {
+  it("maps one normalized login label to one human principal without exposing password material", async () => {
+    const database = createDatabase();
+    seedOwner(database);
+
+    const account = await createTeamsLocalAccount({
+      id: "account-1",
+      principalId: owner.id,
+      loginLabel: "  OWNER@Example.COM  ",
+      password: "correct horse battery staple",
+      database,
+    });
+
+    expect(account).toEqual({
+      id: "account-1",
+      principalId: owner.id,
+      loginLabel: "owner@example.com",
+      createdAt: expect.any(Number),
+    });
+    expect(Object.keys(account)).not.toContain("passwordHash");
+    expect(Object.keys(account)).not.toContain("passwordSalt");
+
+    await expect(
+      authenticateTeamsLocalAccount({
+        loginLabel: "Owner@example.com",
+        password: "correct horse battery staple",
+        database,
+      }),
+    ).resolves.toEqual(account);
+    await expect(
+      authenticateTeamsLocalAccount({
+        loginLabel: "owner@example.com",
+        password: "wrong password",
+        database,
+      }),
+    ).resolves.toBeUndefined();
+
+    const { db } = openOpenClawStateDatabase(database);
+    const stored = db
+      .prepare(
+        `SELECT login_label, password_salt, password_verifier
+           FROM teams_local_accounts
+          WHERE account_id = ?`,
+      )
+      .get(account.id) as {
+      login_label: string;
+      password_salt: Uint8Array;
+      password_verifier: Uint8Array;
+    };
+    expect(stored.login_label).toBe("owner@example.com");
+    expect(Buffer.from(stored.password_salt).toString("utf8")).not.toContain(account.loginLabel);
+    expect(Buffer.from(stored.password_verifier).toString("utf8")).not.toContain(
+      "correct horse battery staple",
+    );
+  });
+
+  it("rejects duplicate normalized labels, non-human mappings, and oversized passwords", async () => {
+    const database = createDatabase();
+    seedOwner(database);
+    await createTeamsLocalAccount({
+      id: "account-1",
+      principalId: owner.id,
+      loginLabel: "owner@example.com",
+      password: "correct horse battery staple",
+      database,
+    });
+
+    await expect(
+      createTeamsLocalAccount({
+        id: "account-2",
+        principalId: owner.id,
+        loginLabel: " OWNER@example.com ",
+        password: "another safe password",
+        database,
+      }),
+    ).rejects.toThrow(/login label is already in use/i);
+
+    const service = {
+      id: "principal-service",
+      principal: { issuer: "core", subject: "agent:main", kind: "service" },
+    } as const;
+    putAuthorizationPrincipal({ ...service, database });
+    await expect(
+      createTeamsLocalAccount({
+        id: "account-service",
+        principalId: service.id,
+        loginLabel: "agent@example.com",
+        password: "another safe password",
+        database,
+      }),
+    ).rejects.toThrow(/human principal/i);
+
+    await expect(
+      createTeamsLocalAccount({
+        id: "account-large",
+        principalId: owner.id,
+        loginLabel: "large@example.com",
+        password: "x".repeat(1_025),
+        database,
+      }),
+    ).rejects.toThrow(/password/i);
+  });
+});
+
+describe("Teams sessions", () => {
+  it("stores only a token digest and resolves one exact unexpired domain session", async () => {
+    const database = createDatabase();
+    seedOwner(database);
+    await createTeamsLocalAccount({
+      id: "account-1",
+      principalId: owner.id,
+      loginLabel: "owner@example.com",
+      password: "correct horse battery staple",
+      database,
+    });
+
+    const created = createTeamsSession({
+      accountId: "account-1",
+      domainId: "domain-1",
+      ttlMs: 60_000,
+      database,
+    });
+    expect(created.token).toMatch(/^[A-Za-z0-9_-]{40,}$/);
+    expect(created.session).toMatchObject({
+      id: expect.any(String),
+      accountId: "account-1",
+      principalId: owner.id,
+      principal: owner.principal,
+      domainId: "domain-1",
+      state: "active",
+    });
+    expect(Object.keys(created.session)).not.toContain("tokenDigest");
+    expect(resolveTeamsSession({ token: created.token, database })).toEqual(created.session);
+    expect(resolveTeamsSession({ token: `${created.token}x`, database })).toBeUndefined();
+
+    const listed = listTeamsSessions({ accountId: "account-1", database });
+    expect(listed).toEqual([created.session]);
+    expect(JSON.stringify(listed)).not.toContain(created.token);
+
+    const { db } = openOpenClawStateDatabase(database);
+    const stored = db
+      .prepare("SELECT token_digest FROM teams_sessions WHERE session_id = ?")
+      .get(created.session.id) as { token_digest: string };
+    expect(stored.token_digest).toMatch(/^[a-f0-9]{64}$/);
+    expect(stored.token_digest).not.toBe(created.token);
+  });
+
+  it("rejects non-members, expires sessions, and makes revocation monotonic", async () => {
+    const database = createDatabase();
+    seedOwner(database);
+    await createTeamsLocalAccount({
+      id: "account-1",
+      principalId: owner.id,
+      loginLabel: "owner@example.com",
+      password: "correct horse battery staple",
+      database,
+    });
+    expect(() =>
+      createTeamsSession({
+        accountId: "account-1",
+        domainId: "missing-domain",
+        ttlMs: 60_000,
+        database,
+      }),
+    ).toThrow(/domain member/i);
+
+    const created = createTeamsSession({
+      accountId: "account-1",
+      domainId: "domain-1",
+      ttlMs: 60_000,
+      now: 10_000,
+      database,
+    });
+    expect(resolveTeamsSession({ token: created.token, now: 69_999, database })).toBeDefined();
+    expect(resolveTeamsSession({ token: created.token, now: 70_000, database })).toBeUndefined();
+
+    const active = createTeamsSession({
+      accountId: "account-1",
+      domainId: "domain-1",
+      ttlMs: 60_000,
+      now: 20_000,
+      database,
+    });
+    revokeTeamsSession({
+      id: active.session.id,
+      revokedByPrincipalId: owner.id,
+      now: 30_000,
+      database,
+    });
+    expect(resolveTeamsSession({ token: active.token, now: 30_001, database })).toBeUndefined();
+
+    const { db } = openOpenClawStateDatabase(database);
+    expect(() =>
+      db
+        .prepare(
+          "UPDATE teams_sessions SET state = 'active', revoked_at = NULL, revoked_by_principal_id = NULL WHERE session_id = ?",
+        )
+        .run(active.session.id),
+    ).toThrow(/cannot be reactivated/i);
+    expect(() =>
+      db.prepare("DELETE FROM teams_sessions WHERE session_id = ?").run(active.session.id),
+    ).toThrow(/cannot be deleted/i);
+  });
+
+  it("stops resolving a session when its principal leaves the exact domain", async () => {
+    const database = createDatabase();
+    seedOwner(database);
+    const member = {
+      id: "principal-member",
+      principal: { issuer: "local", subject: "member", kind: "human" },
+    } as const;
+    putAuthorizationPrincipal({ ...member, database });
+    addIsolationDomainMember({
+      domainId: "domain-1",
+      principalId: member.id,
+      addedByPrincipalId: owner.id,
+      database,
+    });
+    await createTeamsLocalAccount({
+      id: "account-member",
+      principalId: member.id,
+      loginLabel: "member@example.com",
+      password: "correct horse battery staple",
+      database,
+    });
+    const created = createTeamsSession({
+      accountId: "account-member",
+      domainId: "domain-1",
+      ttlMs: 60_000,
+      database,
+    });
+
+    removeIsolationDomainMember({
+      domainId: "domain-1",
+      principalId: member.id,
+      removedByPrincipalId: owner.id,
+      database,
+    });
+    expect(resolveTeamsSession({ token: created.token, database })).toBeUndefined();
+  });
+});

--- a/src/gateway/authorization/teams-identity.test.ts
+++ b/src/gateway/authorization/teams-identity.test.ts
@@ -16,6 +16,7 @@ import {
   createTeamsSession,
   listTeamsSessions,
   resolveTeamsSession,
+  resolveTeamsSessionById,
   revokeTeamsSession,
 } from "./teams-identity.js";
 
@@ -175,6 +176,7 @@ describe("Teams sessions", () => {
     });
     expect(Object.keys(created.session)).not.toContain("tokenDigest");
     expect(resolveTeamsSession({ token: created.token, database })).toEqual(created.session);
+    expect(resolveTeamsSessionById({ id: created.session.id, database })).toEqual(created.session);
     expect(resolveTeamsSession({ token: `${created.token}x`, database })).toBeUndefined();
 
     const listed = listTeamsSessions({ accountId: "account-1", database });
@@ -217,6 +219,9 @@ describe("Teams sessions", () => {
     });
     expect(resolveTeamsSession({ token: created.token, now: 69_999, database })).toBeDefined();
     expect(resolveTeamsSession({ token: created.token, now: 70_000, database })).toBeUndefined();
+    expect(
+      resolveTeamsSessionById({ id: created.session.id, now: 70_000, database }),
+    ).toBeUndefined();
 
     const active = createTeamsSession({
       accountId: "account-1",
@@ -232,6 +237,9 @@ describe("Teams sessions", () => {
       database,
     });
     expect(resolveTeamsSession({ token: active.token, now: 30_001, database })).toBeUndefined();
+    expect(
+      resolveTeamsSessionById({ id: active.session.id, now: 30_001, database }),
+    ).toBeUndefined();
 
     const { db } = openOpenClawStateDatabase(database);
     expect(() =>
@@ -281,5 +289,6 @@ describe("Teams sessions", () => {
       database,
     });
     expect(resolveTeamsSession({ token: created.token, database })).toBeUndefined();
+    expect(resolveTeamsSessionById({ id: created.session.id, database })).toBeUndefined();
   });
 });

--- a/src/gateway/authorization/teams-identity.ts
+++ b/src/gateway/authorization/teams-identity.ts
@@ -1,0 +1,408 @@
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import type { DatabaseSync } from "node:sqlite";
+import type { GatewayPrincipal } from "../../../packages/gateway-protocol/src/schema/frames.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../../infra/kysely-sync.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabaseOptions,
+} from "../../state/openclaw-state-db.js";
+import {
+  normalizeTeamsLoginLabel,
+  prepareTeamsPassword,
+  verifyTeamsPassword,
+} from "./teams-password.js";
+
+type TeamsIdentityDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  | "authorization_domain_memberships"
+  | "authorization_principals"
+  | "teams_local_accounts"
+  | "teams_sessions"
+>;
+
+type DatabaseInput = { database?: OpenClawStateDatabaseOptions };
+
+const MIN_SESSION_TTL_MS = 60_000;
+const MAX_SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1_000;
+
+export type TeamsLocalAccount = Readonly<{
+  id: string;
+  principalId: string;
+  loginLabel: string;
+  createdAt: number;
+}>;
+
+export type TeamsSession = Readonly<{
+  id: string;
+  accountId: string;
+  principalId: string;
+  principal: GatewayPrincipal;
+  domainId: string;
+  state: "active" | "revoked";
+  createdAt: number;
+  expiresAt: number;
+  revokedAt: number | null;
+  revokedByPrincipalId: string | null;
+}>;
+
+export type CreatedTeamsSession = Readonly<{
+  token: string;
+  session: TeamsSession;
+}>;
+
+function getTeamsIdentityKysely(db: DatabaseSync) {
+  return getNodeSqliteKysely<TeamsIdentityDatabase>(db);
+}
+
+function requiredIdentifier(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return normalized;
+}
+
+function validateTtl(ttlMs: number): void {
+  if (!Number.isSafeInteger(ttlMs) || ttlMs < MIN_SESSION_TTL_MS || ttlMs > MAX_SESSION_TTL_MS) {
+    throw new Error("Teams session TTL is outside the supported range");
+  }
+}
+
+function digestOpaqueToken(token: string): string {
+  return createHash("sha256").update(token, "utf8").digest("hex");
+}
+
+function mapAccount(row: {
+  account_id: string;
+  principal_id: string;
+  login_label: string;
+  created_at: number;
+}): TeamsLocalAccount {
+  return Object.freeze({
+    id: row.account_id,
+    principalId: row.principal_id,
+    loginLabel: row.login_label,
+    createdAt: row.created_at,
+  });
+}
+
+function mapSession(row: {
+  session_id: string;
+  account_id: string;
+  principal_id: string;
+  issuer: string;
+  subject: string;
+  kind: string;
+  domain_id: string;
+  state: string;
+  created_at: number;
+  expires_at: number;
+  revoked_at: number | null;
+  revoked_by_principal_id: string | null;
+}): TeamsSession {
+  if ((row.state !== "active" && row.state !== "revoked") || row.kind !== "human") {
+    throw new Error("Teams session has an invalid persisted state");
+  }
+  return Object.freeze({
+    id: row.session_id,
+    accountId: row.account_id,
+    principalId: row.principal_id,
+    principal: Object.freeze({ issuer: row.issuer, subject: row.subject, kind: row.kind }),
+    domainId: row.domain_id,
+    state: row.state,
+    createdAt: row.created_at,
+    expiresAt: row.expires_at,
+    revokedAt: row.revoked_at,
+    revokedByPrincipalId: row.revoked_by_principal_id,
+  });
+}
+
+export async function createTeamsLocalAccount(
+  input: DatabaseInput & {
+    id: string;
+    principalId: string;
+    loginLabel: string;
+    password: string;
+  },
+): Promise<TeamsLocalAccount> {
+  const id = requiredIdentifier(input.id, "Teams account id");
+  const principalId = requiredIdentifier(input.principalId, "Teams account principal id");
+  const loginLabel = normalizeTeamsLoginLabel(input.loginLabel);
+  const password = await prepareTeamsPassword(input.password);
+
+  return runOpenClawStateWriteTransaction(({ db }) => {
+    const kysely = getTeamsIdentityKysely(db);
+    const principal = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_principals")
+        .select("kind")
+        .where("principal_id", "=", principalId),
+    );
+    if (principal?.kind !== "human") {
+      throw new Error("Teams local account must map to a human principal");
+    }
+    const existing = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("teams_local_accounts")
+        .select(["account_id", "principal_id", "login_label"])
+        .where((where) =>
+          where.or([
+            where("account_id", "=", id),
+            where("principal_id", "=", principalId),
+            where("login_label", "=", loginLabel),
+          ]),
+        ),
+    );
+    if (existing) {
+      if (existing.login_label === loginLabel) {
+        throw new Error("Teams login label is already in use");
+      }
+      throw new Error("Teams account id or principal is already mapped");
+    }
+
+    const createdAt = Date.now();
+    executeSqliteQuerySync(
+      db,
+      kysely.insertInto("teams_local_accounts").values({
+        account_id: id,
+        principal_id: principalId,
+        login_label: loginLabel,
+        password_salt: password.salt,
+        password_verifier: password.verifier,
+        password_scrypt_n: password.n,
+        password_scrypt_r: password.r,
+        password_scrypt_p: password.p,
+        created_at: createdAt,
+      }),
+    );
+    return Object.freeze({ id, principalId, loginLabel, createdAt });
+  }, input.database);
+}
+
+export async function authenticateTeamsLocalAccount(
+  input: DatabaseInput & { loginLabel: string; password: string },
+): Promise<TeamsLocalAccount | undefined> {
+  let loginLabel: string;
+  try {
+    loginLabel = normalizeTeamsLoginLabel(input.loginLabel);
+  } catch {
+    return undefined;
+  }
+
+  const { db } = openOpenClawStateDatabase(input.database);
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    getTeamsIdentityKysely(db)
+      .selectFrom("teams_local_accounts")
+      .selectAll()
+      .where("login_label", "=", loginLabel),
+  );
+  const verified = await verifyTeamsPassword(
+    input.password,
+    row
+      ? {
+          salt: row.password_salt,
+          verifier: row.password_verifier,
+          n: row.password_scrypt_n,
+          r: row.password_scrypt_r,
+          p: row.password_scrypt_p,
+        }
+      : undefined,
+  );
+  if (!row || !verified) {
+    return undefined;
+  }
+  return mapAccount(row);
+}
+
+export function createTeamsSession(
+  input: DatabaseInput & {
+    accountId: string;
+    domainId: string;
+    ttlMs: number;
+    now?: number;
+  },
+): CreatedTeamsSession {
+  const accountId = requiredIdentifier(input.accountId, "Teams account id");
+  const domainId = requiredIdentifier(input.domainId, "Teams session domain id");
+  validateTtl(input.ttlMs);
+  const now = input.now ?? Date.now();
+  const token = randomBytes(32).toString("base64url");
+  const sessionId = randomUUID();
+  const tokenDigest = digestOpaqueToken(token);
+
+  const session = runOpenClawStateWriteTransaction(({ db }) => {
+    const kysely = getTeamsIdentityKysely(db);
+    const account = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("teams_local_accounts as account")
+        .innerJoin(
+          "authorization_principals as principal",
+          "principal.principal_id",
+          "account.principal_id",
+        )
+        .innerJoin("authorization_domain_memberships as membership", (join) =>
+          join
+            .onRef("membership.principal_id", "=", "account.principal_id")
+            .on("membership.domain_id", "=", domainId),
+        )
+        .select(["account.principal_id", "principal.issuer", "principal.subject", "principal.kind"])
+        .where("account.account_id", "=", accountId),
+    );
+    if (account?.kind !== "human") {
+      throw new Error("Teams session account principal must be a human domain member");
+    }
+    const row = {
+      session_id: sessionId,
+      token_digest: tokenDigest,
+      account_id: accountId,
+      principal_id: account.principal_id,
+      domain_id: domainId,
+      state: "active",
+      created_at: now,
+      expires_at: now + input.ttlMs,
+      revoked_at: null,
+      revoked_by_principal_id: null,
+    } as const;
+    executeSqliteQuerySync(db, kysely.insertInto("teams_sessions").values(row));
+    return mapSession({
+      ...row,
+      issuer: account.issuer,
+      subject: account.subject,
+      kind: account.kind,
+    });
+  }, input.database);
+
+  return Object.freeze({ token, session });
+}
+
+export function resolveTeamsSession(
+  input: DatabaseInput & { token: string; now?: number },
+): TeamsSession | undefined {
+  const tokenDigest = digestOpaqueToken(input.token);
+  const now = input.now ?? Date.now();
+  const { db } = openOpenClawStateDatabase(input.database);
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    getTeamsIdentityKysely(db)
+      .selectFrom("teams_sessions as session")
+      .innerJoin("teams_local_accounts as account", (join) =>
+        join
+          .onRef("account.account_id", "=", "session.account_id")
+          .onRef("account.principal_id", "=", "session.principal_id"),
+      )
+      .innerJoin("authorization_domain_memberships as membership", (join) =>
+        join
+          .onRef("membership.domain_id", "=", "session.domain_id")
+          .onRef("membership.principal_id", "=", "session.principal_id"),
+      )
+      .innerJoin(
+        "authorization_principals as principal",
+        "principal.principal_id",
+        "session.principal_id",
+      )
+      .select([
+        "session.session_id",
+        "session.account_id",
+        "session.principal_id",
+        "principal.issuer",
+        "principal.subject",
+        "principal.kind",
+        "session.domain_id",
+        "session.state",
+        "session.created_at",
+        "session.expires_at",
+        "session.revoked_at",
+        "session.revoked_by_principal_id",
+      ])
+      .where("session.token_digest", "=", tokenDigest)
+      .where("session.state", "=", "active")
+      .where("session.expires_at", ">", now),
+  );
+  return row ? mapSession(row) : undefined;
+}
+
+export function listTeamsSessions(
+  input: DatabaseInput & { accountId: string },
+): readonly TeamsSession[] {
+  const accountId = requiredIdentifier(input.accountId, "Teams account id");
+  const { db } = openOpenClawStateDatabase(input.database);
+  return executeSqliteQuerySync(
+    db,
+    getTeamsIdentityKysely(db)
+      .selectFrom("teams_sessions as session")
+      .innerJoin(
+        "authorization_principals as principal",
+        "principal.principal_id",
+        "session.principal_id",
+      )
+      .select([
+        "session.session_id",
+        "session.account_id",
+        "session.principal_id",
+        "principal.issuer",
+        "principal.subject",
+        "principal.kind",
+        "session.domain_id",
+        "session.state",
+        "session.created_at",
+        "session.expires_at",
+        "session.revoked_at",
+        "session.revoked_by_principal_id",
+      ])
+      .where("session.account_id", "=", accountId)
+      .orderBy("session.created_at", "desc")
+      .orderBy("session.session_id", "asc"),
+  ).rows.map(mapSession);
+}
+
+export function revokeTeamsSession(
+  input: DatabaseInput & {
+    id: string;
+    revokedByPrincipalId: string;
+    now?: number;
+  },
+): void {
+  const id = requiredIdentifier(input.id, "Teams session id");
+  const revokedByPrincipalId = requiredIdentifier(
+    input.revokedByPrincipalId,
+    "Teams session revoking principal id",
+  );
+  runOpenClawStateWriteTransaction(({ db }) => {
+    const kysely = getTeamsIdentityKysely(db);
+    const row = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("teams_sessions")
+        .select(["state", "created_at"])
+        .where("session_id", "=", id),
+    );
+    if (!row) {
+      throw new Error("unknown Teams session");
+    }
+    if (row.state === "revoked") {
+      return;
+    }
+    executeSqliteQuerySync(
+      db,
+      kysely
+        .updateTable("teams_sessions")
+        .set({
+          state: "revoked",
+          revoked_at: input.now ?? Date.now(),
+          revoked_by_principal_id: revokedByPrincipalId,
+        })
+        .where("session_id", "=", id)
+        .where("state", "=", "active"),
+    );
+  }, input.database);
+}

--- a/src/gateway/authorization/teams-identity.ts
+++ b/src/gateway/authorization/teams-identity.ts
@@ -331,6 +331,53 @@ export function resolveTeamsSession(
   return row ? mapSession(row) : undefined;
 }
 
+/** Resolves one active session by its server-private id for established WS revalidation. */
+export function resolveTeamsSessionById(
+  input: DatabaseInput & { id: string; now?: number },
+): TeamsSession | undefined {
+  const id = requiredIdentifier(input.id, "Teams session id");
+  const now = input.now ?? Date.now();
+  const { db } = openOpenClawStateDatabase(input.database);
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    getTeamsIdentityKysely(db)
+      .selectFrom("teams_sessions as session")
+      .innerJoin("teams_local_accounts as account", (join) =>
+        join
+          .onRef("account.account_id", "=", "session.account_id")
+          .onRef("account.principal_id", "=", "session.principal_id"),
+      )
+      .innerJoin("authorization_domain_memberships as membership", (join) =>
+        join
+          .onRef("membership.domain_id", "=", "session.domain_id")
+          .onRef("membership.principal_id", "=", "session.principal_id"),
+      )
+      .innerJoin(
+        "authorization_principals as principal",
+        "principal.principal_id",
+        "session.principal_id",
+      )
+      .select([
+        "session.session_id",
+        "session.account_id",
+        "session.principal_id",
+        "principal.issuer",
+        "principal.subject",
+        "principal.kind",
+        "session.domain_id",
+        "session.state",
+        "session.created_at",
+        "session.expires_at",
+        "session.revoked_at",
+        "session.revoked_by_principal_id",
+      ])
+      .where("session.session_id", "=", id)
+      .where("session.state", "=", "active")
+      .where("session.expires_at", ">", now),
+  );
+  return row ? mapSession(row) : undefined;
+}
+
 export function listTeamsSessions(
   input: DatabaseInput & { accountId: string },
 ): readonly TeamsSession[] {

--- a/src/gateway/authorization/teams-invites.test.ts
+++ b/src/gateway/authorization/teams-invites.test.ts
@@ -1,0 +1,428 @@
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
+import type { GatewayResourceRef } from "./contracts.js";
+import {
+  bindAuthorizationResource,
+  createIsolationDomain,
+  putAuthorizationPrincipal,
+  retireAuthorizationResource,
+} from "./state-store.js";
+import { resolveTeamsSession } from "./teams-identity.js";
+import {
+  createTeamsInvite,
+  listTeamsInvites,
+  redeemTeamsInvite,
+  registerTeamsLocalAccountFromInvite,
+  revokeTeamsInvite,
+} from "./teams-invites.js";
+
+const tempDirs: string[] = [];
+const owner = {
+  id: "principal-owner",
+  principal: { issuer: "local", subject: "owner", kind: "human" },
+} as const;
+const recipient = {
+  id: "principal-recipient",
+  principal: { issuer: "local", subject: "recipient", kind: "human" },
+} as const;
+const workspace: GatewayResourceRef = {
+  namespace: "workspaces",
+  type: "workspace",
+  id: "workspace-1",
+};
+const tab: GatewayResourceRef = { namespace: "workspaces", type: "tab", id: "tab-1" };
+
+function createDatabase() {
+  return { path: `${makeTempDir(tempDirs, "openclaw-teams-invite-")}/openclaw.sqlite` };
+}
+
+function seed(database: ReturnType<typeof createDatabase>) {
+  putAuthorizationPrincipal({ ...owner, database });
+  putAuthorizationPrincipal({ ...recipient, database });
+  createIsolationDomain({ id: "domain-1", ownerPrincipalId: owner.id, database });
+  bindAuthorizationResource({
+    domainId: "domain-1",
+    resource: workspace,
+    ownerPrincipalId: owner.id,
+    database,
+  });
+  bindAuthorizationResource({
+    domainId: "domain-1",
+    resource: tab,
+    parent: workspace,
+    ownerPrincipalId: owner.id,
+    database,
+  });
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
+
+afterAll(() => {
+  cleanupTempDirs(tempDirs);
+});
+
+describe("Teams one-time invites", () => {
+  it("stores only a code digest and lists an exact safe grant manifest", () => {
+    const database = createDatabase();
+    seed(database);
+    const created = createTeamsInvite({
+      id: "invite-1",
+      domainId: "domain-1",
+      createdByPrincipalId: owner.id,
+      recipientLabel: "  teammate@example.com ",
+      ttlMs: 60_000,
+      grants: [
+        { resource: tab, permission: "workspaces.tab.read" },
+        { resource: tab, permission: "workspaces.tab.request-changes" },
+      ],
+      database,
+    });
+
+    expect(created.code).toMatch(/^[A-Za-z0-9_-]{40,}$/);
+    expect(created.invite).toEqual({
+      id: "invite-1",
+      domainId: "domain-1",
+      createdByPrincipalId: owner.id,
+      recipientLabel: "teammate@example.com",
+      state: "active",
+      createdAt: expect.any(Number),
+      expiresAt: expect.any(Number),
+      redeemedAt: null,
+      redeemedByPrincipalId: null,
+      revokedAt: null,
+      grants: [
+        { resource: tab, permission: "workspaces.tab.read" },
+        { resource: tab, permission: "workspaces.tab.request-changes" },
+      ],
+    });
+    expect(
+      listTeamsInvites({ domainId: "domain-1", requestedByPrincipalId: owner.id, database }),
+    ).toEqual([created.invite]);
+    expect(JSON.stringify(created.invite)).not.toContain(created.code);
+
+    const { db } = openOpenClawStateDatabase(database);
+    const row = db
+      .prepare("SELECT code_digest FROM teams_invites WHERE invite_id = ?")
+      .get(created.invite.id) as { code_digest: string };
+    expect(row.code_digest).toMatch(/^[a-f0-9]{64}$/);
+    expect(row.code_digest).not.toBe(created.code);
+  });
+
+  it("requires a current human domain owner and active exact resources", () => {
+    const database = createDatabase();
+    seed(database);
+    expect(() =>
+      createTeamsInvite({
+        domainId: "domain-1",
+        createdByPrincipalId: recipient.id,
+        ttlMs: 60_000,
+        grants: [{ resource: tab, permission: "workspaces.tab.read" }],
+        database,
+      }),
+    ).toThrow(/domain owner/i);
+    expect(() =>
+      createTeamsInvite({
+        domainId: "domain-1",
+        createdByPrincipalId: owner.id,
+        ttlMs: 60_000,
+        grants: [{ resource: { ...tab, id: "missing-tab" }, permission: "workspaces.tab.read" }],
+        database,
+      }),
+    ).toThrow(/active resource/i);
+  });
+
+  it("atomically redeems once into membership and exact grants", () => {
+    const database = createDatabase();
+    seed(database);
+    const created = createTeamsInvite({
+      id: "invite-1",
+      domainId: "domain-1",
+      createdByPrincipalId: owner.id,
+      ttlMs: 60_000,
+      now: 10_000,
+      grants: [{ resource: tab, permission: "workspaces.tab.read" }],
+      database,
+    });
+
+    const redeemed = redeemTeamsInvite({
+      code: created.code,
+      principalId: recipient.id,
+      now: 20_000,
+      database,
+    });
+    expect(redeemed).toMatchObject({
+      id: "invite-1",
+      state: "redeemed",
+      redeemedAt: 20_000,
+      redeemedByPrincipalId: recipient.id,
+    });
+
+    const { db } = openOpenClawStateDatabase(database);
+    expect(
+      db
+        .prepare(
+          "SELECT role FROM authorization_domain_memberships WHERE domain_id = ? AND principal_id = ?",
+        )
+        .get("domain-1", recipient.id),
+    ).toEqual({ role: "member" });
+    expect(
+      db
+        .prepare(
+          `SELECT permission FROM authorization_grants
+            WHERE domain_id = ? AND principal_id = ? AND namespace = ? AND resource_type = ? AND resource_id = ?`,
+        )
+        .all("domain-1", recipient.id, tab.namespace, tab.type, tab.id),
+    ).toEqual([{ permission: "workspaces.tab.read" }]);
+  });
+
+  it("atomically registers a local account, redeems its invite, and issues the domain session", async () => {
+    const database = createDatabase();
+    seed(database);
+    const created = createTeamsInvite({
+      id: "invite-registration",
+      domainId: "domain-1",
+      createdByPrincipalId: owner.id,
+      ttlMs: 60_000,
+      now: 10_000,
+      grants: [{ resource: tab, permission: "workspaces.tab.read" }],
+      database,
+    });
+
+    const registration = await registerTeamsLocalAccountFromInvite({
+      code: created.code,
+      accountId: "account-new",
+      principalId: "principal-new",
+      loginLabel: " New.User@Example.com ",
+      password: "correct horse battery staple",
+      sessionTtlMs: 60_000,
+      now: 20_000,
+      database,
+    });
+
+    expect(registration.account).toEqual({
+      id: "account-new",
+      principalId: "principal-new",
+      loginLabel: "new.user@example.com",
+      createdAt: 20_000,
+    });
+    expect(registration.invite).toMatchObject({
+      id: "invite-registration",
+      state: "redeemed",
+      redeemedByPrincipalId: "principal-new",
+    });
+    expect(registration.session.session).toMatchObject({
+      accountId: "account-new",
+      principalId: "principal-new",
+      principal: {
+        issuer: "openclaw-local",
+        subject: "new.user@example.com",
+        kind: "human",
+      },
+      domainId: "domain-1",
+    });
+    expect(
+      resolveTeamsSession({ token: registration.session.token, now: 20_001, database }),
+    ).toEqual(registration.session.session);
+  });
+
+  it("leaves no principal or account when invite registration is invalid or loses redemption", async () => {
+    const database = createDatabase();
+    seed(database);
+    await expect(
+      registerTeamsLocalAccountFromInvite({
+        code: "unknown-code",
+        accountId: "account-invalid",
+        principalId: "principal-invalid",
+        loginLabel: "invalid@example.com",
+        password: "correct horse battery staple",
+        sessionTtlMs: 60_000,
+        database,
+      }),
+    ).rejects.toThrow("invite is invalid or unavailable");
+
+    const created = createTeamsInvite({
+      id: "invite-race",
+      domainId: "domain-1",
+      createdByPrincipalId: owner.id,
+      ttlMs: 60_000,
+      grants: [{ resource: tab, permission: "workspaces.tab.read" }],
+      database,
+    });
+    const results = await Promise.allSettled([
+      registerTeamsLocalAccountFromInvite({
+        code: created.code,
+        accountId: "account-contender-1",
+        principalId: "principal-contender-1",
+        loginLabel: "contender-1@example.com",
+        password: "correct horse battery staple",
+        sessionTtlMs: 60_000,
+        database,
+      }),
+      registerTeamsLocalAccountFromInvite({
+        code: created.code,
+        accountId: "account-contender-2",
+        principalId: "principal-contender-2",
+        loginLabel: "contender-2@example.com",
+        password: "correct horse battery staple",
+        sessionTtlMs: 60_000,
+        database,
+      }),
+    ]);
+    expect(results.map((result) => result.status).toSorted()).toEqual(["fulfilled", "rejected"]);
+    const rejected = results.find((result) => result.status === "rejected");
+    expect(rejected?.reason).toEqual(new Error("invite is invalid or unavailable"));
+
+    const { db } = openOpenClawStateDatabase(database);
+    expect(
+      db
+        .prepare("SELECT principal_id FROM authorization_principals WHERE principal_id IN (?, ?)")
+        .all("principal-contender-1", "principal-contender-2"),
+    ).toHaveLength(1);
+    expect(
+      db
+        .prepare("SELECT account_id FROM teams_local_accounts WHERE account_id IN (?, ?)")
+        .all("account-contender-1", "account-contender-2"),
+    ).toHaveLength(1);
+    expect(
+      db
+        .prepare("SELECT 1 AS found FROM authorization_principals WHERE principal_id = ?")
+        .get("principal-invalid"),
+    ).toBeUndefined();
+    expect(
+      db
+        .prepare("SELECT 1 AS found FROM teams_local_accounts WHERE account_id = ?")
+        .get("account-invalid"),
+    ).toBeUndefined();
+  });
+
+  it("uses one generic failure for replay, expiry, revocation, and unknown codes", () => {
+    const database = createDatabase();
+    seed(database);
+    const replay = createTeamsInvite({
+      domainId: "domain-1",
+      createdByPrincipalId: owner.id,
+      ttlMs: 60_000,
+      now: 10_000,
+      grants: [{ resource: tab, permission: "workspaces.tab.read" }],
+      database,
+    });
+    redeemTeamsInvite({ code: replay.code, principalId: recipient.id, now: 20_000, database });
+
+    const expired = createTeamsInvite({
+      domainId: "domain-1",
+      createdByPrincipalId: owner.id,
+      ttlMs: 60_000,
+      now: 30_000,
+      grants: [{ resource: tab, permission: "workspaces.tab.read" }],
+      database,
+    });
+    const revoked = createTeamsInvite({
+      domainId: "domain-1",
+      createdByPrincipalId: owner.id,
+      ttlMs: 60_000,
+      now: 40_000,
+      grants: [{ resource: tab, permission: "workspaces.tab.read" }],
+      database,
+    });
+    revokeTeamsInvite({
+      id: revoked.invite.id,
+      domainId: "domain-1",
+      revokedByPrincipalId: owner.id,
+      now: 45_000,
+      database,
+    });
+
+    const messages = [
+      () =>
+        redeemTeamsInvite({ code: replay.code, principalId: recipient.id, now: 50_000, database }),
+      () =>
+        redeemTeamsInvite({ code: expired.code, principalId: recipient.id, now: 90_000, database }),
+      () =>
+        redeemTeamsInvite({ code: revoked.code, principalId: recipient.id, now: 50_000, database }),
+      () =>
+        redeemTeamsInvite({
+          code: "unknown-code",
+          principalId: recipient.id,
+          now: 50_000,
+          database,
+        }),
+    ].map((redeem) => {
+      try {
+        redeem();
+        return "unexpected success";
+      } catch (error) {
+        return error instanceof Error ? error.message : String(error);
+      }
+    });
+    expect(new Set(messages)).toEqual(new Set(["invite is invalid or unavailable"]));
+  });
+
+  it("fails generically and atomically when a shared resource retires before redemption", () => {
+    const database = createDatabase();
+    seed(database);
+    const created = createTeamsInvite({
+      domainId: "domain-1",
+      createdByPrincipalId: owner.id,
+      ttlMs: 60_000,
+      grants: [{ resource: tab, permission: "workspaces.tab.read" }],
+      database,
+    });
+    retireAuthorizationResource({
+      domainId: "domain-1",
+      resource: tab,
+      retiredByPrincipalId: owner.id,
+      database,
+    });
+
+    expect(() =>
+      redeemTeamsInvite({ code: created.code, principalId: recipient.id, database }),
+    ).toThrow("invite is invalid or unavailable");
+    const { db } = openOpenClawStateDatabase(database);
+    expect(
+      db
+        .prepare(
+          "SELECT 1 AS found FROM authorization_domain_memberships WHERE domain_id = ? AND principal_id = ?",
+        )
+        .get("domain-1", recipient.id),
+    ).toBeUndefined();
+  });
+
+  it("guards invite payload and terminal states against direct SQL mutation", () => {
+    const database = createDatabase();
+    seed(database);
+    const created = createTeamsInvite({
+      id: "invite-1",
+      domainId: "domain-1",
+      createdByPrincipalId: owner.id,
+      ttlMs: 60_000,
+      grants: [{ resource: tab, permission: "workspaces.tab.read" }],
+      database,
+    });
+    revokeTeamsInvite({
+      id: created.invite.id,
+      domainId: "domain-1",
+      revokedByPrincipalId: owner.id,
+      database,
+    });
+    const { db } = openOpenClawStateDatabase(database);
+    expect(() =>
+      db
+        .prepare("UPDATE teams_invites SET state = 'active', revoked_at = NULL WHERE invite_id = ?")
+        .run(created.invite.id),
+    ).toThrow(/terminal/i);
+    expect(() =>
+      db
+        .prepare("UPDATE teams_invites SET code_digest = ? WHERE invite_id = ?")
+        .run("x", created.invite.id),
+    ).toThrow(/immutable/i);
+    expect(() =>
+      db.prepare("DELETE FROM teams_invites WHERE invite_id = ?").run(created.invite.id),
+    ).toThrow(/cannot be deleted/i);
+  });
+});

--- a/src/gateway/authorization/teams-invites.test.ts
+++ b/src/gateway/authorization/teams-invites.test.ts
@@ -246,6 +246,36 @@ describe("Teams one-time invites", () => {
       }),
     ).rejects.toThrow("invite is invalid or unavailable");
 
+    const unsupported = createTeamsInvite({
+      id: "invite-unsupported",
+      domainId: "domain-1",
+      createdByPrincipalId: owner.id,
+      ttlMs: 60_000,
+      grants: [{ resource: tab, permission: "workspaces.tab.read" }],
+      database,
+    });
+    await expect(
+      registerTeamsLocalAccountFromInvite({
+        code: unsupported.code,
+        accountId: "account-unsupported",
+        principalId: "principal-unsupported",
+        loginLabel: "unsupported@example.com",
+        password: "correct horse battery staple",
+        sessionTtlMs: 60_000,
+        validateInvite: () => {
+          throw new Error("unsupported invite landing");
+        },
+        database,
+      }),
+    ).rejects.toThrow("unsupported invite landing");
+    expect(
+      listTeamsInvites({
+        domainId: "domain-1",
+        requestedByPrincipalId: owner.id,
+        database,
+      }).find((invite) => invite.id === unsupported.invite.id)?.state,
+    ).toBe("active");
+
     const created = createTeamsInvite({
       id: "invite-race",
       domainId: "domain-1",
@@ -298,6 +328,11 @@ describe("Teams one-time invites", () => {
       db
         .prepare("SELECT 1 AS found FROM teams_local_accounts WHERE account_id = ?")
         .get("account-invalid"),
+    ).toBeUndefined();
+    expect(
+      db
+        .prepare("SELECT 1 AS found FROM teams_local_accounts WHERE account_id = ?")
+        .get("account-unsupported"),
     ).toBeUndefined();
   });
 

--- a/src/gateway/authorization/teams-invites.ts
+++ b/src/gateway/authorization/teams-invites.ts
@@ -1,0 +1,657 @@
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import type { DatabaseSync } from "node:sqlite";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../../infra/kysely-sync.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabaseOptions,
+} from "../../state/openclaw-state-db.js";
+import type { GatewayResourceRef } from "./contracts.js";
+import {
+  createTeamsSession,
+  type CreatedTeamsSession,
+  type TeamsLocalAccount,
+} from "./teams-identity.js";
+import { normalizeTeamsLoginLabel, prepareTeamsPassword } from "./teams-password.js";
+
+type TeamsInviteDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  | "authorization_domain_memberships"
+  | "authorization_grants"
+  | "authorization_principals"
+  | "authorization_resources"
+  | "teams_invite_grants"
+  | "teams_invites"
+  | "teams_local_accounts"
+>;
+
+type DatabaseInput = { database?: OpenClawStateDatabaseOptions };
+const MIN_INVITE_TTL_MS = 60_000;
+const MAX_INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1_000;
+const INVITE_UNAVAILABLE_MESSAGE = "invite is invalid or unavailable";
+
+export type TeamsInviteGrant = Readonly<{
+  resource: GatewayResourceRef;
+  permission: string;
+}>;
+
+export type TeamsInvite = Readonly<{
+  id: string;
+  domainId: string;
+  createdByPrincipalId: string;
+  recipientLabel: string | null;
+  state: "active" | "redeemed" | "revoked";
+  createdAt: number;
+  expiresAt: number;
+  redeemedAt: number | null;
+  redeemedByPrincipalId: string | null;
+  revokedAt: number | null;
+  grants: readonly TeamsInviteGrant[];
+}>;
+
+export type CreatedTeamsInvite = Readonly<{
+  code: string;
+  invite: TeamsInvite;
+}>;
+
+export type RegisteredTeamsLocalAccountFromInvite = Readonly<{
+  account: TeamsLocalAccount;
+  invite: TeamsInvite;
+  session: CreatedTeamsSession;
+}>;
+
+type RedeemableInvite = Readonly<{
+  invite_id: string;
+  domain_id: string;
+  created_by_principal_id: string;
+}>;
+
+function getTeamsInviteKysely(db: DatabaseSync) {
+  return getNodeSqliteKysely<TeamsInviteDatabase>(db);
+}
+
+function requiredIdentifier(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return normalized;
+}
+
+function normalizeRecipientLabel(value: string | undefined): string | null {
+  if (value === undefined) {
+    return null;
+  }
+  const normalized = value.normalize("NFKC").trim().toLowerCase();
+  if (!normalized || normalized.length > 254) {
+    throw new Error("invite recipient label must contain between 1 and 254 characters");
+  }
+  // V1 deliberately treats this as display-only; possession of the opaque code is the proof.
+  return normalized;
+}
+
+function normalizeResource(resource: GatewayResourceRef): GatewayResourceRef {
+  return Object.freeze({
+    namespace: requiredIdentifier(resource.namespace, "invite resource namespace"),
+    type: requiredIdentifier(resource.type, "invite resource type"),
+    id: requiredIdentifier(resource.id, "invite resource id"),
+  });
+}
+
+function normalizeGrants(grants: readonly TeamsInviteGrant[]): readonly TeamsInviteGrant[] {
+  if (grants.length === 0 || grants.length > 100) {
+    throw new Error("Teams invite must contain between 1 and 100 grants");
+  }
+  const seen = new Set<string>();
+  return grants.map((grant) => {
+    const resource = normalizeResource(grant.resource);
+    const permission = requiredIdentifier(grant.permission, "invite permission");
+    const key = `${resource.namespace}\u0000${resource.type}\u0000${resource.id}\u0000${permission}`;
+    if (seen.has(key)) {
+      throw new Error("Teams invite contains a duplicate resource permission grant");
+    }
+    seen.add(key);
+    return Object.freeze({ resource, permission });
+  });
+}
+
+function validateTtl(ttlMs: number): void {
+  if (!Number.isSafeInteger(ttlMs) || ttlMs < MIN_INVITE_TTL_MS || ttlMs > MAX_INVITE_TTL_MS) {
+    throw new Error("Teams invite TTL is outside the supported range");
+  }
+}
+
+function digestInviteCode(code: string): string {
+  return createHash("sha256").update(code, "utf8").digest("hex");
+}
+
+function requireDomainOwner(db: DatabaseSync, domainId: string, principalId: string): void {
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    getTeamsInviteKysely(db)
+      .selectFrom("authorization_domain_memberships as membership")
+      .innerJoin(
+        "authorization_principals as principal",
+        "principal.principal_id",
+        "membership.principal_id",
+      )
+      .select(["membership.role", "principal.kind"])
+      .where("membership.domain_id", "=", domainId)
+      .where("membership.principal_id", "=", principalId),
+  );
+  if (row?.role !== "owner" || row.kind !== "human") {
+    throw new Error("Teams invite creator must be the current human domain owner");
+  }
+}
+
+function mapInviteGrant(row: {
+  namespace: string;
+  resource_type: string;
+  resource_id: string;
+  permission: string;
+}): TeamsInviteGrant {
+  return Object.freeze({
+    resource: Object.freeze({
+      namespace: row.namespace,
+      type: row.resource_type,
+      id: row.resource_id,
+    }),
+    permission: row.permission,
+  });
+}
+
+function mapInvite(
+  row: {
+    invite_id: string;
+    domain_id: string;
+    created_by_principal_id: string;
+    recipient_label: string | null;
+    state: string;
+    created_at: number;
+    expires_at: number;
+    redeemed_at: number | null;
+    redeemed_by_principal_id: string | null;
+    revoked_at: number | null;
+  },
+  grants: readonly TeamsInviteGrant[],
+): TeamsInvite {
+  if (row.state !== "active" && row.state !== "redeemed" && row.state !== "revoked") {
+    throw new Error("Teams invite has an invalid persisted state");
+  }
+  return Object.freeze({
+    id: row.invite_id,
+    domainId: row.domain_id,
+    createdByPrincipalId: row.created_by_principal_id,
+    recipientLabel: row.recipient_label,
+    state: row.state,
+    createdAt: row.created_at,
+    expiresAt: row.expires_at,
+    redeemedAt: row.redeemed_at,
+    redeemedByPrincipalId: row.redeemed_by_principal_id,
+    revokedAt: row.revoked_at,
+    grants: Object.freeze([...grants]),
+  });
+}
+
+function loadInvite(db: DatabaseSync, inviteId: string): TeamsInvite | undefined {
+  const kysely = getTeamsInviteKysely(db);
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    kysely
+      .selectFrom("teams_invites")
+      .select([
+        "invite_id",
+        "domain_id",
+        "created_by_principal_id",
+        "recipient_label",
+        "state",
+        "created_at",
+        "expires_at",
+        "redeemed_at",
+        "redeemed_by_principal_id",
+        "revoked_at",
+      ])
+      .where("invite_id", "=", inviteId),
+  );
+  if (!row) {
+    return undefined;
+  }
+  const grants = executeSqliteQuerySync(
+    db,
+    kysely
+      .selectFrom("teams_invite_grants")
+      .select(["namespace", "resource_type", "resource_id", "permission"])
+      .where("invite_id", "=", inviteId)
+      .orderBy("created_at", "asc")
+      .orderBy("namespace", "asc")
+      .orderBy("resource_type", "asc")
+      .orderBy("resource_id", "asc")
+      .orderBy("permission", "asc"),
+  ).rows.map(mapInviteGrant);
+  return mapInvite(row, grants);
+}
+
+function loadRedeemableInvite(db: DatabaseSync, codeDigest: string, now: number): RedeemableInvite {
+  const invite = executeSqliteQueryTakeFirstSync(
+    db,
+    getTeamsInviteKysely(db)
+      .selectFrom("teams_invites")
+      .select(["invite_id", "domain_id", "created_by_principal_id"])
+      .where("code_digest", "=", codeDigest)
+      .where("state", "=", "active")
+      .where("expires_at", ">", now),
+  );
+  if (!invite) {
+    throw new Error(INVITE_UNAVAILABLE_MESSAGE);
+  }
+  return invite;
+}
+
+function redeemInviteForHumanPrincipal(input: {
+  db: DatabaseSync;
+  invite: RedeemableInvite;
+  principalId: string;
+  now: number;
+}): TeamsInvite {
+  const kysely = getTeamsInviteKysely(input.db);
+  const principal = executeSqliteQueryTakeFirstSync(
+    input.db,
+    kysely
+      .selectFrom("authorization_principals")
+      .select("kind")
+      .where("principal_id", "=", input.principalId),
+  );
+  if (principal?.kind !== "human") {
+    throw new Error(INVITE_UNAVAILABLE_MESSAGE);
+  }
+  const grants = executeSqliteQuerySync(
+    input.db,
+    kysely
+      .selectFrom("teams_invite_grants as manifest")
+      .innerJoin("authorization_resources as resource", (join) =>
+        join
+          .onRef("resource.domain_id", "=", "manifest.domain_id")
+          .onRef("resource.namespace", "=", "manifest.namespace")
+          .onRef("resource.resource_type", "=", "manifest.resource_type")
+          .onRef("resource.resource_id", "=", "manifest.resource_id"),
+      )
+      .select([
+        "manifest.namespace",
+        "manifest.resource_type",
+        "manifest.resource_id",
+        "manifest.permission",
+      ])
+      .where("manifest.invite_id", "=", input.invite.invite_id)
+      .where("resource.retired_at", "is", null),
+  ).rows;
+  const manifestCount = executeSqliteQueryTakeFirstSync(
+    input.db,
+    kysely
+      .selectFrom("teams_invite_grants")
+      .select((select) => select.fn.countAll<number>().as("count"))
+      .where("invite_id", "=", input.invite.invite_id),
+  )?.count;
+  if (grants.length === 0 || grants.length !== manifestCount) {
+    throw new Error(INVITE_UNAVAILABLE_MESSAGE);
+  }
+
+  executeSqliteQuerySync(
+    input.db,
+    kysely
+      .insertInto("authorization_domain_memberships")
+      .values({
+        domain_id: input.invite.domain_id,
+        principal_id: input.principalId,
+        role: "member",
+        added_by_principal_id: input.invite.created_by_principal_id,
+        added_by_role: "owner",
+        created_at: input.now,
+      })
+      .onConflict((conflict) => conflict.columns(["domain_id", "principal_id"]).doNothing()),
+  );
+  for (const grant of grants) {
+    executeSqliteQuerySync(
+      input.db,
+      kysely
+        .insertInto("authorization_grants")
+        .values({
+          domain_id: input.invite.domain_id,
+          principal_id: input.principalId,
+          namespace: grant.namespace,
+          resource_type: grant.resource_type,
+          resource_id: grant.resource_id,
+          permission: grant.permission,
+          granted_by_principal_id: input.invite.created_by_principal_id,
+          created_at: input.now,
+        })
+        .onConflict((conflict) =>
+          conflict
+            .columns([
+              "domain_id",
+              "principal_id",
+              "namespace",
+              "resource_type",
+              "resource_id",
+              "permission",
+            ])
+            .doNothing(),
+        ),
+    );
+  }
+  const claimed = executeSqliteQuerySync(
+    input.db,
+    kysely
+      .updateTable("teams_invites")
+      .set({
+        state: "redeemed",
+        redeemed_at: input.now,
+        redeemed_by_principal_id: input.principalId,
+      })
+      .where("invite_id", "=", input.invite.invite_id)
+      .where("state", "=", "active")
+      .where("expires_at", ">", input.now),
+  );
+  if (claimed.numAffectedRows !== 1n) {
+    throw new Error(INVITE_UNAVAILABLE_MESSAGE);
+  }
+  const loaded = loadInvite(input.db, input.invite.invite_id);
+  if (!loaded) {
+    throw new Error(INVITE_UNAVAILABLE_MESSAGE);
+  }
+  return loaded;
+}
+
+export function createTeamsInvite(
+  input: DatabaseInput & {
+    id?: string;
+    domainId: string;
+    createdByPrincipalId: string;
+    recipientLabel?: string;
+    ttlMs: number;
+    grants: readonly TeamsInviteGrant[];
+    now?: number;
+  },
+): CreatedTeamsInvite {
+  const id = requiredIdentifier(input.id ?? randomUUID(), "Teams invite id");
+  const domainId = requiredIdentifier(input.domainId, "Teams invite domain id");
+  const createdByPrincipalId = requiredIdentifier(
+    input.createdByPrincipalId,
+    "Teams invite creator principal id",
+  );
+  const recipientLabel = normalizeRecipientLabel(input.recipientLabel);
+  const grants = normalizeGrants(input.grants);
+  validateTtl(input.ttlMs);
+  const code = randomBytes(32).toString("base64url");
+  const codeDigest = digestInviteCode(code);
+  const createdAt = input.now ?? Date.now();
+
+  const invite = runOpenClawStateWriteTransaction(({ db }) => {
+    requireDomainOwner(db, domainId, createdByPrincipalId);
+    const kysely = getTeamsInviteKysely(db);
+    for (const grant of grants) {
+      const resource = executeSqliteQueryTakeFirstSync(
+        db,
+        kysely
+          .selectFrom("authorization_resources")
+          .select("retired_at")
+          .where("domain_id", "=", domainId)
+          .where("namespace", "=", grant.resource.namespace)
+          .where("resource_type", "=", grant.resource.type)
+          .where("resource_id", "=", grant.resource.id),
+      );
+      if (!resource || resource.retired_at !== null) {
+        throw new Error("Teams invite grant must reference an active resource in the domain");
+      }
+    }
+
+    executeSqliteQuerySync(
+      db,
+      kysely.insertInto("teams_invites").values({
+        invite_id: id,
+        code_digest: codeDigest,
+        domain_id: domainId,
+        created_by_principal_id: createdByPrincipalId,
+        recipient_label: recipientLabel,
+        state: "active",
+        created_at: createdAt,
+        expires_at: createdAt + input.ttlMs,
+        redeemed_at: null,
+        redeemed_by_principal_id: null,
+        revoked_at: null,
+        revoked_by_principal_id: null,
+      }),
+    );
+    for (const grant of grants) {
+      executeSqliteQuerySync(
+        db,
+        kysely.insertInto("teams_invite_grants").values({
+          invite_id: id,
+          domain_id: domainId,
+          namespace: grant.resource.namespace,
+          resource_type: grant.resource.type,
+          resource_id: grant.resource.id,
+          permission: grant.permission,
+          created_at: createdAt,
+        }),
+      );
+    }
+    const loaded = loadInvite(db, id);
+    if (!loaded) {
+      throw new Error("failed to load the created Teams invite");
+    }
+    return loaded;
+  }, input.database);
+
+  return Object.freeze({ code, invite });
+}
+
+export function listTeamsInvites(
+  input: DatabaseInput & { domainId: string; requestedByPrincipalId: string },
+): readonly TeamsInvite[] {
+  const domainId = requiredIdentifier(input.domainId, "Teams invite domain id");
+  const requestedByPrincipalId = requiredIdentifier(
+    input.requestedByPrincipalId,
+    "Teams invite requesting principal id",
+  );
+  const { db } = openOpenClawStateDatabase(input.database);
+  requireDomainOwner(db, domainId, requestedByPrincipalId);
+  const ids = executeSqliteQuerySync(
+    db,
+    getTeamsInviteKysely(db)
+      .selectFrom("teams_invites")
+      .select("invite_id")
+      .where("domain_id", "=", domainId)
+      .orderBy("created_at", "desc")
+      .orderBy("invite_id", "asc"),
+  ).rows;
+  return ids.map(({ invite_id }) => {
+    const invite = loadInvite(db, invite_id);
+    if (!invite) {
+      throw new Error("Teams invite disappeared while listing");
+    }
+    return invite;
+  });
+}
+
+export function redeemTeamsInvite(
+  input: DatabaseInput & {
+    code: string;
+    principalId: string;
+    now?: number;
+  },
+): TeamsInvite {
+  const codeDigest = digestInviteCode(input.code);
+  const principalId = requiredIdentifier(input.principalId, "Teams invite recipient principal id");
+  const now = input.now ?? Date.now();
+
+  return runOpenClawStateWriteTransaction(({ db }) => {
+    const invite = loadRedeemableInvite(db, codeDigest, now);
+    return redeemInviteForHumanPrincipal({ db, invite, principalId, now });
+  }, input.database);
+}
+
+export async function registerTeamsLocalAccountFromInvite(
+  input: DatabaseInput & {
+    code: string;
+    accountId?: string;
+    principalId?: string;
+    loginLabel: string;
+    password: string;
+    sessionTtlMs: number;
+    now?: number;
+  },
+): Promise<RegisteredTeamsLocalAccountFromInvite> {
+  const codeDigest = digestInviteCode(input.code);
+  const accountId = requiredIdentifier(input.accountId ?? randomUUID(), "Teams account id");
+  const principalId = requiredIdentifier(input.principalId ?? randomUUID(), "Teams principal id");
+  const loginLabel = normalizeTeamsLoginLabel(input.loginLabel);
+  // Scrypt stays off the synchronous SQLite critical section; no identity rows exist yet.
+  const password = await prepareTeamsPassword(input.password);
+  const now = input.now ?? Date.now();
+  const principal = Object.freeze({
+    issuer: "openclaw-local",
+    subject: loginLabel,
+    kind: "human" as const,
+  });
+
+  return runOpenClawStateWriteTransaction(({ db }) => {
+    const kysely = getTeamsInviteKysely(db);
+    const invite = loadRedeemableInvite(db, codeDigest, now);
+    const existing = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("teams_local_accounts as account")
+        .leftJoin("authorization_principals as principal", (join) =>
+          join
+            .on("principal.principal_id", "=", principalId)
+            .on("principal.issuer", "=", principal.issuer)
+            .on("principal.subject", "=", principal.subject)
+            .on("principal.kind", "=", principal.kind),
+        )
+        .select(["account.account_id", "account.login_label", "principal.principal_id"])
+        .where((where) =>
+          where.or([
+            where("account.account_id", "=", accountId),
+            where("account.principal_id", "=", principalId),
+            where("account.login_label", "=", loginLabel),
+          ]),
+        ),
+    );
+    if (existing?.login_label === loginLabel) {
+      throw new Error("Teams login label is already in use");
+    }
+    if (existing) {
+      throw new Error("Teams account id or principal is already mapped");
+    }
+    const principalIdentity = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("authorization_principals")
+        .select("principal_id")
+        .where((where) =>
+          where.or([
+            where("principal_id", "=", principalId),
+            where.and([
+              where("issuer", "=", principal.issuer),
+              where("subject", "=", principal.subject),
+              where("kind", "=", principal.kind),
+            ]),
+          ]),
+        ),
+    );
+    if (principalIdentity) {
+      throw new Error("Teams account id or principal is already mapped");
+    }
+
+    executeSqliteQuerySync(
+      db,
+      kysely.insertInto("authorization_principals").values({
+        principal_id: principalId,
+        issuer: principal.issuer,
+        subject: principal.subject,
+        kind: principal.kind,
+        created_at: now,
+        updated_at: now,
+      }),
+    );
+    executeSqliteQuerySync(
+      db,
+      kysely.insertInto("teams_local_accounts").values({
+        account_id: accountId,
+        principal_id: principalId,
+        login_label: loginLabel,
+        password_salt: password.salt,
+        password_verifier: password.verifier,
+        password_scrypt_n: password.n,
+        password_scrypt_r: password.r,
+        password_scrypt_p: password.p,
+        created_at: now,
+      }),
+    );
+    const redeemedInvite = redeemInviteForHumanPrincipal({ db, invite, principalId, now });
+    const session = createTeamsSession({
+      accountId,
+      domainId: invite.domain_id,
+      ttlMs: input.sessionTtlMs,
+      now,
+      database: input.database,
+    });
+    const account = Object.freeze({ id: accountId, principalId, loginLabel, createdAt: now });
+    return Object.freeze({ account, invite: redeemedInvite, session });
+  }, input.database);
+}
+
+export function revokeTeamsInvite(
+  input: DatabaseInput & {
+    id: string;
+    domainId: string;
+    revokedByPrincipalId: string;
+    now?: number;
+  },
+): void {
+  const id = requiredIdentifier(input.id, "Teams invite id");
+  const domainId = requiredIdentifier(input.domainId, "Teams invite domain id");
+  const revokedByPrincipalId = requiredIdentifier(
+    input.revokedByPrincipalId,
+    "Teams invite revoking principal id",
+  );
+  runOpenClawStateWriteTransaction(({ db }) => {
+    requireDomainOwner(db, domainId, revokedByPrincipalId);
+    const kysely = getTeamsInviteKysely(db);
+    const row = executeSqliteQueryTakeFirstSync(
+      db,
+      kysely
+        .selectFrom("teams_invites")
+        .select("state")
+        .where("invite_id", "=", id)
+        .where("domain_id", "=", domainId),
+    );
+    if (!row) {
+      throw new Error("unknown Teams invite");
+    }
+    if (row.state === "revoked") {
+      return;
+    }
+    if (row.state !== "active") {
+      throw new Error("redeemed Teams invite cannot be revoked");
+    }
+    executeSqliteQuerySync(
+      db,
+      kysely
+        .updateTable("teams_invites")
+        .set({
+          state: "revoked",
+          revoked_at: input.now ?? Date.now(),
+          revoked_by_principal_id: revokedByPrincipalId,
+        })
+        .where("invite_id", "=", id)
+        .where("domain_id", "=", domainId)
+        .where("state", "=", "active"),
+    );
+  }, input.database);
+}

--- a/src/gateway/authorization/teams-invites.ts
+++ b/src/gateway/authorization/teams-invites.ts
@@ -63,6 +63,7 @@ export type RegisteredTeamsLocalAccountFromInvite = Readonly<{
   account: TeamsLocalAccount;
   invite: TeamsInvite;
   session: CreatedTeamsSession;
+  validation?: unknown;
 }>;
 
 type RedeemableInvite = Readonly<{
@@ -503,6 +504,7 @@ export async function registerTeamsLocalAccountFromInvite(
     loginLabel: string;
     password: string;
     sessionTtlMs: number;
+    validateInvite?: (invite: TeamsInvite) => unknown;
     now?: number;
   },
 ): Promise<RegisteredTeamsLocalAccountFromInvite> {
@@ -522,6 +524,11 @@ export async function registerTeamsLocalAccountFromInvite(
   return runOpenClawStateWriteTransaction(({ db }) => {
     const kysely = getTeamsInviteKysely(db);
     const invite = loadRedeemableInvite(db, codeDigest, now);
+    const loadedInvite = loadInvite(db, invite.invite_id);
+    if (!loadedInvite) {
+      throw new Error(INVITE_UNAVAILABLE_MESSAGE);
+    }
+    const validation = input.validateInvite?.(loadedInvite);
     const existing = executeSqliteQueryTakeFirstSync(
       db,
       kysely
@@ -602,7 +609,12 @@ export async function registerTeamsLocalAccountFromInvite(
       database: input.database,
     });
     const account = Object.freeze({ id: accountId, principalId, loginLabel, createdAt: now });
-    return Object.freeze({ account, invite: redeemedInvite, session });
+    return Object.freeze({
+      account,
+      invite: redeemedInvite,
+      session,
+      ...(input.validateInvite ? { validation } : {}),
+    });
   }, input.database);
 }
 

--- a/src/gateway/authorization/teams-password.ts
+++ b/src/gateway/authorization/teams-password.ts
@@ -1,0 +1,84 @@
+import { randomBytes, scrypt, timingSafeEqual } from "node:crypto";
+
+const KEY_LENGTH = 32;
+const SALT_LENGTH = 16;
+const MIN_PASSWORD_BYTES = 8;
+const MAX_PASSWORD_BYTES = 1_024;
+const DUMMY_SALT = Buffer.alloc(SALT_LENGTH, 0xa5);
+const DUMMY_VERIFIER = Buffer.alloc(KEY_LENGTH, 0x5a);
+
+export const TEAMS_PASSWORD_SCRYPT = Object.freeze({
+  N: 16_384,
+  r: 8,
+  p: 1,
+  maxmem: 32 * 1024 * 1024,
+});
+
+export type TeamsPasswordCredential = Readonly<{
+  salt: Uint8Array;
+  verifier: Uint8Array;
+  n: number;
+  r: number;
+  p: number;
+}>;
+
+export function normalizeTeamsLoginLabel(value: string): string {
+  const normalized = value.normalize("NFKC").trim().toLowerCase();
+  if (!normalized || normalized.length > 254) {
+    throw new Error("login label must contain between 1 and 254 characters");
+  }
+  return normalized;
+}
+
+function validatePassword(password: string): void {
+  const byteLength = Buffer.byteLength(password, "utf8");
+  if (byteLength < MIN_PASSWORD_BYTES || byteLength > MAX_PASSWORD_BYTES) {
+    throw new Error(
+      `password must contain between ${MIN_PASSWORD_BYTES} and ${MAX_PASSWORD_BYTES} UTF-8 bytes`,
+    );
+  }
+}
+
+function derive(password: string, salt: Uint8Array): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    scrypt(password, salt, KEY_LENGTH, TEAMS_PASSWORD_SCRYPT, (error, derivedKey) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(derivedKey);
+    });
+  });
+}
+
+export async function prepareTeamsPassword(password: string): Promise<TeamsPasswordCredential> {
+  validatePassword(password);
+  const salt = randomBytes(SALT_LENGTH);
+  const verifier = await derive(password, salt);
+  return Object.freeze({
+    salt,
+    verifier,
+    n: TEAMS_PASSWORD_SCRYPT.N,
+    r: TEAMS_PASSWORD_SCRYPT.r,
+    p: TEAMS_PASSWORD_SCRYPT.p,
+  });
+}
+
+export async function verifyTeamsPassword(
+  password: string,
+  stored: TeamsPasswordCredential | undefined,
+): Promise<boolean> {
+  try {
+    validatePassword(password);
+  } catch {
+    return false;
+  }
+  const parametersAreCurrent =
+    stored?.n === TEAMS_PASSWORD_SCRYPT.N &&
+    stored.r === TEAMS_PASSWORD_SCRYPT.r &&
+    stored.p === TEAMS_PASSWORD_SCRYPT.p;
+  const salt = parametersAreCurrent ? stored.salt : DUMMY_SALT;
+  const expected = parametersAreCurrent ? stored.verifier : DUMMY_VERIFIER;
+  const actual = await derive(password, salt);
+  return parametersAreCurrent && timingSafeEqual(actual, Buffer.from(expected));
+}

--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -402,6 +402,32 @@ describe("gateway broadcaster", () => {
     expect(workerSocket.send).not.toHaveBeenCalled();
   });
 
+  it("never sends gateway-global events to Teams members", () => {
+    const memberSocket = makeRecordingSocket();
+    const operatorSocket = makeRecordingSocket();
+    const clients = new Set<GatewayWsClient>([
+      makeGatewayWsClient("c-member", memberSocket, {
+        role: "member",
+        scopes: [],
+      } as unknown as GatewayWsClient["connect"]),
+      makeOperatorWsClient("c-operator", operatorSocket, ["operator.read"]),
+    ]);
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    for (const event of ["presence", "health", "heartbeat", "tick", "update.available"]) {
+      broadcast(event, { marker: "other-domain" });
+    }
+
+    expect(memberSocket.sent).toEqual([]);
+    expect(sentEvents(operatorSocket)).toEqual([
+      "presence",
+      "health",
+      "heartbeat",
+      "tick",
+      "update.available",
+    ]);
+  });
+
   it("filters approval and pairing events by scope", () => {
     const approvalsSocket: TestSocket = {
       bufferedAmount: 0,

--- a/src/gateway/http-auth-utils.ts
+++ b/src/gateway/http-auth-utils.ts
@@ -41,6 +41,7 @@ export function getBearerToken(req: IncomingMessage): string | undefined {
 type SharedSecretGatewayAuth = Pick<ResolvedGatewayAuth, "mode">;
 export type AuthorizedGatewayHttpRequest = {
   authMethod?: GatewayAuthResult["method"];
+  principal?: GatewayAuthResult["principal"];
   trustDeclaredOperatorScopes: boolean;
 };
 
@@ -133,6 +134,7 @@ export async function checkGatewayHttpRequestAuth(params: {
     ok: true,
     requestAuth: {
       authMethod: authResult.method,
+      ...(authResult.principal ? { principal: authResult.principal } : {}),
       // Shared-secret bearer auth proves possession of the gateway secret, but it
       // does not prove a narrower per-request operator identity. HTTP endpoints
       // must opt in explicitly if they want to treat that shared-secret path as a

--- a/src/gateway/http-utils.authorize-request.test.ts
+++ b/src/gateway/http-utils.authorize-request.test.ts
@@ -66,10 +66,15 @@ describe("authorizeGatewayHttpRequestOrReply", () => {
   });
 
   it("keeps trusted-proxy requests eligible for declared HTTP scopes", async () => {
+    const principal = {
+      issuer: "trusted-proxy",
+      subject: "operator",
+      kind: "human" as const,
+    };
     vi.mocked(authorizeHttpGatewayConnect).mockResolvedValue({
       ok: true,
       method: "trusted-proxy",
-      user: "operator",
+      principal,
     });
 
     await expect(
@@ -85,6 +90,7 @@ describe("authorizeGatewayHttpRequestOrReply", () => {
       }),
     ).resolves.toEqual({
       authMethod: "trusted-proxy",
+      principal,
       trustDeclaredOperatorScopes: true,
     });
   });
@@ -93,7 +99,11 @@ describe("authorizeGatewayHttpRequestOrReply", () => {
     vi.mocked(authorizeHttpGatewayConnect).mockResolvedValue({
       ok: true,
       method: "trusted-proxy",
-      user: "operator",
+      principal: {
+        issuer: "trusted-proxy",
+        subject: "operator",
+        kind: "human",
+      },
     });
 
     await authorizeGatewayHttpRequestOrReply({

--- a/src/gateway/local-request-context.test.ts
+++ b/src/gateway/local-request-context.test.ts
@@ -4,11 +4,14 @@
 import { beforeAll, describe, expect, it } from "vitest";
 import type { CliDeps } from "../cli/deps.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
+import type { GatewayAuthorizationRuntime } from "./authorization/contracts.js";
 import { withLocalGatewayRequestScope } from "./local-request-context.js";
 import { dispatchGatewayMethodInProcessRaw } from "./server-plugins.js";
 
 describe("local gateway request context", () => {
   let response: Awaited<ReturnType<typeof dispatchGatewayMethodInProcessRaw>>;
+  let authorization: GatewayAuthorizationRuntime | undefined;
 
   beforeAll(async () => {
     const cfg = {
@@ -22,15 +25,21 @@ describe("local gateway request context", () => {
         deps: {} as CliDeps,
         getRuntimeConfig: () => cfg,
       },
-      () =>
-        dispatchGatewayMethodInProcessRaw("agent.identity.get", {
+      () => {
+        authorization = getPluginRuntimeGatewayRequestScope()?.context?.authorization;
+        return dispatchGatewayMethodInProcessRaw("agent.identity.get", {
           agentId: "main",
-        }),
+        });
+      },
     );
   });
 
   it("lets embedded local runs dispatch gateway methods in-process", () => {
     expect(response.ok).toBe(true);
     expect(response.payload).toMatchObject({ agentId: "main" });
+  });
+
+  it("keeps embedded local authorization explicitly dormant", () => {
+    expect(authorization).toEqual({ mode: "legacy" });
   });
 });

--- a/src/gateway/local-request-context.ts
+++ b/src/gateway/local-request-context.ts
@@ -74,6 +74,7 @@ function createLocalGatewayRequestContext(
     }
   };
   return {
+    authorization: { mode: "legacy" },
     deps: params.deps,
     cron: unavailableCron,
     cronStorePath: "",

--- a/src/gateway/mcp-grant-store.test.ts
+++ b/src/gateway/mcp-grant-store.test.ts
@@ -100,6 +100,18 @@ describe("mcp-grant-store", () => {
     const context = {
       sessionKey: " agent:main:telegram:group:1 ",
       sessionId: "session-1",
+      authorizationSubject: {
+        principal: { issuer: "core", subject: "agent:main", kind: "service" as const },
+        domain: { id: "domain-1" },
+        agentSession: {
+          id: "binding-1",
+          invokingPrincipal: {
+            issuer: "trusted-proxy",
+            subject: "owner@example.com",
+            kind: "human" as const,
+          },
+        },
+      },
       messageProvider: "telegram",
       clientCaps: ["tool-events"],
       currentChannelId: "telegram:-1001",
@@ -126,7 +138,11 @@ describe("mcp-grant-store", () => {
     ).toBe(true);
 
     context.clientCaps.push("caller-mutation");
+    context.authorizationSubject.domain.id = "caller-mutation";
     grant.context.clientCaps?.push("return-value-mutation");
+    if (grant.context.authorizationSubject) {
+      (grant.context.authorizationSubject.domain as { id: string }).id = "return-value-mutation";
+    }
 
     expect(
       resolveMcpLoopbackClientGrant({
@@ -138,6 +154,18 @@ describe("mcp-grant-store", () => {
       ...context,
       sessionKey: "agent:main:telegram:group:1",
       clientCaps: ["tool-events"],
+      authorizationSubject: {
+        principal: { issuer: "core", subject: "agent:main", kind: "service" },
+        domain: { id: "domain-1" },
+        agentSession: {
+          id: "binding-1",
+          invokingPrincipal: {
+            issuer: "trusted-proxy",
+            subject: "owner@example.com",
+            kind: "human",
+          },
+        },
+      },
     });
   });
 

--- a/src/gateway/mcp-grant-store.ts
+++ b/src/gateway/mcp-grant-store.ts
@@ -7,6 +7,7 @@ import type {
 } from "../auto-reply/get-reply-options.types.js";
 import type { InboundEventKind } from "../channels/inbound-event/kind.js";
 import type { PluginHookChannelContext } from "../plugins/hook-types.js";
+import type { GatewayAuthorizationSubject } from "./authorization/contracts.js";
 
 export type McpLoopbackRequestContext = {
   sessionKey: string;
@@ -14,6 +15,7 @@ export type McpLoopbackRequestContext = {
   agentId?: string;
   sessionId?: string;
   runId?: string;
+  authorizationSubject?: GatewayAuthorizationSubject;
   modelProvider?: string;
   modelId?: string;
   messageProvider?: string;

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -9,6 +9,7 @@ import type {
 import type { InboundEventKind } from "../channels/inbound-event/kind.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginHookChannelContext } from "../plugins/hook-types.js";
+import type { GatewayAuthorizationSubject } from "./authorization/contracts.js";
 import {
   buildMcpToolSchema,
   type McpLoopbackTool,
@@ -37,6 +38,7 @@ type McpLoopbackScopeParams = {
   runtimePolicySessionKey?: string;
   agentId?: string;
   sessionId?: string;
+  authorizationSubject?: GatewayAuthorizationSubject;
   modelProvider?: string;
   modelId?: string;
   yieldContextCacheKey?: string;
@@ -103,6 +105,16 @@ export class McpLoopbackToolCache {
       params.runtimePolicySessionKey ?? "",
       params.agentId ?? "",
       params.sessionId ?? "",
+      params.authorizationSubject?.principal.issuer ?? "",
+      params.authorizationSubject?.principal.subject ?? "",
+      params.authorizationSubject?.principal.kind ?? "",
+      params.authorizationSubject?.domain.id ?? "",
+      params.authorizationSubject?.delegation?.id ?? "",
+      params.authorizationSubject?.delegation?.assignmentId ?? "",
+      params.authorizationSubject?.agentSession?.id ?? "",
+      params.authorizationSubject?.agentSession?.invokingPrincipal.issuer ?? "",
+      params.authorizationSubject?.agentSession?.invokingPrincipal.subject ?? "",
+      params.authorizationSubject?.agentSession?.invokingPrincipal.kind ?? "",
       params.modelProvider ?? "",
       params.modelId ?? "",
       params.yieldContextCacheKey ?? "",

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -45,6 +45,7 @@ type ScopedToolsCall = {
   runtimePolicySessionKey?: string;
   agentId?: string;
   sessionId?: string;
+  authorizationSubject?: import("./authorization/contracts.js").GatewayAuthorizationSubject;
   modelProvider?: string;
   modelId?: string;
   yieldContextCacheKey?: string;
@@ -1045,6 +1046,11 @@ describe("mcp loopback server", () => {
 
   it("binds a CLI grant's complete context and ignores spoofed scope headers", async () => {
     const { port, runtime } = await startLoopbackServerForTest();
+    const authorizationSubject = {
+      principal: { issuer: "core", subject: "agent:worker", kind: "service" as const },
+      domain: { id: "domain-bound" },
+      delegation: { id: "delegation-bound", assignmentId: "assignment-bound" },
+    };
     const grant = mintMcpLoopbackClientGrant({
       context: {
         sessionKey: "agent:main:discord:channel:bound",
@@ -1052,6 +1058,7 @@ describe("mcp loopback server", () => {
         agentId: "worker",
         sessionId: "session-bound",
         runId: "run-bound",
+        authorizationSubject,
         modelProvider: "anthropic",
         modelId: "claude-opus-4-7",
         messageProvider: "discord",
@@ -1133,6 +1140,7 @@ describe("mcp loopback server", () => {
       runtimePolicySessionKey: "agent:worker:discord:default:direct:bound-user",
       agentId: "worker",
       sessionId: "session-bound",
+      authorizationSubject,
       modelProvider: "anthropic",
       modelId: "claude-opus-4-7",
       messageProvider: "discord",
@@ -1479,6 +1487,38 @@ describe("mcp loopback server", () => {
     expect(unknownSecond.toolSchema.map((tool) => tool.name)).toContain("cron");
 
     expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("keeps Teams authorization subjects domain-bound in the loopback cache", () => {
+    const cache = new McpLoopbackToolCache();
+    const baseParams = {
+      cfg: {} as never,
+      sessionKey: "agent:main:direct:test",
+      messageProvider: undefined,
+      currentChannelId: undefined,
+      currentThreadTs: undefined,
+      currentMessageId: undefined,
+      currentInboundAudio: undefined,
+      accountId: undefined,
+      inboundEventKind: undefined,
+      sourceReplyDeliveryMode: undefined,
+      senderIsOwner: false,
+    } satisfies Parameters<McpLoopbackToolCache["resolve"]>[0];
+    const subjectFor = (domainId: string) => ({
+      principal: { issuer: "core", subject: "agent:main", kind: "service" as const },
+      domain: { id: domainId },
+    });
+    resolveGatewayScopedToolsMock.mockImplementation((input: unknown) => ({
+      agentId: "main",
+      tools: [makeMockTool({ name: (input as ScopedToolsCall).authorizationSubject?.domain.id })],
+    }));
+
+    const first = cache.resolve({ ...baseParams, authorizationSubject: subjectFor("domain-a") });
+    const second = cache.resolve({ ...baseParams, authorizationSubject: subjectFor("domain-b") });
+
+    expect(first.toolSchema.map((tool) => tool.name)).toContain("domain-a");
+    expect(second.toolSchema.map((tool) => tool.name)).toContain("domain-b");
+    expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(2);
   });
 
   it("keeps CLI node-exec capability and session defaults cache-bound", () => {

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -278,6 +278,7 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
           runtimePolicySessionKey: requestContext.runtimePolicySessionKey,
           agentId: requestContext.agentId,
           sessionId: requestContext.sessionId,
+          authorizationSubject: requestContext.authorizationSubject,
           modelProvider: requestContext.modelProvider,
           modelId: requestContext.modelId,
           yieldContextCacheKey: yieldContext?.cacheKey,

--- a/src/gateway/methods/descriptor.ts
+++ b/src/gateway/methods/descriptor.ts
@@ -49,6 +49,7 @@ export type GatewayMethodRegistryView = {
   listMethods: () => string[];
   listAdvertisedMethods: () => string[];
   getScope: (name: string) => GatewayMethodScope | undefined;
+  getOwner: (name: string) => GatewayMethodOwner | undefined;
   getAccessPolicy: (name: string) => GatewayMethodAccessPolicy | undefined;
   isStartupUnavailable: (name: string) => boolean;
   isControlPlaneWrite: (name: string) => boolean;

--- a/src/gateway/methods/descriptor.ts
+++ b/src/gateway/methods/descriptor.ts
@@ -1,3 +1,4 @@
+import type { GatewayMethodAccessPolicy } from "../authorization/contracts.js";
 // Gateway method descriptor types define the reusable contract shared by core, plugin, channel, and auxiliary methods.
 import type { OperatorScope } from "../operator-scopes.js";
 
@@ -29,6 +30,7 @@ export type GatewayMethodDescriptor = {
   name: string;
   handler: GatewayMethodHandler;
   scope: GatewayMethodScope;
+  access?: GatewayMethodAccessPolicy;
   owner: GatewayMethodOwner;
   startup?: GatewayMethodStartupAvailability;
   controlPlaneWrite?: boolean;
@@ -47,6 +49,7 @@ export type GatewayMethodRegistryView = {
   listMethods: () => string[];
   listAdvertisedMethods: () => string[];
   getScope: (name: string) => GatewayMethodScope | undefined;
+  getAccessPolicy: (name: string) => GatewayMethodAccessPolicy | undefined;
   isStartupUnavailable: (name: string) => boolean;
   isControlPlaneWrite: (name: string) => boolean;
   descriptors: () => readonly GatewayMethodDescriptor[];

--- a/src/gateway/methods/registry.test.ts
+++ b/src/gateway/methods/registry.test.ts
@@ -1,7 +1,8 @@
 /**
  * Gateway method registry tests.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayMethodAccessPolicy } from "../authorization/contracts.js";
 import { ADMIN_SCOPE, READ_SCOPE, WRITE_SCOPE } from "../operator-scopes.js";
 import type { GatewayRequestHandler } from "../server-methods/types.js";
 import {
@@ -97,6 +98,98 @@ describe("gateway method registry", () => {
 
     expect(registry.getScope("config.demo")).toBe(ADMIN_SCOPE);
     expect(registry.descriptors()[0]?.owner).toEqual({ kind: "plugin", pluginId: "demo" });
+  });
+
+  it("rejects a raw plugin attempt to mark a gateway method public", () => {
+    expect(() =>
+      createPluginGatewayMethodDescriptor({
+        pluginId: "demo",
+        name: "demo.public",
+        handler,
+        access: { kind: "public" },
+      }),
+    ).toThrow(/plugin gateway method access must be resource-scoped/i);
+  });
+
+  it("copies and freezes plugin access policy instead of retaining plugin objects", async () => {
+    const resource = { namespace: "demo", type: "card", id: "card-1" };
+    const access = {
+      kind: "resource" as "resource" | "public",
+      permission: "demo.card.read",
+      resolveResources: () => [resource],
+    };
+    const registry = createGatewayMethodRegistry([
+      createPluginGatewayMethodDescriptor({
+        pluginId: "demo",
+        name: "demo.card.get",
+        handler,
+        access: access as GatewayMethodAccessPolicy,
+      }),
+    ]);
+
+    access.kind = "public";
+    access.permission = "demo.card.write";
+
+    const stored = registry.getAccessPolicy("demo.card.get");
+    expect(stored).not.toBe(access);
+    expect(Object.isFrozen(stored)).toBe(true);
+    expect(stored).toMatchObject({ kind: "resource", permission: "demo.card.read" });
+    if (stored?.kind !== "resource") {
+      throw new Error("expected canonical resource access policy");
+    }
+    await expect(
+      stored.resolveResources({ method: "demo.card.get", params: {}, config: {} }),
+    ).resolves.toEqual([{ namespace: "demo", type: "card", id: "card-1" }]);
+  });
+
+  it("snapshots plugin policy getters and rejects foreign resource namespaces", async () => {
+    const reads = { kind: 0, permission: 0, resolver: 0 };
+    const resolveResources = vi.fn(() => [
+      { namespace: "other-plugin", type: "card", id: "card-1" },
+    ]);
+    const access = Object.defineProperties(
+      {},
+      {
+        kind: {
+          get: () => {
+            reads.kind += 1;
+            return "resource";
+          },
+        },
+        permission: {
+          get: () => {
+            reads.permission += 1;
+            return "demo.card.read";
+          },
+        },
+        resolveResources: {
+          get: () => {
+            reads.resolver += 1;
+            return resolveResources;
+          },
+        },
+      },
+    ) as GatewayMethodAccessPolicy;
+    const registry = createGatewayMethodRegistry([
+      {
+        name: "demo.card.get",
+        handler,
+        scope: READ_SCOPE,
+        owner: { kind: "plugin", pluginId: "demo" },
+        access,
+      },
+    ]);
+    const stored = registry.getAccessPolicy("demo.card.get");
+
+    expect(reads).toEqual({ kind: 1, permission: 1, resolver: 1 });
+    expect(() => registry.getAccessPolicy("demo.card.get")).not.toThrow();
+    expect(reads).toEqual({ kind: 1, permission: 1, resolver: 1 });
+    if (stored?.kind !== "resource") {
+      throw new Error("expected canonical resource access policy");
+    }
+    await expect(
+      stored.resolveResources({ method: "demo.card.get", params: {}, config: {} }),
+    ).rejects.toThrow(/loader-bound plugin namespace/i);
   });
 
   it("preserves reserved core and aux scopes", () => {

--- a/src/gateway/methods/registry.test.ts
+++ b/src/gateway/methods/registry.test.ts
@@ -14,12 +14,18 @@ const handler: GatewayRequestHandler = ({ respond }) => respond(true, { ok: true
 
 describe("gateway method registry", () => {
   it("indexes handlers, scopes, startup state, and control-plane metadata", () => {
+    const access = {
+      kind: "resource" as const,
+      permission: "example.read",
+      resolveResources: () => [{ namespace: "core", type: "example", id: "one" }],
+    };
     const registry = createGatewayMethodRegistry([
       {
         name: "example.read",
         handler,
         scope: READ_SCOPE,
         owner: { kind: "core", area: "test" },
+        access,
       },
       {
         name: "example.write",
@@ -36,8 +42,28 @@ describe("gateway method registry", () => {
     expect(registry.listAdvertisedMethods()).toEqual(["example.read"]);
     expect(registry.getHandler("example.read")).toBe(handler);
     expect(registry.getScope("example.write")).toBe(WRITE_SCOPE);
+    expect(registry.getAccessPolicy("example.read")).toBe(access);
+    expect(registry.getAccessPolicy("example.write")).toBeUndefined();
     expect(registry.isStartupUnavailable("example.write")).toBe(true);
     expect(registry.isControlPlaneWrite("example.write")).toBe(true);
+  });
+
+  it("rejects a blank resource permission", () => {
+    expect(() =>
+      createGatewayMethodRegistry([
+        {
+          name: "example.blank-permission",
+          handler,
+          scope: READ_SCOPE,
+          owner: { kind: "core", area: "test" },
+          access: {
+            kind: "resource",
+            permission: "   ",
+            resolveResources: () => [{ namespace: "core", type: "example", id: "one" }],
+          },
+        },
+      ]),
+    ).toThrow("gateway method access permission must not be empty: example.blank-permission");
   });
 
   it("rejects duplicate method names", () => {
@@ -103,5 +129,6 @@ describe("gateway method registry", () => {
     expect(registry.listMethods()).toEqual(["legacy.ping"]);
     expect(registry.getHandler("legacy.ping")).toBe(handler);
     expect(registry.getScope("legacy.ping")).toBe(ADMIN_SCOPE);
+    expect(registry.getAccessPolicy("legacy.ping")).toBeUndefined();
   });
 });

--- a/src/gateway/methods/registry.ts
+++ b/src/gateway/methods/registry.ts
@@ -39,6 +39,9 @@ function normalizeDescriptor(input: GatewayMethodDescriptorInput): GatewayMethod
   if (!normalizedScope) {
     throw new Error(`gateway method descriptor is missing a scope: ${name}`);
   }
+  if (input.access?.kind === "resource" && !input.access.permission.trim()) {
+    throw new Error(`gateway method access permission must not be empty: ${name}`);
+  }
   return {
     ...input,
     name,
@@ -73,6 +76,7 @@ export function createGatewayMethodRegistry(
         .filter((descriptor) => descriptor.advertise !== false)
         .map((descriptor) => descriptor.name),
     getScope: (name) => byName.get(name)?.scope,
+    getAccessPolicy: (name) => byName.get(name)?.access,
     isStartupUnavailable: (name) => byName.get(name)?.startup === "unavailable-until-sidecars",
     isControlPlaneWrite: (name) => byName.get(name)?.controlPlaneWrite === true,
     descriptors: () => descriptors,

--- a/src/gateway/methods/registry.ts
+++ b/src/gateway/methods/registry.ts
@@ -40,6 +40,8 @@ function canonicalizePluginAccessPolicy(params: {
     kind === "resource"
       ? (params.access as { resolveResources?: unknown }).resolveResources
       : undefined;
+  const member: unknown =
+    kind === "resource" ? (params.access as { member?: unknown }).member : undefined;
   if (kind !== "resource") {
     throw new Error(`plugin gateway method access must be resource-scoped: ${params.method}`);
   }
@@ -54,6 +56,7 @@ function canonicalizePluginAccessPolicy(params: {
   ) => Promise<readonly GatewayResourceRef[]> | readonly GatewayResourceRef[];
   return Object.freeze({
     kind: "resource" as const,
+    ...(member === true ? { member: true } : {}),
     permission: permission.trim(),
     resolveResources: async (input: GatewayResourceResolutionInput) => {
       const resources = await resolveResources(input);

--- a/src/gateway/methods/registry.ts
+++ b/src/gateway/methods/registry.ts
@@ -1,6 +1,11 @@
 // Gateway method registry normalizes method descriptors, enforces unique names, and exposes dispatch policy metadata.
 import type { PluginRegistry } from "../../plugins/registry-types.js";
 import { normalizePluginGatewayMethodScope } from "../../shared/gateway-method-policy.js";
+import type {
+  GatewayMethodAccessPolicy,
+  GatewayResourceRef,
+  GatewayResourceResolutionInput,
+} from "../authorization/contracts.js";
 import { ADMIN_SCOPE, type OperatorScope } from "../operator-scopes.js";
 import {
   createCoreGatewayMethodDescriptors,
@@ -23,6 +28,54 @@ function normalizeMethodName(name: string): string {
   return name.trim();
 }
 
+function canonicalizePluginAccessPolicy(params: {
+  pluginId: string;
+  method: string;
+  access: GatewayMethodAccessPolicy;
+}): GatewayMethodAccessPolicy {
+  const kind: unknown = params.access.kind;
+  const permission: unknown =
+    kind === "resource" ? (params.access as { permission?: unknown }).permission : undefined;
+  const resolver: unknown =
+    kind === "resource"
+      ? (params.access as { resolveResources?: unknown }).resolveResources
+      : undefined;
+  if (kind !== "resource") {
+    throw new Error(`plugin gateway method access must be resource-scoped: ${params.method}`);
+  }
+  if (typeof permission !== "string" || !permission.trim()) {
+    throw new Error(`gateway method access permission must not be empty: ${params.method}`);
+  }
+  if (typeof resolver !== "function") {
+    throw new Error(`plugin gateway method access resolver must be a function: ${params.method}`);
+  }
+  const resolveResources = resolver as (
+    input: GatewayResourceResolutionInput,
+  ) => Promise<readonly GatewayResourceRef[]> | readonly GatewayResourceRef[];
+  return Object.freeze({
+    kind: "resource" as const,
+    permission: permission.trim(),
+    resolveResources: async (input: GatewayResourceResolutionInput) => {
+      const resources = await resolveResources(input);
+      if (!Array.isArray(resources)) {
+        throw new Error("plugin gateway resource resolver must return an array");
+      }
+      return Object.freeze(
+        resources.map((resource) => {
+          if (!resource || resource.namespace !== params.pluginId) {
+            throw new Error("plugin gateway resources must use the loader-bound plugin namespace");
+          }
+          return Object.freeze({
+            namespace: params.pluginId,
+            type: resource.type,
+            id: resource.id,
+          });
+        }),
+      );
+    },
+  });
+}
+
 function normalizeDescriptor(input: GatewayMethodDescriptorInput): GatewayMethodDescriptor {
   const name = normalizeMethodName(input.name);
   if (!name) {
@@ -39,13 +92,22 @@ function normalizeDescriptor(input: GatewayMethodDescriptorInput): GatewayMethod
   if (!normalizedScope) {
     throw new Error(`gateway method descriptor is missing a scope: ${name}`);
   }
-  if (input.access?.kind === "resource" && !input.access.permission.trim()) {
+  const access =
+    input.access && input.owner.kind === "plugin"
+      ? canonicalizePluginAccessPolicy({
+          pluginId: input.owner.pluginId,
+          method: name,
+          access: input.access,
+        })
+      : input.access;
+  if (access?.kind === "resource" && !access.permission.trim()) {
     throw new Error(`gateway method access permission must not be empty: ${name}`);
   }
   return {
     ...input,
     name,
     scope: normalizedScope,
+    ...(access ? { access } : {}),
     ...(input.startup === "unavailable-until-sidecars"
       ? { startup: "unavailable-until-sidecars" }
       : {}),
@@ -76,6 +138,7 @@ export function createGatewayMethodRegistry(
         .filter((descriptor) => descriptor.advertise !== false)
         .map((descriptor) => descriptor.name),
     getScope: (name) => byName.get(name)?.scope,
+    getOwner: (name) => byName.get(name)?.owner,
     getAccessPolicy: (name) => byName.get(name)?.access,
     isStartupUnavailable: (name) => byName.get(name)?.startup === "unavailable-until-sidecars",
     isControlPlaneWrite: (name) => byName.get(name)?.controlPlaneWrite === true,
@@ -111,13 +174,22 @@ export function createPluginGatewayMethodDescriptor(params: {
   name: string;
   handler: GatewayMethodHandler;
   scope?: OperatorScope;
+  access?: GatewayMethodAccessPolicy;
 }): GatewayMethodDescriptorInput {
+  const access = params.access
+    ? canonicalizePluginAccessPolicy({
+        pluginId: params.pluginId,
+        method: params.name,
+        access: params.access,
+      })
+    : undefined;
   const normalizedScope = normalizePluginGatewayMethodScope(params.name, params.scope).scope;
   return {
     name: params.name,
     handler: params.handler,
     owner: { kind: "plugin", pluginId: params.pluginId },
     scope: normalizedScope ?? ADMIN_SCOPE,
+    ...(access ? { access } : {}),
   };
 }
 

--- a/src/gateway/role-policy.test.ts
+++ b/src/gateway/role-policy.test.ts
@@ -3,6 +3,7 @@
  */
 import { describe, expect, test } from "vitest";
 import {
+  filterAdvertisedGatewayMethodsForRole,
   isRoleAuthorizedForMethod,
   parseGatewayRole,
   roleCanSkipDeviceIdentity,
@@ -12,6 +13,7 @@ describe("gateway role policy", () => {
   test("parses supported roles", () => {
     expect(parseGatewayRole("operator")).toBe("operator");
     expect(parseGatewayRole("node")).toBe("node");
+    expect(parseGatewayRole("member")).toBe("member");
     expect(parseGatewayRole("admin")).toBeNull();
     expect(parseGatewayRole(undefined)).toBeNull();
   });
@@ -20,6 +22,7 @@ describe("gateway role policy", () => {
     expect(roleCanSkipDeviceIdentity("operator", true)).toBe(true);
     expect(roleCanSkipDeviceIdentity("operator", false)).toBe(false);
     expect(roleCanSkipDeviceIdentity("node", true)).toBe(false);
+    expect(roleCanSkipDeviceIdentity("member", true)).toBe(false);
   });
 
   test("authorizes roles against node vs operator methods", () => {
@@ -35,5 +38,39 @@ describe("gateway role policy", () => {
     expect(isRoleAuthorizedForMethod("operator", "node.skills.update")).toBe(false);
     expect(isRoleAuthorizedForMethod("operator", "node.pending.drain")).toBe(false);
     expect(isRoleAuthorizedForMethod("operator", "node.event")).toBe(false);
+    expect(
+      isRoleAuthorizedForMethod("member", "workspace.tab.get", {
+        kind: "resource",
+        member: true,
+      }),
+    ).toBe(true);
+    expect(isRoleAuthorizedForMethod("member", "workspace.tab.get", { kind: "resource" })).toBe(
+      false,
+    );
+    expect(isRoleAuthorizedForMethod("member", "workspace.tab.get")).toBe(false);
+    expect(isRoleAuthorizedForMethod("member", "config.get", { kind: "resource" })).toBe(false);
+  });
+
+  test("filters the post-auth Hello method list to plugin resources for members", () => {
+    const policies = new Map([
+      ["workspace.tab.get", { kind: "resource" as const, member: true }],
+      ["workspace.get", undefined],
+      ["config.get", { kind: "resource" as const }],
+    ]);
+
+    expect(
+      filterAdvertisedGatewayMethodsForRole(
+        "member",
+        ["workspace.tab.get", "workspace.get", "config.get"],
+        (method) => policies.get(method),
+      ),
+    ).toEqual(["workspace.tab.get"]);
+    expect(
+      filterAdvertisedGatewayMethodsForRole(
+        "operator",
+        ["workspace.tab.get", "workspace.get", "config.get"],
+        (method) => policies.get(method),
+      ),
+    ).toEqual(["workspace.tab.get", "workspace.get", "config.get"]);
   });
 });

--- a/src/gateway/role-policy.ts
+++ b/src/gateway/role-policy.ts
@@ -1,15 +1,18 @@
 // Gateway connection role policy.
 // Separates node-role RPCs from operator RPCs before method scope checks.
 import { isNodeRoleMethod } from "./method-scopes.js";
+import { isCoreGatewayMethodClassified } from "./methods/core-descriptors.js";
 
-const GATEWAY_ROLES = ["operator", "node"] as const;
+const GATEWAY_ROLES = ["operator", "node", "member"] as const;
+
+type GatewayAccessMarker = Readonly<{ kind: string; member?: boolean }>;
 
 /** Gateway connection roles used before method-level operator scope checks. */
 export type GatewayRole = (typeof GATEWAY_ROLES)[number];
 
 /** Parses the untrusted role claim from connect params into the closed role set. */
 export function parseGatewayRole(roleRaw: unknown): GatewayRole | null {
-  if (roleRaw === "operator" || roleRaw === "node") {
+  if (roleRaw === "operator" || roleRaw === "node" || roleRaw === "member") {
     return roleRaw;
   }
   return null;
@@ -21,9 +24,34 @@ export function roleCanSkipDeviceIdentity(role: GatewayRole, sharedAuthOk: boole
 }
 
 /** Keeps node-originated notifications off the operator RPC surface, and vice versa. */
-export function isRoleAuthorizedForMethod(role: GatewayRole, method: string): boolean {
+export function isRoleAuthorizedForMethod(
+  role: GatewayRole,
+  method: string,
+  access?: GatewayAccessMarker,
+): boolean {
   if (isNodeRoleMethod(method)) {
     return role === "node";
   }
+  if (role === "member") {
+    return (
+      access?.kind === "resource" &&
+      access.member === true &&
+      !isCoreGatewayMethodClassified(method)
+    );
+  }
   return role === "operator";
+}
+
+/** Removes every broad/core method from the capability list advertised to member clients. */
+export function filterAdvertisedGatewayMethodsForRole(
+  role: GatewayRole,
+  methods: readonly string[],
+  getAccessPolicy: (method: string) => GatewayAccessMarker | undefined,
+): string[] {
+  if (role !== "member") {
+    return [...methods];
+  }
+  return methods.filter((method) =>
+    isRoleAuthorizedForMethod(role, method, getAccessPolicy(method)),
+  );
 }

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -73,7 +73,7 @@ function serializeFrameField(name: "payload" | "stateVersion", value: unknown): 
 }
 
 function hasEventScope(client: GatewayWsClient, event: string): boolean {
-  if (client.connectionKind === "worker") {
+  if (client.connectionKind === "worker" || (client.connect.role ?? "operator") === "member") {
     return false;
   }
   const required = EVENT_SCOPE_GUARDS[event];

--- a/src/gateway/server-http.teams.test.ts
+++ b/src/gateway/server-http.teams.test.ts
@@ -1,0 +1,78 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AUTH_NONE,
+  createRequest,
+  createResponse,
+  createTestGatewayServer,
+  dispatchRequest,
+  withGatewayTempConfig,
+} from "./server-http.test-harness.js";
+
+const mocks = vi.hoisted(() => ({
+  handleTeamsHttpRequest: vi.fn(
+    async (_req: IncomingMessage, res: ServerResponse): Promise<boolean> => {
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "application/json; charset=utf-8");
+      res.end('{"ok":true,"route":"teams"}');
+      return true;
+    },
+  ),
+}));
+
+vi.mock("./teams-http.js", () => ({
+  handleTeamsHttpRequest: mocks.handleTeamsHttpRequest,
+}));
+
+describe("Gateway Teams HTTP routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("dispatches Teams account routes before the Control UI SPA catch-all", async () => {
+    await withGatewayTempConfig("openclaw-teams-http-route-", async () => {
+      const server = createTestGatewayServer({
+        resolvedAuth: AUTH_NONE,
+        overrides: {
+          controlUiEnabled: true,
+          controlUiBasePath: "/",
+        },
+      });
+      const req = createRequest({
+        path: "/api/teams/session",
+        headers: { origin: "http://localhost:18789" },
+      });
+      const response = createResponse();
+
+      await dispatchRequest(server, req, response.res);
+
+      expect(response.res.statusCode).toBe(200);
+      expect(response.getBody()).toBe('{"ok":true,"route":"teams"}');
+      expect(mocks.handleTeamsHttpRequest).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("dispatches dynamic Teams owner invite routes before the Control UI SPA catch-all", async () => {
+    await withGatewayTempConfig("openclaw-teams-http-route-", async () => {
+      const server = createTestGatewayServer({
+        resolvedAuth: AUTH_NONE,
+        overrides: {
+          controlUiEnabled: true,
+          controlUiBasePath: "/",
+        },
+      });
+      const req = createRequest({
+        method: "DELETE",
+        path: "/api/teams/invites/invite-1",
+        headers: { origin: "http://localhost:18789", "content-type": "application/json" },
+      });
+      const response = createResponse();
+
+      await dispatchRequest(server, req, response.res);
+
+      expect(response.res.statusCode).toBe(200);
+      expect(response.getBody()).toBe('{"ok":true,"route":"teams"}');
+      expect(mocks.handleTeamsHttpRequest).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -110,6 +110,8 @@ const getSessionKillHttpModule = createLazyRuntimeModule(() => import("./session
 
 const getToolsInvokeHttpModule = createLazyRuntimeModule(() => import("./tools-invoke-http.js"));
 
+const getTeamsHttpModule = createLazyRuntimeModule(() => import("./teams-http.js"));
+
 const getPluginNodeCapabilityAuthModule = createLazyRuntimeModule(
   () => import("./server/plugin-node-capability-auth.js"),
 );
@@ -195,6 +197,18 @@ function isSessionKillPath(pathname: string): boolean {
 
 function isSessionHistoryPath(pathname: string): boolean {
   return /^\/sessions\/[^/]+\/history$/.test(pathname);
+}
+
+function isTeamsAccountPath(pathname: string): boolean {
+  return (
+    pathname === "/api/teams/login" ||
+    pathname === "/api/teams/logout" ||
+    pathname === "/api/teams/session" ||
+    pathname === "/api/teams/invites/accept" ||
+    pathname === "/api/teams/invite-presets" ||
+    pathname === "/api/teams/invites" ||
+    /^\/api\/teams\/invites\/[^/]+$/.test(pathname)
+  );
 }
 
 function shouldEnforceDefaultPluginGatewayAuth(pathContext: PluginRoutePathContext): boolean {
@@ -579,6 +593,20 @@ export function createGatewayHttpServer(opts: {
           run: () => handleHooksRequest(req, res),
         },
       ];
+      if (isTeamsAccountPath(scopedRequestPath)) {
+        requestStages.push({
+          name: "teams-account-session",
+          run: async () =>
+            await runWithGatewayHttpWorkAdmission(res, async () =>
+              (await getTeamsHttpModule()).handleTeamsHttpRequest(req, res, {
+                allowedOrigins: configSnapshot.gateway?.controlUi?.allowedOrigins,
+                trustedProxies,
+                allowRealIpFallback,
+                rateLimiter,
+              }),
+            ),
+        });
+      }
       if (opts.handleWatchNodeRequest && scopedRequestPath.startsWith("/api/nodes/watch/")) {
         requestStages.push({
           name: "watch-node",

--- a/src/gateway/server-methods.authorization.test.ts
+++ b/src/gateway/server-methods.authorization.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
+import type {
+  GatewayAuthorizationRuntime,
+  GatewayMethodAccessPolicy,
+  GatewayRbacDenialReason,
+} from "./authorization/contracts.js";
+import { testing as controlPlaneRateLimitTesting } from "./control-plane-rate-limit.js";
+import { NODE_GATEWAY_METHOD_SCOPE } from "./methods/descriptor.js";
 import {
   createGatewayMethodRegistry,
   createPluginGatewayMethodDescriptor,
@@ -9,6 +17,16 @@ import { handleGatewayRequest } from "./server-methods.js";
 import type { GatewayRequestHandler } from "./server-methods/types.js";
 
 const METHOD = "workboard.cards.dispatch";
+const PRINCIPAL = {
+  issuer: "trusted-proxy",
+  subject: "member@example.com",
+  kind: "human",
+} as const;
+const ACCESS_POLICY: GatewayMethodAccessPolicy = {
+  kind: "resource",
+  permission: "workboard.card.read",
+  resolveResources: () => [{ namespace: "plugin:workboard", type: "card", id: "card-1" }],
+};
 
 afterEach(() => {
   setActivePluginRegistry(createEmptyPluginRegistry());
@@ -43,9 +61,11 @@ describe("gateway method authorization", () => {
         },
       } as Parameters<typeof handleGatewayRequest>[0]["client"],
       isWebchatConnect: () => false,
-      context: { logGateway: { warn: vi.fn() } } as unknown as Parameters<
-        typeof handleGatewayRequest
-      >[0]["context"],
+      context: {
+        authorization: { mode: "legacy" },
+        getRuntimeConfig: () => ({}),
+        logGateway: { warn: vi.fn() },
+      } as unknown as Parameters<typeof handleGatewayRequest>[0]["context"],
       methodRegistry,
     });
     return respond;
@@ -61,5 +81,227 @@ describe("gateway method authorization", () => {
       undefined,
       expect.objectContaining({ message: "missing scope: operator.write" }),
     );
+  });
+
+  async function dispatchIsolated(params: {
+    role?: "operator" | "node";
+    scopes?: string[];
+    principal?: typeof PRINCIPAL;
+    access?: GatewayMethodAccessPolicy;
+    authorization: GatewayAuthorizationRuntime;
+    getRuntimeConfig?: () => Record<string, unknown>;
+    synthetic?: boolean;
+    unavailableMethods?: ReadonlySet<string>;
+    controlPlaneWrite?: boolean;
+  }) {
+    const handler = vi.fn<GatewayRequestHandler>(({ respond }) => respond(true, { ok: true }));
+    const method = params.role === "node" ? "node.event" : METHOD;
+    const descriptor =
+      params.role === "node"
+        ? {
+            name: method,
+            handler,
+            owner: { kind: "core" as const, area: "test" },
+            scope: NODE_GATEWAY_METHOD_SCOPE,
+            ...(params.access ? { access: params.access } : {}),
+            ...(params.controlPlaneWrite ? { controlPlaneWrite: true } : {}),
+          }
+        : {
+            ...createPluginGatewayMethodDescriptor({
+              pluginId: "workboard",
+              name: method,
+              handler,
+              scope: "operator.write",
+            }),
+            ...(params.access ? { access: params.access } : {}),
+            ...(params.controlPlaneWrite ? { controlPlaneWrite: true } : {}),
+          };
+    const methodRegistry = createGatewayMethodRegistry([descriptor]);
+    const respond = vi.fn();
+
+    await handleGatewayRequest({
+      req: { type: "req", id: "req-isolated", method },
+      respond,
+      client: {
+        connId: "conn-isolated",
+        connect: {
+          role: params.role ?? "operator",
+          scopes: params.scopes ?? ["operator.write"],
+          client: { id: "test", version: "1", platform: "test", mode: "test" },
+          minProtocol: 1,
+          maxProtocol: 1,
+        },
+        ...(params.principal ? { principal: params.principal } : {}),
+        ...(params.synthetic ? { internal: { pluginRuntimeOwnerId: "trusted-plugin-owner" } } : {}),
+      } as Parameters<typeof handleGatewayRequest>[0]["client"],
+      isWebchatConnect: () => false,
+      context: {
+        authorization: params.authorization,
+        getRuntimeConfig: params.getRuntimeConfig ?? (() => ({})),
+        logGateway: { warn: vi.fn() },
+        ...(params.unavailableMethods
+          ? { unavailableGatewayMethods: params.unavailableMethods }
+          : {}),
+      } as unknown as Parameters<typeof handleGatewayRequest>[0]["context"],
+      methodRegistry,
+    });
+
+    return { handler, respond };
+  }
+
+  it("does not call an unclassified handler in isolated mode", async () => {
+    const authorize = vi.fn();
+    const { handler, respond } = await dispatchIsolated({
+      authorization: { mode: "isolated", authorize },
+      principal: PRINCIPAL,
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(authorize).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "resource not found" }),
+    );
+  });
+
+  it("does not treat synthetic admin scopes or plugin ownership as an isolated principal", async () => {
+    const authorize = vi.fn();
+    const { handler, respond } = await dispatchIsolated({
+      authorization: { mode: "isolated", authorize },
+      access: ACCESS_POLICY,
+      scopes: ["operator.admin"],
+      synthetic: true,
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(authorize).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "resource not found" }),
+    );
+  });
+
+  it("denies before disclosing startup availability", async () => {
+    const { respond } = await dispatchIsolated({
+      authorization: { mode: "isolated", authorize: vi.fn() },
+      principal: PRINCIPAL,
+      unavailableMethods: new Set([METHOD]),
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ code: "INVALID_REQUEST", message: "resource not found" }),
+    );
+    expect(JSON.stringify(respond.mock.calls)).not.toContain("UNAVAILABLE");
+  });
+
+  it("does not consume control-plane budget or acquire root admission for an isolated denial", async () => {
+    controlPlaneRateLimitTesting.resetControlPlaneRateLimitState();
+    try {
+      const denied = await dispatchIsolated({
+        authorization: { mode: "isolated", authorize: vi.fn() },
+        principal: PRINCIPAL,
+        controlPlaneWrite: true,
+      });
+
+      expect(denied.handler).not.toHaveBeenCalled();
+      expect(getActiveGatewayRootWorkCount()).toBe(0);
+
+      for (let index = 0; index < 3; index += 1) {
+        const allowed = await dispatchIsolated({
+          authorization: { mode: "legacy" },
+          controlPlaneWrite: true,
+        });
+        expect(allowed.handler).toHaveBeenCalledOnce();
+      }
+    } finally {
+      controlPlaneRateLimitTesting.resetControlPlaneRateLimitState();
+    }
+  });
+
+  it.each([
+    { role: "operator" as const, scopes: ["operator.admin"] },
+    { role: "node" as const, scopes: [] },
+  ])(
+    "does not let $role scope handling bypass isolated authorization",
+    async ({ role, scopes }) => {
+      const authorize = vi.fn(async () => ({ allowed: false, reason: "forbidden" }) as const);
+      const { handler } = await dispatchIsolated({
+        role,
+        scopes,
+        principal: PRINCIPAL,
+        access: ACCESS_POLICY,
+        authorization: { mode: "isolated", authorize },
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(authorize).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("uses the access policy from the attached dispatch registry", async () => {
+    const authorize = vi.fn(async () => ({
+      allowed: true as const,
+      principalId: "principal-1",
+      domain: { id: "domain-1" },
+    }));
+    const { handler, respond } = await dispatchIsolated({
+      principal: PRINCIPAL,
+      access: ACCESS_POLICY,
+      authorization: { mode: "isolated", authorize },
+    });
+
+    expect(authorize).toHaveBeenCalledWith({
+      principal: PRINCIPAL,
+      method: METHOD,
+      permission: "workboard.card.read",
+      resources: [{ namespace: "plugin:workboard", type: "card", id: "card-1" }],
+    });
+    expect(handler).toHaveBeenCalledOnce();
+    expect(respond).toHaveBeenCalledWith(true, { ok: true });
+  });
+
+  it("preserves unclassified method dispatch in explicit legacy mode", async () => {
+    const getRuntimeConfig = vi.fn(() => {
+      throw new Error("legacy dispatch must not resolve config");
+    });
+    const { handler, respond } = await dispatchIsolated({
+      authorization: { mode: "legacy" },
+      getRuntimeConfig,
+    });
+
+    expect(getRuntimeConfig).not.toHaveBeenCalled();
+    expect(handler).toHaveBeenCalledOnce();
+    expect(respond).toHaveBeenCalledWith(true, { ok: true });
+  });
+
+  it("redacts sensitive isolated denial reasons to one wire response", async () => {
+    const responses: unknown[] = [];
+    for (const reason of [
+      "unbound-resource",
+      "cross-domain",
+      "forbidden",
+      "indeterminate",
+    ] satisfies GatewayRbacDenialReason[]) {
+      const { respond } = await dispatchIsolated({
+        principal: PRINCIPAL,
+        access: ACCESS_POLICY,
+        authorization: {
+          mode: "isolated",
+          authorize: async () => ({ allowed: false, reason }),
+        },
+      });
+      responses.push(respond.mock.calls[0]);
+    }
+
+    expect(responses).toHaveLength(4);
+    expect(
+      responses.every((response) => JSON.stringify(response) === JSON.stringify(responses[0])),
+    ).toBe(true);
+    expect(JSON.stringify(responses[0])).not.toContain("cross-domain");
+    expect(JSON.stringify(responses[0])).not.toContain("forbidden");
   });
 });

--- a/src/gateway/server-methods.authorization.test.ts
+++ b/src/gateway/server-methods.authorization.test.ts
@@ -1,8 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GatewayPrincipal } from "../../packages/gateway-protocol/src/schema/frames.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
-import { bindGatewayClientAuthorizationDomain } from "./authorization/client-domain.js";
+import {
+  bindGatewayClientAuthorizationDelegation,
+  bindGatewayClientAuthorizationDomain,
+} from "./authorization/client-domain.js";
 import type {
   GatewayAuthorizationRuntime,
   GatewayMethodAccessPolicy,
@@ -28,7 +32,7 @@ const DOMAIN = { id: "domain-1" } as const;
 const ACCESS_POLICY: GatewayMethodAccessPolicy = {
   kind: "resource",
   permission: "workboard.card.read",
-  resolveResources: () => [{ namespace: "plugin:workboard", type: "card", id: "card-1" }],
+  resolveResources: () => [{ namespace: "workboard", type: "card", id: "card-1" }],
 };
 
 afterEach(() => {
@@ -89,12 +93,20 @@ describe("gateway method authorization", () => {
   async function dispatchIsolated(params: {
     role?: "operator" | "node";
     scopes?: string[];
-    principal?: typeof PRINCIPAL;
+    principal?: GatewayPrincipal;
     domain?: typeof DOMAIN;
     access?: GatewayMethodAccessPolicy;
     authorization: GatewayAuthorizationRuntime;
     getRuntimeConfig?: () => Record<string, unknown>;
     synthetic?: boolean;
+    delegation?: {
+      id: string;
+      assignmentId: string;
+    };
+    injectedDelegation?: {
+      id: string;
+      assignmentId: string;
+    };
     unavailableMethods?: ReadonlySet<string>;
     controlPlaneWrite?: boolean;
   }) {
@@ -120,8 +132,8 @@ describe("gateway method authorization", () => {
               name: method,
               handler,
               scope: "operator.write",
+              access: params.access,
             }),
-            ...(params.access ? { access: params.access } : {}),
             ...(params.controlPlaneWrite ? { controlPlaneWrite: true } : {}),
           };
     const methodRegistry = createGatewayMethodRegistry([descriptor]);
@@ -136,10 +148,22 @@ describe("gateway method authorization", () => {
         maxProtocol: 1,
       },
       ...(params.principal ? { principal: params.principal } : {}),
-      ...(params.synthetic ? { internal: { pluginRuntimeOwnerId: "trusted-plugin-owner" } } : {}),
+      ...(params.synthetic || params.injectedDelegation
+        ? {
+            internal: {
+              ...(params.synthetic ? { pluginRuntimeOwnerId: "trusted-plugin-owner" } : {}),
+              ...(params.injectedDelegation
+                ? { authorizationDelegation: params.injectedDelegation }
+                : {}),
+            },
+          }
+        : {}),
     } as NonNullable<Parameters<typeof handleGatewayRequest>[0]["client"]>;
     if (params.domain) {
       bindGatewayClientAuthorizationDomain(client, params.domain);
+    }
+    if (params.delegation) {
+      bindGatewayClientAuthorizationDelegation(client, params.delegation);
     }
 
     await handleGatewayRequest({
@@ -276,11 +300,88 @@ describe("gateway method authorization", () => {
       domain: DOMAIN,
       method: METHOD,
       permission: "workboard.card.read",
-      resources: [{ namespace: "plugin:workboard", type: "card", id: "card-1" }],
+      resources: [{ namespace: "workboard", type: "card", id: "card-1" }],
     });
     expect(handler).toHaveBeenCalledOnce();
-    expect(authorizationContexts).toEqual([{ principalId: "principal-1", domain: DOMAIN }]);
+    expect(authorizationContexts).toEqual([
+      {
+        principalId: "principal-1",
+        principalKind: "human",
+        domain: DOMAIN,
+        method: METHOD,
+        permission: "workboard.card.read",
+        resources: [{ namespace: "workboard", type: "card", id: "card-1" }],
+        pluginId: "workboard",
+        requestId: "req-isolated",
+      },
+    ]);
     expect(respond).toHaveBeenCalledWith(true, { ok: true });
+  });
+
+  it("projects only a server-attested service delegation into request context", async () => {
+    const servicePrincipal = {
+      issuer: "core",
+      subject: "agent:main",
+      kind: "service",
+    } as const;
+    const delegation = {
+      id: "delegation-1",
+      assignmentId: "assignment-1",
+    };
+    const { authorizationContexts } = await dispatchIsolated({
+      principal: servicePrincipal,
+      domain: DOMAIN,
+      access: ACCESS_POLICY,
+      delegation,
+      authorization: {
+        mode: "isolated",
+        authorize: async () => ({
+          allowed: true,
+          principalId: "principal-agent",
+          domain: DOMAIN,
+          delegation: { ...delegation, sponsorPrincipalId: "principal-owner" },
+        }),
+      },
+    });
+
+    expect(authorizationContexts).toEqual([
+      expect.objectContaining({
+        principalId: "principal-agent",
+        principalKind: "service",
+        requestId: "req-isolated",
+        delegation: { ...delegation, sponsorPrincipalId: "principal-owner" },
+      }),
+    ]);
+  });
+
+  it("ignores delegation injected through the plugin-visible client object", async () => {
+    const servicePrincipal = {
+      issuer: "core",
+      subject: "agent:main",
+      kind: "service",
+    } as const;
+    const injectedDelegation = {
+      id: "delegation-1",
+      assignmentId: "assignment-1",
+    };
+    const authorize = vi.fn(async () => ({
+      allowed: true as const,
+      principalId: "principal-agent",
+      domain: DOMAIN,
+      delegation: { ...injectedDelegation, sponsorPrincipalId: "principal-owner" },
+    }));
+    const { handler } = await dispatchIsolated({
+      principal: servicePrincipal,
+      domain: DOMAIN,
+      access: ACCESS_POLICY,
+      injectedDelegation,
+      authorization: { mode: "isolated", authorize },
+    });
+
+    expect(authorize).toHaveBeenCalledWith(
+      expect.not.objectContaining({ delegation: expect.anything() }),
+    );
+    expect(handler).not.toHaveBeenCalled();
   });
 
   it("preserves unclassified method dispatch in explicit legacy mode", async () => {

--- a/src/gateway/server-methods.authorization.test.ts
+++ b/src/gateway/server-methods.authorization.test.ts
@@ -2,11 +2,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
+import { bindGatewayClientAuthorizationDomain } from "./authorization/client-domain.js";
 import type {
   GatewayAuthorizationRuntime,
   GatewayMethodAccessPolicy,
   GatewayRbacDenialReason,
 } from "./authorization/contracts.js";
+import { getGatewayAuthorizationContext } from "./authorization/request-context.js";
 import { testing as controlPlaneRateLimitTesting } from "./control-plane-rate-limit.js";
 import { NODE_GATEWAY_METHOD_SCOPE } from "./methods/descriptor.js";
 import {
@@ -22,6 +24,7 @@ const PRINCIPAL = {
   subject: "member@example.com",
   kind: "human",
 } as const;
+const DOMAIN = { id: "domain-1" } as const;
 const ACCESS_POLICY: GatewayMethodAccessPolicy = {
   kind: "resource",
   permission: "workboard.card.read",
@@ -87,6 +90,7 @@ describe("gateway method authorization", () => {
     role?: "operator" | "node";
     scopes?: string[];
     principal?: typeof PRINCIPAL;
+    domain?: typeof DOMAIN;
     access?: GatewayMethodAccessPolicy;
     authorization: GatewayAuthorizationRuntime;
     getRuntimeConfig?: () => Record<string, unknown>;
@@ -94,7 +98,11 @@ describe("gateway method authorization", () => {
     unavailableMethods?: ReadonlySet<string>;
     controlPlaneWrite?: boolean;
   }) {
-    const handler = vi.fn<GatewayRequestHandler>(({ respond }) => respond(true, { ok: true }));
+    const authorizationContexts: Array<ReturnType<typeof getGatewayAuthorizationContext>> = [];
+    const handler = vi.fn<GatewayRequestHandler>(({ respond }) => {
+      authorizationContexts.push(getGatewayAuthorizationContext());
+      respond(true, { ok: true });
+    });
     const method = params.role === "node" ? "node.event" : METHOD;
     const descriptor =
       params.role === "node"
@@ -118,22 +126,26 @@ describe("gateway method authorization", () => {
           };
     const methodRegistry = createGatewayMethodRegistry([descriptor]);
     const respond = vi.fn();
+    const client = {
+      connId: "conn-isolated",
+      connect: {
+        role: params.role ?? "operator",
+        scopes: params.scopes ?? ["operator.write"],
+        client: { id: "test", version: "1", platform: "test", mode: "test" },
+        minProtocol: 1,
+        maxProtocol: 1,
+      },
+      ...(params.principal ? { principal: params.principal } : {}),
+      ...(params.synthetic ? { internal: { pluginRuntimeOwnerId: "trusted-plugin-owner" } } : {}),
+    } as NonNullable<Parameters<typeof handleGatewayRequest>[0]["client"]>;
+    if (params.domain) {
+      bindGatewayClientAuthorizationDomain(client, params.domain);
+    }
 
     await handleGatewayRequest({
       req: { type: "req", id: "req-isolated", method },
       respond,
-      client: {
-        connId: "conn-isolated",
-        connect: {
-          role: params.role ?? "operator",
-          scopes: params.scopes ?? ["operator.write"],
-          client: { id: "test", version: "1", platform: "test", mode: "test" },
-          minProtocol: 1,
-          maxProtocol: 1,
-        },
-        ...(params.principal ? { principal: params.principal } : {}),
-        ...(params.synthetic ? { internal: { pluginRuntimeOwnerId: "trusted-plugin-owner" } } : {}),
-      } as Parameters<typeof handleGatewayRequest>[0]["client"],
+      client,
       isWebchatConnect: () => false,
       context: {
         authorization: params.authorization,
@@ -146,7 +158,7 @@ describe("gateway method authorization", () => {
       methodRegistry,
     });
 
-    return { handler, respond };
+    return { authorizationContexts, handler, respond };
   }
 
   it("does not call an unclassified handler in isolated mode", async () => {
@@ -154,6 +166,7 @@ describe("gateway method authorization", () => {
     const { handler, respond } = await dispatchIsolated({
       authorization: { mode: "isolated", authorize },
       principal: PRINCIPAL,
+      domain: DOMAIN,
     });
 
     expect(handler).not.toHaveBeenCalled();
@@ -187,6 +200,7 @@ describe("gateway method authorization", () => {
     const { respond } = await dispatchIsolated({
       authorization: { mode: "isolated", authorize: vi.fn() },
       principal: PRINCIPAL,
+      domain: DOMAIN,
       unavailableMethods: new Set([METHOD]),
     });
 
@@ -204,6 +218,7 @@ describe("gateway method authorization", () => {
       const denied = await dispatchIsolated({
         authorization: { mode: "isolated", authorize: vi.fn() },
         principal: PRINCIPAL,
+        domain: DOMAIN,
         controlPlaneWrite: true,
       });
 
@@ -233,6 +248,7 @@ describe("gateway method authorization", () => {
         role,
         scopes,
         principal: PRINCIPAL,
+        domain: DOMAIN,
         access: ACCESS_POLICY,
         authorization: { mode: "isolated", authorize },
       });
@@ -248,19 +264,22 @@ describe("gateway method authorization", () => {
       principalId: "principal-1",
       domain: { id: "domain-1" },
     }));
-    const { handler, respond } = await dispatchIsolated({
+    const { authorizationContexts, handler, respond } = await dispatchIsolated({
       principal: PRINCIPAL,
+      domain: DOMAIN,
       access: ACCESS_POLICY,
       authorization: { mode: "isolated", authorize },
     });
 
     expect(authorize).toHaveBeenCalledWith({
       principal: PRINCIPAL,
+      domain: DOMAIN,
       method: METHOD,
       permission: "workboard.card.read",
       resources: [{ namespace: "plugin:workboard", type: "card", id: "card-1" }],
     });
     expect(handler).toHaveBeenCalledOnce();
+    expect(authorizationContexts).toEqual([{ principalId: "principal-1", domain: DOMAIN }]);
     expect(respond).toHaveBeenCalledWith(true, { ok: true });
   });
 
@@ -288,6 +307,7 @@ describe("gateway method authorization", () => {
     ] satisfies GatewayRbacDenialReason[]) {
       const { respond } = await dispatchIsolated({
         principal: PRINCIPAL,
+        domain: DOMAIN,
         access: ACCESS_POLICY,
         authorization: {
           mode: "isolated",

--- a/src/gateway/server-methods.control-plane-rate-limit.test.ts
+++ b/src/gateway/server-methods.control-plane-rate-limit.test.ts
@@ -33,6 +33,8 @@ describe("gateway control-plane write rate limit", () => {
 
   function buildContext(logWarn = vi.fn()) {
     return {
+      authorization: { mode: "legacy" },
+      getRuntimeConfig: () => ({}),
       logGateway: {
         warn: logWarn,
       },

--- a/src/gateway/server-methods.member-authorization.test.ts
+++ b/src/gateway/server-methods.member-authorization.test.ts
@@ -1,0 +1,343 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayPrincipal } from "../../packages/gateway-protocol/src/schema/frames.js";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  bindGatewayClientAuthorizationDomain,
+  bindGatewayClientTeamsSession,
+} from "./authorization/client-domain.js";
+import type { GatewayMethodAccessPolicy, GatewayResourceRef } from "./authorization/contracts.js";
+import {
+  addIsolationDomainMember,
+  bindAuthorizationResource,
+  createIsolationDomain,
+  grantAuthorizationPermission,
+  putAuthorizationPrincipal,
+} from "./authorization/state-store.js";
+import {
+  createGatewayMethodRegistry,
+  createPluginGatewayMethodDescriptor,
+} from "./methods/registry.js";
+import { handleGatewayRequest } from "./server-methods.js";
+import type { GatewayClient, GatewayRequestHandler } from "./server-methods/types.js";
+
+const mocks = vi.hoisted(() => ({ resolveTeamsSessionById: vi.fn() }));
+
+vi.mock("./authorization/teams-identity.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./authorization/teams-identity.js")>()),
+  resolveTeamsSessionById: mocks.resolveTeamsSessionById,
+}));
+
+const tempDirs: string[] = [];
+const owner = {
+  id: "principal-owner",
+  principal: { issuer: "teams", subject: "owner@example.com", kind: "human" as const },
+};
+const member = {
+  id: "principal-member",
+  principal: { issuer: "teams", subject: "member@example.com", kind: "human" as const },
+};
+const tab: GatewayResourceRef = { namespace: "workspaces", type: "tab", id: "tab-1" };
+const access: GatewayMethodAccessPolicy = {
+  kind: "resource",
+  member: true,
+  permission: "workspaces.tab.read",
+  resolveResources: () => [tab],
+};
+
+function seedDomain(params: { domainId: string; grant?: boolean }) {
+  putAuthorizationPrincipal(owner);
+  putAuthorizationPrincipal(member);
+  createIsolationDomain({ id: params.domainId, ownerPrincipalId: owner.id });
+  addIsolationDomainMember({
+    domainId: params.domainId,
+    principalId: member.id,
+    addedByPrincipalId: owner.id,
+  });
+  bindAuthorizationResource({
+    domainId: params.domainId,
+    resource: tab,
+    ownerPrincipalId: owner.id,
+  });
+  if (params.grant) {
+    grantAuthorizationPermission({
+      domainId: params.domainId,
+      principalId: member.id,
+      resource: tab,
+      permission: "workspaces.tab.read",
+      grantedByPrincipalId: owner.id,
+    });
+  }
+}
+
+function makeClient(params: {
+  role: "member" | "operator";
+  scopes?: string[];
+  principal?: GatewayPrincipal;
+  domainId?: string;
+}): GatewayClient {
+  const client: GatewayClient = {
+    connId: "conn-member",
+    connect: {
+      role: params.role,
+      scopes: params.scopes ?? [],
+      client: { id: "test", version: "1", platform: "test", mode: "test" },
+      minProtocol: 1,
+      maxProtocol: 1,
+    },
+    ...(params.principal ? { principal: params.principal } : {}),
+  };
+  if (params.domainId) {
+    bindGatewayClientAuthorizationDomain(client, { id: params.domainId });
+    if (params.role === "member" && params.principal?.kind === "human") {
+      bindGatewayClientTeamsSession(client, {
+        id: `teams-session-${params.domainId}`,
+        principalId: member.id,
+        domainId: params.domainId,
+      });
+    }
+  }
+  return client;
+}
+
+async function dispatch(params: {
+  role?: "member" | "operator";
+  scopes?: string[];
+  principal?: GatewayPrincipal;
+  domainId?: string;
+  access?: GatewayMethodAccessPolicy;
+  method?: string;
+}) {
+  const handler = vi.fn<GatewayRequestHandler>(({ respond }) => respond(true, { ok: true }));
+  const method = params.method ?? "workspaces.tab.get";
+  const registry = createGatewayMethodRegistry([
+    createPluginGatewayMethodDescriptor({
+      pluginId: "workspaces",
+      name: method,
+      handler,
+      scope: "operator.admin",
+      access: params.access,
+    }),
+  ]);
+  const respond = vi.fn();
+  await handleGatewayRequest({
+    req: { type: "req", id: "req-member", method, params: { id: tab.id } },
+    respond,
+    client: makeClient({
+      role: params.role ?? "member",
+      scopes: params.scopes,
+      principal: params.principal,
+      domainId: params.domainId,
+    }),
+    isWebchatConnect: () => false,
+    context: {
+      authorization: { mode: "legacy" },
+      getRuntimeConfig: () => ({}),
+      logGateway: { warn: vi.fn() },
+    } as unknown as Parameters<typeof handleGatewayRequest>[0]["context"],
+    methodRegistry: registry,
+  });
+  return { handler, respond };
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  vi.unstubAllEnvs();
+});
+
+afterAll(() => cleanupTempDirs(tempDirs));
+
+describe("member gateway authorization", () => {
+  beforeEach(() => {
+    mocks.resolveTeamsSessionById.mockImplementation(({ id }: { id: string }) => {
+      const domainId = id.replace(/^teams-session-/, "");
+      return {
+        id,
+        principalId: member.id,
+        principal: member.principal,
+        domainId,
+        state: "active",
+        accountId: "account-member",
+        createdAt: 1,
+        expiresAt: Date.now() + 60_000,
+        revokedAt: null,
+        revokedByPrincipalId: null,
+      };
+    });
+  });
+
+  function useDatabase() {
+    vi.stubEnv("OPENCLAW_STATE_DIR", makeTempDir(tempDirs, "openclaw-member-dispatch-"));
+  }
+
+  it("allows an exact resource grant without operator scopes", async () => {
+    useDatabase();
+    seedDomain({ domainId: "domain-1", grant: true });
+
+    const { handler, respond } = await dispatch({
+      principal: member.principal,
+      domainId: "domain-1",
+      access,
+    });
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(respond).toHaveBeenCalledWith(true, { ok: true });
+  });
+
+  it("does not let broad operator scopes affect member authorization", async () => {
+    useDatabase();
+    seedDomain({ domainId: "domain-1", grant: true });
+
+    const { handler } = await dispatch({
+      scopes: ["operator.admin"],
+      principal: member.principal,
+      domainId: "domain-1",
+      access,
+    });
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("denies member methods without a resource access policy", async () => {
+    useDatabase();
+    const { handler, respond } = await dispatch({ scopes: ["operator.admin"] });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "authentication required" }),
+    );
+  });
+
+  it("denies resource methods that did not explicitly opt into the member surface", async () => {
+    useDatabase();
+    seedDomain({ domainId: "domain-1", grant: true });
+    const { member: _member, ...operatorOnlyAccess } = access;
+
+    const { handler, respond } = await dispatch({
+      principal: member.principal,
+      domainId: "domain-1",
+      access: operatorOnlyAccess,
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "unauthorized role: member" }),
+    );
+  });
+
+  it.each(["config.get", "sessions.list", "agent", "terminal.open"])(
+    "denies the core method %s even if a descriptor claims resource access",
+    async (method) => {
+      useDatabase();
+      const { handler } = await dispatch({
+        method,
+        scopes: ["operator.admin"],
+        principal: member.principal,
+        domainId: "domain-1",
+        access,
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+    },
+  );
+
+  it("denies an unbound member before dispatch", async () => {
+    useDatabase();
+    const { handler, respond } = await dispatch({ principal: member.principal, access });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "authentication required" }),
+    );
+  });
+
+  it("denies the same established member client after its Teams session is revoked", async () => {
+    useDatabase();
+    seedDomain({ domainId: "domain-1", grant: true });
+    mocks.resolveTeamsSessionById.mockReturnValue(undefined);
+
+    const { handler, respond } = await dispatch({
+      principal: member.principal,
+      domainId: "domain-1",
+      access,
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "authentication required" }),
+    );
+  });
+
+  it("denies missing grants and cross-domain resources through state authorization", async () => {
+    useDatabase();
+    seedDomain({ domainId: "domain-1" });
+    createIsolationDomain({ id: "domain-2", ownerPrincipalId: owner.id });
+    addIsolationDomainMember({
+      domainId: "domain-2",
+      principalId: member.id,
+      addedByPrincipalId: owner.id,
+    });
+
+    const forbidden = await dispatch({
+      principal: member.principal,
+      domainId: "domain-1",
+      access,
+    });
+    const crossDomain = await dispatch({
+      principal: member.principal,
+      domainId: "domain-2",
+      access,
+    });
+
+    expect(forbidden.handler).not.toHaveBeenCalled();
+    expect(crossDomain.handler).not.toHaveBeenCalled();
+    expect(forbidden.respond.mock.calls[0]).toEqual(crossDomain.respond.mock.calls[0]);
+  });
+
+  it("requires state authorization for a domain-bound service client", async () => {
+    useDatabase();
+    seedDomain({ domainId: "domain-1", grant: true });
+
+    const { handler } = await dispatch({
+      scopes: ["operator.admin"],
+      principal: { issuer: "core", subject: "agent:main", kind: "service" },
+      domainId: "domain-1",
+      access,
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("does not let a domain-bound operator use legacy admin scope to bypass resource policy", async () => {
+    useDatabase();
+    seedDomain({ domainId: "domain-1", grant: true });
+
+    const { handler } = await dispatch({
+      role: "operator",
+      scopes: ["operator.admin"],
+      principal: member.principal,
+      domainId: "domain-1",
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("preserves legacy scope dispatch for unbound operators", async () => {
+    useDatabase();
+    const { handler, respond } = await dispatch({
+      role: "operator",
+      scopes: ["operator.admin"],
+    });
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(respond).toHaveBeenCalledWith(true, { ok: true });
+  });
+});

--- a/src/gateway/server-methods.plugin-gateway-dispatch.test.ts
+++ b/src/gateway/server-methods.plugin-gateway-dispatch.test.ts
@@ -60,6 +60,8 @@ describe("handleGatewayRequest plugin gateway dispatch", () => {
       },
       isWebchatConnect: () => false,
       context: {
+        authorization: { mode: "legacy" },
+        getRuntimeConfig: () => ({}),
         logGateway: { warn: vi.fn() },
       } as unknown as Parameters<typeof handleGatewayRequest>[0]["context"],
       methodRegistry: staleStartupRegistry,
@@ -100,6 +102,8 @@ describe("handleGatewayRequest plugin gateway dispatch", () => {
       },
       isWebchatConnect: () => false,
       context: {
+        authorization: { mode: "legacy" },
+        getRuntimeConfig: () => ({}),
         logGateway: { warn: vi.fn() },
       } as unknown as Parameters<typeof handleGatewayRequest>[0]["context"],
       methodRegistry: attachedRegistry,
@@ -128,6 +132,8 @@ describe("handleGatewayRequest plugin gateway dispatch", () => {
       },
       isWebchatConnect: () => false,
       context: {
+        authorization: { mode: "legacy" },
+        getRuntimeConfig: () => ({}),
         logGateway: { warn: vi.fn() },
       } as unknown as Parameters<typeof handleGatewayRequest>[0]["context"],
       methodRegistry: createGatewayMethodRegistry([]),

--- a/src/gateway/server-methods.suspension-admission.test.ts
+++ b/src/gateway/server-methods.suspension-admission.test.ts
@@ -63,9 +63,11 @@ function dispatch(params: {
     isWebchatConnect: () => false,
     context:
       params.context ??
-      ({ logGateway: { warn: vi.fn() } } as unknown as Parameters<
-        typeof handleGatewayRequest
-      >[0]["context"]),
+      ({
+        authorization: { mode: "legacy" },
+        getRuntimeConfig: () => ({}),
+        logGateway: { warn: vi.fn() },
+      } as unknown as Parameters<typeof handleGatewayRequest>[0]["context"]),
     methodRegistry,
   });
   return { request, respond };
@@ -132,6 +134,8 @@ describe("gateway request suspension admission", () => {
       getSuspensionBlockerCount: vi.fn(() => 0),
     };
     const context = {
+      authorization: { mode: "legacy" },
+      getRuntimeConfig: () => ({}),
       cron,
       logGateway: { warn: vi.fn() },
       chatAbortControllers: new Map(),

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -12,6 +12,7 @@ import {
   isGatewayRestartDraining,
   tryBeginGatewayRootWorkAdmission,
 } from "../process/gateway-work-admission.js";
+import { authorizeGatewayAccess } from "./authorization/kernel.js";
 import { formatControlPlaneActor, resolveControlPlaneActor } from "./control-plane-audit.js";
 import { consumeControlPlaneWriteBudget } from "./control-plane-rate-limit.js";
 import {
@@ -849,6 +850,28 @@ export async function handleGatewayRequest(
     respond(false, undefined, authError);
     return;
   }
+  const handler = methodRegistry.getHandler(req.method) as GatewayRequestHandler | undefined;
+  if (!handler) {
+    respond(
+      false,
+      undefined,
+      errorShape(ErrorCodes.INVALID_REQUEST, `unknown method: ${req.method}`),
+    );
+    return;
+  }
+  const access = await authorizeGatewayAccess({
+    runtime: context.authorization,
+    policy: methodRegistry.getAccessPolicy(req.method),
+    principal: client?.principal,
+    method: req.method,
+    params: req.params,
+    getConfig: context.getRuntimeConfig,
+  });
+  if (!access.allowed) {
+    context.logGateway.warn(`gateway access denied method=${req.method} reason=${access.reason}`);
+    respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "resource not found"));
+    return;
+  }
   if (context.unavailableGatewayMethods?.has(req.method)) {
     // During startup, methods can be listed before their runtime is ready. Return the protocol
     // retry shape so clients can back off without treating startup as a permanent unknown method.
@@ -896,15 +919,6 @@ export async function handleGatewayRequest(
   const isSuspendPrepare = req.method === "gateway.suspend.prepare";
   if (isSuspendPrepare && rejectRateLimitedControlPlaneWrite()) {
     // Preparation must stay protected even before it owns the root admission that it closes.
-    return;
-  }
-  const handler = methodRegistry.getHandler(req.method) as GatewayRequestHandler | undefined;
-  if (!handler) {
-    respond(
-      false,
-      undefined,
-      errorShape(ErrorCodes.INVALID_REQUEST, `unknown method: ${req.method}`),
-    );
     return;
   }
   const rootWorkAdmission = tryBeginGatewayRootWorkAdmission();

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -15,9 +15,12 @@ import {
 import {
   getGatewayClientAuthorizationDelegation,
   getGatewayClientAuthorizationDomain,
+  getGatewayClientTeamsSession,
 } from "./authorization/client-domain.js";
 import { authorizeGatewayAccess } from "./authorization/kernel.js";
 import { withGatewayAuthorizationContext } from "./authorization/request-context.js";
+import { createStateGatewayAuthorizationRuntime } from "./authorization/state-provider.js";
+import { resolveTeamsSessionById } from "./authorization/teams-identity.js";
 import { formatControlPlaneActor, resolveControlPlaneActor } from "./control-plane-audit.js";
 import { consumeControlPlaneWriteBudget } from "./control-plane-rate-limit.js";
 import {
@@ -318,10 +321,14 @@ function authorizeGatewayMethod(
     return errorShape(ErrorCodes.INVALID_REQUEST, `unauthorized role: ${roleRaw}`);
   }
   const scopes = client.connect.scopes ?? [];
-  if (!isRoleAuthorizedForMethod(role, method)) {
+  const accessPolicy = methodRegistry.getAccessPolicy(method);
+  if (!isRoleAuthorizedForMethod(role, method, accessPolicy)) {
     return errorShape(ErrorCodes.INVALID_REQUEST, `unauthorized role: ${role}`);
   }
   if (role === "node") {
+    return null;
+  }
+  if (role === "member") {
     return null;
   }
   if (scopes.includes(ADMIN_SCOPE)) {
@@ -850,6 +857,29 @@ export async function handleGatewayRequest(
     opts.methodRegistry?.getHandler(req.method) !== undefined
       ? opts.methodRegistry
       : createRequestGatewayMethodRegistry(opts.extraHandlers);
+  const role = parseGatewayRole(client?.connect.role ?? "operator");
+  const domain = getGatewayClientAuthorizationDomain(client);
+  if (role === "member") {
+    const binding = getGatewayClientTeamsSession(client);
+    const session = binding ? resolveTeamsSessionById({ id: binding.id }) : undefined;
+    const principal = client?.principal;
+    if (
+      !binding ||
+      !session ||
+      !domain ||
+      principal?.kind !== "human" ||
+      session.id !== binding.id ||
+      session.principalId !== binding.principalId ||
+      session.domainId !== binding.domainId ||
+      domain.id !== binding.domainId ||
+      session.principal.issuer !== principal.issuer ||
+      session.principal.subject !== principal.subject ||
+      session.principal.kind !== principal.kind
+    ) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "authentication required"));
+      return;
+    }
+  }
   const authError = authorizeGatewayMethod(req.method, client, req.params, methodRegistry);
   if (authError) {
     respond(false, undefined, authError);
@@ -864,11 +894,19 @@ export async function handleGatewayRequest(
     );
     return;
   }
+  const principalKind = client?.principal?.kind;
+  const requiresStateAuthorization =
+    role === "member" ||
+    (domain !== undefined && (principalKind === "human" || principalKind === "service"));
+  const authorizationRuntime =
+    requiresStateAuthorization && context.authorization.mode === "legacy"
+      ? createStateGatewayAuthorizationRuntime()
+      : context.authorization;
   const access = await authorizeGatewayAccess({
-    runtime: context.authorization,
+    runtime: authorizationRuntime,
     policy: methodRegistry.getAccessPolicy(req.method),
     principal: client?.principal,
-    domain: getGatewayClientAuthorizationDomain(client),
+    domain,
     delegation: getGatewayClientAuthorizationDelegation(client),
     method: req.method,
     params: req.params,

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -12,7 +12,10 @@ import {
   isGatewayRestartDraining,
   tryBeginGatewayRootWorkAdmission,
 } from "../process/gateway-work-admission.js";
-import { getGatewayClientAuthorizationDomain } from "./authorization/client-domain.js";
+import {
+  getGatewayClientAuthorizationDelegation,
+  getGatewayClientAuthorizationDomain,
+} from "./authorization/client-domain.js";
 import { authorizeGatewayAccess } from "./authorization/kernel.js";
 import { withGatewayAuthorizationContext } from "./authorization/request-context.js";
 import { formatControlPlaneActor, resolveControlPlaneActor } from "./control-plane-audit.js";
@@ -866,6 +869,7 @@ export async function handleGatewayRequest(
     policy: methodRegistry.getAccessPolicy(req.method),
     principal: client?.principal,
     domain: getGatewayClientAuthorizationDomain(client),
+    delegation: getGatewayClientAuthorizationDelegation(client),
     method: req.method,
     params: req.params,
     getConfig: context.getRuntimeConfig,
@@ -981,8 +985,16 @@ export async function handleGatewayRequest(
   // subagent methods (e.g. context engine tools spawning sub-agents
   // during tool execution) can dispatch back into the gateway.
   // The scope also carries caller identity into plugin-owned gateway methods.
+  const methodOwner = methodRegistry.getOwner(req.method);
+  const requestAuthorizationContext = access.security
+    ? Object.freeze({
+        ...access.security,
+        requestId: req.id,
+        ...(methodOwner?.kind === "plugin" ? { pluginId: methodOwner.pluginId } : {}),
+      })
+    : undefined;
   const invokeWithRequestScope = async () =>
-    await withGatewayAuthorizationContext(access.security, () =>
+    await withGatewayAuthorizationContext(requestAuthorizationContext, () =>
       withPluginRuntimeGatewayRequestScope({ context, client, isWebchatConnect }, invokeHandler),
     );
   if (!rootWorkAdmission) {

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -12,7 +12,9 @@ import {
   isGatewayRestartDraining,
   tryBeginGatewayRootWorkAdmission,
 } from "../process/gateway-work-admission.js";
+import { getGatewayClientAuthorizationDomain } from "./authorization/client-domain.js";
 import { authorizeGatewayAccess } from "./authorization/kernel.js";
+import { withGatewayAuthorizationContext } from "./authorization/request-context.js";
 import { formatControlPlaneActor, resolveControlPlaneActor } from "./control-plane-audit.js";
 import { consumeControlPlaneWriteBudget } from "./control-plane-rate-limit.js";
 import {
@@ -863,6 +865,7 @@ export async function handleGatewayRequest(
     runtime: context.authorization,
     policy: methodRegistry.getAccessPolicy(req.method),
     principal: client?.principal,
+    domain: getGatewayClientAuthorizationDomain(client),
     method: req.method,
     params: req.params,
     getConfig: context.getRuntimeConfig,
@@ -979,9 +982,8 @@ export async function handleGatewayRequest(
   // during tool execution) can dispatch back into the gateway.
   // The scope also carries caller identity into plugin-owned gateway methods.
   const invokeWithRequestScope = async () =>
-    await withPluginRuntimeGatewayRequestScope(
-      { context, client, isWebchatConnect },
-      invokeHandler,
+    await withGatewayAuthorizationContext(access.security, () =>
+      withPluginRuntimeGatewayRequestScope({ context, client, isWebchatConnect }, invokeHandler),
     );
   if (!rootWorkAdmission) {
     await invokeWithRequestScope();

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -105,6 +105,7 @@ const mocks = vi.hoisted(() => ({
       lastInteractionAt: entry?.lastInteractionAt,
     }),
   ),
+  resolveAuthorizedGatewayAgentAuthorizationSubject: vi.fn(),
   lifecycleGeneration: "test-generation",
 }));
 
@@ -165,6 +166,11 @@ vi.mock("../../config/sessions/session-accessor.js", async () => {
 vi.mock("../../commands/agent.js", () => ({
   agentCommand: mocks.agentCommand,
   agentCommandFromIngress: mocks.agentCommand,
+}));
+
+vi.mock("../authorization/agent-session-bindings.js", () => ({
+  resolveAuthorizedGatewayAgentAuthorizationSubject:
+    mocks.resolveAuthorizedGatewayAgentAuthorizationSubject,
 }));
 
 vi.mock("../../acp/runtime/session-meta.js", async () => {
@@ -836,6 +842,21 @@ function operatorWriteCliClient(): AgentHandlerArgs["client"] {
   } as AgentHandlerArgs["client"];
 }
 
+function authenticatedHumanGatewayClient(): AgentHandlerArgs["client"] {
+  const client = operatorWriteGatewayClient();
+  if (!client) {
+    throw new Error("expected authenticated gateway client");
+  }
+  return {
+    ...client,
+    principal: {
+      issuer: "trusted-proxy",
+      subject: "owner@example.com",
+      kind: "human",
+    },
+  };
+}
+
 async function waitForAgentCommandCall<
   T extends AgentCommandCall = AgentCommandCall,
 >(): Promise<T> {
@@ -963,10 +984,216 @@ describe("gateway agent handler", () => {
           lastInteractionAt: entry?.lastInteractionAt,
         }),
       );
+    mocks.resolveAuthorizedGatewayAgentAuthorizationSubject.mockReset();
     mocks.lifecycleGeneration = "test-generation";
     dateOnlyFakeClockActive = false;
     vi.useRealTimers();
     resetExecApprovalFollowupRuntimeHandoffsForTests();
+  });
+
+  it("issues the bound service-agent authorization subject only to a direct authenticated run", async () => {
+    const authorizationSubject = Object.freeze({
+      principal: Object.freeze({ issuer: "core", subject: "agent:main", kind: "service" as const }),
+      domain: Object.freeze({ id: "domain-1" }),
+      delegation: Object.freeze({ id: "delegation-1", assignmentId: "assignment-1" }),
+    });
+    primeMainAgentRun();
+    mocks.agentCommand.mockClear();
+    mocks.resolveAuthorizedGatewayAgentAuthorizationSubject.mockResolvedValue(authorizationSubject);
+
+    await invokeAgent(
+      {
+        message: "authorized direct run",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        idempotencyKey: "teams-auth-direct",
+      },
+      { client: authenticatedHumanGatewayClient(), reqId: "teams-auth-direct" },
+    );
+
+    await waitForAgentCommandCall();
+    expect(mocks.resolveAuthorizedGatewayAgentAuthorizationSubject).toHaveBeenCalledOnce();
+    expect(mocks.resolveAuthorizedGatewayAgentAuthorizationSubject).toHaveBeenCalledWith({
+      invokingPrincipal: {
+        issuer: "trusted-proxy",
+        subject: "owner@example.com",
+        kind: "human",
+      },
+      runtimeAgentId: "main",
+      sessionKey: "agent:main:main",
+    });
+    const commandInvocation = mocks.agentCommand.mock.calls.at(-1);
+    expect(commandInvocation?.[0]).not.toHaveProperty("authorizationSubject");
+    expect(commandInvocation?.[3]).toEqual({ authorizationSubject });
+  });
+
+  it("continues without authority when the final agent session has no binding", async () => {
+    primeMainAgentRun();
+    mocks.agentCommand.mockClear();
+    mocks.resolveAuthorizedGatewayAgentAuthorizationSubject.mockResolvedValue(undefined);
+
+    await invokeAgent(
+      {
+        message: "unbound direct run",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        idempotencyKey: "teams-auth-unbound",
+      },
+      { client: authenticatedHumanGatewayClient(), reqId: "teams-auth-unbound" },
+    );
+
+    await waitForAgentCommandCall();
+    expect(mocks.resolveAuthorizedGatewayAgentAuthorizationSubject).toHaveBeenCalledOnce();
+    expect(mocks.agentCommand.mock.calls.at(-1)?.[3]).toBeUndefined();
+  });
+
+  it("continues without authority when caller authorization resolution fails", async () => {
+    primeMainAgentRun();
+    mocks.agentCommand.mockClear();
+    mocks.resolveAuthorizedGatewayAgentAuthorizationSubject.mockRejectedValue(
+      new Error("authorization state unavailable"),
+    );
+    const context = makeContext();
+
+    await invokeAgent(
+      {
+        message: "authorization lookup failure",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        idempotencyKey: "teams-auth-lookup-failure",
+      },
+      {
+        client: authenticatedHumanGatewayClient(),
+        context,
+        reqId: "teams-auth-lookup-failure",
+      },
+    );
+
+    await waitForAgentCommandCall();
+    expect(mocks.agentCommand.mock.calls.at(-1)?.[3]).toBeUndefined();
+    expect(context.logGateway.warn).toHaveBeenCalledWith(
+      expect.stringContaining("continuing without Teams authority"),
+    );
+  });
+
+  it.each([
+    {
+      name: "a null client",
+      client: null,
+      params: {},
+    },
+    {
+      name: "a principal-less operator client",
+      client: operatorWriteGatewayClient(),
+      params: {},
+    },
+    {
+      name: "an internal backend handoff",
+      client: backendGatewayClient(),
+      params: { sessionEffects: "internal" as const, suppressPromptPersistence: true },
+    },
+    {
+      name: "inter-session provenance",
+      client: authenticatedHumanGatewayClient(),
+      params: {
+        inputProvenance: {
+          kind: "inter_session" as const,
+          sourceSessionKey: "agent:main:subagent:child",
+          sourceTool: "sessions_send",
+        },
+      },
+    },
+    {
+      name: "internal-system provenance",
+      client: authenticatedHumanGatewayClient(),
+      params: {
+        inputProvenance: {
+          kind: "internal_system" as const,
+          sourceTool: "runtime_resume",
+        },
+      },
+    },
+    {
+      name: "a one-shot model probe",
+      client: authenticatedHumanGatewayClient(),
+      params: { modelRun: true },
+    },
+    {
+      name: "a cron bootstrap run",
+      client: authenticatedHumanGatewayClient(),
+      params: { bootstrapContextRunKind: "cron" as const },
+    },
+  ])(
+    "does not issue a service-agent authorization subject for $name",
+    async ({ client, params }) => {
+      primeMainAgentRun();
+      mocks.agentCommand.mockClear();
+      mocks.resolveAuthorizedGatewayAgentAuthorizationSubject.mockClear();
+      mocks.resolveAuthorizedGatewayAgentAuthorizationSubject.mockResolvedValue({
+        principal: { issuer: "core", subject: "agent:main", kind: "service" },
+        domain: { id: "domain-1" },
+        delegation: { id: "delegation-1", assignmentId: "assignment-1" },
+      });
+
+      await invokeAgent(
+        {
+          message: "ineligible run",
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          idempotencyKey: `teams-auth-denied-${params.inputProvenance?.kind ?? params.bootstrapContextRunKind ?? (params.modelRun ? "probe" : client ? "backend" : "null")}`,
+          ...params,
+        },
+        { client, reqId: "teams-auth-denied" },
+      );
+
+      await waitForAgentCommandCall();
+      expect(mocks.resolveAuthorizedGatewayAgentAuthorizationSubject).not.toHaveBeenCalled();
+      expect(mocks.agentCommand.mock.calls.at(-1)?.[3]).toBeUndefined();
+    },
+  );
+
+  it("does not issue a service-agent authorization subject to a subagent session", async () => {
+    const sessionKey = "agent:main:subagent:child";
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      entry: {
+        sessionId: "subagent-session-id",
+        updatedAt: Date.now(),
+        spawnedBy: "agent:main:main",
+      },
+      canonicalKey: sessionKey,
+    });
+    mocks.updateSessionStore.mockImplementation(
+      async (_path, updater) =>
+        await updater({
+          [sessionKey]: {
+            sessionId: "subagent-session-id",
+            updatedAt: Date.now(),
+            spawnedBy: "agent:main:main",
+          },
+        }),
+    );
+    mocks.agentCommand.mockResolvedValue({ payloads: [{ text: "ok" }], meta: { durationMs: 100 } });
+    mocks.resolveAuthorizedGatewayAgentAuthorizationSubject.mockResolvedValue({
+      principal: { issuer: "core", subject: "agent:main", kind: "service" },
+      domain: { id: "domain-1" },
+      delegation: { id: "delegation-1", assignmentId: "assignment-1" },
+    });
+
+    await invokeAgent(
+      {
+        message: "subagent work",
+        agentId: "main",
+        sessionKey,
+        idempotencyKey: "teams-auth-denied-subagent",
+      },
+      { client: authenticatedHumanGatewayClient(), reqId: "teams-auth-denied-subagent" },
+    );
+
+    await waitForAgentCommandCall();
+    expect(mocks.resolveAuthorizedGatewayAgentAuthorizationSubject).not.toHaveBeenCalled();
+    expect(mocks.agentCommand.mock.calls.at(-1)?.[3]).toBeUndefined();
   });
 
   it("passes resolved maintenance config to the gateway admission store write", async () => {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -146,6 +146,8 @@ import {
 } from "../../sessions/input-provenance.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import {
+  isCronSessionKey,
+  isSubagentSessionKey,
   parseCronRunScopeSuffix,
   parseRawSessionConversationRef,
   parseThreadSessionSuffix,
@@ -177,6 +179,8 @@ import {
 import { setSafeTimeout } from "../../utils/timer-delay.js";
 import { resolveGatewayAssistantAvatar } from "../assistant-avatar.js";
 import { resolveAssistantIdentity } from "../assistant-identity.js";
+import { resolveAuthorizedGatewayAgentAuthorizationSubject } from "../authorization/agent-session-bindings.js";
+import type { GatewayAuthorizationSubject } from "../authorization/contracts.js";
 import {
   type ChatAbortControllerEntry,
   registerChatAbortController,
@@ -787,6 +791,65 @@ function resolveGatewayAgentTaskTrackingMode(params: {
   return "cli";
 }
 
+async function resolveDirectGatewayAgentAuthorizationSubject(params: {
+  client: GatewayRequestHandlerOptions["client"];
+  runtimeAgentId: string;
+  sessionKey?: string;
+  spawnedBy?: string;
+  inputProvenance?: InputProvenance;
+  bootstrapContextRunKind?: "default" | "heartbeat" | "cron";
+  modelRun: boolean;
+  internalSessionEffects: boolean;
+  hasInternalEvents: boolean;
+  restoredCronContinuation: boolean;
+  logGateway: Pick<GatewayRequestContext["logGateway"], "warn">;
+}): Promise<GatewayAuthorizationSubject | undefined> {
+  const sessionKey = params.sessionKey?.trim();
+  const clientMode = params.client?.connect?.client?.mode;
+  const internalClient = params.client?.internal;
+  if (
+    !params.client?.connect ||
+    !sessionKey ||
+    !params.runtimeAgentId.trim() ||
+    clientMode === GATEWAY_CLIENT_MODES.BACKEND ||
+    params.client.principal?.kind !== "human" ||
+    internalClient?.cronRunContinuation === true ||
+    internalClient?.agentRuntimeIdentity !== undefined ||
+    internalClient?.pluginRuntimeOwnerId !== undefined ||
+    internalClient?.agentRunTracking === "plugin_subagent" ||
+    params.restoredCronContinuation ||
+    params.modelRun ||
+    params.internalSessionEffects ||
+    params.hasInternalEvents ||
+    params.bootstrapContextRunKind === "cron" ||
+    params.bootstrapContextRunKind === "heartbeat" ||
+    params.inputProvenance?.kind === "inter_session" ||
+    params.inputProvenance?.kind === "internal_system" ||
+    Boolean(params.spawnedBy?.trim()) ||
+    isSubagentSessionKey(sessionKey) ||
+    isCronSessionKey(sessionKey) ||
+    isAcpSessionKey(sessionKey)
+  ) {
+    return undefined;
+  }
+  try {
+    return await resolveAuthorizedGatewayAgentAuthorizationSubject({
+      invokingPrincipal: params.client.principal,
+      runtimeAgentId: params.runtimeAgentId,
+      sessionKey,
+    });
+  } catch (error) {
+    // A stale or unavailable authorization binding must never make a normal
+    // agent run fail, and it must never fall back to a broader authority.
+    params.logGateway.warn(
+      `failed to resolve agent authorization subject for ${sessionKey}; continuing without Teams authority: ${formatForLog(
+        error,
+      )}`,
+    );
+    return undefined;
+  }
+}
+
 function isTrustedBackendAcpSpawnClient(client: GatewayRequestHandlerOptions["client"]): boolean {
   // The ACP spawn control plane reaches the gateway through the in-process
   // backend client (src/gateway/call.ts -> mode "backend", id "gateway-client").
@@ -939,6 +1002,7 @@ function deleteGatewayDedupeEntries(params: {
 
 function dispatchAgentRunFromGateway(params: {
   ingressOpts: Parameters<typeof agentCommandFromIngress>[0];
+  authorizationSubject?: GatewayAuthorizationSubject;
   runId: string;
   dedupeKeys: readonly string[];
   /**
@@ -1000,7 +1064,12 @@ function dispatchAgentRunFromGateway(params: {
       return false;
     }
   };
-  void agentCommandFromIngress(params.ingressOpts, defaultRuntime, params.context.deps)
+  void agentCommandFromIngress(
+    params.ingressOpts,
+    defaultRuntime,
+    params.context.deps,
+    params.authorizationSubject ? { authorizationSubject: params.authorizationSubject } : undefined,
+  )
     .then(async (result) => {
       const aborted = result?.meta?.aborted === true;
       const timeoutAttribution = readAgentRunTimeoutAttribution(result?.meta);
@@ -3843,8 +3912,22 @@ export const agentHandlers: GatewayRequestHandlers = {
           }
           const execApprovalFollowupElevatedDefaults =
             execApprovalFollowupRuntimeHandoff?.bashElevated;
+          const authorizationSubject = await resolveDirectGatewayAgentAuthorizationSubject({
+            client,
+            runtimeAgentId: activeSessionAgentId,
+            sessionKey: resolvedSessionKey,
+            spawnedBy: spawnedByValue,
+            inputProvenance,
+            bootstrapContextRunKind: effectiveBootstrapContextRunKind,
+            modelRun: isOneShotModelRun,
+            internalSessionEffects: suppressVisibleSessionEffects,
+            hasInternalEvents: Boolean(request.internalEvents?.length),
+            restoredCronContinuation: restoredCronContinuation !== undefined,
+            logGateway: context.logGateway,
+          });
 
           dispatchAgentRunFromGateway({
+            authorizationSubject,
             ingressOpts: {
               message,
               images,

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -19,6 +19,7 @@ import type {
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { WizardSession } from "../../wizard/session.js";
 import type { AgentRuntimeIdentity } from "../agent-runtime-identity-token.js";
+import type { GatewayAuthorizationRuntime } from "../authorization/contracts.js";
 import type { ChatAbortControllerEntry } from "../chat-abort.js";
 import type { GatewayHotReloadStatus } from "../config-reload-status.types.js";
 import type { ExecApprovalManager, ExecApprovalRecord } from "../exec-approval-manager.js";
@@ -89,6 +90,7 @@ type GatewayCrestodianSession = {
 
 /** Runtime services and mutable gateway state available to request handlers. */
 export type GatewayRequestContext = {
+  authorization: GatewayAuthorizationRuntime;
   deps: CliDeps;
   cron: GatewayCronServiceContract;
   cronStorePath: string;

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -4,6 +4,7 @@ import type { SessionApprovalReplay } from "../../../packages/gateway-protocol/s
 import type {
   ConnectParams,
   ErrorShape,
+  GatewayPrincipal,
   RequestFrame,
 } from "../../../packages/gateway-protocol/src/schema/frames.js";
 import type { ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
@@ -47,6 +48,7 @@ type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 /** Per-connection client metadata captured after the gateway handshake. */
 export type GatewayClient = {
   connect: ConnectParams;
+  principal?: GatewayPrincipal;
   connId?: string;
   clientIp?: string;
   pluginSurfaceUrls?: Record<string, string>;

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -870,6 +870,80 @@ describe("loadGatewayPlugins", () => {
     ).resolves.toEqual({ status: "ok" });
   });
 
+  test("preserves the authenticated principal for scoped nested gateway dispatch", async () => {
+    const context = createTestContext("principal-preserved");
+    const principal = {
+      issuer: "trusted-proxy",
+      subject: "member@example.com",
+      kind: "human" as const,
+    };
+    const client = {
+      connect: {
+        minProtocol: 1,
+        maxProtocol: 1,
+        client: { id: "test", version: "1", platform: "test", mode: "test" },
+        role: "operator" as const,
+        scopes: ["operator.write"],
+      },
+      principal,
+    } as GatewayRequestOptions["client"];
+    handleGatewayRequest.mockImplementationOnce(async (opts: HandleGatewayRequestOptions) => {
+      expect(opts.client?.principal).toEqual(principal);
+      opts.respond(true, { ok: true });
+    });
+
+    await expect(
+      gatewayRequestScopeModule.withPluginRuntimeGatewayRequestScope(
+        { context, client, isWebchatConnect: () => false },
+        () => serverPluginsModule.dispatchGatewayMethodInProcess("sessions.get", { key: "s-1" }),
+      ),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  test("does not copy an ambient principal onto forced synthetic trusted-plugin dispatch", async () => {
+    const context = createTestContext("principal-not-synthetic");
+    const client = {
+      connect: {
+        minProtocol: 1,
+        maxProtocol: 1,
+        client: { id: "test", version: "1", platform: "test", mode: "test" },
+        role: "operator" as const,
+        scopes: ["operator.admin"],
+      },
+      principal: {
+        issuer: "trusted-proxy",
+        subject: "member@example.com",
+        kind: "human" as const,
+      },
+    } as GatewayRequestOptions["client"];
+    handleGatewayRequest.mockImplementationOnce(async (opts: HandleGatewayRequestOptions) => {
+      expect(opts.client?.principal).toBeUndefined();
+      expect(opts.client?.connect.scopes).toEqual(["operator.admin"]);
+      expect(opts.client?.internal?.pluginRuntimeOwnerId).toBe("trusted-plugin-owner");
+      opts.respond(true, { ok: true });
+    });
+
+    await expect(
+      gatewayRequestScopeModule.withPluginRuntimeGatewayRequestScope(
+        { context, client, isWebchatConnect: () => false },
+        () =>
+          gatewayRequestScopeModule.withPluginRuntimePluginScope(
+            { pluginId: "trusted-plugin", pluginOrigin: "bundled" },
+            () =>
+              serverPluginsModule.dispatchGatewayMethodInProcess(
+                "sessions.get",
+                { key: "s-1" },
+                {
+                  forceSyntheticClient: true,
+                  syntheticScopes: ["operator.admin"],
+                  pluginRuntimeOwnerId: "trusted-plugin-owner",
+                },
+              ),
+          ),
+      ),
+    ).resolves.toEqual({ ok: true });
+  });
+
   test("uses one timeout budget across accepted and final in-process responses", async () => {
     vi.useFakeTimers();
     try {

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -30,6 +30,7 @@ import { resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 import {
   inheritGatewayClientAuthorizationDelegation,
   inheritGatewayClientAuthorizationDomain,
+  inheritGatewayClientTeamsSession,
 } from "./authorization/client-domain.js";
 import { ADMIN_SCOPE, APPROVALS_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
 import { normalizeOperatorScopeList, type OperatorScope } from "./operator-scopes.js";
@@ -284,6 +285,7 @@ function mergeGatewayClientInternal(
   };
   inheritGatewayClientAuthorizationDomain(client, merged);
   inheritGatewayClientAuthorizationDelegation(client, merged);
+  inheritGatewayClientTeamsSession(client, merged);
   return merged;
 }
 

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -27,7 +27,10 @@ import type { PluginRuntime, RuntimeGatewayRequestOptions } from "../plugins/run
 import type { PluginLogger, PluginOrigin } from "../plugins/types.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
-import { inheritGatewayClientAuthorizationDomain } from "./authorization/client-domain.js";
+import {
+  inheritGatewayClientAuthorizationDelegation,
+  inheritGatewayClientAuthorizationDomain,
+} from "./authorization/client-domain.js";
 import { ADMIN_SCOPE, APPROVALS_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
 import { normalizeOperatorScopeList, type OperatorScope } from "./operator-scopes.js";
 import type { GatewayRequestHandler, GatewayRequestOptions } from "./server-methods/types.js";
@@ -280,6 +283,7 @@ function mergeGatewayClientInternal(
     },
   };
   inheritGatewayClientAuthorizationDomain(client, merged);
+  inheritGatewayClientAuthorizationDelegation(client, merged);
   return merged;
 }
 

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -27,6 +27,7 @@ import type { PluginRuntime, RuntimeGatewayRequestOptions } from "../plugins/run
 import type { PluginLogger, PluginOrigin } from "../plugins/types.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
+import { inheritGatewayClientAuthorizationDomain } from "./authorization/client-domain.js";
 import { ADMIN_SCOPE, APPROVALS_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
 import { normalizeOperatorScopeList, type OperatorScope } from "./operator-scopes.js";
 import type { GatewayRequestHandler, GatewayRequestOptions } from "./server-methods/types.js";
@@ -271,13 +272,15 @@ function mergeGatewayClientInternal(
   if (!client || !internal) {
     return client ?? null;
   }
-  return {
+  const merged = {
     ...client,
     internal: {
       ...client.internal,
       ...internal,
     },
   };
+  inheritGatewayClientAuthorizationDomain(client, merged);
+  return merged;
 }
 
 type DispatchGatewayMethodInProcessOptions = {

--- a/src/gateway/server-request-context.test.ts
+++ b/src/gateway/server-request-context.test.ts
@@ -102,6 +102,7 @@ describe("createGatewayRequestContext", () => {
 
     const context = createGatewayRequestContext(makeContextParams({ runtimeState }));
 
+    expect(context.authorization).toEqual({ mode: "legacy" });
     expect(context.cron).toBe(cronA);
     expect(context.cronStorePath).toBe("/tmp/cron-a");
 

--- a/src/gateway/server-request-context.ts
+++ b/src/gateway/server-request-context.ts
@@ -94,6 +94,7 @@ export function createGatewayRequestContext(
   };
 
   return {
+    authorization: { mode: "legacy" },
     deps: params.deps,
     // Keep cron reads live so config hot reload can swap cron/store state without rebuilding
     // every handler closure that already holds this request context.

--- a/src/gateway/server/plugins-http.runtime-scopes.test.ts
+++ b/src/gateway/server/plugins-http.runtime-scopes.test.ts
@@ -249,6 +249,81 @@ describe("plugin HTTP route runtime scopes", () => {
     });
   });
 
+  it("threads the authenticated HTTP principal into plugin runtime scope", async () => {
+    const principal = {
+      issuer: "trusted-proxy",
+      subject: "alice@example.com",
+      kind: "human" as const,
+    };
+    let observedPrincipal: AuthorizedGatewayHttpRequest["principal"];
+    const handler = createPluginRequestHandler({
+      routes: [
+        createRoute({
+          path: SECURE_HOOK_PATH,
+          auth: "gateway",
+          handler: async () => {
+            observedPrincipal = getPluginRuntimeGatewayRequestScope()?.client?.principal;
+            return true;
+          },
+        }),
+      ],
+    });
+
+    const { handled, res } = await dispatchPluginRequest(handler, {
+      path: SECURE_HOOK_PATH,
+      authContext: {
+        gatewayAuthSatisfied: true,
+        gatewayRequestAuth: {
+          authMethod: "trusted-proxy",
+          principal,
+          trustDeclaredOperatorScopes: true,
+        },
+        gatewayRequestOperatorScopes: ["operator.read"],
+      },
+    });
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(observedPrincipal).toEqual(principal);
+  });
+
+  it("does not expose an ambient gateway principal to plugin-auth routes", async () => {
+    let observedPrincipal: unknown;
+    const handler = createPluginRequestHandler({
+      routes: [
+        createRoute({
+          path: "/plugin-hook",
+          auth: "plugin",
+          handler: async () => {
+            observedPrincipal = getPluginRuntimeGatewayRequestScope()?.client?.principal;
+            return true;
+          },
+        }),
+      ],
+    });
+
+    const { handled, res } = await dispatchPluginRequest(handler, {
+      path: "/plugin-hook",
+      authContext: {
+        gatewayAuthSatisfied: true,
+        gatewayRequestAuth: {
+          authMethod: "trusted-proxy",
+          principal: {
+            issuer: "trusted-proxy",
+            subject: "alice@example.com",
+            kind: "human",
+          },
+          trustDeclaredOperatorScopes: true,
+        },
+        gatewayRequestOperatorScopes: ["operator.read"],
+      },
+    });
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(observedPrincipal).toBeUndefined();
+  });
+
   it("threads resolved HTTP client IP into the shared control-plane rate identity", async () => {
     const observed: Array<{ clientIp?: string; connId?: string; rateLimitKey: string }> = [];
     const handler = createPluginRequestHandler({

--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -167,8 +167,19 @@ async function invokeImessageWebhook(params: {
   return { handled, res };
 }
 
-async function invokeCanvasGatewayUpgrade(params: { gatewayAuthSatisfied: boolean }) {
-  const routeUpgradeHandler = vi.fn(async () => true);
+async function invokeCanvasGatewayUpgrade(params: {
+  gatewayAuthSatisfied: boolean;
+  principal?: {
+    issuer: string;
+    subject: string;
+    kind: "human";
+  };
+}) {
+  let observedPrincipal: unknown;
+  const routeUpgradeHandler = vi.fn(async () => {
+    observedPrincipal = getPluginRuntimeGatewayRequestScope()?.client?.principal;
+    return true;
+  });
   const handler = createGatewayPluginUpgradeHandler({
     registry: createTestRegistry({
       httpRoutes: [
@@ -190,9 +201,18 @@ async function invokeCanvasGatewayUpgrade(params: { gatewayAuthSatisfied: boolea
     {
       gatewayAuthSatisfied: params.gatewayAuthSatisfied,
       ...(params.gatewayAuthSatisfied ? { gatewayRequestOperatorScopes: ["operator.read"] } : {}),
+      ...(params.principal
+        ? {
+            gatewayRequestAuth: {
+              authMethod: "trusted-proxy" as const,
+              principal: params.principal,
+              trustDeclaredOperatorScopes: true,
+            },
+          }
+        : {}),
     },
   );
-  return { handled, routeUpgradeHandler, socket };
+  return { handled, observedPrincipal, routeUpgradeHandler, socket };
 }
 
 describe("createGatewayPluginRequestHandler", () => {
@@ -574,6 +594,22 @@ describe("createGatewayPluginUpgradeHandler", () => {
     expect(routeUpgradeHandler).toHaveBeenCalledTimes(1);
     expect(socket.destroyed).toBe(false);
     expect(socket.chunks).toStrictEqual([]);
+  });
+
+  it("threads the authenticated principal through gateway upgrade runtime scope", async () => {
+    const principal = {
+      issuer: "trusted-proxy",
+      subject: "alice@example.com",
+      kind: "human" as const,
+    };
+    const { handled, observedPrincipal, routeUpgradeHandler } = await invokeCanvasGatewayUpgrade({
+      gatewayAuthSatisfied: true,
+      principal,
+    });
+
+    expect(handled).toBe(true);
+    expect(routeUpgradeHandler).toHaveBeenCalledTimes(1);
+    expect(observedPrincipal).toEqual(principal);
   });
 });
 

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -51,10 +51,12 @@ function resolvePluginRoutePathContextForRequest(
 function createPluginRouteRuntimeClient(
   scopes: readonly string[],
   clientIp: string | undefined,
+  principal: AuthorizedGatewayHttpRequest["principal"],
 ): GatewayRequestOptions["client"] {
   return {
     connId: `plugin-http:${clientIp ?? "unknown"}`,
     ...(clientIp ? { clientIp } : {}),
+    ...(principal ? { principal } : {}),
     connect: {
       minProtocol: PROTOCOL_VERSION,
       maxProtocol: PROTOCOL_VERSION,
@@ -125,6 +127,7 @@ function createPluginRouteRuntimeScope(params: {
   const runtimeClient = createPluginRouteRuntimeClient(
     runtimeScopes,
     params.gatewayRequestClientIp,
+    params.route.auth === "gateway" ? params.gatewayRequestAuth?.principal : undefined,
   );
   return {
     ...(params.gatewayRequestContext ? { context: params.gatewayRequestContext } : {}),

--- a/src/gateway/server/ws-connection/connect-admission.ts
+++ b/src/gateway/server/ws-connection/connect-admission.ts
@@ -142,6 +142,13 @@ export async function admitGatewayConnect(context: GatewayConnectPhaseContext) {
   const scopes = Array.isArray(connectParams.scopes) ? connectParams.scopes : [];
   connectParams.role = role;
   connectParams.scopes = scopes;
+  if (role === "member" && scopes.length > 0) {
+    const message = "member sessions cannot request operator scopes";
+    markHandshakeFailure("member-scopes-forbidden", { scopeCount: scopes.length });
+    sendHandshakeErrorResponse(ErrorCodes.INVALID_REQUEST, message);
+    close(1008, message);
+    return undefined;
+  }
 
   const isControlUi = isOperatorUiClient(connectParams.client);
   const isBrowserOperatorUi = isBrowserOperatorUiClient(connectParams.client);

--- a/src/gateway/server/ws-connection/connect-auth.ts
+++ b/src/gateway/server/ws-connection/connect-auth.ts
@@ -11,6 +11,7 @@ import {
 import { verifyDeviceToken } from "../../../infra/device-pairing.js";
 import type { DeviceBootstrapProfile } from "../../../shared/device-bootstrap-profile.js";
 import type { GatewayAuthResult } from "../../auth.js";
+import { resolveTeamsSessionFromRequest } from "../../teams-http.js";
 import { formatForLog } from "../../ws-log.js";
 import { truncateCloseReason } from "../close-reason.js";
 import { resolveSharedGatewaySessionGeneration } from "../ws-shared-generation.js";
@@ -95,6 +96,7 @@ export async function authenticateGatewayConnect(
     isWebchat,
     isNativeAppUi,
   } = admission;
+  const teamsSession = role === "member" ? resolveTeamsSessionFromRequest(upgradeReq) : undefined;
 
   const deviceRaw = connectParams.device;
   const hasTokenAuth = Boolean(connectParams.auth?.token);
@@ -102,7 +104,13 @@ export async function authenticateGatewayConnect(
   const hasSharedAuth = hasTokenAuth || hasPasswordAuth;
   const controlUiAuthPolicy = resolveControlUiAuthPolicy({
     isControlUi,
-    controlUiConfig: configSnapshot.gateway?.controlUi,
+    controlUiConfig:
+      role === "member"
+        ? {
+            ...configSnapshot.gateway?.controlUi,
+            dangerouslyDisableDeviceAuth: false,
+          }
+        : configSnapshot.gateway?.controlUi,
     deviceRaw,
   });
   const device = controlUiAuthPolicy.device;
@@ -113,7 +121,7 @@ export async function authenticateGatewayConnect(
   if (hasRawHandshakeCredentials) {
     advanceHandshakePhase("auth_credentials_received");
   }
-  const connectAuthState = await resolveConnectAuthState({
+  const sharedConnectAuthState = await resolveConnectAuthState({
     resolvedAuth,
     connectAuth: connectParams.auth,
     hasDeviceIdentity: Boolean(device),
@@ -123,6 +131,33 @@ export async function authenticateGatewayConnect(
     rateLimiter: authRateLimiter,
     clientIp: browserRateLimitClientIp,
   });
+  const connectAuthState =
+    role !== "member"
+      ? sharedConnectAuthState
+      : teamsSession
+        ? {
+            ...sharedConnectAuthState,
+            authResult: {
+              ok: true,
+              method: "teams-session" as const,
+              principal: teamsSession.principal,
+            },
+            authOk: true,
+            authMethod: "teams-session" as const,
+            sharedAuthOk: false,
+            sharedAuthProvided: false,
+          }
+        : {
+            ...sharedConnectAuthState,
+            authResult: { ok: false, reason: "teams_session_required" },
+            authOk: false,
+            authMethod: "teams-session" as const,
+            sharedAuthOk: false,
+            sharedAuthProvided: false,
+            bootstrapTokenCandidate: undefined,
+            deviceTokenCandidate: undefined,
+            deviceTokenCandidateSource: undefined,
+          };
   const {
     sharedAuthOk,
     bootstrapTokenCandidate,
@@ -204,6 +239,10 @@ export async function authenticateGatewayConnect(
     });
     close(1008, truncateCloseReason(authMessage));
   };
+  if (role === "member" && !teamsSession) {
+    rejectUnauthorized(connectAuthState.authResult);
+    return undefined;
+  }
   const clearUnboundScopes = () => {
     if (scopes.length > 0) {
       scopes = [];
@@ -470,6 +509,7 @@ export async function authenticateGatewayConnect(
     sessionSharedGatewaySessionGeneration,
     issuedBootstrapProfile,
     handoffBootstrapProfile,
+    teamsSession,
     trustedProxyAuthOk,
     skipControlUiPairingForDevice,
     skipLocalBackendSelfPairing,

--- a/src/gateway/server/ws-connection/connect-device-pairing.ts
+++ b/src/gateway/server/ws-connection/connect-device-pairing.ts
@@ -72,6 +72,7 @@ export async function authorizeGatewayConnectDevice(
     authMethod,
     bootstrapTokenCandidate,
     pairingLocality,
+    teamsSession,
     skipLocalBackendSelfPairing,
     skipControlUiPairingForDevice,
   } = state;
@@ -143,6 +144,12 @@ export async function authorizeGatewayConnectDevice(
           isNativeAppUi,
           reason,
         });
+      const allowTeamsMemberSessionPairing =
+        authMethod === "teams-session" &&
+        teamsSession !== undefined &&
+        role === "member" &&
+        scopes.length === 0 &&
+        isControlUi;
       const allowSilentTrustedCidrsNodePairing = shouldAutoApproveNodePairingFromTrustedCidrs({
         existingPairedDevice: Boolean(existingPairedDevice),
         role,
@@ -229,6 +236,7 @@ export async function authorizeGatewayConnectDevice(
           reason === "scope-upgrade"
             ? false
             : allowSilentLocalPairing ||
+              allowTeamsMemberSessionPairing ||
               allowSilentTrustedCidrsNodePairing ||
               allowSetupCodeMobileBootstrapPairing ||
               allowControlUiOperatorBootstrapPairing,
@@ -278,7 +286,11 @@ export async function authorizeGatewayConnectDevice(
               // Same-host local approvals are prune-eligible "silent";
               // trusted-CIDR approvals cross hosts and must never be
               // auto-pruned, so they carry their own provenance.
-              approvedVia: allowSilentLocalPairing ? "silent" : "trusted-cidr",
+              approvedVia: allowTeamsMemberSessionPairing
+                ? "teams-session"
+                : allowSilentLocalPairing
+                  ? "silent"
+                  : "trusted-cidr",
             });
         if (approved?.status === "approved") {
           if (bootstrapApprovalProfile) {

--- a/src/gateway/server/ws-connection/connect-hello.ts
+++ b/src/gateway/server/ws-connection/connect-hello.ts
@@ -14,6 +14,7 @@ import { resolveRuntimeServiceVersion } from "../../../version.js";
 import { listControlUiPluginTabs } from "../../control-ui-plugin-tabs.js";
 import { ADMIN_SCOPE } from "../../method-scopes.js";
 import { scheduleNodeConnectionNotification } from "../../node-connection-notifications.js";
+import { filterAdvertisedGatewayMethodsForRole } from "../../role-policy.js";
 import { MAX_BUFFERED_BYTES, MAX_PAYLOAD_BYTES, TICK_INTERVAL_MS } from "../../server-constants.js";
 import { formatError } from "../../server-utils.js";
 import { formatForLog, logWs } from "../../ws-log.js";
@@ -34,6 +35,7 @@ export async function sendGatewayHello(
     nodeReapprovalCoordinator,
     gatewayMethods,
     events,
+    getMethodRegistry,
     buildRequestContext,
     refreshHealthSnapshot,
     close,
@@ -67,13 +69,26 @@ export async function sendGatewayHello(
   const snapshot = buildGatewaySnapshot({
     includeSensitive: scopes.includes(ADMIN_SCOPE),
   });
-  const cachedHealth = getHealthCache();
-  if (cachedHealth) {
+  const cachedHealth = role === "member" ? null : getHealthCache();
+  if (role === "member") {
+    snapshot.presence = [];
+    snapshot.health = {};
+    snapshot.stateVersion.presence = 0;
+    snapshot.stateVersion.health = 0;
+    delete snapshot.sessionDefaults;
+    delete snapshot.updateAvailable;
+  } else if (cachedHealth) {
     snapshot.health = cachedHealth;
     snapshot.stateVersion.health = getHealthVersion();
   }
   const helloOkAuthScopes = deviceToken ? deviceToken.scopes : scopes;
   const controlUiTabs = listControlUiPluginTabs(helloOkAuthScopes);
+  const advertisedMethodRegistry = role === "member" ? getMethodRegistry?.() : undefined;
+  const advertisedGatewayMethods = filterAdvertisedGatewayMethodsForRole(
+    role,
+    gatewayMethods,
+    (method) => advertisedMethodRegistry?.getAccessPolicy(method),
+  );
   const helloOk: HelloOk = {
     type: "hello-ok",
     protocol: PROTOCOL_VERSION,
@@ -82,16 +97,18 @@ export async function sendGatewayHello(
       connId,
     },
     features: {
-      methods: gatewayMethods,
-      events,
+      methods: advertisedGatewayMethods,
+      events: role === "member" ? [] : events,
       capabilities: [
         GATEWAY_SERVER_CAPS.CHAT_SEND_ROUTING_CONTRACT,
         GATEWAY_SERVER_CAPS.CRESTODIAN_SETUP_MODEL_REF,
       ],
     },
     snapshot,
-    ...(controlUiTabs.length > 0 ? { controlUiTabs } : {}),
-    ...(Object.keys(pluginSurfaceUrls).length > 0 ? { pluginSurfaceUrls } : {}),
+    ...(role !== "member" && controlUiTabs.length > 0 ? { controlUiTabs } : {}),
+    ...(role !== "member" && Object.keys(pluginSurfaceUrls).length > 0
+      ? { pluginSurfaceUrls }
+      : {}),
     auth: {
       role,
       scopes: helloOkAuthScopes,
@@ -221,7 +238,7 @@ export async function sendGatewayHello(
   }
   logWs("out", "hello-ok", {
     connId,
-    methods: gatewayMethods.length,
+    methods: advertisedGatewayMethods.length,
     events: events.length,
     presence: snapshot.presence.length,
     stateVersion: snapshot.stateVersion.presence,

--- a/src/gateway/server/ws-connection/connect-hello.ts
+++ b/src/gateway/server/ws-connection/connect-hello.ts
@@ -2,6 +2,7 @@
 import {
   GATEWAY_SERVER_CAPS,
   PROTOCOL_VERSION,
+  type HelloOk,
 } from "../../../../packages/gateway-protocol/src/index.js";
 import {
   redeemDeviceBootstrapTokenProfile,
@@ -56,6 +57,7 @@ export async function sendGatewayHello(
     hasTokenAuth,
     hasPasswordAuth,
     bootstrapTokenCandidate,
+    authResult,
     authMethod,
     issuedBootstrapProfile,
     handoffBootstrapProfile,
@@ -72,7 +74,7 @@ export async function sendGatewayHello(
   }
   const helloOkAuthScopes = deviceToken ? deviceToken.scopes : scopes;
   const controlUiTabs = listControlUiPluginTabs(helloOkAuthScopes);
-  const helloOk = {
+  const helloOk: HelloOk = {
     type: "hello-ok",
     protocol: PROTOCOL_VERSION,
     server: {
@@ -93,6 +95,7 @@ export async function sendGatewayHello(
     auth: {
       role,
       scopes: helloOkAuthScopes,
+      ...(authResult.principal ? { principal: authResult.principal } : {}),
       ...(deviceToken
         ? {
             deviceToken: deviceToken.token,

--- a/src/gateway/server/ws-connection/connect-session.ts
+++ b/src/gateway/server/ws-connection/connect-session.ts
@@ -19,6 +19,10 @@ import { recordRemoteNodeInfo, refreshRemoteNodeBins } from "../../../skills/run
 import { isEphemeralGatewayClient } from "../../../utils/message-channel.js";
 import { resolveRuntimeServiceVersion } from "../../../version.js";
 import { verifyAgentRuntimeIdentityToken } from "../../agent-runtime-identity-token.js";
+import {
+  bindGatewayClientAuthorizationDomain,
+  bindGatewayClientTeamsSession,
+} from "../../authorization/client-domain.js";
 import { APPROVALS_SCOPE } from "../../method-scopes.js";
 import { isOperatorApprovalRuntimeToken } from "../../operator-approval-runtime-token.js";
 import {
@@ -119,6 +123,7 @@ export async function attachAuthenticatedGatewayConnect(
     pairingLocality,
     sessionUsesSharedGatewayAuth,
     sessionSharedGatewaySessionGeneration,
+    teamsSession,
   } = state;
   if (!(await prepareGatewayNodeConnect(context, state))) {
     return;
@@ -237,6 +242,14 @@ export async function attachAuthenticatedGatewayConnect(
       ? { pluginNodeCapabilitySurfaces }
       : {}),
   };
+  if (teamsSession) {
+    bindGatewayClientAuthorizationDomain(nextClient, { id: teamsSession.domainId });
+    bindGatewayClientTeamsSession(nextClient, {
+      id: teamsSession.id,
+      principalId: teamsSession.principalId,
+      domainId: teamsSession.domainId,
+    });
+  }
   for (const entry of pendingPluginNodeCapabilities) {
     setClientPluginNodeCapability({
       client: nextClient,

--- a/src/gateway/server/ws-connection/connect-session.ts
+++ b/src/gateway/server/ws-connection/connect-session.ts
@@ -114,6 +114,7 @@ export async function attachAuthenticatedGatewayConnect(
     role,
     scopes,
     device,
+    authResult,
     authMethod,
     pairingLocality,
     sessionUsesSharedGatewayAuth,
@@ -222,6 +223,7 @@ export async function attachAuthenticatedGatewayConnect(
   const nextClient: GatewayWsClient = {
     socket,
     connect: connectParams,
+    ...(authResult.principal ? { principal: authResult.principal } : {}),
     connId,
     connectionKind: "gateway",
     isDeviceTokenAuth: authMethod === "device-token",

--- a/src/gateway/server/ws-connection/message-handler-types.ts
+++ b/src/gateway/server/ws-connection/message-handler-types.ts
@@ -11,6 +11,7 @@ import type { createSubsystemLogger } from "../../../logging/subsystem.js";
 import type { DeviceBootstrapProfile } from "../../../shared/device-bootstrap-profile.js";
 import type { AuthRateLimiter } from "../../auth-rate-limit.js";
 import type { GatewayAuthResult, ResolvedGatewayAuth } from "../../auth.js";
+import type { TeamsSession } from "../../authorization/teams-identity.js";
 import type { GatewayMethodRegistry } from "../../methods/registry.js";
 import type { NodePairingAutoApproveClientIpSource } from "../../node-pairing-auto-approve.js";
 import type { NodeReapprovalCoordinator } from "../../node-reapproval-coordinator.js";
@@ -140,6 +141,7 @@ export type AuthenticatedGatewayConnect = {
   sessionSharedGatewaySessionGeneration?: string;
   issuedBootstrapProfile: DeviceBootstrapProfile | null;
   handoffBootstrapProfile: DeviceBootstrapProfile | null;
+  teamsSession?: TeamsSession;
   trustedProxyAuthOk: boolean;
   skipControlUiPairingForDevice: boolean;
   skipLocalBackendSelfPairing: boolean;

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -38,7 +38,7 @@ const {
   getHealthCacheMock: vi.fn(() => null),
   getHealthVersionMock: vi.fn(() => 1),
   incrementPresenceVersionMock: vi.fn(() => 2),
-  loadConfigMock: vi.fn(() => ({
+  loadConfigMock: vi.fn<() => MockGatewayConfig>(() => ({
     gateway: {
       auth: { mode: "none" },
       controlUi: {
@@ -74,6 +74,17 @@ vi.mock("../health-state.js", () => ({
 }));
 
 import { testing, attachGatewayWsMessageHandler } from "./message-handler.js";
+
+type MockGatewayConfig = {
+  gateway: {
+    auth: { mode: string };
+    trustedProxies?: string[];
+    controlUi: {
+      allowedOrigins: string[];
+      dangerouslyDisableDeviceAuth: boolean;
+    };
+  };
+};
 
 const DEVICE_TOKEN_MUTATION_PARAMS = {
   deviceId: "device-1",
@@ -181,6 +192,7 @@ function attachGatewayHarness(options: {
   refreshHealthSnapshot?: GatewayRequestContext["refreshHealthSnapshot"];
   requestOrigin?: string;
   requestHost?: string;
+  requestHeaders?: Record<string, string>;
   remoteAddr?: string;
   localAddr?: string;
   resolvedAuth?: ResolvedGatewayAuth;
@@ -219,6 +231,7 @@ function attachGatewayHarness(options: {
       headers: {
         host: requestHost,
         ...(options.requestOrigin ? { origin: options.requestOrigin } : {}),
+        ...options.requestHeaders,
       },
       socket: { localAddress: localAddr, remoteAddress: remoteAddr },
     } as unknown as IncomingMessage,
@@ -290,6 +303,75 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
   beforeEach(() => {
     resetDiagnosticEventsForTest();
     vi.clearAllMocks();
+    loadConfigMock.mockReturnValue({
+      gateway: {
+        auth: { mode: "none" },
+        controlUi: {
+          allowedOrigins: ["http://127.0.0.1:19001"],
+          dangerouslyDisableDeviceAuth: true,
+        },
+      },
+    });
+  });
+
+  it("retains the server-issued trusted-proxy principal on the connected client", async () => {
+    loadConfigMock.mockReturnValue({
+      gateway: {
+        auth: { mode: "trusted-proxy" },
+        trustedProxies: ["127.0.0.1"],
+        controlUi: {
+          allowedOrigins: ["http://127.0.0.1:19001"],
+          dangerouslyDisableDeviceAuth: true,
+        },
+      },
+    });
+    const harness = attachGatewayHarness({
+      connId: "conn-trusted-principal",
+      connectNonce: "nonce-trusted-principal",
+      requestOrigin: "http://127.0.0.1:19001",
+      requestHeaders: { "x-forwarded-user": "alice@example.com" },
+      resolvedAuth: {
+        mode: "trusted-proxy",
+        allowTailscale: false,
+        trustedProxy: {
+          userHeader: "x-forwarded-user",
+          allowLoopback: true,
+        },
+      },
+    });
+
+    harness.sendConnect("connect-trusted-principal", {
+      minProtocol: PROTOCOL_VERSION,
+      maxProtocol: PROTOCOL_VERSION,
+      client: {
+        id: "openclaw-control-ui",
+        version: "dev",
+        platform: "test",
+        mode: "ui",
+      },
+      role: "operator",
+      scopes: [],
+      caps: [],
+    });
+
+    await vi.waitFor(() => {
+      expect(harness.client).toMatchObject({
+        principal: {
+          issuer: "trusted-proxy",
+          subject: "alice@example.com",
+          kind: "human",
+        },
+      });
+      expect(harness.socketSend).toHaveBeenCalled();
+    });
+    const helloFrame = JSON.parse(harness.socketSend.mock.calls.at(0)?.[0] ?? "{}") as {
+      payload?: { auth?: { principal?: unknown } };
+    };
+    expect(helloFrame.payload?.auth?.principal).toEqual({
+      issuer: "trusted-proxy",
+      subject: "alice@example.com",
+      kind: "human",
+    });
   });
 
   it("closes invalidated clients before dispatching queued requests", () => {

--- a/src/gateway/server/ws-connection/message-handler.teams-session.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.teams-session.test.ts
@@ -1,0 +1,406 @@
+import type { IncomingMessage } from "node:http";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WebSocket } from "ws";
+import { PROTOCOL_VERSION } from "../../../../packages/gateway-protocol/src/index.js";
+import {
+  loadOrCreateDeviceIdentity,
+  publicKeyRawBase64UrlFromPem,
+  signDevicePayload,
+} from "../../../infra/device-identity.js";
+import {
+  getGatewayClientAuthorizationDomain,
+  getGatewayClientTeamsSession,
+} from "../../authorization/client-domain.js";
+import { buildDeviceAuthPayload } from "../../device-auth.js";
+
+const mocks = vi.hoisted(() => ({
+  pairedPublicKey: "",
+  resolveTeamsSessionFromRequest: vi.fn(),
+  getPairedDevice: vi.fn(async () => null as unknown),
+  requestDevicePairing: vi.fn(async () => null as unknown),
+  approveDevicePairing: vi.fn(async () => null as unknown),
+  ensureDeviceToken: vi.fn(async () => ({
+    token: "member-device-token",
+    role: "member",
+    scopes: [],
+    createdAtMs: 1,
+  })),
+  updatePairedDeviceMetadata: vi.fn(async () => undefined),
+  loadConfig: vi.fn(() => ({
+    gateway: {
+      auth: { mode: "token" },
+      controlUi: {
+        allowedOrigins: ["https://gateway.example.com"],
+        dangerouslyDisableDeviceAuth: true,
+      },
+    },
+  })),
+}));
+
+vi.mock("../../teams-http.js", () => ({
+  resolveTeamsSessionFromRequest: mocks.resolveTeamsSessionFromRequest,
+}));
+
+vi.mock("../../../config/config.js", () => ({
+  getRuntimeConfig: mocks.loadConfig,
+  loadConfig: mocks.loadConfig,
+}));
+
+vi.mock("../../../config/io.js", () => ({
+  getRuntimeConfig: mocks.loadConfig,
+}));
+
+vi.mock("../../../infra/device-pairing.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../infra/device-pairing.js")>();
+  return {
+    ...actual,
+    getPairedDevice: mocks.getPairedDevice,
+    requestDevicePairing: mocks.requestDevicePairing,
+    approveDevicePairing: mocks.approveDevicePairing,
+    ensureDeviceToken: mocks.ensureDeviceToken,
+    updatePairedDeviceMetadata: mocks.updatePairedDeviceMetadata,
+    hasEffectivePairedDeviceRole: vi.fn(() => true),
+    listApprovedPairedDeviceRoles: vi.fn(() => ["member"]),
+    listEffectivePairedDeviceRoles: vi.fn(() => ["member"]),
+  };
+});
+
+vi.mock("../../../infra/system-presence.js", () => ({
+  upsertPresence: vi.fn(),
+}));
+
+vi.mock("../health-state.js", () => ({
+  buildGatewaySnapshot: vi.fn(() => ({
+    presence: [{ host: "192.168.1.99", deviceId: "other-device" }],
+    health: { channels: { telegram: { accountId: "other-account" } } },
+    stateVersion: { presence: 1, health: 1 },
+    uptimeMs: 1,
+    sessionDefaults: {
+      defaultAgentId: "main",
+      mainKey: "main",
+      mainSessionKey: "main",
+      scope: "per-sender",
+    },
+  })),
+  getHealthCache: vi.fn(() => null),
+  getHealthVersion: vi.fn(() => 1),
+  incrementPresenceVersion: vi.fn(() => 2),
+}));
+
+import { attachGatewayWsMessageHandler } from "./message-handler.js";
+
+const teamsSession = Object.freeze({
+  id: "teams-session-1",
+  accountId: "account-1",
+  principalId: "principal-1",
+  principal: Object.freeze({
+    issuer: "openclaw-local",
+    subject: "member@example.com",
+    kind: "human" as const,
+  }),
+  domainId: "domain-1",
+  state: "active" as const,
+  createdAt: 1,
+  expiresAt: Date.now() + 60_000,
+  revokedAt: null,
+  revokedByPrincipalId: null,
+});
+
+function createLogger() {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+function attachHarness() {
+  let onMessage: ((data: string) => void) | undefined;
+  const socketSend = vi.fn((_payload: string, cb?: (err?: Error) => void) => cb?.());
+  const socket = {
+    _receiver: {},
+    send: socketSend,
+    on: vi.fn((event: string, handler: (data: string) => void) => {
+      if (event === "message") {
+        onMessage = handler;
+      }
+      return socket;
+    }),
+  } as unknown as WebSocket;
+  let client: unknown = null;
+  const send = vi.fn();
+  const close = vi.fn();
+  const connectNonce = "member-connect-nonce";
+  const logGateway = createLogger();
+  const upgradeReq = {
+    headers: {
+      host: "gateway.example.com",
+      origin: "https://gateway.example.com",
+      cookie: "openclaw_teams_session=opaque-cookie-token",
+    },
+    socket: { localAddress: "127.0.0.1", remoteAddress: "203.0.113.8" },
+  } as unknown as IncomingMessage;
+
+  attachGatewayWsMessageHandler({
+    socket,
+    upgradeReq,
+    connId: "member-conn-1",
+    remoteAddr: "203.0.113.8",
+    localAddr: "127.0.0.1",
+    requestHost: "gateway.example.com",
+    requestOrigin: "https://gateway.example.com",
+    connectNonce,
+    getResolvedAuth: () => ({ mode: "token", token: "shared-root-secret", allowTailscale: false }),
+    gatewayMethods: [],
+    events: [],
+    extraHandlers: {},
+    buildRequestContext: () => ({ broadcast: vi.fn() }) as never,
+    refreshHealthSnapshot: vi.fn(async () => ({}) as never),
+    send,
+    close,
+    isClosed: () => false,
+    clearHandshakeTimer: vi.fn(),
+    getClient: () => client as never,
+    setClient: (next) => {
+      client = next;
+      return true;
+    },
+    setHandshakeState: vi.fn(),
+    advanceHandshakePhase: vi.fn(),
+    setCloseCause: vi.fn(),
+    setLastFrameMeta: vi.fn(),
+    originCheckMetrics: { hostHeaderFallbackAccepted: 0 },
+    logGateway: logGateway as never,
+    logHealth: createLogger() as never,
+    logWsControl: createLogger() as never,
+  });
+  if (!onMessage) {
+    throw new Error("expected message listener");
+  }
+  return {
+    close,
+    connectNonce,
+    send,
+    sendConnect: (params: Record<string, unknown>) =>
+      onMessage?.(JSON.stringify({ type: "req", id: "connect-1", method: "connect", params })),
+    socketSend,
+    logGateway,
+    get client() {
+      return client;
+    },
+  };
+}
+
+function baseConnectParams() {
+  return {
+    minProtocol: PROTOCOL_VERSION,
+    maxProtocol: PROTOCOL_VERSION,
+    client: {
+      id: "openclaw-control-ui",
+      version: "dev",
+      platform: "test",
+      mode: "ui",
+    },
+    role: "member",
+    scopes: [],
+    caps: [],
+  };
+}
+
+describe("Teams member websocket sessions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.pairedPublicKey = "";
+    mocks.resolveTeamsSessionFromRequest.mockReturnValue(undefined);
+    mocks.getPairedDevice.mockResolvedValue(null);
+    mocks.requestDevicePairing.mockResolvedValue(null);
+    mocks.approveDevicePairing.mockResolvedValue(null);
+  });
+
+  it("does not let a generic shared gateway token mint a member human", async () => {
+    const harness = attachHarness();
+    harness.sendConnect({
+      ...baseConnectParams(),
+      auth: { token: "shared-root-secret" },
+    });
+
+    await vi.waitFor(() => expect(harness.close).toHaveBeenCalled());
+    expect(harness.client).toBeNull();
+    expect(mocks.resolveTeamsSessionFromRequest).toHaveBeenCalledOnce();
+    const errorFrame = harness.send.mock.calls.find(
+      ([frame]) => (frame as { type?: string }).type === "res",
+    )?.[0] as { error?: { message?: string } } | undefined;
+    expect(errorFrame?.error?.message).toMatch(/unauthorized/i);
+  });
+
+  it("requires the signed nonce-bound browser device even when operator device auth is disabled", async () => {
+    mocks.resolveTeamsSessionFromRequest.mockReturnValue(teamsSession);
+    const harness = attachHarness();
+    harness.sendConnect(baseConnectParams());
+
+    await vi.waitFor(() => expect(harness.close).toHaveBeenCalled());
+    expect(harness.client).toBeNull();
+    const errorFrame = harness.send.mock.calls.find(
+      ([frame]) => (frame as { type?: string }).type === "res",
+    )?.[0] as { error?: { message?: string } } | undefined;
+    expect(errorFrame?.error?.message).toContain("device identity");
+  });
+
+  it("rejects operator scopes on a Teams member session", async () => {
+    mocks.resolveTeamsSessionFromRequest.mockReturnValue(teamsSession);
+    const harness = attachHarness();
+    harness.sendConnect({
+      ...baseConnectParams(),
+      scopes: ["operator.admin"],
+    });
+
+    await vi.waitFor(() => expect(harness.close).toHaveBeenCalled());
+    expect(harness.client).toBeNull();
+    const errorFrame = harness.send.mock.calls.find(
+      ([frame]) => (frame as { type?: string }).type === "res",
+    )?.[0] as { error?: { message?: string } } | undefined;
+    expect(errorFrame?.error?.message).toBe("member sessions cannot request operator scopes");
+  });
+
+  it("binds the server-issued principal and exact session domain after signed-device verification", async () => {
+    mocks.resolveTeamsSessionFromRequest.mockReturnValue(teamsSession);
+    const identity = loadOrCreateDeviceIdentity();
+    const publicKey = publicKeyRawBase64UrlFromPem(identity.publicKeyPem);
+    mocks.getPairedDevice.mockResolvedValue({
+      deviceId: identity.deviceId,
+      publicKey,
+      role: "member",
+      roles: ["member"],
+      scopes: [],
+      approvedScopes: [],
+      tokens: {
+        member: {
+          token: "existing-member-device-token",
+          role: "member",
+          scopes: [],
+          createdAtMs: 1,
+        },
+      },
+      platform: "test",
+    });
+    const harness = attachHarness();
+    const signedAt = Date.now();
+    const payload = buildDeviceAuthPayload({
+      deviceId: identity.deviceId,
+      clientId: "openclaw-control-ui",
+      clientMode: "ui",
+      role: "member",
+      scopes: [],
+      signedAtMs: signedAt,
+      token: null,
+      nonce: harness.connectNonce,
+    });
+    harness.sendConnect({
+      ...baseConnectParams(),
+      device: {
+        id: identity.deviceId,
+        publicKey,
+        signature: signDevicePayload(identity.privateKeyPem, payload),
+        signedAt,
+        nonce: harness.connectNonce,
+      },
+    });
+
+    await vi.waitFor(() => expect(harness.client).not.toBeNull());
+    expect(harness.client).toMatchObject({ principal: teamsSession.principal });
+    expect(getGatewayClientAuthorizationDomain(harness.client as never)).toEqual({
+      id: teamsSession.domainId,
+    });
+    expect(getGatewayClientTeamsSession(harness.client as never)).toEqual({
+      id: teamsSession.id,
+      principalId: teamsSession.principalId,
+      domainId: teamsSession.domainId,
+    });
+    expect(harness.socketSend).toHaveBeenCalled();
+    const hello = harness.socketSend.mock.calls
+      .map(
+        ([framePayload]) =>
+          JSON.parse(framePayload) as {
+            payload?: {
+              type?: string;
+              features?: { events?: string[] };
+              snapshot?: Record<string, unknown>;
+            };
+          },
+      )
+      .map((frame) => frame.payload)
+      .find((frame) => frame?.type === "hello-ok");
+    expect(hello?.features?.events).toEqual([]);
+    expect(hello?.snapshot).toMatchObject({ presence: [], health: {} });
+    expect(hello?.snapshot).not.toHaveProperty("sessionDefaults");
+    expect(harness.logGateway.error).not.toHaveBeenCalled();
+    expect(harness.close).not.toHaveBeenCalled();
+  });
+
+  it("silently approves a signed scope-less member device under the authenticated account", async () => {
+    mocks.resolveTeamsSessionFromRequest.mockReturnValue(teamsSession);
+    const identity = loadOrCreateDeviceIdentity();
+    const publicKey = publicKeyRawBase64UrlFromPem(identity.publicKeyPem);
+    mocks.requestDevicePairing.mockResolvedValue({
+      request: {
+        requestId: "member-pairing-1",
+        deviceId: identity.deviceId,
+        publicKey,
+        role: "member",
+        roles: ["member"],
+        scopes: [],
+        silent: true,
+      },
+      created: true,
+      superseded: [],
+    });
+    mocks.approveDevicePairing.mockResolvedValue({
+      status: "approved",
+      device: {
+        deviceId: identity.deviceId,
+        publicKey,
+        role: "member",
+        roles: ["member"],
+        scopes: [],
+        approvedScopes: [],
+        tokens: {},
+        approvedAtMs: Date.now(),
+      },
+    });
+    const harness = attachHarness();
+    const signedAt = Date.now();
+    const payload = buildDeviceAuthPayload({
+      deviceId: identity.deviceId,
+      clientId: "openclaw-control-ui",
+      clientMode: "ui",
+      role: "member",
+      scopes: [],
+      signedAtMs: signedAt,
+      token: null,
+      nonce: harness.connectNonce,
+    });
+    harness.sendConnect({
+      ...baseConnectParams(),
+      device: {
+        id: identity.deviceId,
+        publicKey,
+        signature: signDevicePayload(identity.privateKeyPem, payload),
+        signedAt,
+        nonce: harness.connectNonce,
+      },
+    });
+
+    await vi.waitFor(() => expect(mocks.requestDevicePairing).toHaveBeenCalled());
+    expect(mocks.requestDevicePairing).toHaveBeenCalledWith(
+      expect.objectContaining({ role: "member", scopes: [], silent: true }),
+    );
+    await vi.waitFor(() => expect(mocks.approveDevicePairing).toHaveBeenCalled());
+    expect(mocks.approveDevicePairing).toHaveBeenCalledWith(
+      "member-pairing-1",
+      expect.objectContaining({ approvedVia: "teams-session" }),
+    );
+    expect(harness.logGateway.error).not.toHaveBeenCalled();
+    expect(harness.close).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(harness.client).not.toBeNull());
+    expect(getGatewayClientAuthorizationDomain(harness.client as never)).toEqual({
+      id: teamsSession.domainId,
+    });
+    expect(harness.close).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server/ws-types.ts
+++ b/src/gateway/server/ws-types.ts
@@ -1,6 +1,9 @@
 // Gateway WebSocket client types describe authenticated client state retained by the server.
 import type { WebSocket } from "ws";
-import type { ConnectParams } from "../../../packages/gateway-protocol/src/schema/frames.js";
+import type {
+  ConnectParams,
+  GatewayPrincipal,
+} from "../../../packages/gateway-protocol/src/schema/frames.js";
 import type { AgentRuntimeIdentity } from "../agent-runtime-identity-token.js";
 import type { PluginNodeCapabilityClient } from "../plugin-node-capability.js";
 import type { WorkerConnectionIdentity } from "../worker-environments/connection-identity.js";
@@ -23,6 +26,7 @@ export type GatewayIngressWebSocket = WebSocket & {
 export type GatewayWsClient = PluginNodeCapabilityClient & {
   socket: WebSocket;
   connect: ConnectParams;
+  principal?: GatewayPrincipal;
   connId: string;
   connectionKind?: GatewayWsConnectionKind;
   worker?: WorkerConnectionIdentity;

--- a/src/gateway/teams-flow.integration.test.ts
+++ b/src/gateway/teams-flow.integration.test.ts
@@ -1,0 +1,126 @@
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  bindGatewayClientAuthorizationDomain,
+  bindGatewayClientTeamsSession,
+} from "./authorization/client-domain.js";
+import { bindAuthorizationResource } from "./authorization/state-store.js";
+import { bootstrapTeamsOwner } from "./authorization/teams-bootstrap.js";
+import { revokeTeamsSession } from "./authorization/teams-identity.js";
+import {
+  createTeamsInvite,
+  registerTeamsLocalAccountFromInvite,
+} from "./authorization/teams-invites.js";
+import {
+  createGatewayMethodRegistry,
+  createPluginGatewayMethodDescriptor,
+} from "./methods/registry.js";
+import { handleGatewayRequest } from "./server-methods.js";
+import type { GatewayClient, GatewayRequestHandler } from "./server-methods/types.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  vi.unstubAllEnvs();
+});
+
+afterAll(() => cleanupTempDirs(tempDirs));
+
+describe("Teams owner-to-member authorization flow", () => {
+  it("bootstraps, invites, dispatches one exact tab, and invalidates the open client on logout", async () => {
+    vi.stubEnv("OPENCLAW_STATE_DIR", makeTempDir(tempDirs, "openclaw-teams-flow-"));
+    const owner = await bootstrapTeamsOwner({
+      loginLabel: "owner@example.com",
+      password: "correct horse battery staple",
+      domainId: "domain-1",
+    });
+    const workspace = { namespace: "workspaces", type: "workspace", id: "default" } as const;
+    const sharedTab = { namespace: "workspaces", type: "tab", id: "main" } as const;
+    const privateTab = { namespace: "workspaces", type: "tab", id: "private" } as const;
+    bindAuthorizationResource({
+      domainId: owner.domainId,
+      resource: privateTab,
+      parent: workspace,
+      ownerPrincipalId: owner.account.principalId,
+    });
+    const invite = createTeamsInvite({
+      domainId: owner.domainId,
+      createdByPrincipalId: owner.account.principalId,
+      ttlMs: 60_000,
+      grants: [{ resource: sharedTab, permission: "workspaces.tab.read" }],
+    });
+    const registered = await registerTeamsLocalAccountFromInvite({
+      code: invite.code,
+      loginLabel: "member@example.com",
+      password: "another correct horse battery staple",
+      sessionTtlMs: 60_000,
+    });
+    const session = registered.session.session;
+    const client: GatewayClient = {
+      connId: "member-conn",
+      connect: {
+        role: "member",
+        scopes: [],
+        minProtocol: 1,
+        maxProtocol: 1,
+        client: { id: "openclaw-control-ui", version: "1", platform: "test", mode: "ui" },
+      },
+      principal: session.principal,
+    };
+    bindGatewayClientAuthorizationDomain(client, { id: session.domainId });
+    bindGatewayClientTeamsSession(client, {
+      id: session.id,
+      principalId: session.principalId,
+      domainId: session.domainId,
+    });
+    const handler = vi.fn<GatewayRequestHandler>(({ respond }) => respond(true, { ok: true }));
+    const registry = createGatewayMethodRegistry([
+      createPluginGatewayMethodDescriptor({
+        pluginId: "workspaces",
+        name: "workspaces.tab.get",
+        handler,
+        scope: "operator.read",
+        access: {
+          kind: "resource",
+          member: true,
+          permission: "workspaces.tab.read",
+          resolveResources: ({ params }) => [
+            { namespace: "workspaces", type: "tab", id: (params as { id: string }).id },
+          ],
+        },
+      }),
+    ]);
+    const dispatch = async (id: string) => {
+      const respond = vi.fn();
+      await handleGatewayRequest({
+        req: { type: "req", id: `request-${id}`, method: "workspaces.tab.get", params: { id } },
+        respond,
+        client,
+        isWebchatConnect: () => false,
+        context: {
+          authorization: { mode: "legacy" },
+          getRuntimeConfig: () => ({}),
+          logGateway: { warn: vi.fn() },
+        } as unknown as Parameters<typeof handleGatewayRequest>[0]["context"],
+        methodRegistry: registry,
+      });
+      return respond;
+    };
+
+    expect(await dispatch(sharedTab.id)).toHaveBeenCalledWith(true, { ok: true });
+    expect(await dispatch(privateTab.id)).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "resource not found" }),
+    );
+    revokeTeamsSession({ id: session.id, revokedByPrincipalId: session.principalId });
+    expect(await dispatch(sharedTab.id)).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "authentication required" }),
+    );
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/gateway/teams-http-cookie.ts
+++ b/src/gateway/teams-http-cookie.ts
@@ -1,0 +1,77 @@
+import type { IncomingMessage } from "node:http";
+import { isLoopbackHost } from "./net.js";
+
+export const TEAMS_SESSION_COOKIE_NAME = "openclaw_teams_session";
+
+function hasCookieControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit <= 0x20 || codeUnit === 0x7f) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function parseCookieHeader(header: string | undefined): Map<string, string[]> {
+  const cookies = new Map<string, string[]>();
+  for (const part of header?.split(";") ?? []) {
+    const separator = part.indexOf("=");
+    if (separator <= 0) {
+      continue;
+    }
+    const name = part.slice(0, separator).trim();
+    const value = part.slice(separator + 1).trim();
+    const values = cookies.get(name) ?? [];
+    values.push(value);
+    cookies.set(name, values);
+  }
+  return cookies;
+}
+
+/** Reads the one opaque Teams token; duplicates fail closed to avoid proxy/parser ambiguity. */
+export function readTeamsSessionCookie(req: IncomingMessage): string | undefined {
+  const values = parseCookieHeader(req.headers.cookie).get(TEAMS_SESSION_COOKIE_NAME);
+  if (values?.length !== 1) {
+    return undefined;
+  }
+  const token = values[0];
+  if (!token || token.length > 1_024 || hasCookieControlCharacter(token)) {
+    return undefined;
+  }
+  return token;
+}
+
+export function isExplicitLoopbackHttpDev(params: {
+  directLocalRequest: boolean;
+  requestHost?: string;
+  requestOrigin?: string;
+}): boolean {
+  if (!params.directLocalRequest || !params.requestHost || !params.requestOrigin) {
+    return false;
+  }
+  try {
+    const origin = new URL(params.requestOrigin);
+    const requestHost = new URL(`http://${params.requestHost}`).hostname;
+    return (
+      origin.protocol === "http:" && isLoopbackHost(origin.hostname) && isLoopbackHost(requestHost)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function serializeTeamsSessionCookie(token: string, secure: boolean): string {
+  const attributes = [
+    `${TEAMS_SESSION_COOKIE_NAME}=${token}`,
+    "Path=/",
+    "HttpOnly",
+    ...(secure ? ["Secure"] : []),
+    "SameSite=Strict",
+  ];
+  return attributes.join("; ");
+}
+
+export function serializeExpiredTeamsSessionCookie(secure: boolean): string {
+  return `${serializeTeamsSessionCookie("", secure)}; Max-Age=0`;
+}

--- a/src/gateway/teams-http.test.ts
+++ b/src/gateway/teams-http.test.ts
@@ -1,0 +1,578 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getAuthorizationResourceParent } from "./authorization/resource-operations.js";
+import {
+  authenticateTeamsLocalAccount,
+  createTeamsSession,
+  resolveTeamsSession,
+  revokeTeamsSession,
+} from "./authorization/teams-identity.js";
+import {
+  createTeamsInvite,
+  listTeamsInvites,
+  registerTeamsLocalAccountFromInvite,
+  revokeTeamsInvite,
+} from "./authorization/teams-invites.js";
+import { handleTeamsHttpRequest } from "./teams-http.js";
+
+vi.mock("./authorization/teams-identity.js", () => ({
+  authenticateTeamsLocalAccount: vi.fn(),
+  createTeamsSession: vi.fn(),
+  resolveTeamsSession: vi.fn(),
+  revokeTeamsSession: vi.fn(),
+}));
+
+vi.mock("./authorization/teams-invites.js", () => ({
+  createTeamsInvite: vi.fn(),
+  listTeamsInvites: vi.fn(),
+  registerTeamsLocalAccountFromInvite: vi.fn(),
+  revokeTeamsInvite: vi.fn(),
+}));
+
+vi.mock("./authorization/resource-operations.js", () => ({
+  getAuthorizationResourceParent: vi.fn(),
+}));
+
+const account = Object.freeze({
+  id: "account-1",
+  principalId: "principal-1",
+  loginLabel: "member@example.com",
+  createdAt: 1,
+});
+const session = Object.freeze({
+  id: "session-1",
+  accountId: account.id,
+  principalId: account.principalId,
+  principal: Object.freeze({
+    issuer: "openclaw-local",
+    subject: account.loginLabel,
+    kind: "human" as const,
+  }),
+  domainId: "domain-1",
+  state: "active" as const,
+  createdAt: 1,
+  expiresAt: 86_400_001,
+  revokedAt: null,
+  revokedByPrincipalId: null,
+});
+const ownerInvite = Object.freeze({
+  id: "invite-2",
+  domainId: session.domainId,
+  createdByPrincipalId: session.principalId,
+  recipientLabel: "person@example.com",
+  state: "active" as const,
+  createdAt: 2,
+  expiresAt: 3,
+  redeemedAt: null,
+  redeemedByPrincipalId: null,
+  revokedAt: null,
+  grants: [
+    {
+      resource: { namespace: "workspaces", type: "tab", id: "tab-1" },
+      permission: "workspaces.tab.read",
+    },
+  ],
+});
+
+function createRequest(params: {
+  path: string;
+  method?: string;
+  body?: unknown;
+  headers?: Record<string, string>;
+  remoteAddress?: string;
+  includeOrigin?: boolean;
+  encrypted?: boolean;
+}): IncomingMessage {
+  const body = params.body === undefined ? "" : JSON.stringify(params.body);
+  const req = Readable.from(body ? [body] : []) as IncomingMessage;
+  req.method = params.method ?? "GET";
+  req.url = params.path;
+  req.headers = {
+    host: "gateway.example.com",
+    ...(params.includeOrigin === false ? {} : { origin: "https://gateway.example.com" }),
+    ...(body ? { "content-type": "application/json", "content-length": String(body.length) } : {}),
+    ...params.headers,
+  };
+  Object.defineProperty(req, "socket", {
+    value: {
+      remoteAddress: params.remoteAddress ?? "203.0.113.8",
+      encrypted: params.encrypted ?? true,
+    },
+  });
+  return req;
+}
+
+function createResponse(): {
+  res: ServerResponse;
+  headers: Map<string, string | number | readonly string[]>;
+  body: () => string;
+} {
+  const headers = new Map<string, string | number | readonly string[]>();
+  let body = "";
+  const res = {
+    statusCode: 200,
+    setHeader: (name: string, value: string | number | readonly string[]) => {
+      headers.set(name.toLowerCase(), value);
+      return res;
+    },
+    end: (chunk?: string) => {
+      body = chunk ?? "";
+      return res;
+    },
+  } as unknown as ServerResponse;
+  return { res, headers, body: () => body };
+}
+
+async function dispatch(
+  req: IncomingMessage,
+  opts: Partial<Parameters<typeof handleTeamsHttpRequest>[2]> = {},
+) {
+  const response = createResponse();
+  const handled = await handleTeamsHttpRequest(req, response.res, {
+    allowedOrigins: ["https://gateway.example.com"],
+    trustedProxies: [],
+    allowRealIpFallback: false,
+    ...opts,
+  });
+  return { handled, ...response };
+}
+
+describe("Teams HTTP account sessions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateTeamsLocalAccount).mockResolvedValue(account);
+    vi.mocked(createTeamsSession).mockReturnValue({ token: "opaque-session-secret", session });
+    vi.mocked(resolveTeamsSession).mockReturnValue(session);
+    vi.mocked(registerTeamsLocalAccountFromInvite).mockResolvedValue({
+      account,
+      invite: {
+        id: "invite-1",
+        domainId: session.domainId,
+        createdByPrincipalId: "owner-1",
+        recipientLabel: null,
+        state: "redeemed",
+        createdAt: 1,
+        expiresAt: 2,
+        redeemedAt: 1,
+        redeemedByPrincipalId: account.principalId,
+        revokedAt: null,
+        grants: ownerInvite.grants,
+      },
+      session: { token: "invite-session-secret", session },
+      validation: { workspaceId: "default", tabId: "tab-1" },
+    });
+    vi.mocked(createTeamsInvite).mockReturnValue({
+      code: "opaque-invite-code",
+      invite: ownerInvite,
+    });
+    vi.mocked(listTeamsInvites).mockReturnValue([]);
+    vi.mocked(getAuthorizationResourceParent).mockReturnValue({
+      namespace: "workspaces",
+      type: "workspace",
+      id: "default",
+    });
+  });
+
+  it("logs in only to a server-validated domain and returns the token only in a secure cookie", async () => {
+    const result = await dispatch(
+      createRequest({
+        path: "/api/teams/login",
+        method: "POST",
+        body: {
+          loginLabel: account.loginLabel,
+          password: "correct horse battery staple",
+          domainId: session.domainId,
+        },
+      }),
+    );
+
+    expect(result.handled).toBe(true);
+    expect(result.res.statusCode).toBe(200);
+    expect(authenticateTeamsLocalAccount).toHaveBeenCalledWith({
+      loginLabel: account.loginLabel,
+      password: "correct horse battery staple",
+    });
+    expect(createTeamsSession).toHaveBeenCalledWith({
+      accountId: account.id,
+      domainId: session.domainId,
+      ttlMs: 24 * 60 * 60 * 1_000,
+    });
+    expect(result.headers.get("set-cookie")).toBe(
+      "openclaw_teams_session=opaque-session-secret; Path=/; HttpOnly; Secure; SameSite=Strict",
+    );
+    expect(result.body()).not.toContain("opaque-session-secret");
+    expect(JSON.parse(result.body())).toEqual({
+      ok: true,
+      session: {
+        authenticated: true,
+        principal: session.principal,
+        domainId: session.domainId,
+        expiresAt: session.expiresAt,
+      },
+    });
+  });
+
+  it("accepts an origin-less same-origin browser GET but rejects a cross-site fetch", async () => {
+    const sameOrigin = await dispatch(
+      createRequest({
+        path: "/api/teams/session",
+        includeOrigin: false,
+        headers: { "sec-fetch-site": "same-origin" },
+      }),
+    );
+    expect(sameOrigin.res.statusCode).toBe(200);
+
+    const crossSite = await dispatch(
+      createRequest({
+        path: "/api/teams/session",
+        includeOrigin: false,
+        headers: { "sec-fetch-site": "cross-site" },
+      }),
+    );
+    expect(crossSite.res.statusCode).toBe(403);
+  });
+
+  it("uses a non-Secure cookie only for explicit direct loopback HTTP development", async () => {
+    const result = await dispatch(
+      createRequest({
+        path: "/api/teams/login",
+        method: "POST",
+        remoteAddress: "127.0.0.1",
+        encrypted: false,
+        headers: { host: "127.0.0.1:18789", origin: "http://127.0.0.1:18789" },
+        body: {
+          loginLabel: account.loginLabel,
+          password: "correct horse battery staple",
+          domainId: session.domainId,
+        },
+      }),
+      { allowedOrigins: ["http://127.0.0.1:18789"] },
+    );
+
+    expect(result.headers.get("set-cookie")).toBe(
+      "openclaw_teams_session=opaque-session-secret; Path=/; HttpOnly; SameSite=Strict",
+    );
+  });
+
+  it("rejects remote plaintext login and invite credentials before processing them", async () => {
+    const login = await dispatch(
+      createRequest({
+        path: "/api/teams/login",
+        method: "POST",
+        encrypted: false,
+        headers: { host: "192.168.1.20:18789", origin: "http://192.168.1.20:18789" },
+        body: {
+          loginLabel: account.loginLabel,
+          password: "correct horse battery staple",
+          domainId: session.domainId,
+        },
+      }),
+      { allowedOrigins: ["http://192.168.1.20:18789"] },
+    );
+    const invite = await dispatch(
+      createRequest({
+        path: "/api/teams/invites/accept",
+        method: "POST",
+        encrypted: false,
+        headers: { host: "192.168.1.20:18789", origin: "http://192.168.1.20:18789" },
+        body: { code: "one-time-code", loginLabel: account.loginLabel, password: "password" },
+      }),
+      { allowedOrigins: ["http://192.168.1.20:18789"] },
+    );
+
+    expect(login.res.statusCode).toBe(403);
+    expect(invite.res.statusCode).toBe(403);
+    expect(authenticateTeamsLocalAccount).not.toHaveBeenCalled();
+    expect(registerTeamsLocalAccountFromInvite).not.toHaveBeenCalled();
+  });
+
+  it("trusts forwarded HTTPS only from a configured immediate proxy", async () => {
+    const body = {
+      loginLabel: account.loginLabel,
+      password: "correct horse battery staple",
+      domainId: session.domainId,
+    };
+    const spoofed = await dispatch(
+      createRequest({
+        path: "/api/teams/login",
+        method: "POST",
+        encrypted: false,
+        headers: { "x-forwarded-proto": "https" },
+        body,
+      }),
+    );
+    const trusted = await dispatch(
+      createRequest({
+        path: "/api/teams/login",
+        method: "POST",
+        encrypted: false,
+        remoteAddress: "10.0.0.1",
+        headers: { "x-forwarded-proto": "https" },
+        body,
+      }),
+      { trustedProxies: ["10.0.0.1"] },
+    );
+
+    expect(spoofed.res.statusCode).toBe(403);
+    expect(trusted.res.statusCode).toBe(200);
+    expect(trusted.headers.get("set-cookie")).toContain("; Secure;");
+  });
+
+  it("rejects hostile origins before credential verification", async () => {
+    const result = await dispatch(
+      createRequest({
+        path: "/api/teams/login",
+        method: "POST",
+        headers: { origin: "https://evil.example" },
+        body: {
+          loginLabel: account.loginLabel,
+          password: "correct horse battery staple",
+          domainId: session.domainId,
+        },
+      }),
+    );
+
+    expect(result.res.statusCode).toBe(403);
+    expect(result.body()).toBe('{"error":{"message":"Forbidden","type":"forbidden"}}');
+    expect(authenticateTeamsLocalAccount).not.toHaveBeenCalled();
+  });
+
+  it("returns one generic error for invalid credentials and invalid domain membership", async () => {
+    vi.mocked(authenticateTeamsLocalAccount).mockResolvedValueOnce(undefined);
+    const invalidCredentials = await dispatch(
+      createRequest({
+        path: "/api/teams/login",
+        method: "POST",
+        body: { loginLabel: account.loginLabel, password: "wrong", domainId: session.domainId },
+      }),
+    );
+    vi.mocked(createTeamsSession).mockImplementationOnce(() => {
+      throw new Error("Teams session account principal must be a human domain member");
+    });
+    const invalidDomain = await dispatch(
+      createRequest({
+        path: "/api/teams/login",
+        method: "POST",
+        body: {
+          loginLabel: account.loginLabel,
+          password: "correct horse battery staple",
+          domainId: "attacker-selected-domain",
+        },
+      }),
+    );
+
+    expect(invalidCredentials.res.statusCode).toBe(401);
+    expect(invalidDomain.res.statusCode).toBe(401);
+    expect(invalidCredentials.body()).toBe(invalidDomain.body());
+    expect(invalidDomain.body()).not.toContain("domain");
+  });
+
+  it("accepts invite codes only from a POST body and never returns the issued token", async () => {
+    const queryAttempt = await dispatch(
+      createRequest({
+        path: "/api/teams/invites/accept?code=leaked-in-history",
+        method: "POST",
+        body: {
+          loginLabel: account.loginLabel,
+          password: "correct horse battery staple",
+        },
+      }),
+    );
+    expect(queryAttempt.res.statusCode).toBe(400);
+    expect(registerTeamsLocalAccountFromInvite).not.toHaveBeenCalled();
+
+    const accepted = await dispatch(
+      createRequest({
+        path: "/api/teams/invites/accept",
+        method: "POST",
+        body: {
+          code: "invite-code-from-fragment-post-body",
+          loginLabel: account.loginLabel,
+          password: "correct horse battery staple",
+        },
+      }),
+    );
+    expect(accepted.res.statusCode).toBe(201);
+    expect(accepted.headers.get("set-cookie")).toContain(
+      "openclaw_teams_session=invite-session-secret",
+    );
+    expect(accepted.body()).not.toContain("invite-session-secret");
+    expect(JSON.parse(accepted.body())).toMatchObject({
+      destination: { workspaceId: "default", tabId: "tab-1" },
+    });
+    expect(accepted.body()).not.toContain("workspaces.tab.read");
+    expect(registerTeamsLocalAccountFromInvite).toHaveBeenCalledWith({
+      code: "invite-code-from-fragment-post-body",
+      loginLabel: account.loginLabel,
+      password: "correct horse battery staple",
+      sessionTtlMs: 24 * 60 * 60 * 1_000,
+      validateInvite: expect.any(Function),
+    });
+  });
+
+  it("reports expired or revoked cookies as unauthenticated and clears them", async () => {
+    vi.mocked(resolveTeamsSession).mockReturnValueOnce(undefined);
+    const result = await dispatch(
+      createRequest({
+        path: "/api/teams/session",
+        headers: { cookie: "openclaw_teams_session=expired-secret" },
+      }),
+    );
+
+    expect(result.res.statusCode).toBe(200);
+    expect(result.body()).toBe('{"ok":true,"session":{"authenticated":false}}');
+    expect(result.headers.get("set-cookie")).toContain(
+      "openclaw_teams_session=; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=0",
+    );
+  });
+
+  it("revokes the current session on logout without echoing its cookie token", async () => {
+    const result = await dispatch(
+      createRequest({
+        path: "/api/teams/logout",
+        method: "POST",
+        headers: { cookie: "openclaw_teams_session=current-secret" },
+        body: {},
+      }),
+    );
+
+    expect(revokeTeamsSession).toHaveBeenCalledWith({
+      id: session.id,
+      revokedByPrincipalId: session.principalId,
+    });
+    expect(result.res.statusCode).toBe(200);
+    expect(result.body()).toBe('{"ok":true}');
+    expect(result.body()).not.toContain("current-secret");
+    expect(result.headers.get("set-cookie")).toContain("Max-Age=0");
+  });
+
+  it("enforces method, JSON content type, and bounded request bodies", async () => {
+    const wrongMethod = await dispatch(createRequest({ path: "/api/teams/login" }));
+    expect(wrongMethod.res.statusCode).toBe(405);
+
+    const wrongType = await dispatch(
+      createRequest({
+        path: "/api/teams/login",
+        method: "POST",
+        headers: { "content-type": "text/plain" },
+        body: { loginLabel: "a", password: "b", domainId: "c" },
+      }),
+    );
+    expect(wrongType.res.statusCode).toBe(415);
+
+    const oversized = await dispatch(
+      createRequest({
+        path: "/api/teams/login",
+        method: "POST",
+        body: { loginLabel: "a".repeat(20_000), password: "b", domainId: "c" },
+      }),
+    );
+    expect(oversized.res.statusCode).toBe(413);
+  });
+
+  it("issues an owner invite from a closed preset without accepting caller-selected grants", async () => {
+    const created = await dispatch(
+      createRequest({
+        path: "/api/teams/invites",
+        method: "POST",
+        headers: { cookie: "openclaw_teams_session=current-secret" },
+        body: {
+          workspaceId: "default",
+          tabId: "tab-1",
+          preset: "read",
+          recipientLabel: "person@example.com",
+          ttlMs: 60_000,
+        },
+      }),
+    );
+
+    expect(created.res.statusCode).toBe(201);
+    expect(createTeamsInvite).toHaveBeenCalledWith({
+      domainId: session.domainId,
+      createdByPrincipalId: session.principalId,
+      recipientLabel: "person@example.com",
+      ttlMs: 60_000,
+      grants: [
+        {
+          resource: { namespace: "workspaces", type: "tab", id: "tab-1" },
+          permission: "workspaces.tab.read",
+        },
+      ],
+    });
+    expect(created.body()).toContain("opaque-invite-code");
+    expect(created.body()).toContain('"preset":"read"');
+    expect(created.body()).toContain('"tabId":"tab-1"');
+    expect(created.body()).not.toContain("workspaces.tab.read");
+
+    vi.mocked(createTeamsInvite).mockClear();
+    const rejected = await dispatch(
+      createRequest({
+        path: "/api/teams/invites",
+        method: "POST",
+        headers: { cookie: "openclaw_teams_session=current-secret" },
+        body: {
+          workspaceId: "default",
+          tabId: "tab-1",
+          preset: "read",
+          grants: [{ permission: "workspaces.tab.write" }],
+        },
+      }),
+    );
+    expect(rejected.res.statusCode).toBe(400);
+    expect(createTeamsInvite).not.toHaveBeenCalled();
+
+    vi.mocked(getAuthorizationResourceParent).mockReturnValue({
+      namespace: "workspaces",
+      type: "workspace",
+      id: "another-workspace",
+    });
+    const wrongParent = await dispatch(
+      createRequest({
+        path: "/api/teams/invites",
+        method: "POST",
+        headers: { cookie: "openclaw_teams_session=current-secret" },
+        body: { workspaceId: "default", tabId: "tab-1", preset: "read" },
+      }),
+    );
+    expect(wrongParent.res.statusCode).toBe(400);
+    expect(createTeamsInvite).not.toHaveBeenCalled();
+  });
+
+  it("does not disclose an invite code in owner list, revoke, or preset responses", async () => {
+    vi.mocked(listTeamsInvites).mockReturnValueOnce([ownerInvite]);
+    const headers = {
+      cookie: "openclaw_teams_session=current-secret",
+      "content-type": "application/json",
+    };
+    const [presets, listed, revoked] = await Promise.all([
+      dispatch(createRequest({ path: "/api/teams/invite-presets", headers })),
+      dispatch(createRequest({ path: "/api/teams/invites", headers })),
+      dispatch(
+        createRequest({
+          path: "/api/teams/invites/invite-2",
+          method: "DELETE",
+          headers,
+          body: {},
+        }),
+      ),
+    ]);
+
+    expect(presets.res.statusCode).toBe(200);
+    expect(presets.body()).toContain('"read"');
+    expect(presets.body()).not.toContain("workspaces.tab.read");
+    expect(listed.res.statusCode).toBe(200);
+    expect(listed.body()).toContain('"preset":"read"');
+    expect(listed.body()).toContain('"tabId":"tab-1"');
+    expect(revoked.res.statusCode).toBe(200);
+    expect(revokeTeamsInvite).toHaveBeenCalledWith({
+      id: "invite-2",
+      domainId: session.domainId,
+      revokedByPrincipalId: session.principalId,
+    });
+    for (const result of [presets, listed, revoked]) {
+      expect(result.body()).not.toContain("opaque-invite-code");
+      expect(result.body()).not.toContain("workspaces.tab.read");
+    }
+  });
+});

--- a/src/gateway/teams-http.ts
+++ b/src/gateway/teams-http.ts
@@ -1,0 +1,726 @@
+// Gateway-hosted Teams identity routes keep opaque session credentials in HttpOnly cookies.
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { getRuntimeConfig } from "../config/io.js";
+import type { AuthRateLimiter } from "./auth-rate-limit.js";
+import { isLocalDirectRequest } from "./auth.js";
+import { getAuthorizationResourceParent } from "./authorization/resource-operations.js";
+import {
+  authenticateTeamsLocalAccount,
+  createTeamsSession,
+  resolveTeamsSession,
+  revokeTeamsSession,
+  type TeamsSession,
+} from "./authorization/teams-identity.js";
+import {
+  createTeamsInvite,
+  listTeamsInvites,
+  registerTeamsLocalAccountFromInvite,
+  revokeTeamsInvite,
+  type TeamsInvite,
+} from "./authorization/teams-invites.js";
+import {
+  readJsonBodyOrError,
+  sendInvalidRequest,
+  sendJson,
+  sendMethodNotAllowed,
+  sendRateLimited,
+} from "./http-common.js";
+import { isTrustedProxyAddress, resolveRequestClientIp } from "./net.js";
+import { checkBrowserOrigin } from "./origin-check.js";
+import { withSerializedRateLimitAttempt } from "./rate-limit-attempt-serialization.js";
+import {
+  isExplicitLoopbackHttpDev,
+  readTeamsSessionCookie,
+  serializeExpiredTeamsSessionCookie,
+  serializeTeamsSessionCookie,
+} from "./teams-http-cookie.js";
+
+const TEAMS_API_PREFIX = "/api/teams";
+const TEAMS_LOGIN_PATH = `${TEAMS_API_PREFIX}/login`;
+const TEAMS_LOGOUT_PATH = `${TEAMS_API_PREFIX}/logout`;
+const TEAMS_SESSION_PATH = `${TEAMS_API_PREFIX}/session`;
+const TEAMS_INVITE_ACCEPT_PATH = `${TEAMS_API_PREFIX}/invites/accept`;
+const TEAMS_INVITE_PRESETS_PATH = `${TEAMS_API_PREFIX}/invite-presets`;
+const TEAMS_INVITES_PATH = `${TEAMS_API_PREFIX}/invites`;
+const TEAMS_SESSION_TTL_MS = 24 * 60 * 60 * 1_000;
+const MAX_TEAMS_BODY_BYTES = 16 * 1_024;
+const TEAMS_LOGIN_RATE_LIMIT_SCOPE = "teams-login";
+const TEAMS_INVITE_RATE_LIMIT_SCOPE = "teams-invite-accept";
+const TEAMS_INVITE_CREATE_RATE_LIMIT_SCOPE = "teams-invite-create";
+const TEAMS_INVITE_REVOKE_RATE_LIMIT_SCOPE = "teams-invite-revoke";
+
+const TEAMS_INVITE_PRESETS = {
+  read: { label: "Read" },
+  request: { label: "Request changes" },
+  write: { label: "Write" },
+} as const;
+
+type TeamsInvitePreset = keyof typeof TEAMS_INVITE_PRESETS;
+
+type TeamsHttpOptions = {
+  allowedOrigins?: string[];
+  trustedProxies?: string[];
+  allowRealIpFallback?: boolean;
+  rateLimiter?: AuthRateLimiter;
+  sessionTtlMs?: number;
+};
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasExactKeys(value: JsonRecord, keys: readonly string[]): boolean {
+  const actual = Object.keys(value).toSorted();
+  const expected = [...keys].toSorted();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function hasOnlyKeys(
+  value: JsonRecord,
+  required: readonly string[],
+  optional: readonly string[],
+): boolean {
+  const allowed = new Set([...required, ...optional]);
+  return (
+    required.every((key) => key in value) && Object.keys(value).every((key) => allowed.has(key))
+  );
+}
+
+function requiredBodyString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.trim();
+  return normalized || undefined;
+}
+
+function resolveSecureCookie(req: IncomingMessage, options: TeamsHttpOptions): boolean {
+  const trustedProxies = options.trustedProxies ?? [];
+  const allowRealIpFallback = options.allowRealIpFallback === true;
+  const directLocalRequest = isLocalDirectRequest(req, trustedProxies, allowRealIpFallback);
+  return !isExplicitLoopbackHttpDev({
+    directLocalRequest,
+    requestHost: req.headers.host,
+    requestOrigin: req.headers.origin,
+  });
+}
+
+function sendForbidden(res: ServerResponse): void {
+  sendJson(res, 403, { error: { message: "Forbidden", type: "forbidden" } });
+}
+
+function sendGenericLoginFailure(res: ServerResponse): void {
+  sendJson(res, 401, {
+    error: { message: "Invalid login credentials", type: "unauthorized" },
+  });
+}
+
+function sendGenericInviteFailure(res: ServerResponse): void {
+  sendJson(res, 400, {
+    error: { message: "Invite is invalid or unavailable", type: "invalid_request_error" },
+  });
+}
+
+function sendGenericInviteAdminFailure(res: ServerResponse): void {
+  sendJson(res, 400, {
+    error: { message: "Invite request is unavailable", type: "invalid_request_error" },
+  });
+}
+
+function sendUnauthorized(res: ServerResponse): void {
+  sendJson(res, 401, { error: { message: "Unauthorized", type: "unauthorized" } });
+}
+
+function writeSessionCookie(res: ServerResponse, token: string, secure: boolean): void {
+  res.setHeader("Set-Cookie", serializeTeamsSessionCookie(token, secure));
+}
+
+function clearSessionCookie(res: ServerResponse, secure: boolean): void {
+  res.setHeader("Set-Cookie", serializeExpiredTeamsSessionCookie(secure));
+}
+
+function publicSession(session: TeamsSession) {
+  return {
+    authenticated: true,
+    principal: session.principal,
+    domainId: session.domainId,
+    expiresAt: session.expiresAt,
+  } as const;
+}
+
+function publicInvite(invite: TeamsInvite) {
+  const tabIds = new Set(
+    invite.grants
+      .filter((grant) => grant.resource.namespace === "workspaces" && grant.resource.type === "tab")
+      .map((grant) => grant.resource.id),
+  );
+  const permissions = new Set(invite.grants.map((grant) => grant.permission));
+  const preset: TeamsInvitePreset | undefined =
+    permissions.size === 1 && permissions.has("workspaces.tab.read")
+      ? "read"
+      : permissions.size === 2 &&
+          permissions.has("workspaces.tab.read") &&
+          permissions.has("workspaces.tab.changeRequest.create")
+        ? "request"
+        : permissions.size === 2 &&
+            permissions.has("workspaces.tab.read") &&
+            permissions.has("workspaces.tab.write")
+          ? "write"
+          : undefined;
+  return {
+    id: invite.id,
+    ...(preset ? { preset } : {}),
+    ...(tabIds.size === 1 ? { tabId: [...tabIds][0] } : {}),
+    recipientLabel: invite.recipientLabel,
+    state: invite.state,
+    createdAt: invite.createdAt,
+    expiresAt: invite.expiresAt,
+    redeemedAt: invite.redeemedAt,
+    revokedAt: invite.revokedAt,
+  } as const;
+}
+
+function inviteDestination(invite: TeamsInvite): { workspaceId: string; tabId: string } {
+  const tabIds = new Set(
+    invite.grants
+      .filter((grant) => grant.resource.namespace === "workspaces" && grant.resource.type === "tab")
+      .map((grant) => grant.resource.id),
+  );
+  if (tabIds.size !== 1) {
+    throw new Error("Teams invite has no exact tab destination");
+  }
+  const tabId = [...tabIds][0]!;
+  const parent = getAuthorizationResourceParent({
+    domainId: invite.domainId,
+    resource: { namespace: "workspaces", type: "tab", id: tabId },
+  });
+  if (parent?.namespace !== "workspaces" || parent.type !== "workspace") {
+    throw new Error("Teams invite tab destination is unavailable");
+  }
+  return { workspaceId: parent.id, tabId };
+}
+
+function inviteGrants(preset: TeamsInvitePreset, tabId: string) {
+  const resource = { namespace: "workspaces", type: "tab", id: tabId } as const;
+  const permissions =
+    preset === "read"
+      ? ["workspaces.tab.read"]
+      : preset === "request"
+        ? ["workspaces.tab.read", "workspaces.tab.changeRequest.create"]
+        : ["workspaces.tab.read", "workspaces.tab.write"];
+  return permissions.map((permission) => ({ resource, permission }));
+}
+
+function isTeamsInvitePreset(value: unknown): value is TeamsInvitePreset {
+  return typeof value === "string" && value in TEAMS_INVITE_PRESETS;
+}
+
+function checkSameOrigin(req: IncomingMessage, options: TeamsHttpOptions): boolean {
+  const origin = Array.isArray(req.headers.origin) ? undefined : req.headers.origin;
+  const directLocalRequest = isLocalDirectRequest(
+    req,
+    options.trustedProxies ?? [],
+    options.allowRealIpFallback === true,
+  );
+  if (!origin && req.method === "GET") {
+    return directLocalRequest || req.headers["sec-fetch-site"] === "same-origin";
+  }
+  return checkBrowserOrigin({
+    requestHost: req.headers.host,
+    origin,
+    allowedOrigins: options.allowedOrigins,
+    isLocalClient: directLocalRequest,
+  }).ok;
+}
+
+function isSecureTeamsTransport(req: IncomingMessage, options: TeamsHttpOptions): boolean {
+  if ((req.socket as IncomingMessage["socket"] & { encrypted?: boolean }).encrypted === true) {
+    return true;
+  }
+  const directLocalRequest = isLocalDirectRequest(
+    req,
+    options.trustedProxies ?? [],
+    options.allowRealIpFallback === true,
+  );
+  if (
+    isExplicitLoopbackHttpDev({
+      directLocalRequest,
+      requestHost: req.headers.host,
+      requestOrigin: Array.isArray(req.headers.origin) ? undefined : req.headers.origin,
+    })
+  ) {
+    return true;
+  }
+  const forwardedProto = req.headers["x-forwarded-proto"];
+  return (
+    typeof forwardedProto === "string" &&
+    forwardedProto.trim().toLowerCase() === "https" &&
+    isTrustedProxyAddress(req.socket.remoteAddress, options.trustedProxies)
+  );
+}
+
+function requireJsonContentType(req: IncomingMessage, res: ServerResponse): boolean {
+  const contentType = req.headers["content-type"]?.split(";", 1)[0]?.trim().toLowerCase();
+  if (contentType === "application/json") {
+    return true;
+  }
+  sendJson(res, 415, {
+    error: { message: "Content-Type must be application/json", type: "invalid_request_error" },
+  });
+  return false;
+}
+
+async function readStrictJsonRecord(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<JsonRecord | undefined> {
+  if (!requireJsonContentType(req, res)) {
+    return undefined;
+  }
+  const value = await readJsonBodyOrError(req, res, MAX_TEAMS_BODY_BYTES);
+  if (!isRecord(value)) {
+    if (value !== undefined) {
+      sendInvalidRequest(res, "request body must be a JSON object");
+    }
+    return undefined;
+  }
+  return value;
+}
+
+async function withRateLimit<T>(params: {
+  limiter: AuthRateLimiter | undefined;
+  ip: string | undefined;
+  scope: string;
+  res: ServerResponse;
+  attempt: () => Promise<T | undefined>;
+}): Promise<T | undefined> {
+  return await withSerializedRateLimitAttempt({
+    ip: params.ip,
+    scope: params.scope,
+    run: async () => {
+      const limit = params.limiter?.check(params.ip, params.scope);
+      if (limit && !limit.allowed) {
+        sendRateLimited(params.res, limit.retryAfterMs);
+        return undefined;
+      }
+      return await params.attempt();
+    },
+  });
+}
+
+/** Resolves the current request's valid Teams session without exposing its opaque cookie token. */
+export function resolveTeamsSessionFromRequest(req: IncomingMessage): TeamsSession | undefined {
+  const token = readTeamsSessionCookie(req);
+  return token ? resolveTeamsSession({ token }) : undefined;
+}
+
+function requireTeamsSession(req: IncomingMessage, res: ServerResponse): TeamsSession | undefined {
+  const session = resolveTeamsSessionFromRequest(req);
+  if (!session) {
+    sendUnauthorized(res);
+  }
+  return session;
+}
+
+async function handleLogin(
+  req: IncomingMessage,
+  res: ServerResponse,
+  options: TeamsHttpOptions,
+): Promise<void> {
+  if (req.method !== "POST") {
+    sendMethodNotAllowed(res, "POST");
+    return;
+  }
+  const body = await readStrictJsonRecord(req, res);
+  if (!body) {
+    return;
+  }
+  if (!hasExactKeys(body, ["loginLabel", "password", "domainId"])) {
+    sendInvalidRequest(res, "invalid login request");
+    return;
+  }
+  const loginLabel = requiredBodyString(body.loginLabel);
+  const password = requiredBodyString(body.password);
+  const domainId = requiredBodyString(body.domainId);
+  if (!loginLabel || !password || !domainId) {
+    sendInvalidRequest(res, "invalid login request");
+    return;
+  }
+
+  const clientIp = resolveRequestClientIp(
+    req,
+    options.trustedProxies ?? [],
+    options.allowRealIpFallback === true,
+  );
+  await withRateLimit({
+    limiter: options.rateLimiter,
+    ip: clientIp,
+    scope: TEAMS_LOGIN_RATE_LIMIT_SCOPE,
+    res,
+    attempt: async () => {
+      try {
+        const account = await authenticateTeamsLocalAccount({ loginLabel, password });
+        if (!account) {
+          options.rateLimiter?.recordFailure(clientIp, TEAMS_LOGIN_RATE_LIMIT_SCOPE);
+          sendGenericLoginFailure(res);
+          return;
+        }
+        // createTeamsSession performs the authoritative current membership check.
+        const created = createTeamsSession({
+          accountId: account.id,
+          domainId,
+          ttlMs: options.sessionTtlMs ?? TEAMS_SESSION_TTL_MS,
+        });
+        options.rateLimiter?.reset(clientIp, TEAMS_LOGIN_RATE_LIMIT_SCOPE);
+        writeSessionCookie(res, created.token, resolveSecureCookie(req, options));
+        sendJson(res, 200, { ok: true, session: publicSession(created.session) });
+      } catch {
+        options.rateLimiter?.recordFailure(clientIp, TEAMS_LOGIN_RATE_LIMIT_SCOPE);
+        sendGenericLoginFailure(res);
+      }
+    },
+  });
+}
+
+async function handleInviteAcceptance(
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: URL,
+  options: TeamsHttpOptions,
+): Promise<void> {
+  if (req.method !== "POST") {
+    sendMethodNotAllowed(res, "POST");
+    return;
+  }
+  if (url.search) {
+    sendInvalidRequest(res, "invite code must be submitted in the request body");
+    return;
+  }
+  const body = await readStrictJsonRecord(req, res);
+  if (!body) {
+    return;
+  }
+  if (!hasExactKeys(body, ["code", "loginLabel", "password"])) {
+    sendInvalidRequest(res, "invalid invite request");
+    return;
+  }
+  const code = requiredBodyString(body.code);
+  const loginLabel = requiredBodyString(body.loginLabel);
+  const password = requiredBodyString(body.password);
+  if (!code || !loginLabel || !password) {
+    sendInvalidRequest(res, "invalid invite request");
+    return;
+  }
+
+  const clientIp = resolveRequestClientIp(
+    req,
+    options.trustedProxies ?? [],
+    options.allowRealIpFallback === true,
+  );
+  await withRateLimit({
+    limiter: options.rateLimiter,
+    ip: clientIp,
+    scope: TEAMS_INVITE_RATE_LIMIT_SCOPE,
+    res,
+    attempt: async () => {
+      try {
+        const registered = await registerTeamsLocalAccountFromInvite({
+          code,
+          loginLabel,
+          password,
+          sessionTtlMs: options.sessionTtlMs ?? TEAMS_SESSION_TTL_MS,
+          validateInvite: inviteDestination,
+        });
+        options.rateLimiter?.reset(clientIp, TEAMS_INVITE_RATE_LIMIT_SCOPE);
+        const destination = registered.validation as ReturnType<typeof inviteDestination>;
+        writeSessionCookie(res, registered.session.token, resolveSecureCookie(req, options));
+        sendJson(res, 201, {
+          ok: true,
+          session: publicSession(registered.session.session),
+          destination,
+        });
+      } catch {
+        options.rateLimiter?.recordFailure(clientIp, TEAMS_INVITE_RATE_LIMIT_SCOPE);
+        sendGenericInviteFailure(res);
+      }
+    },
+  });
+}
+
+async function handleLogout(
+  req: IncomingMessage,
+  res: ServerResponse,
+  options: TeamsHttpOptions,
+): Promise<void> {
+  if (req.method !== "POST") {
+    sendMethodNotAllowed(res, "POST");
+    return;
+  }
+  const body = await readStrictJsonRecord(req, res);
+  if (!body) {
+    return;
+  }
+  if (!hasExactKeys(body, [])) {
+    sendInvalidRequest(res, "invalid logout request");
+    return;
+  }
+  const session = resolveTeamsSessionFromRequest(req);
+  if (session) {
+    revokeTeamsSession({ id: session.id, revokedByPrincipalId: session.principalId });
+  }
+  clearSessionCookie(res, resolveSecureCookie(req, options));
+  sendJson(res, 200, { ok: true });
+}
+
+function handleSessionStatus(
+  req: IncomingMessage,
+  res: ServerResponse,
+  options: TeamsHttpOptions,
+): void {
+  if (req.method !== "GET") {
+    sendMethodNotAllowed(res, "GET");
+    return;
+  }
+  const session = resolveTeamsSessionFromRequest(req);
+  if (!session) {
+    clearSessionCookie(res, resolveSecureCookie(req, options));
+    sendJson(res, 200, { ok: true, session: { authenticated: false } });
+    return;
+  }
+  sendJson(res, 200, { ok: true, session: publicSession(session) });
+}
+
+function handleInvitePresets(req: IncomingMessage, res: ServerResponse): void {
+  if (req.method !== "GET") {
+    sendMethodNotAllowed(res, "GET");
+    return;
+  }
+  if (!requireTeamsSession(req, res)) {
+    return;
+  }
+  sendJson(res, 200, {
+    ok: true,
+    presets: Object.entries(TEAMS_INVITE_PRESETS).map(([id, preset]) => ({
+      id,
+      label: preset.label,
+    })),
+  });
+}
+
+function handleInviteList(req: IncomingMessage, res: ServerResponse): void {
+  if (req.method !== "GET") {
+    sendMethodNotAllowed(res, "GET");
+    return;
+  }
+  const session = requireTeamsSession(req, res);
+  if (!session) {
+    return;
+  }
+  try {
+    const invites = listTeamsInvites({
+      domainId: session.domainId,
+      requestedByPrincipalId: session.principalId,
+    });
+    sendJson(res, 200, { ok: true, invites: invites.map(publicInvite) });
+  } catch {
+    sendGenericInviteAdminFailure(res);
+  }
+}
+
+async function handleInviteCreate(
+  req: IncomingMessage,
+  res: ServerResponse,
+  options: TeamsHttpOptions,
+): Promise<void> {
+  if (req.method !== "POST") {
+    sendMethodNotAllowed(res, "POST");
+    return;
+  }
+  const session = requireTeamsSession(req, res);
+  if (!session) {
+    return;
+  }
+  const body = await readStrictJsonRecord(req, res);
+  if (!body) {
+    return;
+  }
+  if (!hasOnlyKeys(body, ["workspaceId", "tabId", "preset"], ["recipientLabel", "ttlMs"])) {
+    sendInvalidRequest(res, "invalid invite request");
+    return;
+  }
+  const workspaceId = requiredBodyString(body.workspaceId);
+  const tabId = requiredBodyString(body.tabId);
+  const preset = isTeamsInvitePreset(body.preset) ? body.preset : undefined;
+  const recipientLabel =
+    body.recipientLabel === undefined ? undefined : requiredBodyString(body.recipientLabel);
+  const ttlMs =
+    body.ttlMs === undefined
+      ? undefined
+      : typeof body.ttlMs === "number" && Number.isSafeInteger(body.ttlMs)
+        ? body.ttlMs
+        : undefined;
+  if (
+    !workspaceId ||
+    !tabId ||
+    !preset ||
+    (body.recipientLabel !== undefined && !recipientLabel) ||
+    (body.ttlMs !== undefined && (ttlMs === undefined || ttlMs <= 0))
+  ) {
+    sendInvalidRequest(res, "invalid invite request");
+    return;
+  }
+  const parent = getAuthorizationResourceParent({
+    domainId: session.domainId,
+    resource: { namespace: "workspaces", type: "tab", id: tabId },
+  });
+  if (
+    parent?.namespace !== "workspaces" ||
+    parent.type !== "workspace" ||
+    parent.id !== workspaceId
+  ) {
+    sendGenericInviteAdminFailure(res);
+    return;
+  }
+
+  const clientIp = resolveRequestClientIp(
+    req,
+    options.trustedProxies ?? [],
+    options.allowRealIpFallback === true,
+  );
+  await withRateLimit({
+    limiter: options.rateLimiter,
+    ip: clientIp,
+    scope: TEAMS_INVITE_CREATE_RATE_LIMIT_SCOPE,
+    res,
+    attempt: async () => {
+      try {
+        // The session fixes the domain and human creator; the preset fixes the exact tab grants.
+        const created = createTeamsInvite({
+          domainId: session.domainId,
+          createdByPrincipalId: session.principalId,
+          recipientLabel,
+          ttlMs: ttlMs ?? TEAMS_SESSION_TTL_MS,
+          grants: inviteGrants(preset, tabId),
+        });
+        options.rateLimiter?.reset(clientIp, TEAMS_INVITE_CREATE_RATE_LIMIT_SCOPE);
+        sendJson(res, 201, { ok: true, code: created.code, invite: publicInvite(created.invite) });
+      } catch {
+        options.rateLimiter?.recordFailure(clientIp, TEAMS_INVITE_CREATE_RATE_LIMIT_SCOPE);
+        sendGenericInviteAdminFailure(res);
+      }
+    },
+  });
+}
+
+async function handleInviteRevoke(
+  req: IncomingMessage,
+  res: ServerResponse,
+  inviteId: string,
+  options: TeamsHttpOptions,
+): Promise<void> {
+  if (req.method !== "DELETE") {
+    sendMethodNotAllowed(res, "DELETE");
+    return;
+  }
+  const session = requireTeamsSession(req, res);
+  if (!session) {
+    return;
+  }
+  const body = await readStrictJsonRecord(req, res);
+  if (!body) {
+    return;
+  }
+  if (!hasExactKeys(body, [])) {
+    sendInvalidRequest(res, "invalid invite revoke request");
+    return;
+  }
+  const clientIp = resolveRequestClientIp(
+    req,
+    options.trustedProxies ?? [],
+    options.allowRealIpFallback === true,
+  );
+  await withRateLimit({
+    limiter: options.rateLimiter,
+    ip: clientIp,
+    scope: TEAMS_INVITE_REVOKE_RATE_LIMIT_SCOPE,
+    res,
+    attempt: async () => {
+      try {
+        revokeTeamsInvite({
+          id: inviteId,
+          domainId: session.domainId,
+          revokedByPrincipalId: session.principalId,
+        });
+        options.rateLimiter?.reset(clientIp, TEAMS_INVITE_REVOKE_RATE_LIMIT_SCOPE);
+        sendJson(res, 200, { ok: true });
+      } catch {
+        options.rateLimiter?.recordFailure(clientIp, TEAMS_INVITE_REVOKE_RATE_LIMIT_SCOPE);
+        sendGenericInviteAdminFailure(res);
+      }
+    },
+  });
+}
+
+/** Handles gateway-hosted Teams login/logout/invite/session routes before the SPA catch-all. */
+export async function handleTeamsHttpRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  input: TeamsHttpOptions = {},
+): Promise<boolean> {
+  const url = new URL(req.url ?? "/", "http://localhost");
+  if (
+    url.pathname !== TEAMS_LOGIN_PATH &&
+    url.pathname !== TEAMS_LOGOUT_PATH &&
+    url.pathname !== TEAMS_SESSION_PATH &&
+    url.pathname !== TEAMS_INVITE_ACCEPT_PATH &&
+    url.pathname !== TEAMS_INVITE_PRESETS_PATH &&
+    url.pathname !== TEAMS_INVITES_PATH &&
+    !/^\/api\/teams\/invites\/[^/]+$/.test(url.pathname)
+  ) {
+    return false;
+  }
+  const config = getRuntimeConfig();
+  const options: TeamsHttpOptions = {
+    trustedProxies: input.trustedProxies ?? config.gateway?.trustedProxies ?? [],
+    allowRealIpFallback: input.allowRealIpFallback ?? config.gateway?.allowRealIpFallback ?? false,
+    allowedOrigins: input.allowedOrigins ?? config.gateway?.controlUi?.allowedOrigins,
+    rateLimiter: input.rateLimiter,
+    sessionTtlMs: input.sessionTtlMs,
+  };
+  if (!checkSameOrigin(req, options)) {
+    sendForbidden(res);
+    return true;
+  }
+  if (!isSecureTeamsTransport(req, options)) {
+    sendForbidden(res);
+    return true;
+  }
+
+  if (url.pathname === TEAMS_LOGIN_PATH) {
+    await handleLogin(req, res, options);
+  } else if (url.pathname === TEAMS_INVITE_ACCEPT_PATH) {
+    await handleInviteAcceptance(req, res, url, options);
+  } else if (url.pathname === TEAMS_INVITE_PRESETS_PATH) {
+    handleInvitePresets(req, res);
+  } else if (url.pathname === TEAMS_INVITES_PATH) {
+    if (req.method === "GET") {
+      handleInviteList(req, res);
+    } else {
+      await handleInviteCreate(req, res, options);
+    }
+  } else if (url.pathname.startsWith(`${TEAMS_INVITES_PATH}/`)) {
+    const inviteId = url.pathname.slice(`${TEAMS_INVITES_PATH}/`.length);
+    if (!requiredBodyString(inviteId)) {
+      sendInvalidRequest(res, "invalid invite request");
+    } else {
+      await handleInviteRevoke(req, res, inviteId, options);
+    }
+  } else if (url.pathname === TEAMS_LOGOUT_PATH) {
+    await handleLogout(req, res, options);
+  } else {
+    handleSessionStatus(req, res, options);
+  }
+  return true;
+}

--- a/src/gateway/tool-resolution.exclude.test.ts
+++ b/src/gateway/tool-resolution.exclude.test.ts
@@ -3,6 +3,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { GatewayAuthorizationSubject } from "./authorization/contracts.js";
 
 type CreateOpenClawToolsArg = {
   clientCaps?: string[];
@@ -12,6 +13,7 @@ type CreateOpenClawToolsArg = {
   pluginToolDenylist?: string[];
   sandboxed?: boolean;
   requesterAgentIdOverride?: string;
+  authorizationSubject?: GatewayAuthorizationSubject;
 };
 
 type LazyExecToolDefaults = {
@@ -102,6 +104,22 @@ describe("resolveGatewayScopedTools excludeToolNames", () => {
     });
 
     expect(readCreateToolsArgs().clientCaps).toEqual(["tool-events", "inline-widgets"]);
+  });
+
+  it("forwards the server-owned Teams subject into plugin tool construction", () => {
+    const authorizationSubject = {
+      principal: { issuer: "core", subject: "agent:main", kind: "service" as const },
+      domain: { id: "domain-1" },
+    };
+
+    resolveGatewayScopedTools({
+      cfg: {} as OpenClawConfig,
+      sessionKey: "agent:main:direct:test",
+      surface: "loopback",
+      authorizationSubject,
+    });
+
+    expect(readCreateToolsArgs().authorizationSubject).toBe(authorizationSubject);
   });
 
   it("filters loopback dedup exclusions without inheriting policy denies", () => {

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -57,6 +57,7 @@ import {
 } from "../security/dangerous-tools.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel-constants.js";
 import { normalizeMessageChannel } from "../utils/message-channel-core.js";
+import type { GatewayAuthorizationSubject } from "./authorization/contracts.js";
 
 type GatewayScopedToolSurface = "http" | "loopback";
 
@@ -67,6 +68,7 @@ export function resolveGatewayScopedTools(params: {
   runtimePolicySessionKey?: string;
   agentId?: string;
   sessionId?: string;
+  authorizationSubject?: GatewayAuthorizationSubject;
   modelProvider?: string;
   modelId?: string;
   onYield?: (message: string) => Promise<void> | void;
@@ -272,6 +274,7 @@ export function resolveGatewayScopedTools(params: {
     currentMessageId: params.currentMessageId,
     currentInboundAudio: params.currentInboundAudio,
     sessionId: params.sessionId,
+    authorizationSubject: params.authorizationSubject,
     onYield: params.onYield,
     requireExplicitMessageTarget: params.requireExplicitMessageTarget,
     senderIsOwner: params.senderIsOwner,

--- a/src/infra/device-pairing-store.ts
+++ b/src/infra/device-pairing-store.ts
@@ -49,6 +49,7 @@ const APPROVAL_KIND_MEMBERS = {
   silent: true,
   "trusted-cidr": true,
   "ssh-verified": true,
+  "teams-session": true,
   bootstrap: true,
 } satisfies Record<PairedDeviceApprovalKind, true>;
 const APPROVAL_KINDS = new Set(Object.keys(APPROVAL_KIND_MEMBERS));

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -786,7 +786,7 @@ export async function approveDevicePairing(
     accessMetadata?: DevicePairingAccessMetadata;
     approvedVia?: Extract<
       PairedDeviceApprovalKind,
-      "owner" | "silent" | "trusted-cidr" | "ssh-verified"
+      "owner" | "silent" | "trusted-cidr" | "ssh-verified" | "teams-session"
     >;
   },
   baseDir?: string,
@@ -799,7 +799,7 @@ export async function approveDevicePairing(
         accessMetadata?: DevicePairingAccessMetadata;
         approvedVia?: Extract<
           PairedDeviceApprovalKind,
-          "owner" | "silent" | "trusted-cidr" | "ssh-verified"
+          "owner" | "silent" | "trusted-cidr" | "ssh-verified" | "teams-session"
         >;
       }
     | string,

--- a/src/infra/device-pairing.types.ts
+++ b/src/infra/device-pairing.types.ts
@@ -52,14 +52,16 @@ export type DeviceAuthToken = {
  * silently and cannot collide with another machine's records. "trusted-cidr"
  * and "ssh-verified" are also non-interactive but cross hosts, so they are
  * never pruned automatically (display metadata is not a machine identity).
- * "owner" and "bootstrap" approvals required a user action and are never
- * pruned.
+ * "teams-session" is bound to a current human account session and may cross
+ * hosts, so it is never pruned automatically. "owner" and "bootstrap"
+ * approvals required a user action and are never pruned.
  */
 export type PairedDeviceApprovalKind =
   | "owner"
   | "silent"
   | "trusted-cidr"
   | "ssh-verified"
+  | "teams-session"
   | "bootstrap";
 
 /**

--- a/src/plugin-sdk/plugin-test-api.ts
+++ b/src/plugin-sdk/plugin-test-api.ts
@@ -3,6 +3,7 @@ import {
   attachPluginApiFacades,
   type OpenClawPluginApiWithoutFacades,
 } from "../plugins/api-facades.js";
+import { createPluginTeamsApi } from "../plugins/teams-api.js";
 import type { OpenClawPluginApi } from "./plugin-runtime.js";
 
 /** Partial plugin API overrides accepted by the SDK test helper. */
@@ -10,7 +11,7 @@ export type TestPluginApiInput = Partial<OpenClawPluginApi>;
 
 /** Create a minimal plugin API object for plugin-sdk contract and unit tests. */
 export function createTestPluginApi(api: TestPluginApiInput = {}): OpenClawPluginApi {
-  const { agent, lifecycle, runContext, session, ...flatApi } = api;
+  const { agent, lifecycle, runContext, session, teams, ...flatApi } = api;
   const mergedApi = {
     id: "test-plugin",
     name: "test-plugin",
@@ -95,15 +96,18 @@ export function createTestPluginApi(api: TestPluginApiInput = {}): OpenClawPlugi
     on() {},
     ...flatApi,
   } satisfies OpenClawPluginApiWithoutFacades;
-  // Facades derive nested `agent`, `lifecycle`, `runContext`, and `session`
+  // Facades derive nested `agent`, `lifecycle`, `runContext`, `session`, and `teams`
   // views from the flat API; explicit overrides below let tests replace only
   // the nested surface under test without rebuilding every no-op method.
-  const withFacades = attachPluginApiFacades(mergedApi);
+  const withFacades = attachPluginApiFacades(mergedApi, {
+    teams: teams ?? createPluginTeamsApi({ pluginId: mergedApi.id }),
+  });
   return {
     ...withFacades,
     ...(agent ? { agent } : {}),
     ...(lifecycle ? { lifecycle } : {}),
     ...(runContext ? { runContext } : {}),
     ...(session ? { session } : {}),
+    ...(teams ? { teams } : {}),
   };
 }

--- a/src/plugins/api-builder.ts
+++ b/src/plugins/api-builder.ts
@@ -2,6 +2,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { attachPluginApiFacades, type OpenClawPluginApiWithoutFacades } from "./api-facades.js";
 import type { PluginRuntime } from "./runtime/types.js";
+import { createPluginTeamsApi } from "./teams-api.js";
 import type { OpenClawPluginApi, PluginLogger } from "./types.js";
 
 type BuildPluginApiParams = {
@@ -297,5 +298,7 @@ export function buildPluginApi(params: BuildPluginApiParams): OpenClawPluginApi 
     resolvePath: params.resolvePath,
     on: handlers.on ?? noopOn,
   };
-  return attachPluginApiFacades(api);
+  return attachPluginApiFacades(api, {
+    teams: createPluginTeamsApi({ pluginId: params.id }),
+  });
 }

--- a/src/plugins/api-facades.ts
+++ b/src/plugins/api-facades.ts
@@ -3,7 +3,7 @@ import type { OpenClawPluginApi } from "./types.js";
 
 type PluginApiFacadeFields = Pick<
   OpenClawPluginApi,
-  "agent" | "lifecycle" | "runContext" | "session"
+  "agent" | "lifecycle" | "runContext" | "session" | "teams"
 >;
 /** Plugin API shape without nested facade namespaces attached. */
 export type OpenClawPluginApiWithoutFacades = Omit<OpenClawPluginApi, keyof PluginApiFacadeFields>;
@@ -28,7 +28,9 @@ type PluginApiFacadeSource = Pick<
 /** Attaches nested facade namespaces to the flat plugin API implementation. */
 export function attachPluginApiFacades<T extends object>(
   api: T & PluginApiFacadeSource & Partial<PluginApiFacadeFields>,
+  facades: Pick<PluginApiFacadeFields, "teams">,
 ): T & PluginApiFacadeFields {
+  api.teams = facades.teams;
   api.session = {
     state: {
       registerSessionExtension: (...args) => api.registerSessionExtension(...args),

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1855,7 +1855,17 @@ describe("loadOpenClawPlugins", () => {
           body: `module.exports = {
   id: "allowed-config-path",
   register(api) {
-    api.registerGatewayMethod("allowed-config-path.ping", ({ respond }) => respond(true, { ok: true }));
+    api.registerGatewayMethod(
+      "allowed-config-path.ping",
+      ({ respond }) => respond(true, { ok: true }),
+      {
+        access: {
+          kind: "resource",
+          permission: "allowed-config-path.read",
+          resolveResources: () => [{ namespace: "allowed-config-path", type: "ping", id: "one" }],
+        },
+      },
+    );
   },
 };`,
         });
@@ -1878,6 +1888,10 @@ describe("loadOpenClawPlugins", () => {
           {
             name: "allowed-config-path.ping",
             owner: { kind: "plugin", pluginId: "allowed-config-path" },
+            access: {
+              kind: "resource",
+              permission: "allowed-config-path.read",
+            },
           },
         ]);
       },

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -416,6 +416,7 @@ function createGuardedPluginRegistrationApi(api: OpenClawPluginApi): {
         };
       },
     }),
+    { teams: api.teams },
   );
   return {
     api: guardedApi,

--- a/src/plugins/registry-registrars-network.ts
+++ b/src/plugins/registry-registrars-network.ts
@@ -1,7 +1,6 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import { createPluginGatewayMethodDescriptor } from "../gateway/methods/registry.js";
-import type { OperatorScope } from "../gateway/operator-scopes.js";
 import type { GatewayRequestHandler, RespondFn } from "../gateway/server-methods/types.js";
 import { normalizePluginGatewayMethodScope } from "../shared/gateway-method-policy.js";
 import { normalizeRegisteredChannelPlugin } from "./channel-validation.js";
@@ -13,6 +12,7 @@ import {
 } from "./registry-state.js";
 import type { PluginHttpRouteRegistration, PluginRecord } from "./registry-types.js";
 import type { SessionCatalogProvider } from "./session-catalog.js";
+import type { OpenClawPluginApi } from "./types.js";
 import type {
   OpenClawPluginChannelRegistration,
   OpenClawPluginHostedMediaResolver,

--- a/src/plugins/registry-registrars-network.ts
+++ b/src/plugins/registry-registrars-network.ts
@@ -44,7 +44,7 @@ export function createNetworkRegistrars(state: PluginRegistryState) {
     record: PluginRecord,
     method: string,
     handler: GatewayRequestHandler,
-    opts?: { scope?: OperatorScope },
+    opts?: Parameters<OpenClawPluginApi["registerGatewayMethod"]>[2],
   ) => {
     const trimmed = method.trim();
     if (!trimmed) {
@@ -76,6 +76,7 @@ export function createNetworkRegistrars(state: PluginRegistryState) {
         name: trimmed,
         handler: wrappedHandler,
         scope: normalizedScope.scope,
+        access: opts?.access,
       }),
     );
   };

--- a/src/plugins/teams-api.test.ts
+++ b/src/plugins/teams-api.test.ts
@@ -1,0 +1,497 @@
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import { bindGatewayClientAuthorizationDomain } from "../gateway/authorization/client-domain.js";
+import { createAuthorizationDelegation } from "../gateway/authorization/delegations.js";
+import { withGatewayAuthorizationContext } from "../gateway/authorization/request-context.js";
+import { createStateGatewayAuthorizationRuntime } from "../gateway/authorization/state-provider.js";
+import {
+  addIsolationDomainMember,
+  bindAuthorizationResource,
+  createIsolationDomain,
+  putAuthorizationPrincipal,
+} from "../gateway/authorization/state-store.js";
+import {
+  createGatewayMethodRegistry,
+  createPluginGatewayMethodDescriptors,
+} from "../gateway/methods/registry.js";
+import { handleGatewayRequest } from "../gateway/server-methods.js";
+import type { GatewayClient } from "../gateway/server-methods/shared-types.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { loadOpenClawPlugins } from "./loader.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "./loader.test-fixtures.js";
+import { createPluginTeamsApi } from "./teams-api.js";
+
+const tempDirs: string[] = [];
+const owner = {
+  id: "principal-owner",
+  principal: { issuer: "trusted-proxy", subject: "owner@example.com", kind: "human" },
+} as const;
+const agent = {
+  id: "principal-agent",
+  principal: { issuer: "core", subject: "agent:main", kind: "service" },
+} as const;
+const workspace = { namespace: "workspaces", type: "workspace", id: "workspace-1" } as const;
+const tab = { namespace: "workspaces", type: "tab", id: "tab-1" } as const;
+
+function asError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value));
+}
+
+function createDatabase() {
+  return { path: `${makeTempDir(tempDirs, "openclaw-teams-api-")}/openclaw.sqlite` };
+}
+
+function seed(database: ReturnType<typeof createDatabase>) {
+  putAuthorizationPrincipal({ ...owner, database });
+  createIsolationDomain({ id: "domain-1", ownerPrincipalId: owner.id, database });
+  bindAuthorizationResource({
+    domainId: "domain-1",
+    resource: workspace,
+    ownerPrincipalId: owner.id,
+    database,
+  });
+}
+
+function authorizationContext() {
+  return Object.freeze({
+    principalId: owner.id,
+    principalKind: "human" as const,
+    domain: Object.freeze({ id: "domain-1" }),
+    method: "workspaces.tab.create",
+    permission: "workspaces.workspace.createTab",
+    resources: Object.freeze([workspace]),
+    pluginId: "workspaces",
+    requestId: "request-1",
+  });
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  resetPluginLoaderTestStateForTest();
+});
+afterAll(() => {
+  cleanupTempDirs(tempDirs);
+  cleanupPluginLoaderFixturesForTest();
+});
+
+describe("host-bound plugin Teams API", () => {
+  it("fails closed without a trusted authorization request", () => {
+    const teams = createPluginTeamsApi({ pluginId: "workspaces" });
+    expect(() => teams.context.require()).toThrow(/trusted.*authorization context/i);
+  });
+
+  it("derives tenant and actor identity and rejects a copied context token", async () => {
+    const database = createDatabase();
+    seed(database);
+    const teams = createPluginTeamsApi({ pluginId: "workspaces", database });
+    const trusted = authorizationContext();
+
+    await withGatewayAuthorizationContext(trusted, async () => {
+      const context = teams.context.require();
+      expect(context).toEqual({
+        isolationDomainId: "domain-1",
+        principal: { id: owner.id, kind: "human" },
+        requestId: "request-1",
+      });
+
+      await expect(
+        teams.resources.prepareRegister({
+          context: { ...context },
+          resource: tab,
+          parent: workspace,
+          requiredAction: "workspaces.workspace.createTab",
+          idempotencyKey: "create-tab-1",
+        }),
+      ).rejects.toThrow(/trusted teams request context/i);
+    });
+  });
+
+  it("revokes inherited async-local authority when the request handler returns", async () => {
+    const teams = createPluginTeamsApi({ pluginId: "workspaces" });
+    const trusted = authorizationContext();
+    let resolveProbe: ((error?: Error) => void) | undefined;
+    const probed = new Promise<Error | undefined>((resolve) => {
+      resolveProbe = resolve;
+    });
+
+    withGatewayAuthorizationContext(trusted, () => {
+      setImmediate(() => {
+        try {
+          expect(() => teams.context.require()).toThrow(/active trusted gateway authorization/i);
+          resolveProbe?.();
+        } catch (error) {
+          resolveProbe?.(asError(error));
+        }
+      });
+    });
+
+    const error = await probed;
+    if (error) {
+      throw error;
+    }
+  });
+
+  it("cannot suppress request lifetime cleanup by overriding Promise.finally", async () => {
+    const teams = createPluginTeamsApi({ pluginId: "workspaces" });
+    const trusted = authorizationContext();
+    let resolveProbe: ((error?: Error) => void) | undefined;
+    const probed = new Promise<Error | undefined>((resolve) => {
+      resolveProbe = resolve;
+    });
+    const handlerResult = Promise.resolve();
+    void Object.defineProperty(handlerResult, "finally", {
+      value: () => handlerResult,
+    });
+
+    await withGatewayAuthorizationContext(trusted, () => {
+      void handlerResult.then(() => {
+        setImmediate(() => {
+          try {
+            expect(() => teams.context.require()).toThrow(/active trusted gateway authorization/i);
+            resolveProbe?.();
+          } catch (error) {
+            resolveProbe?.(asError(error));
+          }
+        });
+      });
+      return handlerResult;
+    });
+
+    const error = await probed;
+    if (error) {
+      throw error;
+    }
+  });
+
+  it("rechecks request lifetime after lazy host operations suspend", async () => {
+    const database = createDatabase();
+    seed(database);
+    const teams = createPluginTeamsApi({ pluginId: "workspaces", database });
+    let register: Promise<string> | undefined;
+    let retire: Promise<string> | undefined;
+    let lookup: Promise<{ principalId: string }> | undefined;
+
+    withGatewayAuthorizationContext(authorizationContext(), () => {
+      const context = teams.context.require();
+      register = teams.resources.prepareRegister({
+        context,
+        resource: tab,
+        parent: workspace,
+        requiredAction: "workspaces.workspace.createTab",
+        idempotencyKey: "escaped-register",
+      });
+    });
+    withGatewayAuthorizationContext(
+      Object.freeze({
+        ...authorizationContext(),
+        permission: "workspaces.workspace.retire",
+      }),
+      () => {
+        const context = teams.context.require();
+        retire = teams.resources.prepareRetire({
+          context,
+          resource: workspace,
+          requiredAction: "workspaces.workspace.retire",
+          idempotencyKey: "escaped-retire",
+        });
+      },
+    );
+    withGatewayAuthorizationContext(
+      Object.freeze({
+        ...authorizationContext(),
+        permission: "workspaces.workspace.read",
+      }),
+      () => {
+        const context = teams.context.require();
+        lookup = teams.resources.owner({ context, resource: workspace });
+      },
+    );
+
+    await expect(register).rejects.toThrow(/active trusted teams request context/i);
+    await expect(retire).rejects.toThrow(/active trusted teams request context/i);
+    await expect(lookup).rejects.toThrow(/active trusted teams request context/i);
+  });
+
+  it("rejects resources outside the loader-bound plugin namespace", async () => {
+    const database = createDatabase();
+    seed(database);
+    const teams = createPluginTeamsApi({ pluginId: "workspaces", database });
+
+    await withGatewayAuthorizationContext(authorizationContext(), async () => {
+      const context = teams.context.require();
+      await expect(
+        teams.resources.prepareRegister({
+          context,
+          resource: { namespace: "core", type: "session", id: "session-1" },
+          parent: workspace,
+          requiredAction: "workspaces.workspace.createTab",
+          idempotencyKey: "cross-namespace-1",
+        }),
+      ).rejects.toThrow(/loader-bound plugin namespace/i);
+    });
+  });
+
+  it("binds resource operations to the host plugin identity and persisted domain", async () => {
+    const database = createDatabase();
+    seed(database);
+    const workspaces = createPluginTeamsApi({ pluginId: "workspaces", database });
+    const otherPlugin = createPluginTeamsApi({ pluginId: "other-plugin", database });
+    const trusted = authorizationContext();
+    let operation = "";
+
+    const readContext = Object.freeze({
+      ...trusted,
+      method: "workspaces.tab.get",
+      permission: "workspaces.tab.read",
+      resources: Object.freeze([tab]),
+      requestId: "request-2",
+    });
+    await withGatewayAuthorizationContext(trusted, async () => {
+      const context = workspaces.context.require();
+      expect(() => otherPlugin.context.require()).toThrow(/different plugin/i);
+      operation = await workspaces.resources.prepareRegister({
+        context,
+        resource: tab,
+        parent: workspace,
+        requiredAction: "workspaces.workspace.createTab",
+        idempotencyKey: "create-tab-1",
+      });
+    });
+
+    await expect(otherPlugin.resources.replayPrepared({ operation })).rejects.toThrow(/unknown/i);
+    await expect(workspaces.resources.replayPrepared({ operation })).resolves.toBeUndefined();
+    await withGatewayAuthorizationContext(readContext, async () => {
+      const context = workspaces.context.require();
+      await expect(workspaces.resources.owner({ context, resource: tab })).resolves.toEqual({
+        principalId: owner.id,
+      });
+    });
+  });
+
+  it("rejects a Teams context whose authorized resources belong to another plugin", () => {
+    const teams = createPluginTeamsApi({ pluginId: "workspaces" });
+    const foreignContext = Object.freeze({
+      ...authorizationContext(),
+      resources: Object.freeze([
+        { namespace: "other-plugin", type: "workspace", id: "workspace-1" },
+      ]),
+    });
+
+    expect(() =>
+      withGatewayAuthorizationContext(foreignContext, () => teams.context.require()),
+    ).toThrow(/loader-bound plugin namespace/i);
+  });
+
+  it("requires a server-attested delegation and keeps the human sponsor as custodian", async () => {
+    const database = createDatabase();
+    seed(database);
+    putAuthorizationPrincipal({ ...agent, database });
+    addIsolationDomainMember({
+      domainId: "domain-1",
+      principalId: agent.id,
+      addedByPrincipalId: owner.id,
+      database,
+    });
+    createAuthorizationDelegation({
+      id: "delegation-1",
+      assignmentId: "assignment-1",
+      domainId: "domain-1",
+      agentPrincipalId: agent.id,
+      sponsorPrincipalId: owner.id,
+      createdByPrincipalId: owner.id,
+      database,
+    });
+    const teams = createPluginTeamsApi({ pluginId: "workspaces", database });
+    const baseAgentContext = Object.freeze({
+      ...authorizationContext(),
+      principalId: agent.id,
+      principalKind: "service" as const,
+      requestId: "agent-request-1",
+    });
+
+    expect(() =>
+      withGatewayAuthorizationContext(baseAgentContext, () => teams.context.require()),
+    ).toThrow(/server-attested delegation/i);
+
+    const delegatedContext = Object.freeze({
+      ...baseAgentContext,
+      delegation: Object.freeze({
+        id: "delegation-1",
+        assignmentId: "assignment-1",
+        sponsorPrincipalId: owner.id,
+      }),
+    });
+    let operation = "";
+    await withGatewayAuthorizationContext(delegatedContext, async () => {
+      const context = teams.context.require();
+      expect(context.principal).toEqual({ id: agent.id, kind: "agent" });
+      expect(context.delegatedSession).toEqual({
+        id: "delegation-1",
+        assignmentId: "assignment-1",
+        sponsorPrincipalId: owner.id,
+      });
+      operation = await teams.resources.prepareRegister({
+        context,
+        resource: tab,
+        parent: workspace,
+        requiredAction: "workspaces.workspace.createTab",
+        idempotencyKey: "agent-create-tab-1",
+      });
+    });
+    await teams.resources.replayPrepared({ operation });
+
+    const readContext = Object.freeze({
+      ...delegatedContext,
+      method: "workspaces.tab.get",
+      permission: "workspaces.tab.read",
+      resources: Object.freeze([tab]),
+      requestId: "agent-request-2",
+    });
+    await withGatewayAuthorizationContext(readContext, async () => {
+      const context = teams.context.require();
+      await expect(teams.resources.owner({ context, resource: tab })).resolves.toEqual({
+        principalId: owner.id,
+      });
+    });
+  });
+
+  it("reaches api.teams through real plugin registration and isolated dispatch", async () => {
+    const database = createDatabase();
+    seed(database);
+    bindAuthorizationResource({
+      domainId: "domain-1",
+      resource: { namespace: "other-plugin", type: "workspace", id: "foreign-workspace" },
+      ownerPrincipalId: owner.id,
+      database,
+    });
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "workspaces",
+      filename: "workspaces.cjs",
+      body: `module.exports = {
+  id: "workspaces",
+  register(api) {
+    const workspaceAccess = {
+      kind: "resource",
+      permission: "workspaces.workspace.read",
+      resolveResources: ({ params }) => [
+        { namespace: "workspaces", type: "workspace", id: params.workspaceId },
+      ],
+    };
+    api.registerGatewayMethod(
+      "workspaces.test.workspace.get",
+      () => api.teams.context.require(),
+      {
+        scope: "operator.read",
+        access: workspaceAccess,
+      },
+    );
+    workspaceAccess.permission = "other-plugin.workspace.read";
+    workspaceAccess.resolveResources = () => [
+      { namespace: "other-plugin", type: "workspace", id: "foreign-workspace" },
+    ];
+    api.registerGatewayMethod(
+      "workspaces.test.foreign.get",
+      () => api.teams.context.require(),
+      {
+        scope: "operator.read",
+        access: {
+          kind: "resource",
+          permission: "other-plugin.workspace.read",
+          resolveResources: () => [
+            { namespace: "other-plugin", type: "workspace", id: "foreign-workspace" },
+          ],
+        },
+      },
+    );
+  },
+};`,
+    });
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: [plugin.id],
+        },
+      },
+    });
+    const methodRegistry = createGatewayMethodRegistry(
+      createPluginGatewayMethodDescriptors(registry),
+    );
+    expect(methodRegistry.getAccessPolicy("workspaces.test.workspace.get")).toMatchObject({
+      kind: "resource",
+      permission: "workspaces.workspace.read",
+    });
+    const client: GatewayClient = {
+      connect: {
+        role: "operator" as const,
+        scopes: ["operator.read"],
+        client: { id: "test", version: "1", platform: "test", mode: "test" },
+        minProtocol: 1,
+        maxProtocol: 1,
+      },
+      principal: owner.principal,
+    };
+    bindGatewayClientAuthorizationDomain(client, { id: "domain-1" });
+    const respond = vi.fn();
+
+    await handleGatewayRequest({
+      req: {
+        type: "req",
+        id: "request-real-plugin",
+        method: "workspaces.test.workspace.get",
+        params: { workspaceId: workspace.id },
+      },
+      client,
+      respond,
+      isWebchatConnect: () => false,
+      context: {
+        authorization: createStateGatewayAuthorizationRuntime({ database }),
+        getRuntimeConfig: () => ({}),
+        logGateway: { warn() {} },
+      } as unknown as Parameters<typeof handleGatewayRequest>[0]["context"],
+      methodRegistry,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      {
+        isolationDomainId: "domain-1",
+        principal: { id: owner.id, kind: "human" },
+        requestId: "request-real-plugin",
+      },
+      undefined,
+      undefined,
+    );
+
+    respond.mockClear();
+    await handleGatewayRequest({
+      req: {
+        type: "req",
+        id: "request-foreign-plugin-resource",
+        method: "workspaces.test.foreign.get",
+      },
+      client,
+      respond,
+      isWebchatConnect: () => false,
+      context: {
+        authorization: createStateGatewayAuthorizationRuntime({ database }),
+        getRuntimeConfig: () => ({}),
+        logGateway: { warn() {} },
+      } as unknown as Parameters<typeof handleGatewayRequest>[0]["context"],
+      methodRegistry,
+    });
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "resource not found" }),
+    );
+  });
+});

--- a/src/plugins/teams-api.test.ts
+++ b/src/plugins/teams-api.test.ts
@@ -101,6 +101,26 @@ afterAll(() => {
 });
 
 describe("host-bound plugin Teams API", () => {
+  it("does not invoke a plugin tool callback when its signal is already aborted", () => {
+    const controller = new AbortController();
+    controller.abort();
+    const run = vi.fn();
+
+    expect(() =>
+      withPluginToolAuthorizationInvocation(
+        {
+          pluginId: "workspaces",
+          toolName: "workspace_get",
+          toolCallId: "aborted-call",
+          context: {},
+          signal: controller.signal,
+        },
+        run,
+      ),
+    ).toThrow(/aborted/i);
+    expect(run).not.toHaveBeenCalled();
+  });
+
   it("fails closed without a trusted authorization request", () => {
     const teams = createPluginTeamsApi({ pluginId: "workspaces" });
     expect(() => teams.context.require()).toThrow(/trusted.*authorization context/i);
@@ -129,6 +149,65 @@ describe("host-bound plugin Teams API", () => {
           idempotencyKey: "create-tab-1",
         }),
       ).rejects.toThrow(/trusted teams request context/i);
+    });
+  });
+
+  it("rechecks additional resource permissions for the active gateway request", async () => {
+    const database = createDatabase();
+    seed(database);
+    putAuthorizationPrincipal({ ...member, database });
+    addIsolationDomainMember({
+      domainId: "domain-1",
+      principalId: member.id,
+      addedByPrincipalId: owner.id,
+      database,
+    });
+    bindAuthorizationResource({
+      domainId: "domain-1",
+      resource: tab,
+      parent: workspace,
+      ownerPrincipalId: owner.id,
+      database,
+    });
+    for (const permission of ["workspaces.tab.read", "workspaces.tab.write"]) {
+      grantAuthorizationPermission({
+        domainId: "domain-1",
+        principalId: member.id,
+        resource: tab,
+        permission,
+        grantedByPrincipalId: owner.id,
+        database,
+      });
+    }
+    const teams = createPluginTeamsApi({ pluginId: "workspaces", database });
+    const trusted = Object.freeze({
+      principalId: member.id,
+      principalKind: "human" as const,
+      principal: member.principal,
+      domain: Object.freeze({ id: "domain-1" }),
+      method: "workspaces.tab.get",
+      permission: "workspaces.tab.read",
+      resources: Object.freeze([tab]),
+      pluginId: "workspaces",
+      requestId: "request-capabilities-1",
+    });
+
+    await withGatewayAuthorizationContext(trusted, async () => {
+      const context = teams.context.require();
+      await expect(
+        teams.authorization.decide({
+          context,
+          permission: "workspaces.tab.write",
+          resources: [tab],
+        }),
+      ).resolves.toMatchObject({ allowed: true });
+      await expect(
+        teams.authorization.decide({
+          context,
+          permission: "workspaces.tab.changeRequest.create",
+          resources: [tab],
+        }),
+      ).resolves.toEqual({ allowed: false });
     });
   });
 

--- a/src/plugins/teams-api.test.ts
+++ b/src/plugins/teams-api.test.ts
@@ -1,5 +1,10 @@
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import {
+  createAuthorizationAgentSessionBinding,
+  GATEWAY_AGENT_SESSION_INVOKE_PERMISSION,
+  revokeAuthorizationAgentSessionBinding,
+} from "../gateway/authorization/agent-session-bindings.js";
 import { bindGatewayClientAuthorizationDomain } from "../gateway/authorization/client-domain.js";
 import { createAuthorizationDelegation } from "../gateway/authorization/delegations.js";
 import { withGatewayAuthorizationContext } from "../gateway/authorization/request-context.js";
@@ -8,7 +13,9 @@ import {
   addIsolationDomainMember,
   bindAuthorizationResource,
   createIsolationDomain,
+  grantAuthorizationPermission,
   putAuthorizationPrincipal,
+  revokeAuthorizationPermission,
 } from "../gateway/authorization/state-store.js";
 import {
   createGatewayMethodRegistry,
@@ -25,6 +32,10 @@ import {
   writePlugin,
 } from "./loader.test-fixtures.js";
 import { createPluginTeamsApi } from "./teams-api.js";
+import {
+  bindPluginToolAuthorizationSubject,
+  withPluginToolAuthorizationInvocation,
+} from "./tool-authorization-context.js";
 
 const tempDirs: string[] = [];
 const owner = {
@@ -35,8 +46,18 @@ const agent = {
   id: "principal-agent",
   principal: { issuer: "core", subject: "agent:main", kind: "service" },
 } as const;
+const member = {
+  id: "principal-member",
+  principal: { issuer: "trusted-proxy", subject: "member@example.com", kind: "human" },
+} as const;
 const workspace = { namespace: "workspaces", type: "workspace", id: "workspace-1" } as const;
 const tab = { namespace: "workspaces", type: "tab", id: "tab-1" } as const;
+const agentSession = { namespace: "core", type: "agent-session", id: "assignment-1" } as const;
+
+const agentSessionProof = {
+  id: "binding-1",
+  invokingPrincipal: owner.principal,
+} as const;
 
 function asError(value: unknown): Error {
   return value instanceof Error ? value : new Error(String(value));
@@ -306,6 +327,22 @@ describe("host-bound plugin Teams API", () => {
       createdByPrincipalId: owner.id,
       database,
     });
+    bindAuthorizationResource({
+      domainId: "domain-1",
+      resource: agentSession,
+      ownerPrincipalId: owner.id,
+      database,
+    });
+    createAuthorizationAgentSessionBinding({
+      id: "binding-1",
+      domainId: "domain-1",
+      runtimeAgentId: "main",
+      sessionKey: "agent:main:main",
+      delegationId: "delegation-1",
+      assignmentId: "assignment-1",
+      createdByPrincipalId: owner.id,
+      database,
+    });
     const teams = createPluginTeamsApi({ pluginId: "workspaces", database });
     const baseAgentContext = Object.freeze({
       ...authorizationContext(),
@@ -358,6 +395,241 @@ describe("host-bound plugin Teams API", () => {
         principalId: owner.id,
       });
     });
+  });
+
+  it("authorizes the exact active delegated tool call and returns a fresh resource proof", async () => {
+    const database = createDatabase();
+    seed(database);
+    putAuthorizationPrincipal({ ...agent, database });
+    addIsolationDomainMember({
+      domainId: "domain-1",
+      principalId: agent.id,
+      addedByPrincipalId: owner.id,
+      database,
+    });
+    createAuthorizationDelegation({
+      id: "delegation-1",
+      assignmentId: "assignment-1",
+      domainId: "domain-1",
+      agentPrincipalId: agent.id,
+      sponsorPrincipalId: owner.id,
+      createdByPrincipalId: owner.id,
+      database,
+    });
+    bindAuthorizationResource({
+      domainId: "domain-1",
+      resource: agentSession,
+      ownerPrincipalId: owner.id,
+      database,
+    });
+    createAuthorizationAgentSessionBinding({
+      id: "binding-1",
+      domainId: "domain-1",
+      runtimeAgentId: "main",
+      sessionKey: "agent:main:main",
+      delegationId: "delegation-1",
+      assignmentId: "assignment-1",
+      createdByPrincipalId: owner.id,
+      database,
+    });
+    putAuthorizationPrincipal({ ...member, database });
+    addIsolationDomainMember({
+      domainId: "domain-1",
+      principalId: member.id,
+      addedByPrincipalId: owner.id,
+      database,
+    });
+    grantAuthorizationPermission({
+      domainId: "domain-1",
+      principalId: member.id,
+      resource: agentSession,
+      permission: GATEWAY_AGENT_SESSION_INVOKE_PERMISSION,
+      grantedByPrincipalId: owner.id,
+      database,
+    });
+    grantAuthorizationPermission({
+      domainId: "domain-1",
+      principalId: agent.id,
+      resource: workspace,
+      permission: "workspaces.workspace.read",
+      grantedByPrincipalId: owner.id,
+      database,
+    });
+    const teams = createPluginTeamsApi({ pluginId: "workspaces", database });
+    const toolContext = { agentId: "main", sessionKey: "agent:main:main" };
+    bindPluginToolAuthorizationSubject(toolContext, {
+      principal: agent.principal,
+      domain: { id: "domain-1" },
+      delegation: { id: "delegation-1", assignmentId: "assignment-1" },
+      agentSession: { id: "binding-1", invokingPrincipal: member.principal },
+    });
+    let retainedCall: ReturnType<typeof teams.context.require> | undefined;
+
+    await withPluginToolAuthorizationInvocation(
+      {
+        pluginId: "workspaces",
+        toolName: "workspace_get",
+        toolCallId: "tool-call-1",
+        context: toolContext,
+      },
+      async () => {
+        const call = teams.context.require(toolContext);
+        retainedCall = call;
+        expect(call).toEqual({ callId: "tool-call-1" });
+        expect(() => teams.context.require({ ...toolContext })).toThrow(
+          /active host-authorized plugin tool invocation/i,
+        );
+        const decision = await teams.authorization.decide({
+          context: call,
+          permission: "workspaces.workspace.read",
+          resources: [workspace],
+        });
+        expect(decision).toEqual({
+          allowed: true,
+          context: {
+            isolationDomainId: "domain-1",
+            principal: { id: agent.id, kind: "agent" },
+            delegatedSession: {
+              id: "delegation-1",
+              assignmentId: "assignment-1",
+              sponsorPrincipalId: owner.id,
+            },
+            requestId: "tool-call-1",
+          },
+        });
+        if (!decision.allowed) {
+          throw new Error("expected tool authorization to allow");
+        }
+        await expect(
+          teams.resources.owner({ context: decision.context, resource: workspace }),
+        ).resolves.toEqual({ principalId: owner.id });
+
+        revokeAuthorizationPermission({
+          domainId: "domain-1",
+          principalId: member.id,
+          resource: agentSession,
+          permission: GATEWAY_AGENT_SESSION_INVOKE_PERMISSION,
+          revokedByPrincipalId: owner.id,
+          database,
+        });
+        await expect(
+          teams.authorization.decide({
+            context: call,
+            permission: "workspaces.workspace.read",
+            resources: [workspace],
+          }),
+        ).resolves.toEqual({ allowed: false });
+
+        grantAuthorizationPermission({
+          domainId: "domain-1",
+          principalId: member.id,
+          resource: agentSession,
+          permission: GATEWAY_AGENT_SESSION_INVOKE_PERMISSION,
+          grantedByPrincipalId: owner.id,
+          database,
+        });
+        await expect(
+          teams.authorization.decide({
+            context: call,
+            permission: "workspaces.workspace.read",
+            resources: [workspace],
+          }),
+        ).resolves.toMatchObject({ allowed: true });
+        revokeAuthorizationAgentSessionBinding({
+          domainId: "domain-1",
+          id: "binding-1",
+          revokedByPrincipalId: owner.id,
+          database,
+        });
+        await expect(
+          teams.authorization.decide({
+            context: call,
+            permission: "workspaces.workspace.read",
+            resources: [workspace],
+          }),
+        ).resolves.toEqual({ allowed: false });
+      },
+    );
+
+    await expect(
+      teams.authorization.decide({
+        context: retainedCall as never,
+        permission: "workspaces.workspace.read",
+        resources: [workspace],
+      }),
+    ).rejects.toThrow(/no longer active/i);
+  });
+
+  it("fails closed for a delegated tool subject with the wrong assignment", async () => {
+    const database = createDatabase();
+    seed(database);
+    putAuthorizationPrincipal({ ...agent, database });
+    addIsolationDomainMember({
+      domainId: "domain-1",
+      principalId: agent.id,
+      addedByPrincipalId: owner.id,
+      database,
+    });
+    createAuthorizationDelegation({
+      id: "delegation-1",
+      assignmentId: "assignment-1",
+      domainId: "domain-1",
+      agentPrincipalId: agent.id,
+      sponsorPrincipalId: owner.id,
+      createdByPrincipalId: owner.id,
+      database,
+    });
+    bindAuthorizationResource({
+      domainId: "domain-1",
+      resource: agentSession,
+      ownerPrincipalId: owner.id,
+      database,
+    });
+    createAuthorizationAgentSessionBinding({
+      id: "binding-1",
+      domainId: "domain-1",
+      runtimeAgentId: "main",
+      sessionKey: "agent:main:main",
+      delegationId: "delegation-1",
+      assignmentId: "assignment-1",
+      createdByPrincipalId: owner.id,
+      database,
+    });
+    grantAuthorizationPermission({
+      domainId: "domain-1",
+      principalId: agent.id,
+      resource: workspace,
+      permission: "workspaces.workspace.read",
+      grantedByPrincipalId: owner.id,
+      database,
+    });
+    const teams = createPluginTeamsApi({ pluginId: "workspaces", database });
+    const toolContext = { agentId: "main", sessionKey: "agent:main:main" };
+    bindPluginToolAuthorizationSubject(toolContext, {
+      principal: agent.principal,
+      domain: { id: "domain-1" },
+      delegation: { id: "delegation-1", assignmentId: "wrong-assignment" },
+      agentSession: agentSessionProof,
+    });
+
+    await withPluginToolAuthorizationInvocation(
+      {
+        pluginId: "workspaces",
+        toolName: "workspace_get",
+        toolCallId: "tool-call-wrong",
+        context: toolContext,
+      },
+      async () => {
+        const call = teams.context.require(toolContext);
+        await expect(
+          teams.authorization.decide({
+            context: call,
+            permission: "workspaces.workspace.read",
+            resources: [workspace],
+          }),
+        ).resolves.toEqual({ allowed: false });
+      },
+    );
   });
 
   it("reaches api.teams through real plugin registration and isolated dispatch", async () => {

--- a/src/plugins/teams-api.ts
+++ b/src/plugins/teams-api.ts
@@ -1,0 +1,214 @@
+import type {
+  GatewayAuthorizationContext,
+  GatewayResourceRef,
+} from "../gateway/authorization/contracts.js";
+import {
+  getGatewayAuthorizationContext,
+  isGatewayAuthorizationContextActive,
+} from "../gateway/authorization/request-context.js";
+import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
+import type {
+  OpenClawPluginTeamsApi,
+  OpenClawPluginTeamsRequestContext,
+  OpenClawPluginTeamsResourceRef,
+} from "./teams-types.js";
+
+function requiredIdentifier(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return normalized;
+}
+
+function normalizeResource(resource: OpenClawPluginTeamsResourceRef): GatewayResourceRef {
+  return Object.freeze({
+    namespace: requiredIdentifier(resource.namespace, "resource namespace"),
+    type: requiredIdentifier(resource.type, "resource type"),
+    id: requiredIdentifier(resource.id, "resource id"),
+  });
+}
+
+function sameResource(first: GatewayResourceRef, second: GatewayResourceRef): boolean {
+  return (
+    first.namespace === second.namespace && first.type === second.type && first.id === second.id
+  );
+}
+
+function requirePluginResourceNamespace(resource: GatewayResourceRef, pluginId: string): void {
+  if (resource.namespace !== pluginId) {
+    throw new Error("Teams resources must use the loader-bound plugin namespace");
+  }
+}
+
+export function createPluginTeamsApi(input: {
+  pluginId: string;
+  database?: OpenClawStateDatabaseOptions;
+}): OpenClawPluginTeamsApi {
+  const pluginId = requiredIdentifier(input.pluginId, "plugin id");
+  const operationScope = `plugin:${pluginId}`;
+  const trustedContexts = new WeakMap<object, GatewayAuthorizationContext>();
+
+  const requireTrustedContext = (
+    context: OpenClawPluginTeamsRequestContext,
+  ): GatewayAuthorizationContext => {
+    const trusted = trustedContexts.get(context);
+    if (
+      !trusted ||
+      getGatewayAuthorizationContext() !== trusted ||
+      !isGatewayAuthorizationContextActive(trusted)
+    ) {
+      throw new Error("an active trusted Teams request context is required");
+    }
+    return trusted;
+  };
+
+  const requireAuthorizedAction = (
+    trusted: GatewayAuthorizationContext,
+    requiredAction: string,
+    resource: GatewayResourceRef,
+  ): void => {
+    const action = requiredIdentifier(requiredAction, "required Teams action");
+    if (
+      trusted.permission !== action ||
+      !trusted.resources.some((entry) => sameResource(entry, resource))
+    ) {
+      throw new Error("the trusted Teams request was not authorized for the required action");
+    }
+  };
+
+  const contextApi: OpenClawPluginTeamsApi["context"] = {
+    require: () => {
+      const trusted = getGatewayAuthorizationContext();
+      if (!trusted || !trusted.requestId || !isGatewayAuthorizationContextActive(trusted)) {
+        throw new Error("an active trusted gateway authorization context is required");
+      }
+      if (trusted.pluginId !== pluginId) {
+        throw new Error("the trusted Teams request belongs to a different plugin");
+      }
+      if (
+        trusted.resources.length === 0 ||
+        trusted.resources.some((resource) => resource.namespace !== pluginId)
+      ) {
+        throw new Error("Teams authorization must use the loader-bound plugin namespace");
+      }
+      if (trusted.principalKind !== "human" && trusted.principalKind !== "service") {
+        throw new Error("Teams requests require a human or delegated agent principal");
+      }
+      if (trusted.principalKind === "service" && !trusted.delegation) {
+        throw new Error("Teams agent requests require a server-attested delegation");
+      }
+      const context: OpenClawPluginTeamsRequestContext = Object.freeze({
+        isolationDomainId: trusted.domain.id,
+        principal: Object.freeze({
+          id: trusted.principalId,
+          kind: trusted.principalKind === "human" ? "human" : "agent",
+        }),
+        ...(trusted.delegation
+          ? {
+              delegatedSession: Object.freeze({
+                id: trusted.delegation.id,
+                assignmentId: trusted.delegation.assignmentId,
+                sponsorPrincipalId: trusted.delegation.sponsorPrincipalId,
+              }),
+            }
+          : {}),
+        requestId: trusted.requestId,
+      });
+      trustedContexts.set(context, trusted);
+      return context;
+    },
+  };
+
+  return {
+    context: contextApi,
+    resources: {
+      prepareRegister: async ({
+        context,
+        resource: rawResource,
+        parent: rawParent,
+        requiredAction,
+        idempotencyKey,
+      }) => {
+        const trusted = requireTrustedContext(context);
+        const resource = normalizeResource(rawResource);
+        const parent = rawParent ? normalizeResource(rawParent) : undefined;
+        requirePluginResourceNamespace(resource, pluginId);
+        if (parent) {
+          requirePluginResourceNamespace(parent, pluginId);
+        }
+        requireAuthorizedAction(trusted, requiredAction, parent ?? resource);
+        const { prepareAuthorizationResourceRegistration } =
+          await import("../gateway/authorization/resource-operations.js");
+        requireTrustedContext(context);
+        const prepared = prepareAuthorizationResourceRegistration({
+          operationScope,
+          idempotencyKey,
+          domainId: trusted.domain.id,
+          resource,
+          ...(parent ? { parent } : {}),
+          actor:
+            trusted.principalKind === "human"
+              ? { kind: "human", principalId: trusted.principalId }
+              : {
+                  kind: "delegated-agent",
+                  principalId: trusted.principalId,
+                  sponsorPrincipalId: trusted.delegation!.sponsorPrincipalId,
+                  delegationId: trusted.delegation!.id,
+                  assignmentId: trusted.delegation!.assignmentId,
+                },
+          database: input.database,
+        });
+        return prepared.operationId;
+      },
+      prepareRetire: async ({ context, resource: rawResource, requiredAction, idempotencyKey }) => {
+        const trusted = requireTrustedContext(context);
+        const resource = normalizeResource(rawResource);
+        requirePluginResourceNamespace(resource, pluginId);
+        requireAuthorizedAction(trusted, requiredAction, resource);
+        const { prepareAuthorizationResourceRetirement } =
+          await import("../gateway/authorization/resource-operations.js");
+        requireTrustedContext(context);
+        const prepared = prepareAuthorizationResourceRetirement({
+          operationScope,
+          idempotencyKey,
+          domainId: trusted.domain.id,
+          resource,
+          actorPrincipalId: trusted.principalId,
+          database: input.database,
+        });
+        return prepared.operationId;
+      },
+      replayPrepared: async ({ operation }) => {
+        const operationId = requiredIdentifier(operation, "authorization operation");
+        const { replayAuthorizationResourceOperationForHost } =
+          await import("../gateway/authorization/resource-operations.js");
+        replayAuthorizationResourceOperationForHost({
+          operationScope,
+          operationId,
+          database: input.database,
+        });
+      },
+      owner: async ({ context, resource: rawResource }) => {
+        const trusted = requireTrustedContext(context);
+        const resource = normalizeResource(rawResource);
+        requirePluginResourceNamespace(resource, pluginId);
+        if (!trusted.resources.some((entry) => sameResource(entry, resource))) {
+          throw new Error("the trusted Teams request was not authorized for this resource");
+        }
+        const { getAuthorizationResourceOwner } =
+          await import("../gateway/authorization/resource-operations.js");
+        requireTrustedContext(context);
+        const owner = getAuthorizationResourceOwner({
+          domainId: trusted.domain.id,
+          resource,
+          database: input.database,
+        });
+        if (!owner) {
+          throw new Error("authorization resource owner is unavailable");
+        }
+        return owner;
+      },
+    },
+  };
+}

--- a/src/plugins/teams-api.ts
+++ b/src/plugins/teams-api.ts
@@ -11,7 +11,14 @@ import type {
   OpenClawPluginTeamsApi,
   OpenClawPluginTeamsRequestContext,
   OpenClawPluginTeamsResourceRef,
+  OpenClawPluginTeamsToolCallContext,
 } from "./teams-types.js";
+import {
+  requireCurrentPluginToolAuthorizationInvocation,
+  requirePluginToolAuthorizationInvocation,
+  type PluginToolAuthorizationInvocation,
+} from "./tool-authorization-context.js";
+import type { OpenClawPluginToolContext } from "./tool-types.js";
 
 function requiredIdentifier(value: string, label: string): string {
   const normalized = value.trim();
@@ -47,20 +54,38 @@ export function createPluginTeamsApi(input: {
 }): OpenClawPluginTeamsApi {
   const pluginId = requiredIdentifier(input.pluginId, "plugin id");
   const operationScope = `plugin:${pluginId}`;
-  const trustedContexts = new WeakMap<object, GatewayAuthorizationContext>();
+  const trustedContexts = new WeakMap<
+    object,
+    | { kind: "gateway"; authorization: GatewayAuthorizationContext }
+    | {
+        kind: "tool";
+        authorization: GatewayAuthorizationContext;
+        invocation: PluginToolAuthorizationInvocation;
+      }
+  >();
+  const trustedToolCalls = new WeakMap<
+    OpenClawPluginTeamsToolCallContext,
+    PluginToolAuthorizationInvocation
+  >();
 
   const requireTrustedContext = (
     context: OpenClawPluginTeamsRequestContext,
   ): GatewayAuthorizationContext => {
-    const trusted = trustedContexts.get(context);
+    const binding = trustedContexts.get(context);
+    if (!binding) {
+      throw new Error("an active trusted Teams request context is required");
+    }
+    if (binding.kind === "tool") {
+      requireCurrentPluginToolAuthorizationInvocation(binding.invocation);
+      return binding.authorization;
+    }
     if (
-      !trusted ||
-      getGatewayAuthorizationContext() !== trusted ||
-      !isGatewayAuthorizationContextActive(trusted)
+      getGatewayAuthorizationContext() !== binding.authorization ||
+      !isGatewayAuthorizationContextActive(binding.authorization)
     ) {
       throw new Error("an active trusted Teams request context is required");
     }
-    return trusted;
+    return binding.authorization;
   };
 
   const requireAuthorizedAction = (
@@ -77,51 +102,122 @@ export function createPluginTeamsApi(input: {
     }
   };
 
-  const contextApi: OpenClawPluginTeamsApi["context"] = {
-    require: () => {
-      const trusted = getGatewayAuthorizationContext();
-      if (!trusted || !trusted.requestId || !isGatewayAuthorizationContextActive(trusted)) {
-        throw new Error("an active trusted gateway authorization context is required");
-      }
-      if (trusted.pluginId !== pluginId) {
-        throw new Error("the trusted Teams request belongs to a different plugin");
-      }
-      if (
-        trusted.resources.length === 0 ||
-        trusted.resources.some((resource) => resource.namespace !== pluginId)
-      ) {
-        throw new Error("Teams authorization must use the loader-bound plugin namespace");
-      }
-      if (trusted.principalKind !== "human" && trusted.principalKind !== "service") {
-        throw new Error("Teams requests require a human or delegated agent principal");
-      }
-      if (trusted.principalKind === "service" && !trusted.delegation) {
-        throw new Error("Teams agent requests require a server-attested delegation");
-      }
-      const context: OpenClawPluginTeamsRequestContext = Object.freeze({
-        isolationDomainId: trusted.domain.id,
-        principal: Object.freeze({
-          id: trusted.principalId,
-          kind: trusted.principalKind === "human" ? "human" : "agent",
-        }),
-        ...(trusted.delegation
-          ? {
-              delegatedSession: Object.freeze({
-                id: trusted.delegation.id,
-                assignmentId: trusted.delegation.assignmentId,
-                sponsorPrincipalId: trusted.delegation.sponsorPrincipalId,
-              }),
-            }
-          : {}),
-        requestId: trusted.requestId,
+  const projectRequestContext = (
+    trusted: GatewayAuthorizationContext,
+  ): OpenClawPluginTeamsRequestContext =>
+    Object.freeze({
+      isolationDomainId: trusted.domain.id,
+      principal: Object.freeze({
+        id: trusted.principalId,
+        kind: trusted.principalKind === "human" ? "human" : "agent",
+      }),
+      ...(trusted.delegation
+        ? {
+            delegatedSession: Object.freeze({
+              id: trusted.delegation.id,
+              assignmentId: trusted.delegation.assignmentId,
+              sponsorPrincipalId: trusted.delegation.sponsorPrincipalId,
+            }),
+          }
+        : {}),
+      requestId: trusted.requestId!,
+    });
+
+  const requireContext = ((toolContext?: OpenClawPluginToolContext) => {
+    if (toolContext) {
+      const invocation = requirePluginToolAuthorizationInvocation({
+        pluginId,
+        context: toolContext,
       });
-      trustedContexts.set(context, trusted);
+      const context: OpenClawPluginTeamsToolCallContext = Object.freeze({
+        callId: invocation.toolCallId,
+      });
+      trustedToolCalls.set(context, invocation);
       return context;
-    },
+    }
+    const trusted = getGatewayAuthorizationContext();
+    if (!trusted || !trusted.requestId || !isGatewayAuthorizationContextActive(trusted)) {
+      throw new Error("an active trusted gateway authorization context is required");
+    }
+    if (trusted.pluginId !== pluginId) {
+      throw new Error("the trusted Teams request belongs to a different plugin");
+    }
+    if (
+      trusted.resources.length === 0 ||
+      trusted.resources.some((resource) => resource.namespace !== pluginId)
+    ) {
+      throw new Error("Teams authorization must use the loader-bound plugin namespace");
+    }
+    if (trusted.principalKind !== "human" && trusted.principalKind !== "service") {
+      throw new Error("Teams requests require a human or delegated agent principal");
+    }
+    if (trusted.principalKind === "service" && !trusted.delegation) {
+      throw new Error("Teams agent requests require a server-attested delegation");
+    }
+    const context = projectRequestContext(trusted);
+    trustedContexts.set(context, { kind: "gateway", authorization: trusted });
+    return context;
+  }) as OpenClawPluginTeamsApi["context"]["require"];
+
+  const contextApi: OpenClawPluginTeamsApi["context"] = {
+    require: requireContext,
   };
 
   return {
     context: contextApi,
+    authorization: {
+      decide: async ({ context, permission: rawPermission, resources: rawResources }) => {
+        const invocation = trustedToolCalls.get(context);
+        if (!invocation || invocation.toolCallId !== context.callId || !invocation.subject) {
+          throw new Error("an active trusted Teams tool call context is required");
+        }
+        requireCurrentPluginToolAuthorizationInvocation(invocation);
+        const permission = requiredIdentifier(rawPermission, "Teams permission");
+        if (!Array.isArray(rawResources) || rawResources.length === 0) {
+          throw new Error("Teams authorization requires at least one resource");
+        }
+        const resources = Object.freeze(
+          rawResources.map((rawResource) => {
+            const resource = normalizeResource(rawResource);
+            requirePluginResourceNamespace(resource, pluginId);
+            return resource;
+          }),
+        );
+        const [{ authorizeGatewayAccess }, { createStateGatewayAuthorizationRuntime }] =
+          await Promise.all([
+            import("../gateway/authorization/kernel.js"),
+            import("../gateway/authorization/state-provider.js"),
+          ]);
+        requireCurrentPluginToolAuthorizationInvocation(invocation);
+        const outcome = await authorizeGatewayAccess({
+          runtime: createStateGatewayAuthorizationRuntime({ database: input.database }),
+          policy: { kind: "resource", permission, resolveResources: () => resources },
+          principal: invocation.subject.principal,
+          domain: invocation.subject.domain,
+          delegation: invocation.subject.delegation,
+          agentSession: invocation.subject.agentSession,
+          method: `plugin-tool:${pluginId}:${invocation.toolName}`,
+          params: undefined,
+          getConfig: () => ({}),
+        });
+        requireCurrentPluginToolAuthorizationInvocation(invocation);
+        if (!outcome.allowed || !outcome.security) {
+          return { allowed: false };
+        }
+        const trusted = Object.freeze({
+          ...outcome.security,
+          pluginId,
+          requestId: invocation.toolCallId,
+        });
+        const requestContext = projectRequestContext(trusted);
+        trustedContexts.set(requestContext, {
+          kind: "tool",
+          authorization: trusted,
+          invocation,
+        });
+        return { allowed: true, context: requestContext };
+      },
+    },
     resources: {
       prepareRegister: async ({
         context,

--- a/src/plugins/teams-api.ts
+++ b/src/plugins/teams-api.ts
@@ -14,6 +14,7 @@ import type {
   OpenClawPluginTeamsToolCallContext,
 } from "./teams-types.js";
 import {
+  hasPluginToolAuthorizationSubject,
   requireCurrentPluginToolAuthorizationInvocation,
   requirePluginToolAuthorizationInvocation,
   type PluginToolAuthorizationInvocation,
@@ -160,6 +161,7 @@ export function createPluginTeamsApi(input: {
   }) as OpenClawPluginTeamsApi["context"]["require"];
 
   const contextApi: OpenClawPluginTeamsApi["context"] = {
+    isBound: hasPluginToolAuthorizationSubject,
     require: requireContext,
   };
 
@@ -167,11 +169,19 @@ export function createPluginTeamsApi(input: {
     context: contextApi,
     authorization: {
       decide: async ({ context, permission: rawPermission, resources: rawResources }) => {
-        const invocation = trustedToolCalls.get(context);
-        if (!invocation || invocation.toolCallId !== context.callId || !invocation.subject) {
-          throw new Error("an active trusted Teams tool call context is required");
+        const invocation = trustedToolCalls.get(context as OpenClawPluginTeamsToolCallContext);
+        const gatewayContext = invocation
+          ? undefined
+          : requireTrustedContext(context as OpenClawPluginTeamsRequestContext);
+        if (invocation) {
+          if (
+            invocation.toolCallId !== (context as OpenClawPluginTeamsToolCallContext).callId ||
+            !invocation.subject
+          ) {
+            throw new Error("an active trusted Teams tool call context is required");
+          }
+          requireCurrentPluginToolAuthorizationInvocation(invocation);
         }
-        requireCurrentPluginToolAuthorizationInvocation(invocation);
         const permission = requiredIdentifier(rawPermission, "Teams permission");
         if (!Array.isArray(rawResources) || rawResources.length === 0) {
           throw new Error("Teams authorization requires at least one resource");
@@ -188,37 +198,86 @@ export function createPluginTeamsApi(input: {
             import("../gateway/authorization/kernel.js"),
             import("../gateway/authorization/state-provider.js"),
           ]);
-        requireCurrentPluginToolAuthorizationInvocation(invocation);
+        let principal;
+        let domain;
+        let delegation;
+        let agentSession;
+        let requestId;
+        if (invocation) {
+          requireCurrentPluginToolAuthorizationInvocation(invocation);
+          principal = invocation.subject!.principal;
+          domain = invocation.subject!.domain;
+          delegation = invocation.subject!.delegation;
+          agentSession = invocation.subject!.agentSession;
+          requestId = invocation.toolCallId;
+        } else {
+          requireTrustedContext(context as OpenClawPluginTeamsRequestContext);
+          const { getAuthorizationPrincipalById } =
+            await import("../gateway/authorization/state-store.js");
+          requireTrustedContext(context as OpenClawPluginTeamsRequestContext);
+          principal = getAuthorizationPrincipalById({
+            id: gatewayContext!.principalId,
+            database: input.database,
+          });
+          if (!principal || principal.kind !== gatewayContext!.principalKind) {
+            throw new Error("the trusted Teams request principal is unavailable");
+          }
+          domain = gatewayContext!.domain;
+          delegation = gatewayContext!.delegation;
+          requestId = gatewayContext!.requestId!;
+        }
         const outcome = await authorizeGatewayAccess({
           runtime: createStateGatewayAuthorizationRuntime({ database: input.database }),
           policy: { kind: "resource", permission, resolveResources: () => resources },
-          principal: invocation.subject.principal,
-          domain: invocation.subject.domain,
-          delegation: invocation.subject.delegation,
-          agentSession: invocation.subject.agentSession,
-          method: `plugin-tool:${pluginId}:${invocation.toolName}`,
+          principal,
+          domain,
+          ...(delegation ? { delegation } : {}),
+          ...(agentSession ? { agentSession } : {}),
+          method: invocation
+            ? `plugin-tool:${pluginId}:${invocation.toolName}`
+            : `plugin-capability:${pluginId}`,
           params: undefined,
           getConfig: () => ({}),
         });
-        requireCurrentPluginToolAuthorizationInvocation(invocation);
+        if (invocation) {
+          requireCurrentPluginToolAuthorizationInvocation(invocation);
+        } else {
+          requireTrustedContext(context as OpenClawPluginTeamsRequestContext);
+        }
         if (!outcome.allowed || !outcome.security) {
           return { allowed: false };
         }
         const trusted = Object.freeze({
           ...outcome.security,
           pluginId,
-          requestId: invocation.toolCallId,
+          requestId,
         });
         const requestContext = projectRequestContext(trusted);
-        trustedContexts.set(requestContext, {
-          kind: "tool",
-          authorization: trusted,
-          invocation,
-        });
+        trustedContexts.set(
+          requestContext,
+          invocation
+            ? { kind: "tool", authorization: trusted, invocation }
+            : { kind: "gateway", authorization: trusted },
+        );
         return { allowed: true, context: requestContext };
       },
     },
     resources: {
+      listChildren: async ({ context, parent: rawParent, requiredAction, type }) => {
+        const trusted = requireTrustedContext(context);
+        const parent = normalizeResource(rawParent);
+        requirePluginResourceNamespace(parent, pluginId);
+        requireAuthorizedAction(trusted, requiredAction, parent);
+        const { listAuthorizationResourceChildren } =
+          await import("../gateway/authorization/resource-operations.js");
+        requireTrustedContext(context);
+        return listAuthorizationResourceChildren({
+          domainId: trusted.domain.id,
+          parent,
+          ...(type ? { type: requiredIdentifier(type, "resource child type") } : {}),
+          database: input.database,
+        });
+      },
       prepareRegister: async ({
         context,
         resource: rawResource,
@@ -257,11 +316,21 @@ export function createPluginTeamsApi(input: {
         });
         return prepared.operationId;
       },
-      prepareRetire: async ({ context, resource: rawResource, requiredAction, idempotencyKey }) => {
+      prepareRetire: async ({
+        context,
+        resource: rawResource,
+        parent: rawParent,
+        requiredAction,
+        idempotencyKey,
+      }) => {
         const trusted = requireTrustedContext(context);
         const resource = normalizeResource(rawResource);
+        const parent = rawParent ? normalizeResource(rawParent) : undefined;
         requirePluginResourceNamespace(resource, pluginId);
-        requireAuthorizedAction(trusted, requiredAction, resource);
+        if (parent) {
+          requirePluginResourceNamespace(parent, pluginId);
+        }
+        requireAuthorizedAction(trusted, requiredAction, parent ?? resource);
         const { prepareAuthorizationResourceRetirement } =
           await import("../gateway/authorization/resource-operations.js");
         requireTrustedContext(context);
@@ -270,6 +339,7 @@ export function createPluginTeamsApi(input: {
           idempotencyKey,
           domainId: trusted.domain.id,
           resource,
+          ...(parent ? { parent } : {}),
           actorPrincipalId: trusted.principalId,
           database: input.database,
         });

--- a/src/plugins/teams-types.ts
+++ b/src/plugins/teams-types.ts
@@ -1,0 +1,46 @@
+export type OpenClawPluginTeamsRequestContext = Readonly<{
+  isolationDomainId: string;
+  principal: Readonly<{
+    id: string;
+    kind: "human" | "agent";
+  }>;
+  delegatedSession?: Readonly<{
+    id: string;
+    assignmentId: string;
+    sponsorPrincipalId: string;
+  }>;
+  requestId: string;
+}>;
+
+export type OpenClawPluginTeamsResourceRef = Readonly<{
+  namespace: string;
+  type: string;
+  id: string;
+}>;
+
+export type OpenClawPluginTeamsApi = {
+  context: {
+    /** Resolve only the current host-authorized request; no identity fields are accepted. */
+    require: () => OpenClawPluginTeamsRequestContext;
+  };
+  resources: {
+    prepareRegister: (input: {
+      context: OpenClawPluginTeamsRequestContext;
+      resource: OpenClawPluginTeamsResourceRef;
+      parent?: OpenClawPluginTeamsResourceRef;
+      requiredAction: string;
+      idempotencyKey: string;
+    }) => Promise<string>;
+    prepareRetire: (input: {
+      context: OpenClawPluginTeamsRequestContext;
+      resource: OpenClawPluginTeamsResourceRef;
+      requiredAction: string;
+      idempotencyKey: string;
+    }) => Promise<string>;
+    replayPrepared: (input: { operation: string }) => Promise<void>;
+    owner: (input: {
+      context: OpenClawPluginTeamsRequestContext;
+      resource: OpenClawPluginTeamsResourceRef;
+    }) => Promise<{ principalId: string }>;
+  };
+};

--- a/src/plugins/teams-types.ts
+++ b/src/plugins/teams-types.ts
@@ -1,3 +1,5 @@
+import type { OpenClawPluginToolContext } from "./tool-types.js";
+
 export type OpenClawPluginTeamsRequestContext = Readonly<{
   isolationDomainId: string;
   principal: Readonly<{
@@ -12,6 +14,10 @@ export type OpenClawPluginTeamsRequestContext = Readonly<{
   requestId: string;
 }>;
 
+export type OpenClawPluginTeamsToolCallContext = Readonly<{
+  callId: string;
+}>;
+
 export type OpenClawPluginTeamsResourceRef = Readonly<{
   namespace: string;
   type: string;
@@ -21,7 +27,19 @@ export type OpenClawPluginTeamsResourceRef = Readonly<{
 export type OpenClawPluginTeamsApi = {
   context: {
     /** Resolve only the current host-authorized request; no identity fields are accepted. */
-    require: () => OpenClawPluginTeamsRequestContext;
+    require: {
+      (): OpenClawPluginTeamsRequestContext;
+      (toolContext: OpenClawPluginToolContext): OpenClawPluginTeamsToolCallContext;
+    };
+  };
+  authorization: {
+    decide: (input: {
+      context: OpenClawPluginTeamsToolCallContext;
+      permission: string;
+      resources: readonly OpenClawPluginTeamsResourceRef[];
+    }) => Promise<
+      { allowed: true; context: OpenClawPluginTeamsRequestContext } | { allowed: false }
+    >;
   };
   resources: {
     prepareRegister: (input: {

--- a/src/plugins/teams-types.ts
+++ b/src/plugins/teams-types.ts
@@ -26,6 +26,8 @@ export type OpenClawPluginTeamsResourceRef = Readonly<{
 
 export type OpenClawPluginTeamsApi = {
   context: {
+    /** Distinguishes a core-bound delegated run from an ordinary legacy/local tool run. */
+    isBound: (toolContext: OpenClawPluginToolContext) => boolean;
     /** Resolve only the current host-authorized request; no identity fields are accepted. */
     require: {
       (): OpenClawPluginTeamsRequestContext;
@@ -34,7 +36,7 @@ export type OpenClawPluginTeamsApi = {
   };
   authorization: {
     decide: (input: {
-      context: OpenClawPluginTeamsToolCallContext;
+      context: OpenClawPluginTeamsToolCallContext | OpenClawPluginTeamsRequestContext;
       permission: string;
       resources: readonly OpenClawPluginTeamsResourceRef[];
     }) => Promise<
@@ -42,6 +44,12 @@ export type OpenClawPluginTeamsApi = {
     >;
   };
   resources: {
+    listChildren: (input: {
+      context: OpenClawPluginTeamsRequestContext;
+      parent: OpenClawPluginTeamsResourceRef;
+      requiredAction: string;
+      type?: string;
+    }) => Promise<readonly OpenClawPluginTeamsResourceRef[]>;
     prepareRegister: (input: {
       context: OpenClawPluginTeamsRequestContext;
       resource: OpenClawPluginTeamsResourceRef;
@@ -52,6 +60,7 @@ export type OpenClawPluginTeamsApi = {
     prepareRetire: (input: {
       context: OpenClawPluginTeamsRequestContext;
       resource: OpenClawPluginTeamsResourceRef;
+      parent?: OpenClawPluginTeamsResourceRef;
       requiredAction: string;
       idempotencyKey: string;
     }) => Promise<string>;

--- a/src/plugins/tool-authorization-context.ts
+++ b/src/plugins/tool-authorization-context.ts
@@ -109,6 +109,11 @@ export function bindPluginToolAuthorizationSubject(
   contextSubjects.set(context, existing ?? canonical);
 }
 
+/** True only when core bound a delegated Teams subject to this exact factory context. */
+export function hasPluginToolAuthorizationSubject(context: OpenClawPluginToolContext): boolean {
+  return contextSubjects.has(context);
+}
+
 function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
   return (
     (typeof value === "object" || typeof value === "function") &&
@@ -128,6 +133,9 @@ export function withPluginToolAuthorizationInvocation<T>(
   },
   run: () => T,
 ): T {
+  if (input.signal?.aborted) {
+    throw new Error("plugin tool authorization invocation was aborted before execution");
+  }
   const subject = contextSubjects.get(input.context);
   const invocation: PluginToolAuthorizationInvocation = Object.freeze({
     pluginId: requiredIdentifier(input.pluginId, "plugin id"),
@@ -141,9 +149,6 @@ export function withPluginToolAuthorizationInvocation<T>(
     lifetime.active = false;
   };
   input.signal?.addEventListener("abort", deactivate, { once: true });
-  if (input.signal?.aborted) {
-    deactivate();
-  }
   invocationLifetimes.set(invocation, lifetime);
   return pluginToolAuthorizationInvocation.run(invocation, () => {
     try {

--- a/src/plugins/tool-authorization-context.ts
+++ b/src/plugins/tool-authorization-context.ts
@@ -1,0 +1,200 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { GatewayAuthorizationSubject } from "../gateway/authorization/contracts.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import type { OpenClawPluginToolContext } from "./tool-types.js";
+
+export type PluginToolAuthorizationInvocation = Readonly<{
+  pluginId: string;
+  toolName: string;
+  toolCallId: string;
+  context: OpenClawPluginToolContext;
+  subject?: GatewayAuthorizationSubject;
+}>;
+
+const PLUGIN_TOOL_AUTHORIZATION_INVOCATION_KEY: unique symbol = Symbol.for(
+  "openclaw.pluginToolAuthorizationInvocation",
+);
+const pluginToolAuthorizationInvocation = resolveGlobalSingleton<
+  AsyncLocalStorage<PluginToolAuthorizationInvocation | undefined>
+>(PLUGIN_TOOL_AUTHORIZATION_INVOCATION_KEY, () => new AsyncLocalStorage());
+
+const contextSubjects = new WeakMap<OpenClawPluginToolContext, GatewayAuthorizationSubject>();
+const invocationLifetimes = new WeakMap<PluginToolAuthorizationInvocation, { active: boolean }>();
+
+function requiredIdentifier(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`${label} must be non-empty`);
+  }
+  return normalized;
+}
+
+function canonicalSubject(subject: GatewayAuthorizationSubject): GatewayAuthorizationSubject {
+  const principal = subject.principal;
+  const domain = subject.domain;
+  const delegation = subject.delegation;
+  const agentSession = subject.agentSession;
+  const kind = principal.kind;
+  if (kind !== "service" || !delegation || !agentSession) {
+    throw new Error(
+      "plugin tool authorization requires a delegated service principal with an agent-session proof",
+    );
+  }
+  if (agentSession.invokingPrincipal.kind !== "human") {
+    throw new Error("plugin tool authorization requires a human invoking principal");
+  }
+  return Object.freeze({
+    principal: Object.freeze({
+      issuer: requiredIdentifier(principal.issuer, "authorization principal issuer"),
+      subject: requiredIdentifier(principal.subject, "authorization principal subject"),
+      kind,
+    }),
+    domain: Object.freeze({
+      id: requiredIdentifier(domain.id, "authorization domain id"),
+    }),
+    delegation: Object.freeze({
+      id: requiredIdentifier(delegation.id, "authorization delegation id"),
+      assignmentId: requiredIdentifier(delegation.assignmentId, "authorization assignment id"),
+    }),
+    agentSession: Object.freeze({
+      id: requiredIdentifier(agentSession.id, "authorization agent session binding id"),
+      invokingPrincipal: Object.freeze({
+        issuer: requiredIdentifier(
+          agentSession.invokingPrincipal.issuer,
+          "authorization invoking principal issuer",
+        ),
+        subject: requiredIdentifier(
+          agentSession.invokingPrincipal.subject,
+          "authorization invoking principal subject",
+        ),
+        kind: agentSession.invokingPrincipal.kind,
+      }),
+    }),
+  });
+}
+
+function sameSubject(
+  first: GatewayAuthorizationSubject,
+  second: GatewayAuthorizationSubject,
+): boolean {
+  return (
+    first.principal.issuer === second.principal.issuer &&
+    first.principal.subject === second.principal.subject &&
+    first.principal.kind === second.principal.kind &&
+    first.domain.id === second.domain.id &&
+    first.delegation?.id === second.delegation?.id &&
+    first.delegation?.assignmentId === second.delegation?.assignmentId &&
+    first.agentSession?.id === second.agentSession?.id &&
+    first.agentSession?.invokingPrincipal.issuer ===
+      second.agentSession?.invokingPrincipal.issuer &&
+    first.agentSession?.invokingPrincipal.subject ===
+      second.agentSession?.invokingPrincipal.subject &&
+    first.agentSession?.invokingPrincipal.kind === second.agentSession?.invokingPrincipal.kind
+  );
+}
+
+/** Core-only binding from a trusted run subject to the exact plugin factory context object. */
+export function bindPluginToolAuthorizationSubject(
+  context: OpenClawPluginToolContext,
+  subject: GatewayAuthorizationSubject | undefined,
+): void {
+  if (!subject) {
+    return;
+  }
+  const canonical = canonicalSubject(subject);
+  const existing = contextSubjects.get(context);
+  if (existing && !sameSubject(existing, canonical)) {
+    throw new Error("plugin tool authorization subject is already bound differently");
+  }
+  contextSubjects.set(context, existing ?? canonical);
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    (typeof value === "object" || typeof value === "function") &&
+    value !== null &&
+    typeof (value as PromiseLike<unknown>).then === "function"
+  );
+}
+
+/** Installs authority only around one owning plugin tool execute callback. */
+export function withPluginToolAuthorizationInvocation<T>(
+  input: {
+    pluginId: string;
+    toolName: string;
+    toolCallId: string;
+    context: OpenClawPluginToolContext;
+    signal?: AbortSignal;
+  },
+  run: () => T,
+): T {
+  const subject = contextSubjects.get(input.context);
+  const invocation: PluginToolAuthorizationInvocation = Object.freeze({
+    pluginId: requiredIdentifier(input.pluginId, "plugin id"),
+    toolName: requiredIdentifier(input.toolName, "plugin tool name"),
+    toolCallId: requiredIdentifier(input.toolCallId, "plugin tool call id"),
+    context: input.context,
+    ...(subject ? { subject } : {}),
+  });
+  const lifetime = { active: true };
+  const deactivate = () => {
+    lifetime.active = false;
+  };
+  input.signal?.addEventListener("abort", deactivate, { once: true });
+  if (input.signal?.aborted) {
+    deactivate();
+  }
+  invocationLifetimes.set(invocation, lifetime);
+  return pluginToolAuthorizationInvocation.run(invocation, () => {
+    try {
+      const result = run();
+      if (isPromiseLike(result)) {
+        return (async () => {
+          try {
+            return await result;
+          } finally {
+            deactivate();
+            input.signal?.removeEventListener("abort", deactivate);
+          }
+        })() as T;
+      }
+      deactivate();
+      input.signal?.removeEventListener("abort", deactivate);
+      return result;
+    } catch (error) {
+      deactivate();
+      input.signal?.removeEventListener("abort", deactivate);
+      throw error;
+    }
+  });
+}
+
+/** Resolves only the current owning invocation and exact factory context object. */
+export function requirePluginToolAuthorizationInvocation(input: {
+  pluginId: string;
+  context: OpenClawPluginToolContext;
+}): PluginToolAuthorizationInvocation {
+  const invocation = pluginToolAuthorizationInvocation.getStore();
+  if (
+    !invocation ||
+    invocation.pluginId !== input.pluginId ||
+    invocation.context !== input.context ||
+    invocationLifetimes.get(invocation)?.active !== true ||
+    !invocation.subject
+  ) {
+    throw new Error("an active host-authorized plugin tool invocation is required");
+  }
+  return invocation;
+}
+
+/** Revalidates an invocation after asynchronous authorization or lazy imports. */
+export function requireCurrentPluginToolAuthorizationInvocation(
+  expected: PluginToolAuthorizationInvocation,
+): void {
+  if (
+    pluginToolAuthorizationInvocation.getStore() !== expected ||
+    invocationLifetimes.get(expected)?.active !== true
+  ) {
+    throw new Error("the plugin tool authorization invocation is no longer active");
+  }
+}

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -6,6 +6,11 @@ import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { loggingState } from "../logging/state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
+import {
+  bindPluginToolAuthorizationSubject,
+  requireCurrentPluginToolAuthorizationInvocation,
+  requirePluginToolAuthorizationInvocation,
+} from "./tool-authorization-context.js";
 
 type MockRegistryToolEntry = {
   pluginId: string;
@@ -611,6 +616,201 @@ describe("resolvePluginTools optional tools", () => {
         pluginSource: "/tmp/optional-demo.js",
       },
     ]);
+  });
+
+  it("binds Teams authority to the exact factory context and execute lifetime", async () => {
+    const firstContext = createContext();
+    const secondContext = createContext();
+    const subject = {
+      principal: { issuer: "core", subject: "agent:main", kind: "service" as const },
+      domain: { id: "domain-1" },
+      delegation: { id: "delegation-1", assignmentId: "assignment-1" },
+      agentSession: {
+        id: "binding-1",
+        invokingPrincipal: {
+          issuer: "trusted-proxy",
+          subject: "owner@example.com",
+          kind: "human" as const,
+        },
+      },
+    };
+    bindPluginToolAuthorizationSubject(firstContext as never, subject);
+    bindPluginToolAuthorizationSubject(secondContext as never, subject);
+    subject.domain.id = "forged-domain";
+    subject.delegation.assignmentId = "forged-assignment";
+    const factoryContexts: unknown[] = [];
+    let retainedInvocation: ReturnType<typeof requirePluginToolAuthorizationInvocation> | undefined;
+    const rawTool = {
+      name: "authorized_tool",
+      description: "authorized tool",
+      parameters: { type: "object", properties: {} },
+      prepareArguments() {
+        for (const context of factoryContexts) {
+          expect(() =>
+            requirePluginToolAuthorizationInvocation({
+              pluginId: "multi",
+              context: context as never,
+            }),
+          ).toThrow(/active host-authorized plugin tool invocation/i);
+        }
+        return {};
+      },
+      async execute() {
+        const active = factoryContexts.flatMap((context) => {
+          try {
+            return [
+              requirePluginToolAuthorizationInvocation({
+                pluginId: "multi",
+                context: context as never,
+              }),
+            ];
+          } catch {
+            return [];
+          }
+        });
+        expect(active).toHaveLength(1);
+        const currentInvocation = active[0];
+        if (!currentInvocation) {
+          throw new Error("expected one active plugin tool invocation");
+        }
+        retainedInvocation = currentInvocation;
+        expect(currentInvocation.subject).toEqual({
+          principal: { issuer: "core", subject: "agent:main", kind: "service" },
+          domain: { id: "domain-1" },
+          delegation: { id: "delegation-1", assignmentId: "assignment-1" },
+          agentSession: {
+            id: "binding-1",
+            invokingPrincipal: {
+              issuer: "trusted-proxy",
+              subject: "owner@example.com",
+              kind: "human",
+            },
+          },
+        });
+        expect(() =>
+          requirePluginToolAuthorizationInvocation({
+            pluginId: "other-plugin",
+            context: currentInvocation.context,
+          }),
+        ).toThrow(/active host-authorized plugin tool invocation/i);
+        expect(() =>
+          requirePluginToolAuthorizationInvocation({
+            pluginId: "multi",
+            context: { ...currentInvocation.context },
+          }),
+        ).toThrow(/active host-authorized plugin tool invocation/i);
+        return { content: [{ type: "text", text: "ok" }] };
+      },
+    };
+    setRegistry([
+      {
+        pluginId: "multi",
+        optional: false,
+        source: "/tmp/multi.js",
+        names: ["authorized_tool"],
+        factory: (context) => {
+          factoryContexts.push(context);
+          return rawTool;
+        },
+      },
+    ]);
+
+    const [first] = resolvePluginTools(createResolveToolsParams({ context: firstContext }));
+    const [second] = resolvePluginTools(createResolveToolsParams({ context: secondContext }));
+    expect(first).not.toBe(second);
+    first.prepareArguments?.({});
+    await first.execute("call-1", {}, undefined);
+    await second.execute("call-2", {}, undefined);
+    expect(retainedInvocation).toBeDefined();
+    expect(() => requireCurrentPluginToolAuthorizationInvocation(retainedInvocation!)).toThrow(
+      /no longer active/i,
+    );
+  });
+
+  it("revokes retained Teams authority when an abort-ignoring tool is cancelled", async () => {
+    const context = createContext();
+    bindPluginToolAuthorizationSubject(context as never, {
+      principal: { issuer: "core", subject: "agent:main", kind: "service" },
+      domain: { id: "domain-1" },
+      delegation: { id: "delegation-1", assignmentId: "assignment-1" },
+      agentSession: {
+        id: "binding-1",
+        invokingPrincipal: {
+          issuer: "trusted-proxy",
+          subject: "owner@example.com",
+          kind: "human",
+        },
+      },
+    });
+    let releaseRetainedCallback: (() => void) | undefined;
+    let settleTool: (() => void) | undefined;
+    let factoryContext: unknown;
+    let resolveProbe: ((error?: Error) => void) | undefined;
+    const probed = new Promise<Error | undefined>((resolve) => {
+      resolveProbe = resolve;
+    });
+    setRegistry([
+      {
+        pluginId: "multi",
+        optional: false,
+        source: "/tmp/multi.js",
+        names: ["abort_ignoring_tool"],
+        factory: (toolContext) => {
+          factoryContext = toolContext;
+          return {
+            name: "abort_ignoring_tool",
+            description: "abort ignoring tool",
+            parameters: { type: "object", properties: {} },
+            execute() {
+              const invocation = requirePluginToolAuthorizationInvocation({
+                pluginId: "multi",
+                context: factoryContext as never,
+              });
+              const retainedGate = new Promise<void>((resolve) => {
+                releaseRetainedCallback = resolve;
+              });
+              void retainedGate.then(() => {
+                try {
+                  expect(() => requireCurrentPluginToolAuthorizationInvocation(invocation)).toThrow(
+                    /no longer active/i,
+                  );
+                  resolveProbe?.();
+                } catch (error) {
+                  resolveProbe?.(error instanceof Error ? error : new Error(String(error)));
+                }
+              });
+              return new Promise((resolve) => {
+                settleTool = () =>
+                  resolve({ content: [{ type: "text" as const, text: "finished" }] });
+              });
+            },
+          };
+        },
+      },
+    ]);
+    const [tool] = resolvePluginTools(createResolveToolsParams({ context }));
+    const controller = new AbortController();
+    const pending = tool.execute("call-abort", {}, controller.signal);
+    await vi.waitFor(() => expect(releaseRetainedCallback).toBeTypeOf("function"));
+
+    controller.abort();
+    releaseRetainedCallback?.();
+    const error = await probed;
+    if (error) {
+      throw error;
+    }
+    settleTool?.();
+    await pending;
+  });
+
+  it("rejects delegated plugin-tool authority without an agent-session proof", () => {
+    expect(() =>
+      bindPluginToolAuthorizationSubject(createContext() as never, {
+        principal: { issuer: "core", subject: "agent:main", kind: "service" },
+        domain: { id: "domain-1" },
+        delegation: { id: "delegation-1", assignmentId: "assignment-1" },
+      }),
+    ).toThrow(/agent-session proof/i);
   });
 
   it("wraps every array tool callback and restores caller scope after errors", async () => {

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -31,6 +31,7 @@ import {
   resolvePluginRuntimeLoadContext,
 } from "./runtime/load-context.js";
 import { ensureStandaloneRuntimePluginRegistryLoaded } from "./runtime/standalone-runtime-registry-loader.js";
+import { withPluginToolAuthorizationInvocation } from "./tool-authorization-context.js";
 import { findUndeclaredPluginToolNames } from "./tool-contracts.js";
 import {
   buildPluginToolDescriptorCacheKey,
@@ -81,7 +82,10 @@ const PLUGIN_TOOL_FACTORY_WARN_FACTORY_MS = 1_000;
 const PLUGIN_TOOL_FACTORY_SUMMARY_LIMIT = 20;
 
 const pluginToolMeta = new WeakMap<AnyAgentTool, PluginToolMeta>();
-const scopedPluginTools = new WeakMap<AnyAgentTool, Map<string, AnyAgentTool>>();
+const scopedPluginTools = new WeakMap<
+  AnyAgentTool,
+  Map<string, WeakMap<OpenClawPluginToolContext, AnyAgentTool>>
+>();
 
 /** Attaches plugin ownership metadata to a concrete agent tool instance. */
 export function setPluginToolMeta(tool: AnyAgentTool, meta: PluginToolMeta): void {
@@ -124,10 +128,15 @@ function isAgentTool(value: unknown): value is AnyAgentTool {
   );
 }
 
-function wrapPluginToolCallbacks(entry: PluginToolRegistration, tool: AnyAgentTool): AnyAgentTool {
+function wrapPluginToolCallbacks(
+  entry: PluginToolRegistration,
+  tool: AnyAgentTool,
+  context: OpenClawPluginToolContext,
+): AnyAgentTool {
   const key = pluginToolScopeKey(entry);
   const scopedByKey = scopedPluginTools.get(tool);
-  const cached = scopedByKey?.get(key);
+  const scopedByContext = scopedByKey?.get(key);
+  const cached = scopedByContext?.get(context);
   if (cached) {
     return cached;
   }
@@ -143,12 +152,20 @@ function wrapPluginToolCallbacks(entry: PluginToolRegistration, tool: AnyAgentTo
     signal?: AbortSignal,
     onUpdate?: unknown,
   ) =>
-    runWithPluginToolScope(
-      entry,
-      () =>
-        Reflect.apply(tool.execute, tool, [toolCallId, params, signal, onUpdate]) as ReturnType<
-          AnyAgentTool["execute"]
-        >,
+    runWithPluginToolScope(entry, () =>
+      withPluginToolAuthorizationInvocation(
+        {
+          pluginId: entry.pluginId,
+          toolName: tool.name,
+          toolCallId,
+          context,
+          signal,
+        },
+        () =>
+          Reflect.apply(tool.execute, tool, [toolCallId, params, signal, onUpdate]) as ReturnType<
+            AnyAgentTool["execute"]
+          >,
+      ),
     );
   const wrapped = new Proxy<AnyAgentTool>(tool, {
     get(target, prop) {
@@ -182,8 +199,10 @@ function wrapPluginToolCallbacks(entry: PluginToolRegistration, tool: AnyAgentTo
   });
 
   copyPluginToolMeta(tool, wrapped);
-  const nextScopedByKey = scopedByKey ?? new Map<string, AnyAgentTool>();
-  nextScopedByKey.set(key, wrapped);
+  const nextScopedByKey = scopedByKey ?? new Map();
+  const nextScopedByContext = scopedByContext ?? new WeakMap();
+  nextScopedByContext.set(context, wrapped);
+  nextScopedByKey.set(key, nextScopedByContext);
   scopedPluginTools.set(tool, nextScopedByKey);
   return wrapped;
 }
@@ -191,16 +210,19 @@ function wrapPluginToolCallbacks(entry: PluginToolRegistration, tool: AnyAgentTo
 function wrapPluginToolFactoryResult(
   entry: PluginToolRegistration,
   result: PluginToolFactoryResult,
+  context: OpenClawPluginToolContext,
 ): PluginToolFactoryResult {
   if (Array.isArray(result)) {
-    return result.map((tool) => (isAgentTool(tool) ? wrapPluginToolCallbacks(entry, tool) : tool));
+    return result.map((tool) =>
+      isAgentTool(tool) ? wrapPluginToolCallbacks(entry, tool, context) : tool,
+    );
   }
-  return isAgentTool(result) ? wrapPluginToolCallbacks(entry, result) : result;
+  return isAgentTool(result) ? wrapPluginToolCallbacks(entry, result, context) : result;
 }
 
 function resolvePluginToolFactory(entry: PluginToolRegistration, ctx: OpenClawPluginToolContext) {
   return runWithPluginToolScope(entry, () =>
-    wrapPluginToolFactoryResult(entry, entry.factory(ctx)),
+    wrapPluginToolFactoryResult(entry, entry.factory(ctx), ctx),
   );
 }
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -25,6 +25,7 @@ import type { ThinkLevel } from "../auto-reply/thinking.shared.js";
 import type { ModelProviderConfig } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { SecretRef } from "../config/types.secrets.js";
+import type { GatewayMethodAccessPolicy } from "../gateway/authorization/contracts.js";
 import type { OperatorScope } from "../gateway/operator-scopes.js";
 import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
 import type { InternalHookHandler } from "../hooks/internal-hook-types.js";
@@ -145,6 +146,7 @@ import type {
 } from "./provider-thinking.types.js";
 import type { PluginRuntime } from "./runtime/types.js";
 import type { SessionCatalogProvider } from "./session-catalog.js";
+import type { OpenClawPluginTeamsApi } from "./teams-types.js";
 import type {
   OpenClawPluginHookOptions,
   OpenClawPluginToolFactory,
@@ -173,6 +175,11 @@ export type {
   OpenClawPluginToolOptions,
 } from "./tool-types.js";
 export type { AnyAgentTool } from "../agents/tools/common.js";
+export type {
+  OpenClawPluginTeamsApi,
+  OpenClawPluginTeamsRequestContext,
+  OpenClawPluginTeamsResourceRef,
+} from "./teams-types.js";
 export type { AgentHarness } from "../agents/harness/types.js";
 export type {
   AgentToolResultMiddleware,
@@ -2744,6 +2751,12 @@ export type OpenClawPluginLifecycleApi = {
   registerRuntimeLifecycle: (lifecycle: PluginRuntimeLifecycleRegistration) => void;
 };
 
+/** Resource policy declared by a plugin method; plugins cannot mark methods core-public. */
+export type OpenClawPluginGatewayMethodAccessPolicy = Extract<
+  GatewayMethodAccessPolicy,
+  { kind: "resource" }
+>;
+
 /** Main registration API injected into native plugin entry files. */
 export type OpenClawPluginApi = {
   id: string;
@@ -2774,6 +2787,8 @@ export type OpenClawPluginApi = {
   runContext: OpenClawPluginRunContextApi;
   /** Grouped facade for plugin-owned lifecycle cleanup hooks. */
   lifecycle: OpenClawPluginLifecycleApi;
+  /** Host-bound multi-tenant identity and resource capabilities. */
+  teams: OpenClawPluginTeamsApi;
   registerTool: (
     tool: AnyAgentTool | OpenClawPluginToolFactory,
     opts?: OpenClawPluginToolOptions,
@@ -2798,7 +2813,7 @@ export type OpenClawPluginApi = {
   registerGatewayMethod: (
     method: string,
     handler: GatewayRequestHandler,
-    opts?: { scope?: OperatorScope },
+    opts?: { scope?: OperatorScope; access?: OpenClawPluginGatewayMethodAccessPolicy },
   ) => void;
   /** Register a read-only external-session catalog with optional native adoption actions. */
   registerSessionCatalog: (provider: SessionCatalogProvider) => void;

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -179,6 +179,7 @@ export type {
   OpenClawPluginTeamsApi,
   OpenClawPluginTeamsRequestContext,
   OpenClawPluginTeamsResourceRef,
+  OpenClawPluginTeamsToolCallContext,
 } from "./teams-types.js";
 export type { AgentHarness } from "../agents/harness/types.js";
 export type {

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -154,7 +154,6 @@ export interface AuthorizationGrants {
   created_at: number;
   domain_id: string;
   granted_by_principal_id: string;
-  granted_by_role: string;
   namespace: string;
   permission: string;
   principal_id: string;

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -135,6 +135,26 @@ export interface AuthProfileStores {
   updated_at: number;
 }
 
+export interface AuthorizationAgentSponsors {
+  agent_principal_id: string;
+  created_at: number;
+  domain_id: string;
+  sponsor_principal_id: string;
+}
+
+export interface AuthorizationDelegations {
+  agent_principal_id: string;
+  assignment_id: string;
+  created_at: number;
+  created_by_principal_id: string;
+  delegation_id: string;
+  domain_id: string;
+  revoked_at: number | null;
+  sponsor_principal_id: string;
+  state: string;
+  updated_at: number;
+}
+
 export interface AuthorizationDomainMemberships {
   added_by_principal_id: string;
   added_by_role: string;
@@ -170,6 +190,28 @@ export interface AuthorizationPrincipals {
   updated_at: number;
 }
 
+export interface AuthorizationResourceOperations {
+  actor_principal_id: string;
+  applied_at: number | null;
+  assignment_id: string | null;
+  created_at: number;
+  delegation_id: string | null;
+  domain_id: string;
+  idempotency_key: string;
+  namespace: string;
+  operation_id: string;
+  operation_scope: string;
+  operation_type: string;
+  owner_principal_id: string;
+  parent_namespace: string | null;
+  parent_resource_id: string | null;
+  parent_resource_type: string | null;
+  resource_id: string;
+  resource_type: string;
+  state: string;
+  updated_at: number;
+}
+
 export interface AuthorizationResources {
   created_at: number;
   domain_id: string;
@@ -181,6 +223,7 @@ export interface AuthorizationResources {
   resource_id: string;
   resource_type: string;
   retired_at: number | null;
+  retired_by_principal_id: string | null;
   updated_at: number;
 }
 
@@ -1253,10 +1296,13 @@ export interface DB {
   audit_identity_keys: AuditIdentityKeys;
   auth_profile_state: AuthProfileState;
   auth_profile_stores: AuthProfileStores;
+  authorization_agent_sponsors: AuthorizationAgentSponsors;
+  authorization_delegations: AuthorizationDelegations;
   authorization_domain_memberships: AuthorizationDomainMemberships;
   authorization_domains: AuthorizationDomains;
   authorization_grants: AuthorizationGrants;
   authorization_principals: AuthorizationPrincipals;
+  authorization_resource_operations: AuthorizationResourceOperations;
   authorization_resources: AuthorizationResources;
   backup_runs: BackupRuns;
   capture_blobs: CaptureBlobs;

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -1138,6 +1138,56 @@ export interface TaskRuns {
   tool_use_count: number | null;
 }
 
+export interface TeamsInviteGrants {
+  created_at: number;
+  domain_id: string;
+  invite_id: string;
+  namespace: string;
+  permission: string;
+  resource_id: string;
+  resource_type: string;
+}
+
+export interface TeamsInvites {
+  code_digest: string;
+  created_at: number;
+  created_by_principal_id: string;
+  domain_id: string;
+  expires_at: number;
+  invite_id: string;
+  recipient_label: string | null;
+  redeemed_at: number | null;
+  redeemed_by_principal_id: string | null;
+  revoked_at: number | null;
+  revoked_by_principal_id: string | null;
+  state: string;
+}
+
+export interface TeamsLocalAccounts {
+  account_id: string;
+  created_at: number;
+  login_label: string;
+  password_salt: Uint8Array;
+  password_scrypt_n: number;
+  password_scrypt_p: number;
+  password_scrypt_r: number;
+  password_verifier: Uint8Array;
+  principal_id: string;
+}
+
+export interface TeamsSessions {
+  account_id: string;
+  created_at: number;
+  domain_id: string;
+  expires_at: number;
+  principal_id: string;
+  revoked_at: number | null;
+  revoked_by_principal_id: string | null;
+  session_id: string;
+  state: string;
+  token_digest: string;
+}
+
 export interface TuiLastSessions {
   scope_key: string;
   session_key: string;
@@ -1379,6 +1429,10 @@ export interface DB {
   subagent_runs: SubagentRuns;
   task_delivery_state: TaskDeliveryState;
   task_runs: TaskRuns;
+  teams_invite_grants: TeamsInviteGrants;
+  teams_invites: TeamsInvites;
+  teams_local_accounts: TeamsLocalAccounts;
+  teams_sessions: TeamsSessions;
   tui_last_sessions: TuiLastSessions;
   update_check_state: UpdateCheckState;
   voicewake_routing_config: VoicewakeRoutingConfig;

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -135,6 +135,22 @@ export interface AuthProfileStores {
   updated_at: number;
 }
 
+export interface AuthorizationAgentSessionBindings {
+  agent_principal_id: string;
+  assignment_id: string;
+  binding_id: string;
+  created_at: number;
+  created_by_principal_id: string;
+  delegation_id: string;
+  domain_id: string;
+  revoked_at: number | null;
+  runtime_agent_id: string;
+  session_key: string;
+  sponsor_principal_id: string;
+  state: string;
+  updated_at: number;
+}
+
 export interface AuthorizationAgentSponsors {
   agent_principal_id: string;
   created_at: number;
@@ -1296,6 +1312,7 @@ export interface DB {
   audit_identity_keys: AuditIdentityKeys;
   auth_profile_state: AuthProfileState;
   auth_profile_stores: AuthProfileStores;
+  authorization_agent_session_bindings: AuthorizationAgentSessionBindings;
   authorization_agent_sponsors: AuthorizationAgentSponsors;
   authorization_delegations: AuthorizationDelegations;
   authorization_domain_memberships: AuthorizationDomainMemberships;

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -135,6 +135,51 @@ export interface AuthProfileStores {
   updated_at: number;
 }
 
+export interface AuthorizationDomainMemberships {
+  added_by_principal_id: string;
+  added_by_role: string;
+  created_at: number;
+  domain_id: string;
+  principal_id: string;
+  role: string;
+}
+
+export interface AuthorizationDomains {
+  created_at: number;
+  domain_id: string;
+  updated_at: number;
+}
+
+export interface AuthorizationGrants {
+  created_at: number;
+  domain_id: string;
+  granted_by_principal_id: string;
+  granted_by_role: string;
+  namespace: string;
+  permission: string;
+  principal_id: string;
+  resource_id: string;
+  resource_type: string;
+}
+
+export interface AuthorizationPrincipals {
+  created_at: number;
+  issuer: string;
+  kind: string;
+  principal_id: string;
+  subject: string;
+  updated_at: number;
+}
+
+export interface AuthorizationResources {
+  created_at: number;
+  domain_id: string;
+  namespace: string;
+  owner_principal_id: string;
+  resource_id: string;
+  resource_type: string;
+}
+
 export interface BackupRuns {
   archive_path: string;
   created_at: number;
@@ -1204,6 +1249,11 @@ export interface DB {
   audit_identity_keys: AuditIdentityKeys;
   auth_profile_state: AuthProfileState;
   auth_profile_stores: AuthProfileStores;
+  authorization_domain_memberships: AuthorizationDomainMemberships;
+  authorization_domains: AuthorizationDomains;
+  authorization_grants: AuthorizationGrants;
+  authorization_principals: AuthorizationPrincipals;
+  authorization_resources: AuthorizationResources;
   backup_runs: BackupRuns;
   capture_blobs: CaptureBlobs;
   capture_events: CaptureEvents;

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -175,8 +175,13 @@ export interface AuthorizationResources {
   domain_id: string;
   namespace: string;
   owner_principal_id: string;
+  parent_namespace: string | null;
+  parent_resource_id: string | null;
+  parent_resource_type: string | null;
   resource_id: string;
   resource_type: string;
+  retired_at: number | null;
+  updated_at: number;
 }
 
 export interface BackupRuns {

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -1518,6 +1518,11 @@ function ensureAdditiveStateColumns(db: DatabaseSync): void {
   ensureColumn(db, "official_external_plugin_catalog_snapshots", "trust_signature_count INTEGER");
   ensureColumn(db, "official_external_plugin_catalog_snapshots", "trust_threshold INTEGER");
   ensureColumn(db, "official_external_plugin_catalog_snapshots", "trust_verified_at TEXT");
+  ensureColumn(db, "authorization_resources", "parent_namespace TEXT");
+  ensureColumn(db, "authorization_resources", "parent_resource_type TEXT");
+  ensureColumn(db, "authorization_resources", "parent_resource_id TEXT");
+  ensureColumn(db, "authorization_resources", "retired_at INTEGER");
+  ensureColumn(db, "authorization_resources", "updated_at INTEGER NOT NULL DEFAULT 0");
   const addedTaskRequesterAgentId = ensureColumn(db, "task_runs", "requester_agent_id TEXT");
   if (addedTaskRequesterAgentId) {
     repairLegacyTaskAgentAttribution(db);

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -238,6 +238,14 @@ function tableExists(db: DatabaseSync, tableName: string): boolean {
   return row?.ok === 1;
 }
 
+function hasCanonicalAuthorizationResourcesPrimaryKey(db: DatabaseSync): boolean {
+  return (
+    !tableExists(db, "authorization_resources") ||
+    JSON.stringify(tablePrimaryKeyColumns(db, "authorization_resources")) ===
+      JSON.stringify(["domain_id", "namespace", "resource_type", "resource_id"])
+  );
+}
+
 function ensureColumn(db: DatabaseSync, tableName: string, columnSql: string): boolean {
   const columnName = columnSql.trim().split(/\s+/, 1)[0];
   if (!columnName || !tableExists(db, tableName) || tableHasColumn(db, tableName, columnName)) {
@@ -782,6 +790,11 @@ function assertCanonicalStateSchemaShape(db: DatabaseSync, pathname: string): vo
     }
     throw new Error(
       `OpenClaw state database ${pathname} has a noncanonical audit event schema that cannot be repaired automatically; restore the canonical audit_events shape before retrying.`,
+    );
+  }
+  if (!hasCanonicalAuthorizationResourcesPrimaryKey(db)) {
+    throw new Error(
+      `OpenClaw state database ${pathname} has a noncanonical authorization resource schema; rebuild the unpublished Teams authorization state before enabling isolated mode.`,
     );
   }
 }

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -1535,6 +1535,7 @@ function ensureAdditiveStateColumns(db: DatabaseSync): void {
   ensureColumn(db, "authorization_resources", "parent_resource_type TEXT");
   ensureColumn(db, "authorization_resources", "parent_resource_id TEXT");
   ensureColumn(db, "authorization_resources", "retired_at INTEGER");
+  ensureColumn(db, "authorization_resources", "retired_by_principal_id TEXT");
   ensureColumn(db, "authorization_resources", "updated_at INTEGER NOT NULL DEFAULT 0");
   const addedTaskRequesterAgentId = ensureColumn(db, "task_runs", "requester_agent_id TEXT");
   if (addedTaskRequesterAgentId) {
@@ -1561,6 +1562,33 @@ function ensureAdditiveStateColumns(db: DatabaseSync): void {
   ensureOperatorApprovalResolutionRefs(db);
 }
 
+function replaceAuthorizationResourceRetirementTrigger(db: DatabaseSync, pathname: string): void {
+  if (
+    !tableExists(db, "authorization_resources") ||
+    !tableHasColumn(db, "authorization_resources", "retired_by_principal_id")
+  ) {
+    return;
+  }
+  const ambiguousRetirement = db
+    .prepare(
+      `SELECT 1 AS found
+         FROM authorization_resources
+        WHERE retired_at IS NOT NULL
+          AND retired_by_principal_id IS NULL
+        LIMIT 1`,
+    )
+    .get() as { found?: number } | undefined;
+  if (ambiguousRetirement) {
+    throw new Error(
+      `noncanonical authorization retirement provenance in ${pathname}; rebuild this unpublished authorization state before continuing`,
+    );
+  }
+  // The prior dormant schema used this trigger name with an older column list.
+  // CREATE TRIGGER IF NOT EXISTS cannot upgrade it, so replace it deliberately;
+  // the canonical schema execution immediately below recreates the current guard.
+  db.exec("DROP TRIGGER IF EXISTS authorization_resources_retirement_monotonic;");
+}
+
 function ensureSchema(db: DatabaseSync, pathname: string): void {
   const now = Date.now();
   const kysely = getNodeSqliteKysely<OpenClawStateMetadataDatabase>(db);
@@ -1570,6 +1598,7 @@ function ensureSchema(db: DatabaseSync, pathname: string): void {
       assertSupportedSchemaVersion(db, pathname);
       ensureAdditiveStateColumns(db);
       assertCanonicalStateSchemaShape(db, pathname);
+      replaceAuthorizationResourceRetirementTrigger(db, pathname);
       db.exec(OPENCLAW_STATE_SCHEMA_SQL);
       repairCanonicalSqliteUniqueIndexes(db, pathname, OPENCLAW_STATE_CANONICAL_UNIQUE_INDEXES);
       // Retired node_pairing_* tables were created by earlier schema revisions but

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -828,6 +828,159 @@ BEGIN
   SELECT RAISE(ABORT, 'authorization delegations cannot be deleted');
 END;
 
+CREATE TABLE IF NOT EXISTS authorization_agent_session_bindings (
+  domain_id TEXT NOT NULL,
+  binding_id TEXT NOT NULL,
+  runtime_agent_id TEXT NOT NULL CHECK (length(trim(runtime_agent_id)) > 0),
+  session_key TEXT NOT NULL CHECK (length(trim(session_key)) > 0),
+  delegation_id TEXT NOT NULL,
+  assignment_id TEXT NOT NULL,
+  agent_principal_id TEXT NOT NULL,
+  sponsor_principal_id TEXT NOT NULL,
+  created_by_principal_id TEXT NOT NULL,
+  state TEXT NOT NULL CHECK (state IN ('active', 'revoked')),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  revoked_at INTEGER,
+  PRIMARY KEY (domain_id, binding_id),
+  CHECK (created_by_principal_id = sponsor_principal_id),
+  CHECK (
+    (state = 'active' AND revoked_at IS NULL)
+    OR (state = 'revoked' AND revoked_at IS NOT NULL)
+  ),
+  FOREIGN KEY (domain_id) REFERENCES authorization_domains(domain_id),
+  FOREIGN KEY (agent_principal_id) REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (sponsor_principal_id) REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (created_by_principal_id) REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (
+    domain_id,
+    delegation_id,
+    assignment_id,
+    agent_principal_id,
+    sponsor_principal_id
+  ) REFERENCES authorization_delegations(
+    domain_id,
+    delegation_id,
+    assignment_id,
+    agent_principal_id,
+    sponsor_principal_id
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_authorization_agent_session_bindings_runtime
+  ON authorization_agent_session_bindings(runtime_agent_id, session_key, state);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_authorization_agent_session_bindings_active_runtime
+  ON authorization_agent_session_bindings(runtime_agent_id, session_key)
+  WHERE state = 'active';
+
+CREATE TRIGGER IF NOT EXISTS authorization_agent_session_bindings_insert_guard
+BEFORE INSERT ON authorization_agent_session_bindings
+FOR EACH ROW
+WHEN
+  NEW.state <> 'active'
+  OR NEW.revoked_at IS NOT NULL
+  OR NOT EXISTS (
+    SELECT 1
+    FROM authorization_delegations AS delegation
+    INNER JOIN authorization_domain_memberships AS sponsor_membership
+      ON sponsor_membership.domain_id = delegation.domain_id
+     AND sponsor_membership.principal_id = delegation.sponsor_principal_id
+    WHERE delegation.domain_id = NEW.domain_id
+      AND delegation.delegation_id = NEW.delegation_id
+      AND delegation.assignment_id = NEW.assignment_id
+      AND delegation.agent_principal_id = NEW.agent_principal_id
+      AND delegation.sponsor_principal_id = NEW.sponsor_principal_id
+      AND delegation.state = 'active'
+      AND sponsor_membership.role = 'owner'
+  )
+  OR NOT EXISTS (
+    SELECT 1
+    FROM authorization_resources AS resource
+    WHERE resource.domain_id = NEW.domain_id
+      AND resource.namespace = 'core'
+      AND resource.resource_type = 'agent-session'
+      AND resource.resource_id = NEW.assignment_id
+      AND resource.owner_principal_id = NEW.sponsor_principal_id
+      AND resource.retired_at IS NULL
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'authorization agent session binding requires an active canonical delegation and owned agent-session resource');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_agent_session_bindings_payload_immutable
+BEFORE UPDATE OF
+  domain_id,
+  binding_id,
+  runtime_agent_id,
+  session_key,
+  delegation_id,
+  assignment_id,
+  agent_principal_id,
+  sponsor_principal_id,
+  created_by_principal_id,
+  created_at
+ON authorization_agent_session_bindings
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'authorization agent session binding payload is immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_agent_session_bindings_state_monotonic
+BEFORE UPDATE OF state, revoked_at ON authorization_agent_session_bindings
+FOR EACH ROW
+WHEN NOT (
+  OLD.state = 'active'
+  AND OLD.revoked_at IS NULL
+  AND NEW.state = 'revoked'
+  AND NEW.revoked_at IS NOT NULL
+)
+BEGIN
+  SELECT RAISE(ABORT, 'authorization agent session binding revocation is monotonic');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_agent_session_bindings_delete_forbidden
+BEFORE DELETE ON authorization_agent_session_bindings
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'authorization agent session bindings cannot be deleted');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_agent_session_resource_owner_binding_guard
+BEFORE UPDATE OF owner_principal_id ON authorization_resources
+FOR EACH ROW
+WHEN
+  OLD.namespace = 'core'
+  AND OLD.resource_type = 'agent-session'
+  AND NEW.owner_principal_id <> OLD.owner_principal_id
+  AND EXISTS (
+    SELECT 1
+    FROM authorization_agent_session_bindings AS binding
+    WHERE binding.domain_id = OLD.domain_id
+      AND binding.assignment_id = OLD.resource_id
+      AND binding.state = 'active'
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'an active agent-session binding keeps its canonical sponsor owner; share access with grants');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_delegation_revoke_session_bindings
+AFTER UPDATE OF state, revoked_at ON authorization_delegations
+FOR EACH ROW
+WHEN
+  OLD.state = 'active'
+  AND NEW.state = 'revoked'
+BEGIN
+  UPDATE authorization_agent_session_bindings
+  SET
+    state = 'revoked',
+    revoked_at = NEW.revoked_at,
+    updated_at = NEW.updated_at
+  WHERE domain_id = NEW.domain_id
+    AND delegation_id = NEW.delegation_id
+    AND state = 'active';
+END;
+
 CREATE TRIGGER IF NOT EXISTS authorization_membership_delete_revokes_delegations
 BEFORE DELETE ON authorization_domain_memberships
 FOR EACH ROW

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -418,7 +418,6 @@ CREATE TABLE IF NOT EXISTS authorization_grants (
   resource_id TEXT NOT NULL,
   permission TEXT NOT NULL CHECK (length(trim(permission)) > 0),
   granted_by_principal_id TEXT NOT NULL,
-  granted_by_role TEXT NOT NULL CHECK (granted_by_role = 'owner'),
   created_at INTEGER NOT NULL,
   PRIMARY KEY (
     domain_id,
@@ -430,8 +429,8 @@ CREATE TABLE IF NOT EXISTS authorization_grants (
   ),
   FOREIGN KEY (domain_id, principal_id)
     REFERENCES authorization_domain_memberships(domain_id, principal_id),
-  FOREIGN KEY (domain_id, granted_by_principal_id, granted_by_role)
-    REFERENCES authorization_domain_memberships(domain_id, principal_id, role),
+  FOREIGN KEY (domain_id, granted_by_principal_id)
+    REFERENCES authorization_domain_memberships(domain_id, principal_id),
   FOREIGN KEY (domain_id, namespace, resource_type, resource_id)
     REFERENCES authorization_resources(domain_id, namespace, resource_type, resource_id)
 );
@@ -445,6 +444,45 @@ CREATE INDEX IF NOT EXISTS idx_authorization_grants_lookup
     resource_id,
     domain_id
   );
+
+CREATE TRIGGER IF NOT EXISTS authorization_grants_owner_guard
+BEFORE INSERT ON authorization_grants
+FOR EACH ROW
+WHEN
+  NOT EXISTS (
+    SELECT 1
+    FROM authorization_principals AS principal
+    WHERE principal.principal_id = NEW.granted_by_principal_id
+      AND principal.kind = 'human'
+  )
+  OR (
+    NOT EXISTS (
+      SELECT 1
+      FROM authorization_domain_memberships AS membership
+      WHERE membership.domain_id = NEW.domain_id
+        AND membership.principal_id = NEW.granted_by_principal_id
+        AND membership.role = 'owner'
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM authorization_resources AS resource
+      WHERE resource.domain_id = NEW.domain_id
+        AND resource.namespace = NEW.namespace
+        AND resource.resource_type = NEW.resource_type
+        AND resource.resource_id = NEW.resource_id
+        AND resource.owner_principal_id = NEW.granted_by_principal_id
+    )
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'authorization grantor must own the domain or resource');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_grants_immutable
+BEFORE UPDATE ON authorization_grants
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'authorization grants are immutable; revoke and recreate instead');
+END;
 
 CREATE TABLE IF NOT EXISTS device_pairing_pending (
   request_id TEXT NOT NULL PRIMARY KEY,

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -404,6 +404,7 @@ CREATE TABLE IF NOT EXISTS authorization_resources (
   parent_resource_type TEXT,
   parent_resource_id TEXT,
   retired_at INTEGER,
+  retired_by_principal_id TEXT,
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL,
   PRIMARY KEY (domain_id, namespace, resource_type, resource_id),
@@ -424,8 +425,14 @@ CREATE TABLE IF NOT EXISTS authorization_resources (
       )
     )
   ),
+  CHECK (
+    (retired_at IS NULL AND retired_by_principal_id IS NULL)
+    OR (retired_at IS NOT NULL AND retired_by_principal_id IS NOT NULL)
+  ),
   FOREIGN KEY (domain_id, owner_principal_id)
     REFERENCES authorization_domain_memberships(domain_id, principal_id),
+  FOREIGN KEY (retired_by_principal_id)
+    REFERENCES authorization_principals(principal_id),
   FOREIGN KEY (domain_id, parent_namespace, parent_resource_type, parent_resource_id)
     REFERENCES authorization_resources(domain_id, namespace, resource_type, resource_id)
 );
@@ -555,10 +562,36 @@ BEGIN
   SELECT RAISE(ABORT, 'authorization resource has an active child resource');
 END;
 
-CREATE TRIGGER IF NOT EXISTS authorization_resources_retirement_monotonic
-BEFORE UPDATE OF retired_at ON authorization_resources
+CREATE TRIGGER IF NOT EXISTS authorization_resources_retirement_insert_guard
+BEFORE INSERT ON authorization_resources
 FOR EACH ROW
-WHEN OLD.retired_at IS NOT NULL OR NEW.retired_at IS NULL
+WHEN
+  (NEW.retired_at IS NULL) <> (NEW.retired_by_principal_id IS NULL)
+  OR (
+    NEW.retired_by_principal_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1
+      FROM authorization_principals AS principal
+      WHERE principal.principal_id = NEW.retired_by_principal_id
+    )
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'retired authorization resources require a known retiring principal');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_resources_retirement_monotonic
+BEFORE UPDATE OF retired_at, retired_by_principal_id ON authorization_resources
+FOR EACH ROW
+WHEN
+  OLD.retired_at IS NOT NULL
+  OR OLD.retired_by_principal_id IS NOT NULL
+  OR NEW.retired_at IS NULL
+  OR NEW.retired_by_principal_id IS NULL
+  OR NOT EXISTS (
+    SELECT 1
+    FROM authorization_principals AS principal
+    WHERE principal.principal_id = NEW.retired_by_principal_id
+  )
 BEGIN
   SELECT RAISE(ABORT, 'retired authorization resources cannot be reactivated or retimestamped');
 END;
@@ -635,6 +668,440 @@ BEFORE UPDATE ON authorization_grants
 FOR EACH ROW
 BEGIN
   SELECT RAISE(ABORT, 'authorization grants are immutable; revoke and recreate instead');
+END;
+
+CREATE TABLE IF NOT EXISTS authorization_agent_sponsors (
+  domain_id TEXT NOT NULL,
+  agent_principal_id TEXT NOT NULL,
+  sponsor_principal_id TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (domain_id, agent_principal_id),
+  UNIQUE (domain_id, agent_principal_id, sponsor_principal_id),
+  FOREIGN KEY (domain_id) REFERENCES authorization_domains(domain_id),
+  FOREIGN KEY (agent_principal_id) REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (sponsor_principal_id) REFERENCES authorization_principals(principal_id)
+);
+
+CREATE TRIGGER IF NOT EXISTS authorization_agent_sponsors_insert_guard
+BEFORE INSERT ON authorization_agent_sponsors
+FOR EACH ROW
+WHEN
+  NOT EXISTS (
+    SELECT 1
+    FROM authorization_domain_memberships AS membership
+    INNER JOIN authorization_principals AS principal
+      ON principal.principal_id = membership.principal_id
+    WHERE membership.domain_id = NEW.domain_id
+      AND membership.principal_id = NEW.agent_principal_id
+      AND principal.kind = 'service'
+  )
+  OR NOT EXISTS (
+    SELECT 1
+    FROM authorization_domain_memberships AS membership
+    INNER JOIN authorization_principals AS principal
+      ON principal.principal_id = membership.principal_id
+    WHERE membership.domain_id = NEW.domain_id
+      AND membership.principal_id = NEW.sponsor_principal_id
+      AND membership.role = 'owner'
+      AND principal.kind = 'human'
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'authorization agent canonical sponsor must be the human domain owner');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_agent_sponsors_immutable
+BEFORE UPDATE ON authorization_agent_sponsors
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'authorization agent canonical sponsor is immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_agent_sponsors_delete_forbidden
+BEFORE DELETE ON authorization_agent_sponsors
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'authorization agent canonical sponsors cannot be deleted');
+END;
+
+CREATE TABLE IF NOT EXISTS authorization_delegations (
+  domain_id TEXT NOT NULL,
+  delegation_id TEXT NOT NULL,
+  assignment_id TEXT NOT NULL,
+  agent_principal_id TEXT NOT NULL,
+  sponsor_principal_id TEXT NOT NULL,
+  created_by_principal_id TEXT NOT NULL,
+  state TEXT NOT NULL CHECK (state IN ('active', 'revoked')),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  revoked_at INTEGER,
+  PRIMARY KEY (domain_id, delegation_id),
+  UNIQUE (domain_id, assignment_id),
+  UNIQUE (
+    domain_id,
+    delegation_id,
+    assignment_id,
+    agent_principal_id,
+    sponsor_principal_id
+  ),
+  CHECK (created_by_principal_id = sponsor_principal_id),
+  CHECK (
+    (state = 'active' AND revoked_at IS NULL)
+    OR (state = 'revoked' AND revoked_at IS NOT NULL)
+  ),
+  FOREIGN KEY (domain_id) REFERENCES authorization_domains(domain_id),
+  FOREIGN KEY (agent_principal_id) REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (sponsor_principal_id) REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (created_by_principal_id) REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (domain_id, agent_principal_id, sponsor_principal_id)
+    REFERENCES authorization_agent_sponsors(
+      domain_id,
+      agent_principal_id,
+      sponsor_principal_id
+    )
+);
+
+CREATE TRIGGER IF NOT EXISTS authorization_delegations_insert_guard
+BEFORE INSERT ON authorization_delegations
+FOR EACH ROW
+WHEN
+  NOT EXISTS (
+    SELECT 1
+    FROM authorization_domain_memberships AS membership
+    INNER JOIN authorization_principals AS principal
+      ON principal.principal_id = membership.principal_id
+    WHERE membership.domain_id = NEW.domain_id
+      AND membership.principal_id = NEW.agent_principal_id
+      AND principal.kind = 'service'
+  )
+  OR NOT EXISTS (
+    SELECT 1
+    FROM authorization_domain_memberships AS membership
+    INNER JOIN authorization_principals AS principal
+      ON principal.principal_id = membership.principal_id
+    WHERE membership.domain_id = NEW.domain_id
+      AND membership.principal_id = NEW.sponsor_principal_id
+      AND principal.kind = 'human'
+  )
+  OR NOT EXISTS (
+    SELECT 1
+    FROM authorization_agent_sponsors AS sponsor
+    WHERE sponsor.domain_id = NEW.domain_id
+      AND sponsor.agent_principal_id = NEW.agent_principal_id
+      AND sponsor.sponsor_principal_id = NEW.sponsor_principal_id
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'authorization delegation requires its canonical human sponsor and service agent in the domain');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_delegations_payload_immutable
+BEFORE UPDATE OF
+  domain_id,
+  delegation_id,
+  assignment_id,
+  agent_principal_id,
+  sponsor_principal_id,
+  created_by_principal_id,
+  created_at
+ON authorization_delegations
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'authorization delegation payload is immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_delegations_state_monotonic
+BEFORE UPDATE OF state, revoked_at ON authorization_delegations
+FOR EACH ROW
+WHEN NOT (
+  OLD.state = 'active'
+  AND OLD.revoked_at IS NULL
+  AND NEW.state = 'revoked'
+  AND NEW.revoked_at IS NOT NULL
+)
+BEGIN
+  SELECT RAISE(ABORT, 'authorization delegation revocation is monotonic');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_delegations_delete_forbidden
+BEFORE DELETE ON authorization_delegations
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'authorization delegations cannot be deleted');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_membership_delete_revokes_delegations
+BEFORE DELETE ON authorization_domain_memberships
+FOR EACH ROW
+WHEN EXISTS (
+  SELECT 1
+  FROM authorization_delegations AS delegation
+  WHERE delegation.domain_id = OLD.domain_id
+    AND delegation.state = 'active'
+    AND (
+      delegation.agent_principal_id = OLD.principal_id
+      OR delegation.sponsor_principal_id = OLD.principal_id
+    )
+)
+BEGIN
+  UPDATE authorization_delegations
+  SET
+    state = 'revoked',
+    revoked_at = CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER),
+    updated_at = CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)
+  WHERE domain_id = OLD.domain_id
+    AND state = 'active'
+    AND (
+      agent_principal_id = OLD.principal_id
+      OR sponsor_principal_id = OLD.principal_id
+    );
+END;
+
+CREATE TABLE IF NOT EXISTS authorization_resource_operations (
+  operation_id TEXT NOT NULL PRIMARY KEY,
+  operation_scope TEXT NOT NULL CHECK (length(trim(operation_scope)) > 0),
+  idempotency_key TEXT NOT NULL CHECK (length(trim(idempotency_key)) > 0),
+  operation_type TEXT NOT NULL CHECK (operation_type IN ('register', 'retire')),
+  domain_id TEXT NOT NULL,
+  namespace TEXT NOT NULL CHECK (length(trim(namespace)) > 0),
+  resource_type TEXT NOT NULL CHECK (length(trim(resource_type)) > 0),
+  resource_id TEXT NOT NULL CHECK (length(trim(resource_id)) > 0),
+  parent_namespace TEXT,
+  parent_resource_type TEXT,
+  parent_resource_id TEXT,
+  actor_principal_id TEXT NOT NULL,
+  owner_principal_id TEXT NOT NULL,
+  delegation_id TEXT,
+  assignment_id TEXT,
+  state TEXT NOT NULL CHECK (state IN ('pending', 'applied')),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  applied_at INTEGER,
+  UNIQUE (domain_id, operation_scope, idempotency_key),
+  CHECK (
+    (state = 'pending' AND applied_at IS NULL)
+    OR (state = 'applied' AND applied_at IS NOT NULL)
+  ),
+  CHECK (
+    (
+      parent_namespace IS NULL
+      AND parent_resource_type IS NULL
+      AND parent_resource_id IS NULL
+    )
+    OR (
+      parent_namespace IS NOT NULL
+      AND parent_resource_type IS NOT NULL
+      AND parent_resource_id IS NOT NULL
+    )
+  ),
+  CHECK (
+    (delegation_id IS NULL AND assignment_id IS NULL)
+    OR (delegation_id IS NOT NULL AND assignment_id IS NOT NULL)
+  ),
+  FOREIGN KEY (domain_id) REFERENCES authorization_domains(domain_id),
+  FOREIGN KEY (actor_principal_id) REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (owner_principal_id) REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (
+    domain_id,
+    delegation_id,
+    assignment_id,
+    actor_principal_id,
+    owner_principal_id
+  ) REFERENCES authorization_delegations(
+    domain_id,
+    delegation_id,
+    assignment_id,
+    agent_principal_id,
+    sponsor_principal_id
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_authorization_resource_operations_pending
+  ON authorization_resource_operations(state, domain_id, operation_scope, created_at);
+
+CREATE TRIGGER IF NOT EXISTS authorization_resource_operations_insert_guard
+BEFORE INSERT ON authorization_resource_operations
+FOR EACH ROW
+WHEN
+  NEW.state <> 'pending'
+  OR NEW.applied_at IS NOT NULL
+  OR (
+    NEW.operation_type = 'register'
+    AND NOT (
+      (
+        NEW.delegation_id IS NULL
+        AND NEW.assignment_id IS NULL
+        AND NEW.actor_principal_id = NEW.owner_principal_id
+        AND EXISTS (
+          SELECT 1
+          FROM authorization_domain_memberships AS membership
+          INNER JOIN authorization_principals AS principal
+            ON principal.principal_id = membership.principal_id
+          WHERE membership.domain_id = NEW.domain_id
+            AND membership.principal_id = NEW.actor_principal_id
+            AND principal.kind = 'human'
+        )
+      )
+      OR (
+        NEW.delegation_id IS NOT NULL
+        AND NEW.assignment_id IS NOT NULL
+        AND EXISTS (
+          SELECT 1
+          FROM authorization_delegations AS delegation
+          INNER JOIN authorization_domain_memberships AS agent_membership
+            ON agent_membership.domain_id = delegation.domain_id
+           AND agent_membership.principal_id = delegation.agent_principal_id
+          INNER JOIN authorization_domain_memberships AS sponsor_membership
+            ON sponsor_membership.domain_id = delegation.domain_id
+           AND sponsor_membership.principal_id = delegation.sponsor_principal_id
+          WHERE delegation.domain_id = NEW.domain_id
+            AND delegation.delegation_id = NEW.delegation_id
+            AND delegation.assignment_id = NEW.assignment_id
+            AND delegation.agent_principal_id = NEW.actor_principal_id
+            AND delegation.sponsor_principal_id = NEW.owner_principal_id
+            AND delegation.state = 'active'
+        )
+      )
+    )
+  )
+  OR (
+    NEW.operation_type = 'retire'
+    AND NOT (
+      NEW.delegation_id IS NULL
+      AND NEW.assignment_id IS NULL
+      AND EXISTS (
+        SELECT 1
+        FROM authorization_resources AS resource
+        INNER JOIN authorization_domain_memberships AS membership
+          ON membership.domain_id = resource.domain_id
+         AND membership.principal_id = NEW.actor_principal_id
+        INNER JOIN authorization_principals AS principal
+          ON principal.principal_id = membership.principal_id
+        WHERE resource.domain_id = NEW.domain_id
+          AND resource.namespace = NEW.namespace
+          AND resource.resource_type = NEW.resource_type
+          AND resource.resource_id = NEW.resource_id
+          AND resource.owner_principal_id = NEW.owner_principal_id
+          AND resource.retired_at IS NULL
+          AND principal.kind = 'human'
+          AND (
+            membership.role = 'owner'
+            OR resource.owner_principal_id = NEW.actor_principal_id
+          )
+      )
+    )
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'authorization operation must start pending and requires a human actor-owner or active delegation');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_resource_operations_payload_immutable
+BEFORE UPDATE OF
+  operation_id,
+  operation_scope,
+  idempotency_key,
+  operation_type,
+  domain_id,
+  namespace,
+  resource_type,
+  resource_id,
+  parent_namespace,
+  parent_resource_type,
+  parent_resource_id,
+  actor_principal_id,
+  owner_principal_id,
+  delegation_id,
+  assignment_id,
+  created_at
+ON authorization_resource_operations
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'authorization resource operation payload is immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_resource_operations_apply_guard
+BEFORE UPDATE OF state, applied_at ON authorization_resource_operations
+FOR EACH ROW
+WHEN NOT (
+  OLD.state = 'pending'
+  AND OLD.applied_at IS NULL
+  AND NEW.state = 'applied'
+  AND NEW.applied_at IS NOT NULL
+  AND (
+    (
+      OLD.operation_type = 'register'
+      AND EXISTS (
+        SELECT 1
+        FROM authorization_resources AS resource
+        WHERE resource.domain_id = OLD.domain_id
+          AND resource.namespace = OLD.namespace
+          AND resource.resource_type = OLD.resource_type
+          AND resource.resource_id = OLD.resource_id
+          AND resource.owner_principal_id = OLD.owner_principal_id
+          AND resource.retired_at IS NULL
+          AND resource.parent_namespace IS OLD.parent_namespace
+          AND resource.parent_resource_type IS OLD.parent_resource_type
+          AND resource.parent_resource_id IS OLD.parent_resource_id
+          AND (
+            (
+              OLD.delegation_id IS NULL
+              AND OLD.assignment_id IS NULL
+              AND OLD.actor_principal_id = OLD.owner_principal_id
+              AND EXISTS (
+                SELECT 1
+                FROM authorization_domain_memberships AS membership
+                INNER JOIN authorization_principals AS principal
+                  ON principal.principal_id = membership.principal_id
+                WHERE membership.domain_id = OLD.domain_id
+                  AND membership.principal_id = OLD.actor_principal_id
+                  AND principal.kind = 'human'
+              )
+            )
+            OR (
+              OLD.delegation_id IS NOT NULL
+              AND OLD.assignment_id IS NOT NULL
+              AND EXISTS (
+                SELECT 1
+                FROM authorization_delegations AS delegation
+                INNER JOIN authorization_domain_memberships AS agent_membership
+                  ON agent_membership.domain_id = delegation.domain_id
+                 AND agent_membership.principal_id = delegation.agent_principal_id
+                INNER JOIN authorization_domain_memberships AS sponsor_membership
+                  ON sponsor_membership.domain_id = delegation.domain_id
+                 AND sponsor_membership.principal_id = delegation.sponsor_principal_id
+                WHERE delegation.domain_id = OLD.domain_id
+                  AND delegation.delegation_id = OLD.delegation_id
+                  AND delegation.assignment_id = OLD.assignment_id
+                  AND delegation.agent_principal_id = OLD.actor_principal_id
+                  AND delegation.sponsor_principal_id = OLD.owner_principal_id
+                  AND delegation.state = 'active'
+              )
+            )
+          )
+      )
+    )
+    OR (
+      OLD.operation_type = 'retire'
+      AND EXISTS (
+        SELECT 1
+        FROM authorization_resources AS resource
+        WHERE resource.domain_id = OLD.domain_id
+          AND resource.namespace = OLD.namespace
+          AND resource.resource_type = OLD.resource_type
+          AND resource.resource_id = OLD.resource_id
+          AND resource.retired_at IS NOT NULL
+          AND resource.retired_by_principal_id = OLD.actor_principal_id
+      )
+    )
+  )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'authorization operation cannot be applied before resource state matches');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_resource_operations_delete_forbidden
+BEFORE DELETE ON authorization_resource_operations
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'authorization resource operations cannot be deleted');
 END;
 
 CREATE TABLE IF NOT EXISTS device_pairing_pending (

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -400,15 +400,169 @@ CREATE TABLE IF NOT EXISTS authorization_resources (
   resource_id TEXT NOT NULL CHECK (length(trim(resource_id)) > 0),
   domain_id TEXT NOT NULL,
   owner_principal_id TEXT NOT NULL,
+  parent_namespace TEXT,
+  parent_resource_type TEXT,
+  parent_resource_id TEXT,
+  retired_at INTEGER,
   created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
   PRIMARY KEY (namespace, resource_type, resource_id),
   UNIQUE (domain_id, namespace, resource_type, resource_id),
+  CHECK (
+    (
+      parent_namespace IS NULL
+      AND parent_resource_type IS NULL
+      AND parent_resource_id IS NULL
+    )
+    OR (
+      parent_namespace IS NOT NULL
+      AND parent_resource_type IS NOT NULL
+      AND parent_resource_id IS NOT NULL
+      AND NOT (
+        namespace = parent_namespace
+        AND resource_type = parent_resource_type
+        AND resource_id = parent_resource_id
+      )
+    )
+  ),
   FOREIGN KEY (domain_id, owner_principal_id)
-    REFERENCES authorization_domain_memberships(domain_id, principal_id)
+    REFERENCES authorization_domain_memberships(domain_id, principal_id),
+  FOREIGN KEY (domain_id, parent_namespace, parent_resource_type, parent_resource_id)
+    REFERENCES authorization_resources(domain_id, namespace, resource_type, resource_id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_authorization_resources_domain
   ON authorization_resources(domain_id, namespace, resource_type, resource_id);
+
+CREATE INDEX IF NOT EXISTS idx_authorization_resources_parent
+  ON authorization_resources(
+    domain_id,
+    parent_namespace,
+    parent_resource_type,
+    parent_resource_id,
+    retired_at
+  );
+
+CREATE INDEX IF NOT EXISTS idx_authorization_resources_active_list
+  ON authorization_resources(
+    domain_id,
+    namespace,
+    resource_type,
+    retired_at,
+    resource_id
+  );
+
+CREATE TRIGGER IF NOT EXISTS authorization_resources_insert_owner_guard
+BEFORE INSERT ON authorization_resources
+FOR EACH ROW
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM authorization_domain_memberships AS membership
+  INNER JOIN authorization_principals AS principal
+    ON principal.principal_id = membership.principal_id
+  WHERE membership.domain_id = NEW.domain_id
+    AND membership.principal_id = NEW.owner_principal_id
+    AND principal.kind = 'human'
+)
+BEGIN
+  SELECT RAISE(ABORT, 'authorization resource owner must be a human domain member');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_resources_update_owner_guard
+BEFORE UPDATE OF owner_principal_id ON authorization_resources
+FOR EACH ROW
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM authorization_domain_memberships AS membership
+  INNER JOIN authorization_principals AS principal
+    ON principal.principal_id = membership.principal_id
+  WHERE membership.domain_id = NEW.domain_id
+    AND membership.principal_id = NEW.owner_principal_id
+    AND principal.kind = 'human'
+)
+BEGIN
+  SELECT RAISE(ABORT, 'authorization resource owner must be a human domain member');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_resources_parent_guard
+BEFORE INSERT ON authorization_resources
+FOR EACH ROW
+WHEN
+  (
+    (NEW.parent_namespace IS NULL) <> (NEW.parent_resource_type IS NULL)
+    OR (NEW.parent_namespace IS NULL) <> (NEW.parent_resource_id IS NULL)
+  )
+  OR (
+    NEW.parent_namespace IS NOT NULL
+    AND (
+      (
+        NEW.namespace = NEW.parent_namespace
+        AND NEW.resource_type = NEW.parent_resource_type
+        AND NEW.resource_id = NEW.parent_resource_id
+      )
+      OR NOT EXISTS (
+        SELECT 1
+        FROM authorization_resources AS parent
+        WHERE parent.domain_id = NEW.domain_id
+          AND parent.namespace = NEW.parent_namespace
+          AND parent.resource_type = NEW.parent_resource_type
+          AND parent.resource_id = NEW.parent_resource_id
+          AND parent.retired_at IS NULL
+      )
+    )
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'authorization resource parent must be active in the same domain');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_resources_identity_immutable
+BEFORE UPDATE OF
+  namespace,
+  resource_type,
+  resource_id,
+  domain_id,
+  parent_namespace,
+  parent_resource_type,
+  parent_resource_id
+ON authorization_resources
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'authorization resource identity and parent are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_resources_delete_forbidden
+BEFORE DELETE ON authorization_resources
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'authorization resources cannot be deleted; retire them instead');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_resources_active_child_guard
+BEFORE UPDATE OF retired_at ON authorization_resources
+FOR EACH ROW
+WHEN
+  OLD.retired_at IS NULL
+  AND NEW.retired_at IS NOT NULL
+  AND EXISTS (
+    SELECT 1
+    FROM authorization_resources AS child
+    WHERE child.domain_id = OLD.domain_id
+      AND child.parent_namespace = OLD.namespace
+      AND child.parent_resource_type = OLD.resource_type
+      AND child.parent_resource_id = OLD.resource_id
+      AND child.retired_at IS NULL
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'authorization resource has an active child resource');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_resources_retirement_monotonic
+BEFORE UPDATE OF retired_at ON authorization_resources
+FOR EACH ROW
+WHEN OLD.retired_at IS NOT NULL OR NEW.retired_at IS NULL
+BEGIN
+  SELECT RAISE(ABORT, 'retired authorization resources cannot be reactivated or retimestamped');
+END;
 
 CREATE TABLE IF NOT EXISTS authorization_grants (
   domain_id TEXT NOT NULL,

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -406,8 +406,7 @@ CREATE TABLE IF NOT EXISTS authorization_resources (
   retired_at INTEGER,
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL,
-  PRIMARY KEY (namespace, resource_type, resource_id),
-  UNIQUE (domain_id, namespace, resource_type, resource_id),
+  PRIMARY KEY (domain_id, namespace, resource_type, resource_id),
   CHECK (
     (
       parent_namespace IS NULL

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -354,6 +354,98 @@ CREATE TABLE IF NOT EXISTS schema_meta (
   updated_at INTEGER NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS authorization_principals (
+  principal_id TEXT NOT NULL PRIMARY KEY CHECK (length(trim(principal_id)) > 0),
+  issuer TEXT NOT NULL CHECK (length(trim(issuer)) > 0),
+  subject TEXT NOT NULL CHECK (length(trim(subject)) > 0),
+  kind TEXT NOT NULL CHECK (kind IN ('human', 'device', 'service', 'shared')),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (issuer, subject, kind)
+);
+
+CREATE TABLE IF NOT EXISTS authorization_domains (
+  domain_id TEXT NOT NULL PRIMARY KEY CHECK (length(trim(domain_id)) > 0),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS authorization_domain_memberships (
+  domain_id TEXT NOT NULL,
+  principal_id TEXT NOT NULL,
+  role TEXT NOT NULL CHECK (role IN ('owner', 'member')),
+  added_by_principal_id TEXT NOT NULL,
+  added_by_role TEXT NOT NULL CHECK (added_by_role = 'owner'),
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (domain_id, principal_id),
+  UNIQUE (domain_id, principal_id, role),
+  FOREIGN KEY (domain_id) REFERENCES authorization_domains(domain_id),
+  FOREIGN KEY (principal_id) REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (added_by_principal_id) REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (domain_id, added_by_principal_id, added_by_role)
+    REFERENCES authorization_domain_memberships(domain_id, principal_id, role)
+    DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_authorization_domain_owner
+  ON authorization_domain_memberships(domain_id)
+  WHERE role = 'owner';
+
+CREATE INDEX IF NOT EXISTS idx_authorization_memberships_principal
+  ON authorization_domain_memberships(principal_id, domain_id);
+
+CREATE TABLE IF NOT EXISTS authorization_resources (
+  namespace TEXT NOT NULL CHECK (length(trim(namespace)) > 0),
+  resource_type TEXT NOT NULL CHECK (length(trim(resource_type)) > 0),
+  resource_id TEXT NOT NULL CHECK (length(trim(resource_id)) > 0),
+  domain_id TEXT NOT NULL,
+  owner_principal_id TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (namespace, resource_type, resource_id),
+  UNIQUE (domain_id, namespace, resource_type, resource_id),
+  FOREIGN KEY (domain_id, owner_principal_id)
+    REFERENCES authorization_domain_memberships(domain_id, principal_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_authorization_resources_domain
+  ON authorization_resources(domain_id, namespace, resource_type, resource_id);
+
+CREATE TABLE IF NOT EXISTS authorization_grants (
+  domain_id TEXT NOT NULL,
+  principal_id TEXT NOT NULL,
+  namespace TEXT NOT NULL,
+  resource_type TEXT NOT NULL,
+  resource_id TEXT NOT NULL,
+  permission TEXT NOT NULL CHECK (length(trim(permission)) > 0),
+  granted_by_principal_id TEXT NOT NULL,
+  granted_by_role TEXT NOT NULL CHECK (granted_by_role = 'owner'),
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (
+    domain_id,
+    principal_id,
+    namespace,
+    resource_type,
+    resource_id,
+    permission
+  ),
+  FOREIGN KEY (domain_id, principal_id)
+    REFERENCES authorization_domain_memberships(domain_id, principal_id),
+  FOREIGN KEY (domain_id, granted_by_principal_id, granted_by_role)
+    REFERENCES authorization_domain_memberships(domain_id, principal_id, role),
+  FOREIGN KEY (domain_id, namespace, resource_type, resource_id)
+    REFERENCES authorization_resources(domain_id, namespace, resource_type, resource_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_authorization_grants_lookup
+  ON authorization_grants(
+    principal_id,
+    permission,
+    namespace,
+    resource_type,
+    resource_id,
+    domain_id
+  );
+
 CREATE TABLE IF NOT EXISTS device_pairing_pending (
   request_id TEXT NOT NULL PRIMARY KEY,
   device_id TEXT NOT NULL,

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -670,6 +670,398 @@ BEGIN
   SELECT RAISE(ABORT, 'authorization grants are immutable; revoke and recreate instead');
 END;
 
+CREATE TABLE IF NOT EXISTS teams_local_accounts (
+  account_id TEXT NOT NULL PRIMARY KEY CHECK (length(trim(account_id)) > 0),
+  principal_id TEXT NOT NULL UNIQUE,
+  login_label TEXT NOT NULL COLLATE NOCASE UNIQUE
+    CHECK (
+      length(login_label) BETWEEN 1 AND 254
+      AND login_label = lower(trim(login_label))
+    ),
+  password_salt BLOB NOT NULL CHECK (length(password_salt) = 16),
+  password_verifier BLOB NOT NULL CHECK (length(password_verifier) = 32),
+  password_scrypt_n INTEGER NOT NULL CHECK (
+    password_scrypt_n BETWEEN 16384 AND 131072
+    AND (password_scrypt_n & (password_scrypt_n - 1)) = 0
+  ),
+  password_scrypt_r INTEGER NOT NULL CHECK (password_scrypt_r BETWEEN 8 AND 32),
+  password_scrypt_p INTEGER NOT NULL CHECK (password_scrypt_p BETWEEN 1 AND 4),
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (principal_id) REFERENCES authorization_principals(principal_id)
+);
+
+CREATE TRIGGER IF NOT EXISTS teams_local_accounts_human_guard
+BEFORE INSERT ON teams_local_accounts
+FOR EACH ROW
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM authorization_principals AS principal
+  WHERE principal.principal_id = NEW.principal_id
+    AND principal.kind = 'human'
+)
+BEGIN
+  SELECT RAISE(ABORT, 'Teams local account must map to a human principal');
+END;
+
+CREATE TRIGGER IF NOT EXISTS teams_local_accounts_immutable
+BEFORE UPDATE ON teams_local_accounts
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'Teams local accounts are immutable in v1');
+END;
+
+CREATE TRIGGER IF NOT EXISTS teams_local_accounts_delete_forbidden
+BEFORE DELETE ON teams_local_accounts
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'Teams local accounts cannot be deleted');
+END;
+
+CREATE TABLE IF NOT EXISTS teams_sessions (
+  session_id TEXT NOT NULL PRIMARY KEY CHECK (length(trim(session_id)) > 0),
+  token_digest TEXT NOT NULL UNIQUE CHECK (
+    length(token_digest) = 64
+    AND token_digest NOT GLOB '*[^0-9a-f]*'
+  ),
+  account_id TEXT NOT NULL,
+  principal_id TEXT NOT NULL,
+  domain_id TEXT NOT NULL,
+  state TEXT NOT NULL CHECK (state IN ('active', 'revoked')),
+  expires_at INTEGER NOT NULL,
+  revoked_at INTEGER,
+  revoked_by_principal_id TEXT,
+  created_at INTEGER NOT NULL,
+  CHECK (expires_at > created_at AND expires_at <= created_at + 2592000000),
+  CHECK (
+    (state = 'active' AND revoked_at IS NULL AND revoked_by_principal_id IS NULL)
+    OR
+    (state = 'revoked' AND revoked_at IS NOT NULL AND revoked_by_principal_id IS NOT NULL)
+  ),
+  FOREIGN KEY (account_id) REFERENCES teams_local_accounts(account_id),
+  FOREIGN KEY (principal_id) REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (revoked_by_principal_id)
+    REFERENCES authorization_principals(principal_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_teams_sessions_account
+  ON teams_sessions(account_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_teams_sessions_domain
+  ON teams_sessions(domain_id, state, expires_at);
+
+CREATE TRIGGER IF NOT EXISTS teams_sessions_insert_guard
+BEFORE INSERT ON teams_sessions
+FOR EACH ROW
+WHEN
+  NEW.state <> 'active'
+  OR NOT EXISTS (
+    SELECT 1
+    FROM teams_local_accounts AS account
+    INNER JOIN authorization_principals AS principal
+      ON principal.principal_id = account.principal_id
+    INNER JOIN authorization_domain_memberships AS membership
+      ON membership.principal_id = account.principal_id
+      AND membership.domain_id = NEW.domain_id
+    WHERE account.account_id = NEW.account_id
+      AND account.principal_id = NEW.principal_id
+      AND principal.kind = 'human'
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'Teams session requires an active human account domain member');
+END;
+
+CREATE TRIGGER IF NOT EXISTS teams_sessions_payload_immutable
+BEFORE UPDATE OF
+  session_id,
+  token_digest,
+  account_id,
+  principal_id,
+  domain_id,
+  expires_at,
+  created_at
+ON teams_sessions
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'Teams session identity and expiry are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS teams_sessions_state_monotonic
+BEFORE UPDATE OF state, revoked_at, revoked_by_principal_id ON teams_sessions
+FOR EACH ROW
+WHEN
+  OLD.state <> 'active'
+  OR NEW.state <> 'revoked'
+  OR NEW.revoked_at IS NULL
+  OR NEW.revoked_at < OLD.created_at
+  OR NEW.revoked_by_principal_id IS NULL
+  OR NOT EXISTS (
+    SELECT 1
+    FROM authorization_domain_memberships AS membership
+    INNER JOIN authorization_principals AS principal
+      ON principal.principal_id = membership.principal_id
+    WHERE membership.domain_id = OLD.domain_id
+      AND membership.principal_id = NEW.revoked_by_principal_id
+      AND principal.kind = 'human'
+      AND (
+        membership.principal_id = OLD.principal_id
+        OR membership.role = 'owner'
+      )
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'Teams session cannot be reactivated or retimestamped');
+END;
+
+CREATE TRIGGER IF NOT EXISTS teams_sessions_delete_forbidden
+BEFORE DELETE ON teams_sessions
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'Teams sessions cannot be deleted');
+END;
+
+CREATE TABLE IF NOT EXISTS teams_invites (
+  invite_id TEXT NOT NULL PRIMARY KEY CHECK (length(trim(invite_id)) > 0),
+  code_digest TEXT NOT NULL UNIQUE CHECK (
+    length(code_digest) = 64
+    AND code_digest NOT GLOB '*[^0-9a-f]*'
+  ),
+  domain_id TEXT NOT NULL,
+  created_by_principal_id TEXT NOT NULL,
+  recipient_label TEXT COLLATE NOCASE CHECK (
+    recipient_label IS NULL
+    OR (
+      length(recipient_label) BETWEEN 1 AND 254
+      AND recipient_label = lower(trim(recipient_label))
+    )
+  ),
+  state TEXT NOT NULL CHECK (state IN ('active', 'redeemed', 'revoked')),
+  expires_at INTEGER NOT NULL,
+  redeemed_at INTEGER,
+  redeemed_by_principal_id TEXT,
+  revoked_at INTEGER,
+  revoked_by_principal_id TEXT,
+  created_at INTEGER NOT NULL,
+  UNIQUE (invite_id, domain_id),
+  CHECK (
+    expires_at >= created_at + 60000
+    AND expires_at <= created_at + 604800000
+  ),
+  CHECK (
+    (
+      state = 'active'
+      AND redeemed_at IS NULL
+      AND redeemed_by_principal_id IS NULL
+      AND revoked_at IS NULL
+      AND revoked_by_principal_id IS NULL
+    )
+    OR (
+      state = 'redeemed'
+      AND redeemed_at IS NOT NULL
+      AND redeemed_by_principal_id IS NOT NULL
+      AND revoked_at IS NULL
+      AND revoked_by_principal_id IS NULL
+    )
+    OR (
+      state = 'revoked'
+      AND redeemed_at IS NULL
+      AND redeemed_by_principal_id IS NULL
+      AND revoked_at IS NOT NULL
+      AND revoked_by_principal_id IS NOT NULL
+    )
+  ),
+  FOREIGN KEY (domain_id) REFERENCES authorization_domains(domain_id),
+  FOREIGN KEY (created_by_principal_id)
+    REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (redeemed_by_principal_id)
+    REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (revoked_by_principal_id)
+    REFERENCES authorization_principals(principal_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_teams_invites_domain
+  ON teams_invites(domain_id, state, expires_at, created_at DESC);
+
+CREATE TRIGGER IF NOT EXISTS teams_invites_insert_guard
+BEFORE INSERT ON teams_invites
+FOR EACH ROW
+WHEN
+  NEW.state <> 'active'
+  OR NOT EXISTS (
+    SELECT 1
+    FROM authorization_domain_memberships AS membership
+    INNER JOIN authorization_principals AS principal
+      ON principal.principal_id = membership.principal_id
+    WHERE membership.domain_id = NEW.domain_id
+      AND membership.principal_id = NEW.created_by_principal_id
+      AND membership.role = 'owner'
+      AND principal.kind = 'human'
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'Teams invite creator must be the current human domain owner');
+END;
+
+CREATE TRIGGER IF NOT EXISTS teams_invites_payload_immutable
+BEFORE UPDATE OF
+  invite_id,
+  code_digest,
+  domain_id,
+  created_by_principal_id,
+  recipient_label,
+  expires_at,
+  created_at
+ON teams_invites
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'Teams invite payload is immutable');
+END;
+
+CREATE TABLE IF NOT EXISTS teams_invite_grants (
+  invite_id TEXT NOT NULL,
+  domain_id TEXT NOT NULL,
+  namespace TEXT NOT NULL CHECK (length(trim(namespace)) > 0),
+  resource_type TEXT NOT NULL CHECK (length(trim(resource_type)) > 0),
+  resource_id TEXT NOT NULL CHECK (length(trim(resource_id)) > 0),
+  permission TEXT NOT NULL CHECK (length(trim(permission)) > 0),
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (
+    invite_id,
+    namespace,
+    resource_type,
+    resource_id,
+    permission
+  ),
+  FOREIGN KEY (invite_id, domain_id)
+    REFERENCES teams_invites(invite_id, domain_id),
+  FOREIGN KEY (domain_id, namespace, resource_type, resource_id)
+    REFERENCES authorization_resources(domain_id, namespace, resource_type, resource_id)
+);
+
+CREATE TRIGGER IF NOT EXISTS teams_invite_grants_insert_guard
+BEFORE INSERT ON teams_invite_grants
+FOR EACH ROW
+WHEN
+  NOT EXISTS (
+    SELECT 1
+    FROM teams_invites AS invite
+    WHERE invite.invite_id = NEW.invite_id
+      AND invite.domain_id = NEW.domain_id
+      AND invite.state = 'active'
+  )
+  OR NOT EXISTS (
+    SELECT 1
+    FROM authorization_resources AS resource
+    WHERE resource.domain_id = NEW.domain_id
+      AND resource.namespace = NEW.namespace
+      AND resource.resource_type = NEW.resource_type
+      AND resource.resource_id = NEW.resource_id
+      AND resource.retired_at IS NULL
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'Teams invite grant requires an active invite and active resource');
+END;
+
+CREATE TRIGGER IF NOT EXISTS teams_invite_grants_immutable
+BEFORE UPDATE ON teams_invite_grants
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'Teams invite grants are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS teams_invite_grants_delete_forbidden
+BEFORE DELETE ON teams_invite_grants
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'Teams invite grants cannot be deleted');
+END;
+
+CREATE TRIGGER IF NOT EXISTS teams_invites_state_monotonic
+BEFORE UPDATE OF
+  state,
+  redeemed_at,
+  redeemed_by_principal_id,
+  revoked_at,
+  revoked_by_principal_id
+ON teams_invites
+FOR EACH ROW
+WHEN
+  OLD.state <> 'active'
+  OR (
+    NEW.state = 'redeemed'
+    AND (
+      NEW.redeemed_at IS NULL
+      OR NEW.redeemed_at < OLD.created_at
+      OR NEW.redeemed_at >= OLD.expires_at
+      OR NEW.redeemed_by_principal_id IS NULL
+      OR NOT EXISTS (
+        SELECT 1
+        FROM authorization_domain_memberships AS membership
+        INNER JOIN authorization_principals AS principal
+          ON principal.principal_id = membership.principal_id
+        WHERE membership.domain_id = OLD.domain_id
+          AND membership.principal_id = NEW.redeemed_by_principal_id
+          AND principal.kind = 'human'
+      )
+      OR NOT EXISTS (
+        SELECT 1 FROM teams_invite_grants AS manifest
+        WHERE manifest.invite_id = OLD.invite_id
+      )
+      OR EXISTS (
+        SELECT 1
+        FROM teams_invite_grants AS manifest
+        WHERE manifest.invite_id = OLD.invite_id
+          AND (
+            NOT EXISTS (
+              SELECT 1
+              FROM authorization_resources AS resource
+              WHERE resource.domain_id = OLD.domain_id
+                AND resource.namespace = manifest.namespace
+                AND resource.resource_type = manifest.resource_type
+                AND resource.resource_id = manifest.resource_id
+                AND resource.retired_at IS NULL
+            )
+            OR NOT EXISTS (
+              SELECT 1
+              FROM authorization_grants AS grant_row
+              WHERE grant_row.domain_id = OLD.domain_id
+                AND grant_row.principal_id = NEW.redeemed_by_principal_id
+                AND grant_row.namespace = manifest.namespace
+                AND grant_row.resource_type = manifest.resource_type
+                AND grant_row.resource_id = manifest.resource_id
+                AND grant_row.permission = manifest.permission
+            )
+          )
+      )
+    )
+  )
+  OR (
+    NEW.state = 'revoked'
+    AND (
+      NEW.revoked_at IS NULL
+      OR NEW.revoked_at < OLD.created_at
+      OR NEW.revoked_by_principal_id IS NULL
+      OR NOT EXISTS (
+        SELECT 1
+        FROM authorization_domain_memberships AS membership
+        INNER JOIN authorization_principals AS principal
+          ON principal.principal_id = membership.principal_id
+        WHERE membership.domain_id = OLD.domain_id
+          AND membership.principal_id = NEW.revoked_by_principal_id
+          AND membership.role = 'owner'
+          AND principal.kind = 'human'
+      )
+    )
+  )
+  OR NEW.state NOT IN ('redeemed', 'revoked')
+BEGIN
+  SELECT RAISE(ABORT, 'Teams invite terminal state is monotonic');
+END;
+
+CREATE TRIGGER IF NOT EXISTS teams_invites_delete_forbidden
+BEFORE DELETE ON teams_invites
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'Teams invites cannot be deleted');
+END;
+
 CREATE TABLE IF NOT EXISTS authorization_agent_sponsors (
   domain_id TEXT NOT NULL,
   agent_principal_id TEXT NOT NULL,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -413,7 +413,6 @@ CREATE TABLE IF NOT EXISTS authorization_grants (
   resource_id TEXT NOT NULL,
   permission TEXT NOT NULL CHECK (length(trim(permission)) > 0),
   granted_by_principal_id TEXT NOT NULL,
-  granted_by_role TEXT NOT NULL CHECK (granted_by_role = 'owner'),
   created_at INTEGER NOT NULL,
   PRIMARY KEY (
     domain_id,
@@ -425,8 +424,8 @@ CREATE TABLE IF NOT EXISTS authorization_grants (
   ),
   FOREIGN KEY (domain_id, principal_id)
     REFERENCES authorization_domain_memberships(domain_id, principal_id),
-  FOREIGN KEY (domain_id, granted_by_principal_id, granted_by_role)
-    REFERENCES authorization_domain_memberships(domain_id, principal_id, role),
+  FOREIGN KEY (domain_id, granted_by_principal_id)
+    REFERENCES authorization_domain_memberships(domain_id, principal_id),
   FOREIGN KEY (domain_id, namespace, resource_type, resource_id)
     REFERENCES authorization_resources(domain_id, namespace, resource_type, resource_id)
 );
@@ -440,6 +439,45 @@ CREATE INDEX IF NOT EXISTS idx_authorization_grants_lookup
     resource_id,
     domain_id
   );
+
+CREATE TRIGGER IF NOT EXISTS authorization_grants_owner_guard
+BEFORE INSERT ON authorization_grants
+FOR EACH ROW
+WHEN
+  NOT EXISTS (
+    SELECT 1
+    FROM authorization_principals AS principal
+    WHERE principal.principal_id = NEW.granted_by_principal_id
+      AND principal.kind = 'human'
+  )
+  OR (
+    NOT EXISTS (
+      SELECT 1
+      FROM authorization_domain_memberships AS membership
+      WHERE membership.domain_id = NEW.domain_id
+        AND membership.principal_id = NEW.granted_by_principal_id
+        AND membership.role = 'owner'
+    )
+    AND NOT EXISTS (
+      SELECT 1
+      FROM authorization_resources AS resource
+      WHERE resource.domain_id = NEW.domain_id
+        AND resource.namespace = NEW.namespace
+        AND resource.resource_type = NEW.resource_type
+        AND resource.resource_id = NEW.resource_id
+        AND resource.owner_principal_id = NEW.granted_by_principal_id
+    )
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'authorization grantor must own the domain or resource');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_grants_immutable
+BEFORE UPDATE ON authorization_grants
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'authorization grants are immutable; revoke and recreate instead');
+END;
 
 CREATE TABLE IF NOT EXISTS device_pairing_pending (
   request_id TEXT NOT NULL PRIMARY KEY,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -823,6 +823,159 @@ BEGIN
   SELECT RAISE(ABORT, 'authorization delegations cannot be deleted');
 END;
 
+CREATE TABLE IF NOT EXISTS authorization_agent_session_bindings (
+  domain_id TEXT NOT NULL,
+  binding_id TEXT NOT NULL,
+  runtime_agent_id TEXT NOT NULL CHECK (length(trim(runtime_agent_id)) > 0),
+  session_key TEXT NOT NULL CHECK (length(trim(session_key)) > 0),
+  delegation_id TEXT NOT NULL,
+  assignment_id TEXT NOT NULL,
+  agent_principal_id TEXT NOT NULL,
+  sponsor_principal_id TEXT NOT NULL,
+  created_by_principal_id TEXT NOT NULL,
+  state TEXT NOT NULL CHECK (state IN ('active', 'revoked')),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  revoked_at INTEGER,
+  PRIMARY KEY (domain_id, binding_id),
+  CHECK (created_by_principal_id = sponsor_principal_id),
+  CHECK (
+    (state = 'active' AND revoked_at IS NULL)
+    OR (state = 'revoked' AND revoked_at IS NOT NULL)
+  ),
+  FOREIGN KEY (domain_id) REFERENCES authorization_domains(domain_id),
+  FOREIGN KEY (agent_principal_id) REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (sponsor_principal_id) REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (created_by_principal_id) REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (
+    domain_id,
+    delegation_id,
+    assignment_id,
+    agent_principal_id,
+    sponsor_principal_id
+  ) REFERENCES authorization_delegations(
+    domain_id,
+    delegation_id,
+    assignment_id,
+    agent_principal_id,
+    sponsor_principal_id
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_authorization_agent_session_bindings_runtime
+  ON authorization_agent_session_bindings(runtime_agent_id, session_key, state);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_authorization_agent_session_bindings_active_runtime
+  ON authorization_agent_session_bindings(runtime_agent_id, session_key)
+  WHERE state = 'active';
+
+CREATE TRIGGER IF NOT EXISTS authorization_agent_session_bindings_insert_guard
+BEFORE INSERT ON authorization_agent_session_bindings
+FOR EACH ROW
+WHEN
+  NEW.state <> 'active'
+  OR NEW.revoked_at IS NOT NULL
+  OR NOT EXISTS (
+    SELECT 1
+    FROM authorization_delegations AS delegation
+    INNER JOIN authorization_domain_memberships AS sponsor_membership
+      ON sponsor_membership.domain_id = delegation.domain_id
+     AND sponsor_membership.principal_id = delegation.sponsor_principal_id
+    WHERE delegation.domain_id = NEW.domain_id
+      AND delegation.delegation_id = NEW.delegation_id
+      AND delegation.assignment_id = NEW.assignment_id
+      AND delegation.agent_principal_id = NEW.agent_principal_id
+      AND delegation.sponsor_principal_id = NEW.sponsor_principal_id
+      AND delegation.state = 'active'
+      AND sponsor_membership.role = 'owner'
+  )
+  OR NOT EXISTS (
+    SELECT 1
+    FROM authorization_resources AS resource
+    WHERE resource.domain_id = NEW.domain_id
+      AND resource.namespace = 'core'
+      AND resource.resource_type = 'agent-session'
+      AND resource.resource_id = NEW.assignment_id
+      AND resource.owner_principal_id = NEW.sponsor_principal_id
+      AND resource.retired_at IS NULL
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'authorization agent session binding requires an active canonical delegation and owned agent-session resource');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_agent_session_bindings_payload_immutable
+BEFORE UPDATE OF
+  domain_id,
+  binding_id,
+  runtime_agent_id,
+  session_key,
+  delegation_id,
+  assignment_id,
+  agent_principal_id,
+  sponsor_principal_id,
+  created_by_principal_id,
+  created_at
+ON authorization_agent_session_bindings
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'authorization agent session binding payload is immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_agent_session_bindings_state_monotonic
+BEFORE UPDATE OF state, revoked_at ON authorization_agent_session_bindings
+FOR EACH ROW
+WHEN NOT (
+  OLD.state = 'active'
+  AND OLD.revoked_at IS NULL
+  AND NEW.state = 'revoked'
+  AND NEW.revoked_at IS NOT NULL
+)
+BEGIN
+  SELECT RAISE(ABORT, 'authorization agent session binding revocation is monotonic');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_agent_session_bindings_delete_forbidden
+BEFORE DELETE ON authorization_agent_session_bindings
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'authorization agent session bindings cannot be deleted');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_agent_session_resource_owner_binding_guard
+BEFORE UPDATE OF owner_principal_id ON authorization_resources
+FOR EACH ROW
+WHEN
+  OLD.namespace = 'core'
+  AND OLD.resource_type = 'agent-session'
+  AND NEW.owner_principal_id <> OLD.owner_principal_id
+  AND EXISTS (
+    SELECT 1
+    FROM authorization_agent_session_bindings AS binding
+    WHERE binding.domain_id = OLD.domain_id
+      AND binding.assignment_id = OLD.resource_id
+      AND binding.state = 'active'
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'an active agent-session binding keeps its canonical sponsor owner; share access with grants');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_delegation_revoke_session_bindings
+AFTER UPDATE OF state, revoked_at ON authorization_delegations
+FOR EACH ROW
+WHEN
+  OLD.state = 'active'
+  AND NEW.state = 'revoked'
+BEGIN
+  UPDATE authorization_agent_session_bindings
+  SET
+    state = 'revoked',
+    revoked_at = NEW.revoked_at,
+    updated_at = NEW.updated_at
+  WHERE domain_id = NEW.domain_id
+    AND delegation_id = NEW.delegation_id
+    AND state = 'active';
+END;
+
 CREATE TRIGGER IF NOT EXISTS authorization_membership_delete_revokes_delegations
 BEFORE DELETE ON authorization_domain_memberships
 FOR EACH ROW

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -395,15 +395,169 @@ CREATE TABLE IF NOT EXISTS authorization_resources (
   resource_id TEXT NOT NULL CHECK (length(trim(resource_id)) > 0),
   domain_id TEXT NOT NULL,
   owner_principal_id TEXT NOT NULL,
+  parent_namespace TEXT,
+  parent_resource_type TEXT,
+  parent_resource_id TEXT,
+  retired_at INTEGER,
   created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
   PRIMARY KEY (namespace, resource_type, resource_id),
   UNIQUE (domain_id, namespace, resource_type, resource_id),
+  CHECK (
+    (
+      parent_namespace IS NULL
+      AND parent_resource_type IS NULL
+      AND parent_resource_id IS NULL
+    )
+    OR (
+      parent_namespace IS NOT NULL
+      AND parent_resource_type IS NOT NULL
+      AND parent_resource_id IS NOT NULL
+      AND NOT (
+        namespace = parent_namespace
+        AND resource_type = parent_resource_type
+        AND resource_id = parent_resource_id
+      )
+    )
+  ),
   FOREIGN KEY (domain_id, owner_principal_id)
-    REFERENCES authorization_domain_memberships(domain_id, principal_id)
+    REFERENCES authorization_domain_memberships(domain_id, principal_id),
+  FOREIGN KEY (domain_id, parent_namespace, parent_resource_type, parent_resource_id)
+    REFERENCES authorization_resources(domain_id, namespace, resource_type, resource_id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_authorization_resources_domain
   ON authorization_resources(domain_id, namespace, resource_type, resource_id);
+
+CREATE INDEX IF NOT EXISTS idx_authorization_resources_parent
+  ON authorization_resources(
+    domain_id,
+    parent_namespace,
+    parent_resource_type,
+    parent_resource_id,
+    retired_at
+  );
+
+CREATE INDEX IF NOT EXISTS idx_authorization_resources_active_list
+  ON authorization_resources(
+    domain_id,
+    namespace,
+    resource_type,
+    retired_at,
+    resource_id
+  );
+
+CREATE TRIGGER IF NOT EXISTS authorization_resources_insert_owner_guard
+BEFORE INSERT ON authorization_resources
+FOR EACH ROW
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM authorization_domain_memberships AS membership
+  INNER JOIN authorization_principals AS principal
+    ON principal.principal_id = membership.principal_id
+  WHERE membership.domain_id = NEW.domain_id
+    AND membership.principal_id = NEW.owner_principal_id
+    AND principal.kind = 'human'
+)
+BEGIN
+  SELECT RAISE(ABORT, 'authorization resource owner must be a human domain member');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_resources_update_owner_guard
+BEFORE UPDATE OF owner_principal_id ON authorization_resources
+FOR EACH ROW
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM authorization_domain_memberships AS membership
+  INNER JOIN authorization_principals AS principal
+    ON principal.principal_id = membership.principal_id
+  WHERE membership.domain_id = NEW.domain_id
+    AND membership.principal_id = NEW.owner_principal_id
+    AND principal.kind = 'human'
+)
+BEGIN
+  SELECT RAISE(ABORT, 'authorization resource owner must be a human domain member');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_resources_parent_guard
+BEFORE INSERT ON authorization_resources
+FOR EACH ROW
+WHEN
+  (
+    (NEW.parent_namespace IS NULL) <> (NEW.parent_resource_type IS NULL)
+    OR (NEW.parent_namespace IS NULL) <> (NEW.parent_resource_id IS NULL)
+  )
+  OR (
+    NEW.parent_namespace IS NOT NULL
+    AND (
+      (
+        NEW.namespace = NEW.parent_namespace
+        AND NEW.resource_type = NEW.parent_resource_type
+        AND NEW.resource_id = NEW.parent_resource_id
+      )
+      OR NOT EXISTS (
+        SELECT 1
+        FROM authorization_resources AS parent
+        WHERE parent.domain_id = NEW.domain_id
+          AND parent.namespace = NEW.parent_namespace
+          AND parent.resource_type = NEW.parent_resource_type
+          AND parent.resource_id = NEW.parent_resource_id
+          AND parent.retired_at IS NULL
+      )
+    )
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'authorization resource parent must be active in the same domain');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_resources_identity_immutable
+BEFORE UPDATE OF
+  namespace,
+  resource_type,
+  resource_id,
+  domain_id,
+  parent_namespace,
+  parent_resource_type,
+  parent_resource_id
+ON authorization_resources
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'authorization resource identity and parent are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_resources_delete_forbidden
+BEFORE DELETE ON authorization_resources
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'authorization resources cannot be deleted; retire them instead');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_resources_active_child_guard
+BEFORE UPDATE OF retired_at ON authorization_resources
+FOR EACH ROW
+WHEN
+  OLD.retired_at IS NULL
+  AND NEW.retired_at IS NOT NULL
+  AND EXISTS (
+    SELECT 1
+    FROM authorization_resources AS child
+    WHERE child.domain_id = OLD.domain_id
+      AND child.parent_namespace = OLD.namespace
+      AND child.parent_resource_type = OLD.resource_type
+      AND child.parent_resource_id = OLD.resource_id
+      AND child.retired_at IS NULL
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'authorization resource has an active child resource');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_resources_retirement_monotonic
+BEFORE UPDATE OF retired_at ON authorization_resources
+FOR EACH ROW
+WHEN OLD.retired_at IS NOT NULL OR NEW.retired_at IS NULL
+BEGIN
+  SELECT RAISE(ABORT, 'retired authorization resources cannot be reactivated or retimestamped');
+END;
 
 CREATE TABLE IF NOT EXISTS authorization_grants (
   domain_id TEXT NOT NULL,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -401,8 +401,7 @@ CREATE TABLE IF NOT EXISTS authorization_resources (
   retired_at INTEGER,
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL,
-  PRIMARY KEY (namespace, resource_type, resource_id),
-  UNIQUE (domain_id, namespace, resource_type, resource_id),
+  PRIMARY KEY (domain_id, namespace, resource_type, resource_id),
   CHECK (
     (
       parent_namespace IS NULL

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -399,6 +399,7 @@ CREATE TABLE IF NOT EXISTS authorization_resources (
   parent_resource_type TEXT,
   parent_resource_id TEXT,
   retired_at INTEGER,
+  retired_by_principal_id TEXT,
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL,
   PRIMARY KEY (domain_id, namespace, resource_type, resource_id),
@@ -419,8 +420,14 @@ CREATE TABLE IF NOT EXISTS authorization_resources (
       )
     )
   ),
+  CHECK (
+    (retired_at IS NULL AND retired_by_principal_id IS NULL)
+    OR (retired_at IS NOT NULL AND retired_by_principal_id IS NOT NULL)
+  ),
   FOREIGN KEY (domain_id, owner_principal_id)
     REFERENCES authorization_domain_memberships(domain_id, principal_id),
+  FOREIGN KEY (retired_by_principal_id)
+    REFERENCES authorization_principals(principal_id),
   FOREIGN KEY (domain_id, parent_namespace, parent_resource_type, parent_resource_id)
     REFERENCES authorization_resources(domain_id, namespace, resource_type, resource_id)
 );
@@ -550,10 +557,36 @@ BEGIN
   SELECT RAISE(ABORT, 'authorization resource has an active child resource');
 END;
 
-CREATE TRIGGER IF NOT EXISTS authorization_resources_retirement_monotonic
-BEFORE UPDATE OF retired_at ON authorization_resources
+CREATE TRIGGER IF NOT EXISTS authorization_resources_retirement_insert_guard
+BEFORE INSERT ON authorization_resources
 FOR EACH ROW
-WHEN OLD.retired_at IS NOT NULL OR NEW.retired_at IS NULL
+WHEN
+  (NEW.retired_at IS NULL) <> (NEW.retired_by_principal_id IS NULL)
+  OR (
+    NEW.retired_by_principal_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1
+      FROM authorization_principals AS principal
+      WHERE principal.principal_id = NEW.retired_by_principal_id
+    )
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'retired authorization resources require a known retiring principal');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_resources_retirement_monotonic
+BEFORE UPDATE OF retired_at, retired_by_principal_id ON authorization_resources
+FOR EACH ROW
+WHEN
+  OLD.retired_at IS NOT NULL
+  OR OLD.retired_by_principal_id IS NOT NULL
+  OR NEW.retired_at IS NULL
+  OR NEW.retired_by_principal_id IS NULL
+  OR NOT EXISTS (
+    SELECT 1
+    FROM authorization_principals AS principal
+    WHERE principal.principal_id = NEW.retired_by_principal_id
+  )
 BEGIN
   SELECT RAISE(ABORT, 'retired authorization resources cannot be reactivated or retimestamped');
 END;
@@ -630,6 +663,440 @@ BEFORE UPDATE ON authorization_grants
 FOR EACH ROW
 BEGIN
   SELECT RAISE(ABORT, 'authorization grants are immutable; revoke and recreate instead');
+END;
+
+CREATE TABLE IF NOT EXISTS authorization_agent_sponsors (
+  domain_id TEXT NOT NULL,
+  agent_principal_id TEXT NOT NULL,
+  sponsor_principal_id TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (domain_id, agent_principal_id),
+  UNIQUE (domain_id, agent_principal_id, sponsor_principal_id),
+  FOREIGN KEY (domain_id) REFERENCES authorization_domains(domain_id),
+  FOREIGN KEY (agent_principal_id) REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (sponsor_principal_id) REFERENCES authorization_principals(principal_id)
+);
+
+CREATE TRIGGER IF NOT EXISTS authorization_agent_sponsors_insert_guard
+BEFORE INSERT ON authorization_agent_sponsors
+FOR EACH ROW
+WHEN
+  NOT EXISTS (
+    SELECT 1
+    FROM authorization_domain_memberships AS membership
+    INNER JOIN authorization_principals AS principal
+      ON principal.principal_id = membership.principal_id
+    WHERE membership.domain_id = NEW.domain_id
+      AND membership.principal_id = NEW.agent_principal_id
+      AND principal.kind = 'service'
+  )
+  OR NOT EXISTS (
+    SELECT 1
+    FROM authorization_domain_memberships AS membership
+    INNER JOIN authorization_principals AS principal
+      ON principal.principal_id = membership.principal_id
+    WHERE membership.domain_id = NEW.domain_id
+      AND membership.principal_id = NEW.sponsor_principal_id
+      AND membership.role = 'owner'
+      AND principal.kind = 'human'
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'authorization agent canonical sponsor must be the human domain owner');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_agent_sponsors_immutable
+BEFORE UPDATE ON authorization_agent_sponsors
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'authorization agent canonical sponsor is immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_agent_sponsors_delete_forbidden
+BEFORE DELETE ON authorization_agent_sponsors
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'authorization agent canonical sponsors cannot be deleted');
+END;
+
+CREATE TABLE IF NOT EXISTS authorization_delegations (
+  domain_id TEXT NOT NULL,
+  delegation_id TEXT NOT NULL,
+  assignment_id TEXT NOT NULL,
+  agent_principal_id TEXT NOT NULL,
+  sponsor_principal_id TEXT NOT NULL,
+  created_by_principal_id TEXT NOT NULL,
+  state TEXT NOT NULL CHECK (state IN ('active', 'revoked')),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  revoked_at INTEGER,
+  PRIMARY KEY (domain_id, delegation_id),
+  UNIQUE (domain_id, assignment_id),
+  UNIQUE (
+    domain_id,
+    delegation_id,
+    assignment_id,
+    agent_principal_id,
+    sponsor_principal_id
+  ),
+  CHECK (created_by_principal_id = sponsor_principal_id),
+  CHECK (
+    (state = 'active' AND revoked_at IS NULL)
+    OR (state = 'revoked' AND revoked_at IS NOT NULL)
+  ),
+  FOREIGN KEY (domain_id) REFERENCES authorization_domains(domain_id),
+  FOREIGN KEY (agent_principal_id) REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (sponsor_principal_id) REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (created_by_principal_id) REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (domain_id, agent_principal_id, sponsor_principal_id)
+    REFERENCES authorization_agent_sponsors(
+      domain_id,
+      agent_principal_id,
+      sponsor_principal_id
+    )
+);
+
+CREATE TRIGGER IF NOT EXISTS authorization_delegations_insert_guard
+BEFORE INSERT ON authorization_delegations
+FOR EACH ROW
+WHEN
+  NOT EXISTS (
+    SELECT 1
+    FROM authorization_domain_memberships AS membership
+    INNER JOIN authorization_principals AS principal
+      ON principal.principal_id = membership.principal_id
+    WHERE membership.domain_id = NEW.domain_id
+      AND membership.principal_id = NEW.agent_principal_id
+      AND principal.kind = 'service'
+  )
+  OR NOT EXISTS (
+    SELECT 1
+    FROM authorization_domain_memberships AS membership
+    INNER JOIN authorization_principals AS principal
+      ON principal.principal_id = membership.principal_id
+    WHERE membership.domain_id = NEW.domain_id
+      AND membership.principal_id = NEW.sponsor_principal_id
+      AND principal.kind = 'human'
+  )
+  OR NOT EXISTS (
+    SELECT 1
+    FROM authorization_agent_sponsors AS sponsor
+    WHERE sponsor.domain_id = NEW.domain_id
+      AND sponsor.agent_principal_id = NEW.agent_principal_id
+      AND sponsor.sponsor_principal_id = NEW.sponsor_principal_id
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'authorization delegation requires its canonical human sponsor and service agent in the domain');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_delegations_payload_immutable
+BEFORE UPDATE OF
+  domain_id,
+  delegation_id,
+  assignment_id,
+  agent_principal_id,
+  sponsor_principal_id,
+  created_by_principal_id,
+  created_at
+ON authorization_delegations
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'authorization delegation payload is immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_delegations_state_monotonic
+BEFORE UPDATE OF state, revoked_at ON authorization_delegations
+FOR EACH ROW
+WHEN NOT (
+  OLD.state = 'active'
+  AND OLD.revoked_at IS NULL
+  AND NEW.state = 'revoked'
+  AND NEW.revoked_at IS NOT NULL
+)
+BEGIN
+  SELECT RAISE(ABORT, 'authorization delegation revocation is monotonic');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_delegations_delete_forbidden
+BEFORE DELETE ON authorization_delegations
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'authorization delegations cannot be deleted');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_membership_delete_revokes_delegations
+BEFORE DELETE ON authorization_domain_memberships
+FOR EACH ROW
+WHEN EXISTS (
+  SELECT 1
+  FROM authorization_delegations AS delegation
+  WHERE delegation.domain_id = OLD.domain_id
+    AND delegation.state = 'active'
+    AND (
+      delegation.agent_principal_id = OLD.principal_id
+      OR delegation.sponsor_principal_id = OLD.principal_id
+    )
+)
+BEGIN
+  UPDATE authorization_delegations
+  SET
+    state = 'revoked',
+    revoked_at = CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER),
+    updated_at = CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)
+  WHERE domain_id = OLD.domain_id
+    AND state = 'active'
+    AND (
+      agent_principal_id = OLD.principal_id
+      OR sponsor_principal_id = OLD.principal_id
+    );
+END;
+
+CREATE TABLE IF NOT EXISTS authorization_resource_operations (
+  operation_id TEXT NOT NULL PRIMARY KEY,
+  operation_scope TEXT NOT NULL CHECK (length(trim(operation_scope)) > 0),
+  idempotency_key TEXT NOT NULL CHECK (length(trim(idempotency_key)) > 0),
+  operation_type TEXT NOT NULL CHECK (operation_type IN ('register', 'retire')),
+  domain_id TEXT NOT NULL,
+  namespace TEXT NOT NULL CHECK (length(trim(namespace)) > 0),
+  resource_type TEXT NOT NULL CHECK (length(trim(resource_type)) > 0),
+  resource_id TEXT NOT NULL CHECK (length(trim(resource_id)) > 0),
+  parent_namespace TEXT,
+  parent_resource_type TEXT,
+  parent_resource_id TEXT,
+  actor_principal_id TEXT NOT NULL,
+  owner_principal_id TEXT NOT NULL,
+  delegation_id TEXT,
+  assignment_id TEXT,
+  state TEXT NOT NULL CHECK (state IN ('pending', 'applied')),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  applied_at INTEGER,
+  UNIQUE (domain_id, operation_scope, idempotency_key),
+  CHECK (
+    (state = 'pending' AND applied_at IS NULL)
+    OR (state = 'applied' AND applied_at IS NOT NULL)
+  ),
+  CHECK (
+    (
+      parent_namespace IS NULL
+      AND parent_resource_type IS NULL
+      AND parent_resource_id IS NULL
+    )
+    OR (
+      parent_namespace IS NOT NULL
+      AND parent_resource_type IS NOT NULL
+      AND parent_resource_id IS NOT NULL
+    )
+  ),
+  CHECK (
+    (delegation_id IS NULL AND assignment_id IS NULL)
+    OR (delegation_id IS NOT NULL AND assignment_id IS NOT NULL)
+  ),
+  FOREIGN KEY (domain_id) REFERENCES authorization_domains(domain_id),
+  FOREIGN KEY (actor_principal_id) REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (owner_principal_id) REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (
+    domain_id,
+    delegation_id,
+    assignment_id,
+    actor_principal_id,
+    owner_principal_id
+  ) REFERENCES authorization_delegations(
+    domain_id,
+    delegation_id,
+    assignment_id,
+    agent_principal_id,
+    sponsor_principal_id
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_authorization_resource_operations_pending
+  ON authorization_resource_operations(state, domain_id, operation_scope, created_at);
+
+CREATE TRIGGER IF NOT EXISTS authorization_resource_operations_insert_guard
+BEFORE INSERT ON authorization_resource_operations
+FOR EACH ROW
+WHEN
+  NEW.state <> 'pending'
+  OR NEW.applied_at IS NOT NULL
+  OR (
+    NEW.operation_type = 'register'
+    AND NOT (
+      (
+        NEW.delegation_id IS NULL
+        AND NEW.assignment_id IS NULL
+        AND NEW.actor_principal_id = NEW.owner_principal_id
+        AND EXISTS (
+          SELECT 1
+          FROM authorization_domain_memberships AS membership
+          INNER JOIN authorization_principals AS principal
+            ON principal.principal_id = membership.principal_id
+          WHERE membership.domain_id = NEW.domain_id
+            AND membership.principal_id = NEW.actor_principal_id
+            AND principal.kind = 'human'
+        )
+      )
+      OR (
+        NEW.delegation_id IS NOT NULL
+        AND NEW.assignment_id IS NOT NULL
+        AND EXISTS (
+          SELECT 1
+          FROM authorization_delegations AS delegation
+          INNER JOIN authorization_domain_memberships AS agent_membership
+            ON agent_membership.domain_id = delegation.domain_id
+           AND agent_membership.principal_id = delegation.agent_principal_id
+          INNER JOIN authorization_domain_memberships AS sponsor_membership
+            ON sponsor_membership.domain_id = delegation.domain_id
+           AND sponsor_membership.principal_id = delegation.sponsor_principal_id
+          WHERE delegation.domain_id = NEW.domain_id
+            AND delegation.delegation_id = NEW.delegation_id
+            AND delegation.assignment_id = NEW.assignment_id
+            AND delegation.agent_principal_id = NEW.actor_principal_id
+            AND delegation.sponsor_principal_id = NEW.owner_principal_id
+            AND delegation.state = 'active'
+        )
+      )
+    )
+  )
+  OR (
+    NEW.operation_type = 'retire'
+    AND NOT (
+      NEW.delegation_id IS NULL
+      AND NEW.assignment_id IS NULL
+      AND EXISTS (
+        SELECT 1
+        FROM authorization_resources AS resource
+        INNER JOIN authorization_domain_memberships AS membership
+          ON membership.domain_id = resource.domain_id
+         AND membership.principal_id = NEW.actor_principal_id
+        INNER JOIN authorization_principals AS principal
+          ON principal.principal_id = membership.principal_id
+        WHERE resource.domain_id = NEW.domain_id
+          AND resource.namespace = NEW.namespace
+          AND resource.resource_type = NEW.resource_type
+          AND resource.resource_id = NEW.resource_id
+          AND resource.owner_principal_id = NEW.owner_principal_id
+          AND resource.retired_at IS NULL
+          AND principal.kind = 'human'
+          AND (
+            membership.role = 'owner'
+            OR resource.owner_principal_id = NEW.actor_principal_id
+          )
+      )
+    )
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'authorization operation must start pending and requires a human actor-owner or active delegation');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_resource_operations_payload_immutable
+BEFORE UPDATE OF
+  operation_id,
+  operation_scope,
+  idempotency_key,
+  operation_type,
+  domain_id,
+  namespace,
+  resource_type,
+  resource_id,
+  parent_namespace,
+  parent_resource_type,
+  parent_resource_id,
+  actor_principal_id,
+  owner_principal_id,
+  delegation_id,
+  assignment_id,
+  created_at
+ON authorization_resource_operations
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'authorization resource operation payload is immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_resource_operations_apply_guard
+BEFORE UPDATE OF state, applied_at ON authorization_resource_operations
+FOR EACH ROW
+WHEN NOT (
+  OLD.state = 'pending'
+  AND OLD.applied_at IS NULL
+  AND NEW.state = 'applied'
+  AND NEW.applied_at IS NOT NULL
+  AND (
+    (
+      OLD.operation_type = 'register'
+      AND EXISTS (
+        SELECT 1
+        FROM authorization_resources AS resource
+        WHERE resource.domain_id = OLD.domain_id
+          AND resource.namespace = OLD.namespace
+          AND resource.resource_type = OLD.resource_type
+          AND resource.resource_id = OLD.resource_id
+          AND resource.owner_principal_id = OLD.owner_principal_id
+          AND resource.retired_at IS NULL
+          AND resource.parent_namespace IS OLD.parent_namespace
+          AND resource.parent_resource_type IS OLD.parent_resource_type
+          AND resource.parent_resource_id IS OLD.parent_resource_id
+          AND (
+            (
+              OLD.delegation_id IS NULL
+              AND OLD.assignment_id IS NULL
+              AND OLD.actor_principal_id = OLD.owner_principal_id
+              AND EXISTS (
+                SELECT 1
+                FROM authorization_domain_memberships AS membership
+                INNER JOIN authorization_principals AS principal
+                  ON principal.principal_id = membership.principal_id
+                WHERE membership.domain_id = OLD.domain_id
+                  AND membership.principal_id = OLD.actor_principal_id
+                  AND principal.kind = 'human'
+              )
+            )
+            OR (
+              OLD.delegation_id IS NOT NULL
+              AND OLD.assignment_id IS NOT NULL
+              AND EXISTS (
+                SELECT 1
+                FROM authorization_delegations AS delegation
+                INNER JOIN authorization_domain_memberships AS agent_membership
+                  ON agent_membership.domain_id = delegation.domain_id
+                 AND agent_membership.principal_id = delegation.agent_principal_id
+                INNER JOIN authorization_domain_memberships AS sponsor_membership
+                  ON sponsor_membership.domain_id = delegation.domain_id
+                 AND sponsor_membership.principal_id = delegation.sponsor_principal_id
+                WHERE delegation.domain_id = OLD.domain_id
+                  AND delegation.delegation_id = OLD.delegation_id
+                  AND delegation.assignment_id = OLD.assignment_id
+                  AND delegation.agent_principal_id = OLD.actor_principal_id
+                  AND delegation.sponsor_principal_id = OLD.owner_principal_id
+                  AND delegation.state = 'active'
+              )
+            )
+          )
+      )
+    )
+    OR (
+      OLD.operation_type = 'retire'
+      AND EXISTS (
+        SELECT 1
+        FROM authorization_resources AS resource
+        WHERE resource.domain_id = OLD.domain_id
+          AND resource.namespace = OLD.namespace
+          AND resource.resource_type = OLD.resource_type
+          AND resource.resource_id = OLD.resource_id
+          AND resource.retired_at IS NOT NULL
+          AND resource.retired_by_principal_id = OLD.actor_principal_id
+      )
+    )
+  )
+)
+BEGIN
+  SELECT RAISE(ABORT, 'authorization operation cannot be applied before resource state matches');
+END;
+
+CREATE TRIGGER IF NOT EXISTS authorization_resource_operations_delete_forbidden
+BEFORE DELETE ON authorization_resource_operations
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'authorization resource operations cannot be deleted');
 END;
 
 CREATE TABLE IF NOT EXISTS device_pairing_pending (

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -349,6 +349,98 @@ CREATE TABLE IF NOT EXISTS schema_meta (
   updated_at INTEGER NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS authorization_principals (
+  principal_id TEXT NOT NULL PRIMARY KEY CHECK (length(trim(principal_id)) > 0),
+  issuer TEXT NOT NULL CHECK (length(trim(issuer)) > 0),
+  subject TEXT NOT NULL CHECK (length(trim(subject)) > 0),
+  kind TEXT NOT NULL CHECK (kind IN ('human', 'device', 'service', 'shared')),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (issuer, subject, kind)
+);
+
+CREATE TABLE IF NOT EXISTS authorization_domains (
+  domain_id TEXT NOT NULL PRIMARY KEY CHECK (length(trim(domain_id)) > 0),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS authorization_domain_memberships (
+  domain_id TEXT NOT NULL,
+  principal_id TEXT NOT NULL,
+  role TEXT NOT NULL CHECK (role IN ('owner', 'member')),
+  added_by_principal_id TEXT NOT NULL,
+  added_by_role TEXT NOT NULL CHECK (added_by_role = 'owner'),
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (domain_id, principal_id),
+  UNIQUE (domain_id, principal_id, role),
+  FOREIGN KEY (domain_id) REFERENCES authorization_domains(domain_id),
+  FOREIGN KEY (principal_id) REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (added_by_principal_id) REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (domain_id, added_by_principal_id, added_by_role)
+    REFERENCES authorization_domain_memberships(domain_id, principal_id, role)
+    DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_authorization_domain_owner
+  ON authorization_domain_memberships(domain_id)
+  WHERE role = 'owner';
+
+CREATE INDEX IF NOT EXISTS idx_authorization_memberships_principal
+  ON authorization_domain_memberships(principal_id, domain_id);
+
+CREATE TABLE IF NOT EXISTS authorization_resources (
+  namespace TEXT NOT NULL CHECK (length(trim(namespace)) > 0),
+  resource_type TEXT NOT NULL CHECK (length(trim(resource_type)) > 0),
+  resource_id TEXT NOT NULL CHECK (length(trim(resource_id)) > 0),
+  domain_id TEXT NOT NULL,
+  owner_principal_id TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (namespace, resource_type, resource_id),
+  UNIQUE (domain_id, namespace, resource_type, resource_id),
+  FOREIGN KEY (domain_id, owner_principal_id)
+    REFERENCES authorization_domain_memberships(domain_id, principal_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_authorization_resources_domain
+  ON authorization_resources(domain_id, namespace, resource_type, resource_id);
+
+CREATE TABLE IF NOT EXISTS authorization_grants (
+  domain_id TEXT NOT NULL,
+  principal_id TEXT NOT NULL,
+  namespace TEXT NOT NULL,
+  resource_type TEXT NOT NULL,
+  resource_id TEXT NOT NULL,
+  permission TEXT NOT NULL CHECK (length(trim(permission)) > 0),
+  granted_by_principal_id TEXT NOT NULL,
+  granted_by_role TEXT NOT NULL CHECK (granted_by_role = 'owner'),
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (
+    domain_id,
+    principal_id,
+    namespace,
+    resource_type,
+    resource_id,
+    permission
+  ),
+  FOREIGN KEY (domain_id, principal_id)
+    REFERENCES authorization_domain_memberships(domain_id, principal_id),
+  FOREIGN KEY (domain_id, granted_by_principal_id, granted_by_role)
+    REFERENCES authorization_domain_memberships(domain_id, principal_id, role),
+  FOREIGN KEY (domain_id, namespace, resource_type, resource_id)
+    REFERENCES authorization_resources(domain_id, namespace, resource_type, resource_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_authorization_grants_lookup
+  ON authorization_grants(
+    principal_id,
+    permission,
+    namespace,
+    resource_type,
+    resource_id,
+    domain_id
+  );
+
 CREATE TABLE IF NOT EXISTS device_pairing_pending (
   request_id TEXT NOT NULL PRIMARY KEY,
   device_id TEXT NOT NULL,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -665,6 +665,398 @@ BEGIN
   SELECT RAISE(ABORT, 'authorization grants are immutable; revoke and recreate instead');
 END;
 
+CREATE TABLE IF NOT EXISTS teams_local_accounts (
+  account_id TEXT NOT NULL PRIMARY KEY CHECK (length(trim(account_id)) > 0),
+  principal_id TEXT NOT NULL UNIQUE,
+  login_label TEXT NOT NULL COLLATE NOCASE UNIQUE
+    CHECK (
+      length(login_label) BETWEEN 1 AND 254
+      AND login_label = lower(trim(login_label))
+    ),
+  password_salt BLOB NOT NULL CHECK (length(password_salt) = 16),
+  password_verifier BLOB NOT NULL CHECK (length(password_verifier) = 32),
+  password_scrypt_n INTEGER NOT NULL CHECK (
+    password_scrypt_n BETWEEN 16384 AND 131072
+    AND (password_scrypt_n & (password_scrypt_n - 1)) = 0
+  ),
+  password_scrypt_r INTEGER NOT NULL CHECK (password_scrypt_r BETWEEN 8 AND 32),
+  password_scrypt_p INTEGER NOT NULL CHECK (password_scrypt_p BETWEEN 1 AND 4),
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (principal_id) REFERENCES authorization_principals(principal_id)
+);
+
+CREATE TRIGGER IF NOT EXISTS teams_local_accounts_human_guard
+BEFORE INSERT ON teams_local_accounts
+FOR EACH ROW
+WHEN NOT EXISTS (
+  SELECT 1
+  FROM authorization_principals AS principal
+  WHERE principal.principal_id = NEW.principal_id
+    AND principal.kind = 'human'
+)
+BEGIN
+  SELECT RAISE(ABORT, 'Teams local account must map to a human principal');
+END;
+
+CREATE TRIGGER IF NOT EXISTS teams_local_accounts_immutable
+BEFORE UPDATE ON teams_local_accounts
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'Teams local accounts are immutable in v1');
+END;
+
+CREATE TRIGGER IF NOT EXISTS teams_local_accounts_delete_forbidden
+BEFORE DELETE ON teams_local_accounts
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'Teams local accounts cannot be deleted');
+END;
+
+CREATE TABLE IF NOT EXISTS teams_sessions (
+  session_id TEXT NOT NULL PRIMARY KEY CHECK (length(trim(session_id)) > 0),
+  token_digest TEXT NOT NULL UNIQUE CHECK (
+    length(token_digest) = 64
+    AND token_digest NOT GLOB '*[^0-9a-f]*'
+  ),
+  account_id TEXT NOT NULL,
+  principal_id TEXT NOT NULL,
+  domain_id TEXT NOT NULL,
+  state TEXT NOT NULL CHECK (state IN ('active', 'revoked')),
+  expires_at INTEGER NOT NULL,
+  revoked_at INTEGER,
+  revoked_by_principal_id TEXT,
+  created_at INTEGER NOT NULL,
+  CHECK (expires_at > created_at AND expires_at <= created_at + 2592000000),
+  CHECK (
+    (state = 'active' AND revoked_at IS NULL AND revoked_by_principal_id IS NULL)
+    OR
+    (state = 'revoked' AND revoked_at IS NOT NULL AND revoked_by_principal_id IS NOT NULL)
+  ),
+  FOREIGN KEY (account_id) REFERENCES teams_local_accounts(account_id),
+  FOREIGN KEY (principal_id) REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (revoked_by_principal_id)
+    REFERENCES authorization_principals(principal_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_teams_sessions_account
+  ON teams_sessions(account_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_teams_sessions_domain
+  ON teams_sessions(domain_id, state, expires_at);
+
+CREATE TRIGGER IF NOT EXISTS teams_sessions_insert_guard
+BEFORE INSERT ON teams_sessions
+FOR EACH ROW
+WHEN
+  NEW.state <> 'active'
+  OR NOT EXISTS (
+    SELECT 1
+    FROM teams_local_accounts AS account
+    INNER JOIN authorization_principals AS principal
+      ON principal.principal_id = account.principal_id
+    INNER JOIN authorization_domain_memberships AS membership
+      ON membership.principal_id = account.principal_id
+      AND membership.domain_id = NEW.domain_id
+    WHERE account.account_id = NEW.account_id
+      AND account.principal_id = NEW.principal_id
+      AND principal.kind = 'human'
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'Teams session requires an active human account domain member');
+END;
+
+CREATE TRIGGER IF NOT EXISTS teams_sessions_payload_immutable
+BEFORE UPDATE OF
+  session_id,
+  token_digest,
+  account_id,
+  principal_id,
+  domain_id,
+  expires_at,
+  created_at
+ON teams_sessions
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'Teams session identity and expiry are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS teams_sessions_state_monotonic
+BEFORE UPDATE OF state, revoked_at, revoked_by_principal_id ON teams_sessions
+FOR EACH ROW
+WHEN
+  OLD.state <> 'active'
+  OR NEW.state <> 'revoked'
+  OR NEW.revoked_at IS NULL
+  OR NEW.revoked_at < OLD.created_at
+  OR NEW.revoked_by_principal_id IS NULL
+  OR NOT EXISTS (
+    SELECT 1
+    FROM authorization_domain_memberships AS membership
+    INNER JOIN authorization_principals AS principal
+      ON principal.principal_id = membership.principal_id
+    WHERE membership.domain_id = OLD.domain_id
+      AND membership.principal_id = NEW.revoked_by_principal_id
+      AND principal.kind = 'human'
+      AND (
+        membership.principal_id = OLD.principal_id
+        OR membership.role = 'owner'
+      )
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'Teams session cannot be reactivated or retimestamped');
+END;
+
+CREATE TRIGGER IF NOT EXISTS teams_sessions_delete_forbidden
+BEFORE DELETE ON teams_sessions
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'Teams sessions cannot be deleted');
+END;
+
+CREATE TABLE IF NOT EXISTS teams_invites (
+  invite_id TEXT NOT NULL PRIMARY KEY CHECK (length(trim(invite_id)) > 0),
+  code_digest TEXT NOT NULL UNIQUE CHECK (
+    length(code_digest) = 64
+    AND code_digest NOT GLOB '*[^0-9a-f]*'
+  ),
+  domain_id TEXT NOT NULL,
+  created_by_principal_id TEXT NOT NULL,
+  recipient_label TEXT COLLATE NOCASE CHECK (
+    recipient_label IS NULL
+    OR (
+      length(recipient_label) BETWEEN 1 AND 254
+      AND recipient_label = lower(trim(recipient_label))
+    )
+  ),
+  state TEXT NOT NULL CHECK (state IN ('active', 'redeemed', 'revoked')),
+  expires_at INTEGER NOT NULL,
+  redeemed_at INTEGER,
+  redeemed_by_principal_id TEXT,
+  revoked_at INTEGER,
+  revoked_by_principal_id TEXT,
+  created_at INTEGER NOT NULL,
+  UNIQUE (invite_id, domain_id),
+  CHECK (
+    expires_at >= created_at + 60000
+    AND expires_at <= created_at + 604800000
+  ),
+  CHECK (
+    (
+      state = 'active'
+      AND redeemed_at IS NULL
+      AND redeemed_by_principal_id IS NULL
+      AND revoked_at IS NULL
+      AND revoked_by_principal_id IS NULL
+    )
+    OR (
+      state = 'redeemed'
+      AND redeemed_at IS NOT NULL
+      AND redeemed_by_principal_id IS NOT NULL
+      AND revoked_at IS NULL
+      AND revoked_by_principal_id IS NULL
+    )
+    OR (
+      state = 'revoked'
+      AND redeemed_at IS NULL
+      AND redeemed_by_principal_id IS NULL
+      AND revoked_at IS NOT NULL
+      AND revoked_by_principal_id IS NOT NULL
+    )
+  ),
+  FOREIGN KEY (domain_id) REFERENCES authorization_domains(domain_id),
+  FOREIGN KEY (created_by_principal_id)
+    REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (redeemed_by_principal_id)
+    REFERENCES authorization_principals(principal_id),
+  FOREIGN KEY (revoked_by_principal_id)
+    REFERENCES authorization_principals(principal_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_teams_invites_domain
+  ON teams_invites(domain_id, state, expires_at, created_at DESC);
+
+CREATE TRIGGER IF NOT EXISTS teams_invites_insert_guard
+BEFORE INSERT ON teams_invites
+FOR EACH ROW
+WHEN
+  NEW.state <> 'active'
+  OR NOT EXISTS (
+    SELECT 1
+    FROM authorization_domain_memberships AS membership
+    INNER JOIN authorization_principals AS principal
+      ON principal.principal_id = membership.principal_id
+    WHERE membership.domain_id = NEW.domain_id
+      AND membership.principal_id = NEW.created_by_principal_id
+      AND membership.role = 'owner'
+      AND principal.kind = 'human'
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'Teams invite creator must be the current human domain owner');
+END;
+
+CREATE TRIGGER IF NOT EXISTS teams_invites_payload_immutable
+BEFORE UPDATE OF
+  invite_id,
+  code_digest,
+  domain_id,
+  created_by_principal_id,
+  recipient_label,
+  expires_at,
+  created_at
+ON teams_invites
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'Teams invite payload is immutable');
+END;
+
+CREATE TABLE IF NOT EXISTS teams_invite_grants (
+  invite_id TEXT NOT NULL,
+  domain_id TEXT NOT NULL,
+  namespace TEXT NOT NULL CHECK (length(trim(namespace)) > 0),
+  resource_type TEXT NOT NULL CHECK (length(trim(resource_type)) > 0),
+  resource_id TEXT NOT NULL CHECK (length(trim(resource_id)) > 0),
+  permission TEXT NOT NULL CHECK (length(trim(permission)) > 0),
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (
+    invite_id,
+    namespace,
+    resource_type,
+    resource_id,
+    permission
+  ),
+  FOREIGN KEY (invite_id, domain_id)
+    REFERENCES teams_invites(invite_id, domain_id),
+  FOREIGN KEY (domain_id, namespace, resource_type, resource_id)
+    REFERENCES authorization_resources(domain_id, namespace, resource_type, resource_id)
+);
+
+CREATE TRIGGER IF NOT EXISTS teams_invite_grants_insert_guard
+BEFORE INSERT ON teams_invite_grants
+FOR EACH ROW
+WHEN
+  NOT EXISTS (
+    SELECT 1
+    FROM teams_invites AS invite
+    WHERE invite.invite_id = NEW.invite_id
+      AND invite.domain_id = NEW.domain_id
+      AND invite.state = 'active'
+  )
+  OR NOT EXISTS (
+    SELECT 1
+    FROM authorization_resources AS resource
+    WHERE resource.domain_id = NEW.domain_id
+      AND resource.namespace = NEW.namespace
+      AND resource.resource_type = NEW.resource_type
+      AND resource.resource_id = NEW.resource_id
+      AND resource.retired_at IS NULL
+  )
+BEGIN
+  SELECT RAISE(ABORT, 'Teams invite grant requires an active invite and active resource');
+END;
+
+CREATE TRIGGER IF NOT EXISTS teams_invite_grants_immutable
+BEFORE UPDATE ON teams_invite_grants
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'Teams invite grants are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS teams_invite_grants_delete_forbidden
+BEFORE DELETE ON teams_invite_grants
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'Teams invite grants cannot be deleted');
+END;
+
+CREATE TRIGGER IF NOT EXISTS teams_invites_state_monotonic
+BEFORE UPDATE OF
+  state,
+  redeemed_at,
+  redeemed_by_principal_id,
+  revoked_at,
+  revoked_by_principal_id
+ON teams_invites
+FOR EACH ROW
+WHEN
+  OLD.state <> 'active'
+  OR (
+    NEW.state = 'redeemed'
+    AND (
+      NEW.redeemed_at IS NULL
+      OR NEW.redeemed_at < OLD.created_at
+      OR NEW.redeemed_at >= OLD.expires_at
+      OR NEW.redeemed_by_principal_id IS NULL
+      OR NOT EXISTS (
+        SELECT 1
+        FROM authorization_domain_memberships AS membership
+        INNER JOIN authorization_principals AS principal
+          ON principal.principal_id = membership.principal_id
+        WHERE membership.domain_id = OLD.domain_id
+          AND membership.principal_id = NEW.redeemed_by_principal_id
+          AND principal.kind = 'human'
+      )
+      OR NOT EXISTS (
+        SELECT 1 FROM teams_invite_grants AS manifest
+        WHERE manifest.invite_id = OLD.invite_id
+      )
+      OR EXISTS (
+        SELECT 1
+        FROM teams_invite_grants AS manifest
+        WHERE manifest.invite_id = OLD.invite_id
+          AND (
+            NOT EXISTS (
+              SELECT 1
+              FROM authorization_resources AS resource
+              WHERE resource.domain_id = OLD.domain_id
+                AND resource.namespace = manifest.namespace
+                AND resource.resource_type = manifest.resource_type
+                AND resource.resource_id = manifest.resource_id
+                AND resource.retired_at IS NULL
+            )
+            OR NOT EXISTS (
+              SELECT 1
+              FROM authorization_grants AS grant_row
+              WHERE grant_row.domain_id = OLD.domain_id
+                AND grant_row.principal_id = NEW.redeemed_by_principal_id
+                AND grant_row.namespace = manifest.namespace
+                AND grant_row.resource_type = manifest.resource_type
+                AND grant_row.resource_id = manifest.resource_id
+                AND grant_row.permission = manifest.permission
+            )
+          )
+      )
+    )
+  )
+  OR (
+    NEW.state = 'revoked'
+    AND (
+      NEW.revoked_at IS NULL
+      OR NEW.revoked_at < OLD.created_at
+      OR NEW.revoked_by_principal_id IS NULL
+      OR NOT EXISTS (
+        SELECT 1
+        FROM authorization_domain_memberships AS membership
+        INNER JOIN authorization_principals AS principal
+          ON principal.principal_id = membership.principal_id
+        WHERE membership.domain_id = OLD.domain_id
+          AND membership.principal_id = NEW.revoked_by_principal_id
+          AND membership.role = 'owner'
+          AND principal.kind = 'human'
+      )
+    )
+  )
+  OR NEW.state NOT IN ('redeemed', 'revoked')
+BEGIN
+  SELECT RAISE(ABORT, 'Teams invite terminal state is monotonic');
+END;
+
+CREATE TRIGGER IF NOT EXISTS teams_invites_delete_forbidden
+BEFORE DELETE ON teams_invites
+FOR EACH ROW
+BEGIN
+  SELECT RAISE(ABORT, 'Teams invites cannot be deleted');
+END;
+
 CREATE TABLE IF NOT EXISTS authorization_agent_sponsors (
   domain_id TEXT NOT NULL,
   agent_principal_id TEXT NOT NULL,

--- a/ui/src/api/gateway.node.test.ts
+++ b/ui/src/api/gateway.node.test.ts
@@ -143,6 +143,7 @@ type ConnectFrame = {
     maxProtocol?: number;
     minProtocol?: number;
     caps?: string[];
+    role?: string;
     scopes?: string[];
   };
 };
@@ -421,6 +422,32 @@ describe("GatewayBrowserClient", () => {
       GATEWAY_CLIENT_CAPS.INLINE_WIDGETS,
     ]);
     expect(connectFrame.params?.scopes).toEqual([...CONTROL_UI_OPERATOR_SCOPES]);
+  });
+
+  it("connects a Teams browser session as a scope-less member while preserving device signing", async () => {
+    const client = new GatewayBrowserClient({
+      url: "wss://gateway.example",
+      role: "member",
+      scopes: [],
+    });
+
+    const { connectFrame } = await startConnect(client);
+
+    expect(connectFrame.params?.role).toBe("member");
+    expect(connectFrame.params?.scopes).toEqual([]);
+    expect(connectFrame.params?.caps).toEqual([]);
+    const [, signedPayload] = requireFirstSignCall();
+    expect(signedPayload.split("|")).toEqual([
+      "v2",
+      "device-1",
+      "openclaw-control-ui",
+      "webchat",
+      "member",
+      "",
+      expect.stringMatching(/^\d+$/),
+      "",
+      "nonce-1",
+    ]);
   });
 
   it("requests handoff scopes with bootstrap token auth", async () => {

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -301,6 +301,9 @@ export type GatewayBrowserClientOptions = {
   token?: string;
   bootstrapToken?: string;
   password?: string;
+  role?: string;
+  scopes?: string[];
+  caps?: string[];
   clientName?: GatewayClientName;
   clientVersion?: string;
   platform?: string;
@@ -801,11 +804,15 @@ export class GatewayBrowserClient {
       role: plan.role,
       scopes: plan.scopes,
       device: plan.device,
-      caps: [
-        GATEWAY_CLIENT_CAPS.TASK_SUGGESTIONS,
-        GATEWAY_CLIENT_CAPS.TOOL_EVENTS,
-        GATEWAY_CLIENT_CAPS.INLINE_WIDGETS,
-      ],
+      caps: this.opts.caps
+        ? [...this.opts.caps]
+        : plan.role === CONTROL_UI_OPERATOR_ROLE
+          ? [
+              GATEWAY_CLIENT_CAPS.TASK_SUGGESTIONS,
+              GATEWAY_CLIENT_CAPS.TOOL_EVENTS,
+              GATEWAY_CLIENT_CAPS.INLINE_WIDGETS,
+            ]
+          : [],
       auth: plan.auth,
       userAgent: navigator.userAgent,
       locale: navigator.language,
@@ -816,7 +823,7 @@ export class GatewayBrowserClient {
     connectNonce: string | null,
     generation: number,
   ): Promise<ConnectPlan> {
-    const role = CONTROL_UI_OPERATOR_ROLE;
+    const role = this.opts.role?.trim() || CONTROL_UI_OPERATOR_ROLE;
     const client = this.buildConnectClient();
     const explicitGatewayToken = this.opts.token?.trim() || undefined;
     const explicitPassword = this.opts.password?.trim() || undefined;
@@ -843,7 +850,9 @@ export class GatewayBrowserClient {
         deviceId: deviceIdentity.deviceId,
       });
     }
-    const scopes = resolveControlUiConnectScopes(selectedAuth);
+    const scopes = this.opts.scopes
+      ? [...this.opts.scopes]
+      : resolveControlUiConnectScopes(selectedAuth);
     const device = await buildGatewayConnectDevice({
       deviceIdentity,
       client,

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2107,6 +2107,16 @@ export const en: TranslationMap = {
     header: {
       subtitle: "Arrange widgets and tabs for this workspace.",
     },
+    distribution: {
+      export: "Export",
+      import: "Import",
+      previewTitle: "Review workspace import",
+      previewSummary:
+        "Add {tabs} tabs and {widgets} widgets. {customWidgets} custom widgets require separate approval.",
+      customPending:
+        "Custom widgets stay pending and cannot run until you approve their installed files separately.",
+      approve: "Approve import",
+    },
     onboarding: {
       title: "Build your first workspace tab",
       primary: "Ask your agent to build a tab.",

--- a/ui/src/lib/workspace/index.test.ts
+++ b/ui/src/lib/workspace/index.test.ts
@@ -5,6 +5,8 @@ import {
   applyPointer,
   cancelActiveDrag,
   clearActiveDrag,
+  commitWorkspaceImport,
+  exportWorkspace,
   WORKSPACE_POLL_INTERVAL_MS,
   getWorkspaceState,
   hiddenTabs,
@@ -18,6 +20,7 @@ import {
   removeWidgetFromTab,
   resolveActiveSlug,
   resolveBinding,
+  previewWorkspaceImport,
   setWidgetCollapsed,
   updateWidgetTitle,
   startBindingPolling,
@@ -69,11 +72,21 @@ describe("normalizeWorkspace", () => {
   it("normalizes tabs, widgets, and prefs defensively", () => {
     const ws = normalizeWorkspace(sampleDoc);
     expect(ws.workspaceVersion).toBe(3);
+    expect(ws.workspaceId).toBe("default");
     expect(ws.tabs).toHaveLength(2);
     expect(itemAt(itemAt(ws.tabs, 0, "workspace tab").widgets, 0, "workspace widget").grid).toEqual(
       { x: 0, y: 0, w: 4, h: 2 },
     );
     expect(ws.prefs.tabOrder).toEqual(["archive", "main"]);
+  });
+
+  it("keeps immutable resource ids needed by distribution and Teams access", () => {
+    const ws = normalizeWorkspace({
+      workspaceId: "workspace-1",
+      tabs: [{ id: "tab-1", revision: 4, slug: "main", title: "Main", widgets: [] }],
+    });
+    expect(ws.workspaceId).toBe("workspace-1");
+    expect(ws.tabs[0]).toMatchObject({ id: "tab-1", revision: 4 });
   });
 
   it("drops malformed tabs and widgets", () => {
@@ -97,6 +110,84 @@ describe("normalizeWorkspace", () => {
     expect(itemAt(itemAt(ws.tabs, 0, "workspace tab").widgets, 0, "workspace widget").grid).toEqual(
       { x: 0, y: 0, w: 12, h: 1 },
     );
+  });
+});
+
+describe("workspace distribution RPC", () => {
+  it("uses the workspace id for owner export and preview", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ filename: "workspace.json", content: "{}" })
+      .mockResolvedValueOnce({
+        previewId: "preview-1",
+        workspaceId: "workspace-1",
+        baseWorkspaceVersion: 3,
+        expiresAt: 10,
+        summary: { tabs: 1, widgets: 2, customWidgets: 1 },
+        tabs: [{ slug: "finance-2", title: "Finance", widgets: 2, customWidgets: 1 }],
+      });
+    const client = mockClient({ request: request as never });
+
+    await expect(exportWorkspace(client, "workspace-1")).resolves.toEqual({
+      filename: "workspace.json",
+      content: "{}",
+    });
+    await expect(previewWorkspaceImport(client, "workspace-1", "package")).resolves.toMatchObject({
+      previewId: "preview-1",
+      summary: { tabs: 1, widgets: 2, customWidgets: 1 },
+    });
+    expect(request).toHaveBeenNthCalledWith(1, "workspaces.export", {
+      workspaceId: "workspace-1",
+    });
+    expect(request).toHaveBeenNthCalledWith(2, "workspaces.import.preview", {
+      workspaceId: "workspace-1",
+      content: "package",
+    });
+  });
+
+  it("falls back to the exact tab export for a shared member", async () => {
+    const request = vi.fn().mockResolvedValueOnce({ filename: "tab.json", content: "{}" });
+    const client = mockClient({ request: request as never });
+
+    await expect(exportWorkspace(client, "workspace-1", "tab-1", false)).resolves.toEqual({
+      filename: "tab.json",
+      content: "{}",
+    });
+    expect(request).toHaveBeenCalledWith("workspaces.tab.export", {
+      workspaceId: "workspace-1",
+      tabId: "tab-1",
+    });
+  });
+
+  it("sets owner approval and completes sharing sync after committing a preview", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ workspaceVersion: 4, sharingSyncRequired: true })
+      .mockResolvedValueOnce({ tabs: [] });
+    const client = mockClient({ request: request as never });
+    await expect(commitWorkspaceImport(client, "workspace-1", "preview-1")).resolves.toEqual({
+      sharingSyncError: null,
+    });
+    expect(request).toHaveBeenNthCalledWith(1, "workspaces.import.commit", {
+      workspaceId: "workspace-1",
+      previewId: "preview-1",
+      approved: true,
+    });
+    expect(request).toHaveBeenNthCalledWith(2, "workspaces.sharing.sync", {
+      workspaceId: "workspace-1",
+    });
+  });
+
+  it("reports sharing sync failure separately from a durable import", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ workspaceVersion: 4, sharingSyncRequired: true })
+      .mockRejectedValueOnce(new Error("sync unavailable"));
+    const client = mockClient({ request: request as never });
+
+    const result = await commitWorkspaceImport(client, "workspace-1", "preview-1");
+
+    expect(result.sharingSyncError?.message).toBe("sync unavailable");
   });
 });
 
@@ -130,13 +221,18 @@ describe("loadWorkspace", () => {
     const state = getWorkspaceState(host);
     const client = mockClient({
       // Real gateway shape: workspaces.get returns { doc, workspaceVersion }.
-      request: vi.fn(async () => ({ doc: sampleDoc, workspaceVersion: 3 })) as never,
+      request: vi.fn(async () => ({
+        doc: sampleDoc,
+        workspaceVersion: 3,
+        distributionAccess: { owner: true },
+      })) as never,
     });
     await loadWorkspace(state, client, { requestedSlug: "archive" });
     expect(state.loaded).toBe(true);
     // The workspace actually populates (tabs present), not an empty fallback.
     expect(state.workspace?.workspaceVersion).toBe(3);
     expect(state.workspace?.tabs).toHaveLength(2);
+    expect(state.distributionOwner).toBe(true);
     expect(state.activeSlug).toBe("archive");
   });
 

--- a/ui/src/lib/workspace/index.ts
+++ b/ui/src/lib/workspace/index.ts
@@ -27,6 +27,8 @@ export type WorkspaceUiState = {
   loaded: boolean;
   error: string | null;
   workspace: WorkspaceDocument | null;
+  /** Canonical ownership for distribution controls, resolved by the gateway. */
+  distributionOwner: boolean;
   /** Slug of the workspace tab in view; null until the doc resolves a default. */
   activeSlug: string | null;
   /** Whether the hidden-tabs overflow menu is open. */
@@ -90,6 +92,7 @@ export function getWorkspaceState(host: WorkspaceHost): WorkspaceUiState {
       loaded: false,
       error: null,
       workspace: null,
+      distributionOwner: false,
       activeSlug: null,
       hiddenMenuOpen: false,
       pendingWidgetIds: new Set(),
@@ -198,6 +201,8 @@ function normalizeTab(value: unknown): WorkspaceTab | null {
         .filter((w): w is WorkspaceWidget => w !== null)
     : [];
   return {
+    id: readString(value.id, slug),
+    revision: Math.max(1, Math.trunc(readNumber(value.revision, 1))),
     slug,
     title: readString(value.title, slug),
     hidden: value.hidden === true,
@@ -249,12 +254,83 @@ export function normalizeWorkspace(payload: unknown): WorkspaceDocument {
     ? prefsRecord.tabOrder.filter((slug): slug is string => typeof slug === "string")
     : [];
   return {
+    workspaceId: readString(record.workspaceId, "default"),
     schemaVersion: readNumber(record.schemaVersion, 1),
     workspaceVersion: readNumber(record.workspaceVersion, 0),
     tabs,
     prefs: { tabOrder },
     widgetsRegistry: normalizeWidgetsRegistry(record.widgetsRegistry),
   };
+}
+
+export type WorkspaceImportPreview = {
+  previewId: string;
+  workspaceId: string;
+  baseWorkspaceVersion: number;
+  expiresAt: number;
+  summary: { tabs: number; widgets: number; customWidgets: number };
+  tabs: Array<{ slug: string; title: string; widgets: number; customWidgets: number }>;
+};
+
+export async function exportWorkspace(
+  client: GatewayBrowserClient,
+  workspaceId: string,
+  tabId?: string,
+  owner = true,
+): Promise<{ filename: string; content: string }> {
+  let payload: unknown;
+  if (!owner) {
+    if (!tabId) {
+      throw new Error("Shared workspace export requires an exact tab id.");
+    }
+    payload = await client.request("workspaces.tab.export", { workspaceId, tabId });
+  } else {
+    payload = await client.request("workspaces.export", { workspaceId });
+  }
+  const result = isRecord(payload) ? payload : {};
+  const filename = readString(result.filename).trim();
+  const content = readString(result.content);
+  if (!filename || !content) {
+    throw new Error("Workspace export returned an invalid response.");
+  }
+  return { filename, content };
+}
+
+export async function previewWorkspaceImport(
+  client: GatewayBrowserClient,
+  workspaceId: string,
+  content: string,
+): Promise<WorkspaceImportPreview> {
+  const payload = await client.request("workspaces.import.preview", { workspaceId, content });
+  if (!isRecord(payload) || !isRecord(payload.summary) || !Array.isArray(payload.tabs)) {
+    throw new Error("Workspace import preview returned an invalid response.");
+  }
+  const previewId = readString(payload.previewId).trim();
+  const returnedWorkspaceId = readString(payload.workspaceId).trim();
+  if (!previewId || returnedWorkspaceId !== workspaceId) {
+    throw new Error("Workspace import preview returned an invalid response.");
+  }
+  return payload as unknown as WorkspaceImportPreview;
+}
+
+export async function commitWorkspaceImport(
+  client: GatewayBrowserClient,
+  workspaceId: string,
+  previewId: string,
+): Promise<{ sharingSyncError: Error | null }> {
+  const result = await client.request("workspaces.import.commit", {
+    workspaceId,
+    previewId,
+    approved: true,
+  });
+  if (isRecord(result) && result.sharingSyncRequired === true) {
+    try {
+      await client.request("workspaces.sharing.sync", { workspaceId });
+    } catch (error) {
+      return { sharingSyncError: error instanceof Error ? error : new Error(String(error)) };
+    }
+  }
+  return { sharingSyncError: null };
 }
 
 /** The `custom:<name>` widget name, or null for builtin/unknown kinds. */
@@ -368,6 +444,10 @@ export async function loadWorkspace(
       isRecord(payload) && "doc" in payload ? payload.doc : payload,
     );
     state.workspace = workspace;
+    state.distributionOwner =
+      isRecord(payload) &&
+      isRecord(payload.distributionAccess) &&
+      payload.distributionAccess.owner === true;
     state.activeSlug = resolveActiveSlug(workspace, opts?.requestedSlug ?? state.activeSlug);
     state.error = null;
     state.loaded = true;

--- a/ui/src/lib/workspace/types.ts
+++ b/ui/src/lib/workspace/types.ts
@@ -47,6 +47,10 @@ export type WorkspaceWidget = {
 };
 
 export type WorkspaceTab = {
+  /** Immutable authorization resource id; present on current gateway payloads. */
+  id?: string;
+  /** Store-owned optimistic-concurrency revision. */
+  revision?: number;
   slug: string;
   title: string;
   icon?: string;
@@ -71,6 +75,8 @@ export type WorkspaceWidgetRegistryEntry = {
 };
 
 export type WorkspaceDocument = {
+  /** Immutable workspace authorization resource id. */
+  workspaceId?: string;
   schemaVersion: number;
   workspaceVersion: number;
   tabs: WorkspaceTab[];

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -1,9 +1,9 @@
 // Control UI module implements main behavior.
 import "./styles.css";
-import "./app/app-host.ts";
 import { inferControlUiPublicAssetPath } from "./app/public-assets.ts";
 import { installStaleChunkReloadListener } from "./app/stale-chunk-reload.ts";
 import { CONTROL_UI_BUILD_INFO } from "./build-info.ts";
+import { isTeamsPortalPath, mountTeamsPortal } from "./pages/teams/teams-portal.ts";
 
 type ViteImportMeta = ImportMeta & {
   readonly env?: {
@@ -16,6 +16,23 @@ const currentControlUiBuildId = CONTROL_UI_BUILD_INFO.buildId;
 
 syncDocumentPublicAssetLinks();
 installStaleChunkReloadListener();
+
+const teamsRoute = isTeamsPortalPath(window.location.pathname);
+if (teamsRoute) {
+  // Teams runs before the operator app mounts so browser-held gateway tokens
+  // can never open the full-control shell on a member route.
+  const operatorMount = document.querySelector("openclaw-app");
+  operatorMount?.setAttribute("hidden", "");
+  if (!customElements.get("openclaw-app")) {
+    customElements.define("openclaw-app", class extends HTMLElement {});
+  }
+  const host = document.createElement("div");
+  host.dataset.teamsPortal = "true";
+  document.body.append(host);
+  mountTeamsPortal({ host, route: teamsRoute });
+} else {
+  void import("./app/app-host.ts");
+}
 
 if (isProd && "serviceWorker" in navigator) {
   const swUrl = new URL(inferControlUiPublicAssetPath("sw.js"), window.location.origin);

--- a/ui/src/pages/plugin/workspace-view.test.ts
+++ b/ui/src/pages/plugin/workspace-view.test.ts
@@ -98,6 +98,7 @@ describe("renderWorkspace", () => {
     const state = getWorkspaceState(host);
     state.loaded = true;
     state.workspace = doc;
+    state.distributionOwner = true;
     state.activeSlug = "main";
     const container = renderView(host);
     const tabs = container.querySelectorAll('[data-test-id="workspace-tab"]');
@@ -105,6 +106,25 @@ describe("renderWorkspace", () => {
     expect(container.querySelector(".workspace-tabs__hidden")).not.toBeNull();
     // Active tab's widget grid renders.
     expect(container.querySelector('[data-test-id="workspace-grid"]')).not.toBeNull();
+    expect(container.querySelector('[data-test-id="workspace-export"]')).not.toBeNull();
+    expect(container.querySelector('[data-test-id="workspace-import"]')).not.toBeNull();
+  });
+
+  it("never sends a ws deep link as gateway authorization input", async () => {
+    window.history.replaceState({}, "", "/plugin?plugin=workspaces&id=workspaces&ws=archive");
+    const host = document.createElement("div");
+    const request = vi.fn(async () => ({ doc }));
+    const client = {
+      request,
+      addEventListener: vi.fn(() => () => {}),
+    } as unknown as GatewayBrowserClient;
+
+    render(renderWorkspace({ host, client, connected: true }), host);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith("workspaces.get", {}));
+    expect(
+      request.mock.calls.some(([, params]) => (params as { ws?: string }).ws === "archive"),
+    ).toBe(false);
+    stopWorkspace(host);
   });
 
   it("renders the empty-tab hint for a tab with no widgets", () => {

--- a/ui/src/pages/plugin/workspace-view.test.ts
+++ b/ui/src/pages/plugin/workspace-view.test.ts
@@ -78,7 +78,7 @@ describe("renderWorkspace", () => {
     window.history.replaceState({}, "", "/");
   });
 
-  it("shows the onboarding empty state with no tabs", () => {
+  it("keeps the owner import entrypoint in a zero-tab workspace", () => {
     const host = {};
     const state = getWorkspaceState(host);
     state.loaded = true;
@@ -89,8 +89,10 @@ describe("renderWorkspace", () => {
       widgetsRegistry: {},
       prefs: { tabOrder: [] },
     };
+    state.distributionOwner = true;
     const container = renderView(host);
     expect(container.querySelector('[data-test-id="workspace-empty"]')).not.toBeNull();
+    expect(container.querySelector('[data-test-id="workspace-import"]')).not.toBeNull();
   });
 
   it("renders the tab strip with visible tabs and a hidden overflow", () => {

--- a/ui/src/pages/plugin/workspace-view.ts
+++ b/ui/src/pages/plugin/workspace-view.ts
@@ -961,6 +961,7 @@ function renderBody(
   }
   if (workspace.tabs.length === 0) {
     return html`
+      ${renderWorkspacesHeader(props, state, viewState)}
       <div class="workspace-empty workspace-empty--onboarding" data-test-id="workspace-empty">
         <div class="workspace-empty__title">${t("workspaces.empty.onboardingTitle")}</div>
         <div class="workspace-empty__sub">${t("workspaces.empty.onboardingSubtitle")}</div>
@@ -1044,9 +1045,9 @@ function renderDistributionPreview(
         </div>
         <div class="exec-approval-sub">
           ${t("workspaces.distribution.previewSummary", {
-            tabs: preview.summary.tabs,
-            widgets: preview.summary.widgets,
-            customWidgets: preview.summary.customWidgets,
+            tabs: String(preview.summary.tabs),
+            widgets: String(preview.summary.widgets),
+            customWidgets: String(preview.summary.customWidgets),
           })}
         </div>
         <ul class="workspace-distribution__tabs">
@@ -1079,7 +1080,7 @@ function renderWorkspacesHeader(
   props: WorkspaceProps,
   state: WorkspaceUiState,
   viewState: WorkspaceViewState,
-  tab: WorkspaceTab,
+  tab?: WorkspaceTab,
 ): TemplateResult {
   const workspaceId = state.workspace?.workspaceId ?? "default";
   const exportCurrent = async () => {
@@ -1092,7 +1093,7 @@ function renderWorkspacesHeader(
       const exported = await exportWorkspace(
         props.client,
         workspaceId,
-        tab.id,
+        tab?.id,
         state.distributionOwner,
       );
       downloadWorkspaceFile(exported.filename, exported.content);
@@ -1129,19 +1130,21 @@ function renderWorkspacesHeader(
   return html`
     <div class="workspace-page-header" data-test-id="workspace-page-header">
       <div>
-        <div class="page-title">${tab.title}</div>
+        <div class="page-title">${tab?.title ?? t("workspaces.tabs.label")}</div>
         <div class="page-sub">${t("workspaces.header.subtitle")}</div>
       </div>
       <div class="workspace-page-header__actions">
-        <button
-          class="btn btn--small"
-          type="button"
-          data-test-id="workspace-export"
-          ?disabled=${viewState.distributionBusy}
-          @click=${exportCurrent}
-        >
-          ${t("workspaces.distribution.export")}
-        </button>
+        ${state.distributionOwner || tab?.id
+          ? html`<button
+              class="btn btn--small"
+              type="button"
+              data-test-id="workspace-export"
+              ?disabled=${viewState.distributionBusy}
+              @click=${exportCurrent}
+            >
+              ${t("workspaces.distribution.export")}
+            </button>`
+          : nothing}
         ${state.distributionOwner
           ? html`<label class="btn btn--small" data-test-id="workspace-import-label">
               ${t("workspaces.distribution.import")}

--- a/ui/src/pages/plugin/workspace-view.ts
+++ b/ui/src/pages/plugin/workspace-view.ts
@@ -31,16 +31,19 @@ import {
 import {
   approveWidget,
   clearActiveDrag,
+  commitWorkspaceImport,
   customWidgetName,
   customWidgetStatus,
   findTab,
   getWorkspaceState,
   hiddenTabs,
   hideWidget,
+  exportWorkspace,
   loadWorkspace,
   moveWidget,
   moveWidgetToTab,
   orderedTabs,
+  previewWorkspaceImport,
   removeWidgetFromTab,
   resolveActiveSlug,
   registerActiveDrag,
@@ -51,6 +54,7 @@ import {
   updateWidgetTitle,
   visibleTabs,
   type WorkspaceBindingResult,
+  type WorkspaceImportPreview,
   type WorkspaceUiState,
 } from "../../lib/workspace/index.ts";
 import type {
@@ -106,6 +110,8 @@ type WorkspaceViewState = {
   dataVersion: number;
   /** Active themed dialog (#12) for edit-title / move-to-tab, or null. */
   dialog: WorkspaceDialogState | null;
+  distributionPreview: WorkspaceImportPreview | null;
+  distributionBusy: boolean;
   /** First-visit onboarding banner dismissed this session (#5); mirrors localStorage. */
   onboardingDismissed: boolean;
 };
@@ -226,6 +232,8 @@ function getViewState(host: object): WorkspaceViewState {
       manifestEpoch: 0,
       dataVersion: 0,
       dialog: null,
+      distributionPreview: null,
+      distributionBusy: false,
       onboardingDismissed: isOnboardingDismissed(),
     };
     workspaceViewStates.set(host, state);
@@ -967,7 +975,7 @@ function renderBody(
     </div>`;
   }
   return html`
-    ${renderWorkspacesHeader(tab)}
+    ${renderWorkspacesHeader(props, state, viewState, tab)}
     ${renderOnboardingBanner(viewState, () => props.onRequestUpdate?.())}
     ${renderTabStrip(state, workspace)} ${renderGrid(props, state, viewState, workspace, tab)}
   `;
@@ -978,12 +986,178 @@ function renderBody(
  * the title with a subtitle line, matching the app's .page-title / .page-sub
  * idiom used by the other top-level pages.
  */
-function renderWorkspacesHeader(tab: WorkspaceTab): TemplateResult {
+function downloadWorkspaceFile(filename: string, content: string): void {
+  const url = URL.createObjectURL(new Blob([content], { type: "application/json" }));
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+function renderDistributionPreview(
+  props: WorkspaceProps,
+  state: WorkspaceUiState,
+  viewState: WorkspaceViewState,
+): TemplateResult | typeof nothing {
+  const preview = viewState.distributionPreview;
+  if (!preview) {
+    return nothing;
+  }
+  const close = () => {
+    viewState.distributionPreview = null;
+    props.onRequestUpdate?.();
+  };
+  const approve = async (event: SubmitEvent) => {
+    event.preventDefault();
+    if (!props.client || viewState.distributionBusy) {
+      return;
+    }
+    viewState.distributionBusy = true;
+    props.onRequestUpdate?.();
+    try {
+      const commit = await commitWorkspaceImport(
+        props.client,
+        preview.workspaceId,
+        preview.previewId,
+      );
+      viewState.distributionPreview = null;
+      await loadWorkspace(state, props.client, { silent: true });
+      if (commit.sharingSyncError) {
+        state.actionError = `Import succeeded, but sharing sync failed: ${commit.sharingSyncError.message}`;
+      }
+    } catch (error) {
+      state.actionError = error instanceof Error ? error.message : String(error);
+    } finally {
+      viewState.distributionBusy = false;
+      props.onRequestUpdate?.();
+    }
+  };
+  return html`
+    <openclaw-modal-dialog
+      label=${t("workspaces.distribution.previewTitle")}
+      @modal-cancel=${close}
+    >
+      <form class="exec-approval-card" @submit=${approve}>
+        <div class="exec-approval-header">
+          <div class="exec-approval-title">${t("workspaces.distribution.previewTitle")}</div>
+        </div>
+        <div class="exec-approval-sub">
+          ${t("workspaces.distribution.previewSummary", {
+            tabs: preview.summary.tabs,
+            widgets: preview.summary.widgets,
+            customWidgets: preview.summary.customWidgets,
+          })}
+        </div>
+        <ul class="workspace-distribution__tabs">
+          ${preview.tabs.map(
+            (tab) => html`<li><strong>${tab.title}</strong> <code>${tab.slug}</code></li>`,
+          )}
+        </ul>
+        ${preview.summary.customWidgets > 0
+          ? html`<div class="callout warning" role="note">
+              ${t("workspaces.distribution.customPending")}
+            </div>`
+          : nothing}
+        <div class="exec-approval-actions">
+          <button
+            class="btn btn--primary"
+            type="submit"
+            data-test-id="workspace-import-approve"
+            ?disabled=${viewState.distributionBusy}
+          >
+            ${t("workspaces.distribution.approve")}
+          </button>
+          <button class="btn" type="button" @click=${close}>${t("common.cancel")}</button>
+        </div>
+      </form>
+    </openclaw-modal-dialog>
+  `;
+}
+
+function renderWorkspacesHeader(
+  props: WorkspaceProps,
+  state: WorkspaceUiState,
+  viewState: WorkspaceViewState,
+  tab: WorkspaceTab,
+): TemplateResult {
+  const workspaceId = state.workspace?.workspaceId ?? "default";
+  const exportCurrent = async () => {
+    if (!props.client || viewState.distributionBusy) {
+      return;
+    }
+    viewState.distributionBusy = true;
+    props.onRequestUpdate?.();
+    try {
+      const exported = await exportWorkspace(
+        props.client,
+        workspaceId,
+        tab.id,
+        state.distributionOwner,
+      );
+      downloadWorkspaceFile(exported.filename, exported.content);
+    } catch (error) {
+      state.actionError = error instanceof Error ? error.message : String(error);
+    } finally {
+      viewState.distributionBusy = false;
+      props.onRequestUpdate?.();
+    }
+  };
+  const selectImport = (event: Event) => {
+    const input = event.currentTarget as HTMLInputElement;
+    const file = input.files?.[0];
+    input.value = "";
+    if (!file || !props.client || viewState.distributionBusy) {
+      return;
+    }
+    viewState.distributionBusy = true;
+    props.onRequestUpdate?.();
+    void file
+      .text()
+      .then((content) => previewWorkspaceImport(props.client!, workspaceId, content))
+      .then((preview) => {
+        viewState.distributionPreview = preview;
+      })
+      .catch((error: unknown) => {
+        state.actionError = error instanceof Error ? error.message : String(error);
+      })
+      .finally(() => {
+        viewState.distributionBusy = false;
+        props.onRequestUpdate?.();
+      });
+  };
   return html`
     <div class="workspace-page-header" data-test-id="workspace-page-header">
-      <div class="page-title">${tab.title}</div>
-      <div class="page-sub">${t("workspaces.header.subtitle")}</div>
+      <div>
+        <div class="page-title">${tab.title}</div>
+        <div class="page-sub">${t("workspaces.header.subtitle")}</div>
+      </div>
+      <div class="workspace-page-header__actions">
+        <button
+          class="btn btn--small"
+          type="button"
+          data-test-id="workspace-export"
+          ?disabled=${viewState.distributionBusy}
+          @click=${exportCurrent}
+        >
+          ${t("workspaces.distribution.export")}
+        </button>
+        ${state.distributionOwner
+          ? html`<label class="btn btn--small" data-test-id="workspace-import-label">
+              ${t("workspaces.distribution.import")}
+              <input
+                class="workspace-distribution__input"
+                type="file"
+                accept="application/json,.json"
+                data-test-id="workspace-import"
+                ?disabled=${viewState.distributionBusy}
+                @change=${selectImport}
+              />
+            </label>`
+          : nothing}
+      </div>
     </div>
+    ${renderDistributionPreview(props, state, viewState)}
   `;
 }
 

--- a/ui/src/pages/teams/teams-portal.test.ts
+++ b/ui/src/pages/teams/teams-portal.test.ts
@@ -1,0 +1,937 @@
+/* @vitest-environment jsdom */
+
+import { render } from "lit";
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient, GatewayBrowserClientOptions } from "../../api/gateway.ts";
+import {
+  buildTeamsInviteLink,
+  consumeInviteCodeFromFragment,
+  isTeamsPortalPath,
+  renderTeamsPortal,
+  TeamsPortalStore,
+  type TeamsPortalGateway,
+} from "./teams-portal.ts";
+
+function authenticatedSession(expiresAt = Date.now() + 60_000) {
+  return {
+    authenticated: true as const,
+    principal: { issuer: "openclaw-local", subject: "ada", kind: "human" as const },
+    domainId: "domain-1",
+    expiresAt,
+  };
+}
+
+function tabResult(mode: "read" | "request" | "write" = "read") {
+  return {
+    workspaceId: "workspace-1",
+    workspaceVersion: 8,
+    capabilityMode: mode,
+    tab: {
+      id: "tab-1",
+      revision: 4,
+      slug: "planning",
+      title: "Planning",
+      hidden: false,
+      widgets: [{ id: "widget-1", kind: "builtin:markdown", title: "Roadmap" }],
+    },
+  };
+}
+
+function createGateway(response = tabResult()): TeamsPortalGateway & {
+  request: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+} {
+  return {
+    request: vi.fn(async () => response),
+    stop: vi.fn(),
+  };
+}
+
+function createStore(params: {
+  session?: ReturnType<typeof authenticatedSession>;
+  gateway?: ReturnType<typeof createGateway>;
+  gatewayOptions?: (options: GatewayBrowserClientOptions) => void;
+  fetcher?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+}) {
+  const gateway = params.gateway ?? createGateway();
+  const defaultFetcher = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.endsWith("/api/teams/session")) {
+      return new Response(JSON.stringify(params.session ?? authenticatedSession()), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    if (url.endsWith("/api/teams/invites/accept")) {
+      return new Response(
+        JSON.stringify({
+          session: params.session ?? authenticatedSession(),
+          destination: { workspaceId: "workspace-1", tabId: "tab-1" },
+        }),
+        { status: 201, headers: { "content-type": "application/json" } },
+      );
+    }
+    return new Response(JSON.stringify(params.session ?? authenticatedSession()), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+  const store = new TeamsPortalStore({
+    fetcher: params.fetcher ?? defaultFetcher,
+    gatewayFactory: (options) => {
+      params.gatewayOptions?.(options);
+      options.onHello?.({
+        type: "hello-ok",
+        protocol: 1,
+        auth: { role: "member", scopes: [] },
+      });
+      return gateway as unknown as GatewayBrowserClient;
+    },
+    gatewayUrl: "wss://gateway.example",
+  });
+  return { store, gateway, fetcher: params.fetcher ?? defaultFetcher };
+}
+
+describe("Teams public route", () => {
+  it("recognizes only the restricted Teams login and invite paths", () => {
+    expect(isTeamsPortalPath("/teams")).toBe("login");
+    expect(isTeamsPortalPath("/base/teams/invite")).toBe("invite");
+    expect(isTeamsPortalPath("/teams/settings")).toBeNull();
+  });
+
+  it("consumes an opaque invite from the fragment and strips it immediately", () => {
+    const replaceState = vi.fn();
+    const location = {
+      pathname: "/teams/invite",
+      search: "?workspaceId=workspace-1&tabId=tab-1",
+      hash: "#invite-secret",
+    };
+
+    const code = consumeInviteCodeFromFragment(location, { replaceState });
+
+    expect(code).toBe("invite-secret");
+    expect(replaceState).toHaveBeenCalledWith(
+      null,
+      "",
+      "/teams/invite?workspaceId=workspace-1&tabId=tab-1",
+    );
+    expect(replaceState.mock.calls.flat().join(" ")).not.toContain("invite-secret");
+  });
+
+  it("rejects invite codes supplied through the query string", () => {
+    const replaceState = vi.fn();
+
+    expect(
+      consumeInviteCodeFromFragment(
+        { pathname: "/teams/invite", search: "?code=invite-secret", hash: "" },
+        { replaceState },
+      ),
+    ).toBeNull();
+    expect(replaceState).not.toHaveBeenCalled();
+  });
+
+  it("creates one-time owner links with the invite code only in the fragment", () => {
+    const link = buildTeamsInviteLink({
+      location: { origin: "https://teams.example", pathname: "/base/teams" },
+      workspaceId: "workspace-1",
+      tabId: "tab-1",
+      code: "opaque invite code",
+    });
+
+    expect(link).toBe(
+      "https://teams.example/base/teams/invite?workspaceId=workspace-1&tabId=tab-1#opaque%20invite%20code",
+    );
+    expect(new URL(link).searchParams.has("code")).toBe(false);
+  });
+});
+
+describe("Teams portal store", () => {
+  it("connects as a member and requests only the exact shared tab", async () => {
+    let options: GatewayBrowserClientOptions | undefined;
+    const { store, gateway } = createStore({ gatewayOptions: (value) => (options = value) });
+
+    await store.start({
+      route: "login",
+      workspaceId: "workspace-1",
+      tabId: "tab-1",
+    });
+
+    expect(options).toMatchObject({ role: "member", scopes: [] });
+    expect(gateway.request).toHaveBeenCalledWith("workspaces.tab.get", {
+      workspaceId: "workspace-1",
+      id: "tab-1",
+    });
+    expect(gateway.request.mock.calls.some(([method]) => method === "workspaces.get")).toBe(false);
+  });
+
+  it("syncs owner sharing before loading the exact tab and selects that tab by default", async () => {
+    const gateway = {
+      request: vi.fn(async (method: string, params?: unknown) => {
+        if (method === "workspaces.sharing.sync") {
+          return {
+            tabs: [
+              { id: "tab-1", revision: 4, slug: "planning", title: "Planning" },
+              { id: "tab-2", revision: 2, slug: "review", title: "Review" },
+            ],
+          };
+        }
+        if (method === "workspaces.changeRequest.list") {
+          return {
+            requests: [
+              {
+                id: "request-1",
+                requester: { principalId: "ada", kind: "human" },
+                proposal: { title: "Revised planning" },
+              },
+            ],
+          };
+        }
+        return tabResult();
+      }),
+      stop: vi.fn(),
+    };
+    const fetcher = vi.fn(async (input: RequestInfo | URL) => {
+      const path = String(input);
+      if (path.endsWith("/api/teams/session")) {
+        return new Response(JSON.stringify(authenticatedSession()), { status: 200 });
+      }
+      if (path.endsWith("/api/teams/invite-presets")) {
+        return new Response(JSON.stringify({ presets: ["read"] }), { status: 200 });
+      }
+      if (path.endsWith("/api/teams/invites")) {
+        return new Response(JSON.stringify({ invites: [] }), { status: 200 });
+      }
+      throw new Error(`unexpected ${path}`);
+    });
+    const { store } = createStore({
+      fetcher,
+      gateway: gateway as unknown as ReturnType<typeof createGateway>,
+    });
+
+    await store.start({ route: "login", workspaceId: "workspace-1", tabId: "tab-1" });
+
+    expect(gateway.request).toHaveBeenNthCalledWith(1, "workspaces.sharing.sync", {
+      workspaceId: "workspace-1",
+    });
+    expect(gateway.request).toHaveBeenNthCalledWith(2, "workspaces.tab.get", {
+      workspaceId: "workspace-1",
+      id: "tab-1",
+    });
+    expect(store.snapshot.selectedShareTabId).toBe("tab-1");
+    expect(store.snapshot.shareTabs?.map((tab) => tab.id)).toEqual(["tab-1", "tab-2"]);
+    expect(gateway.request).toHaveBeenNthCalledWith(3, "workspaces.changeRequest.list", {
+      workspaceId: "workspace-1",
+      tabId: "tab-1",
+      state: "pending",
+    });
+    expect(store.snapshot.pendingChangeRequests?.[0]).toMatchObject({
+      id: "request-1",
+      requester: "ada",
+      proposedTitle: "Revised planning",
+    });
+  });
+
+  it("lets an owner decide a pending change request and refreshes the review list", async () => {
+    let listed = 0;
+    const gateway = {
+      request: vi.fn(async (method: string, params?: unknown) => {
+        if (method === "workspaces.sharing.sync") {
+          return { tabs: [{ id: "tab-1", revision: 4, slug: "planning", title: "Planning" }] };
+        }
+        if (method === "workspaces.changeRequest.list") {
+          listed += 1;
+          return listed === 1
+            ? {
+                requests: [
+                  {
+                    id: "request-1",
+                    requester: { principalId: "ada", kind: "human" },
+                    proposal: { title: "Revised planning" },
+                  },
+                ],
+              }
+            : { requests: [] };
+        }
+        if (method === "workspaces.changeRequest.decide") {
+          return {
+            workspaceId: "workspace-1",
+            applied: true,
+            tab: { ...tabResult("write").tab, revision: 5, title: "Revised planning" },
+          };
+        }
+        if (method === "workspaces.tab.update") {
+          return {
+            workspaceId: "workspace-1",
+            tab: {
+              ...tabResult("write").tab,
+              revision: 6,
+              title: (params as { patch: { title: string } }).patch.title,
+            },
+          };
+        }
+        return method === "workspaces.tab.get" ? tabResult("write") : { ok: true };
+      }),
+      stop: vi.fn(),
+    };
+    const fetcher = vi.fn(async (input: RequestInfo | URL) => {
+      const path = String(input);
+      if (path.endsWith("/api/teams/session")) {
+        return new Response(JSON.stringify(authenticatedSession()), { status: 200 });
+      }
+      if (path.endsWith("/api/teams/invite-presets")) {
+        return new Response(JSON.stringify({ presets: ["read"] }), { status: 200 });
+      }
+      if (path.endsWith("/api/teams/invites")) {
+        return new Response(JSON.stringify({ invites: [] }), { status: 200 });
+      }
+      throw new Error(`unexpected ${path}`);
+    });
+    const { store } = createStore({
+      fetcher,
+      gateway: gateway as unknown as ReturnType<typeof createGateway>,
+    });
+    await store.start({ route: "login", workspaceId: "workspace-1", tabId: "tab-1" });
+
+    await store.decideOwnerChangeRequest({ requestId: "request-1", decision: "approved" });
+
+    expect(gateway.request).toHaveBeenCalledWith("workspaces.changeRequest.decide", {
+      workspaceId: "workspace-1",
+      tabId: "tab-1",
+      requestId: "request-1",
+      decision: "approved",
+    });
+    expect(gateway.request).toHaveBeenLastCalledWith("workspaces.changeRequest.list", {
+      workspaceId: "workspace-1",
+      tabId: "tab-1",
+      state: "pending",
+    });
+    expect(store.snapshot.pendingChangeRequests).toEqual([]);
+    expect(store.snapshot.tab).toMatchObject({ revision: 5, title: "Revised planning" });
+
+    store.setDraftTitle("Owner follow-up");
+    await store.submitDraft();
+    expect(gateway.request).toHaveBeenCalledWith(
+      "workspaces.tab.update",
+      expect.objectContaining({ ifRevision: 5 }),
+    );
+  });
+
+  it("submits request-mode edits as a proposal instead of a direct write", async () => {
+    const gateway = createGateway(tabResult("request"));
+    const { store } = createStore({ gateway });
+    await store.start({ route: "login", workspaceId: "workspace-1", tabId: "tab-1" });
+
+    store.setDraftTitle("Requested title");
+    await store.submitDraft();
+
+    expect(gateway.request).toHaveBeenCalledWith(
+      "workspaces.changeRequest.create",
+      expect.objectContaining({
+        workspaceId: "workspace-1",
+        tabId: "tab-1",
+        baseRevision: 4,
+        idempotencyKey: expect.stringMatching(/^portal-/),
+        proposal: expect.objectContaining({ title: "Requested title" }),
+      }),
+    );
+    expect(gateway.request.mock.calls.some(([method]) => method === "workspaces.tab.update")).toBe(
+      false,
+    );
+  });
+
+  it("writes an exact tab id with optimistic revision in write mode", async () => {
+    const gateway = createGateway(tabResult("write"));
+    const { store } = createStore({ gateway });
+    await store.start({ route: "login", workspaceId: "workspace-1", tabId: "tab-1" });
+
+    store.setDraftTitle("Written title");
+    await store.submitDraft();
+
+    expect(gateway.request).toHaveBeenCalledWith("workspaces.tab.update", {
+      workspaceId: "workspace-1",
+      id: "tab-1",
+      ifRevision: 4,
+      patch: { title: "Written title" },
+    });
+  });
+
+  it("adopts the server revision after each write and strips untrusted tab fields", async () => {
+    let revision = 4;
+    const gateway = {
+      request: vi.fn(async (method: string, params?: unknown) => {
+        if (method === "workspaces.sharing.sync") {
+          throw new Error("member");
+        }
+        if (method === "workspaces.tab.get") {
+          return tabResult("write");
+        }
+        if (method === "workspaces.tab.update") {
+          revision += 1;
+          const title = (params as { patch: { title: string } }).patch.title;
+          return {
+            workspaceId: "workspace-1",
+            tab: {
+              ...tabResult("write").tab,
+              revision,
+              title,
+              widgets: [
+                {
+                  id: "widget-1",
+                  kind: "builtin:markdown",
+                  title: "Roadmap",
+                  props: { secret: "do-not-retain" },
+                  bindings: { source: { source: "file", path: "private.json" } },
+                },
+              ],
+            },
+          };
+        }
+        return { requests: [] };
+      }),
+      stop: vi.fn(),
+    };
+    const { store } = createStore({
+      gateway: gateway as unknown as ReturnType<typeof createGateway>,
+    });
+    await store.start({ route: "login", workspaceId: "workspace-1", tabId: "tab-1" });
+
+    store.setDraftTitle("First");
+    await store.submitDraft();
+    store.setDraftTitle("Second");
+    await store.submitDraft();
+
+    const writes = gateway.request.mock.calls.filter(
+      ([method]) => method === "workspaces.tab.update",
+    );
+    expect(writes[0]?.[1]).toMatchObject({ ifRevision: 4 });
+    expect(writes[1]?.[1]).toMatchObject({ ifRevision: 5 });
+    expect(store.snapshot.tab).toMatchObject({ revision: 6, title: "Second" });
+    expect(JSON.stringify(store.snapshot.tab)).not.toContain("do-not-retain");
+    expect(JSON.stringify(store.snapshot.tab)).not.toContain("private.json");
+  });
+
+  it("clears the cached tab on logout and session expiry", async () => {
+    const { store, fetcher } = createStore({});
+    await store.start({ route: "login", workspaceId: "workspace-1", tabId: "tab-1" });
+    expect(store.snapshot.tab?.id).toBe("tab-1");
+
+    await store.logout();
+    expect(fetcher).toHaveBeenCalledWith(
+      "/api/teams/logout",
+      expect.objectContaining({ method: "POST", credentials: "include" }),
+    );
+    expect(store.snapshot.tab).toBeNull();
+
+    const second = createStore({});
+    await second.store.start({ route: "login", workspaceId: "workspace-1", tabId: "tab-1" });
+    second.store.expireSession();
+    expect(second.store.snapshot.tab).toBeNull();
+    expect(second.store.snapshot.status).toBe("signed-out");
+  });
+
+  it("uses credentialed same-origin calls for login and invite acceptance", async () => {
+    const { store, fetcher } = createStore({});
+
+    await store.login({
+      loginLabel: "ada@example.com",
+      password: "correct horse battery staple",
+      domainId: "domain-1",
+    });
+    await store.acceptInvite({
+      code: "invite-secret",
+      loginLabel: "ada@example.com",
+      password: "correct horse battery staple",
+    });
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "/api/teams/login",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    expect(fetcher).toHaveBeenCalledWith(
+      "/api/teams/invites/accept",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  });
+
+  it("uses the server-authoritative invite destination even without URL routing hints", async () => {
+    const { store, gateway } = createStore({});
+    await store.start({ route: "invite", inviteCode: "invite-secret" });
+
+    await store.acceptInvite({
+      loginLabel: "ada@example.com",
+      password: "correct horse battery staple",
+    });
+
+    expect(gateway.request).toHaveBeenCalledWith("workspaces.tab.get", {
+      workspaceId: "workspace-1",
+      id: "tab-1",
+    });
+    expect(store.snapshot.workspaceId).toBe("workspace-1");
+    expect(store.snapshot.tabId).toBe("tab-1");
+  });
+
+  it("settles a failed pre-hello websocket instead of remaining loading", async () => {
+    let options: GatewayBrowserClientOptions | undefined;
+    const gateway = { request: vi.fn(), start: vi.fn(), stop: vi.fn() };
+    const store = new TeamsPortalStore({
+      fetcher: vi.fn(
+        async () => new Response(JSON.stringify(authenticatedSession()), { status: 200 }),
+      ),
+      gatewayFactory: (value) => {
+        options = value;
+        return gateway as unknown as GatewayBrowserClient;
+      },
+      gatewayUrl: "wss://gateway.example",
+    });
+    const start = store.start({ route: "login", workspaceId: "workspace-1", tabId: "tab-1" });
+    await vi.waitFor(() => expect(options).toBeDefined());
+    options?.onClose?.({ code: 1008, reason: "internal detail", willRetry: false });
+    await start;
+
+    expect(store.snapshot.status).toBe("error");
+    expect(store.snapshot.tab).toBeNull();
+    expect(gateway.request).not.toHaveBeenCalled();
+    expect(store.snapshot.error).not.toContain("internal detail");
+  });
+
+  it("lets an owner create a preset invite for the exact tab and revoke it", async () => {
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const path = String(input);
+      if (path.endsWith("/api/teams/session")) {
+        return new Response(JSON.stringify(authenticatedSession()), { status: 200 });
+      }
+      if (path.endsWith("/api/teams/invite-presets")) {
+        return new Response(JSON.stringify({ presets: ["read", "request", "write"] }), {
+          status: 200,
+        });
+      }
+      if (path.endsWith("/api/teams/invites") && !init?.method) {
+        return new Response(JSON.stringify({ invites: [] }), { status: 200 });
+      }
+      if (path.endsWith("/api/teams/invites") && init?.method === "POST") {
+        return new Response(
+          JSON.stringify({
+            invite: {
+              id: "invite-1",
+              preset: "write",
+              tabId: "tab-1",
+              state: "active",
+              createdAt: 1,
+              expiresAt: Date.now() + 60_000,
+            },
+            code: "one-time-code",
+          }),
+          { status: 201 },
+        );
+      }
+      if (path.endsWith("/api/teams/invites/invite-1") && init?.method === "DELETE") {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      throw new Error(`unexpected ${path}`);
+    });
+    const { store } = createStore({ fetcher });
+
+    await store.start({ route: "login", workspaceId: "workspace-1", tabId: "tab-1" });
+    await store.createOwnerInvite({ preset: "write", recipientLabel: "Ada" });
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "/api/teams/invites",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "include",
+        body: JSON.stringify({
+          workspaceId: "workspace-1",
+          tabId: "tab-1",
+          preset: "write",
+          recipientLabel: "Ada",
+        }),
+      }),
+    );
+    expect(store.snapshot.oneTimeInviteLink).toContain("#one-time-code");
+    expect(
+      new URL(store.snapshot.oneTimeInviteLink ?? "https://invalid.example").searchParams.has(
+        "code",
+      ),
+    ).toBe(false);
+    expect(store.snapshot.ownerInvites).toEqual([
+      expect.objectContaining({ id: "invite-1", preset: "write" }),
+    ]);
+
+    await store.revokeOwnerInvite("invite-1");
+    expect(fetcher).toHaveBeenCalledWith(
+      "/api/teams/invites/invite-1",
+      expect.objectContaining({ method: "DELETE", credentials: "include", body: "{}" }),
+    );
+    expect(store.snapshot.ownerInvites).toEqual([]);
+  });
+
+  it("does not show a late invite link under a newly selected tab", async () => {
+    let resolveCreate: ((response: Response) => void) | undefined;
+    const gateway = {
+      request: vi.fn(async (method: string) => {
+        if (method === "workspaces.sharing.sync") {
+          return {
+            tabs: [
+              { id: "tab-1", revision: 4, slug: "planning", title: "Planning" },
+              { id: "tab-2", revision: 1, slug: "review", title: "Review" },
+            ],
+          };
+        }
+        if (method === "workspaces.changeRequest.list") {
+          return { requests: [] };
+        }
+        return tabResult();
+      }),
+      stop: vi.fn(),
+    };
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const path = String(input);
+      if (path.endsWith("/api/teams/session")) {
+        return new Response(JSON.stringify(authenticatedSession()), { status: 200 });
+      }
+      if (path.endsWith("/api/teams/invite-presets")) {
+        return new Response(JSON.stringify({ presets: ["read"] }), { status: 200 });
+      }
+      if (path.endsWith("/api/teams/invites") && !init?.method) {
+        return new Response(JSON.stringify({ invites: [] }), { status: 200 });
+      }
+      if (path.endsWith("/api/teams/invites") && init?.method === "POST") {
+        return await new Promise<Response>((resolve) => {
+          resolveCreate = resolve;
+        });
+      }
+      throw new Error(`unexpected ${path}`);
+    });
+    const { store } = createStore({
+      fetcher,
+      gateway: gateway as unknown as ReturnType<typeof createGateway>,
+    });
+    await store.start({ route: "login", workspaceId: "workspace-1", tabId: "tab-1" });
+    const create = store.createOwnerInvite({ preset: "read" });
+    await vi.waitFor(() => expect(resolveCreate).toBeDefined());
+    store.setSelectedShareTabId("tab-2");
+    resolveCreate?.(
+      new Response(
+        JSON.stringify({
+          invite: {
+            id: "invite-a",
+            preset: "read",
+            tabId: "tab-1",
+            state: "active",
+            createdAt: 1,
+            expiresAt: Date.now() + 60_000,
+          },
+          code: "code-a",
+        }),
+        { status: 201 },
+      ),
+    );
+    await create;
+
+    expect(store.snapshot.selectedShareTabId).toBe("tab-2");
+    expect(store.snapshot.oneTimeInviteLink).toContain("#code-a");
+    expect(store.snapshot.ownerInvites?.map((invite) => invite.id)).toContain("invite-a");
+    const host = document.createElement("div");
+    render(renderTeamsPortal(store.snapshot), host);
+    expect(host.querySelector('[aria-label="One-time invite link"]')).toBeNull();
+    store.setSelectedShareTabId("tab-1");
+    render(renderTeamsPortal(store.snapshot), host);
+    expect(
+      (host.querySelector('[aria-label="One-time invite link"]') as HTMLInputElement).value,
+    ).toContain("#code-a");
+  });
+
+  it("does not let a stale tab request failure clear the newly selected tab", async () => {
+    let listCalls = 0;
+    let rejectTabA: ((error: Error) => void) | undefined;
+    let resolveTabB: ((value: unknown) => void) | undefined;
+    const gateway = {
+      request: vi.fn(async (method: string) => {
+        if (method === "workspaces.sharing.sync") {
+          return {
+            tabs: [
+              { id: "tab-1", revision: 4, slug: "planning", title: "Planning" },
+              { id: "tab-2", revision: 1, slug: "review", title: "Review" },
+            ],
+          };
+        }
+        if (method === "workspaces.changeRequest.list") {
+          listCalls += 1;
+          if (listCalls === 1) {
+            return { requests: [] };
+          }
+          if (listCalls === 2) {
+            return await new Promise((_, reject) => {
+              rejectTabA = reject;
+            });
+          }
+          return await new Promise((resolve) => {
+            resolveTabB = resolve;
+          });
+        }
+        return tabResult();
+      }),
+      stop: vi.fn(),
+    };
+    const fetcher = vi.fn(async (input: RequestInfo | URL) => {
+      const path = String(input);
+      if (path.endsWith("/api/teams/session")) {
+        return new Response(JSON.stringify(authenticatedSession()), { status: 200 });
+      }
+      if (path.endsWith("/api/teams/invite-presets")) {
+        return new Response(JSON.stringify({ presets: ["read"] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ invites: [] }), { status: 200 });
+    });
+    const { store } = createStore({
+      fetcher,
+      gateway: gateway as unknown as ReturnType<typeof createGateway>,
+    });
+    await store.start({ route: "login", workspaceId: "workspace-1", tabId: "tab-1" });
+    store.setSelectedShareTabId("tab-1");
+    store.setSelectedShareTabId("tab-2");
+    await vi.waitFor(() => {
+      expect(rejectTabA).toBeDefined();
+      expect(resolveTabB).toBeDefined();
+    });
+    resolveTabB?.({
+      requests: [
+        {
+          id: "request-b",
+          requester: { principalId: "member-b" },
+          proposal: { title: "Review B" },
+        },
+      ],
+    });
+    await vi.waitFor(() => expect(store.snapshot.pendingChangeRequests?.[0]?.id).toBe("request-b"));
+    rejectTabA?.(new Error("stale A failure"));
+    await Promise.resolve();
+
+    expect(store.snapshot.pendingChangeRequests?.[0]?.id).toBe("request-b");
+  });
+
+  it("hides owner sharing controls after a generic owner API failure without losing tab access", async () => {
+    const fetcher = vi.fn(async (input: RequestInfo | URL) => {
+      const path = String(input);
+      if (path.endsWith("/api/teams/session")) {
+        return new Response(JSON.stringify(authenticatedSession()), { status: 200 });
+      }
+      if (path.endsWith("/api/teams/invite-presets")) {
+        return new Response(JSON.stringify({ error: { message: "Not available" } }), {
+          status: 403,
+        });
+      }
+      throw new Error(`unexpected ${path}`);
+    });
+    const { store } = createStore({ fetcher });
+    await store.start({ route: "login", workspaceId: "workspace-1", tabId: "tab-1" });
+    const host = document.createElement("div");
+    render(renderTeamsPortal(store.snapshot), host);
+
+    expect(store.snapshot.tab?.id).toBe("tab-1");
+    expect(store.snapshot.ownerSharing).toBe(false);
+    expect(host.querySelector("[data-teams-owner-sharing]")).toBeNull();
+  });
+
+  it("filters owner invites to the selected tab and revokes only active links", () => {
+    const host = document.createElement("div");
+    render(
+      renderTeamsPortal({
+        status: "ready",
+        route: "login",
+        session: authenticatedSession(),
+        tab: tabResult().tab,
+        workspaceId: "workspace-1",
+        tabId: "tab-1",
+        mode: "read",
+        draftTitle: "Planning",
+        error: null,
+        ownerSharing: true,
+        selectedShareTabId: "tab-2",
+        ownerInvites: [
+          { id: "a", preset: "read", tabId: "tab-1", state: "active", createdAt: 1, expiresAt: 2 },
+          {
+            id: "b",
+            preset: "write",
+            tabId: "tab-2",
+            state: "redeemed",
+            createdAt: 1,
+            expiresAt: 2,
+          },
+        ],
+      }),
+      host,
+    );
+
+    expect(host.textContent).toContain("Write redeemed");
+    expect(host.textContent).not.toContain("Read active");
+    expect(
+      [...host.querySelectorAll("button")].some((button) => button.textContent === "Revoke"),
+    ).toBe(false);
+  });
+
+  it("clears the one-time invite link on logout and session expiry", async () => {
+    const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const path = String(input);
+      if (path.endsWith("/api/teams/session")) {
+        return new Response(JSON.stringify(authenticatedSession()), { status: 200 });
+      }
+      if (path.endsWith("/api/teams/invite-presets")) {
+        return new Response(JSON.stringify({ presets: ["read"] }), { status: 200 });
+      }
+      if (path.endsWith("/api/teams/invites") && !init?.method) {
+        return new Response(JSON.stringify({ invites: [] }), { status: 200 });
+      }
+      if (path.endsWith("/api/teams/invites") && init?.method === "POST") {
+        return new Response(
+          JSON.stringify({
+            invite: {
+              id: "invite-1",
+              preset: "read",
+              tabId: "tab-1",
+              state: "active",
+              createdAt: 1,
+              expiresAt: Date.now() + 60_000,
+            },
+            code: "one-time-code",
+          }),
+          { status: 201 },
+        );
+      }
+      if (path.endsWith("/api/teams/logout")) {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      throw new Error(`unexpected ${path}`);
+    });
+    const { store } = createStore({ fetcher });
+    await store.start({ route: "login", workspaceId: "workspace-1", tabId: "tab-1" });
+    await store.createOwnerInvite({ preset: "read" });
+
+    await store.logout();
+    expect(store.snapshot.oneTimeInviteLink).toBeNull();
+
+    await store.start({ route: "login", workspaceId: "workspace-1", tabId: "tab-1" });
+    await store.createOwnerInvite({ preset: "read" });
+    store.expireSession();
+    expect(store.snapshot.oneTimeInviteLink).toBeNull();
+  });
+
+  it("does not restore owner metadata when an in-flight response finishes after expiry", async () => {
+    let resolvePresets: ((response: Response) => void) | undefined;
+    let resolveInvites: ((response: Response) => void) | undefined;
+    const fetcher = vi.fn(async (input: RequestInfo | URL) => {
+      const path = String(input);
+      if (path.endsWith("/api/teams/session")) {
+        return new Response(JSON.stringify(authenticatedSession()), { status: 200 });
+      }
+      if (path.endsWith("/api/teams/invite-presets")) {
+        return await new Promise<Response>((resolve) => {
+          resolvePresets = resolve;
+        });
+      }
+      if (path.endsWith("/api/teams/invites")) {
+        return await new Promise<Response>((resolve) => {
+          resolveInvites = resolve;
+        });
+      }
+      throw new Error(`unexpected ${path}`);
+    });
+    const { store } = createStore({ fetcher });
+    const start = store.start({ route: "login", workspaceId: "workspace-1", tabId: "tab-1" });
+    await vi.waitFor(() => {
+      expect(resolvePresets).toBeDefined();
+      expect(resolveInvites).toBeDefined();
+    });
+
+    store.expireSession();
+    resolvePresets?.(new Response(JSON.stringify({ presets: ["write"] }), { status: 200 }));
+    resolveInvites?.(
+      new Response(
+        JSON.stringify({
+          invites: [
+            {
+              id: "late",
+              preset: "write",
+              tabId: "tab-1",
+              state: "active",
+              createdAt: 1,
+              expiresAt: Date.now() + 60_000,
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+    await start;
+
+    expect(store.snapshot.status).toBe("signed-out");
+    expect(store.snapshot.ownerSharing).toBe(false);
+    expect(store.snapshot.ownerInvites).toEqual([]);
+    expect(store.snapshot.invitePresets).toEqual([]);
+  });
+});
+
+describe("restricted Teams shell", () => {
+  it("renders no dashboard navigation and hides all edit controls in read mode", () => {
+    const host = document.createElement("div");
+    render(
+      renderTeamsPortal({
+        status: "ready",
+        route: "login",
+        session: authenticatedSession(),
+        tab: tabResult("read").tab,
+        workspaceId: "workspace-1",
+        tabId: "tab-1",
+        mode: "read",
+        draftTitle: "Planning",
+        error: null,
+      }),
+      host,
+    );
+
+    expect(host.querySelector("openclaw-app-sidebar")).toBeNull();
+    expect(host.querySelector("openclaw-settings-sidebar")).toBeNull();
+    expect(host.querySelector("openclaw-command-palette")).toBeNull();
+    expect(host.querySelector('[data-action="submit-draft"]')).toBeNull();
+    expect(host.querySelector("textarea, input[data-teams-draft]")).toBeNull();
+    expect(host.textContent).toContain("Planning");
+  });
+
+  it("redacts raw custom, file, and RPC widgets", () => {
+    const host = document.createElement("div");
+    render(
+      renderTeamsPortal({
+        status: "ready",
+        route: "login",
+        session: authenticatedSession(),
+        tab: {
+          ...tabResult("read").tab,
+          widgets: [
+            { id: "custom", kind: "custom", title: "Do not render" },
+            { id: "file", kind: "file", title: "Also hidden" },
+            { id: "rpc", kind: "rpc", title: "Never execute" },
+          ],
+        },
+        workspaceId: "workspace-1",
+        tabId: "tab-1",
+        mode: "read",
+        draftTitle: "Planning",
+        error: null,
+      }),
+      host,
+    );
+
+    expect(host.textContent).toContain("Restricted content");
+    expect(host.textContent).not.toContain("Do not render");
+    expect(host.textContent).not.toContain("Also hidden");
+    expect(host.textContent).not.toContain("Never execute");
+  });
+});

--- a/ui/src/pages/teams/teams-portal.test.ts
+++ b/ui/src/pages/teams/teams-portal.test.ts
@@ -166,7 +166,7 @@ describe("Teams portal store", () => {
 
   it("syncs owner sharing before loading the exact tab and selects that tab by default", async () => {
     const gateway = {
-      request: vi.fn(async (method: string, params?: unknown) => {
+      request: vi.fn(async (method: string, _params?: unknown) => {
         if (method === "workspaces.sharing.sync") {
           return {
             tabs: [

--- a/ui/src/pages/teams/teams-portal.ts
+++ b/ui/src/pages/teams/teams-portal.ts
@@ -1,0 +1,1370 @@
+import { html, render, type TemplateResult } from "lit";
+import { GatewayBrowserClient, type GatewayBrowserClientOptions } from "../../api/gateway.ts";
+
+export type TeamsPortalRoute = "login" | "invite";
+export type TeamsPortalMode = "read" | "request" | "write";
+
+type TeamsPrincipal = {
+  issuer: string;
+  subject: string;
+  kind: "human";
+};
+
+export type TeamsPortalSession =
+  | { authenticated: false }
+  | {
+      authenticated: true;
+      principal: TeamsPrincipal;
+      domainId: string;
+      expiresAt: number;
+    };
+
+export type TeamsPortalWidget = {
+  id: string;
+  kind: string;
+  title?: string;
+};
+
+export type TeamsInvitePreset = "read" | "request" | "write";
+
+export type TeamsOwnerInvite = {
+  id: string;
+  preset: TeamsInvitePreset;
+  tabId: string;
+  state: "active" | "redeemed" | "revoked";
+  createdAt: number;
+  expiresAt: number;
+  recipientLabel?: string;
+};
+
+export type TeamsShareTab = {
+  id: string;
+  revision: number;
+  slug: string;
+  title: string;
+};
+
+export type TeamsPendingChangeRequest = {
+  id: string;
+  requester: string;
+  proposedTitle: string;
+};
+
+export type TeamsPortalTab = {
+  id: string;
+  revision: number;
+  slug: string;
+  title: string;
+  hidden: boolean;
+  widgets: TeamsPortalWidget[];
+};
+
+type TeamsPortalTabResult = {
+  workspaceId: string;
+  capabilityMode: TeamsPortalMode;
+  tab: TeamsPortalTab;
+};
+
+export type TeamsPortalGateway = {
+  request: (method?: string, params?: unknown) => Promise<unknown>;
+  stop?: unknown;
+  start?: () => void;
+};
+
+type Fetcher = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+type TeamsPortalStoreOptions = {
+  fetcher?: Fetcher;
+  gatewayFactory?: (options: GatewayBrowserClientOptions) => GatewayBrowserClient;
+  gatewayUrl?: string;
+  portalLocation?: Pick<Location, "origin" | "pathname">;
+};
+
+export type TeamsPortalSnapshot = {
+  status: "idle" | "loading" | "ready" | "signed-out" | "error";
+  route: TeamsPortalRoute;
+  session: TeamsPortalSession | null;
+  tab: TeamsPortalTab | null;
+  workspaceId: string | null;
+  tabId: string | null;
+  mode: TeamsPortalMode | null;
+  draftTitle: string;
+  error: string | null;
+  invitePending?: boolean;
+  ownerSharing?: boolean;
+  invitePresets?: TeamsInvitePreset[];
+  ownerInvites?: TeamsOwnerInvite[];
+  oneTimeInviteLink?: string | null;
+  oneTimeInviteTabId?: string | null;
+  oneTimeInviteId?: string | null;
+  shareTabs?: TeamsShareTab[];
+  selectedShareTabId?: string | null;
+  pendingChangeRequests?: TeamsPendingChangeRequest[];
+};
+
+type StartParams = {
+  route: TeamsPortalRoute;
+  workspaceId?: string | null;
+  tabId?: string | null;
+  inviteCode?: string | null;
+};
+
+type LoginParams = {
+  loginLabel: string;
+  password: string;
+  domainId: string;
+};
+
+type InviteParams = {
+  code?: string;
+  loginLabel: string;
+  password: string;
+};
+
+function defaultGatewayUrl(): string {
+  const url = new URL(window.location.href);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  url.pathname = "/";
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
+
+function responseSession(payload: unknown): TeamsPortalSession {
+  const value =
+    payload && typeof payload === "object" && "session" in payload
+      ? (payload as { session: unknown }).session
+      : payload;
+  if (
+    !value ||
+    typeof value !== "object" ||
+    (value as { authenticated?: unknown }).authenticated !== true
+  ) {
+    return { authenticated: false };
+  }
+  const session = value as Partial<{
+    authenticated: true;
+    principal: TeamsPrincipal;
+    domainId: string;
+    expiresAt: number;
+  }>;
+  if (
+    !session.principal ||
+    typeof session.principal.issuer !== "string" ||
+    typeof session.principal.subject !== "string" ||
+    session.principal.kind !== "human" ||
+    typeof session.domainId !== "string" ||
+    !session.domainId.trim() ||
+    typeof session.expiresAt !== "number" ||
+    !Number.isFinite(session.expiresAt) ||
+    session.expiresAt <= Date.now()
+  ) {
+    return { authenticated: false };
+  }
+  return {
+    authenticated: true,
+    principal: {
+      issuer: session.principal.issuer,
+      subject: session.principal.subject,
+      kind: "human",
+    },
+    domainId: session.domainId,
+    expiresAt: session.expiresAt,
+  };
+}
+
+function responseError(payload: unknown): string {
+  if (payload && typeof payload === "object") {
+    const message = (payload as { error?: { message?: unknown } }).error?.message;
+    if (typeof message === "string" && message.trim()) {
+      return message;
+    }
+  }
+  return "Unable to complete the Teams request.";
+}
+
+function requestParam(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized || null;
+}
+
+function isInvitePreset(value: unknown): value is TeamsInvitePreset {
+  return value === "read" || value === "request" || value === "write";
+}
+
+function isInviteState(value: unknown): value is TeamsOwnerInvite["state"] {
+  return value === "active" || value === "redeemed" || value === "revoked";
+}
+
+function isPortalMode(value: unknown): value is TeamsPortalMode {
+  return value === "read" || value === "request" || value === "write";
+}
+
+function readPortalWidget(value: unknown): TeamsPortalWidget | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const widget = value as { id?: unknown; kind?: unknown; title?: unknown };
+  if (typeof widget.id !== "string" || typeof widget.kind !== "string") {
+    return undefined;
+  }
+  return {
+    id: widget.id,
+    kind: widget.kind,
+    ...(typeof widget.title === "string" ? { title: widget.title } : {}),
+  };
+}
+
+function readPortalTab(value: unknown): TeamsPortalTab | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const tab = value as Partial<TeamsPortalTab>;
+  if (
+    typeof tab.id !== "string" ||
+    !Number.isSafeInteger(tab.revision) ||
+    (tab.revision ?? 0) < 1 ||
+    typeof tab.slug !== "string" ||
+    typeof tab.title !== "string" ||
+    typeof tab.hidden !== "boolean" ||
+    !Array.isArray(tab.widgets)
+  ) {
+    return undefined;
+  }
+  const widgets = tab.widgets.map(readPortalWidget);
+  if (widgets.some((widget) => !widget)) {
+    return undefined;
+  }
+  return {
+    id: tab.id,
+    revision: tab.revision!,
+    slug: tab.slug,
+    title: tab.title,
+    hidden: tab.hidden,
+    widgets: widgets as TeamsPortalWidget[],
+  };
+}
+
+function readPortalTabResult(
+  payload: unknown,
+  expected: { workspaceId: string; tabId: string },
+): TeamsPortalTabResult {
+  const result =
+    payload && typeof payload === "object" ? (payload as Partial<TeamsPortalTabResult>) : {};
+  const tab = readPortalTab(result.tab);
+  if (
+    result.workspaceId !== expected.workspaceId ||
+    !isPortalMode(result.capabilityMode) ||
+    !tab ||
+    tab.id !== expected.tabId
+  ) {
+    throw new Error("The requested Teams tab is unavailable.");
+  }
+  return { workspaceId: expected.workspaceId, capabilityMode: result.capabilityMode, tab };
+}
+
+function readPortalTabUpdateResult(
+  payload: unknown,
+  expected: { workspaceId: string; tabId: string },
+): TeamsPortalTab {
+  const result =
+    payload && typeof payload === "object"
+      ? (payload as { workspaceId?: unknown; tab?: unknown })
+      : {};
+  const tab = readPortalTab(result.tab);
+  if (result.workspaceId !== expected.workspaceId || !tab || tab.id !== expected.tabId) {
+    throw new Error("The updated Teams tab is unavailable.");
+  }
+  return tab;
+}
+
+function readInviteDestination(
+  payload: unknown,
+): { workspaceId: string; tabId: string } | undefined {
+  const destination =
+    payload && typeof payload === "object"
+      ? (payload as { destination?: unknown }).destination
+      : undefined;
+  if (!destination || typeof destination !== "object") {
+    return undefined;
+  }
+  const value = destination as { workspaceId?: unknown; tabId?: unknown };
+  return typeof value.workspaceId === "string" &&
+    value.workspaceId.trim() &&
+    typeof value.tabId === "string" &&
+    value.tabId.trim()
+    ? { workspaceId: value.workspaceId, tabId: value.tabId }
+    : undefined;
+}
+
+function readInvitePresets(payload: unknown): TeamsInvitePreset[] {
+  const source = Array.isArray(payload)
+    ? payload
+    : payload &&
+        typeof payload === "object" &&
+        Array.isArray((payload as { presets?: unknown }).presets)
+      ? (payload as { presets: unknown[] }).presets
+      : [];
+  return source
+    .map((entry) =>
+      typeof entry === "string"
+        ? entry
+        : entry && typeof entry === "object"
+          ? ((entry as { preset?: unknown; id?: unknown }).preset ?? (entry as { id?: unknown }).id)
+          : undefined,
+    )
+    .filter(isInvitePreset);
+}
+
+function readOwnerInvites(payload: unknown): TeamsOwnerInvite[] {
+  const source = Array.isArray(payload)
+    ? payload
+    : payload &&
+        typeof payload === "object" &&
+        Array.isArray((payload as { invites?: unknown }).invites)
+      ? (payload as { invites: unknown[] }).invites
+      : payload && typeof payload === "object"
+        ? [payload]
+        : [];
+  return source.flatMap((entry) => {
+    if (!entry || typeof entry !== "object") {
+      return [];
+    }
+    const invite = entry as {
+      id?: unknown;
+      preset?: unknown;
+      tabId?: unknown;
+      state?: unknown;
+      createdAt?: unknown;
+      expiresAt?: unknown;
+      recipientLabel?: unknown;
+    };
+    if (
+      typeof invite.id !== "string" ||
+      !isInvitePreset(invite.preset) ||
+      typeof invite.tabId !== "string" ||
+      !isInviteState(invite.state) ||
+      typeof invite.createdAt !== "number" ||
+      !Number.isFinite(invite.createdAt) ||
+      typeof invite.expiresAt !== "number" ||
+      !Number.isFinite(invite.expiresAt)
+    ) {
+      return [];
+    }
+    return [
+      {
+        id: invite.id,
+        preset: invite.preset,
+        tabId: invite.tabId,
+        state: invite.state,
+        createdAt: invite.createdAt,
+        expiresAt: invite.expiresAt,
+        ...(typeof invite.recipientLabel === "string" && invite.recipientLabel.trim()
+          ? { recipientLabel: invite.recipientLabel }
+          : {}),
+      },
+    ];
+  });
+}
+
+function readShareTabs(payload: unknown): TeamsShareTab[] {
+  const source =
+    payload && typeof payload === "object" && Array.isArray((payload as { tabs?: unknown }).tabs)
+      ? (payload as { tabs: unknown[] }).tabs
+      : [];
+  return source.flatMap((entry) => {
+    if (!entry || typeof entry !== "object") {
+      return [];
+    }
+    const tab = entry as Partial<TeamsShareTab>;
+    if (
+      typeof tab.id !== "string" ||
+      typeof tab.revision !== "number" ||
+      typeof tab.slug !== "string" ||
+      typeof tab.title !== "string"
+    ) {
+      return [];
+    }
+    return [{ id: tab.id, revision: tab.revision, slug: tab.slug, title: tab.title }];
+  });
+}
+
+function readPendingChangeRequests(payload: unknown): TeamsPendingChangeRequest[] {
+  const source =
+    payload &&
+    typeof payload === "object" &&
+    Array.isArray((payload as { requests?: unknown }).requests)
+      ? (payload as { requests: unknown[] }).requests
+      : [];
+  return source.flatMap((entry) => {
+    if (!entry || typeof entry !== "object") {
+      return [];
+    }
+    const request = entry as {
+      id?: unknown;
+      requester?: { principalId?: unknown };
+      proposal?: { title?: unknown };
+    };
+    if (
+      typeof request.id !== "string" ||
+      typeof request.requester?.principalId !== "string" ||
+      typeof request.proposal?.title !== "string"
+    ) {
+      return [];
+    }
+    return [
+      {
+        id: request.id,
+        requester: request.requester.principalId,
+        proposedTitle: request.proposal.title,
+      },
+    ];
+  });
+}
+
+function portalBasePath(pathname: string): string {
+  const marker = "/teams";
+  const index = pathname.lastIndexOf(marker);
+  return index >= 0 ? pathname.slice(0, index) : "";
+}
+
+export function buildTeamsInviteLink(params: {
+  location: Pick<Location, "origin" | "pathname">;
+  workspaceId: string;
+  tabId: string;
+  code: string;
+}): string {
+  const search = new URLSearchParams({ workspaceId: params.workspaceId, tabId: params.tabId });
+  return `${params.location.origin}${portalBasePath(params.location.pathname)}/teams/invite?${search.toString()}#${encodeURIComponent(params.code)}`;
+}
+
+export function isTeamsPortalPath(pathname: string): TeamsPortalRoute | null {
+  const segments = pathname.split("/").filter(Boolean);
+  const last = segments.at(-1);
+  if (last === "teams") {
+    return "login";
+  }
+  if (last === "invite" && segments.at(-2) === "teams") {
+    return "invite";
+  }
+  return null;
+}
+
+export function consumeInviteCodeFromFragment(
+  location: Pick<Location, "pathname" | "search" | "hash">,
+  history: Pick<History, "replaceState">,
+): string | null {
+  if (!location.hash.startsWith("#") || location.hash.length <= 1) {
+    return null;
+  }
+  let code: string;
+  try {
+    code = decodeURIComponent(location.hash.slice(1));
+  } catch {
+    return null;
+  }
+  if (!code) {
+    return null;
+  }
+  history.replaceState(null, "", `${location.pathname}${location.search}`);
+  return code;
+}
+
+export class TeamsPortalStore {
+  private readonly fetcher: Fetcher;
+  private readonly gatewayFactory: (options: GatewayBrowserClientOptions) => GatewayBrowserClient;
+  private readonly gatewayUrl: string;
+  private readonly portalLocation: Pick<Location, "origin" | "pathname">;
+  private gateway: TeamsPortalGateway | null = null;
+  private expiryTimer: number | null = null;
+  private listeners = new Set<(snapshot: TeamsPortalSnapshot) => void>();
+  private inviteCode: string | null = null;
+  private lifecycleGeneration = 0;
+  private snapshotValue: TeamsPortalSnapshot = {
+    status: "idle",
+    route: "login",
+    session: null,
+    tab: null,
+    workspaceId: null,
+    tabId: null,
+    mode: null,
+    draftTitle: "",
+    error: null,
+    invitePending: false,
+    ownerSharing: false,
+    invitePresets: [],
+    ownerInvites: [],
+    oneTimeInviteLink: null,
+    oneTimeInviteTabId: null,
+    oneTimeInviteId: null,
+    shareTabs: [],
+    selectedShareTabId: null,
+    pendingChangeRequests: [],
+  };
+
+  constructor(options: TeamsPortalStoreOptions = {}) {
+    this.fetcher = options.fetcher ?? fetch;
+    this.gatewayFactory =
+      options.gatewayFactory ?? ((clientOptions) => new GatewayBrowserClient(clientOptions));
+    this.gatewayUrl = options.gatewayUrl ?? defaultGatewayUrl();
+    this.portalLocation = options.portalLocation ?? window.location;
+  }
+
+  get snapshot(): TeamsPortalSnapshot {
+    return this.snapshotValue;
+  }
+
+  subscribe(listener: (snapshot: TeamsPortalSnapshot) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  async start(params: StartParams): Promise<void> {
+    const generation = this.beginLifecycle();
+    this.inviteCode = params.inviteCode ?? null;
+    this.update({
+      status: "loading",
+      route: params.route,
+      workspaceId: requestParam(params.workspaceId),
+      tabId: requestParam(params.tabId),
+      invitePending: Boolean(this.inviteCode),
+    });
+    try {
+      const session = await this.getSession();
+      if (!this.isCurrent(generation)) {
+        return;
+      }
+      if (!session.authenticated) {
+        this.update({ status: "signed-out", session, invitePending: Boolean(this.inviteCode) });
+        return;
+      }
+      await this.useSession(session, generation);
+    } catch (error) {
+      if (this.isCurrent(generation)) {
+        this.clearPortalState();
+        this.update({ status: "error", error: errorMessage(error) });
+      }
+    }
+  }
+
+  async login(params: LoginParams): Promise<void> {
+    await this.authenticate("/api/teams/login", params);
+  }
+
+  async acceptInvite(params: InviteParams): Promise<void> {
+    const code = params.code ?? this.inviteCode;
+    this.inviteCode = null;
+    this.update({ invitePending: false });
+    if (!code) {
+      this.update({ status: "error", error: "An invite link is required." });
+      return;
+    }
+    await this.authenticate("/api/teams/invites/accept", {
+      code,
+      loginLabel: params.loginLabel,
+      password: params.password,
+    });
+  }
+
+  setDraftTitle(title: string): void {
+    if (!this.snapshotValue.tab || this.snapshotValue.mode === "read") {
+      return;
+    }
+    this.update({ draftTitle: title });
+  }
+
+  async submitDraft(): Promise<void> {
+    const generation = this.lifecycleGeneration;
+    const gateway = this.gateway;
+    const { mode, tab, workspaceId, draftTitle } = this.snapshotValue;
+    if (!gateway || !mode || !tab || !workspaceId || mode === "read") {
+      return;
+    }
+    try {
+      if (mode === "request") {
+        await gateway.request("workspaces.changeRequest.create", {
+          workspaceId,
+          tabId: tab.id,
+          baseRevision: tab.revision,
+          idempotencyKey: `portal-${crypto.randomUUID()}`,
+          proposal: { title: draftTitle },
+        });
+      } else {
+        const payload = await gateway.request("workspaces.tab.update", {
+          workspaceId,
+          id: tab.id,
+          ifRevision: tab.revision,
+          patch: { title: draftTitle },
+        });
+        const updated = readPortalTabUpdateResult(payload, { workspaceId, tabId: tab.id });
+        if (!this.isCurrent(generation) || this.gateway !== gateway) {
+          return;
+        }
+        this.update({ tab: updated, draftTitle: updated.title });
+      }
+      if (this.isCurrent(generation) && this.gateway === gateway) {
+        this.update({ error: null });
+      }
+    } catch (error) {
+      if (this.isCurrent(generation) && this.gateway === gateway) {
+        this.update({ error: errorMessage(error) });
+      }
+    }
+  }
+
+  async createOwnerInvite(params: {
+    preset: TeamsInvitePreset;
+    recipientLabel?: string;
+    tabId?: string;
+  }): Promise<void> {
+    const { ownerSharing, workspaceId } = this.snapshotValue;
+    const tabId = params.tabId ?? this.snapshotValue.selectedShareTabId;
+    if (!ownerSharing || !workspaceId || !tabId) {
+      return;
+    }
+    const recipientLabel = params.recipientLabel?.trim();
+    const generation = this.lifecycleGeneration;
+    try {
+      const payload = await this.requestJson("/api/teams/invites", "POST", {
+        workspaceId,
+        tabId,
+        preset: params.preset,
+        ...(recipientLabel ? { recipientLabel } : {}),
+      });
+      const code =
+        payload && typeof payload === "object" ? (payload as { code?: unknown }).code : undefined;
+      if (typeof code !== "string" || !code.trim()) {
+        throw new Error("The invite could not be created.");
+      }
+      const created = readOwnerInvites(
+        payload && typeof payload === "object"
+          ? (payload as { invite?: unknown }).invite
+          : undefined,
+      )[0];
+      if (
+        !this.isCurrent(generation) ||
+        !created ||
+        created.tabId !== tabId ||
+        created.state !== "active"
+      ) {
+        if (this.isCurrent(generation)) {
+          throw new Error("The invite could not be created.");
+        }
+        return;
+      }
+      this.update({
+        oneTimeInviteLink: buildTeamsInviteLink({
+          location: this.portalLocation,
+          workspaceId,
+          tabId,
+          code,
+        }),
+        oneTimeInviteTabId: tabId,
+        oneTimeInviteId: created.id,
+        ownerInvites: [...(this.snapshotValue.ownerInvites ?? []), created],
+        error: null,
+      });
+    } catch (error) {
+      if (this.isCurrent(generation)) {
+        this.update({ error: errorMessage(error) });
+      }
+    }
+  }
+
+  setSelectedShareTabId(tabId: string): void {
+    if ((this.snapshotValue.shareTabs ?? []).some((tab) => tab.id === tabId)) {
+      this.update({ selectedShareTabId: tabId });
+      void this.refreshPendingChangeRequests(tabId, this.lifecycleGeneration);
+    }
+  }
+
+  async decideOwnerChangeRequest(params: {
+    requestId: string;
+    decision: "approved" | "rejected";
+  }): Promise<void> {
+    const gateway = this.gateway;
+    const { ownerSharing, workspaceId, selectedShareTabId } = this.snapshotValue;
+    const generation = this.lifecycleGeneration;
+    if (
+      !gateway ||
+      !ownerSharing ||
+      !workspaceId ||
+      !selectedShareTabId ||
+      !params.requestId.trim()
+    ) {
+      return;
+    }
+    try {
+      const payload = await gateway.request("workspaces.changeRequest.decide", {
+        workspaceId,
+        tabId: selectedShareTabId,
+        requestId: params.requestId,
+        decision: params.decision,
+      });
+      if (!this.isCurrent(generation) || this.gateway !== gateway) {
+        return;
+      }
+      if (
+        params.decision === "approved" &&
+        payload &&
+        typeof payload === "object" &&
+        (payload as { applied?: unknown }).applied === true
+      ) {
+        const updated = readPortalTabUpdateResult(payload, {
+          workspaceId,
+          tabId: selectedShareTabId,
+        });
+        this.update({
+          ...(this.snapshotValue.tab?.id === selectedShareTabId
+            ? { tab: updated, draftTitle: updated.title }
+            : {}),
+          shareTabs: (this.snapshotValue.shareTabs ?? []).map((tab) =>
+            tab.id === updated.id
+              ? {
+                  id: updated.id,
+                  revision: updated.revision,
+                  slug: updated.slug,
+                  title: updated.title,
+                }
+              : tab,
+          ),
+        });
+      }
+      await this.refreshPendingChangeRequests(selectedShareTabId, generation);
+      if (this.isCurrent(generation) && this.gateway === gateway) {
+        this.update({ error: null });
+      }
+    } catch (error) {
+      if (this.isCurrent(generation) && this.gateway === gateway) {
+        this.update({ error: errorMessage(error) });
+      }
+    }
+  }
+
+  async revokeOwnerInvite(id: string): Promise<void> {
+    if (!this.snapshotValue.ownerSharing || !id.trim()) {
+      return;
+    }
+    const generation = this.lifecycleGeneration;
+    try {
+      await this.requestJson(`/api/teams/invites/${encodeURIComponent(id)}`, "DELETE", {});
+      if (!this.isCurrent(generation)) {
+        return;
+      }
+      this.update({
+        ownerInvites: (this.snapshotValue.ownerInvites ?? []).filter((invite) => invite.id !== id),
+        ...(this.snapshotValue.oneTimeInviteId === id
+          ? { oneTimeInviteLink: null, oneTimeInviteTabId: null, oneTimeInviteId: null }
+          : {}),
+        error: null,
+      });
+    } catch (error) {
+      if (this.isCurrent(generation)) {
+        this.update({ error: errorMessage(error) });
+      }
+    }
+  }
+
+  async logout(): Promise<void> {
+    this.invalidateLifecycle();
+    this.update({ status: "signed-out", session: { authenticated: false } });
+    try {
+      await this.post("/api/teams/logout", {});
+    } catch {
+      // Local authority is cleared immediately; logout remains best effort.
+    }
+  }
+
+  expireSession(): void {
+    this.invalidateLifecycle();
+    this.update({ status: "signed-out", session: { authenticated: false } });
+  }
+
+  dispose(): void {
+    this.invalidateLifecycle();
+    this.listeners.clear();
+  }
+
+  clearOneTimeInviteLink(): void {
+    if (this.snapshotValue.oneTimeInviteLink) {
+      this.update({ oneTimeInviteLink: null, oneTimeInviteTabId: null, oneTimeInviteId: null });
+    }
+  }
+
+  private async authenticate(path: "/api/teams/login" | "/api/teams/invites/accept", body: object) {
+    const generation = this.beginLifecycle();
+    this.update({ status: "loading", error: null });
+    try {
+      const payload = await this.post(path, body);
+      if (!this.isCurrent(generation)) {
+        return;
+      }
+      if (path === "/api/teams/invites/accept") {
+        const destination = readInviteDestination(payload);
+        if (!destination) {
+          throw new Error("The invite destination is unavailable.");
+        }
+        this.update({ workspaceId: destination.workspaceId, tabId: destination.tabId });
+      }
+      const session = responseSession(payload);
+      if (!session.authenticated) {
+        this.update({ status: "signed-out", session, error: "Authentication was not accepted." });
+        return;
+      }
+      await this.useSession(session, generation);
+    } catch (error) {
+      if (this.isCurrent(generation)) {
+        this.clearPortalState();
+        this.update({ status: "error", error: errorMessage(error) });
+      }
+    }
+  }
+
+  private async getSession(): Promise<TeamsPortalSession> {
+    const response = await this.fetcher("/api/teams/session", { credentials: "include" });
+    const payload = await response.json();
+    if (!response.ok) {
+      throw new Error(responseError(payload));
+    }
+    return responseSession(payload);
+  }
+
+  private async post(path: string, body: object): Promise<unknown> {
+    return await this.requestJson(path, "POST", body);
+  }
+
+  private async get(path: string): Promise<unknown> {
+    const response = await this.fetcher(path, { credentials: "include" });
+    const payload = await response.json();
+    if (!response.ok) {
+      throw new Error(responseError(payload));
+    }
+    return payload;
+  }
+
+  private async requestJson(
+    path: string,
+    method: "POST" | "DELETE",
+    body: object,
+  ): Promise<unknown> {
+    const response = await this.fetcher(path, {
+      method,
+      credentials: "include",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const payload = await response.json();
+    if (!response.ok) {
+      throw new Error(responseError(payload));
+    }
+    return payload;
+  }
+
+  private async refreshOwnerSharing(generation: number): Promise<void> {
+    try {
+      const [presets, invites] = await Promise.all([
+        this.get("/api/teams/invite-presets"),
+        this.get("/api/teams/invites"),
+      ]);
+      if (!this.isCurrent(generation)) {
+        return;
+      }
+      this.update({
+        ownerSharing: true,
+        invitePresets: readInvitePresets(presets),
+        ownerInvites: readOwnerInvites(invites),
+      });
+    } catch {
+      // Owner-only endpoints intentionally fail generically for members. Their
+      // shared tab remains available; only the owner controls disappear.
+      if (this.isCurrent(generation)) {
+        this.update({
+          ownerSharing: false,
+          invitePresets: [],
+          ownerInvites: [],
+          oneTimeInviteLink: null,
+          oneTimeInviteTabId: null,
+          oneTimeInviteId: null,
+        });
+      }
+    }
+  }
+
+  private async refreshPendingChangeRequests(tabId: string, generation: number): Promise<void> {
+    const gateway = this.gateway;
+    const workspaceId = this.snapshotValue.workspaceId;
+    if (!gateway || !workspaceId) {
+      return;
+    }
+    try {
+      const payload = await gateway.request("workspaces.changeRequest.list", {
+        workspaceId,
+        tabId,
+        state: "pending",
+      });
+      if (
+        this.isCurrent(generation) &&
+        this.gateway === gateway &&
+        this.snapshotValue.selectedShareTabId === tabId
+      ) {
+        this.update({ pendingChangeRequests: readPendingChangeRequests(payload) });
+      }
+    } catch {
+      if (
+        this.isCurrent(generation) &&
+        this.gateway === gateway &&
+        this.snapshotValue.selectedShareTabId === tabId
+      ) {
+        this.update({ pendingChangeRequests: [] });
+      }
+    }
+  }
+
+  private async useSession(
+    session: Extract<TeamsPortalSession, { authenticated: true }>,
+    generation: number,
+  ): Promise<void> {
+    this.update({ session, status: "loading", error: null });
+    this.armExpiry(session.expiresAt);
+    const workspaceId = this.snapshotValue.workspaceId;
+    const tabId = this.snapshotValue.tabId;
+    if (!workspaceId || !tabId) {
+      this.update({ status: "ready" });
+      return;
+    }
+    let resolveHello: (() => void) | undefined;
+    let rejectHello: ((error: Error) => void) | undefined;
+    let helloComplete = false;
+    let helloBeforeAssignment = false;
+    let closeBeforeAssignment = false;
+    let gateway: TeamsPortalGateway | null = null;
+    const hello = new Promise<void>((resolve, reject) => {
+      resolveHello = resolve;
+      rejectHello = reject;
+    });
+    const previousGateway = this.gateway;
+    this.gateway = null;
+    if (typeof previousGateway?.stop === "function") {
+      previousGateway.stop();
+    }
+    const createdGateway = this.gatewayFactory({
+      url: this.gatewayUrl,
+      role: "member",
+      scopes: [],
+      caps: [],
+      onHello: () => {
+        if (!helloComplete && this.isCurrent(generation)) {
+          helloComplete = true;
+          if (gateway && this.gateway === gateway) {
+            resolveHello?.();
+          } else {
+            helloBeforeAssignment = true;
+          }
+        }
+      },
+      onClose: () => {
+        if (!gateway) {
+          closeBeforeAssignment = true;
+          return;
+        }
+        if (!this.isCurrent(generation) || this.gateway !== gateway) {
+          return;
+        }
+        if (!helloComplete) {
+          helloComplete = true;
+          rejectHello?.(new Error("The Teams connection could not be established."));
+          return;
+        }
+        this.invalidateLifecycle();
+        this.update({ status: "error", error: "The Teams connection was lost." });
+      },
+    }) as TeamsPortalGateway;
+    gateway = createdGateway;
+    this.gateway = gateway;
+    if (closeBeforeAssignment && !helloComplete) {
+      helloComplete = true;
+      rejectHello?.(new Error("The Teams connection could not be established."));
+    } else if (helloBeforeAssignment) {
+      resolveHello?.();
+    }
+    gateway.start?.();
+    await hello;
+    if (
+      !this.isCurrent(generation) ||
+      this.gateway !== gateway ||
+      !this.snapshotValue.session?.authenticated
+    ) {
+      return;
+    }
+    // Canonical owners register tabs before inviting people to them. A member
+    // can still load its exact shared tab when the owner-only sync is denied.
+    const sharingSync = await gateway
+      .request("workspaces.sharing.sync", { workspaceId })
+      .catch(() => null);
+    const result = readPortalTabResult(
+      await gateway.request("workspaces.tab.get", {
+        workspaceId,
+        id: tabId,
+      }),
+      { workspaceId, tabId },
+    );
+    if (!this.isCurrent(generation) || this.gateway !== gateway) {
+      return;
+    }
+    this.update({
+      status: "ready",
+      tab: result.tab,
+      mode: result.capabilityMode,
+      draftTitle: result.tab.title,
+      error: null,
+      shareTabs: readShareTabs(sharingSync),
+      selectedShareTabId: tabId,
+    });
+    await this.refreshOwnerSharing(generation);
+    if (sharingSync !== null) {
+      await this.refreshPendingChangeRequests(tabId, generation);
+    }
+  }
+
+  private armExpiry(expiresAt: number): void {
+    this.clearExpiryTimer();
+    if (!Number.isFinite(expiresAt)) {
+      return;
+    }
+    this.expiryTimer = window.setTimeout(
+      () => this.expireSession(),
+      Math.max(0, expiresAt - Date.now()),
+    );
+  }
+
+  private clearPortalState(): void {
+    this.clearExpiryTimer();
+    const gateway = this.gateway;
+    this.gateway = null;
+    if (typeof gateway?.stop === "function") {
+      gateway.stop();
+    }
+    this.inviteCode = null;
+    this.snapshotValue = {
+      ...this.snapshotValue,
+      session: null,
+      tab: null,
+      mode: null,
+      draftTitle: "",
+      error: null,
+      invitePending: false,
+      ownerSharing: false,
+      invitePresets: [],
+      ownerInvites: [],
+      oneTimeInviteLink: null,
+      oneTimeInviteTabId: null,
+      oneTimeInviteId: null,
+      shareTabs: [],
+      selectedShareTabId: null,
+      pendingChangeRequests: [],
+    };
+  }
+
+  private beginLifecycle(): number {
+    this.lifecycleGeneration += 1;
+    this.clearPortalState();
+    return this.lifecycleGeneration;
+  }
+
+  private invalidateLifecycle(): void {
+    this.lifecycleGeneration += 1;
+    this.clearPortalState();
+  }
+
+  private isCurrent(generation: number): boolean {
+    return generation === this.lifecycleGeneration;
+  }
+
+  private clearExpiryTimer(): void {
+    if (this.expiryTimer !== null) {
+      window.clearTimeout(this.expiryTimer);
+      this.expiryTimer = null;
+    }
+  }
+
+  private update(patch: Partial<TeamsPortalSnapshot>): void {
+    this.snapshotValue = { ...this.snapshotValue, ...patch };
+    for (const listener of this.listeners) {
+      listener(this.snapshotValue);
+    }
+  }
+}
+
+type TeamsPortalActions = {
+  onLogin?: (params: LoginParams) => void;
+  onAcceptInvite?: (params: Omit<InviteParams, "code">) => void;
+  onDraftTitle?: (title: string) => void;
+  onSubmitDraft?: () => void;
+  onLogout?: () => void;
+  onCreateOwnerInvite?: (params: { preset: TeamsInvitePreset; recipientLabel?: string }) => void;
+  onRevokeOwnerInvite?: (id: string) => void;
+  onSelectShareTab?: (tabId: string) => void;
+  onDecideChangeRequest?: (params: {
+    requestId: string;
+    decision: "approved" | "rejected";
+  }) => void;
+};
+
+function formValues(event: SubmitEvent): {
+  loginLabel: string;
+  password: string;
+  domainId: string;
+} {
+  const values = new FormData(event.currentTarget as HTMLFormElement);
+  return {
+    loginLabel: String(values.get("loginLabel") ?? ""),
+    password: String(values.get("password") ?? ""),
+    domainId: String(values.get("domainId") ?? ""),
+  };
+}
+
+function renderWidget(widget: TeamsPortalWidget): TemplateResult {
+  if (!["builtin:markdown", "builtin:stat-card", "builtin:table"].includes(widget.kind)) {
+    return html`<li data-teams-widget="restricted">Restricted content</li>`;
+  }
+  return html`<li data-teams-widget=${widget.kind}>${widget.title ?? "Untitled widget"}</li>`;
+}
+
+function presetLabel(preset: TeamsInvitePreset): string {
+  return preset === "read" ? "Read" : preset === "request" ? "Request changes" : "Write";
+}
+
+export function renderTeamsPortal(
+  snapshot: TeamsPortalSnapshot,
+  actions: TeamsPortalActions = {},
+): TemplateResult {
+  const editable = snapshot.mode === "request" || snapshot.mode === "write";
+  const submitLabel = snapshot.mode === "request" ? "Request change" : "Save change";
+  const visibleInvites = (snapshot.ownerInvites ?? []).filter(
+    (invite) => invite.tabId === snapshot.selectedShareTabId,
+  );
+  const visibleOneTimeInviteLink =
+    snapshot.oneTimeInviteTabId === snapshot.selectedShareTabId ? snapshot.oneTimeInviteLink : null;
+  return html`
+    <main class="teams-portal" aria-live="polite">
+      <header>
+        <h1>Teams</h1>
+        ${snapshot.session?.authenticated
+          ? html`<button @click=${actions.onLogout}>Log out</button>`
+          : ""}
+      </header>
+      ${snapshot.error ? html`<p role="alert">${snapshot.error}</p>` : ""}
+      ${snapshot.status === "loading" ? html`<p>Loading…</p>` : ""}
+      ${snapshot.status === "signed-out" && snapshot.route === "invite" && snapshot.invitePending
+        ? html`<form
+            @submit=${(event: SubmitEvent) => {
+              event.preventDefault();
+              const values = formValues(event);
+              actions.onAcceptInvite?.({
+                loginLabel: values.loginLabel,
+                password: values.password,
+              });
+            }}
+          >
+            <label>Email <input name="loginLabel" autocomplete="username" required /></label>
+            <label
+              >Password <input name="password" type="password" autocomplete="new-password" required
+            /></label>
+            <button type="submit">Accept invite</button>
+          </form>`
+        : ""}
+      ${snapshot.status === "signed-out" && (!snapshot.invitePending || snapshot.route === "login")
+        ? html`<form
+            @submit=${(event: SubmitEvent) => {
+              event.preventDefault();
+              const values = formValues(event);
+              actions.onLogin?.(values);
+            }}
+          >
+            <label>Email <input name="loginLabel" autocomplete="username" required /></label>
+            <label
+              >Password
+              <input name="password" type="password" autocomplete="current-password" required
+            /></label>
+            <label>Domain <input name="domainId" required /></label>
+            <button type="submit">Log in</button>
+          </form>`
+        : ""}
+      ${snapshot.tab
+        ? html`<section>
+            <h2>${snapshot.tab.title}</h2>
+            <ul>
+              ${snapshot.tab.widgets.map(renderWidget)}
+            </ul>
+            ${editable
+              ? html`<label
+                    >Title
+                    <input
+                      data-teams-draft
+                      .value=${snapshot.draftTitle}
+                      @input=${(event: InputEvent) =>
+                        actions.onDraftTitle?.((event.target as HTMLInputElement).value)}
+                    />
+                  </label>
+                  <button data-action="submit-draft" @click=${actions.onSubmitDraft}>
+                    ${submitLabel}
+                  </button>`
+              : ""}
+            ${snapshot.ownerSharing
+              ? html`<section data-teams-owner-sharing aria-label="Share this tab">
+                  <h3>Share this tab</h3>
+                  <form
+                    @submit=${(event: SubmitEvent) => {
+                      event.preventDefault();
+                      const values = new FormData(event.currentTarget as HTMLFormElement);
+                      const preset = values.get("preset");
+                      if (!isInvitePreset(preset)) {
+                        return;
+                      }
+                      const recipientLabel = String(values.get("recipientLabel") ?? "").trim();
+                      actions.onCreateOwnerInvite?.({
+                        preset,
+                        ...(recipientLabel ? { recipientLabel } : {}),
+                      });
+                    }}
+                  >
+                    <label
+                      >Access
+                      <select name="preset" required>
+                        ${(snapshot.invitePresets ?? []).map(
+                          (preset) => html`<option value=${preset}>${presetLabel(preset)}</option>`,
+                        )}
+                      </select>
+                    </label>
+                    <label
+                      >Tab
+                      <select
+                        data-teams-share-tab
+                        .value=${snapshot.selectedShareTabId ?? ""}
+                        @change=${(event: Event) =>
+                          actions.onSelectShareTab?.((event.target as HTMLSelectElement).value)}
+                      >
+                        ${(snapshot.shareTabs ?? []).map(
+                          (tab) => html`<option value=${tab.id}>${tab.title}</option>`,
+                        )}
+                      </select>
+                    </label>
+                    <label
+                      >Recipient (optional) <input name="recipientLabel" autocomplete="off"
+                    /></label>
+                    <button type="submit">Create invite</button>
+                  </form>
+                  ${visibleOneTimeInviteLink
+                    ? html`<label
+                        >One-time invite link
+                        <input
+                          readonly
+                          .value=${visibleOneTimeInviteLink}
+                          aria-label="One-time invite link"
+                        />
+                      </label>`
+                    : ""}
+                  <ul>
+                    ${visibleInvites.map(
+                      (invite) => html`<li>
+                        ${presetLabel(invite.preset)}
+                        ${invite.state}${invite.recipientLabel
+                          ? ` for ${invite.recipientLabel}`
+                          : ""}
+                        ${invite.state === "active"
+                          ? html`<button @click=${() => actions.onRevokeOwnerInvite?.(invite.id)}>
+                              Revoke
+                            </button>`
+                          : ""}
+                      </li>`,
+                    )}
+                  </ul>
+                  ${(snapshot.pendingChangeRequests ?? []).length
+                    ? html`<h4>Pending changes</h4>
+                        <ul>
+                          ${(snapshot.pendingChangeRequests ?? []).map(
+                            (request) => html`<li>
+                              ${request.requester} requested “${request.proposedTitle}”
+                              <button
+                                @click=${() =>
+                                  actions.onDecideChangeRequest?.({
+                                    requestId: request.id,
+                                    decision: "approved",
+                                  })}
+                              >
+                                Approve
+                              </button>
+                              <button
+                                @click=${() =>
+                                  actions.onDecideChangeRequest?.({
+                                    requestId: request.id,
+                                    decision: "rejected",
+                                  })}
+                              >
+                                Reject
+                              </button>
+                            </li>`,
+                          )}
+                        </ul>`
+                    : ""}
+                </section>`
+              : ""}
+          </section>`
+        : ""}
+    </main>
+  `;
+}
+
+export function mountTeamsPortal(params: {
+  host: HTMLElement;
+  route: TeamsPortalRoute;
+  location?: Pick<Location, "pathname" | "search" | "hash">;
+  history?: Pick<History, "replaceState">;
+}): () => void {
+  const location = params.location ?? window.location;
+  const history = params.history ?? window.history;
+  const search = new URLSearchParams(location.search);
+  const store = new TeamsPortalStore();
+  const redraw = () => {
+    render(
+      renderTeamsPortal(store.snapshot, {
+        onLogin: (input) => void store.login(input),
+        onAcceptInvite: (input) => void store.acceptInvite(input),
+        onDraftTitle: (title) => store.setDraftTitle(title),
+        onSubmitDraft: () => void store.submitDraft(),
+        onLogout: () => void store.logout(),
+        onCreateOwnerInvite: (input) => void store.createOwnerInvite(input),
+        onRevokeOwnerInvite: (id) => void store.revokeOwnerInvite(id),
+        onSelectShareTab: (tabId) => store.setSelectedShareTabId(tabId),
+        onDecideChangeRequest: (input) => void store.decideOwnerChangeRequest(input),
+      }),
+      params.host,
+    );
+  };
+  const unsubscribe = store.subscribe(redraw);
+  redraw();
+  const inviteCode =
+    params.route === "invite" ? consumeInviteCodeFromFragment(location, history) : null;
+  void store.start({
+    route: params.route,
+    workspaceId: search.get("workspaceId"),
+    tabId: search.get("tabId"),
+    inviteCode,
+  });
+  const clearOneTimeInviteLink = () => store.clearOneTimeInviteLink();
+  window.addEventListener("pagehide", clearOneTimeInviteLink);
+  window.addEventListener("popstate", clearOneTimeInviteLink);
+  return () => {
+    unsubscribe();
+    window.removeEventListener("pagehide", clearOneTimeInviteLink);
+    window.removeEventListener("popstate", clearOneTimeInviteLink);
+    store.dispose();
+    render(null, params.host);
+  };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error && error.message
+    ? error.message
+    : "Unable to load the Teams portal.";
+}

--- a/ui/src/pages/teams/teams-portal.ts
+++ b/ui/src/pages/teams/teams-portal.ts
@@ -1267,8 +1267,7 @@ export function renderTeamsPortal(
                   <ul>
                     ${visibleInvites.map(
                       (invite) => html`<li>
-                        ${presetLabel(invite.preset)}
-                        ${invite.state}${invite.recipientLabel
+                        ${`${presetLabel(invite.preset)} ${invite.state}`}${invite.recipientLabel
                           ? ` for ${invite.recipientLabel}`
                           : ""}
                         ${invite.state === "active"

--- a/ui/src/styles/workspace.css
+++ b/ui/src/styles/workspace.css
@@ -25,6 +25,27 @@
   gap: 2px;
 }
 
+.workspace-page-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.workspace-distribution__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.workspace-distribution__tabs {
+  margin: 12px 0;
+  padding-left: 20px;
+}
+
 /* --- Tab strip ----------------------------------------------------------- */
 
 .workspace-tabs {


### PR DESCRIPTION
## What Problem This Solves

Workspace owners need a safe way to move a dashboard layout between installations without exporting private data, preserving authorization by accident, or letting imported custom code become executable. The previous distribution work predated the first-class Teams tenant, principal, and exact-resource grant contracts and could not safely distinguish an owner export from a member's exact shared-tab export.

## Why This Change Was Made

This rebuild makes distribution a Workspaces-owned, authorization-aware workflow:

- canonical workspace owners may export the layout for the full workspace;
- external members may export only the exact tab granted to their Teams principal;
- exports are versioned and layout-only: bindings, opaque widget props, credentials, grants, presence, and session data are not included;
- imports are owner-only and use a bounded preview followed by an explicit commit;
- preview state is short-lived and bound to the owner, isolation domain, workspace, and source workspace version;
- imported tabs, widgets, slugs, and custom-widget namespaces receive fresh collision-safe identities;
- imported custom widgets always return to `pending` approval and cannot inherit an executable snapshot;
- an agent-facing `WORKSPACE-DESIGN.md` documents the review/refine loop and distribution security contract; it is guidance only and cannot grant access or approve custom widgets;
- the commit preserves tab order, performs bounded capacity eviction only when a reserved slot is needed, and synchronizes the new tab inventory with the canonical Teams resource registry;
- a post-commit sharing-sync failure is returned as a warning after the durable import succeeds, rather than falsely reporting the import as rolled back;
- a `?ws=` deep link selects presentation state only and is never accepted as authorization input.

The implementation reuses the Teams resource-specific owner signal and exact-tab authorization rather than creating a second distribution permission model.

## User Impact

Owners can review and import a shared workspace package without exposing workspace data or silently trusting custom code. Team members can carry away only the tab they were actually granted. Imported layouts remain useful, while every security-sensitive identity and approval is regenerated locally.

## Evidence

- Restacked onto Teams foundation `d3ca7fa6ccf9b80eb52b310f956a35112561a0cd`, based on upstream main `7da28f370476ef53c025f37339c1b128f6ed3933` captured `2026-07-13T09:16:13Z`; both feature commits range-diff identically.
- Focused Workspaces proof: 25 extension tests and 49 UI tests passed (74 total), including owner/member export boundaries, preview binding, collision handling, capacity eviction, tab-order preservation, pending custom widgets, sharing-sync warnings, and deep-link authorization isolation.
- `pnpm tsgo:extensions`, scoped Oxlint, and `git diff --check` passed.
- Structured review findings were classified under the scope governor and all accepted distribution correctness/security findings were fixed with regression coverage.
- No dependency or lockfile change remains in the rebuilt branch.
- Only the English source locale changes here; generated non-English locale bundles remain owned by the authenticated post-merge locale refresh workflow.

Closes #101155. Addresses #101154. Partially addresses #101156.
