### PR TITLE
fix(agents): keep tool-result truncation UTF-16 safe

### DIFF
--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -167,41 +167,32 @@ describe("truncateToolResultText", () => {
     expect(result.length).toBeGreaterThan(250);
   });
 
-  it("does not split surrogate pairs when truncating at a char boundary", () => {
-    // Emoji 😀 is U+1F600, a surrogate pair (2 UTF-16 code units).
-    const text = "a".repeat(100) + "😀".repeat(10) + "b".repeat(100);
-    const result = truncateToolResultText(text, 50);
-    expect(result.length).toBeLessThan(text.length);
-    expect(hasLoneSurrogate(result)).toBe(false);
+  it("keeps direct and suffix-only cuts on complete code points", () => {
+    expect(
+      truncateToolResultText("aaa😀z", 5, {
+        suffix: "!",
+        minKeepChars: 0,
+      }),
+    ).toBe("aaa!");
+    expect(
+      truncateToolResultText("abcdef", 1, {
+        suffix: "😀",
+        minKeepChars: 0,
+      }),
+    ).toBe("");
   });
 
-  it("does not split surrogate pairs in head+tail error-preserving truncation", () => {
-    const head = "line\n".repeat(500);
-    const middle = "x".repeat(10_000);
-    // Place an emoji so it sits right at the tail budget boundary.
-    const tail = "\nError: process failed 😀\n";
-    const text = head + middle + tail;
-    const result = truncateToolResultText(text, 5_000);
-    expect(result).toContain("Error: process failed");
-    expect(hasLoneSurrogate(result)).toBe(false);
+  it("keeps both head and tail cuts on complete code points", () => {
+    const marker = "\n\n⚠️ [... middle content omitted — showing head and tail ...]\n\n";
+    const text = `${"a".repeat(6)}😀${"m".repeat(100)}😀${"x".repeat(22)} Error`;
+    expect(
+      truncateToolResultText(text, 100, {
+        suffix: "!",
+        minKeepChars: 1,
+      }),
+    ).toBe(`${"a".repeat(6)}${marker}${"x".repeat(22)} Error!`);
   });
 });
-
-function hasLoneSurrogate(value: string): boolean {
-  for (let index = 0; index < value.length; index++) {
-    const code = value.charCodeAt(index);
-    if (code >= 0xd800 && code <= 0xdbff) {
-      const next = value.charCodeAt(index + 1);
-      if (next < 0xdc00 || next > 0xdfff) {
-        return true;
-      }
-      index++;
-    } else if (code >= 0xdc00 && code <= 0xdfff) {
-      return true;
-    }
-  }
-  return false;
-}
 
 describe("getToolResultTextLength", () => {
   it("sums all text blocks in tool results", () => {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -166,7 +166,42 @@ describe("truncateToolResultText", () => {
     expect(result).toContain("[custom-truncated]");
     expect(result.length).toBeGreaterThan(250);
   });
+
+  it("does not split surrogate pairs when truncating at a char boundary", () => {
+    // Emoji 😀 is U+1F600, a surrogate pair (2 UTF-16 code units).
+    const text = "a".repeat(100) + "😀".repeat(10) + "b".repeat(100);
+    const result = truncateToolResultText(text, 50);
+    expect(result.length).toBeLessThan(text.length);
+    expect(hasLoneSurrogate(result)).toBe(false);
+  });
+
+  it("does not split surrogate pairs in head+tail error-preserving truncation", () => {
+    const head = "line\n".repeat(500);
+    const middle = "x".repeat(10_000);
+    // Place an emoji so it sits right at the tail budget boundary.
+    const tail = "\nError: process failed 😀\n";
+    const text = head + middle + tail;
+    const result = truncateToolResultText(text, 5_000);
+    expect(result).toContain("Error: process failed");
+    expect(hasLoneSurrogate(result)).toBe(false);
+  });
 });
+
+function hasLoneSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) {
+        return true;
+      }
+      index++;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
 
 describe("getToolResultTextLength", () => {
   it("sums all text blocks in tool results", () => {

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -516,7 +516,7 @@ function formatAggregateElisionText(
   if (spillMarkers?.compact && spillMarkers.compact.length <= remainingTextBudget) {
     return spillMarkers.compact;
   }
-  return truncateUtf16Safe(AGGREGATE_ELISION_MARKER, remainingTextBudget);
+  return AGGREGATE_ELISION_MARKER.slice(0, remainingTextBudget);
 }
 
 /**

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -3,6 +3,7 @@
  */
 import { existsSync } from "node:fs";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { TextContent } from "../../llm/types.js";
@@ -139,11 +140,12 @@ function appendBoundedTruncationSuffix(params: {
       return finalText;
     }
     if (keptText.length === 0) {
-      return finalText.slice(0, params.maxChars);
+      return truncateUtf16Safe(finalText, params.maxChars);
     }
     const overflow = finalText.length - params.maxChars;
-    const nextKeptText = keptText.slice(0, Math.max(0, keptText.length - overflow));
-    keptText = nextKeptText.length < keptText.length ? nextKeptText : keptText.slice(0, -1);
+    const nextKeptText = sliceUtf16Safe(keptText, 0, Math.max(0, keptText.length - overflow));
+    keptText =
+      nextKeptText.length < keptText.length ? nextKeptText : sliceUtf16Safe(keptText, 0, -1);
   }
 }
 
@@ -158,8 +160,8 @@ const MIDDLE_OMISSION_MARKER =
  * which should be preserved during truncation.
  */
 function hasImportantTail(text: string): boolean {
-  // Check last ~2000 chars for error-like patterns
-  const tail = normalizeLowercaseStringOrEmpty(text.slice(-2000));
+  // Check last ~2000 chars for error-like patterns without splitting a surrogate pair.
+  const tail = normalizeLowercaseStringOrEmpty(sliceUtf16Safe(text, -2000));
   return (
     /\b(error|exception|failed|fatal|traceback|panic|stack trace|errno|exit code)\b/.test(tail) ||
     // JSON closing — if the output is JSON, the tail has closing structure
@@ -213,7 +215,8 @@ export function truncateToolResultText(
         tailStart = tailNewline + 1;
       }
 
-      const keptText = text.slice(0, headCut) + MIDDLE_OMISSION_MARKER + text.slice(tailStart);
+      const keptText =
+        sliceUtf16Safe(text, 0, headCut) + MIDDLE_OMISSION_MARKER + sliceUtf16Safe(text, tailStart);
       return appendBoundedTruncationSuffix({
         keptText,
         originalTextLength: text.length,
@@ -229,7 +232,7 @@ export function truncateToolResultText(
   if (lastNewline > budget * 0.8) {
     cutPoint = lastNewline;
   }
-  const keptText = text.slice(0, cutPoint);
+  const keptText = sliceUtf16Safe(text, 0, cutPoint);
   return appendBoundedTruncationSuffix({
     keptText,
     originalTextLength: text.length,
@@ -513,7 +516,7 @@ function formatAggregateElisionText(
   if (spillMarkers?.compact && spillMarkers.compact.length <= remainingTextBudget) {
     return spillMarkers.compact;
   }
-  return AGGREGATE_ELISION_MARKER.slice(0, remainingTextBudget);
+  return truncateUtf16Safe(AGGREGATE_ELISION_MARKER, remainingTextBudget);
 }
 
 /**


### PR DESCRIPTION
## Summary

- AI-assisted with Codex; I inspected the changed production path and can explain the change.
- Tool-result truncation now preserves UTF-16 boundaries when capping single results, detecting important error tails, and producing aggregate elision markers.
- Uses the existing `@openclaw/normalization-core/utf16-slice` helpers (`sliceUtf16Safe` / `truncateUtf16Safe`) instead of raw string slicing.
- Intentionally out of scope: unrelated truncation sites, response-read bounding, config changes, and behavior outside this specific formatting boundary.

## Linked context

- No linked issue.
- Related to the existing OpenClaw UTF-16-safe truncation hardening pattern (follow-up to Alix-007's merged UTF-16 campaign).

## Real behavior proof (required for external PRs)

- **Behavior addressed:** Tool-result truncation preserves UTF-16 boundaries when capping single results, detecting important error tails, and producing aggregate elision markers.
- **Real environment tested:** local OpenClaw source checkout on Node v22.22.0; PR head e050e018ff.
- **Exact steps or command run after this patch:** `node --import tsx` directly drives the exported truncation functions and checks for lone surrogates; plus `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-result-truncation.test.ts`.
- **Evidence after fix:** terminal capture from the current PR branch shows the affected paths no longer return a lone surrogate.

```text
$ node --import tsx -e '<drive truncateToolResultText + truncateToolResultMessage on emoji-crossing-boundary inputs>'
simple truncation lone surrogate: false
head+tail truncation lone surrogate: false
head+tail truncation keeps error: true
message truncation lone surrogate: false

$ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-result-truncation.test.ts
[test] starting test/vitest/vitest.agents.config.ts
...
Test Files 1 passed (1)
Tests 59 passed (59)
```

- **Observed result after fix:** the affected tool-result truncation paths keep output well-formed at the emoji/surrogate-pair boundary and preserve existing truncation markers, caps, and error-tail detection.
- **What was not tested:** full production deployment and unrelated provider/channel end-to-end delivery were not run; this proof is scoped to the touched local runtime path.
- **Proof limitations or environment constraints:** no private credentials or live third-party service were required; proof uses local runtime execution and focused regression coverage for this formatting bug.
- **Before evidence (optional but encouraged):** raw JavaScript string slicing can cut between a high and low surrogate at these boundaries, which produces a malformed dangling surrogate in tool output/prompts.

## Tests and validation

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-result-truncation.test.ts`
- Added focused regression coverage for the UTF-16 boundary case (simple truncation and head+tail error preservation).
- No known local failures from this change.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Malformed truncated tool output is now avoided while preserving existing caps and truncation markers.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

agent tool-result formatting.

How is that risk mitigated?

The patch is limited to the existing truncation boundaries and is covered by focused regression proof above.

## Current review state

What is the next action?

ClawSweeper re-review and maintainer review after this proof/body refresh.

What is still waiting on author, maintainer, CI, or external proof?

Nothing is waiting on the author after this proof update; waiting on CI/ClawSweeper/maintainer review.

Which bot or reviewer comments were addressed?

N/A — new PR.
