### PR TITLE
refactor(policy): localize internal declarations

### DIFF
--- a/extensions/policy/src/cli.ts
+++ b/extensions/policy/src/cli.ts
@@ -20,24 +20,24 @@ import {
 } from "./policy-conformance.js";
 import { createPolicyAttestation } from "./policy-state.js";
 
-export type PolicyCommandRuntime = {
+type PolicyCommandRuntime = {
   writeStdout(value: string): void;
   error(value: string): void;
   sleep?(ms: number): Promise<void>;
 };
 
-export interface PolicyCheckOptions {
+interface PolicyCheckOptions {
   readonly json?: boolean;
   readonly severityMin?: string;
   readonly cwd?: string;
 }
 
-export interface PolicyWatchOptions extends PolicyCheckOptions {
+interface PolicyWatchOptions extends PolicyCheckOptions {
   readonly intervalMs?: string | number;
   readonly once?: boolean;
 }
 
-export interface PolicyCompareOptions {
+interface PolicyCompareOptions {
   readonly baseline?: string;
   readonly policy?: string;
   readonly json?: boolean;

--- a/extensions/policy/src/doctor/fix-metadata.ts
+++ b/extensions/policy/src/doctor/fix-metadata.ts
@@ -1,12 +1,7 @@
 // Policy doctor fix metadata classifies findings before patch builders exist.
 import { CHECK_IDS, POLICY_CHECK_IDS } from "./metadata.js";
 
-export type PolicyFixClass =
-  | "automatic"
-  | "reviewRequired"
-  | "manual"
-  | "validateOnly"
-  | "unsupported";
+type PolicyFixClass = "automatic" | "reviewRequired" | "manual" | "validateOnly" | "unsupported";
 
 export type PolicyFixMetadata = {
   readonly checkId: (typeof POLICY_CHECK_IDS)[number];

--- a/extensions/policy/src/doctor/register.ts
+++ b/extensions/policy/src/doctor/register.ts
@@ -119,7 +119,7 @@ const SUPPORTED_SANDBOX_MODES = ["off", "non-main", "all"] as const;
 let registered = false;
 const policyEvaluationCache = new WeakMap<HealthCheckContext, Promise<PolicyEvaluation>>();
 
-export type PolicyDoctorRegistrationHost = {
+type PolicyDoctorRegistrationHost = {
   readonly registerHealthCheck: (check: HealthCheck) => void;
 };
 

--- a/extensions/policy/src/policy-conformance.ts
+++ b/extensions/policy/src/policy-conformance.ts
@@ -13,13 +13,13 @@ import {
   type PolicyScopeSelectorKind,
 } from "./doctor/register.js";
 
-export const POLICY_CONFORMANCE_CHECK_IDS = {
+const POLICY_CONFORMANCE_CHECK_IDS = {
   missing: "policy/policy-conformance-missing",
   weaker: "policy/policy-conformance-weaker",
   invalid: "policy/policy-conformance-invalid",
 } as const;
 
-export type PolicyConformanceFinding = {
+type PolicyConformanceFinding = {
   readonly checkId: (typeof POLICY_CONFORMANCE_CHECK_IDS)[keyof typeof POLICY_CONFORMANCE_CHECK_IDS];
   readonly severity: "error";
   readonly message: string;

--- a/extensions/policy/src/policy-state.ts
+++ b/extensions/policy/src/policy-state.ts
@@ -25,7 +25,7 @@ const ALLOWLIST_DEFAULT_INGRESS_GROUP_POLICY_CHANNELS = new Set([
 ]);
 const OPEN_GROUPS_DEFAULT_TO_NO_MENTION_CHANNELS = new Set(["feishu", "qa-channel"]);
 
-export type PolicyAttestation = {
+type PolicyAttestation = {
   readonly checkedAt: string;
   readonly policy?: {
     readonly path: string;
@@ -57,14 +57,14 @@ export type PolicyEvidence = {
   readonly execApprovals?: readonly PolicyExecApprovalEvidence[];
 };
 
-export type PolicyChannelEvidence = {
+type PolicyChannelEvidence = {
   readonly id: string;
   readonly provider: string;
   readonly source: string;
   readonly enabled?: boolean;
 };
 
-export type PolicyMcpServerEvidence = {
+type PolicyMcpServerEvidence = {
   readonly id: string;
   readonly transport: "stdio" | "sse" | "streamable-http" | "unknown";
   readonly source: string;
@@ -72,7 +72,7 @@ export type PolicyMcpServerEvidence = {
   readonly url?: string;
 };
 
-export type PolicyToolEvidence = {
+type PolicyToolEvidence = {
   readonly id: string;
   readonly source: string;
   readonly line: number;
@@ -125,19 +125,19 @@ export type PolicySandboxPostureEvidence = {
   readonly explicit?: boolean;
 };
 
-export type PolicyModelProviderEvidence = {
+type PolicyModelProviderEvidence = {
   readonly id: string;
   readonly source: string;
 };
 
-export type PolicyModelRefEvidence = {
+type PolicyModelRefEvidence = {
   readonly ref: string;
   readonly provider: string;
   readonly model: string;
   readonly source: string;
 };
 
-export type PolicyNetworkEvidence = {
+type PolicyNetworkEvidence = {
   readonly id: string;
   readonly source: string;
   readonly value: boolean;
@@ -158,7 +158,7 @@ export type PolicyIngressEvidence = {
   readonly explicit?: boolean;
 };
 
-export type PolicyGatewayExposureEvidence = {
+type PolicyGatewayExposureEvidence = {
   readonly id: string;
   readonly kind:
     | "auth"
@@ -195,7 +195,7 @@ export type PolicyAgentWorkspaceEvidence = {
   readonly explicit?: boolean;
 };
 
-export type PolicySecretEvidence = {
+type PolicySecretEvidence = {
   readonly id: string;
   readonly kind: "input" | "provider";
   readonly source: string;


### PR DESCRIPTION
## What Problem This Solves

The private Policy plugin exported 17 declarations that have no consumers outside their defining files. Its public API exposes only `registerPolicyDoctorChecks`.

## Why This Change Was Made

Internal CLI, doctor, conformance, and attestation declarations should not expand the module surface. Localizing them improves dead-code and API analysis without changing runtime behavior or the plugin entry contract.

## User Impact

No behavior change. Policy CLI output, doctor registration, conformance reports, and attestations remain unchanged.

## Evidence

- Fresh full codebase-memory MCP graph: 281,352 nodes and 1,135,029 edges.
- MCP `search_graph` and repository-wide scans found each localized declaration confined to one file.
- `extensions/policy/api.ts` still exposes its sole public contract, `registerPolicyDoctorChecks`.
- Testbox `tbx_01kwzqnryqgv100cqcgg1zct1e`: `pnpm check:changed` passed.
- `pnpm test:serial extensions/policy` passed: five files, 340 tests.
- `pnpm build` passed, including plugin SDK export guards and the Control UI build.
- Local autoreview: clean, confidence 0.87.
- Branch autoreview: clean at 0.86, then clean at 0.87 after rebasing onto current `origin/main`.
- Diff: five files, 17 localized declarations, net five production lines removed.
