### PR TITLE
fix: keep status OAuth diagnostics when messages contain braces

### DIFF
--- a/src/commands/status-all/gateway.test.ts
+++ b/src/commands/status-all/gateway.test.ts
@@ -24,6 +24,19 @@ describe("summarizeLogTail", () => {
     expect(lines).toEqual(["[openai] token refresh 401 invalid_grant · re-auth required"]);
   });
 
+  it("keeps OAuth JSON diagnostics when the message contains braces", () => {
+    const lines = summarizeLogTail([
+      "[openai] Token refresh failed: 401 {",
+      `"error":${JSON.stringify({
+        code: "invalid_grant",
+        message: "Session invalidated } due to signing in again",
+      })}`,
+      "}",
+    ]);
+
+    expect(lines).toEqual(["[openai] token refresh 401 invalid_grant · re-auth required"]);
+  });
+
   it("keeps bounded OAuth diagnostics UTF-16 well-formed", () => {
     const lines = summarizeLogTail([
       "[openai] Token refresh failed: 500 {",

--- a/src/commands/status-all/gateway.ts
+++ b/src/commands/status-all/gateway.ts
@@ -16,13 +16,6 @@ export async function readFileTailLines(filePath: string, maxLines: number): Pro
   return out.map((line) => line.trimEnd()).filter((line) => line.trim().length > 0);
 }
 
-function countMatches(haystack: string, needle: string): number {
-  if (!haystack || !needle) {
-    return 0;
-  }
-  return haystack.split(needle).length - 1;
-}
-
 function shorten(message: string, maxLen: number): string {
   const cleaned = message.replace(/\s+/g, " ").trim();
   if (cleaned.length <= maxLen) {
@@ -52,13 +45,41 @@ function consumeJsonBlock(
   }
 
   const parts: string[] = [startLine.slice(braceAt)];
-  let depth = countMatches(parts[0] ?? "", "{") - countMatches(parts[0] ?? "", "}");
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  const scan = (text: string) => {
+    // Gateway logs carry JSON fragments as text; braces inside quoted strings
+    // must not end the block or OAuth diagnostics lose their provider message.
+    for (const char of text) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (inString) {
+        if (char === "\\") {
+          escaped = true;
+        } else if (char === '"') {
+          inString = false;
+        }
+        continue;
+      }
+      if (char === '"') {
+        inString = true;
+      } else if (char === "{") {
+        depth += 1;
+      } else if (char === "}") {
+        depth -= 1;
+      }
+    }
+  };
+  scan(parts[0] ?? "");
   let i = startIndex;
   while (depth > 0 && i + 1 < lines.length) {
     i += 1;
     const next = lines[i] ?? "";
     parts.push(next);
-    depth += countMatches(next, "{") - countMatches(next, "}");
+    scan(next);
   }
   return { json: parts.join("\n"), endIndex: i };
 }


### PR DESCRIPTION
## What Problem This Solves

`openclaw status --all` summarizes Gateway log tails into compact diagnostics. The `consumeJsonBlock` helper used a simple brace counter (`countMatches`) that could not distinguish structural braces from braces inside quoted JSON strings. When a provider OAuth error message contained `}` (e.g. "Session invalidated } due to signing in again"), the block closed prematurely and the diagnostic was silently truncated.

### Before

Gateway log:

```
[openai] Token refresh failed: 401 {
{"error":{"code":"invalid_grant","message":"Session invalidated } due to signing in again"}}
}
```

`summarizeLogTail` → `[openai] token refresh 401` (message lost)

### After

`summarizeLogTail` → `[openai] token refresh 401 invalid_grant · re-auth required`

## Why This Change Was Made

Replaced the brace counter with a character-level state machine that tracks:

- **`inString`** — whether the cursor is inside a double-quoted string
- **`escaped`** — whether the previous character was `\` (prevents `\"` from falsely ending a string)

| State | Input | Action |
|-------|-------|--------|
| normal | `"` | enter string |
| normal | `{` | depth += 1 |
| normal | `}` | depth -= 1 |
| string | `\` | set escaped |
| string (escaped) | any | clear escaped |
| string | `"` | exit string |
| string | any | continue |

Braces inside quoted strings are ignored for depth counting. Escaped quotes (`\"`) do not toggle string state.

## User Impact

`openclaw status --all` now shows complete OAuth refresh diagnostics when provider error messages contain braces. Operators can diagnose auth failures from status output without opening the raw Gateway log.

## Real Behavior Proof

Verified against commit `55787eb` on branch `fix/fix-status-all-json-brace-summary`.

### Test result

```
$ pnpm test src/commands/status-all/gateway.test.ts
Test Files  1 passed (1)
Tests       7 passed (7)
```

### Regression case

```typescript
it("keeps OAuth JSON diagnostics when the message contains braces", () => {
  const lines = summarizeLogTail([
    "[openai] Token refresh failed: 401 {",
    `"error":${JSON.stringify({
      code: "invalid_grant",
      message: "Session invalidated } due to signing in again",
    })}`,
    "}",
  ]);
  expect(lines).toEqual(["[openai] token refresh 401 invalid_grant · re-auth required"]);
});
```

### Edge cases verified

| Input | Expected | Actual |
|-------|----------|--------|
| `{"msg":"brace } inside"}` | `}` inside string ignored | PASS |
| `{"msg":"escaped \\" quote"}` | `\\"` does not toggle string | PASS |
| Two adjacent JSON objects | Independent depth tracking | PASS |
| No braces in line | `depth` unchanged | PASS |

## Risk Checklist

- **User-visible behavior:** No — `status --all` diagnostic output is more complete; previously-truncated provider messages are now visible.
- **Config/env/migration behavior:** No.
- **Security/auth/secrets/network/tool execution:** No.
- **Plugins/providers/channels/SDK:** No — log summarization only.
- **Highest-risk area:** None. The scanner is a pure function on log text; the only behavioral difference is braces inside strings are now correctly excluded from depth counting.
- **Mitigation:** 7 unit tests cover the original behavior and the new regression case.

Closes: N/A
