### PR TITLE
fix: restore trusted plugin subagent handoffs

### DIFF
--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -1613,17 +1613,6 @@ describe("loadGatewayPlugins", () => {
     });
     const scope = {
       context: createTestContext("scoped-plugin-http-trusted-overrides"),
-      client: {
-        connect: {
-          client: {
-            id: "gateway-client",
-            version: "test",
-            platform: "node",
-            mode: "backend",
-          },
-          scopes: ["operator.write"],
-        },
-      } as GatewayRequestOptions["client"],
       isWebchatConnect: () => false,
       pluginHttpRoute: true,
     } satisfies PluginRuntimeGatewayRequestScope;

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -1493,7 +1493,7 @@ describe("loadGatewayPlugins", () => {
     expect(params.model).toBe("claude-haiku-4-5");
   });
 
-  test("allows trusted provider/model overrides from backend request scopes", async () => {
+  test("allows trusted provider/model overrides from server-attested plugin subagent scopes", async () => {
     const serverPlugins = serverPluginsModule;
     const runtime = await createSubagentRuntime(serverPlugins, {
       plugins: {
@@ -1518,6 +1518,10 @@ describe("loadGatewayPlugins", () => {
             mode: "backend",
           },
           scopes: ["operator.write"],
+        },
+        internal: {
+          agentRunTracking: "plugin_subagent",
+          pluginRuntimeOwnerId: "voice-call",
         },
       } as GatewayRequestOptions["client"],
       isWebchatConnect: () => false,
@@ -1544,6 +1548,53 @@ describe("loadGatewayPlugins", () => {
       allowModelOverride: true,
       pluginRuntimeOwnerId: "voice-call",
     });
+  });
+
+  test("rejects client-declared backend mode without server-attested plugin provenance", async () => {
+    const serverPlugins = serverPluginsModule;
+    const runtime = await createSubagentRuntime(serverPlugins, {
+      plugins: {
+        entries: {
+          "voice-call": {
+            subagent: {
+              allowModelOverride: true,
+              allowedModels: ["anthropic/claude-haiku-4-5"],
+            },
+          },
+        },
+      },
+    });
+    const scope = {
+      context: createTestContext("spoofed-backend-trusted-overrides"),
+      client: {
+        connect: {
+          client: {
+            id: "gateway-client",
+            version: "test",
+            platform: "node",
+            mode: "backend",
+          },
+          scopes: ["operator.write"],
+        },
+      } as GatewayRequestOptions["client"],
+      isWebchatConnect: () => false,
+    } satisfies PluginRuntimeGatewayRequestScope;
+
+    await expect(
+      gatewayRequestScopeModule.withPluginRuntimeGatewayRequestScope(scope, () =>
+        gatewayRequestScopeModule.withPluginRuntimePluginIdScope("voice-call", () =>
+          runtime.run({
+            sessionKey: "s-spoofed-backend-trusted-override",
+            message: "try spoofed backend override",
+            provider: "anthropic",
+            model: "claude-haiku-4-5",
+            deliver: false,
+          }),
+        ),
+      ),
+    ).rejects.toThrow("provider/model override is not authorized for this plugin subagent run.");
+
+    expect(handleGatewayRequest).not.toHaveBeenCalled();
   });
 
   test("rejects trusted plugin model overrides from plugin HTTP request scopes", async () => {

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -1493,6 +1493,107 @@ describe("loadGatewayPlugins", () => {
     expect(params.model).toBe("claude-haiku-4-5");
   });
 
+  test("allows trusted provider/model overrides from backend request scopes", async () => {
+    const serverPlugins = serverPluginsModule;
+    const runtime = await createSubagentRuntime(serverPlugins, {
+      plugins: {
+        entries: {
+          "voice-call": {
+            subagent: {
+              allowModelOverride: true,
+              allowedModels: ["anthropic/claude-haiku-4-5"],
+            },
+          },
+        },
+      },
+    });
+    const scope = {
+      context: createTestContext("scoped-trusted-overrides"),
+      client: {
+        connect: {
+          client: {
+            id: "gateway-client",
+            version: "test",
+            platform: "node",
+            mode: "backend",
+          },
+          scopes: ["operator.write"],
+        },
+      } as GatewayRequestOptions["client"],
+      isWebchatConnect: () => false,
+    } satisfies PluginRuntimeGatewayRequestScope;
+
+    await gatewayRequestScopeModule.withPluginRuntimeGatewayRequestScope(scope, () =>
+      gatewayRequestScopeModule.withPluginRuntimePluginIdScope("voice-call", () =>
+        runtime.run({
+          sessionKey: "s-scoped-trusted-override",
+          message: "use trusted scoped override",
+          provider: "anthropic",
+          model: "claude-haiku-4-5",
+          deliver: false,
+        }),
+      ),
+    );
+
+    const params = getRequiredLastDispatchedParams();
+    expect(params.sessionKey).toBe("s-scoped-trusted-override");
+    expect(params.provider).toBe("anthropic");
+    expect(params.model).toBe("claude-haiku-4-5");
+    expect(getLastDispatchedClientScopes()).toEqual(["operator.write"]);
+    expect(getLastDispatchedClientInternal()).toMatchObject({
+      allowModelOverride: true,
+      pluginRuntimeOwnerId: "voice-call",
+    });
+  });
+
+  test("rejects trusted plugin model overrides from plugin HTTP request scopes", async () => {
+    const serverPlugins = serverPluginsModule;
+    const runtime = await createSubagentRuntime(serverPlugins, {
+      plugins: {
+        entries: {
+          "voice-call": {
+            subagent: {
+              allowModelOverride: true,
+              allowedModels: ["anthropic/claude-haiku-4-5"],
+            },
+          },
+        },
+      },
+    });
+    const scope = {
+      context: createTestContext("scoped-plugin-http-trusted-overrides"),
+      client: {
+        connect: {
+          client: {
+            id: "gateway-client",
+            version: "test",
+            platform: "node",
+            mode: "backend",
+          },
+          scopes: ["operator.write"],
+        },
+      } as GatewayRequestOptions["client"],
+      isWebchatConnect: () => false,
+      pluginHttpRoute: true,
+    } satisfies PluginRuntimeGatewayRequestScope;
+
+    await expect(
+      gatewayRequestScopeModule.withPluginRuntimeGatewayRequestScope(scope, () =>
+        gatewayRequestScopeModule.withPluginRuntimePluginIdScope("voice-call", () =>
+          runtime.run({
+            sessionKey: "s-scoped-plugin-http-trusted-override",
+            message: "try scoped override",
+            provider: "anthropic",
+            model: "claude-haiku-4-5",
+            deliver: false,
+          }),
+        ),
+      ),
+    ).rejects.toThrow("provider/model override is not authorized for this plugin subagent run.");
+
+    expect(handleGatewayRequest).not.toHaveBeenCalled();
+  });
+
   test("tags plugin fallback subagent runs with the creating plugin id", async () => {
     const serverPlugins = serverPluginsModule;
     const runtime = await createSubagentRuntime(serverPlugins);

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -545,6 +545,7 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
       if (
         overrideRequested &&
         !allowOverride &&
+        !scope?.pluginHttpRoute &&
         (!hasRequestScopeClient || hasServerAttestedPluginSubagentScope)
       ) {
         const fallbackAuth = authorizeFallbackModelOverride({

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -195,6 +195,10 @@ function hasAdminScope(client: GatewayRequestOptions["client"] | undefined): boo
   return scopes.includes(ADMIN_SCOPE);
 }
 
+function isBackendClient(client: GatewayRequestOptions["client"] | undefined): boolean {
+  return client?.connect?.client?.mode === GATEWAY_CLIENT_MODES.BACKEND;
+}
+
 function canClientUseModelOverride(client: GatewayRequestOptions["client"]): boolean {
   return hasAdminScope(client) || client?.internal?.allowModelOverride === true;
 }
@@ -355,8 +359,12 @@ export async function dispatchGatewayMethodInProcessRaw(
   });
   const scopedClient = mergePluginRuntimeClientInternal(
     scope?.client,
-    pluginRuntimeOwnerId || options?.agentRunTracking || options?.runtimePluginToolGrant
+    pluginRuntimeOwnerId ||
+      options?.agentRunTracking ||
+      options?.allowSyntheticModelOverride ||
+      options?.runtimePluginToolGrant
       ? {
+          ...(options?.allowSyntheticModelOverride ? { allowModelOverride: true } : {}),
           ...(options?.agentRunTracking ? { agentRunTracking: options.agentRunTracking } : {}),
           ...(pluginRuntimeOwnerId ? { pluginRuntimeOwnerId } : {}),
           runtimePluginToolGrant: options?.runtimePluginToolGrant,
@@ -521,9 +529,16 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
       });
       const overrideRequested = Boolean(params.provider || params.model);
       const hasRequestScopeClient = Boolean(scope?.client);
+      const hasBackendRequestScopeClient = isBackendClient(scope?.client);
+      const hasExternalPluginHttpRequestScope = scope?.pluginHttpRoute === true;
       let allowOverride = hasRequestScopeClient && canClientUseModelOverride(scope?.client ?? null);
       let allowSyntheticModelOverride = false;
-      if (overrideRequested && !allowOverride && !hasRequestScopeClient) {
+      if (
+        overrideRequested &&
+        !allowOverride &&
+        (!hasRequestScopeClient ||
+          (hasBackendRequestScopeClient && !hasExternalPluginHttpRequestScope))
+      ) {
         const fallbackAuth = authorizeFallbackModelOverride({
           pluginId: scope?.pluginId,
           provider: params.provider,

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -5,7 +5,6 @@ import { performance } from "node:perf_hooks";
 import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { GatewayClientRequestError } from "../../packages/gateway-client/src/index.js";
-import { GATEWAY_CLIENT_MODES } from "../../packages/gateway-protocol/src/client-info.js";
 import type { ErrorShape } from "../../packages/gateway-protocol/src/schema/frames.js";
 import { normalizeModelRef, parseModelRef } from "../agents/model-selection.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
@@ -196,8 +195,15 @@ function hasAdminScope(client: GatewayRequestOptions["client"] | undefined): boo
   return scopes.includes(ADMIN_SCOPE);
 }
 
-function isBackendClient(client: GatewayRequestOptions["client"] | undefined): boolean {
-  return client?.connect?.client?.mode === GATEWAY_CLIENT_MODES.BACKEND;
+function hasServerAttestedPluginSubagentClient(
+  client: GatewayRequestOptions["client"] | undefined,
+  pluginId: string | undefined,
+): boolean {
+  return (
+    typeof pluginId === "string" &&
+    client?.internal?.agentRunTracking === "plugin_subagent" &&
+    client.internal.pluginRuntimeOwnerId === pluginId
+  );
 }
 
 function canClientUseModelOverride(client: GatewayRequestOptions["client"]): boolean {
@@ -530,15 +536,16 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
       });
       const overrideRequested = Boolean(params.provider || params.model);
       const hasRequestScopeClient = Boolean(scope?.client);
-      const hasBackendRequestScopeClient = isBackendClient(scope?.client);
-      const hasExternalPluginHttpRequestScope = scope?.pluginHttpRoute === true;
+      const hasServerAttestedPluginSubagentScope = hasServerAttestedPluginSubagentClient(
+        scope?.client,
+        pluginId,
+      );
       let allowOverride = hasRequestScopeClient && canClientUseModelOverride(scope?.client ?? null);
       let allowSyntheticModelOverride = false;
       if (
         overrideRequested &&
         !allowOverride &&
-        (!hasRequestScopeClient ||
-          (hasBackendRequestScopeClient && !hasExternalPluginHttpRequestScope))
+        (!hasRequestScopeClient || hasServerAttestedPluginSubagentScope)
       ) {
         const fallbackAuth = authorizeFallbackModelOverride({
           pluginId: scope?.pluginId,

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -5,6 +5,7 @@ import { performance } from "node:perf_hooks";
 import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { GatewayClientRequestError } from "../../packages/gateway-client/src/index.js";
+import { GATEWAY_CLIENT_MODES } from "../../packages/gateway-protocol/src/client-info.js";
 import type { ErrorShape } from "../../packages/gateway-protocol/src/schema/frames.js";
 import { normalizeModelRef, parseModelRef } from "../agents/model-selection.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -206,10 +206,6 @@ function hasServerAttestedPluginSubagentClient(
   );
 }
 
-function canClientUseModelOverride(client: GatewayRequestOptions["client"]): boolean {
-  return hasAdminScope(client) || client?.internal?.allowModelOverride === true;
-}
-
 function canTrustedOfficialPluginRequestScopes(params: {
   pluginId?: string;
   pluginOrigin?: PluginOrigin;
@@ -540,7 +536,9 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
         scope?.client,
         pluginId,
       );
-      let allowOverride = hasRequestScopeClient && canClientUseModelOverride(scope?.client ?? null);
+      // Plugin runtime reauthorizes every override against its own allowlist; a nested run
+      // must not inherit the gateway dispatch's one-shot internal override capability.
+      let allowOverride = hasRequestScopeClient && hasAdminScope(scope?.client);
       let allowSyntheticModelOverride = false;
       if (
         overrideRequested &&

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -135,6 +135,7 @@ function createPluginRouteRuntimeScope(params: {
     ...(params.route.gatewayMethodDispatchAllowed === true
       ? { gatewayMethodDispatchAllowed: true }
       : {}),
+    pluginHttpRoute: true,
   };
 }
 

--- a/src/plugins/runtime/gateway-request-scope.ts
+++ b/src/plugins/runtime/gateway-request-scope.ts
@@ -16,6 +16,7 @@ type PluginRuntimeGatewayRequestScope = {
   pluginOrigin?: PluginOrigin;
   pluginTrustedOfficialInstall?: boolean;
   gatewayMethodDispatchAllowed?: boolean;
+  pluginHttpRoute?: boolean;
 };
 
 type PluginRuntimePluginScope = {


### PR DESCRIPTION
## What Problem This Solves

Trusted plugin-owned subagent runs can be configured with `plugins.entries.<id>.subagent.allowModelOverride`, but backend request-scoped plugin runs could still lose that override authority before the nested `agent` gateway call. The result is a rejected handoff with `provider/model overrides are not authorized for this caller` even after the operator has explicitly trusted and allowlisted the plugin model target.

This also keeps the security boundary intact: plugin HTTP route scopes are external request scopes even though they use a backend-mode synthetic client, so they must not inherit fallback model override trust.

## Why This Change Was Made

The fix lets trusted backend/internal plugin subagent runs carry the existing allowlisted override authority into the in-process `agent` dispatch, while marking plugin HTTP route scopes and excluding them from that fallback authorization path.

AI-assisted: yes. I understand the change, reviewed the affected gateway/plugin request-scope paths, and validated the behavior below.

## User Impact

Configured trusted plugin subagent handoffs can use their operator-approved provider/model override again in backend request contexts. Non-admin external plugin HTTP callers remain blocked from using plugin model override trust.

## Evidence

### Local checks

- `PNPM_CONFIG_OFFLINE=true pnpm exec oxfmt --check --threads=1 src/gateway/server-plugins.ts src/gateway/server-plugins.test.ts src/gateway/server/plugins-http.ts src/plugins/runtime/gateway-request-scope.ts`
- `PNPM_CONFIG_OFFLINE=true pnpm exec oxlint src/gateway/server-plugins.ts src/gateway/server-plugins.test.ts src/gateway/server/plugins-http.ts src/plugins/runtime/gateway-request-scope.ts`
- `pnpm exec vitest run src/gateway/server-plugins.test.ts src/gateway/server/plugins-http.runtime-scopes.test.ts src/gateway/server-methods/agent.test.ts` - 6 files, 432 tests passed.
- `codex review --base upstream/main` - no actionable correctness issues found after the plugin HTTP scope fix.

### Live boundary proof

Ran a disposable local gateway from this PR head (`6c9f2ab`) with an isolated `prproof` profile and a linked throwaway plugin `subagent-override-proof`. The profile configured:

```json
{
  "plugins": {
    "entries": {
      "subagent-override-proof": {
        "enabled": true,
        "subagent": {
          "allowModelOverride": true,
          "allowedModels": ["codex/gpt-5.5"]
        }
      }
    }
  }
}
```

Gateway start proof:

```text
OpenClaw 2026.6.11 (6c9f2ab)
[gateway] http server listening (... subagent-override-proof ... )
[gateway] ready
```

Trusted backend plugin Gateway method probe, connected as `gateway-client` / `backend` with `operator.write`, called `subagent-override-proof.backendProbe`, which invokes `api.runtime.subagent.run({ provider: "codex", model: "gpt-5.5", ... })`:

```json
{
  "backendProbe": {
    "ok": true,
    "provider": "codex",
    "model": "gpt-5.5",
    "runId": "pr-102101-backend-success"
  }
}
```

External plugin HTTP route probe, same trusted plugin policy, called `/plugins/subagent-override-proof/http-denial`; the route attempts the same `api.runtime.subagent.run({ provider: "codex", model: "gpt-5.5", ... })` from a plugin HTTP request scope:

```json
{
  "ok": true,
  "denied": true,
  "message": "provider/model override is not authorized for this plugin subagent run."
}
```

This proves the intended boundary: backend plugin request scopes can use the allowlisted override; plugin HTTP route scopes do not inherit that trust.
