### PR TITLE
fix(gateway): OAuth-only xAI tools are missing from CLI-backend sessions

### DIFF
--- a/extensions/xai/src/cli-backend-loopback-oauth-proof.test.ts
+++ b/extensions/xai/src/cli-backend-loopback-oauth-proof.test.ts
@@ -67,9 +67,7 @@ describe("xAI OAuth CLI-backend loopback tool surface proof", () => {
         })),
       },
     };
-    // eslint-disable-next-line no-console
     console.log("[xai-oauth-loopback-proof] MCP tools/list response:");
-    // eslint-disable-next-line no-console
     console.log(JSON.stringify(mcpToolsListResponse, null, 2));
 
     expect(names).toContain("x_search");

--- a/extensions/xai/src/cli-backend-loopback-oauth-proof.test.ts
+++ b/extensions/xai/src/cli-backend-loopback-oauth-proof.test.ts
@@ -1,0 +1,78 @@
+// Real-behavior proof: with an OAuth auth context, the xAI plugin registers
+// x_search and code_execution for loopback/CLI-backend tool surfaces.
+import { describe, expect, it } from "vitest";
+import type { AnyAgentTool } from "../../../src/agents/tools/common.js";
+import xaiPlugin from "../index.js";
+
+type ToolFactory = (ctx: {
+  config?: Record<string, unknown>;
+  runtimeConfig?: Record<string, unknown>;
+  hasAuthForProvider?: (providerId: string) => boolean;
+  resolveApiKeyForProvider?: (providerId: string) => Promise<string | undefined>;
+}) => AnyAgentTool | AnyAgentTool[] | null | undefined;
+
+type ToolRegistration = {
+  name: string;
+  factory: ToolFactory;
+};
+
+describe("xAI OAuth CLI-backend loopback tool surface proof", () => {
+  it("registers x_search and code_execution when an xAI OAuth auth context is present", () => {
+    const registeredTools: ToolRegistration[] = [];
+
+    const api = {
+      registerTool: (factory: ToolFactory, options: { name: string }) => {
+        registeredTools.push({ name: options.name, factory });
+      },
+      // Provider-entry stubs needed before tool registration is reached.
+      registerProvider: () => {},
+      registerModelCatalogProvider: () => {},
+      registerWebSearchProvider: () => {},
+      registerMediaUnderstandingProvider: () => {},
+      registerVideoGenerationProvider: () => {},
+      registerImageGenerationProvider: () => {},
+      registerSpeechProvider: () => {},
+      registerRealtimeTranscriptionProvider: () => {},
+    };
+
+    xaiPlugin.register(api as never);
+
+    const authContext = {
+      hasAuthForProvider: (providerId: string) => providerId === "xai",
+      resolveApiKeyForProvider: async () => "REDACTED_API_KEY",
+    };
+
+    const resolvedTools: AnyAgentTool[] = [];
+    for (const registration of registeredTools) {
+      const result = registration.factory({
+        config: {},
+        runtimeConfig: {},
+        ...authContext,
+      });
+      if (result) {
+        for (const tool of Array.isArray(result) ? result : [result]) {
+          resolvedTools.push(tool);
+        }
+      }
+    }
+
+    const names = resolvedTools.map((tool) => tool.name).toSorted();
+    const mcpToolsListResponse = {
+      jsonrpc: "2.0",
+      id: "proof-tools-list",
+      result: {
+        tools: resolvedTools.map((tool) => ({
+          name: tool.name,
+          description: tool.description,
+        })),
+      },
+    };
+    // eslint-disable-next-line no-console
+    console.log("[xai-oauth-loopback-proof] MCP tools/list response:");
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(mcpToolsListResponse, null, 2));
+
+    expect(names).toContain("x_search");
+    expect(names).toContain("code_execution");
+  });
+});

--- a/extensions/xai/src/cli-backend-loopback-oauth-proof.test.ts
+++ b/extensions/xai/src/cli-backend-loopback-oauth-proof.test.ts
@@ -1,15 +1,19 @@
 // Real-behavior proof: with an OAuth auth context, the xAI plugin registers
 // x_search and code_execution for loopback/CLI-backend tool surfaces.
 import { describe, expect, it } from "vitest";
-import type { AnyAgentTool } from "../../../src/agents/tools/common.js";
 import xaiPlugin from "../index.js";
+
+type ProofTool = {
+  name: string;
+  description: string;
+};
 
 type ToolFactory = (ctx: {
   config?: Record<string, unknown>;
   runtimeConfig?: Record<string, unknown>;
   hasAuthForProvider?: (providerId: string) => boolean;
   resolveApiKeyForProvider?: (providerId: string) => Promise<string | undefined>;
-}) => AnyAgentTool | AnyAgentTool[] | null | undefined;
+}) => ProofTool | ProofTool[] | null | undefined;
 
 type ToolRegistration = {
   name: string;
@@ -42,7 +46,7 @@ describe("xAI OAuth CLI-backend loopback tool surface proof", () => {
       resolveApiKeyForProvider: async () => "REDACTED_API_KEY",
     };
 
-    const resolvedTools: AnyAgentTool[] = [];
+    const resolvedTools: ProofTool[] = [];
     for (const registration of registeredTools) {
       const result = registration.factory({
         config: {},

--- a/extensions/xai/src/xai-oauth-tool-registration.test.ts
+++ b/extensions/xai/src/xai-oauth-tool-registration.test.ts
@@ -20,7 +20,7 @@ type ToolRegistration = {
   factory: ToolFactory;
 };
 
-describe("xAI OAuth CLI-backend loopback tool surface proof", () => {
+describe("xAI OAuth tool registration", () => {
   it("registers x_search and code_execution when an xAI OAuth auth context is present", () => {
     const registeredTools: ToolRegistration[] = [];
 

--- a/scripts/proof/xai-oauth-loopback-tools.ts
+++ b/scripts/proof/xai-oauth-loopback-tools.ts
@@ -75,11 +75,13 @@ async function main(): Promise<void> {
   );
 
   const authProfileStore = createXaiOAuthProfileStore();
+  const agentDir = "/tmp/xai-oauth-proof/agent-main";
   const result = resolveGatewayScopedTools({
     cfg: { tools: { profile: "coding" } } as OpenClawConfig,
     sessionKey: "agent:main",
     surface: "loopback",
     authProfileStore,
+    agentDir,
   });
 
   const toolNames = result.tools.map((tool) => tool.name).toSorted();

--- a/scripts/proof/xai-oauth-loopback-tools.ts
+++ b/scripts/proof/xai-oauth-loopback-tools.ts
@@ -1,10 +1,11 @@
 // Real-behavior proof: OAuth-only xAI tools on the CLI-backend loopback path.
 //
-// This script exercises the actual gateway tool-resolution path
-// (resolveGatewayScopedTools -> createOpenClawTools -> plugin registry) with a
-// real xAI plugin registration and an OAuth-only auth profile store. It prints
-// the resulting tool surface in MCP tools/list JSON-RPC form. All tokens, keys,
-// account IDs, phone numbers, IPs, and non-public endpoints are redacted.
+// This script builds a real plugin registry containing the bundled xAI plugin,
+// activates it, and then exercises the actual gateway tool-resolution path
+// (resolveGatewayScopedTools -> createOpenClawTools -> plugin registry) with an
+// OAuth-only auth profile store. It prints the resulting tool surface in MCP
+// tools/list JSON-RPC form. All tokens, keys, account IDs, phone numbers, IPs,
+// and non-public endpoints are redacted.
 
 import xaiPlugin from "../../extensions/xai/index.js";
 import type { AuthProfileStore } from "../../src/agents/auth-profiles/types.js";
@@ -12,7 +13,9 @@ import type { OpenClawConfig } from "../../src/config/types.openclaw.js";
 import { resolveGatewayScopedTools } from "../../src/gateway/tool-resolution.js";
 import { buildPluginApi } from "../../src/plugins/api-builder.js";
 import { createEmptyPluginRegistry } from "../../src/plugins/registry-empty.js";
+import type { PluginToolRegistration } from "../../src/plugins/registry-types.js";
 import { setActivePluginRegistry } from "../../src/plugins/runtime.js";
+import type { OpenClawPluginToolFactory } from "../../src/plugins/types.js";
 
 function createXaiOAuthProfileStore(): AuthProfileStore {
   return {
@@ -41,10 +44,35 @@ async function main(): Promise<void> {
     runtime: {} as never,
     logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
     resolvePath: (input: string) => input,
+    handlers: {
+      registerTool: (tool, opts) => {
+        const names = [...(opts?.names ?? []), ...(opts?.name ? [opts.name] : [])];
+        const factory: OpenClawPluginToolFactory = typeof tool === "function" ? tool : () => tool;
+        if (typeof tool !== "function") {
+          names.push(tool.name);
+        }
+        const registration: PluginToolRegistration = {
+          pluginId: "xai",
+          pluginName: "xai",
+          factory,
+          names: [...new Set(names.filter((name) => name.length > 0))],
+          declaredNames: [],
+          optional: opts?.optional === true,
+          source: "bundled",
+        };
+        registry.tools.push(registration);
+      },
+    },
   });
 
   xaiPlugin.register(api);
   setActivePluginRegistry(registry, "proof", "default", "/tmp/xai-oauth-proof");
+
+  console.log("[xai-oauth-loopback-proof] registered plugin tool count:", registry.tools.length);
+  console.log(
+    "[xai-oauth-loopback-proof] registered plugin tool names:",
+    registry.tools.flatMap((entry) => entry.names).join(", ") || "(none)",
+  );
 
   const authProfileStore = createXaiOAuthProfileStore();
   const result = resolveGatewayScopedTools({

--- a/scripts/proof/xai-oauth-loopback-tools.ts
+++ b/scripts/proof/xai-oauth-loopback-tools.ts
@@ -1,0 +1,81 @@
+// Real-behavior proof: OAuth-only xAI tools on the CLI-backend loopback path.
+//
+// This script exercises the actual gateway tool-resolution path
+// (resolveGatewayScopedTools -> createOpenClawTools -> plugin registry) with a
+// real xAI plugin registration and an OAuth-only auth profile store. It prints
+// the resulting tool surface in MCP tools/list JSON-RPC form. All tokens, keys,
+// account IDs, phone numbers, IPs, and non-public endpoints are redacted.
+
+import xaiPlugin from "../../extensions/xai/index.js";
+import type { AuthProfileStore } from "../../src/agents/auth-profiles/types.js";
+import type { OpenClawConfig } from "../../src/config/types.openclaw.js";
+import { resolveGatewayScopedTools } from "../../src/gateway/tool-resolution.js";
+import { buildPluginApi } from "../../src/plugins/api-builder.js";
+import { createEmptyPluginRegistry } from "../../src/plugins/registry-empty.js";
+import { setActivePluginRegistry } from "../../src/plugins/runtime.js";
+
+function createXaiOAuthProfileStore(): AuthProfileStore {
+  return {
+    version: 1,
+    profiles: {
+      "xai-oauth": {
+        type: "oauth",
+        provider: "xai",
+        access: "REDACTED_ACCESS_TOKEN",
+        refresh: "REDACTED_REFRESH_TOKEN",
+        expires: 1_900_000_000_000,
+      },
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  const registry = createEmptyPluginRegistry();
+
+  const api = buildPluginApi({
+    id: "xai",
+    name: "xai",
+    source: "bundled",
+    registrationMode: "bundled",
+    config: { tools: { profile: "coding" } } as OpenClawConfig,
+    runtime: {} as never,
+    logger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+    resolvePath: (input: string) => input,
+  });
+
+  xaiPlugin.register(api);
+  setActivePluginRegistry(registry, "proof", "default", "/tmp/xai-oauth-proof");
+
+  const authProfileStore = createXaiOAuthProfileStore();
+  const result = resolveGatewayScopedTools({
+    cfg: { tools: { profile: "coding" } } as OpenClawConfig,
+    sessionKey: "agent:main",
+    surface: "loopback",
+    authProfileStore,
+  });
+
+  const toolNames = result.tools.map((tool) => tool.name).toSorted();
+  const mcpToolsListResponse = {
+    jsonrpc: "2.0",
+    id: "proof-tools-list",
+    result: {
+      tools: result.tools.map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+      })),
+    },
+  };
+
+  console.log("[xai-oauth-loopback-proof] resolved loopback tool names:", toolNames.join(", "));
+  console.log("[xai-oauth-loopback-proof] MCP tools/list response:");
+  console.log(JSON.stringify(mcpToolsListResponse, null, 2));
+
+  if (!toolNames.includes("x_search") || !toolNames.includes("code_execution")) {
+    console.error("FAIL: x_search and/or code_execution were not surfaced.");
+    process.exit(1);
+  }
+
+  console.log("PASS: x_search and code_execution are present on the loopback surface.");
+}
+
+void main();

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -22,6 +22,7 @@ import {
   clearRuntimeAuthProfileStoreSnapshots,
   getRuntimeAuthProfileStoreSnapshot,
   loadAuthProfileStoreForRuntime,
+  loadAuthProfileStoreForSecretsRuntime,
   loadAuthProfileStoreWithoutExternalProfiles,
   replaceRuntimeAuthProfileStoreSnapshots,
   saveAuthProfileStore,
@@ -599,6 +600,39 @@ describe("promoteAuthProfileInOrder", () => {
       });
 
       expect(loadAuthProfileStoreForRuntime(agentDir).lastGood?.["openai"]).toBe(goodProfileId);
+    });
+  });
+
+  describe("loadAuthProfileStoreForSecretsRuntime excludeMainOverlay", () => {
+    it("does not inherit main OAuth profiles when excludeMainOverlay is true", async () => {
+      await withAuthProfileTestState("auth-secrets-exclude-main", async ({ agentDirFor }) => {
+        const mainDir = agentDirFor("main");
+        const otherDir = agentDirFor("other");
+        const profileId = "xai:oauth";
+        const mainProfile: AuthProfileStore = {
+          version: AUTH_STORE_VERSION,
+          profiles: {
+            [profileId]: {
+              type: "oauth",
+              provider: "xai",
+              access: "main-access-token",
+              refresh: "main-refresh-token",
+              expires: Date.now() + 60_000,
+            },
+          },
+        };
+        saveAuthProfileStore(mainProfile, mainDir);
+
+        const inheritedStore = loadAuthProfileStoreForSecretsRuntime(otherDir);
+        expect(inheritedStore.profiles[profileId]).toMatchObject({
+          access: "main-access-token",
+        });
+
+        const agentLocalStore = loadAuthProfileStoreForSecretsRuntime(otherDir, {
+          excludeMainOverlay: true,
+        });
+        expect(agentLocalStore.profiles[profileId]).toBeUndefined();
+      });
     });
   });
 });

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -57,6 +57,8 @@ type LoadAuthProfileStoreOptions = {
   syncExternalCli?: boolean;
   externalCliProviderIds?: Iterable<string>;
   externalCliProfileIds?: Iterable<string>;
+  /** When true, agent-local loads do not inherit persisted main-store OAuth profiles. */
+  excludeMainOverlay?: boolean;
 };
 
 type SaveAuthProfileStoreOptions = {
@@ -818,7 +820,7 @@ export function loadAuthProfileStoreForRuntime(
   const authPath = resolveAuthStorePath(agentDir);
   const mainAuthPath = resolveAuthStorePath();
   const externalCli = resolveExternalCliOverlayOptions(options);
-  if (!agentDir || authPath === mainAuthPath) {
+  if (!agentDir || authPath === mainAuthPath || options?.excludeMainOverlay === true) {
     return overlayExternalAuthProfiles(store, {
       agentDir,
       ...externalCli,
@@ -842,7 +844,11 @@ export function loadAuthProfileStoreForSecretsRuntime(
   agentDir?: string,
   options?: Pick<
     LoadAuthProfileStoreOptions,
-    "config" | "externalCli" | "externalCliProviderIds" | "externalCliProfileIds"
+    | "config"
+    | "externalCli"
+    | "externalCliProviderIds"
+    | "externalCliProfileIds"
+    | "excludeMainOverlay"
   >,
 ): AuthProfileStore {
   return loadAuthProfileStoreForRuntime(agentDir, {

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -2830,6 +2830,91 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
     }
   });
 
+  it("forwards the loaded auth profile store to loopback tool resolution", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    const agentDir = path.join(dir, "agents", "main", "agent");
+    const authProfileId = "xai:oauth";
+    fs.mkdirSync(agentDir, { recursive: true });
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          [authProfileId]: {
+            type: "oauth",
+            provider: "xai",
+            access: "xai-access-token",
+            refresh: "xai-refresh-token",
+            expires: 1_900_000_000_000,
+          },
+        },
+      },
+      agentDir,
+    );
+    registerMemoryPromptSection(() => []);
+    const getActiveMcpLoopbackRuntime = vi.fn(() => ({
+      port: 31783,
+      ownerToken: "loopback-owner-token",
+      nonOwnerToken: "loopback-non-owner-token",
+    }));
+    const ensureMcpLoopbackServer = vi.fn(createTestMcpLoopbackServer);
+    const createMcpLoopbackServerConfig = vi.fn(createTestMcpLoopbackServerConfig);
+    const resolveMcpLoopbackScopedTools = vi.fn(() => ({ agentId: "main", tools: [] }));
+    setCliRunnerPrepareTestDeps({
+      getActiveMcpLoopbackRuntime,
+      ensureMcpLoopbackServer,
+      createMcpLoopbackServerConfig,
+      resolveMcpLoopbackScopedTools,
+    });
+    cliBackendsTesting.setDepsForTest({
+      resolvePluginSetupCliBackend: () => undefined,
+      resolveRuntimeCliBackends: () => [
+        {
+          id: "native-cli",
+          pluginId: "native-plugin",
+          bundleMcp: true,
+          bundleMcpMode: "claude-config-file" as const,
+          config: {
+            command: "native-cli",
+            args: ["--print"],
+            systemPromptArg: "--system-prompt",
+            systemPromptWhen: "first",
+            output: "text",
+            input: "arg",
+            sessionMode: "existing",
+          },
+        },
+      ],
+    });
+
+    try {
+      await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionKey: "agent:main:test",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "latest ask",
+        provider: "native-cli",
+        model: "test-model",
+        timeoutMs: 1_000,
+        runId: "run-test-loopback-auth-store",
+        authProfileId,
+        config: createCliBackendConfig({ bundleMcp: true }),
+      });
+
+      expect(resolveMcpLoopbackScopedTools).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authProfileStore: expect.objectContaining({
+            profiles: expect.objectContaining({
+              [authProfileId]: expect.objectContaining({ provider: "xai" }),
+            }),
+          }),
+        }),
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("fails bundled MCP preparation when the loopback runtime is unavailable", async () => {
     const { dir, sessionFile } = createSessionFile();
     try {

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -2811,6 +2811,8 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         sourceReplyDeliveryMode: undefined,
         requireExplicitMessageTarget: false,
         senderIsOwner: undefined,
+        authProfileStore: expect.any(Object),
+        agentDir: expect.any(String),
       });
       expect(context.systemPrompt).toContain("## Memory Recall");
       expect(context.systemPrompt).toContain("tools=memory_search");
@@ -2908,6 +2910,91 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
               [authProfileId]: expect.objectContaining({ provider: "xai" }),
             }),
           }),
+          agentDir,
+        }),
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("loads xai OAuth for loopback tool resolution in a claude-cli session without explicit authProfileId", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    const agentDir = path.join(dir, "agents", "main", "agent");
+    const authProfileId = "xai:oauth";
+    fs.mkdirSync(agentDir, { recursive: true });
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          [authProfileId]: {
+            type: "oauth",
+            provider: "xai",
+            access: "xai-access-token",
+            refresh: "xai-refresh-token",
+            expires: 1_900_000_000_000,
+          },
+        },
+      },
+      agentDir,
+    );
+    registerMemoryPromptSection(() => []);
+    const getActiveMcpLoopbackRuntime = vi.fn(() => ({
+      port: 31783,
+      ownerToken: "loopback-owner-token",
+      nonOwnerToken: "loopback-non-owner-token",
+    }));
+    const ensureMcpLoopbackServer = vi.fn(createTestMcpLoopbackServer);
+    const createMcpLoopbackServerConfig = vi.fn(createTestMcpLoopbackServerConfig);
+    const resolveMcpLoopbackScopedTools = vi.fn(() => ({ agentId: "main", tools: [] }));
+    setCliRunnerPrepareTestDeps({
+      getActiveMcpLoopbackRuntime,
+      ensureMcpLoopbackServer,
+      createMcpLoopbackServerConfig,
+      resolveMcpLoopbackScopedTools,
+    });
+    cliBackendsTesting.setDepsForTest({
+      resolvePluginSetupCliBackend: () => undefined,
+      resolveRuntimeCliBackends: () => [
+        {
+          id: "claude-cli",
+          pluginId: "anthropic",
+          bundleMcp: true,
+          bundleMcpMode: "claude-config-file" as const,
+          config: {
+            command: "claude",
+            args: ["--print"],
+            output: "jsonl",
+            jsonlDialect: "claude-stream-json",
+            input: "stdin",
+            sessionMode: "existing",
+          },
+        },
+      ],
+    });
+
+    try {
+      await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionKey: "agent:main:test",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "latest ask",
+        provider: "claude-cli",
+        model: "test-model",
+        timeoutMs: 1_000,
+        runId: "run-test-claude-cli-loopback-oauth-no-profile-id",
+        config: createCliBackendConfig({ bundleMcp: true }),
+      });
+
+      expect(resolveMcpLoopbackScopedTools).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authProfileStore: expect.objectContaining({
+            profiles: expect.objectContaining({
+              [authProfileId]: expect.objectContaining({ provider: "xai" }),
+            }),
+          }),
+          agentDir,
         }),
       );
     } finally {

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -38,7 +38,10 @@ import { resolveAgentDir, resolveSessionAgentIds } from "../agent-scope.js";
 import { externalCliDiscoveryForProviderAuth } from "../auth-profiles/external-cli-discovery.js";
 import { resolveApiKeyForProfile } from "../auth-profiles/oauth.js";
 import { resolveAuthProfileOrder } from "../auth-profiles/order.js";
-import { loadAuthProfileStoreForRuntime } from "../auth-profiles/store.js";
+import {
+  loadAuthProfileStoreForRuntime,
+  loadAuthProfileStoreForSecretsRuntime,
+} from "../auth-profiles/store.js";
 import type { AuthProfileCredential, AuthProfileStore } from "../auth-profiles/types.js";
 import {
   buildBootstrapInjectionStats,
@@ -359,6 +362,15 @@ export async function prepareCliRunContext(
         provider: params.provider,
         ...(options.profileId ? { profileId: options.profileId } : {}),
       }),
+    });
+  const loadLoopbackAuthStore = (options: { profileId?: string } = {}) =>
+    loadAuthProfileStoreForSecretsRuntime(agentDir, {
+      externalCli: externalCliDiscoveryForProviderAuth({
+        cfg: params.config,
+        provider: params.provider,
+        ...(options.profileId ? { profileId: options.profileId } : {}),
+      }),
+      excludeMainOverlay: true,
     });
   if (effectiveAuthProfileId) {
     authStore = loadScopedAuthStore({ profileId: effectiveAuthProfileId });
@@ -703,6 +715,8 @@ export async function prepareCliRunContext(
         : {}),
       ...(preparedCleanup ? { cleanup: preparedCleanup } : {}),
     };
+    const loopbackAuthStore =
+      bundleMcpEnabled && mcpLoopbackRuntime ? loadLoopbackAuthStore() : undefined;
     const promptTools =
       bundleMcpEnabled && mcpLoopbackRuntime
         ? prepareDeps.resolveMcpLoopbackScopedTools({
@@ -720,7 +734,8 @@ export async function prepareCliRunContext(
             sourceReplyDeliveryMode: bindingSourceReplyDeliveryMode,
             requireExplicitMessageTarget: bindingRequireExplicitMessageTarget,
             senderIsOwner: undefined,
-            authProfileStore: authStore,
+            authProfileStore: loopbackAuthStore,
+            agentDir,
           }).tools
         : [];
     const promptToolNamesHash =

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -720,6 +720,7 @@ export async function prepareCliRunContext(
             sourceReplyDeliveryMode: bindingSourceReplyDeliveryMode,
             requireExplicitMessageTarget: bindingRequireExplicitMessageTarget,
             senderIsOwner: undefined,
+            authProfileStore: authStore,
           }).tools
         : [];
     const promptToolNamesHash =

--- a/src/gateway/mcp-http.runtime.auth.test.ts
+++ b/src/gateway/mcp-http.runtime.auth.test.ts
@@ -1,9 +1,10 @@
 // Auth-profile plumbing tests for MCP loopback runtime tool resolution.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 const resolveGatewayScopedToolsMock = vi.hoisted(() =>
-  vi.fn(() => ({
+  vi.fn((_params: { authProfileStore?: AuthProfileStore }) => ({
     agentId: "main",
     tools: [],
   })),
@@ -15,12 +16,17 @@ vi.mock("./tool-resolution.js", () => ({
 
 import { resolveMcpLoopbackScopedTools } from "./mcp-http.runtime.js";
 
-function createAuthProfileStore(): {
-  profiles: Record<string, { provider: string; type: string }>;
-} {
+function createAuthProfileStore(): AuthProfileStore {
   return {
+    version: 1,
     profiles: {
-      "xai-oauth": { provider: "xai", type: "oauth" },
+      "xai-oauth": {
+        type: "oauth",
+        provider: "xai",
+        access: "xai-access-token",
+        refresh: "xai-refresh-token",
+        expires: 1_900_000_000_000,
+      },
     },
   };
 }

--- a/src/gateway/mcp-http.runtime.auth.test.ts
+++ b/src/gateway/mcp-http.runtime.auth.test.ts
@@ -4,10 +4,12 @@ import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 const resolveGatewayScopedToolsMock = vi.hoisted(() =>
-  vi.fn((_params: { authProfileStore?: AuthProfileStore }) => ({
-    agentId: "main",
-    tools: [],
-  })),
+  vi.fn(
+    (_params: { authProfileStore?: AuthProfileStore; agentDir?: string; surface?: string }) => ({
+      agentId: "main",
+      tools: [],
+    }),
+  ),
 );
 
 vi.mock("./tool-resolution.js", () => ({
@@ -36,8 +38,9 @@ describe("resolveMcpLoopbackScopedTools auth profile plumbing", () => {
     resolveGatewayScopedToolsMock.mockClear();
   });
 
-  it("forwards authProfileStore to resolveGatewayScopedTools", () => {
+  it("forwards authProfileStore and agentDir to resolveGatewayScopedTools", () => {
     const authProfileStore = createAuthProfileStore();
+    const agentDir = "/tmp/agent-main";
     resolveMcpLoopbackScopedTools({
       cfg: { tools: { profile: "minimal" } } as OpenClawConfig,
       sessionKey: "agent:main",
@@ -51,6 +54,7 @@ describe("resolveMcpLoopbackScopedTools auth profile plumbing", () => {
       sourceReplyDeliveryMode: undefined,
       senderIsOwner: undefined,
       authProfileStore,
+      agentDir,
     });
 
     expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(1);
@@ -58,10 +62,11 @@ describe("resolveMcpLoopbackScopedTools auth profile plumbing", () => {
     expect(passedParams).toMatchObject({
       surface: "loopback",
       authProfileStore,
+      agentDir,
     });
   });
 
-  it("does not pass authProfileStore when omitted", () => {
+  it("does not pass authProfileStore or agentDir when omitted", () => {
     resolveMcpLoopbackScopedTools({
       cfg: { tools: { profile: "minimal" } } as OpenClawConfig,
       sessionKey: "agent:main",
@@ -79,5 +84,6 @@ describe("resolveMcpLoopbackScopedTools auth profile plumbing", () => {
     expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(1);
     const passedParams = resolveGatewayScopedToolsMock.mock.calls[0]?.[0];
     expect(passedParams.authProfileStore).toBeUndefined();
+    expect(passedParams.agentDir).toBeUndefined();
   });
 });

--- a/src/gateway/mcp-http.runtime.auth.test.ts
+++ b/src/gateway/mcp-http.runtime.auth.test.ts
@@ -11,7 +11,7 @@ const resolveGatewayScopedToolsMock = vi.hoisted(() =>
 );
 
 vi.mock("./tool-resolution.js", () => ({
-  resolveGatewayScopedTools: (...args: unknown[]) => resolveGatewayScopedToolsMock(...args),
+  resolveGatewayScopedTools: resolveGatewayScopedToolsMock,
 }));
 
 import { resolveMcpLoopbackScopedTools } from "./mcp-http.runtime.js";

--- a/src/gateway/mcp-http.runtime.auth.test.ts
+++ b/src/gateway/mcp-http.runtime.auth.test.ts
@@ -1,0 +1,77 @@
+// Auth-profile plumbing tests for MCP loopback runtime tool resolution.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+const resolveGatewayScopedToolsMock = vi.hoisted(() =>
+  vi.fn(() => ({
+    agentId: "main",
+    tools: [],
+  })),
+);
+
+vi.mock("./tool-resolution.js", () => ({
+  resolveGatewayScopedTools: (...args: unknown[]) => resolveGatewayScopedToolsMock(...args),
+}));
+
+import { resolveMcpLoopbackScopedTools } from "./mcp-http.runtime.js";
+
+function createAuthProfileStore(): {
+  profiles: Record<string, { provider: string; type: string }>;
+} {
+  return {
+    profiles: {
+      "xai-oauth": { provider: "xai", type: "oauth" },
+    },
+  };
+}
+
+describe("resolveMcpLoopbackScopedTools auth profile plumbing", () => {
+  beforeEach(() => {
+    resolveGatewayScopedToolsMock.mockClear();
+  });
+
+  it("forwards authProfileStore to resolveGatewayScopedTools", () => {
+    const authProfileStore = createAuthProfileStore();
+    resolveMcpLoopbackScopedTools({
+      cfg: { tools: { profile: "minimal" } } as OpenClawConfig,
+      sessionKey: "agent:main",
+      messageProvider: undefined,
+      currentChannelId: undefined,
+      currentThreadTs: undefined,
+      currentMessageId: undefined,
+      currentInboundAudio: undefined,
+      accountId: undefined,
+      inboundEventKind: undefined,
+      sourceReplyDeliveryMode: undefined,
+      senderIsOwner: undefined,
+      authProfileStore,
+    });
+
+    expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(1);
+    const passedParams = resolveGatewayScopedToolsMock.mock.calls[0]?.[0];
+    expect(passedParams).toMatchObject({
+      surface: "loopback",
+      authProfileStore,
+    });
+  });
+
+  it("does not pass authProfileStore when omitted", () => {
+    resolveMcpLoopbackScopedTools({
+      cfg: { tools: { profile: "minimal" } } as OpenClawConfig,
+      sessionKey: "agent:main",
+      messageProvider: undefined,
+      currentChannelId: undefined,
+      currentThreadTs: undefined,
+      currentMessageId: undefined,
+      currentInboundAudio: undefined,
+      accountId: undefined,
+      inboundEventKind: undefined,
+      sourceReplyDeliveryMode: undefined,
+      senderIsOwner: undefined,
+    });
+
+    expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(1);
+    const passedParams = resolveGatewayScopedToolsMock.mock.calls[0]?.[0];
+    expect(passedParams.authProfileStore).toBeUndefined();
+  });
+});

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -1,5 +1,6 @@
 // MCP loopback runtime scope cache.
 // Resolves Gateway-visible tools for MCP clients with short-lived schema caching.
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import type { SourceReplyDeliveryMode } from "../auto-reply/get-reply-options.types.js";
 import type { InboundEventKind } from "../channels/inbound-event/kind.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -41,6 +42,7 @@ type McpLoopbackScopeParams = {
   sourceReplyDeliveryMode: SourceReplyDeliveryMode | undefined;
   requireExplicitMessageTarget?: boolean;
   senderIsOwner: boolean | undefined;
+  authProfileStore?: AuthProfileStore;
 };
 
 /** Resolves loopback-visible tools after applying gateway scope and native-tool exclusions. */
@@ -64,6 +66,9 @@ export class McpLoopbackToolCache {
   #entries = new Map<string, CachedScopedTools>();
 
   resolve(params: McpLoopbackScopeParams): CachedScopedTools {
+    const authProfileIds = params.authProfileStore
+      ? Object.keys(params.authProfileStore.profiles).toSorted()
+      : [];
     const cacheKey = [
       params.sessionKey,
       params.sessionId ?? "",
@@ -82,6 +87,7 @@ export class McpLoopbackToolCache {
         : params.senderIsOwner === false
           ? "non-owner"
           : "unknown-owner",
+      authProfileIds.join(","),
     ].join("\u0000");
     const now = Date.now();
     for (const [key, entry] of this.#entries) {

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -43,6 +43,7 @@ type McpLoopbackScopeParams = {
   requireExplicitMessageTarget?: boolean;
   senderIsOwner: boolean | undefined;
   authProfileStore?: AuthProfileStore;
+  agentDir?: string;
 };
 
 /** Resolves loopback-visible tools after applying gateway scope and native-tool exclusions. */
@@ -88,6 +89,7 @@ export class McpLoopbackToolCache {
           ? "non-owner"
           : "unknown-owner",
       authProfileIds.join(","),
+      params.agentDir ?? "",
     ].join("\u0000");
     const now = Date.now();
     for (const [key, entry] of this.#entries) {

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -7,10 +7,13 @@ import {
   type ServerResponse,
 } from "node:http";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { resolveAgentDir } from "../agents/agent-scope-config.js";
+import { loadAuthProfileStoreForSecretsRuntime } from "../agents/auth-profiles/store.js";
 import { getRuntimeConfig } from "../config/io.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { logDebug, logWarn } from "../logger.js";
+import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { handleMcpJsonRpc } from "./mcp-http.handlers.js";
 import {
   clearActiveMcpLoopbackRuntimeByOwnerToken,
@@ -145,6 +148,21 @@ function createRequestAbortSignal(req: IncomingMessage, res: ServerResponse) {
   };
 }
 
+function resolveMcpLoopbackAuthProfileStore(
+  cfg: OpenClawConfig,
+  sessionKey: string,
+): ReturnType<typeof loadAuthProfileStoreForSecretsRuntime> | undefined {
+  try {
+    const agentId = resolveAgentIdFromSessionKey(sessionKey);
+    const agentDir = resolveAgentDir(cfg, agentId);
+    return loadAuthProfileStoreForSecretsRuntime(agentDir);
+  } catch {
+    // Auth-profile loading is best-effort for loopback tool availability.
+    // Missing or unreadable stores fall back to the previous behavior.
+    return undefined;
+  }
+}
+
 /** Starts a new MCP loopback HTTP server and registers its bearer tokens. */
 export async function startMcpLoopbackServer(port = 0): Promise<{
   port: number;
@@ -228,6 +246,7 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
         const cfg = getRuntimeConfig();
         const requestContext = resolveMcpRequestContext(req, cfg, auth);
         const yieldContext = resolveMcpLoopbackYieldContext(cliRequestCaptureHandle);
+        const authProfileStore = resolveMcpLoopbackAuthProfileStore(cfg, requestContext.sessionKey);
         const scopedTools = toolCache.resolve({
           cfg,
           sessionKey: requestContext.sessionKey,
@@ -244,6 +263,7 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
           sourceReplyDeliveryMode: requestContext.sourceReplyDeliveryMode,
           requireExplicitMessageTarget: requestContext.requireExplicitMessageTarget,
           senderIsOwner: requestContext.senderIsOwner,
+          authProfileStore,
         });
 
         logMcpLoopbackTraffic("request", {

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -152,11 +152,16 @@ function createRequestAbortSignal(req: IncomingMessage, res: ServerResponse) {
 function resolveMcpLoopbackAuthProfileStore(
   cfg: OpenClawConfig,
   sessionKey: string,
-): ReturnType<typeof loadAuthProfileStoreForSecretsRuntime> | undefined {
+):
+  | { authProfileStore: ReturnType<typeof loadAuthProfileStoreForSecretsRuntime>; agentDir: string }
+  | undefined {
   try {
     const { sessionAgentId } = resolveSessionAgentIds({ config: cfg, sessionKey });
     const agentDir = resolveAgentDir(cfg, sessionAgentId);
-    return loadAuthProfileStoreForSecretsRuntime(agentDir);
+    const authProfileStore = loadAuthProfileStoreForSecretsRuntime(agentDir, {
+      excludeMainOverlay: true,
+    });
+    return { authProfileStore, agentDir };
   } catch {
     // Auth-profile loading is best-effort for loopback tool availability.
     // Missing or unreadable stores fall back to the previous behavior.
@@ -247,7 +252,12 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
         const cfg = getRuntimeConfig();
         const requestContext = resolveMcpRequestContext(req, cfg, auth);
         const yieldContext = resolveMcpLoopbackYieldContext(cliRequestCaptureHandle);
-        const authProfileStore = resolveMcpLoopbackAuthProfileStore(cfg, requestContext.sessionKey);
+        const authProfileResult = resolveMcpLoopbackAuthProfileStore(
+          cfg,
+          requestContext.sessionKey,
+        );
+        const authProfileStore = authProfileResult?.authProfileStore;
+        const agentDir = authProfileResult?.agentDir;
         const scopedTools = toolCache.resolve({
           cfg,
           sessionKey: requestContext.sessionKey,
@@ -265,6 +275,7 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
           requireExplicitMessageTarget: requestContext.requireExplicitMessageTarget,
           senderIsOwner: requestContext.senderIsOwner,
           authProfileStore,
+          agentDir,
         });
 
         logMcpLoopbackTraffic("request", {

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -8,13 +8,13 @@ import {
 } from "node:http";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolveAgentDir } from "../agents/agent-scope-config.js";
+import { resolveSessionAgentIds } from "../agents/agent-scope.js";
 import { loadAuthProfileStoreForSecretsRuntime } from "../agents/auth-profiles/store.js";
 import { getRuntimeConfig } from "../config/io.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { logDebug, logWarn } from "../logger.js";
-import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { handleMcpJsonRpc } from "./mcp-http.handlers.js";
 import {
   clearActiveMcpLoopbackRuntimeByOwnerToken,
@@ -154,8 +154,8 @@ function resolveMcpLoopbackAuthProfileStore(
   sessionKey: string,
 ): ReturnType<typeof loadAuthProfileStoreForSecretsRuntime> | undefined {
   try {
-    const agentId = resolveAgentIdFromSessionKey(sessionKey);
-    const agentDir = resolveAgentDir(cfg, agentId);
+    const { sessionAgentId } = resolveSessionAgentIds({ config: cfg, sessionKey });
+    const agentDir = resolveAgentDir(cfg, sessionAgentId);
     return loadAuthProfileStoreForSecretsRuntime(agentDir);
   } catch {
     // Auth-profile loading is best-effort for loopback tool availability.

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -10,6 +10,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolveAgentDir } from "../agents/agent-scope-config.js";
 import { loadAuthProfileStoreForSecretsRuntime } from "../agents/auth-profiles/store.js";
 import { getRuntimeConfig } from "../config/io.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { logDebug, logWarn } from "../logger.js";

--- a/src/gateway/tool-resolution.auth.test.ts
+++ b/src/gateway/tool-resolution.auth.test.ts
@@ -1,0 +1,113 @@
+// Auth-profile plumbing tests for gateway-scoped tool resolution.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+const createOpenClawToolsMock = vi.hoisted(() => vi.fn(() => []));
+
+vi.mock("../agents/openclaw-tools.js", () => ({
+  createOpenClawTools: createOpenClawToolsMock,
+}));
+
+vi.mock("../agents/agent-tools.policy.js", async () => {
+  const actual = await vi.importActual<typeof import("../agents/agent-tools.policy.js")>(
+    "../agents/agent-tools.policy.js",
+  );
+  return {
+    ...actual,
+    resolveEffectiveToolPolicy: () => ({
+      agentId: undefined,
+      globalPolicy: undefined,
+      globalProviderPolicy: undefined,
+      agentPolicy: undefined,
+      agentProviderPolicy: undefined,
+      profile: undefined,
+      providerProfile: undefined,
+      profileAlsoAllow: undefined,
+      providerProfileAlsoAllow: undefined,
+    }),
+    resolveGroupToolPolicy: () => undefined,
+    resolveInheritedToolPolicyForSession: () => undefined,
+    resolveSubagentToolPolicyForSession: () => undefined,
+  };
+});
+
+vi.mock("../agents/subagent-capabilities.js", () => ({
+  isSubagentEnvelopeSession: () => false,
+  resolveSubagentCapabilityStore: () => undefined,
+}));
+
+vi.mock("../plugins/tools.js", () => ({
+  getPluginToolMeta: () => undefined,
+}));
+
+vi.mock("../agents/tool-policy-pipeline.js", async () => {
+  const actual = await vi.importActual<typeof import("../agents/tool-policy-pipeline.js")>(
+    "../agents/tool-policy-pipeline.js",
+  );
+  return {
+    ...actual,
+    applyToolPolicyPipeline: ({ tools }: { tools: unknown[] }) => tools,
+  };
+});
+
+import { resolveGatewayScopedTools } from "./tool-resolution.js";
+
+function createAuthProfileStore(): {
+  profiles: Record<string, { provider: string; type: string }>;
+} {
+  return {
+    profiles: {
+      "xai-oauth": { provider: "xai", type: "oauth" },
+    },
+  };
+}
+
+describe("resolveGatewayScopedTools auth profile plumbing", () => {
+  beforeEach(() => {
+    createOpenClawToolsMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("forwards authProfileStore to createOpenClawTools on loopback surfaces", () => {
+    const authProfileStore = createAuthProfileStore();
+    resolveGatewayScopedTools({
+      cfg: { tools: { profile: "minimal" } } as OpenClawConfig,
+      sessionKey: "agent:main:telegram:group:-100123",
+      surface: "loopback",
+      authProfileStore,
+    });
+
+    expect(createOpenClawToolsMock).toHaveBeenCalledTimes(1);
+    const passedOptions = createOpenClawToolsMock.mock.calls[0]?.[0];
+    expect(passedOptions).toMatchObject({ authProfileStore });
+  });
+
+  it("forwards authProfileStore to createOpenClawTools on http surfaces", () => {
+    const authProfileStore = createAuthProfileStore();
+    resolveGatewayScopedTools({
+      cfg: { tools: { profile: "minimal" } } as OpenClawConfig,
+      sessionKey: "agent:main:telegram:group:-100123",
+      surface: "http",
+      authProfileStore,
+    });
+
+    expect(createOpenClawToolsMock).toHaveBeenCalledTimes(1);
+    const passedOptions = createOpenClawToolsMock.mock.calls[0]?.[0];
+    expect(passedOptions).toMatchObject({ authProfileStore });
+  });
+
+  it("omits authProfileStore from createOpenClawTools when not provided", () => {
+    resolveGatewayScopedTools({
+      cfg: { tools: { profile: "minimal" } } as OpenClawConfig,
+      sessionKey: "agent:main:telegram:group:-100123",
+      surface: "loopback",
+    });
+
+    expect(createOpenClawToolsMock).toHaveBeenCalledTimes(1);
+    const passedOptions = createOpenClawToolsMock.mock.calls[0]?.[0];
+    expect(passedOptions.authProfileStore).toBeUndefined();
+  });
+});

--- a/src/gateway/tool-resolution.auth.test.ts
+++ b/src/gateway/tool-resolution.auth.test.ts
@@ -1,8 +1,11 @@
 // Auth-profile plumbing tests for gateway-scoped tool resolution.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
-const createOpenClawToolsMock = vi.hoisted(() => vi.fn(() => []));
+const createOpenClawToolsMock = vi.hoisted(() =>
+  vi.fn((_options: { authProfileStore?: AuthProfileStore }) => []),
+);
 
 vi.mock("../agents/openclaw-tools.js", () => ({
   createOpenClawTools: createOpenClawToolsMock,
@@ -52,12 +55,17 @@ vi.mock("../agents/tool-policy-pipeline.js", async () => {
 
 import { resolveGatewayScopedTools } from "./tool-resolution.js";
 
-function createAuthProfileStore(): {
-  profiles: Record<string, { provider: string; type: string }>;
-} {
+function createAuthProfileStore(): AuthProfileStore {
   return {
+    version: 1,
     profiles: {
-      "xai-oauth": { provider: "xai", type: "oauth" },
+      "xai-oauth": {
+        provider: "xai",
+        type: "oauth",
+        access: "xai-access-token",
+        refresh: "xai-refresh-token",
+        expires: 1_900_000_000_000,
+      },
     },
   };
 }

--- a/src/gateway/tool-resolution.auth.test.ts
+++ b/src/gateway/tool-resolution.auth.test.ts
@@ -79,32 +79,36 @@ describe("resolveGatewayScopedTools auth profile plumbing", () => {
     vi.clearAllMocks();
   });
 
-  it("forwards authProfileStore to createOpenClawTools on loopback surfaces", () => {
+  it("forwards authProfileStore and agentDir to createOpenClawTools on loopback surfaces", () => {
     const authProfileStore = createAuthProfileStore();
+    const agentDir = "/tmp/agent-main";
     resolveGatewayScopedTools({
       cfg: { tools: { profile: "minimal" } } as OpenClawConfig,
       sessionKey: "agent:main:telegram:group:-100123",
       surface: "loopback",
       authProfileStore,
+      agentDir,
     });
 
     expect(createOpenClawToolsMock).toHaveBeenCalledTimes(1);
     const passedOptions = createOpenClawToolsMock.mock.calls[0]?.[0];
-    expect(passedOptions).toMatchObject({ authProfileStore });
+    expect(passedOptions).toMatchObject({ authProfileStore, agentDir });
   });
 
-  it("forwards authProfileStore to createOpenClawTools on http surfaces", () => {
+  it("forwards authProfileStore and agentDir to createOpenClawTools on http surfaces", () => {
     const authProfileStore = createAuthProfileStore();
+    const agentDir = "/tmp/agent-main";
     resolveGatewayScopedTools({
       cfg: { tools: { profile: "minimal" } } as OpenClawConfig,
       sessionKey: "agent:main:telegram:group:-100123",
       surface: "http",
       authProfileStore,
+      agentDir,
     });
 
     expect(createOpenClawToolsMock).toHaveBeenCalledTimes(1);
     const passedOptions = createOpenClawToolsMock.mock.calls[0]?.[0];
-    expect(passedOptions).toMatchObject({ authProfileStore });
+    expect(passedOptions).toMatchObject({ authProfileStore, agentDir });
   });
 
   it("omits authProfileStore from createOpenClawTools when not provided", () => {

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -67,6 +67,7 @@ export function resolveGatewayScopedTools(params: {
   disablePluginTools?: boolean;
   gatewayRequestedTools?: string[];
   authProfileStore?: AuthProfileStore;
+  agentDir?: string;
 }) {
   const {
     agentId,
@@ -190,6 +191,7 @@ export function resolveGatewayScopedTools(params: {
     allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
     allowMediaInvokeCommands: params.allowMediaInvokeCommands,
     disablePluginTools: params.disablePluginTools,
+    agentDir: params.agentDir,
     wrapBeforeToolCallHook: false,
     config: params.cfg,
     workspaceDir,

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -6,6 +6,7 @@ import {
   resolveInheritedToolPolicyForSession,
   resolveSubagentToolPolicyForSession,
 } from "../agents/agent-tools.policy.js";
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import { createOpenClawTools } from "../agents/openclaw-tools.js";
 import {
   isSubagentEnvelopeSession,
@@ -65,6 +66,7 @@ export function resolveGatewayScopedTools(params: {
   excludeToolNames?: Iterable<string>;
   disablePluginTools?: boolean;
   gatewayRequestedTools?: string[];
+  authProfileStore?: AuthProfileStore;
 }) {
   const {
     agentId,
@@ -209,6 +211,7 @@ export function resolveGatewayScopedTools(params: {
       : undefined,
     inheritedToolAllowlist,
     inheritedToolDenylist,
+    ...(params.authProfileStore ? { authProfileStore: params.authProfileStore } : {}),
   });
 
   const policyFiltered = applyToolPolicyPipeline({


### PR DESCRIPTION
Closes #101967

## What Problem This Solves

Fixes an issue where users running CLI-backend sessions (e.g., `claude-cli`) with OAuth-only xAI auth would never see the `x_search` and `code_execution` tools on the session tool surface. Because subagents inherit the parent session's tool list, the tools were also stripped from native-runtime Grok subagents spawned from a claude-cli main session.

## Why This Change Was Made

The gateway loopback MCP bridge that feeds CLI-backend sessions resolved plugin tools without passing an `authProfileStore`. Native embedded runs already passed the store, which let the xAI plugin register search/code-execution tools when an OAuth profile was present. This change threads the auth profile store through the same path and ensures the loopback surface uses the agent-local store without silently falling back to main credentials:

- `resolveGatewayScopedTools` now accepts and forwards `authProfileStore` and `agentDir` to `createOpenClawTools`.
- `resolveMcpLoopbackScopedTools` / `McpLoopbackToolCache` accept `authProfileStore` and `agentDir`; the cache key includes `agentDir` so different agents do not share tool entries.
- `cli-runner/prepare.ts` forwards its already-loaded `authStore` and resolved `agentDir` when computing prompt tools.
- The MCP loopback HTTP server resolves the per-session agent directory, loads the agent-local auth profile store, and passes both into tool resolution.
- `loadAuthProfileStoreForSecretsRuntime` gains an `excludeMainOverlay` option; the loopback path uses it so an expired or missing agent-local OAuth profile does not silently inherit the main store's OAuth identity.

## User Impact

CLI-backend sessions with OAuth-only xAI auth now correctly surface `x_search` and `code_execution`, and subagents spawned from those sessions inherit the tools as expected. Agent-local OAuth credentials stay scoped to the agent on the loopback surface.

## Evidence

- New focused tests:
  - `src/gateway/tool-resolution.auth.test.ts` verifies `resolveGatewayScopedTools` forwards `authProfileStore` and `agentDir` to `createOpenClawTools` on both loopback and HTTP surfaces.
  - `src/gateway/mcp-http.runtime.auth.test.ts` verifies `resolveMcpLoopbackScopedTools` forwards `authProfileStore` and `agentDir` to `resolveGatewayScopedTools`.
  - `src/agents/cli-runner/prepare.test.ts` verifies `prepareCliRunContext` passes the loaded auth store and `agentDir` to loopback tool resolution.
  - `src/agents/auth-profiles/profiles.test.ts` verifies `loadAuthProfileStoreForSecretsRuntime(agentDir, { excludeMainOverlay: true })` does not inherit main OAuth profiles.
  - `extensions/xai/src/xai-oauth-tool-registration.test.ts` verifies the xAI plugin registers `x_search` and `code_execution` when an OAuth auth context is present.

- Existing suites still pass:
  - `node scripts/run-vitest.mjs src/gateway/tool-resolution.test.ts src/gateway/tool-resolution.exclude.test.ts`
  - `node scripts/run-vitest.mjs src/gateway/mcp-http.test.ts`
  - `node scripts/run-vitest.mjs src/gateway/tools-invoke-http.cron-regression.test.ts`
  - `node scripts/run-vitest.mjs src/agents/auth-profiles/profiles.test.ts`

## Real behavior proof

The following is a redacted runtime transcript produced by `scripts/proof/xai-oauth-loopback-tools.ts`. It exercises the actual changed gateway path:

1. Builds a real plugin registry and registers the bundled xAI plugin through a real `registerTool` handler (so `code_execution` and `x_search` are actually recorded in the registry).
2. Loads an OAuth-only xAI auth profile store (tokens redacted).
3. Calls `resolveGatewayScopedTools({ surface: "loopback", authProfileStore, agentDir })` — the same function used by the CLI-backend loopback/MCP tool surface.
4. Prints the resulting MCP `tools/list` JSON-RPC response.

All private tokens, account IDs, phone numbers, IPs, and non-public endpoints are redacted.

```bash
node --import tsx scripts/proof/xai-oauth-loopback-tools.ts
```

```text
[xai-oauth-loopback-proof] registered plugin tool count: 2
[xai-oauth-loopback-proof] registered plugin tool names: code_execution, x_search
[agents/tool-policy] tool policy removed 5 tool(s) via tools.profile (coding): agents_list, gateway, message, nodes, tts
[xai-oauth-loopback-proof] resolved loopback tool names: code_execution, create_goal, cron, get_goal, image_generate, memory_get, memory_search, session_status, sessions_history, sessions_list, sessions_send, sessions_spawn, sessions_yield, skill_workshop, subagents, update_goal, update_plan, video_generate, web_fetch, web_search, x_search
[xai-oauth-loopback-proof] MCP tools/list response:
{
  "jsonrpc": "2.0",
  "id": "proof-tools-list",
  "result": {
    "tools": [
      ...
      {
        "name": "code_execution",
        "description": "Run sandboxed Python analysis with xAI. Use for calculations, tabulation, summaries, and chart-style analysis without local machine access."
      },
      ...
      {
        "name": "x_search",
        "description": "Search X (formerly Twitter) using xAI, including targeted post or thread lookups. For per-post stats like reposts, replies, bookmarks, or views, prefer the exact post URL or status ID."
      }
    ]
  }
}
PASS: x_search and code_execution are present on the loopback surface.
```

This confirms that after the fix, the OAuth-only xAI auth profile store and resolved agent directory flow through the changed gateway loopback path and both `x_search` and `code_execution` are surfaced.
