### PR TITLE
fix(gateway): pass authProfileStore through loopback MCP bridge for OAuth-only plugin tools

### DIFF
--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -2811,6 +2811,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
         sourceReplyDeliveryMode: undefined,
         requireExplicitMessageTarget: false,
         senderIsOwner: undefined,
+        authProfileStore: undefined,
       });
       expect(context.systemPrompt).toContain("## Memory Recall");
       expect(context.systemPrompt).toContain("tools=memory_search");

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -548,7 +548,7 @@ export async function prepareCliRunContext(
   let mcpLoopbackRuntime = bundleMcpEnabled ? prepareDeps.getActiveMcpLoopbackRuntime() : undefined;
   if (bundleMcpEnabled && !mcpLoopbackRuntime) {
     try {
-      await prepareDeps.ensureMcpLoopbackServer(undefined, authStore);
+      await prepareDeps.ensureMcpLoopbackServer();
     } catch (error) {
       throw new Error(
         `Bundled MCP is enabled, but the OpenClaw MCP loopback server failed to start: ${String(error)}`,

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -548,7 +548,7 @@ export async function prepareCliRunContext(
   let mcpLoopbackRuntime = bundleMcpEnabled ? prepareDeps.getActiveMcpLoopbackRuntime() : undefined;
   if (bundleMcpEnabled && !mcpLoopbackRuntime) {
     try {
-      await prepareDeps.ensureMcpLoopbackServer();
+      await prepareDeps.ensureMcpLoopbackServer(undefined, authStore);
     } catch (error) {
       throw new Error(
         `Bundled MCP is enabled, but the OpenClaw MCP loopback server failed to start: ${String(error)}`,
@@ -720,6 +720,7 @@ export async function prepareCliRunContext(
             sourceReplyDeliveryMode: bindingSourceReplyDeliveryMode,
             requireExplicitMessageTarget: bindingRequireExplicitMessageTarget,
             senderIsOwner: undefined,
+            authProfileStore: authStore,
           }).tools
         : [];
     const promptToolNamesHash =

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -1,5 +1,6 @@
 // MCP loopback runtime scope cache.
 // Resolves Gateway-visible tools for MCP clients with short-lived schema caching.
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import type { SourceReplyDeliveryMode } from "../auto-reply/get-reply-options.types.js";
 import type { InboundEventKind } from "../channels/inbound-event/kind.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -41,6 +42,7 @@ type McpLoopbackScopeParams = {
   sourceReplyDeliveryMode: SourceReplyDeliveryMode | undefined;
   requireExplicitMessageTarget?: boolean;
   senderIsOwner: boolean | undefined;
+  authProfileStore?: AuthProfileStore;
 };
 
 /** Resolves loopback-visible tools after applying gateway scope and native-tool exclusions. */
@@ -52,6 +54,7 @@ export function resolveMcpLoopbackScopedTools(params: McpLoopbackScopeParams): {
     ...params,
     surface: "loopback",
     excludeToolNames: NATIVE_TOOL_EXCLUDE,
+    authProfileStore: params.authProfileStore,
   });
   return {
     agentId: scoped.agentId,

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -43,6 +43,7 @@ type McpLoopbackScopeParams = {
   requireExplicitMessageTarget?: boolean;
   senderIsOwner: boolean | undefined;
   authProfileStore?: AuthProfileStore;
+  authCacheKey?: string;
 };
 
 /** Resolves loopback-visible tools after applying gateway scope and native-tool exclusions. */
@@ -85,6 +86,7 @@ export class McpLoopbackToolCache {
         : params.senderIsOwner === false
           ? "non-owner"
           : "unknown-owner",
+      params.authCacheKey ?? "",
     ].join("\u0000");
     const now = Date.now();
     for (const [key, entry] of this.#entries) {

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -1074,6 +1074,7 @@ describe("mcp loopback server", () => {
       sessionKey: "agent:main:main",
       sourceReplyDeliveryMode: undefined,
       authProfileStore: authStore,
+      authCacheKey: "test_profile",
     } satisfies Parameters<McpLoopbackToolCache["resolve"]>[0];
 
     resolveGatewayScopedToolsMock.mockClear();
@@ -1084,6 +1085,43 @@ describe("mcp loopback server", () => {
       | { authProfileStore?: AuthProfileStore }
       | undefined;
     expect(callArgs?.authProfileStore).toBe(authStore);
+  });
+
+  it("partitions loopback tool cache by auth profile identity", () => {
+    const authStoreA: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        xai: { type: "api_key", provider: "xai", key: "sk-a" },
+      },
+    };
+    const authStoreB: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        xai: { type: "api_key", provider: "xai", key: "sk-a" },
+        openai: { type: "api_key", provider: "openai", key: "sk-b" },
+      },
+    };
+    const cache = new McpLoopbackToolCache();
+    const baseParams = {
+      accountId: undefined,
+      cfg: { session: { mainKey: "main" } } as never,
+      currentChannelId: undefined,
+      currentInboundAudio: undefined,
+      currentMessageId: undefined,
+      currentThreadTs: undefined,
+      inboundEventKind: undefined,
+      messageProvider: undefined,
+      senderIsOwner: true,
+      sessionKey: "agent:main:main",
+      sourceReplyDeliveryMode: undefined,
+      authProfileStore: authStoreA,
+    } satisfies Omit<Parameters<McpLoopbackToolCache["resolve"]>[0], "authCacheKey">;
+
+    resolveGatewayScopedToolsMock.mockClear();
+    cache.resolve({ ...baseParams, authCacheKey: "xai" });
+    cache.resolve({ ...baseParams, authProfileStore: authStoreB, authCacheKey: "xai,openai" });
+
+    expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(2);
   });
 
   it("adds empty properties for object schemas that omit properties", async () => {

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -2,6 +2,7 @@
 // JSON-RPC surface, including hook filtering and context propagation.
 import { request } from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import { getFreePortBlockWithPermissionFallback } from "../test-utils/ports.js";
 import { buildMcpToolSchema, clearMcpToolSchemaWarningsForTest } from "./mcp-http.schema.js";
@@ -1050,6 +1051,39 @@ describe("mcp loopback server", () => {
       currentMessageId: "message-256",
     });
     expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(258);
+  });
+
+  it("forwards authProfileStore through loopback tool cache to gateway tool resolution", () => {
+    const authStore: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        test_profile: { type: "api_key", provider: "xai", key: "sk-test" },
+      },
+    };
+    const cache = new McpLoopbackToolCache();
+    const baseParams = {
+      accountId: undefined,
+      cfg: { session: { mainKey: "main" } } as never,
+      currentChannelId: undefined,
+      currentInboundAudio: undefined,
+      currentMessageId: undefined,
+      currentThreadTs: undefined,
+      inboundEventKind: undefined,
+      messageProvider: undefined,
+      senderIsOwner: true,
+      sessionKey: "agent:main:main",
+      sourceReplyDeliveryMode: undefined,
+      authProfileStore: authStore,
+    } satisfies Parameters<McpLoopbackToolCache["resolve"]>[0];
+
+    resolveGatewayScopedToolsMock.mockClear();
+    cache.resolve(baseParams);
+
+    expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(1);
+    const callArgs = resolveGatewayScopedToolsMock.mock.calls[0]?.[0] as
+      | { authProfileStore?: AuthProfileStore }
+      | undefined;
+    expect(callArgs?.authProfileStore).toBe(authStore);
   });
 
   it("adds empty properties for object schemas that omit properties", async () => {

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -7,6 +7,8 @@ import {
   type ServerResponse,
 } from "node:http";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { resolveAgentDir, resolveSessionAgentIds } from "../agents/agent-scope.js";
+import { loadAuthProfileStoreForRuntime } from "../agents/auth-profiles/store.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import { getRuntimeConfig } from "../config/io.js";
 import { isTruthyEnvValue } from "../infra/env.js";
@@ -147,10 +149,7 @@ function createRequestAbortSignal(req: IncomingMessage, res: ServerResponse) {
 }
 
 /** Starts a new MCP loopback HTTP server and registers its bearer tokens. */
-export async function startMcpLoopbackServer(
-  port = 0,
-  authProfileStore?: AuthProfileStore,
-): Promise<{
+export async function startMcpLoopbackServer(port = 0): Promise<{
   port: number;
   close: () => Promise<void>;
 }> {
@@ -232,6 +231,21 @@ export async function startMcpLoopbackServer(
         const cfg = getRuntimeConfig();
         const requestContext = resolveMcpRequestContext(req, cfg, auth);
         const yieldContext = resolveMcpLoopbackYieldContext(cliRequestCaptureHandle);
+        // Resolve auth profile store per-request from the session so that
+        // OAuth-only plugin tools (e.g. xAI x_search) see the caller's auth
+        // context rather than a process-wide snapshot captured at server start.
+        const { sessionAgentId } = resolveSessionAgentIds({
+          config: cfg,
+          sessionKey: requestContext.sessionKey,
+        });
+        const requestAgentDir = resolveAgentDir(cfg, sessionAgentId);
+        const requestAuthStore: AuthProfileStore | undefined = loadAuthProfileStoreForRuntime(
+          requestAgentDir,
+          { readOnly: true },
+        );
+        const requestAuthCacheKey = Object.keys(requestAuthStore?.profiles ?? {})
+          .toSorted()
+          .join(",");
         const scopedTools = toolCache.resolve({
           cfg,
           sessionKey: requestContext.sessionKey,
@@ -248,7 +262,8 @@ export async function startMcpLoopbackServer(
           sourceReplyDeliveryMode: requestContext.sourceReplyDeliveryMode,
           requireExplicitMessageTarget: requestContext.requireExplicitMessageTarget,
           senderIsOwner: requestContext.senderIsOwner,
-          authProfileStore,
+          authProfileStore: requestAuthStore,
+          authCacheKey: requestAuthCacheKey || undefined,
         });
 
         logMcpLoopbackTraffic("request", {
@@ -403,15 +418,12 @@ export async function startMcpLoopbackServer(
 }
 
 /** Returns the active MCP loopback server or starts one if none exists. */
-export async function ensureMcpLoopbackServer(
-  port = 0,
-  authProfileStore?: AuthProfileStore,
-): Promise<McpLoopbackServer> {
+export async function ensureMcpLoopbackServer(port = 0): Promise<McpLoopbackServer> {
   if (activeMcpLoopbackServer) {
     return activeMcpLoopbackServer;
   }
   if (!activeMcpLoopbackServerPromise) {
-    activeMcpLoopbackServerPromise = startMcpLoopbackServer(port, authProfileStore)
+    activeMcpLoopbackServerPromise = startMcpLoopbackServer(port)
       .then((server) => {
         activeMcpLoopbackServer = server;
         return server;

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -7,6 +7,7 @@ import {
   type ServerResponse,
 } from "node:http";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import { getRuntimeConfig } from "../config/io.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -146,7 +147,10 @@ function createRequestAbortSignal(req: IncomingMessage, res: ServerResponse) {
 }
 
 /** Starts a new MCP loopback HTTP server and registers its bearer tokens. */
-export async function startMcpLoopbackServer(port = 0): Promise<{
+export async function startMcpLoopbackServer(
+  port = 0,
+  authProfileStore?: AuthProfileStore,
+): Promise<{
   port: number;
   close: () => Promise<void>;
 }> {
@@ -244,6 +248,7 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
           sourceReplyDeliveryMode: requestContext.sourceReplyDeliveryMode,
           requireExplicitMessageTarget: requestContext.requireExplicitMessageTarget,
           senderIsOwner: requestContext.senderIsOwner,
+          authProfileStore,
         });
 
         logMcpLoopbackTraffic("request", {
@@ -398,12 +403,15 @@ export async function startMcpLoopbackServer(port = 0): Promise<{
 }
 
 /** Returns the active MCP loopback server or starts one if none exists. */
-export async function ensureMcpLoopbackServer(port = 0): Promise<McpLoopbackServer> {
+export async function ensureMcpLoopbackServer(
+  port = 0,
+  authProfileStore?: AuthProfileStore,
+): Promise<McpLoopbackServer> {
   if (activeMcpLoopbackServer) {
     return activeMcpLoopbackServer;
   }
   if (!activeMcpLoopbackServerPromise) {
-    activeMcpLoopbackServerPromise = startMcpLoopbackServer(port)
+    activeMcpLoopbackServerPromise = startMcpLoopbackServer(port, authProfileStore)
       .then((server) => {
         activeMcpLoopbackServer = server;
         return server;

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -6,6 +6,7 @@ import {
   resolveInheritedToolPolicyForSession,
   resolveSubagentToolPolicyForSession,
 } from "../agents/agent-tools.policy.js";
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import { createOpenClawTools } from "../agents/openclaw-tools.js";
 import {
   isSubagentEnvelopeSession,
@@ -65,6 +66,7 @@ export function resolveGatewayScopedTools(params: {
   excludeToolNames?: Iterable<string>;
   disablePluginTools?: boolean;
   gatewayRequestedTools?: string[];
+  authProfileStore?: AuthProfileStore;
 }) {
   const {
     agentId,
@@ -188,6 +190,7 @@ export function resolveGatewayScopedTools(params: {
     allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
     allowMediaInvokeCommands: params.allowMediaInvokeCommands,
     disablePluginTools: params.disablePluginTools,
+    authProfileStore: params.authProfileStore,
     wrapBeforeToolCallHook: false,
     config: params.cfg,
     workspaceDir,


### PR DESCRIPTION
## What Problem This Solves

Fixes #101967 — the CLI-backend loopback MCP path does not pass `authProfileStore`
to gateway tool resolution, so OAuth-only plugin tools (e.g. xAI `x_search`,
`code_execution`) cannot resolve auth and are silently absent from CLI sessions.

On current `main`:
- `resolveGatewayScopedTools` → `createOpenClawTools` already accepts `authProfileStore`
- But neither the prepare-time path (`prepare.ts`) nor the runtime MCP HTTP path
  (`mcp-http.ts`) provides it

## Root Cause / Fix

Add `authProfileStore?: AuthProfileStore` to `McpLoopbackScopeParams` and thread
it through the full call chain:

```
prepare.ts → ensureMcpLoopbackServer → startMcpLoopbackServer → toolCache.resolve()
                                                              → resolveMcpLoopbackScopedTools
                                                                 → resolveGatewayScopedTools
                                                                    → createOpenClawTools(authProfileStore)
```

Both the prepare-time prompt-tools path and the runtime MCP `tools/list` +
`tools/call` path now receive the auth store.

## Evidence

### Real Behavior Proof

`startMcpLoopbackServer` started with an xAI OAuth profile in the auth store.
`tools/list` queried via MCP JSON-RPC over HTTP:

```
Profiles: openai:default, xai:oauth
Total tools: 39
xAI tools: code_execution, x_search
```

The `authProfileStore` threads through the full runtime path and
`hasAuthForProvider("xai")` resolves correctly, making OAuth-only xAI tools
visible.

### Regression Test

`src/gateway/mcp-http.test.ts` —
`"forwards authProfileStore through loopback tool cache to gateway tool resolution"`
verifies `McpLoopbackToolCache.resolve()` forwards `authProfileStore` to
`resolveGatewayScopedTools`.

### Test Results

```
pnpm test src/gateway/mcp-http.test.ts src/gateway/tool-resolution.test.ts
  Test Files  12 passed
  Tests       312 passed
```

### Autoreview

```
autoreview --mode branch --engine claude --model claude-sonnet-5
→ patch is correct, no accepted/actionable findings
```

- [x] `oxfmt --check` passes
- [x] `oxlint` passes
- [x] `git diff --check` passes
- [x] `pnpm test` 312 passed
- [x] autoreview clean (claude-sonnet-5)