### PR TITLE
fix: stop doctor schema errors for video model inputs

### DIFF
--- a/src/agents/sessions/model-registry.test.ts
+++ b/src/agents/sessions/model-registry.test.ts
@@ -174,6 +174,43 @@ describe("ModelRegistry models.json auth", () => {
     expect(registry.find("zai", "glm-5.1")?.name).toBe("GLM 5.1");
   });
 
+  it("accepts audio and video input modalities from generated plugin catalog shards", () => {
+    const modelsPath = writeModelsJsonWithPluginCatalog({
+      root: { providers: {} },
+      pluginRelativePath: join("plugins", "openrouter", PLUGIN_MODEL_CATALOG_FILE),
+      pluginCatalog: {
+        generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+        providers: {
+          openrouter: {
+            baseUrl: "https://openrouter.ai/api/v1",
+            api: "openai-completions",
+            apiKey: "OPENROUTER_API_KEY",
+            models: [
+              {
+                id: "minimax/minimax-m3",
+                name: "MiniMax M3",
+                input: ["text", "video", "audio"],
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const registry = ModelRegistry.create(
+      AuthStorage.inMemory({ openrouter: { type: "api_key", key: "sk-test" } }),
+      modelsPath,
+      { pluginMetadataSnapshot: pluginOwnerSnapshot("openrouter", "openrouter") },
+    );
+
+    expect(registry.getError()).toBeUndefined();
+    expect(registry.find("openrouter", "minimax/minimax-m3")?.input).toEqual([
+      "text",
+      "video",
+      "audio",
+    ]);
+  });
+
   it("isolates invalid generated plugin catalog shards from valid models", () => {
     const modelsPath = writeModelsJsonWithPluginCatalogs({
       root: {

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -152,6 +152,13 @@ const ProviderAuthModeSchema = Type.Union([
   Type.Literal("token"),
 ]);
 type ProviderAuthMode = Static<typeof ProviderAuthModeSchema>;
+const ModelInputSchema = Type.Union([
+  Type.Literal("text"),
+  Type.Literal("image"),
+  Type.Literal("video"),
+  Type.Literal("audio"),
+]);
+type ModelInputModality = Static<typeof ModelInputSchema>;
 
 // Schema for custom model definition
 // Most fields are optional with sensible defaults for local models (Ollama, LM Studio, etc.)
@@ -162,7 +169,7 @@ const ModelDefinitionSchema = Type.Object({
   baseUrl: Type.Optional(Type.String({ minLength: 1 })),
   reasoning: Type.Optional(Type.Boolean()),
   thinkingLevelMap: Type.Optional(ThinkingLevelMapSchema),
-  input: Type.Optional(Type.Array(Type.Union([Type.Literal("text"), Type.Literal("image")]))),
+  input: Type.Optional(Type.Array(ModelInputSchema)),
   cost: Type.Optional(
     Type.Object({
       input: Type.Number(),
@@ -926,7 +933,7 @@ export interface ProviderConfigInput {
     baseUrl?: string;
     reasoning: boolean;
     thinkingLevelMap?: Model["thinkingLevelMap"];
-    input: ("text" | "image")[];
+    input: ModelInputModality[];
     cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
     contextWindow: number;
     maxTokens: number;


### PR DESCRIPTION
Closes #101918

## What Problem This Solves

Fixes an issue where users running `openclaw doctor` could see a false-positive `Invalid models.json schema` error when a generated plugin model catalog includes `video` or `audio` input modalities. This could make a working OpenRouter catalog look broken even though those modalities are already accepted by the config contract.

## Why This Change Was Made

The model registry validation schema now accepts the same runtime model input modalities as the config schema: `text`, `image`, `video`, and `audio`. The change stays scoped to runtime model inputs and does not add `document`, which remains a catalog/UI modality rather than a supported runtime model definition input.

Risk note: this touches model catalog validation, so the regression test uses the generated plugin `catalog.json` shard path and keeps existing invalid-shard isolation coverage intact.

## User Impact

Users with provider-generated catalogs that advertise audio or video model inputs should no longer get scary doctor schema errors for otherwise usable model catalogs.

## Evidence

Before fix, the same generated plugin catalog shape failed through the real `ModelRegistry` path:

```text
Invalid models.json schema:
  - providers.openrouter.models.0.input.1: must be equal to constant
  - providers.openrouter.models.0.input.1: must be equal to constant
  - providers.openrouter.models.0.input.1: must match a schema in anyOf
  - providers.openrouter.models.0.input.2: must be equal to constant
  - providers.openrouter.models.0.input.2: must be equal to constant
  - providers.openrouter.models.0.input.2: must match a schema in anyOf
```

After fix, the same real registry path loads the catalog and preserves the modalities:

```text
{"error":null,"input":["text","video","audio"]}
```

Validation run:

```text
node scripts/run-vitest.mjs src/agents/sessions/model-registry.test.ts
# Test Files  1 passed (1)
# Tests  9 passed (9)

pnpm exec oxfmt --check --threads=1 src/agents/sessions/model-registry.ts src/agents/sessions/model-registry.test.ts
# All matched files use the correct format.

git diff --check
# passed

node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
# passed

node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
# passed

.agents/skills/autoreview/scripts/autoreview --mode local
# autoreview clean: no accepted/actionable findings reported
```

The source CLI auto-build completed during `node scripts/run-node.mjs --help` and during a local embedded agent run.

Real provider proof with the local DeepSeek environment:

```text
node scripts/run-node.mjs agent --local --session-id issue-101918-proof --model deepseek/deepseek-v4-pro --message 'Reply exactly: OPENCLAW_101918_OK' --thinking off --json
# provider=deepseek model=deepseek-v4-pro status=200
# finalAssistantVisibleText: OPENCLAW_101918_OK
```

AI-assisted: Codex was used to inspect the issue, implement the fix, and run the proof above.
