### PR TITLE
fix(telemetry): record session.ended trajectory event after flush, not inline with model.completed

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -5952,12 +5952,6 @@ export async function runEmbeddedAttempt(
         yieldDetected: yieldDetected || undefined,
       };
     } finally {
-      await flushEmbeddedAttemptTrajectoryRecorder({
-        runId: params.runId,
-        sessionId: params.sessionId,
-        log,
-        trajectoryRecorder,
-      });
       // Always tear down the session (and release the lock) before we leave this attempt.
       //
       // BUGFIX: Wait for the agent to be truly idle before flushing pending tool results.
@@ -6065,6 +6059,14 @@ export async function runEmbeddedAttempt(
         });
         trajectoryEndRecorded = true;
       }
+      // Flush after the final events so session.cleanup_completed and
+      // session.ended are persisted in the trajectory sidecar before export.
+      await flushEmbeddedAttemptTrajectoryRecorder({
+        runId: params.runId,
+        sessionId: params.sessionId,
+        log,
+        trajectoryRecorder,
+      });
     }
   } finally {
     removeExternalAbortSignalListener?.();

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -5997,6 +5997,33 @@ export async function runEmbeddedAttempt(
       } catch (err) {
         cleanupError = err;
       }
+      // Record final trajectory events and flush before any rethrow so
+      // cleanup failures do not leave the session trajectory incomplete.
+      // See: https://github.com/openclaw/openclaw/issues/102014
+      if (trajectoryRecorder && !trajectoryEndRecorded) {
+        trajectoryRecorder.recordEvent("session.cleanup_completed");
+        trajectoryRecorder.recordEvent("session.ended", {
+          status:
+            trajectoryTerminalStatus ??
+            (promptError ? "error" : aborted || timedOut ? "interrupted" : "cleanup"),
+          aborted,
+          externalAbort,
+          timedOut,
+          idleTimedOut,
+          timedOutDuringCompaction,
+          timedOutDuringToolExecution,
+          timedOutByRunBudget,
+          promptError: promptError ? formatErrorMessage(promptError) : undefined,
+          terminalError: trajectoryTerminalError,
+        });
+        trajectoryEndRecorded = true;
+      }
+      await flushEmbeddedAttemptTrajectoryRecorder({
+        runId: params.runId,
+        sessionId: params.sessionId,
+        log,
+        trajectoryRecorder,
+      });
       const synthesizedCleanupTakeoverError =
         !cleanupError && promptError && sessionLockController.hasSessionTakeover()
           ? new EmbeddedAttemptSessionTakeoverError(params.sessionFile)
@@ -6038,35 +6065,6 @@ export async function runEmbeddedAttempt(
           await Promise.reject(toErrorObject(cleanupFailure, "Non-Error rejection"));
         }
       }
-      // Record session.ended after cleanup completes so the timestamp reflects
-      // actual session end including teardown and state persistence.
-      // See: https://github.com/openclaw/openclaw/issues/102014
-      if (trajectoryRecorder && !trajectoryEndRecorded) {
-        trajectoryRecorder.recordEvent("session.cleanup_completed");
-        trajectoryRecorder.recordEvent("session.ended", {
-          status:
-            trajectoryTerminalStatus ??
-            (promptError ? "error" : aborted || timedOut ? "interrupted" : "cleanup"),
-          aborted,
-          externalAbort,
-          timedOut,
-          idleTimedOut,
-          timedOutDuringCompaction,
-          timedOutDuringToolExecution,
-          timedOutByRunBudget,
-          promptError: promptError ? formatErrorMessage(promptError) : undefined,
-          terminalError: trajectoryTerminalError,
-        });
-        trajectoryEndRecorded = true;
-      }
-      // Flush after the final events so session.cleanup_completed and
-      // session.ended are persisted in the trajectory sidecar before export.
-      await flushEmbeddedAttemptTrajectoryRecorder({
-        runId: params.runId,
-        sessionId: params.sessionId,
-        log,
-        trajectoryRecorder,
-      });
     }
   } finally {
     removeExternalAbortSignalListener?.();

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -6048,6 +6048,7 @@ export async function runEmbeddedAttempt(
       // actual session end including teardown and state persistence.
       // See: https://github.com/openclaw/openclaw/issues/102014
       if (trajectoryRecorder && !trajectoryEndRecorded) {
+        trajectoryRecorder.recordEvent("session.cleanup_completed");
         trajectoryRecorder.recordEvent("session.ended", {
           status:
             trajectoryTerminalStatus ??

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -5997,15 +5997,24 @@ export async function runEmbeddedAttempt(
       } catch (err) {
         cleanupError = err;
       }
+      const synthesizedCleanupTakeoverError =
+        !cleanupError && promptError && sessionLockController.hasSessionTakeover()
+          ? new EmbeddedAttemptSessionTakeoverError(params.sessionFile)
+          : undefined;
+      const cleanupFailure = cleanupError ?? synthesizedCleanupTakeoverError;
       // Record final trajectory events and flush before any rethrow so
       // cleanup failures do not leave the session trajectory incomplete.
+      // Only emit session.cleanup_completed when cleanup succeeded.
       // See: https://github.com/openclaw/openclaw/issues/102014
       if (trajectoryRecorder && !trajectoryEndRecorded) {
-        trajectoryRecorder.recordEvent("session.cleanup_completed");
+        if (!cleanupFailure) {
+          trajectoryRecorder.recordEvent("session.cleanup_completed");
+        }
         trajectoryRecorder.recordEvent("session.ended", {
-          status:
-            trajectoryTerminalStatus ??
-            (promptError ? "error" : aborted || timedOut ? "interrupted" : "cleanup"),
+          status: cleanupFailure
+            ? "error"
+            : (trajectoryTerminalStatus ??
+              (promptError ? "error" : aborted || timedOut ? "interrupted" : "cleanup")),
           aborted,
           externalAbort,
           timedOut,
@@ -6024,11 +6033,6 @@ export async function runEmbeddedAttempt(
         log,
         trajectoryRecorder,
       });
-      const synthesizedCleanupTakeoverError =
-        !cleanupError && promptError && sessionLockController.hasSessionTakeover()
-          ? new EmbeddedAttemptSessionTakeoverError(params.sessionFile)
-          : undefined;
-      const cleanupFailure = cleanupError ?? synthesizedCleanupTakeoverError;
       const shouldPreservePromptError = shouldPreservePromptErrorAfterCleanupError({
         promptError,
         cleanupError: cleanupFailure,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -5952,23 +5952,6 @@ export async function runEmbeddedAttempt(
         yieldDetected: yieldDetected || undefined,
       };
     } finally {
-      if (trajectoryRecorder && !trajectoryEndRecorded) {
-        trajectoryRecorder.recordEvent("session.ended", {
-          status:
-            trajectoryTerminalStatus ??
-            (promptError ? "error" : aborted || timedOut ? "interrupted" : "cleanup"),
-          aborted,
-          externalAbort,
-          timedOut,
-          idleTimedOut,
-          timedOutDuringCompaction,
-          timedOutDuringToolExecution,
-          timedOutByRunBudget,
-          promptError: promptError ? formatErrorMessage(promptError) : undefined,
-          terminalError: trajectoryTerminalError,
-        });
-        trajectoryEndRecorded = true;
-      }
       await flushEmbeddedAttemptTrajectoryRecorder({
         runId: params.runId,
         sessionId: params.sessionId,
@@ -6060,6 +6043,26 @@ export async function runEmbeddedAttempt(
         } else {
           await Promise.reject(toErrorObject(cleanupFailure, "Non-Error rejection"));
         }
+      }
+      // Record session.ended after cleanup completes so the timestamp reflects
+      // actual session end including teardown and state persistence.
+      // See: https://github.com/openclaw/openclaw/issues/102014
+      if (trajectoryRecorder && !trajectoryEndRecorded) {
+        trajectoryRecorder.recordEvent("session.ended", {
+          status:
+            trajectoryTerminalStatus ??
+            (promptError ? "error" : aborted || timedOut ? "interrupted" : "cleanup"),
+          aborted,
+          externalAbort,
+          timedOut,
+          idleTimedOut,
+          timedOutDuringCompaction,
+          timedOutDuringToolExecution,
+          timedOutByRunBudget,
+          promptError: promptError ? formatErrorMessage(promptError) : undefined,
+          terminalError: trajectoryTerminalError,
+        });
+        trajectoryEndRecorded = true;
       }
     }
   } finally {

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2216,6 +2216,7 @@ export async function runEmbeddedAttempt(
     let trajectoryRecorder: ReturnType<typeof createTrajectoryRuntimeRecorder> | null = null;
     let trajectoryEndRecorded = false;
     let trajectoryTerminalError: string | undefined;
+    let trajectoryTerminalStatus: string | undefined;
     let buildAbortSettlePromise: () => Promise<void> | null = () => null;
     let cleanupYieldAborted = false;
     let repairedRejectedThinkingReplay = false;
@@ -5841,6 +5842,7 @@ export async function runEmbeddedAttempt(
         hasTerminalOutput,
       });
       trajectoryTerminalError = attemptTrajectoryTerminal.terminalError;
+      trajectoryTerminalStatus = attemptTrajectoryTerminal.status;
       trajectoryRecorder?.recordEvent("model.completed", {
         aborted,
         externalAbort,
@@ -5950,15 +5952,11 @@ export async function runEmbeddedAttempt(
         yieldDetected: yieldDetected || undefined,
       };
     } finally {
-      await flushEmbeddedAttemptTrajectoryRecorder({
-        runId: params.runId,
-        sessionId: params.sessionId,
-        log,
-        trajectoryRecorder,
-      });
       if (trajectoryRecorder && !trajectoryEndRecorded) {
         trajectoryRecorder.recordEvent("session.ended", {
-          status: promptError ? "error" : aborted || timedOut ? "interrupted" : "cleanup",
+          status:
+            trajectoryTerminalStatus ??
+            (promptError ? "error" : aborted || timedOut ? "interrupted" : "cleanup"),
           aborted,
           externalAbort,
           timedOut,
@@ -5971,6 +5969,12 @@ export async function runEmbeddedAttempt(
         });
         trajectoryEndRecorded = true;
       }
+      await flushEmbeddedAttemptTrajectoryRecorder({
+        runId: params.runId,
+        sessionId: params.sessionId,
+        log,
+        trajectoryRecorder,
+      });
       // Always tear down the session (and release the lock) before we leave this attempt.
       //
       // BUGFIX: Wait for the agent to be truly idle before flushing pending tool results.

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2215,6 +2215,7 @@ export async function runEmbeddedAttempt(
     let removeToolResultContextGuard: (() => void) | undefined;
     let trajectoryRecorder: ReturnType<typeof createTrajectoryRuntimeRecorder> | null = null;
     let trajectoryEndRecorded = false;
+    let trajectoryTerminalError: string | undefined;
     let buildAbortSettlePromise: () => Promise<void> | null = () => null;
     let cleanupYieldAborted = false;
     let repairedRejectedThinkingReplay = false;
@@ -5839,6 +5840,7 @@ export async function runEmbeddedAttempt(
         lastAssistantStopReason: lastAssistant?.stopReason,
         hasTerminalOutput,
       });
+      trajectoryTerminalError = attemptTrajectoryTerminal.terminalError;
       trajectoryRecorder?.recordEvent("model.completed", {
         aborted,
         externalAbort,
@@ -5886,19 +5888,9 @@ export async function runEmbeddedAttempt(
           lastToolError,
         }),
       );
-      trajectoryRecorder?.recordEvent("session.ended", {
-        status: attemptTrajectoryTerminal.status,
-        aborted,
-        externalAbort,
-        timedOut,
-        idleTimedOut,
-        timedOutDuringCompaction,
-        timedOutDuringToolExecution,
-        timedOutByRunBudget,
-        promptError: promptError ? formatErrorMessage(promptError) : undefined,
-        terminalError: attemptTrajectoryTerminal.terminalError,
-      });
-      trajectoryEndRecorded = true;
+      // Defer session.ended to the finally block so its timestamp reflects
+      // the actual session end (after flush + cleanup), not model.completed.
+      // See: https://github.com/openclaw/openclaw/issues/102014
 
       return {
         replayMetadata,
@@ -5958,6 +5950,12 @@ export async function runEmbeddedAttempt(
         yieldDetected: yieldDetected || undefined,
       };
     } finally {
+      await flushEmbeddedAttemptTrajectoryRecorder({
+        runId: params.runId,
+        sessionId: params.sessionId,
+        log,
+        trajectoryRecorder,
+      });
       if (trajectoryRecorder && !trajectoryEndRecorded) {
         trajectoryRecorder.recordEvent("session.ended", {
           status: promptError ? "error" : aborted || timedOut ? "interrupted" : "cleanup",
@@ -5969,14 +5967,10 @@ export async function runEmbeddedAttempt(
           timedOutDuringToolExecution,
           timedOutByRunBudget,
           promptError: promptError ? formatErrorMessage(promptError) : undefined,
+          terminalError: trajectoryTerminalError,
         });
+        trajectoryEndRecorded = true;
       }
-      await flushEmbeddedAttemptTrajectoryRecorder({
-        runId: params.runId,
-        sessionId: params.sessionId,
-        log,
-        trajectoryRecorder,
-      });
       // Always tear down the session (and release the lock) before we leave this attempt.
       //
       // BUGFIX: Wait for the agent to be truly idle before flushing pending tool results.


### PR DESCRIPTION
## What Problem This Solves

Fixes #102014 — `session.ended` trajectory event timestamp equals
`model.completed`, making session cleanup duration invisible in traces.

## Root Cause

`session.ended` was recorded inline after `model.completed` in the same
synchronous block, sharing the same millisecond timestamp.

## Fix

1. Defer `session.ended` to after cleanup in the finally block
2. Emit `session.cleanup_completed` before `session.ended` so cleanup is visible
3. **Flush after** the final events so they are persisted in the trajectory
   sidecar before teardown and export
4. Carry `attemptTrajectoryTerminal.status` and `terminalError`

## Evidence

### Real Behavior Proof

Trajectory export from live agent session on this branch:

```
seq=5  model.completed                 10.937
seq=6  trace.artifacts                 10.939
seq=7  session.cleanup_completed       10.966   ← cleanup done (27ms later)
seq=8  session.ended                   10.967   ← session terminated
```

`session.cleanup_completed` proves cleanup ran. Flush after seq=8 persists all
events in the trajectory sidecar.

### Autoreview (claude-sonnet-5)
→ patch is correct (0.95), no accepted/actionable findings

- [x] `oxfmt --check` passes
- [x] `oxlint` passes
- [x] `git diff --check` passes
- [x] autoreview clean (claude-sonnet-5, 0.95)