### PR TITLE
feat(slack): open group DMs from App Home

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -148,6 +148,7 @@ openclaw plugins install @openclaw/slack
   },
   "settings": {
     "socket_mode_enabled": true,
+    "interactivity": { "is_enabled": true },
     "event_subscriptions": {
       "bot_events": [
         "app_home_opened",
@@ -223,6 +224,7 @@ openclaw plugins install @openclaw/slack
   },
   "settings": {
     "socket_mode_enabled": true,
+    "interactivity": { "is_enabled": true },
     "event_subscriptions": {
       "bot_events": [
         "app_home_opened",
@@ -624,6 +626,7 @@ Base manifest (Socket Mode default):
   },
   "settings": {
     "socket_mode_enabled": true,
+    "interactivity": { "is_enabled": true },
     "event_subscriptions": {
       "bot_events": [
         "app_home_opened",
@@ -695,7 +698,25 @@ For **HTTP Request URLs mode**, replace `settings` with the HTTP variant and add
 
 Surface different features that extend the above defaults.
 
-The default manifest enables the Slack App Home **Home** tab and subscribes to `app_home_opened`. When a workspace member opens the Home tab, OpenClaw publishes a safe default Home view with `views.publish`; no conversation payload or private configuration is included. The **Messages** tab remains enabled for Slack DMs. The manifest also enables Slack assistant threads with `features.assistant_view`, `assistant:write`, `assistant_thread_started`, and `assistant_thread_context_changed`; assistant threads route to their own OpenClaw thread sessions and keep Slack-provided thread context available to the agent.
+The default manifest enables the Slack App Home **Home** tab, Slack interactivity, and the `app_home_opened` event. When a workspace member opens the Home tab, OpenClaw publishes a safe default Home view with `views.publish`; no conversation payload or private configuration is included. The **Messages** tab remains enabled for Slack DMs. The manifest also enables Slack assistant threads with `features.assistant_view`, `assistant:write`, `assistant_thread_started`, and `assistant_thread_context_changed`; assistant threads route to their own OpenClaw thread sessions and keep Slack-provided thread context available to the agent.
+
+### Open a group DM from App Home
+
+OpenClaw can open or resume a bot-inclusive Slack group DM from its App Home:
+
+1. Set `channels.slack.dm.groupEnabled: true`.
+2. Omit `dm.groupChannels`, leave it empty, or include `"*"`. A concrete-only MPIM allowlist hides the control because a new conversation ID is not known yet.
+3. Restart the Gateway, then open **Apps → OpenClaw → Home** in Slack.
+4. Under **Who else?**, choose one to seven people and select **Open group DM**. OpenClaw includes you automatically; Slack includes the bot.
+5. Follow the App Home link to the ready conversation.
+
+Slack resumes an existing bot-inclusive MPIM when the exact participant set already exists. Otherwise it opens a separate MPIM and OpenClaw posts one starter message. The person clicking the control must pass `dm.enabled`, `dmPolicy`, `allowFrom`, and pairing; with the default pairing policy, an unpaired creator sees pairing instructions in App Home and must be approved before retrying. After the MPIM opens, every selected member can interact with OpenClaw in that conversation. `dm.groupEnabled` and `dm.groupChannels` govern the group rather than applying the creator's DM allowlist to each member. Enabling this control therefore lets any DM-authorized creator grant group-scoped access to the people they select.
+
+<Warning>
+  This does not add OpenClaw to the original people-only group DM and does not copy that conversation's messages or files. A newly opened MPIM starts with its own history. If retaining the original history matters, [convert that DM to a private channel](https://slack.com/help/articles/217555437-Convert-a-group-direct-message-to-a-private-channel) and invite OpenClaw there instead; Slack keeps the original messages and files visible.
+</Warning>
+
+The recommended manifest already enables App Home and interactivity and requests `mpim:write`, `mpim:read`, `mpim:history`, `chat:write`, `app_home_opened`, and `message.mpim`. Custom or minimal apps need those capabilities; reinstall the app after adding scopes. The App Home flow works in Socket Mode and HTTP Request URLs mode. Relay mode currently forwards messages, not App Home or block-action payloads.
 
 <AccordionGroup>
   <Accordion title="Optional native slash commands">
@@ -1513,6 +1534,20 @@ openclaw doctor
 ```bash
 openclaw pairing list slack
 ```
+
+  </Accordion>
+
+  <Accordion title="App Home group DM control missing or failing">
+    Check, in order:
+
+    - `channels.slack.dm.enabled` and `channels.slack.dm.groupEnabled`
+    - `dm.groupChannels` is omitted, empty, or contains `"*"`
+    - the user is approved by `dmPolicy`, `allowFrom`, or pairing
+    - the Slack app has App Home and Interactivity enabled
+    - the bot token has `mpim:write`, `mpim:read`, `mpim:history`, and `chat:write`; reinstall the app after adding scopes
+    - `app_home_opened` and `message.mpim` are subscribed
+
+    For Slack Connect, an `invalid_user_combination` error means all selected external people must already share at least one channel. Missing history from the people-only DM is expected; the App Home flow opens a separate bot-inclusive MPIM.
 
   </Accordion>
 

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -845,6 +845,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Socket Mode transport tuning
   - H2: Manifest and scope checklist
   - H3: Additional manifest settings
+  - H3: Open a group DM from App Home
   - H2: Token model
   - H2: Actions and gates
   - H2: Access control and routing

--- a/extensions/slack/src/monitor/events/home.test.ts
+++ b/extensions/slack/src/monitor/events/home.test.ts
@@ -1,40 +1,108 @@
 // Slack tests cover home plugin behavior.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
+const resolveSlackEffectiveAllowFromMock = vi.hoisted(() => vi.fn());
+const issuePairingChallengeMock = vi.hoisted(() => vi.fn());
+
 let buildSlackHomeView: typeof import("./home.js").buildSlackHomeView;
+let handleSlackHomeBlockAction: typeof import("./home.js").handleSlackHomeBlockAction;
+let slackHomeGroupDmActionId: typeof import("./home.js").SLACK_HOME_GROUP_DM_ACTION_ID;
 let registerSlackHomeEvents: typeof import("./home.js").registerSlackHomeEvents;
 let createSlackSystemEventTestHarness: typeof import("./system-event-test-harness.js").createSlackSystemEventTestHarness;
+
+vi.mock("../auth.js", () => ({
+  resolveSlackEffectiveAllowFrom: (...args: unknown[]) =>
+    resolveSlackEffectiveAllowFromMock(...args),
+}));
+
+vi.mock("openclaw/plugin-sdk/channel-pairing", () => ({
+  createChannelPairingChallengeIssuer: () => issuePairingChallengeMock,
+}));
 
 type HomeHandler = (args: { event: Record<string, unknown>; body: unknown }) => Promise<void>;
 
 function createHomeContext(params?: {
   trackEvent?: () => void;
   shouldDropMismatchedSlackEvent?: (body: unknown) => boolean;
+  groupDmEnabled?: boolean;
+  groupDmChannels?: string[];
+  dmPolicy?: "open" | "allowlist" | "pairing" | "disabled";
+  alreadyOpen?: boolean;
 }) {
   const harness = createSlackSystemEventTestHarness();
   const publish = vi.fn().mockResolvedValue({ ok: true });
+  const open = vi.fn().mockResolvedValue({
+    ok: true,
+    already_open: params?.alreadyOpen ?? false,
+    channel: { id: "G123" },
+  });
+  const postMessage = vi.fn().mockResolvedValue({ ok: true, ts: "100.200" });
   if (params?.shouldDropMismatchedSlackEvent) {
     harness.ctx.shouldDropMismatchedSlackEvent = params.shouldDropMismatchedSlackEvent;
   }
   harness.ctx.botToken = "xoxb-test";
-  (harness.ctx.app as unknown as { client: { views: { publish: typeof publish } } }).client = {
+  harness.ctx.groupDmEnabled = params?.groupDmEnabled ?? false;
+  harness.ctx.groupDmChannels = params?.groupDmChannels ?? [];
+  harness.ctx.dmPolicy = params?.dmPolicy ?? "open";
+  (
+    harness.ctx.app as unknown as {
+      client: {
+        views: { publish: typeof publish };
+        conversations: { open: typeof open };
+        chat: { postMessage: typeof postMessage };
+      };
+    }
+  ).client = {
     views: { publish },
+    conversations: { open },
+    chat: { postMessage },
   };
   registerSlackHomeEvents({ ctx: harness.ctx, trackEvent: params?.trackEvent });
   return {
+    ctx: harness.ctx,
     publish,
+    open,
+    postMessage,
     getHomeHandler: () => harness.getHandler("app_home_opened") as HomeHandler | null,
+  };
+}
+
+function buildGroupDmActionBody(selectedUsers: string[]) {
+  return {
+    user: { id: "U_ACTOR" },
+    view: { callback_id: "openclaw:home" },
+    state: {
+      values: {
+        "openclaw:home:group-members": {
+          "openclaw:home:group-members": {
+            type: "multi_users_select",
+            selected_users: selectedUsers,
+          },
+        },
+      },
+    },
   };
 }
 
 describe("registerSlackHomeEvents", () => {
   beforeAll(async () => {
-    ({ buildSlackHomeView, registerSlackHomeEvents } = await import("./home.js"));
+    ({
+      buildSlackHomeView,
+      handleSlackHomeBlockAction,
+      registerSlackHomeEvents,
+      SLACK_HOME_GROUP_DM_ACTION_ID: slackHomeGroupDmActionId,
+    } = await import("./home.js"));
     ({ createSlackSystemEventTestHarness } = await import("./system-event-test-harness.js"));
   });
 
   beforeEach(() => {
     vi.clearAllMocks();
+    resolveSlackEffectiveAllowFromMock.mockResolvedValue(["*"]);
+    issuePairingChallengeMock.mockImplementation(
+      async (params: { sendPairingReply: (text: string) => Promise<void> }) => {
+        await params.sendPairingReply("Pairing approval required. Code: `PAIR1234`");
+      },
+    );
   });
 
   it("publishes the default Home tab view for app_home_opened", async () => {
@@ -101,5 +169,158 @@ describe("registerSlackHomeEvents", () => {
 
     expect(trackEvent).not.toHaveBeenCalled();
     expect(publish).not.toHaveBeenCalled();
+  });
+
+  it("shows the group DM picker only when new group DMs are allowed", async () => {
+    const enabled = createHomeContext({ groupDmEnabled: true });
+    const restricted = createHomeContext({
+      groupDmEnabled: true,
+      groupDmChannels: ["G_ALLOWED"],
+    });
+
+    await enabled.getHomeHandler()!({
+      event: { type: "app_home_opened", user: "U123", tab: "home" },
+      body: {},
+    });
+    await restricted.getHomeHandler()!({
+      event: { type: "app_home_opened", user: "U123", tab: "home" },
+      body: {},
+    });
+
+    const enabledView = enabled.publish.mock.calls[0]?.[0]?.view;
+    const restrictedView = restricted.publish.mock.calls[0]?.[0]?.view;
+    expect(enabledView?.blocks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "input",
+          block_id: "openclaw:home:group-members",
+          dispatch_action: false,
+          element: expect.objectContaining({
+            type: "multi_users_select",
+            action_id: "openclaw:home:group-members",
+            max_selected_items: 7,
+          }),
+        }),
+        expect.objectContaining({
+          type: "actions",
+          elements: [
+            expect.objectContaining({
+              action_id: slackHomeGroupDmActionId,
+              text: expect.objectContaining({ text: "Open group DM" }),
+            }),
+          ],
+        }),
+      ]),
+    );
+    expect(JSON.stringify(restrictedView)).not.toContain(slackHomeGroupDmActionId);
+  });
+
+  it("opens a bot-inclusive group DM from the Home picker", async () => {
+    const { ctx, open, postMessage, publish } = createHomeContext({ groupDmEnabled: true });
+
+    const handled = await handleSlackHomeBlockAction({
+      ctx,
+      actionId: slackHomeGroupDmActionId,
+      body: buildGroupDmActionBody(["U2", "U_ACTOR", "U_BOT", "U2", "U3"]),
+    });
+
+    expect(handled).toBe(true);
+    expect(resolveSlackEffectiveAllowFromMock).toHaveBeenCalledWith(ctx, {
+      includePairingStore: true,
+    });
+    expect(open).toHaveBeenCalledWith({
+      token: "xoxb-test",
+      users: "U_ACTOR,U2,U3",
+      return_im: true,
+    });
+    expect(postMessage).toHaveBeenCalledWith({
+      token: "xoxb-test",
+      channel: "G123",
+      text: "OpenClaw is ready in this group DM. Send a message here to start.",
+    });
+    expect(JSON.stringify(publish.mock.calls.at(-1)?.[0]?.view)).toContain(
+      "https://slack.com/app_redirect?team=T_TEST&channel=G123",
+    );
+  });
+
+  it("does not post another starter message when Slack resumes the same group DM", async () => {
+    const { ctx, postMessage } = createHomeContext({
+      groupDmEnabled: true,
+      alreadyOpen: true,
+    });
+
+    await handleSlackHomeBlockAction({
+      ctx,
+      actionId: slackHomeGroupDmActionId,
+      body: buildGroupDmActionBody(["U2"]),
+    });
+
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  it("requires another human participant", async () => {
+    const { ctx, open, publish } = createHomeContext({ groupDmEnabled: true });
+
+    await handleSlackHomeBlockAction({
+      ctx,
+      actionId: slackHomeGroupDmActionId,
+      body: buildGroupDmActionBody(["U_ACTOR", "U_BOT"]),
+    });
+
+    expect(open).not.toHaveBeenCalled();
+    expect(JSON.stringify(publish.mock.calls.at(-1)?.[0]?.view)).toContain(
+      "Choose at least one other person.",
+    );
+  });
+
+  it("requires pairing before opening the group DM", async () => {
+    resolveSlackEffectiveAllowFromMock.mockResolvedValueOnce([]);
+    const { ctx, open, publish } = createHomeContext({
+      groupDmEnabled: true,
+      dmPolicy: "pairing",
+    });
+
+    await handleSlackHomeBlockAction({
+      ctx,
+      actionId: slackHomeGroupDmActionId,
+      body: buildGroupDmActionBody(["U2"]),
+    });
+
+    expect(open).not.toHaveBeenCalled();
+    expect(issuePairingChallengeMock).toHaveBeenCalledOnce();
+    expect(JSON.stringify(publish.mock.calls.at(-1)?.[0]?.view)).toContain(
+      "Pairing approval required. Code: `PAIR1234`",
+    );
+  });
+
+  it("keeps the picker retryable when Slack cannot open the group DM", async () => {
+    const { ctx, open, publish } = createHomeContext({ groupDmEnabled: true });
+    open.mockRejectedValueOnce(new Error("missing_scope"));
+
+    await handleSlackHomeBlockAction({
+      ctx,
+      actionId: slackHomeGroupDmActionId,
+      body: buildGroupDmActionBody(["U2"]),
+    });
+
+    const view = publish.mock.calls.at(-1)?.[0]?.view;
+    expect(JSON.stringify(view)).toContain("Slack could not open that group DM.");
+    expect(JSON.stringify(view)).toContain('"initial_users":["U2"]');
+  });
+
+  it("ignores the reserved action id outside the OpenClaw Home view", async () => {
+    const { ctx, open } = createHomeContext({ groupDmEnabled: true });
+
+    const handled = await handleSlackHomeBlockAction({
+      ctx,
+      actionId: slackHomeGroupDmActionId,
+      body: {
+        ...buildGroupDmActionBody(["U2"]),
+        view: { callback_id: "another-app-home" },
+      },
+    });
+
+    expect(handled).toBe(false);
+    expect(open).not.toHaveBeenCalled();
   });
 });

--- a/extensions/slack/src/monitor/events/home.ts
+++ b/extensions/slack/src/monitor/events/home.ts
@@ -3,39 +3,335 @@ import type { SlackEventMiddlewareArgs } from "@slack/bolt";
 import type { HomeView } from "@slack/types";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
+import {
+  normalizeOptionalString,
+  normalizeUniqueTrimmedStringList,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveSlackEffectiveAllowFrom } from "../auth.js";
 import type { SlackMonitorContext } from "../context.js";
+import { authorizeSlackDirectMessage } from "../dm-auth.js";
 import type { SlackAppHomeOpenedEvent } from "../types.js";
 
-export function buildSlackHomeView(): HomeView {
+const SLACK_HOME_CALLBACK_ID = "openclaw:home";
+const SLACK_HOME_GROUP_DM_BLOCK_ID = "openclaw:home:group-members";
+const SLACK_HOME_GROUP_DM_SELECT_ACTION_ID = "openclaw:home:group-members";
+export const SLACK_HOME_GROUP_DM_ACTION_ID = "openclaw:home:open-group-dm";
+
+type SlackHomeGroupDmStatus =
+  | {
+      kind: "error";
+      message: string;
+      initialUsers?: string[];
+    }
+  | {
+      kind: "success";
+      channelId: string;
+      starterMessageFailed: boolean;
+    };
+
+type SlackHomeActionBody = {
+  user?: { id?: string };
+  view?: { callback_id?: string };
+  state?: { values?: unknown };
+};
+
+function isSlackHomeGroupDmEnabled(ctx: SlackMonitorContext): boolean {
+  const allowsNewGroupDm =
+    ctx.groupDmChannels.length === 0 || ctx.groupDmChannels.some((entry) => entry.trim() === "*");
+  return ctx.dmEnabled && ctx.dmPolicy !== "disabled" && ctx.groupDmEnabled && allowsNewGroupDm;
+}
+
+function readSlackHomeSelectedUsers(body: SlackHomeActionBody): string[] {
+  const values = body.state?.values;
+  if (!values || typeof values !== "object" || Array.isArray(values)) {
+    return [];
+  }
+  const block = (values as Record<string, unknown>)[SLACK_HOME_GROUP_DM_BLOCK_ID];
+  if (!block || typeof block !== "object" || Array.isArray(block)) {
+    return [];
+  }
+  const action = (block as Record<string, unknown>)[SLACK_HOME_GROUP_DM_SELECT_ACTION_ID];
+  if (!action || typeof action !== "object" || Array.isArray(action)) {
+    return [];
+  }
+  const selectedUsers = (action as { selected_users?: unknown }).selected_users;
+  if (!Array.isArray(selectedUsers)) {
+    return [];
+  }
+  return normalizeUniqueTrimmedStringList(
+    selectedUsers.filter((entry): entry is string => typeof entry === "string"),
+  );
+}
+
+function buildSlackHomeStatusBlock(params: {
+  status: SlackHomeGroupDmStatus;
+  teamId: string;
+}): HomeView["blocks"][number] {
+  if (params.status.kind === "error") {
+    return {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `:warning: ${params.status.message}`,
+      },
+    };
+  }
+  const groupDmUrl = `https://slack.com/app_redirect?team=${encodeURIComponent(params.teamId)}&channel=${encodeURIComponent(params.status.channelId)}`;
+  const message = params.status.starterMessageFailed
+    ? `:warning: Group DM is ready, but OpenClaw could not post its starter message. <${groupDmUrl}|Open it in Slack>.`
+    : `:white_check_mark: Group DM is ready. <${groupDmUrl}|Open it in Slack>.`;
   return {
-    type: "home",
-    callback_id: "openclaw:home",
-    blocks: [
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: message,
+    },
+  };
+}
+
+export function buildSlackHomeView(params?: {
+  groupDmEnabled?: boolean;
+  groupDmStatus?: SlackHomeGroupDmStatus;
+  teamId?: string;
+}): HomeView {
+  const blocks: HomeView["blocks"] = [
+    {
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: "OpenClaw",
+      },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "Send a DM, mention OpenClaw in a channel, or use `/openclaw` to start a session.",
+      },
+    },
+  ];
+  if (params?.groupDmStatus) {
+    blocks.push(
+      buildSlackHomeStatusBlock({
+        status: params.groupDmStatus,
+        teamId: params.teamId ?? "",
+      }),
+    );
+  }
+  if (params?.groupDmEnabled) {
+    const initialUsers =
+      params.groupDmStatus?.kind === "error" ? params.groupDmStatus.initialUsers : undefined;
+    blocks.push(
       {
-        type: "header",
-        text: {
+        type: "input",
+        block_id: SLACK_HOME_GROUP_DM_BLOCK_ID,
+        dispatch_action: false,
+        label: {
           type: "plain_text",
-          text: "OpenClaw",
+          text: "Who else?",
+        },
+        hint: {
+          type: "plain_text",
+          text: "Choose 1–7 people. You and OpenClaw are included; everyone in the group can use the agent.",
+        },
+        element: {
+          type: "multi_users_select",
+          action_id: SLACK_HOME_GROUP_DM_SELECT_ACTION_ID,
+          placeholder: {
+            type: "plain_text",
+            text: "Choose people",
+          },
+          max_selected_items: 7,
+          ...(initialUsers?.length ? { initial_users: initialUsers } : {}),
         },
       },
       {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: "Send a DM, mention OpenClaw in a channel, or use `/openclaw` to start a session.",
-        },
-      },
-      {
-        type: "context",
+        type: "actions",
         elements: [
           {
-            type: "mrkdwn",
-            text: "This Home tab is safe to show to any workspace member who opens the app.",
+            type: "button",
+            action_id: SLACK_HOME_GROUP_DM_ACTION_ID,
+            style: "primary",
+            text: {
+              type: "plain_text",
+              text: "Open group DM",
+            },
           },
         ],
       },
+    );
+  }
+  blocks.push({
+    type: "context",
+    elements: [
+      {
+        type: "mrkdwn",
+        text: "This Home tab is safe to show to any workspace member who opens the app.",
+      },
     ],
+  });
+  return {
+    type: "home",
+    callback_id: SLACK_HOME_CALLBACK_ID,
+    blocks,
   };
+}
+
+async function publishSlackHomeView(params: {
+  ctx: SlackMonitorContext;
+  userId: string;
+  status?: SlackHomeGroupDmStatus;
+}): Promise<void> {
+  await params.ctx.app.client.views.publish({
+    token: params.ctx.botToken,
+    user_id: params.userId,
+    view: buildSlackHomeView({
+      groupDmEnabled: isSlackHomeGroupDmEnabled(params.ctx),
+      groupDmStatus: params.status,
+      teamId: params.ctx.teamId,
+    }),
+  });
+}
+
+async function publishSlackHomeActionStatus(params: {
+  ctx: SlackMonitorContext;
+  userId: string;
+  status: SlackHomeGroupDmStatus;
+}): Promise<void> {
+  try {
+    await publishSlackHomeView(params);
+  } catch (error) {
+    params.ctx.runtime.error?.(
+      danger(`slack app home update failed: ${formatErrorMessage(error)}`),
+    );
+  }
+}
+
+export async function handleSlackHomeBlockAction(params: {
+  ctx: SlackMonitorContext;
+  actionId: string;
+  body: unknown;
+}): Promise<boolean> {
+  if (params.actionId !== SLACK_HOME_GROUP_DM_ACTION_ID) {
+    return false;
+  }
+  const body = params.body as SlackHomeActionBody;
+  if (body.view?.callback_id !== SLACK_HOME_CALLBACK_ID) {
+    return false;
+  }
+
+  const userId = normalizeOptionalString(body.user?.id);
+  if (!userId) {
+    params.ctx.runtime.log?.("slack:app-home drop group DM action reason=missing-user");
+    return true;
+  }
+  const selectedUsers = readSlackHomeSelectedUsers(body);
+  const publishError = (message: string, initialUsers?: string[]) =>
+    publishSlackHomeActionStatus({
+      ctx: params.ctx,
+      userId,
+      status: {
+        kind: "error",
+        message,
+        initialUsers,
+      },
+    });
+  if (!isSlackHomeGroupDmEnabled(params.ctx)) {
+    await publishError("Group DM creation is not enabled for this Slack account.");
+    return true;
+  }
+
+  // MPIM access is conversation-scoped. With unrestricted group IDs enabled,
+  // the authorized creator's explicit selection defines who can use the agent there.
+  const initialUsers = selectedUsers.filter(
+    (selectedUserId) => selectedUserId !== userId && selectedUserId !== params.ctx.botUserId,
+  );
+  const allowFromLower = await resolveSlackEffectiveAllowFrom(params.ctx, {
+    includePairingStore: true,
+  });
+  const creatorAllowed = await authorizeSlackDirectMessage({
+    ctx: params.ctx,
+    accountId: params.ctx.accountId,
+    senderId: userId,
+    allowFromLower,
+    resolveSenderName: params.ctx.resolveUserName,
+    sendPairingReply: async (text) => {
+      await publishError(text, initialUsers);
+    },
+    onDisabled: async () => {
+      await publishError("Slack DMs are disabled for this account.", initialUsers);
+    },
+    onUnauthorized: async ({ allowMatchMeta }) => {
+      params.ctx.runtime.log?.(
+        `slack:app-home drop group DM action user=${userId} dmPolicy=${params.ctx.dmPolicy} ${allowMatchMeta}`,
+      );
+      await publishError(
+        "You are not authorized to open an OpenClaw group DM. Ask an administrator for access.",
+        initialUsers,
+      );
+    },
+    log: (message) => params.ctx.runtime.log?.(message),
+  });
+  if (!creatorAllowed) {
+    return true;
+  }
+  if (initialUsers.length === 0) {
+    await publishError("Choose at least one other person.");
+    return true;
+  }
+  if (initialUsers.length > 7) {
+    await publishError("Choose no more than seven other people.", initialUsers.slice(0, 7));
+    return true;
+  }
+
+  try {
+    const response = await params.ctx.app.client.conversations.open({
+      token: params.ctx.botToken,
+      users: [userId, ...initialUsers].join(","),
+      return_im: true,
+    });
+    const channelId = normalizeOptionalString(response.channel?.id);
+    if (!channelId) {
+      throw new Error("Slack conversations.open returned no conversation ID");
+    }
+
+    let starterMessageFailed = false;
+    // Exact member sets resume an existing MPIM; only a genuinely new one gets a starter message.
+    if (response.already_open !== true) {
+      try {
+        /* eslint-disable unicorn/require-post-message-target-origin -- Slack Web API, not Window.postMessage. */
+        await params.ctx.app.client.chat.postMessage({
+          token: params.ctx.botToken,
+          channel: channelId,
+          text: "OpenClaw is ready in this group DM. Send a message here to start.",
+        });
+        /* eslint-enable unicorn/require-post-message-target-origin */
+      } catch (error) {
+        starterMessageFailed = true;
+        params.ctx.runtime.error?.(
+          danger(`slack group DM starter message failed: ${formatErrorMessage(error)}`),
+        );
+      }
+    }
+    await publishSlackHomeActionStatus({
+      ctx: params.ctx,
+      userId,
+      status: {
+        kind: "success",
+        channelId,
+        starterMessageFailed,
+      },
+    });
+  } catch (error) {
+    params.ctx.runtime.error?.(
+      danger(`slack app home group DM failed: ${formatErrorMessage(error)}`),
+    );
+    await publishError(
+      "Slack could not open that group DM. Check app permissions and participant access, then try again.",
+      initialUsers,
+    );
+  }
+  return true;
 }
 
 export function registerSlackHomeEvents(params: {
@@ -58,11 +354,7 @@ export function registerSlackHomeEvents(params: {
           return;
         }
 
-        await ctx.app.client.views.publish({
-          token: ctx.botToken,
-          user_id: payload.user,
-          view: buildSlackHomeView(),
-        });
+        await publishSlackHomeView({ ctx, userId: payload.user });
       } catch (err) {
         ctx.runtime.error?.(danger(`slack app home handler failed: ${formatErrorMessage(err)}`));
       }

--- a/extensions/slack/src/monitor/events/interactions.block-actions.ts
+++ b/extensions/slack/src/monitor/events/interactions.block-actions.ts
@@ -36,6 +36,7 @@ import {
   resolvePluginConversationBindingApproval,
 } from "../conversation.runtime.js";
 import { escapeSlackMrkdwn } from "../mrkdwn.js";
+import { handleSlackHomeBlockAction } from "./home.js";
 
 type InteractionMessageBlock = {
   type?: string;
@@ -921,6 +922,16 @@ async function handleSlackBlockAction(params: {
     return;
   }
   params.trackEvent?.();
+  // Bolt runs overlapping action listeners, so Home actions stay in this catch-all
+  // to preserve one acknowledgement and avoid also waking the agent.
+  const handledHomeAction = await handleSlackHomeBlockAction({
+    ctx: params.ctx,
+    actionId: parsed.actionId,
+    body,
+  });
+  if (handledHomeAction) {
+    return;
+  }
   const pluginInteractionData = buildSlackPluginInteractionData({
     actionId: parsed.actionId,
     summary: parsed.actionSummary,

--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -137,6 +137,8 @@ type RegisteredHandler = (args: {
     channel?: { id?: string };
     container?: { channel_id?: string; message_ts?: string; thread_ts?: string };
     message?: { ts?: string; thread_ts?: string; text?: string; blocks?: unknown[] };
+    view?: { callback_id?: string };
+    state?: { values?: Record<string, Record<string, Record<string, unknown>>> };
   };
   action: Record<string, unknown>;
   respond?: (payload: { text: string; response_type: string }) => Promise<void>;
@@ -188,6 +190,8 @@ type RegisteredShortcutHandler = (
 function createContext(overrides?: {
   dmEnabled?: boolean;
   dmPolicy?: "open" | "allowlist" | "pairing" | "disabled";
+  groupDmEnabled?: boolean;
+  groupDmChannels?: string[];
   allowFrom?: string[];
   allowNameMatching?: boolean;
   useAccessGroups?: boolean;
@@ -227,6 +231,17 @@ function createContext(overrides?: {
     client: {
       chat: {
         update: vi.fn().mockResolvedValue(undefined),
+        postMessage: vi.fn().mockResolvedValue({ ok: true, ts: "300.400" }),
+      },
+      conversations: {
+        open: vi.fn().mockResolvedValue({
+          ok: true,
+          already_open: false,
+          channel: { id: "G123" },
+        }),
+      },
+      views: {
+        publish: vi.fn().mockResolvedValue({ ok: true }),
       },
     },
   };
@@ -257,6 +272,9 @@ function createContext(overrides?: {
   const ctx = {
     app,
     accountId: "default",
+    botToken: "xoxb-test",
+    botUserId: "U_BOT",
+    teamId: "T9",
     cfg: overrides?.cfg ?? {
       channels: {
         slack: {
@@ -271,6 +289,8 @@ function createContext(overrides?: {
     runtime: { log: runtimeLog },
     dmEnabled: overrides?.dmEnabled ?? true,
     dmPolicy: overrides?.dmPolicy ?? ("open" as const),
+    groupDmEnabled: overrides?.groupDmEnabled ?? false,
+    groupDmChannels: overrides?.groupDmChannels ?? [],
     allowFrom: overrides?.allowFrom ?? ["*"],
     allowNameMatching: overrides?.allowNameMatching ?? false,
     useAccessGroups: overrides?.useAccessGroups ?? true,
@@ -643,6 +663,51 @@ describe("registerSlackInteractionEvents", () => {
     });
     expect(trackEvent).toHaveBeenCalledTimes(1);
     expect(app.client.chat.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles the App Home group DM control without routing it to the agent", async () => {
+    const { ctx, app, getHandler } = createContext({ groupDmEnabled: true });
+    const trackEvent = vi.fn();
+    registerSlackInteractionEvents({ ctx: ctx as never, trackEvent });
+    const ack = vi.fn().mockResolvedValue(undefined);
+
+    await getHandler()({
+      ack,
+      body: {
+        user: { id: "U123" },
+        team: { id: "T9" },
+        view: { callback_id: "openclaw:home" },
+        state: {
+          values: {
+            "openclaw:home:group-members": {
+              "openclaw:home:group-members": {
+                type: "multi_users_select",
+                selected_users: ["U456"],
+              },
+            },
+          },
+        },
+      },
+      action: {
+        type: "button",
+        action_id: "openclaw:home:open-group-dm",
+        block_id: "openclaw:home:group-actions",
+        text: { type: "plain_text", text: "Open group DM" },
+      },
+    });
+
+    expect(ack).toHaveBeenCalledOnce();
+    expect(trackEvent).toHaveBeenCalledOnce();
+    expect(app.client.conversations.open).toHaveBeenCalledWith({
+      token: "xoxb-test",
+      users: "U123,U456",
+      return_im: true,
+    });
+    expect(app.client.chat.postMessage).toHaveBeenCalledOnce();
+    expect(app.client.views.publish).toHaveBeenCalledOnce();
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(dispatchPluginInteractiveHandlerMock).not.toHaveBeenCalled();
+    expect(app.client.chat.update).not.toHaveBeenCalled();
   });
 
   it("registers a matcher that accepts plugin action ids beyond the OpenClaw prefix", () => {

--- a/extensions/slack/src/setup-shared.ts
+++ b/extensions/slack/src/setup-shared.ts
@@ -82,6 +82,9 @@ export function buildSlackManifest(botName = "OpenClaw") {
     },
     settings: {
       socket_mode_enabled: true,
+      interactivity: {
+        is_enabled: true,
+      },
       event_subscriptions: {
         bot_events: [
           "app_home_opened",
@@ -112,7 +115,8 @@ export function buildSlackSetupLines(): string[] {
     "2) Add Socket Mode + enable it to get the app-level token (xapp-...)",
     "3) Install App to workspace to get the xoxb- bot token",
     "4) Enable Event Subscriptions (socket) for message, App Home, and assistant events",
-    "5) App Home -> enable the Home tab, Messages tab for DMs, and AI assistant view",
+    "5) Enable Interactivity & Shortcuts (no Request URL in Socket Mode)",
+    "6) App Home -> enable the Home tab, Messages tab for DMs, and AI assistant view",
     "Manifest JSON follows as plain text for copy/paste.",
     "Tip: set SLACK_BOT_TOKEN + SLACK_APP_TOKEN in your env.",
     `Docs: ${formatDocsLink("/slack", "slack")}`,

--- a/extensions/slack/src/setup-surface.test.ts
+++ b/extensions/slack/src/setup-surface.test.ts
@@ -182,6 +182,9 @@ describe("slackSetupWizard.prepare", () => {
       },
       settings: {
         socket_mode_enabled: true,
+        interactivity: {
+          is_enabled: true,
+        },
         event_subscriptions: {
           bot_events: [
             "app_home_opened",


### PR DESCRIPTION
## What Problem This Solves

Slack does not let people add an app to an existing people-only group DM, and OpenClaw did not provide a supported way to create the equivalent bot-inclusive conversation. Searching for the app in Slack's **Add people** dialog therefore returns no result, while `/openclaw` starts a session without changing the conversation membership.

Fixes #102038.

## Why This Change Was Made

This adds an inline App Home flow instead of another slash command or modal:

- a native Slack people picker selects 1–7 other members;
- the authenticated actor and OpenClaw are included automatically;
- `conversations.open` creates or resumes the exact-member MPIM;
- the existing catch-all block-action listener owns the click, preserving one acknowledgement and preventing an agent wake-up;
- existing DM authorization and group-DM configuration remain the gate;
- the generated Socket Mode manifest now enables interactivity.

The Slack guide explains setup, authorization, exact-member resumption, relay limitations, troubleshooting, and the key platform constraint: this creates a separate bot-inclusive group DM and cannot copy history from the original people-only DM. Users who need to preserve that history can instead convert the original group DM to a private channel and invite OpenClaw there.

## User Impact

When Slack DMs and unrestricted group DMs are enabled, an authorized user can open **Apps → OpenClaw → Home**, choose people, and open the resulting group DM. Everyone selected can use the agent in that conversation, which is disclosed in the picker and documentation. Existing configurations with group DMs disabled or concrete-only group-DM allowlists do not expose the control.

Related documentation work in #101944 by @clawSean covers general group-DM membership semantics; this PR preserves that scope and adds only the implemented App Home creation flow.

Release-note context: Slack users can create or resume bot-inclusive group DMs from OpenClaw's App Home.

## Evidence

- AWS Crabbox run `run_fec2cfe63716`: 73 focused Slack tests passed across App Home, block-action routing, and setup-manifest coverage before the final authorization hardening.
- AWS Crabbox run `run_177b3c67449e`: changed-file gates passed, including extension production/test `tsgo`, lint, plugin SDK boundaries, conflict/dependency/runtime guards, and import-cycle checks.
- Documentation checks passed directly: 701 MDX files, i18n glossary, 5,758 internal links with 0 broken links, generated docs map current, and `git diff --check` clean.
- Manual review covered the App Home ownership seam, Bolt listener overlap, authorization/delegation semantics, Slack API limits, exact-member reopening, and documentation accuracy.
- Fresh autoreview found an unpaired-creator authorization bypass; the flow now reuses `authorizeSlackDirectMessage`, includes pairing-store approvals, displays pairing instructions privately in App Home, and has a regression test. The required rerun completed with zero findings.

Known proof gaps:

- A live Slack create/reopen round trip was not run because no workspace credential was authorized for this task. The Slack Web API contract and installed SDK types were inspected directly; CI and reviewer live verification remain useful because Slack's scope documentation is internally inconsistent about bot-token MPIM creation.
- The post-hardening focused test rerun could not start because the reusable AWS lease was no longer available and the disposable dependency tree had been pruned. Draft CI run `28922743345` admitted the exact SHA but intentionally skipped test jobs; exact-head test proof remains for the ready-for-review run.
- The aggregate `check:docs`/anchor wrappers could not finish after `pnpm dlx` corrupted its disposable cache (`ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND`); their component MDX, glossary, link, and docs-map checks passed as listed above.
