### PR TITLE
fix(tools): do not mark exact-size web_fetch responses as truncated (#101837)

### DIFF
--- a/src/agents/tools/web-shared.test.ts
+++ b/src/agents/tools/web-shared.test.ts
@@ -190,4 +190,23 @@ describe("readResponseText", () => {
     });
     expect(text).toHaveBeenCalledTimes(1);
   });
+
+  it("does not mark exact-size responses as truncated", async () => {
+    const cancel = vi.fn(async () => undefined);
+    const releaseLock = vi.fn();
+    // Chunk is exactly maxBytes — should not be truncated
+    const response = responseFromReader({
+      chunks: ["hello"],
+      cancel,
+      releaseLock,
+    });
+
+    await expect(readResponseText(response, { maxBytes: 5 })).resolves.toEqual({
+      text: "hello",
+      truncated: false,
+      bytesRead: 5,
+    });
+    expect(cancel).not.toHaveBeenCalled();
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -272,8 +272,7 @@ export async function readResponseText(
         bytesRead += chunk.byteLength;
         parts.push(chunk);
 
-        if (truncated || bytesRead >= maxBytes) {
-          truncated = true;
+        if (truncated) {
           break;
         }
       }


### PR DESCRIPTION
## What Problem This Solves

web_fetch reports responses as truncated when the streamed body is exactly maxResponseBytes bytes, even though no bytes were omitted. The `readResponseText` helper breaks with `truncated: true` when `bytesRead >= maxBytes`, treating exact-size responses the same as oversized ones.

## Why This Change Was Made

The break condition at web-shared.ts:275 was `truncated || bytesRead >= maxBytes`, which unconditionally set `truncated = true` when `bytesRead` hit the limit exactly. The fix removes the `bytesRead >= maxBytes` early-break, letting the loop continue naturally. If the response has more data, the chunk-trimming logic at line 262 will detect the overflow and set `truncated = true`. If the stream ends at exactly maxBytes, the `done` check at line 254 will break the loop with `truncated` still false.

## User Impact

- Responses that are exactly maxResponseBytes are now returned as complete (truncated: false)
- No misleading truncation warnings in web_fetch output
- No change for responses that genuinely exceed the limit

## Evidence

- 12/12 tests pass in web-shared.test.ts (including new regression test)
- Format clean (oxfmt)

Fixes #101837
