### PR TITLE
fix: clear session suspension timers on gateway shutdown

### DIFF
--- a/src/agents/session-suspension.test.ts
+++ b/src/agents/session-suspension.test.ts
@@ -1,7 +1,6 @@
 // Verifies quota suspension persists lane state and auto-resumes safely.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_CRON_MAX_CONCURRENT_RUNS } from "../config/cron-limits.js";
-import type { QuotaSuspension } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { CommandLane } from "../process/lanes.js";
 import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
@@ -135,10 +134,8 @@ describe("session suspension", () => {
     await suspendLane(Number.MAX_SAFE_INTEGER, {} as OpenClawConfig, CommandLane.Main);
 
     expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
-    const patch = sessionStoreMocks.applySessionStoreEntryPatch.mock.calls[0]?.[0].patch as {
-      quotaSuspension?: QuotaSuspension;
-    };
-    const expectedSuspension: QuotaSuspension = {
+    const patch = sessionStoreMocks.applySessionStoreEntryPatch.mock.calls[0]?.[0].patch;
+    const expectedSuspension = {
       schemaVersion: 1,
       suspendedAt: 1_000,
       reason: "quota_exhausted",
@@ -147,7 +144,7 @@ describe("session suspension", () => {
       laneId: CommandLane.Main,
       expectedResumeBy: 1_000 + MAX_TIMER_TIMEOUT_MS,
       state: "suspended",
-    };
+    } as const;
     expect(patch.quotaSuspension).toMatchObject(expectedSuspension);
     expect(patch.quotaSuspension).toStrictEqual({
       ...expectedSuspension,

--- a/src/agents/session-suspension.test.ts
+++ b/src/agents/session-suspension.test.ts
@@ -1,6 +1,7 @@
 // Verifies quota suspension persists lane state and auto-resumes safely.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_CRON_MAX_CONCURRENT_RUNS } from "../config/cron-limits.js";
+import type { QuotaSuspension } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { CommandLane } from "../process/lanes.js";
 import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
@@ -135,8 +136,9 @@ describe("session suspension", () => {
 
     expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
     const patch = sessionStoreMocks.applySessionStoreEntryPatch.mock.calls[0]?.[0].patch as {
-      quotaSuspension?: { expectedResumeBy?: number };
+      quotaSuspension?: QuotaSuspension;
     };
+    expect(patch.quotaSuspension?.schemaVersion).toBe(1);
     expect(patch.quotaSuspension?.expectedResumeBy).toBe(1_000 + MAX_TIMER_TIMEOUT_MS);
   });
 

--- a/src/agents/session-suspension.test.ts
+++ b/src/agents/session-suspension.test.ts
@@ -138,8 +138,21 @@ describe("session suspension", () => {
     const patch = sessionStoreMocks.applySessionStoreEntryPatch.mock.calls[0]?.[0].patch as {
       quotaSuspension?: QuotaSuspension;
     };
-    expect(patch.quotaSuspension?.schemaVersion).toBe(1);
-    expect(patch.quotaSuspension?.expectedResumeBy).toBe(1_000 + MAX_TIMER_TIMEOUT_MS);
+    const expectedSuspension: QuotaSuspension = {
+      schemaVersion: 1,
+      suspendedAt: 1_000,
+      reason: "quota_exhausted",
+      failedProvider: "anthropic",
+      failedModel: "claude-opus-4-6",
+      laneId: CommandLane.Main,
+      expectedResumeBy: 1_000 + MAX_TIMER_TIMEOUT_MS,
+      state: "suspended",
+    };
+    expect(patch.quotaSuspension).toMatchObject(expectedSuspension);
+    expect(patch.quotaSuspension).toStrictEqual({
+      ...expectedSuspension,
+      summary: undefined,
+    });
   });
 
   it("defers session suspension only for the outer fallback candidate run", async () => {

--- a/src/agents/session-suspension.test.ts
+++ b/src/agents/session-suspension.test.ts
@@ -40,6 +40,8 @@ async function suspendLane(ttlMs: number, cfg: OpenClawConfig, laneId: CommandLa
 
 describe("session suspension", () => {
   afterEach(async () => {
+    const { clearSessionSuspensionAutoResumeTimers } = await import("./session-suspension.js");
+    clearSessionSuspensionAutoResumeTimers();
     if (vi.isFakeTimers()) {
       await vi.runOnlyPendingTimersAsync();
       vi.clearAllTimers();
@@ -103,6 +105,24 @@ describe("session suspension", () => {
       CommandLane.Cron,
       1,
     );
+  });
+
+  it("clears pending auto-resume timers without restoring lane concurrency", async () => {
+    vi.useFakeTimers();
+    const { clearSessionSuspensionAutoResumeTimers } = await import("./session-suspension.js");
+
+    await suspendLane(
+      100,
+      { agents: { defaults: { maxConcurrent: 4 } } } as OpenClawConfig,
+      CommandLane.Main,
+    );
+
+    expect(commandQueueMocks.setCommandLaneConcurrency).toHaveBeenCalledWith(CommandLane.Main, 0);
+    clearSessionSuspensionAutoResumeTimers();
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(commandQueueMocks.setCommandLaneConcurrency).toHaveBeenCalledTimes(1);
   });
 
   it("clamps oversized suspension TTLs for timers and persisted resume time", async () => {

--- a/src/agents/session-suspension.ts
+++ b/src/agents/session-suspension.ts
@@ -8,7 +8,6 @@ import path from "node:path";
 import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
 import { resolveCronMaxConcurrentRuns } from "../config/cron-limits.js";
 import { applySessionStoreEntryPatch } from "../config/sessions.js";
-import type { QuotaSuspension } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { setCommandLaneConcurrency } from "../process/command-queue.js";
@@ -133,17 +132,6 @@ export async function suspendSession(params: SessionSuspensionParams) {
   const ttlMs = resolveTimerTimeoutMs(params.ttlMs, DEFAULT_QUOTA_SUSPENSION_RESUME_MS, 0);
   const now = Date.now();
   const expectedResumeBy = resolveExpiresAtMsFromDurationMs(ttlMs, { nowMs: now }) ?? now;
-  const quotaSuspension: QuotaSuspension = {
-    schemaVersion: 1,
-    suspendedAt: now,
-    reason: params.reason,
-    failedProvider: params.failedProvider,
-    failedModel: params.failedModel,
-    summary: params.summary,
-    laneId: params.laneId,
-    expectedResumeBy,
-    state: "suspended",
-  };
 
   try {
     await applySessionStoreEntryPatch({
@@ -152,7 +140,17 @@ export async function suspendSession(params: SessionSuspensionParams) {
       skipMaintenance: true,
       takeCacheOwnership: true,
       patch: {
-        quotaSuspension,
+        quotaSuspension: {
+          schemaVersion: 1,
+          suspendedAt: now,
+          reason: params.reason,
+          failedProvider: params.failedProvider,
+          failedModel: params.failedModel,
+          summary: params.summary,
+          laneId: params.laneId,
+          expectedResumeBy,
+          state: "suspended",
+        },
       },
     });
   } catch (err) {

--- a/src/agents/session-suspension.ts
+++ b/src/agents/session-suspension.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
 import { resolveCronMaxConcurrentRuns } from "../config/cron-limits.js";
 import { applySessionStoreEntryPatch } from "../config/sessions.js";
+import type { QuotaSuspension } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { setCommandLaneConcurrency } from "../process/command-queue.js";
@@ -132,6 +133,17 @@ export async function suspendSession(params: SessionSuspensionParams) {
   const ttlMs = resolveTimerTimeoutMs(params.ttlMs, DEFAULT_QUOTA_SUSPENSION_RESUME_MS, 0);
   const now = Date.now();
   const expectedResumeBy = resolveExpiresAtMsFromDurationMs(ttlMs, { nowMs: now }) ?? now;
+  const quotaSuspension: QuotaSuspension = {
+    schemaVersion: 1,
+    suspendedAt: now,
+    reason: params.reason,
+    failedProvider: params.failedProvider,
+    failedModel: params.failedModel,
+    summary: params.summary,
+    laneId: params.laneId,
+    expectedResumeBy,
+    state: "suspended",
+  };
 
   try {
     await applySessionStoreEntryPatch({
@@ -140,17 +152,7 @@ export async function suspendSession(params: SessionSuspensionParams) {
       skipMaintenance: true,
       takeCacheOwnership: true,
       patch: {
-        quotaSuspension: {
-          schemaVersion: 1,
-          suspendedAt: now,
-          reason: params.reason,
-          failedProvider: params.failedProvider,
-          failedModel: params.failedModel,
-          summary: params.summary,
-          laneId: params.laneId,
-          expectedResumeBy,
-          state: "suspended",
-        },
+        quotaSuspension,
       },
     });
   } catch (err) {

--- a/src/agents/session-suspension.ts
+++ b/src/agents/session-suspension.ts
@@ -107,6 +107,13 @@ function scheduleLaneAutoResume(laneId: string, delayMs: number, resumeConcurren
   laneResumeTimers.set(laneId, timer);
 }
 
+export function clearSessionSuspensionAutoResumeTimers(): void {
+  for (const timer of laneResumeTimers.values()) {
+    clearTimeout(timer);
+  }
+  laneResumeTimers.clear();
+}
+
 export async function suspendSession(params: SessionSuspensionParams) {
   if (!params.cfg) {
     return;

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   listChannelPlugins: vi.fn((): Array<{ id: "telegram" | "discord" }> => []),
   disposeAgentHarnesses: vi.fn(async () => undefined),
   disposeAllSessionMcpRuntimes: vi.fn(async () => undefined),
+  clearSessionSuspensionAutoResumeTimers: vi.fn(),
   triggerInternalHook: vi.fn<TriggerInternalHookMock>(async (_eventValue) => undefined),
   disposeAllBundleLspRuntimes: vi.fn(async () => undefined),
 }));
@@ -53,6 +54,10 @@ vi.mock("../agents/agent-bundle-mcp-tools.js", async () => ({
     "../agents/agent-bundle-mcp-tools.js",
   )),
   disposeAllSessionMcpRuntimes: mocks.disposeAllSessionMcpRuntimes,
+}));
+
+vi.mock("../agents/session-suspension.js", () => ({
+  clearSessionSuspensionAutoResumeTimers: mocks.clearSessionSuspensionAutoResumeTimers,
 }));
 
 vi.mock("../agents/agent-bundle-lsp-runtime.js", async () => ({
@@ -156,6 +161,7 @@ describe("createGatewayCloseHandler", () => {
     mocks.disposeAgentHarnesses.mockResolvedValue(undefined);
     mocks.disposeAllSessionMcpRuntimes.mockClear();
     mocks.disposeAllSessionMcpRuntimes.mockResolvedValue(undefined);
+    mocks.clearSessionSuspensionAutoResumeTimers.mockClear();
     mocks.triggerInternalHook.mockReset();
     mocks.triggerInternalHook.mockResolvedValue(undefined);
     mocks.disposeAllBundleLspRuntimes.mockClear();
@@ -183,6 +189,14 @@ describe("createGatewayCloseHandler", () => {
     expect(deps.cron.stop).toHaveBeenCalledTimes(1);
     expect(deps.heartbeatRunner.stop).toHaveBeenCalledTimes(1);
     expect(deps.chatRunState.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears session suspension auto-resume timers during shutdown", async () => {
+    const close = createGatewayCloseHandler(createGatewayCloseTestDeps());
+
+    await close({ reason: "test" });
+
+    expect(mocks.clearSessionSuspensionAutoResumeTimers).toHaveBeenCalledTimes(1);
   });
 
   it("stops plugin services before channel runtimes", async () => {

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -6,6 +6,7 @@ import type { WebSocketServer } from "ws";
 import { disposeAllSessionMcpRuntimes } from "../agents/agent-bundle-mcp-tools.js";
 import { disposeRegisteredAgentHarnesses } from "../agents/harness/registry.js";
 import { createAgentRunRestartAbortError } from "../agents/run-termination.js";
+import { clearSessionSuspensionAutoResumeTimers } from "../agents/session-suspension.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
 import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
@@ -826,6 +827,13 @@ export function createGatewayCloseHandler(
           ),
         );
       }
+      await shutdownStep(
+        "session-suspension",
+        () => {
+          clearSessionSuspensionAutoResumeTimers();
+        },
+        warnings,
+      );
       if (params.bonjourStop) {
         await shutdownStep("bonjour", () => params.bonjourStop!(), warnings);
       }


### PR DESCRIPTION
Closes #101720

## What Problem This Solves

Fixes an issue where sessions suspended for quota or circuit reasons could leave lane auto-resume timers pending while the gateway was shutting down. Those timers could later call back into command lane concurrency after shutdown had already begun.

## Why This Change Was Made

The session-suspension module now owns a cleanup hook for pending lane auto-resume timers, and the gateway shutdown path invokes it after drain handling and before tearing down runtimes and background services. The change keeps normal TTL auto-resume behavior intact while preventing stale shutdown-time timer callbacks.

## User Impact

Gateway shutdown and restart are less likely to race with delayed session-suspension timers. Suspended lanes still auto-resume normally during regular runtime operation.

## Data Model / Upgrade Compatibility

No persisted schema or migration behavior changes. The production change only clears the in-memory `laneResumeTimers` map during gateway shutdown. Existing `quotaSuspension` entries remain schemaVersion 1 and are neither rewritten nor migrated by the new cleanup hook. The serialized-state surface ClawSweeper detected is test coverage around the existing session suspension shape, not a new stored field.

## Evidence

- `node scripts/run-vitest.mjs src/agents/session-suspension.test.ts src/gateway/server-close.test.ts` - passed, 2 Vitest shards.
- `node_modules/.bin/oxfmt --check --threads=1 src/agents/session-suspension.ts src/agents/session-suspension.test.ts src/gateway/server-close.ts src/gateway/server-close.test.ts` - passed.
- `git diff --check` - passed.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false node scripts/check-changed.mjs -- src/agents/session-suspension.ts src/gateway/server-close.ts src/agents/session-suspension.test.ts src/gateway/server-close.test.ts` - passed locally in child mode. Testbox delegation was blocked because the local Crabbox binary is 0.15.0 and the Testbox flow requires >=0.22.0; the local run also emitted Node 22.18.0 engine warnings.

## Real Behavior Proof

Ran a standalone Node/tsx proof that imports the real `suspendSession()`, real command queue state, real timers, and the real `createGatewayCloseHandler()` shutdown path. The control leg proves the pending auto-resume timer normally fires after TTL; the shutdown leg proves gateway close clears the pending timer so it cannot restore lane concurrency after teardown begins.

```text
$ node --import tsx --input-type=module <standalone #101720 shutdown proof>
OpenClaw #101720 runtime proof root: /var/folders/sx/2qmmyr8s7rz8m6d22p3htynw0000gn/T/openclaw-101720-proof-pZFur4
Using real suspendSession(), real timers, real command queue, and createGatewayCloseHandler().
control after suspend: lane=main maxConcurrent=0 queued=0 active=0
[session-suspension] auto-resumed lane after suspension TTL
control after ttl without shutdown: lane=main maxConcurrent=4 queued=0 active=0
shutdown case after suspend: lane=main maxConcurrent=0 queued=0 active=0
[shutdown] started: proof shutdown for #101720
shutdown drainActiveSessionsForShutdown reason=shutdown
[gmail-watcher] gmail watcher stopped
[shutdown] completed cleanly in 29ms
gateway close completed warnings=[] durationMs=29
shutdown case immediately after close: lane=main maxConcurrent=0 queued=0 active=0
shutdown case after ttl post-close: lane=main maxConcurrent=0 queued=0 active=0
```

The important behavior is the final line: after waiting longer than the suspension TTL after gateway close, the main lane remains suspended at `maxConcurrent=0`; in the control leg, the same TTL restores the lane to `maxConcurrent=4`.