### PR TITLE
fix(qa-lab): return stable diagnostic for malformed JSON in QA HTTP endpoints

### DIFF
--- a/extensions/qa-lab/src/bus-server.test.ts
+++ b/extensions/qa-lab/src/bus-server.test.ts
@@ -249,4 +249,18 @@ describe("handleQaBusRequest", () => {
     expect(res.statusCode).toBe(413);
     expect(JSON.parse(res.body)).toEqual({ error: "Payload too large" });
   });
+
+  it("returns a controlled error when a v1 POST body is malformed JSON", async () => {
+    const state = createQaBusState();
+    const bus = await startQaBusServer({ state });
+    try {
+      const response = await postQaBusRawJson(bus.baseUrl, "/v1/reset", "{");
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        error: "Malformed JSON body",
+      });
+    } finally {
+      await closeQaHttpServer(bus.server);
+    }
+  });
 });

--- a/extensions/qa-lab/src/bus-server.ts
+++ b/extensions/qa-lab/src/bus-server.ts
@@ -34,7 +34,12 @@ export async function readQaJsonBody(req: IncomingMessage): Promise<unknown> {
       timeoutMs: QA_HTTP_JSON_BODY_TIMEOUT_MS,
     })
   ).trim();
-  return text ? (JSON.parse(text) as unknown) : {};
+  if (!text) return {};
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new Error("Malformed JSON body");
+  }
 }
 
 export function writeJson(res: ServerResponse, statusCode: number, body: unknown) {


### PR DESCRIPTION
## What Problem This Solves

QA Bus and QA Lab HTTP endpoints leak raw JavaScript parser error text
when the JSON request body is malformed. Instead of a stable OpenClaw
diagnostic, callers see messages like "Expected property name or '}'
in JSON at position 1" that vary by Node version and parser internals.

Fixes #102055.

## Why This Change Was Made

`readQaJsonBody` in `extensions/qa-lab/src/bus-server.ts` called
`JSON.parse(text)` directly. The resulting `SyntaxError` was caught by
each caller's generic error handler and formatted through
`formatErrorMessage`, which preserves the parser-specific message.

The fix catches `SyntaxError` inside `readQaJsonBody` itself — the
shared boundary used by both QA Bus (`handleQaBusRequest`) and QA Lab
routes — and throws a stable `"Malformed JSON body"` error. This
matches the existing precedent in the mock-openai QA provider
(`extensions/qa-lab/src/providers/mock-openai/server.ts`), which
already returns the same diagnostic for malformed JSON.

## Evidence

### Test results (Vitest)

```
$ npx vitest run extensions/qa-lab/src/bus-server.test.ts --no-coverage

 Test Files  1 passed (1)
      Tests  7 passed (7)
   Duration  2.94s
```

1 regression test added: `POST /v1/reset` with `{` body → 400
`{"error":"Malformed JSON body"}`. All 6 existing tests pass unchanged.

### Pre-commit checks pass

```
$ git diff --cached --stat
 extensions/qa-lab/src/bus-server.test.ts | 14 ++++++++++++++
 extensions/qa-lab/src/bus-server.ts      |  7 ++++++-
 2 files changed, 20 insertions(+), 1 deletion(-)
```

No lockfile or unrelated file changes.

## Merge Risk

Low. The change is scoped to one function (`readQaJsonBody`) with a
single guarded `try/catch` around `JSON.parse`. Empty body `{}` behavior
is preserved (early return before the try block). Existing body-limit
error handling (`writeQaRequestBodyLimitError`) is unchanged — limit
errors are thrown by `readRequestBodyWithLimit` before `JSON.parse` runs.