### PR TITLE
fix(acp): keep background-task summaries UTF-16 safe at truncation boundaries

### DIFF
--- a/src/acp/control-plane/manager.background-task.test.ts
+++ b/src/acp/control-plane/manager.background-task.test.ts
@@ -1,0 +1,67 @@
+/** Regression coverage for ACP background-task summary truncation boundaries. */
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  appendBackgroundTaskProgressSummary,
+  resolveBackgroundTaskContext,
+} from "./manager.background-task.js";
+import type { AcpSessionManagerDeps } from "./manager.types.js";
+
+// U+1F99E (🦞) is a surrogate pair in UTF-16; a raw .slice() boundary can split it.
+const LOBSTER = "🦞";
+
+const HIGH_SURROGATE_WITHOUT_LOW = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
+
+function fakeDeps(): AcpSessionManagerDeps {
+  const readSessionEntry = (params: { sessionKey: string }) =>
+    params.sessionKey === "child-session"
+      ? { entry: { spawnedBy: "requester-session" } }
+      : { entry: {} };
+  return { readSessionEntry } as unknown as AcpSessionManagerDeps;
+}
+
+describe("appendBackgroundTaskProgressSummary", () => {
+  it("keeps surrogate pairs intact at the progress truncation boundary", () => {
+    // combined length 244 puts the pair astride the 239-char cut point.
+    const result = appendBackgroundTaskProgressSummary("x".repeat(238), `${LOBSTER}tail`);
+    expect(result).toBe(`${"x".repeat(238)}…`);
+    expect(HIGH_SURROGATE_WITHOUT_LOW.test(result)).toBe(false);
+    expect(result.length).toBeLessThanOrEqual(240);
+  });
+
+  it("still truncates plain ASCII exactly at the boundary", () => {
+    const result = appendBackgroundTaskProgressSummary("a".repeat(240), "b");
+    expect(result).toBe(`${"a".repeat(239)}…`);
+  });
+
+  it("returns short combined summaries unchanged", () => {
+    expect(appendBackgroundTaskProgressSummary("done: ", "ok")).toBe("done: ok");
+    expect(appendBackgroundTaskProgressSummary("", `  step ${LOBSTER}`)).toBe(`step ${LOBSTER}`);
+  });
+});
+
+describe("resolveBackgroundTaskContext", () => {
+  it("keeps surrogate pairs intact in the bounded task label", () => {
+    // normalized length 164 puts the pair astride the 159-char cut point.
+    const context = resolveBackgroundTaskContext({
+      deps: fakeDeps(),
+      cfg: {} as unknown as OpenClawConfig,
+      sessionKey: "child-session",
+      requestId: "run-1",
+      text: `${"y".repeat(158)}${LOBSTER}tail`,
+    });
+    expect(context?.task).toBe(`${"y".repeat(158)}…`);
+    expect(HIGH_SURROGATE_WITHOUT_LOW.test(context?.task ?? "")).toBe(false);
+  });
+
+  it("passes short task text through unchanged", () => {
+    const context = resolveBackgroundTaskContext({
+      deps: fakeDeps(),
+      cfg: {} as unknown as OpenClawConfig,
+      sessionKey: "child-session",
+      requestId: "run-2",
+      text: `summarize ${LOBSTER} feedback`,
+    });
+    expect(context?.task).toBe(`summarize ${LOBSTER} feedback`);
+  });
+});

--- a/src/acp/control-plane/manager.background-task.ts
+++ b/src/acp/control-plane/manager.background-task.ts
@@ -1,4 +1,5 @@
 /** Mirrors child ACP turns into detached-task status for requester-facing progress. */
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import {
@@ -32,7 +33,7 @@ function summarizeBackgroundTaskText(text: string): string {
   if (normalized.length <= ACP_BACKGROUND_TASK_TEXT_MAX_LENGTH) {
     return normalized;
   }
-  return `${normalized.slice(0, ACP_BACKGROUND_TASK_TEXT_MAX_LENGTH - 1)}…`;
+  return `${truncateUtf16Safe(normalized, ACP_BACKGROUND_TASK_TEXT_MAX_LENGTH - 1)}…`;
 }
 
 /** Appends bounded progress text while preserving a single-line task summary. */
@@ -49,7 +50,7 @@ export function appendBackgroundTaskProgressSummary(current: string, chunk: stri
   if (combined.length <= ACP_BACKGROUND_TASK_PROGRESS_MAX_LENGTH) {
     return combined;
   }
-  return `${combined.slice(0, ACP_BACKGROUND_TASK_PROGRESS_MAX_LENGTH - 1)}…`;
+  return `${truncateUtf16Safe(combined, ACP_BACKGROUND_TASK_PROGRESS_MAX_LENGTH - 1)}…`;
 }
 
 /** Maps ACP runtime failures to detached-task terminal states. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators watching a child ACP background run would see a corrupted replacement character (U+FFFD) at the end of the task label or progress summary when the truncation boundary landed in the middle of an emoji or other astral character. Both requester-facing strings for detached ACP tasks were affected.

Part of the UTF-16 safety sweep (same defect class as the landed `acp/event-mapper`, `http-error-body`, `tasks`, and `control-ui-assets` fixes).

## Why This Change Was Made

`src/acp/control-plane/manager.background-task.ts` bounded both summaries with raw `String.slice`: `summarizeBackgroundTaskText()` cut at `ACP_BACKGROUND_TASK_TEXT_MAX_LENGTH - 1` (159) and `appendBackgroundTaskProgressSummary()` at `ACP_BACKGROUND_TASK_PROGRESS_MAX_LENGTH - 1` (239). A surrogate pair astride either index leaves a lone high surrogate before the `…` marker. Both sites now use `truncateUtf16Safe()` from `@openclaw/normalization-core/utf16-slice`, the same helper the sibling ACP `event-mapper.ts` already uses for its argument previews.

This module owns the bounded requester-facing task strings; the PR changes only these two truncation expressions and leaves chunk normalization, terminal-result inference, and the task-registry calls intact.

Non-goals: no change to the length limits themselves, to whitespace normalization, or to any other truncation site in the codebase.

## User Impact

ACP background-task labels and progress lines now always end with well-formed text before the ellipsis — no more `�` in task status when the summary happens to cut through an emoji. Plain-ASCII truncation output is byte-for-byte unchanged (covered by regression).

## Evidence

All proof from current head `8c96243892` (branched from `upstream/main` `6765eb0166`), Node v24.4.0.

Real module behavior — the exported `appendBackgroundTaskProgressSummary()` invoked via `tsx`, before/after:

```text
--- unpatched main ---
tail of progress summary: "xx\ud83e…"     ← lone high surrogate (renders as U+FFFD)
well-formed UTF-16: false
--- with this fix ---
tail of progress summary: "xxx…"
well-formed UTF-16: true
length: 239 (max 240)
```

Negative control — with the new regression tests present but the source fix reverted, exactly the two surrogate-boundary tests fail and the plain-ASCII behavior tests still pass (confirming no behavior change outside the boundary):

```text
× keeps surrogate pairs intact at the progress truncation boundary
× keeps surrogate pairs intact in the bounded task label
Tests  2 failed | 3 passed (5)
```

After fix:

```text
Test Files  1 passed (1)
Tests       5 passed (5)
```

- `node scripts/run-vitest.mjs src/acp/control-plane/manager.background-task.test.ts` — 5 passed
- `pnpm exec oxlint <changed files>` — clean
- `pnpm exec oxfmt --check --threads=1 <changed files>` — "All matched files use the correct format"
- `pnpm tsgo` — passed
- Not run: `pnpm check:changed` delegates to the Blacksmith Testbox remote sandbox, which contributor machines cannot dispatch; the local lanes above cover lint, format, types, and the changed test file.

AI-assisted (Claude Code); I have reviewed and understand every line.
