### PR TITLE
fix(channels): keep native /think menus responsive

### DIFF
--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -486,10 +486,10 @@ async function dispatchDiscordCommandInteraction(params: {
         threadBindings,
       })
     : null;
-  // Native /think choices need live-discovery metadata; empty keeps config fallback.
+  // Native /think must not wait on provider discovery; persisted rows retain its metadata.
   const menuModelCatalog =
     command.key === "think" && menuNeedsModelContext
-      ? await loadModelCatalog({ config: cfg })
+      ? await loadModelCatalog({ config: cfg, readOnly: true })
       : undefined;
   const menu = resolveCommandArgMenu({
     command,

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -582,10 +582,10 @@ export async function registerSlackMonitorSlashCommands(params: {
               sessionKey: menuRoute.sessionKey,
             })
           : {};
-        // Native /think choices need live-discovery metadata; empty keeps config fallback.
+        // Native /think must not wait on provider discovery; persisted rows retain its metadata.
         const menuModelCatalog =
           commandDefinition.key === "think" && menuNeedsModelContext
-            ? await loadModelCatalog({ config: cfg })
+            ? await loadModelCatalog({ config: cfg, readOnly: true })
             : undefined;
         const menu = resolveCommandArgMenu({
           command: commandDefinition,

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -942,15 +942,28 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     expect(replyMocks.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
   });
 
-  it("hydrates runtime catalog metadata for thinking menu defaults", async () => {
+  it("uses the read-only catalog for Claude CLI thinking menus", async () => {
     const cfg = {
       agents: {
         defaults: {
-          model: { primary: "openai/gpt-5.5" },
+          model: { primary: "anthropic/claude-opus-4-8" },
         },
       },
     } as OpenClawConfig;
     sessionMocks.loadSessionStore.mockReturnValue({});
+    agentRuntimeMocks.loadModelCatalog.mockImplementation(async (params) => {
+      if (!params?.readOnly) {
+        throw new Error("native /think must not start full model discovery");
+      }
+      return [
+        {
+          provider: "anthropic",
+          id: "claude-opus-4-8",
+          name: "Claude Opus 4.8",
+          reasoning: true,
+        },
+      ];
+    });
 
     const { handler, sendMessage } = registerAndResolveCommandHandler({
       commandName: "think",
@@ -961,13 +974,14 @@ describe("registerTelegramNativeCommands — session metadata", () => {
 
     expect(agentRuntimeMocks.loadModelCatalog).toHaveBeenCalledWith({
       config: cfg,
+      readOnly: true,
     });
     expectSendMessageCall({
       sendMessage,
       chatId: 100,
-      textIncludes: "Current thinking level: medium.\nChoose level for /think.",
+      textIncludes: "Current thinking level: off.\nChoose level for /think.",
       requireReplyMarkup: true,
-      label: "runtime catalog thinking menu",
+      label: "Claude CLI thinking menu",
     });
     expect(replyMocks.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
   });

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -400,25 +400,13 @@ function resolveTelegramFastCommandState(params: {
   }
 }
 
-async function resolveTelegramDefaultThinkingLevel(params: {
-  cfg: OpenClawConfig;
-  provider: string;
-  model: string;
-}): Promise<string> {
-  return resolveThinkingDefaultWithRuntimeCatalog({
-    cfg: params.cfg,
-    provider: params.provider,
-    model: params.model,
-    loadModelCatalog: () => loadModelCatalog({ config: params.cfg }),
-  });
-}
-
 async function resolveTelegramThinkMenuCurrentLevel(params: {
   cfg: OpenClawConfig;
   agentId: string;
   provider?: string;
   model?: string;
   thinkingLevel?: string;
+  catalog: Awaited<ReturnType<typeof loadModelCatalog>>;
 }): Promise<string> {
   const explicit = normalizeOptionalString(params.thinkingLevel);
   if (explicit) {
@@ -434,10 +422,11 @@ async function resolveTelegramThinkMenuCurrentLevel(params: {
     cfg: params.cfg,
     agentId: params.agentId,
   });
-  return await resolveTelegramDefaultThinkingLevel({
+  return await resolveThinkingDefaultWithRuntimeCatalog({
     cfg: params.cfg,
     provider: params.provider ?? defaultModel.provider,
     model: params.model ?? defaultModel.model,
+    loadModelCatalog: async () => params.catalog,
   });
 }
 
@@ -1406,10 +1395,10 @@ export const registerTelegramNativeCommands = ({
                 sessionKey: targetSessionKeyForMenu,
               }))
             : {};
-        // Native /think choices need live-discovery metadata; empty keeps config fallback.
+        // Native /think must not wait on provider discovery; persisted rows retain its metadata.
         const menuModelCatalog =
           commandDefinition?.key === "think" && menuNeedsModelContext
-            ? await loadModelCatalog({ config: runtimeCfg })
+            ? await loadModelCatalog({ config: runtimeCfg, readOnly: true })
             : undefined;
         const menu = commandDefinition
           ? resolveCommandArgMenu({
@@ -1430,6 +1419,7 @@ export const registerTelegramNativeCommands = ({
                     cfg: runtimeCfg,
                     agentId: route.agentId,
                     ...menuModelContext,
+                    catalog: menuModelCatalog ?? [],
                   })
                 : undefined,
             currentFastModeStatus:


### PR DESCRIPTION
Related: #94067

## What Problem This Solves

Fixes an issue where users opening the native `/think` menu could receive no response when model discovery was already slow or blocked. This was observed on Telegram with an Anthropic Claude CLI session while `/status` remained responsive.

## Why This Change Was Made

Native `/think` menus now read persisted model-catalog metadata without joining mutable provider discovery. Telegram also reuses that same catalog snapshot when resolving the displayed current thinking level, removing a second blocking discovery call. Discord and Slack use the same non-blocking catalog path.

## User Impact

Bare `/think` commands respond promptly with the available thinking levels while retaining capability metadata for live-discovered models. Explicit `/think <level>` behavior is unchanged.

## Evidence

- Added a Telegram regression for `anthropic/claude-opus-4-8` that rejects any full-discovery call and verifies the menu response.
- Exact-head Testbox `tbx_01kwzma4sk9anfc0q9emrdrzvf`: `pnpm check:changed` passed and 81/81 focused Telegram, Discord, and Slack tests passed on `a2857fe645a`.
- Autoreview against current `origin/main` after the final rebase: clean, no actionable findings.
- Provenance: the blocking catalog loads were introduced by #94067, authored by @openperf and merged by @steipete on June 21, 2026.

AI-assisted change; implementation and validation were reviewed by the maintainer.
