### PR TITLE
fix(web-shared): treat exact-limit response reads as complete

### DIFF
--- a/src/agents/tools/web-shared.test.ts
+++ b/src/agents/tools/web-shared.test.ts
@@ -175,6 +175,42 @@ describe("readResponseText", () => {
     });
   });
 
+  it("does not mark an exact-limit read as truncated", async () => {
+    const cancel = vi.fn(async () => undefined);
+    const releaseLock = vi.fn();
+    const response = responseFromReader({
+      chunks: ["hello", " world"],
+      cancel,
+      releaseLock,
+    });
+
+    await expect(readResponseText(response, { maxBytes: 11 })).resolves.toEqual({
+      text: "hello world",
+      truncated: false,
+      bytesRead: 11,
+    });
+    expect(cancel).not.toHaveBeenCalled();
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks as truncated when the next chunk confirms more data after exact limit", async () => {
+    const cancel = vi.fn(async () => undefined);
+    const releaseLock = vi.fn();
+    const response = responseFromReader({
+      chunks: ["hello", " world", "more data"],
+      cancel,
+      releaseLock,
+    });
+
+    await expect(readResponseText(response, { maxBytes: 11 })).resolves.toEqual({
+      text: "hello world",
+      truncated: true,
+      bytesRead: 11,
+    });
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
   it("preserves uncapped text-only fallback byte accounting", async () => {
     const value = "中文🔥";
     const text = vi.fn(async () => value);

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -272,8 +272,12 @@ export async function readResponseText(
         bytesRead += chunk.byteLength;
         parts.push(chunk);
 
-        if (truncated || bytesRead >= maxBytes) {
-          truncated = true;
+        if (truncated) {
+          break;
+        }
+        if (bytesRead >= maxBytes) {
+          const next = await reader.read();
+          truncated = !next.done && next.value != null && next.value.byteLength > 0;
           break;
         }
       }


### PR DESCRIPTION
## What Problem This Solves

`readResponseText` in `src/agents/tools/web-shared.ts` marks a bounded streamed read as truncated when `bytesRead >= maxBytes`, even when the response body is exactly `maxBytes` bytes. This produces a false `truncated: true` for exact-size responses, which `web_fetch` surfaces as a user-visible "response body truncated" warning.

## Why This Change Was Made

The original code at line 275:

```ts
if (truncated || bytesRead >= maxBytes) {
  truncated = true;
  break;
}
```

When a chunk fills `maxBytes` exactly (e.g. 11 bytes in two chunks "hello" + " world"), the overflow guard on line 262 (`bytesRead + chunk.byteLength > maxBytes`) does not fire, so we reach line 275 with `bytesRead === maxBytes` and `truncated === false`. The `>=` check unconditionally marks this as truncated.

Fix: when `truncated` is already true (trimmed overflow chunk), break immediately. When `bytesRead` hits the limit without overflow, read one more chunk from the stream to confirm whether data was actually omitted.

## Evidence

Two new regression tests in `src/agents/tools/web-shared.test.ts`:

1. **Exact-limit read is NOT truncated**: `["hello", " world"]` with `maxBytes: 11` → `{ text: "hello world", truncated: false, bytesRead: 11 }`, no reader cancellation
2. **More data after exact limit IS truncated**: `["hello", " world", "more data"]` with `maxBytes: 11` → `{ text: "hello world", truncated: true, bytesRead: 11 }`, reader cancelled

```
✓ does not mark an exact-limit read as truncated
✓ marks as truncated when the next chunk confirms more data after exact limit
```

All 26 tests across all web-shared test suites pass.

## Merge Risk

Low — one targeted change to the boundary condition in the streaming read loop. The overflow-trimming path and the fully-uncapped path are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)