### PR TITLE
fix: avoid truncating exact-limit web_fetch responses

### DIFF
--- a/src/agents/tools/web-shared.test.ts
+++ b/src/agents/tools/web-shared.test.ts
@@ -147,6 +147,24 @@ describe("readResponseText", () => {
     expect(releaseLock).toHaveBeenCalledTimes(1);
   });
 
+  it("does not mark exact-limit reads as truncated", async () => {
+    const cancel = vi.fn(async () => undefined);
+    const releaseLock = vi.fn();
+    const response = responseFromReader({
+      chunks: ["hello", " world"],
+      cancel,
+      releaseLock,
+    });
+
+    await expect(readResponseText(response, { maxBytes: 11 })).resolves.toEqual({
+      text: "hello world",
+      truncated: false,
+      bytesRead: 11,
+    });
+    expect(cancel).not.toHaveBeenCalled();
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
   it("does not invoke whole-body fallbacks when maxBytes is set", async () => {
     const arrayBuffer = vi.fn(async () => new TextEncoder().encode("hello").buffer);
     const text = vi.fn(async () => "hello");

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -272,8 +272,7 @@ export async function readResponseText(
         bytesRead += chunk.byteLength;
         parts.push(chunk);
 
-        if (truncated || bytesRead >= maxBytes) {
-          truncated = true;
+        if (truncated) {
           break;
         }
       }


### PR DESCRIPTION
## Summary
- stop marking `readResponseText()` results as truncated when the response size lands exactly on `maxBytes`
- add a regression test for an exact-limit read that should stay untruncated

Fixes #101837

## Validation
- `pnpm -C ~/clawd/pr-worktrees/issue-101837-web-fetch-exact-limit exec vitest run src/agents/tools/web-shared.test.ts`