### PR TITLE
refactor(googlechat): localize internal declarations

### DIFF
--- a/extensions/googlechat/src/approval-card-actions.ts
+++ b/extensions/googlechat/src/approval-card-actions.ts
@@ -10,7 +10,7 @@ const GOOGLECHAT_APPROVAL_ACTION_VALUE = "approval";
 const MANUAL_EXEC_APPROVAL_COMMAND_RE =
   /(?:^|[\s`])\/approve[ \t]+([^ \t\r\n`|]+)[ \t]+(allow-once|allow-always|deny)(?=$|[\s`|.,;:!?])/giu;
 
-export type GoogleChatApprovalCardBinding = {
+type GoogleChatApprovalCardBinding = {
   token: string;
   accountId: string;
   approvalId: string;
@@ -45,7 +45,7 @@ type GoogleChatManualApprovalFollowupSuppression = {
   expiresAtMs: number;
 };
 
-export type GoogleChatApprovalCardClaim =
+type GoogleChatApprovalCardClaim =
   | { kind: "claimed"; binding: GoogleChatApprovalCardBinding }
   | { kind: "missing" }
   | { kind: "in-flight" };

--- a/extensions/googlechat/src/channel-base.ts
+++ b/extensions/googlechat/src/channel-base.ts
@@ -20,7 +20,7 @@ import { googlechatSetupWizard } from "./setup-surface.js";
 
 export const GOOGLECHAT_CHANNEL_ID = "googlechat" as const;
 
-export const googlechatMeta = {
+const googlechatMeta = {
   id: GOOGLECHAT_CHANNEL_ID,
   label: "Google Chat",
   selectionLabel: "Google Chat (Chat API)",

--- a/extensions/googlechat/src/monitor-durable.ts
+++ b/extensions/googlechat/src/monitor-durable.ts
@@ -1,7 +1,7 @@
 // Googlechat plugin module implements monitor durable behavior.
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 
-export type GoogleChatDurableReplyOptions = {
+type GoogleChatDurableReplyOptions = {
   to: string;
   replyToId?: string;
   threadId?: string;

--- a/extensions/googlechat/src/types.ts
+++ b/extensions/googlechat/src/types.ts
@@ -97,13 +97,13 @@ export type GoogleChatReaction = {
   emoji?: { unicode?: string };
 };
 
-export type GoogleChatTextParagraphWidget = {
+type GoogleChatTextParagraphWidget = {
   textParagraph: {
     text: string;
   };
 };
 
-export type GoogleChatButtonWidget = {
+type GoogleChatButtonWidget = {
   buttonList: {
     buttons: Array<{
       text: string;
@@ -118,9 +118,9 @@ export type GoogleChatButtonWidget = {
   };
 };
 
-export type GoogleChatDividerWidget = { divider: Record<string, never> };
+type GoogleChatDividerWidget = { divider: Record<string, never> };
 
-export type GoogleChatWidget =
+type GoogleChatWidget =
   | GoogleChatTextParagraphWidget
   | GoogleChatButtonWidget
   | GoogleChatDividerWidget;


### PR DESCRIPTION
## What Problem This Solves

Eight Google Chat implementation details were exported from internal modules even though no repository consumer imports them. That makes the plugin's apparent TypeScript API larger than its actual supported entrypoints.

## Why This Change Was Made

Make the declarations file-local while preserving all existing same-module use:

- approval-card binding and claim types
- channel metadata
- durable reply options
- card widget component and union types

Repository search and the refreshed code graph found only same-file consumers. The plugin entrypoint and public API barrels do not expose these declarations.

## User Impact

No runtime behavior changes. This narrows internal module surfaces and improves dead-code/export analysis accuracy.

## Evidence

- Based on current `origin/main` at `bdc1ce8dede018e809e1d145e308848c49107feb`
- Testbox `tbx_01kx007gaegyf0zmnd5z1wjyqx`: changed extension and extension-test gates passed
- `pnpm test:serial extensions/googlechat`: 20 files, 185 tests passed
- `pnpm build`: passed, including declaration emission and plugin SDK export validation
- Fresh local autoreview: clean, confidence 0.91
- Fresh branch autoreview: clean, confidence 0.86
