### PR TITLE
refactor(whatsapp): localize internal types

### DIFF
--- a/extensions/whatsapp/src/auto-reply/mentions.ts
+++ b/extensions/whatsapp/src/auto-reply/mentions.ts
@@ -21,7 +21,7 @@ export type MentionConfig = {
   isSelfChat?: boolean;
 };
 
-export type MentionTargets = {
+type MentionTargets = {
   normalizedMentions: WhatsAppIdentity[];
   self: WhatsAppIdentity;
 };

--- a/extensions/whatsapp/src/inbound-policy.ts
+++ b/extensions/whatsapp/src/inbound-policy.ts
@@ -19,7 +19,7 @@ import type { AdmittedWebInboundMessage } from "./inbound/types.js";
 import { resolveWhatsAppRuntimeGroupPolicy } from "./runtime-group-policy.js";
 import { isSelfChatMode, normalizeE164 } from "./text-runtime.js";
 
-export type ResolvedWhatsAppInboundPolicy = {
+type ResolvedWhatsAppInboundPolicy = {
   account: ResolvedWhatsAppAccount;
   dmPolicy: DmPolicy;
   groupPolicy: GroupPolicy;

--- a/extensions/whatsapp/src/inbound/access-control.ts
+++ b/extensions/whatsapp/src/inbound/access-control.ts
@@ -7,7 +7,7 @@ import { warnMissingProviderGroupPolicyFallbackOnce } from "openclaw/plugin-sdk/
 import { resolveWhatsAppInboundPolicy, resolveWhatsAppIngressAccess } from "../inbound-policy.js";
 import { buildWhatsAppInboundAdmission, type WhatsAppInboundAdmission } from "./admission.js";
 
-export type BlockedInboundAccessControlResult = {
+type BlockedInboundAccessControlResult = {
   allowed: false;
   shouldMarkRead: false;
   isSelfChat: boolean;

--- a/extensions/whatsapp/src/inbound/durable-receive.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.ts
@@ -17,7 +17,7 @@ export type WhatsAppReadReceiptTarget = {
   participant?: string;
 };
 
-export type SerializedWhatsAppDurableInboundMessage = PluginJsonValue;
+type SerializedWhatsAppDurableInboundMessage = PluginJsonValue;
 
 export type WhatsAppDurableInboundPayload = {
   message: SerializedWhatsAppDurableInboundMessage;

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -137,7 +137,7 @@ function resolveRetryableWhatsAppInboundError(
   return new WhatsAppRetryableInboundError(formatErrorMessage(error), { cause: error });
 }
 export type WhatsAppGroupMetadataCache = Map<string, WhatsAppGroupMetadataCacheEntry>;
-export type WhatsAppBaileysCacheEntry<T> = {
+type WhatsAppBaileysCacheEntry<T> = {
   expiresAt: number;
   value: T;
 };

--- a/extensions/whatsapp/src/inbound/test-message.test-helper.ts
+++ b/extensions/whatsapp/src/inbound/test-message.test-helper.ts
@@ -12,7 +12,7 @@ import type {
   WhatsAppInboundPlatform,
 } from "./types.js";
 
-export type TestWhatsAppInboundAdmissionOverrides = Partial<
+type TestWhatsAppInboundAdmissionOverrides = Partial<
   Omit<
     WhatsAppInboundAdmission,
     | "account"

--- a/extensions/whatsapp/src/qa-driver.runtime.ts
+++ b/extensions/whatsapp/src/qa-driver.runtime.ts
@@ -19,7 +19,7 @@ import {
 } from "./socket-timing.js";
 import { jidToE164 } from "./text-runtime.js";
 
-export type WhatsAppQaDriverObservedMessageKind =
+type WhatsAppQaDriverObservedMessageKind =
   | "media"
   | "location"
   | "poll"
@@ -27,20 +27,20 @@ export type WhatsAppQaDriverObservedMessageKind =
   | "text"
   | "unknown";
 
-export type WhatsAppQaDriverQuotedMessage = {
+type WhatsAppQaDriverQuotedMessage = {
   messageId?: string;
   participant?: string;
   text?: string;
 };
 
-export type WhatsAppQaDriverObservedReaction = {
+type WhatsAppQaDriverObservedReaction = {
   emoji: string;
   fromMe?: boolean;
   messageId?: string;
   participant?: string;
 };
 
-export type WhatsAppQaDriverObservedPoll = {
+type WhatsAppQaDriverObservedPoll = {
   options: string[];
   question?: string;
 };
@@ -61,14 +61,14 @@ export type WhatsAppQaDriverObservedMessage = {
   text: string;
 };
 
-export type WhatsAppQaDriverSendTextOptions = Pick<ActiveWebSendOptions, "quotedMessageKey">;
+type WhatsAppQaDriverSendTextOptions = Pick<ActiveWebSendOptions, "quotedMessageKey">;
 
-export type WhatsAppQaDriverSendMediaOptions = Pick<
+type WhatsAppQaDriverSendMediaOptions = Pick<
   ActiveWebSendOptions,
   "asDocument" | "fileName" | "gifPlayback" | "quotedMessageKey"
 >;
 
-export type WhatsAppQaDriverSendReactionOptions = {
+type WhatsAppQaDriverSendReactionOptions = {
   fromMe: boolean;
   participant?: string;
 };

--- a/extensions/whatsapp/src/resolve-outbound-target.ts
+++ b/extensions/whatsapp/src/resolve-outbound-target.ts
@@ -7,9 +7,7 @@ import {
   normalizeWhatsAppTarget,
 } from "./normalize-target.js";
 
-export type WhatsAppOutboundTargetResolution =
-  | { ok: true; to: string }
-  | { ok: false; error: Error };
+type WhatsAppOutboundTargetResolution = { ok: true; to: string } | { ok: false; error: Error };
 
 function whatsappAllowFromPolicyError(target: string): Error {
   return new Error(`Target "${target}" is not listed in the configured WhatsApp allowFrom policy.`);


### PR DESCRIPTION
## What Problem This Solves

WhatsApp implementation and QA modules exported 14 type aliases that have no consumers outside their defining files and are not named by the plugin's public, runtime, contract, or test API barrels.

## Why This Change Was Made

File-private helper types should not expand the apparent package surface. Localizing them improves dead-code and API analysis while preserving higher-level exported declarations and all runtime behavior.

## User Impact

No behavior change. WhatsApp runtime behavior and published API barrels remain unchanged.

## Evidence

- Fresh full codebase-memory MCP graph: 281,358 nodes and 1,133,963 edges.
- MCP `search_graph` and repository-wide scans found only defining-module references for the localized types.
- Audited public, runtime, contract, setup, security, doctor, directory, and test barrels; none name these aliases.
- TypeScript production/test declaration checks passed with non-exported helper aliases referenced by still-public outer types.
- Testbox `tbx_01kwzq1hd83ajch1bnk6zq1yrs`: `pnpm check:changed` passed.
- `pnpm test:serial extensions/whatsapp` passed: 86 files, 1,029 tests.
- `pnpm build` passed, including plugin SDK export guards and the Control UI build.
- Local autoreview: clean, confidence 0.90.
- Branch autoreview after rebasing onto current `origin/main`: clean, confidence 0.91.
- Diff: eight files, 14 localized types, net two production lines removed.
