### PR TITLE
fix(byteplus): apply configured request policy overrides for video generation

### DIFF
--- a/extensions/byteplus/video-generation-provider.test.ts
+++ b/extensions/byteplus/video-generation-provider.test.ts
@@ -5,13 +5,17 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 // Submit/poll transport is mocked locally so each test can inject the BytePlus task JSON
 // bodies, while readProviderJsonResponse is kept REAL (via importActual) so the byte-bounded
 // reader actually streams and cancels oversized bodies under test instead of a stub.
-const { postJsonRequestMock, fetchWithTimeoutMock, resolveApiKeyForProviderMock } = vi.hoisted(
-  () => ({
-    postJsonRequestMock: vi.fn(),
-    fetchWithTimeoutMock: vi.fn(),
-    resolveApiKeyForProviderMock: vi.fn(async () => ({ apiKey: "provider-key" })),
-  }),
-);
+const {
+  postJsonRequestMock,
+  fetchWithTimeoutMock,
+  fetchWithTimeoutGuardedMock,
+  resolveApiKeyForProviderMock,
+} = vi.hoisted(() => ({
+  postJsonRequestMock: vi.fn(),
+  fetchWithTimeoutMock: vi.fn(),
+  fetchWithTimeoutGuardedMock: vi.fn(),
+  resolveApiKeyForProviderMock: vi.fn(async () => ({ apiKey: "provider-key" })),
+}));
 
 vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
   resolveApiKeyForProvider: resolveApiKeyForProviderMock,
@@ -24,6 +28,7 @@ vi.mock("openclaw/plugin-sdk/provider-http", async (importActual) => {
   return {
     // REAL byte-bounded JSON reader under test — not stubbed.
     readProviderJsonResponse: actual.readProviderJsonResponse,
+    sanitizeConfiguredModelProviderRequest: actual.sanitizeConfiguredModelProviderRequest,
     postJsonRequest: postJsonRequestMock,
     fetchProviderOperationResponse: async (params: {
       url: string;
@@ -37,7 +42,13 @@ vi.mock("openclaw/plugin-sdk/provider-http", async (importActual) => {
       timeoutMs?: unknown;
       fetchFn: typeof fetch;
     }) => fetchWithTimeoutMock(params.url, params.init ?? {}, resolveTimeoutMs(params.timeoutMs)),
-    assertOkOrThrowHttpError: async () => {},
+    fetchWithTimeoutGuarded: fetchWithTimeoutGuardedMock.mockImplementation(
+      async (url: string, init: RequestInit, timeoutMs: number) => ({
+        response: await fetchWithTimeoutMock(url, init, timeoutMs),
+        release: vi.fn(async () => {}),
+      }),
+    ),
+    assertOkOrThrowHttpError: actual.assertOkOrThrowHttpError,
     createProviderOperationDeadline: ({
       label,
       timeoutMs,
@@ -56,12 +67,26 @@ vi.mock("openclaw/plugin-sdk/provider-http", async (importActual) => {
       defaultBaseUrl: string;
       allowPrivateNetwork?: boolean;
       defaultHeaders?: Record<string, string>;
-    }) => ({
-      baseUrl: params.baseUrl ?? params.defaultBaseUrl,
-      allowPrivateNetwork: params.allowPrivateNetwork === true,
-      headers: new Headers(params.defaultHeaders),
-      dispatcherPolicy: undefined,
-    }),
+      request?: {
+        allowPrivateNetwork?: boolean;
+        headers?: Record<string, string>;
+      };
+    }) => {
+      const mergedHeaders = new Headers(params.defaultHeaders);
+      if (params.request?.headers) {
+        for (const [key, value] of Object.entries(params.request.headers)) {
+          mergedHeaders.set(key, value);
+        }
+      }
+      const allowPrivateNetwork =
+        params.allowPrivateNetwork ?? params.request?.allowPrivateNetwork ?? false;
+      return {
+        baseUrl: params.baseUrl ?? params.defaultBaseUrl,
+        allowPrivateNetwork,
+        headers: mergedHeaders,
+        dispatcherPolicy: undefined,
+      };
+    },
     waitProviderOperationPollInterval: async () => {},
   };
 });
@@ -75,6 +100,7 @@ beforeAll(async () => {
 afterEach(() => {
   postJsonRequestMock.mockReset();
   fetchWithTimeoutMock.mockReset();
+  fetchWithTimeoutGuardedMock.mockClear();
   resolveApiKeyForProviderMock.mockClear();
 });
 
@@ -96,10 +122,11 @@ function mockSuccessfulBytePlusTask(params?: { model?: string }) {
         model: params?.model ?? "seedance-1-0-lite-t2v-250428",
       }),
     )
-    .mockResolvedValueOnce({
-      headers: new Headers({ "content-type": "video/webm" }),
-      arrayBuffer: async () => Buffer.from("webm-bytes"),
-    });
+    .mockResolvedValueOnce(
+      new Response(Buffer.from("webm-bytes"), {
+        headers: new Headers({ "content-type": "video/webm" }),
+      }),
+    );
 }
 
 function requireBytePlusPostRequest(): { body?: Record<string, unknown>; url?: string } {
@@ -213,6 +240,111 @@ describe("byteplus video generation provider", () => {
     expect(video.fileName).toBe("video-1.webm");
     const metadata = result.metadata as Record<string, unknown>;
     expect(metadata.taskId).toBe("task_123");
+  });
+
+  it("applies configured provider request overrides to transport", async () => {
+    mockSuccessfulBytePlusTask();
+
+    const provider = buildBytePlusVideoGenerationProvider();
+    await provider.generateVideo({
+      provider: "byteplus",
+      model: "seedance-1-0-lite-t2v-250428",
+      prompt: "A lantern floats upward into the night sky",
+      cfg: {
+        models: {
+          providers: {
+            byteplus: {
+              baseUrl: "https://ark.ap-southeast.bytepluses.com/api/v3",
+              models: [],
+              request: {
+                allowPrivateNetwork: true,
+                headers: {
+                  "X-Custom-Header": "custom-value",
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(postJsonRequestMock).toHaveBeenCalledTimes(1);
+    const [postCall] = postJsonRequestMock.mock.calls;
+    if (!postCall) {
+      throw new Error("expected BytePlus video request");
+    }
+    const [postRequest] = postCall as [Record<string, unknown>];
+    expect(postRequest.allowPrivateNetwork).toBe(true);
+    const postHeaders = postRequest.headers as Headers;
+    expect(postHeaders.get("X-Custom-Header")).toBe("custom-value");
+    expect(postHeaders.get("Authorization")).toBe("Bearer provider-key");
+
+    // Status poll and video download must also use the configured private-network policy.
+    expect(fetchWithTimeoutGuardedMock).toHaveBeenCalledTimes(2);
+    const [pollCall, downloadCall] = fetchWithTimeoutGuardedMock.mock.calls;
+    if (!pollCall || !downloadCall) {
+      throw new Error("expected BytePlus guarded poll and download requests");
+    }
+    const pollOptions = pollCall[4] as {
+      ssrfPolicy?: { allowPrivateNetwork?: boolean };
+      auditContext?: string;
+    };
+    expect(pollOptions.ssrfPolicy?.allowPrivateNetwork).toBe(true);
+    expect(pollOptions.auditContext).toBe("byteplus-video-poll");
+    const downloadUrl = downloadCall[0] as string;
+    const downloadOptions = downloadCall[4] as {
+      ssrfPolicy?: { allowPrivateNetwork?: boolean };
+      auditContext?: string;
+    };
+    expect(downloadUrl).toBe("https://example.com/byteplus.mp4");
+    expect(downloadOptions.ssrfPolicy?.allowPrivateNetwork).toBe(true);
+    expect(downloadOptions.auditContext).toBe("byteplus-video-download");
+
+    // Guarded poll/download results must be released to avoid leaking dispatcher connections.
+    const [pollResult, downloadResult] = fetchWithTimeoutGuardedMock.mock.results;
+    if (pollResult?.type === "return") {
+      const { release } = (await pollResult.value) as { release: ReturnType<typeof vi.fn> };
+      expect(release).toHaveBeenCalledTimes(1);
+    }
+    if (downloadResult?.type === "return") {
+      const { release } = (await downloadResult.value) as { release: ReturnType<typeof vi.fn> };
+      expect(release).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("releases guarded results when a non-2xx poll/download response is returned", async () => {
+    postJsonRequestMock.mockResolvedValue({
+      response: streamedJsonResponse({ id: "task_500" }),
+      release: vi.fn(async () => {}),
+    });
+    fetchWithTimeoutMock.mockResolvedValueOnce(new Response("BytePlus error", { status: 500 }));
+
+    const provider = buildBytePlusVideoGenerationProvider();
+    await expect(
+      provider.generateVideo({
+        provider: "byteplus",
+        model: "seedance-1-0-lite-t2v-250428",
+        prompt: "guarded error path",
+        cfg: {
+          models: {
+            providers: {
+              byteplus: {
+                baseUrl: "https://ark.ap-southeast.bytepluses.com/api/v3",
+                models: [],
+                request: { allowPrivateNetwork: true },
+              },
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow();
+
+    expect(fetchWithTimeoutGuardedMock).toHaveBeenCalledTimes(1);
+    const [pollResult] = fetchWithTimeoutGuardedMock.mock.results;
+    if (pollResult?.type === "return") {
+      const { release } = (await pollResult.value) as { release: ReturnType<typeof vi.fn> };
+      expect(release).toHaveBeenCalledTimes(1);
+    }
   });
 
   it("rejects generated video downloads that exceed the configured media cap", async () => {
@@ -343,10 +475,11 @@ describe("byteplus video generation provider", () => {
           duration: 1.5,
         }),
       )
-      .mockResolvedValueOnce({
-        headers: new Headers({ "content-type": "video/mp4" }),
-        arrayBuffer: async () => Buffer.from("mp4-bytes"),
-      });
+      .mockResolvedValueOnce(
+        new Response(Buffer.from("mp4-bytes"), {
+          headers: new Headers({ "content-type": "video/mp4" }),
+        }),
+      );
 
     const provider = buildBytePlusVideoGenerationProvider();
     const result = await provider.generateVideo({

--- a/extensions/byteplus/video-generation-provider.ts
+++ b/extensions/byteplus/video-generation-provider.ts
@@ -1,3 +1,4 @@
+import type { PinnedDispatcherPolicy } from "openclaw/plugin-sdk/fetch-runtime";
 /**
  * BytePlus Seedance video generation provider implementation.
  */
@@ -9,12 +10,13 @@ import {
   assertOkOrThrowHttpError,
   createProviderOperationDeadline,
   createProviderOperationTimeoutResolver,
-  fetchProviderDownloadResponse,
   fetchProviderOperationResponse,
+  fetchWithTimeoutGuarded,
   postJsonRequest,
   readProviderJsonResponse,
   resolveProviderOperationTimeoutMs,
   resolveProviderHttpRequestConfig,
+  sanitizeConfiguredModelProviderRequest,
   waitProviderOperationPollInterval,
   type ProviderOperationTimeoutMs,
 } from "openclaw/plugin-sdk/provider-http";
@@ -152,19 +154,80 @@ function readBytePlusDurationSeconds(value: unknown): number | undefined {
   });
 }
 
-async function pollBytePlusTask(params: {
-  taskId: string;
-  headers: Headers;
-  timeoutMs?: number;
-  baseUrl: string;
-  fetchFn: typeof fetch;
-}): Promise<BytePlusTaskResponse> {
+type BytePlusVideoRequestPolicy = {
+  allowPrivateNetwork?: boolean;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
+};
+
+type BytePlusOperationResponse = {
+  response: Response;
+  release: () => Promise<void>;
+};
+
+/** Fetches a BytePlus operation response, applying any configured request policy. */
+async function fetchBytePlusOperationResponse(
+  params: {
+    stage: "poll" | "download";
+    url: string;
+    init?: RequestInit;
+    timeoutMs?: ProviderOperationTimeoutMs;
+    fetchFn: typeof fetch;
+    provider?: string;
+    requestFailedMessage?: string;
+  } & BytePlusVideoRequestPolicy,
+): Promise<BytePlusOperationResponse> {
+  if (!params.allowPrivateNetwork && !params.dispatcherPolicy) {
+    const response = await fetchProviderOperationResponse({
+      stage: params.stage,
+      url: params.url,
+      init: params.init,
+      timeoutMs: params.timeoutMs,
+      fetchFn: params.fetchFn,
+      provider: params.provider,
+      requestFailedMessage: params.requestFailedMessage,
+    });
+    return { response, release: async () => {} };
+  }
+
+  const result = await fetchWithTimeoutGuarded(
+    params.url,
+    params.init ?? {},
+    typeof params.timeoutMs === "function" ? params.timeoutMs() : params.timeoutMs,
+    params.fetchFn,
+    {
+      ...(params.allowPrivateNetwork ? { ssrfPolicy: { allowPrivateNetwork: true } } : {}),
+      ...(params.dispatcherPolicy ? { dispatcherPolicy: params.dispatcherPolicy } : {}),
+      auditContext: `byteplus-video-${params.stage}`,
+    },
+  );
+  if (params.requestFailedMessage) {
+    try {
+      await assertOkOrThrowHttpError(result.response, params.requestFailedMessage);
+    } catch (error) {
+      // The caller never receives the guarded result when status assertion throws,
+      // so release the dispatcher connection here to avoid leaking sockets.
+      await result.release();
+      throw error;
+    }
+  }
+  return result;
+}
+
+async function pollBytePlusTask(
+  params: {
+    taskId: string;
+    headers: Headers;
+    timeoutMs?: number;
+    baseUrl: string;
+    fetchFn: typeof fetch;
+  } & BytePlusVideoRequestPolicy,
+): Promise<BytePlusTaskResponse> {
   const deadline = createProviderOperationDeadline({
     timeoutMs: params.timeoutMs,
     label: `BytePlus video generation task ${params.taskId}`,
   });
   for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt += 1) {
-    const response = await fetchProviderOperationResponse({
+    const { response, release } = await fetchBytePlusOperationResponse({
       stage: "poll",
       url: `${params.baseUrl}/contents/generations/tasks/${params.taskId}`,
       init: {
@@ -178,51 +241,69 @@ async function pollBytePlusTask(params: {
       fetchFn: params.fetchFn,
       provider: "byteplus",
       requestFailedMessage: "BytePlus video status request failed",
+      allowPrivateNetwork: params.allowPrivateNetwork,
+      dispatcherPolicy: params.dispatcherPolicy,
     });
-    const payload = await readBytePlusJsonResponse<BytePlusTaskResponse>(
-      response,
-      "BytePlus video status request failed",
-    );
-    switch (readBytePlusTaskStatus(payload)) {
-      case "succeeded":
-        return payload;
-      case "failed":
-      case "cancelled":
-        throw new Error(
-          readBytePlusErrorMessage(payload.error) || "BytePlus video generation failed",
-        );
-      default:
-        await waitProviderOperationPollInterval({ deadline, pollIntervalMs: POLL_INTERVAL_MS });
-        break;
+    try {
+      const payload = await readBytePlusJsonResponse<BytePlusTaskResponse>(
+        response,
+        "BytePlus video status request failed",
+      );
+      switch (readBytePlusTaskStatus(payload)) {
+        case "succeeded":
+          return payload;
+        case "failed":
+        case "cancelled":
+          throw new Error(
+            readBytePlusErrorMessage(payload.error) || "BytePlus video generation failed",
+          );
+        default:
+          await waitProviderOperationPollInterval({ deadline, pollIntervalMs: POLL_INTERVAL_MS });
+          break;
+      }
+    } finally {
+      // Guarded fetch returns a response that may hold a dispatcher connection;
+      // always release after reading to avoid leaking sockets on long polls.
+      await release();
     }
   }
   throw new Error(`BytePlus video generation task ${params.taskId} did not finish in time`);
 }
 
-async function downloadBytePlusVideo(params: {
-  url: string;
-  timeoutMs?: ProviderOperationTimeoutMs;
-  fetchFn: typeof fetch;
-  maxBytes: number;
-}): Promise<GeneratedVideoAsset> {
-  const response = await fetchProviderDownloadResponse({
+async function downloadBytePlusVideo(
+  params: {
+    url: string;
+    timeoutMs?: ProviderOperationTimeoutMs;
+    fetchFn: typeof fetch;
+    maxBytes: number;
+  } & BytePlusVideoRequestPolicy,
+): Promise<GeneratedVideoAsset> {
+  const { response, release } = await fetchBytePlusOperationResponse({
+    stage: "download",
     url: params.url,
     init: { method: "GET" },
     timeoutMs: params.timeoutMs ?? DEFAULT_TIMEOUT_MS,
     fetchFn: params.fetchFn,
     provider: "byteplus",
     requestFailedMessage: "BytePlus generated video download failed",
+    allowPrivateNetwork: params.allowPrivateNetwork,
+    dispatcherPolicy: params.dispatcherPolicy,
   });
-  const mimeType = normalizeOptionalString(response.headers.get("content-type")) ?? "video/mp4";
-  const buffer = await readResponseWithLimit(response, params.maxBytes, {
-    onOverflow: ({ maxBytes }) =>
-      new Error(`BytePlus generated video download exceeds ${maxBytes} bytes`),
-  });
-  return {
-    buffer,
-    mimeType,
-    fileName: `video-1.${extensionForMime(mimeType)?.slice(1) ?? "mp4"}`,
-  };
+  try {
+    const mimeType = normalizeOptionalString(response.headers.get("content-type")) ?? "video/mp4";
+    const buffer = await readResponseWithLimit(response, params.maxBytes, {
+      onOverflow: ({ maxBytes }) =>
+        new Error(`BytePlus generated video download exceeds ${maxBytes} bytes`),
+    });
+    return {
+      buffer,
+      mimeType,
+      fileName: `video-1.${extensionForMime(mimeType)?.slice(1) ?? "mp4"}`,
+    };
+  } finally {
+    // Guarded fetch responses may hold a dispatcher connection; release after reading.
+    await release();
+  }
 }
 
 /** Builds the BytePlus video generation provider registered by the plugin. */
@@ -293,7 +374,9 @@ export function buildBytePlusVideoGenerationProvider(): VideoGenerationProvider 
         resolveProviderHttpRequestConfig({
           baseUrl: resolveBytePlusVideoBaseUrl(req),
           defaultBaseUrl: BYTEPLUS_BASE_URL,
-          allowPrivateNetwork: false,
+          request: sanitizeConfiguredModelProviderRequest(
+            req.cfg.models?.providers?.byteplus?.request,
+          ),
           defaultHeaders: {
             Authorization: `Bearer ${auth.apiKey}`,
             "Content-Type": "application/json",
@@ -395,6 +478,8 @@ export function buildBytePlusVideoGenerationProvider(): VideoGenerationProvider 
           }),
           baseUrl,
           fetchFn,
+          allowPrivateNetwork,
+          dispatcherPolicy,
         });
         const videoUrl = readBytePlusVideoUrl(completed);
         const video = await downloadBytePlusVideo({
@@ -405,6 +490,8 @@ export function buildBytePlusVideoGenerationProvider(): VideoGenerationProvider 
           }),
           fetchFn,
           maxBytes: resolveGeneratedVideoMaxBytes(req),
+          allowPrivateNetwork,
+          dispatcherPolicy,
         });
         return {
           videos: [video],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where BytePlus video generation ignored operator-configured request overrides (`models.providers.byteplus.request`) and hardcoded `allowPrivateNetwork: false`. This prevented users from supplying custom headers or opting into private-network access for BytePlus video generation, even though the same config surface already works for other providers.

## Why This Change Was Made

This change routes `req.cfg.models.providers.byteplus.request` through `sanitizeConfiguredModelProviderRequest` and passes the sanitized overrides into `resolveProviderHttpRequestConfig`, replacing the hardcoded `allowPrivateNetwork: false`. The resolved `allowPrivateNetwork` and `dispatcherPolicy` are now threaded through the task-create POST, status polling, and video download paths. When a configured policy is present, the provider uses `fetchWithTimeoutGuarded` and preserves/calls the returned `release()` handle to avoid leaking dispatcher resources, matching the OpenAI video provider pattern. Non-2xx poll/download responses now release the guarded result inside the helper before throwing, so the dispatcher connection is not leaked when status assertion fails.

## User Impact

Operators can now configure `models.providers.byteplus.request.{headers,allowPrivateNetwork,proxy,tls,...}` and have those overrides apply consistently to the full BytePlus video generation operation.

## Evidence

- Focused local test run:
  - `node scripts/run-vitest.mjs extensions/byteplus/video-generation-provider.test.ts --run` → 15/15 passed.
- Type checks:
  - `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo` → passed.
  - `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo` → passed.
- Lint:
  - `node scripts/run-oxlint.mjs --tsconfig extensions/byteplus/tsconfig.json extensions/byteplus/video-generation-provider.ts extensions/byteplus/video-generation-provider.test.ts` → passed.
- Regression tests verify that configured `allowPrivateNetwork: true` and a custom header reach `postJsonRequest`, that status polling and video download receive the same `ssrfPolicy` and `auditContext`, that the guarded poll/download `release()` handles are called on success, and that a non-2xx guarded poll response releases the handle before throwing.
