### PR TITLE
fix(nodes-cli): return stable diagnostic for malformed --params JSON

### DIFF
--- a/src/cli/nodes-cli.coverage.test.ts
+++ b/src/cli/nodes-cli.coverage.test.ts
@@ -339,4 +339,15 @@ describe("nodes-cli coverage", () => {
     expect(runtimeErrors.at(-1)).toContain(`${flag} must be`);
     expect(lastNodeInvokeCall).toBeNull();
   });
+
+  it("rejects nodes invoke with malformed --params JSON", async () => {
+    await expect(
+      sharedProgram.parseAsync(
+        ["nodes", "invoke", "--node", "mac-1", "--command", "canvas.eval", "--params", "not-json"],
+        { from: "user" },
+      ),
+    ).rejects.toThrow("__exit__:1");
+    expect(runtimeErrors.at(-1)).toContain("--params must be valid JSON");
+    expect(lastNodeInvokeCall).toBeNull();
+  });
 });

--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -43,7 +43,12 @@ export function registerNodesInvokeCommands(nodes: Command) {
               `command "${command}" is reserved for shell execution; use the exec tool with host=node instead`,
             );
           }
-          const params = JSON.parse(opts.params ?? "{}") as unknown;
+          let params: unknown;
+          try {
+            params = JSON.parse(opts.params ?? "{}") as unknown;
+          } catch {
+            throw new Error("--params must be valid JSON");
+          }
           const timeoutMs = parseOptionalNodePositiveInteger(
             opts.invokeTimeout,
             "--invoke-timeout",


### PR DESCRIPTION
## What Problem This Solves

`openclaw nodes invoke --params <malformed-json>` leaks raw JavaScript
parser error text (e.g. "Unexpected token 'n', ... is not valid JSON")
instead of identifying `--params` as the invalid option.

Fixes #101835.

## Why This Change Was Made

`register.invoke.ts` calls `JSON.parse(opts.params ?? "{}")` directly
at line 46. The thrown `SyntaxError` propagates through `runNodesCommand`
which formats it as `nodes invoke failed: <raw parser message>`, with no
indication that `--params` is the invalid flag.

The fix wraps `JSON.parse` in a try/catch and throws a stable
`"--params must be valid JSON"` error, matching the existing CLI
convention for malformed numeric options (e.g. `--invoke-timeout`).

## Evidence

### Test results (Vitest)

```
$ npx vitest run src/cli/nodes-cli.coverage.test.ts --no-coverage

 Test Files  1 passed (1)
      Tests  23 passed (23)
   Duration  15.66s
```

1 regression test added: `nodes invoke --params not-json` → exits with
error `--params must be valid JSON` and confirms no `node.invoke`
gateway call was made. All 22 existing tests continue to pass.

### Pre-commit checks pass

```
$ git diff --cached --stat
 src/cli/nodes-cli.coverage.test.ts   | 11 +++++++++++
 src/cli/nodes-cli/register.invoke.ts |  7 ++++++-
 2 files changed, 17 insertions(+), 1 deletion(-)
```

No lockfile or unrelated file changes.

## Merge Risk

Low. The fix adds a 4-line try/catch around a single `JSON.parse` call.
The thrown error type changes from `SyntaxError` to `Error`, but the
caller (`runNodesCommand`) already catches both identically via
`formatErrorMessage`.