### PR TITLE
fix(agents): preserve tool-result text blocks during images-only sanitization

### DIFF
--- a/src/agents/embedded-agent-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
+++ b/src/agents/embedded-agent-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
@@ -346,6 +346,43 @@ describe("sanitizeSessionMessagesImages", () => {
     expect(out[1]?.role).toBe("toolResult");
   });
 
+  it("preserves tool-result text blocks through images-only sanitization", async () => {
+    // Regression for #98680: mixed text+image tool results must keep their text
+    // so providers can extract it instead of falling back to media placeholders.
+    const input = [
+      {
+        role: "toolResult",
+        toolCallId: "tool-1",
+        toolName: "read",
+        isError: false,
+        content: [
+          { type: "text", text: "file contents" },
+          { type: "image", data: "", mimeType: "image/png" },
+        ],
+        timestamp: nextTimestamp(),
+      } satisfies ToolResultMessage,
+    ];
+
+    const out = await sanitizeSessionMessagesImages(input, "test", {
+      sanitizeMode: "images-only",
+    });
+
+    expect(out).toHaveLength(1);
+    const toolResult = out[0];
+    expect(toolResult?.role).toBe("toolResult");
+    if (toolResult?.role !== "toolResult") {
+      throw new Error("expected toolResult");
+    }
+    const textBlocks = toolResult.content.filter(
+      (block): block is { type: "text"; text: string } =>
+        block != null &&
+        typeof block === "object" &&
+        (block as { type?: unknown }).type === "text" &&
+        typeof (block as { text?: unknown }).text === "string",
+    );
+    expect(textBlocks.some((block) => block.text === "file contents")).toBe(true);
+  });
+
   describe("thought_signature stripping", () => {
     it("strips msg_-prefixed thought_signature from assistant message content blocks", async () => {
       // msg_ values are OpenClaw message ids, not provider signatures.

--- a/src/agents/embedded-agent-helpers/images.ts
+++ b/src/agents/embedded-agent-helpers/images.ts
@@ -11,16 +11,20 @@ import { stripThoughtSignatures } from "./bootstrap.js";
 type ContentBlock = AgentToolResult<unknown>["content"][number];
 const EMPTY_CONTENT_PLACEHOLDER = "[empty content omitted]";
 
+function isTextBlock(block: unknown): block is { type: "text"; text: string } {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  const rec = block as { type?: unknown; text?: unknown };
+  return rec.type === "text" && typeof rec.text === "string";
+}
+
 function dropEmptyTextBlocks<T>(content: T[]): T[] {
   return content.filter((block) => {
-    if (!block || typeof block !== "object") {
+    if (!isTextBlock(block)) {
       return true;
     }
-    const rec = block as { type?: unknown; text?: unknown };
-    if (rec.type !== "text" || typeof rec.text !== "string") {
-      return true;
-    }
-    return rec.text.trim().length > 0;
+    return block.text.trim().length > 0;
   });
 }
 
@@ -79,11 +83,34 @@ export async function sanitizeSessionMessagesImages(
     if (role === "toolResult") {
       const toolMsg = msg as Extract<AgentMessage, { role: "toolResult" }>;
       const content = Array.isArray(toolMsg.content) ? toolMsg.content : [];
-      const nextContent = (await sanitizeContentBlocksImages(
-        content,
-        label,
-        imageSanitization,
-      )) as unknown as typeof toolMsg.content;
+      // Keep text blocks untouched by image sanitization so mixed text+image
+      // tool results cannot lose their text during "images-only" replay.
+      // Providers extract explicit text blocks to avoid media placeholders
+      // like "(see attached image)" (see #98680).
+      const nonTextBlocks = content.filter((block) => !isTextBlock(block)) as ContentBlock[];
+      const sanitizedNonText = nonTextBlocks.length
+        ? ((await sanitizeContentBlocksImages(
+            nonTextBlocks,
+            label,
+            imageSanitization,
+          )) as ContentBlock[])
+        : [];
+      const nonTextByIndex = new Map<number, ContentBlock>();
+      let nonTextIndex = 0;
+      for (const [index, block] of content.entries()) {
+        if (!isTextBlock(block)) {
+          const sanitized = sanitizedNonText[nonTextIndex++];
+          if (sanitized !== undefined) {
+            nonTextByIndex.set(index, sanitized);
+          }
+        }
+      }
+      const nextContent = content.map((block, index) => {
+        if (isTextBlock(block)) {
+          return block;
+        }
+        return (nonTextByIndex.get(index) ?? block) as ContentBlock;
+      }) as unknown as typeof toolMsg.content;
       out.push({ ...toolMsg, content: ensureNonEmptyContent(dropEmptyTextBlocks(nextContent)) });
       continue;
     }


### PR DESCRIPTION
### What Problem This Solves

Issue #98680 reports that `sanitizeMode: "images-only"` can strip text content from tool results, causing providers to fall back to placeholders like `(see attached image)` instead of the actual tool output.

### Why This Change Was Made

In `sanitizeSessionMessagesImages`, tool-result content was passed wholesale to `sanitizeContentBlocksImages`. While that function normally preserves text blocks, mixing text and image blocks in a single sanitization pass made it possible for text to be dropped or reordered as a side effect of image handling on certain provider replay paths.

This change explicitly separates text blocks from non-text blocks for `toolResult` messages, sanitizes only the non-text blocks, and merges them back in their original order. Text blocks are never touched by image sanitization, so provider text extraction continues to work for mixed text+image tool results.

### User Impact

- Tool results that contain both text and images now reliably preserve their text when replayed with `images-only` sanitization.
- Models see the actual tool output text instead of only `(see attached image)`.

### Evidence

- Added a regression test in `src/agents/embedded-agent-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts` that verifies a mixed text+image `toolResult` keeps its text block through `images-only` sanitization.
- Existing tests still pass:
  - `src/agents/embedded-agent-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts` (19 tests)
  - `src/agents/tool-images.test.ts` (11 tests)
- Formatted with `oxfmt`.

Fixes #98680.