### PR TITLE
fix(google): return disabled thinking when clampThinkingLevel maps to off

### DIFF
--- a/packages/ai/src/providers/google-shared.test.ts
+++ b/packages/ai/src/providers/google-shared.test.ts
@@ -6,6 +6,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../utils/system-prompt-cache-boundary.js";
 import {
   buildGoogleGenerateContentParams,
+  buildGoogleSimpleThinking,
   consumeGoogleGenerateContentStream,
 } from "./google-shared.js";
 
@@ -248,5 +249,18 @@ describe("buildGoogleGenerateContentParams", () => {
 
     expect(params.config?.systemInstruction).toBe("Stable\nDynamic");
     expect(JSON.stringify(params)).not.toContain("OPENCLAW_CACHE_BOUNDARY");
+  });
+});
+
+describe("buildGoogleSimpleThinking", () => {
+  it("returns disabled thinking when clampThinkingLevel maps to off", () => {
+    const noReasoningModel: Model<"google-generative-ai"> = {
+      ...model,
+      reasoning: false,
+    };
+    const result = buildGoogleSimpleThinking(noReasoningModel, {
+      reasoning: "high",
+    });
+    expect(result).toEqual({ enabled: false });
   });
 });

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -557,8 +557,11 @@ export function buildGoogleSimpleThinking<T extends GoogleApiType>(
   }
 
   const clampedReasoning = clampThinkingLevel(model, options.reasoning);
+  if (clampedReasoning === "off") {
+    return { enabled: false };
+  }
   const effort = (
-    clampedReasoning === "off" || clampedReasoning === "max" ? "high" : clampedReasoning
+    clampedReasoning === "max" ? "high" : clampedReasoning
   ) as ClampedGoogleThinkingLevel;
 
   if (


### PR DESCRIPTION
## What Problem This Solves

When `clampThinkingLevel()` clamps a requested reasoning level to `"off"` (e.g. because the model does not support reasoning), `buildGoogleSimpleThinking()` was still constructing a thinking config with `effort: "high"` and `enabled: true`. This happened because the `"off"` → `"high"` coercion sat on the same ternary line as the `"max"` → `"high"` coercion:

```ts
const effort = (
  clampedReasoning === "off" || clampedReasoning === "max" ? "high" : clampedReasoning
) as ClampedGoogleThinkingLevel;
```

This forces thinking to be enabled at HIGH level for models that should have it disabled, causing unexpected API failures or token overhead.

## Why This Change Was Made

Return early with `{ enabled: false }` when `clampedReasoning === "off"`, before the effort coercion line. This matches the expected contract: if thinking is clamped off, the caller should see a disabled thinking config, not one with a valid effort level and `enabled: true`.

## Evidence

**Test**: `buildGoogleSimpleThinking` → `returns disabled thinking when clampThinkingLevel maps to off`

```ts
const noReasoningModel: Model<"google-generative-ai"> = {
  ...model,
  reasoning: false,
};
const result = buildGoogleSimpleThinking(noReasoningModel, {
  reasoning: "high",
});
expect(result).toEqual({ enabled: false });
```

All 10 tests in `google-shared.test.ts` pass:
```
✓ buildGoogleSimpleThinking
  ✓ returns disabled thinking when clampThinkingLevel maps to off
✓ consumeGoogleGenerateContentStream
  ✓ projects text, thinking, tool calls, response id, and usage
  ✓ preserves MAX_TOKENS when partial response contains a function call
  ✓ generates a new id when Google repeats a streamed tool-call id
✓ buildGoogleGenerateContentParams
  ✓ forwards stop sequences
  ✓ strips the internal cache boundary marker
Tests  10 passed (10)
```

## Merge Risk

Low — single early-return guard, no behavior change for non-"off" paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)