### PR TITLE
fix(qqbot): add timeout to speech transcription requests

### DIFF
--- a/docs/channels/qqbot.md
+++ b/docs/channels/qqbot.md
@@ -259,6 +259,11 @@ STT and TTS support two-level configuration with priority fallback:
 Set `enabled: false` on either to disable. Account-level TTS overrides use the
 same shape as `messages.tts` and deep-merge over channel/global TTS config.
 
+STT requests time out after 60 seconds by default. Plugin-specific STT uses the
+selected `models.providers.<id>.timeoutSeconds` override. Framework audio STT
+uses `tools.media.audio.models[0].timeoutSeconds`, then
+`tools.media.audio.timeoutSeconds`, then the selected provider override.
+
 Inbound QQ voice attachments are exposed to agents as audio media metadata
 while keeping raw voice files out of generic `MediaPaths`. `[[audio_as_voice]]`
 in a plain-text reply synthesizes TTS and sends a native QQ voice message when

--- a/extensions/qqbot/src/engine/utils/stt.test.ts
+++ b/extensions/qqbot/src/engine/utils/stt.test.ts
@@ -75,6 +75,7 @@ function requireFirstSsrfRequest(): {
   url?: unknown;
   auditContext?: unknown;
   init?: RequestInit;
+  timeoutMs?: unknown;
 } {
   const [call] = ssrfRuntimeMocks.fetchWithSsrFGuard.mock.calls;
   if (!call) {
@@ -84,6 +85,7 @@ function requireFirstSsrfRequest(): {
     url?: unknown;
     auditContext?: unknown;
     init?: RequestInit;
+    timeoutMs?: unknown;
   };
 }
 
@@ -118,6 +120,7 @@ describe("engine/utils/stt", () => {
         providers: {
           openai: {
             apiKey: "provider-key",
+            timeoutSeconds: 45,
           },
         },
       },
@@ -127,6 +130,7 @@ describe("engine/utils/stt", () => {
       baseUrl: "https://api.example.test/v1",
       apiKey: "provider-key",
       model: "whisper-large",
+      timeoutMs: 45_000,
     });
   });
 
@@ -136,13 +140,14 @@ describe("engine/utils/stt", () => {
       tools: {
         media: {
           audio: {
+            timeoutSeconds: 90,
             models: [{ provider: "local", baseUrl: "https://stt.example.test/", model: "sense" }],
           },
         },
       },
       models: {
         providers: {
-          local: { apiKey: "local-key" },
+          local: { apiKey: "local-key", timeoutSeconds: 120 },
         },
       },
     };
@@ -151,7 +156,11 @@ describe("engine/utils/stt", () => {
       baseUrl: "https://stt.example.test",
       apiKey: "local-key",
       model: "sense",
+      timeoutMs: 90_000,
     });
+
+    Object.assign(cfg.tools.media.audio.models[0], { timeoutSeconds: 75 });
+    expect(resolveSTTConfig(cfg)?.timeoutMs).toBe(75_000);
   });
 
   it("returns null when no usable STT credentials are configured", () => {
@@ -191,6 +200,7 @@ describe("engine/utils/stt", () => {
       const request = requireFirstSsrfRequest();
       expect(request.url).toBe("https://api.example.test/v1/audio/transcriptions");
       expect(request.auditContext).toBe("qqbot-stt");
+      expect(request.timeoutMs).toBe(60_000);
       expect(request.init?.method).toBe("POST");
       expect(request.init?.headers).toEqual({ Authorization: "Bearer secret" });
       expect(request.init?.body).toBeInstanceOf(FormData);

--- a/extensions/qqbot/src/engine/utils/stt.ts
+++ b/extensions/qqbot/src/engine/utils/stt.ts
@@ -8,6 +8,7 @@
 import * as fs from "node:fs";
 import path from "node:path";
 import { mimeTypeFromFilePath } from "openclaw/plugin-sdk/media-mime";
+import { finiteSecondsToTimerSafeMilliseconds } from "openclaw/plugin-sdk/number-runtime";
 import {
   readProviderJsonResponse,
   readResponseTextLimited,
@@ -22,11 +23,23 @@ import {
 } from "./string-normalize.js";
 
 const STT_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
+const DEFAULT_STT_TIMEOUT_MS = 60_000;
 
 interface STTConfig {
   baseUrl: string;
   apiKey: string;
   model: string;
+  timeoutMs: number;
+}
+
+function resolveSTTTimeoutMs(...timeoutSeconds: unknown[]): number {
+  for (const value of timeoutSeconds) {
+    const timeoutMs = finiteSecondsToTimerSafeMilliseconds(value);
+    if (timeoutMs !== undefined) {
+      return timeoutMs;
+    }
+  }
+  return DEFAULT_STT_TIMEOUT_MS;
 }
 
 /** Resolve the STT configuration from the nested config object. */
@@ -45,7 +58,12 @@ export function resolveSTTConfig(cfg: Record<string, unknown>): STTConfig | null
     const apiKey = readString(channelStt, "apiKey") ?? readString(providerCfg, "apiKey");
     const model = readString(channelStt, "model") ?? "whisper-1";
     if (baseUrl && apiKey) {
-      return { baseUrl: baseUrl.replace(/\/+$/, ""), apiKey, model };
+      return {
+        baseUrl: baseUrl.replace(/\/+$/, ""),
+        apiKey,
+        model,
+        timeoutMs: resolveSTTTimeoutMs(providerCfg?.timeoutSeconds),
+      };
     }
   }
 
@@ -62,7 +80,16 @@ export function resolveSTTConfig(cfg: Record<string, unknown>): STTConfig | null
     const apiKey = readString(audioModelEntry, "apiKey") ?? readString(providerCfg, "apiKey");
     const model = readString(audioModelEntry, "model") ?? "whisper-1";
     if (baseUrl && apiKey) {
-      return { baseUrl: baseUrl.replace(/\/+$/, ""), apiKey, model };
+      return {
+        baseUrl: baseUrl.replace(/\/+$/, ""),
+        apiKey,
+        model,
+        timeoutMs: resolveSTTTimeoutMs(
+          audioModelEntry.timeoutSeconds,
+          audio?.timeoutSeconds,
+          providerCfg?.timeoutSeconds,
+        ),
+      };
     }
   }
 
@@ -90,6 +117,7 @@ export async function transcribeAudio(
   const { response: resp, release } = await fetchWithSsrFGuard({
     url: `${sttCfg.baseUrl}/audio/transcriptions`,
     auditContext: "qqbot-stt",
+    timeoutMs: sttCfg.timeoutMs,
     init: {
       method: "POST",
       headers: { Authorization: `Bearer ${sttCfg.apiKey}` },


### PR DESCRIPTION
## What Problem This Solves

QQBot voice-message handling could wait indefinitely when an OpenAI-compatible STT endpoint accepted the transcription request but never responded.

## Why This Change Was Made

The transcription POST now carries a timer-safe deadline through the existing `fetchWithSsrFGuard` boundary. The implementation uses only existing public `timeoutSeconds` settings:

- plugin-specific STT uses `models.providers.<id>.timeoutSeconds`;
- framework audio STT uses model, audio, then provider precedence;
- otherwise the request uses the existing 60-second media-audio default.

This avoids a QQBot-only timeout key and removes the earlier duplicated timeout parsing and test harness.

## User Impact

A stalled STT provider no longer blocks the QQBot inbound attachment path indefinitely. Slow self-hosted providers can raise an existing provider or media timeout setting. Timeout failures keep the established platform-ASR or transcription-failed fallback behavior.

## Evidence

- Blacksmith Testbox `tbx_01kx3bajwrmdeepkwxd0390qnf`: `pnpm test extensions/qqbot/src/engine/utils/stt.test.ts extensions/qqbot/src/config.test.ts extensions/qqbot/src/manifest-schema.test.ts` passed, 27/27 tests.
- Same Testbox: `pnpm test ... src/infra/net/fetch-guard.ssrf.test.ts` passed the guarded-fetch suite, 91/91 tests.
- Same Testbox: `node scripts/test-live.mjs -- extensions/qqbot/src/engine/utils/stt.live.test.ts` passed a temporary real HTTP scenario in which the server received the multipart POST and never replied; the request rejected after the configured one-second deadline.
- Same Testbox: `pnpm check:changed` passed extension production/test typechecks, lint, docs checks, and architecture guards.
- Fresh Codex autoreview: no actionable findings, confidence 0.93.
- `git diff --check` passed.

## Real behavior proof

The live probe exercised the exported `resolveSTTConfig` and `transcribeAudio` path against a real loopback HTTP server that accepted the request and deliberately never sent a response. The rewritten path rejected with `TimeoutError` after the configured deadline instead of remaining pending.

Live QQ platform traffic and a third-party STT account were not used; the provider hang itself was reproduced with the no-response server.
