### PR TITLE
fix(qa-lab): control malformed JSON body errors

### DIFF
--- a/extensions/qa-lab/src/bus-server.test.ts
+++ b/extensions/qa-lab/src/bus-server.test.ts
@@ -172,6 +172,19 @@ describe("qa-bus server", () => {
     });
   });
 
+  it("returns a controlled error when a JSON body is malformed", async () => {
+    const state = createQaBusState();
+    const bus = await startQaBusServer({ state });
+    stops.push(bus["stop"]);
+
+    const response = await postQaBusRawJson(bus.baseUrl, "/v1/reset", "{");
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Malformed JSON body.",
+    });
+  });
+
   it("keeps oversized numeric poll and search fields bounded", async () => {
     const state = createQaBusState();
     const bus = await startQaBusServer({ state });

--- a/extensions/qa-lab/src/bus-server.ts
+++ b/extensions/qa-lab/src/bus-server.ts
@@ -27,6 +27,14 @@ const QA_BUS_POLL_TIMEOUT_MAX_MS = 30_000;
 const QA_BUS_POLL_LIMIT_MAX = 500;
 const QA_BUS_SEARCH_LIMIT_MAX = 100;
 
+export class QaMalformedJsonBodyError extends Error {
+  readonly statusCode = 400;
+
+  constructor() {
+    super("Malformed JSON body.");
+  }
+}
+
 export async function readQaJsonBody(req: IncomingMessage): Promise<unknown> {
   const text = (
     await readRequestBodyWithLimit(req, {
@@ -34,7 +42,14 @@ export async function readQaJsonBody(req: IncomingMessage): Promise<unknown> {
       timeoutMs: QA_HTTP_JSON_BODY_TIMEOUT_MS,
     })
   ).trim();
-  return text ? (JSON.parse(text) as unknown) : {};
+  try {
+    return text ? (JSON.parse(text) as unknown) : {};
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new QaMalformedJsonBodyError();
+    }
+    throw error;
+  }
 }
 
 export function writeJson(res: ServerResponse, statusCode: number, body: unknown) {
@@ -54,6 +69,10 @@ export function writeError(res: ServerResponse, statusCode: number, error: unkno
 
 export function writeQaRequestBodyLimitError(res: ServerResponse, error: unknown): boolean {
   if (!isRequestBodyLimitError(error)) {
+    if (error instanceof QaMalformedJsonBodyError) {
+      writeError(res, error.statusCode, error.message);
+      return true;
+    }
     return false;
   }
   writeError(res, error.statusCode, requestBodyErrorToText(error.code));

--- a/extensions/qa-lab/src/bus-server.ts
+++ b/extensions/qa-lab/src/bus-server.ts
@@ -27,11 +27,12 @@ const QA_BUS_POLL_TIMEOUT_MAX_MS = 30_000;
 const QA_BUS_POLL_LIMIT_MAX = 500;
 const QA_BUS_SEARCH_LIMIT_MAX = 100;
 
-export class QaMalformedJsonBodyError extends Error {
+class QaMalformedJsonBodyError extends Error {
   readonly statusCode = 400;
 
   constructor() {
     super("Malformed JSON body.");
+    this.name = "QaMalformedJsonBodyError";
   }
 }
 
@@ -68,11 +69,11 @@ export function writeError(res: ServerResponse, statusCode: number, error: unkno
 }
 
 export function writeQaRequestBodyLimitError(res: ServerResponse, error: unknown): boolean {
+  if (error instanceof QaMalformedJsonBodyError) {
+    writeError(res, error.statusCode, error.message);
+    return true;
+  }
   if (!isRequestBodyLimitError(error)) {
-    if (error instanceof QaMalformedJsonBodyError) {
-      writeError(res, error.statusCode, error.message);
-      return true;
-    }
     return false;
   }
   writeError(res, error.statusCode, requestBodyErrorToText(error.code));

--- a/extensions/qa-lab/src/lab-server.test.ts
+++ b/extensions/qa-lab/src/lab-server.test.ts
@@ -639,6 +639,28 @@ describe("qa-lab server", () => {
     expect(JSON.parse(res.body)).toEqual({ error: "Payload too large" });
   });
 
+  it("returns controlled errors for malformed JSON body reads", async () => {
+    const lab = await startQaLabServerForTest({
+      host: "127.0.0.1",
+      port: 0,
+      embeddedGateway: "disabled",
+    });
+    cleanups.push(async () => {
+      await lab.stop();
+    });
+
+    const response = await fetch(`${lab.baseUrl}/api/inbound/message`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: "{",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Malformed JSON body." });
+  });
+
   it("anchors direct self-check runs under the explicit repo root by default", async () => {
     const repoRoot = await mkdtemp(path.join(os.tmpdir(), "qa-lab-self-check-root-"));
     cleanups.push(async () => {


### PR DESCRIPTION
﻿Closes #102055

## What Problem This Solves

Fixes an issue where QA Lab and QA Bus users would receive runtime-specific JavaScript parser error text when sending malformed JSON request bodies to HTTP POST endpoints.

## Why This Change Was Made

The shared QA HTTP JSON body reader now converts `JSON.parse` syntax failures into a stable malformed-body error, and the existing QA request error writer maps that boundary error to a 400 JSON response. Oversized body handling and existing request validation behavior are unchanged.

## User Impact

QA Lab and QA Bus operators now get a predictable `{ "error": "Malformed JSON body." }` response for malformed JSON instead of Node parser wording that can vary by runtime.

## Evidence

- Current-main source check: `readQaJsonBody` in `extensions/qa-lab/src/bus-server.ts` read bounded body text but passed malformed JSON directly through `JSON.parse`, while only body-limit errors had a stable writer path.
- Focused regression: `node scripts/run-vitest.mjs extensions/qa-lab/src/bus-server.test.ts extensions/qa-lab/src/lab-server.test.ts` passed: 2 files, 23 tests.
- Whitespace check: `git diff --check` passed.
- Auto review: `python .agents\skills\autoreview\scripts\autoreview --mode local` passed with no accepted/actionable findings.
