### PR TITLE
fix(session): avoid stalls when parent token probing hangs

### DIFF
--- a/src/auto-reply/reply/session-fork.test.ts
+++ b/src/auto-reply/reply/session-fork.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { forkSessionEntryFromParent } from "./session-fork.js";
+import { forkSessionEntryFromParent, resolveParentForkDecision } from "./session-fork.js";
 
 const runtimeMocks = vi.hoisted(() => ({
   resolveParentForkTokenCountRuntime: vi.fn(),
@@ -13,6 +13,8 @@ const runtimeMocks = vi.hoisted(() => ({
 vi.mock("./session-fork.runtime.js", () => runtimeMocks);
 
 const roots: string[] = [];
+const parentTooLargeMessage =
+  "Parent context is too large to fork (170000/100000 tokens); starting with isolated context instead.";
 
 async function makeRoot(prefix: string): Promise<string> {
   // realpath first: macOS tmpdir is a /var -> /private/var symlink and the
@@ -23,8 +25,68 @@ async function makeRoot(prefix: string): Promise<string> {
 }
 
 afterEach(async () => {
+  vi.useRealTimers();
   runtimeMocks.resolveParentForkTokenCountRuntime.mockReset();
   await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+describe("resolveParentForkDecision", () => {
+  it("uses fresh parent token counts without transcript probing", async () => {
+    runtimeMocks.resolveParentForkTokenCountRuntime.mockReturnValue(new Promise(() => {}));
+
+    await expect(
+      resolveParentForkDecision({
+        parentEntry: {
+          sessionId: "parent-session",
+          updatedAt: 1,
+          totalTokens: 170_000,
+          totalTokensFresh: true,
+        },
+        storePath: path.join(os.tmpdir(), "sessions.json"),
+      }),
+    ).resolves.toEqual({
+      status: "skip",
+      reason: "parent-too-large",
+      maxTokens: 100_000,
+      parentTokens: 170_000,
+      message: parentTooLargeMessage,
+    });
+    expect(runtimeMocks.resolveParentForkTokenCountRuntime).not.toHaveBeenCalled();
+  });
+
+  it("continues with a fork decision when parent token probing stalls", async () => {
+    vi.useFakeTimers();
+    runtimeMocks.resolveParentForkTokenCountRuntime.mockReturnValue(new Promise(() => {}));
+
+    const decision = resolveParentForkDecision({
+      parentEntry: { sessionId: "parent-session", updatedAt: 1 },
+      storePath: path.join(os.tmpdir(), "sessions.json"),
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(decision).resolves.toEqual({
+      status: "fork",
+      maxTokens: 100_000,
+    });
+  });
+
+  it("still skips quickly resolved oversized parent sessions", async () => {
+    runtimeMocks.resolveParentForkTokenCountRuntime.mockResolvedValue(170_000);
+
+    await expect(
+      resolveParentForkDecision({
+        parentEntry: { sessionId: "parent-session", updatedAt: 1 },
+        storePath: path.join(os.tmpdir(), "sessions.json"),
+      }),
+    ).resolves.toEqual({
+      status: "skip",
+      reason: "parent-too-large",
+      maxTokens: 100_000,
+      parentTokens: 170_000,
+      message: parentTooLargeMessage,
+    });
+  });
 });
 
 describe("forkSessionEntryFromParent", () => {

--- a/src/auto-reply/reply/session-fork.test.ts
+++ b/src/auto-reply/reply/session-fork.test.ts
@@ -15,6 +15,8 @@ vi.mock("./session-fork.runtime.js", () => runtimeMocks);
 const roots: string[] = [];
 const parentTooLargeMessage =
   "Parent context is too large to fork (170000/100000 tokens); starting with isolated context instead.";
+const parentSizeTimeoutMessage =
+  "Parent context size could not be verified within 1000ms; starting with isolated context instead.";
 
 async function makeRoot(prefix: string): Promise<string> {
   // realpath first: macOS tmpdir is a /var -> /private/var symlink and the
@@ -54,7 +56,7 @@ describe("resolveParentForkDecision", () => {
     expect(runtimeMocks.resolveParentForkTokenCountRuntime).not.toHaveBeenCalled();
   });
 
-  it("continues with a fork decision when parent token probing stalls", async () => {
+  it("starts isolated when parent token probing stalls", async () => {
     vi.useFakeTimers();
     runtimeMocks.resolveParentForkTokenCountRuntime.mockReturnValue(new Promise(() => {}));
 
@@ -66,8 +68,10 @@ describe("resolveParentForkDecision", () => {
     await vi.advanceTimersByTimeAsync(1_000);
 
     await expect(decision).resolves.toEqual({
-      status: "fork",
+      status: "skip",
+      reason: "parent-size-timeout",
       maxTokens: 100_000,
+      message: parentSizeTimeoutMessage,
     });
   });
 
@@ -161,5 +165,61 @@ describe("forkSessionEntryFromParent", () => {
     >;
     expect(stored[sessionKey]?.sessionId).toBe(result.fork.sessionId);
     expect(stored[sessionKey]?.sessionFile).toBe(result.fork.sessionFile);
+  });
+
+  it("does not read the parent transcript after a stalled parent size probe", async () => {
+    vi.useFakeTimers();
+    const root = await makeRoot("openclaw-session-fork-timeout-");
+    const activeStoreDir = path.join(root, "active-store");
+    await fs.mkdir(activeStoreDir, { recursive: true });
+    const storePath = path.join(activeStoreDir, "sessions.json");
+    const parentSessionKey = "agent:main:main";
+    const sessionKey = "agent:main:subagent:child";
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          [parentSessionKey]: {
+            sessionId: "parent-session",
+            sessionFile: path.join(activeStoreDir, "missing-parent.jsonl"),
+            updatedAt: 1,
+          },
+          [sessionKey]: { sessionId: "", updatedAt: 2 },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    runtimeMocks.resolveParentForkTokenCountRuntime.mockReturnValue(new Promise(() => {}));
+
+    const resultPromise = forkSessionEntryFromParent({
+      agentId: "main",
+      decisionSkipPatch: () => ({
+        forkedFromParent: false,
+      }),
+      fallbackEntry: { sessionId: "", updatedAt: 2 },
+      parentSessionKey,
+      sessionKey,
+      storePath,
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    const result = await resultPromise;
+
+    expect(result).toMatchObject({
+      status: "skipped",
+      reason: "decision-skip",
+      decision: {
+        status: "skip",
+        reason: "parent-size-timeout",
+        maxTokens: 100_000,
+        message: parentSizeTimeoutMessage,
+      },
+    });
+    if (result.status !== "skipped") {
+      throw new Error("expected skipped result");
+    }
+    expect(result.sessionEntry.forkedFromParent).toBe(false);
   });
 });

--- a/src/auto-reply/reply/session-fork.ts
+++ b/src/auto-reply/reply/session-fork.ts
@@ -5,7 +5,7 @@ import {
   type ParentForkedSessionTranscript,
   type SessionParentForkDecision,
 } from "../../config/sessions/session-accessor.js";
-import type { SessionEntry } from "../../config/sessions/types.js";
+import { resolveFreshSessionTotalTokens, type SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 
@@ -15,6 +15,7 @@ import { createLazyImportLoader } from "../../shared/lazy-promise.js";
  * See #26905.
  */
 const DEFAULT_PARENT_FORK_MAX_TOKENS = 100_000;
+const PARENT_FORK_TOKEN_COUNT_TIMEOUT_MS = 1_000;
 const sessionForkRuntimeLoader = createLazyImportLoader(() => import("./session-fork.runtime.js"));
 
 export type ParentForkDecision = SessionParentForkDecision;
@@ -108,10 +109,12 @@ export async function resolveParentForkDecision(
   params: ParentForkDecisionParams,
 ): Promise<ParentForkDecision> {
   const maxTokens = DEFAULT_PARENT_FORK_MAX_TOKENS;
-  const parentTokens = await resolveParentForkTokenCount({
-    parentEntry: params.parentEntry,
-    storePath: resolveParentForkStorePath(params),
-  });
+  const parentTokens =
+    resolveFreshSessionTotalTokens(params.parentEntry) ??
+    (await resolveParentForkTokenCountWithTimeout({
+      parentEntry: params.parentEntry,
+      storePath: resolveParentForkStorePath(params),
+    }));
   if (typeof parentTokens === "number" && parentTokens > maxTokens) {
     return {
       status: "skip",
@@ -201,4 +204,22 @@ async function resolveParentForkTokenCount(params: {
 }): Promise<number | undefined> {
   const runtime = await loadSessionForkRuntime();
   return runtime.resolveParentForkTokenCountRuntime(params);
+}
+
+async function resolveParentForkTokenCountWithTimeout(params: {
+  parentEntry: SessionEntry;
+  storePath: string;
+}): Promise<number | undefined> {
+  let timeoutId: number | undefined;
+  const timeout = new Promise<undefined>((resolve) => {
+    timeoutId = setTimeout(resolve, PARENT_FORK_TOKEN_COUNT_TIMEOUT_MS);
+  });
+  try {
+    // Availability wins over exact sizing when transcript probing stalls.
+    return await Promise.race([resolveParentForkTokenCount(params), timeout]);
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  }
 }

--- a/src/auto-reply/reply/session-fork.ts
+++ b/src/auto-reply/reply/session-fork.ts
@@ -20,6 +20,10 @@ const sessionForkRuntimeLoader = createLazyImportLoader(() => import("./session-
 
 export type ParentForkDecision = SessionParentForkDecision;
 
+type ParentForkTokenCountResolution =
+  | { status: "resolved"; parentTokens?: number }
+  | { status: "timed-out" };
+
 type ParentForkDecisionParams = {
   parentEntry: SessionEntry;
   agentId?: string;
@@ -95,6 +99,17 @@ function formatParentForkTooLargeMessage(params: {
   );
 }
 
+function formatParentForkTokenProbeTimeoutMessage(): string {
+  return (
+    `Parent context size could not be verified within ${PARENT_FORK_TOKEN_COUNT_TIMEOUT_MS}ms; ` +
+    "starting with isolated context instead."
+  );
+}
+
+function formatParentForkTokenProbeUnavailableMessage(): string {
+  return "Parent context size could not be verified; starting with isolated context instead.";
+}
+
 function resolveParentForkStorePath(params: {
   agentId?: string;
   config?: OpenClawConfig;
@@ -109,12 +124,37 @@ export async function resolveParentForkDecision(
   params: ParentForkDecisionParams,
 ): Promise<ParentForkDecision> {
   const maxTokens = DEFAULT_PARENT_FORK_MAX_TOKENS;
-  const parentTokens =
-    resolveFreshSessionTotalTokens(params.parentEntry) ??
-    (await resolveParentForkTokenCountWithTimeout({
-      parentEntry: params.parentEntry,
-      storePath: resolveParentForkStorePath(params),
-    }));
+  const freshParentTokens = resolveFreshSessionTotalTokens(params.parentEntry);
+  if (typeof freshParentTokens === "number" && freshParentTokens > maxTokens) {
+    return {
+      status: "skip",
+      reason: "parent-too-large",
+      maxTokens,
+      parentTokens: freshParentTokens,
+      message: formatParentForkTooLargeMessage({ parentTokens: freshParentTokens, maxTokens }),
+    };
+  }
+  if (typeof freshParentTokens === "number") {
+    return {
+      status: "fork",
+      maxTokens,
+      parentTokens: freshParentTokens,
+    };
+  }
+
+  const tokenCountResolution = await resolveParentForkTokenCountWithTimeout({
+    parentEntry: params.parentEntry,
+    storePath: resolveParentForkStorePath(params),
+  });
+  if (tokenCountResolution.status === "timed-out") {
+    return {
+      status: "skip",
+      reason: "parent-size-timeout",
+      maxTokens,
+      message: formatParentForkTokenProbeTimeoutMessage(),
+    };
+  }
+  const parentTokens = tokenCountResolution.parentTokens;
   if (typeof parentTokens === "number" && parentTokens > maxTokens) {
     return {
       status: "skip",
@@ -124,10 +164,18 @@ export async function resolveParentForkDecision(
       message: formatParentForkTooLargeMessage({ parentTokens, maxTokens }),
     };
   }
+  if (typeof parentTokens !== "number") {
+    return {
+      status: "skip",
+      reason: "parent-size-unavailable",
+      maxTokens,
+      message: formatParentForkTokenProbeUnavailableMessage(),
+    };
+  }
   return {
     status: "fork",
     maxTokens,
-    ...(typeof parentTokens === "number" ? { parentTokens } : {}),
+    parentTokens,
   };
 }
 
@@ -209,14 +257,22 @@ async function resolveParentForkTokenCount(params: {
 async function resolveParentForkTokenCountWithTimeout(params: {
   parentEntry: SessionEntry;
   storePath: string;
-}): Promise<number | undefined> {
-  let timeoutId: number | undefined;
-  const timeout = new Promise<undefined>((resolve) => {
-    timeoutId = setTimeout(resolve, PARENT_FORK_TOKEN_COUNT_TIMEOUT_MS);
+}): Promise<ParentForkTokenCountResolution> {
+  let timeoutId: Parameters<typeof clearTimeout>[0];
+  const tokenCount = resolveParentForkTokenCount(params).then((parentTokens) =>
+    typeof parentTokens === "number"
+      ? ({ status: "resolved", parentTokens } as const)
+      : ({ status: "resolved" } as const),
+  );
+  const timeout = new Promise<ParentForkTokenCountResolution>((resolve) => {
+    timeoutId = setTimeout(
+      () => resolve({ status: "timed-out" }),
+      PARENT_FORK_TOKEN_COUNT_TIMEOUT_MS,
+    );
   });
   try {
-    // Availability wins over exact sizing when transcript probing stalls.
-    return await Promise.race([resolveParentForkTokenCount(params), timeout]);
+    // Isolated context wins when parent sizing stalls or cannot be verified.
+    return await Promise.race([tokenCount, timeout]);
   } finally {
     if (timeoutId !== undefined) {
       clearTimeout(timeoutId);

--- a/src/auto-reply/reply/session-parent-fork-prepare.ts
+++ b/src/auto-reply/reply/session-parent-fork-prepare.ts
@@ -29,11 +29,15 @@ export async function prepareReplySessionParentFork(params: {
     storePath: params.storePath,
   });
   if (decision.status === "skip") {
-    // The parent branch is too large to inherit usefully. Start fresh and
-    // mark as handled so the thread does not retry this decision every turn.
+    // The parent branch is not safe to inherit. Start fresh and mark as
+    // handled so the thread does not retry this decision every turn.
+    const tokenDetails =
+      decision.reason === "parent-too-large"
+        ? ` parentTokens=${decision.parentTokens} maxTokens=${decision.maxTokens}`
+        : "";
     params.warn(
-      `skipping parent fork (parent too large): parentKey=${params.parentSessionKey} → sessionKey=${params.sessionKey} ` +
-        `parentTokens=${decision.parentTokens} maxTokens=${decision.maxTokens}`,
+      `skipping parent fork (${decision.reason}): parentKey=${params.parentSessionKey} → sessionKey=${params.sessionKey}` +
+        tokenDetails,
     );
     return { ...params.sessionEntry, forkedFromParent: true };
   }

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -1394,6 +1394,12 @@ export type SessionParentForkDecision =
       maxTokens: number;
       parentTokens: number;
       message: string;
+    }
+  | {
+      status: "skip";
+      reason: "parent-size-timeout" | "parent-size-unavailable";
+      maxTokens: number;
+      message: string;
     };
 
 /** Transcript identity created for a child fork. */

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -437,12 +437,13 @@ export async function createGatewaySession(params: {
           storePath: parentSessionTarget.storePath,
         });
         if (forkDecision.status === "skip") {
+          const message =
+            forkDecision.reason === "parent-too-large"
+              ? `parent session is too large to fork (${forkDecision.parentTokens}/${forkDecision.maxTokens} tokens)`
+              : forkDecision.message;
           return {
             ok: false,
-            error: errorShape(
-              ErrorCodes.INVALID_REQUEST,
-              `parent session is too large to fork (${forkDecision.parentTokens}/${forkDecision.maxTokens} tokens)`,
-            ),
+            error: errorShape(ErrorCodes.INVALID_REQUEST, message),
           };
         }
         const fork = await forkSessionFromParent({


### PR DESCRIPTION
Closes #101718

## What Problem This Solves

Fixes an issue where users creating or forking a session from a parent could wait indefinitely when parent transcript token probing did not settle.

## Why This Change Was Made

The parent fork decision now uses fresh persisted token counts immediately, and otherwise bounds transcript token probing to a short wait. If probing times out or cannot verify the parent size, OpenClaw starts the child with isolated context instead of continuing into parent transcript copy. Quickly resolved small parents still fork, and fresh or quickly resolved oversized parents still use the existing isolated-session skip behavior.

## User Impact

Session creation and parent-fork workflows no longer stay blocked behind a stuck parent token probe or continue into another unbounded parent transcript read after the probe timeout. Users with oversized or unverified parent sessions get isolated context instead of inheriting unsafe parent history.

## Impact Assessment

- Scope: parent-session fork decision logic shared by session creation, parent-fork prepare, and subagent spawn paths.
- Downstream: callers already handle `skip` decisions by avoiding transcript copy; timeout and unavailable-size probes now use that existing isolated-context path.
- Edge cases: fresh token counts bypass transcript probing; quickly resolved oversized counts still skip; stalled probes clear their timer after the bounded wait; unresolved size probes do not fork.
- Config surface: no new configuration, environment variable, or storage format.

## Evidence

- `node scripts/run-vitest.mjs src/auto-reply/reply/session-fork.test.ts`

```text
[test] starting test/vitest/vitest.auto-reply.config.ts
[test] passed 1 Vitest shard in 22.71s
```

- `pnpm tsgo:prod`

```text
passed
```

- `pnpm check:test-types`

```text
passed
```

## Real behavior proof

**Behavior addressed:** Parent fork caller paths return instead of waiting indefinitely when parent token probing does not settle, and the timeout path avoids the later parent transcript copy.
**Environment tested:** Linux, Node v22.22.0, local source checkout on branch `fix/101718-session-fork-token-timeout`, isolated temporary `OPENCLAW_HOME` and `OPENCLAW_STATE_DIR`.
**Steps run after the patch:** Called the patched `forkSessionEntryFromParent` production caller path with a parent transcript whose token-probe `fs.promises.stat` never resolves, then verified fresh oversized parent tokens still produce the existing skip decision.
**Evidence after fix:**

```bash
node --import tsx --no-warnings -e '
import fs from "node:fs/promises";
import os from "node:os";
import path from "node:path";

const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-101718-proof-")));
process.env.OPENCLAW_HOME = path.join(root, "home");
process.env.OPENCLAW_STATE_DIR = path.join(root, "state");
const { forkSessionEntryFromParent } = await import("./src/auto-reply/reply/session-fork.js");
const activeStoreDir = path.join(root, "active-store");
await fs.mkdir(activeStoreDir, { recursive: true });
const storePath = path.join(activeStoreDir, "sessions.json");
const parentSessionKey = "agent:main:main";
const sessionKey = "agent:main:subagent:child";
const parentSessionFile = path.join(activeStoreDir, "parent.jsonl");
const now = Date.now();
await fs.writeFile(parentSessionFile, [
  JSON.stringify({ type: "session", version: 3, id: "parent-session", timestamp: "2026-07-08T00:00:00.000Z", cwd: root }),
  JSON.stringify({ type: "message", id: "assistant-1", parentId: null, timestamp: "2026-07-08T00:00:01.000Z", message: { role: "assistant", content: "parent branch" } }),
].join("\n") + "\n", "utf-8");
await fs.writeFile(storePath, JSON.stringify({
  [parentSessionKey]: { sessionId: "parent-session", sessionFile: parentSessionFile, updatedAt: now },
  [sessionKey]: { sessionId: "", updatedAt: now },
}, null, 2), "utf-8");

const originalStat = fs.stat;
let parentStatCalls = 0;
fs.stat = async (filePath, ...args) => {
  if (String(filePath) === parentSessionFile) {
    parentStatCalls += 1;
    return await new Promise(() => {});
  }
  return await originalStat.call(fs, filePath, ...args);
};

const started = Date.now();
try {
  const result = await forkSessionEntryFromParent({
    agentId: "main",
    decisionSkipPatch: () => ({ forkedFromParent: false }),
    fallbackEntry: { sessionId: "", updatedAt: now },
    parentSessionKey,
    sessionKey,
    storePath,
  });
  const elapsedMs = Date.now() - started;
  const allFiles = await fs.readdir(activeStoreDir);
  console.log(JSON.stringify({
    elapsedMs,
    parentStatCalls,
    resultStatus: result.status,
    decisionReason: result.status === "skipped" ? result.decision?.reason : null,
    resultSessionEntry: result.status === "skipped" ? result.sessionEntry : null,
    activeStoreFiles: allFiles.sort(),
    createdForkTranscriptCount: allFiles.filter((name) => name.endsWith(".jsonl") && name !== "parent.jsonl").length,
  }, null, 2));
} finally {
  fs.stat = originalStat;
  await fs.rm(root, { recursive: true, force: true });
}
'
```

```text
{
  "elapsedMs": 1032,
  "parentStatCalls": 1,
  "resultStatus": "skipped",
  "decisionReason": "parent-size-timeout",
  "resultSessionEntry": {
    "sessionId": "",
    "updatedAt": 1783476977699,
    "forkedFromParent": false
  },
  "activeStoreFiles": [
    "parent.jsonl",
    "sessions.json"
  ],
  "createdForkTranscriptCount": 0
}
```

```bash
node --import tsx --no-warnings --input-type=module -e '
process.env.OPENCLAW_HOME = "/tmp/openclaw-101718-proof-home";
process.env.OPENCLAW_STATE_DIR = "/tmp/openclaw-101718-proof-state";
const { resolveParentForkDecision } = await import("./src/auto-reply/reply/session-fork.js");
const decision = await resolveParentForkDecision({
  parentEntry: {
    sessionId: "parent-session",
    updatedAt: Date.now(),
    totalTokens: 170_000,
    totalTokensFresh: true,
  },
  storePath: "/tmp/openclaw-sessions.json",
});
console.log(JSON.stringify({
  status: decision.status,
  reason: decision.status === "skip" ? decision.reason : null,
  maxTokens: decision.maxTokens,
  parentTokens: "parentTokens" in decision ? decision.parentTokens : null,
}, null, 2));
'
```

```text
{
  "status": "skip",
  "reason": "parent-too-large",
  "maxTokens": 100000,
  "parentTokens": 170000
}
```

**Observed result after the fix:** The stalled parent token-probe caller path returned `skipped` with `parent-size-timeout` after roughly one second, kept the original `parent.jsonl`, and created zero fork transcripts. Fresh oversized tokens still returned `parent-too-large`.
**Not tested:** A live gateway session creation with a real remote filesystem or transcript handle blocked indefinitely was not exercised locally.
