### PR TITLE
refactor(qa-lab): localize utility types

### DIFF
--- a/extensions/qa-lab/src/child-output.ts
+++ b/extensions/qa-lab/src/child-output.ts
@@ -2,14 +2,14 @@
 export const QA_CHILD_STDOUT_MAX_BYTES = 1024 * 1024;
 export const QA_CHILD_STDERR_TAIL_BYTES = 64 * 1024;
 
-export type QaChildOutputCapture = {
+type QaChildOutputCapture = {
   chunks: Buffer[];
   bytes: number;
   exceeded: boolean;
   maxBytes: number;
 };
 
-export type QaChildOutputTail = {
+type QaChildOutputTail = {
   buffer: Buffer;
   maxBytes: number;
   truncated: boolean;

--- a/extensions/qa-lab/src/errors.ts
+++ b/extensions/qa-lab/src/errors.ts
@@ -1,5 +1,5 @@
 // Qa Lab plugin module defines shared suite errors.
-export type QaSuiteArtifactErrorCode =
+type QaSuiteArtifactErrorCode =
   | "evidence_missing"
   | "report_missing"
   | "summary_missing"
@@ -18,7 +18,7 @@ export class QaSuiteArtifactError extends Error {
   }
 }
 
-export type QaSuiteInfraErrorCode =
+type QaSuiteInfraErrorCode =
   | "agent_wait_failed"
   | "gateway_startup_unhealthy"
   | "gateway_ready_timeout"


### PR DESCRIPTION
## What Problem This Solves

QA Lab exported four implementation-only type aliases from its child-output and shared-error modules even though they have no repository consumers and are not part of the supported API barrel.

## Why This Change Was Made

Keep those utility types private to their owning modules while preserving the exported runtime helpers, error classes, and behavior.

## User Impact

None. This is an internal TypeScript API-surface cleanup with no runtime change.

## Evidence

- Codebase-memory graph refreshed from the fresh full worktree: 281,363 nodes / 1,134,333 edges.
- MCP and repository-wide symbol searches found no external consumers for the four removed exports.
- `pnpm check:changed` passed on Blacksmith Testbox `tbx_01kwzvadn6tbw54ze3tyzgyft0`.
- Focused patched suites passed: 3 files, 107 tests.
- A wider four-file run passed 196/197 tests; the lone `cli.runtime.test.ts` Crabline taxonomy expectation failure reproduces on pristine current `origin/main`.
- `pnpm build` passed on the same Testbox with the patch applied.
- Fresh local autoreview: clean, confidence 0.90.
- Fresh branch autoreview: clean, confidence 0.90.
