### PR TITLE
refactor(memory-wiki): localize internal helper types

### DIFF
--- a/extensions/memory-wiki/src/config.ts
+++ b/extensions/memory-wiki/src/config.ts
@@ -4,13 +4,13 @@ import path from "node:path";
 import { mapPluginConfigIssues } from "openclaw/plugin-sdk/extension-shared";
 import { buildPluginConfigSchema, z, type OpenClawPluginConfigSchema } from "../api.js";
 
-export const WIKI_VAULT_MODES = ["isolated", "bridge", "unsafe-local"] as const;
-export const WIKI_RENDER_MODES = ["native", "obsidian"] as const;
+const WIKI_VAULT_MODES = ["isolated", "bridge", "unsafe-local"] as const;
+const WIKI_RENDER_MODES = ["native", "obsidian"] as const;
 export const WIKI_SEARCH_BACKENDS = ["shared", "local"] as const;
 export const WIKI_SEARCH_CORPORA = ["wiki", "memory", "all"] as const;
 
-export type WikiVaultMode = (typeof WIKI_VAULT_MODES)[number];
-export type WikiRenderMode = (typeof WIKI_RENDER_MODES)[number];
+type WikiVaultMode = (typeof WIKI_VAULT_MODES)[number];
+type WikiRenderMode = (typeof WIKI_RENDER_MODES)[number];
 export type WikiSearchBackend = (typeof WIKI_SEARCH_BACKENDS)[number];
 export type WikiSearchCorpus = (typeof WIKI_SEARCH_CORPORA)[number];
 

--- a/extensions/memory-wiki/src/import-runs-state.ts
+++ b/extensions/memory-wiki/src/import-runs-state.ts
@@ -7,7 +7,7 @@ import type {
   PluginStateKeyedStore,
 } from "openclaw/plugin-sdk/plugin-state-runtime";
 
-export type ChatGptImportRunEntry = {
+type ChatGptImportRunEntry = {
   path: string;
   snapshotPath?: string;
 };

--- a/extensions/memory-wiki/src/markdown.ts
+++ b/extensions/memory-wiki/src/markdown.ts
@@ -115,7 +115,7 @@ export type WikiPageSummary = {
   updatedAt?: string;
 };
 
-export type WikiPageSummaryScanResult =
+type WikiPageSummaryScanResult =
   | { status: "valid"; page: WikiPageSummary }
   | { status: "invalid-frontmatter"; error: WikiPageFrontmatterError }
   | { status: "ignored" };

--- a/extensions/memory-wiki/src/okf.ts
+++ b/extensions/memory-wiki/src/okf.ts
@@ -56,13 +56,13 @@ type OkfImportedPage = {
   created: boolean;
 };
 
-export type ImportMemoryWikiOkfWarning = {
+type ImportMemoryWikiOkfWarning = {
   code: "invalid-concept" | "missing-type" | "unreadable-entry";
   path: string;
   message: string;
 };
 
-export type ImportMemoryWikiOkfResult = {
+type ImportMemoryWikiOkfResult = {
   bundlePath: string;
   bundleName: string;
   okfVersion?: string;

--- a/extensions/memory-wiki/src/source-sync-state.ts
+++ b/extensions/memory-wiki/src/source-sync-state.ts
@@ -10,7 +10,7 @@ import type {
 
 export type MemoryWikiImportedSourceGroup = "bridge" | "unsafe-local";
 
-export type MemoryWikiImportedSourceStateEntry = {
+type MemoryWikiImportedSourceStateEntry = {
   group: MemoryWikiImportedSourceGroup;
   pagePath: string;
   sourcePath: string;
@@ -19,7 +19,7 @@ export type MemoryWikiImportedSourceStateEntry = {
   renderFingerprint: string;
 };
 
-export type MemoryWikiImportedSourceState = {
+type MemoryWikiImportedSourceState = {
   version: 1;
   entries: Record<string, MemoryWikiImportedSourceStateEntry>;
 };

--- a/extensions/memory-wiki/src/vault-page-write.ts
+++ b/extensions/memory-wiki/src/vault-page-write.ts
@@ -4,7 +4,7 @@ import { FsSafeError, root as fsRoot } from "openclaw/plugin-sdk/security-runtim
 
 type VaultRoot = Awaited<ReturnType<typeof fsRoot>>;
 
-export type FileStatLike = {
+type FileStatLike = {
   isFile?: unknown;
   nlink?: unknown;
 };


### PR DESCRIPTION
## What Problem This Solves

Memory Wiki still exported eleven constants and helper types that are only referenced inside their defining modules. Those exports enlarge the plugin's apparent internal API and make dead-code discovery noisier.

## Why This Change Was Made

Localize the declarations while preserving the exports that are actually consumed across module boundaries. This is a declaration-surface cleanup only; runtime behavior and generated values are unchanged.

## User Impact

No user-visible behavior change. The private Memory Wiki plugin exposes a smaller, more accurate module surface.

## Evidence

- Fresh full worktree from `origin/main` at `1aee742d230e5e50f6f580e19655fa22b21eefee`
- codebase-memory graph refreshed after the latest rebase: 21,043 files, 281,317 nodes, 1,139,618 edges
- repository-wide reference scan confirms all eleven declarations are used only in their defining modules
- Testbox `tbx_01kwzjjpysmwp90t1wcbzf9256`: `pnpm check:changed`
- Testbox `tbx_01kwzjjpysmwp90t1wcbzf9256`: Memory Wiki suite, 33 files / 241 tests passed
- Testbox `tbx_01kwzjjpysmwp90t1wcbzf9256`: full `pnpm build`
- fresh local autoreview: clean, confidence 0.92
- fresh branch autoreview: clean, confidence 0.91
- `git diff --check`
