### PR TITLE
refactor(google-meet): localize internal declarations

### DIFF
--- a/extensions/google-meet/src/cli.ts
+++ b/extensions/google-meet/src/cli.ts
@@ -98,7 +98,7 @@ type MeetArtifactOptions = ResolveSpaceOptions & {
   output?: string;
 };
 
-export type GoogleMeetExportRequest = {
+type GoogleMeetExportRequest = {
   meeting?: string;
   conferenceRecord?: string;
   calendarEventId?: string;
@@ -113,7 +113,7 @@ export type GoogleMeetExportRequest = {
   earlyBeforeMinutes?: number;
 };
 
-export type GoogleMeetExportWarning = {
+type GoogleMeetExportWarning = {
   type:
     | "smart_notes"
     | "transcript_entries"
@@ -124,7 +124,7 @@ export type GoogleMeetExportWarning = {
   message: string;
 };
 
-export type GoogleMeetExportManifest = {
+type GoogleMeetExportManifest = {
   generatedAt: string;
   request?: GoogleMeetExportRequest;
   tokenSource?: "cached-access-token" | "refresh-token";

--- a/extensions/google-meet/src/config.ts
+++ b/extensions/google-meet/src/config.ts
@@ -18,7 +18,7 @@ import {
 export type GoogleMeetTransport = "chrome" | "chrome-node" | "twilio";
 export type GoogleMeetMode = "agent" | "bidi" | "transcribe";
 export type GoogleMeetModeInput = GoogleMeetMode | "realtime";
-export type GoogleMeetRealtimeStrategy = "agent" | "bidi";
+type GoogleMeetRealtimeStrategy = "agent" | "bidi";
 type GoogleMeetChromeAudioFormat = "pcm16-24khz" | "g711-ulaw-8khz";
 export type GoogleMeetToolPolicy = RealtimeVoiceAgentConsultToolPolicy;
 
@@ -106,7 +106,7 @@ export function resolveGoogleMeetGatewayOperationTimeoutMs(config: GoogleMeetCon
 
 const SOX_DEFAULT_BUFFER_BYTES = 8192;
 const SOX_MIN_BUFFER_BYTES = 17;
-export const DEFAULT_GOOGLE_MEET_AUDIO_BUFFER_BYTES = SOX_DEFAULT_BUFFER_BYTES / 2;
+const DEFAULT_GOOGLE_MEET_AUDIO_BUFFER_BYTES = SOX_DEFAULT_BUFFER_BYTES / 2;
 const PLAIN_DECIMAL_NUMBER_RE = /^\d+(?:\.\d+)?$/;
 
 function withSoxBuffer(command: readonly string[], bufferBytes: number): string[] {

--- a/extensions/google-meet/src/meet.ts
+++ b/extensions/google-meet/src/meet.ts
@@ -23,7 +23,7 @@ export type GoogleMeetSpaceConfig = {
   entryPointAccess?: GoogleMeetEntryPointAccess;
 };
 
-export type GoogleMeetSpace = {
+type GoogleMeetSpace = {
   name: string;
   meetingCode?: string;
   meetingUri?: string;
@@ -31,7 +31,7 @@ export type GoogleMeetSpace = {
   config?: GoogleMeetSpaceConfig & Record<string, unknown>;
 };
 
-export type GoogleMeetPreflightReport = {
+type GoogleMeetPreflightReport = {
   input: string;
   resolvedSpaceName: string;
   meetingCode?: string;
@@ -42,17 +42,17 @@ export type GoogleMeetPreflightReport = {
   blockers: string[];
 };
 
-export type GoogleMeetCreateSpaceResult = {
+type GoogleMeetCreateSpaceResult = {
   space: GoogleMeetSpace;
   meetingUri: string;
 };
 
-export type GoogleMeetEndActiveConferenceResult = {
+type GoogleMeetEndActiveConferenceResult = {
   space: string;
   ended: true;
 };
 
-export type GoogleMeetConferenceRecord = {
+type GoogleMeetConferenceRecord = {
   name: string;
   space?: string;
   startTime?: string;

--- a/extensions/google-meet/src/oauth.ts
+++ b/extensions/google-meet/src/oauth.ts
@@ -43,7 +43,7 @@ function resolveGoogleMeetTokenExpiresAt(value: unknown, nowMs = Date.now()): nu
   );
 }
 
-export type GoogleMeetOAuthTokens = {
+type GoogleMeetOAuthTokens = {
   accessToken: string;
   expiresAt: number;
   refreshToken?: string;


### PR DESCRIPTION
## What Problem This Solves

Eleven Google Meet implementation declarations were exported even though they have no repository consumers and are not re-exported by the plugin entrypoint.

## Why This Change Was Made

Keep CLI manifest shapes, internal Meet API response types, the OAuth token result, the realtime strategy alias, and the audio buffer constant local to their owning modules. The exported runtime functions and supported plugin entrypoint remain unchanged.

## User Impact

None. This is export-surface cleanup only; Google Meet CLI, config, OAuth, API, and transport behavior are unchanged.

## Evidence

- Fresh codebase-memory graph: 281,366 nodes / 1,134,640 edges.
- MCP inbound-edge query found only each symbol's defining edge; repository/docs search found no imports, consumers, or entrypoint re-exports.
- Testbox `tbx_01kwzxqeaarkf2p9n587zsr0jj`: `pnpm check:changed` passed for extension production and test lanes.
- Five focused Google Meet suites passed: 156/156 tests.
- Full build passed, including TypeScript declaration emit, runtime postbuild, plugin SDK export checks, and Control UI build.
- Fresh autoreview: local 0.84 and branch 0.90; no accepted/actionable findings.
