### PR TITLE
fix: clarify malformed nodes invoke params errors

### DIFF
--- a/src/cli/nodes-cli.coverage.test.ts
+++ b/src/cli/nodes-cli.coverage.test.ts
@@ -208,6 +208,20 @@ describe("nodes-cli coverage", () => {
     expect(runtimeErrors.at(-1)).toContain('command "system.run" is reserved for shell execution');
   });
 
+  it("reports malformed --params JSON before invoking the node", async () => {
+    await expect(
+      sharedProgram.parseAsync(
+        ["nodes", "invoke", "--node", "mac-1", "--command", "canvas.eval", "--params", "not-json"],
+        { from: "user" },
+      ),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(callGateway).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: "node.invoke" }),
+    );
+    expect(runtimeErrors.at(-1)).toContain("--params must be valid JSON");
+  });
+
   it("invokes system.notify with provided fields", async () => {
     const invoke = await runNodesCommand([
       "nodes",

--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -43,7 +43,13 @@ export function registerNodesInvokeCommands(nodes: Command) {
               `command "${command}" is reserved for shell execution; use the exec tool with host=node instead`,
             );
           }
-          const params = JSON.parse(opts.params ?? "{}") as unknown;
+          let params: unknown;
+          try {
+            params = JSON.parse(opts.params ?? "{}") as unknown;
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            throw new Error(`--params must be valid JSON: ${message}`, { cause: error });
+          }
           const timeoutMs = parseOptionalNodePositiveInteger(
             opts.invokeTimeout,
             "--invoke-timeout",


### PR DESCRIPTION
## Summary
- catch `--params` JSON parse failures inside `nodes invoke`
- return an error that explicitly points to `--params` instead of surfacing the raw parser failure
- add coverage for malformed `--params` input

Fixes #101835

## Validation
- `pnpm -C ~/clawd/pr-worktrees/issue-101835-nodes-invoke-params-json tsgo:core`
- direct inspection of the new CLI coverage assertion (targeted vitest runs were flaky in this worktree)