### PR TITLE
refactor(signal): localize internal declarations

### DIFF
--- a/extensions/signal/src/aliases.ts
+++ b/extensions/signal/src/aliases.ts
@@ -5,15 +5,15 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import { resolveSignalAccount } from "./accounts.js";
 import { looksLikeSignalTargetId, normalizeSignalMessagingTarget } from "./normalize.js";
 
-export type SignalResolvedTargetKind = "user" | "group";
+type SignalResolvedTargetKind = "user" | "group";
 
-export type ResolvedSignalAliasTarget = {
+type ResolvedSignalAliasTarget = {
   to: string;
   kind: SignalResolvedTargetKind;
   alias: string;
 };
 
-export type ResolvedSignalTarget =
+type ResolvedSignalTarget =
   | (ResolvedSignalAliasTarget & { source: "alias" })
   | {
       to: string;

--- a/extensions/signal/src/approval-reactions.ts
+++ b/extensions/signal/src/approval-reactions.ts
@@ -33,7 +33,7 @@ const PERSISTENT_NAMESPACE = "signal.approval-reactions.v2";
 const PERSISTENT_MAX_ENTRIES = 1000;
 const DEFAULT_REACTION_TARGET_TTL_MS = 24 * 60 * 60 * 1000;
 
-export type SignalApprovalReactionBinding = ApprovalReactionDecisionBinding;
+type SignalApprovalReactionBinding = ApprovalReactionDecisionBinding;
 
 type SignalApprovalReactionResolution = {
   approvalId: string;

--- a/extensions/signal/src/client-container.ts
+++ b/extensions/signal/src/client-container.ts
@@ -21,14 +21,14 @@ import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtim
 import { readRegularFile } from "openclaw/plugin-sdk/security-runtime";
 import WebSocket from "ws";
 
-export type ContainerRpcOptions = {
+type ContainerRpcOptions = {
   baseUrl: string;
   timeoutMs?: number;
   maxResponseBytes?: number;
   maxAttachmentBytes?: number;
 };
 
-export type ContainerWebSocketMessage = {
+type ContainerWebSocketMessage = {
   envelope?: {
     syncMessage?: unknown;
     dataMessage?: {

--- a/extensions/signal/src/client.ts
+++ b/extensions/signal/src/client.ts
@@ -12,7 +12,7 @@ export type SignalRpcOptions = {
   maxResponseBytes?: number;
 };
 
-export type SignalRpcError = {
+type SignalRpcError = {
   code?: number;
   message?: string;
   data?: unknown;


### PR DESCRIPTION
## What Problem This Solves

Signal still exported seven declaration-only implementation types that have no consumers outside their defining modules. That unnecessarily widens the plugin's internal TypeScript surface.

## Why This Change Was Made

Repository-wide search and the refreshed codebase-memory graph found no external consumers. Signal's public API and runtime barrels export the owning functions and intentional contract types, not these helper declarations, so they can remain module-local without changing runtime behavior or callable shapes.

## User Impact

None. This is a dead-export cleanup; Signal runtime behavior and public entrypoints are unchanged.

## Evidence

- Changed gates passed on Testbox `tbx_01kx02pxt11qyq0wh0bfhbh8gb`
- `pnpm test:serial extensions/signal`: 31 files, 481 tests passed
- `pnpm build`: passed, including declaration generation and plugin SDK export checks
- local autoreview: clean, confidence 0.87
- committed branch autoreview: clean, confidence 0.91
- `git diff --check`: passed
