### PR TITLE
refactor(line): localize internal declarations

### DIFF
--- a/extensions/line/src/actions.ts
+++ b/extensions/line/src/actions.ts
@@ -3,7 +3,7 @@ import type { messagingApi } from "@line/bot-sdk";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 export type Action = messagingApi.Action;
-export const LINE_ACTION_LABEL_LIMIT = 20;
+const LINE_ACTION_LABEL_LIMIT = 20;
 const LINE_ACTION_DATA_LIMIT = 300;
 
 export function truncateLineActionLabel(label: string, limit = LINE_ACTION_LABEL_LIMIT): string {

--- a/extensions/line/src/auto-reply-delivery.ts
+++ b/extensions/line/src/auto-reply-delivery.ts
@@ -43,7 +43,7 @@ export type LineAutoReplyDeps = {
   | "onReplyError"
 >;
 
-export type LineAutoReplyDeliveryResult =
+type LineAutoReplyDeliveryResult =
   | { status: "delivered"; replyTokenUsed: boolean }
   | { status: "partial"; replyTokenUsed: boolean; error: Error };
 

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -66,7 +66,7 @@ function isDownloadableLineMessageType(
   return LINE_DOWNLOADABLE_MESSAGE_TYPES.has(messageType);
 }
 
-export interface LineHandlerContext {
+interface LineHandlerContext {
   cfg: OpenClawConfig;
   account: ResolvedLineAccount;
   runtime: RuntimeEnv;
@@ -79,7 +79,7 @@ export interface LineHandlerContext {
 
 const LINE_WEBHOOK_REPLAY_WINDOW_MS = 10 * 60 * 1000;
 const LINE_WEBHOOK_REPLAY_MAX_ENTRIES = 4096;
-export type LineWebhookReplayCache = ClaimableDedupe;
+type LineWebhookReplayCache = ClaimableDedupe;
 
 function normalizeLineIngressEntry(value: string): string | null {
   return normalizeLineAllowEntry(value) || null;

--- a/extensions/line/src/monitor-durable.ts
+++ b/extensions/line/src/monitor-durable.ts
@@ -3,7 +3,7 @@ import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-pay
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type { LineChannelData } from "./types.js";
 
-export type LineDurableReplyOptions = {
+type LineDurableReplyOptions = {
   to: string;
 };
 

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -46,7 +46,7 @@ import type { LineChannelData, ResolvedLineAccount } from "./types.js";
 import { createLineNodeWebhookHandler, readLineWebhookRequestBody } from "./webhook-node.js";
 import { parseLineWebhookBody, validateLineSignature } from "./webhook-utils.js";
 
-export interface MonitorLineProviderOptions {
+interface MonitorLineProviderOptions {
   channelAccessToken: string;
   channelSecret: string;
   accountId?: string;
@@ -57,7 +57,7 @@ export interface MonitorLineProviderOptions {
   webhookPath?: string;
 }
 
-export interface LineProviderMonitor {
+interface LineProviderMonitor {
   account: ResolvedLineAccount;
   handleWebhook: (body: webhook.CallbackRequest) => Promise<void>;
   stop: () => void;


### PR DESCRIPTION
## What Problem This Solves

Seven LINE implementation details were exported from internal modules even though no repository consumer imports them. This overstates the plugin's supported TypeScript surface.

## Why This Change Was Made

Make the declarations file-local while preserving all same-module use:

- action label limit
- auto-reply delivery result
- webhook handler context and replay cache
- durable reply options
- monitor options and result

Repository search and the refreshed code graph found only same-file consumers. Supported runtime/API barrels continue to export the actual plugin functions.

## User Impact

No runtime behavior changes. The refactor narrows internal module surfaces and improves dead-code/export analysis accuracy.

## Evidence

- Rebased onto current `origin/main` at `35d5ea069ae90d9377df69dbdb5c636c05f58ecd`
- Testbox `tbx_01kx01batv41yaharpb5atem13`: changed extension and extension-test gates passed
- `pnpm test:serial extensions/line`: 26 files, 306 tests passed
- `pnpm build`: passed, including declaration emission and plugin SDK export validation
- Fresh pre-commit local autoreview: clean, confidence 0.93
- Fresh post-rebase branch autoreview: clean, confidence 0.89
