### PR TITLE
fix(sdk): preserve zero sequence values in normalized gateway event IDs

### DIFF
--- a/packages/sdk/src/normalize.test.ts
+++ b/packages/sdk/src/normalize.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { normalizeGatewayEvent } from "./normalize.js";
+import type { GatewayEvent } from "./types.js";
 
 // Terminal tool/item events are emitted with phase:"end" plus the real status
 // (running|completed|failed|blocked), so failed/blocked must not collapse to completed.
@@ -30,5 +31,29 @@ describe("normalizeGatewayEvent terminal tool item status", () => {
     expect(normalizeGatewayEvent(agentItemEvent({ phase: "end" })).type).toBe(
       "tool.call.completed",
     );
+  });
+});
+
+describe("normalizeGatewayEvent ID construction", () => {
+  it("preserves seq:0 in the normalized event ID", () => {
+    const event: GatewayEvent = {
+      event: "agent",
+      seq: 0,
+      payload: { runId: "r1", sessionKey: "main", ts: 0, stream: "lifecycle", data: {} },
+    };
+    const result = normalizeGatewayEvent(event);
+    expect(result.id).toContain(":0");
+  });
+
+  it("preserves ts:0 in the normalized event ID", () => {
+    const event: GatewayEvent = {
+      event: "agent",
+      seq: 1,
+      payload: { runId: "r1", sessionKey: "main", ts: 0, stream: "lifecycle", data: {} },
+    };
+    const result = normalizeGatewayEvent(event);
+    const parts = result.id.split(":");
+    const lastPart = parts[parts.length - 1];
+    expect(lastPart).toBe("0");
   });
 });

--- a/packages/sdk/src/normalize.ts
+++ b/packages/sdk/src/normalize.ts
@@ -177,7 +177,9 @@ export function normalizeGatewayEvent(event: GatewayEvent): OpenClawEvent {
   const taskId = readString(payload.taskId);
   const agentId = readString(payload.agentId);
   const ts = readNumber(payload.ts) ?? Date.now();
-  const idParts = [event.seq ?? "local", event.event, runId, sessionKey, ts].filter(Boolean);
+  const idParts = [event.seq ?? "local", event.event, runId, sessionKey, ts].filter(
+    (v) => v != null && v !== "",
+  );
 
   return {
     version: 1,


### PR DESCRIPTION
## What Problem This Solves

SDK event normalization drops protocol-valid `seq: 0` and `ts: 0` from
normalized event IDs because `.filter(Boolean)` treats numeric zero as
falsy. This weakens event replay/dedupe identity for zero-sequence
gateway events.

Fixes #101768.

## Why This Change Was Made

`normalizeGatewayEvent()` in `packages/sdk/src/normalize.ts` builds event
IDs from `[event.seq, event.event, runId, sessionKey, ts]` and applies
`.filter(Boolean)` before joining. The gateway protocol schema allows
`seq` as an integer with `minimum: 0`, so zero is a valid value.

The fix replaces `.filter(Boolean)` with `.filter((v) => v != null && v !== "")`,
preserving finite zero values while still omitting absent optional parts.

## Evidence

### Test results (Vitest)

```
$ npx vitest run packages/sdk/src/normalize.test.ts --no-coverage

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Duration  2.39s
```

2 regression tests added:
- `seq: 0` survives in the normalized ID
- `ts: 0` survives as the last ID part

## Merge Risk

Low. Single-line change in a pure string-building function. The
`.filter()` replacement preserves the existing behavior for all non-zero
values and empty strings.