### PR TITLE
fix(slack): suppress progress chrome sends

### DIFF
--- a/extensions/slack/src/blocks.test-helpers.ts
+++ b/extensions/slack/src/blocks.test-helpers.ts
@@ -14,6 +14,9 @@ export type SlackSendTestClient = WebClient & {
   chat: {
     postMessage: ReturnType<typeof vi.fn>;
   };
+  reactions: {
+    add: ReturnType<typeof vi.fn>;
+  };
 };
 
 const slackBlockTestState = vi.hoisted(() => ({
@@ -54,6 +57,9 @@ export function createSlackSendTestClient(): SlackSendTestClient {
     },
     chat: {
       postMessage: vi.fn(async () => ({ ts: "171234.567" })),
+    },
+    reactions: {
+      add: vi.fn(async () => ({})),
     },
   } as unknown as SlackSendTestClient;
 }

--- a/extensions/slack/src/send.identity-fallback.test.ts
+++ b/extensions/slack/src/send.identity-fallback.test.ts
@@ -9,7 +9,7 @@ vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
 }));
 
 installSlackBlockTestMocks();
-const { sendMessageSlack } = await import("./send.js");
+const { detectSlackProgressChromeReaction, sendMessageSlack } = await import("./send.js");
 const SLACK_TEST_CFG = { channels: { slack: { botToken: "xoxb-test" } } };
 
 type SlackMissingScopeError = Error & {
@@ -44,6 +44,52 @@ function buildMissingScopeError(overrides?: {
 describe("sendMessageSlack customize-scope fallback", () => {
   beforeEach(() => {
     vi.mocked(logVerbose).mockClear();
+  });
+
+  it("converts progress chrome text to a thread reaction instead of chat.postMessage", async () => {
+    const client = createSlackSendTestClient();
+
+    const result = await sendMessageSlack("channel:C123", ":hammer_and_wrench: `pnpm test`", {
+      token: "xoxb-test",
+      cfg: SLACK_TEST_CFG,
+      client,
+      threadTs: "171234.000",
+    });
+
+    expect(client.chat.postMessage).not.toHaveBeenCalled();
+    expect(client.reactions.add).toHaveBeenCalledWith({
+      channel: "C123",
+      timestamp: "171234.000",
+      name: "hammer_and_wrench",
+    });
+    expect(result.messageId).toBe("suppressed");
+    expect(result.channelId).toBe("C123");
+  });
+
+  it("fails closed on progress chrome text without a reaction target", async () => {
+    const client = createSlackSendTestClient();
+
+    const result = await sendMessageSlack("channel:C123", ":writing_hand: Write: MEMORY.md", {
+      token: "xoxb-test",
+      cfg: SLACK_TEST_CFG,
+      client,
+    });
+
+    expect(client.chat.postMessage).not.toHaveBeenCalled();
+    expect(client.reactions.add).not.toHaveBeenCalled();
+    expect(result.messageId).toBe("suppressed");
+    expect(result.channelId).toBe("C123");
+  });
+
+  it("does not classify semantic Slack replies as progress chrome", () => {
+    expect(
+      detectSlackProgressChromeReaction(
+        ":hammer_and_wrench: I fixed the deployment issue and verified production.",
+      ),
+    ).toBeUndefined();
+    expect(
+      detectSlackProgressChromeReaction(":email: Message sent to the client."),
+    ).toBeUndefined();
   });
 
   it("retries without identity when needed contains chat:write.customize", async () => {

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -31,6 +31,13 @@ const SLACK_UPLOAD_SSRF_POLICY = {
   allowRfc2544BenchmarkRange: true,
 };
 const SLACK_DM_CHANNEL_CACHE_MAX = 1024;
+const PROGRESS_CHROME_REACTION_BY_EMOJI = new Map<string, string>([
+  ["hammer_and_wrench", "hammer_and_wrench"],
+  ["writing_hand", "writing_hand"],
+  ["email", "email"],
+  ["mag", "mag"],
+  ["floppy_disk", "floppy_disk"],
+]);
 const slackDmChannelCache = new Map<string, string>();
 const slackSendQueues = new Map<string, Promise<void>>();
 
@@ -97,6 +104,48 @@ function isSlackCustomizeScopeError(err: unknown): boolean {
     ...(maybeData.data?.response_metadata?.acceptedScopes ?? []),
   ].map((scope) => normalizeLowercaseStringOrEmpty(scope));
   return scopes.includes("chat:write.customize");
+}
+
+export function detectSlackProgressChromeReaction(text: string): string | undefined {
+  const trimmed = text.trim();
+  const match = /^:([a-z0-9_+-]+):\s+([\s\S]*)$/i.exec(trimmed);
+  if (!match) {
+    return undefined;
+  }
+  const emoji = match[1]?.toLowerCase();
+  const body = match[2]?.trim() ?? "";
+  const reaction = emoji ? PROGRESS_CHROME_REACTION_BY_EMOJI.get(emoji) : undefined;
+  if (!reaction || !body) {
+    return undefined;
+  }
+
+  const hasBacktickCommand = /`[^`\n]{1,240}`/.test(body);
+  const hasProgressLabel =
+    /^(?:write|read|edit|update|message|email|search|save|run|exec|bash|cmd)(?:\s*:|\s+`)/i.test(
+      body,
+    );
+  const lineCount = body.split(/\r?\n/).filter((line) => line.trim()).length;
+  const hasSentencePunctuation = /[.!?](?:\s|$)/.test(body);
+  const wordCount = (body.match(/[A-Za-z0-9_/-]+/g) ?? []).length;
+
+  if ((hasBacktickCommand || hasProgressLabel) && lineCount <= 2 && !hasSentencePunctuation) {
+    return reaction;
+  }
+  if (hasBacktickCommand && wordCount <= 12 && lineCount <= 3) {
+    return reaction;
+  }
+  return undefined;
+}
+
+function hasSlackPlatformError(err: unknown, code: string): boolean {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  const data = (err as { data?: unknown }).data;
+  if (!data || typeof data !== "object") {
+    return false;
+  }
+  return (data as { error?: unknown }).error === code;
 }
 
 async function postSlackMessageBestEffort(params: {
@@ -407,6 +456,32 @@ async function sendMessageSlackQueued(params: {
     accountId: account.accountId,
     token,
   });
+  if (!blocks && !opts.mediaUrl) {
+    const progressReaction = detectSlackProgressChromeReaction(trimmedMessage);
+    if (progressReaction) {
+      if (opts.threadTs) {
+        try {
+          await client.reactions.add({
+            channel: channelId,
+            timestamp: opts.threadTs,
+            name: progressReaction,
+          });
+          logVerbose("slack send: converted progress chrome payload to reaction");
+        } catch (err) {
+          if (!hasSlackPlatformError(err, "already_reacted")) {
+            throw err;
+          }
+          logVerbose("slack send: progress chrome reaction already present");
+        }
+      } else {
+        logVerbose("slack send: suppressed progress chrome payload without reaction target");
+      }
+      return {
+        messageId: "suppressed",
+        channelId,
+      };
+    }
+  }
   if (blocks) {
     if (opts.mediaUrl) {
       throw new Error("Slack send does not support blocks with mediaUrl");


### PR DESCRIPTION
## Summary
- detect progress-only Slack tool chrome payloads with leading tool emoji plus command/status body
- convert thread-scoped chrome to reactions instead of chat.postMessage
- fail closed by suppressing chrome without a reaction target while preserving semantic replies

## What Problem This Solves
Progress-only operational chrome like `:hammer_and_wrench: `pnpm test`` or `:writing_hand: Write: MEMORY.md` can leak into Slack as user-visible messages when a tool/status payload accidentally reaches the Slack send path. This creates noise in working channels and violates the progress-chrome pre-send gate. The Slack extension now classifies only narrow progress-only payloads and prevents them from becoming chat posts.

## Evidence
- `CI=true pnpm oxfmt --check extensions/slack/src/send.ts extensions/slack/src/send.identity-fallback.test.ts extensions/slack/src/blocks.test-helpers.ts`
- `CI=true pnpm vitest run extensions/slack/src/send.identity-fallback.test.ts` (15 tests)
- `CI=true pnpm tsgo:extensions`
- `git diff --check`

## Verification
- Thread-scoped progress chrome converts to `reactions.add` instead of `chat.postMessage`.
- Progress chrome without a reaction target is suppressed before Slack post.
- Semantic replies using the same leading emoji remain sendable.
