### PR TITLE
fix(browser): return JSON-RPC errors for malformed CDP client frames in relay bridge

### DIFF
--- a/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
@@ -368,4 +368,44 @@ describe("ExtensionRelayBridge", () => {
     expect(socket.closed).toBe(true);
     expect(bridge.extensionConnected).toBe(false);
   });
+
+  it("responds with JSON-RPC parse error on malformed JSON from CDP client", () => {
+    const bridge = new ExtensionRelayBridge();
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+    cdp.onMessage("{");
+    const frames = client.frames();
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toMatchObject({
+      id: null,
+      error: { code: -32700, message: "Parse error" },
+    });
+  });
+
+  it("responds with JSON-RPC invalid request error when CDP client frame lacks id or method", () => {
+    const bridge = new ExtensionRelayBridge();
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+    // Missing id and method
+    cdp.onMessage(JSON.stringify({ params: {} }));
+    const frames = client.frames();
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toMatchObject({
+      id: null,
+      error: { code: -32600, message: "Invalid Request" },
+    });
+  });
+
+  it("responds with invalid request error when CDP client frame has id but no method", () => {
+    const bridge = new ExtensionRelayBridge();
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+    cdp.onMessage(JSON.stringify({ id: 7 }));
+    const frames = client.frames();
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toMatchObject({
+      id: 7,
+      error: { code: -32600, message: "Invalid Request" },
+    });
+  });
 });

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -74,7 +74,12 @@ type ExtensionIdentity = {
   extensionVersion: string;
 };
 
-function toErrorPayload(id: number, sessionId: string | undefined, message: string, code = -32000) {
+function toErrorPayload(
+  id: number | null,
+  sessionId: string | undefined,
+  message: string,
+  code = -32000,
+) {
   return JSON.stringify({ id, ...(sessionId ? { sessionId } : {}), error: { code, message } });
 }
 
@@ -498,9 +503,18 @@ export class ExtensionRelayBridge {
       try {
         request = JSON.parse(raw) as CdpRequest;
       } catch {
+        client.socket.send(toErrorPayload(null, undefined, "Parse error", -32700));
         return;
       }
       if (typeof request?.id !== "number" || typeof request?.method !== "string") {
+        client.socket.send(
+          toErrorPayload(
+            typeof request?.id === "number" ? request.id : null,
+            undefined,
+            "Invalid Request",
+            -32600,
+          ),
+        );
         return;
       }
       void this.handleCdpRequest(client, request);


### PR DESCRIPTION
## What Problem This Solves

The browser extension relay bridge's `attachCdpClientSocket` silently
drops malformed JSON and invalid CDP request frames without sending any
response to the client. This leaves automation clients (e.g. Playwright
`connectOverCDP`) waiting for their own timeout instead of receiving an
immediate protocol error.

Fixes #102057.

## Why This Change Was Made

The `onMessage` handler in `attachCdpClientSocket` had two silent-return
paths:
1. `catch` block after `JSON.parse` — malformed JSON
2. Missing `id` (number) or `method` (string) guard — invalid request

Both returned without writing anything to the client socket. The fix
sends JSON-RPC 2.0 error responses:

- **Parse error (-32700)**: malformed JSON, `id: null`
- **Invalid Request (-32600)**: missing required fields, preserves `id`
  from the parsed object when available

This matches the existing JSON-RPC error precedent in the gateway MCP
HTTP path (`src/gateway/mcp-http.ts`), which already returns `-32700`
and `-32600` at protocol boundaries.

`toErrorPayload` was loosened from `id: number` to `id: number | null`
so parse errors can use a null id as specified by JSON-RPC 2.0.

## Evidence

### Test results (Vitest)

```
$ npx vitest run extensions/browser/src/browser/extension-relay/relay-bridge.test.ts --no-coverage

 Test Files  1 passed (1)
      Tests  13 passed (13)
   Duration  10.99s
```

3 regression tests added (all existing 10 tests continue to pass):

1. **Malformed JSON** (`{`) → parse error -32700 with `id: null`
2. **Invalid request (no id or method)** (`{params:{}}`) → invalid
   request -32600 with `id: null`
3. **Has id but no method** (`{id:7}`) → invalid request -32600 with
   `id: 7`

### Pre-commit checks pass

```
$ git diff --cached --stat
 extensions/browser/.../relay-bridge.test.ts | 40 ++++++++++++++++++++++
 extensions/browser/.../relay-bridge.ts      | 16 ++++++++-
 2 files changed, 55 insertions(+), 1 deletion(-)
```

No lockfile or unrelated file changes.

## Merge Risk

Low. The change is scoped to two guarded early-return paths in a single
CDP client message handler. The only behavioral difference is that
clients now receive an error response instead of silence. Normal CDP
routing through `handleCdpRequest` is unchanged.