### PR TITLE
refactor(matrix): localize internal types

### DIFF
--- a/extensions/matrix/src/approval-handler.runtime.ts
+++ b/extensions/matrix/src/approval-handler.runtime.ts
@@ -129,7 +129,7 @@ type MatrixPrepareTargetParams = {
 const MATRIX_APPROVAL_DELIVERY_ATTEMPTS = 3;
 const MATRIX_APPROVAL_DELIVERY_RETRY_DELAY_MS = 250;
 
-export type MatrixApprovalHandlerDeps = {
+type MatrixApprovalHandlerDeps = {
   nowMs?: () => number;
   sendMessage?: typeof sendMessageMatrix;
   sendSingleTextMessage?: typeof sendSingleTextMessageMatrix;

--- a/extensions/matrix/src/approval-reactions.ts
+++ b/extensions/matrix/src/approval-reactions.ts
@@ -30,7 +30,7 @@ const PERSISTENT_NAMESPACE = "matrix.approval-reactions";
 const PERSISTENT_MAX_ENTRIES = 1000;
 const DEFAULT_REACTION_TARGET_TTL_MS = 24 * 60 * 60 * 1000;
 
-export type MatrixApprovalReactionBinding = {
+type MatrixApprovalReactionBinding = {
   decision: ExecApprovalReplyDecision;
   emoji: string;
   label: string;

--- a/extensions/matrix/src/matrix/actions/verification.ts
+++ b/extensions/matrix/src/matrix/actions/verification.ts
@@ -18,7 +18,7 @@ type MatrixVerificationDmLookupOpts = {
   verificationDmUserId?: string;
 };
 
-export type MatrixSelfVerificationResult = MatrixVerificationSummary & {
+type MatrixSelfVerificationResult = MatrixVerificationSummary & {
   deviceOwnerVerified: boolean;
   ownerVerification: MatrixOwnDeviceVerificationStatus;
 };

--- a/extensions/matrix/src/matrix/client/file-sync-store.ts
+++ b/extensions/matrix/src/matrix/client/file-sync-store.ts
@@ -31,7 +31,7 @@ const SYNC_CACHE_STATE_KEY = "current";
 // PluginState serializes this string inside a row object; 24KB leaves room for JSON escaping.
 const SYNC_CACHE_CHUNK_BYTES = 24_000;
 
-export type PersistedMatrixSyncStore = {
+type PersistedMatrixSyncStore = {
   version: number;
   savedSync: ISyncData | null;
   clientOptions?: IStoredClientOpts;

--- a/extensions/matrix/src/matrix/device-health.ts
+++ b/extensions/matrix/src/matrix/device-health.ts
@@ -5,7 +5,7 @@ export type MatrixManagedDeviceInfo = {
   current: boolean;
 };
 
-export type MatrixDeviceHealthSummary = {
+type MatrixDeviceHealthSummary = {
   currentDeviceId: string | null;
   staleOpenClawDevices: MatrixManagedDeviceInfo[];
   currentOpenClawDevices: MatrixManagedDeviceInfo[];

--- a/extensions/matrix/src/matrix/direct-management.ts
+++ b/extensions/matrix/src/matrix/direct-management.ts
@@ -14,7 +14,7 @@ export type MatrixDirectRoomCandidate = {
   source: "account-data" | "joined";
 };
 
-export type MatrixDirectRoomInspection = {
+type MatrixDirectRoomInspection = {
   selfUserId: string | null;
   remoteUserId: string;
   mappedRoomIds: string[];
@@ -23,14 +23,14 @@ export type MatrixDirectRoomInspection = {
   activeRoomId: string | null;
 };
 
-export type MatrixDirectRoomRepairResult = MatrixDirectRoomInspection & {
+type MatrixDirectRoomRepairResult = MatrixDirectRoomInspection & {
   createdRoomId: string | null;
   changed: boolean;
   directContentBefore: MatrixDirectAccountData;
   directContentAfter: MatrixDirectAccountData;
 };
 
-export type MatrixDirectRoomPromotionResult =
+type MatrixDirectRoomPromotionResult =
   | {
       classifyAsDirect: true;
       repaired: boolean;

--- a/extensions/matrix/src/matrix/direct-room.ts
+++ b/extensions/matrix/src/matrix/direct-room.ts
@@ -72,7 +72,7 @@ export async function hasDirectMatrixMemberFlag(
   }
 }
 
-export type MatrixDirectRoomEvidence = {
+type MatrixDirectRoomEvidence = {
   joinedMembers: string[] | null;
   strict: boolean;
   viaMemberState: boolean;

--- a/extensions/matrix/src/matrix/draft-stream.ts
+++ b/extensions/matrix/src/matrix/draft-stream.ts
@@ -26,7 +26,7 @@ function resolveDraftPreviewOptions(mode: MatrixDraftPreviewMode): {
   };
 }
 
-export type MatrixDraftStream = {
+type MatrixDraftStream = {
   /** Update the draft with the latest accumulated text for the current block. */
   update: (text: string) => void;
   /** Ensure the last pending update has been sent. */

--- a/extensions/matrix/src/matrix/legacy-crypto-inspector.ts
+++ b/extensions/matrix/src/matrix/legacy-crypto-inspector.ts
@@ -5,7 +5,7 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import { ensureMatrixCryptoRuntime } from "./deps.js";
 
-export type MatrixLegacyCryptoInspectionResult = {
+type MatrixLegacyCryptoInspectionResult = {
   deviceId: string | null;
   roomKeyCounts: {
     total: number;

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -58,7 +58,7 @@ import { createMatrixMonitorStatusController } from "./status.js";
 import { createMatrixMonitorSyncLifecycle } from "./sync-lifecycle.js";
 import { createMatrixMonitorTaskRunner } from "./task-runner.js";
 
-export type MonitorMatrixOpts = {
+type MonitorMatrixOpts = {
   runtime?: RuntimeEnv;
   channelRuntime?: ChannelRuntimeSurface;
   abortSignal?: AbortSignal;

--- a/extensions/matrix/src/matrix/monitor/reaction-events.ts
+++ b/extensions/matrix/src/matrix/monitor/reaction-events.ts
@@ -22,7 +22,7 @@ const loadExecApprovalResolver = createLazyRuntimeModule(
   () => import("../../exec-approval-resolver.js"),
 );
 
-export type MatrixReactionNotificationMode = "off" | "own";
+type MatrixReactionNotificationMode = "off" | "own";
 
 function resolveMatrixReactionNotificationMode(params: {
   cfg: CoreConfig;

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -234,7 +234,7 @@ export type MatrixRecoveryKeyVerificationResult = MatrixOwnDeviceVerificationSta
   error?: string;
 };
 
-export type MatrixOwnCrossSigningPublicationStatus = {
+type MatrixOwnCrossSigningPublicationStatus = {
   userId: string | null;
   masterKeyPublished: boolean;
   selfSigningKeyPublished: boolean;
@@ -282,7 +282,7 @@ export type MatrixOwnDeviceInfo = {
   current: boolean;
 };
 
-export type MatrixRoomKeyBackupResetOptions = {
+type MatrixRoomKeyBackupResetOptions = {
   rotateRecoveryKey?: boolean;
 };
 

--- a/extensions/matrix/src/matrix/sdk/crypto-node.runtime.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-node.runtime.ts
@@ -6,10 +6,7 @@ import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 type MatrixCryptoNodePackage = typeof import("@matrix-org/matrix-sdk-crypto-nodejs");
 
-export type MatrixCryptoNodeBindings = Pick<
-  MatrixCryptoNodePackage,
-  "Attachment" | "EncryptedAttachment"
->;
+type MatrixCryptoNodeBindings = Pick<MatrixCryptoNodePackage, "Attachment" | "EncryptedAttachment">;
 
 export function loadMatrixCryptoNodeBindings(): MatrixCryptoNodeBindings {
   const { Attachment, EncryptedAttachment } =

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -54,14 +54,14 @@ export type { MatrixSendOpts, MatrixSendResult } from "./send/types.js";
 export { resolveMatrixMentionsForBody } from "./send/formatting.js";
 export { resolveMatrixRoomId } from "./send/targets.js";
 
-export type MatrixPreparedSingleText = {
+type MatrixPreparedSingleText = {
   trimmedText: string;
   convertedText: string;
   singleEventLimit: number;
   fitsInSingleEvent: boolean;
 };
 
-export type MatrixPreparedChunkedText = MatrixPreparedSingleText & {
+type MatrixPreparedChunkedText = MatrixPreparedSingleText & {
   chunks: string[];
 };
 

--- a/extensions/matrix/src/matrix/sqlite-state.ts
+++ b/extensions/matrix/src/matrix/sqlite-state.ts
@@ -2,7 +2,7 @@
 import os from "node:os";
 import { getMatrixRuntime } from "../runtime.js";
 
-export type MatrixSqliteStateOptions = {
+type MatrixSqliteStateOptions = {
   env?: NodeJS.ProcessEnv;
   stateDir?: string;
   stateRootDir?: string;

--- a/extensions/matrix/src/setup-bootstrap.ts
+++ b/extensions/matrix/src/setup-bootstrap.ts
@@ -6,7 +6,7 @@ import { formatMatrixErrorMessage } from "./matrix/errors.js";
 import type { RuntimeEnv } from "./runtime-api.js";
 import type { CoreConfig } from "./types.js";
 
-export type MatrixSetupVerificationBootstrapResult = {
+type MatrixSetupVerificationBootstrapResult = {
   attempted: boolean;
   success: boolean;
   recoveryKeyCreatedAt: string | null;


### PR DESCRIPTION
## What Problem This Solves

Matrix implementation modules exported 20 type aliases that have no consumers outside their defining files and are not part of the plugin's public API, test API, runtime, or contract barrels.

## Why This Change Was Made

File-private types should not expand the apparent package surface. Localizing them improves dead-code and API analysis while preserving every runtime definition and call path.

## User Impact

No behavior change. Matrix runtime behavior and published API barrels remain unchanged.

## Evidence

- Fresh full codebase-memory MCP graph: 281,353 nodes and 1,134,093 edges.
- MCP `search_graph` plus repository-wide import scanning found only defining-module references for the localized types.
- Audited `api.ts`, `test-api.ts`, runtime, setup, contract, doctor, helper, and session-binding barrels; none expose these names.
- Testbox `tbx_01kwzpapz5fn7654z8jrgj3j5f`: `pnpm check:changed` passed.
- `pnpm test:serial extensions/matrix` passed: 123 files, 1,428 tests.
- `pnpm build` passed, including plugin SDK export guards and the Control UI build.
- Local autoreview: clean, confidence 0.86.
- Branch autoreview: clean, confidence 0.89.
- Diff: 16 files, 20 localized types, net three production lines removed.
