### PR TITLE
fix(chutes): add timeouts to OAuth HTTP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.
 - **Model pin hot reload and fallback:** keep explicit `/model` selections authoritative across Telegram config reloads and model fallback, capture one live config snapshot per assembled turn, and leave fallback candidates turn-local instead of persisting them over the user's pin. (#103324, #103417) Thanks @obviyus.
 - **Swift protocol initializers:** default every schema-optional generated initializer parameter to `nil` so additive protocol fields no longer break SDK construction call sites.
 - **OpenCode Go MiMo catalog:** stop exposing the deprecated `mimo-v2-omni` and `mimo-v2-pro` aliases that reject agent requests, and keep release validation on the active MiMo V2.5 routes. (#103311, #103329) Thanks @krissding.

--- a/extensions/chutes/oauth.test.ts
+++ b/extensions/chutes/oauth.test.ts
@@ -1,7 +1,5 @@
 // Chutes tests cover oauth plugin behavior.
-import { createServer } from "node:http";
-import type { Socket } from "node:net";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { loginChutes } from "./oauth.js";
 
 const CHUTES_TOKEN_ENDPOINT = "https://api.chutes.ai/idp/token";
@@ -57,157 +55,46 @@ function fetchInputUrl(input: RequestInfo | URL): string {
   return input.url;
 }
 
-function timeoutResult<T>(value: T, timeoutMs: number): Promise<T> {
-  return new Promise((resolve) => {
-    setTimeout(() => resolve(value), timeoutMs);
-  });
-}
-
-async function listenOnLoopback(server: ReturnType<typeof createServer>): Promise<number> {
-  return await new Promise((resolve, reject) => {
-    const onError = (err: Error) => reject(err);
-    server.once("error", onError);
-    server.listen(0, "127.0.0.1", () => {
-      server.off("error", onError);
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        reject(new Error("expected loopback TCP address"));
-        return;
-      }
-      resolve(address.port);
-    });
-  });
-}
-
-async function startHangingLoopbackServer(): Promise<{
-  origin: string;
-  requests: string[];
-  waitForRequestCount: (count: number) => Promise<void>;
-  close: () => Promise<void>;
-}> {
-  type RequestWaiter = {
-    count: number;
-    resolve: () => void;
-    reject: (error: Error) => void;
-    timer?: ReturnType<typeof setTimeout>;
-  };
-
-  const sockets = new Set<Socket>();
-  const requests: string[] = [];
-  const waiters: RequestWaiter[] = [];
-
-  const resolveWaiters = () => {
-    for (let index = waiters.length - 1; index >= 0; index -= 1) {
-      const waiter = waiters[index];
-      if (!waiter || requests.length < waiter.count) {
-        continue;
-      }
-      waiters.splice(index, 1);
-      if (waiter.timer) {
-        clearTimeout(waiter.timer);
-      }
-      waiter.resolve();
+function rejectWhenAborted(init?: RequestInit): Promise<Response> {
+  const signal = init?.signal;
+  if (!signal) {
+    return Promise.reject(new Error("missing OAuth request signal"));
+  }
+  return new Promise((_, reject) => {
+    const rejectWithReason = () => reject(signal.reason);
+    if (signal.aborted) {
+      rejectWithReason();
+      return;
     }
-  };
-
-  const server = createServer((req, _res) => {
-    requests.push(req.url ?? "");
-    req.resume();
-    resolveWaiters();
+    signal.addEventListener("abort", rejectWithReason, { once: true });
   });
-  server.on("connection", (socket) => {
-    sockets.add(socket);
-    socket.on("close", () => sockets.delete(socket));
+}
+
+function useImmediateOAuthDeadline() {
+  return vi.spyOn(AbortSignal, "timeout").mockImplementation((delay) => {
+    expect(delay).toBe(30_000);
+    return AbortSignal.abort(new DOMException("OAuth request timed out", "TimeoutError"));
   });
+}
 
-  const port = await listenOnLoopback(server);
-  return {
-    origin: `http://127.0.0.1:${port}`,
-    requests,
-    waitForRequestCount: async (count: number) => {
-      if (requests.length >= count) {
-        return;
-      }
-      await new Promise<void>((resolve, reject) => {
-        const waiter: RequestWaiter = {
-          count,
-          resolve,
-          reject,
-        };
-        waiter.timer = setTimeout(() => {
-          const index = waiters.indexOf(waiter);
-          if (index >= 0) {
-            waiters.splice(index, 1);
-          }
-          reject(new Error(`server received ${requests.length} request(s), expected ${count}`));
-        }, 500);
-        waiters.push(waiter);
-      });
+function loginWithFetch(fetchFn: typeof fetch) {
+  return loginChutes({
+    app: {
+      clientId: "cid_test",
+      redirectUri: REDIRECT_URI,
+      scopes: ["openid"],
     },
-    close: async () => {
-      for (const waiter of waiters.splice(0)) {
-        if (waiter.timer) {
-          clearTimeout(waiter.timer);
-        }
-        waiter.reject(new Error("server closed"));
-      }
-      for (const socket of sockets) {
-        socket.destroy();
-      }
-      await new Promise<void>((resolve, reject) => {
-        server.close((err) => {
-          if (err) {
-            reject(err);
-            return;
-          }
-          resolve();
-        });
-      });
-    },
-  };
+    manual: true,
+    createState: () => "state_test",
+    onAuth: vi.fn(async () => {}),
+    onPrompt: vi.fn(async () => `${REDIRECT_URI}?code=code_test&state=state_test`),
+    fetchFn,
+  });
 }
 
-async function expectFetchWithoutDeadlineToStayPending(url: string, init?: RequestInit) {
-  const controller = new AbortController();
-  const request = fetch(url, { ...init, signal: controller.signal });
-  request.catch(() => undefined);
-
-  const result = await Promise.race([
-    request.then(
-      () => "settled" as const,
-      () => "settled" as const,
-    ),
-    timeoutResult("pending" as const, 30),
-  ]);
-
-  controller.abort();
-  await request.catch(() => undefined);
-  expect(result).toBe("pending");
-}
-
-async function loginOutcomeWithin(
-  promise: Promise<unknown>,
-  timeoutMs: number,
-): Promise<
-  | { status: "pending" }
-  | { status: "resolved" }
-  | {
-      status: "rejected";
-      error: unknown;
-    }
-> {
-  return await Promise.race([
-    promise.then(
-      () => ({ status: "resolved" as const }),
-      (error: unknown) => ({ status: "rejected" as const, error }),
-    ),
-    timeoutResult({ status: "pending" as const }, timeoutMs),
-  ]);
-}
-
-function expectAbortOrTimeoutError(error: unknown) {
-  expect(error).toHaveProperty("name", expect.stringMatching(/^(AbortError|TimeoutError)$/));
-}
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("chutes plugin OAuth", () => {
   it("rejects unsafe token lifetimes before storing credentials", async () => {
@@ -344,95 +231,37 @@ describe("chutes plugin OAuth", () => {
     expect(bytesPulled).toBeLessThan(TOTAL_CHUNKS * ONE_MIB);
   });
 
-  it("times out token exchange HTTP requests against a hanging loopback server", async () => {
-    const server = await startHangingLoopbackServer();
-    let loginPromise: Promise<unknown> | undefined;
+  it("uses the fixed deadline for token exchange requests", async () => {
+    const timeoutSpy = useImmediateOAuthDeadline();
+    const fetchFn = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      return await rejectWhenAborted(init);
+    });
 
-    try {
-      await expectFetchWithoutDeadlineToStayPending(`${server.origin}/control`, {
-        method: "POST",
-        body: "grant_type=authorization_code",
-      });
-      await server.waitForRequestCount(1);
-
-      const fetchFn = vi.fn(
-        async (_input: RequestInfo | URL, init?: RequestInit) =>
-          await fetch(`${server.origin}/token`, init),
-      );
-      loginPromise = loginChutes({
-        app: {
-          clientId: "cid_test",
-          redirectUri: REDIRECT_URI,
-          scopes: ["openid"],
-        },
-        manual: true,
-        createState: () => "state_test",
-        onAuth: vi.fn(async () => {}),
-        onPrompt: vi.fn(async () => `${REDIRECT_URI}?code=code_test&state=state_test`),
-        fetchFn,
-        requestTimeoutMs: 50,
-      });
-      loginPromise.catch(() => undefined);
-
-      await server.waitForRequestCount(2);
-      const result = await loginOutcomeWithin(loginPromise, 500);
-      if (result.status !== "rejected") {
-        throw new Error(`expected token exchange to reject, got ${result.status}`);
-      }
-      expectAbortOrTimeoutError(result.error);
-      expect(server.requests).toContain("/token");
-    } finally {
-      await server.close();
-      await loginPromise?.catch(() => undefined);
-    }
+    await expect(loginWithFetch(fetchFn)).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(timeoutSpy).toHaveBeenCalledOnce();
   });
 
-  it("times out userinfo HTTP requests against a hanging loopback server", async () => {
-    const server = await startHangingLoopbackServer();
-    let loginPromise: Promise<unknown> | undefined;
-
-    try {
-      await expectFetchWithoutDeadlineToStayPending(`${server.origin}/control`);
-      await server.waitForRequestCount(1);
-
-      const fetchFn = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-        const url = fetchInputUrl(input);
-        if (url === CHUTES_TOKEN_ENDPOINT) {
-          return new Response(
-            '{"access_token":"at_timeout","refresh_token":"rt_timeout","expires_in":3600}',
-            { status: 200, headers: { "Content-Type": "application/json" } },
-          );
-        }
-        if (url === CHUTES_USERINFO_ENDPOINT) {
-          return await fetch(`${server.origin}/userinfo`, init);
-        }
-        return new Response("not found", { status: 404 });
-      });
-      loginPromise = loginChutes({
-        app: {
-          clientId: "cid_test",
-          redirectUri: REDIRECT_URI,
-          scopes: ["openid"],
-        },
-        manual: true,
-        createState: () => "state_test",
-        onAuth: vi.fn(async () => {}),
-        onPrompt: vi.fn(async () => `${REDIRECT_URI}?code=code_test&state=state_test`),
-        fetchFn,
-        requestTimeoutMs: 50,
-      });
-      loginPromise.catch(() => undefined);
-
-      await server.waitForRequestCount(2);
-      const result = await loginOutcomeWithin(loginPromise, 500);
-      if (result.status !== "rejected") {
-        throw new Error(`expected userinfo fetch to reject, got ${result.status}`);
+  it("keeps issued tokens when userinfo exceeds the fixed deadline", async () => {
+    const timeoutSpy = useImmediateOAuthDeadline();
+    const fetchFn = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = fetchInputUrl(input);
+      if (url === CHUTES_TOKEN_ENDPOINT) {
+        return new Response(
+          '{"access_token":"at_timeout","refresh_token":"rt_timeout","expires_in":3600}',
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
       }
-      expectAbortOrTimeoutError(result.error);
-      expect(server.requests).toContain("/userinfo");
-    } finally {
-      await server.close();
-      await loginPromise?.catch(() => undefined);
-    }
+      if (url === CHUTES_USERINFO_ENDPOINT) {
+        return await rejectWhenAborted(init);
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const credentials = await loginWithFetch(fetchFn);
+
+    expect(credentials).toMatchObject({ access: "at_timeout", refresh: "rt_timeout" });
+    expect(credentials.email).toBeUndefined();
+    expect(credentials.accountId).toBeUndefined();
+    expect(timeoutSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/extensions/chutes/oauth.test.ts
+++ b/extensions/chutes/oauth.test.ts
@@ -61,7 +61,8 @@ function rejectWhenAborted(init?: RequestInit): Promise<Response> {
     return Promise.reject(new Error("missing OAuth request signal"));
   }
   return new Promise((_, reject) => {
-    const rejectWithReason = () => reject(signal.reason);
+    const rejectWithReason = () =>
+      reject(signal.reason instanceof Error ? signal.reason : new Error("OAuth request aborted"));
     if (signal.aborted) {
       rejectWithReason();
       return;

--- a/extensions/chutes/oauth.test.ts
+++ b/extensions/chutes/oauth.test.ts
@@ -1,6 +1,12 @@
 // Chutes tests cover oauth plugin behavior.
+import { createServer } from "node:http";
+import type { Socket } from "node:net";
 import { describe, expect, it, vi } from "vitest";
 import { loginChutes } from "./oauth.js";
+
+const CHUTES_TOKEN_ENDPOINT = "https://api.chutes.ai/idp/token";
+const CHUTES_USERINFO_ENDPOINT = "https://api.chutes.ai/idp/userinfo";
+const REDIRECT_URI = "http://127.0.0.1:1456/oauth-callback";
 
 function boundedErrorResponse(
   body: string,
@@ -39,6 +45,168 @@ function boundedErrorResponse(
   } as unknown as Response;
 
   return { response, cancel, releaseLock, text };
+}
+
+function fetchInputUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.href;
+  }
+  return input.url;
+}
+
+function timeoutResult<T>(value: T, timeoutMs: number): Promise<T> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(value), timeoutMs);
+  });
+}
+
+async function listenOnLoopback(server: ReturnType<typeof createServer>): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const onError = (err: Error) => reject(err);
+    server.once("error", onError);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", onError);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("expected loopback TCP address"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+async function startHangingLoopbackServer(): Promise<{
+  origin: string;
+  requests: string[];
+  waitForRequestCount: (count: number) => Promise<void>;
+  close: () => Promise<void>;
+}> {
+  type RequestWaiter = {
+    count: number;
+    resolve: () => void;
+    reject: (error: Error) => void;
+    timer?: ReturnType<typeof setTimeout>;
+  };
+
+  const sockets = new Set<Socket>();
+  const requests: string[] = [];
+  const waiters: RequestWaiter[] = [];
+
+  const resolveWaiters = () => {
+    for (let index = waiters.length - 1; index >= 0; index -= 1) {
+      const waiter = waiters[index];
+      if (!waiter || requests.length < waiter.count) {
+        continue;
+      }
+      waiters.splice(index, 1);
+      if (waiter.timer) {
+        clearTimeout(waiter.timer);
+      }
+      waiter.resolve();
+    }
+  };
+
+  const server = createServer((req, _res) => {
+    requests.push(req.url ?? "");
+    req.resume();
+    resolveWaiters();
+  });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+  });
+
+  const port = await listenOnLoopback(server);
+  return {
+    origin: `http://127.0.0.1:${port}`,
+    requests,
+    waitForRequestCount: async (count: number) => {
+      if (requests.length >= count) {
+        return;
+      }
+      await new Promise<void>((resolve, reject) => {
+        const waiter: RequestWaiter = {
+          count,
+          resolve,
+          reject,
+        };
+        waiter.timer = setTimeout(() => {
+          const index = waiters.indexOf(waiter);
+          if (index >= 0) {
+            waiters.splice(index, 1);
+          }
+          reject(new Error(`server received ${requests.length} request(s), expected ${count}`));
+        }, 500);
+        waiters.push(waiter);
+      });
+    },
+    close: async () => {
+      for (const waiter of waiters.splice(0)) {
+        if (waiter.timer) {
+          clearTimeout(waiter.timer);
+        }
+        waiter.reject(new Error("server closed"));
+      }
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+async function expectFetchWithoutDeadlineToStayPending(url: string, init?: RequestInit) {
+  const controller = new AbortController();
+  const request = fetch(url, { ...init, signal: controller.signal });
+  request.catch(() => undefined);
+
+  const result = await Promise.race([
+    request.then(
+      () => "settled" as const,
+      () => "settled" as const,
+    ),
+    timeoutResult("pending" as const, 30),
+  ]);
+
+  controller.abort();
+  await request.catch(() => undefined);
+  expect(result).toBe("pending");
+}
+
+async function loginOutcomeWithin(
+  promise: Promise<unknown>,
+  timeoutMs: number,
+): Promise<
+  | { status: "pending" }
+  | { status: "resolved" }
+  | {
+      status: "rejected";
+      error: unknown;
+    }
+> {
+  return await Promise.race([
+    promise.then(
+      () => ({ status: "resolved" as const }),
+      (error: unknown) => ({ status: "rejected" as const, error }),
+    ),
+    timeoutResult({ status: "pending" as const }, timeoutMs),
+  ]);
+}
+
+function expectAbortOrTimeoutError(error: unknown) {
+  expect(error).toHaveProperty("name", expect.stringMatching(/^(AbortError|TimeoutError)$/));
 }
 
 describe("chutes plugin OAuth", () => {
@@ -174,5 +342,97 @@ describe("chutes plugin OAuth", () => {
 
     expect(canceled).toBe(true);
     expect(bytesPulled).toBeLessThan(TOTAL_CHUNKS * ONE_MIB);
+  });
+
+  it("times out token exchange HTTP requests against a hanging loopback server", async () => {
+    const server = await startHangingLoopbackServer();
+    let loginPromise: Promise<unknown> | undefined;
+
+    try {
+      await expectFetchWithoutDeadlineToStayPending(`${server.origin}/control`, {
+        method: "POST",
+        body: "grant_type=authorization_code",
+      });
+      await server.waitForRequestCount(1);
+
+      const fetchFn = vi.fn(
+        async (_input: RequestInfo | URL, init?: RequestInit) =>
+          await fetch(`${server.origin}/token`, init),
+      );
+      loginPromise = loginChutes({
+        app: {
+          clientId: "cid_test",
+          redirectUri: REDIRECT_URI,
+          scopes: ["openid"],
+        },
+        manual: true,
+        createState: () => "state_test",
+        onAuth: vi.fn(async () => {}),
+        onPrompt: vi.fn(async () => `${REDIRECT_URI}?code=code_test&state=state_test`),
+        fetchFn,
+        requestTimeoutMs: 50,
+      });
+      loginPromise.catch(() => undefined);
+
+      await server.waitForRequestCount(2);
+      const result = await loginOutcomeWithin(loginPromise, 500);
+      if (result.status !== "rejected") {
+        throw new Error(`expected token exchange to reject, got ${result.status}`);
+      }
+      expectAbortOrTimeoutError(result.error);
+      expect(server.requests).toContain("/token");
+    } finally {
+      await server.close();
+      await loginPromise?.catch(() => undefined);
+    }
+  });
+
+  it("times out userinfo HTTP requests against a hanging loopback server", async () => {
+    const server = await startHangingLoopbackServer();
+    let loginPromise: Promise<unknown> | undefined;
+
+    try {
+      await expectFetchWithoutDeadlineToStayPending(`${server.origin}/control`);
+      await server.waitForRequestCount(1);
+
+      const fetchFn = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = fetchInputUrl(input);
+        if (url === CHUTES_TOKEN_ENDPOINT) {
+          return new Response(
+            '{"access_token":"at_timeout","refresh_token":"rt_timeout","expires_in":3600}',
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        if (url === CHUTES_USERINFO_ENDPOINT) {
+          return await fetch(`${server.origin}/userinfo`, init);
+        }
+        return new Response("not found", { status: 404 });
+      });
+      loginPromise = loginChutes({
+        app: {
+          clientId: "cid_test",
+          redirectUri: REDIRECT_URI,
+          scopes: ["openid"],
+        },
+        manual: true,
+        createState: () => "state_test",
+        onAuth: vi.fn(async () => {}),
+        onPrompt: vi.fn(async () => `${REDIRECT_URI}?code=code_test&state=state_test`),
+        fetchFn,
+        requestTimeoutMs: 50,
+      });
+      loginPromise.catch(() => undefined);
+
+      await server.waitForRequestCount(2);
+      const result = await loginOutcomeWithin(loginPromise, 500);
+      if (result.status !== "rejected") {
+        throw new Error(`expected userinfo fetch to reject, got ${result.status}`);
+      }
+      expectAbortOrTimeoutError(result.error);
+      expect(server.requests).toContain("/userinfo");
+    } finally {
+      await server.close();
+      await loginPromise?.catch(() => undefined);
+    }
   });
 });

--- a/extensions/chutes/oauth.ts
+++ b/extensions/chutes/oauth.ts
@@ -11,6 +11,7 @@ import {
   parseOAuthCallbackInput,
   waitForLocalOAuthCallback,
 } from "openclaw/plugin-sdk/provider-auth-runtime";
+import { buildOAuthRequestSignal } from "openclaw/plugin-sdk/provider-oauth-runtime";
 import {
   readProviderJsonResponse,
   readResponseTextLimited,
@@ -21,7 +22,7 @@ const CHUTES_AUTHORIZE_ENDPOINT = "https://api.chutes.ai/idp/authorize";
 const CHUTES_TOKEN_ENDPOINT = "https://api.chutes.ai/idp/token";
 const CHUTES_USERINFO_ENDPOINT = "https://api.chutes.ai/idp/userinfo";
 const CHUTES_TOKEN_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
-const CHUTES_OAUTH_FETCH_TIMEOUT_MS = 10_000;
+const CHUTES_OAUTH_FETCH_TIMEOUT_MS = 30_000;
 
 type OAuthPrompt = {
   message: string;
@@ -130,7 +131,7 @@ async function fetchChutesUserInfo(params: {
   const fetchFn = params.fetchFn ?? fetch;
   const response = await fetchFn(CHUTES_USERINFO_ENDPOINT, {
     headers: { Authorization: `Bearer ${params.accessToken}` },
-    signal: AbortSignal.timeout(params.requestTimeoutMs),
+    signal: buildOAuthRequestSignal({ timeoutMs: params.requestTimeoutMs }),
   });
   if (!response.ok) {
     return null;
@@ -167,7 +168,7 @@ async function exchangeChutesCodeForTokens(params: {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body,
-    signal: AbortSignal.timeout(requestTimeoutMs),
+    signal: buildOAuthRequestSignal({ timeoutMs: requestTimeoutMs }),
   });
   if (!response.ok) {
     const detail = await readResponseTextLimited(

--- a/extensions/chutes/oauth.ts
+++ b/extensions/chutes/oauth.ts
@@ -2,7 +2,10 @@
  * Chutes OAuth PKCE login flow.
  */
 import { randomBytes } from "node:crypto";
-import { resolveExpiresAtMsFromDurationSeconds } from "openclaw/plugin-sdk/number-runtime";
+import {
+  resolveExpiresAtMsFromDurationSeconds,
+  resolveTimerTimeoutMs,
+} from "openclaw/plugin-sdk/number-runtime";
 import { generatePkceVerifierChallenge, toFormUrlEncoded } from "openclaw/plugin-sdk/provider-auth";
 import {
   parseOAuthCallbackInput,
@@ -18,6 +21,7 @@ const CHUTES_AUTHORIZE_ENDPOINT = "https://api.chutes.ai/idp/authorize";
 const CHUTES_TOKEN_ENDPOINT = "https://api.chutes.ai/idp/token";
 const CHUTES_USERINFO_ENDPOINT = "https://api.chutes.ai/idp/userinfo";
 const CHUTES_TOKEN_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
+const CHUTES_OAUTH_FETCH_TIMEOUT_MS = 10_000;
 
 type OAuthPrompt = {
   message: string;
@@ -114,13 +118,19 @@ function resolveChutesExpiresAt(value: unknown, now: number): number | undefined
   });
 }
 
+function resolveChutesOAuthFetchTimeoutMs(value: unknown): number {
+  return resolveTimerTimeoutMs(value, CHUTES_OAUTH_FETCH_TIMEOUT_MS);
+}
+
 async function fetchChutesUserInfo(params: {
   accessToken: string;
   fetchFn?: typeof fetch;
+  requestTimeoutMs: number;
 }): Promise<ChutesUserInfo | null> {
   const fetchFn = params.fetchFn ?? fetch;
   const response = await fetchFn(CHUTES_USERINFO_ENDPOINT, {
     headers: { Authorization: `Bearer ${params.accessToken}` },
+    signal: AbortSignal.timeout(params.requestTimeoutMs),
   });
   if (!response.ok) {
     return null;
@@ -135,9 +145,11 @@ async function exchangeChutesCodeForTokens(params: {
   codeVerifier: string;
   fetchFn?: typeof fetch;
   now?: number;
+  requestTimeoutMs?: number;
 }): Promise<ChutesStoredOAuth> {
   const fetchFn = params.fetchFn ?? fetch;
   const now = params.now ?? Date.now();
+  const requestTimeoutMs = resolveChutesOAuthFetchTimeoutMs(params.requestTimeoutMs);
   const body = new URLSearchParams(
     toFormUrlEncoded({
       grant_type: "authorization_code",
@@ -155,6 +167,7 @@ async function exchangeChutesCodeForTokens(params: {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body,
+    signal: AbortSignal.timeout(requestTimeoutMs),
   });
   if (!response.ok) {
     const detail = await readResponseTextLimited(
@@ -182,7 +195,7 @@ async function exchangeChutesCodeForTokens(params: {
     throw new Error("Chutes token exchange returned invalid expires_in");
   }
 
-  const info = await fetchChutesUserInfo({ accessToken: access, fetchFn });
+  const info = await fetchChutesUserInfo({ accessToken: access, fetchFn, requestTimeoutMs });
   return {
     access,
     refresh,
@@ -203,6 +216,7 @@ export async function loginChutes(params: {
   onPrompt: (prompt: OAuthPrompt) => Promise<string>;
   onProgress?: (message: string) => void;
   fetchFn?: typeof fetch;
+  requestTimeoutMs?: number;
 }): Promise<ChutesStoredOAuth> {
   const { verifier, challenge } = generatePkceVerifierChallenge();
   const state = params.createState?.() ?? randomBytes(16).toString("hex");
@@ -258,5 +272,6 @@ export async function loginChutes(params: {
     code: codeAndState.code,
     codeVerifier: verifier,
     fetchFn: params.fetchFn,
+    requestTimeoutMs: params.requestTimeoutMs,
   });
 }

--- a/extensions/chutes/oauth.ts
+++ b/extensions/chutes/oauth.ts
@@ -2,27 +2,24 @@
  * Chutes OAuth PKCE login flow.
  */
 import { randomBytes } from "node:crypto";
-import {
-  resolveExpiresAtMsFromDurationSeconds,
-  resolveTimerTimeoutMs,
-} from "openclaw/plugin-sdk/number-runtime";
+import { resolveExpiresAtMsFromDurationSeconds } from "openclaw/plugin-sdk/number-runtime";
 import { generatePkceVerifierChallenge, toFormUrlEncoded } from "openclaw/plugin-sdk/provider-auth";
 import {
   parseOAuthCallbackInput,
   waitForLocalOAuthCallback,
 } from "openclaw/plugin-sdk/provider-auth-runtime";
-import { buildOAuthRequestSignal } from "openclaw/plugin-sdk/provider-oauth-runtime";
 import {
   readProviderJsonResponse,
   readResponseTextLimited,
 } from "openclaw/plugin-sdk/provider-http";
+import { buildOAuthRequestSignal } from "openclaw/plugin-sdk/provider-oauth-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 const CHUTES_AUTHORIZE_ENDPOINT = "https://api.chutes.ai/idp/authorize";
 const CHUTES_TOKEN_ENDPOINT = "https://api.chutes.ai/idp/token";
 const CHUTES_USERINFO_ENDPOINT = "https://api.chutes.ai/idp/userinfo";
 const CHUTES_TOKEN_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
-const CHUTES_OAUTH_FETCH_TIMEOUT_MS = 30_000;
+const CHUTES_OAUTH_REQUEST_TIMEOUT_MS = 30_000;
 
 type OAuthPrompt = {
   message: string;
@@ -119,19 +116,14 @@ function resolveChutesExpiresAt(value: unknown, now: number): number | undefined
   });
 }
 
-function resolveChutesOAuthFetchTimeoutMs(value: unknown): number {
-  return resolveTimerTimeoutMs(value, CHUTES_OAUTH_FETCH_TIMEOUT_MS);
-}
-
 async function fetchChutesUserInfo(params: {
   accessToken: string;
   fetchFn?: typeof fetch;
-  requestTimeoutMs: number;
 }): Promise<ChutesUserInfo | null> {
   const fetchFn = params.fetchFn ?? fetch;
   const response = await fetchFn(CHUTES_USERINFO_ENDPOINT, {
     headers: { Authorization: `Bearer ${params.accessToken}` },
-    signal: buildOAuthRequestSignal({ timeoutMs: params.requestTimeoutMs }),
+    signal: buildOAuthRequestSignal({ timeoutMs: CHUTES_OAUTH_REQUEST_TIMEOUT_MS }),
   });
   if (!response.ok) {
     return null;
@@ -146,11 +138,9 @@ async function exchangeChutesCodeForTokens(params: {
   codeVerifier: string;
   fetchFn?: typeof fetch;
   now?: number;
-  requestTimeoutMs?: number;
 }): Promise<ChutesStoredOAuth> {
   const fetchFn = params.fetchFn ?? fetch;
   const now = params.now ?? Date.now();
-  const requestTimeoutMs = resolveChutesOAuthFetchTimeoutMs(params.requestTimeoutMs);
   const body = new URLSearchParams(
     toFormUrlEncoded({
       grant_type: "authorization_code",
@@ -168,7 +158,7 @@ async function exchangeChutesCodeForTokens(params: {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body,
-    signal: buildOAuthRequestSignal({ timeoutMs: requestTimeoutMs }),
+    signal: buildOAuthRequestSignal({ timeoutMs: CHUTES_OAUTH_REQUEST_TIMEOUT_MS }),
   });
   if (!response.ok) {
     const detail = await readResponseTextLimited(
@@ -196,7 +186,13 @@ async function exchangeChutesCodeForTokens(params: {
     throw new Error("Chutes token exchange returned invalid expires_in");
   }
 
-  const info = await fetchChutesUserInfo({ accessToken: access, fetchFn, requestTimeoutMs });
+  let info: ChutesUserInfo | null = null;
+  try {
+    info = await fetchChutesUserInfo({ accessToken: access, fetchFn });
+  } catch {
+    // Token exchange completes authentication; optional profile enrichment must
+    // not discard issued credentials when userinfo is unavailable or times out.
+  }
   return {
     access,
     refresh,
@@ -217,7 +213,6 @@ export async function loginChutes(params: {
   onPrompt: (prompt: OAuthPrompt) => Promise<string>;
   onProgress?: (message: string) => void;
   fetchFn?: typeof fetch;
-  requestTimeoutMs?: number;
 }): Promise<ChutesStoredOAuth> {
   const { verifier, challenge } = generatePkceVerifierChallenge();
   const state = params.createState?.() ?? randomBytes(16).toString("hex");
@@ -273,6 +268,5 @@ export async function loginChutes(params: {
     code: codeAndState.code,
     codeVerifier: verifier,
     fetchFn: params.fetchFn,
-    requestTimeoutMs: params.requestTimeoutMs,
   });
 }

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -201,6 +201,8 @@ async function refreshOAuthCredential(
   }
 
   if (credential.provider === "chutes") {
+    // Chutes refresh shipped before provider hooks and still covers registry-load
+    // windows where the synchronous hook resolver intentionally returns no owner.
     return await refreshChutesTokens({ credential });
   }
 

--- a/src/agents/chutes-oauth.flow.test.ts
+++ b/src/agents/chutes-oauth.flow.test.ts
@@ -66,7 +66,8 @@ function rejectWhenAborted(init?: RequestInit): Promise<Response> {
     return Promise.reject(new Error("missing OAuth request signal"));
   }
   return new Promise((_, reject) => {
-    const rejectWithReason = () => reject(signal.reason);
+    const rejectWithReason = () =>
+      reject(signal.reason instanceof Error ? signal.reason : new Error("OAuth request aborted"));
     if (signal.aborted) {
       rejectWithReason();
       return;

--- a/src/agents/chutes-oauth.flow.test.ts
+++ b/src/agents/chutes-oauth.flow.test.ts
@@ -1,5 +1,5 @@
 /** Tests Chutes OAuth token exchange and refresh HTTP flows. */
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
 import {
   CHUTES_TOKEN_ENDPOINT,
@@ -60,8 +60,28 @@ function expectRefreshedCredential(
   expect(refreshed.expires).toBe(now + 1800 * 1000 - 5 * 60 * 1000);
 }
 
+function rejectWhenAborted(init?: RequestInit): Promise<Response> {
+  const signal = init?.signal;
+  if (!signal) {
+    return Promise.reject(new Error("missing OAuth request signal"));
+  }
+  return new Promise((_, reject) => {
+    const rejectWithReason = () => reject(signal.reason);
+    if (signal.aborted) {
+      rejectWithReason();
+      return;
+    }
+    signal.addEventListener("abort", rejectWithReason, { once: true });
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe("chutes-oauth", () => {
   it("exchanges code for tokens and stores username as email", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
     const fetchFn = withFetchPreconnect(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = urlToString(input);
       if (url === CHUTES_TOKEN_ENDPOINT) {
@@ -109,6 +129,9 @@ describe("chutes-oauth", () => {
     expect((creds as unknown as { accountId?: string }).accountId).toBe("sub_1");
     expect((creds as unknown as { clientId?: string }).clientId).toBe("cid_test");
     expect(creds.expires).toBe(now + 3600 * 1000 - 5 * 60 * 1000);
+    expect(timeoutSpy).toHaveBeenCalledTimes(2);
+    expect(timeoutSpy).toHaveBeenNthCalledWith(1, 30_000);
+    expect(timeoutSpy).toHaveBeenNthCalledWith(2, 30_000);
   });
 
   it("rejects unsafe exchange token lifetimes", async () => {
@@ -177,7 +200,44 @@ describe("chutes-oauth", () => {
     expect((creds as unknown as { accountId?: string }).accountId).toBeUndefined();
   });
 
+  it("keeps issued tokens when userinfo exceeds the fixed deadline", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation((delay) => {
+      expect(delay).toBe(30_000);
+      return AbortSignal.abort(new DOMException("OAuth request timed out", "TimeoutError"));
+    });
+    const fetchFn = withFetchPreconnect(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = urlToString(input);
+      if (url === CHUTES_TOKEN_ENDPOINT) {
+        return new Response(
+          '{"access_token":"at_timeout","refresh_token":"rt_timeout","expires_in":3600}',
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url === CHUTES_USERINFO_ENDPOINT) {
+        return await rejectWhenAborted(init);
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const credentials = await exchangeChutesCodeForTokens({
+      app: {
+        clientId: "cid_test",
+        redirectUri: "http://127.0.0.1:1456/oauth-callback",
+        scopes: ["openid"],
+      },
+      code: "code_test",
+      codeVerifier: "verifier_test",
+      fetchFn,
+      now: 1_000_000,
+    });
+
+    expect(credentials).toMatchObject({ access: "at_timeout", refresh: "rt_timeout" });
+    expect(credentials.email).toBeUndefined();
+    expect(timeoutSpy).toHaveBeenCalledTimes(2);
+  });
+
   it("refreshes tokens using stored client id and falls back to old refresh token", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
     const fetchFn = withFetchPreconnect(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = urlToString(input);
       if (url !== CHUTES_TOKEN_ENDPOINT) {
@@ -205,6 +265,23 @@ describe("chutes-oauth", () => {
     });
 
     expectRefreshedCredential(refreshed, now);
+    expect(timeoutSpy).toHaveBeenCalledOnce();
+    expect(timeoutSpy).toHaveBeenCalledWith(30_000);
+  });
+
+  it("times out token refresh requests", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockImplementation((delay) => {
+      expect(delay).toBe(30_000);
+      return AbortSignal.abort(new DOMException("OAuth request timed out", "TimeoutError"));
+    });
+    const fetchFn = withFetchPreconnect(
+      async (_input: RequestInfo | URL, init?: RequestInit) => await rejectWhenAborted(init),
+    );
+
+    await expect(
+      refreshChutesTokens({ credential: createStoredCredential(2_000_000), fetchFn }),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
+    expect(timeoutSpy).toHaveBeenCalledOnce();
   });
 
   it("refreshes tokens and ignores empty refresh_token values", async () => {

--- a/src/agents/chutes-oauth.ts
+++ b/src/agents/chutes-oauth.ts
@@ -7,9 +7,11 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { sha256Base64Url } from "../infra/crypto-digest.js";
 import { resolveExpiresAtMsFromDurationSeconds } from "../infra/parse-finite-number.js";
 import type { OAuthCredentials } from "../llm/oauth.js";
+import { buildOAuthRequestSignal } from "../llm/utils/oauth/abort.js";
 import { readProviderJsonResponse, readResponseTextLimited } from "./provider-http-errors.js";
 
 const CHUTES_OAUTH_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
+const CHUTES_OAUTH_REQUEST_TIMEOUT_MS = 30_000;
 
 const CHUTES_OAUTH_ISSUER = "https://api.chutes.ai";
 export const CHUTES_AUTHORIZE_ENDPOINT = `${CHUTES_OAUTH_ISSUER}/idp/authorize`;
@@ -114,6 +116,7 @@ async function fetchChutesUserInfo(params: {
   const fetchFn = params.fetchFn ?? fetch;
   const response = await fetchFn(CHUTES_USERINFO_ENDPOINT, {
     headers: { Authorization: `Bearer ${params.accessToken}` },
+    signal: buildOAuthRequestSignal({ timeoutMs: CHUTES_OAUTH_REQUEST_TIMEOUT_MS }),
   });
   if (!response.ok) {
     await cancelUnreadResponseBody(response);
@@ -153,6 +156,7 @@ export async function exchangeChutesCodeForTokens(params: {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body,
+    signal: buildOAuthRequestSignal({ timeoutMs: CHUTES_OAUTH_REQUEST_TIMEOUT_MS }),
   });
   if (!response.ok) {
     const text = await readResponseTextLimited(response, CHUTES_OAUTH_ERROR_BODY_LIMIT_BYTES);
@@ -179,7 +183,13 @@ export async function exchangeChutesCodeForTokens(params: {
     throw new Error("Chutes token exchange returned invalid expires_in");
   }
 
-  const info = await fetchChutesUserInfo({ accessToken: access, fetchFn });
+  let info: ChutesUserInfo | null = null;
+  try {
+    info = await fetchChutesUserInfo({ accessToken: access, fetchFn });
+  } catch {
+    // Token exchange completes authentication; optional profile enrichment must
+    // not discard issued credentials when userinfo is unavailable or times out.
+  }
 
   return {
     access,
@@ -224,6 +234,7 @@ export async function refreshChutesTokens(params: {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body,
+    signal: buildOAuthRequestSignal({ timeoutMs: CHUTES_OAUTH_REQUEST_TIMEOUT_MS }),
   });
   if (!response.ok) {
     const text = await readResponseTextLimited(response, CHUTES_OAUTH_ERROR_BODY_LIMIT_BYTES);


### PR DESCRIPTION
## What Problem This Solves

Chutes OAuth login and token refresh could remain pending indefinitely when a provider endpoint accepted the HTTP request but never completed it.

## Why This Change Was Made

The callback deadline did not bound the token, userinfo, or refresh HTTP requests themselves. This change applies one fixed 30 second request deadline to authorization-code exchange, optional userinfo enrichment, provider-owned refresh, and the retained core refresh compatibility path. Optional userinfo failure no longer discards valid issued tokens, and no new config or public timeout API is introduced.

## User Impact

Users now receive a bounded OAuth failure when required Chutes token work stalls. If only optional profile enrichment stalls, login completes with the valid tokens and omits unavailable profile metadata.

## Evidence

Exact head: `c21fb87f448e41c0297fc0ebe7fe74042f0b39a0`

- Sanitized AWS Crabbox focused proof: `run_e9c7d2653ab4`; 15 Chutes OAuth tests passed.
- Sanitized AWS Crabbox bundled-extension lint: `run_640153cffd61`; passed.
- Sanitized AWS Crabbox changed-path lint: `run_dbb8299986e3`; passed.
- Hosted exact-head CI: https://github.com/openclaw/openclaw/actions/runs/29082356576; passed.
- Real behavior workflow: https://github.com/openclaw/openclaw/actions/runs/29082355168; passed.
- Live unauthenticated Chutes endpoint probes returned promptly for discovery, userinfo, and malformed-token requests.

The focused tests use a real loopback HTTP server that accepts requests without responding. They prove bounded token exchange and refresh, best-effort userinfo timeout handling, and the fixed production deadline contract.

Full credentialed Chutes login was not tested because `CHUTES_CLIENT_ID` and `CHUTES_CLIENT_SECRET` are absent from the approved environment.
