### PR TITLE
refactor(imessage): localize internal helper symbols

### DIFF
--- a/extensions/imessage/src/approval-auth.ts
+++ b/extensions/imessage/src/approval-auth.ts
@@ -8,7 +8,7 @@ import { normalizeIMessageHandle } from "./targets.js";
 
 type ApprovalKind = "exec" | "plugin";
 
-export function normalizeIMessageApproverId(value: string | number): string | undefined {
+function normalizeIMessageApproverId(value: string | number): string | undefined {
   const raw = String(value).trim();
   if (!raw) {
     return undefined;

--- a/extensions/imessage/src/approval-reactions.ts
+++ b/extensions/imessage/src/approval-reactions.ts
@@ -27,13 +27,13 @@ const PERSISTENT_NAMESPACE = "imessage.approval-reactions";
 const PERSISTENT_MAX_ENTRIES = 1000;
 const DEFAULT_REACTION_TARGET_TTL_MS = 24 * 60 * 60 * 1000;
 
-export type IMessageApprovalReactionBinding = ApprovalReactionDecisionBinding;
+type IMessageApprovalReactionBinding = ApprovalReactionDecisionBinding;
 
 type IMessageApprovalReactionResolution = {
   approvalId: string;
   decision: ExecApprovalReplyDecision;
 };
-export type IMessageApprovalReactionHandleResult =
+type IMessageApprovalReactionHandleResult =
   | { handled: false; stopPolling: false }
   | { handled: true; stopPolling: false }
   | {

--- a/extensions/imessage/src/cli-output.ts
+++ b/extensions/imessage/src/cli-output.ts
@@ -1,8 +1,8 @@
 // Imessage plugin module implements cli output behavior.
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 
-export const IMESSAGE_CLI_STDOUT_MAX_CHARS = 8 * 1024 * 1024;
-export const IMESSAGE_CLI_STDERR_TAIL_CHARS = 64 * 1024;
+const IMESSAGE_CLI_STDOUT_MAX_CHARS = 8 * 1024 * 1024;
+const IMESSAGE_CLI_STDERR_TAIL_CHARS = 64 * 1024;
 
 type AppendStdoutResult = { ok: true; value: string } | { ok: false; message: string };
 

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -7,13 +7,13 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import { resolveUserPath } from "openclaw/plugin-sdk/text-utility-runtime";
 import { DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS } from "./constants.js";
 
-export type IMessageRpcError = {
+type IMessageRpcError = {
   code?: number;
   message?: string;
   data?: unknown;
 };
 
-export type IMessageRpcResponse<T> = {
+type IMessageRpcResponse<T> = {
   jsonrpc?: string;
   id?: string | number | null;
   result?: T;
@@ -22,12 +22,12 @@ export type IMessageRpcResponse<T> = {
   params?: unknown;
 };
 
-export type IMessageRpcNotification = {
+type IMessageRpcNotification = {
   method: string;
   params?: unknown;
 };
 
-export type IMessageRpcClientOptions = {
+type IMessageRpcClientOptions = {
   cliPath?: string;
   dbPath?: string;
   runtime?: RuntimeEnv;

--- a/extensions/imessage/src/install-imsg.ts
+++ b/extensions/imessage/src/install-imsg.ts
@@ -7,7 +7,7 @@ import { resolveBrewExecutable } from "openclaw/plugin-sdk/setup-tools";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { IMESSAGE_INSTALL_COMMAND } from "./setup-core.js";
 
-export type IMessageInstallResult = {
+type IMessageInstallResult = {
   ok: boolean;
   cliPath?: string;
   version?: string;

--- a/extensions/imessage/src/markdown-format.ts
+++ b/extensions/imessage/src/markdown-format.ts
@@ -29,9 +29,9 @@
  * plain-text emoji/punctuation that happens to look like markdown.
  */
 
-export type IMessageFormatStyle = "bold" | "italic" | "underline" | "strikethrough";
+type IMessageFormatStyle = "bold" | "italic" | "underline" | "strikethrough";
 
-export type IMessageFormatRange = {
+type IMessageFormatRange = {
   start: number;
   length: number;
   styles: IMessageFormatStyle[];

--- a/extensions/imessage/src/monitor/catchup-bridge.ts
+++ b/extensions/imessage/src/monitor/catchup-bridge.ts
@@ -42,7 +42,7 @@ type RuntimeLogger = {
   error?: (msg: string) => void;
 };
 
-export type RunIMessageCatchupParams = {
+type RunIMessageCatchupParams = {
   client: IMessageRpcClient;
   accountId: string;
   config: ResolvedCatchupConfig;

--- a/extensions/imessage/src/monitor/catchup.ts
+++ b/extensions/imessage/src/monitor/catchup.ts
@@ -32,7 +32,7 @@ export const IMESSAGE_CATCHUP_CURSOR_NAMESPACE = "imessage.catchup-cursors";
 export const IMESSAGE_CATCHUP_CURSOR_MAX_ENTRIES = 256;
 const cursorWriteQueue = new KeyedAsyncQueue();
 
-export type IMessageCatchupConfig = {
+type IMessageCatchupConfig = {
   enabled?: boolean;
   maxAgeMinutes?: number;
   perRunLimit?: number;
@@ -311,7 +311,7 @@ export type CatchupFetchFn = (params: {
 
 export type CatchupDispatchFn = (row: IMessageCatchupRow) => Promise<{ ok: boolean }>;
 
-export type PerformCatchupParams = {
+type PerformCatchupParams = {
   accountId: string;
   config: ResolvedCatchupConfig;
   now?: number;

--- a/extensions/imessage/src/monitor/coalesce.ts
+++ b/extensions/imessage/src/monitor/coalesce.ts
@@ -77,7 +77,7 @@ export function shouldCombineIMessagePayloadBucket(
   return true;
 }
 
-export type CoalescedIMessagePayload = IMessagePayload & {
+type CoalescedIMessagePayload = IMessagePayload & {
   /**
    * Source GUIDs folded into this merged payload, in arrival order. Includes
    * GUIDs from entries that were dropped by the entry cap so downstream

--- a/extensions/imessage/src/monitor/conversation-repair.ts
+++ b/extensions/imessage/src/monitor/conversation-repair.ts
@@ -19,7 +19,7 @@ type MessagesHistoryResult = {
   messages?: unknown[];
 };
 
-export type RepairIMessageConversationAnchorParams = {
+type RepairIMessageConversationAnchorParams = {
   client: IMessageRpcClient;
   message: IMessagePayload;
   runtime?: RuntimeLogger;

--- a/extensions/imessage/src/monitor/dm-history.ts
+++ b/extensions/imessage/src/monitor/dm-history.ts
@@ -20,7 +20,7 @@ type IMessageDmHistoryConfig = {
   dms?: Record<string, { historyLimit?: number }>;
 };
 
-export type IMessageDmHistoryEntry = {
+type IMessageDmHistoryEntry = {
   sender: string;
   body: string;
   timestamp?: number;

--- a/extensions/imessage/src/monitor/inbound-dedupe.ts
+++ b/extensions/imessage/src/monitor/inbound-dedupe.ts
@@ -19,7 +19,7 @@ const IMESSAGE_INBOUND_DEDUPE_NAMESPACE_PREFIX = "imessage.inbound-dedupe";
 // 4h recency window: long enough to absorb a reconnect/restart burst that
 // re-emits recently dispatched rows, short enough that a genuinely-new message
 // reusing a stale composite key after hours is not wrongly suppressed.
-export const IMESSAGE_INBOUND_DEDUPE_TTL_MS = 4 * 60 * 60 * 1000;
+const IMESSAGE_INBOUND_DEDUPE_TTL_MS = 4 * 60 * 60 * 1000;
 const IMESSAGE_INBOUND_DEDUPE_MEMORY_MAX = 5_000;
 const IMESSAGE_INBOUND_DEDUPE_STATE_MAX_ENTRIES = 10_000;
 

--- a/extensions/imessage/src/monitor/media-staging.ts
+++ b/extensions/imessage/src/monitor/media-staging.ts
@@ -6,12 +6,12 @@ import { saveMediaBuffer } from "openclaw/plugin-sdk/media-store";
 import { loadWebMedia } from "openclaw/plugin-sdk/web-media";
 import type { IMessageAttachment } from "./types.js";
 
-export type StagedIMessageAttachment = {
+type StagedIMessageAttachment = {
   path: string;
   contentType?: string;
 };
 
-export type StagedIMessageAttachments = {
+type StagedIMessageAttachments = {
   attachments: StagedIMessageAttachment[];
   unavailableCount: number;
 };

--- a/extensions/imessage/src/monitor/reaction-system-event.ts
+++ b/extensions/imessage/src/monitor/reaction-system-event.ts
@@ -2,7 +2,7 @@
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 
-export type IMessageReactionSystemEventDecision = {
+type IMessageReactionSystemEventDecision = {
   text: string;
   contextKey: string;
   route: {

--- a/extensions/imessage/src/monitor/types.ts
+++ b/extensions/imessage/src/monitor/types.ts
@@ -11,12 +11,12 @@ export type IMessageAttachment = {
   uti?: string | null;
 };
 
-export type IMessagePollOption = {
+type IMessagePollOption = {
   id: string;
   text: string;
 };
 
-export type IMessagePollVote = {
+type IMessagePollVote = {
   option_id?: string | null;
   option_text?: string | null;
   participant?: string | null;

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -90,7 +90,7 @@ type IMessageSendOpts = {
   }) => Promise<string | null> | string | null;
 };
 
-export type IMessageSendResult = {
+type IMessageSendResult = {
   /**
    * Generic identifier returned by the bridge. May be a GUID string, a
    * numeric ROWID stringified, or the literal "ok"/"unknown" placeholders


### PR DESCRIPTION
## What Problem This Solves

The private iMessage plugin still exported twenty-five helper types, constants,
and one normalization function that are only referenced inside their defining
modules. Those exports enlarge the apparent implementation API and add noise to
dead-code analysis.

## Why This Change Was Made

Localize the remaining declarations while preserving the exports intentionally
exposed by `extensions/imessage/api.ts`. This is a module-surface cleanup only;
definitions, callers, values, and control flow are unchanged.

## User Impact

No user-visible behavior change. The bundled private plugin exposes a smaller,
more accurate internal module surface.

## Evidence

- Fresh full, non-shallow worktree from `origin/main` at `81d0f3f37291b199005ace7c55db1d9c6d060c70`
- codebase-memory graph refreshed on commit `765c1b36e98d3b21fe0f3abbee1098cc7b52b8d4`: 21,043 files, 281,325 nodes, 1,139,718 edges
- repository-wide source scan confirms all twenty-five declarations are confined to their defining modules
- post-edit scanner reports zero remaining iMessage candidates in this batch
- Testbox `tbx_01kwzk7wy9zabpb7dsy18mxyvk`: `pnpm check:changed`
- Testbox `tbx_01kwzk7wy9zabpb7dsy18mxyvk`: iMessage suite, 60 files / 726 tests passed
- Testbox `tbx_01kwzk7wy9zabpb7dsy18mxyvk`: full `pnpm build`
- fresh local autoreview: clean, confidence 0.89
- fresh branch autoreview: clean, confidence 0.86
- `git diff --check`
