### PR TITLE
refactor(feishu): localize internal declarations

### DIFF
--- a/extensions/feishu/src/app-registration.ts
+++ b/extensions/feishu/src/app-registration.ts
@@ -42,7 +42,7 @@ interface InitResponse {
   supported_auth_methods: string[];
 }
 
-export interface BeginResult {
+interface BeginResult {
   deviceCode: string;
   qrUrl: string;
   userCode: string;
@@ -52,7 +52,7 @@ export interface BeginResult {
 
 export type FeishuAppRegistrationFetch = typeof fetch;
 
-export type FeishuAppRegistrationFetchOptions = {
+type FeishuAppRegistrationFetchOptions = {
   /** Override fetch for tests while preserving the real SSRF guard path. */
   fetchImpl?: FeishuAppRegistrationFetch;
   /** Override hostname lookup for hermetic SSRF-guard tests. */
@@ -79,7 +79,7 @@ interface PollResponse {
   error_description?: string;
 }
 
-export type PollOutcome =
+type PollOutcome =
   | { status: "success"; result: AppRegistrationResult }
   | { status: "access_denied" }
   | { status: "expired" }

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -200,7 +200,7 @@ export function createFeishuClient(creds: FeishuClientCredentials): Lark.Client 
   return client;
 }
 
-export type FeishuWsClientCallbacks = Pick<
+type FeishuWsClientCallbacks = Pick<
   ConstructorParameters<typeof feishuClientSdk.WSClient>[0],
   "onError" | "onReady" | "onReconnected" | "onReconnecting"
 >;

--- a/extensions/feishu/src/comment-shared.ts
+++ b/extensions/feishu/src/comment-shared.ts
@@ -78,7 +78,7 @@ function formatFeishuApiFailure(
   return `${errorPrefix}: ${details || "unknown error"}`;
 }
 
-export function createFeishuApiError(
+function createFeishuApiError(
   error: unknown,
   errorPrefix: string,
   options: {

--- a/extensions/feishu/src/doctor.ts
+++ b/extensions/feishu/src/doctor.ts
@@ -64,7 +64,7 @@ type FeishuDoctorSessionEntry = {
   entry: FeishuSessionEntry;
 };
 
-export type FeishuDoctorInspection = {
+type FeishuDoctorInspection = {
   stateDir: string;
   feishuStateDir: string;
   findings: FeishuDoctorFinding[];

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -594,7 +594,7 @@ async function queryCommentById(
   return response.data?.items?.find((comment) => comment.comment_id?.trim() === params.comment_id);
 }
 
-export async function replyComment(
+async function replyComment(
   client: Lark.Client,
   params: {
     file_token: string;

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -51,7 +51,7 @@ const FEISHU_TRANSCODABLE_AUDIO_EXTS = new Set([
   ".wma",
 ]);
 
-export type SaveMessageResourceResult = {
+type SaveMessageResourceResult = {
   saved: SavedMedia;
   contentType?: string;
   fileName?: string;
@@ -398,11 +398,11 @@ export async function saveMessageResourceFeishu(params: {
   }
 }
 
-export type UploadImageResult = {
+type UploadImageResult = {
   imageKey: string;
 };
 
-export type UploadFileResult = {
+type UploadFileResult = {
   fileKey: string;
 };
 

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -445,11 +445,11 @@ function registerEventHandlers(
   });
 }
 
-export type BotOpenIdSource =
+type BotOpenIdSource =
   | { kind: "prefetched"; botOpenId?: string; botName?: string }
   | { kind: "fetch" };
 
-export type MonitorSingleAccountParams = {
+type MonitorSingleAccountParams = {
   cfg: ClawdbotConfig;
   account: ResolvedFeishuAccount;
   channelRuntime?: PluginRuntime["channel"];

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -10,7 +10,7 @@ import {
   stopFeishuMonitorState,
 } from "./monitor.state.js";
 
-export type MonitorFeishuOpts = {
+type MonitorFeishuOpts = {
   config?: ClawdbotConfig;
   runtime?: RuntimeEnv;
   channelRuntime?: PluginRuntime["channel"];

--- a/extensions/feishu/src/probe.ts
+++ b/extensions/feishu/src/probe.ts
@@ -18,7 +18,7 @@ const PROBE_SUCCESS_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const PROBE_ERROR_TTL_MS = 60 * 1000; // 1 minute
 const MAX_PROBE_CACHE_SIZE = 64;
 export const FEISHU_PROBE_REQUEST_TIMEOUT_MS = 10_000;
-export type ProbeFeishuOptions = {
+type ProbeFeishuOptions = {
   timeoutMs?: number;
   abortSignal?: AbortSignal;
 };

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -425,7 +425,7 @@ export async function getMessageFeishu(params: {
   }
 }
 
-export type FeishuThreadMessageInfo = {
+type FeishuThreadMessageInfo = {
   messageId: string;
   senderId?: string;
   senderType?: string;
@@ -518,7 +518,7 @@ export async function listFeishuThreadMessages(params: {
   return results;
 }
 
-export type SendFeishuMessageParams = {
+type SendFeishuMessageParams = {
   cfg: ClawdbotConfig;
   to: string;
   text: string;
@@ -618,7 +618,7 @@ export async function sendMessageFeishu(
   });
 }
 
-export type SendFeishuCardParams = {
+type SendFeishuCardParams = {
   cfg: ClawdbotConfig;
   to: string;
   card: Record<string, unknown>;

--- a/extensions/feishu/src/sequential-queue.ts
+++ b/extensions/feishu/src/sequential-queue.ts
@@ -21,7 +21,7 @@ import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 
 const DEFAULT_TASK_TIMEOUT_MS = 5 * 60 * 1000;
 
-export interface SequentialQueueOptions {
+interface SequentialQueueOptions {
   /**
    * Maximum time (ms) to block subsequent same-key tasks behind a single
    * in-flight task. Pass 0 (or a non-finite value) to disable the cap and

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -28,7 +28,7 @@ type CardState = {
 
 export type FeishuStreamingFetch = typeof fetch;
 
-export type FeishuStreamingDeps = {
+type FeishuStreamingDeps = {
   /** Override fetch for tests while preserving the real SSRF guard path. */
   fetchImpl?: FeishuStreamingFetch;
   /** Override hostname lookup for hermetic SSRF-guard tests. */


### PR DESCRIPTION
## What Problem This Solves

Feishu implementation modules exported 19 declarations that have no consumers outside their defining files and are not part of the plugin's public API barrels.

## Why This Change Was Made

Keeping file-private declarations exported expands the apparent package surface and makes dead-code and API analysis noisier. This localizes those declarations without changing their runtime definitions or call paths.

## User Impact

No behavior change. Feishu runtime behavior and its published API remain unchanged.

## Evidence

- `OPENCLAW_TESTBOX=1 pnpm check:changed` passed in Testbox `tbx_01kwznjmetm791ezwftksg2ayc`.
- `pnpm test:serial extensions/feishu` passed: 75 files, 1,031 tests.
- `pnpm build` passed, including plugin SDK export guards and the Control UI build.
- Repository-wide import scan found no consumers for the localized declarations.
- `extensions/feishu/api.ts` and runtime/contract barrels do not expose these names.
- Local autoreview: clean, confidence 0.86.
- Branch autoreview after rebasing onto current `origin/main`: clean, confidence 0.90.
- Diff: 12 files, 19 insertions, 19 deletions; no production LOC growth.
