### PR TITLE
fix(codex): ungate app-server terminal liveness and fan out poisoned-client retirement

### DIFF
--- a/extensions/codex/src/app-server/attempt-client-cleanup.test.ts
+++ b/extensions/codex/src/app-server/attempt-client-cleanup.test.ts
@@ -50,6 +50,7 @@ describe("Codex app-server attempt client cleanup", () => {
       threadId: "thread-1",
       turnId: "turn-1",
       reason: "turn_terminal_idle_timeout",
+      suspectPhysicalClient: true,
     });
 
     expect(request).toHaveBeenCalledWith(

--- a/extensions/codex/src/app-server/attempt-client-cleanup.test.ts
+++ b/extensions/codex/src/app-server/attempt-client-cleanup.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   interruptCodexTurnBestEffort,
+  retireCodexAppServerClientAfterTimedOutTurn,
   unsubscribeCodexThreadBestEffort,
 } from "./attempt-client-cleanup.js";
 
@@ -39,5 +40,28 @@ describe("Codex app-server attempt client cleanup", () => {
       { threadId: "thread-1" },
       { timeoutMs: 123 },
     );
+  });
+
+  it("closes only the isolated client after timed-out turn cleanup", async () => {
+    const request = vi.fn(async () => ({}));
+    const close = vi.fn();
+
+    await retireCodexAppServerClientAfterTimedOutTurn({ request, close } as never, {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      reason: "turn_terminal_idle_timeout",
+    });
+
+    expect(request).toHaveBeenCalledWith(
+      "turn/interrupt",
+      { threadId: "thread-1", turnId: "turn-1" },
+      { timeoutMs: 5_000 },
+    );
+    expect(request).toHaveBeenCalledWith(
+      "thread/unsubscribe",
+      { threadId: "thread-1" },
+      { timeoutMs: 5_000 },
+    );
+    expect(close).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/codex/src/app-server/attempt-client-cleanup.ts
+++ b/extensions/codex/src/app-server/attempt-client-cleanup.ts
@@ -144,23 +144,34 @@ export async function retireCodexAppServerClientAfterTimedOutTurn(
     threadId: string;
     turnId: string;
     reason: string;
+    /**
+     * Only the terminal-idle watch proves the physical client is dead (zero
+     * notifications for the whole window). Completion/assistant/budget
+     * timeouts are per-turn conditions on a possibly healthy shared process —
+     * failing co-leases for those would abort innocent sibling turns.
+     */
+    suspectPhysicalClient: boolean;
   },
 ): Promise<void> {
-  // A timed-out turn marks the physical client suspect: fail co-leased
-  // attempts into their retry path instead of leaving them wedged on it.
   const retiredSharedClient = retireSharedCodexAppServerClientIfCurrent(client, {
-    failActiveLeases: true,
+    failActiveLeases: params.suspectPhysicalClient,
   });
   const detachedSharedClient = Boolean(retiredSharedClient);
-  interruptCodexTurnBestEffort(client, {
-    threadId: params.threadId,
-    turnId: params.turnId,
-    timeoutMs: CODEX_APP_SERVER_INTERRUPT_TIMEOUT_MS,
-  });
-  await unsubscribeCodexThreadBestEffort(client, {
-    threadId: params.threadId,
-    timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
-  });
+  const clientAlreadyClosed =
+    params.suspectPhysicalClient && (retiredSharedClient?.closed ?? false);
+  // Best-effort interrupt/unsubscribe only make sense while the transport is
+  // still open; a suspect client was just closed (child gets SIGKILLed).
+  if (!clientAlreadyClosed) {
+    interruptCodexTurnBestEffort(client, {
+      threadId: params.threadId,
+      turnId: params.turnId,
+      timeoutMs: CODEX_APP_SERVER_INTERRUPT_TIMEOUT_MS,
+    });
+    await unsubscribeCodexThreadBestEffort(client, {
+      threadId: params.threadId,
+      timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+    });
+  }
   let closedClient = retiredSharedClient?.closed ?? false;
   if (!detachedSharedClient) {
     const close = (client as { close?: () => void }).close;

--- a/extensions/codex/src/app-server/attempt-client-cleanup.ts
+++ b/extensions/codex/src/app-server/attempt-client-cleanup.ts
@@ -146,7 +146,11 @@ export async function retireCodexAppServerClientAfterTimedOutTurn(
     reason: string;
   },
 ): Promise<void> {
-  const retiredSharedClient = retireSharedCodexAppServerClientIfCurrent(client);
+  // A timed-out turn marks the physical client suspect: fail co-leased
+  // attempts into their retry path instead of leaving them wedged on it.
+  const retiredSharedClient = retireSharedCodexAppServerClientIfCurrent(client, {
+    failActiveLeases: true,
+  });
   const detachedSharedClient = Boolean(retiredSharedClient);
   interruptCodexTurnBestEffort(client, {
     threadId: params.threadId,

--- a/extensions/codex/src/app-server/attempt-results.test.ts
+++ b/extensions/codex/src/app-server/attempt-results.test.ts
@@ -67,7 +67,7 @@ describe("Codex app-server attempt results", () => {
     expect(
       buildCodexAppServerPromptTimeoutOutcome({
         result: createResult({
-          toolMetas: [{ toolName: "exec" }],
+          assistantTexts: ["Salvaged answer."],
         }),
         turnCompletionIdleTimedOut: true,
         turnWatchTimeoutKind: "terminal",
@@ -127,6 +127,29 @@ describe("Codex app-server attempt results", () => {
     ).toEqual({
       message:
         "Codex stopped before confirming the turn was complete. Some work may already have been performed; verify the current state before retrying.",
+      replayInvalid: true,
+      livenessState: "abandoned",
+    });
+  });
+
+  it("builds an honest terminal-idle outcome instead of budget advice", () => {
+    expect(
+      buildCodexAppServerPromptTimeoutOutcome({
+        result: createResult({}),
+        turnCompletionIdleTimedOut: true,
+        turnWatchTimeoutKind: "terminal",
+      }),
+    ).toEqual({
+      message:
+        "Codex stopped responding: no activity arrived for the turn's liveness window, so the turn was ended and the connection was replaced. Retry to continue on a fresh session.",
+    });
+    expect(
+      buildCodexAppServerPromptTimeoutOutcome({
+        result: createResult({ toolMetas: [{ toolName: "exec" }] }),
+        turnCompletionIdleTimedOut: true,
+        turnWatchTimeoutKind: "terminal",
+      }),
+    ).toMatchObject({
       replayInvalid: true,
       livenessState: "abandoned",
     });

--- a/extensions/codex/src/app-server/attempt-results.ts
+++ b/extensions/codex/src/app-server/attempt-results.ts
@@ -14,6 +14,8 @@ const CODEX_APP_SERVER_MISSING_TERMINAL_EVENT_USER_MESSAGE =
   "Codex stopped before confirming the turn was complete. The response may be incomplete; retry if needed.";
 const CODEX_APP_SERVER_MISSING_TERMINAL_EVENT_SIDE_EFFECT_USER_MESSAGE =
   "Codex stopped before confirming the turn was complete. Some work may already have been performed; verify the current state before retrying.";
+const CODEX_APP_SERVER_TERMINAL_IDLE_USER_MESSAGE =
+  "Codex stopped responding: no activity arrived for the turn's liveness window, so the turn was ended and the connection was replaced. Retry to continue on a fresh session.";
 
 /** Joins terminal assistant text blocks into the final attempt answer. */
 export function collectTerminalAssistantText(result: EmbeddedRunAttemptResult): string {
@@ -31,6 +33,25 @@ export function buildCodexAppServerPromptTimeoutOutcome(params: {
 }): EmbeddedRunAttemptResult["promptTimeoutOutcome"] {
   if (!params.turnCompletionIdleTimedOut) {
     return undefined;
+  }
+  // Terminal-idle kills are dead-client events, not slow turns: the generic
+  // "increase agents.defaults.timeoutSeconds" advice would be wrong because
+  // that watch deliberately ignores the agent budget. Salvaged assistant
+  // output still wins over any timeout notice.
+  if (params.turnWatchTimeoutKind === "terminal") {
+    if (collectTerminalAssistantText(params.result)) {
+      return undefined;
+    }
+    const terminalReplayBlockedReason = resolveCodexAppServerReplayBlockedReason(params.result);
+    return {
+      message: CODEX_APP_SERVER_TERMINAL_IDLE_USER_MESSAGE,
+      ...(terminalReplayBlockedReason
+        ? {
+            replayInvalid: true,
+            livenessState: "abandoned" as const,
+          }
+        : {}),
+    };
   }
   if (params.turnWatchTimeoutKind !== undefined && params.turnWatchTimeoutKind !== "completion") {
     return undefined;

--- a/extensions/codex/src/app-server/attempt-turn-watches.test.ts
+++ b/extensions/codex/src/app-server/attempt-turn-watches.test.ts
@@ -171,6 +171,80 @@ describe("Codex app-server attempt turn watches", () => {
     expect(harness.abortController.signal.aborted).toBe(false);
   });
 
+  it("fires terminal idle timeout while an app-server request is in flight", () => {
+    const harness = createController();
+    harness.activeRequests = 1;
+
+    harness.controller.armTerminalIdleWatch();
+    vi.advanceTimersByTime(10);
+
+    expect(harness.timeouts).toMatchObject([
+      {
+        kind: "terminal",
+        idleMs: 10,
+        timeoutMs: 10,
+        lastActivityReason: "startup",
+      },
+    ]);
+    expect(harness.abortController.signal.reason).toBe("turn_terminal_idle_timeout");
+  });
+
+  it("keeps terminal idle alive when notifications arrive during an in-flight request", () => {
+    const harness = createController();
+    harness.activeRequests = 1;
+
+    harness.controller.armTerminalIdleWatch();
+    vi.advanceTimersByTime(9);
+    harness.controller.noteNotificationReceived("item/commandExecution/outputDelta");
+    vi.advanceTimersByTime(9);
+
+    expect(harness.timeouts).toEqual([]);
+    expect(harness.abortController.signal.aborted).toBe(false);
+
+    vi.advanceTimersByTime(1);
+    expect(harness.timeouts).toMatchObject([
+      {
+        kind: "terminal",
+        idleMs: 10,
+        timeoutMs: 10,
+        lastActivityReason: "notification:item/commandExecution/outputDelta",
+      },
+    ]);
+  });
+
+  it("keeps completion idle gated while a request is in flight", () => {
+    const harness = createController();
+    harness.activeRequests = 1;
+
+    harness.controller.touchActivity("turn:start", { arm: true });
+    vi.advanceTimersByTime(10);
+
+    expect(harness.timeouts).toEqual([]);
+    expect(harness.abortController.signal.aborted).toBe(false);
+
+    harness.activeRequests = 0;
+    harness.controller.scheduleProgressWatches();
+    vi.advanceTimersByTime(1);
+
+    expect(harness.timeouts).toMatchObject([{ kind: "completion" }]);
+  });
+
+  it("keeps assistant-completion gated while a request is in flight", () => {
+    const harness = createController();
+    harness.activeRequests = 1;
+
+    harness.controller.armAssistantCompletionIdleWatch();
+    vi.advanceTimersByTime(10);
+
+    expect(harness.completed).toBe(false);
+    expect(harness.abortController.signal.aborted).toBe(false);
+
+    harness.activeRequests = 0;
+    vi.advanceTimersByTime(1);
+
+    expect(harness.completed).toBe(true);
+  });
+
   it("waits for active completion blocker items before firing completion idle timeout", () => {
     const harness = createController();
     harness.activeCompletionBlockers = 1;

--- a/extensions/codex/src/app-server/attempt-turn-watches.ts
+++ b/extensions/codex/src/app-server/attempt-turn-watches.ts
@@ -166,12 +166,7 @@ export function createCodexAttemptTurnWatchController(params: {
 
   function scheduleTerminalIdleWatch() {
     clearTerminalIdleTimer();
-    if (
-      params.isCompleted() ||
-      params.signal.aborted ||
-      !terminalIdleWatchArmed ||
-      params.getActiveAppServerTurnRequests() > 0
-    ) {
+    if (params.isCompleted() || params.signal.aborted || !terminalIdleWatchArmed) {
       return;
     }
     const elapsedMs = Math.max(0, Date.now() - completionLastActivityAt);
@@ -371,12 +366,14 @@ export function createCodexAttemptTurnWatchController(params: {
   }
 
   function fireTerminalIdleTimeout() {
+    // This is the physical-client liveness backstop. An in-flight request can
+    // be silent forever if the client is wedged, so only real notifications
+    // reset the terminal clock.
     if (
       params.isCompleted() ||
       params.isTerminalTurnNotificationQueued() ||
       params.signal.aborted ||
-      !terminalIdleWatchArmed ||
-      params.getActiveAppServerTurnRequests() > 0
+      !terminalIdleWatchArmed
     ) {
       return;
     }

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -3185,6 +3185,7 @@ export async function runCodexAppServerAttempt(
           threadId: thread.threadId,
           turnId: activeTurnId,
           reason: String(runAbortController.signal.reason ?? "timeout"),
+          suspectPhysicalClient: turnWatchTimeoutKind === "terminal",
         });
       })().finally(() => {
         resolveCompletion?.();

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -537,7 +537,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     });
   });
 
-  it("does not use completion timeout outcome for terminal timeout with active mutating item", async () => {
+  it("uses the terminal dead-client outcome for silent terminal timeouts", async () => {
     const harness = createStartedThreadHarness();
     const params = createParams(
       path.join(tempDir, "session.jsonl"),
@@ -572,7 +572,11 @@ describe("runCodexAppServerAttempt turn watches", () => {
     expect(result.codexAppServerFailure?.replaySafe).toBe(false);
     expect(result.codexAppServerFailure?.replayBlockedReason).toBe("potential_side_effect");
     expect(result.codexAppServerFailure?.diagnostics).toBeUndefined();
-    expect(result.promptTimeoutOutcome).toBeUndefined();
+    expect(result.promptTimeoutOutcome).toMatchObject({
+      message: expect.stringContaining("Codex stopped responding"),
+      replayInvalid: true,
+      livenessState: "abandoned",
+    });
   });
 
   it("recovers completed assistant output from a non-completion timeout", async () => {

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -797,6 +797,32 @@ describe("shared Codex app-server client", () => {
     expect(second.process.stdin.destroyed).toBe(false);
   });
 
+  it("suspect retirement closes a client that was already gracefully detached", async () => {
+    const first = createClientHarness();
+    vi.spyOn(CodexAppServerClient, "start").mockReturnValueOnce(first.client);
+
+    const lease = getLeasedSharedCodexAppServerClient({ timeoutMs: 1000 });
+    await sendInitializeResult(first, "openclaw/0.142.0 (macOS; test)");
+    await expect(lease).resolves.toBe(first.client);
+
+    // Routine cleanup detaches gracefully; a later terminal-idle kill must
+    // still be able to fail the leaseholders off the poisoned process.
+    expect(retireSharedCodexAppServerClientIfCurrent(first.client)).toEqual({
+      activeLeases: 1,
+      closed: false,
+    });
+    expect(first.process.stdin.destroyed).toBe(false);
+
+    expect(
+      retireSharedCodexAppServerClientIfCurrent(first.client, { failActiveLeases: true }),
+    ).toEqual({
+      activeLeases: 1,
+      closed: true,
+    });
+    expect(first.process.stdin.destroyed).toBe(true);
+    expect(releaseLeasedSharedCodexAppServerClient(first.client)).toBe(true);
+  });
+
   it("retires gracefully by default: leased clients close on release, not immediately", async () => {
     const first = createClientHarness();
     vi.spyOn(CodexAppServerClient, "start").mockReturnValueOnce(first.client);

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -699,7 +699,7 @@ describe("shared Codex app-server client", () => {
     expect(second.process.stdin.destroyed).toBe(true);
   });
 
-  it("closes a retired shared app-server after all active leases release", async () => {
+  it("closes a retired shared app-server and forces active leases onto the retryable close path", async () => {
     const first = createClientHarness();
     const second = createClientHarness();
     vi.spyOn(CodexAppServerClient, "start")
@@ -715,11 +715,15 @@ describe("shared Codex app-server client", () => {
     const releaseSecond = retainSharedCodexAppServerClientIfCurrent(first.client);
     expect(releaseFirst).toBeTypeOf("function");
     expect(releaseSecond).toBeTypeOf("function");
-    expect(retireSharedCodexAppServerClientIfCurrent(first.client)).toEqual({
+    const activeRequest = first.client.request("test/pending", {});
+    expect(
+      retireSharedCodexAppServerClientIfCurrent(first.client, { failActiveLeases: true }),
+    ).toEqual({
       activeLeases: 2,
-      closed: false,
+      closed: true,
     });
-    expect(first.process.stdin.destroyed).toBe(false);
+    expect(first.process.stdin.destroyed).toBe(true);
+    await expect(activeRequest).rejects.toThrow("codex app-server client is closed");
 
     const secondList = listCodexAppServerModels({ timeoutMs: 1000 });
     await sendInitializeResult(second, "openclaw/0.142.0 (macOS; test)");
@@ -727,7 +731,6 @@ describe("shared Codex app-server client", () => {
     await expect(secondList).resolves.toEqual({ models: [] });
 
     releaseFirst?.();
-    expect(first.process.stdin.destroyed).toBe(false);
     releaseSecond?.();
     expect(first.process.stdin.destroyed).toBe(true);
     expect(second.process.kill).not.toHaveBeenCalled();
@@ -748,21 +751,70 @@ describe("shared Codex app-server client", () => {
     await expect(firstLease).resolves.toBe(first.client);
     await expect(secondLease).resolves.toBe(first.client);
 
-    expect(retireSharedCodexAppServerClientIfCurrent(first.client)).toEqual({
+    expect(
+      retireSharedCodexAppServerClientIfCurrent(first.client, { failActiveLeases: true }),
+    ).toEqual({
+      activeLeases: 2,
+      closed: true,
+    });
+    expect(
+      retireSharedCodexAppServerClientIfCurrent(first.client, { failActiveLeases: true }),
+    ).toEqual({
       activeLeases: 2,
       closed: false,
     });
+    expect(first.process.stdin.destroyed).toBe(true);
+
+    expect(releaseLeasedSharedCodexAppServerClient(first.client)).toBe(true);
+    expect(releaseLeasedSharedCodexAppServerClient(first.client)).toBe(true);
+    expect(first.process.stdin.destroyed).toBe(true);
+    expect(releaseLeasedSharedCodexAppServerClient(first.client)).toBe(false);
+  });
+
+  it("rejects pending acquires during shared-client retirement", async () => {
+    const first = createClientHarness();
+    const second = createClientHarness();
+    vi.spyOn(CodexAppServerClient, "start")
+      .mockReturnValueOnce(first.client)
+      .mockReturnValueOnce(second.client);
+
+    const firstLease = getLeasedSharedCodexAppServerClient();
+    const pendingLease = getLeasedSharedCodexAppServerClient();
+    await vi.waitFor(() => expect(first.writes.length).toBeGreaterThanOrEqual(1));
+
+    expect(
+      retireSharedCodexAppServerClientIfCurrent(first.client, { failActiveLeases: true }),
+    ).toEqual({
+      activeLeases: 0,
+      closed: true,
+    });
+    await expect(firstLease).rejects.toThrow("codex app-server client is closed");
+    await expect(pendingLease).rejects.toThrow("codex app-server client is closed");
+
+    const freshLease = getLeasedSharedCodexAppServerClient({ timeoutMs: 1000 });
+    await sendInitializeResult(second, "openclaw/0.142.0 (macOS; test)");
+    await expect(freshLease).resolves.toBe(second.client);
+    expect(second.process.stdin.destroyed).toBe(false);
+  });
+
+  it("retires gracefully by default: leased clients close on release, not immediately", async () => {
+    const first = createClientHarness();
+    vi.spyOn(CodexAppServerClient, "start").mockReturnValueOnce(first.client);
+
+    const lease = getLeasedSharedCodexAppServerClient({ timeoutMs: 1000 });
+    await sendInitializeResult(first, "openclaw/0.142.0 (macOS; test)");
+    await expect(lease).resolves.toBe(first.client);
+
+    // Routine cleanup (e.g. one-shot bundle-MCP) must not yank a healthy
+    // client from co-leased sessions; only suspect retirement does.
     expect(retireSharedCodexAppServerClientIfCurrent(first.client)).toEqual({
-      activeLeases: 2,
+      activeLeases: 1,
       closed: false,
     });
     expect(first.process.stdin.destroyed).toBe(false);
 
     expect(releaseLeasedSharedCodexAppServerClient(first.client)).toBe(true);
-    expect(first.process.stdin.destroyed).toBe(false);
-    expect(releaseLeasedSharedCodexAppServerClient(first.client)).toBe(true);
     expect(first.process.stdin.destroyed).toBe(true);
-    expect(releaseLeasedSharedCodexAppServerClient(first.client)).toBe(false);
   });
 
   it("waits only for the shared client that is still current", async () => {

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -34,6 +34,10 @@ type SharedCodexAppServerClientState = {
   leasedReleases: WeakMap<CodexAppServerClient, Array<() => void>>;
 };
 
+// Clients we already force-closed for suspect retirement; a repeat retire must
+// report closed:false instead of pretending to close the corpse again.
+const suspectClosedClients = new WeakSet<CodexAppServerClient>();
+
 // Symbol.for shares one client table across duplicate module copies (dist +
 // src bundles in one process). Plugin updates restart the gateway, so every
 // copy writing this state runs the same code and the shape never migrates.
@@ -436,6 +440,9 @@ export function retireSharedCodexAppServerClientIfCurrent(
       if (opts?.failActiveLeases) {
         entry.closeError = new Error("codex app-server client is closed");
         const closed = closeRetiredSharedClientEntry(entry);
+        if (closed) {
+          suspectClosedClients.add(client);
+        }
         return { activeLeases: entry.activeLeases, closed };
       }
       const closed = closeRetiredSharedClientEntryIfIdle(entry);
@@ -444,6 +451,14 @@ export function retireSharedCodexAppServerClientIfCurrent(
   }
   const activeLeases = state.leasedReleases.get(client)?.length ?? 0;
   if (activeLeases > 0) {
+    // A gracefully detached client (e.g. one-shot cleanup) can still be leased
+    // when a later terminal-idle kill declares it suspect; the map miss must
+    // not let the poisoned process keep serving those co-leases.
+    if (opts?.failActiveLeases && !suspectClosedClients.has(client)) {
+      suspectClosedClients.add(client);
+      client.close();
+      return { activeLeases, closed: true };
+    }
     return { activeLeases, closed: false };
   }
   return undefined;

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -26,6 +26,7 @@ type SharedCodexAppServerClientEntry = {
   activeLeases: number;
   pendingAcquires: number;
   closeWhenIdle: boolean;
+  closeError?: Error;
 };
 
 type SharedCodexAppServerClientState = {
@@ -212,6 +213,9 @@ async function acquireSharedCodexAppServerClient(
       options?.timeoutMs ?? 0,
       "codex app-server initialize timed out",
     );
+    if (entry.closeError) {
+      throw entry.closeError;
+    }
     // Later leases of the same keyed client may carry fresher config; the
     // runtime install itself stays one-per-physical-client.
     ensureCodexAppServerClientRuntime(client, {
@@ -408,9 +412,18 @@ export function retainSharedCodexAppServerClientIfCurrent(
   return undefined;
 }
 
-/** Marks a matching shared client to close after active leases/acquires drain. */
+/**
+ * Retires a matching shared client. Default is graceful: detach from the map
+ * (future acquisitions get a fresh client) and close once leases drain.
+ * `failActiveLeases` is for suspect clients only (timed-out turns): it closes
+ * the physical connection immediately so co-leased attempts hit the normal
+ * client-closed retry path, and pending acquires reject instead of leasing
+ * the poisoned process. Routine cleanup must NOT use it — it would abort
+ * healthy sibling turns on a working client.
+ */
 export function retireSharedCodexAppServerClientIfCurrent(
   client: CodexAppServerClient | undefined,
+  opts?: { failActiveLeases?: boolean },
 ): { activeLeases: number; closed: boolean } | undefined {
   if (!client) {
     return undefined;
@@ -420,6 +433,11 @@ export function retireSharedCodexAppServerClientIfCurrent(
     if (entry.client === client) {
       state.clients.delete(key);
       entry.closeWhenIdle = true;
+      if (opts?.failActiveLeases) {
+        entry.closeError = new Error("codex app-server client is closed");
+        const closed = closeRetiredSharedClientEntry(entry);
+        return { activeLeases: entry.activeLeases, closed };
+      }
       const closed = closeRetiredSharedClientEntryIfIdle(entry);
       return { activeLeases: entry.activeLeases, closed };
     }
@@ -551,6 +569,16 @@ function closeRetiredSharedClientEntryIfIdle(entry: SharedCodexAppServerClientEn
   }
   const client = entry.client;
   entry.closeWhenIdle = false;
+  entry.client = undefined;
+  client.close();
+  return true;
+}
+
+function closeRetiredSharedClientEntry(entry: SharedCodexAppServerClientEntry): boolean {
+  const client = entry.client;
+  if (!client) {
+    return false;
+  }
   entry.client = undefined;
   client.close();
   return true;


### PR DESCRIPTION
### What Problem This Solves

Track B2 of #101863 — the Codex app-server half of the liveness redesign (#89742, regression of #82681; also #85251, #90673).

One shared app-server client serves every session with the same auth profile + start options (`shared-client.ts` keyed global map). Two verified defects:

1. **Every fast watch is gated by in-flight server→client requests.** `activeAppServerTurnRequests > 0` suppresses the completion-idle (60s), assistant-completion (10s), *and* terminal-idle (30 min) watches. A client that goes silent with a request outstanding (the reported 429-burst shape: `turn/started`, then nothing) is exactly the state no watch can see; the only remaining bound is the whole run budget.
2. **Retiring a poisoned client doesn't fan out.** After a timed-out turn, the shared entry is detached so *future* acquisitions get a fresh client — but sessions already leased on the wedged process keep waiting with nothing to abort them.

### Why This Change Was Made

**Protocol proof (Codex gate).** Inspected sibling `openai/codex` source directly: server→client requests register a oneshot callback and await the client's response (`codex-rs/app-server/src/outgoing_message.rs:272-350`), completely separate from fire-and-forget server notifications (`outgoing_message.rs:589-629`; envelope split in `app-server-transport/src/outgoing_message.rs:21-31`; types in `app-server-protocol/src/protocol/common.rs:1199-1252, 1630-1658`). An in-flight request therefore proves nothing about notification liveness in either direction — gating a notification-silence watchdog on the request counter is unsound.

Changes (all in `extensions/codex/src/app-server/`):

1. **Terminal-idle watch ungated** (`attempt-turn-watches.ts`): the 30-minute zero-notification backstop now fires regardless of in-flight requests. Its clock still resets on every real notification, so healthy turns — including ones legitimately waiting on approvals/elicitation — are untouched as long as the server emits anything within the window. The completion-idle and assistant-completion watches keep their request gates: they express turn-completion semantics, which are genuinely indeterminate while a request is being served. No timeout constants changed.
2. **Suspect-client retirement fans out** (`shared-client.ts`, `attempt-client-cleanup.ts`): `retireSharedCodexAppServerClientIfCurrent` gains an explicit `failActiveLeases` mode used only by the timed-out-turn path — it closes the physical client immediately (transport close SIGKILLs the child after 1s), so co-leased attempts hit the existing client-closed retry path and re-run on a fresh client, and pending acquires reject instead of leasing the poisoned process. **Default retirement stays graceful** (detach + close-when-idle): routine one-shot bundle-MCP cleanup and startup-failure paths keep `main`'s behavior — the initial implementation applied immediate-close to all callers, which would have yanked healthy clients from co-leased sessions at every one-shot run end; review caught it and scoped it, restoring `main`'s two graceful-retirement tests verbatim and adding a pin test for the default.

Stated tradeoff: a healthy sibling turn co-leased on a client that another turn timed out gets aborted-and-retried. Intentional — a client suspect enough to deny future sessions should not keep serving current ones — and the failure is retryable, not user-terminal.

### User Impact

- A wedged shared app-server client is now bounded at 30 minutes of true silence instead of the full run budget (up to 48h), even mid-request.
- One poisoned client no longer wedges every co-leased session: siblings fail over to a fresh client automatically.
- No behavior change for healthy clients, isolated-client mode, or routine cleanup paths.

### Evidence

- Protocol citations above from direct `../codex` inspection (`f1affbac`), verified independently by implementer and reviewer.
- Tests: terminal watch fires with requests in flight + zero notifications (previously structurally impossible); does not fire while notifications arrive; completion/assistant gates regression-pinned; fan-out (co-lease sees retryable client-closed failure, pending acquires reject, fresh acquisition gets a new client); graceful-default retirement pinned (leased client survives routine retire, closes on release); isolated-client path unchanged.
- Validation: full `extensions/codex` suite green (96 files / 2005 tests on Testbox; app-server subset 78 files / 1681 tests re-run green after review edits), extensions tsgo + extensions-test tsgo lanes exit 0, oxlint/oxfmt clean.

Part of #101863 (Track B2). Fixes #89742; addresses #85251 / #90673 (same wedge class — will verify against each before closing).
