### PR TITLE
fix(twilio): redact webhook turnToken diagnostics

### DIFF
--- a/extensions/voice-call/src/providers/twilio.test.ts
+++ b/extensions/voice-call/src/providers/twilio.test.ts
@@ -12,6 +12,7 @@ vi.mock("./shared/guarded-json-api.js", () => ({
 import type { WebhookContext } from "../types.js";
 import { TwilioProvider } from "./twilio.js";
 import { TwilioApiError } from "./twilio/api.js";
+import { verifyTwilioProviderWebhook } from "./twilio/webhook.js";
 
 const STREAM_URL = "wss://example.ngrok.app/voice/stream";
 
@@ -123,6 +124,36 @@ function configureTelephonyTwiMlFallback(params: { providerCallId: string; strea
 }
 
 describe("TwilioProvider", () => {
+  it("redacts turnToken query params from failed verification warnings", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const result = verifyTwilioProviderWebhook({
+        ctx: {
+          headers: {
+            host: "example.com",
+            "x-twilio-signature": "invalid",
+          },
+          rawBody: "CallSid=CS123&CallStatus=completed&From=%2B15550000000",
+          url: "https://example.com/voice/twilio?callId=call-1&turnToken=secret-turn-token",
+          method: "POST",
+          query: { callId: "call-1", turnToken: "secret-turn-token" },
+        },
+        authToken: "test-auth-token",
+        currentPublicUrl: null,
+        options: {},
+      });
+
+      const messages = warn.mock.calls.map((call) => call.join(" ")).join("\n");
+      expect(result.ok).toBe(false);
+      expect(messages).toContain("turnToken=***");
+      expect(messages).toContain("callId=***");
+      expect(messages).not.toContain("secret-turn-token");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it("uses the derived regional hostname for call status", async () => {
     guardedJsonApiRequestMock.mockResolvedValue({ status: "completed" });
     const provider = new TwilioProvider({

--- a/extensions/voice-call/src/providers/twilio.test.ts
+++ b/extensions/voice-call/src/providers/twilio.test.ts
@@ -149,6 +149,7 @@ describe("TwilioProvider", () => {
       expect(messages).toContain("turnToken=***");
       expect(messages).toContain("callId=***");
       expect(messages).not.toContain("secret-turn-token");
+      expect(warn).toHaveBeenCalledOnce();
     } finally {
       warn.mockRestore();
     }

--- a/extensions/voice-call/src/providers/twilio/webhook.ts
+++ b/extensions/voice-call/src/providers/twilio/webhook.ts
@@ -24,9 +24,6 @@ export function verifyTwilioProviderWebhook(params: {
 
   if (!result.ok) {
     console.warn(`[twilio] Webhook verification failed: ${result.reason}`);
-    if (result.verificationUrl) {
-      console.warn(`[twilio] Verification URL: ${result.verificationUrl}`);
-    }
   }
 
   return {

--- a/extensions/voice-call/src/webhook-security.test.ts
+++ b/extensions/voice-call/src/webhook-security.test.ts
@@ -583,7 +583,7 @@ describe("verifyTwilioWebhook", () => {
   it("uses request query when publicUrl omits it", () => {
     const authToken = "test-auth-token";
     const publicUrl = "https://example.com/voice/webhook";
-    const urlWithQuery = `${publicUrl}?callId=abc`;
+    const urlWithQuery = `${publicUrl}?callId=abc&turnToken=secret-turn-token`;
     const postBody = "CallSid=CS123&CallStatus=completed&From=%2B15550000000";
 
     const signature = twilioSignature({
@@ -600,15 +600,40 @@ describe("verifyTwilioWebhook", () => {
           "x-twilio-signature": signature,
         },
         rawBody: postBody,
-        url: "http://local/voice/webhook?callId=abc",
+        url: "http://local/voice/webhook?callId=abc&turnToken=secret-turn-token",
         method: "POST",
-        query: { callId: "abc" },
+        query: { callId: "abc", turnToken: "secret-turn-token" },
       },
       authToken,
       { publicUrl },
     );
 
     expect(result.ok).toBe(true);
+    expect(result.verificationUrl).toBe(urlWithQuery);
+  });
+
+  it("redacts query params from invalid Twilio signature diagnostics", () => {
+    const result = verifyTwilioWebhook(
+      {
+        headers: {
+          host: "example.com",
+          "x-twilio-signature": "invalid",
+        },
+        rawBody: "CallSid=CS123&CallStatus=completed&From=%2B15550000000",
+        url: "https://example.com/voice/webhook?callId=call-1&turnToken=secret-turn-token",
+        method: "POST",
+        query: { callId: "call-1", turnToken: "secret-turn-token" },
+      },
+      "test-auth-token",
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("Invalid signature for URL:");
+    expect(result.reason).toContain("turnToken=***");
+    expect(result.reason).toContain("callId=***");
+    expect(result.reason).not.toContain("secret-turn-token");
+    expect(result.verificationUrl).toContain("turnToken=***");
+    expect(result.verificationUrl).not.toContain("secret-turn-token");
   });
 
   it("treats changed idempotency header as replay for identical signed requests", () => {

--- a/extensions/voice-call/src/webhook-security.test.ts
+++ b/extensions/voice-call/src/webhook-security.test.ts
@@ -625,6 +625,7 @@ describe("verifyTwilioWebhook", () => {
         query: { callId: "call-1", turnToken: "secret-turn-token" },
       },
       "test-auth-token",
+      { publicUrl: "https://user:pass@example.com/callback#fragment-secret" },
     );
 
     expect(result.ok).toBe(false);
@@ -632,8 +633,27 @@ describe("verifyTwilioWebhook", () => {
     expect(result.reason).toContain("turnToken=***");
     expect(result.reason).toContain("callId=***");
     expect(result.reason).not.toContain("secret-turn-token");
-    expect(result.verificationUrl).toContain("turnToken=***");
-    expect(result.verificationUrl).not.toContain("secret-turn-token");
+    expect(result.reason).not.toContain("user:pass");
+    expect(result.reason).not.toContain("fragment-secret");
+  });
+
+  it("does not echo malformed verification URLs in diagnostics", () => {
+    const result = verifyTwilioWebhook(
+      {
+        headers: { "x-twilio-signature": "invalid" },
+        rawBody: "CallSid=CS123",
+        url: "https://local/voice/webhook",
+        method: "POST",
+      },
+      "test-auth-token",
+      { publicUrl: "not a url?turnToken=secret-turn-token" },
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "Invalid signature for URL: <invalid verification URL>",
+    });
+    expect(result.reason).not.toContain("secret-turn-token");
   });
 
   it("treats changed idempotency header as replay for identical signed requests", () => {
@@ -738,7 +758,8 @@ describe("verifyTwilioWebhook", () => {
 
     expect(result.ok).toBe(false);
     // Attacker's host is ignored - uses Host header instead
-    expect(result.verificationUrl).toBe("https://legitimate.example.com/voice/webhook");
+    expect(result.reason).toContain("https://legitimate.example.com/voice/webhook");
+    expect(result.verificationUrl).toBeUndefined();
   });
 
   it("uses X-Forwarded-Host when allowedHosts whitelist is provided", () => {
@@ -820,7 +841,8 @@ describe("verifyTwilioWebhook", () => {
 
     expect(result.ok).toBe(false);
     // Attacker's host not in whitelist, falls back to Host header
-    expect(result.verificationUrl).toBe("https://localhost/voice/webhook");
+    expect(result.reason).toContain("https://localhost/voice/webhook");
+    expect(result.verificationUrl).toBeUndefined();
   });
 
   it("trusts forwarding headers only from trusted proxy IPs", () => {
@@ -900,7 +922,8 @@ describe("verifyTwilioWebhook", () => {
     );
 
     expect(result.ok).toBe(false);
-    expect(result.verificationUrl).toBe("https://legitimate.example.com/voice/webhook");
+    expect(result.reason).toContain("https://legitimate.example.com/voice/webhook");
+    expect(result.verificationUrl).toBeUndefined();
   });
   it("succeeds when Twilio signs URL without port but server URL has port", () => {
     const authToken = "test-auth-token";

--- a/extensions/voice-call/src/webhook-security.ts
+++ b/extensions/voice-call/src/webhook-security.ts
@@ -313,12 +313,15 @@ function buildTwilioVerificationUrl(
 function redactTwilioVerificationUrlForDiagnostics(url: string): string {
   try {
     const parsed = new URL(url);
+    parsed.username = parsed.username ? "***" : "";
+    parsed.password = parsed.password ? "***" : "";
+    parsed.hash = parsed.hash ? "#***" : "";
     for (const key of Array.from(parsed.searchParams.keys())) {
       parsed.searchParams.set(key, "***");
     }
     return parsed.toString();
   } catch {
-    return url.replace(/([?&])([^=&]+)=([^&]*)/g, "$1$2=***");
+    return "<invalid verification URL>";
   }
 }
 
@@ -363,7 +366,7 @@ function extractPortFromHostHeader(hostHeader?: string): string | undefined {
 interface TwilioVerificationResult {
   ok: boolean;
   reason?: string;
-  /** The URL that was used for verification; redacted on failed verification diagnostics. */
+  /** The original URL that passed signature verification; never set on failures. */
   verificationUrl?: string;
   /** Whether we're running behind ngrok free tier */
   isNgrokFreeTier?: boolean;
@@ -636,7 +639,6 @@ export function verifyTwilioWebhook(
   return {
     ok: false,
     reason: `Invalid signature for URL: ${diagnosticVerificationUrl}`,
-    verificationUrl: diagnosticVerificationUrl,
     isNgrokFreeTier,
   };
 }

--- a/extensions/voice-call/src/webhook-security.ts
+++ b/extensions/voice-call/src/webhook-security.ts
@@ -310,6 +310,18 @@ function buildTwilioVerificationUrl(
   }
 }
 
+function redactTwilioVerificationUrlForDiagnostics(url: string): string {
+  try {
+    const parsed = new URL(url);
+    for (const key of Array.from(parsed.searchParams.keys())) {
+      parsed.searchParams.set(key, "***");
+    }
+    return parsed.toString();
+  } catch {
+    return url.replace(/([?&])([^=&]+)=([^&]*)/g, "$1$2=***");
+  }
+}
+
 function stripPortFromUrl(url: string): string {
   try {
     const parsed = new URL(url);
@@ -351,7 +363,7 @@ function extractPortFromHostHeader(hostHeader?: string): string | undefined {
 interface TwilioVerificationResult {
   ok: boolean;
   reason?: string;
-  /** The URL that was used for verification (for debugging) */
+  /** The URL that was used for verification; redacted on failed verification diagnostics. */
   verificationUrl?: string;
   /** Whether we're running behind ngrok free tier */
   isNgrokFreeTier?: boolean;
@@ -619,11 +631,12 @@ export function verifyTwilioWebhook(
   // Check if this is ngrok free tier - the URL might have different format
   const isNgrokFreeTier =
     verificationUrl.includes(".ngrok-free.app") || verificationUrl.includes(".ngrok.io");
+  const diagnosticVerificationUrl = redactTwilioVerificationUrlForDiagnostics(verificationUrl);
 
   return {
     ok: false,
-    reason: `Invalid signature for URL: ${verificationUrl}`,
-    verificationUrl,
+    reason: `Invalid signature for URL: ${diagnosticVerificationUrl}`,
+    verificationUrl: diagnosticVerificationUrl,
     isNgrokFreeTier,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Twilio signature failures included the full verification URL in diagnostics. Because Twilio signs the exact callback URL, including query parameters, that URL can contain `turnToken` or other sensitive callback state. The provider also logged the same URL twice.

## Why This Change Was Made

The maintainer rewrite keeps signature verification and diagnostic rendering as separate contracts:

- verification still uses the original exact URL and form parameters required by Twilio;
- valid, query-bearing signed requests retain the original verified URL on the success result;
- failed results contain only a sanitized diagnostic URL: username, password, fragment, and every query value are redacted;
- malformed configured URLs use a fixed `<invalid verification URL>` placeholder rather than a regex fallback that could echo secrets;
- the Twilio adapter emits one actionable verification warning instead of logging the URL a second time.

This is the bounded fix at the webhook-security owner boundary. It does not change Twilio signature inputs, webhook routing, call state, or provider configuration.

## User Impact

Failed Twilio webhook diagnostics remain useful without exposing callback tokens or other URL values in logs. Valid signatures, including signatures over callback URLs with query parameters, continue to pass unchanged.

## Evidence

- Official Twilio webhook-security documentation confirms signature validation uses the exact request URL and parameters: https://www.twilio.com/docs/usage/webhooks/webhooks-security
- Sanitized public-network AWS Crabbox proof on exact SHA `d36fb89f479389490be907bb60b2b4773ecf4203`; no Tailscale, instance profile, or hydrated credentials.
- Crabbox `run_c43be9d22666`: focused webhook-security and Twilio provider suites, 2 files / 56 tests passed.
- Crabbox `run_9160006a7c56`: extension/test typechecks, lint, and changed-file repository guards passed.
- Source-blind behavior contract: 5 passed, 0 failed, 0 blocked (valid exact URL, fail-closed behavior, secret redaction, one warning, malformed-URL placeholder).
- Fresh autoreview: clean after two repair cycles; correctness 0.95.
- `git diff --check`: clean.

The root changelog is release-owned. Release-note context and contributor credit are retained here for @Alix-007.
