### PR TITLE
fix(acp): guard child process pipe stream errors in createAcpClient

### DIFF
--- a/src/acp/client.stream-errors.test.ts
+++ b/src/acp/client.stream-errors.test.ts
@@ -58,7 +58,6 @@ vi.mock("./client-helpers.js", () => ({
   shouldStripProviderAuthEnvVarsForAcpServer: mocks.shouldStripProviderAuthEnvVarsForAcpServer,
 }));
 
-let sdkInitResolve: () => void;
 let sdkInitReject: (e: Error) => void;
 
 vi.mock("@agentclientprotocol/sdk", () => {

--- a/src/acp/client.stream-errors.test.ts
+++ b/src/acp/client.stream-errors.test.ts
@@ -66,7 +66,7 @@ vi.mock("@agentclientprotocol/sdk", () => {
       initialize: vi.fn(
         () =>
           new Promise<void>((resolve, reject) => {
-            sdkInitResolve = resolve;
+            void resolve;
             sdkInitReject = reject;
           }),
       ),

--- a/src/acp/client.stream-errors.test.ts
+++ b/src/acp/client.stream-errors.test.ts
@@ -1,0 +1,67 @@
+// ACP client stream error tests verify that the error handlers registered
+// on the spawned child process pipes prevent unhandled stream errors from
+// crashing the host Node process.
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { describe, expect, it } from "vitest";
+
+describe("ACP client stream error handlers", () => {
+  it.each(["stdout", "stdin"] as const)(
+    "bug: PassThrough emits unhandled error → process crash",
+    (stream) => {
+      // Negative control: without a registered 'error' listener, a
+      // PassThrough stream throws on emit("error", ...). This is the
+      // Node.js behavior that createAcpClient must guard against.
+      const raw = new PassThrough();
+      expect(() => {
+        raw.emit("error", new Error(`${stream} EPIPE`));
+      }).toThrow();
+    },
+  );
+
+  it.each(["stdout", "stdin"] as const)(
+    "fix: registered error listener on %s prevents crash",
+    (stream) => {
+      // The production code (createAcpClient ~line 155) registers:
+      //   agent.stdout.on("error", onStreamError);
+      //   agent.stdin.on("error", onStreamError);
+      //   agent.on("error", onStreamError);
+      // This test proves that registering an error listener prevents
+      // the throw that would otherwise crash the process.
+      const s = new PassThrough();
+      s.on("error", () => {});
+      expect(() => {
+        s.emit("error", new Error(`${stream} EPIPE`));
+      }).not.toThrow();
+    },
+  );
+
+  it("fix: process error listener prevents crash", () => {
+    // agent.on("error", ...) guards spawn-level ENOENT etc.
+    const p = new EventEmitter();
+    p.on("error", () => {});
+    expect(() => {
+      p.emit("error", new Error("spawn ENOENT"));
+    }).not.toThrow();
+  });
+
+  it("handles simultaneous stdout+stdin errors", () => {
+    const out = new PassThrough();
+    const inp = new PassThrough();
+    out.on("error", () => {});
+    inp.on("error", () => {});
+    expect(() => {
+      out.emit("error", new Error("stdout first"));
+      inp.emit("error", new Error("stdin second"));
+    }).not.toThrow();
+  });
+
+  it("handles late error after stream closed", () => {
+    const out = new PassThrough();
+    out.on("error", () => {});
+    out.destroy();
+    expect(() => {
+      out.emit("error", new Error("write after end"));
+    }).not.toThrow();
+  });
+});

--- a/src/acp/client.stream-errors.test.ts
+++ b/src/acp/client.stream-errors.test.ts
@@ -1,67 +1,166 @@
-// ACP client stream error tests verify that the error handlers registered
-// on the spawned child process pipes prevent unhandled stream errors from
-// crashing the host Node process.
+// ACP client stream error tests — verify that createAcpClient registers
+// error handlers on the spawned child process pipes. The tests call the
+// production function and prove the handlers exist by emitting errors
+// that would otherwise crash the process.
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-describe("ACP client stream error handlers", () => {
-  it.each(["stdout", "stdin"] as const)(
-    "bug: PassThrough emits unhandled error → process crash",
-    (stream) => {
-      // Negative control: without a registered 'error' listener, a
-      // PassThrough stream throws on emit("error", ...). This is the
-      // Node.js behavior that createAcpClient must guard against.
-      const raw = new PassThrough();
-      expect(() => {
-        raw.emit("error", new Error(`${stream} EPIPE`));
-      }).toThrow();
-    },
-  );
+type MockChild = ReturnType<typeof createChild>;
 
-  it.each(["stdout", "stdin"] as const)(
-    "fix: registered error listener on %s prevents crash",
-    (stream) => {
-      // The production code (createAcpClient ~line 155) registers:
-      //   agent.stdout.on("error", onStreamError);
-      //   agent.stdin.on("error", onStreamError);
-      //   agent.on("error", onStreamError);
-      // This test proves that registering an error listener prevents
-      // the throw that would otherwise crash the process.
-      const s = new PassThrough();
-      s.on("error", () => {});
-      expect(() => {
-        s.emit("error", new Error(`${stream} EPIPE`));
-      }).not.toThrow();
-    },
-  );
+function createChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdin: PassThrough;
+    stdout: PassThrough;
+    stderr: PassThrough;
+    pid: number;
+    killed: boolean;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.pid = 12345;
+  child.killed = false;
+  child.kill = vi.fn(() => {
+    child.killed = true;
+    return true;
+  });
+  return child;
+}
 
-  it("fix: process error listener prevents crash", () => {
-    // agent.on("error", ...) guards spawn-level ENOENT etc.
-    const p = new EventEmitter();
-    p.on("error", () => {});
-    expect(() => {
-      p.emit("error", new Error("spawn ENOENT"));
-    }).not.toThrow();
+let child: MockChild;
+
+const mocks = vi.hoisted(() => ({
+  spawn: vi.fn(() => child),
+  ensureOpenClawCliOnPath: vi.fn(),
+  getActiveSkillEnvKeys: vi.fn(() => []),
+  buildAcpClientStripKeys: vi.fn(() => []),
+  resolveAcpClientSpawnEnv: vi.fn(() => ({ OPENCLAW_ACP: "1" })),
+  resolveAcpClientSpawnInvocation: vi.fn(() => ({
+    command: "/usr/bin/env",
+    args: ["openclaw", "acp"],
+    shell: false,
+    windowsHide: true,
+  })),
+  shouldStripProviderAuthEnvVarsForAcpServer: vi.fn(() => false),
+}));
+
+vi.mock("node:child_process", () => ({ spawn: mocks.spawn }));
+vi.mock("../infra/path-env.js", () => ({ ensureOpenClawCliOnPath: mocks.ensureOpenClawCliOnPath }));
+vi.mock("../skills/runtime/env-overrides.runtime.js", () => ({
+  getActiveSkillEnvKeys: mocks.getActiveSkillEnvKeys,
+}));
+vi.mock("./client-helpers.js", () => ({
+  buildAcpClientStripKeys: mocks.buildAcpClientStripKeys,
+  resolveAcpClientSpawnEnv: mocks.resolveAcpClientSpawnEnv,
+  resolveAcpClientSpawnInvocation: mocks.resolveAcpClientSpawnInvocation,
+  shouldStripProviderAuthEnvVarsForAcpServer: mocks.shouldStripProviderAuthEnvVarsForAcpServer,
+}));
+
+let sdkInitResolve: () => void;
+let sdkInitReject: (e: Error) => void;
+
+vi.mock("@agentclientprotocol/sdk", () => {
+  function MockClientSideConnection() {
+    return {
+      initialize: vi.fn(
+        () =>
+          new Promise<void>((resolve, reject) => {
+            sdkInitResolve = resolve;
+            sdkInitReject = reject;
+          }),
+      ),
+      newSession: vi.fn(async () => ({ sessionId: "test" })),
+    };
+  }
+  return {
+    ClientSideConnection: MockClientSideConnection,
+    PROTOCOL_VERSION: 1,
+    ndJsonStream: vi.fn(() => ({})),
+  };
+});
+
+type ClientModule = typeof import("./client.js");
+let createAcpClient: ClientModule["testing"]["createAcpClient"];
+
+describe("ACP client stream errors (production path)", () => {
+  beforeAll(async () => {
+    ({
+      testing: { createAcpClient },
+    } = await import("./client.js"));
   });
 
-  it("handles simultaneous stdout+stdin errors", () => {
-    const out = new PassThrough();
-    const inp = new PassThrough();
-    out.on("error", () => {});
-    inp.on("error", () => {});
-    expect(() => {
-      out.emit("error", new Error("stdout first"));
-      inp.emit("error", new Error("stdin second"));
-    }).not.toThrow();
+  beforeEach(() => {
+    child = createChild();
+    vi.clearAllMocks();
   });
 
-  it("handles late error after stream closed", () => {
-    const out = new PassThrough();
-    out.on("error", () => {});
-    out.destroy();
+  afterEach(() => {
+    // Clean up hanging promise
+    try {
+      sdkInitReject(new Error("cleanup"));
+    } catch {}
+    vi.clearAllMocks();
+  });
+
+  it("registers error handler on stdout through createAcpClient", async () => {
+    const promise = createAcpClient({ cwd: "/tmp", serverCommand: "echo" });
+    await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalledOnce());
+    // Production code registered agent.stdout.on("error", ...) — emitting must not crash.
     expect(() => {
-      out.emit("error", new Error("write after end"));
+      child.stdout.emit("error", new Error("stdout EPIPE"));
     }).not.toThrow();
+    sdkInitReject(new Error("cleanup"));
+    try {
+      await promise;
+    } catch {}
+  });
+
+  it("registers error handler on stdin through createAcpClient", async () => {
+    const promise = createAcpClient({ cwd: "/tmp", serverCommand: "echo" });
+    await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalledOnce());
+    expect(() => {
+      child.stdin.emit("error", new Error("stdin EPIPE"));
+    }).not.toThrow();
+    sdkInitReject(new Error("cleanup"));
+    try {
+      await promise;
+    } catch {}
+  });
+
+  it("registers error handler on child process through createAcpClient", async () => {
+    const promise = createAcpClient({ cwd: "/tmp", serverCommand: "echo" });
+    await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalledOnce());
+    expect(() => {
+      child.emit("error", new Error("spawn ENOENT"));
+    }).not.toThrow();
+    sdkInitReject(new Error("cleanup"));
+    try {
+      await promise;
+    } catch {}
+  });
+
+  it("handles simultaneous stdout+stdin errors through createAcpClient", async () => {
+    const promise = createAcpClient({ cwd: "/tmp", serverCommand: "echo" });
+    await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalledOnce());
+    expect(() => {
+      child.stdout.emit("error", new Error("stdout first"));
+      child.stdin.emit("error", new Error("stdin second"));
+    }).not.toThrow();
+    sdkInitReject(new Error("cleanup"));
+    try {
+      await promise;
+    } catch {}
+  });
+
+  // Negative control: without error listener, PassThrough throws.
+  // Removing the production handlers would make this test pass —
+  // but then createAcpClient would crash on a real EPIPE.
+  it("negative control: PassThrough without error listener throws", () => {
+    const raw = new PassThrough();
+    expect(() => {
+      raw.emit("error", new Error("unhandled EPIPE"));
+    }).toThrow();
   });
 });

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -151,6 +151,17 @@ async function createAcpClient(opts: AcpClientOptions = {}): Promise<AcpClientHa
     throw new Error("Failed to create ACP stdio pipes");
   }
 
+  // Guard pipe streams so a mid-session stream error (e.g. EPIPE when the
+  // child exits unexpectedly) does not crash the host process.
+  const onStreamError = (label: string, err: Error) => {
+    if (verbose) {
+      console.error(`[acp-client] stream error on ${label}:`, err.message);
+    }
+  };
+  agent.stdout.on("error", (err) => onStreamError("stdout", err));
+  agent.stdin.on("error", (err) => onStreamError("stdin", err));
+  agent.on("error", (err) => onStreamError("spawn", err));
+
   const input = Writable.toWeb(agent.stdin);
   const output = Readable.toWeb(agent.stdout) as unknown as ReadableStream<Uint8Array>;
   const stream = ndJsonStream(input, output);

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -251,3 +251,8 @@ export async function runAcpClientInteractive(opts: AcpClientOptions = {}): Prom
     process.exit(code ?? 0);
   });
 }
+
+// Exported for testing only.
+export const testing = {
+  createAcpClient,
+} as const;


### PR DESCRIPTION
## What Problem This Solves

`createAcpClient` spawns an ACP server with `stdio: ["pipe", "pipe", "inherit"]` but registered no `error` listeners on the child stdout, stdin, or process. An EPIPE or stream error on either pipe would trigger an unhandled `error` event, crashing the host Node process.

## Why This Change Was Made

Added three `on("error")` handlers in `createAcpClient`:
- `agent.stdout.on("error", …)` — stdout read pipe
- `agent.stdin.on("error", …)` — stdin write pipe
- `agent.on("error", …)` — spawn-level failures

Same pattern as grep.ts (#101014), find.ts, bash tool, ssh sandbox. Exported `createAcpClient` via a `testing` namespace (#101749 conventions) so production-path tests can exercise the handlers.

## User Impact

No behavioral change for normal ACP sessions. Stream errors now log to stderr (in verbose mode) instead of crashing the gateway.

## Evidence

### Real process proof — spawned child processes, triggered EPIPE, host survived

```
$ node outputs/issue-102047/live-acp-proof.mjs

Test 1: Kill child → EPIPE on pipe (WITH handler, matches client.ts:155-159)
  Process survived — no crash. ✓

Test 2: Simultaneous stdout+stdin EPIPE → both caught
  [stdout] stdout EPIPE
  [stdin] stdin EPIPE
  Both caught (2), process survived. ✓

Test 3: Process-level error (ENOENT) → caught, no crash
  [process] spawn /nonexistent/binary ENOENT
  ENOENT caught: true, host survived. ✓

All 3 live tests passed
```

Without the error handlers from this PR, each test would crash the Node process with `Unhandled 'error' event`.

### Production-path tests — calls createAcpClient, emits errors on its pipes

```
 ✓ registers error handler on stdout through createAcpClient
 ✓ registers error handler on stdin through createAcpClient
 ✓ registers error handler on child process through createAcpClient
 ✓ handles simultaneous stdout+stdin errors through createAcpClient
 ✓ negative control: PassThrough without error listener throws

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

### Production handler locations

```
src/acp/client.ts:157:  agent.stdout.on("error", (err) => onStreamError("stdout", err));
src/acp/client.ts:158:  agent.stdin.on("error", (err) => onStreamError("stdin", err));
src/acp/client.ts:159:  agent.on("error", (err) => onStreamError("spawn", err));
```

AI-assisted: built with Codex