### PR TITLE
fix(doctor): keep scrubbed error truncation UTF-16 safe

### DIFF
--- a/src/flows/doctor-error-message.ts
+++ b/src/flows/doctor-error-message.ts
@@ -1,3 +1,5 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+
 // Shared sanitization for doctor/lint/repair errors shown in terminal output.
 const ERR_MESSAGE_MAX_LEN = 256;
 
@@ -14,5 +16,5 @@ export function scrubDoctorErrorMessage(err: unknown): string {
   if (stripped.length <= ERR_MESSAGE_MAX_LEN) {
     return stripped;
   }
-  return `${stripped.slice(0, ERR_MESSAGE_MAX_LEN - 3)}...`;
+  return `${truncateUtf16Safe(stripped, ERR_MESSAGE_MAX_LEN - 3)}...`;
 }

--- a/src/flows/doctor-lint-flow.test.ts
+++ b/src/flows/doctor-lint-flow.test.ts
@@ -24,22 +24,6 @@ function check(id: string, detect: HealthCheck["detect"]): HealthCheck {
   };
 }
 
-function hasUnpairedSurrogate(value: string): boolean {
-  for (let index = 0; index < value.length; index++) {
-    const code = value.charCodeAt(index);
-    if (code >= 0xd800 && code <= 0xdbff) {
-      const next = value.charCodeAt(index + 1);
-      if (next < 0xdc00 || next > 0xdfff) {
-        return true;
-      }
-      index++;
-    } else if (code >= 0xdc00 && code <= 0xdfff) {
-      return true;
-    }
-  }
-  return false;
-}
-
 describe("runDoctorLintChecks", () => {
   it("filters selected checks and reports skipped count", async () => {
     const result = await runDoctorLintChecks(ctx, {
@@ -162,10 +146,7 @@ describe("runDoctorLintChecks", () => {
       ],
     });
 
-    const message = result.findings[0]?.message ?? "";
-    expect(message).toMatch(/^health check threw: /);
-    expect(message.endsWith("...")).toBe(true);
-    expect(hasUnpairedSurrogate(message)).toBe(false);
+    expect(result.findings[0]?.message).toBe(`health check threw: ${"A".repeat(252)}...`);
   });
 });
 

--- a/src/flows/doctor-lint-flow.test.ts
+++ b/src/flows/doctor-lint-flow.test.ts
@@ -24,6 +24,22 @@ function check(id: string, detect: HealthCheck["detect"]): HealthCheck {
   };
 }
 
+function hasUnpairedSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) {
+        return true;
+      }
+      index++;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
 describe("runDoctorLintChecks", () => {
   it("filters selected checks and reports skipped count", async () => {
     const result = await runDoctorLintChecks(ctx, {
@@ -134,6 +150,22 @@ describe("runDoctorLintChecks", () => {
         message: "health check threw: nope",
       },
     ]);
+  });
+
+  it("keeps truncated thrown error messages UTF-16 safe", async () => {
+    const emoji = "\u{1F600}";
+    const result = await runDoctorLintChecks(ctx, {
+      checks: [
+        check("emoji-boom", async () => {
+          throw new Error(`${"A".repeat(252)}${emoji}${"B".repeat(10)}`);
+        }),
+      ],
+    });
+
+    const message = result.findings[0]?.message ?? "";
+    expect(message).toMatch(/^health check threw: /);
+    expect(message.endsWith("...")).toBe(true);
+    expect(hasUnpairedSurrogate(message)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Doctor/lint/repair errors are scrubbed and capped before reaching terminal findings. The shared scrubber used raw slicing at its 253-unit content boundary, which could retain a lone high surrogate before the existing `...` suffix.

## Why This Change Was Made

`scrubDoctorErrorMessage` now delegates the cut to the canonical `truncateUtf16Safe` helper. ANSI stripping, error coercion, the 256-unit total cap, suffix, check execution, and finding policy remain unchanged.

The maintainer fixup replaces a 20-line surrogate scanner with one exact assertion through `runDoctorLintChecks`, covering the complete thrown-error-to-finding path.

## User Impact

Long doctor errors remain readable when the cap crosses an emoji or another astral character.

## Evidence

- Exact production-path finding assertion through `runDoctorLintChecks`.
- Targeted oxfmt and `git diff --check`: pass.
- Fresh local-diff and full-branch autoreviews: clean, confidence 0.99.
- Exact-head CI run `28991884349`, OpenGrep run `28991884305`, CodeQL Critical Quality run `28991884323`, and CodeQL run `28991884318` on `56727ca1c7ef06c6706401e3a122719403284006`: success.

AI-assisted: yes. Maintainer-reviewed and tightened.
