### PR TITLE
refactor(mattermost): localize internal declarations

### DIFF
--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -70,7 +70,7 @@ export const MattermostPostSchema = z
 
 export type MattermostPost = z.infer<typeof MattermostPostSchema>;
 
-export type MattermostFileInfo = {
+type MattermostFileInfo = {
   id: string;
   name?: string | null;
   mime_type?: string | null;
@@ -615,7 +615,7 @@ export async function createMattermostPost(
   });
 }
 
-export type MattermostTeam = {
+type MattermostTeam = {
   id: string;
   name?: string | null;
   display_name?: string | null;

--- a/extensions/mattermost/src/mattermost/directory.ts
+++ b/extensions/mattermost/src/mattermost/directory.ts
@@ -11,7 +11,7 @@ import {
 } from "./client.js";
 import type { ChannelDirectoryEntry, OpenClawConfig, RuntimeEnv } from "./runtime-api.js";
 
-export type MattermostDirectoryParams = {
+type MattermostDirectoryParams = {
   cfg: OpenClawConfig;
   accountId?: string | null;
   query?: string | null;

--- a/extensions/mattermost/src/mattermost/monitor-auth.ts
+++ b/extensions/mattermost/src/mattermost/monitor-auth.ts
@@ -104,7 +104,7 @@ function mapMattermostChannelKind(channelType?: string | null): "direct" | "grou
   return "channel";
 }
 
-export type MattermostCommandAuthDecision =
+type MattermostCommandAuthDecision =
   | {
       ok: true;
       commandAuthorized: boolean;

--- a/extensions/mattermost/src/mattermost/monitor-resources.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.ts
@@ -16,7 +16,7 @@ import {
 } from "./client.js";
 import { buildButtonProps, type MattermostInteractionResponse } from "./interactions.js";
 
-export type MattermostMediaKind = "image" | "audio" | "video" | "document" | "unknown";
+type MattermostMediaKind = "image" | "audio" | "video" | "document" | "unknown";
 
 export type MattermostMediaInfo = {
   path: string;

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -135,7 +135,7 @@ export type {
   MattermostRequireMentionResolverInput,
 } from "./monitor-gating.js";
 
-export type MonitorMattermostOpts = {
+type MonitorMattermostOpts = {
   botToken?: string;
   baseUrl?: string;
   accountId?: string;

--- a/extensions/mattermost/src/mattermost/no-visible-reply-diagnostic.ts
+++ b/extensions/mattermost/src/mattermost/no-visible-reply-diagnostic.ts
@@ -3,7 +3,7 @@ import { countOutboundMedia } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type { MattermostReplyDeliveryOutcome } from "./reply-delivery.js";
 
-export type MattermostNoVisibleReplyViolation = {
+type MattermostNoVisibleReplyViolation = {
   reason: "no-visible-reply-after-final-delivery";
   outcome: MattermostReplyDeliveryOutcome;
   finalTextLength: number;

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -35,7 +35,7 @@ import {
 import { loadOutboundMediaFromUrl, type OpenClawConfig } from "./runtime-api.js";
 import { isMattermostId, resolveMattermostOpaqueTarget } from "./target-resolution.js";
 
-export type MattermostSendOpts = {
+type MattermostSendOpts = {
   cfg: OpenClawConfig;
   botToken?: string;
   baseUrl?: string;
@@ -56,7 +56,7 @@ export type MattermostSendOpts = {
   onDmChannelResolution?: (resolution: PromiseLike<unknown>) => void;
 };
 
-export type MattermostSendResult = {
+type MattermostSendResult = {
   messageId: string;
   channelId: string;
   receipt: MessageReceipt;

--- a/extensions/mattermost/src/mattermost/target-resolution.ts
+++ b/extensions/mattermost/src/mattermost/target-resolution.ts
@@ -9,7 +9,7 @@ import {
 } from "./client.js";
 import type { OpenClawConfig } from "./runtime-api.js";
 
-export type MattermostOpaqueTargetResolution = {
+type MattermostOpaqueTargetResolution = {
   kind: "user" | "channel";
   id: string;
   to: string;


### PR DESCRIPTION
## What Problem This Solves

Mattermost still exported ten declaration-only implementation types that have no consumers outside their defining modules. That needlessly widens the plugin's internal TypeScript surface.

## Why This Change Was Made

Repository-wide search and the refreshed codebase-memory graph found no external consumers. The public Mattermost entrypoints export the owning functions, not these declaration names, so the aliases can remain module-local without changing runtime behavior or callable function shapes.

## User Impact

None. This is a dead-export cleanup; Mattermost runtime behavior and public entrypoints are unchanged.

## Evidence

- `OPENCLAW_TESTBOX=1 pnpm check:changed` equivalent on Testbox `tbx_01kx020nmxmy5gvjjqkcwzbp1n`
- `pnpm test:serial extensions/mattermost`: 42 files, 527 tests passed
- `pnpm build`: passed, including declaration generation and plugin SDK export checks
- local autoreview: clean, confidence 0.89
- committed branch autoreview: clean, confidence 0.87
- `git diff --check`: passed
