### PR TITLE
fix(lobster): keep ordinary run/resume on default flow fields

### DIFF
--- a/extensions/lobster/src/lobster-tool.test.ts
+++ b/extensions/lobster/src/lobster-tool.test.ts
@@ -180,6 +180,24 @@ describe("lobster plugin tool", () => {
     expect(details.status).toBe("ok");
   });
 
+  it("rejects resume with a non-default flow revision but no flowId", async () => {
+    const runner = { run: vi.fn() };
+    const tool = createLobsterTool(fakeApi(), {
+      runner,
+      taskFlow: createFakeTaskFlow(),
+    });
+
+    await expect(
+      tool.execute("call-revision-without-flow-id", {
+        action: "resume",
+        token: "resume-token-1",
+        approve: true,
+        flowExpectedRevision: 1,
+      }),
+    ).rejects.toThrow(/flowId required when using managed TaskFlow resume mode/);
+    expect(runner.run).not.toHaveBeenCalled();
+  });
+
   it("normalizes numeric string run limits before invoking the runner", async () => {
     const runner = {
       run: vi.fn().mockResolvedValue({

--- a/extensions/lobster/src/lobster-tool.test.ts
+++ b/extensions/lobster/src/lobster-tool.test.ts
@@ -323,6 +323,41 @@ describe("lobster plugin tool", () => {
     expect(mutation.applied).toBe(true);
   });
 
+  it("preserves explicit empty flow state in managed TaskFlow run mode", async () => {
+    const runner = {
+      run: vi.fn().mockResolvedValue({
+        ok: true,
+        status: "ok",
+        output: [],
+        requiresApproval: null,
+      }),
+    };
+    const taskFlow = createFakeTaskFlow();
+
+    const tool = createLobsterTool(fakeApi(), { runner, taskFlow });
+    await tool.execute("call-managed-run-empty-state", {
+      action: "run",
+      pipeline: "noop",
+      flowControllerId: "tests/lobster",
+      flowGoal: "Run Lobster workflow",
+      flowStateJson: "{}",
+    });
+
+    expect(taskFlow.createManaged).toHaveBeenCalledWith({
+      controllerId: "tests/lobster",
+      goal: "Run Lobster workflow",
+      currentStep: "run_lobster",
+      stateJson: {},
+    });
+    expect(runner.run).toHaveBeenCalledWith({
+      action: "run",
+      pipeline: "noop",
+      cwd: process.cwd(),
+      timeoutMs: 20_000,
+      maxStdoutBytes: 512_000,
+    });
+  });
+
   it("rejects managed TaskFlow params when no bound taskFlow runtime is available", async () => {
     const tool = createLobsterTool(fakeApi(), {
       runner: { run: vi.fn() },

--- a/extensions/lobster/src/lobster-tool.test.ts
+++ b/extensions/lobster/src/lobster-tool.test.ts
@@ -146,6 +146,28 @@ describe("lobster plugin tool", () => {
     expect(details.status).toBe("needs_approval");
   });
 
+  it.each([{ flowId: "flow-1" }, { flowExpectedRevision: 1 }])(
+    "rejects resume-only fields on run before the ordinary fallback",
+    async (resumeFields) => {
+      const runner = { run: vi.fn() };
+      const tool = createLobsterTool(fakeApi(), {
+        runner,
+        taskFlow: createFakeTaskFlow(),
+      });
+
+      await expect(
+        tool.execute("call-run-with-resume-fields", {
+          action: "run",
+          pipeline: "noop",
+          flowStateJson: "{}",
+          flowExpectedRevision: 0,
+          ...resumeFields,
+        }),
+      ).rejects.toThrow(/run action does not accept flowId or flowExpectedRevision/);
+      expect(runner.run).not.toHaveBeenCalled();
+    },
+  );
+
   it("keeps ordinary resume on the embedded runner when flow defaults are injected", async () => {
     const runner = {
       run: vi.fn().mockResolvedValue({
@@ -178,6 +200,29 @@ describe("lobster plugin tool", () => {
     const details = requireRecord(res.details, "ordinary resume with flow defaults details");
     expect(details.ok).toBe(true);
     expect(details.status).toBe("ok");
+  });
+
+  it.each([
+    { flowControllerId: "tests/lobster" },
+    { flowGoal: "Run Lobster workflow" },
+    { flowStateJson: '{"lane":"email"}' },
+  ])("rejects run-only fields on resume before the ordinary fallback", async (runFields) => {
+    const runner = { run: vi.fn() };
+    const tool = createLobsterTool(fakeApi(), {
+      runner,
+      taskFlow: createFakeTaskFlow(),
+    });
+
+    await expect(
+      tool.execute("call-resume-with-run-fields", {
+        action: "resume",
+        token: "resume-token-1",
+        approve: true,
+        flowExpectedRevision: 0,
+        ...runFields,
+      }),
+    ).rejects.toThrow(/resume action does not accept flowControllerId, flowGoal, or flowStateJson/);
+    expect(runner.run).not.toHaveBeenCalled();
   });
 
   it("rejects resume with a non-default flow revision but no flowId", async () => {

--- a/extensions/lobster/src/lobster-tool.test.ts
+++ b/extensions/lobster/src/lobster-tool.test.ts
@@ -110,6 +110,76 @@ describe("lobster plugin tool", () => {
     expect(approval.resumeToken).toBe("resume-token-1");
   });
 
+  it("keeps ordinary run on the embedded runner when flow defaults are injected", async () => {
+    const runner = {
+      run: vi.fn().mockResolvedValue({
+        ok: true,
+        status: "needs_approval",
+        output: [],
+        requiresApproval: {
+          type: "approval_request",
+          prompt: "Continue?",
+          items: [],
+          resumeToken: "resume-token-1",
+        },
+      }),
+    };
+    const taskFlow = createFakeTaskFlow();
+
+    const tool = createLobsterTool(fakeApi(), { runner, taskFlow });
+    const res = await tool.execute("call-default-flow-run", {
+      action: "run",
+      pipeline: "noop",
+      flowStateJson: "{}",
+      flowExpectedRevision: 0,
+    });
+
+    expect(taskFlow.createManaged).not.toHaveBeenCalled();
+    expect(runner.run).toHaveBeenCalledWith({
+      action: "run",
+      pipeline: "noop",
+      cwd: process.cwd(),
+      timeoutMs: 20_000,
+      maxStdoutBytes: 512_000,
+    });
+    const details = requireRecord(res.details, "ordinary run with flow defaults details");
+    expect(details.status).toBe("needs_approval");
+  });
+
+  it("keeps ordinary resume on the embedded runner when flow defaults are injected", async () => {
+    const runner = {
+      run: vi.fn().mockResolvedValue({
+        ok: true,
+        status: "ok",
+        output: [{ approved: true }],
+        requiresApproval: null,
+      }),
+    };
+    const taskFlow = createFakeTaskFlow();
+
+    const tool = createLobsterTool(fakeApi(), { runner, taskFlow });
+    const res = await tool.execute("call-default-flow-resume", {
+      action: "resume",
+      token: "resume-token-1",
+      approve: true,
+      flowStateJson: "{}",
+      flowExpectedRevision: 0,
+    });
+
+    expect(taskFlow.resume).not.toHaveBeenCalled();
+    expect(runner.run).toHaveBeenCalledWith({
+      action: "resume",
+      token: "resume-token-1",
+      approve: true,
+      cwd: process.cwd(),
+      timeoutMs: 20_000,
+      maxStdoutBytes: 512_000,
+    });
+    const details = requireRecord(res.details, "ordinary resume with flow defaults details");
+    expect(details.ok).toBe(true);
+    expect(details.status).toBe("ok");
+  });
+
   it("normalizes numeric string run limits before invoking the runner", async () => {
     const runner = {
       run: vi.fn().mockResolvedValue({
@@ -203,6 +273,7 @@ describe("lobster plugin tool", () => {
       flowControllerId: "tests/lobster",
       flowGoal: "Run Lobster workflow",
       flowStateJson: '{"lane":"email"}',
+      flowExpectedRevision: 0,
       flowCurrentStep: "run_lobster",
       flowWaitingStep: "await_review",
     });
@@ -284,6 +355,7 @@ describe("lobster plugin tool", () => {
       approve: true,
       flowId: "flow-1",
       flowExpectedRevision: 1,
+      flowStateJson: "{}",
       flowCurrentStep: "resume_lobster",
     });
 

--- a/extensions/lobster/src/lobster-tool.ts
+++ b/extensions/lobster/src/lobster-tool.ts
@@ -128,6 +128,10 @@ function parseRunFlowParams(params: Record<string, unknown>): ManagedFlowRunPara
   const resumeRevision = readOptionalNumber(params.flowExpectedRevision, "flowExpectedRevision");
   const stateJsonSignalsRunMode = stateJson !== undefined && !isEmptyJsonObject(stateJson);
 
+  if (resumeFlowId !== undefined || (resumeRevision !== undefined && resumeRevision !== 0)) {
+    throw new Error("run action does not accept flowId or flowExpectedRevision");
+  }
+
   const hasRunFields =
     controllerId !== undefined ||
     goal !== undefined ||
@@ -137,9 +141,6 @@ function parseRunFlowParams(params: Record<string, unknown>): ManagedFlowRunPara
 
   if (!hasRunFields) {
     return null;
-  }
-  if (resumeFlowId !== undefined || (resumeRevision !== undefined && resumeRevision !== 0)) {
-    throw new Error("run action does not accept flowId or flowExpectedRevision");
   }
   if (!controllerId) {
     throw new Error("flowControllerId required when using managed TaskFlow run mode");
@@ -166,6 +167,12 @@ function parseResumeFlowParams(params: Record<string, unknown>): ManagedFlowResu
   const approve = readOptionalBoolean(params.approve, "approve");
   const runControllerId = readOptionalTrimmedString(params.flowControllerId, "flowControllerId");
   const runGoal = readOptionalTrimmedString(params.flowGoal, "flowGoal");
+  const stateJson = parseOptionalFlowStateJson(params.flowStateJson);
+  const stateJsonDisallowed = stateJson !== undefined && !isEmptyJsonObject(stateJson);
+
+  if (runControllerId !== undefined || runGoal !== undefined || stateJsonDisallowed) {
+    throw new Error("resume action does not accept flowControllerId, flowGoal, or flowStateJson");
+  }
 
   const hasResumeFields =
     flowId !== undefined ||
@@ -175,11 +182,6 @@ function parseResumeFlowParams(params: Record<string, unknown>): ManagedFlowResu
 
   if (!hasResumeFields) {
     return null;
-  }
-  const stateJson = parseOptionalFlowStateJson(params.flowStateJson);
-  const stateJsonDisallowed = stateJson !== undefined && !isEmptyJsonObject(stateJson);
-  if (runControllerId !== undefined || runGoal !== undefined || stateJsonDisallowed) {
-    throw new Error("resume action does not accept flowControllerId, flowGoal, or flowStateJson");
   }
   if (!flowId) {
     throw new Error("flowId required when using managed TaskFlow resume mode");

--- a/extensions/lobster/src/lobster-tool.ts
+++ b/extensions/lobster/src/lobster-tool.ts
@@ -97,8 +97,21 @@ function parseOptionalFlowStateJson(value: unknown): JsonLike | undefined {
   if (typeof value !== "string") {
     throw new Error("flowStateJson must be a JSON string");
   }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
   try {
-    return JSON.parse(value) as JsonLike;
+    const parsed = JSON.parse(trimmed) as JsonLike;
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed) &&
+      Object.keys(parsed).length === 0
+    ) {
+      return undefined;
+    }
+    return parsed;
   } catch {
     throw new Error("flowStateJson must be valid JSON");
   }
@@ -111,7 +124,6 @@ function parseRunFlowParams(params: Record<string, unknown>): ManagedFlowRunPara
   const waitingStep = readOptionalTrimmedString(params.flowWaitingStep, "flowWaitingStep");
   const stateJson = parseOptionalFlowStateJson(params.flowStateJson);
   const resumeFlowId = readOptionalTrimmedString(params.flowId, "flowId");
-  const resumeRevision = readOptionalNumber(params.flowExpectedRevision, "flowExpectedRevision");
 
   const hasRunFields =
     controllerId !== undefined ||
@@ -123,7 +135,7 @@ function parseRunFlowParams(params: Record<string, unknown>): ManagedFlowRunPara
   if (!hasRunFields) {
     return null;
   }
-  if (resumeFlowId !== undefined || resumeRevision !== undefined) {
+  if (resumeFlowId !== undefined) {
     throw new Error("run action does not accept flowId or flowExpectedRevision");
   }
   if (!controllerId) {
@@ -143,7 +155,6 @@ function parseRunFlowParams(params: Record<string, unknown>): ManagedFlowRunPara
 
 function parseResumeFlowParams(params: Record<string, unknown>): ManagedFlowResumeParams | null {
   const flowId = readOptionalTrimmedString(params.flowId, "flowId");
-  const expectedRevision = readOptionalNumber(params.flowExpectedRevision, "flowExpectedRevision");
   const currentStep = readOptionalTrimmedString(params.flowCurrentStep, "flowCurrentStep");
   const waitingStep = readOptionalTrimmedString(params.flowWaitingStep, "flowWaitingStep");
   const token = readOptionalTrimmedString(params.token, "token");
@@ -151,17 +162,15 @@ function parseResumeFlowParams(params: Record<string, unknown>): ManagedFlowResu
   const approve = readOptionalBoolean(params.approve, "approve");
   const runControllerId = readOptionalTrimmedString(params.flowControllerId, "flowControllerId");
   const runGoal = readOptionalTrimmedString(params.flowGoal, "flowGoal");
-  const stateJson = params.flowStateJson;
 
   const hasResumeFields =
-    flowId !== undefined ||
-    expectedRevision !== undefined ||
-    currentStep !== undefined ||
-    waitingStep !== undefined;
+    flowId !== undefined || currentStep !== undefined || waitingStep !== undefined;
 
   if (!hasResumeFields) {
     return null;
   }
+  const expectedRevision = readOptionalNumber(params.flowExpectedRevision, "flowExpectedRevision");
+  const stateJson = parseOptionalFlowStateJson(params.flowStateJson);
   if (runControllerId !== undefined || runGoal !== undefined || stateJson !== undefined) {
     throw new Error("resume action does not accept flowControllerId, flowGoal, or flowStateJson");
   }

--- a/extensions/lobster/src/lobster-tool.ts
+++ b/extensions/lobster/src/lobster-tool.ts
@@ -124,6 +124,7 @@ function parseRunFlowParams(params: Record<string, unknown>): ManagedFlowRunPara
   const waitingStep = readOptionalTrimmedString(params.flowWaitingStep, "flowWaitingStep");
   const stateJson = parseOptionalFlowStateJson(params.flowStateJson);
   const resumeFlowId = readOptionalTrimmedString(params.flowId, "flowId");
+  const resumeRevision = readOptionalNumber(params.flowExpectedRevision, "flowExpectedRevision");
 
   const hasRunFields =
     controllerId !== undefined ||
@@ -135,7 +136,7 @@ function parseRunFlowParams(params: Record<string, unknown>): ManagedFlowRunPara
   if (!hasRunFields) {
     return null;
   }
-  if (resumeFlowId !== undefined) {
+  if (resumeFlowId !== undefined || (resumeRevision !== undefined && resumeRevision !== 0)) {
     throw new Error("run action does not accept flowId or flowExpectedRevision");
   }
   if (!controllerId) {
@@ -155,6 +156,7 @@ function parseRunFlowParams(params: Record<string, unknown>): ManagedFlowRunPara
 
 function parseResumeFlowParams(params: Record<string, unknown>): ManagedFlowResumeParams | null {
   const flowId = readOptionalTrimmedString(params.flowId, "flowId");
+  const expectedRevision = readOptionalNumber(params.flowExpectedRevision, "flowExpectedRevision");
   const currentStep = readOptionalTrimmedString(params.flowCurrentStep, "flowCurrentStep");
   const waitingStep = readOptionalTrimmedString(params.flowWaitingStep, "flowWaitingStep");
   const token = readOptionalTrimmedString(params.token, "token");
@@ -164,12 +166,14 @@ function parseResumeFlowParams(params: Record<string, unknown>): ManagedFlowResu
   const runGoal = readOptionalTrimmedString(params.flowGoal, "flowGoal");
 
   const hasResumeFields =
-    flowId !== undefined || currentStep !== undefined || waitingStep !== undefined;
+    flowId !== undefined ||
+    (expectedRevision !== undefined && expectedRevision !== 0) ||
+    currentStep !== undefined ||
+    waitingStep !== undefined;
 
   if (!hasResumeFields) {
     return null;
   }
-  const expectedRevision = readOptionalNumber(params.flowExpectedRevision, "flowExpectedRevision");
   const stateJson = parseOptionalFlowStateJson(params.flowStateJson);
   if (runControllerId !== undefined || runGoal !== undefined || stateJson !== undefined) {
     throw new Error("resume action does not accept flowControllerId, flowGoal, or flowStateJson");

--- a/extensions/lobster/src/lobster-tool.ts
+++ b/extensions/lobster/src/lobster-tool.ts
@@ -102,19 +102,20 @@ function parseOptionalFlowStateJson(value: unknown): JsonLike | undefined {
     return undefined;
   }
   try {
-    const parsed = JSON.parse(trimmed) as JsonLike;
-    if (
-      parsed !== null &&
-      typeof parsed === "object" &&
-      !Array.isArray(parsed) &&
-      Object.keys(parsed).length === 0
-    ) {
-      return undefined;
-    }
-    return parsed;
+    return JSON.parse(trimmed) as JsonLike;
   } catch {
     throw new Error("flowStateJson must be valid JSON");
   }
+}
+
+function isEmptyJsonObject(value: JsonLike | undefined): boolean {
+  return (
+    value !== undefined &&
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.keys(value).length === 0
+  );
 }
 
 function parseRunFlowParams(params: Record<string, unknown>): ManagedFlowRunParams | null {
@@ -125,13 +126,14 @@ function parseRunFlowParams(params: Record<string, unknown>): ManagedFlowRunPara
   const stateJson = parseOptionalFlowStateJson(params.flowStateJson);
   const resumeFlowId = readOptionalTrimmedString(params.flowId, "flowId");
   const resumeRevision = readOptionalNumber(params.flowExpectedRevision, "flowExpectedRevision");
+  const stateJsonSignalsRunMode = stateJson !== undefined && !isEmptyJsonObject(stateJson);
 
   const hasRunFields =
     controllerId !== undefined ||
     goal !== undefined ||
     currentStep !== undefined ||
     waitingStep !== undefined ||
-    stateJson !== undefined;
+    stateJsonSignalsRunMode;
 
   if (!hasRunFields) {
     return null;
@@ -175,7 +177,8 @@ function parseResumeFlowParams(params: Record<string, unknown>): ManagedFlowResu
     return null;
   }
   const stateJson = parseOptionalFlowStateJson(params.flowStateJson);
-  if (runControllerId !== undefined || runGoal !== undefined || stateJson !== undefined) {
+  const stateJsonDisallowed = stateJson !== undefined && !isEmptyJsonObject(stateJson);
+  if (runControllerId !== undefined || runGoal !== undefined || stateJsonDisallowed) {
     throw new Error("resume action does not accept flowControllerId, flowGoal, or flowStateJson");
   }
   if (!flowId) {


### PR DESCRIPTION
Closes #102011

## What Problem This Solves

Ordinary `@openclaw/lobster` `run` and `resume` calls could be routed into managed TaskFlow parsing when the tool payload contained schema-injected defaults such as `flowStateJson: "{}"` and `flowExpectedRevision: 0`.

## Why This Change Was Made

The Lobster parser now distinguishes injected empty defaults from intentional managed fields:

- blank flow state is treated as absent;
- an empty object does not select managed mode by itself;
- explicit managed runs still preserve `stateJson: {}`;
- revision `0` alone does not select managed mode;
- explicit cross-mode fields are rejected before ordinary fallback.

This stays inside the Lobster plugin parser. It does not change core TaskFlow, protocol, configuration, migration, storage, or dependency contracts.

## User Impact

Ordinary Lobster approval workflows can run and resume without being asked for TaskFlow-only fields the caller did not intend to provide. Managed TaskFlow callers retain existing validation and can explicitly start with an empty state object.

## Evidence

Validated exact head `c12bf2f48570da79968487e1dcc10fb4b9ac2f35`.

- Sanitized AWS Crabbox lease `cbx_c92971815ef7`, run `run_f48d59554de8`, exit `0`; lease released after proof.
- `pnpm test extensions/lobster/src/lobster-tool.test.ts extensions/lobster/src/lobster-runner.test.ts`: 2 files, 52 tests passed.
- Real `createLobsterTool(createEmbeddedLobsterRunner())` ordinary run -> approval -> resume with injected `{}` and revision `0`: passed without a TaskFlow runtime.
- Real embedded managed run retained an own `stateJson` property equal to `{}`.
- Full remote `pnpm check:changed`: passed, including extension production/test typechecks, lint, database/storage guards, and import-cycle checks.
- Hosted CI run `28920766065`: 63 successful checks, no failures or pending checks.
- Fresh autoreview after the maintainer strictness repair: clean, no actionable findings.
- `git diff --check`: passed.

No documentation or changelog update is required; the public call shapes are unchanged and release generation owns `CHANGELOG.md`.
