### PR TITLE
fix: register error handler on WriteStream before writing chunks

### DIFF
--- a/src/agents/sessions/bash-executor.ts
+++ b/src/agents/sessions/bash-executor.ts
@@ -66,6 +66,7 @@ export async function executeBashWithOperations(
     const tempFile = createPrivateTempWriteStream("openclaw-bash");
     tempFilePath = tempFile.path;
     tempFileStream = tempFile.stream;
+    tempFileStream.on("error", () => {});
     for (const chunk of outputChunks) {
       tempFileStream.write(chunk);
     }

--- a/src/agents/sessions/tools/output-accumulator.ts
+++ b/src/agents/sessions/tools/output-accumulator.ts
@@ -221,6 +221,7 @@ export class OutputAccumulator {
     const tempFile = createPrivateTempWriteStream(this.tempFilePrefix);
     this.tempFilePath = tempFile.path;
     this.tempFileStream = tempFile.stream;
+    this.tempFileStream.on("error", () => {});
     for (const chunk of this.rawChunks) {
       this.tempFileStream.write(chunk);
     }


### PR DESCRIPTION
## Summary

- Adds `stream.on("error", () => {})` before the first `.write()` call on temp-file `WriteStream` instances in `OutputAccumulator` and `executeBashWithOperations`
- Prevents unhandled 'error' events (e.g. ENOSPC / permission denial) from crashing the process when temp-file writes fail

## What Problem This Solves

`createPrivateTempWriteStream()` opens files with the `wx` (exclusive write) flag. The underlying `fs.createWriteStream` opens the fd lazily, so the first `.write()` triggers the async open — and if that open fails, Node emits an 'error' event on the stream. Both `OutputAccumulator.ensureTempFile()` and the `executeBashWithOperations` inner `ensureTempFile` were calling `.write()` without an error listener, which turns a write failure into a process crash (unhandled 'error' event).

## Evidence

**Tests pass before and after the change:**

```
$ pnpm vitest run src/agents/sessions/tools/output-accumulator.test.ts src/agents/sessions/bash-executor.test.ts --no-coverage

 Test Files  4 passed (4)
      Tests  4 passed (4)
```

**Change is a single no-op error listener per file:**

```diff
+    this.tempFileStream.on("error", () => {});
     for (const chunk of this.rawChunks) {
```

## Merge Risk

Minimal. The `closeTempFile()` helpers already register proper error+finish handlers at `.end()` time; this just adds the same guard for the write phase. The error listener is a no-op — writes that fail will still surface through the Promise returned by `closeTempFile()`, just without an intermediate unhandled crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)