### PR TITLE
fix(agents): keep compact tokens whole in keyed multi-question answers (#101722)

### DIFF
--- a/src/agents/harness/user-input-bridge.test.ts
+++ b/src/agents/harness/user-input-bridge.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Regression tests for multi-question user-input answer parsing. The keyed
+ * parser must route explicit `key: value` answers without splitting ordinary
+ * answers that happen to contain ":" or "=" (times, URLs, paths, key=value).
+ */
+import { describe, expect, it } from "vitest";
+import {
+  buildAgentHarnessUserInputAnswers,
+  type AgentHarnessUserInputQuestion,
+} from "./user-input-bridge.js";
+
+const timeQuestions: readonly AgentHarnessUserInputQuestion[] = [
+  { id: "start", header: "Start", question: "Start time?", isOther: true },
+  { id: "end", header: "End", question: "End time?", isOther: true },
+];
+
+describe("buildAgentHarnessUserInputAnswers", () => {
+  it("keeps positional time answers whole instead of splitting at the colon", () => {
+    expect(buildAgentHarnessUserInputAnswers(timeQuestions, "1:30\n2:45")).toEqual({
+      answers: {
+        start: { answers: ["1:30"] },
+        end: { answers: ["2:45"] },
+      },
+    });
+  });
+
+  it("routes keyed answers whose value itself contains a colon", () => {
+    expect(buildAgentHarnessUserInputAnswers(timeQuestions, "end: 2:45\nstart: 1:30")).toEqual({
+      answers: {
+        start: { answers: ["1:30"] },
+        end: { answers: ["2:45"] },
+      },
+    });
+  });
+
+  it("still supports answering by 1-based position number", () => {
+    expect(buildAgentHarnessUserInputAnswers(timeQuestions, "1: 1:30\n2: 2:45")).toEqual({
+      answers: {
+        start: { answers: ["1:30"] },
+        end: { answers: ["2:45"] },
+      },
+    });
+  });
+
+  it("routes hyphenated question keys without splitting at the hyphen", () => {
+    const questions: readonly AgentHarnessUserInputQuestion[] = [
+      { id: "auth-method", header: "Auth Method", question: "Which auth?", isOther: true },
+      { id: "note", header: "Note", question: "Anything else?", isOther: true },
+    ];
+    expect(buildAgentHarnessUserInputAnswers(questions, "auth-method: oauth\nnote: none")).toEqual({
+      answers: {
+        "auth-method": { answers: ["oauth"] },
+        note: { answers: ["none"] },
+      },
+    });
+  });
+
+  it("keeps positional answers containing URLs and paths intact", () => {
+    const questions: readonly AgentHarnessUserInputQuestion[] = [
+      { id: "url", header: "URL", question: "Endpoint?", isOther: true },
+      { id: "path", header: "Path", question: "Config path?", isOther: true },
+    ];
+    expect(
+      buildAgentHarnessUserInputAnswers(questions, "https://example.com\nC:\\Users\\foo"),
+    ).toEqual({
+      answers: {
+        url: { answers: ["https://example.com"] },
+        path: { answers: ["C:\\Users\\foo"] },
+      },
+    });
+  });
+});

--- a/src/agents/harness/user-input-bridge.ts
+++ b/src/agents/harness/user-input-bridge.ts
@@ -90,9 +90,7 @@ export function buildAgentHarnessUserInputAnswers(
   }
 
   const keyed = parseKeyedAnswers(inputText);
-  const fallbackLines = inputText
-    .split(/\r?\n/)
-    .map((line) => line.trim());
+  const fallbackLines = inputText.split(/\r?\n/).map((line) => line.trim());
   questions.forEach((question, index) => {
     const key =
       keyed.get(question.id.toLowerCase()) ??
@@ -130,7 +128,12 @@ export function normalizeAgentHarnessUserInputAnswer(
 function parseKeyedAnswers(inputText: string): Map<string, string> {
   const answers = new Map<string, string>();
   for (const line of inputText.split(/\r?\n/)) {
-    const match = line.match(/^\s*([^:=-]+?)\s*[:=-]\s*(.+?)\s*$/);
+    // A keyed answer separates the key from its value with whitespace, like
+    // "mode: deep" or "2: fast". Compact tokens such as "14:30", "https://x",
+    // "C:\\path", or "key=value" have no separating space, so they stay whole
+    // ordinary answers instead of being split at the first delimiter. "-" is
+    // not a delimiter: it is common inside answers and hyphenated keys.
+    const match = line.match(/^\s*([^:=]+?)\s*[:=]\s+(.+?)\s*$/);
     if (!match) {
       continue;
     }


### PR DESCRIPTION
Closes #101722

## What Problem This Solves

Fixes an issue where a user answering a multi-question agent prompt would have
their answer silently corrupted when it contained a colon, equals, or hyphen.
For example, replying with a time like `1:30` to the first of several questions
made the agent receive `30`; a hyphenated labeled answer like `auth-method:
oauth` was dropped and the raw line was passed through instead of `oauth`. The
agent then acted on truncated/garbled input.

## Why This Change Was Made

The multi-question parser (`parseKeyedAnswers` in
`src/agents/harness/user-input-bridge.ts`) split every reply line at the first
`:`, `=`, or `-`, then routed the fragment by the leading token — including the
question's 1-based index, so `1:30` became key `1` / value `30` and was routed
to question 1. The fix makes a line count as a labeled answer only when the
`key:`/`key=` delimiter is followed by whitespace (the same rule YAML and TOML
use), and drops `-` as a delimiter. Explicit labels (`header: value`, `2:
fast`) still route; compact tokens (`14:30`, `https://x`, `C:\path`,
`key=value`) stay whole ordinary answers. Hyphenated keys (`auth-method:`) now
match instead of splitting at the hyphen.

## User Impact

Users replying to multi-question prompts can include times, URLs, file paths,
version strings, `key=value` snippets, and hyphenated text in their answers
without the first delimiter truncating the value. Explicit `header: value` and
`N: value` labeling continue to work.

## Evidence

Focused regression tests added in
`src/agents/harness/user-input-bridge.test.ts` (5 cases) plus the existing
`agent-harness-runtime.test.ts` suite (16 cases) pass locally via
`node scripts/run-vitest.mjs run`.

Real behavior proof — drove the actual production function
`buildAgentHarnessUserInputAnswers` (no reimplementation) before and after the
patch, same inputs:

```
BEFORE (current main)                       AFTER (this PR)
input "1:30\n2:45"  (two questions)
  start => ["30"]    end => ["45"]   ❌      start => ["1:30"]  end => ["2:45"]  ✅
input "auth-method: oauth\nnote: none"
  auth-method => ["auth-method: oauth"] ❌   auth-method => ["oauth"]  note => ["none"] ✅
input "https://example.com\nC:\\Users\\foo"
  url => ["https://example.com"]  ✅         url => ["https://example.com"]  ✅  (unchanged)
input "start: 1:30\nend: 2:45"   (explicit labels, must still route)
  start => ["1:30"]  end => ["2:45"] ✅      start => ["1:30"]  end => ["2:45"] ✅
input "1: 1:30\n2: 2:45"   (answer by position number, must still route)
  start => ["1:30"]  end => ["2:45"] ✅      start => ["1:30"]  end => ["2:45"] ✅
```

Setup: `pnpm install` on a clean checkout at the PR head, ran the repro with
`tsx` importing the source module directly; toggled the one-line regex change
with `git stash` to capture the before/after columns above.

Not tested end-to-end through a live channel (the parser is channel-agnostic
core; the proof exercises it directly).

---

AI-assisted: written with Claude Code. The before/after evidence above is from
running the real function locally, not AI-generated test output.
