### PR TITLE
refactor(zalo): localize internal declarations

### DIFF
--- a/extensions/zalo/src/api.ts
+++ b/extensions/zalo/src/api.ts
@@ -13,7 +13,7 @@ const ZALO_MEDIA_SSRF_POLICY: SsrFPolicy = {};
 
 export type ZaloFetch = (input: string, init?: RequestInit) => Promise<Response>;
 
-export type ZaloApiResponse<T = unknown> = {
+type ZaloApiResponse<T = unknown> = {
   ok: boolean;
   result?: T;
   error_code?: number;
@@ -57,34 +57,34 @@ export type ZaloUpdate = {
   message?: ZaloMessage;
 };
 
-export type ZaloSendMessageParams = {
+type ZaloSendMessageParams = {
   chat_id: string;
   text: string;
 };
 
-export type ZaloSendPhotoParams = {
+type ZaloSendPhotoParams = {
   chat_id: string;
   photo: string;
   caption?: string;
 };
 
-export type ZaloSendChatActionParams = {
+type ZaloSendChatActionParams = {
   chat_id: string;
   action: "typing" | "upload_photo";
 };
 
-export type ZaloSetWebhookParams = {
+type ZaloSetWebhookParams = {
   url: string;
   secret_token: string;
 };
 
-export type ZaloWebhookInfo = {
+type ZaloWebhookInfo = {
   url?: string;
   updated_at?: number;
   has_custom_certificate?: boolean;
 };
 
-export type ZaloGetUpdatesParams = {
+type ZaloGetUpdatesParams = {
   /** Timeout in seconds (passed as string to API) */
   timeout?: number;
 };

--- a/extensions/zalo/src/monitor-durable.ts
+++ b/extensions/zalo/src/monitor-durable.ts
@@ -3,7 +3,7 @@ import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import type { OutboundReplyPayload } from "openclaw/plugin-sdk/reply-payload";
 
-export type ZaloDurableReplyOptions = {
+type ZaloDurableReplyOptions = {
   to: string;
 };
 

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -49,7 +49,7 @@ import {
   tryHandleHostedZaloMediaRequest,
 } from "./outbound-media.js";
 
-export type ZaloMonitorOptions = {
+type ZaloMonitorOptions = {
   token: string;
   account: ResolvedZaloAccount;
   config: OpenClawConfig;

--- a/extensions/zalo/src/monitor.webhook.ts
+++ b/extensions/zalo/src/monitor.webhook.ts
@@ -24,7 +24,7 @@ import {
 
 const ZALO_WEBHOOK_REPLAY_WINDOW_MS = 5 * 60_000;
 
-export type ZaloWebhookTarget = {
+type ZaloWebhookTarget = {
   token: string;
   account: ResolvedZaloAccount;
   config: OpenClawConfig;


### PR DESCRIPTION
## What Problem This Solves

The Zalo plugin still exported ten declaration-only implementation types that have no consumers outside their defining modules. That unnecessarily widens the plugin's internal TypeScript surface.

## Why This Change Was Made

Repository-wide exact-name search and the refreshed codebase-memory graph found no external consumers. Zalo's explicit public barrels do not expose these declarations, so they can remain module-local without changing exported functions, monitor entrypoints, structural signatures, or runtime behavior.

## User Impact

None. This is a dead-export cleanup; Zalo behavior and intentional public entrypoints are unchanged.

## Evidence

- Refreshed codebase-memory graph: 281,396 nodes / 1,134,242 edges
- Changed gates passed on Testbox `tbx_01kx0686z4zbjfvgft12rb9egc`
- Complete Zalo suite: 25 files and 115 tests passed
- Full `pnpm build`: passed, including declaration generation and plugin SDK export checks
- Pre-commit autoreview: clean, confidence 0.90
- Committed branch autoreview: clean, confidence 0.87
- Post-edit dead-export scan: no remaining candidates for the ten declarations
- `git diff --check`: passed
