### PR TITLE
fix(agents): do not mark exact-size streamed responses as truncated

### DIFF
--- a/src/agents/tools/web-shared.test.ts
+++ b/src/agents/tools/web-shared.test.ts
@@ -129,6 +129,24 @@ describe("readResponseText", () => {
     expect(releaseLock).toHaveBeenCalledTimes(1);
   });
 
+  it("does not flag a response whose stream ends exactly at the byte limit as truncated", async () => {
+    const cancel = vi.fn(async () => undefined);
+    const releaseLock = vi.fn();
+    const response = responseFromReader({
+      chunks: ["hello", " world"],
+      cancel,
+      releaseLock,
+    });
+
+    await expect(readResponseText(response, { maxBytes: 11 })).resolves.toEqual({
+      text: "hello world",
+      truncated: false,
+      bytesRead: 11,
+    });
+    expect(cancel).not.toHaveBeenCalled();
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
   it("cancels and releases bounded response readers after truncation", async () => {
     const cancel = vi.fn(async () => undefined);
     const releaseLock = vi.fn();

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -272,8 +272,7 @@ export async function readResponseText(
         bytesRead += chunk.byteLength;
         parts.push(chunk);
 
-        if (truncated || bytesRead >= maxBytes) {
-          truncated = true;
+        if (truncated) {
           break;
         }
       }


### PR DESCRIPTION
Closes #101837

## What Problem This Solves

Fixes an issue where `web_fetch` reports a response body as truncated when the streamed response is exactly `maxResponseBytes` bytes long, even though no bytes were omitted. This produces a false "Response body truncated" warning and triggers unnecessary spill handling.

## Why This Change Was Made

`readResponseText` in `src/agents/tools/web-shared.ts` treated `bytesRead >= maxBytes` as truncation. An exact-size stream already stops cleanly when the reader returns `done`, so the extra `>=` check was incorrect. The fix only sets `truncated` when an actual overflow chunk is seen.

## User Impact

Users no longer see a truncation warning for web_fetch responses that exactly fit the configured byte limit.

## Evidence

Added a focused regression test in `src/agents/tools/web-shared.test.ts` that streams two chunks totaling exactly the `maxBytes` limit and expects `truncated: false`.

Before the fix, the new test fails:

```
FAIL  |agents| src/agents/tools/web-shared.test.ts > readResponseText > does not flag a response whose stream ends exactly at the byte limit as truncated
AssertionError: expected { text: 'hello world', …(2) } to deeply equal { text: 'hello world', …(2) }
- Expected
+ Received
  {
    "bytesRead": 11,
    "text": "hello world",
-   "truncated": false,
+   "truncated": true,
  }
```

After the fix, the test passes, and the existing truncation test still passes:

```
✓ |agents| src/agents/tools/web-shared.test.ts (12 tests)
✓ |agents| tools/web-fetch.test.ts (14 tests)
✓ |agents| tools/web-tools.fetch.test.ts (28 tests)
```
