### PR TITLE
feat(android): adopt device chat session on connect

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -7,7 +7,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/AppLanguage.kt",
       "source": "OpenClaw translations · $languageTag",
       "surface": "android",
-      "id": "native.android.85cc8de945e3929c"
+      "id": "native.android.c2a6e38ba0ac5d69"
     },
     {
       "kind": "conditional-branch",
@@ -15,7 +15,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/AppLanguage.kt",
       "source": "Follow Android · $systemLanguageTag",
       "surface": "android",
-      "id": "native.android.914725056e04bd7a"
+      "id": "native.android.bd86676d38a98747"
     },
     {
       "kind": "conditional-branch",
@@ -23,7 +23,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/CronJobDetail.kt",
       "source": "Off",
       "surface": "android",
-      "id": "native.android.d55616e142c8be0f"
+      "id": "native.android.67f2f22fa99358b1"
     },
     {
       "kind": "conditional-branch",
@@ -31,7 +31,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/CronJobDetail.kt",
       "source": "Default",
       "surface": "android",
-      "id": "native.android.f59b83f58086eb89"
+      "id": "native.android.f5fa3a841ce8c234"
     },
     {
       "kind": "conditional-branch",
@@ -143,7 +143,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Ready",
       "surface": "android",
-      "id": "native.android.805d35da3b3c9d18"
+      "id": "native.android.3004053ed98f6e4b"
     },
     {
       "kind": "conditional-branch",
@@ -151,7 +151,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Needs setup",
       "surface": "android",
-      "id": "native.android.44c06b96c01cb062"
+      "id": "native.android.98e6f239bdf361aa"
     },
     {
       "kind": "conditional-branch",
@@ -159,7 +159,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Unverified",
       "surface": "android",
-      "id": "native.android.1bd3499b4cf8c3f2"
+      "id": "native.android.469b184060165bd6"
     },
     {
       "kind": "conditional-branch",
@@ -167,7 +167,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "${state.provider.label} via Gateway relay",
       "surface": "android",
-      "id": "native.android.66f091d1fc047eff"
+      "id": "native.android.90241f592c7c1cce"
     },
     {
       "kind": "conditional-branch",
@@ -175,7 +175,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Gateway talk catalog not loaded",
       "surface": "android",
-      "id": "native.android.859f7fec2019b314"
+      "id": "native.android.a24ef3a97a2c8c07"
     },
     {
       "kind": "conditional-branch",
@@ -183,7 +183,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Could not load Gateway talk catalog",
       "surface": "android",
-      "id": "native.android.ecb051798c98537f"
+      "id": "native.android.9c86ef6aed5b3720"
     },
     {
       "kind": "conditional-branch",
@@ -191,7 +191,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Gateway did not return ${issue.target.title} setup",
       "surface": "android",
-      "id": "native.android.95b5551fcb519c1f"
+      "id": "native.android.7ac71cb673d6399e"
     },
     {
       "kind": "conditional-branch",
@@ -199,7 +199,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "No ${issue.target.title} provider is configured on the Gateway",
       "surface": "android",
-      "id": "native.android.328d435e93e9a2b2"
+      "id": "native.android.1349ccf44bb43398"
     },
     {
       "kind": "conditional-branch",
@@ -207,7 +207,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Gateway selected unknown provider ${issue.providerId}",
       "surface": "android",
-      "id": "native.android.b3ee0bd7fd90a9e7"
+      "id": "native.android.384d856d68320eb2"
     },
     {
       "kind": "conditional-branch",
@@ -215,7 +215,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Gateway did not return ${issue.target.title} readiness",
       "surface": "android",
-      "id": "native.android.04086b6aed3c2ce5"
+      "id": "native.android.1409da872534c08c"
     },
     {
       "kind": "conditional-branch",
@@ -223,7 +223,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Configure a ${issue.target.title} provider on the Gateway",
       "surface": "android",
-      "id": "native.android.27f61e5f9b33b6f9"
+      "id": "native.android.3ea36b85bb5ae44c"
     },
     {
       "kind": "conditional-branch",
@@ -231,7 +231,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Gateway did not identify the active ${issue.target.title} provider",
       "surface": "android",
-      "id": "native.android.e4fe3a325a6d6299"
+      "id": "native.android.f6cec337d1e0980e"
     },
     {
       "kind": "conditional-branch",
@@ -239,7 +239,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Choose a supported ${issue.target.title} provider on the Gateway",
       "surface": "android",
-      "id": "native.android.7e6b01f6e7c9bc92"
+      "id": "native.android.8fadd97a13ca7651"
     },
     {
       "kind": "conditional-branch",
@@ -247,7 +247,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Configure ${issue.providerLabel} on the Gateway",
       "surface": "android",
-      "id": "native.android.39bdbc9a546c7f1d"
+      "id": "native.android.394044d0402d59e5"
     },
     {
       "kind": "ui-toast",
@@ -263,7 +263,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt",
       "source": "OPENCLAW",
       "surface": "android",
-      "id": "native.android.ff4c22906eac1e9e"
+      "id": "native.android.3e9d9afe68d1b86a"
     },
     {
       "kind": "ui-state-text",
@@ -271,7 +271,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Searching…",
       "surface": "android",
-      "id": "native.android.dec357dfc9b8c0a5"
+      "id": "native.android.1e8c8e1a337b1cfb"
     },
     {
       "kind": "ui-state-text",
@@ -279,7 +279,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
-      "id": "native.android.567482ea1118eb13"
+      "id": "native.android.87b8d3e5c4bc6cc2"
     },
     {
       "kind": "ui-state-text",
@@ -287,7 +287,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
-      "id": "native.android.c8cf4a2716b649e4"
+      "id": "native.android.57039daea3680b32"
     },
     {
       "kind": "conditional-branch",
@@ -295,7 +295,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": "Connected",
       "surface": "android",
-      "id": "native.android.012c8499137972ad"
+      "id": "native.android.bdb23d09ec892aff"
     },
     {
       "kind": "conditional-branch",
@@ -303,7 +303,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": "Talk mode active",
       "surface": "android",
-      "id": "native.android.3e0889d921c92cab"
+      "id": "native.android.07568bc2777e31cf"
     },
     {
       "kind": "conditional-branch",
@@ -319,7 +319,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": " · Mic: Listening",
       "surface": "android",
-      "id": "native.android.ae88801e6a1b3343"
+      "id": "native.android.6432b484134d2a61"
     },
     {
       "kind": "conditional-branch",
@@ -327,11 +327,11 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": " · Mic: Pending",
       "surface": "android",
-      "id": "native.android.7521acb4a7bc9a75"
+      "id": "native.android.f7d1b25cfbc4cebc"
     },
     {
       "kind": "conditional-branch",
-      "line": 127,
+      "line": 128,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
       "surface": "android",
@@ -339,7 +339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 129,
+      "line": 130,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The Gateway still shows this approval as pending. Review it before trying again.",
       "surface": "android",
@@ -347,7 +347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 131,
+      "line": 132,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approval details. Refresh and try again.",
       "surface": "android",
@@ -355,7 +355,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 133,
+      "line": 134,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approvals.",
       "surface": "android",
@@ -363,7 +363,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 135,
+      "line": 136,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not resolve approval. Refresh and try again.",
       "surface": "android",
@@ -371,71 +371,71 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 697,
+      "line": 698,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
-      "id": "native.android.c65b61de70a063e7"
+      "id": "native.android.9529170a4389644c"
     },
     {
       "kind": "conditional-branch",
-      "line": 1596,
+      "line": 1628,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron job started.",
       "surface": "android",
-      "id": "native.android.fef5049bc20826c7"
+      "id": "native.android.1ebef3822941cdb6"
     },
     {
       "kind": "conditional-branch",
-      "line": 1596,
+      "line": 1628,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron run queued.",
       "surface": "android",
-      "id": "native.android.c39fb6f80dbf6820"
+      "id": "native.android.d8ba5136a17f7618"
     },
     {
       "kind": "conditional-branch",
-      "line": 1640,
+      "line": 1672,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron job disabled.",
       "surface": "android",
-      "id": "native.android.b878b2913410055a"
+      "id": "native.android.8a758d2851f3db17"
     },
     {
       "kind": "conditional-branch",
-      "line": 1640,
+      "line": 1672,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron job enabled.",
       "surface": "android",
-      "id": "native.android.a45ec59239fbfff0"
+      "id": "native.android.fda9390dc0d4bdea"
     },
     {
       "kind": "conditional-branch",
-      "line": 3247,
+      "line": 3279,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
-      "id": "native.android.4b07456682e725d9"
+      "id": "native.android.3ff4dd2f45fcbb3e"
     },
     {
       "kind": "conditional-branch",
-      "line": 3249,
+      "line": 3281,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
-      "id": "native.android.467899bb510b8e34"
+      "id": "native.android.bc5a666c1549dc34"
     },
     {
       "kind": "conditional-branch",
-      "line": 3251,
+      "line": 3283,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
-      "id": "native.android.84ce52ae1375fded"
+      "id": "native.android.350a8a4635d3afb0"
     },
     {
       "kind": "conditional-branch",
-      "line": 4025,
+      "line": 4056,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Update your Gateway to view provider model config.",
       "surface": "android",
@@ -443,7 +443,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 4027,
+      "line": 4058,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider model config.",
       "surface": "android",
@@ -455,7 +455,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Permission required",
       "surface": "android",
-      "id": "native.android.c28c08aed378b051"
+      "id": "native.android.fbf72e04a0b69341"
     },
     {
       "kind": "ui-dialog",
@@ -463,7 +463,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Continue",
       "surface": "android",
-      "id": "native.android.d5aead6db3dd65fd"
+      "id": "native.android.40777e57e2c6fcf8"
     },
     {
       "kind": "ui-dialog",
@@ -471,7 +471,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Not now",
       "surface": "android",
-      "id": "native.android.8b5866c0ea9b3918"
+      "id": "native.android.e4def4463cc1e694"
     },
     {
       "kind": "ui-dialog",
@@ -479,7 +479,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Enable permission in Settings",
       "surface": "android",
-      "id": "native.android.1f681dbe04d36798"
+      "id": "native.android.318ff24e3636bea0"
     },
     {
       "kind": "ui-dialog",
@@ -487,7 +487,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Open Settings",
       "surface": "android",
-      "id": "native.android.d136904b63062d5f"
+      "id": "native.android.ebdd4a402bb6506f"
     },
     {
       "kind": "ui-dialog",
@@ -495,7 +495,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Cancel",
       "surface": "android",
-      "id": "native.android.d5e9f727ca9dbf9f"
+      "id": "native.android.97a7a01b4463d8b1"
     },
     {
       "kind": "conditional-branch",
@@ -503,7 +503,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "OpenClaw needs ${labels.joinToString(\", \")} permissions to continue.",
       "surface": "android",
-      "id": "native.android.237761be968be3f4"
+      "id": "native.android.df09fca17a135a63"
     },
     {
       "kind": "conditional-branch",
@@ -511,7 +511,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Please enable ${labels.joinToString(\", \")} in Android Settings to continue.",
       "surface": "android",
-      "id": "native.android.f9b9d558dc078d96"
+      "id": "native.android.b3e03b906c7d520b"
     },
     {
       "kind": "conditional-branch",
@@ -519,7 +519,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Camera",
       "surface": "android",
-      "id": "native.android.e4c48a99de505454"
+      "id": "native.android.315f7c8adfd969d8"
     },
     {
       "kind": "conditional-branch",
@@ -527,7 +527,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Microphone",
       "surface": "android",
-      "id": "native.android.569334e85c7d2862"
+      "id": "native.android.3d9487b153749cc5"
     },
     {
       "kind": "conditional-branch",
@@ -535,7 +535,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Send SMS",
       "surface": "android",
-      "id": "native.android.8b87f961f51aaacc"
+      "id": "native.android.27011e390920e0e9"
     },
     {
       "kind": "conditional-branch",
@@ -543,7 +543,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Read SMS",
       "surface": "android",
-      "id": "native.android.5606642bd91f3a05"
+      "id": "native.android.433a488fa5424773"
     },
     {
       "kind": "conditional-branch",
@@ -551,7 +551,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Read Contacts",
       "surface": "android",
-      "id": "native.android.1215f26e8342c4e7"
+      "id": "native.android.0d171b2b5fe90830"
     },
     {
       "kind": "conditional-branch",
@@ -559,7 +559,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Write Contacts",
       "surface": "android",
-      "id": "native.android.66892d0ae6630720"
+      "id": "native.android.14d2331db12657ea"
     },
     {
       "kind": "conditional-branch",
@@ -567,7 +567,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Read Calendar",
       "surface": "android",
-      "id": "native.android.407387e45dbb6487"
+      "id": "native.android.4e7798b1015a01d2"
     },
     {
       "kind": "conditional-branch",
@@ -575,7 +575,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Write Calendar",
       "surface": "android",
-      "id": "native.android.1a79e1ef4f0b3305"
+      "id": "native.android.eb94700838b151e8"
     },
     {
       "kind": "conditional-branch",
@@ -583,7 +583,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Read Call Log",
       "surface": "android",
-      "id": "native.android.7ebc21ff3437f6b3"
+      "id": "native.android.cbbf53c95d194699"
     },
     {
       "kind": "conditional-branch",
@@ -591,7 +591,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Motion Activity",
       "surface": "android",
-      "id": "native.android.143bc0ded8478566"
+      "id": "native.android.c1998543419722ab"
     },
     {
       "kind": "conditional-branch",
@@ -599,7 +599,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Photos",
       "surface": "android",
-      "id": "native.android.1e4171b934bcfc63"
+      "id": "native.android.ca984bf3408181aa"
     },
     {
       "kind": "ui-state-text",
@@ -607,7 +607,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt",
       "source": "Searching…",
       "surface": "android",
-      "id": "native.android.93ecb3b3e1f02b63"
+      "id": "native.android.5640822ab2dfd74b"
     },
     {
       "kind": "conditional-branch",
@@ -615,7 +615,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Connecting…",
       "surface": "android",
-      "id": "native.android.1cbaba9cbffb2f97"
+      "id": "native.android.192e4333f5d4cc55"
     },
     {
       "kind": "conditional-branch",
@@ -623,7 +623,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Reconnecting…",
       "surface": "android",
-      "id": "native.android.f3bae11d8f364701"
+      "id": "native.android.21741462c2bec768"
     },
     {
       "kind": "conditional-branch",
@@ -631,7 +631,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/node/DebugHandler.kt",
       "source": "${signature.take(20)}... (OK)",
       "surface": "android",
-      "id": "native.android.0a51e1306357556c"
+      "id": "native.android.e7453bd695a5deb4"
     },
     {
       "kind": "conditional-branch",
@@ -639,7 +639,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/node/DebugHandler.kt",
       "source": "NULL (FAILED)",
       "surface": "android",
-      "id": "native.android.6aa748e98888623e"
+      "id": "native.android.79fda7eedabf4e93"
     },
     {
       "kind": "conditional-branch",
@@ -647,7 +647,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/node/NodePresenceAliveBeacon.kt",
       "source": "Android $release (SDK ${Build.VERSION.SDK_INT})",
       "surface": "android",
-      "id": "native.android.5b17d331b254e403"
+      "id": "native.android.a0e7167784ae9c65"
     },
     {
       "kind": "conditional-branch",
@@ -671,7 +671,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Home canvas",
       "surface": "android",
-      "id": "native.android.cc8d2e1456629a59"
+      "id": "native.android.8cc30254e2980b0c"
     },
     {
       "kind": "conditional-branch",
@@ -679,7 +679,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Live page",
       "surface": "android",
-      "id": "native.android.79fff0ded9891781"
+      "id": "native.android.f23129b28583843c"
     },
     {
       "kind": "ui-named-argument",
@@ -687,7 +687,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Canvas",
       "surface": "android",
-      "id": "native.android.82ab699f88638b8a"
+      "id": "native.android.89f93a6f991f8a2d"
     },
     {
       "kind": "ui-named-argument",
@@ -695,7 +695,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Current screen output and interactive app surface.",
       "surface": "android",
-      "id": "native.android.d5938abf7b7a7ee9"
+      "id": "native.android.e7f515d8660ca4b1"
     },
     {
       "kind": "conditional-branch",
@@ -703,7 +703,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Offline",
       "surface": "android",
-      "id": "native.android.c4abd4ecd607865f"
+      "id": "native.android.05cc02338329a059"
     },
     {
       "kind": "conditional-branch",
@@ -711,7 +711,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Online",
       "surface": "android",
-      "id": "native.android.27c3e59e49776d1a"
+      "id": "native.android.36fba2ca803e8b62"
     },
     {
       "kind": "conditional-branch",
@@ -719,7 +719,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Ready",
       "surface": "android",
-      "id": "native.android.697dc7666c2cd6a3"
+      "id": "native.android.d6ee752ec23ebe9c"
     },
     {
       "kind": "conditional-branch",
@@ -727,7 +727,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Standby",
       "surface": "android",
-      "id": "native.android.eeb3048253bde229"
+      "id": "native.android.20d6718c5701d65f"
     },
     {
       "kind": "conditional-branch",
@@ -735,7 +735,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Refresh Screen",
       "surface": "android",
-      "id": "native.android.70a7ab0c61036745"
+      "id": "native.android.6c5efcaaab6b6e16"
     },
     {
       "kind": "conditional-branch",
@@ -743,7 +743,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
-      "id": "native.android.2a870631873082b6"
+      "id": "native.android.a525741e5ad2000c"
     },
     {
       "kind": "conditional-branch",
@@ -751,7 +751,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Open Screen",
       "surface": "android",
-      "id": "native.android.7b8f4a7869855aea"
+      "id": "native.android.d0cf4d0358dfbe2b"
     },
     {
       "kind": "conditional-branch",
@@ -759,7 +759,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Reconnect",
       "surface": "android",
-      "id": "native.android.ec3669686494575b"
+      "id": "native.android.3536586f88be2ae6"
     },
     {
       "kind": "conditional-branch",
@@ -767,7 +767,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Connect the gateway",
       "surface": "android",
-      "id": "native.android.284be58a340fe172"
+      "id": "native.android.8489f94450b69f8f"
     },
     {
       "kind": "conditional-branch",
@@ -775,7 +775,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Screen surface ready",
       "surface": "android",
-      "id": "native.android.56d1d3f645832a4d"
+      "id": "native.android.87da16b04f072025"
     },
     {
       "kind": "conditional-branch",
@@ -783,7 +783,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Canvas output needs an active gateway connection.",
       "surface": "android",
-      "id": "native.android.3b37959b1d369a28"
+      "id": "native.android.86e277ee09c85d80"
     },
     {
       "kind": "conditional-branch",
@@ -791,7 +791,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Open the current Canvas surface to inspect or interact with it.",
       "surface": "android",
-      "id": "native.android.cd92e0961b0bf500"
+      "id": "native.android.2a16dff830477ab7"
     },
     {
       "kind": "ui-named-argument",
@@ -799,7 +799,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Channels",
       "surface": "android",
-      "id": "native.android.624fec3507aca6ed"
+      "id": "native.android.8f16d1e77c4908df"
     },
     {
       "kind": "ui-named-argument",
@@ -807,7 +807,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Messaging surfaces connected to this gateway.",
       "surface": "android",
-      "id": "native.android.269dcd676377df1a"
+      "id": "native.android.3c8f08f9297661c8"
     },
     {
       "kind": "conditional-branch",
@@ -815,7 +815,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Refresh",
       "surface": "android",
-      "id": "native.android.3ae4829888a376e6"
+      "id": "native.android.6cd158ad0913d564"
     },
     {
       "kind": "conditional-branch",
@@ -823,7 +823,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
-      "id": "native.android.5d0b97b67465eabe"
+      "id": "native.android.edd5e6335ed8b9be"
     },
     {
       "kind": "ui-named-argument",
@@ -831,7 +831,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Connect the gateway to load channels.",
       "surface": "android",
-      "id": "native.android.5ade075ecd0175d3"
+      "id": "native.android.1b8bcdd0cbe69512"
     },
     {
       "kind": "ui-named-argument",
@@ -839,7 +839,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "No channels found.",
       "surface": "android",
-      "id": "native.android.992528cbc6e1d47c"
+      "id": "native.android.32ddf1415de934ad"
     },
     {
       "kind": "ui-named-argument",
@@ -847,7 +847,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Telegram, WhatsApp, email, and other channels appear here after setup.",
       "surface": "android",
-      "id": "native.android.484f73775ff81a33"
+      "id": "native.android.0b6493ccef5577a7"
     },
     {
       "kind": "conditional-branch",
@@ -855,7 +855,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Some channel status checks did not complete.",
       "surface": "android",
-      "id": "native.android.0015adc34e74003b"
+      "id": "native.android.95d8abe6c4a09b0a"
     },
     {
       "kind": "ui-named-argument",
@@ -863,7 +863,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Close search",
       "surface": "android",
-      "id": "native.android.3fc6f9784b0d9334"
+      "id": "native.android.7cf6aa1df0a831c3"
     },
     {
       "kind": "ui-named-argument",
@@ -871,7 +871,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Search",
       "surface": "android",
-      "id": "native.android.7a804b9140cae09c"
+      "id": "native.android.87c9ce0ec2bca55a"
     },
     {
       "kind": "ui-named-argument",
@@ -879,7 +879,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "OC",
       "surface": "android",
-      "id": "native.android.39b8fec9527afedd"
+      "id": "native.android.f6b137e81ba6b241"
     },
     {
       "kind": "ui-named-argument",
@@ -887,7 +887,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Search OpenClaw",
       "surface": "android",
-      "id": "native.android.9f877120690b0c59"
+      "id": "native.android.15721c9f1a4bbb89"
     },
     {
       "kind": "ui-named-argument",
@@ -895,7 +895,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Quick actions",
       "surface": "android",
-      "id": "native.android.c142846e7b88306c"
+      "id": "native.android.cc7482733d97e5df"
     },
     {
       "kind": "ui-named-argument",
@@ -903,7 +903,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "No actions found",
       "surface": "android",
-      "id": "native.android.7c4288229860edf1"
+      "id": "native.android.1a646e08e4a8b502"
     },
     {
       "kind": "ui-named-argument",
@@ -911,7 +911,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
       "surface": "android",
-      "id": "native.android.48ad0ae0e930e02b"
+      "id": "native.android.29048b2ee2c3c0f6"
     },
     {
       "kind": "ui-named-argument",
@@ -919,7 +919,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Sessions",
       "surface": "android",
-      "id": "native.android.d4fbd1ee4f55a5db"
+      "id": "native.android.2eb8597697a9582e"
     },
     {
       "kind": "conditional-branch",
@@ -927,7 +927,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Connect the Gateway to search sessions.",
       "surface": "android",
-      "id": "native.android.207c2170504e99e6"
+      "id": "native.android.81b2c221ee0b7dc5"
     },
     {
       "kind": "conditional-branch",
@@ -935,7 +935,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "No matching sessions yet.",
       "surface": "android",
-      "id": "native.android.25d2c2d792c952fe"
+      "id": "native.android.cf93c8306951bbc2"
     },
     {
       "kind": "conditional-branch",
@@ -943,7 +943,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Assistant working",
       "surface": "android",
-      "id": "native.android.1d009aa9b54d689d"
+      "id": "native.android.f2702b980b6ec319"
     },
     {
       "kind": "conditional-branch",
@@ -951,7 +951,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "OpenClaw session",
       "surface": "android",
-      "id": "native.android.8f8384286317f5c9"
+      "id": "native.android.bae8ae739b84cd84"
     },
     {
       "kind": "ui-named-argument",
@@ -959,7 +959,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Open ${row.title}",
       "surface": "android",
-      "id": "native.android.23321276a6c8e11e"
+      "id": "native.android.7783a76d10d5bc03"
     },
     {
       "kind": "ui-named-argument",
@@ -967,7 +967,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Open session",
       "surface": "android",
-      "id": "native.android.15799e57704b20c6"
+      "id": "native.android.992ac1f4eb3f9728"
     },
     {
       "kind": "conditional-branch",
@@ -975,7 +975,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Connect Gateway to view providers",
       "surface": "android",
-      "id": "native.android.42fd88c3d0418a4a"
+      "id": "native.android.8ed4adcba7f88c24"
     },
     {
       "kind": "conditional-branch",
@@ -983,7 +983,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "$readyProviderCount providers ready",
       "surface": "android",
-      "id": "native.android.cb4cc4336cf67145"
+      "id": "native.android.059784fcf871ff29"
     },
     {
       "kind": "conditional-branch",
@@ -999,7 +999,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "No ready providers",
       "surface": "android",
-      "id": "native.android.d5aca322cbdaad85"
+      "id": "native.android.35c66a4a919ec390"
     },
     {
       "kind": "conditional-branch",
@@ -1007,7 +1007,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Main session",
       "surface": "android",
-      "id": "native.android.73e6ab1a168fd381"
+      "id": "native.android.fbaa31465843ccf4"
     },
     {
       "kind": "ui-call",
@@ -1015,7 +1015,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Delete",
       "surface": "android",
-      "id": "native.android.c4a902430c22030c"
+      "id": "native.android.357076952c35ceea"
     },
     {
       "kind": "ui-call",
@@ -1023,7 +1023,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Cancel",
       "surface": "android",
-      "id": "native.android.6e1aaf9469428b28"
+      "id": "native.android.2d3a02b350515797"
     },
     {
       "kind": "ui-call",
@@ -1031,7 +1031,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Delete cron job?",
       "surface": "android",
-      "id": "native.android.ec06722578a6027e"
+      "id": "native.android.9191cefdc7a0648e"
     },
     {
       "kind": "ui-call",
@@ -1039,7 +1039,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "This permanently removes the scheduled job from the gateway.",
       "surface": "android",
-      "id": "native.android.362073d4e1e4624d"
+      "id": "native.android.f5156edc640fa13a"
     },
     {
       "kind": "conditional-branch",
@@ -1063,7 +1063,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Admin access required",
       "surface": "android",
-      "id": "native.android.212889821e40127e"
+      "id": "native.android.00c56ce92a3fa169"
     },
     {
       "kind": "ui-named-argument-concatenated",
@@ -1079,7 +1079,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Disable",
       "surface": "android",
-      "id": "native.android.f5ed7396dc317625"
+      "id": "native.android.0aeb0b9c33d6eb9c"
     },
     {
       "kind": "conditional-branch",
@@ -1087,7 +1087,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Enable",
       "surface": "android",
-      "id": "native.android.1e3d5d4e62b4a7b0"
+      "id": "native.android.59abd1b2564ecace"
     },
     {
       "kind": "ui-named-argument",
@@ -1095,7 +1095,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Delete Job",
       "surface": "android",
-      "id": "native.android.1fed5d5912a9679c"
+      "id": "native.android.91944307e272d456"
     },
     {
       "kind": "ui-named-argument",
@@ -1103,7 +1103,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Edit Job",
       "surface": "android",
-      "id": "native.android.da9ecf342cbd7035"
+      "id": "native.android.703b4568e0e76795"
     },
     {
       "kind": "ui-named-argument",
@@ -1111,7 +1111,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Enabled",
       "surface": "android",
-      "id": "native.android.006f60922ae98063"
+      "id": "native.android.104e4f3c11e88d7e"
     },
     {
       "kind": "ui-named-argument",
@@ -1119,7 +1119,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Allow the scheduler to run this job.",
       "surface": "android",
-      "id": "native.android.8b967e5cba1edfd8"
+      "id": "native.android.d8425c7e0769a452"
     },
     {
       "kind": "ui-named-argument",
@@ -1127,7 +1127,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Delete after run",
       "surface": "android",
-      "id": "native.android.f5fe0e769a9df4f8"
+      "id": "native.android.b8a57f83f10d4c5e"
     },
     {
       "kind": "ui-named-argument",
@@ -1135,7 +1135,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Remove this job after a successful one-shot run.",
       "surface": "android",
-      "id": "native.android.9ed8d09744263540"
+      "id": "native.android.fc744c61f3324b8d"
     },
     {
       "kind": "ui-named-argument",
@@ -1143,7 +1143,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Job name",
       "surface": "android",
-      "id": "native.android.8faa8ae2ea76fe52"
+      "id": "native.android.16ea42c6aeec16f5"
     },
     {
       "kind": "ui-named-argument",
@@ -1151,7 +1151,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Name",
       "surface": "android",
-      "id": "native.android.e3a12cf55b2caea3"
+      "id": "native.android.713ce0a27e97ed68"
     },
     {
       "kind": "ui-named-argument",
@@ -1159,7 +1159,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Optional description",
       "surface": "android",
-      "id": "native.android.6c87607a5cebdb8e"
+      "id": "native.android.e6f76a6e0cb04da9"
     },
     {
       "kind": "ui-named-argument",
@@ -1167,7 +1167,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Description",
       "surface": "android",
-      "id": "native.android.0889eb39d1b58159"
+      "id": "native.android.42eb09f228b1ccd9"
     },
     {
       "kind": "ui-named-argument",
@@ -1175,7 +1175,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "main, isolated, current, or session:<id>",
       "surface": "android",
-      "id": "native.android.853d7f21386e00ce"
+      "id": "native.android.6a62274abe78b05d"
     },
     {
       "kind": "ui-named-argument",
@@ -1183,7 +1183,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Session target",
       "surface": "android",
-      "id": "native.android.65d7bb7d9f9b082f"
+      "id": "native.android.0b13762e7a971bb4"
     },
     {
       "kind": "conditional-branch",
@@ -1191,7 +1191,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Save Changes",
       "surface": "android",
-      "id": "native.android.d84417059750df22"
+      "id": "native.android.ee45f4172c37361b"
     },
     {
       "kind": "conditional-branch",
@@ -1199,7 +1199,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Working",
       "surface": "android",
-      "id": "native.android.2e09de2153828824"
+      "id": "native.android.701dc5f4f73d1413"
     },
     {
       "kind": "ui-named-argument",
@@ -1207,7 +1207,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Revert Changes",
       "surface": "android",
-      "id": "native.android.e4c8c46ac5a926f7"
+      "id": "native.android.794135f9eb9fa9d9"
     },
     {
       "kind": "ui-named-argument",
@@ -1215,7 +1215,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Schedule · ${cronScheduleKindLabel(schedule)}",
       "surface": "android",
-      "id": "native.android.6709a2ee21539fac"
+      "id": "native.android.a76c03d10b89ec0c"
     },
     {
       "kind": "ui-named-argument",
@@ -1223,7 +1223,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "ISO time, e.g. 2026-07-09T09:30:00Z",
       "surface": "android",
-      "id": "native.android.c5c8713fcc8b695b"
+      "id": "native.android.fe3d57c15d174752"
     },
     {
       "kind": "ui-named-argument",
@@ -1231,7 +1231,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Run at",
       "surface": "android",
-      "id": "native.android.af7a2e3e4e43b695"
+      "id": "native.android.27055d0f1127f89d"
     },
     {
       "kind": "ui-named-argument",
@@ -1239,7 +1239,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Milliseconds",
       "surface": "android",
-      "id": "native.android.67f1f087d42411e7"
+      "id": "native.android.5f600b28cff9043a"
     },
     {
       "kind": "ui-named-argument",
@@ -1247,7 +1247,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Interval",
       "surface": "android",
-      "id": "native.android.4a97c2ca6b3a2ea6"
+      "id": "native.android.b62227884b6d9256"
     },
     {
       "kind": "ui-named-argument",
@@ -1255,7 +1255,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Epoch milliseconds (optional)",
       "surface": "android",
-      "id": "native.android.af67797053368f7a"
+      "id": "native.android.fa0770de33b08f46"
     },
     {
       "kind": "ui-named-argument",
@@ -1263,7 +1263,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Anchor",
       "surface": "android",
-      "id": "native.android.f92ca93c74dd9ec6"
+      "id": "native.android.3bf9e34dd98407bb"
     },
     {
       "kind": "ui-named-argument",
@@ -1271,7 +1271,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Cron expression, e.g. 0 9 * * *",
       "surface": "android",
-      "id": "native.android.ec1404d32b37a228"
+      "id": "native.android.eb943d422fbabac1"
     },
     {
       "kind": "ui-named-argument",
@@ -1279,7 +1279,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Expression",
       "surface": "android",
-      "id": "native.android.7224806b900ea27b"
+      "id": "native.android.012eb58dbb5a923d"
     },
     {
       "kind": "ui-named-argument",
@@ -1287,7 +1287,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "e.g. America/New_York",
       "surface": "android",
-      "id": "native.android.3fd296fbbcbd0e80"
+      "id": "native.android.bee25563912907ce"
     },
     {
       "kind": "ui-named-argument",
@@ -1295,7 +1295,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Timezone",
       "surface": "android",
-      "id": "native.android.6a15bddd2f00a26b"
+      "id": "native.android.d2fc93656117d688"
     },
     {
       "kind": "ui-named-argument",
@@ -1303,7 +1303,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "0 = exact",
       "surface": "android",
-      "id": "native.android.0f3a49d995ed9910"
+      "id": "native.android.2870735fc8ed7ef9"
     },
     {
       "kind": "ui-named-argument",
@@ -1311,7 +1311,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Stagger ms",
       "surface": "android",
-      "id": "native.android.9c4cd709af2884fd"
+      "id": "native.android.8242e0f118d88a6b"
     },
     {
       "kind": "ui-named-argument",
@@ -1319,7 +1319,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Command to watch",
       "surface": "android",
-      "id": "native.android.36ef6b38d936f70f"
+      "id": "native.android.9274985cbdc77132"
     },
     {
       "kind": "ui-named-argument",
@@ -1327,7 +1327,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Command",
       "surface": "android",
-      "id": "native.android.09bb59bcf0c7e009"
+      "id": "native.android.7cb96c3ca20def5f"
     },
     {
       "kind": "ui-named-argument",
@@ -1335,7 +1335,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Working directory",
       "surface": "android",
-      "id": "native.android.cad18710a0fdaa21"
+      "id": "native.android.04c77d1b81874906"
     },
     {
       "kind": "ui-named-argument",
@@ -1343,7 +1343,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Payload · ${cronPayloadKindLabel(payload)}",
       "surface": "android",
-      "id": "native.android.06fb3142ca1b9d7a"
+      "id": "native.android.5f2dfb4437da54bc"
     },
     {
       "kind": "ui-named-argument",
@@ -1351,7 +1351,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "System event text",
       "surface": "android",
-      "id": "native.android.9719574f53e9ee15"
+      "id": "native.android.a9ad0131f8c13832"
     },
     {
       "kind": "ui-named-argument",
@@ -1359,7 +1359,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Event text",
       "surface": "android",
-      "id": "native.android.268f6823b43b3177"
+      "id": "native.android.4e726a5b9986d8da"
     },
     {
       "kind": "ui-named-argument",
@@ -1367,7 +1367,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Agent message",
       "surface": "android",
-      "id": "native.android.406fffc637df0bc0"
+      "id": "native.android.cc5d86241bff114f"
     },
     {
       "kind": "ui-named-argument",
@@ -1375,7 +1375,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Message",
       "surface": "android",
-      "id": "native.android.657a9cba38e35a9c"
+      "id": "native.android.54ea9f436040fb65"
     },
     {
       "kind": "ui-named-argument",
@@ -1383,7 +1383,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Model",
       "surface": "android",
-      "id": "native.android.282315578422bf23"
+      "id": "native.android.0e48df116a7c8712"
     },
     {
       "kind": "ui-named-argument",
@@ -1391,7 +1391,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Optional override",
       "surface": "android",
-      "id": "native.android.aca463f1ba7edde5"
+      "id": "native.android.97e636d1128629df"
     },
     {
       "kind": "ui-named-argument",
@@ -1399,7 +1399,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Thinking",
       "surface": "android",
-      "id": "native.android.7f45799d74ee7587"
+      "id": "native.android.65a0249a9d6a598f"
     },
     {
       "kind": "ui-named-argument",
@@ -1407,7 +1407,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Command argv JSON array",
       "surface": "android",
-      "id": "native.android.0a20280e51a2c61b"
+      "id": "native.android.94412766a31dcff6"
     },
     {
       "kind": "ui-named-argument",
@@ -1415,7 +1415,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Arguments",
       "surface": "android",
-      "id": "native.android.04c3a1825c19886e"
+      "id": "native.android.0dc63f7146334b8c"
     },
     {
       "kind": "ui-named-argument",
@@ -1423,7 +1423,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Optional path",
       "surface": "android",
-      "id": "native.android.e45a470156b0f564"
+      "id": "native.android.76dad38b77c9a4cf"
     },
     {
       "kind": "conditional-branch",
@@ -1447,7 +1447,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "The gateway can change this path but cannot clear an existing path.",
       "surface": "android",
-      "id": "native.android.00a27842963455a7"
+      "id": "native.android.dbe0f281bf1caea1"
     },
     {
       "kind": "ui-named-argument",
@@ -1455,7 +1455,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Recent Runs",
       "surface": "android",
-      "id": "native.android.b0de849068a82211"
+      "id": "native.android.4ff0531390ea8a40"
     },
     {
       "kind": "conditional-branch",
@@ -1463,7 +1463,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Loading",
       "surface": "android",
-      "id": "native.android.9b6b1f5c976e23fa"
+      "id": "native.android.b86336562ac63ec2"
     },
     {
       "kind": "conditional-branch",
@@ -1471,7 +1471,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Reload",
       "surface": "android",
-      "id": "native.android.30ea2a568e832013"
+      "id": "native.android.a4eb2acccc5ded54"
     },
     {
       "kind": "conditional-branch",
@@ -1479,7 +1479,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Loading recent runs…",
       "surface": "android",
-      "id": "native.android.677d53d3c85c3d7e"
+      "id": "native.android.babccd556ac46f93"
     },
     {
       "kind": "conditional-branch",
@@ -1487,7 +1487,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "No recent runs yet.",
       "surface": "android",
-      "id": "native.android.9daf37294c74454c"
+      "id": "native.android.97363cc482924983"
     },
     {
       "kind": "conditional-branch",
@@ -1495,7 +1495,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "One time",
       "surface": "android",
-      "id": "native.android.322daf975eb5e204"
+      "id": "native.android.dba9901722fa52ee"
     },
     {
       "kind": "conditional-branch",
@@ -1503,7 +1503,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Cron",
       "surface": "android",
-      "id": "native.android.d8dfc026668cdc81"
+      "id": "native.android.69c356133463eb59"
     },
     {
       "kind": "conditional-branch",
@@ -1511,7 +1511,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "On command exit",
       "surface": "android",
-      "id": "native.android.da05d4ae32ae6a75"
+      "id": "native.android.5ff52e2d6cf1abec"
     },
     {
       "kind": "conditional-branch",
@@ -1519,7 +1519,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "System event",
       "surface": "android",
-      "id": "native.android.22f6ed1cadece34c"
+      "id": "native.android.5f4d89cd808b21dd"
     },
     {
       "kind": "conditional-branch",
@@ -1527,7 +1527,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Agent turn",
       "surface": "android",
-      "id": "native.android.24e541dd61519341"
+      "id": "native.android.b4076cab2747e088"
     },
     {
       "kind": "ui-named-argument",
@@ -1535,7 +1535,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "Dreaming",
       "surface": "android",
-      "id": "native.android.b735fb6c7d284ecf"
+      "id": "native.android.c469d668e93d3dbb"
     },
     {
       "kind": "ui-named-argument",
@@ -1543,7 +1543,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "Memory consolidation and dream diary.",
       "surface": "android",
-      "id": "native.android.4f96e0e1568d3220"
+      "id": "native.android.0069bfbabcfddb7f"
     },
     {
       "kind": "conditional-branch",
@@ -1551,7 +1551,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "Off",
       "surface": "android",
-      "id": "native.android.fe6205cd51ca9294"
+      "id": "native.android.858d7af028e3dea8"
     },
     {
       "kind": "conditional-branch",
@@ -1559,7 +1559,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "On",
       "surface": "android",
-      "id": "native.android.4f1e1ae70b8be673"
+      "id": "native.android.6742798589066927"
     },
     {
       "kind": "conditional-branch",
@@ -1567,7 +1567,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "Refresh",
       "surface": "android",
-      "id": "native.android.a0f6d433844d6129"
+      "id": "native.android.ff8d182bc37b17a8"
     },
     {
       "kind": "conditional-branch",
@@ -1575,7 +1575,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
-      "id": "native.android.8f415a13cb47b13f"
+      "id": "native.android.d95680057e8f9428"
     },
     {
       "kind": "ui-named-argument",
@@ -1583,7 +1583,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "Connect the gateway to load dreaming.",
       "surface": "android",
-      "id": "native.android.5aa176a33e0ccf39"
+      "id": "native.android.4fb6008edcfd284c"
     },
     {
       "kind": "ui-named-argument",
@@ -1591,7 +1591,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "Memory Store",
       "surface": "android",
-      "id": "native.android.eddd9c73506fb13d"
+      "id": "native.android.270803cd26af07a1"
     },
     {
       "kind": "ui-named-argument",
@@ -1599,7 +1599,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "Signal Index",
       "surface": "android",
-      "id": "native.android.ee38e75c2cb266ff"
+      "id": "native.android.32050f86b121c166"
     },
     {
       "kind": "conditional-branch",
@@ -1607,7 +1607,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "Healthy",
       "surface": "android",
-      "id": "native.android.aad1071140b4d96a"
+      "id": "native.android.d151b5e42563285f"
     },
     {
       "kind": "conditional-branch",
@@ -1615,7 +1615,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "Needs attention",
       "surface": "android",
-      "id": "native.android.a63b20ed6c7ca049"
+      "id": "native.android.08c0fa02933271fa"
     },
     {
       "kind": "ui-named-argument",
@@ -1623,7 +1623,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "Promoted",
       "surface": "android",
-      "id": "native.android.1fa9bba1998478db"
+      "id": "native.android.e4b7ed277d6fba43"
     },
     {
       "kind": "ui-named-argument",
@@ -1631,7 +1631,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "DIARY",
       "surface": "android",
-      "id": "native.android.76726c57be04cd2a"
+      "id": "native.android.d9458f8640c33986"
     },
     {
       "kind": "ui-named-argument",
@@ -1639,7 +1639,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "No dream diary yet.",
       "surface": "android",
-      "id": "native.android.15e1398d4eff28f4"
+      "id": "native.android.2448184ddbeecce4"
     },
     {
       "kind": "ui-named-argument",
@@ -1647,7 +1647,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "Entries appear after a dreaming cycle writes a narrative summary.",
       "surface": "android",
-      "id": "native.android.79b6db08d385f76f"
+      "id": "native.android.25045fdc8cb1c1ba"
     },
     {
       "kind": "ui-named-argument",
@@ -1655,7 +1655,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "The diary is waiting for its first entry.",
       "surface": "android",
-      "id": "native.android.b5f63fbf76f816f3"
+      "id": "native.android.20371ad7f7b5d52b"
     },
     {
       "kind": "ui-named-argument",
@@ -1663,7 +1663,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "D",
       "surface": "android",
-      "id": "native.android.a45b15d8549e9539"
+      "id": "native.android.87e2d2971c09552d"
     },
     {
       "kind": "conditional-branch",
@@ -1687,7 +1687,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "Setup code points to an insecure remote gateway. $remoteGatewaySecurityRule $remoteGatewaySecurityFix",
       "surface": "android",
-      "id": "native.android.458f8fd9ad7485a7"
+      "id": "native.android.180483eb1b7a4ff1"
     },
     {
       "kind": "conditional-branch",
@@ -1695,7 +1695,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "QR code points to an insecure remote gateway. $remoteGatewaySecurityRule $remoteGatewaySecurityFix",
       "surface": "android",
-      "id": "native.android.1a15475cf8d92de8"
+      "id": "native.android.9504a95ceefca5e8"
     },
     {
       "kind": "conditional-branch",
@@ -1703,7 +1703,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "$remoteGatewaySecurityRule $remoteGatewaySecurityFix",
       "surface": "android",
-      "id": "native.android.a77d1e3d811ad9d8"
+      "id": "native.android.9373db8f4269091a"
     },
     {
       "kind": "conditional-branch",
@@ -1711,7 +1711,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "Setup code uses an IPv6 zone ID. Use an unscoped IPv6 address or a LAN hostname.",
       "surface": "android",
-      "id": "native.android.d5230e4551045851"
+      "id": "native.android.84ea70ae0976dca7"
     },
     {
       "kind": "conditional-branch",
@@ -1719,7 +1719,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "QR code uses an IPv6 zone ID. Use an unscoped IPv6 address or a LAN hostname.",
       "surface": "android",
-      "id": "native.android.ca9fc2ce10f4028a"
+      "id": "native.android.1c32685b70f0585d"
     },
     {
       "kind": "conditional-branch",
@@ -1727,7 +1727,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "IPv6 zone IDs are not supported. Use an unscoped IPv6 address or a LAN hostname.",
       "surface": "android",
-      "id": "native.android.141236601fece71e"
+      "id": "native.android.b1ab0f426dacc83f"
     },
     {
       "kind": "conditional-branch",
@@ -1735,7 +1735,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "Setup code has invalid gateway URL.",
       "surface": "android",
-      "id": "native.android.47e3c19d55f0150b"
+      "id": "native.android.b35f854c0bf08eda"
     },
     {
       "kind": "conditional-branch",
@@ -1743,7 +1743,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "QR code did not contain a valid setup code.",
       "surface": "android",
-      "id": "native.android.b0cc3253031d22c2"
+      "id": "native.android.9598911ada12ef86"
     },
     {
       "kind": "conditional-branch",
@@ -1751,7 +1751,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "Enter a valid manual endpoint to connect.",
       "surface": "android",
-      "id": "native.android.732f5b59ba7e1513"
+      "id": "native.android.864a4b7e75710d7c"
     },
     {
       "kind": "conditional-branch",
@@ -1759,7 +1759,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
       "source": "Setup code expired",
       "surface": "android",
-      "id": "native.android.b331b5b54e147e41"
+      "id": "native.android.e1054f3bc0555d58"
     },
     {
       "kind": "conditional-branch",
@@ -1767,7 +1767,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
       "source": "Gateway token needed",
       "surface": "android",
-      "id": "native.android.fd29725b5271ffcc"
+      "id": "native.android.f2193ad06a43f411"
     },
     {
       "kind": "conditional-branch",
@@ -1775,7 +1775,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
       "source": "Gateway token not configured",
       "surface": "android",
-      "id": "native.android.a20706c18b04439c"
+      "id": "native.android.0f4d4e9558c7af45"
     },
     {
       "kind": "conditional-branch",
@@ -1783,7 +1783,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
       "source": "Gateway password needed",
       "surface": "android",
-      "id": "native.android.ef63577677f434bd"
+      "id": "native.android.cfb8e679760a1b88"
     },
     {
       "kind": "conditional-branch",
@@ -1791,7 +1791,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
       "source": "Gateway password invalid",
       "surface": "android",
-      "id": "native.android.841612944fc3c917"
+      "id": "native.android.75212695995bedef"
     },
     {
       "kind": "conditional-branch",
@@ -1799,7 +1799,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
       "source": "Gateway password not configured",
       "surface": "android",
-      "id": "native.android.746689fea659f156"
+      "id": "native.android.4c6ce02882c01df6"
     },
     {
       "kind": "conditional-branch",
@@ -1807,7 +1807,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
       "source": "Gateway access needs review",
       "surface": "android",
-      "id": "native.android.3b34fd01c808e358"
+      "id": "native.android.99754af2b0e2ff9e"
     },
     {
       "kind": "conditional-branch",
@@ -1815,7 +1815,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
       "source": "Saved auth invalid",
       "surface": "android",
-      "id": "native.android.baaf14ba36d7cc94"
+      "id": "native.android.9582ed70d6d95c12"
     },
     {
       "kind": "conditional-branch",
@@ -1823,7 +1823,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
       "source": "Device identity required",
       "surface": "android",
-      "id": "native.android.ec80b07c46a3bb1f"
+      "id": "native.android.48344496b7f8cc0a"
     },
     {
       "kind": "ui-toast",
@@ -1831,7 +1831,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
       "source": "Copied gateway diagnostics",
       "surface": "android",
-      "id": "native.android.b44fc3039e0fb9fa"
+      "id": "native.android.4e0df754986fed99"
     },
     {
       "kind": "ui-named-argument",
@@ -1839,7 +1839,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Health",
       "surface": "android",
-      "id": "native.android.d5902896d7b92cc9"
+      "id": "native.android.31b5f89b8517a3ec"
     },
     {
       "kind": "ui-named-argument",
@@ -1847,7 +1847,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Gateway status, phone node readiness, and recent log stream.",
       "surface": "android",
-      "id": "native.android.6c1eb72c4b19c43a"
+      "id": "native.android.9ce89a78454d843f"
     },
     {
       "kind": "conditional-branch",
@@ -1855,7 +1855,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Offline",
       "surface": "android",
-      "id": "native.android.cac027a1232254cd"
+      "id": "native.android.d4c845fc444ac249"
     },
     {
       "kind": "conditional-branch",
@@ -1863,7 +1863,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Online",
       "surface": "android",
-      "id": "native.android.59602ad037679006"
+      "id": "native.android.828b547bbf84f52e"
     },
     {
       "kind": "conditional-branch",
@@ -1871,7 +1871,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Waiting",
       "surface": "android",
-      "id": "native.android.a328ef4e475c8fbe"
+      "id": "native.android.a1e0eae53bd96822"
     },
     {
       "kind": "conditional-branch",
@@ -1879,7 +1879,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Needs connection",
       "surface": "android",
-      "id": "native.android.96f94678e3776142"
+      "id": "native.android.75d85550f6902f37"
     },
     {
       "kind": "conditional-branch",
@@ -1887,7 +1887,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Ready",
       "surface": "android",
-      "id": "native.android.2a50ec20cdf08301"
+      "id": "native.android.0560195a6fbe78fc"
     },
     {
       "kind": "conditional-branch",
@@ -1895,7 +1895,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "$pendingRunCount active",
       "surface": "android",
-      "id": "native.android.327e2c1665be1925"
+      "id": "native.android.f7f1d2acc89303b1"
     },
     {
       "kind": "conditional-branch",
@@ -1903,7 +1903,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Idle",
       "surface": "android",
-      "id": "native.android.6a62b57b708f9750"
+      "id": "native.android.bf50c0368dcf5db1"
     },
     {
       "kind": "conditional-branch",
@@ -1911,7 +1911,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Refresh Logs",
       "surface": "android",
-      "id": "native.android.d881aa24cd9688dc"
+      "id": "native.android.7400d2313e5b03a2"
     },
     {
       "kind": "conditional-branch",
@@ -1919,7 +1919,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
-      "id": "native.android.5a5d32406f0854f0"
+      "id": "native.android.7d2cb0b8b261d2f0"
     },
     {
       "kind": "ui-named-argument",
@@ -1927,7 +1927,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Log Entry",
       "surface": "android",
-      "id": "native.android.3abbc8d1a0faf105"
+      "id": "native.android.3fac7c82ee6a600c"
     },
     {
       "kind": "ui-named-argument",
@@ -1935,7 +1935,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Readable gateway log detail.",
       "surface": "android",
-      "id": "native.android.dd65a0b8f32f1441"
+      "id": "native.android.5e352a51d4d85ed7"
     },
     {
       "kind": "ui-named-argument",
@@ -1943,7 +1943,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Message",
       "surface": "android",
-      "id": "native.android.27493dc9da0b1868"
+      "id": "native.android.5100dab91f1f95b9"
     },
     {
       "kind": "ui-named-argument",
@@ -1951,7 +1951,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Raw",
       "surface": "android",
-      "id": "native.android.7787d6ba8f47569a"
+      "id": "native.android.3649668ff4995030"
     },
     {
       "kind": "ui-named-argument",
@@ -1959,7 +1959,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Gateway",
       "surface": "android",
-      "id": "native.android.66abf18b56db44b2"
+      "id": "native.android.42c5e031e9e482fa"
     },
     {
       "kind": "ui-named-argument",
@@ -1967,7 +1967,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Phone Node",
       "surface": "android",
-      "id": "native.android.44cae82f7d34a414"
+      "id": "native.android.495b30194d79a50b"
     },
     {
       "kind": "ui-named-argument",
@@ -1975,7 +1975,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Chat",
       "surface": "android",
-      "id": "native.android.cd3cb6251f3f2829"
+      "id": "native.android.f5990f63fc162ab0"
     },
     {
       "kind": "ui-named-argument",
@@ -1983,7 +1983,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Models",
       "surface": "android",
-      "id": "native.android.b6ca712c36059f82"
+      "id": "native.android.7103c01e56184baf"
     },
     {
       "kind": "ui-named-argument",
@@ -1991,7 +1991,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Voice",
       "surface": "android",
-      "id": "native.android.0fe10ad070cea5c3"
+      "id": "native.android.6c6ca3ed9b1f9ce7"
     },
     {
       "kind": "ui-named-argument",
@@ -1999,7 +1999,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Runs",
       "surface": "android",
-      "id": "native.android.9a2dc9af65486b8a"
+      "id": "native.android.45155181110d5f55"
     },
     {
       "kind": "ui-named-argument",
@@ -2007,7 +2007,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "RECENT LOGS",
       "surface": "android",
-      "id": "native.android.72cda57e789dde68"
+      "id": "native.android.606caf039fbfa644"
     },
     {
       "kind": "ui-named-argument",
@@ -2015,7 +2015,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Connect the gateway to load recent logs.",
       "surface": "android",
-      "id": "native.android.049ae19c839e5937"
+      "id": "native.android.3dbd01c55d01ad48"
     },
     {
       "kind": "ui-named-argument",
@@ -2023,7 +2023,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "No recent log entries.",
       "surface": "android",
-      "id": "native.android.cefb84bdae346c7e"
+      "id": "native.android.8763f5ab69f7339c"
     },
     {
       "kind": "ui-named-argument",
@@ -2031,7 +2031,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Showing the latest log chunk.",
       "surface": "android",
-      "id": "native.android.47fa6b7f49434581"
+      "id": "native.android.a7785c0f856f94f2"
     },
     {
       "kind": "ui-named-argument",
@@ -2039,7 +2039,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Nodes & Devices",
       "surface": "android",
-      "id": "native.android.7eda627dad7e16cf"
+      "id": "native.android.b7656cb0285bf159"
     },
     {
       "kind": "ui-named-argument",
@@ -2047,7 +2047,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Live nodes, paired phones, and pending device requests.",
       "surface": "android",
-      "id": "native.android.006a92f5811c5406"
+      "id": "native.android.521e3ad46416eace"
     },
     {
       "kind": "conditional-branch",
@@ -2055,7 +2055,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Refresh",
       "surface": "android",
-      "id": "native.android.a14d051ca26b222a"
+      "id": "native.android.03ed0cbae9bb5859"
     },
     {
       "kind": "conditional-branch",
@@ -2063,7 +2063,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
-      "id": "native.android.67733e0b49b52cac"
+      "id": "native.android.8aef1b4460eec07e"
     },
     {
       "kind": "ui-named-argument",
@@ -2071,7 +2071,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Connect the gateway to load nodes and paired devices.",
       "surface": "android",
-      "id": "native.android.c7a463dfd4e2132d"
+      "id": "native.android.35162358c7e1c893"
     },
     {
       "kind": "ui-named-argument",
@@ -2079,7 +2079,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "No nodes or paired devices.",
       "surface": "android",
-      "id": "native.android.548e83e2900b7689"
+      "id": "native.android.c6210d3bdb161a91"
     },
     {
       "kind": "ui-named-argument",
@@ -2087,7 +2087,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Linked phones and node hosts will appear here after pairing.",
       "surface": "android",
-      "id": "native.android.c8ce503b95d13058"
+      "id": "native.android.c01e8f39ac0ff17d"
     },
     {
       "kind": "ui-named-argument",
@@ -2095,7 +2095,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Node approval required",
       "surface": "android",
-      "id": "native.android.e177c7f189c1a472"
+      "id": "native.android.68b7d57d738a4c8c"
     },
     {
       "kind": "ui-named-argument",
@@ -2103,7 +2103,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Run on the Gateway host:",
       "surface": "android",
-      "id": "native.android.a850defd5857e7d1"
+      "id": "native.android.707694138bcea92d"
     },
     {
       "kind": "ui-named-argument",
@@ -2111,7 +2111,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Pending Requests",
       "surface": "android",
-      "id": "native.android.70b6f8fccd67f4ce"
+      "id": "native.android.e425c18977a6f063"
     },
     {
       "kind": "ui-named-argument",
@@ -2119,7 +2119,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Nodes",
       "surface": "android",
-      "id": "native.android.5ab18b6bcca8b935"
+      "id": "native.android.5a260a008e0ccbb0"
     },
     {
       "kind": "ui-named-argument",
@@ -2127,7 +2127,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Paired Devices",
       "surface": "android",
-      "id": "native.android.e162df4ac19113aa"
+      "id": "native.android.c2c153da92fb66bf"
     },
     {
       "kind": "conditional-branch",
@@ -2135,7 +2135,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Repair",
       "surface": "android",
-      "id": "native.android.77935d2df6e42230"
+      "id": "native.android.2d49ea3af98a219c"
     },
     {
       "kind": "conditional-branch",
@@ -2143,7 +2143,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Review",
       "surface": "android",
-      "id": "native.android.e29ce7466bc4062a"
+      "id": "native.android.242a6741e592f1ae"
     },
     {
       "kind": "conditional-branch",
@@ -2151,7 +2151,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Paired",
       "surface": "android",
-      "id": "native.android.840e5f49154642c7"
+      "id": "native.android.637e485f2f63d62d"
     },
     {
       "kind": "conditional-branch",
@@ -2159,7 +2159,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Unpaired",
       "surface": "android",
-      "id": "native.android.1a2836f275433165"
+      "id": "native.android.3fae2c80a5c5f51a"
     },
     {
       "kind": "conditional-branch",
@@ -2167,7 +2167,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Needs approval",
       "surface": "android",
-      "id": "native.android.bda106fdedede36c"
+      "id": "native.android.8b9f85be726224fc"
     },
     {
       "kind": "conditional-branch",
@@ -2175,7 +2175,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Needs reapproval",
       "surface": "android",
-      "id": "native.android.a6da605b35be717c"
+      "id": "native.android.bf09c5d014a7c359"
     },
     {
       "kind": "conditional-branch",
@@ -2183,7 +2183,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Unapproved",
       "surface": "android",
-      "id": "native.android.2ea603624b785f18"
+      "id": "native.android.d4ee2c0656e25c4e"
     },
     {
       "kind": "conditional-branch",
@@ -2191,7 +2191,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Offline",
       "surface": "android",
-      "id": "native.android.a6785924afa501a6"
+      "id": "native.android.c42c2a17793748f3"
     },
     {
       "kind": "conditional-branch",
@@ -2199,7 +2199,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Online",
       "surface": "android",
-      "id": "native.android.0bbe0d733b1328fd"
+      "id": "native.android.a7f846dfd8757c0b"
     },
     {
       "kind": "conditional-branch",
@@ -2215,7 +2215,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Trust",
       "surface": "android",
-      "id": "native.android.9ac2d4498b17d478"
+      "id": "native.android.2be55b098fdd3e00"
     },
     {
       "kind": "ui-call",
@@ -2223,7 +2223,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Cancel",
       "surface": "android",
-      "id": "native.android.e26ee07a1d1911be"
+      "id": "native.android.96adee75eb648213"
     },
     {
       "kind": "ui-named-argument",
@@ -2231,7 +2231,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Welcome to OpenClaw",
       "surface": "android",
-      "id": "native.android.64c8db13ef91513c"
+      "id": "native.android.c495432e17643430"
     },
     {
       "kind": "ui-named-argument",
@@ -2239,7 +2239,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Turn this device into a secure OpenClaw node for chat, voice, camera, and device tools.",
       "surface": "android",
-      "id": "native.android.c38e106cc8f1e9ff"
+      "id": "native.android.50ff8eac48445327"
     },
     {
       "kind": "ui-named-argument",
@@ -2247,7 +2247,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "OpenClaw logo",
       "surface": "android",
-      "id": "native.android.f941909a3fa51055"
+      "id": "native.android.6fb50213c46094c8"
     },
     {
       "kind": "ui-named-argument",
@@ -2255,7 +2255,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connect to your Gateway",
       "surface": "android",
-      "id": "native.android.cc878f72a6b70b23"
+      "id": "native.android.942db0370fd15c76"
     },
     {
       "kind": "ui-named-argument",
@@ -2263,7 +2263,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose device permissions",
       "surface": "android",
-      "id": "native.android.bf3750bf264f0063"
+      "id": "native.android.7a2fea26568cf42e"
     },
     {
       "kind": "ui-named-argument",
@@ -2271,7 +2271,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use OpenClaw from your phone",
       "surface": "android",
-      "id": "native.android.3bfe29d4d13d3c3e"
+      "id": "native.android.625b7a24614f4f21"
     },
     {
       "kind": "ui-named-argument",
@@ -2279,7 +2279,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Security notice",
       "surface": "android",
-      "id": "native.android.c0b539eeb4612f5d"
+      "id": "native.android.484966aff6e53901"
     },
     {
       "kind": "ui-named-argument",
@@ -2287,7 +2287,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "The connected OpenClaw agent can use device capabilities you enable. Continue only if you trust the Gateway and agent you connect to.",
       "surface": "android",
-      "id": "native.android.5aed4b5c8d6b246d"
+      "id": "native.android.782acb3787860c7e"
     },
     {
       "kind": "ui-named-argument",
@@ -2295,7 +2295,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connect Gateway",
       "surface": "android",
-      "id": "native.android.63c31ee564d63347"
+      "id": "native.android.fca8a3a515cef8d8"
     },
     {
       "kind": "ui-named-argument",
@@ -2303,7 +2303,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Scan a QR code or use the setup code from your OpenClaw Gateway.",
       "surface": "android",
-      "id": "native.android.f50a9c1ee6d47055"
+      "id": "native.android.e32df9497b746ecf"
     },
     {
       "kind": "ui-toast",
@@ -2311,7 +2311,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Could not open setup guide.",
       "surface": "android",
-      "id": "native.android.58d80589d9d4b7ff"
+      "id": "native.android.7f94bd5688f9cc04"
     },
     {
       "kind": "ui-named-argument",
@@ -2319,7 +2319,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Scan QR or setup code",
       "surface": "android",
-      "id": "native.android.18d6dd32cfcc1c9a"
+      "id": "native.android.81bc77801d27232b"
     },
     {
       "kind": "ui-named-argument",
@@ -2327,7 +2327,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Set up manually",
       "surface": "android",
-      "id": "native.android.8b8acc5b98b8c99f"
+      "id": "native.android.98cbffb3634f0eed"
     },
     {
       "kind": "ui-named-argument",
@@ -2335,7 +2335,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Before you start",
       "surface": "android",
-      "id": "native.android.debd7b3e59db6ab2"
+      "id": "native.android.8f5b8bd8c9d58006"
     },
     {
       "kind": "ui-named-argument",
@@ -2343,7 +2343,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Access to the Gateway device",
       "surface": "android",
-      "id": "native.android.9cfcf68aae2c05c6"
+      "id": "native.android.a78c0233b6e64f3b"
     },
     {
       "kind": "ui-named-argument",
@@ -2351,7 +2351,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Have a terminal open on the device running OpenClaw.",
       "surface": "android",
-      "id": "native.android.c8a43dbba02941f0"
+      "id": "native.android.931a71e7a37bfe8c"
     },
     {
       "kind": "ui-named-argument",
@@ -2359,7 +2359,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Phone can reach the Gateway",
       "surface": "android",
-      "id": "native.android.71ce00f359981a0b"
+      "id": "native.android.b97f86ea52ad42ed"
     },
     {
       "kind": "ui-named-argument",
@@ -2367,7 +2367,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use the same network, or a secure remote Gateway URL.",
       "surface": "android",
-      "id": "native.android.08aa33afe19b0c9c"
+      "id": "native.android.bf987f2d208694ea"
     },
     {
       "kind": "ui-named-argument",
@@ -2375,7 +2375,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Android setup guide",
       "surface": "android",
-      "id": "native.android.68a31cee94a9db86"
+      "id": "native.android.1ae80af456ede5a8"
     },
     {
       "kind": "ui-named-argument",
@@ -2383,7 +2383,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup Gateway",
       "surface": "android",
-      "id": "native.android.d514a981f80779e9"
+      "id": "native.android.87e734a42506c768"
     },
     {
       "kind": "ui-named-argument",
@@ -2391,7 +2391,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Start your Gateway.",
       "surface": "android",
-      "id": "native.android.6a45e2dae35ab5a7"
+      "id": "native.android.2ccb4b2eb2374747"
     },
     {
       "kind": "ui-named-argument",
@@ -2399,7 +2399,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "openclaw gateway",
       "surface": "android",
-      "id": "native.android.d4b295b5146af4b8"
+      "id": "native.android.afee939eac293fce"
     },
     {
       "kind": "ui-named-argument",
@@ -2407,7 +2407,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Generate a QR code.",
       "surface": "android",
-      "id": "native.android.c6f9da7008df05a6"
+      "id": "native.android.7c2f04af312ae9cc"
     },
     {
       "kind": "ui-named-argument",
@@ -2415,7 +2415,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "openclaw qr",
       "surface": "android",
-      "id": "native.android.db24e4be7a1b5547"
+      "id": "native.android.75bdb708d4f8b3f6"
     },
     {
       "kind": "ui-named-argument",
@@ -2423,7 +2423,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose from gallery",
       "surface": "android",
-      "id": "native.android.96d40475de2885d6"
+      "id": "native.android.64e1f77563acef87"
     },
     {
       "kind": "ui-named-argument",
@@ -2431,7 +2431,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "QR code not accepted",
       "surface": "android",
-      "id": "native.android.fd83bd36419ef526"
+      "id": "native.android.68cf31864e7393ad"
     },
     {
       "kind": "ui-named-argument",
@@ -2439,7 +2439,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose another image",
       "surface": "android",
-      "id": "native.android.4dde43318559c65d"
+      "id": "native.android.1efe0da86f3816bd"
     },
     {
       "kind": "ui-named-argument",
@@ -2447,7 +2447,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Scan QR code",
       "surface": "android",
-      "id": "native.android.54bab6e4054484d0"
+      "id": "native.android.488aada5e9eba49c"
     },
     {
       "kind": "ui-named-argument",
@@ -2455,7 +2455,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Open the camera and frame the code from openclaw qr.",
       "surface": "android",
-      "id": "native.android.05987e822ac102ec"
+      "id": "native.android.da118b69f1cd83d4"
     },
     {
       "kind": "ui-named-argument",
@@ -2463,7 +2463,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Align the QR code inside the square.",
       "surface": "android",
-      "id": "native.android.90fa932d2e0adbd9"
+      "id": "native.android.cd5121098eb8d404"
     },
     {
       "kind": "ui-named-argument",
@@ -2471,7 +2471,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Camera access is needed to scan the setup QR.",
       "surface": "android",
-      "id": "native.android.7a817ddf54373dbf"
+      "id": "native.android.b7128178c5bb56ab"
     },
     {
       "kind": "ui-named-argument",
@@ -2479,7 +2479,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Allow camera",
       "surface": "android",
-      "id": "native.android.c8d5f12cb28f3853"
+      "id": "native.android.62d3b74be3cd042c"
     },
     {
       "kind": "ui-named-argument",
@@ -2487,7 +2487,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Close scanner",
       "surface": "android",
-      "id": "native.android.7efba153567b1232"
+      "id": "native.android.edd7982abd878d2a"
     },
     {
       "kind": "ui-named-argument",
@@ -2495,7 +2495,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Enter setup code",
       "surface": "android",
-      "id": "native.android.b8d5431e1e441f74"
+      "id": "native.android.95f0cf50cba907fe"
     },
     {
       "kind": "ui-named-argument",
@@ -2503,7 +2503,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code",
       "surface": "android",
-      "id": "native.android.41e3fbccb2ad5a4c"
+      "id": "native.android.5d05930ed1f0267a"
     },
     {
       "kind": "ui-named-argument",
@@ -2511,7 +2511,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Paste setup code",
       "surface": "android",
-      "id": "native.android.06a2214da1eee841"
+      "id": "native.android.e9d0c5660b8b9c62"
     },
     {
       "kind": "ui-named-argument",
@@ -2519,7 +2519,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code was not accepted",
       "surface": "android",
-      "id": "native.android.35aec8a97ac12e1c"
+      "id": "native.android.af6e7f1c3b9be902"
     },
     {
       "kind": "ui-named-argument",
@@ -2527,7 +2527,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use setup code",
       "surface": "android",
-      "id": "native.android.9aaee5a05de93dbe"
+      "id": "native.android.96f8a67e325811c6"
     },
     {
       "kind": "ui-named-argument",
@@ -2535,7 +2535,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Manual setup",
       "surface": "android",
-      "id": "native.android.073c93545602b198"
+      "id": "native.android.1f58a38c5434782d"
     },
     {
       "kind": "ui-named-argument",
@@ -2543,7 +2543,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway URL",
       "surface": "android",
-      "id": "native.android.46d58ca58c32ad52"
+      "id": "native.android.1281f7d653adb9a6"
     },
     {
       "kind": "ui-named-argument",
@@ -2551,7 +2551,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Host",
       "surface": "android",
-      "id": "native.android.d54b9e3433ffd809"
+      "id": "native.android.a2c381b9cf9f4eb3"
     },
     {
       "kind": "ui-named-argument",
@@ -2559,7 +2559,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Port",
       "surface": "android",
-      "id": "native.android.e7f368b47b705410"
+      "id": "native.android.425e73e2fb1ef9f4"
     },
     {
       "kind": "ui-named-argument",
@@ -2567,7 +2567,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use the Gateway computer's LAN address or secure remote hostname.",
       "surface": "android",
-      "id": "native.android.1b0d9893ae4c0682"
+      "id": "native.android.d75b906c9af7db89"
     },
     {
       "kind": "ui-named-argument",
@@ -2575,7 +2575,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Token",
       "surface": "android",
-      "id": "native.android.bfc48711d6deed92"
+      "id": "native.android.29a662868cbbab20"
     },
     {
       "kind": "ui-named-argument",
@@ -2583,7 +2583,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Paste token",
       "surface": "android",
-      "id": "native.android.7ac2b9aec9d78cda"
+      "id": "native.android.faa0a8feacf9c326"
     },
     {
       "kind": "ui-named-argument",
@@ -2591,7 +2591,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Paste a shared Gateway token or operator-issued token.",
       "surface": "android",
-      "id": "native.android.96ba0e3919c3955a"
+      "id": "native.android.05d75fcef84c66df"
     },
     {
       "kind": "ui-named-argument",
@@ -2599,7 +2599,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Password",
       "surface": "android",
-      "id": "native.android.4a5a1702f0130328"
+      "id": "native.android.1c6739b9e66a0dab"
     },
     {
       "kind": "ui-named-argument",
@@ -2607,7 +2607,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Password optional",
       "surface": "android",
-      "id": "native.android.e7045d344dd32ddc"
+      "id": "native.android.5b28494bb9c24519"
     },
     {
       "kind": "ui-named-argument",
@@ -2615,7 +2615,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connection security",
       "surface": "android",
-      "id": "native.android.0b90d2ae01fe2adc"
+      "id": "native.android.a6f58fcce0c449f2"
     },
     {
       "kind": "ui-named-argument",
@@ -2623,7 +2623,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Unencrypted",
       "surface": "android",
-      "id": "native.android.475b12d58426a78b"
+      "id": "native.android.16c5a0c3029bf13e"
     },
     {
       "kind": "ui-named-argument",
@@ -2631,7 +2631,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Secure (TLS)",
       "surface": "android",
-      "id": "native.android.60133981279752d2"
+      "id": "native.android.a6df1be9820c2685"
     },
     {
       "kind": "ui-named-argument",
@@ -2639,7 +2639,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Could not test connection",
       "surface": "android",
-      "id": "native.android.24a0a4819f223b87"
+      "id": "native.android.8b8410873d160265"
     },
     {
       "kind": "ui-named-argument",
@@ -2647,7 +2647,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Test connection",
       "surface": "android",
-      "id": "native.android.9a8f8ba539d4dd68"
+      "id": "native.android.363737eebe277a8a"
     },
     {
       "kind": "ui-call",
@@ -2655,7 +2655,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "View details",
       "surface": "android",
-      "id": "native.android.a1c6ad798cdb4e32"
+      "id": "native.android.31f77070d11be4e2"
     },
     {
       "kind": "ui-call",
@@ -2663,7 +2663,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connection details",
       "surface": "android",
-      "id": "native.android.ebdc41fd34eab0a5"
+      "id": "native.android.39d844c2b604873f"
     },
     {
       "kind": "ui-call",
@@ -2671,7 +2671,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Copy",
       "surface": "android",
-      "id": "native.android.f982d1f6ad7b3e5d"
+      "id": "native.android.8521a3750162347c"
     },
     {
       "kind": "ui-call",
@@ -2679,7 +2679,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Close",
       "surface": "android",
-      "id": "native.android.fa2a2369f23aa195"
+      "id": "native.android.700f22f8f7faa5b1"
     },
     {
       "kind": "ui-toast",
@@ -2687,7 +2687,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Details copied",
       "surface": "android",
-      "id": "native.android.50cca1e186823cd6"
+      "id": "native.android.555c943ed221a8ab"
     },
     {
       "kind": "ui-named-argument",
@@ -2695,7 +2695,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approve node access",
       "surface": "android",
-      "id": "native.android.31a4bf3ed4071f7c"
+      "id": "native.android.e60b8e592911d6ac"
     },
     {
       "kind": "ui-named-argument",
@@ -2703,7 +2703,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway pairing is complete. Approve this phone as a node so OpenClaw can use the device capabilities you enable.",
       "surface": "android",
-      "id": "native.android.f43cb6ed03dc6766"
+      "id": "native.android.19d18f23beaf40a1"
     },
     {
       "kind": "ui-named-argument",
@@ -2711,7 +2711,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "On the Gateway computer, run:",
       "surface": "android",
-      "id": "native.android.8e49feba12c350ac"
+      "id": "native.android.4315471ce8517607"
     },
     {
       "kind": "ui-named-argument",
@@ -2719,7 +2719,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use the requestId from the pending command in the approve command.",
       "surface": "android",
-      "id": "native.android.6189b5e2af7cc793"
+      "id": "native.android.5079042575298d22"
     },
     {
       "kind": "ui-named-argument",
@@ -2727,7 +2727,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "I have approved",
       "surface": "android",
-      "id": "native.android.53bcd45eeb574d74"
+      "id": "native.android.0c2d81ab522c7d65"
     },
     {
       "kind": "ui-named-argument",
@@ -2735,7 +2735,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Checking approval…",
       "surface": "android",
-      "id": "native.android.0d4dd8ed358a6fb2"
+      "id": "native.android.ec205ff9768fd7e6"
     },
     {
       "kind": "ui-named-argument",
@@ -2743,7 +2743,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Still waiting for approval",
       "surface": "android",
-      "id": "native.android.cdc44aaeb8bd6e4a"
+      "id": "native.android.808599f9ed1698be"
     },
     {
       "kind": "ui-named-argument",
@@ -2751,7 +2751,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Run the approve command on the Gateway computer, then check again.",
       "surface": "android",
-      "id": "native.android.df5cc00eb95c21ad"
+      "id": "native.android.2cd132b805435c33"
     },
     {
       "kind": "ui-named-argument",
@@ -2759,7 +2759,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "OK",
       "surface": "android",
-      "id": "native.android.f579f91c216dd6c4"
+      "id": "native.android.8f850c91c031351f"
     },
     {
       "kind": "ui-named-argument",
@@ -2767,7 +2767,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Copy approval command",
       "surface": "android",
-      "id": "native.android.b80462122abbe312"
+      "id": "native.android.fee9740343810174"
     },
     {
       "kind": "ui-named-argument",
@@ -2775,7 +2775,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Only enable access you are comfortable letting OpenClaw use while this phone is connected. You can change these later in Android Settings.",
       "surface": "android",
-      "id": "native.android.d4c3bcf880727fb3"
+      "id": "native.android.f7f307a8c7f3e8b6"
     },
     {
       "kind": "ui-named-argument",
@@ -2783,7 +2783,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Continue",
       "surface": "android",
-      "id": "native.android.d7ea800cc2475013"
+      "id": "native.android.70a9b5a70e06b56e"
     },
     {
       "kind": "ui-named-argument",
@@ -2791,7 +2791,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Back",
       "surface": "android",
-      "id": "native.android.44549cfd7e6a1ab8"
+      "id": "native.android.81c8796fb187e5a9"
     },
     {
       "kind": "ui-named-argument",
@@ -2799,7 +2799,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Permissions",
       "surface": "android",
-      "id": "native.android.f3f0527db434d756"
+      "id": "native.android.4f47ce320ad8c52c"
     },
     {
       "kind": "conditional-branch",
@@ -2823,7 +2823,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "The code may have expired or been generated for another Gateway.",
       "surface": "android",
-      "id": "native.android.29732759e050c874"
+      "id": "native.android.0bb4ad115bcdcaf2"
     },
     {
       "kind": "conditional-branch",
@@ -2831,7 +2831,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway password is required. Enter it again or edit this connection.",
       "surface": "android",
-      "id": "native.android.511925b4321aae31"
+      "id": "native.android.b28a4a569b4e817f"
     },
     {
       "kind": "conditional-branch",
@@ -2839,7 +2839,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway password is invalid. Re-enter it or reset this gateway connection.",
       "surface": "android",
-      "id": "native.android.beeae935716d1ff4"
+      "id": "native.android.d5d21b945c516dd1"
     },
     {
       "kind": "conditional-branch",
@@ -2847,7 +2847,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway token is required. Enter it again or edit this connection.",
       "surface": "android",
-      "id": "native.android.0a5468f24a0ef9e8"
+      "id": "native.android.f2eb6c0db5749ba0"
     },
     {
       "kind": "conditional-branch",
@@ -2855,7 +2855,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway requires this device identity. Re-authenticate or reset this gateway connection.",
       "surface": "android",
-      "id": "native.android.11fbe9c58ebab116"
+      "id": "native.android.2dba22e8313e9aa5"
     },
     {
       "kind": "conditional-branch",
@@ -2863,7 +2863,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Saved authentication is invalid. Re-authenticate or reset this gateway connection.",
       "surface": "android",
-      "id": "native.android.8a4c5b042f04d8ed"
+      "id": "native.android.b80bc209ee14fbc7"
     },
     {
       "kind": "conditional-branch",
@@ -2871,7 +2871,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication is not configured. Edit this connection and try again.",
       "surface": "android",
-      "id": "native.android.214b03b4cd2199b1"
+      "id": "native.android.49ea7621e189e5d3"
     },
     {
       "kind": "conditional-branch",
@@ -2879,7 +2879,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication needs review. Check gateway settings, then retry.",
       "surface": "android",
-      "id": "native.android.1ccbb6f3911e7219"
+      "id": "native.android.e49f9b63c68f6687"
     },
     {
       "kind": "conditional-branch",
@@ -2919,7 +2919,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approval command copied",
       "surface": "android",
-      "id": "native.android.a7933196a18ec924"
+      "id": "native.android.5735ab0a49a54808"
     },
     {
       "kind": "ui-toast",
@@ -2927,7 +2927,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Command copied",
       "surface": "android",
-      "id": "native.android.32690c5e41e8a4cb"
+      "id": "native.android.92539440f4982c2b"
     },
     {
       "kind": "conditional-branch",
@@ -2935,7 +2935,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Granted",
       "surface": "android",
-      "id": "native.android.437599c024df158e"
+      "id": "native.android.794d39baacf4ce44"
     },
     {
       "kind": "conditional-branch",
@@ -2943,7 +2943,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Not granted",
       "surface": "android",
-      "id": "native.android.cf8344d3562e28e3"
+      "id": "native.android.5fc5b5bd849534e0"
     },
     {
       "kind": "ui-named-argument",
@@ -2951,7 +2951,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Back",
       "surface": "android",
-      "id": "native.android.3b7e036da1b10671"
+      "id": "native.android.531091c529120e0d"
     },
     {
       "kind": "ui-named-argument",
@@ -2959,7 +2959,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Providers & Models",
       "surface": "android",
-      "id": "native.android.82131f121c1cff31"
+      "id": "native.android.f5181cf318851526"
     },
     {
       "kind": "ui-named-argument",
@@ -2967,7 +2967,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Review provider readiness\nand configured models.",
       "surface": "android",
-      "id": "native.android.8eb76aa712ea142a"
+      "id": "native.android.91dd65f8409bcb8b"
     },
     {
       "kind": "ui-named-argument",
@@ -2983,7 +2983,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Connect your Gateway to load provider readiness.",
       "surface": "android",
-      "id": "native.android.c76ebb6f80eaad93"
+      "id": "native.android.0fd8de438e0a87d9"
     },
     {
       "kind": "ui-named-argument",
@@ -2991,7 +2991,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
-      "id": "native.android.bffaa0de604a6248"
+      "id": "native.android.62ef5bc56b0d90d6"
     },
     {
       "kind": "conditional-branch",
@@ -2999,7 +2999,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Loading",
       "surface": "android",
-      "id": "native.android.cc7752fdd9d78d63"
+      "id": "native.android.b5667eb889b75a22"
     },
     {
       "kind": "conditional-branch",
@@ -3007,7 +3007,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "No providers",
       "surface": "android",
-      "id": "native.android.a8af20d207693faa"
+      "id": "native.android.1ee8a786a3171849"
     },
     {
       "kind": "ui-named-argument",
@@ -3015,7 +3015,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Ready",
       "surface": "android",
-      "id": "native.android.07ade123217b0689"
+      "id": "native.android.e5ff67f18327eea1"
     },
     {
       "kind": "ui-named-argument",
@@ -3023,7 +3023,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Needs",
       "surface": "android",
-      "id": "native.android.b36b0c2003a82b53"
+      "id": "native.android.9d70f16c1d754fd9"
     },
     {
       "kind": "ui-named-argument",
@@ -3047,7 +3047,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Connect your Gateway to view provider readiness.",
       "surface": "android",
-      "id": "native.android.24fe64a90afae34e"
+      "id": "native.android.c320f32f079be5b4"
     },
     {
       "kind": "conditional-branch",
@@ -3055,7 +3055,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Refresh",
       "surface": "android",
-      "id": "native.android.7a7bcb60c83ed920"
+      "id": "native.android.198c8d7aa060337c"
     },
     {
       "kind": "conditional-branch",
@@ -3063,7 +3063,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
-      "id": "native.android.f4b6dd970359c304"
+      "id": "native.android.0991c60b26231b1d"
     },
     {
       "kind": "conditional-branch",
@@ -3079,7 +3079,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "No configured models",
       "surface": "android",
-      "id": "native.android.51228649f9d8627a"
+      "id": "native.android.1cd594eae2fddcf5"
     },
     {
       "kind": "conditional-branch",
@@ -3095,7 +3095,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Sessions",
       "surface": "android",
-      "id": "native.android.0e3157c15c56944f"
+      "id": "native.android.5bc8cf7e1d3da771"
     },
     {
       "kind": "ui-named-argument",
@@ -3111,7 +3111,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Recent",
       "surface": "android",
-      "id": "native.android.e0f10db479f627eb"
+      "id": "native.android.d2161471cf1befc0"
     },
     {
       "kind": "ui-named-argument",
@@ -3119,7 +3119,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Current",
       "surface": "android",
-      "id": "native.android.9bc0d0b631dca571"
+      "id": "native.android.bc12df59f85912a6"
     },
     {
       "kind": "ui-named-argument",
@@ -3127,7 +3127,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Archived",
       "surface": "android",
-      "id": "native.android.78654c0f198c6df2"
+      "id": "native.android.5c6f7188e99feb0f"
     },
     {
       "kind": "ui-named-argument",
@@ -3135,7 +3135,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Search sessions",
       "surface": "android",
-      "id": "native.android.b9cf34c137e4cf03"
+      "id": "native.android.1c7b52c649612b82"
     },
     {
       "kind": "ui-named-argument",
@@ -3151,7 +3151,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Newest first",
       "surface": "android",
-      "id": "native.android.dc52c5f9d7b85ec8"
+      "id": "native.android.7d67f14936d152e9"
     },
     {
       "kind": "conditional-branch",
@@ -3159,7 +3159,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Oldest first",
       "surface": "android",
-      "id": "native.android.78b9d0ab41446a1b"
+      "id": "native.android.1f38aef85d823ba8"
     },
     {
       "kind": "ui-named-argument",
@@ -3175,7 +3175,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Toggle session layout",
       "surface": "android",
-      "id": "native.android.c6bf8751e2a7f5c7"
+      "id": "native.android.63ff902213008135"
     },
     {
       "kind": "conditional-branch",
@@ -3183,7 +3183,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Layout: Compact",
       "surface": "android",
-      "id": "native.android.49db3101cf9c806c"
+      "id": "native.android.fe3cdfc2185d1ea2"
     },
     {
       "kind": "conditional-branch",
@@ -3191,7 +3191,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Layout: Detailed",
       "surface": "android",
-      "id": "native.android.bf4f2bc2e1d10e54"
+      "id": "native.android.e7aa1e9cc11f4595"
     },
     {
       "kind": "ui-named-argument",
@@ -3231,7 +3231,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Start Chat",
       "surface": "android",
-      "id": "native.android.75bff03b36200e7b"
+      "id": "native.android.8cecfad5ae72da7f"
     },
     {
       "kind": "conditional-branch",
@@ -3239,7 +3239,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Current session",
       "surface": "android",
-      "id": "native.android.f10d4df7cbc6df4f"
+      "id": "native.android.6ffb1a6fed300f56"
     },
     {
       "kind": "conditional-branch",
@@ -3247,7 +3247,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "OpenClaw session",
       "surface": "android",
-      "id": "native.android.8f0482425838ae64"
+      "id": "native.android.f63640e4154afe78"
     },
     {
       "kind": "ui-named-argument",
@@ -3255,7 +3255,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Rename session",
       "surface": "android",
-      "id": "native.android.786774c8a76e50d7"
+      "id": "native.android.cd2fd07d6ac3c650"
     },
     {
       "kind": "ui-named-argument",
@@ -3263,7 +3263,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Rename group",
       "surface": "android",
-      "id": "native.android.fa420bc51ff675a1"
+      "id": "native.android.6187aa35434029f6"
     },
     {
       "kind": "ui-named-argument",
@@ -3271,7 +3271,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Rename",
       "surface": "android",
-      "id": "native.android.f869da474db7cf6e"
+      "id": "native.android.dff01f28d4e8b1fe"
     },
     {
       "kind": "ui-named-argument",
@@ -3279,7 +3279,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "New group",
       "surface": "android",
-      "id": "native.android.ddbfb1989d641bd2"
+      "id": "native.android.5b00bda0b8c52a7f"
     },
     {
       "kind": "ui-named-argument",
@@ -3287,7 +3287,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Create",
       "surface": "android",
-      "id": "native.android.3208d7c67e225e7f"
+      "id": "native.android.062bafdd9bf01e51"
     },
     {
       "kind": "ui-call",
@@ -3295,7 +3295,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Delete group?",
       "surface": "android",
-      "id": "native.android.8b1585a8a84dc4d9"
+      "id": "native.android.4ba8b58e882c49a1"
     },
     {
       "kind": "ui-call",
@@ -3303,7 +3303,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
       "surface": "android",
-      "id": "native.android.3455fc2f77d564e3"
+      "id": "native.android.bfa8fa468f247d7c"
     },
     {
       "kind": "ui-call",
@@ -3311,7 +3311,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Delete session?",
       "surface": "android",
-      "id": "native.android.4805fb9d6623e8c0"
+      "id": "native.android.5ae62fc38ec68a58"
     },
     {
       "kind": "ui-call",
@@ -3319,7 +3319,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "This permanently deletes the session and its transcript.",
       "surface": "android",
-      "id": "native.android.0c3283a2b2445eae"
+      "id": "native.android.ce4f31b10a74d2bc"
     },
     {
       "kind": "ui-call",
@@ -3327,7 +3327,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Delete",
       "surface": "android",
-      "id": "native.android.807ba5c6699af2f1"
+      "id": "native.android.97db8ec926eed422"
     },
     {
       "kind": "ui-named-argument",
@@ -3335,7 +3335,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Pinned",
       "surface": "android",
-      "id": "native.android.03fd4e5e90f1afe7"
+      "id": "native.android.150f98702b4cbd35"
     },
     {
       "kind": "ui-named-argument",
@@ -3343,7 +3343,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Workspace",
       "surface": "android",
-      "id": "native.android.94a95bad91565148"
+      "id": "native.android.cbab164cec6dc03d"
     },
     {
       "kind": "conditional-branch",
@@ -3351,7 +3351,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
-      "id": "native.android.b5e4ae7f8c9eca2d"
+      "id": "native.android.e0af5898db3ba68c"
     },
     {
       "kind": "ui-call",
@@ -3391,7 +3391,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Pin",
       "surface": "android",
-      "id": "native.android.6637da0312da85f9"
+      "id": "native.android.944b2ebf00a3a3b9"
     },
     {
       "kind": "conditional-branch",
@@ -3399,7 +3399,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Unpin",
       "surface": "android",
-      "id": "native.android.fb512b81634fa8c4"
+      "id": "native.android.3c9623820a99e95e"
     },
     {
       "kind": "conditional-branch",
@@ -3407,7 +3407,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Mark as read",
       "surface": "android",
-      "id": "native.android.b75c8710d4537222"
+      "id": "native.android.d83f18a21fea9f9c"
     },
     {
       "kind": "conditional-branch",
@@ -3415,7 +3415,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Mark as unread",
       "surface": "android",
-      "id": "native.android.a9619e8ed4fd6aa2"
+      "id": "native.android.4df85a10f035d0a2"
     },
     {
       "kind": "ui-call",
@@ -3479,7 +3479,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Group name",
       "surface": "android",
-      "id": "native.android.54c10a1eec2fa17c"
+      "id": "native.android.79969911d667cfc6"
     },
     {
       "kind": "conditional-branch",
@@ -3487,7 +3487,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Name",
       "surface": "android",
-      "id": "native.android.91851a0eb519765f"
+      "id": "native.android.f19f5ac953ff3442"
     },
     {
       "kind": "ui-call",
@@ -3495,7 +3495,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Cancel",
       "surface": "android",
-      "id": "native.android.4e1ffc65a44efec5"
+      "id": "native.android.6e5d1bbd82cee714"
     },
     {
       "kind": "conditional-branch",
@@ -3503,7 +3503,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "No sessions yet",
       "surface": "android",
-      "id": "native.android.db243d71d056afa4"
+      "id": "native.android.43e1ee987cc3f3e1"
     },
     {
       "kind": "conditional-branch",
@@ -3511,7 +3511,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "No current session",
       "surface": "android",
-      "id": "native.android.5b4eee6a8092925e"
+      "id": "native.android.679f6979c9e6ed5a"
     },
     {
       "kind": "conditional-branch",
@@ -3519,7 +3519,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "No archived sessions",
       "surface": "android",
-      "id": "native.android.acbcc9c9ea53d8c0"
+      "id": "native.android.911a85279b8847df"
     },
     {
       "kind": "conditional-branch",
@@ -3527,7 +3527,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Start a new conversation and it will show up here.",
       "surface": "android",
-      "id": "native.android.0a38a1167c6b6941"
+      "id": "native.android.574847da210cac45"
     },
     {
       "kind": "conditional-branch",
@@ -3535,7 +3535,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Open Chat to start or resume the current session.",
       "surface": "android",
-      "id": "native.android.56fcd605dc7be3c0"
+      "id": "native.android.7de883b2a9aadd4c"
     },
     {
       "kind": "conditional-branch",
@@ -3543,7 +3543,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Archived sessions will show up here.",
       "surface": "android",
-      "id": "native.android.085515989f8a2022"
+      "id": "native.android.905745e4c9a5f4fa"
     },
     {
       "kind": "ui-named-argument",
@@ -3551,7 +3551,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Provider limits and quota health.",
       "surface": "android",
-      "id": "native.android.dcb7d5956029bbc4"
+      "id": "native.android.68c92c7c02da533c"
     },
     {
       "kind": "ui-named-argument",
@@ -3559,7 +3559,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Usage",
       "surface": "android",
-      "id": "native.android.aa3fb483f7e264fe"
+      "id": "native.android.e0cb096f6db8aa3d"
     },
     {
       "kind": "ui-named-argument",
@@ -3567,7 +3567,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load usage.",
       "surface": "android",
-      "id": "native.android.e3bdc31bd2f499d7"
+      "id": "native.android.9fd97798f9b3ca15"
     },
     {
       "kind": "ui-named-argument",
@@ -3575,7 +3575,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No usage data yet.",
       "surface": "android",
-      "id": "native.android.0da8c424891138e7"
+      "id": "native.android.d729b8de84be1c3c"
     },
     {
       "kind": "ui-named-argument",
@@ -3583,7 +3583,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Provider limits will appear here when your gateway reports them.",
       "surface": "android",
-      "id": "native.android.e3f6fa2b034cd7f3"
+      "id": "native.android.ab766c96bd46e332"
     },
     {
       "kind": "ui-named-argument",
@@ -3591,7 +3591,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cron Jobs",
       "surface": "android",
-      "id": "native.android.962a15bdb26cb6e1"
+      "id": "native.android.92608ef73f6c6887"
     },
     {
       "kind": "ui-named-argument",
@@ -3599,7 +3599,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scheduled OpenClaw work from your gateway.",
       "surface": "android",
-      "id": "native.android.5e3e4cd42004cb28"
+      "id": "native.android.77e5306c191a88ef"
     },
     {
       "kind": "ui-named-argument",
@@ -3607,7 +3607,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open a job to inspect its configuration and run history. Admin-scoped connections can also run, edit, enable, disable, or delete it.",
       "surface": "android",
-      "id": "native.android.3cd22006987fde12"
+      "id": "native.android.4298c149fc5f86ea"
     },
     {
       "kind": "ui-named-argument",
@@ -3615,7 +3615,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load cron jobs.",
       "surface": "android",
-      "id": "native.android.9354a5bf1e4ce5a5"
+      "id": "native.android.0cbf27ac1bd9c417"
     },
     {
       "kind": "ui-named-argument",
@@ -3623,7 +3623,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No scheduled jobs.",
       "surface": "android",
-      "id": "native.android.239e2598dab8a8b1"
+      "id": "native.android.db1008eb60e10b7d"
     },
     {
       "kind": "ui-named-argument",
@@ -3631,7 +3631,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scheduled work created on the gateway will appear here.",
       "surface": "android",
-      "id": "native.android.bc88f537cd309fcb"
+      "id": "native.android.9d6ba6143a35fc9a"
     },
     {
       "kind": "ui-named-argument",
@@ -3639,7 +3639,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Inspect scheduled gateway work.",
       "surface": "android",
-      "id": "native.android.f6dd71419863574c"
+      "id": "native.android.5d4614bfbd2e3fab"
     },
     {
       "kind": "ui-named-argument",
@@ -3647,7 +3647,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to inspect cron jobs.",
       "surface": "android",
-      "id": "native.android.e3a6337e3c28d3f5"
+      "id": "native.android.f835be79791b2138"
     },
     {
       "kind": "conditional-branch",
@@ -3655,7 +3655,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cron job not loaded.",
       "surface": "android",
-      "id": "native.android.2d3daa5032913461"
+      "id": "native.android.7a43ce366049744c"
     },
     {
       "kind": "conditional-branch",
@@ -3663,7 +3663,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Loading cron job…",
       "surface": "android",
-      "id": "native.android.401993832e04f790"
+      "id": "native.android.16b41bd483c6918c"
     },
     {
       "kind": "ui-named-argument",
@@ -3671,7 +3671,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agents",
       "surface": "android",
-      "id": "native.android.6da97c8c6e1a3d3a"
+      "id": "native.android.badc7bcbe4c2502b"
     },
     {
       "kind": "ui-named-argument",
@@ -3679,7 +3679,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose and inspect the assistants available on this gateway.",
       "surface": "android",
-      "id": "native.android.0f33ca43db97b2a9"
+      "id": "native.android.04972ec470c35978"
     },
     {
       "kind": "ui-named-argument",
@@ -3687,7 +3687,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load agents.",
       "surface": "android",
-      "id": "native.android.8db68417b1226437"
+      "id": "native.android.b860068169f58c6b"
     },
     {
       "kind": "ui-named-argument",
@@ -3695,7 +3695,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No agents loaded yet.",
       "surface": "android",
-      "id": "native.android.c6b1cb74e88b533b"
+      "id": "native.android.d6247aa4b96f0747"
     },
     {
       "kind": "ui-named-argument",
@@ -3703,7 +3703,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Approvals",
       "surface": "android",
-      "id": "native.android.1ba6a31da5ad58e7"
+      "id": "native.android.e9e386dce41162e8"
     },
     {
       "kind": "ui-named-argument",
@@ -3711,7 +3711,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review actions that need your attention.",
       "surface": "android",
-      "id": "native.android.b53cdcaacd0eb0f2"
+      "id": "native.android.7d2dbaeb2fe5f819"
     },
     {
       "kind": "conditional-branch",
@@ -3719,7 +3719,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refresh",
       "surface": "android",
-      "id": "native.android.2f7b688eb1fe6797"
+      "id": "native.android.09f7eeb6cb63d5b6"
     },
     {
       "kind": "conditional-branch",
@@ -3727,7 +3727,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refreshing",
       "surface": "android",
-      "id": "native.android.ffcaffbb2569327b"
+      "id": "native.android.0cafcd5d016933b7"
     },
     {
       "kind": "ui-named-argument",
@@ -3735,7 +3735,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway disconnected.",
       "surface": "android",
-      "id": "native.android.ffeaae71512cf19b"
+      "id": "native.android.67f88e7b433c8a5d"
     },
     {
       "kind": "ui-named-argument",
@@ -3743,7 +3743,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load approval requests in the app.",
       "surface": "android",
-      "id": "native.android.f97e44de2d358dae"
+      "id": "native.android.fba8ef171574a814"
     },
     {
       "kind": "ui-named-argument",
@@ -3751,7 +3751,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No gateway approvals.",
       "surface": "android",
-      "id": "native.android.ee786857e3c467b2"
+      "id": "native.android.eeb2f3d04bda1d60"
     },
     {
       "kind": "ui-named-argument",
@@ -3759,7 +3759,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Exec approval requests will appear here while this phone is connected.",
       "surface": "android",
-      "id": "native.android.38bce22c657f484d"
+      "id": "native.android.b94315856f9107de"
     },
     {
       "kind": "ui-named-argument",
@@ -3767,7 +3767,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Session activity",
       "surface": "android",
-      "id": "native.android.dc3e7ca5a491103a"
+      "id": "native.android.5179b702decbe2f9"
     },
     {
       "kind": "ui-named-argument",
@@ -3775,7 +3775,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Chat tool calls waiting in the active session remain visible here.",
       "surface": "android",
-      "id": "native.android.8551e02b060bd7d8"
+      "id": "native.android.d5125aa479ac68df"
     },
     {
       "kind": "ui-named-argument",
@@ -3783,7 +3783,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "How this phone appears to OpenClaw.",
       "surface": "android",
-      "id": "native.android.fea93eda5bf97d9e"
+      "id": "native.android.5320efca61eb6e96"
     },
     {
       "kind": "ui-named-argument",
@@ -3791,7 +3791,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Profile",
       "surface": "android",
-      "id": "native.android.695229fd01afbc2d"
+      "id": "native.android.8a3af46b848c92fa"
     },
     {
       "kind": "ui-named-argument",
@@ -3799,7 +3799,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Device name",
       "surface": "android",
-      "id": "native.android.dbd3c9b24f72837a"
+      "id": "native.android.aa1c31cf12413052"
     },
     {
       "kind": "ui-named-argument",
@@ -3807,7 +3807,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save Profile",
       "surface": "android",
-      "id": "native.android.18cd027f897c1ba8"
+      "id": "native.android.1ab95b9deae71fc8"
     },
     {
       "kind": "ui-named-argument",
@@ -3815,7 +3815,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Configure voice, transport, and playback.",
       "surface": "android",
-      "id": "native.android.19f0834b4dbcc85a"
+      "id": "native.android.9ee19d22678583ec"
     },
     {
       "kind": "ui-named-argument",
@@ -3823,7 +3823,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Talk Provider Setup",
       "surface": "android",
-      "id": "native.android.8d0458a4fe154e9b"
+      "id": "native.android.ab62b4bf1d71b6ed"
     },
     {
       "kind": "ui-named-argument",
@@ -3831,7 +3831,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Audio Test",
       "surface": "android",
-      "id": "native.android.98a8bbb2b1f382e6"
+      "id": "native.android.a0aa588581ddde85"
     },
     {
       "kind": "ui-named-argument",
@@ -3839,7 +3839,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check that OpenClaw can speak clearly on this phone.",
       "surface": "android",
-      "id": "native.android.5ff888931aae2738"
+      "id": "native.android.9504fb427982df0b"
     },
     {
       "kind": "conditional-branch",
@@ -3847,7 +3847,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enable speaker",
       "surface": "android",
-      "id": "native.android.f82d5d81f5dc9b43"
+      "id": "native.android.7a43d6d9b0acd231"
     },
     {
       "kind": "conditional-branch",
@@ -3855,7 +3855,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Mute speaker",
       "surface": "android",
-      "id": "native.android.4d8d05659dbd4a69"
+      "id": "native.android.479c4a669a7c712a"
     },
     {
       "kind": "conditional-branch",
@@ -3863,7 +3863,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Assistant speech muted",
       "surface": "android",
-      "id": "native.android.fe8d975ef971d148"
+      "id": "native.android.b3d088a0a09536eb"
     },
     {
       "kind": "conditional-branch",
@@ -3871,7 +3871,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replies play aloud",
       "surface": "android",
-      "id": "native.android.7e49f1aeb4888e9a"
+      "id": "native.android.ec6a6d7f89a5ab1b"
     },
     {
       "kind": "conditional-branch",
@@ -3879,7 +3879,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Muted",
       "surface": "android",
-      "id": "native.android.38e5aceba237ea3c"
+      "id": "native.android.6606f93a2265317c"
     },
     {
       "kind": "conditional-branch",
@@ -3887,7 +3887,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "On",
       "surface": "android",
-      "id": "native.android.8e352f042c44c2c2"
+      "id": "native.android.e8a3a1d9409d9726"
     },
     {
       "kind": "ui-named-argument",
@@ -3895,7 +3895,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Done",
       "surface": "android",
-      "id": "native.android.05bd460309ac6db6"
+      "id": "native.android.cb4df5665d87e2a5"
     },
     {
       "kind": "ui-named-argument",
@@ -3903,7 +3903,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Realtime Talk",
       "surface": "android",
-      "id": "native.android.60cf67eb5ec46ea0"
+      "id": "native.android.13dca938e7f478a4"
     },
     {
       "kind": "ui-named-argument",
@@ -3911,7 +3911,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Dictation",
       "surface": "android",
-      "id": "native.android.c80e9a8e3d393676"
+      "id": "native.android.8292ed8d2ae0d333"
     },
     {
       "kind": "conditional-branch",
@@ -3919,7 +3919,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allowlist",
       "surface": "android",
-      "id": "native.android.94527c3346897c00"
+      "id": "native.android.399e2d40d2f8f2dc"
     },
     {
       "kind": "conditional-branch",
@@ -3927,7 +3927,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Blocklist",
       "surface": "android",
-      "id": "native.android.333ae4741b8f80fe"
+      "id": "native.android.e4edbf013d999cb8"
     },
     {
       "kind": "ui-named-argument",
@@ -3935,7 +3935,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose what reaches OpenClaw.",
       "surface": "android",
-      "id": "native.android.9feed8722db5d2cc"
+      "id": "native.android.14d8154e983fc4e2"
     },
     {
       "kind": "ui-named-argument",
@@ -3943,7 +3943,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Notifications",
       "surface": "android",
-      "id": "native.android.d32071018de11907"
+      "id": "native.android.984ea6539b67c942"
     },
     {
       "kind": "conditional-branch",
@@ -3951,7 +3951,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Alerts stay on this phone.",
       "surface": "android",
-      "id": "native.android.c9d07c5b26b5c088"
+      "id": "native.android.437fd06fe33dd131"
     },
     {
       "kind": "conditional-branch",
@@ -3959,7 +3959,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can receive selected alerts.",
       "surface": "android",
-      "id": "native.android.5a077bf9cf4f47c8"
+      "id": "native.android.4c38dd46b7c40131"
     },
     {
       "kind": "ui-call",
@@ -3983,7 +3983,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Granted",
       "surface": "android",
-      "id": "native.android.ebeec52e498bc128"
+      "id": "native.android.66f59b166a4eca9b"
     },
     {
       "kind": "conditional-branch",
@@ -3991,7 +3991,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup",
       "surface": "android",
-      "id": "native.android.08511b2bd4b6103a"
+      "id": "native.android.68bc7dc0171c80e8"
     },
     {
       "kind": "conditional-branch",
@@ -3999,7 +3999,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check Access",
       "surface": "android",
-      "id": "native.android.887a50e577908c66"
+      "id": "native.android.31153e5aa8f9c879"
     },
     {
       "kind": "conditional-branch",
@@ -4007,7 +4007,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open System Access",
       "surface": "android",
-      "id": "native.android.a36abaf83c7830d9"
+      "id": "native.android.83bf4b18f79e45c0"
     },
     {
       "kind": "ui-named-argument",
@@ -4015,7 +4015,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forwarding Mode",
       "surface": "android",
-      "id": "native.android.c21fbdec8c4b390d"
+      "id": "native.android.04307aa27f184f25"
     },
     {
       "kind": "ui-named-argument",
@@ -4023,7 +4023,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App Filter",
       "surface": "android",
-      "id": "native.android.67b1229c396cc573"
+      "id": "native.android.8fd65bacb45c86d6"
     },
     {
       "kind": "conditional-branch",
@@ -4031,7 +4031,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Close App Picker",
       "surface": "android",
-      "id": "native.android.55a7cc971f233829"
+      "id": "native.android.5db8b6b503cc4d6f"
     },
     {
       "kind": "conditional-branch",
@@ -4039,7 +4039,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open App Picker",
       "surface": "android",
-      "id": "native.android.dada58f73e10c525"
+      "id": "native.android.762ea2f0f95f53a4"
     },
     {
       "kind": "ui-named-argument",
@@ -4047,7 +4047,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Search apps",
       "surface": "android",
-      "id": "native.android.05f0112f3661e947"
+      "id": "native.android.2ef4439fb6648b6b"
     },
     {
       "kind": "ui-named-argument",
@@ -4055,7 +4055,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Show System Apps",
       "surface": "android",
-      "id": "native.android.e267498ebcb5245a"
+      "id": "native.android.091931a457c0aa19"
     },
     {
       "kind": "ui-named-argument",
@@ -4063,7 +4063,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Include Android and background packages.",
       "surface": "android",
-      "id": "native.android.4859d7f773be5e98"
+      "id": "native.android.c4148486e118d42f"
     },
     {
       "kind": "ui-named-argument",
@@ -4071,7 +4071,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No matching apps.",
       "surface": "android",
-      "id": "native.android.5a5f58fc2b917d5b"
+      "id": "native.android.3e70c1068b78ebc5"
     },
     {
       "kind": "ui-named-argument",
@@ -4079,7 +4079,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Showing ${visibleApps.size} of ${apps.size}. Refine search for more.",
       "surface": "android",
-      "id": "native.android.7c979f32e6ea115f"
+      "id": "native.android.83ac29ac417ae7e6"
     },
     {
       "kind": "ui-named-argument",
@@ -4087,7 +4087,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose what this phone can share.",
       "surface": "android",
-      "id": "native.android.ae3122660b0489fc"
+      "id": "native.android.0573637895ccf664"
     },
     {
       "kind": "ui-named-argument",
@@ -4095,7 +4095,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Phone Capabilities",
       "surface": "android",
-      "id": "native.android.13c46f9ddf516110"
+      "id": "native.android.fbdd50dbc2f9d7da"
     },
     {
       "kind": "ui-call",
@@ -4127,7 +4127,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow photo library access.",
       "surface": "android",
-      "id": "native.android.7d943661c4341ef0"
+      "id": "native.android.8316cb678ec45750"
     },
     {
       "kind": "conditional-branch",
@@ -4135,7 +4135,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected or full photo access granted.",
       "surface": "android",
-      "id": "native.android.8424669e7840699a"
+      "id": "native.android.891d5c618b7957bf"
     },
     {
       "kind": "ui-call",
@@ -4151,7 +4151,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App list stays on this phone.",
       "surface": "android",
-      "id": "native.android.8ed8ecbbd6112e81"
+      "id": "native.android.edc881f01de4ec74"
     },
     {
       "kind": "conditional-branch",
@@ -4159,7 +4159,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can list launcher-visible apps.",
       "surface": "android",
-      "id": "native.android.bdafaceb7af93f5a"
+      "id": "native.android.fb212783fa45411a"
     },
     {
       "kind": "ui-call",
@@ -4183,7 +4183,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Location",
       "surface": "android",
-      "id": "native.android.4ea310efb1f0e7ff"
+      "id": "native.android.6a65012614f96a0f"
     },
     {
       "kind": "ui-named-argument",
@@ -4191,7 +4191,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always allows requested location checks while OpenClaw is in the background; Android shows this in the persistent node notification.",
       "surface": "android",
-      "id": "native.android.58549715b04997cc"
+      "id": "native.android.251b363c1274cf86"
     },
     {
       "kind": "ui-call",
@@ -4199,7 +4199,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow background location?",
       "surface": "android",
-      "id": "native.android.d5a8d7f97a7971b1"
+      "id": "native.android.55290601441f728a"
     },
     {
       "kind": "ui-call-concatenated",
@@ -4215,7 +4215,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open Settings",
       "surface": "android",
-      "id": "native.android.c48805f3de1d72ca"
+      "id": "native.android.ee4b67ae53763dc6"
     },
     {
       "kind": "ui-call",
@@ -4255,7 +4255,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not Now",
       "surface": "android",
-      "id": "native.android.fd97640418602532"
+      "id": "native.android.95ffc3dd6bc588e4"
     },
     {
       "kind": "ui-call",
@@ -4263,7 +4263,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace gateway setup?",
       "surface": "android",
-      "id": "native.android.f3d5fd047bfdb023"
+      "id": "native.android.f5b8e92ddfefd3c2"
     },
     {
       "kind": "ui-call",
@@ -4271,7 +4271,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace setup",
       "surface": "android",
-      "id": "native.android.869c8be127ce5282"
+      "id": "native.android.be3a12fde0fe71bf"
     },
     {
       "kind": "ui-call",
@@ -4279,7 +4279,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forget gateway?",
       "surface": "android",
-      "id": "native.android.66aad1078731e6a3"
+      "id": "native.android.6412338d3381cbbc"
     },
     {
       "kind": "ui-call",
@@ -4295,7 +4295,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cancel",
       "surface": "android",
-      "id": "native.android.c6c8e0c4b8a9a7cf"
+      "id": "native.android.56fc5118a72dbb37"
     },
     {
       "kind": "ui-named-argument",
@@ -4303,7 +4303,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection between this phone and OpenClaw.",
       "surface": "android",
-      "id": "native.android.9d658ff26e59274b"
+      "id": "native.android.43915f59da302c47"
     },
     {
       "kind": "conditional-branch",
@@ -4311,7 +4311,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connected",
       "surface": "android",
-      "id": "native.android.718cb50d1bff3e32"
+      "id": "native.android.781165db00a32682"
     },
     {
       "kind": "conditional-branch",
@@ -4319,7 +4319,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Offline",
       "surface": "android",
-      "id": "native.android.326c79e18db465ce"
+      "id": "native.android.4dd9b73df50a8be1"
     },
     {
       "kind": "conditional-branch",
@@ -4327,7 +4327,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not paired",
       "surface": "android",
-      "id": "native.android.c0cbf2ed1fc50e4c"
+      "id": "native.android.69b5802d638613c9"
     },
     {
       "kind": "conditional-branch",
@@ -4335,7 +4335,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Online",
       "surface": "android",
-      "id": "native.android.dd5b083db9470281"
+      "id": "native.android.479456a8ed7b6940"
     },
     {
       "kind": "ui-named-argument",
@@ -4343,7 +4343,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Reconnect",
       "surface": "android",
-      "id": "native.android.7b12195e02ebcc34"
+      "id": "native.android.e6b0bcd443b461fd"
     },
     {
       "kind": "ui-named-argument",
@@ -4351,7 +4351,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Disconnect",
       "surface": "android",
-      "id": "native.android.e11f54696b376155"
+      "id": "native.android.7a82cda2c639c389"
     },
     {
       "kind": "ui-named-argument",
@@ -4359,7 +4359,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateways",
       "surface": "android",
-      "id": "native.android.87eee1e2bafbf13b"
+      "id": "native.android.a7d20f8defcf355e"
     },
     {
       "kind": "ui-named-argument",
@@ -4367,7 +4367,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No paired gateways.",
       "surface": "android",
-      "id": "native.android.c3974020a08e239e"
+      "id": "native.android.e9c03df6bc77be18"
     },
     {
       "kind": "ui-call",
@@ -4375,7 +4375,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forget",
       "surface": "android",
-      "id": "native.android.74ee3bbbd2e37e9c"
+      "id": "native.android.0c3e6f3deca4e417"
     },
     {
       "kind": "ui-named-argument",
@@ -4383,7 +4383,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway setup",
       "surface": "android",
-      "id": "native.android.56e98811c4e9b027"
+      "id": "native.android.d4e7423018581e73"
     },
     {
       "kind": "ui-named-argument",
@@ -4391,7 +4391,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scan or paste a setup code to add another gateway.",
       "surface": "android",
-      "id": "native.android.c040d4ee72a810e0"
+      "id": "native.android.2996a332e6e26832"
     },
     {
       "kind": "ui-named-argument",
@@ -4399,7 +4399,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Add gateway",
       "surface": "android",
-      "id": "native.android.a7c243ff3f1d6447"
+      "id": "native.android.b2a4ef45d8132923"
     },
     {
       "kind": "ui-named-argument",
@@ -4407,7 +4407,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup Code",
       "surface": "android",
-      "id": "native.android.77a03c8c22155ec5"
+      "id": "native.android.2d40d0b0a0944eb6"
     },
     {
       "kind": "ui-named-argument",
@@ -4415,7 +4415,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Android can scan or paste an existing setup code, but this gateway does not expose setup-code generation to the app yet. Generate the QR/code on the gateway host with openclaw qr, then scan it here or paste the setup code below.",
       "surface": "android",
-      "id": "native.android.de12fd162a566974"
+      "id": "native.android.393c1f24c4f2ad19"
     },
     {
       "kind": "ui-named-argument",
@@ -4423,7 +4423,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection Setup",
       "surface": "android",
-      "id": "native.android.0e8f4c02f7aa20e9"
+      "id": "native.android.7e84f3bfd234998d"
     },
     {
       "kind": "ui-named-argument",
@@ -4431,7 +4431,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup code",
       "surface": "android",
-      "id": "native.android.1fcfa6e7f5daac35"
+      "id": "native.android.b82f4717096c01c7"
     },
     {
       "kind": "ui-named-argument",
@@ -4439,7 +4439,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Host",
       "surface": "android",
-      "id": "native.android.29fe804ebbaed339"
+      "id": "native.android.f50329d05a2b3676"
     },
     {
       "kind": "ui-named-argument",
@@ -4447,7 +4447,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Port",
       "surface": "android",
-      "id": "native.android.066ae1c70e6db5c1"
+      "id": "native.android.6557999d9fd5aa01"
     },
     {
       "kind": "ui-named-argument",
@@ -4455,7 +4455,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection security",
       "surface": "android",
-      "id": "native.android.16e2f44030be076a"
+      "id": "native.android.8f642d973491194a"
     },
     {
       "kind": "conditional-branch",
@@ -4463,7 +4463,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Secure (TLS)",
       "surface": "android",
-      "id": "native.android.6701e8520a27c448"
+      "id": "native.android.35908838152b14d3"
     },
     {
       "kind": "conditional-branch",
@@ -4471,7 +4471,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Unencrypted",
       "surface": "android",
-      "id": "native.android.86aeb5011ef180cb"
+      "id": "native.android.44b6133bcd9fac99"
     },
     {
       "kind": "ui-named-argument",
@@ -4479,7 +4479,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Token",
       "surface": "android",
-      "id": "native.android.ce47022dd4d431fe"
+      "id": "native.android.a8eabe81edff3ca0"
     },
     {
       "kind": "ui-named-argument",
@@ -4487,7 +4487,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Bootstrap",
       "surface": "android",
-      "id": "native.android.1ac555d95edfac77"
+      "id": "native.android.b00f8fe469850d4c"
     },
     {
       "kind": "ui-named-argument",
@@ -4495,7 +4495,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Password",
       "surface": "android",
-      "id": "native.android.348365a5b167510d"
+      "id": "native.android.860ab2d58b9bff4f"
     },
     {
       "kind": "ui-named-argument",
@@ -4503,7 +4503,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save & Connect",
       "surface": "android",
-      "id": "native.android.d11061d5b8123994"
+      "id": "native.android.c034f78fc099ea2d"
     },
     {
       "kind": "ui-named-argument",
@@ -4511,7 +4511,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enter a valid setup code or gateway address.",
       "surface": "android",
-      "id": "native.android.633d0dcf4b6d6ed8"
+      "id": "native.android.8327ac42acdd8080"
     },
     {
       "kind": "ui-named-argument",
@@ -4519,7 +4519,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Appearance",
       "surface": "android",
-      "id": "native.android.5311e446ce2bf857"
+      "id": "native.android.ac2cf01d6878dcd1"
     },
     {
       "kind": "ui-named-argument",
@@ -4527,7 +4527,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme and translated Android text.",
       "surface": "android",
-      "id": "native.android.15d4461b5fbdc203"
+      "id": "native.android.cb3894b10e28a093"
     },
     {
       "kind": "ui-named-argument",
@@ -4535,7 +4535,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme",
       "surface": "android",
-      "id": "native.android.0e5de6796bc8d8f9"
+      "id": "native.android.5e54f785cffa644f"
     },
     {
       "kind": "ui-named-argument",
@@ -4543,7 +4543,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App language",
       "surface": "android",
-      "id": "native.android.bd997c088145929f"
+      "id": "native.android.b38f23b59c3fe3e1"
     },
     {
       "kind": "ui-named-argument",
@@ -4551,7 +4551,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Changes Android text that OpenClaw has translated. Screens with English-only copy stay unchanged.",
       "surface": "android",
-      "id": "native.android.1fc742aceae3f137"
+      "id": "native.android.fe2de2e947c325dc"
     },
     {
       "kind": "ui-named-argument",
@@ -4559,7 +4559,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected",
       "surface": "android",
-      "id": "native.android.3d640706b2b6b93a"
+      "id": "native.android.2a2b2e3e4791169a"
     },
     {
       "kind": "conditional-branch",
@@ -4567,7 +4567,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Ready",
       "surface": "android",
-      "id": "native.android.664db1aad9792c18"
+      "id": "native.android.f4ca288a4bf10b2b"
     },
     {
       "kind": "ui-named-argument",
@@ -4575,7 +4575,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "About",
       "surface": "android",
-      "id": "native.android.2df2dec704f91977"
+      "id": "native.android.073f2f5ac3a0e495"
     },
     {
       "kind": "ui-named-argument",
@@ -4583,7 +4583,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw for Android.",
       "surface": "android",
-      "id": "native.android.c2d37ac2ad4c9e3c"
+      "id": "native.android.0221754fa3e5df6d"
     },
     {
       "kind": "ui-named-argument",
@@ -4591,7 +4591,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway",
       "surface": "android",
-      "id": "native.android.d744d434533ea8ed"
+      "id": "native.android.eac6c60f9479eab9"
     },
     {
       "kind": "ui-named-argument",
@@ -4599,7 +4599,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Runtime",
       "surface": "android",
-      "id": "native.android.ff6f3e4026089be2"
+      "id": "native.android.1fd548f7c0bb5297"
     },
     {
       "kind": "ui-named-argument",
@@ -4607,7 +4607,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Update",
       "surface": "android",
-      "id": "native.android.b84ae70dbae95380"
+      "id": "native.android.10bcdde8ff9d33bb"
     },
     {
       "kind": "ui-named-argument",
@@ -4615,7 +4615,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "© 2026 OpenClaw Foundation — MIT License.",
       "surface": "android",
-      "id": "native.android.aac3310699b496c8"
+      "id": "native.android.3fdffcb285e875e8"
     },
     {
       "kind": "ui-named-argument",
@@ -4623,7 +4623,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw logo",
       "surface": "android",
-      "id": "native.android.a157bbb606e9b398"
+      "id": "native.android.2a94b5f795f3956d"
     },
     {
       "kind": "ui-named-argument",
@@ -4631,7 +4631,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw",
       "surface": "android",
-      "id": "native.android.7b78b4869baf2160"
+      "id": "native.android.fef1c35e1ac5e5e1"
     },
     {
       "kind": "ui-named-argument",
@@ -4639,7 +4639,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Personal AI on your devices",
       "surface": "android",
-      "id": "native.android.ad4c14835d1b71ca"
+      "id": "native.android.37a73ecc4d53b662"
     },
     {
       "kind": "ui-named-argument",
@@ -4647,7 +4647,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Licenses",
       "surface": "android",
-      "id": "native.android.13f70e22b5648308"
+      "id": "native.android.43bd7acb4e9e2a78"
     },
     {
       "kind": "conditional-branch",
@@ -4655,7 +4655,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw appreciates its partners in the open-source community.",
       "surface": "android",
-      "id": "native.android.996367534eb94cc2"
+      "id": "native.android.d28f97e1a67d60ea"
     },
     {
       "kind": "ui-named-argument",
@@ -4663,7 +4663,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No license notices are packaged in this build.",
       "surface": "android",
-      "id": "native.android.24da1d2eb750ba07"
+      "id": "native.android.82a3b287c0738e8b"
     },
     {
       "kind": "ui-named-argument",
@@ -4671,7 +4671,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open ${license.title}",
       "surface": "android",
-      "id": "native.android.933e72cac84c571e"
+      "id": "native.android.f69c55643aed0781"
     },
     {
       "kind": "conditional-branch",
@@ -4687,7 +4687,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check",
       "surface": "android",
-      "id": "native.android.cfffa5b838a65ca4"
+      "id": "native.android.59f439464fbc62ba"
     },
     {
       "kind": "conditional-branch",
@@ -4711,7 +4711,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Back",
       "surface": "android",
-      "id": "native.android.877490cc2551c8b2"
+      "id": "native.android.9a401c593615eee2"
     },
     {
       "kind": "ui-named-argument",
@@ -4727,7 +4727,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Sending",
       "surface": "android",
-      "id": "native.android.6bbeb853f2a32dba"
+      "id": "native.android.aaf75d99030a0d1b"
     },
     {
       "kind": "ui-named-argument",
@@ -4751,7 +4751,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review",
       "surface": "android",
-      "id": "native.android.4d44e246d2cba408"
+      "id": "native.android.2b8066fd548c47d7"
     },
     {
       "kind": "conditional-branch",
@@ -4759,7 +4759,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Issue",
       "surface": "android",
-      "id": "native.android.1f03bb42f27b48ea"
+      "id": "native.android.16d504af55f23683"
     },
     {
       "kind": "conditional-branch",
@@ -4767,7 +4767,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enabled",
       "surface": "android",
-      "id": "native.android.4a583b7a36684ed7"
+      "id": "native.android.955fcbabac189168"
     },
     {
       "kind": "conditional-branch",
@@ -4775,7 +4775,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No",
       "surface": "android",
-      "id": "native.android.1a3b13c02f53120f"
+      "id": "native.android.7e77c1b8f3d54328"
     },
     {
       "kind": "conditional-branch",
@@ -4783,7 +4783,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Yes",
       "surface": "android",
-      "id": "native.android.9f6111d68ea1c273"
+      "id": "native.android.8cad377065be204a"
     },
     {
       "kind": "ui-named-argument",
@@ -4791,7 +4791,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Error",
       "surface": "android",
-      "id": "native.android.4fcad8b85203f5a8"
+      "id": "native.android.924bbb7bcb446b52"
     },
     {
       "kind": "ui-named-argument",
@@ -4799,7 +4799,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery Error",
       "surface": "android",
-      "id": "native.android.369f2775636e8fd4"
+      "id": "native.android.f77d467f435351d9"
     },
     {
       "kind": "ui-named-argument",
@@ -4807,7 +4807,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Tap to copy",
       "surface": "android",
-      "id": "native.android.d02323bcac09c67f"
+      "id": "native.android.d3442fa9f58a5336"
     },
     {
       "kind": "ui-toast",
@@ -4815,7 +4815,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$title copied",
       "surface": "android",
-      "id": "native.android.09641868d42a68fb"
+      "id": "native.android.407cdad664238a54"
     },
     {
       "kind": "conditional-branch",
@@ -4823,7 +4823,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default assistant",
       "surface": "android",
-      "id": "native.android.727e7f203b075b43"
+      "id": "native.android.bc3a1613d2e311a9"
     },
     {
       "kind": "conditional-branch",
@@ -4831,7 +4831,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default",
       "surface": "android",
-      "id": "native.android.b3185067fb7fa30e"
+      "id": "native.android.4ea819adf440aa71"
     },
     {
       "kind": "conditional-branch",
@@ -4839,7 +4839,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Needs attention",
       "surface": "android",
-      "id": "native.android.ca48afdb0328a6f5"
+      "id": "native.android.65a55e26ff8a0c09"
     },
     {
       "kind": "conditional-branch",
@@ -4847,7 +4847,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting ${minutes}m",
       "surface": "android",
-      "id": "native.android.ee80b2364df97d06"
+      "id": "native.android.dd02cc0b3aa09876"
     },
     {
       "kind": "conditional-branch",
@@ -4855,7 +4855,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting for review",
       "surface": "android",
-      "id": "native.android.fb3f6764d53e5384"
+      "id": "native.android.aee121024405b3d3"
     },
     {
       "kind": "conditional-branch",
@@ -4863,7 +4863,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}",
       "surface": "android",
-      "id": "native.android.98b1e19bdbc1e640"
+      "id": "native.android.157d9164fe973773"
     },
     {
       "kind": "conditional-branch",
@@ -4871,7 +4871,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Off",
       "surface": "android",
-      "id": "native.android.35d4bc86e9ba395d"
+      "id": "native.android.cb46c799211fba00"
     },
     {
       "kind": "conditional-branch",
@@ -4879,7 +4879,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "System Event Text",
       "surface": "android",
-      "id": "native.android.22f3549d0fab271d"
+      "id": "native.android.4b490d2afd0a9296"
     },
     {
       "kind": "conditional-branch",
@@ -4887,7 +4887,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agent Prompt",
       "surface": "android",
-      "id": "native.android.35e7850777bd6c6a"
+      "id": "native.android.9ecb4bf3e5b77bc6"
     },
     {
       "kind": "conditional-branch",
@@ -4895,7 +4895,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Command",
       "surface": "android",
-      "id": "native.android.c49027320aa3f807"
+      "id": "native.android.7fffa742de42a974"
     },
     {
       "kind": "conditional-branch",
@@ -4903,7 +4903,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Payload Text",
       "surface": "android",
-      "id": "native.android.f36439e78187c554"
+      "id": "native.android.71d5efbf19cf8910"
     },
     {
       "kind": "conditional-branch",
@@ -4943,7 +4943,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Close Canvas",
       "surface": "android",
-      "id": "native.android.30d8b822fa68d6c4"
+      "id": "native.android.4597f8605d5af4a5"
     },
     {
       "kind": "ui-named-argument",
@@ -4951,7 +4951,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Overview",
       "surface": "android",
-      "id": "native.android.3d83e0755437a5f9"
+      "id": "native.android.f16d35b6eb88ce55"
     },
     {
       "kind": "ui-named-argument",
@@ -4959,7 +4959,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No recent sessions",
       "surface": "android",
-      "id": "native.android.a5c0f8b3112aa58c"
+      "id": "native.android.b05995ccf255d8ff"
     },
     {
       "kind": "ui-named-argument",
@@ -4967,7 +4967,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Start a chat and your active OpenClaw conversations will appear here.",
       "surface": "android",
-      "id": "native.android.2e33a4fd5f60b550"
+      "id": "native.android.08188983fb7afdce"
     },
     {
       "kind": "ui-named-argument",
@@ -4975,7 +4975,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Start Chat",
       "surface": "android",
-      "id": "native.android.85726cfd4207d48a"
+      "id": "native.android.ee5d1b376e8afd50"
     },
     {
       "kind": "ui-named-argument",
@@ -4983,7 +4983,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
-      "id": "native.android.4f369a09c8731092"
+      "id": "native.android.e1a7cc2e4f02a109"
     },
     {
       "kind": "ui-named-argument",
@@ -4991,7 +4991,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Search",
       "surface": "android",
-      "id": "native.android.097cf19d48e09476"
+      "id": "native.android.c52f025b7e5b1009"
     },
     {
       "kind": "ui-named-argument",
@@ -4999,7 +4999,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "ACTIVE AGENT",
       "surface": "android",
-      "id": "native.android.586490ecd89b15cc"
+      "id": "native.android.09e0827eea5f6784"
     },
     {
       "kind": "conditional-branch",
@@ -5015,7 +5015,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "View",
       "surface": "android",
-      "id": "native.android.c9a9b5795b73925d"
+      "id": "native.android.89fcf7f25f9f2e27"
     },
     {
       "kind": "conditional-branch",
@@ -5023,7 +5023,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$pendingRunCount active",
       "surface": "android",
-      "id": "native.android.57cd2ad60079a630"
+      "id": "native.android.15715cbf095c3988"
     },
     {
       "kind": "conditional-branch",
@@ -5031,7 +5031,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Idle",
       "surface": "android",
-      "id": "native.android.459a499468f5a968"
+      "id": "native.android.b7ada2fda4f6c78f"
     },
     {
       "kind": "ui-named-argument",
@@ -5039,7 +5039,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Runs",
       "surface": "android",
-      "id": "native.android.0a1783caa00ac109"
+      "id": "native.android.0089f7fb2c3ed2ff"
     },
     {
       "kind": "conditional-branch",
@@ -5047,7 +5047,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$sessionCount recent",
       "surface": "android",
-      "id": "native.android.cda6c35cacd55529"
+      "id": "native.android.9c61d0c4e401cd05"
     },
     {
       "kind": "ui-named-argument",
@@ -5055,7 +5055,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Sessions",
       "surface": "android",
-      "id": "native.android.16c3425d3a594481"
+      "id": "native.android.325e45af57d0fde4"
     },
     {
       "kind": "ui-named-argument",
@@ -5063,7 +5063,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Cron",
       "surface": "android",
-      "id": "native.android.9453625738319f06"
+      "id": "native.android.efda5e3e5d5c47f4"
     },
     {
       "kind": "ui-named-argument",
@@ -5071,7 +5071,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Chat",
       "surface": "android",
-      "id": "native.android.5e85ef06f9edc30b"
+      "id": "native.android.012cfc69377230f0"
     },
     {
       "kind": "ui-named-argument",
@@ -5079,7 +5079,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Reconnect gateway",
       "surface": "android",
-      "id": "native.android.9b6c16a36dff5990"
+      "id": "native.android.451edb17c49bf3dc"
     },
     {
       "kind": "ui-named-argument",
@@ -5087,7 +5087,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open ${card.title}",
       "surface": "android",
-      "id": "native.android.42ab09663b243eaa"
+      "id": "native.android.02acef7a7c238987"
     },
     {
       "kind": "ui-named-argument",
@@ -5095,7 +5095,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Talk",
       "surface": "android",
-      "id": "native.android.b61560e884d5b805"
+      "id": "native.android.25ca3ae6935abaa9"
     },
     {
       "kind": "ui-named-argument",
@@ -5103,7 +5103,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open Talk",
       "surface": "android",
-      "id": "native.android.08e318000994609e"
+      "id": "native.android.5503fe9d2ec620a2"
     },
     {
       "kind": "ui-named-argument",
@@ -5111,7 +5111,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Talk settings",
       "surface": "android",
-      "id": "native.android.2b01c53de95831ae"
+      "id": "native.android.e844255ae4ca1e07"
     },
     {
       "kind": "ui-named-argument",
@@ -5119,7 +5119,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Recent Sessions",
       "surface": "android",
-      "id": "native.android.73f07a5d54915259"
+      "id": "native.android.716f7e2778aad382"
     },
     {
       "kind": "ui-named-argument",
@@ -5127,7 +5127,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "View all",
       "surface": "android",
-      "id": "native.android.e7e2862bffbd0706"
+      "id": "native.android.abd4350e362b9af7"
     },
     {
       "kind": "conditional-branch",
@@ -5135,7 +5135,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$onlineNodes/$nodeCount",
       "surface": "android",
-      "id": "native.android.c6943c0abb7897a6"
+      "id": "native.android.1f421fe9eed414ed"
     },
     {
       "kind": "conditional-branch",
@@ -5143,7 +5143,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "None",
       "surface": "android",
-      "id": "native.android.abd477deede96a15"
+      "id": "native.android.b9210c0e76045890"
     },
     {
       "kind": "conditional-branch",
@@ -5159,7 +5159,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Recent conversations",
       "surface": "android",
-      "id": "native.android.7178756ffe9e4c72"
+      "id": "native.android.8ba1171ef6e7f251"
     },
     {
       "kind": "conditional-branch",
@@ -5167,7 +5167,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Browse",
       "surface": "android",
-      "id": "native.android.cbdaff5e476b7dad"
+      "id": "native.android.6eb189d979fa1f3b"
     },
     {
       "kind": "conditional-branch",
@@ -5175,7 +5175,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Offline",
       "surface": "android",
-      "id": "native.android.c093a2297a02405a"
+      "id": "native.android.38f0da7f6cb0da99"
     },
     {
       "kind": "conditional-branch",
@@ -5183,7 +5183,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Working · $pendingRunCount active ${pluralize(\"run\", pendingRunCount)}",
       "surface": "android",
-      "id": "native.android.1196e848f04a3dc1"
+      "id": "native.android.150e7c05abfee1e5"
     },
     {
       "kind": "ui-named-argument",
@@ -5191,7 +5191,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Needs attention",
       "surface": "android",
-      "id": "native.android.f23eab3d31c5e25c"
+      "id": "native.android.27b640f8a13d3656"
     },
     {
       "kind": "ui-named-argument",
@@ -5199,7 +5199,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open ${row.title}",
       "surface": "android",
-      "id": "native.android.8452bcda8a619361"
+      "id": "native.android.d62f3095acdc2da0"
     },
     {
       "kind": "ui-named-argument",
@@ -5207,7 +5207,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open session",
       "surface": "android",
-      "id": "native.android.a65477861c7203aa"
+      "id": "native.android.3b88dc4e5b6b8a17"
     },
     {
       "kind": "ui-named-argument",
@@ -5215,7 +5215,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Back",
       "surface": "android",
-      "id": "native.android.ede6f2717ca8e267"
+      "id": "native.android.1c64619e67254840"
     },
     {
       "kind": "ui-named-argument",
@@ -5223,7 +5223,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Settings",
       "surface": "android",
-      "id": "native.android.ed7e1e2e97bfdd0a"
+      "id": "native.android.cff1475877f8a806"
     },
     {
       "kind": "ui-named-argument",
@@ -5231,7 +5231,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Search settings",
       "surface": "android",
-      "id": "native.android.74a2f842d14cdd25"
+      "id": "native.android.11fccf3dedc569e2"
     },
     {
       "kind": "conditional-branch",
@@ -5239,7 +5239,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Speaker muted",
       "surface": "android",
-      "id": "native.android.68c6f975e8448995"
+      "id": "native.android.345d2424511d2d53"
     },
     {
       "kind": "conditional-branch",
@@ -5247,7 +5247,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Speaker on",
       "surface": "android",
-      "id": "native.android.2ee6a4bee2bffe2a"
+      "id": "native.android.8a1bf1154936cef1"
     },
     {
       "kind": "conditional-branch",
@@ -5255,7 +5255,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Off",
       "surface": "android",
-      "id": "native.android.cd87288a95aa2bf3"
+      "id": "native.android.acc528fb9824c697"
     },
     {
       "kind": "conditional-branch",
@@ -5263,7 +5263,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Smart delivery",
       "surface": "android",
-      "id": "native.android.e471a3620a50dd42"
+      "id": "native.android.69b33c2492973ac3"
     },
     {
       "kind": "conditional-branch",
@@ -5271,7 +5271,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Camera enabled",
       "surface": "android",
-      "id": "native.android.e51cc066a8b41880"
+      "id": "native.android.b93e11ff55b87203"
     },
     {
       "kind": "conditional-branch",
@@ -5279,7 +5279,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Locked",
       "surface": "android",
-      "id": "native.android.a6179e3618d40108"
+      "id": "native.android.c373c56a0e1486b9"
     },
     {
       "kind": "ui-call",
@@ -5303,7 +5303,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "surface": "android",
-      "id": "native.android.ca1451df912ed5cf"
+      "id": "native.android.4e0a2f3a8cdc9440"
     },
     {
       "kind": "conditional-branch",
@@ -5311,7 +5311,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "All systems operational",
       "surface": "android",
-      "id": "native.android.b7d8c506999a68f7"
+      "id": "native.android.7dc95887ece41f83"
     },
     {
       "kind": "conditional-branch",
@@ -5319,7 +5319,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Gateway not connected",
       "surface": "android",
-      "id": "native.android.a818149891391827"
+      "id": "native.android.eb52bb0e9ac4e5cb"
     },
     {
       "kind": "conditional-branch",
@@ -5327,7 +5327,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No provider usage",
       "surface": "android",
-      "id": "native.android.b790e7b89f4b44cc"
+      "id": "native.android.c726f01b481dead2"
     },
     {
       "kind": "conditional-branch",
@@ -5335,7 +5335,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 provider",
       "surface": "android",
-      "id": "native.android.18dd89960d95d098"
+      "id": "native.android.505abbb4d5bf8b5e"
     },
     {
       "kind": "conditional-branch",
@@ -5343,7 +5343,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$count providers",
       "surface": "android",
-      "id": "native.android.22d0e2dfa67399d3"
+      "id": "native.android.2f9b9794176fbf22"
     },
     {
       "kind": "conditional-branch",
@@ -5351,7 +5351,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$pending pending",
       "surface": "android",
-      "id": "native.android.560fea9426127f28"
+      "id": "native.android.45281acf18c320d3"
     },
     {
       "kind": "conditional-branch",
@@ -5359,7 +5359,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 pending",
       "surface": "android",
-      "id": "native.android.5d6077f3ff6528f8"
+      "id": "native.android.43b540ec2036d674"
     },
     {
       "kind": "conditional-branch",
@@ -5367,7 +5367,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$held held",
       "surface": "android",
-      "id": "native.android.c233607d1c8f2b91"
+      "id": "native.android.c949994f34d7e811"
     },
     {
       "kind": "conditional-branch",
@@ -5375,7 +5375,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 held",
       "surface": "android",
-      "id": "native.android.139b4b73d5b2b093"
+      "id": "native.android.78b077eae65134fe"
     },
     {
       "kind": "conditional-branch",
@@ -5383,7 +5383,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$applied applied",
       "surface": "android",
-      "id": "native.android.c13bf9565ea436b4"
+      "id": "native.android.9e06dbae5cff2d1e"
     },
     {
       "kind": "conditional-branch",
@@ -5391,7 +5391,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 applied",
       "surface": "android",
-      "id": "native.android.c4036bd26d44345c"
+      "id": "native.android.de8fe49ac422d924"
     },
     {
       "kind": "ui-named-argument",
@@ -5399,7 +5399,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw mobile",
       "surface": "android",
-      "id": "native.android.e197964b10ba02ce"
+      "id": "native.android.4c701ce37c2c3107"
     },
     {
       "kind": "ui-named-argument",
@@ -5407,7 +5407,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open profile",
       "surface": "android",
-      "id": "native.android.45005deba537cc59"
+      "id": "native.android.6854fc1b51788c24"
     },
     {
       "kind": "conditional-branch",
@@ -5415,7 +5415,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Main session",
       "surface": "android",
-      "id": "native.android.22d755834386db07"
+      "id": "native.android.09c4483b6fd9d92c"
     },
     {
       "kind": "ui-named-argument",
@@ -5423,7 +5423,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Skill Workshop",
       "surface": "android",
-      "id": "native.android.7c6f9feb2c16785f"
+      "id": "native.android.bbebf907cb56f3b8"
     },
     {
       "kind": "ui-named-argument",
@@ -5431,7 +5431,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Review generated skill proposals before they become live skills.",
       "surface": "android",
-      "id": "native.android.21c19709950c3f39"
+      "id": "native.android.3434da6bf61b96c6"
     },
     {
       "kind": "ui-named-argument",
@@ -5439,7 +5439,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
-      "id": "native.android.a68e07b919a2a0d1"
+      "id": "native.android.7e73d08c8e2569d6"
     },
     {
       "kind": "ui-named-argument",
@@ -5447,7 +5447,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Connect to a Gateway to load Skill Workshop proposals.",
       "surface": "android",
-      "id": "native.android.f4baaca21d1b59d8"
+      "id": "native.android.d45bc66e17605adf"
     },
     {
       "kind": "ui-named-argument",
@@ -5455,7 +5455,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "No proposals",
       "surface": "android",
-      "id": "native.android.cbb84c87811aa6d4"
+      "id": "native.android.a3363194a67b865a"
     },
     {
       "kind": "ui-named-argument",
@@ -5463,7 +5463,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Matching proposals will appear here after agents create reusable skill drafts.",
       "surface": "android",
-      "id": "native.android.90a5b0a2e06cd91e"
+      "id": "native.android.d8e3c2c2929d68ad"
     },
     {
       "kind": "ui-call",
@@ -5471,7 +5471,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "${action.action.label} proposal?",
       "surface": "android",
-      "id": "native.android.445ab883554e0249"
+      "id": "native.android.c4cc1cc99ac23927"
     },
     {
       "kind": "ui-named-argument",
@@ -5479,7 +5479,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "This will ${action.action.label.lowercase()} \"${action.title}\" and refresh Skill Workshop state from the gateway.",
       "surface": "android",
-      "id": "native.android.3b3a3f231ac05371"
+      "id": "native.android.12f02a9a855c5d2d"
     },
     {
       "kind": "ui-call",
@@ -5487,7 +5487,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Cancel",
       "surface": "android",
-      "id": "native.android.de53fb795cb7dbea"
+      "id": "native.android.64d222c4541bf328"
     },
     {
       "kind": "conditional-branch",
@@ -5495,7 +5495,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Refresh",
       "surface": "android",
-      "id": "native.android.4c29d1be6804b451"
+      "id": "native.android.e05d8dd3465f3c4a"
     },
     {
       "kind": "conditional-branch",
@@ -5503,7 +5503,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
-      "id": "native.android.bb2b28111f0f9190"
+      "id": "native.android.ee815c98e77fab95"
     },
     {
       "kind": "ui-named-argument",
@@ -5511,7 +5511,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Search proposals",
       "surface": "android",
-      "id": "native.android.cb094500c3b20cfe"
+      "id": "native.android.8971eb1e0cd41b98"
     },
     {
       "kind": "conditional-branch",
@@ -5519,7 +5519,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Open",
       "surface": "android",
-      "id": "native.android.71aa271f37832333"
+      "id": "native.android.ff486cf26bbb3e0f"
     },
     {
       "kind": "conditional-branch",
@@ -5527,7 +5527,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Selected",
       "surface": "android",
-      "id": "native.android.f032646f923b66b3"
+      "id": "native.android.fee3a46bbf30f40a"
     },
     {
       "kind": "ui-named-argument",
@@ -5535,7 +5535,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Apply, reject, and quarantine require operator.admin scope. Reconnect with shared gateway auth or approve an operator.admin device scope upgrade to enable lifecycle actions.",
       "surface": "android",
-      "id": "native.android.cc4d05c30c0dcaa7"
+      "id": "native.android.f93d8fc8b45f6440"
     },
     {
       "kind": "ui-named-argument",
@@ -5543,7 +5543,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Skill Workshop inspect and apply actions",
       "surface": "android",
-      "id": "native.android.b03bb83bfe200f83"
+      "id": "native.android.125ee1012734f227"
     },
     {
       "kind": "conditional-branch",
@@ -5551,7 +5551,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Inspect",
       "surface": "android",
-      "id": "native.android.96e9ca04a5f6b505"
+      "id": "native.android.a502462d359b6e1a"
     },
     {
       "kind": "conditional-branch",
@@ -5559,7 +5559,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Inspecting",
       "surface": "android",
-      "id": "native.android.3be9c3b373e250ed"
+      "id": "native.android.f87ade5b4c3dead6"
     },
     {
       "kind": "conditional-branch",
@@ -5567,7 +5567,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Apply",
       "surface": "android",
-      "id": "native.android.e16e6dd1cfd597e6"
+      "id": "native.android.35209f02829bc8fb"
     },
     {
       "kind": "conditional-branch",
@@ -5575,7 +5575,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Working",
       "surface": "android",
-      "id": "native.android.144ff98399b6eb4a"
+      "id": "native.android.89f5f8fe544cb24e"
     },
     {
       "kind": "ui-named-argument",
@@ -5583,7 +5583,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Skill Workshop reject and quarantine actions",
       "surface": "android",
-      "id": "native.android.6f4c6b0e89efb38f"
+      "id": "native.android.0bbb78824d9947bd"
     },
     {
       "kind": "ui-named-argument",
@@ -5591,7 +5591,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Reject",
       "surface": "android",
-      "id": "native.android.63c1b72274895358"
+      "id": "native.android.a996208b9eb1d248"
     },
     {
       "kind": "ui-named-argument",
@@ -5599,7 +5599,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Quarantine",
       "surface": "android",
-      "id": "native.android.b3b9eca78bd90d1c"
+      "id": "native.android.509600924993700d"
     },
     {
       "kind": "conditional-branch",
@@ -5607,7 +5607,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Pending",
       "surface": "android",
-      "id": "native.android.cabcb1f61fa3cd6f"
+      "id": "native.android.14225e4ee140db83"
     },
     {
       "kind": "conditional-branch",
@@ -5615,7 +5615,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Held",
       "surface": "android",
-      "id": "native.android.2d78d0c70c1913ac"
+      "id": "native.android.a88229b76768cd99"
     },
     {
       "kind": "conditional-branch",
@@ -5623,7 +5623,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Applied",
       "surface": "android",
-      "id": "native.android.733725d1c8280de8"
+      "id": "native.android.90123e136e3b619e"
     },
     {
       "kind": "conditional-branch",
@@ -5631,7 +5631,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Rejected",
       "surface": "android",
-      "id": "native.android.bb3a115829f2c1ec"
+      "id": "native.android.436406d1449eb75c"
     },
     {
       "kind": "conditional-branch",
@@ -5639,7 +5639,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "All",
       "surface": "android",
-      "id": "native.android.10bf039a2781c9b3"
+      "id": "native.android.d7ae7f03ca7d3337"
     },
     {
       "kind": "conditional-branch",
@@ -5647,7 +5647,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Default agent",
       "surface": "android",
-      "id": "native.android.6ce9b4b919803618"
+      "id": "native.android.893dc9ccc7f4c616"
     },
     {
       "kind": "ui-named-argument",
@@ -5655,7 +5655,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Skills",
       "surface": "android",
-      "id": "native.android.4590ee99228ab55f"
+      "id": "native.android.80c31a76d36911e0"
     },
     {
       "kind": "ui-named-argument",
@@ -5663,7 +5663,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Installed capabilities available to OpenClaw.",
       "surface": "android",
-      "id": "native.android.73a666b0a4a0e617"
+      "id": "native.android.e54f8b86c7107c5d"
     },
     {
       "kind": "conditional-branch",
@@ -5671,7 +5671,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Refresh",
       "surface": "android",
-      "id": "native.android.9507bc022dc2e3ed"
+      "id": "native.android.75df82cae92feb0a"
     },
     {
       "kind": "conditional-branch",
@@ -5679,7 +5679,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
-      "id": "native.android.7d03a8b47442f3c4"
+      "id": "native.android.440cbea9e5ec8535"
     },
     {
       "kind": "ui-named-argument",
@@ -5687,7 +5687,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Connect the gateway to load skills.",
       "surface": "android",
-      "id": "native.android.73f15da5b2ffdf3c"
+      "id": "native.android.d8bb7c815d6f476c"
     },
     {
       "kind": "ui-named-argument",
@@ -5695,7 +5695,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "No skills installed.",
       "surface": "android",
-      "id": "native.android.619e28818ef4952c"
+      "id": "native.android.055fa27a85844f96"
     },
     {
       "kind": "ui-named-argument",
@@ -5703,7 +5703,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Skills installed on the gateway will appear here.",
       "surface": "android",
-      "id": "native.android.ab93e3d2d6496eda"
+      "id": "native.android.4d7bd951b8afc5a6"
     },
     {
       "kind": "ui-named-argument",
@@ -5711,7 +5711,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Inspect installed skill capability and setup state.",
       "surface": "android",
-      "id": "native.android.81d900273232ce39"
+      "id": "native.android.280f2fb5970d8c7c"
     },
     {
       "kind": "ui-named-argument",
@@ -5719,7 +5719,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Setup",
       "surface": "android",
-      "id": "native.android.f8ddbaf7e1288598"
+      "id": "native.android.f680471aff2e7905"
     },
     {
       "kind": "ui-named-argument",
@@ -5727,7 +5727,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Connect the gateway to load skill details.",
       "surface": "android",
-      "id": "native.android.28e324e5ddfa47b8"
+      "id": "native.android.a7d72ff3468dd07c"
     },
     {
       "kind": "ui-named-argument",
@@ -5735,7 +5735,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Skill detail is not available in the current skills status.",
       "surface": "android",
-      "id": "native.android.7aec7b029a6fc11d"
+      "id": "native.android.4bcee4717129c7ae"
     },
     {
       "kind": "ui-named-argument",
@@ -5743,7 +5743,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Description",
       "surface": "android",
-      "id": "native.android.3b697df990c29cb3"
+      "id": "native.android.35249c704e7b4753"
     },
     {
       "kind": "conditional-branch",
@@ -5751,7 +5751,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Built-in",
       "surface": "android",
-      "id": "native.android.d4839a05fe9c87f6"
+      "id": "native.android.b4beaa70a73d98be"
     },
     {
       "kind": "conditional-branch",
@@ -5759,7 +5759,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Bundled",
       "surface": "android",
-      "id": "native.android.22b4fbf77219bd16"
+      "id": "native.android.c58175350498ccb4"
     },
     {
       "kind": "conditional-branch",
@@ -5767,7 +5767,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Installed",
       "surface": "android",
-      "id": "native.android.ad7cf15ce9d982b4"
+      "id": "native.android.45ac30aa89a70f73"
     },
     {
       "kind": "conditional-branch",
@@ -5775,7 +5775,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Workspace",
       "surface": "android",
-      "id": "native.android.5f25a347c064cb57"
+      "id": "native.android.b5ffe9c62fe2d8e1"
     },
     {
       "kind": "conditional-branch",
@@ -5783,7 +5783,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Extra",
       "surface": "android",
-      "id": "native.android.61a83abee9380b37"
+      "id": "native.android.e5d8e623204c2b24"
     },
     {
       "kind": "conditional-branch",
@@ -5791,7 +5791,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Skill",
       "surface": "android",
-      "id": "native.android.14d7845e9790eaab"
+      "id": "native.android.1f7938aac01e5d63"
     },
     {
       "kind": "ui-named-argument",
@@ -5799,7 +5799,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/TerminalSettingsScreen.kt",
       "source": "Back",
       "surface": "android",
-      "id": "native.android.efc938b5cc23e079"
+      "id": "native.android.57a047bc1549ceab"
     },
     {
       "kind": "ui-named-argument",
@@ -5807,7 +5807,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/TerminalSettingsScreen.kt",
       "source": "Terminal",
       "surface": "android",
-      "id": "native.android.3e0f25545a6ccfb4"
+      "id": "native.android.657133107ee77be1"
     },
     {
       "kind": "ui-named-argument",
@@ -5815,7 +5815,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/TerminalSettingsScreen.kt",
       "source": "Terminal needs a connected gateway",
       "surface": "android",
-      "id": "native.android.a196c4c819426137"
+      "id": "native.android.1f2001a736b51519"
     },
     {
       "kind": "ui-named-argument",
@@ -5823,7 +5823,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/TerminalSettingsScreen.kt",
       "source": "Connect to your gateway to open a shell in the agent workspace.",
       "surface": "android",
-      "id": "native.android.9f3ceb93047671b5"
+      "id": "native.android.9bc2c2fe13f9f8ec"
     },
     {
       "kind": "ui-named-argument",
@@ -5831,7 +5831,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Dictation",
       "surface": "android",
-      "id": "native.android.5e0524a5d86e673a"
+      "id": "native.android.9376e1fcf5fdecde"
     },
     {
       "kind": "ui-named-argument",
@@ -5839,7 +5839,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Transcribe then send",
       "surface": "android",
-      "id": "native.android.afda4b6690e194bb"
+      "id": "native.android.e11270d1dc9ccd81"
     },
     {
       "kind": "ui-named-argument",
@@ -5847,7 +5847,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Dictation settings",
       "surface": "android",
-      "id": "native.android.198d5005ddb92f81"
+      "id": "native.android.de440b43aa477aaa"
     },
     {
       "kind": "conditional-branch",
@@ -5855,7 +5855,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Sending to chat...",
       "surface": "android",
-      "id": "native.android.c6b9223985115579"
+      "id": "native.android.d6740dd3f5dfdf89"
     },
     {
       "kind": "conditional-branch",
@@ -5863,7 +5863,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Start speaking...",
       "surface": "android",
-      "id": "native.android.3d692aaf1d8db847"
+      "id": "native.android.a360bf29e64910a6"
     },
     {
       "kind": "ui-named-argument",
@@ -5871,7 +5871,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Speech provider",
       "surface": "android",
-      "id": "native.android.6849abfceeca563e"
+      "id": "native.android.7bf45e4340eca6d9"
     },
     {
       "kind": "ui-named-argument",
@@ -5879,7 +5879,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Tip: stop listening to send the captured turn.",
       "surface": "android",
-      "id": "native.android.83e924e18ed13f80"
+      "id": "native.android.9c73b948a811ff7f"
     },
     {
       "kind": "ui-named-argument",
@@ -5887,7 +5887,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Cancel",
       "surface": "android",
-      "id": "native.android.6e03e484667c0fae"
+      "id": "native.android.8aaa040065bd09c4"
     },
     {
       "kind": "conditional-branch",
@@ -5895,7 +5895,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Send to Chat",
       "surface": "android",
-      "id": "native.android.be60507f8320ba30"
+      "id": "native.android.cf827f2c85d0894d"
     },
     {
       "kind": "ui-named-argument",
@@ -5903,7 +5903,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Back to voice",
       "surface": "android",
-      "id": "native.android.01fbec5b76e35975"
+      "id": "native.android.be27ec477fe4a4b2"
     },
     {
       "kind": "ui-named-argument",
@@ -5911,7 +5911,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Realtime Talk",
       "surface": "android",
-      "id": "native.android.3d5d539d6adde13c"
+      "id": "native.android.84c700e5cb2b6144"
     },
     {
       "kind": "conditional-branch",
@@ -5943,7 +5943,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Talk settings",
       "surface": "android",
-      "id": "native.android.33ec06cb156adf64"
+      "id": "native.android.334cbe27e8c4f8ea"
     },
     {
       "kind": "ui-named-argument",
@@ -5951,7 +5951,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Live transcript",
       "surface": "android",
-      "id": "native.android.fa79aec52f4ca61c"
+      "id": "native.android.b62bc0f7524af22b"
     },
     {
       "kind": "conditional-branch",
@@ -5959,7 +5959,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Mute",
       "surface": "android",
-      "id": "native.android.c8f07b6659f101b0"
+      "id": "native.android.b99a47f342b7178d"
     },
     {
       "kind": "conditional-branch",
@@ -5967,7 +5967,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Unmute",
       "surface": "android",
-      "id": "native.android.5d4f2992e2320c3e"
+      "id": "native.android.402ab18984cb3c66"
     },
     {
       "kind": "ui-named-argument",
@@ -5975,7 +5975,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "End",
       "surface": "android",
-      "id": "native.android.d7ffaa41c514ba38"
+      "id": "native.android.a773b2e88c4bcf79"
     },
     {
       "kind": "ui-named-argument",
@@ -5983,7 +5983,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Listening for your next turn.",
       "surface": "android",
-      "id": "native.android.b67e9d126075dc78"
+      "id": "native.android.a3b5da4f39064711"
     },
     {
       "kind": "ui-named-argument",
@@ -5991,7 +5991,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
-      "id": "native.android.253debc9d0714dda"
+      "id": "native.android.41ee56880eb211cb"
     },
     {
       "kind": "ui-named-argument",
@@ -5999,7 +5999,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Search voice",
       "surface": "android",
-      "id": "native.android.ece74bf084239d34"
+      "id": "native.android.05e4aee51d2763fb"
     },
     {
       "kind": "ui-named-argument",
@@ -6007,7 +6007,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Voice",
       "surface": "android",
-      "id": "native.android.f2c14708240881f4"
+      "id": "native.android.44b12f2d29cfe297"
     },
     {
       "kind": "conditional-branch",
@@ -6015,7 +6015,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Mute speaker",
       "surface": "android",
-      "id": "native.android.3f08bdce481e440f"
+      "id": "native.android.3da73c3abd286e61"
     },
     {
       "kind": "conditional-branch",
@@ -6023,7 +6023,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Unmute speaker",
       "surface": "android",
-      "id": "native.android.756c27fec566684c"
+      "id": "native.android.ac98e3c297355929"
     },
     {
       "kind": "conditional-branch",
@@ -6031,7 +6031,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "End Talk",
       "surface": "android",
-      "id": "native.android.1493d618a615552d"
+      "id": "native.android.8d3669607b164169"
     },
     {
       "kind": "conditional-branch",
@@ -6039,7 +6039,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Stop Dictation",
       "surface": "android",
-      "id": "native.android.13e71be7bb52391b"
+      "id": "native.android.7bf5317e8204e16b"
     },
     {
       "kind": "ui-named-argument",
@@ -6047,7 +6047,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Voice setup",
       "surface": "android",
-      "id": "native.android.71fa9c845cdb89bd"
+      "id": "native.android.c801692a185c938a"
     },
     {
       "kind": "conditional-branch",
@@ -6055,7 +6055,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "You",
       "surface": "android",
-      "id": "native.android.24057bba4bbfa27a"
+      "id": "native.android.f3db8d90d17cdff1"
     },
     {
       "kind": "ui-named-argument",
@@ -6063,7 +6063,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Sending",
       "surface": "android",
-      "id": "native.android.c4423034d764ee3f"
+      "id": "native.android.f4cba4d63463dd93"
     },
     {
       "kind": "ui-named-argument",
@@ -6071,7 +6071,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
-      "id": "native.android.5b8bd9f2b69b91ea"
+      "id": "native.android.5bc7ecbc5f2a49cf"
     },
     {
       "kind": "ui-named-argument",
@@ -6079,7 +6079,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Permission needed",
       "surface": "android",
-      "id": "native.android.420cccbd48298a8d"
+      "id": "native.android.ee9debbf2637b6de"
     },
     {
       "kind": "ui-named-argument",
@@ -6087,7 +6087,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Microphone access is needed.",
       "surface": "android",
-      "id": "native.android.d0cc4cfee06d9849"
+      "id": "native.android.97e9ed6b1046e4a8"
     },
     {
       "kind": "ui-named-argument",
@@ -6095,7 +6095,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "OpenClaw only listens when you start Talk or Dictation.",
       "surface": "android",
-      "id": "native.android.285eeed928be0fc1"
+      "id": "native.android.14d924bca8ecc830"
     },
     {
       "kind": "ui-named-argument",
@@ -6103,7 +6103,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Enable Microphone",
       "surface": "android",
-      "id": "native.android.b10a51fe9d4b8d2d"
+      "id": "native.android.f2850b632d11d3bc"
     },
     {
       "kind": "ui-named-argument",
@@ -6119,7 +6119,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "Files unavailable",
       "surface": "android",
-      "id": "native.android.eb6ff96aba8f67b4"
+      "id": "native.android.9b3592fd32526671"
     },
     {
       "kind": "ui-named-argument",
@@ -6127,7 +6127,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "Empty folder",
       "surface": "android",
-      "id": "native.android.fefb4a6c1717210d"
+      "id": "native.android.ecf78c5481c7dc8f"
     },
     {
       "kind": "ui-named-argument",
@@ -6135,7 +6135,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "This folder has no files yet.",
       "surface": "android",
-      "id": "native.android.b74f90dc5f65b1da"
+      "id": "native.android.9511ba3213bf7810"
     },
     {
       "kind": "ui-named-argument",
@@ -6143,7 +6143,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "Could not load this folder.",
       "surface": "android",
-      "id": "native.android.8f0b5317c75e334d"
+      "id": "native.android.d5dd23746acf7456"
     },
     {
       "kind": "ui-named-argument",
@@ -6151,7 +6151,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "Load more",
       "surface": "android",
-      "id": "native.android.4e48916e1b0f86ab"
+      "id": "native.android.b5c0cb8521d7fc26"
     },
     {
       "kind": "ui-named-argument",
@@ -6159,7 +6159,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "${entries.size} of $totalEntries",
       "surface": "android",
-      "id": "native.android.f26b7b179d4765b0"
+      "id": "native.android.5395b58a53fcd10e"
     },
     {
       "kind": "ui-named-argument",
@@ -6167,7 +6167,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "Back",
       "surface": "android",
-      "id": "native.android.b2a525ca00a799df"
+      "id": "native.android.65e71f667e84ef39"
     },
     {
       "kind": "ui-named-argument",
@@ -6175,7 +6175,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "Share file",
       "surface": "android",
-      "id": "native.android.737edf881bc586d5"
+      "id": "native.android.be124067c7b9c709"
     },
     {
       "kind": "ui-named-argument",
@@ -6183,7 +6183,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "No preview",
       "surface": "android",
-      "id": "native.android.095574301bf487a1"
+      "id": "native.android.45b1bf9726e61a27"
     },
     {
       "kind": "ui-named-argument",
@@ -6191,7 +6191,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "This image could not be decoded.",
       "surface": "android",
-      "id": "native.android.f57b231996a10d14"
+      "id": "native.android.b3454d7755ab7fab"
     },
     {
       "kind": "conditional-branch",
@@ -6207,7 +6207,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMarkdown.kt",
       "source": "$index.",
       "surface": "android",
-      "id": "native.android.cd2033b0a82a72dd"
+      "id": "native.android.5e4eb33858d294ff"
     },
     {
       "kind": "ui-named-argument",
@@ -6215,7 +6215,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMarkdown.kt",
       "source": "Image unavailable",
       "surface": "android",
-      "id": "native.android.bef360f847488651"
+      "id": "native.android.3b3fc26137bee567"
     },
     {
       "kind": "conditional-branch",
@@ -6223,7 +6223,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "$quoted\n\n",
       "surface": "android",
-      "id": "native.android.e64a6673728dadcb"
+      "id": "native.android.547147ddb32a7a2a"
     },
     {
       "kind": "ui-named-argument",
@@ -6231,7 +6231,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Message actions",
       "surface": "android",
-      "id": "native.android.7bf61a1da504c271"
+      "id": "native.android.14a2c20fedc07713"
     },
     {
       "kind": "conditional-branch",
@@ -6239,7 +6239,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Listen",
       "surface": "android",
-      "id": "native.android.9b4d58eb6f2eb2af"
+      "id": "native.android.187b68770a1879c3"
     },
     {
       "kind": "conditional-branch",
@@ -6247,7 +6247,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Stop",
       "surface": "android",
-      "id": "native.android.dc64ec935e5d0de4"
+      "id": "native.android.36e9ad12ce427210"
     },
     {
       "kind": "ui-named-argument",
@@ -6255,7 +6255,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Copy",
       "surface": "android",
-      "id": "native.android.fab176fe78fc2500"
+      "id": "native.android.c57de75229e8df1c"
     },
     {
       "kind": "ui-named-argument",
@@ -6263,7 +6263,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Select text",
       "surface": "android",
-      "id": "native.android.319b4a29df279bb3"
+      "id": "native.android.da09739e056101ad"
     },
     {
       "kind": "ui-named-argument",
@@ -6271,7 +6271,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Share",
       "surface": "android",
-      "id": "native.android.fc50d4d9ec3b5a0b"
+      "id": "native.android.c2009f686014fa7a"
     },
     {
       "kind": "ui-named-argument",
@@ -6279,7 +6279,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Reply",
       "surface": "android",
-      "id": "native.android.7b896902a024d85f"
+      "id": "native.android.173af6a0cba08b7c"
     },
     {
       "kind": "ui-call",
@@ -6287,7 +6287,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Done",
       "surface": "android",
-      "id": "native.android.3f40011c9f02a65a"
+      "id": "native.android.7ce13e4e77388dfa"
     },
     {
       "kind": "ui-toast",
@@ -6295,7 +6295,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Message copied",
       "surface": "android",
-      "id": "native.android.833dec4c78ab5eae"
+      "id": "native.android.22fc823b544f8e3c"
     },
     {
       "kind": "ui-chooser",
@@ -6303,7 +6303,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Share message",
       "surface": "android",
-      "id": "native.android.7fecaa645b302769"
+      "id": "native.android.80e2f709f949d686"
     },
     {
       "kind": "ui-toast",
@@ -6311,7 +6311,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "No app can share this message",
       "surface": "android",
-      "id": "native.android.d06711f88020d74e"
+      "id": "native.android.39cafe851e4917e8"
     },
     {
       "kind": "conditional-branch",
@@ -6319,7 +6319,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Preparing audio…",
       "surface": "android",
-      "id": "native.android.9ab1dd78954fc3c2"
+      "id": "native.android.e951bed9cad8e7e2"
     },
     {
       "kind": "conditional-branch",
@@ -6327,7 +6327,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Speaking…",
       "surface": "android",
-      "id": "native.android.0ee4d153c4e592d3"
+      "id": "native.android.53e70a782848c575"
     },
     {
       "kind": "ui-named-argument",
@@ -6335,7 +6335,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Preview · $domain",
       "surface": "android",
-      "id": "native.android.71ef7f8dbe2b0dbe"
+      "id": "native.android.3f797bd46f64c399"
     },
     {
       "kind": "ui-named-argument",
@@ -6343,7 +6343,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Expand link preview",
       "surface": "android",
-      "id": "native.android.b49e81e487cdbaa3"
+      "id": "native.android.146ad6126d0d743b"
     },
     {
       "kind": "ui-call",
@@ -6351,7 +6351,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Loading preview…",
       "surface": "android",
-      "id": "native.android.986fd353169b6153"
+      "id": "native.android.a68b57ad9bbdfd61"
     },
     {
       "kind": "ui-call",
@@ -6359,7 +6359,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "No preview available",
       "surface": "android",
-      "id": "native.android.edb04556385d80d5"
+      "id": "native.android.462d3d24e221d604"
     },
     {
       "kind": "ui-call",
@@ -6367,7 +6367,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Thinking...",
       "surface": "android",
-      "id": "native.android.a50e44d8f380f9ad"
+      "id": "native.android.566e7b170900c696"
     },
     {
       "kind": "ui-named-argument",
@@ -6375,7 +6375,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Tools",
       "surface": "android",
-      "id": "native.android.ff4a092a02bd5d17"
+      "id": "native.android.d284c6fe721265ee"
     },
     {
       "kind": "ui-call",
@@ -6383,7 +6383,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Running tools...",
       "surface": "android",
-      "id": "native.android.3788802f6c138c8b"
+      "id": "native.android.a9994372273d3405"
     },
     {
       "kind": "ui-call",
@@ -6391,7 +6391,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "${display.emoji} ${display.label}",
       "surface": "android",
-      "id": "native.android.5f93173e06eda5c0"
+      "id": "native.android.8a136560c51b9e3e"
     },
     {
       "kind": "ui-named-argument",
@@ -6399,7 +6399,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "... +${toolCalls.size - 6} more",
       "surface": "android",
-      "id": "native.android.29021f925bf290c7"
+      "id": "native.android.642ebd06e4e64b15"
     },
     {
       "kind": "ui-call",
@@ -6415,7 +6415,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "You",
       "surface": "android",
-      "id": "native.android.b3ff30d4e0b3ce58"
+      "id": "native.android.844586e4424bfc28"
     },
     {
       "kind": "ui-named-argument",
@@ -6431,7 +6431,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Retry",
       "surface": "android",
-      "id": "native.android.9bd31c23ebdf7c7a"
+      "id": "native.android.aaae8873b8fa69dd"
     },
     {
       "kind": "ui-named-argument",
@@ -6439,7 +6439,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Delete",
       "surface": "android",
-      "id": "native.android.b728b15914267f57"
+      "id": "native.android.2d681bab2e92e2de"
     },
     {
       "kind": "ui-call",
@@ -6455,7 +6455,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "OpenClaw · Live",
       "surface": "android",
-      "id": "native.android.dfbd755eb43b4d26"
+      "id": "native.android.60c9a2b33fed8aac"
     },
     {
       "kind": "conditional-branch",
@@ -6463,7 +6463,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "System",
       "surface": "android",
-      "id": "native.android.d29098025118ce4b"
+      "id": "native.android.e3541114ce44342d"
     },
     {
       "kind": "conditional-branch",
@@ -6471,7 +6471,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "OpenClaw",
       "surface": "android",
-      "id": "native.android.82e9fe45e93909b6"
+      "id": "native.android.31e961bd32783c5d"
     },
     {
       "kind": "ui-named-argument",
@@ -6495,7 +6495,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Unsupported attachment",
       "surface": "android",
-      "id": "native.android.09720189ba712747"
+      "id": "native.android.42470ffb9dd06aa0"
     },
     {
       "kind": "conditional-branch",
@@ -6511,7 +6511,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat needs attention",
       "surface": "android",
-      "id": "native.android.22a4efbe2bab8b80"
+      "id": "native.android.039c8d56bac7f017"
     },
     {
       "kind": "ui-named-argument",
@@ -6519,7 +6519,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
-      "id": "native.android.b73c79389a8cff07"
+      "id": "native.android.d966f773e31302ac"
     },
     {
       "kind": "ui-named-argument",
@@ -6527,7 +6527,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
-      "id": "native.android.25d8575c0063aee5"
+      "id": "native.android.ee660a4842207fb6"
     },
     {
       "kind": "ui-named-argument",
@@ -6535,7 +6535,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
-      "id": "native.android.4437f3cbdb3c8cbe"
+      "id": "native.android.9113a8f1d915f708"
     },
     {
       "kind": "ui-named-argument",
@@ -6543,7 +6543,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "More new chat options",
       "surface": "android",
-      "id": "native.android.6b0f8ea129bca167"
+      "id": "native.android.3e731ba817462206"
     },
     {
       "kind": "ui-named-argument",
@@ -6551,7 +6551,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
-      "id": "native.android.0066c3883e9eff15"
+      "id": "native.android.0e76fbb496811ed5"
     },
     {
       "kind": "ui-named-argument",
@@ -6559,7 +6559,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
-      "id": "native.android.707eccff20a79f65"
+      "id": "native.android.f60ba3ea5cc2670e"
     },
     {
       "kind": "ui-named-argument",
@@ -6567,7 +6567,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading session",
       "surface": "android",
-      "id": "native.android.882cc14a58e7e105"
+      "id": "native.android.1b8a464ad323ed86"
     },
     {
       "kind": "ui-named-argument",
@@ -6575,7 +6575,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
-      "id": "native.android.2c1106e1687ab258"
+      "id": "native.android.79e6a7b8fad4a0d9"
     },
     {
       "kind": "conditional-branch",
@@ -6583,7 +6583,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
-      "id": "native.android.9df2c9d68bad169f"
+      "id": "native.android.9adfe0fe0dfd0d71"
     },
     {
       "kind": "conditional-branch",
@@ -6615,7 +6615,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
-      "id": "native.android.6bbe3c5b5193d985"
+      "id": "native.android.81767170cb87af93"
     },
     {
       "kind": "ui-named-argument",
@@ -6623,7 +6623,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
-      "id": "native.android.579c05816c7dfa79"
+      "id": "native.android.20ccd2b43bbdce99"
     },
     {
       "kind": "conditional-branch",
@@ -6631,7 +6631,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Preparing audio…",
       "surface": "android",
-      "id": "native.android.5aafbef3744d86f3"
+      "id": "native.android.448d75947f69746a"
     },
     {
       "kind": "conditional-branch",
@@ -6639,7 +6639,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Speaking…",
       "surface": "android",
-      "id": "native.android.d7919c440a82f426"
+      "id": "native.android.73d50d3aa44254e5"
     },
     {
       "kind": "ui-named-argument",
@@ -6647,7 +6647,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
-      "id": "native.android.781f84dfaf7da9d6"
+      "id": "native.android.85156730449587a5"
     },
     {
       "kind": "ui-named-argument",
@@ -6655,7 +6655,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is working",
       "surface": "android",
-      "id": "native.android.d851a32f367f8b31"
+      "id": "native.android.a7049c6ca1631d53"
     },
     {
       "kind": "ui-named-argument",
@@ -6663,7 +6663,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
-      "id": "native.android.0fd6b75cadc0ce75"
+      "id": "native.android.97f3ec3a2698bc89"
     },
     {
       "kind": "ui-named-argument",
@@ -6671,7 +6671,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
-      "id": "native.android.7e0aea1dca378135"
+      "id": "native.android.f793872105b71f5c"
     },
     {
       "kind": "ui-named-argument",
@@ -6679,7 +6679,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
-      "id": "native.android.98a0d4d5bba788c4"
+      "id": "native.android.fbf542fa6c554bc2"
     },
     {
       "kind": "ui-named-argument",
@@ -6695,7 +6695,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
-      "id": "native.android.76d574acfac94fee"
+      "id": "native.android.fe15e047ed00f6c2"
     },
     {
       "kind": "ui-named-argument",
@@ -6703,7 +6703,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Default",
       "surface": "android",
-      "id": "native.android.2cb3ec7379426dfe"
+      "id": "native.android.93b1a319b6210883"
     },
     {
       "kind": "conditional-branch",
@@ -6711,7 +6711,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Pin model",
       "surface": "android",
-      "id": "native.android.f8d0f6ba7608abc3"
+      "id": "native.android.6d8ff45bb2f49515"
     },
     {
       "kind": "conditional-branch",
@@ -6719,7 +6719,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Unpin model",
       "surface": "android",
-      "id": "native.android.09a13ed8f039a9c3"
+      "id": "native.android.1bb8eeba5c2c8cbf"
     },
     {
       "kind": "ui-named-argument",
@@ -6727,7 +6727,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
-      "id": "native.android.5953c956ff208e6e"
+      "id": "native.android.24fe1cac748d327b"
     },
     {
       "kind": "ui-named-argument",
@@ -6735,7 +6735,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
-      "id": "native.android.8e3e367df24cae4b"
+      "id": "native.android.34065f11257bd8d6"
     },
     {
       "kind": "conditional-branch",
@@ -6759,7 +6759,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
-      "id": "native.android.623e434c83e3c020"
+      "id": "native.android.3f0cc86baa23528c"
     },
     {
       "kind": "ui-named-argument",
@@ -6767,7 +6767,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
-      "id": "native.android.f1d69eb66c5dfa39"
+      "id": "native.android.377738368b2028c0"
     },
     {
       "kind": "ui-named-argument",
@@ -6775,7 +6775,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Open voice",
       "surface": "android",
-      "id": "native.android.97602a28629a331f"
+      "id": "native.android.61a15f4f636f31ce"
     },
     {
       "kind": "ui-named-argument",
@@ -6783,7 +6783,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
-      "id": "native.android.5054269049758d6a"
+      "id": "native.android.3fd764f16df42c0d"
     },
     {
       "kind": "conditional-branch",
@@ -6791,7 +6791,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
-      "id": "native.android.5fa853a957713a56"
+      "id": "native.android.c22d101ed0256dea"
     },
     {
       "kind": "conditional-branch",
@@ -6799,7 +6799,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$emoji $name",
       "surface": "android",
-      "id": "native.android.6ef0b7ad012c32da"
+      "id": "native.android.c2abc42af6bbf273"
     },
     {
       "kind": "ui-named-argument",
@@ -6807,7 +6807,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
-      "id": "native.android.6e2fcc9d67fc1273"
+      "id": "native.android.466310cf1fe922d7"
     },
     {
       "kind": "conditional-branch",
@@ -6815,7 +6815,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",
-      "id": "native.android.4e6c67df44d588d3"
+      "id": "native.android.4107ab7369c81b20"
     },
     {
       "kind": "ui-named-argument",
@@ -6823,7 +6823,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/VoiceNoteComposer.kt",
       "source": "Preparing voice note…",
       "surface": "android",
-      "id": "native.android.3df4e24a0fc8810b"
+      "id": "native.android.20d589c9b34d08e5"
     },
     {
       "kind": "ui-named-argument",
@@ -6831,7 +6831,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/VoiceNoteComposer.kt",
       "source": "Record voice note",
       "surface": "android",
-      "id": "native.android.06ab95879f652d3e"
+      "id": "native.android.5649ada7a9295f5b"
     },
     {
       "kind": "ui-named-argument",
@@ -6839,7 +6839,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/VoiceNoteComposer.kt",
       "source": "Cancel voice note",
       "surface": "android",
-      "id": "native.android.8a7653317387033f"
+      "id": "native.android.2a2c5ad98a6ddc2d"
     },
     {
       "kind": "ui-named-argument",
@@ -6847,7 +6847,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/VoiceNoteComposer.kt",
       "source": "Finish voice note",
       "surface": "android",
-      "id": "native.android.fb327cd3030aae44"
+      "id": "native.android.6af7a9209409e0fc"
     },
     {
       "kind": "ui-named-argument",
@@ -6855,7 +6855,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/VoiceNoteComposer.kt",
       "source": "Voice note",
       "surface": "android",
-      "id": "native.android.e9d238668cb46e71"
+      "id": "native.android.a9dffd00a4789c03"
     },
     {
       "kind": "ui-named-argument",
@@ -6863,7 +6863,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Local command center",
       "surface": "android",
-      "id": "native.android.64459adde73e63f2"
+      "id": "native.android.48878d597b77627b"
     },
     {
       "kind": "ui-named-argument",
@@ -6871,7 +6871,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "OC",
       "surface": "android",
-      "id": "native.android.dc3aa392cc80e61c"
+      "id": "native.android.fe1563c75a718246"
     },
     {
       "kind": "ui-named-argument",
@@ -6879,7 +6879,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Search",
       "surface": "android",
-      "id": "native.android.f5fd5dc2947b2d8f"
+      "id": "native.android.328d7e498cb4fddf"
     },
     {
       "kind": "ui-named-argument",
@@ -6887,7 +6887,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "OpenClaw",
       "surface": "android",
-      "id": "native.android.79d7a1026ef43e80"
+      "id": "native.android.ff13ffcb0f13c2d0"
     },
     {
       "kind": "ui-named-argument",
@@ -6895,7 +6895,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Design system prototype",
       "surface": "android",
-      "id": "native.android.e8318a46a213cb91"
+      "id": "native.android.c21e3ea23a01cf14"
     },
     {
       "kind": "ui-named-argument",
@@ -6903,7 +6903,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Connected",
       "surface": "android",
-      "id": "native.android.082bff8feba7dab7"
+      "id": "native.android.39176ac7b4baed2c"
     },
     {
       "kind": "ui-named-argument",
@@ -6911,7 +6911,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Sessions",
       "surface": "android",
-      "id": "native.android.81931886b9caf3ab"
+      "id": "native.android.a09d2db471e98067"
     },
     {
       "kind": "ui-named-argument",
@@ -6919,7 +6919,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Testing testing 1 2 3",
       "surface": "android",
-      "id": "native.android.e4dc7610b0898e37"
+      "id": "native.android.63c1a0823f81fad6"
     },
     {
       "kind": "ui-named-argument",
@@ -6927,7 +6927,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "14 messages · Android",
       "surface": "android",
-      "id": "native.android.9ffcbda6cdb9bc00"
+      "id": "native.android.80215e310c00378e"
     },
     {
       "kind": "ui-named-argument",
@@ -6935,7 +6935,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Provider setup",
       "surface": "android",
-      "id": "native.android.5c84ed8a78a5c5d5"
+      "id": "native.android.a3df85d63a5e097b"
     },
     {
       "kind": "ui-named-argument",
@@ -6943,7 +6943,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "OpenClaw gateway",
       "surface": "android",
-      "id": "native.android.794873efdfcdff4f"
+      "id": "native.android.d704e1644ae338b0"
     },
     {
       "kind": "ui-named-argument",
@@ -6951,7 +6951,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Ask OpenClaw anything",
       "surface": "android",
-      "id": "native.android.2d3b6dd9a8f186fe"
+      "id": "native.android.8432ceda35222fe7"
     },
     {
       "kind": "ui-named-argument",
@@ -6959,7 +6959,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Start Chat",
       "surface": "android",
-      "id": "native.android.608ccdaeababf056"
+      "id": "native.android.4ff19ec4e36594cf"
     },
     {
       "kind": "ui-named-argument",
@@ -6967,7 +6967,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Voice",
       "surface": "android",
-      "id": "native.android.e5c1ad9a97e2192c"
+      "id": "native.android.50e1fc168e3192ce"
     },
     {
       "kind": "ui-named-argument",
@@ -6975,7 +6975,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Realtime",
       "surface": "android",
-      "id": "native.android.efeaa73f880276a0"
+      "id": "native.android.8799e7d7da0053c6"
     },
     {
       "kind": "ui-named-argument",
@@ -6983,7 +6983,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Dictation",
       "surface": "android",
-      "id": "native.android.4552f643f5af9ace"
+      "id": "native.android.dbf1f49e91f92a8d"
     },
     {
       "kind": "ui-named-argument",
@@ -6991,7 +6991,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Screen",
       "surface": "android",
-      "id": "native.android.46b35cc0fdc3c1bd"
+      "id": "native.android.35c848cbc6d50957"
     },
     {
       "kind": "ui-named-argument",
@@ -6999,7 +6999,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Nothing needs your attention",
       "surface": "android",
-      "id": "native.android.994ac738d819f2e6"
+      "id": "native.android.5e75c2a9ccb2dc3a"
     },
     {
       "kind": "ui-named-argument",
@@ -7007,7 +7007,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "OpenClaw will surface approvals, failed jobs, and channel issues here.",
       "surface": "android",
-      "id": "native.android.3457b4ee28d964ee"
+      "id": "native.android.db422f5953772c69"
     },
     {
       "kind": "ui-call",
@@ -7031,7 +7031,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Speaking · waiting for reply",
       "surface": "android",
-      "id": "native.android.c5e56f0e8af094fb"
+      "id": "native.android.1b90d84b8fbff362"
     },
     {
       "kind": "conditional-branch",
@@ -7039,7 +7039,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Speaking…",
       "surface": "android",
-      "id": "native.android.7228c229ce9f97c6"
+      "id": "native.android.63722e202a33bd02"
     },
     {
       "kind": "conditional-branch",
@@ -7047,7 +7047,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Mic on · waiting for gateway",
       "surface": "android",
-      "id": "native.android.6fbf0916309dbaba"
+      "id": "native.android.1369ecf9bc8adc90"
     },
     {
       "kind": "conditional-branch",
@@ -7055,7 +7055,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Mic off",
       "surface": "android",
-      "id": "native.android.d84c6c14e42763ff"
+      "id": "native.android.fd6e35016b990650"
     },
     {
       "kind": "conditional-branch",
@@ -7063,7 +7063,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Mic off · sending…",
       "surface": "android",
-      "id": "native.android.9dda2b87d9668a4b"
+      "id": "native.android.ca2190761f679d29"
     },
     {
       "kind": "conditional-branch",
@@ -7071,7 +7071,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Listening · sending queued voice",
       "surface": "android",
-      "id": "native.android.c802b757f76226d9"
+      "id": "native.android.04465040125a492a"
     },
     {
       "kind": "conditional-branch",
@@ -7079,7 +7079,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Sending queued voice",
       "surface": "android",
-      "id": "native.android.01ac388cd8ae0732"
+      "id": "native.android.8dd66e315d86e834"
     },
     {
       "kind": "conditional-branch",
@@ -7095,7 +7095,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Listening",
       "surface": "android",
-      "id": "native.android.b4f67e96603515bd"
+      "id": "native.android.7b4dacae0686d138"
     },
     {
       "kind": "conditional-branch",
@@ -7103,7 +7103,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Ready",
       "surface": "android",
-      "id": "native.android.b88e4278ead724ba"
+      "id": "native.android.47a59f8798682ea0"
     },
     {
       "kind": "conditional-branch",
@@ -7111,7 +7111,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Off",
       "surface": "android",
-      "id": "native.android.8d8230088f3baa2a"
+      "id": "native.android.24bc808758b925ca"
     },
     {
       "kind": "conditional-branch",
@@ -7119,7 +7119,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: Realtime provider closed unexpectedly.",
       "surface": "android",
-      "id": "native.android.d6b7f86564ac3147"
+      "id": "native.android.fcd38b57e71b0a44"
     },
     {
       "kind": "conditional-branch",
@@ -7127,7 +7127,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: Realtime provider closed: $reason",
       "surface": "android",
-      "id": "native.android.eb6ac739ad55e63a"
+      "id": "native.android.508073ba8ce8dbab"
     },
     {
       "kind": "conditional-branch",
@@ -7135,7 +7135,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Aborted",
       "surface": "android",
-      "id": "native.android.13531fe081a45711"
+      "id": "native.android.a052faac05102427"
     },
     {
       "kind": "conditional-branch",
@@ -7143,7 +7143,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Chat error",
       "surface": "android",
-      "id": "native.android.42af8acef7e61a34"
+      "id": "native.android.d74e945c050d1270"
     },
     {
       "kind": "resource-item",
@@ -7151,7 +7151,7 @@
       "path": "apps/android/app/src/main/res/values/assistant.xml",
       "source": "ask OpenClaw $prompt",
       "surface": "android",
-      "id": "native.android.f392ee2d50d6b7ce"
+      "id": "native.android.1c8204beac579400"
     },
     {
       "kind": "resource-item",
@@ -7159,7 +7159,7 @@
       "path": "apps/android/app/src/main/res/values/assistant.xml",
       "source": "tell OpenClaw to $prompt",
       "surface": "android",
-      "id": "native.android.ea9d1a78cfa13033"
+      "id": "native.android.5e6a4cdb1a3396b4"
     },
     {
       "kind": "resource-item",
@@ -7167,7 +7167,7 @@
       "path": "apps/android/app/src/main/res/values/assistant.xml",
       "source": "open OpenClaw and ask $prompt",
       "surface": "android",
-      "id": "native.android.7f96ac9b9e10abd0"
+      "id": "native.android.955cf25f83e27ddf"
     },
     {
       "kind": "resource-string",
@@ -7175,7 +7175,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "OpenClaw Node",
       "surface": "android",
-      "id": "native.android.a3c395b04ae7a621"
+      "id": "native.android.0896dd39a15d179c"
     },
     {
       "kind": "resource-string",
@@ -7183,7 +7183,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Trust this gateway?",
       "surface": "android",
-      "id": "native.android.cd32b06480d9bb69"
+      "id": "native.android.c2ad57046ba6ec63"
     },
     {
       "kind": "resource-string",
@@ -7191,7 +7191,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Trust and continue",
       "surface": "android",
-      "id": "native.android.402c9af5ba395caf"
+      "id": "native.android.da307d07e759a49c"
     },
     {
       "kind": "resource-string",
@@ -7199,7 +7199,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Cancel",
       "surface": "android",
-      "id": "native.android.bc749f6034799c2e"
+      "id": "native.android.9f4bb5310986e12a"
     },
     {
       "kind": "resource-string",
@@ -7207,7 +7207,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "New chat in worktree",
       "surface": "android",
-      "id": "native.android.88d68890ea867ffc"
+      "id": "native.android.ec5b929bd9e4e691"
     },
     {
       "kind": "resource-string",
@@ -7215,7 +7215,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Verify the certificate fingerprint before trusting this gateway.\n\n%1$s",
       "surface": "android",
-      "id": "native.android.288b83f93172c633"
+      "id": "native.android.795c1befed52cda1"
     },
     {
       "kind": "resource-string",
@@ -7223,7 +7223,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "surface": "android",
-      "id": "native.android.6ad2d3f084142bed"
+      "id": "native.android.a1a61798ee1fbb0c"
     },
     {
       "kind": "resource-string",
@@ -7231,7 +7231,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Unknown",
       "surface": "android",
-      "id": "native.android.f1252c0c03619337"
+      "id": "native.android.ce9a512f967ff31b"
     },
     {
       "kind": "resource-string",
@@ -7239,7 +7239,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "VERSION",
       "surface": "android",
-      "id": "native.android.c0b5650d8639911c"
+      "id": "native.android.a5f7189cdf721ca4"
     },
     {
       "kind": "resource-string",
@@ -7247,7 +7247,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "COMMIT",
       "surface": "android",
-      "id": "native.android.d6f7fd58d1959e6f"
+      "id": "native.android.6e043b7d5cf526c1"
     },
     {
       "kind": "resource-string",
@@ -7255,7 +7255,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "BUILT",
       "surface": "android",
-      "id": "native.android.b28b492b48e83ad3"
+      "id": "native.android.37510143af4aa75b"
     },
     {
       "kind": "resource-string",
@@ -7263,7 +7263,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Version %1$s",
       "surface": "android",
-      "id": "native.android.115aa71eb2a66fb6"
+      "id": "native.android.aba33d677f46c9d2"
     },
     {
       "kind": "resource-string",
@@ -7271,7 +7271,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Git commit %1$s",
       "surface": "android",
-      "id": "native.android.eeddd6984c0eb974"
+      "id": "native.android.04ea7703e47e9f3a"
     },
     {
       "kind": "resource-string",
@@ -7279,7 +7279,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Built %1$s UTC, timestamp %2$s",
       "surface": "android",
-      "id": "native.android.a253a9c122cc5871"
+      "id": "native.android.63331a879e3cccc0"
     },
     {
       "kind": "resource-string",
@@ -7287,7 +7287,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Build date %1$s",
       "surface": "android",
-      "id": "native.android.e2d234b2ea956a77"
+      "id": "native.android.941fcaadbe5408e0"
     },
     {
       "kind": "resource-string",
@@ -7295,7 +7295,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Copy full Git commit hash",
       "surface": "android",
-      "id": "native.android.eaf3c88646e35cab"
+      "id": "native.android.ad691cc437cb8853"
     },
     {
       "kind": "resource-string",
@@ -7303,7 +7303,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Copy full build timestamp",
       "surface": "android",
-      "id": "native.android.d869a719216054b8"
+      "id": "native.android.5a1fef71971ff3b0"
     },
     {
       "kind": "resource-string",
@@ -7311,7 +7311,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "OpenClaw Git commit",
       "surface": "android",
-      "id": "native.android.e3661fcea979a74c"
+      "id": "native.android.f9df2e488784cea9"
     },
     {
       "kind": "resource-string",
@@ -7319,7 +7319,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "OpenClaw build timestamp",
       "surface": "android",
-      "id": "native.android.a610564c863cdef7"
+      "id": "native.android.b8a8b10e70efee90"
     },
     {
       "kind": "resource-string",
@@ -7327,7 +7327,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Git commit copied",
       "surface": "android",
-      "id": "native.android.9b9a42b4f56bea2a"
+      "id": "native.android.9b58b180900f5f21"
     },
     {
       "kind": "resource-string",
@@ -7335,7 +7335,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Build timestamp copied",
       "surface": "android",
-      "id": "native.android.6a0c0b0dc97333fe"
+      "id": "native.android.22b65d6917035a20"
     },
     {
       "kind": "plist-string",
@@ -7343,7 +7343,7 @@
       "path": "apps/ios/ActivityWidget/Info.plist",
       "source": "OpenClaw Activity",
       "surface": "apple",
-      "id": "native.apple.8f741d09cc1d5495"
+      "id": "native.apple.77e1b76264f6e734"
     },
     {
       "kind": "ui-call",
@@ -7351,7 +7351,7 @@
       "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
       "source": "OpenClaw",
       "surface": "apple",
-      "id": "native.apple.86d546e1f1247028"
+      "id": "native.apple.767a39dadf2f332a"
     },
     {
       "kind": "plist-string",
@@ -7359,7 +7359,7 @@
       "path": "apps/ios/ShareExtension/Info.plist",
       "source": "OpenClaw Share",
       "surface": "apple",
-      "id": "native.apple.9168fcd110c3019a"
+      "id": "native.apple.0efe0a6cd715517f"
     },
     {
       "kind": "conditional-branch",
@@ -7375,7 +7375,7 @@
       "path": "apps/ios/Sources/Camera/CameraController.swift",
       "source": "Camera",
       "surface": "apple",
-      "id": "native.apple.23834d0ff7589921"
+      "id": "native.apple.d2f42e4947258847"
     },
     {
       "kind": "conditional-branch",
@@ -7383,7 +7383,7 @@
       "path": "apps/ios/Sources/Camera/CameraController.swift",
       "source": "Microphone",
       "surface": "apple",
-      "id": "native.apple.9c73bf4bd647d298"
+      "id": "native.apple.cf938712869b588d"
     },
     {
       "kind": "conditional-branch",
@@ -7399,7 +7399,7 @@
       "path": "apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift",
       "source": "that request",
       "surface": "apple",
-      "id": "native.apple.a811eb3e4d2174d5"
+      "id": "native.apple.9ae16535e59ef8de"
     },
     {
       "kind": "ui-named-argument",
@@ -7407,7 +7407,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Promoted Entries",
       "surface": "apple",
-      "id": "native.apple.6507fad2526215fc"
+      "id": "native.apple.51431f85d6a50322"
     },
     {
       "kind": "ui-named-argument",
@@ -7415,7 +7415,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "No promoted entries",
       "surface": "apple",
-      "id": "native.apple.7e73f233a79a8007"
+      "id": "native.apple.5e974464e65728ab"
     },
     {
       "kind": "ui-named-argument",
@@ -7423,7 +7423,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Dreaming has not promoted durable memory entries yet.",
       "surface": "apple",
-      "id": "native.apple.e20c6da13995b769"
+      "id": "native.apple.92587ce949bbbbe1"
     },
     {
       "kind": "ui-named-argument",
@@ -7431,7 +7431,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Signal Entries",
       "surface": "apple",
-      "id": "native.apple.f37dc8d03ad70555"
+      "id": "native.apple.f3d75171719dce87"
     },
     {
       "kind": "ui-named-argument",
@@ -7439,7 +7439,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "No signal entries",
       "surface": "apple",
-      "id": "native.apple.2802710c41f25f87"
+      "id": "native.apple.7e6152828d5363c5"
     },
     {
       "kind": "ui-named-argument",
@@ -7447,7 +7447,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "No recent recall, daily, grounded, or phase signals were reported.",
       "surface": "apple",
-      "id": "native.apple.2665e709446f3510"
+      "id": "native.apple.9da02020361eb35b"
     },
     {
       "kind": "ui-named-argument",
@@ -7455,7 +7455,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Short-Term Recall",
       "surface": "apple",
-      "id": "native.apple.188e21c57debe55d"
+      "id": "native.apple.3fa5573b7ed1013c"
     },
     {
       "kind": "ui-named-argument",
@@ -7463,7 +7463,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "No short-term entries",
       "surface": "apple",
-      "id": "native.apple.da521f32f4d1b56d"
+      "id": "native.apple.e16abefdccd7168e"
     },
     {
       "kind": "ui-named-argument",
@@ -7471,7 +7471,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "The short-term dreaming store is empty.",
       "surface": "apple",
-      "id": "native.apple.3533db79b1ce15b2"
+      "id": "native.apple.2f54677eed397b9a"
     },
     {
       "kind": "ui-named-argument",
@@ -7479,7 +7479,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Dreaming",
       "surface": "apple",
-      "id": "native.apple.66facc5ade07c85d"
+      "id": "native.apple.b8c0aec8efcb198c"
     },
     {
       "kind": "conditional-branch",
@@ -7487,7 +7487,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Backfill",
       "surface": "apple",
-      "id": "native.apple.db33016dc3f5171e"
+      "id": "native.apple.40a661e3dff0953d"
     },
     {
       "kind": "conditional-branch",
@@ -7495,7 +7495,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Repair",
       "surface": "apple",
-      "id": "native.apple.ae45153f28d9cf2a"
+      "id": "native.apple.9b35a13ad5fff363"
     },
     {
       "kind": "conditional-branch",
@@ -7503,7 +7503,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Dedupe",
       "surface": "apple",
-      "id": "native.apple.dace92af637733b7"
+      "id": "native.apple.980a4259e40ce99c"
     },
     {
       "kind": "ui-call",
@@ -7511,7 +7511,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Memory State",
       "surface": "apple",
-      "id": "native.apple.7d9b95f78347a27a"
+      "id": "native.apple.000658bd55f9813c"
     },
     {
       "kind": "ui-named-argument",
@@ -7519,7 +7519,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Short-term",
       "surface": "apple",
-      "id": "native.apple.fdd09340ada60b38"
+      "id": "native.apple.8dd008a25a37d79f"
     },
     {
       "kind": "ui-named-argument",
@@ -7527,7 +7527,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Signals",
       "surface": "apple",
-      "id": "native.apple.36e11955fdfc44ce"
+      "id": "native.apple.3f92dbe8d17a10ce"
     },
     {
       "kind": "ui-named-argument",
@@ -7535,7 +7535,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Promoted",
       "surface": "apple",
-      "id": "native.apple.eac7739027672f59"
+      "id": "native.apple.fc528817dc32cf70"
     },
     {
       "kind": "ui-call",
@@ -7543,7 +7543,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Maintenance",
       "surface": "apple",
-      "id": "native.apple.f880ca9213d28fc5"
+      "id": "native.apple.9e7eb42044221e88"
     },
     {
       "kind": "ui-call",
@@ -7551,7 +7551,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Refresh reads live state. Maintenance actions update the gateway diary/artifacts.",
       "surface": "apple",
-      "id": "native.apple.6c3fd9dc73e28915"
+      "id": "native.apple.57bb1ed1677bb994"
     },
     {
       "kind": "ui-modifier",
@@ -7559,7 +7559,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Refresh dreaming",
       "surface": "apple",
-      "id": "native.apple.3b974332d3bb23be"
+      "id": "native.apple.c9dc489c933640d3"
     },
     {
       "kind": "ui-named-argument",
@@ -7567,7 +7567,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Dream Diary",
       "surface": "apple",
-      "id": "native.apple.cfa8f0184b619533"
+      "id": "native.apple.bbb58365e349332b"
     },
     {
       "kind": "ui-named-argument",
@@ -7575,7 +7575,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "No day entries",
       "surface": "apple",
-      "id": "native.apple.825726d0205d5bd4"
+      "id": "native.apple.73d1a8ff30991be4"
     },
     {
       "kind": "ui-named-argument",
@@ -7583,7 +7583,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "The diary is present, but it does not contain dated Dream Diary blocks.",
       "surface": "apple",
-      "id": "native.apple.ab19be5a9d08b82e"
+      "id": "native.apple.738a1138025d94fa"
     },
     {
       "kind": "conditional-branch",
@@ -7591,7 +7591,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Dream diary is empty",
       "surface": "apple",
-      "id": "native.apple.0dbb5d2148a696d3"
+      "id": "native.apple.263550d57ff17055"
     },
     {
       "kind": "conditional-branch",
@@ -7599,7 +7599,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "No dream diary yet",
       "surface": "apple",
-      "id": "native.apple.875fab1238950ad0"
+      "id": "native.apple.1ebe616a41aec86a"
     },
     {
       "kind": "conditional-branch",
@@ -7607,7 +7607,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "\\(diary.path) exists but has no readable content.",
       "surface": "apple",
-      "id": "native.apple.bb7c4a8dbc801a19"
+      "id": "native.apple.46ee8fce8d8039f9"
     },
     {
       "kind": "conditional-branch",
@@ -7615,7 +7615,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
       "surface": "apple",
-      "id": "native.apple.a6a454a28f1db7df"
+      "id": "native.apple.74c5daff400e35b5"
     },
     {
       "kind": "conditional-branch",
@@ -7623,7 +7623,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Diary unavailable",
       "surface": "apple",
-      "id": "native.apple.11ae1c140df749a6"
+      "id": "native.apple.c29ab1ae29461af7"
     },
     {
       "kind": "conditional-branch",
@@ -7631,7 +7631,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "The gateway did not return dream diary content.",
       "surface": "apple",
-      "id": "native.apple.6f80c38b0b83c057"
+      "id": "native.apple.d6e2bd333d7d674e"
     },
     {
       "kind": "conditional-branch",
@@ -7639,7 +7639,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Connect a gateway to read dream diary entries.",
       "surface": "apple",
-      "id": "native.apple.e9772e2a1bbfb483"
+      "id": "native.apple.7a4c4b7574021a26"
     },
     {
       "kind": "ui-modifier",
@@ -7647,7 +7647,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Dream diary day",
       "surface": "apple",
-      "id": "native.apple.95300e4dfd7aad42"
+      "id": "native.apple.f2ad889bcd3e37c0"
     },
     {
       "kind": "ui-named-argument",
@@ -7655,7 +7655,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Connect a gateway to load dreaming entries.",
       "surface": "apple",
-      "id": "native.apple.f0df95f0790fe675"
+      "id": "native.apple.0f010e53712cab1f"
     },
     {
       "kind": "ui-call",
@@ -7663,7 +7663,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "\\(entry.totalSignalCount)",
       "surface": "apple",
-      "id": "native.apple.32c1207f3fb0ea37"
+      "id": "native.apple.f7207b4c80fe1954"
     },
     {
       "kind": "ui-named-argument",
@@ -7671,7 +7671,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Phases",
       "surface": "apple",
-      "id": "native.apple.bc3cd66fe555c668"
+      "id": "native.apple.43fb7f0ef002147a"
     },
     {
       "kind": "conditional-branch",
@@ -7679,7 +7679,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Dreaming unavailable",
       "surface": "apple",
-      "id": "native.apple.d6c5aa460338b9b5"
+      "id": "native.apple.99c4bd24dd165855"
     },
     {
       "kind": "conditional-branch",
@@ -7687,7 +7687,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "No phase status",
       "surface": "apple",
-      "id": "native.apple.cbfc7159dd411b7c"
+      "id": "native.apple.e81afdfd72780d3a"
     },
     {
       "kind": "conditional-branch",
@@ -7695,7 +7695,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "The gateway did not return dreaming phase details.",
       "surface": "apple",
-      "id": "native.apple.128c6782a7b1d919"
+      "id": "native.apple.7ce717ec7320c926"
     },
     {
       "kind": "conditional-branch",
@@ -7703,7 +7703,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Connect a gateway to load dreaming phases.",
       "surface": "apple",
-      "id": "native.apple.3ce988bd2b2215b2"
+      "id": "native.apple.e561c276882bed72"
     },
     {
       "kind": "conditional-branch",
@@ -7711,7 +7711,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "artifacts repaired",
       "surface": "apple",
-      "id": "native.apple.95e346b05c4acf8a"
+      "id": "native.apple.2e2540e53a7dec77"
     },
     {
       "kind": "conditional-branch",
@@ -7719,7 +7719,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "no repair needed",
       "surface": "apple",
-      "id": "native.apple.da9b0546b320aa00"
+      "id": "native.apple.47cb2f87524c4855"
     },
     {
       "kind": "conditional-branch",
@@ -7743,7 +7743,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Instances",
       "surface": "apple",
-      "id": "native.apple.d6d76334ab8bbf86"
+      "id": "native.apple.861659224ffe3946"
     },
     {
       "kind": "ui-call",
@@ -7751,7 +7751,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Presence",
       "surface": "apple",
-      "id": "native.apple.c0a8f74751fe7761"
+      "id": "native.apple.da1c869363d9d87b"
     },
     {
       "kind": "ui-named-argument",
@@ -7759,7 +7759,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Connected",
       "surface": "apple",
-      "id": "native.apple.d38e2bcc42b99a32"
+      "id": "native.apple.5028affd069d47f5"
     },
     {
       "kind": "ui-named-argument",
@@ -7767,7 +7767,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Agents",
       "surface": "apple",
-      "id": "native.apple.880e2ddd260c7c2e"
+      "id": "native.apple.123d21c3987542ac"
     },
     {
       "kind": "ui-named-argument",
@@ -7775,7 +7775,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Gateway",
       "surface": "apple",
-      "id": "native.apple.cddd5f7fef6839af"
+      "id": "native.apple.36ee6e32243e2626"
     },
     {
       "kind": "ui-named-argument",
@@ -7783,7 +7783,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Connected Instances",
       "surface": "apple",
-      "id": "native.apple.9a1211ec7db72f53"
+      "id": "native.apple.49198f034c45cb0c"
     },
     {
       "kind": "conditional-branch",
@@ -7791,7 +7791,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Instances unavailable",
       "surface": "apple",
-      "id": "native.apple.19c05f4f4cc76646"
+      "id": "native.apple.af23bba33bb3065c"
     },
     {
       "kind": "conditional-branch",
@@ -7799,7 +7799,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "No instances connected",
       "surface": "apple",
-      "id": "native.apple.c43a5621c65fe121"
+      "id": "native.apple.48eb8340063b9662"
     },
     {
       "kind": "conditional-branch",
@@ -7807,7 +7807,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "The gateway did not report any system presence entries.",
       "surface": "apple",
-      "id": "native.apple.26327e8fdd0a869b"
+      "id": "native.apple.17517f53b8e7671d"
     },
     {
       "kind": "conditional-branch",
@@ -7815,7 +7815,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Connect a gateway to inspect connected instances.",
       "surface": "apple",
-      "id": "native.apple.36618248cdaccc84"
+      "id": "native.apple.da5ee25bd3e2b34a"
     },
     {
       "kind": "ui-call",
@@ -7823,7 +7823,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Instance",
       "surface": "apple",
-      "id": "native.apple.e51fe4f1d2c94caa"
+      "id": "native.apple.a17b90e197cd6ee8"
     },
     {
       "kind": "ui-call",
@@ -7831,7 +7831,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Device",
       "surface": "apple",
-      "id": "native.apple.7450caafbc4c4905"
+      "id": "native.apple.630236487eac5955"
     },
     {
       "kind": "ui-call",
@@ -7839,7 +7839,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Host",
       "surface": "apple",
-      "id": "native.apple.918d896da8c9690b"
+      "id": "native.apple.605f959bbe99502e"
     },
     {
       "kind": "ui-call",
@@ -7847,7 +7847,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "IP",
       "surface": "apple",
-      "id": "native.apple.2f6eab7cb6d67e11"
+      "id": "native.apple.9ab7b45d47e0cb9a"
     },
     {
       "kind": "ui-call",
@@ -7855,7 +7855,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Platform",
       "surface": "apple",
-      "id": "native.apple.8b827c9e2747230b"
+      "id": "native.apple.59ab35d009d04e75"
     },
     {
       "kind": "ui-call",
@@ -7863,7 +7863,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Version",
       "surface": "apple",
-      "id": "native.apple.78ed7a935ffced12"
+      "id": "native.apple.8e2c90f81fb2513c"
     },
     {
       "kind": "ui-call",
@@ -7871,7 +7871,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Mode",
       "surface": "apple",
-      "id": "native.apple.752a753f245e5ca4"
+      "id": "native.apple.b0d1373614cb2e3e"
     },
     {
       "kind": "ui-named-argument",
@@ -7879,7 +7879,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Scopes",
       "surface": "apple",
-      "id": "native.apple.cef6a48e33c99f34"
+      "id": "native.apple.cf12fe3c768f5014"
     },
     {
       "kind": "ui-named-argument",
@@ -7887,7 +7887,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Roles",
       "surface": "apple",
-      "id": "native.apple.4f46ad7f7a534bdf"
+      "id": "native.apple.0831cf5d331ce83b"
     },
     {
       "kind": "ui-named-argument",
@@ -7895,7 +7895,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Tags",
       "surface": "apple",
-      "id": "native.apple.9d5774d05481002d"
+      "id": "native.apple.a79122d8afaf8611"
     },
     {
       "kind": "ui-modifier",
@@ -7903,7 +7903,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Copy \\(title)",
       "surface": "apple",
-      "id": "native.apple.4b2a40c2512edb6b"
+      "id": "native.apple.2e909de6981dc60b"
     },
     {
       "kind": "ui-call",
@@ -7911,7 +7911,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "None reported.",
       "surface": "apple",
-      "id": "native.apple.e9c4662a91a0188e"
+      "id": "native.apple.c899ccbdb4502d5f"
     },
     {
       "kind": "conditional-branch",
@@ -7935,7 +7935,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Cron.swift",
       "source": "Scheduler",
       "surface": "apple",
-      "id": "native.apple.828de90d8dfed4ad"
+      "id": "native.apple.67531bb640a736cb"
     },
     {
       "kind": "ui-named-argument",
@@ -7943,7 +7943,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Cron.swift",
       "source": "Next",
       "surface": "apple",
-      "id": "native.apple.982637a16129712e"
+      "id": "native.apple.649494049a94f494"
     },
     {
       "kind": "ui-named-argument",
@@ -7951,7 +7951,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Cron.swift",
       "source": "Jobs",
       "surface": "apple",
-      "id": "native.apple.265fe9a6fd48774a"
+      "id": "native.apple.8fcff357f5dd43e9"
     },
     {
       "kind": "ui-call",
@@ -7959,7 +7959,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Cron.swift",
       "source": "Run",
       "surface": "apple",
-      "id": "native.apple.e8964650f824c877"
+      "id": "native.apple.afc05f80e48e5dc0"
     },
     {
       "kind": "conditional-branch",
@@ -7967,7 +7967,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Cron.swift",
       "source": "Enable",
       "surface": "apple",
-      "id": "native.apple.7a755374bfce2d24"
+      "id": "native.apple.feef8c1e76736990"
     },
     {
       "kind": "conditional-branch",
@@ -7975,7 +7975,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Cron.swift",
       "source": "Pause",
       "surface": "apple",
-      "id": "native.apple.85e60d2e562e3d2b"
+      "id": "native.apple.3a8ea51b4ddf2309"
     },
     {
       "kind": "conditional-branch",
@@ -7983,7 +7983,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Cron.swift",
       "source": "Enabled \\(job.name).",
       "surface": "apple",
-      "id": "native.apple.5c9bbc2dc26712ef"
+      "id": "native.apple.a97c2ca7a1926fbc"
     },
     {
       "kind": "conditional-branch",
@@ -7991,7 +7991,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Cron.swift",
       "source": "Paused \\(job.name).",
       "surface": "apple",
-      "id": "native.apple.8658a6a0ee787fc3"
+      "id": "native.apple.4a98c9d99b13dc36"
     },
     {
       "kind": "ui-named-argument",
@@ -7999,7 +7999,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Destinations.swift",
       "source": "Search agents",
       "surface": "apple",
-      "id": "native.apple.a373bf2332f0ab6a"
+      "id": "native.apple.88ac71979fd62d9a"
     },
     {
       "kind": "ui-named-argument",
@@ -8007,7 +8007,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Destinations.swift",
       "source": "Skills",
       "surface": "apple",
-      "id": "native.apple.929053bc7d51b98f"
+      "id": "native.apple.a21ddaeb799ac71c"
     },
     {
       "kind": "ui-named-argument",
@@ -8015,7 +8015,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Destinations.swift",
       "source": "Cron Jobs",
       "surface": "apple",
-      "id": "native.apple.45c3f045dd9a3507"
+      "id": "native.apple.1ce66a071588b402"
     },
     {
       "kind": "ui-named-argument",
@@ -8023,7 +8023,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Destinations.swift",
       "source": "Usage",
       "surface": "apple",
-      "id": "native.apple.4bee0220d011ab53"
+      "id": "native.apple.63a1b3f7555ca4ac"
     },
     {
       "kind": "conditional-branch",
@@ -8039,7 +8039,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+GatewayData.swift",
       "source": "Online",
       "surface": "apple",
-      "id": "native.apple.5fbed24f057edea8"
+      "id": "native.apple.a3c09040677501c7"
     },
     {
       "kind": "conditional-branch",
@@ -8047,7 +8047,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+GatewayData.swift",
       "source": "Ready",
       "surface": "apple",
-      "id": "native.apple.f1958c5f0d880a4a"
+      "id": "native.apple.85d1c890206ae780"
     },
     {
       "kind": "conditional-branch",
@@ -8055,7 +8055,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+GatewayData.swift",
       "source": "Not selected",
       "surface": "apple",
-      "id": "native.apple.056ac76b75d6795d"
+      "id": "native.apple.d7f2facb78d38216"
     },
     {
       "kind": "conditional-branch",
@@ -8063,7 +8063,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+GatewayData.swift",
       "source": "Selected",
       "surface": "apple",
-      "id": "native.apple.c29b4a63fb797a83"
+      "id": "native.apple.eedd6be1eba18105"
     },
     {
       "kind": "ui-named-argument",
@@ -8071,7 +8071,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "\\(self.sortedAgents.count) total",
       "surface": "apple",
-      "id": "native.apple.6992ddf119f4d920"
+      "id": "native.apple.e85a7435bf6e94b6"
     },
     {
       "kind": "ui-named-argument",
@@ -8079,7 +8079,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Search agents",
       "surface": "apple",
-      "id": "native.apple.5ee1fa5a66b2d846"
+      "id": "native.apple.0c34680726baafe0"
     },
     {
       "kind": "ui-modifier",
@@ -8087,7 +8087,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Clear filters",
       "surface": "apple",
-      "id": "native.apple.5cc5151b7946d32e"
+      "id": "native.apple.dbf80973ff5965e7"
     },
     {
       "kind": "ui-call",
@@ -8095,7 +8095,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Agent status",
       "surface": "apple",
-      "id": "native.apple.23ed9b5b0d1721d3"
+      "id": "native.apple.dd558c53b47eabc6"
     },
     {
       "kind": "ui-call",
@@ -8103,7 +8103,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Clear Filters",
       "surface": "apple",
-      "id": "native.apple.a254ffbe0cd16f72"
+      "id": "native.apple.752fc7d9a9aa4d3d"
     },
     {
       "kind": "ui-call",
@@ -8111,7 +8111,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Filter agents",
       "surface": "apple",
-      "id": "native.apple.5648148ca9be82bc"
+      "id": "native.apple.c5ca90a58f6873bd"
     },
     {
       "kind": "conditional-branch",
@@ -8119,7 +8119,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Gateway offline",
       "surface": "apple",
-      "id": "native.apple.0938c66b5382e9b5"
+      "id": "native.apple.507ad2de5cadd6c7"
     },
     {
       "kind": "conditional-branch",
@@ -8127,7 +8127,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Gateway online",
       "surface": "apple",
-      "id": "native.apple.6f0aae58035253c8"
+      "id": "native.apple.0ea7a2c36b62c588"
     },
     {
       "kind": "ui-modifier",
@@ -8135,7 +8135,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Opens Settings / Gateway",
       "surface": "apple",
-      "id": "native.apple.9c45abb65d0ba8f3"
+      "id": "native.apple.dfdca8006a06d277"
     },
     {
       "kind": "ui-named-argument",
@@ -8143,7 +8143,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Live Operations",
       "surface": "apple",
-      "id": "native.apple.c50e3ea900992af2"
+      "id": "native.apple.1c12532d35337068"
     },
     {
       "kind": "ui-named-argument",
@@ -8151,7 +8151,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Skills",
       "surface": "apple",
-      "id": "native.apple.297d31f435acc655"
+      "id": "native.apple.5234d372d85277ce"
     },
     {
       "kind": "ui-named-argument",
@@ -8159,7 +8159,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Instances",
       "surface": "apple",
-      "id": "native.apple.74ac93726c9730d4"
+      "id": "native.apple.620a63341e9932b8"
     },
     {
       "kind": "ui-named-argument",
@@ -8167,7 +8167,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Cron",
       "surface": "apple",
-      "id": "native.apple.0648f34212e23f0b"
+      "id": "native.apple.3f3d44e92b010179"
     },
     {
       "kind": "ui-named-argument",
@@ -8175,7 +8175,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Usage",
       "surface": "apple",
-      "id": "native.apple.1e10dc4a13db5f3f"
+      "id": "native.apple.30b328e340643aff"
     },
     {
       "kind": "ui-named-argument",
@@ -8183,7 +8183,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Files",
       "surface": "apple",
-      "id": "native.apple.f48d33a93f53ae56"
+      "id": "native.apple.d323532b955ce413"
     },
     {
       "kind": "ui-named-argument",
@@ -8191,7 +8191,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Workspace files",
       "surface": "apple",
-      "id": "native.apple.b84aa382768fe819"
+      "id": "native.apple.a478055bcc7801b1"
     },
     {
       "kind": "ui-named-argument",
@@ -8199,7 +8199,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Dreaming",
       "surface": "apple",
-      "id": "native.apple.98306aca23d04451"
+      "id": "native.apple.dc13598070d11e61"
     },
     {
       "kind": "ui-named-argument",
@@ -8207,7 +8207,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Scheduled Work",
       "surface": "apple",
-      "id": "native.apple.4999264d74844f21"
+      "id": "native.apple.03471f7487610989"
     },
     {
       "kind": "conditional-branch",
@@ -8215,7 +8215,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Selected agent",
       "surface": "apple",
-      "id": "native.apple.13245a5075869f14"
+      "id": "native.apple.7eba9e55d31d84ef"
     },
     {
       "kind": "conditional-branch",
@@ -8223,7 +8223,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Selects this agent",
       "surface": "apple",
-      "id": "native.apple.ae9101fc699ad5f8"
+      "id": "native.apple.9472b8bd11e03486"
     },
     {
       "kind": "conditional-branch",
@@ -8231,7 +8231,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Cron unavailable",
       "surface": "apple",
-      "id": "native.apple.e347d159f30bca34"
+      "id": "native.apple.539213cfdc023cd1"
     },
     {
       "kind": "conditional-branch",
@@ -8239,7 +8239,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "No scheduled jobs",
       "surface": "apple",
-      "id": "native.apple.4f053bb46f35a802"
+      "id": "native.apple.11121bef4b7d0613"
     },
     {
       "kind": "conditional-branch",
@@ -8247,7 +8247,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "The gateway has no visible cron jobs.",
       "surface": "apple",
-      "id": "native.apple.0cd04bacdbcd8fa5"
+      "id": "native.apple.42278c9b95e4465b"
     },
     {
       "kind": "conditional-branch",
@@ -8255,7 +8255,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Connect a gateway to load scheduled work.",
       "surface": "apple",
-      "id": "native.apple.ae4aa2339b285164"
+      "id": "native.apple.d7e375e66c36d701"
     },
     {
       "kind": "conditional-branch",
@@ -8263,7 +8263,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Loading skill status.",
       "surface": "apple",
-      "id": "native.apple.13e776bd20f1df1c"
+      "id": "native.apple.b51fbc49b1e180a9"
     },
     {
       "kind": "conditional-branch",
@@ -8271,7 +8271,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Skill status is available from the gateway.",
       "surface": "apple",
-      "id": "native.apple.13f557aa09fe87ca"
+      "id": "native.apple.4da7a5333f98a6f1"
     },
     {
       "kind": "conditional-branch",
@@ -8279,7 +8279,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Instance presence is available.",
       "surface": "apple",
-      "id": "native.apple.6276902cd4fe942d"
+      "id": "native.apple.e71d8e35138a31ed"
     },
     {
       "kind": "conditional-branch",
@@ -8287,7 +8287,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Loading instance presence.",
       "surface": "apple",
-      "id": "native.apple.30b12adf015466a3"
+      "id": "native.apple.7d72d4fadf0deadb"
     },
     {
       "kind": "conditional-branch",
@@ -8295,7 +8295,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "\\(cronStatus.jobs)",
       "surface": "apple",
-      "id": "native.apple.2beba7d892331495"
+      "id": "native.apple.698e5dacdc928825"
     },
     {
       "kind": "conditional-branch",
@@ -8303,7 +8303,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Cron status is available.",
       "surface": "apple",
-      "id": "native.apple.f0d3f77e976e0392"
+      "id": "native.apple.a95a7611cd576918"
     },
     {
       "kind": "conditional-branch",
@@ -8311,7 +8311,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Loading cron status.",
       "surface": "apple",
-      "id": "native.apple.a08cca83d5753d7b"
+      "id": "native.apple.7449f78a2c9082ad"
     },
     {
       "kind": "conditional-branch",
@@ -8319,7 +8319,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Scheduler disabled",
       "surface": "apple",
-      "id": "native.apple.2f89185965cb4c09"
+      "id": "native.apple.e692a306f562ede8"
     },
     {
       "kind": "conditional-branch",
@@ -8327,7 +8327,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Scheduler enabled",
       "surface": "apple",
-      "id": "native.apple.59cb26a37071e5b8"
+      "id": "native.apple.bd5e4b50050f3b71"
     },
     {
       "kind": "conditional-branch",
@@ -8335,7 +8335,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Loading recent usage.",
       "surface": "apple",
-      "id": "native.apple.c3ebef43c447e296"
+      "id": "native.apple.cd78344554d0cdc3"
     },
     {
       "kind": "conditional-branch",
@@ -8343,7 +8343,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Recent usage is available.",
       "surface": "apple",
-      "id": "native.apple.4f650e85964e9585"
+      "id": "native.apple.1d7435a25bfc4e6f"
     },
     {
       "kind": "conditional-branch",
@@ -8351,7 +8351,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Background memory status is available.",
       "surface": "apple",
-      "id": "native.apple.524a87549db68abc"
+      "id": "native.apple.7ab4c593017ca9c5"
     },
     {
       "kind": "conditional-branch",
@@ -8359,7 +8359,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Loading dreaming status.",
       "surface": "apple",
-      "id": "native.apple.9b141e37ef320c38"
+      "id": "native.apple.4ce484b622fe69d3"
     },
     {
       "kind": "conditional-branch",
@@ -8367,7 +8367,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "\\(self.agentSkillFilter?.count ?? 0)",
       "surface": "apple",
-      "id": "native.apple.79e92dff90eb58d0"
+      "id": "native.apple.8643941f2bbcd0f5"
     },
     {
       "kind": "ui-call",
@@ -8375,7 +8375,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Enable All",
       "surface": "apple",
-      "id": "native.apple.78806bca85333d64"
+      "id": "native.apple.905151f59396a34f"
     },
     {
       "kind": "ui-call",
@@ -8383,7 +8383,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Disable All",
       "surface": "apple",
-      "id": "native.apple.f3262359a64b27b1"
+      "id": "native.apple.ba8b14c32feaeff5"
     },
     {
       "kind": "ui-call",
@@ -8391,7 +8391,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Reset",
       "surface": "apple",
-      "id": "native.apple.d9ba2e8c076bcb15"
+      "id": "native.apple.42d7da7551988f08"
     },
     {
       "kind": "ui-call",
@@ -8399,7 +8399,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Search skills",
       "surface": "apple",
-      "id": "native.apple.6cf10999f4618500"
+      "id": "native.apple.eb5c0b2bb09fac9d"
     },
     {
       "kind": "ui-call",
@@ -8407,7 +8407,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Status",
       "surface": "apple",
-      "id": "native.apple.c8f32d85993b1de0"
+      "id": "native.apple.cb6a56e6eee1dd09"
     },
     {
       "kind": "ui-call",
@@ -8415,7 +8415,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Install Skills",
       "surface": "apple",
-      "id": "native.apple.248f9e1ad5721249"
+      "id": "native.apple.57ac4444a4727ecb"
     },
     {
       "kind": "ui-call",
@@ -8423,7 +8423,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Search ClawHub and install into this workspace.",
       "surface": "apple",
-      "id": "native.apple.c3d3c59138c22954"
+      "id": "native.apple.278a520abb2c5fd2"
     },
     {
       "kind": "ui-call",
@@ -8431,7 +8431,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Search ClawHub",
       "surface": "apple",
-      "id": "native.apple.efcb886f500e918d"
+      "id": "native.apple.6a3103226f57ca6f"
     },
     {
       "kind": "ui-modifier",
@@ -8439,7 +8439,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Install \\(result.displayName)",
       "surface": "apple",
-      "id": "native.apple.a46408193c7d93e8"
+      "id": "native.apple.353ee249b86146b9"
     },
     {
       "kind": "ui-named-argument",
@@ -8447,7 +8447,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Installed Skills",
       "surface": "apple",
-      "id": "native.apple.b11c71227fc1e5fd"
+      "id": "native.apple.74122e404098636e"
     },
     {
       "kind": "conditional-branch",
@@ -8455,7 +8455,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "No skills found",
       "surface": "apple",
-      "id": "native.apple.76c00eaca8702b59"
+      "id": "native.apple.a0122155cb108c7d"
     },
     {
       "kind": "conditional-branch",
@@ -8463,7 +8463,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Skills unavailable",
       "surface": "apple",
-      "id": "native.apple.ed2e16466b28e4e1"
+      "id": "native.apple.2673c591e9cd0817"
     },
     {
       "kind": "conditional-branch",
@@ -8471,7 +8471,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Try a different search or refresh from the gateway.",
       "surface": "apple",
-      "id": "native.apple.698f37c66a7d9436"
+      "id": "native.apple.baaef0e314088d72"
     },
     {
       "kind": "conditional-branch",
@@ -8479,7 +8479,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Connect a gateway to load workspace skills.",
       "surface": "apple",
-      "id": "native.apple.37c0e98e8a49fe44"
+      "id": "native.apple.47ec2c5d0809468b"
     },
     {
       "kind": "ui-call",
@@ -8487,7 +8487,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Setup: \\(install)",
       "surface": "apple",
-      "id": "native.apple.61ebcf220ca6f7f4"
+      "id": "native.apple.f936e2373817f4cd"
     },
     {
       "kind": "ui-modifier",
@@ -8495,7 +8495,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Set up \\(skill.displayName)",
       "surface": "apple",
-      "id": "native.apple.e94ab5a64ed0052b"
+      "id": "native.apple.eb076df03b4fc631"
     },
     {
       "kind": "ui-modifier",
@@ -8503,7 +8503,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Edit \\(skill.displayName)",
       "surface": "apple",
-      "id": "native.apple.801febb8177c45d6"
+      "id": "native.apple.1a82788bf9b227a1"
     },
     {
       "kind": "ui-call",
@@ -8511,7 +8511,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Skill unavailable",
       "surface": "apple",
-      "id": "native.apple.de59fbc2807318fc"
+      "id": "native.apple.6621df6e2d27b8f7"
     },
     {
       "kind": "ui-call",
@@ -8519,7 +8519,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Return to the skills list and choose another skill.",
       "surface": "apple",
-      "id": "native.apple.2e0b19585f4fec18"
+      "id": "native.apple.bd59f4cf7d4c5a26"
     },
     {
       "kind": "ui-modifier",
@@ -8527,7 +8527,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Skill",
       "surface": "apple",
-      "id": "native.apple.29d82bdb73f5a551"
+      "id": "native.apple.e6c62703e532032c"
     },
     {
       "kind": "ui-call",
@@ -8535,7 +8535,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Close",
       "surface": "apple",
-      "id": "native.apple.8869a6b2fde070b8"
+      "id": "native.apple.b70b85f12e8f9582"
     },
     {
       "kind": "ui-call",
@@ -8543,7 +8543,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Enabled globally",
       "surface": "apple",
-      "id": "native.apple.05e570a704fc1119"
+      "id": "native.apple.bfc8fb9b10c1aea9"
     },
     {
       "kind": "ui-call",
@@ -8551,7 +8551,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "API key",
       "surface": "apple",
-      "id": "native.apple.866ef51a89c50e1a"
+      "id": "native.apple.6275e29855a11ee7"
     },
     {
       "kind": "ui-call",
@@ -8559,7 +8559,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Save key",
       "surface": "apple",
-      "id": "native.apple.339b853be8c8ea60"
+      "id": "native.apple.4b0d877ea18086e4"
     },
     {
       "kind": "ui-call",
@@ -8567,7 +8567,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Get key",
       "surface": "apple",
-      "id": "native.apple.21d8b3ce307083a7"
+      "id": "native.apple.580d729993d33480"
     },
     {
       "kind": "conditional-branch",
@@ -8575,7 +8575,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Off",
       "surface": "apple",
-      "id": "native.apple.35b53a42c15293a5"
+      "id": "native.apple.dcb8bded6a98beff"
     },
     {
       "kind": "conditional-branch",
@@ -8583,7 +8583,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "On",
       "surface": "apple",
-      "id": "native.apple.67b446d27dd34d9b"
+      "id": "native.apple.356a262e715cdedc"
     },
     {
       "kind": "ui-call",
@@ -8591,7 +8591,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Setup",
       "surface": "apple",
-      "id": "native.apple.07884c9a5b6dc1e4"
+      "id": "native.apple.5af1de4a58f9458f"
     },
     {
       "kind": "ui-call",
@@ -8599,7 +8599,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Missing: \\(missing)",
       "surface": "apple",
-      "id": "native.apple.7c9ea375c01972ee"
+      "id": "native.apple.858bbe1cc51caf7f"
     },
     {
       "kind": "ui-call",
@@ -8607,7 +8607,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "No missing requirements reported.",
       "surface": "apple",
-      "id": "native.apple.51d5e0c708a3fa66"
+      "id": "native.apple.f6391f150128c160"
     },
     {
       "kind": "ui-named-argument",
@@ -8615,7 +8615,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Key",
       "surface": "apple",
-      "id": "native.apple.453b9c34c602da10"
+      "id": "native.apple.199b8d809f8f3da6"
     },
     {
       "kind": "ui-named-argument",
@@ -8623,7 +8623,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Source",
       "surface": "apple",
-      "id": "native.apple.470eb21dde82b914"
+      "id": "native.apple.243421e788e78a23"
     },
     {
       "kind": "conditional-branch",
@@ -8631,7 +8631,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Skill policy reset.",
       "surface": "apple",
-      "id": "native.apple.9726d2ef2c71346f"
+      "id": "native.apple.42e5d30c3b5c701b"
     },
     {
       "kind": "conditional-branch",
@@ -8639,7 +8639,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Skill policy saved.",
       "surface": "apple",
-      "id": "native.apple.c291324b9104375f"
+      "id": "native.apple.488d78178b4cefea"
     },
     {
       "kind": "conditional-branch",
@@ -8647,7 +8647,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Skill disabled.",
       "surface": "apple",
-      "id": "native.apple.872f785c02062877"
+      "id": "native.apple.089235da42d8ffc8"
     },
     {
       "kind": "conditional-branch",
@@ -8655,7 +8655,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Skill enabled.",
       "surface": "apple",
-      "id": "native.apple.dd816fa90c09b604"
+      "id": "native.apple.4f4b9515dbcfdb6b"
     },
     {
       "kind": "conditional-branch",
@@ -8663,7 +8663,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "API key cleared.",
       "surface": "apple",
-      "id": "native.apple.ab9749bd8de35a71"
+      "id": "native.apple.90af89a15f2d19dc"
     },
     {
       "kind": "conditional-branch",
@@ -8671,7 +8671,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "API key saved.",
       "surface": "apple",
-      "id": "native.apple.8eb83d034b37b949"
+      "id": "native.apple.5a82be79fab324db"
     },
     {
       "kind": "ui-call",
@@ -8679,7 +8679,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Usage.swift",
       "source": "Totals",
       "surface": "apple",
-      "id": "native.apple.a65066d19ed879fd"
+      "id": "native.apple.4ca9438c6ce4c08e"
     },
     {
       "kind": "ui-named-argument",
@@ -8687,7 +8687,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Usage.swift",
       "source": "Cost",
       "surface": "apple",
-      "id": "native.apple.e601b94c12d2b98e"
+      "id": "native.apple.c302fc984f54d047"
     },
     {
       "kind": "ui-named-argument",
@@ -8695,7 +8695,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Usage.swift",
       "source": "Tokens",
       "surface": "apple",
-      "id": "native.apple.463a0c3fc0724429"
+      "id": "native.apple.ecdc9e4aba1f9bc5"
     },
     {
       "kind": "ui-named-argument",
@@ -8703,7 +8703,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Usage.swift",
       "source": "Cache",
       "surface": "apple",
-      "id": "native.apple.509cb464bd3190dd"
+      "id": "native.apple.b74b20bf703b7987"
     },
     {
       "kind": "ui-named-argument",
@@ -8711,7 +8711,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Usage.swift",
       "source": "Daily",
       "surface": "apple",
-      "id": "native.apple.f81476c427e8a023"
+      "id": "native.apple.5d2b6f1366cf2ee8"
     },
     {
       "kind": "ui-named-argument",
@@ -8719,7 +8719,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Usage.swift",
       "source": "No daily usage yet",
       "surface": "apple",
-      "id": "native.apple.51f8cdef7b566774"
+      "id": "native.apple.2b9a8f07dfc2afca"
     },
     {
       "kind": "ui-named-argument",
@@ -8727,7 +8727,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Usage.swift",
       "source": "The gateway returned totals without daily session cost rows.",
       "surface": "apple",
-      "id": "native.apple.85a6c5af01f07a8b"
+      "id": "native.apple.0eee5afee789f3f5"
     },
     {
       "kind": "ui-call",
@@ -8735,7 +8735,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Usage.swift",
       "source": "\\(Self.compactNumber(day.totalTokens ?? 0)) tokens",
       "surface": "apple",
-      "id": "native.apple.a17ce77200834d9c"
+      "id": "native.apple.3e7279eebc9d08b5"
     },
     {
       "kind": "conditional-branch",
@@ -8743,7 +8743,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab.swift",
       "source": "Enabled",
       "surface": "apple",
-      "id": "native.apple.fb60c35df83a0768"
+      "id": "native.apple.fa0cf88428461836"
     },
     {
       "kind": "conditional-branch",
@@ -8751,7 +8751,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab.swift",
       "source": "Off",
       "surface": "apple",
-      "id": "native.apple.9bd563ec9f88b66f"
+      "id": "native.apple.85ee47880905319e"
     },
     {
       "kind": "conditional-branch",
@@ -8759,7 +8759,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab.swift",
       "source": "Setup",
       "surface": "apple",
-      "id": "native.apple.1a0589c434d56aa0"
+      "id": "native.apple.041399e554bbf83d"
     },
     {
       "kind": "conditional-branch",
@@ -8767,7 +8767,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab.swift",
       "source": "Blocked",
       "surface": "apple",
-      "id": "native.apple.58c675b87f0cd712"
+      "id": "native.apple.5a805478c3b41941"
     },
     {
       "kind": "conditional-branch",
@@ -8775,7 +8775,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab.swift",
       "source": "All",
       "surface": "apple",
-      "id": "native.apple.c1520bfdcd827e55"
+      "id": "native.apple.e4e2e137d656d2fb"
     },
     {
       "kind": "conditional-branch",
@@ -8783,7 +8783,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab.swift",
       "source": "Online",
       "surface": "apple",
-      "id": "native.apple.2be2d2e1fb0c140a"
+      "id": "native.apple.cb88b3767220ef0a"
     },
     {
       "kind": "conditional-branch",
@@ -8791,7 +8791,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab.swift",
       "source": "Ready",
       "surface": "apple",
-      "id": "native.apple.a97cdae7c8e13f0e"
+      "id": "native.apple.aedbbd2dcbc87ed4"
     },
     {
       "kind": "ui-named-argument",
@@ -8799,7 +8799,7 @@
       "path": "apps/ios/Sources/Design/AgentWorkspaceFilesScreen.swift",
       "source": "Files",
       "surface": "apple",
-      "id": "native.apple.9c4e8b82edf0b324"
+      "id": "native.apple.4b8e23199c9b474d"
     },
     {
       "kind": "ui-call",
@@ -8807,7 +8807,7 @@
       "path": "apps/ios/Sources/Design/AgentWorkspaceFilesScreen.swift",
       "source": "This folder is empty.",
       "surface": "apple",
-      "id": "native.apple.ada58d7ce8866f71"
+      "id": "native.apple.628a1ad4bbd9f1a9"
     },
     {
       "kind": "ui-call",
@@ -8815,7 +8815,7 @@
       "path": "apps/ios/Sources/Design/AgentWorkspaceFilesScreen.swift",
       "source": "Load More",
       "surface": "apple",
-      "id": "native.apple.35512c4d46a2da28"
+      "id": "native.apple.ec3dd6687663751d"
     },
     {
       "kind": "ui-call",
@@ -8823,7 +8823,7 @@
       "path": "apps/ios/Sources/Design/AgentWorkspaceFilesScreen.swift",
       "source": "\\(self.entries.count) of \\(self.totalEntries)",
       "surface": "apple",
-      "id": "native.apple.e617cdacc3bce5ea"
+      "id": "native.apple.0e6c1fdea127743b"
     },
     {
       "kind": "ui-modifier",
@@ -8831,7 +8831,7 @@
       "path": "apps/ios/Sources/Design/AgentWorkspaceFilesScreen.swift",
       "source": "Share file",
       "surface": "apple",
-      "id": "native.apple.336a7eeb12d6e5f4"
+      "id": "native.apple.001ecfe4d0e4932e"
     },
     {
       "kind": "ui-modifier",
@@ -8839,7 +8839,7 @@
       "path": "apps/ios/Sources/Design/AgentWorkspaceFilesScreen.swift",
       "source": "Could not share this file.",
       "surface": "apple",
-      "id": "native.apple.0ab324ff650d720c"
+      "id": "native.apple.70134cd69bfcee2f"
     },
     {
       "kind": "ui-call",
@@ -8847,7 +8847,7 @@
       "path": "apps/ios/Sources/Design/AgentWorkspaceFilesScreen.swift",
       "source": "OK",
       "surface": "apple",
-      "id": "native.apple.8218f673399060cc"
+      "id": "native.apple.3704986fe73a9e39"
     },
     {
       "kind": "ui-localized-call",
@@ -8855,7 +8855,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unable to Export Transcript",
       "surface": "apple",
-      "id": "native.apple.e5524d5756a62744"
+      "id": "native.apple.d8a473ff35837e6d"
     },
     {
       "kind": "ui-call",
@@ -8863,7 +8863,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "OK",
       "surface": "apple",
-      "id": "native.apple.942d6a10fd90d6e3"
+      "id": "native.apple.562d65e955f03a10"
     },
     {
       "kind": "ui-call",
@@ -8871,7 +8871,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "OpenClaw could not prepare the Markdown file.",
       "surface": "apple",
-      "id": "native.apple.3548c8d1ab43e85e"
+      "id": "native.apple.a80ae10704a44df1"
     },
     {
       "kind": "ui-localized-call",
@@ -8879,7 +8879,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What would you like to work on?",
       "surface": "apple",
-      "id": "native.apple.202b97e93b938049"
+      "id": "native.apple.40e41857534ae660"
     },
     {
       "kind": "ui-call",
@@ -8887,7 +8887,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "The session attaches once the gateway is ready.",
       "surface": "apple",
-      "id": "native.apple.32179ce0b6d4543f"
+      "id": "native.apple.ed7f703a8809b564"
     },
     {
       "kind": "ui-modifier",
@@ -8895,7 +8895,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Opens Settings / Gateway",
       "surface": "apple",
-      "id": "native.apple.d19c9577e0fdfea7"
+      "id": "native.apple.86888478e9c9408a"
     },
     {
       "kind": "ui-call",
@@ -8903,7 +8903,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Chat",
       "surface": "apple",
-      "id": "native.apple.7c87384c7d1370e1"
+      "id": "native.apple.0e86b658650c8821"
     },
     {
       "kind": "ui-call",
@@ -8911,7 +8911,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Chat in Worktree",
       "surface": "apple",
-      "id": "native.apple.1876037e64a74110"
+      "id": "native.apple.a42b3f7341ab854d"
     },
     {
       "kind": "ui-call",
@@ -8919,7 +8919,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Export Transcript",
       "surface": "apple",
-      "id": "native.apple.ced228bb4d20a726"
+      "id": "native.apple.4130fc39fcbc0bfc"
     },
     {
       "kind": "ui-modifier",
@@ -8927,7 +8927,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Chat actions",
       "surface": "apple",
-      "id": "native.apple.940e1f943750c94b"
+      "id": "native.apple.473e399157b58d5b"
     },
     {
       "kind": "conditional-branch",
@@ -8935,7 +8935,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connected",
       "surface": "apple",
-      "id": "native.apple.b635acd93246d67b"
+      "id": "native.apple.c694b0d5c5ec09dd"
     },
     {
       "kind": "conditional-branch",
@@ -8943,7 +8943,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unavailable",
       "surface": "apple",
-      "id": "native.apple.04934af85e3b9d6e"
+      "id": "native.apple.b65a1e536c99e7f3"
     },
     {
       "kind": "ui-localized-call",
@@ -8951,7 +8951,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message \\(self.agentDisplayName)...",
       "surface": "apple",
-      "id": "native.apple.4dcedefea4b49a1c"
+      "id": "native.apple.3346197ab0e4c93e"
     },
     {
       "kind": "ui-localized-call",
@@ -8959,7 +8959,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message \\(self.agentDisplayName); sends when connected",
       "surface": "apple",
-      "id": "native.apple.84767ec18054524b"
+      "id": "native.apple.37dc4df311e21014"
     },
     {
       "kind": "ui-localized-call",
@@ -8967,7 +8967,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connect to a gateway",
       "surface": "apple",
-      "id": "native.apple.11b20bef7e51ab69"
+      "id": "native.apple.63c54e148a3a237d"
     },
     {
       "kind": "ui-localized-call",
@@ -8975,7 +8975,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Check OpenClaw status",
       "surface": "apple",
-      "id": "native.apple.14492e334b87e4f2"
+      "id": "native.apple.e1501481753605ff"
     },
     {
       "kind": "ui-localized-call",
@@ -8983,7 +8983,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Summarize the current OpenClaw status and tell me what needs attention.",
       "surface": "apple",
-      "id": "native.apple.bbf7bd23da1e7865"
+      "id": "native.apple.dbac5d9eaf51f8e5"
     },
     {
       "kind": "ui-localized-call",
@@ -8991,7 +8991,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What can I control here?",
       "surface": "apple",
-      "id": "native.apple.ea8cbb1b4230c652"
+      "id": "native.apple.5508d38f4a5363a3"
     },
     {
       "kind": "ui-localized-call",
@@ -8999,7 +8999,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Show me which phone controls and device capabilities are available right now.",
       "surface": "apple",
-      "id": "native.apple.451d25bdb3130ed0"
+      "id": "native.apple.075991f0c700ec98"
     },
     {
       "kind": "ui-localized-call",
@@ -9007,7 +9007,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start voice chat",
       "surface": "apple",
-      "id": "native.apple.503ec402d08bd43a"
+      "id": "native.apple.b756860596294232"
     },
     {
       "kind": "ui-localized-call",
@@ -9015,7 +9015,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start a realtime voice session from this phone.",
       "surface": "apple",
-      "id": "native.apple.65e462758be96174"
+      "id": "native.apple.3bdf3dc66964c67d"
     },
     {
       "kind": "ui-call",
@@ -9023,7 +9023,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Unarchive",
       "surface": "apple",
-      "id": "native.apple.41afc4a5d600ded5"
+      "id": "native.apple.5358ee1a7154e827"
     },
     {
       "kind": "conditional-branch",
@@ -9031,7 +9031,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Pin",
       "surface": "apple",
-      "id": "native.apple.69b8d4842a6b18ca"
+      "id": "native.apple.2bd38e22a7cd45c4"
     },
     {
       "kind": "conditional-branch",
@@ -9039,7 +9039,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Unpin",
       "surface": "apple",
-      "id": "native.apple.43b1796d55760cbf"
+      "id": "native.apple.93348a0df87d34ba"
     },
     {
       "kind": "conditional-branch",
@@ -9047,7 +9047,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Mark as Read",
       "surface": "apple",
-      "id": "native.apple.48fe0c28f708d02d"
+      "id": "native.apple.bce681f8ec643fa4"
     },
     {
       "kind": "conditional-branch",
@@ -9055,7 +9055,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Mark as Unread",
       "surface": "apple",
-      "id": "native.apple.b0c19ea32f3b60dc"
+      "id": "native.apple.5e4f126c79628f9c"
     },
     {
       "kind": "ui-call",
@@ -9063,7 +9063,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Rename…",
       "surface": "apple",
-      "id": "native.apple.1a700eb0a3a26dd2"
+      "id": "native.apple.6dda1b61963245ec"
     },
     {
       "kind": "ui-call",
@@ -9071,7 +9071,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Fork",
       "surface": "apple",
-      "id": "native.apple.036b0faa4e17f39c"
+      "id": "native.apple.445630a5a98164e6"
     },
     {
       "kind": "ui-call",
@@ -9079,7 +9079,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Archive",
       "surface": "apple",
-      "id": "native.apple.35e23b306162f6ad"
+      "id": "native.apple.155f50cfb6cd013e"
     },
     {
       "kind": "conditional-branch",
@@ -9087,7 +9087,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Create",
       "surface": "apple",
-      "id": "native.apple.ef105487ab62349a"
+      "id": "native.apple.c0ac2c39ec17fbb6"
     },
     {
       "kind": "conditional-branch",
@@ -9095,7 +9095,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Save",
       "surface": "apple",
-      "id": "native.apple.1d017f810676d86b"
+      "id": "native.apple.cfdbbb92d1514a24"
     },
     {
       "kind": "ui-modifier",
@@ -9103,7 +9103,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Delete Session?",
       "surface": "apple",
-      "id": "native.apple.f488b9caf6e51ac3"
+      "id": "native.apple.e7382c53c7dd48f7"
     },
     {
       "kind": "ui-call",
@@ -9111,7 +9111,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Delete Session",
       "surface": "apple",
-      "id": "native.apple.8634b17be9b111bc"
+      "id": "native.apple.702fd8b48da56065"
     },
     {
       "kind": "ui-call",
@@ -9119,7 +9119,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Cancel",
       "surface": "apple",
-      "id": "native.apple.9b1aed19568a048e"
+      "id": "native.apple.09a899ba9d9b61b9"
     },
     {
       "kind": "ui-call",
@@ -9127,7 +9127,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "This permanently deletes the session and its transcript.",
       "surface": "apple",
-      "id": "native.apple.4a9568ac9b18d8d3"
+      "id": "native.apple.61f3f19ea24c6012"
     },
     {
       "kind": "ui-call",
@@ -9135,7 +9135,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "New Group…",
       "surface": "apple",
-      "id": "native.apple.0965d8d2429c3b9f"
+      "id": "native.apple.0861aee9da492d87"
     },
     {
       "kind": "ui-call",
@@ -9143,7 +9143,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Remove from Group",
       "surface": "apple",
-      "id": "native.apple.e6506ceb05d0ab33"
+      "id": "native.apple.16c4a1eff2a6a398"
     },
     {
       "kind": "ui-call",
@@ -9151,7 +9151,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Move to Group",
       "surface": "apple",
-      "id": "native.apple.6def347a80370aac"
+      "id": "native.apple.8e8b3d47fd59c907"
     },
     {
       "kind": "ui-call",
@@ -9159,7 +9159,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Delete…",
       "surface": "apple",
-      "id": "native.apple.de18cef702422ac0"
+      "id": "native.apple.052b20659077baa5"
     },
     {
       "kind": "conditional-branch",
@@ -9167,7 +9167,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "New Group",
       "surface": "apple",
-      "id": "native.apple.6595d3fd006a1a01"
+      "id": "native.apple.2202551ee0195c91"
     },
     {
       "kind": "conditional-branch",
@@ -9175,7 +9175,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Rename Session",
       "surface": "apple",
-      "id": "native.apple.5bccdc23a1640895"
+      "id": "native.apple.cd368674179237a0"
     },
     {
       "kind": "conditional-branch",
@@ -9183,7 +9183,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Group name",
       "surface": "apple",
-      "id": "native.apple.31424500c53d6c32"
+      "id": "native.apple.1f11f99fd9d4f4d9"
     },
     {
       "kind": "conditional-branch",
@@ -9191,7 +9191,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Session name",
       "surface": "apple",
-      "id": "native.apple.af789b2d2fda0f67"
+      "id": "native.apple.8b54306971cfa8c9"
     },
     {
       "kind": "ui-call",
@@ -9199,7 +9199,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "View More",
       "surface": "apple",
-      "id": "native.apple.e8018adcccaa2a4d"
+      "id": "native.apple.0c9421c29362d86b"
     },
     {
       "kind": "ui-modifier",
@@ -9207,7 +9207,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Gateway settings",
       "surface": "apple",
-      "id": "native.apple.65fb4d9ce6e5bbda"
+      "id": "native.apple.03a4cf69952364ac"
     },
     {
       "kind": "ui-modifier",
@@ -9215,7 +9215,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Opens gateway settings",
       "surface": "apple",
-      "id": "native.apple.4eaa7637d355c07c"
+      "id": "native.apple.f2164090736ada49"
     },
     {
       "kind": "ui-named-argument",
@@ -9223,7 +9223,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Gateway",
       "surface": "apple",
-      "id": "native.apple.9e1806d7f3980f47"
+      "id": "native.apple.63a54b768d63946d"
     },
     {
       "kind": "ui-named-argument",
@@ -9231,7 +9231,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Connection",
       "surface": "apple",
-      "id": "native.apple.88d022e6c15a3dc3"
+      "id": "native.apple.48090a32e9e032b1"
     },
     {
       "kind": "ui-named-argument",
@@ -9239,7 +9239,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Address",
       "surface": "apple",
-      "id": "native.apple.722d7754e946480d"
+      "id": "native.apple.e6175670f78fafee"
     },
     {
       "kind": "ui-named-argument",
@@ -9247,7 +9247,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Agents",
       "surface": "apple",
-      "id": "native.apple.e0c68adcc22af34a"
+      "id": "native.apple.61a3188faf165168"
     },
     {
       "kind": "ui-named-argument",
@@ -9255,7 +9255,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Agent session",
       "surface": "apple",
-      "id": "native.apple.a3bde8045fe9224a"
+      "id": "native.apple.789d5d0790fd18ca"
     },
     {
       "kind": "ui-named-argument",
@@ -9263,7 +9263,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Recent sessions",
       "surface": "apple",
-      "id": "native.apple.27f775de30b37ff8"
+      "id": "native.apple.ee45dce4a2e44737"
     },
     {
       "kind": "conditional-branch",
@@ -9271,7 +9271,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Gateway offline",
       "surface": "apple",
-      "id": "native.apple.9161ca3c61de6cc7"
+      "id": "native.apple.6f62aefe0095fcbb"
     },
     {
       "kind": "conditional-branch",
@@ -9279,7 +9279,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Online",
       "surface": "apple",
-      "id": "native.apple.e01aac63fda4c147"
+      "id": "native.apple.b467d2945a05a9d1"
     },
     {
       "kind": "conditional-branch",
@@ -9287,7 +9287,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Connecting",
       "surface": "apple",
-      "id": "native.apple.a857bc74fd053781"
+      "id": "native.apple.5ecae309f5192f0c"
     },
     {
       "kind": "conditional-branch",
@@ -9295,7 +9295,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Attention",
       "surface": "apple",
-      "id": "native.apple.a36675969878b0d8"
+      "id": "native.apple.a063c4bd06cdfaed"
     },
     {
       "kind": "conditional-branch",
@@ -9303,7 +9303,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Offline",
       "surface": "apple",
-      "id": "native.apple.89989b6d557090e8"
+      "id": "native.apple.8953a423bbeb8332"
     },
     {
       "kind": "ui-call",
@@ -9311,7 +9311,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Group name",
       "surface": "apple",
-      "id": "native.apple.9aba1ae114cf9848"
+      "id": "native.apple.4c11bcf5550624fa"
     },
     {
       "kind": "conditional-branch",
@@ -9319,7 +9319,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Create",
       "surface": "apple",
-      "id": "native.apple.fdd3242467eb5c34"
+      "id": "native.apple.07e6e3e1cb4e0b12"
     },
     {
       "kind": "conditional-branch",
@@ -9327,7 +9327,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Save",
       "surface": "apple",
-      "id": "native.apple.b976b71411e9c78d"
+      "id": "native.apple.30002605e6bb08ea"
     },
     {
       "kind": "ui-modifier",
@@ -9335,7 +9335,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Delete Group?",
       "surface": "apple",
-      "id": "native.apple.b2ab82ca08392d29"
+      "id": "native.apple.8653bc3bc8cfed37"
     },
     {
       "kind": "ui-call",
@@ -9343,7 +9343,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Delete Group",
       "surface": "apple",
-      "id": "native.apple.886ca5d9c049307b"
+      "id": "native.apple.292eb94002bfed70"
     },
     {
       "kind": "ui-call",
@@ -9351,7 +9351,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Cancel",
       "surface": "apple",
-      "id": "native.apple.ccc876bc505512fc"
+      "id": "native.apple.43cf470289f1b829"
     },
     {
       "kind": "ui-call",
@@ -9359,7 +9359,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Sessions in \\u{201C}\\(group)\\u{201D} move back to Ungrouped.",
       "surface": "apple",
-      "id": "native.apple.82f2bbb1828494f2"
+      "id": "native.apple.c606e3a0185136fd"
     },
     {
       "kind": "ui-call",
@@ -9367,7 +9367,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Sessions",
       "surface": "apple",
-      "id": "native.apple.9f2fd65953013b7c"
+      "id": "native.apple.7a6511a467e34f69"
     },
     {
       "kind": "conditional-branch",
@@ -9375,7 +9375,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Archived sessions",
       "surface": "apple",
-      "id": "native.apple.0422818cc95d5071"
+      "id": "native.apple.e6b8913014b64f0a"
     },
     {
       "kind": "ui-call",
@@ -9383,7 +9383,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Show Archived",
       "surface": "apple",
-      "id": "native.apple.bc8e64efb095a625"
+      "id": "native.apple.99301fe71e23c03f"
     },
     {
       "kind": "ui-named-argument",
@@ -9391,7 +9391,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Sessions unavailable",
       "surface": "apple",
-      "id": "native.apple.b272115c83f7ef58"
+      "id": "native.apple.119433782518f199"
     },
     {
       "kind": "ui-named-argument",
@@ -9399,7 +9399,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Connect to the gateway.",
       "surface": "apple",
-      "id": "native.apple.79937d7781fb65ae"
+      "id": "native.apple.ccefda5056fe3e02"
     },
     {
       "kind": "conditional-branch",
@@ -9407,7 +9407,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Loading archived sessions",
       "surface": "apple",
-      "id": "native.apple.54f8260c9b863087"
+      "id": "native.apple.9882fbadac3bea03"
     },
     {
       "kind": "conditional-branch",
@@ -9415,7 +9415,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Loading recent sessions",
       "surface": "apple",
-      "id": "native.apple.9b305868873dade2"
+      "id": "native.apple.16dca1cfac8a571b"
     },
     {
       "kind": "conditional-branch",
@@ -9423,7 +9423,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "No archived sessions",
       "surface": "apple",
-      "id": "native.apple.1f4501a6bf2bae4c"
+      "id": "native.apple.a0b4091bf77d4060"
     },
     {
       "kind": "conditional-branch",
@@ -9431,7 +9431,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "No recent sessions",
       "surface": "apple",
-      "id": "native.apple.28c97cf23665ee01"
+      "id": "native.apple.c97e0382e578a2f7"
     },
     {
       "kind": "conditional-branch",
@@ -9439,7 +9439,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Archived sessions will appear here.",
       "surface": "apple",
-      "id": "native.apple.2a1ba7a5e1979c9e"
+      "id": "native.apple.acfdf5c72e289736"
     },
     {
       "kind": "conditional-branch",
@@ -9447,7 +9447,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Start a chat and it will appear here.",
       "surface": "apple",
-      "id": "native.apple.bb1a311441d3cf24"
+      "id": "native.apple.ae77089e775af79c"
     },
     {
       "kind": "ui-call",
@@ -9455,7 +9455,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Rename Group…",
       "surface": "apple",
-      "id": "native.apple.e8e8cea7ec44fe08"
+      "id": "native.apple.70f3837cffd6532b"
     },
     {
       "kind": "ui-call",
@@ -9463,7 +9463,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "New Group…",
       "surface": "apple",
-      "id": "native.apple.b2e6a4382a540792"
+      "id": "native.apple.51465e9c69274d8c"
     },
     {
       "kind": "ui-call",
@@ -9471,7 +9471,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Delete Group…",
       "surface": "apple",
-      "id": "native.apple.553df9e842173417"
+      "id": "native.apple.bcfa3237ed778cb2"
     },
     {
       "kind": "conditional-branch",
@@ -9479,7 +9479,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "New Group",
       "surface": "apple",
-      "id": "native.apple.7b06349d79d0c217"
+      "id": "native.apple.23639ef62b3af09d"
     },
     {
       "kind": "conditional-branch",
@@ -9487,7 +9487,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Rename Group",
       "surface": "apple",
-      "id": "native.apple.1b727fbf231de39f"
+      "id": "native.apple.9c26bf2d4360434b"
     },
     {
       "kind": "conditional-branch",
@@ -9503,7 +9503,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Activity",
       "surface": "apple",
-      "id": "native.apple.ffaad4538bcfe1ac"
+      "id": "native.apple.c7facd80484d0d0c"
     },
     {
       "kind": "ui-named-argument",
@@ -9511,7 +9511,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Live device and gateway activity.",
       "surface": "apple",
-      "id": "native.apple.55a6a9eba5f6110c"
+      "id": "native.apple.3f18ddd8d4402f8e"
     },
     {
       "kind": "conditional-branch",
@@ -9519,7 +9519,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "\\(self.appModel.gatewayAgents.count)",
       "surface": "apple",
-      "id": "native.apple.5e343529932d0efd"
+      "id": "native.apple.f92cdb404a330d9b"
     },
     {
       "kind": "conditional-branch",
@@ -9527,7 +9527,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "\\(self.sessionRows.count)",
       "surface": "apple",
-      "id": "native.apple.b004055c5bac6681"
+      "id": "native.apple.eea7b404a461a985"
     },
     {
       "kind": "ui-named-argument",
@@ -9535,7 +9535,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Recent activity",
       "surface": "apple",
-      "id": "native.apple.4813254a14ae910f"
+      "id": "native.apple.282e02f7e21eb310"
     },
     {
       "kind": "conditional-branch",
@@ -9551,7 +9551,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.f7b3242d69bc344b"
+      "id": "native.apple.158e075d19295090"
     },
     {
       "kind": "ui-named-argument",
@@ -9559,7 +9559,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Approval needed",
       "surface": "apple",
-      "id": "native.apple.591061645bc8be64"
+      "id": "native.apple.d364bb0dded9c049"
     },
     {
       "kind": "ui-named-argument",
@@ -9567,7 +9567,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Gateway",
       "surface": "apple",
-      "id": "native.apple.c541794e6ce09dc7"
+      "id": "native.apple.c666d7f977619887"
     },
     {
       "kind": "ui-named-argument",
@@ -9575,7 +9575,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Share intake",
       "surface": "apple",
-      "id": "native.apple.13470ea9f78fea51"
+      "id": "native.apple.818cec9442bb0d0c"
     },
     {
       "kind": "ui-named-argument",
@@ -9583,7 +9583,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Loading sessions",
       "surface": "apple",
-      "id": "native.apple.2360d25fe6ae9946"
+      "id": "native.apple.4c5b2ecf243cfbbc"
     },
     {
       "kind": "ui-named-argument",
@@ -9591,7 +9591,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Fetching recent activity from the gateway.",
       "surface": "apple",
-      "id": "native.apple.48655128d0a34e44"
+      "id": "native.apple.d496c99524704c89"
     },
     {
       "kind": "ui-named-argument",
@@ -9599,7 +9599,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Sessions unavailable",
       "surface": "apple",
-      "id": "native.apple.c334f2e86702a7b8"
+      "id": "native.apple.c4479934c65c973c"
     },
     {
       "kind": "conditional-branch",
@@ -9607,7 +9607,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "No recent sessions",
       "surface": "apple",
-      "id": "native.apple.6cc6efb7a03960b6"
+      "id": "native.apple.6e67b64954ba3002"
     },
     {
       "kind": "conditional-branch",
@@ -9615,7 +9615,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Session activity offline",
       "surface": "apple",
-      "id": "native.apple.08483af2d043bee6"
+      "id": "native.apple.5dce07848bec08b5"
     },
     {
       "kind": "conditional-branch",
@@ -9623,7 +9623,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Start a chat and it will appear here.",
       "surface": "apple",
-      "id": "native.apple.e3586d8a603f67e0"
+      "id": "native.apple.745ca87aa532b619"
     },
     {
       "kind": "conditional-branch",
@@ -9631,7 +9631,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Connect to the gateway to load recent chat activity.",
       "surface": "apple",
-      "id": "native.apple.f47ceff451b1cce8"
+      "id": "native.apple.72bbc8719353d4c7"
     },
     {
       "kind": "conditional-branch",
@@ -9647,7 +9647,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Open",
       "surface": "apple",
-      "id": "native.apple.fb6493b448a3f62a"
+      "id": "native.apple.13e799f5171c2c62"
     },
     {
       "kind": "conditional-branch",
@@ -9671,7 +9671,7 @@
       "path": "apps/ios/Sources/Design/IPadSidebarFeatureScreens.swift",
       "source": "Gateway offline.",
       "surface": "apple",
-      "id": "native.apple.39681d2062a338cf"
+      "id": "native.apple.4d22689ffce54960"
     },
     {
       "kind": "conditional-branch",
@@ -9679,7 +9679,7 @@
       "path": "apps/ios/Sources/Design/IPadSidebarFeatureScreens.swift",
       "source": "Could not encode request.",
       "surface": "apple",
-      "id": "native.apple.1e0f08bfa15fb1fc"
+      "id": "native.apple.bbeb3ce2bceddb34"
     },
     {
       "kind": "ui-modifier",
@@ -9687,7 +9687,7 @@
       "path": "apps/ios/Sources/Design/IPadSidebarScreenChrome.swift",
       "source": "Gateway settings",
       "surface": "apple",
-      "id": "native.apple.df57f7bdc11feff1"
+      "id": "native.apple.aba0e26194f6926c"
     },
     {
       "kind": "ui-modifier",
@@ -9695,7 +9695,7 @@
       "path": "apps/ios/Sources/Design/IPadSidebarScreenChrome.swift",
       "source": "Opens Settings / Gateway",
       "surface": "apple",
-      "id": "native.apple.749ac5e78033000f"
+      "id": "native.apple.e487a75c14fca62b"
     },
     {
       "kind": "ui-named-argument",
@@ -9703,7 +9703,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Skill Workshop",
       "surface": "apple",
-      "id": "native.apple.9da8bb9b1b8aa353"
+      "id": "native.apple.c70f75e90a66e03a"
     },
     {
       "kind": "ui-named-argument",
@@ -9711,7 +9711,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Review and apply proposed skills.",
       "surface": "apple",
-      "id": "native.apple.e3bcf286b266f54c"
+      "id": "native.apple.54b4f8475d9abcaf"
     },
     {
       "kind": "ui-modifier",
@@ -9719,7 +9719,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Proposal",
       "surface": "apple",
-      "id": "native.apple.bae7e51d0e736886"
+      "id": "native.apple.59602569c0ad69fc"
     },
     {
       "kind": "ui-call",
@@ -9727,7 +9727,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Done",
       "surface": "apple",
-      "id": "native.apple.d690a258effde59c"
+      "id": "native.apple.fee7146dbd3a4b4d"
     },
     {
       "kind": "ui-call",
@@ -9735,7 +9735,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "\\(self.filteredProposals.count) proposals",
       "surface": "apple",
-      "id": "native.apple.57ea1dae1aa22723"
+      "id": "native.apple.3c152431c85e47df"
     },
     {
       "kind": "ui-call",
@@ -9743,7 +9743,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Status",
       "surface": "apple",
-      "id": "native.apple.daffe56ff9b28fa8"
+      "id": "native.apple.4bfc76b4be4e7d06"
     },
     {
       "kind": "ui-call",
@@ -9751,7 +9751,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.f343b3c8847ae5a6"
+      "id": "native.apple.79233f9c2bb91772"
     },
     {
       "kind": "ui-call",
@@ -9759,7 +9759,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Search proposals",
       "surface": "apple",
-      "id": "native.apple.5a499d3e1bf372ce"
+      "id": "native.apple.61d175f424519081"
     },
     {
       "kind": "ui-call",
@@ -9767,7 +9767,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Agent",
       "surface": "apple",
-      "id": "native.apple.8c05535490c13854"
+      "id": "native.apple.02b131e12753f566"
     },
     {
       "kind": "ui-call",
@@ -9775,7 +9775,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Default agent",
       "surface": "apple",
-      "id": "native.apple.1b494b6dc7ed0ec6"
+      "id": "native.apple.29d9ffd4065105f2"
     },
     {
       "kind": "ui-modifier",
@@ -9783,7 +9783,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Skill Workshop agent scope",
       "surface": "apple",
-      "id": "native.apple.429fbc96ee068cb0"
+      "id": "native.apple.75343c6542706e32"
     },
     {
       "kind": "conditional-branch",
@@ -9791,7 +9791,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "No proposals",
       "surface": "apple",
-      "id": "native.apple.0426cf61cbd72dd4"
+      "id": "native.apple.60c163d47db8658a"
     },
     {
       "kind": "conditional-branch",
@@ -9799,7 +9799,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "No proposals loaded",
       "surface": "apple",
-      "id": "native.apple.56b46d5289e460a7"
+      "id": "native.apple.5aa551b7a52709d6"
     },
     {
       "kind": "conditional-branch",
@@ -9807,7 +9807,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "New proposals will appear here when agents draft skills.",
       "surface": "apple",
-      "id": "native.apple.401016421351cd1d"
+      "id": "native.apple.ed2a3ec0705ebca3"
     },
     {
       "kind": "conditional-branch",
@@ -9815,7 +9815,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Connect from Settings to load Skill Workshop proposals.",
       "surface": "apple",
-      "id": "native.apple.bacbe7d1ade39252"
+      "id": "native.apple.61b17eef56270df7"
     },
     {
       "kind": "ui-named-argument",
@@ -9823,7 +9823,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Queue",
       "surface": "apple",
-      "id": "native.apple.610d75ef598b0732"
+      "id": "native.apple.9917eb13fd775dad"
     },
     {
       "kind": "ui-named-argument",
@@ -9831,7 +9831,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Proposal unavailable",
       "surface": "apple",
-      "id": "native.apple.7df7629c97f9ce5c"
+      "id": "native.apple.bc8ff3d4d2efc77f"
     },
     {
       "kind": "ui-named-argument",
@@ -9839,7 +9839,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Return to the queue and choose another proposal.",
       "surface": "apple",
-      "id": "native.apple.4346e78325e97c0b"
+      "id": "native.apple.67d0dd8899d52c04"
     },
     {
       "kind": "ui-call",
@@ -9847,7 +9847,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Select refresh to load the proposal body.",
       "surface": "apple",
-      "id": "native.apple.0fea571f6d470cd1"
+      "id": "native.apple.1bc05cf8ad9561f0"
     },
     {
       "kind": "ui-call",
@@ -9855,7 +9855,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Support files",
       "surface": "apple",
-      "id": "native.apple.a7cf31dea97d6a4c"
+      "id": "native.apple.2ec291f474703e3a"
     },
     {
       "kind": "ui-call",
@@ -9863,7 +9863,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Admin scope required.",
       "surface": "apple",
-      "id": "native.apple.9cc0c7366724336d"
+      "id": "native.apple.69fd00c6086fe6ad"
     },
     {
       "kind": "conditional-branch",
@@ -9871,7 +9871,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Proposal applied.",
       "surface": "apple",
-      "id": "native.apple.79e7355c669bf71e"
+      "id": "native.apple.51c2a607a7519f5d"
     },
     {
       "kind": "conditional-branch",
@@ -9879,7 +9879,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Proposal rejected.",
       "surface": "apple",
-      "id": "native.apple.0b2d2e1dc00b709e"
+      "id": "native.apple.9219ffa8ab5af913"
     },
     {
       "kind": "ui-named-argument",
@@ -9887,7 +9887,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "No \\(IPadSkillWorkshopScreen.proposalLaneLabel(self.status).lowercased()) proposals",
       "surface": "apple",
-      "id": "native.apple.16e5b5a92891e431"
+      "id": "native.apple.a6d7f78785bd06d7"
     },
     {
       "kind": "ui-named-argument",
@@ -9895,7 +9895,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Matching proposals appear here after gateway refresh.",
       "surface": "apple",
-      "id": "native.apple.d551631fd59d66ba"
+      "id": "native.apple.66e9b298b37de8ff"
     },
     {
       "kind": "ui-modifier",
@@ -9903,7 +9903,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Apply Proposal",
       "surface": "apple",
-      "id": "native.apple.d02a3df75b832c44"
+      "id": "native.apple.e5e1bc7e7c0bbfda"
     },
     {
       "kind": "ui-modifier",
@@ -9911,7 +9911,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Reject Proposal",
       "surface": "apple",
-      "id": "native.apple.a13064eb47c83eb8"
+      "id": "native.apple.a4cfb66a1d59e243"
     },
     {
       "kind": "ui-modifier",
@@ -9919,7 +9919,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Inspect Proposal",
       "surface": "apple",
-      "id": "native.apple.87a5f8581e42877d"
+      "id": "native.apple.da7ddf9e4ecfe658"
     },
     {
       "kind": "ui-call",
@@ -9927,7 +9927,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Inspect",
       "surface": "apple",
-      "id": "native.apple.5cf8a3ccae1db3e6"
+      "id": "native.apple.14eb423e0c4e44ff"
     },
     {
       "kind": "ui-call",
@@ -9935,7 +9935,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Apply",
       "surface": "apple",
-      "id": "native.apple.f716605808ff03fc"
+      "id": "native.apple.b77f9f273e7ce412"
     },
     {
       "kind": "ui-call",
@@ -9943,7 +9943,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Reject",
       "surface": "apple",
-      "id": "native.apple.c83a84bb8d0ab095"
+      "id": "native.apple.59d5bca9a466ecad"
     },
     {
       "kind": "ui-named-argument",
@@ -9951,7 +9951,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Workboard",
       "surface": "apple",
-      "id": "native.apple.f12f3fcc4fa6b04b"
+      "id": "native.apple.7ab687186fadfc76"
     },
     {
       "kind": "ui-call",
@@ -9959,7 +9959,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Search cards",
       "surface": "apple",
-      "id": "native.apple.57baf3d2a463af6d"
+      "id": "native.apple.342ff334d870f412"
     },
     {
       "kind": "ui-call",
@@ -9967,7 +9967,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Scope",
       "surface": "apple",
-      "id": "native.apple.6d5fff8d127eeb0a"
+      "id": "native.apple.836fe8ff57836a99"
     },
     {
       "kind": "ui-call",
@@ -9975,7 +9975,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.f3ab09d2ffba5d9b"
+      "id": "native.apple.9ffdadd05ebcd9b4"
     },
     {
       "kind": "ui-call",
@@ -9983,7 +9983,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "\\(self.filteredCards.count) cards",
       "surface": "apple",
-      "id": "native.apple.fb9e29033d18989e"
+      "id": "native.apple.79f76baaecd38dd4"
     },
     {
       "kind": "ui-call",
@@ -9991,7 +9991,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Dispatch",
       "surface": "apple",
-      "id": "native.apple.218fbb58080fb72d"
+      "id": "native.apple.fef5b5ea3dd57bfa"
     },
     {
       "kind": "ui-modifier",
@@ -9999,7 +9999,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Refresh workboard",
       "surface": "apple",
-      "id": "native.apple.8f223078cd6ac6a3"
+      "id": "native.apple.7389a6b4e45aebc6"
     },
     {
       "kind": "ui-call",
@@ -10007,7 +10007,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "New Card",
       "surface": "apple",
-      "id": "native.apple.48006e54096957cd"
+      "id": "native.apple.0492d2ba165f9dd2"
     },
     {
       "kind": "ui-modifier",
@@ -10015,7 +10015,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Opens card title and notes entry",
       "surface": "apple",
-      "id": "native.apple.a96a3caad5b92660"
+      "id": "native.apple.8b4984907a73a394"
     },
     {
       "kind": "ui-call",
@@ -10023,7 +10023,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "active",
       "surface": "apple",
-      "id": "native.apple.a14964a14217bd01"
+      "id": "native.apple.f7fcb69602f94f64"
     },
     {
       "kind": "ui-modifier",
@@ -10031,7 +10031,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Show \\(IPadWorkboardDefaults.label(for: status)) cards",
       "surface": "apple",
-      "id": "native.apple.1025db84f77e09e2"
+      "id": "native.apple.f69a2f9daa810d75"
     },
     {
       "kind": "ui-call",
@@ -10039,7 +10039,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Board",
       "surface": "apple",
-      "id": "native.apple.d451be3a2cbc14a2"
+      "id": "native.apple.63ec16fd003c72cb"
     },
     {
       "kind": "ui-call",
@@ -10047,7 +10047,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "All boards",
       "surface": "apple",
-      "id": "native.apple.4ed27158ad8a0f9b"
+      "id": "native.apple.c983ee21eb37d094"
     },
     {
       "kind": "ui-modifier",
@@ -10055,7 +10055,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Workboard board scope",
       "surface": "apple",
-      "id": "native.apple.e2418405eb6a9908"
+      "id": "native.apple.d8851ecfd78a344d"
     },
     {
       "kind": "ui-call",
@@ -10063,7 +10063,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Active",
       "surface": "apple",
-      "id": "native.apple.bec86362b812a969"
+      "id": "native.apple.fdb9c61ba76d0053"
     },
     {
       "kind": "ui-named-argument",
@@ -10071,7 +10071,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Queue",
       "surface": "apple",
-      "id": "native.apple.116ad51e94090396"
+      "id": "native.apple.82be1a5de9f45491"
     },
     {
       "kind": "conditional-branch",
@@ -10079,7 +10079,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "No cards",
       "surface": "apple",
-      "id": "native.apple.53ff83914372dbc4"
+      "id": "native.apple.32f4651d5435080e"
     },
     {
       "kind": "conditional-branch",
@@ -10087,7 +10087,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "No cards loaded",
       "surface": "apple",
-      "id": "native.apple.2467cc9a85c3a33f"
+      "id": "native.apple.eea8b87c5cf0fd3b"
     },
     {
       "kind": "conditional-branch",
@@ -10095,7 +10095,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Create a card or change the filter.",
       "surface": "apple",
-      "id": "native.apple.d150c79eaa14ec76"
+      "id": "native.apple.52015bb5fc923caa"
     },
     {
       "kind": "conditional-branch",
@@ -10103,7 +10103,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Connect from Settings to load workboard cards.",
       "surface": "apple",
-      "id": "native.apple.60483b8876b7f59f"
+      "id": "native.apple.e3e02f176ae010a7"
     },
     {
       "kind": "ui-call",
@@ -10111,7 +10111,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Notes",
       "surface": "apple",
-      "id": "native.apple.24fb5469bb5a5b37"
+      "id": "native.apple.07170eb527fff636"
     },
     {
       "kind": "ui-call",
@@ -10119,7 +10119,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Cancel",
       "surface": "apple",
-      "id": "native.apple.d34aa91acc1064ad"
+      "id": "native.apple.365cbbf1aa009ef9"
     },
     {
       "kind": "conditional-branch",
@@ -10127,7 +10127,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Create",
       "surface": "apple",
-      "id": "native.apple.5c1a338af512a718"
+      "id": "native.apple.67645e205fff9031"
     },
     {
       "kind": "conditional-branch",
@@ -10135,7 +10135,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Creating...",
       "surface": "apple",
-      "id": "native.apple.6d92a8218bb832f5"
+      "id": "native.apple.af2c039b2dce4ab7"
     },
     {
       "kind": "conditional-branch",
@@ -10143,7 +10143,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Connect from Settings to create, move, and dispatch cards.",
       "surface": "apple",
-      "id": "native.apple.13138f666cdcf858"
+      "id": "native.apple.1e30b27627e4ddac"
     },
     {
       "kind": "conditional-branch",
@@ -10151,7 +10151,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Read-only gateway.",
       "surface": "apple",
-      "id": "native.apple.3a979dd267aec356"
+      "id": "native.apple.d33993cdb2f30882"
     },
     {
       "kind": "ui-named-argument",
@@ -10159,7 +10159,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "No \\(IPadWorkboardDefaults.label(for: self.status).lowercased()) cards",
       "surface": "apple",
-      "id": "native.apple.32c4f348c9f4e313"
+      "id": "native.apple.7d9cccea80bfb9a0"
     },
     {
       "kind": "ui-named-argument",
@@ -10167,7 +10167,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Cards moved into this lane appear here.",
       "surface": "apple",
-      "id": "native.apple.30c47306610cb517"
+      "id": "native.apple.f1ff845665521f57"
     },
     {
       "kind": "ui-modifier",
@@ -10175,7 +10175,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Card Actions",
       "surface": "apple",
-      "id": "native.apple.7c47d0fcdeb2d0d3"
+      "id": "native.apple.615cf44f494e7e25"
     },
     {
       "kind": "ui-call",
@@ -10183,7 +10183,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Open",
       "surface": "apple",
-      "id": "native.apple.651ec246396255cd"
+      "id": "native.apple.f187c2900fbe7254"
     },
     {
       "kind": "ui-call",
@@ -10191,7 +10191,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Inspect",
       "surface": "apple",
-      "id": "native.apple.c1f2821d719e37f8"
+      "id": "native.apple.0d23c6702b5a0aa0"
     },
     {
       "kind": "ui-call",
@@ -10199,7 +10199,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Move to \\(IPadWorkboardDefaults.label(for: status))",
       "surface": "apple",
-      "id": "native.apple.774f595a01eca278"
+      "id": "native.apple.a18d25d511979e0c"
     },
     {
       "kind": "conditional-branch",
@@ -10207,7 +10207,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Default agent",
       "surface": "apple",
-      "id": "native.apple.1345612333480144"
+      "id": "native.apple.61b4e4726d1e60ff"
     },
     {
       "kind": "ui-call",
@@ -10215,7 +10215,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Title",
       "surface": "apple",
-      "id": "native.apple.77a417fa0f2aba1d"
+      "id": "native.apple.40d27d3b708a00ae"
     },
     {
       "kind": "ui-call",
@@ -10223,7 +10223,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Status",
       "surface": "apple",
-      "id": "native.apple.6662824115f6982a"
+      "id": "native.apple.d40c58190ea3ce6a"
     },
     {
       "kind": "ui-call",
@@ -10231,7 +10231,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Card",
       "surface": "apple",
-      "id": "native.apple.0c99715b98ca22a2"
+      "id": "native.apple.0e59a134340e68b7"
     },
     {
       "kind": "ui-call",
@@ -10239,7 +10239,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Open Session",
       "surface": "apple",
-      "id": "native.apple.93eeaedb2ff61043"
+      "id": "native.apple.3edbccb7c14b693c"
     },
     {
       "kind": "ui-call",
@@ -10247,7 +10247,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Move",
       "surface": "apple",
-      "id": "native.apple.a2732e4ff77a201b"
+      "id": "native.apple.81a91254f857c615"
     },
     {
       "kind": "conditional-branch",
@@ -10255,7 +10255,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Archive",
       "surface": "apple",
-      "id": "native.apple.f0d98558ee17ffe2"
+      "id": "native.apple.74307b392a619c81"
     },
     {
       "kind": "conditional-branch",
@@ -10263,7 +10263,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Unarchive",
       "surface": "apple",
-      "id": "native.apple.dab3609e8a71ed48"
+      "id": "native.apple.9dec96f01e7aaebb"
     },
     {
       "kind": "ui-call",
@@ -10271,7 +10271,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Actions",
       "surface": "apple",
-      "id": "native.apple.68a43a9e8939f395"
+      "id": "native.apple.24de77ef3ebb77be"
     },
     {
       "kind": "ui-call",
@@ -10279,7 +10279,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Done",
       "surface": "apple",
-      "id": "native.apple.07a313e2adf7227b"
+      "id": "native.apple.77a8a3e8fffd1843"
     },
     {
       "kind": "conditional-branch",
@@ -10287,7 +10287,7 @@
       "path": "apps/ios/Sources/Design/OpenClawBrand.swift",
       "source": "System",
       "surface": "apple",
-      "id": "native.apple.132b2b13adbcee9d"
+      "id": "native.apple.f1c2754e127d35a8"
     },
     {
       "kind": "conditional-branch",
@@ -10295,7 +10295,7 @@
       "path": "apps/ios/Sources/Design/OpenClawBrand.swift",
       "source": "Light",
       "surface": "apple",
-      "id": "native.apple.f666f2dfc656500f"
+      "id": "native.apple.f36a72d6749a4957"
     },
     {
       "kind": "conditional-branch",
@@ -10303,7 +10303,7 @@
       "path": "apps/ios/Sources/Design/OpenClawBrand.swift",
       "source": "Dark",
       "surface": "apple",
-      "id": "native.apple.e3576faef11c7eba"
+      "id": "native.apple.c78f78c1231dca4e"
     },
     {
       "kind": "ui-modifier",
@@ -10311,7 +10311,7 @@
       "path": "apps/ios/Sources/Design/OpenClawDocsScreen.swift",
       "source": "Gateway settings",
       "surface": "apple",
-      "id": "native.apple.f64f4306f8047c7d"
+      "id": "native.apple.72e131e6c59d9aa2"
     },
     {
       "kind": "ui-named-argument",
@@ -10319,7 +10319,7 @@
       "path": "apps/ios/Sources/Design/OpenClawDocsScreen.swift",
       "source": "Docs",
       "surface": "apple",
-      "id": "native.apple.187f468d1f0a0c82"
+      "id": "native.apple.99059a2947897ec4"
     },
     {
       "kind": "ui-named-argument",
@@ -10327,7 +10327,7 @@
       "path": "apps/ios/Sources/Design/OpenClawDocsScreen.swift",
       "source": "Gateway setup, pairing, channels, and mobile node reference.",
       "surface": "apple",
-      "id": "native.apple.809781d0475b8058"
+      "id": "native.apple.f09e1d926dfb62e7"
     },
     {
       "kind": "ui-modifier",
@@ -10335,7 +10335,7 @@
       "path": "apps/ios/Sources/Design/OpenClawDocsScreen.swift",
       "source": "Opens Settings / Gateway",
       "surface": "apple",
-      "id": "native.apple.5c5978aabd24bbce"
+      "id": "native.apple.f5b51e0af861474c"
     },
     {
       "kind": "ui-named-argument",
@@ -10343,7 +10343,7 @@
       "path": "apps/ios/Sources/Design/OpenClawDocsScreen.swift",
       "source": "Docs Home",
       "surface": "apple",
-      "id": "native.apple.4c34fd079149ed02"
+      "id": "native.apple.a67a5039f5cb5e33"
     },
     {
       "kind": "ui-named-argument",
@@ -10351,7 +10351,7 @@
       "path": "apps/ios/Sources/Design/OpenClawDocsScreen.swift",
       "source": "Browse the current OpenClaw reference.",
       "surface": "apple",
-      "id": "native.apple.56935c5384889b8e"
+      "id": "native.apple.8e6797ab3b17ba28"
     },
     {
       "kind": "ui-named-argument",
@@ -10359,7 +10359,7 @@
       "path": "apps/ios/Sources/Design/OpenClawDocsScreen.swift",
       "source": "Gateway",
       "surface": "apple",
-      "id": "native.apple.2ee2f8c71fa2d2cc"
+      "id": "native.apple.ef48769a5f23b10d"
     },
     {
       "kind": "ui-named-argument",
@@ -10367,7 +10367,7 @@
       "path": "apps/ios/Sources/Design/OpenClawDocsScreen.swift",
       "source": "Connection, auth, and diagnostics.",
       "surface": "apple",
-      "id": "native.apple.610af6c97ab9f33a"
+      "id": "native.apple.4ffb70b541b05680"
     },
     {
       "kind": "ui-named-argument",
@@ -10375,7 +10375,7 @@
       "path": "apps/ios/Sources/Design/OpenClawDocsScreen.swift",
       "source": "Pairing",
       "surface": "apple",
-      "id": "native.apple.a25d827f6577a87f"
+      "id": "native.apple.dee7639745ddcd6b"
     },
     {
       "kind": "ui-named-argument",
@@ -10383,7 +10383,7 @@
       "path": "apps/ios/Sources/Design/OpenClawDocsScreen.swift",
       "source": "Mobile setup codes, QR, and node approval.",
       "surface": "apple",
-      "id": "native.apple.5217a044d98947d5"
+      "id": "native.apple.04a62e7d37c97129"
     },
     {
       "kind": "ui-call",
@@ -10391,7 +10391,7 @@
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Request ID: \\(value)",
       "surface": "apple",
-      "id": "native.apple.f36a9ff70377109b"
+      "id": "native.apple.def747b532c8cc10"
     },
     {
       "kind": "ui-modifier",
@@ -10399,7 +10399,7 @@
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "OpenClaw",
       "surface": "apple",
-      "id": "native.apple.cf9bb65f8e405cc8"
+      "id": "native.apple.8ccc4a8d1a4a904b"
     },
     {
       "kind": "ui-modifier",
@@ -10407,7 +10407,7 @@
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Gateway \\(self.title)",
       "surface": "apple",
-      "id": "native.apple.51c566ed34b67acf"
+      "id": "native.apple.53841314242e9b14"
     },
     {
       "kind": "conditional-branch",
@@ -10415,7 +10415,7 @@
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Online",
       "surface": "apple",
-      "id": "native.apple.72baecec6cf1b462"
+      "id": "native.apple.dcff65ad8bf64957"
     },
     {
       "kind": "conditional-branch",
@@ -10423,7 +10423,7 @@
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Connecting",
       "surface": "apple",
-      "id": "native.apple.ca9dfb05d9034ff7"
+      "id": "native.apple.eb7444b4c1a37f3d"
     },
     {
       "kind": "conditional-branch",
@@ -10431,7 +10431,7 @@
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Attention",
       "surface": "apple",
-      "id": "native.apple.d7a3d53412e23e88"
+      "id": "native.apple.9fbc88df62ebf3d8"
     },
     {
       "kind": "conditional-branch",
@@ -10439,7 +10439,7 @@
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Offline",
       "surface": "apple",
-      "id": "native.apple.1fc3cbd16076f75f"
+      "id": "native.apple.42e6cb6c54619df1"
     },
     {
       "kind": "ui-modifier",
@@ -10447,7 +10447,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Control",
       "surface": "apple",
-      "id": "native.apple.a2d8e7b4dba29764"
+      "id": "native.apple.4883398341dc7aa0"
     },
     {
       "kind": "ui-modifier",
@@ -10455,7 +10455,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Opens Settings / Gateway",
       "surface": "apple",
-      "id": "native.apple.597471e86dda3d38"
+      "id": "native.apple.465b1445efb3da90"
     },
     {
       "kind": "ui-named-argument",
@@ -10463,7 +10463,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Agent chat and recent work.",
       "surface": "apple",
-      "id": "native.apple.ed16c9793f468dcd"
+      "id": "native.apple.d8667bf65ab3e4f1"
     },
     {
       "kind": "ui-named-argument",
@@ -10471,7 +10471,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Realtime voice and controls.",
       "surface": "apple",
-      "id": "native.apple.a30d0a950d0a77aa"
+      "id": "native.apple.f3c7630577053de4"
     },
     {
       "kind": "ui-named-argument",
@@ -10479,7 +10479,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Overview",
       "surface": "apple",
-      "id": "native.apple.a03e961ab14ba060"
+      "id": "native.apple.a5bd3566d760b166"
     },
     {
       "kind": "ui-named-argument",
@@ -10487,7 +10487,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Instances",
       "surface": "apple",
-      "id": "native.apple.feb28c9cba676ba2"
+      "id": "native.apple.cabc2b15a2b72ca6"
     },
     {
       "kind": "ui-named-argument",
@@ -10495,7 +10495,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Files",
       "surface": "apple",
-      "id": "native.apple.3f2726ccd1acd987"
+      "id": "native.apple.b0ff384e03794169"
     },
     {
       "kind": "ui-named-argument",
@@ -10503,7 +10503,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Dreaming",
       "surface": "apple",
-      "id": "native.apple.614c9b40919fb103"
+      "id": "native.apple.81636957f8c74c24"
     },
     {
       "kind": "ui-named-argument",
@@ -10511,7 +10511,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Usage",
       "surface": "apple",
-      "id": "native.apple.e2b5c2d7c5d461a3"
+      "id": "native.apple.6d80ef2f1402b026"
     },
     {
       "kind": "ui-named-argument",
@@ -10519,7 +10519,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Cron Jobs",
       "surface": "apple",
-      "id": "native.apple.9eb33a11fb81796b"
+      "id": "native.apple.ae4c14b1758ac672"
     },
     {
       "kind": "ui-call",
@@ -10527,7 +10527,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Gateway",
       "surface": "apple",
-      "id": "native.apple.e0e99a802f07cc68"
+      "id": "native.apple.57b584ff83b40beb"
     },
     {
       "kind": "ui-call",
@@ -10535,7 +10535,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Gateway \\(self.gatewayStateText), \\(gatewayDisplayLabel), \\(self.sidebarActiveAgentTitle)",
       "surface": "apple",
-      "id": "native.apple.e30d7d35682e8ffa"
+      "id": "native.apple.8f80f56442bc2abd"
     },
     {
       "kind": "ui-call",
@@ -10543,7 +10543,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Gateway \\(self.gatewayStateText), \\(self.sidebarActiveAgentTitle)",
       "surface": "apple",
-      "id": "native.apple.75b65c24f3607c35"
+      "id": "native.apple.61e9abc9db4ec4fb"
     },
     {
       "kind": "conditional-branch",
@@ -10551,7 +10551,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Online",
       "surface": "apple",
-      "id": "native.apple.01ad746119fbc27d"
+      "id": "native.apple.b125d7318f96ef61"
     },
     {
       "kind": "conditional-branch",
@@ -10559,7 +10559,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Connecting",
       "surface": "apple",
-      "id": "native.apple.e253ef19f6e53371"
+      "id": "native.apple.ffb669ae1646d183"
     },
     {
       "kind": "conditional-branch",
@@ -10567,7 +10567,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Attention",
       "surface": "apple",
-      "id": "native.apple.6f28b07ebdc2b25d"
+      "id": "native.apple.a5693bac0436c69d"
     },
     {
       "kind": "conditional-branch",
@@ -10575,7 +10575,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Offline",
       "surface": "apple",
-      "id": "native.apple.1c931bcd1cd20334"
+      "id": "native.apple.ebf806b5a1ff167b"
     },
     {
       "kind": "ui-call",
@@ -10583,7 +10583,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Channels / Integrations",
       "surface": "apple",
-      "id": "native.apple.65602c216b89032d"
+      "id": "native.apple.96e79ba170adea15"
     },
     {
       "kind": "ui-named-argument",
@@ -10591,7 +10591,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Loading channels",
       "surface": "apple",
-      "id": "native.apple.aacfc3d31109d5ab"
+      "id": "native.apple.7efea4282407470c"
     },
     {
       "kind": "ui-named-argument",
@@ -10599,7 +10599,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Fetching installed channels, accounts, and routing status from the gateway.",
       "surface": "apple",
-      "id": "native.apple.373913573fe8474a"
+      "id": "native.apple.7b12c5deebaa94bf"
     },
     {
       "kind": "ui-call",
@@ -10607,7 +10607,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Stop",
       "surface": "apple",
-      "id": "native.apple.d0eb2c9b73d0e34c"
+      "id": "native.apple.6e7f0741e6ab8b1f"
     },
     {
       "kind": "ui-call",
@@ -10615,7 +10615,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Start",
       "surface": "apple",
-      "id": "native.apple.4333e9ef3a21e90e"
+      "id": "native.apple.2dff13408913eaf1"
     },
     {
       "kind": "ui-call",
@@ -10623,7 +10623,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Logout",
       "surface": "apple",
-      "id": "native.apple.19108f0f755e083d"
+      "id": "native.apple.968335a401d81cc7"
     },
     {
       "kind": "conditional-branch",
@@ -10631,7 +10631,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Could not encode channel request.",
       "surface": "apple",
-      "id": "native.apple.9ac0bbf442dd842f"
+      "id": "native.apple.e0dc5c4065a92e3c"
     },
     {
       "kind": "ui-call",
@@ -10639,7 +10639,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Connected",
       "surface": "apple",
-      "id": "native.apple.98c951a7322c94dc"
+      "id": "native.apple.d50654ae6808d0a7"
     },
     {
       "kind": "ui-call",
@@ -10647,7 +10647,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Loading",
       "surface": "apple",
-      "id": "native.apple.e9a0639e3df7d270"
+      "id": "native.apple.a45c8e447188a0cb"
     },
     {
       "kind": "ui-named-argument",
@@ -10655,7 +10655,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Loading channel status",
       "surface": "apple",
-      "id": "native.apple.39ec8a10330f9bb0"
+      "id": "native.apple.bc112e895fd77b31"
     },
     {
       "kind": "ui-named-argument",
@@ -10663,7 +10663,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Checking installed channel clients and account state.",
       "surface": "apple",
-      "id": "native.apple.2183ebee2edb4b04"
+      "id": "native.apple.8b9242b781898b0a"
     },
     {
       "kind": "ui-call",
@@ -10671,7 +10671,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Empty",
       "surface": "apple",
-      "id": "native.apple.5499301c35444424"
+      "id": "native.apple.366a77f110681578"
     },
     {
       "kind": "ui-named-argument",
@@ -10679,7 +10679,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Message Routing",
       "surface": "apple",
-      "id": "native.apple.5fbbe373a4d427fa"
+      "id": "native.apple.0c8a603f7646e0a6"
     },
     {
       "kind": "ui-named-argument",
@@ -10687,7 +10687,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Refresh Channels",
       "surface": "apple",
-      "id": "native.apple.9918aa58bf346645"
+      "id": "native.apple.523ea4b446a6d72a"
     },
     {
       "kind": "ui-named-argument",
@@ -10695,7 +10695,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "No channel plugins reported",
       "surface": "apple",
-      "id": "native.apple.de33101d0c049a5f"
+      "id": "native.apple.4ba6c1af518dedff"
     },
     {
       "kind": "ui-named-argument",
@@ -10703,7 +10703,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Install or enable channel plugins on the gateway, then refresh.",
       "surface": "apple",
-      "id": "native.apple.afee604367e1caee"
+      "id": "native.apple.8cab40fe53165339"
     },
     {
       "kind": "ui-call",
@@ -10711,7 +10711,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Error",
       "surface": "apple",
-      "id": "native.apple.67ef5e90c3ea315b"
+      "id": "native.apple.be909d396399237b"
     },
     {
       "kind": "ui-named-argument",
@@ -10719,7 +10719,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Channel status unavailable",
       "surface": "apple",
-      "id": "native.apple.aa97425de5b33828"
+      "id": "native.apple.1b5e3bf243a6ebd8"
     },
     {
       "kind": "ui-named-argument",
@@ -10727,7 +10727,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Gateway returned an unexpected channel status response.",
       "surface": "apple",
-      "id": "native.apple.889115c46972d544"
+      "id": "native.apple.94f73cc6841fe247"
     },
     {
       "kind": "ui-call",
@@ -10735,7 +10735,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Offline",
       "surface": "apple",
-      "id": "native.apple.042fad5f44e4a00c"
+      "id": "native.apple.82f15aba24e2fafb"
     },
     {
       "kind": "ui-named-argument",
@@ -10743,7 +10743,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Gateway offline",
       "surface": "apple",
-      "id": "native.apple.59c349b1b581354f"
+      "id": "native.apple.e66416898782fbcc"
     },
     {
       "kind": "ui-named-argument",
@@ -10751,7 +10751,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Connect to the gateway to load installed channels, accounts, and routing status.",
       "surface": "apple",
-      "id": "native.apple.6308264d116d5be6"
+      "id": "native.apple.37e299525940057f"
     },
     {
       "kind": "ui-modifier",
@@ -10759,7 +10759,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Settings",
       "surface": "apple",
-      "id": "native.apple.ecf68905545575e6"
+      "id": "native.apple.520d26673d6ad925"
     },
     {
       "kind": "ui-modifier",
@@ -10767,7 +10767,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Scan QR Code",
       "surface": "apple",
-      "id": "native.apple.adae4106b8b9c38b"
+      "id": "native.apple.8a9d262ac9a7af24"
     },
     {
       "kind": "ui-modifier",
@@ -10775,7 +10775,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Reset Onboarding?",
       "surface": "apple",
-      "id": "native.apple.22b4d5d925ada9ee"
+      "id": "native.apple.94ebe6bce24af4a5"
     },
     {
       "kind": "ui-call",
@@ -10783,7 +10783,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Reset",
       "surface": "apple",
-      "id": "native.apple.4ed955a25c8ed47c"
+      "id": "native.apple.606b02f9771a84d5"
     },
     {
       "kind": "ui-call",
@@ -10791,7 +10791,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "This disconnects, clears saved gateway credentials, and reopens onboarding.",
       "surface": "apple",
-      "id": "native.apple.800904a3c6cdc147"
+      "id": "native.apple.ea7d7870072619ab"
     },
     {
       "kind": "ui-modifier",
@@ -10799,7 +10799,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "QR Scanner Unavailable",
       "surface": "apple",
-      "id": "native.apple.fed30be42b5be08e"
+      "id": "native.apple.d7d993f61b8f2153"
     },
     {
       "kind": "ui-call",
@@ -10807,7 +10807,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "OK",
       "surface": "apple",
-      "id": "native.apple.541078d5af9de662"
+      "id": "native.apple.19664950840c36c0"
     },
     {
       "kind": "ui-modifier",
@@ -10815,7 +10815,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Access Level",
       "surface": "apple",
-      "id": "native.apple.32230ecb2fbc2378"
+      "id": "native.apple.8eb3e4a8f5d9fa07"
     },
     {
       "kind": "ui-call",
@@ -10823,7 +10823,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "While Using the App",
       "surface": "apple",
-      "id": "native.apple.7ed27029e9c313cc"
+      "id": "native.apple.67b51ea21c427c4b"
     },
     {
       "kind": "ui-call",
@@ -10831,7 +10831,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Always",
       "surface": "apple",
-      "id": "native.apple.b975064b240c9fd6"
+      "id": "native.apple.33beb5644e52f122"
     },
     {
       "kind": "ui-call",
@@ -10839,7 +10839,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Choose when OpenClaw may share this iPhone's location with gateway tools.",
       "surface": "apple",
-      "id": "native.apple.756ff21ca904b2d8"
+      "id": "native.apple.e124c1310f5bd253"
     },
     {
       "kind": "ui-modifier",
@@ -10855,7 +10855,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Forget Gateway",
       "surface": "apple",
-      "id": "native.apple.ab8d7959b6ab66f9"
+      "id": "native.apple.e04f0bf5056c4892"
     },
     {
       "kind": "ui-call",
@@ -10863,7 +10863,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Cancel",
       "surface": "apple",
-      "id": "native.apple.0cb64be43c0b3d97"
+      "id": "native.apple.1ea33287d0845846"
     },
     {
       "kind": "ui-call-concatenated",
@@ -10871,7 +10871,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "This removes saved credentials, device access, TLS trust, and cached chats for this gateway.",
       "surface": "apple",
-      "id": "native.apple.53bb7808a1ae62bb"
+      "id": "native.apple.0735bc878408b001"
     },
     {
       "kind": "ui-call",
@@ -10879,7 +10879,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Enable OpenClaw Hosted Push Relay?",
       "surface": "apple",
-      "id": "native.apple.9bb1dae351d0e3a4"
+      "id": "native.apple.b71aa3216235c1dd"
     },
     {
       "kind": "ui-call",
@@ -10887,7 +10887,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Continue",
       "surface": "apple",
-      "id": "native.apple.f8c042a923222472"
+      "id": "native.apple.e0285faf26771e5e"
     },
     {
       "kind": "ui-call",
@@ -10895,7 +10895,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Not Now",
       "surface": "apple",
-      "id": "native.apple.e212e27354542d3b"
+      "id": "native.apple.27763ca1db2aae66"
     },
     {
       "kind": "ui-call",
@@ -10903,7 +10903,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Checks",
       "surface": "apple",
-      "id": "native.apple.d77230c105bfb69f"
+      "id": "native.apple.812b1afdc0149f1d"
     },
     {
       "kind": "ui-named-argument",
@@ -10911,7 +10911,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Last Run",
       "surface": "apple",
-      "id": "native.apple.00a5d93faa0d6491"
+      "id": "native.apple.34b636a28a323db6"
     },
     {
       "kind": "ui-named-argument",
@@ -10919,7 +10919,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Gateway Link",
       "surface": "apple",
-      "id": "native.apple.75c3292448aa0f89"
+      "id": "native.apple.4c825af0bbfc1f19"
     },
     {
       "kind": "ui-named-argument",
@@ -10927,7 +10927,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Discovery",
       "surface": "apple",
-      "id": "native.apple.33a2c183e95f7a3b"
+      "id": "native.apple.9116327e75750671"
     },
     {
       "kind": "ui-named-argument",
@@ -10935,7 +10935,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Talk Config",
       "surface": "apple",
-      "id": "native.apple.950847e4e29fc836"
+      "id": "native.apple.2f230d6f3b54c99e"
     },
     {
       "kind": "ui-named-argument",
@@ -10943,7 +10943,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Notifications",
       "surface": "apple",
-      "id": "native.apple.2a54915eabe91c06"
+      "id": "native.apple.2c51e14332f0cc71"
     },
     {
       "kind": "ui-named-argument",
@@ -10951,7 +10951,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Approval and event alert channel",
       "surface": "apple",
-      "id": "native.apple.5f795158b2f43ea8"
+      "id": "native.apple.7aa132aaf9f3e0ab"
     },
     {
       "kind": "ui-named-argument",
@@ -10959,7 +10959,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Screen Capture",
       "surface": "apple",
-      "id": "native.apple.ab6c665aea1a9525"
+      "id": "native.apple.9141bdd675672a6b"
     },
     {
       "kind": "ui-named-argument",
@@ -10967,7 +10967,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Live foreground capture state",
       "surface": "apple",
-      "id": "native.apple.d5c33a7a3b374f89"
+      "id": "native.apple.8d189015d58b40e3"
     },
     {
       "kind": "ui-named-argument",
@@ -10975,7 +10975,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Voice Wake",
       "surface": "apple",
-      "id": "native.apple.e641f2eb5c7bce81"
+      "id": "native.apple.d3f62f328adce82b"
     },
     {
       "kind": "conditional-branch",
@@ -10991,7 +10991,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Discovered",
       "surface": "apple",
-      "id": "native.apple.0a3f566ac6a35d90"
+      "id": "native.apple.188eb42d49f56b6c"
     },
     {
       "kind": "conditional-branch",
@@ -10999,7 +10999,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Discovered • TLS",
       "surface": "apple",
-      "id": "native.apple.1fe7af76a372f7dd"
+      "id": "native.apple.06da175683078b92"
     },
     {
       "kind": "conditional-branch",
@@ -11007,7 +11007,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "surface": "apple",
-      "id": "native.apple.3503aca018f04865"
+      "id": "native.apple.97b4f45efb35431f"
     },
     {
       "kind": "conditional-branch",
@@ -11015,7 +11015,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
       "surface": "apple",
-      "id": "native.apple.a9a778465dfe1198"
+      "id": "native.apple.28b25a11c0c8692a"
     },
     {
       "kind": "conditional-branch",
@@ -11023,7 +11023,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Configured",
       "surface": "apple",
-      "id": "native.apple.fbf8fb158f556a76"
+      "id": "native.apple.5ec38987b39279be"
     },
     {
       "kind": "conditional-branch",
@@ -11031,7 +11031,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Not configured",
       "surface": "apple",
-      "id": "native.apple.ad28c6e82fda63b0"
+      "id": "native.apple.792865cc320e22a5"
     },
     {
       "kind": "conditional-branch",
@@ -11047,7 +11047,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connect to the gateway.",
       "surface": "apple",
-      "id": "native.apple.0e6f25ab4a59543a"
+      "id": "native.apple.aba908391206b282"
     },
     {
       "kind": "conditional-branch",
@@ -11055,7 +11055,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Gateway requests will appear here.",
       "surface": "apple",
-      "id": "native.apple.0b7a54926d06b7d8"
+      "id": "native.apple.08f8ff249eb92776"
     },
     {
       "kind": "conditional-branch",
@@ -11079,7 +11079,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "High",
       "surface": "apple",
-      "id": "native.apple.0194fd3744125fd1"
+      "id": "native.apple.0e6374735564f939"
     },
     {
       "kind": "conditional-branch",
@@ -11087,7 +11087,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Resolving",
       "surface": "apple",
-      "id": "native.apple.cf64badb547e25c3"
+      "id": "native.apple.65db2459c9fe2ffd"
     },
     {
       "kind": "conditional-branch",
@@ -11095,7 +11095,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "One-time approval",
       "surface": "apple",
-      "id": "native.apple.c84829a753b01fe6"
+      "id": "native.apple.f8a79e13751914d9"
     },
     {
       "kind": "conditional-branch",
@@ -11103,7 +11103,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Permission can be saved",
       "surface": "apple",
-      "id": "native.apple.b02830c5966591df"
+      "id": "native.apple.062831956ee66b51"
     },
     {
       "kind": "conditional-branch",
@@ -11111,7 +11111,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Medium",
       "surface": "apple",
-      "id": "native.apple.3ce9dc6fee455ee5"
+      "id": "native.apple.1d997081ebcef122"
     },
     {
       "kind": "conditional-branch",
@@ -11119,7 +11119,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Review",
       "surface": "apple",
-      "id": "native.apple.7d5aa3128fb859da"
+      "id": "native.apple.778b4f9ae0fe994d"
     },
     {
       "kind": "conditional-branch",
@@ -11127,7 +11127,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "\\(diagnosticsIssueCount)",
       "surface": "apple",
-      "id": "native.apple.8ae57748b0b13d62"
+      "id": "native.apple.a95f6fe71bb1c4d1"
     },
     {
       "kind": "ui-modifier",
@@ -11135,7 +11135,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Choose system, light, or dark appearance",
       "surface": "apple",
-      "id": "native.apple.80fade864c8ad242"
+      "id": "native.apple.971844abef4e01c9"
     },
     {
       "kind": "ui-call",
@@ -11143,7 +11143,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Appearance",
       "surface": "apple",
-      "id": "native.apple.747143c7ef879774"
+      "id": "native.apple.067a5d2d5d180bc6"
     },
     {
       "kind": "conditional-branch",
@@ -11151,7 +11151,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Selected",
       "surface": "apple",
-      "id": "native.apple.f459c262b181a64b"
+      "id": "native.apple.4c364abf4a9f934b"
     },
     {
       "kind": "ui-call",
@@ -11159,7 +11159,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "System follows this device’s appearance setting.",
       "surface": "apple",
-      "id": "native.apple.998482352d20ebaa"
+      "id": "native.apple.5b72a4a0846d9de9"
     },
     {
       "kind": "ui-call",
@@ -11167,7 +11167,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Connection",
       "surface": "apple",
-      "id": "native.apple.70eca66c79335a6e"
+      "id": "native.apple.2b7499c8af24e546"
     },
     {
       "kind": "ui-named-argument",
@@ -11175,7 +11175,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Permissions",
       "surface": "apple",
-      "id": "native.apple.2c2cdafd79f8ba5b"
+      "id": "native.apple.bac6ce1e60b68af6"
     },
     {
       "kind": "ui-named-argument",
@@ -11183,7 +11183,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Channels",
       "surface": "apple",
-      "id": "native.apple.8a159fab30307884"
+      "id": "native.apple.5237358181ee8cdf"
     },
     {
       "kind": "ui-named-argument",
@@ -11191,7 +11191,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Diagnostics",
       "surface": "apple",
-      "id": "native.apple.1573249126ddd84f"
+      "id": "native.apple.2ac8e6968f723a6e"
     },
     {
       "kind": "ui-named-argument",
@@ -11199,7 +11199,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Privacy",
       "surface": "apple",
-      "id": "native.apple.464377858fd51ef3"
+      "id": "native.apple.0b3b9fcae57baa54"
     },
     {
       "kind": "ui-named-argument",
@@ -11207,7 +11207,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "About",
       "surface": "apple",
-      "id": "native.apple.f52553cad6c1f307"
+      "id": "native.apple.51487d4944f7e0ae"
     },
     {
       "kind": "ui-named-argument",
@@ -11215,7 +11215,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Licenses",
       "surface": "apple",
-      "id": "native.apple.529c06f7f7f6e428"
+      "id": "native.apple.55e8c7024736b1a7"
     },
     {
       "kind": "ui-named-argument",
@@ -11223,7 +11223,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway",
       "surface": "apple",
-      "id": "native.apple.5c4427c5a67068d6"
+      "id": "native.apple.edb095efd13ebfdc"
     },
     {
       "kind": "ui-call",
@@ -11231,7 +11231,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Address",
       "surface": "apple",
-      "id": "native.apple.800b6502b5b49941"
+      "id": "native.apple.52279c4b046bb63d"
     },
     {
       "kind": "ui-call",
@@ -11239,7 +11239,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Server",
       "surface": "apple",
-      "id": "native.apple.fde8b41db7ec49f3"
+      "id": "native.apple.6f9634642f8cbeb7"
     },
     {
       "kind": "ui-call",
@@ -11247,7 +11247,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovered",
       "surface": "apple",
-      "id": "native.apple.624f9dc99e8f9ff4"
+      "id": "native.apple.d2e489a70a83e516"
     },
     {
       "kind": "ui-call",
@@ -11255,7 +11255,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Agents",
       "surface": "apple",
-      "id": "native.apple.8e3656d85f092897"
+      "id": "native.apple.494217d3fb8c09fa"
     },
     {
       "kind": "ui-modifier",
@@ -11263,7 +11263,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Switch Gateway",
       "surface": "apple",
-      "id": "native.apple.88835de05348122a"
+      "id": "native.apple.e7d1a835000a7a85"
     },
     {
       "kind": "ui-named-argument",
@@ -11271,7 +11271,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Approvals",
       "surface": "apple",
-      "id": "native.apple.3c8f5bb5ce507cf9"
+      "id": "native.apple.67d6c8ced44b370d"
     },
     {
       "kind": "conditional-branch",
@@ -11287,7 +11287,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "No gateway actions are waiting for review.",
       "surface": "apple",
-      "id": "native.apple.bbc85e1645e8ccf1"
+      "id": "native.apple.6d7cc3eec4d32226"
     },
     {
       "kind": "conditional-branch",
@@ -11311,7 +11311,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Apple Watch",
       "surface": "apple",
-      "id": "native.apple.561d865ad24910d2"
+      "id": "native.apple.73793edde8e57a57"
     },
     {
       "kind": "conditional-branch",
@@ -11319,7 +11319,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Relay remains available; direct mode adds an independent Gateway node.",
       "surface": "apple",
-      "id": "native.apple.df05bfb397806b0d"
+      "id": "native.apple.6a046fd93df77020"
     },
     {
       "kind": "conditional-branch",
@@ -11327,7 +11327,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Install the OpenClaw watch app before enabling direct mode.",
       "surface": "apple",
-      "id": "native.apple.1bd0f0b41f4d4750"
+      "id": "native.apple.f31590a34ada7ea2"
     },
     {
       "kind": "conditional-branch",
@@ -11335,7 +11335,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Installed",
       "surface": "apple",
-      "id": "native.apple.cfa1c0be2d607257"
+      "id": "native.apple.1965c06e17786ed2"
     },
     {
       "kind": "conditional-branch",
@@ -11351,7 +11351,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Unavailable",
       "surface": "apple",
-      "id": "native.apple.59405b82eb08ae1e"
+      "id": "native.apple.19733b4ad0362082"
     },
     {
       "kind": "ui-call",
@@ -11359,7 +11359,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Enable Direct Gateway Connection",
       "surface": "apple",
-      "id": "native.apple.0177670438314602"
+      "id": "native.apple.add90173692666d2"
     },
     {
       "kind": "ui-call",
@@ -11367,7 +11367,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "The watch receives a one-time pairing code and stores its own device token. A reachable secure Gateway URL is required away from the iPhone.",
       "surface": "apple",
-      "id": "native.apple.eff9b913b3ae1c89"
+      "id": "native.apple.e0c6c949870b9c86"
     },
     {
       "kind": "ui-call",
@@ -11375,7 +11375,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Direct node features",
       "surface": "apple",
-      "id": "native.apple.c46c07933202448e"
+      "id": "native.apple.04943319a7abf864"
     },
     {
       "kind": "ui-call",
@@ -11383,7 +11383,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Notifications are off",
       "surface": "apple",
-      "id": "native.apple.db2079af09ca465a"
+      "id": "native.apple.7624063ebdbd3069"
     },
     {
       "kind": "ui-call",
@@ -11391,7 +11391,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Enable Notifications to receive approval alerts while OpenClaw is not open.",
       "surface": "apple",
-      "id": "native.apple.2e042499c42824f5"
+      "id": "native.apple.9b0d31ed51e810b9"
     },
     {
       "kind": "ui-call",
@@ -11399,7 +11399,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Open Notifications",
       "surface": "apple",
-      "id": "native.apple.fc1f2fdbe437cb9d"
+      "id": "native.apple.0834d89936666a38"
     },
     {
       "kind": "ui-call",
@@ -11447,7 +11447,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Deny",
       "surface": "apple",
-      "id": "native.apple.47aa34a39a9e05e5"
+      "id": "native.apple.7f6a03ac2a3d3686"
     },
     {
       "kind": "ui-call",
@@ -11463,7 +11463,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "No approvals waiting",
       "surface": "apple",
-      "id": "native.apple.9bc57eb179ada99d"
+      "id": "native.apple.9e6b547853ee3916"
     },
     {
       "kind": "ui-named-argument",
@@ -11471,7 +11471,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Camera",
       "surface": "apple",
-      "id": "native.apple.8486e210bfe6a446"
+      "id": "native.apple.c2d8d7de9ce25b08"
     },
     {
       "kind": "ui-named-argument",
@@ -11479,7 +11479,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Keep Awake",
       "surface": "apple",
-      "id": "native.apple.1826e2be7765ee28"
+      "id": "native.apple.d4db6d03f0bdab56"
     },
     {
       "kind": "ui-named-argument",
@@ -11487,7 +11487,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice & Talk",
       "surface": "apple",
-      "id": "native.apple.1dc29a33b5cd648a"
+      "id": "native.apple.560ef3ee39afa2fe"
     },
     {
       "kind": "ui-named-argument",
@@ -11495,7 +11495,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Health Check",
       "surface": "apple",
-      "id": "native.apple.a387f8cb16d76a93"
+      "id": "native.apple.97b060c5444877f6"
     },
     {
       "kind": "ui-named-argument",
@@ -11503,7 +11503,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Run app, permission, and gateway-adjacent checks without editing setup.",
       "surface": "apple",
-      "id": "native.apple.076a83f6eed9161a"
+      "id": "native.apple.9c2f6fa6cfa61b7e"
     },
     {
       "kind": "ui-call",
@@ -11511,7 +11511,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Run Diagnostics",
       "surface": "apple",
-      "id": "native.apple.e06f8e5c2bb61fe0"
+      "id": "native.apple.9b1338a386c54ec0"
     },
     {
       "kind": "ui-call",
@@ -11519,7 +11519,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Platform",
       "surface": "apple",
-      "id": "native.apple.83d3e72aa909f1a7"
+      "id": "native.apple.4b98da9e8179b554"
     },
     {
       "kind": "ui-call",
@@ -11527,7 +11527,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "App",
       "surface": "apple",
-      "id": "native.apple.a67b37443560bdef"
+      "id": "native.apple.4c50f9294f49ea75"
     },
     {
       "kind": "ui-call",
@@ -11535,7 +11535,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Model",
       "surface": "apple",
-      "id": "native.apple.6a7636305327b0fd"
+      "id": "native.apple.ed93ba5b5fb421e9"
     },
     {
       "kind": "ui-named-argument",
@@ -11543,7 +11543,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Camera Access",
       "surface": "apple",
-      "id": "native.apple.11954b310eb31f5e"
+      "id": "native.apple.cb9766c0f02db23c"
     },
     {
       "kind": "ui-named-argument",
@@ -11551,7 +11551,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Background Listening",
       "surface": "apple",
-      "id": "native.apple.a0ed2e431173327d"
+      "id": "native.apple.afd7a9bacf121f8e"
     },
     {
       "kind": "ui-call",
@@ -11559,7 +11559,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Notifications",
       "surface": "apple",
-      "id": "native.apple.bf8da7a7b0730861"
+      "id": "native.apple.227eaf4ef28e1a09"
     },
     {
       "kind": "ui-modifier",
@@ -11567,7 +11567,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Turns OpenClaw notification delivery on or off",
       "surface": "apple",
-      "id": "native.apple.d1ee91d07764faf0"
+      "id": "native.apple.aeb8d6201e4faa50"
     },
     {
       "kind": "ui-named-argument",
@@ -11575,7 +11575,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Reconnect",
       "surface": "apple",
-      "id": "native.apple.31f9c5fa6c3ca5dd"
+      "id": "native.apple.1239441ee0ab3262"
     },
     {
       "kind": "ui-named-argument",
@@ -11583,7 +11583,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Diagnose",
       "surface": "apple",
-      "id": "native.apple.1dc0c6ff4da2deca"
+      "id": "native.apple.3a588bbe942e2b6b"
     },
     {
       "kind": "ui-call",
@@ -11591,7 +11591,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "License files are not available in this build.",
       "surface": "apple",
-      "id": "native.apple.af22fba4150f2c1d"
+      "id": "native.apple.6f2fccdccf984741"
     },
     {
       "kind": "ui-call",
@@ -11599,7 +11599,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "OpenClaw appreciates its partners in the open-source community.",
       "surface": "apple",
-      "id": "native.apple.a82dc4a746268028"
+      "id": "native.apple.91db6b9cf4db2aaa"
     },
     {
       "kind": "ui-call",
@@ -11607,7 +11607,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "OpenClaw",
       "surface": "apple",
-      "id": "native.apple.fc49f9b63e160581"
+      "id": "native.apple.31ec646e921aa707"
     },
     {
       "kind": "ui-call",
@@ -11615,7 +11615,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Personal AI on your devices",
       "surface": "apple",
-      "id": "native.apple.eaa4fe72f3730f3f"
+      "id": "native.apple.ca81d76f6bd3762a"
     },
     {
       "kind": "ui-call",
@@ -11623,7 +11623,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "iOS",
       "surface": "apple",
-      "id": "native.apple.bbb2c589c2049217"
+      "id": "native.apple.56bd1f113649f6f7"
     },
     {
       "kind": "ui-named-argument",
@@ -11631,7 +11631,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Website",
       "surface": "apple",
-      "id": "native.apple.9f71c5c00d1bba49"
+      "id": "native.apple.b7d2d3ca0b4c13c1"
     },
     {
       "kind": "ui-named-argument",
@@ -11639,7 +11639,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Docs",
       "surface": "apple",
-      "id": "native.apple.7d10fb0ea5b704fa"
+      "id": "native.apple.7f5c2ebb7bb8d7d8"
     },
     {
       "kind": "ui-named-argument",
@@ -11647,7 +11647,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "GitHub",
       "surface": "apple",
-      "id": "native.apple.e501402343d42f4d"
+      "id": "native.apple.2f8329d5bd85b3ea"
     },
     {
       "kind": "ui-named-argument",
@@ -11655,7 +11655,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discord",
       "surface": "apple",
-      "id": "native.apple.ee880812d92bcacf"
+      "id": "native.apple.ee232b946bcd09ad"
     },
     {
       "kind": "ui-call",
@@ -11663,7 +11663,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "© 2026 OpenClaw Foundation — MIT License.",
       "surface": "apple",
-      "id": "native.apple.b962116ff5bf1905"
+      "id": "native.apple.aaf59ca16bbe895a"
     },
     {
       "kind": "ui-call",
@@ -11671,7 +11671,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Title",
       "surface": "apple",
-      "id": "native.apple.106434d1305d153b"
+      "id": "native.apple.1e0af5cbf7032c15"
     },
     {
       "kind": "ui-call",
@@ -11679,7 +11679,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Location",
       "surface": "apple",
-      "id": "native.apple.0535a52a62812307"
+      "id": "native.apple.fa96d0964c4e4dd0"
     },
     {
       "kind": "ui-modifier",
@@ -11687,7 +11687,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Location Sharing",
       "surface": "apple",
-      "id": "native.apple.72d124648efb5a97"
+      "id": "native.apple.0b66acb9f386d26f"
     },
     {
       "kind": "ui-call",
@@ -11695,7 +11695,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Access Level",
       "surface": "apple",
-      "id": "native.apple.aadb749ebce75251"
+      "id": "native.apple.fb2945d3d5f6f97f"
     },
     {
       "kind": "ui-modifier",
@@ -11703,7 +11703,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Chooses While Using the App or Always",
       "surface": "apple",
-      "id": "native.apple.d8c7ed70277b3ff1"
+      "id": "native.apple.d22aef6c0256dece"
     },
     {
       "kind": "ui-call",
@@ -11711,7 +11711,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Default Agent",
       "surface": "apple",
-      "id": "native.apple.cb38cf4f01de7a6d"
+      "id": "native.apple.24f7b511e01a8d15"
     },
     {
       "kind": "ui-call",
@@ -11719,7 +11719,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Default",
       "surface": "apple",
-      "id": "native.apple.6ace5e6f09ec98c7"
+      "id": "native.apple.48cbc4f5abe9e292"
     },
     {
       "kind": "ui-call",
@@ -11727,7 +11727,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Used for new Chat and Talk sessions.",
       "surface": "apple",
-      "id": "native.apple.3de045f17ea3c6d0"
+      "id": "native.apple.6805480889265026"
     },
     {
       "kind": "ui-call",
@@ -11735,7 +11735,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Paste setup code",
       "surface": "apple",
-      "id": "native.apple.313eb24efcb8d4a0"
+      "id": "native.apple.3c667ebdaf176fb6"
     },
     {
       "kind": "ui-named-argument",
@@ -11743,7 +11743,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Scan QR",
       "surface": "apple",
-      "id": "native.apple.19552e71de246322"
+      "id": "native.apple.9bf7cef3d081f023"
     },
     {
       "kind": "ui-named-argument",
@@ -11751,7 +11751,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Connect",
       "surface": "apple",
-      "id": "native.apple.f4afcfbe4e4a72f8"
+      "id": "native.apple.ea22b78e5ab1b827"
     },
     {
       "kind": "ui-call",
@@ -11759,7 +11759,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Setup Code",
       "surface": "apple",
-      "id": "native.apple.d8a5510f1a2e1701"
+      "id": "native.apple.c95cd5b8711e54e3"
     },
     {
       "kind": "ui-call",
@@ -11767,7 +11767,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovered Gateways",
       "surface": "apple",
-      "id": "native.apple.adb22453596f1d78"
+      "id": "native.apple.c66e36b5b3427183"
     },
     {
       "kind": "ui-call",
@@ -11775,7 +11775,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "surface": "apple",
-      "id": "native.apple.64b89f4aa3a81aef"
+      "id": "native.apple.71f783b295743ef3"
     },
     {
       "kind": "ui-call",
@@ -11783,7 +11783,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Pair a gateway to make it available here.",
       "surface": "apple",
-      "id": "native.apple.75c61c4ee1ecc6d8"
+      "id": "native.apple.e5788ef9b2af9191"
     },
     {
       "kind": "ui-call",
@@ -11791,7 +11791,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Paired Gateways",
       "surface": "apple",
-      "id": "native.apple.1ac3dd03c773c86a"
+      "id": "native.apple.b1a5dd4a8435fa78"
     },
     {
       "kind": "ui-call",
@@ -11799,7 +11799,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Switch gateways without pairing again.",
       "surface": "apple",
-      "id": "native.apple.9a6bd720a544ec04"
+      "id": "native.apple.aee28050f19601cf"
     },
     {
       "kind": "ui-modifier",
@@ -11807,7 +11807,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Active Gateway",
       "surface": "apple",
-      "id": "native.apple.5f33cfe2d21e6dc6"
+      "id": "native.apple.096d4caf5244a452"
     },
     {
       "kind": "ui-call",
@@ -11815,7 +11815,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Forget",
       "surface": "apple",
-      "id": "native.apple.4e1792b1044ec4a9"
+      "id": "native.apple.b5cbb46b8dd65ef6"
     },
     {
       "kind": "ui-call",
@@ -11823,7 +11823,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Forget Gateway",
       "surface": "apple",
-      "id": "native.apple.da00d975209e0bb6"
+      "id": "native.apple.c88c16f2d5f7ecd4"
     },
     {
       "kind": "ui-call",
@@ -11831,7 +11831,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Manual Gateway",
       "surface": "apple",
-      "id": "native.apple.08a67e763668db42"
+      "id": "native.apple.5062aebdb0210ab9"
     },
     {
       "kind": "ui-call",
@@ -11839,7 +11839,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Use Manual Gateway",
       "surface": "apple",
-      "id": "native.apple.c39f3a597f674aca"
+      "id": "native.apple.3149f01b08d5e123"
     },
     {
       "kind": "ui-call",
@@ -11847,7 +11847,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Host",
       "surface": "apple",
-      "id": "native.apple.c3d6c69cdb46769e"
+      "id": "native.apple.682774caecd34b94"
     },
     {
       "kind": "ui-call",
@@ -11855,7 +11855,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Port",
       "surface": "apple",
-      "id": "native.apple.600f8f373f177a74"
+      "id": "native.apple.fe67da4874dc59d2"
     },
     {
       "kind": "ui-call",
@@ -11863,7 +11863,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Unencrypted",
       "surface": "apple",
-      "id": "native.apple.74dd3ea86bc67545"
+      "id": "native.apple.64a579a8773c3cc4"
     },
     {
       "kind": "ui-call",
@@ -11871,7 +11871,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Secure (TLS)",
       "surface": "apple",
-      "id": "native.apple.8eca91d435b2aec0"
+      "id": "native.apple.49536933abe56786"
     },
     {
       "kind": "ui-call",
@@ -11879,7 +11879,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Connection security",
       "surface": "apple",
-      "id": "native.apple.ab61dd967122023c"
+      "id": "native.apple.166e500ba88914ed"
     },
     {
       "kind": "ui-named-argument",
@@ -11887,7 +11887,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Connect Manual",
       "surface": "apple",
-      "id": "native.apple.a3b6d069aebc0ab1"
+      "id": "native.apple.7990ce682bee850f"
     },
     {
       "kind": "ui-call",
@@ -11895,7 +11895,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Auto-connect on launch",
       "surface": "apple",
-      "id": "native.apple.b156004754dc59bd"
+      "id": "native.apple.a9f1e65b532cb33c"
     },
     {
       "kind": "ui-call",
@@ -11903,7 +11903,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Auth Token",
       "surface": "apple",
-      "id": "native.apple.cf932b2ca61d1e6b"
+      "id": "native.apple.bc98ab0e70108b88"
     },
     {
       "kind": "ui-call",
@@ -11911,7 +11911,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Password",
       "surface": "apple",
-      "id": "native.apple.92a1a902541660c4"
+      "id": "native.apple.951baab277b66642"
     },
     {
       "kind": "ui-call",
@@ -11919,7 +11919,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Custom Headers",
       "surface": "apple",
-      "id": "native.apple.438ae7e5b8544548"
+      "id": "native.apple.c67da92370fa3a4c"
     },
     {
       "kind": "ui-call",
@@ -11927,7 +11927,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Reset Onboarding",
       "surface": "apple",
-      "id": "native.apple.c9cd035bc39af480"
+      "id": "native.apple.312828d3eec448f3"
     },
     {
       "kind": "ui-call",
@@ -11935,7 +11935,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice Wake",
       "surface": "apple",
-      "id": "native.apple.5869824f66e222ed"
+      "id": "native.apple.e420a1d37795a358"
     },
     {
       "kind": "ui-call",
@@ -11943,7 +11943,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Talk Mode",
       "surface": "apple",
-      "id": "native.apple.88a997009842ffa0"
+      "id": "native.apple.09b42d493423bd70"
     },
     {
       "kind": "ui-call",
@@ -11951,7 +11951,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Speech Language",
       "surface": "apple",
-      "id": "native.apple.1f3ab82ab342555c"
+      "id": "native.apple.1c5b2360b2751a8b"
     },
     {
       "kind": "ui-call",
@@ -11959,7 +11959,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Speakerphone",
       "surface": "apple",
-      "id": "native.apple.518cef9408771a92"
+      "id": "native.apple.d7e8acb877ffa385"
     },
     {
       "kind": "ui-call",
@@ -11967,7 +11967,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Wake Words",
       "surface": "apple",
-      "id": "native.apple.1604352fea16d495"
+      "id": "native.apple.2f38df824041778e"
     },
     {
       "kind": "ui-call",
@@ -11975,7 +11975,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice",
       "surface": "apple",
-      "id": "native.apple.698d47c5569f8d3b"
+      "id": "native.apple.b1e74f9b4993d9ba"
     },
     {
       "kind": "ui-call",
@@ -11983,7 +11983,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Provider",
       "surface": "apple",
-      "id": "native.apple.24ee619948d75837"
+      "id": "native.apple.5a50ff9d1498d13b"
     },
     {
       "kind": "ui-call",
@@ -11991,7 +11991,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Realtime Voice",
       "surface": "apple",
-      "id": "native.apple.47dd7fb00a4eb621"
+      "id": "native.apple.b10d027621f24380"
     },
     {
       "kind": "ui-call",
@@ -11999,7 +11999,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Default",
       "surface": "apple",
-      "id": "native.apple.8c4c000f6606efc6"
+      "id": "native.apple.58ff78054dd585f4"
     },
     {
       "kind": "ui-call",
@@ -12007,7 +12007,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice Mode",
       "surface": "apple",
-      "id": "native.apple.55ddaeb92a2e98ff"
+      "id": "native.apple.7975561c52a9d131"
     },
     {
       "kind": "ui-call",
@@ -12015,7 +12015,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Active Voice",
       "surface": "apple",
-      "id": "native.apple.f384dc02b45f2fde"
+      "id": "native.apple.8a06e38a50ea9a5c"
     },
     {
       "kind": "ui-call",
@@ -12023,7 +12023,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Last Voice Issue",
       "surface": "apple",
-      "id": "native.apple.8a8d2629c30d57dd"
+      "id": "native.apple.f0064f19c646b3f3"
     },
     {
       "kind": "ui-call",
@@ -12031,7 +12031,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Transport",
       "surface": "apple",
-      "id": "native.apple.38c50d290be5736c"
+      "id": "native.apple.e7d3086462695804"
     },
     {
       "kind": "ui-call",
@@ -12039,7 +12039,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "API Key",
       "surface": "apple",
-      "id": "native.apple.6e5b8e1e2b341677"
+      "id": "native.apple.94ee17ba8b0476dc"
     },
     {
       "kind": "ui-call",
@@ -12047,7 +12047,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Show Talk Control",
       "surface": "apple",
-      "id": "native.apple.27457003271bd73d"
+      "id": "native.apple.90fe9d867c7b69b8"
     },
     {
       "kind": "ui-call",
@@ -12055,7 +12055,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Default Share Instruction",
       "surface": "apple",
-      "id": "native.apple.1300f0857e49b6e9"
+      "id": "native.apple.7299d852826e045a"
     },
     {
       "kind": "ui-call",
@@ -12063,7 +12063,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Run Share Self-Test",
       "surface": "apple",
-      "id": "native.apple.ccb60c6b4d40b204"
+      "id": "native.apple.d68e2f63e54bf21d"
     },
     {
       "kind": "ui-call",
@@ -12071,7 +12071,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovery Debug Logs",
       "surface": "apple",
-      "id": "native.apple.dfbbe0f7c038894a"
+      "id": "native.apple.3a40d37fb7b8ce08"
     },
     {
       "kind": "ui-call",
@@ -12079,7 +12079,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Debug Screen Status",
       "surface": "apple",
-      "id": "native.apple.c695f785d4f3331a"
+      "id": "native.apple.f69932b3ed05ba5b"
     },
     {
       "kind": "ui-call",
@@ -12087,7 +12087,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovery Logs",
       "surface": "apple",
-      "id": "native.apple.8584babe715b1133"
+      "id": "native.apple.5ccafc9f972de682"
     },
     {
       "kind": "ui-call",
@@ -12095,7 +12095,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Device",
       "surface": "apple",
-      "id": "native.apple.f0a16e985312895b"
+      "id": "native.apple.d54c2a63508adeca"
     },
     {
       "kind": "ui-call",
@@ -12103,7 +12103,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Device Name",
       "surface": "apple",
-      "id": "native.apple.540b648f9486bb50"
+      "id": "native.apple.1b32b788bd9d6557"
     },
     {
       "kind": "ui-call",
@@ -12111,7 +12111,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Instance ID",
       "surface": "apple",
-      "id": "native.apple.b7c2d54bc3894446"
+      "id": "native.apple.f42ec6e9ac59cb2f"
     },
     {
       "kind": "conditional-branch",
@@ -12119,7 +12119,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Off",
       "surface": "apple",
-      "id": "native.apple.40692c0b7ad6a05d"
+      "id": "native.apple.576f2d4025c0a928"
     },
     {
       "kind": "conditional-branch",
@@ -12127,7 +12127,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "On",
       "surface": "apple",
-      "id": "native.apple.0fca0d66e1fc4fa0"
+      "id": "native.apple.0100c34bb0a33c70"
     },
     {
       "kind": "ui-call",
@@ -12135,7 +12135,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Copy full commit hash",
       "surface": "apple",
-      "id": "native.apple.2834f131e112b1b4"
+      "id": "native.apple.4e4fd98ec575aa4c"
     },
     {
       "kind": "ui-call",
@@ -12143,7 +12143,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Copy build info",
       "surface": "apple",
-      "id": "native.apple.e93e23f03719e358"
+      "id": "native.apple.bbd5c192c15fea8d"
     },
     {
       "kind": "ui-call",
@@ -12151,7 +12151,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Copy Commit",
       "surface": "apple",
-      "id": "native.apple.34d0503d7d5ed23d"
+      "id": "native.apple.02e9eb37ac53cdbd"
     },
     {
       "kind": "ui-call",
@@ -12159,7 +12159,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Copy Build Info",
       "surface": "apple",
-      "id": "native.apple.9be4a644273089ce"
+      "id": "native.apple.f931dcc88c0b6518"
     },
     {
       "kind": "ui-call",
@@ -12167,7 +12167,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Unavailable",
       "surface": "apple",
-      "id": "native.apple.50991f9fae2ab99b"
+      "id": "native.apple.ce28d70078afb196"
     },
     {
       "kind": "ui-call",
@@ -12175,7 +12175,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Version \\(version), commit \\(commit), built \\(built), timestamp \\(timestamp)",
       "surface": "apple",
-      "id": "native.apple.b10bfeade7e6dcc4"
+      "id": "native.apple.8bc1d3e7bc3044c6"
     },
     {
       "kind": "ui-call",
@@ -12183,7 +12183,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Version \\(version), commit \\(commit), build date unavailable",
       "surface": "apple",
-      "id": "native.apple.32c68e6864c7faa5"
+      "id": "native.apple.cdb2c3f7f7627077"
     },
     {
       "kind": "ui-call",
@@ -12191,7 +12191,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Version \\(version), commit unavailable, built \\(built), timestamp \\(timestamp)",
       "surface": "apple",
-      "id": "native.apple.664c866505040add"
+      "id": "native.apple.658e7ed79db4c451"
     },
     {
       "kind": "ui-call",
@@ -12199,7 +12199,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Version \\(version), commit unavailable, build date unavailable",
       "surface": "apple",
-      "id": "native.apple.29192c8dd3ef0f5e"
+      "id": "native.apple.4ce6f0ea4ce9ac7f"
     },
     {
       "kind": "conditional-branch",
@@ -12207,7 +12207,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Checking",
       "surface": "apple",
-      "id": "native.apple.f5d9409953949617"
+      "id": "native.apple.8c42c3f2109aab19"
     },
     {
       "kind": "conditional-branch",
@@ -12215,7 +12215,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Enabled",
       "surface": "apple",
-      "id": "native.apple.1e38b2ba7a1c1e45"
+      "id": "native.apple.e8608b93d18ddb92"
     },
     {
       "kind": "conditional-branch",
@@ -12223,7 +12223,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Off",
       "surface": "apple",
-      "id": "native.apple.06aecb73b4caf15e"
+      "id": "native.apple.ca1d67ec3832f6e7"
     },
     {
       "kind": "conditional-branch",
@@ -12231,7 +12231,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Setup",
       "surface": "apple",
-      "id": "native.apple.b2feb29a6a0c009e"
+      "id": "native.apple.ed4dd210f496e3ab"
     },
     {
       "kind": "conditional-branch",
@@ -12239,7 +12239,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Denied",
       "surface": "apple",
-      "id": "native.apple.994d1db10eca51a4"
+      "id": "native.apple.21a66315d0935902"
     },
     {
       "kind": "conditional-branch",
@@ -12247,7 +12247,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Not Enabled",
       "surface": "apple",
-      "id": "native.apple.2d649df414b36d45"
+      "id": "native.apple.d34b626a9e9357a8"
     },
     {
       "kind": "conditional-branch",
@@ -12255,7 +12255,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Unknown",
       "surface": "apple",
-      "id": "native.apple.b6eb08125322e79c"
+      "id": "native.apple.8c2b6e6d707f3f8b"
     },
     {
       "kind": "conditional-branch",
@@ -12263,7 +12263,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Checking iOS notification permission.",
       "surface": "apple",
-      "id": "native.apple.aaa60df66ca6fb07"
+      "id": "native.apple.921c5e3c07784504"
     },
     {
       "kind": "conditional-branch",
@@ -12271,7 +12271,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "OpenClaw can show approval prompts and event alerts when the app is not active.",
       "surface": "apple",
-      "id": "native.apple.675219772ee5adf0"
+      "id": "native.apple.98471e5735f9ff12"
     },
     {
       "kind": "conditional-branch",
@@ -12279,7 +12279,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "OpenClaw notifications are off.",
       "surface": "apple",
-      "id": "native.apple.44133229b2b05062"
+      "id": "native.apple.cf35fb743bf5bd6a"
     },
     {
       "kind": "conditional-branch",
@@ -12287,7 +12287,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Finish notification setup to receive alerts when the app is not active.",
       "surface": "apple",
-      "id": "native.apple.9794732a37cb580f"
+      "id": "native.apple.3ce6e6157efc8efd"
     },
     {
       "kind": "conditional-branch",
@@ -12295,7 +12295,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Notifications have been denied. Enable them in iOS Settings.",
       "surface": "apple",
-      "id": "native.apple.195375b3e1db5401"
+      "id": "native.apple.4577df5d6ce7babc"
     },
     {
       "kind": "conditional-branch",
@@ -12303,7 +12303,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Enable notifications to receive approval prompts and event alerts outside the app.",
       "surface": "apple",
-      "id": "native.apple.c0a27e1b0f797fd6"
+      "id": "native.apple.8836e3c9b2a9a811"
     },
     {
       "kind": "conditional-branch",
@@ -12311,7 +12311,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "OpenClaw cannot determine the current notification permission state.",
       "surface": "apple",
-      "id": "native.apple.bfe6a918d23fa20e"
+      "id": "native.apple.34e46ffc0dac7b3d"
     },
     {
       "kind": "ui-call",
@@ -12319,7 +12319,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Connected",
       "surface": "apple",
-      "id": "native.apple.fc7d007916016c0d"
+      "id": "native.apple.5062046a82049d84"
     },
     {
       "kind": "ui-named-argument",
@@ -12327,7 +12327,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Gateway online",
       "surface": "apple",
-      "id": "native.apple.f79541e88a1434df"
+      "id": "native.apple.dd63ff92b1f0d265"
     },
     {
       "kind": "ui-named-argument",
@@ -12335,7 +12335,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Connected to openclaw-gateway.tailnet.ts.net.",
       "surface": "apple",
-      "id": "native.apple.737eb52b08f2640c"
+      "id": "native.apple.2f58eec336d3f675"
     },
     {
       "kind": "ui-call",
@@ -12343,7 +12343,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Loading",
       "surface": "apple",
-      "id": "native.apple.b59e37e73db49f94"
+      "id": "native.apple.3291260739cbb077"
     },
     {
       "kind": "ui-named-argument",
@@ -12351,7 +12351,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Checking gateway",
       "surface": "apple",
-      "id": "native.apple.2b5177b11661390e"
+      "id": "native.apple.393160b1f7ba2d7f"
     },
     {
       "kind": "ui-named-argument",
@@ -12359,7 +12359,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Refreshing connection, discovery, and device trust state.",
       "surface": "apple",
-      "id": "native.apple.1b2d7d34531acc5d"
+      "id": "native.apple.ce0f1f186161a3f5"
     },
     {
       "kind": "ui-call",
@@ -12367,7 +12367,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Empty",
       "surface": "apple",
-      "id": "native.apple.511630542db1aa6f"
+      "id": "native.apple.b5c38673941ea2ac"
     },
     {
       "kind": "ui-named-argument",
@@ -12375,7 +12375,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "No gateway configured",
       "surface": "apple",
-      "id": "native.apple.54df46d3690853c8"
+      "id": "native.apple.dd4f9baf1dd631e9"
     },
     {
       "kind": "ui-named-argument",
@@ -12383,7 +12383,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Scan a setup QR code, paste a setup code, or choose a discovered gateway.",
       "surface": "apple",
-      "id": "native.apple.856d2ed1c64b9da1"
+      "id": "native.apple.3645697cd635f42e"
     },
     {
       "kind": "ui-call",
@@ -12391,7 +12391,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Error",
       "surface": "apple",
-      "id": "native.apple.2f70e6702c85bedf"
+      "id": "native.apple.17ef87abc0cbf854"
     },
     {
       "kind": "ui-named-argument",
@@ -12399,7 +12399,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Tailscale warning",
       "surface": "apple",
-      "id": "native.apple.eadc497b8d3f3b5e"
+      "id": "native.apple.75652d20acdb3f66"
     },
     {
       "kind": "ui-named-argument",
@@ -12407,7 +12407,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Tailscale is off on this device. Turn it on, then try again.",
       "surface": "apple",
-      "id": "native.apple.50af8defa8d7594e"
+      "id": "native.apple.a6975cfedb43e96e"
     },
     {
       "kind": "ui-call",
@@ -12415,7 +12415,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Address",
       "surface": "apple",
-      "id": "native.apple.79dec753eca2d3bb"
+      "id": "native.apple.9721b17e2b2757b9"
     },
     {
       "kind": "ui-call",
@@ -12423,7 +12423,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Server",
       "surface": "apple",
-      "id": "native.apple.95af8f5aee7320a9"
+      "id": "native.apple.8d837aeb32871690"
     },
     {
       "kind": "ui-call",
@@ -12431,7 +12431,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Discovered",
       "surface": "apple",
-      "id": "native.apple.97bfac52b2b29eeb"
+      "id": "native.apple.311f5d51147ef78f"
     },
     {
       "kind": "ui-call",
@@ -12439,7 +12439,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Default Agent",
       "surface": "apple",
-      "id": "native.apple.a07ae673f44be041"
+      "id": "native.apple.bf57c0bcbb3cc33f"
     },
     {
       "kind": "ui-call",
@@ -12447,7 +12447,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Reconnect",
       "surface": "apple",
-      "id": "native.apple.385825a3993c5f2a"
+      "id": "native.apple.a402cef0554ad9c3"
     },
     {
       "kind": "ui-call",
@@ -12455,7 +12455,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Diagnose",
       "surface": "apple",
-      "id": "native.apple.42e107ba01cd3840"
+      "id": "native.apple.a80e88931ebdf9fe"
     },
     {
       "kind": "ui-call",
@@ -12463,7 +12463,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Scan QR",
       "surface": "apple",
-      "id": "native.apple.acd10851c7e1885d"
+      "id": "native.apple.05d387529c7a9b97"
     },
     {
       "kind": "ui-call",
@@ -12471,7 +12471,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Connect",
       "surface": "apple",
-      "id": "native.apple.a9c35036bf9e02a8"
+      "id": "native.apple.7ef31be9d4795792"
     },
     {
       "kind": "ui-call",
@@ -12479,7 +12479,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "surface": "apple",
-      "id": "native.apple.f439c34a9ce3a332"
+      "id": "native.apple.ab8baa3290dcab1e"
     },
     {
       "kind": "ui-call",
@@ -12487,7 +12487,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Not Now",
       "surface": "apple",
-      "id": "native.apple.c6e171128190d131"
+      "id": "native.apple.630738aefc3e7a2e"
     },
     {
       "kind": "ui-modifier",
@@ -12495,7 +12495,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Talk",
       "surface": "apple",
-      "id": "native.apple.e4b15aef3c2e3da7"
+      "id": "native.apple.2caacbe8915fce80"
     },
     {
       "kind": "ui-call",
@@ -12503,7 +12503,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Conversation",
       "surface": "apple",
-      "id": "native.apple.ab3381742bdff650"
+      "id": "native.apple.3d71c9560c740e44"
     },
     {
       "kind": "ui-call",
@@ -12511,7 +12511,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Agent",
       "surface": "apple",
-      "id": "native.apple.7af100f6640c6a69"
+      "id": "native.apple.8f6226cc6ea8e258"
     },
     {
       "kind": "ui-call",
@@ -12519,7 +12519,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Session",
       "surface": "apple",
-      "id": "native.apple.49c4de60117b1a98"
+      "id": "native.apple.ea2deaf868ab8a8e"
     },
     {
       "kind": "ui-call",
@@ -12527,7 +12527,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Runtime",
       "surface": "apple",
-      "id": "native.apple.37c29d2506b955e9"
+      "id": "native.apple.a3ce2b6fdef9f5d9"
     },
     {
       "kind": "ui-call",
@@ -12535,7 +12535,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Voice Mode",
       "surface": "apple",
-      "id": "native.apple.13e0ad79b141576e"
+      "id": "native.apple.809c47f578fb300b"
     },
     {
       "kind": "ui-call",
@@ -12543,7 +12543,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Configured",
       "surface": "apple",
-      "id": "native.apple.e8035b71bab833c7"
+      "id": "native.apple.efd81a082e762e19"
     },
     {
       "kind": "ui-call",
@@ -12551,7 +12551,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Active",
       "surface": "apple",
-      "id": "native.apple.1b2845ec89d20eef"
+      "id": "native.apple.f408cd314c58beda"
     },
     {
       "kind": "ui-call",
@@ -12559,7 +12559,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Transport",
       "surface": "apple",
-      "id": "native.apple.a82c07df64d13b23"
+      "id": "native.apple.6b092e76e8cd7077"
     },
     {
       "kind": "ui-call",
@@ -12567,7 +12567,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Last issue",
       "surface": "apple",
-      "id": "native.apple.384e097278f76954"
+      "id": "native.apple.85cf5997f880320e"
     },
     {
       "kind": "ui-call",
@@ -12575,7 +12575,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Permission",
       "surface": "apple",
-      "id": "native.apple.a6d8fc7bfd98836f"
+      "id": "native.apple.5f23def3f9cc0265"
     },
     {
       "kind": "ui-call",
@@ -12583,7 +12583,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Speech language",
       "surface": "apple",
-      "id": "native.apple.983bdcd5e3f1baa8"
+      "id": "native.apple.31dce524ee35c207"
     },
     {
       "kind": "ui-call",
@@ -12591,7 +12591,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Controls",
       "surface": "apple",
-      "id": "native.apple.32e7fa2b1798e9c3"
+      "id": "native.apple.cf7c334bf3535237"
     },
     {
       "kind": "ui-call",
@@ -12599,7 +12599,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Speakerphone",
       "surface": "apple",
-      "id": "native.apple.0eb012a5d3d81b32"
+      "id": "native.apple.aba6f2c7c9f0513e"
     },
     {
       "kind": "ui-call",
@@ -12607,7 +12607,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Background listening",
       "surface": "apple",
-      "id": "native.apple.ef8699e2718346da"
+      "id": "native.apple.76a72b78ae43b051"
     },
     {
       "kind": "ui-call",
@@ -12615,7 +12615,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Voice & Talk Settings",
       "surface": "apple",
-      "id": "native.apple.1e6938a09b4fbe77"
+      "id": "native.apple.09251d869394ee9e"
     },
     {
       "kind": "conditional-branch",
@@ -12631,7 +12631,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Gateway permission required",
       "surface": "apple",
-      "id": "native.apple.05c434bb5fe3c275"
+      "id": "native.apple.f11f0536c6c91730"
     },
     {
       "kind": "conditional-branch",
@@ -12639,7 +12639,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Requesting approval",
       "surface": "apple",
-      "id": "native.apple.105896ad894955b4"
+      "id": "native.apple.740f853e31f4cbd6"
     },
     {
       "kind": "conditional-branch",
@@ -12647,7 +12647,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Approval requested",
       "surface": "apple",
-      "id": "native.apple.d0cf291f96827526"
+      "id": "native.apple.ca8a15aeaa073b49"
     },
     {
       "kind": "conditional-branch",
@@ -12655,7 +12655,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Voice API key missing",
       "surface": "apple",
-      "id": "native.apple.e8c2902caf83b20e"
+      "id": "native.apple.e8ca3240ed3459e1"
     },
     {
       "kind": "conditional-branch",
@@ -12663,7 +12663,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Voice config failed",
       "surface": "apple",
-      "id": "native.apple.364bb50be18c79c7"
+      "id": "native.apple.2037e95c83eb3140"
     },
     {
       "kind": "conditional-branch",
@@ -12671,7 +12671,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Start Talk",
       "surface": "apple",
-      "id": "native.apple.87fca324b443b623"
+      "id": "native.apple.86c1d181ae4eea07"
     },
     {
       "kind": "conditional-branch",
@@ -12679,7 +12679,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Stop Talk",
       "surface": "apple",
-      "id": "native.apple.8cba3288f401cbfb"
+      "id": "native.apple.f2cd3be54a1a6091"
     },
     {
       "kind": "conditional-branch",
@@ -12687,7 +12687,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Enable Talk",
       "surface": "apple",
-      "id": "native.apple.798c3584ad95f8da"
+      "id": "native.apple.d13508d0dae4141b"
     },
     {
       "kind": "conditional-branch",
@@ -12695,7 +12695,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Open Gateway Settings",
       "surface": "apple",
-      "id": "native.apple.1620f7cb3deea133"
+      "id": "native.apple.9df75003606e2ffe"
     },
     {
       "kind": "conditional-branch",
@@ -12703,7 +12703,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Open Voice Settings",
       "surface": "apple",
-      "id": "native.apple.3fd2706ef0f14fd2"
+      "id": "native.apple.6351026d09ad03e1"
     },
     {
       "kind": "conditional-branch",
@@ -12711,7 +12711,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Demo Mode Only",
       "surface": "apple",
-      "id": "native.apple.3cc9cd23a67db077"
+      "id": "native.apple.9b78fbac2e82beb6"
     },
     {
       "kind": "conditional-branch",
@@ -12719,7 +12719,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Waiting for Approval",
       "surface": "apple",
-      "id": "native.apple.12c9d8231777366c"
+      "id": "native.apple.69188230a514c5c0"
     },
     {
       "kind": "ui-named-argument",
@@ -12727,7 +12727,7 @@
       "path": "apps/ios/Sources/Design/TalkRuntimeIssueBanner.swift",
       "source": "Open Settings",
       "surface": "apple",
-      "id": "native.apple.dc57861a3ac5a08e"
+      "id": "native.apple.9ac1842135b768aa"
     },
     {
       "kind": "ui-named-argument",
@@ -12735,7 +12735,7 @@
       "path": "apps/ios/Sources/Design/TalkRuntimeIssueBanner.swift",
       "source": "Details",
       "surface": "apple",
-      "id": "native.apple.8218d64ec7ae90cc"
+      "id": "native.apple.0648f0cc87d543d5"
     },
     {
       "kind": "ui-call",
@@ -12743,7 +12743,7 @@
       "path": "apps/ios/Sources/Design/TalkRuntimeIssueBanner.swift",
       "source": "Copy diagnostics",
       "surface": "apple",
-      "id": "native.apple.79b30b1d014a383d"
+      "id": "native.apple.934cb0493a08efae"
     },
     {
       "kind": "ui-call",
@@ -12751,7 +12751,7 @@
       "path": "apps/ios/Sources/Design/TalkRuntimeIssueBanner.swift",
       "source": "Technical details",
       "surface": "apple",
-      "id": "native.apple.677a41ec947a185b"
+      "id": "native.apple.05720056d12cca98"
     },
     {
       "kind": "ui-modifier",
@@ -12759,7 +12759,7 @@
       "path": "apps/ios/Sources/Design/TalkRuntimeIssueBanner.swift",
       "source": "Talk fallback",
       "surface": "apple",
-      "id": "native.apple.e87c850114041ce8"
+      "id": "native.apple.d203ac14cba893ae"
     },
     {
       "kind": "ui-call",
@@ -12767,7 +12767,7 @@
       "path": "apps/ios/Sources/Design/TalkRuntimeIssueBanner.swift",
       "source": "Done",
       "surface": "apple",
-      "id": "native.apple.073825a7670d08cc"
+      "id": "native.apple.46baa157a6f3bf45"
     },
     {
       "kind": "ui-call",
@@ -12775,7 +12775,7 @@
       "path": "apps/ios/Sources/Gateway/DeepLinkAgentPromptAlert.swift",
       "source": "Run OpenClaw agent?",
       "surface": "apple",
-      "id": "native.apple.c218ef5194d0ee56"
+      "id": "native.apple.ff54e660cf3e40e9"
     },
     {
       "kind": "ui-call",
@@ -12783,7 +12783,7 @@
       "path": "apps/ios/Sources/Gateway/DeepLinkAgentPromptAlert.swift",
       "source": "Message:\n\\(prompt.messagePreview)\n\nURL:\n\\(prompt.urlPreview)",
       "surface": "apple",
-      "id": "native.apple.32dc136ac23fef8c"
+      "id": "native.apple.364bea5035361bb0"
     },
     {
       "kind": "ui-call",
@@ -12791,7 +12791,7 @@
       "path": "apps/ios/Sources/Gateway/DeepLinkAgentPromptAlert.swift",
       "source": "Cancel",
       "surface": "apple",
-      "id": "native.apple.fd7a510d373bb915"
+      "id": "native.apple.8e6e42a2a74596e9"
     },
     {
       "kind": "ui-call",
@@ -12799,7 +12799,7 @@
       "path": "apps/ios/Sources/Gateway/DeepLinkAgentPromptAlert.swift",
       "source": "Run",
       "surface": "apple",
-      "id": "native.apple.556a5ad9893871c8"
+      "id": "native.apple.86e2769119731fa1"
     },
     {
       "kind": "ui-call",
@@ -12807,7 +12807,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "Exec approval required",
       "surface": "apple",
-      "id": "native.apple.8affb166c6d3eb43"
+      "id": "native.apple.fcbca7eff2c55c51"
     },
     {
       "kind": "ui-call",
@@ -12815,7 +12815,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "Review this exec request before continuing. Your decision will be sent back to the gateway.",
       "surface": "apple",
-      "id": "native.apple.cc304ba214b8a9df"
+      "id": "native.apple.28b66b20fd82ac2e"
     },
     {
       "kind": "ui-named-argument",
@@ -12823,7 +12823,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "Host",
       "surface": "apple",
-      "id": "native.apple.1f2576ef69108e39"
+      "id": "native.apple.82fee6773239d6cf"
     },
     {
       "kind": "ui-named-argument",
@@ -12831,7 +12831,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "Node",
       "surface": "apple",
-      "id": "native.apple.40e78558a531ba3a"
+      "id": "native.apple.70571f3adbfb2f7d"
     },
     {
       "kind": "ui-named-argument",
@@ -12839,7 +12839,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "Agent",
       "surface": "apple",
-      "id": "native.apple.b3914073e8a72a9a"
+      "id": "native.apple.bf2e86c25b0bab30"
     },
     {
       "kind": "ui-named-argument",
@@ -12847,7 +12847,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "Expires",
       "surface": "apple",
-      "id": "native.apple.b2e4502116389233"
+      "id": "native.apple.9d9ec6cea0ee15c6"
     },
     {
       "kind": "ui-call",
@@ -12855,7 +12855,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "Resolving…",
       "surface": "apple",
-      "id": "native.apple.ffeadaa59fd07335"
+      "id": "native.apple.420c9a94e62a3745"
     },
     {
       "kind": "ui-call",
@@ -12863,7 +12863,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "Allow Once",
       "surface": "apple",
-      "id": "native.apple.88dd5e6f5e90514d"
+      "id": "native.apple.eb5b1e6c34c1a176"
     },
     {
       "kind": "ui-call",
@@ -12871,7 +12871,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "Allow Always",
       "surface": "apple",
-      "id": "native.apple.bc243f646ddc3656"
+      "id": "native.apple.91771a0e5ae5e75c"
     },
     {
       "kind": "ui-call",
@@ -12887,7 +12887,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "Deny",
       "surface": "apple",
-      "id": "native.apple.ac88205cbb8a974d"
+      "id": "native.apple.302320808554ec80"
     },
     {
       "kind": "ui-call",
@@ -12895,7 +12895,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "Cancel",
       "surface": "apple",
-      "id": "native.apple.7292be2c03d1caa4"
+      "id": "native.apple.815fd6a1fe7a0215"
     },
     {
       "kind": "conditional-branch",
@@ -12903,7 +12903,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "about 1 minute",
       "surface": "apple",
-      "id": "native.apple.03e81e2c3208e897"
+      "id": "native.apple.2675811292376a95"
     },
     {
       "kind": "conditional-branch",
@@ -12911,7 +12911,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "about \\(minutes) minutes",
       "surface": "apple",
-      "id": "native.apple.caf9889b0b0e18b6"
+      "id": "native.apple.24948701a0802b9d"
     },
     {
       "kind": "conditional-branch",
@@ -12919,7 +12919,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "about 1 hour",
       "surface": "apple",
-      "id": "native.apple.00ef62d3eae63065"
+      "id": "native.apple.df1fe07ca4431570"
     },
     {
       "kind": "conditional-branch",
@@ -12927,7 +12927,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "about \\(hours) hours",
       "surface": "apple",
-      "id": "native.apple.09312ef7ca727f4b"
+      "id": "native.apple.1b6923bba2c4a8f4"
     },
     {
       "kind": "ui-localized-call",
@@ -12935,7 +12935,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "Connect",
       "surface": "apple",
-      "id": "native.apple.3cb1f1788ffb16e2"
+      "id": "native.apple.9df80f4ad340fac7"
     },
     {
       "kind": "ui-localized-call",
@@ -12943,7 +12943,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "TLS required",
       "surface": "apple",
-      "id": "native.apple.b6ea004a3ef09501"
+      "id": "native.apple.99f9997fa7381cf2"
     },
     {
       "kind": "ui-localized-call-multiline",
@@ -12951,7 +12951,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "Enable Gateway TLS, or enter your Tailscale Serve HTTPS host in Manual Setup. Use Unencrypted only with a trusted private-LAN address.",
       "surface": "apple",
-      "id": "native.apple.16e06dae717734de"
+      "id": "native.apple.ea999c184d17e0bc"
     },
     {
       "kind": "ui-localized-call-multiline",
@@ -12959,7 +12959,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "Can't reach gateway at \\(host):\\(port). Verify Tailscale Serve is enabled and publishes this Gateway.",
       "surface": "apple",
-      "id": "native.apple.ccfde3d74305d096"
+      "id": "native.apple.9c262d42363100f1"
     },
     {
       "kind": "ui-localized-call",
@@ -12967,7 +12967,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "Can't reach gateway at \\(host):\\(port). Check Tailscale or LAN.",
       "surface": "apple",
-      "id": "native.apple.fe8f13e52e05ff77"
+      "id": "native.apple.a9ba291db9cfd0b3"
     },
     {
       "kind": "ui-call",
@@ -12975,7 +12975,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayDiscoveryDebugLogView.swift",
       "source": "Enable “Discovery Debug Logs” to start collecting events.",
       "surface": "apple",
-      "id": "native.apple.c741e0a44409ac2a"
+      "id": "native.apple.bef3f9c88e02d037"
     },
     {
       "kind": "ui-call",
@@ -12983,7 +12983,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayDiscoveryDebugLogView.swift",
       "source": "No log entries yet.",
       "surface": "apple",
-      "id": "native.apple.94e50889eec05b85"
+      "id": "native.apple.e17805a02a1da11a"
     },
     {
       "kind": "ui-modifier",
@@ -12991,7 +12991,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayDiscoveryDebugLogView.swift",
       "source": "Discovery Logs",
       "surface": "apple",
-      "id": "native.apple.c80ead1ebfcfd78c"
+      "id": "native.apple.ff8c924b3b61228d"
     },
     {
       "kind": "ui-call",
@@ -12999,7 +12999,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayDiscoveryDebugLogView.swift",
       "source": "Copy",
       "surface": "apple",
-      "id": "native.apple.f21a8e304b607dc8"
+      "id": "native.apple.c0f731f9f5c84629"
     },
     {
       "kind": "ui-named-argument",
@@ -13007,7 +13007,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Details",
       "surface": "apple",
-      "id": "native.apple.a7866a6499f4462a"
+      "id": "native.apple.339a8edf9c9a815a"
     },
     {
       "kind": "conditional-branch",
@@ -13015,7 +13015,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Fix on gateway",
       "surface": "apple",
-      "id": "native.apple.0dbec123f10f54a3"
+      "id": "native.apple.dad01fdeb5f018ce"
     },
     {
       "kind": "conditional-branch",
@@ -13023,7 +13023,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Fix on this device",
       "surface": "apple",
-      "id": "native.apple.bb01fb5dffc27820"
+      "id": "native.apple.f6f0d63324bdebda"
     },
     {
       "kind": "conditional-branch",
@@ -13031,7 +13031,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Check both",
       "surface": "apple",
-      "id": "native.apple.99963509b4eedf05"
+      "id": "native.apple.6edf410bcce83ad7"
     },
     {
       "kind": "conditional-branch",
@@ -13039,7 +13039,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Check network",
       "surface": "apple",
-      "id": "native.apple.95e5718913e74c81"
+      "id": "native.apple.c2a5671d29a535fa"
     },
     {
       "kind": "conditional-branch",
@@ -13047,7 +13047,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Needs attention",
       "surface": "apple",
-      "id": "native.apple.b872c06ff0f48f3d"
+      "id": "native.apple.3f4316b823b69124"
     },
     {
       "kind": "ui-call",
@@ -13055,7 +13055,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Copy request ID",
       "surface": "apple",
-      "id": "native.apple.ae581f232bd0ecc0"
+      "id": "native.apple.2dd7e716b0937232"
     },
     {
       "kind": "ui-call",
@@ -13063,7 +13063,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Request",
       "surface": "apple",
-      "id": "native.apple.fd04cd49334845a9"
+      "id": "native.apple.7dd5c1028aefd2be"
     },
     {
       "kind": "ui-call",
@@ -13071,7 +13071,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Copy command",
       "surface": "apple",
-      "id": "native.apple.98df0e8ba486e4d1"
+      "id": "native.apple.0b8a40c10a02cf43"
     },
     {
       "kind": "ui-call",
@@ -13079,7 +13079,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Gateway command",
       "surface": "apple",
-      "id": "native.apple.50622ef698ba07f5"
+      "id": "native.apple.85d8db66aae5ccc5"
     },
     {
       "kind": "ui-call",
@@ -13087,7 +13087,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Open docs",
       "surface": "apple",
-      "id": "native.apple.32ea6ea1f9aea920"
+      "id": "native.apple.5422c65417d30419"
     },
     {
       "kind": "ui-call",
@@ -13095,7 +13095,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Help",
       "surface": "apple",
-      "id": "native.apple.6b1a61d6c9510bdb"
+      "id": "native.apple.d214c5b5ead92ee9"
     },
     {
       "kind": "ui-call",
@@ -13103,7 +13103,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Technical details",
       "surface": "apple",
-      "id": "native.apple.7041ebbb775bfdd7"
+      "id": "native.apple.228f252b1558f714"
     },
     {
       "kind": "ui-call",
@@ -13111,7 +13111,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Connection problem",
       "surface": "apple",
-      "id": "native.apple.f307f967ec2df705"
+      "id": "native.apple.d6f21a9ecbbf4068"
     },
     {
       "kind": "ui-call",
@@ -13119,7 +13119,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Done",
       "surface": "apple",
-      "id": "native.apple.9bdfbc3e1ea38cb3"
+      "id": "native.apple.fc4dc59107012c26"
     },
     {
       "kind": "ui-call",
@@ -13127,7 +13127,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Connecting…",
       "surface": "apple",
-      "id": "native.apple.e8f30dffd2d62d96"
+      "id": "native.apple.c3026ecefcb062a0"
     },
     {
       "kind": "ui-call",
@@ -13135,7 +13135,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Connect to this Gateway",
       "surface": "apple",
-      "id": "native.apple.78d430515e5bb8eb"
+      "id": "native.apple.3165281df48ab522"
     },
     {
       "kind": "ui-call",
@@ -13143,7 +13143,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Use Manual Setup",
       "surface": "apple",
-      "id": "native.apple.91a0ab004066bacb"
+      "id": "native.apple.e84f60ce8e1d46c1"
     },
     {
       "kind": "ui-call",
@@ -13151,7 +13151,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Not now",
       "surface": "apple",
-      "id": "native.apple.102d0ce74e6253f3"
+      "id": "native.apple.c8bdf51862099c64"
     },
     {
       "kind": "ui-call",
@@ -13159,7 +13159,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Don't show this again",
       "surface": "apple",
-      "id": "native.apple.5204dc0158d98ebf"
+      "id": "native.apple.0a591c749e4f5df2"
     },
     {
       "kind": "ui-modifier",
@@ -13167,7 +13167,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Quick Setup",
       "surface": "apple",
-      "id": "native.apple.476757fc54c63560"
+      "id": "native.apple.d190c67798bfda23"
     },
     {
       "kind": "ui-call",
@@ -13175,7 +13175,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Close",
       "surface": "apple",
-      "id": "native.apple.977a6e4a5022184f"
+      "id": "native.apple.a7f85d7c15c51840"
     },
     {
       "kind": "ui-call",
@@ -13183,7 +13183,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Connect a nearby Gateway",
       "surface": "apple",
-      "id": "native.apple.f2642d91a3ac8c25"
+      "id": "native.apple.6c2149ce9b4a51f0"
     },
     {
       "kind": "conditional-branch",
@@ -13191,7 +13191,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Local",
       "surface": "apple",
-      "id": "native.apple.63bb4ac4eaf496bc"
+      "id": "native.apple.6d7861b38549db04"
     },
     {
       "kind": "conditional-branch",
@@ -13199,7 +13199,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Secure",
       "surface": "apple",
-      "id": "native.apple.1122855cccc617bd"
+      "id": "native.apple.42a7cbaa5a4a1aec"
     },
     {
       "kind": "ui-named-argument",
@@ -13207,7 +13207,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Discovery",
       "surface": "apple",
-      "id": "native.apple.052a650dbff9657b"
+      "id": "native.apple.e63abd2b87564f55"
     },
     {
       "kind": "ui-named-argument",
@@ -13215,7 +13215,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Gateway",
       "surface": "apple",
-      "id": "native.apple.c284afdefb55f224"
+      "id": "native.apple.144f6d64846034c8"
     },
     {
       "kind": "ui-named-argument",
@@ -13223,7 +13223,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Node",
       "surface": "apple",
-      "id": "native.apple.26a7ff6b06dbeb67"
+      "id": "native.apple.0e34f14699cd5184"
     },
     {
       "kind": "ui-named-argument",
@@ -13231,7 +13231,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Operator",
       "surface": "apple",
-      "id": "native.apple.f2c3934d3e670237"
+      "id": "native.apple.20b1bc5e6f9b3507"
     },
     {
       "kind": "ui-call",
@@ -13239,7 +13239,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Looking for a Gateway",
       "surface": "apple",
-      "id": "native.apple.33be51249563ed37"
+      "id": "native.apple.49bfb37d47d3d427"
     },
     {
       "kind": "ui-call",
@@ -13247,7 +13247,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Keep your iPhone on the same LAN or tailnet, then start the Gateway on your host machine.",
       "surface": "apple",
-      "id": "native.apple.0e828048fafce681"
+      "id": "native.apple.76c837838276639d"
     },
     {
       "kind": "ui-named-argument",
@@ -13255,7 +13255,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Run openclaw gateway --port 18789.",
       "surface": "apple",
-      "id": "native.apple.c18f5bd36f119282"
+      "id": "native.apple.0a0790581bac81ad"
     },
     {
       "kind": "ui-named-argument",
@@ -13263,7 +13263,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Check that Bonjour discovery is enabled.",
       "surface": "apple",
-      "id": "native.apple.a4eb9a9b02915961"
+      "id": "native.apple.c03c045809206aef"
     },
     {
       "kind": "ui-named-argument",
@@ -13271,7 +13271,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Open Settings if you need a manual host.",
       "surface": "apple",
-      "id": "native.apple.72083d0b7fc77a6d"
+      "id": "native.apple.a099ee002dc520ba"
     },
     {
       "kind": "conditional-branch",
@@ -13295,7 +13295,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayTrustPromptAlert.swift",
       "source": "Trust this gateway?",
       "surface": "apple",
-      "id": "native.apple.8ef0909bddf2f9ee"
+      "id": "native.apple.797e08ab6281f76f"
     },
     {
       "kind": "ui-call",
@@ -13303,7 +13303,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayTrustPromptAlert.swift",
       "source": "Cancel",
       "surface": "apple",
-      "id": "native.apple.a026715905bfd429"
+      "id": "native.apple.5261200f4b1ce74b"
     },
     {
       "kind": "ui-call",
@@ -13311,7 +13311,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayTrustPromptAlert.swift",
       "source": "Trust and connect",
       "surface": "apple",
-      "id": "native.apple.0892fd4bee73202a"
+      "id": "native.apple.f3873a81d5476a5a"
     },
     {
       "kind": "ui-call",
@@ -13319,7 +13319,7 @@
       "path": "apps/ios/Sources/Gateway/NotificationPermissionGuidanceDialog.swift",
       "source": "Notifications are off",
       "surface": "apple",
-      "id": "native.apple.381baa85bbbd0f31"
+      "id": "native.apple.2d4fabce5737ee0a"
     },
     {
       "kind": "ui-call",
@@ -13327,7 +13327,7 @@
       "path": "apps/ios/Sources/Gateway/NotificationPermissionGuidanceDialog.swift",
       "source": "Exec approvals can only be reviewed while OpenClaw is open and connected.\n\nEnable Notifications to receive approval notifications while OpenClaw is not open.",
       "surface": "apple",
-      "id": "native.apple.8f6f60c9a5196918"
+      "id": "native.apple.b3bddc21aad139d0"
     },
     {
       "kind": "ui-call",
@@ -13335,7 +13335,7 @@
       "path": "apps/ios/Sources/Gateway/NotificationPermissionGuidanceDialog.swift",
       "source": "Open Notifications Settings",
       "surface": "apple",
-      "id": "native.apple.a2378696390cca1e"
+      "id": "native.apple.d50d57ba17a17db8"
     },
     {
       "kind": "ui-call",
@@ -13343,7 +13343,7 @@
       "path": "apps/ios/Sources/Gateway/NotificationPermissionGuidanceDialog.swift",
       "source": "Not Now",
       "surface": "apple",
-      "id": "native.apple.807456c9b744662b"
+      "id": "native.apple.dc6fbd0b31330488"
     },
     {
       "kind": "ui-call",
@@ -13351,7 +13351,7 @@
       "path": "apps/ios/Sources/Gateway/NotificationPermissionGuidanceDialog.swift",
       "source": "Don't show again",
       "surface": "apple",
-      "id": "native.apple.d180e6d9a4963c2b"
+      "id": "native.apple.963233fa6210d916"
     },
     {
       "kind": "plist-string",
@@ -13359,7 +13359,7 @@
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw uses your calendars to show events and scheduling context when you enable calendar access.",
       "surface": "apple",
-      "id": "native.apple.cf820096080f7031"
+      "id": "native.apple.061bdfeae10e7edb"
     },
     {
       "kind": "plist-string",
@@ -13367,7 +13367,7 @@
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw uses your calendars to add events when you enable calendar access.",
       "surface": "apple",
-      "id": "native.apple.fe85b609e9a9a144"
+      "id": "native.apple.a0809d595c57e45f"
     },
     {
       "kind": "plist-string",
@@ -13375,7 +13375,7 @@
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw uses the camera when you scan a Gateway setup QR code or ask your paired Gateway or assistant to capture a photo or short video from this iPhone, for example to connect to your Gateway or show your assistant a document, device screen, or workspace.",
       "surface": "apple",
-      "id": "native.apple.ff5729a17d66ad91"
+      "id": "native.apple.0b4699f009127b0f"
     },
     {
       "kind": "plist-string",
@@ -13383,7 +13383,7 @@
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw uses your contacts so you can search and reference people while using the assistant.",
       "surface": "apple",
-      "id": "native.apple.2f21aa6f5cd72915"
+      "id": "native.apple.1709a63b06e06e29"
     },
     {
       "kind": "plist-string",
@@ -13391,7 +13391,7 @@
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw discovers and connects to your OpenClaw gateway on the local network.",
       "surface": "apple",
-      "id": "native.apple.9d550c77a37bb165"
+      "id": "native.apple.4dfc6013662fc044"
     },
     {
       "kind": "plist-string",
@@ -13399,7 +13399,7 @@
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw can share your location in the background when you enable Always.",
       "surface": "apple",
-      "id": "native.apple.d822c41a0b7e9739"
+      "id": "native.apple.5926060694e6bae2"
     },
     {
       "kind": "plist-string",
@@ -13407,7 +13407,7 @@
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw uses your location when you allow location sharing.",
       "surface": "apple",
-      "id": "native.apple.441062ce99375692"
+      "id": "native.apple.0a682f55d98cef2c"
     },
     {
       "kind": "plist-string",
@@ -13415,7 +13415,7 @@
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw uses the microphone for realtime chat, voice wake, push-to-talk, and voice notes.",
       "surface": "apple",
-      "id": "native.apple.7c2cbe7077e4eff1"
+      "id": "native.apple.9c7f16e9b041a73d"
     },
     {
       "kind": "plist-string",
@@ -13423,7 +13423,7 @@
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw may use motion data to support device-aware interactions and automations.",
       "surface": "apple",
-      "id": "native.apple.85345f18204d67ec"
+      "id": "native.apple.821e25899c1e574b"
     },
     {
       "kind": "plist-string",
@@ -13431,7 +13431,7 @@
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw lets your assistant read photos you allow and lets you choose photos to share.",
       "surface": "apple",
-      "id": "native.apple.40ed4259ec869f1b"
+      "id": "native.apple.adcb63cd7ae5e07d"
     },
     {
       "kind": "plist-string",
@@ -13439,7 +13439,7 @@
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw uses your reminders to list, add, and complete tasks when you enable reminders access.",
       "surface": "apple",
-      "id": "native.apple.81b673f0c6fc4371"
+      "id": "native.apple.c7f4ebf4bf2a601b"
     },
     {
       "kind": "plist-string",
@@ -13447,7 +13447,7 @@
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw uses on-device speech recognition for talk mode and voice wake.",
       "surface": "apple",
-      "id": "native.apple.2275552c26460945"
+      "id": "native.apple.f66ac0cd280d1f8f"
     },
     {
       "kind": "conditional-branch",
@@ -13455,7 +13455,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Off",
       "surface": "apple",
-      "id": "native.apple.cf0450b542893fb5"
+      "id": "native.apple.364ebb67d7b71d08"
     },
     {
       "kind": "conditional-branch",
@@ -13463,7 +13463,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "While Using",
       "surface": "apple",
-      "id": "native.apple.c470d02f26ac51f6"
+      "id": "native.apple.b593fed81c279d19"
     },
     {
       "kind": "conditional-branch",
@@ -13471,7 +13471,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Always",
       "surface": "apple",
-      "id": "native.apple.663b3e453bb47c07"
+      "id": "native.apple.eb0a1e7e85f4eaec"
     },
     {
       "kind": "conditional-branch",
@@ -13479,7 +13479,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location sharing is disabled in OpenClaw. Location Services are off in iOS Settings.",
       "surface": "apple",
-      "id": "native.apple.2dc593065171c201"
+      "id": "native.apple.8506df62d1e0bdc3"
     },
     {
       "kind": "conditional-branch",
@@ -13487,7 +13487,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location sharing is disabled in OpenClaw. iOS currently allows Always.",
       "surface": "apple",
-      "id": "native.apple.1dc990a9cc0500c5"
+      "id": "native.apple.b8dd114f2f71712e"
     },
     {
       "kind": "conditional-branch",
@@ -13495,7 +13495,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location sharing is disabled in OpenClaw. iOS currently allows While Using.",
       "surface": "apple",
-      "id": "native.apple.9a4e858d2b218d41"
+      "id": "native.apple.1a92067e10a1e618"
     },
     {
       "kind": "conditional-branch",
@@ -13503,7 +13503,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location sharing is disabled.",
       "surface": "apple",
-      "id": "native.apple.ab481eb11214797f"
+      "id": "native.apple.a47ad87fd6d0b88c"
     },
     {
       "kind": "conditional-branch",
@@ -13511,7 +13511,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location Services are off in iOS Settings.",
       "surface": "apple",
-      "id": "native.apple.34699b6a26b51110"
+      "id": "native.apple.210dabc05ab1ae3f"
     },
     {
       "kind": "conditional-branch",
@@ -13519,7 +13519,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Foreground location requests are allowed. Precise Location is on.",
       "surface": "apple",
-      "id": "native.apple.3b96b639e7442ee3"
+      "id": "native.apple.3c2fc0066357f5c9"
     },
     {
       "kind": "conditional-branch",
@@ -13527,7 +13527,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Foreground location requests are allowed. Precise Location is off.",
       "surface": "apple",
-      "id": "native.apple.9e537e22f834f4d5"
+      "id": "native.apple.a1dccdb2059ed665"
     },
     {
       "kind": "conditional-branch",
@@ -13535,7 +13535,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Foreground location requests are allowed.",
       "surface": "apple",
-      "id": "native.apple.3241d6de1ab6b340"
+      "id": "native.apple.1799fbd4cbebc6d5"
     },
     {
       "kind": "conditional-branch",
@@ -13543,7 +13543,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Background location requests and significant-change updates are allowed. Precise Location is on.",
       "surface": "apple",
-      "id": "native.apple.7b16935cf96c6ee3"
+      "id": "native.apple.4daa9e136532b89a"
     },
     {
       "kind": "conditional-branch",
@@ -13551,7 +13551,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Background location requests and significant-change updates are allowed. Precise Location is off.",
       "surface": "apple",
-      "id": "native.apple.b1503179f7e1058d"
+      "id": "native.apple.d986afe686bc78df"
     },
     {
       "kind": "conditional-branch",
@@ -13559,7 +13559,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Background location requests and significant-change updates are allowed.",
       "surface": "apple",
-      "id": "native.apple.6f63c4f93b7a9ab5"
+      "id": "native.apple.ec1a9f1ea8fef344"
     },
     {
       "kind": "conditional-branch",
@@ -13567,7 +13567,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Always is selected, but iOS currently allows location only while using the app. Precise Location is on.",
       "surface": "apple",
-      "id": "native.apple.95a6772115ad8b63"
+      "id": "native.apple.429caec30214b7db"
     },
     {
       "kind": "conditional-branch",
@@ -13575,7 +13575,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Always is selected, but iOS currently allows location only while using the app. Precise Location is off.",
       "surface": "apple",
-      "id": "native.apple.8ab7fd180dc593f6"
+      "id": "native.apple.f296eba86280ba95"
     },
     {
       "kind": "conditional-branch",
@@ -13583,7 +13583,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Always is selected, but iOS currently allows location only while using the app.",
       "surface": "apple",
-      "id": "native.apple.15bc589594491413"
+      "id": "native.apple.d78efb686e0542d2"
     },
     {
       "kind": "conditional-branch",
@@ -13591,7 +13591,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location permission is denied in iOS Settings.",
       "surface": "apple",
-      "id": "native.apple.30ce7ced43a0a752"
+      "id": "native.apple.09f7e10303fa51d0"
     },
     {
       "kind": "conditional-branch",
@@ -13599,7 +13599,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location permission is restricted on this device.",
       "surface": "apple",
-      "id": "native.apple.0de03d90e4280432"
+      "id": "native.apple.93f1be684c1511c8"
     },
     {
       "kind": "conditional-branch",
@@ -13607,7 +13607,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Choose a location mode to request iOS permission.",
       "surface": "apple",
-      "id": "native.apple.0d0506a7417e7d92"
+      "id": "native.apple.442cf2bf281ec3f1"
     },
     {
       "kind": "conditional-branch",
@@ -13615,7 +13615,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "OpenClaw cannot determine the current iOS location permission.",
       "surface": "apple",
-      "id": "native.apple.633f011b81108a8c"
+      "id": "native.apple.db42a5ecf1647d12"
     },
     {
       "kind": "ui-localized-call",
@@ -13623,7 +13623,7 @@
       "path": "apps/ios/Sources/Location/LocationSettingsPresentation.swift",
       "source": "Location Services are off in iOS Settings.",
       "surface": "apple",
-      "id": "native.apple.e5673992d3aeac64"
+      "id": "native.apple.fa7243038f90e157"
     },
     {
       "kind": "ui-localized-call",
@@ -13631,7 +13631,7 @@
       "path": "apps/ios/Sources/Location/LocationSettingsPresentation.swift",
       "source": "iOS permission is required to share location.",
       "surface": "apple",
-      "id": "native.apple.270f9edf88f41fbf"
+      "id": "native.apple.cde6b7a36f2918a3"
     },
     {
       "kind": "ui-localized-call",
@@ -13639,7 +13639,7 @@
       "path": "apps/ios/Sources/Location/LocationSettingsPresentation.swift",
       "source": "Location permission is denied in iOS Settings.",
       "surface": "apple",
-      "id": "native.apple.8cb96b0bb1921610"
+      "id": "native.apple.49d5c019fa976791"
     },
     {
       "kind": "ui-localized-call",
@@ -13647,7 +13647,7 @@
       "path": "apps/ios/Sources/Location/LocationSettingsPresentation.swift",
       "source": "Location permission is restricted on this device.",
       "surface": "apple",
-      "id": "native.apple.d7da989dd737723c"
+      "id": "native.apple.850483a11234dcc9"
     },
     {
       "kind": "ui-localized-call",
@@ -13655,7 +13655,7 @@
       "path": "apps/ios/Sources/Location/LocationSettingsPresentation.swift",
       "source": "iOS currently allows location only while using the app.",
       "surface": "apple",
-      "id": "native.apple.cc1df565f1194db4"
+      "id": "native.apple.66da5b758062d2a3"
     },
     {
       "kind": "ui-localized-call",
@@ -13663,7 +13663,7 @@
       "path": "apps/ios/Sources/Location/LocationSettingsPresentation.swift",
       "source": "OpenClaw cannot determine the current iOS location permission.",
       "surface": "apple",
-      "id": "native.apple.f6b19113d5d8e7db"
+      "id": "native.apple.9f430559440a9dbf"
     },
     {
       "kind": "ui-localized-call",
@@ -13671,7 +13671,7 @@
       "path": "apps/ios/Sources/Location/LocationSettingsPresentation.swift",
       "source": "While Using the App",
       "surface": "apple",
-      "id": "native.apple.2892e5b02c6789f0"
+      "id": "native.apple.69e7d591f2200793"
     },
     {
       "kind": "ui-localized-call",
@@ -13679,7 +13679,7 @@
       "path": "apps/ios/Sources/Location/LocationSettingsPresentation.swift",
       "source": "Always",
       "surface": "apple",
-      "id": "native.apple.f689e63e18ca692d"
+      "id": "native.apple.f072ede3fd94df1f"
     },
     {
       "kind": "conditional-branch",
@@ -13687,7 +13687,7 @@
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Action required",
       "surface": "apple",
-      "id": "native.apple.0d030e96f7738497"
+      "id": "native.apple.1eba9f60b9b08582"
     },
     {
       "kind": "conditional-branch",
@@ -13695,7 +13695,7 @@
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval needed",
       "surface": "apple",
-      "id": "native.apple.ce6a022159f2fb41"
+      "id": "native.apple.0f92ad952e864b6a"
     },
     {
       "kind": "conditional-branch",
@@ -13703,7 +13703,7 @@
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
-      "id": "native.apple.b0d9c1ba8ef7ec19"
+      "id": "native.apple.8a5926535c7bea31"
     },
     {
       "kind": "conditional-branch",
@@ -13711,7 +13711,7 @@
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
-      "id": "native.apple.bd98e19b49309284"
+      "id": "native.apple.940a499f0115f7ff"
     },
     {
       "kind": "conditional-branch",
@@ -13719,7 +13719,7 @@
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting...",
       "surface": "apple",
-      "id": "native.apple.6504753f3621269e"
+      "id": "native.apple.eb3d81029883a5ad"
     },
     {
       "kind": "conditional-branch",
@@ -13727,7 +13727,7 @@
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting...",
       "surface": "apple",
-      "id": "native.apple.c7fbe2a713d78714"
+      "id": "native.apple.003b917d18b51901"
     },
     {
       "kind": "conditional-branch",
@@ -13735,7 +13735,7 @@
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connected",
       "surface": "apple",
-      "id": "native.apple.c0a005f81d588867"
+      "id": "native.apple.bb5520c54af43804"
     },
     {
       "kind": "conditional-branch",
@@ -13743,7 +13743,7 @@
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Offline",
       "surface": "apple",
-      "id": "native.apple.ae33908b61c6d70b"
+      "id": "native.apple.045b07104fbfb6be"
     },
     {
       "kind": "conditional-branch",
@@ -13799,7 +13799,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingStateStore.swift",
       "source": "Home Network",
       "surface": "apple",
-      "id": "native.apple.11687a3d87afd0d7"
+      "id": "native.apple.35f1257ef7d59336"
     },
     {
       "kind": "conditional-branch",
@@ -13807,7 +13807,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingStateStore.swift",
       "source": "Remote Domain",
       "surface": "apple",
-      "id": "native.apple.49174538b8e8cae5"
+      "id": "native.apple.1776aefb26062d91"
     },
     {
       "kind": "conditional-branch",
@@ -13815,7 +13815,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingStateStore.swift",
       "source": "Same Machine (Dev)",
       "surface": "apple",
-      "id": "native.apple.5b0997ed2ebf70c7"
+      "id": "native.apple.07077a531e820341"
     },
     {
       "kind": "ui-named-argument",
@@ -13823,7 +13823,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Home Network",
       "surface": "apple",
-      "id": "native.apple.95e2c98254da2aba"
+      "id": "native.apple.95bd66690e09e9aa"
     },
     {
       "kind": "ui-named-argument",
@@ -13831,7 +13831,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "LAN or Tailscale host",
       "surface": "apple",
-      "id": "native.apple.d9a6d673aa6693ee"
+      "id": "native.apple.04f3fe009f96fbf0"
     },
     {
       "kind": "ui-named-argument",
@@ -13839,7 +13839,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Remote Domain",
       "surface": "apple",
-      "id": "native.apple.431d02f8b68a96cf"
+      "id": "native.apple.bcde7d8af2671671"
     },
     {
       "kind": "ui-named-argument",
@@ -13847,7 +13847,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "VPS with domain",
       "surface": "apple",
-      "id": "native.apple.7021301971f631bf"
+      "id": "native.apple.c9079ed7743cbde9"
     },
     {
       "kind": "ui-named-argument",
@@ -13855,7 +13855,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Same Machine (Dev)",
       "surface": "apple",
-      "id": "native.apple.7451f8d052016642"
+      "id": "native.apple.a3b04247b1b22037"
     },
     {
       "kind": "ui-named-argument",
@@ -13863,7 +13863,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "For local iOS app development",
       "surface": "apple",
-      "id": "native.apple.22e740296a762256"
+      "id": "native.apple.489d6506e3dbed8d"
     },
     {
       "kind": "ui-call",
@@ -13871,7 +13871,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Manual Connection",
       "surface": "apple",
-      "id": "native.apple.e1b1ccbfc9e73df8"
+      "id": "native.apple.e28f880ddbea8a08"
     },
     {
       "kind": "ui-call",
@@ -13879,7 +13879,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Continue",
       "surface": "apple",
-      "id": "native.apple.b7dc527c2a7e95cb"
+      "id": "native.apple.1b48769cec747f28"
     },
     {
       "kind": "ui-call",
@@ -13887,7 +13887,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Developer mode",
       "surface": "apple",
-      "id": "native.apple.93d3e17fabd5e082"
+      "id": "native.apple.69fd85c2a8413f2d"
     },
     {
       "kind": "ui-named-argument",
@@ -13895,7 +13895,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Connection Failed",
       "surface": "apple",
-      "id": "native.apple.e8b90e582100294d"
+      "id": "native.apple.0f4152d417918852"
     },
     {
       "kind": "ui-named-argument",
@@ -13903,7 +13903,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Needs attention",
       "surface": "apple",
-      "id": "native.apple.9e208d090ce2e84f"
+      "id": "native.apple.d1ea3dcd94907d9b"
     },
     {
       "kind": "conditional-branch",
@@ -13919,7 +13919,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Ready to Connect",
       "surface": "apple",
-      "id": "native.apple.e71e20089bcc4cfb"
+      "id": "native.apple.8bea970cd5085564"
     },
     {
       "kind": "ui-call",
@@ -13927,7 +13927,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Host",
       "surface": "apple",
-      "id": "native.apple.3d6cf0499c8e5980"
+      "id": "native.apple.18a0a0afc685c3f6"
     },
     {
       "kind": "ui-call",
@@ -13935,7 +13935,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Port",
       "surface": "apple",
-      "id": "native.apple.7cf97afea0a8ef4e"
+      "id": "native.apple.b98dba4969a1e649"
     },
     {
       "kind": "ui-call",
@@ -13943,7 +13943,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Security",
       "surface": "apple",
-      "id": "native.apple.cf616b515da5bc19"
+      "id": "native.apple.1e1f0819ba974ba2"
     },
     {
       "kind": "conditional-branch",
@@ -13951,7 +13951,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Plaintext (local network)",
       "surface": "apple",
-      "id": "native.apple.4014217851d06190"
+      "id": "native.apple.9f3300c7e248d6cc"
     },
     {
       "kind": "ui-call",
@@ -13959,7 +13959,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Connecting…",
       "surface": "apple",
-      "id": "native.apple.8c3050f34db919c7"
+      "id": "native.apple.6be3a153c38ea18d"
     },
     {
       "kind": "ui-call",
@@ -13967,7 +13967,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Connect",
       "surface": "apple",
-      "id": "native.apple.3e81935f219ca978"
+      "id": "native.apple.8137d4d29d3cdf6a"
     },
     {
       "kind": "ui-call",
@@ -13975,7 +13975,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Use Manual Setup",
       "surface": "apple",
-      "id": "native.apple.db7b52a1bbc6fac5"
+      "id": "native.apple.f263874106ab9d6e"
     },
     {
       "kind": "ui-call",
@@ -13983,7 +13983,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Setup Link",
       "surface": "apple",
-      "id": "native.apple.7dbdf9a439f64f08"
+      "id": "native.apple.327b3fab462c31ff"
     },
     {
       "kind": "conditional-branch",
@@ -13991,7 +13991,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "surface": "apple",
-      "id": "native.apple.3329c7f367f10c78"
+      "id": "native.apple.f0aeb496631a06b4"
     },
     {
       "kind": "conditional-branch",
@@ -13999,7 +13999,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
       "surface": "apple",
-      "id": "native.apple.6bfb611862fb1687"
+      "id": "native.apple.0792e5bfc5917767"
     },
     {
       "kind": "ui-call",
@@ -14007,7 +14007,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "No gateways found yet.",
       "surface": "apple",
-      "id": "native.apple.2f00ef4bc35ecb8d"
+      "id": "native.apple.0b8f879b0a927350"
     },
     {
       "kind": "ui-call",
@@ -14015,7 +14015,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Restart Discovery",
       "surface": "apple",
-      "id": "native.apple.94c9697fb748d05d"
+      "id": "native.apple.26223c0b79210f6e"
     },
     {
       "kind": "ui-call",
@@ -14023,7 +14023,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Discovered Gateways",
       "surface": "apple",
-      "id": "native.apple.07ebd3b75969629f"
+      "id": "native.apple.df726976d165732a"
     },
     {
       "kind": "ui-call",
@@ -14031,7 +14031,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Security notice",
       "surface": "apple",
-      "id": "native.apple.09e7832b23cf14f6"
+      "id": "native.apple.d7de1640cd83b30d"
     },
     {
       "kind": "ui-call",
@@ -14039,7 +14039,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "The connected OpenClaw agent can use device capabilities you enable.",
       "surface": "apple",
-      "id": "native.apple.d4d9568dca8ceaa9"
+      "id": "native.apple.048f49e40b4c8dfd"
     },
     {
       "kind": "ui-call",
@@ -14047,7 +14047,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Camera, microphone, photos, contacts, calendar, and location may be available.",
       "surface": "apple",
-      "id": "native.apple.fdd93eb6b6eef525"
+      "id": "native.apple.500cc16ca47793aa"
     },
     {
       "kind": "ui-call",
@@ -14055,7 +14055,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Continue only if you trust the gateway and agent you connect to.",
       "surface": "apple",
-      "id": "native.apple.7cc0f656abb41f6d"
+      "id": "native.apple.d9233b8153cbfa51"
     },
     {
       "kind": "ui-modifier",
@@ -14063,7 +14063,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Copy setup code command",
       "surface": "apple",
-      "id": "native.apple.eae3bd9e4e9112a0"
+      "id": "native.apple.f841b3d18cc6073b"
     },
     {
       "kind": "conditional-branch",
@@ -14079,7 +14079,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "OpenClaw",
       "surface": "apple",
-      "id": "native.apple.e8b4dc00cd23ae73"
+      "id": "native.apple.749270d1ad655ca9"
     },
     {
       "kind": "ui-named-argument",
@@ -14087,7 +14087,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Securely connect this iPhone to your gateway.",
       "surface": "apple",
-      "id": "native.apple.c9419426ba8c2a2e"
+      "id": "native.apple.f378ca9fc19f6835"
     },
     {
       "kind": "ui-named-argument",
@@ -14095,7 +14095,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Connect to your gateway",
       "surface": "apple",
-      "id": "native.apple.3e233ba3ed3181d4"
+      "id": "native.apple.9050502c2dfdbd08"
     },
     {
       "kind": "ui-named-argument",
@@ -14103,7 +14103,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Choose device permissions",
       "surface": "apple",
-      "id": "native.apple.b6978424ac0a4d14"
+      "id": "native.apple.c834115a6a973c08"
     },
     {
       "kind": "ui-named-argument",
@@ -14111,7 +14111,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Use OpenClaw from your phone",
       "surface": "apple",
-      "id": "native.apple.4109460a5b8927d8"
+      "id": "native.apple.92c8f15731183c84"
     },
     {
       "kind": "ui-call",
@@ -14119,7 +14119,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Continue",
       "surface": "apple",
-      "id": "native.apple.cae311a6e975c879"
+      "id": "native.apple.246af90092725464"
     },
     {
       "kind": "ui-named-argument",
@@ -14127,7 +14127,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Connect Gateway",
       "surface": "apple",
-      "id": "native.apple.c686068c2a79bf9e"
+      "id": "native.apple.78ce2252d123519c"
     },
     {
       "kind": "ui-named-argument",
@@ -14135,7 +14135,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Run this on your gateway host and scan the code",
       "surface": "apple",
-      "id": "native.apple.8f76a5962329b43f"
+      "id": "native.apple.068d3e124deca287"
     },
     {
       "kind": "ui-call",
@@ -14143,7 +14143,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Connecting…",
       "surface": "apple",
-      "id": "native.apple.d71a98568b7184a5"
+      "id": "native.apple.92447f10c8408561"
     },
     {
       "kind": "ui-call",
@@ -14151,7 +14151,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Scan QR",
       "surface": "apple",
-      "id": "native.apple.577764b38b1d903c"
+      "id": "native.apple.5bcd0c2ea7791d72"
     },
     {
       "kind": "ui-named-argument",
@@ -14159,7 +14159,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "or",
       "surface": "apple",
-      "id": "native.apple.913a586956440f64"
+      "id": "native.apple.91337129a1eaad02"
     },
     {
       "kind": "ui-call",
@@ -14167,7 +14167,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Connect Manually",
       "surface": "apple",
-      "id": "native.apple.57614f0c4e59677b"
+      "id": "native.apple.474efa99af12e8b2"
     },
     {
       "kind": "ui-call",
@@ -14175,7 +14175,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "You're connected",
       "surface": "apple",
-      "id": "native.apple.4916d34cab45e6c3"
+      "id": "native.apple.257bd3fa156a09b2"
     },
     {
       "kind": "ui-call",
@@ -14183,7 +14183,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Go to Chat",
       "surface": "apple",
-      "id": "native.apple.b5e401fa9bfb4b49"
+      "id": "native.apple.cc0423e431b2da20"
     },
     {
       "kind": "conditional-branch",
@@ -14191,7 +14191,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway auth token is missing.",
       "surface": "apple",
-      "id": "native.apple.bdc551ec6154a4de"
+      "id": "native.apple.785f53402b93d2ef"
     },
     {
       "kind": "conditional-branch",
@@ -14199,7 +14199,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway rejected credentials.",
       "surface": "apple",
-      "id": "native.apple.303cd481d965b513"
+      "id": "native.apple.44b61ae1c6757049"
     },
     {
       "kind": "conditional-branch",
@@ -14207,7 +14207,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Could not reach the gateway.",
       "surface": "apple",
-      "id": "native.apple.b1ad23ecc5f4b0c2"
+      "id": "native.apple.9387cdd2a05c875c"
     },
     {
       "kind": "ui-modifier",
@@ -14215,7 +14215,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "QR Scanner Unavailable",
       "surface": "apple",
-      "id": "native.apple.a62e0764b51937cb"
+      "id": "native.apple.342d77f542fc06c1"
     },
     {
       "kind": "ui-call",
@@ -14223,7 +14223,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "OK",
       "surface": "apple",
-      "id": "native.apple.0a329fe4d4aef5bb"
+      "id": "native.apple.e85c4f6e42d38422"
     },
     {
       "kind": "ui-call",
@@ -14231,7 +14231,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Scan Setup Code",
       "surface": "apple",
-      "id": "native.apple.d50aa0885c7e064f"
+      "id": "native.apple.52bb089f43889b95"
     },
     {
       "kind": "ui-call",
@@ -14239,7 +14239,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Cancel",
       "surface": "apple",
-      "id": "native.apple.f58429a2d9d3371f"
+      "id": "native.apple.07ba8a0e5a623228"
     },
     {
       "kind": "ui-call",
@@ -14247,7 +14247,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Photos",
       "surface": "apple",
-      "id": "native.apple.f0a022bd1772fda0"
+      "id": "native.apple.706cf2bed9dfa2d1"
     },
     {
       "kind": "ui-modifier",
@@ -14255,7 +14255,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Back",
       "surface": "apple",
-      "id": "native.apple.09ed26daf34a4c5d"
+      "id": "native.apple.ccf758caa953d5f9"
     },
     {
       "kind": "ui-call",
@@ -14263,7 +14263,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Close",
       "surface": "apple",
-      "id": "native.apple.e58367cfa71115cc"
+      "id": "native.apple.2a5e2d97339e2446"
     },
     {
       "kind": "ui-modifier",
@@ -14271,7 +14271,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Dismiss Keyboard",
       "surface": "apple",
-      "id": "native.apple.1e60db061979db60"
+      "id": "native.apple.dcd80e92827338ed"
     },
     {
       "kind": "ui-call",
@@ -14279,7 +14279,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Mode",
       "surface": "apple",
-      "id": "native.apple.d444d84eb269f529"
+      "id": "native.apple.cf1bee5ce0e03b58"
     },
     {
       "kind": "ui-call",
@@ -14287,7 +14287,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Discovery",
       "surface": "apple",
-      "id": "native.apple.d5d2681fc2d9b10d"
+      "id": "native.apple.45d8576b6a8627f4"
     },
     {
       "kind": "ui-call",
@@ -14295,7 +14295,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Status",
       "surface": "apple",
-      "id": "native.apple.2034ab1aeebbab91"
+      "id": "native.apple.34b1c695bb91946c"
     },
     {
       "kind": "ui-call",
@@ -14303,7 +14303,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Choose a mode first.",
       "surface": "apple",
-      "id": "native.apple.17e200e7cbad27ae"
+      "id": "native.apple.1d04728fde2b5203"
     },
     {
       "kind": "ui-call",
@@ -14311,7 +14311,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Back to Mode Selection",
       "surface": "apple",
-      "id": "native.apple.378c2c7be159c1f2"
+      "id": "native.apple.d804f4a034e647fe"
     },
     {
       "kind": "ui-named-argument",
@@ -14319,7 +14319,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Manual Fallback",
       "surface": "apple",
-      "id": "native.apple.1284354b0d0098ad"
+      "id": "native.apple.3ad38183e6e45001"
     },
     {
       "kind": "ui-named-argument",
@@ -14327,7 +14327,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Domain Settings",
       "surface": "apple",
-      "id": "native.apple.db2b3720c08fca4d"
+      "id": "native.apple.22e974597c20b33b"
     },
     {
       "kind": "ui-call",
@@ -14335,7 +14335,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Developer Local",
       "surface": "apple",
-      "id": "native.apple.36bb966d0789414d"
+      "id": "native.apple.110e2d5313667f29"
     },
     {
       "kind": "ui-call",
@@ -14343,7 +14343,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Default host is localhost. Use your Mac LAN IP if simulator networking requires it.",
       "surface": "apple",
-      "id": "native.apple.dc8b73d67a261e73"
+      "id": "native.apple.33828417c20cce7e"
     },
     {
       "kind": "ui-call",
@@ -14351,7 +14351,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway rejected credentials. Scan a fresh setup code or update token/password.",
       "surface": "apple",
-      "id": "native.apple.5847cf494847ed98"
+      "id": "native.apple.20889b6dc7841793"
     },
     {
       "kind": "ui-call",
@@ -14359,7 +14359,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "OpenClaw is checking gateway and node access.",
       "surface": "apple",
-      "id": "native.apple.559dccb9f9dfbbad"
+      "id": "native.apple.707d3aa0552d4424"
     },
     {
       "kind": "ui-call",
@@ -14367,7 +14367,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Resume After Approval",
       "surface": "apple",
-      "id": "native.apple.4404f435fb496b62"
+      "id": "native.apple.58f14a0bf3a8ed8c"
     },
     {
       "kind": "ui-call",
@@ -14375,7 +14375,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Pairing Approval",
       "surface": "apple",
-      "id": "native.apple.44233bae1c0afe68"
+      "id": "native.apple.4b1fb7f06bd6bc3b"
     },
     {
       "kind": "ui-call-concatenated",
@@ -14383,7 +14383,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Approve this device on the gateway.\n1) `\\(commandLine)`\n2) `/pair approve` in your OpenClaw chat\n\\(requestLine)\nOpenClaw will also retry automatically when you return to this app.",
       "surface": "apple",
-      "id": "native.apple.9725443db32f5158"
+      "id": "native.apple.ff68473aad93fe5e"
     },
     {
       "kind": "ui-call",
@@ -14391,7 +14391,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Scan Setup Code Again",
       "surface": "apple",
-      "id": "native.apple.af3890b1e07c3084"
+      "id": "native.apple.00a542500b9ece4f"
     },
     {
       "kind": "ui-call",
@@ -14399,7 +14399,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Retry Connection",
       "surface": "apple",
-      "id": "native.apple.0134e9bd57c74d27"
+      "id": "native.apple.9ae99eeabd029455"
     },
     {
       "kind": "ui-call",
@@ -14407,7 +14407,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Enter setup code",
       "surface": "apple",
-      "id": "native.apple.abe248e02d451890"
+      "id": "native.apple.564762557c6f4fd1"
     },
     {
       "kind": "ui-call",
@@ -14415,7 +14415,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Apply",
       "surface": "apple",
-      "id": "native.apple.d9e6ff8a72f4525b"
+      "id": "native.apple.94f126685955376a"
     },
     {
       "kind": "ui-call",
@@ -14423,7 +14423,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Setup Code",
       "surface": "apple",
-      "id": "native.apple.74d4be2078a04261"
+      "id": "native.apple.102df5e30b073ebe"
     },
     {
       "kind": "ui-call",
@@ -14431,7 +14431,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Use this if you have a setup code instead of scanning.",
       "surface": "apple",
-      "id": "native.apple.ee24a5a75d7b1e4f"
+      "id": "native.apple.f7b828f7d7002f5f"
     },
     {
       "kind": "ui-call",
@@ -14439,7 +14439,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Host",
       "surface": "apple",
-      "id": "native.apple.826c84d7090d253c"
+      "id": "native.apple.63f1d5fe6fffa39b"
     },
     {
       "kind": "ui-call",
@@ -14447,7 +14447,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Port",
       "surface": "apple",
-      "id": "native.apple.9e9de5d188e3c693"
+      "id": "native.apple.7599beed5b46ee31"
     },
     {
       "kind": "ui-call",
@@ -14455,7 +14455,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Discovery Domain (optional)",
       "surface": "apple",
-      "id": "native.apple.b1fdf88fe407cf7b"
+      "id": "native.apple.e1364730639bafdf"
     },
     {
       "kind": "ui-call",
@@ -14463,7 +14463,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway Auth Token",
       "surface": "apple",
-      "id": "native.apple.600ba39ce56ddd62"
+      "id": "native.apple.54df1d842fbb868f"
     },
     {
       "kind": "ui-call",
@@ -14471,7 +14471,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway Password",
       "surface": "apple",
-      "id": "native.apple.a5943eaea2db1d6d"
+      "id": "native.apple.30a1f14828de9569"
     },
     {
       "kind": "ui-call",
@@ -14479,7 +14479,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Unencrypted",
       "surface": "apple",
-      "id": "native.apple.3e34c28edd053285"
+      "id": "native.apple.536c9453100b8288"
     },
     {
       "kind": "ui-call",
@@ -14487,7 +14487,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Secure (TLS)",
       "surface": "apple",
-      "id": "native.apple.19ce2a63ffa5562a"
+      "id": "native.apple.1d47e6515a89823d"
     },
     {
       "kind": "ui-call",
@@ -14495,7 +14495,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Connection security",
       "surface": "apple",
-      "id": "native.apple.a1eb951133402dd4"
+      "id": "native.apple.189c54620317f831"
     },
     {
       "kind": "ui-call",
@@ -14503,7 +14503,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Connecting…",
       "surface": "apple",
-      "id": "native.apple.6c3fe084ab7b318d"
+      "id": "native.apple.a471965d9a0b3a24"
     },
     {
       "kind": "ui-call",
@@ -14511,7 +14511,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Connect",
       "surface": "apple",
-      "id": "native.apple.ab58b30ddda7aeb0"
+      "id": "native.apple.3092a8e342aa043f"
     },
     {
       "kind": "conditional-branch",
@@ -14535,7 +14535,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Talk",
       "surface": "apple",
-      "id": "native.apple.f2ea327bfea8b8e3"
+      "id": "native.apple.2a338ac871ecb7fe"
     },
     {
       "kind": "ui-call",
@@ -14543,7 +14543,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Control",
       "surface": "apple",
-      "id": "native.apple.bda6cfa988e49a75"
+      "id": "native.apple.731252cc63ef4eca"
     },
     {
       "kind": "ui-call",
@@ -14551,7 +14551,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Agent",
       "surface": "apple",
-      "id": "native.apple.3c80f5351055a5f3"
+      "id": "native.apple.7456e2f9439034e7"
     },
     {
       "kind": "ui-call",
@@ -14559,7 +14559,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Settings",
       "surface": "apple",
-      "id": "native.apple.22d107db5b905ef4"
+      "id": "native.apple.6573d500ca6879ef"
     },
     {
       "kind": "ui-call",
@@ -14567,7 +14567,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw",
       "surface": "apple",
-      "id": "native.apple.c23d35de8d70863f"
+      "id": "native.apple.84ea52fed0394561"
     },
     {
       "kind": "ui-modifier",
@@ -14575,7 +14575,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw \\(self.sidebarGatewayStatusTitle)",
       "surface": "apple",
-      "id": "native.apple.39042da9fc187030"
+      "id": "native.apple.cb006ba6f4011f73"
     },
     {
       "kind": "conditional-branch",
@@ -14583,7 +14583,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Online",
       "surface": "apple",
-      "id": "native.apple.f4eea6473f43388d"
+      "id": "native.apple.bb5a64079d5dd251"
     },
     {
       "kind": "conditional-branch",
@@ -14591,7 +14591,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Connecting",
       "surface": "apple",
-      "id": "native.apple.9e2aea6088887f1f"
+      "id": "native.apple.4af0f1f4ad2deeb6"
     },
     {
       "kind": "conditional-branch",
@@ -14599,7 +14599,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Needs attention",
       "surface": "apple",
-      "id": "native.apple.3624978c7d43335a"
+      "id": "native.apple.06a7f9fdeeb95881"
     },
     {
       "kind": "conditional-branch",
@@ -14607,7 +14607,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Offline",
       "surface": "apple",
-      "id": "native.apple.7da053dd774cb201"
+      "id": "native.apple.623535bbd51e4a4b"
     },
     {
       "kind": "ui-named-argument",
@@ -14615,7 +14615,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Chat",
       "surface": "apple",
-      "id": "native.apple.a4256b2ab523ee60"
+      "id": "native.apple.4d24eb02c634e5d3"
     },
     {
       "kind": "ui-named-argument",
@@ -14623,7 +14623,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Overview",
       "surface": "apple",
-      "id": "native.apple.64d7dc062ef4cc81"
+      "id": "native.apple.143565a5ab324c3b"
     },
     {
       "kind": "ui-named-argument",
@@ -14631,7 +14631,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Agents",
       "surface": "apple",
-      "id": "native.apple.11f98fe0650d52f5"
+      "id": "native.apple.be6dd25682178eed"
     },
     {
       "kind": "ui-named-argument",
@@ -14639,7 +14639,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Instances",
       "surface": "apple",
-      "id": "native.apple.47426e84372bc0a5"
+      "id": "native.apple.1f3dccec9147b95e"
     },
     {
       "kind": "ui-named-argument",
@@ -14647,7 +14647,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Files",
       "surface": "apple",
-      "id": "native.apple.d1a5c9b0c4acbfe2"
+      "id": "native.apple.8c9cdab957b0651d"
     },
     {
       "kind": "ui-named-argument",
@@ -14655,7 +14655,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Dreaming",
       "surface": "apple",
-      "id": "native.apple.ad3c65353227b63e"
+      "id": "native.apple.11e4feacdd66b471"
     },
     {
       "kind": "ui-named-argument",
@@ -14663,7 +14663,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Usage",
       "surface": "apple",
-      "id": "native.apple.a3ba593df67a8673"
+      "id": "native.apple.eeaf566d56befff7"
     },
     {
       "kind": "ui-named-argument",
@@ -14671,7 +14671,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Cron Jobs",
       "surface": "apple",
-      "id": "native.apple.db0d9af6d0855d18"
+      "id": "native.apple.2cc59621d0777089"
     },
     {
       "kind": "ui-modifier",
@@ -14679,7 +14679,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Hide Sidebar",
       "surface": "apple",
-      "id": "native.apple.72fab75688479b3e"
+      "id": "native.apple.9a813708c69992e4"
     },
     {
       "kind": "ui-modifier",
@@ -14687,7 +14687,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Close canvas",
       "surface": "apple",
-      "id": "native.apple.8af43f59602ec0d8"
+      "id": "native.apple.766267e34342d769"
     },
     {
       "kind": "conditional-branch",
@@ -14695,7 +14695,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway needs attention",
       "surface": "apple",
-      "id": "native.apple.8a4751c86aa6fe77"
+      "id": "native.apple.ab6b0e43b6bcf5ff"
     },
     {
       "kind": "conditional-branch",
@@ -14703,7 +14703,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw iOS",
       "surface": "apple",
-      "id": "native.apple.a55a43940452b04b"
+      "id": "native.apple.9da57c45433e8fe9"
     },
     {
       "kind": "conditional-branch",
@@ -14711,7 +14711,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Available",
       "surface": "apple",
-      "id": "native.apple.35b6f99d627028f6"
+      "id": "native.apple.fd66d1ffbe5f9b72"
     },
     {
       "kind": "conditional-branch",
@@ -14719,7 +14719,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway default",
       "surface": "apple",
-      "id": "native.apple.e91893761485b9e8"
+      "id": "native.apple.98915ebb62287a02"
     },
     {
       "kind": "conditional-branch",
@@ -14735,7 +14735,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Chat",
       "surface": "apple",
-      "id": "native.apple.a29418bbb3169404"
+      "id": "native.apple.e55c99a74ecb9429"
     },
     {
       "kind": "conditional-branch",
@@ -14743,7 +14743,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Talk",
       "surface": "apple",
-      "id": "native.apple.febca7528af94342"
+      "id": "native.apple.addf7e959238c434"
     },
     {
       "kind": "conditional-branch",
@@ -14751,7 +14751,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Overview",
       "surface": "apple",
-      "id": "native.apple.e26bbe303d8a9544"
+      "id": "native.apple.e31e7d688db1e507"
     },
     {
       "kind": "conditional-branch",
@@ -14759,7 +14759,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Activity",
       "surface": "apple",
-      "id": "native.apple.1bae45caee11d1a4"
+      "id": "native.apple.978a93d5f6c1492b"
     },
     {
       "kind": "conditional-branch",
@@ -14767,7 +14767,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Agents",
       "surface": "apple",
-      "id": "native.apple.dea6129f5908f494"
+      "id": "native.apple.039d5323b4133540"
     },
     {
       "kind": "conditional-branch",
@@ -14775,7 +14775,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Workboard",
       "surface": "apple",
-      "id": "native.apple.1b9a298ab6e87f5f"
+      "id": "native.apple.eb8da3ac76a36319"
     },
     {
       "kind": "conditional-branch",
@@ -14783,7 +14783,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Skill Workshop",
       "surface": "apple",
-      "id": "native.apple.2492086244fda7c6"
+      "id": "native.apple.5f58ed7fd9de7c40"
     },
     {
       "kind": "conditional-branch",
@@ -14791,7 +14791,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Instances",
       "surface": "apple",
-      "id": "native.apple.7482f18faae25219"
+      "id": "native.apple.c022f8541ef2af61"
     },
     {
       "kind": "conditional-branch",
@@ -14799,7 +14799,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Sessions",
       "surface": "apple",
-      "id": "native.apple.3579cf2750470a22"
+      "id": "native.apple.e3e3ce1a79ebbd70"
     },
     {
       "kind": "conditional-branch",
@@ -14807,7 +14807,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Files",
       "surface": "apple",
-      "id": "native.apple.253cb2debeb51859"
+      "id": "native.apple.9a2e934b2c0f7b9c"
     },
     {
       "kind": "conditional-branch",
@@ -14815,7 +14815,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Dreaming",
       "surface": "apple",
-      "id": "native.apple.f7e04202c3e37bd8"
+      "id": "native.apple.4b487e0b204100d2"
     },
     {
       "kind": "conditional-branch",
@@ -14823,7 +14823,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Usage",
       "surface": "apple",
-      "id": "native.apple.006c21319c07c995"
+      "id": "native.apple.a68defb824f08706"
     },
     {
       "kind": "conditional-branch",
@@ -14831,7 +14831,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Cron Jobs",
       "surface": "apple",
-      "id": "native.apple.0b4e807d2449e93f"
+      "id": "native.apple.f44d1d607d617560"
     },
     {
       "kind": "conditional-branch",
@@ -14839,7 +14839,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Terminal",
       "surface": "apple",
-      "id": "native.apple.b3b5114b91a8db8f"
+      "id": "native.apple.0a89db5f6440494e"
     },
     {
       "kind": "conditional-branch",
@@ -14847,7 +14847,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Docs",
       "surface": "apple",
-      "id": "native.apple.584dfce592c64899"
+      "id": "native.apple.0ddc5e5f7cabc9d7"
     },
     {
       "kind": "conditional-branch",
@@ -14855,7 +14855,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Settings",
       "surface": "apple",
-      "id": "native.apple.32f7a12fd39a135c"
+      "id": "native.apple.5c4975b8af9d262b"
     },
     {
       "kind": "conditional-branch",
@@ -14863,7 +14863,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Settings / Gateway",
       "surface": "apple",
-      "id": "native.apple.65ed76ea0b539052"
+      "id": "native.apple.a293fea3dfaa52b3"
     },
     {
       "kind": "conditional-branch",
@@ -14871,7 +14871,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Connection",
       "surface": "apple",
-      "id": "native.apple.e69088f1f2dcbd99"
+      "id": "native.apple.873fedc2bc9a5c1b"
     },
     {
       "kind": "ui-call",
@@ -14879,7 +14879,7 @@
       "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
       "source": "Value",
       "surface": "apple",
-      "id": "native.apple.41e812a22a1b042d"
+      "id": "native.apple.122e1ca6eeee1cea"
     },
     {
       "kind": "ui-call",
@@ -14887,7 +14887,7 @@
       "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
       "source": "Headers",
       "surface": "apple",
-      "id": "native.apple.acc5936e406af08c"
+      "id": "native.apple.d8a299893eee8eab"
     },
     {
       "kind": "ui-call-concatenated",
@@ -14895,7 +14895,7 @@
       "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
       "source": "Sent with foreground app connections to this gateway. Changes apply on the next reconnect; Share extension delivery is not yet supported.",
       "surface": "apple",
-      "id": "native.apple.8896386269ac4882"
+      "id": "native.apple.a06159354eb7fa6f"
     },
     {
       "kind": "ui-call",
@@ -14903,7 +14903,7 @@
       "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
       "source": "Header name",
       "surface": "apple",
-      "id": "native.apple.319594454c1ff701"
+      "id": "native.apple.8211f29003986cb7"
     },
     {
       "kind": "ui-call",
@@ -14911,7 +14911,7 @@
       "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
       "source": "Header value",
       "surface": "apple",
-      "id": "native.apple.7c4ff27cd7fa2c96"
+      "id": "native.apple.429e3660a6be650d"
     },
     {
       "kind": "ui-call",
@@ -14919,7 +14919,7 @@
       "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
       "source": "Add Header",
       "surface": "apple",
-      "id": "native.apple.a1368ad2d29a1152"
+      "id": "native.apple.5096f2465a6e89aa"
     },
     {
       "kind": "ui-modifier",
@@ -14927,7 +14927,7 @@
       "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
       "source": "Custom Headers",
       "surface": "apple",
-      "id": "native.apple.19fba912c31023b5"
+      "id": "native.apple.928311f3bf4593b7"
     },
     {
       "kind": "ui-named-argument",
@@ -14935,7 +14935,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Contacts",
       "surface": "apple",
-      "id": "native.apple.4dac301c7e0c921c"
+      "id": "native.apple.228b55b725147d23"
     },
     {
       "kind": "ui-named-argument",
@@ -14943,7 +14943,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Search and add contacts from the assistant.",
       "surface": "apple",
-      "id": "native.apple.01f362d70f6ddb4e"
+      "id": "native.apple.b7aa02b8a3532616"
     },
     {
       "kind": "ui-named-argument",
@@ -14951,7 +14951,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Photos",
       "surface": "apple",
-      "id": "native.apple.eda8d96e40bcc36a"
+      "id": "native.apple.8341e1eb9d9a44a6"
     },
     {
       "kind": "ui-named-argument",
@@ -14959,7 +14959,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Calendar (Add Events)",
       "surface": "apple",
-      "id": "native.apple.df0159ff34744870"
+      "id": "native.apple.44e37360bfb1f0bd"
     },
     {
       "kind": "ui-named-argument",
@@ -14967,7 +14967,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Add events with least privilege.",
       "surface": "apple",
-      "id": "native.apple.c6db4240083c0435"
+      "id": "native.apple.90ee11662883e606"
     },
     {
       "kind": "ui-named-argument",
@@ -14975,7 +14975,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Calendar (View Events)",
       "surface": "apple",
-      "id": "native.apple.dc62e22f0b2726c5"
+      "id": "native.apple.fb04e1587f094b26"
     },
     {
       "kind": "ui-named-argument",
@@ -14983,7 +14983,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "List and read calendar events.",
       "surface": "apple",
-      "id": "native.apple.650091bc632b3120"
+      "id": "native.apple.756cd399529a94b0"
     },
     {
       "kind": "ui-named-argument",
@@ -14991,7 +14991,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Reminders",
       "surface": "apple",
-      "id": "native.apple.7a81d1f17d9d90c0"
+      "id": "native.apple.574b1a6d76979e00"
     },
     {
       "kind": "ui-named-argument",
@@ -14999,7 +14999,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "List, add, and complete reminders.",
       "surface": "apple",
-      "id": "native.apple.d6fd5e9f85b0e298"
+      "id": "native.apple.57e576d4fad2a437"
     },
     {
       "kind": "ui-call",
@@ -15007,7 +15007,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Privacy & Access",
       "surface": "apple",
-      "id": "native.apple.bb572eab08269809"
+      "id": "native.apple.b99b977127320607"
     },
     {
       "kind": "conditional-branch",
@@ -15015,7 +15015,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Limited",
       "surface": "apple",
-      "id": "native.apple.651cc89381dd69c0"
+      "id": "native.apple.94208c3068dae5b9"
     },
     {
       "kind": "conditional-branch",
@@ -15023,7 +15023,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Read photos you select for the assistant.",
       "surface": "apple",
-      "id": "native.apple.ab998419291361da"
+      "id": "native.apple.eba3ae5d9442e1a5"
     },
     {
       "kind": "conditional-branch",
@@ -15031,7 +15031,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Read recent photos for the assistant.",
       "surface": "apple",
-      "id": "native.apple.e8c07f7c48d086f9"
+      "id": "native.apple.d1d10d1140299230"
     },
     {
       "kind": "conditional-branch",
@@ -15039,7 +15039,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Allowed",
       "surface": "apple",
-      "id": "native.apple.22b335bddf72e453"
+      "id": "native.apple.32aabe66f916a809"
     },
     {
       "kind": "conditional-branch",
@@ -15047,7 +15047,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Add-Only",
       "surface": "apple",
-      "id": "native.apple.d2f5de202e0426f8"
+      "id": "native.apple.e5a601c8fe47e9ed"
     },
     {
       "kind": "conditional-branch",
@@ -15055,7 +15055,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Not Set",
       "surface": "apple",
-      "id": "native.apple.62f71c671e344fef"
+      "id": "native.apple.aa6ff8becab99fdc"
     },
     {
       "kind": "conditional-branch",
@@ -15063,7 +15063,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Not Allowed",
       "surface": "apple",
-      "id": "native.apple.1f17d59d38e1fe83"
+      "id": "native.apple.92223852c90e286d"
     },
     {
       "kind": "conditional-branch",
@@ -15071,7 +15071,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Unknown",
       "surface": "apple",
-      "id": "native.apple.6b95517f513d9b7c"
+      "id": "native.apple.03e2f7265119d263"
     },
     {
       "kind": "ui-call",
@@ -15079,7 +15079,7 @@
       "path": "apps/ios/Sources/Settings/VoiceWakeWordsSettingsView.swift",
       "source": "Wake word",
       "surface": "apple",
-      "id": "native.apple.d9f9a74e25431256"
+      "id": "native.apple.7c949a356120988c"
     },
     {
       "kind": "ui-call",
@@ -15087,7 +15087,7 @@
       "path": "apps/ios/Sources/Settings/VoiceWakeWordsSettingsView.swift",
       "source": "Add word",
       "surface": "apple",
-      "id": "native.apple.afc6f7fed2ea65d6"
+      "id": "native.apple.f0ef9f5a19da870e"
     },
     {
       "kind": "ui-call",
@@ -15095,7 +15095,7 @@
       "path": "apps/ios/Sources/Settings/VoiceWakeWordsSettingsView.swift",
       "source": "Reset defaults",
       "surface": "apple",
-      "id": "native.apple.193005a2cdf1257f"
+      "id": "native.apple.f71632a9501aa18d"
     },
     {
       "kind": "ui-call",
@@ -15103,7 +15103,7 @@
       "path": "apps/ios/Sources/Settings/VoiceWakeWordsSettingsView.swift",
       "source": "Wake Words",
       "surface": "apple",
-      "id": "native.apple.c1314556e24659d1"
+      "id": "native.apple.5ba5bed6fcb2cd09"
     },
     {
       "kind": "ui-call-concatenated",
@@ -15111,7 +15111,7 @@
       "path": "apps/ios/Sources/Settings/VoiceWakeWordsSettingsView.swift",
       "source": "OpenClaw reacts when any trigger appears in a transcription. Keep them short to avoid false positives.",
       "surface": "apple",
-      "id": "native.apple.4ebb39f445d7dbff"
+      "id": "native.apple.e0eaa88f187271fc"
     },
     {
       "kind": "ui-modifier",
@@ -15119,7 +15119,7 @@
       "path": "apps/ios/Sources/Status/VoiceWakeToast.swift",
       "source": "Voice Wake triggered",
       "surface": "apple",
-      "id": "native.apple.994760420a194561"
+      "id": "native.apple.d0c5295e1ce2766d"
     },
     {
       "kind": "ui-modifier",
@@ -15127,7 +15127,7 @@
       "path": "apps/ios/Sources/Terminal/TerminalHubScreen.swift",
       "source": "Terminal",
       "surface": "apple",
-      "id": "native.apple.8ba33bf5712e3af2"
+      "id": "native.apple.1cbb41bbfba541d4"
     },
     {
       "kind": "ui-modifier",
@@ -15135,7 +15135,7 @@
       "path": "apps/ios/Sources/Terminal/TerminalHubScreen.swift",
       "source": "Gateway settings",
       "surface": "apple",
-      "id": "native.apple.2f67b32536f24e9d"
+      "id": "native.apple.e7bccb36675c0dc3"
     },
     {
       "kind": "ui-call",
@@ -15143,7 +15143,7 @@
       "path": "apps/ios/Sources/Terminal/TerminalHubScreen.swift",
       "source": "Terminal needs a connected gateway",
       "surface": "apple",
-      "id": "native.apple.25e3befd890f1a73"
+      "id": "native.apple.6af51557f2c86834"
     },
     {
       "kind": "ui-call",
@@ -15151,7 +15151,7 @@
       "path": "apps/ios/Sources/Terminal/TerminalHubScreen.swift",
       "source": "Connect to your gateway to open a shell in the agent workspace.",
       "surface": "apple",
-      "id": "native.apple.197411362978db2d"
+      "id": "native.apple.ee381620916bdd04"
     },
     {
       "kind": "ui-call",
@@ -15159,7 +15159,7 @@
       "path": "apps/ios/Sources/Terminal/TerminalHubScreen.swift",
       "source": "Open Gateway Settings",
       "surface": "apple",
-      "id": "native.apple.0a687ce373931085"
+      "id": "native.apple.910f54df5b7ea2cb"
     },
     {
       "kind": "conditional-branch",
@@ -15175,7 +15175,7 @@
       "path": "apps/ios/Sources/Voice/TalkGatewayPermissionState.swift",
       "source": "Not checked",
       "surface": "apple",
-      "id": "native.apple.3b21081fb5ce84ba"
+      "id": "native.apple.59ca4f429f6f5c96"
     },
     {
       "kind": "conditional-branch",
@@ -15183,7 +15183,7 @@
       "path": "apps/ios/Sources/Voice/TalkGatewayPermissionState.swift",
       "source": "Ready",
       "surface": "apple",
-      "id": "native.apple.1e2a98b4f50dbfe6"
+      "id": "native.apple.18050bc2867c5994"
     },
     {
       "kind": "conditional-branch",
@@ -15191,7 +15191,7 @@
       "path": "apps/ios/Sources/Voice/TalkGatewayPermissionState.swift",
       "source": "Missing \\(scope)",
       "surface": "apple",
-      "id": "native.apple.1b7c66d315581f73"
+      "id": "native.apple.d766aa08919787b4"
     },
     {
       "kind": "conditional-branch",
@@ -15199,7 +15199,7 @@
       "path": "apps/ios/Sources/Voice/TalkGatewayPermissionState.swift",
       "source": "Requesting approval",
       "surface": "apple",
-      "id": "native.apple.08acd077aaacb96f"
+      "id": "native.apple.fd1bb0c5e7d50665"
     },
     {
       "kind": "conditional-branch",
@@ -15207,7 +15207,7 @@
       "path": "apps/ios/Sources/Voice/TalkGatewayPermissionState.swift",
       "source": "Approval requested",
       "surface": "apple",
-      "id": "native.apple.f9bc177bff07a6d4"
+      "id": "native.apple.d26d3cadd2e08dbe"
     },
     {
       "kind": "conditional-branch",
@@ -15215,7 +15215,7 @@
       "path": "apps/ios/Sources/Voice/TalkGatewayPermissionState.swift",
       "source": "Request failed",
       "surface": "apple",
-      "id": "native.apple.9d92e1e15bf191d9"
+      "id": "native.apple.c9ea3d5d08bf598b"
     },
     {
       "kind": "conditional-branch",
@@ -15223,7 +15223,7 @@
       "path": "apps/ios/Sources/Voice/TalkGatewayPermissionState.swift",
       "source": "API key missing",
       "surface": "apple",
-      "id": "native.apple.8512935c96c4a2e2"
+      "id": "native.apple.f235a9d4adb4940f"
     },
     {
       "kind": "conditional-branch",
@@ -15231,7 +15231,7 @@
       "path": "apps/ios/Sources/Voice/TalkGatewayPermissionState.swift",
       "source": "Load failed",
       "surface": "apple",
-      "id": "native.apple.0a0e11e7aefde770"
+      "id": "native.apple.cd6fbd46d3f737e1"
     },
     {
       "kind": "conditional-branch",
@@ -15255,7 +15255,7 @@
       "path": "apps/ios/Sources/Voice/TalkModeGatewayConfig.swift",
       "source": "Gateway Default",
       "surface": "apple",
-      "id": "native.apple.8b95eb816538a735"
+      "id": "native.apple.e5f40026770d4fba"
     },
     {
       "kind": "conditional-branch",
@@ -15263,7 +15263,7 @@
       "path": "apps/ios/Sources/Voice/TalkModeGatewayConfig.swift",
       "source": "ElevenLabs",
       "surface": "apple",
-      "id": "native.apple.12f6c5d01ca2cc0e"
+      "id": "native.apple.5dc98e7ec544c522"
     },
     {
       "kind": "conditional-branch",
@@ -15271,7 +15271,7 @@
       "path": "apps/ios/Sources/Voice/TalkModeGatewayConfig.swift",
       "source": "Realtime-2 (OpenAI)",
       "surface": "apple",
-      "id": "native.apple.61beb986ac24f37b"
+      "id": "native.apple.f1a267ebaff4cf7b"
     },
     {
       "kind": "conditional-branch",
@@ -15279,7 +15279,7 @@
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Offline",
       "surface": "apple",
-      "id": "native.apple.c09f4e3bbef8177a"
+      "id": "native.apple.cdf5ea9b1001d6c5"
     },
     {
       "kind": "conditional-branch",
@@ -15287,7 +15287,7 @@
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Ready",
       "surface": "apple",
-      "id": "native.apple.5839cdb826c12c71"
+      "id": "native.apple.7d021b4cdcd3ee81"
     },
     {
       "kind": "conditional-branch",
@@ -15295,7 +15295,7 @@
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Listening",
       "surface": "apple",
-      "id": "native.apple.794c5c98f3a4238d"
+      "id": "native.apple.76b5706e02403f25"
     },
     {
       "kind": "conditional-branch",
@@ -15303,7 +15303,7 @@
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speech error: \\(msg)",
       "surface": "apple",
-      "id": "native.apple.0b35fc3b0b221098"
+      "id": "native.apple.29b061ea9ee317c4"
     },
     {
       "kind": "conditional-branch",
@@ -15311,7 +15311,7 @@
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Aborted",
       "surface": "apple",
-      "id": "native.apple.96c7457cafa7dd47"
+      "id": "native.apple.e428ad2976011640"
     },
     {
       "kind": "conditional-branch",
@@ -15319,7 +15319,7 @@
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Chat error",
       "surface": "apple",
-      "id": "native.apple.7c027ae095940485"
+      "id": "native.apple.1caf5dda2d79880b"
     },
     {
       "kind": "conditional-branch",
@@ -15335,7 +15335,7 @@
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Native",
       "surface": "apple",
-      "id": "native.apple.c48dc51b49089432"
+      "id": "native.apple.b52d0d9dee6cc8e9"
     },
     {
       "kind": "conditional-branch",
@@ -15343,7 +15343,7 @@
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Native WebRTC",
       "surface": "apple",
-      "id": "native.apple.b0eb8a8cad908166"
+      "id": "native.apple.34ab07cdf4ffe1ef"
     },
     {
       "kind": "ui-call",
@@ -15351,7 +15351,7 @@
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Request ID",
       "surface": "apple",
-      "id": "native.apple.0189269b6a863dc2"
+      "id": "native.apple.64602baa14e2bcfd"
     },
     {
       "kind": "ui-call",
@@ -15359,7 +15359,7 @@
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Sending...",
       "surface": "apple",
-      "id": "native.apple.f9d69f27f9d7f4de"
+      "id": "native.apple.6abcf981b74965dc"
     },
     {
       "kind": "ui-call",
@@ -15367,7 +15367,7 @@
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Retry",
       "surface": "apple",
-      "id": "native.apple.0c5336129f70faed"
+      "id": "native.apple.5902a95299b5174b"
     },
     {
       "kind": "conditional-branch",
@@ -15375,7 +15375,7 @@
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Sending approval request",
       "surface": "apple",
-      "id": "native.apple.7b23f0a89d3ad411"
+      "id": "native.apple.1f30a51f2efde8ca"
     },
     {
       "kind": "conditional-branch",
@@ -15383,7 +15383,7 @@
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Approval sent",
       "surface": "apple",
-      "id": "native.apple.55db7317a2542e51"
+      "id": "native.apple.1a0030c6f298824a"
     },
     {
       "kind": "conditional-branch",
@@ -15391,7 +15391,7 @@
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Could not request approval",
       "surface": "apple",
-      "id": "native.apple.06330f62ab254a0e"
+      "id": "native.apple.9772d3aa1e771b30"
     },
     {
       "kind": "conditional-branch",
@@ -15399,7 +15399,7 @@
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Enable Talk",
       "surface": "apple",
-      "id": "native.apple.6580d3d1cdda682d"
+      "id": "native.apple.95a81f83a644d8ec"
     },
     {
       "kind": "conditional-branch",
@@ -15407,7 +15407,7 @@
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Sending a new pairing request to your gateway...",
       "surface": "apple",
-      "id": "native.apple.abbfc1ba85a230b4"
+      "id": "native.apple.10123e7cd19ed9fc"
     },
     {
       "kind": "conditional-branch",
@@ -15415,7 +15415,7 @@
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Approve this request on your gateway. Talk will start automatically when approval lands.",
       "surface": "apple",
-      "id": "native.apple.2880deb53ea2fd86"
+      "id": "native.apple.e37dba5567f0691e"
     },
     {
       "kind": "conditional-branch",
@@ -15431,7 +15431,7 @@
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Request Again",
       "surface": "apple",
-      "id": "native.apple.88b0a2e2986fcebf"
+      "id": "native.apple.0cc36971509f7d3b"
     },
     {
       "kind": "conditional-branch",
@@ -15439,7 +15439,7 @@
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Send Approval Request",
       "surface": "apple",
-      "id": "native.apple.5a3faae3472b4b86"
+      "id": "native.apple.6f8a589d1a3dd2c1"
     },
     {
       "kind": "conditional-branch",
@@ -15447,7 +15447,7 @@
       "path": "apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift",
       "source": "Asking OpenClaw",
       "surface": "apple",
-      "id": "native.apple.1065cfe92d7c1eb6"
+      "id": "native.apple.d05a2230509ea290"
     },
     {
       "kind": "conditional-branch",
@@ -15455,7 +15455,7 @@
       "path": "apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift",
       "source": "Updating OpenClaw",
       "surface": "apple",
-      "id": "native.apple.d2db26b3bb266491"
+      "id": "native.apple.e16d8f941f841046"
     },
     {
       "kind": "conditional-branch",
@@ -15463,7 +15463,7 @@
       "path": "apps/ios/Sources/Voice/VoiceWakeManager.swift",
       "source": "Off",
       "surface": "apple",
-      "id": "native.apple.b6bc54876f20104f"
+      "id": "native.apple.44e57b0ab0a141a4"
     },
     {
       "kind": "conditional-branch",
@@ -15471,7 +15471,7 @@
       "path": "apps/ios/Sources/Voice/VoiceWakeManager.swift",
       "source": "Paused",
       "surface": "apple",
-      "id": "native.apple.5590d661cdc81fbf"
+      "id": "native.apple.b1c79b0219df9811"
     },
     {
       "kind": "plist-string",
@@ -15479,7 +15479,7 @@
       "path": "apps/ios/WatchApp/Info.plist",
       "source": "OpenClaw connects this Apple Watch directly to your Gateway on trusted local networks.",
       "surface": "apple",
-      "id": "native.apple.12a4a51d251f65c0"
+      "id": "native.apple.646968ab814b22e8"
     },
     {
       "kind": "conditional-branch",
@@ -15519,7 +15519,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchDirectNode.swift",
       "source": "Ready to connect",
       "surface": "apple",
-      "id": "native.apple.d4c7af4a7bfeb382"
+      "id": "native.apple.b89a692d71bea552"
     },
     {
       "kind": "conditional-branch",
@@ -15527,7 +15527,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchDirectNode.swift",
       "source": "Direct connection is off",
       "surface": "apple",
-      "id": "native.apple.01062f110734602f"
+      "id": "native.apple.f3ab5c3a788b1867"
     },
     {
       "kind": "conditional-branch",
@@ -15535,7 +15535,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchDirectNode.swift",
       "source": "Use iPhone Settings to enable direct connection.",
       "surface": "apple",
-      "id": "native.apple.0e0763442f318e2f"
+      "id": "native.apple.a363367c5a190289"
     },
     {
       "kind": "conditional-branch",
@@ -15567,7 +15567,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Talk to Claw",
       "surface": "apple",
-      "id": "native.apple.732051c3e897a9f1"
+      "id": "native.apple.ea2178198f6c58d3"
     },
     {
       "kind": "ui-named-argument",
@@ -15575,7 +15575,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "What needs you",
       "surface": "apple",
-      "id": "native.apple.73d98baeb297e2fc"
+      "id": "native.apple.530a2a113d5ea6fb"
     },
     {
       "kind": "ui-named-argument",
@@ -15583,7 +15583,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Caught up",
       "surface": "apple",
-      "id": "native.apple.c10e2d4eaebd38e8"
+      "id": "native.apple.ff436bd6a6461e21"
     },
     {
       "kind": "conditional-branch",
@@ -15591,7 +15591,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "No chats or approvals need you",
       "surface": "apple",
-      "id": "native.apple.477c0403c6734d0a"
+      "id": "native.apple.1d4017cae81c01dd"
     },
     {
       "kind": "ui-named-argument",
@@ -15599,7 +15599,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Continue on iPhone",
       "surface": "apple",
-      "id": "native.apple.6a2c7f809c734c45"
+      "id": "native.apple.bb76fa1eb305acb2"
     },
     {
       "kind": "ui-named-argument",
@@ -15607,7 +15607,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Chat",
       "surface": "apple",
-      "id": "native.apple.a974845eb4fcc692"
+      "id": "native.apple.1da9d8f97ddb7b17"
     },
     {
       "kind": "conditional-branch",
@@ -15615,7 +15615,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Nothing waiting",
       "surface": "apple",
-      "id": "native.apple.dc532fb77a310766"
+      "id": "native.apple.e66a8bd97c13c56c"
     },
     {
       "kind": "ui-named-argument",
@@ -15623,7 +15623,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Approval needed",
       "surface": "apple",
-      "id": "native.apple.d740d67943737c80"
+      "id": "native.apple.1516f8433fd14dd8"
     },
     {
       "kind": "ui-modifier",
@@ -15671,7 +15671,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Review again",
       "surface": "apple",
-      "id": "native.apple.373973b577f97d63"
+      "id": "native.apple.dfc4aba2a4c89fda"
     },
     {
       "kind": "ui-named-argument",
@@ -15679,7 +15679,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Open all approvals",
       "surface": "apple",
-      "id": "native.apple.6fc58b4047340605"
+      "id": "native.apple.ae2140c5d6eb326a"
     },
     {
       "kind": "conditional-branch",
@@ -15687,7 +15687,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Direct Gateway",
       "surface": "apple",
-      "id": "native.apple.577dd5b3738b6aec"
+      "id": "native.apple.d2411ef9ed767185"
     },
     {
       "kind": "conditional-branch",
@@ -15695,7 +15695,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Watch node online",
       "surface": "apple",
-      "id": "native.apple.b5ac093277f18109"
+      "id": "native.apple.6835fa5b40e65443"
     },
     {
       "kind": "conditional-branch",
@@ -15703,7 +15703,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Direct",
       "surface": "apple",
-      "id": "native.apple.82fa10a36cbd5773"
+      "id": "native.apple.86219fbb9685d9c2"
     },
     {
       "kind": "conditional-branch",
@@ -15711,7 +15711,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Setup",
       "surface": "apple",
-      "id": "native.apple.e0f952b8832b1ca4"
+      "id": "native.apple.c89dfb83444e6662"
     },
     {
       "kind": "conditional-branch",
@@ -15719,7 +15719,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Uses Wi-Fi or cellular while OpenClaw is active",
       "surface": "apple",
-      "id": "native.apple.c7d87356e6cdb374"
+      "id": "native.apple.709a8396352de098"
     },
     {
       "kind": "conditional-branch",
@@ -15727,7 +15727,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Open iPhone Settings → Apple Watch",
       "surface": "apple",
-      "id": "native.apple.08583448d9b2455e"
+      "id": "native.apple.fcc3c10609d70bd0"
     },
     {
       "kind": "conditional-branch",
@@ -15735,7 +15735,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Offline",
       "surface": "apple",
-      "id": "native.apple.f748dad8f2ce22ae"
+      "id": "native.apple.a956cb124e12ad8e"
     },
     {
       "kind": "conditional-branch",
@@ -15743,7 +15743,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Online",
       "surface": "apple",
-      "id": "native.apple.60cdcd03d8b51965"
+      "id": "native.apple.ad6d8fa55d4850ff"
     },
     {
       "kind": "ui-named-argument-multiline",
@@ -15751,7 +15751,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Direct mode supports device info, status, and notifications. Chat, Talk, and approvals still use the iPhone.",
       "surface": "apple",
-      "id": "native.apple.088f07637cc141c9"
+      "id": "native.apple.de3c38f6c39cbc63"
     },
     {
       "kind": "ui-call",
@@ -15759,7 +15759,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Direct connection",
       "surface": "apple",
-      "id": "native.apple.d7000ec82e411988"
+      "id": "native.apple.4af340e468b815ec"
     },
     {
       "kind": "ui-named-argument",
@@ -15767,7 +15767,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Forget direct setup",
       "surface": "apple",
-      "id": "native.apple.72270e305e05cf02"
+      "id": "native.apple.11f8c28ee110627c"
     },
     {
       "kind": "ui-named-argument",
@@ -15775,7 +15775,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "The iPhone securely sends a one-time setup code. Existing relay features stay available.",
       "surface": "apple",
-      "id": "native.apple.aef0e6d8d3fa0903"
+      "id": "native.apple.9716a20353b33e69"
     },
     {
       "kind": "conditional-branch",
@@ -15783,7 +15783,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "\\(self.chatCount)",
       "surface": "apple",
-      "id": "native.apple.00d2c14f9f635100"
+      "id": "native.apple.1efbd6b721049855"
     },
     {
       "kind": "conditional-branch",
@@ -15791,7 +15791,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "\\(self.approvalCount)",
       "surface": "apple",
-      "id": "native.apple.c3f1a9e79f6e0e97"
+      "id": "native.apple.2a25bbc529b4249b"
     },
     {
       "kind": "conditional-branch",
@@ -15799,7 +15799,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "AI agent online",
       "surface": "apple",
-      "id": "native.apple.eb8d87882ee9d932"
+      "id": "native.apple.46c94f3d910a276f"
     },
     {
       "kind": "conditional-branch",
@@ -15807,7 +15807,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Reconnect on iPhone",
       "surface": "apple",
-      "id": "native.apple.1fed99e43ac07133"
+      "id": "native.apple.8b053b41b060e0f9"
     },
     {
       "kind": "conditional-branch",
@@ -15815,7 +15815,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Pairing",
       "surface": "apple",
-      "id": "native.apple.a240e731ca37dbdd"
+      "id": "native.apple.d13292625f1a084d"
     },
     {
       "kind": "conditional-branch",
@@ -15823,7 +15823,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Running",
       "surface": "apple",
-      "id": "native.apple.381d10256d49d0e0"
+      "id": "native.apple.e24ef2f9292edf69"
     },
     {
       "kind": "conditional-branch",
@@ -15831,7 +15831,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Ready for quick actions",
       "surface": "apple",
-      "id": "native.apple.643a9402efef3924"
+      "id": "native.apple.302b505eea188676"
     },
     {
       "kind": "conditional-branch",
@@ -15839,7 +15839,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Waiting for iPhone sync",
       "surface": "apple",
-      "id": "native.apple.e927c0240dd8ab4b"
+      "id": "native.apple.08f531eebdfc9257"
     },
     {
       "kind": "conditional-branch",
@@ -15847,7 +15847,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "1 approval waiting",
       "surface": "apple",
-      "id": "native.apple.6a607ff2270f7234"
+      "id": "native.apple.516ff7d3edd7acfd"
     },
     {
       "kind": "conditional-branch",
@@ -15855,7 +15855,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "\\(self.approvalCount) approvals",
       "surface": "apple",
-      "id": "native.apple.046272dd8fbd45cd"
+      "id": "native.apple.5942c98ade8335a5"
     },
     {
       "kind": "conditional-branch",
@@ -15863,7 +15863,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Decide from watch",
       "surface": "apple",
-      "id": "native.apple.c938aa514b77854a"
+      "id": "native.apple.cd0c842b9918ff9a"
     },
     {
       "kind": "conditional-branch",
@@ -15871,7 +15871,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "No approvals",
       "surface": "apple",
-      "id": "native.apple.0201a3557b1a8a4a"
+      "id": "native.apple.d035f467078f6569"
     },
     {
       "kind": "conditional-branch",
@@ -15879,7 +15879,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "1 recent message",
       "surface": "apple",
-      "id": "native.apple.84674ce9751faffd"
+      "id": "native.apple.3e73492ae085f697"
     },
     {
       "kind": "conditional-branch",
@@ -15887,7 +15887,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "\\(self.chatCount) recent messages",
       "surface": "apple",
-      "id": "native.apple.1495106ee09cc268"
+      "id": "native.apple.ab05591e87f42cda"
     },
     {
       "kind": "conditional-branch",
@@ -15895,7 +15895,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "No messages synced",
       "surface": "apple",
-      "id": "native.apple.2b7032e200b1d495"
+      "id": "native.apple.d7037443e402c9c2"
     },
     {
       "kind": "conditional-branch",
@@ -15903,7 +15903,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Synced",
       "surface": "apple",
-      "id": "native.apple.5e32bb776eec9d39"
+      "id": "native.apple.18a4876f83b0bebc"
     },
     {
       "kind": "conditional-branch",
@@ -15911,7 +15911,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Waiting for iPhone",
       "surface": "apple",
-      "id": "native.apple.e3a9d9067b1ccf6a"
+      "id": "native.apple.ebb1c452cd5139f8"
     },
     {
       "kind": "ui-named-argument",
@@ -15919,7 +15919,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Inbox",
       "surface": "apple",
-      "id": "native.apple.fadaa0ca97ba0c43"
+      "id": "native.apple.9a5cc2d5d1a0d111"
     },
     {
       "kind": "ui-named-argument",
@@ -15927,7 +15927,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "OpenClaw",
       "surface": "apple",
-      "id": "native.apple.3fdc651e507de84b"
+      "id": "native.apple.e54d954151312621"
     },
     {
       "kind": "ui-call",
@@ -15959,7 +15959,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "You",
       "surface": "apple",
-      "id": "native.apple.337c2164038d1a5a"
+      "id": "native.apple.7e75a9f9ccac6339"
     },
     {
       "kind": "conditional-branch",
@@ -15967,7 +15967,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "System",
       "surface": "apple",
-      "id": "native.apple.a8cfe6cb5bc33c21"
+      "id": "native.apple.6bdcf6e7dcc633d9"
     },
     {
       "kind": "ui-named-argument",
@@ -15975,7 +15975,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.c1de056da9ee1b27"
+      "id": "native.apple.ae726bf4a1a46259"
     },
     {
       "kind": "ui-call",
@@ -15983,7 +15983,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "No chat synced",
       "surface": "apple",
-      "id": "native.apple.5f277949dc42b1c3"
+      "id": "native.apple.4bfedcfebb4ac336"
     },
     {
       "kind": "ui-call",
@@ -15991,7 +15991,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Tap the message pill below to start from your watch.",
       "surface": "apple",
-      "id": "native.apple.9119276e0f1b473d"
+      "id": "native.apple.7363b130792ae2de"
     },
     {
       "kind": "ui-call",
@@ -15999,7 +15999,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Message OpenClaw",
       "surface": "apple",
-      "id": "native.apple.b816e4b9e492ae6c"
+      "id": "native.apple.068d84c26a524222"
     },
     {
       "kind": "ui-named-argument",
@@ -16007,7 +16007,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Approvals",
       "surface": "apple",
-      "id": "native.apple.f3ccbf04d80cf021"
+      "id": "native.apple.d07b6a8fd99ce03d"
     },
     {
       "kind": "ui-named-argument",
@@ -16015,7 +16015,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Clear",
       "surface": "apple",
-      "id": "native.apple.fde372bcd0305149"
+      "id": "native.apple.095c77bdc7f04529"
     },
     {
       "kind": "ui-named-argument",
@@ -16023,7 +16023,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "No approvals waiting",
       "surface": "apple",
-      "id": "native.apple.30184946721b66e9"
+      "id": "native.apple.170b8f490c219f8a"
     },
     {
       "kind": "ui-named-argument",
@@ -16031,7 +16031,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Approval",
       "surface": "apple",
-      "id": "native.apple.ef3ff87537a32741"
+      "id": "native.apple.af4c704413af1944"
     },
     {
       "kind": "conditional-branch",
@@ -16071,7 +16071,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Deny",
       "surface": "apple",
-      "id": "native.apple.096fb24013ac5455"
+      "id": "native.apple.5b9b5f18b19cd65a"
     },
     {
       "kind": "conditional-branch",
@@ -16087,7 +16087,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "OpenClaw",
       "surface": "apple",
-      "id": "native.apple.5ac0c79487a492b4"
+      "id": "native.apple.4d3f983a1ea909ee"
     },
     {
       "kind": "ui-call",
@@ -16095,7 +16095,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Menu bar companion for notifications, screenshots, and privileged agent actions.",
       "surface": "apple",
-      "id": "native.apple.95b5730738a28d71"
+      "id": "native.apple.629596bfcfcc8b7e"
     },
     {
       "kind": "ui-named-argument",
@@ -16103,7 +16103,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Website",
       "surface": "apple",
-      "id": "native.apple.63e488db74990ce5"
+      "id": "native.apple.de49b5a079d1f073"
     },
     {
       "kind": "ui-named-argument",
@@ -16111,7 +16111,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Docs",
       "surface": "apple",
-      "id": "native.apple.a6ce39368a3dcba9"
+      "id": "native.apple.6eb3516132d8b8d0"
     },
     {
       "kind": "ui-named-argument",
@@ -16119,7 +16119,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "GitHub",
       "surface": "apple",
-      "id": "native.apple.953dd3deb91be186"
+      "id": "native.apple.b99853fc93521b66"
     },
     {
       "kind": "ui-named-argument",
@@ -16127,7 +16127,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Discord",
       "surface": "apple",
-      "id": "native.apple.3f2971f0141e1cf6"
+      "id": "native.apple.55eb5a5afc7ed0b6"
     },
     {
       "kind": "ui-call",
@@ -16135,7 +16135,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Check for updates automatically",
       "surface": "apple",
-      "id": "native.apple.32ce87cf5adca95c"
+      "id": "native.apple.4614b81fb158704d"
     },
     {
       "kind": "ui-call",
@@ -16143,7 +16143,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Check for Updates…",
       "surface": "apple",
-      "id": "native.apple.5e0de63984ca40c9"
+      "id": "native.apple.86d66ab7a1cdd785"
     },
     {
       "kind": "ui-call",
@@ -16151,7 +16151,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Updates unavailable in this build.",
       "surface": "apple",
-      "id": "native.apple.ddec1d4e5e5b43cb"
+      "id": "native.apple.96d32f2f282caf28"
     },
     {
       "kind": "ui-call",
@@ -16159,7 +16159,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "© 2026 OpenClaw Foundation — MIT License.",
       "surface": "apple",
-      "id": "native.apple.4ec07761308f7f50"
+      "id": "native.apple.44b8ba7768ea2e7b"
     },
     {
       "kind": "ui-call",
@@ -16167,7 +16167,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Copy full commit hash",
       "surface": "apple",
-      "id": "native.apple.37661ff1af405580"
+      "id": "native.apple.2f1ed8af4e606d51"
     },
     {
       "kind": "ui-call",
@@ -16175,7 +16175,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Copy build info",
       "surface": "apple",
-      "id": "native.apple.2916df231993897d"
+      "id": "native.apple.be3b629054aea291"
     },
     {
       "kind": "ui-call",
@@ -16183,7 +16183,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Copy Commit",
       "surface": "apple",
-      "id": "native.apple.f870085ee74e9885"
+      "id": "native.apple.d13d41e610c7ba3d"
     },
     {
       "kind": "ui-call",
@@ -16191,7 +16191,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Copy Build Info",
       "surface": "apple",
-      "id": "native.apple.be5af46a63f9d1da"
+      "id": "native.apple.8a09595137a100f3"
     },
     {
       "kind": "ui-call",
@@ -16199,7 +16199,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Unavailable",
       "surface": "apple",
-      "id": "native.apple.ddd4228d93680320"
+      "id": "native.apple.dfd7e13a7310c757"
     },
     {
       "kind": "ui-call",
@@ -16207,7 +16207,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Version \\(version), commit \\(commit), built \\(built), timestamp \\(timestamp)",
       "surface": "apple",
-      "id": "native.apple.0e7c932e0d8fb288"
+      "id": "native.apple.5c99acde65040d0a"
     },
     {
       "kind": "ui-call",
@@ -16215,7 +16215,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Version \\(version), commit \\(commit), build date unavailable",
       "surface": "apple",
-      "id": "native.apple.d4ef93e8ebca2d55"
+      "id": "native.apple.ee173a469b20fe4c"
     },
     {
       "kind": "ui-call",
@@ -16223,7 +16223,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Version \\(version), commit unavailable, built \\(built), timestamp \\(timestamp)",
       "surface": "apple",
-      "id": "native.apple.f67aac55a340fda0"
+      "id": "native.apple.9380d0a152f7a3b7"
     },
     {
       "kind": "ui-call",
@@ -16231,7 +16231,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Version \\(version), commit unavailable, build date unavailable",
       "surface": "apple",
-      "id": "native.apple.76472e074114886c"
+      "id": "native.apple.483fcc32d8f0044b"
     },
     {
       "kind": "ui-call",
@@ -16239,7 +16239,7 @@
       "path": "apps/macos/Sources/OpenClaw/AgentEventsWindow.swift",
       "source": "Agent Events",
       "surface": "apple",
-      "id": "native.apple.c6148a145aa87e36"
+      "id": "native.apple.da7667b4cfb4e60f"
     },
     {
       "kind": "ui-call",
@@ -16247,7 +16247,7 @@
       "path": "apps/macos/Sources/OpenClaw/AgentEventsWindow.swift",
       "source": "Clear",
       "surface": "apple",
-      "id": "native.apple.c8d2fe5403e9df00"
+      "id": "native.apple.52d1518b0987d6af"
     },
     {
       "kind": "conditional-branch",
@@ -16255,7 +16255,7 @@
       "path": "apps/macos/Sources/OpenClaw/AppState.swift",
       "source": "\\(user)@\\(host)",
       "surface": "apple",
-      "id": "native.apple.9cd2ced909f0952d"
+      "id": "native.apple.dc69311b669398ed"
     },
     {
       "kind": "conditional-branch",
@@ -16263,7 +16263,7 @@
       "path": "apps/macos/Sources/OpenClaw/AppState.swift",
       "source": "\\(user)@\\(host):\\(port)",
       "surface": "apple",
-      "id": "native.apple.69b64bb81b900cc4"
+      "id": "native.apple.acb2c7bacc8a9416"
     },
     {
       "kind": "ui-call",
@@ -16519,7 +16519,7 @@
       "path": "apps/macos/Sources/OpenClaw/CLIInstaller.swift",
       "source": "OpenClaw Gateway \\(version) is ready.",
       "surface": "apple",
-      "id": "native.apple.cfc2509b8bbcf1d7"
+      "id": "native.apple.d56c7e42cf2c4813"
     },
     {
       "kind": "conditional-branch",
@@ -16527,7 +16527,7 @@
       "path": "apps/macos/Sources/OpenClaw/CLIInstaller.swift",
       "source": "OpenClaw Gateway is not installed yet.",
       "surface": "apple",
-      "id": "native.apple.9b767e46895714f9"
+      "id": "native.apple.75d3c619b85985dd"
     },
     {
       "kind": "conditional-branch",
@@ -16535,7 +16535,7 @@
       "path": "apps/macos/Sources/OpenClaw/CLIInstaller.swift",
       "source": "The OpenClaw Gateway could not be verified. Setup will repair it.",
       "surface": "apple",
-      "id": "native.apple.b4dc58a1b294e140"
+      "id": "native.apple.ecb715a65dcb04b3"
     },
     {
       "kind": "conditional-branch",
@@ -16543,7 +16543,7 @@
       "path": "apps/macos/Sources/OpenClaw/CLIInstaller.swift",
       "source": "Gateway \\(found) does not match app \\(required). Setup will update it.",
       "surface": "apple",
-      "id": "native.apple.4088056ae7b0f3b4"
+      "id": "native.apple.93f35303954266b9"
     },
     {
       "kind": "conditional-branch",
@@ -16551,7 +16551,7 @@
       "path": "apps/macos/Sources/OpenClaw/CameraCaptureService.swift",
       "source": "Camera",
       "surface": "apple",
-      "id": "native.apple.6f14c557e2573526"
+      "id": "native.apple.d1e5eeb96a2882ee"
     },
     {
       "kind": "conditional-branch",
@@ -16559,7 +16559,7 @@
       "path": "apps/macos/Sources/OpenClaw/CameraCaptureService.swift",
       "source": "Microphone",
       "surface": "apple",
-      "id": "native.apple.40d3846b9b907a73"
+      "id": "native.apple.badeaf60e96929d3"
     },
     {
       "kind": "conditional-branch",
@@ -16575,7 +16575,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Enabled",
       "surface": "apple",
-      "id": "native.apple.90dacdcac6e6bd80"
+      "id": "native.apple.11f2d12dfe82dabb"
     },
     {
       "kind": "ui-call",
@@ -16583,7 +16583,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Unsupported field type.",
       "surface": "apple",
-      "id": "native.apple.198eae468f234acb"
+      "id": "native.apple.68c9b4ca6b4e34a6"
     },
     {
       "kind": "ui-call",
@@ -16591,7 +16591,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "No quick settings for this channel.",
       "surface": "apple",
-      "id": "native.apple.dbc78800d9f382b9"
+      "id": "native.apple.5b8318daab6c011a"
     },
     {
       "kind": "ui-call",
@@ -16599,7 +16599,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Use Config for account, guild, action, and policy details.",
       "surface": "apple",
-      "id": "native.apple.cbf7ef1afeae9ff8"
+      "id": "native.apple.da9ed95a558aa5ff"
     },
     {
       "kind": "ui-call",
@@ -16607,7 +16607,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Select…",
       "surface": "apple",
-      "id": "native.apple.71dc5674a2bda6d1"
+      "id": "native.apple.02806dc0ed3038fb"
     },
     {
       "kind": "ui-call",
@@ -16615,7 +16615,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Extra entries",
       "surface": "apple",
-      "id": "native.apple.ce17aea717f97f4d"
+      "id": "native.apple.75b5255c0a940da0"
     },
     {
       "kind": "ui-call",
@@ -16623,7 +16623,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "No extra entries yet.",
       "surface": "apple",
-      "id": "native.apple.7b5de9206729e420"
+      "id": "native.apple.bb804e0a6f1374e8"
     },
     {
       "kind": "ui-call",
@@ -16631,7 +16631,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Key",
       "surface": "apple",
-      "id": "native.apple.017ff7fa7b3e26c4"
+      "id": "native.apple.4c33cb6e37da5de2"
     },
     {
       "kind": "ui-call",
@@ -16639,7 +16639,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Remove",
       "surface": "apple",
-      "id": "native.apple.18b74467bb3a710d"
+      "id": "native.apple.7bf77a51527eb799"
     },
     {
       "kind": "ui-call",
@@ -16647,7 +16647,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Add",
       "surface": "apple",
-      "id": "native.apple.b237bc0cf8595b6d"
+      "id": "native.apple.b240832d93a650c3"
     },
     {
       "kind": "ui-named-argument",
@@ -16655,7 +16655,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Loading channel settings",
       "surface": "apple",
-      "id": "native.apple.cbe5124df0a065b4"
+      "id": "native.apple.8d3a4f411b2d157c"
     },
     {
       "kind": "ui-call",
@@ -16663,7 +16663,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Configuration",
       "surface": "apple",
-      "id": "native.apple.468ae6c91ff752d8"
+      "id": "native.apple.066d89a44ba77325"
     },
     {
       "kind": "ui-named-argument",
@@ -16671,7 +16671,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Schema unavailable",
       "surface": "apple",
-      "id": "native.apple.18ae184a7dad6464"
+      "id": "native.apple.0e113b32a05c554d"
     },
     {
       "kind": "ui-named-argument",
@@ -16679,7 +16679,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "OpenClaw could not load editable settings for this channel.",
       "surface": "apple",
-      "id": "native.apple.81435e60c0b78093"
+      "id": "native.apple.9a58a96b30b47d0f"
     },
     {
       "kind": "ui-call",
@@ -16687,7 +16687,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+ChannelSections.swift",
       "source": "Logout",
       "surface": "apple",
-      "id": "native.apple.f74dfc887ee4f936"
+      "id": "native.apple.2e43bd1988926223"
     },
     {
       "kind": "ui-call",
@@ -16695,7 +16695,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+ChannelSections.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.c6587031bbc3e4e0"
+      "id": "native.apple.3c1087f079d77ddb"
     },
     {
       "kind": "ui-call",
@@ -16703,7 +16703,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+ChannelSections.swift",
       "source": "Linking",
       "surface": "apple",
-      "id": "native.apple.af173734eb7ad231"
+      "id": "native.apple.681a46d16196f1be"
     },
     {
       "kind": "ui-call",
@@ -16711,7 +16711,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+ChannelSections.swift",
       "source": "Show QR",
       "surface": "apple",
-      "id": "native.apple.b1d834b36062043d"
+      "id": "native.apple.ee76aa477b01f407"
     },
     {
       "kind": "ui-call",
@@ -16719,7 +16719,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+ChannelSections.swift",
       "source": "Relink",
       "surface": "apple",
-      "id": "native.apple.eecd32848403c3c4"
+      "id": "native.apple.e5c723e9881c1d05"
     },
     {
       "kind": "ui-call",
@@ -16727,7 +16727,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+ChannelSections.swift",
       "source": "Save",
       "surface": "apple",
-      "id": "native.apple.35729b2cd003a68a"
+      "id": "native.apple.5f31b36d714b0aa7"
     },
     {
       "kind": "ui-call",
@@ -16735,7 +16735,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+ChannelSections.swift",
       "source": "Reload",
       "surface": "apple",
-      "id": "native.apple.91dcf68eb2e49095"
+      "id": "native.apple.ea898eb7ffa40086"
     },
     {
       "kind": "ui-call",
@@ -16743,7 +16743,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+View.swift",
       "source": "Configured",
       "surface": "apple",
-      "id": "native.apple.7d0c11e9c4314931"
+      "id": "native.apple.6092b0813210678e"
     },
     {
       "kind": "ui-call",
@@ -16751,7 +16751,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+View.swift",
       "source": "Available",
       "surface": "apple",
-      "id": "native.apple.5a468760837c956b"
+      "id": "native.apple.3908d09d66db5c68"
     },
     {
       "kind": "ui-call",
@@ -16759,7 +16759,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+View.swift",
       "source": "Channels",
       "surface": "apple",
-      "id": "native.apple.bf4f425bd0dc0c74"
+      "id": "native.apple.0cf13d9e65ee5ac4"
     },
     {
       "kind": "ui-call",
@@ -16767,7 +16767,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+View.swift",
       "source": "Select a channel to view status and settings.",
       "surface": "apple",
-      "id": "native.apple.4d0dfdb0ac98fb47"
+      "id": "native.apple.1e5f6b8165df7699"
     },
     {
       "kind": "ui-call",
@@ -16775,7 +16775,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+View.swift",
       "source": "Last check \\(self.channelLastCheckText(channel))",
       "surface": "apple",
-      "id": "native.apple.b4bc7f2d70f7d6f6"
+      "id": "native.apple.5075aef1de390771"
     },
     {
       "kind": "ui-call",
@@ -16783,7 +16783,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+View.swift",
       "source": "Error",
       "surface": "apple",
-      "id": "native.apple.c05a9f1925dc6f02"
+      "id": "native.apple.3700c04b8dd4762f"
     },
     {
       "kind": "conditional-branch",
@@ -16799,7 +16799,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsStore+Lifecycle.swift",
       "source": "Logged out and cleared credentials.",
       "surface": "apple",
-      "id": "native.apple.313dabb10c37e00c"
+      "id": "native.apple.25f326f27ea64d36"
     },
     {
       "kind": "conditional-branch",
@@ -16807,7 +16807,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsStore+Lifecycle.swift",
       "source": "No WhatsApp session found.",
       "surface": "apple",
-      "id": "native.apple.b98078a5cac29eaf"
+      "id": "native.apple.cc44b98c938d7eab"
     },
     {
       "kind": "conditional-branch",
@@ -16815,7 +16815,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsStore+Lifecycle.swift",
       "source": "Telegram token cleared.",
       "surface": "apple",
-      "id": "native.apple.de729686d8ba05d6"
+      "id": "native.apple.ad138e64e962584d"
     },
     {
       "kind": "conditional-branch",
@@ -16823,7 +16823,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsStore+Lifecycle.swift",
       "source": "No Telegram token configured.",
       "surface": "apple",
-      "id": "native.apple.53f4d1e63fb7d589"
+      "id": "native.apple.bc2c079a3c0d8016"
     },
     {
       "kind": "ui-call",
@@ -16831,7 +16831,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "No config sections available.",
       "surface": "apple",
-      "id": "native.apple.0a65101d40a6704c"
+      "id": "native.apple.0efd499899ab17e9"
     },
     {
       "kind": "ui-call",
@@ -16839,7 +16839,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "Select a config section to view settings.",
       "surface": "apple",
-      "id": "native.apple.cb9d6dbd9d5b038c"
+      "id": "native.apple.f5b3d811bee4e27b"
     },
     {
       "kind": "ui-call",
@@ -16847,7 +16847,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "Unsaved changes",
       "surface": "apple",
-      "id": "native.apple.7eb0ce9d97e01663"
+      "id": "native.apple.560ab05f67d4aad9"
     },
     {
       "kind": "ui-call",
@@ -16855,7 +16855,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "Config",
       "surface": "apple",
-      "id": "native.apple.4042c565a6f65501"
+      "id": "native.apple.2ff772966bb46ccf"
     },
     {
       "kind": "conditional-branch",
@@ -16863,7 +16863,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "This tab is read-only in Nix mode. Edit config via Nix and rebuild.",
       "surface": "apple",
-      "id": "native.apple.e7afd1797978a4fd"
+      "id": "native.apple.5e41a954dfc83551"
     },
     {
       "kind": "conditional-branch",
@@ -16871,7 +16871,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
       "surface": "apple",
-      "id": "native.apple.8103e662c0e40760"
+      "id": "native.apple.70a98fb062cce821"
     },
     {
       "kind": "ui-call",
@@ -16879,7 +16879,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "Reload",
       "surface": "apple",
-      "id": "native.apple.a3465ec90e435ea9"
+      "id": "native.apple.df089b635f5e8e0f"
     },
     {
       "kind": "conditional-branch",
@@ -16887,7 +16887,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "Save",
       "surface": "apple",
-      "id": "native.apple.945e60a42bc8d782"
+      "id": "native.apple.695a47942f5cbaef"
     },
     {
       "kind": "conditional-branch",
@@ -16895,7 +16895,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "Saving…",
       "surface": "apple",
-      "id": "native.apple.194e47f6f849c1ce"
+      "id": "native.apple.d7dbdcf2aa25d251"
     },
     {
       "kind": "ui-call",
@@ -16903,7 +16903,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "Loading current values…",
       "surface": "apple",
-      "id": "native.apple.2efbb034dfb1c8f6"
+      "id": "native.apple.8312b288532c0342"
     },
     {
       "kind": "ui-call",
@@ -16911,7 +16911,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "Wildcard config entries are edited from their concrete key.",
       "surface": "apple",
-      "id": "native.apple.5d4cb34e9ab41e84"
+      "id": "native.apple.ad7a5ac108e51b3a"
     },
     {
       "kind": "ui-call",
@@ -16919,7 +16919,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "Retry",
       "surface": "apple",
-      "id": "native.apple.88b63f0b2ca895e6"
+      "id": "native.apple.d5fdba4e535fa3d2"
     },
     {
       "kind": "ui-call",
@@ -16927,7 +16927,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "Required",
       "surface": "apple",
-      "id": "native.apple.b77bd2f246efcbe1"
+      "id": "native.apple.a5e3a5e8f99f50ea"
     },
     {
       "kind": "ui-named-argument",
@@ -16935,7 +16935,7 @@
       "path": "apps/macos/Sources/OpenClaw/ContextMenuCardView.swift",
       "source": "Context",
       "surface": "apple",
-      "id": "native.apple.ff860c1c4be92ede"
+      "id": "native.apple.aa40b6794e2973bf"
     },
     {
       "kind": "ui-call",
@@ -16943,7 +16943,7 @@
       "path": "apps/macos/Sources/OpenClaw/ContextMenuCardView.swift",
       "source": "No active sessions",
       "surface": "apple",
-      "id": "native.apple.185e2d2285227daf"
+      "id": "native.apple.173d298c01fcfc44"
     },
     {
       "kind": "ui-call",
@@ -16951,7 +16951,7 @@
       "path": "apps/macos/Sources/OpenClaw/ContextMenuCardView.swift",
       "source": "main",
       "surface": "apple",
-      "id": "native.apple.285a3ac6017334f9"
+      "id": "native.apple.24837598afa71683"
     },
     {
       "kind": "ui-call",
@@ -16959,7 +16959,7 @@
       "path": "apps/macos/Sources/OpenClaw/ContextMenuCardView.swift",
       "source": "000k/000k",
       "surface": "apple",
-      "id": "native.apple.7d8890e2fc64e695"
+      "id": "native.apple.f16e48c1c0fd3872"
     },
     {
       "kind": "ui-call",
@@ -16967,7 +16967,7 @@
       "path": "apps/macos/Sources/OpenClaw/ContextRootMenuLabelView.swift",
       "source": "Context",
       "surface": "apple",
-      "id": "native.apple.ae89998eb6f436e0"
+      "id": "native.apple.42079ea1e74e5b4e"
     },
     {
       "kind": "ui-modifier",
@@ -16975,7 +16975,7 @@
       "path": "apps/macos/Sources/OpenClaw/ContextUsageBar.swift",
       "source": "Context usage",
       "surface": "apple",
-      "id": "native.apple.c8e1c903a53d1abc"
+      "id": "native.apple.2cec80203bf33687"
     },
     {
       "kind": "conditional-branch",
@@ -16983,7 +16983,7 @@
       "path": "apps/macos/Sources/OpenClaw/ControlChannel.swift",
       "source": "degraded: \\(message)",
       "surface": "apple",
-      "id": "native.apple.dac4643a71326e9b"
+      "id": "native.apple.23947c44a80ad86c"
     },
     {
       "kind": "conditional-branch",
@@ -16999,7 +16999,7 @@
       "path": "apps/macos/Sources/OpenClaw/CostUsageMenuView.swift",
       "source": "Today",
       "surface": "apple",
-      "id": "native.apple.47eb7fbdc9792b54"
+      "id": "native.apple.3738036b9840d0e0"
     },
     {
       "kind": "ui-call",
@@ -17007,7 +17007,7 @@
       "path": "apps/macos/Sources/OpenClaw/CostUsageMenuView.swift",
       "source": "Last \\(self.summary.days)d",
       "surface": "apple",
-      "id": "native.apple.ebfc6af133da68bf"
+      "id": "native.apple.fa327c274d8a37f2"
     },
     {
       "kind": "ui-call",
@@ -17015,7 +17015,7 @@
       "path": "apps/macos/Sources/OpenClaw/CostUsageMenuView.swift",
       "source": "Partial: \\(self.summary.totals.missingCostEntries) entries missing cost",
       "surface": "apple",
-      "id": "native.apple.936bfd42a2f08232"
+      "id": "native.apple.b5292a166ca26276"
     },
     {
       "kind": "ui-named-argument",
@@ -17023,7 +17023,7 @@
       "path": "apps/macos/Sources/OpenClaw/CrestodianSettings.swift",
       "source": "Crestodian",
       "surface": "apple",
-      "id": "native.apple.84f1d9ae4965cfe0"
+      "id": "native.apple.5d80cdbc0d3dddb2"
     },
     {
       "kind": "ui-named-argument-concatenated",
@@ -17039,7 +17039,7 @@
       "path": "apps/macos/Sources/OpenClaw/CrestodianSettings.swift",
       "source": "Chat",
       "surface": "apple",
-      "id": "native.apple.648423d89aec0c13"
+      "id": "native.apple.e6b5803c7696f248"
     },
     {
       "kind": "ui-call",
@@ -17047,7 +17047,7 @@
       "path": "apps/macos/Sources/OpenClaw/CrestodianSettings.swift",
       "source": "Tip: try “status”, “doctor”, “set default model …”, or “connect telegram”.",
       "surface": "apple",
-      "id": "native.apple.bd180b943ee89cfe"
+      "id": "native.apple.2c3fe9fd20f9bae5"
     },
     {
       "kind": "conditional-branch",
@@ -17055,7 +17055,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Edit cron job",
       "surface": "apple",
-      "id": "native.apple.779f488d2ddd9eaf"
+      "id": "native.apple.5625495307c01cb8"
     },
     {
       "kind": "conditional-branch",
@@ -17063,7 +17063,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "New cron job",
       "surface": "apple",
-      "id": "native.apple.33558c9ead40a7a1"
+      "id": "native.apple.486fb23d241ee744"
     },
     {
       "kind": "ui-call",
@@ -17071,7 +17071,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Name",
       "surface": "apple",
-      "id": "native.apple.f3e018806829cda3"
+      "id": "native.apple.ba4538d2a944365a"
     },
     {
       "kind": "ui-call",
@@ -17079,7 +17079,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Required (e.g. “Daily summary”)",
       "surface": "apple",
-      "id": "native.apple.d15ab158b3c13020"
+      "id": "native.apple.9f6b351b3c8413f1"
     },
     {
       "kind": "ui-call",
@@ -17087,7 +17087,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Description",
       "surface": "apple",
-      "id": "native.apple.5d3f6ae647ede805"
+      "id": "native.apple.b93691b2b0d5a2a7"
     },
     {
       "kind": "ui-call",
@@ -17095,7 +17095,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Optional notes",
       "surface": "apple",
-      "id": "native.apple.0e62d328b9b20553"
+      "id": "native.apple.a3f3769386767dfe"
     },
     {
       "kind": "ui-call",
@@ -17103,7 +17103,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Agent ID",
       "surface": "apple",
-      "id": "native.apple.6773dec468741604"
+      "id": "native.apple.e56fb7d4e4719305"
     },
     {
       "kind": "ui-call",
@@ -17111,7 +17111,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Optional (default agent)",
       "surface": "apple",
-      "id": "native.apple.16586aa545b687a0"
+      "id": "native.apple.b0ad9a4beafce7ea"
     },
     {
       "kind": "ui-call",
@@ -17119,7 +17119,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Enabled",
       "surface": "apple",
-      "id": "native.apple.eeba38110f1a3c12"
+      "id": "native.apple.38806eff2430a869"
     },
     {
       "kind": "ui-call",
@@ -17127,7 +17127,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Session target",
       "surface": "apple",
-      "id": "native.apple.bcc9d1eb3289bc25"
+      "id": "native.apple.99d43552f0d46fd0"
     },
     {
       "kind": "ui-call",
@@ -17135,7 +17135,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "main",
       "surface": "apple",
-      "id": "native.apple.3e408bf7fd913139"
+      "id": "native.apple.a712937d2757ec07"
     },
     {
       "kind": "ui-call",
@@ -17143,7 +17143,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "isolated",
       "surface": "apple",
-      "id": "native.apple.926b2cd8c6dbbc45"
+      "id": "native.apple.abf99ffddce2f1f6"
     },
     {
       "kind": "ui-call",
@@ -17151,7 +17151,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "current",
       "surface": "apple",
-      "id": "native.apple.a3a4fb0c68d6aa82"
+      "id": "native.apple.aead85c2ccc506b5"
     },
     {
       "kind": "ui-call",
@@ -17159,7 +17159,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Wake mode",
       "surface": "apple",
-      "id": "native.apple.ec2f3c99d04a641f"
+      "id": "native.apple.1b5b2bbccd76d8d2"
     },
     {
       "kind": "ui-call",
@@ -17167,7 +17167,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "now",
       "surface": "apple",
-      "id": "native.apple.7bcc0a63bfc663e3"
+      "id": "native.apple.7ccc350fc7cfdc01"
     },
     {
       "kind": "ui-call",
@@ -17175,7 +17175,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "next-heartbeat",
       "surface": "apple",
-      "id": "native.apple.0f943be2a3559a24"
+      "id": "native.apple.b9aa32fa8096f3da"
     },
     {
       "kind": "ui-call",
@@ -17183,7 +17183,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "at",
       "surface": "apple",
-      "id": "native.apple.288d76f698265dc7"
+      "id": "native.apple.71539eff3cdc3636"
     },
     {
       "kind": "ui-call",
@@ -17191,7 +17191,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "every",
       "surface": "apple",
-      "id": "native.apple.981882337a41b775"
+      "id": "native.apple.f6a7a241b7689780"
     },
     {
       "kind": "ui-call",
@@ -17199,7 +17199,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "cron",
       "surface": "apple",
-      "id": "native.apple.8f029a66e8558108"
+      "id": "native.apple.63a2546194a7af45"
     },
     {
       "kind": "ui-call",
@@ -17207,7 +17207,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "At",
       "surface": "apple",
-      "id": "native.apple.da555c22da16bc6c"
+      "id": "native.apple.db6e0e9a88f35016"
     },
     {
       "kind": "ui-call",
@@ -17215,7 +17215,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Auto-delete",
       "surface": "apple",
-      "id": "native.apple.fa03647816776b55"
+      "id": "native.apple.1e500d9905edb953"
     },
     {
       "kind": "ui-call",
@@ -17223,7 +17223,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Delete after successful run",
       "surface": "apple",
-      "id": "native.apple.8eea808cb55c1f88"
+      "id": "native.apple.5528db819ca2198e"
     },
     {
       "kind": "ui-call",
@@ -17231,7 +17231,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Every",
       "surface": "apple",
-      "id": "native.apple.6eb1c75f9733d7a7"
+      "id": "native.apple.bc4570f983731115"
     },
     {
       "kind": "ui-call",
@@ -17239,7 +17239,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "10m, 1h, 1d",
       "surface": "apple",
-      "id": "native.apple.e1299f47ac33f3ad"
+      "id": "native.apple.05b3c4eaa42b457e"
     },
     {
       "kind": "ui-call",
@@ -17247,7 +17247,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Expression",
       "surface": "apple",
-      "id": "native.apple.170810a5a91fed11"
+      "id": "native.apple.b75ee26e3b0e9384"
     },
     {
       "kind": "ui-call",
@@ -17255,7 +17255,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "e.g. 0 9 * * 3",
       "surface": "apple",
-      "id": "native.apple.767058f99028f188"
+      "id": "native.apple.dfd068cc8b127a31"
     },
     {
       "kind": "ui-call",
@@ -17263,7 +17263,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Timezone",
       "surface": "apple",
-      "id": "native.apple.05b31f0b14270fb7"
+      "id": "native.apple.4c89de0919c749d9"
     },
     {
       "kind": "ui-call",
@@ -17271,7 +17271,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Optional (e.g. America/Los_Angeles)",
       "surface": "apple",
-      "id": "native.apple.46908ba87434178e"
+      "id": "native.apple.3c6d0adbbd37697c"
     },
     {
       "kind": "ui-call",
@@ -17279,7 +17279,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Kind",
       "surface": "apple",
-      "id": "native.apple.cfc085d7f55ec6bb"
+      "id": "native.apple.0664a99ae25c1874"
     },
     {
       "kind": "ui-call",
@@ -17287,7 +17287,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "systemEvent",
       "surface": "apple",
-      "id": "native.apple.400a2807228864fe"
+      "id": "native.apple.7081e314aecb1b4a"
     },
     {
       "kind": "ui-call",
@@ -17295,7 +17295,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "agentTurn",
       "surface": "apple",
-      "id": "native.apple.f0fd21111cd7005e"
+      "id": "native.apple.ea123b1a695f721a"
     },
     {
       "kind": "ui-call",
@@ -17303,7 +17303,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "System event text",
       "surface": "apple",
-      "id": "native.apple.316094e1fc93af44"
+      "id": "native.apple.e5153522b34e401e"
     },
     {
       "kind": "ui-call",
@@ -17311,7 +17311,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Cancel",
       "surface": "apple",
-      "id": "native.apple.b15d95fbd7ab04b2"
+      "id": "native.apple.05d982c8442dba38"
     },
     {
       "kind": "ui-call",
@@ -17319,7 +17319,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Save",
       "surface": "apple",
-      "id": "native.apple.88f23c037d54887b"
+      "id": "native.apple.825872d770f6fee5"
     },
     {
       "kind": "ui-call",
@@ -17327,7 +17327,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Message",
       "surface": "apple",
-      "id": "native.apple.ebff58db1a257892"
+      "id": "native.apple.ca32bcf744cdad6d"
     },
     {
       "kind": "ui-call",
@@ -17335,7 +17335,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "What should OpenClaw do?",
       "surface": "apple",
-      "id": "native.apple.df6243155293f80b"
+      "id": "native.apple.e8071fa049d8aa30"
     },
     {
       "kind": "ui-call",
@@ -17343,7 +17343,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Thinking",
       "surface": "apple",
-      "id": "native.apple.81b5ba441a230f07"
+      "id": "native.apple.3c275caf2dd7075e"
     },
     {
       "kind": "ui-call",
@@ -17351,7 +17351,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Optional (e.g. low)",
       "surface": "apple",
-      "id": "native.apple.80ef7233b7508f01"
+      "id": "native.apple.fc711ddc3722480e"
     },
     {
       "kind": "ui-call",
@@ -17359,7 +17359,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Timeout",
       "surface": "apple",
-      "id": "native.apple.3ba268889ad0bb29"
+      "id": "native.apple.f504998dec5ee83d"
     },
     {
       "kind": "ui-call",
@@ -17367,7 +17367,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Seconds (optional)",
       "surface": "apple",
-      "id": "native.apple.32f1ef2c514bc5f2"
+      "id": "native.apple.de0fd61936c6807b"
     },
     {
       "kind": "ui-call",
@@ -17375,7 +17375,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Delivery",
       "surface": "apple",
-      "id": "native.apple.8559c9accb62a451"
+      "id": "native.apple.3bf29ec53e434cec"
     },
     {
       "kind": "ui-call",
@@ -17383,7 +17383,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Announce summary",
       "surface": "apple",
-      "id": "native.apple.a7deff2e1f9a2d4b"
+      "id": "native.apple.97e4b933ea09752d"
     },
     {
       "kind": "ui-call",
@@ -17391,7 +17391,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "None",
       "surface": "apple",
-      "id": "native.apple.b9d67998af15a52b"
+      "id": "native.apple.4eb375e186aa4029"
     },
     {
       "kind": "ui-call",
@@ -17399,7 +17399,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Channel",
       "surface": "apple",
-      "id": "native.apple.297903b6d84321d7"
+      "id": "native.apple.3b3aea1f79470746"
     },
     {
       "kind": "ui-call",
@@ -17407,7 +17407,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "To",
       "surface": "apple",
-      "id": "native.apple.5cee9c451573efbc"
+      "id": "native.apple.d56f7639f1c38816"
     },
     {
       "kind": "ui-call",
@@ -17415,7 +17415,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Optional override (phone number / chat id / Discord channel)",
       "surface": "apple",
-      "id": "native.apple.f635a754de997a56"
+      "id": "native.apple.f8db8919f56e49a8"
     },
     {
       "kind": "ui-call",
@@ -17423,7 +17423,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Best-effort",
       "surface": "apple",
-      "id": "native.apple.2281bf826d28ffb7"
+      "id": "native.apple.405e37338cdaae5c"
     },
     {
       "kind": "ui-call",
@@ -17431,7 +17431,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Do not fail the job if announce fails",
       "surface": "apple",
-      "id": "native.apple.75ea8e8d38238dfd"
+      "id": "native.apple.e63028d5a07fc239"
     },
     {
       "kind": "conditional-branch",
@@ -17447,7 +17447,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Delete cron job?",
       "surface": "apple",
-      "id": "native.apple.2c7610400993c954"
+      "id": "native.apple.ae4461c1a974b6e6"
     },
     {
       "kind": "ui-call",
@@ -17455,7 +17455,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Cancel",
       "surface": "apple",
-      "id": "native.apple.1b124194b8cb5fd5"
+      "id": "native.apple.0250ddc8f983e2b5"
     },
     {
       "kind": "ui-call",
@@ -17463,7 +17463,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Delete",
       "surface": "apple",
-      "id": "native.apple.5457b9d0c551b472"
+      "id": "native.apple.85de879487e6bf00"
     },
     {
       "kind": "ui-call",
@@ -17471,7 +17471,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Cron scheduler is disabled",
       "surface": "apple",
-      "id": "native.apple.0d7cc44ae0dab2f7"
+      "id": "native.apple.c70c9f19b8deb639"
     },
     {
       "kind": "ui-call-concatenated",
@@ -17479,7 +17479,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Jobs are saved, but they will not run automatically until `cron.enabled` is set to `true` and the Gateway restarts.",
       "surface": "apple",
-      "id": "native.apple.dea81e38c91f67f1"
+      "id": "native.apple.3d9533a9eece1ac8"
     },
     {
       "kind": "ui-call",
@@ -17487,7 +17487,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Cron Jobs",
       "surface": "apple",
-      "id": "native.apple.832eb0b0712fd34a"
+      "id": "native.apple.a1bbecf59eceb28e"
     },
     {
       "kind": "ui-call",
@@ -17495,7 +17495,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Manage Gateway cron jobs and inspect run history.",
       "surface": "apple",
-      "id": "native.apple.0de268bcd943ee00"
+      "id": "native.apple.76e1ecc684794ad1"
     },
     {
       "kind": "ui-call",
@@ -17503,7 +17503,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.0c4ffb322b3e65de"
+      "id": "native.apple.db83190b64638992"
     },
     {
       "kind": "ui-call",
@@ -17511,7 +17511,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "New Job",
       "surface": "apple",
-      "id": "native.apple.7f5f9b82bb18d061"
+      "id": "native.apple.1bdad8701e5c4267"
     },
     {
       "kind": "ui-call",
@@ -17519,7 +17519,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Error: \\(err)",
       "surface": "apple",
-      "id": "native.apple.62a13e9cad6985af"
+      "id": "native.apple.b6fd2601f57e948f"
     },
     {
       "kind": "ui-call",
@@ -17527,7 +17527,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "No cron jobs yet.",
       "surface": "apple",
-      "id": "native.apple.33a31e8e9f2003af"
+      "id": "native.apple.719225ab772d5847"
     },
     {
       "kind": "ui-call",
@@ -17535,7 +17535,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Select a job to inspect details and run history.",
       "surface": "apple",
-      "id": "native.apple.03b0c3fb3259236c"
+      "id": "native.apple.feba2cab61dfcfc0"
     },
     {
       "kind": "ui-call",
@@ -17543,7 +17543,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Tip: use ‘New Job’ to add one, or enable cron in your gateway config.",
       "surface": "apple",
-      "id": "native.apple.60409b6f360a2726"
+      "id": "native.apple.2b31872e1a35f164"
     },
     {
       "kind": "ui-named-argument",
@@ -17551,7 +17551,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "disabled",
       "surface": "apple",
-      "id": "native.apple.920b1625c66d2fbf"
+      "id": "native.apple.d94b55a9b857e9f1"
     },
     {
       "kind": "ui-named-argument",
@@ -17559,7 +17559,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "no next run",
       "surface": "apple",
-      "id": "native.apple.90a2ebfd0143ae3d"
+      "id": "native.apple.400c8c0a958e3684"
     },
     {
       "kind": "ui-named-argument",
@@ -17567,7 +17567,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "agent \\(agentId)",
       "surface": "apple",
-      "id": "native.apple.b349868bdc72ecbe"
+      "id": "native.apple.63db9fb9c080c92f"
     },
     {
       "kind": "ui-call",
@@ -17575,7 +17575,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Run now",
       "surface": "apple",
-      "id": "native.apple.b3049b1b58de4e0a"
+      "id": "native.apple.582e6a0cc361b350"
     },
     {
       "kind": "ui-call",
@@ -17583,7 +17583,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Open transcript",
       "surface": "apple",
-      "id": "native.apple.022656e82944b598"
+      "id": "native.apple.d050cb62cbf6b4eb"
     },
     {
       "kind": "conditional-branch",
@@ -17591,7 +17591,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Disable",
       "surface": "apple",
-      "id": "native.apple.a821d3c97c51498c"
+      "id": "native.apple.6b8f9f64b7939daf"
     },
     {
       "kind": "conditional-branch",
@@ -17599,7 +17599,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Enable",
       "surface": "apple",
-      "id": "native.apple.13f8628d1493d45f"
+      "id": "native.apple.2bbab9b9ba943b53"
     },
     {
       "kind": "ui-call",
@@ -17607,7 +17607,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Edit…",
       "surface": "apple",
-      "id": "native.apple.8c48d1d69ed81f7e"
+      "id": "native.apple.8db6456d1afb6184"
     },
     {
       "kind": "ui-call",
@@ -17615,7 +17615,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Delete…",
       "surface": "apple",
-      "id": "native.apple.5684d3181ce22018"
+      "id": "native.apple.7b7a20836cf59b0f"
     },
     {
       "kind": "ui-call",
@@ -17623,7 +17623,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Enabled",
       "surface": "apple",
-      "id": "native.apple.7ded1df100694ac3"
+      "id": "native.apple.ae5403e34540b504"
     },
     {
       "kind": "ui-call",
@@ -17631,7 +17631,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Run",
       "surface": "apple",
-      "id": "native.apple.9130853a425f720d"
+      "id": "native.apple.33ab9ed8c4c31a22"
     },
     {
       "kind": "ui-call",
@@ -17639,7 +17639,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Transcript",
       "surface": "apple",
-      "id": "native.apple.f34de6490071b8e5"
+      "id": "native.apple.f310936525d971cf"
     },
     {
       "kind": "ui-call",
@@ -17647,7 +17647,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Edit",
       "surface": "apple",
-      "id": "native.apple.4bffda5fcd7a290d"
+      "id": "native.apple.0bd23806a5e953d2"
     },
     {
       "kind": "ui-call",
@@ -17655,7 +17655,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Schedule",
       "surface": "apple",
-      "id": "native.apple.04c710cf31471ebd"
+      "id": "native.apple.b5e0e6255c999bae"
     },
     {
       "kind": "ui-call",
@@ -17663,7 +17663,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Auto-delete",
       "surface": "apple",
-      "id": "native.apple.a0c6656d9919acd7"
+      "id": "native.apple.879c72e4da389850"
     },
     {
       "kind": "ui-call",
@@ -17671,7 +17671,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "after success",
       "surface": "apple",
-      "id": "native.apple.89cad86b7d3a1ed8"
+      "id": "native.apple.e0484961984a1829"
     },
     {
       "kind": "ui-call",
@@ -17679,7 +17679,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Description",
       "surface": "apple",
-      "id": "native.apple.0b2a438527591597"
+      "id": "native.apple.1c2185a5305d0c0f"
     },
     {
       "kind": "ui-call",
@@ -17687,7 +17687,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Agent",
       "surface": "apple",
-      "id": "native.apple.e8ddda1d43812c1d"
+      "id": "native.apple.216b0f15bd816b78"
     },
     {
       "kind": "ui-call",
@@ -17695,7 +17695,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Session",
       "surface": "apple",
-      "id": "native.apple.a9ed6399f6985efb"
+      "id": "native.apple.44c820fbed87b3af"
     },
     {
       "kind": "ui-call",
@@ -17703,7 +17703,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Wake",
       "surface": "apple",
-      "id": "native.apple.4dde8cb5e531bb81"
+      "id": "native.apple.2dfcc7da7297245f"
     },
     {
       "kind": "ui-call",
@@ -17711,7 +17711,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Next run",
       "surface": "apple",
-      "id": "native.apple.014262bb8068c0a1"
+      "id": "native.apple.623bbe433f0b8977"
     },
     {
       "kind": "ui-call",
@@ -17719,7 +17719,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Last run",
       "surface": "apple",
-      "id": "native.apple.8ec0a4219e5e76ce"
+      "id": "native.apple.397b2ef934549237"
     },
     {
       "kind": "ui-call",
@@ -17727,7 +17727,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "\\(date.formatted(date: .abbreviated, time: .standard)) · \\(relativeAge(from: date))",
       "surface": "apple",
-      "id": "native.apple.7718fbae883d5389"
+      "id": "native.apple.ec1fd395efda9833"
     },
     {
       "kind": "ui-call",
@@ -17735,7 +17735,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Last status",
       "surface": "apple",
-      "id": "native.apple.87247dcb9a2857ed"
+      "id": "native.apple.f668db14f031b70f"
     },
     {
       "kind": "ui-call",
@@ -17743,7 +17743,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Run history",
       "surface": "apple",
-      "id": "native.apple.bac4e36acb29ec13"
+      "id": "native.apple.17895f7c89845c4c"
     },
     {
       "kind": "ui-call",
@@ -17751,7 +17751,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.f614be2891ac9a70"
+      "id": "native.apple.f4bb1ca188e6c7ab"
     },
     {
       "kind": "ui-call",
@@ -17759,7 +17759,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "No run log entries yet.",
       "surface": "apple",
-      "id": "native.apple.1d31c7c3dc040e9e"
+      "id": "native.apple.6ad598f84141ad14"
     },
     {
       "kind": "ui-call",
@@ -17767,7 +17767,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "\\(ms)ms",
       "surface": "apple",
-      "id": "native.apple.6ec996f25c175bbc"
+      "id": "native.apple.75e1c7a889f492b1"
     },
     {
       "kind": "ui-call",
@@ -17775,7 +17775,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Payload",
       "surface": "apple",
-      "id": "native.apple.07c987127cde7927"
+      "id": "native.apple.18f67b0fe6b08d36"
     },
     {
       "kind": "ui-named-argument",
@@ -17783,7 +17783,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "think \\(thinking)",
       "surface": "apple",
-      "id": "native.apple.a687603203fec348"
+      "id": "native.apple.77b9a97950a062ff"
     },
     {
       "kind": "ui-named-argument",
@@ -17791,7 +17791,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "\\(timeoutSeconds)s",
       "surface": "apple",
-      "id": "native.apple.a513a17d658a1aa2"
+      "id": "native.apple.290c1d66f24eb79c"
     },
     {
       "kind": "ui-named-argument",
@@ -17799,7 +17799,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "announce",
       "surface": "apple",
-      "id": "native.apple.41cd997805bd59e3"
+      "id": "native.apple.564f7cedfd7a3fe3"
     },
     {
       "kind": "ui-named-argument",
@@ -17807,7 +17807,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "no delivery",
       "surface": "apple",
-      "id": "native.apple.6e5597dd202288ee"
+      "id": "native.apple.8b7368aa83ac1696"
     },
     {
       "kind": "ui-named-argument",
@@ -17863,7 +17863,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "surface": "apple",
-      "id": "native.apple.4c70e8fb1c642be1"
+      "id": "native.apple.10e786234c8e745c"
     },
     {
       "kind": "ui-call",
@@ -17871,7 +17871,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "This process looks expected for the current mode. Kill anyway?",
       "surface": "apple",
-      "id": "native.apple.a8e0eda487b545fb"
+      "id": "native.apple.3082271f6fd8f780"
     },
     {
       "kind": "ui-call",
@@ -17879,7 +17879,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Attach only (skip launchd install)",
       "surface": "apple",
-      "id": "native.apple.85986510973b69a5"
+      "id": "native.apple.e9a312657ae30eb8"
     },
     {
       "kind": "ui-call-concatenated",
@@ -17887,7 +17887,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "When enabled, OpenClaw won't install or manage \\(gatewayLaunchdLabel). It will only attach to an existing Gateway.",
       "surface": "apple",
-      "id": "native.apple.d8b3e55c41a77627"
+      "id": "native.apple.07e8e02d85bc8750"
     },
     {
       "kind": "ui-call",
@@ -17895,7 +17895,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Debug",
       "surface": "apple",
-      "id": "native.apple.15e528c55a96394f"
+      "id": "native.apple.4198ecd66007b98f"
     },
     {
       "kind": "ui-call",
@@ -17903,7 +17903,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Tools for diagnosing local issues (Gateway, ports, logs, Canvas).",
       "surface": "apple",
-      "id": "native.apple.334ebd156b980d53"
+      "id": "native.apple.40520fed8aa3630d"
     },
     {
       "kind": "ui-named-argument",
@@ -17911,7 +17911,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "App Health",
       "surface": "apple",
-      "id": "native.apple.bea6c3a6ee04749e"
+      "id": "native.apple.d81d09fa8b377521"
     },
     {
       "kind": "ui-named-argument",
@@ -17919,7 +17919,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Gateway",
       "surface": "apple",
-      "id": "native.apple.aefd694194f18104"
+      "id": "native.apple.1d3301aa2c6f17f4"
     },
     {
       "kind": "conditional-branch",
@@ -17927,7 +17927,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Local process",
       "surface": "apple",
-      "id": "native.apple.ee22afbade2976eb"
+      "id": "native.apple.2c9e273b2f92c17a"
     },
     {
       "kind": "conditional-branch",
@@ -17935,7 +17935,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Remote connection",
       "surface": "apple",
-      "id": "native.apple.d018b788de2625d4"
+      "id": "native.apple.d3b859c83141b384"
     },
     {
       "kind": "ui-named-argument",
@@ -17943,7 +17943,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "App PID",
       "surface": "apple",
-      "id": "native.apple.09ab439549787a34"
+      "id": "native.apple.e78e04e8d182b174"
     },
     {
       "kind": "ui-call",
@@ -17951,7 +17951,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Health",
       "surface": "apple",
-      "id": "native.apple.c89b5449fe399633"
+      "id": "native.apple.f28b0c656bc6b9e1"
     },
     {
       "kind": "ui-call",
@@ -17959,7 +17959,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "CLI",
       "surface": "apple",
-      "id": "native.apple.11bf6f17b2c17d01"
+      "id": "native.apple.1f723ea4de7bcd62"
     },
     {
       "kind": "ui-call",
@@ -17967,7 +17967,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "PID",
       "surface": "apple",
-      "id": "native.apple.50a498bb5d21fce5"
+      "id": "native.apple.72cecad387820dc6"
     },
     {
       "kind": "ui-call",
@@ -17975,7 +17975,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "\\(ProcessInfo.processInfo.processIdentifier)",
       "surface": "apple",
-      "id": "native.apple.a1b7117088ad315f"
+      "id": "native.apple.84485f274232fda6"
     },
     {
       "kind": "ui-call",
@@ -17983,7 +17983,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Binary path",
       "surface": "apple",
-      "id": "native.apple.6ae192c6a5942a53"
+      "id": "native.apple.9f229e36dd9f873e"
     },
     {
       "kind": "ui-call",
@@ -17991,7 +17991,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Status",
       "surface": "apple",
-      "id": "native.apple.117165abb75eb58b"
+      "id": "native.apple.34b2f835274d60b7"
     },
     {
       "kind": "ui-call",
@@ -17999,7 +17999,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Key",
       "surface": "apple",
-      "id": "native.apple.5432c42ec6020ef0"
+      "id": "native.apple.8e5e40c66cde8a96"
     },
     {
       "kind": "ui-call",
@@ -18007,7 +18007,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Copy",
       "surface": "apple",
-      "id": "native.apple.6675a44c2884bf14"
+      "id": "native.apple.68b3cf039815d1e0"
     },
     {
       "kind": "ui-call",
@@ -18015,7 +18015,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Copy sample URL",
       "surface": "apple",
-      "id": "native.apple.d88bd4f76c454179"
+      "id": "native.apple.8b849808942b6bf7"
     },
     {
       "kind": "ui-call",
@@ -18023,7 +18023,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Deep links (openclaw://…) are always enabled; the key controls unattended runs.",
       "surface": "apple",
-      "id": "native.apple.f8e4e2b25dbdbd44"
+      "id": "native.apple.12a909f68c3f2a7a"
     },
     {
       "kind": "ui-call",
@@ -18031,7 +18031,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Stdout / stderr",
       "surface": "apple",
-      "id": "native.apple.aeba5ae43a292c55"
+      "id": "native.apple.fe536192769282ae"
     },
     {
       "kind": "ui-call",
@@ -18039,7 +18039,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Restart Gateway",
       "surface": "apple",
-      "id": "native.apple.93d4f16afee5753a"
+      "id": "native.apple.1bfa2d286c1b767a"
     },
     {
       "kind": "ui-call",
@@ -18047,7 +18047,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Clear log",
       "surface": "apple",
-      "id": "native.apple.f552a3cb08f36b37"
+      "id": "native.apple.ceea0bb35d2eaeae"
     },
     {
       "kind": "ui-call",
@@ -18055,7 +18055,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Pino log",
       "surface": "apple",
-      "id": "native.apple.ec9654e76a7c3f6f"
+      "id": "native.apple.de9bcce9f614cde3"
     },
     {
       "kind": "ui-call",
@@ -18063,7 +18063,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Open",
       "surface": "apple",
-      "id": "native.apple.ac5b3114ca2f9f9c"
+      "id": "native.apple.a3a3ad4f23b35bc9"
     },
     {
       "kind": "ui-call",
@@ -18071,7 +18071,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "App logging",
       "surface": "apple",
-      "id": "native.apple.73375aaca7469480"
+      "id": "native.apple.382c8060383a6f2c"
     },
     {
       "kind": "ui-call",
@@ -18079,7 +18079,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Verbosity",
       "surface": "apple",
-      "id": "native.apple.45ca609245731590"
+      "id": "native.apple.8960d9d8a14fab21"
     },
     {
       "kind": "ui-modifier",
@@ -18087,7 +18087,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Controls the macOS app log verbosity.",
       "surface": "apple",
-      "id": "native.apple.9f5ec48a00c7bba6"
+      "id": "native.apple.63c650ed822e7b20"
     },
     {
       "kind": "ui-call",
@@ -18095,7 +18095,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Write rolling diagnostics log (JSONL)",
       "surface": "apple",
-      "id": "native.apple.badf38ad13935f27"
+      "id": "native.apple.483f7c97c4353b24"
     },
     {
       "kind": "ui-modifier-concatenated",
@@ -18111,7 +18111,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Open folder",
       "surface": "apple",
-      "id": "native.apple.5b35a89bea603457"
+      "id": "native.apple.0b66962f1ac2921b"
     },
     {
       "kind": "ui-call",
@@ -18119,7 +18119,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Clear",
       "surface": "apple",
-      "id": "native.apple.1b7e3b03bf00eed6"
+      "id": "native.apple.3dc2c37c1ba229bb"
     },
     {
       "kind": "ui-call",
@@ -18127,7 +18127,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Port diagnostics",
       "surface": "apple",
-      "id": "native.apple.0e058d4bd1e38466"
+      "id": "native.apple.b7ab15465aeee65b"
     },
     {
       "kind": "ui-call",
@@ -18135,7 +18135,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Check gateway ports",
       "surface": "apple",
-      "id": "native.apple.49c55c23f1b30c49"
+      "id": "native.apple.6926cf7b08fd5122"
     },
     {
       "kind": "ui-call",
@@ -18143,7 +18143,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Reset SSH tunnel",
       "surface": "apple",
-      "id": "native.apple.f41a77907a653c26"
+      "id": "native.apple.cc6c261bac0c2b62"
     },
     {
       "kind": "ui-call",
@@ -18151,7 +18151,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Check which process owns \\(GatewayEnvironment.gatewayPort()) and suggest fixes.",
       "surface": "apple",
-      "id": "native.apple.7d3bb8db32ac31b8"
+      "id": "native.apple.b1ee37438dacb4b9"
     },
     {
       "kind": "ui-call",
@@ -18159,7 +18159,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Port \\(report.port)",
       "surface": "apple",
-      "id": "native.apple.b5c922d5a81b9a82"
+      "id": "native.apple.81b2e322566bbeb8"
     },
     {
       "kind": "ui-call",
@@ -18167,7 +18167,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "\\(listener.command) (\\(listener.pid))",
       "surface": "apple",
-      "id": "native.apple.0dbd56f870683617"
+      "id": "native.apple.8c7ea9e72e42a8eb"
     },
     {
       "kind": "ui-call",
@@ -18175,7 +18175,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Kill",
       "surface": "apple",
-      "id": "native.apple.eb373e180ce4eb57"
+      "id": "native.apple.bc13d895b4064248"
     },
     {
       "kind": "ui-call",
@@ -18183,7 +18183,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "OpenClaw project root",
       "surface": "apple",
-      "id": "native.apple.5e9e8bf8e35c48ef"
+      "id": "native.apple.813c8586ae04a3fc"
     },
     {
       "kind": "ui-call",
@@ -18191,7 +18191,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Path to openclaw repo",
       "surface": "apple",
-      "id": "native.apple.8b01a6daf7a7b94e"
+      "id": "native.apple.3d393b31f86fbec3"
     },
     {
       "kind": "ui-call",
@@ -18199,7 +18199,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Reset",
       "surface": "apple",
-      "id": "native.apple.b9e064d213c6b451"
+      "id": "native.apple.309a454d79dd1e60"
     },
     {
       "kind": "ui-call",
@@ -18207,7 +18207,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Used for pnpm/node fallback and PATH population when launching the gateway.",
       "surface": "apple",
-      "id": "native.apple.2c9911885c449665"
+      "id": "native.apple.6cf1c1aa26cf61e1"
     },
     {
       "kind": "ui-call",
@@ -18215,7 +18215,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Session store",
       "surface": "apple",
-      "id": "native.apple.b1d1a6049ad5abb8"
+      "id": "native.apple.f1d5d9737e0138e5"
     },
     {
       "kind": "ui-call",
@@ -18223,7 +18223,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Path",
       "surface": "apple",
-      "id": "native.apple.745141d448a91b84"
+      "id": "native.apple.c9561d28544f0670"
     },
     {
       "kind": "ui-call",
@@ -18231,7 +18231,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Save",
       "surface": "apple",
-      "id": "native.apple.fa6607e762a540c0"
+      "id": "native.apple.1eb757c53daed0b6"
     },
     {
       "kind": "ui-call",
@@ -18239,7 +18239,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Used by the CLI session loader; stored in ~/.openclaw/openclaw.json.",
       "surface": "apple",
-      "id": "native.apple.a8154f17cda71415"
+      "id": "native.apple.eb97e49cfbb16619"
     },
     {
       "kind": "ui-call",
@@ -18247,7 +18247,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Send Test Notification",
       "surface": "apple",
-      "id": "native.apple.3e472353e27107af"
+      "id": "native.apple.7bc3cbec7550fdcf"
     },
     {
       "kind": "ui-call",
@@ -18255,7 +18255,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Open Agent Events",
       "surface": "apple",
-      "id": "native.apple.9fdf25afbeb46192"
+      "id": "native.apple.cdaa6f65335979a9"
     },
     {
       "kind": "conditional-branch",
@@ -18263,7 +18263,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Send debug voice",
       "surface": "apple",
-      "id": "native.apple.42bbba51b2fd6cfa"
+      "id": "native.apple.60d37af992545a36"
     },
     {
       "kind": "conditional-branch",
@@ -18271,7 +18271,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Sending debug voice…",
       "surface": "apple",
-      "id": "native.apple.12fbaf28bf105c23"
+      "id": "native.apple.18aaef5bb8f63a4c"
     },
     {
       "kind": "ui-call",
@@ -18279,7 +18279,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Uses the Voice Wake path: forwards over SSH when configured,\notherwise runs locally via rpc.",
       "surface": "apple",
-      "id": "native.apple.652d5fb7136dfd92"
+      "id": "native.apple.6ef0b7e40637cd4a"
     },
     {
       "kind": "ui-call",
@@ -18287,7 +18287,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Note: macOS may require restarting OpenClaw after enabling Accessibility or Screen Recording.",
       "surface": "apple",
-      "id": "native.apple.3307505d507faf31"
+      "id": "native.apple.01a504ea12505286"
     },
     {
       "kind": "ui-call",
@@ -18295,7 +18295,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Restart OpenClaw",
       "surface": "apple",
-      "id": "native.apple.e52d463773aef1e1"
+      "id": "native.apple.f596e59c9f0bb0a0"
     },
     {
       "kind": "ui-call",
@@ -18303,7 +18303,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Restart app",
       "surface": "apple",
-      "id": "native.apple.e299e77f3ad75a75"
+      "id": "native.apple.a7c3852141d74507"
     },
     {
       "kind": "ui-call",
@@ -18311,7 +18311,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Restart onboarding",
       "surface": "apple",
-      "id": "native.apple.902488e753844202"
+      "id": "native.apple.8ff8af440e017d64"
     },
     {
       "kind": "ui-call",
@@ -18319,7 +18319,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Reveal app in Finder",
       "surface": "apple",
-      "id": "native.apple.98b02027c57eda8b"
+      "id": "native.apple.f4ff6092d26790ea"
     },
     {
       "kind": "ui-call",
@@ -18327,7 +18327,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Enable/disable Canvas in General settings.",
       "surface": "apple",
-      "id": "native.apple.04eaabb42454944b"
+      "id": "native.apple.390a76559ead3b34"
     },
     {
       "kind": "ui-call",
@@ -18335,7 +18335,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Session",
       "surface": "apple",
-      "id": "native.apple.b2bebe675c30727a"
+      "id": "native.apple.bb69dfb5bee6b938"
     },
     {
       "kind": "ui-call",
@@ -18343,7 +18343,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Show panel",
       "surface": "apple",
-      "id": "native.apple.99861950da1e69ba"
+      "id": "native.apple.e1ae0b4e2f265c90"
     },
     {
       "kind": "ui-call",
@@ -18351,7 +18351,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Hide panel",
       "surface": "apple",
-      "id": "native.apple.33eb8f297296ec9c"
+      "id": "native.apple.eb37355c55fdc055"
     },
     {
       "kind": "ui-call",
@@ -18359,7 +18359,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Write sample page",
       "surface": "apple",
-      "id": "native.apple.547643e9375bf49c"
+      "id": "native.apple.bfdcd5a46d498903"
     },
     {
       "kind": "ui-call",
@@ -18367,7 +18367,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Eval JS",
       "surface": "apple",
-      "id": "native.apple.fea4c2dbfc571ab6"
+      "id": "native.apple.1f4333c6069859ad"
     },
     {
       "kind": "ui-call",
@@ -18375,7 +18375,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Eval",
       "surface": "apple",
-      "id": "native.apple.940c0085416c853c"
+      "id": "native.apple.ca55ead6aa5c8c14"
     },
     {
       "kind": "ui-call",
@@ -18383,7 +18383,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Snapshot",
       "surface": "apple",
-      "id": "native.apple.a4e7bea688bf372c"
+      "id": "native.apple.f67001b5ceac0dbd"
     },
     {
       "kind": "ui-call",
@@ -18391,7 +18391,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "eval → \\(canvasEvalResult)",
       "surface": "apple",
-      "id": "native.apple.ad26da5399b2e89a"
+      "id": "native.apple.9672fc4e0f242276"
     },
     {
       "kind": "ui-call",
@@ -18399,7 +18399,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "snapshot → \\(canvasSnapshotPath)",
       "surface": "apple",
-      "id": "native.apple.2fa497069eba7671"
+      "id": "native.apple.dc4541ce5f69d040"
     },
     {
       "kind": "ui-call",
@@ -18407,7 +18407,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Reveal",
       "surface": "apple",
-      "id": "native.apple.1c45fe5f7f9e7f51"
+      "id": "native.apple.d44bc2abed998669"
     },
     {
       "kind": "ui-call",
@@ -18415,7 +18415,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Tip: the session directory is returned by “Show panel”.",
       "surface": "apple",
-      "id": "native.apple.44008e46c4816fcb"
+      "id": "native.apple.60b35092f75f6bb7"
     },
     {
       "kind": "ui-call",
@@ -18423,7 +18423,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Icon override",
       "surface": "apple",
-      "id": "native.apple.cf253de8a6d44fdc"
+      "id": "native.apple.2684fb74b8c8cabe"
     },
     {
       "kind": "ui-call",
@@ -18431,7 +18431,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Chat",
       "surface": "apple",
-      "id": "native.apple.5a465c703604e054"
+      "id": "native.apple.df3e3d8d7d2286dc"
     },
     {
       "kind": "ui-call",
@@ -18439,7 +18439,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Native SwiftUI",
       "surface": "apple",
-      "id": "native.apple.39cdf5187168b1a0"
+      "id": "native.apple.75185bde52bb5fc0"
     },
     {
       "kind": "conditional-branch",
@@ -18447,7 +18447,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Unknown",
       "surface": "apple",
-      "id": "native.apple.6a013ae216593687"
+      "id": "native.apple.b74168a58543dfbb"
     },
     {
       "kind": "conditional-branch",
@@ -18455,7 +18455,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Healthy",
       "surface": "apple",
-      "id": "native.apple.6978f2d8499b3b30"
+      "id": "native.apple.f3d8b72e39bda8c0"
     },
     {
       "kind": "conditional-branch",
@@ -18463,7 +18463,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Needs Link",
       "surface": "apple",
-      "id": "native.apple.6431f5299453465b"
+      "id": "native.apple.bdc0e8ebf0aef583"
     },
     {
       "kind": "conditional-branch",
@@ -18471,7 +18471,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Degraded",
       "surface": "apple",
-      "id": "native.apple.e7d1ee5662c1d646"
+      "id": "native.apple.c488f6aaf29dc922"
     },
     {
       "kind": "ui-call",
@@ -18479,7 +18479,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Test",
       "surface": "apple",
-      "id": "native.apple.0397fa643df26663"
+      "id": "native.apple.64a6e6075dd45570"
     },
     {
       "kind": "ui-named-argument",
@@ -18487,7 +18487,7 @@
       "path": "apps/macos/Sources/OpenClaw/DeepLinks.swift",
       "source": "OpenClaw is paused",
       "surface": "apple",
-      "id": "native.apple.a8af393b84d63ab8"
+      "id": "native.apple.4b18bc3c8eece07f"
     },
     {
       "kind": "ui-named-argument",
@@ -18495,7 +18495,7 @@
       "path": "apps/macos/Sources/OpenClaw/DeepLinks.swift",
       "source": "Unpause OpenClaw to run agent actions.",
       "surface": "apple",
-      "id": "native.apple.7ba1542539c0d40b"
+      "id": "native.apple.3231abf69ea32ce3"
     },
     {
       "kind": "ui-named-argument",
@@ -18503,7 +18503,7 @@
       "path": "apps/macos/Sources/OpenClaw/DeepLinks.swift",
       "source": "Deep link too large",
       "surface": "apple",
-      "id": "native.apple.7c1e1dbfde976ab9"
+      "id": "native.apple.8ef3af581f3c0aab"
     },
     {
       "kind": "ui-named-argument",
@@ -18511,7 +18511,7 @@
       "path": "apps/macos/Sources/OpenClaw/DeepLinks.swift",
       "source": "Message exceeds 20,000 characters.",
       "surface": "apple",
-      "id": "native.apple.6f83894cf1e88558"
+      "id": "native.apple.e94b1093e6658125"
     },
     {
       "kind": "ui-named-argument",
@@ -18519,7 +18519,7 @@
       "path": "apps/macos/Sources/OpenClaw/DeepLinks.swift",
       "source": "Deep link blocked",
       "surface": "apple",
-      "id": "native.apple.333dcda29354b1d0"
+      "id": "native.apple.4ad97dc6dd4ddefe"
     },
     {
       "kind": "conditional-branch",
@@ -18535,7 +18535,7 @@
       "path": "apps/macos/Sources/OpenClaw/DeepLinks.swift",
       "source": "Run OpenClaw agent?",
       "surface": "apple",
-      "id": "native.apple.50f1211af2a1945e"
+      "id": "native.apple.ded882f2033ad61b"
     },
     {
       "kind": "ui-named-argument",
@@ -18543,7 +18543,7 @@
       "path": "apps/macos/Sources/OpenClaw/DeepLinks.swift",
       "source": "Agent request failed",
       "surface": "apple",
-      "id": "native.apple.4f3841d5de0135c4"
+      "id": "native.apple.2884ce4401bc0d19"
     },
     {
       "kind": "conditional-branch",
@@ -18551,7 +18551,7 @@
       "path": "apps/macos/Sources/OpenClaw/ExecApprovals.swift",
       "source": "Allowlist",
       "surface": "apple",
-      "id": "native.apple.3bed795cded1caa6"
+      "id": "native.apple.63babf5552212d5c"
     },
     {
       "kind": "conditional-branch",
@@ -18559,7 +18559,7 @@
       "path": "apps/macos/Sources/OpenClaw/ExecApprovals.swift",
       "source": "Deny",
       "surface": "apple",
-      "id": "native.apple.aec1bd885ac9d40b"
+      "id": "native.apple.cccb5562e058c674"
     },
     {
       "kind": "conditional-branch",
@@ -18567,7 +18567,7 @@
       "path": "apps/macos/Sources/OpenClaw/ExecApprovals.swift",
       "source": "Always Allow",
       "surface": "apple",
-      "id": "native.apple.0922ae2298cc7215"
+      "id": "native.apple.bdfa57e56c573c6f"
     },
     {
       "kind": "conditional-branch",
@@ -18575,7 +18575,7 @@
       "path": "apps/macos/Sources/OpenClaw/ExecApprovals.swift",
       "source": "Never Ask",
       "surface": "apple",
-      "id": "native.apple.feee9ce5c746096b"
+      "id": "native.apple.dfcc1c426ab88a0e"
     },
     {
       "kind": "conditional-branch",
@@ -18583,7 +18583,7 @@
       "path": "apps/macos/Sources/OpenClaw/ExecApprovals.swift",
       "source": "Ask on Allowlist Miss",
       "surface": "apple",
-      "id": "native.apple.aa8b4e24f0bfb8b4"
+      "id": "native.apple.ec72760649c924b5"
     },
     {
       "kind": "conditional-branch",
@@ -18591,7 +18591,7 @@
       "path": "apps/macos/Sources/OpenClaw/ExecApprovals.swift",
       "source": "Always Ask",
       "surface": "apple",
-      "id": "native.apple.6d4f37b9ae9027d3"
+      "id": "native.apple.b0c74781683b78cf"
     },
     {
       "kind": "conditional-branch",
@@ -18599,7 +18599,7 @@
       "path": "apps/macos/Sources/OpenClaw/ExecApprovals.swift",
       "source": "Pattern cannot be empty.",
       "surface": "apple",
-      "id": "native.apple.a46f0710e99df741"
+      "id": "native.apple.dd99db476e298aaa"
     },
     {
       "kind": "conditional-branch",
@@ -18623,7 +18623,7 @@
       "path": "apps/macos/Sources/OpenClaw/ExecApprovals.swift",
       "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
       "surface": "apple",
-      "id": "native.apple.511333a8588db7e2"
+      "id": "native.apple.62972cd07b37a7f7"
     },
     {
       "kind": "conditional-branch",
@@ -18639,7 +18639,7 @@
       "path": "apps/macos/Sources/OpenClaw/GatewayDiscoveryHelpers.swift",
       "source": ":\\(endpoint.port)",
       "surface": "apple",
-      "id": "native.apple.db0fa6b60bd859f8"
+      "id": "native.apple.ac6754d18dc43eba"
     },
     {
       "kind": "ui-call",
@@ -18647,7 +18647,7 @@
       "path": "apps/macos/Sources/OpenClaw/GatewayDiscoveryMenu.swift",
       "source": "No gateways found yet.",
       "surface": "apple",
-      "id": "native.apple.6867a83813911d74"
+      "id": "native.apple.319879192f9fb125"
     },
     {
       "kind": "conditional-branch",
@@ -18655,7 +18655,7 @@
       "path": "apps/macos/Sources/OpenClaw/GatewayDiscoveryMenu.swift",
       "source": "Click a discovered gateway to fill the gateway URL.",
       "surface": "apple",
-      "id": "native.apple.08a145c293ac0695"
+      "id": "native.apple.210e3bb184fa6dfa"
     },
     {
       "kind": "conditional-branch",
@@ -18663,7 +18663,7 @@
       "path": "apps/macos/Sources/OpenClaw/GatewayDiscoveryMenu.swift",
       "source": "Click a discovered gateway to fill the SSH target.",
       "surface": "apple",
-      "id": "native.apple.2a5e0e9e073b8db1"
+      "id": "native.apple.ec827387088356de"
     },
     {
       "kind": "ui-modifier",
@@ -18671,7 +18671,7 @@
       "path": "apps/macos/Sources/OpenClaw/GatewayDiscoveryMenu.swift",
       "source": "Discover OpenClaw gateways on your LAN",
       "surface": "apple",
-      "id": "native.apple.66ad783199ef9729"
+      "id": "native.apple.154a5f838bdc1dcd"
     },
     {
       "kind": "conditional-branch",
@@ -18695,7 +18695,7 @@
       "path": "apps/macos/Sources/OpenClaw/GatewayProcessManager.swift",
       "source": "Stopped",
       "surface": "apple",
-      "id": "native.apple.f33dc515a78428f1"
+      "id": "native.apple.cd8f35bf9ab6f81c"
     },
     {
       "kind": "conditional-branch",
@@ -18703,7 +18703,7 @@
       "path": "apps/macos/Sources/OpenClaw/GatewayProcessManager.swift",
       "source": "Starting…",
       "surface": "apple",
-      "id": "native.apple.1be3e61e52abb0b9"
+      "id": "native.apple.7eb2f61ef34fa19e"
     },
     {
       "kind": "conditional-branch",
@@ -18711,7 +18711,7 @@
       "path": "apps/macos/Sources/OpenClaw/GatewayProcessManager.swift",
       "source": "Failed: \\(reason)",
       "surface": "apple",
-      "id": "native.apple.1ae0d775c7fabc51"
+      "id": "native.apple.8c07081ec85be076"
     },
     {
       "kind": "conditional-branch",
@@ -18719,7 +18719,7 @@
       "path": "apps/macos/Sources/OpenClaw/GatewayProcessManager.swift",
       "source": "not linked",
       "surface": "apple",
-      "id": "native.apple.151e5b5ab7d08a2a"
+      "id": "native.apple.d1ad574a4cc83ba0"
     },
     {
       "kind": "conditional-branch",
@@ -18735,7 +18735,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "General",
       "surface": "apple",
-      "id": "native.apple.7b5eaba753440639"
+      "id": "native.apple.fc628a891fd079f6"
     },
     {
       "kind": "ui-named-argument",
@@ -18743,7 +18743,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Everyday OpenClaw app behavior.",
       "surface": "apple",
-      "id": "native.apple.1c4fca89983d7487"
+      "id": "native.apple.76c1df348dd821b2"
     },
     {
       "kind": "ui-call",
@@ -18751,7 +18751,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "App",
       "surface": "apple",
-      "id": "native.apple.7d03158a40ddb60a"
+      "id": "native.apple.f2d092bb38ad3da6"
     },
     {
       "kind": "ui-named-argument",
@@ -18759,7 +18759,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Launch at login",
       "surface": "apple",
-      "id": "native.apple.a861b3a0aafb24cc"
+      "id": "native.apple.40d19b4daa601e7e"
     },
     {
       "kind": "conditional-branch",
@@ -18767,7 +18767,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Automatically start OpenClaw after you sign in.",
       "surface": "apple",
-      "id": "native.apple.405e74c96498b7c0"
+      "id": "native.apple.738cdc07c3539aca"
     },
     {
       "kind": "conditional-branch",
@@ -18783,7 +18783,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Show Dock icon",
       "surface": "apple",
-      "id": "native.apple.927819c087ca3520"
+      "id": "native.apple.e96e6ddccf505fdc"
     },
     {
       "kind": "ui-named-argument-multiline",
@@ -18791,7 +18791,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Keep OpenClaw visible in the Dock. When off, windows still show the Dock icon while open.",
       "surface": "apple",
-      "id": "native.apple.e7a0819bd2f4e1dc"
+      "id": "native.apple.8d1a58acc47b52d1"
     },
     {
       "kind": "ui-named-argument",
@@ -18799,7 +18799,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Play menu bar icon animations",
       "surface": "apple",
-      "id": "native.apple.af23f7b5fb03a877"
+      "id": "native.apple.077d3b8ca5c9c84c"
     },
     {
       "kind": "ui-named-argument",
@@ -18807,7 +18807,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Enable idle blinks and wiggles on the status icon.",
       "surface": "apple",
-      "id": "native.apple.bdb0b9020356722a"
+      "id": "native.apple.9f55e40f3de4df44"
     },
     {
       "kind": "ui-call",
@@ -18815,7 +18815,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Capabilities",
       "surface": "apple",
-      "id": "native.apple.a66c725f98bfa823"
+      "id": "native.apple.30290877cb9f42d6"
     },
     {
       "kind": "ui-named-argument",
@@ -18823,7 +18823,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Allow Canvas",
       "surface": "apple",
-      "id": "native.apple.1a038afba254784e"
+      "id": "native.apple.455390ccfb5e6646"
     },
     {
       "kind": "ui-named-argument",
@@ -18831,7 +18831,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Allow the agent to show and control the Canvas panel.",
       "surface": "apple",
-      "id": "native.apple.9044833ccf5370bd"
+      "id": "native.apple.5d17eedf219bf21d"
     },
     {
       "kind": "ui-named-argument",
@@ -18839,7 +18839,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Allow Camera",
       "surface": "apple",
-      "id": "native.apple.d272331ace65ddb9"
+      "id": "native.apple.a002c697be567239"
     },
     {
       "kind": "ui-named-argument",
@@ -18847,7 +18847,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Allow the agent to capture a photo or short video via the built-in camera.",
       "surface": "apple",
-      "id": "native.apple.3aba44d09d7ae354"
+      "id": "native.apple.59cddc9af4db74b3"
     },
     {
       "kind": "ui-named-argument",
@@ -18855,7 +18855,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Allow Computer Control",
       "surface": "apple",
-      "id": "native.apple.6db2112acf394e43"
+      "id": "native.apple.35d037749f8e2ffc"
     },
     {
       "kind": "ui-named-argument-multiline",
@@ -18863,7 +18863,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Let an authorized agent move the pointer, click, and type on this Mac. Also requires Accessibility, Screen Recording, and gateway command authorization. High risk.",
       "surface": "apple",
-      "id": "native.apple.124d07cfaa03f5e5"
+      "id": "native.apple.32aeb3a28adb64b2"
     },
     {
       "kind": "ui-named-argument",
@@ -18871,7 +18871,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Enable Peekaboo Bridge",
       "surface": "apple",
-      "id": "native.apple.35cdb39a1214e0d8"
+      "id": "native.apple.bd68de701bd5be0b"
     },
     {
       "kind": "ui-named-argument",
@@ -18879,7 +18879,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
       "surface": "apple",
-      "id": "native.apple.82e287000e34b51e"
+      "id": "native.apple.e654f0f2cb9b130f"
     },
     {
       "kind": "ui-call",
@@ -18919,7 +18919,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Developer",
       "surface": "apple",
-      "id": "native.apple.476c2358c26250a7"
+      "id": "native.apple.6e7aa698548c3eb1"
     },
     {
       "kind": "ui-named-argument",
@@ -18927,7 +18927,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Enable debug tools",
       "surface": "apple",
-      "id": "native.apple.ac05a7eb1770d52f"
+      "id": "native.apple.4a5f9e4d4461acac"
     },
     {
       "kind": "ui-named-argument",
@@ -18935,7 +18935,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Show the Debug page with development utilities.",
       "surface": "apple",
-      "id": "native.apple.8ea31fa89ced9a96"
+      "id": "native.apple.3c108670a78dea8e"
     },
     {
       "kind": "ui-call",
@@ -18943,7 +18943,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "App session",
       "surface": "apple",
-      "id": "native.apple.050e1ad36603504f"
+      "id": "native.apple.cea4a676ce240da3"
     },
     {
       "kind": "ui-call",
@@ -18951,7 +18951,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Quit only when you want to stop the menu bar app completely.",
       "surface": "apple",
-      "id": "native.apple.67650c4eb108086a"
+      "id": "native.apple.823b3ed6515ef0a1"
     },
     {
       "kind": "ui-call",
@@ -18959,7 +18959,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Quit",
       "surface": "apple",
-      "id": "native.apple.c8c53e5345460948"
+      "id": "native.apple.28732de42191e235"
     },
     {
       "kind": "conditional-branch",
@@ -18967,7 +18967,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "OpenClaw paused",
       "surface": "apple",
-      "id": "native.apple.64e197a4a8b384ef"
+      "id": "native.apple.e9d809a3de586f91"
     },
     {
       "kind": "ui-call",
@@ -18975,7 +18975,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "OpenClaw active",
       "surface": "apple",
-      "id": "native.apple.7fe6df69d8050832"
+      "id": "native.apple.5b090fade239551d"
     },
     {
       "kind": "conditional-branch",
@@ -18983,7 +18983,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Processing messages through the local Gateway on this Mac.",
       "surface": "apple",
-      "id": "native.apple.2f4258fa73e04344"
+      "id": "native.apple.c73f6a502e684640"
     },
     {
       "kind": "conditional-branch",
@@ -18991,7 +18991,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Connected to a remote Gateway configuration.",
       "surface": "apple",
-      "id": "native.apple.82bbee94fd6c9afd"
+      "id": "native.apple.1c0b83945920fdac"
     },
     {
       "kind": "conditional-branch",
@@ -18999,7 +18999,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Ready to run after you choose a Gateway connection.",
       "surface": "apple",
-      "id": "native.apple.57c062682e2a1b08"
+      "id": "native.apple.624832d45328d12d"
     },
     {
       "kind": "ui-named-argument",
@@ -19007,7 +19007,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Connection",
       "surface": "apple",
-      "id": "native.apple.eac861e2d1da4745"
+      "id": "native.apple.e445713e8bf26eb8"
     },
     {
       "kind": "ui-named-argument",
@@ -19015,7 +19015,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Choose where the Gateway runs and how this Mac app reaches it.",
       "surface": "apple",
-      "id": "native.apple.e23f67caacc93476"
+      "id": "native.apple.573324016158ca02"
     },
     {
       "kind": "ui-call",
@@ -19023,7 +19023,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "\\(Int(ping)) ms",
       "surface": "apple",
-      "id": "native.apple.8d5db3462778dd6f"
+      "id": "native.apple.a33062fb9adb15c1"
     },
     {
       "kind": "conditional-branch",
@@ -19031,7 +19031,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Local Gateway",
       "surface": "apple",
-      "id": "native.apple.886bdf6bcea84209"
+      "id": "native.apple.82bc7b126a07a887"
     },
     {
       "kind": "conditional-branch",
@@ -19039,7 +19039,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote Gateway direct",
       "surface": "apple",
-      "id": "native.apple.9a273161518b6d6b"
+      "id": "native.apple.72c7f4b17003d1f0"
     },
     {
       "kind": "conditional-branch",
@@ -19047,7 +19047,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote Gateway via SSH",
       "surface": "apple",
-      "id": "native.apple.72ed757ec4358aed"
+      "id": "native.apple.e8cfae7970353858"
     },
     {
       "kind": "conditional-branch",
@@ -19055,7 +19055,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway not configured",
       "surface": "apple",
-      "id": "native.apple.11b407abb1de07df"
+      "id": "native.apple.54bc283ddd7c0a7c"
     },
     {
       "kind": "conditional-branch",
@@ -19063,7 +19063,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "OpenClaw starts and monitors the Gateway on this Mac.",
       "surface": "apple",
-      "id": "native.apple.8021dcd7963a4cc2"
+      "id": "native.apple.8a1da5add032f549"
     },
     {
       "kind": "conditional-branch",
@@ -19071,7 +19071,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Choose local or remote before the app can attach to a Gateway.",
       "surface": "apple",
-      "id": "native.apple.fe2a790f28ffd1ae"
+      "id": "native.apple.378dd1b31976a5de"
     },
     {
       "kind": "ui-call",
@@ -19079,7 +19079,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway",
       "surface": "apple",
-      "id": "native.apple.5d2df8163bd92cde"
+      "id": "native.apple.f8f12521f2e303fd"
     },
     {
       "kind": "ui-named-argument",
@@ -19087,7 +19087,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "OpenClaw runs",
       "surface": "apple",
-      "id": "native.apple.d261da13966fa812"
+      "id": "native.apple.020b57c84c6cba10"
     },
     {
       "kind": "ui-named-argument",
@@ -19095,7 +19095,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Pick whether this app owns a local Gateway or attaches to another host.",
       "surface": "apple",
-      "id": "native.apple.397850fa5e803f53"
+      "id": "native.apple.45fa5b9a930a433a"
     },
     {
       "kind": "ui-call",
@@ -19103,7 +19103,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway location",
       "surface": "apple",
-      "id": "native.apple.f9b44adeadaace42"
+      "id": "native.apple.34551cf2aabe9c0f"
     },
     {
       "kind": "ui-call",
@@ -19111,7 +19111,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Not configured",
       "surface": "apple",
-      "id": "native.apple.4bc5101dc5f03eca"
+      "id": "native.apple.be49d17fa62e4357"
     },
     {
       "kind": "ui-call",
@@ -19119,7 +19119,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Local (this Mac)",
       "surface": "apple",
-      "id": "native.apple.26d3cba2f28bc7ee"
+      "id": "native.apple.25a89a4b380a1a0b"
     },
     {
       "kind": "ui-call",
@@ -19127,7 +19127,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote (another host)",
       "surface": "apple",
-      "id": "native.apple.e862ce24b922a761"
+      "id": "native.apple.09331b684283b6f8"
     },
     {
       "kind": "ui-named-argument",
@@ -19135,7 +19135,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Setup needed",
       "surface": "apple",
-      "id": "native.apple.1bd6792ad936d581"
+      "id": "native.apple.48cab6619a4b6912"
     },
     {
       "kind": "ui-named-argument-multiline",
@@ -19143,7 +19143,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Local is best for this Mac. Remote is best when the Gateway already runs on a Mac Studio or server.",
       "surface": "apple",
-      "id": "native.apple.f27f32453c7c27aa"
+      "id": "native.apple.8ef32dcad8e9f362"
     },
     {
       "kind": "ui-call",
@@ -19151,7 +19151,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote Access",
       "surface": "apple",
-      "id": "native.apple.de902001d9e0c2fc"
+      "id": "native.apple.446cf4d6647903fb"
     },
     {
       "kind": "ui-call",
@@ -19159,7 +19159,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Discovery & Status",
       "surface": "apple",
-      "id": "native.apple.290d7f86f03d27c5"
+      "id": "native.apple.58e546a6f33dbfbe"
     },
     {
       "kind": "ui-call",
@@ -19167,7 +19167,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Nearby gateways",
       "surface": "apple",
-      "id": "native.apple.df878fd5df528bd9"
+      "id": "native.apple.fd981a60d1154385"
     },
     {
       "kind": "ui-named-argument",
@@ -19175,7 +19175,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote test",
       "surface": "apple",
-      "id": "native.apple.95028d5447df11e0"
+      "id": "native.apple.3fa97c86fdfce8da"
     },
     {
       "kind": "ui-named-argument",
@@ -19183,7 +19183,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Control channel",
       "surface": "apple",
-      "id": "native.apple.cff94f13853364c2"
+      "id": "native.apple.1701c60e6218e664"
     },
     {
       "kind": "ui-named-argument",
@@ -19191,7 +19191,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Recommended setup",
       "surface": "apple",
-      "id": "native.apple.b28d766383f819ce"
+      "id": "native.apple.a6cc91ac26900fbc"
     },
     {
       "kind": "conditional-branch",
@@ -19199,7 +19199,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "surface": "apple",
-      "id": "native.apple.5eebc911fb011a34"
+      "id": "native.apple.149fedda0985cd49"
     },
     {
       "kind": "conditional-branch",
@@ -19207,7 +19207,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
       "surface": "apple",
-      "id": "native.apple.ff5020c25b825be3"
+      "id": "native.apple.b9aa4a81e9d4f2e6"
     },
     {
       "kind": "ui-call",
@@ -19215,7 +19215,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Advanced",
       "surface": "apple",
-      "id": "native.apple.773d2937062cf86c"
+      "id": "native.apple.ccfc1bf47f888c87"
     },
     {
       "kind": "ui-call",
@@ -19223,7 +19223,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Identity file",
       "surface": "apple",
-      "id": "native.apple.2e33f01115fd73dd"
+      "id": "native.apple.3cd8cb72a11d382d"
     },
     {
       "kind": "ui-named-argument",
@@ -19231,7 +19231,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "/Users/you/.ssh/id_ed25519",
       "surface": "apple",
-      "id": "native.apple.5eaffd822af43300"
+      "id": "native.apple.df5a12307af219d8"
     },
     {
       "kind": "ui-call",
@@ -19239,7 +19239,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Project root",
       "surface": "apple",
-      "id": "native.apple.8bd4eccc71e5668f"
+      "id": "native.apple.95d0ec1ae70efc36"
     },
     {
       "kind": "ui-named-argument",
@@ -19247,7 +19247,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "/home/you/Projects/openclaw",
       "surface": "apple",
-      "id": "native.apple.c663b8a50de8a7d8"
+      "id": "native.apple.d149fdc6d1146a8d"
     },
     {
       "kind": "ui-call",
@@ -19255,7 +19255,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "CLI path",
       "surface": "apple",
-      "id": "native.apple.938ee646aac4ce66"
+      "id": "native.apple.03a35bd626e99a93"
     },
     {
       "kind": "ui-named-argument",
@@ -19263,7 +19263,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "/Applications/OpenClaw.app/.../openclaw",
       "surface": "apple",
-      "id": "native.apple.09f99e863e081f9f"
+      "id": "native.apple.dcfa754168e437b2"
     },
     {
       "kind": "ui-call",
@@ -19271,7 +19271,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "SSH command details",
       "surface": "apple",
-      "id": "native.apple.f588f7dad51aae2e"
+      "id": "native.apple.1b864ea7d1795466"
     },
     {
       "kind": "ui-named-argument",
@@ -19279,7 +19279,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Transport",
       "surface": "apple",
-      "id": "native.apple.a04182cfc2292a90"
+      "id": "native.apple.1d34bf122d97303e"
     },
     {
       "kind": "ui-named-argument",
@@ -19287,7 +19287,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "SSH keeps the Gateway private; direct is best for HTTPS or Tailscale Serve.",
       "surface": "apple",
-      "id": "native.apple.0b3bf35360212894"
+      "id": "native.apple.006fc27e5e8f68ba"
     },
     {
       "kind": "ui-call",
@@ -19295,7 +19295,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "SSH tunnel",
       "surface": "apple",
-      "id": "native.apple.5120bd84625c827a"
+      "id": "native.apple.b5281c3252a88ea6"
     },
     {
       "kind": "ui-call",
@@ -19303,7 +19303,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Direct (ws/wss)",
       "surface": "apple",
-      "id": "native.apple.c58937e43a5b4591"
+      "id": "native.apple.96950c9ecb874bc6"
     },
     {
       "kind": "ui-named-argument",
@@ -19311,7 +19311,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "SSH target",
       "surface": "apple",
-      "id": "native.apple.655c71a562ce5ecb"
+      "id": "native.apple.2d49cb855c4aa5ad"
     },
     {
       "kind": "ui-named-argument",
@@ -19319,7 +19319,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "User and host for the remote Gateway machine.",
       "surface": "apple",
-      "id": "native.apple.feced5a9b26f7437"
+      "id": "native.apple.8a395366d92d72a0"
     },
     {
       "kind": "ui-named-argument",
@@ -19327,7 +19327,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway URL",
       "surface": "apple",
-      "id": "native.apple.5dbab4c147041b65"
+      "id": "native.apple.9744cdf68f13c005"
     },
     {
       "kind": "ui-named-argument",
@@ -19335,7 +19335,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "The WebSocket URL exposed by the remote Gateway.",
       "surface": "apple",
-      "id": "native.apple.fe7e313b29c88daa"
+      "id": "native.apple.a69538465d9ec7c3"
     },
     {
       "kind": "ui-call",
@@ -19343,7 +19343,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "wss://gateway.example.ts.net",
       "surface": "apple",
-      "id": "native.apple.a8d207eec188d22d"
+      "id": "native.apple.798aab93ee1e1513"
     },
     {
       "kind": "ui-call",
@@ -19351,7 +19351,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Use wss:// for public hosts. ws:// is allowed for localhost, LAN, .local, and Tailnet hosts.",
       "surface": "apple",
-      "id": "native.apple.e568ae49d007dc03"
+      "id": "native.apple.204fe478872a2b4f"
     },
     {
       "kind": "ui-named-argument",
@@ -19359,7 +19359,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway token",
       "surface": "apple",
-      "id": "native.apple.e3ff06b581e72632"
+      "id": "native.apple.341b05ac99ff5ba6"
     },
     {
       "kind": "ui-named-argument",
@@ -19367,7 +19367,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Used when the remote gateway requires token auth.",
       "surface": "apple",
-      "id": "native.apple.6e9b05c98cb09528"
+      "id": "native.apple.77ae2826c3ca67b0"
     },
     {
       "kind": "ui-call",
@@ -19375,7 +19375,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "remote gateway auth token (gateway.remote.token)",
       "surface": "apple",
-      "id": "native.apple.053a95077f2d4045"
+      "id": "native.apple.a0be5d50345e05ed"
     },
     {
       "kind": "ui-call-concatenated",
@@ -19383,7 +19383,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "The current gateway.remote.token value is not plain text. OpenClaw for macOS cannot use it directly; enter a plaintext token here to replace it.",
       "surface": "apple",
-      "id": "native.apple.24aa092829f9a3b1"
+      "id": "native.apple.333f0cbf7e54578e"
     },
     {
       "kind": "ui-call",
@@ -19391,7 +19391,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Test remote",
       "surface": "apple",
-      "id": "native.apple.d0b21bc12ab63cad"
+      "id": "native.apple.646f8265d3454fde"
     },
     {
       "kind": "ui-call",
@@ -19399,7 +19399,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Testing…",
       "surface": "apple",
-      "id": "native.apple.5e3968d04d63200c"
+      "id": "native.apple.8485969ebb3c71b0"
     },
     {
       "kind": "ui-call",
@@ -19407,7 +19407,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Installed: \\(gatewayVersion) · Required: \\(required)",
       "surface": "apple",
-      "id": "native.apple.9ff8bc297026d7cb"
+      "id": "native.apple.177dd2f4ffab4228"
     },
     {
       "kind": "ui-call",
@@ -19415,7 +19415,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway \\(gatewayVersion) detected",
       "surface": "apple",
-      "id": "native.apple.6a9514b81425ea1d"
+      "id": "native.apple.d710fd743785f90b"
     },
     {
       "kind": "ui-call",
@@ -19423,7 +19423,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Node \\(node)",
       "surface": "apple",
-      "id": "native.apple.4593770894a0b662"
+      "id": "native.apple.65c1fb3df7e06af3"
     },
     {
       "kind": "ui-call",
@@ -19431,7 +19431,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Last failure: \\(failure)",
       "surface": "apple",
-      "id": "native.apple.50ab01059b763acd"
+      "id": "native.apple.72451cf1de112d7f"
     },
     {
       "kind": "ui-call",
@@ -19439,7 +19439,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Recheck",
       "surface": "apple",
-      "id": "native.apple.c55734a4ee849a4c"
+      "id": "native.apple.4812a491527bfb17"
     },
     {
       "kind": "ui-call",
@@ -19447,7 +19447,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway auto-starts in local mode via launchd (\\(gatewayLaunchdLabel)).",
       "surface": "apple",
-      "id": "native.apple.8fcaa10d4558a03d"
+      "id": "native.apple.0b01d45bfe76884d"
     },
     {
       "kind": "ui-call",
@@ -19455,7 +19455,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Retry now",
       "surface": "apple",
-      "id": "native.apple.7a4bfb585fed2598"
+      "id": "native.apple.63ecf66b9ebc3302"
     },
     {
       "kind": "ui-call",
@@ -19463,7 +19463,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Open logs",
       "surface": "apple",
-      "id": "native.apple.6393591d17837eb0"
+      "id": "native.apple.7f95e19b6b944ba6"
     },
     {
       "kind": "conditional-branch",
@@ -19471,7 +19471,7 @@
       "path": "apps/macos/Sources/OpenClaw/HealthStore.swift",
       "source": "probe degraded",
       "surface": "apple",
-      "id": "native.apple.4d96b20de25a9ddf"
+      "id": "native.apple.91ae5bf0c612f83c"
     },
     {
       "kind": "conditional-branch",
@@ -19479,7 +19479,7 @@
       "path": "apps/macos/Sources/OpenClaw/HealthStore.swift",
       "source": "probe degraded · status \\(status)",
       "surface": "apple",
-      "id": "native.apple.4c7be809a4a75de5"
+      "id": "native.apple.e07ed281690bdeb1"
     },
     {
       "kind": "conditional-branch",
@@ -19487,7 +19487,7 @@
       "path": "apps/macos/Sources/OpenClaw/IconState.swift",
       "source": "System (auto)",
       "surface": "apple",
-      "id": "native.apple.b71cafd438433073"
+      "id": "native.apple.4337b8c51d321980"
     },
     {
       "kind": "conditional-branch",
@@ -19495,7 +19495,7 @@
       "path": "apps/macos/Sources/OpenClaw/IconState.swift",
       "source": "Idle",
       "surface": "apple",
-      "id": "native.apple.41a193b83852fbf9"
+      "id": "native.apple.8b105a2a0875b01f"
     },
     {
       "kind": "conditional-branch",
@@ -19503,7 +19503,7 @@
       "path": "apps/macos/Sources/OpenClaw/IconState.swift",
       "source": "Working main – bash",
       "surface": "apple",
-      "id": "native.apple.71196aeed6421e87"
+      "id": "native.apple.3cb2f76afb99cc29"
     },
     {
       "kind": "conditional-branch",
@@ -19511,7 +19511,7 @@
       "path": "apps/macos/Sources/OpenClaw/IconState.swift",
       "source": "Working main – read",
       "surface": "apple",
-      "id": "native.apple.4b5ed94600721e7d"
+      "id": "native.apple.26aed51b6cf47d35"
     },
     {
       "kind": "conditional-branch",
@@ -19519,7 +19519,7 @@
       "path": "apps/macos/Sources/OpenClaw/IconState.swift",
       "source": "Working main – write",
       "surface": "apple",
-      "id": "native.apple.cb8ea16eac409225"
+      "id": "native.apple.33c20ee58341f044"
     },
     {
       "kind": "conditional-branch",
@@ -19527,7 +19527,7 @@
       "path": "apps/macos/Sources/OpenClaw/IconState.swift",
       "source": "Working main – edit",
       "surface": "apple",
-      "id": "native.apple.4eee079c9e883a4c"
+      "id": "native.apple.5dab24519ea2ac5b"
     },
     {
       "kind": "conditional-branch",
@@ -19535,7 +19535,7 @@
       "path": "apps/macos/Sources/OpenClaw/IconState.swift",
       "source": "Working main – other",
       "surface": "apple",
-      "id": "native.apple.f9923af586dbd6c6"
+      "id": "native.apple.e519ba15367ceb00"
     },
     {
       "kind": "conditional-branch",
@@ -19543,7 +19543,7 @@
       "path": "apps/macos/Sources/OpenClaw/IconState.swift",
       "source": "Working other – bash",
       "surface": "apple",
-      "id": "native.apple.fb68dca095076425"
+      "id": "native.apple.3903fa17d9a05a81"
     },
     {
       "kind": "conditional-branch",
@@ -19551,7 +19551,7 @@
       "path": "apps/macos/Sources/OpenClaw/IconState.swift",
       "source": "Working other – read",
       "surface": "apple",
-      "id": "native.apple.6b742d3ef334effa"
+      "id": "native.apple.97a369eac52aee6b"
     },
     {
       "kind": "conditional-branch",
@@ -19559,7 +19559,7 @@
       "path": "apps/macos/Sources/OpenClaw/IconState.swift",
       "source": "Working other – write",
       "surface": "apple",
-      "id": "native.apple.33041a8417e0c1c9"
+      "id": "native.apple.d46c178f62c10355"
     },
     {
       "kind": "conditional-branch",
@@ -19567,7 +19567,7 @@
       "path": "apps/macos/Sources/OpenClaw/IconState.swift",
       "source": "Working other – edit",
       "surface": "apple",
-      "id": "native.apple.5cfc973ba627e3ac"
+      "id": "native.apple.2cff0185068bea0d"
     },
     {
       "kind": "conditional-branch",
@@ -19575,7 +19575,7 @@
       "path": "apps/macos/Sources/OpenClaw/IconState.swift",
       "source": "Working other – other",
       "surface": "apple",
-      "id": "native.apple.01aaae29e90965d8"
+      "id": "native.apple.808a1acb132a7474"
     },
     {
       "kind": "ui-call",
@@ -19583,7 +19583,7 @@
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "Error: \\(err)",
       "surface": "apple",
-      "id": "native.apple.729f356a45366d00"
+      "id": "native.apple.e880546b24a30d7f"
     },
     {
       "kind": "ui-call",
@@ -19591,7 +19591,7 @@
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "No instances reported yet.",
       "surface": "apple",
-      "id": "native.apple.766ddaa931c544df"
+      "id": "native.apple.123db058e1a3f288"
     },
     {
       "kind": "ui-call",
@@ -19599,7 +19599,7 @@
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "Connected Instances",
       "surface": "apple",
-      "id": "native.apple.c04316f1c7e825c9"
+      "id": "native.apple.c3258589233be7ab"
     },
     {
       "kind": "ui-call",
@@ -19607,7 +19607,7 @@
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "Latest presence beacons from OpenClaw nodes. Updated periodically.",
       "surface": "apple",
-      "id": "native.apple.876c066efa88aee3"
+      "id": "native.apple.1c2e64bd2112e266"
     },
     {
       "kind": "ui-named-argument",
@@ -19615,7 +19615,7 @@
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "\\(device.title) · \\(prettyPlatform)",
       "surface": "apple",
-      "id": "native.apple.8a6bcd51fd9f1f62"
+      "id": "native.apple.ae82f8548372aeea"
     },
     {
       "kind": "ui-named-argument",
@@ -19623,7 +19623,7 @@
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "\\(secs)s ago",
       "surface": "apple",
-      "id": "native.apple.775418faaf244b72"
+      "id": "native.apple.b335572316a0d501"
     },
     {
       "kind": "ui-call",
@@ -19631,7 +19631,7 @@
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "Copy Debug Summary",
       "surface": "apple",
-      "id": "native.apple.d49a2a06f0b30967"
+      "id": "native.apple.6962a33e7bf6d24d"
     },
     {
       "kind": "ui-modifier",
@@ -19639,7 +19639,7 @@
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "Presence updated \\(inst.ageDescription).",
       "surface": "apple",
-      "id": "native.apple.231b8e86486fd129"
+      "id": "native.apple.f8bef683f596096a"
     },
     {
       "kind": "ui-modifier",
@@ -19647,7 +19647,7 @@
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "\\(status.label) presence",
       "surface": "apple",
-      "id": "native.apple.12d83e5f01c98fc0"
+      "id": "native.apple.c48950fcf4e4ee95"
     },
     {
       "kind": "ui-named-argument",
@@ -19655,7 +19655,7 @@
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "Android",
       "surface": "apple",
-      "id": "native.apple.ee499f632a5076c5"
+      "id": "native.apple.bdb8d0c0a3e3358f"
     },
     {
       "kind": "ui-named-argument",
@@ -19663,7 +19663,7 @@
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "Sparkles",
       "surface": "apple",
-      "id": "native.apple.57ca2baac54a05fc"
+      "id": "native.apple.f3561daffa0bc556"
     },
     {
       "kind": "ui-named-argument",
@@ -19671,7 +19671,7 @@
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "Plain",
       "surface": "apple",
-      "id": "native.apple.c9a63d0f5247185d"
+      "id": "native.apple.4ae3d7db5fa4b5a5"
     },
     {
       "kind": "conditional-branch",
@@ -19679,7 +19679,7 @@
       "path": "apps/macos/Sources/OpenClaw/Logging/OpenClawLogging.swift",
       "source": "Trace",
       "surface": "apple",
-      "id": "native.apple.3f4378c2de189ec9"
+      "id": "native.apple.a14ab15b55339391"
     },
     {
       "kind": "conditional-branch",
@@ -19687,7 +19687,7 @@
       "path": "apps/macos/Sources/OpenClaw/Logging/OpenClawLogging.swift",
       "source": "Debug",
       "surface": "apple",
-      "id": "native.apple.abc6d01481fe6ab5"
+      "id": "native.apple.b9ea54141e7aced5"
     },
     {
       "kind": "conditional-branch",
@@ -19695,7 +19695,7 @@
       "path": "apps/macos/Sources/OpenClaw/Logging/OpenClawLogging.swift",
       "source": "Info",
       "surface": "apple",
-      "id": "native.apple.284419a69ba9e608"
+      "id": "native.apple.a26609efc4e730be"
     },
     {
       "kind": "conditional-branch",
@@ -19703,7 +19703,7 @@
       "path": "apps/macos/Sources/OpenClaw/Logging/OpenClawLogging.swift",
       "source": "Notice",
       "surface": "apple",
-      "id": "native.apple.ca37d4d419889d09"
+      "id": "native.apple.284f3ae6af29b0ad"
     },
     {
       "kind": "conditional-branch",
@@ -19711,7 +19711,7 @@
       "path": "apps/macos/Sources/OpenClaw/Logging/OpenClawLogging.swift",
       "source": "Warning",
       "surface": "apple",
-      "id": "native.apple.078501e974c7bb15"
+      "id": "native.apple.707ae81c9d6d4b34"
     },
     {
       "kind": "conditional-branch",
@@ -19719,7 +19719,7 @@
       "path": "apps/macos/Sources/OpenClaw/Logging/OpenClawLogging.swift",
       "source": "Error",
       "surface": "apple",
-      "id": "native.apple.ee2ad2d2d6e65813"
+      "id": "native.apple.a4da1aa6a65fdc88"
     },
     {
       "kind": "conditional-branch",
@@ -19727,7 +19727,7 @@
       "path": "apps/macos/Sources/OpenClaw/Logging/OpenClawLogging.swift",
       "source": "Critical",
       "surface": "apple",
-      "id": "native.apple.01e6a456cdadce81"
+      "id": "native.apple.331ef50368eeb6ff"
     },
     {
       "kind": "ui-call",
@@ -19735,7 +19735,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Settings...",
       "surface": "apple",
-      "id": "native.apple.185a1b27c9859cc0"
+      "id": "native.apple.832e6653badf8e20"
     },
     {
       "kind": "ui-call",
@@ -19759,7 +19759,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "OpenClaw - Voice Wake live meter active",
       "surface": "apple",
-      "id": "native.apple.13a7356f48278757"
+      "id": "native.apple.c8c910234d1b2ab8"
     },
     {
       "kind": "conditional-branch",
@@ -19767,7 +19767,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "OpenClaw",
       "surface": "apple",
-      "id": "native.apple.fae2cf18519da0d5"
+      "id": "native.apple.c463c0849cb4242c"
     },
     {
       "kind": "conditional-branch",
@@ -19775,7 +19775,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Close Canvas",
       "surface": "apple",
-      "id": "native.apple.ef59188264be95d4"
+      "id": "native.apple.aed2d2e92fef765d"
     },
     {
       "kind": "conditional-branch",
@@ -19783,7 +19783,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Open Canvas",
       "surface": "apple",
-      "id": "native.apple.9559a5e927db06c0"
+      "id": "native.apple.a7d381352bd74739"
     },
     {
       "kind": "ui-named-argument",
@@ -19791,7 +19791,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Pairing approval pending (\\(self.pairingPrompter.pendingCount))",
       "surface": "apple",
-      "id": "native.apple.66280f3e99ab2f36"
+      "id": "native.apple.c38740d20747ba27"
     },
     {
       "kind": "conditional-branch",
@@ -19799,7 +19799,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": " · \\(repairCount) repair",
       "surface": "apple",
-      "id": "native.apple.e47f5616f3dae081"
+      "id": "native.apple.76afe883a5389900"
     },
     {
       "kind": "ui-named-argument",
@@ -19807,7 +19807,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Device pairing pending (\\(self.devicePairingPrompter.pendingCount))\\(repairSuffix)",
       "surface": "apple",
-      "id": "native.apple.166030936b7fae68"
+      "id": "native.apple.5a20d9c055ab4af8"
     },
     {
       "kind": "ui-call",
@@ -19815,7 +19815,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Send Heartbeats",
       "surface": "apple",
-      "id": "native.apple.4362f273c3b52793"
+      "id": "native.apple.cd838d022aa510b1"
     },
     {
       "kind": "ui-call",
@@ -19823,7 +19823,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Browser Control",
       "surface": "apple",
-      "id": "native.apple.2ad22b3ef37afe46"
+      "id": "native.apple.6808738b29288c78"
     },
     {
       "kind": "ui-call",
@@ -19831,7 +19831,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Allow Camera",
       "surface": "apple",
-      "id": "native.apple.eb06374f7d430549"
+      "id": "native.apple.c10db6e03522f769"
     },
     {
       "kind": "ui-call",
@@ -19839,7 +19839,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Exec Approvals",
       "surface": "apple",
-      "id": "native.apple.a7298f07a717f564"
+      "id": "native.apple.ddc44cd39d2f7ca9"
     },
     {
       "kind": "ui-call",
@@ -19847,7 +19847,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Loading Exec Approvals…",
       "surface": "apple",
-      "id": "native.apple.348d4adeb2afab25"
+      "id": "native.apple.567cb7a37e7d8143"
     },
     {
       "kind": "ui-call",
@@ -19855,7 +19855,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Retry Exec Approvals",
       "surface": "apple",
-      "id": "native.apple.b2f5f038c81a4a89"
+      "id": "native.apple.9a0b3343ce35cee7"
     },
     {
       "kind": "ui-call",
@@ -19863,7 +19863,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Allow Canvas",
       "surface": "apple",
-      "id": "native.apple.fa9ee90b4a391979"
+      "id": "native.apple.099122b656be2993"
     },
     {
       "kind": "ui-call",
@@ -19871,7 +19871,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Voice Wake",
       "surface": "apple",
-      "id": "native.apple.4cbde322496c96d7"
+      "id": "native.apple.c17cd79eb5342242"
     },
     {
       "kind": "ui-call",
@@ -19879,7 +19879,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Dashboard",
       "surface": "apple",
-      "id": "native.apple.95959926dc363f2e"
+      "id": "native.apple.7b3ebf1cd2bb5628"
     },
     {
       "kind": "ui-call",
@@ -19887,7 +19887,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Chat",
       "surface": "apple",
-      "id": "native.apple.723e0d2283af1458"
+      "id": "native.apple.f010e8bfc29c7136"
     },
     {
       "kind": "conditional-branch",
@@ -19895,7 +19895,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Close Canvas",
       "surface": "apple",
-      "id": "native.apple.5e3cd7734f27f447"
+      "id": "native.apple.b2c500c88847a18b"
     },
     {
       "kind": "conditional-branch",
@@ -19903,7 +19903,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Canvas",
       "surface": "apple",
-      "id": "native.apple.2a9ba12370118594"
+      "id": "native.apple.47e7106aab2624ce"
     },
     {
       "kind": "conditional-branch",
@@ -19911,7 +19911,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Stop Talk Mode",
       "surface": "apple",
-      "id": "native.apple.6c543df49aa45eef"
+      "id": "native.apple.8d434c066c97089d"
     },
     {
       "kind": "conditional-branch",
@@ -19919,7 +19919,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Talk Mode",
       "surface": "apple",
-      "id": "native.apple.f829a2e0409193b6"
+      "id": "native.apple.b9fd20376beb78d2"
     },
     {
       "kind": "ui-call",
@@ -19927,7 +19927,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Settings…",
       "surface": "apple",
-      "id": "native.apple.e96f53fc66acbb95"
+      "id": "native.apple.611c2cf487f4b4e0"
     },
     {
       "kind": "ui-call",
@@ -19935,7 +19935,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "About OpenClaw",
       "surface": "apple",
-      "id": "native.apple.fbab65790d6eca89"
+      "id": "native.apple.4f087c4a5c95a11c"
     },
     {
       "kind": "ui-call",
@@ -19943,7 +19943,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Update ready, restart now?",
       "surface": "apple",
-      "id": "native.apple.14c8f4b1a57569f3"
+      "id": "native.apple.7c5e2ed864a3d77e"
     },
     {
       "kind": "ui-call",
@@ -19951,7 +19951,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Quit",
       "surface": "apple",
-      "id": "native.apple.f20b8f0da1520f4b"
+      "id": "native.apple.08c50ff254ac2d62"
     },
     {
       "kind": "conditional-branch",
@@ -19959,7 +19959,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "OpenClaw Not Configured",
       "surface": "apple",
-      "id": "native.apple.5021ed413c045620"
+      "id": "native.apple.9d051748e2c10422"
     },
     {
       "kind": "conditional-branch",
@@ -19967,7 +19967,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Remote OpenClaw Active",
       "surface": "apple",
-      "id": "native.apple.4d10ab5feb4add3f"
+      "id": "native.apple.5d24c331c2277614"
     },
     {
       "kind": "conditional-branch",
@@ -19975,7 +19975,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "OpenClaw Active",
       "surface": "apple",
-      "id": "native.apple.b49dea5c1fdb3dd3"
+      "id": "native.apple.fd36a99642534de1"
     },
     {
       "kind": "ui-call",
@@ -19983,7 +19983,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Debug",
       "surface": "apple",
-      "id": "native.apple.1df24a30d7963640"
+      "id": "native.apple.b26a1a083c2e06fa"
     },
     {
       "kind": "ui-call",
@@ -19991,7 +19991,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Config Folder",
       "surface": "apple",
-      "id": "native.apple.24b2a8b6549236c4"
+      "id": "native.apple.39ca4998055aec22"
     },
     {
       "kind": "ui-call",
@@ -19999,7 +19999,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Run Health Check Now",
       "surface": "apple",
-      "id": "native.apple.bb94be83a9083e18"
+      "id": "native.apple.7850bf7baae21550"
     },
     {
       "kind": "ui-call",
@@ -20007,7 +20007,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Send Test Heartbeat",
       "surface": "apple",
-      "id": "native.apple.406f1a5866bf0bd0"
+      "id": "native.apple.a389789475e5dff8"
     },
     {
       "kind": "ui-call",
@@ -20015,7 +20015,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Show Pairing Panel (Demo)",
       "surface": "apple",
-      "id": "native.apple.79a6d2d396cd5477"
+      "id": "native.apple.d8fdac3676b02326"
     },
     {
       "kind": "ui-named-argument",
@@ -20023,7 +20023,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Remote Tunnel",
       "surface": "apple",
-      "id": "native.apple.5e9ea5d8470d105a"
+      "id": "native.apple.72b41fc08d1ea566"
     },
     {
       "kind": "ui-call",
@@ -20031,7 +20031,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Reset Remote Tunnel",
       "surface": "apple",
-      "id": "native.apple.872bee8f298e59ef"
+      "id": "native.apple.48ba1ccb1bc4b3ab"
     },
     {
       "kind": "conditional-branch",
@@ -20039,7 +20039,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Verbose Logging (Main): On",
       "surface": "apple",
-      "id": "native.apple.e9868e7cdc856b06"
+      "id": "native.apple.4b94f2526090962a"
     },
     {
       "kind": "conditional-branch",
@@ -20047,7 +20047,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Verbose Logging (Main): Off",
       "surface": "apple",
-      "id": "native.apple.a03ddd3d711b5a36"
+      "id": "native.apple.071399dac3dff54a"
     },
     {
       "kind": "ui-call",
@@ -20055,7 +20055,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Verbosity",
       "surface": "apple",
-      "id": "native.apple.ecde91c32bcc0da5"
+      "id": "native.apple.2a485d8d8baa5270"
     },
     {
       "kind": "conditional-branch",
@@ -20063,7 +20063,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "File Logging: On",
       "surface": "apple",
-      "id": "native.apple.4f577b502efb658c"
+      "id": "native.apple.b5e63c3328ab8122"
     },
     {
       "kind": "conditional-branch",
@@ -20071,7 +20071,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "File Logging: Off",
       "surface": "apple",
-      "id": "native.apple.b0785f8c2ae712ff"
+      "id": "native.apple.7e117eb03928127a"
     },
     {
       "kind": "ui-call",
@@ -20079,7 +20079,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "App Logging",
       "surface": "apple",
-      "id": "native.apple.f9dfd69b4f83afa1"
+      "id": "native.apple.b743dbc0d4287bd7"
     },
     {
       "kind": "ui-call",
@@ -20087,7 +20087,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Session Store",
       "surface": "apple",
-      "id": "native.apple.0627f0cfb40a10c8"
+      "id": "native.apple.224af928511c3cd8"
     },
     {
       "kind": "ui-call",
@@ -20095,7 +20095,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Agent Events…",
       "surface": "apple",
-      "id": "native.apple.645ddb678c201ac8"
+      "id": "native.apple.dea4e367762f3176"
     },
     {
       "kind": "ui-call",
@@ -20103,7 +20103,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Log",
       "surface": "apple",
-      "id": "native.apple.c8cb59f8c2e28468"
+      "id": "native.apple.afc402901f4d986f"
     },
     {
       "kind": "ui-call",
@@ -20111,7 +20111,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Send Debug Voice Text",
       "surface": "apple",
-      "id": "native.apple.aba07ae46ea14d1e"
+      "id": "native.apple.533afe6a6ec71238"
     },
     {
       "kind": "ui-call",
@@ -20119,7 +20119,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Send Test Notification",
       "surface": "apple",
-      "id": "native.apple.2d85e94cb51ec35c"
+      "id": "native.apple.dc56248f6a24a860"
     },
     {
       "kind": "ui-call",
@@ -20127,7 +20127,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Restart Gateway",
       "surface": "apple",
-      "id": "native.apple.0f9e668602baf391"
+      "id": "native.apple.a4ebd9afec6f8fd1"
     },
     {
       "kind": "ui-call",
@@ -20135,7 +20135,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Restart Onboarding",
       "surface": "apple",
-      "id": "native.apple.ed98a6c0df41cdde"
+      "id": "native.apple.97d65b820852ca13"
     },
     {
       "kind": "ui-call",
@@ -20143,7 +20143,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Restart App",
       "surface": "apple",
-      "id": "native.apple.2ebeecbd1b177e61"
+      "id": "native.apple.14a8a7593116f708"
     },
     {
       "kind": "conditional-branch",
@@ -20151,7 +20151,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Main",
       "surface": "apple",
-      "id": "native.apple.3cef985bef918988"
+      "id": "native.apple.65edb1ee08ee7d2f"
     },
     {
       "kind": "conditional-branch",
@@ -20159,7 +20159,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Other",
       "surface": "apple",
-      "id": "native.apple.5eca63e1a931e290"
+      "id": "native.apple.cee824dbf4d5515e"
     },
     {
       "kind": "ui-modifier",
@@ -20167,7 +20167,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Show pairing requests",
       "surface": "apple",
-      "id": "native.apple.72d7e38d56c76ff8"
+      "id": "native.apple.85c8fe408312fdea"
     },
     {
       "kind": "ui-call",
@@ -20175,7 +20175,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Refreshing microphones…",
       "surface": "apple",
-      "id": "native.apple.469c920582755860"
+      "id": "native.apple.93e493a9c625590c"
     },
     {
       "kind": "ui-call",
@@ -20183,7 +20183,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Microphone",
       "surface": "apple",
-      "id": "native.apple.c0c6172187ca749a"
+      "id": "native.apple.d42b81d507e74489"
     },
     {
       "kind": "ui-call",
@@ -20191,7 +20191,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Disconnected (using System default)",
       "surface": "apple",
-      "id": "native.apple.3e248379359c7593"
+      "id": "native.apple.57d3ac59060048c3"
     },
     {
       "kind": "conditional-branch",
@@ -20207,7 +20207,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsHeaderView.swift",
       "source": "Context",
       "surface": "apple",
-      "id": "native.apple.5a99e1ae62fe0ab9"
+      "id": "native.apple.18047394f8bcdf4e"
     },
     {
       "kind": "conditional-branch",
@@ -20215,7 +20215,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Loading devices...",
       "surface": "apple",
-      "id": "native.apple.71d571a51fc1dd07"
+      "id": "native.apple.4cbca38a8dccdf77"
     },
     {
       "kind": "conditional-branch",
@@ -20223,7 +20223,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "No devices yet",
       "surface": "apple",
-      "id": "native.apple.1b885476267aec98"
+      "id": "native.apple.34d79b94dde63370"
     },
     {
       "kind": "conditional-branch",
@@ -20231,7 +20231,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "No",
       "surface": "apple",
-      "id": "native.apple.88ac623ee1a9929a"
+      "id": "native.apple.6fb6152078955a6a"
     },
     {
       "kind": "conditional-branch",
@@ -20239,7 +20239,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Yes",
       "surface": "apple",
-      "id": "native.apple.7782c047f2f09120"
+      "id": "native.apple.620b6a509e8ca909"
     },
     {
       "kind": "ui-named-argument",
@@ -20247,7 +20247,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Update thinking failed",
       "surface": "apple",
-      "id": "native.apple.c847ab5573bcbc26"
+      "id": "native.apple.6c93278ef4b22f19"
     },
     {
       "kind": "ui-named-argument",
@@ -20255,7 +20255,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Update verbose failed",
       "surface": "apple",
-      "id": "native.apple.4e45d5ed653259d1"
+      "id": "native.apple.2cf1c47995829999"
     },
     {
       "kind": "ui-named-argument",
@@ -20263,7 +20263,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Reset session?",
       "surface": "apple",
-      "id": "native.apple.675bea191c16ad31"
+      "id": "native.apple.412f037bfcccc1cf"
     },
     {
       "kind": "ui-named-argument",
@@ -20271,7 +20271,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Starts a new session id for “\\(key)”.",
       "surface": "apple",
-      "id": "native.apple.e63cf5e18950a31a"
+      "id": "native.apple.ce1a5cf971cdf846"
     },
     {
       "kind": "ui-named-argument",
@@ -20279,7 +20279,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Reset failed",
       "surface": "apple",
-      "id": "native.apple.bc784754f0d1bdda"
+      "id": "native.apple.f7858ff8d1ec8153"
     },
     {
       "kind": "ui-named-argument",
@@ -20287,7 +20287,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Compact session log?",
       "surface": "apple",
-      "id": "native.apple.f01b4b170022c829"
+      "id": "native.apple.4cda7e3ea8279e7b"
     },
     {
       "kind": "ui-named-argument",
@@ -20295,7 +20295,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Keeps the last 400 lines; archives the old file.",
       "surface": "apple",
-      "id": "native.apple.0665671dadf0d19a"
+      "id": "native.apple.e5e4c273e81aa51f"
     },
     {
       "kind": "ui-named-argument",
@@ -20303,7 +20303,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Compact failed",
       "surface": "apple",
-      "id": "native.apple.8446ea98af8411a0"
+      "id": "native.apple.a10b72974b739b6a"
     },
     {
       "kind": "ui-named-argument",
@@ -20311,7 +20311,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Delete session?",
       "surface": "apple",
-      "id": "native.apple.bbe5d1663b0933b5"
+      "id": "native.apple.ee11e91136f366b3"
     },
     {
       "kind": "ui-named-argument",
@@ -20319,7 +20319,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Deletes the “\\(key)” entry and archives its transcript.",
       "surface": "apple",
-      "id": "native.apple.8720ae7f5f206a63"
+      "id": "native.apple.177e27e4e57dccee"
     },
     {
       "kind": "ui-named-argument",
@@ -20327,7 +20327,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Delete failed",
       "surface": "apple",
-      "id": "native.apple.3e0daab58958c203"
+      "id": "native.apple.9970c1359738a7e9"
     },
     {
       "kind": "ui-named-argument",
@@ -20335,7 +20335,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuUsageHeaderView.swift",
       "source": "Usage",
       "surface": "apple",
-      "id": "native.apple.737e72233a7b88e6"
+      "id": "native.apple.2e301b6071e0ab44"
     },
     {
       "kind": "conditional-branch",
@@ -20359,7 +20359,7 @@
       "path": "apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift",
       "source": "Node pairing approved",
       "surface": "apple",
-      "id": "native.apple.7eb0a88b8274ced8"
+      "id": "native.apple.811b7f3e9ddca5e1"
     },
     {
       "kind": "conditional-branch",
@@ -20367,7 +20367,7 @@
       "path": "apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift",
       "source": "Node pairing rejected",
       "surface": "apple",
-      "id": "native.apple.6c08dad7c7371b74"
+      "id": "native.apple.145b0862aa2b0036"
     },
     {
       "kind": "ui-call",
@@ -20375,7 +20375,7 @@
       "path": "apps/macos/Sources/OpenClaw/NodesMenu.swift",
       "source": "\\(self.label):",
       "surface": "apple",
-      "id": "native.apple.4443962db00a2def"
+      "id": "native.apple.d1e225c38143b7ed"
     },
     {
       "kind": "conditional-branch",
@@ -20383,7 +20383,7 @@
       "path": "apps/macos/Sources/OpenClaw/Onboarding.swift",
       "source": "Finish",
       "surface": "apple",
-      "id": "native.apple.800d9fd07f5dde85"
+      "id": "native.apple.9e73dd4dfaf3017b"
     },
     {
       "kind": "conditional-branch",
@@ -20391,7 +20391,7 @@
       "path": "apps/macos/Sources/OpenClaw/Onboarding.swift",
       "source": "Next",
       "surface": "apple",
-      "id": "native.apple.dca2e9174fec56ce"
+      "id": "native.apple.ea54e864464f0797"
     },
     {
       "kind": "conditional-branch",
@@ -20839,7 +20839,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingCrestodianChat.swift",
       "source": "Crestodian was interrupted. Restart to try again.",
       "surface": "apple",
-      "id": "native.apple.722995710f90cfc6"
+      "id": "native.apple.1d6f15d108da0656"
     },
     {
       "kind": "conditional-branch",
@@ -20847,7 +20847,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingCrestodianChat.swift",
       "source": "The Gateway connection changed. Restart Crestodian to reconnect.",
       "surface": "apple",
-      "id": "native.apple.6596e00d4333081e"
+      "id": "native.apple.622cb233ed708c7d"
     },
     {
       "kind": "ui-call",
@@ -20855,7 +20855,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingCrestodianChat.swift",
       "source": "Crestodian is working…",
       "surface": "apple",
-      "id": "native.apple.6124d93872cfcfe4"
+      "id": "native.apple.a7be6a912d204b2f"
     },
     {
       "kind": "ui-call",
@@ -20863,7 +20863,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingCrestodianChat.swift",
       "source": "Restart",
       "surface": "apple",
-      "id": "native.apple.105683a219ce17d7"
+      "id": "native.apple.48ca6e7a236b9edb"
     },
     {
       "kind": "ui-call",
@@ -20871,7 +20871,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingCrestodianChat.swift",
       "source": "Enter secret…",
       "surface": "apple",
-      "id": "native.apple.839da8db3e4256b2"
+      "id": "native.apple.4ba4fee5c8d0bb86"
     },
     {
       "kind": "ui-call",
@@ -20879,7 +20879,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingCrestodianChat.swift",
       "source": "Reply to Crestodian… (yes sets everything up)",
       "surface": "apple",
-      "id": "native.apple.3e9e9347173fffbc"
+      "id": "native.apple.5db93d8c4808e5cd"
     },
     {
       "kind": "ui-call",
@@ -20887,7 +20887,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+AISetupPage.swift",
       "source": "Connect your AI",
       "surface": "apple",
-      "id": "native.apple.78d1ad73762a7ce8"
+      "id": "native.apple.e319780979ae71d1"
     },
     {
       "kind": "ui-call",
@@ -20895,7 +20895,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift",
       "source": "Back",
       "surface": "apple",
-      "id": "native.apple.c8a2f8dc424fe447"
+      "id": "native.apple.d6ece940ccc75e49"
     },
     {
       "kind": "ui-call",
@@ -20903,7 +20903,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Welcome to OpenClaw",
       "surface": "apple",
-      "id": "native.apple.ea8beaeecef15e54"
+      "id": "native.apple.6f266200b7b28e40"
     },
     {
       "kind": "ui-call",
@@ -20911,7 +20911,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Your personal AI assistant, living on your own Mac.",
       "surface": "apple",
-      "id": "native.apple.0629bbbd6db95199"
+      "id": "native.apple.e24e92f45c29eddb"
     },
     {
       "kind": "ui-call-concatenated",
@@ -20919,7 +20919,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "It answers questions, works with your files and apps, and can chat with you on WhatsApp or Telegram. Setup takes about two minutes.",
       "surface": "apple",
-      "id": "native.apple.ff6f4069f0185b9b"
+      "id": "native.apple.2a2d720cd6cdf8eb"
     },
     {
       "kind": "ui-named-argument",
@@ -20927,7 +20927,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Ask, create, and automate",
       "surface": "apple",
-      "id": "native.apple.86e4509eb0626ec8"
+      "id": "native.apple.1d11702068e086b6"
     },
     {
       "kind": "ui-named-argument",
@@ -20935,7 +20935,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Give your assistant tasks and let it help across your Mac.",
       "surface": "apple",
-      "id": "native.apple.a6950fed99ae450d"
+      "id": "native.apple.4df9fcc7df38e96c"
     },
     {
       "kind": "ui-named-argument",
@@ -20943,7 +20943,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Chat wherever you like",
       "surface": "apple",
-      "id": "native.apple.8496e933d9cbc56d"
+      "id": "native.apple.6b1ce83cf72fc9b2"
     },
     {
       "kind": "ui-named-argument",
@@ -20951,7 +20951,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "This app, WhatsApp, Telegram, Discord, Slack — your choice.",
       "surface": "apple",
-      "id": "native.apple.d6ca07ea4a825a3f"
+      "id": "native.apple.d1e2c5399d78cedc"
     },
     {
       "kind": "ui-named-argument",
@@ -20959,7 +20959,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Stay in control",
       "surface": "apple",
-      "id": "native.apple.caf822c2d393914f"
+      "id": "native.apple.5f34ad31222c61cb"
     },
     {
       "kind": "ui-named-argument",
@@ -20967,7 +20967,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Everything runs where you decide, with permissions you grant.",
       "surface": "apple",
-      "id": "native.apple.46514f735df5cddc"
+      "id": "native.apple.9ee350a791d7ae82"
     },
     {
       "kind": "ui-call-concatenated",
@@ -20975,7 +20975,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "OpenClaw can take actions using the permissions and services you enable. Review prompts and only connect tools you trust.",
       "surface": "apple",
-      "id": "native.apple.fb64a5b187cfdc15"
+      "id": "native.apple.d84eeb9852925b96"
     },
     {
       "kind": "ui-call",
@@ -20983,7 +20983,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Where should your assistant live?",
       "surface": "apple",
-      "id": "native.apple.a5d02aaf6208e924"
+      "id": "native.apple.a4142be1d0fe5025"
     },
     {
       "kind": "ui-call-concatenated",
@@ -20991,7 +20991,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Most people pick this Mac — OpenClaw installs everything and keeps it running in the background. You can change this anytime in Settings.",
       "surface": "apple",
-      "id": "native.apple.e6acb60b10ef1206"
+      "id": "native.apple.5cf89a37e2eaddf1"
     },
     {
       "kind": "ui-named-argument",
@@ -20999,7 +20999,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "On this Mac",
       "surface": "apple",
-      "id": "native.apple.21f1053c1054db24"
+      "id": "native.apple.4e9cd339836d3f4f"
     },
     {
       "kind": "ui-named-argument",
@@ -21007,7 +21007,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "On another computer",
       "surface": "apple",
-      "id": "native.apple.848c45dfcda2c160"
+      "id": "native.apple.762d9c2364cdee21"
     },
     {
       "kind": "ui-call",
@@ -21015,7 +21015,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Set up later",
       "surface": "apple",
-      "id": "native.apple.1921bcc57bcd747d"
+      "id": "native.apple.e833affb20c48d40"
     },
     {
       "kind": "ui-modifier",
@@ -21023,7 +21023,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Skip Gateway setup for now; pick Local or Remote later in Settings → General.",
       "surface": "apple",
-      "id": "native.apple.3647303a73877ecf"
+      "id": "native.apple.cb9ad999edeb923b"
     },
     {
       "kind": "ui-call",
@@ -21031,7 +21031,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "OK — OpenClaw won’t start anything yet. Pick Local or Remote later in Settings → General.",
       "surface": "apple",
-      "id": "native.apple.d54084b48f40aa0a"
+      "id": "native.apple.a3c214bd839492b6"
     },
     {
       "kind": "conditional-branch",
@@ -21039,7 +21039,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Existing gateway detected",
       "surface": "apple",
-      "id": "native.apple.8d9eb247d41a0ca7"
+      "id": "native.apple.0f1358b381263a4a"
     },
     {
       "kind": "conditional-branch",
@@ -21047,7 +21047,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Port \\(probe.port) already in use",
       "surface": "apple",
-      "id": "native.apple.335bb6b21095d15a"
+      "id": "native.apple.03f64ebb6b039fd0"
     },
     {
       "kind": "conditional-branch",
@@ -21055,7 +21055,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": " (\\(probe.command) pid \\(probe.pid))",
       "surface": "apple",
-      "id": "native.apple.de453cb637c46670"
+      "id": "native.apple.d7b634908d991212"
     },
     {
       "kind": "conditional-branch",
@@ -21063,7 +21063,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "1 gateway found on your network — click to choose it.",
       "surface": "apple",
-      "id": "native.apple.9ab228a4cb7d4403"
+      "id": "native.apple.8826546033ff4516"
     },
     {
       "kind": "conditional-branch",
@@ -21071,7 +21071,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "\\(count) gateways found on your network — click to choose one.",
       "surface": "apple",
-      "id": "native.apple.279c63b244b85ece"
+      "id": "native.apple.b6ccb9486c3d4fd1"
     },
     {
       "kind": "ui-call",
@@ -21079,7 +21079,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "No gateways found on your network yet.",
       "surface": "apple",
-      "id": "native.apple.43777eabc068e240"
+      "id": "native.apple.15ca77cb469246d2"
     },
     {
       "kind": "ui-call",
@@ -21087,7 +21087,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Look again",
       "surface": "apple",
-      "id": "native.apple.b485089ad79067a9"
+      "id": "native.apple.902e221a6b25dc38"
     },
     {
       "kind": "ui-modifier",
@@ -21095,7 +21095,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Retry discovery (Bonjour + Tailscale DNS-SD).",
       "surface": "apple",
-      "id": "native.apple.e39798604090ef9c"
+      "id": "native.apple.a753fd161e1d57cb"
     },
     {
       "kind": "conditional-branch",
@@ -21103,7 +21103,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Advanced…",
       "surface": "apple",
-      "id": "native.apple.94575e6937b47f7b"
+      "id": "native.apple.103ca17ff07ae794"
     },
     {
       "kind": "conditional-branch",
@@ -21111,7 +21111,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Hide Advanced",
       "surface": "apple",
-      "id": "native.apple.22947c17e44f76af"
+      "id": "native.apple.db92f3f5b7207a02"
     },
     {
       "kind": "ui-call",
@@ -21119,7 +21119,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Transport",
       "surface": "apple",
-      "id": "native.apple.7881cec64b177026"
+      "id": "native.apple.60a2f474da8ae80a"
     },
     {
       "kind": "ui-call",
@@ -21127,7 +21127,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "SSH tunnel",
       "surface": "apple",
-      "id": "native.apple.8413b40cd91c9a19"
+      "id": "native.apple.059da4aa6d917db8"
     },
     {
       "kind": "ui-call",
@@ -21135,7 +21135,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Direct (ws/wss)",
       "surface": "apple",
-      "id": "native.apple.915c50965d971bb4"
+      "id": "native.apple.6bf23cdfbba79b16"
     },
     {
       "kind": "ui-call",
@@ -21143,7 +21143,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Gateway URL",
       "surface": "apple",
-      "id": "native.apple.9c90f7bc1b9564b1"
+      "id": "native.apple.74fb65dbdf17643b"
     },
     {
       "kind": "ui-call",
@@ -21151,7 +21151,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "wss://gateway.example.ts.net",
       "surface": "apple",
-      "id": "native.apple.ba96e44d673d04d3"
+      "id": "native.apple.e675ecdf9c29fbfb"
     },
     {
       "kind": "ui-call",
@@ -21159,7 +21159,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "SSH target",
       "surface": "apple",
-      "id": "native.apple.a193ae2a5ff9decd"
+      "id": "native.apple.c69c21b11c82dd0d"
     },
     {
       "kind": "ui-call",
@@ -21167,7 +21167,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Identity file",
       "surface": "apple",
-      "id": "native.apple.ecf41ca39add6b84"
+      "id": "native.apple.9c0fa56a7ac3518b"
     },
     {
       "kind": "ui-call",
@@ -21175,7 +21175,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "/Users/you/.ssh/id_ed25519",
       "surface": "apple",
-      "id": "native.apple.ef96d6a2a48a4c54"
+      "id": "native.apple.28129f0aeb62d776"
     },
     {
       "kind": "ui-call",
@@ -21183,7 +21183,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Project root",
       "surface": "apple",
-      "id": "native.apple.0ef039b18340a2e1"
+      "id": "native.apple.1da09b5d1db36b6b"
     },
     {
       "kind": "ui-call",
@@ -21191,7 +21191,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "/home/you/Projects/openclaw",
       "surface": "apple",
-      "id": "native.apple.dca75ab0dd73f0a4"
+      "id": "native.apple.eabfba3b5c98fa0b"
     },
     {
       "kind": "ui-call",
@@ -21199,7 +21199,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "CLI path",
       "surface": "apple",
-      "id": "native.apple.6998a7754dea6eb1"
+      "id": "native.apple.5eda80a1108b432a"
     },
     {
       "kind": "ui-call",
@@ -21207,7 +21207,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "/Applications/OpenClaw.app/.../openclaw",
       "surface": "apple",
-      "id": "native.apple.5a3f4f943c8ee86a"
+      "id": "native.apple.bd1a05baee1eabaf"
     },
     {
       "kind": "conditional-branch",
@@ -21215,7 +21215,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "surface": "apple",
-      "id": "native.apple.56e9b0831ec1eded"
+      "id": "native.apple.544b95327c839df9"
     },
     {
       "kind": "conditional-branch",
@@ -21223,7 +21223,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
       "surface": "apple",
-      "id": "native.apple.ab88df30f426b434"
+      "id": "native.apple.c80d394fabda1a0e"
     },
     {
       "kind": "ui-call",
@@ -21231,7 +21231,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Remote connection",
       "surface": "apple",
-      "id": "native.apple.2e11404d7539301e"
+      "id": "native.apple.655f1d9395d93cb1"
     },
     {
       "kind": "ui-call",
@@ -21239,7 +21239,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Checks the real remote websocket and auth handshake.",
       "surface": "apple",
-      "id": "native.apple.bee162bb681696a3"
+      "id": "native.apple.d9e7fc4c40dfcd9a"
     },
     {
       "kind": "ui-call",
@@ -21247,7 +21247,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Check connection",
       "surface": "apple",
-      "id": "native.apple.6e5d3a3c3022e8c8"
+      "id": "native.apple.5614cd2141315e7e"
     },
     {
       "kind": "ui-call",
@@ -21255,7 +21255,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Gateway token",
       "surface": "apple",
-      "id": "native.apple.1907a86a6cc2165b"
+      "id": "native.apple.653d66e0695bdfc1"
     },
     {
       "kind": "ui-call",
@@ -21263,7 +21263,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "remote gateway auth token (gateway.remote.token)",
       "surface": "apple",
-      "id": "native.apple.014d9fcbd97f6c48"
+      "id": "native.apple.49121841f9e3510e"
     },
     {
       "kind": "ui-call",
@@ -21271,7 +21271,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Used when the remote gateway requires token auth.",
       "surface": "apple",
-      "id": "native.apple.cc14b91d20cc33ba"
+      "id": "native.apple.0bce8531f76b02d1"
     },
     {
       "kind": "ui-call-concatenated",
@@ -21279,7 +21279,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "The current gateway.remote.token value is not plain text. OpenClaw for macOS cannot use it directly; enter a plaintext token here to replace it.",
       "surface": "apple",
-      "id": "native.apple.2a50c3ee94dde35d"
+      "id": "native.apple.f6c0c6ce1542d5ad"
     },
     {
       "kind": "ui-call",
@@ -21287,7 +21287,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Checking remote gateway…",
       "surface": "apple",
-      "id": "native.apple.ef011af3c0e22127"
+      "id": "native.apple.d032a76c6bdec6e9"
     },
     {
       "kind": "conditional-branch",
@@ -21295,7 +21295,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": " · ssh \\(parsed.port)",
       "surface": "apple",
-      "id": "native.apple.f2e8a7cfa21a0008"
+      "id": "native.apple.d25899da0fea9fd1"
     },
     {
       "kind": "ui-call",
@@ -21303,7 +21303,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Grant permissions",
       "surface": "apple",
-      "id": "native.apple.4bad86566d023a64"
+      "id": "native.apple.c59f7838d36e7316"
     },
     {
       "kind": "ui-call-concatenated",
@@ -21311,7 +21311,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "These macOS permissions let OpenClaw automate apps and capture context on this Mac. Status updates automatically.",
       "surface": "apple",
-      "id": "native.apple.ce0d1241d7417406"
+      "id": "native.apple.cc90f4f4fe246989"
     },
     {
       "kind": "ui-call",
@@ -21319,7 +21319,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Getting things ready",
       "surface": "apple",
-      "id": "native.apple.42af85cdf91d0264"
+      "id": "native.apple.ec77c26b599c99d3"
     },
     {
       "kind": "ui-call-concatenated",
@@ -21327,7 +21327,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "OpenClaw is setting up its background service on this Mac. This usually takes under a minute — no Terminal, no administrator password.",
       "surface": "apple",
-      "id": "native.apple.183aee003b44ede6"
+      "id": "native.apple.369d3719a7869c25"
     },
     {
       "kind": "ui-named-argument",
@@ -21335,7 +21335,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Install OpenClaw",
       "surface": "apple",
-      "id": "native.apple.d0b8cf59f852b3d0"
+      "id": "native.apple.e95f1cc961aee5a3"
     },
     {
       "kind": "ui-named-argument",
@@ -21343,7 +21343,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Start the background service",
       "surface": "apple",
-      "id": "native.apple.0112e18fa97e7c0c"
+      "id": "native.apple.58607cc9f6fb73dc"
     },
     {
       "kind": "ui-named-argument",
@@ -21351,7 +21351,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Runs quietly and starts again after a restart.",
       "surface": "apple",
-      "id": "native.apple.d1f9f278b55fe9b0"
+      "id": "native.apple.e7f623955648d07d"
     },
     {
       "kind": "ui-named-argument",
@@ -21359,7 +21359,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Ready for the next step",
       "surface": "apple",
-      "id": "native.apple.0357f1eea66db068"
+      "id": "native.apple.3b6bc0a5104d890b"
     },
     {
       "kind": "ui-named-argument",
@@ -21367,7 +21367,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Once the service answers, you’ll connect your AI.",
       "surface": "apple",
-      "id": "native.apple.9f58badc863cbf2b"
+      "id": "native.apple.40bcb49b3291e417"
     },
     {
       "kind": "ui-named-argument",
@@ -21375,7 +21375,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "The Gateway didn’t start",
       "surface": "apple",
-      "id": "native.apple.3bcb83316b3d90bb"
+      "id": "native.apple.e1563c28dab091f4"
     },
     {
       "kind": "ui-named-argument",
@@ -21383,7 +21383,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Try again",
       "surface": "apple",
-      "id": "native.apple.f36edc58238aa8ce"
+      "id": "native.apple.7d40d63ba0729923"
     },
     {
       "kind": "ui-call",
@@ -21391,7 +21391,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "You’re all set!",
       "surface": "apple",
-      "id": "native.apple.25e82538dc9e9aad"
+      "id": "native.apple.66f87ff56e8be6d8"
     },
     {
       "kind": "ui-call",
@@ -21399,7 +21399,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Finish opens the chat — say hi to your new agent.",
       "surface": "apple",
-      "id": "native.apple.9f73f753266a9fa2"
+      "id": "native.apple.bac72cb2b1c283fe"
     },
     {
       "kind": "ui-named-argument",
@@ -21407,7 +21407,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Configure later",
       "surface": "apple",
-      "id": "native.apple.678dee9dedd72ce4"
+      "id": "native.apple.6b47f49b8c933c76"
     },
     {
       "kind": "ui-named-argument",
@@ -21415,7 +21415,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Pick Local or Remote in Settings → General whenever you’re ready.",
       "surface": "apple",
-      "id": "native.apple.f87bc67e676d1289"
+      "id": "native.apple.9a0d519d6323de90"
     },
     {
       "kind": "ui-named-argument",
@@ -21423,7 +21423,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Remote gateway checklist",
       "surface": "apple",
-      "id": "native.apple.2eb061cd9d5f19fe"
+      "id": "native.apple.f330090303d6d3de"
     },
     {
       "kind": "ui-named-argument-multiline",
@@ -21431,7 +21431,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "On your gateway host: install/update the `openclaw` package and make sure credentials exist\n(typically `~/.openclaw/credentials/oauth.json`). Then connect again if needed.",
       "surface": "apple",
-      "id": "native.apple.952e85bfb2d4b4f5"
+      "id": "native.apple.2371586c6343c0d4"
     },
     {
       "kind": "ui-named-argument",
@@ -21439,7 +21439,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open the menu bar panel",
       "surface": "apple",
-      "id": "native.apple.4e5ccb411db3e80f"
+      "id": "native.apple.5f591d3c4947df43"
     },
     {
       "kind": "ui-named-argument",
@@ -21447,7 +21447,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Click the OpenClaw menu bar icon for quick chat and status.",
       "surface": "apple",
-      "id": "native.apple.f99e39e248dbc8ed"
+      "id": "native.apple.18c7845e518d4414"
     },
     {
       "kind": "ui-named-argument",
@@ -21455,7 +21455,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Connect Discord, Slack, Telegram, WhatsApp, …",
       "surface": "apple",
-      "id": "native.apple.1b6cfcf3be8765c2"
+      "id": "native.apple.8e025bf69b7fd07c"
     },
     {
       "kind": "ui-named-argument",
@@ -21463,7 +21463,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Channels to link channels and monitor status.",
       "surface": "apple",
-      "id": "native.apple.568b8fcf5608d3ea"
+      "id": "native.apple.bcb90769c4ce6c59"
     },
     {
       "kind": "ui-named-argument",
@@ -21471,7 +21471,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Channels",
       "surface": "apple",
-      "id": "native.apple.c37c668c737e8b71"
+      "id": "native.apple.abf6f66ebbd6ab34"
     },
     {
       "kind": "ui-named-argument",
@@ -21479,7 +21479,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Try Voice Wake",
       "surface": "apple",
-      "id": "native.apple.a39db653e07954af"
+      "id": "native.apple.0151f13b28118ac8"
     },
     {
       "kind": "ui-named-argument",
@@ -21487,7 +21487,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Enable Voice Wake in Settings for hands-free commands with a live transcript overlay.",
       "surface": "apple",
-      "id": "native.apple.bc571b825ef967a0"
+      "id": "native.apple.c9aa1b6019361263"
     },
     {
       "kind": "ui-named-argument",
@@ -21495,7 +21495,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Use the panel + Canvas",
       "surface": "apple",
-      "id": "native.apple.349252c2bd1d7b9d"
+      "id": "native.apple.bd3ddfa27560e804"
     },
     {
       "kind": "ui-named-argument-concatenated",
@@ -21511,7 +21511,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Give your agent more powers",
       "surface": "apple",
-      "id": "native.apple.9b44b38b75a868d8"
+      "id": "native.apple.129ee3c19501abe8"
     },
     {
       "kind": "ui-named-argument",
@@ -21519,7 +21519,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Enable optional skills (Peekaboo, oracle, camsnap, …) from Settings → Skills.",
       "surface": "apple",
-      "id": "native.apple.fea44c40dc512455"
+      "id": "native.apple.4f907c9bf5aff5c7"
     },
     {
       "kind": "ui-named-argument",
@@ -21527,7 +21527,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Skills",
       "surface": "apple",
-      "id": "native.apple.420781e5adca4122"
+      "id": "native.apple.110fc8f583a66435"
     },
     {
       "kind": "ui-call",
@@ -21535,7 +21535,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Launch at login",
       "surface": "apple",
-      "id": "native.apple.e54dfc2913c56f6f"
+      "id": "native.apple.950fb5cbb85269f6"
     },
     {
       "kind": "ui-call",
@@ -21543,7 +21543,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Skills included",
       "surface": "apple",
-      "id": "native.apple.040f2884f928f376"
+      "id": "native.apple.6eb6b27196ec0fa8"
     },
     {
       "kind": "ui-call",
@@ -21551,7 +21551,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.e38ea89bafb6b75d"
+      "id": "native.apple.d1973c29b61aa97c"
     },
     {
       "kind": "ui-call",
@@ -21559,7 +21559,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Couldn’t load skills from the Gateway.",
       "surface": "apple",
-      "id": "native.apple.38fc7e2b80c4e0fa"
+      "id": "native.apple.2cb56d71cbcbd17c"
     },
     {
       "kind": "ui-call-concatenated",
@@ -21567,7 +21567,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Make sure the Gateway is running and connected, then hit Refresh (or open Settings → Skills).",
       "surface": "apple",
-      "id": "native.apple.3b06694a81edc126"
+      "id": "native.apple.52eec6377af66f60"
     },
     {
       "kind": "ui-call",
@@ -21575,7 +21575,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Details: \\(error)",
       "surface": "apple",
-      "id": "native.apple.b6de2a51e5fb8397"
+      "id": "native.apple.68577d8b1064fe16"
     },
     {
       "kind": "ui-call",
@@ -21583,7 +21583,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "No skills reported yet.",
       "surface": "apple",
-      "id": "native.apple.b82621bc28d4c6e3"
+      "id": "native.apple.5b24d20f6bc718ff"
     },
     {
       "kind": "ui-call",
@@ -21591,7 +21591,7 @@
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Not Now",
       "surface": "apple",
-      "id": "native.apple.048e9cc88fb7af55"
+      "id": "native.apple.4c083e16441ff0a2"
     },
     {
       "kind": "ui-call",
@@ -21615,7 +21615,7 @@
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Pairing Request",
       "surface": "apple",
-      "id": "native.apple.57e27a9a3ef63ac4"
+      "id": "native.apple.cd13e51bf71ab6c5"
     },
     {
       "kind": "conditional-branch",
@@ -21623,7 +21623,7 @@
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Pairing Requests",
       "surface": "apple",
-      "id": "native.apple.61152c2ea359eaa0"
+      "id": "native.apple.dd6312b3e8ec6484"
     },
     {
       "kind": "ui-modifier",
@@ -21631,7 +21631,7 @@
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Copy full ID",
       "surface": "apple",
-      "id": "native.apple.d3b539b5e822f581"
+      "id": "native.apple.85ad1c8614eac249"
     },
     {
       "kind": "conditional-branch",
@@ -21639,7 +21639,7 @@
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Approve Device",
       "surface": "apple",
-      "id": "native.apple.01bd6552a4adee7c"
+      "id": "native.apple.cd653991c846b0f1"
     },
     {
       "kind": "conditional-branch",
@@ -21647,7 +21647,7 @@
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Approve Node",
       "surface": "apple",
-      "id": "native.apple.b12ad4f00b1cd3d1"
+      "id": "native.apple.900661cb771e935d"
     },
     {
       "kind": "ui-call",
@@ -21655,7 +21655,7 @@
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Reject",
       "surface": "apple",
-      "id": "native.apple.8878bb60553ad307"
+      "id": "native.apple.66410331e4296fec"
     },
     {
       "kind": "conditional-branch",
@@ -21663,7 +21663,7 @@
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "A node wants to connect to OpenClaw.",
       "surface": "apple",
-      "id": "native.apple.11b1b5e9dd510766"
+      "id": "native.apple.fcef164f14da6208"
     },
     {
       "kind": "conditional-branch",
@@ -21671,7 +21671,7 @@
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "A device wants to connect to OpenClaw.",
       "surface": "apple",
-      "id": "native.apple.2e9d9d1f5d4346d4"
+      "id": "native.apple.217056cdb4424709"
     },
     {
       "kind": "conditional-branch",
@@ -21679,7 +21679,7 @@
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "New device",
       "surface": "apple",
-      "id": "native.apple.2412e85f7d11395e"
+      "id": "native.apple.713286b17f6b5f79"
     },
     {
       "kind": "conditional-branch",
@@ -21687,7 +21687,7 @@
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "OpenClaw Mac app",
       "surface": "apple",
-      "id": "native.apple.a09a61f4efe1e63e"
+      "id": "native.apple.154fe84f1d704fb5"
     },
     {
       "kind": "conditional-branch",
@@ -21711,7 +21711,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Permissions",
       "surface": "apple",
-      "id": "native.apple.6223e5f12aa9464b"
+      "id": "native.apple.51a204c438cd49af"
     },
     {
       "kind": "ui-named-argument",
@@ -21719,7 +21719,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "macOS access for notifications, capture, voice, and device context.",
       "surface": "apple",
-      "id": "native.apple.13de15babf16f5a1"
+      "id": "native.apple.179d3c1b6f6be0d3"
     },
     {
       "kind": "ui-call",
@@ -21727,7 +21727,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "System Access",
       "surface": "apple",
-      "id": "native.apple.d103265c3c4586f2"
+      "id": "native.apple.ab7ad51cdcff0376"
     },
     {
       "kind": "ui-call",
@@ -21735,7 +21735,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Setup",
       "surface": "apple",
-      "id": "native.apple.89a4f5934df8268a"
+      "id": "native.apple.9141245b1f1fc704"
     },
     {
       "kind": "ui-named-argument",
@@ -21743,7 +21743,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Onboarding walkthrough",
       "surface": "apple",
-      "id": "native.apple.7df9aa7e39b10c6f"
+      "id": "native.apple.d5e4fd3f85426f12"
     },
     {
       "kind": "ui-named-argument",
@@ -21751,7 +21751,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Use this if macOS prompts were skipped or permissions need a fresh walkthrough.",
       "surface": "apple",
-      "id": "native.apple.88b8006036788e0f"
+      "id": "native.apple.43e2bb40b382ba46"
     },
     {
       "kind": "ui-call",
@@ -21759,7 +21759,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Restart onboarding",
       "surface": "apple",
-      "id": "native.apple.f68a3f48ba505366"
+      "id": "native.apple.2d98029f6ba3df46"
     },
     {
       "kind": "conditional-branch",
@@ -21767,7 +21767,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "All access granted",
       "surface": "apple",
-      "id": "native.apple.19f209e84449fd85"
+      "id": "native.apple.e79191e199cf406b"
     },
     {
       "kind": "conditional-branch",
@@ -21775,7 +21775,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "\\(granted) of \\(total) permissions granted",
       "surface": "apple",
-      "id": "native.apple.22089fc9d573f6ea"
+      "id": "native.apple.9532e2ef2c5c5c77"
     },
     {
       "kind": "ui-call",
@@ -21783,7 +21783,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "OpenClaw only asks for macOS capabilities when a feature needs them.",
       "surface": "apple",
-      "id": "native.apple.4344ff6c0e9d7187"
+      "id": "native.apple.49b40cdcd258b296"
     },
     {
       "kind": "ui-named-argument",
@@ -21791,7 +21791,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Location access",
       "surface": "apple",
-      "id": "native.apple.4fecdab98e2f6a11"
+      "id": "native.apple.5dbbe7e1d951f633"
     },
     {
       "kind": "ui-named-argument",
@@ -21799,7 +21799,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Allow agents to use device location when a tool asks for it.",
       "surface": "apple",
-      "id": "native.apple.2f44a5e39b905093"
+      "id": "native.apple.ff95a392ced899c4"
     },
     {
       "kind": "ui-call",
@@ -21807,7 +21807,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Location Access",
       "surface": "apple",
-      "id": "native.apple.3aa3ccdcc285b461"
+      "id": "native.apple.d018a1315fa35aea"
     },
     {
       "kind": "ui-call",
@@ -21815,7 +21815,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Off",
       "surface": "apple",
-      "id": "native.apple.cf3a5c243de1ef5a"
+      "id": "native.apple.2c1fe8eff308f98b"
     },
     {
       "kind": "ui-call",
@@ -21823,7 +21823,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "While Using",
       "surface": "apple",
-      "id": "native.apple.d5020a219ed1ac41"
+      "id": "native.apple.f62423c183fd5950"
     },
     {
       "kind": "ui-call",
@@ -21831,7 +21831,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Always",
       "surface": "apple",
-      "id": "native.apple.e03eebb9f39381b4"
+      "id": "native.apple.d8e576369690f45c"
     },
     {
       "kind": "ui-named-argument",
@@ -21839,7 +21839,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Precise location",
       "surface": "apple",
-      "id": "native.apple.397066524678f9bb"
+      "id": "native.apple.476c5d14d3b288c0"
     },
     {
       "kind": "ui-named-argument",
@@ -21847,7 +21847,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Always may require System Settings to approve background location.",
       "surface": "apple",
-      "id": "native.apple.ef9aee632b333f9f"
+      "id": "native.apple.f18b96d468ca7e4f"
     },
     {
       "kind": "ui-call",
@@ -21855,7 +21855,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Precise Location",
       "surface": "apple",
-      "id": "native.apple.f2cad6d6841591ae"
+      "id": "native.apple.0b44b2b295c8cfd2"
     },
     {
       "kind": "ui-named-argument",
@@ -21863,7 +21863,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Refresh status",
       "surface": "apple",
-      "id": "native.apple.518ac87e9fb6185b"
+      "id": "native.apple.515269a7b1435412"
     },
     {
       "kind": "ui-named-argument",
@@ -21871,7 +21871,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Recheck macOS after approving access in System Settings.",
       "surface": "apple",
-      "id": "native.apple.7fbaadabe2055224"
+      "id": "native.apple.81afbe6e3021b522"
     },
     {
       "kind": "ui-call",
@@ -21879,7 +21879,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.cc8c64fe846d3cca"
+      "id": "native.apple.db3b191e4eb78075"
     },
     {
       "kind": "ui-call",
@@ -21887,7 +21887,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Grant",
       "surface": "apple",
-      "id": "native.apple.7b62187659c9925f"
+      "id": "native.apple.17ba9157c0c8cc84"
     },
     {
       "kind": "ui-call",
@@ -21895,7 +21895,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Granted",
       "surface": "apple",
-      "id": "native.apple.9587edffda4b78f0"
+      "id": "native.apple.24badbca9bd8f460"
     },
     {
       "kind": "ui-call",
@@ -21903,7 +21903,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Checking…",
       "surface": "apple",
-      "id": "native.apple.27ff5be3db0efbd0"
+      "id": "native.apple.3eea5844d6247c58"
     },
     {
       "kind": "ui-call",
@@ -21911,7 +21911,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Request access",
       "surface": "apple",
-      "id": "native.apple.c8a3879230179938"
+      "id": "native.apple.5303d5f2a8e5473b"
     },
     {
       "kind": "conditional-branch",
@@ -21919,7 +21919,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Automation (AppleScript)",
       "surface": "apple",
-      "id": "native.apple.8d8386041799d2b0"
+      "id": "native.apple.e468c430777cab76"
     },
     {
       "kind": "conditional-branch",
@@ -21927,7 +21927,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Notifications",
       "surface": "apple",
-      "id": "native.apple.bc935384479c2f48"
+      "id": "native.apple.862bc4fa0bb22c5e"
     },
     {
       "kind": "conditional-branch",
@@ -21935,7 +21935,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Accessibility",
       "surface": "apple",
-      "id": "native.apple.922a8b5e049ef146"
+      "id": "native.apple.1980c81c0b9ede5e"
     },
     {
       "kind": "conditional-branch",
@@ -21943,7 +21943,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Screen Recording",
       "surface": "apple",
-      "id": "native.apple.c2f2fac8ab1ef9c0"
+      "id": "native.apple.08caf4429feb223f"
     },
     {
       "kind": "conditional-branch",
@@ -21951,7 +21951,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Microphone",
       "surface": "apple",
-      "id": "native.apple.5ec94fe5a6864de7"
+      "id": "native.apple.448ea72ec1841808"
     },
     {
       "kind": "conditional-branch",
@@ -21959,7 +21959,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Speech Recognition",
       "surface": "apple",
-      "id": "native.apple.b27a5cb9cffe05f0"
+      "id": "native.apple.09caf8087458206b"
     },
     {
       "kind": "conditional-branch",
@@ -21967,7 +21967,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Camera",
       "surface": "apple",
-      "id": "native.apple.3639c706ed77975c"
+      "id": "native.apple.ff630389be6e4956"
     },
     {
       "kind": "conditional-branch",
@@ -21975,7 +21975,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Location",
       "surface": "apple",
-      "id": "native.apple.fee0f3732a447f35"
+      "id": "native.apple.8139888a0fcede71"
     },
     {
       "kind": "conditional-branch",
@@ -21983,7 +21983,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Control other apps (e.g. Terminal) for automation actions",
       "surface": "apple",
-      "id": "native.apple.4a4c10ca63e99590"
+      "id": "native.apple.e8c371d1195c8314"
     },
     {
       "kind": "conditional-branch",
@@ -21991,7 +21991,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Show desktop alerts for agent activity",
       "surface": "apple",
-      "id": "native.apple.5f7eb4234f63c4ad"
+      "id": "native.apple.5f05b07c12c9e4ba"
     },
     {
       "kind": "conditional-branch",
@@ -21999,7 +21999,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Control UI elements when an action requires it",
       "surface": "apple",
-      "id": "native.apple.229e60ca0a750f1c"
+      "id": "native.apple.a65532abd8b09118"
     },
     {
       "kind": "conditional-branch",
@@ -22007,7 +22007,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Capture the screen for context or screenshots",
       "surface": "apple",
-      "id": "native.apple.0a07b117054babb0"
+      "id": "native.apple.6526588e5f3f2eb3"
     },
     {
       "kind": "conditional-branch",
@@ -22015,7 +22015,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Allow Voice Wake and audio capture",
       "surface": "apple",
-      "id": "native.apple.b004145c37a470f8"
+      "id": "native.apple.924be7cdb34e97e6"
     },
     {
       "kind": "conditional-branch",
@@ -22023,7 +22023,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Transcribe Voice Wake trigger phrases on-device",
       "surface": "apple",
-      "id": "native.apple.7c8b825829b3924d"
+      "id": "native.apple.d1a3f84cfc8aa293"
     },
     {
       "kind": "conditional-branch",
@@ -22031,7 +22031,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Capture photos and video from the camera",
       "surface": "apple",
-      "id": "native.apple.37880f3b7ae6c259"
+      "id": "native.apple.c5e443694f999653"
     },
     {
       "kind": "conditional-branch",
@@ -22039,7 +22039,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Share location when requested by the agent",
       "surface": "apple",
-      "id": "native.apple.1f5015480ea0f783"
+      "id": "native.apple.edd4b0ed3c0bcb23"
     },
     {
       "kind": "conditional-branch",
@@ -22047,7 +22047,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway requires an auth token",
       "surface": "apple",
-      "id": "native.apple.1eeca02c45d3db5a"
+      "id": "native.apple.30b85d1139d9ae9f"
     },
     {
       "kind": "conditional-branch",
@@ -22055,7 +22055,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "That token did not match the gateway",
       "surface": "apple",
-      "id": "native.apple.b45db388b1bd36bb"
+      "id": "native.apple.9577d1b8b3ed1dc4"
     },
     {
       "kind": "conditional-branch",
@@ -22063,7 +22063,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway host needs token setup",
       "surface": "apple",
-      "id": "native.apple.199c0835c6de23e5"
+      "id": "native.apple.49bb6be2d695c330"
     },
     {
       "kind": "conditional-branch",
@@ -22071,7 +22071,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This setup code is no longer valid",
       "surface": "apple",
-      "id": "native.apple.ff1cbf5fb69f6d53"
+      "id": "native.apple.a89437e1da2cf7a3"
     },
     {
       "kind": "conditional-branch",
@@ -22079,7 +22079,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway is using unsupported auth",
       "surface": "apple",
-      "id": "native.apple.4f751db2308294e1"
+      "id": "native.apple.bc92346e2f93f44b"
     },
     {
       "kind": "conditional-branch",
@@ -22087,7 +22087,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This device needs pairing approval",
       "surface": "apple",
-      "id": "native.apple.2e5704a3b8fcc47f"
+      "id": "native.apple.2f7f665be741d381"
     },
     {
       "kind": "conditional-branch",
@@ -22103,7 +22103,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Check `gateway.auth.token` or `OPENCLAW_GATEWAY_TOKEN` on the gateway host and try again.",
       "surface": "apple",
-      "id": "native.apple.bbb87d21ce8a291e"
+      "id": "native.apple.dde3a28878883443"
     },
     {
       "kind": "conditional-branch",
@@ -22119,7 +22119,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Scan or paste a fresh setup code from an already-paired OpenClaw client, then try again.",
       "surface": "apple",
-      "id": "native.apple.83145f8f53d7be34"
+      "id": "native.apple.e85b68221571e93c"
     },
     {
       "kind": "conditional-branch",
@@ -22143,7 +22143,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway requires an auth token from the gateway host.",
       "surface": "apple",
-      "id": "native.apple.e73170e4ab1dbe8f"
+      "id": "native.apple.63104b46c850820d"
     },
     {
       "kind": "conditional-branch",
@@ -22151,7 +22151,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Gateway token mismatch. Check gateway.auth.token or OPENCLAW_GATEWAY_TOKEN on the gateway host.",
       "surface": "apple",
-      "id": "native.apple.e3f983b8c517da29"
+      "id": "native.apple.d7a042a3fa394c0a"
     },
     {
       "kind": "conditional-branch",
@@ -22159,7 +22159,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway has token auth enabled, but no gateway.auth.token is configured on the host.",
       "surface": "apple",
-      "id": "native.apple.cd96754a96e5aa35"
+      "id": "native.apple.6a3ffe9bb4cb1f73"
     },
     {
       "kind": "conditional-branch",
@@ -22167,7 +22167,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Setup code expired or already used. Scan a fresh setup code, then try again.",
       "surface": "apple",
-      "id": "native.apple.b58556877f8eba24"
+      "id": "native.apple.1253ca7643f527c9"
     },
     {
       "kind": "conditional-branch",
@@ -22175,7 +22175,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway uses password auth. Remote onboarding on macOS cannot collect gateway passwords yet.",
       "surface": "apple",
-      "id": "native.apple.49ea9045d0c7402d"
+      "id": "native.apple.5e47691ccacd5e6d"
     },
     {
       "kind": "conditional-branch",
@@ -22191,7 +22191,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Connected via paired device",
       "surface": "apple",
-      "id": "native.apple.58e76e9c8b04290a"
+      "id": "native.apple.5fb55d9d6e58eb32"
     },
     {
       "kind": "conditional-branch",
@@ -22199,7 +22199,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Connected with setup code",
       "surface": "apple",
-      "id": "native.apple.dbe7f99297c2269d"
+      "id": "native.apple.aac72b3f665fc1a2"
     },
     {
       "kind": "conditional-branch",
@@ -22207,7 +22207,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Connected with gateway token",
       "surface": "apple",
-      "id": "native.apple.a3c2651d36de9c7f"
+      "id": "native.apple.934b96bcaeade5a5"
     },
     {
       "kind": "conditional-branch",
@@ -22215,7 +22215,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Connected with password",
       "surface": "apple",
-      "id": "native.apple.f9df689f570952aa"
+      "id": "native.apple.9ede96375789333b"
     },
     {
       "kind": "conditional-branch",
@@ -22223,7 +22223,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Remote gateway ready",
       "surface": "apple",
-      "id": "native.apple.ebfc72d56c8b3e3a"
+      "id": "native.apple.b91f95273c683db5"
     },
     {
       "kind": "conditional-branch",
@@ -22231,7 +22231,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemotePortTunnel.swift",
       "source": "ssh tunnel exited before listening",
       "surface": "apple",
-      "id": "native.apple.6d7241b4b36686bb"
+      "id": "native.apple.eb846295467ca892"
     },
     {
       "kind": "conditional-branch",
@@ -22239,7 +22239,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemotePortTunnel.swift",
       "source": "ssh tunnel did not open local port \\(localPort)",
       "surface": "apple",
-      "id": "native.apple.253f6eb372b87540"
+      "id": "native.apple.115b9f62f8f84688"
     },
     {
       "kind": "conditional-branch",
@@ -22247,7 +22247,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemotePortTunnel.swift",
       "source": "ssh tunnel failed: \\(stderr)",
       "surface": "apple",
-      "id": "native.apple.3744275a6a0eaaa2"
+      "id": "native.apple.cb2c889fb02d7042"
     },
     {
       "kind": "plist-string",
@@ -22255,7 +22255,7 @@
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw needs notification permission to show alerts for agent actions.",
       "surface": "apple",
-      "id": "native.apple.2d7556d00f123112"
+      "id": "native.apple.fcf7fea1fb2c473a"
     },
     {
       "kind": "plist-string",
@@ -22263,7 +22263,7 @@
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw captures the screen when the agent needs screenshots for context.",
       "surface": "apple",
-      "id": "native.apple.d9e7be03543b508f"
+      "id": "native.apple.9b068dd56129fa27"
     },
     {
       "kind": "plist-string",
@@ -22271,7 +22271,7 @@
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw can capture photos or short video clips when requested by the agent.",
       "surface": "apple",
-      "id": "native.apple.eca927767423799c"
+      "id": "native.apple.21db425107db803c"
     },
     {
       "kind": "plist-string",
@@ -22279,7 +22279,7 @@
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw can share your location when requested by the agent.",
       "surface": "apple",
-      "id": "native.apple.9389d1100944a1fd"
+      "id": "native.apple.f3aca271d395e69f"
     },
     {
       "kind": "plist-string",
@@ -22287,7 +22287,7 @@
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw uses the local network to connect to your remote OpenClaw gateway over LAN, Tailnet, or SSH.",
       "surface": "apple",
-      "id": "native.apple.59da76aed1cb07ee"
+      "id": "native.apple.74e5fb413c010dcd"
     },
     {
       "kind": "plist-string",
@@ -22295,7 +22295,7 @@
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw needs the mic for Voice Wake tests and agent audio capture.",
       "surface": "apple",
-      "id": "native.apple.5db9a976fd1c7fcb"
+      "id": "native.apple.d42cf498a4763c52"
     },
     {
       "kind": "plist-string",
@@ -22303,7 +22303,7 @@
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw uses speech recognition to detect your Voice Wake trigger phrase.",
       "surface": "apple",
-      "id": "native.apple.b7aba524ef867e7f"
+      "id": "native.apple.9a85fef692acd907"
     },
     {
       "kind": "plist-string",
@@ -22311,7 +22311,7 @@
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw needs Automation (AppleScript) permission to drive Terminal and other apps for agent actions.",
       "surface": "apple",
-      "id": "native.apple.2d5411b5cc54a93e"
+      "id": "native.apple.192b374844204d37"
     },
     {
       "kind": "plist-string",
@@ -22319,7 +22319,7 @@
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw can access Reminders when requested by the agent for the apple-reminders skill.",
       "surface": "apple",
-      "id": "native.apple.e16fc45de0f2bb86"
+      "id": "native.apple.5ebea77709397c1c"
     },
     {
       "kind": "conditional-branch",
@@ -22327,7 +22327,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionData.swift",
       "source": "Cron",
       "surface": "apple",
-      "id": "native.apple.6f7c6ef00a40a571"
+      "id": "native.apple.5dd4c0beab591811"
     },
     {
       "kind": "conditional-branch",
@@ -22335,7 +22335,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionData.swift",
       "source": "Direct",
       "surface": "apple",
-      "id": "native.apple.919c478455279274"
+      "id": "native.apple.2bcf0cb05b6503fb"
     },
     {
       "kind": "conditional-branch",
@@ -22343,7 +22343,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionData.swift",
       "source": "Group",
       "surface": "apple",
-      "id": "native.apple.d90d9456fbd96681"
+      "id": "native.apple.5ae4a6d35078287e"
     },
     {
       "kind": "conditional-branch",
@@ -22351,7 +22351,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionData.swift",
       "source": "Global",
       "surface": "apple",
-      "id": "native.apple.ef8c8542159968f8"
+      "id": "native.apple.af42a67494ad80b3"
     },
     {
       "kind": "conditional-branch",
@@ -22359,7 +22359,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionData.swift",
       "source": "Unknown",
       "surface": "apple",
-      "id": "native.apple.c69d014c626f3c53"
+      "id": "native.apple.318cf5d04ea1680c"
     },
     {
       "kind": "ui-call",
@@ -22367,7 +22367,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionMenuLabelView.swift",
       "source": "\\(self.row.tokens.contextSummaryShort) · \\(self.row.ageText)",
       "surface": "apple",
-      "id": "native.apple.c83f50f9eafa4e4a"
+      "id": "native.apple.5a8fed37790804fb"
     },
     {
       "kind": "conditional-branch",
@@ -22375,7 +22375,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionMenuPreviewView.swift",
       "source": "User",
       "surface": "apple",
-      "id": "native.apple.c0a774fe7e5cfc29"
+      "id": "native.apple.87440c9bdbcb7fcc"
     },
     {
       "kind": "conditional-branch",
@@ -22383,7 +22383,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionMenuPreviewView.swift",
       "source": "Agent",
       "surface": "apple",
-      "id": "native.apple.698ebf4ad46a412b"
+      "id": "native.apple.b3a05b6d17787569"
     },
     {
       "kind": "conditional-branch",
@@ -22391,7 +22391,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionMenuPreviewView.swift",
       "source": "Tool",
       "surface": "apple",
-      "id": "native.apple.5f2fd2617a999a52"
+      "id": "native.apple.fb211cfd4abae507"
     },
     {
       "kind": "conditional-branch",
@@ -22399,7 +22399,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionMenuPreviewView.swift",
       "source": "System",
       "surface": "apple",
-      "id": "native.apple.50ac80f686775ccc"
+      "id": "native.apple.0be1e1f174d5bbfc"
     },
     {
       "kind": "conditional-branch",
@@ -22407,7 +22407,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionMenuPreviewView.swift",
       "source": "Other",
       "surface": "apple",
-      "id": "native.apple.d39019414981fe78"
+      "id": "native.apple.31ab431975cf88ed"
     },
     {
       "kind": "ui-call",
@@ -22415,7 +22415,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionMenuPreviewView.swift",
       "source": "Loading preview…",
       "surface": "apple",
-      "id": "native.apple.d3bd405935159f59"
+      "id": "native.apple.8b544d5a6eb0de48"
     },
     {
       "kind": "ui-call",
@@ -22423,7 +22423,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionMenuPreviewView.swift",
       "source": "No recent messages",
       "surface": "apple",
-      "id": "native.apple.4927996a6552bca2"
+      "id": "native.apple.00b81a608b0f4047"
     },
     {
       "kind": "ui-call",
@@ -22431,7 +22431,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionsSettings.swift",
       "source": "Sessions",
       "surface": "apple",
-      "id": "native.apple.1ff8aec0044934c3"
+      "id": "native.apple.a9fbaedd2eccc345"
     },
     {
       "kind": "ui-call",
@@ -22439,7 +22439,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionsSettings.swift",
       "source": "Peek at the stored conversation buckets the CLI reuses for context and rate limits.",
       "surface": "apple",
-      "id": "native.apple.74f66e96c112c3fa"
+      "id": "native.apple.b25085e978ec5484"
     },
     {
       "kind": "ui-call",
@@ -22447,7 +22447,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionsSettings.swift",
       "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
       "surface": "apple",
-      "id": "native.apple.bab897f3252b134c"
+      "id": "native.apple.0765808d387f4e63"
     },
     {
       "kind": "ui-call",
@@ -22455,7 +22455,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionsSettings.swift",
       "source": "Context",
       "surface": "apple",
-      "id": "native.apple.cebd5d2895976bee"
+      "id": "native.apple.62a67b49534dfc10"
     },
     {
       "kind": "ui-named-argument",
@@ -22463,7 +22463,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionsSettings.swift",
       "source": "\\(row.tokens.input) in",
       "surface": "apple",
-      "id": "native.apple.eadc3062b763cc17"
+      "id": "native.apple.f5281aae5e3d8057"
     },
     {
       "kind": "ui-named-argument",
@@ -22471,7 +22471,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionsSettings.swift",
       "source": "\\(row.tokens.output) out",
       "surface": "apple",
-      "id": "native.apple.250094959877efb0"
+      "id": "native.apple.9da146d21bb4a19c"
     },
     {
       "kind": "ui-call",
@@ -22479,7 +22479,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRefreshButton.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.3c7279b3288a44da"
+      "id": "native.apple.650edfd9bf78df64"
     },
     {
       "kind": "ui-call",
@@ -22487,7 +22487,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Managed by Nix",
       "surface": "apple",
-      "id": "native.apple.05918601c3b3b241"
+      "id": "native.apple.19bac0fbee189391"
     },
     {
       "kind": "ui-call",
@@ -22495,7 +22495,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Config: \\(configPath)",
       "surface": "apple",
-      "id": "native.apple.deb89a876875cb48"
+      "id": "native.apple.a142cff76404833b"
     },
     {
       "kind": "ui-call",
@@ -22503,7 +22503,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "State:  \\(stateDir)",
       "surface": "apple",
-      "id": "native.apple.96221e7b3b153764"
+      "id": "native.apple.5735ec2f87becaaa"
     },
     {
       "kind": "conditional-branch",
@@ -22511,7 +22511,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "General",
       "surface": "apple",
-      "id": "native.apple.d59e05a8305df17c"
+      "id": "native.apple.6fa153cb1b922306"
     },
     {
       "kind": "conditional-branch",
@@ -22519,7 +22519,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Connection",
       "surface": "apple",
-      "id": "native.apple.2af062df8d3934a4"
+      "id": "native.apple.2689694494e1b0f1"
     },
     {
       "kind": "conditional-branch",
@@ -22527,7 +22527,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Permissions",
       "surface": "apple",
-      "id": "native.apple.8c2b0262f3a5ebea"
+      "id": "native.apple.ab9c8c59c2a8a7d3"
     },
     {
       "kind": "conditional-branch",
@@ -22535,7 +22535,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Voice & Talk",
       "surface": "apple",
-      "id": "native.apple.f5f4ff67674093ec"
+      "id": "native.apple.5e4b8974a30f27b0"
     },
     {
       "kind": "conditional-branch",
@@ -22543,7 +22543,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Crestodian",
       "surface": "apple",
-      "id": "native.apple.f5aa19bc071cf585"
+      "id": "native.apple.e7fb336701ed3d29"
     },
     {
       "kind": "conditional-branch",
@@ -22551,7 +22551,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Channels",
       "surface": "apple",
-      "id": "native.apple.04b9c8402f19b8ce"
+      "id": "native.apple.5e121e46b7df6fcb"
     },
     {
       "kind": "conditional-branch",
@@ -22559,7 +22559,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Skills",
       "surface": "apple",
-      "id": "native.apple.7b0912ebdda53aa7"
+      "id": "native.apple.cfa1623d2c7c9be2"
     },
     {
       "kind": "conditional-branch",
@@ -22567,7 +22567,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Cron Jobs",
       "surface": "apple",
-      "id": "native.apple.bf08d706c71f2d9b"
+      "id": "native.apple.9f28d6f214b45c82"
     },
     {
       "kind": "conditional-branch",
@@ -22575,7 +22575,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Exec Approvals",
       "surface": "apple",
-      "id": "native.apple.bf80bdb5a3dda276"
+      "id": "native.apple.ebc3bb82d126786c"
     },
     {
       "kind": "conditional-branch",
@@ -22583,7 +22583,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Sessions",
       "surface": "apple",
-      "id": "native.apple.64a6dc7d49e8fb57"
+      "id": "native.apple.d06b0a2ab653b605"
     },
     {
       "kind": "conditional-branch",
@@ -22591,7 +22591,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Instances",
       "surface": "apple",
-      "id": "native.apple.704924cd0704b5b5"
+      "id": "native.apple.877047c64f34f8d1"
     },
     {
       "kind": "conditional-branch",
@@ -22599,7 +22599,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Config",
       "surface": "apple",
-      "id": "native.apple.033d7a0753f0844a"
+      "id": "native.apple.481f9f25738b893e"
     },
     {
       "kind": "conditional-branch",
@@ -22607,7 +22607,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Debug",
       "surface": "apple",
-      "id": "native.apple.149b9ff742e6ff4f"
+      "id": "native.apple.34abdf0f9c0114c4"
     },
     {
       "kind": "conditional-branch",
@@ -22615,7 +22615,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "About",
       "surface": "apple",
-      "id": "native.apple.7ff14339afa21b57"
+      "id": "native.apple.c020dba4ebc41441"
     },
     {
       "kind": "ui-named-argument",
@@ -22623,7 +22623,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Skills",
       "surface": "apple",
-      "id": "native.apple.d1576a88854dcd99"
+      "id": "native.apple.688b539dc0f686a3"
     },
     {
       "kind": "ui-named-argument",
@@ -22631,7 +22631,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Optional capabilities that become available when their requirements are met.",
       "surface": "apple",
-      "id": "native.apple.0f62bd687b786431"
+      "id": "native.apple.c94c9ec6b9c8d938"
     },
     {
       "kind": "conditional-branch",
@@ -22639,7 +22639,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Loading skills",
       "surface": "apple",
-      "id": "native.apple.d40a7bb04c5534ec"
+      "id": "native.apple.1b2d195af6a1a87e"
     },
     {
       "kind": "conditional-branch",
@@ -22647,7 +22647,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "\\(ready) ready · \\(needsSetup) need setup",
       "surface": "apple",
-      "id": "native.apple.767c2d19030d459a"
+      "id": "native.apple.8096bebff6fc7a91"
     },
     {
       "kind": "ui-call",
@@ -22655,7 +22655,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Enable ready skills, or install missing tools on the Gateway or this Mac.",
       "surface": "apple",
-      "id": "native.apple.6a9cf4d0e171abb0"
+      "id": "native.apple.70cca3c13c018f45"
     },
     {
       "kind": "ui-call",
@@ -22663,7 +22663,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "\\(total)",
       "surface": "apple",
-      "id": "native.apple.79d4590049b0a8f2"
+      "id": "native.apple.6edb2a569b1bde19"
     },
     {
       "kind": "ui-call",
@@ -22671,7 +22671,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Controls",
       "surface": "apple",
-      "id": "native.apple.07f69b9ef2f5f80e"
+      "id": "native.apple.13e0f4a1cefe44b6"
     },
     {
       "kind": "ui-named-argument",
@@ -22679,7 +22679,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Skill catalog",
       "surface": "apple",
-      "id": "native.apple.1253563cada71e4d"
+      "id": "native.apple.fb917861231ee50b"
     },
     {
       "kind": "ui-named-argument",
@@ -22687,7 +22687,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Refresh after changing binaries, environment variables, or skill config.",
       "surface": "apple",
-      "id": "native.apple.7bcdd77b0b2657e3"
+      "id": "native.apple.0ce8065d6517ccef"
     },
     {
       "kind": "ui-call",
@@ -22695,7 +22695,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.be08a918dffd2913"
+      "id": "native.apple.4c7db32479c42e0d"
     },
     {
       "kind": "conditional-branch",
@@ -22703,7 +22703,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Loading…",
       "surface": "apple",
-      "id": "native.apple.85a9941ff7a30fbe"
+      "id": "native.apple.98a6120efa25808e"
     },
     {
       "kind": "conditional-branch",
@@ -22711,7 +22711,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "No skills reported yet",
       "surface": "apple",
-      "id": "native.apple.8f5459c837515766"
+      "id": "native.apple.0e3a101b8734762d"
     },
     {
       "kind": "conditional-branch",
@@ -22727,7 +22727,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "No skills match this filter.",
       "surface": "apple",
-      "id": "native.apple.ddac24dd3c4ad758"
+      "id": "native.apple.6fd4ee769eb0bc85"
     },
     {
       "kind": "ui-call",
@@ -22735,7 +22735,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Filter",
       "surface": "apple",
-      "id": "native.apple.2beddcc70ea0d96a"
+      "id": "native.apple.b0f748e6782b506b"
     },
     {
       "kind": "conditional-branch",
@@ -22743,7 +22743,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "All",
       "surface": "apple",
-      "id": "native.apple.eb868667821fbf7c"
+      "id": "native.apple.bf020a56e774e0ed"
     },
     {
       "kind": "conditional-branch",
@@ -22751,7 +22751,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Ready",
       "surface": "apple",
-      "id": "native.apple.dfef84686e0e48b8"
+      "id": "native.apple.cf938dfa98547f53"
     },
     {
       "kind": "conditional-branch",
@@ -22759,7 +22759,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Needs Setup",
       "surface": "apple",
-      "id": "native.apple.e4104925870c47b2"
+      "id": "native.apple.9442bd64b2dfc989"
     },
     {
       "kind": "conditional-branch",
@@ -22767,7 +22767,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Disabled",
       "surface": "apple",
-      "id": "native.apple.c2059055c673e88b"
+      "id": "native.apple.b788024f52f39719"
     },
     {
       "kind": "ui-call",
@@ -22775,7 +22775,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Website",
       "surface": "apple",
-      "id": "native.apple.d863af685def7a16"
+      "id": "native.apple.2459547e5dcb47d7"
     },
     {
       "kind": "ui-call",
@@ -22783,7 +22783,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Details",
       "surface": "apple",
-      "id": "native.apple.f8994366d9516e2a"
+      "id": "native.apple.1918d92935d9b890"
     },
     {
       "kind": "conditional-branch",
@@ -22791,7 +22791,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Needs setup",
       "surface": "apple",
-      "id": "native.apple.2f55e65c7c94f978"
+      "id": "native.apple.da42c0e9b695af67"
     },
     {
       "kind": "conditional-branch",
@@ -22799,7 +22799,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Managed",
       "surface": "apple",
-      "id": "native.apple.1b2cab26853b1074"
+      "id": "native.apple.cfe9aeef3878443a"
     },
     {
       "kind": "conditional-branch",
@@ -22807,7 +22807,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Workspace",
       "surface": "apple",
-      "id": "native.apple.4edf9ab6280b72ff"
+      "id": "native.apple.6dcec9f767411497"
     },
     {
       "kind": "conditional-branch",
@@ -22815,7 +22815,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Extra",
       "surface": "apple",
-      "id": "native.apple.595947c1bbbfda3f"
+      "id": "native.apple.501ca510acbcd7b9"
     },
     {
       "kind": "conditional-branch",
@@ -22823,7 +22823,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Plugin",
       "surface": "apple",
-      "id": "native.apple.50ba37dad6e4dde7"
+      "id": "native.apple.37d7aede5d6d079c"
     },
     {
       "kind": "ui-call",
@@ -22831,7 +22831,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Missing binaries: \\(self.missingBins.joined(separator: \", \"))",
       "surface": "apple",
-      "id": "native.apple.98b6632aebcd482a"
+      "id": "native.apple.ed1d8de50a5175a6"
     },
     {
       "kind": "ui-call",
@@ -22839,7 +22839,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Missing env: \\(self.missingEnv.joined(separator: \", \"))",
       "surface": "apple",
-      "id": "native.apple.1ffd9ad47f1dd74a"
+      "id": "native.apple.98c2ee66c2a348d5"
     },
     {
       "kind": "ui-call",
@@ -22847,7 +22847,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Requires config: \\(self.missingConfig.joined(separator: \", \"))",
       "surface": "apple",
-      "id": "native.apple.c9ef14276ce395c1"
+      "id": "native.apple.c28dec5712a1a4e4"
     },
     {
       "kind": "conditional-branch",
@@ -22855,7 +22855,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Set \\(envKey)",
       "surface": "apple",
-      "id": "native.apple.c588ae10b9fae52b"
+      "id": "native.apple.0ba091f0963a859a"
     },
     {
       "kind": "ui-call",
@@ -22863,7 +22863,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Install on Gateway",
       "surface": "apple",
-      "id": "native.apple.494d34a89a55787c"
+      "id": "native.apple.271aecab8ee8daae"
     },
     {
       "kind": "ui-call",
@@ -22871,7 +22871,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Install on This Mac",
       "surface": "apple",
-      "id": "native.apple.4dc7c4fc6c93d9d7"
+      "id": "native.apple.11a57c92c83a9c1d"
     },
     {
       "kind": "conditional-branch",
@@ -22879,7 +22879,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Switches to Local mode to install on this Mac.",
       "surface": "apple",
-      "id": "native.apple.594ec7446d99d669"
+      "id": "native.apple.8b0d1fa47901f3d1"
     },
     {
       "kind": "ui-call",
@@ -22887,7 +22887,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Get your key →",
       "surface": "apple",
-      "id": "native.apple.d2d1e65ac3406c3b"
+      "id": "native.apple.6d54f73392b52e5e"
     },
     {
       "kind": "ui-call",
@@ -22895,7 +22895,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Saved to openclaw.json under skills.entries.\\(self.editor.skillKey)",
       "surface": "apple",
-      "id": "native.apple.d769a8ac65441d48"
+      "id": "native.apple.1818adfc77bea7c6"
     },
     {
       "kind": "ui-call",
@@ -22903,7 +22903,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Cancel",
       "surface": "apple",
-      "id": "native.apple.af47aadb262d225d"
+      "id": "native.apple.b2175b7065d31dec"
     },
     {
       "kind": "ui-call",
@@ -22911,7 +22911,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Save",
       "surface": "apple",
-      "id": "native.apple.25beb661ec932b3b"
+      "id": "native.apple.ce625995c2ee1153"
     },
     {
       "kind": "conditional-branch",
@@ -22919,7 +22919,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Set API Key",
       "surface": "apple",
-      "id": "native.apple.3ffd977cb7d7ddcb"
+      "id": "native.apple.76282dc8f59ee8ed"
     },
     {
       "kind": "conditional-branch",
@@ -22927,7 +22927,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Set Environment Variable",
       "surface": "apple",
-      "id": "native.apple.6cdf55c74657ea8c"
+      "id": "native.apple.d02c8e20326a8194"
     },
     {
       "kind": "conditional-branch",
@@ -22935,7 +22935,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Skill disabled",
       "surface": "apple",
-      "id": "native.apple.ff923ba48cc8136a"
+      "id": "native.apple.6ca4205fb3545e06"
     },
     {
       "kind": "conditional-branch",
@@ -22943,7 +22943,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Skill enabled",
       "surface": "apple",
-      "id": "native.apple.6b59063df92d2991"
+      "id": "native.apple.85ed8da0c8b8da24"
     },
     {
       "kind": "ui-named-argument",
@@ -22951,7 +22951,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Bundled",
       "surface": "apple",
-      "id": "native.apple.5bea2c67b8d4ccf9"
+      "id": "native.apple.ae5bf34054b226e9"
     },
     {
       "kind": "ui-named-argument",
@@ -22959,7 +22959,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Exec Approvals",
       "surface": "apple",
-      "id": "native.apple.9df0af709d3b38bf"
+      "id": "native.apple.baa1e9ad00a283be"
     },
     {
       "kind": "ui-named-argument",
@@ -22967,7 +22967,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Control how agent shell commands are approved on this Mac.",
       "surface": "apple",
-      "id": "native.apple.e5198b803f0b5c9f"
+      "id": "native.apple.cee6e1f2850c237d"
     },
     {
       "kind": "ui-named-argument",
@@ -22975,7 +22975,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Loading settings…",
       "surface": "apple",
-      "id": "native.apple.4ec0e98876dd4130"
+      "id": "native.apple.eece16607fdfb91b"
     },
     {
       "kind": "ui-named-argument",
@@ -22983,7 +22983,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Reading the persisted policy.",
       "surface": "apple",
-      "id": "native.apple.15112b7a64de6801"
+      "id": "native.apple.f94e1d20ca21be54"
     },
     {
       "kind": "ui-call",
@@ -22991,7 +22991,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Exec Approvals Unavailable",
       "surface": "apple",
-      "id": "native.apple.10ccbcb69920d863"
+      "id": "native.apple.64f921bb347daf1f"
     },
     {
       "kind": "ui-named-argument",
@@ -22999,7 +22999,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Settings could not be read",
       "surface": "apple",
-      "id": "native.apple.f8de480303620970"
+      "id": "native.apple.62ea09ef72587ca8"
     },
     {
       "kind": "ui-call",
@@ -23007,7 +23007,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Retry",
       "surface": "apple",
-      "id": "native.apple.761db018bc2fc118"
+      "id": "native.apple.22c40f0c6dbc546b"
     },
     {
       "kind": "ui-call",
@@ -23015,7 +23015,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Scope",
       "surface": "apple",
-      "id": "native.apple.4c894d7779471cda"
+      "id": "native.apple.b556ccf4fd9f87e7"
     },
     {
       "kind": "ui-call",
@@ -23023,7 +23023,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Policy",
       "surface": "apple",
-      "id": "native.apple.4c1463daa4dfc183"
+      "id": "native.apple.169ad3eee4985f74"
     },
     {
       "kind": "ui-named-argument",
@@ -23031,7 +23031,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Command access",
       "surface": "apple",
-      "id": "native.apple.2d5b07fb998add6d"
+      "id": "native.apple.5527cc88ed43b2bb"
     },
     {
       "kind": "ui-named-argument",
@@ -23039,7 +23039,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Prompt behavior",
       "surface": "apple",
-      "id": "native.apple.1f9c1d124943525f"
+      "id": "native.apple.005664d83ab07fb8"
     },
     {
       "kind": "ui-named-argument",
@@ -23047,7 +23047,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Fallback when unreachable",
       "surface": "apple",
-      "id": "native.apple.661bf7c8dc9f072e"
+      "id": "native.apple.25e544e713763429"
     },
     {
       "kind": "ui-named-argument",
@@ -23055,7 +23055,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Used when the companion UI cannot display an approval prompt.",
       "surface": "apple",
-      "id": "native.apple.c8c17f7110f6c2a5"
+      "id": "native.apple.10f3181b3f99acbf"
     },
     {
       "kind": "ui-call",
@@ -23063,7 +23063,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Fallback",
       "surface": "apple",
-      "id": "native.apple.f7b187b19d3ce46c"
+      "id": "native.apple.f9d4a2d868a8677b"
     },
     {
       "kind": "ui-call",
@@ -23071,7 +23071,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Automatic Trust",
       "surface": "apple",
-      "id": "native.apple.e8789cac2796fa81"
+      "id": "native.apple.b567690434254608"
     },
     {
       "kind": "ui-named-argument",
@@ -23079,7 +23079,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Auto-allow skill CLIs",
       "surface": "apple",
-      "id": "native.apple.058dc79972ce1eb0"
+      "id": "native.apple.a8d36717d2647c89"
     },
     {
       "kind": "ui-named-argument",
@@ -23087,7 +23087,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Let bundled skill command-line tools run without prompting.",
       "surface": "apple",
-      "id": "native.apple.11336f8872783288"
+      "id": "native.apple.69e83614fee0fed1"
     },
     {
       "kind": "ui-call",
@@ -23095,7 +23095,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Trusted skill binaries",
       "surface": "apple",
-      "id": "native.apple.84e1f8a42caf871f"
+      "id": "native.apple.da2a40ad4cbb5cbe"
     },
     {
       "kind": "ui-call",
@@ -23103,7 +23103,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Add Command",
       "surface": "apple",
-      "id": "native.apple.f9494753c8f18ad5"
+      "id": "native.apple.1f76b291a5a4fe09"
     },
     {
       "kind": "ui-named-argument",
@@ -23111,7 +23111,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Pattern",
       "surface": "apple",
-      "id": "native.apple.d4acabb5ab2a35bd"
+      "id": "native.apple.8895efca8eabc6e6"
     },
     {
       "kind": "ui-named-argument",
@@ -23119,7 +23119,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Bare names match PATH commands. Use a path glob for a specific binary.",
       "surface": "apple",
-      "id": "native.apple.bd3e049ced941d24"
+      "id": "native.apple.c93a946b29888019"
     },
     {
       "kind": "ui-call",
@@ -23127,7 +23127,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "rg or /opt/homebrew/bin/*",
       "surface": "apple",
-      "id": "native.apple.76e2478e29a4800e"
+      "id": "native.apple.ef41d55bc4d49e9c"
     },
     {
       "kind": "ui-call",
@@ -23135,7 +23135,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Add",
       "surface": "apple",
-      "id": "native.apple.6efbcd37d228a21f"
+      "id": "native.apple.b44c00fb3b814788"
     },
     {
       "kind": "ui-call",
@@ -23143,7 +23143,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Allowed Commands",
       "surface": "apple",
-      "id": "native.apple.e1a6a94d63202cb8"
+      "id": "native.apple.3c4cdf3ce30ccbad"
     },
     {
       "kind": "ui-call",
@@ -23151,7 +23151,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Allowlists are per-agent",
       "surface": "apple",
-      "id": "native.apple.656126ceb089f03f"
+      "id": "native.apple.28b320fe6537b205"
     },
     {
       "kind": "ui-call",
@@ -23159,7 +23159,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Select an agent scope above to add trusted commands.",
       "surface": "apple",
-      "id": "native.apple.2bbd6fb7cf2fa71b"
+      "id": "native.apple.e938b56a78d7f2a0"
     },
     {
       "kind": "ui-call",
@@ -23167,7 +23167,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "No trusted commands yet",
       "surface": "apple",
-      "id": "native.apple.a09fabb585670140"
+      "id": "native.apple.8d1b6df732d09321"
     },
     {
       "kind": "ui-call",
@@ -23175,7 +23175,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Commands that miss the allowlist follow the prompt and fallback policy above.",
       "surface": "apple",
-      "id": "native.apple.7071e7264f7b3bd1"
+      "id": "native.apple.caaa7cbd56db3384"
     },
     {
       "kind": "conditional-branch",
@@ -23183,7 +23183,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Access",
       "surface": "apple",
-      "id": "native.apple.d11a83c13e02e770"
+      "id": "native.apple.6965aa87ad2b32d8"
     },
     {
       "kind": "conditional-branch",
@@ -23191,7 +23191,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Allowlist",
       "surface": "apple",
-      "id": "native.apple.c93bc33b48fd43a0"
+      "id": "native.apple.8d322dce94945b6f"
     },
     {
       "kind": "ui-call",
@@ -23199,7 +23199,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Last used \\(Self.relativeFormatter.localizedString(for: date, relativeTo: Date()))",
       "surface": "apple",
-      "id": "native.apple.61954e6ed7118ddb"
+      "id": "native.apple.f6a5624779dc6de4"
     },
     {
       "kind": "ui-call",
@@ -23207,7 +23207,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Last command: \\(lastUsedCommand)",
       "surface": "apple",
-      "id": "native.apple.29f7d0d5d832b577"
+      "id": "native.apple.da4cf90fe860cd86"
     },
     {
       "kind": "ui-call",
@@ -23215,7 +23215,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Resolved path: \\(lastResolvedPath)",
       "surface": "apple",
-      "id": "native.apple.0ac3d7bc8c69e6a2"
+      "id": "native.apple.8b452c0aa187bf3a"
     },
     {
       "kind": "conditional-branch",
@@ -23223,7 +23223,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Shell commands blocked",
       "surface": "apple",
-      "id": "native.apple.5a99ffadcc47a57d"
+      "id": "native.apple.671cd5ae31cf2c9d"
     },
     {
       "kind": "conditional-branch",
@@ -23231,7 +23231,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Trusted commands can run",
       "surface": "apple",
-      "id": "native.apple.373242ed9f8b3b8f"
+      "id": "native.apple.f767df97563e5e92"
     },
     {
       "kind": "conditional-branch",
@@ -23239,7 +23239,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Shell commands allowed",
       "surface": "apple",
-      "id": "native.apple.b725dd915c5582c9"
+      "id": "native.apple.ef2767bc3bfa5ed4"
     },
     {
       "kind": "conditional-branch",
@@ -23247,7 +23247,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "system.run requests are denied unless the policy changes.",
       "surface": "apple",
-      "id": "native.apple.5dd3ebaacc99121e"
+      "id": "native.apple.794a6631e98e27b0"
     },
     {
       "kind": "conditional-branch",
@@ -23255,7 +23255,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Known commands can run; new commands use the prompt policy.",
       "surface": "apple",
-      "id": "native.apple.642d027da7623994"
+      "id": "native.apple.1fc6280b1b4c7b44"
     },
     {
       "kind": "conditional-branch",
@@ -23263,7 +23263,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Agents can run shell commands on this Mac without allowlist checks.",
       "surface": "apple",
-      "id": "native.apple.093b7f30aa7b08f6"
+      "id": "native.apple.1ef5a6923caab5da"
     },
     {
       "kind": "conditional-branch",
@@ -23271,7 +23271,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Block agent shell commands on this Mac.",
       "surface": "apple",
-      "id": "native.apple.c8e6fc08f04b8d9f"
+      "id": "native.apple.5184684dc4a62edb"
     },
     {
       "kind": "conditional-branch",
@@ -23279,7 +23279,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Allow trusted command patterns and handle misses with prompts.",
       "surface": "apple",
-      "id": "native.apple.e9371d48f629b039"
+      "id": "native.apple.bf1e546102919d3f"
     },
     {
       "kind": "conditional-branch",
@@ -23287,7 +23287,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Allow shell commands without checking the allowlist.",
       "surface": "apple",
-      "id": "native.apple.935c981496e8689b"
+      "id": "native.apple.84214f3fae821163"
     },
     {
       "kind": "conditional-branch",
@@ -23295,7 +23295,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Never show approval prompts.",
       "surface": "apple",
-      "id": "native.apple.c494c0bb6a4182a2"
+      "id": "native.apple.d7404aa083ad6d58"
     },
     {
       "kind": "conditional-branch",
@@ -23303,7 +23303,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Ask only when a command is not trusted yet.",
       "surface": "apple",
-      "id": "native.apple.c04df969fed1b2ca"
+      "id": "native.apple.093c3c01af530076"
     },
     {
       "kind": "conditional-branch",
@@ -23311,7 +23311,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Ask before every shell command.",
       "surface": "apple",
-      "id": "native.apple.19950d3e6e99ee47"
+      "id": "native.apple.a5161a377e784404"
     },
     {
       "kind": "conditional-branch",
@@ -23319,7 +23319,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Off",
       "surface": "apple",
-      "id": "native.apple.b18215308bc4e7cf"
+      "id": "native.apple.5f0099993dc18200"
     },
     {
       "kind": "conditional-branch",
@@ -23327,7 +23327,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Tailnet (Serve)",
       "surface": "apple",
-      "id": "native.apple.16cb95866e07c33a"
+      "id": "native.apple.75660b064ceb43a0"
     },
     {
       "kind": "conditional-branch",
@@ -23335,7 +23335,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Public (Funnel)",
       "surface": "apple",
-      "id": "native.apple.5d1bfae92686efdc"
+      "id": "native.apple.eee39fddacb60361"
     },
     {
       "kind": "conditional-branch",
@@ -23343,7 +23343,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "No automatic Tailscale configuration.",
       "surface": "apple",
-      "id": "native.apple.1efcf02284f3ea5e"
+      "id": "native.apple.368d45c7390ef8f2"
     },
     {
       "kind": "conditional-branch",
@@ -23351,7 +23351,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Tailnet-only HTTPS via Tailscale Serve.",
       "surface": "apple",
-      "id": "native.apple.0b2f7d7d50026ac4"
+      "id": "native.apple.4119785e43ec7c31"
     },
     {
       "kind": "conditional-branch",
@@ -23359,7 +23359,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Public HTTPS via Tailscale Funnel (requires auth).",
       "surface": "apple",
-      "id": "native.apple.1f7daed940897f17"
+      "id": "native.apple.53731650034c8363"
     },
     {
       "kind": "ui-call",
@@ -23367,7 +23367,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Tailscale (dashboard access)",
       "surface": "apple",
-      "id": "native.apple.96bb9bb74999aec3"
+      "id": "native.apple.3a78ea65307529fd"
     },
     {
       "kind": "ui-call",
@@ -23375,7 +23375,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Local mode required. Update settings on the gateway host.",
       "surface": "apple",
-      "id": "native.apple.5a382f1b024300a1"
+      "id": "native.apple.f89b107bd8568de8"
     },
     {
       "kind": "ui-call",
@@ -23383,7 +23383,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.26e0afc4575fbc70"
+      "id": "native.apple.63251a0397755541"
     },
     {
       "kind": "ui-call",
@@ -23391,7 +23391,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "App Store",
       "surface": "apple",
-      "id": "native.apple.62dcf1a51e15d52a"
+      "id": "native.apple.ea8761dddd5b1116"
     },
     {
       "kind": "ui-call",
@@ -23399,7 +23399,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Direct Download",
       "surface": "apple",
-      "id": "native.apple.fe89247395645ff4"
+      "id": "native.apple.456358fd5d50a617"
     },
     {
       "kind": "ui-call",
@@ -23407,7 +23407,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Setup Guide",
       "surface": "apple",
-      "id": "native.apple.fc4886c7228bc04f"
+      "id": "native.apple.814ebeca21fb8a21"
     },
     {
       "kind": "ui-call",
@@ -23415,7 +23415,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Exposure mode",
       "surface": "apple",
-      "id": "native.apple.726161ce2c382170"
+      "id": "native.apple.481018f23a7b817d"
     },
     {
       "kind": "ui-call",
@@ -23423,7 +23423,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Exposure",
       "surface": "apple",
-      "id": "native.apple.fadc7522289dd272"
+      "id": "native.apple.98808079f70d5bca"
     },
     {
       "kind": "ui-call",
@@ -23431,7 +23431,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Dashboard URL:",
       "surface": "apple",
-      "id": "native.apple.657ee675aa5c5d91"
+      "id": "native.apple.56501bfe461b402e"
     },
     {
       "kind": "ui-call",
@@ -23439,7 +23439,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Start Tailscale to get your tailnet hostname.",
       "surface": "apple",
-      "id": "native.apple.b40617c102f55113"
+      "id": "native.apple.6bb7a419c1f37204"
     },
     {
       "kind": "ui-call",
@@ -23447,7 +23447,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Start Tailscale",
       "surface": "apple",
-      "id": "native.apple.719949d1f6bdc263"
+      "id": "native.apple.93103f084d194a09"
     },
     {
       "kind": "ui-call",
@@ -23455,7 +23455,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Require credentials",
       "surface": "apple",
-      "id": "native.apple.8fedb0008df7e179"
+      "id": "native.apple.5b47c57b7011e562"
     },
     {
       "kind": "ui-call",
@@ -23463,7 +23463,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Serve uses Tailscale identity headers; no password required.",
       "surface": "apple",
-      "id": "native.apple.de7ce19eaf2a6fee"
+      "id": "native.apple.d453179a614add8f"
     },
     {
       "kind": "ui-call",
@@ -23471,7 +23471,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Funnel requires authentication.",
       "surface": "apple",
-      "id": "native.apple.f00022aabd2fa142"
+      "id": "native.apple.a3bdced52327d532"
     },
     {
       "kind": "ui-call",
@@ -23479,7 +23479,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Password",
       "surface": "apple",
-      "id": "native.apple.9b1c9f02ab3eefa5"
+      "id": "native.apple.22bb4f71f665204b"
     },
     {
       "kind": "ui-call",
@@ -23487,7 +23487,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Stored in ~/.openclaw/openclaw.json. Prefer OPENCLAW_GATEWAY_PASSWORD for production.",
       "surface": "apple",
-      "id": "native.apple.800bb607f45c05e4"
+      "id": "native.apple.b7505005ad8df9b0"
     },
     {
       "kind": "ui-call",
@@ -23495,7 +23495,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Update password",
       "surface": "apple",
-      "id": "native.apple.3942d43ca047de29"
+      "id": "native.apple.930e134515c7fef0"
     },
     {
       "kind": "conditional-branch",
@@ -23503,7 +23503,7 @@
       "path": "apps/macos/Sources/OpenClaw/TalkModeController.swift",
       "source": "Bottle",
       "surface": "apple",
-      "id": "native.apple.022603dec29eeb31"
+      "id": "native.apple.f86914d9c7756d35"
     },
     {
       "kind": "conditional-branch",
@@ -23511,7 +23511,7 @@
       "path": "apps/macos/Sources/OpenClaw/TalkModeController.swift",
       "source": "Submarine",
       "surface": "apple",
-      "id": "native.apple.acf5be731170759f"
+      "id": "native.apple.7479886e7d784236"
     },
     {
       "kind": "conditional-branch",
@@ -23519,7 +23519,7 @@
       "path": "apps/macos/Sources/OpenClaw/UsageData.swift",
       "source": "\\(hours)h",
       "surface": "apple",
-      "id": "native.apple.c5a4c9a669e2b7ae"
+      "id": "native.apple.397c30d24e50811d"
     },
     {
       "kind": "conditional-branch",
@@ -23527,7 +23527,7 @@
       "path": "apps/macos/Sources/OpenClaw/UsageData.swift",
       "source": "\\(hours)h \\(mins)m",
       "surface": "apple",
-      "id": "native.apple.b03d60f17ede11df"
+      "id": "native.apple.46decfbb91821121"
     },
     {
       "kind": "conditional-branch",
@@ -23535,7 +23535,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeChime.swift",
       "source": "No Sound",
       "surface": "apple",
-      "id": "native.apple.16e9766e8b59af53"
+      "id": "native.apple.d40072f3684bf574"
     },
     {
       "kind": "conditional-branch",
@@ -23551,7 +23551,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Voice Wake requires macOS 26 or newer",
       "surface": "apple",
-      "id": "native.apple.0577606e681fcf35"
+      "id": "native.apple.2ff579aec88de6ec"
     },
     {
       "kind": "ui-call",
@@ -23559,7 +23559,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "The Voice Wake and push-to-talk controls are hidden on older macOS versions.",
       "surface": "apple",
-      "id": "native.apple.013200734769f33a"
+      "id": "native.apple.3d7d47667e586149"
     },
     {
       "kind": "ui-named-argument",
@@ -23567,7 +23567,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Voice & Talk",
       "surface": "apple",
-      "id": "native.apple.91d77e9c8fd7cf64"
+      "id": "native.apple.e603fd0daaca11ce"
     },
     {
       "kind": "ui-named-argument",
@@ -23575,7 +23575,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Wake phrases, push-to-talk, microphone input, and Talk Mode feedback.",
       "surface": "apple",
-      "id": "native.apple.91fe621c927f977e"
+      "id": "native.apple.b847b7e88f6d0e4a"
     },
     {
       "kind": "ui-call",
@@ -23583,7 +23583,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Activation",
       "surface": "apple",
-      "id": "native.apple.392a57d31b6a94ea"
+      "id": "native.apple.40e743944b92a737"
     },
     {
       "kind": "ui-named-argument",
@@ -23591,7 +23591,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Enable Voice Wake",
       "surface": "apple",
-      "id": "native.apple.ef337702bfdcde32"
+      "id": "native.apple.893414230c405a6b"
     },
     {
       "kind": "ui-named-argument-multiline",
@@ -23599,7 +23599,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Listen for a wake phrase before running voice commands. Recognition runs fully on-device.",
       "surface": "apple",
-      "id": "native.apple.e992b45cdbccdd10"
+      "id": "native.apple.ca70303dd9f7dc69"
     },
     {
       "kind": "ui-named-argument",
@@ -23607,7 +23607,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Trigger Talk Mode",
       "surface": "apple",
-      "id": "native.apple.475eb587a8accd92"
+      "id": "native.apple.46a4f5a5a87982b2"
     },
     {
       "kind": "ui-named-argument",
@@ -23615,7 +23615,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Start a full voice conversation when a wake phrase is detected.",
       "surface": "apple",
-      "id": "native.apple.b225402585009eb9"
+      "id": "native.apple.f2957b9b1cc51bf1"
     },
     {
       "kind": "ui-named-argument",
@@ -23623,7 +23623,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Hold Right Option to talk",
       "surface": "apple",
-      "id": "native.apple.4eab66621bb04dd6"
+      "id": "native.apple.1550cdb367f5fae8"
     },
     {
       "kind": "ui-named-argument",
@@ -23631,7 +23631,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Start listening while you hold the key and show the preview overlay.",
       "surface": "apple",
-      "id": "native.apple.7bb4ce4870ca14a2"
+      "id": "native.apple.7055b58966b996f6"
     },
     {
       "kind": "ui-named-argument",
@@ -23639,7 +23639,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Push-to-talk paused",
       "surface": "apple",
-      "id": "native.apple.65d87751e185d1a5"
+      "id": "native.apple.030948354864ede8"
     },
     {
       "kind": "ui-named-argument",
@@ -23647,7 +23647,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Push-to-Talk resumes when Talk Mode is turned off.",
       "surface": "apple",
-      "id": "native.apple.2d6d7f132131424e"
+      "id": "native.apple.ecf6297cccdc5696"
     },
     {
       "kind": "ui-named-argument",
@@ -23655,7 +23655,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Play phase-transition sounds",
       "surface": "apple",
-      "id": "native.apple.4d245d48ccb84004"
+      "id": "native.apple.b3178dc16d5e6a19"
     },
     {
       "kind": "ui-named-argument-multiline",
@@ -23663,7 +23663,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Play short sounds when Talk Mode switches between listening, thinking, and speaking.",
       "surface": "apple",
-      "id": "native.apple.41f46ea2f1360ba1"
+      "id": "native.apple.6342c549c3a4d3de"
     },
     {
       "kind": "ui-named-argument",
@@ -23671,7 +23671,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Right Option stops speech",
       "surface": "apple",
-      "id": "native.apple.7ce0b620891b342f"
+      "id": "native.apple.d10e5af90f1043cb"
     },
     {
       "kind": "ui-named-argument",
@@ -23679,7 +23679,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Tap Right Option to interrupt speech and return to listening.",
       "surface": "apple",
-      "id": "native.apple.95e2b41ea266ae26"
+      "id": "native.apple.53058e129e8adb90"
     },
     {
       "kind": "ui-call",
@@ -23687,7 +23687,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Recognition",
       "surface": "apple",
-      "id": "native.apple.a252af04733488f3"
+      "id": "native.apple.7421fad6107b9876"
     },
     {
       "kind": "ui-call",
@@ -23695,7 +23695,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Test",
       "surface": "apple",
-      "id": "native.apple.7d6ec57f4b64649c"
+      "id": "native.apple.69934b21a31d3c9f"
     },
     {
       "kind": "ui-call",
@@ -23703,7 +23703,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Trigger Words",
       "surface": "apple",
-      "id": "native.apple.72334cdb6e483bb2"
+      "id": "native.apple.6b70638a81af67b3"
     },
     {
       "kind": "ui-named-argument",
@@ -23711,7 +23711,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Wake phrases",
       "surface": "apple",
-      "id": "native.apple.519ad1a3454893af"
+      "id": "native.apple.5b9eb01b16e81a31"
     },
     {
       "kind": "ui-named-argument",
@@ -23719,7 +23719,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Short phrases that start voice wake detection.",
       "surface": "apple",
-      "id": "native.apple.5c6d32ae2f16617e"
+      "id": "native.apple.808e80fed46f80c8"
     },
     {
       "kind": "ui-call",
@@ -23727,7 +23727,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Add word",
       "surface": "apple",
-      "id": "native.apple.2b5d3b9bb23d4790"
+      "id": "native.apple.a44f0041f9e5fe48"
     },
     {
       "kind": "ui-call",
@@ -23735,7 +23735,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Reset",
       "surface": "apple",
-      "id": "native.apple.64a5ed78f1daef4f"
+      "id": "native.apple.35503c4949f8405c"
     },
     {
       "kind": "ui-call",
@@ -23743,7 +23743,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "No wake phrases configured",
       "surface": "apple",
-      "id": "native.apple.261b2e1a284a4a23"
+      "id": "native.apple.dd327a9ea2873cf4"
     },
     {
       "kind": "ui-call",
@@ -23751,7 +23751,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Sounds",
       "surface": "apple",
-      "id": "native.apple.137bcbf83dadd760"
+      "id": "native.apple.5a03dd68632d7873"
     },
     {
       "kind": "ui-named-argument",
@@ -23759,7 +23759,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Trigger sound",
       "surface": "apple",
-      "id": "native.apple.057f356e1dad268c"
+      "id": "native.apple.56eb8f1e824d6d2b"
     },
     {
       "kind": "ui-named-argument",
@@ -23767,7 +23767,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Send sound",
       "surface": "apple",
-      "id": "native.apple.3df4382a91dea75a"
+      "id": "native.apple.30ce86886e31f18c"
     },
     {
       "kind": "ui-call",
@@ -23775,7 +23775,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "No Sound",
       "surface": "apple",
-      "id": "native.apple.01dc8f0c65a84aa2"
+      "id": "native.apple.9b4387e37d683aef"
     },
     {
       "kind": "ui-call",
@@ -23783,7 +23783,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Choose file…",
       "surface": "apple",
-      "id": "native.apple.434b52758b95741a"
+      "id": "native.apple.0528c6758e290369"
     },
     {
       "kind": "ui-call",
@@ -23791,7 +23791,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Play",
       "surface": "apple",
-      "id": "native.apple.cfbff3ff838c859c"
+      "id": "native.apple.0e5e44c406a7b9b8"
     },
     {
       "kind": "ui-named-argument",
@@ -23799,7 +23799,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Microphone",
       "surface": "apple",
-      "id": "native.apple.cda210e895dc1778"
+      "id": "native.apple.41359da0ac894b51"
     },
     {
       "kind": "ui-call",
@@ -23807,7 +23807,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "System default",
       "surface": "apple",
-      "id": "native.apple.061460a0ef5d6017"
+      "id": "native.apple.0a81206706fdadee"
     },
     {
       "kind": "conditional-branch",
@@ -23823,7 +23823,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Disconnected (using System default)",
       "surface": "apple",
-      "id": "native.apple.5135e9bec6346f0d"
+      "id": "native.apple.149f4d076da22182"
     },
     {
       "kind": "ui-named-argument",
@@ -23831,7 +23831,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Recognition language",
       "surface": "apple",
-      "id": "native.apple.5f981202f828ecb6"
+      "id": "native.apple.ca4d74dadd215b29"
     },
     {
       "kind": "ui-named-argument",
@@ -23839,7 +23839,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Languages are tried in order. Models may need a first-use download on macOS 26.",
       "surface": "apple",
-      "id": "native.apple.2e38529b5d47f62d"
+      "id": "native.apple.a52618a1010652b0"
     },
     {
       "kind": "ui-call",
@@ -23847,7 +23847,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Language",
       "surface": "apple",
-      "id": "native.apple.b5868ea893d6a974"
+      "id": "native.apple.e1db8711bc4383b0"
     },
     {
       "kind": "ui-call",
@@ -23855,7 +23855,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "\\(self.friendlyName(for: current)) (System)",
       "surface": "apple",
-      "id": "native.apple.d57fd5213daf2a6e"
+      "id": "native.apple.af375210418389a2"
     },
     {
       "kind": "ui-named-argument",
@@ -23863,7 +23863,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Additional languages",
       "surface": "apple",
-      "id": "native.apple.79db41c7b941a50f"
+      "id": "native.apple.10b2092001406760"
     },
     {
       "kind": "ui-named-argument",
@@ -23871,7 +23871,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Add another language",
       "surface": "apple",
-      "id": "native.apple.7049d6b0db7fb80b"
+      "id": "native.apple.1760c75ee8fc1038"
     },
     {
       "kind": "ui-call",
@@ -23879,7 +23879,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Add",
       "surface": "apple",
-      "id": "native.apple.41d06b5cfa8e5b2f"
+      "id": "native.apple.034b0a5bc36f00d3"
     },
     {
       "kind": "ui-named-argument",
@@ -23887,7 +23887,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Live level",
       "surface": "apple",
-      "id": "native.apple.041c1e5c2d56d45a"
+      "id": "native.apple.90cafdb4910000f6"
     },
     {
       "kind": "ui-call",
@@ -23895,7 +23895,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Wake phrase",
       "surface": "apple",
-      "id": "native.apple.a5088b30807780db"
+      "id": "native.apple.0b723d79c6075b9e"
     },
     {
       "kind": "ui-modifier",
@@ -23903,7 +23903,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Remove trigger word",
       "surface": "apple",
-      "id": "native.apple.87c3465e9398bc2f"
+      "id": "native.apple.a217c76f0fa0097e"
     },
     {
       "kind": "ui-named-argument",
@@ -23911,7 +23911,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Language \\(self.index + 2)",
       "surface": "apple",
-      "id": "native.apple.65b2687f8f16f9b2"
+      "id": "native.apple.17f4cb7dd5186d1d"
     },
     {
       "kind": "ui-named-argument",
@@ -23919,7 +23919,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Fallback recognition language.",
       "surface": "apple",
-      "id": "native.apple.a767de022c4a06db"
+      "id": "native.apple.5aec57b9913966cf"
     },
     {
       "kind": "ui-modifier",
@@ -23927,7 +23927,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Remove language",
       "surface": "apple",
-      "id": "native.apple.cfab77826c9ac1d1"
+      "id": "native.apple.2da4a867843585fa"
     },
     {
       "kind": "ui-call-concatenated",
@@ -23935,7 +23935,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "OpenClaw reacts when any trigger appears in a transcription. Keep phrases short to avoid false positives.",
       "surface": "apple",
-      "id": "native.apple.237e9371a693b0ff"
+      "id": "native.apple.e209dd9ba19b81fe"
     },
     {
       "kind": "ui-call",
@@ -23943,7 +23943,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeTestCard.swift",
       "source": "Test Voice Wake",
       "surface": "apple",
-      "id": "native.apple.2bcc6f4eca98f7f2"
+      "id": "native.apple.d749a6acb290d4aa"
     },
     {
       "kind": "conditional-branch",
@@ -23951,7 +23951,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeTestCard.swift",
       "source": "Start test",
       "surface": "apple",
-      "id": "native.apple.44c32fe7fef5e7e5"
+      "id": "native.apple.3512d7bbd871e8b6"
     },
     {
       "kind": "conditional-branch",
@@ -23959,7 +23959,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeTestCard.swift",
       "source": "Stop",
       "surface": "apple",
-      "id": "native.apple.fd8cfc2a33b87fba"
+      "id": "native.apple.9ad633fd4df59e4a"
     },
     {
       "kind": "conditional-branch",
@@ -23967,7 +23967,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeTestCard.swift",
       "source": "Press start, say a trigger word, and wait for detection.",
       "surface": "apple",
-      "id": "native.apple.a94e02a9668e9b59"
+      "id": "native.apple.f2f416ae36f62232"
     },
     {
       "kind": "conditional-branch",
@@ -23975,7 +23975,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeTestCard.swift",
       "source": "Requesting mic & speech permission…",
       "surface": "apple",
-      "id": "native.apple.3abd330410d4a00a"
+      "id": "native.apple.b9e4f6ee0262538f"
     },
     {
       "kind": "conditional-branch",
@@ -23983,7 +23983,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeTestCard.swift",
       "source": "Listening… say your trigger word.",
       "surface": "apple",
-      "id": "native.apple.9dfd570fa4c12d11"
+      "id": "native.apple.e97a8c71b0497cfa"
     },
     {
       "kind": "conditional-branch",
@@ -23991,7 +23991,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeTestCard.swift",
       "source": "Heard: \\(text)",
       "surface": "apple",
-      "id": "native.apple.5b1f53381d4ff861"
+      "id": "native.apple.167cdab67491a81d"
     },
     {
       "kind": "conditional-branch",
@@ -23999,7 +23999,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeTestCard.swift",
       "source": "Finalizing…",
       "surface": "apple",
-      "id": "native.apple.8a176d8996538aae"
+      "id": "native.apple.3a09b96f2a7e9373"
     },
     {
       "kind": "conditional-branch",
@@ -24007,7 +24007,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeTestCard.swift",
       "source": "Voice wake detected!",
       "surface": "apple",
-      "id": "native.apple.26960f2b7ebad5f9"
+      "id": "native.apple.e3667f05c57cc7fd"
     },
     {
       "kind": "conditional-branch",
@@ -24015,7 +24015,7 @@
       "path": "apps/macos/Sources/OpenClawMacCLI/DiscoverCommand.swift",
       "source": " (local filtered)",
       "surface": "apple",
-      "id": "native.apple.c5d8bca2d78e1b9b"
+      "id": "native.apple.586cd4ddbc79bd1e"
     },
     {
       "kind": "conditional-branch",
@@ -24031,7 +24031,7 @@
       "path": "apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift",
       "source": "Invalid URL: \\(raw)",
       "surface": "apple",
-      "id": "native.apple.4730f0dfb78617a2"
+      "id": "native.apple.3dd6dc9964ec1147"
     },
     {
       "kind": "conditional-branch",
@@ -24039,7 +24039,7 @@
       "path": "apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift",
       "source": "gateway.remote.url is missing",
       "surface": "apple",
-      "id": "native.apple.70fa502613dd19e1"
+      "id": "native.apple.31426e0cb51903c0"
     },
     {
       "kind": "conditional-branch",
@@ -24047,7 +24047,7 @@
       "path": "apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift",
       "source": "Wizard cancelled",
       "surface": "apple",
-      "id": "native.apple.70daa9528cfa07c7"
+      "id": "native.apple.3cbce5d897d4447e"
     },
     {
       "kind": "conditional-branch",
@@ -24055,7 +24055,7 @@
       "path": "apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift",
       "source": " [\\(initial)]",
       "surface": "apple",
-      "id": "native.apple.2b7392aa9f8b47df"
+      "id": "native.apple.cab68ed6edeabd61"
     },
     {
       "kind": "conditional-branch",
@@ -24063,7 +24063,7 @@
       "path": "apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift",
       "source": " — \\(option.hint!)",
       "surface": "apple",
-      "id": "native.apple.9e54815f3eca97bf"
+      "id": "native.apple.dfb1201b4e07f3e1"
     },
     {
       "kind": "conditional-branch",
@@ -24079,7 +24079,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/AssistantTextParser.swift",
       "source": "</\\(tag)",
       "surface": "apple",
-      "id": "native.apple.dbc2ff188682dee3"
+      "id": "native.apple.78ebdc797462620c"
     },
     {
       "kind": "conditional-branch",
@@ -24087,7 +24087,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/AssistantTextParser.swift",
       "source": "<\\(tag)",
       "surface": "apple",
-      "id": "native.apple.d4f7cdeb3737a201"
+      "id": "native.apple.79621e3cd582e085"
     },
     {
       "kind": "ui-modifier",
@@ -24095,7 +24095,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Context \\(percentage)% used",
       "surface": "apple",
-      "id": "native.apple.38a8e96962b1a93d"
+      "id": "native.apple.01113cff9a7f9556"
     },
     {
       "kind": "ui-call",
@@ -24103,7 +24103,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Thinking",
       "surface": "apple",
-      "id": "native.apple.510c6dfa05924ae2"
+      "id": "native.apple.6e204a530cff78e0"
     },
     {
       "kind": "ui-call",
@@ -24111,7 +24111,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Pinned",
       "surface": "apple",
-      "id": "native.apple.745b004e0b5b6b80"
+      "id": "native.apple.65237734e52023b9"
     },
     {
       "kind": "ui-call",
@@ -24119,7 +24119,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Recent",
       "surface": "apple",
-      "id": "native.apple.69381a0a462ccd84"
+      "id": "native.apple.b5cdc1c2c10da9c4"
     },
     {
       "kind": "ui-call",
@@ -24127,7 +24127,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Models",
       "surface": "apple",
-      "id": "native.apple.aa321cf4820426ef"
+      "id": "native.apple.e97d08d2a15cb6ee"
     },
     {
       "kind": "ui-call",
@@ -24135,7 +24135,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Model",
       "surface": "apple",
-      "id": "native.apple.0fce9d743a640218"
+      "id": "native.apple.0998a10ffd7e76d3"
     },
     {
       "kind": "conditional-branch",
@@ -24143,7 +24143,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Pin model",
       "surface": "apple",
-      "id": "native.apple.75550b03f06d6abc"
+      "id": "native.apple.aef0bfe7e8a32fba"
     },
     {
       "kind": "conditional-branch",
@@ -24151,7 +24151,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Unpin model",
       "surface": "apple",
-      "id": "native.apple.af4df27bdbacb5de"
+      "id": "native.apple.5f6e0eb1dda6c10f"
     },
     {
       "kind": "ui-call",
@@ -24159,7 +24159,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Session",
       "surface": "apple",
-      "id": "native.apple.5dfc0700d8dff8de"
+      "id": "native.apple.d7e1ae4e4e7bde84"
     },
     {
       "kind": "ui-modifier",
@@ -24167,7 +24167,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Add Image",
       "surface": "apple",
-      "id": "native.apple.284b2b94c272591d"
+      "id": "native.apple.5a1b5f0450e8c1e1"
     },
     {
       "kind": "ui-modifier",
@@ -24175,7 +24175,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Attachments",
       "surface": "apple",
-      "id": "native.apple.1963dfa3285cb715"
+      "id": "native.apple.2d5ac96da778014b"
     },
     {
       "kind": "ui-call",
@@ -24183,7 +24183,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Voice note",
       "surface": "apple",
-      "id": "native.apple.f8dda832ed76441d"
+      "id": "native.apple.12c4792f15f4b351"
     },
     {
       "kind": "conditional-branch",
@@ -24191,7 +24191,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Talk",
       "surface": "apple",
-      "id": "native.apple.ee2c0d22f5861159"
+      "id": "native.apple.9757a0706f47e293"
     },
     {
       "kind": "conditional-branch",
@@ -24199,7 +24199,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start realtime chat",
       "surface": "apple",
-      "id": "native.apple.5d5041aefe6dfddd"
+      "id": "native.apple.d73e9a8b230b62af"
     },
     {
       "kind": "conditional-branch",
@@ -24207,7 +24207,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop realtime chat",
       "surface": "apple",
-      "id": "native.apple.21a7d3a3386a2218"
+      "id": "native.apple.75d8e63b44a2cf84"
     },
     {
       "kind": "conditional-branch",
@@ -24215,7 +24215,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start",
       "surface": "apple",
-      "id": "native.apple.88c2de261ddae511"
+      "id": "native.apple.bd575c071e51bc9c"
     },
     {
       "kind": "conditional-branch",
@@ -24223,7 +24223,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop",
       "surface": "apple",
-      "id": "native.apple.72e5aa4446eaca9e"
+      "id": "native.apple.e6433c213efc62a0"
     },
     {
       "kind": "ui-call",
@@ -24231,7 +24231,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Loading commands",
       "surface": "apple",
-      "id": "native.apple.9d4bdedcbf74d86c"
+      "id": "native.apple.025c836eff37ec7d"
     },
     {
       "kind": "ui-call",
@@ -24239,7 +24239,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Commands unavailable",
       "surface": "apple",
-      "id": "native.apple.fdd34aa94629c962"
+      "id": "native.apple.6d5a260544ac3454"
     },
     {
       "kind": "ui-call",
@@ -24247,7 +24247,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Retry",
       "surface": "apple",
-      "id": "native.apple.a1953e3e9be8b8d5"
+      "id": "native.apple.482b6c244b2f98de"
     },
     {
       "kind": "ui-call",
@@ -24255,7 +24255,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "No matching commands",
       "surface": "apple",
-      "id": "native.apple.0f942ca442f88936"
+      "id": "native.apple.de20827f0471a1b2"
     },
     {
       "kind": "ui-modifier",
@@ -24263,7 +24263,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop response",
       "surface": "apple",
-      "id": "native.apple.afd8a2b9e3bf6d60"
+      "id": "native.apple.717ce3a6710f9662"
     },
     {
       "kind": "ui-modifier",
@@ -24271,7 +24271,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Send message",
       "surface": "apple",
-      "id": "native.apple.d30969d467c66537"
+      "id": "native.apple.5ae97e248c06d374"
     },
     {
       "kind": "ui-modifier",
@@ -24279,7 +24279,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.f4473f79bb87b2fd"
+      "id": "native.apple.f9e18a470335738b"
     },
     {
       "kind": "conditional-branch",
@@ -24287,7 +24287,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Connecting...",
       "surface": "apple",
-      "id": "native.apple.6c984c0e3ed3a69e"
+      "id": "native.apple.1641e23203e93d89"
     },
     {
       "kind": "conditional-branch",
@@ -24295,7 +24295,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Gateway connected",
       "surface": "apple",
-      "id": "native.apple.898849eb2bcb0b53"
+      "id": "native.apple.6e75710fceb513ba"
     },
     {
       "kind": "conditional-branch",
@@ -24311,7 +24311,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "Input tokens: \\(input)",
       "surface": "apple",
-      "id": "native.apple.c622ecbe64757e20"
+      "id": "native.apple.7622351111d0dbf5"
     },
     {
       "kind": "ui-localized-call",
@@ -24319,7 +24319,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "Output tokens: \\(output)",
       "surface": "apple",
-      "id": "native.apple.9a2df48646af1dde"
+      "id": "native.apple.6483e4f5f14c7a6a"
     },
     {
       "kind": "ui-localized-call",
@@ -24327,7 +24327,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "Cache read tokens: \\(cacheRead)",
       "surface": "apple",
-      "id": "native.apple.0c6c7b65489adafa"
+      "id": "native.apple.0bac4e4f235efa13"
     },
     {
       "kind": "ui-localized-call",
@@ -24335,7 +24335,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "Cache write tokens: \\(cacheWrite)",
       "surface": "apple",
-      "id": "native.apple.c71fa1cad2deba7e"
+      "id": "native.apple.1c7899cd135c4506"
     },
     {
       "kind": "ui-localized-call",
@@ -24343,7 +24343,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "Cost: \\(formattedCost)",
       "surface": "apple",
-      "id": "native.apple.62bcf67218a0ecd0"
+      "id": "native.apple.150bfffa693fcefc"
     },
     {
       "kind": "ui-localized-call",
@@ -24351,7 +24351,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "ctx",
       "surface": "apple",
-      "id": "native.apple.118ab29788bb00fd"
+      "id": "native.apple.e27f633db4ba7e49"
     },
     {
       "kind": "ui-localized-call",
@@ -24359,7 +24359,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "\\(contextPercent) percent of context used",
       "surface": "apple",
-      "id": "native.apple.1b6b0d02dc774cc3"
+      "id": "native.apple.aa15ae08b51aac94"
     },
     {
       "kind": "ui-localized-call",
@@ -24367,7 +24367,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "Warning: \\(contextPercent) percent of context used",
       "surface": "apple",
-      "id": "native.apple.4e7cd5b3f4e0ddc0"
+      "id": "native.apple.e28c698580084851"
     },
     {
       "kind": "ui-localized-call",
@@ -24375,7 +24375,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "Critical: \\(contextPercent) percent of context used",
       "surface": "apple",
-      "id": "native.apple.107321cf0b74cb7f"
+      "id": "native.apple.6d6bf645b99c4ffe"
     },
     {
       "kind": "ui-call",
@@ -24383,7 +24383,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "\\(percent)%",
       "surface": "apple",
-      "id": "native.apple.e8fba80e238f4283"
+      "id": "native.apple.7429c9095e7bbd1a"
     },
     {
       "kind": "ui-modifier",
@@ -24391,7 +24391,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "Context usage",
       "surface": "apple",
-      "id": "native.apple.a902d7f653b46010"
+      "id": "native.apple.5563ad1aa3bd30bf"
     },
     {
       "kind": "conditional-branch",
@@ -24407,7 +24407,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "\\(display.emoji) \\(display.title)",
       "surface": "apple",
-      "id": "native.apple.8509385953c19619"
+      "id": "native.apple.b304621c63871fb8"
     },
     {
       "kind": "ui-localized-call",
@@ -24415,7 +24415,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Message usage",
       "surface": "apple",
-      "id": "native.apple.6426e369511b043c"
+      "id": "native.apple.eb452758b2d770d5"
     },
     {
       "kind": "conditional-branch",
@@ -24431,7 +24431,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Show full output",
       "surface": "apple",
-      "id": "native.apple.aff6385b0a8dd0ac"
+      "id": "native.apple.f42cc258acfb67de"
     },
     {
       "kind": "conditional-branch",
@@ -24439,7 +24439,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Show less",
       "surface": "apple",
-      "id": "native.apple.b9c78020ae8be34a"
+      "id": "native.apple.9d4cffc5588d8730"
     },
     {
       "kind": "ui-call",
@@ -24447,7 +24447,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Writing",
       "surface": "apple",
-      "id": "native.apple.e9914cfc93a514cb"
+      "id": "native.apple.9f296429941bcaaf"
     },
     {
       "kind": "ui-call",
@@ -24455,7 +24455,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio…",
       "surface": "apple",
-      "id": "native.apple.cbc285107b965641"
+      "id": "native.apple.1521f9182b8bb00b"
     },
     {
       "kind": "ui-call",
@@ -24463,7 +24463,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking…",
       "surface": "apple",
-      "id": "native.apple.d781ade49132fec6"
+      "id": "native.apple.7ace1c606a9ae6d1"
     },
     {
       "kind": "conditional-branch",
@@ -24471,7 +24471,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio, tap to cancel",
       "surface": "apple",
-      "id": "native.apple.9e4b306460f4a32d"
+      "id": "native.apple.f94ee25675989434"
     },
     {
       "kind": "conditional-branch",
@@ -24479,7 +24479,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking, tap to stop",
       "surface": "apple",
-      "id": "native.apple.142c01bf6b97e380"
+      "id": "native.apple.641f936a5583b9e0"
     },
     {
       "kind": "conditional-branch",
@@ -24487,7 +24487,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Queued",
       "surface": "apple",
-      "id": "native.apple.86695104895ebed8"
+      "id": "native.apple.19b4b71a188ba284"
     },
     {
       "kind": "conditional-branch",
@@ -24495,7 +24495,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Sending…",
       "surface": "apple",
-      "id": "native.apple.a85f179b35d39d8f"
+      "id": "native.apple.2f15e75ada9fe222"
     },
     {
       "kind": "conditional-branch",
@@ -24503,7 +24503,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Confirming…",
       "surface": "apple",
-      "id": "native.apple.38722ea25417ad4f"
+      "id": "native.apple.15e28ba0e2d92c1a"
     },
     {
       "kind": "conditional-branch",
@@ -24511,7 +24511,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Delivery unknown",
       "surface": "apple",
-      "id": "native.apple.78682085b14232f8"
+      "id": "native.apple.be374fc498bf16bb"
     },
     {
       "kind": "conditional-branch",
@@ -24519,7 +24519,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Not sent",
       "surface": "apple",
-      "id": "native.apple.2888a268bfa49e9e"
+      "id": "native.apple.baa183eb2a5eca02"
     },
     {
       "kind": "conditional-branch",
@@ -24527,7 +24527,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Queued, sends when reconnected",
       "surface": "apple",
-      "id": "native.apple.593219d4c4479c59"
+      "id": "native.apple.bcb53d221f1881d0"
     },
     {
       "kind": "conditional-branch",
@@ -24535,7 +24535,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Sending",
       "surface": "apple",
-      "id": "native.apple.00e673b9c5263c5c"
+      "id": "native.apple.dad0e6c151326bae"
     },
     {
       "kind": "conditional-branch",
@@ -24543,7 +24543,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Sent, waiting for chat history confirmation",
       "surface": "apple",
-      "id": "native.apple.bfe7aab77abe9a2c"
+      "id": "native.apple.f82ed0bf07d5bdb1"
     },
     {
       "kind": "conditional-branch",
@@ -24551,7 +24551,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Delivery unconfirmed, touch and hold to retry or delete",
       "surface": "apple",
-      "id": "native.apple.7eb6eca416d33bb4"
+      "id": "native.apple.eab9d75789a06b3c"
     },
     {
       "kind": "conditional-branch",
@@ -24559,7 +24559,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Not sent, touch and hold to retry or delete",
       "surface": "apple",
-      "id": "native.apple.df1a81bd7a0bca36"
+      "id": "native.apple.505063034c724544"
     },
     {
       "kind": "ui-call",
@@ -24567,7 +24567,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Running tools…",
       "surface": "apple",
-      "id": "native.apple.6b18ea1d85b5d3a2"
+      "id": "native.apple.14589eec3b0a4b79"
     },
     {
       "kind": "ui-call",
@@ -24575,7 +24575,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "\\(display.emoji) \\(display.label)",
       "surface": "apple",
-      "id": "native.apple.7c99becc26501014"
+      "id": "native.apple.e0ffb5273f89f7a0"
     },
     {
       "kind": "ui-named-argument",
@@ -24583,7 +24583,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift",
       "source": "Pinned",
       "surface": "apple",
-      "id": "native.apple.63320b6d5138c0db"
+      "id": "native.apple.867687a50de01ebb"
     },
     {
       "kind": "conditional-branch",
@@ -24591,7 +24591,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Active",
       "surface": "apple",
-      "id": "native.apple.0d9f7c1e0e65a820"
+      "id": "native.apple.c320ac446bc59973"
     },
     {
       "kind": "conditional-branch",
@@ -24599,7 +24599,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Archived",
       "surface": "apple",
-      "id": "native.apple.3c71a4c13836cc75"
+      "id": "native.apple.c4edd77327e0cad6"
     },
     {
       "kind": "ui-call",
@@ -24607,7 +24607,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Scope",
       "surface": "apple",
-      "id": "native.apple.0489ad746c8d35c2"
+      "id": "native.apple.0ec3ac37d8b9cbe9"
     },
     {
       "kind": "ui-named-argument",
@@ -24615,7 +24615,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Search sessions",
       "surface": "apple",
-      "id": "native.apple.2c37581c7b88f741"
+      "id": "native.apple.b7a67b9febd19c36"
     },
     {
       "kind": "ui-modifier",
@@ -24623,7 +24623,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Sessions",
       "surface": "apple",
-      "id": "native.apple.43be8a2336e42faf"
+      "id": "native.apple.dab45ff4927c1073"
     },
     {
       "kind": "ui-modifier",
@@ -24631,7 +24631,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Rename Session",
       "surface": "apple",
-      "id": "native.apple.0b379cdfcbd3247f"
+      "id": "native.apple.bf9dd70fa814f104"
     },
     {
       "kind": "ui-call",
@@ -24639,7 +24639,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Session name",
       "surface": "apple",
-      "id": "native.apple.54b6fbd9e41db009"
+      "id": "native.apple.7917bd3d15457177"
     },
     {
       "kind": "ui-call",
@@ -24647,7 +24647,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Cancel",
       "surface": "apple",
-      "id": "native.apple.833fe2915430c89d"
+      "id": "native.apple.e8cda2d73c0320f1"
     },
     {
       "kind": "conditional-branch",
@@ -24655,7 +24655,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "No archived sessions",
       "surface": "apple",
-      "id": "native.apple.b67eaecec1b423ac"
+      "id": "native.apple.2fe5cf385c84439f"
     },
     {
       "kind": "conditional-branch",
@@ -24663,7 +24663,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "No sessions found",
       "surface": "apple",
-      "id": "native.apple.b2435a79abf0c794"
+      "id": "native.apple.e7bfc76394f72597"
     },
     {
       "kind": "ui-modifier",
@@ -24671,7 +24671,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Pinned",
       "surface": "apple",
-      "id": "native.apple.05cb1fecc5844b69"
+      "id": "native.apple.8b56a35cb939fc5b"
     },
     {
       "kind": "ui-call",
@@ -24679,7 +24679,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Rename",
       "surface": "apple",
-      "id": "native.apple.080fce25e4a9bb61"
+      "id": "native.apple.bbfaf47ddcce8bf4"
     },
     {
       "kind": "conditional-branch",
@@ -24687,7 +24687,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Pin",
       "surface": "apple",
-      "id": "native.apple.d148288258094aa6"
+      "id": "native.apple.408be3d929be77f7"
     },
     {
       "kind": "conditional-branch",
@@ -24695,7 +24695,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Unpin",
       "surface": "apple",
-      "id": "native.apple.3c62aaf44e6ab4d4"
+      "id": "native.apple.b37c95b4fd1e4aa8"
     },
     {
       "kind": "conditional-branch",
@@ -24703,7 +24703,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Archive",
       "surface": "apple",
-      "id": "native.apple.666ba6eb696e649f"
+      "id": "native.apple.5c16badc72eab28a"
     },
     {
       "kind": "conditional-branch",
@@ -24711,7 +24711,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Unarchive",
       "surface": "apple",
-      "id": "native.apple.34b910911a05110e"
+      "id": "native.apple.fd17768ea5408e76"
     },
     {
       "kind": "conditional-branch",
@@ -24759,7 +24759,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Retry Send",
       "surface": "apple",
-      "id": "native.apple.5824df4efbf6c977"
+      "id": "native.apple.0399ffc649163f1e"
     },
     {
       "kind": "ui-call",
@@ -24767,7 +24767,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Delete",
       "surface": "apple",
-      "id": "native.apple.cdad35e9657fa693"
+      "id": "native.apple.9296170b1b2144c2"
     },
     {
       "kind": "ui-call",
@@ -24775,7 +24775,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Stop Listening",
       "surface": "apple",
-      "id": "native.apple.9d58b2a2a23c0d69"
+      "id": "native.apple.cfb20c308a06ba9d"
     },
     {
       "kind": "ui-call",
@@ -24783,7 +24783,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Listen",
       "surface": "apple",
-      "id": "native.apple.99df7de891c8235f"
+      "id": "native.apple.977f6f71bc076bdd"
     },
     {
       "kind": "ui-call",
@@ -24791,7 +24791,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Copy Message",
       "surface": "apple",
-      "id": "native.apple.fe9f30f12f1dcfaf"
+      "id": "native.apple.9d927293f1e1221d"
     },
     {
       "kind": "ui-call",
@@ -24799,7 +24799,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest",
       "surface": "apple",
-      "id": "native.apple.f84b674ad395b694"
+      "id": "native.apple.66e1bdca9ef40646"
     },
     {
       "kind": "ui-modifier",
@@ -24807,7 +24807,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest reply",
       "surface": "apple",
-      "id": "native.apple.429d825201b2cb85"
+      "id": "native.apple.54f4f44846a814f4"
     },
     {
       "kind": "ui-named-argument",
@@ -24815,7 +24815,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.9ab586b85834705c"
+      "id": "native.apple.074b2b466e960e78"
     },
     {
       "kind": "ui-call",
@@ -24823,7 +24823,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Loading chat",
       "surface": "apple",
-      "id": "native.apple.28c2691c03030434"
+      "id": "native.apple.27e6c69d5e2c08db"
     },
     {
       "kind": "ui-modifier",
@@ -24831,7 +24831,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Dismiss",
       "surface": "apple",
-      "id": "native.apple.5c481fea4eb3dc17"
+      "id": "native.apple.7a3ed586a2fc1cdd"
     },
     {
       "kind": "ui-localized-call",
@@ -24839,7 +24839,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "Could not attach voice note: \\(error.localizedDescription)",
       "surface": "apple",
-      "id": "native.apple.82befa424fe7bace"
+      "id": "native.apple.ca9493176c336c60"
     },
     {
       "kind": "ui-localized-call",
@@ -24847,7 +24847,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "Voice note exceeds the 5 MB attachment limit",
       "surface": "apple",
-      "id": "native.apple.ec5daba7e38184dc"
+      "id": "native.apple.148b7fb638070466"
     },
     {
       "kind": "conditional-branch",
@@ -24855,7 +24855,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "\\(baseName).jpg",
       "surface": "apple",
-      "id": "native.apple.82c2287cd78da56f"
+      "id": "native.apple.d0c9d4d007b2fe58"
     },
     {
       "kind": "conditional-branch",
@@ -24879,7 +24879,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "delivery unconfirmed",
       "surface": "apple",
-      "id": "native.apple.2b45abdc56b2caed"
+      "id": "native.apple.6ba00167996b4263"
     },
     {
       "kind": "conditional-branch",
@@ -24887,7 +24887,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "queued after route change",
       "surface": "apple",
-      "id": "native.apple.722f1f90b97e8e45"
+      "id": "native.apple.f2d9e7a0937f0f5c"
     },
     {
       "kind": "ui-localized-call",
@@ -24895,7 +24895,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before switching chats.",
       "surface": "apple",
-      "id": "native.apple.710c7bd117a7cc12"
+      "id": "native.apple.93ba9ee66114532a"
     },
     {
       "kind": "ui-localized-call",
@@ -24903,7 +24903,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before starting a new chat.",
       "surface": "apple",
-      "id": "native.apple.d93e6fe16ec1b0e5"
+      "id": "native.apple.fa3c2d1c4e5c1610"
     },
     {
       "kind": "ui-modifier",
@@ -24911,7 +24911,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Clear this session's history?",
       "surface": "apple",
-      "id": "native.apple.87ba543b42696b92"
+      "id": "native.apple.c30842a34c0dbeaa"
     },
     {
       "kind": "ui-call",
@@ -24919,7 +24919,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Clear History",
       "surface": "apple",
-      "id": "native.apple.6192578088f1b100"
+      "id": "native.apple.7c47639bfb532810"
     },
     {
       "kind": "ui-call",
@@ -24927,7 +24927,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "This resets the conversation for \\(self.activeSessionTitle). The session key stays the same.",
       "surface": "apple",
-      "id": "native.apple.ca701776b3d9ce70"
+      "id": "native.apple.18bde57ec1737f33"
     },
     {
       "kind": "ui-call",
@@ -24935,7 +24935,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Export Transcript",
       "surface": "apple",
-      "id": "native.apple.2ee7858b00a47c42"
+      "id": "native.apple.fd2ce51f4d8e0c16"
     },
     {
       "kind": "ui-call",
@@ -24943,7 +24943,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Thinking",
       "surface": "apple",
-      "id": "native.apple.b1f10b5e9113881d"
+      "id": "native.apple.34b6e23c835cad90"
     },
     {
       "kind": "ui-modifier",
@@ -24951,7 +24951,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Thinking level",
       "surface": "apple",
-      "id": "native.apple.48dde5fe65b841a3"
+      "id": "native.apple.432204f516a5d6cb"
     },
     {
       "kind": "ui-call",
@@ -24959,7 +24959,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Pinned",
       "surface": "apple",
-      "id": "native.apple.17ea1ddec4a7b7a8"
+      "id": "native.apple.88055057e800e9d7"
     },
     {
       "kind": "ui-call",
@@ -24967,7 +24967,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Recent",
       "surface": "apple",
-      "id": "native.apple.f5bbceea34d12623"
+      "id": "native.apple.76416eba17946ba3"
     },
     {
       "kind": "ui-call",
@@ -24975,7 +24975,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Models",
       "surface": "apple",
-      "id": "native.apple.f41f892742244520"
+      "id": "native.apple.fcfb8eca34977f8c"
     },
     {
       "kind": "ui-call",
@@ -24983,7 +24983,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Model",
       "surface": "apple",
-      "id": "native.apple.273aa7b9194a8d0d"
+      "id": "native.apple.4142eb0c3721ba95"
     },
     {
       "kind": "ui-call",
@@ -24991,7 +24991,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.5361129a24118af6"
+      "id": "native.apple.5d5c36afdc42855f"
     },
     {
       "kind": "ui-call",
@@ -24999,7 +24999,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Export Transcript…",
       "surface": "apple",
-      "id": "native.apple.9b2ad72143b931bf"
+      "id": "native.apple.24f1f311dfba03d5"
     },
     {
       "kind": "ui-call",
@@ -25007,7 +25007,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Clear History…",
       "surface": "apple",
-      "id": "native.apple.4b24d792545e5086"
+      "id": "native.apple.6e8f27111bdf8685"
     },
     {
       "kind": "ui-call",
@@ -25015,7 +25015,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Session",
       "surface": "apple",
-      "id": "native.apple.920fe8a7a33f9e92"
+      "id": "native.apple.5513db0da0a88eb6"
     },
     {
       "kind": "ui-modifier",
@@ -25023,7 +25023,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Session actions",
       "surface": "apple",
-      "id": "native.apple.185a401f78328b0f"
+      "id": "native.apple.a4986742449874ad"
     },
     {
       "kind": "ui-call",
@@ -25031,7 +25031,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Session cost \\(ChatContextUsageFormatter.cost(cost))",
       "surface": "apple",
-      "id": "native.apple.547fe762a61d08a6"
+      "id": "native.apple.a5124b2fde49e645"
     },
     {
       "kind": "ui-call",
@@ -25039,7 +25039,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Compact Session",
       "surface": "apple",
-      "id": "native.apple.f0a4720df5f5f403"
+      "id": "native.apple.076b729703163c3d"
     },
     {
       "kind": "ui-named-argument",
@@ -25047,7 +25047,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Search sessions",
       "surface": "apple",
-      "id": "native.apple.0b9fc81ff2031799"
+      "id": "native.apple.aee00276ee72ce99"
     },
     {
       "kind": "conditional-branch",
@@ -25055,7 +25055,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "No Results",
       "surface": "apple",
-      "id": "native.apple.f10d5ccfd0530fec"
+      "id": "native.apple.6343b2e6129c02b8"
     },
     {
       "kind": "conditional-branch",
@@ -25063,7 +25063,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "No Sessions",
       "surface": "apple",
-      "id": "native.apple.42b0ee4c8b3326b6"
+      "id": "native.apple.73d51b329a4a0436"
     },
     {
       "kind": "ui-call",
@@ -25071,7 +25071,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "New Session",
       "surface": "apple",
-      "id": "native.apple.eb58552e43c8dde2"
+      "id": "native.apple.920a0842d2282cd6"
     },
     {
       "kind": "ui-modifier",
@@ -25079,7 +25079,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "New session",
       "surface": "apple",
-      "id": "native.apple.247771e4350c006f"
+      "id": "native.apple.17bc26471a0deb71"
     },
     {
       "kind": "ui-call",
@@ -25087,7 +25087,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Delete Session",
       "surface": "apple",
-      "id": "native.apple.d9a72d07e8d95d35"
+      "id": "native.apple.4ae30ec826d4e2c9"
     },
     {
       "kind": "ui-call",
@@ -25095,7 +25095,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "The session and its transcript are removed from the gateway.",
       "surface": "apple",
-      "id": "native.apple.499537ec30a28ae0"
+      "id": "native.apple.6466310a79ba3fb9"
     },
     {
       "kind": "ui-modifier",
@@ -25103,7 +25103,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Unread",
       "surface": "apple",
-      "id": "native.apple.1bd1b747fd161df5"
+      "id": "native.apple.e840198e8640d89e"
     },
     {
       "kind": "conditional-branch",
@@ -25111,7 +25111,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Pin",
       "surface": "apple",
-      "id": "native.apple.a8a2f4b248663f97"
+      "id": "native.apple.86b5ad3787a5fb63"
     },
     {
       "kind": "conditional-branch",
@@ -25119,7 +25119,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Unpin",
       "surface": "apple",
-      "id": "native.apple.8768f9ed198edc54"
+      "id": "native.apple.f4327b2a30a5cec4"
     },
     {
       "kind": "ui-call",
@@ -25127,7 +25127,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Copy Session Key",
       "surface": "apple",
-      "id": "native.apple.27ddbe5e4643b60f"
+      "id": "native.apple.76d9c8c2860edb32"
     },
     {
       "kind": "ui-call",
@@ -25135,7 +25135,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Delete Session…",
       "surface": "apple",
-      "id": "native.apple.a994d072ab35cb35"
+      "id": "native.apple.a5ed649fd45061cf"
     },
     {
       "kind": "conditional-branch",
@@ -25143,7 +25143,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Connecting…",
       "surface": "apple",
-      "id": "native.apple.22d5ce71e22a7f73"
+      "id": "native.apple.f94741348470ac9b"
     },
     {
       "kind": "conditional-branch",
@@ -25151,7 +25151,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Gateway connected",
       "surface": "apple",
-      "id": "native.apple.8d0606ab1a2c0f44"
+      "id": "native.apple.9230cb93205a9a6d"
     },
     {
       "kind": "ui-call",
@@ -25167,7 +25167,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteComposerViews.swift",
       "source": "Record Voice Note",
       "surface": "apple",
-      "id": "native.apple.71e0219d1501de06"
+      "id": "native.apple.19a81624cefb644f"
     },
     {
       "kind": "ui-modifier",
@@ -25175,7 +25175,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteComposerViews.swift",
       "source": "Record voice note",
       "surface": "apple",
-      "id": "native.apple.e6770d7cc616021f"
+      "id": "native.apple.2b6768d908e17d3b"
     },
     {
       "kind": "ui-modifier",
@@ -25183,7 +25183,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteComposerViews.swift",
       "source": "Recording",
       "surface": "apple",
-      "id": "native.apple.4a226d89671518e1"
+      "id": "native.apple.374831d59c35d337"
     },
     {
       "kind": "ui-modifier",
@@ -25191,7 +25191,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteComposerViews.swift",
       "source": "Cancel voice note",
       "surface": "apple",
-      "id": "native.apple.0fb64b1b7ea0aa5e"
+      "id": "native.apple.820da20ec0bdc6ef"
     },
     {
       "kind": "ui-modifier",
@@ -25199,7 +25199,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteComposerViews.swift",
       "source": "Finish voice note",
       "surface": "apple",
-      "id": "native.apple.b7a9de9b3c8e4bad"
+      "id": "native.apple.cf194c67a68eb7ff"
     },
     {
       "kind": "ui-localized-call",
@@ -25207,7 +25207,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift",
       "source": "Another feature is using the microphone.",
       "surface": "apple",
-      "id": "native.apple.6d9fb086956fe48a"
+      "id": "native.apple.fdd9ab1433eb5ae3"
     },
     {
       "kind": "ui-localized-call",
@@ -25215,7 +25215,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift",
       "source": "Microphone access is required. Enable it in Settings.",
       "surface": "apple",
-      "id": "native.apple.1fc7530ccdfc937e"
+      "id": "native.apple.ca02c18298949313"
     },
     {
       "kind": "ui-localized-call",
@@ -25223,7 +25223,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift",
       "source": "Could not start recording: \\(error.localizedDescription)",
       "surface": "apple",
-      "id": "native.apple.c963f6dfaa0610b5"
+      "id": "native.apple.c3a3ee46fd4d7550"
     },
     {
       "kind": "ui-localized-call",
@@ -25231,7 +25231,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift",
       "source": "Recording was interrupted. Try again.",
       "surface": "apple",
-      "id": "native.apple.bb00abc2aa9ae5e1"
+      "id": "native.apple.510e9bd5beb36673"
     },
     {
       "kind": "conditional-branch",
@@ -25239,7 +25239,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectionProblem.swift",
       "source": "Retry once",
       "surface": "apple",
-      "id": "native.apple.59aa8697b933d6b6"
+      "id": "native.apple.8d54365d14d49a6c"
     },
     {
       "kind": "conditional-branch",
@@ -25247,7 +25247,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectionProblem.swift",
       "source": "Update gateway token",
       "surface": "apple",
-      "id": "native.apple.82effdf06c40ec03"
+      "id": "native.apple.64766643b05237f9"
     },
     {
       "kind": "conditional-branch",
@@ -25255,7 +25255,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectionProblem.swift",
       "source": " The new certificate is trusted by this device; this is commonly caused by certificate rotation.",
       "surface": "apple",
-      "id": "native.apple.0bfc4194742bc860"
+      "id": "native.apple.22c799a546080d56"
     },
     {
       "kind": "conditional-branch",
@@ -25263,7 +25263,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectionProblem.swift",
       "source": " This device could not verify the new certificate.",
       "surface": "apple",
-      "id": "native.apple.31178752f837d528"
+      "id": "native.apple.902e16355bb2f822"
     },
     {
       "kind": "conditional-branch",
@@ -25271,7 +25271,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayDiscoveryStatusText.swift",
       "source": "Idle",
       "surface": "apple",
-      "id": "native.apple.a825441f646eb195"
+      "id": "native.apple.8240ef6286e413ae"
     },
     {
       "kind": "conditional-branch",
@@ -25279,7 +25279,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayDiscoveryStatusText.swift",
       "source": "Setup",
       "surface": "apple",
-      "id": "native.apple.0cb1206714c2bf4d"
+      "id": "native.apple.435b9166934b8447"
     },
     {
       "kind": "conditional-branch",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -7,7 +7,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/AppLanguage.kt",
       "source": "OpenClaw translations · $languageTag",
       "surface": "android",
-      "id": "native.android.c2a6e38ba0ac5d69"
+      "id": "native.android.85cc8de945e3929c"
     },
     {
       "kind": "conditional-branch",
@@ -15,7 +15,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/AppLanguage.kt",
       "source": "Follow Android · $systemLanguageTag",
       "surface": "android",
-      "id": "native.android.bd86676d38a98747"
+      "id": "native.android.914725056e04bd7a"
     },
     {
       "kind": "conditional-branch",
@@ -23,7 +23,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/CronJobDetail.kt",
       "source": "Off",
       "surface": "android",
-      "id": "native.android.67f2f22fa99358b1"
+      "id": "native.android.d55616e142c8be0f"
     },
     {
       "kind": "conditional-branch",
@@ -31,7 +31,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/CronJobDetail.kt",
       "source": "Default",
       "surface": "android",
-      "id": "native.android.f5fa3a841ce8c234"
+      "id": "native.android.f59b83f58086eb89"
     },
     {
       "kind": "conditional-branch",
@@ -143,7 +143,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Ready",
       "surface": "android",
-      "id": "native.android.3004053ed98f6e4b"
+      "id": "native.android.805d35da3b3c9d18"
     },
     {
       "kind": "conditional-branch",
@@ -151,7 +151,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Needs setup",
       "surface": "android",
-      "id": "native.android.98e6f239bdf361aa"
+      "id": "native.android.44c06b96c01cb062"
     },
     {
       "kind": "conditional-branch",
@@ -159,7 +159,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Unverified",
       "surface": "android",
-      "id": "native.android.469b184060165bd6"
+      "id": "native.android.1bd3499b4cf8c3f2"
     },
     {
       "kind": "conditional-branch",
@@ -167,7 +167,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "${state.provider.label} via Gateway relay",
       "surface": "android",
-      "id": "native.android.90241f592c7c1cce"
+      "id": "native.android.66f091d1fc047eff"
     },
     {
       "kind": "conditional-branch",
@@ -175,7 +175,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Gateway talk catalog not loaded",
       "surface": "android",
-      "id": "native.android.a24ef3a97a2c8c07"
+      "id": "native.android.859f7fec2019b314"
     },
     {
       "kind": "conditional-branch",
@@ -183,7 +183,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Could not load Gateway talk catalog",
       "surface": "android",
-      "id": "native.android.9c86ef6aed5b3720"
+      "id": "native.android.ecb051798c98537f"
     },
     {
       "kind": "conditional-branch",
@@ -191,7 +191,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Gateway did not return ${issue.target.title} setup",
       "surface": "android",
-      "id": "native.android.7ac71cb673d6399e"
+      "id": "native.android.95b5551fcb519c1f"
     },
     {
       "kind": "conditional-branch",
@@ -199,7 +199,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "No ${issue.target.title} provider is configured on the Gateway",
       "surface": "android",
-      "id": "native.android.1349ccf44bb43398"
+      "id": "native.android.328d435e93e9a2b2"
     },
     {
       "kind": "conditional-branch",
@@ -207,7 +207,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Gateway selected unknown provider ${issue.providerId}",
       "surface": "android",
-      "id": "native.android.384d856d68320eb2"
+      "id": "native.android.b3ee0bd7fd90a9e7"
     },
     {
       "kind": "conditional-branch",
@@ -215,7 +215,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Gateway did not return ${issue.target.title} readiness",
       "surface": "android",
-      "id": "native.android.1409da872534c08c"
+      "id": "native.android.04086b6aed3c2ce5"
     },
     {
       "kind": "conditional-branch",
@@ -223,7 +223,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Configure a ${issue.target.title} provider on the Gateway",
       "surface": "android",
-      "id": "native.android.3ea36b85bb5ae44c"
+      "id": "native.android.27f61e5f9b33b6f9"
     },
     {
       "kind": "conditional-branch",
@@ -231,7 +231,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Gateway did not identify the active ${issue.target.title} provider",
       "surface": "android",
-      "id": "native.android.f6cec337d1e0980e"
+      "id": "native.android.e4fe3a325a6d6299"
     },
     {
       "kind": "conditional-branch",
@@ -239,7 +239,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Choose a supported ${issue.target.title} provider on the Gateway",
       "surface": "android",
-      "id": "native.android.8fadd97a13ca7651"
+      "id": "native.android.7e6b01f6e7c9bc92"
     },
     {
       "kind": "conditional-branch",
@@ -247,7 +247,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/GatewayTalkSetupReadiness.kt",
       "source": "Configure ${issue.providerLabel} on the Gateway",
       "surface": "android",
-      "id": "native.android.394044d0402d59e5"
+      "id": "native.android.39bdbc9a546c7f1d"
     },
     {
       "kind": "ui-toast",
@@ -263,7 +263,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt",
       "source": "OPENCLAW",
       "surface": "android",
-      "id": "native.android.3e9d9afe68d1b86a"
+      "id": "native.android.ff4c22906eac1e9e"
     },
     {
       "kind": "ui-state-text",
@@ -271,7 +271,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Searching…",
       "surface": "android",
-      "id": "native.android.1e8c8e1a337b1cfb"
+      "id": "native.android.dec357dfc9b8c0a5"
     },
     {
       "kind": "ui-state-text",
@@ -279,7 +279,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
-      "id": "native.android.87b8d3e5c4bc6cc2"
+      "id": "native.android.567482ea1118eb13"
     },
     {
       "kind": "ui-state-text",
@@ -287,7 +287,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
-      "id": "native.android.57039daea3680b32"
+      "id": "native.android.c8cf4a2716b649e4"
     },
     {
       "kind": "conditional-branch",
@@ -295,7 +295,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": "Connected",
       "surface": "android",
-      "id": "native.android.bdb23d09ec892aff"
+      "id": "native.android.012c8499137972ad"
     },
     {
       "kind": "conditional-branch",
@@ -303,7 +303,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": "Talk mode active",
       "surface": "android",
-      "id": "native.android.07568bc2777e31cf"
+      "id": "native.android.3e0889d921c92cab"
     },
     {
       "kind": "conditional-branch",
@@ -319,7 +319,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": " · Mic: Listening",
       "surface": "android",
-      "id": "native.android.6432b484134d2a61"
+      "id": "native.android.ae88801e6a1b3343"
     },
     {
       "kind": "conditional-branch",
@@ -327,7 +327,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": " · Mic: Pending",
       "surface": "android",
-      "id": "native.android.f7d1b25cfbc4cebc"
+      "id": "native.android.7521acb4a7bc9a75"
     },
     {
       "kind": "conditional-branch",
@@ -375,7 +375,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
-      "id": "native.android.9529170a4389644c"
+      "id": "native.android.c65b61de70a063e7"
     },
     {
       "kind": "conditional-branch",
@@ -383,7 +383,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron job started.",
       "surface": "android",
-      "id": "native.android.1ebef3822941cdb6"
+      "id": "native.android.fef5049bc20826c7"
     },
     {
       "kind": "conditional-branch",
@@ -391,7 +391,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron run queued.",
       "surface": "android",
-      "id": "native.android.d8ba5136a17f7618"
+      "id": "native.android.c39fb6f80dbf6820"
     },
     {
       "kind": "conditional-branch",
@@ -399,7 +399,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron job disabled.",
       "surface": "android",
-      "id": "native.android.8a758d2851f3db17"
+      "id": "native.android.b878b2913410055a"
     },
     {
       "kind": "conditional-branch",
@@ -407,7 +407,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron job enabled.",
       "surface": "android",
-      "id": "native.android.fda9390dc0d4bdea"
+      "id": "native.android.a45ec59239fbfff0"
     },
     {
       "kind": "conditional-branch",
@@ -415,7 +415,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
-      "id": "native.android.3ff4dd2f45fcbb3e"
+      "id": "native.android.4b07456682e725d9"
     },
     {
       "kind": "conditional-branch",
@@ -423,7 +423,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
-      "id": "native.android.bc5a666c1549dc34"
+      "id": "native.android.467899bb510b8e34"
     },
     {
       "kind": "conditional-branch",
@@ -431,7 +431,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
-      "id": "native.android.350a8a4635d3afb0"
+      "id": "native.android.84ce52ae1375fded"
     },
     {
       "kind": "conditional-branch",
@@ -455,7 +455,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Permission required",
       "surface": "android",
-      "id": "native.android.fbf72e04a0b69341"
+      "id": "native.android.c28c08aed378b051"
     },
     {
       "kind": "ui-dialog",
@@ -463,7 +463,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Continue",
       "surface": "android",
-      "id": "native.android.40777e57e2c6fcf8"
+      "id": "native.android.d5aead6db3dd65fd"
     },
     {
       "kind": "ui-dialog",
@@ -471,7 +471,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Not now",
       "surface": "android",
-      "id": "native.android.e4def4463cc1e694"
+      "id": "native.android.8b5866c0ea9b3918"
     },
     {
       "kind": "ui-dialog",
@@ -479,7 +479,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Enable permission in Settings",
       "surface": "android",
-      "id": "native.android.318ff24e3636bea0"
+      "id": "native.android.1f681dbe04d36798"
     },
     {
       "kind": "ui-dialog",
@@ -487,7 +487,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Open Settings",
       "surface": "android",
-      "id": "native.android.ebdd4a402bb6506f"
+      "id": "native.android.d136904b63062d5f"
     },
     {
       "kind": "ui-dialog",
@@ -495,7 +495,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Cancel",
       "surface": "android",
-      "id": "native.android.97a7a01b4463d8b1"
+      "id": "native.android.d5e9f727ca9dbf9f"
     },
     {
       "kind": "conditional-branch",
@@ -503,7 +503,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "OpenClaw needs ${labels.joinToString(\", \")} permissions to continue.",
       "surface": "android",
-      "id": "native.android.df09fca17a135a63"
+      "id": "native.android.237761be968be3f4"
     },
     {
       "kind": "conditional-branch",
@@ -511,7 +511,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Please enable ${labels.joinToString(\", \")} in Android Settings to continue.",
       "surface": "android",
-      "id": "native.android.b3e03b906c7d520b"
+      "id": "native.android.f9b9d558dc078d96"
     },
     {
       "kind": "conditional-branch",
@@ -519,7 +519,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Camera",
       "surface": "android",
-      "id": "native.android.315f7c8adfd969d8"
+      "id": "native.android.e4c48a99de505454"
     },
     {
       "kind": "conditional-branch",
@@ -527,7 +527,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Microphone",
       "surface": "android",
-      "id": "native.android.3d9487b153749cc5"
+      "id": "native.android.569334e85c7d2862"
     },
     {
       "kind": "conditional-branch",
@@ -535,7 +535,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Send SMS",
       "surface": "android",
-      "id": "native.android.27011e390920e0e9"
+      "id": "native.android.8b87f961f51aaacc"
     },
     {
       "kind": "conditional-branch",
@@ -543,7 +543,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Read SMS",
       "surface": "android",
-      "id": "native.android.433a488fa5424773"
+      "id": "native.android.5606642bd91f3a05"
     },
     {
       "kind": "conditional-branch",
@@ -551,7 +551,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Read Contacts",
       "surface": "android",
-      "id": "native.android.0d171b2b5fe90830"
+      "id": "native.android.1215f26e8342c4e7"
     },
     {
       "kind": "conditional-branch",
@@ -559,7 +559,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Write Contacts",
       "surface": "android",
-      "id": "native.android.14d2331db12657ea"
+      "id": "native.android.66892d0ae6630720"
     },
     {
       "kind": "conditional-branch",
@@ -567,7 +567,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Read Calendar",
       "surface": "android",
-      "id": "native.android.4e7798b1015a01d2"
+      "id": "native.android.407387e45dbb6487"
     },
     {
       "kind": "conditional-branch",
@@ -575,7 +575,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Write Calendar",
       "surface": "android",
-      "id": "native.android.eb94700838b151e8"
+      "id": "native.android.1a79e1ef4f0b3305"
     },
     {
       "kind": "conditional-branch",
@@ -583,7 +583,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Read Call Log",
       "surface": "android",
-      "id": "native.android.cbbf53c95d194699"
+      "id": "native.android.7ebc21ff3437f6b3"
     },
     {
       "kind": "conditional-branch",
@@ -591,7 +591,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Motion Activity",
       "surface": "android",
-      "id": "native.android.c1998543419722ab"
+      "id": "native.android.143bc0ded8478566"
     },
     {
       "kind": "conditional-branch",
@@ -599,7 +599,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Photos",
       "surface": "android",
-      "id": "native.android.ca984bf3408181aa"
+      "id": "native.android.1e4171b934bcfc63"
     },
     {
       "kind": "ui-state-text",
@@ -607,7 +607,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt",
       "source": "Searching…",
       "surface": "android",
-      "id": "native.android.5640822ab2dfd74b"
+      "id": "native.android.93ecb3b3e1f02b63"
     },
     {
       "kind": "conditional-branch",
@@ -615,7 +615,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Connecting…",
       "surface": "android",
-      "id": "native.android.192e4333f5d4cc55"
+      "id": "native.android.1cbaba9cbffb2f97"
     },
     {
       "kind": "conditional-branch",
@@ -623,7 +623,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Reconnecting…",
       "surface": "android",
-      "id": "native.android.21741462c2bec768"
+      "id": "native.android.f3bae11d8f364701"
     },
     {
       "kind": "conditional-branch",
@@ -631,7 +631,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/node/DebugHandler.kt",
       "source": "${signature.take(20)}... (OK)",
       "surface": "android",
-      "id": "native.android.e7453bd695a5deb4"
+      "id": "native.android.0a51e1306357556c"
     },
     {
       "kind": "conditional-branch",
@@ -639,7 +639,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/node/DebugHandler.kt",
       "source": "NULL (FAILED)",
       "surface": "android",
-      "id": "native.android.79fda7eedabf4e93"
+      "id": "native.android.6aa748e98888623e"
     },
     {
       "kind": "conditional-branch",
@@ -647,7 +647,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/node/NodePresenceAliveBeacon.kt",
       "source": "Android $release (SDK ${Build.VERSION.SDK_INT})",
       "surface": "android",
-      "id": "native.android.a0e7167784ae9c65"
+      "id": "native.android.5b17d331b254e403"
     },
     {
       "kind": "conditional-branch",
@@ -671,7 +671,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Home canvas",
       "surface": "android",
-      "id": "native.android.8cc30254e2980b0c"
+      "id": "native.android.cc8d2e1456629a59"
     },
     {
       "kind": "conditional-branch",
@@ -679,7 +679,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Live page",
       "surface": "android",
-      "id": "native.android.f23129b28583843c"
+      "id": "native.android.79fff0ded9891781"
     },
     {
       "kind": "ui-named-argument",
@@ -687,7 +687,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Canvas",
       "surface": "android",
-      "id": "native.android.89f93a6f991f8a2d"
+      "id": "native.android.82ab699f88638b8a"
     },
     {
       "kind": "ui-named-argument",
@@ -695,7 +695,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Current screen output and interactive app surface.",
       "surface": "android",
-      "id": "native.android.e7f515d8660ca4b1"
+      "id": "native.android.d5938abf7b7a7ee9"
     },
     {
       "kind": "conditional-branch",
@@ -703,7 +703,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Offline",
       "surface": "android",
-      "id": "native.android.05cc02338329a059"
+      "id": "native.android.c4abd4ecd607865f"
     },
     {
       "kind": "conditional-branch",
@@ -711,7 +711,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Online",
       "surface": "android",
-      "id": "native.android.36fba2ca803e8b62"
+      "id": "native.android.27c3e59e49776d1a"
     },
     {
       "kind": "conditional-branch",
@@ -719,7 +719,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Ready",
       "surface": "android",
-      "id": "native.android.d6ee752ec23ebe9c"
+      "id": "native.android.697dc7666c2cd6a3"
     },
     {
       "kind": "conditional-branch",
@@ -727,7 +727,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Standby",
       "surface": "android",
-      "id": "native.android.20d6718c5701d65f"
+      "id": "native.android.eeb3048253bde229"
     },
     {
       "kind": "conditional-branch",
@@ -735,7 +735,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Refresh Screen",
       "surface": "android",
-      "id": "native.android.6c5efcaaab6b6e16"
+      "id": "native.android.70a7ab0c61036745"
     },
     {
       "kind": "conditional-branch",
@@ -743,7 +743,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
-      "id": "native.android.a525741e5ad2000c"
+      "id": "native.android.2a870631873082b6"
     },
     {
       "kind": "conditional-branch",
@@ -751,7 +751,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Open Screen",
       "surface": "android",
-      "id": "native.android.d0cf4d0358dfbe2b"
+      "id": "native.android.7b8f4a7869855aea"
     },
     {
       "kind": "conditional-branch",
@@ -759,7 +759,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Reconnect",
       "surface": "android",
-      "id": "native.android.3536586f88be2ae6"
+      "id": "native.android.ec3669686494575b"
     },
     {
       "kind": "conditional-branch",
@@ -767,7 +767,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Connect the gateway",
       "surface": "android",
-      "id": "native.android.8489f94450b69f8f"
+      "id": "native.android.284be58a340fe172"
     },
     {
       "kind": "conditional-branch",
@@ -775,7 +775,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Screen surface ready",
       "surface": "android",
-      "id": "native.android.87da16b04f072025"
+      "id": "native.android.56d1d3f645832a4d"
     },
     {
       "kind": "conditional-branch",
@@ -783,7 +783,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Canvas output needs an active gateway connection.",
       "surface": "android",
-      "id": "native.android.86e277ee09c85d80"
+      "id": "native.android.3b37959b1d369a28"
     },
     {
       "kind": "conditional-branch",
@@ -791,7 +791,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
       "source": "Open the current Canvas surface to inspect or interact with it.",
       "surface": "android",
-      "id": "native.android.2a16dff830477ab7"
+      "id": "native.android.cd92e0961b0bf500"
     },
     {
       "kind": "ui-named-argument",
@@ -799,7 +799,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Channels",
       "surface": "android",
-      "id": "native.android.8f16d1e77c4908df"
+      "id": "native.android.624fec3507aca6ed"
     },
     {
       "kind": "ui-named-argument",
@@ -807,7 +807,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Messaging surfaces connected to this gateway.",
       "surface": "android",
-      "id": "native.android.3c8f08f9297661c8"
+      "id": "native.android.269dcd676377df1a"
     },
     {
       "kind": "conditional-branch",
@@ -815,7 +815,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Refresh",
       "surface": "android",
-      "id": "native.android.6cd158ad0913d564"
+      "id": "native.android.3ae4829888a376e6"
     },
     {
       "kind": "conditional-branch",
@@ -823,7 +823,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
-      "id": "native.android.edd5e6335ed8b9be"
+      "id": "native.android.5d0b97b67465eabe"
     },
     {
       "kind": "ui-named-argument",
@@ -831,7 +831,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Connect the gateway to load channels.",
       "surface": "android",
-      "id": "native.android.1b8bcdd0cbe69512"
+      "id": "native.android.5ade075ecd0175d3"
     },
     {
       "kind": "ui-named-argument",
@@ -839,7 +839,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "No channels found.",
       "surface": "android",
-      "id": "native.android.32ddf1415de934ad"
+      "id": "native.android.992528cbc6e1d47c"
     },
     {
       "kind": "ui-named-argument",
@@ -847,7 +847,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Telegram, WhatsApp, email, and other channels appear here after setup.",
       "surface": "android",
-      "id": "native.android.0b6493ccef5577a7"
+      "id": "native.android.484f73775ff81a33"
     },
     {
       "kind": "conditional-branch",
@@ -855,7 +855,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
       "source": "Some channel status checks did not complete.",
       "surface": "android",
-      "id": "native.android.95d8abe6c4a09b0a"
+      "id": "native.android.0015adc34e74003b"
     },
     {
       "kind": "ui-named-argument",
@@ -863,7 +863,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Close search",
       "surface": "android",
-      "id": "native.android.7cf6aa1df0a831c3"
+      "id": "native.android.3fc6f9784b0d9334"
     },
     {
       "kind": "ui-named-argument",
@@ -871,7 +871,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Search",
       "surface": "android",
-      "id": "native.android.87c9ce0ec2bca55a"
+      "id": "native.android.7a804b9140cae09c"
     },
     {
       "kind": "ui-named-argument",
@@ -879,7 +879,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "OC",
       "surface": "android",
-      "id": "native.android.f6b137e81ba6b241"
+      "id": "native.android.39b8fec9527afedd"
     },
     {
       "kind": "ui-named-argument",
@@ -887,7 +887,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Search OpenClaw",
       "surface": "android",
-      "id": "native.android.15721c9f1a4bbb89"
+      "id": "native.android.9f877120690b0c59"
     },
     {
       "kind": "ui-named-argument",
@@ -895,7 +895,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Quick actions",
       "surface": "android",
-      "id": "native.android.cc7482733d97e5df"
+      "id": "native.android.c142846e7b88306c"
     },
     {
       "kind": "ui-named-argument",
@@ -903,7 +903,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "No actions found",
       "surface": "android",
-      "id": "native.android.1a646e08e4a8b502"
+      "id": "native.android.7c4288229860edf1"
     },
     {
       "kind": "ui-named-argument",
@@ -911,7 +911,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
       "surface": "android",
-      "id": "native.android.29048b2ee2c3c0f6"
+      "id": "native.android.48ad0ae0e930e02b"
     },
     {
       "kind": "ui-named-argument",
@@ -919,7 +919,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Sessions",
       "surface": "android",
-      "id": "native.android.2eb8597697a9582e"
+      "id": "native.android.d4fbd1ee4f55a5db"
     },
     {
       "kind": "conditional-branch",
@@ -927,7 +927,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Connect the Gateway to search sessions.",
       "surface": "android",
-      "id": "native.android.81b2c221ee0b7dc5"
+      "id": "native.android.207c2170504e99e6"
     },
     {
       "kind": "conditional-branch",
@@ -935,7 +935,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "No matching sessions yet.",
       "surface": "android",
-      "id": "native.android.cf93c8306951bbc2"
+      "id": "native.android.25d2c2d792c952fe"
     },
     {
       "kind": "conditional-branch",
@@ -943,7 +943,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Assistant working",
       "surface": "android",
-      "id": "native.android.f2702b980b6ec319"
+      "id": "native.android.1d009aa9b54d689d"
     },
     {
       "kind": "conditional-branch",
@@ -951,7 +951,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "OpenClaw session",
       "surface": "android",
-      "id": "native.android.bae8ae739b84cd84"
+      "id": "native.android.8f8384286317f5c9"
     },
     {
       "kind": "ui-named-argument",
@@ -959,7 +959,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Open ${row.title}",
       "surface": "android",
-      "id": "native.android.7783a76d10d5bc03"
+      "id": "native.android.23321276a6c8e11e"
     },
     {
       "kind": "ui-named-argument",
@@ -967,7 +967,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Open session",
       "surface": "android",
-      "id": "native.android.992ac1f4eb3f9728"
+      "id": "native.android.15799e57704b20c6"
     },
     {
       "kind": "conditional-branch",
@@ -975,7 +975,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Connect Gateway to view providers",
       "surface": "android",
-      "id": "native.android.8ed4adcba7f88c24"
+      "id": "native.android.42fd88c3d0418a4a"
     },
     {
       "kind": "conditional-branch",
@@ -983,7 +983,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "$readyProviderCount providers ready",
       "surface": "android",
-      "id": "native.android.059784fcf871ff29"
+      "id": "native.android.cb4cc4336cf67145"
     },
     {
       "kind": "conditional-branch",
@@ -999,7 +999,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "No ready providers",
       "surface": "android",
-      "id": "native.android.35c66a4a919ec390"
+      "id": "native.android.d5aca322cbdaad85"
     },
     {
       "kind": "conditional-branch",
@@ -1007,7 +1007,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Main session",
       "surface": "android",
-      "id": "native.android.fbaa31465843ccf4"
+      "id": "native.android.73e6ab1a168fd381"
     },
     {
       "kind": "ui-call",
@@ -1015,7 +1015,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Delete",
       "surface": "android",
-      "id": "native.android.357076952c35ceea"
+      "id": "native.android.c4a902430c22030c"
     },
     {
       "kind": "ui-call",
@@ -1023,7 +1023,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Cancel",
       "surface": "android",
-      "id": "native.android.2d3a02b350515797"
+      "id": "native.android.6e1aaf9469428b28"
     },
     {
       "kind": "ui-call",
@@ -1031,7 +1031,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Delete cron job?",
       "surface": "android",
-      "id": "native.android.9191cefdc7a0648e"
+      "id": "native.android.ec06722578a6027e"
     },
     {
       "kind": "ui-call",
@@ -1039,7 +1039,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "This permanently removes the scheduled job from the gateway.",
       "surface": "android",
-      "id": "native.android.f5156edc640fa13a"
+      "id": "native.android.362073d4e1e4624d"
     },
     {
       "kind": "conditional-branch",
@@ -1063,7 +1063,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Admin access required",
       "surface": "android",
-      "id": "native.android.00c56ce92a3fa169"
+      "id": "native.android.212889821e40127e"
     },
     {
       "kind": "ui-named-argument-concatenated",
@@ -1079,7 +1079,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Disable",
       "surface": "android",
-      "id": "native.android.0aeb0b9c33d6eb9c"
+      "id": "native.android.f5ed7396dc317625"
     },
     {
       "kind": "conditional-branch",
@@ -1087,7 +1087,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Enable",
       "surface": "android",
-      "id": "native.android.59abd1b2564ecace"
+      "id": "native.android.1e3d5d4e62b4a7b0"
     },
     {
       "kind": "ui-named-argument",
@@ -1095,7 +1095,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Delete Job",
       "surface": "android",
-      "id": "native.android.91944307e272d456"
+      "id": "native.android.1fed5d5912a9679c"
     },
     {
       "kind": "ui-named-argument",
@@ -1103,7 +1103,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Edit Job",
       "surface": "android",
-      "id": "native.android.703b4568e0e76795"
+      "id": "native.android.da9ecf342cbd7035"
     },
     {
       "kind": "ui-named-argument",
@@ -1111,7 +1111,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Enabled",
       "surface": "android",
-      "id": "native.android.104e4f3c11e88d7e"
+      "id": "native.android.006f60922ae98063"
     },
     {
       "kind": "ui-named-argument",
@@ -1119,7 +1119,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Allow the scheduler to run this job.",
       "surface": "android",
-      "id": "native.android.d8425c7e0769a452"
+      "id": "native.android.8b967e5cba1edfd8"
     },
     {
       "kind": "ui-named-argument",
@@ -1127,7 +1127,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Delete after run",
       "surface": "android",
-      "id": "native.android.b8a57f83f10d4c5e"
+      "id": "native.android.f5fe0e769a9df4f8"
     },
     {
       "kind": "ui-named-argument",
@@ -1135,7 +1135,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Remove this job after a successful one-shot run.",
       "surface": "android",
-      "id": "native.android.fc744c61f3324b8d"
+      "id": "native.android.9ed8d09744263540"
     },
     {
       "kind": "ui-named-argument",
@@ -1143,7 +1143,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Job name",
       "surface": "android",
-      "id": "native.android.16ea42c6aeec16f5"
+      "id": "native.android.8faa8ae2ea76fe52"
     },
     {
       "kind": "ui-named-argument",
@@ -1151,7 +1151,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Name",
       "surface": "android",
-      "id": "native.android.713ce0a27e97ed68"
+      "id": "native.android.e3a12cf55b2caea3"
     },
     {
       "kind": "ui-named-argument",
@@ -1159,7 +1159,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Optional description",
       "surface": "android",
-      "id": "native.android.e6f76a6e0cb04da9"
+      "id": "native.android.6c87607a5cebdb8e"
     },
     {
       "kind": "ui-named-argument",
@@ -1167,7 +1167,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Description",
       "surface": "android",
-      "id": "native.android.42eb09f228b1ccd9"
+      "id": "native.android.0889eb39d1b58159"
     },
     {
       "kind": "ui-named-argument",
@@ -1175,7 +1175,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "main, isolated, current, or session:<id>",
       "surface": "android",
-      "id": "native.android.6a62274abe78b05d"
+      "id": "native.android.853d7f21386e00ce"
     },
     {
       "kind": "ui-named-argument",
@@ -1183,7 +1183,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Session target",
       "surface": "android",
-      "id": "native.android.0b13762e7a971bb4"
+      "id": "native.android.65d7bb7d9f9b082f"
     },
     {
       "kind": "conditional-branch",
@@ -1191,7 +1191,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Save Changes",
       "surface": "android",
-      "id": "native.android.ee45f4172c37361b"
+      "id": "native.android.d84417059750df22"
     },
     {
       "kind": "conditional-branch",
@@ -1199,7 +1199,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Working",
       "surface": "android",
-      "id": "native.android.701dc5f4f73d1413"
+      "id": "native.android.2e09de2153828824"
     },
     {
       "kind": "ui-named-argument",
@@ -1207,7 +1207,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Revert Changes",
       "surface": "android",
-      "id": "native.android.794135f9eb9fa9d9"
+      "id": "native.android.e4c8c46ac5a926f7"
     },
     {
       "kind": "ui-named-argument",
@@ -1215,7 +1215,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Schedule · ${cronScheduleKindLabel(schedule)}",
       "surface": "android",
-      "id": "native.android.a76c03d10b89ec0c"
+      "id": "native.android.6709a2ee21539fac"
     },
     {
       "kind": "ui-named-argument",
@@ -1223,7 +1223,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "ISO time, e.g. 2026-07-09T09:30:00Z",
       "surface": "android",
-      "id": "native.android.fe3d57c15d174752"
+      "id": "native.android.c5c8713fcc8b695b"
     },
     {
       "kind": "ui-named-argument",
@@ -1231,7 +1231,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Run at",
       "surface": "android",
-      "id": "native.android.27055d0f1127f89d"
+      "id": "native.android.af7a2e3e4e43b695"
     },
     {
       "kind": "ui-named-argument",
@@ -1239,7 +1239,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Milliseconds",
       "surface": "android",
-      "id": "native.android.5f600b28cff9043a"
+      "id": "native.android.67f1f087d42411e7"
     },
     {
       "kind": "ui-named-argument",
@@ -1247,7 +1247,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Interval",
       "surface": "android",
-      "id": "native.android.b62227884b6d9256"
+      "id": "native.android.4a97c2ca6b3a2ea6"
     },
     {
       "kind": "ui-named-argument",
@@ -1255,7 +1255,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Epoch milliseconds (optional)",
       "surface": "android",
-      "id": "native.android.fa0770de33b08f46"
+      "id": "native.android.af67797053368f7a"
     },
     {
       "kind": "ui-named-argument",
@@ -1263,7 +1263,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Anchor",
       "surface": "android",
-      "id": "native.android.3bf9e34dd98407bb"
+      "id": "native.android.f92ca93c74dd9ec6"
     },
     {
       "kind": "ui-named-argument",
@@ -1271,7 +1271,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Cron expression, e.g. 0 9 * * *",
       "surface": "android",
-      "id": "native.android.eb943d422fbabac1"
+      "id": "native.android.ec1404d32b37a228"
     },
     {
       "kind": "ui-named-argument",
@@ -1279,7 +1279,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Expression",
       "surface": "android",
-      "id": "native.android.012eb58dbb5a923d"
+      "id": "native.android.7224806b900ea27b"
     },
     {
       "kind": "ui-named-argument",
@@ -1287,7 +1287,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "e.g. America/New_York",
       "surface": "android",
-      "id": "native.android.bee25563912907ce"
+      "id": "native.android.3fd296fbbcbd0e80"
     },
     {
       "kind": "ui-named-argument",
@@ -1295,7 +1295,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Timezone",
       "surface": "android",
-      "id": "native.android.d2fc93656117d688"
+      "id": "native.android.6a15bddd2f00a26b"
     },
     {
       "kind": "ui-named-argument",
@@ -1303,7 +1303,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "0 = exact",
       "surface": "android",
-      "id": "native.android.2870735fc8ed7ef9"
+      "id": "native.android.0f3a49d995ed9910"
     },
     {
       "kind": "ui-named-argument",
@@ -1311,7 +1311,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Stagger ms",
       "surface": "android",
-      "id": "native.android.8242e0f118d88a6b"
+      "id": "native.android.9c4cd709af2884fd"
     },
     {
       "kind": "ui-named-argument",
@@ -1319,7 +1319,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Command to watch",
       "surface": "android",
-      "id": "native.android.9274985cbdc77132"
+      "id": "native.android.36ef6b38d936f70f"
     },
     {
       "kind": "ui-named-argument",
@@ -1327,7 +1327,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Command",
       "surface": "android",
-      "id": "native.android.7cb96c3ca20def5f"
+      "id": "native.android.09bb59bcf0c7e009"
     },
     {
       "kind": "ui-named-argument",
@@ -1335,7 +1335,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Working directory",
       "surface": "android",
-      "id": "native.android.04c77d1b81874906"
+      "id": "native.android.cad18710a0fdaa21"
     },
     {
       "kind": "ui-named-argument",
@@ -1343,7 +1343,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Payload · ${cronPayloadKindLabel(payload)}",
       "surface": "android",
-      "id": "native.android.5f2dfb4437da54bc"
+      "id": "native.android.06fb3142ca1b9d7a"
     },
     {
       "kind": "ui-named-argument",
@@ -1351,7 +1351,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "System event text",
       "surface": "android",
-      "id": "native.android.a9ad0131f8c13832"
+      "id": "native.android.9719574f53e9ee15"
     },
     {
       "kind": "ui-named-argument",
@@ -1359,7 +1359,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Event text",
       "surface": "android",
-      "id": "native.android.4e726a5b9986d8da"
+      "id": "native.android.268f6823b43b3177"
     },
     {
       "kind": "ui-named-argument",
@@ -1367,7 +1367,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Agent message",
       "surface": "android",
-      "id": "native.android.cc5d86241bff114f"
+      "id": "native.android.406fffc637df0bc0"
     },
     {
       "kind": "ui-named-argument",
@@ -1375,7 +1375,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Message",
       "surface": "android",
-      "id": "native.android.54ea9f436040fb65"
+      "id": "native.android.657a9cba38e35a9c"
     },
     {
       "kind": "ui-named-argument",
@@ -1383,7 +1383,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Model",
       "surface": "android",
-      "id": "native.android.0e48df116a7c8712"
+      "id": "native.android.282315578422bf23"
     },
     {
       "kind": "ui-named-argument",
@@ -1391,7 +1391,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Optional override",
       "surface": "android",
-      "id": "native.android.97e636d1128629df"
+      "id": "native.android.aca463f1ba7edde5"
     },
     {
       "kind": "ui-named-argument",
@@ -1399,7 +1399,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Thinking",
       "surface": "android",
-      "id": "native.android.65a0249a9d6a598f"
+      "id": "native.android.7f45799d74ee7587"
     },
     {
       "kind": "ui-named-argument",
@@ -1407,7 +1407,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Command argv JSON array",
       "surface": "android",
-      "id": "native.android.94412766a31dcff6"
+      "id": "native.android.0a20280e51a2c61b"
     },
     {
       "kind": "ui-named-argument",
@@ -1415,7 +1415,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Arguments",
       "surface": "android",
-      "id": "native.android.0dc63f7146334b8c"
+      "id": "native.android.04c3a1825c19886e"
     },
     {
       "kind": "ui-named-argument",
@@ -1423,7 +1423,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Optional path",
       "surface": "android",
-      "id": "native.android.76dad38b77c9a4cf"
+      "id": "native.android.e45a470156b0f564"
     },
     {
       "kind": "conditional-branch",
@@ -1447,7 +1447,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "The gateway can change this path but cannot clear an existing path.",
       "surface": "android",
-      "id": "native.android.dbe0f281bf1caea1"
+      "id": "native.android.00a27842963455a7"
     },
     {
       "kind": "ui-named-argument",
@@ -1455,7 +1455,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Recent Runs",
       "surface": "android",
-      "id": "native.android.4ff0531390ea8a40"
+      "id": "native.android.b0de849068a82211"
     },
     {
       "kind": "conditional-branch",
@@ -1463,7 +1463,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Loading",
       "surface": "android",
-      "id": "native.android.b86336562ac63ec2"
+      "id": "native.android.9b6b1f5c976e23fa"
     },
     {
       "kind": "conditional-branch",
@@ -1471,7 +1471,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Reload",
       "surface": "android",
-      "id": "native.android.a4eb2acccc5ded54"
+      "id": "native.android.30ea2a568e832013"
     },
     {
       "kind": "conditional-branch",
@@ -1479,7 +1479,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Loading recent runs…",
       "surface": "android",
-      "id": "native.android.babccd556ac46f93"
+      "id": "native.android.677d53d3c85c3d7e"
     },
     {
       "kind": "conditional-branch",
@@ -1487,7 +1487,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "No recent runs yet.",
       "surface": "android",
-      "id": "native.android.97363cc482924983"
+      "id": "native.android.9daf37294c74454c"
     },
     {
       "kind": "conditional-branch",
@@ -1495,7 +1495,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "One time",
       "surface": "android",
-      "id": "native.android.dba9901722fa52ee"
+      "id": "native.android.322daf975eb5e204"
     },
     {
       "kind": "conditional-branch",
@@ -1503,7 +1503,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Cron",
       "surface": "android",
-      "id": "native.android.69c356133463eb59"
+      "id": "native.android.d8dfc026668cdc81"
     },
     {
       "kind": "conditional-branch",
@@ -1511,7 +1511,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "On command exit",
       "surface": "android",
-      "id": "native.android.5ff52e2d6cf1abec"
+      "id": "native.android.da05d4ae32ae6a75"
     },
     {
       "kind": "conditional-branch",
@@ -1519,7 +1519,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "System event",
       "surface": "android",
-      "id": "native.android.5f4d89cd808b21dd"
+      "id": "native.android.22f6ed1cadece34c"
     },
     {
       "kind": "conditional-branch",
@@ -1527,7 +1527,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt",
       "source": "Agent turn",
       "surface": "android",
-      "id": "native.android.b4076cab2747e088"
+      "id": "native.android.24e541dd61519341"
     },
     {
       "kind": "ui-named-argument",
@@ -1535,7 +1535,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "Dreaming",
       "surface": "android",
-      "id": "native.android.c469d668e93d3dbb"
+      "id": "native.android.b735fb6c7d284ecf"
     },
     {
       "kind": "ui-named-argument",
@@ -1543,7 +1543,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "Memory consolidation and dream diary.",
       "surface": "android",
-      "id": "native.android.0069bfbabcfddb7f"
+      "id": "native.android.4f96e0e1568d3220"
     },
     {
       "kind": "conditional-branch",
@@ -1551,7 +1551,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "Off",
       "surface": "android",
-      "id": "native.android.858d7af028e3dea8"
+      "id": "native.android.fe6205cd51ca9294"
     },
     {
       "kind": "conditional-branch",
@@ -1559,7 +1559,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "On",
       "surface": "android",
-      "id": "native.android.6742798589066927"
+      "id": "native.android.4f1e1ae70b8be673"
     },
     {
       "kind": "conditional-branch",
@@ -1567,7 +1567,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "Refresh",
       "surface": "android",
-      "id": "native.android.ff8d182bc37b17a8"
+      "id": "native.android.a0f6d433844d6129"
     },
     {
       "kind": "conditional-branch",
@@ -1575,7 +1575,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
-      "id": "native.android.d95680057e8f9428"
+      "id": "native.android.8f415a13cb47b13f"
     },
     {
       "kind": "ui-named-argument",
@@ -1583,7 +1583,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "Connect the gateway to load dreaming.",
       "surface": "android",
-      "id": "native.android.4fb6008edcfd284c"
+      "id": "native.android.5aa176a33e0ccf39"
     },
     {
       "kind": "ui-named-argument",
@@ -1591,7 +1591,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "Memory Store",
       "surface": "android",
-      "id": "native.android.270803cd26af07a1"
+      "id": "native.android.eddd9c73506fb13d"
     },
     {
       "kind": "ui-named-argument",
@@ -1599,7 +1599,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "Signal Index",
       "surface": "android",
-      "id": "native.android.32050f86b121c166"
+      "id": "native.android.ee38e75c2cb266ff"
     },
     {
       "kind": "conditional-branch",
@@ -1607,7 +1607,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "Healthy",
       "surface": "android",
-      "id": "native.android.d151b5e42563285f"
+      "id": "native.android.aad1071140b4d96a"
     },
     {
       "kind": "conditional-branch",
@@ -1615,7 +1615,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "Needs attention",
       "surface": "android",
-      "id": "native.android.08c0fa02933271fa"
+      "id": "native.android.a63b20ed6c7ca049"
     },
     {
       "kind": "ui-named-argument",
@@ -1623,7 +1623,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "Promoted",
       "surface": "android",
-      "id": "native.android.e4b7ed277d6fba43"
+      "id": "native.android.1fa9bba1998478db"
     },
     {
       "kind": "ui-named-argument",
@@ -1631,7 +1631,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "DIARY",
       "surface": "android",
-      "id": "native.android.d9458f8640c33986"
+      "id": "native.android.76726c57be04cd2a"
     },
     {
       "kind": "ui-named-argument",
@@ -1639,7 +1639,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "No dream diary yet.",
       "surface": "android",
-      "id": "native.android.2448184ddbeecce4"
+      "id": "native.android.15e1398d4eff28f4"
     },
     {
       "kind": "ui-named-argument",
@@ -1647,7 +1647,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "Entries appear after a dreaming cycle writes a narrative summary.",
       "surface": "android",
-      "id": "native.android.25045fdc8cb1c1ba"
+      "id": "native.android.79b6db08d385f76f"
     },
     {
       "kind": "ui-named-argument",
@@ -1655,7 +1655,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "The diary is waiting for its first entry.",
       "surface": "android",
-      "id": "native.android.20371ad7f7b5d52b"
+      "id": "native.android.b5f63fbf76f816f3"
     },
     {
       "kind": "ui-named-argument",
@@ -1663,7 +1663,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
       "source": "D",
       "surface": "android",
-      "id": "native.android.87e2d2971c09552d"
+      "id": "native.android.a45b15d8549e9539"
     },
     {
       "kind": "conditional-branch",
@@ -1687,7 +1687,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "Setup code points to an insecure remote gateway. $remoteGatewaySecurityRule $remoteGatewaySecurityFix",
       "surface": "android",
-      "id": "native.android.180483eb1b7a4ff1"
+      "id": "native.android.458f8fd9ad7485a7"
     },
     {
       "kind": "conditional-branch",
@@ -1695,7 +1695,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "QR code points to an insecure remote gateway. $remoteGatewaySecurityRule $remoteGatewaySecurityFix",
       "surface": "android",
-      "id": "native.android.9504a95ceefca5e8"
+      "id": "native.android.1a15475cf8d92de8"
     },
     {
       "kind": "conditional-branch",
@@ -1703,7 +1703,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "$remoteGatewaySecurityRule $remoteGatewaySecurityFix",
       "surface": "android",
-      "id": "native.android.9373db8f4269091a"
+      "id": "native.android.a77d1e3d811ad9d8"
     },
     {
       "kind": "conditional-branch",
@@ -1711,7 +1711,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "Setup code uses an IPv6 zone ID. Use an unscoped IPv6 address or a LAN hostname.",
       "surface": "android",
-      "id": "native.android.84ea70ae0976dca7"
+      "id": "native.android.d5230e4551045851"
     },
     {
       "kind": "conditional-branch",
@@ -1719,7 +1719,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "QR code uses an IPv6 zone ID. Use an unscoped IPv6 address or a LAN hostname.",
       "surface": "android",
-      "id": "native.android.1c32685b70f0585d"
+      "id": "native.android.ca9fc2ce10f4028a"
     },
     {
       "kind": "conditional-branch",
@@ -1727,7 +1727,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "IPv6 zone IDs are not supported. Use an unscoped IPv6 address or a LAN hostname.",
       "surface": "android",
-      "id": "native.android.b1ab0f426dacc83f"
+      "id": "native.android.141236601fece71e"
     },
     {
       "kind": "conditional-branch",
@@ -1735,7 +1735,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "Setup code has invalid gateway URL.",
       "surface": "android",
-      "id": "native.android.b35f854c0bf08eda"
+      "id": "native.android.47e3c19d55f0150b"
     },
     {
       "kind": "conditional-branch",
@@ -1743,7 +1743,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "QR code did not contain a valid setup code.",
       "surface": "android",
-      "id": "native.android.9598911ada12ef86"
+      "id": "native.android.b0cc3253031d22c2"
     },
     {
       "kind": "conditional-branch",
@@ -1751,7 +1751,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "Enter a valid manual endpoint to connect.",
       "surface": "android",
-      "id": "native.android.864a4b7e75710d7c"
+      "id": "native.android.732f5b59ba7e1513"
     },
     {
       "kind": "conditional-branch",
@@ -1759,7 +1759,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
       "source": "Setup code expired",
       "surface": "android",
-      "id": "native.android.e1054f3bc0555d58"
+      "id": "native.android.b331b5b54e147e41"
     },
     {
       "kind": "conditional-branch",
@@ -1767,7 +1767,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
       "source": "Gateway token needed",
       "surface": "android",
-      "id": "native.android.f2193ad06a43f411"
+      "id": "native.android.fd29725b5271ffcc"
     },
     {
       "kind": "conditional-branch",
@@ -1775,7 +1775,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
       "source": "Gateway token not configured",
       "surface": "android",
-      "id": "native.android.0f4d4e9558c7af45"
+      "id": "native.android.a20706c18b04439c"
     },
     {
       "kind": "conditional-branch",
@@ -1783,7 +1783,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
       "source": "Gateway password needed",
       "surface": "android",
-      "id": "native.android.cfb8e679760a1b88"
+      "id": "native.android.ef63577677f434bd"
     },
     {
       "kind": "conditional-branch",
@@ -1791,7 +1791,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
       "source": "Gateway password invalid",
       "surface": "android",
-      "id": "native.android.75212695995bedef"
+      "id": "native.android.841612944fc3c917"
     },
     {
       "kind": "conditional-branch",
@@ -1799,7 +1799,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
       "source": "Gateway password not configured",
       "surface": "android",
-      "id": "native.android.4c6ce02882c01df6"
+      "id": "native.android.746689fea659f156"
     },
     {
       "kind": "conditional-branch",
@@ -1807,7 +1807,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
       "source": "Gateway access needs review",
       "surface": "android",
-      "id": "native.android.99754af2b0e2ff9e"
+      "id": "native.android.3b34fd01c808e358"
     },
     {
       "kind": "conditional-branch",
@@ -1815,7 +1815,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
       "source": "Saved auth invalid",
       "surface": "android",
-      "id": "native.android.9582ed70d6d95c12"
+      "id": "native.android.baaf14ba36d7cc94"
     },
     {
       "kind": "conditional-branch",
@@ -1823,7 +1823,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
       "source": "Device identity required",
       "surface": "android",
-      "id": "native.android.48344496b7f8cc0a"
+      "id": "native.android.ec80b07c46a3bb1f"
     },
     {
       "kind": "ui-toast",
@@ -1831,7 +1831,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt",
       "source": "Copied gateway diagnostics",
       "surface": "android",
-      "id": "native.android.4e0df754986fed99"
+      "id": "native.android.b44fc3039e0fb9fa"
     },
     {
       "kind": "ui-named-argument",
@@ -1839,7 +1839,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Health",
       "surface": "android",
-      "id": "native.android.31b5f89b8517a3ec"
+      "id": "native.android.d5902896d7b92cc9"
     },
     {
       "kind": "ui-named-argument",
@@ -1847,7 +1847,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Gateway status, phone node readiness, and recent log stream.",
       "surface": "android",
-      "id": "native.android.9ce89a78454d843f"
+      "id": "native.android.6c1eb72c4b19c43a"
     },
     {
       "kind": "conditional-branch",
@@ -1855,7 +1855,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Offline",
       "surface": "android",
-      "id": "native.android.d4c845fc444ac249"
+      "id": "native.android.cac027a1232254cd"
     },
     {
       "kind": "conditional-branch",
@@ -1863,7 +1863,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Online",
       "surface": "android",
-      "id": "native.android.828b547bbf84f52e"
+      "id": "native.android.59602ad037679006"
     },
     {
       "kind": "conditional-branch",
@@ -1871,7 +1871,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Waiting",
       "surface": "android",
-      "id": "native.android.a1e0eae53bd96822"
+      "id": "native.android.a328ef4e475c8fbe"
     },
     {
       "kind": "conditional-branch",
@@ -1879,7 +1879,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Needs connection",
       "surface": "android",
-      "id": "native.android.75d85550f6902f37"
+      "id": "native.android.96f94678e3776142"
     },
     {
       "kind": "conditional-branch",
@@ -1887,7 +1887,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Ready",
       "surface": "android",
-      "id": "native.android.0560195a6fbe78fc"
+      "id": "native.android.2a50ec20cdf08301"
     },
     {
       "kind": "conditional-branch",
@@ -1895,7 +1895,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "$pendingRunCount active",
       "surface": "android",
-      "id": "native.android.f7f1d2acc89303b1"
+      "id": "native.android.327e2c1665be1925"
     },
     {
       "kind": "conditional-branch",
@@ -1903,7 +1903,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Idle",
       "surface": "android",
-      "id": "native.android.bf50c0368dcf5db1"
+      "id": "native.android.6a62b57b708f9750"
     },
     {
       "kind": "conditional-branch",
@@ -1911,7 +1911,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Refresh Logs",
       "surface": "android",
-      "id": "native.android.7400d2313e5b03a2"
+      "id": "native.android.d881aa24cd9688dc"
     },
     {
       "kind": "conditional-branch",
@@ -1919,7 +1919,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
-      "id": "native.android.7d2cb0b8b261d2f0"
+      "id": "native.android.5a5d32406f0854f0"
     },
     {
       "kind": "ui-named-argument",
@@ -1927,7 +1927,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Log Entry",
       "surface": "android",
-      "id": "native.android.3fac7c82ee6a600c"
+      "id": "native.android.3abbc8d1a0faf105"
     },
     {
       "kind": "ui-named-argument",
@@ -1935,7 +1935,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Readable gateway log detail.",
       "surface": "android",
-      "id": "native.android.5e352a51d4d85ed7"
+      "id": "native.android.dd65a0b8f32f1441"
     },
     {
       "kind": "ui-named-argument",
@@ -1943,7 +1943,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Message",
       "surface": "android",
-      "id": "native.android.5100dab91f1f95b9"
+      "id": "native.android.27493dc9da0b1868"
     },
     {
       "kind": "ui-named-argument",
@@ -1951,7 +1951,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Raw",
       "surface": "android",
-      "id": "native.android.3649668ff4995030"
+      "id": "native.android.7787d6ba8f47569a"
     },
     {
       "kind": "ui-named-argument",
@@ -1959,7 +1959,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Gateway",
       "surface": "android",
-      "id": "native.android.42c5e031e9e482fa"
+      "id": "native.android.66abf18b56db44b2"
     },
     {
       "kind": "ui-named-argument",
@@ -1967,7 +1967,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Phone Node",
       "surface": "android",
-      "id": "native.android.495b30194d79a50b"
+      "id": "native.android.44cae82f7d34a414"
     },
     {
       "kind": "ui-named-argument",
@@ -1975,7 +1975,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Chat",
       "surface": "android",
-      "id": "native.android.f5990f63fc162ab0"
+      "id": "native.android.cd3cb6251f3f2829"
     },
     {
       "kind": "ui-named-argument",
@@ -1983,7 +1983,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Models",
       "surface": "android",
-      "id": "native.android.7103c01e56184baf"
+      "id": "native.android.b6ca712c36059f82"
     },
     {
       "kind": "ui-named-argument",
@@ -1991,7 +1991,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Voice",
       "surface": "android",
-      "id": "native.android.6c6ca3ed9b1f9ce7"
+      "id": "native.android.0fe10ad070cea5c3"
     },
     {
       "kind": "ui-named-argument",
@@ -1999,7 +1999,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Runs",
       "surface": "android",
-      "id": "native.android.45155181110d5f55"
+      "id": "native.android.9a2dc9af65486b8a"
     },
     {
       "kind": "ui-named-argument",
@@ -2007,7 +2007,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "RECENT LOGS",
       "surface": "android",
-      "id": "native.android.606caf039fbfa644"
+      "id": "native.android.72cda57e789dde68"
     },
     {
       "kind": "ui-named-argument",
@@ -2015,7 +2015,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Connect the gateway to load recent logs.",
       "surface": "android",
-      "id": "native.android.3dbd01c55d01ad48"
+      "id": "native.android.049ae19c839e5937"
     },
     {
       "kind": "ui-named-argument",
@@ -2023,7 +2023,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "No recent log entries.",
       "surface": "android",
-      "id": "native.android.8763f5ab69f7339c"
+      "id": "native.android.cefb84bdae346c7e"
     },
     {
       "kind": "ui-named-argument",
@@ -2031,7 +2031,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
       "source": "Showing the latest log chunk.",
       "surface": "android",
-      "id": "native.android.a7785c0f856f94f2"
+      "id": "native.android.47fa6b7f49434581"
     },
     {
       "kind": "ui-named-argument",
@@ -2039,7 +2039,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Nodes & Devices",
       "surface": "android",
-      "id": "native.android.b7656cb0285bf159"
+      "id": "native.android.7eda627dad7e16cf"
     },
     {
       "kind": "ui-named-argument",
@@ -2047,7 +2047,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Live nodes, paired phones, and pending device requests.",
       "surface": "android",
-      "id": "native.android.521e3ad46416eace"
+      "id": "native.android.006a92f5811c5406"
     },
     {
       "kind": "conditional-branch",
@@ -2055,7 +2055,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Refresh",
       "surface": "android",
-      "id": "native.android.03ed0cbae9bb5859"
+      "id": "native.android.a14d051ca26b222a"
     },
     {
       "kind": "conditional-branch",
@@ -2063,7 +2063,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
-      "id": "native.android.8aef1b4460eec07e"
+      "id": "native.android.67733e0b49b52cac"
     },
     {
       "kind": "ui-named-argument",
@@ -2071,7 +2071,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Connect the gateway to load nodes and paired devices.",
       "surface": "android",
-      "id": "native.android.35162358c7e1c893"
+      "id": "native.android.c7a463dfd4e2132d"
     },
     {
       "kind": "ui-named-argument",
@@ -2079,7 +2079,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "No nodes or paired devices.",
       "surface": "android",
-      "id": "native.android.c6210d3bdb161a91"
+      "id": "native.android.548e83e2900b7689"
     },
     {
       "kind": "ui-named-argument",
@@ -2087,7 +2087,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Linked phones and node hosts will appear here after pairing.",
       "surface": "android",
-      "id": "native.android.c01e8f39ac0ff17d"
+      "id": "native.android.c8ce503b95d13058"
     },
     {
       "kind": "ui-named-argument",
@@ -2095,7 +2095,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Node approval required",
       "surface": "android",
-      "id": "native.android.68b7d57d738a4c8c"
+      "id": "native.android.e177c7f189c1a472"
     },
     {
       "kind": "ui-named-argument",
@@ -2103,7 +2103,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Run on the Gateway host:",
       "surface": "android",
-      "id": "native.android.707694138bcea92d"
+      "id": "native.android.a850defd5857e7d1"
     },
     {
       "kind": "ui-named-argument",
@@ -2111,7 +2111,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Pending Requests",
       "surface": "android",
-      "id": "native.android.e425c18977a6f063"
+      "id": "native.android.70b6f8fccd67f4ce"
     },
     {
       "kind": "ui-named-argument",
@@ -2119,7 +2119,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Nodes",
       "surface": "android",
-      "id": "native.android.5a260a008e0ccbb0"
+      "id": "native.android.5ab18b6bcca8b935"
     },
     {
       "kind": "ui-named-argument",
@@ -2127,7 +2127,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Paired Devices",
       "surface": "android",
-      "id": "native.android.c2c153da92fb66bf"
+      "id": "native.android.e162df4ac19113aa"
     },
     {
       "kind": "conditional-branch",
@@ -2135,7 +2135,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Repair",
       "surface": "android",
-      "id": "native.android.2d49ea3af98a219c"
+      "id": "native.android.77935d2df6e42230"
     },
     {
       "kind": "conditional-branch",
@@ -2143,7 +2143,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Review",
       "surface": "android",
-      "id": "native.android.242a6741e592f1ae"
+      "id": "native.android.e29ce7466bc4062a"
     },
     {
       "kind": "conditional-branch",
@@ -2151,7 +2151,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Paired",
       "surface": "android",
-      "id": "native.android.637e485f2f63d62d"
+      "id": "native.android.840e5f49154642c7"
     },
     {
       "kind": "conditional-branch",
@@ -2159,7 +2159,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Unpaired",
       "surface": "android",
-      "id": "native.android.3fae2c80a5c5f51a"
+      "id": "native.android.1a2836f275433165"
     },
     {
       "kind": "conditional-branch",
@@ -2167,7 +2167,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Needs approval",
       "surface": "android",
-      "id": "native.android.8b9f85be726224fc"
+      "id": "native.android.bda106fdedede36c"
     },
     {
       "kind": "conditional-branch",
@@ -2175,7 +2175,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Needs reapproval",
       "surface": "android",
-      "id": "native.android.bf09c5d014a7c359"
+      "id": "native.android.a6da605b35be717c"
     },
     {
       "kind": "conditional-branch",
@@ -2183,7 +2183,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Unapproved",
       "surface": "android",
-      "id": "native.android.d4ee2c0656e25c4e"
+      "id": "native.android.2ea603624b785f18"
     },
     {
       "kind": "conditional-branch",
@@ -2191,7 +2191,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Offline",
       "surface": "android",
-      "id": "native.android.c42c2a17793748f3"
+      "id": "native.android.a6785924afa501a6"
     },
     {
       "kind": "conditional-branch",
@@ -2199,7 +2199,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Online",
       "surface": "android",
-      "id": "native.android.a7f846dfd8757c0b"
+      "id": "native.android.0bbe0d733b1328fd"
     },
     {
       "kind": "conditional-branch",
@@ -2215,7 +2215,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Trust",
       "surface": "android",
-      "id": "native.android.2be55b098fdd3e00"
+      "id": "native.android.9ac2d4498b17d478"
     },
     {
       "kind": "ui-call",
@@ -2223,7 +2223,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Cancel",
       "surface": "android",
-      "id": "native.android.96adee75eb648213"
+      "id": "native.android.e26ee07a1d1911be"
     },
     {
       "kind": "ui-named-argument",
@@ -2231,7 +2231,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Welcome to OpenClaw",
       "surface": "android",
-      "id": "native.android.c495432e17643430"
+      "id": "native.android.64c8db13ef91513c"
     },
     {
       "kind": "ui-named-argument",
@@ -2239,7 +2239,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Turn this device into a secure OpenClaw node for chat, voice, camera, and device tools.",
       "surface": "android",
-      "id": "native.android.50ff8eac48445327"
+      "id": "native.android.c38e106cc8f1e9ff"
     },
     {
       "kind": "ui-named-argument",
@@ -2247,7 +2247,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "OpenClaw logo",
       "surface": "android",
-      "id": "native.android.6fb50213c46094c8"
+      "id": "native.android.f941909a3fa51055"
     },
     {
       "kind": "ui-named-argument",
@@ -2255,7 +2255,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connect to your Gateway",
       "surface": "android",
-      "id": "native.android.942db0370fd15c76"
+      "id": "native.android.cc878f72a6b70b23"
     },
     {
       "kind": "ui-named-argument",
@@ -2263,7 +2263,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose device permissions",
       "surface": "android",
-      "id": "native.android.7a2fea26568cf42e"
+      "id": "native.android.bf3750bf264f0063"
     },
     {
       "kind": "ui-named-argument",
@@ -2271,7 +2271,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use OpenClaw from your phone",
       "surface": "android",
-      "id": "native.android.625b7a24614f4f21"
+      "id": "native.android.3bfe29d4d13d3c3e"
     },
     {
       "kind": "ui-named-argument",
@@ -2279,7 +2279,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Security notice",
       "surface": "android",
-      "id": "native.android.484966aff6e53901"
+      "id": "native.android.c0b539eeb4612f5d"
     },
     {
       "kind": "ui-named-argument",
@@ -2287,7 +2287,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "The connected OpenClaw agent can use device capabilities you enable. Continue only if you trust the Gateway and agent you connect to.",
       "surface": "android",
-      "id": "native.android.782acb3787860c7e"
+      "id": "native.android.5aed4b5c8d6b246d"
     },
     {
       "kind": "ui-named-argument",
@@ -2295,7 +2295,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connect Gateway",
       "surface": "android",
-      "id": "native.android.fca8a3a515cef8d8"
+      "id": "native.android.63c31ee564d63347"
     },
     {
       "kind": "ui-named-argument",
@@ -2303,7 +2303,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Scan a QR code or use the setup code from your OpenClaw Gateway.",
       "surface": "android",
-      "id": "native.android.e32df9497b746ecf"
+      "id": "native.android.f50a9c1ee6d47055"
     },
     {
       "kind": "ui-toast",
@@ -2311,7 +2311,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Could not open setup guide.",
       "surface": "android",
-      "id": "native.android.7f94bd5688f9cc04"
+      "id": "native.android.58d80589d9d4b7ff"
     },
     {
       "kind": "ui-named-argument",
@@ -2319,7 +2319,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Scan QR or setup code",
       "surface": "android",
-      "id": "native.android.81bc77801d27232b"
+      "id": "native.android.18d6dd32cfcc1c9a"
     },
     {
       "kind": "ui-named-argument",
@@ -2327,7 +2327,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Set up manually",
       "surface": "android",
-      "id": "native.android.98cbffb3634f0eed"
+      "id": "native.android.8b8acc5b98b8c99f"
     },
     {
       "kind": "ui-named-argument",
@@ -2335,7 +2335,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Before you start",
       "surface": "android",
-      "id": "native.android.8f5b8bd8c9d58006"
+      "id": "native.android.debd7b3e59db6ab2"
     },
     {
       "kind": "ui-named-argument",
@@ -2343,7 +2343,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Access to the Gateway device",
       "surface": "android",
-      "id": "native.android.a78c0233b6e64f3b"
+      "id": "native.android.9cfcf68aae2c05c6"
     },
     {
       "kind": "ui-named-argument",
@@ -2351,7 +2351,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Have a terminal open on the device running OpenClaw.",
       "surface": "android",
-      "id": "native.android.931a71e7a37bfe8c"
+      "id": "native.android.c8a43dbba02941f0"
     },
     {
       "kind": "ui-named-argument",
@@ -2359,7 +2359,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Phone can reach the Gateway",
       "surface": "android",
-      "id": "native.android.b97f86ea52ad42ed"
+      "id": "native.android.71ce00f359981a0b"
     },
     {
       "kind": "ui-named-argument",
@@ -2367,7 +2367,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use the same network, or a secure remote Gateway URL.",
       "surface": "android",
-      "id": "native.android.bf987f2d208694ea"
+      "id": "native.android.08aa33afe19b0c9c"
     },
     {
       "kind": "ui-named-argument",
@@ -2375,7 +2375,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Android setup guide",
       "surface": "android",
-      "id": "native.android.1ae80af456ede5a8"
+      "id": "native.android.68a31cee94a9db86"
     },
     {
       "kind": "ui-named-argument",
@@ -2383,7 +2383,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup Gateway",
       "surface": "android",
-      "id": "native.android.87e734a42506c768"
+      "id": "native.android.d514a981f80779e9"
     },
     {
       "kind": "ui-named-argument",
@@ -2391,7 +2391,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Start your Gateway.",
       "surface": "android",
-      "id": "native.android.2ccb4b2eb2374747"
+      "id": "native.android.6a45e2dae35ab5a7"
     },
     {
       "kind": "ui-named-argument",
@@ -2399,7 +2399,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "openclaw gateway",
       "surface": "android",
-      "id": "native.android.afee939eac293fce"
+      "id": "native.android.d4b295b5146af4b8"
     },
     {
       "kind": "ui-named-argument",
@@ -2407,7 +2407,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Generate a QR code.",
       "surface": "android",
-      "id": "native.android.7c2f04af312ae9cc"
+      "id": "native.android.c6f9da7008df05a6"
     },
     {
       "kind": "ui-named-argument",
@@ -2415,7 +2415,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "openclaw qr",
       "surface": "android",
-      "id": "native.android.75bdb708d4f8b3f6"
+      "id": "native.android.db24e4be7a1b5547"
     },
     {
       "kind": "ui-named-argument",
@@ -2423,7 +2423,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose from gallery",
       "surface": "android",
-      "id": "native.android.64e1f77563acef87"
+      "id": "native.android.96d40475de2885d6"
     },
     {
       "kind": "ui-named-argument",
@@ -2431,7 +2431,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "QR code not accepted",
       "surface": "android",
-      "id": "native.android.68cf31864e7393ad"
+      "id": "native.android.fd83bd36419ef526"
     },
     {
       "kind": "ui-named-argument",
@@ -2439,7 +2439,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose another image",
       "surface": "android",
-      "id": "native.android.1efe0da86f3816bd"
+      "id": "native.android.4dde43318559c65d"
     },
     {
       "kind": "ui-named-argument",
@@ -2447,7 +2447,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Scan QR code",
       "surface": "android",
-      "id": "native.android.488aada5e9eba49c"
+      "id": "native.android.54bab6e4054484d0"
     },
     {
       "kind": "ui-named-argument",
@@ -2455,7 +2455,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Open the camera and frame the code from openclaw qr.",
       "surface": "android",
-      "id": "native.android.da118b69f1cd83d4"
+      "id": "native.android.05987e822ac102ec"
     },
     {
       "kind": "ui-named-argument",
@@ -2463,7 +2463,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Align the QR code inside the square.",
       "surface": "android",
-      "id": "native.android.cd5121098eb8d404"
+      "id": "native.android.90fa932d2e0adbd9"
     },
     {
       "kind": "ui-named-argument",
@@ -2471,7 +2471,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Camera access is needed to scan the setup QR.",
       "surface": "android",
-      "id": "native.android.b7128178c5bb56ab"
+      "id": "native.android.7a817ddf54373dbf"
     },
     {
       "kind": "ui-named-argument",
@@ -2479,7 +2479,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Allow camera",
       "surface": "android",
-      "id": "native.android.62d3b74be3cd042c"
+      "id": "native.android.c8d5f12cb28f3853"
     },
     {
       "kind": "ui-named-argument",
@@ -2487,7 +2487,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Close scanner",
       "surface": "android",
-      "id": "native.android.edd7982abd878d2a"
+      "id": "native.android.7efba153567b1232"
     },
     {
       "kind": "ui-named-argument",
@@ -2495,7 +2495,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Enter setup code",
       "surface": "android",
-      "id": "native.android.95f0cf50cba907fe"
+      "id": "native.android.b8d5431e1e441f74"
     },
     {
       "kind": "ui-named-argument",
@@ -2503,7 +2503,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code",
       "surface": "android",
-      "id": "native.android.5d05930ed1f0267a"
+      "id": "native.android.41e3fbccb2ad5a4c"
     },
     {
       "kind": "ui-named-argument",
@@ -2511,7 +2511,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Paste setup code",
       "surface": "android",
-      "id": "native.android.e9d0c5660b8b9c62"
+      "id": "native.android.06a2214da1eee841"
     },
     {
       "kind": "ui-named-argument",
@@ -2519,7 +2519,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code was not accepted",
       "surface": "android",
-      "id": "native.android.af6e7f1c3b9be902"
+      "id": "native.android.35aec8a97ac12e1c"
     },
     {
       "kind": "ui-named-argument",
@@ -2527,7 +2527,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use setup code",
       "surface": "android",
-      "id": "native.android.96f8a67e325811c6"
+      "id": "native.android.9aaee5a05de93dbe"
     },
     {
       "kind": "ui-named-argument",
@@ -2535,7 +2535,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Manual setup",
       "surface": "android",
-      "id": "native.android.1f58a38c5434782d"
+      "id": "native.android.073c93545602b198"
     },
     {
       "kind": "ui-named-argument",
@@ -2543,7 +2543,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway URL",
       "surface": "android",
-      "id": "native.android.1281f7d653adb9a6"
+      "id": "native.android.46d58ca58c32ad52"
     },
     {
       "kind": "ui-named-argument",
@@ -2551,7 +2551,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Host",
       "surface": "android",
-      "id": "native.android.a2c381b9cf9f4eb3"
+      "id": "native.android.d54b9e3433ffd809"
     },
     {
       "kind": "ui-named-argument",
@@ -2559,7 +2559,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Port",
       "surface": "android",
-      "id": "native.android.425e73e2fb1ef9f4"
+      "id": "native.android.e7f368b47b705410"
     },
     {
       "kind": "ui-named-argument",
@@ -2567,7 +2567,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use the Gateway computer's LAN address or secure remote hostname.",
       "surface": "android",
-      "id": "native.android.d75b906c9af7db89"
+      "id": "native.android.1b0d9893ae4c0682"
     },
     {
       "kind": "ui-named-argument",
@@ -2575,7 +2575,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Token",
       "surface": "android",
-      "id": "native.android.29a662868cbbab20"
+      "id": "native.android.bfc48711d6deed92"
     },
     {
       "kind": "ui-named-argument",
@@ -2583,7 +2583,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Paste token",
       "surface": "android",
-      "id": "native.android.faa0a8feacf9c326"
+      "id": "native.android.7ac2b9aec9d78cda"
     },
     {
       "kind": "ui-named-argument",
@@ -2591,7 +2591,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Paste a shared Gateway token or operator-issued token.",
       "surface": "android",
-      "id": "native.android.05d75fcef84c66df"
+      "id": "native.android.96ba0e3919c3955a"
     },
     {
       "kind": "ui-named-argument",
@@ -2599,7 +2599,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Password",
       "surface": "android",
-      "id": "native.android.1c6739b9e66a0dab"
+      "id": "native.android.4a5a1702f0130328"
     },
     {
       "kind": "ui-named-argument",
@@ -2607,7 +2607,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Password optional",
       "surface": "android",
-      "id": "native.android.5b28494bb9c24519"
+      "id": "native.android.e7045d344dd32ddc"
     },
     {
       "kind": "ui-named-argument",
@@ -2615,7 +2615,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connection security",
       "surface": "android",
-      "id": "native.android.a6f58fcce0c449f2"
+      "id": "native.android.0b90d2ae01fe2adc"
     },
     {
       "kind": "ui-named-argument",
@@ -2623,7 +2623,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Unencrypted",
       "surface": "android",
-      "id": "native.android.16c5a0c3029bf13e"
+      "id": "native.android.475b12d58426a78b"
     },
     {
       "kind": "ui-named-argument",
@@ -2631,7 +2631,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Secure (TLS)",
       "surface": "android",
-      "id": "native.android.a6df1be9820c2685"
+      "id": "native.android.60133981279752d2"
     },
     {
       "kind": "ui-named-argument",
@@ -2639,7 +2639,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Could not test connection",
       "surface": "android",
-      "id": "native.android.8b8410873d160265"
+      "id": "native.android.24a0a4819f223b87"
     },
     {
       "kind": "ui-named-argument",
@@ -2647,7 +2647,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Test connection",
       "surface": "android",
-      "id": "native.android.363737eebe277a8a"
+      "id": "native.android.9a8f8ba539d4dd68"
     },
     {
       "kind": "ui-call",
@@ -2655,7 +2655,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "View details",
       "surface": "android",
-      "id": "native.android.31f77070d11be4e2"
+      "id": "native.android.a1c6ad798cdb4e32"
     },
     {
       "kind": "ui-call",
@@ -2663,7 +2663,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connection details",
       "surface": "android",
-      "id": "native.android.39d844c2b604873f"
+      "id": "native.android.ebdc41fd34eab0a5"
     },
     {
       "kind": "ui-call",
@@ -2671,7 +2671,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Copy",
       "surface": "android",
-      "id": "native.android.8521a3750162347c"
+      "id": "native.android.f982d1f6ad7b3e5d"
     },
     {
       "kind": "ui-call",
@@ -2679,7 +2679,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Close",
       "surface": "android",
-      "id": "native.android.700f22f8f7faa5b1"
+      "id": "native.android.fa2a2369f23aa195"
     },
     {
       "kind": "ui-toast",
@@ -2687,7 +2687,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Details copied",
       "surface": "android",
-      "id": "native.android.555c943ed221a8ab"
+      "id": "native.android.50cca1e186823cd6"
     },
     {
       "kind": "ui-named-argument",
@@ -2695,7 +2695,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approve node access",
       "surface": "android",
-      "id": "native.android.e60b8e592911d6ac"
+      "id": "native.android.31a4bf3ed4071f7c"
     },
     {
       "kind": "ui-named-argument",
@@ -2703,7 +2703,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway pairing is complete. Approve this phone as a node so OpenClaw can use the device capabilities you enable.",
       "surface": "android",
-      "id": "native.android.19d18f23beaf40a1"
+      "id": "native.android.f43cb6ed03dc6766"
     },
     {
       "kind": "ui-named-argument",
@@ -2711,7 +2711,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "On the Gateway computer, run:",
       "surface": "android",
-      "id": "native.android.4315471ce8517607"
+      "id": "native.android.8e49feba12c350ac"
     },
     {
       "kind": "ui-named-argument",
@@ -2719,7 +2719,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use the requestId from the pending command in the approve command.",
       "surface": "android",
-      "id": "native.android.5079042575298d22"
+      "id": "native.android.6189b5e2af7cc793"
     },
     {
       "kind": "ui-named-argument",
@@ -2727,7 +2727,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "I have approved",
       "surface": "android",
-      "id": "native.android.0c2d81ab522c7d65"
+      "id": "native.android.53bcd45eeb574d74"
     },
     {
       "kind": "ui-named-argument",
@@ -2735,7 +2735,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Checking approval…",
       "surface": "android",
-      "id": "native.android.ec205ff9768fd7e6"
+      "id": "native.android.0d4dd8ed358a6fb2"
     },
     {
       "kind": "ui-named-argument",
@@ -2743,7 +2743,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Still waiting for approval",
       "surface": "android",
-      "id": "native.android.808599f9ed1698be"
+      "id": "native.android.cdc44aaeb8bd6e4a"
     },
     {
       "kind": "ui-named-argument",
@@ -2751,7 +2751,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Run the approve command on the Gateway computer, then check again.",
       "surface": "android",
-      "id": "native.android.2cd132b805435c33"
+      "id": "native.android.df5cc00eb95c21ad"
     },
     {
       "kind": "ui-named-argument",
@@ -2759,7 +2759,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "OK",
       "surface": "android",
-      "id": "native.android.8f850c91c031351f"
+      "id": "native.android.f579f91c216dd6c4"
     },
     {
       "kind": "ui-named-argument",
@@ -2767,7 +2767,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Copy approval command",
       "surface": "android",
-      "id": "native.android.fee9740343810174"
+      "id": "native.android.b80462122abbe312"
     },
     {
       "kind": "ui-named-argument",
@@ -2775,7 +2775,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Only enable access you are comfortable letting OpenClaw use while this phone is connected. You can change these later in Android Settings.",
       "surface": "android",
-      "id": "native.android.f7f307a8c7f3e8b6"
+      "id": "native.android.d4c3bcf880727fb3"
     },
     {
       "kind": "ui-named-argument",
@@ -2783,7 +2783,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Continue",
       "surface": "android",
-      "id": "native.android.70a9b5a70e06b56e"
+      "id": "native.android.d7ea800cc2475013"
     },
     {
       "kind": "ui-named-argument",
@@ -2791,7 +2791,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Back",
       "surface": "android",
-      "id": "native.android.81c8796fb187e5a9"
+      "id": "native.android.44549cfd7e6a1ab8"
     },
     {
       "kind": "ui-named-argument",
@@ -2799,7 +2799,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Permissions",
       "surface": "android",
-      "id": "native.android.4f47ce320ad8c52c"
+      "id": "native.android.f3f0527db434d756"
     },
     {
       "kind": "conditional-branch",
@@ -2823,7 +2823,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "The code may have expired or been generated for another Gateway.",
       "surface": "android",
-      "id": "native.android.0bb4ad115bcdcaf2"
+      "id": "native.android.29732759e050c874"
     },
     {
       "kind": "conditional-branch",
@@ -2831,7 +2831,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway password is required. Enter it again or edit this connection.",
       "surface": "android",
-      "id": "native.android.b28a4a569b4e817f"
+      "id": "native.android.511925b4321aae31"
     },
     {
       "kind": "conditional-branch",
@@ -2839,7 +2839,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway password is invalid. Re-enter it or reset this gateway connection.",
       "surface": "android",
-      "id": "native.android.d5d21b945c516dd1"
+      "id": "native.android.beeae935716d1ff4"
     },
     {
       "kind": "conditional-branch",
@@ -2847,7 +2847,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway token is required. Enter it again or edit this connection.",
       "surface": "android",
-      "id": "native.android.f2eb6c0db5749ba0"
+      "id": "native.android.0a5468f24a0ef9e8"
     },
     {
       "kind": "conditional-branch",
@@ -2855,7 +2855,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway requires this device identity. Re-authenticate or reset this gateway connection.",
       "surface": "android",
-      "id": "native.android.2dba22e8313e9aa5"
+      "id": "native.android.11fbe9c58ebab116"
     },
     {
       "kind": "conditional-branch",
@@ -2863,7 +2863,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Saved authentication is invalid. Re-authenticate or reset this gateway connection.",
       "surface": "android",
-      "id": "native.android.b80bc209ee14fbc7"
+      "id": "native.android.8a4c5b042f04d8ed"
     },
     {
       "kind": "conditional-branch",
@@ -2871,7 +2871,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication is not configured. Edit this connection and try again.",
       "surface": "android",
-      "id": "native.android.49ea7621e189e5d3"
+      "id": "native.android.214b03b4cd2199b1"
     },
     {
       "kind": "conditional-branch",
@@ -2879,7 +2879,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication needs review. Check gateway settings, then retry.",
       "surface": "android",
-      "id": "native.android.e49f9b63c68f6687"
+      "id": "native.android.1ccbb6f3911e7219"
     },
     {
       "kind": "conditional-branch",
@@ -2919,7 +2919,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approval command copied",
       "surface": "android",
-      "id": "native.android.5735ab0a49a54808"
+      "id": "native.android.a7933196a18ec924"
     },
     {
       "kind": "ui-toast",
@@ -2927,7 +2927,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Command copied",
       "surface": "android",
-      "id": "native.android.92539440f4982c2b"
+      "id": "native.android.32690c5e41e8a4cb"
     },
     {
       "kind": "conditional-branch",
@@ -2935,7 +2935,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Granted",
       "surface": "android",
-      "id": "native.android.794d39baacf4ce44"
+      "id": "native.android.437599c024df158e"
     },
     {
       "kind": "conditional-branch",
@@ -2943,7 +2943,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Not granted",
       "surface": "android",
-      "id": "native.android.5fc5b5bd849534e0"
+      "id": "native.android.cf8344d3562e28e3"
     },
     {
       "kind": "ui-named-argument",
@@ -2951,7 +2951,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Back",
       "surface": "android",
-      "id": "native.android.531091c529120e0d"
+      "id": "native.android.3b7e036da1b10671"
     },
     {
       "kind": "ui-named-argument",
@@ -2959,7 +2959,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Providers & Models",
       "surface": "android",
-      "id": "native.android.f5181cf318851526"
+      "id": "native.android.82131f121c1cff31"
     },
     {
       "kind": "ui-named-argument",
@@ -2967,7 +2967,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Review provider readiness\nand configured models.",
       "surface": "android",
-      "id": "native.android.91dd65f8409bcb8b"
+      "id": "native.android.8eb76aa712ea142a"
     },
     {
       "kind": "ui-named-argument",
@@ -2983,7 +2983,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Connect your Gateway to load provider readiness.",
       "surface": "android",
-      "id": "native.android.0fd8de438e0a87d9"
+      "id": "native.android.c76ebb6f80eaad93"
     },
     {
       "kind": "ui-named-argument",
@@ -2991,7 +2991,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
-      "id": "native.android.62ef5bc56b0d90d6"
+      "id": "native.android.bffaa0de604a6248"
     },
     {
       "kind": "conditional-branch",
@@ -2999,7 +2999,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Loading",
       "surface": "android",
-      "id": "native.android.b5667eb889b75a22"
+      "id": "native.android.cc7752fdd9d78d63"
     },
     {
       "kind": "conditional-branch",
@@ -3007,7 +3007,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "No providers",
       "surface": "android",
-      "id": "native.android.1ee8a786a3171849"
+      "id": "native.android.a8af20d207693faa"
     },
     {
       "kind": "ui-named-argument",
@@ -3015,7 +3015,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Ready",
       "surface": "android",
-      "id": "native.android.e5ff67f18327eea1"
+      "id": "native.android.07ade123217b0689"
     },
     {
       "kind": "ui-named-argument",
@@ -3023,7 +3023,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Needs",
       "surface": "android",
-      "id": "native.android.9d70f16c1d754fd9"
+      "id": "native.android.b36b0c2003a82b53"
     },
     {
       "kind": "ui-named-argument",
@@ -3047,7 +3047,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Connect your Gateway to view provider readiness.",
       "surface": "android",
-      "id": "native.android.c320f32f079be5b4"
+      "id": "native.android.24fe64a90afae34e"
     },
     {
       "kind": "conditional-branch",
@@ -3055,7 +3055,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Refresh",
       "surface": "android",
-      "id": "native.android.198c8d7aa060337c"
+      "id": "native.android.7a7bcb60c83ed920"
     },
     {
       "kind": "conditional-branch",
@@ -3063,7 +3063,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
-      "id": "native.android.0991c60b26231b1d"
+      "id": "native.android.f4b6dd970359c304"
     },
     {
       "kind": "conditional-branch",
@@ -3079,7 +3079,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
       "source": "No configured models",
       "surface": "android",
-      "id": "native.android.1cd594eae2fddcf5"
+      "id": "native.android.51228649f9d8627a"
     },
     {
       "kind": "conditional-branch",
@@ -3095,7 +3095,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Sessions",
       "surface": "android",
-      "id": "native.android.5bc8cf7e1d3da771"
+      "id": "native.android.0e3157c15c56944f"
     },
     {
       "kind": "ui-named-argument",
@@ -3111,7 +3111,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Recent",
       "surface": "android",
-      "id": "native.android.d2161471cf1befc0"
+      "id": "native.android.e0f10db479f627eb"
     },
     {
       "kind": "ui-named-argument",
@@ -3119,7 +3119,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Current",
       "surface": "android",
-      "id": "native.android.bc12df59f85912a6"
+      "id": "native.android.9bc0d0b631dca571"
     },
     {
       "kind": "ui-named-argument",
@@ -3127,7 +3127,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Archived",
       "surface": "android",
-      "id": "native.android.5c6f7188e99feb0f"
+      "id": "native.android.78654c0f198c6df2"
     },
     {
       "kind": "ui-named-argument",
@@ -3135,7 +3135,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Search sessions",
       "surface": "android",
-      "id": "native.android.1c7b52c649612b82"
+      "id": "native.android.b9cf34c137e4cf03"
     },
     {
       "kind": "ui-named-argument",
@@ -3151,7 +3151,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Newest first",
       "surface": "android",
-      "id": "native.android.7d67f14936d152e9"
+      "id": "native.android.dc52c5f9d7b85ec8"
     },
     {
       "kind": "conditional-branch",
@@ -3159,7 +3159,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Oldest first",
       "surface": "android",
-      "id": "native.android.1f38aef85d823ba8"
+      "id": "native.android.78b9d0ab41446a1b"
     },
     {
       "kind": "ui-named-argument",
@@ -3175,7 +3175,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Toggle session layout",
       "surface": "android",
-      "id": "native.android.63ff902213008135"
+      "id": "native.android.c6bf8751e2a7f5c7"
     },
     {
       "kind": "conditional-branch",
@@ -3183,7 +3183,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Layout: Compact",
       "surface": "android",
-      "id": "native.android.fe3cdfc2185d1ea2"
+      "id": "native.android.49db3101cf9c806c"
     },
     {
       "kind": "conditional-branch",
@@ -3191,7 +3191,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Layout: Detailed",
       "surface": "android",
-      "id": "native.android.e7aa1e9cc11f4595"
+      "id": "native.android.bf4f2bc2e1d10e54"
     },
     {
       "kind": "ui-named-argument",
@@ -3231,7 +3231,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Start Chat",
       "surface": "android",
-      "id": "native.android.8cecfad5ae72da7f"
+      "id": "native.android.75bff03b36200e7b"
     },
     {
       "kind": "conditional-branch",
@@ -3239,7 +3239,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Current session",
       "surface": "android",
-      "id": "native.android.6ffb1a6fed300f56"
+      "id": "native.android.f10d4df7cbc6df4f"
     },
     {
       "kind": "conditional-branch",
@@ -3247,7 +3247,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "OpenClaw session",
       "surface": "android",
-      "id": "native.android.f63640e4154afe78"
+      "id": "native.android.8f0482425838ae64"
     },
     {
       "kind": "ui-named-argument",
@@ -3255,7 +3255,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Rename session",
       "surface": "android",
-      "id": "native.android.cd2fd07d6ac3c650"
+      "id": "native.android.786774c8a76e50d7"
     },
     {
       "kind": "ui-named-argument",
@@ -3263,7 +3263,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Rename group",
       "surface": "android",
-      "id": "native.android.6187aa35434029f6"
+      "id": "native.android.fa420bc51ff675a1"
     },
     {
       "kind": "ui-named-argument",
@@ -3271,7 +3271,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Rename",
       "surface": "android",
-      "id": "native.android.dff01f28d4e8b1fe"
+      "id": "native.android.f869da474db7cf6e"
     },
     {
       "kind": "ui-named-argument",
@@ -3279,7 +3279,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "New group",
       "surface": "android",
-      "id": "native.android.5b00bda0b8c52a7f"
+      "id": "native.android.ddbfb1989d641bd2"
     },
     {
       "kind": "ui-named-argument",
@@ -3287,7 +3287,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Create",
       "surface": "android",
-      "id": "native.android.062bafdd9bf01e51"
+      "id": "native.android.3208d7c67e225e7f"
     },
     {
       "kind": "ui-call",
@@ -3295,7 +3295,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Delete group?",
       "surface": "android",
-      "id": "native.android.4ba8b58e882c49a1"
+      "id": "native.android.8b1585a8a84dc4d9"
     },
     {
       "kind": "ui-call",
@@ -3303,7 +3303,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
       "surface": "android",
-      "id": "native.android.bfa8fa468f247d7c"
+      "id": "native.android.3455fc2f77d564e3"
     },
     {
       "kind": "ui-call",
@@ -3311,7 +3311,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Delete session?",
       "surface": "android",
-      "id": "native.android.5ae62fc38ec68a58"
+      "id": "native.android.4805fb9d6623e8c0"
     },
     {
       "kind": "ui-call",
@@ -3319,7 +3319,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "This permanently deletes the session and its transcript.",
       "surface": "android",
-      "id": "native.android.ce4f31b10a74d2bc"
+      "id": "native.android.0c3283a2b2445eae"
     },
     {
       "kind": "ui-call",
@@ -3327,7 +3327,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Delete",
       "surface": "android",
-      "id": "native.android.97db8ec926eed422"
+      "id": "native.android.807ba5c6699af2f1"
     },
     {
       "kind": "ui-named-argument",
@@ -3335,7 +3335,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Pinned",
       "surface": "android",
-      "id": "native.android.150f98702b4cbd35"
+      "id": "native.android.03fd4e5e90f1afe7"
     },
     {
       "kind": "ui-named-argument",
@@ -3343,7 +3343,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Workspace",
       "surface": "android",
-      "id": "native.android.cbab164cec6dc03d"
+      "id": "native.android.94a95bad91565148"
     },
     {
       "kind": "conditional-branch",
@@ -3351,7 +3351,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
-      "id": "native.android.e0af5898db3ba68c"
+      "id": "native.android.b5e4ae7f8c9eca2d"
     },
     {
       "kind": "ui-call",
@@ -3391,7 +3391,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Pin",
       "surface": "android",
-      "id": "native.android.944b2ebf00a3a3b9"
+      "id": "native.android.6637da0312da85f9"
     },
     {
       "kind": "conditional-branch",
@@ -3399,7 +3399,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Unpin",
       "surface": "android",
-      "id": "native.android.3c9623820a99e95e"
+      "id": "native.android.fb512b81634fa8c4"
     },
     {
       "kind": "conditional-branch",
@@ -3407,7 +3407,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Mark as read",
       "surface": "android",
-      "id": "native.android.d83f18a21fea9f9c"
+      "id": "native.android.b75c8710d4537222"
     },
     {
       "kind": "conditional-branch",
@@ -3415,7 +3415,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Mark as unread",
       "surface": "android",
-      "id": "native.android.4df85a10f035d0a2"
+      "id": "native.android.a9619e8ed4fd6aa2"
     },
     {
       "kind": "ui-call",
@@ -3479,7 +3479,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Group name",
       "surface": "android",
-      "id": "native.android.79969911d667cfc6"
+      "id": "native.android.54c10a1eec2fa17c"
     },
     {
       "kind": "conditional-branch",
@@ -3487,7 +3487,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Name",
       "surface": "android",
-      "id": "native.android.f19f5ac953ff3442"
+      "id": "native.android.91851a0eb519765f"
     },
     {
       "kind": "ui-call",
@@ -3495,7 +3495,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Cancel",
       "surface": "android",
-      "id": "native.android.6e5d1bbd82cee714"
+      "id": "native.android.4e1ffc65a44efec5"
     },
     {
       "kind": "conditional-branch",
@@ -3503,7 +3503,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "No sessions yet",
       "surface": "android",
-      "id": "native.android.43e1ee987cc3f3e1"
+      "id": "native.android.db243d71d056afa4"
     },
     {
       "kind": "conditional-branch",
@@ -3511,7 +3511,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "No current session",
       "surface": "android",
-      "id": "native.android.679f6979c9e6ed5a"
+      "id": "native.android.5b4eee6a8092925e"
     },
     {
       "kind": "conditional-branch",
@@ -3519,7 +3519,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "No archived sessions",
       "surface": "android",
-      "id": "native.android.911a85279b8847df"
+      "id": "native.android.acbcc9c9ea53d8c0"
     },
     {
       "kind": "conditional-branch",
@@ -3527,7 +3527,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Start a new conversation and it will show up here.",
       "surface": "android",
-      "id": "native.android.574847da210cac45"
+      "id": "native.android.0a38a1167c6b6941"
     },
     {
       "kind": "conditional-branch",
@@ -3535,7 +3535,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Open Chat to start or resume the current session.",
       "surface": "android",
-      "id": "native.android.7de883b2a9aadd4c"
+      "id": "native.android.56fcd605dc7be3c0"
     },
     {
       "kind": "conditional-branch",
@@ -3543,7 +3543,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Archived sessions will show up here.",
       "surface": "android",
-      "id": "native.android.905745e4c9a5f4fa"
+      "id": "native.android.085515989f8a2022"
     },
     {
       "kind": "ui-named-argument",
@@ -3551,7 +3551,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Provider limits and quota health.",
       "surface": "android",
-      "id": "native.android.68c92c7c02da533c"
+      "id": "native.android.dcb7d5956029bbc4"
     },
     {
       "kind": "ui-named-argument",
@@ -3559,7 +3559,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Usage",
       "surface": "android",
-      "id": "native.android.e0cb096f6db8aa3d"
+      "id": "native.android.aa3fb483f7e264fe"
     },
     {
       "kind": "ui-named-argument",
@@ -3567,7 +3567,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load usage.",
       "surface": "android",
-      "id": "native.android.9fd97798f9b3ca15"
+      "id": "native.android.e3bdc31bd2f499d7"
     },
     {
       "kind": "ui-named-argument",
@@ -3575,7 +3575,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No usage data yet.",
       "surface": "android",
-      "id": "native.android.d729b8de84be1c3c"
+      "id": "native.android.0da8c424891138e7"
     },
     {
       "kind": "ui-named-argument",
@@ -3583,7 +3583,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Provider limits will appear here when your gateway reports them.",
       "surface": "android",
-      "id": "native.android.ab766c96bd46e332"
+      "id": "native.android.e3f6fa2b034cd7f3"
     },
     {
       "kind": "ui-named-argument",
@@ -3591,7 +3591,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cron Jobs",
       "surface": "android",
-      "id": "native.android.92608ef73f6c6887"
+      "id": "native.android.962a15bdb26cb6e1"
     },
     {
       "kind": "ui-named-argument",
@@ -3599,7 +3599,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scheduled OpenClaw work from your gateway.",
       "surface": "android",
-      "id": "native.android.77e5306c191a88ef"
+      "id": "native.android.5e3e4cd42004cb28"
     },
     {
       "kind": "ui-named-argument",
@@ -3607,7 +3607,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open a job to inspect its configuration and run history. Admin-scoped connections can also run, edit, enable, disable, or delete it.",
       "surface": "android",
-      "id": "native.android.4298c149fc5f86ea"
+      "id": "native.android.3cd22006987fde12"
     },
     {
       "kind": "ui-named-argument",
@@ -3615,7 +3615,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load cron jobs.",
       "surface": "android",
-      "id": "native.android.0cbf27ac1bd9c417"
+      "id": "native.android.9354a5bf1e4ce5a5"
     },
     {
       "kind": "ui-named-argument",
@@ -3623,7 +3623,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No scheduled jobs.",
       "surface": "android",
-      "id": "native.android.db1008eb60e10b7d"
+      "id": "native.android.239e2598dab8a8b1"
     },
     {
       "kind": "ui-named-argument",
@@ -3631,7 +3631,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scheduled work created on the gateway will appear here.",
       "surface": "android",
-      "id": "native.android.9d6ba6143a35fc9a"
+      "id": "native.android.bc88f537cd309fcb"
     },
     {
       "kind": "ui-named-argument",
@@ -3639,7 +3639,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Inspect scheduled gateway work.",
       "surface": "android",
-      "id": "native.android.5d4614bfbd2e3fab"
+      "id": "native.android.f6dd71419863574c"
     },
     {
       "kind": "ui-named-argument",
@@ -3647,7 +3647,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to inspect cron jobs.",
       "surface": "android",
-      "id": "native.android.f835be79791b2138"
+      "id": "native.android.e3a6337e3c28d3f5"
     },
     {
       "kind": "conditional-branch",
@@ -3655,7 +3655,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cron job not loaded.",
       "surface": "android",
-      "id": "native.android.7a43ce366049744c"
+      "id": "native.android.2d3daa5032913461"
     },
     {
       "kind": "conditional-branch",
@@ -3663,7 +3663,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Loading cron job…",
       "surface": "android",
-      "id": "native.android.16b41bd483c6918c"
+      "id": "native.android.401993832e04f790"
     },
     {
       "kind": "ui-named-argument",
@@ -3671,7 +3671,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agents",
       "surface": "android",
-      "id": "native.android.badc7bcbe4c2502b"
+      "id": "native.android.6da97c8c6e1a3d3a"
     },
     {
       "kind": "ui-named-argument",
@@ -3679,7 +3679,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose and inspect the assistants available on this gateway.",
       "surface": "android",
-      "id": "native.android.04972ec470c35978"
+      "id": "native.android.0f33ca43db97b2a9"
     },
     {
       "kind": "ui-named-argument",
@@ -3687,7 +3687,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load agents.",
       "surface": "android",
-      "id": "native.android.b860068169f58c6b"
+      "id": "native.android.8db68417b1226437"
     },
     {
       "kind": "ui-named-argument",
@@ -3695,7 +3695,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No agents loaded yet.",
       "surface": "android",
-      "id": "native.android.d6247aa4b96f0747"
+      "id": "native.android.c6b1cb74e88b533b"
     },
     {
       "kind": "ui-named-argument",
@@ -3703,7 +3703,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Approvals",
       "surface": "android",
-      "id": "native.android.e9e386dce41162e8"
+      "id": "native.android.1ba6a31da5ad58e7"
     },
     {
       "kind": "ui-named-argument",
@@ -3711,7 +3711,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review actions that need your attention.",
       "surface": "android",
-      "id": "native.android.7d2dbaeb2fe5f819"
+      "id": "native.android.b53cdcaacd0eb0f2"
     },
     {
       "kind": "conditional-branch",
@@ -3719,7 +3719,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refresh",
       "surface": "android",
-      "id": "native.android.09f7eeb6cb63d5b6"
+      "id": "native.android.2f7b688eb1fe6797"
     },
     {
       "kind": "conditional-branch",
@@ -3727,7 +3727,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refreshing",
       "surface": "android",
-      "id": "native.android.0cafcd5d016933b7"
+      "id": "native.android.ffcaffbb2569327b"
     },
     {
       "kind": "ui-named-argument",
@@ -3735,7 +3735,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway disconnected.",
       "surface": "android",
-      "id": "native.android.67f88e7b433c8a5d"
+      "id": "native.android.ffeaae71512cf19b"
     },
     {
       "kind": "ui-named-argument",
@@ -3743,7 +3743,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load approval requests in the app.",
       "surface": "android",
-      "id": "native.android.fba8ef171574a814"
+      "id": "native.android.f97e44de2d358dae"
     },
     {
       "kind": "ui-named-argument",
@@ -3751,7 +3751,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No gateway approvals.",
       "surface": "android",
-      "id": "native.android.eeb2f3d04bda1d60"
+      "id": "native.android.ee786857e3c467b2"
     },
     {
       "kind": "ui-named-argument",
@@ -3759,7 +3759,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Exec approval requests will appear here while this phone is connected.",
       "surface": "android",
-      "id": "native.android.b94315856f9107de"
+      "id": "native.android.38bce22c657f484d"
     },
     {
       "kind": "ui-named-argument",
@@ -3767,7 +3767,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Session activity",
       "surface": "android",
-      "id": "native.android.5179b702decbe2f9"
+      "id": "native.android.dc3e7ca5a491103a"
     },
     {
       "kind": "ui-named-argument",
@@ -3775,7 +3775,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Chat tool calls waiting in the active session remain visible here.",
       "surface": "android",
-      "id": "native.android.d5125aa479ac68df"
+      "id": "native.android.8551e02b060bd7d8"
     },
     {
       "kind": "ui-named-argument",
@@ -3783,7 +3783,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "How this phone appears to OpenClaw.",
       "surface": "android",
-      "id": "native.android.5320efca61eb6e96"
+      "id": "native.android.fea93eda5bf97d9e"
     },
     {
       "kind": "ui-named-argument",
@@ -3791,7 +3791,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Profile",
       "surface": "android",
-      "id": "native.android.8a3af46b848c92fa"
+      "id": "native.android.695229fd01afbc2d"
     },
     {
       "kind": "ui-named-argument",
@@ -3799,7 +3799,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Device name",
       "surface": "android",
-      "id": "native.android.aa1c31cf12413052"
+      "id": "native.android.dbd3c9b24f72837a"
     },
     {
       "kind": "ui-named-argument",
@@ -3807,7 +3807,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save Profile",
       "surface": "android",
-      "id": "native.android.1ab95b9deae71fc8"
+      "id": "native.android.18cd027f897c1ba8"
     },
     {
       "kind": "ui-named-argument",
@@ -3815,7 +3815,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Configure voice, transport, and playback.",
       "surface": "android",
-      "id": "native.android.9ee19d22678583ec"
+      "id": "native.android.19f0834b4dbcc85a"
     },
     {
       "kind": "ui-named-argument",
@@ -3823,7 +3823,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Talk Provider Setup",
       "surface": "android",
-      "id": "native.android.ab62b4bf1d71b6ed"
+      "id": "native.android.8d0458a4fe154e9b"
     },
     {
       "kind": "ui-named-argument",
@@ -3831,7 +3831,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Audio Test",
       "surface": "android",
-      "id": "native.android.a0aa588581ddde85"
+      "id": "native.android.98a8bbb2b1f382e6"
     },
     {
       "kind": "ui-named-argument",
@@ -3839,7 +3839,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check that OpenClaw can speak clearly on this phone.",
       "surface": "android",
-      "id": "native.android.9504fb427982df0b"
+      "id": "native.android.5ff888931aae2738"
     },
     {
       "kind": "conditional-branch",
@@ -3847,7 +3847,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enable speaker",
       "surface": "android",
-      "id": "native.android.7a43d6d9b0acd231"
+      "id": "native.android.f82d5d81f5dc9b43"
     },
     {
       "kind": "conditional-branch",
@@ -3855,7 +3855,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Mute speaker",
       "surface": "android",
-      "id": "native.android.479c4a669a7c712a"
+      "id": "native.android.4d8d05659dbd4a69"
     },
     {
       "kind": "conditional-branch",
@@ -3863,7 +3863,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Assistant speech muted",
       "surface": "android",
-      "id": "native.android.b3d088a0a09536eb"
+      "id": "native.android.fe8d975ef971d148"
     },
     {
       "kind": "conditional-branch",
@@ -3871,7 +3871,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replies play aloud",
       "surface": "android",
-      "id": "native.android.ec6a6d7f89a5ab1b"
+      "id": "native.android.7e49f1aeb4888e9a"
     },
     {
       "kind": "conditional-branch",
@@ -3879,7 +3879,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Muted",
       "surface": "android",
-      "id": "native.android.6606f93a2265317c"
+      "id": "native.android.38e5aceba237ea3c"
     },
     {
       "kind": "conditional-branch",
@@ -3887,7 +3887,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "On",
       "surface": "android",
-      "id": "native.android.e8a3a1d9409d9726"
+      "id": "native.android.8e352f042c44c2c2"
     },
     {
       "kind": "ui-named-argument",
@@ -3895,7 +3895,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Done",
       "surface": "android",
-      "id": "native.android.cb4df5665d87e2a5"
+      "id": "native.android.05bd460309ac6db6"
     },
     {
       "kind": "ui-named-argument",
@@ -3903,7 +3903,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Realtime Talk",
       "surface": "android",
-      "id": "native.android.13dca938e7f478a4"
+      "id": "native.android.60cf67eb5ec46ea0"
     },
     {
       "kind": "ui-named-argument",
@@ -3911,7 +3911,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Dictation",
       "surface": "android",
-      "id": "native.android.8292ed8d2ae0d333"
+      "id": "native.android.c80e9a8e3d393676"
     },
     {
       "kind": "conditional-branch",
@@ -3919,7 +3919,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allowlist",
       "surface": "android",
-      "id": "native.android.399e2d40d2f8f2dc"
+      "id": "native.android.94527c3346897c00"
     },
     {
       "kind": "conditional-branch",
@@ -3927,7 +3927,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Blocklist",
       "surface": "android",
-      "id": "native.android.e4edbf013d999cb8"
+      "id": "native.android.333ae4741b8f80fe"
     },
     {
       "kind": "ui-named-argument",
@@ -3935,7 +3935,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose what reaches OpenClaw.",
       "surface": "android",
-      "id": "native.android.14d8154e983fc4e2"
+      "id": "native.android.9feed8722db5d2cc"
     },
     {
       "kind": "ui-named-argument",
@@ -3943,7 +3943,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Notifications",
       "surface": "android",
-      "id": "native.android.984ea6539b67c942"
+      "id": "native.android.d32071018de11907"
     },
     {
       "kind": "conditional-branch",
@@ -3951,7 +3951,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Alerts stay on this phone.",
       "surface": "android",
-      "id": "native.android.437fd06fe33dd131"
+      "id": "native.android.c9d07c5b26b5c088"
     },
     {
       "kind": "conditional-branch",
@@ -3959,7 +3959,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can receive selected alerts.",
       "surface": "android",
-      "id": "native.android.4c38dd46b7c40131"
+      "id": "native.android.5a077bf9cf4f47c8"
     },
     {
       "kind": "ui-call",
@@ -3983,7 +3983,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Granted",
       "surface": "android",
-      "id": "native.android.66f59b166a4eca9b"
+      "id": "native.android.ebeec52e498bc128"
     },
     {
       "kind": "conditional-branch",
@@ -3991,7 +3991,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup",
       "surface": "android",
-      "id": "native.android.68bc7dc0171c80e8"
+      "id": "native.android.08511b2bd4b6103a"
     },
     {
       "kind": "conditional-branch",
@@ -3999,7 +3999,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check Access",
       "surface": "android",
-      "id": "native.android.31153e5aa8f9c879"
+      "id": "native.android.887a50e577908c66"
     },
     {
       "kind": "conditional-branch",
@@ -4007,7 +4007,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open System Access",
       "surface": "android",
-      "id": "native.android.83bf4b18f79e45c0"
+      "id": "native.android.a36abaf83c7830d9"
     },
     {
       "kind": "ui-named-argument",
@@ -4015,7 +4015,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forwarding Mode",
       "surface": "android",
-      "id": "native.android.04307aa27f184f25"
+      "id": "native.android.c21fbdec8c4b390d"
     },
     {
       "kind": "ui-named-argument",
@@ -4023,7 +4023,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App Filter",
       "surface": "android",
-      "id": "native.android.8fd65bacb45c86d6"
+      "id": "native.android.67b1229c396cc573"
     },
     {
       "kind": "conditional-branch",
@@ -4031,7 +4031,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Close App Picker",
       "surface": "android",
-      "id": "native.android.5db8b6b503cc4d6f"
+      "id": "native.android.55a7cc971f233829"
     },
     {
       "kind": "conditional-branch",
@@ -4039,7 +4039,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open App Picker",
       "surface": "android",
-      "id": "native.android.762ea2f0f95f53a4"
+      "id": "native.android.dada58f73e10c525"
     },
     {
       "kind": "ui-named-argument",
@@ -4047,7 +4047,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Search apps",
       "surface": "android",
-      "id": "native.android.2ef4439fb6648b6b"
+      "id": "native.android.05f0112f3661e947"
     },
     {
       "kind": "ui-named-argument",
@@ -4055,7 +4055,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Show System Apps",
       "surface": "android",
-      "id": "native.android.091931a457c0aa19"
+      "id": "native.android.e267498ebcb5245a"
     },
     {
       "kind": "ui-named-argument",
@@ -4063,7 +4063,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Include Android and background packages.",
       "surface": "android",
-      "id": "native.android.c4148486e118d42f"
+      "id": "native.android.4859d7f773be5e98"
     },
     {
       "kind": "ui-named-argument",
@@ -4071,7 +4071,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No matching apps.",
       "surface": "android",
-      "id": "native.android.3e70c1068b78ebc5"
+      "id": "native.android.5a5f58fc2b917d5b"
     },
     {
       "kind": "ui-named-argument",
@@ -4079,7 +4079,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Showing ${visibleApps.size} of ${apps.size}. Refine search for more.",
       "surface": "android",
-      "id": "native.android.83ac29ac417ae7e6"
+      "id": "native.android.7c979f32e6ea115f"
     },
     {
       "kind": "ui-named-argument",
@@ -4087,7 +4087,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose what this phone can share.",
       "surface": "android",
-      "id": "native.android.0573637895ccf664"
+      "id": "native.android.ae3122660b0489fc"
     },
     {
       "kind": "ui-named-argument",
@@ -4095,7 +4095,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Phone Capabilities",
       "surface": "android",
-      "id": "native.android.fbdd50dbc2f9d7da"
+      "id": "native.android.13c46f9ddf516110"
     },
     {
       "kind": "ui-call",
@@ -4127,7 +4127,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow photo library access.",
       "surface": "android",
-      "id": "native.android.8316cb678ec45750"
+      "id": "native.android.7d943661c4341ef0"
     },
     {
       "kind": "conditional-branch",
@@ -4135,7 +4135,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected or full photo access granted.",
       "surface": "android",
-      "id": "native.android.891d5c618b7957bf"
+      "id": "native.android.8424669e7840699a"
     },
     {
       "kind": "ui-call",
@@ -4151,7 +4151,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App list stays on this phone.",
       "surface": "android",
-      "id": "native.android.edc881f01de4ec74"
+      "id": "native.android.8ed8ecbbd6112e81"
     },
     {
       "kind": "conditional-branch",
@@ -4159,7 +4159,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can list launcher-visible apps.",
       "surface": "android",
-      "id": "native.android.fb212783fa45411a"
+      "id": "native.android.bdafaceb7af93f5a"
     },
     {
       "kind": "ui-call",
@@ -4183,7 +4183,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Location",
       "surface": "android",
-      "id": "native.android.6a65012614f96a0f"
+      "id": "native.android.4ea310efb1f0e7ff"
     },
     {
       "kind": "ui-named-argument",
@@ -4191,7 +4191,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always allows requested location checks while OpenClaw is in the background; Android shows this in the persistent node notification.",
       "surface": "android",
-      "id": "native.android.251b363c1274cf86"
+      "id": "native.android.58549715b04997cc"
     },
     {
       "kind": "ui-call",
@@ -4199,7 +4199,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow background location?",
       "surface": "android",
-      "id": "native.android.55290601441f728a"
+      "id": "native.android.d5a8d7f97a7971b1"
     },
     {
       "kind": "ui-call-concatenated",
@@ -4215,7 +4215,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open Settings",
       "surface": "android",
-      "id": "native.android.ee4b67ae53763dc6"
+      "id": "native.android.c48805f3de1d72ca"
     },
     {
       "kind": "ui-call",
@@ -4255,7 +4255,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not Now",
       "surface": "android",
-      "id": "native.android.95ffc3dd6bc588e4"
+      "id": "native.android.fd97640418602532"
     },
     {
       "kind": "ui-call",
@@ -4263,7 +4263,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace gateway setup?",
       "surface": "android",
-      "id": "native.android.f5b8e92ddfefd3c2"
+      "id": "native.android.f3d5fd047bfdb023"
     },
     {
       "kind": "ui-call",
@@ -4271,7 +4271,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace setup",
       "surface": "android",
-      "id": "native.android.be3a12fde0fe71bf"
+      "id": "native.android.869c8be127ce5282"
     },
     {
       "kind": "ui-call",
@@ -4279,7 +4279,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forget gateway?",
       "surface": "android",
-      "id": "native.android.6412338d3381cbbc"
+      "id": "native.android.66aad1078731e6a3"
     },
     {
       "kind": "ui-call",
@@ -4295,7 +4295,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cancel",
       "surface": "android",
-      "id": "native.android.56fc5118a72dbb37"
+      "id": "native.android.c6c8e0c4b8a9a7cf"
     },
     {
       "kind": "ui-named-argument",
@@ -4303,7 +4303,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection between this phone and OpenClaw.",
       "surface": "android",
-      "id": "native.android.43915f59da302c47"
+      "id": "native.android.9d658ff26e59274b"
     },
     {
       "kind": "conditional-branch",
@@ -4311,7 +4311,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connected",
       "surface": "android",
-      "id": "native.android.781165db00a32682"
+      "id": "native.android.718cb50d1bff3e32"
     },
     {
       "kind": "conditional-branch",
@@ -4319,7 +4319,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Offline",
       "surface": "android",
-      "id": "native.android.4dd9b73df50a8be1"
+      "id": "native.android.326c79e18db465ce"
     },
     {
       "kind": "conditional-branch",
@@ -4327,7 +4327,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not paired",
       "surface": "android",
-      "id": "native.android.69b5802d638613c9"
+      "id": "native.android.c0cbf2ed1fc50e4c"
     },
     {
       "kind": "conditional-branch",
@@ -4335,7 +4335,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Online",
       "surface": "android",
-      "id": "native.android.479456a8ed7b6940"
+      "id": "native.android.dd5b083db9470281"
     },
     {
       "kind": "ui-named-argument",
@@ -4343,7 +4343,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Reconnect",
       "surface": "android",
-      "id": "native.android.e6b0bcd443b461fd"
+      "id": "native.android.7b12195e02ebcc34"
     },
     {
       "kind": "ui-named-argument",
@@ -4351,7 +4351,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Disconnect",
       "surface": "android",
-      "id": "native.android.7a82cda2c639c389"
+      "id": "native.android.e11f54696b376155"
     },
     {
       "kind": "ui-named-argument",
@@ -4359,7 +4359,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateways",
       "surface": "android",
-      "id": "native.android.a7d20f8defcf355e"
+      "id": "native.android.87eee1e2bafbf13b"
     },
     {
       "kind": "ui-named-argument",
@@ -4367,7 +4367,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No paired gateways.",
       "surface": "android",
-      "id": "native.android.e9c03df6bc77be18"
+      "id": "native.android.c3974020a08e239e"
     },
     {
       "kind": "ui-call",
@@ -4375,7 +4375,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forget",
       "surface": "android",
-      "id": "native.android.0c3e6f3deca4e417"
+      "id": "native.android.74ee3bbbd2e37e9c"
     },
     {
       "kind": "ui-named-argument",
@@ -4383,7 +4383,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway setup",
       "surface": "android",
-      "id": "native.android.d4e7423018581e73"
+      "id": "native.android.56e98811c4e9b027"
     },
     {
       "kind": "ui-named-argument",
@@ -4391,7 +4391,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scan or paste a setup code to add another gateway.",
       "surface": "android",
-      "id": "native.android.2996a332e6e26832"
+      "id": "native.android.c040d4ee72a810e0"
     },
     {
       "kind": "ui-named-argument",
@@ -4399,7 +4399,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Add gateway",
       "surface": "android",
-      "id": "native.android.b2a4ef45d8132923"
+      "id": "native.android.a7c243ff3f1d6447"
     },
     {
       "kind": "ui-named-argument",
@@ -4407,7 +4407,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup Code",
       "surface": "android",
-      "id": "native.android.2d40d0b0a0944eb6"
+      "id": "native.android.77a03c8c22155ec5"
     },
     {
       "kind": "ui-named-argument",
@@ -4415,7 +4415,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Android can scan or paste an existing setup code, but this gateway does not expose setup-code generation to the app yet. Generate the QR/code on the gateway host with openclaw qr, then scan it here or paste the setup code below.",
       "surface": "android",
-      "id": "native.android.393c1f24c4f2ad19"
+      "id": "native.android.de12fd162a566974"
     },
     {
       "kind": "ui-named-argument",
@@ -4423,7 +4423,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection Setup",
       "surface": "android",
-      "id": "native.android.7e84f3bfd234998d"
+      "id": "native.android.0e8f4c02f7aa20e9"
     },
     {
       "kind": "ui-named-argument",
@@ -4431,7 +4431,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup code",
       "surface": "android",
-      "id": "native.android.b82f4717096c01c7"
+      "id": "native.android.1fcfa6e7f5daac35"
     },
     {
       "kind": "ui-named-argument",
@@ -4439,7 +4439,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Host",
       "surface": "android",
-      "id": "native.android.f50329d05a2b3676"
+      "id": "native.android.29fe804ebbaed339"
     },
     {
       "kind": "ui-named-argument",
@@ -4447,7 +4447,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Port",
       "surface": "android",
-      "id": "native.android.6557999d9fd5aa01"
+      "id": "native.android.066ae1c70e6db5c1"
     },
     {
       "kind": "ui-named-argument",
@@ -4455,7 +4455,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection security",
       "surface": "android",
-      "id": "native.android.8f642d973491194a"
+      "id": "native.android.16e2f44030be076a"
     },
     {
       "kind": "conditional-branch",
@@ -4463,7 +4463,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Secure (TLS)",
       "surface": "android",
-      "id": "native.android.35908838152b14d3"
+      "id": "native.android.6701e8520a27c448"
     },
     {
       "kind": "conditional-branch",
@@ -4471,7 +4471,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Unencrypted",
       "surface": "android",
-      "id": "native.android.44b6133bcd9fac99"
+      "id": "native.android.86aeb5011ef180cb"
     },
     {
       "kind": "ui-named-argument",
@@ -4479,7 +4479,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Token",
       "surface": "android",
-      "id": "native.android.a8eabe81edff3ca0"
+      "id": "native.android.ce47022dd4d431fe"
     },
     {
       "kind": "ui-named-argument",
@@ -4487,7 +4487,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Bootstrap",
       "surface": "android",
-      "id": "native.android.b00f8fe469850d4c"
+      "id": "native.android.1ac555d95edfac77"
     },
     {
       "kind": "ui-named-argument",
@@ -4495,7 +4495,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Password",
       "surface": "android",
-      "id": "native.android.860ab2d58b9bff4f"
+      "id": "native.android.348365a5b167510d"
     },
     {
       "kind": "ui-named-argument",
@@ -4503,7 +4503,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save & Connect",
       "surface": "android",
-      "id": "native.android.c034f78fc099ea2d"
+      "id": "native.android.d11061d5b8123994"
     },
     {
       "kind": "ui-named-argument",
@@ -4511,7 +4511,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enter a valid setup code or gateway address.",
       "surface": "android",
-      "id": "native.android.8327ac42acdd8080"
+      "id": "native.android.633d0dcf4b6d6ed8"
     },
     {
       "kind": "ui-named-argument",
@@ -4519,7 +4519,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Appearance",
       "surface": "android",
-      "id": "native.android.ac2cf01d6878dcd1"
+      "id": "native.android.5311e446ce2bf857"
     },
     {
       "kind": "ui-named-argument",
@@ -4527,7 +4527,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme and translated Android text.",
       "surface": "android",
-      "id": "native.android.cb3894b10e28a093"
+      "id": "native.android.15d4461b5fbdc203"
     },
     {
       "kind": "ui-named-argument",
@@ -4535,7 +4535,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme",
       "surface": "android",
-      "id": "native.android.5e54f785cffa644f"
+      "id": "native.android.0e5de6796bc8d8f9"
     },
     {
       "kind": "ui-named-argument",
@@ -4543,7 +4543,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App language",
       "surface": "android",
-      "id": "native.android.b38f23b59c3fe3e1"
+      "id": "native.android.bd997c088145929f"
     },
     {
       "kind": "ui-named-argument",
@@ -4551,7 +4551,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Changes Android text that OpenClaw has translated. Screens with English-only copy stay unchanged.",
       "surface": "android",
-      "id": "native.android.fe2de2e947c325dc"
+      "id": "native.android.1fc742aceae3f137"
     },
     {
       "kind": "ui-named-argument",
@@ -4559,7 +4559,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected",
       "surface": "android",
-      "id": "native.android.2a2b2e3e4791169a"
+      "id": "native.android.3d640706b2b6b93a"
     },
     {
       "kind": "conditional-branch",
@@ -4567,7 +4567,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Ready",
       "surface": "android",
-      "id": "native.android.f4ca288a4bf10b2b"
+      "id": "native.android.664db1aad9792c18"
     },
     {
       "kind": "ui-named-argument",
@@ -4575,7 +4575,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "About",
       "surface": "android",
-      "id": "native.android.073f2f5ac3a0e495"
+      "id": "native.android.2df2dec704f91977"
     },
     {
       "kind": "ui-named-argument",
@@ -4583,7 +4583,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw for Android.",
       "surface": "android",
-      "id": "native.android.0221754fa3e5df6d"
+      "id": "native.android.c2d37ac2ad4c9e3c"
     },
     {
       "kind": "ui-named-argument",
@@ -4591,7 +4591,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway",
       "surface": "android",
-      "id": "native.android.eac6c60f9479eab9"
+      "id": "native.android.d744d434533ea8ed"
     },
     {
       "kind": "ui-named-argument",
@@ -4599,7 +4599,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Runtime",
       "surface": "android",
-      "id": "native.android.1fd548f7c0bb5297"
+      "id": "native.android.ff6f3e4026089be2"
     },
     {
       "kind": "ui-named-argument",
@@ -4607,7 +4607,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Update",
       "surface": "android",
-      "id": "native.android.10bcdde8ff9d33bb"
+      "id": "native.android.b84ae70dbae95380"
     },
     {
       "kind": "ui-named-argument",
@@ -4615,7 +4615,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "© 2026 OpenClaw Foundation — MIT License.",
       "surface": "android",
-      "id": "native.android.3fdffcb285e875e8"
+      "id": "native.android.aac3310699b496c8"
     },
     {
       "kind": "ui-named-argument",
@@ -4623,7 +4623,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw logo",
       "surface": "android",
-      "id": "native.android.2a94b5f795f3956d"
+      "id": "native.android.a157bbb606e9b398"
     },
     {
       "kind": "ui-named-argument",
@@ -4631,7 +4631,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw",
       "surface": "android",
-      "id": "native.android.fef1c35e1ac5e5e1"
+      "id": "native.android.7b78b4869baf2160"
     },
     {
       "kind": "ui-named-argument",
@@ -4639,7 +4639,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Personal AI on your devices",
       "surface": "android",
-      "id": "native.android.37a73ecc4d53b662"
+      "id": "native.android.ad4c14835d1b71ca"
     },
     {
       "kind": "ui-named-argument",
@@ -4647,7 +4647,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Licenses",
       "surface": "android",
-      "id": "native.android.43bd7acb4e9e2a78"
+      "id": "native.android.13f70e22b5648308"
     },
     {
       "kind": "conditional-branch",
@@ -4655,7 +4655,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw appreciates its partners in the open-source community.",
       "surface": "android",
-      "id": "native.android.d28f97e1a67d60ea"
+      "id": "native.android.996367534eb94cc2"
     },
     {
       "kind": "ui-named-argument",
@@ -4663,7 +4663,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No license notices are packaged in this build.",
       "surface": "android",
-      "id": "native.android.82a3b287c0738e8b"
+      "id": "native.android.24da1d2eb750ba07"
     },
     {
       "kind": "ui-named-argument",
@@ -4671,7 +4671,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open ${license.title}",
       "surface": "android",
-      "id": "native.android.f69c55643aed0781"
+      "id": "native.android.933e72cac84c571e"
     },
     {
       "kind": "conditional-branch",
@@ -4687,7 +4687,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check",
       "surface": "android",
-      "id": "native.android.59f439464fbc62ba"
+      "id": "native.android.cfffa5b838a65ca4"
     },
     {
       "kind": "conditional-branch",
@@ -4711,7 +4711,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Back",
       "surface": "android",
-      "id": "native.android.9a401c593615eee2"
+      "id": "native.android.877490cc2551c8b2"
     },
     {
       "kind": "ui-named-argument",
@@ -4727,7 +4727,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Sending",
       "surface": "android",
-      "id": "native.android.aaf75d99030a0d1b"
+      "id": "native.android.6bbeb853f2a32dba"
     },
     {
       "kind": "ui-named-argument",
@@ -4751,7 +4751,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review",
       "surface": "android",
-      "id": "native.android.2b8066fd548c47d7"
+      "id": "native.android.4d44e246d2cba408"
     },
     {
       "kind": "conditional-branch",
@@ -4759,7 +4759,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Issue",
       "surface": "android",
-      "id": "native.android.16d504af55f23683"
+      "id": "native.android.1f03bb42f27b48ea"
     },
     {
       "kind": "conditional-branch",
@@ -4767,7 +4767,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enabled",
       "surface": "android",
-      "id": "native.android.955fcbabac189168"
+      "id": "native.android.4a583b7a36684ed7"
     },
     {
       "kind": "conditional-branch",
@@ -4775,7 +4775,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No",
       "surface": "android",
-      "id": "native.android.7e77c1b8f3d54328"
+      "id": "native.android.1a3b13c02f53120f"
     },
     {
       "kind": "conditional-branch",
@@ -4783,7 +4783,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Yes",
       "surface": "android",
-      "id": "native.android.8cad377065be204a"
+      "id": "native.android.9f6111d68ea1c273"
     },
     {
       "kind": "ui-named-argument",
@@ -4791,7 +4791,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Error",
       "surface": "android",
-      "id": "native.android.924bbb7bcb446b52"
+      "id": "native.android.4fcad8b85203f5a8"
     },
     {
       "kind": "ui-named-argument",
@@ -4799,7 +4799,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery Error",
       "surface": "android",
-      "id": "native.android.f77d467f435351d9"
+      "id": "native.android.369f2775636e8fd4"
     },
     {
       "kind": "ui-named-argument",
@@ -4807,7 +4807,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Tap to copy",
       "surface": "android",
-      "id": "native.android.d3442fa9f58a5336"
+      "id": "native.android.d02323bcac09c67f"
     },
     {
       "kind": "ui-toast",
@@ -4815,7 +4815,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$title copied",
       "surface": "android",
-      "id": "native.android.407cdad664238a54"
+      "id": "native.android.09641868d42a68fb"
     },
     {
       "kind": "conditional-branch",
@@ -4823,7 +4823,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default assistant",
       "surface": "android",
-      "id": "native.android.bc3a1613d2e311a9"
+      "id": "native.android.727e7f203b075b43"
     },
     {
       "kind": "conditional-branch",
@@ -4831,7 +4831,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default",
       "surface": "android",
-      "id": "native.android.4ea819adf440aa71"
+      "id": "native.android.b3185067fb7fa30e"
     },
     {
       "kind": "conditional-branch",
@@ -4839,7 +4839,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Needs attention",
       "surface": "android",
-      "id": "native.android.65a55e26ff8a0c09"
+      "id": "native.android.ca48afdb0328a6f5"
     },
     {
       "kind": "conditional-branch",
@@ -4847,7 +4847,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting ${minutes}m",
       "surface": "android",
-      "id": "native.android.dd02cc0b3aa09876"
+      "id": "native.android.ee80b2364df97d06"
     },
     {
       "kind": "conditional-branch",
@@ -4855,7 +4855,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting for review",
       "surface": "android",
-      "id": "native.android.aee121024405b3d3"
+      "id": "native.android.fb3f6764d53e5384"
     },
     {
       "kind": "conditional-branch",
@@ -4863,7 +4863,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}",
       "surface": "android",
-      "id": "native.android.157d9164fe973773"
+      "id": "native.android.98b1e19bdbc1e640"
     },
     {
       "kind": "conditional-branch",
@@ -4871,7 +4871,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Off",
       "surface": "android",
-      "id": "native.android.cb46c799211fba00"
+      "id": "native.android.35d4bc86e9ba395d"
     },
     {
       "kind": "conditional-branch",
@@ -4879,7 +4879,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "System Event Text",
       "surface": "android",
-      "id": "native.android.4b490d2afd0a9296"
+      "id": "native.android.22f3549d0fab271d"
     },
     {
       "kind": "conditional-branch",
@@ -4887,7 +4887,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agent Prompt",
       "surface": "android",
-      "id": "native.android.9ecb4bf3e5b77bc6"
+      "id": "native.android.35e7850777bd6c6a"
     },
     {
       "kind": "conditional-branch",
@@ -4895,7 +4895,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Command",
       "surface": "android",
-      "id": "native.android.7fffa742de42a974"
+      "id": "native.android.c49027320aa3f807"
     },
     {
       "kind": "conditional-branch",
@@ -4903,7 +4903,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Payload Text",
       "surface": "android",
-      "id": "native.android.71d5efbf19cf8910"
+      "id": "native.android.f36439e78187c554"
     },
     {
       "kind": "conditional-branch",
@@ -4943,7 +4943,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Close Canvas",
       "surface": "android",
-      "id": "native.android.4597f8605d5af4a5"
+      "id": "native.android.30d8b822fa68d6c4"
     },
     {
       "kind": "ui-named-argument",
@@ -4951,7 +4951,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Overview",
       "surface": "android",
-      "id": "native.android.f16d35b6eb88ce55"
+      "id": "native.android.3d83e0755437a5f9"
     },
     {
       "kind": "ui-named-argument",
@@ -4959,7 +4959,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No recent sessions",
       "surface": "android",
-      "id": "native.android.b05995ccf255d8ff"
+      "id": "native.android.a5c0f8b3112aa58c"
     },
     {
       "kind": "ui-named-argument",
@@ -4967,7 +4967,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Start a chat and your active OpenClaw conversations will appear here.",
       "surface": "android",
-      "id": "native.android.08188983fb7afdce"
+      "id": "native.android.2e33a4fd5f60b550"
     },
     {
       "kind": "ui-named-argument",
@@ -4975,7 +4975,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Start Chat",
       "surface": "android",
-      "id": "native.android.ee5d1b376e8afd50"
+      "id": "native.android.85726cfd4207d48a"
     },
     {
       "kind": "ui-named-argument",
@@ -4983,7 +4983,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
-      "id": "native.android.e1a7cc2e4f02a109"
+      "id": "native.android.4f369a09c8731092"
     },
     {
       "kind": "ui-named-argument",
@@ -4991,7 +4991,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Search",
       "surface": "android",
-      "id": "native.android.c52f025b7e5b1009"
+      "id": "native.android.097cf19d48e09476"
     },
     {
       "kind": "ui-named-argument",
@@ -4999,7 +4999,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "ACTIVE AGENT",
       "surface": "android",
-      "id": "native.android.09e0827eea5f6784"
+      "id": "native.android.586490ecd89b15cc"
     },
     {
       "kind": "conditional-branch",
@@ -5015,7 +5015,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "View",
       "surface": "android",
-      "id": "native.android.89fcf7f25f9f2e27"
+      "id": "native.android.c9a9b5795b73925d"
     },
     {
       "kind": "conditional-branch",
@@ -5023,7 +5023,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$pendingRunCount active",
       "surface": "android",
-      "id": "native.android.15715cbf095c3988"
+      "id": "native.android.57cd2ad60079a630"
     },
     {
       "kind": "conditional-branch",
@@ -5031,7 +5031,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Idle",
       "surface": "android",
-      "id": "native.android.b7ada2fda4f6c78f"
+      "id": "native.android.459a499468f5a968"
     },
     {
       "kind": "ui-named-argument",
@@ -5039,7 +5039,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Runs",
       "surface": "android",
-      "id": "native.android.0089f7fb2c3ed2ff"
+      "id": "native.android.0a1783caa00ac109"
     },
     {
       "kind": "conditional-branch",
@@ -5047,7 +5047,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$sessionCount recent",
       "surface": "android",
-      "id": "native.android.9c61d0c4e401cd05"
+      "id": "native.android.cda6c35cacd55529"
     },
     {
       "kind": "ui-named-argument",
@@ -5055,7 +5055,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Sessions",
       "surface": "android",
-      "id": "native.android.325e45af57d0fde4"
+      "id": "native.android.16c3425d3a594481"
     },
     {
       "kind": "ui-named-argument",
@@ -5063,7 +5063,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Cron",
       "surface": "android",
-      "id": "native.android.efda5e3e5d5c47f4"
+      "id": "native.android.9453625738319f06"
     },
     {
       "kind": "ui-named-argument",
@@ -5071,7 +5071,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Chat",
       "surface": "android",
-      "id": "native.android.012cfc69377230f0"
+      "id": "native.android.5e85ef06f9edc30b"
     },
     {
       "kind": "ui-named-argument",
@@ -5079,7 +5079,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Reconnect gateway",
       "surface": "android",
-      "id": "native.android.451edb17c49bf3dc"
+      "id": "native.android.9b6c16a36dff5990"
     },
     {
       "kind": "ui-named-argument",
@@ -5087,7 +5087,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open ${card.title}",
       "surface": "android",
-      "id": "native.android.02acef7a7c238987"
+      "id": "native.android.42ab09663b243eaa"
     },
     {
       "kind": "ui-named-argument",
@@ -5095,7 +5095,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Talk",
       "surface": "android",
-      "id": "native.android.25ca3ae6935abaa9"
+      "id": "native.android.b61560e884d5b805"
     },
     {
       "kind": "ui-named-argument",
@@ -5103,7 +5103,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open Talk",
       "surface": "android",
-      "id": "native.android.5503fe9d2ec620a2"
+      "id": "native.android.08e318000994609e"
     },
     {
       "kind": "ui-named-argument",
@@ -5111,7 +5111,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Talk settings",
       "surface": "android",
-      "id": "native.android.e844255ae4ca1e07"
+      "id": "native.android.2b01c53de95831ae"
     },
     {
       "kind": "ui-named-argument",
@@ -5119,7 +5119,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Recent Sessions",
       "surface": "android",
-      "id": "native.android.716f7e2778aad382"
+      "id": "native.android.73f07a5d54915259"
     },
     {
       "kind": "ui-named-argument",
@@ -5127,7 +5127,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "View all",
       "surface": "android",
-      "id": "native.android.abd4350e362b9af7"
+      "id": "native.android.e7e2862bffbd0706"
     },
     {
       "kind": "conditional-branch",
@@ -5135,7 +5135,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$onlineNodes/$nodeCount",
       "surface": "android",
-      "id": "native.android.1f421fe9eed414ed"
+      "id": "native.android.c6943c0abb7897a6"
     },
     {
       "kind": "conditional-branch",
@@ -5143,7 +5143,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "None",
       "surface": "android",
-      "id": "native.android.b9210c0e76045890"
+      "id": "native.android.abd477deede96a15"
     },
     {
       "kind": "conditional-branch",
@@ -5159,7 +5159,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Recent conversations",
       "surface": "android",
-      "id": "native.android.8ba1171ef6e7f251"
+      "id": "native.android.7178756ffe9e4c72"
     },
     {
       "kind": "conditional-branch",
@@ -5167,7 +5167,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Browse",
       "surface": "android",
-      "id": "native.android.6eb189d979fa1f3b"
+      "id": "native.android.cbdaff5e476b7dad"
     },
     {
       "kind": "conditional-branch",
@@ -5175,7 +5175,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Offline",
       "surface": "android",
-      "id": "native.android.38f0da7f6cb0da99"
+      "id": "native.android.c093a2297a02405a"
     },
     {
       "kind": "conditional-branch",
@@ -5183,7 +5183,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Working · $pendingRunCount active ${pluralize(\"run\", pendingRunCount)}",
       "surface": "android",
-      "id": "native.android.150e7c05abfee1e5"
+      "id": "native.android.1196e848f04a3dc1"
     },
     {
       "kind": "ui-named-argument",
@@ -5191,7 +5191,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Needs attention",
       "surface": "android",
-      "id": "native.android.27b640f8a13d3656"
+      "id": "native.android.f23eab3d31c5e25c"
     },
     {
       "kind": "ui-named-argument",
@@ -5199,7 +5199,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open ${row.title}",
       "surface": "android",
-      "id": "native.android.d62f3095acdc2da0"
+      "id": "native.android.8452bcda8a619361"
     },
     {
       "kind": "ui-named-argument",
@@ -5207,7 +5207,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open session",
       "surface": "android",
-      "id": "native.android.3b88dc4e5b6b8a17"
+      "id": "native.android.a65477861c7203aa"
     },
     {
       "kind": "ui-named-argument",
@@ -5215,7 +5215,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Back",
       "surface": "android",
-      "id": "native.android.1c64619e67254840"
+      "id": "native.android.ede6f2717ca8e267"
     },
     {
       "kind": "ui-named-argument",
@@ -5223,7 +5223,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Settings",
       "surface": "android",
-      "id": "native.android.cff1475877f8a806"
+      "id": "native.android.ed7e1e2e97bfdd0a"
     },
     {
       "kind": "ui-named-argument",
@@ -5231,7 +5231,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Search settings",
       "surface": "android",
-      "id": "native.android.11fccf3dedc569e2"
+      "id": "native.android.74a2f842d14cdd25"
     },
     {
       "kind": "conditional-branch",
@@ -5239,7 +5239,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Speaker muted",
       "surface": "android",
-      "id": "native.android.345d2424511d2d53"
+      "id": "native.android.68c6f975e8448995"
     },
     {
       "kind": "conditional-branch",
@@ -5247,7 +5247,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Speaker on",
       "surface": "android",
-      "id": "native.android.8a1bf1154936cef1"
+      "id": "native.android.2ee6a4bee2bffe2a"
     },
     {
       "kind": "conditional-branch",
@@ -5255,7 +5255,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Off",
       "surface": "android",
-      "id": "native.android.acc528fb9824c697"
+      "id": "native.android.cd87288a95aa2bf3"
     },
     {
       "kind": "conditional-branch",
@@ -5263,7 +5263,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Smart delivery",
       "surface": "android",
-      "id": "native.android.69b33c2492973ac3"
+      "id": "native.android.e471a3620a50dd42"
     },
     {
       "kind": "conditional-branch",
@@ -5271,7 +5271,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Camera enabled",
       "surface": "android",
-      "id": "native.android.b93e11ff55b87203"
+      "id": "native.android.e51cc066a8b41880"
     },
     {
       "kind": "conditional-branch",
@@ -5279,7 +5279,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Locked",
       "surface": "android",
-      "id": "native.android.c373c56a0e1486b9"
+      "id": "native.android.a6179e3618d40108"
     },
     {
       "kind": "ui-call",
@@ -5303,7 +5303,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "surface": "android",
-      "id": "native.android.4e0a2f3a8cdc9440"
+      "id": "native.android.ca1451df912ed5cf"
     },
     {
       "kind": "conditional-branch",
@@ -5311,7 +5311,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "All systems operational",
       "surface": "android",
-      "id": "native.android.7dc95887ece41f83"
+      "id": "native.android.b7d8c506999a68f7"
     },
     {
       "kind": "conditional-branch",
@@ -5319,7 +5319,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Gateway not connected",
       "surface": "android",
-      "id": "native.android.eb52bb0e9ac4e5cb"
+      "id": "native.android.a818149891391827"
     },
     {
       "kind": "conditional-branch",
@@ -5327,7 +5327,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No provider usage",
       "surface": "android",
-      "id": "native.android.c726f01b481dead2"
+      "id": "native.android.b790e7b89f4b44cc"
     },
     {
       "kind": "conditional-branch",
@@ -5335,7 +5335,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 provider",
       "surface": "android",
-      "id": "native.android.505abbb4d5bf8b5e"
+      "id": "native.android.18dd89960d95d098"
     },
     {
       "kind": "conditional-branch",
@@ -5343,7 +5343,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$count providers",
       "surface": "android",
-      "id": "native.android.2f9b9794176fbf22"
+      "id": "native.android.22d0e2dfa67399d3"
     },
     {
       "kind": "conditional-branch",
@@ -5351,7 +5351,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$pending pending",
       "surface": "android",
-      "id": "native.android.45281acf18c320d3"
+      "id": "native.android.560fea9426127f28"
     },
     {
       "kind": "conditional-branch",
@@ -5359,7 +5359,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 pending",
       "surface": "android",
-      "id": "native.android.43b540ec2036d674"
+      "id": "native.android.5d6077f3ff6528f8"
     },
     {
       "kind": "conditional-branch",
@@ -5367,7 +5367,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$held held",
       "surface": "android",
-      "id": "native.android.c949994f34d7e811"
+      "id": "native.android.c233607d1c8f2b91"
     },
     {
       "kind": "conditional-branch",
@@ -5375,7 +5375,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 held",
       "surface": "android",
-      "id": "native.android.78b077eae65134fe"
+      "id": "native.android.139b4b73d5b2b093"
     },
     {
       "kind": "conditional-branch",
@@ -5383,7 +5383,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$applied applied",
       "surface": "android",
-      "id": "native.android.9e06dbae5cff2d1e"
+      "id": "native.android.c13bf9565ea436b4"
     },
     {
       "kind": "conditional-branch",
@@ -5391,7 +5391,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 applied",
       "surface": "android",
-      "id": "native.android.de8fe49ac422d924"
+      "id": "native.android.c4036bd26d44345c"
     },
     {
       "kind": "ui-named-argument",
@@ -5399,7 +5399,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw mobile",
       "surface": "android",
-      "id": "native.android.4c701ce37c2c3107"
+      "id": "native.android.e197964b10ba02ce"
     },
     {
       "kind": "ui-named-argument",
@@ -5407,7 +5407,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open profile",
       "surface": "android",
-      "id": "native.android.6854fc1b51788c24"
+      "id": "native.android.45005deba537cc59"
     },
     {
       "kind": "conditional-branch",
@@ -5415,7 +5415,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Main session",
       "surface": "android",
-      "id": "native.android.09c4483b6fd9d92c"
+      "id": "native.android.22d755834386db07"
     },
     {
       "kind": "ui-named-argument",
@@ -5423,7 +5423,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Skill Workshop",
       "surface": "android",
-      "id": "native.android.bbebf907cb56f3b8"
+      "id": "native.android.7c6f9feb2c16785f"
     },
     {
       "kind": "ui-named-argument",
@@ -5431,7 +5431,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Review generated skill proposals before they become live skills.",
       "surface": "android",
-      "id": "native.android.3434da6bf61b96c6"
+      "id": "native.android.21c19709950c3f39"
     },
     {
       "kind": "ui-named-argument",
@@ -5439,7 +5439,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
-      "id": "native.android.7e73d08c8e2569d6"
+      "id": "native.android.a68e07b919a2a0d1"
     },
     {
       "kind": "ui-named-argument",
@@ -5447,7 +5447,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Connect to a Gateway to load Skill Workshop proposals.",
       "surface": "android",
-      "id": "native.android.d45bc66e17605adf"
+      "id": "native.android.f4baaca21d1b59d8"
     },
     {
       "kind": "ui-named-argument",
@@ -5455,7 +5455,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "No proposals",
       "surface": "android",
-      "id": "native.android.a3363194a67b865a"
+      "id": "native.android.cbb84c87811aa6d4"
     },
     {
       "kind": "ui-named-argument",
@@ -5463,7 +5463,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Matching proposals will appear here after agents create reusable skill drafts.",
       "surface": "android",
-      "id": "native.android.d8e3c2c2929d68ad"
+      "id": "native.android.90a5b0a2e06cd91e"
     },
     {
       "kind": "ui-call",
@@ -5471,7 +5471,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "${action.action.label} proposal?",
       "surface": "android",
-      "id": "native.android.c4cc1cc99ac23927"
+      "id": "native.android.445ab883554e0249"
     },
     {
       "kind": "ui-named-argument",
@@ -5479,7 +5479,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "This will ${action.action.label.lowercase()} \"${action.title}\" and refresh Skill Workshop state from the gateway.",
       "surface": "android",
-      "id": "native.android.12f02a9a855c5d2d"
+      "id": "native.android.3b3a3f231ac05371"
     },
     {
       "kind": "ui-call",
@@ -5487,7 +5487,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Cancel",
       "surface": "android",
-      "id": "native.android.64d222c4541bf328"
+      "id": "native.android.de53fb795cb7dbea"
     },
     {
       "kind": "conditional-branch",
@@ -5495,7 +5495,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Refresh",
       "surface": "android",
-      "id": "native.android.e05d8dd3465f3c4a"
+      "id": "native.android.4c29d1be6804b451"
     },
     {
       "kind": "conditional-branch",
@@ -5503,7 +5503,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
-      "id": "native.android.ee815c98e77fab95"
+      "id": "native.android.bb2b28111f0f9190"
     },
     {
       "kind": "ui-named-argument",
@@ -5511,7 +5511,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Search proposals",
       "surface": "android",
-      "id": "native.android.8971eb1e0cd41b98"
+      "id": "native.android.cb094500c3b20cfe"
     },
     {
       "kind": "conditional-branch",
@@ -5519,7 +5519,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Open",
       "surface": "android",
-      "id": "native.android.ff486cf26bbb3e0f"
+      "id": "native.android.71aa271f37832333"
     },
     {
       "kind": "conditional-branch",
@@ -5527,7 +5527,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Selected",
       "surface": "android",
-      "id": "native.android.fee3a46bbf30f40a"
+      "id": "native.android.f032646f923b66b3"
     },
     {
       "kind": "ui-named-argument",
@@ -5535,7 +5535,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Apply, reject, and quarantine require operator.admin scope. Reconnect with shared gateway auth or approve an operator.admin device scope upgrade to enable lifecycle actions.",
       "surface": "android",
-      "id": "native.android.f93d8fc8b45f6440"
+      "id": "native.android.cc4d05c30c0dcaa7"
     },
     {
       "kind": "ui-named-argument",
@@ -5543,7 +5543,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Skill Workshop inspect and apply actions",
       "surface": "android",
-      "id": "native.android.125ee1012734f227"
+      "id": "native.android.b03bb83bfe200f83"
     },
     {
       "kind": "conditional-branch",
@@ -5551,7 +5551,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Inspect",
       "surface": "android",
-      "id": "native.android.a502462d359b6e1a"
+      "id": "native.android.96e9ca04a5f6b505"
     },
     {
       "kind": "conditional-branch",
@@ -5559,7 +5559,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Inspecting",
       "surface": "android",
-      "id": "native.android.f87ade5b4c3dead6"
+      "id": "native.android.3be9c3b373e250ed"
     },
     {
       "kind": "conditional-branch",
@@ -5567,7 +5567,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Apply",
       "surface": "android",
-      "id": "native.android.35209f02829bc8fb"
+      "id": "native.android.e16e6dd1cfd597e6"
     },
     {
       "kind": "conditional-branch",
@@ -5575,7 +5575,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Working",
       "surface": "android",
-      "id": "native.android.89f5f8fe544cb24e"
+      "id": "native.android.144ff98399b6eb4a"
     },
     {
       "kind": "ui-named-argument",
@@ -5583,7 +5583,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Skill Workshop reject and quarantine actions",
       "surface": "android",
-      "id": "native.android.0bbb78824d9947bd"
+      "id": "native.android.6f4c6b0e89efb38f"
     },
     {
       "kind": "ui-named-argument",
@@ -5591,7 +5591,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Reject",
       "surface": "android",
-      "id": "native.android.a996208b9eb1d248"
+      "id": "native.android.63c1b72274895358"
     },
     {
       "kind": "ui-named-argument",
@@ -5599,7 +5599,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Quarantine",
       "surface": "android",
-      "id": "native.android.509600924993700d"
+      "id": "native.android.b3b9eca78bd90d1c"
     },
     {
       "kind": "conditional-branch",
@@ -5607,7 +5607,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Pending",
       "surface": "android",
-      "id": "native.android.14225e4ee140db83"
+      "id": "native.android.cabcb1f61fa3cd6f"
     },
     {
       "kind": "conditional-branch",
@@ -5615,7 +5615,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Held",
       "surface": "android",
-      "id": "native.android.a88229b76768cd99"
+      "id": "native.android.2d78d0c70c1913ac"
     },
     {
       "kind": "conditional-branch",
@@ -5623,7 +5623,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Applied",
       "surface": "android",
-      "id": "native.android.90123e136e3b619e"
+      "id": "native.android.733725d1c8280de8"
     },
     {
       "kind": "conditional-branch",
@@ -5631,7 +5631,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Rejected",
       "surface": "android",
-      "id": "native.android.436406d1449eb75c"
+      "id": "native.android.bb3a115829f2c1ec"
     },
     {
       "kind": "conditional-branch",
@@ -5639,7 +5639,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "All",
       "surface": "android",
-      "id": "native.android.d7ae7f03ca7d3337"
+      "id": "native.android.10bf039a2781c9b3"
     },
     {
       "kind": "conditional-branch",
@@ -5647,7 +5647,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillWorkshopSettingsScreen.kt",
       "source": "Default agent",
       "surface": "android",
-      "id": "native.android.893dc9ccc7f4c616"
+      "id": "native.android.6ce9b4b919803618"
     },
     {
       "kind": "ui-named-argument",
@@ -5655,7 +5655,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Skills",
       "surface": "android",
-      "id": "native.android.80c31a76d36911e0"
+      "id": "native.android.4590ee99228ab55f"
     },
     {
       "kind": "ui-named-argument",
@@ -5663,7 +5663,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Installed capabilities available to OpenClaw.",
       "surface": "android",
-      "id": "native.android.e54f8b86c7107c5d"
+      "id": "native.android.73a666b0a4a0e617"
     },
     {
       "kind": "conditional-branch",
@@ -5671,7 +5671,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Refresh",
       "surface": "android",
-      "id": "native.android.75df82cae92feb0a"
+      "id": "native.android.9507bc022dc2e3ed"
     },
     {
       "kind": "conditional-branch",
@@ -5679,7 +5679,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
-      "id": "native.android.440cbea9e5ec8535"
+      "id": "native.android.7d03a8b47442f3c4"
     },
     {
       "kind": "ui-named-argument",
@@ -5687,7 +5687,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Connect the gateway to load skills.",
       "surface": "android",
-      "id": "native.android.d8bb7c815d6f476c"
+      "id": "native.android.73f15da5b2ffdf3c"
     },
     {
       "kind": "ui-named-argument",
@@ -5695,7 +5695,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "No skills installed.",
       "surface": "android",
-      "id": "native.android.055fa27a85844f96"
+      "id": "native.android.619e28818ef4952c"
     },
     {
       "kind": "ui-named-argument",
@@ -5703,7 +5703,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Skills installed on the gateway will appear here.",
       "surface": "android",
-      "id": "native.android.4d7bd951b8afc5a6"
+      "id": "native.android.ab93e3d2d6496eda"
     },
     {
       "kind": "ui-named-argument",
@@ -5711,7 +5711,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Inspect installed skill capability and setup state.",
       "surface": "android",
-      "id": "native.android.280f2fb5970d8c7c"
+      "id": "native.android.81d900273232ce39"
     },
     {
       "kind": "ui-named-argument",
@@ -5719,7 +5719,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Setup",
       "surface": "android",
-      "id": "native.android.f680471aff2e7905"
+      "id": "native.android.f8ddbaf7e1288598"
     },
     {
       "kind": "ui-named-argument",
@@ -5727,7 +5727,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Connect the gateway to load skill details.",
       "surface": "android",
-      "id": "native.android.a7d72ff3468dd07c"
+      "id": "native.android.28e324e5ddfa47b8"
     },
     {
       "kind": "ui-named-argument",
@@ -5735,7 +5735,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Skill detail is not available in the current skills status.",
       "surface": "android",
-      "id": "native.android.4bcee4717129c7ae"
+      "id": "native.android.7aec7b029a6fc11d"
     },
     {
       "kind": "ui-named-argument",
@@ -5743,7 +5743,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Description",
       "surface": "android",
-      "id": "native.android.35249c704e7b4753"
+      "id": "native.android.3b697df990c29cb3"
     },
     {
       "kind": "conditional-branch",
@@ -5751,7 +5751,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Built-in",
       "surface": "android",
-      "id": "native.android.b4beaa70a73d98be"
+      "id": "native.android.d4839a05fe9c87f6"
     },
     {
       "kind": "conditional-branch",
@@ -5759,7 +5759,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Bundled",
       "surface": "android",
-      "id": "native.android.c58175350498ccb4"
+      "id": "native.android.22b4fbf77219bd16"
     },
     {
       "kind": "conditional-branch",
@@ -5767,7 +5767,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Installed",
       "surface": "android",
-      "id": "native.android.45ac30aa89a70f73"
+      "id": "native.android.ad7cf15ce9d982b4"
     },
     {
       "kind": "conditional-branch",
@@ -5775,7 +5775,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Workspace",
       "surface": "android",
-      "id": "native.android.b5ffe9c62fe2d8e1"
+      "id": "native.android.5f25a347c064cb57"
     },
     {
       "kind": "conditional-branch",
@@ -5783,7 +5783,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Extra",
       "surface": "android",
-      "id": "native.android.e5d8e623204c2b24"
+      "id": "native.android.61a83abee9380b37"
     },
     {
       "kind": "conditional-branch",
@@ -5791,7 +5791,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
       "source": "Skill",
       "surface": "android",
-      "id": "native.android.1f7938aac01e5d63"
+      "id": "native.android.14d7845e9790eaab"
     },
     {
       "kind": "ui-named-argument",
@@ -5799,7 +5799,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/TerminalSettingsScreen.kt",
       "source": "Back",
       "surface": "android",
-      "id": "native.android.57a047bc1549ceab"
+      "id": "native.android.efc938b5cc23e079"
     },
     {
       "kind": "ui-named-argument",
@@ -5807,7 +5807,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/TerminalSettingsScreen.kt",
       "source": "Terminal",
       "surface": "android",
-      "id": "native.android.657133107ee77be1"
+      "id": "native.android.3e0f25545a6ccfb4"
     },
     {
       "kind": "ui-named-argument",
@@ -5815,7 +5815,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/TerminalSettingsScreen.kt",
       "source": "Terminal needs a connected gateway",
       "surface": "android",
-      "id": "native.android.1f2001a736b51519"
+      "id": "native.android.a196c4c819426137"
     },
     {
       "kind": "ui-named-argument",
@@ -5823,7 +5823,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/TerminalSettingsScreen.kt",
       "source": "Connect to your gateway to open a shell in the agent workspace.",
       "surface": "android",
-      "id": "native.android.9bc2c2fe13f9f8ec"
+      "id": "native.android.9f3ceb93047671b5"
     },
     {
       "kind": "ui-named-argument",
@@ -5831,7 +5831,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Dictation",
       "surface": "android",
-      "id": "native.android.9376e1fcf5fdecde"
+      "id": "native.android.5e0524a5d86e673a"
     },
     {
       "kind": "ui-named-argument",
@@ -5839,7 +5839,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Transcribe then send",
       "surface": "android",
-      "id": "native.android.e11270d1dc9ccd81"
+      "id": "native.android.afda4b6690e194bb"
     },
     {
       "kind": "ui-named-argument",
@@ -5847,7 +5847,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Dictation settings",
       "surface": "android",
-      "id": "native.android.de440b43aa477aaa"
+      "id": "native.android.198d5005ddb92f81"
     },
     {
       "kind": "conditional-branch",
@@ -5855,7 +5855,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Sending to chat...",
       "surface": "android",
-      "id": "native.android.d6740dd3f5dfdf89"
+      "id": "native.android.c6b9223985115579"
     },
     {
       "kind": "conditional-branch",
@@ -5863,7 +5863,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Start speaking...",
       "surface": "android",
-      "id": "native.android.a360bf29e64910a6"
+      "id": "native.android.3d692aaf1d8db847"
     },
     {
       "kind": "ui-named-argument",
@@ -5871,7 +5871,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Speech provider",
       "surface": "android",
-      "id": "native.android.7bf45e4340eca6d9"
+      "id": "native.android.6849abfceeca563e"
     },
     {
       "kind": "ui-named-argument",
@@ -5879,7 +5879,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Tip: stop listening to send the captured turn.",
       "surface": "android",
-      "id": "native.android.9c73b948a811ff7f"
+      "id": "native.android.83e924e18ed13f80"
     },
     {
       "kind": "ui-named-argument",
@@ -5887,7 +5887,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Cancel",
       "surface": "android",
-      "id": "native.android.8aaa040065bd09c4"
+      "id": "native.android.6e03e484667c0fae"
     },
     {
       "kind": "conditional-branch",
@@ -5895,7 +5895,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Send to Chat",
       "surface": "android",
-      "id": "native.android.cf827f2c85d0894d"
+      "id": "native.android.be60507f8320ba30"
     },
     {
       "kind": "ui-named-argument",
@@ -5903,7 +5903,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Back to voice",
       "surface": "android",
-      "id": "native.android.be27ec477fe4a4b2"
+      "id": "native.android.01fbec5b76e35975"
     },
     {
       "kind": "ui-named-argument",
@@ -5911,7 +5911,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Realtime Talk",
       "surface": "android",
-      "id": "native.android.84c700e5cb2b6144"
+      "id": "native.android.3d5d539d6adde13c"
     },
     {
       "kind": "conditional-branch",
@@ -5943,7 +5943,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Talk settings",
       "surface": "android",
-      "id": "native.android.334cbe27e8c4f8ea"
+      "id": "native.android.33ec06cb156adf64"
     },
     {
       "kind": "ui-named-argument",
@@ -5951,7 +5951,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Live transcript",
       "surface": "android",
-      "id": "native.android.b62bc0f7524af22b"
+      "id": "native.android.fa79aec52f4ca61c"
     },
     {
       "kind": "conditional-branch",
@@ -5959,7 +5959,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Mute",
       "surface": "android",
-      "id": "native.android.b99a47f342b7178d"
+      "id": "native.android.c8f07b6659f101b0"
     },
     {
       "kind": "conditional-branch",
@@ -5967,7 +5967,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Unmute",
       "surface": "android",
-      "id": "native.android.402ab18984cb3c66"
+      "id": "native.android.5d4f2992e2320c3e"
     },
     {
       "kind": "ui-named-argument",
@@ -5975,7 +5975,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "End",
       "surface": "android",
-      "id": "native.android.a773b2e88c4bcf79"
+      "id": "native.android.d7ffaa41c514ba38"
     },
     {
       "kind": "ui-named-argument",
@@ -5983,7 +5983,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Listening for your next turn.",
       "surface": "android",
-      "id": "native.android.a3b5da4f39064711"
+      "id": "native.android.b67e9d126075dc78"
     },
     {
       "kind": "ui-named-argument",
@@ -5991,7 +5991,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
-      "id": "native.android.41ee56880eb211cb"
+      "id": "native.android.253debc9d0714dda"
     },
     {
       "kind": "ui-named-argument",
@@ -5999,7 +5999,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Search voice",
       "surface": "android",
-      "id": "native.android.05e4aee51d2763fb"
+      "id": "native.android.ece74bf084239d34"
     },
     {
       "kind": "ui-named-argument",
@@ -6007,7 +6007,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Voice",
       "surface": "android",
-      "id": "native.android.44b12f2d29cfe297"
+      "id": "native.android.f2c14708240881f4"
     },
     {
       "kind": "conditional-branch",
@@ -6015,7 +6015,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Mute speaker",
       "surface": "android",
-      "id": "native.android.3da73c3abd286e61"
+      "id": "native.android.3f08bdce481e440f"
     },
     {
       "kind": "conditional-branch",
@@ -6023,7 +6023,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Unmute speaker",
       "surface": "android",
-      "id": "native.android.ac98e3c297355929"
+      "id": "native.android.756c27fec566684c"
     },
     {
       "kind": "conditional-branch",
@@ -6031,7 +6031,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "End Talk",
       "surface": "android",
-      "id": "native.android.8d3669607b164169"
+      "id": "native.android.1493d618a615552d"
     },
     {
       "kind": "conditional-branch",
@@ -6039,7 +6039,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Stop Dictation",
       "surface": "android",
-      "id": "native.android.7bf5317e8204e16b"
+      "id": "native.android.13e71be7bb52391b"
     },
     {
       "kind": "ui-named-argument",
@@ -6047,7 +6047,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Voice setup",
       "surface": "android",
-      "id": "native.android.c801692a185c938a"
+      "id": "native.android.71fa9c845cdb89bd"
     },
     {
       "kind": "conditional-branch",
@@ -6055,7 +6055,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "You",
       "surface": "android",
-      "id": "native.android.f3db8d90d17cdff1"
+      "id": "native.android.24057bba4bbfa27a"
     },
     {
       "kind": "ui-named-argument",
@@ -6063,7 +6063,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Sending",
       "surface": "android",
-      "id": "native.android.f4cba4d63463dd93"
+      "id": "native.android.c4423034d764ee3f"
     },
     {
       "kind": "ui-named-argument",
@@ -6071,7 +6071,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
-      "id": "native.android.5bc7ecbc5f2a49cf"
+      "id": "native.android.5b8bd9f2b69b91ea"
     },
     {
       "kind": "ui-named-argument",
@@ -6079,7 +6079,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Permission needed",
       "surface": "android",
-      "id": "native.android.ee9debbf2637b6de"
+      "id": "native.android.420cccbd48298a8d"
     },
     {
       "kind": "ui-named-argument",
@@ -6087,7 +6087,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Microphone access is needed.",
       "surface": "android",
-      "id": "native.android.97e9ed6b1046e4a8"
+      "id": "native.android.d0cc4cfee06d9849"
     },
     {
       "kind": "ui-named-argument",
@@ -6095,7 +6095,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "OpenClaw only listens when you start Talk or Dictation.",
       "surface": "android",
-      "id": "native.android.14d924bca8ecc830"
+      "id": "native.android.285eeed928be0fc1"
     },
     {
       "kind": "ui-named-argument",
@@ -6103,7 +6103,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Enable Microphone",
       "surface": "android",
-      "id": "native.android.f2850b632d11d3bc"
+      "id": "native.android.b10a51fe9d4b8d2d"
     },
     {
       "kind": "ui-named-argument",
@@ -6119,7 +6119,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "Files unavailable",
       "surface": "android",
-      "id": "native.android.9b3592fd32526671"
+      "id": "native.android.eb6ff96aba8f67b4"
     },
     {
       "kind": "ui-named-argument",
@@ -6127,7 +6127,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "Empty folder",
       "surface": "android",
-      "id": "native.android.ecf78c5481c7dc8f"
+      "id": "native.android.fefb4a6c1717210d"
     },
     {
       "kind": "ui-named-argument",
@@ -6135,7 +6135,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "This folder has no files yet.",
       "surface": "android",
-      "id": "native.android.9511ba3213bf7810"
+      "id": "native.android.b74f90dc5f65b1da"
     },
     {
       "kind": "ui-named-argument",
@@ -6143,7 +6143,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "Could not load this folder.",
       "surface": "android",
-      "id": "native.android.d5dd23746acf7456"
+      "id": "native.android.8f0b5317c75e334d"
     },
     {
       "kind": "ui-named-argument",
@@ -6151,7 +6151,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "Load more",
       "surface": "android",
-      "id": "native.android.b5c0cb8521d7fc26"
+      "id": "native.android.4e48916e1b0f86ab"
     },
     {
       "kind": "ui-named-argument",
@@ -6159,7 +6159,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "${entries.size} of $totalEntries",
       "surface": "android",
-      "id": "native.android.5395b58a53fcd10e"
+      "id": "native.android.f26b7b179d4765b0"
     },
     {
       "kind": "ui-named-argument",
@@ -6167,7 +6167,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "Back",
       "surface": "android",
-      "id": "native.android.65e71f667e84ef39"
+      "id": "native.android.b2a525ca00a799df"
     },
     {
       "kind": "ui-named-argument",
@@ -6175,7 +6175,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "Share file",
       "surface": "android",
-      "id": "native.android.be124067c7b9c709"
+      "id": "native.android.737edf881bc586d5"
     },
     {
       "kind": "ui-named-argument",
@@ -6183,7 +6183,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "No preview",
       "surface": "android",
-      "id": "native.android.45b1bf9726e61a27"
+      "id": "native.android.095574301bf487a1"
     },
     {
       "kind": "ui-named-argument",
@@ -6191,7 +6191,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "This image could not be decoded.",
       "surface": "android",
-      "id": "native.android.b3454d7755ab7fab"
+      "id": "native.android.f57b231996a10d14"
     },
     {
       "kind": "conditional-branch",
@@ -6207,7 +6207,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMarkdown.kt",
       "source": "$index.",
       "surface": "android",
-      "id": "native.android.5e4eb33858d294ff"
+      "id": "native.android.cd2033b0a82a72dd"
     },
     {
       "kind": "ui-named-argument",
@@ -6215,7 +6215,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMarkdown.kt",
       "source": "Image unavailable",
       "surface": "android",
-      "id": "native.android.3b3fc26137bee567"
+      "id": "native.android.bef360f847488651"
     },
     {
       "kind": "conditional-branch",
@@ -6223,7 +6223,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "$quoted\n\n",
       "surface": "android",
-      "id": "native.android.547147ddb32a7a2a"
+      "id": "native.android.e64a6673728dadcb"
     },
     {
       "kind": "ui-named-argument",
@@ -6231,7 +6231,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Message actions",
       "surface": "android",
-      "id": "native.android.14a2c20fedc07713"
+      "id": "native.android.7bf61a1da504c271"
     },
     {
       "kind": "conditional-branch",
@@ -6239,7 +6239,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Listen",
       "surface": "android",
-      "id": "native.android.187b68770a1879c3"
+      "id": "native.android.9b4d58eb6f2eb2af"
     },
     {
       "kind": "conditional-branch",
@@ -6247,7 +6247,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Stop",
       "surface": "android",
-      "id": "native.android.36e9ad12ce427210"
+      "id": "native.android.dc64ec935e5d0de4"
     },
     {
       "kind": "ui-named-argument",
@@ -6255,7 +6255,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Copy",
       "surface": "android",
-      "id": "native.android.c57de75229e8df1c"
+      "id": "native.android.fab176fe78fc2500"
     },
     {
       "kind": "ui-named-argument",
@@ -6263,7 +6263,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Select text",
       "surface": "android",
-      "id": "native.android.da09739e056101ad"
+      "id": "native.android.319b4a29df279bb3"
     },
     {
       "kind": "ui-named-argument",
@@ -6271,7 +6271,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Share",
       "surface": "android",
-      "id": "native.android.c2009f686014fa7a"
+      "id": "native.android.fc50d4d9ec3b5a0b"
     },
     {
       "kind": "ui-named-argument",
@@ -6279,7 +6279,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Reply",
       "surface": "android",
-      "id": "native.android.173af6a0cba08b7c"
+      "id": "native.android.7b896902a024d85f"
     },
     {
       "kind": "ui-call",
@@ -6287,7 +6287,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Done",
       "surface": "android",
-      "id": "native.android.7ce13e4e77388dfa"
+      "id": "native.android.3f40011c9f02a65a"
     },
     {
       "kind": "ui-toast",
@@ -6295,7 +6295,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Message copied",
       "surface": "android",
-      "id": "native.android.22fc823b544f8e3c"
+      "id": "native.android.833dec4c78ab5eae"
     },
     {
       "kind": "ui-chooser",
@@ -6303,7 +6303,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Share message",
       "surface": "android",
-      "id": "native.android.80e2f709f949d686"
+      "id": "native.android.7fecaa645b302769"
     },
     {
       "kind": "ui-toast",
@@ -6311,7 +6311,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "No app can share this message",
       "surface": "android",
-      "id": "native.android.39cafe851e4917e8"
+      "id": "native.android.d06711f88020d74e"
     },
     {
       "kind": "conditional-branch",
@@ -6319,7 +6319,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Preparing audio…",
       "surface": "android",
-      "id": "native.android.e951bed9cad8e7e2"
+      "id": "native.android.9ab1dd78954fc3c2"
     },
     {
       "kind": "conditional-branch",
@@ -6327,7 +6327,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Speaking…",
       "surface": "android",
-      "id": "native.android.53e70a782848c575"
+      "id": "native.android.0ee4d153c4e592d3"
     },
     {
       "kind": "ui-named-argument",
@@ -6335,7 +6335,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Preview · $domain",
       "surface": "android",
-      "id": "native.android.3f797bd46f64c399"
+      "id": "native.android.71ef7f8dbe2b0dbe"
     },
     {
       "kind": "ui-named-argument",
@@ -6343,7 +6343,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Expand link preview",
       "surface": "android",
-      "id": "native.android.146ad6126d0d743b"
+      "id": "native.android.b49e81e487cdbaa3"
     },
     {
       "kind": "ui-call",
@@ -6351,7 +6351,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Loading preview…",
       "surface": "android",
-      "id": "native.android.a68b57ad9bbdfd61"
+      "id": "native.android.986fd353169b6153"
     },
     {
       "kind": "ui-call",
@@ -6359,7 +6359,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "No preview available",
       "surface": "android",
-      "id": "native.android.462d3d24e221d604"
+      "id": "native.android.edb04556385d80d5"
     },
     {
       "kind": "ui-call",
@@ -6367,7 +6367,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Thinking...",
       "surface": "android",
-      "id": "native.android.566e7b170900c696"
+      "id": "native.android.a50e44d8f380f9ad"
     },
     {
       "kind": "ui-named-argument",
@@ -6375,7 +6375,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Tools",
       "surface": "android",
-      "id": "native.android.d284c6fe721265ee"
+      "id": "native.android.ff4a092a02bd5d17"
     },
     {
       "kind": "ui-call",
@@ -6383,7 +6383,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Running tools...",
       "surface": "android",
-      "id": "native.android.a9994372273d3405"
+      "id": "native.android.3788802f6c138c8b"
     },
     {
       "kind": "ui-call",
@@ -6391,7 +6391,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "${display.emoji} ${display.label}",
       "surface": "android",
-      "id": "native.android.8a136560c51b9e3e"
+      "id": "native.android.5f93173e06eda5c0"
     },
     {
       "kind": "ui-named-argument",
@@ -6399,7 +6399,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "... +${toolCalls.size - 6} more",
       "surface": "android",
-      "id": "native.android.642ebd06e4e64b15"
+      "id": "native.android.29021f925bf290c7"
     },
     {
       "kind": "ui-call",
@@ -6415,7 +6415,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "You",
       "surface": "android",
-      "id": "native.android.844586e4424bfc28"
+      "id": "native.android.b3ff30d4e0b3ce58"
     },
     {
       "kind": "ui-named-argument",
@@ -6431,7 +6431,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Retry",
       "surface": "android",
-      "id": "native.android.aaae8873b8fa69dd"
+      "id": "native.android.9bd31c23ebdf7c7a"
     },
     {
       "kind": "ui-named-argument",
@@ -6439,7 +6439,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Delete",
       "surface": "android",
-      "id": "native.android.2d681bab2e92e2de"
+      "id": "native.android.b728b15914267f57"
     },
     {
       "kind": "ui-call",
@@ -6455,7 +6455,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "OpenClaw · Live",
       "surface": "android",
-      "id": "native.android.60c9a2b33fed8aac"
+      "id": "native.android.dfbd755eb43b4d26"
     },
     {
       "kind": "conditional-branch",
@@ -6463,7 +6463,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "System",
       "surface": "android",
-      "id": "native.android.e3541114ce44342d"
+      "id": "native.android.d29098025118ce4b"
     },
     {
       "kind": "conditional-branch",
@@ -6471,7 +6471,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "OpenClaw",
       "surface": "android",
-      "id": "native.android.31e961bd32783c5d"
+      "id": "native.android.82e9fe45e93909b6"
     },
     {
       "kind": "ui-named-argument",
@@ -6495,7 +6495,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Unsupported attachment",
       "surface": "android",
-      "id": "native.android.42470ffb9dd06aa0"
+      "id": "native.android.09720189ba712747"
     },
     {
       "kind": "conditional-branch",
@@ -6511,7 +6511,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat needs attention",
       "surface": "android",
-      "id": "native.android.039c8d56bac7f017"
+      "id": "native.android.22a4efbe2bab8b80"
     },
     {
       "kind": "ui-named-argument",
@@ -6519,7 +6519,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
-      "id": "native.android.d966f773e31302ac"
+      "id": "native.android.b73c79389a8cff07"
     },
     {
       "kind": "ui-named-argument",
@@ -6527,7 +6527,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
-      "id": "native.android.ee660a4842207fb6"
+      "id": "native.android.25d8575c0063aee5"
     },
     {
       "kind": "ui-named-argument",
@@ -6535,7 +6535,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
-      "id": "native.android.9113a8f1d915f708"
+      "id": "native.android.4437f3cbdb3c8cbe"
     },
     {
       "kind": "ui-named-argument",
@@ -6543,7 +6543,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "More new chat options",
       "surface": "android",
-      "id": "native.android.3e731ba817462206"
+      "id": "native.android.6b0f8ea129bca167"
     },
     {
       "kind": "ui-named-argument",
@@ -6551,7 +6551,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
-      "id": "native.android.0e76fbb496811ed5"
+      "id": "native.android.0066c3883e9eff15"
     },
     {
       "kind": "ui-named-argument",
@@ -6559,7 +6559,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
-      "id": "native.android.f60ba3ea5cc2670e"
+      "id": "native.android.707eccff20a79f65"
     },
     {
       "kind": "ui-named-argument",
@@ -6567,7 +6567,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading session",
       "surface": "android",
-      "id": "native.android.1b8a464ad323ed86"
+      "id": "native.android.882cc14a58e7e105"
     },
     {
       "kind": "ui-named-argument",
@@ -6575,7 +6575,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
-      "id": "native.android.79e6a7b8fad4a0d9"
+      "id": "native.android.2c1106e1687ab258"
     },
     {
       "kind": "conditional-branch",
@@ -6583,7 +6583,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
-      "id": "native.android.9adfe0fe0dfd0d71"
+      "id": "native.android.9df2c9d68bad169f"
     },
     {
       "kind": "conditional-branch",
@@ -6615,7 +6615,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
-      "id": "native.android.81767170cb87af93"
+      "id": "native.android.6bbe3c5b5193d985"
     },
     {
       "kind": "ui-named-argument",
@@ -6623,7 +6623,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
-      "id": "native.android.20ccd2b43bbdce99"
+      "id": "native.android.579c05816c7dfa79"
     },
     {
       "kind": "conditional-branch",
@@ -6631,7 +6631,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Preparing audio…",
       "surface": "android",
-      "id": "native.android.448d75947f69746a"
+      "id": "native.android.5aafbef3744d86f3"
     },
     {
       "kind": "conditional-branch",
@@ -6639,7 +6639,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Speaking…",
       "surface": "android",
-      "id": "native.android.73d50d3aa44254e5"
+      "id": "native.android.d7919c440a82f426"
     },
     {
       "kind": "ui-named-argument",
@@ -6647,7 +6647,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
-      "id": "native.android.85156730449587a5"
+      "id": "native.android.781f84dfaf7da9d6"
     },
     {
       "kind": "ui-named-argument",
@@ -6655,7 +6655,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is working",
       "surface": "android",
-      "id": "native.android.a7049c6ca1631d53"
+      "id": "native.android.d851a32f367f8b31"
     },
     {
       "kind": "ui-named-argument",
@@ -6663,7 +6663,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
-      "id": "native.android.97f3ec3a2698bc89"
+      "id": "native.android.0fd6b75cadc0ce75"
     },
     {
       "kind": "ui-named-argument",
@@ -6671,7 +6671,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
-      "id": "native.android.f793872105b71f5c"
+      "id": "native.android.7e0aea1dca378135"
     },
     {
       "kind": "ui-named-argument",
@@ -6679,7 +6679,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
-      "id": "native.android.fbf542fa6c554bc2"
+      "id": "native.android.98a0d4d5bba788c4"
     },
     {
       "kind": "ui-named-argument",
@@ -6695,7 +6695,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
-      "id": "native.android.fe15e047ed00f6c2"
+      "id": "native.android.76d574acfac94fee"
     },
     {
       "kind": "ui-named-argument",
@@ -6703,7 +6703,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Default",
       "surface": "android",
-      "id": "native.android.93b1a319b6210883"
+      "id": "native.android.2cb3ec7379426dfe"
     },
     {
       "kind": "conditional-branch",
@@ -6711,7 +6711,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Pin model",
       "surface": "android",
-      "id": "native.android.6d8ff45bb2f49515"
+      "id": "native.android.f8d0f6ba7608abc3"
     },
     {
       "kind": "conditional-branch",
@@ -6719,7 +6719,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Unpin model",
       "surface": "android",
-      "id": "native.android.1bb8eeba5c2c8cbf"
+      "id": "native.android.09a13ed8f039a9c3"
     },
     {
       "kind": "ui-named-argument",
@@ -6727,7 +6727,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
-      "id": "native.android.24fe1cac748d327b"
+      "id": "native.android.5953c956ff208e6e"
     },
     {
       "kind": "ui-named-argument",
@@ -6735,7 +6735,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
-      "id": "native.android.34065f11257bd8d6"
+      "id": "native.android.8e3e367df24cae4b"
     },
     {
       "kind": "conditional-branch",
@@ -6759,7 +6759,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
-      "id": "native.android.3f0cc86baa23528c"
+      "id": "native.android.623e434c83e3c020"
     },
     {
       "kind": "ui-named-argument",
@@ -6767,7 +6767,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
-      "id": "native.android.377738368b2028c0"
+      "id": "native.android.f1d69eb66c5dfa39"
     },
     {
       "kind": "ui-named-argument",
@@ -6775,7 +6775,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Open voice",
       "surface": "android",
-      "id": "native.android.61a15f4f636f31ce"
+      "id": "native.android.97602a28629a331f"
     },
     {
       "kind": "ui-named-argument",
@@ -6783,7 +6783,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
-      "id": "native.android.3fd764f16df42c0d"
+      "id": "native.android.5054269049758d6a"
     },
     {
       "kind": "conditional-branch",
@@ -6791,7 +6791,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
-      "id": "native.android.c22d101ed0256dea"
+      "id": "native.android.5fa853a957713a56"
     },
     {
       "kind": "conditional-branch",
@@ -6799,7 +6799,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$emoji $name",
       "surface": "android",
-      "id": "native.android.c2abc42af6bbf273"
+      "id": "native.android.6ef0b7ad012c32da"
     },
     {
       "kind": "ui-named-argument",
@@ -6807,7 +6807,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
-      "id": "native.android.466310cf1fe922d7"
+      "id": "native.android.6e2fcc9d67fc1273"
     },
     {
       "kind": "conditional-branch",
@@ -6815,7 +6815,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",
-      "id": "native.android.4107ab7369c81b20"
+      "id": "native.android.4e6c67df44d588d3"
     },
     {
       "kind": "ui-named-argument",
@@ -6823,7 +6823,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/VoiceNoteComposer.kt",
       "source": "Preparing voice note…",
       "surface": "android",
-      "id": "native.android.20d589c9b34d08e5"
+      "id": "native.android.3df4e24a0fc8810b"
     },
     {
       "kind": "ui-named-argument",
@@ -6831,7 +6831,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/VoiceNoteComposer.kt",
       "source": "Record voice note",
       "surface": "android",
-      "id": "native.android.5649ada7a9295f5b"
+      "id": "native.android.06ab95879f652d3e"
     },
     {
       "kind": "ui-named-argument",
@@ -6839,7 +6839,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/VoiceNoteComposer.kt",
       "source": "Cancel voice note",
       "surface": "android",
-      "id": "native.android.2a2c5ad98a6ddc2d"
+      "id": "native.android.8a7653317387033f"
     },
     {
       "kind": "ui-named-argument",
@@ -6847,7 +6847,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/VoiceNoteComposer.kt",
       "source": "Finish voice note",
       "surface": "android",
-      "id": "native.android.6af7a9209409e0fc"
+      "id": "native.android.fb327cd3030aae44"
     },
     {
       "kind": "ui-named-argument",
@@ -6855,7 +6855,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/VoiceNoteComposer.kt",
       "source": "Voice note",
       "surface": "android",
-      "id": "native.android.a9dffd00a4789c03"
+      "id": "native.android.e9d238668cb46e71"
     },
     {
       "kind": "ui-named-argument",
@@ -6863,7 +6863,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Local command center",
       "surface": "android",
-      "id": "native.android.48878d597b77627b"
+      "id": "native.android.64459adde73e63f2"
     },
     {
       "kind": "ui-named-argument",
@@ -6871,7 +6871,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "OC",
       "surface": "android",
-      "id": "native.android.fe1563c75a718246"
+      "id": "native.android.dc3aa392cc80e61c"
     },
     {
       "kind": "ui-named-argument",
@@ -6879,7 +6879,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Search",
       "surface": "android",
-      "id": "native.android.328d7e498cb4fddf"
+      "id": "native.android.f5fd5dc2947b2d8f"
     },
     {
       "kind": "ui-named-argument",
@@ -6887,7 +6887,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "OpenClaw",
       "surface": "android",
-      "id": "native.android.ff13ffcb0f13c2d0"
+      "id": "native.android.79d7a1026ef43e80"
     },
     {
       "kind": "ui-named-argument",
@@ -6895,7 +6895,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Design system prototype",
       "surface": "android",
-      "id": "native.android.c21e3ea23a01cf14"
+      "id": "native.android.e8318a46a213cb91"
     },
     {
       "kind": "ui-named-argument",
@@ -6903,7 +6903,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Connected",
       "surface": "android",
-      "id": "native.android.39176ac7b4baed2c"
+      "id": "native.android.082bff8feba7dab7"
     },
     {
       "kind": "ui-named-argument",
@@ -6911,7 +6911,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Sessions",
       "surface": "android",
-      "id": "native.android.a09d2db471e98067"
+      "id": "native.android.81931886b9caf3ab"
     },
     {
       "kind": "ui-named-argument",
@@ -6919,7 +6919,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Testing testing 1 2 3",
       "surface": "android",
-      "id": "native.android.63c1a0823f81fad6"
+      "id": "native.android.e4dc7610b0898e37"
     },
     {
       "kind": "ui-named-argument",
@@ -6927,7 +6927,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "14 messages · Android",
       "surface": "android",
-      "id": "native.android.80215e310c00378e"
+      "id": "native.android.9ffcbda6cdb9bc00"
     },
     {
       "kind": "ui-named-argument",
@@ -6935,7 +6935,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Provider setup",
       "surface": "android",
-      "id": "native.android.a3df85d63a5e097b"
+      "id": "native.android.5c84ed8a78a5c5d5"
     },
     {
       "kind": "ui-named-argument",
@@ -6943,7 +6943,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "OpenClaw gateway",
       "surface": "android",
-      "id": "native.android.d704e1644ae338b0"
+      "id": "native.android.794873efdfcdff4f"
     },
     {
       "kind": "ui-named-argument",
@@ -6951,7 +6951,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Ask OpenClaw anything",
       "surface": "android",
-      "id": "native.android.8432ceda35222fe7"
+      "id": "native.android.2d3b6dd9a8f186fe"
     },
     {
       "kind": "ui-named-argument",
@@ -6959,7 +6959,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Start Chat",
       "surface": "android",
-      "id": "native.android.4ff19ec4e36594cf"
+      "id": "native.android.608ccdaeababf056"
     },
     {
       "kind": "ui-named-argument",
@@ -6967,7 +6967,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Voice",
       "surface": "android",
-      "id": "native.android.50e1fc168e3192ce"
+      "id": "native.android.e5c1ad9a97e2192c"
     },
     {
       "kind": "ui-named-argument",
@@ -6975,7 +6975,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Realtime",
       "surface": "android",
-      "id": "native.android.8799e7d7da0053c6"
+      "id": "native.android.efeaa73f880276a0"
     },
     {
       "kind": "ui-named-argument",
@@ -6983,7 +6983,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Dictation",
       "surface": "android",
-      "id": "native.android.dbf1f49e91f92a8d"
+      "id": "native.android.4552f643f5af9ace"
     },
     {
       "kind": "ui-named-argument",
@@ -6991,7 +6991,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Screen",
       "surface": "android",
-      "id": "native.android.35c848cbc6d50957"
+      "id": "native.android.46b35cc0fdc3c1bd"
     },
     {
       "kind": "ui-named-argument",
@@ -6999,7 +6999,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Nothing needs your attention",
       "surface": "android",
-      "id": "native.android.5e75c2a9ccb2dc3a"
+      "id": "native.android.994ac738d819f2e6"
     },
     {
       "kind": "ui-named-argument",
@@ -7007,7 +7007,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "OpenClaw will surface approvals, failed jobs, and channel issues here.",
       "surface": "android",
-      "id": "native.android.db422f5953772c69"
+      "id": "native.android.3457b4ee28d964ee"
     },
     {
       "kind": "ui-call",
@@ -7031,7 +7031,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Speaking · waiting for reply",
       "surface": "android",
-      "id": "native.android.1b90d84b8fbff362"
+      "id": "native.android.c5e56f0e8af094fb"
     },
     {
       "kind": "conditional-branch",
@@ -7039,7 +7039,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Speaking…",
       "surface": "android",
-      "id": "native.android.63722e202a33bd02"
+      "id": "native.android.7228c229ce9f97c6"
     },
     {
       "kind": "conditional-branch",
@@ -7047,7 +7047,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Mic on · waiting for gateway",
       "surface": "android",
-      "id": "native.android.1369ecf9bc8adc90"
+      "id": "native.android.6fbf0916309dbaba"
     },
     {
       "kind": "conditional-branch",
@@ -7055,7 +7055,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Mic off",
       "surface": "android",
-      "id": "native.android.fd6e35016b990650"
+      "id": "native.android.d84c6c14e42763ff"
     },
     {
       "kind": "conditional-branch",
@@ -7063,7 +7063,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Mic off · sending…",
       "surface": "android",
-      "id": "native.android.ca2190761f679d29"
+      "id": "native.android.9dda2b87d9668a4b"
     },
     {
       "kind": "conditional-branch",
@@ -7071,7 +7071,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Listening · sending queued voice",
       "surface": "android",
-      "id": "native.android.04465040125a492a"
+      "id": "native.android.c802b757f76226d9"
     },
     {
       "kind": "conditional-branch",
@@ -7079,7 +7079,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Sending queued voice",
       "surface": "android",
-      "id": "native.android.8dd66e315d86e834"
+      "id": "native.android.01ac388cd8ae0732"
     },
     {
       "kind": "conditional-branch",
@@ -7095,7 +7095,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Listening",
       "surface": "android",
-      "id": "native.android.7b4dacae0686d138"
+      "id": "native.android.b4f67e96603515bd"
     },
     {
       "kind": "conditional-branch",
@@ -7103,7 +7103,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Ready",
       "surface": "android",
-      "id": "native.android.47a59f8798682ea0"
+      "id": "native.android.b88e4278ead724ba"
     },
     {
       "kind": "conditional-branch",
@@ -7111,7 +7111,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Off",
       "surface": "android",
-      "id": "native.android.24bc808758b925ca"
+      "id": "native.android.8d8230088f3baa2a"
     },
     {
       "kind": "conditional-branch",
@@ -7119,7 +7119,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: Realtime provider closed unexpectedly.",
       "surface": "android",
-      "id": "native.android.fcd38b57e71b0a44"
+      "id": "native.android.d6b7f86564ac3147"
     },
     {
       "kind": "conditional-branch",
@@ -7127,7 +7127,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: Realtime provider closed: $reason",
       "surface": "android",
-      "id": "native.android.508073ba8ce8dbab"
+      "id": "native.android.eb6ac739ad55e63a"
     },
     {
       "kind": "conditional-branch",
@@ -7135,7 +7135,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Aborted",
       "surface": "android",
-      "id": "native.android.a052faac05102427"
+      "id": "native.android.13531fe081a45711"
     },
     {
       "kind": "conditional-branch",
@@ -7143,7 +7143,7 @@
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Chat error",
       "surface": "android",
-      "id": "native.android.d74e945c050d1270"
+      "id": "native.android.42af8acef7e61a34"
     },
     {
       "kind": "resource-item",
@@ -7151,7 +7151,7 @@
       "path": "apps/android/app/src/main/res/values/assistant.xml",
       "source": "ask OpenClaw $prompt",
       "surface": "android",
-      "id": "native.android.1c8204beac579400"
+      "id": "native.android.f392ee2d50d6b7ce"
     },
     {
       "kind": "resource-item",
@@ -7159,7 +7159,7 @@
       "path": "apps/android/app/src/main/res/values/assistant.xml",
       "source": "tell OpenClaw to $prompt",
       "surface": "android",
-      "id": "native.android.5e6a4cdb1a3396b4"
+      "id": "native.android.ea9d1a78cfa13033"
     },
     {
       "kind": "resource-item",
@@ -7167,7 +7167,7 @@
       "path": "apps/android/app/src/main/res/values/assistant.xml",
       "source": "open OpenClaw and ask $prompt",
       "surface": "android",
-      "id": "native.android.955cf25f83e27ddf"
+      "id": "native.android.7f96ac9b9e10abd0"
     },
     {
       "kind": "resource-string",
@@ -7175,7 +7175,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "OpenClaw Node",
       "surface": "android",
-      "id": "native.android.0896dd39a15d179c"
+      "id": "native.android.a3c395b04ae7a621"
     },
     {
       "kind": "resource-string",
@@ -7183,7 +7183,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Trust this gateway?",
       "surface": "android",
-      "id": "native.android.c2ad57046ba6ec63"
+      "id": "native.android.cd32b06480d9bb69"
     },
     {
       "kind": "resource-string",
@@ -7191,7 +7191,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Trust and continue",
       "surface": "android",
-      "id": "native.android.da307d07e759a49c"
+      "id": "native.android.402c9af5ba395caf"
     },
     {
       "kind": "resource-string",
@@ -7199,7 +7199,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Cancel",
       "surface": "android",
-      "id": "native.android.9f4bb5310986e12a"
+      "id": "native.android.bc749f6034799c2e"
     },
     {
       "kind": "resource-string",
@@ -7207,7 +7207,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "New chat in worktree",
       "surface": "android",
-      "id": "native.android.ec5b929bd9e4e691"
+      "id": "native.android.88d68890ea867ffc"
     },
     {
       "kind": "resource-string",
@@ -7215,7 +7215,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Verify the certificate fingerprint before trusting this gateway.\n\n%1$s",
       "surface": "android",
-      "id": "native.android.795c1befed52cda1"
+      "id": "native.android.288b83f93172c633"
     },
     {
       "kind": "resource-string",
@@ -7223,7 +7223,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "surface": "android",
-      "id": "native.android.a1a61798ee1fbb0c"
+      "id": "native.android.6ad2d3f084142bed"
     },
     {
       "kind": "resource-string",
@@ -7231,7 +7231,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Unknown",
       "surface": "android",
-      "id": "native.android.ce9a512f967ff31b"
+      "id": "native.android.f1252c0c03619337"
     },
     {
       "kind": "resource-string",
@@ -7239,7 +7239,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "VERSION",
       "surface": "android",
-      "id": "native.android.a5f7189cdf721ca4"
+      "id": "native.android.c0b5650d8639911c"
     },
     {
       "kind": "resource-string",
@@ -7247,7 +7247,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "COMMIT",
       "surface": "android",
-      "id": "native.android.6e043b7d5cf526c1"
+      "id": "native.android.d6f7fd58d1959e6f"
     },
     {
       "kind": "resource-string",
@@ -7255,7 +7255,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "BUILT",
       "surface": "android",
-      "id": "native.android.37510143af4aa75b"
+      "id": "native.android.b28b492b48e83ad3"
     },
     {
       "kind": "resource-string",
@@ -7263,7 +7263,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Version %1$s",
       "surface": "android",
-      "id": "native.android.aba33d677f46c9d2"
+      "id": "native.android.115aa71eb2a66fb6"
     },
     {
       "kind": "resource-string",
@@ -7271,7 +7271,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Git commit %1$s",
       "surface": "android",
-      "id": "native.android.04ea7703e47e9f3a"
+      "id": "native.android.eeddd6984c0eb974"
     },
     {
       "kind": "resource-string",
@@ -7279,7 +7279,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Built %1$s UTC, timestamp %2$s",
       "surface": "android",
-      "id": "native.android.63331a879e3cccc0"
+      "id": "native.android.a253a9c122cc5871"
     },
     {
       "kind": "resource-string",
@@ -7287,7 +7287,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Build date %1$s",
       "surface": "android",
-      "id": "native.android.941fcaadbe5408e0"
+      "id": "native.android.e2d234b2ea956a77"
     },
     {
       "kind": "resource-string",
@@ -7295,7 +7295,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Copy full Git commit hash",
       "surface": "android",
-      "id": "native.android.ad691cc437cb8853"
+      "id": "native.android.eaf3c88646e35cab"
     },
     {
       "kind": "resource-string",
@@ -7303,7 +7303,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Copy full build timestamp",
       "surface": "android",
-      "id": "native.android.5a1fef71971ff3b0"
+      "id": "native.android.d869a719216054b8"
     },
     {
       "kind": "resource-string",
@@ -7311,7 +7311,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "OpenClaw Git commit",
       "surface": "android",
-      "id": "native.android.f9df2e488784cea9"
+      "id": "native.android.e3661fcea979a74c"
     },
     {
       "kind": "resource-string",
@@ -7319,7 +7319,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "OpenClaw build timestamp",
       "surface": "android",
-      "id": "native.android.b8a8b10e70efee90"
+      "id": "native.android.a610564c863cdef7"
     },
     {
       "kind": "resource-string",
@@ -7327,7 +7327,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Git commit copied",
       "surface": "android",
-      "id": "native.android.9b58b180900f5f21"
+      "id": "native.android.9b9a42b4f56bea2a"
     },
     {
       "kind": "resource-string",
@@ -7335,7 +7335,7 @@
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Build timestamp copied",
       "surface": "android",
-      "id": "native.android.22b65d6917035a20"
+      "id": "native.android.6a0c0b0dc97333fe"
     },
     {
       "kind": "plist-string",
@@ -7343,7 +7343,7 @@
       "path": "apps/ios/ActivityWidget/Info.plist",
       "source": "OpenClaw Activity",
       "surface": "apple",
-      "id": "native.apple.77e1b76264f6e734"
+      "id": "native.apple.8f741d09cc1d5495"
     },
     {
       "kind": "ui-call",
@@ -7351,7 +7351,7 @@
       "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
       "source": "OpenClaw",
       "surface": "apple",
-      "id": "native.apple.767a39dadf2f332a"
+      "id": "native.apple.86d546e1f1247028"
     },
     {
       "kind": "plist-string",
@@ -7359,7 +7359,7 @@
       "path": "apps/ios/ShareExtension/Info.plist",
       "source": "OpenClaw Share",
       "surface": "apple",
-      "id": "native.apple.0efe0a6cd715517f"
+      "id": "native.apple.9168fcd110c3019a"
     },
     {
       "kind": "conditional-branch",
@@ -7375,7 +7375,7 @@
       "path": "apps/ios/Sources/Camera/CameraController.swift",
       "source": "Camera",
       "surface": "apple",
-      "id": "native.apple.d2f42e4947258847"
+      "id": "native.apple.23834d0ff7589921"
     },
     {
       "kind": "conditional-branch",
@@ -7383,7 +7383,7 @@
       "path": "apps/ios/Sources/Camera/CameraController.swift",
       "source": "Microphone",
       "surface": "apple",
-      "id": "native.apple.cf938712869b588d"
+      "id": "native.apple.9c73bf4bd647d298"
     },
     {
       "kind": "conditional-branch",
@@ -7399,7 +7399,7 @@
       "path": "apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift",
       "source": "that request",
       "surface": "apple",
-      "id": "native.apple.9ae16535e59ef8de"
+      "id": "native.apple.a811eb3e4d2174d5"
     },
     {
       "kind": "ui-named-argument",
@@ -7407,7 +7407,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Promoted Entries",
       "surface": "apple",
-      "id": "native.apple.51431f85d6a50322"
+      "id": "native.apple.6507fad2526215fc"
     },
     {
       "kind": "ui-named-argument",
@@ -7415,7 +7415,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "No promoted entries",
       "surface": "apple",
-      "id": "native.apple.5e974464e65728ab"
+      "id": "native.apple.7e73f233a79a8007"
     },
     {
       "kind": "ui-named-argument",
@@ -7423,7 +7423,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Dreaming has not promoted durable memory entries yet.",
       "surface": "apple",
-      "id": "native.apple.92587ce949bbbbe1"
+      "id": "native.apple.e20c6da13995b769"
     },
     {
       "kind": "ui-named-argument",
@@ -7431,7 +7431,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Signal Entries",
       "surface": "apple",
-      "id": "native.apple.f3d75171719dce87"
+      "id": "native.apple.f37dc8d03ad70555"
     },
     {
       "kind": "ui-named-argument",
@@ -7439,7 +7439,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "No signal entries",
       "surface": "apple",
-      "id": "native.apple.7e6152828d5363c5"
+      "id": "native.apple.2802710c41f25f87"
     },
     {
       "kind": "ui-named-argument",
@@ -7447,7 +7447,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "No recent recall, daily, grounded, or phase signals were reported.",
       "surface": "apple",
-      "id": "native.apple.9da02020361eb35b"
+      "id": "native.apple.2665e709446f3510"
     },
     {
       "kind": "ui-named-argument",
@@ -7455,7 +7455,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Short-Term Recall",
       "surface": "apple",
-      "id": "native.apple.3fa5573b7ed1013c"
+      "id": "native.apple.188e21c57debe55d"
     },
     {
       "kind": "ui-named-argument",
@@ -7463,7 +7463,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "No short-term entries",
       "surface": "apple",
-      "id": "native.apple.e16abefdccd7168e"
+      "id": "native.apple.da521f32f4d1b56d"
     },
     {
       "kind": "ui-named-argument",
@@ -7471,7 +7471,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "The short-term dreaming store is empty.",
       "surface": "apple",
-      "id": "native.apple.2f54677eed397b9a"
+      "id": "native.apple.3533db79b1ce15b2"
     },
     {
       "kind": "ui-named-argument",
@@ -7479,7 +7479,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Dreaming",
       "surface": "apple",
-      "id": "native.apple.b8c0aec8efcb198c"
+      "id": "native.apple.66facc5ade07c85d"
     },
     {
       "kind": "conditional-branch",
@@ -7487,7 +7487,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Backfill",
       "surface": "apple",
-      "id": "native.apple.40a661e3dff0953d"
+      "id": "native.apple.db33016dc3f5171e"
     },
     {
       "kind": "conditional-branch",
@@ -7495,7 +7495,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Repair",
       "surface": "apple",
-      "id": "native.apple.9b35a13ad5fff363"
+      "id": "native.apple.ae45153f28d9cf2a"
     },
     {
       "kind": "conditional-branch",
@@ -7503,7 +7503,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Dedupe",
       "surface": "apple",
-      "id": "native.apple.980a4259e40ce99c"
+      "id": "native.apple.dace92af637733b7"
     },
     {
       "kind": "ui-call",
@@ -7511,7 +7511,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Memory State",
       "surface": "apple",
-      "id": "native.apple.000658bd55f9813c"
+      "id": "native.apple.7d9b95f78347a27a"
     },
     {
       "kind": "ui-named-argument",
@@ -7519,7 +7519,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Short-term",
       "surface": "apple",
-      "id": "native.apple.8dd008a25a37d79f"
+      "id": "native.apple.fdd09340ada60b38"
     },
     {
       "kind": "ui-named-argument",
@@ -7527,7 +7527,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Signals",
       "surface": "apple",
-      "id": "native.apple.3f92dbe8d17a10ce"
+      "id": "native.apple.36e11955fdfc44ce"
     },
     {
       "kind": "ui-named-argument",
@@ -7535,7 +7535,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Promoted",
       "surface": "apple",
-      "id": "native.apple.fc528817dc32cf70"
+      "id": "native.apple.eac7739027672f59"
     },
     {
       "kind": "ui-call",
@@ -7543,7 +7543,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Maintenance",
       "surface": "apple",
-      "id": "native.apple.9e7eb42044221e88"
+      "id": "native.apple.f880ca9213d28fc5"
     },
     {
       "kind": "ui-call",
@@ -7551,7 +7551,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Refresh reads live state. Maintenance actions update the gateway diary/artifacts.",
       "surface": "apple",
-      "id": "native.apple.57bb1ed1677bb994"
+      "id": "native.apple.6c3fd9dc73e28915"
     },
     {
       "kind": "ui-modifier",
@@ -7559,7 +7559,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Refresh dreaming",
       "surface": "apple",
-      "id": "native.apple.c9dc489c933640d3"
+      "id": "native.apple.3b974332d3bb23be"
     },
     {
       "kind": "ui-named-argument",
@@ -7567,7 +7567,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Dream Diary",
       "surface": "apple",
-      "id": "native.apple.bbb58365e349332b"
+      "id": "native.apple.cfa8f0184b619533"
     },
     {
       "kind": "ui-named-argument",
@@ -7575,7 +7575,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "No day entries",
       "surface": "apple",
-      "id": "native.apple.73d1a8ff30991be4"
+      "id": "native.apple.825726d0205d5bd4"
     },
     {
       "kind": "ui-named-argument",
@@ -7583,7 +7583,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "The diary is present, but it does not contain dated Dream Diary blocks.",
       "surface": "apple",
-      "id": "native.apple.738a1138025d94fa"
+      "id": "native.apple.ab19be5a9d08b82e"
     },
     {
       "kind": "conditional-branch",
@@ -7591,7 +7591,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Dream diary is empty",
       "surface": "apple",
-      "id": "native.apple.263550d57ff17055"
+      "id": "native.apple.0dbb5d2148a696d3"
     },
     {
       "kind": "conditional-branch",
@@ -7599,7 +7599,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "No dream diary yet",
       "surface": "apple",
-      "id": "native.apple.1ebe616a41aec86a"
+      "id": "native.apple.875fab1238950ad0"
     },
     {
       "kind": "conditional-branch",
@@ -7607,7 +7607,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "\\(diary.path) exists but has no readable content.",
       "surface": "apple",
-      "id": "native.apple.46ee8fce8d8039f9"
+      "id": "native.apple.bb7c4a8dbc801a19"
     },
     {
       "kind": "conditional-branch",
@@ -7615,7 +7615,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "The gateway did not find DREAMS.md or dreams.md in the active agent workspace.",
       "surface": "apple",
-      "id": "native.apple.74c5daff400e35b5"
+      "id": "native.apple.a6a454a28f1db7df"
     },
     {
       "kind": "conditional-branch",
@@ -7623,7 +7623,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Diary unavailable",
       "surface": "apple",
-      "id": "native.apple.c29ab1ae29461af7"
+      "id": "native.apple.11ae1c140df749a6"
     },
     {
       "kind": "conditional-branch",
@@ -7631,7 +7631,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "The gateway did not return dream diary content.",
       "surface": "apple",
-      "id": "native.apple.d6e2bd333d7d674e"
+      "id": "native.apple.6f80c38b0b83c057"
     },
     {
       "kind": "conditional-branch",
@@ -7639,7 +7639,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Connect a gateway to read dream diary entries.",
       "surface": "apple",
-      "id": "native.apple.7a4c4b7574021a26"
+      "id": "native.apple.e9772e2a1bbfb483"
     },
     {
       "kind": "ui-modifier",
@@ -7647,7 +7647,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Dream diary day",
       "surface": "apple",
-      "id": "native.apple.f2ad889bcd3e37c0"
+      "id": "native.apple.95300e4dfd7aad42"
     },
     {
       "kind": "ui-named-argument",
@@ -7655,7 +7655,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Connect a gateway to load dreaming entries.",
       "surface": "apple",
-      "id": "native.apple.0f010e53712cab1f"
+      "id": "native.apple.f0df95f0790fe675"
     },
     {
       "kind": "ui-call",
@@ -7663,7 +7663,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "\\(entry.totalSignalCount)",
       "surface": "apple",
-      "id": "native.apple.f7207b4c80fe1954"
+      "id": "native.apple.32c1207f3fb0ea37"
     },
     {
       "kind": "ui-named-argument",
@@ -7671,7 +7671,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Phases",
       "surface": "apple",
-      "id": "native.apple.43fb7f0ef002147a"
+      "id": "native.apple.bc3cd66fe555c668"
     },
     {
       "kind": "conditional-branch",
@@ -7679,7 +7679,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Dreaming unavailable",
       "surface": "apple",
-      "id": "native.apple.99c4bd24dd165855"
+      "id": "native.apple.d6c5aa460338b9b5"
     },
     {
       "kind": "conditional-branch",
@@ -7687,7 +7687,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "No phase status",
       "surface": "apple",
-      "id": "native.apple.e81afdfd72780d3a"
+      "id": "native.apple.cbfc7159dd411b7c"
     },
     {
       "kind": "conditional-branch",
@@ -7695,7 +7695,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "The gateway did not return dreaming phase details.",
       "surface": "apple",
-      "id": "native.apple.7ce717ec7320c926"
+      "id": "native.apple.128c6782a7b1d919"
     },
     {
       "kind": "conditional-branch",
@@ -7703,7 +7703,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "Connect a gateway to load dreaming phases.",
       "surface": "apple",
-      "id": "native.apple.e561c276882bed72"
+      "id": "native.apple.3ce988bd2b2215b2"
     },
     {
       "kind": "conditional-branch",
@@ -7711,7 +7711,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "artifacts repaired",
       "surface": "apple",
-      "id": "native.apple.2e2540e53a7dec77"
+      "id": "native.apple.95e346b05c4acf8a"
     },
     {
       "kind": "conditional-branch",
@@ -7719,7 +7719,7 @@
       "path": "apps/ios/Sources/Design/AgentProDreamingDestination.swift",
       "source": "no repair needed",
       "surface": "apple",
-      "id": "native.apple.47cb2f87524c4855"
+      "id": "native.apple.da9b0546b320aa00"
     },
     {
       "kind": "conditional-branch",
@@ -7743,7 +7743,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Instances",
       "surface": "apple",
-      "id": "native.apple.861659224ffe3946"
+      "id": "native.apple.d6d76334ab8bbf86"
     },
     {
       "kind": "ui-call",
@@ -7751,7 +7751,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Presence",
       "surface": "apple",
-      "id": "native.apple.da1c869363d9d87b"
+      "id": "native.apple.c0a8f74751fe7761"
     },
     {
       "kind": "ui-named-argument",
@@ -7759,7 +7759,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Connected",
       "surface": "apple",
-      "id": "native.apple.5028affd069d47f5"
+      "id": "native.apple.d38e2bcc42b99a32"
     },
     {
       "kind": "ui-named-argument",
@@ -7767,7 +7767,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Agents",
       "surface": "apple",
-      "id": "native.apple.123d21c3987542ac"
+      "id": "native.apple.880e2ddd260c7c2e"
     },
     {
       "kind": "ui-named-argument",
@@ -7775,7 +7775,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Gateway",
       "surface": "apple",
-      "id": "native.apple.36ee6e32243e2626"
+      "id": "native.apple.cddd5f7fef6839af"
     },
     {
       "kind": "ui-named-argument",
@@ -7783,7 +7783,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Connected Instances",
       "surface": "apple",
-      "id": "native.apple.49198f034c45cb0c"
+      "id": "native.apple.9a1211ec7db72f53"
     },
     {
       "kind": "conditional-branch",
@@ -7791,7 +7791,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Instances unavailable",
       "surface": "apple",
-      "id": "native.apple.af23bba33bb3065c"
+      "id": "native.apple.19c05f4f4cc76646"
     },
     {
       "kind": "conditional-branch",
@@ -7799,7 +7799,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "No instances connected",
       "surface": "apple",
-      "id": "native.apple.48eb8340063b9662"
+      "id": "native.apple.c43a5621c65fe121"
     },
     {
       "kind": "conditional-branch",
@@ -7807,7 +7807,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "The gateway did not report any system presence entries.",
       "surface": "apple",
-      "id": "native.apple.17517f53b8e7671d"
+      "id": "native.apple.26327e8fdd0a869b"
     },
     {
       "kind": "conditional-branch",
@@ -7815,7 +7815,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Connect a gateway to inspect connected instances.",
       "surface": "apple",
-      "id": "native.apple.da5ee25bd3e2b34a"
+      "id": "native.apple.36618248cdaccc84"
     },
     {
       "kind": "ui-call",
@@ -7823,7 +7823,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Instance",
       "surface": "apple",
-      "id": "native.apple.a17b90e197cd6ee8"
+      "id": "native.apple.e51fe4f1d2c94caa"
     },
     {
       "kind": "ui-call",
@@ -7831,7 +7831,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Device",
       "surface": "apple",
-      "id": "native.apple.630236487eac5955"
+      "id": "native.apple.7450caafbc4c4905"
     },
     {
       "kind": "ui-call",
@@ -7839,7 +7839,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Host",
       "surface": "apple",
-      "id": "native.apple.605f959bbe99502e"
+      "id": "native.apple.918d896da8c9690b"
     },
     {
       "kind": "ui-call",
@@ -7847,7 +7847,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "IP",
       "surface": "apple",
-      "id": "native.apple.9ab7b45d47e0cb9a"
+      "id": "native.apple.2f6eab7cb6d67e11"
     },
     {
       "kind": "ui-call",
@@ -7855,7 +7855,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Platform",
       "surface": "apple",
-      "id": "native.apple.59ab35d009d04e75"
+      "id": "native.apple.8b827c9e2747230b"
     },
     {
       "kind": "ui-call",
@@ -7863,7 +7863,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Version",
       "surface": "apple",
-      "id": "native.apple.8e2c90f81fb2513c"
+      "id": "native.apple.78ed7a935ffced12"
     },
     {
       "kind": "ui-call",
@@ -7871,7 +7871,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Mode",
       "surface": "apple",
-      "id": "native.apple.b0d1373614cb2e3e"
+      "id": "native.apple.752a753f245e5ca4"
     },
     {
       "kind": "ui-named-argument",
@@ -7879,7 +7879,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Scopes",
       "surface": "apple",
-      "id": "native.apple.cf12fe3c768f5014"
+      "id": "native.apple.cef6a48e33c99f34"
     },
     {
       "kind": "ui-named-argument",
@@ -7887,7 +7887,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Roles",
       "surface": "apple",
-      "id": "native.apple.0831cf5d331ce83b"
+      "id": "native.apple.4f46ad7f7a534bdf"
     },
     {
       "kind": "ui-named-argument",
@@ -7895,7 +7895,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Tags",
       "surface": "apple",
-      "id": "native.apple.a79122d8afaf8611"
+      "id": "native.apple.9d5774d05481002d"
     },
     {
       "kind": "ui-modifier",
@@ -7903,7 +7903,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "Copy \\(title)",
       "surface": "apple",
-      "id": "native.apple.2e909de6981dc60b"
+      "id": "native.apple.4b2a40c2512edb6b"
     },
     {
       "kind": "ui-call",
@@ -7911,7 +7911,7 @@
       "path": "apps/ios/Sources/Design/AgentProNodesDestination.swift",
       "source": "None reported.",
       "surface": "apple",
-      "id": "native.apple.c899ccbdb4502d5f"
+      "id": "native.apple.e9c4662a91a0188e"
     },
     {
       "kind": "conditional-branch",
@@ -7935,7 +7935,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Cron.swift",
       "source": "Scheduler",
       "surface": "apple",
-      "id": "native.apple.67531bb640a736cb"
+      "id": "native.apple.828de90d8dfed4ad"
     },
     {
       "kind": "ui-named-argument",
@@ -7943,7 +7943,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Cron.swift",
       "source": "Next",
       "surface": "apple",
-      "id": "native.apple.649494049a94f494"
+      "id": "native.apple.982637a16129712e"
     },
     {
       "kind": "ui-named-argument",
@@ -7951,7 +7951,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Cron.swift",
       "source": "Jobs",
       "surface": "apple",
-      "id": "native.apple.8fcff357f5dd43e9"
+      "id": "native.apple.265fe9a6fd48774a"
     },
     {
       "kind": "ui-call",
@@ -7959,7 +7959,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Cron.swift",
       "source": "Run",
       "surface": "apple",
-      "id": "native.apple.afc05f80e48e5dc0"
+      "id": "native.apple.e8964650f824c877"
     },
     {
       "kind": "conditional-branch",
@@ -7967,7 +7967,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Cron.swift",
       "source": "Enable",
       "surface": "apple",
-      "id": "native.apple.feef8c1e76736990"
+      "id": "native.apple.7a755374bfce2d24"
     },
     {
       "kind": "conditional-branch",
@@ -7975,7 +7975,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Cron.swift",
       "source": "Pause",
       "surface": "apple",
-      "id": "native.apple.3a8ea51b4ddf2309"
+      "id": "native.apple.85e60d2e562e3d2b"
     },
     {
       "kind": "conditional-branch",
@@ -7983,7 +7983,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Cron.swift",
       "source": "Enabled \\(job.name).",
       "surface": "apple",
-      "id": "native.apple.a97c2ca7a1926fbc"
+      "id": "native.apple.5c9bbc2dc26712ef"
     },
     {
       "kind": "conditional-branch",
@@ -7991,7 +7991,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Cron.swift",
       "source": "Paused \\(job.name).",
       "surface": "apple",
-      "id": "native.apple.4a98c9d99b13dc36"
+      "id": "native.apple.8658a6a0ee787fc3"
     },
     {
       "kind": "ui-named-argument",
@@ -7999,7 +7999,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Destinations.swift",
       "source": "Search agents",
       "surface": "apple",
-      "id": "native.apple.88ac71979fd62d9a"
+      "id": "native.apple.a373bf2332f0ab6a"
     },
     {
       "kind": "ui-named-argument",
@@ -8007,7 +8007,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Destinations.swift",
       "source": "Skills",
       "surface": "apple",
-      "id": "native.apple.a21ddaeb799ac71c"
+      "id": "native.apple.929053bc7d51b98f"
     },
     {
       "kind": "ui-named-argument",
@@ -8015,7 +8015,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Destinations.swift",
       "source": "Cron Jobs",
       "surface": "apple",
-      "id": "native.apple.1ce66a071588b402"
+      "id": "native.apple.45c3f045dd9a3507"
     },
     {
       "kind": "ui-named-argument",
@@ -8023,7 +8023,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Destinations.swift",
       "source": "Usage",
       "surface": "apple",
-      "id": "native.apple.63a1b3f7555ca4ac"
+      "id": "native.apple.4bee0220d011ab53"
     },
     {
       "kind": "conditional-branch",
@@ -8039,7 +8039,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+GatewayData.swift",
       "source": "Online",
       "surface": "apple",
-      "id": "native.apple.a3c09040677501c7"
+      "id": "native.apple.5fbed24f057edea8"
     },
     {
       "kind": "conditional-branch",
@@ -8047,7 +8047,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+GatewayData.swift",
       "source": "Ready",
       "surface": "apple",
-      "id": "native.apple.85d1c890206ae780"
+      "id": "native.apple.f1958c5f0d880a4a"
     },
     {
       "kind": "conditional-branch",
@@ -8055,7 +8055,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+GatewayData.swift",
       "source": "Not selected",
       "surface": "apple",
-      "id": "native.apple.d7f2facb78d38216"
+      "id": "native.apple.056ac76b75d6795d"
     },
     {
       "kind": "conditional-branch",
@@ -8063,7 +8063,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+GatewayData.swift",
       "source": "Selected",
       "surface": "apple",
-      "id": "native.apple.eedd6be1eba18105"
+      "id": "native.apple.c29b4a63fb797a83"
     },
     {
       "kind": "ui-named-argument",
@@ -8071,7 +8071,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "\\(self.sortedAgents.count) total",
       "surface": "apple",
-      "id": "native.apple.e85a7435bf6e94b6"
+      "id": "native.apple.6992ddf119f4d920"
     },
     {
       "kind": "ui-named-argument",
@@ -8079,7 +8079,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Search agents",
       "surface": "apple",
-      "id": "native.apple.0c34680726baafe0"
+      "id": "native.apple.5ee1fa5a66b2d846"
     },
     {
       "kind": "ui-modifier",
@@ -8087,7 +8087,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Clear filters",
       "surface": "apple",
-      "id": "native.apple.dbf80973ff5965e7"
+      "id": "native.apple.5cc5151b7946d32e"
     },
     {
       "kind": "ui-call",
@@ -8095,7 +8095,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Agent status",
       "surface": "apple",
-      "id": "native.apple.dd558c53b47eabc6"
+      "id": "native.apple.23ed9b5b0d1721d3"
     },
     {
       "kind": "ui-call",
@@ -8103,7 +8103,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Clear Filters",
       "surface": "apple",
-      "id": "native.apple.752fc7d9a9aa4d3d"
+      "id": "native.apple.a254ffbe0cd16f72"
     },
     {
       "kind": "ui-call",
@@ -8111,7 +8111,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Filter agents",
       "surface": "apple",
-      "id": "native.apple.c5ca90a58f6873bd"
+      "id": "native.apple.5648148ca9be82bc"
     },
     {
       "kind": "conditional-branch",
@@ -8119,7 +8119,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Gateway offline",
       "surface": "apple",
-      "id": "native.apple.507ad2de5cadd6c7"
+      "id": "native.apple.0938c66b5382e9b5"
     },
     {
       "kind": "conditional-branch",
@@ -8127,7 +8127,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Gateway online",
       "surface": "apple",
-      "id": "native.apple.0ea7a2c36b62c588"
+      "id": "native.apple.6f0aae58035253c8"
     },
     {
       "kind": "ui-modifier",
@@ -8135,7 +8135,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Opens Settings / Gateway",
       "surface": "apple",
-      "id": "native.apple.dfdca8006a06d277"
+      "id": "native.apple.9c45abb65d0ba8f3"
     },
     {
       "kind": "ui-named-argument",
@@ -8143,7 +8143,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Live Operations",
       "surface": "apple",
-      "id": "native.apple.1c12532d35337068"
+      "id": "native.apple.c50e3ea900992af2"
     },
     {
       "kind": "ui-named-argument",
@@ -8151,7 +8151,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Skills",
       "surface": "apple",
-      "id": "native.apple.5234d372d85277ce"
+      "id": "native.apple.297d31f435acc655"
     },
     {
       "kind": "ui-named-argument",
@@ -8159,7 +8159,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Instances",
       "surface": "apple",
-      "id": "native.apple.620a63341e9932b8"
+      "id": "native.apple.74ac93726c9730d4"
     },
     {
       "kind": "ui-named-argument",
@@ -8167,7 +8167,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Cron",
       "surface": "apple",
-      "id": "native.apple.3f3d44e92b010179"
+      "id": "native.apple.0648f34212e23f0b"
     },
     {
       "kind": "ui-named-argument",
@@ -8175,7 +8175,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Usage",
       "surface": "apple",
-      "id": "native.apple.30b328e340643aff"
+      "id": "native.apple.1e10dc4a13db5f3f"
     },
     {
       "kind": "ui-named-argument",
@@ -8183,7 +8183,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Files",
       "surface": "apple",
-      "id": "native.apple.d323532b955ce413"
+      "id": "native.apple.f48d33a93f53ae56"
     },
     {
       "kind": "ui-named-argument",
@@ -8191,7 +8191,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Workspace files",
       "surface": "apple",
-      "id": "native.apple.a478055bcc7801b1"
+      "id": "native.apple.b84aa382768fe819"
     },
     {
       "kind": "ui-named-argument",
@@ -8199,7 +8199,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Dreaming",
       "surface": "apple",
-      "id": "native.apple.dc13598070d11e61"
+      "id": "native.apple.98306aca23d04451"
     },
     {
       "kind": "ui-named-argument",
@@ -8207,7 +8207,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Scheduled Work",
       "surface": "apple",
-      "id": "native.apple.03471f7487610989"
+      "id": "native.apple.4999264d74844f21"
     },
     {
       "kind": "conditional-branch",
@@ -8215,7 +8215,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Selected agent",
       "surface": "apple",
-      "id": "native.apple.7eba9e55d31d84ef"
+      "id": "native.apple.13245a5075869f14"
     },
     {
       "kind": "conditional-branch",
@@ -8223,7 +8223,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Selects this agent",
       "surface": "apple",
-      "id": "native.apple.9472b8bd11e03486"
+      "id": "native.apple.ae9101fc699ad5f8"
     },
     {
       "kind": "conditional-branch",
@@ -8231,7 +8231,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Cron unavailable",
       "surface": "apple",
-      "id": "native.apple.539213cfdc023cd1"
+      "id": "native.apple.e347d159f30bca34"
     },
     {
       "kind": "conditional-branch",
@@ -8239,7 +8239,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "No scheduled jobs",
       "surface": "apple",
-      "id": "native.apple.11121bef4b7d0613"
+      "id": "native.apple.4f053bb46f35a802"
     },
     {
       "kind": "conditional-branch",
@@ -8247,7 +8247,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "The gateway has no visible cron jobs.",
       "surface": "apple",
-      "id": "native.apple.42278c9b95e4465b"
+      "id": "native.apple.0cd04bacdbcd8fa5"
     },
     {
       "kind": "conditional-branch",
@@ -8255,7 +8255,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Connect a gateway to load scheduled work.",
       "surface": "apple",
-      "id": "native.apple.d7e375e66c36d701"
+      "id": "native.apple.ae4aa2339b285164"
     },
     {
       "kind": "conditional-branch",
@@ -8263,7 +8263,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Loading skill status.",
       "surface": "apple",
-      "id": "native.apple.b51fbc49b1e180a9"
+      "id": "native.apple.13e776bd20f1df1c"
     },
     {
       "kind": "conditional-branch",
@@ -8271,7 +8271,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Skill status is available from the gateway.",
       "surface": "apple",
-      "id": "native.apple.4da7a5333f98a6f1"
+      "id": "native.apple.13f557aa09fe87ca"
     },
     {
       "kind": "conditional-branch",
@@ -8279,7 +8279,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Instance presence is available.",
       "surface": "apple",
-      "id": "native.apple.e71d8e35138a31ed"
+      "id": "native.apple.6276902cd4fe942d"
     },
     {
       "kind": "conditional-branch",
@@ -8287,7 +8287,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Loading instance presence.",
       "surface": "apple",
-      "id": "native.apple.7d72d4fadf0deadb"
+      "id": "native.apple.30b12adf015466a3"
     },
     {
       "kind": "conditional-branch",
@@ -8295,7 +8295,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "\\(cronStatus.jobs)",
       "surface": "apple",
-      "id": "native.apple.698e5dacdc928825"
+      "id": "native.apple.2beba7d892331495"
     },
     {
       "kind": "conditional-branch",
@@ -8303,7 +8303,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Cron status is available.",
       "surface": "apple",
-      "id": "native.apple.a95a7611cd576918"
+      "id": "native.apple.f0d3f77e976e0392"
     },
     {
       "kind": "conditional-branch",
@@ -8311,7 +8311,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Loading cron status.",
       "surface": "apple",
-      "id": "native.apple.7449f78a2c9082ad"
+      "id": "native.apple.a08cca83d5753d7b"
     },
     {
       "kind": "conditional-branch",
@@ -8319,7 +8319,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Scheduler disabled",
       "surface": "apple",
-      "id": "native.apple.e692a306f562ede8"
+      "id": "native.apple.2f89185965cb4c09"
     },
     {
       "kind": "conditional-branch",
@@ -8327,7 +8327,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Scheduler enabled",
       "surface": "apple",
-      "id": "native.apple.bd5e4b50050f3b71"
+      "id": "native.apple.59cb26a37071e5b8"
     },
     {
       "kind": "conditional-branch",
@@ -8335,7 +8335,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Loading recent usage.",
       "surface": "apple",
-      "id": "native.apple.cd78344554d0cdc3"
+      "id": "native.apple.c3ebef43c447e296"
     },
     {
       "kind": "conditional-branch",
@@ -8343,7 +8343,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Recent usage is available.",
       "surface": "apple",
-      "id": "native.apple.1d7435a25bfc4e6f"
+      "id": "native.apple.4f650e85964e9585"
     },
     {
       "kind": "conditional-branch",
@@ -8351,7 +8351,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Background memory status is available.",
       "surface": "apple",
-      "id": "native.apple.7ab4c593017ca9c5"
+      "id": "native.apple.524a87549db68abc"
     },
     {
       "kind": "conditional-branch",
@@ -8359,7 +8359,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Overview.swift",
       "source": "Loading dreaming status.",
       "surface": "apple",
-      "id": "native.apple.4ce484b622fe69d3"
+      "id": "native.apple.9b141e37ef320c38"
     },
     {
       "kind": "conditional-branch",
@@ -8367,7 +8367,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "\\(self.agentSkillFilter?.count ?? 0)",
       "surface": "apple",
-      "id": "native.apple.8643941f2bbcd0f5"
+      "id": "native.apple.79e92dff90eb58d0"
     },
     {
       "kind": "ui-call",
@@ -8375,7 +8375,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Enable All",
       "surface": "apple",
-      "id": "native.apple.905151f59396a34f"
+      "id": "native.apple.78806bca85333d64"
     },
     {
       "kind": "ui-call",
@@ -8383,7 +8383,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Disable All",
       "surface": "apple",
-      "id": "native.apple.ba8b14c32feaeff5"
+      "id": "native.apple.f3262359a64b27b1"
     },
     {
       "kind": "ui-call",
@@ -8391,7 +8391,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Reset",
       "surface": "apple",
-      "id": "native.apple.42d7da7551988f08"
+      "id": "native.apple.d9ba2e8c076bcb15"
     },
     {
       "kind": "ui-call",
@@ -8399,7 +8399,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Search skills",
       "surface": "apple",
-      "id": "native.apple.eb5c0b2bb09fac9d"
+      "id": "native.apple.6cf10999f4618500"
     },
     {
       "kind": "ui-call",
@@ -8407,7 +8407,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Status",
       "surface": "apple",
-      "id": "native.apple.cb6a56e6eee1dd09"
+      "id": "native.apple.c8f32d85993b1de0"
     },
     {
       "kind": "ui-call",
@@ -8415,7 +8415,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Install Skills",
       "surface": "apple",
-      "id": "native.apple.57ac4444a4727ecb"
+      "id": "native.apple.248f9e1ad5721249"
     },
     {
       "kind": "ui-call",
@@ -8423,7 +8423,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Search ClawHub and install into this workspace.",
       "surface": "apple",
-      "id": "native.apple.278a520abb2c5fd2"
+      "id": "native.apple.c3d3c59138c22954"
     },
     {
       "kind": "ui-call",
@@ -8431,7 +8431,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Search ClawHub",
       "surface": "apple",
-      "id": "native.apple.6a3103226f57ca6f"
+      "id": "native.apple.efcb886f500e918d"
     },
     {
       "kind": "ui-modifier",
@@ -8439,7 +8439,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Install \\(result.displayName)",
       "surface": "apple",
-      "id": "native.apple.353ee249b86146b9"
+      "id": "native.apple.a46408193c7d93e8"
     },
     {
       "kind": "ui-named-argument",
@@ -8447,7 +8447,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Installed Skills",
       "surface": "apple",
-      "id": "native.apple.74122e404098636e"
+      "id": "native.apple.b11c71227fc1e5fd"
     },
     {
       "kind": "conditional-branch",
@@ -8455,7 +8455,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "No skills found",
       "surface": "apple",
-      "id": "native.apple.a0122155cb108c7d"
+      "id": "native.apple.76c00eaca8702b59"
     },
     {
       "kind": "conditional-branch",
@@ -8463,7 +8463,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Skills unavailable",
       "surface": "apple",
-      "id": "native.apple.2673c591e9cd0817"
+      "id": "native.apple.ed2e16466b28e4e1"
     },
     {
       "kind": "conditional-branch",
@@ -8471,7 +8471,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Try a different search or refresh from the gateway.",
       "surface": "apple",
-      "id": "native.apple.baaef0e314088d72"
+      "id": "native.apple.698f37c66a7d9436"
     },
     {
       "kind": "conditional-branch",
@@ -8479,7 +8479,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Connect a gateway to load workspace skills.",
       "surface": "apple",
-      "id": "native.apple.47ec2c5d0809468b"
+      "id": "native.apple.37c0e98e8a49fe44"
     },
     {
       "kind": "ui-call",
@@ -8487,7 +8487,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Setup: \\(install)",
       "surface": "apple",
-      "id": "native.apple.f936e2373817f4cd"
+      "id": "native.apple.61ebcf220ca6f7f4"
     },
     {
       "kind": "ui-modifier",
@@ -8495,7 +8495,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Set up \\(skill.displayName)",
       "surface": "apple",
-      "id": "native.apple.eb076df03b4fc631"
+      "id": "native.apple.e94ab5a64ed0052b"
     },
     {
       "kind": "ui-modifier",
@@ -8503,7 +8503,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Edit \\(skill.displayName)",
       "surface": "apple",
-      "id": "native.apple.1a82788bf9b227a1"
+      "id": "native.apple.801febb8177c45d6"
     },
     {
       "kind": "ui-call",
@@ -8511,7 +8511,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Skill unavailable",
       "surface": "apple",
-      "id": "native.apple.6621df6e2d27b8f7"
+      "id": "native.apple.de59fbc2807318fc"
     },
     {
       "kind": "ui-call",
@@ -8519,7 +8519,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Return to the skills list and choose another skill.",
       "surface": "apple",
-      "id": "native.apple.bd59f4cf7d4c5a26"
+      "id": "native.apple.2e0b19585f4fec18"
     },
     {
       "kind": "ui-modifier",
@@ -8527,7 +8527,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Skill",
       "surface": "apple",
-      "id": "native.apple.e6c62703e532032c"
+      "id": "native.apple.29d82bdb73f5a551"
     },
     {
       "kind": "ui-call",
@@ -8535,7 +8535,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Close",
       "surface": "apple",
-      "id": "native.apple.b70b85f12e8f9582"
+      "id": "native.apple.8869a6b2fde070b8"
     },
     {
       "kind": "ui-call",
@@ -8543,7 +8543,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Enabled globally",
       "surface": "apple",
-      "id": "native.apple.bfc8fb9b10c1aea9"
+      "id": "native.apple.05e570a704fc1119"
     },
     {
       "kind": "ui-call",
@@ -8551,7 +8551,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "API key",
       "surface": "apple",
-      "id": "native.apple.6275e29855a11ee7"
+      "id": "native.apple.866ef51a89c50e1a"
     },
     {
       "kind": "ui-call",
@@ -8559,7 +8559,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Save key",
       "surface": "apple",
-      "id": "native.apple.4b0d877ea18086e4"
+      "id": "native.apple.339b853be8c8ea60"
     },
     {
       "kind": "ui-call",
@@ -8567,7 +8567,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Get key",
       "surface": "apple",
-      "id": "native.apple.580d729993d33480"
+      "id": "native.apple.21d8b3ce307083a7"
     },
     {
       "kind": "conditional-branch",
@@ -8575,7 +8575,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Off",
       "surface": "apple",
-      "id": "native.apple.dcb8bded6a98beff"
+      "id": "native.apple.35b53a42c15293a5"
     },
     {
       "kind": "conditional-branch",
@@ -8583,7 +8583,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "On",
       "surface": "apple",
-      "id": "native.apple.356a262e715cdedc"
+      "id": "native.apple.67b446d27dd34d9b"
     },
     {
       "kind": "ui-call",
@@ -8591,7 +8591,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Setup",
       "surface": "apple",
-      "id": "native.apple.5af1de4a58f9458f"
+      "id": "native.apple.07884c9a5b6dc1e4"
     },
     {
       "kind": "ui-call",
@@ -8599,7 +8599,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Missing: \\(missing)",
       "surface": "apple",
-      "id": "native.apple.858bbe1cc51caf7f"
+      "id": "native.apple.7c9ea375c01972ee"
     },
     {
       "kind": "ui-call",
@@ -8607,7 +8607,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "No missing requirements reported.",
       "surface": "apple",
-      "id": "native.apple.f6391f150128c160"
+      "id": "native.apple.51d5e0c708a3fa66"
     },
     {
       "kind": "ui-named-argument",
@@ -8615,7 +8615,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Key",
       "surface": "apple",
-      "id": "native.apple.199b8d809f8f3da6"
+      "id": "native.apple.453b9c34c602da10"
     },
     {
       "kind": "ui-named-argument",
@@ -8623,7 +8623,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Source",
       "surface": "apple",
-      "id": "native.apple.243421e788e78a23"
+      "id": "native.apple.470eb21dde82b914"
     },
     {
       "kind": "conditional-branch",
@@ -8631,7 +8631,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Skill policy reset.",
       "surface": "apple",
-      "id": "native.apple.42e5d30c3b5c701b"
+      "id": "native.apple.9726d2ef2c71346f"
     },
     {
       "kind": "conditional-branch",
@@ -8639,7 +8639,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Skill policy saved.",
       "surface": "apple",
-      "id": "native.apple.488d78178b4cefea"
+      "id": "native.apple.c291324b9104375f"
     },
     {
       "kind": "conditional-branch",
@@ -8647,7 +8647,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Skill disabled.",
       "surface": "apple",
-      "id": "native.apple.089235da42d8ffc8"
+      "id": "native.apple.872f785c02062877"
     },
     {
       "kind": "conditional-branch",
@@ -8655,7 +8655,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "Skill enabled.",
       "surface": "apple",
-      "id": "native.apple.4f4b9515dbcfdb6b"
+      "id": "native.apple.dd816fa90c09b604"
     },
     {
       "kind": "conditional-branch",
@@ -8663,7 +8663,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "API key cleared.",
       "surface": "apple",
-      "id": "native.apple.90af89a15f2d19dc"
+      "id": "native.apple.ab9749bd8de35a71"
     },
     {
       "kind": "conditional-branch",
@@ -8671,7 +8671,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Skills.swift",
       "source": "API key saved.",
       "surface": "apple",
-      "id": "native.apple.5a82be79fab324db"
+      "id": "native.apple.8eb83d034b37b949"
     },
     {
       "kind": "ui-call",
@@ -8679,7 +8679,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Usage.swift",
       "source": "Totals",
       "surface": "apple",
-      "id": "native.apple.4ca9438c6ce4c08e"
+      "id": "native.apple.a65066d19ed879fd"
     },
     {
       "kind": "ui-named-argument",
@@ -8687,7 +8687,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Usage.swift",
       "source": "Cost",
       "surface": "apple",
-      "id": "native.apple.c302fc984f54d047"
+      "id": "native.apple.e601b94c12d2b98e"
     },
     {
       "kind": "ui-named-argument",
@@ -8695,7 +8695,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Usage.swift",
       "source": "Tokens",
       "surface": "apple",
-      "id": "native.apple.ecdc9e4aba1f9bc5"
+      "id": "native.apple.463a0c3fc0724429"
     },
     {
       "kind": "ui-named-argument",
@@ -8703,7 +8703,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Usage.swift",
       "source": "Cache",
       "surface": "apple",
-      "id": "native.apple.b74b20bf703b7987"
+      "id": "native.apple.509cb464bd3190dd"
     },
     {
       "kind": "ui-named-argument",
@@ -8711,7 +8711,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Usage.swift",
       "source": "Daily",
       "surface": "apple",
-      "id": "native.apple.5d2b6f1366cf2ee8"
+      "id": "native.apple.f81476c427e8a023"
     },
     {
       "kind": "ui-named-argument",
@@ -8719,7 +8719,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Usage.swift",
       "source": "No daily usage yet",
       "surface": "apple",
-      "id": "native.apple.2b9a8f07dfc2afca"
+      "id": "native.apple.51f8cdef7b566774"
     },
     {
       "kind": "ui-named-argument",
@@ -8727,7 +8727,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Usage.swift",
       "source": "The gateway returned totals without daily session cost rows.",
       "surface": "apple",
-      "id": "native.apple.0eee5afee789f3f5"
+      "id": "native.apple.85a6c5af01f07a8b"
     },
     {
       "kind": "ui-call",
@@ -8735,7 +8735,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab+Usage.swift",
       "source": "\\(Self.compactNumber(day.totalTokens ?? 0)) tokens",
       "surface": "apple",
-      "id": "native.apple.3e7279eebc9d08b5"
+      "id": "native.apple.a17ce77200834d9c"
     },
     {
       "kind": "conditional-branch",
@@ -8743,7 +8743,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab.swift",
       "source": "Enabled",
       "surface": "apple",
-      "id": "native.apple.fa0cf88428461836"
+      "id": "native.apple.fb60c35df83a0768"
     },
     {
       "kind": "conditional-branch",
@@ -8751,7 +8751,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab.swift",
       "source": "Off",
       "surface": "apple",
-      "id": "native.apple.85ee47880905319e"
+      "id": "native.apple.9bd563ec9f88b66f"
     },
     {
       "kind": "conditional-branch",
@@ -8759,7 +8759,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab.swift",
       "source": "Setup",
       "surface": "apple",
-      "id": "native.apple.041399e554bbf83d"
+      "id": "native.apple.1a0589c434d56aa0"
     },
     {
       "kind": "conditional-branch",
@@ -8767,7 +8767,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab.swift",
       "source": "Blocked",
       "surface": "apple",
-      "id": "native.apple.5a805478c3b41941"
+      "id": "native.apple.58c675b87f0cd712"
     },
     {
       "kind": "conditional-branch",
@@ -8775,7 +8775,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab.swift",
       "source": "All",
       "surface": "apple",
-      "id": "native.apple.e4e2e137d656d2fb"
+      "id": "native.apple.c1520bfdcd827e55"
     },
     {
       "kind": "conditional-branch",
@@ -8783,7 +8783,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab.swift",
       "source": "Online",
       "surface": "apple",
-      "id": "native.apple.cb88b3767220ef0a"
+      "id": "native.apple.2be2d2e1fb0c140a"
     },
     {
       "kind": "conditional-branch",
@@ -8791,7 +8791,7 @@
       "path": "apps/ios/Sources/Design/AgentProTab.swift",
       "source": "Ready",
       "surface": "apple",
-      "id": "native.apple.aedbbd2dcbc87ed4"
+      "id": "native.apple.a97cdae7c8e13f0e"
     },
     {
       "kind": "ui-named-argument",
@@ -8799,7 +8799,7 @@
       "path": "apps/ios/Sources/Design/AgentWorkspaceFilesScreen.swift",
       "source": "Files",
       "surface": "apple",
-      "id": "native.apple.4b8e23199c9b474d"
+      "id": "native.apple.9c4e8b82edf0b324"
     },
     {
       "kind": "ui-call",
@@ -8807,7 +8807,7 @@
       "path": "apps/ios/Sources/Design/AgentWorkspaceFilesScreen.swift",
       "source": "This folder is empty.",
       "surface": "apple",
-      "id": "native.apple.628a1ad4bbd9f1a9"
+      "id": "native.apple.ada58d7ce8866f71"
     },
     {
       "kind": "ui-call",
@@ -8815,7 +8815,7 @@
       "path": "apps/ios/Sources/Design/AgentWorkspaceFilesScreen.swift",
       "source": "Load More",
       "surface": "apple",
-      "id": "native.apple.ec3dd6687663751d"
+      "id": "native.apple.35512c4d46a2da28"
     },
     {
       "kind": "ui-call",
@@ -8823,7 +8823,7 @@
       "path": "apps/ios/Sources/Design/AgentWorkspaceFilesScreen.swift",
       "source": "\\(self.entries.count) of \\(self.totalEntries)",
       "surface": "apple",
-      "id": "native.apple.0e6c1fdea127743b"
+      "id": "native.apple.e617cdacc3bce5ea"
     },
     {
       "kind": "ui-modifier",
@@ -8831,7 +8831,7 @@
       "path": "apps/ios/Sources/Design/AgentWorkspaceFilesScreen.swift",
       "source": "Share file",
       "surface": "apple",
-      "id": "native.apple.001ecfe4d0e4932e"
+      "id": "native.apple.336a7eeb12d6e5f4"
     },
     {
       "kind": "ui-modifier",
@@ -8839,7 +8839,7 @@
       "path": "apps/ios/Sources/Design/AgentWorkspaceFilesScreen.swift",
       "source": "Could not share this file.",
       "surface": "apple",
-      "id": "native.apple.70134cd69bfcee2f"
+      "id": "native.apple.0ab324ff650d720c"
     },
     {
       "kind": "ui-call",
@@ -8847,7 +8847,7 @@
       "path": "apps/ios/Sources/Design/AgentWorkspaceFilesScreen.swift",
       "source": "OK",
       "surface": "apple",
-      "id": "native.apple.3704986fe73a9e39"
+      "id": "native.apple.8218f673399060cc"
     },
     {
       "kind": "ui-localized-call",
@@ -8855,7 +8855,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unable to Export Transcript",
       "surface": "apple",
-      "id": "native.apple.d8a473ff35837e6d"
+      "id": "native.apple.e5524d5756a62744"
     },
     {
       "kind": "ui-call",
@@ -8863,7 +8863,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "OK",
       "surface": "apple",
-      "id": "native.apple.562d65e955f03a10"
+      "id": "native.apple.942d6a10fd90d6e3"
     },
     {
       "kind": "ui-call",
@@ -8871,7 +8871,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "OpenClaw could not prepare the Markdown file.",
       "surface": "apple",
-      "id": "native.apple.a80ae10704a44df1"
+      "id": "native.apple.3548c8d1ab43e85e"
     },
     {
       "kind": "ui-localized-call",
@@ -8879,7 +8879,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What would you like to work on?",
       "surface": "apple",
-      "id": "native.apple.40e41857534ae660"
+      "id": "native.apple.202b97e93b938049"
     },
     {
       "kind": "ui-call",
@@ -8887,7 +8887,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "The session attaches once the gateway is ready.",
       "surface": "apple",
-      "id": "native.apple.ed7f703a8809b564"
+      "id": "native.apple.32179ce0b6d4543f"
     },
     {
       "kind": "ui-modifier",
@@ -8895,7 +8895,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Opens Settings / Gateway",
       "surface": "apple",
-      "id": "native.apple.86888478e9c9408a"
+      "id": "native.apple.d19c9577e0fdfea7"
     },
     {
       "kind": "ui-call",
@@ -8903,7 +8903,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Chat",
       "surface": "apple",
-      "id": "native.apple.0e86b658650c8821"
+      "id": "native.apple.7c87384c7d1370e1"
     },
     {
       "kind": "ui-call",
@@ -8911,7 +8911,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Chat in Worktree",
       "surface": "apple",
-      "id": "native.apple.a42b3f7341ab854d"
+      "id": "native.apple.1876037e64a74110"
     },
     {
       "kind": "ui-call",
@@ -8919,7 +8919,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Export Transcript",
       "surface": "apple",
-      "id": "native.apple.4130fc39fcbc0bfc"
+      "id": "native.apple.ced228bb4d20a726"
     },
     {
       "kind": "ui-modifier",
@@ -8927,7 +8927,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Chat actions",
       "surface": "apple",
-      "id": "native.apple.473e399157b58d5b"
+      "id": "native.apple.940e1f943750c94b"
     },
     {
       "kind": "conditional-branch",
@@ -8935,7 +8935,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connected",
       "surface": "apple",
-      "id": "native.apple.c694b0d5c5ec09dd"
+      "id": "native.apple.b635acd93246d67b"
     },
     {
       "kind": "conditional-branch",
@@ -8943,7 +8943,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unavailable",
       "surface": "apple",
-      "id": "native.apple.b65a1e536c99e7f3"
+      "id": "native.apple.04934af85e3b9d6e"
     },
     {
       "kind": "ui-localized-call",
@@ -8951,7 +8951,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message \\(self.agentDisplayName)...",
       "surface": "apple",
-      "id": "native.apple.3346197ab0e4c93e"
+      "id": "native.apple.4dcedefea4b49a1c"
     },
     {
       "kind": "ui-localized-call",
@@ -8959,7 +8959,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message \\(self.agentDisplayName); sends when connected",
       "surface": "apple",
-      "id": "native.apple.37dc4df311e21014"
+      "id": "native.apple.84767ec18054524b"
     },
     {
       "kind": "ui-localized-call",
@@ -8967,7 +8967,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connect to a gateway",
       "surface": "apple",
-      "id": "native.apple.63c54e148a3a237d"
+      "id": "native.apple.11b20bef7e51ab69"
     },
     {
       "kind": "ui-localized-call",
@@ -8975,7 +8975,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Check OpenClaw status",
       "surface": "apple",
-      "id": "native.apple.e1501481753605ff"
+      "id": "native.apple.14492e334b87e4f2"
     },
     {
       "kind": "ui-localized-call",
@@ -8983,7 +8983,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Summarize the current OpenClaw status and tell me what needs attention.",
       "surface": "apple",
-      "id": "native.apple.dbac5d9eaf51f8e5"
+      "id": "native.apple.bbf7bd23da1e7865"
     },
     {
       "kind": "ui-localized-call",
@@ -8991,7 +8991,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What can I control here?",
       "surface": "apple",
-      "id": "native.apple.5508d38f4a5363a3"
+      "id": "native.apple.ea8cbb1b4230c652"
     },
     {
       "kind": "ui-localized-call",
@@ -8999,7 +8999,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Show me which phone controls and device capabilities are available right now.",
       "surface": "apple",
-      "id": "native.apple.075991f0c700ec98"
+      "id": "native.apple.451d25bdb3130ed0"
     },
     {
       "kind": "ui-localized-call",
@@ -9007,7 +9007,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start voice chat",
       "surface": "apple",
-      "id": "native.apple.b756860596294232"
+      "id": "native.apple.503ec402d08bd43a"
     },
     {
       "kind": "ui-localized-call",
@@ -9015,7 +9015,7 @@
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start a realtime voice session from this phone.",
       "surface": "apple",
-      "id": "native.apple.3bdf3dc66964c67d"
+      "id": "native.apple.65e462758be96174"
     },
     {
       "kind": "ui-call",
@@ -9023,7 +9023,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Unarchive",
       "surface": "apple",
-      "id": "native.apple.5358ee1a7154e827"
+      "id": "native.apple.41afc4a5d600ded5"
     },
     {
       "kind": "conditional-branch",
@@ -9031,7 +9031,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Pin",
       "surface": "apple",
-      "id": "native.apple.2bd38e22a7cd45c4"
+      "id": "native.apple.69b8d4842a6b18ca"
     },
     {
       "kind": "conditional-branch",
@@ -9039,7 +9039,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Unpin",
       "surface": "apple",
-      "id": "native.apple.93348a0df87d34ba"
+      "id": "native.apple.43b1796d55760cbf"
     },
     {
       "kind": "conditional-branch",
@@ -9047,7 +9047,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Mark as Read",
       "surface": "apple",
-      "id": "native.apple.bce681f8ec643fa4"
+      "id": "native.apple.48fe0c28f708d02d"
     },
     {
       "kind": "conditional-branch",
@@ -9055,7 +9055,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Mark as Unread",
       "surface": "apple",
-      "id": "native.apple.5e4f126c79628f9c"
+      "id": "native.apple.b0c19ea32f3b60dc"
     },
     {
       "kind": "ui-call",
@@ -9063,7 +9063,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Rename…",
       "surface": "apple",
-      "id": "native.apple.6dda1b61963245ec"
+      "id": "native.apple.1a700eb0a3a26dd2"
     },
     {
       "kind": "ui-call",
@@ -9071,7 +9071,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Fork",
       "surface": "apple",
-      "id": "native.apple.445630a5a98164e6"
+      "id": "native.apple.036b0faa4e17f39c"
     },
     {
       "kind": "ui-call",
@@ -9079,7 +9079,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Archive",
       "surface": "apple",
-      "id": "native.apple.155f50cfb6cd013e"
+      "id": "native.apple.35e23b306162f6ad"
     },
     {
       "kind": "conditional-branch",
@@ -9087,7 +9087,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Create",
       "surface": "apple",
-      "id": "native.apple.c0ac2c39ec17fbb6"
+      "id": "native.apple.ef105487ab62349a"
     },
     {
       "kind": "conditional-branch",
@@ -9095,7 +9095,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Save",
       "surface": "apple",
-      "id": "native.apple.cfdbbb92d1514a24"
+      "id": "native.apple.1d017f810676d86b"
     },
     {
       "kind": "ui-modifier",
@@ -9103,7 +9103,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Delete Session?",
       "surface": "apple",
-      "id": "native.apple.e7382c53c7dd48f7"
+      "id": "native.apple.f488b9caf6e51ac3"
     },
     {
       "kind": "ui-call",
@@ -9111,7 +9111,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Delete Session",
       "surface": "apple",
-      "id": "native.apple.702fd8b48da56065"
+      "id": "native.apple.8634b17be9b111bc"
     },
     {
       "kind": "ui-call",
@@ -9119,7 +9119,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Cancel",
       "surface": "apple",
-      "id": "native.apple.09a899ba9d9b61b9"
+      "id": "native.apple.9b1aed19568a048e"
     },
     {
       "kind": "ui-call",
@@ -9127,7 +9127,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "This permanently deletes the session and its transcript.",
       "surface": "apple",
-      "id": "native.apple.61f3f19ea24c6012"
+      "id": "native.apple.4a9568ac9b18d8d3"
     },
     {
       "kind": "ui-call",
@@ -9135,7 +9135,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "New Group…",
       "surface": "apple",
-      "id": "native.apple.0861aee9da492d87"
+      "id": "native.apple.0965d8d2429c3b9f"
     },
     {
       "kind": "ui-call",
@@ -9143,7 +9143,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Remove from Group",
       "surface": "apple",
-      "id": "native.apple.16c4a1eff2a6a398"
+      "id": "native.apple.e6506ceb05d0ab33"
     },
     {
       "kind": "ui-call",
@@ -9151,7 +9151,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Move to Group",
       "surface": "apple",
-      "id": "native.apple.8e8b3d47fd59c907"
+      "id": "native.apple.6def347a80370aac"
     },
     {
       "kind": "ui-call",
@@ -9159,7 +9159,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Delete…",
       "surface": "apple",
-      "id": "native.apple.052b20659077baa5"
+      "id": "native.apple.de18cef702422ac0"
     },
     {
       "kind": "conditional-branch",
@@ -9167,7 +9167,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "New Group",
       "surface": "apple",
-      "id": "native.apple.2202551ee0195c91"
+      "id": "native.apple.6595d3fd006a1a01"
     },
     {
       "kind": "conditional-branch",
@@ -9175,7 +9175,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Rename Session",
       "surface": "apple",
-      "id": "native.apple.cd368674179237a0"
+      "id": "native.apple.5bccdc23a1640895"
     },
     {
       "kind": "conditional-branch",
@@ -9183,7 +9183,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Group name",
       "surface": "apple",
-      "id": "native.apple.1f11f99fd9d4f4d9"
+      "id": "native.apple.31424500c53d6c32"
     },
     {
       "kind": "conditional-branch",
@@ -9191,7 +9191,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "Session name",
       "surface": "apple",
-      "id": "native.apple.8b54306971cfa8c9"
+      "id": "native.apple.af789b2d2fda0f67"
     },
     {
       "kind": "ui-call",
@@ -9199,7 +9199,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "View More",
       "surface": "apple",
-      "id": "native.apple.0c9421c29362d86b"
+      "id": "native.apple.e8018adcccaa2a4d"
     },
     {
       "kind": "ui-modifier",
@@ -9207,7 +9207,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Gateway settings",
       "surface": "apple",
-      "id": "native.apple.03a4cf69952364ac"
+      "id": "native.apple.65fb4d9ce6e5bbda"
     },
     {
       "kind": "ui-modifier",
@@ -9215,7 +9215,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Opens gateway settings",
       "surface": "apple",
-      "id": "native.apple.f2164090736ada49"
+      "id": "native.apple.4eaa7637d355c07c"
     },
     {
       "kind": "ui-named-argument",
@@ -9223,7 +9223,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Gateway",
       "surface": "apple",
-      "id": "native.apple.63a54b768d63946d"
+      "id": "native.apple.9e1806d7f3980f47"
     },
     {
       "kind": "ui-named-argument",
@@ -9231,7 +9231,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Connection",
       "surface": "apple",
-      "id": "native.apple.48090a32e9e032b1"
+      "id": "native.apple.88d022e6c15a3dc3"
     },
     {
       "kind": "ui-named-argument",
@@ -9239,7 +9239,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Address",
       "surface": "apple",
-      "id": "native.apple.e6175670f78fafee"
+      "id": "native.apple.722d7754e946480d"
     },
     {
       "kind": "ui-named-argument",
@@ -9247,7 +9247,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Agents",
       "surface": "apple",
-      "id": "native.apple.61a3188faf165168"
+      "id": "native.apple.e0c68adcc22af34a"
     },
     {
       "kind": "ui-named-argument",
@@ -9255,7 +9255,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Agent session",
       "surface": "apple",
-      "id": "native.apple.789d5d0790fd18ca"
+      "id": "native.apple.a3bde8045fe9224a"
     },
     {
       "kind": "ui-named-argument",
@@ -9263,7 +9263,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Recent sessions",
       "surface": "apple",
-      "id": "native.apple.ee45dce4a2e44737"
+      "id": "native.apple.27f775de30b37ff8"
     },
     {
       "kind": "conditional-branch",
@@ -9271,7 +9271,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Gateway offline",
       "surface": "apple",
-      "id": "native.apple.6f62aefe0095fcbb"
+      "id": "native.apple.9161ca3c61de6cc7"
     },
     {
       "kind": "conditional-branch",
@@ -9279,7 +9279,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Online",
       "surface": "apple",
-      "id": "native.apple.b467d2945a05a9d1"
+      "id": "native.apple.e01aac63fda4c147"
     },
     {
       "kind": "conditional-branch",
@@ -9287,7 +9287,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Connecting",
       "surface": "apple",
-      "id": "native.apple.5ecae309f5192f0c"
+      "id": "native.apple.a857bc74fd053781"
     },
     {
       "kind": "conditional-branch",
@@ -9295,7 +9295,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Attention",
       "surface": "apple",
-      "id": "native.apple.a063c4bd06cdfaed"
+      "id": "native.apple.a36675969878b0d8"
     },
     {
       "kind": "conditional-branch",
@@ -9303,7 +9303,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Offline",
       "surface": "apple",
-      "id": "native.apple.8953a423bbeb8332"
+      "id": "native.apple.89989b6d557090e8"
     },
     {
       "kind": "ui-call",
@@ -9311,7 +9311,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Group name",
       "surface": "apple",
-      "id": "native.apple.4c11bcf5550624fa"
+      "id": "native.apple.9aba1ae114cf9848"
     },
     {
       "kind": "conditional-branch",
@@ -9319,7 +9319,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Create",
       "surface": "apple",
-      "id": "native.apple.07e6e3e1cb4e0b12"
+      "id": "native.apple.fdd3242467eb5c34"
     },
     {
       "kind": "conditional-branch",
@@ -9327,7 +9327,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Save",
       "surface": "apple",
-      "id": "native.apple.30002605e6bb08ea"
+      "id": "native.apple.b976b71411e9c78d"
     },
     {
       "kind": "ui-modifier",
@@ -9335,7 +9335,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Delete Group?",
       "surface": "apple",
-      "id": "native.apple.8653bc3bc8cfed37"
+      "id": "native.apple.b2ab82ca08392d29"
     },
     {
       "kind": "ui-call",
@@ -9343,7 +9343,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Delete Group",
       "surface": "apple",
-      "id": "native.apple.292eb94002bfed70"
+      "id": "native.apple.886ca5d9c049307b"
     },
     {
       "kind": "ui-call",
@@ -9351,7 +9351,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Cancel",
       "surface": "apple",
-      "id": "native.apple.43cf470289f1b829"
+      "id": "native.apple.ccc876bc505512fc"
     },
     {
       "kind": "ui-call",
@@ -9359,7 +9359,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Sessions in \\u{201C}\\(group)\\u{201D} move back to Ungrouped.",
       "surface": "apple",
-      "id": "native.apple.c606e3a0185136fd"
+      "id": "native.apple.82f2bbb1828494f2"
     },
     {
       "kind": "ui-call",
@@ -9367,7 +9367,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Sessions",
       "surface": "apple",
-      "id": "native.apple.7a6511a467e34f69"
+      "id": "native.apple.9f2fd65953013b7c"
     },
     {
       "kind": "conditional-branch",
@@ -9375,7 +9375,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Archived sessions",
       "surface": "apple",
-      "id": "native.apple.e6b8913014b64f0a"
+      "id": "native.apple.0422818cc95d5071"
     },
     {
       "kind": "ui-call",
@@ -9383,7 +9383,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Show Archived",
       "surface": "apple",
-      "id": "native.apple.99301fe71e23c03f"
+      "id": "native.apple.bc8e64efb095a625"
     },
     {
       "kind": "ui-named-argument",
@@ -9391,7 +9391,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Sessions unavailable",
       "surface": "apple",
-      "id": "native.apple.119433782518f199"
+      "id": "native.apple.b272115c83f7ef58"
     },
     {
       "kind": "ui-named-argument",
@@ -9399,7 +9399,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Connect to the gateway.",
       "surface": "apple",
-      "id": "native.apple.ccefda5056fe3e02"
+      "id": "native.apple.79937d7781fb65ae"
     },
     {
       "kind": "conditional-branch",
@@ -9407,7 +9407,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Loading archived sessions",
       "surface": "apple",
-      "id": "native.apple.9882fbadac3bea03"
+      "id": "native.apple.54f8260c9b863087"
     },
     {
       "kind": "conditional-branch",
@@ -9415,7 +9415,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Loading recent sessions",
       "surface": "apple",
-      "id": "native.apple.16dca1cfac8a571b"
+      "id": "native.apple.9b305868873dade2"
     },
     {
       "kind": "conditional-branch",
@@ -9423,7 +9423,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "No archived sessions",
       "surface": "apple",
-      "id": "native.apple.a0b4091bf77d4060"
+      "id": "native.apple.1f4501a6bf2bae4c"
     },
     {
       "kind": "conditional-branch",
@@ -9431,7 +9431,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "No recent sessions",
       "surface": "apple",
-      "id": "native.apple.c97e0382e578a2f7"
+      "id": "native.apple.28c97cf23665ee01"
     },
     {
       "kind": "conditional-branch",
@@ -9439,7 +9439,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Archived sessions will appear here.",
       "surface": "apple",
-      "id": "native.apple.acfdf5c72e289736"
+      "id": "native.apple.2a1ba7a5e1979c9e"
     },
     {
       "kind": "conditional-branch",
@@ -9447,7 +9447,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Start a chat and it will appear here.",
       "surface": "apple",
-      "id": "native.apple.ae77089e775af79c"
+      "id": "native.apple.bb1a311441d3cf24"
     },
     {
       "kind": "ui-call",
@@ -9455,7 +9455,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Rename Group…",
       "surface": "apple",
-      "id": "native.apple.70f3837cffd6532b"
+      "id": "native.apple.e8e8cea7ec44fe08"
     },
     {
       "kind": "ui-call",
@@ -9463,7 +9463,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "New Group…",
       "surface": "apple",
-      "id": "native.apple.51465e9c69274d8c"
+      "id": "native.apple.b2e6a4382a540792"
     },
     {
       "kind": "ui-call",
@@ -9471,7 +9471,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Delete Group…",
       "surface": "apple",
-      "id": "native.apple.bcfa3237ed778cb2"
+      "id": "native.apple.553df9e842173417"
     },
     {
       "kind": "conditional-branch",
@@ -9479,7 +9479,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "New Group",
       "surface": "apple",
-      "id": "native.apple.23639ef62b3af09d"
+      "id": "native.apple.7b06349d79d0c217"
     },
     {
       "kind": "conditional-branch",
@@ -9487,7 +9487,7 @@
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Rename Group",
       "surface": "apple",
-      "id": "native.apple.9c26bf2d4360434b"
+      "id": "native.apple.1b727fbf231de39f"
     },
     {
       "kind": "conditional-branch",
@@ -9503,7 +9503,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Activity",
       "surface": "apple",
-      "id": "native.apple.c7facd80484d0d0c"
+      "id": "native.apple.ffaad4538bcfe1ac"
     },
     {
       "kind": "ui-named-argument",
@@ -9511,7 +9511,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Live device and gateway activity.",
       "surface": "apple",
-      "id": "native.apple.3f18ddd8d4402f8e"
+      "id": "native.apple.55a6a9eba5f6110c"
     },
     {
       "kind": "conditional-branch",
@@ -9519,7 +9519,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "\\(self.appModel.gatewayAgents.count)",
       "surface": "apple",
-      "id": "native.apple.f92cdb404a330d9b"
+      "id": "native.apple.5e343529932d0efd"
     },
     {
       "kind": "conditional-branch",
@@ -9527,7 +9527,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "\\(self.sessionRows.count)",
       "surface": "apple",
-      "id": "native.apple.eea7b404a461a985"
+      "id": "native.apple.b004055c5bac6681"
     },
     {
       "kind": "ui-named-argument",
@@ -9535,7 +9535,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Recent activity",
       "surface": "apple",
-      "id": "native.apple.282e02f7e21eb310"
+      "id": "native.apple.4813254a14ae910f"
     },
     {
       "kind": "conditional-branch",
@@ -9551,7 +9551,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.158e075d19295090"
+      "id": "native.apple.f7b3242d69bc344b"
     },
     {
       "kind": "ui-named-argument",
@@ -9559,7 +9559,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Approval needed",
       "surface": "apple",
-      "id": "native.apple.d364bb0dded9c049"
+      "id": "native.apple.591061645bc8be64"
     },
     {
       "kind": "ui-named-argument",
@@ -9567,7 +9567,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Gateway",
       "surface": "apple",
-      "id": "native.apple.c666d7f977619887"
+      "id": "native.apple.c541794e6ce09dc7"
     },
     {
       "kind": "ui-named-argument",
@@ -9575,7 +9575,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Share intake",
       "surface": "apple",
-      "id": "native.apple.818cec9442bb0d0c"
+      "id": "native.apple.13470ea9f78fea51"
     },
     {
       "kind": "ui-named-argument",
@@ -9583,7 +9583,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Loading sessions",
       "surface": "apple",
-      "id": "native.apple.4c5b2ecf243cfbbc"
+      "id": "native.apple.2360d25fe6ae9946"
     },
     {
       "kind": "ui-named-argument",
@@ -9591,7 +9591,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Fetching recent activity from the gateway.",
       "surface": "apple",
-      "id": "native.apple.d496c99524704c89"
+      "id": "native.apple.48655128d0a34e44"
     },
     {
       "kind": "ui-named-argument",
@@ -9599,7 +9599,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Sessions unavailable",
       "surface": "apple",
-      "id": "native.apple.c4479934c65c973c"
+      "id": "native.apple.c334f2e86702a7b8"
     },
     {
       "kind": "conditional-branch",
@@ -9607,7 +9607,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "No recent sessions",
       "surface": "apple",
-      "id": "native.apple.6e67b64954ba3002"
+      "id": "native.apple.6cc6efb7a03960b6"
     },
     {
       "kind": "conditional-branch",
@@ -9615,7 +9615,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Session activity offline",
       "surface": "apple",
-      "id": "native.apple.5dce07848bec08b5"
+      "id": "native.apple.08483af2d043bee6"
     },
     {
       "kind": "conditional-branch",
@@ -9623,7 +9623,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Start a chat and it will appear here.",
       "surface": "apple",
-      "id": "native.apple.745ca87aa532b619"
+      "id": "native.apple.e3586d8a603f67e0"
     },
     {
       "kind": "conditional-branch",
@@ -9631,7 +9631,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Connect to the gateway to load recent chat activity.",
       "surface": "apple",
-      "id": "native.apple.72bbc8719353d4c7"
+      "id": "native.apple.f47ceff451b1cce8"
     },
     {
       "kind": "conditional-branch",
@@ -9647,7 +9647,7 @@
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
       "source": "Open",
       "surface": "apple",
-      "id": "native.apple.13e799f5171c2c62"
+      "id": "native.apple.fb6493b448a3f62a"
     },
     {
       "kind": "conditional-branch",
@@ -9671,7 +9671,7 @@
       "path": "apps/ios/Sources/Design/IPadSidebarFeatureScreens.swift",
       "source": "Gateway offline.",
       "surface": "apple",
-      "id": "native.apple.4d22689ffce54960"
+      "id": "native.apple.39681d2062a338cf"
     },
     {
       "kind": "conditional-branch",
@@ -9679,7 +9679,7 @@
       "path": "apps/ios/Sources/Design/IPadSidebarFeatureScreens.swift",
       "source": "Could not encode request.",
       "surface": "apple",
-      "id": "native.apple.bbeb3ce2bceddb34"
+      "id": "native.apple.1e0f08bfa15fb1fc"
     },
     {
       "kind": "ui-modifier",
@@ -9687,7 +9687,7 @@
       "path": "apps/ios/Sources/Design/IPadSidebarScreenChrome.swift",
       "source": "Gateway settings",
       "surface": "apple",
-      "id": "native.apple.aba0e26194f6926c"
+      "id": "native.apple.df57f7bdc11feff1"
     },
     {
       "kind": "ui-modifier",
@@ -9695,7 +9695,7 @@
       "path": "apps/ios/Sources/Design/IPadSidebarScreenChrome.swift",
       "source": "Opens Settings / Gateway",
       "surface": "apple",
-      "id": "native.apple.e487a75c14fca62b"
+      "id": "native.apple.749ac5e78033000f"
     },
     {
       "kind": "ui-named-argument",
@@ -9703,7 +9703,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Skill Workshop",
       "surface": "apple",
-      "id": "native.apple.c70f75e90a66e03a"
+      "id": "native.apple.9da8bb9b1b8aa353"
     },
     {
       "kind": "ui-named-argument",
@@ -9711,7 +9711,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Review and apply proposed skills.",
       "surface": "apple",
-      "id": "native.apple.54b4f8475d9abcaf"
+      "id": "native.apple.e3bcf286b266f54c"
     },
     {
       "kind": "ui-modifier",
@@ -9719,7 +9719,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Proposal",
       "surface": "apple",
-      "id": "native.apple.59602569c0ad69fc"
+      "id": "native.apple.bae7e51d0e736886"
     },
     {
       "kind": "ui-call",
@@ -9727,7 +9727,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Done",
       "surface": "apple",
-      "id": "native.apple.fee7146dbd3a4b4d"
+      "id": "native.apple.d690a258effde59c"
     },
     {
       "kind": "ui-call",
@@ -9735,7 +9735,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "\\(self.filteredProposals.count) proposals",
       "surface": "apple",
-      "id": "native.apple.3c152431c85e47df"
+      "id": "native.apple.57ea1dae1aa22723"
     },
     {
       "kind": "ui-call",
@@ -9743,7 +9743,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Status",
       "surface": "apple",
-      "id": "native.apple.4bfc76b4be4e7d06"
+      "id": "native.apple.daffe56ff9b28fa8"
     },
     {
       "kind": "ui-call",
@@ -9751,7 +9751,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.79233f9c2bb91772"
+      "id": "native.apple.f343b3c8847ae5a6"
     },
     {
       "kind": "ui-call",
@@ -9759,7 +9759,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Search proposals",
       "surface": "apple",
-      "id": "native.apple.61d175f424519081"
+      "id": "native.apple.5a499d3e1bf372ce"
     },
     {
       "kind": "ui-call",
@@ -9767,7 +9767,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Agent",
       "surface": "apple",
-      "id": "native.apple.02b131e12753f566"
+      "id": "native.apple.8c05535490c13854"
     },
     {
       "kind": "ui-call",
@@ -9775,7 +9775,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Default agent",
       "surface": "apple",
-      "id": "native.apple.29d9ffd4065105f2"
+      "id": "native.apple.1b494b6dc7ed0ec6"
     },
     {
       "kind": "ui-modifier",
@@ -9783,7 +9783,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Skill Workshop agent scope",
       "surface": "apple",
-      "id": "native.apple.75343c6542706e32"
+      "id": "native.apple.429fbc96ee068cb0"
     },
     {
       "kind": "conditional-branch",
@@ -9791,7 +9791,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "No proposals",
       "surface": "apple",
-      "id": "native.apple.60c163d47db8658a"
+      "id": "native.apple.0426cf61cbd72dd4"
     },
     {
       "kind": "conditional-branch",
@@ -9799,7 +9799,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "No proposals loaded",
       "surface": "apple",
-      "id": "native.apple.5aa551b7a52709d6"
+      "id": "native.apple.56b46d5289e460a7"
     },
     {
       "kind": "conditional-branch",
@@ -9807,7 +9807,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "New proposals will appear here when agents draft skills.",
       "surface": "apple",
-      "id": "native.apple.ed2a3ec0705ebca3"
+      "id": "native.apple.401016421351cd1d"
     },
     {
       "kind": "conditional-branch",
@@ -9815,7 +9815,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Connect from Settings to load Skill Workshop proposals.",
       "surface": "apple",
-      "id": "native.apple.61b17eef56270df7"
+      "id": "native.apple.bacbe7d1ade39252"
     },
     {
       "kind": "ui-named-argument",
@@ -9823,7 +9823,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Queue",
       "surface": "apple",
-      "id": "native.apple.9917eb13fd775dad"
+      "id": "native.apple.610d75ef598b0732"
     },
     {
       "kind": "ui-named-argument",
@@ -9831,7 +9831,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Proposal unavailable",
       "surface": "apple",
-      "id": "native.apple.bc8ff3d4d2efc77f"
+      "id": "native.apple.7df7629c97f9ce5c"
     },
     {
       "kind": "ui-named-argument",
@@ -9839,7 +9839,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Return to the queue and choose another proposal.",
       "surface": "apple",
-      "id": "native.apple.67d0dd8899d52c04"
+      "id": "native.apple.4346e78325e97c0b"
     },
     {
       "kind": "ui-call",
@@ -9847,7 +9847,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Select refresh to load the proposal body.",
       "surface": "apple",
-      "id": "native.apple.1bc05cf8ad9561f0"
+      "id": "native.apple.0fea571f6d470cd1"
     },
     {
       "kind": "ui-call",
@@ -9855,7 +9855,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Support files",
       "surface": "apple",
-      "id": "native.apple.2ec291f474703e3a"
+      "id": "native.apple.a7cf31dea97d6a4c"
     },
     {
       "kind": "ui-call",
@@ -9863,7 +9863,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Admin scope required.",
       "surface": "apple",
-      "id": "native.apple.69fd00c6086fe6ad"
+      "id": "native.apple.9cc0c7366724336d"
     },
     {
       "kind": "conditional-branch",
@@ -9871,7 +9871,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Proposal applied.",
       "surface": "apple",
-      "id": "native.apple.51c2a607a7519f5d"
+      "id": "native.apple.79e7355c669bf71e"
     },
     {
       "kind": "conditional-branch",
@@ -9879,7 +9879,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Proposal rejected.",
       "surface": "apple",
-      "id": "native.apple.9219ffa8ab5af913"
+      "id": "native.apple.0b2d2e1dc00b709e"
     },
     {
       "kind": "ui-named-argument",
@@ -9887,7 +9887,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "No \\(IPadSkillWorkshopScreen.proposalLaneLabel(self.status).lowercased()) proposals",
       "surface": "apple",
-      "id": "native.apple.a6d7f78785bd06d7"
+      "id": "native.apple.16e5b5a92891e431"
     },
     {
       "kind": "ui-named-argument",
@@ -9895,7 +9895,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Matching proposals appear here after gateway refresh.",
       "surface": "apple",
-      "id": "native.apple.66e9b298b37de8ff"
+      "id": "native.apple.d551631fd59d66ba"
     },
     {
       "kind": "ui-modifier",
@@ -9903,7 +9903,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Apply Proposal",
       "surface": "apple",
-      "id": "native.apple.e5e1bc7e7c0bbfda"
+      "id": "native.apple.d02a3df75b832c44"
     },
     {
       "kind": "ui-modifier",
@@ -9911,7 +9911,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Reject Proposal",
       "surface": "apple",
-      "id": "native.apple.a4cfb66a1d59e243"
+      "id": "native.apple.a13064eb47c83eb8"
     },
     {
       "kind": "ui-modifier",
@@ -9919,7 +9919,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Inspect Proposal",
       "surface": "apple",
-      "id": "native.apple.da7ddf9e4ecfe658"
+      "id": "native.apple.87a5f8581e42877d"
     },
     {
       "kind": "ui-call",
@@ -9927,7 +9927,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Inspect",
       "surface": "apple",
-      "id": "native.apple.14eb423e0c4e44ff"
+      "id": "native.apple.5cf8a3ccae1db3e6"
     },
     {
       "kind": "ui-call",
@@ -9935,7 +9935,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Apply",
       "surface": "apple",
-      "id": "native.apple.b77f9f273e7ce412"
+      "id": "native.apple.f716605808ff03fc"
     },
     {
       "kind": "ui-call",
@@ -9943,7 +9943,7 @@
       "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift",
       "source": "Reject",
       "surface": "apple",
-      "id": "native.apple.59d5bca9a466ecad"
+      "id": "native.apple.c83a84bb8d0ab095"
     },
     {
       "kind": "ui-named-argument",
@@ -9951,7 +9951,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Workboard",
       "surface": "apple",
-      "id": "native.apple.7ab687186fadfc76"
+      "id": "native.apple.f12f3fcc4fa6b04b"
     },
     {
       "kind": "ui-call",
@@ -9959,7 +9959,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Search cards",
       "surface": "apple",
-      "id": "native.apple.342ff334d870f412"
+      "id": "native.apple.57baf3d2a463af6d"
     },
     {
       "kind": "ui-call",
@@ -9967,7 +9967,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Scope",
       "surface": "apple",
-      "id": "native.apple.836fe8ff57836a99"
+      "id": "native.apple.6d5fff8d127eeb0a"
     },
     {
       "kind": "ui-call",
@@ -9975,7 +9975,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.9ffdadd05ebcd9b4"
+      "id": "native.apple.f3ab09d2ffba5d9b"
     },
     {
       "kind": "ui-call",
@@ -9983,7 +9983,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "\\(self.filteredCards.count) cards",
       "surface": "apple",
-      "id": "native.apple.79f76baaecd38dd4"
+      "id": "native.apple.fb9e29033d18989e"
     },
     {
       "kind": "ui-call",
@@ -9991,7 +9991,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Dispatch",
       "surface": "apple",
-      "id": "native.apple.fef5b5ea3dd57bfa"
+      "id": "native.apple.218fbb58080fb72d"
     },
     {
       "kind": "ui-modifier",
@@ -9999,7 +9999,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Refresh workboard",
       "surface": "apple",
-      "id": "native.apple.7389a6b4e45aebc6"
+      "id": "native.apple.8f223078cd6ac6a3"
     },
     {
       "kind": "ui-call",
@@ -10007,7 +10007,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "New Card",
       "surface": "apple",
-      "id": "native.apple.0492d2ba165f9dd2"
+      "id": "native.apple.48006e54096957cd"
     },
     {
       "kind": "ui-modifier",
@@ -10015,7 +10015,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Opens card title and notes entry",
       "surface": "apple",
-      "id": "native.apple.8b4984907a73a394"
+      "id": "native.apple.a96a3caad5b92660"
     },
     {
       "kind": "ui-call",
@@ -10023,7 +10023,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "active",
       "surface": "apple",
-      "id": "native.apple.f7fcb69602f94f64"
+      "id": "native.apple.a14964a14217bd01"
     },
     {
       "kind": "ui-modifier",
@@ -10031,7 +10031,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Show \\(IPadWorkboardDefaults.label(for: status)) cards",
       "surface": "apple",
-      "id": "native.apple.f69a2f9daa810d75"
+      "id": "native.apple.1025db84f77e09e2"
     },
     {
       "kind": "ui-call",
@@ -10039,7 +10039,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Board",
       "surface": "apple",
-      "id": "native.apple.63ec16fd003c72cb"
+      "id": "native.apple.d451be3a2cbc14a2"
     },
     {
       "kind": "ui-call",
@@ -10047,7 +10047,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "All boards",
       "surface": "apple",
-      "id": "native.apple.c983ee21eb37d094"
+      "id": "native.apple.4ed27158ad8a0f9b"
     },
     {
       "kind": "ui-modifier",
@@ -10055,7 +10055,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Workboard board scope",
       "surface": "apple",
-      "id": "native.apple.d8851ecfd78a344d"
+      "id": "native.apple.e2418405eb6a9908"
     },
     {
       "kind": "ui-call",
@@ -10063,7 +10063,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Active",
       "surface": "apple",
-      "id": "native.apple.fdb9c61ba76d0053"
+      "id": "native.apple.bec86362b812a969"
     },
     {
       "kind": "ui-named-argument",
@@ -10071,7 +10071,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Queue",
       "surface": "apple",
-      "id": "native.apple.82be1a5de9f45491"
+      "id": "native.apple.116ad51e94090396"
     },
     {
       "kind": "conditional-branch",
@@ -10079,7 +10079,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "No cards",
       "surface": "apple",
-      "id": "native.apple.32f4651d5435080e"
+      "id": "native.apple.53ff83914372dbc4"
     },
     {
       "kind": "conditional-branch",
@@ -10087,7 +10087,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "No cards loaded",
       "surface": "apple",
-      "id": "native.apple.eea8b87c5cf0fd3b"
+      "id": "native.apple.2467cc9a85c3a33f"
     },
     {
       "kind": "conditional-branch",
@@ -10095,7 +10095,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Create a card or change the filter.",
       "surface": "apple",
-      "id": "native.apple.52015bb5fc923caa"
+      "id": "native.apple.d150c79eaa14ec76"
     },
     {
       "kind": "conditional-branch",
@@ -10103,7 +10103,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Connect from Settings to load workboard cards.",
       "surface": "apple",
-      "id": "native.apple.e3e02f176ae010a7"
+      "id": "native.apple.60483b8876b7f59f"
     },
     {
       "kind": "ui-call",
@@ -10111,7 +10111,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Notes",
       "surface": "apple",
-      "id": "native.apple.07170eb527fff636"
+      "id": "native.apple.24fb5469bb5a5b37"
     },
     {
       "kind": "ui-call",
@@ -10119,7 +10119,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Cancel",
       "surface": "apple",
-      "id": "native.apple.365cbbf1aa009ef9"
+      "id": "native.apple.d34aa91acc1064ad"
     },
     {
       "kind": "conditional-branch",
@@ -10127,7 +10127,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Create",
       "surface": "apple",
-      "id": "native.apple.67645e205fff9031"
+      "id": "native.apple.5c1a338af512a718"
     },
     {
       "kind": "conditional-branch",
@@ -10135,7 +10135,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Creating...",
       "surface": "apple",
-      "id": "native.apple.af2c039b2dce4ab7"
+      "id": "native.apple.6d92a8218bb832f5"
     },
     {
       "kind": "conditional-branch",
@@ -10143,7 +10143,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Connect from Settings to create, move, and dispatch cards.",
       "surface": "apple",
-      "id": "native.apple.1e30b27627e4ddac"
+      "id": "native.apple.13138f666cdcf858"
     },
     {
       "kind": "conditional-branch",
@@ -10151,7 +10151,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Read-only gateway.",
       "surface": "apple",
-      "id": "native.apple.d33993cdb2f30882"
+      "id": "native.apple.3a979dd267aec356"
     },
     {
       "kind": "ui-named-argument",
@@ -10159,7 +10159,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "No \\(IPadWorkboardDefaults.label(for: self.status).lowercased()) cards",
       "surface": "apple",
-      "id": "native.apple.7d9cccea80bfb9a0"
+      "id": "native.apple.32c4f348c9f4e313"
     },
     {
       "kind": "ui-named-argument",
@@ -10167,7 +10167,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Cards moved into this lane appear here.",
       "surface": "apple",
-      "id": "native.apple.f1ff845665521f57"
+      "id": "native.apple.30c47306610cb517"
     },
     {
       "kind": "ui-modifier",
@@ -10175,7 +10175,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Card Actions",
       "surface": "apple",
-      "id": "native.apple.615cf44f494e7e25"
+      "id": "native.apple.7c47d0fcdeb2d0d3"
     },
     {
       "kind": "ui-call",
@@ -10183,7 +10183,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Open",
       "surface": "apple",
-      "id": "native.apple.f187c2900fbe7254"
+      "id": "native.apple.651ec246396255cd"
     },
     {
       "kind": "ui-call",
@@ -10191,7 +10191,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Inspect",
       "surface": "apple",
-      "id": "native.apple.0d23c6702b5a0aa0"
+      "id": "native.apple.c1f2821d719e37f8"
     },
     {
       "kind": "ui-call",
@@ -10199,7 +10199,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Move to \\(IPadWorkboardDefaults.label(for: status))",
       "surface": "apple",
-      "id": "native.apple.a18d25d511979e0c"
+      "id": "native.apple.774f595a01eca278"
     },
     {
       "kind": "conditional-branch",
@@ -10207,7 +10207,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Default agent",
       "surface": "apple",
-      "id": "native.apple.61b4e4726d1e60ff"
+      "id": "native.apple.1345612333480144"
     },
     {
       "kind": "ui-call",
@@ -10215,7 +10215,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Title",
       "surface": "apple",
-      "id": "native.apple.40d27d3b708a00ae"
+      "id": "native.apple.77a417fa0f2aba1d"
     },
     {
       "kind": "ui-call",
@@ -10223,7 +10223,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Status",
       "surface": "apple",
-      "id": "native.apple.d40c58190ea3ce6a"
+      "id": "native.apple.6662824115f6982a"
     },
     {
       "kind": "ui-call",
@@ -10231,7 +10231,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Card",
       "surface": "apple",
-      "id": "native.apple.0e59a134340e68b7"
+      "id": "native.apple.0c99715b98ca22a2"
     },
     {
       "kind": "ui-call",
@@ -10239,7 +10239,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Open Session",
       "surface": "apple",
-      "id": "native.apple.3edbccb7c14b693c"
+      "id": "native.apple.93eeaedb2ff61043"
     },
     {
       "kind": "ui-call",
@@ -10247,7 +10247,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Move",
       "surface": "apple",
-      "id": "native.apple.81a91254f857c615"
+      "id": "native.apple.a2732e4ff77a201b"
     },
     {
       "kind": "conditional-branch",
@@ -10255,7 +10255,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Archive",
       "surface": "apple",
-      "id": "native.apple.74307b392a619c81"
+      "id": "native.apple.f0d98558ee17ffe2"
     },
     {
       "kind": "conditional-branch",
@@ -10263,7 +10263,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Unarchive",
       "surface": "apple",
-      "id": "native.apple.9dec96f01e7aaebb"
+      "id": "native.apple.dab3609e8a71ed48"
     },
     {
       "kind": "ui-call",
@@ -10271,7 +10271,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Actions",
       "surface": "apple",
-      "id": "native.apple.24de77ef3ebb77be"
+      "id": "native.apple.68a43a9e8939f395"
     },
     {
       "kind": "ui-call",
@@ -10279,7 +10279,7 @@
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
       "source": "Done",
       "surface": "apple",
-      "id": "native.apple.77a8a3e8fffd1843"
+      "id": "native.apple.07a313e2adf7227b"
     },
     {
       "kind": "conditional-branch",
@@ -10287,7 +10287,7 @@
       "path": "apps/ios/Sources/Design/OpenClawBrand.swift",
       "source": "System",
       "surface": "apple",
-      "id": "native.apple.f1c2754e127d35a8"
+      "id": "native.apple.132b2b13adbcee9d"
     },
     {
       "kind": "conditional-branch",
@@ -10295,7 +10295,7 @@
       "path": "apps/ios/Sources/Design/OpenClawBrand.swift",
       "source": "Light",
       "surface": "apple",
-      "id": "native.apple.f36a72d6749a4957"
+      "id": "native.apple.f666f2dfc656500f"
     },
     {
       "kind": "conditional-branch",
@@ -10303,7 +10303,7 @@
       "path": "apps/ios/Sources/Design/OpenClawBrand.swift",
       "source": "Dark",
       "surface": "apple",
-      "id": "native.apple.c78f78c1231dca4e"
+      "id": "native.apple.e3576faef11c7eba"
     },
     {
       "kind": "ui-modifier",
@@ -10311,7 +10311,7 @@
       "path": "apps/ios/Sources/Design/OpenClawDocsScreen.swift",
       "source": "Gateway settings",
       "surface": "apple",
-      "id": "native.apple.72e131e6c59d9aa2"
+      "id": "native.apple.f64f4306f8047c7d"
     },
     {
       "kind": "ui-named-argument",
@@ -10319,7 +10319,7 @@
       "path": "apps/ios/Sources/Design/OpenClawDocsScreen.swift",
       "source": "Docs",
       "surface": "apple",
-      "id": "native.apple.99059a2947897ec4"
+      "id": "native.apple.187f468d1f0a0c82"
     },
     {
       "kind": "ui-named-argument",
@@ -10327,7 +10327,7 @@
       "path": "apps/ios/Sources/Design/OpenClawDocsScreen.swift",
       "source": "Gateway setup, pairing, channels, and mobile node reference.",
       "surface": "apple",
-      "id": "native.apple.f09e1d926dfb62e7"
+      "id": "native.apple.809781d0475b8058"
     },
     {
       "kind": "ui-modifier",
@@ -10335,7 +10335,7 @@
       "path": "apps/ios/Sources/Design/OpenClawDocsScreen.swift",
       "source": "Opens Settings / Gateway",
       "surface": "apple",
-      "id": "native.apple.f5b51e0af861474c"
+      "id": "native.apple.5c5978aabd24bbce"
     },
     {
       "kind": "ui-named-argument",
@@ -10343,7 +10343,7 @@
       "path": "apps/ios/Sources/Design/OpenClawDocsScreen.swift",
       "source": "Docs Home",
       "surface": "apple",
-      "id": "native.apple.a67a5039f5cb5e33"
+      "id": "native.apple.4c34fd079149ed02"
     },
     {
       "kind": "ui-named-argument",
@@ -10351,7 +10351,7 @@
       "path": "apps/ios/Sources/Design/OpenClawDocsScreen.swift",
       "source": "Browse the current OpenClaw reference.",
       "surface": "apple",
-      "id": "native.apple.8e6797ab3b17ba28"
+      "id": "native.apple.56935c5384889b8e"
     },
     {
       "kind": "ui-named-argument",
@@ -10359,7 +10359,7 @@
       "path": "apps/ios/Sources/Design/OpenClawDocsScreen.swift",
       "source": "Gateway",
       "surface": "apple",
-      "id": "native.apple.ef48769a5f23b10d"
+      "id": "native.apple.2ee2f8c71fa2d2cc"
     },
     {
       "kind": "ui-named-argument",
@@ -10367,7 +10367,7 @@
       "path": "apps/ios/Sources/Design/OpenClawDocsScreen.swift",
       "source": "Connection, auth, and diagnostics.",
       "surface": "apple",
-      "id": "native.apple.4ffb70b541b05680"
+      "id": "native.apple.610af6c97ab9f33a"
     },
     {
       "kind": "ui-named-argument",
@@ -10375,7 +10375,7 @@
       "path": "apps/ios/Sources/Design/OpenClawDocsScreen.swift",
       "source": "Pairing",
       "surface": "apple",
-      "id": "native.apple.dee7639745ddcd6b"
+      "id": "native.apple.a25d827f6577a87f"
     },
     {
       "kind": "ui-named-argument",
@@ -10383,7 +10383,7 @@
       "path": "apps/ios/Sources/Design/OpenClawDocsScreen.swift",
       "source": "Mobile setup codes, QR, and node approval.",
       "surface": "apple",
-      "id": "native.apple.04a62e7d37c97129"
+      "id": "native.apple.5217a044d98947d5"
     },
     {
       "kind": "ui-call",
@@ -10391,7 +10391,7 @@
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Request ID: \\(value)",
       "surface": "apple",
-      "id": "native.apple.def747b532c8cc10"
+      "id": "native.apple.f36a9ff70377109b"
     },
     {
       "kind": "ui-modifier",
@@ -10399,7 +10399,7 @@
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "OpenClaw",
       "surface": "apple",
-      "id": "native.apple.8ccc4a8d1a4a904b"
+      "id": "native.apple.cf9bb65f8e405cc8"
     },
     {
       "kind": "ui-modifier",
@@ -10407,7 +10407,7 @@
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Gateway \\(self.title)",
       "surface": "apple",
-      "id": "native.apple.53841314242e9b14"
+      "id": "native.apple.51c566ed34b67acf"
     },
     {
       "kind": "conditional-branch",
@@ -10415,7 +10415,7 @@
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Online",
       "surface": "apple",
-      "id": "native.apple.dcff65ad8bf64957"
+      "id": "native.apple.72baecec6cf1b462"
     },
     {
       "kind": "conditional-branch",
@@ -10423,7 +10423,7 @@
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Connecting",
       "surface": "apple",
-      "id": "native.apple.eb7444b4c1a37f3d"
+      "id": "native.apple.ca9dfb05d9034ff7"
     },
     {
       "kind": "conditional-branch",
@@ -10431,7 +10431,7 @@
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Attention",
       "surface": "apple",
-      "id": "native.apple.9fbc88df62ebf3d8"
+      "id": "native.apple.d7a3d53412e23e88"
     },
     {
       "kind": "conditional-branch",
@@ -10439,7 +10439,7 @@
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Offline",
       "surface": "apple",
-      "id": "native.apple.42e6cb6c54619df1"
+      "id": "native.apple.1fc3cbd16076f75f"
     },
     {
       "kind": "ui-modifier",
@@ -10447,7 +10447,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Control",
       "surface": "apple",
-      "id": "native.apple.4883398341dc7aa0"
+      "id": "native.apple.a2d8e7b4dba29764"
     },
     {
       "kind": "ui-modifier",
@@ -10455,7 +10455,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Opens Settings / Gateway",
       "surface": "apple",
-      "id": "native.apple.465b1445efb3da90"
+      "id": "native.apple.597471e86dda3d38"
     },
     {
       "kind": "ui-named-argument",
@@ -10463,7 +10463,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Agent chat and recent work.",
       "surface": "apple",
-      "id": "native.apple.d8667bf65ab3e4f1"
+      "id": "native.apple.ed16c9793f468dcd"
     },
     {
       "kind": "ui-named-argument",
@@ -10471,7 +10471,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Realtime voice and controls.",
       "surface": "apple",
-      "id": "native.apple.f3c7630577053de4"
+      "id": "native.apple.a30d0a950d0a77aa"
     },
     {
       "kind": "ui-named-argument",
@@ -10479,7 +10479,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Overview",
       "surface": "apple",
-      "id": "native.apple.a5bd3566d760b166"
+      "id": "native.apple.a03e961ab14ba060"
     },
     {
       "kind": "ui-named-argument",
@@ -10487,7 +10487,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Instances",
       "surface": "apple",
-      "id": "native.apple.cabc2b15a2b72ca6"
+      "id": "native.apple.feb28c9cba676ba2"
     },
     {
       "kind": "ui-named-argument",
@@ -10495,7 +10495,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Files",
       "surface": "apple",
-      "id": "native.apple.b0ff384e03794169"
+      "id": "native.apple.3f2726ccd1acd987"
     },
     {
       "kind": "ui-named-argument",
@@ -10503,7 +10503,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Dreaming",
       "surface": "apple",
-      "id": "native.apple.81636957f8c74c24"
+      "id": "native.apple.614c9b40919fb103"
     },
     {
       "kind": "ui-named-argument",
@@ -10511,7 +10511,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Usage",
       "surface": "apple",
-      "id": "native.apple.6d80ef2f1402b026"
+      "id": "native.apple.e2b5c2d7c5d461a3"
     },
     {
       "kind": "ui-named-argument",
@@ -10519,7 +10519,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Cron Jobs",
       "surface": "apple",
-      "id": "native.apple.ae4c14b1758ac672"
+      "id": "native.apple.9eb33a11fb81796b"
     },
     {
       "kind": "ui-call",
@@ -10527,7 +10527,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Gateway",
       "surface": "apple",
-      "id": "native.apple.57b584ff83b40beb"
+      "id": "native.apple.e0e99a802f07cc68"
     },
     {
       "kind": "ui-call",
@@ -10535,7 +10535,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Gateway \\(self.gatewayStateText), \\(gatewayDisplayLabel), \\(self.sidebarActiveAgentTitle)",
       "surface": "apple",
-      "id": "native.apple.8f80f56442bc2abd"
+      "id": "native.apple.e30d7d35682e8ffa"
     },
     {
       "kind": "ui-call",
@@ -10543,7 +10543,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Gateway \\(self.gatewayStateText), \\(self.sidebarActiveAgentTitle)",
       "surface": "apple",
-      "id": "native.apple.61e9abc9db4ec4fb"
+      "id": "native.apple.75b65c24f3607c35"
     },
     {
       "kind": "conditional-branch",
@@ -10551,7 +10551,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Online",
       "surface": "apple",
-      "id": "native.apple.b125d7318f96ef61"
+      "id": "native.apple.01ad746119fbc27d"
     },
     {
       "kind": "conditional-branch",
@@ -10559,7 +10559,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Connecting",
       "surface": "apple",
-      "id": "native.apple.ffb669ae1646d183"
+      "id": "native.apple.e253ef19f6e53371"
     },
     {
       "kind": "conditional-branch",
@@ -10567,7 +10567,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Attention",
       "surface": "apple",
-      "id": "native.apple.a5693bac0436c69d"
+      "id": "native.apple.6f28b07ebdc2b25d"
     },
     {
       "kind": "conditional-branch",
@@ -10575,7 +10575,7 @@
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Offline",
       "surface": "apple",
-      "id": "native.apple.ebf806b5a1ff167b"
+      "id": "native.apple.1c931bcd1cd20334"
     },
     {
       "kind": "ui-call",
@@ -10583,7 +10583,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Channels / Integrations",
       "surface": "apple",
-      "id": "native.apple.96e79ba170adea15"
+      "id": "native.apple.65602c216b89032d"
     },
     {
       "kind": "ui-named-argument",
@@ -10591,7 +10591,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Loading channels",
       "surface": "apple",
-      "id": "native.apple.7efea4282407470c"
+      "id": "native.apple.aacfc3d31109d5ab"
     },
     {
       "kind": "ui-named-argument",
@@ -10599,7 +10599,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Fetching installed channels, accounts, and routing status from the gateway.",
       "surface": "apple",
-      "id": "native.apple.7b12c5deebaa94bf"
+      "id": "native.apple.373913573fe8474a"
     },
     {
       "kind": "ui-call",
@@ -10607,7 +10607,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Stop",
       "surface": "apple",
-      "id": "native.apple.6e7f0741e6ab8b1f"
+      "id": "native.apple.d0eb2c9b73d0e34c"
     },
     {
       "kind": "ui-call",
@@ -10615,7 +10615,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Start",
       "surface": "apple",
-      "id": "native.apple.2dff13408913eaf1"
+      "id": "native.apple.4333e9ef3a21e90e"
     },
     {
       "kind": "ui-call",
@@ -10623,7 +10623,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Logout",
       "surface": "apple",
-      "id": "native.apple.968335a401d81cc7"
+      "id": "native.apple.19108f0f755e083d"
     },
     {
       "kind": "conditional-branch",
@@ -10631,7 +10631,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Could not encode channel request.",
       "surface": "apple",
-      "id": "native.apple.e0dc5c4065a92e3c"
+      "id": "native.apple.9ac0bbf442dd842f"
     },
     {
       "kind": "ui-call",
@@ -10639,7 +10639,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Connected",
       "surface": "apple",
-      "id": "native.apple.d50654ae6808d0a7"
+      "id": "native.apple.98c951a7322c94dc"
     },
     {
       "kind": "ui-call",
@@ -10647,7 +10647,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Loading",
       "surface": "apple",
-      "id": "native.apple.a45c8e447188a0cb"
+      "id": "native.apple.e9a0639e3df7d270"
     },
     {
       "kind": "ui-named-argument",
@@ -10655,7 +10655,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Loading channel status",
       "surface": "apple",
-      "id": "native.apple.bc112e895fd77b31"
+      "id": "native.apple.39ec8a10330f9bb0"
     },
     {
       "kind": "ui-named-argument",
@@ -10663,7 +10663,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Checking installed channel clients and account state.",
       "surface": "apple",
-      "id": "native.apple.8b9242b781898b0a"
+      "id": "native.apple.2183ebee2edb4b04"
     },
     {
       "kind": "ui-call",
@@ -10671,7 +10671,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Empty",
       "surface": "apple",
-      "id": "native.apple.366a77f110681578"
+      "id": "native.apple.5499301c35444424"
     },
     {
       "kind": "ui-named-argument",
@@ -10679,7 +10679,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Message Routing",
       "surface": "apple",
-      "id": "native.apple.0c8a603f7646e0a6"
+      "id": "native.apple.5fbbe373a4d427fa"
     },
     {
       "kind": "ui-named-argument",
@@ -10687,7 +10687,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Refresh Channels",
       "surface": "apple",
-      "id": "native.apple.523ea4b446a6d72a"
+      "id": "native.apple.9918aa58bf346645"
     },
     {
       "kind": "ui-named-argument",
@@ -10695,7 +10695,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "No channel plugins reported",
       "surface": "apple",
-      "id": "native.apple.4ba6c1af518dedff"
+      "id": "native.apple.de33101d0c049a5f"
     },
     {
       "kind": "ui-named-argument",
@@ -10703,7 +10703,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Install or enable channel plugins on the gateway, then refresh.",
       "surface": "apple",
-      "id": "native.apple.8cab40fe53165339"
+      "id": "native.apple.afee604367e1caee"
     },
     {
       "kind": "ui-call",
@@ -10711,7 +10711,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Error",
       "surface": "apple",
-      "id": "native.apple.be909d396399237b"
+      "id": "native.apple.67ef5e90c3ea315b"
     },
     {
       "kind": "ui-named-argument",
@@ -10719,7 +10719,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Channel status unavailable",
       "surface": "apple",
-      "id": "native.apple.1b5e3bf243a6ebd8"
+      "id": "native.apple.aa97425de5b33828"
     },
     {
       "kind": "ui-named-argument",
@@ -10727,7 +10727,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Gateway returned an unexpected channel status response.",
       "surface": "apple",
-      "id": "native.apple.94f73cc6841fe247"
+      "id": "native.apple.889115c46972d544"
     },
     {
       "kind": "ui-call",
@@ -10735,7 +10735,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Offline",
       "surface": "apple",
-      "id": "native.apple.82f15aba24e2fafb"
+      "id": "native.apple.042fad5f44e4a00c"
     },
     {
       "kind": "ui-named-argument",
@@ -10743,7 +10743,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Gateway offline",
       "surface": "apple",
-      "id": "native.apple.e66416898782fbcc"
+      "id": "native.apple.59c349b1b581354f"
     },
     {
       "kind": "ui-named-argument",
@@ -10751,7 +10751,7 @@
       "path": "apps/ios/Sources/Design/SettingsChannelsDestination.swift",
       "source": "Connect to the gateway to load installed channels, accounts, and routing status.",
       "surface": "apple",
-      "id": "native.apple.37e299525940057f"
+      "id": "native.apple.6308264d116d5be6"
     },
     {
       "kind": "ui-modifier",
@@ -10759,7 +10759,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Settings",
       "surface": "apple",
-      "id": "native.apple.520d26673d6ad925"
+      "id": "native.apple.ecf68905545575e6"
     },
     {
       "kind": "ui-modifier",
@@ -10767,7 +10767,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Scan QR Code",
       "surface": "apple",
-      "id": "native.apple.8a9d262ac9a7af24"
+      "id": "native.apple.adae4106b8b9c38b"
     },
     {
       "kind": "ui-modifier",
@@ -10775,7 +10775,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Reset Onboarding?",
       "surface": "apple",
-      "id": "native.apple.94ebe6bce24af4a5"
+      "id": "native.apple.22b4d5d925ada9ee"
     },
     {
       "kind": "ui-call",
@@ -10783,7 +10783,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Reset",
       "surface": "apple",
-      "id": "native.apple.606b02f9771a84d5"
+      "id": "native.apple.4ed955a25c8ed47c"
     },
     {
       "kind": "ui-call",
@@ -10791,7 +10791,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "This disconnects, clears saved gateway credentials, and reopens onboarding.",
       "surface": "apple",
-      "id": "native.apple.ea7d7870072619ab"
+      "id": "native.apple.800904a3c6cdc147"
     },
     {
       "kind": "ui-modifier",
@@ -10799,7 +10799,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "QR Scanner Unavailable",
       "surface": "apple",
-      "id": "native.apple.d7d993f61b8f2153"
+      "id": "native.apple.fed30be42b5be08e"
     },
     {
       "kind": "ui-call",
@@ -10807,7 +10807,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "OK",
       "surface": "apple",
-      "id": "native.apple.19664950840c36c0"
+      "id": "native.apple.541078d5af9de662"
     },
     {
       "kind": "ui-modifier",
@@ -10815,7 +10815,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Access Level",
       "surface": "apple",
-      "id": "native.apple.8eb3e4a8f5d9fa07"
+      "id": "native.apple.32230ecb2fbc2378"
     },
     {
       "kind": "ui-call",
@@ -10823,7 +10823,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "While Using the App",
       "surface": "apple",
-      "id": "native.apple.67b51ea21c427c4b"
+      "id": "native.apple.7ed27029e9c313cc"
     },
     {
       "kind": "ui-call",
@@ -10831,7 +10831,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Always",
       "surface": "apple",
-      "id": "native.apple.33beb5644e52f122"
+      "id": "native.apple.b975064b240c9fd6"
     },
     {
       "kind": "ui-call",
@@ -10839,7 +10839,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Choose when OpenClaw may share this iPhone's location with gateway tools.",
       "surface": "apple",
-      "id": "native.apple.e124c1310f5bd253"
+      "id": "native.apple.756ff21ca904b2d8"
     },
     {
       "kind": "ui-modifier",
@@ -10855,7 +10855,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Forget Gateway",
       "surface": "apple",
-      "id": "native.apple.e04f0bf5056c4892"
+      "id": "native.apple.ab8d7959b6ab66f9"
     },
     {
       "kind": "ui-call",
@@ -10863,7 +10863,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Cancel",
       "surface": "apple",
-      "id": "native.apple.1ea33287d0845846"
+      "id": "native.apple.0cb64be43c0b3d97"
     },
     {
       "kind": "ui-call-concatenated",
@@ -10871,7 +10871,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "This removes saved credentials, device access, TLS trust, and cached chats for this gateway.",
       "surface": "apple",
-      "id": "native.apple.0735bc878408b001"
+      "id": "native.apple.53bb7808a1ae62bb"
     },
     {
       "kind": "ui-call",
@@ -10879,7 +10879,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Enable OpenClaw Hosted Push Relay?",
       "surface": "apple",
-      "id": "native.apple.b71aa3216235c1dd"
+      "id": "native.apple.9bb1dae351d0e3a4"
     },
     {
       "kind": "ui-call",
@@ -10887,7 +10887,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Continue",
       "surface": "apple",
-      "id": "native.apple.e0285faf26771e5e"
+      "id": "native.apple.f8c042a923222472"
     },
     {
       "kind": "ui-call",
@@ -10895,7 +10895,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Not Now",
       "surface": "apple",
-      "id": "native.apple.27763ca1db2aae66"
+      "id": "native.apple.e212e27354542d3b"
     },
     {
       "kind": "ui-call",
@@ -10903,7 +10903,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Checks",
       "surface": "apple",
-      "id": "native.apple.812b1afdc0149f1d"
+      "id": "native.apple.d77230c105bfb69f"
     },
     {
       "kind": "ui-named-argument",
@@ -10911,7 +10911,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Last Run",
       "surface": "apple",
-      "id": "native.apple.34b636a28a323db6"
+      "id": "native.apple.00a5d93faa0d6491"
     },
     {
       "kind": "ui-named-argument",
@@ -10919,7 +10919,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Gateway Link",
       "surface": "apple",
-      "id": "native.apple.4c825af0bbfc1f19"
+      "id": "native.apple.75c3292448aa0f89"
     },
     {
       "kind": "ui-named-argument",
@@ -10927,7 +10927,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Discovery",
       "surface": "apple",
-      "id": "native.apple.9116327e75750671"
+      "id": "native.apple.33a2c183e95f7a3b"
     },
     {
       "kind": "ui-named-argument",
@@ -10935,7 +10935,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Talk Config",
       "surface": "apple",
-      "id": "native.apple.2f230d6f3b54c99e"
+      "id": "native.apple.950847e4e29fc836"
     },
     {
       "kind": "ui-named-argument",
@@ -10943,7 +10943,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Notifications",
       "surface": "apple",
-      "id": "native.apple.2c51e14332f0cc71"
+      "id": "native.apple.2a54915eabe91c06"
     },
     {
       "kind": "ui-named-argument",
@@ -10951,7 +10951,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Approval and event alert channel",
       "surface": "apple",
-      "id": "native.apple.7aa132aaf9f3e0ab"
+      "id": "native.apple.5f795158b2f43ea8"
     },
     {
       "kind": "ui-named-argument",
@@ -10959,7 +10959,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Screen Capture",
       "surface": "apple",
-      "id": "native.apple.9141bdd675672a6b"
+      "id": "native.apple.ab6c665aea1a9525"
     },
     {
       "kind": "ui-named-argument",
@@ -10967,7 +10967,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Live foreground capture state",
       "surface": "apple",
-      "id": "native.apple.8d189015d58b40e3"
+      "id": "native.apple.d5c33a7a3b374f89"
     },
     {
       "kind": "ui-named-argument",
@@ -10975,7 +10975,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Voice Wake",
       "surface": "apple",
-      "id": "native.apple.d3f62f328adce82b"
+      "id": "native.apple.e641f2eb5c7bce81"
     },
     {
       "kind": "conditional-branch",
@@ -10991,7 +10991,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Discovered",
       "surface": "apple",
-      "id": "native.apple.188eb42d49f56b6c"
+      "id": "native.apple.0a3f566ac6a35d90"
     },
     {
       "kind": "conditional-branch",
@@ -10999,7 +10999,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Discovered • TLS",
       "surface": "apple",
-      "id": "native.apple.06da175683078b92"
+      "id": "native.apple.1fe7af76a372f7dd"
     },
     {
       "kind": "conditional-branch",
@@ -11007,7 +11007,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "surface": "apple",
-      "id": "native.apple.97b4f45efb35431f"
+      "id": "native.apple.3503aca018f04865"
     },
     {
       "kind": "conditional-branch",
@@ -11015,7 +11015,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
       "surface": "apple",
-      "id": "native.apple.28b25a11c0c8692a"
+      "id": "native.apple.a9a778465dfe1198"
     },
     {
       "kind": "conditional-branch",
@@ -11023,7 +11023,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Configured",
       "surface": "apple",
-      "id": "native.apple.5ec38987b39279be"
+      "id": "native.apple.fbf8fb158f556a76"
     },
     {
       "kind": "conditional-branch",
@@ -11031,7 +11031,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Not configured",
       "surface": "apple",
-      "id": "native.apple.792865cc320e22a5"
+      "id": "native.apple.ad28c6e82fda63b0"
     },
     {
       "kind": "conditional-branch",
@@ -11047,7 +11047,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connect to the gateway.",
       "surface": "apple",
-      "id": "native.apple.aba908391206b282"
+      "id": "native.apple.0e6f25ab4a59543a"
     },
     {
       "kind": "conditional-branch",
@@ -11055,7 +11055,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Gateway requests will appear here.",
       "surface": "apple",
-      "id": "native.apple.08f8ff249eb92776"
+      "id": "native.apple.0b7a54926d06b7d8"
     },
     {
       "kind": "conditional-branch",
@@ -11079,7 +11079,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "High",
       "surface": "apple",
-      "id": "native.apple.0e6374735564f939"
+      "id": "native.apple.0194fd3744125fd1"
     },
     {
       "kind": "conditional-branch",
@@ -11087,7 +11087,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Resolving",
       "surface": "apple",
-      "id": "native.apple.65db2459c9fe2ffd"
+      "id": "native.apple.cf64badb547e25c3"
     },
     {
       "kind": "conditional-branch",
@@ -11095,7 +11095,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "One-time approval",
       "surface": "apple",
-      "id": "native.apple.f8a79e13751914d9"
+      "id": "native.apple.c84829a753b01fe6"
     },
     {
       "kind": "conditional-branch",
@@ -11103,7 +11103,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Permission can be saved",
       "surface": "apple",
-      "id": "native.apple.062831956ee66b51"
+      "id": "native.apple.b02830c5966591df"
     },
     {
       "kind": "conditional-branch",
@@ -11111,7 +11111,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Medium",
       "surface": "apple",
-      "id": "native.apple.1d997081ebcef122"
+      "id": "native.apple.3ce9dc6fee455ee5"
     },
     {
       "kind": "conditional-branch",
@@ -11119,7 +11119,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Review",
       "surface": "apple",
-      "id": "native.apple.778b4f9ae0fe994d"
+      "id": "native.apple.7d5aa3128fb859da"
     },
     {
       "kind": "conditional-branch",
@@ -11127,7 +11127,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "\\(diagnosticsIssueCount)",
       "surface": "apple",
-      "id": "native.apple.a95f6fe71bb1c4d1"
+      "id": "native.apple.8ae57748b0b13d62"
     },
     {
       "kind": "ui-modifier",
@@ -11135,7 +11135,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Choose system, light, or dark appearance",
       "surface": "apple",
-      "id": "native.apple.971844abef4e01c9"
+      "id": "native.apple.80fade864c8ad242"
     },
     {
       "kind": "ui-call",
@@ -11143,7 +11143,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Appearance",
       "surface": "apple",
-      "id": "native.apple.067a5d2d5d180bc6"
+      "id": "native.apple.747143c7ef879774"
     },
     {
       "kind": "conditional-branch",
@@ -11151,7 +11151,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Selected",
       "surface": "apple",
-      "id": "native.apple.4c364abf4a9f934b"
+      "id": "native.apple.f459c262b181a64b"
     },
     {
       "kind": "ui-call",
@@ -11159,7 +11159,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "System follows this device’s appearance setting.",
       "surface": "apple",
-      "id": "native.apple.5b72a4a0846d9de9"
+      "id": "native.apple.998482352d20ebaa"
     },
     {
       "kind": "ui-call",
@@ -11167,7 +11167,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Connection",
       "surface": "apple",
-      "id": "native.apple.2b7499c8af24e546"
+      "id": "native.apple.70eca66c79335a6e"
     },
     {
       "kind": "ui-named-argument",
@@ -11175,7 +11175,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Permissions",
       "surface": "apple",
-      "id": "native.apple.bac6ce1e60b68af6"
+      "id": "native.apple.2c2cdafd79f8ba5b"
     },
     {
       "kind": "ui-named-argument",
@@ -11183,7 +11183,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Channels",
       "surface": "apple",
-      "id": "native.apple.5237358181ee8cdf"
+      "id": "native.apple.8a159fab30307884"
     },
     {
       "kind": "ui-named-argument",
@@ -11191,7 +11191,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Diagnostics",
       "surface": "apple",
-      "id": "native.apple.2ac8e6968f723a6e"
+      "id": "native.apple.1573249126ddd84f"
     },
     {
       "kind": "ui-named-argument",
@@ -11199,7 +11199,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Privacy",
       "surface": "apple",
-      "id": "native.apple.0b3b9fcae57baa54"
+      "id": "native.apple.464377858fd51ef3"
     },
     {
       "kind": "ui-named-argument",
@@ -11207,7 +11207,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "About",
       "surface": "apple",
-      "id": "native.apple.51487d4944f7e0ae"
+      "id": "native.apple.f52553cad6c1f307"
     },
     {
       "kind": "ui-named-argument",
@@ -11215,7 +11215,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Licenses",
       "surface": "apple",
-      "id": "native.apple.55e8c7024736b1a7"
+      "id": "native.apple.529c06f7f7f6e428"
     },
     {
       "kind": "ui-named-argument",
@@ -11223,7 +11223,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway",
       "surface": "apple",
-      "id": "native.apple.edb095efd13ebfdc"
+      "id": "native.apple.5c4427c5a67068d6"
     },
     {
       "kind": "ui-call",
@@ -11231,7 +11231,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Address",
       "surface": "apple",
-      "id": "native.apple.52279c4b046bb63d"
+      "id": "native.apple.800b6502b5b49941"
     },
     {
       "kind": "ui-call",
@@ -11239,7 +11239,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Server",
       "surface": "apple",
-      "id": "native.apple.6f9634642f8cbeb7"
+      "id": "native.apple.fde8b41db7ec49f3"
     },
     {
       "kind": "ui-call",
@@ -11247,7 +11247,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovered",
       "surface": "apple",
-      "id": "native.apple.d2e489a70a83e516"
+      "id": "native.apple.624f9dc99e8f9ff4"
     },
     {
       "kind": "ui-call",
@@ -11255,7 +11255,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Agents",
       "surface": "apple",
-      "id": "native.apple.494217d3fb8c09fa"
+      "id": "native.apple.8e3656d85f092897"
     },
     {
       "kind": "ui-modifier",
@@ -11263,7 +11263,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Switch Gateway",
       "surface": "apple",
-      "id": "native.apple.e7d1a835000a7a85"
+      "id": "native.apple.88835de05348122a"
     },
     {
       "kind": "ui-named-argument",
@@ -11271,7 +11271,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Approvals",
       "surface": "apple",
-      "id": "native.apple.67d6c8ced44b370d"
+      "id": "native.apple.3c8f5bb5ce507cf9"
     },
     {
       "kind": "conditional-branch",
@@ -11287,7 +11287,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "No gateway actions are waiting for review.",
       "surface": "apple",
-      "id": "native.apple.6d7cc3eec4d32226"
+      "id": "native.apple.bbc85e1645e8ccf1"
     },
     {
       "kind": "conditional-branch",
@@ -11311,7 +11311,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Apple Watch",
       "surface": "apple",
-      "id": "native.apple.73793edde8e57a57"
+      "id": "native.apple.561d865ad24910d2"
     },
     {
       "kind": "conditional-branch",
@@ -11319,7 +11319,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Relay remains available; direct mode adds an independent Gateway node.",
       "surface": "apple",
-      "id": "native.apple.6a046fd93df77020"
+      "id": "native.apple.df05bfb397806b0d"
     },
     {
       "kind": "conditional-branch",
@@ -11327,7 +11327,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Install the OpenClaw watch app before enabling direct mode.",
       "surface": "apple",
-      "id": "native.apple.f31590a34ada7ea2"
+      "id": "native.apple.1bd0f0b41f4d4750"
     },
     {
       "kind": "conditional-branch",
@@ -11335,7 +11335,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Installed",
       "surface": "apple",
-      "id": "native.apple.1965c06e17786ed2"
+      "id": "native.apple.cfa1c0be2d607257"
     },
     {
       "kind": "conditional-branch",
@@ -11351,7 +11351,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Unavailable",
       "surface": "apple",
-      "id": "native.apple.19733b4ad0362082"
+      "id": "native.apple.59405b82eb08ae1e"
     },
     {
       "kind": "ui-call",
@@ -11359,7 +11359,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Enable Direct Gateway Connection",
       "surface": "apple",
-      "id": "native.apple.add90173692666d2"
+      "id": "native.apple.0177670438314602"
     },
     {
       "kind": "ui-call",
@@ -11367,7 +11367,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "The watch receives a one-time pairing code and stores its own device token. A reachable secure Gateway URL is required away from the iPhone.",
       "surface": "apple",
-      "id": "native.apple.e0c6c949870b9c86"
+      "id": "native.apple.eff9b913b3ae1c89"
     },
     {
       "kind": "ui-call",
@@ -11375,7 +11375,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Direct node features",
       "surface": "apple",
-      "id": "native.apple.04943319a7abf864"
+      "id": "native.apple.c46c07933202448e"
     },
     {
       "kind": "ui-call",
@@ -11383,7 +11383,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Notifications are off",
       "surface": "apple",
-      "id": "native.apple.7624063ebdbd3069"
+      "id": "native.apple.db2079af09ca465a"
     },
     {
       "kind": "ui-call",
@@ -11391,7 +11391,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Enable Notifications to receive approval alerts while OpenClaw is not open.",
       "surface": "apple",
-      "id": "native.apple.9b0d31ed51e810b9"
+      "id": "native.apple.2e042499c42824f5"
     },
     {
       "kind": "ui-call",
@@ -11399,7 +11399,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Open Notifications",
       "surface": "apple",
-      "id": "native.apple.0834d89936666a38"
+      "id": "native.apple.fc1f2fdbe437cb9d"
     },
     {
       "kind": "ui-call",
@@ -11447,7 +11447,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Deny",
       "surface": "apple",
-      "id": "native.apple.7f6a03ac2a3d3686"
+      "id": "native.apple.47aa34a39a9e05e5"
     },
     {
       "kind": "ui-call",
@@ -11463,7 +11463,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "No approvals waiting",
       "surface": "apple",
-      "id": "native.apple.9e6b547853ee3916"
+      "id": "native.apple.9bc57eb179ada99d"
     },
     {
       "kind": "ui-named-argument",
@@ -11471,7 +11471,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Camera",
       "surface": "apple",
-      "id": "native.apple.c2d8d7de9ce25b08"
+      "id": "native.apple.8486e210bfe6a446"
     },
     {
       "kind": "ui-named-argument",
@@ -11479,7 +11479,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Keep Awake",
       "surface": "apple",
-      "id": "native.apple.d4db6d03f0bdab56"
+      "id": "native.apple.1826e2be7765ee28"
     },
     {
       "kind": "ui-named-argument",
@@ -11487,7 +11487,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice & Talk",
       "surface": "apple",
-      "id": "native.apple.560ef3ee39afa2fe"
+      "id": "native.apple.1dc29a33b5cd648a"
     },
     {
       "kind": "ui-named-argument",
@@ -11495,7 +11495,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Health Check",
       "surface": "apple",
-      "id": "native.apple.97b060c5444877f6"
+      "id": "native.apple.a387f8cb16d76a93"
     },
     {
       "kind": "ui-named-argument",
@@ -11503,7 +11503,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Run app, permission, and gateway-adjacent checks without editing setup.",
       "surface": "apple",
-      "id": "native.apple.9c2f6fa6cfa61b7e"
+      "id": "native.apple.076a83f6eed9161a"
     },
     {
       "kind": "ui-call",
@@ -11511,7 +11511,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Run Diagnostics",
       "surface": "apple",
-      "id": "native.apple.9b1338a386c54ec0"
+      "id": "native.apple.e06f8e5c2bb61fe0"
     },
     {
       "kind": "ui-call",
@@ -11519,7 +11519,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Platform",
       "surface": "apple",
-      "id": "native.apple.4b98da9e8179b554"
+      "id": "native.apple.83d3e72aa909f1a7"
     },
     {
       "kind": "ui-call",
@@ -11527,7 +11527,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "App",
       "surface": "apple",
-      "id": "native.apple.4c50f9294f49ea75"
+      "id": "native.apple.a67b37443560bdef"
     },
     {
       "kind": "ui-call",
@@ -11535,7 +11535,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Model",
       "surface": "apple",
-      "id": "native.apple.ed93ba5b5fb421e9"
+      "id": "native.apple.6a7636305327b0fd"
     },
     {
       "kind": "ui-named-argument",
@@ -11543,7 +11543,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Camera Access",
       "surface": "apple",
-      "id": "native.apple.cb9766c0f02db23c"
+      "id": "native.apple.11954b310eb31f5e"
     },
     {
       "kind": "ui-named-argument",
@@ -11551,7 +11551,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Background Listening",
       "surface": "apple",
-      "id": "native.apple.afd7a9bacf121f8e"
+      "id": "native.apple.a0ed2e431173327d"
     },
     {
       "kind": "ui-call",
@@ -11559,7 +11559,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Notifications",
       "surface": "apple",
-      "id": "native.apple.227eaf4ef28e1a09"
+      "id": "native.apple.bf8da7a7b0730861"
     },
     {
       "kind": "ui-modifier",
@@ -11567,7 +11567,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Turns OpenClaw notification delivery on or off",
       "surface": "apple",
-      "id": "native.apple.aeb8d6201e4faa50"
+      "id": "native.apple.d1ee91d07764faf0"
     },
     {
       "kind": "ui-named-argument",
@@ -11575,7 +11575,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Reconnect",
       "surface": "apple",
-      "id": "native.apple.1239441ee0ab3262"
+      "id": "native.apple.31f9c5fa6c3ca5dd"
     },
     {
       "kind": "ui-named-argument",
@@ -11583,7 +11583,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Diagnose",
       "surface": "apple",
-      "id": "native.apple.3a588bbe942e2b6b"
+      "id": "native.apple.1dc0c6ff4da2deca"
     },
     {
       "kind": "ui-call",
@@ -11591,7 +11591,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "License files are not available in this build.",
       "surface": "apple",
-      "id": "native.apple.6f2fccdccf984741"
+      "id": "native.apple.af22fba4150f2c1d"
     },
     {
       "kind": "ui-call",
@@ -11599,7 +11599,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "OpenClaw appreciates its partners in the open-source community.",
       "surface": "apple",
-      "id": "native.apple.91db6b9cf4db2aaa"
+      "id": "native.apple.a82dc4a746268028"
     },
     {
       "kind": "ui-call",
@@ -11607,7 +11607,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "OpenClaw",
       "surface": "apple",
-      "id": "native.apple.31ec646e921aa707"
+      "id": "native.apple.fc49f9b63e160581"
     },
     {
       "kind": "ui-call",
@@ -11615,7 +11615,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Personal AI on your devices",
       "surface": "apple",
-      "id": "native.apple.ca81d76f6bd3762a"
+      "id": "native.apple.eaa4fe72f3730f3f"
     },
     {
       "kind": "ui-call",
@@ -11623,7 +11623,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "iOS",
       "surface": "apple",
-      "id": "native.apple.56bd1f113649f6f7"
+      "id": "native.apple.bbb2c589c2049217"
     },
     {
       "kind": "ui-named-argument",
@@ -11631,7 +11631,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Website",
       "surface": "apple",
-      "id": "native.apple.b7d2d3ca0b4c13c1"
+      "id": "native.apple.9f71c5c00d1bba49"
     },
     {
       "kind": "ui-named-argument",
@@ -11639,7 +11639,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Docs",
       "surface": "apple",
-      "id": "native.apple.7f5c2ebb7bb8d7d8"
+      "id": "native.apple.7d10fb0ea5b704fa"
     },
     {
       "kind": "ui-named-argument",
@@ -11647,7 +11647,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "GitHub",
       "surface": "apple",
-      "id": "native.apple.2f8329d5bd85b3ea"
+      "id": "native.apple.e501402343d42f4d"
     },
     {
       "kind": "ui-named-argument",
@@ -11655,7 +11655,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discord",
       "surface": "apple",
-      "id": "native.apple.ee232b946bcd09ad"
+      "id": "native.apple.ee880812d92bcacf"
     },
     {
       "kind": "ui-call",
@@ -11663,7 +11663,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "© 2026 OpenClaw Foundation — MIT License.",
       "surface": "apple",
-      "id": "native.apple.aaf59ca16bbe895a"
+      "id": "native.apple.b962116ff5bf1905"
     },
     {
       "kind": "ui-call",
@@ -11671,7 +11671,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Title",
       "surface": "apple",
-      "id": "native.apple.1e0af5cbf7032c15"
+      "id": "native.apple.106434d1305d153b"
     },
     {
       "kind": "ui-call",
@@ -11679,7 +11679,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Location",
       "surface": "apple",
-      "id": "native.apple.fa96d0964c4e4dd0"
+      "id": "native.apple.0535a52a62812307"
     },
     {
       "kind": "ui-modifier",
@@ -11687,7 +11687,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Location Sharing",
       "surface": "apple",
-      "id": "native.apple.0b66acb9f386d26f"
+      "id": "native.apple.72d124648efb5a97"
     },
     {
       "kind": "ui-call",
@@ -11695,7 +11695,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Access Level",
       "surface": "apple",
-      "id": "native.apple.fb2945d3d5f6f97f"
+      "id": "native.apple.aadb749ebce75251"
     },
     {
       "kind": "ui-modifier",
@@ -11703,7 +11703,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Chooses While Using the App or Always",
       "surface": "apple",
-      "id": "native.apple.d22aef6c0256dece"
+      "id": "native.apple.d8c7ed70277b3ff1"
     },
     {
       "kind": "ui-call",
@@ -11711,7 +11711,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Default Agent",
       "surface": "apple",
-      "id": "native.apple.24f7b511e01a8d15"
+      "id": "native.apple.cb38cf4f01de7a6d"
     },
     {
       "kind": "ui-call",
@@ -11719,7 +11719,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Default",
       "surface": "apple",
-      "id": "native.apple.48cbc4f5abe9e292"
+      "id": "native.apple.6ace5e6f09ec98c7"
     },
     {
       "kind": "ui-call",
@@ -11727,7 +11727,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Used for new Chat and Talk sessions.",
       "surface": "apple",
-      "id": "native.apple.6805480889265026"
+      "id": "native.apple.3de045f17ea3c6d0"
     },
     {
       "kind": "ui-call",
@@ -11735,7 +11735,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Paste setup code",
       "surface": "apple",
-      "id": "native.apple.3c667ebdaf176fb6"
+      "id": "native.apple.313eb24efcb8d4a0"
     },
     {
       "kind": "ui-named-argument",
@@ -11743,7 +11743,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Scan QR",
       "surface": "apple",
-      "id": "native.apple.9bf7cef3d081f023"
+      "id": "native.apple.19552e71de246322"
     },
     {
       "kind": "ui-named-argument",
@@ -11751,7 +11751,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Connect",
       "surface": "apple",
-      "id": "native.apple.ea22b78e5ab1b827"
+      "id": "native.apple.f4afcfbe4e4a72f8"
     },
     {
       "kind": "ui-call",
@@ -11759,7 +11759,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Setup Code",
       "surface": "apple",
-      "id": "native.apple.c95cd5b8711e54e3"
+      "id": "native.apple.d8a5510f1a2e1701"
     },
     {
       "kind": "ui-call",
@@ -11767,7 +11767,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovered Gateways",
       "surface": "apple",
-      "id": "native.apple.c66e36b5b3427183"
+      "id": "native.apple.adb22453596f1d78"
     },
     {
       "kind": "ui-call",
@@ -11775,7 +11775,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "surface": "apple",
-      "id": "native.apple.71f783b295743ef3"
+      "id": "native.apple.64b89f4aa3a81aef"
     },
     {
       "kind": "ui-call",
@@ -11783,7 +11783,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Pair a gateway to make it available here.",
       "surface": "apple",
-      "id": "native.apple.e5788ef9b2af9191"
+      "id": "native.apple.75c61c4ee1ecc6d8"
     },
     {
       "kind": "ui-call",
@@ -11791,7 +11791,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Paired Gateways",
       "surface": "apple",
-      "id": "native.apple.b1a5dd4a8435fa78"
+      "id": "native.apple.1ac3dd03c773c86a"
     },
     {
       "kind": "ui-call",
@@ -11799,7 +11799,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Switch gateways without pairing again.",
       "surface": "apple",
-      "id": "native.apple.aee28050f19601cf"
+      "id": "native.apple.9a6bd720a544ec04"
     },
     {
       "kind": "ui-modifier",
@@ -11807,7 +11807,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Active Gateway",
       "surface": "apple",
-      "id": "native.apple.096d4caf5244a452"
+      "id": "native.apple.5f33cfe2d21e6dc6"
     },
     {
       "kind": "ui-call",
@@ -11815,7 +11815,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Forget",
       "surface": "apple",
-      "id": "native.apple.b5cbb46b8dd65ef6"
+      "id": "native.apple.4e1792b1044ec4a9"
     },
     {
       "kind": "ui-call",
@@ -11823,7 +11823,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Forget Gateway",
       "surface": "apple",
-      "id": "native.apple.c88c16f2d5f7ecd4"
+      "id": "native.apple.da00d975209e0bb6"
     },
     {
       "kind": "ui-call",
@@ -11831,7 +11831,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Manual Gateway",
       "surface": "apple",
-      "id": "native.apple.5062aebdb0210ab9"
+      "id": "native.apple.08a67e763668db42"
     },
     {
       "kind": "ui-call",
@@ -11839,7 +11839,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Use Manual Gateway",
       "surface": "apple",
-      "id": "native.apple.3149f01b08d5e123"
+      "id": "native.apple.c39f3a597f674aca"
     },
     {
       "kind": "ui-call",
@@ -11847,7 +11847,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Host",
       "surface": "apple",
-      "id": "native.apple.682774caecd34b94"
+      "id": "native.apple.c3d6c69cdb46769e"
     },
     {
       "kind": "ui-call",
@@ -11855,7 +11855,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Port",
       "surface": "apple",
-      "id": "native.apple.fe67da4874dc59d2"
+      "id": "native.apple.600f8f373f177a74"
     },
     {
       "kind": "ui-call",
@@ -11863,7 +11863,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Unencrypted",
       "surface": "apple",
-      "id": "native.apple.64a579a8773c3cc4"
+      "id": "native.apple.74dd3ea86bc67545"
     },
     {
       "kind": "ui-call",
@@ -11871,7 +11871,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Secure (TLS)",
       "surface": "apple",
-      "id": "native.apple.49536933abe56786"
+      "id": "native.apple.8eca91d435b2aec0"
     },
     {
       "kind": "ui-call",
@@ -11879,7 +11879,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Connection security",
       "surface": "apple",
-      "id": "native.apple.166e500ba88914ed"
+      "id": "native.apple.ab61dd967122023c"
     },
     {
       "kind": "ui-named-argument",
@@ -11887,7 +11887,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Connect Manual",
       "surface": "apple",
-      "id": "native.apple.7990ce682bee850f"
+      "id": "native.apple.a3b6d069aebc0ab1"
     },
     {
       "kind": "ui-call",
@@ -11895,7 +11895,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Auto-connect on launch",
       "surface": "apple",
-      "id": "native.apple.a9f1e65b532cb33c"
+      "id": "native.apple.b156004754dc59bd"
     },
     {
       "kind": "ui-call",
@@ -11903,7 +11903,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Auth Token",
       "surface": "apple",
-      "id": "native.apple.bc98ab0e70108b88"
+      "id": "native.apple.cf932b2ca61d1e6b"
     },
     {
       "kind": "ui-call",
@@ -11911,7 +11911,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Password",
       "surface": "apple",
-      "id": "native.apple.951baab277b66642"
+      "id": "native.apple.92a1a902541660c4"
     },
     {
       "kind": "ui-call",
@@ -11919,7 +11919,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Custom Headers",
       "surface": "apple",
-      "id": "native.apple.c67da92370fa3a4c"
+      "id": "native.apple.438ae7e5b8544548"
     },
     {
       "kind": "ui-call",
@@ -11927,7 +11927,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Reset Onboarding",
       "surface": "apple",
-      "id": "native.apple.312828d3eec448f3"
+      "id": "native.apple.c9cd035bc39af480"
     },
     {
       "kind": "ui-call",
@@ -11935,7 +11935,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice Wake",
       "surface": "apple",
-      "id": "native.apple.e420a1d37795a358"
+      "id": "native.apple.5869824f66e222ed"
     },
     {
       "kind": "ui-call",
@@ -11943,7 +11943,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Talk Mode",
       "surface": "apple",
-      "id": "native.apple.09b42d493423bd70"
+      "id": "native.apple.88a997009842ffa0"
     },
     {
       "kind": "ui-call",
@@ -11951,7 +11951,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Speech Language",
       "surface": "apple",
-      "id": "native.apple.1c5b2360b2751a8b"
+      "id": "native.apple.1f3ab82ab342555c"
     },
     {
       "kind": "ui-call",
@@ -11959,7 +11959,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Speakerphone",
       "surface": "apple",
-      "id": "native.apple.d7e8acb877ffa385"
+      "id": "native.apple.518cef9408771a92"
     },
     {
       "kind": "ui-call",
@@ -11967,7 +11967,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Wake Words",
       "surface": "apple",
-      "id": "native.apple.2f38df824041778e"
+      "id": "native.apple.1604352fea16d495"
     },
     {
       "kind": "ui-call",
@@ -11975,7 +11975,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice",
       "surface": "apple",
-      "id": "native.apple.b1e74f9b4993d9ba"
+      "id": "native.apple.698d47c5569f8d3b"
     },
     {
       "kind": "ui-call",
@@ -11983,7 +11983,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Provider",
       "surface": "apple",
-      "id": "native.apple.5a50ff9d1498d13b"
+      "id": "native.apple.24ee619948d75837"
     },
     {
       "kind": "ui-call",
@@ -11991,7 +11991,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Realtime Voice",
       "surface": "apple",
-      "id": "native.apple.b10d027621f24380"
+      "id": "native.apple.47dd7fb00a4eb621"
     },
     {
       "kind": "ui-call",
@@ -11999,7 +11999,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Default",
       "surface": "apple",
-      "id": "native.apple.58ff78054dd585f4"
+      "id": "native.apple.8c4c000f6606efc6"
     },
     {
       "kind": "ui-call",
@@ -12007,7 +12007,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice Mode",
       "surface": "apple",
-      "id": "native.apple.7975561c52a9d131"
+      "id": "native.apple.55ddaeb92a2e98ff"
     },
     {
       "kind": "ui-call",
@@ -12015,7 +12015,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Active Voice",
       "surface": "apple",
-      "id": "native.apple.8a06e38a50ea9a5c"
+      "id": "native.apple.f384dc02b45f2fde"
     },
     {
       "kind": "ui-call",
@@ -12023,7 +12023,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Last Voice Issue",
       "surface": "apple",
-      "id": "native.apple.f0064f19c646b3f3"
+      "id": "native.apple.8a8d2629c30d57dd"
     },
     {
       "kind": "ui-call",
@@ -12031,7 +12031,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Transport",
       "surface": "apple",
-      "id": "native.apple.e7d3086462695804"
+      "id": "native.apple.38c50d290be5736c"
     },
     {
       "kind": "ui-call",
@@ -12039,7 +12039,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "API Key",
       "surface": "apple",
-      "id": "native.apple.94ee17ba8b0476dc"
+      "id": "native.apple.6e5b8e1e2b341677"
     },
     {
       "kind": "ui-call",
@@ -12047,7 +12047,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Show Talk Control",
       "surface": "apple",
-      "id": "native.apple.90fe9d867c7b69b8"
+      "id": "native.apple.27457003271bd73d"
     },
     {
       "kind": "ui-call",
@@ -12055,7 +12055,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Default Share Instruction",
       "surface": "apple",
-      "id": "native.apple.7299d852826e045a"
+      "id": "native.apple.1300f0857e49b6e9"
     },
     {
       "kind": "ui-call",
@@ -12063,7 +12063,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Run Share Self-Test",
       "surface": "apple",
-      "id": "native.apple.d68e2f63e54bf21d"
+      "id": "native.apple.ccb60c6b4d40b204"
     },
     {
       "kind": "ui-call",
@@ -12071,7 +12071,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovery Debug Logs",
       "surface": "apple",
-      "id": "native.apple.3a40d37fb7b8ce08"
+      "id": "native.apple.dfbbe0f7c038894a"
     },
     {
       "kind": "ui-call",
@@ -12079,7 +12079,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Debug Screen Status",
       "surface": "apple",
-      "id": "native.apple.f69932b3ed05ba5b"
+      "id": "native.apple.c695f785d4f3331a"
     },
     {
       "kind": "ui-call",
@@ -12087,7 +12087,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovery Logs",
       "surface": "apple",
-      "id": "native.apple.5ccafc9f972de682"
+      "id": "native.apple.8584babe715b1133"
     },
     {
       "kind": "ui-call",
@@ -12095,7 +12095,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Device",
       "surface": "apple",
-      "id": "native.apple.d54c2a63508adeca"
+      "id": "native.apple.f0a16e985312895b"
     },
     {
       "kind": "ui-call",
@@ -12103,7 +12103,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Device Name",
       "surface": "apple",
-      "id": "native.apple.1b32b788bd9d6557"
+      "id": "native.apple.540b648f9486bb50"
     },
     {
       "kind": "ui-call",
@@ -12111,7 +12111,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Instance ID",
       "surface": "apple",
-      "id": "native.apple.f42ec6e9ac59cb2f"
+      "id": "native.apple.b7c2d54bc3894446"
     },
     {
       "kind": "conditional-branch",
@@ -12119,7 +12119,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Off",
       "surface": "apple",
-      "id": "native.apple.576f2d4025c0a928"
+      "id": "native.apple.40692c0b7ad6a05d"
     },
     {
       "kind": "conditional-branch",
@@ -12127,7 +12127,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "On",
       "surface": "apple",
-      "id": "native.apple.0100c34bb0a33c70"
+      "id": "native.apple.0fca0d66e1fc4fa0"
     },
     {
       "kind": "ui-call",
@@ -12135,7 +12135,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Copy full commit hash",
       "surface": "apple",
-      "id": "native.apple.4e4fd98ec575aa4c"
+      "id": "native.apple.2834f131e112b1b4"
     },
     {
       "kind": "ui-call",
@@ -12143,7 +12143,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Copy build info",
       "surface": "apple",
-      "id": "native.apple.bbd5c192c15fea8d"
+      "id": "native.apple.e93e23f03719e358"
     },
     {
       "kind": "ui-call",
@@ -12151,7 +12151,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Copy Commit",
       "surface": "apple",
-      "id": "native.apple.02e9eb37ac53cdbd"
+      "id": "native.apple.34d0503d7d5ed23d"
     },
     {
       "kind": "ui-call",
@@ -12159,7 +12159,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Copy Build Info",
       "surface": "apple",
-      "id": "native.apple.f931dcc88c0b6518"
+      "id": "native.apple.9be4a644273089ce"
     },
     {
       "kind": "ui-call",
@@ -12167,7 +12167,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Unavailable",
       "surface": "apple",
-      "id": "native.apple.ce28d70078afb196"
+      "id": "native.apple.50991f9fae2ab99b"
     },
     {
       "kind": "ui-call",
@@ -12175,7 +12175,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Version \\(version), commit \\(commit), built \\(built), timestamp \\(timestamp)",
       "surface": "apple",
-      "id": "native.apple.8bc1d3e7bc3044c6"
+      "id": "native.apple.b10bfeade7e6dcc4"
     },
     {
       "kind": "ui-call",
@@ -12183,7 +12183,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Version \\(version), commit \\(commit), build date unavailable",
       "surface": "apple",
-      "id": "native.apple.cdb2c3f7f7627077"
+      "id": "native.apple.32c68e6864c7faa5"
     },
     {
       "kind": "ui-call",
@@ -12191,7 +12191,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Version \\(version), commit unavailable, built \\(built), timestamp \\(timestamp)",
       "surface": "apple",
-      "id": "native.apple.658e7ed79db4c451"
+      "id": "native.apple.664c866505040add"
     },
     {
       "kind": "ui-call",
@@ -12199,7 +12199,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Version \\(version), commit unavailable, build date unavailable",
       "surface": "apple",
-      "id": "native.apple.4ce6f0ea4ce9ac7f"
+      "id": "native.apple.29192c8dd3ef0f5e"
     },
     {
       "kind": "conditional-branch",
@@ -12207,7 +12207,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Checking",
       "surface": "apple",
-      "id": "native.apple.8c42c3f2109aab19"
+      "id": "native.apple.f5d9409953949617"
     },
     {
       "kind": "conditional-branch",
@@ -12215,7 +12215,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Enabled",
       "surface": "apple",
-      "id": "native.apple.e8608b93d18ddb92"
+      "id": "native.apple.1e38b2ba7a1c1e45"
     },
     {
       "kind": "conditional-branch",
@@ -12223,7 +12223,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Off",
       "surface": "apple",
-      "id": "native.apple.ca1d67ec3832f6e7"
+      "id": "native.apple.06aecb73b4caf15e"
     },
     {
       "kind": "conditional-branch",
@@ -12231,7 +12231,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Setup",
       "surface": "apple",
-      "id": "native.apple.ed4dd210f496e3ab"
+      "id": "native.apple.b2feb29a6a0c009e"
     },
     {
       "kind": "conditional-branch",
@@ -12239,7 +12239,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Denied",
       "surface": "apple",
-      "id": "native.apple.21a66315d0935902"
+      "id": "native.apple.994d1db10eca51a4"
     },
     {
       "kind": "conditional-branch",
@@ -12247,7 +12247,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Not Enabled",
       "surface": "apple",
-      "id": "native.apple.d34b626a9e9357a8"
+      "id": "native.apple.2d649df414b36d45"
     },
     {
       "kind": "conditional-branch",
@@ -12255,7 +12255,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Unknown",
       "surface": "apple",
-      "id": "native.apple.8c2b6e6d707f3f8b"
+      "id": "native.apple.b6eb08125322e79c"
     },
     {
       "kind": "conditional-branch",
@@ -12263,7 +12263,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Checking iOS notification permission.",
       "surface": "apple",
-      "id": "native.apple.921c5e3c07784504"
+      "id": "native.apple.aaa60df66ca6fb07"
     },
     {
       "kind": "conditional-branch",
@@ -12271,7 +12271,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "OpenClaw can show approval prompts and event alerts when the app is not active.",
       "surface": "apple",
-      "id": "native.apple.98471e5735f9ff12"
+      "id": "native.apple.675219772ee5adf0"
     },
     {
       "kind": "conditional-branch",
@@ -12279,7 +12279,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "OpenClaw notifications are off.",
       "surface": "apple",
-      "id": "native.apple.cf35fb743bf5bd6a"
+      "id": "native.apple.44133229b2b05062"
     },
     {
       "kind": "conditional-branch",
@@ -12287,7 +12287,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Finish notification setup to receive alerts when the app is not active.",
       "surface": "apple",
-      "id": "native.apple.3ce6e6157efc8efd"
+      "id": "native.apple.9794732a37cb580f"
     },
     {
       "kind": "conditional-branch",
@@ -12295,7 +12295,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Notifications have been denied. Enable them in iOS Settings.",
       "surface": "apple",
-      "id": "native.apple.4577df5d6ce7babc"
+      "id": "native.apple.195375b3e1db5401"
     },
     {
       "kind": "conditional-branch",
@@ -12303,7 +12303,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Enable notifications to receive approval prompts and event alerts outside the app.",
       "surface": "apple",
-      "id": "native.apple.8836e3c9b2a9a811"
+      "id": "native.apple.c0a27e1b0f797fd6"
     },
     {
       "kind": "conditional-branch",
@@ -12311,7 +12311,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "OpenClaw cannot determine the current notification permission state.",
       "surface": "apple",
-      "id": "native.apple.34e46ffc0dac7b3d"
+      "id": "native.apple.bfe6a918d23fa20e"
     },
     {
       "kind": "ui-call",
@@ -12319,7 +12319,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Connected",
       "surface": "apple",
-      "id": "native.apple.5062046a82049d84"
+      "id": "native.apple.fc7d007916016c0d"
     },
     {
       "kind": "ui-named-argument",
@@ -12327,7 +12327,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Gateway online",
       "surface": "apple",
-      "id": "native.apple.dd63ff92b1f0d265"
+      "id": "native.apple.f79541e88a1434df"
     },
     {
       "kind": "ui-named-argument",
@@ -12335,7 +12335,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Connected to openclaw-gateway.tailnet.ts.net.",
       "surface": "apple",
-      "id": "native.apple.2f58eec336d3f675"
+      "id": "native.apple.737eb52b08f2640c"
     },
     {
       "kind": "ui-call",
@@ -12343,7 +12343,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Loading",
       "surface": "apple",
-      "id": "native.apple.3291260739cbb077"
+      "id": "native.apple.b59e37e73db49f94"
     },
     {
       "kind": "ui-named-argument",
@@ -12351,7 +12351,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Checking gateway",
       "surface": "apple",
-      "id": "native.apple.393160b1f7ba2d7f"
+      "id": "native.apple.2b5177b11661390e"
     },
     {
       "kind": "ui-named-argument",
@@ -12359,7 +12359,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Refreshing connection, discovery, and device trust state.",
       "surface": "apple",
-      "id": "native.apple.ce0f1f186161a3f5"
+      "id": "native.apple.1b2d7d34531acc5d"
     },
     {
       "kind": "ui-call",
@@ -12367,7 +12367,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Empty",
       "surface": "apple",
-      "id": "native.apple.b5c38673941ea2ac"
+      "id": "native.apple.511630542db1aa6f"
     },
     {
       "kind": "ui-named-argument",
@@ -12375,7 +12375,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "No gateway configured",
       "surface": "apple",
-      "id": "native.apple.dd4f9baf1dd631e9"
+      "id": "native.apple.54df46d3690853c8"
     },
     {
       "kind": "ui-named-argument",
@@ -12383,7 +12383,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Scan a setup QR code, paste a setup code, or choose a discovered gateway.",
       "surface": "apple",
-      "id": "native.apple.3645697cd635f42e"
+      "id": "native.apple.856d2ed1c64b9da1"
     },
     {
       "kind": "ui-call",
@@ -12391,7 +12391,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Error",
       "surface": "apple",
-      "id": "native.apple.17ef87abc0cbf854"
+      "id": "native.apple.2f70e6702c85bedf"
     },
     {
       "kind": "ui-named-argument",
@@ -12399,7 +12399,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Tailscale warning",
       "surface": "apple",
-      "id": "native.apple.75652d20acdb3f66"
+      "id": "native.apple.eadc497b8d3f3b5e"
     },
     {
       "kind": "ui-named-argument",
@@ -12407,7 +12407,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Tailscale is off on this device. Turn it on, then try again.",
       "surface": "apple",
-      "id": "native.apple.a6975cfedb43e96e"
+      "id": "native.apple.50af8defa8d7594e"
     },
     {
       "kind": "ui-call",
@@ -12415,7 +12415,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Address",
       "surface": "apple",
-      "id": "native.apple.9721b17e2b2757b9"
+      "id": "native.apple.79dec753eca2d3bb"
     },
     {
       "kind": "ui-call",
@@ -12423,7 +12423,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Server",
       "surface": "apple",
-      "id": "native.apple.8d837aeb32871690"
+      "id": "native.apple.95af8f5aee7320a9"
     },
     {
       "kind": "ui-call",
@@ -12431,7 +12431,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Discovered",
       "surface": "apple",
-      "id": "native.apple.311f5d51147ef78f"
+      "id": "native.apple.97bfac52b2b29eeb"
     },
     {
       "kind": "ui-call",
@@ -12439,7 +12439,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Default Agent",
       "surface": "apple",
-      "id": "native.apple.bf57c0bcbb3cc33f"
+      "id": "native.apple.a07ae673f44be041"
     },
     {
       "kind": "ui-call",
@@ -12447,7 +12447,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Reconnect",
       "surface": "apple",
-      "id": "native.apple.a402cef0554ad9c3"
+      "id": "native.apple.385825a3993c5f2a"
     },
     {
       "kind": "ui-call",
@@ -12455,7 +12455,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Diagnose",
       "surface": "apple",
-      "id": "native.apple.a80e88931ebdf9fe"
+      "id": "native.apple.42e107ba01cd3840"
     },
     {
       "kind": "ui-call",
@@ -12463,7 +12463,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Scan QR",
       "surface": "apple",
-      "id": "native.apple.05d387529c7a9b97"
+      "id": "native.apple.acd10851c7e1885d"
     },
     {
       "kind": "ui-call",
@@ -12471,7 +12471,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Connect",
       "surface": "apple",
-      "id": "native.apple.7ef31be9d4795792"
+      "id": "native.apple.a9c35036bf9e02a8"
     },
     {
       "kind": "ui-call",
@@ -12479,7 +12479,7 @@
       "path": "apps/ios/Sources/Design/SettingsProTabSupport.swift",
       "source": "Discovered gateways and manual setup live here when the gateway has not connected yet.",
       "surface": "apple",
-      "id": "native.apple.ab8baa3290dcab1e"
+      "id": "native.apple.f439c34a9ce3a332"
     },
     {
       "kind": "ui-call",
@@ -12487,7 +12487,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Not Now",
       "surface": "apple",
-      "id": "native.apple.630738aefc3e7a2e"
+      "id": "native.apple.c6e171128190d131"
     },
     {
       "kind": "ui-modifier",
@@ -12495,7 +12495,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Talk",
       "surface": "apple",
-      "id": "native.apple.2caacbe8915fce80"
+      "id": "native.apple.e4b15aef3c2e3da7"
     },
     {
       "kind": "ui-call",
@@ -12503,7 +12503,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Conversation",
       "surface": "apple",
-      "id": "native.apple.3d71c9560c740e44"
+      "id": "native.apple.ab3381742bdff650"
     },
     {
       "kind": "ui-call",
@@ -12511,7 +12511,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Agent",
       "surface": "apple",
-      "id": "native.apple.8f6226cc6ea8e258"
+      "id": "native.apple.7af100f6640c6a69"
     },
     {
       "kind": "ui-call",
@@ -12519,7 +12519,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Session",
       "surface": "apple",
-      "id": "native.apple.ea2deaf868ab8a8e"
+      "id": "native.apple.49c4de60117b1a98"
     },
     {
       "kind": "ui-call",
@@ -12527,7 +12527,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Runtime",
       "surface": "apple",
-      "id": "native.apple.a3ce2b6fdef9f5d9"
+      "id": "native.apple.37c29d2506b955e9"
     },
     {
       "kind": "ui-call",
@@ -12535,7 +12535,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Voice Mode",
       "surface": "apple",
-      "id": "native.apple.809c47f578fb300b"
+      "id": "native.apple.13e0ad79b141576e"
     },
     {
       "kind": "ui-call",
@@ -12543,7 +12543,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Configured",
       "surface": "apple",
-      "id": "native.apple.efd81a082e762e19"
+      "id": "native.apple.e8035b71bab833c7"
     },
     {
       "kind": "ui-call",
@@ -12551,7 +12551,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Active",
       "surface": "apple",
-      "id": "native.apple.f408cd314c58beda"
+      "id": "native.apple.1b2845ec89d20eef"
     },
     {
       "kind": "ui-call",
@@ -12559,7 +12559,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Transport",
       "surface": "apple",
-      "id": "native.apple.6b092e76e8cd7077"
+      "id": "native.apple.a82c07df64d13b23"
     },
     {
       "kind": "ui-call",
@@ -12567,7 +12567,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Last issue",
       "surface": "apple",
-      "id": "native.apple.85cf5997f880320e"
+      "id": "native.apple.384e097278f76954"
     },
     {
       "kind": "ui-call",
@@ -12575,7 +12575,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Permission",
       "surface": "apple",
-      "id": "native.apple.5f23def3f9cc0265"
+      "id": "native.apple.a6d8fc7bfd98836f"
     },
     {
       "kind": "ui-call",
@@ -12583,7 +12583,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Speech language",
       "surface": "apple",
-      "id": "native.apple.31dce524ee35c207"
+      "id": "native.apple.983bdcd5e3f1baa8"
     },
     {
       "kind": "ui-call",
@@ -12591,7 +12591,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Controls",
       "surface": "apple",
-      "id": "native.apple.cf7c334bf3535237"
+      "id": "native.apple.32e7fa2b1798e9c3"
     },
     {
       "kind": "ui-call",
@@ -12599,7 +12599,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Speakerphone",
       "surface": "apple",
-      "id": "native.apple.aba6f2c7c9f0513e"
+      "id": "native.apple.0eb012a5d3d81b32"
     },
     {
       "kind": "ui-call",
@@ -12607,7 +12607,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Background listening",
       "surface": "apple",
-      "id": "native.apple.76a72b78ae43b051"
+      "id": "native.apple.ef8699e2718346da"
     },
     {
       "kind": "ui-call",
@@ -12615,7 +12615,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Voice & Talk Settings",
       "surface": "apple",
-      "id": "native.apple.09251d869394ee9e"
+      "id": "native.apple.1e6938a09b4fbe77"
     },
     {
       "kind": "conditional-branch",
@@ -12631,7 +12631,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Gateway permission required",
       "surface": "apple",
-      "id": "native.apple.f11f0536c6c91730"
+      "id": "native.apple.05c434bb5fe3c275"
     },
     {
       "kind": "conditional-branch",
@@ -12639,7 +12639,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Requesting approval",
       "surface": "apple",
-      "id": "native.apple.740f853e31f4cbd6"
+      "id": "native.apple.105896ad894955b4"
     },
     {
       "kind": "conditional-branch",
@@ -12647,7 +12647,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Approval requested",
       "surface": "apple",
-      "id": "native.apple.ca8a15aeaa073b49"
+      "id": "native.apple.d0cf291f96827526"
     },
     {
       "kind": "conditional-branch",
@@ -12655,7 +12655,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Voice API key missing",
       "surface": "apple",
-      "id": "native.apple.e8ca3240ed3459e1"
+      "id": "native.apple.e8c2902caf83b20e"
     },
     {
       "kind": "conditional-branch",
@@ -12663,7 +12663,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Voice config failed",
       "surface": "apple",
-      "id": "native.apple.2037e95c83eb3140"
+      "id": "native.apple.364bb50be18c79c7"
     },
     {
       "kind": "conditional-branch",
@@ -12671,7 +12671,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Start Talk",
       "surface": "apple",
-      "id": "native.apple.86c1d181ae4eea07"
+      "id": "native.apple.87fca324b443b623"
     },
     {
       "kind": "conditional-branch",
@@ -12679,7 +12679,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Stop Talk",
       "surface": "apple",
-      "id": "native.apple.f2cd3be54a1a6091"
+      "id": "native.apple.8cba3288f401cbfb"
     },
     {
       "kind": "conditional-branch",
@@ -12687,7 +12687,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Enable Talk",
       "surface": "apple",
-      "id": "native.apple.d13508d0dae4141b"
+      "id": "native.apple.798c3584ad95f8da"
     },
     {
       "kind": "conditional-branch",
@@ -12695,7 +12695,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Open Gateway Settings",
       "surface": "apple",
-      "id": "native.apple.9df75003606e2ffe"
+      "id": "native.apple.1620f7cb3deea133"
     },
     {
       "kind": "conditional-branch",
@@ -12703,7 +12703,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Open Voice Settings",
       "surface": "apple",
-      "id": "native.apple.6351026d09ad03e1"
+      "id": "native.apple.3fd2706ef0f14fd2"
     },
     {
       "kind": "conditional-branch",
@@ -12711,7 +12711,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Demo Mode Only",
       "surface": "apple",
-      "id": "native.apple.9b78fbac2e82beb6"
+      "id": "native.apple.3cc9cd23a67db077"
     },
     {
       "kind": "conditional-branch",
@@ -12719,7 +12719,7 @@
       "path": "apps/ios/Sources/Design/TalkProTab.swift",
       "source": "Waiting for Approval",
       "surface": "apple",
-      "id": "native.apple.69188230a514c5c0"
+      "id": "native.apple.12c9d8231777366c"
     },
     {
       "kind": "ui-named-argument",
@@ -12727,7 +12727,7 @@
       "path": "apps/ios/Sources/Design/TalkRuntimeIssueBanner.swift",
       "source": "Open Settings",
       "surface": "apple",
-      "id": "native.apple.9ac1842135b768aa"
+      "id": "native.apple.dc57861a3ac5a08e"
     },
     {
       "kind": "ui-named-argument",
@@ -12735,7 +12735,7 @@
       "path": "apps/ios/Sources/Design/TalkRuntimeIssueBanner.swift",
       "source": "Details",
       "surface": "apple",
-      "id": "native.apple.0648f0cc87d543d5"
+      "id": "native.apple.8218d64ec7ae90cc"
     },
     {
       "kind": "ui-call",
@@ -12743,7 +12743,7 @@
       "path": "apps/ios/Sources/Design/TalkRuntimeIssueBanner.swift",
       "source": "Copy diagnostics",
       "surface": "apple",
-      "id": "native.apple.934cb0493a08efae"
+      "id": "native.apple.79b30b1d014a383d"
     },
     {
       "kind": "ui-call",
@@ -12751,7 +12751,7 @@
       "path": "apps/ios/Sources/Design/TalkRuntimeIssueBanner.swift",
       "source": "Technical details",
       "surface": "apple",
-      "id": "native.apple.05720056d12cca98"
+      "id": "native.apple.677a41ec947a185b"
     },
     {
       "kind": "ui-modifier",
@@ -12759,7 +12759,7 @@
       "path": "apps/ios/Sources/Design/TalkRuntimeIssueBanner.swift",
       "source": "Talk fallback",
       "surface": "apple",
-      "id": "native.apple.d203ac14cba893ae"
+      "id": "native.apple.e87c850114041ce8"
     },
     {
       "kind": "ui-call",
@@ -12767,7 +12767,7 @@
       "path": "apps/ios/Sources/Design/TalkRuntimeIssueBanner.swift",
       "source": "Done",
       "surface": "apple",
-      "id": "native.apple.46baa157a6f3bf45"
+      "id": "native.apple.073825a7670d08cc"
     },
     {
       "kind": "ui-call",
@@ -12775,7 +12775,7 @@
       "path": "apps/ios/Sources/Gateway/DeepLinkAgentPromptAlert.swift",
       "source": "Run OpenClaw agent?",
       "surface": "apple",
-      "id": "native.apple.ff54e660cf3e40e9"
+      "id": "native.apple.c218ef5194d0ee56"
     },
     {
       "kind": "ui-call",
@@ -12783,7 +12783,7 @@
       "path": "apps/ios/Sources/Gateway/DeepLinkAgentPromptAlert.swift",
       "source": "Message:\n\\(prompt.messagePreview)\n\nURL:\n\\(prompt.urlPreview)",
       "surface": "apple",
-      "id": "native.apple.364bea5035361bb0"
+      "id": "native.apple.32dc136ac23fef8c"
     },
     {
       "kind": "ui-call",
@@ -12791,7 +12791,7 @@
       "path": "apps/ios/Sources/Gateway/DeepLinkAgentPromptAlert.swift",
       "source": "Cancel",
       "surface": "apple",
-      "id": "native.apple.8e6e42a2a74596e9"
+      "id": "native.apple.fd7a510d373bb915"
     },
     {
       "kind": "ui-call",
@@ -12799,7 +12799,7 @@
       "path": "apps/ios/Sources/Gateway/DeepLinkAgentPromptAlert.swift",
       "source": "Run",
       "surface": "apple",
-      "id": "native.apple.86e2769119731fa1"
+      "id": "native.apple.556a5ad9893871c8"
     },
     {
       "kind": "ui-call",
@@ -12807,7 +12807,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "Exec approval required",
       "surface": "apple",
-      "id": "native.apple.fcbca7eff2c55c51"
+      "id": "native.apple.8affb166c6d3eb43"
     },
     {
       "kind": "ui-call",
@@ -12815,7 +12815,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "Review this exec request before continuing. Your decision will be sent back to the gateway.",
       "surface": "apple",
-      "id": "native.apple.28b66b20fd82ac2e"
+      "id": "native.apple.cc304ba214b8a9df"
     },
     {
       "kind": "ui-named-argument",
@@ -12823,7 +12823,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "Host",
       "surface": "apple",
-      "id": "native.apple.82fee6773239d6cf"
+      "id": "native.apple.1f2576ef69108e39"
     },
     {
       "kind": "ui-named-argument",
@@ -12831,7 +12831,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "Node",
       "surface": "apple",
-      "id": "native.apple.70571f3adbfb2f7d"
+      "id": "native.apple.40e78558a531ba3a"
     },
     {
       "kind": "ui-named-argument",
@@ -12839,7 +12839,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "Agent",
       "surface": "apple",
-      "id": "native.apple.bf2e86c25b0bab30"
+      "id": "native.apple.b3914073e8a72a9a"
     },
     {
       "kind": "ui-named-argument",
@@ -12847,7 +12847,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "Expires",
       "surface": "apple",
-      "id": "native.apple.9d9ec6cea0ee15c6"
+      "id": "native.apple.b2e4502116389233"
     },
     {
       "kind": "ui-call",
@@ -12855,7 +12855,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "Resolving…",
       "surface": "apple",
-      "id": "native.apple.420c9a94e62a3745"
+      "id": "native.apple.ffeadaa59fd07335"
     },
     {
       "kind": "ui-call",
@@ -12863,7 +12863,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "Allow Once",
       "surface": "apple",
-      "id": "native.apple.eb5b1e6c34c1a176"
+      "id": "native.apple.88dd5e6f5e90514d"
     },
     {
       "kind": "ui-call",
@@ -12871,7 +12871,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "Allow Always",
       "surface": "apple",
-      "id": "native.apple.91771a0e5ae5e75c"
+      "id": "native.apple.bc243f646ddc3656"
     },
     {
       "kind": "ui-call",
@@ -12887,7 +12887,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "Deny",
       "surface": "apple",
-      "id": "native.apple.302320808554ec80"
+      "id": "native.apple.ac88205cbb8a974d"
     },
     {
       "kind": "ui-call",
@@ -12895,7 +12895,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "Cancel",
       "surface": "apple",
-      "id": "native.apple.815fd6a1fe7a0215"
+      "id": "native.apple.7292be2c03d1caa4"
     },
     {
       "kind": "conditional-branch",
@@ -12903,7 +12903,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "about 1 minute",
       "surface": "apple",
-      "id": "native.apple.2675811292376a95"
+      "id": "native.apple.03e81e2c3208e897"
     },
     {
       "kind": "conditional-branch",
@@ -12911,7 +12911,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "about \\(minutes) minutes",
       "surface": "apple",
-      "id": "native.apple.24948701a0802b9d"
+      "id": "native.apple.caf9889b0b0e18b6"
     },
     {
       "kind": "conditional-branch",
@@ -12919,7 +12919,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "about 1 hour",
       "surface": "apple",
-      "id": "native.apple.df1fe07ca4431570"
+      "id": "native.apple.00ef62d3eae63065"
     },
     {
       "kind": "conditional-branch",
@@ -12927,7 +12927,7 @@
       "path": "apps/ios/Sources/Gateway/ExecApprovalPromptDialog.swift",
       "source": "about \\(hours) hours",
       "surface": "apple",
-      "id": "native.apple.1b6923bba2c4a8f4"
+      "id": "native.apple.09312ef7ca727f4b"
     },
     {
       "kind": "ui-localized-call",
@@ -12935,7 +12935,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "Connect",
       "surface": "apple",
-      "id": "native.apple.9df80f4ad340fac7"
+      "id": "native.apple.3cb1f1788ffb16e2"
     },
     {
       "kind": "ui-localized-call",
@@ -12943,7 +12943,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "TLS required",
       "surface": "apple",
-      "id": "native.apple.99f9997fa7381cf2"
+      "id": "native.apple.b6ea004a3ef09501"
     },
     {
       "kind": "ui-localized-call-multiline",
@@ -12951,7 +12951,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "Enable Gateway TLS, or enter your Tailscale Serve HTTPS host in Manual Setup. Use Unencrypted only with a trusted private-LAN address.",
       "surface": "apple",
-      "id": "native.apple.ea999c184d17e0bc"
+      "id": "native.apple.16e06dae717734de"
     },
     {
       "kind": "ui-localized-call-multiline",
@@ -12959,7 +12959,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "Can't reach gateway at \\(host):\\(port). Verify Tailscale Serve is enabled and publishes this Gateway.",
       "surface": "apple",
-      "id": "native.apple.9c262d42363100f1"
+      "id": "native.apple.ccfde3d74305d096"
     },
     {
       "kind": "ui-localized-call",
@@ -12967,7 +12967,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "Can't reach gateway at \\(host):\\(port). Check Tailscale or LAN.",
       "surface": "apple",
-      "id": "native.apple.a9ba291db9cfd0b3"
+      "id": "native.apple.fe8f13e52e05ff77"
     },
     {
       "kind": "ui-call",
@@ -12975,7 +12975,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayDiscoveryDebugLogView.swift",
       "source": "Enable “Discovery Debug Logs” to start collecting events.",
       "surface": "apple",
-      "id": "native.apple.bef3f9c88e02d037"
+      "id": "native.apple.c741e0a44409ac2a"
     },
     {
       "kind": "ui-call",
@@ -12983,7 +12983,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayDiscoveryDebugLogView.swift",
       "source": "No log entries yet.",
       "surface": "apple",
-      "id": "native.apple.e17805a02a1da11a"
+      "id": "native.apple.94e50889eec05b85"
     },
     {
       "kind": "ui-modifier",
@@ -12991,7 +12991,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayDiscoveryDebugLogView.swift",
       "source": "Discovery Logs",
       "surface": "apple",
-      "id": "native.apple.ff8c924b3b61228d"
+      "id": "native.apple.c80ead1ebfcfd78c"
     },
     {
       "kind": "ui-call",
@@ -12999,7 +12999,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayDiscoveryDebugLogView.swift",
       "source": "Copy",
       "surface": "apple",
-      "id": "native.apple.c0f731f9f5c84629"
+      "id": "native.apple.f21a8e304b607dc8"
     },
     {
       "kind": "ui-named-argument",
@@ -13007,7 +13007,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Details",
       "surface": "apple",
-      "id": "native.apple.339a8edf9c9a815a"
+      "id": "native.apple.a7866a6499f4462a"
     },
     {
       "kind": "conditional-branch",
@@ -13015,7 +13015,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Fix on gateway",
       "surface": "apple",
-      "id": "native.apple.dad01fdeb5f018ce"
+      "id": "native.apple.0dbec123f10f54a3"
     },
     {
       "kind": "conditional-branch",
@@ -13023,7 +13023,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Fix on this device",
       "surface": "apple",
-      "id": "native.apple.f6f0d63324bdebda"
+      "id": "native.apple.bb01fb5dffc27820"
     },
     {
       "kind": "conditional-branch",
@@ -13031,7 +13031,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Check both",
       "surface": "apple",
-      "id": "native.apple.6edf410bcce83ad7"
+      "id": "native.apple.99963509b4eedf05"
     },
     {
       "kind": "conditional-branch",
@@ -13039,7 +13039,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Check network",
       "surface": "apple",
-      "id": "native.apple.c2a5671d29a535fa"
+      "id": "native.apple.95e5718913e74c81"
     },
     {
       "kind": "conditional-branch",
@@ -13047,7 +13047,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Needs attention",
       "surface": "apple",
-      "id": "native.apple.3f4316b823b69124"
+      "id": "native.apple.b872c06ff0f48f3d"
     },
     {
       "kind": "ui-call",
@@ -13055,7 +13055,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Copy request ID",
       "surface": "apple",
-      "id": "native.apple.2dd7e716b0937232"
+      "id": "native.apple.ae581f232bd0ecc0"
     },
     {
       "kind": "ui-call",
@@ -13063,7 +13063,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Request",
       "surface": "apple",
-      "id": "native.apple.7dd5c1028aefd2be"
+      "id": "native.apple.fd04cd49334845a9"
     },
     {
       "kind": "ui-call",
@@ -13071,7 +13071,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Copy command",
       "surface": "apple",
-      "id": "native.apple.0b8a40c10a02cf43"
+      "id": "native.apple.98df0e8ba486e4d1"
     },
     {
       "kind": "ui-call",
@@ -13079,7 +13079,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Gateway command",
       "surface": "apple",
-      "id": "native.apple.85d8db66aae5ccc5"
+      "id": "native.apple.50622ef698ba07f5"
     },
     {
       "kind": "ui-call",
@@ -13087,7 +13087,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Open docs",
       "surface": "apple",
-      "id": "native.apple.5422c65417d30419"
+      "id": "native.apple.32ea6ea1f9aea920"
     },
     {
       "kind": "ui-call",
@@ -13095,7 +13095,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Help",
       "surface": "apple",
-      "id": "native.apple.d214c5b5ead92ee9"
+      "id": "native.apple.6b1a61d6c9510bdb"
     },
     {
       "kind": "ui-call",
@@ -13103,7 +13103,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Technical details",
       "surface": "apple",
-      "id": "native.apple.228f252b1558f714"
+      "id": "native.apple.7041ebbb775bfdd7"
     },
     {
       "kind": "ui-call",
@@ -13111,7 +13111,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Connection problem",
       "surface": "apple",
-      "id": "native.apple.d6f21a9ecbbf4068"
+      "id": "native.apple.f307f967ec2df705"
     },
     {
       "kind": "ui-call",
@@ -13119,7 +13119,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayProblemView.swift",
       "source": "Done",
       "surface": "apple",
-      "id": "native.apple.fc4dc59107012c26"
+      "id": "native.apple.9bdfbc3e1ea38cb3"
     },
     {
       "kind": "ui-call",
@@ -13127,7 +13127,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Connecting…",
       "surface": "apple",
-      "id": "native.apple.c3026ecefcb062a0"
+      "id": "native.apple.e8f30dffd2d62d96"
     },
     {
       "kind": "ui-call",
@@ -13135,7 +13135,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Connect to this Gateway",
       "surface": "apple",
-      "id": "native.apple.3165281df48ab522"
+      "id": "native.apple.78d430515e5bb8eb"
     },
     {
       "kind": "ui-call",
@@ -13143,7 +13143,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Use Manual Setup",
       "surface": "apple",
-      "id": "native.apple.e84f60ce8e1d46c1"
+      "id": "native.apple.91a0ab004066bacb"
     },
     {
       "kind": "ui-call",
@@ -13151,7 +13151,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Not now",
       "surface": "apple",
-      "id": "native.apple.c8bdf51862099c64"
+      "id": "native.apple.102d0ce74e6253f3"
     },
     {
       "kind": "ui-call",
@@ -13159,7 +13159,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Don't show this again",
       "surface": "apple",
-      "id": "native.apple.0a591c749e4f5df2"
+      "id": "native.apple.5204dc0158d98ebf"
     },
     {
       "kind": "ui-modifier",
@@ -13167,7 +13167,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Quick Setup",
       "surface": "apple",
-      "id": "native.apple.d190c67798bfda23"
+      "id": "native.apple.476757fc54c63560"
     },
     {
       "kind": "ui-call",
@@ -13175,7 +13175,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Close",
       "surface": "apple",
-      "id": "native.apple.a7f85d7c15c51840"
+      "id": "native.apple.977a6e4a5022184f"
     },
     {
       "kind": "ui-call",
@@ -13183,7 +13183,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Connect a nearby Gateway",
       "surface": "apple",
-      "id": "native.apple.6c2149ce9b4a51f0"
+      "id": "native.apple.f2642d91a3ac8c25"
     },
     {
       "kind": "conditional-branch",
@@ -13191,7 +13191,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Local",
       "surface": "apple",
-      "id": "native.apple.6d7861b38549db04"
+      "id": "native.apple.63bb4ac4eaf496bc"
     },
     {
       "kind": "conditional-branch",
@@ -13199,7 +13199,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Secure",
       "surface": "apple",
-      "id": "native.apple.42a7cbaa5a4a1aec"
+      "id": "native.apple.1122855cccc617bd"
     },
     {
       "kind": "ui-named-argument",
@@ -13207,7 +13207,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Discovery",
       "surface": "apple",
-      "id": "native.apple.e63abd2b87564f55"
+      "id": "native.apple.052a650dbff9657b"
     },
     {
       "kind": "ui-named-argument",
@@ -13215,7 +13215,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Gateway",
       "surface": "apple",
-      "id": "native.apple.144f6d64846034c8"
+      "id": "native.apple.c284afdefb55f224"
     },
     {
       "kind": "ui-named-argument",
@@ -13223,7 +13223,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Node",
       "surface": "apple",
-      "id": "native.apple.0e34f14699cd5184"
+      "id": "native.apple.26a7ff6b06dbeb67"
     },
     {
       "kind": "ui-named-argument",
@@ -13231,7 +13231,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Operator",
       "surface": "apple",
-      "id": "native.apple.20b1bc5e6f9b3507"
+      "id": "native.apple.f2c3934d3e670237"
     },
     {
       "kind": "ui-call",
@@ -13239,7 +13239,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Looking for a Gateway",
       "surface": "apple",
-      "id": "native.apple.49bfb37d47d3d427"
+      "id": "native.apple.33be51249563ed37"
     },
     {
       "kind": "ui-call",
@@ -13247,7 +13247,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Keep your iPhone on the same LAN or tailnet, then start the Gateway on your host machine.",
       "surface": "apple",
-      "id": "native.apple.76c837838276639d"
+      "id": "native.apple.0e828048fafce681"
     },
     {
       "kind": "ui-named-argument",
@@ -13255,7 +13255,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Run openclaw gateway --port 18789.",
       "surface": "apple",
-      "id": "native.apple.0a0790581bac81ad"
+      "id": "native.apple.c18f5bd36f119282"
     },
     {
       "kind": "ui-named-argument",
@@ -13263,7 +13263,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Check that Bonjour discovery is enabled.",
       "surface": "apple",
-      "id": "native.apple.c03c045809206aef"
+      "id": "native.apple.a4eb9a9b02915961"
     },
     {
       "kind": "ui-named-argument",
@@ -13271,7 +13271,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift",
       "source": "Open Settings if you need a manual host.",
       "surface": "apple",
-      "id": "native.apple.a099ee002dc520ba"
+      "id": "native.apple.72083d0b7fc77a6d"
     },
     {
       "kind": "conditional-branch",
@@ -13295,7 +13295,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayTrustPromptAlert.swift",
       "source": "Trust this gateway?",
       "surface": "apple",
-      "id": "native.apple.797e08ab6281f76f"
+      "id": "native.apple.8ef0909bddf2f9ee"
     },
     {
       "kind": "ui-call",
@@ -13303,7 +13303,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayTrustPromptAlert.swift",
       "source": "Cancel",
       "surface": "apple",
-      "id": "native.apple.5261200f4b1ce74b"
+      "id": "native.apple.a026715905bfd429"
     },
     {
       "kind": "ui-call",
@@ -13311,7 +13311,7 @@
       "path": "apps/ios/Sources/Gateway/GatewayTrustPromptAlert.swift",
       "source": "Trust and connect",
       "surface": "apple",
-      "id": "native.apple.f3873a81d5476a5a"
+      "id": "native.apple.0892fd4bee73202a"
     },
     {
       "kind": "ui-call",
@@ -13319,7 +13319,7 @@
       "path": "apps/ios/Sources/Gateway/NotificationPermissionGuidanceDialog.swift",
       "source": "Notifications are off",
       "surface": "apple",
-      "id": "native.apple.2d4fabce5737ee0a"
+      "id": "native.apple.381baa85bbbd0f31"
     },
     {
       "kind": "ui-call",
@@ -13327,7 +13327,7 @@
       "path": "apps/ios/Sources/Gateway/NotificationPermissionGuidanceDialog.swift",
       "source": "Exec approvals can only be reviewed while OpenClaw is open and connected.\n\nEnable Notifications to receive approval notifications while OpenClaw is not open.",
       "surface": "apple",
-      "id": "native.apple.b3bddc21aad139d0"
+      "id": "native.apple.8f6f60c9a5196918"
     },
     {
       "kind": "ui-call",
@@ -13335,7 +13335,7 @@
       "path": "apps/ios/Sources/Gateway/NotificationPermissionGuidanceDialog.swift",
       "source": "Open Notifications Settings",
       "surface": "apple",
-      "id": "native.apple.d50d57ba17a17db8"
+      "id": "native.apple.a2378696390cca1e"
     },
     {
       "kind": "ui-call",
@@ -13343,7 +13343,7 @@
       "path": "apps/ios/Sources/Gateway/NotificationPermissionGuidanceDialog.swift",
       "source": "Not Now",
       "surface": "apple",
-      "id": "native.apple.dc6fbd0b31330488"
+      "id": "native.apple.807456c9b744662b"
     },
     {
       "kind": "ui-call",
@@ -13351,7 +13351,7 @@
       "path": "apps/ios/Sources/Gateway/NotificationPermissionGuidanceDialog.swift",
       "source": "Don't show again",
       "surface": "apple",
-      "id": "native.apple.963233fa6210d916"
+      "id": "native.apple.d180e6d9a4963c2b"
     },
     {
       "kind": "plist-string",
@@ -13359,7 +13359,7 @@
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw uses your calendars to show events and scheduling context when you enable calendar access.",
       "surface": "apple",
-      "id": "native.apple.061bdfeae10e7edb"
+      "id": "native.apple.cf820096080f7031"
     },
     {
       "kind": "plist-string",
@@ -13367,7 +13367,7 @@
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw uses your calendars to add events when you enable calendar access.",
       "surface": "apple",
-      "id": "native.apple.a0809d595c57e45f"
+      "id": "native.apple.fe85b609e9a9a144"
     },
     {
       "kind": "plist-string",
@@ -13375,7 +13375,7 @@
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw uses the camera when you scan a Gateway setup QR code or ask your paired Gateway or assistant to capture a photo or short video from this iPhone, for example to connect to your Gateway or show your assistant a document, device screen, or workspace.",
       "surface": "apple",
-      "id": "native.apple.0b4699f009127b0f"
+      "id": "native.apple.ff5729a17d66ad91"
     },
     {
       "kind": "plist-string",
@@ -13383,7 +13383,7 @@
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw uses your contacts so you can search and reference people while using the assistant.",
       "surface": "apple",
-      "id": "native.apple.1709a63b06e06e29"
+      "id": "native.apple.2f21aa6f5cd72915"
     },
     {
       "kind": "plist-string",
@@ -13391,7 +13391,7 @@
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw discovers and connects to your OpenClaw gateway on the local network.",
       "surface": "apple",
-      "id": "native.apple.4dfc6013662fc044"
+      "id": "native.apple.9d550c77a37bb165"
     },
     {
       "kind": "plist-string",
@@ -13399,7 +13399,7 @@
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw can share your location in the background when you enable Always.",
       "surface": "apple",
-      "id": "native.apple.5926060694e6bae2"
+      "id": "native.apple.d822c41a0b7e9739"
     },
     {
       "kind": "plist-string",
@@ -13407,7 +13407,7 @@
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw uses your location when you allow location sharing.",
       "surface": "apple",
-      "id": "native.apple.0a682f55d98cef2c"
+      "id": "native.apple.441062ce99375692"
     },
     {
       "kind": "plist-string",
@@ -13415,7 +13415,7 @@
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw uses the microphone for realtime chat, voice wake, push-to-talk, and voice notes.",
       "surface": "apple",
-      "id": "native.apple.9c7f16e9b041a73d"
+      "id": "native.apple.7c2cbe7077e4eff1"
     },
     {
       "kind": "plist-string",
@@ -13423,7 +13423,7 @@
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw may use motion data to support device-aware interactions and automations.",
       "surface": "apple",
-      "id": "native.apple.821e25899c1e574b"
+      "id": "native.apple.85345f18204d67ec"
     },
     {
       "kind": "plist-string",
@@ -13431,7 +13431,7 @@
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw lets your assistant read photos you allow and lets you choose photos to share.",
       "surface": "apple",
-      "id": "native.apple.adcb63cd7ae5e07d"
+      "id": "native.apple.40ed4259ec869f1b"
     },
     {
       "kind": "plist-string",
@@ -13439,7 +13439,7 @@
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw uses your reminders to list, add, and complete tasks when you enable reminders access.",
       "surface": "apple",
-      "id": "native.apple.c7f4ebf4bf2a601b"
+      "id": "native.apple.81b673f0c6fc4371"
     },
     {
       "kind": "plist-string",
@@ -13447,7 +13447,7 @@
       "path": "apps/ios/Sources/Info.plist",
       "source": "OpenClaw uses on-device speech recognition for talk mode and voice wake.",
       "surface": "apple",
-      "id": "native.apple.f66ac0cd280d1f8f"
+      "id": "native.apple.2275552c26460945"
     },
     {
       "kind": "conditional-branch",
@@ -13455,7 +13455,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Off",
       "surface": "apple",
-      "id": "native.apple.364ebb67d7b71d08"
+      "id": "native.apple.cf0450b542893fb5"
     },
     {
       "kind": "conditional-branch",
@@ -13463,7 +13463,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "While Using",
       "surface": "apple",
-      "id": "native.apple.b593fed81c279d19"
+      "id": "native.apple.c470d02f26ac51f6"
     },
     {
       "kind": "conditional-branch",
@@ -13471,7 +13471,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Always",
       "surface": "apple",
-      "id": "native.apple.eb0a1e7e85f4eaec"
+      "id": "native.apple.663b3e453bb47c07"
     },
     {
       "kind": "conditional-branch",
@@ -13479,7 +13479,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location sharing is disabled in OpenClaw. Location Services are off in iOS Settings.",
       "surface": "apple",
-      "id": "native.apple.8506df62d1e0bdc3"
+      "id": "native.apple.2dc593065171c201"
     },
     {
       "kind": "conditional-branch",
@@ -13487,7 +13487,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location sharing is disabled in OpenClaw. iOS currently allows Always.",
       "surface": "apple",
-      "id": "native.apple.b8dd114f2f71712e"
+      "id": "native.apple.1dc990a9cc0500c5"
     },
     {
       "kind": "conditional-branch",
@@ -13495,7 +13495,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location sharing is disabled in OpenClaw. iOS currently allows While Using.",
       "surface": "apple",
-      "id": "native.apple.1a92067e10a1e618"
+      "id": "native.apple.9a4e858d2b218d41"
     },
     {
       "kind": "conditional-branch",
@@ -13503,7 +13503,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location sharing is disabled.",
       "surface": "apple",
-      "id": "native.apple.a47ad87fd6d0b88c"
+      "id": "native.apple.ab481eb11214797f"
     },
     {
       "kind": "conditional-branch",
@@ -13511,7 +13511,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location Services are off in iOS Settings.",
       "surface": "apple",
-      "id": "native.apple.210dabc05ab1ae3f"
+      "id": "native.apple.34699b6a26b51110"
     },
     {
       "kind": "conditional-branch",
@@ -13519,7 +13519,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Foreground location requests are allowed. Precise Location is on.",
       "surface": "apple",
-      "id": "native.apple.3c2fc0066357f5c9"
+      "id": "native.apple.3b96b639e7442ee3"
     },
     {
       "kind": "conditional-branch",
@@ -13527,7 +13527,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Foreground location requests are allowed. Precise Location is off.",
       "surface": "apple",
-      "id": "native.apple.a1dccdb2059ed665"
+      "id": "native.apple.9e537e22f834f4d5"
     },
     {
       "kind": "conditional-branch",
@@ -13535,7 +13535,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Foreground location requests are allowed.",
       "surface": "apple",
-      "id": "native.apple.1799fbd4cbebc6d5"
+      "id": "native.apple.3241d6de1ab6b340"
     },
     {
       "kind": "conditional-branch",
@@ -13543,7 +13543,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Background location requests and significant-change updates are allowed. Precise Location is on.",
       "surface": "apple",
-      "id": "native.apple.4daa9e136532b89a"
+      "id": "native.apple.7b16935cf96c6ee3"
     },
     {
       "kind": "conditional-branch",
@@ -13551,7 +13551,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Background location requests and significant-change updates are allowed. Precise Location is off.",
       "surface": "apple",
-      "id": "native.apple.d986afe686bc78df"
+      "id": "native.apple.b1503179f7e1058d"
     },
     {
       "kind": "conditional-branch",
@@ -13559,7 +13559,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Background location requests and significant-change updates are allowed.",
       "surface": "apple",
-      "id": "native.apple.ec1a9f1ea8fef344"
+      "id": "native.apple.6f63c4f93b7a9ab5"
     },
     {
       "kind": "conditional-branch",
@@ -13567,7 +13567,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Always is selected, but iOS currently allows location only while using the app. Precise Location is on.",
       "surface": "apple",
-      "id": "native.apple.429caec30214b7db"
+      "id": "native.apple.95a6772115ad8b63"
     },
     {
       "kind": "conditional-branch",
@@ -13575,7 +13575,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Always is selected, but iOS currently allows location only while using the app. Precise Location is off.",
       "surface": "apple",
-      "id": "native.apple.f296eba86280ba95"
+      "id": "native.apple.8ab7fd180dc593f6"
     },
     {
       "kind": "conditional-branch",
@@ -13583,7 +13583,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Always is selected, but iOS currently allows location only while using the app.",
       "surface": "apple",
-      "id": "native.apple.d78efb686e0542d2"
+      "id": "native.apple.15bc589594491413"
     },
     {
       "kind": "conditional-branch",
@@ -13591,7 +13591,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location permission is denied in iOS Settings.",
       "surface": "apple",
-      "id": "native.apple.09f7e10303fa51d0"
+      "id": "native.apple.30ce7ced43a0a752"
     },
     {
       "kind": "conditional-branch",
@@ -13599,7 +13599,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Location permission is restricted on this device.",
       "surface": "apple",
-      "id": "native.apple.93f1be684c1511c8"
+      "id": "native.apple.0de03d90e4280432"
     },
     {
       "kind": "conditional-branch",
@@ -13607,7 +13607,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "Choose a location mode to request iOS permission.",
       "surface": "apple",
-      "id": "native.apple.442cf2bf281ec3f1"
+      "id": "native.apple.0d0506a7417e7d92"
     },
     {
       "kind": "conditional-branch",
@@ -13615,7 +13615,7 @@
       "path": "apps/ios/Sources/Location/LocationPermissionSummary.swift",
       "source": "OpenClaw cannot determine the current iOS location permission.",
       "surface": "apple",
-      "id": "native.apple.db42a5ecf1647d12"
+      "id": "native.apple.633f011b81108a8c"
     },
     {
       "kind": "ui-localized-call",
@@ -13623,7 +13623,7 @@
       "path": "apps/ios/Sources/Location/LocationSettingsPresentation.swift",
       "source": "Location Services are off in iOS Settings.",
       "surface": "apple",
-      "id": "native.apple.fa7243038f90e157"
+      "id": "native.apple.e5673992d3aeac64"
     },
     {
       "kind": "ui-localized-call",
@@ -13631,7 +13631,7 @@
       "path": "apps/ios/Sources/Location/LocationSettingsPresentation.swift",
       "source": "iOS permission is required to share location.",
       "surface": "apple",
-      "id": "native.apple.cde6b7a36f2918a3"
+      "id": "native.apple.270f9edf88f41fbf"
     },
     {
       "kind": "ui-localized-call",
@@ -13639,7 +13639,7 @@
       "path": "apps/ios/Sources/Location/LocationSettingsPresentation.swift",
       "source": "Location permission is denied in iOS Settings.",
       "surface": "apple",
-      "id": "native.apple.49d5c019fa976791"
+      "id": "native.apple.8cb96b0bb1921610"
     },
     {
       "kind": "ui-localized-call",
@@ -13647,7 +13647,7 @@
       "path": "apps/ios/Sources/Location/LocationSettingsPresentation.swift",
       "source": "Location permission is restricted on this device.",
       "surface": "apple",
-      "id": "native.apple.850483a11234dcc9"
+      "id": "native.apple.d7da989dd737723c"
     },
     {
       "kind": "ui-localized-call",
@@ -13655,7 +13655,7 @@
       "path": "apps/ios/Sources/Location/LocationSettingsPresentation.swift",
       "source": "iOS currently allows location only while using the app.",
       "surface": "apple",
-      "id": "native.apple.66da5b758062d2a3"
+      "id": "native.apple.cc1df565f1194db4"
     },
     {
       "kind": "ui-localized-call",
@@ -13663,7 +13663,7 @@
       "path": "apps/ios/Sources/Location/LocationSettingsPresentation.swift",
       "source": "OpenClaw cannot determine the current iOS location permission.",
       "surface": "apple",
-      "id": "native.apple.9f430559440a9dbf"
+      "id": "native.apple.f6b19113d5d8e7db"
     },
     {
       "kind": "ui-localized-call",
@@ -13671,7 +13671,7 @@
       "path": "apps/ios/Sources/Location/LocationSettingsPresentation.swift",
       "source": "While Using the App",
       "surface": "apple",
-      "id": "native.apple.69e7d591f2200793"
+      "id": "native.apple.2892e5b02c6789f0"
     },
     {
       "kind": "ui-localized-call",
@@ -13679,7 +13679,7 @@
       "path": "apps/ios/Sources/Location/LocationSettingsPresentation.swift",
       "source": "Always",
       "surface": "apple",
-      "id": "native.apple.f072ede3fd94df1f"
+      "id": "native.apple.f689e63e18ca692d"
     },
     {
       "kind": "conditional-branch",
@@ -13687,7 +13687,7 @@
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Action required",
       "surface": "apple",
-      "id": "native.apple.1eba9f60b9b08582"
+      "id": "native.apple.0d030e96f7738497"
     },
     {
       "kind": "conditional-branch",
@@ -13695,7 +13695,7 @@
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval needed",
       "surface": "apple",
-      "id": "native.apple.0f92ad952e864b6a"
+      "id": "native.apple.ce6a022159f2fb41"
     },
     {
       "kind": "conditional-branch",
@@ -13703,7 +13703,7 @@
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
-      "id": "native.apple.8a5926535c7bea31"
+      "id": "native.apple.b0d9c1ba8ef7ec19"
     },
     {
       "kind": "conditional-branch",
@@ -13711,7 +13711,7 @@
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
-      "id": "native.apple.940a499f0115f7ff"
+      "id": "native.apple.bd98e19b49309284"
     },
     {
       "kind": "conditional-branch",
@@ -13719,7 +13719,7 @@
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting...",
       "surface": "apple",
-      "id": "native.apple.eb3d81029883a5ad"
+      "id": "native.apple.6504753f3621269e"
     },
     {
       "kind": "conditional-branch",
@@ -13727,7 +13727,7 @@
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting...",
       "surface": "apple",
-      "id": "native.apple.003b917d18b51901"
+      "id": "native.apple.c7fbe2a713d78714"
     },
     {
       "kind": "conditional-branch",
@@ -13735,7 +13735,7 @@
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connected",
       "surface": "apple",
-      "id": "native.apple.bb5520c54af43804"
+      "id": "native.apple.c0a005f81d588867"
     },
     {
       "kind": "conditional-branch",
@@ -13743,7 +13743,7 @@
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Offline",
       "surface": "apple",
-      "id": "native.apple.045b07104fbfb6be"
+      "id": "native.apple.ae33908b61c6d70b"
     },
     {
       "kind": "conditional-branch",
@@ -13799,7 +13799,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingStateStore.swift",
       "source": "Home Network",
       "surface": "apple",
-      "id": "native.apple.35f1257ef7d59336"
+      "id": "native.apple.11687a3d87afd0d7"
     },
     {
       "kind": "conditional-branch",
@@ -13807,7 +13807,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingStateStore.swift",
       "source": "Remote Domain",
       "surface": "apple",
-      "id": "native.apple.1776aefb26062d91"
+      "id": "native.apple.49174538b8e8cae5"
     },
     {
       "kind": "conditional-branch",
@@ -13815,7 +13815,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingStateStore.swift",
       "source": "Same Machine (Dev)",
       "surface": "apple",
-      "id": "native.apple.07077a531e820341"
+      "id": "native.apple.5b0997ed2ebf70c7"
     },
     {
       "kind": "ui-named-argument",
@@ -13823,7 +13823,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Home Network",
       "surface": "apple",
-      "id": "native.apple.95bd66690e09e9aa"
+      "id": "native.apple.95e2c98254da2aba"
     },
     {
       "kind": "ui-named-argument",
@@ -13831,7 +13831,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "LAN or Tailscale host",
       "surface": "apple",
-      "id": "native.apple.04f3fe009f96fbf0"
+      "id": "native.apple.d9a6d673aa6693ee"
     },
     {
       "kind": "ui-named-argument",
@@ -13839,7 +13839,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Remote Domain",
       "surface": "apple",
-      "id": "native.apple.bcde7d8af2671671"
+      "id": "native.apple.431d02f8b68a96cf"
     },
     {
       "kind": "ui-named-argument",
@@ -13847,7 +13847,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "VPS with domain",
       "surface": "apple",
-      "id": "native.apple.c9079ed7743cbde9"
+      "id": "native.apple.7021301971f631bf"
     },
     {
       "kind": "ui-named-argument",
@@ -13855,7 +13855,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Same Machine (Dev)",
       "surface": "apple",
-      "id": "native.apple.a3b04247b1b22037"
+      "id": "native.apple.7451f8d052016642"
     },
     {
       "kind": "ui-named-argument",
@@ -13863,7 +13863,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "For local iOS app development",
       "surface": "apple",
-      "id": "native.apple.489d6506e3dbed8d"
+      "id": "native.apple.22e740296a762256"
     },
     {
       "kind": "ui-call",
@@ -13871,7 +13871,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Manual Connection",
       "surface": "apple",
-      "id": "native.apple.e28f880ddbea8a08"
+      "id": "native.apple.e1b1ccbfc9e73df8"
     },
     {
       "kind": "ui-call",
@@ -13879,7 +13879,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Continue",
       "surface": "apple",
-      "id": "native.apple.1b48769cec747f28"
+      "id": "native.apple.b7dc527c2a7e95cb"
     },
     {
       "kind": "ui-call",
@@ -13887,7 +13887,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Developer mode",
       "surface": "apple",
-      "id": "native.apple.69fd85c2a8413f2d"
+      "id": "native.apple.93d3e17fabd5e082"
     },
     {
       "kind": "ui-named-argument",
@@ -13895,7 +13895,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Connection Failed",
       "surface": "apple",
-      "id": "native.apple.0f4152d417918852"
+      "id": "native.apple.e8b90e582100294d"
     },
     {
       "kind": "ui-named-argument",
@@ -13903,7 +13903,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Needs attention",
       "surface": "apple",
-      "id": "native.apple.d1ea3dcd94907d9b"
+      "id": "native.apple.9e208d090ce2e84f"
     },
     {
       "kind": "conditional-branch",
@@ -13919,7 +13919,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Ready to Connect",
       "surface": "apple",
-      "id": "native.apple.8bea970cd5085564"
+      "id": "native.apple.e71e20089bcc4cfb"
     },
     {
       "kind": "ui-call",
@@ -13927,7 +13927,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Host",
       "surface": "apple",
-      "id": "native.apple.18a0a0afc685c3f6"
+      "id": "native.apple.3d6cf0499c8e5980"
     },
     {
       "kind": "ui-call",
@@ -13935,7 +13935,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Port",
       "surface": "apple",
-      "id": "native.apple.b98dba4969a1e649"
+      "id": "native.apple.7cf97afea0a8ef4e"
     },
     {
       "kind": "ui-call",
@@ -13943,7 +13943,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Security",
       "surface": "apple",
-      "id": "native.apple.1e1f0819ba974ba2"
+      "id": "native.apple.cf616b515da5bc19"
     },
     {
       "kind": "conditional-branch",
@@ -13951,7 +13951,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Plaintext (local network)",
       "surface": "apple",
-      "id": "native.apple.9f3300c7e248d6cc"
+      "id": "native.apple.4014217851d06190"
     },
     {
       "kind": "ui-call",
@@ -13959,7 +13959,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Connecting…",
       "surface": "apple",
-      "id": "native.apple.6be3a153c38ea18d"
+      "id": "native.apple.8c3050f34db919c7"
     },
     {
       "kind": "ui-call",
@@ -13967,7 +13967,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Connect",
       "surface": "apple",
-      "id": "native.apple.8137d4d29d3cdf6a"
+      "id": "native.apple.3e81935f219ca978"
     },
     {
       "kind": "ui-call",
@@ -13975,7 +13975,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Use Manual Setup",
       "surface": "apple",
-      "id": "native.apple.f263874106ab9d6e"
+      "id": "native.apple.db7b52a1bbc6fac5"
     },
     {
       "kind": "ui-call",
@@ -13983,7 +13983,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Setup Link",
       "surface": "apple",
-      "id": "native.apple.327b3fab462c31ff"
+      "id": "native.apple.7dbdf9a439f64f08"
     },
     {
       "kind": "conditional-branch",
@@ -13991,7 +13991,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "surface": "apple",
-      "id": "native.apple.f0aeb496631a06b4"
+      "id": "native.apple.3329c7f367f10c78"
     },
     {
       "kind": "conditional-branch",
@@ -13999,7 +13999,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Plaintext may expose credentials. Continue only if you trust this local network and host.",
       "surface": "apple",
-      "id": "native.apple.0792e5bfc5917767"
+      "id": "native.apple.6bfb611862fb1687"
     },
     {
       "kind": "ui-call",
@@ -14007,7 +14007,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "No gateways found yet.",
       "surface": "apple",
-      "id": "native.apple.0b8f879b0a927350"
+      "id": "native.apple.2f00ef4bc35ecb8d"
     },
     {
       "kind": "ui-call",
@@ -14015,7 +14015,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Restart Discovery",
       "surface": "apple",
-      "id": "native.apple.26223c0b79210f6e"
+      "id": "native.apple.94c9697fb748d05d"
     },
     {
       "kind": "ui-call",
@@ -14023,7 +14023,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardConnectionSections.swift",
       "source": "Discovered Gateways",
       "surface": "apple",
-      "id": "native.apple.df726976d165732a"
+      "id": "native.apple.07ebd3b75969629f"
     },
     {
       "kind": "ui-call",
@@ -14031,7 +14031,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Security notice",
       "surface": "apple",
-      "id": "native.apple.d7de1640cd83b30d"
+      "id": "native.apple.09e7832b23cf14f6"
     },
     {
       "kind": "ui-call",
@@ -14039,7 +14039,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "The connected OpenClaw agent can use device capabilities you enable.",
       "surface": "apple",
-      "id": "native.apple.048f49e40b4c8dfd"
+      "id": "native.apple.d4d9568dca8ceaa9"
     },
     {
       "kind": "ui-call",
@@ -14047,7 +14047,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Camera, microphone, photos, contacts, calendar, and location may be available.",
       "surface": "apple",
-      "id": "native.apple.500cc16ca47793aa"
+      "id": "native.apple.fdd93eb6b6eef525"
     },
     {
       "kind": "ui-call",
@@ -14055,7 +14055,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Continue only if you trust the gateway and agent you connect to.",
       "surface": "apple",
-      "id": "native.apple.d9233b8153cbfa51"
+      "id": "native.apple.7cc0f656abb41f6d"
     },
     {
       "kind": "ui-modifier",
@@ -14063,7 +14063,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Copy setup code command",
       "surface": "apple",
-      "id": "native.apple.f841b3d18cc6073b"
+      "id": "native.apple.eae3bd9e4e9112a0"
     },
     {
       "kind": "conditional-branch",
@@ -14079,7 +14079,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "OpenClaw",
       "surface": "apple",
-      "id": "native.apple.749270d1ad655ca9"
+      "id": "native.apple.e8b4dc00cd23ae73"
     },
     {
       "kind": "ui-named-argument",
@@ -14087,7 +14087,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Securely connect this iPhone to your gateway.",
       "surface": "apple",
-      "id": "native.apple.f378ca9fc19f6835"
+      "id": "native.apple.c9419426ba8c2a2e"
     },
     {
       "kind": "ui-named-argument",
@@ -14095,7 +14095,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Connect to your gateway",
       "surface": "apple",
-      "id": "native.apple.9050502c2dfdbd08"
+      "id": "native.apple.3e233ba3ed3181d4"
     },
     {
       "kind": "ui-named-argument",
@@ -14103,7 +14103,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Choose device permissions",
       "surface": "apple",
-      "id": "native.apple.c834115a6a973c08"
+      "id": "native.apple.b6978424ac0a4d14"
     },
     {
       "kind": "ui-named-argument",
@@ -14111,7 +14111,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Use OpenClaw from your phone",
       "surface": "apple",
-      "id": "native.apple.92c8f15731183c84"
+      "id": "native.apple.4109460a5b8927d8"
     },
     {
       "kind": "ui-call",
@@ -14119,7 +14119,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Continue",
       "surface": "apple",
-      "id": "native.apple.246af90092725464"
+      "id": "native.apple.cae311a6e975c879"
     },
     {
       "kind": "ui-named-argument",
@@ -14127,7 +14127,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Connect Gateway",
       "surface": "apple",
-      "id": "native.apple.78ce2252d123519c"
+      "id": "native.apple.c686068c2a79bf9e"
     },
     {
       "kind": "ui-named-argument",
@@ -14135,7 +14135,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Run this on your gateway host and scan the code",
       "surface": "apple",
-      "id": "native.apple.068d3e124deca287"
+      "id": "native.apple.8f76a5962329b43f"
     },
     {
       "kind": "ui-call",
@@ -14143,7 +14143,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Connecting…",
       "surface": "apple",
-      "id": "native.apple.92447f10c8408561"
+      "id": "native.apple.d71a98568b7184a5"
     },
     {
       "kind": "ui-call",
@@ -14151,7 +14151,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Scan QR",
       "surface": "apple",
-      "id": "native.apple.5bcd0c2ea7791d72"
+      "id": "native.apple.577764b38b1d903c"
     },
     {
       "kind": "ui-named-argument",
@@ -14159,7 +14159,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "or",
       "surface": "apple",
-      "id": "native.apple.91337129a1eaad02"
+      "id": "native.apple.913a586956440f64"
     },
     {
       "kind": "ui-call",
@@ -14167,7 +14167,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Connect Manually",
       "surface": "apple",
-      "id": "native.apple.474efa99af12e8b2"
+      "id": "native.apple.57614f0c4e59677b"
     },
     {
       "kind": "ui-call",
@@ -14175,7 +14175,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "You're connected",
       "surface": "apple",
-      "id": "native.apple.257bd3fa156a09b2"
+      "id": "native.apple.4916d34cab45e6c3"
     },
     {
       "kind": "ui-call",
@@ -14183,7 +14183,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardSteps.swift",
       "source": "Go to Chat",
       "surface": "apple",
-      "id": "native.apple.cc0423e431b2da20"
+      "id": "native.apple.b5e401fa9bfb4b49"
     },
     {
       "kind": "conditional-branch",
@@ -14191,7 +14191,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway auth token is missing.",
       "surface": "apple",
-      "id": "native.apple.785f53402b93d2ef"
+      "id": "native.apple.bdc551ec6154a4de"
     },
     {
       "kind": "conditional-branch",
@@ -14199,7 +14199,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway rejected credentials.",
       "surface": "apple",
-      "id": "native.apple.44b61ae1c6757049"
+      "id": "native.apple.303cd481d965b513"
     },
     {
       "kind": "conditional-branch",
@@ -14207,7 +14207,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Could not reach the gateway.",
       "surface": "apple",
-      "id": "native.apple.9387cdd2a05c875c"
+      "id": "native.apple.b1ad23ecc5f4b0c2"
     },
     {
       "kind": "ui-modifier",
@@ -14215,7 +14215,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "QR Scanner Unavailable",
       "surface": "apple",
-      "id": "native.apple.342d77f542fc06c1"
+      "id": "native.apple.a62e0764b51937cb"
     },
     {
       "kind": "ui-call",
@@ -14223,7 +14223,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "OK",
       "surface": "apple",
-      "id": "native.apple.e85c4f6e42d38422"
+      "id": "native.apple.0a329fe4d4aef5bb"
     },
     {
       "kind": "ui-call",
@@ -14231,7 +14231,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Scan Setup Code",
       "surface": "apple",
-      "id": "native.apple.52bb089f43889b95"
+      "id": "native.apple.d50aa0885c7e064f"
     },
     {
       "kind": "ui-call",
@@ -14239,7 +14239,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Cancel",
       "surface": "apple",
-      "id": "native.apple.07ba8a0e5a623228"
+      "id": "native.apple.f58429a2d9d3371f"
     },
     {
       "kind": "ui-call",
@@ -14247,7 +14247,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Photos",
       "surface": "apple",
-      "id": "native.apple.706cf2bed9dfa2d1"
+      "id": "native.apple.f0a022bd1772fda0"
     },
     {
       "kind": "ui-modifier",
@@ -14255,7 +14255,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Back",
       "surface": "apple",
-      "id": "native.apple.ccf758caa953d5f9"
+      "id": "native.apple.09ed26daf34a4c5d"
     },
     {
       "kind": "ui-call",
@@ -14263,7 +14263,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Close",
       "surface": "apple",
-      "id": "native.apple.2a5e2d97339e2446"
+      "id": "native.apple.e58367cfa71115cc"
     },
     {
       "kind": "ui-modifier",
@@ -14271,7 +14271,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Dismiss Keyboard",
       "surface": "apple",
-      "id": "native.apple.dcd80e92827338ed"
+      "id": "native.apple.1e60db061979db60"
     },
     {
       "kind": "ui-call",
@@ -14279,7 +14279,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Mode",
       "surface": "apple",
-      "id": "native.apple.cf1bee5ce0e03b58"
+      "id": "native.apple.d444d84eb269f529"
     },
     {
       "kind": "ui-call",
@@ -14287,7 +14287,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Discovery",
       "surface": "apple",
-      "id": "native.apple.45d8576b6a8627f4"
+      "id": "native.apple.d5d2681fc2d9b10d"
     },
     {
       "kind": "ui-call",
@@ -14295,7 +14295,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Status",
       "surface": "apple",
-      "id": "native.apple.34b1c695bb91946c"
+      "id": "native.apple.2034ab1aeebbab91"
     },
     {
       "kind": "ui-call",
@@ -14303,7 +14303,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Choose a mode first.",
       "surface": "apple",
-      "id": "native.apple.1d04728fde2b5203"
+      "id": "native.apple.17e200e7cbad27ae"
     },
     {
       "kind": "ui-call",
@@ -14311,7 +14311,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Back to Mode Selection",
       "surface": "apple",
-      "id": "native.apple.d804f4a034e647fe"
+      "id": "native.apple.378c2c7be159c1f2"
     },
     {
       "kind": "ui-named-argument",
@@ -14319,7 +14319,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Manual Fallback",
       "surface": "apple",
-      "id": "native.apple.3ad38183e6e45001"
+      "id": "native.apple.1284354b0d0098ad"
     },
     {
       "kind": "ui-named-argument",
@@ -14327,7 +14327,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Domain Settings",
       "surface": "apple",
-      "id": "native.apple.22e974597c20b33b"
+      "id": "native.apple.db2b3720c08fca4d"
     },
     {
       "kind": "ui-call",
@@ -14335,7 +14335,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Developer Local",
       "surface": "apple",
-      "id": "native.apple.110e2d5313667f29"
+      "id": "native.apple.36bb966d0789414d"
     },
     {
       "kind": "ui-call",
@@ -14343,7 +14343,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Default host is localhost. Use your Mac LAN IP if simulator networking requires it.",
       "surface": "apple",
-      "id": "native.apple.33828417c20cce7e"
+      "id": "native.apple.dc8b73d67a261e73"
     },
     {
       "kind": "ui-call",
@@ -14351,7 +14351,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway rejected credentials. Scan a fresh setup code or update token/password.",
       "surface": "apple",
-      "id": "native.apple.20889b6dc7841793"
+      "id": "native.apple.5847cf494847ed98"
     },
     {
       "kind": "ui-call",
@@ -14359,7 +14359,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "OpenClaw is checking gateway and node access.",
       "surface": "apple",
-      "id": "native.apple.707d3aa0552d4424"
+      "id": "native.apple.559dccb9f9dfbbad"
     },
     {
       "kind": "ui-call",
@@ -14367,7 +14367,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Resume After Approval",
       "surface": "apple",
-      "id": "native.apple.58f14a0bf3a8ed8c"
+      "id": "native.apple.4404f435fb496b62"
     },
     {
       "kind": "ui-call",
@@ -14375,7 +14375,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Pairing Approval",
       "surface": "apple",
-      "id": "native.apple.4b1fb7f06bd6bc3b"
+      "id": "native.apple.44233bae1c0afe68"
     },
     {
       "kind": "ui-call-concatenated",
@@ -14383,7 +14383,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Approve this device on the gateway.\n1) `\\(commandLine)`\n2) `/pair approve` in your OpenClaw chat\n\\(requestLine)\nOpenClaw will also retry automatically when you return to this app.",
       "surface": "apple",
-      "id": "native.apple.ff68473aad93fe5e"
+      "id": "native.apple.9725443db32f5158"
     },
     {
       "kind": "ui-call",
@@ -14391,7 +14391,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Scan Setup Code Again",
       "surface": "apple",
-      "id": "native.apple.00a542500b9ece4f"
+      "id": "native.apple.af3890b1e07c3084"
     },
     {
       "kind": "ui-call",
@@ -14399,7 +14399,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Retry Connection",
       "surface": "apple",
-      "id": "native.apple.9ae99eeabd029455"
+      "id": "native.apple.0134e9bd57c74d27"
     },
     {
       "kind": "ui-call",
@@ -14407,7 +14407,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Enter setup code",
       "surface": "apple",
-      "id": "native.apple.564762557c6f4fd1"
+      "id": "native.apple.abe248e02d451890"
     },
     {
       "kind": "ui-call",
@@ -14415,7 +14415,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Apply",
       "surface": "apple",
-      "id": "native.apple.94f126685955376a"
+      "id": "native.apple.d9e6ff8a72f4525b"
     },
     {
       "kind": "ui-call",
@@ -14423,7 +14423,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Setup Code",
       "surface": "apple",
-      "id": "native.apple.102df5e30b073ebe"
+      "id": "native.apple.74d4be2078a04261"
     },
     {
       "kind": "ui-call",
@@ -14431,7 +14431,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Use this if you have a setup code instead of scanning.",
       "surface": "apple",
-      "id": "native.apple.f7b828f7d7002f5f"
+      "id": "native.apple.ee24a5a75d7b1e4f"
     },
     {
       "kind": "ui-call",
@@ -14439,7 +14439,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Host",
       "surface": "apple",
-      "id": "native.apple.63f1d5fe6fffa39b"
+      "id": "native.apple.826c84d7090d253c"
     },
     {
       "kind": "ui-call",
@@ -14447,7 +14447,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Port",
       "surface": "apple",
-      "id": "native.apple.7599beed5b46ee31"
+      "id": "native.apple.9e9de5d188e3c693"
     },
     {
       "kind": "ui-call",
@@ -14455,7 +14455,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Discovery Domain (optional)",
       "surface": "apple",
-      "id": "native.apple.e1364730639bafdf"
+      "id": "native.apple.b1fdf88fe407cf7b"
     },
     {
       "kind": "ui-call",
@@ -14463,7 +14463,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway Auth Token",
       "surface": "apple",
-      "id": "native.apple.54df1d842fbb868f"
+      "id": "native.apple.600ba39ce56ddd62"
     },
     {
       "kind": "ui-call",
@@ -14471,7 +14471,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway Password",
       "surface": "apple",
-      "id": "native.apple.30a1f14828de9569"
+      "id": "native.apple.a5943eaea2db1d6d"
     },
     {
       "kind": "ui-call",
@@ -14479,7 +14479,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Unencrypted",
       "surface": "apple",
-      "id": "native.apple.536c9453100b8288"
+      "id": "native.apple.3e34c28edd053285"
     },
     {
       "kind": "ui-call",
@@ -14487,7 +14487,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Secure (TLS)",
       "surface": "apple",
-      "id": "native.apple.1d47e6515a89823d"
+      "id": "native.apple.19ce2a63ffa5562a"
     },
     {
       "kind": "ui-call",
@@ -14495,7 +14495,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Connection security",
       "surface": "apple",
-      "id": "native.apple.189c54620317f831"
+      "id": "native.apple.a1eb951133402dd4"
     },
     {
       "kind": "ui-call",
@@ -14503,7 +14503,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Connecting…",
       "surface": "apple",
-      "id": "native.apple.a471965d9a0b3a24"
+      "id": "native.apple.6c3fe084ab7b318d"
     },
     {
       "kind": "ui-call",
@@ -14511,7 +14511,7 @@
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Connect",
       "surface": "apple",
-      "id": "native.apple.3092a8e342aa043f"
+      "id": "native.apple.ab58b30ddda7aeb0"
     },
     {
       "kind": "conditional-branch",
@@ -14535,7 +14535,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Talk",
       "surface": "apple",
-      "id": "native.apple.2a338ac871ecb7fe"
+      "id": "native.apple.f2ea327bfea8b8e3"
     },
     {
       "kind": "ui-call",
@@ -14543,7 +14543,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Control",
       "surface": "apple",
-      "id": "native.apple.731252cc63ef4eca"
+      "id": "native.apple.bda6cfa988e49a75"
     },
     {
       "kind": "ui-call",
@@ -14551,7 +14551,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Agent",
       "surface": "apple",
-      "id": "native.apple.7456e2f9439034e7"
+      "id": "native.apple.3c80f5351055a5f3"
     },
     {
       "kind": "ui-call",
@@ -14559,7 +14559,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Settings",
       "surface": "apple",
-      "id": "native.apple.6573d500ca6879ef"
+      "id": "native.apple.22d107db5b905ef4"
     },
     {
       "kind": "ui-call",
@@ -14567,7 +14567,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw",
       "surface": "apple",
-      "id": "native.apple.84ea52fed0394561"
+      "id": "native.apple.c23d35de8d70863f"
     },
     {
       "kind": "ui-modifier",
@@ -14575,7 +14575,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw \\(self.sidebarGatewayStatusTitle)",
       "surface": "apple",
-      "id": "native.apple.cb006ba6f4011f73"
+      "id": "native.apple.39042da9fc187030"
     },
     {
       "kind": "conditional-branch",
@@ -14583,7 +14583,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Online",
       "surface": "apple",
-      "id": "native.apple.bb5a64079d5dd251"
+      "id": "native.apple.f4eea6473f43388d"
     },
     {
       "kind": "conditional-branch",
@@ -14591,7 +14591,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Connecting",
       "surface": "apple",
-      "id": "native.apple.4af0f1f4ad2deeb6"
+      "id": "native.apple.9e2aea6088887f1f"
     },
     {
       "kind": "conditional-branch",
@@ -14599,7 +14599,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Needs attention",
       "surface": "apple",
-      "id": "native.apple.06a7f9fdeeb95881"
+      "id": "native.apple.3624978c7d43335a"
     },
     {
       "kind": "conditional-branch",
@@ -14607,7 +14607,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Offline",
       "surface": "apple",
-      "id": "native.apple.623535bbd51e4a4b"
+      "id": "native.apple.7da053dd774cb201"
     },
     {
       "kind": "ui-named-argument",
@@ -14615,7 +14615,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Chat",
       "surface": "apple",
-      "id": "native.apple.4d24eb02c634e5d3"
+      "id": "native.apple.a4256b2ab523ee60"
     },
     {
       "kind": "ui-named-argument",
@@ -14623,7 +14623,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Overview",
       "surface": "apple",
-      "id": "native.apple.143565a5ab324c3b"
+      "id": "native.apple.64d7dc062ef4cc81"
     },
     {
       "kind": "ui-named-argument",
@@ -14631,7 +14631,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Agents",
       "surface": "apple",
-      "id": "native.apple.be6dd25682178eed"
+      "id": "native.apple.11f98fe0650d52f5"
     },
     {
       "kind": "ui-named-argument",
@@ -14639,7 +14639,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Instances",
       "surface": "apple",
-      "id": "native.apple.1f3dccec9147b95e"
+      "id": "native.apple.47426e84372bc0a5"
     },
     {
       "kind": "ui-named-argument",
@@ -14647,7 +14647,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Files",
       "surface": "apple",
-      "id": "native.apple.8c9cdab957b0651d"
+      "id": "native.apple.d1a5c9b0c4acbfe2"
     },
     {
       "kind": "ui-named-argument",
@@ -14655,7 +14655,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Dreaming",
       "surface": "apple",
-      "id": "native.apple.11e4feacdd66b471"
+      "id": "native.apple.ad3c65353227b63e"
     },
     {
       "kind": "ui-named-argument",
@@ -14663,7 +14663,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Usage",
       "surface": "apple",
-      "id": "native.apple.eeaf566d56befff7"
+      "id": "native.apple.a3ba593df67a8673"
     },
     {
       "kind": "ui-named-argument",
@@ -14671,7 +14671,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Cron Jobs",
       "surface": "apple",
-      "id": "native.apple.2cc59621d0777089"
+      "id": "native.apple.db0d9af6d0855d18"
     },
     {
       "kind": "ui-modifier",
@@ -14679,7 +14679,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Hide Sidebar",
       "surface": "apple",
-      "id": "native.apple.9a813708c69992e4"
+      "id": "native.apple.72fab75688479b3e"
     },
     {
       "kind": "ui-modifier",
@@ -14687,7 +14687,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Close canvas",
       "surface": "apple",
-      "id": "native.apple.766267e34342d769"
+      "id": "native.apple.8af43f59602ec0d8"
     },
     {
       "kind": "conditional-branch",
@@ -14695,7 +14695,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway needs attention",
       "surface": "apple",
-      "id": "native.apple.ab6b0e43b6bcf5ff"
+      "id": "native.apple.8a4751c86aa6fe77"
     },
     {
       "kind": "conditional-branch",
@@ -14703,7 +14703,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw iOS",
       "surface": "apple",
-      "id": "native.apple.9da57c45433e8fe9"
+      "id": "native.apple.a55a43940452b04b"
     },
     {
       "kind": "conditional-branch",
@@ -14711,7 +14711,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Available",
       "surface": "apple",
-      "id": "native.apple.fd66d1ffbe5f9b72"
+      "id": "native.apple.35b6f99d627028f6"
     },
     {
       "kind": "conditional-branch",
@@ -14719,7 +14719,7 @@
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway default",
       "surface": "apple",
-      "id": "native.apple.98915ebb62287a02"
+      "id": "native.apple.e91893761485b9e8"
     },
     {
       "kind": "conditional-branch",
@@ -14735,7 +14735,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Chat",
       "surface": "apple",
-      "id": "native.apple.e55c99a74ecb9429"
+      "id": "native.apple.a29418bbb3169404"
     },
     {
       "kind": "conditional-branch",
@@ -14743,7 +14743,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Talk",
       "surface": "apple",
-      "id": "native.apple.addf7e959238c434"
+      "id": "native.apple.febca7528af94342"
     },
     {
       "kind": "conditional-branch",
@@ -14751,7 +14751,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Overview",
       "surface": "apple",
-      "id": "native.apple.e31e7d688db1e507"
+      "id": "native.apple.e26bbe303d8a9544"
     },
     {
       "kind": "conditional-branch",
@@ -14759,7 +14759,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Activity",
       "surface": "apple",
-      "id": "native.apple.978a93d5f6c1492b"
+      "id": "native.apple.1bae45caee11d1a4"
     },
     {
       "kind": "conditional-branch",
@@ -14767,7 +14767,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Agents",
       "surface": "apple",
-      "id": "native.apple.039d5323b4133540"
+      "id": "native.apple.dea6129f5908f494"
     },
     {
       "kind": "conditional-branch",
@@ -14775,7 +14775,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Workboard",
       "surface": "apple",
-      "id": "native.apple.eb8da3ac76a36319"
+      "id": "native.apple.1b9a298ab6e87f5f"
     },
     {
       "kind": "conditional-branch",
@@ -14783,7 +14783,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Skill Workshop",
       "surface": "apple",
-      "id": "native.apple.5f58ed7fd9de7c40"
+      "id": "native.apple.2492086244fda7c6"
     },
     {
       "kind": "conditional-branch",
@@ -14791,7 +14791,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Instances",
       "surface": "apple",
-      "id": "native.apple.c022f8541ef2af61"
+      "id": "native.apple.7482f18faae25219"
     },
     {
       "kind": "conditional-branch",
@@ -14799,7 +14799,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Sessions",
       "surface": "apple",
-      "id": "native.apple.e3e3ce1a79ebbd70"
+      "id": "native.apple.3579cf2750470a22"
     },
     {
       "kind": "conditional-branch",
@@ -14807,7 +14807,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Files",
       "surface": "apple",
-      "id": "native.apple.9a2e934b2c0f7b9c"
+      "id": "native.apple.253cb2debeb51859"
     },
     {
       "kind": "conditional-branch",
@@ -14815,7 +14815,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Dreaming",
       "surface": "apple",
-      "id": "native.apple.4b487e0b204100d2"
+      "id": "native.apple.f7e04202c3e37bd8"
     },
     {
       "kind": "conditional-branch",
@@ -14823,7 +14823,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Usage",
       "surface": "apple",
-      "id": "native.apple.a68defb824f08706"
+      "id": "native.apple.006c21319c07c995"
     },
     {
       "kind": "conditional-branch",
@@ -14831,7 +14831,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Cron Jobs",
       "surface": "apple",
-      "id": "native.apple.f44d1d607d617560"
+      "id": "native.apple.0b4e807d2449e93f"
     },
     {
       "kind": "conditional-branch",
@@ -14839,7 +14839,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Terminal",
       "surface": "apple",
-      "id": "native.apple.0a89db5f6440494e"
+      "id": "native.apple.b3b5114b91a8db8f"
     },
     {
       "kind": "conditional-branch",
@@ -14847,7 +14847,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Docs",
       "surface": "apple",
-      "id": "native.apple.0ddc5e5f7cabc9d7"
+      "id": "native.apple.584dfce592c64899"
     },
     {
       "kind": "conditional-branch",
@@ -14855,7 +14855,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Settings",
       "surface": "apple",
-      "id": "native.apple.5c4975b8af9d262b"
+      "id": "native.apple.32f7a12fd39a135c"
     },
     {
       "kind": "conditional-branch",
@@ -14863,7 +14863,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Settings / Gateway",
       "surface": "apple",
-      "id": "native.apple.a293fea3dfaa52b3"
+      "id": "native.apple.65ed76ea0b539052"
     },
     {
       "kind": "conditional-branch",
@@ -14871,7 +14871,7 @@
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Connection",
       "surface": "apple",
-      "id": "native.apple.873fedc2bc9a5c1b"
+      "id": "native.apple.e69088f1f2dcbd99"
     },
     {
       "kind": "ui-call",
@@ -14879,7 +14879,7 @@
       "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
       "source": "Value",
       "surface": "apple",
-      "id": "native.apple.122e1ca6eeee1cea"
+      "id": "native.apple.41e812a22a1b042d"
     },
     {
       "kind": "ui-call",
@@ -14887,7 +14887,7 @@
       "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
       "source": "Headers",
       "surface": "apple",
-      "id": "native.apple.d8a299893eee8eab"
+      "id": "native.apple.acc5936e406af08c"
     },
     {
       "kind": "ui-call-concatenated",
@@ -14895,7 +14895,7 @@
       "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
       "source": "Sent with foreground app connections to this gateway. Changes apply on the next reconnect; Share extension delivery is not yet supported.",
       "surface": "apple",
-      "id": "native.apple.a06159354eb7fa6f"
+      "id": "native.apple.8896386269ac4882"
     },
     {
       "kind": "ui-call",
@@ -14903,7 +14903,7 @@
       "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
       "source": "Header name",
       "surface": "apple",
-      "id": "native.apple.8211f29003986cb7"
+      "id": "native.apple.319594454c1ff701"
     },
     {
       "kind": "ui-call",
@@ -14911,7 +14911,7 @@
       "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
       "source": "Header value",
       "surface": "apple",
-      "id": "native.apple.429e3660a6be650d"
+      "id": "native.apple.7c4ff27cd7fa2c96"
     },
     {
       "kind": "ui-call",
@@ -14919,7 +14919,7 @@
       "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
       "source": "Add Header",
       "surface": "apple",
-      "id": "native.apple.5096f2465a6e89aa"
+      "id": "native.apple.a1368ad2d29a1152"
     },
     {
       "kind": "ui-modifier",
@@ -14927,7 +14927,7 @@
       "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
       "source": "Custom Headers",
       "surface": "apple",
-      "id": "native.apple.928311f3bf4593b7"
+      "id": "native.apple.19fba912c31023b5"
     },
     {
       "kind": "ui-named-argument",
@@ -14935,7 +14935,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Contacts",
       "surface": "apple",
-      "id": "native.apple.228b55b725147d23"
+      "id": "native.apple.4dac301c7e0c921c"
     },
     {
       "kind": "ui-named-argument",
@@ -14943,7 +14943,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Search and add contacts from the assistant.",
       "surface": "apple",
-      "id": "native.apple.b7aa02b8a3532616"
+      "id": "native.apple.01f362d70f6ddb4e"
     },
     {
       "kind": "ui-named-argument",
@@ -14951,7 +14951,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Photos",
       "surface": "apple",
-      "id": "native.apple.8341e1eb9d9a44a6"
+      "id": "native.apple.eda8d96e40bcc36a"
     },
     {
       "kind": "ui-named-argument",
@@ -14959,7 +14959,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Calendar (Add Events)",
       "surface": "apple",
-      "id": "native.apple.44e37360bfb1f0bd"
+      "id": "native.apple.df0159ff34744870"
     },
     {
       "kind": "ui-named-argument",
@@ -14967,7 +14967,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Add events with least privilege.",
       "surface": "apple",
-      "id": "native.apple.90ee11662883e606"
+      "id": "native.apple.c6db4240083c0435"
     },
     {
       "kind": "ui-named-argument",
@@ -14975,7 +14975,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Calendar (View Events)",
       "surface": "apple",
-      "id": "native.apple.fb04e1587f094b26"
+      "id": "native.apple.dc62e22f0b2726c5"
     },
     {
       "kind": "ui-named-argument",
@@ -14983,7 +14983,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "List and read calendar events.",
       "surface": "apple",
-      "id": "native.apple.756cd399529a94b0"
+      "id": "native.apple.650091bc632b3120"
     },
     {
       "kind": "ui-named-argument",
@@ -14991,7 +14991,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Reminders",
       "surface": "apple",
-      "id": "native.apple.574b1a6d76979e00"
+      "id": "native.apple.7a81d1f17d9d90c0"
     },
     {
       "kind": "ui-named-argument",
@@ -14999,7 +14999,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "List, add, and complete reminders.",
       "surface": "apple",
-      "id": "native.apple.57e576d4fad2a437"
+      "id": "native.apple.d6fd5e9f85b0e298"
     },
     {
       "kind": "ui-call",
@@ -15007,7 +15007,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Privacy & Access",
       "surface": "apple",
-      "id": "native.apple.b99b977127320607"
+      "id": "native.apple.bb572eab08269809"
     },
     {
       "kind": "conditional-branch",
@@ -15015,7 +15015,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Limited",
       "surface": "apple",
-      "id": "native.apple.94208c3068dae5b9"
+      "id": "native.apple.651cc89381dd69c0"
     },
     {
       "kind": "conditional-branch",
@@ -15023,7 +15023,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Read photos you select for the assistant.",
       "surface": "apple",
-      "id": "native.apple.eba3ae5d9442e1a5"
+      "id": "native.apple.ab998419291361da"
     },
     {
       "kind": "conditional-branch",
@@ -15031,7 +15031,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Read recent photos for the assistant.",
       "surface": "apple",
-      "id": "native.apple.d1d10d1140299230"
+      "id": "native.apple.e8c07f7c48d086f9"
     },
     {
       "kind": "conditional-branch",
@@ -15039,7 +15039,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Allowed",
       "surface": "apple",
-      "id": "native.apple.32aabe66f916a809"
+      "id": "native.apple.22b335bddf72e453"
     },
     {
       "kind": "conditional-branch",
@@ -15047,7 +15047,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Add-Only",
       "surface": "apple",
-      "id": "native.apple.e5a601c8fe47e9ed"
+      "id": "native.apple.d2f5de202e0426f8"
     },
     {
       "kind": "conditional-branch",
@@ -15055,7 +15055,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Not Set",
       "surface": "apple",
-      "id": "native.apple.aa6ff8becab99fdc"
+      "id": "native.apple.62f71c671e344fef"
     },
     {
       "kind": "conditional-branch",
@@ -15063,7 +15063,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Not Allowed",
       "surface": "apple",
-      "id": "native.apple.92223852c90e286d"
+      "id": "native.apple.1f17d59d38e1fe83"
     },
     {
       "kind": "conditional-branch",
@@ -15071,7 +15071,7 @@
       "path": "apps/ios/Sources/Settings/PrivacyAccessSectionView.swift",
       "source": "Unknown",
       "surface": "apple",
-      "id": "native.apple.03e2f7265119d263"
+      "id": "native.apple.6b95517f513d9b7c"
     },
     {
       "kind": "ui-call",
@@ -15079,7 +15079,7 @@
       "path": "apps/ios/Sources/Settings/VoiceWakeWordsSettingsView.swift",
       "source": "Wake word",
       "surface": "apple",
-      "id": "native.apple.7c949a356120988c"
+      "id": "native.apple.d9f9a74e25431256"
     },
     {
       "kind": "ui-call",
@@ -15087,7 +15087,7 @@
       "path": "apps/ios/Sources/Settings/VoiceWakeWordsSettingsView.swift",
       "source": "Add word",
       "surface": "apple",
-      "id": "native.apple.f0ef9f5a19da870e"
+      "id": "native.apple.afc6f7fed2ea65d6"
     },
     {
       "kind": "ui-call",
@@ -15095,7 +15095,7 @@
       "path": "apps/ios/Sources/Settings/VoiceWakeWordsSettingsView.swift",
       "source": "Reset defaults",
       "surface": "apple",
-      "id": "native.apple.f71632a9501aa18d"
+      "id": "native.apple.193005a2cdf1257f"
     },
     {
       "kind": "ui-call",
@@ -15103,7 +15103,7 @@
       "path": "apps/ios/Sources/Settings/VoiceWakeWordsSettingsView.swift",
       "source": "Wake Words",
       "surface": "apple",
-      "id": "native.apple.5ba5bed6fcb2cd09"
+      "id": "native.apple.c1314556e24659d1"
     },
     {
       "kind": "ui-call-concatenated",
@@ -15111,7 +15111,7 @@
       "path": "apps/ios/Sources/Settings/VoiceWakeWordsSettingsView.swift",
       "source": "OpenClaw reacts when any trigger appears in a transcription. Keep them short to avoid false positives.",
       "surface": "apple",
-      "id": "native.apple.e0eaa88f187271fc"
+      "id": "native.apple.4ebb39f445d7dbff"
     },
     {
       "kind": "ui-modifier",
@@ -15119,7 +15119,7 @@
       "path": "apps/ios/Sources/Status/VoiceWakeToast.swift",
       "source": "Voice Wake triggered",
       "surface": "apple",
-      "id": "native.apple.d0c5295e1ce2766d"
+      "id": "native.apple.994760420a194561"
     },
     {
       "kind": "ui-modifier",
@@ -15127,7 +15127,7 @@
       "path": "apps/ios/Sources/Terminal/TerminalHubScreen.swift",
       "source": "Terminal",
       "surface": "apple",
-      "id": "native.apple.1cbb41bbfba541d4"
+      "id": "native.apple.8ba33bf5712e3af2"
     },
     {
       "kind": "ui-modifier",
@@ -15135,7 +15135,7 @@
       "path": "apps/ios/Sources/Terminal/TerminalHubScreen.swift",
       "source": "Gateway settings",
       "surface": "apple",
-      "id": "native.apple.e7bccb36675c0dc3"
+      "id": "native.apple.2f67b32536f24e9d"
     },
     {
       "kind": "ui-call",
@@ -15143,7 +15143,7 @@
       "path": "apps/ios/Sources/Terminal/TerminalHubScreen.swift",
       "source": "Terminal needs a connected gateway",
       "surface": "apple",
-      "id": "native.apple.6af51557f2c86834"
+      "id": "native.apple.25e3befd890f1a73"
     },
     {
       "kind": "ui-call",
@@ -15151,7 +15151,7 @@
       "path": "apps/ios/Sources/Terminal/TerminalHubScreen.swift",
       "source": "Connect to your gateway to open a shell in the agent workspace.",
       "surface": "apple",
-      "id": "native.apple.ee381620916bdd04"
+      "id": "native.apple.197411362978db2d"
     },
     {
       "kind": "ui-call",
@@ -15159,7 +15159,7 @@
       "path": "apps/ios/Sources/Terminal/TerminalHubScreen.swift",
       "source": "Open Gateway Settings",
       "surface": "apple",
-      "id": "native.apple.910f54df5b7ea2cb"
+      "id": "native.apple.0a687ce373931085"
     },
     {
       "kind": "conditional-branch",
@@ -15175,7 +15175,7 @@
       "path": "apps/ios/Sources/Voice/TalkGatewayPermissionState.swift",
       "source": "Not checked",
       "surface": "apple",
-      "id": "native.apple.59ca4f429f6f5c96"
+      "id": "native.apple.3b21081fb5ce84ba"
     },
     {
       "kind": "conditional-branch",
@@ -15183,7 +15183,7 @@
       "path": "apps/ios/Sources/Voice/TalkGatewayPermissionState.swift",
       "source": "Ready",
       "surface": "apple",
-      "id": "native.apple.18050bc2867c5994"
+      "id": "native.apple.1e2a98b4f50dbfe6"
     },
     {
       "kind": "conditional-branch",
@@ -15191,7 +15191,7 @@
       "path": "apps/ios/Sources/Voice/TalkGatewayPermissionState.swift",
       "source": "Missing \\(scope)",
       "surface": "apple",
-      "id": "native.apple.d766aa08919787b4"
+      "id": "native.apple.1b7c66d315581f73"
     },
     {
       "kind": "conditional-branch",
@@ -15199,7 +15199,7 @@
       "path": "apps/ios/Sources/Voice/TalkGatewayPermissionState.swift",
       "source": "Requesting approval",
       "surface": "apple",
-      "id": "native.apple.fd1bb0c5e7d50665"
+      "id": "native.apple.08acd077aaacb96f"
     },
     {
       "kind": "conditional-branch",
@@ -15207,7 +15207,7 @@
       "path": "apps/ios/Sources/Voice/TalkGatewayPermissionState.swift",
       "source": "Approval requested",
       "surface": "apple",
-      "id": "native.apple.d26d3cadd2e08dbe"
+      "id": "native.apple.f9bc177bff07a6d4"
     },
     {
       "kind": "conditional-branch",
@@ -15215,7 +15215,7 @@
       "path": "apps/ios/Sources/Voice/TalkGatewayPermissionState.swift",
       "source": "Request failed",
       "surface": "apple",
-      "id": "native.apple.c9ea3d5d08bf598b"
+      "id": "native.apple.9d92e1e15bf191d9"
     },
     {
       "kind": "conditional-branch",
@@ -15223,7 +15223,7 @@
       "path": "apps/ios/Sources/Voice/TalkGatewayPermissionState.swift",
       "source": "API key missing",
       "surface": "apple",
-      "id": "native.apple.f235a9d4adb4940f"
+      "id": "native.apple.8512935c96c4a2e2"
     },
     {
       "kind": "conditional-branch",
@@ -15231,7 +15231,7 @@
       "path": "apps/ios/Sources/Voice/TalkGatewayPermissionState.swift",
       "source": "Load failed",
       "surface": "apple",
-      "id": "native.apple.cd6fbd46d3f737e1"
+      "id": "native.apple.0a0e11e7aefde770"
     },
     {
       "kind": "conditional-branch",
@@ -15255,7 +15255,7 @@
       "path": "apps/ios/Sources/Voice/TalkModeGatewayConfig.swift",
       "source": "Gateway Default",
       "surface": "apple",
-      "id": "native.apple.e5f40026770d4fba"
+      "id": "native.apple.8b95eb816538a735"
     },
     {
       "kind": "conditional-branch",
@@ -15263,7 +15263,7 @@
       "path": "apps/ios/Sources/Voice/TalkModeGatewayConfig.swift",
       "source": "ElevenLabs",
       "surface": "apple",
-      "id": "native.apple.5dc98e7ec544c522"
+      "id": "native.apple.12f6c5d01ca2cc0e"
     },
     {
       "kind": "conditional-branch",
@@ -15271,7 +15271,7 @@
       "path": "apps/ios/Sources/Voice/TalkModeGatewayConfig.swift",
       "source": "Realtime-2 (OpenAI)",
       "surface": "apple",
-      "id": "native.apple.f1a267ebaff4cf7b"
+      "id": "native.apple.61beb986ac24f37b"
     },
     {
       "kind": "conditional-branch",
@@ -15279,7 +15279,7 @@
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Offline",
       "surface": "apple",
-      "id": "native.apple.cdf5ea9b1001d6c5"
+      "id": "native.apple.c09f4e3bbef8177a"
     },
     {
       "kind": "conditional-branch",
@@ -15287,7 +15287,7 @@
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Ready",
       "surface": "apple",
-      "id": "native.apple.7d021b4cdcd3ee81"
+      "id": "native.apple.5839cdb826c12c71"
     },
     {
       "kind": "conditional-branch",
@@ -15295,7 +15295,7 @@
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Listening",
       "surface": "apple",
-      "id": "native.apple.76b5706e02403f25"
+      "id": "native.apple.794c5c98f3a4238d"
     },
     {
       "kind": "conditional-branch",
@@ -15303,7 +15303,7 @@
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speech error: \\(msg)",
       "surface": "apple",
-      "id": "native.apple.29b061ea9ee317c4"
+      "id": "native.apple.0b35fc3b0b221098"
     },
     {
       "kind": "conditional-branch",
@@ -15311,7 +15311,7 @@
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Aborted",
       "surface": "apple",
-      "id": "native.apple.e428ad2976011640"
+      "id": "native.apple.96c7457cafa7dd47"
     },
     {
       "kind": "conditional-branch",
@@ -15319,7 +15319,7 @@
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Chat error",
       "surface": "apple",
-      "id": "native.apple.1caf5dda2d79880b"
+      "id": "native.apple.7c027ae095940485"
     },
     {
       "kind": "conditional-branch",
@@ -15335,7 +15335,7 @@
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Native",
       "surface": "apple",
-      "id": "native.apple.b52d0d9dee6cc8e9"
+      "id": "native.apple.c48dc51b49089432"
     },
     {
       "kind": "conditional-branch",
@@ -15343,7 +15343,7 @@
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Native WebRTC",
       "surface": "apple",
-      "id": "native.apple.34ab07cdf4ffe1ef"
+      "id": "native.apple.b0eb8a8cad908166"
     },
     {
       "kind": "ui-call",
@@ -15351,7 +15351,7 @@
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Request ID",
       "surface": "apple",
-      "id": "native.apple.64602baa14e2bcfd"
+      "id": "native.apple.0189269b6a863dc2"
     },
     {
       "kind": "ui-call",
@@ -15359,7 +15359,7 @@
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Sending...",
       "surface": "apple",
-      "id": "native.apple.6abcf981b74965dc"
+      "id": "native.apple.f9d69f27f9d7f4de"
     },
     {
       "kind": "ui-call",
@@ -15367,7 +15367,7 @@
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Retry",
       "surface": "apple",
-      "id": "native.apple.5902a95299b5174b"
+      "id": "native.apple.0c5336129f70faed"
     },
     {
       "kind": "conditional-branch",
@@ -15375,7 +15375,7 @@
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Sending approval request",
       "surface": "apple",
-      "id": "native.apple.1f30a51f2efde8ca"
+      "id": "native.apple.7b23f0a89d3ad411"
     },
     {
       "kind": "conditional-branch",
@@ -15383,7 +15383,7 @@
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Approval sent",
       "surface": "apple",
-      "id": "native.apple.1a0030c6f298824a"
+      "id": "native.apple.55db7317a2542e51"
     },
     {
       "kind": "conditional-branch",
@@ -15391,7 +15391,7 @@
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Could not request approval",
       "surface": "apple",
-      "id": "native.apple.9772d3aa1e771b30"
+      "id": "native.apple.06330f62ab254a0e"
     },
     {
       "kind": "conditional-branch",
@@ -15399,7 +15399,7 @@
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Enable Talk",
       "surface": "apple",
-      "id": "native.apple.95a81f83a644d8ec"
+      "id": "native.apple.6580d3d1cdda682d"
     },
     {
       "kind": "conditional-branch",
@@ -15407,7 +15407,7 @@
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Sending a new pairing request to your gateway...",
       "surface": "apple",
-      "id": "native.apple.10123e7cd19ed9fc"
+      "id": "native.apple.abbfc1ba85a230b4"
     },
     {
       "kind": "conditional-branch",
@@ -15415,7 +15415,7 @@
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Approve this request on your gateway. Talk will start automatically when approval lands.",
       "surface": "apple",
-      "id": "native.apple.e37dba5567f0691e"
+      "id": "native.apple.2880deb53ea2fd86"
     },
     {
       "kind": "conditional-branch",
@@ -15431,7 +15431,7 @@
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Request Again",
       "surface": "apple",
-      "id": "native.apple.0cc36971509f7d3b"
+      "id": "native.apple.88b0a2e2986fcebf"
     },
     {
       "kind": "conditional-branch",
@@ -15439,7 +15439,7 @@
       "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
       "source": "Send Approval Request",
       "surface": "apple",
-      "id": "native.apple.6f8a589d1a3dd2c1"
+      "id": "native.apple.5a3faae3472b4b86"
     },
     {
       "kind": "conditional-branch",
@@ -15447,7 +15447,7 @@
       "path": "apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift",
       "source": "Asking OpenClaw",
       "surface": "apple",
-      "id": "native.apple.d05a2230509ea290"
+      "id": "native.apple.1065cfe92d7c1eb6"
     },
     {
       "kind": "conditional-branch",
@@ -15455,7 +15455,7 @@
       "path": "apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift",
       "source": "Updating OpenClaw",
       "surface": "apple",
-      "id": "native.apple.e16d8f941f841046"
+      "id": "native.apple.d2db26b3bb266491"
     },
     {
       "kind": "conditional-branch",
@@ -15463,7 +15463,7 @@
       "path": "apps/ios/Sources/Voice/VoiceWakeManager.swift",
       "source": "Off",
       "surface": "apple",
-      "id": "native.apple.44e57b0ab0a141a4"
+      "id": "native.apple.b6bc54876f20104f"
     },
     {
       "kind": "conditional-branch",
@@ -15471,7 +15471,7 @@
       "path": "apps/ios/Sources/Voice/VoiceWakeManager.swift",
       "source": "Paused",
       "surface": "apple",
-      "id": "native.apple.b1c79b0219df9811"
+      "id": "native.apple.5590d661cdc81fbf"
     },
     {
       "kind": "plist-string",
@@ -15479,7 +15479,7 @@
       "path": "apps/ios/WatchApp/Info.plist",
       "source": "OpenClaw connects this Apple Watch directly to your Gateway on trusted local networks.",
       "surface": "apple",
-      "id": "native.apple.646968ab814b22e8"
+      "id": "native.apple.12a4a51d251f65c0"
     },
     {
       "kind": "conditional-branch",
@@ -15519,7 +15519,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchDirectNode.swift",
       "source": "Ready to connect",
       "surface": "apple",
-      "id": "native.apple.b89a692d71bea552"
+      "id": "native.apple.d4c7af4a7bfeb382"
     },
     {
       "kind": "conditional-branch",
@@ -15527,7 +15527,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchDirectNode.swift",
       "source": "Direct connection is off",
       "surface": "apple",
-      "id": "native.apple.f3ab5c3a788b1867"
+      "id": "native.apple.01062f110734602f"
     },
     {
       "kind": "conditional-branch",
@@ -15535,7 +15535,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchDirectNode.swift",
       "source": "Use iPhone Settings to enable direct connection.",
       "surface": "apple",
-      "id": "native.apple.a363367c5a190289"
+      "id": "native.apple.0e0763442f318e2f"
     },
     {
       "kind": "conditional-branch",
@@ -15567,7 +15567,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Talk to Claw",
       "surface": "apple",
-      "id": "native.apple.ea2178198f6c58d3"
+      "id": "native.apple.732051c3e897a9f1"
     },
     {
       "kind": "ui-named-argument",
@@ -15575,7 +15575,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "What needs you",
       "surface": "apple",
-      "id": "native.apple.530a2a113d5ea6fb"
+      "id": "native.apple.73d98baeb297e2fc"
     },
     {
       "kind": "ui-named-argument",
@@ -15583,7 +15583,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Caught up",
       "surface": "apple",
-      "id": "native.apple.ff436bd6a6461e21"
+      "id": "native.apple.c10e2d4eaebd38e8"
     },
     {
       "kind": "conditional-branch",
@@ -15591,7 +15591,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "No chats or approvals need you",
       "surface": "apple",
-      "id": "native.apple.1d4017cae81c01dd"
+      "id": "native.apple.477c0403c6734d0a"
     },
     {
       "kind": "ui-named-argument",
@@ -15599,7 +15599,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Continue on iPhone",
       "surface": "apple",
-      "id": "native.apple.bb76fa1eb305acb2"
+      "id": "native.apple.6a2c7f809c734c45"
     },
     {
       "kind": "ui-named-argument",
@@ -15607,7 +15607,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Chat",
       "surface": "apple",
-      "id": "native.apple.1da9d8f97ddb7b17"
+      "id": "native.apple.a974845eb4fcc692"
     },
     {
       "kind": "conditional-branch",
@@ -15615,7 +15615,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Nothing waiting",
       "surface": "apple",
-      "id": "native.apple.e66a8bd97c13c56c"
+      "id": "native.apple.dc532fb77a310766"
     },
     {
       "kind": "ui-named-argument",
@@ -15623,7 +15623,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Approval needed",
       "surface": "apple",
-      "id": "native.apple.1516f8433fd14dd8"
+      "id": "native.apple.d740d67943737c80"
     },
     {
       "kind": "ui-modifier",
@@ -15671,7 +15671,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Review again",
       "surface": "apple",
-      "id": "native.apple.dfc4aba2a4c89fda"
+      "id": "native.apple.373973b577f97d63"
     },
     {
       "kind": "ui-named-argument",
@@ -15679,7 +15679,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Open all approvals",
       "surface": "apple",
-      "id": "native.apple.ae2140c5d6eb326a"
+      "id": "native.apple.6fc58b4047340605"
     },
     {
       "kind": "conditional-branch",
@@ -15687,7 +15687,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Direct Gateway",
       "surface": "apple",
-      "id": "native.apple.d2411ef9ed767185"
+      "id": "native.apple.577dd5b3738b6aec"
     },
     {
       "kind": "conditional-branch",
@@ -15695,7 +15695,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Watch node online",
       "surface": "apple",
-      "id": "native.apple.6835fa5b40e65443"
+      "id": "native.apple.b5ac093277f18109"
     },
     {
       "kind": "conditional-branch",
@@ -15703,7 +15703,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Direct",
       "surface": "apple",
-      "id": "native.apple.86219fbb9685d9c2"
+      "id": "native.apple.82fa10a36cbd5773"
     },
     {
       "kind": "conditional-branch",
@@ -15711,7 +15711,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Setup",
       "surface": "apple",
-      "id": "native.apple.c89dfb83444e6662"
+      "id": "native.apple.e0f952b8832b1ca4"
     },
     {
       "kind": "conditional-branch",
@@ -15719,7 +15719,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Uses Wi-Fi or cellular while OpenClaw is active",
       "surface": "apple",
-      "id": "native.apple.709a8396352de098"
+      "id": "native.apple.c7d87356e6cdb374"
     },
     {
       "kind": "conditional-branch",
@@ -15727,7 +15727,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Open iPhone Settings → Apple Watch",
       "surface": "apple",
-      "id": "native.apple.fcc3c10609d70bd0"
+      "id": "native.apple.08583448d9b2455e"
     },
     {
       "kind": "conditional-branch",
@@ -15735,7 +15735,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Offline",
       "surface": "apple",
-      "id": "native.apple.a956cb124e12ad8e"
+      "id": "native.apple.f748dad8f2ce22ae"
     },
     {
       "kind": "conditional-branch",
@@ -15743,7 +15743,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Online",
       "surface": "apple",
-      "id": "native.apple.ad6d8fa55d4850ff"
+      "id": "native.apple.60cdcd03d8b51965"
     },
     {
       "kind": "ui-named-argument-multiline",
@@ -15751,7 +15751,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Direct mode supports device info, status, and notifications. Chat, Talk, and approvals still use the iPhone.",
       "surface": "apple",
-      "id": "native.apple.de3c38f6c39cbc63"
+      "id": "native.apple.088f07637cc141c9"
     },
     {
       "kind": "ui-call",
@@ -15759,7 +15759,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Direct connection",
       "surface": "apple",
-      "id": "native.apple.4af340e468b815ec"
+      "id": "native.apple.d7000ec82e411988"
     },
     {
       "kind": "ui-named-argument",
@@ -15767,7 +15767,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Forget direct setup",
       "surface": "apple",
-      "id": "native.apple.11f8c28ee110627c"
+      "id": "native.apple.72270e305e05cf02"
     },
     {
       "kind": "ui-named-argument",
@@ -15775,7 +15775,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "The iPhone securely sends a one-time setup code. Existing relay features stay available.",
       "surface": "apple",
-      "id": "native.apple.9716a20353b33e69"
+      "id": "native.apple.aef0e6d8d3fa0903"
     },
     {
       "kind": "conditional-branch",
@@ -15783,7 +15783,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "\\(self.chatCount)",
       "surface": "apple",
-      "id": "native.apple.1efbd6b721049855"
+      "id": "native.apple.00d2c14f9f635100"
     },
     {
       "kind": "conditional-branch",
@@ -15791,7 +15791,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "\\(self.approvalCount)",
       "surface": "apple",
-      "id": "native.apple.2a25bbc529b4249b"
+      "id": "native.apple.c3f1a9e79f6e0e97"
     },
     {
       "kind": "conditional-branch",
@@ -15799,7 +15799,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "AI agent online",
       "surface": "apple",
-      "id": "native.apple.46c94f3d910a276f"
+      "id": "native.apple.eb8d87882ee9d932"
     },
     {
       "kind": "conditional-branch",
@@ -15807,7 +15807,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Reconnect on iPhone",
       "surface": "apple",
-      "id": "native.apple.8b053b41b060e0f9"
+      "id": "native.apple.1fed99e43ac07133"
     },
     {
       "kind": "conditional-branch",
@@ -15815,7 +15815,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Pairing",
       "surface": "apple",
-      "id": "native.apple.d13292625f1a084d"
+      "id": "native.apple.a240e731ca37dbdd"
     },
     {
       "kind": "conditional-branch",
@@ -15823,7 +15823,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Running",
       "surface": "apple",
-      "id": "native.apple.e24ef2f9292edf69"
+      "id": "native.apple.381d10256d49d0e0"
     },
     {
       "kind": "conditional-branch",
@@ -15831,7 +15831,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Ready for quick actions",
       "surface": "apple",
-      "id": "native.apple.302b505eea188676"
+      "id": "native.apple.643a9402efef3924"
     },
     {
       "kind": "conditional-branch",
@@ -15839,7 +15839,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Waiting for iPhone sync",
       "surface": "apple",
-      "id": "native.apple.08f531eebdfc9257"
+      "id": "native.apple.e927c0240dd8ab4b"
     },
     {
       "kind": "conditional-branch",
@@ -15847,7 +15847,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "1 approval waiting",
       "surface": "apple",
-      "id": "native.apple.516ff7d3edd7acfd"
+      "id": "native.apple.6a607ff2270f7234"
     },
     {
       "kind": "conditional-branch",
@@ -15855,7 +15855,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "\\(self.approvalCount) approvals",
       "surface": "apple",
-      "id": "native.apple.5942c98ade8335a5"
+      "id": "native.apple.046272dd8fbd45cd"
     },
     {
       "kind": "conditional-branch",
@@ -15863,7 +15863,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Decide from watch",
       "surface": "apple",
-      "id": "native.apple.cd0c842b9918ff9a"
+      "id": "native.apple.c938aa514b77854a"
     },
     {
       "kind": "conditional-branch",
@@ -15871,7 +15871,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "No approvals",
       "surface": "apple",
-      "id": "native.apple.d035f467078f6569"
+      "id": "native.apple.0201a3557b1a8a4a"
     },
     {
       "kind": "conditional-branch",
@@ -15879,7 +15879,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "1 recent message",
       "surface": "apple",
-      "id": "native.apple.3e73492ae085f697"
+      "id": "native.apple.84674ce9751faffd"
     },
     {
       "kind": "conditional-branch",
@@ -15887,7 +15887,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "\\(self.chatCount) recent messages",
       "surface": "apple",
-      "id": "native.apple.ab05591e87f42cda"
+      "id": "native.apple.1495106ee09cc268"
     },
     {
       "kind": "conditional-branch",
@@ -15895,7 +15895,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "No messages synced",
       "surface": "apple",
-      "id": "native.apple.d7037443e402c9c2"
+      "id": "native.apple.2b7032e200b1d495"
     },
     {
       "kind": "conditional-branch",
@@ -15903,7 +15903,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Synced",
       "surface": "apple",
-      "id": "native.apple.18a4876f83b0bebc"
+      "id": "native.apple.5e32bb776eec9d39"
     },
     {
       "kind": "conditional-branch",
@@ -15911,7 +15911,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Waiting for iPhone",
       "surface": "apple",
-      "id": "native.apple.ebb1c452cd5139f8"
+      "id": "native.apple.e3a9d9067b1ccf6a"
     },
     {
       "kind": "ui-named-argument",
@@ -15919,7 +15919,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Inbox",
       "surface": "apple",
-      "id": "native.apple.9a5cc2d5d1a0d111"
+      "id": "native.apple.fadaa0ca97ba0c43"
     },
     {
       "kind": "ui-named-argument",
@@ -15927,7 +15927,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "OpenClaw",
       "surface": "apple",
-      "id": "native.apple.e54d954151312621"
+      "id": "native.apple.3fdc651e507de84b"
     },
     {
       "kind": "ui-call",
@@ -15959,7 +15959,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "You",
       "surface": "apple",
-      "id": "native.apple.7e75a9f9ccac6339"
+      "id": "native.apple.337c2164038d1a5a"
     },
     {
       "kind": "conditional-branch",
@@ -15967,7 +15967,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "System",
       "surface": "apple",
-      "id": "native.apple.6bdcf6e7dcc633d9"
+      "id": "native.apple.a8cfe6cb5bc33c21"
     },
     {
       "kind": "ui-named-argument",
@@ -15975,7 +15975,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.ae726bf4a1a46259"
+      "id": "native.apple.c1de056da9ee1b27"
     },
     {
       "kind": "ui-call",
@@ -15983,7 +15983,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "No chat synced",
       "surface": "apple",
-      "id": "native.apple.4bfedcfebb4ac336"
+      "id": "native.apple.5f277949dc42b1c3"
     },
     {
       "kind": "ui-call",
@@ -15991,7 +15991,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Tap the message pill below to start from your watch.",
       "surface": "apple",
-      "id": "native.apple.7363b130792ae2de"
+      "id": "native.apple.9119276e0f1b473d"
     },
     {
       "kind": "ui-call",
@@ -15999,7 +15999,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Message OpenClaw",
       "surface": "apple",
-      "id": "native.apple.068d84c26a524222"
+      "id": "native.apple.b816e4b9e492ae6c"
     },
     {
       "kind": "ui-named-argument",
@@ -16007,7 +16007,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Approvals",
       "surface": "apple",
-      "id": "native.apple.d07b6a8fd99ce03d"
+      "id": "native.apple.f3ccbf04d80cf021"
     },
     {
       "kind": "ui-named-argument",
@@ -16015,7 +16015,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Clear",
       "surface": "apple",
-      "id": "native.apple.095c77bdc7f04529"
+      "id": "native.apple.fde372bcd0305149"
     },
     {
       "kind": "ui-named-argument",
@@ -16023,7 +16023,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "No approvals waiting",
       "surface": "apple",
-      "id": "native.apple.170b8f490c219f8a"
+      "id": "native.apple.30184946721b66e9"
     },
     {
       "kind": "ui-named-argument",
@@ -16031,7 +16031,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Approval",
       "surface": "apple",
-      "id": "native.apple.af4c704413af1944"
+      "id": "native.apple.ef3ff87537a32741"
     },
     {
       "kind": "conditional-branch",
@@ -16071,7 +16071,7 @@
       "path": "apps/ios/WatchApp/Sources/WatchInboxView.swift",
       "source": "Deny",
       "surface": "apple",
-      "id": "native.apple.5b9b5f18b19cd65a"
+      "id": "native.apple.096fb24013ac5455"
     },
     {
       "kind": "conditional-branch",
@@ -16087,7 +16087,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "OpenClaw",
       "surface": "apple",
-      "id": "native.apple.4d3f983a1ea909ee"
+      "id": "native.apple.5ac0c79487a492b4"
     },
     {
       "kind": "ui-call",
@@ -16095,7 +16095,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Menu bar companion for notifications, screenshots, and privileged agent actions.",
       "surface": "apple",
-      "id": "native.apple.629596bfcfcc8b7e"
+      "id": "native.apple.95b5730738a28d71"
     },
     {
       "kind": "ui-named-argument",
@@ -16103,7 +16103,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Website",
       "surface": "apple",
-      "id": "native.apple.de49b5a079d1f073"
+      "id": "native.apple.63e488db74990ce5"
     },
     {
       "kind": "ui-named-argument",
@@ -16111,7 +16111,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Docs",
       "surface": "apple",
-      "id": "native.apple.6eb3516132d8b8d0"
+      "id": "native.apple.a6ce39368a3dcba9"
     },
     {
       "kind": "ui-named-argument",
@@ -16119,7 +16119,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "GitHub",
       "surface": "apple",
-      "id": "native.apple.b99853fc93521b66"
+      "id": "native.apple.953dd3deb91be186"
     },
     {
       "kind": "ui-named-argument",
@@ -16127,7 +16127,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Discord",
       "surface": "apple",
-      "id": "native.apple.55eb5a5afc7ed0b6"
+      "id": "native.apple.3f2971f0141e1cf6"
     },
     {
       "kind": "ui-call",
@@ -16135,7 +16135,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Check for updates automatically",
       "surface": "apple",
-      "id": "native.apple.4614b81fb158704d"
+      "id": "native.apple.32ce87cf5adca95c"
     },
     {
       "kind": "ui-call",
@@ -16143,7 +16143,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Check for Updates…",
       "surface": "apple",
-      "id": "native.apple.86d66ab7a1cdd785"
+      "id": "native.apple.5e0de63984ca40c9"
     },
     {
       "kind": "ui-call",
@@ -16151,7 +16151,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Updates unavailable in this build.",
       "surface": "apple",
-      "id": "native.apple.96d32f2f282caf28"
+      "id": "native.apple.ddec1d4e5e5b43cb"
     },
     {
       "kind": "ui-call",
@@ -16159,7 +16159,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "© 2026 OpenClaw Foundation — MIT License.",
       "surface": "apple",
-      "id": "native.apple.44b8ba7768ea2e7b"
+      "id": "native.apple.4ec07761308f7f50"
     },
     {
       "kind": "ui-call",
@@ -16167,7 +16167,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Copy full commit hash",
       "surface": "apple",
-      "id": "native.apple.2f1ed8af4e606d51"
+      "id": "native.apple.37661ff1af405580"
     },
     {
       "kind": "ui-call",
@@ -16175,7 +16175,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Copy build info",
       "surface": "apple",
-      "id": "native.apple.be3b629054aea291"
+      "id": "native.apple.2916df231993897d"
     },
     {
       "kind": "ui-call",
@@ -16183,7 +16183,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Copy Commit",
       "surface": "apple",
-      "id": "native.apple.d13d41e610c7ba3d"
+      "id": "native.apple.f870085ee74e9885"
     },
     {
       "kind": "ui-call",
@@ -16191,7 +16191,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Copy Build Info",
       "surface": "apple",
-      "id": "native.apple.8a09595137a100f3"
+      "id": "native.apple.be5af46a63f9d1da"
     },
     {
       "kind": "ui-call",
@@ -16199,7 +16199,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Unavailable",
       "surface": "apple",
-      "id": "native.apple.dfd7e13a7310c757"
+      "id": "native.apple.ddd4228d93680320"
     },
     {
       "kind": "ui-call",
@@ -16207,7 +16207,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Version \\(version), commit \\(commit), built \\(built), timestamp \\(timestamp)",
       "surface": "apple",
-      "id": "native.apple.5c99acde65040d0a"
+      "id": "native.apple.0e7c932e0d8fb288"
     },
     {
       "kind": "ui-call",
@@ -16215,7 +16215,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Version \\(version), commit \\(commit), build date unavailable",
       "surface": "apple",
-      "id": "native.apple.ee173a469b20fe4c"
+      "id": "native.apple.d4ef93e8ebca2d55"
     },
     {
       "kind": "ui-call",
@@ -16223,7 +16223,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Version \\(version), commit unavailable, built \\(built), timestamp \\(timestamp)",
       "surface": "apple",
-      "id": "native.apple.9380d0a152f7a3b7"
+      "id": "native.apple.f67aac55a340fda0"
     },
     {
       "kind": "ui-call",
@@ -16231,7 +16231,7 @@
       "path": "apps/macos/Sources/OpenClaw/AboutSettings.swift",
       "source": "Version \\(version), commit unavailable, build date unavailable",
       "surface": "apple",
-      "id": "native.apple.483fcc32d8f0044b"
+      "id": "native.apple.76472e074114886c"
     },
     {
       "kind": "ui-call",
@@ -16239,7 +16239,7 @@
       "path": "apps/macos/Sources/OpenClaw/AgentEventsWindow.swift",
       "source": "Agent Events",
       "surface": "apple",
-      "id": "native.apple.da7667b4cfb4e60f"
+      "id": "native.apple.c6148a145aa87e36"
     },
     {
       "kind": "ui-call",
@@ -16247,7 +16247,7 @@
       "path": "apps/macos/Sources/OpenClaw/AgentEventsWindow.swift",
       "source": "Clear",
       "surface": "apple",
-      "id": "native.apple.52d1518b0987d6af"
+      "id": "native.apple.c8d2fe5403e9df00"
     },
     {
       "kind": "conditional-branch",
@@ -16255,7 +16255,7 @@
       "path": "apps/macos/Sources/OpenClaw/AppState.swift",
       "source": "\\(user)@\\(host)",
       "surface": "apple",
-      "id": "native.apple.dc69311b669398ed"
+      "id": "native.apple.9cd2ced909f0952d"
     },
     {
       "kind": "conditional-branch",
@@ -16263,7 +16263,7 @@
       "path": "apps/macos/Sources/OpenClaw/AppState.swift",
       "source": "\\(user)@\\(host):\\(port)",
       "surface": "apple",
-      "id": "native.apple.acb2c7bacc8a9416"
+      "id": "native.apple.69b64bb81b900cc4"
     },
     {
       "kind": "ui-call",
@@ -16519,7 +16519,7 @@
       "path": "apps/macos/Sources/OpenClaw/CLIInstaller.swift",
       "source": "OpenClaw Gateway \\(version) is ready.",
       "surface": "apple",
-      "id": "native.apple.d56c7e42cf2c4813"
+      "id": "native.apple.cfc2509b8bbcf1d7"
     },
     {
       "kind": "conditional-branch",
@@ -16527,7 +16527,7 @@
       "path": "apps/macos/Sources/OpenClaw/CLIInstaller.swift",
       "source": "OpenClaw Gateway is not installed yet.",
       "surface": "apple",
-      "id": "native.apple.75d3c619b85985dd"
+      "id": "native.apple.9b767e46895714f9"
     },
     {
       "kind": "conditional-branch",
@@ -16535,7 +16535,7 @@
       "path": "apps/macos/Sources/OpenClaw/CLIInstaller.swift",
       "source": "The OpenClaw Gateway could not be verified. Setup will repair it.",
       "surface": "apple",
-      "id": "native.apple.ecb715a65dcb04b3"
+      "id": "native.apple.b4dc58a1b294e140"
     },
     {
       "kind": "conditional-branch",
@@ -16543,7 +16543,7 @@
       "path": "apps/macos/Sources/OpenClaw/CLIInstaller.swift",
       "source": "Gateway \\(found) does not match app \\(required). Setup will update it.",
       "surface": "apple",
-      "id": "native.apple.93f35303954266b9"
+      "id": "native.apple.4088056ae7b0f3b4"
     },
     {
       "kind": "conditional-branch",
@@ -16551,7 +16551,7 @@
       "path": "apps/macos/Sources/OpenClaw/CameraCaptureService.swift",
       "source": "Camera",
       "surface": "apple",
-      "id": "native.apple.d1e5eeb96a2882ee"
+      "id": "native.apple.6f14c557e2573526"
     },
     {
       "kind": "conditional-branch",
@@ -16559,7 +16559,7 @@
       "path": "apps/macos/Sources/OpenClaw/CameraCaptureService.swift",
       "source": "Microphone",
       "surface": "apple",
-      "id": "native.apple.badeaf60e96929d3"
+      "id": "native.apple.40d3846b9b907a73"
     },
     {
       "kind": "conditional-branch",
@@ -16575,7 +16575,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Enabled",
       "surface": "apple",
-      "id": "native.apple.11f2d12dfe82dabb"
+      "id": "native.apple.90dacdcac6e6bd80"
     },
     {
       "kind": "ui-call",
@@ -16583,7 +16583,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Unsupported field type.",
       "surface": "apple",
-      "id": "native.apple.68c9b4ca6b4e34a6"
+      "id": "native.apple.198eae468f234acb"
     },
     {
       "kind": "ui-call",
@@ -16591,7 +16591,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "No quick settings for this channel.",
       "surface": "apple",
-      "id": "native.apple.5b8318daab6c011a"
+      "id": "native.apple.dbc78800d9f382b9"
     },
     {
       "kind": "ui-call",
@@ -16599,7 +16599,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Use Config for account, guild, action, and policy details.",
       "surface": "apple",
-      "id": "native.apple.da9ed95a558aa5ff"
+      "id": "native.apple.cbf7ef1afeae9ff8"
     },
     {
       "kind": "ui-call",
@@ -16607,7 +16607,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Select…",
       "surface": "apple",
-      "id": "native.apple.02806dc0ed3038fb"
+      "id": "native.apple.71dc5674a2bda6d1"
     },
     {
       "kind": "ui-call",
@@ -16615,7 +16615,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Extra entries",
       "surface": "apple",
-      "id": "native.apple.75b5255c0a940da0"
+      "id": "native.apple.ce17aea717f97f4d"
     },
     {
       "kind": "ui-call",
@@ -16623,7 +16623,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "No extra entries yet.",
       "surface": "apple",
-      "id": "native.apple.bb804e0a6f1374e8"
+      "id": "native.apple.7b5de9206729e420"
     },
     {
       "kind": "ui-call",
@@ -16631,7 +16631,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Key",
       "surface": "apple",
-      "id": "native.apple.4c33cb6e37da5de2"
+      "id": "native.apple.017ff7fa7b3e26c4"
     },
     {
       "kind": "ui-call",
@@ -16639,7 +16639,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Remove",
       "surface": "apple",
-      "id": "native.apple.7bf77a51527eb799"
+      "id": "native.apple.18b74467bb3a710d"
     },
     {
       "kind": "ui-call",
@@ -16647,7 +16647,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Add",
       "surface": "apple",
-      "id": "native.apple.b240832d93a650c3"
+      "id": "native.apple.b237bc0cf8595b6d"
     },
     {
       "kind": "ui-named-argument",
@@ -16655,7 +16655,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Loading channel settings",
       "surface": "apple",
-      "id": "native.apple.8d3a4f411b2d157c"
+      "id": "native.apple.cbe5124df0a065b4"
     },
     {
       "kind": "ui-call",
@@ -16663,7 +16663,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Configuration",
       "surface": "apple",
-      "id": "native.apple.066d89a44ba77325"
+      "id": "native.apple.468ae6c91ff752d8"
     },
     {
       "kind": "ui-named-argument",
@@ -16671,7 +16671,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Schema unavailable",
       "surface": "apple",
-      "id": "native.apple.0e113b32a05c554d"
+      "id": "native.apple.18ae184a7dad6464"
     },
     {
       "kind": "ui-named-argument",
@@ -16679,7 +16679,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "OpenClaw could not load editable settings for this channel.",
       "surface": "apple",
-      "id": "native.apple.9a58a96b30b47d0f"
+      "id": "native.apple.81435e60c0b78093"
     },
     {
       "kind": "ui-call",
@@ -16687,7 +16687,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+ChannelSections.swift",
       "source": "Logout",
       "surface": "apple",
-      "id": "native.apple.2e43bd1988926223"
+      "id": "native.apple.f74dfc887ee4f936"
     },
     {
       "kind": "ui-call",
@@ -16695,7 +16695,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+ChannelSections.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.3c1087f079d77ddb"
+      "id": "native.apple.c6587031bbc3e4e0"
     },
     {
       "kind": "ui-call",
@@ -16703,7 +16703,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+ChannelSections.swift",
       "source": "Linking",
       "surface": "apple",
-      "id": "native.apple.681a46d16196f1be"
+      "id": "native.apple.af173734eb7ad231"
     },
     {
       "kind": "ui-call",
@@ -16711,7 +16711,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+ChannelSections.swift",
       "source": "Show QR",
       "surface": "apple",
-      "id": "native.apple.ee76aa477b01f407"
+      "id": "native.apple.b1d834b36062043d"
     },
     {
       "kind": "ui-call",
@@ -16719,7 +16719,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+ChannelSections.swift",
       "source": "Relink",
       "surface": "apple",
-      "id": "native.apple.e5c723e9881c1d05"
+      "id": "native.apple.eecd32848403c3c4"
     },
     {
       "kind": "ui-call",
@@ -16727,7 +16727,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+ChannelSections.swift",
       "source": "Save",
       "surface": "apple",
-      "id": "native.apple.5f31b36d714b0aa7"
+      "id": "native.apple.35729b2cd003a68a"
     },
     {
       "kind": "ui-call",
@@ -16735,7 +16735,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+ChannelSections.swift",
       "source": "Reload",
       "surface": "apple",
-      "id": "native.apple.ea898eb7ffa40086"
+      "id": "native.apple.91dcf68eb2e49095"
     },
     {
       "kind": "ui-call",
@@ -16743,7 +16743,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+View.swift",
       "source": "Configured",
       "surface": "apple",
-      "id": "native.apple.6092b0813210678e"
+      "id": "native.apple.7d0c11e9c4314931"
     },
     {
       "kind": "ui-call",
@@ -16751,7 +16751,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+View.swift",
       "source": "Available",
       "surface": "apple",
-      "id": "native.apple.3908d09d66db5c68"
+      "id": "native.apple.5a468760837c956b"
     },
     {
       "kind": "ui-call",
@@ -16759,7 +16759,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+View.swift",
       "source": "Channels",
       "surface": "apple",
-      "id": "native.apple.0cf13d9e65ee5ac4"
+      "id": "native.apple.bf4f425bd0dc0c74"
     },
     {
       "kind": "ui-call",
@@ -16767,7 +16767,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+View.swift",
       "source": "Select a channel to view status and settings.",
       "surface": "apple",
-      "id": "native.apple.1e5f6b8165df7699"
+      "id": "native.apple.4d0dfdb0ac98fb47"
     },
     {
       "kind": "ui-call",
@@ -16775,7 +16775,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+View.swift",
       "source": "Last check \\(self.channelLastCheckText(channel))",
       "surface": "apple",
-      "id": "native.apple.5075aef1de390771"
+      "id": "native.apple.b4bc7f2d70f7d6f6"
     },
     {
       "kind": "ui-call",
@@ -16783,7 +16783,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsSettings+View.swift",
       "source": "Error",
       "surface": "apple",
-      "id": "native.apple.3700c04b8dd4762f"
+      "id": "native.apple.c05a9f1925dc6f02"
     },
     {
       "kind": "conditional-branch",
@@ -16799,7 +16799,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsStore+Lifecycle.swift",
       "source": "Logged out and cleared credentials.",
       "surface": "apple",
-      "id": "native.apple.25f326f27ea64d36"
+      "id": "native.apple.313dabb10c37e00c"
     },
     {
       "kind": "conditional-branch",
@@ -16807,7 +16807,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsStore+Lifecycle.swift",
       "source": "No WhatsApp session found.",
       "surface": "apple",
-      "id": "native.apple.cc44b98c938d7eab"
+      "id": "native.apple.b98078a5cac29eaf"
     },
     {
       "kind": "conditional-branch",
@@ -16815,7 +16815,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsStore+Lifecycle.swift",
       "source": "Telegram token cleared.",
       "surface": "apple",
-      "id": "native.apple.ad138e64e962584d"
+      "id": "native.apple.de729686d8ba05d6"
     },
     {
       "kind": "conditional-branch",
@@ -16823,7 +16823,7 @@
       "path": "apps/macos/Sources/OpenClaw/ChannelsStore+Lifecycle.swift",
       "source": "No Telegram token configured.",
       "surface": "apple",
-      "id": "native.apple.bc2c079a3c0d8016"
+      "id": "native.apple.53f4d1e63fb7d589"
     },
     {
       "kind": "ui-call",
@@ -16831,7 +16831,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "No config sections available.",
       "surface": "apple",
-      "id": "native.apple.0efd499899ab17e9"
+      "id": "native.apple.0a65101d40a6704c"
     },
     {
       "kind": "ui-call",
@@ -16839,7 +16839,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "Select a config section to view settings.",
       "surface": "apple",
-      "id": "native.apple.f5b3d811bee4e27b"
+      "id": "native.apple.cb9d6dbd9d5b038c"
     },
     {
       "kind": "ui-call",
@@ -16847,7 +16847,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "Unsaved changes",
       "surface": "apple",
-      "id": "native.apple.560ab05f67d4aad9"
+      "id": "native.apple.7eb0ce9d97e01663"
     },
     {
       "kind": "ui-call",
@@ -16855,7 +16855,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "Config",
       "surface": "apple",
-      "id": "native.apple.2ff772966bb46ccf"
+      "id": "native.apple.4042c565a6f65501"
     },
     {
       "kind": "conditional-branch",
@@ -16863,7 +16863,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "This tab is read-only in Nix mode. Edit config via Nix and rebuild.",
       "surface": "apple",
-      "id": "native.apple.5e41a954dfc83551"
+      "id": "native.apple.e7afd1797978a4fd"
     },
     {
       "kind": "conditional-branch",
@@ -16871,7 +16871,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "Edit ~/.openclaw/openclaw.json using the schema-driven form.",
       "surface": "apple",
-      "id": "native.apple.70a98fb062cce821"
+      "id": "native.apple.8103e662c0e40760"
     },
     {
       "kind": "ui-call",
@@ -16879,7 +16879,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "Reload",
       "surface": "apple",
-      "id": "native.apple.df089b635f5e8e0f"
+      "id": "native.apple.a3465ec90e435ea9"
     },
     {
       "kind": "conditional-branch",
@@ -16887,7 +16887,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "Save",
       "surface": "apple",
-      "id": "native.apple.695a47942f5cbaef"
+      "id": "native.apple.945e60a42bc8d782"
     },
     {
       "kind": "conditional-branch",
@@ -16895,7 +16895,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "Saving…",
       "surface": "apple",
-      "id": "native.apple.d7dbdcf2aa25d251"
+      "id": "native.apple.194e47f6f849c1ce"
     },
     {
       "kind": "ui-call",
@@ -16903,7 +16903,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "Loading current values…",
       "surface": "apple",
-      "id": "native.apple.8312b288532c0342"
+      "id": "native.apple.2efbb034dfb1c8f6"
     },
     {
       "kind": "ui-call",
@@ -16911,7 +16911,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "Wildcard config entries are edited from their concrete key.",
       "surface": "apple",
-      "id": "native.apple.ad7a5ac108e51b3a"
+      "id": "native.apple.5d4cb34e9ab41e84"
     },
     {
       "kind": "ui-call",
@@ -16919,7 +16919,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "Retry",
       "surface": "apple",
-      "id": "native.apple.d5fdba4e535fa3d2"
+      "id": "native.apple.88b63f0b2ca895e6"
     },
     {
       "kind": "ui-call",
@@ -16927,7 +16927,7 @@
       "path": "apps/macos/Sources/OpenClaw/ConfigSettings.swift",
       "source": "Required",
       "surface": "apple",
-      "id": "native.apple.a5e3a5e8f99f50ea"
+      "id": "native.apple.b77bd2f246efcbe1"
     },
     {
       "kind": "ui-named-argument",
@@ -16935,7 +16935,7 @@
       "path": "apps/macos/Sources/OpenClaw/ContextMenuCardView.swift",
       "source": "Context",
       "surface": "apple",
-      "id": "native.apple.aa40b6794e2973bf"
+      "id": "native.apple.ff860c1c4be92ede"
     },
     {
       "kind": "ui-call",
@@ -16943,7 +16943,7 @@
       "path": "apps/macos/Sources/OpenClaw/ContextMenuCardView.swift",
       "source": "No active sessions",
       "surface": "apple",
-      "id": "native.apple.173d298c01fcfc44"
+      "id": "native.apple.185e2d2285227daf"
     },
     {
       "kind": "ui-call",
@@ -16951,7 +16951,7 @@
       "path": "apps/macos/Sources/OpenClaw/ContextMenuCardView.swift",
       "source": "main",
       "surface": "apple",
-      "id": "native.apple.24837598afa71683"
+      "id": "native.apple.285a3ac6017334f9"
     },
     {
       "kind": "ui-call",
@@ -16959,7 +16959,7 @@
       "path": "apps/macos/Sources/OpenClaw/ContextMenuCardView.swift",
       "source": "000k/000k",
       "surface": "apple",
-      "id": "native.apple.f16e48c1c0fd3872"
+      "id": "native.apple.7d8890e2fc64e695"
     },
     {
       "kind": "ui-call",
@@ -16967,7 +16967,7 @@
       "path": "apps/macos/Sources/OpenClaw/ContextRootMenuLabelView.swift",
       "source": "Context",
       "surface": "apple",
-      "id": "native.apple.42079ea1e74e5b4e"
+      "id": "native.apple.ae89998eb6f436e0"
     },
     {
       "kind": "ui-modifier",
@@ -16975,7 +16975,7 @@
       "path": "apps/macos/Sources/OpenClaw/ContextUsageBar.swift",
       "source": "Context usage",
       "surface": "apple",
-      "id": "native.apple.2cec80203bf33687"
+      "id": "native.apple.c8e1c903a53d1abc"
     },
     {
       "kind": "conditional-branch",
@@ -16983,7 +16983,7 @@
       "path": "apps/macos/Sources/OpenClaw/ControlChannel.swift",
       "source": "degraded: \\(message)",
       "surface": "apple",
-      "id": "native.apple.23947c44a80ad86c"
+      "id": "native.apple.dac4643a71326e9b"
     },
     {
       "kind": "conditional-branch",
@@ -16999,7 +16999,7 @@
       "path": "apps/macos/Sources/OpenClaw/CostUsageMenuView.swift",
       "source": "Today",
       "surface": "apple",
-      "id": "native.apple.3738036b9840d0e0"
+      "id": "native.apple.47eb7fbdc9792b54"
     },
     {
       "kind": "ui-call",
@@ -17007,7 +17007,7 @@
       "path": "apps/macos/Sources/OpenClaw/CostUsageMenuView.swift",
       "source": "Last \\(self.summary.days)d",
       "surface": "apple",
-      "id": "native.apple.fa327c274d8a37f2"
+      "id": "native.apple.ebfc6af133da68bf"
     },
     {
       "kind": "ui-call",
@@ -17015,7 +17015,7 @@
       "path": "apps/macos/Sources/OpenClaw/CostUsageMenuView.swift",
       "source": "Partial: \\(self.summary.totals.missingCostEntries) entries missing cost",
       "surface": "apple",
-      "id": "native.apple.b5292a166ca26276"
+      "id": "native.apple.936bfd42a2f08232"
     },
     {
       "kind": "ui-named-argument",
@@ -17023,7 +17023,7 @@
       "path": "apps/macos/Sources/OpenClaw/CrestodianSettings.swift",
       "source": "Crestodian",
       "surface": "apple",
-      "id": "native.apple.5d80cdbc0d3dddb2"
+      "id": "native.apple.84f1d9ae4965cfe0"
     },
     {
       "kind": "ui-named-argument-concatenated",
@@ -17039,7 +17039,7 @@
       "path": "apps/macos/Sources/OpenClaw/CrestodianSettings.swift",
       "source": "Chat",
       "surface": "apple",
-      "id": "native.apple.e6b5803c7696f248"
+      "id": "native.apple.648423d89aec0c13"
     },
     {
       "kind": "ui-call",
@@ -17047,7 +17047,7 @@
       "path": "apps/macos/Sources/OpenClaw/CrestodianSettings.swift",
       "source": "Tip: try “status”, “doctor”, “set default model …”, or “connect telegram”.",
       "surface": "apple",
-      "id": "native.apple.2c3fe9fd20f9bae5"
+      "id": "native.apple.bd180b943ee89cfe"
     },
     {
       "kind": "conditional-branch",
@@ -17055,7 +17055,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Edit cron job",
       "surface": "apple",
-      "id": "native.apple.5625495307c01cb8"
+      "id": "native.apple.779f488d2ddd9eaf"
     },
     {
       "kind": "conditional-branch",
@@ -17063,7 +17063,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "New cron job",
       "surface": "apple",
-      "id": "native.apple.486fb23d241ee744"
+      "id": "native.apple.33558c9ead40a7a1"
     },
     {
       "kind": "ui-call",
@@ -17071,7 +17071,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Name",
       "surface": "apple",
-      "id": "native.apple.ba4538d2a944365a"
+      "id": "native.apple.f3e018806829cda3"
     },
     {
       "kind": "ui-call",
@@ -17079,7 +17079,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Required (e.g. “Daily summary”)",
       "surface": "apple",
-      "id": "native.apple.9f6b351b3c8413f1"
+      "id": "native.apple.d15ab158b3c13020"
     },
     {
       "kind": "ui-call",
@@ -17087,7 +17087,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Description",
       "surface": "apple",
-      "id": "native.apple.b93691b2b0d5a2a7"
+      "id": "native.apple.5d3f6ae647ede805"
     },
     {
       "kind": "ui-call",
@@ -17095,7 +17095,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Optional notes",
       "surface": "apple",
-      "id": "native.apple.a3f3769386767dfe"
+      "id": "native.apple.0e62d328b9b20553"
     },
     {
       "kind": "ui-call",
@@ -17103,7 +17103,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Agent ID",
       "surface": "apple",
-      "id": "native.apple.e56fb7d4e4719305"
+      "id": "native.apple.6773dec468741604"
     },
     {
       "kind": "ui-call",
@@ -17111,7 +17111,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Optional (default agent)",
       "surface": "apple",
-      "id": "native.apple.b0ad9a4beafce7ea"
+      "id": "native.apple.16586aa545b687a0"
     },
     {
       "kind": "ui-call",
@@ -17119,7 +17119,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Enabled",
       "surface": "apple",
-      "id": "native.apple.38806eff2430a869"
+      "id": "native.apple.eeba38110f1a3c12"
     },
     {
       "kind": "ui-call",
@@ -17127,7 +17127,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Session target",
       "surface": "apple",
-      "id": "native.apple.99d43552f0d46fd0"
+      "id": "native.apple.bcc9d1eb3289bc25"
     },
     {
       "kind": "ui-call",
@@ -17135,7 +17135,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "main",
       "surface": "apple",
-      "id": "native.apple.a712937d2757ec07"
+      "id": "native.apple.3e408bf7fd913139"
     },
     {
       "kind": "ui-call",
@@ -17143,7 +17143,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "isolated",
       "surface": "apple",
-      "id": "native.apple.abf99ffddce2f1f6"
+      "id": "native.apple.926b2cd8c6dbbc45"
     },
     {
       "kind": "ui-call",
@@ -17151,7 +17151,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "current",
       "surface": "apple",
-      "id": "native.apple.aead85c2ccc506b5"
+      "id": "native.apple.a3a4fb0c68d6aa82"
     },
     {
       "kind": "ui-call",
@@ -17159,7 +17159,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Wake mode",
       "surface": "apple",
-      "id": "native.apple.1b5b2bbccd76d8d2"
+      "id": "native.apple.ec2f3c99d04a641f"
     },
     {
       "kind": "ui-call",
@@ -17167,7 +17167,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "now",
       "surface": "apple",
-      "id": "native.apple.7ccc350fc7cfdc01"
+      "id": "native.apple.7bcc0a63bfc663e3"
     },
     {
       "kind": "ui-call",
@@ -17175,7 +17175,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "next-heartbeat",
       "surface": "apple",
-      "id": "native.apple.b9aa32fa8096f3da"
+      "id": "native.apple.0f943be2a3559a24"
     },
     {
       "kind": "ui-call",
@@ -17183,7 +17183,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "at",
       "surface": "apple",
-      "id": "native.apple.71539eff3cdc3636"
+      "id": "native.apple.288d76f698265dc7"
     },
     {
       "kind": "ui-call",
@@ -17191,7 +17191,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "every",
       "surface": "apple",
-      "id": "native.apple.f6a7a241b7689780"
+      "id": "native.apple.981882337a41b775"
     },
     {
       "kind": "ui-call",
@@ -17199,7 +17199,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "cron",
       "surface": "apple",
-      "id": "native.apple.63a2546194a7af45"
+      "id": "native.apple.8f029a66e8558108"
     },
     {
       "kind": "ui-call",
@@ -17207,7 +17207,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "At",
       "surface": "apple",
-      "id": "native.apple.db6e0e9a88f35016"
+      "id": "native.apple.da555c22da16bc6c"
     },
     {
       "kind": "ui-call",
@@ -17215,7 +17215,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Auto-delete",
       "surface": "apple",
-      "id": "native.apple.1e500d9905edb953"
+      "id": "native.apple.fa03647816776b55"
     },
     {
       "kind": "ui-call",
@@ -17223,7 +17223,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Delete after successful run",
       "surface": "apple",
-      "id": "native.apple.5528db819ca2198e"
+      "id": "native.apple.8eea808cb55c1f88"
     },
     {
       "kind": "ui-call",
@@ -17231,7 +17231,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Every",
       "surface": "apple",
-      "id": "native.apple.bc4570f983731115"
+      "id": "native.apple.6eb1c75f9733d7a7"
     },
     {
       "kind": "ui-call",
@@ -17239,7 +17239,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "10m, 1h, 1d",
       "surface": "apple",
-      "id": "native.apple.05b3c4eaa42b457e"
+      "id": "native.apple.e1299f47ac33f3ad"
     },
     {
       "kind": "ui-call",
@@ -17247,7 +17247,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Expression",
       "surface": "apple",
-      "id": "native.apple.b75ee26e3b0e9384"
+      "id": "native.apple.170810a5a91fed11"
     },
     {
       "kind": "ui-call",
@@ -17255,7 +17255,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "e.g. 0 9 * * 3",
       "surface": "apple",
-      "id": "native.apple.dfd068cc8b127a31"
+      "id": "native.apple.767058f99028f188"
     },
     {
       "kind": "ui-call",
@@ -17263,7 +17263,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Timezone",
       "surface": "apple",
-      "id": "native.apple.4c89de0919c749d9"
+      "id": "native.apple.05b31f0b14270fb7"
     },
     {
       "kind": "ui-call",
@@ -17271,7 +17271,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Optional (e.g. America/Los_Angeles)",
       "surface": "apple",
-      "id": "native.apple.3c6d0adbbd37697c"
+      "id": "native.apple.46908ba87434178e"
     },
     {
       "kind": "ui-call",
@@ -17279,7 +17279,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Kind",
       "surface": "apple",
-      "id": "native.apple.0664a99ae25c1874"
+      "id": "native.apple.cfc085d7f55ec6bb"
     },
     {
       "kind": "ui-call",
@@ -17287,7 +17287,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "systemEvent",
       "surface": "apple",
-      "id": "native.apple.7081e314aecb1b4a"
+      "id": "native.apple.400a2807228864fe"
     },
     {
       "kind": "ui-call",
@@ -17295,7 +17295,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "agentTurn",
       "surface": "apple",
-      "id": "native.apple.ea123b1a695f721a"
+      "id": "native.apple.f0fd21111cd7005e"
     },
     {
       "kind": "ui-call",
@@ -17303,7 +17303,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "System event text",
       "surface": "apple",
-      "id": "native.apple.e5153522b34e401e"
+      "id": "native.apple.316094e1fc93af44"
     },
     {
       "kind": "ui-call",
@@ -17311,7 +17311,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Cancel",
       "surface": "apple",
-      "id": "native.apple.05d982c8442dba38"
+      "id": "native.apple.b15d95fbd7ab04b2"
     },
     {
       "kind": "ui-call",
@@ -17319,7 +17319,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Save",
       "surface": "apple",
-      "id": "native.apple.825872d770f6fee5"
+      "id": "native.apple.88f23c037d54887b"
     },
     {
       "kind": "ui-call",
@@ -17327,7 +17327,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Message",
       "surface": "apple",
-      "id": "native.apple.ca32bcf744cdad6d"
+      "id": "native.apple.ebff58db1a257892"
     },
     {
       "kind": "ui-call",
@@ -17335,7 +17335,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "What should OpenClaw do?",
       "surface": "apple",
-      "id": "native.apple.e8071fa049d8aa30"
+      "id": "native.apple.df6243155293f80b"
     },
     {
       "kind": "ui-call",
@@ -17343,7 +17343,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Thinking",
       "surface": "apple",
-      "id": "native.apple.3c275caf2dd7075e"
+      "id": "native.apple.81b5ba441a230f07"
     },
     {
       "kind": "ui-call",
@@ -17351,7 +17351,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Optional (e.g. low)",
       "surface": "apple",
-      "id": "native.apple.fc711ddc3722480e"
+      "id": "native.apple.80ef7233b7508f01"
     },
     {
       "kind": "ui-call",
@@ -17359,7 +17359,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Timeout",
       "surface": "apple",
-      "id": "native.apple.f504998dec5ee83d"
+      "id": "native.apple.3ba268889ad0bb29"
     },
     {
       "kind": "ui-call",
@@ -17367,7 +17367,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Seconds (optional)",
       "surface": "apple",
-      "id": "native.apple.de0fd61936c6807b"
+      "id": "native.apple.32f1ef2c514bc5f2"
     },
     {
       "kind": "ui-call",
@@ -17375,7 +17375,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Delivery",
       "surface": "apple",
-      "id": "native.apple.3bf29ec53e434cec"
+      "id": "native.apple.8559c9accb62a451"
     },
     {
       "kind": "ui-call",
@@ -17383,7 +17383,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Announce summary",
       "surface": "apple",
-      "id": "native.apple.97e4b933ea09752d"
+      "id": "native.apple.a7deff2e1f9a2d4b"
     },
     {
       "kind": "ui-call",
@@ -17391,7 +17391,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "None",
       "surface": "apple",
-      "id": "native.apple.4eb375e186aa4029"
+      "id": "native.apple.b9d67998af15a52b"
     },
     {
       "kind": "ui-call",
@@ -17399,7 +17399,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Channel",
       "surface": "apple",
-      "id": "native.apple.3b3aea1f79470746"
+      "id": "native.apple.297903b6d84321d7"
     },
     {
       "kind": "ui-call",
@@ -17407,7 +17407,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "To",
       "surface": "apple",
-      "id": "native.apple.d56f7639f1c38816"
+      "id": "native.apple.5cee9c451573efbc"
     },
     {
       "kind": "ui-call",
@@ -17415,7 +17415,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Optional override (phone number / chat id / Discord channel)",
       "surface": "apple",
-      "id": "native.apple.f8db8919f56e49a8"
+      "id": "native.apple.f635a754de997a56"
     },
     {
       "kind": "ui-call",
@@ -17423,7 +17423,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Best-effort",
       "surface": "apple",
-      "id": "native.apple.405e37338cdaae5c"
+      "id": "native.apple.2281bf826d28ffb7"
     },
     {
       "kind": "ui-call",
@@ -17431,7 +17431,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronJobEditor.swift",
       "source": "Do not fail the job if announce fails",
       "surface": "apple",
-      "id": "native.apple.e63028d5a07fc239"
+      "id": "native.apple.75ea8e8d38238dfd"
     },
     {
       "kind": "conditional-branch",
@@ -17447,7 +17447,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Delete cron job?",
       "surface": "apple",
-      "id": "native.apple.ae4461c1a974b6e6"
+      "id": "native.apple.2c7610400993c954"
     },
     {
       "kind": "ui-call",
@@ -17455,7 +17455,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Cancel",
       "surface": "apple",
-      "id": "native.apple.0250ddc8f983e2b5"
+      "id": "native.apple.1b124194b8cb5fd5"
     },
     {
       "kind": "ui-call",
@@ -17463,7 +17463,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Delete",
       "surface": "apple",
-      "id": "native.apple.85de879487e6bf00"
+      "id": "native.apple.5457b9d0c551b472"
     },
     {
       "kind": "ui-call",
@@ -17471,7 +17471,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Cron scheduler is disabled",
       "surface": "apple",
-      "id": "native.apple.c70c9f19b8deb639"
+      "id": "native.apple.0d7cc44ae0dab2f7"
     },
     {
       "kind": "ui-call-concatenated",
@@ -17479,7 +17479,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Jobs are saved, but they will not run automatically until `cron.enabled` is set to `true` and the Gateway restarts.",
       "surface": "apple",
-      "id": "native.apple.3d9533a9eece1ac8"
+      "id": "native.apple.dea81e38c91f67f1"
     },
     {
       "kind": "ui-call",
@@ -17487,7 +17487,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Cron Jobs",
       "surface": "apple",
-      "id": "native.apple.a1bbecf59eceb28e"
+      "id": "native.apple.832eb0b0712fd34a"
     },
     {
       "kind": "ui-call",
@@ -17495,7 +17495,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Manage Gateway cron jobs and inspect run history.",
       "surface": "apple",
-      "id": "native.apple.76e1ecc684794ad1"
+      "id": "native.apple.0de268bcd943ee00"
     },
     {
       "kind": "ui-call",
@@ -17503,7 +17503,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.db83190b64638992"
+      "id": "native.apple.0c4ffb322b3e65de"
     },
     {
       "kind": "ui-call",
@@ -17511,7 +17511,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "New Job",
       "surface": "apple",
-      "id": "native.apple.1bdad8701e5c4267"
+      "id": "native.apple.7f5f9b82bb18d061"
     },
     {
       "kind": "ui-call",
@@ -17519,7 +17519,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Error: \\(err)",
       "surface": "apple",
-      "id": "native.apple.b6fd2601f57e948f"
+      "id": "native.apple.62a13e9cad6985af"
     },
     {
       "kind": "ui-call",
@@ -17527,7 +17527,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "No cron jobs yet.",
       "surface": "apple",
-      "id": "native.apple.719225ab772d5847"
+      "id": "native.apple.33a31e8e9f2003af"
     },
     {
       "kind": "ui-call",
@@ -17535,7 +17535,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Select a job to inspect details and run history.",
       "surface": "apple",
-      "id": "native.apple.feba2cab61dfcfc0"
+      "id": "native.apple.03b0c3fb3259236c"
     },
     {
       "kind": "ui-call",
@@ -17543,7 +17543,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift",
       "source": "Tip: use ‘New Job’ to add one, or enable cron in your gateway config.",
       "surface": "apple",
-      "id": "native.apple.2b31872e1a35f164"
+      "id": "native.apple.60409b6f360a2726"
     },
     {
       "kind": "ui-named-argument",
@@ -17551,7 +17551,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "disabled",
       "surface": "apple",
-      "id": "native.apple.d94b55a9b857e9f1"
+      "id": "native.apple.920b1625c66d2fbf"
     },
     {
       "kind": "ui-named-argument",
@@ -17559,7 +17559,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "no next run",
       "surface": "apple",
-      "id": "native.apple.400c8c0a958e3684"
+      "id": "native.apple.90a2ebfd0143ae3d"
     },
     {
       "kind": "ui-named-argument",
@@ -17567,7 +17567,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "agent \\(agentId)",
       "surface": "apple",
-      "id": "native.apple.63db9fb9c080c92f"
+      "id": "native.apple.b349868bdc72ecbe"
     },
     {
       "kind": "ui-call",
@@ -17575,7 +17575,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Run now",
       "surface": "apple",
-      "id": "native.apple.582e6a0cc361b350"
+      "id": "native.apple.b3049b1b58de4e0a"
     },
     {
       "kind": "ui-call",
@@ -17583,7 +17583,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Open transcript",
       "surface": "apple",
-      "id": "native.apple.d050cb62cbf6b4eb"
+      "id": "native.apple.022656e82944b598"
     },
     {
       "kind": "conditional-branch",
@@ -17591,7 +17591,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Disable",
       "surface": "apple",
-      "id": "native.apple.6b8f9f64b7939daf"
+      "id": "native.apple.a821d3c97c51498c"
     },
     {
       "kind": "conditional-branch",
@@ -17599,7 +17599,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Enable",
       "surface": "apple",
-      "id": "native.apple.2bbab9b9ba943b53"
+      "id": "native.apple.13f8628d1493d45f"
     },
     {
       "kind": "ui-call",
@@ -17607,7 +17607,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Edit…",
       "surface": "apple",
-      "id": "native.apple.8db6456d1afb6184"
+      "id": "native.apple.8c48d1d69ed81f7e"
     },
     {
       "kind": "ui-call",
@@ -17615,7 +17615,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Delete…",
       "surface": "apple",
-      "id": "native.apple.7b7a20836cf59b0f"
+      "id": "native.apple.5684d3181ce22018"
     },
     {
       "kind": "ui-call",
@@ -17623,7 +17623,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Enabled",
       "surface": "apple",
-      "id": "native.apple.ae5403e34540b504"
+      "id": "native.apple.7ded1df100694ac3"
     },
     {
       "kind": "ui-call",
@@ -17631,7 +17631,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Run",
       "surface": "apple",
-      "id": "native.apple.33ab9ed8c4c31a22"
+      "id": "native.apple.9130853a425f720d"
     },
     {
       "kind": "ui-call",
@@ -17639,7 +17639,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Transcript",
       "surface": "apple",
-      "id": "native.apple.f310936525d971cf"
+      "id": "native.apple.f34de6490071b8e5"
     },
     {
       "kind": "ui-call",
@@ -17647,7 +17647,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Edit",
       "surface": "apple",
-      "id": "native.apple.0bd23806a5e953d2"
+      "id": "native.apple.4bffda5fcd7a290d"
     },
     {
       "kind": "ui-call",
@@ -17655,7 +17655,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Schedule",
       "surface": "apple",
-      "id": "native.apple.b5e0e6255c999bae"
+      "id": "native.apple.04c710cf31471ebd"
     },
     {
       "kind": "ui-call",
@@ -17663,7 +17663,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Auto-delete",
       "surface": "apple",
-      "id": "native.apple.879c72e4da389850"
+      "id": "native.apple.a0c6656d9919acd7"
     },
     {
       "kind": "ui-call",
@@ -17671,7 +17671,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "after success",
       "surface": "apple",
-      "id": "native.apple.e0484961984a1829"
+      "id": "native.apple.89cad86b7d3a1ed8"
     },
     {
       "kind": "ui-call",
@@ -17679,7 +17679,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Description",
       "surface": "apple",
-      "id": "native.apple.1c2185a5305d0c0f"
+      "id": "native.apple.0b2a438527591597"
     },
     {
       "kind": "ui-call",
@@ -17687,7 +17687,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Agent",
       "surface": "apple",
-      "id": "native.apple.216b0f15bd816b78"
+      "id": "native.apple.e8ddda1d43812c1d"
     },
     {
       "kind": "ui-call",
@@ -17695,7 +17695,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Session",
       "surface": "apple",
-      "id": "native.apple.44c820fbed87b3af"
+      "id": "native.apple.a9ed6399f6985efb"
     },
     {
       "kind": "ui-call",
@@ -17703,7 +17703,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Wake",
       "surface": "apple",
-      "id": "native.apple.2dfcc7da7297245f"
+      "id": "native.apple.4dde8cb5e531bb81"
     },
     {
       "kind": "ui-call",
@@ -17711,7 +17711,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Next run",
       "surface": "apple",
-      "id": "native.apple.623bbe433f0b8977"
+      "id": "native.apple.014262bb8068c0a1"
     },
     {
       "kind": "ui-call",
@@ -17719,7 +17719,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Last run",
       "surface": "apple",
-      "id": "native.apple.397b2ef934549237"
+      "id": "native.apple.8ec0a4219e5e76ce"
     },
     {
       "kind": "ui-call",
@@ -17727,7 +17727,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "\\(date.formatted(date: .abbreviated, time: .standard)) · \\(relativeAge(from: date))",
       "surface": "apple",
-      "id": "native.apple.ec1fd395efda9833"
+      "id": "native.apple.7718fbae883d5389"
     },
     {
       "kind": "ui-call",
@@ -17735,7 +17735,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Last status",
       "surface": "apple",
-      "id": "native.apple.f668db14f031b70f"
+      "id": "native.apple.87247dcb9a2857ed"
     },
     {
       "kind": "ui-call",
@@ -17743,7 +17743,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Run history",
       "surface": "apple",
-      "id": "native.apple.17895f7c89845c4c"
+      "id": "native.apple.bac4e36acb29ec13"
     },
     {
       "kind": "ui-call",
@@ -17751,7 +17751,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.f4bb1ca188e6c7ab"
+      "id": "native.apple.f614be2891ac9a70"
     },
     {
       "kind": "ui-call",
@@ -17759,7 +17759,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "No run log entries yet.",
       "surface": "apple",
-      "id": "native.apple.6ad598f84141ad14"
+      "id": "native.apple.1d31c7c3dc040e9e"
     },
     {
       "kind": "ui-call",
@@ -17767,7 +17767,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "\\(ms)ms",
       "surface": "apple",
-      "id": "native.apple.75e1c7a889f492b1"
+      "id": "native.apple.6ec996f25c175bbc"
     },
     {
       "kind": "ui-call",
@@ -17775,7 +17775,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "Payload",
       "surface": "apple",
-      "id": "native.apple.18f67b0fe6b08d36"
+      "id": "native.apple.07c987127cde7927"
     },
     {
       "kind": "ui-named-argument",
@@ -17783,7 +17783,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "think \\(thinking)",
       "surface": "apple",
-      "id": "native.apple.77b9a97950a062ff"
+      "id": "native.apple.a687603203fec348"
     },
     {
       "kind": "ui-named-argument",
@@ -17791,7 +17791,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "\\(timeoutSeconds)s",
       "surface": "apple",
-      "id": "native.apple.290c1d66f24eb79c"
+      "id": "native.apple.a513a17d658a1aa2"
     },
     {
       "kind": "ui-named-argument",
@@ -17799,7 +17799,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "announce",
       "surface": "apple",
-      "id": "native.apple.564f7cedfd7a3fe3"
+      "id": "native.apple.41cd997805bd59e3"
     },
     {
       "kind": "ui-named-argument",
@@ -17807,7 +17807,7 @@
       "path": "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift",
       "source": "no delivery",
       "surface": "apple",
-      "id": "native.apple.8b7368aa83ac1696"
+      "id": "native.apple.6e5597dd202288ee"
     },
     {
       "kind": "ui-named-argument",
@@ -17863,7 +17863,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Kill \\(listener.command) (\\(listener.pid))?",
       "surface": "apple",
-      "id": "native.apple.10e786234c8e745c"
+      "id": "native.apple.4c70e8fb1c642be1"
     },
     {
       "kind": "ui-call",
@@ -17871,7 +17871,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "This process looks expected for the current mode. Kill anyway?",
       "surface": "apple",
-      "id": "native.apple.3082271f6fd8f780"
+      "id": "native.apple.a8e0eda487b545fb"
     },
     {
       "kind": "ui-call",
@@ -17879,7 +17879,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Attach only (skip launchd install)",
       "surface": "apple",
-      "id": "native.apple.e9a312657ae30eb8"
+      "id": "native.apple.85986510973b69a5"
     },
     {
       "kind": "ui-call-concatenated",
@@ -17887,7 +17887,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "When enabled, OpenClaw won't install or manage \\(gatewayLaunchdLabel). It will only attach to an existing Gateway.",
       "surface": "apple",
-      "id": "native.apple.07e8e02d85bc8750"
+      "id": "native.apple.d8b3e55c41a77627"
     },
     {
       "kind": "ui-call",
@@ -17895,7 +17895,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Debug",
       "surface": "apple",
-      "id": "native.apple.4198ecd66007b98f"
+      "id": "native.apple.15e528c55a96394f"
     },
     {
       "kind": "ui-call",
@@ -17903,7 +17903,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Tools for diagnosing local issues (Gateway, ports, logs, Canvas).",
       "surface": "apple",
-      "id": "native.apple.40520fed8aa3630d"
+      "id": "native.apple.334ebd156b980d53"
     },
     {
       "kind": "ui-named-argument",
@@ -17911,7 +17911,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "App Health",
       "surface": "apple",
-      "id": "native.apple.d81d09fa8b377521"
+      "id": "native.apple.bea6c3a6ee04749e"
     },
     {
       "kind": "ui-named-argument",
@@ -17919,7 +17919,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Gateway",
       "surface": "apple",
-      "id": "native.apple.1d3301aa2c6f17f4"
+      "id": "native.apple.aefd694194f18104"
     },
     {
       "kind": "conditional-branch",
@@ -17927,7 +17927,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Local process",
       "surface": "apple",
-      "id": "native.apple.2c9e273b2f92c17a"
+      "id": "native.apple.ee22afbade2976eb"
     },
     {
       "kind": "conditional-branch",
@@ -17935,7 +17935,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Remote connection",
       "surface": "apple",
-      "id": "native.apple.d3b859c83141b384"
+      "id": "native.apple.d018b788de2625d4"
     },
     {
       "kind": "ui-named-argument",
@@ -17943,7 +17943,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "App PID",
       "surface": "apple",
-      "id": "native.apple.e78e04e8d182b174"
+      "id": "native.apple.09ab439549787a34"
     },
     {
       "kind": "ui-call",
@@ -17951,7 +17951,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Health",
       "surface": "apple",
-      "id": "native.apple.f28b0c656bc6b9e1"
+      "id": "native.apple.c89b5449fe399633"
     },
     {
       "kind": "ui-call",
@@ -17959,7 +17959,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "CLI",
       "surface": "apple",
-      "id": "native.apple.1f723ea4de7bcd62"
+      "id": "native.apple.11bf6f17b2c17d01"
     },
     {
       "kind": "ui-call",
@@ -17967,7 +17967,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "PID",
       "surface": "apple",
-      "id": "native.apple.72cecad387820dc6"
+      "id": "native.apple.50a498bb5d21fce5"
     },
     {
       "kind": "ui-call",
@@ -17975,7 +17975,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "\\(ProcessInfo.processInfo.processIdentifier)",
       "surface": "apple",
-      "id": "native.apple.84485f274232fda6"
+      "id": "native.apple.a1b7117088ad315f"
     },
     {
       "kind": "ui-call",
@@ -17983,7 +17983,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Binary path",
       "surface": "apple",
-      "id": "native.apple.9f229e36dd9f873e"
+      "id": "native.apple.6ae192c6a5942a53"
     },
     {
       "kind": "ui-call",
@@ -17991,7 +17991,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Status",
       "surface": "apple",
-      "id": "native.apple.34b2f835274d60b7"
+      "id": "native.apple.117165abb75eb58b"
     },
     {
       "kind": "ui-call",
@@ -17999,7 +17999,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Key",
       "surface": "apple",
-      "id": "native.apple.8e5e40c66cde8a96"
+      "id": "native.apple.5432c42ec6020ef0"
     },
     {
       "kind": "ui-call",
@@ -18007,7 +18007,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Copy",
       "surface": "apple",
-      "id": "native.apple.68b3cf039815d1e0"
+      "id": "native.apple.6675a44c2884bf14"
     },
     {
       "kind": "ui-call",
@@ -18015,7 +18015,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Copy sample URL",
       "surface": "apple",
-      "id": "native.apple.8b849808942b6bf7"
+      "id": "native.apple.d88bd4f76c454179"
     },
     {
       "kind": "ui-call",
@@ -18023,7 +18023,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Deep links (openclaw://…) are always enabled; the key controls unattended runs.",
       "surface": "apple",
-      "id": "native.apple.12a909f68c3f2a7a"
+      "id": "native.apple.f8e4e2b25dbdbd44"
     },
     {
       "kind": "ui-call",
@@ -18031,7 +18031,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Stdout / stderr",
       "surface": "apple",
-      "id": "native.apple.fe536192769282ae"
+      "id": "native.apple.aeba5ae43a292c55"
     },
     {
       "kind": "ui-call",
@@ -18039,7 +18039,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Restart Gateway",
       "surface": "apple",
-      "id": "native.apple.1bfa2d286c1b767a"
+      "id": "native.apple.93d4f16afee5753a"
     },
     {
       "kind": "ui-call",
@@ -18047,7 +18047,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Clear log",
       "surface": "apple",
-      "id": "native.apple.ceea0bb35d2eaeae"
+      "id": "native.apple.f552a3cb08f36b37"
     },
     {
       "kind": "ui-call",
@@ -18055,7 +18055,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Pino log",
       "surface": "apple",
-      "id": "native.apple.de9bcce9f614cde3"
+      "id": "native.apple.ec9654e76a7c3f6f"
     },
     {
       "kind": "ui-call",
@@ -18063,7 +18063,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Open",
       "surface": "apple",
-      "id": "native.apple.a3a3ad4f23b35bc9"
+      "id": "native.apple.ac5b3114ca2f9f9c"
     },
     {
       "kind": "ui-call",
@@ -18071,7 +18071,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "App logging",
       "surface": "apple",
-      "id": "native.apple.382c8060383a6f2c"
+      "id": "native.apple.73375aaca7469480"
     },
     {
       "kind": "ui-call",
@@ -18079,7 +18079,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Verbosity",
       "surface": "apple",
-      "id": "native.apple.8960d9d8a14fab21"
+      "id": "native.apple.45ca609245731590"
     },
     {
       "kind": "ui-modifier",
@@ -18087,7 +18087,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Controls the macOS app log verbosity.",
       "surface": "apple",
-      "id": "native.apple.63c650ed822e7b20"
+      "id": "native.apple.9f5ec48a00c7bba6"
     },
     {
       "kind": "ui-call",
@@ -18095,7 +18095,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Write rolling diagnostics log (JSONL)",
       "surface": "apple",
-      "id": "native.apple.483f7c97c4353b24"
+      "id": "native.apple.badf38ad13935f27"
     },
     {
       "kind": "ui-modifier-concatenated",
@@ -18111,7 +18111,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Open folder",
       "surface": "apple",
-      "id": "native.apple.0b66962f1ac2921b"
+      "id": "native.apple.5b35a89bea603457"
     },
     {
       "kind": "ui-call",
@@ -18119,7 +18119,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Clear",
       "surface": "apple",
-      "id": "native.apple.3dc2c37c1ba229bb"
+      "id": "native.apple.1b7e3b03bf00eed6"
     },
     {
       "kind": "ui-call",
@@ -18127,7 +18127,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Port diagnostics",
       "surface": "apple",
-      "id": "native.apple.b7ab15465aeee65b"
+      "id": "native.apple.0e058d4bd1e38466"
     },
     {
       "kind": "ui-call",
@@ -18135,7 +18135,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Check gateway ports",
       "surface": "apple",
-      "id": "native.apple.6926cf7b08fd5122"
+      "id": "native.apple.49c55c23f1b30c49"
     },
     {
       "kind": "ui-call",
@@ -18143,7 +18143,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Reset SSH tunnel",
       "surface": "apple",
-      "id": "native.apple.cc6c261bac0c2b62"
+      "id": "native.apple.f41a77907a653c26"
     },
     {
       "kind": "ui-call",
@@ -18151,7 +18151,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Check which process owns \\(GatewayEnvironment.gatewayPort()) and suggest fixes.",
       "surface": "apple",
-      "id": "native.apple.b1ee37438dacb4b9"
+      "id": "native.apple.7d3bb8db32ac31b8"
     },
     {
       "kind": "ui-call",
@@ -18159,7 +18159,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Port \\(report.port)",
       "surface": "apple",
-      "id": "native.apple.81b2e322566bbeb8"
+      "id": "native.apple.b5c922d5a81b9a82"
     },
     {
       "kind": "ui-call",
@@ -18167,7 +18167,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "\\(listener.command) (\\(listener.pid))",
       "surface": "apple",
-      "id": "native.apple.8c7ea9e72e42a8eb"
+      "id": "native.apple.0dbd56f870683617"
     },
     {
       "kind": "ui-call",
@@ -18175,7 +18175,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Kill",
       "surface": "apple",
-      "id": "native.apple.bc13d895b4064248"
+      "id": "native.apple.eb373e180ce4eb57"
     },
     {
       "kind": "ui-call",
@@ -18183,7 +18183,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "OpenClaw project root",
       "surface": "apple",
-      "id": "native.apple.813c8586ae04a3fc"
+      "id": "native.apple.5e9e8bf8e35c48ef"
     },
     {
       "kind": "ui-call",
@@ -18191,7 +18191,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Path to openclaw repo",
       "surface": "apple",
-      "id": "native.apple.3d393b31f86fbec3"
+      "id": "native.apple.8b01a6daf7a7b94e"
     },
     {
       "kind": "ui-call",
@@ -18199,7 +18199,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Reset",
       "surface": "apple",
-      "id": "native.apple.309a454d79dd1e60"
+      "id": "native.apple.b9e064d213c6b451"
     },
     {
       "kind": "ui-call",
@@ -18207,7 +18207,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Used for pnpm/node fallback and PATH population when launching the gateway.",
       "surface": "apple",
-      "id": "native.apple.6cf1c1aa26cf61e1"
+      "id": "native.apple.2c9911885c449665"
     },
     {
       "kind": "ui-call",
@@ -18215,7 +18215,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Session store",
       "surface": "apple",
-      "id": "native.apple.f1d5d9737e0138e5"
+      "id": "native.apple.b1d1a6049ad5abb8"
     },
     {
       "kind": "ui-call",
@@ -18223,7 +18223,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Path",
       "surface": "apple",
-      "id": "native.apple.c9561d28544f0670"
+      "id": "native.apple.745141d448a91b84"
     },
     {
       "kind": "ui-call",
@@ -18231,7 +18231,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Save",
       "surface": "apple",
-      "id": "native.apple.1eb757c53daed0b6"
+      "id": "native.apple.fa6607e762a540c0"
     },
     {
       "kind": "ui-call",
@@ -18239,7 +18239,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Used by the CLI session loader; stored in ~/.openclaw/openclaw.json.",
       "surface": "apple",
-      "id": "native.apple.eb97e49cfbb16619"
+      "id": "native.apple.a8154f17cda71415"
     },
     {
       "kind": "ui-call",
@@ -18247,7 +18247,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Send Test Notification",
       "surface": "apple",
-      "id": "native.apple.7bc3cbec7550fdcf"
+      "id": "native.apple.3e472353e27107af"
     },
     {
       "kind": "ui-call",
@@ -18255,7 +18255,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Open Agent Events",
       "surface": "apple",
-      "id": "native.apple.cdaa6f65335979a9"
+      "id": "native.apple.9fdf25afbeb46192"
     },
     {
       "kind": "conditional-branch",
@@ -18263,7 +18263,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Send debug voice",
       "surface": "apple",
-      "id": "native.apple.60d37af992545a36"
+      "id": "native.apple.42bbba51b2fd6cfa"
     },
     {
       "kind": "conditional-branch",
@@ -18271,7 +18271,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Sending debug voice…",
       "surface": "apple",
-      "id": "native.apple.18aaef5bb8f63a4c"
+      "id": "native.apple.12fbaf28bf105c23"
     },
     {
       "kind": "ui-call",
@@ -18279,7 +18279,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Uses the Voice Wake path: forwards over SSH when configured,\notherwise runs locally via rpc.",
       "surface": "apple",
-      "id": "native.apple.6ef0b7e40637cd4a"
+      "id": "native.apple.652d5fb7136dfd92"
     },
     {
       "kind": "ui-call",
@@ -18287,7 +18287,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Note: macOS may require restarting OpenClaw after enabling Accessibility or Screen Recording.",
       "surface": "apple",
-      "id": "native.apple.01a504ea12505286"
+      "id": "native.apple.3307505d507faf31"
     },
     {
       "kind": "ui-call",
@@ -18295,7 +18295,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Restart OpenClaw",
       "surface": "apple",
-      "id": "native.apple.f596e59c9f0bb0a0"
+      "id": "native.apple.e52d463773aef1e1"
     },
     {
       "kind": "ui-call",
@@ -18303,7 +18303,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Restart app",
       "surface": "apple",
-      "id": "native.apple.a7c3852141d74507"
+      "id": "native.apple.e299e77f3ad75a75"
     },
     {
       "kind": "ui-call",
@@ -18311,7 +18311,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Restart onboarding",
       "surface": "apple",
-      "id": "native.apple.8ff8af440e017d64"
+      "id": "native.apple.902488e753844202"
     },
     {
       "kind": "ui-call",
@@ -18319,7 +18319,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Reveal app in Finder",
       "surface": "apple",
-      "id": "native.apple.f4ff6092d26790ea"
+      "id": "native.apple.98b02027c57eda8b"
     },
     {
       "kind": "ui-call",
@@ -18327,7 +18327,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Enable/disable Canvas in General settings.",
       "surface": "apple",
-      "id": "native.apple.390a76559ead3b34"
+      "id": "native.apple.04eaabb42454944b"
     },
     {
       "kind": "ui-call",
@@ -18335,7 +18335,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Session",
       "surface": "apple",
-      "id": "native.apple.bb69dfb5bee6b938"
+      "id": "native.apple.b2bebe675c30727a"
     },
     {
       "kind": "ui-call",
@@ -18343,7 +18343,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Show panel",
       "surface": "apple",
-      "id": "native.apple.e1ae0b4e2f265c90"
+      "id": "native.apple.99861950da1e69ba"
     },
     {
       "kind": "ui-call",
@@ -18351,7 +18351,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Hide panel",
       "surface": "apple",
-      "id": "native.apple.eb37355c55fdc055"
+      "id": "native.apple.33eb8f297296ec9c"
     },
     {
       "kind": "ui-call",
@@ -18359,7 +18359,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Write sample page",
       "surface": "apple",
-      "id": "native.apple.bfdcd5a46d498903"
+      "id": "native.apple.547643e9375bf49c"
     },
     {
       "kind": "ui-call",
@@ -18367,7 +18367,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Eval JS",
       "surface": "apple",
-      "id": "native.apple.1f4333c6069859ad"
+      "id": "native.apple.fea4c2dbfc571ab6"
     },
     {
       "kind": "ui-call",
@@ -18375,7 +18375,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Eval",
       "surface": "apple",
-      "id": "native.apple.ca55ead6aa5c8c14"
+      "id": "native.apple.940c0085416c853c"
     },
     {
       "kind": "ui-call",
@@ -18383,7 +18383,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Snapshot",
       "surface": "apple",
-      "id": "native.apple.f67001b5ceac0dbd"
+      "id": "native.apple.a4e7bea688bf372c"
     },
     {
       "kind": "ui-call",
@@ -18391,7 +18391,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "eval → \\(canvasEvalResult)",
       "surface": "apple",
-      "id": "native.apple.9672fc4e0f242276"
+      "id": "native.apple.ad26da5399b2e89a"
     },
     {
       "kind": "ui-call",
@@ -18399,7 +18399,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "snapshot → \\(canvasSnapshotPath)",
       "surface": "apple",
-      "id": "native.apple.dc4541ce5f69d040"
+      "id": "native.apple.2fa497069eba7671"
     },
     {
       "kind": "ui-call",
@@ -18407,7 +18407,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Reveal",
       "surface": "apple",
-      "id": "native.apple.d44bc2abed998669"
+      "id": "native.apple.1c45fe5f7f9e7f51"
     },
     {
       "kind": "ui-call",
@@ -18415,7 +18415,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Tip: the session directory is returned by “Show panel”.",
       "surface": "apple",
-      "id": "native.apple.60b35092f75f6bb7"
+      "id": "native.apple.44008e46c4816fcb"
     },
     {
       "kind": "ui-call",
@@ -18423,7 +18423,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Icon override",
       "surface": "apple",
-      "id": "native.apple.2684fb74b8c8cabe"
+      "id": "native.apple.cf253de8a6d44fdc"
     },
     {
       "kind": "ui-call",
@@ -18431,7 +18431,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Chat",
       "surface": "apple",
-      "id": "native.apple.df3e3d8d7d2286dc"
+      "id": "native.apple.5a465c703604e054"
     },
     {
       "kind": "ui-call",
@@ -18439,7 +18439,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Native SwiftUI",
       "surface": "apple",
-      "id": "native.apple.75185bde52bb5fc0"
+      "id": "native.apple.39cdf5187168b1a0"
     },
     {
       "kind": "conditional-branch",
@@ -18447,7 +18447,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Unknown",
       "surface": "apple",
-      "id": "native.apple.b74168a58543dfbb"
+      "id": "native.apple.6a013ae216593687"
     },
     {
       "kind": "conditional-branch",
@@ -18455,7 +18455,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Healthy",
       "surface": "apple",
-      "id": "native.apple.f3d8b72e39bda8c0"
+      "id": "native.apple.6978f2d8499b3b30"
     },
     {
       "kind": "conditional-branch",
@@ -18463,7 +18463,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Needs Link",
       "surface": "apple",
-      "id": "native.apple.bdc0e8ebf0aef583"
+      "id": "native.apple.6431f5299453465b"
     },
     {
       "kind": "conditional-branch",
@@ -18471,7 +18471,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Degraded",
       "surface": "apple",
-      "id": "native.apple.c488f6aaf29dc922"
+      "id": "native.apple.e7d1ee5662c1d646"
     },
     {
       "kind": "ui-call",
@@ -18479,7 +18479,7 @@
       "path": "apps/macos/Sources/OpenClaw/DebugSettings.swift",
       "source": "Test",
       "surface": "apple",
-      "id": "native.apple.64a6e6075dd45570"
+      "id": "native.apple.0397fa643df26663"
     },
     {
       "kind": "ui-named-argument",
@@ -18487,7 +18487,7 @@
       "path": "apps/macos/Sources/OpenClaw/DeepLinks.swift",
       "source": "OpenClaw is paused",
       "surface": "apple",
-      "id": "native.apple.4b18bc3c8eece07f"
+      "id": "native.apple.a8af393b84d63ab8"
     },
     {
       "kind": "ui-named-argument",
@@ -18495,7 +18495,7 @@
       "path": "apps/macos/Sources/OpenClaw/DeepLinks.swift",
       "source": "Unpause OpenClaw to run agent actions.",
       "surface": "apple",
-      "id": "native.apple.3231abf69ea32ce3"
+      "id": "native.apple.7ba1542539c0d40b"
     },
     {
       "kind": "ui-named-argument",
@@ -18503,7 +18503,7 @@
       "path": "apps/macos/Sources/OpenClaw/DeepLinks.swift",
       "source": "Deep link too large",
       "surface": "apple",
-      "id": "native.apple.8ef3af581f3c0aab"
+      "id": "native.apple.7c1e1dbfde976ab9"
     },
     {
       "kind": "ui-named-argument",
@@ -18511,7 +18511,7 @@
       "path": "apps/macos/Sources/OpenClaw/DeepLinks.swift",
       "source": "Message exceeds 20,000 characters.",
       "surface": "apple",
-      "id": "native.apple.e94b1093e6658125"
+      "id": "native.apple.6f83894cf1e88558"
     },
     {
       "kind": "ui-named-argument",
@@ -18519,7 +18519,7 @@
       "path": "apps/macos/Sources/OpenClaw/DeepLinks.swift",
       "source": "Deep link blocked",
       "surface": "apple",
-      "id": "native.apple.4ad97dc6dd4ddefe"
+      "id": "native.apple.333dcda29354b1d0"
     },
     {
       "kind": "conditional-branch",
@@ -18535,7 +18535,7 @@
       "path": "apps/macos/Sources/OpenClaw/DeepLinks.swift",
       "source": "Run OpenClaw agent?",
       "surface": "apple",
-      "id": "native.apple.ded882f2033ad61b"
+      "id": "native.apple.50f1211af2a1945e"
     },
     {
       "kind": "ui-named-argument",
@@ -18543,7 +18543,7 @@
       "path": "apps/macos/Sources/OpenClaw/DeepLinks.swift",
       "source": "Agent request failed",
       "surface": "apple",
-      "id": "native.apple.2884ce4401bc0d19"
+      "id": "native.apple.4f3841d5de0135c4"
     },
     {
       "kind": "conditional-branch",
@@ -18551,7 +18551,7 @@
       "path": "apps/macos/Sources/OpenClaw/ExecApprovals.swift",
       "source": "Allowlist",
       "surface": "apple",
-      "id": "native.apple.63babf5552212d5c"
+      "id": "native.apple.3bed795cded1caa6"
     },
     {
       "kind": "conditional-branch",
@@ -18559,7 +18559,7 @@
       "path": "apps/macos/Sources/OpenClaw/ExecApprovals.swift",
       "source": "Deny",
       "surface": "apple",
-      "id": "native.apple.cccb5562e058c674"
+      "id": "native.apple.aec1bd885ac9d40b"
     },
     {
       "kind": "conditional-branch",
@@ -18567,7 +18567,7 @@
       "path": "apps/macos/Sources/OpenClaw/ExecApprovals.swift",
       "source": "Always Allow",
       "surface": "apple",
-      "id": "native.apple.bdfa57e56c573c6f"
+      "id": "native.apple.0922ae2298cc7215"
     },
     {
       "kind": "conditional-branch",
@@ -18575,7 +18575,7 @@
       "path": "apps/macos/Sources/OpenClaw/ExecApprovals.swift",
       "source": "Never Ask",
       "surface": "apple",
-      "id": "native.apple.dfcc1c426ab88a0e"
+      "id": "native.apple.feee9ce5c746096b"
     },
     {
       "kind": "conditional-branch",
@@ -18583,7 +18583,7 @@
       "path": "apps/macos/Sources/OpenClaw/ExecApprovals.swift",
       "source": "Ask on Allowlist Miss",
       "surface": "apple",
-      "id": "native.apple.ec72760649c924b5"
+      "id": "native.apple.aa8b4e24f0bfb8b4"
     },
     {
       "kind": "conditional-branch",
@@ -18591,7 +18591,7 @@
       "path": "apps/macos/Sources/OpenClaw/ExecApprovals.swift",
       "source": "Always Ask",
       "surface": "apple",
-      "id": "native.apple.b0c74781683b78cf"
+      "id": "native.apple.6d4f37b9ae9027d3"
     },
     {
       "kind": "conditional-branch",
@@ -18599,7 +18599,7 @@
       "path": "apps/macos/Sources/OpenClaw/ExecApprovals.swift",
       "source": "Pattern cannot be empty.",
       "surface": "apple",
-      "id": "native.apple.dd99db476e298aaa"
+      "id": "native.apple.a46f0710e99df741"
     },
     {
       "kind": "conditional-branch",
@@ -18623,7 +18623,7 @@
       "path": "apps/macos/Sources/OpenClaw/ExecApprovals.swift",
       "source": "Could not save exec approvals. Last known settings are shown; retry the change.",
       "surface": "apple",
-      "id": "native.apple.62972cd07b37a7f7"
+      "id": "native.apple.511333a8588db7e2"
     },
     {
       "kind": "conditional-branch",
@@ -18639,7 +18639,7 @@
       "path": "apps/macos/Sources/OpenClaw/GatewayDiscoveryHelpers.swift",
       "source": ":\\(endpoint.port)",
       "surface": "apple",
-      "id": "native.apple.ac6754d18dc43eba"
+      "id": "native.apple.db0fa6b60bd859f8"
     },
     {
       "kind": "ui-call",
@@ -18647,7 +18647,7 @@
       "path": "apps/macos/Sources/OpenClaw/GatewayDiscoveryMenu.swift",
       "source": "No gateways found yet.",
       "surface": "apple",
-      "id": "native.apple.319879192f9fb125"
+      "id": "native.apple.6867a83813911d74"
     },
     {
       "kind": "conditional-branch",
@@ -18655,7 +18655,7 @@
       "path": "apps/macos/Sources/OpenClaw/GatewayDiscoveryMenu.swift",
       "source": "Click a discovered gateway to fill the gateway URL.",
       "surface": "apple",
-      "id": "native.apple.210e3bb184fa6dfa"
+      "id": "native.apple.08a145c293ac0695"
     },
     {
       "kind": "conditional-branch",
@@ -18663,7 +18663,7 @@
       "path": "apps/macos/Sources/OpenClaw/GatewayDiscoveryMenu.swift",
       "source": "Click a discovered gateway to fill the SSH target.",
       "surface": "apple",
-      "id": "native.apple.ec827387088356de"
+      "id": "native.apple.2a5e0e9e073b8db1"
     },
     {
       "kind": "ui-modifier",
@@ -18671,7 +18671,7 @@
       "path": "apps/macos/Sources/OpenClaw/GatewayDiscoveryMenu.swift",
       "source": "Discover OpenClaw gateways on your LAN",
       "surface": "apple",
-      "id": "native.apple.154a5f838bdc1dcd"
+      "id": "native.apple.66ad783199ef9729"
     },
     {
       "kind": "conditional-branch",
@@ -18695,7 +18695,7 @@
       "path": "apps/macos/Sources/OpenClaw/GatewayProcessManager.swift",
       "source": "Stopped",
       "surface": "apple",
-      "id": "native.apple.cd8f35bf9ab6f81c"
+      "id": "native.apple.f33dc515a78428f1"
     },
     {
       "kind": "conditional-branch",
@@ -18703,7 +18703,7 @@
       "path": "apps/macos/Sources/OpenClaw/GatewayProcessManager.swift",
       "source": "Starting…",
       "surface": "apple",
-      "id": "native.apple.7eb2f61ef34fa19e"
+      "id": "native.apple.1be3e61e52abb0b9"
     },
     {
       "kind": "conditional-branch",
@@ -18711,7 +18711,7 @@
       "path": "apps/macos/Sources/OpenClaw/GatewayProcessManager.swift",
       "source": "Failed: \\(reason)",
       "surface": "apple",
-      "id": "native.apple.8c07081ec85be076"
+      "id": "native.apple.1ae0d775c7fabc51"
     },
     {
       "kind": "conditional-branch",
@@ -18719,7 +18719,7 @@
       "path": "apps/macos/Sources/OpenClaw/GatewayProcessManager.swift",
       "source": "not linked",
       "surface": "apple",
-      "id": "native.apple.d1ad574a4cc83ba0"
+      "id": "native.apple.151e5b5ab7d08a2a"
     },
     {
       "kind": "conditional-branch",
@@ -18735,7 +18735,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "General",
       "surface": "apple",
-      "id": "native.apple.fc628a891fd079f6"
+      "id": "native.apple.7b5eaba753440639"
     },
     {
       "kind": "ui-named-argument",
@@ -18743,7 +18743,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Everyday OpenClaw app behavior.",
       "surface": "apple",
-      "id": "native.apple.76c1df348dd821b2"
+      "id": "native.apple.1c4fca89983d7487"
     },
     {
       "kind": "ui-call",
@@ -18751,7 +18751,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "App",
       "surface": "apple",
-      "id": "native.apple.f2d092bb38ad3da6"
+      "id": "native.apple.7d03158a40ddb60a"
     },
     {
       "kind": "ui-named-argument",
@@ -18759,7 +18759,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Launch at login",
       "surface": "apple",
-      "id": "native.apple.40d19b4daa601e7e"
+      "id": "native.apple.a861b3a0aafb24cc"
     },
     {
       "kind": "conditional-branch",
@@ -18767,7 +18767,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Automatically start OpenClaw after you sign in.",
       "surface": "apple",
-      "id": "native.apple.738cdc07c3539aca"
+      "id": "native.apple.405e74c96498b7c0"
     },
     {
       "kind": "conditional-branch",
@@ -18783,7 +18783,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Show Dock icon",
       "surface": "apple",
-      "id": "native.apple.e96e6ddccf505fdc"
+      "id": "native.apple.927819c087ca3520"
     },
     {
       "kind": "ui-named-argument-multiline",
@@ -18791,7 +18791,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Keep OpenClaw visible in the Dock. When off, windows still show the Dock icon while open.",
       "surface": "apple",
-      "id": "native.apple.8d1a58acc47b52d1"
+      "id": "native.apple.e7a0819bd2f4e1dc"
     },
     {
       "kind": "ui-named-argument",
@@ -18799,7 +18799,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Play menu bar icon animations",
       "surface": "apple",
-      "id": "native.apple.077d3b8ca5c9c84c"
+      "id": "native.apple.af23f7b5fb03a877"
     },
     {
       "kind": "ui-named-argument",
@@ -18807,7 +18807,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Enable idle blinks and wiggles on the status icon.",
       "surface": "apple",
-      "id": "native.apple.9f55e40f3de4df44"
+      "id": "native.apple.bdb0b9020356722a"
     },
     {
       "kind": "ui-call",
@@ -18815,7 +18815,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Capabilities",
       "surface": "apple",
-      "id": "native.apple.30290877cb9f42d6"
+      "id": "native.apple.a66c725f98bfa823"
     },
     {
       "kind": "ui-named-argument",
@@ -18823,7 +18823,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Allow Canvas",
       "surface": "apple",
-      "id": "native.apple.455390ccfb5e6646"
+      "id": "native.apple.1a038afba254784e"
     },
     {
       "kind": "ui-named-argument",
@@ -18831,7 +18831,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Allow the agent to show and control the Canvas panel.",
       "surface": "apple",
-      "id": "native.apple.5d17eedf219bf21d"
+      "id": "native.apple.9044833ccf5370bd"
     },
     {
       "kind": "ui-named-argument",
@@ -18839,7 +18839,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Allow Camera",
       "surface": "apple",
-      "id": "native.apple.a002c697be567239"
+      "id": "native.apple.d272331ace65ddb9"
     },
     {
       "kind": "ui-named-argument",
@@ -18847,7 +18847,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Allow the agent to capture a photo or short video via the built-in camera.",
       "surface": "apple",
-      "id": "native.apple.59cddc9af4db74b3"
+      "id": "native.apple.3aba44d09d7ae354"
     },
     {
       "kind": "ui-named-argument",
@@ -18855,7 +18855,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Allow Computer Control",
       "surface": "apple",
-      "id": "native.apple.35d037749f8e2ffc"
+      "id": "native.apple.6db2112acf394e43"
     },
     {
       "kind": "ui-named-argument-multiline",
@@ -18863,7 +18863,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Let an authorized agent move the pointer, click, and type on this Mac. Also requires Accessibility, Screen Recording, and gateway command authorization. High risk.",
       "surface": "apple",
-      "id": "native.apple.32aeb3a28adb64b2"
+      "id": "native.apple.124d07cfaa03f5e5"
     },
     {
       "kind": "ui-named-argument",
@@ -18871,7 +18871,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Enable Peekaboo Bridge",
       "surface": "apple",
-      "id": "native.apple.bd68de701bd5be0b"
+      "id": "native.apple.35cdb39a1214e0d8"
     },
     {
       "kind": "ui-named-argument",
@@ -18879,7 +18879,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Allow signed tools (e.g. `peekaboo`) to drive UI automation via PeekabooBridge.",
       "surface": "apple",
-      "id": "native.apple.e654f0f2cb9b130f"
+      "id": "native.apple.82e287000e34b51e"
     },
     {
       "kind": "ui-call",
@@ -18919,7 +18919,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Developer",
       "surface": "apple",
-      "id": "native.apple.6e7aa698548c3eb1"
+      "id": "native.apple.476c2358c26250a7"
     },
     {
       "kind": "ui-named-argument",
@@ -18927,7 +18927,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Enable debug tools",
       "surface": "apple",
-      "id": "native.apple.4a5f9e4d4461acac"
+      "id": "native.apple.ac05a7eb1770d52f"
     },
     {
       "kind": "ui-named-argument",
@@ -18935,7 +18935,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Show the Debug page with development utilities.",
       "surface": "apple",
-      "id": "native.apple.3c108670a78dea8e"
+      "id": "native.apple.8ea31fa89ced9a96"
     },
     {
       "kind": "ui-call",
@@ -18943,7 +18943,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "App session",
       "surface": "apple",
-      "id": "native.apple.cea4a676ce240da3"
+      "id": "native.apple.050e1ad36603504f"
     },
     {
       "kind": "ui-call",
@@ -18951,7 +18951,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Quit only when you want to stop the menu bar app completely.",
       "surface": "apple",
-      "id": "native.apple.823b3ed6515ef0a1"
+      "id": "native.apple.67650c4eb108086a"
     },
     {
       "kind": "ui-call",
@@ -18959,7 +18959,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Quit",
       "surface": "apple",
-      "id": "native.apple.28732de42191e235"
+      "id": "native.apple.c8c53e5345460948"
     },
     {
       "kind": "conditional-branch",
@@ -18967,7 +18967,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "OpenClaw paused",
       "surface": "apple",
-      "id": "native.apple.e9d809a3de586f91"
+      "id": "native.apple.64e197a4a8b384ef"
     },
     {
       "kind": "ui-call",
@@ -18975,7 +18975,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "OpenClaw active",
       "surface": "apple",
-      "id": "native.apple.5b090fade239551d"
+      "id": "native.apple.7fe6df69d8050832"
     },
     {
       "kind": "conditional-branch",
@@ -18983,7 +18983,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Processing messages through the local Gateway on this Mac.",
       "surface": "apple",
-      "id": "native.apple.c73f6a502e684640"
+      "id": "native.apple.2f4258fa73e04344"
     },
     {
       "kind": "conditional-branch",
@@ -18991,7 +18991,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Connected to a remote Gateway configuration.",
       "surface": "apple",
-      "id": "native.apple.1c0b83945920fdac"
+      "id": "native.apple.82bbee94fd6c9afd"
     },
     {
       "kind": "conditional-branch",
@@ -18999,7 +18999,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Ready to run after you choose a Gateway connection.",
       "surface": "apple",
-      "id": "native.apple.624832d45328d12d"
+      "id": "native.apple.57c062682e2a1b08"
     },
     {
       "kind": "ui-named-argument",
@@ -19007,7 +19007,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Connection",
       "surface": "apple",
-      "id": "native.apple.e445713e8bf26eb8"
+      "id": "native.apple.eac861e2d1da4745"
     },
     {
       "kind": "ui-named-argument",
@@ -19015,7 +19015,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Choose where the Gateway runs and how this Mac app reaches it.",
       "surface": "apple",
-      "id": "native.apple.573324016158ca02"
+      "id": "native.apple.e23f67caacc93476"
     },
     {
       "kind": "ui-call",
@@ -19023,7 +19023,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "\\(Int(ping)) ms",
       "surface": "apple",
-      "id": "native.apple.a33062fb9adb15c1"
+      "id": "native.apple.8d5db3462778dd6f"
     },
     {
       "kind": "conditional-branch",
@@ -19031,7 +19031,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Local Gateway",
       "surface": "apple",
-      "id": "native.apple.82bc7b126a07a887"
+      "id": "native.apple.886bdf6bcea84209"
     },
     {
       "kind": "conditional-branch",
@@ -19039,7 +19039,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote Gateway direct",
       "surface": "apple",
-      "id": "native.apple.72c7f4b17003d1f0"
+      "id": "native.apple.9a273161518b6d6b"
     },
     {
       "kind": "conditional-branch",
@@ -19047,7 +19047,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote Gateway via SSH",
       "surface": "apple",
-      "id": "native.apple.e8cfae7970353858"
+      "id": "native.apple.72ed757ec4358aed"
     },
     {
       "kind": "conditional-branch",
@@ -19055,7 +19055,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway not configured",
       "surface": "apple",
-      "id": "native.apple.54bc283ddd7c0a7c"
+      "id": "native.apple.11b407abb1de07df"
     },
     {
       "kind": "conditional-branch",
@@ -19063,7 +19063,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "OpenClaw starts and monitors the Gateway on this Mac.",
       "surface": "apple",
-      "id": "native.apple.8a1da5add032f549"
+      "id": "native.apple.8021dcd7963a4cc2"
     },
     {
       "kind": "conditional-branch",
@@ -19071,7 +19071,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Choose local or remote before the app can attach to a Gateway.",
       "surface": "apple",
-      "id": "native.apple.378dd1b31976a5de"
+      "id": "native.apple.fe2a790f28ffd1ae"
     },
     {
       "kind": "ui-call",
@@ -19079,7 +19079,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway",
       "surface": "apple",
-      "id": "native.apple.f8f12521f2e303fd"
+      "id": "native.apple.5d2df8163bd92cde"
     },
     {
       "kind": "ui-named-argument",
@@ -19087,7 +19087,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "OpenClaw runs",
       "surface": "apple",
-      "id": "native.apple.020b57c84c6cba10"
+      "id": "native.apple.d261da13966fa812"
     },
     {
       "kind": "ui-named-argument",
@@ -19095,7 +19095,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Pick whether this app owns a local Gateway or attaches to another host.",
       "surface": "apple",
-      "id": "native.apple.45fa5b9a930a433a"
+      "id": "native.apple.397850fa5e803f53"
     },
     {
       "kind": "ui-call",
@@ -19103,7 +19103,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway location",
       "surface": "apple",
-      "id": "native.apple.34551cf2aabe9c0f"
+      "id": "native.apple.f9b44adeadaace42"
     },
     {
       "kind": "ui-call",
@@ -19111,7 +19111,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Not configured",
       "surface": "apple",
-      "id": "native.apple.be49d17fa62e4357"
+      "id": "native.apple.4bc5101dc5f03eca"
     },
     {
       "kind": "ui-call",
@@ -19119,7 +19119,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Local (this Mac)",
       "surface": "apple",
-      "id": "native.apple.25a89a4b380a1a0b"
+      "id": "native.apple.26d3cba2f28bc7ee"
     },
     {
       "kind": "ui-call",
@@ -19127,7 +19127,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote (another host)",
       "surface": "apple",
-      "id": "native.apple.09331b684283b6f8"
+      "id": "native.apple.e862ce24b922a761"
     },
     {
       "kind": "ui-named-argument",
@@ -19135,7 +19135,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Setup needed",
       "surface": "apple",
-      "id": "native.apple.48cab6619a4b6912"
+      "id": "native.apple.1bd6792ad936d581"
     },
     {
       "kind": "ui-named-argument-multiline",
@@ -19143,7 +19143,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Local is best for this Mac. Remote is best when the Gateway already runs on a Mac Studio or server.",
       "surface": "apple",
-      "id": "native.apple.8ef32dcad8e9f362"
+      "id": "native.apple.f27f32453c7c27aa"
     },
     {
       "kind": "ui-call",
@@ -19151,7 +19151,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote Access",
       "surface": "apple",
-      "id": "native.apple.446cf4d6647903fb"
+      "id": "native.apple.de902001d9e0c2fc"
     },
     {
       "kind": "ui-call",
@@ -19159,7 +19159,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Discovery & Status",
       "surface": "apple",
-      "id": "native.apple.58e546a6f33dbfbe"
+      "id": "native.apple.290d7f86f03d27c5"
     },
     {
       "kind": "ui-call",
@@ -19167,7 +19167,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Nearby gateways",
       "surface": "apple",
-      "id": "native.apple.fd981a60d1154385"
+      "id": "native.apple.df878fd5df528bd9"
     },
     {
       "kind": "ui-named-argument",
@@ -19175,7 +19175,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Remote test",
       "surface": "apple",
-      "id": "native.apple.3fa97c86fdfce8da"
+      "id": "native.apple.95028d5447df11e0"
     },
     {
       "kind": "ui-named-argument",
@@ -19183,7 +19183,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Control channel",
       "surface": "apple",
-      "id": "native.apple.1701c60e6218e664"
+      "id": "native.apple.cff94f13853364c2"
     },
     {
       "kind": "ui-named-argument",
@@ -19191,7 +19191,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Recommended setup",
       "surface": "apple",
-      "id": "native.apple.a6cc91ac26900fbc"
+      "id": "native.apple.b28d766383f819ce"
     },
     {
       "kind": "conditional-branch",
@@ -19199,7 +19199,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "surface": "apple",
-      "id": "native.apple.149fedda0985cd49"
+      "id": "native.apple.5eebc911fb011a34"
     },
     {
       "kind": "conditional-branch",
@@ -19207,7 +19207,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
       "surface": "apple",
-      "id": "native.apple.b9aa4a81e9d4f2e6"
+      "id": "native.apple.ff5020c25b825be3"
     },
     {
       "kind": "ui-call",
@@ -19215,7 +19215,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Advanced",
       "surface": "apple",
-      "id": "native.apple.ccfc1bf47f888c87"
+      "id": "native.apple.773d2937062cf86c"
     },
     {
       "kind": "ui-call",
@@ -19223,7 +19223,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Identity file",
       "surface": "apple",
-      "id": "native.apple.3cd8cb72a11d382d"
+      "id": "native.apple.2e33f01115fd73dd"
     },
     {
       "kind": "ui-named-argument",
@@ -19231,7 +19231,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "/Users/you/.ssh/id_ed25519",
       "surface": "apple",
-      "id": "native.apple.df5a12307af219d8"
+      "id": "native.apple.5eaffd822af43300"
     },
     {
       "kind": "ui-call",
@@ -19239,7 +19239,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Project root",
       "surface": "apple",
-      "id": "native.apple.95d0ec1ae70efc36"
+      "id": "native.apple.8bd4eccc71e5668f"
     },
     {
       "kind": "ui-named-argument",
@@ -19247,7 +19247,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "/home/you/Projects/openclaw",
       "surface": "apple",
-      "id": "native.apple.d149fdc6d1146a8d"
+      "id": "native.apple.c663b8a50de8a7d8"
     },
     {
       "kind": "ui-call",
@@ -19255,7 +19255,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "CLI path",
       "surface": "apple",
-      "id": "native.apple.03a35bd626e99a93"
+      "id": "native.apple.938ee646aac4ce66"
     },
     {
       "kind": "ui-named-argument",
@@ -19263,7 +19263,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "/Applications/OpenClaw.app/.../openclaw",
       "surface": "apple",
-      "id": "native.apple.dcfa754168e437b2"
+      "id": "native.apple.09f99e863e081f9f"
     },
     {
       "kind": "ui-call",
@@ -19271,7 +19271,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "SSH command details",
       "surface": "apple",
-      "id": "native.apple.1b864ea7d1795466"
+      "id": "native.apple.f588f7dad51aae2e"
     },
     {
       "kind": "ui-named-argument",
@@ -19279,7 +19279,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Transport",
       "surface": "apple",
-      "id": "native.apple.1d34bf122d97303e"
+      "id": "native.apple.a04182cfc2292a90"
     },
     {
       "kind": "ui-named-argument",
@@ -19287,7 +19287,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "SSH keeps the Gateway private; direct is best for HTTPS or Tailscale Serve.",
       "surface": "apple",
-      "id": "native.apple.006fc27e5e8f68ba"
+      "id": "native.apple.0b3bf35360212894"
     },
     {
       "kind": "ui-call",
@@ -19295,7 +19295,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "SSH tunnel",
       "surface": "apple",
-      "id": "native.apple.b5281c3252a88ea6"
+      "id": "native.apple.5120bd84625c827a"
     },
     {
       "kind": "ui-call",
@@ -19303,7 +19303,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Direct (ws/wss)",
       "surface": "apple",
-      "id": "native.apple.96950c9ecb874bc6"
+      "id": "native.apple.c58937e43a5b4591"
     },
     {
       "kind": "ui-named-argument",
@@ -19311,7 +19311,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "SSH target",
       "surface": "apple",
-      "id": "native.apple.2d49cb855c4aa5ad"
+      "id": "native.apple.655c71a562ce5ecb"
     },
     {
       "kind": "ui-named-argument",
@@ -19319,7 +19319,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "User and host for the remote Gateway machine.",
       "surface": "apple",
-      "id": "native.apple.8a395366d92d72a0"
+      "id": "native.apple.feced5a9b26f7437"
     },
     {
       "kind": "ui-named-argument",
@@ -19327,7 +19327,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway URL",
       "surface": "apple",
-      "id": "native.apple.9744cdf68f13c005"
+      "id": "native.apple.5dbab4c147041b65"
     },
     {
       "kind": "ui-named-argument",
@@ -19335,7 +19335,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "The WebSocket URL exposed by the remote Gateway.",
       "surface": "apple",
-      "id": "native.apple.a69538465d9ec7c3"
+      "id": "native.apple.fe7e313b29c88daa"
     },
     {
       "kind": "ui-call",
@@ -19343,7 +19343,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "wss://gateway.example.ts.net",
       "surface": "apple",
-      "id": "native.apple.798aab93ee1e1513"
+      "id": "native.apple.a8d207eec188d22d"
     },
     {
       "kind": "ui-call",
@@ -19351,7 +19351,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Use wss:// for public hosts. ws:// is allowed for localhost, LAN, .local, and Tailnet hosts.",
       "surface": "apple",
-      "id": "native.apple.204fe478872a2b4f"
+      "id": "native.apple.e568ae49d007dc03"
     },
     {
       "kind": "ui-named-argument",
@@ -19359,7 +19359,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway token",
       "surface": "apple",
-      "id": "native.apple.341b05ac99ff5ba6"
+      "id": "native.apple.e3ff06b581e72632"
     },
     {
       "kind": "ui-named-argument",
@@ -19367,7 +19367,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Used when the remote gateway requires token auth.",
       "surface": "apple",
-      "id": "native.apple.77ae2826c3ca67b0"
+      "id": "native.apple.6e9b05c98cb09528"
     },
     {
       "kind": "ui-call",
@@ -19375,7 +19375,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "remote gateway auth token (gateway.remote.token)",
       "surface": "apple",
-      "id": "native.apple.a0be5d50345e05ed"
+      "id": "native.apple.053a95077f2d4045"
     },
     {
       "kind": "ui-call-concatenated",
@@ -19383,7 +19383,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "The current gateway.remote.token value is not plain text. OpenClaw for macOS cannot use it directly; enter a plaintext token here to replace it.",
       "surface": "apple",
-      "id": "native.apple.333f0cbf7e54578e"
+      "id": "native.apple.24aa092829f9a3b1"
     },
     {
       "kind": "ui-call",
@@ -19391,7 +19391,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Test remote",
       "surface": "apple",
-      "id": "native.apple.646f8265d3454fde"
+      "id": "native.apple.d0b21bc12ab63cad"
     },
     {
       "kind": "ui-call",
@@ -19399,7 +19399,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Testing…",
       "surface": "apple",
-      "id": "native.apple.8485969ebb3c71b0"
+      "id": "native.apple.5e3968d04d63200c"
     },
     {
       "kind": "ui-call",
@@ -19407,7 +19407,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Installed: \\(gatewayVersion) · Required: \\(required)",
       "surface": "apple",
-      "id": "native.apple.177dd2f4ffab4228"
+      "id": "native.apple.9ff8bc297026d7cb"
     },
     {
       "kind": "ui-call",
@@ -19415,7 +19415,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway \\(gatewayVersion) detected",
       "surface": "apple",
-      "id": "native.apple.d710fd743785f90b"
+      "id": "native.apple.6a9514b81425ea1d"
     },
     {
       "kind": "ui-call",
@@ -19423,7 +19423,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Node \\(node)",
       "surface": "apple",
-      "id": "native.apple.65c1fb3df7e06af3"
+      "id": "native.apple.4593770894a0b662"
     },
     {
       "kind": "ui-call",
@@ -19431,7 +19431,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Last failure: \\(failure)",
       "surface": "apple",
-      "id": "native.apple.72451cf1de112d7f"
+      "id": "native.apple.50ab01059b763acd"
     },
     {
       "kind": "ui-call",
@@ -19439,7 +19439,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Recheck",
       "surface": "apple",
-      "id": "native.apple.4812a491527bfb17"
+      "id": "native.apple.c55734a4ee849a4c"
     },
     {
       "kind": "ui-call",
@@ -19447,7 +19447,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway auto-starts in local mode via launchd (\\(gatewayLaunchdLabel)).",
       "surface": "apple",
-      "id": "native.apple.0b01d45bfe76884d"
+      "id": "native.apple.8fcaa10d4558a03d"
     },
     {
       "kind": "ui-call",
@@ -19455,7 +19455,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Retry now",
       "surface": "apple",
-      "id": "native.apple.63ecf66b9ebc3302"
+      "id": "native.apple.7a4bfb585fed2598"
     },
     {
       "kind": "ui-call",
@@ -19463,7 +19463,7 @@
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Open logs",
       "surface": "apple",
-      "id": "native.apple.7f95e19b6b944ba6"
+      "id": "native.apple.6393591d17837eb0"
     },
     {
       "kind": "conditional-branch",
@@ -19471,7 +19471,7 @@
       "path": "apps/macos/Sources/OpenClaw/HealthStore.swift",
       "source": "probe degraded",
       "surface": "apple",
-      "id": "native.apple.91ae5bf0c612f83c"
+      "id": "native.apple.4d96b20de25a9ddf"
     },
     {
       "kind": "conditional-branch",
@@ -19479,7 +19479,7 @@
       "path": "apps/macos/Sources/OpenClaw/HealthStore.swift",
       "source": "probe degraded · status \\(status)",
       "surface": "apple",
-      "id": "native.apple.e07ed281690bdeb1"
+      "id": "native.apple.4c7be809a4a75de5"
     },
     {
       "kind": "conditional-branch",
@@ -19487,7 +19487,7 @@
       "path": "apps/macos/Sources/OpenClaw/IconState.swift",
       "source": "System (auto)",
       "surface": "apple",
-      "id": "native.apple.4337b8c51d321980"
+      "id": "native.apple.b71cafd438433073"
     },
     {
       "kind": "conditional-branch",
@@ -19495,7 +19495,7 @@
       "path": "apps/macos/Sources/OpenClaw/IconState.swift",
       "source": "Idle",
       "surface": "apple",
-      "id": "native.apple.8b105a2a0875b01f"
+      "id": "native.apple.41a193b83852fbf9"
     },
     {
       "kind": "conditional-branch",
@@ -19503,7 +19503,7 @@
       "path": "apps/macos/Sources/OpenClaw/IconState.swift",
       "source": "Working main – bash",
       "surface": "apple",
-      "id": "native.apple.3cb2f76afb99cc29"
+      "id": "native.apple.71196aeed6421e87"
     },
     {
       "kind": "conditional-branch",
@@ -19511,7 +19511,7 @@
       "path": "apps/macos/Sources/OpenClaw/IconState.swift",
       "source": "Working main – read",
       "surface": "apple",
-      "id": "native.apple.26aed51b6cf47d35"
+      "id": "native.apple.4b5ed94600721e7d"
     },
     {
       "kind": "conditional-branch",
@@ -19519,7 +19519,7 @@
       "path": "apps/macos/Sources/OpenClaw/IconState.swift",
       "source": "Working main – write",
       "surface": "apple",
-      "id": "native.apple.33c20ee58341f044"
+      "id": "native.apple.cb8ea16eac409225"
     },
     {
       "kind": "conditional-branch",
@@ -19527,7 +19527,7 @@
       "path": "apps/macos/Sources/OpenClaw/IconState.swift",
       "source": "Working main – edit",
       "surface": "apple",
-      "id": "native.apple.5dab24519ea2ac5b"
+      "id": "native.apple.4eee079c9e883a4c"
     },
     {
       "kind": "conditional-branch",
@@ -19535,7 +19535,7 @@
       "path": "apps/macos/Sources/OpenClaw/IconState.swift",
       "source": "Working main – other",
       "surface": "apple",
-      "id": "native.apple.e519ba15367ceb00"
+      "id": "native.apple.f9923af586dbd6c6"
     },
     {
       "kind": "conditional-branch",
@@ -19543,7 +19543,7 @@
       "path": "apps/macos/Sources/OpenClaw/IconState.swift",
       "source": "Working other – bash",
       "surface": "apple",
-      "id": "native.apple.3903fa17d9a05a81"
+      "id": "native.apple.fb68dca095076425"
     },
     {
       "kind": "conditional-branch",
@@ -19551,7 +19551,7 @@
       "path": "apps/macos/Sources/OpenClaw/IconState.swift",
       "source": "Working other – read",
       "surface": "apple",
-      "id": "native.apple.97a369eac52aee6b"
+      "id": "native.apple.6b742d3ef334effa"
     },
     {
       "kind": "conditional-branch",
@@ -19559,7 +19559,7 @@
       "path": "apps/macos/Sources/OpenClaw/IconState.swift",
       "source": "Working other – write",
       "surface": "apple",
-      "id": "native.apple.d46c178f62c10355"
+      "id": "native.apple.33041a8417e0c1c9"
     },
     {
       "kind": "conditional-branch",
@@ -19567,7 +19567,7 @@
       "path": "apps/macos/Sources/OpenClaw/IconState.swift",
       "source": "Working other – edit",
       "surface": "apple",
-      "id": "native.apple.2cff0185068bea0d"
+      "id": "native.apple.5cfc973ba627e3ac"
     },
     {
       "kind": "conditional-branch",
@@ -19575,7 +19575,7 @@
       "path": "apps/macos/Sources/OpenClaw/IconState.swift",
       "source": "Working other – other",
       "surface": "apple",
-      "id": "native.apple.808a1acb132a7474"
+      "id": "native.apple.01aaae29e90965d8"
     },
     {
       "kind": "ui-call",
@@ -19583,7 +19583,7 @@
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "Error: \\(err)",
       "surface": "apple",
-      "id": "native.apple.e880546b24a30d7f"
+      "id": "native.apple.729f356a45366d00"
     },
     {
       "kind": "ui-call",
@@ -19591,7 +19591,7 @@
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "No instances reported yet.",
       "surface": "apple",
-      "id": "native.apple.123db058e1a3f288"
+      "id": "native.apple.766ddaa931c544df"
     },
     {
       "kind": "ui-call",
@@ -19599,7 +19599,7 @@
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "Connected Instances",
       "surface": "apple",
-      "id": "native.apple.c3258589233be7ab"
+      "id": "native.apple.c04316f1c7e825c9"
     },
     {
       "kind": "ui-call",
@@ -19607,7 +19607,7 @@
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "Latest presence beacons from OpenClaw nodes. Updated periodically.",
       "surface": "apple",
-      "id": "native.apple.1c2e64bd2112e266"
+      "id": "native.apple.876c066efa88aee3"
     },
     {
       "kind": "ui-named-argument",
@@ -19615,7 +19615,7 @@
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "\\(device.title) · \\(prettyPlatform)",
       "surface": "apple",
-      "id": "native.apple.ae82f8548372aeea"
+      "id": "native.apple.8a6bcd51fd9f1f62"
     },
     {
       "kind": "ui-named-argument",
@@ -19623,7 +19623,7 @@
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "\\(secs)s ago",
       "surface": "apple",
-      "id": "native.apple.b335572316a0d501"
+      "id": "native.apple.775418faaf244b72"
     },
     {
       "kind": "ui-call",
@@ -19631,7 +19631,7 @@
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "Copy Debug Summary",
       "surface": "apple",
-      "id": "native.apple.6962a33e7bf6d24d"
+      "id": "native.apple.d49a2a06f0b30967"
     },
     {
       "kind": "ui-modifier",
@@ -19639,7 +19639,7 @@
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "Presence updated \\(inst.ageDescription).",
       "surface": "apple",
-      "id": "native.apple.f8bef683f596096a"
+      "id": "native.apple.231b8e86486fd129"
     },
     {
       "kind": "ui-modifier",
@@ -19647,7 +19647,7 @@
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "\\(status.label) presence",
       "surface": "apple",
-      "id": "native.apple.c48950fcf4e4ee95"
+      "id": "native.apple.12d83e5f01c98fc0"
     },
     {
       "kind": "ui-named-argument",
@@ -19655,7 +19655,7 @@
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "Android",
       "surface": "apple",
-      "id": "native.apple.bdb8d0c0a3e3358f"
+      "id": "native.apple.ee499f632a5076c5"
     },
     {
       "kind": "ui-named-argument",
@@ -19663,7 +19663,7 @@
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "Sparkles",
       "surface": "apple",
-      "id": "native.apple.f3561daffa0bc556"
+      "id": "native.apple.57ca2baac54a05fc"
     },
     {
       "kind": "ui-named-argument",
@@ -19671,7 +19671,7 @@
       "path": "apps/macos/Sources/OpenClaw/InstancesSettings.swift",
       "source": "Plain",
       "surface": "apple",
-      "id": "native.apple.4ae3d7db5fa4b5a5"
+      "id": "native.apple.c9a63d0f5247185d"
     },
     {
       "kind": "conditional-branch",
@@ -19679,7 +19679,7 @@
       "path": "apps/macos/Sources/OpenClaw/Logging/OpenClawLogging.swift",
       "source": "Trace",
       "surface": "apple",
-      "id": "native.apple.a14ab15b55339391"
+      "id": "native.apple.3f4378c2de189ec9"
     },
     {
       "kind": "conditional-branch",
@@ -19687,7 +19687,7 @@
       "path": "apps/macos/Sources/OpenClaw/Logging/OpenClawLogging.swift",
       "source": "Debug",
       "surface": "apple",
-      "id": "native.apple.b9ea54141e7aced5"
+      "id": "native.apple.abc6d01481fe6ab5"
     },
     {
       "kind": "conditional-branch",
@@ -19695,7 +19695,7 @@
       "path": "apps/macos/Sources/OpenClaw/Logging/OpenClawLogging.swift",
       "source": "Info",
       "surface": "apple",
-      "id": "native.apple.a26609efc4e730be"
+      "id": "native.apple.284419a69ba9e608"
     },
     {
       "kind": "conditional-branch",
@@ -19703,7 +19703,7 @@
       "path": "apps/macos/Sources/OpenClaw/Logging/OpenClawLogging.swift",
       "source": "Notice",
       "surface": "apple",
-      "id": "native.apple.284f3ae6af29b0ad"
+      "id": "native.apple.ca37d4d419889d09"
     },
     {
       "kind": "conditional-branch",
@@ -19711,7 +19711,7 @@
       "path": "apps/macos/Sources/OpenClaw/Logging/OpenClawLogging.swift",
       "source": "Warning",
       "surface": "apple",
-      "id": "native.apple.707ae81c9d6d4b34"
+      "id": "native.apple.078501e974c7bb15"
     },
     {
       "kind": "conditional-branch",
@@ -19719,7 +19719,7 @@
       "path": "apps/macos/Sources/OpenClaw/Logging/OpenClawLogging.swift",
       "source": "Error",
       "surface": "apple",
-      "id": "native.apple.a4da1aa6a65fdc88"
+      "id": "native.apple.ee2ad2d2d6e65813"
     },
     {
       "kind": "conditional-branch",
@@ -19727,7 +19727,7 @@
       "path": "apps/macos/Sources/OpenClaw/Logging/OpenClawLogging.swift",
       "source": "Critical",
       "surface": "apple",
-      "id": "native.apple.331ef50368eeb6ff"
+      "id": "native.apple.01e6a456cdadce81"
     },
     {
       "kind": "ui-call",
@@ -19735,7 +19735,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Settings...",
       "surface": "apple",
-      "id": "native.apple.832e6653badf8e20"
+      "id": "native.apple.185a1b27c9859cc0"
     },
     {
       "kind": "ui-call",
@@ -19759,7 +19759,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "OpenClaw - Voice Wake live meter active",
       "surface": "apple",
-      "id": "native.apple.c8c910234d1b2ab8"
+      "id": "native.apple.13a7356f48278757"
     },
     {
       "kind": "conditional-branch",
@@ -19767,7 +19767,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "OpenClaw",
       "surface": "apple",
-      "id": "native.apple.c463c0849cb4242c"
+      "id": "native.apple.fae2cf18519da0d5"
     },
     {
       "kind": "conditional-branch",
@@ -19775,7 +19775,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Close Canvas",
       "surface": "apple",
-      "id": "native.apple.aed2d2e92fef765d"
+      "id": "native.apple.ef59188264be95d4"
     },
     {
       "kind": "conditional-branch",
@@ -19783,7 +19783,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Open Canvas",
       "surface": "apple",
-      "id": "native.apple.a7d381352bd74739"
+      "id": "native.apple.9559a5e927db06c0"
     },
     {
       "kind": "ui-named-argument",
@@ -19791,7 +19791,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Pairing approval pending (\\(self.pairingPrompter.pendingCount))",
       "surface": "apple",
-      "id": "native.apple.c38740d20747ba27"
+      "id": "native.apple.66280f3e99ab2f36"
     },
     {
       "kind": "conditional-branch",
@@ -19799,7 +19799,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": " · \\(repairCount) repair",
       "surface": "apple",
-      "id": "native.apple.76afe883a5389900"
+      "id": "native.apple.e47f5616f3dae081"
     },
     {
       "kind": "ui-named-argument",
@@ -19807,7 +19807,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Device pairing pending (\\(self.devicePairingPrompter.pendingCount))\\(repairSuffix)",
       "surface": "apple",
-      "id": "native.apple.5a20d9c055ab4af8"
+      "id": "native.apple.166030936b7fae68"
     },
     {
       "kind": "ui-call",
@@ -19815,7 +19815,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Send Heartbeats",
       "surface": "apple",
-      "id": "native.apple.cd838d022aa510b1"
+      "id": "native.apple.4362f273c3b52793"
     },
     {
       "kind": "ui-call",
@@ -19823,7 +19823,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Browser Control",
       "surface": "apple",
-      "id": "native.apple.6808738b29288c78"
+      "id": "native.apple.2ad22b3ef37afe46"
     },
     {
       "kind": "ui-call",
@@ -19831,7 +19831,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Allow Camera",
       "surface": "apple",
-      "id": "native.apple.c10db6e03522f769"
+      "id": "native.apple.eb06374f7d430549"
     },
     {
       "kind": "ui-call",
@@ -19839,7 +19839,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Exec Approvals",
       "surface": "apple",
-      "id": "native.apple.ddc44cd39d2f7ca9"
+      "id": "native.apple.a7298f07a717f564"
     },
     {
       "kind": "ui-call",
@@ -19847,7 +19847,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Loading Exec Approvals…",
       "surface": "apple",
-      "id": "native.apple.567cb7a37e7d8143"
+      "id": "native.apple.348d4adeb2afab25"
     },
     {
       "kind": "ui-call",
@@ -19855,7 +19855,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Retry Exec Approvals",
       "surface": "apple",
-      "id": "native.apple.9a0b3343ce35cee7"
+      "id": "native.apple.b2f5f038c81a4a89"
     },
     {
       "kind": "ui-call",
@@ -19863,7 +19863,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Allow Canvas",
       "surface": "apple",
-      "id": "native.apple.099122b656be2993"
+      "id": "native.apple.fa9ee90b4a391979"
     },
     {
       "kind": "ui-call",
@@ -19871,7 +19871,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Voice Wake",
       "surface": "apple",
-      "id": "native.apple.c17cd79eb5342242"
+      "id": "native.apple.4cbde322496c96d7"
     },
     {
       "kind": "ui-call",
@@ -19879,7 +19879,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Dashboard",
       "surface": "apple",
-      "id": "native.apple.7b3ebf1cd2bb5628"
+      "id": "native.apple.95959926dc363f2e"
     },
     {
       "kind": "ui-call",
@@ -19887,7 +19887,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Chat",
       "surface": "apple",
-      "id": "native.apple.f010e8bfc29c7136"
+      "id": "native.apple.723e0d2283af1458"
     },
     {
       "kind": "conditional-branch",
@@ -19895,7 +19895,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Close Canvas",
       "surface": "apple",
-      "id": "native.apple.b2c500c88847a18b"
+      "id": "native.apple.5e3cd7734f27f447"
     },
     {
       "kind": "conditional-branch",
@@ -19903,7 +19903,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Canvas",
       "surface": "apple",
-      "id": "native.apple.47e7106aab2624ce"
+      "id": "native.apple.2a9ba12370118594"
     },
     {
       "kind": "conditional-branch",
@@ -19911,7 +19911,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Stop Talk Mode",
       "surface": "apple",
-      "id": "native.apple.8d434c066c97089d"
+      "id": "native.apple.6c543df49aa45eef"
     },
     {
       "kind": "conditional-branch",
@@ -19919,7 +19919,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Talk Mode",
       "surface": "apple",
-      "id": "native.apple.b9fd20376beb78d2"
+      "id": "native.apple.f829a2e0409193b6"
     },
     {
       "kind": "ui-call",
@@ -19927,7 +19927,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Settings…",
       "surface": "apple",
-      "id": "native.apple.611c2cf487f4b4e0"
+      "id": "native.apple.e96f53fc66acbb95"
     },
     {
       "kind": "ui-call",
@@ -19935,7 +19935,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "About OpenClaw",
       "surface": "apple",
-      "id": "native.apple.4f087c4a5c95a11c"
+      "id": "native.apple.fbab65790d6eca89"
     },
     {
       "kind": "ui-call",
@@ -19943,7 +19943,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Update ready, restart now?",
       "surface": "apple",
-      "id": "native.apple.7c5e2ed864a3d77e"
+      "id": "native.apple.14c8f4b1a57569f3"
     },
     {
       "kind": "ui-call",
@@ -19951,7 +19951,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Quit",
       "surface": "apple",
-      "id": "native.apple.08c50ff254ac2d62"
+      "id": "native.apple.f20b8f0da1520f4b"
     },
     {
       "kind": "conditional-branch",
@@ -19959,7 +19959,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "OpenClaw Not Configured",
       "surface": "apple",
-      "id": "native.apple.9d051748e2c10422"
+      "id": "native.apple.5021ed413c045620"
     },
     {
       "kind": "conditional-branch",
@@ -19967,7 +19967,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Remote OpenClaw Active",
       "surface": "apple",
-      "id": "native.apple.5d24c331c2277614"
+      "id": "native.apple.4d10ab5feb4add3f"
     },
     {
       "kind": "conditional-branch",
@@ -19975,7 +19975,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "OpenClaw Active",
       "surface": "apple",
-      "id": "native.apple.fd36a99642534de1"
+      "id": "native.apple.b49dea5c1fdb3dd3"
     },
     {
       "kind": "ui-call",
@@ -19983,7 +19983,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Debug",
       "surface": "apple",
-      "id": "native.apple.b26a1a083c2e06fa"
+      "id": "native.apple.1df24a30d7963640"
     },
     {
       "kind": "ui-call",
@@ -19991,7 +19991,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Config Folder",
       "surface": "apple",
-      "id": "native.apple.39ca4998055aec22"
+      "id": "native.apple.24b2a8b6549236c4"
     },
     {
       "kind": "ui-call",
@@ -19999,7 +19999,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Run Health Check Now",
       "surface": "apple",
-      "id": "native.apple.7850bf7baae21550"
+      "id": "native.apple.bb94be83a9083e18"
     },
     {
       "kind": "ui-call",
@@ -20007,7 +20007,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Send Test Heartbeat",
       "surface": "apple",
-      "id": "native.apple.a389789475e5dff8"
+      "id": "native.apple.406f1a5866bf0bd0"
     },
     {
       "kind": "ui-call",
@@ -20015,7 +20015,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Show Pairing Panel (Demo)",
       "surface": "apple",
-      "id": "native.apple.d8fdac3676b02326"
+      "id": "native.apple.79a6d2d396cd5477"
     },
     {
       "kind": "ui-named-argument",
@@ -20023,7 +20023,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Remote Tunnel",
       "surface": "apple",
-      "id": "native.apple.72b41fc08d1ea566"
+      "id": "native.apple.5e9ea5d8470d105a"
     },
     {
       "kind": "ui-call",
@@ -20031,7 +20031,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Reset Remote Tunnel",
       "surface": "apple",
-      "id": "native.apple.48ba1ccb1bc4b3ab"
+      "id": "native.apple.872bee8f298e59ef"
     },
     {
       "kind": "conditional-branch",
@@ -20039,7 +20039,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Verbose Logging (Main): On",
       "surface": "apple",
-      "id": "native.apple.4b94f2526090962a"
+      "id": "native.apple.e9868e7cdc856b06"
     },
     {
       "kind": "conditional-branch",
@@ -20047,7 +20047,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Verbose Logging (Main): Off",
       "surface": "apple",
-      "id": "native.apple.071399dac3dff54a"
+      "id": "native.apple.a03ddd3d711b5a36"
     },
     {
       "kind": "ui-call",
@@ -20055,7 +20055,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Verbosity",
       "surface": "apple",
-      "id": "native.apple.2a485d8d8baa5270"
+      "id": "native.apple.ecde91c32bcc0da5"
     },
     {
       "kind": "conditional-branch",
@@ -20063,7 +20063,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "File Logging: On",
       "surface": "apple",
-      "id": "native.apple.b5e63c3328ab8122"
+      "id": "native.apple.4f577b502efb658c"
     },
     {
       "kind": "conditional-branch",
@@ -20071,7 +20071,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "File Logging: Off",
       "surface": "apple",
-      "id": "native.apple.7e117eb03928127a"
+      "id": "native.apple.b0785f8c2ae712ff"
     },
     {
       "kind": "ui-call",
@@ -20079,7 +20079,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "App Logging",
       "surface": "apple",
-      "id": "native.apple.b743dbc0d4287bd7"
+      "id": "native.apple.f9dfd69b4f83afa1"
     },
     {
       "kind": "ui-call",
@@ -20087,7 +20087,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Session Store",
       "surface": "apple",
-      "id": "native.apple.224af928511c3cd8"
+      "id": "native.apple.0627f0cfb40a10c8"
     },
     {
       "kind": "ui-call",
@@ -20095,7 +20095,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Agent Events…",
       "surface": "apple",
-      "id": "native.apple.dea4e367762f3176"
+      "id": "native.apple.645ddb678c201ac8"
     },
     {
       "kind": "ui-call",
@@ -20103,7 +20103,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Open Log",
       "surface": "apple",
-      "id": "native.apple.afc402901f4d986f"
+      "id": "native.apple.c8cb59f8c2e28468"
     },
     {
       "kind": "ui-call",
@@ -20111,7 +20111,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Send Debug Voice Text",
       "surface": "apple",
-      "id": "native.apple.533afe6a6ec71238"
+      "id": "native.apple.aba07ae46ea14d1e"
     },
     {
       "kind": "ui-call",
@@ -20119,7 +20119,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Send Test Notification",
       "surface": "apple",
-      "id": "native.apple.dc56248f6a24a860"
+      "id": "native.apple.2d85e94cb51ec35c"
     },
     {
       "kind": "ui-call",
@@ -20127,7 +20127,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Restart Gateway",
       "surface": "apple",
-      "id": "native.apple.a4ebd9afec6f8fd1"
+      "id": "native.apple.0f9e668602baf391"
     },
     {
       "kind": "ui-call",
@@ -20135,7 +20135,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Restart Onboarding",
       "surface": "apple",
-      "id": "native.apple.97d65b820852ca13"
+      "id": "native.apple.ed98a6c0df41cdde"
     },
     {
       "kind": "ui-call",
@@ -20143,7 +20143,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Restart App",
       "surface": "apple",
-      "id": "native.apple.14a8a7593116f708"
+      "id": "native.apple.2ebeecbd1b177e61"
     },
     {
       "kind": "conditional-branch",
@@ -20151,7 +20151,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Main",
       "surface": "apple",
-      "id": "native.apple.65edb1ee08ee7d2f"
+      "id": "native.apple.3cef985bef918988"
     },
     {
       "kind": "conditional-branch",
@@ -20159,7 +20159,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Other",
       "surface": "apple",
-      "id": "native.apple.cee824dbf4d5515e"
+      "id": "native.apple.5eca63e1a931e290"
     },
     {
       "kind": "ui-modifier",
@@ -20167,7 +20167,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Show pairing requests",
       "surface": "apple",
-      "id": "native.apple.85c8fe408312fdea"
+      "id": "native.apple.72d7e38d56c76ff8"
     },
     {
       "kind": "ui-call",
@@ -20175,7 +20175,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Refreshing microphones…",
       "surface": "apple",
-      "id": "native.apple.93e493a9c625590c"
+      "id": "native.apple.469c920582755860"
     },
     {
       "kind": "ui-call",
@@ -20183,7 +20183,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Microphone",
       "surface": "apple",
-      "id": "native.apple.d42b81d507e74489"
+      "id": "native.apple.c0c6172187ca749a"
     },
     {
       "kind": "ui-call",
@@ -20191,7 +20191,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Disconnected (using System default)",
       "surface": "apple",
-      "id": "native.apple.57d3ac59060048c3"
+      "id": "native.apple.3e248379359c7593"
     },
     {
       "kind": "conditional-branch",
@@ -20207,7 +20207,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsHeaderView.swift",
       "source": "Context",
       "surface": "apple",
-      "id": "native.apple.18047394f8bcdf4e"
+      "id": "native.apple.5a99e1ae62fe0ab9"
     },
     {
       "kind": "conditional-branch",
@@ -20215,7 +20215,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Loading devices...",
       "surface": "apple",
-      "id": "native.apple.4cbca38a8dccdf77"
+      "id": "native.apple.71d571a51fc1dd07"
     },
     {
       "kind": "conditional-branch",
@@ -20223,7 +20223,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "No devices yet",
       "surface": "apple",
-      "id": "native.apple.34d79b94dde63370"
+      "id": "native.apple.1b885476267aec98"
     },
     {
       "kind": "conditional-branch",
@@ -20231,7 +20231,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "No",
       "surface": "apple",
-      "id": "native.apple.6fb6152078955a6a"
+      "id": "native.apple.88ac623ee1a9929a"
     },
     {
       "kind": "conditional-branch",
@@ -20239,7 +20239,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Yes",
       "surface": "apple",
-      "id": "native.apple.620b6a509e8ca909"
+      "id": "native.apple.7782c047f2f09120"
     },
     {
       "kind": "ui-named-argument",
@@ -20247,7 +20247,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Update thinking failed",
       "surface": "apple",
-      "id": "native.apple.6c93278ef4b22f19"
+      "id": "native.apple.c847ab5573bcbc26"
     },
     {
       "kind": "ui-named-argument",
@@ -20255,7 +20255,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Update verbose failed",
       "surface": "apple",
-      "id": "native.apple.2cf1c47995829999"
+      "id": "native.apple.4e45d5ed653259d1"
     },
     {
       "kind": "ui-named-argument",
@@ -20263,7 +20263,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Reset session?",
       "surface": "apple",
-      "id": "native.apple.412f037bfcccc1cf"
+      "id": "native.apple.675bea191c16ad31"
     },
     {
       "kind": "ui-named-argument",
@@ -20271,7 +20271,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Starts a new session id for “\\(key)”.",
       "surface": "apple",
-      "id": "native.apple.ce1a5cf971cdf846"
+      "id": "native.apple.e63cf5e18950a31a"
     },
     {
       "kind": "ui-named-argument",
@@ -20279,7 +20279,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Reset failed",
       "surface": "apple",
-      "id": "native.apple.f7858ff8d1ec8153"
+      "id": "native.apple.bc784754f0d1bdda"
     },
     {
       "kind": "ui-named-argument",
@@ -20287,7 +20287,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Compact session log?",
       "surface": "apple",
-      "id": "native.apple.4cda7e3ea8279e7b"
+      "id": "native.apple.f01b4b170022c829"
     },
     {
       "kind": "ui-named-argument",
@@ -20295,7 +20295,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Keeps the last 400 lines; archives the old file.",
       "surface": "apple",
-      "id": "native.apple.e5e4c273e81aa51f"
+      "id": "native.apple.0665671dadf0d19a"
     },
     {
       "kind": "ui-named-argument",
@@ -20303,7 +20303,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Compact failed",
       "surface": "apple",
-      "id": "native.apple.a10b72974b739b6a"
+      "id": "native.apple.8446ea98af8411a0"
     },
     {
       "kind": "ui-named-argument",
@@ -20311,7 +20311,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Delete session?",
       "surface": "apple",
-      "id": "native.apple.ee11e91136f366b3"
+      "id": "native.apple.bbe5d1663b0933b5"
     },
     {
       "kind": "ui-named-argument",
@@ -20319,7 +20319,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Deletes the “\\(key)” entry and archives its transcript.",
       "surface": "apple",
-      "id": "native.apple.177e27e4e57dccee"
+      "id": "native.apple.8720ae7f5f206a63"
     },
     {
       "kind": "ui-named-argument",
@@ -20327,7 +20327,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuSessionsInjector.swift",
       "source": "Delete failed",
       "surface": "apple",
-      "id": "native.apple.9970c1359738a7e9"
+      "id": "native.apple.3e0daab58958c203"
     },
     {
       "kind": "ui-named-argument",
@@ -20335,7 +20335,7 @@
       "path": "apps/macos/Sources/OpenClaw/MenuUsageHeaderView.swift",
       "source": "Usage",
       "surface": "apple",
-      "id": "native.apple.2e301b6071e0ab44"
+      "id": "native.apple.737e72233a7b88e6"
     },
     {
       "kind": "conditional-branch",
@@ -20359,7 +20359,7 @@
       "path": "apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift",
       "source": "Node pairing approved",
       "surface": "apple",
-      "id": "native.apple.811b7f3e9ddca5e1"
+      "id": "native.apple.7eb0a88b8274ced8"
     },
     {
       "kind": "conditional-branch",
@@ -20367,7 +20367,7 @@
       "path": "apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift",
       "source": "Node pairing rejected",
       "surface": "apple",
-      "id": "native.apple.145b0862aa2b0036"
+      "id": "native.apple.6c08dad7c7371b74"
     },
     {
       "kind": "ui-call",
@@ -20375,7 +20375,7 @@
       "path": "apps/macos/Sources/OpenClaw/NodesMenu.swift",
       "source": "\\(self.label):",
       "surface": "apple",
-      "id": "native.apple.d1e225c38143b7ed"
+      "id": "native.apple.4443962db00a2def"
     },
     {
       "kind": "conditional-branch",
@@ -20383,7 +20383,7 @@
       "path": "apps/macos/Sources/OpenClaw/Onboarding.swift",
       "source": "Finish",
       "surface": "apple",
-      "id": "native.apple.9e73dd4dfaf3017b"
+      "id": "native.apple.800d9fd07f5dde85"
     },
     {
       "kind": "conditional-branch",
@@ -20391,7 +20391,7 @@
       "path": "apps/macos/Sources/OpenClaw/Onboarding.swift",
       "source": "Next",
       "surface": "apple",
-      "id": "native.apple.ea54e864464f0797"
+      "id": "native.apple.dca2e9174fec56ce"
     },
     {
       "kind": "conditional-branch",
@@ -20839,7 +20839,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingCrestodianChat.swift",
       "source": "Crestodian was interrupted. Restart to try again.",
       "surface": "apple",
-      "id": "native.apple.1d6f15d108da0656"
+      "id": "native.apple.722995710f90cfc6"
     },
     {
       "kind": "conditional-branch",
@@ -20847,7 +20847,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingCrestodianChat.swift",
       "source": "The Gateway connection changed. Restart Crestodian to reconnect.",
       "surface": "apple",
-      "id": "native.apple.622cb233ed708c7d"
+      "id": "native.apple.6596e00d4333081e"
     },
     {
       "kind": "ui-call",
@@ -20855,7 +20855,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingCrestodianChat.swift",
       "source": "Crestodian is working…",
       "surface": "apple",
-      "id": "native.apple.a7be6a912d204b2f"
+      "id": "native.apple.6124d93872cfcfe4"
     },
     {
       "kind": "ui-call",
@@ -20863,7 +20863,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingCrestodianChat.swift",
       "source": "Restart",
       "surface": "apple",
-      "id": "native.apple.48ca6e7a236b9edb"
+      "id": "native.apple.105683a219ce17d7"
     },
     {
       "kind": "ui-call",
@@ -20871,7 +20871,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingCrestodianChat.swift",
       "source": "Enter secret…",
       "surface": "apple",
-      "id": "native.apple.4ba4fee5c8d0bb86"
+      "id": "native.apple.839da8db3e4256b2"
     },
     {
       "kind": "ui-call",
@@ -20879,7 +20879,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingCrestodianChat.swift",
       "source": "Reply to Crestodian… (yes sets everything up)",
       "surface": "apple",
-      "id": "native.apple.5db93d8c4808e5cd"
+      "id": "native.apple.3e9e9347173fffbc"
     },
     {
       "kind": "ui-call",
@@ -20887,7 +20887,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+AISetupPage.swift",
       "source": "Connect your AI",
       "surface": "apple",
-      "id": "native.apple.e319780979ae71d1"
+      "id": "native.apple.78d1ad73762a7ce8"
     },
     {
       "kind": "ui-call",
@@ -20895,7 +20895,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift",
       "source": "Back",
       "surface": "apple",
-      "id": "native.apple.d6ece940ccc75e49"
+      "id": "native.apple.c8a2f8dc424fe447"
     },
     {
       "kind": "ui-call",
@@ -20903,7 +20903,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Welcome to OpenClaw",
       "surface": "apple",
-      "id": "native.apple.6f266200b7b28e40"
+      "id": "native.apple.ea8beaeecef15e54"
     },
     {
       "kind": "ui-call",
@@ -20911,7 +20911,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Your personal AI assistant, living on your own Mac.",
       "surface": "apple",
-      "id": "native.apple.e24e92f45c29eddb"
+      "id": "native.apple.0629bbbd6db95199"
     },
     {
       "kind": "ui-call-concatenated",
@@ -20919,7 +20919,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "It answers questions, works with your files and apps, and can chat with you on WhatsApp or Telegram. Setup takes about two minutes.",
       "surface": "apple",
-      "id": "native.apple.2a2d720cd6cdf8eb"
+      "id": "native.apple.ff6f4069f0185b9b"
     },
     {
       "kind": "ui-named-argument",
@@ -20927,7 +20927,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Ask, create, and automate",
       "surface": "apple",
-      "id": "native.apple.1d11702068e086b6"
+      "id": "native.apple.86e4509eb0626ec8"
     },
     {
       "kind": "ui-named-argument",
@@ -20935,7 +20935,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Give your assistant tasks and let it help across your Mac.",
       "surface": "apple",
-      "id": "native.apple.4df9fcc7df38e96c"
+      "id": "native.apple.a6950fed99ae450d"
     },
     {
       "kind": "ui-named-argument",
@@ -20943,7 +20943,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Chat wherever you like",
       "surface": "apple",
-      "id": "native.apple.6b1ce83cf72fc9b2"
+      "id": "native.apple.8496e933d9cbc56d"
     },
     {
       "kind": "ui-named-argument",
@@ -20951,7 +20951,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "This app, WhatsApp, Telegram, Discord, Slack — your choice.",
       "surface": "apple",
-      "id": "native.apple.d1e2c5399d78cedc"
+      "id": "native.apple.d6ca07ea4a825a3f"
     },
     {
       "kind": "ui-named-argument",
@@ -20959,7 +20959,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Stay in control",
       "surface": "apple",
-      "id": "native.apple.5f34ad31222c61cb"
+      "id": "native.apple.caf822c2d393914f"
     },
     {
       "kind": "ui-named-argument",
@@ -20967,7 +20967,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Everything runs where you decide, with permissions you grant.",
       "surface": "apple",
-      "id": "native.apple.9ee350a791d7ae82"
+      "id": "native.apple.46514f735df5cddc"
     },
     {
       "kind": "ui-call-concatenated",
@@ -20975,7 +20975,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "OpenClaw can take actions using the permissions and services you enable. Review prompts and only connect tools you trust.",
       "surface": "apple",
-      "id": "native.apple.d84eeb9852925b96"
+      "id": "native.apple.fb64a5b187cfdc15"
     },
     {
       "kind": "ui-call",
@@ -20983,7 +20983,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Where should your assistant live?",
       "surface": "apple",
-      "id": "native.apple.a4142be1d0fe5025"
+      "id": "native.apple.a5d02aaf6208e924"
     },
     {
       "kind": "ui-call-concatenated",
@@ -20991,7 +20991,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Most people pick this Mac — OpenClaw installs everything and keeps it running in the background. You can change this anytime in Settings.",
       "surface": "apple",
-      "id": "native.apple.5cf89a37e2eaddf1"
+      "id": "native.apple.e6acb60b10ef1206"
     },
     {
       "kind": "ui-named-argument",
@@ -20999,7 +20999,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "On this Mac",
       "surface": "apple",
-      "id": "native.apple.4e9cd339836d3f4f"
+      "id": "native.apple.21f1053c1054db24"
     },
     {
       "kind": "ui-named-argument",
@@ -21007,7 +21007,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "On another computer",
       "surface": "apple",
-      "id": "native.apple.762d9c2364cdee21"
+      "id": "native.apple.848c45dfcda2c160"
     },
     {
       "kind": "ui-call",
@@ -21015,7 +21015,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Set up later",
       "surface": "apple",
-      "id": "native.apple.e833affb20c48d40"
+      "id": "native.apple.1921bcc57bcd747d"
     },
     {
       "kind": "ui-modifier",
@@ -21023,7 +21023,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Skip Gateway setup for now; pick Local or Remote later in Settings → General.",
       "surface": "apple",
-      "id": "native.apple.cb9ad999edeb923b"
+      "id": "native.apple.3647303a73877ecf"
     },
     {
       "kind": "ui-call",
@@ -21031,7 +21031,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "OK — OpenClaw won’t start anything yet. Pick Local or Remote later in Settings → General.",
       "surface": "apple",
-      "id": "native.apple.a3c214bd839492b6"
+      "id": "native.apple.d54084b48f40aa0a"
     },
     {
       "kind": "conditional-branch",
@@ -21039,7 +21039,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Existing gateway detected",
       "surface": "apple",
-      "id": "native.apple.0f1358b381263a4a"
+      "id": "native.apple.8d9eb247d41a0ca7"
     },
     {
       "kind": "conditional-branch",
@@ -21047,7 +21047,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Port \\(probe.port) already in use",
       "surface": "apple",
-      "id": "native.apple.03f64ebb6b039fd0"
+      "id": "native.apple.335bb6b21095d15a"
     },
     {
       "kind": "conditional-branch",
@@ -21055,7 +21055,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": " (\\(probe.command) pid \\(probe.pid))",
       "surface": "apple",
-      "id": "native.apple.d7b634908d991212"
+      "id": "native.apple.de453cb637c46670"
     },
     {
       "kind": "conditional-branch",
@@ -21063,7 +21063,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "1 gateway found on your network — click to choose it.",
       "surface": "apple",
-      "id": "native.apple.8826546033ff4516"
+      "id": "native.apple.9ab228a4cb7d4403"
     },
     {
       "kind": "conditional-branch",
@@ -21071,7 +21071,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "\\(count) gateways found on your network — click to choose one.",
       "surface": "apple",
-      "id": "native.apple.b6ccb9486c3d4fd1"
+      "id": "native.apple.279c63b244b85ece"
     },
     {
       "kind": "ui-call",
@@ -21079,7 +21079,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "No gateways found on your network yet.",
       "surface": "apple",
-      "id": "native.apple.15ca77cb469246d2"
+      "id": "native.apple.43777eabc068e240"
     },
     {
       "kind": "ui-call",
@@ -21087,7 +21087,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Look again",
       "surface": "apple",
-      "id": "native.apple.902e221a6b25dc38"
+      "id": "native.apple.b485089ad79067a9"
     },
     {
       "kind": "ui-modifier",
@@ -21095,7 +21095,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Retry discovery (Bonjour + Tailscale DNS-SD).",
       "surface": "apple",
-      "id": "native.apple.a753fd161e1d57cb"
+      "id": "native.apple.e39798604090ef9c"
     },
     {
       "kind": "conditional-branch",
@@ -21103,7 +21103,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Advanced…",
       "surface": "apple",
-      "id": "native.apple.103ca17ff07ae794"
+      "id": "native.apple.94575e6937b47f7b"
     },
     {
       "kind": "conditional-branch",
@@ -21111,7 +21111,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Hide Advanced",
       "surface": "apple",
-      "id": "native.apple.db92f3f5b7207a02"
+      "id": "native.apple.22947c17e44f76af"
     },
     {
       "kind": "ui-call",
@@ -21119,7 +21119,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Transport",
       "surface": "apple",
-      "id": "native.apple.60a2f474da8ae80a"
+      "id": "native.apple.7881cec64b177026"
     },
     {
       "kind": "ui-call",
@@ -21127,7 +21127,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "SSH tunnel",
       "surface": "apple",
-      "id": "native.apple.059da4aa6d917db8"
+      "id": "native.apple.8413b40cd91c9a19"
     },
     {
       "kind": "ui-call",
@@ -21135,7 +21135,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Direct (ws/wss)",
       "surface": "apple",
-      "id": "native.apple.6bf23cdfbba79b16"
+      "id": "native.apple.915c50965d971bb4"
     },
     {
       "kind": "ui-call",
@@ -21143,7 +21143,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Gateway URL",
       "surface": "apple",
-      "id": "native.apple.74fb65dbdf17643b"
+      "id": "native.apple.9c90f7bc1b9564b1"
     },
     {
       "kind": "ui-call",
@@ -21151,7 +21151,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "wss://gateway.example.ts.net",
       "surface": "apple",
-      "id": "native.apple.e675ecdf9c29fbfb"
+      "id": "native.apple.ba96e44d673d04d3"
     },
     {
       "kind": "ui-call",
@@ -21159,7 +21159,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "SSH target",
       "surface": "apple",
-      "id": "native.apple.c69c21b11c82dd0d"
+      "id": "native.apple.a193ae2a5ff9decd"
     },
     {
       "kind": "ui-call",
@@ -21167,7 +21167,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Identity file",
       "surface": "apple",
-      "id": "native.apple.9c0fa56a7ac3518b"
+      "id": "native.apple.ecf41ca39add6b84"
     },
     {
       "kind": "ui-call",
@@ -21175,7 +21175,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "/Users/you/.ssh/id_ed25519",
       "surface": "apple",
-      "id": "native.apple.28129f0aeb62d776"
+      "id": "native.apple.ef96d6a2a48a4c54"
     },
     {
       "kind": "ui-call",
@@ -21183,7 +21183,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Project root",
       "surface": "apple",
-      "id": "native.apple.1da09b5d1db36b6b"
+      "id": "native.apple.0ef039b18340a2e1"
     },
     {
       "kind": "ui-call",
@@ -21191,7 +21191,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "/home/you/Projects/openclaw",
       "surface": "apple",
-      "id": "native.apple.eabfba3b5c98fa0b"
+      "id": "native.apple.dca75ab0dd73f0a4"
     },
     {
       "kind": "ui-call",
@@ -21199,7 +21199,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "CLI path",
       "surface": "apple",
-      "id": "native.apple.5eda80a1108b432a"
+      "id": "native.apple.6998a7754dea6eb1"
     },
     {
       "kind": "ui-call",
@@ -21207,7 +21207,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "/Applications/OpenClaw.app/.../openclaw",
       "surface": "apple",
-      "id": "native.apple.bd1a05baee1eabaf"
+      "id": "native.apple.5a3f4f943c8ee86a"
     },
     {
       "kind": "conditional-branch",
@@ -21215,7 +21215,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Tip: use Tailscale Serve so the gateway has a valid HTTPS cert.",
       "surface": "apple",
-      "id": "native.apple.544b95327c839df9"
+      "id": "native.apple.56e9b0831ec1eded"
     },
     {
       "kind": "conditional-branch",
@@ -21223,7 +21223,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Tip: keep Tailscale enabled so your gateway stays reachable.",
       "surface": "apple",
-      "id": "native.apple.c80d394fabda1a0e"
+      "id": "native.apple.ab88df30f426b434"
     },
     {
       "kind": "ui-call",
@@ -21231,7 +21231,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Remote connection",
       "surface": "apple",
-      "id": "native.apple.655f1d9395d93cb1"
+      "id": "native.apple.2e11404d7539301e"
     },
     {
       "kind": "ui-call",
@@ -21239,7 +21239,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Checks the real remote websocket and auth handshake.",
       "surface": "apple",
-      "id": "native.apple.d9e7fc4c40dfcd9a"
+      "id": "native.apple.bee162bb681696a3"
     },
     {
       "kind": "ui-call",
@@ -21247,7 +21247,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Check connection",
       "surface": "apple",
-      "id": "native.apple.5614cd2141315e7e"
+      "id": "native.apple.6e5d3a3c3022e8c8"
     },
     {
       "kind": "ui-call",
@@ -21255,7 +21255,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Gateway token",
       "surface": "apple",
-      "id": "native.apple.653d66e0695bdfc1"
+      "id": "native.apple.1907a86a6cc2165b"
     },
     {
       "kind": "ui-call",
@@ -21263,7 +21263,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "remote gateway auth token (gateway.remote.token)",
       "surface": "apple",
-      "id": "native.apple.49121841f9e3510e"
+      "id": "native.apple.014d9fcbd97f6c48"
     },
     {
       "kind": "ui-call",
@@ -21271,7 +21271,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Used when the remote gateway requires token auth.",
       "surface": "apple",
-      "id": "native.apple.0bce8531f76b02d1"
+      "id": "native.apple.cc14b91d20cc33ba"
     },
     {
       "kind": "ui-call-concatenated",
@@ -21279,7 +21279,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "The current gateway.remote.token value is not plain text. OpenClaw for macOS cannot use it directly; enter a plaintext token here to replace it.",
       "surface": "apple",
-      "id": "native.apple.f6c0c6ce1542d5ad"
+      "id": "native.apple.2a50c3ee94dde35d"
     },
     {
       "kind": "ui-call",
@@ -21287,7 +21287,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Checking remote gateway…",
       "surface": "apple",
-      "id": "native.apple.d032a76c6bdec6e9"
+      "id": "native.apple.ef011af3c0e22127"
     },
     {
       "kind": "conditional-branch",
@@ -21295,7 +21295,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": " · ssh \\(parsed.port)",
       "surface": "apple",
-      "id": "native.apple.d25899da0fea9fd1"
+      "id": "native.apple.f2e8a7cfa21a0008"
     },
     {
       "kind": "ui-call",
@@ -21303,7 +21303,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Grant permissions",
       "surface": "apple",
-      "id": "native.apple.c59f7838d36e7316"
+      "id": "native.apple.4bad86566d023a64"
     },
     {
       "kind": "ui-call-concatenated",
@@ -21311,7 +21311,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "These macOS permissions let OpenClaw automate apps and capture context on this Mac. Status updates automatically.",
       "surface": "apple",
-      "id": "native.apple.cc90f4f4fe246989"
+      "id": "native.apple.ce0d1241d7417406"
     },
     {
       "kind": "ui-call",
@@ -21319,7 +21319,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Getting things ready",
       "surface": "apple",
-      "id": "native.apple.ec77c26b599c99d3"
+      "id": "native.apple.42af85cdf91d0264"
     },
     {
       "kind": "ui-call-concatenated",
@@ -21327,7 +21327,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "OpenClaw is setting up its background service on this Mac. This usually takes under a minute — no Terminal, no administrator password.",
       "surface": "apple",
-      "id": "native.apple.369d3719a7869c25"
+      "id": "native.apple.183aee003b44ede6"
     },
     {
       "kind": "ui-named-argument",
@@ -21335,7 +21335,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Install OpenClaw",
       "surface": "apple",
-      "id": "native.apple.e95f1cc961aee5a3"
+      "id": "native.apple.d0b8cf59f852b3d0"
     },
     {
       "kind": "ui-named-argument",
@@ -21343,7 +21343,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Start the background service",
       "surface": "apple",
-      "id": "native.apple.58607cc9f6fb73dc"
+      "id": "native.apple.0112e18fa97e7c0c"
     },
     {
       "kind": "ui-named-argument",
@@ -21351,7 +21351,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Runs quietly and starts again after a restart.",
       "surface": "apple",
-      "id": "native.apple.e7f623955648d07d"
+      "id": "native.apple.d1f9f278b55fe9b0"
     },
     {
       "kind": "ui-named-argument",
@@ -21359,7 +21359,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Ready for the next step",
       "surface": "apple",
-      "id": "native.apple.3b6bc0a5104d890b"
+      "id": "native.apple.0357f1eea66db068"
     },
     {
       "kind": "ui-named-argument",
@@ -21367,7 +21367,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Once the service answers, you’ll connect your AI.",
       "surface": "apple",
-      "id": "native.apple.40bcb49b3291e417"
+      "id": "native.apple.9f58badc863cbf2b"
     },
     {
       "kind": "ui-named-argument",
@@ -21375,7 +21375,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "The Gateway didn’t start",
       "surface": "apple",
-      "id": "native.apple.e1563c28dab091f4"
+      "id": "native.apple.3bcb83316b3d90bb"
     },
     {
       "kind": "ui-named-argument",
@@ -21383,7 +21383,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Try again",
       "surface": "apple",
-      "id": "native.apple.7d40d63ba0729923"
+      "id": "native.apple.f36edc58238aa8ce"
     },
     {
       "kind": "ui-call",
@@ -21391,7 +21391,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "You’re all set!",
       "surface": "apple",
-      "id": "native.apple.66f87ff56e8be6d8"
+      "id": "native.apple.25e82538dc9e9aad"
     },
     {
       "kind": "ui-call",
@@ -21399,7 +21399,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Finish opens the chat — say hi to your new agent.",
       "surface": "apple",
-      "id": "native.apple.bac72cb2b1c283fe"
+      "id": "native.apple.9f73f753266a9fa2"
     },
     {
       "kind": "ui-named-argument",
@@ -21407,7 +21407,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Configure later",
       "surface": "apple",
-      "id": "native.apple.6b47f49b8c933c76"
+      "id": "native.apple.678dee9dedd72ce4"
     },
     {
       "kind": "ui-named-argument",
@@ -21415,7 +21415,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Pick Local or Remote in Settings → General whenever you’re ready.",
       "surface": "apple",
-      "id": "native.apple.9a0d519d6323de90"
+      "id": "native.apple.f87bc67e676d1289"
     },
     {
       "kind": "ui-named-argument",
@@ -21423,7 +21423,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Remote gateway checklist",
       "surface": "apple",
-      "id": "native.apple.f330090303d6d3de"
+      "id": "native.apple.2eb061cd9d5f19fe"
     },
     {
       "kind": "ui-named-argument-multiline",
@@ -21431,7 +21431,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "On your gateway host: install/update the `openclaw` package and make sure credentials exist\n(typically `~/.openclaw/credentials/oauth.json`). Then connect again if needed.",
       "surface": "apple",
-      "id": "native.apple.2371586c6343c0d4"
+      "id": "native.apple.952e85bfb2d4b4f5"
     },
     {
       "kind": "ui-named-argument",
@@ -21439,7 +21439,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open the menu bar panel",
       "surface": "apple",
-      "id": "native.apple.5f591d3c4947df43"
+      "id": "native.apple.4e5ccb411db3e80f"
     },
     {
       "kind": "ui-named-argument",
@@ -21447,7 +21447,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Click the OpenClaw menu bar icon for quick chat and status.",
       "surface": "apple",
-      "id": "native.apple.18c7845e518d4414"
+      "id": "native.apple.f99e39e248dbc8ed"
     },
     {
       "kind": "ui-named-argument",
@@ -21455,7 +21455,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Connect Discord, Slack, Telegram, WhatsApp, …",
       "surface": "apple",
-      "id": "native.apple.8e025bf69b7fd07c"
+      "id": "native.apple.1b6cfcf3be8765c2"
     },
     {
       "kind": "ui-named-argument",
@@ -21463,7 +21463,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Channels to link channels and monitor status.",
       "surface": "apple",
-      "id": "native.apple.bcb90769c4ce6c59"
+      "id": "native.apple.568b8fcf5608d3ea"
     },
     {
       "kind": "ui-named-argument",
@@ -21471,7 +21471,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Channels",
       "surface": "apple",
-      "id": "native.apple.abf6f66ebbd6ab34"
+      "id": "native.apple.c37c668c737e8b71"
     },
     {
       "kind": "ui-named-argument",
@@ -21479,7 +21479,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Try Voice Wake",
       "surface": "apple",
-      "id": "native.apple.0151f13b28118ac8"
+      "id": "native.apple.a39db653e07954af"
     },
     {
       "kind": "ui-named-argument",
@@ -21487,7 +21487,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Enable Voice Wake in Settings for hands-free commands with a live transcript overlay.",
       "surface": "apple",
-      "id": "native.apple.c9aa1b6019361263"
+      "id": "native.apple.bc571b825ef967a0"
     },
     {
       "kind": "ui-named-argument",
@@ -21495,7 +21495,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Use the panel + Canvas",
       "surface": "apple",
-      "id": "native.apple.bd3ddfa27560e804"
+      "id": "native.apple.349252c2bd1d7b9d"
     },
     {
       "kind": "ui-named-argument-concatenated",
@@ -21511,7 +21511,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Give your agent more powers",
       "surface": "apple",
-      "id": "native.apple.129ee3c19501abe8"
+      "id": "native.apple.9b44b38b75a868d8"
     },
     {
       "kind": "ui-named-argument",
@@ -21519,7 +21519,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Enable optional skills (Peekaboo, oracle, camsnap, …) from Settings → Skills.",
       "surface": "apple",
-      "id": "native.apple.4f907c9bf5aff5c7"
+      "id": "native.apple.fea44c40dc512455"
     },
     {
       "kind": "ui-named-argument",
@@ -21527,7 +21527,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Open Settings → Skills",
       "surface": "apple",
-      "id": "native.apple.110fc8f583a66435"
+      "id": "native.apple.420781e5adca4122"
     },
     {
       "kind": "ui-call",
@@ -21535,7 +21535,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Launch at login",
       "surface": "apple",
-      "id": "native.apple.950fb5cbb85269f6"
+      "id": "native.apple.e54dfc2913c56f6f"
     },
     {
       "kind": "ui-call",
@@ -21543,7 +21543,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Skills included",
       "surface": "apple",
-      "id": "native.apple.6eb6b27196ec0fa8"
+      "id": "native.apple.040f2884f928f376"
     },
     {
       "kind": "ui-call",
@@ -21551,7 +21551,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.d1973c29b61aa97c"
+      "id": "native.apple.e38ea89bafb6b75d"
     },
     {
       "kind": "ui-call",
@@ -21559,7 +21559,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Couldn’t load skills from the Gateway.",
       "surface": "apple",
-      "id": "native.apple.2cb56d71cbcbd17c"
+      "id": "native.apple.38fc7e2b80c4e0fa"
     },
     {
       "kind": "ui-call-concatenated",
@@ -21567,7 +21567,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Make sure the Gateway is running and connected, then hit Refresh (or open Settings → Skills).",
       "surface": "apple",
-      "id": "native.apple.52eec6377af66f60"
+      "id": "native.apple.3b06694a81edc126"
     },
     {
       "kind": "ui-call",
@@ -21575,7 +21575,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "Details: \\(error)",
       "surface": "apple",
-      "id": "native.apple.68577d8b1064fe16"
+      "id": "native.apple.b6de2a51e5fb8397"
     },
     {
       "kind": "ui-call",
@@ -21583,7 +21583,7 @@
       "path": "apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift",
       "source": "No skills reported yet.",
       "surface": "apple",
-      "id": "native.apple.5b24d20f6bc718ff"
+      "id": "native.apple.b82621bc28d4c6e3"
     },
     {
       "kind": "ui-call",
@@ -21591,7 +21591,7 @@
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Not Now",
       "surface": "apple",
-      "id": "native.apple.4c083e16441ff0a2"
+      "id": "native.apple.048e9cc88fb7af55"
     },
     {
       "kind": "ui-call",
@@ -21615,7 +21615,7 @@
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Pairing Request",
       "surface": "apple",
-      "id": "native.apple.cd13e51bf71ab6c5"
+      "id": "native.apple.57e27a9a3ef63ac4"
     },
     {
       "kind": "conditional-branch",
@@ -21623,7 +21623,7 @@
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Pairing Requests",
       "surface": "apple",
-      "id": "native.apple.dd6312b3e8ec6484"
+      "id": "native.apple.61152c2ea359eaa0"
     },
     {
       "kind": "ui-modifier",
@@ -21631,7 +21631,7 @@
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Copy full ID",
       "surface": "apple",
-      "id": "native.apple.85ad1c8614eac249"
+      "id": "native.apple.d3b539b5e822f581"
     },
     {
       "kind": "conditional-branch",
@@ -21639,7 +21639,7 @@
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Approve Device",
       "surface": "apple",
-      "id": "native.apple.cd653991c846b0f1"
+      "id": "native.apple.01bd6552a4adee7c"
     },
     {
       "kind": "conditional-branch",
@@ -21647,7 +21647,7 @@
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Approve Node",
       "surface": "apple",
-      "id": "native.apple.900661cb771e935d"
+      "id": "native.apple.b12ad4f00b1cd3d1"
     },
     {
       "kind": "ui-call",
@@ -21655,7 +21655,7 @@
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "Reject",
       "surface": "apple",
-      "id": "native.apple.66410331e4296fec"
+      "id": "native.apple.8878bb60553ad307"
     },
     {
       "kind": "conditional-branch",
@@ -21663,7 +21663,7 @@
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "A node wants to connect to OpenClaw.",
       "surface": "apple",
-      "id": "native.apple.fcef164f14da6208"
+      "id": "native.apple.11b1b5e9dd510766"
     },
     {
       "kind": "conditional-branch",
@@ -21671,7 +21671,7 @@
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "A device wants to connect to OpenClaw.",
       "surface": "apple",
-      "id": "native.apple.217056cdb4424709"
+      "id": "native.apple.2e9d9d1f5d4346d4"
     },
     {
       "kind": "conditional-branch",
@@ -21679,7 +21679,7 @@
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "New device",
       "surface": "apple",
-      "id": "native.apple.713286b17f6b5f79"
+      "id": "native.apple.2412e85f7d11395e"
     },
     {
       "kind": "conditional-branch",
@@ -21687,7 +21687,7 @@
       "path": "apps/macos/Sources/OpenClaw/PairingApprovalPanelView.swift",
       "source": "OpenClaw Mac app",
       "surface": "apple",
-      "id": "native.apple.154fe84f1d704fb5"
+      "id": "native.apple.a09a61f4efe1e63e"
     },
     {
       "kind": "conditional-branch",
@@ -21711,7 +21711,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Permissions",
       "surface": "apple",
-      "id": "native.apple.51a204c438cd49af"
+      "id": "native.apple.6223e5f12aa9464b"
     },
     {
       "kind": "ui-named-argument",
@@ -21719,7 +21719,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "macOS access for notifications, capture, voice, and device context.",
       "surface": "apple",
-      "id": "native.apple.179d3c1b6f6be0d3"
+      "id": "native.apple.13de15babf16f5a1"
     },
     {
       "kind": "ui-call",
@@ -21727,7 +21727,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "System Access",
       "surface": "apple",
-      "id": "native.apple.ab7ad51cdcff0376"
+      "id": "native.apple.d103265c3c4586f2"
     },
     {
       "kind": "ui-call",
@@ -21735,7 +21735,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Setup",
       "surface": "apple",
-      "id": "native.apple.9141245b1f1fc704"
+      "id": "native.apple.89a4f5934df8268a"
     },
     {
       "kind": "ui-named-argument",
@@ -21743,7 +21743,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Onboarding walkthrough",
       "surface": "apple",
-      "id": "native.apple.d5e4fd3f85426f12"
+      "id": "native.apple.7df9aa7e39b10c6f"
     },
     {
       "kind": "ui-named-argument",
@@ -21751,7 +21751,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Use this if macOS prompts were skipped or permissions need a fresh walkthrough.",
       "surface": "apple",
-      "id": "native.apple.43e2bb40b382ba46"
+      "id": "native.apple.88b8006036788e0f"
     },
     {
       "kind": "ui-call",
@@ -21759,7 +21759,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Restart onboarding",
       "surface": "apple",
-      "id": "native.apple.2d98029f6ba3df46"
+      "id": "native.apple.f68a3f48ba505366"
     },
     {
       "kind": "conditional-branch",
@@ -21767,7 +21767,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "All access granted",
       "surface": "apple",
-      "id": "native.apple.e79191e199cf406b"
+      "id": "native.apple.19f209e84449fd85"
     },
     {
       "kind": "conditional-branch",
@@ -21775,7 +21775,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "\\(granted) of \\(total) permissions granted",
       "surface": "apple",
-      "id": "native.apple.9532e2ef2c5c5c77"
+      "id": "native.apple.22089fc9d573f6ea"
     },
     {
       "kind": "ui-call",
@@ -21783,7 +21783,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "OpenClaw only asks for macOS capabilities when a feature needs them.",
       "surface": "apple",
-      "id": "native.apple.49b40cdcd258b296"
+      "id": "native.apple.4344ff6c0e9d7187"
     },
     {
       "kind": "ui-named-argument",
@@ -21791,7 +21791,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Location access",
       "surface": "apple",
-      "id": "native.apple.5dbbe7e1d951f633"
+      "id": "native.apple.4fecdab98e2f6a11"
     },
     {
       "kind": "ui-named-argument",
@@ -21799,7 +21799,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Allow agents to use device location when a tool asks for it.",
       "surface": "apple",
-      "id": "native.apple.ff95a392ced899c4"
+      "id": "native.apple.2f44a5e39b905093"
     },
     {
       "kind": "ui-call",
@@ -21807,7 +21807,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Location Access",
       "surface": "apple",
-      "id": "native.apple.d018a1315fa35aea"
+      "id": "native.apple.3aa3ccdcc285b461"
     },
     {
       "kind": "ui-call",
@@ -21815,7 +21815,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Off",
       "surface": "apple",
-      "id": "native.apple.2c1fe8eff308f98b"
+      "id": "native.apple.cf3a5c243de1ef5a"
     },
     {
       "kind": "ui-call",
@@ -21823,7 +21823,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "While Using",
       "surface": "apple",
-      "id": "native.apple.f62423c183fd5950"
+      "id": "native.apple.d5020a219ed1ac41"
     },
     {
       "kind": "ui-call",
@@ -21831,7 +21831,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Always",
       "surface": "apple",
-      "id": "native.apple.d8e576369690f45c"
+      "id": "native.apple.e03eebb9f39381b4"
     },
     {
       "kind": "ui-named-argument",
@@ -21839,7 +21839,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Precise location",
       "surface": "apple",
-      "id": "native.apple.476c5d14d3b288c0"
+      "id": "native.apple.397066524678f9bb"
     },
     {
       "kind": "ui-named-argument",
@@ -21847,7 +21847,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Always may require System Settings to approve background location.",
       "surface": "apple",
-      "id": "native.apple.f18b96d468ca7e4f"
+      "id": "native.apple.ef9aee632b333f9f"
     },
     {
       "kind": "ui-call",
@@ -21855,7 +21855,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Precise Location",
       "surface": "apple",
-      "id": "native.apple.0b44b2b295c8cfd2"
+      "id": "native.apple.f2cad6d6841591ae"
     },
     {
       "kind": "ui-named-argument",
@@ -21863,7 +21863,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Refresh status",
       "surface": "apple",
-      "id": "native.apple.515269a7b1435412"
+      "id": "native.apple.518ac87e9fb6185b"
     },
     {
       "kind": "ui-named-argument",
@@ -21871,7 +21871,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Recheck macOS after approving access in System Settings.",
       "surface": "apple",
-      "id": "native.apple.81afbe6e3021b522"
+      "id": "native.apple.7fbaadabe2055224"
     },
     {
       "kind": "ui-call",
@@ -21879,7 +21879,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.db3b191e4eb78075"
+      "id": "native.apple.cc8c64fe846d3cca"
     },
     {
       "kind": "ui-call",
@@ -21887,7 +21887,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Grant",
       "surface": "apple",
-      "id": "native.apple.17ba9157c0c8cc84"
+      "id": "native.apple.7b62187659c9925f"
     },
     {
       "kind": "ui-call",
@@ -21895,7 +21895,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Granted",
       "surface": "apple",
-      "id": "native.apple.24badbca9bd8f460"
+      "id": "native.apple.9587edffda4b78f0"
     },
     {
       "kind": "ui-call",
@@ -21903,7 +21903,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Checking…",
       "surface": "apple",
-      "id": "native.apple.3eea5844d6247c58"
+      "id": "native.apple.27ff5be3db0efbd0"
     },
     {
       "kind": "ui-call",
@@ -21911,7 +21911,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Request access",
       "surface": "apple",
-      "id": "native.apple.5303d5f2a8e5473b"
+      "id": "native.apple.c8a3879230179938"
     },
     {
       "kind": "conditional-branch",
@@ -21919,7 +21919,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Automation (AppleScript)",
       "surface": "apple",
-      "id": "native.apple.e468c430777cab76"
+      "id": "native.apple.8d8386041799d2b0"
     },
     {
       "kind": "conditional-branch",
@@ -21927,7 +21927,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Notifications",
       "surface": "apple",
-      "id": "native.apple.862bc4fa0bb22c5e"
+      "id": "native.apple.bc935384479c2f48"
     },
     {
       "kind": "conditional-branch",
@@ -21935,7 +21935,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Accessibility",
       "surface": "apple",
-      "id": "native.apple.1980c81c0b9ede5e"
+      "id": "native.apple.922a8b5e049ef146"
     },
     {
       "kind": "conditional-branch",
@@ -21943,7 +21943,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Screen Recording",
       "surface": "apple",
-      "id": "native.apple.08caf4429feb223f"
+      "id": "native.apple.c2f2fac8ab1ef9c0"
     },
     {
       "kind": "conditional-branch",
@@ -21951,7 +21951,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Microphone",
       "surface": "apple",
-      "id": "native.apple.448ea72ec1841808"
+      "id": "native.apple.5ec94fe5a6864de7"
     },
     {
       "kind": "conditional-branch",
@@ -21959,7 +21959,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Speech Recognition",
       "surface": "apple",
-      "id": "native.apple.09caf8087458206b"
+      "id": "native.apple.b27a5cb9cffe05f0"
     },
     {
       "kind": "conditional-branch",
@@ -21967,7 +21967,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Camera",
       "surface": "apple",
-      "id": "native.apple.ff630389be6e4956"
+      "id": "native.apple.3639c706ed77975c"
     },
     {
       "kind": "conditional-branch",
@@ -21975,7 +21975,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Location",
       "surface": "apple",
-      "id": "native.apple.8139888a0fcede71"
+      "id": "native.apple.fee0f3732a447f35"
     },
     {
       "kind": "conditional-branch",
@@ -21983,7 +21983,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Control other apps (e.g. Terminal) for automation actions",
       "surface": "apple",
-      "id": "native.apple.e8c371d1195c8314"
+      "id": "native.apple.4a4c10ca63e99590"
     },
     {
       "kind": "conditional-branch",
@@ -21991,7 +21991,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Show desktop alerts for agent activity",
       "surface": "apple",
-      "id": "native.apple.5f05b07c12c9e4ba"
+      "id": "native.apple.5f7eb4234f63c4ad"
     },
     {
       "kind": "conditional-branch",
@@ -21999,7 +21999,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Control UI elements when an action requires it",
       "surface": "apple",
-      "id": "native.apple.a65532abd8b09118"
+      "id": "native.apple.229e60ca0a750f1c"
     },
     {
       "kind": "conditional-branch",
@@ -22007,7 +22007,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Capture the screen for context or screenshots",
       "surface": "apple",
-      "id": "native.apple.6526588e5f3f2eb3"
+      "id": "native.apple.0a07b117054babb0"
     },
     {
       "kind": "conditional-branch",
@@ -22015,7 +22015,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Allow Voice Wake and audio capture",
       "surface": "apple",
-      "id": "native.apple.924be7cdb34e97e6"
+      "id": "native.apple.b004145c37a470f8"
     },
     {
       "kind": "conditional-branch",
@@ -22023,7 +22023,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Transcribe Voice Wake trigger phrases on-device",
       "surface": "apple",
-      "id": "native.apple.d1a3f84cfc8aa293"
+      "id": "native.apple.7c8b825829b3924d"
     },
     {
       "kind": "conditional-branch",
@@ -22031,7 +22031,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Capture photos and video from the camera",
       "surface": "apple",
-      "id": "native.apple.c5e443694f999653"
+      "id": "native.apple.37880f3b7ae6c259"
     },
     {
       "kind": "conditional-branch",
@@ -22039,7 +22039,7 @@
       "path": "apps/macos/Sources/OpenClaw/PermissionsSettings.swift",
       "source": "Share location when requested by the agent",
       "surface": "apple",
-      "id": "native.apple.edd4b0ed3c0bcb23"
+      "id": "native.apple.1f5015480ea0f783"
     },
     {
       "kind": "conditional-branch",
@@ -22047,7 +22047,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway requires an auth token",
       "surface": "apple",
-      "id": "native.apple.30b85d1139d9ae9f"
+      "id": "native.apple.1eeca02c45d3db5a"
     },
     {
       "kind": "conditional-branch",
@@ -22055,7 +22055,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "That token did not match the gateway",
       "surface": "apple",
-      "id": "native.apple.9577d1b8b3ed1dc4"
+      "id": "native.apple.b45db388b1bd36bb"
     },
     {
       "kind": "conditional-branch",
@@ -22063,7 +22063,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway host needs token setup",
       "surface": "apple",
-      "id": "native.apple.49bb6be2d695c330"
+      "id": "native.apple.199c0835c6de23e5"
     },
     {
       "kind": "conditional-branch",
@@ -22071,7 +22071,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This setup code is no longer valid",
       "surface": "apple",
-      "id": "native.apple.a89437e1da2cf7a3"
+      "id": "native.apple.ff1cbf5fb69f6d53"
     },
     {
       "kind": "conditional-branch",
@@ -22079,7 +22079,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway is using unsupported auth",
       "surface": "apple",
-      "id": "native.apple.bc92346e2f93f44b"
+      "id": "native.apple.4f751db2308294e1"
     },
     {
       "kind": "conditional-branch",
@@ -22087,7 +22087,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This device needs pairing approval",
       "surface": "apple",
-      "id": "native.apple.2f7f665be741d381"
+      "id": "native.apple.2e5704a3b8fcc47f"
     },
     {
       "kind": "conditional-branch",
@@ -22103,7 +22103,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Check `gateway.auth.token` or `OPENCLAW_GATEWAY_TOKEN` on the gateway host and try again.",
       "surface": "apple",
-      "id": "native.apple.dde3a28878883443"
+      "id": "native.apple.bbb87d21ce8a291e"
     },
     {
       "kind": "conditional-branch",
@@ -22119,7 +22119,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Scan or paste a fresh setup code from an already-paired OpenClaw client, then try again.",
       "surface": "apple",
-      "id": "native.apple.e85b68221571e93c"
+      "id": "native.apple.83145f8f53d7be34"
     },
     {
       "kind": "conditional-branch",
@@ -22143,7 +22143,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway requires an auth token from the gateway host.",
       "surface": "apple",
-      "id": "native.apple.63104b46c850820d"
+      "id": "native.apple.e73170e4ab1dbe8f"
     },
     {
       "kind": "conditional-branch",
@@ -22151,7 +22151,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Gateway token mismatch. Check gateway.auth.token or OPENCLAW_GATEWAY_TOKEN on the gateway host.",
       "surface": "apple",
-      "id": "native.apple.d7a042a3fa394c0a"
+      "id": "native.apple.e3f983b8c517da29"
     },
     {
       "kind": "conditional-branch",
@@ -22159,7 +22159,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway has token auth enabled, but no gateway.auth.token is configured on the host.",
       "surface": "apple",
-      "id": "native.apple.6a3ffe9bb4cb1f73"
+      "id": "native.apple.cd96754a96e5aa35"
     },
     {
       "kind": "conditional-branch",
@@ -22167,7 +22167,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Setup code expired or already used. Scan a fresh setup code, then try again.",
       "surface": "apple",
-      "id": "native.apple.1253ca7643f527c9"
+      "id": "native.apple.b58556877f8eba24"
     },
     {
       "kind": "conditional-branch",
@@ -22175,7 +22175,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "This gateway uses password auth. Remote onboarding on macOS cannot collect gateway passwords yet.",
       "surface": "apple",
-      "id": "native.apple.5e47691ccacd5e6d"
+      "id": "native.apple.49ea9045d0c7402d"
     },
     {
       "kind": "conditional-branch",
@@ -22191,7 +22191,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Connected via paired device",
       "surface": "apple",
-      "id": "native.apple.5fb55d9d6e58eb32"
+      "id": "native.apple.58e76e9c8b04290a"
     },
     {
       "kind": "conditional-branch",
@@ -22199,7 +22199,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Connected with setup code",
       "surface": "apple",
-      "id": "native.apple.aac72b3f665fc1a2"
+      "id": "native.apple.dbe7f99297c2269d"
     },
     {
       "kind": "conditional-branch",
@@ -22207,7 +22207,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Connected with gateway token",
       "surface": "apple",
-      "id": "native.apple.934b96bcaeade5a5"
+      "id": "native.apple.a3c2651d36de9c7f"
     },
     {
       "kind": "conditional-branch",
@@ -22215,7 +22215,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Connected with password",
       "surface": "apple",
-      "id": "native.apple.9ede96375789333b"
+      "id": "native.apple.f9df689f570952aa"
     },
     {
       "kind": "conditional-branch",
@@ -22223,7 +22223,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift",
       "source": "Remote gateway ready",
       "surface": "apple",
-      "id": "native.apple.b91f95273c683db5"
+      "id": "native.apple.ebfc72d56c8b3e3a"
     },
     {
       "kind": "conditional-branch",
@@ -22231,7 +22231,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemotePortTunnel.swift",
       "source": "ssh tunnel exited before listening",
       "surface": "apple",
-      "id": "native.apple.eb846295467ca892"
+      "id": "native.apple.6d7241b4b36686bb"
     },
     {
       "kind": "conditional-branch",
@@ -22239,7 +22239,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemotePortTunnel.swift",
       "source": "ssh tunnel did not open local port \\(localPort)",
       "surface": "apple",
-      "id": "native.apple.115b9f62f8f84688"
+      "id": "native.apple.253f6eb372b87540"
     },
     {
       "kind": "conditional-branch",
@@ -22247,7 +22247,7 @@
       "path": "apps/macos/Sources/OpenClaw/RemotePortTunnel.swift",
       "source": "ssh tunnel failed: \\(stderr)",
       "surface": "apple",
-      "id": "native.apple.cb2c889fb02d7042"
+      "id": "native.apple.3744275a6a0eaaa2"
     },
     {
       "kind": "plist-string",
@@ -22255,7 +22255,7 @@
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw needs notification permission to show alerts for agent actions.",
       "surface": "apple",
-      "id": "native.apple.fcf7fea1fb2c473a"
+      "id": "native.apple.2d7556d00f123112"
     },
     {
       "kind": "plist-string",
@@ -22263,7 +22263,7 @@
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw captures the screen when the agent needs screenshots for context.",
       "surface": "apple",
-      "id": "native.apple.9b068dd56129fa27"
+      "id": "native.apple.d9e7be03543b508f"
     },
     {
       "kind": "plist-string",
@@ -22271,7 +22271,7 @@
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw can capture photos or short video clips when requested by the agent.",
       "surface": "apple",
-      "id": "native.apple.21db425107db803c"
+      "id": "native.apple.eca927767423799c"
     },
     {
       "kind": "plist-string",
@@ -22279,7 +22279,7 @@
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw can share your location when requested by the agent.",
       "surface": "apple",
-      "id": "native.apple.f3aca271d395e69f"
+      "id": "native.apple.9389d1100944a1fd"
     },
     {
       "kind": "plist-string",
@@ -22287,7 +22287,7 @@
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw uses the local network to connect to your remote OpenClaw gateway over LAN, Tailnet, or SSH.",
       "surface": "apple",
-      "id": "native.apple.74e5fb413c010dcd"
+      "id": "native.apple.59da76aed1cb07ee"
     },
     {
       "kind": "plist-string",
@@ -22295,7 +22295,7 @@
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw needs the mic for Voice Wake tests and agent audio capture.",
       "surface": "apple",
-      "id": "native.apple.d42cf498a4763c52"
+      "id": "native.apple.5db9a976fd1c7fcb"
     },
     {
       "kind": "plist-string",
@@ -22303,7 +22303,7 @@
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw uses speech recognition to detect your Voice Wake trigger phrase.",
       "surface": "apple",
-      "id": "native.apple.9a85fef692acd907"
+      "id": "native.apple.b7aba524ef867e7f"
     },
     {
       "kind": "plist-string",
@@ -22311,7 +22311,7 @@
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw needs Automation (AppleScript) permission to drive Terminal and other apps for agent actions.",
       "surface": "apple",
-      "id": "native.apple.192b374844204d37"
+      "id": "native.apple.2d5411b5cc54a93e"
     },
     {
       "kind": "plist-string",
@@ -22319,7 +22319,7 @@
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw can access Reminders when requested by the agent for the apple-reminders skill.",
       "surface": "apple",
-      "id": "native.apple.5ebea77709397c1c"
+      "id": "native.apple.e16fc45de0f2bb86"
     },
     {
       "kind": "conditional-branch",
@@ -22327,7 +22327,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionData.swift",
       "source": "Cron",
       "surface": "apple",
-      "id": "native.apple.5dd4c0beab591811"
+      "id": "native.apple.6f7c6ef00a40a571"
     },
     {
       "kind": "conditional-branch",
@@ -22335,7 +22335,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionData.swift",
       "source": "Direct",
       "surface": "apple",
-      "id": "native.apple.2bcf0cb05b6503fb"
+      "id": "native.apple.919c478455279274"
     },
     {
       "kind": "conditional-branch",
@@ -22343,7 +22343,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionData.swift",
       "source": "Group",
       "surface": "apple",
-      "id": "native.apple.5ae4a6d35078287e"
+      "id": "native.apple.d90d9456fbd96681"
     },
     {
       "kind": "conditional-branch",
@@ -22351,7 +22351,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionData.swift",
       "source": "Global",
       "surface": "apple",
-      "id": "native.apple.af42a67494ad80b3"
+      "id": "native.apple.ef8c8542159968f8"
     },
     {
       "kind": "conditional-branch",
@@ -22359,7 +22359,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionData.swift",
       "source": "Unknown",
       "surface": "apple",
-      "id": "native.apple.318cf5d04ea1680c"
+      "id": "native.apple.c69d014c626f3c53"
     },
     {
       "kind": "ui-call",
@@ -22367,7 +22367,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionMenuLabelView.swift",
       "source": "\\(self.row.tokens.contextSummaryShort) · \\(self.row.ageText)",
       "surface": "apple",
-      "id": "native.apple.5a8fed37790804fb"
+      "id": "native.apple.c83f50f9eafa4e4a"
     },
     {
       "kind": "conditional-branch",
@@ -22375,7 +22375,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionMenuPreviewView.swift",
       "source": "User",
       "surface": "apple",
-      "id": "native.apple.87440c9bdbcb7fcc"
+      "id": "native.apple.c0a774fe7e5cfc29"
     },
     {
       "kind": "conditional-branch",
@@ -22383,7 +22383,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionMenuPreviewView.swift",
       "source": "Agent",
       "surface": "apple",
-      "id": "native.apple.b3a05b6d17787569"
+      "id": "native.apple.698ebf4ad46a412b"
     },
     {
       "kind": "conditional-branch",
@@ -22391,7 +22391,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionMenuPreviewView.swift",
       "source": "Tool",
       "surface": "apple",
-      "id": "native.apple.fb211cfd4abae507"
+      "id": "native.apple.5f2fd2617a999a52"
     },
     {
       "kind": "conditional-branch",
@@ -22399,7 +22399,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionMenuPreviewView.swift",
       "source": "System",
       "surface": "apple",
-      "id": "native.apple.0be1e1f174d5bbfc"
+      "id": "native.apple.50ac80f686775ccc"
     },
     {
       "kind": "conditional-branch",
@@ -22407,7 +22407,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionMenuPreviewView.swift",
       "source": "Other",
       "surface": "apple",
-      "id": "native.apple.31ab431975cf88ed"
+      "id": "native.apple.d39019414981fe78"
     },
     {
       "kind": "ui-call",
@@ -22415,7 +22415,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionMenuPreviewView.swift",
       "source": "Loading preview…",
       "surface": "apple",
-      "id": "native.apple.8b544d5a6eb0de48"
+      "id": "native.apple.d3bd405935159f59"
     },
     {
       "kind": "ui-call",
@@ -22423,7 +22423,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionMenuPreviewView.swift",
       "source": "No recent messages",
       "surface": "apple",
-      "id": "native.apple.00b81a608b0f4047"
+      "id": "native.apple.4927996a6552bca2"
     },
     {
       "kind": "ui-call",
@@ -22431,7 +22431,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionsSettings.swift",
       "source": "Sessions",
       "surface": "apple",
-      "id": "native.apple.a9fbaedd2eccc345"
+      "id": "native.apple.1ff8aec0044934c3"
     },
     {
       "kind": "ui-call",
@@ -22439,7 +22439,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionsSettings.swift",
       "source": "Peek at the stored conversation buckets the CLI reuses for context and rate limits.",
       "surface": "apple",
-      "id": "native.apple.b25085e978ec5484"
+      "id": "native.apple.74f66e96c112c3fa"
     },
     {
       "kind": "ui-call",
@@ -22447,7 +22447,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionsSettings.swift",
       "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
       "surface": "apple",
-      "id": "native.apple.0765808d387f4e63"
+      "id": "native.apple.bab897f3252b134c"
     },
     {
       "kind": "ui-call",
@@ -22455,7 +22455,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionsSettings.swift",
       "source": "Context",
       "surface": "apple",
-      "id": "native.apple.62a67b49534dfc10"
+      "id": "native.apple.cebd5d2895976bee"
     },
     {
       "kind": "ui-named-argument",
@@ -22463,7 +22463,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionsSettings.swift",
       "source": "\\(row.tokens.input) in",
       "surface": "apple",
-      "id": "native.apple.f5281aae5e3d8057"
+      "id": "native.apple.eadc3062b763cc17"
     },
     {
       "kind": "ui-named-argument",
@@ -22471,7 +22471,7 @@
       "path": "apps/macos/Sources/OpenClaw/SessionsSettings.swift",
       "source": "\\(row.tokens.output) out",
       "surface": "apple",
-      "id": "native.apple.9da146d21bb4a19c"
+      "id": "native.apple.250094959877efb0"
     },
     {
       "kind": "ui-call",
@@ -22479,7 +22479,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRefreshButton.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.650edfd9bf78df64"
+      "id": "native.apple.3c7279b3288a44da"
     },
     {
       "kind": "ui-call",
@@ -22487,7 +22487,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Managed by Nix",
       "surface": "apple",
-      "id": "native.apple.19bac0fbee189391"
+      "id": "native.apple.05918601c3b3b241"
     },
     {
       "kind": "ui-call",
@@ -22495,7 +22495,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Config: \\(configPath)",
       "surface": "apple",
-      "id": "native.apple.a142cff76404833b"
+      "id": "native.apple.deb89a876875cb48"
     },
     {
       "kind": "ui-call",
@@ -22503,7 +22503,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "State:  \\(stateDir)",
       "surface": "apple",
-      "id": "native.apple.5735ec2f87becaaa"
+      "id": "native.apple.96221e7b3b153764"
     },
     {
       "kind": "conditional-branch",
@@ -22511,7 +22511,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "General",
       "surface": "apple",
-      "id": "native.apple.6fa153cb1b922306"
+      "id": "native.apple.d59e05a8305df17c"
     },
     {
       "kind": "conditional-branch",
@@ -22519,7 +22519,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Connection",
       "surface": "apple",
-      "id": "native.apple.2689694494e1b0f1"
+      "id": "native.apple.2af062df8d3934a4"
     },
     {
       "kind": "conditional-branch",
@@ -22527,7 +22527,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Permissions",
       "surface": "apple",
-      "id": "native.apple.ab9c8c59c2a8a7d3"
+      "id": "native.apple.8c2b0262f3a5ebea"
     },
     {
       "kind": "conditional-branch",
@@ -22535,7 +22535,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Voice & Talk",
       "surface": "apple",
-      "id": "native.apple.5e4b8974a30f27b0"
+      "id": "native.apple.f5f4ff67674093ec"
     },
     {
       "kind": "conditional-branch",
@@ -22543,7 +22543,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Crestodian",
       "surface": "apple",
-      "id": "native.apple.e7fb336701ed3d29"
+      "id": "native.apple.f5aa19bc071cf585"
     },
     {
       "kind": "conditional-branch",
@@ -22551,7 +22551,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Channels",
       "surface": "apple",
-      "id": "native.apple.5e121e46b7df6fcb"
+      "id": "native.apple.04b9c8402f19b8ce"
     },
     {
       "kind": "conditional-branch",
@@ -22559,7 +22559,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Skills",
       "surface": "apple",
-      "id": "native.apple.cfa1623d2c7c9be2"
+      "id": "native.apple.7b0912ebdda53aa7"
     },
     {
       "kind": "conditional-branch",
@@ -22567,7 +22567,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Cron Jobs",
       "surface": "apple",
-      "id": "native.apple.9f28d6f214b45c82"
+      "id": "native.apple.bf08d706c71f2d9b"
     },
     {
       "kind": "conditional-branch",
@@ -22575,7 +22575,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Exec Approvals",
       "surface": "apple",
-      "id": "native.apple.ebc3bb82d126786c"
+      "id": "native.apple.bf80bdb5a3dda276"
     },
     {
       "kind": "conditional-branch",
@@ -22583,7 +22583,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Sessions",
       "surface": "apple",
-      "id": "native.apple.d06b0a2ab653b605"
+      "id": "native.apple.64a6dc7d49e8fb57"
     },
     {
       "kind": "conditional-branch",
@@ -22591,7 +22591,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Instances",
       "surface": "apple",
-      "id": "native.apple.877047c64f34f8d1"
+      "id": "native.apple.704924cd0704b5b5"
     },
     {
       "kind": "conditional-branch",
@@ -22599,7 +22599,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Config",
       "surface": "apple",
-      "id": "native.apple.481f9f25738b893e"
+      "id": "native.apple.033d7a0753f0844a"
     },
     {
       "kind": "conditional-branch",
@@ -22607,7 +22607,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Debug",
       "surface": "apple",
-      "id": "native.apple.34abdf0f9c0114c4"
+      "id": "native.apple.149b9ff742e6ff4f"
     },
     {
       "kind": "conditional-branch",
@@ -22615,7 +22615,7 @@
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "About",
       "surface": "apple",
-      "id": "native.apple.c020dba4ebc41441"
+      "id": "native.apple.7ff14339afa21b57"
     },
     {
       "kind": "ui-named-argument",
@@ -22623,7 +22623,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Skills",
       "surface": "apple",
-      "id": "native.apple.688b539dc0f686a3"
+      "id": "native.apple.d1576a88854dcd99"
     },
     {
       "kind": "ui-named-argument",
@@ -22631,7 +22631,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Optional capabilities that become available when their requirements are met.",
       "surface": "apple",
-      "id": "native.apple.c94c9ec6b9c8d938"
+      "id": "native.apple.0f62bd687b786431"
     },
     {
       "kind": "conditional-branch",
@@ -22639,7 +22639,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Loading skills",
       "surface": "apple",
-      "id": "native.apple.1b2d195af6a1a87e"
+      "id": "native.apple.d40a7bb04c5534ec"
     },
     {
       "kind": "conditional-branch",
@@ -22647,7 +22647,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "\\(ready) ready · \\(needsSetup) need setup",
       "surface": "apple",
-      "id": "native.apple.8096bebff6fc7a91"
+      "id": "native.apple.767c2d19030d459a"
     },
     {
       "kind": "ui-call",
@@ -22655,7 +22655,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Enable ready skills, or install missing tools on the Gateway or this Mac.",
       "surface": "apple",
-      "id": "native.apple.70cca3c13c018f45"
+      "id": "native.apple.6a9cf4d0e171abb0"
     },
     {
       "kind": "ui-call",
@@ -22663,7 +22663,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "\\(total)",
       "surface": "apple",
-      "id": "native.apple.6edb2a569b1bde19"
+      "id": "native.apple.79d4590049b0a8f2"
     },
     {
       "kind": "ui-call",
@@ -22671,7 +22671,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Controls",
       "surface": "apple",
-      "id": "native.apple.13e0f4a1cefe44b6"
+      "id": "native.apple.07f69b9ef2f5f80e"
     },
     {
       "kind": "ui-named-argument",
@@ -22679,7 +22679,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Skill catalog",
       "surface": "apple",
-      "id": "native.apple.fb917861231ee50b"
+      "id": "native.apple.1253563cada71e4d"
     },
     {
       "kind": "ui-named-argument",
@@ -22687,7 +22687,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Refresh after changing binaries, environment variables, or skill config.",
       "surface": "apple",
-      "id": "native.apple.0ce8065d6517ccef"
+      "id": "native.apple.7bcdd77b0b2657e3"
     },
     {
       "kind": "ui-call",
@@ -22695,7 +22695,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.4c7db32479c42e0d"
+      "id": "native.apple.be08a918dffd2913"
     },
     {
       "kind": "conditional-branch",
@@ -22703,7 +22703,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Loading…",
       "surface": "apple",
-      "id": "native.apple.98a6120efa25808e"
+      "id": "native.apple.85a9941ff7a30fbe"
     },
     {
       "kind": "conditional-branch",
@@ -22711,7 +22711,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "No skills reported yet",
       "surface": "apple",
-      "id": "native.apple.0e3a101b8734762d"
+      "id": "native.apple.8f5459c837515766"
     },
     {
       "kind": "conditional-branch",
@@ -22727,7 +22727,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "No skills match this filter.",
       "surface": "apple",
-      "id": "native.apple.6fd4ee769eb0bc85"
+      "id": "native.apple.ddac24dd3c4ad758"
     },
     {
       "kind": "ui-call",
@@ -22735,7 +22735,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Filter",
       "surface": "apple",
-      "id": "native.apple.b0f748e6782b506b"
+      "id": "native.apple.2beddcc70ea0d96a"
     },
     {
       "kind": "conditional-branch",
@@ -22743,7 +22743,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "All",
       "surface": "apple",
-      "id": "native.apple.bf020a56e774e0ed"
+      "id": "native.apple.eb868667821fbf7c"
     },
     {
       "kind": "conditional-branch",
@@ -22751,7 +22751,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Ready",
       "surface": "apple",
-      "id": "native.apple.cf938dfa98547f53"
+      "id": "native.apple.dfef84686e0e48b8"
     },
     {
       "kind": "conditional-branch",
@@ -22759,7 +22759,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Needs Setup",
       "surface": "apple",
-      "id": "native.apple.9442bd64b2dfc989"
+      "id": "native.apple.e4104925870c47b2"
     },
     {
       "kind": "conditional-branch",
@@ -22767,7 +22767,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Disabled",
       "surface": "apple",
-      "id": "native.apple.b788024f52f39719"
+      "id": "native.apple.c2059055c673e88b"
     },
     {
       "kind": "ui-call",
@@ -22775,7 +22775,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Website",
       "surface": "apple",
-      "id": "native.apple.2459547e5dcb47d7"
+      "id": "native.apple.d863af685def7a16"
     },
     {
       "kind": "ui-call",
@@ -22783,7 +22783,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Details",
       "surface": "apple",
-      "id": "native.apple.1918d92935d9b890"
+      "id": "native.apple.f8994366d9516e2a"
     },
     {
       "kind": "conditional-branch",
@@ -22791,7 +22791,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Needs setup",
       "surface": "apple",
-      "id": "native.apple.da42c0e9b695af67"
+      "id": "native.apple.2f55e65c7c94f978"
     },
     {
       "kind": "conditional-branch",
@@ -22799,7 +22799,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Managed",
       "surface": "apple",
-      "id": "native.apple.cfe9aeef3878443a"
+      "id": "native.apple.1b2cab26853b1074"
     },
     {
       "kind": "conditional-branch",
@@ -22807,7 +22807,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Workspace",
       "surface": "apple",
-      "id": "native.apple.6dcec9f767411497"
+      "id": "native.apple.4edf9ab6280b72ff"
     },
     {
       "kind": "conditional-branch",
@@ -22815,7 +22815,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Extra",
       "surface": "apple",
-      "id": "native.apple.501ca510acbcd7b9"
+      "id": "native.apple.595947c1bbbfda3f"
     },
     {
       "kind": "conditional-branch",
@@ -22823,7 +22823,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Plugin",
       "surface": "apple",
-      "id": "native.apple.37d7aede5d6d079c"
+      "id": "native.apple.50ba37dad6e4dde7"
     },
     {
       "kind": "ui-call",
@@ -22831,7 +22831,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Missing binaries: \\(self.missingBins.joined(separator: \", \"))",
       "surface": "apple",
-      "id": "native.apple.ed1d8de50a5175a6"
+      "id": "native.apple.98b6632aebcd482a"
     },
     {
       "kind": "ui-call",
@@ -22839,7 +22839,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Missing env: \\(self.missingEnv.joined(separator: \", \"))",
       "surface": "apple",
-      "id": "native.apple.98c2ee66c2a348d5"
+      "id": "native.apple.1ffd9ad47f1dd74a"
     },
     {
       "kind": "ui-call",
@@ -22847,7 +22847,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Requires config: \\(self.missingConfig.joined(separator: \", \"))",
       "surface": "apple",
-      "id": "native.apple.c28dec5712a1a4e4"
+      "id": "native.apple.c9ef14276ce395c1"
     },
     {
       "kind": "conditional-branch",
@@ -22855,7 +22855,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Set \\(envKey)",
       "surface": "apple",
-      "id": "native.apple.0ba091f0963a859a"
+      "id": "native.apple.c588ae10b9fae52b"
     },
     {
       "kind": "ui-call",
@@ -22863,7 +22863,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Install on Gateway",
       "surface": "apple",
-      "id": "native.apple.271aecab8ee8daae"
+      "id": "native.apple.494d34a89a55787c"
     },
     {
       "kind": "ui-call",
@@ -22871,7 +22871,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Install on This Mac",
       "surface": "apple",
-      "id": "native.apple.11a57c92c83a9c1d"
+      "id": "native.apple.4dc7c4fc6c93d9d7"
     },
     {
       "kind": "conditional-branch",
@@ -22879,7 +22879,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Switches to Local mode to install on this Mac.",
       "surface": "apple",
-      "id": "native.apple.8b0d1fa47901f3d1"
+      "id": "native.apple.594ec7446d99d669"
     },
     {
       "kind": "ui-call",
@@ -22887,7 +22887,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Get your key →",
       "surface": "apple",
-      "id": "native.apple.6d54f73392b52e5e"
+      "id": "native.apple.d2d1e65ac3406c3b"
     },
     {
       "kind": "ui-call",
@@ -22895,7 +22895,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Saved to openclaw.json under skills.entries.\\(self.editor.skillKey)",
       "surface": "apple",
-      "id": "native.apple.1818adfc77bea7c6"
+      "id": "native.apple.d769a8ac65441d48"
     },
     {
       "kind": "ui-call",
@@ -22903,7 +22903,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Cancel",
       "surface": "apple",
-      "id": "native.apple.b2175b7065d31dec"
+      "id": "native.apple.af47aadb262d225d"
     },
     {
       "kind": "ui-call",
@@ -22911,7 +22911,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Save",
       "surface": "apple",
-      "id": "native.apple.ce625995c2ee1153"
+      "id": "native.apple.25beb661ec932b3b"
     },
     {
       "kind": "conditional-branch",
@@ -22919,7 +22919,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Set API Key",
       "surface": "apple",
-      "id": "native.apple.76282dc8f59ee8ed"
+      "id": "native.apple.3ffd977cb7d7ddcb"
     },
     {
       "kind": "conditional-branch",
@@ -22927,7 +22927,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Set Environment Variable",
       "surface": "apple",
-      "id": "native.apple.d02c8e20326a8194"
+      "id": "native.apple.6cdf55c74657ea8c"
     },
     {
       "kind": "conditional-branch",
@@ -22935,7 +22935,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Skill disabled",
       "surface": "apple",
-      "id": "native.apple.6ca4205fb3545e06"
+      "id": "native.apple.ff923ba48cc8136a"
     },
     {
       "kind": "conditional-branch",
@@ -22943,7 +22943,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Skill enabled",
       "surface": "apple",
-      "id": "native.apple.85ed8da0c8b8da24"
+      "id": "native.apple.6b59063df92d2991"
     },
     {
       "kind": "ui-named-argument",
@@ -22951,7 +22951,7 @@
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Bundled",
       "surface": "apple",
-      "id": "native.apple.ae5bf34054b226e9"
+      "id": "native.apple.5bea2c67b8d4ccf9"
     },
     {
       "kind": "ui-named-argument",
@@ -22959,7 +22959,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Exec Approvals",
       "surface": "apple",
-      "id": "native.apple.baa1e9ad00a283be"
+      "id": "native.apple.9df0af709d3b38bf"
     },
     {
       "kind": "ui-named-argument",
@@ -22967,7 +22967,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Control how agent shell commands are approved on this Mac.",
       "surface": "apple",
-      "id": "native.apple.cee6e1f2850c237d"
+      "id": "native.apple.e5198b803f0b5c9f"
     },
     {
       "kind": "ui-named-argument",
@@ -22975,7 +22975,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Loading settings…",
       "surface": "apple",
-      "id": "native.apple.eece16607fdfb91b"
+      "id": "native.apple.4ec0e98876dd4130"
     },
     {
       "kind": "ui-named-argument",
@@ -22983,7 +22983,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Reading the persisted policy.",
       "surface": "apple",
-      "id": "native.apple.f94e1d20ca21be54"
+      "id": "native.apple.15112b7a64de6801"
     },
     {
       "kind": "ui-call",
@@ -22991,7 +22991,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Exec Approvals Unavailable",
       "surface": "apple",
-      "id": "native.apple.64f921bb347daf1f"
+      "id": "native.apple.10ccbcb69920d863"
     },
     {
       "kind": "ui-named-argument",
@@ -22999,7 +22999,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Settings could not be read",
       "surface": "apple",
-      "id": "native.apple.62ea09ef72587ca8"
+      "id": "native.apple.f8de480303620970"
     },
     {
       "kind": "ui-call",
@@ -23007,7 +23007,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Retry",
       "surface": "apple",
-      "id": "native.apple.22c40f0c6dbc546b"
+      "id": "native.apple.761db018bc2fc118"
     },
     {
       "kind": "ui-call",
@@ -23015,7 +23015,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Scope",
       "surface": "apple",
-      "id": "native.apple.b556ccf4fd9f87e7"
+      "id": "native.apple.4c894d7779471cda"
     },
     {
       "kind": "ui-call",
@@ -23023,7 +23023,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Policy",
       "surface": "apple",
-      "id": "native.apple.169ad3eee4985f74"
+      "id": "native.apple.4c1463daa4dfc183"
     },
     {
       "kind": "ui-named-argument",
@@ -23031,7 +23031,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Command access",
       "surface": "apple",
-      "id": "native.apple.5527cc88ed43b2bb"
+      "id": "native.apple.2d5b07fb998add6d"
     },
     {
       "kind": "ui-named-argument",
@@ -23039,7 +23039,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Prompt behavior",
       "surface": "apple",
-      "id": "native.apple.005664d83ab07fb8"
+      "id": "native.apple.1f9c1d124943525f"
     },
     {
       "kind": "ui-named-argument",
@@ -23047,7 +23047,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Fallback when unreachable",
       "surface": "apple",
-      "id": "native.apple.25e544e713763429"
+      "id": "native.apple.661bf7c8dc9f072e"
     },
     {
       "kind": "ui-named-argument",
@@ -23055,7 +23055,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Used when the companion UI cannot display an approval prompt.",
       "surface": "apple",
-      "id": "native.apple.10f3181b3f99acbf"
+      "id": "native.apple.c8c17f7110f6c2a5"
     },
     {
       "kind": "ui-call",
@@ -23063,7 +23063,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Fallback",
       "surface": "apple",
-      "id": "native.apple.f9d4a2d868a8677b"
+      "id": "native.apple.f7b187b19d3ce46c"
     },
     {
       "kind": "ui-call",
@@ -23071,7 +23071,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Automatic Trust",
       "surface": "apple",
-      "id": "native.apple.b567690434254608"
+      "id": "native.apple.e8789cac2796fa81"
     },
     {
       "kind": "ui-named-argument",
@@ -23079,7 +23079,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Auto-allow skill CLIs",
       "surface": "apple",
-      "id": "native.apple.a8d36717d2647c89"
+      "id": "native.apple.058dc79972ce1eb0"
     },
     {
       "kind": "ui-named-argument",
@@ -23087,7 +23087,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Let bundled skill command-line tools run without prompting.",
       "surface": "apple",
-      "id": "native.apple.69e83614fee0fed1"
+      "id": "native.apple.11336f8872783288"
     },
     {
       "kind": "ui-call",
@@ -23095,7 +23095,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Trusted skill binaries",
       "surface": "apple",
-      "id": "native.apple.da2a40ad4cbb5cbe"
+      "id": "native.apple.84e1f8a42caf871f"
     },
     {
       "kind": "ui-call",
@@ -23103,7 +23103,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Add Command",
       "surface": "apple",
-      "id": "native.apple.1f76b291a5a4fe09"
+      "id": "native.apple.f9494753c8f18ad5"
     },
     {
       "kind": "ui-named-argument",
@@ -23111,7 +23111,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Pattern",
       "surface": "apple",
-      "id": "native.apple.8895efca8eabc6e6"
+      "id": "native.apple.d4acabb5ab2a35bd"
     },
     {
       "kind": "ui-named-argument",
@@ -23119,7 +23119,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Bare names match PATH commands. Use a path glob for a specific binary.",
       "surface": "apple",
-      "id": "native.apple.c93a946b29888019"
+      "id": "native.apple.bd3e049ced941d24"
     },
     {
       "kind": "ui-call",
@@ -23127,7 +23127,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "rg or /opt/homebrew/bin/*",
       "surface": "apple",
-      "id": "native.apple.ef41d55bc4d49e9c"
+      "id": "native.apple.76e2478e29a4800e"
     },
     {
       "kind": "ui-call",
@@ -23135,7 +23135,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Add",
       "surface": "apple",
-      "id": "native.apple.b44c00fb3b814788"
+      "id": "native.apple.6efbcd37d228a21f"
     },
     {
       "kind": "ui-call",
@@ -23143,7 +23143,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Allowed Commands",
       "surface": "apple",
-      "id": "native.apple.3c4cdf3ce30ccbad"
+      "id": "native.apple.e1a6a94d63202cb8"
     },
     {
       "kind": "ui-call",
@@ -23151,7 +23151,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Allowlists are per-agent",
       "surface": "apple",
-      "id": "native.apple.28b320fe6537b205"
+      "id": "native.apple.656126ceb089f03f"
     },
     {
       "kind": "ui-call",
@@ -23159,7 +23159,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Select an agent scope above to add trusted commands.",
       "surface": "apple",
-      "id": "native.apple.e938b56a78d7f2a0"
+      "id": "native.apple.2bbd6fb7cf2fa71b"
     },
     {
       "kind": "ui-call",
@@ -23167,7 +23167,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "No trusted commands yet",
       "surface": "apple",
-      "id": "native.apple.8d1b6df732d09321"
+      "id": "native.apple.a09fabb585670140"
     },
     {
       "kind": "ui-call",
@@ -23175,7 +23175,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Commands that miss the allowlist follow the prompt and fallback policy above.",
       "surface": "apple",
-      "id": "native.apple.caaa7cbd56db3384"
+      "id": "native.apple.7071e7264f7b3bd1"
     },
     {
       "kind": "conditional-branch",
@@ -23183,7 +23183,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Access",
       "surface": "apple",
-      "id": "native.apple.6965aa87ad2b32d8"
+      "id": "native.apple.d11a83c13e02e770"
     },
     {
       "kind": "conditional-branch",
@@ -23191,7 +23191,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Allowlist",
       "surface": "apple",
-      "id": "native.apple.8d322dce94945b6f"
+      "id": "native.apple.c93bc33b48fd43a0"
     },
     {
       "kind": "ui-call",
@@ -23199,7 +23199,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Last used \\(Self.relativeFormatter.localizedString(for: date, relativeTo: Date()))",
       "surface": "apple",
-      "id": "native.apple.f6a5624779dc6de4"
+      "id": "native.apple.61954e6ed7118ddb"
     },
     {
       "kind": "ui-call",
@@ -23207,7 +23207,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Last command: \\(lastUsedCommand)",
       "surface": "apple",
-      "id": "native.apple.da4cf90fe860cd86"
+      "id": "native.apple.29f7d0d5d832b577"
     },
     {
       "kind": "ui-call",
@@ -23215,7 +23215,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Resolved path: \\(lastResolvedPath)",
       "surface": "apple",
-      "id": "native.apple.8b452c0aa187bf3a"
+      "id": "native.apple.0ac3d7bc8c69e6a2"
     },
     {
       "kind": "conditional-branch",
@@ -23223,7 +23223,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Shell commands blocked",
       "surface": "apple",
-      "id": "native.apple.671cd5ae31cf2c9d"
+      "id": "native.apple.5a99ffadcc47a57d"
     },
     {
       "kind": "conditional-branch",
@@ -23231,7 +23231,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Trusted commands can run",
       "surface": "apple",
-      "id": "native.apple.f767df97563e5e92"
+      "id": "native.apple.373242ed9f8b3b8f"
     },
     {
       "kind": "conditional-branch",
@@ -23239,7 +23239,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Shell commands allowed",
       "surface": "apple",
-      "id": "native.apple.ef2767bc3bfa5ed4"
+      "id": "native.apple.b725dd915c5582c9"
     },
     {
       "kind": "conditional-branch",
@@ -23247,7 +23247,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "system.run requests are denied unless the policy changes.",
       "surface": "apple",
-      "id": "native.apple.794a6631e98e27b0"
+      "id": "native.apple.5dd3ebaacc99121e"
     },
     {
       "kind": "conditional-branch",
@@ -23255,7 +23255,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Known commands can run; new commands use the prompt policy.",
       "surface": "apple",
-      "id": "native.apple.1fc6280b1b4c7b44"
+      "id": "native.apple.642d027da7623994"
     },
     {
       "kind": "conditional-branch",
@@ -23263,7 +23263,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Agents can run shell commands on this Mac without allowlist checks.",
       "surface": "apple",
-      "id": "native.apple.1ef5a6923caab5da"
+      "id": "native.apple.093b7f30aa7b08f6"
     },
     {
       "kind": "conditional-branch",
@@ -23271,7 +23271,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Block agent shell commands on this Mac.",
       "surface": "apple",
-      "id": "native.apple.5184684dc4a62edb"
+      "id": "native.apple.c8e6fc08f04b8d9f"
     },
     {
       "kind": "conditional-branch",
@@ -23279,7 +23279,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Allow trusted command patterns and handle misses with prompts.",
       "surface": "apple",
-      "id": "native.apple.bf1e546102919d3f"
+      "id": "native.apple.e9371d48f629b039"
     },
     {
       "kind": "conditional-branch",
@@ -23287,7 +23287,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Allow shell commands without checking the allowlist.",
       "surface": "apple",
-      "id": "native.apple.84214f3fae821163"
+      "id": "native.apple.935c981496e8689b"
     },
     {
       "kind": "conditional-branch",
@@ -23295,7 +23295,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Never show approval prompts.",
       "surface": "apple",
-      "id": "native.apple.d7404aa083ad6d58"
+      "id": "native.apple.c494c0bb6a4182a2"
     },
     {
       "kind": "conditional-branch",
@@ -23303,7 +23303,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Ask only when a command is not trusted yet.",
       "surface": "apple",
-      "id": "native.apple.093c3c01af530076"
+      "id": "native.apple.c04df969fed1b2ca"
     },
     {
       "kind": "conditional-branch",
@@ -23311,7 +23311,7 @@
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Ask before every shell command.",
       "surface": "apple",
-      "id": "native.apple.a5161a377e784404"
+      "id": "native.apple.19950d3e6e99ee47"
     },
     {
       "kind": "conditional-branch",
@@ -23319,7 +23319,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Off",
       "surface": "apple",
-      "id": "native.apple.5f0099993dc18200"
+      "id": "native.apple.b18215308bc4e7cf"
     },
     {
       "kind": "conditional-branch",
@@ -23327,7 +23327,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Tailnet (Serve)",
       "surface": "apple",
-      "id": "native.apple.75660b064ceb43a0"
+      "id": "native.apple.16cb95866e07c33a"
     },
     {
       "kind": "conditional-branch",
@@ -23335,7 +23335,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Public (Funnel)",
       "surface": "apple",
-      "id": "native.apple.eee39fddacb60361"
+      "id": "native.apple.5d1bfae92686efdc"
     },
     {
       "kind": "conditional-branch",
@@ -23343,7 +23343,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "No automatic Tailscale configuration.",
       "surface": "apple",
-      "id": "native.apple.368d45c7390ef8f2"
+      "id": "native.apple.1efcf02284f3ea5e"
     },
     {
       "kind": "conditional-branch",
@@ -23351,7 +23351,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Tailnet-only HTTPS via Tailscale Serve.",
       "surface": "apple",
-      "id": "native.apple.4119785e43ec7c31"
+      "id": "native.apple.0b2f7d7d50026ac4"
     },
     {
       "kind": "conditional-branch",
@@ -23359,7 +23359,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Public HTTPS via Tailscale Funnel (requires auth).",
       "surface": "apple",
-      "id": "native.apple.53731650034c8363"
+      "id": "native.apple.1f7daed940897f17"
     },
     {
       "kind": "ui-call",
@@ -23367,7 +23367,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Tailscale (dashboard access)",
       "surface": "apple",
-      "id": "native.apple.3a78ea65307529fd"
+      "id": "native.apple.96bb9bb74999aec3"
     },
     {
       "kind": "ui-call",
@@ -23375,7 +23375,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Local mode required. Update settings on the gateway host.",
       "surface": "apple",
-      "id": "native.apple.f89b107bd8568de8"
+      "id": "native.apple.5a382f1b024300a1"
     },
     {
       "kind": "ui-call",
@@ -23383,7 +23383,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.63251a0397755541"
+      "id": "native.apple.26e0afc4575fbc70"
     },
     {
       "kind": "ui-call",
@@ -23391,7 +23391,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "App Store",
       "surface": "apple",
-      "id": "native.apple.ea8761dddd5b1116"
+      "id": "native.apple.62dcf1a51e15d52a"
     },
     {
       "kind": "ui-call",
@@ -23399,7 +23399,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Direct Download",
       "surface": "apple",
-      "id": "native.apple.456358fd5d50a617"
+      "id": "native.apple.fe89247395645ff4"
     },
     {
       "kind": "ui-call",
@@ -23407,7 +23407,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Setup Guide",
       "surface": "apple",
-      "id": "native.apple.814ebeca21fb8a21"
+      "id": "native.apple.fc4886c7228bc04f"
     },
     {
       "kind": "ui-call",
@@ -23415,7 +23415,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Exposure mode",
       "surface": "apple",
-      "id": "native.apple.481018f23a7b817d"
+      "id": "native.apple.726161ce2c382170"
     },
     {
       "kind": "ui-call",
@@ -23423,7 +23423,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Exposure",
       "surface": "apple",
-      "id": "native.apple.98808079f70d5bca"
+      "id": "native.apple.fadc7522289dd272"
     },
     {
       "kind": "ui-call",
@@ -23431,7 +23431,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Dashboard URL:",
       "surface": "apple",
-      "id": "native.apple.56501bfe461b402e"
+      "id": "native.apple.657ee675aa5c5d91"
     },
     {
       "kind": "ui-call",
@@ -23439,7 +23439,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Start Tailscale to get your tailnet hostname.",
       "surface": "apple",
-      "id": "native.apple.6bb7a419c1f37204"
+      "id": "native.apple.b40617c102f55113"
     },
     {
       "kind": "ui-call",
@@ -23447,7 +23447,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Start Tailscale",
       "surface": "apple",
-      "id": "native.apple.93103f084d194a09"
+      "id": "native.apple.719949d1f6bdc263"
     },
     {
       "kind": "ui-call",
@@ -23455,7 +23455,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Require credentials",
       "surface": "apple",
-      "id": "native.apple.5b47c57b7011e562"
+      "id": "native.apple.8fedb0008df7e179"
     },
     {
       "kind": "ui-call",
@@ -23463,7 +23463,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Serve uses Tailscale identity headers; no password required.",
       "surface": "apple",
-      "id": "native.apple.d453179a614add8f"
+      "id": "native.apple.de7ce19eaf2a6fee"
     },
     {
       "kind": "ui-call",
@@ -23471,7 +23471,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Funnel requires authentication.",
       "surface": "apple",
-      "id": "native.apple.a3bdced52327d532"
+      "id": "native.apple.f00022aabd2fa142"
     },
     {
       "kind": "ui-call",
@@ -23479,7 +23479,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Password",
       "surface": "apple",
-      "id": "native.apple.22bb4f71f665204b"
+      "id": "native.apple.9b1c9f02ab3eefa5"
     },
     {
       "kind": "ui-call",
@@ -23487,7 +23487,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Stored in ~/.openclaw/openclaw.json. Prefer OPENCLAW_GATEWAY_PASSWORD for production.",
       "surface": "apple",
-      "id": "native.apple.b7505005ad8df9b0"
+      "id": "native.apple.800bb607f45c05e4"
     },
     {
       "kind": "ui-call",
@@ -23495,7 +23495,7 @@
       "path": "apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift",
       "source": "Update password",
       "surface": "apple",
-      "id": "native.apple.930e134515c7fef0"
+      "id": "native.apple.3942d43ca047de29"
     },
     {
       "kind": "conditional-branch",
@@ -23503,7 +23503,7 @@
       "path": "apps/macos/Sources/OpenClaw/TalkModeController.swift",
       "source": "Bottle",
       "surface": "apple",
-      "id": "native.apple.f86914d9c7756d35"
+      "id": "native.apple.022603dec29eeb31"
     },
     {
       "kind": "conditional-branch",
@@ -23511,7 +23511,7 @@
       "path": "apps/macos/Sources/OpenClaw/TalkModeController.swift",
       "source": "Submarine",
       "surface": "apple",
-      "id": "native.apple.7479886e7d784236"
+      "id": "native.apple.acf5be731170759f"
     },
     {
       "kind": "conditional-branch",
@@ -23519,7 +23519,7 @@
       "path": "apps/macos/Sources/OpenClaw/UsageData.swift",
       "source": "\\(hours)h",
       "surface": "apple",
-      "id": "native.apple.397c30d24e50811d"
+      "id": "native.apple.c5a4c9a669e2b7ae"
     },
     {
       "kind": "conditional-branch",
@@ -23527,7 +23527,7 @@
       "path": "apps/macos/Sources/OpenClaw/UsageData.swift",
       "source": "\\(hours)h \\(mins)m",
       "surface": "apple",
-      "id": "native.apple.46decfbb91821121"
+      "id": "native.apple.b03d60f17ede11df"
     },
     {
       "kind": "conditional-branch",
@@ -23535,7 +23535,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeChime.swift",
       "source": "No Sound",
       "surface": "apple",
-      "id": "native.apple.d40072f3684bf574"
+      "id": "native.apple.16e9766e8b59af53"
     },
     {
       "kind": "conditional-branch",
@@ -23551,7 +23551,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Voice Wake requires macOS 26 or newer",
       "surface": "apple",
-      "id": "native.apple.2ff579aec88de6ec"
+      "id": "native.apple.0577606e681fcf35"
     },
     {
       "kind": "ui-call",
@@ -23559,7 +23559,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "The Voice Wake and push-to-talk controls are hidden on older macOS versions.",
       "surface": "apple",
-      "id": "native.apple.3d7d47667e586149"
+      "id": "native.apple.013200734769f33a"
     },
     {
       "kind": "ui-named-argument",
@@ -23567,7 +23567,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Voice & Talk",
       "surface": "apple",
-      "id": "native.apple.e603fd0daaca11ce"
+      "id": "native.apple.91d77e9c8fd7cf64"
     },
     {
       "kind": "ui-named-argument",
@@ -23575,7 +23575,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Wake phrases, push-to-talk, microphone input, and Talk Mode feedback.",
       "surface": "apple",
-      "id": "native.apple.b847b7e88f6d0e4a"
+      "id": "native.apple.91fe621c927f977e"
     },
     {
       "kind": "ui-call",
@@ -23583,7 +23583,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Activation",
       "surface": "apple",
-      "id": "native.apple.40e743944b92a737"
+      "id": "native.apple.392a57d31b6a94ea"
     },
     {
       "kind": "ui-named-argument",
@@ -23591,7 +23591,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Enable Voice Wake",
       "surface": "apple",
-      "id": "native.apple.893414230c405a6b"
+      "id": "native.apple.ef337702bfdcde32"
     },
     {
       "kind": "ui-named-argument-multiline",
@@ -23599,7 +23599,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Listen for a wake phrase before running voice commands. Recognition runs fully on-device.",
       "surface": "apple",
-      "id": "native.apple.ca70303dd9f7dc69"
+      "id": "native.apple.e992b45cdbccdd10"
     },
     {
       "kind": "ui-named-argument",
@@ -23607,7 +23607,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Trigger Talk Mode",
       "surface": "apple",
-      "id": "native.apple.46a4f5a5a87982b2"
+      "id": "native.apple.475eb587a8accd92"
     },
     {
       "kind": "ui-named-argument",
@@ -23615,7 +23615,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Start a full voice conversation when a wake phrase is detected.",
       "surface": "apple",
-      "id": "native.apple.f2957b9b1cc51bf1"
+      "id": "native.apple.b225402585009eb9"
     },
     {
       "kind": "ui-named-argument",
@@ -23623,7 +23623,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Hold Right Option to talk",
       "surface": "apple",
-      "id": "native.apple.1550cdb367f5fae8"
+      "id": "native.apple.4eab66621bb04dd6"
     },
     {
       "kind": "ui-named-argument",
@@ -23631,7 +23631,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Start listening while you hold the key and show the preview overlay.",
       "surface": "apple",
-      "id": "native.apple.7055b58966b996f6"
+      "id": "native.apple.7bb4ce4870ca14a2"
     },
     {
       "kind": "ui-named-argument",
@@ -23639,7 +23639,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Push-to-talk paused",
       "surface": "apple",
-      "id": "native.apple.030948354864ede8"
+      "id": "native.apple.65d87751e185d1a5"
     },
     {
       "kind": "ui-named-argument",
@@ -23647,7 +23647,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Push-to-Talk resumes when Talk Mode is turned off.",
       "surface": "apple",
-      "id": "native.apple.ecf6297cccdc5696"
+      "id": "native.apple.2d6d7f132131424e"
     },
     {
       "kind": "ui-named-argument",
@@ -23655,7 +23655,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Play phase-transition sounds",
       "surface": "apple",
-      "id": "native.apple.b3178dc16d5e6a19"
+      "id": "native.apple.4d245d48ccb84004"
     },
     {
       "kind": "ui-named-argument-multiline",
@@ -23663,7 +23663,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Play short sounds when Talk Mode switches between listening, thinking, and speaking.",
       "surface": "apple",
-      "id": "native.apple.6342c549c3a4d3de"
+      "id": "native.apple.41f46ea2f1360ba1"
     },
     {
       "kind": "ui-named-argument",
@@ -23671,7 +23671,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Right Option stops speech",
       "surface": "apple",
-      "id": "native.apple.d10e5af90f1043cb"
+      "id": "native.apple.7ce0b620891b342f"
     },
     {
       "kind": "ui-named-argument",
@@ -23679,7 +23679,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Tap Right Option to interrupt speech and return to listening.",
       "surface": "apple",
-      "id": "native.apple.53058e129e8adb90"
+      "id": "native.apple.95e2b41ea266ae26"
     },
     {
       "kind": "ui-call",
@@ -23687,7 +23687,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Recognition",
       "surface": "apple",
-      "id": "native.apple.7421fad6107b9876"
+      "id": "native.apple.a252af04733488f3"
     },
     {
       "kind": "ui-call",
@@ -23695,7 +23695,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Test",
       "surface": "apple",
-      "id": "native.apple.69934b21a31d3c9f"
+      "id": "native.apple.7d6ec57f4b64649c"
     },
     {
       "kind": "ui-call",
@@ -23703,7 +23703,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Trigger Words",
       "surface": "apple",
-      "id": "native.apple.6b70638a81af67b3"
+      "id": "native.apple.72334cdb6e483bb2"
     },
     {
       "kind": "ui-named-argument",
@@ -23711,7 +23711,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Wake phrases",
       "surface": "apple",
-      "id": "native.apple.5b9eb01b16e81a31"
+      "id": "native.apple.519ad1a3454893af"
     },
     {
       "kind": "ui-named-argument",
@@ -23719,7 +23719,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Short phrases that start voice wake detection.",
       "surface": "apple",
-      "id": "native.apple.808e80fed46f80c8"
+      "id": "native.apple.5c6d32ae2f16617e"
     },
     {
       "kind": "ui-call",
@@ -23727,7 +23727,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Add word",
       "surface": "apple",
-      "id": "native.apple.a44f0041f9e5fe48"
+      "id": "native.apple.2b5d3b9bb23d4790"
     },
     {
       "kind": "ui-call",
@@ -23735,7 +23735,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Reset",
       "surface": "apple",
-      "id": "native.apple.35503c4949f8405c"
+      "id": "native.apple.64a5ed78f1daef4f"
     },
     {
       "kind": "ui-call",
@@ -23743,7 +23743,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "No wake phrases configured",
       "surface": "apple",
-      "id": "native.apple.dd327a9ea2873cf4"
+      "id": "native.apple.261b2e1a284a4a23"
     },
     {
       "kind": "ui-call",
@@ -23751,7 +23751,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Sounds",
       "surface": "apple",
-      "id": "native.apple.5a03dd68632d7873"
+      "id": "native.apple.137bcbf83dadd760"
     },
     {
       "kind": "ui-named-argument",
@@ -23759,7 +23759,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Trigger sound",
       "surface": "apple",
-      "id": "native.apple.56eb8f1e824d6d2b"
+      "id": "native.apple.057f356e1dad268c"
     },
     {
       "kind": "ui-named-argument",
@@ -23767,7 +23767,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Send sound",
       "surface": "apple",
-      "id": "native.apple.30ce86886e31f18c"
+      "id": "native.apple.3df4382a91dea75a"
     },
     {
       "kind": "ui-call",
@@ -23775,7 +23775,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "No Sound",
       "surface": "apple",
-      "id": "native.apple.9b4387e37d683aef"
+      "id": "native.apple.01dc8f0c65a84aa2"
     },
     {
       "kind": "ui-call",
@@ -23783,7 +23783,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Choose file…",
       "surface": "apple",
-      "id": "native.apple.0528c6758e290369"
+      "id": "native.apple.434b52758b95741a"
     },
     {
       "kind": "ui-call",
@@ -23791,7 +23791,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Play",
       "surface": "apple",
-      "id": "native.apple.0e5e44c406a7b9b8"
+      "id": "native.apple.cfbff3ff838c859c"
     },
     {
       "kind": "ui-named-argument",
@@ -23799,7 +23799,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Microphone",
       "surface": "apple",
-      "id": "native.apple.41359da0ac894b51"
+      "id": "native.apple.cda210e895dc1778"
     },
     {
       "kind": "ui-call",
@@ -23807,7 +23807,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "System default",
       "surface": "apple",
-      "id": "native.apple.0a81206706fdadee"
+      "id": "native.apple.061460a0ef5d6017"
     },
     {
       "kind": "conditional-branch",
@@ -23823,7 +23823,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Disconnected (using System default)",
       "surface": "apple",
-      "id": "native.apple.149f4d076da22182"
+      "id": "native.apple.5135e9bec6346f0d"
     },
     {
       "kind": "ui-named-argument",
@@ -23831,7 +23831,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Recognition language",
       "surface": "apple",
-      "id": "native.apple.ca4d74dadd215b29"
+      "id": "native.apple.5f981202f828ecb6"
     },
     {
       "kind": "ui-named-argument",
@@ -23839,7 +23839,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Languages are tried in order. Models may need a first-use download on macOS 26.",
       "surface": "apple",
-      "id": "native.apple.a52618a1010652b0"
+      "id": "native.apple.2e38529b5d47f62d"
     },
     {
       "kind": "ui-call",
@@ -23847,7 +23847,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Language",
       "surface": "apple",
-      "id": "native.apple.e1db8711bc4383b0"
+      "id": "native.apple.b5868ea893d6a974"
     },
     {
       "kind": "ui-call",
@@ -23855,7 +23855,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "\\(self.friendlyName(for: current)) (System)",
       "surface": "apple",
-      "id": "native.apple.af375210418389a2"
+      "id": "native.apple.d57fd5213daf2a6e"
     },
     {
       "kind": "ui-named-argument",
@@ -23863,7 +23863,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Additional languages",
       "surface": "apple",
-      "id": "native.apple.10b2092001406760"
+      "id": "native.apple.79db41c7b941a50f"
     },
     {
       "kind": "ui-named-argument",
@@ -23871,7 +23871,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Add another language",
       "surface": "apple",
-      "id": "native.apple.1760c75ee8fc1038"
+      "id": "native.apple.7049d6b0db7fb80b"
     },
     {
       "kind": "ui-call",
@@ -23879,7 +23879,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Add",
       "surface": "apple",
-      "id": "native.apple.034b0a5bc36f00d3"
+      "id": "native.apple.41d06b5cfa8e5b2f"
     },
     {
       "kind": "ui-named-argument",
@@ -23887,7 +23887,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Live level",
       "surface": "apple",
-      "id": "native.apple.90cafdb4910000f6"
+      "id": "native.apple.041c1e5c2d56d45a"
     },
     {
       "kind": "ui-call",
@@ -23895,7 +23895,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Wake phrase",
       "surface": "apple",
-      "id": "native.apple.0b723d79c6075b9e"
+      "id": "native.apple.a5088b30807780db"
     },
     {
       "kind": "ui-modifier",
@@ -23903,7 +23903,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Remove trigger word",
       "surface": "apple",
-      "id": "native.apple.a217c76f0fa0097e"
+      "id": "native.apple.87c3465e9398bc2f"
     },
     {
       "kind": "ui-named-argument",
@@ -23911,7 +23911,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Language \\(self.index + 2)",
       "surface": "apple",
-      "id": "native.apple.17f4cb7dd5186d1d"
+      "id": "native.apple.65b2687f8f16f9b2"
     },
     {
       "kind": "ui-named-argument",
@@ -23919,7 +23919,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Fallback recognition language.",
       "surface": "apple",
-      "id": "native.apple.5aec57b9913966cf"
+      "id": "native.apple.a767de022c4a06db"
     },
     {
       "kind": "ui-modifier",
@@ -23927,7 +23927,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Remove language",
       "surface": "apple",
-      "id": "native.apple.2da4a867843585fa"
+      "id": "native.apple.cfab77826c9ac1d1"
     },
     {
       "kind": "ui-call-concatenated",
@@ -23935,7 +23935,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "OpenClaw reacts when any trigger appears in a transcription. Keep phrases short to avoid false positives.",
       "surface": "apple",
-      "id": "native.apple.e209dd9ba19b81fe"
+      "id": "native.apple.237e9371a693b0ff"
     },
     {
       "kind": "ui-call",
@@ -23943,7 +23943,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeTestCard.swift",
       "source": "Test Voice Wake",
       "surface": "apple",
-      "id": "native.apple.d749a6acb290d4aa"
+      "id": "native.apple.2bcc6f4eca98f7f2"
     },
     {
       "kind": "conditional-branch",
@@ -23951,7 +23951,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeTestCard.swift",
       "source": "Start test",
       "surface": "apple",
-      "id": "native.apple.3512d7bbd871e8b6"
+      "id": "native.apple.44c32fe7fef5e7e5"
     },
     {
       "kind": "conditional-branch",
@@ -23959,7 +23959,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeTestCard.swift",
       "source": "Stop",
       "surface": "apple",
-      "id": "native.apple.9ad633fd4df59e4a"
+      "id": "native.apple.fd8cfc2a33b87fba"
     },
     {
       "kind": "conditional-branch",
@@ -23967,7 +23967,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeTestCard.swift",
       "source": "Press start, say a trigger word, and wait for detection.",
       "surface": "apple",
-      "id": "native.apple.f2f416ae36f62232"
+      "id": "native.apple.a94e02a9668e9b59"
     },
     {
       "kind": "conditional-branch",
@@ -23975,7 +23975,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeTestCard.swift",
       "source": "Requesting mic & speech permission…",
       "surface": "apple",
-      "id": "native.apple.b9e4f6ee0262538f"
+      "id": "native.apple.3abd330410d4a00a"
     },
     {
       "kind": "conditional-branch",
@@ -23983,7 +23983,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeTestCard.swift",
       "source": "Listening… say your trigger word.",
       "surface": "apple",
-      "id": "native.apple.e97a8c71b0497cfa"
+      "id": "native.apple.9dfd570fa4c12d11"
     },
     {
       "kind": "conditional-branch",
@@ -23991,7 +23991,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeTestCard.swift",
       "source": "Heard: \\(text)",
       "surface": "apple",
-      "id": "native.apple.167cdab67491a81d"
+      "id": "native.apple.5b1f53381d4ff861"
     },
     {
       "kind": "conditional-branch",
@@ -23999,7 +23999,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeTestCard.swift",
       "source": "Finalizing…",
       "surface": "apple",
-      "id": "native.apple.3a09b96f2a7e9373"
+      "id": "native.apple.8a176d8996538aae"
     },
     {
       "kind": "conditional-branch",
@@ -24007,7 +24007,7 @@
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeTestCard.swift",
       "source": "Voice wake detected!",
       "surface": "apple",
-      "id": "native.apple.e3667f05c57cc7fd"
+      "id": "native.apple.26960f2b7ebad5f9"
     },
     {
       "kind": "conditional-branch",
@@ -24015,7 +24015,7 @@
       "path": "apps/macos/Sources/OpenClawMacCLI/DiscoverCommand.swift",
       "source": " (local filtered)",
       "surface": "apple",
-      "id": "native.apple.586cd4ddbc79bd1e"
+      "id": "native.apple.c5d8bca2d78e1b9b"
     },
     {
       "kind": "conditional-branch",
@@ -24031,7 +24031,7 @@
       "path": "apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift",
       "source": "Invalid URL: \\(raw)",
       "surface": "apple",
-      "id": "native.apple.3dd6dc9964ec1147"
+      "id": "native.apple.4730f0dfb78617a2"
     },
     {
       "kind": "conditional-branch",
@@ -24039,7 +24039,7 @@
       "path": "apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift",
       "source": "gateway.remote.url is missing",
       "surface": "apple",
-      "id": "native.apple.31426e0cb51903c0"
+      "id": "native.apple.70fa502613dd19e1"
     },
     {
       "kind": "conditional-branch",
@@ -24047,7 +24047,7 @@
       "path": "apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift",
       "source": "Wizard cancelled",
       "surface": "apple",
-      "id": "native.apple.3cbce5d897d4447e"
+      "id": "native.apple.70daa9528cfa07c7"
     },
     {
       "kind": "conditional-branch",
@@ -24055,7 +24055,7 @@
       "path": "apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift",
       "source": " [\\(initial)]",
       "surface": "apple",
-      "id": "native.apple.cab68ed6edeabd61"
+      "id": "native.apple.2b7392aa9f8b47df"
     },
     {
       "kind": "conditional-branch",
@@ -24063,7 +24063,7 @@
       "path": "apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift",
       "source": " — \\(option.hint!)",
       "surface": "apple",
-      "id": "native.apple.dfb1201b4e07f3e1"
+      "id": "native.apple.9e54815f3eca97bf"
     },
     {
       "kind": "conditional-branch",
@@ -24079,7 +24079,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/AssistantTextParser.swift",
       "source": "</\\(tag)",
       "surface": "apple",
-      "id": "native.apple.78ebdc797462620c"
+      "id": "native.apple.dbc2ff188682dee3"
     },
     {
       "kind": "conditional-branch",
@@ -24087,7 +24087,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/AssistantTextParser.swift",
       "source": "<\\(tag)",
       "surface": "apple",
-      "id": "native.apple.79621e3cd582e085"
+      "id": "native.apple.d4f7cdeb3737a201"
     },
     {
       "kind": "ui-modifier",
@@ -24095,7 +24095,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Context \\(percentage)% used",
       "surface": "apple",
-      "id": "native.apple.01113cff9a7f9556"
+      "id": "native.apple.38a8e96962b1a93d"
     },
     {
       "kind": "ui-call",
@@ -24103,7 +24103,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Thinking",
       "surface": "apple",
-      "id": "native.apple.6e204a530cff78e0"
+      "id": "native.apple.510c6dfa05924ae2"
     },
     {
       "kind": "ui-call",
@@ -24111,7 +24111,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Pinned",
       "surface": "apple",
-      "id": "native.apple.65237734e52023b9"
+      "id": "native.apple.745b004e0b5b6b80"
     },
     {
       "kind": "ui-call",
@@ -24119,7 +24119,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Recent",
       "surface": "apple",
-      "id": "native.apple.b5cdc1c2c10da9c4"
+      "id": "native.apple.69381a0a462ccd84"
     },
     {
       "kind": "ui-call",
@@ -24127,7 +24127,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Models",
       "surface": "apple",
-      "id": "native.apple.e97d08d2a15cb6ee"
+      "id": "native.apple.aa321cf4820426ef"
     },
     {
       "kind": "ui-call",
@@ -24135,7 +24135,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Model",
       "surface": "apple",
-      "id": "native.apple.0998a10ffd7e76d3"
+      "id": "native.apple.0fce9d743a640218"
     },
     {
       "kind": "conditional-branch",
@@ -24143,7 +24143,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Pin model",
       "surface": "apple",
-      "id": "native.apple.aef0bfe7e8a32fba"
+      "id": "native.apple.75550b03f06d6abc"
     },
     {
       "kind": "conditional-branch",
@@ -24151,7 +24151,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Unpin model",
       "surface": "apple",
-      "id": "native.apple.5f6e0eb1dda6c10f"
+      "id": "native.apple.af4df27bdbacb5de"
     },
     {
       "kind": "ui-call",
@@ -24159,7 +24159,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Session",
       "surface": "apple",
-      "id": "native.apple.d7e1ae4e4e7bde84"
+      "id": "native.apple.5dfc0700d8dff8de"
     },
     {
       "kind": "ui-modifier",
@@ -24167,7 +24167,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Add Image",
       "surface": "apple",
-      "id": "native.apple.5a1b5f0450e8c1e1"
+      "id": "native.apple.284b2b94c272591d"
     },
     {
       "kind": "ui-modifier",
@@ -24175,7 +24175,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Attachments",
       "surface": "apple",
-      "id": "native.apple.2d5ac96da778014b"
+      "id": "native.apple.1963dfa3285cb715"
     },
     {
       "kind": "ui-call",
@@ -24183,7 +24183,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Voice note",
       "surface": "apple",
-      "id": "native.apple.12c4792f15f4b351"
+      "id": "native.apple.f8dda832ed76441d"
     },
     {
       "kind": "conditional-branch",
@@ -24191,7 +24191,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Talk",
       "surface": "apple",
-      "id": "native.apple.9757a0706f47e293"
+      "id": "native.apple.ee2c0d22f5861159"
     },
     {
       "kind": "conditional-branch",
@@ -24199,7 +24199,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start realtime chat",
       "surface": "apple",
-      "id": "native.apple.d73e9a8b230b62af"
+      "id": "native.apple.5d5041aefe6dfddd"
     },
     {
       "kind": "conditional-branch",
@@ -24207,7 +24207,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop realtime chat",
       "surface": "apple",
-      "id": "native.apple.75d8e63b44a2cf84"
+      "id": "native.apple.21a7d3a3386a2218"
     },
     {
       "kind": "conditional-branch",
@@ -24215,7 +24215,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start",
       "surface": "apple",
-      "id": "native.apple.bd575c071e51bc9c"
+      "id": "native.apple.88c2de261ddae511"
     },
     {
       "kind": "conditional-branch",
@@ -24223,7 +24223,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop",
       "surface": "apple",
-      "id": "native.apple.e6433c213efc62a0"
+      "id": "native.apple.72e5aa4446eaca9e"
     },
     {
       "kind": "ui-call",
@@ -24231,7 +24231,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Loading commands",
       "surface": "apple",
-      "id": "native.apple.025c836eff37ec7d"
+      "id": "native.apple.9d4bdedcbf74d86c"
     },
     {
       "kind": "ui-call",
@@ -24239,7 +24239,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Commands unavailable",
       "surface": "apple",
-      "id": "native.apple.6d5a260544ac3454"
+      "id": "native.apple.fdd34aa94629c962"
     },
     {
       "kind": "ui-call",
@@ -24247,7 +24247,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Retry",
       "surface": "apple",
-      "id": "native.apple.482b6c244b2f98de"
+      "id": "native.apple.a1953e3e9be8b8d5"
     },
     {
       "kind": "ui-call",
@@ -24255,7 +24255,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "No matching commands",
       "surface": "apple",
-      "id": "native.apple.de20827f0471a1b2"
+      "id": "native.apple.0f942ca442f88936"
     },
     {
       "kind": "ui-modifier",
@@ -24263,7 +24263,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop response",
       "surface": "apple",
-      "id": "native.apple.717ce3a6710f9662"
+      "id": "native.apple.afd8a2b9e3bf6d60"
     },
     {
       "kind": "ui-modifier",
@@ -24271,7 +24271,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Send message",
       "surface": "apple",
-      "id": "native.apple.5ae97e248c06d374"
+      "id": "native.apple.d30969d467c66537"
     },
     {
       "kind": "ui-modifier",
@@ -24279,7 +24279,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.f9e18a470335738b"
+      "id": "native.apple.f4473f79bb87b2fd"
     },
     {
       "kind": "conditional-branch",
@@ -24287,7 +24287,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Connecting...",
       "surface": "apple",
-      "id": "native.apple.1641e23203e93d89"
+      "id": "native.apple.6c984c0e3ed3a69e"
     },
     {
       "kind": "conditional-branch",
@@ -24295,7 +24295,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Gateway connected",
       "surface": "apple",
-      "id": "native.apple.6e75710fceb513ba"
+      "id": "native.apple.898849eb2bcb0b53"
     },
     {
       "kind": "conditional-branch",
@@ -24311,7 +24311,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "Input tokens: \\(input)",
       "surface": "apple",
-      "id": "native.apple.7622351111d0dbf5"
+      "id": "native.apple.c622ecbe64757e20"
     },
     {
       "kind": "ui-localized-call",
@@ -24319,7 +24319,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "Output tokens: \\(output)",
       "surface": "apple",
-      "id": "native.apple.6483e4f5f14c7a6a"
+      "id": "native.apple.9a2df48646af1dde"
     },
     {
       "kind": "ui-localized-call",
@@ -24327,7 +24327,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "Cache read tokens: \\(cacheRead)",
       "surface": "apple",
-      "id": "native.apple.0bac4e4f235efa13"
+      "id": "native.apple.0c6c7b65489adafa"
     },
     {
       "kind": "ui-localized-call",
@@ -24335,7 +24335,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "Cache write tokens: \\(cacheWrite)",
       "surface": "apple",
-      "id": "native.apple.1c7899cd135c4506"
+      "id": "native.apple.c71fa1cad2deba7e"
     },
     {
       "kind": "ui-localized-call",
@@ -24343,7 +24343,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "Cost: \\(formattedCost)",
       "surface": "apple",
-      "id": "native.apple.150bfffa693fcefc"
+      "id": "native.apple.62bcf67218a0ecd0"
     },
     {
       "kind": "ui-localized-call",
@@ -24351,7 +24351,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "ctx",
       "surface": "apple",
-      "id": "native.apple.e27f633db4ba7e49"
+      "id": "native.apple.118ab29788bb00fd"
     },
     {
       "kind": "ui-localized-call",
@@ -24359,7 +24359,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "\\(contextPercent) percent of context used",
       "surface": "apple",
-      "id": "native.apple.aa15ae08b51aac94"
+      "id": "native.apple.1b6b0d02dc774cc3"
     },
     {
       "kind": "ui-localized-call",
@@ -24367,7 +24367,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "Warning: \\(contextPercent) percent of context used",
       "surface": "apple",
-      "id": "native.apple.e28c698580084851"
+      "id": "native.apple.4e7cd5b3f4e0ddc0"
     },
     {
       "kind": "ui-localized-call",
@@ -24375,7 +24375,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "Critical: \\(contextPercent) percent of context used",
       "surface": "apple",
-      "id": "native.apple.6d6bf645b99c4ffe"
+      "id": "native.apple.107321cf0b74cb7f"
     },
     {
       "kind": "ui-call",
@@ -24383,7 +24383,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "\\(percent)%",
       "surface": "apple",
-      "id": "native.apple.7429c9095e7bbd1a"
+      "id": "native.apple.e8fba80e238f4283"
     },
     {
       "kind": "ui-modifier",
@@ -24391,7 +24391,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
       "source": "Context usage",
       "surface": "apple",
-      "id": "native.apple.5563ad1aa3bd30bf"
+      "id": "native.apple.a902d7f653b46010"
     },
     {
       "kind": "conditional-branch",
@@ -24407,7 +24407,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "\\(display.emoji) \\(display.title)",
       "surface": "apple",
-      "id": "native.apple.b304621c63871fb8"
+      "id": "native.apple.8509385953c19619"
     },
     {
       "kind": "ui-localized-call",
@@ -24415,7 +24415,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Message usage",
       "surface": "apple",
-      "id": "native.apple.eb452758b2d770d5"
+      "id": "native.apple.6426e369511b043c"
     },
     {
       "kind": "conditional-branch",
@@ -24431,7 +24431,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Show full output",
       "surface": "apple",
-      "id": "native.apple.f42cc258acfb67de"
+      "id": "native.apple.aff6385b0a8dd0ac"
     },
     {
       "kind": "conditional-branch",
@@ -24439,7 +24439,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Show less",
       "surface": "apple",
-      "id": "native.apple.9d4cffc5588d8730"
+      "id": "native.apple.b9c78020ae8be34a"
     },
     {
       "kind": "ui-call",
@@ -24447,7 +24447,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Writing",
       "surface": "apple",
-      "id": "native.apple.9f296429941bcaaf"
+      "id": "native.apple.e9914cfc93a514cb"
     },
     {
       "kind": "ui-call",
@@ -24455,7 +24455,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio…",
       "surface": "apple",
-      "id": "native.apple.1521f9182b8bb00b"
+      "id": "native.apple.cbc285107b965641"
     },
     {
       "kind": "ui-call",
@@ -24463,7 +24463,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking…",
       "surface": "apple",
-      "id": "native.apple.7ace1c606a9ae6d1"
+      "id": "native.apple.d781ade49132fec6"
     },
     {
       "kind": "conditional-branch",
@@ -24471,7 +24471,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio, tap to cancel",
       "surface": "apple",
-      "id": "native.apple.f94ee25675989434"
+      "id": "native.apple.9e4b306460f4a32d"
     },
     {
       "kind": "conditional-branch",
@@ -24479,7 +24479,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking, tap to stop",
       "surface": "apple",
-      "id": "native.apple.641f936a5583b9e0"
+      "id": "native.apple.142c01bf6b97e380"
     },
     {
       "kind": "conditional-branch",
@@ -24487,7 +24487,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Queued",
       "surface": "apple",
-      "id": "native.apple.19b4b71a188ba284"
+      "id": "native.apple.86695104895ebed8"
     },
     {
       "kind": "conditional-branch",
@@ -24495,7 +24495,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Sending…",
       "surface": "apple",
-      "id": "native.apple.2f15e75ada9fe222"
+      "id": "native.apple.a85f179b35d39d8f"
     },
     {
       "kind": "conditional-branch",
@@ -24503,7 +24503,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Confirming…",
       "surface": "apple",
-      "id": "native.apple.15e28ba0e2d92c1a"
+      "id": "native.apple.38722ea25417ad4f"
     },
     {
       "kind": "conditional-branch",
@@ -24511,7 +24511,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Delivery unknown",
       "surface": "apple",
-      "id": "native.apple.be374fc498bf16bb"
+      "id": "native.apple.78682085b14232f8"
     },
     {
       "kind": "conditional-branch",
@@ -24519,7 +24519,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Not sent",
       "surface": "apple",
-      "id": "native.apple.baa183eb2a5eca02"
+      "id": "native.apple.2888a268bfa49e9e"
     },
     {
       "kind": "conditional-branch",
@@ -24527,7 +24527,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Queued, sends when reconnected",
       "surface": "apple",
-      "id": "native.apple.bcb53d221f1881d0"
+      "id": "native.apple.593219d4c4479c59"
     },
     {
       "kind": "conditional-branch",
@@ -24535,7 +24535,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Sending",
       "surface": "apple",
-      "id": "native.apple.dad0e6c151326bae"
+      "id": "native.apple.00e673b9c5263c5c"
     },
     {
       "kind": "conditional-branch",
@@ -24543,7 +24543,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Sent, waiting for chat history confirmation",
       "surface": "apple",
-      "id": "native.apple.f82ed0bf07d5bdb1"
+      "id": "native.apple.bfe7aab77abe9a2c"
     },
     {
       "kind": "conditional-branch",
@@ -24551,7 +24551,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Delivery unconfirmed, touch and hold to retry or delete",
       "surface": "apple",
-      "id": "native.apple.eab9d75789a06b3c"
+      "id": "native.apple.7eb6eca416d33bb4"
     },
     {
       "kind": "conditional-branch",
@@ -24559,7 +24559,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Not sent, touch and hold to retry or delete",
       "surface": "apple",
-      "id": "native.apple.505063034c724544"
+      "id": "native.apple.df1a81bd7a0bca36"
     },
     {
       "kind": "ui-call",
@@ -24567,7 +24567,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Running tools…",
       "surface": "apple",
-      "id": "native.apple.14589eec3b0a4b79"
+      "id": "native.apple.6b18ea1d85b5d3a2"
     },
     {
       "kind": "ui-call",
@@ -24575,7 +24575,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "\\(display.emoji) \\(display.label)",
       "surface": "apple",
-      "id": "native.apple.e0ffb5273f89f7a0"
+      "id": "native.apple.7c99becc26501014"
     },
     {
       "kind": "ui-named-argument",
@@ -24583,7 +24583,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift",
       "source": "Pinned",
       "surface": "apple",
-      "id": "native.apple.867687a50de01ebb"
+      "id": "native.apple.63320b6d5138c0db"
     },
     {
       "kind": "conditional-branch",
@@ -24591,7 +24591,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Active",
       "surface": "apple",
-      "id": "native.apple.c320ac446bc59973"
+      "id": "native.apple.0d9f7c1e0e65a820"
     },
     {
       "kind": "conditional-branch",
@@ -24599,7 +24599,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Archived",
       "surface": "apple",
-      "id": "native.apple.c4edd77327e0cad6"
+      "id": "native.apple.3c71a4c13836cc75"
     },
     {
       "kind": "ui-call",
@@ -24607,7 +24607,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Scope",
       "surface": "apple",
-      "id": "native.apple.0ec3ac37d8b9cbe9"
+      "id": "native.apple.0489ad746c8d35c2"
     },
     {
       "kind": "ui-named-argument",
@@ -24615,7 +24615,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Search sessions",
       "surface": "apple",
-      "id": "native.apple.b7a67b9febd19c36"
+      "id": "native.apple.2c37581c7b88f741"
     },
     {
       "kind": "ui-modifier",
@@ -24623,7 +24623,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Sessions",
       "surface": "apple",
-      "id": "native.apple.dab45ff4927c1073"
+      "id": "native.apple.43be8a2336e42faf"
     },
     {
       "kind": "ui-modifier",
@@ -24631,7 +24631,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Rename Session",
       "surface": "apple",
-      "id": "native.apple.bf9dd70fa814f104"
+      "id": "native.apple.0b379cdfcbd3247f"
     },
     {
       "kind": "ui-call",
@@ -24639,7 +24639,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Session name",
       "surface": "apple",
-      "id": "native.apple.7917bd3d15457177"
+      "id": "native.apple.54b6fbd9e41db009"
     },
     {
       "kind": "ui-call",
@@ -24647,7 +24647,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Cancel",
       "surface": "apple",
-      "id": "native.apple.e8cda2d73c0320f1"
+      "id": "native.apple.833fe2915430c89d"
     },
     {
       "kind": "conditional-branch",
@@ -24655,7 +24655,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "No archived sessions",
       "surface": "apple",
-      "id": "native.apple.2fe5cf385c84439f"
+      "id": "native.apple.b67eaecec1b423ac"
     },
     {
       "kind": "conditional-branch",
@@ -24663,7 +24663,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "No sessions found",
       "surface": "apple",
-      "id": "native.apple.e7bfc76394f72597"
+      "id": "native.apple.b2435a79abf0c794"
     },
     {
       "kind": "ui-modifier",
@@ -24671,7 +24671,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Pinned",
       "surface": "apple",
-      "id": "native.apple.8b56a35cb939fc5b"
+      "id": "native.apple.05cb1fecc5844b69"
     },
     {
       "kind": "ui-call",
@@ -24679,7 +24679,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Rename",
       "surface": "apple",
-      "id": "native.apple.bbfaf47ddcce8bf4"
+      "id": "native.apple.080fce25e4a9bb61"
     },
     {
       "kind": "conditional-branch",
@@ -24687,7 +24687,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Pin",
       "surface": "apple",
-      "id": "native.apple.408be3d929be77f7"
+      "id": "native.apple.d148288258094aa6"
     },
     {
       "kind": "conditional-branch",
@@ -24695,7 +24695,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Unpin",
       "surface": "apple",
-      "id": "native.apple.b37c95b4fd1e4aa8"
+      "id": "native.apple.3c62aaf44e6ab4d4"
     },
     {
       "kind": "conditional-branch",
@@ -24703,7 +24703,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Archive",
       "surface": "apple",
-      "id": "native.apple.5c16badc72eab28a"
+      "id": "native.apple.666ba6eb696e649f"
     },
     {
       "kind": "conditional-branch",
@@ -24711,7 +24711,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Unarchive",
       "surface": "apple",
-      "id": "native.apple.fd17768ea5408e76"
+      "id": "native.apple.34b910911a05110e"
     },
     {
       "kind": "conditional-branch",
@@ -24759,7 +24759,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Retry Send",
       "surface": "apple",
-      "id": "native.apple.0399ffc649163f1e"
+      "id": "native.apple.5824df4efbf6c977"
     },
     {
       "kind": "ui-call",
@@ -24767,7 +24767,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Delete",
       "surface": "apple",
-      "id": "native.apple.9296170b1b2144c2"
+      "id": "native.apple.cdad35e9657fa693"
     },
     {
       "kind": "ui-call",
@@ -24775,7 +24775,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Stop Listening",
       "surface": "apple",
-      "id": "native.apple.cfb20c308a06ba9d"
+      "id": "native.apple.9d58b2a2a23c0d69"
     },
     {
       "kind": "ui-call",
@@ -24783,7 +24783,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Listen",
       "surface": "apple",
-      "id": "native.apple.977f6f71bc076bdd"
+      "id": "native.apple.99df7de891c8235f"
     },
     {
       "kind": "ui-call",
@@ -24791,7 +24791,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Copy Message",
       "surface": "apple",
-      "id": "native.apple.9d927293f1e1221d"
+      "id": "native.apple.fe9f30f12f1dcfaf"
     },
     {
       "kind": "ui-call",
@@ -24799,7 +24799,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest",
       "surface": "apple",
-      "id": "native.apple.66e1bdca9ef40646"
+      "id": "native.apple.f84b674ad395b694"
     },
     {
       "kind": "ui-modifier",
@@ -24807,7 +24807,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest reply",
       "surface": "apple",
-      "id": "native.apple.54f4f44846a814f4"
+      "id": "native.apple.429d825201b2cb85"
     },
     {
       "kind": "ui-named-argument",
@@ -24815,7 +24815,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.074b2b466e960e78"
+      "id": "native.apple.9ab586b85834705c"
     },
     {
       "kind": "ui-call",
@@ -24823,7 +24823,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Loading chat",
       "surface": "apple",
-      "id": "native.apple.27e6c69d5e2c08db"
+      "id": "native.apple.28c2691c03030434"
     },
     {
       "kind": "ui-modifier",
@@ -24831,7 +24831,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Dismiss",
       "surface": "apple",
-      "id": "native.apple.7a3ed586a2fc1cdd"
+      "id": "native.apple.5c481fea4eb3dc17"
     },
     {
       "kind": "ui-localized-call",
@@ -24839,7 +24839,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "Could not attach voice note: \\(error.localizedDescription)",
       "surface": "apple",
-      "id": "native.apple.ca9493176c336c60"
+      "id": "native.apple.82befa424fe7bace"
     },
     {
       "kind": "ui-localized-call",
@@ -24847,7 +24847,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "Voice note exceeds the 5 MB attachment limit",
       "surface": "apple",
-      "id": "native.apple.148b7fb638070466"
+      "id": "native.apple.ec5daba7e38184dc"
     },
     {
       "kind": "conditional-branch",
@@ -24855,7 +24855,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "\\(baseName).jpg",
       "surface": "apple",
-      "id": "native.apple.d0c9d4d007b2fe58"
+      "id": "native.apple.82c2287cd78da56f"
     },
     {
       "kind": "conditional-branch",
@@ -24879,7 +24879,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "delivery unconfirmed",
       "surface": "apple",
-      "id": "native.apple.6ba00167996b4263"
+      "id": "native.apple.2b45abdc56b2caed"
     },
     {
       "kind": "conditional-branch",
@@ -24887,7 +24887,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "queued after route change",
       "surface": "apple",
-      "id": "native.apple.f2d9e7a0937f0f5c"
+      "id": "native.apple.722f1f90b97e8e45"
     },
     {
       "kind": "ui-localized-call",
@@ -24895,7 +24895,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before switching chats.",
       "surface": "apple",
-      "id": "native.apple.93ba9ee66114532a"
+      "id": "native.apple.710c7bd117a7cc12"
     },
     {
       "kind": "ui-localized-call",
@@ -24903,7 +24903,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before starting a new chat.",
       "surface": "apple",
-      "id": "native.apple.fa3c2d1c4e5c1610"
+      "id": "native.apple.d93e6fe16ec1b0e5"
     },
     {
       "kind": "ui-modifier",
@@ -24911,7 +24911,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Clear this session's history?",
       "surface": "apple",
-      "id": "native.apple.c30842a34c0dbeaa"
+      "id": "native.apple.87ba543b42696b92"
     },
     {
       "kind": "ui-call",
@@ -24919,7 +24919,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Clear History",
       "surface": "apple",
-      "id": "native.apple.7c47639bfb532810"
+      "id": "native.apple.6192578088f1b100"
     },
     {
       "kind": "ui-call",
@@ -24927,7 +24927,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "This resets the conversation for \\(self.activeSessionTitle). The session key stays the same.",
       "surface": "apple",
-      "id": "native.apple.18bde57ec1737f33"
+      "id": "native.apple.ca701776b3d9ce70"
     },
     {
       "kind": "ui-call",
@@ -24935,7 +24935,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Export Transcript",
       "surface": "apple",
-      "id": "native.apple.fd2ce51f4d8e0c16"
+      "id": "native.apple.2ee7858b00a47c42"
     },
     {
       "kind": "ui-call",
@@ -24943,7 +24943,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Thinking",
       "surface": "apple",
-      "id": "native.apple.34b6e23c835cad90"
+      "id": "native.apple.b1f10b5e9113881d"
     },
     {
       "kind": "ui-modifier",
@@ -24951,7 +24951,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Thinking level",
       "surface": "apple",
-      "id": "native.apple.432204f516a5d6cb"
+      "id": "native.apple.48dde5fe65b841a3"
     },
     {
       "kind": "ui-call",
@@ -24959,7 +24959,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Pinned",
       "surface": "apple",
-      "id": "native.apple.88055057e800e9d7"
+      "id": "native.apple.17ea1ddec4a7b7a8"
     },
     {
       "kind": "ui-call",
@@ -24967,7 +24967,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Recent",
       "surface": "apple",
-      "id": "native.apple.76416eba17946ba3"
+      "id": "native.apple.f5bbceea34d12623"
     },
     {
       "kind": "ui-call",
@@ -24975,7 +24975,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Models",
       "surface": "apple",
-      "id": "native.apple.fcfb8eca34977f8c"
+      "id": "native.apple.f41f892742244520"
     },
     {
       "kind": "ui-call",
@@ -24983,7 +24983,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Model",
       "surface": "apple",
-      "id": "native.apple.4142eb0c3721ba95"
+      "id": "native.apple.273aa7b9194a8d0d"
     },
     {
       "kind": "ui-call",
@@ -24991,7 +24991,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Refresh",
       "surface": "apple",
-      "id": "native.apple.5d5c36afdc42855f"
+      "id": "native.apple.5361129a24118af6"
     },
     {
       "kind": "ui-call",
@@ -24999,7 +24999,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Export Transcript…",
       "surface": "apple",
-      "id": "native.apple.24f1f311dfba03d5"
+      "id": "native.apple.9b2ad72143b931bf"
     },
     {
       "kind": "ui-call",
@@ -25007,7 +25007,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Clear History…",
       "surface": "apple",
-      "id": "native.apple.6e8f27111bdf8685"
+      "id": "native.apple.4b24d792545e5086"
     },
     {
       "kind": "ui-call",
@@ -25015,7 +25015,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Session",
       "surface": "apple",
-      "id": "native.apple.5513db0da0a88eb6"
+      "id": "native.apple.920fe8a7a33f9e92"
     },
     {
       "kind": "ui-modifier",
@@ -25023,7 +25023,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Session actions",
       "surface": "apple",
-      "id": "native.apple.a4986742449874ad"
+      "id": "native.apple.185a401f78328b0f"
     },
     {
       "kind": "ui-call",
@@ -25031,7 +25031,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Session cost \\(ChatContextUsageFormatter.cost(cost))",
       "surface": "apple",
-      "id": "native.apple.a5124b2fde49e645"
+      "id": "native.apple.547fe762a61d08a6"
     },
     {
       "kind": "ui-call",
@@ -25039,7 +25039,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Compact Session",
       "surface": "apple",
-      "id": "native.apple.076b729703163c3d"
+      "id": "native.apple.f0a4720df5f5f403"
     },
     {
       "kind": "ui-named-argument",
@@ -25047,7 +25047,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Search sessions",
       "surface": "apple",
-      "id": "native.apple.aee00276ee72ce99"
+      "id": "native.apple.0b9fc81ff2031799"
     },
     {
       "kind": "conditional-branch",
@@ -25055,7 +25055,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "No Results",
       "surface": "apple",
-      "id": "native.apple.6343b2e6129c02b8"
+      "id": "native.apple.f10d5ccfd0530fec"
     },
     {
       "kind": "conditional-branch",
@@ -25063,7 +25063,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "No Sessions",
       "surface": "apple",
-      "id": "native.apple.73d51b329a4a0436"
+      "id": "native.apple.42b0ee4c8b3326b6"
     },
     {
       "kind": "ui-call",
@@ -25071,7 +25071,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "New Session",
       "surface": "apple",
-      "id": "native.apple.920a0842d2282cd6"
+      "id": "native.apple.eb58552e43c8dde2"
     },
     {
       "kind": "ui-modifier",
@@ -25079,7 +25079,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "New session",
       "surface": "apple",
-      "id": "native.apple.17bc26471a0deb71"
+      "id": "native.apple.247771e4350c006f"
     },
     {
       "kind": "ui-call",
@@ -25087,7 +25087,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Delete Session",
       "surface": "apple",
-      "id": "native.apple.4ae30ec826d4e2c9"
+      "id": "native.apple.d9a72d07e8d95d35"
     },
     {
       "kind": "ui-call",
@@ -25095,7 +25095,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "The session and its transcript are removed from the gateway.",
       "surface": "apple",
-      "id": "native.apple.6466310a79ba3fb9"
+      "id": "native.apple.499537ec30a28ae0"
     },
     {
       "kind": "ui-modifier",
@@ -25103,7 +25103,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Unread",
       "surface": "apple",
-      "id": "native.apple.e840198e8640d89e"
+      "id": "native.apple.1bd1b747fd161df5"
     },
     {
       "kind": "conditional-branch",
@@ -25111,7 +25111,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Pin",
       "surface": "apple",
-      "id": "native.apple.86b5ad3787a5fb63"
+      "id": "native.apple.a8a2f4b248663f97"
     },
     {
       "kind": "conditional-branch",
@@ -25119,7 +25119,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Unpin",
       "surface": "apple",
-      "id": "native.apple.f4327b2a30a5cec4"
+      "id": "native.apple.8768f9ed198edc54"
     },
     {
       "kind": "ui-call",
@@ -25127,7 +25127,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Copy Session Key",
       "surface": "apple",
-      "id": "native.apple.76d9c8c2860edb32"
+      "id": "native.apple.27ddbe5e4643b60f"
     },
     {
       "kind": "ui-call",
@@ -25135,7 +25135,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Delete Session…",
       "surface": "apple",
-      "id": "native.apple.a5ed649fd45061cf"
+      "id": "native.apple.a994d072ab35cb35"
     },
     {
       "kind": "conditional-branch",
@@ -25143,7 +25143,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Connecting…",
       "surface": "apple",
-      "id": "native.apple.f94741348470ac9b"
+      "id": "native.apple.22d5ce71e22a7f73"
     },
     {
       "kind": "conditional-branch",
@@ -25151,7 +25151,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
       "source": "Gateway connected",
       "surface": "apple",
-      "id": "native.apple.9230cb93205a9a6d"
+      "id": "native.apple.8d0606ab1a2c0f44"
     },
     {
       "kind": "ui-call",
@@ -25167,7 +25167,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteComposerViews.swift",
       "source": "Record Voice Note",
       "surface": "apple",
-      "id": "native.apple.19a81624cefb644f"
+      "id": "native.apple.71e0219d1501de06"
     },
     {
       "kind": "ui-modifier",
@@ -25175,7 +25175,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteComposerViews.swift",
       "source": "Record voice note",
       "surface": "apple",
-      "id": "native.apple.2b6768d908e17d3b"
+      "id": "native.apple.e6770d7cc616021f"
     },
     {
       "kind": "ui-modifier",
@@ -25183,7 +25183,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteComposerViews.swift",
       "source": "Recording",
       "surface": "apple",
-      "id": "native.apple.374831d59c35d337"
+      "id": "native.apple.4a226d89671518e1"
     },
     {
       "kind": "ui-modifier",
@@ -25191,7 +25191,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteComposerViews.swift",
       "source": "Cancel voice note",
       "surface": "apple",
-      "id": "native.apple.820da20ec0bdc6ef"
+      "id": "native.apple.0fb64b1b7ea0aa5e"
     },
     {
       "kind": "ui-modifier",
@@ -25199,7 +25199,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteComposerViews.swift",
       "source": "Finish voice note",
       "surface": "apple",
-      "id": "native.apple.cf194c67a68eb7ff"
+      "id": "native.apple.b7a9de9b3c8e4bad"
     },
     {
       "kind": "ui-localized-call",
@@ -25207,7 +25207,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift",
       "source": "Another feature is using the microphone.",
       "surface": "apple",
-      "id": "native.apple.fdd9ab1433eb5ae3"
+      "id": "native.apple.6d9fb086956fe48a"
     },
     {
       "kind": "ui-localized-call",
@@ -25215,7 +25215,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift",
       "source": "Microphone access is required. Enable it in Settings.",
       "surface": "apple",
-      "id": "native.apple.ca02c18298949313"
+      "id": "native.apple.1fc7530ccdfc937e"
     },
     {
       "kind": "ui-localized-call",
@@ -25223,7 +25223,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift",
       "source": "Could not start recording: \\(error.localizedDescription)",
       "surface": "apple",
-      "id": "native.apple.c3a3ee46fd4d7550"
+      "id": "native.apple.c963f6dfaa0610b5"
     },
     {
       "kind": "ui-localized-call",
@@ -25231,7 +25231,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift",
       "source": "Recording was interrupted. Try again.",
       "surface": "apple",
-      "id": "native.apple.510e9bd5beb36673"
+      "id": "native.apple.bb00abc2aa9ae5e1"
     },
     {
       "kind": "conditional-branch",
@@ -25239,7 +25239,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectionProblem.swift",
       "source": "Retry once",
       "surface": "apple",
-      "id": "native.apple.8d54365d14d49a6c"
+      "id": "native.apple.59aa8697b933d6b6"
     },
     {
       "kind": "conditional-branch",
@@ -25247,7 +25247,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectionProblem.swift",
       "source": "Update gateway token",
       "surface": "apple",
-      "id": "native.apple.64766643b05237f9"
+      "id": "native.apple.82effdf06c40ec03"
     },
     {
       "kind": "conditional-branch",
@@ -25255,7 +25255,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectionProblem.swift",
       "source": " The new certificate is trusted by this device; this is commonly caused by certificate rotation.",
       "surface": "apple",
-      "id": "native.apple.22c799a546080d56"
+      "id": "native.apple.0bfc4194742bc860"
     },
     {
       "kind": "conditional-branch",
@@ -25263,7 +25263,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectionProblem.swift",
       "source": " This device could not verify the new certificate.",
       "surface": "apple",
-      "id": "native.apple.902e16355bb2f822"
+      "id": "native.apple.31178752f837d528"
     },
     {
       "kind": "conditional-branch",
@@ -25271,7 +25271,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayDiscoveryStatusText.swift",
       "source": "Idle",
       "surface": "apple",
-      "id": "native.apple.8240ef6286e413ae"
+      "id": "native.apple.a825441f646eb195"
     },
     {
       "kind": "conditional-branch",
@@ -25279,7 +25279,7 @@
       "path": "apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayDiscoveryStatusText.swift",
       "source": "Setup",
       "surface": "apple",
-      "id": "native.apple.435b9166934b8447"
+      "id": "native.apple.0cb1206714c2bf4d"
     },
     {
       "kind": "conditional-branch",

--- a/apps/android/CHANGELOG.md
+++ b/apps/android/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+Creates or adopts Android's existing per-device chat session before loading connected history, preserving prior conversations while isolating each device. Thanks @snowzlmbot.
 Routes exec approval review through the Gateway's durable approval records, including first-answer-wins results from other authorized surfaces, fail-closed reconciliation after ambiguous writes, and compatibility with older Gateway v4 peers.
 Keeps Android session search in the Sessions screen with direct focus, clear controls, and accurate loading and no-match states. Thanks @IWhatsskill.
 Shows the localized app version, Git commit, and build date together on the About screen, with real provenance in repository-backed debug builds.

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -12,6 +12,7 @@ OpenClaw Android is the officially released Google Play app. It connects to an O
 - [x] QR code scanning in onboarding
 - [x] Performance improvements
 - [x] Streaming support in chat UI
+- [x] Dedicated per-device Android chat session created/adopted on connect without resetting history
 - [x] Request camera/location and other permissions in onboarding/settings flow
 - [x] Push notifications for gateway/chat status updates
 - [x] Security hardening (biometric lock, token handling, safer defaults)

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -11,6 +11,7 @@ import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.ChatThinkingLevelSelection
 import ai.openclaw.app.chat.ChatTranscriptCache
+import ai.openclaw.app.chat.MainSessionBinding
 import ai.openclaw.app.chat.MessageSpeechClient
 import ai.openclaw.app.chat.MessageSpeechController
 import ai.openclaw.app.chat.MessageSpeechState
@@ -915,9 +916,11 @@ class NodeRuntime private constructor(
         replaceGatewayMethods(hello.methods)
         _operatorScopes.value = normalizeOperatorScopes(hello.authScopes)
         _seamColorArgb.value = DEFAULT_SEAM_COLOR_ARGB
-        syncMainSessionKey(resolveAgentIdFromMainSessionKey(hello.mainSessionKey))
-        // Every successful connection refreshes history; reconnects preserve local run ownership.
-        chat.onGatewayConnected()
+        val mainSessionKey =
+          prepareMainSessionKey(resolveAgentIdFromMainSessionKey(hello.mainSessionKey))
+        // Create/adopt before history refresh; this keeps the first connected read on the
+        // device-owned session without changing the shipped key or its existing transcript.
+        chat.onGatewayConnected(mainSessionBinding(mainSessionKey))
         refreshGatewayControlPage()
         updateStatus {
           operatorConnectionProblem = null
@@ -1381,15 +1384,44 @@ class NodeRuntime private constructor(
 
   private fun syncMainSessionKey(agentId: String?) {
     val resolvedKey = resolveNodeMainSessionKey(agentId)
-    // Always push the resolved session key into TalkMode, even when the
-    // state flow value is unchanged, so lazy TalkMode instances do not
-    // stay on the default "main" session key.
     talkMode.setMainSessionKey(resolvedKey)
     if (_mainSessionKey.value == resolvedKey) return
     _mainSessionKey.value = resolvedKey
-    chat.applyMainSessionKey(resolvedKey)
+    if (operatorConnected) {
+      chat.prepareMainSessionKey(resolvedKey)
+      chat.onGatewayConnected(mainSessionBinding(resolvedKey))
+    } else {
+      chat.applyMainSessionKey(resolvedKey)
+    }
     updateHomeCanvasState()
   }
+
+  private fun prepareMainSessionKey(agentId: String?): String {
+    val resolvedKey = resolveNodeMainSessionKey(agentId)
+    // Always push into TalkMode so a lazy instance cannot retain the "main" alias.
+    talkMode.setMainSessionKey(resolvedKey)
+    if (_mainSessionKey.value != resolvedKey) {
+      _mainSessionKey.value = resolvedKey
+      updateHomeCanvasState()
+    }
+    chat.prepareMainSessionKey(resolvedKey)
+    return resolvedKey
+  }
+
+  private fun selectMainSessionKey(agentId: String) {
+    val resolvedKey = resolveNodeMainSessionKey(agentId)
+    talkMode.setMainSessionKey(resolvedKey)
+    _mainSessionKey.value = resolvedKey
+    chat.prepareAndSelectMainSessionKey(resolvedKey)
+    chat.onGatewayConnected(mainSessionBinding(resolvedKey))
+    updateHomeCanvasState()
+  }
+
+  private fun mainSessionBinding(sessionKey: String): MainSessionBinding =
+    MainSessionBinding(
+      key = sessionKey,
+      label = buildAndroidAppSessionLabel(prefs.displayName.value, identityStore.loadOrCreate().deviceId),
+    )
 
   private fun updateStatus(update: () -> Unit = {}) {
     synchronized(gatewayStatusLock) {
@@ -3642,8 +3674,7 @@ class NodeRuntime private constructor(
     // Agent selection owns every main-session consumer; switching chat alone would
     // leave Talk mode and the home canvas bound to the previous agent.
     selectedChatAgentId = normalizedAgentId
-    syncMainSessionKey(normalizedAgentId)
-    chat.switchSession(_mainSessionKey.value)
+    selectMainSessionKey(normalizedAgentId)
   }
 
   suspend fun fetchChatSessionList(

--- a/apps/android/app/src/main/java/ai/openclaw/app/SessionKey.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SessionKey.kt
@@ -25,3 +25,13 @@ internal fun buildNodeMainSessionKey(
   val resolvedAgentId = agentId?.trim().orEmpty().ifEmpty { "main" }
   return "agent:$resolvedAgentId:node-${deviceId.take(12)}"
 }
+
+/** Human-readable, device-unique label applied when Android creates or adopts its session. */
+internal fun buildAndroidAppSessionLabel(
+  displayName: String?,
+  deviceId: String,
+): String {
+  val deviceSuffix = deviceId.take(12)
+  val displaySuffix = displayName?.trim()?.take(96)?.takeIf { it.isNotEmpty() }
+  return listOfNotNull("OpenClaw App", displaySuffix, deviceSuffix).joinToString(" · ")
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -45,6 +45,17 @@ internal data class ChatCacheScope(
   val connectionGeneration: Long,
 )
 
+internal data class MainSessionBinding(
+  val key: String,
+  val label: String,
+)
+
+private data class MainSessionReadiness(
+  val gatewayScope: ChatCacheScope,
+  val binding: MainSessionBinding,
+  val ready: CompletableDeferred<Unit>,
+)
+
 class ChatController internal constructor(
   private val scope: CoroutineScope,
   private val json: Json,
@@ -162,6 +173,13 @@ class ChatController internal constructor(
   private val historyRequestSequence = AtomicLong(0)
   private val modelSelectionGeneration = AtomicLong(0)
   private val sessionsRequestSequence = AtomicLong(0)
+
+  // Every live history path awaits this gateway/session readiness. Per-gateway locking keeps
+  // rapid agent switches from letting an older lookup refresh before the new session is ready.
+  private val mainSessionAdoptionLocks = ConcurrentHashMap<String, Mutex>()
+  private val desiredMainSessions = ConcurrentHashMap<String, MainSessionBinding>()
+  private val mainSessionReadinessLock = Any()
+  private var mainSessionReadiness: MainSessionReadiness? = null
   private val gatewayScopeApplyLock = Any()
   private var latestAppliedHistoryRequest = 0L
   private var latestAppliedInFlightRunId: String? = null
@@ -260,6 +278,81 @@ class ChatController internal constructor(
 
   /** Refreshes the connected gateway while preserving recovery ownership after a disconnect. */
   fun onGatewayConnected() {
+    refreshConnectedGateway()
+  }
+
+  /** Creates/adopts the app-owned main session before connected history can load. */
+  internal fun onGatewayConnected(mainSession: MainSessionBinding) {
+    val requestScope = currentCacheScope()
+    if (requestScope == null) {
+      refreshConnectedGateway()
+      return
+    }
+    desiredMainSessions[requestScope.gatewayId] = mainSession
+    val readiness = CompletableDeferred<Unit>()
+    val supersededReadiness =
+      synchronized(mainSessionReadinessLock) {
+        val current = mainSessionReadiness
+        if (
+          current?.gatewayScope == requestScope &&
+          current.binding == mainSession &&
+          !current.ready.isCompleted
+        ) {
+          return
+        }
+        mainSessionReadiness = MainSessionReadiness(requestScope, mainSession, readiness)
+        current?.ready
+      }
+    supersededReadiness?.complete(Unit)
+    scope.launch {
+      try {
+        val adoptionLock = mainSessionAdoptionLocks.computeIfAbsent(requestScope.gatewayId) { Mutex() }
+        adoptionLock.withLock {
+          if (desiredMainSessions[requestScope.gatewayId] != mainSession) return@withLock
+          try {
+            val describeParams = buildJsonObject { put("key", JsonPrimitive(mainSession.key)) }
+            val describeResponse =
+              requestGatewayBound(requestScope.gatewayId, "sessions.describe", describeParams.toString())
+            val describeRoot = json.parseToJsonElement(describeResponse).asObjectOrNull() ?: error("invalid sessions.describe response")
+            if (!describeRoot.containsKey("session")) error("sessions.describe returned no session field")
+            if (desiredMainSessions[requestScope.gatewayId] != mainSession) return@withLock
+            val existingSession = describeRoot["session"].asObjectOrNull()
+            val existingLabel =
+              existingSession
+                ?.get("label")
+                .asStringOrNull()
+                ?.trim()
+                ?.takeIf { it.isNotEmpty() }
+            if (existingSession == null || existingLabel == null) {
+              val createParams =
+                buildJsonObject {
+                  put("key", JsonPrimitive(mainSession.key))
+                  put("agentId", JsonPrimitive(resolveAgentIdForSessionKey(mainSession.key)))
+                  put("label", JsonPrimitive(mainSession.label))
+                }
+              requestGatewayBound(requestScope.gatewayId, "sessions.create", createParams.toString())
+            }
+          } catch (err: CancellationException) {
+            throw err
+          } catch (_: Throwable) {
+            // History remains usable under the already-bound key when adoption cannot be verified.
+          }
+        }
+      } finally {
+        readiness.complete(Unit)
+      }
+      // A superseded connect owns the next refresh and must not inherit this response.
+      if (
+        requestScope != currentCacheScope() ||
+        desiredMainSessions[requestScope.gatewayId] != mainSession
+      ) {
+        return@launch
+      }
+      refreshConnectedGateway()
+    }
+  }
+
+  private fun refreshConnectedGateway() {
     if (!restoreRunStateOnReconnect) {
       refresh()
       return
@@ -270,6 +363,13 @@ class ChatController internal constructor(
 
   /** Invalidates and clears gateway-bound UI state before a target switch can race old responses. */
   fun onGatewayScopeChanging(retireRunState: Boolean = false) {
+    val staleReadiness =
+      synchronized(mainSessionReadinessLock) {
+        val current = mainSessionReadiness
+        mainSessionReadiness = null
+        current?.ready
+      }
+    staleReadiness?.complete(Unit)
     synchronized(gatewayScopeApplyLock) {
       if (retireRunState) {
         restoreRunStateOnReconnect = false
@@ -330,6 +430,25 @@ class ChatController internal constructor(
 
   /** Rebinds chat to a new canonical main session key after gateway hello/agent changes. */
   fun applyMainSessionKey(mainSessionKey: String) {
+    bindMainSessionKey(mainSessionKey, loadHistory = true)
+  }
+
+  /** Rebinds without loading; the connected lifecycle creates/adopts the session first. */
+  internal fun prepareMainSessionKey(mainSessionKey: String) {
+    bindMainSessionKey(mainSessionKey, loadHistory = false)
+  }
+
+  /** Selects a newly chosen agent's main session without racing history ahead of adoption. */
+  internal fun prepareAndSelectMainSessionKey(mainSessionKey: String) {
+    bindMainSessionKey(mainSessionKey, loadHistory = false)
+    val key = normalizeRequestedSessionKey(mainSessionKey)
+    if (_sessionKey.value != key) beginHistoryLoad(key, clearMessages = true)
+  }
+
+  private fun bindMainSessionKey(
+    mainSessionKey: String,
+    loadHistory: Boolean,
+  ) {
     val trimmed = mainSessionKey.trim()
     if (trimmed.isEmpty()) return
     val nextState =
@@ -341,6 +460,7 @@ class ChatController internal constructor(
     appliedMainSessionKey = nextState.appliedMainSessionKey
     if (_sessionKey.value == nextState.currentSessionKey) return
     val generation = beginHistoryLoad(nextState.currentSessionKey, clearMessages = true)
+    if (!loadHistory) return
     scope.launch {
       bootstrap(
         sessionKey = nextState.currentSessionKey,
@@ -1321,6 +1441,13 @@ class ChatController internal constructor(
     val requestSequence = historyRequestSequence.incrementAndGet()
     val requestModelSelectionGeneration = modelSelectionGeneration.get()
     val requestCacheScope = currentCacheScope()
+    awaitMainSessionReadiness(sessionKey, requestCacheScope)
+    if (
+      !isCurrentHistoryLoad(sessionKey, _sessionKey.value, generation, historyLoadGeneration.get()) ||
+      requestCacheScope != currentCacheScope()
+    ) {
+      return false
+    }
     val history =
       try {
         val historyJson =
@@ -1415,6 +1542,20 @@ class ChatController internal constructor(
     persistTranscript(requestCacheScope, sessionKey, history.messages)
     confirmDurableSendsFromHistory(requestCacheScope, history)
     return true
+  }
+
+  private suspend fun awaitMainSessionReadiness(
+    sessionKey: String,
+    requestScope: ChatCacheScope?,
+  ) {
+    val readiness =
+      synchronized(mainSessionReadinessLock) {
+        mainSessionReadiness
+          ?.takeIf { state ->
+            state.gatewayScope == requestScope && state.binding.key == sessionKey
+          }?.ready
+      }
+    readiness?.await()
   }
 
   /** Canonical history is the only proof that retires journaled sends; every apply checks it. */

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -440,6 +440,9 @@ class ChatController internal constructor(
 
   /** Selects a newly chosen agent's main session without racing history ahead of adoption. */
   internal fun prepareAndSelectMainSessionKey(mainSessionKey: String) {
+    val selectedKey = mainSessionKey.trim()
+    if (selectedKey.isEmpty()) return
+    prepareSessionSelection(selectedKey)
     bindMainSessionKey(mainSessionKey, loadHistory = false)
     val key = normalizeRequestedSessionKey(mainSessionKey)
     if (_sessionKey.value != key) beginHistoryLoad(key, clearMessages = true)
@@ -802,16 +805,20 @@ class ChatController internal constructor(
   fun switchSession(sessionKey: String) {
     val key = normalizeRequestedSessionKey(sessionKey)
     if (key.isEmpty()) return
-    if (key != unreadPatchSessionKey) {
-      unreadPatchSessionKey = key
-      unreadPatchRequested = false
-    }
-    acknowledgeUnreadIfNeeded(key, _sessions.value.firstOrNull { it.key == key })
+    prepareSessionSelection(key)
     if (key == _sessionKey.value) return
     val generation = beginHistoryLoad(key, clearMessages = true)
     scope.launch {
       bootstrap(sessionKey = key, generation = generation, forceHealth = true, refreshSessions = false)
     }
+  }
+
+  private fun prepareSessionSelection(key: String) {
+    if (key != unreadPatchSessionKey) {
+      unreadPatchSessionKey = key
+      unreadPatchRequested = false
+    }
+    acknowledgeUnreadIfNeeded(key, _sessions.value.firstOrNull { it.key == key })
   }
 
   private fun beginHistoryLoad(

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -318,17 +318,9 @@ class ChatController internal constructor(
                   .asStringOrNull()
                   ?.trim()
                   ?.takeIf { it.isNotEmpty() }
-              if (existingSession == null) {
-                val createParams =
-                  buildJsonObject {
-                    put("key", JsonPrimitive(mainSession.key))
-                    put("agentId", JsonPrimitive(resolveAgentIdForSessionKey(mainSession.key)))
-                    put("label", JsonPrimitive(mainSession.label))
-                  }
-                requestGatewayBound(requestScope.gatewayId, "sessions.create", createParams.toString())
-              } else if (existingLabel == null) {
-                // An existing unlabeled session owns upgrade history already. Patch metadata instead
-                // of replaying create lifecycle behavior against that live session.
+              if (existingLabel == null) {
+                // Label-only sessions.patch is operator.write-scoped and atomically upserts the row,
+                // avoiding the concurrent-session identity race in sessions.create.
                 val patchParams =
                   buildJsonObject {
                     put("key", JsonPrimitive(mainSession.key))

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -50,11 +50,13 @@ internal data class MainSessionBinding(
   val label: String,
 )
 
-private data class MainSessionReadiness(
+private class MainSessionReadiness(
   val gatewayScope: ChatCacheScope,
   val binding: MainSessionBinding,
   val ready: CompletableDeferred<Unit>,
-)
+) {
+  var job: Job? = null
+}
 
 class ChatController internal constructor(
   private val scope: CoroutineScope,
@@ -247,6 +249,7 @@ class ChatController internal constructor(
 
   /** Clears transient chat state when the operator gateway session disconnects. */
   fun onDisconnected(message: String) {
+    retireMainSessionReadiness()
     historyLoadGeneration.incrementAndGet()
     restoreRunStateOnReconnect = true
     reconnectRecoveryGeneration = null
@@ -289,67 +292,78 @@ class ChatController internal constructor(
       return
     }
     desiredMainSessions[requestScope.gatewayId] = mainSession
-    val readiness = CompletableDeferred<Unit>()
+    val readiness =
+      MainSessionReadiness(
+        gatewayScope = requestScope,
+        binding = mainSession,
+        ready = CompletableDeferred(),
+      )
+    val adoptionJob =
+      scope.launch(start = CoroutineStart.LAZY) {
+        try {
+          val adoptionLock = mainSessionAdoptionLocks.computeIfAbsent(requestScope.gatewayId) { Mutex() }
+          adoptionLock.withLock {
+            if (desiredMainSessions[requestScope.gatewayId] != mainSession) return@withLock
+            try {
+              val describeParams = buildJsonObject { put("key", JsonPrimitive(mainSession.key)) }
+              val describeResponse =
+                requestGatewayBound(requestScope.gatewayId, "sessions.describe", describeParams.toString())
+              val describeRoot = json.parseToJsonElement(describeResponse).asObjectOrNull() ?: error("invalid sessions.describe response")
+              if (!describeRoot.containsKey("session")) error("sessions.describe returned no session field")
+              if (desiredMainSessions[requestScope.gatewayId] != mainSession) return@withLock
+              val existingSession = describeRoot["session"].asObjectOrNull()
+              val existingLabel =
+                existingSession
+                  ?.get("label")
+                  .asStringOrNull()
+                  ?.trim()
+                  ?.takeIf { it.isNotEmpty() }
+              if (existingSession == null) {
+                val createParams =
+                  buildJsonObject {
+                    put("key", JsonPrimitive(mainSession.key))
+                    put("agentId", JsonPrimitive(resolveAgentIdForSessionKey(mainSession.key)))
+                    put("label", JsonPrimitive(mainSession.label))
+                  }
+                requestGatewayBound(requestScope.gatewayId, "sessions.create", createParams.toString())
+              } else if (existingLabel == null) {
+                // An existing unlabeled session owns upgrade history already. Patch metadata instead
+                // of replaying create lifecycle behavior against that live session.
+                val patchParams =
+                  buildJsonObject {
+                    put("key", JsonPrimitive(mainSession.key))
+                    put("label", JsonPrimitive(mainSession.label))
+                  }
+                requestGatewayBound(requestScope.gatewayId, "sessions.patch", patchParams.toString())
+              }
+            } catch (err: CancellationException) {
+              throw err
+            } catch (_: Throwable) {
+              // History remains usable under the already-bound key when adoption cannot be verified.
+            }
+          }
+        } finally {
+          readiness.ready.complete(Unit)
+        }
+        // A superseded connect owns the next refresh and must not inherit this response.
+        if (
+          synchronized(mainSessionReadinessLock) { mainSessionReadiness === readiness } &&
+          requestScope == currentCacheScope() &&
+          desiredMainSessions[requestScope.gatewayId] == mainSession
+        ) {
+          refreshConnectedGateway()
+        }
+      }
+    readiness.job = adoptionJob
     val supersededReadiness =
       synchronized(mainSessionReadinessLock) {
         val current = mainSessionReadiness
-        if (
-          current?.gatewayScope == requestScope &&
-          current.binding == mainSession &&
-          !current.ready.isCompleted
-        ) {
-          return
-        }
-        mainSessionReadiness = MainSessionReadiness(requestScope, mainSession, readiness)
-        current?.ready
+        mainSessionReadiness = readiness
+        current
       }
-    supersededReadiness?.complete(Unit)
-    scope.launch {
-      try {
-        val adoptionLock = mainSessionAdoptionLocks.computeIfAbsent(requestScope.gatewayId) { Mutex() }
-        adoptionLock.withLock {
-          if (desiredMainSessions[requestScope.gatewayId] != mainSession) return@withLock
-          try {
-            val describeParams = buildJsonObject { put("key", JsonPrimitive(mainSession.key)) }
-            val describeResponse =
-              requestGatewayBound(requestScope.gatewayId, "sessions.describe", describeParams.toString())
-            val describeRoot = json.parseToJsonElement(describeResponse).asObjectOrNull() ?: error("invalid sessions.describe response")
-            if (!describeRoot.containsKey("session")) error("sessions.describe returned no session field")
-            if (desiredMainSessions[requestScope.gatewayId] != mainSession) return@withLock
-            val existingSession = describeRoot["session"].asObjectOrNull()
-            val existingLabel =
-              existingSession
-                ?.get("label")
-                .asStringOrNull()
-                ?.trim()
-                ?.takeIf { it.isNotEmpty() }
-            if (existingSession == null || existingLabel == null) {
-              val createParams =
-                buildJsonObject {
-                  put("key", JsonPrimitive(mainSession.key))
-                  put("agentId", JsonPrimitive(resolveAgentIdForSessionKey(mainSession.key)))
-                  put("label", JsonPrimitive(mainSession.label))
-                }
-              requestGatewayBound(requestScope.gatewayId, "sessions.create", createParams.toString())
-            }
-          } catch (err: CancellationException) {
-            throw err
-          } catch (_: Throwable) {
-            // History remains usable under the already-bound key when adoption cannot be verified.
-          }
-        }
-      } finally {
-        readiness.complete(Unit)
-      }
-      // A superseded connect owns the next refresh and must not inherit this response.
-      if (
-        requestScope != currentCacheScope() ||
-        desiredMainSessions[requestScope.gatewayId] != mainSession
-      ) {
-        return@launch
-      }
-      refreshConnectedGateway()
-    }
+    supersededReadiness?.job?.cancel()
+    supersededReadiness?.ready?.complete(Unit)
+    adoptionJob.start()
   }
 
   private fun refreshConnectedGateway() {
@@ -363,13 +377,7 @@ class ChatController internal constructor(
 
   /** Invalidates and clears gateway-bound UI state before a target switch can race old responses. */
   fun onGatewayScopeChanging(retireRunState: Boolean = false) {
-    val staleReadiness =
-      synchronized(mainSessionReadinessLock) {
-        val current = mainSessionReadiness
-        mainSessionReadiness = null
-        current?.ready
-      }
-    staleReadiness?.complete(Unit)
+    retireMainSessionReadiness()
     synchronized(gatewayScopeApplyLock) {
       if (retireRunState) {
         restoreRunStateOnReconnect = false
@@ -398,6 +406,17 @@ class ChatController internal constructor(
       // Outbox rows are gateway-scoped too; the next publish repopulates them for the new scope.
       _outboxItems.value = emptyList()
     }
+  }
+
+  private fun retireMainSessionReadiness() {
+    val staleReadiness =
+      synchronized(mainSessionReadinessLock) {
+        val current = mainSessionReadiness
+        mainSessionReadiness = null
+        current
+      }
+    staleReadiness?.job?.cancel()
+    staleReadiness?.ready?.complete(Unit)
   }
 
   /** Restores the selected gateway's local state without waiting for transport availability. */

--- a/apps/android/app/src/test/java/ai/openclaw/app/SessionKeyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SessionKeyTest.kt
@@ -13,6 +13,15 @@ class SessionKeyTest {
   }
 
   @Test
+  fun buildAndroidAppSessionLabelIncludesDeviceDisplayName() {
+    assertEquals("OpenClaw App · 1234567890ab", buildAndroidAppSessionLabel(null, "1234567890abcdef"))
+    assertEquals(
+      "OpenClaw App · Pixel · 1234567890ab",
+      buildAndroidAppSessionLabel(" Pixel ", "1234567890abcdef"),
+    )
+  }
+
+  @Test
   fun resolveAgentIdFromMainSessionKeyParsesCanonicalAgentKey() {
     assertEquals("ops", resolveAgentIdFromMainSessionKey("agent:ops:main"))
     assertNull(resolveAgentIdFromMainSessionKey("global"))

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerReconnectRestoreTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerReconnectRestoreTest.kt
@@ -92,6 +92,37 @@ class ChatControllerReconnectRestoreTest {
 
   @Test
   @OptIn(ExperimentalCoroutinesApi::class)
+  fun agentSelectionAcknowledgesUnreadDeviceSession() =
+    runTest {
+      val sessionKey = "agent:main:node-device"
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith(
+        "sessions.describe",
+        """{"session":{"key":"$sessionKey","label":"OpenClaw App · Pixel · device"}}""",
+      )
+      gateway.respondWith("sessions.patch", """{"ok":true,"key":"$sessionKey"}""")
+      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      val controller = newScopedController(gateway)
+      controller.handleGatewayEvent(
+        "sessions.changed",
+        """{"reason":"patch","sessionKey":"$sessionKey","session":{"key":"$sessionKey","unread":true}}""",
+      )
+
+      controller.prepareAndSelectMainSessionKey(sessionKey)
+      controller.onGatewayConnected(MainSessionBinding(sessionKey, "OpenClaw App · Pixel · device"))
+      runCurrent()
+
+      val patchParams =
+        gateway.calls
+          .first { it.method == "sessions.patch" }
+          .paramsJson
+          .orEmpty()
+      assertTrue(patchParams.contains("\"key\":\"$sessionKey\""))
+      assertTrue(patchParams.contains("\"unread\":false"))
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
   fun reconnectRevalidatesWithoutOverwritingExistingLabel() =
     runTest {
       val sessionKey = "agent:main:node-device"

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerReconnectRestoreTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerReconnectRestoreTest.kt
@@ -27,7 +27,232 @@ class ChatControllerReconnectRestoreTest {
 
   private fun TestScope.newController(gateway: ScriptedGateway): ChatController = ChatController(scope = this, json = json, requestGateway = gateway::request)
 
+  private fun TestScope.newScopedController(gateway: ScriptedGateway): ChatController =
+    ChatController(
+      scope = this,
+      json = json,
+      requestGateway = gateway::request,
+      requestGatewayForGateway = { _, method, paramsJson -> gateway.request(method, paramsJson) },
+      cacheScope = { ChatCacheScope(gatewayId = "gateway-a", connectionGeneration = 1) },
+    )
+
   private val userTurn = ReplayHistoryMessage("user", "keep working", 1_000)
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun connectedRefreshCreatesDeviceSessionBeforeLoadingHistory() =
+    runTest {
+      val sessionKey = "agent:main:node-device"
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith("sessions.describe", """{"session":null}""")
+      gateway.respondWith("sessions.create", """{"ok":true,"key":"$sessionKey"}""")
+      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      val controller = newScopedController(gateway)
+
+      controller.load("agent:main:custom")
+      runCurrent()
+      gateway.calls.clear()
+      controller.prepareAndSelectMainSessionKey(sessionKey)
+      controller.onGatewayConnected(MainSessionBinding(sessionKey, "OpenClaw App · Pixel · device"))
+      runCurrent()
+
+      val describeIndex = gateway.calls.indexOfFirst { it.method == "sessions.describe" }
+      val createIndex = gateway.calls.indexOfFirst { it.method == "sessions.create" }
+      val historyIndex = gateway.calls.indexOfFirst { it.method == "chat.history" }
+      assertTrue(describeIndex >= 0)
+      assertTrue(createIndex > describeIndex)
+      assertTrue(historyIndex > createIndex)
+      assertEquals(sessionKey, controller.sessionKey.value)
+      val createParams = json.parseToJsonElement(gateway.calls[createIndex].paramsJson.orEmpty()).jsonObject
+      assertEquals(sessionKey, createParams["key"]?.jsonPrimitive?.content)
+      assertEquals("main", createParams["agentId"]?.jsonPrimitive?.content)
+      assertEquals("OpenClaw App · Pixel · device", createParams["label"]?.jsonPrimitive?.content)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun connectedRefreshContinuesWhenSessionAdoptionFails() =
+    runTest {
+      val sessionKey = "agent:main:node-device"
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith("sessions.describe", """{"session":null}""")
+      gateway.respond("sessions.create") { error("create unavailable") }
+      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      val controller = newScopedController(gateway)
+
+      controller.prepareMainSessionKey(sessionKey)
+      controller.onGatewayConnected(MainSessionBinding(sessionKey, "OpenClaw App · Pixel · device"))
+      runCurrent()
+
+      assertEquals(1, gateway.callCount("sessions.create"))
+      assertEquals(1, gateway.callCount("chat.history"))
+      assertEquals(sessionKey, controller.sessionKey.value)
+      assertNull(controller.errorText.value)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun reconnectRevalidatesWithoutOverwritingExistingLabel() =
+    runTest {
+      val sessionKey = "agent:main:node-device"
+      val gateway = ScriptedGateway(json)
+      var storedLabel: String? = null
+      gateway.respond("sessions.describe") {
+        storedLabel?.let { """{"session":{"key":"$sessionKey","label":"$it"}}""" }
+          ?: """{"session":null}"""
+      }
+      gateway.respond("sessions.create") { paramsJson ->
+        storedLabel =
+          json
+            .parseToJsonElement(paramsJson.orEmpty())
+            .jsonObject["label"]
+            ?.jsonPrimitive
+            ?.content
+        """{"ok":true,"key":"$sessionKey"}"""
+      }
+      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      val controller = newScopedController(gateway)
+      val binding = MainSessionBinding(sessionKey, "OpenClaw App · Pixel · device")
+
+      controller.prepareMainSessionKey(sessionKey)
+      controller.onGatewayConnected(binding)
+      runCurrent()
+      controller.onDisconnected("Reconnecting…")
+      controller.onGatewayConnected(binding)
+      runCurrent()
+
+      assertEquals(1, gateway.callCount("sessions.create"))
+      assertEquals(2, gateway.callCount("sessions.describe"))
+      assertEquals(2, gateway.callCount("chat.history"))
+
+      storedLabel = "My Android session"
+      controller.onGatewayConnected(binding.copy(label = "OpenClaw App · Renamed · device"))
+      runCurrent()
+
+      assertEquals(1, gateway.callCount("sessions.create"))
+      assertEquals(3, gateway.callCount("sessions.describe"))
+      assertEquals(3, gateway.callCount("chat.history"))
+      assertEquals("My Android session", storedLabel)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun agentSwitchWaitsForTheLatestSessionAdoption() =
+    runTest {
+      val firstDescribe = CompletableDeferred<String>()
+      val gateway = ScriptedGateway(json)
+      gateway.respond("sessions.describe") { paramsJson ->
+        val key =
+          json
+            .parseToJsonElement(paramsJson.orEmpty())
+            .jsonObject["key"]
+            ?.jsonPrimitive
+            ?.content
+        if (key == "agent:first:node-device") firstDescribe.await() else """{"session":null}"""
+      }
+      gateway.respond("sessions.create") { paramsJson ->
+        val key =
+          json
+            .parseToJsonElement(paramsJson.orEmpty())
+            .jsonObject["key"]
+            ?.jsonPrimitive
+            ?.content
+        """{"ok":true,"key":"$key"}"""
+      }
+      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      val controller = newScopedController(gateway)
+
+      controller.prepareAndSelectMainSessionKey("agent:first:node-device")
+      controller.onGatewayConnected(MainSessionBinding("agent:first:node-device", "OpenClaw App · Pixel · device"))
+      runCurrent()
+      controller.prepareAndSelectMainSessionKey("agent:second:node-device")
+      controller.onGatewayConnected(MainSessionBinding("agent:second:node-device", "OpenClaw App · Pixel · device"))
+      controller.refresh()
+      runCurrent()
+
+      assertEquals(0, gateway.callCount("chat.history"))
+      firstDescribe.complete("""{"session":null}""")
+      runCurrent()
+
+      val createIndex = gateway.calls.indexOfLast { it.method == "sessions.create" }
+      val historyCalls = gateway.calls.withIndex().filter { it.value.method == "chat.history" }
+      assertTrue(createIndex >= 0)
+      assertTrue(historyCalls.isNotEmpty())
+      assertTrue(historyCalls.all { it.index > createIndex })
+      assertTrue(historyCalls.all { gateway.sessionKeyOf(it.value.paramsJson) == "agent:second:node-device" })
+      assertEquals("agent:second:node-device", controller.sessionKey.value)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun reconnectRecoveryWaitsForSessionReadiness() =
+    runTest {
+      val sessionKey = "agent:main:node-device"
+      val reconnectDescribe = CompletableDeferred<String>()
+      var reconnecting = false
+      val gateway = ScriptedGateway(json)
+      gateway.respond("sessions.describe") {
+        if (reconnecting) {
+          reconnectDescribe.await()
+        } else {
+          """{"session":{"key":"$sessionKey","label":"OpenClaw App · Pixel · device"}}"""
+        }
+      }
+      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      val controller = newScopedController(gateway)
+      val binding = MainSessionBinding(sessionKey, "OpenClaw App · Pixel · device")
+
+      controller.prepareMainSessionKey(sessionKey)
+      controller.onGatewayConnected(binding)
+      runCurrent()
+      val historyCallsBeforeReconnect = gateway.callCount("chat.history")
+      controller.onDisconnected("Reconnecting…")
+      reconnecting = true
+      controller.onGatewayConnected(binding)
+      controller.handleGatewayEvent("tick", null)
+      runCurrent()
+
+      assertEquals(historyCallsBeforeReconnect, gateway.callCount("chat.history"))
+      reconnectDescribe.complete(
+        """{"session":{"key":"$sessionKey","label":"OpenClaw App · Pixel · device"}}""",
+      )
+      runCurrent()
+      assertTrue(gateway.callCount("chat.history") > historyCallsBeforeReconnect)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun reconnectRecreatesSessionDeletedWhileDisconnected() =
+    runTest {
+      val sessionKey = "agent:main:node-device"
+      val gateway = ScriptedGateway(json)
+      var sessionExists = false
+      gateway.respond("sessions.describe") {
+        if (sessionExists) {
+          """{"session":{"key":"$sessionKey","label":"OpenClaw App · Pixel · device"}}"""
+        } else {
+          """{"session":null}"""
+        }
+      }
+      gateway.respond("sessions.create") {
+        sessionExists = true
+        """{"ok":true,"key":"$sessionKey"}"""
+      }
+      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      val controller = newScopedController(gateway)
+      val binding = MainSessionBinding(sessionKey, "OpenClaw App · Pixel · device")
+
+      controller.prepareMainSessionKey(sessionKey)
+      controller.onGatewayConnected(binding)
+      runCurrent()
+      sessionExists = false
+      controller.onDisconnected("Reconnecting…")
+      controller.onGatewayConnected(binding)
+      runCurrent()
+
+      assertEquals(2, gateway.callCount("sessions.describe"))
+      assertEquals(2, gateway.callCount("sessions.create"))
+    }
 
   @Test
   @OptIn(ExperimentalCoroutinesApi::class)

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerReconnectRestoreTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerReconnectRestoreTest.kt
@@ -92,6 +92,32 @@ class ChatControllerReconnectRestoreTest {
 
   @Test
   @OptIn(ExperimentalCoroutinesApi::class)
+  fun connectedRefreshLabelsExistingSessionWithoutRecreatingIt() =
+    runTest {
+      val sessionKey = "agent:main:node-device"
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith("sessions.describe", """{"session":{"key":"$sessionKey"}}""")
+      gateway.respondWith("sessions.patch", """{"ok":true,"key":"$sessionKey"}""")
+      gateway.respondWith("chat.history", historyResponse("existing-session", listOf(userTurn)))
+      val controller = newScopedController(gateway)
+
+      controller.prepareMainSessionKey(sessionKey)
+      controller.onGatewayConnected(MainSessionBinding(sessionKey, "OpenClaw App · Pixel · device"))
+      runCurrent()
+
+      assertEquals(0, gateway.callCount("sessions.create"))
+      val patchIndex = gateway.calls.indexOfFirst { it.method == "sessions.patch" }
+      val historyIndex = gateway.calls.indexOfFirst { it.method == "chat.history" }
+      assertTrue(patchIndex >= 0)
+      assertTrue(historyIndex > patchIndex)
+      val patchParams = json.parseToJsonElement(gateway.calls[patchIndex].paramsJson.orEmpty()).jsonObject
+      assertEquals(sessionKey, patchParams["key"]?.jsonPrimitive?.content)
+      assertEquals("OpenClaw App · Pixel · device", patchParams["label"]?.jsonPrimitive?.content)
+      assertEquals(listOf("keep working"), controller.messages.value.map { it.content.first().text })
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
   fun agentSelectionAcknowledgesUnreadDeviceSession() =
     runTest {
       val sessionKey = "agent:main:node-device"
@@ -249,6 +275,40 @@ class ChatControllerReconnectRestoreTest {
       )
       runCurrent()
       assertTrue(gateway.callCount("chat.history") > historyCallsBeforeReconnect)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun reconnectCancelsStaleAdoptionAndRetriesOnTheNewTransport() =
+    runTest {
+      val sessionKey = "agent:main:node-device"
+      val staleDescribe = CompletableDeferred<String>()
+      var describeCalls = 0
+      val gateway = ScriptedGateway(json)
+      gateway.respond("sessions.describe") {
+        describeCalls += 1
+        if (describeCalls == 1) {
+          staleDescribe.await()
+        } else {
+          """{"session":{"key":"$sessionKey","label":"OpenClaw App · Pixel · device"}}"""
+        }
+      }
+      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      val controller = newScopedController(gateway)
+      val binding = MainSessionBinding(sessionKey, "OpenClaw App · Pixel · device")
+
+      controller.prepareMainSessionKey(sessionKey)
+      controller.onGatewayConnected(binding)
+      runCurrent()
+      assertEquals(1, describeCalls)
+
+      controller.onDisconnected("Reconnecting…")
+      controller.onGatewayConnected(binding)
+      runCurrent()
+
+      assertEquals(2, describeCalls)
+      assertEquals(1, gateway.callCount("chat.history"))
+      assertEquals(sessionKey, controller.sessionKey.value)
     }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerReconnectRestoreTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerReconnectRestoreTest.kt
@@ -40,12 +40,12 @@ class ChatControllerReconnectRestoreTest {
 
   @Test
   @OptIn(ExperimentalCoroutinesApi::class)
-  fun connectedRefreshCreatesDeviceSessionBeforeLoadingHistory() =
+  fun connectedRefreshUpsertsDeviceSessionBeforeLoadingHistory() =
     runTest {
       val sessionKey = "agent:main:node-device"
       val gateway = ScriptedGateway(json)
       gateway.respondWith("sessions.describe", """{"session":null}""")
-      gateway.respondWith("sessions.create", """{"ok":true,"key":"$sessionKey"}""")
+      gateway.respondWith("sessions.patch", """{"ok":true,"key":"$sessionKey"}""")
       gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
       val controller = newScopedController(gateway)
 
@@ -57,16 +57,15 @@ class ChatControllerReconnectRestoreTest {
       runCurrent()
 
       val describeIndex = gateway.calls.indexOfFirst { it.method == "sessions.describe" }
-      val createIndex = gateway.calls.indexOfFirst { it.method == "sessions.create" }
+      val patchIndex = gateway.calls.indexOfFirst { it.method == "sessions.patch" }
       val historyIndex = gateway.calls.indexOfFirst { it.method == "chat.history" }
       assertTrue(describeIndex >= 0)
-      assertTrue(createIndex > describeIndex)
-      assertTrue(historyIndex > createIndex)
+      assertTrue(patchIndex > describeIndex)
+      assertTrue(historyIndex > patchIndex)
       assertEquals(sessionKey, controller.sessionKey.value)
-      val createParams = json.parseToJsonElement(gateway.calls[createIndex].paramsJson.orEmpty()).jsonObject
-      assertEquals(sessionKey, createParams["key"]?.jsonPrimitive?.content)
-      assertEquals("main", createParams["agentId"]?.jsonPrimitive?.content)
-      assertEquals("OpenClaw App · Pixel · device", createParams["label"]?.jsonPrimitive?.content)
+      val patchParams = json.parseToJsonElement(gateway.calls[patchIndex].paramsJson.orEmpty()).jsonObject
+      assertEquals(sessionKey, patchParams["key"]?.jsonPrimitive?.content)
+      assertEquals("OpenClaw App · Pixel · device", patchParams["label"]?.jsonPrimitive?.content)
     }
 
   @Test
@@ -76,7 +75,7 @@ class ChatControllerReconnectRestoreTest {
       val sessionKey = "agent:main:node-device"
       val gateway = ScriptedGateway(json)
       gateway.respondWith("sessions.describe", """{"session":null}""")
-      gateway.respond("sessions.create") { error("create unavailable") }
+      gateway.respond("sessions.patch") { error("patch unavailable") }
       gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
       val controller = newScopedController(gateway)
 
@@ -84,7 +83,7 @@ class ChatControllerReconnectRestoreTest {
       controller.onGatewayConnected(MainSessionBinding(sessionKey, "OpenClaw App · Pixel · device"))
       runCurrent()
 
-      assertEquals(1, gateway.callCount("sessions.create"))
+      assertEquals(1, gateway.callCount("sessions.patch"))
       assertEquals(1, gateway.callCount("chat.history"))
       assertEquals(sessionKey, controller.sessionKey.value)
       assertNull(controller.errorText.value)
@@ -158,7 +157,7 @@ class ChatControllerReconnectRestoreTest {
         storedLabel?.let { """{"session":{"key":"$sessionKey","label":"$it"}}""" }
           ?: """{"session":null}"""
       }
-      gateway.respond("sessions.create") { paramsJson ->
+      gateway.respond("sessions.patch") { paramsJson ->
         storedLabel =
           json
             .parseToJsonElement(paramsJson.orEmpty())
@@ -178,7 +177,7 @@ class ChatControllerReconnectRestoreTest {
       controller.onGatewayConnected(binding)
       runCurrent()
 
-      assertEquals(1, gateway.callCount("sessions.create"))
+      assertEquals(1, gateway.callCount("sessions.patch"))
       assertEquals(2, gateway.callCount("sessions.describe"))
       assertEquals(2, gateway.callCount("chat.history"))
 
@@ -186,7 +185,7 @@ class ChatControllerReconnectRestoreTest {
       controller.onGatewayConnected(binding.copy(label = "OpenClaw App · Renamed · device"))
       runCurrent()
 
-      assertEquals(1, gateway.callCount("sessions.create"))
+      assertEquals(1, gateway.callCount("sessions.patch"))
       assertEquals(3, gateway.callCount("sessions.describe"))
       assertEquals(3, gateway.callCount("chat.history"))
       assertEquals("My Android session", storedLabel)
@@ -207,7 +206,7 @@ class ChatControllerReconnectRestoreTest {
             ?.content
         if (key == "agent:first:node-device") firstDescribe.await() else """{"session":null}"""
       }
-      gateway.respond("sessions.create") { paramsJson ->
+      gateway.respond("sessions.patch") { paramsJson ->
         val key =
           json
             .parseToJsonElement(paramsJson.orEmpty())
@@ -227,17 +226,32 @@ class ChatControllerReconnectRestoreTest {
       controller.refresh()
       runCurrent()
 
-      assertEquals(0, gateway.callCount("chat.history"))
-      firstDescribe.complete("""{"session":null}""")
-      runCurrent()
-
-      val createIndex = gateway.calls.indexOfLast { it.method == "sessions.create" }
+      val patchCalls = gateway.calls.withIndex().filter { it.value.method == "sessions.patch" }
+      val patchIndex = patchCalls.single().index
       val historyCalls = gateway.calls.withIndex().filter { it.value.method == "chat.history" }
-      assertTrue(createIndex >= 0)
+      val patchParams =
+        patchCalls
+          .single()
+          .value
+          .paramsJson
+          .orEmpty()
+      val patchedKey =
+        json
+          .parseToJsonElement(patchParams)
+          .jsonObject["key"]
+          ?.jsonPrimitive
+          ?.content
+      assertEquals("agent:second:node-device", patchedKey)
       assertTrue(historyCalls.isNotEmpty())
-      assertTrue(historyCalls.all { it.index > createIndex })
+      assertTrue(historyCalls.all { it.index > patchIndex })
       assertTrue(historyCalls.all { gateway.sessionKeyOf(it.value.paramsJson) == "agent:second:node-device" })
       assertEquals("agent:second:node-device", controller.sessionKey.value)
+
+      // The cancelled response must remain inert even if its server-side work completes later.
+      firstDescribe.complete("""{"session":null}""")
+      runCurrent()
+      assertEquals(1, gateway.callCount("sessions.patch"))
+      assertTrue(gateway.calls.none { it.method == "chat.history" && gateway.sessionKeyOf(it.paramsJson) == "agent:first:node-device" })
     }
 
   @Test
@@ -313,7 +327,7 @@ class ChatControllerReconnectRestoreTest {
 
   @Test
   @OptIn(ExperimentalCoroutinesApi::class)
-  fun reconnectRecreatesSessionDeletedWhileDisconnected() =
+  fun reconnectUpsertsSessionDeletedWhileDisconnected() =
     runTest {
       val sessionKey = "agent:main:node-device"
       val gateway = ScriptedGateway(json)
@@ -325,7 +339,7 @@ class ChatControllerReconnectRestoreTest {
           """{"session":null}"""
         }
       }
-      gateway.respond("sessions.create") {
+      gateway.respond("sessions.patch") {
         sessionExists = true
         """{"ok":true,"key":"$sessionKey"}"""
       }
@@ -342,7 +356,7 @@ class ChatControllerReconnectRestoreTest {
       runCurrent()
 
       assertEquals(2, gateway.callCount("sessions.describe"))
-      assertEquals(2, gateway.callCount("sessions.create"))
+      assertEquals(2, gateway.callCount("sessions.patch"))
     }
 
   @Test


### PR DESCRIPTION
Related: #45854

## What Problem This Solves

Android already isolates each device on a stable `agent:<agent>:node-<device>` chat key, but the app did not explicitly create/adopt that session before connected history loaded. A new installation could read history before the app-owned session was ready, while renaming the key would strand existing Android conversations.

## Why This Change Was Made

- keep the shipped `node-<device>` key so upgrades retain existing history and context
- derive a device-unique `OpenClaw App · <device> · <id>` label
- describe and create/adopt the same explicit key before connected history can load
- patch metadata non-destructively when an existing upgrade session lacks a label
- serialize readiness per gateway and make reconnect, agent-switch, refresh, and deleted-session paths wait for the current adoption
- preserve a user-customized existing label and recreate a deleted session on reconnect
- keep unread acknowledgement intact when agent selection prepares the app-owned session
- remove the proposed 257-line manual emulator workflow from the product diff

The Gateway's explicit-key `sessions.create` path preserves an existing session ID/transcript. The final implementation therefore adopts the established key rather than migrating to `openclaw-app-*`.

## User Impact

Android users keep their existing device-specific conversation across upgrades. New and reconnected app sessions are ready before history loads, receive a recognizable device-unique label, and retain correct unread state across agent switches.

## Evidence

- exact-head hosted CI is required for final head `04e7d30cfabc`; prior-head Android Play/third-party tests, ktlint, native-i18n, and repository lint passed
- focused regressions cover create-before-history ordering, metadata-only labeling, adoption failure fallback, reconnect revalidation, custom-label preservation, deleted-session recreation, agent-switch supersession, stale-transport cancellation/retry, reconnect readiness, and unread acknowledgement
- Gateway `sessions.create` implementation and tests inspected: an existing explicit key keeps its session ID/transcript while applying metadata
- structured autoreview is clean after fixing the existing-unlabeled metadata path and stale-transport reconnect ownership
- the contributor's earlier emulator artifact demonstrated the end-to-end `sessions.create` then `chat.history` integration shape

## Evidence Source Map

- stable upgrade key and device label: `apps/android/app/src/main/java/ai/openclaw/app/SessionKey.kt`
- connect and agent-selection ownership: `apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt`
- readiness/adoption boundary: `apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt`
- focused behavior coverage: `apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerReconnectRestoreTest.kt`
- original live emulator artifact: https://github.com/snowzlmbot/openclaw/actions/runs/28907001143/artifacts/8154958242

## Risk

Bounded to Android chat connection/session lifecycle. Adoption failures remain non-blocking so older or temporarily unavailable Gateways still load history under the already-bound key. The existing key and transcript are unchanged.

## Rollback

Revert this PR to stop explicit readiness/adoption; the existing `node-*` session and history remain intact.

## Docs Updated

- `apps/android/README.md`
- `apps/android/CHANGELOG.md`

Release note: create/adopt Android's existing per-device chat session before history loads, preserving prior conversations and unread state. Thanks @snowzlmbot.
