### PR TITLE
fix(gateway): bound sessions.usage all-agent session discovery concurrency

### DIFF
--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -589,6 +589,27 @@ describe("gateway usage helpers", () => {
     );
   });
 
+  it("rejects an all-agent usage load when one agent task fails", async () => {
+    const failure = new Error("agent usage load failed");
+    vi.mocked(loadCostUsageSummaryFromCache)
+      .mockResolvedValueOnce(costSummary({ totalTokens: 1, totalCost: 0 }))
+      .mockRejectedValueOnce(failure);
+
+    const respond = vi.fn();
+    const request = usageHandlers["usage.cost"]({
+      respond,
+      params: { startDate: "2026-02-01", endDate: "2026-02-02", agentScope: "all" },
+      context: {
+        getRuntimeConfig: () => ({
+          agents: { list: [{ id: "main" }, { id: "broken" }] },
+        }),
+      },
+    } as unknown as Parameters<(typeof usageHandlers)["usage.cost"]>[0]);
+
+    await expect(request).rejects.toBe(failure);
+    expect(respond).not.toHaveBeenCalled();
+  });
+
   it("bounds sessions.usage all-agent session discovery", async () => {
     const agentCount = 13;
     const concurrencyLimit = 12;

--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -29,10 +29,22 @@ vi.mock("../../infra/session-cost-usage.js", async () => {
         missingCostEntries: 0,
       },
     })),
+    discoverAllSessions: vi.fn(async () => []),
   };
 });
 
-import { loadCostUsageSummaryFromCache } from "../../infra/session-cost-usage.js";
+vi.mock("../session-utils.js", async () => {
+  const actual = await vi.importActual<typeof import("../session-utils.js")>("../session-utils.js");
+  return {
+    ...actual,
+    loadCombinedSessionStoreForGateway: vi.fn(() => ({ storePath: "(multiple)", store: {} })),
+  };
+});
+
+import {
+  discoverAllSessions,
+  loadCostUsageSummaryFromCache,
+} from "../../infra/session-cost-usage.js";
 import { testApi, usageHandlers } from "./usage.js";
 
 describe("gateway usage helpers", () => {
@@ -575,5 +587,57 @@ describe("gateway usage helpers", () => {
       }),
       undefined,
     );
+  });
+
+  it("bounds sessions.usage all-agent session discovery", async () => {
+    const agentCount = 13;
+    const concurrencyLimit = 12;
+    let releaseLoads!: () => void;
+    const loadsReleased = new Promise<void>((resolve) => {
+      releaseLoads = resolve;
+    });
+    let resolveFirstBatchStarted!: () => void;
+    const firstBatchStarted = new Promise<void>((resolve) => {
+      resolveFirstBatchStarted = resolve;
+    });
+    let started = 0;
+    let inFlight = 0;
+    let peakInFlight = 0;
+
+    vi.mocked(discoverAllSessions).mockImplementation(async () => {
+      started += 1;
+      inFlight += 1;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+      if (started === concurrencyLimit) {
+        resolveFirstBatchStarted();
+      }
+      await loadsReleased;
+      inFlight -= 1;
+      return [];
+    });
+
+    const respond = vi.fn();
+    const request = usageHandlers["sessions.usage"]({
+      respond,
+      params: { startDate: "2026-02-01", endDate: "2026-02-02", agentScope: "all" },
+      context: {
+        getRuntimeConfig: () => ({
+          agents: {
+            list: Array.from({ length: agentCount }, (_, i) => ({ id: `agent-${i}` })),
+          },
+        }),
+      },
+    } as unknown as Parameters<(typeof usageHandlers)["sessions.usage"]>[0]);
+
+    await firstBatchStarted;
+    const startedBeforeRelease = started;
+    const peakBeforeRelease = peakInFlight;
+    releaseLoads();
+    await request;
+
+    expect(startedBeforeRelease).toBe(concurrencyLimit);
+    expect(peakBeforeRelease).toBe(concurrencyLimit);
+    expect(vi.mocked(discoverAllSessions)).toHaveBeenCalledTimes(agentCount);
+    expect(respond).toHaveBeenCalledWith(true, expect.any(Object), undefined);
   });
 });

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -66,6 +66,20 @@ const COST_USAGE_CACHE_TTL_MS = 30_000;
 const COST_USAGE_CACHE_MAX = 256;
 const USAGE_AGENT_LOAD_CONCURRENCY = 12;
 
+async function runUsageAgentTasks<T>(tasks: Array<() => Promise<T>>): Promise<T[]> {
+  const result = await runTasksWithConcurrency({
+    tasks,
+    limit: USAGE_AGENT_LOAD_CONCURRENCY,
+    errorMode: "stop",
+  });
+  // These fan-outs historically rejected as one unit. Never return partial
+  // per-agent usage; successful results retain their input order.
+  if (result.hasError) {
+    throw result.firstError;
+  }
+  return result.results;
+}
+
 type DateRange = { startMs: number; endMs: number };
 // Keep validation and parsed timestamps in one result so handlers cannot forward
 // an invalid or backwards window to the usage loaders.
@@ -477,11 +491,8 @@ async function discoverAllSessionsForUsage(params: {
   const agents = requestedAgentId
     ? [{ id: normalizeAgentId(requestedAgentId) }]
     : listAgentsForGateway(params.config).agents;
-  // Bound per-agent discovery like the sibling usage.cost cache load: an
-  // all-agent list on a 100+ agent gateway otherwise scans every agent's
-  // transcript directory concurrently and starves filesystem/IO.
-  const agentLoadResult = await runTasksWithConcurrency({
-    tasks: agents.map((agent) => async () => {
+  const discovered = await runUsageAgentTasks(
+    agents.map((agent) => async () => {
       const agentId = normalizeAgentId(agent.id);
       const sessions = await discoverAllSessions({
         agentId,
@@ -491,13 +502,8 @@ async function discoverAllSessionsForUsage(params: {
       });
       return sessions.map((session) => Object.assign({}, session, { agentId }));
     }),
-    limit: USAGE_AGENT_LOAD_CONCURRENCY,
-    errorMode: "stop",
-  });
-  if (agentLoadResult.hasError) {
-    throw agentLoadResult.firstError;
-  }
-  return agentLoadResult.results.flat().toSorted((a, b) => b.mtime - a.mtime);
+  );
+  return discovered.flat().toSorted((a, b) => b.mtime - a.mtime);
 }
 
 function addUniqueSessionIds(target: string[], ids: Array<string | undefined>): string[] {
@@ -872,8 +878,8 @@ async function loadAllAgentCostUsageSummary(params: {
   const agentIds = listAgentsForGateway(params.config).agents.map((agent) =>
     normalizeAgentId(agent.id),
   );
-  const agentLoadResult = await runTasksWithConcurrency({
-    tasks: agentIds.map(
+  const summaries = await runUsageAgentTasks(
+    agentIds.map(
       (agentId) => () =>
         loadCostUsageSummaryFromCache({
           startMs: params.startMs,
@@ -885,13 +891,7 @@ async function loadAllAgentCostUsageSummary(params: {
           refreshMode: "background",
         }),
     ),
-    limit: USAGE_AGENT_LOAD_CONCURRENCY,
-    errorMode: "stop",
-  });
-  if (agentLoadResult.hasError) {
-    throw agentLoadResult.firstError;
-  }
-  const summaries = agentLoadResult.results;
+  );
   const dailyByDate = new Map<string, CostUsageTotals & { date: string }>();
   const totals = createEmptyCostUsageTotals();
   let cacheStatus: UsageCacheStatus | undefined;
@@ -1283,8 +1283,8 @@ export const usageHandlers: GatewayRequestHandlers = {
       }
     }
 
-    const agentLoadResult = await runTasksWithConcurrency({
-      tasks: Array.from(sessionsByAgent.entries()).map(([agentId, agentSessions]) => async () => ({
+    const agentLoads = await runUsageAgentTasks(
+      Array.from(sessionsByAgent.entries()).map(([agentId, agentSessions]) => async () => ({
         agentSessions,
         loaded: await loadSessionCostSummariesFromCache({
           sessions: agentSessions,
@@ -1295,13 +1295,8 @@ export const usageHandlers: GatewayRequestHandlers = {
           dailyUtcOffsetMinutes,
         }),
       })),
-      limit: USAGE_AGENT_LOAD_CONCURRENCY,
-      errorMode: "stop",
-    });
-    if (agentLoadResult.hasError) {
-      throw agentLoadResult.firstError;
-    }
-    for (const { agentSessions, loaded } of agentLoadResult.results) {
+    );
+    for (const { agentSessions, loaded } of agentLoads) {
       cacheStatus = mergeUsageCacheStatus(cacheStatus, loaded.cacheStatus);
       for (const [index, summary] of loaded.summaries.entries()) {
         if (!summary) {

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -477,8 +477,11 @@ async function discoverAllSessionsForUsage(params: {
   const agents = requestedAgentId
     ? [{ id: normalizeAgentId(requestedAgentId) }]
     : listAgentsForGateway(params.config).agents;
-  const discovered = await Promise.all(
-    agents.map(async (agent) => {
+  // Bound per-agent discovery like the sibling usage.cost cache load: an
+  // all-agent list on a 100+ agent gateway otherwise scans every agent's
+  // transcript directory concurrently and starves filesystem/IO.
+  const agentLoadResult = await runTasksWithConcurrency({
+    tasks: agents.map((agent) => async () => {
       const agentId = normalizeAgentId(agent.id);
       const sessions = await discoverAllSessions({
         agentId,
@@ -488,8 +491,13 @@ async function discoverAllSessionsForUsage(params: {
       });
       return sessions.map((session) => Object.assign({}, session, { agentId }));
     }),
-  );
-  return discovered.flat().toSorted((a, b) => b.mtime - a.mtime);
+    limit: USAGE_AGENT_LOAD_CONCURRENCY,
+    errorMode: "stop",
+  });
+  if (agentLoadResult.hasError) {
+    throw agentLoadResult.firstError;
+  }
+  return agentLoadResult.results.flat().toSorted((a, b) => b.mtime - a.mtime);
 }
 
 function addUniqueSessionIds(target: string[], ids: Array<string | undefined>): string[] {


### PR DESCRIPTION
Related: #101589

## What Problem This Solves

Resolves a problem where a gateway serving many agents can stall its own
filesystem/IO when the dashboard or CLI requests the all-agent session usage
list. The `sessions.usage` RPC (all-agent scope) discovers sessions for every
configured agent at once with no concurrency cap, so on a 100+ agent gateway it
launches 100+ concurrent per-agent transcript-directory scans in a single burst.
This is the same all-agent starvation class that #101589 just fixed for the
sibling usage-cost cache load in this file — the session-discovery fan-out was
left uncapped.

## Why This Change Was Made

`discoverAllSessionsForUsage` used a raw `Promise.all` over
`listAgentsForGateway(config).agents`. This change routes it through the same
`runTasksWithConcurrency` helper (limit `USAGE_AGENT_LOAD_CONCURRENCY = 12`,
`errorMode: "stop"`) that the sibling usage-cost load already uses in this file,
and re-throws the first per-agent error so the RPC keeps its existing
reject-on-failure behavior (no switch to partial/silent results). Result
ordering (`.flat().toSorted(...)`) is unchanged. This is unbounded concurrent
**filesystem** discovery — distinct from the SQLite cost-cache read #101589
bounded — so it is a focused, sibling-shaped follow-up, not a redesign.

## User Impact

Operators running gateways with many agents no longer risk an IO/filesystem
burst (and the resulting latency spike or instability) when the session-usage
list view is opened for all agents. Concurrency is capped at 12 per-agent
discoveries in flight, matching the existing usage-cost path. No API, config, or
response-shape change.

## Evidence

### Real behavior proof (real handler, real agents, real transcripts)

Drove the **real registered `sessions.usage` RPC handler** (`agentScope: "all"`)
over **24 real configured agents**, each with a **real on-disk transcript
directory + JSONL transcript** under a temp `OPENCLAW_STATE_DIR`. No mock of
`discoverAllSessions` / `listAgentsForGateway` / the session store — the full
production path runs unchanged. An observer around `fs.promises.readdir` counts
concurrent per-agent `.../sessions` scans (each per-agent discovery opens exactly
one such readdir, so this is the exact fan-out the cap bounds):

```
=== REAL sessions.usage all-agent proof ===
configured agents      : 24
USAGE_AGENT_LOAD cap   : 12
respond success        : true
error shape            : none
discovered sessions    : 24
peak concurrent per-agent readdir : 12
RESULT: PASS — all-agent request succeeded with peak fan-out 12 <= cap 12
```

The all-agent request **succeeds** and returns all 24 sessions while never
exceeding 12 concurrent transcript-directory scans. Negative control — reverting
`discoverAllSessionsForUsage` to the upstream raw `Promise.all` and re-running the
same real harness — launches all 24 scans at once:

```
respond success        : true
discovered sessions    : 24
peak concurrent per-agent readdir : 24
RESULT: FAIL — peak 24 (ok=true)
```

The response still succeeds functionally without the cap, so the bounded fan-out
is the only behavioral difference — exactly the IO burst this PR removes.

### Focused regression test

A deterministic test drives the public `sessions.usage` handler with
`agentScope: "all"` over 13 agents and a gated `discoverAllSessions`, asserting
peak concurrency stays at the cap and the RPC still responds:

```
 ✓ bounds sessions.usage all-agent session discovery
   expect(peakBeforeRelease).toBe(12)         // 12 in flight, not 13
   expect(discoverAllSessions).toHaveBeenCalledTimes(13)
   expect(respond).toHaveBeenCalledWith(true, ...)

 Test Files  2 passed (2)
      Tests  64 passed (64)
```

Negative control — reverting the fix (restoring the raw `Promise.all`) fails
only this test, confirming it exercises the bound:

```
 × bounds sessions.usage all-agent session discovery
   AssertionError: expected 13 to be 12
      Tests  2 failed | 62 passed (64)
```

Run the unit test locally with
`node scripts/run-vitest.mjs src/gateway/server-methods/usage.test.ts`;
full changed-lane checks are delegated to CI.
