### PR TITLE
refactor(slack): localize internal declarations

### DIFF
--- a/extensions/slack/src/channel-type.ts
+++ b/extensions/slack/src/channel-type.ts
@@ -9,7 +9,7 @@ import { createSlackWebClient } from "./client.js";
 import { normalizeAllowListLower } from "./monitor/allow-list.js";
 import type { OpenClawConfig } from "./runtime-api.js";
 
-export type SlackConversationInfo = {
+type SlackConversationInfo = {
   type: "channel" | "group" | "dm" | "unknown";
   user?: string;
 };

--- a/extensions/slack/src/interactive-dispatch.ts
+++ b/extensions/slack/src/interactive-dispatch.ts
@@ -9,7 +9,7 @@ import {
 } from "openclaw/plugin-sdk/plugin-runtime";
 import type { ModalInputSummary } from "./monitor/events/modal-input-summary.js";
 
-export type SlackInteractiveHandlerResult = {
+type SlackInteractiveHandlerResult = {
   handled?: boolean;
   systemEvent?: {
     summary?: string;

--- a/extensions/slack/src/message-sent-hook.ts
+++ b/extensions/slack/src/message-sent-hook.ts
@@ -19,7 +19,7 @@ import {
 } from "openclaw/plugin-sdk/hook-runtime";
 import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 
-export type EmitSlackMessageSentHookParams = {
+type EmitSlackMessageSentHookParams = {
   /** Optional canonical session key. When set, the internal `message:sent` hook fires too. */
   sessionKeyForInternalHooks?: string;
   /** Slack target (channel ID `C…`, DM channel ID `D…`, group `G…`, or user ID `U…`). */

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context-root.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context-root.ts
@@ -1,10 +1,10 @@
 // Slack plugin module implements prepare thread context root behavior.
-export type SlackBotAuthorIdentity = {
+type SlackBotAuthorIdentity = {
   botUserId?: string;
   botId?: string;
 };
 
-export type SlackThreadAuthorTuple = {
+type SlackThreadAuthorTuple = {
   userId?: string;
   botId?: string;
 };
@@ -14,11 +14,11 @@ export type SlackThreadRootCandidate = SlackThreadAuthorTuple & {
   ts?: string;
 };
 
-export type SlackThreadHistoryFilterPolicy = {
+type SlackThreadHistoryFilterPolicy = {
   retainCurrentBotRootTs?: string;
 };
 
-export type SlackThreadHistoryFilterResult<T> = {
+type SlackThreadHistoryFilterResult<T> = {
   kept: T[];
   omittedCurrentBot: number;
 };


### PR DESCRIPTION
## What Problem This Solves

Slack still exported seven declaration-only implementation types that have no consumers outside their defining modules. That unnecessarily widens the plugin's internal TypeScript surface.

## Why This Change Was Made

Repository-wide search and the refreshed codebase-memory graph found no external consumers. Slack's public API exports the intentional interactive contracts and callable functions, not these helper declarations, so they can remain module-local without changing runtime behavior or structural signatures.

## User Impact

None. This is a dead-export cleanup; Slack runtime behavior and public entrypoints are unchanged.

## Evidence

- Changed gates passed on Testbox `tbx_01kx0396e2qq9z2rdthrsm1m8k`
- `pnpm test:serial extensions/slack`: 106 files, 1,476 tests passed
- `pnpm build`: passed, including declaration generation and plugin SDK export checks
- local autoreview: clean, confidence 0.87
- committed branch autoreview: clean, confidence 0.90
- `git diff --check`: passed
