### PR TITLE
fix: disable Gemini thinking when reasoning clamps off

### DIFF
--- a/packages/ai/src/providers/google-shared.test.ts
+++ b/packages/ai/src/providers/google-shared.test.ts
@@ -6,6 +6,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../utils/system-prompt-cache-boundary.js";
 import {
   buildGoogleGenerateContentParams,
+  buildGoogleSimpleThinking,
   consumeGoogleGenerateContentStream,
 } from "./google-shared.js";
 
@@ -226,6 +227,20 @@ describe("consumeGoogleGenerateContentStream", () => {
         arguments: {},
       },
     ]);
+  });
+});
+
+describe("buildGoogleSimpleThinking", () => {
+  it("disables thinking when the requested level is clamped to off", () => {
+    const nonReasoningModel: Model<"google-generative-ai"> = {
+      ...model,
+      id: "gemini-flash-lite",
+      reasoning: false,
+    };
+
+    expect(buildGoogleSimpleThinking(nonReasoningModel, { reasoning: "high" })).toEqual({
+      enabled: false,
+    });
   });
 });
 

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -557,8 +557,11 @@ export function buildGoogleSimpleThinking<T extends GoogleApiType>(
   }
 
   const clampedReasoning = clampThinkingLevel(model, options.reasoning);
+  if (clampedReasoning === "off") {
+    return { enabled: false };
+  }
   const effort = (
-    clampedReasoning === "off" || clampedReasoning === "max" ? "high" : clampedReasoning
+    clampedReasoning === "max" ? "high" : clampedReasoning
   ) as ClampedGoogleThinkingLevel;
 
   if (


### PR DESCRIPTION
## Summary
- return `{ enabled: false }` when Google reasoning is clamped to `off`
- stop remapping `off` to high thinking
- add a regression test covering non-reasoning Google models

Fixes #101785

## Validation
- `pnpm -C ~/clawd/pr-worktrees/issue-101785-gemini-thinking-off-clamp exec tsx -e "import { buildGoogleSimpleThinking } from './packages/ai/src/providers/google-shared.ts'; const model={id:'gemini-flash-lite',name:'Gemini Flash Lite',api:'google-generative-ai',provider:'google',baseUrl:'',reasoning:false,input:['text'],cost:{input:1,output:1,cacheRead:0,cacheWrite:0},contextWindow:128000,maxTokens:8192}; const result=buildGoogleSimpleThinking(model,{reasoning:'high'}); if (JSON.stringify(result)!==JSON.stringify({enabled:false})) throw new Error('unexpected '+JSON.stringify(result)); console.log(result);"`
