### PR TITLE
refactor(plugins): localize internal declarations

### DIFF
--- a/extensions/diffs/src/language-hints.ts
+++ b/extensions/diffs/src/language-hints.ts
@@ -8,7 +8,7 @@ import {
 } from "./shiki-curated-languages.js";
 import type { DiffViewerPayload } from "./types.js";
 
-export const BASE_DIFF_VIEWER_LANGUAGE_HINTS = [
+const BASE_DIFF_VIEWER_LANGUAGE_HINTS = [
   ...Object.keys(bundledLanguagesBase),
   "text",
   "ansi",

--- a/extensions/diffs/src/viewer-assets.ts
+++ b/extensions/diffs/src/viewer-assets.ts
@@ -8,7 +8,7 @@ export const VIEWER_LOADER_PATH = `${VIEWER_ASSET_PREFIX}viewer.js`;
 export const VIEWER_RUNTIME_PATH = `${VIEWER_ASSET_PREFIX}viewer-runtime.js`;
 export const LANGUAGE_PACK_VIEWER_ASSET_PREFIX = "/plugins/diffs-language-pack/assets/";
 export const LANGUAGE_PACK_VIEWER_LOADER_PATH = `${LANGUAGE_PACK_VIEWER_ASSET_PREFIX}viewer.js`;
-export const LANGUAGE_PACK_VIEWER_RUNTIME_PATH = `${LANGUAGE_PACK_VIEWER_ASSET_PREFIX}viewer-runtime.js`;
+const LANGUAGE_PACK_VIEWER_RUNTIME_PATH = `${LANGUAGE_PACK_VIEWER_ASSET_PREFIX}viewer-runtime.js`;
 const VIEWER_RUNTIME_RELATIVE_IMPORT_PATH = "./viewer-runtime.js";
 const VIEWER_RUNTIME_CANDIDATE_RELATIVE_PATHS = [
   "./assets/viewer-runtime.js",

--- a/extensions/file-transfer/src/tools/descriptors.ts
+++ b/extensions/file-transfer/src/tools/descriptors.ts
@@ -23,7 +23,7 @@ export const FILE_WRITE_HARD_MAX_BYTES = 16 * 1024 * 1024;
 const PAIRED_NODE_DESCRIPTION =
   "Existing paired node id, display name, or IP shown by nodes status. Do not use local, host, gateway, or auto; use local file/exec tools for local workspace paths.";
 
-export const FileFetchToolSchema = Type.Object({
+const FileFetchToolSchema = Type.Object({
   node: Type.String({
     description: PAIRED_NODE_DESCRIPTION,
   }),
@@ -46,7 +46,7 @@ export const FILE_FETCH_TOOL_DESCRIPTOR: FileTransferToolDescriptor = {
   parameters: FileFetchToolSchema,
 };
 
-export const DirListToolSchema = Type.Object({
+const DirListToolSchema = Type.Object({
   node: Type.String({
     description: PAIRED_NODE_DESCRIPTION,
   }),
@@ -75,7 +75,7 @@ export const DIR_LIST_TOOL_DESCRIPTOR: FileTransferToolDescriptor = {
   parameters: DirListToolSchema,
 };
 
-export const DirFetchToolSchema = Type.Object({
+const DirFetchToolSchema = Type.Object({
   node: Type.String({
     description: PAIRED_NODE_DESCRIPTION,
   }),
@@ -104,7 +104,7 @@ export const DIR_FETCH_TOOL_DESCRIPTOR: FileTransferToolDescriptor = {
   parameters: DirFetchToolSchema,
 };
 
-export const FileWriteToolSchema = Type.Object({
+const FileWriteToolSchema = Type.Object({
   node: Type.String({ description: PAIRED_NODE_DESCRIPTION }),
   path: Type.String({
     description: "Absolute path on the node to write. Canonicalized server-side.",


### PR DESCRIPTION
## What Problem This Solves

Six implementation-only declarations were exported from the Diffs and File Transfer plugins even though no repository consumer imports them. That unnecessarily enlarges the modules' apparent API surface.

## Why This Change Was Made

Make the declarations file-local while preserving their existing same-module use:

- Diffs base language hints and language-pack runtime path
- File Transfer schemas for `file_fetch`, `dir_list`, `dir_fetch`, and `file_write`

Repository search and the refreshed code graph found no external consumers.

## User Impact

No runtime behavior changes. This narrows internal TypeScript module surfaces and makes future dead-code analysis more accurate.

## Evidence

- Based on current `origin/main` at `22376d80e1639148d1e0e5ddcadd2c91ba1e5b9e`
- `OPENCLAW_TESTBOX=1 pnpm check:changed` equivalent on Testbox `tbx_01kwzzh8612qsg16sqnb99mzxx`
- `pnpm test:serial extensions/diffs extensions/file-transfer`: 28 files, 302 tests passed
- `pnpm build`: passed, including Diffs asset builds and plugin SDK export validation
- Fresh local autoreview: clean, confidence 0.88
- Fresh post-rebase branch autoreview: clean, confidence 0.86
