### PR TITLE
fix(sessions): preserve user-set label when session lifecycle resets entry

### DIFF
--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -1732,7 +1732,13 @@ export async function persistSessionResetLifecycle(params: {
   let persistError: Error | undefined;
   try {
     await updateSessionStore(params.storePath, (store) => {
-      store[params.sessionKey] = params.nextEntry;
+      // Preserve user-owned metadata (label) from the previous entry so
+      // custom session labels survive resets and sessionId rotations. (#101451)
+      const nextEntry = { ...params.nextEntry };
+      if (params.previousEntry.label && !nextEntry.label) {
+        nextEntry.label = params.previousEntry.label;
+      }
+      store[params.sessionKey] = nextEntry;
     });
   } catch (err) {
     persistError = err instanceof Error ? err : new Error(String(err));


### PR DESCRIPTION
## What Problem This Solves

A custom session `label` added via the Control UI session page silently disappears after session lifecycle events (reset, sessionId rotation, compaction). The label is initially persisted to `sessions.json`, but later rewrites drop the `label` field because `persistSessionResetLifecycle` replaces the entire session entry without carrying forward user-owned metadata.

## Why This Change Was Made

When a session is reset, the caller builds a `nextEntry` without user-owned fields like `label`. The full replacement at `store[sessionKey] = nextEntry` then drops any label the user had set.

Fix: preserve `label` from `previousEntry` when `nextEntry` lacks one, so custom labels survive resets and sessionId rotations.

## Changes

- `src/config/sessions/session-accessor.ts`: Preserve label in `persistSessionResetLifecycle` (1 file, +7/-1)

## Real behavior proof

**Behavior addressed:** Session labels retained through reset lifecycle events.
**Environment tested:** Node 22.x on Linux
**Steps run after the patch:** Verified compilation
**Evidence after fix:**

```
$ node --import tsx --no-warnings -e "import('./src/config/sessions/session-accessor.ts')"
OK
```

**Observed result:** Module compiles cleanly. The fix carries forward `label` from `previousEntry` to the stored entry when `nextEntry` does not have a label set.
**Not tested:** Live Control UI session with label set then reset.

Fixes #101451
