### PR TITLE
refactor(voice-call): localize internal declarations

### DIFF
--- a/extensions/voice-call/src/bounded-child-output.ts
+++ b/extensions/voice-call/src/bounded-child-output.ts
@@ -3,7 +3,7 @@
 const DEFAULT_MAX_OUTPUT_CHARS = 16_384;
 
 /** Captured child output plus truncation flag. */
-export type BoundedChildOutput = {
+type BoundedChildOutput = {
   text: string;
   truncated: boolean;
 };

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -506,7 +506,7 @@ export const VoiceCallConfigSchema = z
   .strict();
 
 export type VoiceCallConfig = z.infer<typeof VoiceCallConfigSchema>;
-export type VoiceCallEffectiveConfigResult = {
+type VoiceCallEffectiveConfigResult = {
   config: VoiceCallConfig;
   numberRouteKey?: string;
 };

--- a/extensions/voice-call/src/manager/store.ts
+++ b/extensions/voice-call/src/manager/store.ts
@@ -38,7 +38,7 @@ type CallRecordEventChunk = {
 };
 
 /** Call record plus stable ordering metadata read from persistence. */
-export type PersistedCallRecord = {
+type PersistedCallRecord = {
   call: CallRecord;
   persistedAt: number;
   sequence: number;

--- a/extensions/voice-call/src/providers/plivo.ts
+++ b/extensions/voice-call/src/providers/plivo.ts
@@ -26,7 +26,7 @@ import { reconstructWebhookUrl, verifyPlivoWebhook } from "../webhook-security.j
 import type { VoiceCallProvider } from "./base.js";
 import { guardedJsonApiRequest } from "./shared/guarded-json-api.js";
 
-export interface PlivoProviderOptions {
+interface PlivoProviderOptions {
   /** Override public URL origin for signature verification */
   publicUrl?: string;
   /** Skip webhook signature verification (development only) */

--- a/extensions/voice-call/src/providers/telnyx.ts
+++ b/extensions/voice-call/src/providers/telnyx.ts
@@ -28,7 +28,7 @@ import { guardedJsonApiRequest } from "./shared/guarded-json-api.js";
  * Uses Telnyx Call Control API v2 for managing calls.
  * @see https://developers.telnyx.com/docs/api/v2/call-control
  */
-export interface TelnyxProviderOptions {
+interface TelnyxProviderOptions {
   /** Skip webhook signature verification (development only, NOT for production) */
   skipVerification?: boolean;
 }

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -15,7 +15,7 @@ import type { CoreAgentDeps, CoreConfig } from "./core-bridge.js";
 import { resolveCallAgentId } from "./resolve-call-agent-id.js";
 import { resolveVoiceResponseModel } from "./response-model.js";
 
-export type VoiceResponseParams = {
+type VoiceResponseParams = {
   /** Voice call config */
   voiceConfig: VoiceCallConfig;
   /** Core OpenClaw config */
@@ -38,7 +38,7 @@ export type VoiceResponseParams = {
   onEarlyText?: (text: string) => Promise<boolean>;
 };
 
-export type VoiceResponseResult = {
+type VoiceResponseResult = {
   text: string | null;
   /** Whether the complete response was handed to the transport before compaction. */
   deliveredEarly: boolean;

--- a/extensions/voice-call/src/webhook-replay.ts
+++ b/extensions/voice-call/src/webhook-replay.ts
@@ -8,7 +8,7 @@ const REPLAY_WINDOW_MS = 10 * 60 * 1000;
 const REPLAY_CACHE_MAX_ENTRIES = 10_000;
 const REPLAY_CACHE_PRUNE_INTERVAL = 64;
 
-export type WebhookReplayCache = {
+type WebhookReplayCache = {
   seenUntil: Map<string, number>;
   calls: number;
 };

--- a/extensions/voice-call/src/webhook/realtime-audio-pacer.ts
+++ b/extensions/voice-call/src/webhook/realtime-audio-pacer.ts
@@ -27,7 +27,7 @@ type RealtimeAudioQueueItem =
     };
 
 /** WebSocket send callback for realtime audio frames. */
-export type RealtimeAudioSend = (message: string) => boolean;
+type RealtimeAudioSend = (message: string) => boolean;
 
 /** Provider-specific serializer for media, clear, and mark frames. */
 export interface RealtimeAudioSerializer {

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -45,7 +45,7 @@ import {
 export type ToolHandlerContext = {
   partialUserTranscript?: string;
 };
-export type ToolHandlerFn = (
+type ToolHandlerFn = (
   args: unknown,
   callId: string,
   context: ToolHandlerContext,
@@ -243,7 +243,7 @@ type PendingStreamToken = {
   callId?: string;
 };
 
-export type StreamSessionRequest = {
+type StreamSessionRequest = {
   providerName?: "twilio" | "telnyx";
   callId?: string;
   from?: string;

--- a/extensions/voice-call/src/webhook/stream-frame-adapter.ts
+++ b/extensions/voice-call/src/webhook/stream-frame-adapter.ts
@@ -1,7 +1,7 @@
 // Provider-specific media stream frame parsing and serialization.
 
 /** Normalized inbound media stream frame. */
-export type StreamFrame =
+type StreamFrame =
   | { kind: "start"; streamId: string; providerCallId: string }
   | {
       kind: "media";


### PR DESCRIPTION
## What Problem This Solves

The voice-call plugin still exported twelve declaration-only implementation types that have no consumers outside their defining modules. That unnecessarily widens the plugin's internal TypeScript surface.

## Why This Change Was Made

Repository-wide exact-name search and the refreshed codebase-memory graph found no external consumers. The plugin's explicit API barrels do not expose these declarations, so they can remain module-local without changing exported functions, classes, structural signatures, or runtime behavior.

## User Impact

None. This is a dead-export cleanup; voice-call behavior and intentional public entrypoints are unchanged.

## Evidence

- Rebasing onto exact `origin/main` `19f7b72a74731438f15aafbfc7c84593f6151dfc` completed cleanly after overlapping voice-call changes landed
- Refreshed codebase-memory graph: 281,412 nodes / 1,138,333 edges
- Changed gates passed on Testbox `tbx_01kx05mxj3z4p5p6g52w23rg78`
- Complete voice-call suite: 50 files and 522 tests passed
- Full `pnpm build`: passed, including declaration generation and plugin SDK export checks
- Fresh post-rebase branch autoreview: clean, confidence 0.86
- Post-rebase dead-export scan: no remaining candidates for the twelve declarations
- `git diff --check`: passed
