### PR TITLE
refactor(qa-lab): localize orchestration declarations

### DIFF
--- a/extensions/qa-lab/shared/evidence-gallery-types.ts
+++ b/extensions/qa-lab/shared/evidence-gallery-types.ts
@@ -1,6 +1,6 @@
-export type QaEvidenceGalleryStatus = "pass" | "fail" | "blocked" | "skipped";
+type QaEvidenceGalleryStatus = "pass" | "fail" | "blocked" | "skipped";
 
-export type QaEvidenceCoverageView = {
+type QaEvidenceCoverageView = {
   id: string;
   role: string;
 };

--- a/extensions/qa-lab/src/ci-smoke-plan.ts
+++ b/extensions/qa-lab/src/ci-smoke-plan.ts
@@ -12,7 +12,7 @@ const QA_SMOKE_PROFILE = "smoke-ci";
 const QA_SMOKE_DEFAULT_CHANNEL_SHARDS = 2;
 const QA_SMOKE_MAX_SHARDS = 8;
 
-export type QaSmokeCiShard = {
+type QaSmokeCiShard = {
   name: string;
   slug: string;
   channel: string;

--- a/extensions/qa-lab/src/qa-gateway-config.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.ts
@@ -23,7 +23,7 @@ export const DEFAULT_QA_CONTROL_UI_ALLOWED_ORIGINS = Object.freeze([
 ]);
 
 export const QA_BASE_RUNTIME_PLUGIN_IDS = Object.freeze(["acpx", "memory-core"]);
-export const QA_LAB_PLUGIN_ID = "qa-lab";
+const QA_LAB_PLUGIN_ID = "qa-lab";
 
 export function mergeQaControlUiAllowedOrigins(extraOrigins?: string[]) {
   const normalizedExtra = (extraOrigins ?? [])

--- a/extensions/qa-lab/src/qa-transport-registry.ts
+++ b/extensions/qa-lab/src/qa-transport-registry.ts
@@ -30,7 +30,7 @@ export type QaTransportAdapterFactoryResult<
 
 export type QaTransportAdapterFactory = NonNullable<QaRunnerCliRegistration["adapterFactory"]>;
 
-export type QaTransportAdapterFactoryRegistry = {
+type QaTransportAdapterFactoryRegistry = {
   create: (context: QaTransportFactoryContext) => Promise<QaTransportAdapterFactoryResult>;
 };
 

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -52,7 +52,7 @@ export type QaSuiteRuntimeResult =
       result: QaUnifiedSuiteResult;
     };
 
-export type QaUnifiedSuiteResult = {
+type QaUnifiedSuiteResult = {
   evidencePath: string;
   outputDir: string;
   report: string;

--- a/extensions/qa-lab/src/test-file-scenario-runner.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.ts
@@ -32,7 +32,7 @@ export type QaTestFileScenario = QaSeedScenarioWithSource & {
 
 export type QaTestFileExecutionKind = "script" | "vitest" | "playwright";
 
-export type QaTestFileScenarioRunParams = {
+type QaTestFileScenarioRunParams = {
   commandTimeoutMs?: number;
   evidenceMode?: QaScorecardEvidenceMode;
   env?: NodeJS.ProcessEnv;


### PR DESCRIPTION
## What Problem This Solves

Seven QA Lab orchestration declarations were exported even though they have no repository consumers and are not part of the package's explicit public API.

## Why This Change Was Made

Keep these declarations local to their owning modules while preserving the exported functions and result types that form the actual QA Lab surface. `QaModelSelection` was deliberately left exported because `model-selection.ts` is re-exported through a wildcard barrel.

## User Impact

None. This is export-surface cleanup only; runtime behavior and supported QA Lab APIs are unchanged.

## Evidence

- Fresh codebase-memory graph: 281,363 nodes / 1,134,383 edges.
- MCP graph search and repository-wide exact search found no external consumers or explicit barrel exports for the seven localized declarations.
- Testbox `tbx_01kwzvzf75590qyxg6nkfwcdm2`: post-rebase `pnpm check:changed` passed, including core and extension type/lint lanes.
- Seven focused patched suites passed: 70/70 tests.
- Full build passed after rebasing onto current `origin/main`.
- A wider eight-suite run was 70/71 because `ci-smoke-plan.test.ts` expects 89 scenarios while current main produces 98; the identical failure was reproduced on pristine current main.
- Fresh autoreview: local 0.89, pre-rebase branch 0.87, post-rebase branch 0.91; no accepted/actionable findings.
