### PR TITLE
fix(security): narrow two audit false positives for single-operator multi-agent setups

### DIFF
--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -397,14 +397,6 @@ function listOpenInboundPolicies(cfg: OpenClawConfig): string[] {
   return out;
 }
 
-function hasConfiguredGroupTargets(section: Record<string, unknown>): boolean {
-  const groupKeys = ["groups", "guilds", "channels", "rooms"];
-  return groupKeys.some((key) => {
-    const value = section[key];
-    return Boolean(value && typeof value === "object" && Object.keys(value).length > 0);
-  });
-}
-
 function listPotentialMultiUserSignals(cfg: OpenClawConfig): string[] {
   const out = new Set<string>();
   const channels = cfg.channels as Record<string, unknown> | undefined;
@@ -414,10 +406,11 @@ function listPotentialMultiUserSignals(cfg: OpenClawConfig): string[] {
 
   const inspectSection = (section: Record<string, unknown>, basePath: string) => {
     const groupPolicy = typeof section.groupPolicy === "string" ? section.groupPolicy : null;
+    // A scoped allowlist with configured group/guild/channel/room targets is an
+    // intentional single-operator multi-agent boundary, not evidence of a shared
+    // multi-user gateway. Only broadening policies count as multi-user signals.
     if (groupPolicy === "open") {
       out.add(`${basePath}.groupPolicy="open"`);
-    } else if (groupPolicy === "allowlist" && hasConfiguredGroupTargets(section)) {
-      out.add(`${basePath}.groupPolicy="allowlist" with configured group targets`);
     }
 
     const dmPolicy = typeof section.dmPolicy === "string" ? section.dmPolicy : null;
@@ -700,14 +693,17 @@ export function collectHooksHardeningFindings(
   }
 
   if (allowRequestSessionKey) {
+    const hasPrefixConstraint = allowedPrefixes.length > 0;
     findings.push({
       checkId: "hooks.request_session_key_enabled",
-      severity: remoteExposure ? "critical" : "warn",
+      severity: hasPrefixConstraint ? "info" : remoteExposure ? "critical" : "warn",
       title: "External hook payloads may override sessionKey",
-      detail:
-        "hooks.allowRequestSessionKey=true allows `/hooks/agent` callers to choose the session key. Treat hook token holders as full-trust unless you also restrict prefixes.",
-      remediation:
-        "Set hooks.allowRequestSessionKey=false (recommended) or constrain hooks.allowedSessionKeyPrefixes.",
+      detail: hasPrefixConstraint
+        ? "hooks.allowRequestSessionKey=true allows `/hooks/agent` callers to choose the session key, but hooks.allowedSessionKeyPrefixes constrains the key shape."
+        : "hooks.allowRequestSessionKey=true allows `/hooks/agent` callers to choose the session key. Treat hook token holders as full-trust unless you also restrict prefixes.",
+      remediation: hasPrefixConstraint
+        ? undefined
+        : "Set hooks.allowRequestSessionKey=false (recommended) or constrain hooks.allowedSessionKeyPrefixes.",
     });
   }
 

--- a/src/security/audit-hooks-routing.test.ts
+++ b/src/security/audit-hooks-routing.test.ts
@@ -7,7 +7,7 @@ import { runSecurityAudit } from "./audit.js";
 function hasFinding(
   findings: ReturnType<typeof collectHooksHardeningFindings>,
   checkId: string,
-  severity: "warn" | "critical",
+  severity: "info" | "warn" | "critical",
 ) {
   return findings.some((finding) => finding.checkId === checkId && finding.severity === severity);
 }
@@ -98,6 +98,29 @@ describe("security audit hooks ingress findings", () => {
         } satisfies OpenClawConfig,
         expectedFinding: "hooks.request_session_key_enabled",
         expectedSeverity: "critical" as const,
+      },
+      {
+        name: "downgrades request sessionKey override to info when prefixes constrain key shape",
+        cfg: {
+          hooks: {
+            ...requestSessionKeyHooks,
+            allowedSessionKeyPrefixes: ["hook:"],
+          },
+        } satisfies OpenClawConfig,
+        expectedFinding: "hooks.request_session_key_enabled",
+        expectedSeverity: "info" as const,
+      },
+      {
+        name: "downgrades remote request sessionKey override to info when prefixes constrain key shape",
+        cfg: {
+          gateway: { bind: "lan" },
+          hooks: {
+            ...requestSessionKeyHooks,
+            allowedSessionKeyPrefixes: ["hook:"],
+          },
+        } satisfies OpenClawConfig,
+        expectedFinding: "hooks.request_session_key_enabled",
+        expectedSeverity: "info" as const,
       },
     ] as const;
 

--- a/src/security/audit-trust-model.test.ts
+++ b/src/security/audit-trust-model.test.ts
@@ -101,6 +101,24 @@ describe("security audit trust model findings", () => {
         cfg: {
           channels: {
             discord: {
+              groupPolicy: "open",
+            },
+          },
+          tools: { elevated: { enabled: false } },
+        } satisfies OpenClawConfig,
+        assert: (findings: ReturnType<typeof audit>) => {
+          const finding = requireMultiUserHeuristicFinding(findings);
+          expect(finding.severity).toBe("warn");
+          expect(finding.detail).toContain('channels.discord.groupPolicy="open"');
+          expect(finding.detail).toContain("personal-assistant");
+          expect(finding.remediation).toContain('agents.defaults.sandbox.mode="all"');
+        },
+      },
+      {
+        name: "does not treat scoped allowlist with configured group targets as a multi-user setup",
+        cfg: {
+          channels: {
+            discord: {
               groupPolicy: "allowlist",
               guilds: {
                 "1234567890": {
@@ -114,14 +132,11 @@ describe("security audit trust model findings", () => {
           tools: { elevated: { enabled: false } },
         } satisfies OpenClawConfig,
         assert: (findings: ReturnType<typeof audit>) => {
-          const finding = requireMultiUserHeuristicFinding(findings);
-          expect(finding.severity).toBe("warn");
-          expect(finding.detail).toContain(
-            'channels.discord.groupPolicy="allowlist" with configured group targets',
-          );
-          expect(finding.detail).toContain("personal-assistant");
-          expect(finding.detail).toContain("https://docs.openclaw.ai/gateway/multi-tenant-hosting");
-          expect(finding.remediation).toContain('agents.defaults.sandbox.mode="all"');
+          expect(
+            findings.some(
+              (finding) => finding.checkId === "security.trust_model.multi_user_heuristic",
+            ),
+          ).toBe(false);
         },
       },
       {


### PR DESCRIPTION
Closes #26859

## What Problem This Solves

Fixes an issue where `openclaw security audit` emits two WARN-level findings that are false positives for legitimate single-operator multi-agent setups:

1. `hooks.request_session_key_enabled` warns even when `hooks.allowedSessionKeyPrefixes` already constrains which session keys callers may request.
2. `security.trust_model.multi_user_heuristic` warns when a scoped channel allowlist has configured group/guild/channel/room targets, which is a normal multi-agent boundary rather than evidence of multiple users.

## Why This Change Was Made

- In `collectHooksHardeningFindings`, the presence of a non-empty `allowedSessionKeyPrefixes` array is now treated as a mitigation: the finding severity is downgraded from `warn`/`critical` to `info` and the remediation is omitted.
- In `listPotentialMultiUserSignals`, the `groupPolicy="allowlist"` + configured targets signal is removed. Only broadening policies (`open`) and wildcard `allowFrom`/`groupAllowFrom` entries remain as multi-user signals.

## User Impact

Operators running single-operator multi-agent gateways (e.g., multiple Discord accounts/agents on the same server) will see fewer false-positive warnings. The audit still flags genuinely risky configurations such as `groupPolicy="open"` or unconstrained `allowRequestSessionKey`.

## Evidence

- `pnpm test src/security/audit-hooks-routing.test.ts src/security/audit-trust-model.test.ts --run`: 14 tests passed.
- `pnpm build`: completed successfully.
- Direct `vitest` run on the affected test files also passed.