### PR TITLE
fix(openrouter): apply request policy to video catalog requests

### DIFF
--- a/extensions/openrouter/video-generation-provider.test.ts
+++ b/extensions/openrouter/video-generation-provider.test.ts
@@ -28,12 +28,27 @@ const {
     const request = params.request as
       | {
           allowPrivateNetwork?: boolean;
+          auth?:
+            | { mode: "provider-default" }
+            | { mode: "authorization-bearer"; token: string }
+            | {
+                mode: "header";
+                headerName: string;
+                value: string;
+                prefix?: string;
+              };
           headers?: Record<string, string>;
         }
       | undefined;
     const headers = new Headers(params.defaultHeaders as HeadersInit | undefined);
     for (const [key, value] of Object.entries(request?.headers ?? {})) {
       headers.set(key, value);
+    }
+    if (request?.auth?.mode === "authorization-bearer") {
+      headers.set("Authorization", `Bearer ${request.auth.token}`);
+    } else if (request?.auth?.mode === "header") {
+      headers.delete("Authorization");
+      headers.set(request.auth.headerName, `${request.auth.prefix ?? ""}${request.auth.value}`);
     }
     return {
       baseUrl: params.baseUrl ?? params.defaultBaseUrl ?? "https://openrouter.ai/api/v1",
@@ -338,6 +353,44 @@ describe("openrouter video generation provider", () => {
       enabled: true,
       maxInputImages: 2,
     });
+  });
+
+  it("lets configured auth replace the OpenRouter catalog default", async () => {
+    fetchWithTimeoutGuardedMock.mockResolvedValueOnce(releasedJson({ data: [] }));
+
+    await listOpenRouterVideoModelCatalog({
+      config: {
+        models: {
+          providers: {
+            openrouter: {
+              request: {
+                auth: {
+                  mode: "authorization-bearer",
+                  token: ["test", "auth"].join("-"),
+                },
+              },
+            },
+          },
+        },
+      } as never,
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: "key", discoveryApiKey: "test-key" }),
+      resolveProviderAuth: () => ({
+        apiKey: "key",
+        discoveryApiKey: "test-key",
+        mode: "api_key" as const,
+        source: "env" as const,
+      }),
+    });
+
+    const requestConfig = requireRecord(
+      requireMockCallArg(resolveProviderHttpRequestConfigMock.mock.calls, 0, 0, "request config"),
+      "request config",
+    );
+    expect(requireRecord(requestConfig.defaultHeaders, "default headers").Authorization).toBe(
+      "Bearer test-key",
+    );
+    expect(requireFetchCallHeaders(0).get("authorization")).toBe("Bearer test-auth");
   });
 
   it("keys live OpenRouter video catalog cache by request policy", async () => {

--- a/extensions/openrouter/video-generation-provider.test.ts
+++ b/extensions/openrouter/video-generation-provider.test.ts
@@ -24,13 +24,25 @@ const {
   fetchWithTimeoutGuardedMock: vi.fn(),
   postJsonRequestMock: vi.fn(),
   resolveApiKeyForProviderMock: vi.fn(async () => ({ apiKey: "openrouter-key" })),
-  resolveProviderHttpRequestConfigMock: vi.fn((params: Record<string, unknown>) => ({
-    baseUrl: params.baseUrl ?? params.defaultBaseUrl ?? "https://openrouter.ai/api/v1",
-    allowPrivateNetwork: false,
-    headers: new Headers(params.defaultHeaders as HeadersInit | undefined),
-    dispatcherPolicy: undefined,
-    requestConfig: {},
-  })),
+  resolveProviderHttpRequestConfigMock: vi.fn((params: Record<string, unknown>) => {
+    const request = params.request as
+      | {
+          allowPrivateNetwork?: boolean;
+          headers?: Record<string, string>;
+        }
+      | undefined;
+    const headers = new Headers(params.defaultHeaders as HeadersInit | undefined);
+    for (const [key, value] of Object.entries(request?.headers ?? {})) {
+      headers.set(key, value);
+    }
+    return {
+      baseUrl: params.baseUrl ?? params.defaultBaseUrl ?? "https://openrouter.ai/api/v1",
+      allowPrivateNetwork: request?.allowPrivateNetwork === true,
+      headers,
+      dispatcherPolicy: undefined,
+      requestConfig: {},
+    };
+  }),
   waitProviderOperationPollIntervalMock: vi.fn(async () => {}),
 }));
 
@@ -144,6 +156,13 @@ function expectOpenRouterFetchCall(index: number, url: string, auditContext: str
   );
 }
 
+function requireFetchGuardOptions(index: number): Record<string, unknown> {
+  return requireRecord(
+    requireMockCallArg(fetchWithTimeoutGuardedMock.mock.calls, index, 4, "fetch guard options"),
+    "OpenRouter fetch guard options",
+  );
+}
+
 function requirePostJsonParams(index = 0): Record<string, unknown> {
   const call = postJsonRequestMock.mock.calls[index] as unknown[] | undefined;
   if (!call) {
@@ -212,6 +231,10 @@ describe("openrouter video generation provider", () => {
   });
 
   it("maps OpenRouter video model discovery into unified catalog rows", async () => {
+    const requestOverrides = {
+      allowPrivateNetwork: true,
+      headers: { "X-OpenRouter-Catalog": "enabled" },
+    };
     fetchWithTimeoutGuardedMock.mockResolvedValueOnce(
       releasedJson({
         data: [
@@ -240,6 +263,7 @@ describe("openrouter video generation provider", () => {
           providers: {
             openrouter: {
               baseUrl: "https://custom.openrouter.test/openrouter/api/v1",
+              request: requestOverrides,
             },
           },
         },
@@ -267,6 +291,7 @@ describe("openrouter video generation provider", () => {
         defaultBaseUrl: "https://openrouter.ai/api/v1",
         provider: "openrouter",
         capability: "video",
+        request: requestOverrides,
       },
     );
     expectOpenRouterFetchCall(
@@ -275,6 +300,8 @@ describe("openrouter video generation provider", () => {
       "openrouter-video-models",
     );
     expect(requireFetchCallHeaders(0).get("authorization")).toBe("Bearer resolved-openrouter-key");
+    expect(requireFetchCallHeaders(0).get("x-openrouter-catalog")).toBe("enabled");
+    expect(requireFetchGuardOptions(0).ssrfPolicy).toEqual({ allowPrivateNetwork: true });
     expectUnifiedModelCatalogEntries(rows, {
       provider: "openrouter",
       kind: "video_generation",
@@ -360,6 +387,10 @@ describe("openrouter video generation provider", () => {
   });
 
   it("resolves live per-model capabilities for runtime overlays", async () => {
+    const requestOverrides = {
+      allowPrivateNetwork: true,
+      headers: { "X-OpenRouter-Capabilities": "enabled" },
+    };
     fetchWithTimeoutGuardedMock.mockResolvedValueOnce(
       releasedJson({
         data: [
@@ -384,6 +415,7 @@ describe("openrouter video generation provider", () => {
           providers: {
             openrouter: {
               baseUrl: "https://custom.openrouter.test/openrouter/api/v1",
+              request: requestOverrides,
             },
           },
         },
@@ -402,6 +434,20 @@ describe("openrouter video generation provider", () => {
       "https://custom.openrouter.test/openrouter/api/v1/videos/models",
       "openrouter-video-models",
     );
+    expectRecordFields(
+      requireRecord(
+        requireMockCallArg(resolveProviderHttpRequestConfigMock.mock.calls, 0, 0, "request config"),
+        "request config",
+      ),
+      {
+        provider: "openrouter",
+        capability: "video",
+        baseUrl: "https://custom.openrouter.test/openrouter/api/v1",
+        request: requestOverrides,
+      },
+    );
+    expect(requireFetchCallHeaders(0).get("x-openrouter-capabilities")).toBe("enabled");
+    expect(requireFetchGuardOptions(0).ssrfPolicy).toEqual({ allowPrivateNetwork: true });
     expect(requireMockCallArg(fetchWithTimeoutGuardedMock.mock.calls, 0, 2, "fetch")).toBe(12_345);
     expect(requireMockCallArg(fetchWithTimeoutGuardedMock.mock.calls, 0, 3, "fetch")).toBeTypeOf(
       "function",

--- a/extensions/openrouter/video-generation-provider.test.ts
+++ b/extensions/openrouter/video-generation-provider.test.ts
@@ -340,6 +340,68 @@ describe("openrouter video generation provider", () => {
     });
   });
 
+  it("keys live OpenRouter video catalog cache by request policy", async () => {
+    fetchWithTimeoutGuardedMock
+      .mockResolvedValueOnce(
+        releasedJson({
+          data: [{ id: "google/veo-3.1-fast", name: "Veo first policy" }],
+        }),
+      )
+      .mockResolvedValueOnce(
+        releasedJson({
+          data: [{ id: "google/veo-3.1-quality", name: "Veo second policy" }],
+        }),
+      );
+
+    const buildCatalogContext = (request: {
+      allowPrivateNetwork?: boolean;
+      headers?: Record<string, string>;
+    }) => ({
+      config: {
+        models: {
+          providers: {
+            openrouter: {
+              baseUrl: "https://custom.openrouter.test/openrouter/api/v1",
+              request,
+            },
+          },
+        },
+      } as never,
+      env: {},
+      resolveProviderApiKey: () => ({
+        apiKey: "OPENROUTER_API_KEY",
+        discoveryApiKey: "resolved-openrouter-key",
+      }),
+      resolveProviderAuth: () => ({
+        apiKey: "OPENROUTER_API_KEY",
+        discoveryApiKey: "resolved-openrouter-key",
+        mode: "api_key",
+        source: "env",
+      }),
+    });
+
+    const firstRows = await listOpenRouterVideoModelCatalog(
+      buildCatalogContext({
+        allowPrivateNetwork: true,
+        headers: { "X-OpenRouter-Policy": "first" },
+      }),
+    );
+    const secondRows = await listOpenRouterVideoModelCatalog(
+      buildCatalogContext({
+        allowPrivateNetwork: false,
+        headers: { "X-OpenRouter-Policy": "second" },
+      }),
+    );
+
+    expect(fetchWithTimeoutGuardedMock).toHaveBeenCalledTimes(2);
+    expect(requireFetchCallHeaders(0).get("x-openrouter-policy")).toBe("first");
+    expect(requireFetchCallHeaders(1).get("x-openrouter-policy")).toBe("second");
+    expect(requireFetchGuardOptions(0).ssrfPolicy).toEqual({ allowPrivateNetwork: true });
+    expect(requireFetchGuardOptions(1).ssrfPolicy).toBeUndefined();
+    expect(firstRows?.[0]?.model).toBe("google/veo-3.1-fast");
+    expect(secondRows?.[0]?.model).toBe("google/veo-3.1-quality");
+  });
+
   it("cancels oversized OpenRouter video catalog success bodies", async () => {
     const oversized = releasedOversizedJsonStream();
     fetchWithTimeoutGuardedMock.mockResolvedValueOnce(oversized);

--- a/extensions/openrouter/video-generation-provider.test.ts
+++ b/extensions/openrouter/video-generation-provider.test.ts
@@ -276,8 +276,8 @@ describe("openrouter video generation provider", () => {
       resolveProviderAuth: () => ({
         apiKey: "OPENROUTER_API_KEY",
         discoveryApiKey: "resolved-openrouter-key",
-        mode: "api_key",
-        source: "env",
+        mode: "api_key" as const,
+        source: "env" as const,
       }),
     });
 
@@ -375,8 +375,8 @@ describe("openrouter video generation provider", () => {
       resolveProviderAuth: () => ({
         apiKey: "OPENROUTER_API_KEY",
         discoveryApiKey: "resolved-openrouter-key",
-        mode: "api_key",
-        source: "env",
+        mode: "api_key" as const,
+        source: "env" as const,
       }),
     });
 
@@ -426,7 +426,7 @@ describe("openrouter video generation provider", () => {
           apiKey: "OPENROUTER_API_KEY",
           discoveryApiKey: "resolved-openrouter-key",
           mode: "api_key",
-          source: "env",
+          source: "env" as const,
         }),
       }),
     ).rejects.toThrow(

--- a/extensions/openrouter/video-model-catalog.ts
+++ b/extensions/openrouter/video-model-catalog.ts
@@ -54,6 +54,10 @@ type OpenRouterVideoModelCatalogCapabilities = VideoGenerationProviderCapabiliti
   pricingSkus?: Readonly<Record<string, string>>;
 };
 
+type OpenRouterVideoRequestPolicyCacheKey = ReturnType<
+  typeof sanitizeConfiguredModelProviderRequest
+>;
+
 function normalizeStringArray(value: unknown): string[] {
   return normalizeTrimmedStringList(value);
 }
@@ -210,16 +214,41 @@ function projectOpenRouterVideoModelsToCatalogEntries(
   return entries;
 }
 
+function stableCacheKeyValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stableCacheKeyValue);
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value)
+      .toSorted(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, stableCacheKeyValue(entry)]),
+  );
+}
+
+function buildRequestPolicyCacheKey(request: OpenRouterVideoRequestPolicyCacheKey): unknown {
+  return stableCacheKeyValue(request ?? null);
+}
+
 async function fetchOpenRouterVideoModels(params: {
   baseUrl: string;
   apiKey: string;
   headers: Headers;
+  requestPolicyCacheKey: unknown;
   timeoutMs: number;
   allowPrivateNetwork: boolean;
   dispatcherPolicy: OpenRouterVideoDispatcherPolicy;
 }): Promise<OpenRouterVideoModelsResponse> {
   return await getCachedLiveCatalogValue({
-    keyParts: ["openrouter", "video-models", params.baseUrl, params.apiKey],
+    keyParts: [
+      "openrouter",
+      "video-models",
+      params.baseUrl,
+      params.apiKey,
+      params.requestPolicyCacheKey,
+    ],
     load: async () => {
       const headers = new Headers(params.headers);
       headers.set("Authorization", `Bearer ${params.apiKey}`);
@@ -254,20 +283,22 @@ export async function listOpenRouterVideoModelCatalog(
   if (!apiKey) {
     return null;
   }
+  const request = sanitizeConfiguredModelProviderRequest(
+    ctx.config.models?.providers?.openrouter?.request,
+  );
   const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
     resolveProviderHttpRequestConfig({
       provider: "openrouter",
       capability: "video",
       baseUrl: ctx.config.models?.providers?.openrouter?.baseUrl,
       defaultBaseUrl: OPENROUTER_BASE_URL,
-      request: sanitizeConfiguredModelProviderRequest(
-        ctx.config.models?.providers?.openrouter?.request,
-      ),
+      request,
     });
   const payload = await fetchOpenRouterVideoModels({
     baseUrl,
     apiKey,
     headers,
+    requestPolicyCacheKey: buildRequestPolicyCacheKey(request),
     timeoutMs: ctx.timeoutMs ?? DEFAULT_HTTP_TIMEOUT_MS,
     allowPrivateNetwork,
     dispatcherPolicy,
@@ -287,20 +318,22 @@ export async function resolveOpenRouterVideoModelCapabilities(
   if (!auth.apiKey) {
     return undefined;
   }
+  const request = sanitizeConfiguredModelProviderRequest(
+    ctx.cfg?.models?.providers?.openrouter?.request,
+  );
   const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
     resolveProviderHttpRequestConfig({
       provider: "openrouter",
       capability: "video",
       baseUrl: ctx.cfg?.models?.providers?.openrouter?.baseUrl,
       defaultBaseUrl: OPENROUTER_BASE_URL,
-      request: sanitizeConfiguredModelProviderRequest(
-        ctx.cfg?.models?.providers?.openrouter?.request,
-      ),
+      request,
     });
   const payload = await fetchOpenRouterVideoModels({
     baseUrl,
     apiKey: auth.apiKey,
     headers,
+    requestPolicyCacheKey: buildRequestPolicyCacheKey(request),
     timeoutMs: ctx.timeoutMs ?? DEFAULT_HTTP_TIMEOUT_MS,
     allowPrivateNetwork,
     dispatcherPolicy,

--- a/extensions/openrouter/video-model-catalog.ts
+++ b/extensions/openrouter/video-model-catalog.ts
@@ -9,6 +9,7 @@ import {
   assertOkOrThrowHttpError,
   readProviderJsonResponse,
   resolveProviderHttpRequestConfig,
+  sanitizeConfiguredModelProviderRequest,
 } from "openclaw/plugin-sdk/provider-http";
 import {
   normalizeOptionalString,
@@ -212,6 +213,7 @@ function projectOpenRouterVideoModelsToCatalogEntries(
 async function fetchOpenRouterVideoModels(params: {
   baseUrl: string;
   apiKey: string;
+  headers: Headers;
   timeoutMs: number;
   allowPrivateNetwork: boolean;
   dispatcherPolicy: OpenRouterVideoDispatcherPolicy;
@@ -219,11 +221,10 @@ async function fetchOpenRouterVideoModels(params: {
   return await getCachedLiveCatalogValue({
     keyParts: ["openrouter", "video-models", params.baseUrl, params.apiKey],
     load: async () => {
-      const headers = new Headers({
-        Authorization: `Bearer ${params.apiKey}`,
-        "HTTP-Referer": "https://openclaw.ai",
-        "X-OpenRouter-Title": "OpenClaw",
-      });
+      const headers = new Headers(params.headers);
+      headers.set("Authorization", `Bearer ${params.apiKey}`);
+      headers.set("HTTP-Referer", "https://openclaw.ai");
+      headers.set("X-OpenRouter-Title", "OpenClaw");
       const { response, release } = await fetchOpenRouterVideoGet({
         url: "videos/models",
         baseUrl: params.baseUrl,
@@ -253,15 +254,20 @@ export async function listOpenRouterVideoModelCatalog(
   if (!apiKey) {
     return null;
   }
-  const { baseUrl, allowPrivateNetwork, dispatcherPolicy } = resolveProviderHttpRequestConfig({
-    provider: "openrouter",
-    capability: "video",
-    baseUrl: ctx.config.models?.providers?.openrouter?.baseUrl,
-    defaultBaseUrl: OPENROUTER_BASE_URL,
-  });
+  const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
+    resolveProviderHttpRequestConfig({
+      provider: "openrouter",
+      capability: "video",
+      baseUrl: ctx.config.models?.providers?.openrouter?.baseUrl,
+      defaultBaseUrl: OPENROUTER_BASE_URL,
+      request: sanitizeConfiguredModelProviderRequest(
+        ctx.config.models?.providers?.openrouter?.request,
+      ),
+    });
   const payload = await fetchOpenRouterVideoModels({
     baseUrl,
     apiKey,
+    headers,
     timeoutMs: ctx.timeoutMs ?? DEFAULT_HTTP_TIMEOUT_MS,
     allowPrivateNetwork,
     dispatcherPolicy,
@@ -281,15 +287,20 @@ export async function resolveOpenRouterVideoModelCapabilities(
   if (!auth.apiKey) {
     return undefined;
   }
-  const { baseUrl, allowPrivateNetwork, dispatcherPolicy } = resolveProviderHttpRequestConfig({
-    provider: "openrouter",
-    capability: "video",
-    baseUrl: ctx.cfg?.models?.providers?.openrouter?.baseUrl,
-    defaultBaseUrl: OPENROUTER_BASE_URL,
-  });
+  const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
+    resolveProviderHttpRequestConfig({
+      provider: "openrouter",
+      capability: "video",
+      baseUrl: ctx.cfg?.models?.providers?.openrouter?.baseUrl,
+      defaultBaseUrl: OPENROUTER_BASE_URL,
+      request: sanitizeConfiguredModelProviderRequest(
+        ctx.cfg?.models?.providers?.openrouter?.request,
+      ),
+    });
   const payload = await fetchOpenRouterVideoModels({
     baseUrl,
     apiKey: auth.apiKey,
+    headers,
     timeoutMs: ctx.timeoutMs ?? DEFAULT_HTTP_TIMEOUT_MS,
     allowPrivateNetwork,
     dispatcherPolicy,

--- a/extensions/openrouter/video-model-catalog.ts
+++ b/extensions/openrouter/video-model-catalog.ts
@@ -58,6 +58,8 @@ type OpenRouterVideoRequestPolicyCacheKey = ReturnType<
   typeof sanitizeConfiguredModelProviderRequest
 >;
 
+type OpenRouterVideoRequestConfig = Parameters<typeof sanitizeConfiguredModelProviderRequest>[0];
+
 function normalizeStringArray(value: unknown): string[] {
   return normalizeTrimmedStringList(value);
 }
@@ -214,6 +216,7 @@ function projectOpenRouterVideoModelsToCatalogEntries(
   return entries;
 }
 
+// Canonical key ordering keeps equivalent request policies on one cache entry.
 function stableCacheKeyValue(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map(stableCacheKeyValue);
@@ -230,6 +233,29 @@ function stableCacheKeyValue(value: unknown): unknown {
 
 function buildRequestPolicyCacheKey(request: OpenRouterVideoRequestPolicyCacheKey): unknown {
   return stableCacheKeyValue(request ?? null);
+}
+
+function resolveOpenRouterVideoCatalogRequest(params: {
+  apiKey: string;
+  baseUrl: string | undefined;
+  request: OpenRouterVideoRequestConfig;
+}) {
+  const request = sanitizeConfiguredModelProviderRequest(params.request);
+  return {
+    ...resolveProviderHttpRequestConfig({
+      provider: "openrouter",
+      capability: "video",
+      baseUrl: params.baseUrl,
+      defaultBaseUrl: OPENROUTER_BASE_URL,
+      defaultHeaders: {
+        Authorization: `Bearer ${params.apiKey}`,
+        "HTTP-Referer": "https://openclaw.ai",
+        "X-OpenRouter-Title": "OpenClaw",
+      },
+      request,
+    }),
+    requestPolicyCacheKey: buildRequestPolicyCacheKey(request),
+  };
 }
 
 async function fetchOpenRouterVideoModels(params: {
@@ -250,14 +276,10 @@ async function fetchOpenRouterVideoModels(params: {
       params.requestPolicyCacheKey,
     ],
     load: async () => {
-      const headers = new Headers(params.headers);
-      headers.set("Authorization", `Bearer ${params.apiKey}`);
-      headers.set("HTTP-Referer", "https://openclaw.ai");
-      headers.set("X-OpenRouter-Title", "OpenClaw");
       const { response, release } = await fetchOpenRouterVideoGet({
         url: "videos/models",
         baseUrl: params.baseUrl,
-        headers,
+        headers: params.headers,
         timeoutMs: params.timeoutMs,
         allowPrivateNetwork: params.allowPrivateNetwork,
         dispatcherPolicy: params.dispatcherPolicy,
@@ -283,22 +305,17 @@ export async function listOpenRouterVideoModelCatalog(
   if (!apiKey) {
     return null;
   }
-  const request = sanitizeConfiguredModelProviderRequest(
-    ctx.config.models?.providers?.openrouter?.request,
-  );
-  const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
-    resolveProviderHttpRequestConfig({
-      provider: "openrouter",
-      capability: "video",
+  const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy, requestPolicyCacheKey } =
+    resolveOpenRouterVideoCatalogRequest({
+      apiKey,
       baseUrl: ctx.config.models?.providers?.openrouter?.baseUrl,
-      defaultBaseUrl: OPENROUTER_BASE_URL,
-      request,
+      request: ctx.config.models?.providers?.openrouter?.request,
     });
   const payload = await fetchOpenRouterVideoModels({
     baseUrl,
     apiKey,
     headers,
-    requestPolicyCacheKey: buildRequestPolicyCacheKey(request),
+    requestPolicyCacheKey,
     timeoutMs: ctx.timeoutMs ?? DEFAULT_HTTP_TIMEOUT_MS,
     allowPrivateNetwork,
     dispatcherPolicy,
@@ -318,22 +335,17 @@ export async function resolveOpenRouterVideoModelCapabilities(
   if (!auth.apiKey) {
     return undefined;
   }
-  const request = sanitizeConfiguredModelProviderRequest(
-    ctx.cfg?.models?.providers?.openrouter?.request,
-  );
-  const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
-    resolveProviderHttpRequestConfig({
-      provider: "openrouter",
-      capability: "video",
+  const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy, requestPolicyCacheKey } =
+    resolveOpenRouterVideoCatalogRequest({
+      apiKey: auth.apiKey,
       baseUrl: ctx.cfg?.models?.providers?.openrouter?.baseUrl,
-      defaultBaseUrl: OPENROUTER_BASE_URL,
-      request,
+      request: ctx.cfg?.models?.providers?.openrouter?.request,
     });
   const payload = await fetchOpenRouterVideoModels({
     baseUrl,
     apiKey: auth.apiKey,
     headers,
-    requestPolicyCacheKey: buildRequestPolicyCacheKey(request),
+    requestPolicyCacheKey,
     timeoutMs: ctx.timeoutMs ?? DEFAULT_HTTP_TIMEOUT_MS,
     allowPrivateNetwork,
     dispatcherPolicy,


### PR DESCRIPTION
## What Problem This Solves

OpenRouter video catalog discovery and per-model capability resolution ignored `models.providers.openrouter.request`. Catalog calls therefore bypassed configured headers, authentication, proxy/TLS transport, and private-network policy; policy-distinct requests could also reuse the same 30-second live-catalog cache entry.

## Why This Change Was Made

- Route both catalog entry points through one OpenRouter-local request resolver.
- Supply the discovery API key and OpenRouter attribution headers as provider defaults, allowing configured request authentication to replace them with the shared resolver's documented precedence.
- Pass the resolver's final headers and network policy through unchanged.
- Add a canonical sanitized request-policy discriminator to the cache key.
- Cover configured bearer-auth replacement at the outbound fetch boundary.

This keeps the fix at the plugin owner boundary; the shared request resolver already owns auth/header/proxy/TLS/SSRF precedence.

## User Impact

OpenRouter video model discovery now honors the same configured provider request policy as other provider HTTP operations. Custom bearer or header authentication is no longer silently replaced by the discovery API key, and catalog results do not cross policy boundaries.

Release note: OpenRouter video catalog requests now honor configured provider request policies and policy-sensitive cache separation. Thanks @Alix-007 for the contribution.

## Evidence

- Sanitized AWS Crabbox run `run_f2a40f921449` on reviewed contributor head `73c4bf32e834a343c508e8cc234cdebd564cd2af`: `pnpm test extensions/openrouter/video-generation-provider.test.ts` — 19/19 passed.
- Maintainer regression: configured bearer auth replaces the discovery-key default in the actual outbound catalog headers.
- Fresh autoreview on exact prepared commit `72157d1b7fa87b2ee5190529466a0735ece379a6`: no accepted/actionable findings; confidence 0.97.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/29138134996. OpenRouter-related checks, lint, production types, test types, dependency checks, and build artifacts passed. Two repository-wide QA Smoke jobs currently reproduce the same release-metadata failure on `main`: `CHANGELOG.md does not contain a release section for 2026.7.2`.
- `git diff --check` — passed.

Not tested against the production OpenRouter endpoint; the contributor's loopback proof and focused tests validate request-policy and cache behavior without sending credentials to a third party.
