### PR TITLE
fix(browser): report malformed relay CDP frames

### DIFF
--- a/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
@@ -324,6 +324,34 @@ describe("ExtensionRelayBridge", () => {
     expect(bridge.extensionConnected).toBe(false);
   });
 
+  it("reports malformed CDP client JSON instead of leaving the client waiting", () => {
+    const bridge = new ExtensionRelayBridge();
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+
+    cdp.onMessage("{");
+
+    expect(client.frames()).toEqual([
+      { id: null, error: { code: -32700, message: "Parse error" } },
+    ]);
+  });
+
+  it("reports invalid CDP client requests instead of leaving the client waiting", () => {
+    const bridge = new ExtensionRelayBridge();
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+
+    cdp.onMessage(JSON.stringify({ id: 7, sessionId: "session-1", params: {} }));
+
+    expect(client.frames()).toEqual([
+      {
+        id: 7,
+        sessionId: "session-1",
+        error: { code: -32600, message: "Invalid request" },
+      },
+    ]);
+  });
+
   it("reaps child sessions when a tab leaves the group (no stale routing)", async () => {
     const bridge = new ExtensionRelayBridge();
     const { handlers } = wireExtension(bridge);

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -41,10 +41,6 @@ type CdpRequest = {
   sessionId?: string;
 };
 
-type CdpRequestParseResult =
-  | { ok: true; request: CdpRequest }
-  | { ok: false; id: number | null; sessionId?: string; message: string; code: number };
-
 type PendingExtensionCommand = {
   resolve: (result: unknown) => void;
   reject: (err: Error) => void;
@@ -83,30 +79,8 @@ function toErrorPayload(
   sessionId: string | undefined,
   message: string,
   code = -32000,
-) {
+): string {
   return JSON.stringify({ id, ...(sessionId ? { sessionId } : {}), error: { code, message } });
-}
-
-function parseCdpRequest(raw: string): CdpRequestParseResult {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return { ok: false, id: null, message: "Parse error", code: -32700 };
-  }
-
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return { ok: false, id: null, message: "Invalid request", code: -32600 };
-  }
-
-  const request = parsed as Record<string, unknown>;
-  const id = typeof request.id === "number" ? request.id : null;
-  const sessionId = typeof request.sessionId === "string" ? request.sessionId : undefined;
-  if (typeof request.id !== "number" || typeof request.method !== "string") {
-    return { ok: false, id, sessionId, message: "Invalid request", code: -32600 };
-  }
-
-  return { ok: true, request: parsed as CdpRequest };
 }
 
 /**
@@ -525,14 +499,26 @@ export class ExtensionRelayBridge {
     const client: CdpClientState = { socket, autoAttach: false, announcedSessions: new Set() };
     this.clients.add(client);
     const onMessage = (raw: string) => {
-      const parsed = parseCdpRequest(raw);
-      if (!parsed.ok) {
-        client.socket.send(
-          toErrorPayload(parsed.id, parsed.sessionId, parsed.message, parsed.code),
-        );
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        client.socket.send(toErrorPayload(null, undefined, "Parse error", -32700));
         return;
       }
-      void this.handleCdpRequest(client, parsed.request);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        client.socket.send(toErrorPayload(null, undefined, "Invalid request", -32600));
+        return;
+      }
+      const request = parsed as Record<string, unknown>;
+      if (typeof request.id !== "number" || typeof request.method !== "string") {
+        const id = typeof request.id === "number" ? request.id : null;
+        const sessionId = typeof request.sessionId === "string" ? request.sessionId : undefined;
+        // Flat CDP routes responses by sessionId before matching the request id.
+        client.socket.send(toErrorPayload(id, sessionId, "Invalid request", -32600));
+        return;
+      }
+      void this.handleCdpRequest(client, request as CdpRequest);
     };
     const onClose = () => {
       this.clients.delete(client);

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -41,6 +41,10 @@ type CdpRequest = {
   sessionId?: string;
 };
 
+type CdpRequestParseResult =
+  | { ok: true; request: CdpRequest }
+  | { ok: false; id: number | null; sessionId?: string; message: string; code: number };
+
 type PendingExtensionCommand = {
   resolve: (result: unknown) => void;
   reject: (err: Error) => void;
@@ -74,8 +78,35 @@ type ExtensionIdentity = {
   extensionVersion: string;
 };
 
-function toErrorPayload(id: number, sessionId: string | undefined, message: string, code = -32000) {
+function toErrorPayload(
+  id: number | null,
+  sessionId: string | undefined,
+  message: string,
+  code = -32000,
+) {
   return JSON.stringify({ id, ...(sessionId ? { sessionId } : {}), error: { code, message } });
+}
+
+function parseCdpRequest(raw: string): CdpRequestParseResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { ok: false, id: null, message: "Parse error", code: -32700 };
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { ok: false, id: null, message: "Invalid request", code: -32600 };
+  }
+
+  const request = parsed as Record<string, unknown>;
+  const id = typeof request.id === "number" ? request.id : null;
+  const sessionId = typeof request.sessionId === "string" ? request.sessionId : undefined;
+  if (typeof request.id !== "number" || typeof request.method !== "string") {
+    return { ok: false, id, sessionId, message: "Invalid request", code: -32600 };
+  }
+
+  return { ok: true, request: parsed as CdpRequest };
 }
 
 /**
@@ -494,16 +525,14 @@ export class ExtensionRelayBridge {
     const client: CdpClientState = { socket, autoAttach: false, announcedSessions: new Set() };
     this.clients.add(client);
     const onMessage = (raw: string) => {
-      let request: CdpRequest;
-      try {
-        request = JSON.parse(raw) as CdpRequest;
-      } catch {
+      const parsed = parseCdpRequest(raw);
+      if (!parsed.ok) {
+        client.socket.send(
+          toErrorPayload(parsed.id, parsed.sessionId, parsed.message, parsed.code),
+        );
         return;
       }
-      if (typeof request?.id !== "number" || typeof request?.method !== "string") {
-        return;
-      }
-      void this.handleCdpRequest(client, request);
+      void this.handleCdpRequest(client, parsed.request);
     };
     const onClose = () => {
       this.clients.delete(client);


### PR DESCRIPTION
﻿Closes #102057

## What Problem This Solves

Fixes an issue where browser extension relay CDP clients would keep waiting when they sent malformed JSON or a structurally invalid CDP request frame.

## Why This Change Was Made

The relay now validates inbound CDP client frames at the socket boundary and returns JSON-RPC parse or invalid-request errors instead of silently dropping those frames. Valid CDP requests continue through the existing request handler unchanged.

## User Impact

Automation clients connected through the browser extension relay now receive immediate protocol errors for malformed client frames instead of timing out without a response.

## Evidence

- Current-main source check: `extensions/browser/src/browser/extension-relay/relay-bridge.ts` previously returned silently when `JSON.parse(raw)` failed or when the parsed request lacked numeric `id` / string `method`.
- Focused regression: `node scripts/run-vitest.mjs extensions/browser/src/browser/extension-relay/relay-bridge.test.ts` passed in the first issue worktree after dependency hydration: 1 file, 12 tests.
- Clean worktree proof: `git diff --check HEAD~1..HEAD` passed.
- Format proof: `pnpm dlx oxfmt@0.57.0 --check --threads=1 extensions/browser/src/browser/extension-relay/relay-bridge.ts extensions/browser/src/browser/extension-relay/relay-bridge.test.ts` passed.
- Closeout review: `python .agents\skills\autoreview\scripts\autoreview --mode local` reported no accepted/actionable findings before commit.
