### PR TITLE
refactor: extract magic numbers into named constants in code-mode.ts

### DIFF
--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -67,6 +67,20 @@ const DEFAULT_SEARCH_LIMIT = 8;
 const DEFAULT_MAX_SEARCH_LIMIT = 50;
 const MAX_ACTIVE_CODE_MODE_RUNS = 64;
 
+// Code Mode runtime limit bounds (clamp values to these safe ranges).
+const MIN_TIMEOUT_MS = 100;
+const MAX_TIMEOUT_MS = 60_000;
+const MIN_MEMORY_BYTES = 1024 * 1024;
+const MAX_MEMORY_BYTES = 1024 * 1024 * 1024;
+const MIN_OUTPUT_BYTES = 1024;
+const MAX_OUTPUT_BYTES = 10 * 1024 * 1024;
+const MIN_SNAPSHOT_BYTES = 1024;
+const MAX_SNAPSHOT_BYTES = 256 * 1024 * 1024;
+const MIN_PENDING_TOOL_CALLS = 1;
+const MAX_PENDING_TOOL_CALLS = 128;
+const MIN_SNAPSHOT_TTL_SECONDS = 1;
+const MAX_SNAPSHOT_TTL_SECONDS = 24 * 60 * 60;
+
 type CodeModeLanguage = "javascript" | "typescript";
 
 /** Resolved Code Mode runtime limits and visible language options. */
@@ -210,31 +224,35 @@ export function resolveCodeModeConfig(config?: OpenClawConfig, agentId?: string)
     runtime: "quickjs-wasi",
     mode: "only",
     languages: readLanguages(raw.languages),
-    timeoutMs: clampInteger(readPositiveInteger(raw.timeoutMs, DEFAULT_TIMEOUT_MS), 100, 60_000),
+    timeoutMs: clampInteger(
+      readPositiveInteger(raw.timeoutMs, DEFAULT_TIMEOUT_MS),
+      MIN_TIMEOUT_MS,
+      MAX_TIMEOUT_MS,
+    ),
     memoryLimitBytes: clampInteger(
       readPositiveInteger(raw.memoryLimitBytes, DEFAULT_MEMORY_LIMIT_BYTES),
-      1024 * 1024,
-      1024 * 1024 * 1024,
+      MIN_MEMORY_BYTES,
+      MAX_MEMORY_BYTES,
     ),
     maxOutputBytes: clampInteger(
       readPositiveInteger(raw.maxOutputBytes, DEFAULT_MAX_OUTPUT_BYTES),
-      1024,
-      10 * 1024 * 1024,
+      MIN_OUTPUT_BYTES,
+      MAX_OUTPUT_BYTES,
     ),
     maxSnapshotBytes: clampInteger(
       readPositiveInteger(raw.maxSnapshotBytes, DEFAULT_MAX_SNAPSHOT_BYTES),
-      1024,
-      256 * 1024 * 1024,
+      MIN_SNAPSHOT_BYTES,
+      MAX_SNAPSHOT_BYTES,
     ),
     maxPendingToolCalls: clampInteger(
       readPositiveInteger(raw.maxPendingToolCalls, DEFAULT_MAX_PENDING_TOOL_CALLS),
-      1,
-      128,
+      MIN_PENDING_TOOL_CALLS,
+      MAX_PENDING_TOOL_CALLS,
     ),
     snapshotTtlSeconds: clampInteger(
       readPositiveInteger(raw.snapshotTtlSeconds, DEFAULT_SNAPSHOT_TTL_SECONDS),
-      1,
-      24 * 60 * 60,
+      MIN_SNAPSHOT_TTL_SECONDS,
+      MAX_SNAPSHOT_TTL_SECONDS,
     ),
     searchDefaultLimit: clampInteger(
       readPositiveInteger(raw.searchDefaultLimit, DEFAULT_SEARCH_LIMIT),


### PR DESCRIPTION
## What Problem This Solves

`resolveCodeModeConfig()` uses inline magic numbers for min/max bounds in six `clampInteger()` calls (e.g. `100`, `60_000`, `1024 * 1024`, `24 * 60 * 60`). Extracting these into named constants improves readability and makes it easy to adjust bounds without searching through the function body.

## Real behavior proof

- **Behavior or issue addressed**: Inline magic numbers → named constants in `code-mode.ts`
- **Real environment tested**: Node 22.22, Linux x86_64, local dev checkout
- **Exact steps or command run after this patch**: `pnpm test src/agents/code-mode.test.ts`
- **Evidence after fix**:
  ```text
  ✓ code-mode.test.ts — 55 tests passed
  ```
  12 magic numbers replaced with named constants. All existing behavior unchanged.
- **Observed result after fix**: No functional change; constants preserve the same values as the inline expressions.
- **What was not tested**: No functional change to test.

## Files Changed

| File | Change |
|---|---|
| `src/agents/code-mode.ts` | Added 12 MIN/MAX constants; replaced inline magic numbers in `resolveCodeModeConfig` |

Generated with Claude Code