### PR TITLE
fix(daemon): route systemd restarts through SIGUSR1

### DIFF
--- a/src/daemon/systemd-unit.test.ts
+++ b/src/daemon/systemd-unit.test.ts
@@ -20,6 +20,7 @@ describe("buildSystemdUnit", () => {
       environment: {},
     });
     expect(unit).toContain("KillMode=control-group");
+    expect(unit).toContain("RestartKillSignal=SIGUSR1");
     expect(unit).toContain("TimeoutStopSec=30");
     expect(unit).toContain("TimeoutStartSec=30");
     expect(unit).toContain("SuccessExitStatus=0 143");

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -77,6 +77,10 @@ export function buildSystemdUnit({
     `ExecStart=${execStart}`,
     "Restart=always",
     "RestartSec=5",
+    // systemctl restart uses RestartKillSignal= when present. Route restarts
+    // through the gateway SIGUSR1 handler so active turns can use restart
+    // recovery instead of being surfaced as ordinary SIGTERM shutdowns.
+    "RestartKillSignal=SIGUSR1",
     "RestartPreventExitStatus=78",
     "TimeoutStopSec=30",
     "TimeoutStartSec=30",


### PR DESCRIPTION
## Summary
- Add `RestartKillSignal=SIGUSR1` to generated Linux systemd gateway units.
- Keep normal stops on SIGTERM/KillSignal while making `systemctl restart` enter the existing SIGUSR1 managed restart path.
- Cover generated unit output in `systemd-unit` tests.

## Observed evidence
On an OpenClaw `2026.7.1-beta.2` Linux deployment, an active Telegram embedded Codex turn was interrupted by an operator `systemctl restart openclaw-gateway-tianji.service`.

The gateway log sequence was:
- `signal SIGTERM received`
- `shutdown started: gateway stopping`
- `codex app-server client closed before turn completed`
- the user-facing fallback reply was sent to Telegram

`2026.7.1-beta.2` already contains the managed restart recovery work from #91357 / #87808. The gap is that Linux systemd restart requests still send SIGTERM by default, so the gateway takes the ordinary stop path instead of the SIGUSR1 restart path that sets restart recovery state.

## Why this fix
systemd supports `RestartKillSignal=` for service restart requests. Setting it to SIGUSR1 routes only restarts through the gateway managed restart handler, while plain stops continue to use the normal SIGTERM/KillSignal behavior.

Related to #87808. Adjacent to #88309, but this patch is specifically for generated Linux systemd units.

## Verification
- Generated unit smoke check with `node --import tsx` confirmed `RestartKillSignal=SIGUSR1`.
- `node scripts/run-vitest.mjs run src/daemon/systemd-unit.test.ts`
- `git diff --check`
- `pnpm exec oxfmt --check --threads=1 src/daemon/systemd-unit.ts src/daemon/systemd-unit.test.ts`