### PR TITLE
fix(lobster): don't route schema-default flowExpectedRevision into TaskFlow (#102011)

### DIFF
--- a/extensions/lobster/src/lobster-tool.test.ts
+++ b/extensions/lobster/src/lobster-tool.test.ts
@@ -234,6 +234,67 @@ describe("lobster plugin tool", () => {
     expect(mutation.applied).toBe(true);
   });
 
+  it("ignores a schema-default flowExpectedRevision on a managed run", async () => {
+    const runner = {
+      run: vi.fn().mockResolvedValue({
+        ok: true,
+        status: "ok",
+        output: [],
+        requiresApproval: null,
+      }),
+    };
+    const taskFlow = createFakeTaskFlow();
+    const tool = createLobsterTool(fakeApi(), { runner, taskFlow });
+
+    // The tool schema can inject flowExpectedRevision=0; a managed run must not
+    // be rejected with "run action does not accept flowExpectedRevision".
+    const res = await tool.execute("call-managed-run-injected-revision", {
+      action: "run",
+      pipeline: "noop",
+      flowControllerId: "tests/lobster",
+      flowGoal: "Run Lobster workflow",
+      flowExpectedRevision: 0,
+    });
+
+    expect(taskFlow.createManaged).toHaveBeenCalled();
+    const details = requireRecord(res.details, "managed run injected-revision details");
+    expect(details.ok).toBe(true);
+  });
+
+  // A schema-injected flowStateJson (blank "" or empty "{}") without
+  // controllerId/goal must not fail JSON parsing or select managed run parsing
+  // (would otherwise fail "flowControllerId required when using managed TaskFlow
+  // run mode" or "flowStateJson must be valid JSON").
+  it.each(["", "{}"])(
+    "routes run carrying only a schema-default flowStateJson %j as ordinary",
+    async (flowStateJson) => {
+      const runner = {
+        run: vi.fn().mockResolvedValue({
+          ok: true,
+          status: "ok",
+          output: [],
+          requiresApproval: null,
+        }),
+      };
+      const taskFlow = createFakeTaskFlow();
+      const tool = createLobsterTool(fakeApi(), { runner, taskFlow });
+
+      const res = await tool.execute("call-ordinary-run-injected-state", {
+        action: "run",
+        pipeline: "noop",
+        flowStateJson,
+        flowExpectedRevision: 0,
+      });
+
+      expect(taskFlow.createManaged).not.toHaveBeenCalled();
+      expect(runner.run).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "run", pipeline: "noop" }),
+      );
+      const details = requireRecord(res.details, "ordinary run injected-state details");
+      expect(details.ok).toBe(true);
+    },
+  );
+
   it("rejects managed TaskFlow params when no bound taskFlow runtime is available", async () => {
     const tool = createLobsterTool(fakeApi(), {
       runner: { run: vi.fn() },
@@ -306,6 +367,35 @@ describe("lobster plugin tool", () => {
     expect(details.status).toBe("ok");
     const mutation = requireRecord(details.mutation, "managed resume mutation details");
     expect(mutation.applied).toBe(true);
+  });
+
+  it("routes resume carrying only a schema-default flowExpectedRevision as ordinary", async () => {
+    const runner = {
+      run: vi.fn().mockResolvedValue({
+        ok: true,
+        status: "ok",
+        output: [],
+        requiresApproval: null,
+      }),
+    };
+    const taskFlow = createFakeTaskFlow();
+    const tool = createLobsterTool(fakeApi(), { runner, taskFlow });
+
+    // flowExpectedRevision=0 is a tool-schema default; without a flowId this is
+    // an ordinary resume and must not be routed into managed TaskFlow mode.
+    const res = await tool.execute("call-ordinary-resume-injected-revision", {
+      action: "resume",
+      token: "resume-token",
+      approve: true,
+      flowExpectedRevision: 0,
+    });
+
+    expect(taskFlow.resume).not.toHaveBeenCalled();
+    expect(runner.run).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "resume", token: "resume-token", approve: true }),
+    );
+    const envelope = requireRecord(res.details, "ordinary resume injected-revision details");
+    expect(envelope.ok).toBe(true);
   });
 
   it("normalizes numeric string flowExpectedRevision before managed resume", async () => {

--- a/extensions/lobster/src/lobster-tool.ts
+++ b/extensions/lobster/src/lobster-tool.ts
@@ -97,8 +97,15 @@ function parseOptionalFlowStateJson(value: unknown): JsonLike | undefined {
   if (typeof value !== "string") {
     throw new Error("flowStateJson must be a JSON string");
   }
+  // A blank/whitespace flowStateJson is a schema default, not a managed-run
+  // request; treat it as absent so it neither fails JSON parsing nor selects
+  // managed run mode on an ordinary call.
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
   try {
-    return JSON.parse(value) as JsonLike;
+    return JSON.parse(trimmed) as JsonLike;
   } catch {
     throw new Error("flowStateJson must be valid JSON");
   }
@@ -111,20 +118,21 @@ function parseRunFlowParams(params: Record<string, unknown>): ManagedFlowRunPara
   const waitingStep = readOptionalTrimmedString(params.flowWaitingStep, "flowWaitingStep");
   const stateJson = parseOptionalFlowStateJson(params.flowStateJson);
   const resumeFlowId = readOptionalTrimmedString(params.flowId, "flowId");
-  const resumeRevision = readOptionalNumber(params.flowExpectedRevision, "flowExpectedRevision");
 
-  const hasRunFields =
-    controllerId !== undefined ||
-    goal !== undefined ||
-    currentStep !== undefined ||
-    waitingStep !== undefined ||
-    stateJson !== undefined;
+  // Managed run is identified by the intentional controllerId/goal fields. The
+  // step and flowStateJson fields can be injected as tool-schema defaults (e.g.
+  // an empty flowStateJson), so they must not route an ordinary run into
+  // managed TaskFlow mode.
+  const hasRunFields = controllerId !== undefined || goal !== undefined;
 
   if (!hasRunFields) {
     return null;
   }
-  if (resumeFlowId !== undefined || resumeRevision !== undefined) {
-    throw new Error("run action does not accept flowId or flowExpectedRevision");
+  // Only an explicit flowId means the caller confused resume with run.
+  // flowExpectedRevision is ignored here because the tool schema can inject a
+  // default (e.g. 0), which must not trip an ordinary managed run.
+  if (resumeFlowId !== undefined) {
+    throw new Error("run action does not accept flowId");
   }
   if (!controllerId) {
     throw new Error("flowControllerId required when using managed TaskFlow run mode");
@@ -153,20 +161,15 @@ function parseResumeFlowParams(params: Record<string, unknown>): ManagedFlowResu
   const runGoal = readOptionalTrimmedString(params.flowGoal, "flowGoal");
   const stateJson = params.flowStateJson;
 
-  const hasResumeFields =
-    flowId !== undefined ||
-    expectedRevision !== undefined ||
-    currentStep !== undefined ||
-    waitingStep !== undefined;
-
-  if (!hasResumeFields) {
+  // Managed resume is identified by flowId. flowExpectedRevision and step
+  // fields can be injected as tool-schema defaults (e.g. flowExpectedRevision
+  // 0), so on their own they must not route an ordinary resume into managed
+  // TaskFlow mode.
+  if (flowId === undefined) {
     return null;
   }
   if (runControllerId !== undefined || runGoal !== undefined || stateJson !== undefined) {
     throw new Error("resume action does not accept flowControllerId, flowGoal, or flowStateJson");
-  }
-  if (!flowId) {
-    throw new Error("flowId required when using managed TaskFlow resume mode");
   }
   if (expectedRevision === undefined) {
     throw new Error("flowExpectedRevision required when using managed TaskFlow resume mode");


### PR DESCRIPTION
Closes #102011

## What Problem This Solves

Fixes an issue where ordinary `@openclaw/lobster` tool `run` / `resume` calls
fail by being misrouted into managed TaskFlow mode. When the tool schema supplies
default flow fields for a minimal call — `flowExpectedRevision` (e.g. `0`) or an
empty `flowStateJson` — the wrapper treated those always-present values as a
managed-flow signal, so an ordinary `resume` errored with `flowId required when
using managed TaskFlow resume mode` and an ordinary `run` with `flowControllerId
required when using managed TaskFlow run mode` / `run action does not accept
flowId or flowExpectedRevision`. The standalone Lobster CLI handled the same
workflow correctly, confirming the fault is in the OpenClaw plugin wrapper.

## Why This Change Was Made

Managed TaskFlow mode is identified only by its intentional flow identifiers —
`flowId` for `resume`, `flowControllerId`/`flowGoal` for `run`. Secondary fields
(`flowExpectedRevision`, `flowStateJson`, and the step fields), which the tool
schema can inject as defaults, no longer select managed mode on their own. Real
managed flows are unchanged: managed `resume` still requires
`flowExpectedRevision`, and managed `run` still needs `flowControllerId`/`flowGoal`.

## User Impact

The documented minimal `run` / `resume` Lobster tool calls work again; ordinary
approval workflows no longer fail with a spurious managed-TaskFlow error.

## Evidence

**Real behavior proof** — drove the actual `createLobsterTool` with the **real
embedded `@clawdbot/lobster` runtime** executing the issue's `approval-smoke`
workflow, passing the schema-injected defaults (`flowExpectedRevision: 0`,
`flowStateJson: "{}"`) on the minimal `run`, then `resume` with the returned
token:

```
BEFORE (current source): the ordinary run is misrouted into managed mode and the
  real lobster runtime call fails with:
    Error: flowControllerId required when using managed TaskFlow run mode
AFTER (this PR): run → needs_approval (real resumeToken), then resume → ok.
  The full run→approval→resume completes through the real runtime.
```

(Ran via a temporary `*.test.ts` using `createEmbeddedLobsterRunner()`; captured
the before/after by toggling the source with `git stash`. Not committed.)

**Regression tests** in `extensions/lobster/src/lobster-tool.test.ts` (colocated,
run the real `createLobsterTool`):
- ordinary `resume` carrying only a schema-default `flowExpectedRevision` runs as
  an ordinary resume instead of erroring;
- ordinary `run` carrying only a schema-default `flowStateJson` runs as an
  ordinary run instead of erroring;
- managed `run` with an injected `flowExpectedRevision: 0` is still accepted.

Full suite passes (20 tests) via `node scripts/run-vitest.mjs run
extensions/lobster/src/lobster-tool.test.ts`. oxfmt/oxlint clean.

---

AI-assisted: written with Claude Code. The before/after evidence is from running
the real lobster runtime locally, not AI-generated assertions taken on faith.
