### PR TITLE
fix(agents): allow re-entrant session write lock for overflow-recovery compaction

### DIFF
--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -170,6 +170,7 @@ const resolveAgentTransportOverrideMock: Mock<(params?: unknown) => string | und
   () => undefined,
 );
 export const resolveSandboxContextMock = vi.fn(async () => null);
+export const acquireSessionWriteLockMock = vi.fn(async () => ({ release: vi.fn(async () => {}) }));
 export const maybeCompactAgentHarnessSessionMock: Mock<
   (params?: unknown, options?: unknown) => Promise<unknown>
 > = vi.fn(async () => undefined);
@@ -364,6 +365,7 @@ export function resetCompactSessionStateMocks(): void {
   applyExtraParamsToAgentMock.mockReset();
   applyExtraParamsToAgentMock.mockReturnValue({ effectiveExtraParams: {} });
   resolveAgentTransportOverrideMock.mockReset();
+  acquireSessionWriteLockMock.mockClear();
   resolveAgentTransportOverrideMock.mockReturnValue(undefined);
   resolveSandboxContextMock.mockReset();
   resolveSandboxContextMock.mockResolvedValue(null);
@@ -448,6 +450,7 @@ export function resetCompactHooksHarnessMocks(): void {
   createPreparedEmbeddedAgentSettingsManagerMock.mockReturnValue({
     getGlobalSettings: vi.fn(() => ({})),
   });
+  acquireSessionWriteLockMock.mockClear();
 }
 
 export async function loadCompactHooksHarness(): Promise<{
@@ -598,7 +601,7 @@ export async function loadCompactHooksHarness(): Promise<{
   }));
 
   vi.doMock("../session-write-lock.js", () => ({
-    acquireSessionWriteLock: vi.fn(async () => ({ release: vi.fn(async () => {}) })),
+    acquireSessionWriteLock: acquireSessionWriteLockMock,
     resolveSessionLockMaxHoldFromTimeout: vi.fn(() => 0),
     resolveSessionWriteLockAcquireTimeoutMs: vi.fn(() => 60_000),
     resolveSessionWriteLockOptions: vi.fn(() => ({

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -4,6 +4,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi, type Mock } from "vite
 import {
   applyExtraParamsToAgentMock,
   applyAgentCompactionSettingsFromConfigMock,
+  acquireSessionWriteLockMock,
   buildEmbeddedSystemPromptMock,
   contextEngineCompactMock,
   compactWithSafetyTimeoutMock,
@@ -1582,6 +1583,25 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
 
     await expect(resultPromise).rejects.toThrow("request timed out");
     expect(sessionAbortCompactionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes allowReentrant:true so overflow-recovery compaction does not block on the self-held lock", async () => {
+    acquireSessionWriteLockMock.mockClear();
+    const result = await compactEmbeddedAgentSessionDirect({
+      sessionId: TEST_SESSION_ID,
+      sessionKey: TEST_SESSION_KEY,
+      sessionFile: TEST_SESSION_FILE,
+      workspaceDir: TEST_WORKSPACE_DIR,
+      config: {},
+      reason: "overflow",
+      reasonCode: "overflow",
+      abort: new AbortController().signal,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(acquireSessionWriteLockMock).toHaveBeenCalledWith(
+      expect.objectContaining({ allowReentrant: true }),
+    );
   });
 });
 

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -1587,16 +1587,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
 
   it("passes allowReentrant:true so overflow-recovery compaction does not block on the self-held lock", async () => {
     acquireSessionWriteLockMock.mockClear();
-    const result = await compactEmbeddedAgentSessionDirect({
-      sessionId: TEST_SESSION_ID,
-      sessionKey: TEST_SESSION_KEY,
-      sessionFile: TEST_SESSION_FILE,
-      workspaceDir: TEST_WORKSPACE_DIR,
-      config: {},
-      reason: "overflow",
-      reasonCode: "overflow",
-      abort: new AbortController().signal,
-    });
+    const result = await compactEmbeddedAgentSessionDirect(wrappedCompactionArgs({ config: {} }));
 
     expect(result.ok).toBe(true);
     expect(acquireSessionWriteLockMock).toHaveBeenCalledWith(

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -1230,6 +1230,10 @@ async function compactEmbeddedAgentSessionDirectOnce(
           timeoutMs: compactionTimeoutMs,
         }),
       }),
+      // Allow re-entrant acquisition so the overflow-recovery compaction
+      // path does not block on the session write lock already held by the
+      // outer embedded agent attempt.
+      allowReentrant: true,
     });
     try {
       await repairSessionFileIfNeeded({


### PR DESCRIPTION
## What Problem This Solves

Fixes #97747: When an embedded agent attempt triggers overflow-recovery auto-compaction, the compaction path re-acquires the same session's write lock inside the same process. `acquireSessionWriteLock` defaults `allowReentrant` to `false`, so the nested acquire blocks for 60s and fails with `SessionWriteLockTimeoutError`. Each model in the fallback chain repeats the same timeout, creating an 18-minute recovery window during which every new message is rejected with `Embedded agent failed before reply: session file locked`.

## Why This Change Was Made

Added `allowReentrant: true` to the `acquireSessionWriteLock` call in the compaction path at `compact.ts:1214`. When the outer embedded agent attempt already holds the write lock, the in-process nested acquire returns immediately with a bumped reference count, matching the behavior of the plugin-sdk `acquireFileLock` path.

## User Impact

- Overflow-recovery compaction no longer deadlocks on the self-held session write lock
- No more 18-minute recovery windows where every message is rejected
- Transparent fix — no config or behavior changes for users

## Evidence

- [x] `pnpm test src/agents/embedded-agent-runner/run.overflow-compaction.test.ts` — 50 tests pass
- [x] `pnpm test src/agents/session-write-lock.test.ts` — 54 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)