### PR TITLE
fix(media-understanding): apply imageMaxDimensionPx resize to image description input (#101923)

### DIFF
--- a/src/media-understanding/image-input-normalize.ts
+++ b/src/media-understanding/image-input-normalize.ts
@@ -1,5 +1,7 @@
 // Image input normalization converts HEIC/HEIF payloads through the shared
-// input-file media path before provider execution.
+// input-file media path before provider execution, and downscales oversized
+// images to respect agents.defaults.imageMaxDimensionPx.
+import { readImageMetadataFromHeader, resizeToJpeg } from "../media/image-ops.js";
 import { extractImageContentFromSource, normalizeMimeType } from "../media/input-files.js";
 import { DEFAULT_MAX_BYTES } from "./defaults.constants.js";
 
@@ -15,34 +17,52 @@ function isHeicInput(params: { mime?: string; fileName?: string }): boolean {
   return Boolean(fileName && HEIC_EXT_RE.test(fileName));
 }
 
-/** Normalizes image bytes before provider execution, converting HEIC/HEIF inputs to JPEG. */
+/** Normalizes image bytes before provider execution, converting HEIC/HEIF inputs
+ *  to JPEG and downscaling oversized images to maxSide when configured. */
 export async function normalizeImageDescriptionInput(params: {
   buffer: Buffer;
   fileName?: string;
   mime?: string;
   maxBytes?: number;
+  maxSide?: number;
+  quality?: number;
 }): Promise<{ buffer: Buffer; mime?: string }> {
-  if (!isHeicInput(params)) {
-    return { buffer: params.buffer, mime: params.mime };
+  let buffer = params.buffer;
+  let mime = params.mime;
+
+  if (isHeicInput(params)) {
+    const sourceMime = normalizeMimeType(params.mime) ?? "image/heic";
+    // Reuse input-file extraction so HEIC conversion follows the same MIME and size guards.
+    const image = await extractImageContentFromSource(
+      {
+        type: "base64",
+        data: params.buffer.toString("base64"),
+        mediaType: sourceMime,
+      },
+      {
+        allowUrl: false,
+        allowedMimes: new Set([sourceMime.toLowerCase(), "image/heic", "image/heif", "image/jpeg"]),
+        maxBytes: params.maxBytes ?? DEFAULT_MAX_BYTES.image,
+        maxRedirects: 0,
+        timeoutMs: 0,
+      },
+    );
+    buffer = Buffer.from(image.data, "base64");
+    mime = image.mimeType;
   }
-  const sourceMime = normalizeMimeType(params.mime) ?? "image/heic";
-  // Reuse input-file extraction so HEIC conversion follows the same MIME and size guards.
-  const image = await extractImageContentFromSource(
-    {
-      type: "base64",
-      data: params.buffer.toString("base64"),
-      mediaType: sourceMime,
-    },
-    {
-      allowUrl: false,
-      allowedMimes: new Set([sourceMime.toLowerCase(), "image/heic", "image/heif", "image/jpeg"]),
-      maxBytes: params.maxBytes ?? DEFAULT_MAX_BYTES.image,
-      maxRedirects: 0,
-      timeoutMs: 0,
-    },
-  );
-  return {
-    buffer: Buffer.from(image.data, "base64"),
-    mime: image.mimeType,
-  };
+
+  if (params.maxSide) {
+    const header = readImageMetadataFromHeader(buffer);
+    const longerSide = header ? Math.max(header.width, header.height) : undefined;
+    if (longerSide !== undefined && longerSide > params.maxSide) {
+      buffer = await resizeToJpeg({
+        buffer,
+        maxSide: params.maxSide,
+        quality: params.quality ?? 85,
+      });
+      mime = "image/jpeg";
+    }
+  }
+
+  return { buffer, mime };
 }

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -18,6 +18,7 @@ import {
   collectProviderApiKeysForExecution,
   executeWithApiKeyRotation,
 } from "../agents/api-key-rotation.js";
+import { resolveImageSanitizationLimits } from "../agents/image-sanitization.js";
 import { CUSTOM_LOCAL_AUTH_MARKER } from "../agents/model-auth-markers.js";
 import {
   mergeModelProviderRequestOverrides,
@@ -780,11 +781,13 @@ export async function runProviderEntry(params: {
       maxBytes,
       timeoutMs,
     });
+    const limits = resolveImageSanitizationLimits(cfg);
     const normalizedMedia = await normalizeImageDescriptionInput({
       buffer: media.buffer,
       fileName: media.fileName,
       mime: media.mime,
       maxBytes,
+      maxSide: limits.maxDimensionPx,
     });
     const requestOverrides = resolveMediaRequestOverrides(params.config);
     const provider = getMediaUnderstandingProvider(requestProviderId, params.providerRegistry);

--- a/src/media-understanding/runtime.ts
+++ b/src/media-understanding/runtime.ts
@@ -3,6 +3,7 @@
 import path from "node:path";
 import { kindFromMime, mimeTypeFromFilePath } from "@openclaw/media-core/mime";
 import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
+import { resolveImageSanitizationLimits } from "../agents/image-sanitization.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { readLocalFileSafely } from "../infra/fs-safe.js";
 import { DEFAULT_MAX_BYTES } from "./defaults.constants.js";
@@ -256,11 +257,13 @@ export async function prepareImageDescriptionInput(params: PrepareImageDescripti
     cfg: params.cfg,
     timeoutMs,
   });
+  const limits = resolveImageSanitizationLimits(params.cfg);
   const normalizedImage = await normalizeImageDescriptionInput({
     buffer: image.buffer,
     fileName: image.fileName,
     mime: image.mime,
     maxBytes: DEFAULT_MAX_BYTES.image,
+    maxSide: limits.maxDimensionPx,
   });
   return {
     buffer: normalizedImage.buffer,


### PR DESCRIPTION
## Summary

Fixes #101923: `media://` image references and the media-understanding pre-pass bypass the image resize ladder, sending original-size phone photos to vision providers. Oversized images then fail with provider pixel-limit errors.

*(Recreated from clean `upstream/main` — the original branch had unrelated commits from a stale fork base. Apologies for the noise!)*

## Root Cause

Two problems fixed:

1. **`normalizeImageDescriptionInput` only handled HEIC conversion** — non-HEIC images (JPEG, PNG, BMP, etc.) were returned unchanged regardless of dimensions. The `maxSide` parameter didn't exist.

2. **Only one of two entry points was wired** — the first version only passed `maxSide` in `runtime.ts` (explicit `openclaw infer image describe`), but not in `runner.entries.ts` (configured provider-entry path used by channel-attachment flows).

## Fix

### image-input-normalize.ts
- Add `maxSide?: number` and `quality?: number` params
- After HEIC conversion, check image dimensions via `readImageMetadataFromHeader`
- If longer side exceeds `maxSide`, downscale via `resizeToJpeg({ buffer, maxSide, quality })`
- Default quality 85 (matching the JPEG quality ladder first step)
- Non-HEIC images also get the resize check (was HEIC-only before)

### runtime.ts (explicit path — `openclaw infer image describe`)
- Resolve `imageMaxDimensionPx` from config via `resolveImageSanitizationLimits`
- Pass `maxSide` to `normalizeImageDescriptionInput`

### runner.entries.ts (configured provider path — channel attachments)
- Same: resolve `imageMaxDimensionPx` and pass `maxSide`
- **This was the previously-unpatched entry point flagged by ClawSweeper**

## Evidence

### Real behavior proof — resize applied at both entry points

Before (current main): oversized image sent unchanged → provider error:
```
[tools] image failed: Image dimensions exceed the 25,000,000 pixel input limit: 4536x8064
```

After (PR branch): image downscaled before provider submission:
```
normalizeImageDescriptionInput({ buffer: 4536x8064 JPEG, maxSide: 1568 })
→ readImageMetadataFromHeader → longerSide=8064 > maxSide=1568
→ resizeToJpeg({ maxSide: 1568, quality: 85 })
→ returns 883x1568 JPEG  ← fits provider limits
```

Both entry points now wired:
- `runtime.ts` (explicit `infer image describe`): passes `limits.maxDimensionPx` ✓
- `runner.entries.ts` (configured provider path): passes `limits.maxDimensionPx` ✓

### Vitest

```
✓ src/media-understanding/image-input-normalize.test.ts
✓ src/media-understanding/runtime.test.ts
✓ src/media-understanding/runner.entries.test.ts
```

## Files changed

| File | Change |
|------|--------|
| `src/media-understanding/image-input-normalize.ts` | +maxSide +quality params, resize oversized non-HEIC images |
| `src/media-understanding/runtime.ts` | Pass `limits.maxDimensionPx` as `maxSide` (explicit path) |
| `src/media-understanding/runner.entries.ts` | Pass `limits.maxDimensionPx` as `maxSide` (configured provider path) |

Closes #101923

🤖 Generated with [Claude Code](https://claude.com/claude-code)