### PR TITLE
feat: bind signed ClawHub default feed trust

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -561,6 +561,38 @@ hosted snapshot or bundled fallback result without failing the command. Pinned
 refreshes fail unless they accept a fresh hosted payload, and successful hosted
 refreshes fail if OpenClaw cannot persist the validated snapshot.
 
+The built-in `clawhub-public` profile expects payload identity
+`clawhub-official`. OpenClaw will bundle ClawHub's production public key after
+ClawHub generates and hands off that key. Until then, staging and private
+deployments can inject both `OPENCLAW_CLAWHUB_FEED_TRUSTED_KEY_ID` and
+`OPENCLAW_CLAWHUB_FEED_TRUSTED_PUBLIC_KEY`; setting only one fails closed before
+fetch. Public keys must come from a trusted release or operator channel, not
+from a key endpoint on the feed host.
+
+Custom signed profiles require an expected `feedId` as well as local trust
+anchors:
+
+```json5
+{
+  marketplaces: {
+    feeds: {
+      acme: {
+        url: "https://packages.acme.example/openclaw/feed",
+        feedId: "acme-plugins",
+        verification: {
+          mode: "signed",
+          keys: [{ keyId: "acme-2026", publicKey: "<Ed25519 public key>" }],
+        },
+      },
+    },
+  },
+}
+```
+
+OpenClaw verifies the DSSE envelope and then requires the decoded payload ID to
+match `feedId`, preventing a valid document for one feed from being replayed
+through another profile.
+
 ## Related
 
 - [Building plugins](/plugins/building-plugins)

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -569,11 +569,18 @@ deployments can inject both `OPENCLAW_CLAWHUB_FEED_TRUSTED_KEY_ID` and
 fetch. Public keys must come from a trusted release or operator channel, not
 from a key endpoint on the feed host.
 
-OpenClaw verifies the DSSE envelope and then requires its decoded payload ID to
-match the selected profile's `feedId`, preventing a valid document for one feed
-from being replayed through another profile. The feed-profile configuration
-surface is landing separately with the presentation metadata needed by Control
-UI; this trust binding does not restore the retired root `marketplaces` key.
+OpenClaw verifies the DSSE envelope and, when a profile declares `feedId`,
+requires the decoded payload ID to match it. The built-in `clawhub-public`
+profile always declares its identity, preventing a valid document for another
+feed from being replayed through that profile.
+
+During the staged rollout, existing custom signed profiles that omit `feedId`
+retain signature verification without payload-identity binding. New custom
+profiles should declare `feedId`. The feed-profile configuration surface is
+landing separately with the presentation metadata needed by Control UI; its
+Doctor diagnostic must ask the operator to supply a missing identity and must
+not infer one from the feed URL. This trust binding does not restore the retired
+root `marketplaces` key.
 
 ## Related
 

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -569,29 +569,11 @@ deployments can inject both `OPENCLAW_CLAWHUB_FEED_TRUSTED_KEY_ID` and
 fetch. Public keys must come from a trusted release or operator channel, not
 from a key endpoint on the feed host.
 
-Custom signed profiles require an expected `feedId` as well as local trust
-anchors:
-
-```json5
-{
-  marketplaces: {
-    feeds: {
-      acme: {
-        url: "https://packages.acme.example/openclaw/feed",
-        feedId: "acme-plugins",
-        verification: {
-          mode: "signed",
-          keys: [{ keyId: "acme-2026", publicKey: "<Ed25519 public key>" }],
-        },
-      },
-    },
-  },
-}
-```
-
-OpenClaw verifies the DSSE envelope and then requires the decoded payload ID to
-match `feedId`, preventing a valid document for one feed from being replayed
-through another profile.
+OpenClaw verifies the DSSE envelope and then requires its decoded payload ID to
+match the selected profile's `feedId`, preventing a valid document for one feed
+from being replayed through another profile. The feed-profile configuration
+surface is landing separately with the presentation metadata needed by Control
+UI; this trust binding does not restore the retired root `marketplaces` key.
 
 ## Related
 

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -11,6 +11,8 @@ import {
   type HostedOfficialExternalPluginCatalogSnapshotStore,
   type OfficialExternalPluginCatalogEntry,
   type OfficialExternalPluginCatalogFeed,
+  DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEY_ID_ENV,
+  DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_PUBLIC_KEY_ENV,
   getOfficialExternalPluginCatalogEntry,
   getOfficialExternalPluginCatalogManifest,
   isOfficialExternalPluginCatalogFeed,
@@ -160,6 +162,7 @@ function signedCatalogConfig(publicKeyPem: string, keyId = "acme-root"): HostedC
     feeds: {
       acme: {
         url: "https://packages.acme.example/openclaw/feed",
+        feedId: "openclaw-official-external-plugins",
         verification: {
           mode: "signed",
           keys: [{ keyId, publicKey: publicKeyPem }],
@@ -343,6 +346,68 @@ describe("official external plugin catalog", () => {
         entries: [],
       }),
     ).toBe(true);
+  });
+
+  it("verifies the default ClawHub profile with injected trust anchors", async () => {
+    const feed = {
+      ...hostedCatalogFeed({ sequence: 12, pluginName: "@openclaw/default-signed" }),
+      id: "clawhub-official",
+    };
+    const signed = signedHostedCatalogFeed({ feed });
+    const fetchImpl = vi.fn(async () => new Response(signed.body, { status: 200 }));
+
+    const result = await loadHostedCatalog({
+      env: {
+        [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEY_ID_ENV]: "acme-root",
+        [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_PUBLIC_KEY_ENV]:
+          signed.publicKeyPem,
+      },
+      fetchImpl,
+      snapshotStore: null,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(result.source).toBe("hosted");
+    expect(result.feed?.id).toBe("clawhub-official");
+    expect(result.trust).toMatchObject({ mode: "signed", signedBy: "acme-root" });
+  });
+
+  it("rejects a valid default-profile envelope for a different feed identity", async () => {
+    const signed = signedHostedCatalogFeed({
+      feed: hostedCatalogFeed({ sequence: 12, pluginName: "@openclaw/replayed" }),
+    });
+
+    const result = await loadHostedCatalog({
+      env: {
+        [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEY_ID_ENV]: "acme-root",
+        [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_PUBLIC_KEY_ENV]:
+          signed.publicKeyPem,
+      },
+      fetchImpl: vi.fn(async () => new Response(signed.body, { status: 200 })),
+      snapshotStore: null,
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    expect(result.entries).toEqual([]);
+    expect(result.error).toContain(
+      'feed id "openclaw-official-external-plugins" did not match expected "clawhub-official"',
+    );
+  });
+
+  it("fails closed before fetch when default ClawHub trust env is incomplete", async () => {
+    const fetchImpl = vi.fn(async () => new Response("{}", { status: 200 }));
+    const result = await loadHostedCatalog({
+      env: {
+        [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEY_ID_ENV]: "acme-root",
+      },
+      fetchImpl,
+      snapshotStore: null,
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(result.source).toBe("bundled-fallback");
+    expect(result.entries).toEqual([]);
+    expect(result.error).toContain("requires both key id and public key env vars");
   });
 
   it("loads schema-v2 marketplace entries and gates installs by state and trust", async () => {
@@ -1194,7 +1259,7 @@ describe("official external plugin catalog", () => {
   it("enforces hosted checksum and response-size limits", async () => {
     const validBody = JSON.stringify({
       schemaVersion: 1,
-      id: "openclaw-official-external-plugins",
+      id: "clawhub-official",
       generatedAt: "2026-06-22T00:00:01.000Z",
       sequence: 1,
       entries: [],
@@ -1245,7 +1310,7 @@ describe("official external plugin catalog", () => {
     const snapshotStore = createInMemoryHostedCatalogSnapshotStore();
     const body = JSON.stringify({
       schemaVersion: 1,
-      id: "openclaw-official-external-plugins",
+      id: "clawhub-official",
       generatedAt: "2026-06-22T00:00:01.000Z",
       sequence: 1,
       entries: [],

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -74,12 +74,14 @@ function createInMemoryHostedCatalogSnapshotStore(
 function hostedCatalogFeed(params: {
   sequence: number;
   pluginName: string;
+  expiresAt?: string;
 }): OfficialExternalPluginCatalogFeed {
   const pluginId = params.pluginName.replace(/^@[^/]+\//u, "");
   return {
     schemaVersion: 1,
     id: "openclaw-official-external-plugins",
     generatedAt: `2026-06-22T00:00:${String(params.sequence).padStart(2, "0")}.000Z`,
+    expiresAt: params.expiresAt ?? "2099-01-01T00:00:00.000Z",
     sequence: params.sequence,
     entries: [
       {
@@ -370,6 +372,60 @@ describe("official external plugin catalog", () => {
     expect(result.source).toBe("hosted");
     expect(result.feed?.id).toBe("clawhub-official");
     expect(result.trust).toMatchObject({ mode: "signed", signedBy: "acme-root" });
+  });
+
+  it("preserves default ClawHub trust when the built-in profile is customized", async () => {
+    const feed = {
+      ...hostedCatalogFeed({ sequence: 12, pluginName: "@openclaw/default-configured" }),
+      id: "clawhub-official",
+    };
+    const signed = signedHostedCatalogFeed({ feed });
+    const result = await loadHostedCatalog({
+      catalogConfig: {
+        feeds: {
+          "clawhub-public": {
+            url: "https://clawhub.ai/v1/feeds/plugins",
+            feedId: "clawhub-official",
+          },
+        },
+      },
+      env: {
+        [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEY_ID_ENV]: "acme-root",
+        [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_PUBLIC_KEY_ENV]:
+          signed.publicKeyPem,
+      },
+      fetchImpl: vi.fn(async () => new Response(signed.body, { status: 200 })),
+      snapshotStore: null,
+    });
+
+    expect(result.source).toBe("hosted");
+    expect(result.trust).toMatchObject({ mode: "signed", signedBy: "acme-root" });
+  });
+
+  it("allows an explicit unsigned downgrade of the default ClawHub profile", async () => {
+    const body = JSON.stringify({
+      ...hostedCatalogFeed({ sequence: 12, pluginName: "@openclaw/default-unsigned" }),
+      id: "clawhub-official",
+    });
+    const result = await loadHostedCatalog({
+      catalogConfig: {
+        feeds: {
+          "clawhub-public": {
+            url: "https://clawhub.ai/v1/feeds/plugins",
+            feedId: "clawhub-official",
+            verification: { mode: "unsigned" },
+          },
+        },
+      },
+      env: {
+        [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEY_ID_ENV]: "incomplete",
+      },
+      fetchImpl: vi.fn(async () => new Response(body, { status: 200 })),
+      snapshotStore: null,
+    });
+
+    expect(result.source).toBe("hosted");
+    expect(result.trust).toBeUndefined();
   });
 
   it("rejects a valid default-profile envelope for a different feed identity", async () => {
@@ -1160,6 +1216,174 @@ describe("official external plugin catalog", () => {
 
     expect(offline.source).toBe("hosted-snapshot");
     expect(offline.entries.map((entry) => entry.name)).toEqual(["@openclaw/legacy-snapshot"]);
+  });
+
+  it("rejects expired signed feeds and keeps expired snapshots visible but not installable", async () => {
+    const feed = {
+      ...hostedCatalogFeed({
+        sequence: 8,
+        pluginName: "@openclaw/expiring",
+        expiresAt: "2026-06-22T00:01:00.000Z",
+      }),
+      entries: [
+        {
+          id: "@openclaw/expiring",
+          name: "@openclaw/expiring",
+          type: "plugin",
+          state: "available",
+          publisher: { id: "openclaw", trust: "official" },
+          install: {
+            candidates: [
+              { sourceRef: "acme-npm", package: "@openclaw/expiring", version: "1.0.0" },
+            ],
+          },
+        },
+      ],
+    } satisfies OfficialExternalPluginCatalogFeed;
+    const signed = signedHostedCatalogFeed({ feed });
+    const catalogConfig = signedCatalogConfig(signed.publicKeyPem);
+    const snapshotStore = createInMemoryHostedCatalogSnapshotStore();
+    const seeded = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig,
+      fetchImpl: vi.fn(
+        async () => new Response(signed.body, { status: 200, headers: { etag: '"expiring"' } }),
+      ),
+      now: () => new Date("2026-06-22T00:00:30.000Z"),
+      snapshotStore,
+    });
+    expect(seeded.source).toBe("hosted");
+    expect(
+      resolveOfficialExternalPluginInstall(seeded.entries[0]!, { catalogConfig }),
+    ).not.toBeNull();
+
+    const expiredFresh = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig,
+      fetchImpl: vi.fn(async () => new Response(signed.body, { status: 200 })),
+      now: () => new Date("2026-06-22T00:01:01.000Z"),
+      snapshotStore: null,
+    });
+    expect(expiredFresh.source).toBe("bundled-fallback");
+    expect(expiredFresh.entries).toEqual([]);
+    expect(expiredFresh.error).toContain("signed feed expired");
+
+    const expiredSnapshot = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig,
+      ifNoneMatch: '"expiring"',
+      fetchImpl: vi.fn(
+        async () => new Response(null, { status: 304, headers: { etag: '"expiring"' } }),
+      ),
+      now: () => new Date("2026-06-22T00:01:01.000Z"),
+      snapshotStore,
+    });
+    expect(expiredSnapshot.source).toBe("hosted-snapshot");
+    expect(expiredSnapshot.entries).toHaveLength(1);
+    expect(expiredSnapshot.entries[0]).toMatchObject({
+      id: "@openclaw/expiring",
+      state: "unavailable",
+    });
+    expect(expiredSnapshot.entries[0]?.install).toBeUndefined();
+    expect(expiredSnapshot.feed.entries[0]?.install).toBeUndefined();
+    expect(
+      resolveOfficialExternalPluginInstall(expiredSnapshot.entries[0]!, { catalogConfig }),
+    ).toBeNull();
+    expect(expiredSnapshot.error).toContain("signed feed expired");
+
+    const expiredOffline = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig,
+      offline: true,
+      now: () => new Date("2026-06-22T00:01:01.000Z"),
+      snapshotStore,
+    });
+    expect(expiredOffline.source).toBe("hosted-snapshot");
+    expect(expiredOffline.entries[0]).toMatchObject({ state: "unavailable" });
+    expect(expiredOffline.error).toContain("signed feed expired");
+
+    const expiredAfterError = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig,
+      fetchImpl: vi.fn(async () => new Response(null, { status: 503 })),
+      now: () => new Date("2026-06-22T00:01:01.000Z"),
+      snapshotStore,
+    });
+    expect(expiredAfterError.source).toBe("hosted-snapshot");
+    expect(expiredAfterError.entries[0]).toMatchObject({ state: "unavailable" });
+    expect(expiredAfterError.error).toContain("signed feed expired");
+  });
+
+  it("rejects signed feeds whose expiry does not follow generation", async () => {
+    const signed = signedHostedCatalogFeed({
+      feed: hostedCatalogFeed({
+        sequence: 8,
+        pluginName: "@openclaw/invalid-expiry",
+        expiresAt: "2026-06-21T23:59:59.000Z",
+      }),
+    });
+    const result = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(signed.publicKeyPem),
+      fetchImpl: vi.fn(async () => new Response(signed.body, { status: 200 })),
+      now: () => new Date("2026-06-22T00:00:30.000Z"),
+      snapshotStore: null,
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    expect(result.entries).toEqual([]);
+    expect(result.error).toContain("expiresAt must be later than generatedAt");
+  });
+
+  it("uses legacy signed snapshots for rollback state without preserving install authority", async () => {
+    const legacyFeed = hostedCatalogFeed({ sequence: 8, pluginName: "@openclaw/legacy" });
+    delete legacyFeed.expiresAt;
+    const legacy = signedHostedCatalogFeed({ feed: legacyFeed });
+    const newer = signedHostedCatalogFeed({
+      feed: hostedCatalogFeed({ sequence: 9, pluginName: "@openclaw/current" }),
+      privateKeyPem: legacy.privateKeyPem,
+    });
+    const url = "https://packages.acme.example/openclaw/feed";
+    const snapshotStore = createInMemoryHostedCatalogSnapshotStore([
+      {
+        body: legacy.body,
+        metadata: {
+          url,
+          status: 200,
+          checksum: `sha256:${crypto.createHash("sha256").update(legacy.body).digest("hex")}`,
+        },
+        savedAt: "2026-06-22T00:00:08.000Z",
+        trust: {
+          mode: "signed",
+          signedBy: "acme-root",
+          signatureCount: 1,
+          threshold: 1,
+          verifiedAt: "2026-06-22T00:00:08.000Z",
+        },
+      },
+    ]);
+    const catalogConfig = signedCatalogConfig(legacy.publicKeyPem);
+
+    const stale = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig,
+      offline: true,
+      snapshotStore,
+    });
+    expect(stale.source).toBe("hosted-snapshot");
+    expect(stale.entries[0]).toMatchObject({ name: "@openclaw/legacy", state: "unavailable" });
+    expect(resolveOfficialExternalPluginInstall(stale.entries[0]!, { catalogConfig })).toBeNull();
+    expect(stale.error).toContain("has no expiresAt");
+
+    const updated = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig,
+      fetchImpl: vi.fn(async () => new Response(newer.body, { status: 200 })),
+      now: () => new Date("2026-06-22T00:00:30.000Z"),
+      snapshotStore,
+    });
+    expect(updated.source).toBe("hosted");
+    expect(updated.entries.map((entry) => entry.name)).toEqual(["@openclaw/current"]);
   });
 
   it.each([

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -585,6 +585,27 @@ describe("official external plugin catalog", () => {
     expect(resolveOfficialExternalPluginInstall(community)).toBeNull();
   });
 
+  it("requires complete schema-v2 install authority when either trust field is present", () => {
+    const manifestInstall = { install: { npmSpec: "@acme/untrusted" } };
+
+    expect(
+      resolveOfficialExternalPluginInstall({
+        name: "@acme/missing-state",
+        kind: "plugin",
+        publisher: { id: "acme", trust: "community" },
+        openclaw: manifestInstall,
+      }),
+    ).toBeNull();
+    expect(
+      resolveOfficialExternalPluginInstall({
+        name: "@acme/missing-publisher",
+        kind: "plugin",
+        state: "available",
+        openclaw: manifestInstall,
+      }),
+    ).toBeNull();
+  });
+
   it("reads and updates hosted catalog snapshots in the SQLite store", async () => {
     const stateDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-hosted-store-"));
     try {

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -11,8 +11,6 @@ import {
   type HostedOfficialExternalPluginCatalogSnapshotStore,
   type OfficialExternalPluginCatalogEntry,
   type OfficialExternalPluginCatalogFeed,
-  DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEY_ID_ENV,
-  DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_PUBLIC_KEY_ENV,
   getOfficialExternalPluginCatalogEntry,
   getOfficialExternalPluginCatalogManifest,
   isOfficialExternalPluginCatalogFeed,
@@ -47,11 +45,32 @@ type ConfiguredHostedCatalogLoadParams = NonNullable<
 type HostedCatalogLoadParams = ConfiguredHostedCatalogLoadParams & {
   catalogConfig?: HostedCatalogConfig;
 };
+type HostedCatalogLoadResult = Awaited<
+  ReturnType<typeof loadConfiguredHostedOfficialExternalPluginCatalogEntries>
+>;
 
 function loadHostedCatalog(
   params: HostedCatalogLoadParams = {},
 ): ReturnType<typeof loadConfiguredHostedOfficialExternalPluginCatalogEntries> {
   return loadConfiguredHostedOfficialExternalPluginCatalogEntries(params);
+}
+
+function expectHosted(
+  result: HostedCatalogLoadResult,
+): asserts result is Extract<HostedCatalogLoadResult, { source: "hosted" }> {
+  expect(result.source).toBe("hosted");
+}
+
+function expectHostedSnapshot(
+  result: HostedCatalogLoadResult,
+): asserts result is Extract<HostedCatalogLoadResult, { source: "hosted-snapshot" }> {
+  expect(result.source).toBe("hosted-snapshot");
+}
+
+function expectBundledFallback(
+  result: HostedCatalogLoadResult,
+): asserts result is Extract<HostedCatalogLoadResult, { source: "bundled-fallback" }> {
+  expect(result.source).toBe("bundled-fallback");
 }
 
 function createInMemoryHostedCatalogSnapshotStore(
@@ -371,9 +390,8 @@ describe("official external plugin catalog", () => {
 
     const result = await loadHostedCatalog({
       env: {
-        [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEY_ID_ENV]: "acme-root",
-        [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_PUBLIC_KEY_ENV]:
-          signed.publicKeyPem,
+        OPENCLAW_CLAWHUB_FEED_TRUSTED_KEY_ID: "acme-root",
+        OPENCLAW_CLAWHUB_FEED_TRUSTED_PUBLIC_KEY: signed.publicKeyPem,
       },
       ifModifiedSince: "Mon, 22 Jun 2026 00:00:00 GMT",
       fetchImpl,
@@ -381,7 +399,7 @@ describe("official external plugin catalog", () => {
     });
 
     expect(fetchImpl).toHaveBeenCalledOnce();
-    expect(result.source).toBe("hosted");
+    expectHosted(result);
     expect(result.feed?.id).toBe("clawhub-official");
     expect(result.trust).toMatchObject({ mode: "signed", signedBy: "acme-root" });
   });
@@ -402,15 +420,14 @@ describe("official external plugin catalog", () => {
         },
       },
       env: {
-        [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEY_ID_ENV]: "acme-root",
-        [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_PUBLIC_KEY_ENV]:
-          signed.publicKeyPem,
+        OPENCLAW_CLAWHUB_FEED_TRUSTED_KEY_ID: "acme-root",
+        OPENCLAW_CLAWHUB_FEED_TRUSTED_PUBLIC_KEY: signed.publicKeyPem,
       },
       fetchImpl: vi.fn(async () => dsseResponse(signed.body, { status: 200 })),
       snapshotStore: null,
     });
 
-    expect(result.source).toBe("hosted");
+    expectHosted(result);
     expect(result.trust).toMatchObject({ mode: "signed", signedBy: "acme-root" });
   });
 
@@ -430,13 +447,13 @@ describe("official external plugin catalog", () => {
         },
       },
       env: {
-        [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEY_ID_ENV]: "incomplete",
+        OPENCLAW_CLAWHUB_FEED_TRUSTED_KEY_ID: "incomplete",
       },
       fetchImpl: vi.fn(async () => new Response(body, { status: 200 })),
       snapshotStore: null,
     });
 
-    expect(result.source).toBe("hosted");
+    expectHosted(result);
     expect(result.trust).toBeUndefined();
   });
 
@@ -447,15 +464,14 @@ describe("official external plugin catalog", () => {
 
     const result = await loadHostedCatalog({
       env: {
-        [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEY_ID_ENV]: "acme-root",
-        [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_PUBLIC_KEY_ENV]:
-          signed.publicKeyPem,
+        OPENCLAW_CLAWHUB_FEED_TRUSTED_KEY_ID: "acme-root",
+        OPENCLAW_CLAWHUB_FEED_TRUSTED_PUBLIC_KEY: signed.publicKeyPem,
       },
       fetchImpl: vi.fn(async () => dsseResponse(signed.body, { status: 200 })),
       snapshotStore: null,
     });
 
-    expect(result.source).toBe("bundled-fallback");
+    expectBundledFallback(result);
     expect(result.entries).toEqual([]);
     expect(result.error).toContain(
       'feed id "openclaw-official-external-plugins" did not match expected "clawhub-official"',
@@ -466,14 +482,14 @@ describe("official external plugin catalog", () => {
     const fetchImpl = vi.fn(async () => new Response("{}", { status: 200 }));
     const result = await loadHostedCatalog({
       env: {
-        [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEY_ID_ENV]: "acme-root",
+        OPENCLAW_CLAWHUB_FEED_TRUSTED_KEY_ID: "acme-root",
       },
       fetchImpl,
       snapshotStore: null,
     });
 
     expect(fetchImpl).not.toHaveBeenCalled();
-    expect(result.source).toBe("bundled-fallback");
+    expectBundledFallback(result);
     expect(result.entries).toEqual([]);
     expect(result.error).toContain("requires both key id and public key env vars");
   });
@@ -483,14 +499,14 @@ describe("official external plugin catalog", () => {
     const result = await loadHostedCatalog({
       feedUrl: "https://clawhub.ai/v1/feeds/plugins",
       env: {
-        [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEY_ID_ENV]: "acme-root",
+        OPENCLAW_CLAWHUB_FEED_TRUSTED_KEY_ID: "acme-root",
       },
       fetchImpl,
       snapshotStore: null,
     });
 
     expect(fetchImpl).not.toHaveBeenCalled();
-    expect(result.source).toBe("bundled-fallback");
+    expectBundledFallback(result);
     expect(result.entries).toEqual([]);
     expect(result.error).toContain("requires both key id and public key env vars");
   });
@@ -572,7 +588,7 @@ describe("official external plugin catalog", () => {
       snapshotStore: null,
     });
 
-    expect(result.source).toBe("hosted");
+    expectHosted(result);
     expect(result.entries.map((entry) => entry.id)).toEqual([
       "@acme/trusted",
       "@acme/disabled",
@@ -901,7 +917,7 @@ describe("official external plugin catalog", () => {
       snapshotStore,
     });
 
-    expect(accepted.source).toBe("hosted");
+    expectHosted(accepted);
     expect(accepted.entries.map((entry) => entry.name)).toEqual(["@openclaw/signed-v10"]);
     if (accepted.source === "hosted") {
       expect(accepted.trust).toMatchObject({
@@ -921,7 +937,7 @@ describe("official external plugin catalog", () => {
       snapshotStore,
     });
 
-    expect(rolledBack.source).toBe("hosted-snapshot");
+    expectHostedSnapshot(rolledBack);
     expect(rolledBack.entries.map((entry) => entry.name)).toEqual(["@openclaw/signed-v10"]);
     if (rolledBack.source === "hosted-snapshot") {
       expect(rolledBack.error).toContain("signed feed sequence is older");
@@ -952,7 +968,7 @@ describe("official external plugin catalog", () => {
         fetchImpl: vi.fn(async () => dsseResponse(accepted.body, { status: 200 })),
         snapshotStore,
       });
-      expect(initial.source).toBe("hosted");
+      expectHosted(initial);
 
       const result = await loadHostedCatalog({
         feedProfile: "acme",
@@ -961,7 +977,7 @@ describe("official external plugin catalog", () => {
         snapshotStore,
       });
 
-      expect(result.source).toBe("hosted-snapshot");
+      expectHostedSnapshot(result);
       expect(result.entries.map((entry) => entry.name)).toEqual(["@openclaw/signed-v10"]);
       if (result.source === "hosted-snapshot") {
         expect(result.error).toContain("payload changed without a sequence increment");
@@ -990,7 +1006,7 @@ describe("official external plugin catalog", () => {
       snapshotStore: createInMemoryHostedCatalogSnapshotStore(),
     });
 
-    expect(result.source).toBe("bundled-fallback");
+    expectBundledFallback(result);
     if (result.source === "bundled-fallback") {
       expect(result.error).toContain("signed envelope payload is invalid");
     }
@@ -1023,7 +1039,7 @@ describe("official external plugin catalog", () => {
       snapshotStore,
     });
 
-    expect(rejected.source).toBe("bundled-fallback");
+    expectBundledFallback(rejected);
     await expect(snapshotStore.read(url)).resolves.toMatchObject({ body: malformed.body });
 
     const result = await loadHostedCatalog({
@@ -1033,7 +1049,7 @@ describe("official external plugin catalog", () => {
       snapshotStore,
     });
 
-    expect(result.source).toBe("hosted");
+    expectHosted(result);
     expect(result.entries.map((entry) => entry.name)).toEqual(["@openclaw/repaired-current"]);
     await expect(snapshotStore.read(url)).resolves.toMatchObject({ body: valid.body });
   });
@@ -1058,7 +1074,7 @@ describe("official external plugin catalog", () => {
       snapshotStore,
     });
 
-    expect(result.source).toBe("bundled-fallback");
+    expectBundledFallback(result);
     if (result.source === "bundled-fallback") {
       expect(result.error).toContain("signature is invalid");
     }
@@ -1088,7 +1104,7 @@ describe("official external plugin catalog", () => {
         now: () => new Date("2026-06-22T00:00:08.000Z"),
         snapshotStore,
       });
-      expect(acceptedPrevious.source).toBe("hosted");
+      expectHosted(acceptedPrevious);
 
       const acceptedCurrent = await loadHostedCatalog({
         feedProfile: "acme",
@@ -1116,7 +1132,7 @@ describe("official external plugin catalog", () => {
         snapshotStore,
       });
 
-      expect(rejectedRollback.source).toBe("bundled-fallback");
+      expectBundledFallback(rejectedRollback);
       expect(rejectedRollback.entries).toEqual([]);
       if (rejectedRollback.source === "bundled-fallback") {
         expect(rejectedRollback.error).toContain("signed feed sequence is older");
@@ -1129,7 +1145,7 @@ describe("official external plugin catalog", () => {
         offline: true,
         snapshotStore,
       });
-      expect(retainedCurrent.source).toBe("hosted-snapshot");
+      expectHostedSnapshot(retainedCurrent);
       expect(retainedCurrent.entries.map((entry) => entry.name)).toEqual(["@openclaw/signed-v9"]);
     } finally {
       closeOpenClawStateDatabaseForTest();
@@ -1205,7 +1221,7 @@ describe("official external plugin catalog", () => {
       snapshotStore: createInMemoryHostedCatalogSnapshotStore(),
     });
 
-    expect(unsigned.source).toBe("bundled-fallback");
+    expectBundledFallback(unsigned);
     expect(unsigned.entries).toEqual([]);
     if (unsigned.source === "bundled-fallback") {
       expect(unsigned.error).toContain("signed envelope is malformed");
@@ -1224,7 +1240,7 @@ describe("official external plugin catalog", () => {
       snapshotStore: signedSnapshot,
     });
 
-    expect(offline.source).toBe("hosted-snapshot");
+    expectHostedSnapshot(offline);
     expect(offline.entries.map((entry) => entry.name)).toEqual(["@openclaw/signed-offline"]);
 
     const unsignedSnapshot = createInMemoryHostedCatalogSnapshotStore([
@@ -1245,7 +1261,7 @@ describe("official external plugin catalog", () => {
       snapshotStore: unsignedSnapshot,
     });
 
-    expect(rejectedSnapshot.source).toBe("bundled-fallback");
+    expectBundledFallback(rejectedSnapshot);
     if (rejectedSnapshot.source === "bundled-fallback") {
       expect(rejectedSnapshot.error).toContain("signed envelope is malformed");
     }
@@ -1265,7 +1281,7 @@ describe("official external plugin catalog", () => {
       snapshotStore: null,
     });
 
-    expect(live.source).toBe("bundled-fallback");
+    expectBundledFallback(live);
     if (live.source === "bundled-fallback") {
       expect(live.error).toContain("signed envelope is malformed");
     }
@@ -1279,7 +1295,7 @@ describe("official external plugin catalog", () => {
       ]),
     });
 
-    expect(offline.source).toBe("hosted-snapshot");
+    expectHostedSnapshot(offline);
     expect(offline.entries.map((entry) => entry.name)).toEqual(["@openclaw/legacy-snapshot"]);
   });
 
@@ -1300,7 +1316,7 @@ describe("official external plugin catalog", () => {
       snapshotStore: createInMemoryHostedCatalogSnapshotStore(),
     });
 
-    expect(result.source).toBe("bundled-fallback");
+    expectBundledFallback(result);
     expect(result.entries).toEqual([]);
     expect(result.error).toContain("must use application/vnd.dsse+json");
   });
@@ -1339,7 +1355,7 @@ describe("official external plugin catalog", () => {
       now: () => new Date("2026-06-22T00:00:30.000Z"),
       snapshotStore,
     });
-    expect(seeded.source).toBe("hosted");
+    expectHosted(seeded);
     expect(
       resolveOfficialExternalPluginInstall(seeded.entries[0]!, { catalogConfig }),
     ).not.toBeNull();
@@ -1351,7 +1367,7 @@ describe("official external plugin catalog", () => {
       now: () => new Date("2026-06-22T00:01:01.000Z"),
       snapshotStore: null,
     });
-    expect(expiredFresh.source).toBe("bundled-fallback");
+    expectBundledFallback(expiredFresh);
     expect(expiredFresh.entries).toEqual([]);
     expect(expiredFresh.error).toContain("signed feed expired");
 
@@ -1365,7 +1381,7 @@ describe("official external plugin catalog", () => {
       now: () => new Date("2026-06-22T00:01:01.000Z"),
       snapshotStore,
     });
-    expect(expiredSnapshot.source).toBe("hosted-snapshot");
+    expectHostedSnapshot(expiredSnapshot);
     expect(expiredSnapshot.entries).toHaveLength(1);
     expect(expiredSnapshot.entries[0]).toMatchObject({
       id: "@openclaw/expiring",
@@ -1385,7 +1401,7 @@ describe("official external plugin catalog", () => {
       now: () => new Date("2026-06-22T00:01:01.000Z"),
       snapshotStore,
     });
-    expect(expiredOffline.source).toBe("hosted-snapshot");
+    expectHostedSnapshot(expiredOffline);
     expect(expiredOffline.entries[0]).toMatchObject({ state: "unavailable" });
     expect(expiredOffline.error).toContain("signed feed expired");
 
@@ -1396,7 +1412,7 @@ describe("official external plugin catalog", () => {
       now: () => new Date("2026-06-22T00:01:01.000Z"),
       snapshotStore,
     });
-    expect(expiredAfterError.source).toBe("hosted-snapshot");
+    expectHostedSnapshot(expiredAfterError);
     expect(expiredAfterError.entries[0]).toMatchObject({ state: "unavailable" });
     expect(expiredAfterError.error).toContain("signed feed expired");
   });
@@ -1417,7 +1433,7 @@ describe("official external plugin catalog", () => {
       snapshotStore: null,
     });
 
-    expect(result.source).toBe("bundled-fallback");
+    expectBundledFallback(result);
     expect(result.entries).toEqual([]);
     expect(result.error).toContain("expiresAt must be later than generatedAt");
   });
@@ -1438,7 +1454,7 @@ describe("official external plugin catalog", () => {
       snapshotStore: null,
     });
 
-    expect(result.source).toBe("bundled-fallback");
+    expectBundledFallback(result);
     expect(result.error).toContain("requires a valid expiresAt value");
   });
 
@@ -1477,7 +1493,7 @@ describe("official external plugin catalog", () => {
       offline: true,
       snapshotStore,
     });
-    expect(stale.source).toBe("hosted-snapshot");
+    expectHostedSnapshot(stale);
     expect(stale.entries[0]).toMatchObject({ name: "@openclaw/legacy", state: "unavailable" });
     expect(resolveOfficialExternalPluginInstall(stale.entries[0]!, { catalogConfig })).toBeNull();
     expect(stale.error).toContain("has no expiresAt");
@@ -1489,7 +1505,7 @@ describe("official external plugin catalog", () => {
       now: () => new Date("2026-06-22T00:00:30.000Z"),
       snapshotStore,
     });
-    expect(updated.source).toBe("hosted");
+    expectHosted(updated);
     expect(updated.entries.map((entry) => entry.name)).toEqual(["@openclaw/current"]);
   });
 
@@ -1518,7 +1534,7 @@ describe("official external plugin catalog", () => {
     const fetchImpl = vi.fn(async () => new Response("{}", { status: 200 }));
     const result = await loadHostedCatalog({ feedUrl, fetchImpl, snapshotStore: null });
 
-    expect(result.source).toBe("bundled-fallback");
+    expectBundledFallback(result);
     expect(fetchImpl).not.toHaveBeenCalled();
     if (result.source === "bundled-fallback") {
       expect(result.error).toContain(expectedError);
@@ -1543,7 +1559,7 @@ describe("official external plugin catalog", () => {
       snapshotStore: null,
     });
 
-    expect(result.source).toBe("hosted");
+    expectHosted(result);
     expect(result.feed?.id).toBe("openclaw-official-external-plugins");
     expect(result.trust).toMatchObject({ mode: "signed", signedBy: "acme-root" });
   });
@@ -1563,7 +1579,7 @@ describe("official external plugin catalog", () => {
       snapshotStore: null,
     });
 
-    expect(result.source).toBe("bundled-fallback");
+    expectBundledFallback(result);
     if (result.source === "bundled-fallback") {
       expect(result.error).toContain("signed envelope is malformed");
     }
@@ -1606,7 +1622,7 @@ describe("official external plugin catalog", () => {
       snapshotStore: null,
     });
 
-    expect(result.source).toBe("hosted");
+    expectHosted(result);
     expect(result.entries.map((entry) => entry.name)).toEqual(["@acme/known-source"]);
   });
 
@@ -1624,7 +1640,7 @@ describe("official external plugin catalog", () => {
       snapshotStore: null,
     });
 
-    expect(mismatch.source).toBe("bundled-fallback");
+    expectBundledFallback(mismatch);
     if (mismatch.source === "bundled-fallback") {
       expect(mismatch.error).toContain("checksum mismatch");
       expect(mismatch.metadata?.checksum).toMatch(/^sha256:[0-9a-f]{64}$/u);
@@ -1635,7 +1651,7 @@ describe("official external plugin catalog", () => {
       fetchImpl: vi.fn(async () => new Response("12345", { status: 200 })),
       snapshotStore: null,
     });
-    expect(oversized.source).toBe("bundled-fallback");
+    expectBundledFallback(oversized);
     if (oversized.source === "bundled-fallback") {
       expect(oversized.error).toContain("exceeds 4 bytes");
     }
@@ -1653,7 +1669,7 @@ describe("official external plugin catalog", () => {
       snapshotStore: null,
     });
 
-    expect(nonStreaming.source).toBe("bundled-fallback");
+    expectBundledFallback(nonStreaming);
     if (nonStreaming.source === "bundled-fallback") {
       expect(nonStreaming.error).toContain("streaming response body unavailable");
     }
@@ -1680,7 +1696,7 @@ describe("official external plugin catalog", () => {
       now: () => new Date("2026-06-22T00:00:01.000Z"),
       snapshotStore,
     });
-    expect(seeded.source).toBe("hosted");
+    expectHosted(seeded);
 
     const reused = await loadHostedCatalog({
       ifNoneMatch: '"snapshot-v1"',
@@ -1689,7 +1705,7 @@ describe("official external plugin catalog", () => {
       ),
       snapshotStore,
     });
-    expect(reused.source).toBe("hosted-snapshot");
+    expectHostedSnapshot(reused);
     if (reused.source === "hosted-snapshot") {
       expect(reused.snapshot.savedAt).toBe("2026-06-22T00:00:01.000Z");
     }

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -557,6 +557,14 @@ describe("official external plugin catalog", () => {
             ],
           },
         },
+        {
+          type: "plugin",
+          id: "@acme/missing-authority",
+          version: "1.0.0",
+          openclaw: {
+            install: { npmSpec: "@acme/missing-authority" },
+          },
+        },
       ],
     });
     const result = await loadHostedCatalog({
@@ -569,9 +577,10 @@ describe("official external plugin catalog", () => {
       "@acme/trusted",
       "@acme/disabled",
       "@acme/community",
+      "@acme/missing-authority",
     ]);
-    const [trusted, disabled, community] = result.entries;
-    if (!trusted || !disabled || !community) {
+    const [trusted, disabled, community, missingAuthority] = result.entries;
+    if (!trusted || !disabled || !community || !missingAuthority) {
       throw new Error("expected schema-v2 marketplace entries");
     }
     expect(resolveOfficialExternalPluginInstall(trusted)).toEqual({
@@ -583,6 +592,7 @@ describe("official external plugin catalog", () => {
     expect(disabled).not.toHaveProperty("featured");
     expect(resolveOfficialExternalPluginInstall(disabled)).toBeNull();
     expect(resolveOfficialExternalPluginInstall(community)).toBeNull();
+    expect(resolveOfficialExternalPluginInstall(missingAuthority)).toBeNull();
   });
 
   it("requires complete schema-v2 install authority when either trust field is present", () => {

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -478,6 +478,23 @@ describe("official external plugin catalog", () => {
     expect(result.error).toContain("requires both key id and public key env vars");
   });
 
+  it("preserves default ClawHub trust for an explicit default feed URL", async () => {
+    const fetchImpl = vi.fn(async () => new Response("{}", { status: 200 }));
+    const result = await loadHostedCatalog({
+      feedUrl: "https://clawhub.ai/v1/feeds/plugins",
+      env: {
+        [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEY_ID_ENV]: "acme-root",
+      },
+      fetchImpl,
+      snapshotStore: null,
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(result.source).toBe("bundled-fallback");
+    expect(result.entries).toEqual([]);
+    expect(result.error).toContain("requires both key id and public key env vars");
+  });
+
   it("loads schema-v2 marketplace entries and gates installs by state and trust", async () => {
     const body = JSON.stringify({
       schemaVersion: 2,
@@ -527,6 +544,9 @@ describe("official external plugin catalog", () => {
           version: "1.0.0",
           state: "available",
           publisher: { id: "acme", trust: "community" },
+          openclaw: {
+            install: { npmSpec: "@acme/community" },
+          },
           install: {
             candidates: [
               {

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -209,6 +209,12 @@ function signedHostedCatalogSnapshot(params: {
   };
 }
 
+function dsseResponse(body: BodyInit | null, init: ResponseInit = {}): Response {
+  const headers = new Headers(init.headers);
+  headers.set("content-type", "application/vnd.dsse+json");
+  return new Response(body, { ...init, headers });
+}
+
 describe("official external plugin catalog", () => {
   it("keeps hosted fetch guard loading lazy for bundled catalog import paths", () => {
     const source = readFileSync(
@@ -356,7 +362,12 @@ describe("official external plugin catalog", () => {
       id: "clawhub-official",
     };
     const signed = signedHostedCatalogFeed({ feed });
-    const fetchImpl = vi.fn(async () => new Response(signed.body, { status: 200 }));
+    const fetchImpl = vi.fn(async (_url, init) => {
+      const headers = new Headers(init?.headers);
+      expect(headers.get("accept")).toBe("application/vnd.dsse+json");
+      expect(headers.has("if-modified-since")).toBe(false);
+      return dsseResponse(signed.body, { status: 200 });
+    });
 
     const result = await loadHostedCatalog({
       env: {
@@ -364,6 +375,7 @@ describe("official external plugin catalog", () => {
         [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_PUBLIC_KEY_ENV]:
           signed.publicKeyPem,
       },
+      ifModifiedSince: "Mon, 22 Jun 2026 00:00:00 GMT",
       fetchImpl,
       snapshotStore: null,
     });
@@ -394,7 +406,7 @@ describe("official external plugin catalog", () => {
         [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_PUBLIC_KEY_ENV]:
           signed.publicKeyPem,
       },
-      fetchImpl: vi.fn(async () => new Response(signed.body, { status: 200 })),
+      fetchImpl: vi.fn(async () => dsseResponse(signed.body, { status: 200 })),
       snapshotStore: null,
     });
 
@@ -439,7 +451,7 @@ describe("official external plugin catalog", () => {
         [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_PUBLIC_KEY_ENV]:
           signed.publicKeyPem,
       },
-      fetchImpl: vi.fn(async () => new Response(signed.body, { status: 200 })),
+      fetchImpl: vi.fn(async () => dsseResponse(signed.body, { status: 200 })),
       snapshotStore: null,
     });
 
@@ -831,7 +843,7 @@ describe("official external plugin catalog", () => {
     const accepted = await loadHostedCatalog({
       feedProfile: "acme",
       catalogConfig,
-      fetchImpl: vi.fn(async () => new Response(newer.body, { status: 200 })),
+      fetchImpl: vi.fn(async () => dsseResponse(newer.body, { status: 200 })),
       now: () => new Date("2026-06-22T00:00:10.000Z"),
       snapshotStore,
     });
@@ -851,7 +863,7 @@ describe("official external plugin catalog", () => {
     const rolledBack = await loadHostedCatalog({
       feedProfile: "acme",
       catalogConfig,
-      fetchImpl: vi.fn(async () => new Response(older.body, { status: 200 })),
+      fetchImpl: vi.fn(async () => dsseResponse(older.body, { status: 200 })),
       now: () => new Date("2026-06-22T00:00:11.000Z"),
       snapshotStore,
     });
@@ -921,7 +933,7 @@ describe("official external plugin catalog", () => {
     const result = await loadHostedCatalog({
       feedProfile: "acme",
       catalogConfig: signedCatalogConfig(malformed.publicKeyPem),
-      fetchImpl: vi.fn(async () => new Response(malformed.body, { status: 200 })),
+      fetchImpl: vi.fn(async () => dsseResponse(malformed.body, { status: 200 })),
       snapshotStore: createInMemoryHostedCatalogSnapshotStore(),
     });
 
@@ -954,7 +966,7 @@ describe("official external plugin catalog", () => {
     const rejected = await loadHostedCatalog({
       feedProfile: "acme",
       catalogConfig: signedCatalogConfig(lower.publicKeyPem),
-      fetchImpl: vi.fn(async () => new Response(lower.body, { status: 200 })),
+      fetchImpl: vi.fn(async () => dsseResponse(lower.body, { status: 200 })),
       snapshotStore,
     });
 
@@ -964,7 +976,7 @@ describe("official external plugin catalog", () => {
     const result = await loadHostedCatalog({
       feedProfile: "acme",
       catalogConfig: signedCatalogConfig(valid.publicKeyPem),
-      fetchImpl: vi.fn(async () => new Response(valid.body, { status: 200 })),
+      fetchImpl: vi.fn(async () => dsseResponse(valid.body, { status: 200 })),
       snapshotStore,
     });
 
@@ -989,7 +1001,7 @@ describe("official external plugin catalog", () => {
     const result = await loadHostedCatalog({
       feedProfile: "acme",
       catalogConfig: signedCatalogConfig(candidate.publicKeyPem),
-      fetchImpl: vi.fn(async () => new Response(candidate.body, { status: 200 })),
+      fetchImpl: vi.fn(async () => dsseResponse(candidate.body, { status: 200 })),
       snapshotStore,
     });
 
@@ -1136,7 +1148,7 @@ describe("official external plugin catalog", () => {
     const unsigned = await loadHostedCatalog({
       feedProfile: "acme",
       catalogConfig,
-      fetchImpl: vi.fn(async () => new Response(unsignedBody, { status: 200 })),
+      fetchImpl: vi.fn(async () => dsseResponse(unsignedBody, { status: 200 })),
       snapshotStore: createInMemoryHostedCatalogSnapshotStore(),
     });
 
@@ -1218,6 +1230,28 @@ describe("official external plugin catalog", () => {
     expect(offline.entries.map((entry) => entry.name)).toEqual(["@openclaw/legacy-snapshot"]);
   });
 
+  it("fails closed when a signed feed response does not use the DSSE media type", async () => {
+    const signed = signedHostedCatalogFeed({
+      feed: hostedCatalogFeed({ sequence: 8, pluginName: "@openclaw/wrong-media-type" }),
+    });
+    const result = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(signed.publicKeyPem),
+      fetchImpl: vi.fn(
+        async () =>
+          new Response(signed.body, {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+      snapshotStore: createInMemoryHostedCatalogSnapshotStore(),
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    expect(result.entries).toEqual([]);
+    expect(result.error).toContain("must use application/vnd.dsse+json");
+  });
+
   it("rejects expired signed feeds and keeps expired snapshots visible but not installable", async () => {
     const feed = {
       ...hostedCatalogFeed({
@@ -1246,8 +1280,8 @@ describe("official external plugin catalog", () => {
     const seeded = await loadHostedCatalog({
       feedProfile: "acme",
       catalogConfig,
-      fetchImpl: vi.fn(
-        async () => new Response(signed.body, { status: 200, headers: { etag: '"expiring"' } }),
+      fetchImpl: vi.fn(async () =>
+        dsseResponse(signed.body, { status: 200, headers: { etag: '"expiring"' } }),
       ),
       now: () => new Date("2026-06-22T00:00:30.000Z"),
       snapshotStore,
@@ -1260,7 +1294,7 @@ describe("official external plugin catalog", () => {
     const expiredFresh = await loadHostedCatalog({
       feedProfile: "acme",
       catalogConfig,
-      fetchImpl: vi.fn(async () => new Response(signed.body, { status: 200 })),
+      fetchImpl: vi.fn(async () => dsseResponse(signed.body, { status: 200 })),
       now: () => new Date("2026-06-22T00:01:01.000Z"),
       snapshotStore: null,
     });
@@ -1325,7 +1359,7 @@ describe("official external plugin catalog", () => {
     const result = await loadHostedCatalog({
       feedProfile: "acme",
       catalogConfig: signedCatalogConfig(signed.publicKeyPem),
-      fetchImpl: vi.fn(async () => new Response(signed.body, { status: 200 })),
+      fetchImpl: vi.fn(async () => dsseResponse(signed.body, { status: 200 })),
       now: () => new Date("2026-06-22T00:00:30.000Z"),
       snapshotStore: null,
     });
@@ -1378,7 +1412,7 @@ describe("official external plugin catalog", () => {
     const updated = await loadHostedCatalog({
       feedProfile: "acme",
       catalogConfig,
-      fetchImpl: vi.fn(async () => new Response(newer.body, { status: 200 })),
+      fetchImpl: vi.fn(async () => dsseResponse(newer.body, { status: 200 })),
       now: () => new Date("2026-06-22T00:00:30.000Z"),
       snapshotStore,
     });
@@ -1429,7 +1463,7 @@ describe("official external plugin catalog", () => {
       feedProfile: "acme",
       feedUrl: "https://clawhub.ai/v1/feeds/plugins",
       catalogConfig: signedCatalogConfig(signed.publicKeyPem),
-      fetchImpl: vi.fn(async () => new Response(unsignedBody, { status: 200 })),
+      fetchImpl: vi.fn(async () => dsseResponse(unsignedBody, { status: 200 })),
       snapshotStore: null,
     });
 

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -916,7 +916,7 @@ describe("official external plugin catalog", () => {
       const initial = await loadHostedCatalog({
         feedProfile: "acme",
         catalogConfig,
-        fetchImpl: vi.fn(async () => new Response(accepted.body, { status: 200 })),
+        fetchImpl: vi.fn(async () => dsseResponse(accepted.body, { status: 200 })),
         snapshotStore,
       });
       expect(initial.source).toBe("hosted");
@@ -924,7 +924,7 @@ describe("official external plugin catalog", () => {
       const result = await loadHostedCatalog({
         feedProfile: "acme",
         catalogConfig,
-        fetchImpl: vi.fn(async () => new Response(conflicting.body, { status: 200 })),
+        fetchImpl: vi.fn(async () => dsseResponse(conflicting.body, { status: 200 })),
         snapshotStore,
       });
 
@@ -1051,7 +1051,7 @@ describe("official external plugin catalog", () => {
       const acceptedPrevious = await loadHostedCatalog({
         feedProfile: "acme",
         catalogConfig: signedCatalogConfig(previous.publicKeyPem, "acme-root-2026-q2"),
-        fetchImpl: vi.fn(async () => new Response(previous.body, { status: 200 })),
+        fetchImpl: vi.fn(async () => dsseResponse(previous.body, { status: 200 })),
         now: () => new Date("2026-06-22T00:00:08.000Z"),
         snapshotStore,
       });
@@ -1060,7 +1060,7 @@ describe("official external plugin catalog", () => {
       const acceptedCurrent = await loadHostedCatalog({
         feedProfile: "acme",
         catalogConfig: signedCatalogConfig(current.publicKeyPem, "acme-root-2026-q3"),
-        fetchImpl: vi.fn(async () => new Response(current.body, { status: 200 })),
+        fetchImpl: vi.fn(async () => dsseResponse(current.body, { status: 200 })),
         now: () => new Date("2026-06-22T00:00:09.000Z"),
         snapshotStore,
       });
@@ -1078,7 +1078,7 @@ describe("official external plugin catalog", () => {
       const rejectedRollback = await loadHostedCatalog({
         feedProfile: "acme",
         catalogConfig: signedCatalogConfig(rolledBack.publicKeyPem, "acme-root-2026-q4"),
-        fetchImpl: vi.fn(async () => new Response(rolledBack.body, { status: 200 })),
+        fetchImpl: vi.fn(async () => dsseResponse(rolledBack.body, { status: 200 })),
         now: () => new Date("2026-06-22T00:00:10.000Z"),
         snapshotStore,
       });
@@ -1141,7 +1141,7 @@ describe("official external plugin catalog", () => {
       const result = await loadHostedCatalog({
         feedProfile: "acme",
         catalogConfig: signedCatalogConfig(repaired.publicKeyPem, "acme-root-2026-q3"),
-        fetchImpl: vi.fn(async () => new Response(repaired.body, { status: 200 })),
+        fetchImpl: vi.fn(async () => dsseResponse(repaired.body, { status: 200 })),
         snapshotStore,
       });
 
@@ -1228,7 +1228,7 @@ describe("official external plugin catalog", () => {
     const live = await loadHostedCatalog({
       feedProfile: "acme",
       catalogConfig,
-      fetchImpl: vi.fn(async () => new Response(legacyBody, { status: 200 })),
+      fetchImpl: vi.fn(async () => dsseResponse(legacyBody, { status: 200 })),
       snapshotStore: null,
     });
 
@@ -1490,6 +1490,29 @@ describe("official external plugin catalog", () => {
     if (result.source === "bundled-fallback") {
       expect(result.error).toContain(expectedError);
     }
+  });
+
+  it.each([
+    ["configured profile", {}],
+    ["direct feed URL override", { feedUrl: "https://clawhub.ai/v1/feeds/plugins" }],
+  ])("keeps a legacy signed profile without feedId usable via %s", async (_label, options) => {
+    const signed = signedHostedCatalogFeed({
+      feed: hostedCatalogFeed({ sequence: 8, pluginName: "@openclaw/legacy-profile" }),
+    });
+    const catalogConfig = signedCatalogConfig(signed.publicKeyPem);
+    delete catalogConfig.feeds?.acme?.feedId;
+
+    const result = await loadHostedCatalog({
+      feedProfile: "acme",
+      ...options,
+      catalogConfig,
+      fetchImpl: vi.fn(async () => dsseResponse(signed.body, { status: 200 })),
+      snapshotStore: null,
+    });
+
+    expect(result.source).toBe("hosted");
+    expect(result.feed?.id).toBe("openclaw-official-external-plugins");
+    expect(result.trust).toMatchObject({ mode: "signed", signedBy: "acme-root" });
   });
 
   it("preserves signed profile verification for direct feed URL overrides", async () => {

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -592,6 +592,8 @@ describe("official external plugin catalog", () => {
     expect(disabled).not.toHaveProperty("featured");
     expect(resolveOfficialExternalPluginInstall(disabled)).toBeNull();
     expect(resolveOfficialExternalPluginInstall(community)).toBeNull();
+    expect(missingAuthority).toMatchObject({ state: "unavailable" });
+    expect(getOfficialExternalPluginCatalogManifest(missingAuthority)?.install).toBeUndefined();
     expect(resolveOfficialExternalPluginInstall(missingAuthority)).toBeNull();
   });
 

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -1369,6 +1369,26 @@ describe("official external plugin catalog", () => {
     expect(result.error).toContain("expiresAt must be later than generatedAt");
   });
 
+  it("rejects impossible ISO calendar dates in signed feed expiry", async () => {
+    const signed = signedHostedCatalogFeed({
+      feed: hostedCatalogFeed({
+        sequence: 8,
+        pluginName: "@openclaw/invalid-expiry-date",
+        expiresAt: "2026-02-30T00:00:00.000Z",
+      }),
+    });
+    const result = await loadHostedCatalog({
+      feedProfile: "acme",
+      catalogConfig: signedCatalogConfig(signed.publicKeyPem),
+      fetchImpl: vi.fn(async () => dsseResponse(signed.body, { status: 200 })),
+      now: () => new Date("2026-02-22T00:00:30.000Z"),
+      snapshotStore: null,
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    expect(result.error).toContain("requires a valid expiresAt value");
+  });
+
   it("uses legacy signed snapshots for rollback state without preserving install authority", async () => {
     const legacyFeed = hostedCatalogFeed({ sequence: 8, pluginName: "@openclaw/legacy" });
     delete legacyFeed.expiresAt;

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -164,7 +164,7 @@ type OfficialExternalPluginCatalogFeedVerification =
       threshold?: number;
     };
 
-export type OfficialExternalPluginCatalogFeedSigningKey = {
+type OfficialExternalPluginCatalogFeedSigningKey = {
   keyId: string;
   publicKey: string;
 };
@@ -263,17 +263,16 @@ type OfficialExternalProviderContract =
   | "webFetchProviders";
 
 const SUPPORTED_OFFICIAL_EXTERNAL_CATALOG_FEED_SCHEMA_VERSIONS = new Set([1, 2]);
-export const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL =
-  "https://clawhub.ai/v1/feeds/plugins";
-export const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE = "clawhub-public";
-export const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_ID = "clawhub-official";
+const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL = "https://clawhub.ai/v1/feeds/plugins";
+const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE = "clawhub-public";
+const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_ID = "clawhub-official";
 const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_SOURCE_REF = "public-clawhub";
 const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_NPM_SOURCE_REF = "public-npm";
-export const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEY_ID_ENV =
+const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEY_ID_ENV =
   "OPENCLAW_CLAWHUB_FEED_TRUSTED_KEY_ID";
-export const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_PUBLIC_KEY_ENV =
+const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_PUBLIC_KEY_ENV =
   "OPENCLAW_CLAWHUB_FEED_TRUSTED_PUBLIC_KEY";
-export const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEYS: readonly OfficialExternalPluginCatalogFeedSigningKey[] =
+const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEYS: readonly OfficialExternalPluginCatalogFeedSigningKey[] =
   [];
 const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_PROFILE_CONFIG: OfficialExternalPluginCatalogProfileConfig =
   {

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -1525,10 +1525,10 @@ export function resolveOfficialExternalPluginInstall(
   params?: { catalogConfig?: OfficialExternalPluginCatalogProfileConfig },
 ): PluginPackageInstall | null {
   const state = normalizeOptionalString(entry.state);
-  if (
-    state &&
-    (state !== "available" || normalizeOptionalString(entry.publisher?.trust) !== "official")
-  ) {
+  const publisherTrust = normalizeOptionalString(entry.publisher?.trust);
+  // Legacy schema-v1 entries have neither field and inherit the signed feed's trust. Once an
+  // entry declares either schema-v2 authority field, require the complete fail-closed pair.
+  if ((state || publisherTrust) && (state !== "available" || publisherTrust !== "official")) {
     return null;
   }
   const manifest = getOfficialExternalPluginCatalogManifest(entry);

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -179,6 +179,7 @@ export type OfficialExternalPluginCatalogFeed = {
   schemaVersion: 1 | 2;
   id: string;
   generatedAt: string;
+  expiresAt?: string;
   sequence: number;
   description?: string;
   entries: readonly OfficialExternalPluginCatalogEntry[];
@@ -429,7 +430,11 @@ function resolveOfficialExternalPluginCatalogProfileConfig(
   config?: OfficialExternalPluginCatalogProfileConfig,
   env?: NodeJS.ProcessEnv,
 ): Required<OfficialExternalPluginCatalogProfileConfig> {
-  const envVerification = resolveDefaultClawHubFeedVerificationFromEnv(env);
+  const configuredDefaultFeed =
+    config?.feeds?.[DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE];
+  const envVerification = configuredDefaultFeed?.verification
+    ? undefined
+    : resolveDefaultClawHubFeedVerificationFromEnv(env);
   const bundledVerification =
     DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEYS.length > 0
       ? {
@@ -446,11 +451,12 @@ function resolveOfficialExternalPluginCatalogProfileConfig(
   };
   return {
     feeds: {
+      ...config?.feeds,
       [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE]: {
         ...defaultFeed,
         ...(defaultVerification ? { verification: defaultVerification } : {}),
+        ...configuredDefaultFeed,
       },
-      ...config?.feeds,
     },
     sources: {
       ...DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_PROFILE_CONFIG.sources,
@@ -482,7 +488,9 @@ function resolveHostedCatalogFeedSource(params: {
         ? undefined
         : resolveOfficialExternalPluginCatalogProfileConfig(
             params.catalogConfig,
-            params.catalogConfig?.feeds?.[explicitProfileName] ? undefined : params.env,
+            explicitProfileName === DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE
+              ? params.env
+              : undefined,
           );
     const profile =
       explicitProfileName === undefined ? undefined : profileConfig?.feeds[explicitProfileName];
@@ -504,7 +512,7 @@ function resolveHostedCatalogFeedSource(params: {
   const profileName = explicitProfileName ?? DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE;
   const profileConfig = resolveOfficialExternalPluginCatalogProfileConfig(
     params.catalogConfig,
-    params.catalogConfig?.feeds?.[profileName] ? undefined : params.env,
+    profileName === DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE ? params.env : undefined,
   );
   const profile = profileConfig.feeds[profileName];
   if (!profile) {
@@ -762,9 +770,13 @@ async function parseHostedCatalogFeedBody(params: {
   verification?: OfficialExternalPluginCatalogFeedVerification;
   verifiedAt: string;
   allowLegacyBetaEnvelope?: boolean;
+  now: Date;
+  allowExpired?: boolean;
+  allowMissingExpiry?: boolean;
 }): Promise<{
   feed: OfficialExternalPluginCatalogFeed;
   trust?: HostedOfficialExternalPluginCatalogTrustState;
+  expired?: boolean;
 }> {
   const raw = JSON.parse(params.body) as unknown;
   if (params.verification?.mode === "signed") {
@@ -793,6 +805,34 @@ async function parseHostedCatalogFeedBody(params: {
         `hosted catalog feed id "${verification.feed.id}" did not match expected "${params.expectedFeedId}"`,
       );
     }
+    const generatedAtMs = Date.parse(verification.feed.generatedAt);
+    const expiresAt = normalizeOptionalString(verification.feed.expiresAt);
+    if (!Number.isFinite(generatedAtMs)) {
+      throw new Error("hosted catalog signed feed requires a valid generatedAt value");
+    }
+    let expired = false;
+    if (!expiresAt) {
+      if (params.allowMissingExpiry !== true) {
+        throw new Error("hosted catalog signed feed requires a valid expiresAt value");
+      }
+      expired = true;
+    } else {
+      const expiresAtMs = Date.parse(expiresAt);
+      if (!Number.isFinite(expiresAtMs)) {
+        throw new Error("hosted catalog signed feed requires a valid expiresAt value");
+      }
+      if (expiresAtMs <= generatedAtMs) {
+        throw new Error("hosted catalog signed feed expiresAt must be later than generatedAt");
+      }
+      expired = expiresAtMs <= params.now.getTime();
+    }
+    if (expired && params.allowExpired !== true) {
+      throw new Error(
+        expiresAt
+          ? `hosted catalog signed feed expired at ${expiresAt}`
+          : "hosted catalog signed feed has no expiresAt",
+      );
+    }
     return {
       feed: verification.feed,
       trust: {
@@ -802,6 +842,7 @@ async function parseHostedCatalogFeedBody(params: {
         threshold,
         verifiedAt: params.verifiedAt,
       },
+      ...(expired ? { expired: true } : {}),
     };
   }
   if (!isOfficialExternalPluginCatalogFeed(raw)) {
@@ -853,6 +894,7 @@ async function loadHostedCatalogSnapshotResult(params: {
   requireManifestInstallSourceRef?: boolean;
   expectedFeedId?: string;
   verification?: OfficialExternalPluginCatalogFeedVerification;
+  now: Date;
 }): Promise<HostedOfficialExternalPluginCatalogLoadResult> {
   assertSnapshotMatchesRequestValidators({
     snapshot: params.snapshot,
@@ -872,23 +914,47 @@ async function loadHostedCatalogSnapshotResult(params: {
     verification: params.verification,
     verifiedAt: params.snapshot.trust?.verifiedAt ?? params.snapshot.savedAt,
     allowLegacyBetaEnvelope: true,
+    now: params.now,
+    allowExpired: true,
+    allowMissingExpiry: true,
   });
+  const entries = dedupeOfficialExternalPluginCatalogEntries(
+    filterOfficialExternalPluginCatalogEntriesBySourceRefs(
+      parseOfficialExternalPluginCatalogEntries(parsed.feed),
+      {
+        catalogConfig: params.catalogConfig,
+        requireManifestInstallSourceRef: params.requireManifestInstallSourceRef,
+      },
+    ),
+  );
+  const visibleEntries = parsed.expired
+    ? entries.map((entry) => removeOfficialExternalPluginCatalogInstallAuthority(entry))
+    : entries;
   return {
     source: "hosted-snapshot",
-    entries: dedupeOfficialExternalPluginCatalogEntries(
-      filterOfficialExternalPluginCatalogEntriesBySourceRefs(
-        parseOfficialExternalPluginCatalogEntries(parsed.feed),
-        {
-          catalogConfig: params.catalogConfig,
-          requireManifestInstallSourceRef: params.requireManifestInstallSourceRef,
-        },
-      ),
-    ),
-    feed: parsed.feed,
+    entries: visibleEntries,
+    feed: parsed.expired ? { ...parsed.feed, entries: visibleEntries } : parsed.feed,
     metadata: params.snapshot.metadata,
     snapshot: params.snapshot,
     ...(parsed.trust ? { trust: parsed.trust } : {}),
-    error: formatHostedCatalogError(params.error),
+    error: parsed.expired
+      ? `${formatHostedCatalogError(params.error)}; ${parsed.feed.expiresAt ? `hosted catalog signed feed expired at ${parsed.feed.expiresAt}` : "hosted catalog signed feed has no expiresAt"}`
+      : formatHostedCatalogError(params.error),
+  };
+}
+
+function removeOfficialExternalPluginCatalogInstallAuthority(
+  entry: OfficialExternalPluginCatalogEntry,
+): OfficialExternalPluginCatalogEntry {
+  const { install: _feedInstall, [MANIFEST_KEY]: manifest, ...metadata } = entry;
+  if (!manifest) {
+    return { ...metadata, state: "unavailable" };
+  }
+  const { install: _manifestInstall, ...manifestMetadata } = manifest;
+  return {
+    ...metadata,
+    state: "unavailable",
+    [MANIFEST_KEY]: manifestMetadata,
   };
 }
 
@@ -937,6 +1003,7 @@ async function snapshotOrBundledFallbackResult(params: {
   requireManifestInstallSourceRef?: boolean;
   expectedFeedId?: string;
   verification?: OfficialExternalPluginCatalogFeedVerification;
+  now: Date;
 }): Promise<HostedOfficialExternalPluginCatalogLoadResult> {
   if (params.snapshotStore) {
     try {
@@ -952,6 +1019,7 @@ async function snapshotOrBundledFallbackResult(params: {
           requireManifestInstallSourceRef: params.requireManifestInstallSourceRef,
           expectedFeedId: params.expectedFeedId,
           verification: params.verification,
+          now: params.now,
         });
       }
     } catch (snapshotErr) {
@@ -1034,6 +1102,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
     stateDatabasePath: params?.stateDatabasePath,
   });
   const expectedSha256 = normalizeOptionalString(params?.expectedSha256);
+  const currentTime = () => params?.now?.() ?? new Date();
   const requireManifestInstallSourceRef = shouldRequireManifestInstallSourceRef({
     feedUrl: params?.feedUrl,
     feedProfile: params?.feedProfile,
@@ -1049,6 +1118,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
       requireManifestInstallSourceRef,
       expectedFeedId: source.expectedFeedId,
       verification: source.verification,
+      now: currentTime(),
     });
   }
   const headers = new Headers();
@@ -1100,6 +1170,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         requireManifestInstallSourceRef,
         expectedFeedId: source.expectedFeedId,
         verification: source.verification,
+        now: currentTime(),
       });
     }
     if (!response.ok) {
@@ -1115,6 +1186,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         requireManifestInstallSourceRef,
         expectedFeedId: source.expectedFeedId,
         verification: source.verification,
+        now: currentTime(),
       });
     }
     const body = await readHostedCatalogResponseText({
@@ -1138,14 +1210,17 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         requireManifestInstallSourceRef,
         expectedFeedId: source.expectedFeedId,
         verification: source.verification,
+        now: currentTime(),
       });
     }
-    const verifiedAt = (params?.now?.() ?? new Date()).toISOString();
+    const now = currentTime();
+    const verifiedAt = now.toISOString();
     const parsed = await parseHostedCatalogFeedBody({
       body,
       expectedFeedId: source.expectedFeedId,
       verification: source.verification,
       verifiedAt,
+      now,
     }).catch(async (err: unknown) => {
       return await snapshotOrBundledFallbackResult({
         error: err,
@@ -1159,6 +1234,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         requireManifestInstallSourceRef,
         expectedFeedId: source.expectedFeedId,
         verification: source.verification,
+        now,
       });
     });
     if ("source" in parsed) {
@@ -1177,6 +1253,9 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
                   verification: source.verification,
                   verifiedAt: currentSnapshot.trust.verifiedAt,
                   allowLegacyBetaEnvelope: true,
+                  now,
+                  allowExpired: true,
+                  allowMissingExpiry: true,
                 }).catch((err: unknown) => {
                   // Only an authenticated invalid-timestamp payload is repairable. Signature
                   // and trust failures must remain fail-closed so rollback checks cannot be bypassed.
@@ -1195,7 +1274,6 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
           throw new HostedCatalogSignedFeedMonotonicityError(
             "hosted catalog signed feed sequence is older than current snapshot",
           );
-        }
         }
       }
     }
@@ -1252,6 +1330,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
       requireManifestInstallSourceRef,
       expectedFeedId: source.expectedFeedId,
       verification: source.verification,
+      now: currentTime(),
     });
   } finally {
     if (response?.bodyUsed !== true) {
@@ -1415,6 +1494,10 @@ export function resolveOfficialExternalPluginInstall(
   entry: OfficialExternalPluginCatalogEntry,
   params?: { catalogConfig?: OfficialExternalPluginCatalogProfileConfig },
 ): PluginPackageInstall | null {
+  const state = normalizeOptionalString(entry.state);
+  if (state && state !== "available") {
+    return null;
+  }
   const manifest = getOfficialExternalPluginCatalogManifest(entry);
   const install = manifest?.install;
   const clawhubSpec = normalizeOptionalString(install?.clawhubSpec);

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -297,6 +297,7 @@ const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_PROFILE_CONFIG: OfficialExternalP
 const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_TIMEOUT_MS = 5000;
 const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_MAX_BYTES = 1024 * 1024;
 const DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CHUNK_TIMEOUT_MS = 5000;
+const DSSE_ENVELOPE_MEDIA_TYPE = "application/vnd.dsse+json";
 const OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST = ["clawhub.ai"];
 const ISO_CALENDAR_DATE_PREFIX_RE = /^(\d{4})-(\d{2})-(\d{2})/u;
 
@@ -414,7 +415,9 @@ function resolveDefaultClawHubFeedVerificationFromEnv(
   const publicKey = normalizeOptionalString(
     env?.[DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_PUBLIC_KEY_ENV],
   );
-  if (!keyId && !publicKey) return undefined;
+  if (!keyId && !publicKey) {
+    return undefined;
+  }
   if (!keyId || !publicKey) {
     throw new HostedCatalogTrustConfigurationError(
       "default ClawHub feed trust requires both key id and public key env vars",
@@ -810,7 +813,7 @@ async function parseHostedCatalogFeedBody(params: {
     if (!Number.isFinite(generatedAtMs)) {
       throw new Error("hosted catalog signed feed requires a valid generatedAt value");
     }
-    let expired = false;
+    let expired: boolean;
     if (!expiresAt) {
       if (params.allowMissingExpiry !== true) {
         throw new Error("hosted catalog signed feed requires a valid expiresAt value");
@@ -1123,12 +1126,18 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
   }
   const headers = new Headers();
   const ifNoneMatch = normalizeOptionalString(params?.ifNoneMatch);
-  const ifModifiedSince = normalizeOptionalString(params?.ifModifiedSince);
+  const signedOperation = source.verification?.mode === "signed";
+  const ifModifiedSince = signedOperation
+    ? undefined
+    : normalizeOptionalString(params?.ifModifiedSince);
   if (ifNoneMatch) {
     headers.set("if-none-match", ifNoneMatch);
   }
   if (ifModifiedSince) {
     headers.set("if-modified-since", ifModifiedSince);
+  }
+  if (signedOperation) {
+    headers.set("accept", DSSE_ENVELOPE_MEDIA_TYPE);
   }
   const metadataBase = (response: Response) => {
     const etag = normalizeHostedCatalogHeader(response.headers.get("etag"));
@@ -1182,6 +1191,25 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         expectedSha256,
         ifNoneMatch,
         ifModifiedSince,
+        catalogConfig: params?.catalogConfig,
+        requireManifestInstallSourceRef,
+        expectedFeedId: source.expectedFeedId,
+        verification: source.verification,
+        now: currentTime(),
+      });
+    }
+    if (
+      signedOperation &&
+      response.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase() !==
+        DSSE_ENVELOPE_MEDIA_TYPE
+    ) {
+      return await snapshotOrBundledFallbackResult({
+        error: `signed hosted catalog feed must use ${DSSE_ENVELOPE_MEDIA_TYPE}`,
+        snapshotStore,
+        url: url.href,
+        metadata: base,
+        expectedSha256,
+        ifNoneMatch,
         catalogConfig: params?.catalogConfig,
         requireManifestInstallSourceRef,
         expectedFeedId: source.expectedFeedId,

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -263,10 +263,6 @@ type OfficialExternalProviderContract =
   | "webFetchProviders";
 
 const SUPPORTED_OFFICIAL_EXTERNAL_CATALOG_FEED_SCHEMA_VERSIONS = new Set([1, 2]);
-const officialExternalPluginCatalogEntrySchemaVersions = new WeakMap<
-  OfficialExternalPluginCatalogEntry,
-  number
->();
 export const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL =
   "https://clawhub.ai/v1/feeds/plugins";
 export const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE = "clawhub-public";
@@ -365,13 +361,9 @@ function parseOfficialExternalPluginCatalogEntries(
     return raw.filter((entry): entry is OfficialExternalPluginCatalogEntry => isRecord(entry));
   }
   if (isOfficialExternalPluginCatalogFeed(raw)) {
-    const entries = raw.entries.filter((entry): entry is OfficialExternalPluginCatalogEntry =>
+    return raw.entries.filter((entry): entry is OfficialExternalPluginCatalogEntry =>
       isRecord(entry),
     );
-    for (const entry of entries) {
-      officialExternalPluginCatalogEntrySchemaVersions.set(entry, raw.schemaVersion);
-    }
-    return entries;
   }
   if (!isRecord(raw)) {
     return [];
@@ -847,7 +839,7 @@ async function parseHostedCatalogFeedBody(params: {
       );
     }
     return {
-      feed: verification.feed,
+      feed: enforceHostedCatalogFeedInstallAuthority(verification.feed),
       trust: {
         mode: "signed",
         signedBy: verification.signedBy,
@@ -866,7 +858,25 @@ async function parseHostedCatalogFeedBody(params: {
       `hosted catalog feed id "${raw.id}" did not match expected "${params.expectedFeedId}"`,
     );
   }
-  return { feed: raw };
+  return { feed: enforceHostedCatalogFeedInstallAuthority(raw) };
+}
+
+function enforceHostedCatalogFeedInstallAuthority(
+  feed: OfficialExternalPluginCatalogFeed,
+): OfficialExternalPluginCatalogFeed {
+  if (feed.schemaVersion < 2) {
+    return feed;
+  }
+  return {
+    ...feed,
+    entries: feed.entries.map((entry) => {
+      const state = normalizeOptionalString(entry.state);
+      const publisherTrust = normalizeOptionalString(entry.publisher?.trust);
+      return state === "available" && publisherTrust === "official"
+        ? entry
+        : removeOfficialExternalPluginCatalogInstallAuthority(entry);
+    }),
+  };
 }
 
 class HostedCatalogFeedTimestampError extends Error {
@@ -1534,13 +1544,9 @@ export function resolveOfficialExternalPluginInstall(
 ): PluginPackageInstall | null {
   const state = normalizeOptionalString(entry.state);
   const publisherTrust = normalizeOptionalString(entry.publisher?.trust);
-  const feedSchemaVersion = officialExternalPluginCatalogEntrySchemaVersions.get(entry);
-  // Legacy schema-v1 entries inherit the feed's trust. Schema-v2 entries must carry their own
-  // complete authority pair; also fail closed if an unversioned entry declares only one field.
-  if (
-    ((feedSchemaVersion !== undefined && feedSchemaVersion >= 2) || state || publisherTrust) &&
-    (state !== "available" || publisherTrust !== "official")
-  ) {
+  // Legacy schema-v1 entries inherit the feed's trust. Hosted schema-v2 parsing strips install
+  // authority from incomplete entries; also fail closed if an unversioned entry declares one field.
+  if ((state || publisherTrust) && (state !== "available" || publisherTrust !== "official")) {
     return null;
   }
   const manifest = getOfficialExternalPluginCatalogManifest(entry);

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -808,9 +808,11 @@ async function parseHostedCatalogFeedBody(params: {
         `hosted catalog feed id "${verification.feed.id}" did not match expected "${params.expectedFeedId}"`,
       );
     }
-    const generatedAtMs = Date.parse(verification.feed.generatedAt);
+    const generatedAtMs = parseOfficialExternalPluginCatalogTimestamp(
+      verification.feed.generatedAt,
+    );
     const expiresAt = normalizeOptionalString(verification.feed.expiresAt);
-    if (!Number.isFinite(generatedAtMs)) {
+    if (generatedAtMs === undefined) {
       throw new Error("hosted catalog signed feed requires a valid generatedAt value");
     }
     let expired: boolean;
@@ -820,8 +822,8 @@ async function parseHostedCatalogFeedBody(params: {
       }
       expired = true;
     } else {
-      const expiresAtMs = Date.parse(expiresAt);
-      if (!Number.isFinite(expiresAtMs)) {
+      const expiresAtMs = parseOfficialExternalPluginCatalogTimestamp(expiresAt);
+      if (expiresAtMs === undefined) {
         throw new Error("hosted catalog signed feed requires a valid expiresAt value");
       }
       if (expiresAtMs <= generatedAtMs) {

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -263,6 +263,10 @@ type OfficialExternalProviderContract =
   | "webFetchProviders";
 
 const SUPPORTED_OFFICIAL_EXTERNAL_CATALOG_FEED_SCHEMA_VERSIONS = new Set([1, 2]);
+const officialExternalPluginCatalogEntrySchemaVersions = new WeakMap<
+  OfficialExternalPluginCatalogEntry,
+  number
+>();
 export const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL =
   "https://clawhub.ai/v1/feeds/plugins";
 export const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE = "clawhub-public";
@@ -361,9 +365,13 @@ function parseOfficialExternalPluginCatalogEntries(
     return raw.filter((entry): entry is OfficialExternalPluginCatalogEntry => isRecord(entry));
   }
   if (isOfficialExternalPluginCatalogFeed(raw)) {
-    return raw.entries.filter((entry): entry is OfficialExternalPluginCatalogEntry =>
+    const entries = raw.entries.filter((entry): entry is OfficialExternalPluginCatalogEntry =>
       isRecord(entry),
     );
+    for (const entry of entries) {
+      officialExternalPluginCatalogEntrySchemaVersions.set(entry, raw.schemaVersion);
+    }
+    return entries;
   }
   if (!isRecord(raw)) {
     return [];
@@ -1526,9 +1534,13 @@ export function resolveOfficialExternalPluginInstall(
 ): PluginPackageInstall | null {
   const state = normalizeOptionalString(entry.state);
   const publisherTrust = normalizeOptionalString(entry.publisher?.trust);
-  // Legacy schema-v1 entries have neither field and inherit the signed feed's trust. Once an
-  // entry declares either schema-v2 authority field, require the complete fail-closed pair.
-  if ((state || publisherTrust) && (state !== "available" || publisherTrust !== "official")) {
+  const feedSchemaVersion = officialExternalPluginCatalogEntrySchemaVersions.get(entry);
+  // Legacy schema-v1 entries inherit the feed's trust. Schema-v2 entries must carry their own
+  // complete authority pair; also fail closed if an unversioned entry declares only one field.
+  if (
+    ((feedSchemaVersion !== undefined && feedSchemaVersion >= 2) || state || publisherTrust) &&
+    (state !== "available" || publisherTrust !== "official")
+  ) {
     return null;
   }
   const manifest = getOfficialExternalPluginCatalogManifest(entry);

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -486,23 +486,33 @@ function resolveHostedCatalogFeedSource(params: {
     if (!OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST.includes(url.hostname)) {
       throw new Error("hosted catalog feed URL hostname is not allowed");
     }
-    const profileConfig =
+    const defaultProfile =
       explicitProfileName === undefined
+        ? resolveOfficialExternalPluginCatalogProfileConfig(params.catalogConfig).feeds[
+            DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE
+          ]
+        : undefined;
+    const profileName =
+      explicitProfileName ??
+      (defaultProfile && resolveHostedCatalogFeedUrl(defaultProfile.url).href === url.href
+        ? DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE
+        : undefined);
+    const profileConfig =
+      profileName === undefined
         ? undefined
         : resolveOfficialExternalPluginCatalogProfileConfig(
             params.catalogConfig,
-            explicitProfileName === DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE
+            profileName === DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE
               ? params.env
               : undefined,
           );
-    const profile =
-      explicitProfileName === undefined ? undefined : profileConfig?.feeds[explicitProfileName];
-    if (explicitProfileName !== undefined && !profile) {
-      throw new Error(`hosted catalog feed profile "${explicitProfileName}" is not configured`);
+    const profile = profileName === undefined ? undefined : profileConfig?.feeds[profileName];
+    if (profileName !== undefined && !profile) {
+      throw new Error(`hosted catalog feed profile "${profileName}" is not configured`);
     }
     if (profile?.verification?.mode === "signed" && !profile.feedId) {
       throw new HostedCatalogTrustConfigurationError(
-        `signed hosted catalog feed profile "${explicitProfileName}" requires feedId`,
+        `signed hosted catalog feed profile "${profileName}" requires feedId`,
       );
     }
     return {
@@ -1525,7 +1535,10 @@ export function resolveOfficialExternalPluginInstall(
   params?: { catalogConfig?: OfficialExternalPluginCatalogProfileConfig },
 ): PluginPackageInstall | null {
   const state = normalizeOptionalString(entry.state);
-  if (state && state !== "available") {
+  if (
+    state &&
+    (state !== "available" || normalizeOptionalString(entry.publisher?.trust) !== "official")
+  ) {
     return null;
   }
   const manifest = getOfficialExternalPluginCatalogManifest(entry);

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -27,6 +27,13 @@ class HostedCatalogSnapshotWriteError extends Error {
   }
 }
 
+class HostedCatalogTrustConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "HostedCatalogTrustConfigurationError";
+  }
+}
+
 export type OfficialExternalProviderAuthChoice = {
   method?: string;
   choiceId?: string;
@@ -143,6 +150,7 @@ type OfficialExternalPluginCatalogSourceProfile =
 
 type OfficialExternalPluginCatalogFeedProfile = {
   url: string;
+  feedId?: string;
   verification?: OfficialExternalPluginCatalogFeedVerification;
 };
 
@@ -156,7 +164,7 @@ type OfficialExternalPluginCatalogFeedVerification =
       threshold?: number;
     };
 
-type OfficialExternalPluginCatalogFeedSigningKey = {
+export type OfficialExternalPluginCatalogFeedSigningKey = {
   keyId: string;
   publicKey: string;
 };
@@ -254,15 +262,24 @@ type OfficialExternalProviderContract =
   | "webFetchProviders";
 
 const SUPPORTED_OFFICIAL_EXTERNAL_CATALOG_FEED_SCHEMA_VERSIONS = new Set([1, 2]);
-const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL = "https://clawhub.ai/v1/feeds/plugins";
-const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE = "clawhub-public";
+export const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL =
+  "https://clawhub.ai/v1/feeds/plugins";
+export const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE = "clawhub-public";
+export const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_ID = "clawhub-official";
 const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_SOURCE_REF = "public-clawhub";
 const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_NPM_SOURCE_REF = "public-npm";
+export const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEY_ID_ENV =
+  "OPENCLAW_CLAWHUB_FEED_TRUSTED_KEY_ID";
+export const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_PUBLIC_KEY_ENV =
+  "OPENCLAW_CLAWHUB_FEED_TRUSTED_PUBLIC_KEY";
+export const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEYS: readonly OfficialExternalPluginCatalogFeedSigningKey[] =
+  [];
 const DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_PROFILE_CONFIG: OfficialExternalPluginCatalogProfileConfig =
   {
     feeds: {
       [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE]: {
         url: DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL,
+        feedId: DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_ID,
       },
     },
     sources: {
@@ -387,12 +404,52 @@ function resolveHostedCatalogFeedUrl(raw: string): URL {
   return parsed;
 }
 
+function resolveDefaultClawHubFeedVerificationFromEnv(
+  env?: NodeJS.ProcessEnv,
+): OfficialExternalPluginCatalogFeedVerification | undefined {
+  const keyId = normalizeOptionalString(
+    env?.[DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEY_ID_ENV],
+  );
+  const publicKey = normalizeOptionalString(
+    env?.[DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_PUBLIC_KEY_ENV],
+  );
+  if (!keyId && !publicKey) return undefined;
+  if (!keyId || !publicKey) {
+    throw new HostedCatalogTrustConfigurationError(
+      "default ClawHub feed trust requires both key id and public key env vars",
+    );
+  }
+  return {
+    mode: "signed",
+    keys: [{ keyId, publicKey }],
+  };
+}
+
 function resolveOfficialExternalPluginCatalogProfileConfig(
   config?: OfficialExternalPluginCatalogProfileConfig,
+  env?: NodeJS.ProcessEnv,
 ): Required<OfficialExternalPluginCatalogProfileConfig> {
+  const envVerification = resolveDefaultClawHubFeedVerificationFromEnv(env);
+  const bundledVerification =
+    DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEYS.length > 0
+      ? {
+          mode: "signed" as const,
+          keys: DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_CLAWHUB_TRUSTED_KEYS,
+        }
+      : undefined;
+  const defaultVerification = envVerification ?? bundledVerification;
+  const defaultFeed = DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_PROFILE_CONFIG.feeds?.[
+    DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE
+  ] ?? {
+    url: DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_URL,
+    feedId: DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_ID,
+  };
   return {
     feeds: {
-      ...DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_PROFILE_CONFIG.feeds,
+      [DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE]: {
+        ...defaultFeed,
+        ...(defaultVerification ? { verification: defaultVerification } : {}),
+      },
       ...config?.feeds,
     },
     sources: {
@@ -406,12 +463,13 @@ function resolveHostedCatalogFeedSource(params: {
   feedUrl?: string;
   feedProfile?: string;
   catalogConfig?: OfficialExternalPluginCatalogProfileConfig;
+  env?: NodeJS.ProcessEnv;
 }): {
   url: URL;
   hostnameAllowlist: string[];
+  expectedFeedId?: string;
   verification?: OfficialExternalPluginCatalogFeedVerification;
 } {
-  const profileConfig = resolveOfficialExternalPluginCatalogProfileConfig(params.catalogConfig);
   const explicitFeedUrl = normalizeOptionalString(params.feedUrl);
   const explicitProfileName = normalizeOptionalString(params.feedProfile);
   if (explicitFeedUrl) {
@@ -419,21 +477,43 @@ function resolveHostedCatalogFeedSource(params: {
     if (!OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST.includes(url.hostname)) {
       throw new Error("hosted catalog feed URL hostname is not allowed");
     }
+    const profileConfig =
+      explicitProfileName === undefined
+        ? undefined
+        : resolveOfficialExternalPluginCatalogProfileConfig(
+            params.catalogConfig,
+            params.catalogConfig?.feeds?.[explicitProfileName] ? undefined : params.env,
+          );
     const profile =
-      explicitProfileName === undefined ? undefined : profileConfig.feeds[explicitProfileName];
+      explicitProfileName === undefined ? undefined : profileConfig?.feeds[explicitProfileName];
     if (explicitProfileName !== undefined && !profile) {
       throw new Error(`hosted catalog feed profile "${explicitProfileName}" is not configured`);
+    }
+    if (profile?.verification?.mode === "signed" && !profile.feedId) {
+      throw new HostedCatalogTrustConfigurationError(
+        `signed hosted catalog feed profile "${explicitProfileName}" requires feedId`,
+      );
     }
     return {
       url,
       hostnameAllowlist: OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST,
+      ...(profile?.feedId ? { expectedFeedId: profile.feedId } : {}),
       ...(profile?.verification ? { verification: profile.verification } : {}),
     };
   }
   const profileName = explicitProfileName ?? DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE;
+  const profileConfig = resolveOfficialExternalPluginCatalogProfileConfig(
+    params.catalogConfig,
+    params.catalogConfig?.feeds?.[profileName] ? undefined : params.env,
+  );
   const profile = profileConfig.feeds[profileName];
   if (!profile) {
     throw new Error(`hosted catalog feed profile "${profileName}" is not configured`);
+  }
+  if (profile.verification?.mode === "signed" && !profile.feedId) {
+    throw new HostedCatalogTrustConfigurationError(
+      `signed hosted catalog feed profile "${profileName}" requires feedId`,
+    );
   }
   const url = resolveHostedCatalogFeedUrl(profile.url);
   return {
@@ -442,6 +522,7 @@ function resolveHostedCatalogFeedSource(params: {
       ...OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST,
       url.hostname,
     ]),
+    ...(profile.feedId ? { expectedFeedId: profile.feedId } : {}),
     verification: profile.verification,
   };
 }
@@ -677,6 +758,7 @@ function emptyBundledFallbackResult(error: unknown): HostedOfficialExternalPlugi
 
 async function parseHostedCatalogFeedBody(params: {
   body: string;
+  expectedFeedId?: string;
   verification?: OfficialExternalPluginCatalogFeedVerification;
   verifiedAt: string;
   allowLegacyBetaEnvelope?: boolean;
@@ -706,6 +788,11 @@ async function parseHostedCatalogFeedBody(params: {
       }
       throw new Error(verification.message);
     }
+    if (params.expectedFeedId && verification.feed.id !== params.expectedFeedId) {
+      throw new Error(
+        `hosted catalog feed id "${verification.feed.id}" did not match expected "${params.expectedFeedId}"`,
+      );
+    }
     return {
       feed: verification.feed,
       trust: {
@@ -719,6 +806,11 @@ async function parseHostedCatalogFeedBody(params: {
   }
   if (!isOfficialExternalPluginCatalogFeed(raw)) {
     throw new Error("hosted catalog feed did not match a supported schema version");
+  }
+  if (params.expectedFeedId && raw.id !== params.expectedFeedId) {
+    throw new Error(
+      `hosted catalog feed id "${raw.id}" did not match expected "${params.expectedFeedId}"`,
+    );
   }
   return { feed: raw };
 }
@@ -759,6 +851,7 @@ async function loadHostedCatalogSnapshotResult(params: {
   ifModifiedSince?: string;
   catalogConfig?: OfficialExternalPluginCatalogProfileConfig;
   requireManifestInstallSourceRef?: boolean;
+  expectedFeedId?: string;
   verification?: OfficialExternalPluginCatalogFeedVerification;
 }): Promise<HostedOfficialExternalPluginCatalogLoadResult> {
   assertSnapshotMatchesRequestValidators({
@@ -775,6 +868,7 @@ async function loadHostedCatalogSnapshotResult(params: {
   }
   const parsed = await parseHostedCatalogFeedBody({
     body: params.snapshot.body,
+    expectedFeedId: params.expectedFeedId,
     verification: params.verification,
     verifiedAt: params.snapshot.trust?.verifiedAt ?? params.snapshot.savedAt,
     allowLegacyBetaEnvelope: true,
@@ -841,6 +935,7 @@ async function snapshotOrBundledFallbackResult(params: {
   ifModifiedSince?: string;
   catalogConfig?: OfficialExternalPluginCatalogProfileConfig;
   requireManifestInstallSourceRef?: boolean;
+  expectedFeedId?: string;
   verification?: OfficialExternalPluginCatalogFeedVerification;
 }): Promise<HostedOfficialExternalPluginCatalogLoadResult> {
   if (params.snapshotStore) {
@@ -855,6 +950,7 @@ async function snapshotOrBundledFallbackResult(params: {
           ifModifiedSince: params.ifModifiedSince,
           catalogConfig: params.catalogConfig,
           requireManifestInstallSourceRef: params.requireManifestInstallSourceRef,
+          expectedFeedId: params.expectedFeedId,
           verification: params.verification,
         });
       }
@@ -915,6 +1011,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
   let source: {
     url: URL;
     hostnameAllowlist: string[];
+    expectedFeedId?: string;
     verification?: OfficialExternalPluginCatalogFeedVerification;
   };
   try {
@@ -922,9 +1019,12 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
       feedUrl: params?.feedUrl,
       feedProfile: params?.feedProfile,
       catalogConfig: params?.catalogConfig,
+      env: params?.env ?? process.env,
     });
   } catch (err) {
-    return bundledFallbackResult(err);
+    return err instanceof HostedCatalogTrustConfigurationError
+      ? emptyBundledFallbackResult(err)
+      : bundledFallbackResult(err);
   }
   const { url } = source;
   const snapshotStore = await resolveHostedCatalogSnapshotStore({
@@ -947,6 +1047,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
       expectedSha256,
       catalogConfig: params?.catalogConfig,
       requireManifestInstallSourceRef,
+      expectedFeedId: source.expectedFeedId,
       verification: source.verification,
     });
   }
@@ -997,6 +1098,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         ifModifiedSince,
         catalogConfig: params?.catalogConfig,
         requireManifestInstallSourceRef,
+        expectedFeedId: source.expectedFeedId,
         verification: source.verification,
       });
     }
@@ -1011,6 +1113,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         ifModifiedSince,
         catalogConfig: params?.catalogConfig,
         requireManifestInstallSourceRef,
+        expectedFeedId: source.expectedFeedId,
         verification: source.verification,
       });
     }
@@ -1033,12 +1136,14 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         ifModifiedSince,
         catalogConfig: params?.catalogConfig,
         requireManifestInstallSourceRef,
+        expectedFeedId: source.expectedFeedId,
         verification: source.verification,
       });
     }
     const verifiedAt = (params?.now?.() ?? new Date()).toISOString();
     const parsed = await parseHostedCatalogFeedBody({
       body,
+      expectedFeedId: source.expectedFeedId,
       verification: source.verification,
       verifiedAt,
     }).catch(async (err: unknown) => {
@@ -1052,6 +1157,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         ifModifiedSince,
         catalogConfig: params?.catalogConfig,
         requireManifestInstallSourceRef,
+        expectedFeedId: source.expectedFeedId,
         verification: source.verification,
       });
     });
@@ -1067,6 +1173,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
             : (
                 await parseHostedCatalogFeedBody({
                   body: currentSnapshot.body,
+                  expectedFeedId: source.expectedFeedId,
                   verification: source.verification,
                   verifiedAt: currentSnapshot.trust.verifiedAt,
                   allowLegacyBetaEnvelope: true,
@@ -1088,6 +1195,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
           throw new HostedCatalogSignedFeedMonotonicityError(
             "hosted catalog signed feed sequence is older than current snapshot",
           );
+        }
         }
       }
     }
@@ -1142,6 +1250,7 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
       ifModifiedSince,
       catalogConfig: params?.catalogConfig,
       requireManifestInstallSourceRef,
+      expectedFeedId: source.expectedFeedId,
       verification: source.verification,
     });
   } finally {

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -510,11 +510,6 @@ function resolveHostedCatalogFeedSource(params: {
     if (profileName !== undefined && !profile) {
       throw new Error(`hosted catalog feed profile "${profileName}" is not configured`);
     }
-    if (profile?.verification?.mode === "signed" && !profile.feedId) {
-      throw new HostedCatalogTrustConfigurationError(
-        `signed hosted catalog feed profile "${profileName}" requires feedId`,
-      );
-    }
     return {
       url,
       hostnameAllowlist: OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST,
@@ -530,11 +525,6 @@ function resolveHostedCatalogFeedSource(params: {
   const profile = profileConfig.feeds[profileName];
   if (!profile) {
     throw new Error(`hosted catalog feed profile "${profileName}" is not configured`);
-  }
-  if (profile.verification?.mode === "signed" && !profile.feedId) {
-    throw new HostedCatalogTrustConfigurationError(
-      `signed hosted catalog feed profile "${profileName}" requires feedId`,
-    );
   }
   const url = resolveHostedCatalogFeedUrl(profile.url);
   return {


### PR DESCRIPTION
<!-- feed-stack:start -->
## Feed stack — OpenClaw trust foundation

**Can review and merge now, in parallel with ClawHub #3005.**  
**Required before:** #110250 (sharded consumer) and production signing activation.

This PR defines and hardens the trust/identity/expiry contract but intentionally does not bundle a production key or activate the default signed feed. Key handoff and activation remain a separate proof-backed operation after the code stack lands.
<!-- feed-stack:end -->

## Summary - bind the built-in `clawhub-public` profile to payload identity `clawhub-official`, preserving built-in/environment trust when the profile is customized - keep existing custom signed profiles without `feedId` operational during the staged rollout; new profiles can opt into identity binding now - support paired key-id/public-key environment overrides and fail closed before fetch when the pair is incomplete - enforce the signed DSSE HTTP contract, payload expiry, monotonic rollback/equivocation protection, and snapshot re-verification - keep expired or legacy no-expiry snapshots visible while stripping install authority - require schema-v2 entries to declare the complete `available` + `official` install-authority pair before overlays or clones - document trusted-key distribution and the non-inventing Doctor migration requirement for the separately landing feed-profile config surface  ## Dependencies - merged envelope compatibility policy: https://github.com/openclaw/openclaw/pull/110037 - merged signed snapshot key rotation: https://github.com/openclaw/openclaw/pull/108342 - ClawHub stored-catalog signer and key-management tooling: https://github.com/openclaw/clawhub/pull/3005 - corrected hosted-feed v1 specs: https://github.com/openclaw/rfcs/pull/39  ## Rollout policy The built-in `clawhub-public` profile is identity-bound immediately. Existing custom signed profiles that omit `feedId` retain signature verification without payload-identity binding during the transition. The separately landing user-facing profile configuration must diagnose the missing value and ask the operator to supply it; Doctor must not infer a feed identity from its URL.  This PR intentionally does not invent or bundle a production key. ClawHub must generate and retain the Ed25519 private key in deployment secret storage and hand OpenClaw the matching public key and key ID. Bundling that trust root and activating the production default remain a separate proof-backed change.  ## Validation - `node scripts/run-vitest.mjs src/plugins/official-external-plugin-catalog-envelope.test.ts src/plugins/official-external-plugin-catalog.test.ts --run`: 74 passed, including SQLite snapshot/rotation cases on Node 24.15 - changed-file `oxfmt`, type-aware `oxlint`, and `git diff --check`: passed - `codex review --base upstream/main` at `51552f0ee4f`: no actionable correctness findings  ## Real behavior proof  Behavior addressed: A customized built-in profile could lose default trust; signed authority lacked a complete expiry and HTTP contract; legacy snapshots could interfere with rollback state; and schema-v2 manifest fallback could bypass entry-level install authority.  Environment tested: WSL Ubuntu with Node 24.15, generated Ed25519 keys, HTTP response fixtures, in-memory snapshots, and the real SQLite snapshot store.  Proof covered: 1. Built-in trust inheritance, explicit unsigned downgrade, incomplete-env failure, and cross-feed replay rejection. 2. Standard DSSE live responses, snapshot-only beta compatibility, ETag-based 304 re-verification, expiry, rollback, equivocation, and key rotation. 3. Expired and no-expiry snapshots remain visible but non-installable. 4. Legacy custom signed profiles without `feedId` work through configured and explicit-URL paths. 5. Schema-v2 entries missing either or both authority fields lose install authority before catalog overlays.  Not yet tested: The production ClawHub signer and bundled public trust root. Those do not exist in this branch and are intentionally reserved for the separate activation proof.  ## Maintainer decision  Approved to merge this as staged trust-binding enforcement before production ClawHub signing-key activation proof. This branch identity-binds the built-in `clawhub-public` profile, preserves the documented legacy custom signed-profile transition, and keeps the production public trust root plus signer activation as a separate proof-backed change. Before that later activation, ClawHub must provide the signing implementation/key handoff and OpenClaw must receive redacted production-equivalent refresh proof for the default path.  