### PR TITLE
refactor(gateway): localize terminal helper types

### DIFF
--- a/src/gateway/terminal/launch.ts
+++ b/src/gateway/terminal/launch.ts
@@ -13,13 +13,13 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 
 /** Why a terminal cannot open, or `null` when it can. */
-export type TerminalLaunchBlock =
+type TerminalLaunchBlock =
   | { kind: "disabled" }
   | { kind: "unknown-agent"; agentId: string }
   | { kind: "sandboxed"; agentId: string; mode: "all" };
 
 /** Resolved plan for a host terminal session. */
-export type TerminalLaunchPlan = {
+type TerminalLaunchPlan = {
   agentId: string;
   cwd: string;
   shell: string;
@@ -31,7 +31,7 @@ export type TerminalLaunchResolution =
   | { ok: true; plan: TerminalLaunchPlan }
   | { ok: false; block: TerminalLaunchBlock };
 
-export type TerminalLaunchPolicy = {
+type TerminalLaunchPolicy = {
   resolve: (agentId?: string) => TerminalLaunchResolution;
   isEnabled: () => boolean;
   prepareConfig: (config: OpenClawConfig, options: { restartPending: boolean }) => void;

--- a/src/gateway/terminal/session-manager.ts
+++ b/src/gateway/terminal/session-manager.ts
@@ -4,10 +4,10 @@ import { randomUUID } from "node:crypto";
 import { spawnTerminalPty, type TerminalPtyHandle } from "./pty.js";
 
 /** Emits one terminal event frame to the single owning connection. */
-export type TerminalEventSink = (connId: string, event: string, payload: unknown) => void;
+type TerminalEventSink = (connId: string, event: string, payload: unknown) => void;
 
 /** Injectable PTY spawner so tests can drive sessions without a real shell. */
-export type TerminalSpawner = typeof spawnTerminalPty;
+type TerminalSpawner = typeof spawnTerminalPty;
 
 export const TERMINAL_EVENT_DATA = "terminal.data" as const;
 export const TERMINAL_EVENT_EXIT = "terminal.exit" as const;
@@ -32,7 +32,7 @@ type TerminalSession = {
 };
 
 /** One session's facts as reported by terminal.list. */
-export type TerminalSessionSummary = {
+type TerminalSessionSummary = {
   sessionId: string;
   agentId: string;
   shell: string;
@@ -95,7 +95,7 @@ class TerminalOutputRing {
   }
 }
 
-export type TerminalSessionManagerOptions = {
+type TerminalSessionManagerOptions = {
   emit: TerminalEventSink;
   spawn?: TerminalSpawner;
   maxSessions?: number;
@@ -123,7 +123,7 @@ export type TerminalOpenRequest = {
   env: Record<string, string>;
 };
 
-export type TerminalOpenOutcome =
+type TerminalOpenOutcome =
   | { ok: true; sessionId: string; agentId: string; cwd: string; shell: string }
   | { ok: false; code: "limit" | "spawn_failed" | "closed"; message: string };
 


### PR DESCRIPTION
## What Problem This Solves

The gateway terminal implementation exported eight helper type aliases that are
only referenced inside their defining modules. Those names enlarge the apparent
core module API despite having no cross-module consumers.

## Why This Change Was Made

Localize the helper aliases while preserving the shared
`TerminalLaunchResolution`, `TerminalOpenRequest`, runtime functions, and
`TerminalSessionManager` exports. Definitions, callers, and behavior are
unchanged.

## User Impact

No user-visible behavior change. The gateway terminal modules expose a smaller,
more accurate implementation surface.

## Evidence

- Fresh full, non-shallow worktree from `origin/main` at `ef91bb370beee4f5bc91a1ce580a405f7021b392`
- codebase-memory graph refreshed on commit `5e400f793a8c3933d29261c8dae272e1927b1da3`: 21,043 files, 281,322 nodes, 1,138,543 edges
- repository-wide source scan confirms all eight declarations are confined to their defining modules
- post-edit scanner reports zero remaining gateway terminal candidates in this batch
- Testbox `tbx_01kwzkzpbwj4ydzbq2qtg3n8rk`: `pnpm check:changed`
- Testbox `tbx_01kwzkzpbwj4ydzbq2qtg3n8rk`: gateway terminal and RPC tests, 18 files / 226 tests passed
- Testbox `tbx_01kwzkzpbwj4ydzbq2qtg3n8rk`: full `pnpm build`
- fresh local autoreview: clean, confidence 0.91
- fresh branch autoreview: clean, confidence 0.88
- `git diff --check`
