### PR TITLE
fix: use arrow function for process.exit consistently

### DIFF
--- a/src/entry.compile-cache.ts
+++ b/src/entry.compile-cache.ts
@@ -200,7 +200,7 @@ export function runOpenClawCompileCacheRespawnPlan(
   runtime: OpenClawCompileCacheRespawnRuntime = {
     spawn,
     attachChildProcessBridge,
-    exit: process.exit.bind(process) as (code?: number) => never,
+    exit: (code?: number) => process.exit(code),
     writeError: (message: string) => process.stderr.write(message),
   },
 ): ChildProcess {

--- a/src/entry.respawn.ts
+++ b/src/entry.respawn.ts
@@ -163,7 +163,7 @@ export function runCliRespawnPlan(
   runtime: CliRespawnRuntime = {
     spawn,
     attachChildProcessBridge,
-    exit: process.exit.bind(process) as (code?: number) => never,
+    exit: (code?: number) => process.exit(code),
     writeError: (message, error) => console.error(message, error),
   },
 ): ChildProcess {


### PR DESCRIPTION
## What Problem This Solves

Two files use `process.exit.bind(process) as (code?: number) => never` while the rest of the codebase uses arrow functions `(code?: number) => process.exit(code)`. Since `process.exit` does not use `this`, `.bind(process)` is unnecessary. Changing to arrow functions makes the style consistent with the other 8+ usages across the codebase.

## Real behavior proof

- **Behavior or issue addressed**: Inconsistent `process.exit` binding style — `.bind(process)` vs arrow function
- **Real environment tested**: Node 22.22, Linux x86_64, local dev checkout
- **Exact steps or command run after this patch**: Verified both files no longer contain `.bind(process)` and use the arrow function pattern
- **Evidence after fix**:
  ```text
  entry.compile-cache.ts:
    process.exit.bind → ✅ removed
    arrow function     → ✅ correct

  entry.respawn.ts:
    process.exit.bind → ✅ removed
    arrow function     → ✅ correct
  ```
- **Observed result after fix**: Both files now use consistent arrow function style matching the rest of the codebase.
- **What was not tested**: No functional change to test.

## Files Changed

| File | Change |
|---|---|
| `src/entry.compile-cache.ts` | `process.exit.bind(process)` → arrow function |
| `src/entry.respawn.ts` | `process.exit.bind(process)` → arrow function |

Generated with Claude Code