### PR TITLE
fix(gateway): pass authProfileStore through loopback MCP bridge for OAuth-only plugin tools

### DIFF
--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -720,6 +720,7 @@ export async function prepareCliRunContext(
             sourceReplyDeliveryMode: bindingSourceReplyDeliveryMode,
             requireExplicitMessageTarget: bindingRequireExplicitMessageTarget,
             senderIsOwner: undefined,
+            authProfileStore: authStore,
           }).tools
         : [];
     const promptToolNamesHash =

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -1,5 +1,6 @@
 // MCP loopback runtime scope cache.
 // Resolves Gateway-visible tools for MCP clients with short-lived schema caching.
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import type { SourceReplyDeliveryMode } from "../auto-reply/get-reply-options.types.js";
 import type { InboundEventKind } from "../channels/inbound-event/kind.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -41,6 +42,7 @@ type McpLoopbackScopeParams = {
   sourceReplyDeliveryMode: SourceReplyDeliveryMode | undefined;
   requireExplicitMessageTarget?: boolean;
   senderIsOwner: boolean | undefined;
+  authProfileStore?: AuthProfileStore;
 };
 
 /** Resolves loopback-visible tools after applying gateway scope and native-tool exclusions. */
@@ -52,6 +54,7 @@ export function resolveMcpLoopbackScopedTools(params: McpLoopbackScopeParams): {
     ...params,
     surface: "loopback",
     excludeToolNames: NATIVE_TOOL_EXCLUDE,
+    authProfileStore: params.authProfileStore,
   });
   return {
     agentId: scoped.agentId,

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -149,7 +149,7 @@ import {
   recordMcpLoopbackToolCallResult,
   waitForMcpLoopbackToolCallCaptureIdle,
 } from "./mcp-http.loopback-runtime.js";
-import { McpLoopbackToolCache } from "./mcp-http.runtime.js";
+import { McpLoopbackToolCache, resolveMcpLoopbackScopedTools } from "./mcp-http.runtime.js";
 
 let server: Awaited<ReturnType<typeof startMcpLoopbackServer>> | undefined;
 
@@ -2157,6 +2157,28 @@ describe("mcp loopback server", () => {
       fetchSite: "cross-site",
       status: 200,
     });
+  });
+
+  it("passes authProfileStore through to resolveGatewayScopedTools", () => {
+    const mockStore = { profiles: {} } as never;
+    resolveMcpLoopbackScopedTools({
+      cfg: { session: { mainKey: "main" } } as never,
+      sessionKey: "agent:main:session-1",
+      messageProvider: "telegram",
+      currentChannelId: "telegram:chat123",
+      currentThreadTs: undefined,
+      currentMessageId: undefined,
+      currentInboundAudio: undefined,
+      inboundEventKind: "room_event",
+      sourceReplyDeliveryMode: undefined,
+      accountId: undefined,
+      senderIsOwner: undefined,
+      authProfileStore: mockStore,
+    });
+
+    expect(resolveGatewayScopedToolsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ authProfileStore: mockStore }),
+    );
   });
 });
 

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -1,4 +1,3 @@
-// Gateway-scoped tool resolution for HTTP and loopback tool surfaces.
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import {
   resolveEffectiveToolPolicy,
@@ -6,6 +5,8 @@ import {
   resolveInheritedToolPolicyForSession,
   resolveSubagentToolPolicyForSession,
 } from "../agents/agent-tools.policy.js";
+// Gateway-scoped tool resolution for HTTP and loopback tool surfaces.
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import { createOpenClawTools } from "../agents/openclaw-tools.js";
 import {
   isSubagentEnvelopeSession,
@@ -65,6 +66,7 @@ export function resolveGatewayScopedTools(params: {
   excludeToolNames?: Iterable<string>;
   disablePluginTools?: boolean;
   gatewayRequestedTools?: string[];
+  authProfileStore?: AuthProfileStore;
 }) {
   const {
     agentId,
@@ -188,6 +190,7 @@ export function resolveGatewayScopedTools(params: {
     allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
     allowMediaInvokeCommands: params.allowMediaInvokeCommands,
     disablePluginTools: params.disablePluginTools,
+    authProfileStore: params.authProfileStore,
     wrapBeforeToolCallHook: false,
     config: params.cfg,
     workspaceDir,


### PR DESCRIPTION
## What Problem This Solves

Fixes #101967: The loopback MCP bridge resolved tools without the auth profile store, so OAuth-only provider tools (e.g. xAI `x_search`/`code_execution`) never registered for CLI-backend (claude-cli) sessions.

## Why This Change Was Made

Added `authProfileStore` to `McpLoopbackScopeParams` and threaded it through `resolveGatewayScopedTools`, matching the pattern used by other tool resolution paths. The fix touches three call sites:

- **`mcp-http.runtime.ts`** — accept `authProfileStore` in the loopback scope params
- **`tool-resolution.ts`** — pipe `authProfileStore` through `resolveGatewayScopedTools`
- **`prepare.ts`** — pass the loaded `authStore` when resolving loopback tools

## Why This Is Better Than #101982

PR #101982 applies the same plumbing fix but adds **no regression test**. This PR includes a focused regression test in `mcp-http.test.ts` that verifies `authProfileStore` is passed through to `resolveGatewayScopedTools` when `resolveMcpLoopbackScopedTools` is called.

## Evidence

- [x] `pnpm test src/gateway/mcp-http.test.ts` — 276 tests pass
- [x] `pnpm test src/agents/cli-runner/prepare.test.ts` — 64 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)