### PR TITLE
refactor(qa-lab): localize evidence summary schemas

### DIFF
--- a/extensions/qa-lab/src/evidence-summary.ts
+++ b/extensions/qa-lab/src/evidence-summary.ts
@@ -182,7 +182,7 @@ const qaEvidenceResultSchema = z
 
 const qaEvidencePostureSchema = z.enum(["direct-gateway", "native-approval", "user-path"]);
 
-export const qaEvidenceSummaryEntrySchema = z
+const qaEvidenceSummaryEntrySchema = z
   .object({
     test: qaEvidenceTestSchema,
     coverage: z.array(qaEvidenceCoverageSchema),
@@ -194,7 +194,7 @@ export const qaEvidenceSummaryEntrySchema = z
   })
   .strict();
 
-export const qaEvidenceSummarySchema = z
+const qaEvidenceSummarySchema = z
   .object({
     kind: z.literal(QA_EVIDENCE_SUMMARY_KIND),
     schemaVersion: z.literal(QA_EVIDENCE_SUMMARY_SCHEMA_VERSION),
@@ -206,7 +206,7 @@ export const qaEvidenceSummarySchema = z
   })
   .strict();
 
-export type QaEvidenceProfile = z.infer<typeof qaEvidenceProfileIdSchema>;
+type QaEvidenceProfile = z.infer<typeof qaEvidenceProfileIdSchema>;
 export type QaEvidenceStatus = z.infer<typeof qaEvidenceStatusSchema>;
 export type QaEvidenceTiming = z.infer<typeof qaEvidenceTimingSchema>;
 export type QaEvidencePackageSource = z.infer<typeof qaEvidencePackageSourceSchema>;


### PR DESCRIPTION
## What Problem This Solves

QA Lab's evidence summary module exported two Zod schemas and one inferred profile type that have no repository consumers and are not part of the extension's supported API barrel.

## Why This Change Was Made

Keep those declarations private to their owning module while preserving the exported derived summary types and all runtime validation behavior.

## User Impact

None. This is an internal dead-code/API-surface cleanup with no runtime or schema-shape change.

## Evidence

- Codebase-memory graph refreshed from the full worktree: 281,363 nodes / 1,133,845 edges.
- Repository-wide symbol search found no external consumers for the three removed exports.
- `pnpm check:changed` passed on Blacksmith Testbox `tbx_01kwztevdpjcffrcb2frhdecfw`.
- `pnpm test:serial extensions/qa-lab/src/evidence-summary.test.ts` passed: 1 file, 14 tests.
- `pnpm build` passed on the same Testbox.
- Fresh local autoreview: clean, confidence 0.89.
- Fresh branch autoreview: clean, confidence 0.86.
