### PR TITLE
fix: QA HTTP endpoints return stable malformed JSON errors

### DIFF
--- a/extensions/qa-lab/src/bus-server.test.ts
+++ b/extensions/qa-lab/src/bus-server.test.ts
@@ -172,6 +172,19 @@ describe("qa-bus server", () => {
     });
   });
 
+  it("returns a controlled error when a v1 POST body contains malformed JSON", async () => {
+    const state = createQaBusState();
+    const bus = await startQaBusServer({ state });
+    stops.push(bus["stop"]);
+
+    const response = await postQaBusRawJson(bus.baseUrl, "/v1/reset", "{");
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Malformed JSON body",
+    });
+  });
+
   it("keeps oversized numeric poll and search fields bounded", async () => {
     const state = createQaBusState();
     const bus = await startQaBusServer({ state });

--- a/extensions/qa-lab/src/bus-server.ts
+++ b/extensions/qa-lab/src/bus-server.ts
@@ -26,6 +26,18 @@ const QA_HTTP_JSON_BODY_TIMEOUT_MS = 5_000;
 const QA_BUS_POLL_TIMEOUT_MAX_MS = 30_000;
 const QA_BUS_POLL_LIMIT_MAX = 500;
 const QA_BUS_SEARCH_LIMIT_MAX = 100;
+const QA_MALFORMED_JSON_BODY_MESSAGE = "Malformed JSON body";
+
+export class QaMalformedJsonBodyError extends Error {
+  constructor() {
+    super(QA_MALFORMED_JSON_BODY_MESSAGE);
+    this.name = "QaMalformedJsonBodyError";
+  }
+}
+
+export function isQaMalformedJsonBodyError(error: unknown): error is QaMalformedJsonBodyError {
+  return error instanceof QaMalformedJsonBodyError;
+}
 
 export async function readQaJsonBody(req: IncomingMessage): Promise<unknown> {
   const text = (
@@ -34,7 +46,14 @@ export async function readQaJsonBody(req: IncomingMessage): Promise<unknown> {
       timeoutMs: QA_HTTP_JSON_BODY_TIMEOUT_MS,
     })
   ).trim();
-  return text ? (JSON.parse(text) as unknown) : {};
+  if (!text) {
+    return {};
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new QaMalformedJsonBodyError();
+  }
 }
 
 export function writeJson(res: ServerResponse, statusCode: number, body: unknown) {

--- a/extensions/qa-lab/src/lab-server.test.ts
+++ b/extensions/qa-lab/src/lab-server.test.ts
@@ -6,12 +6,12 @@ import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readQaJsonBody } from "./bus-server.js";
+import { resolveUiAssetVersion } from "./lab-server-ui.js";
 import {
   startQaLabServer,
   writeQaLabServerError,
   type QaLabServerStartParams,
 } from "./lab-server.js";
-import { resolveUiAssetVersion } from "./lab-server-ui.js";
 
 const qaChannelMock = vi.hoisted(() => ({
   resolveAccount: vi.fn(),
@@ -637,6 +637,26 @@ describe("qa-lab server", () => {
 
     expect(res.statusCode).toBe(413);
     expect(JSON.parse(res.body)).toEqual({ error: "Payload too large" });
+  });
+
+  it("returns controlled errors for malformed JSON body reads", async () => {
+    const lab = await startQaLabServerForTest();
+    cleanups.push(async () => {
+      await lab.stop();
+    });
+
+    const response = await fetch(`${lab.baseUrl}/api/inbound/message`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: "{",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Malformed JSON body",
+    });
   });
 
   it("anchors direct self-check runs under the explicit repo root by default", async () => {

--- a/extensions/qa-lab/src/lab-server.ts
+++ b/extensions/qa-lab/src/lab-server.ts
@@ -10,6 +10,7 @@ import {
 import {
   closeQaHttpServer,
   handleQaBusRequest,
+  isQaMalformedJsonBodyError,
   readQaJsonBody,
   writeError,
   writeJson,
@@ -74,6 +75,10 @@ export type {
 
 export function writeQaLabServerError(res: Parameters<typeof writeError>[0], error: unknown): void {
   if (writeQaRequestBodyLimitError(res, error)) {
+    return;
+  }
+  if (isQaMalformedJsonBodyError(error)) {
+    writeError(res, 400, error.message);
     return;
   }
   if (error instanceof QaEvidenceGalleryError) {


### PR DESCRIPTION
Closes #102055

## What Problem This Solves

Fixes an issue where QA Bus and QA Lab HTTP POST endpoints returned runtime-specific JSON parser diagnostics when operators or tests sent malformed JSON bodies. On QA Lab routes, the same malformed body could also surface as a 500 response instead of a controlled client error.

## Why This Change Was Made

Malformed JSON is now normalized at the shared QA JSON body reader boundary, while the existing bounded body handling for oversized, timed-out, or closed requests is preserved. QA Lab's server error writer maps that malformed-body error to the same stable 400 JSON response used by QA Bus.

## User Impact

QA Lab and QA Bus callers now get a stable `{ "error": "Malformed JSON body" }` response for malformed JSON, making QA HTTP failures easier to assert and troubleshoot across Node versions.

## Evidence

Real HTTP proof after fix, using local source servers and malformed POST bodies outside Vitest:

```text
node --import tsx --input-type=module <inline script that starts startQaBusServer and startQaLabServer, then fetches malformed JSON POST bodies>

QA Bus malformed JSON POST /v1/reset
status=400
body={"error":"Malformed JSON body"}
QA Lab malformed JSON POST /api/inbound/message
status=400
body={"error":"Malformed JSON body"}
```

Before fix, with the production QA body reader restored to `upstream/main` and the new malformed-body regressions still present:

```text
node scripts/run-vitest.mjs extensions/qa-lab/src/bus-server.test.ts extensions/qa-lab/src/lab-server.test.ts -t "malformed JSON"

FAIL bus-server.test.ts > expected { error: "Malformed JSON body" }
received { error: "Expected property name or '}' in JSON at position 1 (line 1 column 2)" }

FAIL lab-server.test.ts > expected 400, received 500
```

After fix:

```text
node scripts/run-vitest.mjs extensions/qa-lab/src/bus-server.test.ts extensions/qa-lab/src/lab-server.test.ts -t "malformed JSON"
Test Files  2 passed (2)
Tests  2 passed | 21 skipped (23)
```

```text
node scripts/run-vitest.mjs extensions/qa-lab/src/bus-server.test.ts extensions/qa-lab/src/lab-server.test.ts
Test Files  2 passed (2)
Tests  23 passed (23)
```

Additional local checks:

```text
node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
# exited 0

node_modules/.bin/oxfmt --check --threads=1 extensions/qa-lab/src/bus-server.ts extensions/qa-lab/src/lab-server.ts extensions/qa-lab/src/bus-server.test.ts extensions/qa-lab/src/lab-server.test.ts
All matched files use the correct format.

git diff --check
# no output
```

Local live agent proof using the configured DeepSeek provider:

```text
pnpm openclaw agent --local --model deepseek/deepseek-v4-pro --session-key agent:main:issue-102055-proof --message "Reply exactly: OPENCLAW_DEEPSEEK_OK" --timeout 120 --json
payload text: OPENCLAW_DEEPSEEK_OK
provider: deepseek
model: deepseek-v4-pro
executionTrace result: success
fallbackUsed: false
```

Autoreview:

```text
.agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
```

AI-assisted.
