### PR TITLE
refactor(qqbot): localize internal declarations

### DIFF
--- a/extensions/qqbot/src/engine/adapter/mention-gate.port.ts
+++ b/extensions/qqbot/src/engine/adapter/mention-gate.port.ts
@@ -11,7 +11,7 @@
 type ImplicitMentionKind = "reply_to_bot" | "quoted_bot" | "bot_thread_participant" | "native";
 
 /** Facts about the current message's mention state. */
-export interface MentionFacts {
+interface MentionFacts {
   canDetectMention: boolean;
   wasMentioned: boolean;
   hasAnyMention?: boolean;
@@ -19,7 +19,7 @@ export interface MentionFacts {
 }
 
 /** Policy configuration for the mention gate. */
-export interface MentionPolicy {
+interface MentionPolicy {
   isGroup: boolean;
   requireMention: boolean;
   allowTextCommands: boolean;
@@ -28,7 +28,7 @@ export interface MentionPolicy {
 }
 
 /** Result of the mention gate evaluation. */
-export interface MentionGateDecision {
+interface MentionGateDecision {
   effectiveWasMentioned: boolean;
   shouldSkip: boolean;
   shouldBypassMention: boolean;

--- a/extensions/qqbot/src/engine/commands/command-visibility.ts
+++ b/extensions/qqbot/src/engine/commands/command-visibility.ts
@@ -1,7 +1,7 @@
 // Qqbot plugin module classifies slash-command visibility for QQ group chats.
 import type { QQBotGroupCommandLevel } from "../config/group.js";
 
-export type GroupCommandVisibility = "group" | "hidden" | "private" | "unknown";
+type GroupCommandVisibility = "group" | "hidden" | "private" | "unknown";
 
 export const PRIVATE_CHAT_ONLY_TEXT = "该命令仅限私聊使用，请在私聊中发送。";
 

--- a/extensions/qqbot/src/engine/gateway/active-cfg.ts
+++ b/extensions/qqbot/src/engine/gateway/active-cfg.ts
@@ -15,11 +15,11 @@ import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
 
 export type GatewayCfgLoader = () => OpenClawConfig;
 
-export interface ActiveCfgProvider {
+interface ActiveCfgProvider {
   getActiveCfg(): OpenClawConfig;
 }
 
-export interface ActiveCfgProviderOptions {
+interface ActiveCfgProviderOptions {
   fallback: OpenClawConfig;
   load?: GatewayCfgLoader;
 }

--- a/extensions/qqbot/src/engine/gateway/ws-client.ts
+++ b/extensions/qqbot/src/engine/gateway/ws-client.ts
@@ -3,7 +3,7 @@ import type { Agent } from "node:http";
 import { resolveAmbientNodeProxyAgent } from "openclaw/plugin-sdk/extension-shared";
 import WebSocket from "ws";
 
-export interface QQWSClientOptions {
+interface QQWSClientOptions {
   gatewayUrl: string;
   userAgent: string;
 }

--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
@@ -16,7 +16,7 @@ type ActiveFence = {
   marker: string;
 };
 
-export type QQBotMarkdownChunker = {
+type QQBotMarkdownChunker = {
   chunkText: (text: string, limit: number) => string[];
   flushPendingText: (limit: number) => string[];
 };

--- a/extensions/qqbot/src/types.ts
+++ b/extensions/qqbot/src/types.ts
@@ -37,7 +37,7 @@ export interface QQBotExecApprovalConfig {
   target?: "dm" | "channel" | "both";
 }
 
-export interface QQBotGroupConfig {
+interface QQBotGroupConfig {
   requireMention?: boolean;
   commandLevel?: QQBotGroupCommandLevel;
   ignoreOtherMentions?: boolean;


### PR DESCRIPTION
## What Problem This Solves

QQBot still exported nine declaration-only implementation types that have no consumers outside their defining modules. That unnecessarily widens the plugin's internal TypeScript surface.

## Why This Change Was Made

Repository-wide search and the refreshed codebase-memory graph found no external consumers. QQBot's public API exports the intentional account/config contracts and callable functions, not these helper declarations, so they can remain module-local without changing runtime behavior or structural signatures.

## User Impact

None. This is a dead-export cleanup; QQBot runtime behavior and public entrypoints are unchanged.

## Evidence

- Changed gates passed on Testbox `tbx_01kx04ehb2dsm7mh9v56x13s7x`
- Six directly touched QQBot test files: 67 tests passed
- Broad QQBot suite: 73 files and 669 tests passed; one unrelated existing failure in `engine/approval/index.test.ts`
- The same approval test fails with the six PR files restored from exact base `8cbcc41ccbb93f9143f58c86b39b0c35c20fa504`, proving it is present on current `main`
- `pnpm build`: passed, including declaration generation and plugin SDK export checks
- fresh post-rebase branch autoreview: clean, confidence 0.85
- `git diff --check`: passed
