### PR TITLE
refactor(oc-path): localize internal result types

### DIFF
--- a/extensions/oc-path/src/cli.ts
+++ b/extensions/oc-path/src/cli.ts
@@ -38,7 +38,7 @@ export type OutputRuntimeEnv = {
   exit(code: number): void;
 };
 
-export interface PathCommandOptions {
+interface PathCommandOptions {
   readonly json?: boolean;
   readonly human?: boolean;
   readonly valueJson?: boolean;

--- a/extensions/oc-path/src/oc-path/edit.ts
+++ b/extensions/oc-path/src/oc-path/edit.ts
@@ -13,7 +13,7 @@ import type { AstBlock, AstItem, FrontmatterEntry, MdAst } from "./ast.js";
 import { formatOcPath, type OcPath } from "./oc-path.js";
 import { guardSentinel } from "./sentinel.js";
 
-export type MdEditResult =
+type MdEditResult =
   | { readonly ok: true; readonly ast: MdAst }
   | {
       readonly ok: false;

--- a/extensions/oc-path/src/oc-path/jsonc/edit.ts
+++ b/extensions/oc-path/src/oc-path/jsonc/edit.ts
@@ -15,7 +15,7 @@ import { parseJsonc } from "./parse.js";
 
 type JsoncEditPath = Array<string | number>;
 
-export type JsoncEditResult =
+type JsoncEditResult =
   | { readonly ok: true; readonly ast: JsoncAst }
   | { readonly ok: false; readonly reason: "unresolved" | "no-root" };
 

--- a/extensions/oc-path/src/oc-path/jsonc/resolve-value.ts
+++ b/extensions/oc-path/src/oc-path/jsonc/resolve-value.ts
@@ -2,7 +2,7 @@
 import { isPositionalSeg, parseArrayIndexSegment, resolvePositionalSeg } from "../oc-path.js";
 import type { JsoncEntry, JsoncValue } from "./ast.js";
 
-export type JsoncValueOcPathMatch =
+type JsoncValueOcPathMatch =
   | { readonly kind: "value"; readonly node: JsoncValue; readonly path: readonly string[] }
   | {
       readonly kind: "object-entry";

--- a/extensions/oc-path/src/oc-path/jsonc/resolve.ts
+++ b/extensions/oc-path/src/oc-path/jsonc/resolve.ts
@@ -11,7 +11,7 @@ import { isQuotedSeg, splitRespectingBrackets, unquoteSeg } from "../oc-path.js"
 import type { JsoncAst, JsoncEntry, JsoncValue } from "./ast.js";
 import { resolveJsoncValueOcPath } from "./resolve-value.js";
 
-export type JsoncOcPathMatch =
+type JsoncOcPathMatch =
   | { readonly kind: "root"; readonly node: JsoncAst }
   | { readonly kind: "value"; readonly node: JsoncValue; readonly path: readonly string[] }
   | {

--- a/extensions/oc-path/src/oc-path/jsonl/edit.ts
+++ b/extensions/oc-path/src/oc-path/jsonl/edit.ts
@@ -18,7 +18,7 @@ import {
 import type { JsonlAst, JsonlLine } from "./ast.js";
 import { emitJsonl } from "./emit.js";
 
-export type JsonlEditResult =
+type JsonlEditResult =
   | { readonly ok: true; readonly ast: JsonlAst }
   | { readonly ok: false; readonly reason: "unresolved" | "not-a-value-line" };
 

--- a/extensions/oc-path/src/oc-path/jsonl/resolve.ts
+++ b/extensions/oc-path/src/oc-path/jsonl/resolve.ts
@@ -22,7 +22,7 @@ import { isQuotedSeg, splitRespectingBrackets, unquoteSeg } from "../oc-path.js"
 import type { JsonlAst, JsonlLine } from "./ast.js";
 import { pickJsonlLine } from "./line.js";
 
-export type JsonlOcPathMatch =
+type JsonlOcPathMatch =
   | { readonly kind: "root"; readonly node: JsonlAst }
   | { readonly kind: "line"; readonly node: JsonlLine }
   | {

--- a/extensions/oc-path/src/oc-path/oc-path.ts
+++ b/extensions/oc-path/src/oc-path/oc-path.ts
@@ -459,7 +459,7 @@ export function parseUnionSeg(seg: string): readonly string[] | null {
  * Value predicate `[key<op>value]`. Operators: `=` `!=` (string),
  * `<` `<=` `>` `>=` (numeric). Multi-char tried before single-char.
  */
-export type PredicateOp = "=" | "!=" | "<" | "<=" | ">" | ">=";
+type PredicateOp = "=" | "!=" | "<" | "<=" | ">" | ">=";
 
 const PREDICATE_OPS: readonly PredicateOp[] = ["!=", "<=", ">=", "<", ">", "="];
 

--- a/extensions/oc-path/src/oc-path/universal.ts
+++ b/extensions/oc-path/src/oc-path/universal.ts
@@ -99,7 +99,7 @@ export type SetResult =
       readonly detail?: string;
     };
 
-export type SetOcPathOptions = {
+type SetOcPathOptions = {
   readonly valueJson?: boolean;
 };
 

--- a/extensions/oc-path/src/oc-path/yaml/edit.ts
+++ b/extensions/oc-path/src/oc-path/yaml/edit.ts
@@ -22,7 +22,7 @@ import {
 import { guardSentinel } from "../sentinel.js";
 import type { YamlAst } from "./ast.js";
 
-export type YamlEditResult =
+type YamlEditResult =
   | { readonly ok: true; readonly ast: YamlAst }
   | {
       readonly ok: false;

--- a/extensions/oc-path/src/oc-path/yaml/resolve.ts
+++ b/extensions/oc-path/src/oc-path/yaml/resolve.ts
@@ -11,7 +11,7 @@ import {
 } from "../oc-path.js";
 import type { YamlAst } from "./ast.js";
 
-export type YamlOcPathMatch =
+type YamlOcPathMatch =
   | { readonly kind: "root"; readonly node: YamlAst }
   | { readonly kind: "scalar"; readonly value: unknown; readonly path: readonly string[] }
   | {


### PR DESCRIPTION
## What Problem This Solves

Removes stale internal type exports from OC Path implementation modules that had no consumers outside their defining files.

## Why This Change Was Made

OC Path has an explicit documented public barrel. These CLI option and per-format result types are intentionally absent from it and remain local implementation details, so narrowing their visibility removes dead module surface without changing runtime behavior.

## User Impact

No user-visible behavior changes. The private OC Path plugin exposes a smaller, more accurate internal API.

## Evidence

- Testbox `tbx_01kwzh6k4dp333n643j7ev5jd6`: `pnpm check:changed`
- `pnpm test:serial extensions/oc-path`: 40 files, 701 tests passed
- `pnpm build`
- local autoreview: clean, 0.92 confidence
- branch autoreview: clean, 0.88 confidence
- codebase-memory graph: 21,043 files, 281,316 nodes, 1,134,118 edges
