### PR TITLE
fix(agents): align TOOL_RESULT_CHARS_PER_TOKEN with ESTIMATED_CHARS_PER_TOKEN

### DIFF
--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
@@ -266,14 +266,14 @@ describe("preemptive-compaction", () => {
       prompt: "continue",
     });
 
-    expect(estimatedPromptTokens).toBeGreaterThan(80_000);
+    expect(estimatedPromptTokens).toBeGreaterThan(40_000);
 
     const result = shouldPreemptivelyCompactBeforePrompt({
       messages,
       systemPrompt: "sys",
       prompt: "continue",
-      contextTokenBudget: 96_000,
-      reserveTokens: 20_000,
+      contextTokenBudget: 52_000,
+      reserveTokens: 5_000,
     });
 
     expect(result.route).not.toBe("fits");
@@ -300,7 +300,7 @@ describe("preemptive-compaction", () => {
     expect(estimatedPromptTokens).toBeGreaterThan(30_000);
   });
 
-  it("prechecks a regression-sized synthetic tool-heavy transcript as over budget", () => {
+  it("prechecks a regression-sized synthetic tool-heavy transcript as within the prompt budget", () => {
     const toolResultCharsPerMessage = Math.ceil(427_000 / 120);
     const generalCharsPerMessage = Math.ceil((503_000 - 427_000) / 121);
     const messages: AgentMessage[] = [];
@@ -325,10 +325,10 @@ describe("preemptive-compaction", () => {
       reserveTokens: 32_000,
     });
 
-    expect(result.estimatedPromptTokens).toBeGreaterThan(200_000);
+    expect(result.estimatedPromptTokens).toBeLessThan(168_000);
     expect(result.promptBudgetBeforeReserve).toBe(168_000);
-    expect(result.route).not.toBe("fits");
-    expect(result.overflowTokens).toBeGreaterThan(0);
+    expect(result.route).toBe("fits");
+    expect(result.overflowTokens).toBe(0);
   });
 
   it("caps reserve tokens so small context models keep usable prompt budget", () => {
@@ -517,7 +517,7 @@ describe("preemptive-compaction", () => {
     expect(aboveCutoff - belowCutoff).toBeLessThanOrEqual(2);
   });
 
-  it("keeps the conservative ratio for non-CJK tool results", () => {
+  it("uses the normal text ratio for non-CJK tool results", () => {
     const latinText = "alpha beta gamma delta epsilon ".repeat(1000);
     const toolResultTokens = estimateLlmBoundaryTokenPressure({
       messages: [makeToolResultMessage(latinText)],
@@ -530,8 +530,7 @@ describe("preemptive-compaction", () => {
       prompt: "continue",
     });
 
-    expect(toolResultTokens).toBeGreaterThan(assistantTokens * 1.5);
-    expect(toolResultTokens).toBeLessThan(assistantTokens * 2.5);
+    expect(Math.abs(toolResultTokens - assistantTokens)).toBeLessThanOrEqual(5);
   });
 
   it("applies the CJK-aware ratio to JSON tool-result payloads", () => {
@@ -583,5 +582,35 @@ describe("preemptive-compaction", () => {
     });
 
     expect(Number.isFinite(result.estimatedPromptTokens)).toBe(true);
+  });
+
+  it("does not false-positive overflow for a tool-result-heavy turn within the context window (#101929)", () => {
+    // The reporter's scenario: ~250k chars of tool result text across ~20
+    // tool-result messages on a 200k context window with 50k reserve tokens.
+    // With TOOL_RESULT_CHARS_PER_TOKEN=4 the estimate stays comfortably below
+    // the 150k prompt budget (200k − 50k), where TOOL_RESULT_CHARS_PER_TOKEN=2
+    // produced ~162k estimated tokens → false-positive overflow.
+    const toolCharsPerMessage = Math.ceil(250_000 / 20);
+    const messages: AgentMessage[] = [];
+    for (let i = 0; i < 43; i += 1) {
+      if (i % 2 === 0) {
+        messages.push(makeToolResultMessage("x".repeat(toolCharsPerMessage)));
+      } else {
+        messages.push(makeAssistantHistory("y".repeat(500)));
+      }
+    }
+
+    const result = shouldPreemptivelyCompactBeforePrompt({
+      messages,
+      systemPrompt: "sys",
+      prompt: "continue",
+      contextTokenBudget: 200_000,
+      reserveTokens: 50_000,
+    });
+
+    expect(result.estimatedPromptTokens).toBeLessThan(150_000);
+    expect(result.route).toBe("fits");
+    expect(result.shouldCompact).toBe(false);
+    expect(result.overflowTokens).toBe(0);
   });
 });

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
@@ -24,7 +24,7 @@ export const PREEMPTIVE_OVERFLOW_ERROR_TEXT =
   "Context overflow: prompt too large for the model (precheck).";
 
 const ESTIMATED_CHARS_PER_TOKEN = 4;
-const TOOL_RESULT_CHARS_PER_TOKEN = 2;
+const TOOL_RESULT_CHARS_PER_TOKEN = 4;
 const JSON_PAYLOAD_CHARS_PER_TOKEN = 3;
 const MESSAGE_BOUNDARY_OVERHEAD_TOKENS = 12;
 const CONTENT_BLOCK_OVERHEAD_TOKENS = 6;


### PR DESCRIPTION
## What Problem This Solves

`context-overflow-midturn-precheck` over-estimates tool-result token pressure by ~2x on Latin/ASCII-heavy tool outputs, triggering destructive `truncate_tool_results_only` recovery on turns well within the real context window.
- Problem: `TOOL_RESULT_CHARS_PER_TOKEN = 2` treats tool-result text as twice as token-dense as ordinary text, causing the estimator to fire at ~2.3-2.6x above provider-billed usage
- Solution: Change `TOOL_RESULT_CHARS_PER_TOKEN` from 2 to 4, matching `ESTIMATED_CHARS_PER_TOKEN` used everywhere else in the estimator
- What changed: `src/agents/embedded-agent-runner/run/preemptive-compaction.ts` (one constant), `src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts` (updated thresholds + regression test)
- What did NOT change: `SAFETY_MARGIN` (still 1.2x), `ESTIMATED_CHARS_PER_TOKEN` (unchanged at 4), `JSON_PAYLOAD_CHARS_PER_TOKEN` (unchanged at 3), CJK estimation path (unchanged), tool-result-char-estimator.ts (separate code path, not part of the reported over-count), no import additions or structural changes

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related to #101929
- [x] This PR fixes a bug or regression

## Motivation

Users with `midTurnPrecheck.enabled: true` on tool-result-heavy agent turns experience false-positive overflow detection. The precheck fires `truncate_tool_results_only` recovery that rewrites all prior tool results into tiny stubs, causing the model to re-fetch data it already obtained. This wastes tokens (~3x in the reporter's case), increases latency, and exposes long-running turns to transient provider errors.

The root cause is `TOOL_RESULT_CHARS_PER_TOKEN = 2`, which was set conservatively when the mid-turn precheck was first introduced. Real tokenizers (GPT, Claude) encode English tool-result text at approximately the same 4 chars/token rate as ordinary text.

The separate CJK estimation path (`estimateStringTokenPressure` via `estimateStringChars`) is unaffected because CJK chars are already weighted at 4 chars/code-point, and the `Math.max(conservativeToolResultEstimate, cjkAwareEstimate)` structure ensures the CJK-aware estimate dominates when CJK content is present.

## Evidence

- Behavior addressed: context-overflow-midturn-precheck false-positive on tool-result-heavy turns
- Real environment tested: Ubuntu Linux, Node 22.19, branch fix/midturn-toolresult-ratio-101929
- Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts --run
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-result-context-guard.test.ts --run
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-result-truncation.test.ts --run
npx oxfmt --check src/agents/embedded-agent-runner/run/preemptive-compaction.ts src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
```

- Evidence after fix:

```console
$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts --run
 Test Files  1 passed (1)
      Tests  23 passed (23)

$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-result-context-guard.test.ts --run
 Test Files  1 passed (1)
      Tests  45 passed (45)

$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-result-truncation.test.ts --run
 Test Files  1 passed (1)
      Tests  57 passed (57)

$ npx oxfmt --check src/agents/embedded-agent-runner/run/preemptive-compaction.ts src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
All matched files use the correct format.
```

- Matrix of estimator behavior change:

| Input | Old TOOL_RESULT_CHARS_PER_TOKEN=2 | New TOOL_RESULT_CHARS_PER_TOKEN=4 |
|-------|-----------------------------------|-----------------------------------|
| Latin text tool result (1000 chars) | ~500 tokens | ~250 tokens |
| CJK text tool result | ~500 tokens per 1000 CJK chars | ~500 tokens per 1000 CJK chars (unchanged) |
| JSON tool result payload | ~93k tokens for 120-row payload | ~46.5k tokens (correct density) |
| Reporter scenario (~250k chars, 200k ctx, 50k reserve) | ~162k tokens → false overflow | <150k tokens → fits |

- Observed result after fix:
  1. The new regression test (exact reporter scenario) passes: route=fits, overflowTokens=0
  2. The "regression-sized" synthetic test now correctly routes as "fits" instead of false overflow
  3. The "counts array/object tool-result payloads" test still verifies overflow is detected with a tight budget
  4. Non-CJK tool result text now uses the same density as normal text (= 4 chars/token)
  5. CJK tool result estimation is completely unchanged
  6. All 125 related tests pass with no regressions
- What was not tested: Live end-to-end agent run with a real provider (GPT-5.5 / Claude) to confirm billed usage matches the new estimate — would require a running OpenClaw instance with valid credentials

## Root Cause (if applicable)

`TOOL_RESULT_CHARS_PER_TOKEN = 2` in `estimateToolResultStringTokenPressure()` at `preemptive-compaction.ts:115-118`. Introduced by commit c08400ea7d5 (Jason, 2026-05-22) carrying forward the conservative ratio from the earlier char estimator. Made visible by the mid-turn precheck path (b85147ff7615, marchpure) that surfaces the conservative ratio as a false-positive routing signal.

The estimator also counts over the untruncated in-memory transcript, but for the reporter's 200k context window scenario the aggregate tool-result cap is 400k chars — well above the ~250k chars of tool results — so aggregate projection does not help here. The ratio is the sole fix for this bug.

## User-visible / Behavior Changes

Users running tool-heavy agent sessions with `midTurnPrecheck.enabled: true` should see fewer unnecessary mid-turn context-overflow aborts and compaction retries. Runs that are genuinely over the effective prompt budget still raise the mid-turn precheck signal.

## Security Impact (required)

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Human Verification (required)

- Verified scenarios: Token estimator unit tests (23/23), related agent runner suites (125/125), no regression in tool-result truncation or context guard paths
- Edge cases checked: JSON tool-result payloads, CJK tool result content (unchanged), assistant tool-call arguments, circular reference handling, reserve token capping, message boundary overhead
- What you did NOT verify: Live provider run with real token billing comparison; non-ASCII-encoded tool result edge cases

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- [x] Backward compatible? Yes
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes — changing the constant from 2 to 4 is the minimal, correct fix. The value 4 matches `ESTIMATED_CHARS_PER_TOKEN` used everywhere else in the estimator. The `SAFETY_MARGIN = 1.2` already provides 20% headroom for tokenizer variance. The separate CJK path is unaffected. Aggregate projection alignment (for tool-result payloads >400k chars on a 200k context window) is a potential follow-up enhancement.
- **Refactor needed**: No — the char-based estimator in `tool-result-char-estimator.ts` is a separate code path (context guard, not the token estimator) and not part of the reported over-count.
- **Alternative considered**: Raising to 3 (half-measure, no principled basis). Removing the conservative branch entirely (broader than needed — would change global compaction safety policy). Adding aggregate projection (only helps for >400k chars, not the reporter's scenario, and mixing concerns would repeat the maintainer feedback on #101952).

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes
- **AI prompts / session excerpts**: Analyzed issue #101929 root cause, traced `TOOL_RESULT_CHARS_PER_TOKEN = 2` provenance, evaluated three competing PR approaches, designed focused one-constant fix with regression test

## Risks and Mitigations

- **Highest risk area**: The new 4 chars/token ratio could under-estimate for tool results with very efficient tokenization (e.g. purely numeric content or scripts with high token-compression ratios).
- **Mitigations**: The `SAFETY_MARGIN = 1.2` provides 20% buffer. The `Math.max(conservativeToolResultEstimate, cjkAwareEstimate)` structure preserves the CJK-aware path as a safety net. The `ESTIMATED_CHARS_PER_TOKEN = 4` has been the system-wide default for all non-tool-result text without issues.
- **Compatibility impact**: None — purely internal estimator constant change. No config keys, no API surface, no stored state format change.
