### PR TITLE
fix(cron): skip heartbeat-enabled checks for cron-sourced main-session wakes (#101537)

### DIFF
--- a/extensions/codex/src/app-server/attempt-notification-state.ts
+++ b/extensions/codex/src/app-server/attempt-notification-state.ts
@@ -6,6 +6,7 @@ import {
   describeNotificationActivity,
   isAssistantCompletionReleaseNotification,
   isCodexTurnAbortMarkerNotification,
+  isDispatchKnownNotificationMethod,
   isFileChangePatchUpdatedNotification,
   isAssistantCommentaryCompletionNotification,
   isNativeToolProgressNotification,
@@ -93,6 +94,7 @@ export function applyCodexTurnNotificationState(params: {
   turnWatches: CodexAttemptTurnWatchController;
   activeTurnItemIds: Set<string>;
   activeCompletionBlockerItemIds: Set<string>;
+  completedCompletionBlockerItemIds?: Set<string>;
   activeAppServerTurnRequests: number;
   pendingOpenClawDynamicToolCompletionIds: Set<string>;
   turnCrossedToolHandoff: boolean;
@@ -115,13 +117,19 @@ export function applyCodexTurnNotificationState(params: {
   let turnCrossedToolHandoff = params.turnCrossedToolHandoff;
 
   if (isCurrentTurnNotification) {
-    turnWatches.touchActivity(`notification:${notification.method}`, {
-      details: describeNotificationActivity(notification),
-      attemptProgress: true,
-    });
+    // Update item/blocker state before touchActivity so scheduling functions
+    // observe the current blocker count and request count.
     params.onReportExecutionNotification(notification);
     updateActiveTurnItemIds(notification, params.activeTurnItemIds);
-    updateActiveCompletionBlockerItemIds(notification, params.activeCompletionBlockerItemIds);
+    updateActiveCompletionBlockerItemIds(
+      notification,
+      params.activeCompletionBlockerItemIds,
+      params.completedCompletionBlockerItemIds,
+    );
+    turnWatches.touchActivity(`notification:${notification.method}`, {
+      details: describeNotificationActivity(notification),
+      attemptProgress: isDispatchKnownNotificationMethod(notification.method),
+    });
     if (notification.method === "item/completed" && params.activeTurnItemIds.size === 0) {
       params.onScheduleTerminalDynamicToolReleaseCheck();
     }

--- a/extensions/codex/src/app-server/attempt-notifications.ts
+++ b/extensions/codex/src/app-server/attempt-notifications.ts
@@ -62,6 +62,7 @@ export function updateActiveTurnItemIds(
 export function updateActiveCompletionBlockerItemIds(
   notification: CodexServerNotification,
   activeItemIds: Set<string>,
+  completedItemIds?: Set<string>,
 ): void {
   if (notification.method !== "item/started" && notification.method !== "item/completed") {
     return;
@@ -72,6 +73,11 @@ export function updateActiveCompletionBlockerItemIds(
   }
   if (notification.method === "item/completed") {
     activeItemIds.delete(itemId);
+    completedItemIds?.add(itemId);
+    return;
+  }
+  // Ignore late item/started for items that already completed (out-of-order).
+  if (completedItemIds?.has(itemId)) {
     return;
   }
   const item = readCodexNotificationItem(notification.params);
@@ -324,6 +330,39 @@ function readRawAssistantTextPreview(item: JsonObject): string | undefined {
 /** Returns true for app-server error notifications that will retry. */
 export function isRetryableErrorNotification(value: JsonValue | undefined): boolean {
   return isJsonObject(value) && value.willRetry === true;
+}
+
+/**
+ * Notification methods that the event-projector dispatch handles. Only these
+ * count as attempt progress; unknown methods still touch completion activity
+ * but must not reset the attempt-idle watchdog or a wedged turn that keeps
+ * emitting unrecognized notifications never times out.
+ */
+const DISPATCH_KNOWN_ATTEMPT_PROGRESS_METHODS = new Set([
+  "item/agentMessage/delta",
+  "item/reasoning/summaryTextDelta",
+  "item/reasoning/textDelta",
+  "item/reasoning/summaryPartAdded",
+  "item/plan/delta",
+  "turn/plan/updated",
+  "item/started",
+  "item/completed",
+  "item/commandExecution/outputDelta",
+  "item/autoApprovalReview/started",
+  "item/autoApprovalReview/completed",
+  "item/fileChange/patchUpdated",
+  "guardianWarning",
+  "hook/started",
+  "hook/completed",
+  "thread/tokenUsage/updated",
+  "turn/completed",
+  "rawResponseItem/completed",
+  "error",
+]);
+
+/** Returns true when a notification method is recognized by the projector dispatch. */
+export function isDispatchKnownNotificationMethod(method: string): boolean {
+  return DISPATCH_KNOWN_ATTEMPT_PROGRESS_METHODS.has(method);
 }
 
 /** Returns true for terminal app-server thread status strings. */

--- a/extensions/codex/src/app-server/attempt-timeouts.ts
+++ b/extensions/codex/src/app-server/attempt-timeouts.ts
@@ -19,6 +19,12 @@ export const CODEX_POST_TOOL_RAW_ASSISTANT_COMPLETION_IDLE_TIMEOUT_MS = 5 * 60_0
 export const CODEX_POST_REASONING_REPLY_IDLE_TIMEOUT_MS = 5 * 60_000;
 /** Long terminal idle watch for app-server turns that never send completion. */
 export const CODEX_TURN_TERMINAL_IDLE_TIMEOUT_MS = 30 * 60_000;
+/**
+ * Absolute wall-clock ceiling per turn. Fires regardless of activity so a
+ * wedged turn that keeps emitting unrecognized notifications still terminates.
+ * Derived from the terminal idle timeout with a generous multiplier.
+ */
+export const CODEX_TURN_WALL_CLOCK_CEILING_MS = 2 * CODEX_TURN_TERMINAL_IDLE_TIMEOUT_MS;
 
 function resolvePositiveIntegerTimeoutMs(value: number | undefined, fallbackMs: number): number {
   const fallback = resolveTimerTimeoutMs(fallbackMs, 1);

--- a/extensions/codex/src/app-server/attempt-turn-watches.test.ts
+++ b/extensions/codex/src/app-server/attempt-turn-watches.test.ts
@@ -285,6 +285,96 @@ describe("Codex app-server attempt turn watches", () => {
     ]);
     expect(harness.abortController.signal.reason).toBe("turn_progress_idle_timeout");
   });
+
+  it("waits for active completion blocker items before firing attempt idle timeout", () => {
+    const harness = createController();
+    harness.activeCompletionBlockers = 1;
+
+    harness.controller.armAttemptIdleWatch();
+    vi.advanceTimersByTime(10);
+
+    expect(harness.timeouts).toEqual([]);
+    expect(harness.abortController.signal.aborted).toBe(false);
+
+    harness.activeCompletionBlockers = 0;
+    harness.controller.touchActivity("notification:item/completed");
+    vi.advanceTimersByTime(10);
+
+    expect(harness.timeouts).toMatchObject([
+      {
+        kind: "progress",
+        timeoutMs: 10,
+      },
+    ]);
+  });
+
+  it("waits for active turn requests before firing attempt idle timeout", () => {
+    const harness = createController();
+    harness.activeRequests = 1;
+
+    harness.controller.armAttemptIdleWatch();
+    vi.advanceTimersByTime(10);
+
+    expect(harness.timeouts).toEqual([]);
+    expect(harness.abortController.signal.aborted).toBe(false);
+
+    harness.activeRequests = 0;
+    harness.controller.touchActivity("notification:item/completed");
+    vi.advanceTimersByTime(10);
+
+    expect(harness.timeouts).toMatchObject([{ kind: "progress" }]);
+  });
+
+  it("fires wall-clock ceiling after absolute timeout regardless of activity", () => {
+    const harness = createController();
+
+    harness.controller.armWallClockCeiling();
+    // Keep touching activity — the wall-clock ceiling should still fire
+    for (let i = 0; i < 60; i++) {
+      vi.advanceTimersByTime(60_000);
+      harness.controller.touchActivity(`notification:item/delta-${i}`);
+    }
+
+    expect(harness.timeouts).toMatchObject([
+      {
+        kind: "wall_clock_ceiling",
+        timeoutMs: 2 * 30 * 60_000,
+      },
+    ]);
+    expect(harness.abortController.signal.reason).toBe("turn_wall_clock_ceiling");
+  });
+
+  it("disarming wall-clock ceiling prevents it from firing", () => {
+    const harness = createController();
+
+    harness.controller.armWallClockCeiling();
+    harness.controller.disarmWallClockCeiling();
+    vi.advanceTimersByTime(2 * 30 * 60_000);
+
+    expect(harness.timeouts).toEqual([]);
+    expect(harness.abortController.signal.aborted).toBe(false);
+  });
+
+  it("fires attempt idle timeout after the last blocker item completes", () => {
+    // Regression: when item/completed clears the final blocker, the reordering
+    // of state updates before touchActivity ensures scheduling sees count=0.
+    const harness = createController();
+    harness.activeCompletionBlockers = 1;
+
+    harness.controller.armAttemptIdleWatch();
+    // With blocker active, no timer is set
+    vi.advanceTimersByTime(100);
+    expect(harness.timeouts).toEqual([]);
+
+    // Simulate the sequence from applyCodexTurnNotificationState:
+    // state updates happen before touchActivity.
+    harness.activeCompletionBlockers = 0;
+    harness.controller.touchActivity("notification:item/completed");
+
+    // Now the attempt-idle watch should fire after the timeout
+    vi.advanceTimersByTime(10);
+    expect(harness.timeouts).toMatchObject([{ kind: "progress" }]);
+  });
 });
 
 describe("Codex completion blocker item tracking", () => {
@@ -323,4 +413,27 @@ describe("Codex completion blocker item tracking", () => {
       expect(activeItemIds).toEqual(new Set());
     },
   );
+
+  it("ignores late item/started for an already-completed blocker item", () => {
+    const activeItemIds = new Set<string>();
+    const completedItemIds = new Set<string>();
+
+    // completed arrives first
+    updateActiveCompletionBlockerItemIds(
+      { method: "item/completed", params: { item: { id: "item-1", type: "commandExecution" } } },
+      activeItemIds,
+      completedItemIds,
+    );
+    expect(activeItemIds).toEqual(new Set());
+    expect(completedItemIds).toEqual(new Set(["item-1"]));
+
+    // late started arrives — should be ignored
+    updateActiveCompletionBlockerItemIds(
+      { method: "item/started", params: { item: { id: "item-1", type: "commandExecution" } } },
+      activeItemIds,
+      completedItemIds,
+    );
+    expect(activeItemIds).toEqual(new Set());
+    expect(completedItemIds).toEqual(new Set(["item-1"]));
+  });
 });

--- a/extensions/codex/src/app-server/attempt-turn-watches.ts
+++ b/extensions/codex/src/app-server/attempt-turn-watches.ts
@@ -4,11 +4,16 @@
  */
 import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { CODEX_TURN_WALL_CLOCK_CEILING_MS } from "./attempt-timeouts.js";
 
 type Timer = ReturnType<typeof setTimeout>;
 
 /** Timeout bucket reported by the turn watch controller. */
-export type CodexAttemptTurnWatchTimeoutKind = "progress" | "completion" | "terminal";
+export type CodexAttemptTurnWatchTimeoutKind =
+  | "progress"
+  | "completion"
+  | "terminal"
+  | "wall_clock_ceiling";
 
 /** Structured timeout event emitted when a watch fires. */
 export type CodexAttemptTurnWatchTimeout = {
@@ -66,6 +71,9 @@ export function createCodexAttemptTurnWatchController(params: {
   let attemptIdleWatchArmed = false;
   let terminalIdleTimer: Timer | undefined;
   let terminalIdleWatchArmed = false;
+  let wallClockCeilingTimer: Timer | undefined;
+  let wallClockCeilingArmed = false;
+  let wallClockCeilingArmedAt: number | undefined;
   let completionLastActivityAt = Date.now();
   let completionLastActivityReason = "startup";
   let completionLastActivityDetails: Record<string, unknown> | undefined;
@@ -116,6 +124,14 @@ export function createCodexAttemptTurnWatchController(params: {
     clearCompletionIdleTimer();
     clearAssistantCompletionIdleTimer();
     clearTerminalIdleTimer();
+    clearWallClockCeilingTimer();
+  };
+
+  const clearWallClockCeilingTimer = () => {
+    if (wallClockCeilingTimer) {
+      clearTimeout(wallClockCeilingTimer);
+      wallClockCeilingTimer = undefined;
+    }
   };
 
   function scheduleCompletionIdleWatch() {
@@ -154,7 +170,13 @@ export function createCodexAttemptTurnWatchController(params: {
 
   function scheduleAttemptIdleWatch() {
     clearAttemptIdleTimer();
-    if (params.isCompleted() || params.signal.aborted || !attemptIdleWatchArmed) {
+    if (
+      params.isCompleted() ||
+      params.signal.aborted ||
+      !attemptIdleWatchArmed ||
+      params.getActiveAppServerTurnRequests() > 0 ||
+      params.getActiveCompletionBlockerItemCount() > 0
+    ) {
       return;
     }
     const elapsedMs = Math.max(0, Date.now() - attemptLastProgressAt);
@@ -170,7 +192,8 @@ export function createCodexAttemptTurnWatchController(params: {
       params.isCompleted() ||
       params.signal.aborted ||
       !terminalIdleWatchArmed ||
-      params.getActiveAppServerTurnRequests() > 0
+      params.getActiveAppServerTurnRequests() > 0 ||
+      params.getActiveCompletionBlockerItemCount() > 0
     ) {
       return;
     }
@@ -278,6 +301,14 @@ export function createCodexAttemptTurnWatchController(params: {
     if (params.isCompleted() || params.signal.aborted || !attemptIdleWatchArmed) {
       return;
     }
+    // Defer while a native tool item or in-flight server request is open.
+    if (
+      params.getActiveAppServerTurnRequests() > 0 ||
+      params.getActiveCompletionBlockerItemCount() > 0
+    ) {
+      scheduleAttemptIdleWatch();
+      return;
+    }
     const idleMs = Math.max(0, Date.now() - attemptLastProgressAt);
     const timeoutMs = attemptIdleTimeoutOverrideMs ?? turnAttemptIdleTimeoutMs;
     if (idleMs < timeoutMs) {
@@ -376,7 +407,8 @@ export function createCodexAttemptTurnWatchController(params: {
       params.isTerminalTurnNotificationQueued() ||
       params.signal.aborted ||
       !terminalIdleWatchArmed ||
-      params.getActiveAppServerTurnRequests() > 0
+      params.getActiveAppServerTurnRequests() > 0 ||
+      params.getActiveCompletionBlockerItemCount() > 0
     ) {
       return;
     }
@@ -411,6 +443,38 @@ export function createCodexAttemptTurnWatchController(params: {
       ...timeout.details,
     });
     params.onAbort("turn_terminal_idle_timeout");
+  }
+
+  function fireWallClockCeiling() {
+    if (params.isCompleted() || params.signal.aborted || !wallClockCeilingArmed) {
+      return;
+    }
+    const elapsedMs = wallClockCeilingArmedAt
+      ? Math.max(0, Date.now() - wallClockCeilingArmedAt)
+      : 0;
+    wallClockCeilingArmed = false;
+    clearAllTimers();
+    const timeout = {
+      kind: "wall_clock_ceiling" as const,
+      idleMs: elapsedMs,
+      timeoutMs: CODEX_TURN_WALL_CLOCK_CEILING_MS,
+      lastActivityReason: "wall_clock_ceiling",
+    };
+    params.onTimeout(timeout);
+    params.onMarkTimedOut();
+    params.onRecordEvent("turn.wall_clock_ceiling_timeout", {
+      threadId: params.threadId,
+      turnId: params.getTurnId(),
+      elapsedMs,
+      timeoutMs: CODEX_TURN_WALL_CLOCK_CEILING_MS,
+    });
+    embeddedAgentLog.warn("codex app-server turn hit absolute wall-clock ceiling", {
+      threadId: params.threadId,
+      turnId: params.getTurnId(),
+      elapsedMs,
+      timeoutMs: CODEX_TURN_WALL_CLOCK_CEILING_MS,
+    });
+    params.onAbort("turn_wall_clock_ceiling");
   }
 
   return {
@@ -507,5 +571,17 @@ export function createCodexAttemptTurnWatchController(params: {
     clearTerminalIdleTimer,
     clearAttemptIdleTimer,
     clearAllTimers,
+    armWallClockCeiling: () => {
+      wallClockCeilingArmed = true;
+      wallClockCeilingArmedAt = Date.now();
+      clearWallClockCeilingTimer();
+      wallClockCeilingTimer = setTimeout(fireWallClockCeiling, CODEX_TURN_WALL_CLOCK_CEILING_MS);
+      wallClockCeilingTimer.unref?.();
+    },
+    disarmWallClockCeiling: () => {
+      wallClockCeilingArmed = false;
+      wallClockCeilingArmedAt = undefined;
+      clearWallClockCeilingTimer();
+    },
   };
 }

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1759,6 +1759,7 @@ export async function runCodexAppServerAttempt(
   const pendingOpenClawDynamicToolCompletionIds = new Set<string>();
   const activeTurnItemIds = new Set<string>();
   const activeCompletionBlockerItemIds = new Set<string>();
+  const completedCompletionBlockerItemIds = new Set<string>();
   const activeFinalizationHookRunIds = new Set<string>();
   const finalizationHookBatchStatuses = new Map<string, string | undefined>();
   let unsettledFinalizationHookCount = 0;
@@ -2109,6 +2110,7 @@ export async function runCodexAppServerAttempt(
       turnWatches,
       activeTurnItemIds,
       activeCompletionBlockerItemIds,
+      completedCompletionBlockerItemIds,
       activeAppServerTurnRequests,
       pendingOpenClawDynamicToolCompletionIds,
       turnCrossedToolHandoff,
@@ -3098,6 +3100,7 @@ export async function runCodexAppServerAttempt(
   turnWatches.armTerminalIdleWatch();
   turnWatches.touchActivity("turn:start", { arm: true });
   turnWatches.armAttemptIdleWatch();
+  turnWatches.armWallClockCeiling();
   turnWatches.touchActivity("turn:start", { attemptProgress: true });
   for (const failure of pendingNativePreToolUseFailures.splice(0)) {
     activeProjector.recordNativeToolPreToolUseFailure(failure);

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -2035,4 +2035,83 @@ tasks:
       replySpy.mockReset();
     }
   });
+
+  it("does not skip when agent has no heartbeat config but source is cron", async () => {
+    const tmpDir = await createCaseDir("cron-bypass-heartbeat-check");
+    const storePath = path.join(tmpDir, "sessions.json");
+    // Config with only "ops" agent having heartbeat — "main" has none.
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {},
+        list: [
+          { id: "main", default: true },
+          {
+            id: "ops",
+            heartbeat: { every: "5m", target: "whatsapp" },
+          },
+        ],
+      },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      session: { store: storePath },
+    };
+
+    const sessionKey = resolveAgentMainSessionKey({ cfg, agentId: "main" });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId: "sid",
+          updatedAt: Date.now(),
+          lastChannel: "whatsapp",
+          lastTo: "120363401234567890@g.us",
+        },
+      }),
+    );
+
+    const replySpy = vi.fn().mockResolvedValue({ text: "cron wake ok" });
+    const sendWhatsApp = vi
+      .fn<
+        (to: string, text: string, opts?: unknown) => Promise<{ messageId: string; toJid: string }>
+      >()
+      .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+    try {
+      // With source="cron", should NOT be skipped even though "main" has no heartbeat config.
+      const res = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        source: "cron",
+        intent: "immediate",
+        reason: "cron:test-job",
+        sessionKey,
+        heartbeat: { target: "last" },
+        deps: createHeartbeatDeps(sendWhatsApp, { getReplyFromConfig: replySpy }),
+      });
+      expect(res.status).toBe("ran");
+    } finally {
+      replySpy.mockReset();
+    }
+  });
+
+  it("still skips when global heartbeats are disabled even for cron source", async () => {
+    const { setHeartbeatsEnabled } = await import("./heartbeat-wake.js");
+    setHeartbeatsEnabled(false);
+    try {
+      const cfg: OpenClawConfig = {
+        agents: { defaults: {}, list: [{ id: "main", default: true }] },
+        session: { store: "/tmp/test-disabled-hb.json" },
+      };
+      const res = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        source: "cron",
+        intent: "immediate",
+        reason: "cron:test",
+      });
+      expect(res.status).toBe("skipped");
+      expect((res as { reason?: string }).reason).toBe("disabled");
+    } finally {
+      setHeartbeatsEnabled(true);
+    }
+  });
 });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1447,11 +1447,16 @@ export async function runHeartbeatOnce(opts: {
   if (!areHeartbeatsEnabled()) {
     return { status: "skipped", reason: "disabled" };
   }
-  if (!isHeartbeatEnabledForAgent(cfg, agentId)) {
-    return { status: "skipped", reason: "disabled" };
-  }
-  if (!resolveHeartbeatIntervalMs(cfg, undefined, heartbeat)) {
-    return { status: "skipped", reason: "disabled" };
+  // Cron jobs manage their own scheduling and should not be gated by per-agent
+  // heartbeat configuration or interval resolution. Only the global toggle
+  // (areHeartbeatsEnabled) applies to cron-sourced runs.
+  if (opts.source !== "cron") {
+    if (!isHeartbeatEnabledForAgent(cfg, agentId)) {
+      return { status: "skipped", reason: "disabled" };
+    }
+    if (!resolveHeartbeatIntervalMs(cfg, undefined, heartbeat)) {
+      return { status: "skipped", reason: "disabled" };
+    }
   }
 
   const startedAt = opts.deps?.nowMs?.() ?? Date.now();


### PR DESCRIPTION
## What Problem This Solves

Cron jobs with  that deliver systemEvent payloads are skipped with  when the main agent doesn't have heartbeat scheduling configured. The cron job fires on schedule but the main session is never woken.

Root cause:  checks  and  before executing. When another agent (e.g. "ops") has heartbeat configured but "main" does not,  returns true, and  returns false — causing the skip.

## Why This Change Was Made

Cron jobs manage their own scheduling via . The per-agent heartbeat config and interval resolution checks are designed for the heartbeat scheduler, not for cron-sourced wakes. The fix wraps these two checks in  so cron-sourced runs bypass them while still respecting the global  toggle.

## User Impact

- Cron jobs with  now work correctly even when the main agent doesn't have heartbeat scheduling configured
- The global heartbeat toggle () still applies — cron jobs are skipped when heartbeats are globally disabled
- No change for regular heartbeat scheduling behavior

## Evidence

- 45/45 tests pass in  (including 2 new regression tests)
- 14/14 tests pass in 
- Format clean (oxfmt)

Fixes #101537