### PR TITLE
fix(qa-lab): fail qa cli runs on stream errors

### DIFF
--- a/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
@@ -155,6 +155,9 @@ describe("qa suite runtime agent process helpers", () => {
 
   it("rejects and kills the qa cli when stdout emits an error", async () => {
     const child = createSpawnedProcess();
+    child.kill.mockImplementation(() => {
+      child.emit("close", 0);
+    });
     spawnMock.mockReturnValue(child);
 
     const pending = runQaCli(
@@ -174,7 +177,6 @@ describe("qa suite runtime agent process helpers", () => {
 
     await waitForSpawnCount(1);
     child.stdout.emit("error", new Error("pipe broke"));
-    child.emit("close", 0);
 
     await assertion;
     expect(child.kill).toHaveBeenCalledWith("SIGKILL");
@@ -182,6 +184,9 @@ describe("qa suite runtime agent process helpers", () => {
 
   it("rejects and kills the qa cli when stderr emits an error", async () => {
     const child = createSpawnedProcess();
+    child.kill.mockImplementation(() => {
+      child.emit("close", 0);
+    });
     spawnMock.mockReturnValue(child);
 
     const pending = runQaCli(
@@ -202,7 +207,6 @@ describe("qa suite runtime agent process helpers", () => {
 
     await waitForSpawnCount(1);
     child.stderr.emit("error", new Error("pipe broke"));
-    child.emit("close", 0);
 
     await assertion;
     expect(child.kill).toHaveBeenCalledWith("SIGKILL");

--- a/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
@@ -153,6 +153,61 @@ describe("qa suite runtime agent process helpers", () => {
     }
   });
 
+  it("rejects and kills the qa cli when stdout emits an error", async () => {
+    const child = createSpawnedProcess();
+    spawnMock.mockReturnValue(child);
+
+    const pending = runQaCli(
+      {
+        repoRoot: "/repo",
+        gateway: {
+          tempRoot: "/tmp/runtime",
+          runtimeEnv: { PATH: "/usr/bin" },
+        },
+        primaryModel: "openai/gpt-5.5",
+        alternateModel: "openai/gpt-5.5-mini",
+        providerMode: "mock-openai",
+      } as never,
+      ["qa", "suite"],
+    );
+    const assertion = expect(pending).rejects.toThrow("qa cli stdout error: pipe broke");
+
+    await waitForSpawnCount(1);
+    child.stdout.emit("error", new Error("pipe broke"));
+    child.emit("close", 0);
+
+    await assertion;
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+
+  it("rejects and kills the qa cli when stderr emits an error", async () => {
+    const child = createSpawnedProcess();
+    spawnMock.mockReturnValue(child);
+
+    const pending = runQaCli(
+      {
+        repoRoot: "/repo",
+        gateway: {
+          tempRoot: "/tmp/runtime",
+          runtimeEnv: { PATH: "/usr/bin" },
+        },
+        primaryModel: "openai/gpt-5.5",
+        alternateModel: "openai/gpt-5.5-mini",
+        providerMode: "mock-openai",
+      } as never,
+      ["memory", "search", "--json"],
+      { json: true },
+    );
+    const assertion = expect(pending).rejects.toThrow("qa cli stderr error: pipe broke");
+
+    await waitForSpawnCount(1);
+    child.stderr.emit("error", new Error("pipe broke"));
+    child.emit("close", 0);
+
+    await assertion;
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+
   it.runIf(process.platform !== "win32")("kills timed-out qa cli process groups", async () => {
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
     try {

--- a/extensions/qa-lab/src/suite-runtime-agent-process.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.ts
@@ -274,25 +274,30 @@ async function runQaCli(
     let settled = false;
     const settleOnce = (settle: () => void) => {
       if (settled) {
-        return;
+        return false;
       }
       settled = true;
       clearTimeout(timeout);
       settle();
+      return true;
     };
     const rejectOutputStreamError = (streamName: "stdout" | "stderr", error: unknown) => {
-      signalQaCliProcessTree(child, "SIGKILL");
-      settleOnce(() => {
+      const didSettle = settleOnce(() => {
         reject(new Error(`qa cli ${streamName} error: ${formatErrorMessage(error)}`));
       });
+      if (didSettle) {
+        signalQaCliProcessTree(child, "SIGKILL");
+      }
     };
     const timeout = setTimeout(() => {
-      signalQaCliProcessTree(child, "SIGKILL");
-      settleOnce(() => {
+      const didSettle = settleOnce(() => {
         reject(
           new QaSuiteInfraError("qa_cli_timeout", `qa cli timed out: openclaw ${args.join(" ")}`),
         );
       });
+      if (didSettle) {
+        signalQaCliProcessTree(child, "SIGKILL");
+      }
     }, timeoutMs);
     child.stdout.on("data", (chunk) => appendQaChildOutput(stdout, chunk));
     child.stdout.once("error", (error) => rejectOutputStreamError("stdout", error));

--- a/extensions/qa-lab/src/suite-runtime-agent-process.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.ts
@@ -271,19 +271,41 @@ async function runQaCli(
       stdio: ["ignore", "pipe", "pipe"],
     });
     const timeoutMs = resolveTimerTimeoutMs(opts?.timeoutMs, 60_000);
+    let settled = false;
+    const settleOnce = (settle: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      settle();
+    };
+    const rejectOutputStreamError = (streamName: "stdout" | "stderr", error: unknown) => {
+      signalQaCliProcessTree(child, "SIGKILL");
+      settleOnce(() => {
+        reject(new Error(`qa cli ${streamName} error: ${formatErrorMessage(error)}`));
+      });
+    };
     const timeout = setTimeout(() => {
       signalQaCliProcessTree(child, "SIGKILL");
-      reject(
-        new QaSuiteInfraError("qa_cli_timeout", `qa cli timed out: openclaw ${args.join(" ")}`),
-      );
+      settleOnce(() => {
+        reject(
+          new QaSuiteInfraError("qa_cli_timeout", `qa cli timed out: openclaw ${args.join(" ")}`),
+        );
+      });
     }, timeoutMs);
     child.stdout.on("data", (chunk) => appendQaChildOutput(stdout, chunk));
+    child.stdout.once("error", (error) => rejectOutputStreamError("stdout", error));
     child.stderr.on("data", (chunk) => appendQaChildOutputTail(stderr, chunk));
+    child.stderr.once("error", (error) => rejectOutputStreamError("stderr", error));
     child.once("error", (error) => {
-      clearTimeout(timeout);
-      reject(error);
+      settleOnce(() => reject(error));
     });
     child.once("close", (code) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
       clearTimeout(timeout);
       if (code === 0) {
         if (stdout.exceeded) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QA Lab runs that invoke the OpenClaw CLI could keep waiting on a child process or report a misleading close/timeout result when the child's stdout or stderr stream failed.

## Why This Change Was Made

`runQaCli` now treats stdout and stderr stream errors as terminal child-process failures, kills the CLI process tree, and settles the run exactly once so a later close event cannot overwrite the original stream error.

## User Impact

QA Lab operators get a direct `qa cli stdout/stderr error` failure instead of a hung or ambiguous QA run when the CLI output pipe fails.

## Evidence

- Current-main source check: `extensions/qa-lab/src/suite-runtime-agent-process.ts` only listened for child `error` and `close`, while stdout/stderr only had `data` listeners.
- Focused regression: `node scripts/run-vitest.mjs extensions/qa-lab/src/suite-runtime-agent-process.test.ts` passed once in the first isolated worktree: 1 file, 26 passed, 1 skipped. That worktree was then rebuilt after `pnpm install` disturbed tracked workspace `node_modules` links on Windows; the final clean worktree was not reinstalled to avoid reintroducing those unrelated link mutations.
- Static proof: `git diff --check` passed in the final clean worktree.
- Follow-up fix: tightened stream-error settlement so stdout/stderr errors settle before killing the process tree; the regression mocks `kill()` to emit `close` synchronously and catch the race.
- Review: `python .agents\skills\autoreview\scripts\autoreview --mode local --base upstream/main` passed with no accepted/actionable findings.