### PR TITLE
feat(runtime): show OpenClaw sessions in Live Activity

### DIFF
--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -12,6 +12,7 @@ import {
   queueReplyRunMessage,
   waitForReplyRunEndBySessionId,
 } from "../../auto-reply/reply/reply-run-registry.js";
+import { emitRuntimeTurnActivityLease } from "../../infra/runtime-activity-emitter.js";
 import {
   markDiagnosticEmbeddedRunEnded,
   markDiagnosticEmbeddedRunStarted,
@@ -804,6 +805,7 @@ export function setActiveEmbeddedRun(
     reason: wasActive ? "run_replaced" : "run_started",
   });
   markDiagnosticEmbeddedRunStarted({ sessionId, sessionKey });
+  emitRuntimeTurnActivityLease({ sessionId, sessionKey, runId: handle.runId });
   if (!sessionId.startsWith("probe-")) {
     diag.debug(`run registered: sessionId=${sessionId} totalActive=${ACTIVE_EMBEDDED_RUNS.size}`);
   }

--- a/src/channels/message/send.ts
+++ b/src/channels/message/send.ts
@@ -16,6 +16,7 @@ import {
   type DeliverOutboundPayloadsParams,
   type OutboundDeliveryIntent,
 } from "../../infra/outbound/deliver.js";
+import { emitRuntimeReplyActivityLease } from "../../infra/runtime-activity-emitter.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { createLiveMessageState, markLiveMessagePreviewUpdated } from "./live.js";
 import { createMessageReceiptFromOutboundResults } from "./receipt.js";
@@ -271,6 +272,7 @@ export async function withDurableMessageSendContext<T>(
             deliveryIntent = intent;
             const durableIntent = toDurableMessageIntent(intent, rendered);
             ctx.intent = durableIntent;
+            emitRuntimeReplyActivityLease({ intent: durableIntent, session: params.session });
             onDeliveryIntent?.(durableIntent);
           },
         });

--- a/src/infra/runtime-activity-emitter.test.ts
+++ b/src/infra/runtime-activity-emitter.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  emitRuntimeReplyActivityLease,
+  emitRuntimeTurnActivityLease,
+  testing,
+} from "./runtime-activity-emitter.js";
+
+const ORIGINAL_ENDPOINT = process.env.OPENCLAW_AGENT_ACTIVITY_ENDPOINT;
+const ORIGINAL_BEARER = process.env.OPENCLAW_AGENT_ACTIVITY_BEARER;
+
+function restoreActivityEnv(): void {
+  if (ORIGINAL_ENDPOINT === undefined) {
+    delete process.env.OPENCLAW_AGENT_ACTIVITY_ENDPOINT;
+  } else {
+    process.env.OPENCLAW_AGENT_ACTIVITY_ENDPOINT = ORIGINAL_ENDPOINT;
+  }
+  if (ORIGINAL_BEARER === undefined) {
+    delete process.env.OPENCLAW_AGENT_ACTIVITY_BEARER;
+  } else {
+    process.env.OPENCLAW_AGENT_ACTIVITY_BEARER = ORIGINAL_BEARER;
+  }
+}
+
+function configureActivityEnv(): void {
+  process.env.OPENCLAW_AGENT_ACTIVITY_ENDPOINT =
+    "https://command-center.test/api/agents/agent-1/activity";
+  process.env.OPENCLAW_AGENT_ACTIVITY_BEARER = "activity-token";
+}
+
+function latestFetchJson(fetchMock: ReturnType<typeof vi.fn>): Record<string, unknown> {
+  const request = fetchMock.mock.calls.at(-1)?.[1] as { body?: string } | undefined;
+  if (!request?.body) {
+    throw new Error("Expected activity request body");
+  }
+  return JSON.parse(request.body) as Record<string, unknown>;
+}
+
+afterEach(() => {
+  restoreActivityEnv();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("runtime activity emitter", () => {
+  it("stays disabled until both endpoint and bearer are configured", () => {
+    delete process.env.OPENCLAW_AGENT_ACTIVITY_ENDPOINT;
+    delete process.env.OPENCLAW_AGENT_ACTIVITY_BEARER;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    emitRuntimeTurnActivityLease({
+      sessionId: "session-1",
+      sessionKey: "agent:main:slack:channel:C123",
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(testing.endpointConfig()).toBeUndefined();
+  });
+
+  it("posts a coarse turn-start lease without message content", () => {
+    configureActivityEnv();
+    const fetchMock = vi.fn(() => new Promise(() => {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    emitRuntimeTurnActivityLease({
+      sessionId: "session-1",
+      sessionKey: "agent:main:slack:channel:C123:thread:1710000000.000100",
+      runId: "run-1",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://command-center.test/api/agents/agent-1/activity",
+    );
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      method: "POST",
+      headers: {
+        Authorization: "Bearer activity-token",
+        "Content-Type": "application/json",
+      },
+    });
+    const body = latestFetchJson(fetchMock);
+    expect(body).toMatchObject({
+      state: "working",
+      currentAction: "Running Slack session",
+      actionIcon: "code",
+    });
+    expect(body.sessions).toMatchObject([
+      {
+        sessionId: "runtime:agent:main:slack:channel:C123:thread:1710000000.000100",
+        kind: "manual",
+        status: "running",
+        phase: "running",
+        currentAction: "Running Slack session",
+        actionIcon: "code",
+        runId: "run-1",
+        threadId: "agent:main:slack:channel:C123:thread:1710000000.000100",
+      },
+    ]);
+    expect(JSON.stringify(body)).not.toContain("secret message");
+  });
+
+  it("posts a distinct reply lease keyed by the source session", () => {
+    configureActivityEnv();
+    const fetchMock = vi.fn(() => Promise.resolve(new Response(null, { status: 204 })));
+    vi.stubGlobal("fetch", fetchMock);
+
+    emitRuntimeReplyActivityLease({
+      intent: {
+        id: "queue-1",
+        channel: "slack",
+        to: "C123",
+        durability: "required",
+        renderedBatch: {
+          payloads: [{ text: "do not leak this" }],
+          plan: {
+            payloadCount: 1,
+            textCount: 1,
+            mediaCount: 0,
+            voiceCount: 0,
+            presentationCount: 0,
+            interactiveCount: 0,
+            channelDataCount: 0,
+            items: [],
+          },
+        },
+      },
+      session: { key: "agent:main:slack:channel:C123" },
+    });
+
+    const body = latestFetchJson(fetchMock);
+    expect(body).toMatchObject({
+      state: "working",
+      currentAction: "Replying in Slack",
+      actionIcon: "message",
+    });
+    expect(body.sessions).toMatchObject([
+      {
+        sessionId: "reply:agent:main:slack:channel:C123",
+        phase: "replying",
+        currentAction: "Replying in Slack",
+        runId: "queue-1",
+        threadId: "agent:main:slack:channel:C123",
+      },
+    ]);
+    expect(JSON.stringify(body)).not.toContain("do not leak this");
+  });
+});

--- a/src/infra/runtime-activity-emitter.ts
+++ b/src/infra/runtime-activity-emitter.ts
@@ -1,0 +1,139 @@
+/**
+ * Optional Command Center live-activity leases for active OpenClaw runtime work.
+ */
+import type { DurableMessageSendIntent } from "../channels/message/types.js";
+import type { OutboundSessionContext } from "./outbound/session-context.js";
+
+const ACTIVITY_ENDPOINT_ENV = "OPENCLAW_AGENT_ACTIVITY_ENDPOINT";
+const ACTIVITY_BEARER_ENV = "OPENCLAW_AGENT_ACTIVITY_BEARER";
+const ACTIVITY_POST_TIMEOUT_MS = 1500;
+
+type RuntimeActivitySession = {
+  sessionId: string;
+  kind: "manual";
+  status: "running";
+  phase: string;
+  currentAction: string;
+  actionIcon: string;
+  startedAt: string;
+  runId?: string;
+  threadId?: string;
+};
+
+function normalizeOptionalString(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function sanitizeActivityKey(value: string): string {
+  return value
+    .trim()
+    .replace(/[^A-Za-z0-9_.:-]/g, "-")
+    .slice(0, 96);
+}
+
+function formatChannelName(channel: string | undefined): string {
+  const normalized = normalizeOptionalString(channel)?.toLowerCase();
+  if (!normalized) {
+    return "session";
+  }
+  return (
+    (normalized === "slack"
+      ? "Slack"
+      : normalized
+          .split(/[-_\s]+/)
+          .filter(Boolean)
+          .map((part) => part[0]?.toUpperCase() + part.slice(1))
+          .join(" ")) || "session"
+  );
+}
+
+function channelFromSessionKey(sessionKey: string | undefined): string | undefined {
+  const normalized = normalizeOptionalString(sessionKey);
+  if (!normalized) {
+    return undefined;
+  }
+  const parts = normalized.split(":");
+  return normalizeOptionalString(parts[2]);
+}
+
+function endpointConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): { endpoint: string; bearer: string } | undefined {
+  const endpoint = normalizeOptionalString(env[ACTIVITY_ENDPOINT_ENV]);
+  const bearer = normalizeOptionalString(env[ACTIVITY_BEARER_ENV]);
+  return endpoint && bearer ? { endpoint, bearer } : undefined;
+}
+
+function postActivityLease(session: RuntimeActivitySession): void {
+  const config = endpointConfig();
+  if (!config || typeof fetch !== "function") {
+    return;
+  }
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), ACTIVITY_POST_TIMEOUT_MS);
+  void fetch(config.endpoint, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${config.bearer}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      state: "working",
+      currentAction: session.currentAction,
+      actionIcon: session.actionIcon,
+      sessions: [session],
+    }),
+    signal: controller.signal,
+  })
+    .catch(() => {
+      // Live Activity must never affect the runtime path it observes.
+    })
+    .finally(() => clearTimeout(timeout));
+}
+
+export function emitRuntimeTurnActivityLease(params: {
+  sessionId: string;
+  sessionKey?: string;
+  runId?: string;
+}): void {
+  const stableId = normalizeOptionalString(params.sessionKey) ?? params.sessionId;
+  const channel = channelFromSessionKey(params.sessionKey);
+  const channelLabel = formatChannelName(channel);
+  postActivityLease({
+    sessionId: sanitizeActivityKey(`runtime:${stableId}`),
+    kind: "manual",
+    status: "running",
+    phase: "running",
+    currentAction: channel ? `Running ${channelLabel} session` : "Running OpenClaw session",
+    actionIcon: "code",
+    startedAt: new Date().toISOString(),
+    ...(params.runId ? { runId: params.runId } : {}),
+    ...(params.sessionKey ? { threadId: params.sessionKey } : {}),
+  });
+}
+
+export function emitRuntimeReplyActivityLease(params: {
+  intent: DurableMessageSendIntent;
+  session?: OutboundSessionContext;
+}): void {
+  const sessionKey = params.session?.key ?? params.session?.policyKey;
+  const channelLabel = formatChannelName(params.intent.channel);
+  const stableId =
+    normalizeOptionalString(sessionKey) ?? `${params.intent.channel}:${params.intent.to}`;
+  postActivityLease({
+    sessionId: sanitizeActivityKey(`reply:${stableId}`),
+    kind: "manual",
+    status: "running",
+    phase: "replying",
+    currentAction: `Replying in ${channelLabel}`,
+    actionIcon: "message",
+    startedAt: new Date().toISOString(),
+    runId: params.intent.id,
+    ...(sessionKey ? { threadId: sessionKey } : {}),
+  });
+}
+
+export const testing = {
+  endpointConfig,
+};


### PR DESCRIPTION
Related: Command Center task 6a3caa68e15a73bd7ec5e692

## What Problem This Solves

Resolves a problem where Command Center Live Activity can show an agent as idle while the same agent is actively running an OpenClaw session or sending a Slack/channel reply.

## Why This Change Was Made

This adds an optional, env-gated runtime activity lease emitter that posts coarse non-content activity to the existing Command Center agent activity endpoint. It hooks the two runtime choke points from Jack's review: embedded-run registration for active sessions and durable message delivery intent for replies. The POST is fire-and-forget with a short timeout, no retries, and silent no-op behavior unless both endpoint and bearer env vars are configured.

## User Impact

Operators can see active OpenClaw runtime turns and Slack/channel replies reflected in Command Center Live Activity instead of those agents collapsing to idle during real work. Message content is not sent; only action class, channel label, session/run keys, and lease metadata are emitted.

## Evidence

- `git diff --check`
- `node scripts/run-vitest.mjs src/infra/runtime-activity-emitter.test.ts src/channels/message/send.test.ts`
  - infra shard: 3 tests passed
  - channels shard: 17 tests passed
