### PR TITLE
fix(media-understanding): downscale configured image descriptions

### DIFF
--- a/src/agents/image-compression-policy.ts
+++ b/src/agents/image-compression-policy.ts
@@ -1,24 +1,17 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type {
-  ImageCompressionModelPolicy,
-  ImageCompressionPolicy,
-} from "../media/web-media.js";
 import { normalizeMediaProviderId } from "../media-understanding/provider-id.js";
+import type { ImageCompressionModelPolicy, ImageCompressionPolicy } from "../media/web-media.js";
 import {
   isManifestPluginAvailableForControlPlane,
   loadManifestMetadataSnapshot,
 } from "../plugins/manifest-contract-eligibility.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
+import { resolveModelAsync } from "./embedded-agent-runner/model.js";
 import {
   bundledStaticCatalogProviderUsesRuntimeAugment,
   resolveBundledStaticCatalogModel,
 } from "./embedded-agent-runner/model.static-catalog.js";
-import { resolveModelAsync } from "./embedded-agent-runner/model.js";
-
-export type ImageCompressionModelCandidate = {
-  provider: string;
-  model: string;
-};
+import type { ImageCompressionModelCandidate } from "./image-compression-policy.types.js";
 
 export type ImageCompressionPolicyDeps = {
   resolveBundledStaticCatalogModel: typeof resolveBundledStaticCatalogModel;

--- a/src/agents/image-compression-policy.ts
+++ b/src/agents/image-compression-policy.ts
@@ -1,0 +1,237 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type {
+  ImageCompressionModelPolicy,
+  ImageCompressionPolicy,
+} from "../media/web-media.js";
+import { normalizeMediaProviderId } from "../media-understanding/provider-id.js";
+import {
+  isManifestPluginAvailableForControlPlane,
+  loadManifestMetadataSnapshot,
+} from "../plugins/manifest-contract-eligibility.js";
+import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
+import {
+  bundledStaticCatalogProviderUsesRuntimeAugment,
+  resolveBundledStaticCatalogModel,
+} from "./embedded-agent-runner/model.static-catalog.js";
+import { resolveModelAsync } from "./embedded-agent-runner/model.js";
+
+export type ImageCompressionModelCandidate = {
+  provider: string;
+  model: string;
+};
+
+export type ImageCompressionPolicyDeps = {
+  resolveBundledStaticCatalogModel: typeof resolveBundledStaticCatalogModel;
+  resolveModelAsync: typeof resolveModelAsync;
+};
+
+const defaultImageCompressionPolicyDeps: ImageCompressionPolicyDeps = {
+  resolveBundledStaticCatalogModel,
+  resolveModelAsync,
+};
+
+function imageCompressionPolicyHasDimensionLimit(policy: ImageCompressionModelPolicy): boolean {
+  return typeof policy.maxSidePx === "number" || typeof policy.maxPixels === "number";
+}
+
+function imageCompressionModelPolicyHasAnyLimit(policy: ImageCompressionModelPolicy): boolean {
+  return (
+    typeof policy.maxBytes === "number" ||
+    typeof policy.maxSidePx === "number" ||
+    typeof policy.maxPixels === "number" ||
+    typeof policy.preferredSidePx === "number"
+  );
+}
+
+function mergeImageCompressionPolicies(params: {
+  runtimePolicy: ImageCompressionModelPolicy;
+  staticPolicy: ImageCompressionModelPolicy;
+}): ImageCompressionModelPolicy {
+  return {
+    ...params.runtimePolicy,
+    ...params.staticPolicy,
+  };
+}
+
+function resolveBundledStaticCompressionModelPolicy(params: {
+  cfg?: OpenClawConfig;
+  deps: ImageCompressionPolicyDeps;
+  provider: string;
+  model: string;
+  workspaceDir?: string;
+}): ImageCompressionModelPolicy {
+  const model = params.deps.resolveBundledStaticCatalogModel({
+    provider: params.provider,
+    modelId: params.model,
+    cfg: params.cfg,
+    workspaceDir: params.workspaceDir,
+    includeRuntimeDiscovery: true,
+  });
+  return model?.mediaInput?.image ?? {};
+}
+
+function providerUsesRuntimeModelAugment(params: {
+  cfg?: OpenClawConfig;
+  provider: string;
+  workspaceDir?: string;
+}): boolean {
+  const provider = normalizeMediaProviderId(params.provider);
+  if (!provider) {
+    return false;
+  }
+  if (bundledStaticCatalogProviderUsesRuntimeAugment({ provider })) {
+    return true;
+  }
+  const config = params.cfg ?? {};
+  const snapshot = loadManifestMetadataSnapshot({
+    config,
+    env: process.env,
+    ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
+  });
+  return snapshot.plugins.some((plugin) => {
+    const ownsProvider =
+      plugin.providers.some((candidate) => normalizeMediaProviderId(candidate) === provider) ||
+      Boolean(plugin.modelCatalog?.providers?.[provider]);
+    if (!ownsProvider) {
+      return false;
+    }
+    const runtimeAugment =
+      plugin.modelCatalog?.runtimeAugment === true ||
+      (plugin.origin !== "bundled" &&
+        plugin.providers.some((candidate) => normalizeMediaProviderId(candidate) === provider));
+    if (!runtimeAugment) {
+      return false;
+    }
+    return isManifestPluginAvailableForControlPlane({
+      snapshot,
+      plugin,
+      config,
+    });
+  });
+}
+
+async function resolveCompressionModelPolicyWithHooks(params: {
+  cfg?: OpenClawConfig;
+  deps: ImageCompressionPolicyDeps;
+  provider: string;
+  model: string;
+  agentDir?: string;
+  workspaceDir?: string;
+  skipProviderRuntimeHooks: boolean;
+}): Promise<ImageCompressionModelPolicy> {
+  try {
+    const resolved = await params.deps.resolveModelAsync(
+      params.provider,
+      params.model,
+      params.agentDir,
+      params.cfg,
+      {
+        allowBundledStaticCatalogFallback: true,
+        skipProviderRuntimeHooks: params.skipProviderRuntimeHooks,
+        skipAgentDiscovery: true,
+        workspaceDir: params.workspaceDir,
+      },
+    );
+    return (resolved.model as ProviderRuntimeModel | undefined)?.mediaInput?.image ?? {};
+  } catch {
+    return {};
+  }
+}
+
+async function resolveCompressionModelPolicy(params: {
+  cfg?: OpenClawConfig;
+  deps: ImageCompressionPolicyDeps;
+  provider: string;
+  model: string;
+  agentDir?: string;
+  workspaceDir?: string;
+}): Promise<ImageCompressionModelPolicy> {
+  const configuredStaticPolicy = await resolveCompressionModelPolicyWithHooks({
+    ...params,
+    skipProviderRuntimeHooks: true,
+  });
+  const staticPolicy = mergeImageCompressionPolicies({
+    runtimePolicy: resolveBundledStaticCompressionModelPolicy(params),
+    staticPolicy: configuredStaticPolicy,
+  });
+  if (
+    imageCompressionPolicyHasDimensionLimit(staticPolicy) ||
+    !providerUsesRuntimeModelAugment({
+      cfg: params.cfg,
+      provider: params.provider,
+      workspaceDir: params.workspaceDir,
+    })
+  ) {
+    return staticPolicy;
+  }
+  const runtimePolicy = await resolveCompressionModelPolicyWithHooks({
+    ...params,
+    skipProviderRuntimeHooks: false,
+  });
+  return mergeImageCompressionPolicies({ runtimePolicy, staticPolicy });
+}
+
+function configuredMaxSidePolicy(
+  cfg: OpenClawConfig | undefined,
+): ImageCompressionModelPolicy | null {
+  const configured = cfg?.agents?.defaults?.imageMaxDimensionPx;
+  if (typeof configured !== "number" || !Number.isFinite(configured) || configured <= 0) {
+    return null;
+  }
+  return { maxSidePx: Math.floor(configured) };
+}
+
+export async function resolveModelAwareImageCompressionPolicy(params: {
+  cfg?: OpenClawConfig;
+  modelCandidates: readonly ImageCompressionModelCandidate[];
+  imageCount?: number;
+  agentDir?: string;
+  workspaceDir?: string;
+  includeConfiguredMaxSide?: boolean;
+  includeImageCountWithoutPolicy?: boolean;
+  preserveEmptyModelPolicies?: boolean;
+  deps?: Partial<ImageCompressionPolicyDeps>;
+}): Promise<ImageCompressionPolicy | undefined> {
+  const deps: ImageCompressionPolicyDeps = {
+    resolveBundledStaticCatalogModel:
+      params.deps?.resolveBundledStaticCatalogModel ??
+      defaultImageCompressionPolicyDeps.resolveBundledStaticCatalogModel,
+    resolveModelAsync:
+      params.deps?.resolveModelAsync ?? defaultImageCompressionPolicyDeps.resolveModelAsync,
+  };
+  const resolvedModels = await Promise.all(
+    params.modelCandidates.map(async (candidate) =>
+      resolveCompressionModelPolicy({
+        cfg: params.cfg,
+        deps,
+        provider: candidate.provider,
+        model: candidate.model,
+        agentDir: params.agentDir,
+        workspaceDir: params.workspaceDir,
+      }),
+    ),
+  );
+  const modelPolicies = params.preserveEmptyModelPolicies
+    ? resolvedModels
+    : resolvedModels.filter(imageCompressionModelPolicyHasAnyLimit);
+  const configuredPolicy = params.includeConfiguredMaxSide
+    ? configuredMaxSidePolicy(params.cfg)
+    : null;
+  const models = configuredPolicy ? [configuredPolicy, ...modelPolicies] : modelPolicies;
+  const quality = params.cfg?.agents?.defaults?.imageQuality;
+  const imageCount =
+    typeof params.imageCount === "number" && Number.isFinite(params.imageCount)
+      ? Math.max(1, Math.floor(params.imageCount))
+      : undefined;
+  const includeImageCount =
+    imageCount !== undefined &&
+    (params.includeImageCountWithoutPolicy !== false || Boolean(quality) || models.length > 0);
+  if (!quality && models.length === 0 && !includeImageCount) {
+    return undefined;
+  }
+  return {
+    ...(quality ? { quality } : {}),
+    ...(models.length > 0 ? { models } : {}),
+    ...(includeImageCount ? { imageCount } : {}),
+  };
+}

--- a/src/agents/image-compression-policy.types.ts
+++ b/src/agents/image-compression-policy.types.ts
@@ -1,0 +1,7 @@
+// Leaf contract for the model-aware image compression resolver. Kept free of the
+// embedded-agent-runner model runtime so media-understanding can name a candidate
+// without importing the model hub, which would close an agents<->media import cycle.
+export type ImageCompressionModelCandidate = {
+  provider: string;
+  model: string;
+};

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -23,27 +23,16 @@ import {
   classifyMediaReferenceSource,
   normalizeMediaReferenceSource,
 } from "../../media/media-reference.js";
-import type {
-  ImageCompressionModelPolicy,
-  ImageCompressionPolicy,
-  WebMediaResult,
-} from "../../media/web-media.js";
+import type { ImageCompressionPolicy, WebMediaResult } from "../../media/web-media.js";
 import {
   describeImageWithModel,
   describeImagesWithModel,
   type MediaUnderstandingProvider,
 } from "../../plugin-sdk/media-understanding.js";
-import {
-  isManifestPluginAvailableForControlPlane,
-  loadManifestMetadataSnapshot,
-} from "../../plugins/manifest-contract-eligibility.js";
-import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
+import { resolveModelAwareImageCompressionPolicy } from "../image-compression-policy.js";
 import { resolveUserPath } from "../../utils.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
-import {
-  bundledStaticCatalogProviderUsesRuntimeAugment,
-  resolveBundledStaticCatalogModel,
-} from "../embedded-agent-runner/model.static-catalog.js";
+import { resolveBundledStaticCatalogModel } from "../embedded-agent-runner/model.static-catalog.js";
 import { isMinimaxVlmProvider } from "../minimax-vlm.js";
 import {
   resolveImageFallbackCandidates,
@@ -414,135 +403,6 @@ function resolveCompressionModelCandidates(params: {
   });
 }
 
-function imageCompressionPolicyHasDimensionLimit(policy: ImageCompressionModelPolicy): boolean {
-  return typeof policy.maxSidePx === "number" || typeof policy.maxPixels === "number";
-}
-
-function mergeImageCompressionPolicies(params: {
-  runtimePolicy: ImageCompressionModelPolicy;
-  staticPolicy: ImageCompressionModelPolicy;
-}): ImageCompressionModelPolicy {
-  return {
-    ...params.runtimePolicy,
-    ...params.staticPolicy,
-  };
-}
-
-function resolveBundledStaticCompressionModelPolicy(params: {
-  cfg?: OpenClawConfig;
-  provider: string;
-  model: string;
-  workspaceDir?: string;
-}): ImageCompressionModelPolicy {
-  const model = imageToolProviderDeps.resolveBundledStaticCatalogModel({
-    provider: params.provider,
-    modelId: params.model,
-    cfg: params.cfg,
-    workspaceDir: params.workspaceDir,
-    includeRuntimeDiscovery: true,
-  });
-  return model?.mediaInput?.image ?? {};
-}
-
-function providerUsesRuntimeModelAugment(params: {
-  cfg?: OpenClawConfig;
-  provider: string;
-  workspaceDir?: string;
-}): boolean {
-  const provider = normalizeMediaProviderId(params.provider);
-  if (!provider) {
-    return false;
-  }
-  if (bundledStaticCatalogProviderUsesRuntimeAugment({ provider })) {
-    return true;
-  }
-  const config = params.cfg ?? {};
-  const snapshot = loadManifestMetadataSnapshot({
-    config,
-    env: process.env,
-    ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
-  });
-  return snapshot.plugins.some((plugin) => {
-    const ownsProvider =
-      plugin.providers.some((candidate) => normalizeMediaProviderId(candidate) === provider) ||
-      Boolean(plugin.modelCatalog?.providers?.[provider]);
-    if (!ownsProvider) {
-      return false;
-    }
-    const runtimeAugment =
-      plugin.modelCatalog?.runtimeAugment === true ||
-      (plugin.origin !== "bundled" &&
-        plugin.providers.some((candidate) => normalizeMediaProviderId(candidate) === provider));
-    if (!runtimeAugment) {
-      return false;
-    }
-    return isManifestPluginAvailableForControlPlane({
-      snapshot,
-      plugin,
-      config,
-    });
-  });
-}
-
-async function resolveCompressionModelPolicyWithHooks(params: {
-  cfg?: OpenClawConfig;
-  provider: string;
-  model: string;
-  agentDir?: string;
-  workspaceDir?: string;
-  skipProviderRuntimeHooks: boolean;
-}): Promise<ImageCompressionModelPolicy> {
-  try {
-    const resolved = await imageToolProviderDeps.resolveModelAsync(
-      params.provider,
-      params.model,
-      params.agentDir,
-      params.cfg,
-      {
-        allowBundledStaticCatalogFallback: true,
-        skipProviderRuntimeHooks: params.skipProviderRuntimeHooks,
-        skipAgentDiscovery: true,
-        workspaceDir: params.workspaceDir,
-      },
-    );
-    return (resolved.model as ProviderRuntimeModel | undefined)?.mediaInput?.image ?? {};
-  } catch {
-    return {};
-  }
-}
-
-async function resolveCompressionModelPolicy(params: {
-  cfg?: OpenClawConfig;
-  provider: string;
-  model: string;
-  agentDir?: string;
-  workspaceDir?: string;
-}): Promise<ImageCompressionModelPolicy> {
-  const configuredStaticPolicy = await resolveCompressionModelPolicyWithHooks({
-    ...params,
-    skipProviderRuntimeHooks: true,
-  });
-  const staticPolicy = mergeImageCompressionPolicies({
-    runtimePolicy: resolveBundledStaticCompressionModelPolicy(params),
-    staticPolicy: configuredStaticPolicy,
-  });
-  if (
-    imageCompressionPolicyHasDimensionLimit(staticPolicy) ||
-    !providerUsesRuntimeModelAugment({
-      cfg: params.cfg,
-      provider: params.provider,
-      workspaceDir: params.workspaceDir,
-    })
-  ) {
-    return staticPolicy;
-  }
-  const runtimePolicy = await resolveCompressionModelPolicyWithHooks({
-    ...params,
-    skipProviderRuntimeHooks: false,
-  });
-  return mergeImageCompressionPolicies({ runtimePolicy, staticPolicy });
-}
-
 async function resolveImageCompressionPolicy(params: {
   cfg?: OpenClawConfig;
   imageModelConfig?: ImageModelConfig | null;
@@ -552,23 +412,20 @@ async function resolveImageCompressionPolicy(params: {
   workspaceDir?: string;
 }): Promise<ImageCompressionPolicy> {
   const modelCandidates = resolveCompressionModelCandidates(params);
-  const quality = params.cfg?.agents?.defaults?.imageQuality;
-  const models: ImageCompressionModelPolicy[] = await Promise.all(
-    modelCandidates.map(async (candidate): Promise<ImageCompressionModelPolicy> => {
-      return resolveCompressionModelPolicy({
-        cfg: params.cfg,
-        provider: candidate.provider,
-        model: candidate.model,
-        agentDir: params.agentDir,
-        workspaceDir: params.workspaceDir,
-      });
-    }),
+  return (
+    (await resolveModelAwareImageCompressionPolicy({
+      cfg: params.cfg,
+      modelCandidates,
+      imageCount: params.imageCount,
+      agentDir: params.agentDir,
+      workspaceDir: params.workspaceDir,
+      preserveEmptyModelPolicies: true,
+      deps: {
+        resolveBundledStaticCatalogModel: imageToolProviderDeps.resolveBundledStaticCatalogModel,
+        resolveModelAsync: imageToolProviderDeps.resolveModelAsync,
+      },
+    })) ?? { imageCount: params.imageCount }
   );
-  return {
-    imageCount: params.imageCount,
-    ...(models.length > 0 ? { models } : {}),
-    ...(quality ? { quality } : {}),
-  };
 }
 
 function matchesImageTimeoutEntry(params: {

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -29,10 +29,10 @@ import {
   describeImagesWithModel,
   type MediaUnderstandingProvider,
 } from "../../plugin-sdk/media-understanding.js";
-import { resolveModelAwareImageCompressionPolicy } from "../image-compression-policy.js";
 import { resolveUserPath } from "../../utils.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import { resolveBundledStaticCatalogModel } from "../embedded-agent-runner/model.static-catalog.js";
+import { resolveModelAwareImageCompressionPolicy } from "../image-compression-policy.js";
 import { isMinimaxVlmProvider } from "../minimax-vlm.js";
 import {
   resolveImageFallbackCandidates,

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -615,6 +615,7 @@ describe("capability cli", () => {
     filePath?: string;
     mediaUrl?: string;
     model?: unknown;
+    modelCandidates?: unknown;
     prompt?: unknown;
     provider?: unknown;
     timeoutMs?: unknown;
@@ -1455,6 +1456,10 @@ describe("capability cli", () => {
     });
 
     expect(mocks.prepareImageDescriptionInput).toHaveBeenCalledTimes(1);
+    expect(firstImagePrepareCall()?.modelCandidates).toEqual([
+      { provider: "openrouter", model: "google/gemma-4-31b-it:free" },
+      { provider: "openrouter", model: "google/gemma-4-31b-it" },
+    ]);
     const calls = mocks.describePreparedImageWithModel.mock.calls as unknown as Array<
       [ImageDescribeParams]
     >;

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -29,7 +29,11 @@ import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import { resolveApiKeyForProvider } from "../agents/model-auth.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
-import { runWithImageModelFallback } from "../agents/model-fallback.js";
+import {
+  resolveImageFallbackCandidates,
+  resolveImageFallbackDefaultProvider,
+  runWithImageModelFallback,
+} from "../agents/model-fallback.js";
 import { canonicalizeCaseOnlyCatalogModelRef } from "../agents/model-selection.js";
 import { assertOkOrThrowHttpError } from "../agents/provider-http-errors.js";
 import {
@@ -1092,22 +1096,31 @@ async function runImageDescribe(params: {
     params.files.map(async (filePath) => {
       const resolvedPath = resolveImageDescribeInput(filePath);
       const isRemoteUrl = /^https?:\/\//i.test(resolvedPath);
+      const modelOverride = activeModel
+        ? `${activeModel.provider}/${activeModel.model}`
+        : undefined;
+      const imageModelCandidates = modelOverride
+        ? resolveImageFallbackCandidates({
+            cfg,
+            defaultProvider: resolveImageFallbackDefaultProvider(cfg),
+            modelOverride,
+          })
+        : [];
       const preparedImage = activeModel
-          ? await prepareImageDescriptionInput({
-              filePath: resolvedPath,
-              ...(isRemoteUrl ? { mediaUrl: resolvedPath } : {}),
-              cfg,
-              agentDir,
-              provider: activeModel.provider,
-              model: activeModel.model,
-              timeoutMs: params.timeoutMs,
-            })
+        ? await prepareImageDescriptionInput({
+            filePath: resolvedPath,
+            ...(isRemoteUrl ? { mediaUrl: resolvedPath } : {}),
+            cfg,
+            agentDir,
+            modelCandidates: imageModelCandidates,
+            timeoutMs: params.timeoutMs,
+          })
         : undefined;
       const result =
         activeModel && preparedImage
           ? await runWithImageModelFallback({
               cfg,
-              modelOverride: `${activeModel.provider}/${activeModel.model}`,
+              modelOverride,
               run: async (provider, model) => {
                 const described = await describePreparedImageWithModel({
                   image: preparedImage,

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -1093,12 +1093,15 @@ async function runImageDescribe(params: {
       const resolvedPath = resolveImageDescribeInput(filePath);
       const isRemoteUrl = /^https?:\/\//i.test(resolvedPath);
       const preparedImage = activeModel
-        ? await prepareImageDescriptionInput({
-            filePath: resolvedPath,
-            ...(isRemoteUrl ? { mediaUrl: resolvedPath } : {}),
-            cfg,
-            timeoutMs: params.timeoutMs,
-          })
+          ? await prepareImageDescriptionInput({
+              filePath: resolvedPath,
+              ...(isRemoteUrl ? { mediaUrl: resolvedPath } : {}),
+              cfg,
+              agentDir,
+              provider: activeModel.provider,
+              model: activeModel.model,
+              timeoutMs: params.timeoutMs,
+            })
         : undefined;
       const result =
         activeModel && preparedImage

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -327,6 +327,14 @@ describe("applyMediaUnderstanding", () => {
     vi.doMock("../process/exec.js", () => ({
       runExec: runExecMock,
     }));
+    // These integration tests cover apply/HEIC/workspace routing, not the
+    // model-aware compression resolver (unit-tested in image-compression-policy
+    // and image-input-normalize tests). Keep the pre-compression passthrough so
+    // the real optimizer never runs against synthetic image buffers.
+    vi.doMock("./image-compression-policy.js", () => ({
+      resolveImageDescriptionCompressionPolicy: vi.fn(async () => undefined),
+      resolveImageDescriptionPreCompressionMaxBytes: (maxBytes: number) => maxBytes,
+    }));
     vi.doMock("./provider-registry.js", async () => {
       const actual =
         await vi.importActual<typeof import("./provider-registry.js")>("./provider-registry.js");

--- a/src/media-understanding/image-compression-policy.ts
+++ b/src/media-understanding/image-compression-policy.ts
@@ -4,6 +4,15 @@ import {
 } from "../agents/image-compression-policy.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type { ImageCompressionPolicy } from "../media/web-media.js";
+import { DEFAULT_MAX_BYTES } from "./defaults.constants.js";
+
+// Image descriptions can shrink oversized originals before provider execution;
+// keep source reads bounded, then enforce the provider maxBytes after compression.
+const IMAGE_DESCRIPTION_PRE_COMPRESSION_MAX_BYTES = DEFAULT_MAX_BYTES.video;
+
+export function resolveImageDescriptionPreCompressionMaxBytes(maxBytes: number): number {
+  return Math.max(maxBytes, IMAGE_DESCRIPTION_PRE_COMPRESSION_MAX_BYTES);
+}
 
 /** Resolves media-understanding image compression from selected model metadata and user config. */
 export async function resolveImageDescriptionCompressionPolicy(params: {

--- a/src/media-understanding/image-compression-policy.ts
+++ b/src/media-understanding/image-compression-policy.ts
@@ -1,0 +1,31 @@
+import {
+  resolveModelAwareImageCompressionPolicy,
+  type ImageCompressionModelCandidate,
+} from "../agents/image-compression-policy.js";
+import type { OpenClawConfig } from "../config/types.js";
+import type { ImageCompressionPolicy } from "../media/web-media.js";
+
+/** Resolves media-understanding image compression from selected model metadata and user config. */
+export async function resolveImageDescriptionCompressionPolicy(params: {
+  cfg?: OpenClawConfig;
+  provider?: string;
+  model?: string;
+  modelCandidates?: readonly ImageCompressionModelCandidate[];
+  agentDir?: string;
+  workspaceDir?: string;
+}): Promise<ImageCompressionPolicy | undefined> {
+  const provider = params.provider?.trim();
+  const model = params.model?.trim();
+  const modelCandidates =
+    params.modelCandidates ?? (provider && model ? [{ provider, model }] : []);
+  return await resolveModelAwareImageCompressionPolicy({
+    cfg: params.cfg,
+    modelCandidates,
+    imageCount: 1,
+    agentDir: params.agentDir,
+    workspaceDir: params.workspaceDir,
+    includeConfiguredMaxSide: true,
+    includeImageCountWithoutPolicy: false,
+    preserveEmptyModelPolicies: false,
+  });
+}

--- a/src/media-understanding/image-compression-policy.ts
+++ b/src/media-understanding/image-compression-policy.ts
@@ -1,7 +1,5 @@
-import {
-  resolveModelAwareImageCompressionPolicy,
-  type ImageCompressionModelCandidate,
-} from "../agents/image-compression-policy.js";
+import { resolveModelAwareImageCompressionPolicy } from "../agents/image-compression-policy.js";
+import type { ImageCompressionModelCandidate } from "../agents/image-compression-policy.types.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type { ImageCompressionPolicy } from "../media/web-media.js";
 import { DEFAULT_MAX_BYTES } from "./defaults.constants.js";

--- a/src/media-understanding/image-input-normalize.test.ts
+++ b/src/media-understanding/image-input-normalize.test.ts
@@ -1,0 +1,115 @@
+// Image description input normalization guards byte limits around HEIC conversion
+// and optional provider-aware compression.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ImageCompressionPolicy } from "../media/web-media.js";
+import {
+  isImageDescriptionMaxBytesError,
+  normalizeImageDescriptionInput,
+} from "./image-input-normalize.js";
+
+const mocks = vi.hoisted(() => ({
+  convertHeicToJpeg: vi.fn(async () => Buffer.from("jpeg-normalized")),
+  optimizeImageBufferForWebMedia: vi.fn(async ({ buffer, contentType, fileName }) => ({
+    buffer,
+    contentType,
+    fileName,
+    kind: "image" as const,
+  })),
+}));
+
+vi.mock("../media/media-services.js", () => ({
+  convertHeicToJpeg: mocks.convertHeicToJpeg,
+}));
+
+vi.mock("../media/web-media.js", () => ({
+  optimizeImageBufferForWebMedia: mocks.optimizeImageBufferForWebMedia,
+}));
+
+describe("normalizeImageDescriptionInput", () => {
+  afterEach(() => {
+    mocks.convertHeicToJpeg.mockReset();
+    mocks.convertHeicToJpeg.mockResolvedValue(Buffer.from("jpeg-normalized"));
+    mocks.optimizeImageBufferForWebMedia.mockReset();
+    mocks.optimizeImageBufferForWebMedia.mockImplementation(
+      async ({ buffer, contentType, fileName }) => ({
+        buffer,
+        contentType,
+        fileName,
+        kind: "image" as const,
+      }),
+    );
+  });
+
+  it("allows HEIC source bytes above the final provider cap when compression applies", async () => {
+    const imageCompression = { quality: "balanced" } satisfies ImageCompressionPolicy;
+    mocks.optimizeImageBufferForWebMedia.mockResolvedValue({
+      buffer: Buffer.from("ok"),
+      contentType: "image/jpeg",
+      fileName: "photo.heic",
+      kind: "image",
+    });
+
+    const result = await normalizeImageDescriptionInput({
+      buffer: Buffer.from("oversized-heic"),
+      fileName: "photo.heic",
+      imageCompression,
+      maxBytes: 8,
+      mime: "image/heic",
+      sourceMaxBytes: 32,
+    });
+
+    expect(mocks.convertHeicToJpeg).toHaveBeenCalledWith(Buffer.from("oversized-heic"));
+    expect(mocks.optimizeImageBufferForWebMedia).toHaveBeenCalledWith({
+      buffer: Buffer.from("jpeg-normalized"),
+      contentType: "image/jpeg",
+      fileName: "photo.heic",
+      maxBytes: 8,
+      imageCompression,
+    });
+    expect(result).toEqual({ buffer: Buffer.from("ok"), mime: "image/jpeg" });
+  });
+
+  it("enforces the final provider cap after HEIC compression", async () => {
+    const imageCompression = { quality: "balanced" } satisfies ImageCompressionPolicy;
+    mocks.optimizeImageBufferForWebMedia.mockResolvedValue({
+      buffer: Buffer.from("still-large"),
+      contentType: "image/jpeg",
+      fileName: "photo.heic",
+      kind: "image",
+    });
+
+    await expect(
+      normalizeImageDescriptionInput({
+        buffer: Buffer.from("oversized-heic"),
+        fileName: "photo.heic",
+        imageCompression,
+        maxBytes: 8,
+        mime: "image/heic",
+        sourceMaxBytes: 32,
+      }),
+    ).rejects.toThrow("Image exceeds maxBytes 8");
+  });
+
+  it("wraps optimizer cap failures in an image maxBytes error", async () => {
+    const imageCompression = { quality: "balanced" } satisfies ImageCompressionPolicy;
+    mocks.optimizeImageBufferForWebMedia.mockRejectedValue(
+      new Error("Media could not be reduced below 1MB (got 2MB)"),
+    );
+
+    let caught: unknown;
+    try {
+      await normalizeImageDescriptionInput({
+        buffer: Buffer.from("jpeg-source"),
+        fileName: "photo.jpg",
+        imageCompression,
+        maxBytes: 8,
+        mime: "image/jpeg",
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(isImageDescriptionMaxBytesError(caught)).toBe(true);
+    expect(caught).toMatchObject({ maxBytes: 8 });
+  });
+});

--- a/src/media-understanding/image-input-normalize.ts
+++ b/src/media-understanding/image-input-normalize.ts
@@ -88,26 +88,3 @@ export async function normalizeImageDescriptionInput(params: {
     mime: normalized.mime,
   });
 }
-
-/** Resolves user-configured image compression controls for media-understanding inputs. */
-export function resolveImageDescriptionCompressionPolicy(cfg?: {
-  agents?: { defaults?: { imageMaxDimensionPx?: number; imageQuality?: string } };
-}): ImageCompressionPolicy | undefined {
-  const maxSidePx = cfg?.agents?.defaults?.imageMaxDimensionPx;
-  const quality = cfg?.agents?.defaults?.imageQuality;
-  const modelPolicy =
-    typeof maxSidePx === "number" && Number.isFinite(maxSidePx) && maxSidePx > 0
-      ? { maxSidePx: Math.floor(maxSidePx) }
-      : undefined;
-  const normalizedQuality =
-    quality === "auto" || quality === "efficient" || quality === "balanced" || quality === "high"
-      ? quality
-      : undefined;
-  if (!modelPolicy && !normalizedQuality) {
-    return undefined;
-  }
-  return {
-    ...(normalizedQuality ? { quality: normalizedQuality } : {}),
-    ...(modelPolicy ? { models: [modelPolicy] } : {}),
-  };
-}

--- a/src/media-understanding/image-input-normalize.ts
+++ b/src/media-understanding/image-input-normalize.ts
@@ -8,6 +8,34 @@ import { DEFAULT_MAX_BYTES } from "./defaults.constants.js";
 const HEIC_MIME_RE = /^image\/hei[cf]$/i;
 const HEIC_EXT_RE = /\.(heic|heif)$/i;
 
+export class ImageDescriptionMaxBytesError extends Error {
+  readonly maxBytes: number;
+
+  constructor(maxBytes: number, cause?: unknown) {
+    super(`Image exceeds maxBytes ${maxBytes}`, cause === undefined ? undefined : { cause });
+    this.name = "ImageDescriptionMaxBytesError";
+    this.maxBytes = maxBytes;
+  }
+}
+
+export function isImageDescriptionMaxBytesError(
+  err: unknown,
+): err is ImageDescriptionMaxBytesError {
+  return err instanceof ImageDescriptionMaxBytesError;
+}
+
+function isImageOptimizationMaxBytesError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const message = err.message.toLowerCase();
+  return (
+    message.includes("could not be reduced below") ||
+    message.includes("exceeds maxbytes") ||
+    (message.includes("exceeds") && message.includes("limit"))
+  );
+}
+
 function isHeicInput(params: { mime?: string; fileName?: string }): boolean {
   const mime = normalizeMimeType(params.mime);
   if (mime && HEIC_MIME_RE.test(mime)) {
@@ -32,14 +60,29 @@ async function maybeOptimizeImageDescriptionInput(params: {
     return { buffer: params.buffer, mime: params.mime };
   }
   const mime = resolveImageInputMime(params);
-  const optimized = await optimizeImageBufferForWebMedia({
-    buffer: params.buffer,
-    contentType: mime,
-    fileName: params.fileName,
-    maxBytes: params.maxBytes,
-    imageCompression: params.imageCompression,
-  });
+  let optimized: Awaited<ReturnType<typeof optimizeImageBufferForWebMedia>>;
+  try {
+    optimized = await optimizeImageBufferForWebMedia({
+      buffer: params.buffer,
+      contentType: mime,
+      fileName: params.fileName,
+      maxBytes: params.maxBytes,
+      imageCompression: params.imageCompression,
+    });
+  } catch (err) {
+    if (isImageOptimizationMaxBytesError(err)) {
+      throw new ImageDescriptionMaxBytesError(params.maxBytes, err);
+    }
+    throw err;
+  }
   return { buffer: optimized.buffer, mime: optimized.contentType ?? mime };
+}
+
+function assertImageDescriptionMaxBytes(params: { buffer: Buffer; maxBytes: number }): void {
+  if (params.buffer.length <= params.maxBytes) {
+    return;
+  }
+  throw new ImageDescriptionMaxBytesError(params.maxBytes);
 }
 
 /** Normalizes image bytes before provider execution, converting HEIC/HEIF inputs to JPEG. */
@@ -49,8 +92,10 @@ export async function normalizeImageDescriptionInput(params: {
   imageCompression?: ImageCompressionPolicy;
   mime?: string;
   maxBytes?: number;
+  sourceMaxBytes?: number;
 }): Promise<{ buffer: Buffer; mime?: string }> {
   const maxBytes = params.maxBytes ?? DEFAULT_MAX_BYTES.image;
+  const sourceMaxBytes = params.sourceMaxBytes ?? maxBytes;
   if (!isHeicInput(params)) {
     return await maybeOptimizeImageDescriptionInput({
       buffer: params.buffer,
@@ -71,7 +116,7 @@ export async function normalizeImageDescriptionInput(params: {
     {
       allowUrl: false,
       allowedMimes: new Set([sourceMime.toLowerCase(), "image/heic", "image/heif", "image/jpeg"]),
-      maxBytes,
+      maxBytes: sourceMaxBytes,
       maxRedirects: 0,
       timeoutMs: 0,
     },
@@ -80,11 +125,15 @@ export async function normalizeImageDescriptionInput(params: {
     buffer: Buffer.from(image.data, "base64"),
     mime: image.mimeType,
   };
-  return await maybeOptimizeImageDescriptionInput({
+  const result = await maybeOptimizeImageDescriptionInput({
     buffer: normalized.buffer,
     fileName: params.fileName,
     maxBytes,
     imageCompression: params.imageCompression,
     mime: normalized.mime,
   });
+  if (sourceMaxBytes > maxBytes) {
+    assertImageDescriptionMaxBytes({ buffer: result.buffer, maxBytes });
+  }
+  return result;
 }

--- a/src/media-understanding/image-input-normalize.ts
+++ b/src/media-understanding/image-input-normalize.ts
@@ -1,6 +1,8 @@
 // Image input normalization converts HEIC/HEIF payloads through the shared
 // input-file media path before provider execution.
+import { mimeTypeFromFilePath } from "@openclaw/media-core/mime";
 import { extractImageContentFromSource, normalizeMimeType } from "../media/input-files.js";
+import { optimizeImageBufferForWebMedia, type ImageCompressionPolicy } from "../media/web-media.js";
 import { DEFAULT_MAX_BYTES } from "./defaults.constants.js";
 
 const HEIC_MIME_RE = /^image\/hei[cf]$/i;
@@ -15,15 +17,48 @@ function isHeicInput(params: { mime?: string; fileName?: string }): boolean {
   return Boolean(fileName && HEIC_EXT_RE.test(fileName));
 }
 
+function resolveImageInputMime(params: { mime?: string; fileName?: string }): string | undefined {
+  return normalizeMimeType(params.mime) ?? mimeTypeFromFilePath(params.fileName) ?? params.mime;
+}
+
+async function maybeOptimizeImageDescriptionInput(params: {
+  buffer: Buffer;
+  fileName?: string;
+  imageCompression?: ImageCompressionPolicy;
+  maxBytes: number;
+  mime?: string;
+}): Promise<{ buffer: Buffer; mime?: string }> {
+  if (!params.imageCompression) {
+    return { buffer: params.buffer, mime: params.mime };
+  }
+  const mime = resolveImageInputMime(params);
+  const optimized = await optimizeImageBufferForWebMedia({
+    buffer: params.buffer,
+    contentType: mime,
+    fileName: params.fileName,
+    maxBytes: params.maxBytes,
+    imageCompression: params.imageCompression,
+  });
+  return { buffer: optimized.buffer, mime: optimized.contentType ?? mime };
+}
+
 /** Normalizes image bytes before provider execution, converting HEIC/HEIF inputs to JPEG. */
 export async function normalizeImageDescriptionInput(params: {
   buffer: Buffer;
   fileName?: string;
+  imageCompression?: ImageCompressionPolicy;
   mime?: string;
   maxBytes?: number;
 }): Promise<{ buffer: Buffer; mime?: string }> {
+  const maxBytes = params.maxBytes ?? DEFAULT_MAX_BYTES.image;
   if (!isHeicInput(params)) {
-    return { buffer: params.buffer, mime: params.mime };
+    return await maybeOptimizeImageDescriptionInput({
+      buffer: params.buffer,
+      fileName: params.fileName,
+      maxBytes,
+      imageCompression: params.imageCompression,
+      mime: params.mime,
+    });
   }
   const sourceMime = normalizeMimeType(params.mime) ?? "image/heic";
   // Reuse input-file extraction so HEIC conversion follows the same MIME and size guards.
@@ -36,13 +71,43 @@ export async function normalizeImageDescriptionInput(params: {
     {
       allowUrl: false,
       allowedMimes: new Set([sourceMime.toLowerCase(), "image/heic", "image/heif", "image/jpeg"]),
-      maxBytes: params.maxBytes ?? DEFAULT_MAX_BYTES.image,
+      maxBytes,
       maxRedirects: 0,
       timeoutMs: 0,
     },
   );
-  return {
+  const normalized = {
     buffer: Buffer.from(image.data, "base64"),
     mime: image.mimeType,
+  };
+  return await maybeOptimizeImageDescriptionInput({
+    buffer: normalized.buffer,
+    fileName: params.fileName,
+    maxBytes,
+    imageCompression: params.imageCompression,
+    mime: normalized.mime,
+  });
+}
+
+/** Resolves user-configured image compression controls for media-understanding inputs. */
+export function resolveImageDescriptionCompressionPolicy(cfg?: {
+  agents?: { defaults?: { imageMaxDimensionPx?: number; imageQuality?: string } };
+}): ImageCompressionPolicy | undefined {
+  const maxSidePx = cfg?.agents?.defaults?.imageMaxDimensionPx;
+  const quality = cfg?.agents?.defaults?.imageQuality;
+  const modelPolicy =
+    typeof maxSidePx === "number" && Number.isFinite(maxSidePx) && maxSidePx > 0
+      ? { maxSidePx: Math.floor(maxSidePx) }
+      : undefined;
+  const normalizedQuality =
+    quality === "auto" || quality === "efficient" || quality === "balanced" || quality === "high"
+      ? quality
+      : undefined;
+  if (!modelPolicy && !normalizedQuality) {
+    return undefined;
+  }
+  return {
+    ...(normalizedQuality ? { quality: normalizedQuality } : {}),
+    ...(modelPolicy ? { models: [modelPolicy] } : {}),
   };
 }

--- a/src/media-understanding/runner.entries.image-cap.test.ts
+++ b/src/media-understanding/runner.entries.image-cap.test.ts
@@ -46,14 +46,13 @@ describe("runProviderEntry image maxBytes", () => {
       new mocks.MockImageDescriptionMaxBytesError(10 * 1024 * 1024),
     );
     const describeImage = vi.fn(async () => ({ text: "should not run" }));
-    const cache = {
-      getBuffer: vi.fn(async () => ({
-        buffer: Buffer.from("oversized-jpeg"),
-        fileName: "large.jpg",
-        mime: "image/jpeg",
-        size: 20 * 1024 * 1024,
-      })),
-    } as unknown as MediaAttachmentCache;
+    const getBuffer = vi.fn(async () => ({
+      buffer: Buffer.from("oversized-jpeg"),
+      fileName: "large.jpg",
+      mime: "image/jpeg",
+      size: 20 * 1024 * 1024,
+    }));
+    const cache = { getBuffer } as unknown as MediaAttachmentCache;
 
     await expect(
       runProviderEntry({
@@ -81,7 +80,7 @@ describe("runProviderEntry image maxBytes", () => {
       message: "Attachment 1 exceeds maxBytes 10485760",
     });
 
-    expect(cache.getBuffer).toHaveBeenCalledWith({
+    expect(getBuffer).toHaveBeenCalledWith({
       attachmentIndex: 0,
       maxBytes: 50 * 1024 * 1024,
       timeoutMs: 60_000,

--- a/src/media-understanding/runner.entries.image-cap.test.ts
+++ b/src/media-understanding/runner.entries.image-cap.test.ts
@@ -1,0 +1,91 @@
+// Provider entry tests for image normalization byte-limit failures.
+import { describe, expect, it, vi } from "vitest";
+import type { MsgContext } from "../auto-reply/templating.js";
+import type { OpenClawConfig } from "../config/types.js";
+import type { MediaAttachmentCache } from "./attachments.js";
+import type { MediaUnderstandingProvider } from "./types.js";
+
+const mocks = vi.hoisted(() => {
+  class MockImageDescriptionMaxBytesError extends Error {
+    readonly maxBytes: number;
+
+    constructor(maxBytes: number) {
+      super(`Image exceeds maxBytes ${maxBytes}`);
+      this.name = "ImageDescriptionMaxBytesError";
+      this.maxBytes = maxBytes;
+    }
+  }
+
+  return {
+    MockImageDescriptionMaxBytesError,
+    normalizeImageDescriptionInput: vi.fn(),
+    resolveImageDescriptionCompressionPolicy: vi.fn(async () => ({ quality: "balanced" })),
+    resolveImageDescriptionPreCompressionMaxBytes: vi.fn((maxBytes: number) =>
+      Math.max(maxBytes, 50 * 1024 * 1024),
+    ),
+  };
+});
+
+vi.mock("./image-input-normalize.js", () => ({
+  normalizeImageDescriptionInput: mocks.normalizeImageDescriptionInput,
+  isImageDescriptionMaxBytesError: (err: unknown) =>
+    err instanceof mocks.MockImageDescriptionMaxBytesError,
+}));
+
+vi.mock("./image-compression-policy.js", () => ({
+  resolveImageDescriptionCompressionPolicy: mocks.resolveImageDescriptionCompressionPolicy,
+  resolveImageDescriptionPreCompressionMaxBytes:
+    mocks.resolveImageDescriptionPreCompressionMaxBytes,
+}));
+
+const { runProviderEntry } = await import("./runner.entries.js");
+
+describe("runProviderEntry image maxBytes", () => {
+  it("reports post-compression image cap failures as skipped maxBytes attempts", async () => {
+    mocks.normalizeImageDescriptionInput.mockRejectedValue(
+      new mocks.MockImageDescriptionMaxBytesError(10 * 1024 * 1024),
+    );
+    const describeImage = vi.fn(async () => ({ text: "should not run" }));
+    const cache = {
+      getBuffer: vi.fn(async () => ({
+        buffer: Buffer.from("oversized-jpeg"),
+        fileName: "large.jpg",
+        mime: "image/jpeg",
+        size: 20 * 1024 * 1024,
+      })),
+    } as unknown as MediaAttachmentCache;
+
+    await expect(
+      runProviderEntry({
+        capability: "image",
+        entry: { provider: "openrouter", model: "vision-model" },
+        cfg: {} as OpenClawConfig,
+        ctx: {} as MsgContext,
+        attachmentIndex: 0,
+        cache,
+        agentDir: "/tmp/agent",
+        providerRegistry: new Map<string, MediaUnderstandingProvider>([
+          [
+            "openrouter",
+            {
+              id: "openrouter",
+              capabilities: ["image"],
+              describeImage,
+            },
+          ],
+        ]),
+      }),
+    ).rejects.toMatchObject({
+      name: "MediaUnderstandingSkipError",
+      reason: "maxBytes",
+      message: "Attachment 1 exceeds maxBytes 10485760",
+    });
+
+    expect(cache.getBuffer).toHaveBeenCalledWith({
+      attachmentIndex: 0,
+      maxBytes: 50 * 1024 * 1024,
+      timeoutMs: 60_000,
+    });
+    expect(describeImage).not.toHaveBeenCalled();
+  });
+});

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -50,13 +50,18 @@ import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { MediaAttachmentCache } from "./attachments.js";
 import {
   CLI_OUTPUT_MAX_BUFFER,
-  DEFAULT_MAX_BYTES,
   DEFAULT_TIMEOUT_SECONDS,
   MIN_AUDIO_FILE_BYTES,
 } from "./defaults.constants.js";
 import { fileExists } from "./fs.js";
-import { resolveImageDescriptionCompressionPolicy } from "./image-compression-policy.js";
-import { normalizeImageDescriptionInput } from "./image-input-normalize.js";
+import {
+  resolveImageDescriptionCompressionPolicy,
+  resolveImageDescriptionPreCompressionMaxBytes,
+} from "./image-compression-policy.js";
+import {
+  isImageDescriptionMaxBytesError,
+  normalizeImageDescriptionInput,
+} from "./image-input-normalize.js";
 import { describeImageWithModel } from "./image-runtime.js";
 import {
   recordLocalAudioBackendObservation,
@@ -76,14 +81,6 @@ import type {
 
 type ProviderRegistry = Map<string, MediaUnderstandingProvider>;
 const loadModelAuth = createLazyRuntimeModule(async () => await import("../agents/model-auth.js"));
-
-// Image entries may shrink oversized originals before provider execution; keep
-// the source read bounded, then enforce the provider maxBytes after compression.
-const IMAGE_PRE_COMPRESSION_MAX_BYTES = DEFAULT_MAX_BYTES.video;
-
-function resolveImagePreCompressionMaxBytes(maxBytes: number): number {
-  return Math.max(maxBytes, IMAGE_PRE_COMPRESSION_MAX_BYTES);
-}
 
 function resolveLiteralProviderApiKey(params: {
   cfg: OpenClawConfig;
@@ -840,24 +837,40 @@ export async function runProviderEntry(params: {
     if (!modelId) {
       throw new Error("Image understanding requires model id");
     }
+    const imageCompression = await resolveImageDescriptionCompressionPolicy({
+      cfg,
+      provider: requestProviderId,
+      model: modelId,
+      agentDir: params.agentDir,
+      workspaceDir: params.workspaceDir,
+    });
+    const sourceMaxBytes = imageCompression
+      ? resolveImageDescriptionPreCompressionMaxBytes(maxBytes)
+      : maxBytes;
     const media = await params.cache.getBuffer({
       attachmentIndex: params.attachmentIndex,
-      maxBytes: resolveImagePreCompressionMaxBytes(maxBytes),
+      maxBytes: sourceMaxBytes,
       timeoutMs,
     });
-    const normalizedMedia = await normalizeImageDescriptionInput({
-      buffer: media.buffer,
-      fileName: media.fileName,
-      imageCompression: await resolveImageDescriptionCompressionPolicy({
-        cfg,
-        provider: requestProviderId,
-        model: modelId,
-        agentDir: params.agentDir,
-        workspaceDir: params.workspaceDir,
-      }),
-      mime: media.mime,
-      maxBytes,
-    });
+    let normalizedMedia: Awaited<ReturnType<typeof normalizeImageDescriptionInput>>;
+    try {
+      normalizedMedia = await normalizeImageDescriptionInput({
+        buffer: media.buffer,
+        fileName: media.fileName,
+        imageCompression,
+        mime: media.mime,
+        maxBytes,
+        sourceMaxBytes,
+      });
+    } catch (err) {
+      if (isImageDescriptionMaxBytesError(err)) {
+        throw new MediaUnderstandingSkipError(
+          "maxBytes",
+          `Attachment ${params.attachmentIndex + 1} exceeds maxBytes ${maxBytes}`,
+        );
+      }
+      throw err;
+    }
     assertMediaMaxBytes({
       size: normalizedMedia.buffer.length,
       maxBytes,

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -53,7 +53,6 @@ import {
   DEFAULT_TIMEOUT_SECONDS,
   MIN_AUDIO_FILE_BYTES,
 } from "./defaults.constants.js";
-import { fileExists } from "./fs.js";
 import {
   resolveImageDescriptionCompressionPolicy,
   resolveImageDescriptionPreCompressionMaxBytes,

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -50,6 +50,7 @@ import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { MediaAttachmentCache } from "./attachments.js";
 import {
   CLI_OUTPUT_MAX_BUFFER,
+  DEFAULT_MAX_BYTES,
   DEFAULT_TIMEOUT_SECONDS,
   MIN_AUDIO_FILE_BYTES,
 } from "./defaults.constants.js";
@@ -75,6 +76,14 @@ import type {
 
 type ProviderRegistry = Map<string, MediaUnderstandingProvider>;
 const loadModelAuth = createLazyRuntimeModule(async () => await import("../agents/model-auth.js"));
+
+// Image entries may shrink oversized originals before provider execution; keep
+// the source read bounded, then enforce the provider maxBytes after compression.
+const IMAGE_PRE_COMPRESSION_MAX_BYTES = DEFAULT_MAX_BYTES.video;
+
+function resolveImagePreCompressionMaxBytes(maxBytes: number): number {
+  return Math.max(maxBytes, IMAGE_PRE_COMPRESSION_MAX_BYTES);
+}
 
 function resolveLiteralProviderApiKey(params: {
   cfg: OpenClawConfig;
@@ -735,6 +744,20 @@ function assertMinAudioSize(params: { size: number; attachmentIndex: number }): 
   );
 }
 
+function assertMediaMaxBytes(params: {
+  size: number;
+  maxBytes: number;
+  attachmentIndex: number;
+}): void {
+  if (params.size <= params.maxBytes) {
+    return;
+  }
+  throw new MediaUnderstandingSkipError(
+    "maxBytes",
+    `Attachment ${params.attachmentIndex + 1} exceeds maxBytes ${params.maxBytes}`,
+  );
+}
+
 /**
  * Build an actionable hint suffix for "provider not available" errors.
  *
@@ -819,7 +842,7 @@ export async function runProviderEntry(params: {
     }
     const media = await params.cache.getBuffer({
       attachmentIndex: params.attachmentIndex,
-      maxBytes,
+      maxBytes: resolveImagePreCompressionMaxBytes(maxBytes),
       timeoutMs,
     });
     const normalizedMedia = await normalizeImageDescriptionInput({
@@ -834,6 +857,11 @@ export async function runProviderEntry(params: {
       }),
       mime: media.mime,
       maxBytes,
+    });
+    assertMediaMaxBytes({
+      size: normalizedMedia.buffer.length,
+      maxBytes,
+      attachmentIndex: params.attachmentIndex,
     });
     const requestOverrides = resolveMediaRequestOverrides(params.config);
     const provider = getMediaUnderstandingProvider(requestProviderId, params.providerRegistry);

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -54,10 +54,8 @@ import {
   MIN_AUDIO_FILE_BYTES,
 } from "./defaults.constants.js";
 import { fileExists } from "./fs.js";
-import {
-  normalizeImageDescriptionInput,
-  resolveImageDescriptionCompressionPolicy,
-} from "./image-input-normalize.js";
+import { resolveImageDescriptionCompressionPolicy } from "./image-compression-policy.js";
+import { normalizeImageDescriptionInput } from "./image-input-normalize.js";
 import { describeImageWithModel } from "./image-runtime.js";
 import {
   recordLocalAudioBackendObservation,
@@ -827,7 +825,13 @@ export async function runProviderEntry(params: {
     const normalizedMedia = await normalizeImageDescriptionInput({
       buffer: media.buffer,
       fileName: media.fileName,
-      imageCompression: resolveImageDescriptionCompressionPolicy(cfg),
+      imageCompression: await resolveImageDescriptionCompressionPolicy({
+        cfg,
+        provider: requestProviderId,
+        model: modelId,
+        agentDir: params.agentDir,
+        workspaceDir: params.workspaceDir,
+      }),
       mime: media.mime,
       maxBytes,
     });

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -53,7 +53,11 @@ import {
   DEFAULT_TIMEOUT_SECONDS,
   MIN_AUDIO_FILE_BYTES,
 } from "./defaults.constants.js";
-import { normalizeImageDescriptionInput } from "./image-input-normalize.js";
+import { fileExists } from "./fs.js";
+import {
+  normalizeImageDescriptionInput,
+  resolveImageDescriptionCompressionPolicy,
+} from "./image-input-normalize.js";
 import { describeImageWithModel } from "./image-runtime.js";
 import {
   recordLocalAudioBackendObservation,
@@ -823,6 +827,7 @@ export async function runProviderEntry(params: {
     const normalizedMedia = await normalizeImageDescriptionInput({
       buffer: media.buffer,
       fileName: media.fileName,
+      imageCompression: resolveImageDescriptionCompressionPolicy(cfg),
       mime: media.mime,
       maxBytes,
     });

--- a/src/media-understanding/runner.vision-skip.test.ts
+++ b/src/media-understanding/runner.vision-skip.test.ts
@@ -33,6 +33,8 @@ const baseCatalog: TestCatalogEntry[] = [
 ];
 let catalog: TestCatalogEntry[] = [...baseCatalog];
 const plantedVisionSentinel = "PLANTED_VISION_DESC_zq7x";
+const ONE_PIXEL_PNG_B64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
 
 const loadModelCatalog = vi.hoisted(() => vi.fn(async () => catalog));
 
@@ -337,10 +339,12 @@ describe("runCapability image skip", () => {
         filePrefix: "openclaw-image-explicit-vision",
         extension: "png",
         mediaType: "image/png",
-        fileContents: Buffer.from("image"),
+        fileContents: Buffer.from(ONE_PIXEL_PNG_B64, "base64"),
       },
       async ({ ctx, media, cache }) => {
-        const cfg = {} as OpenClawConfig;
+        const cfg = {
+          agents: { defaults: { imageQuality: "balanced" } },
+        } as OpenClawConfig;
         const getBufferSpy = vi.spyOn(cache, "getBuffer");
 
         const result = await runCapability({

--- a/src/media-understanding/runner.vision-skip.test.ts
+++ b/src/media-understanding/runner.vision-skip.test.ts
@@ -341,6 +341,7 @@ describe("runCapability image skip", () => {
       },
       async ({ ctx, media, cache }) => {
         const cfg = {} as OpenClawConfig;
+        const getBufferSpy = vi.spyOn(cache, "getBuffer");
 
         const result = await runCapability({
           capability: "image",
@@ -365,6 +366,11 @@ describe("runCapability image skip", () => {
           activeModel: { provider: "openai", model: "gpt-4.1" },
         });
 
+        expect(getBufferSpy).toHaveBeenCalledWith({
+          attachmentIndex: 0,
+          maxBytes: 50 * 1024 * 1024,
+          timeoutMs: 60_000,
+        });
         expect(result.decision.outcome).toBe("success");
         expect(requireCapabilityOutput(result, 0)).toEqual({
           kind: "image.description",

--- a/src/media-understanding/runtime-types.ts
+++ b/src/media-understanding/runtime-types.ts
@@ -2,6 +2,7 @@ import type { ActiveMediaModel } from "../../packages/media-understanding-common
 // Public media-understanding runtime API types for file-based image/audio/video
 // helpers and direct structured extraction.
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
+import type { ImageCompressionModelCandidate } from "../agents/image-compression-policy.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type {
   MediaUnderstandingDecision,
@@ -75,7 +76,9 @@ export type PrepareImageDescriptionInputParams = Pick<
   DescribeImageFileWithModelParams,
   "filePath" | "mediaUrl" | "mime" | "cfg" | "agentDir" | "workspaceDir" | "timeoutMs"
 > &
-  Partial<Pick<DescribeImageFileWithModelParams, "provider" | "model">>;
+  Partial<Pick<DescribeImageFileWithModelParams, "provider" | "model">> & {
+    modelCandidates?: readonly ImageCompressionModelCandidate[];
+  };
 
 export type DescribePreparedImageWithModelParams = Omit<
   DescribeImageFileWithModelParams,

--- a/src/media-understanding/runtime-types.ts
+++ b/src/media-understanding/runtime-types.ts
@@ -73,8 +73,9 @@ export type PreparedImageDescriptionInput = {
 
 export type PrepareImageDescriptionInputParams = Pick<
   DescribeImageFileWithModelParams,
-  "filePath" | "mediaUrl" | "mime" | "cfg" | "timeoutMs"
->;
+  "filePath" | "mediaUrl" | "mime" | "cfg" | "agentDir" | "workspaceDir" | "timeoutMs"
+> &
+  Partial<Pick<DescribeImageFileWithModelParams, "provider" | "model">>;
 
 export type DescribePreparedImageWithModelParams = Omit<
   DescribeImageFileWithModelParams,

--- a/src/media-understanding/runtime-types.ts
+++ b/src/media-understanding/runtime-types.ts
@@ -2,7 +2,7 @@ import type { ActiveMediaModel } from "../../packages/media-understanding-common
 // Public media-understanding runtime API types for file-based image/audio/video
 // helpers and direct structured extraction.
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
-import type { ImageCompressionModelCandidate } from "../agents/image-compression-policy.js";
+import type { ImageCompressionModelCandidate } from "../agents/image-compression-policy.types.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type {
   MediaUnderstandingDecision,

--- a/src/media-understanding/runtime.test.ts
+++ b/src/media-understanding/runtime.test.ts
@@ -33,6 +33,12 @@ const mocks = vi.hoisted(() => {
     readLocalFileSafely: vi.fn(async () => ({ buffer: Buffer.from("image") })),
     describeImageWithModel: vi.fn(async () => ({ text: "generic image ok", model: "vision" })),
     convertHeicToJpeg: vi.fn(async () => Buffer.from("jpeg-normalized")),
+    optimizeImageBufferForWebMedia: vi.fn(async ({ buffer, contentType, fileName }) => ({
+      buffer,
+      contentType,
+      fileName,
+      kind: "image" as const,
+    })),
     runCapability: vi.fn(),
     cleanup,
     getBuffer,
@@ -64,6 +70,10 @@ vi.mock("../media/media-services.js", () => ({
   convertHeicToJpeg: mocks.convertHeicToJpeg,
 }));
 
+vi.mock("../media/web-media.js", () => ({
+  optimizeImageBufferForWebMedia: mocks.optimizeImageBufferForWebMedia,
+}));
+
 function requireRunCapabilityRequest(): unknown {
   // File API tests verify the normalized request handed to runCapability, not
   // just the public return shape.
@@ -92,6 +102,15 @@ describe("media-understanding runtime", () => {
     mocks.describeImageWithModel.mockResolvedValue({ text: "generic image ok", model: "vision" });
     mocks.convertHeicToJpeg.mockReset();
     mocks.convertHeicToJpeg.mockResolvedValue(Buffer.from("jpeg-normalized"));
+    mocks.optimizeImageBufferForWebMedia.mockReset();
+    mocks.optimizeImageBufferForWebMedia.mockImplementation(
+      async ({ buffer, contentType, fileName }) => ({
+        buffer,
+        contentType,
+        fileName,
+        kind: "image" as const,
+      }),
+    );
     mocks.runCapability.mockReset();
     mocks.cleanup.mockReset();
     mocks.cleanup.mockResolvedValue(undefined);
@@ -541,6 +560,92 @@ describe("media-understanding runtime", () => {
         buffer: Buffer.from("jpeg-normalized"),
         fileName: "sample.bin",
         mime: "image/jpeg",
+      }),
+    );
+  });
+
+  it("applies configured image compression before explicit image provider execution", async () => {
+    mocks.readLocalFileSafely.mockResolvedValue({ buffer: Buffer.from("oversized-jpeg") });
+    mocks.optimizeImageBufferForWebMedia.mockResolvedValue({
+      buffer: Buffer.from("compressed-jpeg"),
+      contentType: "image/jpeg",
+      fileName: "sample.jpg",
+      kind: "image",
+    });
+
+    await describeImageFileWithModel({
+      filePath: "/tmp/sample.jpg",
+      mime: "image/jpeg",
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      prompt: "Describe it",
+      cfg: {
+        agents: {
+          defaults: {
+            imageMaxDimensionPx: 1568.9,
+            imageQuality: "balanced",
+          },
+        },
+      } as OpenClawConfig,
+      agentDir: "/tmp/agent",
+    });
+
+    expect(mocks.optimizeImageBufferForWebMedia).toHaveBeenCalledWith({
+      buffer: Buffer.from("oversized-jpeg"),
+      contentType: "image/jpeg",
+      fileName: "sample.jpg",
+      maxBytes: 10 * 1024 * 1024,
+      imageCompression: {
+        quality: "balanced",
+        models: [{ maxSidePx: 1568 }],
+      },
+    });
+    expect(mocks.describeImageWithModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        buffer: Buffer.from("compressed-jpeg"),
+        fileName: "sample.jpg",
+        mime: "image/jpeg",
+      }),
+    );
+  });
+
+  it("infers GIF MIME before configured image compression", async () => {
+    mocks.readLocalFileSafely.mockResolvedValue({ buffer: Buffer.from("gif-bytes") });
+    mocks.optimizeImageBufferForWebMedia.mockResolvedValue({
+      buffer: Buffer.from("gif-bytes"),
+      contentType: "image/gif",
+      fileName: "anim.gif",
+      kind: "image",
+    });
+
+    await describeImageFileWithModel({
+      filePath: "/tmp/anim.gif",
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      prompt: "Describe it",
+      cfg: {
+        agents: {
+          defaults: {
+            imageQuality: "balanced",
+          },
+        },
+      } as OpenClawConfig,
+      agentDir: "/tmp/agent",
+    });
+
+    expect(mocks.optimizeImageBufferForWebMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        buffer: Buffer.from("gif-bytes"),
+        contentType: "image/gif",
+        fileName: "anim.gif",
+        imageCompression: { quality: "balanced" },
+      }),
+    );
+    expect(mocks.describeImageWithModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        buffer: Buffer.from("gif-bytes"),
+        fileName: "anim.gif",
+        mime: "image/gif",
       }),
     );
   });

--- a/src/media-understanding/runtime.test.ts
+++ b/src/media-understanding/runtime.test.ts
@@ -33,8 +33,9 @@ const mocks = vi.hoisted(() => {
     readLocalFileSafely: vi.fn(async () => ({ buffer: Buffer.from("image") })),
     describeImageWithModel: vi.fn(async () => ({ text: "generic image ok", model: "vision" })),
     convertHeicToJpeg: vi.fn(async () => Buffer.from("jpeg-normalized")),
-    resolveImageDescriptionCompressionPolicy: vi.fn<() => Promise<unknown>>(
-      async () => undefined,
+    resolveImageDescriptionCompressionPolicy: vi.fn<() => Promise<unknown>>(async () => undefined),
+    resolveImageDescriptionPreCompressionMaxBytes: vi.fn((maxBytes: number) =>
+      Math.max(maxBytes, 50 * 1024 * 1024),
     ),
     optimizeImageBufferForWebMedia: vi.fn(async ({ buffer, contentType, fileName }) => ({
       buffer,
@@ -75,6 +76,8 @@ vi.mock("../media/media-services.js", () => ({
 
 vi.mock("./image-compression-policy.js", () => ({
   resolveImageDescriptionCompressionPolicy: mocks.resolveImageDescriptionCompressionPolicy,
+  resolveImageDescriptionPreCompressionMaxBytes:
+    mocks.resolveImageDescriptionPreCompressionMaxBytes,
 }));
 
 vi.mock("../media/web-media.js", () => ({
@@ -111,6 +114,10 @@ describe("media-understanding runtime", () => {
     mocks.convertHeicToJpeg.mockResolvedValue(Buffer.from("jpeg-normalized"));
     mocks.resolveImageDescriptionCompressionPolicy.mockReset();
     mocks.resolveImageDescriptionCompressionPolicy.mockResolvedValue(undefined);
+    mocks.resolveImageDescriptionPreCompressionMaxBytes.mockReset();
+    mocks.resolveImageDescriptionPreCompressionMaxBytes.mockImplementation((maxBytes: number) =>
+      Math.max(maxBytes, 50 * 1024 * 1024),
+    );
     mocks.optimizeImageBufferForWebMedia.mockReset();
     mocks.optimizeImageBufferForWebMedia.mockImplementation(
       async ({ buffer, contentType, fileName }) => ({
@@ -710,6 +717,62 @@ describe("media-understanding runtime", () => {
         buffer: Buffer.from("remote-image"),
         fileName: "photo.png",
         mime: "image/png",
+      }),
+    );
+    expect(mocks.cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("fetches remote explicit image descriptions with a pre-compression cap", async () => {
+    mocks.normalizeMediaAttachments.mockReturnValue([
+      { index: 0, url: "https://example.com/large.jpg", mime: "image/jpeg" },
+    ]);
+    mocks.resolveImageDescriptionCompressionPolicy.mockResolvedValue({ quality: "balanced" });
+    mocks.getBuffer.mockResolvedValue({
+      buffer: Buffer.from("oversized-jpeg"),
+      fileName: "large.jpg",
+      mime: "image/jpeg",
+      size: 20 * 1024 * 1024,
+    });
+    mocks.optimizeImageBufferForWebMedia.mockResolvedValue({
+      buffer: Buffer.from("compressed-jpeg"),
+      contentType: "image/jpeg",
+      fileName: "large.jpg",
+      kind: "image",
+    });
+
+    await describeImageFileWithModel({
+      filePath: "https://example.com/large.jpg",
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      prompt: "Describe it",
+      cfg: {
+        agents: {
+          defaults: {
+            imageQuality: "balanced",
+          },
+        },
+      } as OpenClawConfig,
+      agentDir: "/tmp/agent",
+      timeoutMs: 45_000,
+    });
+
+    expect(mocks.getBuffer).toHaveBeenCalledWith({
+      attachmentIndex: 0,
+      maxBytes: 50 * 1024 * 1024,
+      timeoutMs: 45_000,
+    });
+    expect(mocks.optimizeImageBufferForWebMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        buffer: Buffer.from("oversized-jpeg"),
+        maxBytes: 10 * 1024 * 1024,
+        imageCompression: { quality: "balanced" },
+      }),
+    );
+    expect(mocks.describeImageWithModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        buffer: Buffer.from("compressed-jpeg"),
+        fileName: "large.jpg",
+        mime: "image/jpeg",
       }),
     );
     expect(mocks.cleanup).toHaveBeenCalledTimes(1);

--- a/src/media-understanding/runtime.test.ts
+++ b/src/media-understanding/runtime.test.ts
@@ -33,6 +33,9 @@ const mocks = vi.hoisted(() => {
     readLocalFileSafely: vi.fn(async () => ({ buffer: Buffer.from("image") })),
     describeImageWithModel: vi.fn(async () => ({ text: "generic image ok", model: "vision" })),
     convertHeicToJpeg: vi.fn(async () => Buffer.from("jpeg-normalized")),
+    resolveImageDescriptionCompressionPolicy: vi.fn<() => Promise<unknown>>(
+      async () => undefined,
+    ),
     optimizeImageBufferForWebMedia: vi.fn(async ({ buffer, contentType, fileName }) => ({
       buffer,
       contentType,
@@ -70,6 +73,10 @@ vi.mock("../media/media-services.js", () => ({
   convertHeicToJpeg: mocks.convertHeicToJpeg,
 }));
 
+vi.mock("./image-compression-policy.js", () => ({
+  resolveImageDescriptionCompressionPolicy: mocks.resolveImageDescriptionCompressionPolicy,
+}));
+
 vi.mock("../media/web-media.js", () => ({
   optimizeImageBufferForWebMedia: mocks.optimizeImageBufferForWebMedia,
 }));
@@ -102,6 +109,8 @@ describe("media-understanding runtime", () => {
     mocks.describeImageWithModel.mockResolvedValue({ text: "generic image ok", model: "vision" });
     mocks.convertHeicToJpeg.mockReset();
     mocks.convertHeicToJpeg.mockResolvedValue(Buffer.from("jpeg-normalized"));
+    mocks.resolveImageDescriptionCompressionPolicy.mockReset();
+    mocks.resolveImageDescriptionCompressionPolicy.mockResolvedValue(undefined);
     mocks.optimizeImageBufferForWebMedia.mockReset();
     mocks.optimizeImageBufferForWebMedia.mockImplementation(
       async ({ buffer, contentType, fileName }) => ({
@@ -564,8 +573,13 @@ describe("media-understanding runtime", () => {
     );
   });
 
-  it("applies configured image compression before explicit image provider execution", async () => {
+  it("applies resolved image compression before explicit image provider execution", async () => {
     mocks.readLocalFileSafely.mockResolvedValue({ buffer: Buffer.from("oversized-jpeg") });
+    mocks.resolveImageDescriptionCompressionPolicy.mockResolvedValue({
+      quality: "balanced",
+      models: [{ maxSidePx: 1568 }, { maxSidePx: 2576, preferredSidePx: 2576 }],
+      imageCount: 1,
+    });
     mocks.optimizeImageBufferForWebMedia.mockResolvedValue({
       buffer: Buffer.from("compressed-jpeg"),
       contentType: "image/jpeg",
@@ -590,6 +604,20 @@ describe("media-understanding runtime", () => {
       agentDir: "/tmp/agent",
     });
 
+    expect(mocks.resolveImageDescriptionCompressionPolicy).toHaveBeenCalledWith({
+      cfg: {
+        agents: {
+          defaults: {
+            imageMaxDimensionPx: 1568.9,
+            imageQuality: "balanced",
+          },
+        },
+      },
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      agentDir: "/tmp/agent",
+      workspaceDir: undefined,
+    });
     expect(mocks.optimizeImageBufferForWebMedia).toHaveBeenCalledWith({
       buffer: Buffer.from("oversized-jpeg"),
       contentType: "image/jpeg",
@@ -597,7 +625,8 @@ describe("media-understanding runtime", () => {
       maxBytes: 10 * 1024 * 1024,
       imageCompression: {
         quality: "balanced",
-        models: [{ maxSidePx: 1568 }],
+        models: [{ maxSidePx: 1568 }, { maxSidePx: 2576, preferredSidePx: 2576 }],
+        imageCount: 1,
       },
     });
     expect(mocks.describeImageWithModel).toHaveBeenCalledWith(
@@ -611,6 +640,7 @@ describe("media-understanding runtime", () => {
 
   it("infers GIF MIME before configured image compression", async () => {
     mocks.readLocalFileSafely.mockResolvedValue({ buffer: Buffer.from("gif-bytes") });
+    mocks.resolveImageDescriptionCompressionPolicy.mockResolvedValue({ quality: "balanced" });
     mocks.optimizeImageBufferForWebMedia.mockResolvedValue({
       buffer: Buffer.from("gif-bytes"),
       contentType: "image/gif",
@@ -633,6 +663,19 @@ describe("media-understanding runtime", () => {
       agentDir: "/tmp/agent",
     });
 
+    expect(mocks.resolveImageDescriptionCompressionPolicy).toHaveBeenCalledWith({
+      cfg: {
+        agents: {
+          defaults: {
+            imageQuality: "balanced",
+          },
+        },
+      },
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      agentDir: "/tmp/agent",
+      workspaceDir: undefined,
+    });
     expect(mocks.optimizeImageBufferForWebMedia).toHaveBeenCalledWith(
       expect.objectContaining({
         buffer: Buffer.from("gif-bytes"),

--- a/src/media-understanding/runtime.ts
+++ b/src/media-understanding/runtime.ts
@@ -262,8 +262,9 @@ export async function prepareImageDescriptionInput(params: PrepareImageDescripti
     fileName: image.fileName,
     imageCompression: await resolveImageDescriptionCompressionPolicy({
       cfg: params.cfg,
-      provider: params.provider,
-      model: params.model,
+      ...(params.modelCandidates
+        ? { modelCandidates: params.modelCandidates }
+        : { provider: params.provider, model: params.model }),
       agentDir: params.agentDir,
       workspaceDir: params.workspaceDir,
     }),

--- a/src/media-understanding/runtime.ts
+++ b/src/media-understanding/runtime.ts
@@ -6,7 +6,10 @@ import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
 import type { OpenClawConfig } from "../config/types.js";
 import { readLocalFileSafely } from "../infra/fs-safe.js";
 import { DEFAULT_MAX_BYTES } from "./defaults.constants.js";
-import { resolveImageDescriptionCompressionPolicy } from "./image-compression-policy.js";
+import {
+  resolveImageDescriptionCompressionPolicy,
+  resolveImageDescriptionPreCompressionMaxBytes,
+} from "./image-compression-policy.js";
 import { normalizeImageDescriptionInput } from "./image-input-normalize.js";
 import { describeImageWithModel } from "./image-runtime.js";
 import {
@@ -250,26 +253,32 @@ export async function describeImageFile(
 /** Reads and normalizes image input once before explicit-model fallback attempts. */
 export async function prepareImageDescriptionInput(params: PrepareImageDescriptionInputParams) {
   const timeoutMs = resolveMediaRuntimeTimeoutMs(params.timeoutMs);
+  const imageCompression = await resolveImageDescriptionCompressionPolicy({
+    cfg: params.cfg,
+    ...(params.modelCandidates
+      ? { modelCandidates: params.modelCandidates }
+      : { provider: params.provider, model: params.model }),
+    agentDir: params.agentDir,
+    workspaceDir: params.workspaceDir,
+  });
+  const sourceMaxBytes = imageCompression
+    ? resolveImageDescriptionPreCompressionMaxBytes(DEFAULT_MAX_BYTES.image)
+    : DEFAULT_MAX_BYTES.image;
   const image = await readImageDescriptionInput({
     filePath: params.filePath,
     mediaUrl: params.mediaUrl,
     mime: params.mime,
     cfg: params.cfg,
     timeoutMs,
+    maxBytes: sourceMaxBytes,
   });
   const normalizedImage = await normalizeImageDescriptionInput({
     buffer: image.buffer,
     fileName: image.fileName,
-    imageCompression: await resolveImageDescriptionCompressionPolicy({
-      cfg: params.cfg,
-      ...(params.modelCandidates
-        ? { modelCandidates: params.modelCandidates }
-        : { provider: params.provider, model: params.model }),
-      agentDir: params.agentDir,
-      workspaceDir: params.workspaceDir,
-    }),
+    imageCompression,
     mime: image.mime,
     maxBytes: DEFAULT_MAX_BYTES.image,
+    sourceMaxBytes,
   });
   return {
     buffer: normalizedImage.buffer,
@@ -314,6 +323,7 @@ async function readImageDescriptionInput(params: {
   mime?: string;
   cfg: OpenClawConfig;
   timeoutMs: number;
+  maxBytes: number;
 }): Promise<{ buffer: Buffer; fileName: string; mime?: string }> {
   const remoteRef =
     params.mediaUrl ??
@@ -334,7 +344,7 @@ async function readImageDescriptionInput(params: {
   try {
     const media = await cache.getBuffer({
       attachmentIndex: 0,
-      maxBytes: DEFAULT_MAX_BYTES.image,
+      maxBytes: params.maxBytes,
       timeoutMs: params.timeoutMs,
     });
     return {

--- a/src/media-understanding/runtime.ts
+++ b/src/media-understanding/runtime.ts
@@ -6,10 +6,8 @@ import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
 import type { OpenClawConfig } from "../config/types.js";
 import { readLocalFileSafely } from "../infra/fs-safe.js";
 import { DEFAULT_MAX_BYTES } from "./defaults.constants.js";
-import {
-  normalizeImageDescriptionInput,
-  resolveImageDescriptionCompressionPolicy,
-} from "./image-input-normalize.js";
+import { resolveImageDescriptionCompressionPolicy } from "./image-compression-policy.js";
+import { normalizeImageDescriptionInput } from "./image-input-normalize.js";
 import { describeImageWithModel } from "./image-runtime.js";
 import {
   buildMediaUnderstandingRegistry,
@@ -262,7 +260,13 @@ export async function prepareImageDescriptionInput(params: PrepareImageDescripti
   const normalizedImage = await normalizeImageDescriptionInput({
     buffer: image.buffer,
     fileName: image.fileName,
-    imageCompression: resolveImageDescriptionCompressionPolicy(params.cfg),
+    imageCompression: await resolveImageDescriptionCompressionPolicy({
+      cfg: params.cfg,
+      provider: params.provider,
+      model: params.model,
+      agentDir: params.agentDir,
+      workspaceDir: params.workspaceDir,
+    }),
     mime: image.mime,
     maxBytes: DEFAULT_MAX_BYTES.image,
   });

--- a/src/media-understanding/runtime.ts
+++ b/src/media-understanding/runtime.ts
@@ -6,7 +6,10 @@ import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
 import type { OpenClawConfig } from "../config/types.js";
 import { readLocalFileSafely } from "../infra/fs-safe.js";
 import { DEFAULT_MAX_BYTES } from "./defaults.constants.js";
-import { normalizeImageDescriptionInput } from "./image-input-normalize.js";
+import {
+  normalizeImageDescriptionInput,
+  resolveImageDescriptionCompressionPolicy,
+} from "./image-input-normalize.js";
 import { describeImageWithModel } from "./image-runtime.js";
 import {
   buildMediaUnderstandingRegistry,
@@ -259,6 +262,7 @@ export async function prepareImageDescriptionInput(params: PrepareImageDescripti
   const normalizedImage = await normalizeImageDescriptionInput({
     buffer: image.buffer,
     fileName: image.fileName,
+    imageCompression: resolveImageDescriptionCompressionPolicy(params.cfg),
     mime: image.mime,
     maxBytes: DEFAULT_MAX_BYTES.image,
   });


### PR DESCRIPTION
Closes #101923

## What Problem This Solves

Fixes media-understanding image-description paths that could still reject or send oversized images even when an image resize policy was available from configured defaults or selected provider/model metadata.

## Why This Change Was Made

Media-understanding now reuses the shared model-aware image compression resolver used by the image tool instead of maintaining a config-only policy path. Explicit image descriptions, CLI image describe fallback candidates, and configured provider-entry runs resolve compression before reading/fetching bytes, use a bounded pre-compression source cap, then enforce the final provider `maxBytes` after optimization.

This also keeps HEIC conversion and GIF preservation on the shared normalization path, and maps post-compression byte-cap failures back to the existing media-understanding `maxBytes` skip contract instead of reporting them as provider failures.

## User Impact

Oversized photos sent through media-understanding image-description flows can be resized consistently with provider/model image limits and user image-quality defaults. Large inputs that still cannot be reduced to the provider cap remain non-fatal skipped attachments rather than failed provider attempts.

AI-assisted: yes. I reviewed the shared compression resolver, media-understanding explicit/provider-entry paths, CLI fallback candidate handoff, cap-ordering behavior, and focused test coverage in this PR. A sanitized local agent transcript was not included because this automation run did not have interactive approval to attach one.

## Evidence

- `git diff --check` passed.
- `node scripts/run-vitest.mjs src/media-understanding/image-input-normalize.test.ts src/media-understanding/runner.entries.image-cap.test.ts src/media-understanding/runtime.test.ts src/media-understanding/runner.vision-skip.test.ts src/cli/capability-cli.test.ts src/media/web-media.test.ts src/agents/tools/image-tool.test.ts` passed: 4 Vitest shards, 321 tests total.
  - media: 75 tests
  - media-understanding: 46 tests
  - CLI: 106 tests
  - agents/image-tool: 94 tests
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` passed clean after the repair commits: no accepted/actionable findings; overall patch correct.
- Branch rebased onto `origin/main` at `b81666ca6a`; current pushed head is `da6f13cf83`.

Not run: live Anthropic/OpenClaw image-description repro with a real oversized phone photo. Crabbox/Testbox proof was unavailable in this worktree because the Crabbox wrapper failed its basic binary sanity check, so this update proves the source/runtime/CLI fallback behavior and local review gate but does not yet provide live provider proof.