### PR TITLE
fix(cron): skip completed restart catchup slots

### DIFF
--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -2,6 +2,8 @@
 import { describe, expect, it } from "vitest";
 import {
   applyJobPatch,
+  computeJobNextRunAtMs,
+  computeJobPreviousRunAtOrBeforeMs,
   createJob,
   nextWakeAtMs,
   recomputeNextRuns,
@@ -1091,6 +1093,45 @@ describe("cron stagger defaults", () => {
     if (job.schedule.kind === "cron") {
       expect(job.schedule.staggerMs).toBe(DEFAULT_TOP_OF_HOUR_STAGGER_MS);
     }
+  });
+});
+
+describe("computeJobPreviousRunAtOrBeforeMs", () => {
+  function createCronJob(schedule: Extract<CronJob["schedule"], { kind: "cron" }>): CronJob {
+    return {
+      id: "inclusive-previous-run",
+      name: "inclusive previous run",
+      enabled: true,
+      createdAtMs: 0,
+      updatedAtMs: 0,
+      schedule,
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "tick" },
+      state: {},
+    };
+  }
+
+  it("includes an exact boundary and keeps the prior slot between boundaries", () => {
+    const job = createCronJob({ kind: "cron", expr: "* * * * * *", tz: "UTC", staggerMs: 0 });
+    const boundary = Date.parse("2025-12-13T04:02:00.000Z");
+
+    expect(computeJobPreviousRunAtOrBeforeMs(job, boundary)).toBe(boundary);
+    expect(computeJobPreviousRunAtOrBeforeMs(job, boundary + 500)).toBe(boundary);
+  });
+
+  it("includes an exact effective boundary after per-job staggering", () => {
+    const job = createCronJob({
+      kind: "cron",
+      expr: "0 * * * * *",
+      tz: "UTC",
+      staggerMs: 30_000,
+    });
+    const cursor = Date.parse("2025-12-13T04:02:00.000Z");
+    const effectiveBoundary = computeJobNextRunAtMs(job, cursor);
+
+    expect(effectiveBoundary).toBeTypeOf("number");
+    expect(computeJobPreviousRunAtOrBeforeMs(job, effectiveBoundary!)).toBe(effectiveBoundary);
   });
 });
 

--- a/src/cron/service.restart-catchup.test.ts
+++ b/src/cron/service.restart-catchup.test.ts
@@ -270,59 +270,64 @@ describe("CronService restart catch-up", () => {
     }
   });
 
-  it("does not defer an isolated cron agent-turn whose persisted due slot already succeeded", async () => {
-    const store = await makeStorePath();
-    const startNow = Date.parse("2025-12-13T11:00:00.000Z");
-    const dueAt = Date.parse("2025-12-13T09:10:00.000Z");
-    const completedAt = Date.parse("2025-12-13T09:10:30.000Z");
-    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
-    const enqueueSystemEvent = vi.fn();
-    const requestHeartbeat = vi.fn();
+  it.each(["ok", "skipped"] as const)(
+    "does not defer an isolated cron agent-turn whose persisted due slot finished as %s",
+    async (lastRunStatus) => {
+      const store = await makeStorePath();
+      const startNow = Date.parse("2025-12-13T11:00:00.000Z");
+      const dueAt = Date.parse("2025-12-13T09:10:00.000Z");
+      const completedAt = Date.parse("2025-12-13T09:10:30.000Z");
+      const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
+      const enqueueSystemEvent = vi.fn();
+      const requestHeartbeat = vi.fn();
 
-    await writeStoreJobs(store.storePath, [
-      {
-        id: "startup-isolated-agent-already-ok",
-        name: "startup isolated agent already ok",
-        enabled: true,
-        createdAtMs: Date.parse("2025-12-10T12:00:00.000Z"),
-        updatedAtMs: completedAt,
-        schedule: { kind: "cron", expr: "10 9 * * *", tz: "UTC" },
-        sessionTarget: "isolated",
-        wakeMode: "next-heartbeat",
-        payload: { kind: "agentTurn", message: "daily reminder" },
-        state: {
-          nextRunAtMs: dueAt,
-          lastRunAtMs: completedAt,
-          lastRunStatus: "ok",
+      await writeStoreJobs(store.storePath, [
+        {
+          id: `startup-isolated-agent-already-${lastRunStatus}`,
+          name: `startup isolated agent already ${lastRunStatus}`,
+          enabled: true,
+          createdAtMs: Date.parse("2025-12-10T12:00:00.000Z"),
+          updatedAtMs: completedAt,
+          schedule: { kind: "cron", expr: "10 9 * * *", tz: "UTC" },
+          sessionTarget: "isolated",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "agentTurn", message: "daily reminder" },
+          state: {
+            nextRunAtMs: dueAt,
+            lastRunAtMs: completedAt,
+            lastRunStatus,
+          },
         },
-      },
-    ]);
+      ]);
 
-    const cron = createRestartCronService({
-      storePath: store.storePath,
-      enqueueSystemEvent,
-      requestHeartbeat,
-      runIsolatedAgentJob,
-      nowMs: () => startNow,
-      startupDeferredMissedAgentJobDelayMs: 120_000,
-    });
+      const cron = createRestartCronService({
+        storePath: store.storePath,
+        enqueueSystemEvent,
+        requestHeartbeat,
+        runIsolatedAgentJob,
+        nowMs: () => startNow,
+        startupDeferredMissedAgentJobDelayMs: 120_000,
+      });
 
-    try {
-      await cron.start();
+      try {
+        await cron.start();
 
-      expect(runIsolatedAgentJob).not.toHaveBeenCalled();
-      expect(enqueueSystemEvent).not.toHaveBeenCalled();
-      expect(requestHeartbeat).not.toHaveBeenCalled();
+        expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+        expect(enqueueSystemEvent).not.toHaveBeenCalled();
+        expect(requestHeartbeat).not.toHaveBeenCalled();
 
-      const listedJobs = await cron.list({ includeDisabled: true });
-      const updated = listedJobs.find((job) => job.id === "startup-isolated-agent-already-ok");
-      expect(updated?.state.lastRunStatus).toBe("ok");
-      expect(updated?.state.nextRunAtMs).toBe(Date.parse("2025-12-14T09:10:00.000Z"));
-    } finally {
-      cron.stop();
-      await store.cleanup();
-    }
-  });
+        const listedJobs = await cron.list({ includeDisabled: true });
+        const updated = listedJobs.find(
+          (job) => job.id === `startup-isolated-agent-already-${lastRunStatus}`,
+        );
+        expect(updated?.state.lastRunStatus).toBe(lastRunStatus);
+        expect(updated?.state.nextRunAtMs).toBe(Date.parse("2025-12-14T09:10:00.000Z"));
+      } finally {
+        cron.stop();
+        await store.cleanup();
+      }
+    },
+  );
 
   it("replays a newer missed cron slot behind a completed persisted slot", async () => {
     vi.setSystemTime(new Date("2025-12-13T04:10:00.000Z"));

--- a/src/cron/service.restart-catchup.test.ts
+++ b/src/cron/service.restart-catchup.test.ts
@@ -270,6 +270,116 @@ describe("CronService restart catch-up", () => {
     }
   });
 
+  it("does not defer an isolated cron agent-turn whose persisted due slot already succeeded", async () => {
+    const store = await makeStorePath();
+    const startNow = Date.parse("2025-12-13T11:00:00.000Z");
+    const dueAt = Date.parse("2025-12-13T09:10:00.000Z");
+    const completedAt = Date.parse("2025-12-13T09:10:30.000Z");
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeat = vi.fn();
+
+    await writeStoreJobs(store.storePath, [
+      {
+        id: "startup-isolated-agent-already-ok",
+        name: "startup isolated agent already ok",
+        enabled: true,
+        createdAtMs: Date.parse("2025-12-10T12:00:00.000Z"),
+        updatedAtMs: completedAt,
+        schedule: { kind: "cron", expr: "10 9 * * *", tz: "UTC" },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "daily reminder" },
+        state: {
+          nextRunAtMs: dueAt,
+          lastRunAtMs: completedAt,
+          lastRunStatus: "ok",
+        },
+      },
+    ]);
+
+    const cron = createRestartCronService({
+      storePath: store.storePath,
+      enqueueSystemEvent,
+      requestHeartbeat,
+      runIsolatedAgentJob,
+      nowMs: () => startNow,
+      startupDeferredMissedAgentJobDelayMs: 120_000,
+    });
+
+    try {
+      await cron.start();
+
+      expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+      expect(enqueueSystemEvent).not.toHaveBeenCalled();
+      expect(requestHeartbeat).not.toHaveBeenCalled();
+
+      const listedJobs = await cron.list({ includeDisabled: true });
+      const updated = listedJobs.find((job) => job.id === "startup-isolated-agent-already-ok");
+      expect(updated?.state.lastRunStatus).toBe("ok");
+      expect(updated?.state.nextRunAtMs).toBe(Date.parse("2025-12-14T09:10:00.000Z"));
+    } finally {
+      cron.stop();
+      await store.cleanup();
+    }
+  });
+
+  it("replays a newer missed cron slot behind a completed persisted slot", async () => {
+    vi.setSystemTime(new Date("2025-12-13T04:10:00.000Z"));
+    await withRestartedCron(
+      [
+        {
+          id: "restart-completed-slot-newer-miss",
+          name: "completed slot with newer miss",
+          enabled: true,
+          createdAtMs: Date.parse("2025-12-10T12:00:00.000Z"),
+          updatedAtMs: Date.parse("2025-12-13T04:01:30.000Z"),
+          schedule: { kind: "cron", expr: "* * * * *", tz: "UTC" },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "systemEvent", text: "newer slot missed" },
+          state: {
+            nextRunAtMs: Date.parse("2025-12-13T04:01:00.000Z"),
+            lastRunAtMs: Date.parse("2025-12-13T04:01:00.000Z"),
+            lastRunStatus: "ok",
+          },
+        },
+      ],
+      async ({ enqueueSystemEvent, requestHeartbeat }) => {
+        expectQueuedSystemEvent(enqueueSystemEvent, "newer slot missed");
+        expect(requestHeartbeat).toHaveBeenCalled();
+      },
+    );
+  });
+
+  it("replays a cron slot due exactly at restart behind a completed persisted slot", async () => {
+    vi.setSystemTime(new Date("2025-12-13T04:02:00.000Z"));
+    await withRestartedCron(
+      [
+        {
+          id: "restart-completed-slot-boundary-miss",
+          name: "completed slot with boundary miss",
+          enabled: true,
+          createdAtMs: Date.parse("2025-12-10T12:00:00.000Z"),
+          updatedAtMs: Date.parse("2025-12-13T04:01:30.000Z"),
+          schedule: { kind: "cron", expr: "* * * * *", tz: "UTC" },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "systemEvent", text: "boundary slot missed" },
+          state: {
+            nextRunAtMs: Date.parse("2025-12-13T04:01:00.000Z"),
+            lastRunAtMs: Date.parse("2025-12-13T04:01:00.000Z"),
+            lastRunStatus: "ok",
+          },
+        },
+      ],
+      async ({ enqueueSystemEvent, requestHeartbeat }) => {
+        expectQueuedSystemEvent(enqueueSystemEvent, "boundary slot missed");
+        expect(requestHeartbeat).toHaveBeenCalled();
+      },
+    );
+  });
+
   it("marks interrupted recurring jobs failed instead of replaying them on startup", async () => {
     const dueAt = Date.parse("2025-12-13T16:00:00.000Z");
     const staleRunningAt = Date.parse("2025-12-13T16:30:00.000Z");

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -181,17 +181,32 @@ function computeStaggeredCronPreviousRunAtMs(job: CronJob, nowMs: number) {
   return undefined;
 }
 
+function computeStaggeredCronPreviousRunAtOrBeforeMs(job: CronJob, nowMs: number) {
+  const previous = computeStaggeredCronPreviousRunAtMs(job, nowMs);
+  const probeMs = nowMs + 1_000;
+  if (!Number.isFinite(probeMs)) {
+    return previous;
+  }
+
+  // Croner previous-run queries are strict-before and second-granular. Keep
+  // the strict result, then probe past the current second to include a slot
+  // exactly at now without losing the prior slot between boundaries.
+  const boundary = computeStaggeredCronPreviousRunAtMs(job, probeMs);
+  if (
+    isFiniteTimestamp(boundary) &&
+    boundary <= nowMs &&
+    (!isFiniteTimestamp(previous) || boundary > previous)
+  ) {
+    return boundary;
+  }
+  return previous;
+}
+
 function isStaggeredCronRunAtMs(job: CronJob, runAtMs: number): boolean {
   if (job.schedule.kind !== "cron" || !isFiniteTimestamp(runAtMs)) {
     return false;
   }
-  // Probe past the candidate second. Croner-style second-granular schedules
-  // normalize a 1ms probe back to the candidate's second, so
-  // `previousRuns(1, runAtMs + 1)` returns the slot before the candidate
-  // rather than the candidate itself and exact-second slots get misclassified
-  // as stale. A 1s probe lands past the candidate second, matching the cursor
-  // step used elsewhere in this file (cf. #81691).
-  const previous = computeStaggeredCronPreviousRunAtMs(job, runAtMs + 1_000);
+  const previous = computeStaggeredCronPreviousRunAtOrBeforeMs(job, runAtMs);
   return previous === runAtMs;
 }
 
@@ -507,6 +522,15 @@ export function computeJobPreviousRunAtMs(job: CronJob, nowMs: number): number |
     return undefined;
   }
   const previous = computeStaggeredCronPreviousRunAtMs(job, nowMs);
+  return isFiniteTimestamp(previous) ? previous : undefined;
+}
+
+/** Computes the latest effective cron timestamp at or before the supplied time. */
+export function computeJobPreviousRunAtOrBeforeMs(job: CronJob, nowMs: number): number | undefined {
+  if (!isJobEnabled(job) || job.schedule.kind !== "cron") {
+    return undefined;
+  }
+  const previous = computeStaggeredCronPreviousRunAtOrBeforeMs(job, nowMs);
   return isFiniteTimestamp(previous) ? previous : undefined;
 }
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1840,7 +1840,7 @@ function isRunnableJob(params: {
     const alreadyCompletedDueCronSlot =
       params.allowCronMissedRunByLastRun &&
       job.schedule.kind === "cron" &&
-      lastRunStatus === "ok" &&
+      (lastRunStatus === "ok" || lastRunStatus === "skipped") &&
       typeof lastRunAtMs === "number" &&
       Number.isFinite(lastRunAtMs) &&
       lastRunAtMs >= next;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -69,6 +69,7 @@ import {
 } from "./failure-alerts.js";
 import {
   DEFAULT_ERROR_BACKOFF_SCHEDULE_MS,
+  computeJobPreviousRunAtOrBeforeMs,
   computeJobPreviousRunAtMs,
   computeJobNextRunAtMs,
   errorBackoffMs,
@@ -1833,7 +1834,26 @@ function isRunnableJob(params: {
     return false;
   }
   if (hasScheduledNextRunAtMs(next) && nowMs >= next) {
-    return true;
+    const lastRunAtMs = job.state.lastRunAtMs;
+    // Startup loads persisted state before maintenance recompute. Suppress a
+    // completed stale slot, but still replay a newer slot due by restart time.
+    const alreadyCompletedDueCronSlot =
+      params.allowCronMissedRunByLastRun &&
+      job.schedule.kind === "cron" &&
+      lastRunStatus === "ok" &&
+      typeof lastRunAtMs === "number" &&
+      Number.isFinite(lastRunAtMs) &&
+      lastRunAtMs >= next;
+    if (!alreadyCompletedDueCronSlot) {
+      return true;
+    }
+    let latestRunAtMs: number | undefined;
+    try {
+      latestRunAtMs = computeJobPreviousRunAtOrBeforeMs(job, nowMs);
+    } catch {
+      return false;
+    }
+    return typeof latestRunAtMs === "number" && latestRunAtMs > lastRunAtMs;
   }
   if (!params.allowCronMissedRunByLastRun || job.schedule.kind !== "cron") {
     return false;


### PR DESCRIPTION
Closes #101988

## What Problem This Solves

Gateway restart catch-up could treat a stale persisted cron `nextRunAtMs` as runnable before checking whether the job had already completed that schedule slot. For isolated agent-turn cron jobs, this could defer and rerun a successful daily reminder after restart, causing duplicate notifications.

## Why This Change Was Made

The runnable check now recognizes the specific restart state where a cron job has a due `nextRunAtMs`, `lastRunStatus: ok`, and `lastRunAtMs` already covers that due slot. Instead of immediately marking the job runnable, it falls through to the existing previous-slot guard so only genuinely missed later slots are replayed. Failed or skipped jobs still keep their existing retry behavior.

## User Impact

Users should no longer receive duplicate isolated-agent cron messages after restarting the Gateway when the current schedule tick already ran successfully. Legitimate missed cron work and failure retry paths remain eligible for catch-up.

## Evidence

- `node scripts/run-vitest.mjs src/cron/service.restart-catchup.test.ts src/cron/service/timer.regression.test.ts`

```text
[test] starting test/vitest/vitest.cron.config.ts
[test] passed 1 Vitest shard in 20.51s
```

- `git diff --check`

```text
passed
```

## Real behavior proof

**Behavior addressed:** Restart catch-up skips a stale due cron slot when the isolated agent-turn job already completed that slot successfully.
**Environment tested:** Linux, Node v22.22.0, local source checkout on branch `fix/101988-cron-catchup-window`, isolated temporary `OPENCLAW_HOME` and `OPENCLAW_STATE_DIR`.
**Steps run after the patch:** Created a real cron store with an isolated agent-turn cron job whose persisted `nextRunAtMs` was 2025-12-13 09:10 UTC, `lastRunStatus` was `ok`, and `lastRunAtMs` was 2025-12-13 09:10:30 UTC; started the production `CronService` at 2025-12-13 11:00 UTC and listed the stored job.
**Evidence after fix:**

```bash
node --import tsx --no-warnings -e '
import fs from "node:fs/promises";
import os from "node:os";
import path from "node:path";
const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-101988-proof-")));
process.env.OPENCLAW_HOME = path.join(root, "home");
process.env.OPENCLAW_STATE_DIR = path.join(root, "state");
const { CronService } = await import("./src/cron/service.js");
const { saveCronStore } = await import("./src/cron/store.js");
const storePath = path.join(root, "cron.json");
const startNow = Date.parse("2025-12-13T11:00:00.000Z");
const dueAt = Date.parse("2025-12-13T09:10:00.000Z");
const completedAt = Date.parse("2025-12-13T09:10:30.000Z");
const runIsolatedAgentJobCalls = [];
const heartbeatCalls = [];
const events = [];
await saveCronStore(storePath, {
  version: 1,
  jobs: [{
    id: "startup-isolated-agent-already-ok",
    name: "startup isolated agent already ok",
    enabled: true,
    createdAtMs: Date.parse("2025-12-10T12:00:00.000Z"),
    updatedAtMs: completedAt,
    schedule: { kind: "cron", expr: "10 9 * * *", tz: "UTC" },
    sessionTarget: "isolated",
    wakeMode: "next-heartbeat",
    payload: { kind: "agentTurn", message: "daily reminder" },
    state: { nextRunAtMs: dueAt, lastRunAtMs: completedAt, lastRunStatus: "ok" },
  }],
});
const cron = new CronService({
  storePath,
  cronEnabled: true,
  log: { debug() {}, info() {}, warn() {}, error() {} },
  nowMs: () => startNow,
  enqueueSystemEvent: async () => ({ status: "queued" }),
  requestHeartbeat: async (...args) => { heartbeatCalls.push(args); },
  runIsolatedAgentJob: async (...args) => {
    runIsolatedAgentJobCalls.push(args);
    return { status: "ok" };
  },
  onEvent: (evt) => events.push(evt),
  startupDeferredMissedAgentJobDelayMs: 120_000,
});
try {
  await cron.start();
  const [job] = await cron.list({ includeDisabled: true });
  console.log(JSON.stringify({
    runIsolatedAgentJobCalls: runIsolatedAgentJobCalls.length,
    heartbeatCalls: heartbeatCalls.length,
    startedEvents: events.filter((evt) => evt.action === "started").length,
    lastRunStatus: job?.state.lastRunStatus,
    lastRunAtIso: new Date(job?.state.lastRunAtMs ?? 0).toISOString(),
    nextRunAtIso: new Date(job?.state.nextRunAtMs ?? 0).toISOString(),
  }, null, 2));
} finally {
  cron.stop();
  await fs.rm(root, { recursive: true, force: true });
}
'
```

```text
{
  "runIsolatedAgentJobCalls": 0,
  "heartbeatCalls": 0,
  "startedEvents": 0,
  "lastRunStatus": "ok",
  "lastRunAtIso": "2025-12-13T09:10:30.000Z",
  "nextRunAtIso": "2025-12-14T09:10:00.000Z"
}
```

**Observed result after the fix:** Gateway startup did not run or defer the already-completed isolated agent-turn slot; no agent job, heartbeat, or started event was emitted, and the job advanced to the next natural daily cron slot.
**Not tested:** A live macOS Gateway restart with real channel delivery credentials was not exercised locally.
