### PR TITLE
refactor(discord): localize internal declarations

### DIFF
--- a/extensions/discord/src/account-token-inspect.ts
+++ b/extensions/discord/src/account-token-inspect.ts
@@ -5,7 +5,7 @@ import {
 } from "openclaw/plugin-sdk/secret-input";
 import type { DiscordCredentialStatus } from "./token.js";
 
-export type InspectedDiscordConfiguredToken = {
+type InspectedDiscordConfiguredToken = {
   token: string;
   tokenSource: "config";
   tokenStatus: Exclude<DiscordCredentialStatus, "missing">;

--- a/extensions/discord/src/internal/commands.ts
+++ b/extensions/discord/src/internal/commands.ts
@@ -8,7 +8,7 @@ import {
 import type { BaseMessageInteractiveComponent } from "./components.js";
 import type { AutocompleteInteraction, CommandInteraction } from "./interactions.js";
 
-export type ConditionalCommandOption = (interaction: unknown) => boolean;
+type ConditionalCommandOption = (interaction: unknown) => boolean;
 export type CommandOption = Record<string, unknown> & {
   name: string;
   description?: string;

--- a/extensions/discord/src/internal/listeners.ts
+++ b/extensions/discord/src/internal/listeners.ts
@@ -10,7 +10,7 @@ import {
 import type { Client } from "./client.js";
 import { Guild, Message, User } from "./structures.js";
 
-export type DiscordMessageDispatchData = {
+type DiscordMessageDispatchData = {
   id?: string;
   channel_id: string;
   channelId?: string;
@@ -23,7 +23,7 @@ export type DiscordMessageDispatchData = {
   channel?: unknown;
 };
 
-export type DiscordReactionDispatchData = {
+type DiscordReactionDispatchData = {
   user_id?: string;
   channel_id: string;
   message_id: string;
@@ -38,7 +38,7 @@ export type DiscordReactionDispatchData = {
   rawMessage?: APIMessage;
 };
 
-export abstract class BaseListener {
+abstract class BaseListener {
   abstract readonly type: string;
   abstract handle(data: unknown, client: Client): Promise<void> | void;
 }

--- a/extensions/discord/src/internal/rest-scheduler.ts
+++ b/extensions/discord/src/internal/rest-scheduler.ts
@@ -39,7 +39,7 @@ type BucketState<TData> = {
   routeKeys: Set<string>;
 };
 
-export type RestSchedulerLaneOptions = {
+type RestSchedulerLaneOptions = {
   maxQueueSize: number;
   staleAfterMs?: number;
   weight: number;

--- a/extensions/discord/src/internal/rest.ts
+++ b/extensions/discord/src/internal/rest.ts
@@ -26,9 +26,9 @@ import { isDiscordRateLimitBody } from "./schemas.js";
 
 export { DiscordError, isUnknownDiscordVoiceStateError, RateLimitError } from "./rest-errors.js";
 
-export type RuntimeProfile = "serverless" | "persistent";
+type RuntimeProfile = "serverless" | "persistent";
 export type RequestPriority = RestRequestPriority;
-export type RequestSchedulerOptions = {
+type RequestSchedulerOptions = {
   lanes?: Partial<
     Record<RequestPriority, { maxQueueSize?: number; staleAfterMs?: number; weight?: number }>
   >;

--- a/extensions/discord/src/internal/structures.ts
+++ b/extensions/discord/src/internal/structures.ts
@@ -27,7 +27,7 @@ export type StructureClient = {
   fetchUser(id: string): Promise<User>;
 };
 
-export class Base {
+class Base {
   constructor(protected client: StructureClient) {}
 }
 

--- a/extensions/discord/src/monitor/channel-access.ts
+++ b/extensions/discord/src/monitor/channel-access.ts
@@ -57,7 +57,7 @@ function resolveDiscordChannelStringWithAliasSafe(
   return resolveDiscordChannelStringPropertySafe(rawData, snakeKey);
 }
 
-export type DiscordChannelInfoSafe = {
+type DiscordChannelInfoSafe = {
   name?: string;
   topic?: string;
   type?: number;

--- a/extensions/discord/src/monitor/gateway-metadata.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.ts
@@ -28,7 +28,7 @@ export type DiscordGatewayFetch = (
   input: string,
   init?: DiscordGatewayFetchInit,
 ) => Promise<DiscordGatewayMetadataResponse>;
-export type DiscordGatewayMetadataFetchOptions = {
+type DiscordGatewayMetadataFetchOptions = {
   capture?: false | { flowId: string; meta: Record<string, unknown> };
   proxyUrl?: string;
 };

--- a/extensions/discord/src/monitor/listeners.ts
+++ b/extensions/discord/src/monitor/listeners.ts
@@ -17,7 +17,7 @@ import { closeDiscordThreadSessions } from "./thread-session-close.js";
 type Logger = ReturnType<typeof import("openclaw/plugin-sdk/runtime-env").createSubsystemLogger>;
 
 export type DiscordMessageEvent = Parameters<MessageCreateListener["handle"]>[0];
-export type DiscordInteractionEvent = Parameters<InteractionCreateListener["handle"]>[0];
+type DiscordInteractionEvent = Parameters<InteractionCreateListener["handle"]>[0];
 
 export type DiscordMessageHandler = (
   data: DiscordMessageEvent,

--- a/extensions/discord/src/monitor/message-handler.reply-typing-policy.ts
+++ b/extensions/discord/src/monitor/message-handler.reply-typing-policy.ts
@@ -4,7 +4,7 @@ import type { DiscordMessagePreflightContext } from "./message-handler.preflight
 
 type SourceReplyDeliveryMode = ReturnType<typeof resolveChannelMessageSourceReplyDeliveryMode>;
 
-export type DiscordAcceptedTypingPrestartDecision = {
+type DiscordAcceptedTypingPrestartDecision = {
   sourceReplyDeliveryMode: SourceReplyDeliveryMode;
   shouldPrestart: boolean;
   reason:

--- a/extensions/discord/src/monitor/message-handler.ts
+++ b/extensions/discord/src/monitor/message-handler.ts
@@ -66,7 +66,7 @@ const loadMessagePreflightRuntime = createLazyRuntimeModule(
   () => import("./message-handler.preflight.js"),
 );
 
-export type DiscordMessageHandlerWithLifecycle = DiscordMessageHandler & {
+type DiscordMessageHandlerWithLifecycle = DiscordMessageHandler & {
   deactivate: () => void;
 };
 

--- a/extensions/discord/src/monitor/reply-delivery.ts
+++ b/extensions/discord/src/monitor/reply-delivery.ts
@@ -23,7 +23,7 @@ import { sendMessageDiscord, sendVoiceMessageDiscord } from "../send.js";
 import type { DiscordAllowedMentions } from "../send.shared.js";
 import { sanitizeDiscordFrontChannelReplyPayloads } from "./reply-safety.js";
 
-export type DiscordThreadBindingLookupRecord = {
+type DiscordThreadBindingLookupRecord = {
   accountId: string;
   channelId: string;
   threadId: string;

--- a/extensions/discord/src/monitor/thread-bindings.lifecycle.ts
+++ b/extensions/discord/src/monitor/thread-bindings.lifecycle.ts
@@ -36,9 +36,9 @@ export type AcpThreadBindingReconciliationResult = {
   staleSessionKeys: string[];
 };
 
-export type AcpThreadBindingHealthStatus = "healthy" | "stale" | "uncertain";
+type AcpThreadBindingHealthStatus = "healthy" | "stale" | "uncertain";
 
-export type AcpThreadBindingHealthProbe = (params: {
+type AcpThreadBindingHealthProbe = (params: {
   cfg: OpenClawConfig;
   accountId: string;
   sessionKey: string;

--- a/extensions/discord/src/send.guild.ts
+++ b/extensions/discord/src/send.guild.ts
@@ -39,13 +39,13 @@ import type {
 } from "./send.types.js";
 import { DISCORD_MAX_EVENT_COVER_BYTES } from "./send.types.js";
 
-export type DiscordAbsentVoiceState = Pick<APIVoiceState, "guild_id" | "user_id" | "channel_id"> & {
+type DiscordAbsentVoiceState = Pick<APIVoiceState, "guild_id" | "user_id" | "channel_id"> & {
   connected: false;
   absent: true;
   reason: "unknown_voice_state";
 };
 
-export type DiscordVoiceStatus = APIVoiceState | DiscordAbsentVoiceState;
+type DiscordVoiceStatus = APIVoiceState | DiscordAbsentVoiceState;
 
 export async function fetchMemberInfoDiscord(
   guildId: string,

--- a/extensions/discord/src/voice/agent-control.ts
+++ b/extensions/discord/src/voice/agent-control.ts
@@ -6,7 +6,7 @@ import {
 } from "openclaw/plugin-sdk/realtime-voice";
 import type { VoiceSessionEntry } from "./session.js";
 
-export type DiscordVoiceAgentControlOutcome =
+type DiscordVoiceAgentControlOutcome =
   | {
       handled: true;
       result: RealtimeVoiceAgentControlResult;

--- a/extensions/discord/src/voice/ingress.ts
+++ b/extensions/discord/src/voice/ingress.ts
@@ -21,7 +21,7 @@ export type DiscordVoiceIngressContext = {
   speakerLabel: string;
 };
 
-export type DiscordVoiceAgentTurnResult = {
+type DiscordVoiceAgentTurnResult = {
   context: DiscordVoiceIngressContext;
   text: string;
 };


### PR DESCRIPTION
## What Problem This Solves

Discord implementation modules still exported 21 helper types and base classes that are only used inside their defining files. Those exports enlarge internal declaration surfaces without serving the plugin's explicit public API.

## Why This Change Was Made

Localize the unused exports while preserving every runtime export and every symbol exposed through `@openclaw/discord/api.js`.

## User Impact

No runtime behavior change. The Discord plugin exposes a smaller, more accurate internal TypeScript surface.

## Evidence

- `pnpm check:changed` on Testbox `tbx_01kwzmrpct83rcgzzf6p2vrqyv`: passed.
- `pnpm build` on the same Testbox: passed.
- Discord suite: 164/165 files and 1,896/1,898 tests passed.
- The only failures, `extensions/discord/src/monitor/route-resolution.test.ts`, reproduce unchanged on the base commit because current route output includes `dmScope: "main"`.
- Repo-wide export scan: none of the 21 localized declarations is referenced outside its defining file or exposed from the explicit Discord public API.
- Fresh local and branch autoreview: clean, confidence 0.86.
