### PR TITLE
[AI] fix(agents): align TOOL_RESULT_CHARS_PER_TOKEN with ESTIMATED_CH…

### DIFF
--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
@@ -268,14 +268,14 @@ describe("preemptive-compaction", () => {
       prompt: "continue",
     });
 
-    expect(estimatedPromptTokens).toBeGreaterThan(80_000);
+    expect(estimatedPromptTokens).toBeGreaterThan(40_000);
 
     const result = shouldPreemptivelyCompactBeforePrompt({
       messages,
       systemPrompt: "sys",
       prompt: "continue",
-      contextTokenBudget: 96_000,
-      reserveTokens: 20_000,
+      contextTokenBudget: 40_000,
+      reserveTokens: 0,
     });
 
     expect(result.route).not.toBe("fits");
@@ -323,12 +323,12 @@ describe("preemptive-compaction", () => {
       messages,
       systemPrompt: "system".repeat(200),
       prompt: "continue",
-      contextTokenBudget: 200_000,
-      reserveTokens: 32_000,
+      contextTokenBudget: 130_000,
+      reserveTokens: 0,
     });
 
-    expect(result.estimatedPromptTokens).toBeGreaterThan(200_000);
-    expect(result.promptBudgetBeforeReserve).toBe(168_000);
+    expect(result.estimatedPromptTokens).toBeGreaterThan(130_000);
+    expect(result.promptBudgetBeforeReserve).toBe(130_000);
     expect(result.route).not.toBe("fits");
     expect(result.overflowTokens).toBeGreaterThan(0);
   });
@@ -454,5 +454,37 @@ describe("preemptive-compaction", () => {
     expect(potential.maxReducibleChars).toBeGreaterThan(desiredOverflowTokens * 4);
     expect(result.route).toBe("truncate_tool_results_only");
     expect(result.shouldCompact).toBe(false);
+  });
+
+  it("does not false-positive overflow for a tool-result-heavy turn well within the context window (#101929)", () => {
+    // ~250k chars of tool result text across ~20 messages, plus assistant turns.
+    // With TOOL_RESULT_CHARS_PER_TOKEN=4, this should estimate far below the
+    // 150k prompt budget (200k context − 50k reserve) instead of the ~162k
+    // false overflow the old TOOL_RESULT_CHARS_PER_TOKEN=2 would produce.
+    const toolCharsPerMessage = Math.ceil(250_000 / 20);
+    const messages: AgentMessage[] = [];
+    for (let i = 0; i < 43; i += 1) {
+      if (i % 2 === 0) {
+        messages.push(makeToolResultMessage("x".repeat(toolCharsPerMessage)));
+      } else {
+        messages.push(makeAssistantHistory("y".repeat(500)));
+      }
+    }
+
+    const result = shouldPreemptivelyCompactBeforePrompt({
+      messages,
+      systemPrompt: "sys",
+      prompt: "continue",
+      contextTokenBudget: 200_000,
+      reserveTokens: 50_000,
+    });
+
+    // The prompt budget before reserve is 150k. The corrected estimator
+    // should produce an estimate comfortably below that for ~250k chars
+    // of tool results plus minor assistant overhead.
+    expect(result.estimatedPromptTokens).toBeLessThan(150_000);
+    expect(result.route).toBe("fits");
+    expect(result.shouldCompact).toBe(false);
+    expect(result.overflowTokens).toBe(0);
   });
 });

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
@@ -17,7 +17,7 @@ export const PREEMPTIVE_OVERFLOW_ERROR_TEXT =
   "Context overflow: prompt too large for the model (precheck).";
 
 const ESTIMATED_CHARS_PER_TOKEN = 4;
-const TOOL_RESULT_CHARS_PER_TOKEN = 2;
+const TOOL_RESULT_CHARS_PER_TOKEN = 4;
 const JSON_PAYLOAD_CHARS_PER_TOKEN = 3;
 const MESSAGE_BOUNDARY_OVERHEAD_TOKENS = 12;
 const CONTENT_BLOCK_OVERHEAD_TOKENS = 6;


### PR DESCRIPTION
## Summary

The mid-turn precheck token estimator over-counted tool-result text by ~2× because `TOOL_RESULT_CHARS_PER_TOKEN=2` treated tool results as twice as token-dense as ordinary text. Aligning it with `ESTIMATED_CHARS_PER_TOKEN=4` eliminates the systematic over-estimate while retaining the 1.2× safety margin.

- **Problem**: `TOOL_RESULT_CHARS_PER_TOKEN=2` in `estimateToolResultContentTokenPressure()` causes `context-overflow-midturn-precheck` to fire at ~2.3-2.6× above real provider-billed usage, triggering destructive `truncate_tool_results_only` recovery on turns well within the context window
- **Solution**: Change `TOOL_RESULT_CHARS_PER_TOKEN` from 2 to 4, matching `ESTIMATED_CHARS_PER_TOKEN` used everywhere else
- **What changed**: `src/agents/embedded-agent-runner/run/preemptive-compaction.ts` (one constant), `src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts` (updated thresholds + regression test)
- **What did NOT change**: `SAFETY_MARGIN` (still 1.2×), `ESTIMATED_CHARS_PER_TOKEN` (unchanged at 4), `TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE` in `tool-result-char-estimator.ts` (separate char-estimation path, not the token estimator), aggregate truncation projection in the estimator (kept scope minimal)

## Change Type & Scope

### Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

### Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue

- Related to #101929
- [x] This PR fixes a bug or regression

## Motivation

Users with `midTurnPrecheck.enabled: true` on tool-result-heavy agent turns (e.g. work-queue digest agents) experience false-positive overflow detection. The precheck fires `truncate_tool_results_only` recovery that rewrites all prior tool results into tiny stubs, causing the model to re-fetch data it already obtained. This wastes tokens (~3× in the reporter's case), increases latency, and exposes long-running turns to transient provider errors — all while the turn is well within the real context window.

The root cause is the conservative `TOOL_RESULT_CHARS_PER_TOKEN=2` which was set when the mid-turn precheck was first introduced. Real tokenizers (GPT, Claude) encode English tool-result text at approximately the same 4 chars/token rate as ordinary text, making the 2 value a systematic 2× over-count.

## Review Contract

```text
Ref: #101929 / PR #TBD
Surface: agents / compaction / mid-turn precheck estimator

Bug: TOOL_RESULT_CHARS_PER_TOKEN=2 causes context-overflow-midturn-precheck to over-estimate tool-result token pressure by ~2× vs provider-billed usage
Cause: estimateToolResultContentTokenPressure() at preemptive-compaction.ts:108-122 divides tool-result chars by 2 instead of 4, and the mid-turn precheck at tool-result-context-guard.ts:530 calls shouldPreemptivelyCompactBeforePrompt over the untruncated in-memory transcript before the provider-boundary aggregate truncation
Provenance:
  introduced by: 2d033d2aa84 (Peter Steinberger, 2026-03-03) — TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE=2 in char estimator
  carried forward by: c08400ea7d5 (Jason, 2026-05-22) — TOOL_RESULT_CHARS_PER_TOKEN=2 in token estimator
  made visible by: b85147ff7615 (marchpure) — mid-turn precheck path that surfaces the conservative ratio
  Confidence: clear

Best fix: Yes — aligning TOOL_RESULT_CHARS_PER_TOKEN with ESTIMATED_CHARS_PER_TOKEN is the minimal, correct fix. The SAFETY_MARGIN=1.2 already provides headroom for tokenizer variance. A more comprehensive fix (applying provider-boundary aggregate truncation projection) would add import-cycle risk without proportional benefit for the common case.
Refactor: No — the char-based estimator in tool-result-char-estimator.ts is a separate code path (context guard, not token estimator) and not part of the reported over-count
Proof: 17 unit tests pass including new regression test; related suites pass (attempt.llm-boundary: 23, tool-result-truncation: 38, tool-result-context-guard: 45, overflow-compaction-loop: 26)
Risk: Changing the constant from 2→4 could theoretically under-estimate for highly tokenization-efficient tool results (e.g. pure numeric JSON or non-English scripts). The SAFETY_MARGIN=1.2 and the fact that normal text has always used 4 chars/token mitigate this. The separate char-estimator path (tool-result-char-estimator.ts) keeps its own TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE=2 for the context guard, which is unchanged.
```

## Real Behavior Proof

**Behavior addressed**: On a tool-result-heavy turn with ~250k chars of tool result text across ~20 calls, a 200k context window, and 50k reserve tokens, the old estimator produced `estimatedPromptTokens ≈ 162k` (>150k prompt budget), triggering false overflow. The corrected estimator produces an estimate comfortably below 150k.

**Real environment tested**: Ubuntu Linux, Node 22.19, branch `fix/midturn-precheck-estimator-101929`, local checkout

**Exact steps or command run after this patch**:

```bash
# Run the preemptive-compaction unit tests (16 original + 1 new regression)
$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts --run

# Verify related suites are unaffected
$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts --run
$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-result-truncation.test.ts --run
$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-result-context-guard.test.ts --run
$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts --run
```

**Evidence after fix**:

```console
$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts --run
 RUN  v4.1.8 /home/0668000999/OpenClaw
 Test Files  1 passed (1)
      Tests  17 passed (17)

$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts --run
 Test Files  1 passed (1)
      Tests  23 passed (23)

$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-result-truncation.test.ts --run
 Test Files  1 passed (1)
      Tests  38 passed (38)

$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-result-context-guard.test.ts --run
 Test Files  1 passed (1)
      Tests  45 passed (45)

$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts --run
 Test Files  1 passed (1)
      Tests  26 passed (26)
```

**Observed result after fix**:

- The new regression test passes: `~250k` chars of tool results + 200k context + 50k reserve → `route=fits`, `shouldCompact=false`, `overflowTokens=0`, `estimatedPromptTokens < 150_000`
- All 16 existing tests continue to pass with adjusted thresholds
- No regressions across 149 related tests (attempt.llm-boundary, tool-result-truncation, tool-result-context-guard, overflow-compaction-loop)

**What was not tested**:

- Live end-to-end agent run with a real provider (GPT-5.5 / Claude) to confirm billed usage matches the new estimate — would require a running OpenClaw instance with valid credentials
- CJK-heavy tool result text with the new ratio (the CJK-aware `estimateStringChars` handles encoding differences, but the chars-per-token ratio is encoding-agnostic)

### Verification Environment

- OS: Ubuntu Linux (server)
- Runtime: Node 22.19
- Model/provider: N/A (unit test only)
- Integration/channel: N/A

## Risks and Mitigations

- **highest risk area**: The new 4 chars/token ratio could under-estimate for tool results with very efficient tokenization (e.g. repetitive JSON arrays, pure numeric content, or scripts with high token-compression ratios). The SAFETY_MARGIN=1.2 provides some headroom, and the fact that `ESTIMATED_CHARS_PER_TOKEN=4` has been the system-wide default for all non-tool-result text without issues suggests this risk is low.
- **Relief methods**: The SAFETY_MARGIN multiplier (1.2) is applied after estimation, providing a 20% buffer. The aggregate truncation projection at the provider boundary provides an additional implicit safety net — even if the estimate is slightly low, the real outbound prompt is smaller than the in-memory transcript.
- **Compatibility impact**: None — this is a purely internal estimator constant change. No config keys, no API surface, no stored state format change.

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Compatibility / Migration

- [x] Backward compatible? Yes
- [x] Config/env changes? No
- [x] Migration needed? No

## Human Verification

- **Verified scenarios**: Token estimator unit tests (17/17), related agent runner tests (149/149), no regression in tool-result truncation, context guard, overflow compaction, or LLM boundary paths
- **Edge cases checked**: Mixed oversized + aggregate tool tails, array/object tool-result payloads, JSON tool results, assistant tool-call argument counting, reserve token capping for small context models
- **What you did NOT verify**: Live provider run with real token billing comparison; CJK-heavy tool result edge case with the new ratio

## AI Assistance 🤖

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Pending
- **AI prompts / session excerpts**: Analyzed issue #101929 root cause, traced `TOOL_RESULT_CHARS_PER_TOKEN=2` provenance to commits `2d033d2aa84` and `c08400ea7d5`, proposed and implemented one-constant fix with test updates.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

Related to #101929
