### PR TITLE
refactor(plugins): localize internal helper types

### DIFF
--- a/extensions/clickclack/src/activity.ts
+++ b/extensions/clickclack/src/activity.ts
@@ -22,7 +22,7 @@ import type { ClickClackMessage, ClickClackMessageProvenance } from "./types.js"
 const CLICKCLACK_COMMENTARY_FLUSH_MS = 700;
 
 /** Item event payload shape delivered by `replyOptions.onItemEvent`. */
-export type ClickClackItemEventPayload = {
+type ClickClackItemEventPayload = {
   itemId?: string;
   toolCallId?: string;
   kind?: string;
@@ -36,7 +36,7 @@ export type ClickClackItemEventPayload = {
 };
 
 /** Destination for durable activity rows (channel or DM conversation). */
-export type ClickClackActivityTarget = {
+type ClickClackActivityTarget = {
   channelId?: string;
   conversationId?: string;
 };

--- a/extensions/clickclack/src/types.ts
+++ b/extensions/clickclack/src/types.ts
@@ -25,7 +25,7 @@ export type ClickClackAccountConfig = {
 };
 
 /** Root ClickClack channel config with optional named accounts. */
-export type ClickClackConfig = ClickClackAccountConfig & {
+type ClickClackConfig = ClickClackAccountConfig & {
   accounts?: Record<string, Partial<ClickClackAccountConfig>>;
   defaultAccount?: string;
 };

--- a/extensions/logbook/src/analyze.ts
+++ b/extensions/logbook/src/analyze.ts
@@ -11,7 +11,7 @@ const BATCH_MAX_GAP_MS = 2 * 60 * 1000;
 /** Upper bound of images sent to the vision model per batch. */
 export const MAX_FRAMES_PER_CALL = 16;
 
-export type ParsedSegment = { startMs: number; endMs: number; text: string };
+type ParsedSegment = { startMs: number; endMs: number; text: string };
 
 /** Parses "HH:MM:SS" (or "H:MM", with optional am/pm) on a local day into epoch ms. */
 export function clockToMs(day: string, clock: string): number | null {
@@ -120,9 +120,7 @@ type RawCard = {
   appSites?: unknown;
 };
 
-export type CardParseResult =
-  | { ok: true; drafts: LogbookCardDraft[] }
-  | { ok: false; error: string };
+type CardParseResult = { ok: true; drafts: LogbookCardDraft[] } | { ok: false; error: string };
 
 function normalizeCategory(value: unknown): string {
   const category = typeof value === "string" ? value.trim().toLowerCase() : "";

--- a/extensions/logbook/src/node-host.ts
+++ b/extensions/logbook/src/node-host.ts
@@ -16,7 +16,7 @@ type LogbookSnapshotParams = {
   quality?: number;
 };
 
-export type LogbookSnapshotPayload = { format: "jpeg"; base64: string } | { error: string };
+type LogbookSnapshotPayload = { format: "jpeg"; base64: string } | { error: string };
 
 function readParams(value: unknown): LogbookSnapshotParams {
   if (!value || typeof value !== "object") {

--- a/extensions/logbook/src/service.ts
+++ b/extensions/logbook/src/service.ts
@@ -73,7 +73,7 @@ function unwrapInvokePayload(raw: unknown): SnapshotPayload | null {
 /** Capture commands in preference order: app nodes first, headless node hosts second. */
 const CAPTURE_COMMANDS = ["screen.snapshot", "logbook.snapshot"] as const;
 
-export type LogbookStatus = {
+type LogbookStatus = {
   captureEnabled: boolean;
   capturePaused: boolean;
   captureIntervalSeconds: number;


### PR DESCRIPTION
## What Problem This Solves

Removes stale internal type exports from ClickClack and Logbook modules that had no consumers outside their defining files.

## Why This Change Was Made

The affected types remain local implementation details. ClickClack's explicit public API barrels do not expose them, and Logbook is a private plugin, so narrowing visibility removes dead module surface without changing runtime behavior.

## User Impact

No user-visible behavior changes. The plugin modules expose a smaller, more accurate internal API.

## Evidence

- `OPENCLAW_TESTBOX=1 pnpm check:changed` equivalent on Testbox `tbx_01kwzghwwsgqsd212tepxyzy6h`
- `pnpm test:serial extensions/clickclack extensions/logbook`: 11 files, 88 tests passed
- `pnpm build`
- local autoreview: clean, 0.90 confidence
- branch autoreview: clean, 0.93 confidence
- codebase-memory graph: 21,043 files, 281,316 nodes, 1,134,607 edges
