### PR TITLE
fix: expose model fallback transitions in diagnostics

### DIFF
--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -4,6 +4,11 @@ import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { TranscriptNotContinuableError } from "../../packages/agent-core/src/errors.js";
 import type { OpenClawConfig } from "../config/config.js";
+import {
+  onTrustedInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  type DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { createWarnLogCapture } from "../logging/test-helpers/warn-log-capture.js";
 import {
@@ -213,6 +218,7 @@ function resetModelFallbackTestState(): void {
   providerModelNormalizationMock.normalizeProviderModelIdWithRuntime
     .mockReset()
     .mockReturnValue(undefined);
+  resetDiagnosticEventsForTest();
 }
 
 function setDefaultPluginMetadataSnapshot(): void {
@@ -561,6 +567,65 @@ const INSUFFICIENT_QUOTA_PAYLOAD =
   '{"type":"error","error":{"type":"insufficient_quota","message":"Your account has insufficient quota balance to run this request."}}';
 
 describe("runWithModelFallback", () => {
+  it("emits model failover diagnostics for ordinary fallback transitions", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.4",
+            fallbacks: ["anthropic/claude-sonnet-4-6"],
+          },
+        },
+      },
+    });
+    const failoverEvents: Array<Extract<DiagnosticEventPayload, { type: "model.failover" }>> = [];
+    const unsubscribe = onTrustedInternalDiagnosticEvent((event) => {
+      if (event.type === "model.failover") {
+        failoverEvents.push(event);
+      }
+    });
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new FailoverError("primary rate limited", {
+          provider: "openai",
+          model: "gpt-5.4",
+          reason: "rate_limit",
+        }),
+      )
+      .mockResolvedValueOnce("ok");
+
+    try {
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-5.4",
+        sessionId: "session:failover-diagnostics",
+        sessionKey: "agent:test:failover-diagnostics",
+        lane: "main",
+        run,
+      });
+
+      expect(result.result).toBe("ok");
+      expect(failoverEvents).toHaveLength(1);
+      expect(failoverEvents[0]).toMatchObject({
+        type: "model.failover",
+        sessionId: "session:failover-diagnostics",
+        sessionKey: "agent:test:failover-diagnostics",
+        lane: "main",
+        fromProvider: "openai",
+        fromModel: "gpt-5.4",
+        toProvider: "anthropic",
+        toModel: "claude-sonnet-4-6",
+        reason: "rate_limit",
+        cascadeDepth: 1,
+        suspended: false,
+      });
+    } finally {
+      unsubscribe();
+    }
+  });
+
   it("uses the opt-in auth skip cache on the second turn for the same session", async () => {
     const previous = process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS;
     process.env.OPENCLAW_FALLBACK_SKIP_TTL_MS = "60000";

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -1875,6 +1875,21 @@ async function runWithModelFallbackInternal<T>(
       }
 
       lastError = isKnownFailover ? normalized : err;
+      const nextCandidate = candidates[i + 1];
+      if (nextCandidate) {
+        emitFailoverEvent({
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          lane: params.lane,
+          fromProvider: candidate.provider,
+          fromModel: candidate.model,
+          toProvider: nextCandidate.provider,
+          toModel: nextCandidate.model,
+          reason: isKnownFailover ? normalized.reason : "unknown",
+          cascadeDepth: i + 1,
+          suspended: false,
+        });
+      }
       await observeFailedCandidate({
         attempts,
         candidate,
@@ -1886,7 +1901,7 @@ async function runWithModelFallbackInternal<T>(
         requestedModel: params.model,
         attempt: i + 1,
         total: candidates.length,
-        nextCandidate: candidates[i + 1],
+        nextCandidate,
         isPrimary,
         requestedModelMatched: requestedModel,
         fallbackConfigured: hasFallbackCandidates,


### PR DESCRIPTION
Closes #102015

## What Problem This Solves

Fixes an issue where operators inspecting telemetry for model fallback chains would not see ordinary model-to-model fallback transitions, making retry storms and degraded-provider cascades invisible outside trajectory records.

## Why This Change Was Made

The existing `model.failover` diagnostic/exporter contract already represents fallback source, destination, reason, suspension state, and cascade depth. This change emits that existing trusted diagnostic event when a candidate fails and OpenClaw continues to the next configured model, while leaving fallback selection, retry policy, backoff, and circuit-breaking behavior unchanged.

Provenance: the existing failover diagnostic event was introduced by 029ca8c268 in the state-aware failover/lane-suspension work, but current main only emitted it from the cooldown suspension branch; ordinary candidate failure to next candidate only reached `model.fallback_step` trajectory recording.

## User Impact

Operators can now observe normal fallback chains through the diagnostics pipeline. Existing OTel and Prometheus exporters receive the already-supported `model.failover` event with from/to provider and model attributes, reason, `suspended=false`, and cascade depth for each transition.

AI-assisted: implemented with Codex; no local transcript is included in this PR body.

## Evidence

- `node scripts/run-vitest.mjs src/agents/model-fallback.test.ts` - 116 tests passed.
- `node scripts/run-vitest.mjs extensions/diagnostics-otel/src/service.test.ts extensions/diagnostics-prometheus/src/service.test.ts` - OTel and Prometheus diagnostics exporter contract tests passed.
- `node scripts/run-vitest.mjs src/agents/model-fallback.test.ts extensions/diagnostics-otel/src/service.test.ts extensions/diagnostics-prometheus/src/service.test.ts` - combined rerun passed after formatting.
- `pnpm format:check -- src/agents/model-fallback.ts src/agents/model-fallback.test.ts` - formatting passed.
- `git diff --check` - whitespace check passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` - clean, no accepted/actionable findings.
