### PR TITLE
fix: skip already-run cron catchup after restart

### DIFF
--- a/src/cron/service.restart-catchup.test.ts
+++ b/src/cron/service.restart-catchup.test.ts
@@ -270,6 +270,114 @@ describe("CronService restart catch-up", () => {
     }
   });
 
+  it("does not defer stale due isolated cron slot that already succeeded before restart", async () => {
+    const store = await makeStorePath();
+    const startNow = Date.parse("2025-12-13T04:02:00.000Z");
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeat = vi.fn();
+
+    await writeStoreJobs(store.storePath, [
+      {
+        id: "startup-isolated-already-ran",
+        name: "startup isolated already ran",
+        enabled: true,
+        createdAtMs: Date.parse("2025-12-10T12:00:00.000Z"),
+        updatedAtMs: Date.parse("2025-12-13T04:01:30.000Z"),
+        schedule: { kind: "cron", expr: "1,11,21,31,41,51 4-20 * * *", tz: "UTC" },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "already sent" },
+        state: {
+          nextRunAtMs: Date.parse("2025-12-13T04:01:00.000Z"),
+          lastRunAtMs: Date.parse("2025-12-13T04:01:00.000Z"),
+          lastRunStatus: "ok",
+        },
+      },
+    ]);
+
+    const cron = createRestartCronService({
+      storePath: store.storePath,
+      enqueueSystemEvent,
+      requestHeartbeat,
+      runIsolatedAgentJob,
+      nowMs: () => startNow,
+      startupDeferredMissedAgentJobDelayMs: 120_000,
+    });
+
+    try {
+      await cron.start();
+
+      expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+      expect(enqueueSystemEvent).not.toHaveBeenCalled();
+      expect(requestHeartbeat).not.toHaveBeenCalled();
+
+      const listedJobs = await cron.list({ includeDisabled: true });
+      const updated = listedJobs.find((job) => job.id === "startup-isolated-already-ran");
+      expect(updated?.state.lastRunStatus).toBe("ok");
+      expect(updated?.state.nextRunAtMs).toBe(Date.parse("2025-12-13T04:11:00.000Z"));
+    } finally {
+      cron.stop();
+      await store.cleanup();
+    }
+  });
+
+  it("replays newer missed cron slot when stale due slot already succeeded before restart", async () => {
+    vi.setSystemTime(new Date("2025-12-13T04:10:00.000Z"));
+    await withRestartedCron(
+      [
+        {
+          id: "restart-stale-success-newer-miss",
+          name: "stale success with newer miss",
+          enabled: true,
+          createdAtMs: Date.parse("2025-12-10T12:00:00.000Z"),
+          updatedAtMs: Date.parse("2025-12-13T04:01:30.000Z"),
+          schedule: { kind: "cron", expr: "* * * * *", tz: "UTC" },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "systemEvent", text: "newer slot missed" },
+          state: {
+            nextRunAtMs: Date.parse("2025-12-13T04:01:00.000Z"),
+            lastRunAtMs: Date.parse("2025-12-13T04:01:00.000Z"),
+            lastRunStatus: "ok",
+          },
+        },
+      ],
+      async ({ enqueueSystemEvent, requestHeartbeat }) => {
+        expectQueuedSystemEvent(enqueueSystemEvent, "newer slot missed");
+        expect(requestHeartbeat).toHaveBeenCalled();
+      },
+    );
+  });
+
+  it("replays cron slot due exactly at restart when prior stale slot already succeeded", async () => {
+    vi.setSystemTime(new Date("2025-12-13T04:02:00.000Z"));
+    await withRestartedCron(
+      [
+        {
+          id: "restart-stale-success-boundary-miss",
+          name: "stale success with boundary miss",
+          enabled: true,
+          createdAtMs: Date.parse("2025-12-10T12:00:00.000Z"),
+          updatedAtMs: Date.parse("2025-12-13T04:01:30.000Z"),
+          schedule: { kind: "cron", expr: "* * * * *", tz: "UTC" },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "systemEvent", text: "boundary slot missed" },
+          state: {
+            nextRunAtMs: Date.parse("2025-12-13T04:01:00.000Z"),
+            lastRunAtMs: Date.parse("2025-12-13T04:01:00.000Z"),
+            lastRunStatus: "ok",
+          },
+        },
+      ],
+      async ({ enqueueSystemEvent, requestHeartbeat }) => {
+        expectQueuedSystemEvent(enqueueSystemEvent, "boundary slot missed");
+        expect(requestHeartbeat).toHaveBeenCalled();
+      },
+    );
+  });
+
   it("marks interrupted recurring jobs failed instead of replaying them on startup", async () => {
     const dueAt = Date.parse("2025-12-13T16:00:00.000Z");
     const staleRunningAt = Date.parse("2025-12-13T16:30:00.000Z");

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1640,6 +1640,18 @@ function isRunnableJob(params: {
     return false;
   }
   if (hasScheduledNextRunAtMs(next) && nowMs >= next) {
+    if (
+      params.skipAtIfAlreadyRan &&
+      params.allowCronMissedRunByLastRun &&
+      job.schedule.kind === "cron" &&
+      lastRunStatus === "ok"
+    ) {
+      const lastRunAtMs = job.state.lastRunAtMs;
+      if (typeof lastRunAtMs === "number" && Number.isFinite(lastRunAtMs) && lastRunAtMs >= next) {
+        const previousRunAtMs = computeJobPreviousRunAtOrBeforeMs(job, nowMs);
+        return typeof previousRunAtMs === "number" && previousRunAtMs > lastRunAtMs;
+      }
+    }
     return true;
   }
   if (!params.allowCronMissedRunByLastRun || job.schedule.kind !== "cron") {
@@ -1660,6 +1672,34 @@ function isRunnableJob(params: {
     return false;
   }
   return previousRunAtMs > lastRunAtMs;
+}
+
+function computeJobPreviousRunAtOrBeforeMs(job: CronJob, nowMs: number): number | undefined {
+  let previousRunAtMs: number | undefined;
+  try {
+    previousRunAtMs = computeJobPreviousRunAtMs(job, nowMs);
+  } catch {
+    return undefined;
+  }
+
+  try {
+    // `computeJobPreviousRunAtMs` is strict-before. Probe just past `nowMs`
+    // so startup catch-up still sees a cron slot due exactly at restart.
+    const probeMs = nowMs + (nowMs % 1000 === 0 ? 1_000 : 1);
+    const boundaryRunAtMs = computeJobPreviousRunAtMs(job, probeMs);
+    if (
+      typeof boundaryRunAtMs === "number" &&
+      Number.isFinite(boundaryRunAtMs) &&
+      boundaryRunAtMs <= nowMs &&
+      (previousRunAtMs === undefined || boundaryRunAtMs > previousRunAtMs)
+    ) {
+      previousRunAtMs = boundaryRunAtMs;
+    }
+  } catch {
+    // The strict-before result is still usable when a boundary probe fails.
+  }
+
+  return previousRunAtMs;
 }
 
 function isErrorBackoffPending(state: CronServiceState, job: CronJob, nowMs: number): boolean {


### PR DESCRIPTION
Closes #101988

## What Problem This Solves

Fixes an issue where users with successful cron jobs could receive duplicate startup catch-up runs after a Gateway restart when the persisted due slot had already completed.

## Why This Change Was Made

Startup catch-up now treats a stale successful cron due slot as already covered only when no later cron occurrence has been missed. The check still replays legitimate missed cron slots, including a slot due exactly at restart time, and leaves failed/skipped retry and backoff behavior unchanged.

## User Impact

Users should no longer see duplicate scheduled cron output after restarting the Gateway when the current schedule window already completed successfully. Missed later cron windows still catch up instead of being silently advanced away.

## Evidence

- `git diff --check`
- `node scripts/run-vitest.mjs src/cron/service.restart-catchup.test.ts` (18 tests passed)
- `node scripts/run-vitest.mjs src/cron/service/timer.regression.test.ts` (66 tests passed)
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean: no accepted/actionable findings)

AI-assisted by Codex.
