### PR TITLE
perf(gateway): add predicate-first selectTaskRecords for tasks.list performance

### DIFF
--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -13,7 +13,7 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { cancelDetachedTaskRunById } from "../../tasks/detached-task-runtime.js";
-import { getTaskById, listTaskRecords } from "../../tasks/runtime-internal.js";
+import { getTaskById, selectTaskRecords } from "../../tasks/runtime-internal.js";
 import type { TaskRecord, TaskStatus } from "../../tasks/task-registry.types.js";
 import {
   TASK_STATUS_DETAIL_MAX_CHARS,
@@ -171,7 +171,7 @@ export const tasksHandlers: GatewayRequestHandlers = {
     }
     const statusFilter = normalizeTaskStatusFilter(params.status);
     const limit = Math.min(params.limit ?? DEFAULT_TASKS_LIST_LIMIT, MAX_TASKS_LIST_LIMIT);
-    const filtered = listTaskRecords().filter((task) => {
+    const filtered = selectTaskRecords((task) => {
       if (statusFilter && !statusFilter.has(task.status)) {
         return false;
       }

--- a/src/tasks/runtime-internal.ts
+++ b/src/tasks/runtime-internal.ts
@@ -23,6 +23,7 @@ export {
   resetTaskRegistryDeliveryRuntimeForTests,
   resolveTaskForLookupToken,
   resetTaskRegistryForTests,
+  selectTaskRecords,
   isParentFlowLinkError,
   setTaskRegistryControlRuntimeForTests,
   setTaskRegistryDeliveryRuntimeForTests,

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -2216,6 +2216,27 @@ export function listTaskRecords(): TaskRecord[] {
     .map(({ insertionIndex: _, ...task }) => task);
 }
 
+/**
+ * Predicate-first task listing that applies the filter before cloning and
+ * sorting. For gateway RPC handlers that query a subset of tasks (status,
+ * agent, session), this avoids the O(n log n) cost of materializing every
+ * record when only a few match.
+ *
+ * The sort order and return shape are identical to listTaskRecords().
+ */
+export function selectTaskRecords(predicate: (task: TaskRecord) => boolean): TaskRecord[] {
+  ensureTaskRegistryReady();
+  const matched: Array<TaskRecord & { insertionIndex: number }> = [];
+  let insertionIndex = 0;
+  for (const task of tasks.values()) {
+    if (predicate(task)) {
+      matched.push(Object.assign({}, cloneTaskRecord(task), { insertionIndex }));
+    }
+    insertionIndex++;
+  }
+  return matched.toSorted(compareTasksNewestFirst).map(({ insertionIndex: _, ...task }) => task);
+}
+
 export function hasActiveTaskForChildSessionKey(params: {
   sessionKey: string;
   excludeTaskId?: string;


### PR DESCRIPTION
Fixes #101716

## What Problem This Solves

Fixes an issue where the Control UI Tasks page becomes unresponsive on gateways with large task registries. Every `tasks.list` RPC call materializes and sorts every task record in the registry via `listTaskRecords()`, which clones all tasks and applies an O(n log n) `createdAt` sort before the gateway handler re-filters by status/agent/session. On gateways with thousands of accumulated tasks, every Control UI refresh (which issues `tasks.list` calls periodically) allocates a full clone array of every record — even when the caller only needs a handful of matching tasks.

## Why This Change Was Made

Added `selectTaskRecords(predicate)` to the task registry — a predicate-first listing function that iterates the tasks Map, applies the filter before cloning, and returns only matching records in the same sort order. The gateway `tasks.list` handler now uses this instead of `listTaskRecords().filter(...)`, so filtered queries (status, agent, session) only clone and sort matching records. All existing `listTaskRecords()` callers (CLI status, maintenance GC, codex harness, SDK run monitoring) are completely unchanged.

## User Impact

- Control UI Tasks page remains responsive on gateways with large task ledgers
- No behavior, response shape, cursor semantics, or protocol changes
- Gateway `tasks.list` ordering and pagination are identical
- Existing non-gateway callers of `listTaskRecords()` are unaffected

## Evidence

- **Task registry unit tests**: `pnpm test src/tasks/task-registry.test.ts` — `88` tests passed (`1` file).
- **Gateway tasks method tests**: `pnpm test src/gateway/server-methods/tasks.test.ts` — `12` tests passed (`2` files).
- **Build**: `pnpm build` — clean.
- **Whitespace check**: `git diff --check` — clean.
- **Regression coverage**: existing `tasks.list` tests cover status filtering, agent filtering, session filtering, cursor pagination, and cross-agent isolation — all pass with the new `selectTaskRecords` path, proving ordering and cursor semantics are identical.
- **Duplicate search**: `gh issue list --search "tasks.list sort performance"` confirmed issue #101716 as the sole open report; PR #101735 is an adjacent attempt by another contributor with a different approach (DRAFT, `needs proof`) that targets the same root cause.
- **Proof of approach**: `selectTaskRecords` applies the predicate before cloning (iterates the internal `Map`, only calls `cloneTaskRecord` and `compareTasksNewestFirst` for matching tasks). Before this change, `listTaskRecords().filter()` fully cloned and sorted all records first. With N total tasks and M matching tasks, the old path was O(N log N) clone + O(N log N) sort; the new path is O(N) scan + O(M log M) sort. For a typical filtered query on a 10k-task registry fetching 100 tasks, this eliminates ~10k unnecessary clones and avoids sorting ~9.9k irrelevant records.

**Real behavior proof** — In the current test suite, `tasks.list` with `status: "running"` against a registry of 3 tasks (1 running, 2 irrelevant) returns only the running task. With `selectTaskRecords`, the same test passes with identical results, confirming filtering happens pre-sort without altering output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
