### PR TITLE
fix(google-meet): handle stdout/stderr stream errors in node host

### DIFF
--- a/extensions/google-meet/node-host.test.ts
+++ b/extensions/google-meet/node-host.test.ts
@@ -9,7 +9,7 @@ type MockChild = EventEmitter & {
   kill: ReturnType<typeof vi.fn>;
   stdout?: EventEmitter;
   stderr?: EventEmitter;
-  stdin?: { write: ReturnType<typeof vi.fn> };
+  stdin?: EventEmitter & { write: ReturnType<typeof vi.fn> };
 };
 
 const children: MockChild[] = [];
@@ -34,7 +34,7 @@ vi.mock("node:child_process", async (importOriginal) => {
         }),
         stdout: new EventEmitter(),
         stderr: new EventEmitter(),
-        stdin: { write: vi.fn() },
+        stdin: Object.assign(new EventEmitter(), { write: vi.fn() }),
       }) as MockChild;
       children.push(child);
       return child;
@@ -196,6 +196,48 @@ describe("google-meet node host bridge sessions", () => {
           bridgeId: start.bridgeId,
         }),
       );
+    } finally {
+      Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    }
+  });
+
+  it("closes once when command-pair streams fail together", async () => {
+    const originalPlatform = process.platform;
+    children.length = 0;
+
+    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
+    try {
+      const start = JSON.parse(
+        await handleGoogleMeetNodeHostCommand(
+          JSON.stringify({
+            action: "start",
+            url: "https://meet.google.com/xyz-abcd-uvw",
+            mode: "realtime",
+            launch: false,
+            audioInputCommand: ["mock-rec"],
+            audioOutputCommand: ["mock-play"],
+          }),
+        ),
+      );
+      const [outputProcess, inputProcess] = children;
+      if (!outputProcess || !inputProcess) {
+        throw new Error("expected Google Meet node host command-pair processes");
+      }
+
+      outputProcess.stderr?.emit("error", new Error("output stderr failed"));
+      inputProcess.stdout?.emit("error", new Error("input stdout failed"));
+      inputProcess.stderr?.emit("error", new Error("input stderr failed"));
+
+      const status = JSON.parse(
+        await handleGoogleMeetNodeHostCommand(
+          JSON.stringify({ action: "status", bridgeId: start.bridgeId }),
+        ),
+      );
+      expect(status.bridge.closed).toBe(true);
+      expect(outputProcess.kill).toHaveBeenCalledTimes(1);
+      expect(inputProcess.kill).toHaveBeenCalledTimes(1);
+      expect(outputProcess.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(inputProcess.kill).toHaveBeenCalledWith("SIGTERM");
     } finally {
       Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
     }

--- a/extensions/google-meet/src/node-host.ts
+++ b/extensions/google-meet/src/node-host.ts
@@ -107,32 +107,28 @@ function wake(session: NodeBridgeSession) {
 }
 
 function stopSession(session: NodeBridgeSession) {
-  const wasClosed = session.closed;
+  // Process and stream errors can arrive together during teardown. Close once
+  // so the same children do not get duplicate termination timers.
+  if (session.closed) {
+    return;
+  }
   session.closed = true;
-  session.closedAt ??= new Date().toISOString();
+  session.closedAt = new Date().toISOString();
   terminateChild(session.input);
   terminateChild(session.output);
-  if (!wasClosed) {
-    wake(session);
-  }
+  wake(session);
 }
 
 function attachOutputProcessHandlers(session: NodeBridgeSession, outputProcess: ChildProcess) {
-  outputProcess.on("exit", () => {
+  const stopIfCurrent = () => {
     if (session.output === outputProcess) {
       stopSession(session);
     }
-  });
-  outputProcess.on("error", () => {
-    if (session.output === outputProcess) {
-      stopSession(session);
-    }
-  });
-  outputProcess.stdin?.on?.("error", () => {
-    if (session.output === outputProcess) {
-      stopSession(session);
-    }
-  });
+  };
+  outputProcess.on("exit", stopIfCurrent);
+  outputProcess.on("error", stopIfCurrent);
+  outputProcess.stdin?.on("error", stopIfCurrent);
+  outputProcess.stderr?.on("error", stopIfCurrent);
 }
 
 function startOutputProcess(command: { command: string; args: string[] }) {
@@ -178,9 +174,12 @@ function startCommandPair(params: {
     }
     wake(session);
   });
-  inputProcess.on("exit", () => stopSession(session));
+  const stop = () => stopSession(session);
+  inputProcess.on("exit", stop);
+  inputProcess.on("error", stop);
+  inputProcess.stdout?.on("error", stop);
+  inputProcess.stderr?.on("error", stop);
   attachOutputProcessHandlers(session, outputProcess);
-  inputProcess.on("error", () => stopSession(session));
   sessions.set(session.id, session);
   return session;
 }


### PR DESCRIPTION
## What Problem This Solves

The Google Meet node-host command pair handled child-process failures but left the input stdout/stderr and output stderr streams without `error` listeners. A stream failure could therefore escape the bridge lifecycle as an unhandled EventEmitter error, while a burst of related process and stream failures could schedule child termination repeatedly.

## Why This Change Was Made

The node-host now routes every piped stream failure through one idempotent session stop path. Output handlers share a current-process guard so a replaced playback process cannot close the active bridge; input and output children are terminated only on the first failure.

The original four-commit implementation and its test-only production exports were replaced with a smaller refactor and a regression in the existing public node-host command suite.

## User Impact

Google Meet Chrome-node audio sessions now close cleanly when their local audio command pipes fail instead of risking a gateway crash or duplicated termination timers. Normal bridge start, output clearing, and stop behavior is unchanged.

## Evidence

- `node scripts/run-vitest.mjs extensions/google-meet/node-host.test.ts --reporter=verbose` on Linux Testbox: 1 file, 6 tests passed.
- Touched-surface `pnpm check:changed` on Linux Testbox: extension production/test types, lint, import cycles, and repository guards passed.
- Fresh structured autoreview: clean, no accepted or actionable findings.
- `git diff --check`: passed.

### Real behavior proof

The public `handleGoogleMeetNodeHostCommand` test starts the command-pair lifecycle, emits output-stderr and input-stdout/input-stderr errors in one teardown burst, then verifies the bridge is closed and each child receives exactly one `SIGTERM`. Removing any new listener makes the corresponding EventEmitter `error` unhandled; removing the idempotent stop guard makes the termination-count assertion fail.

### Known proof gap

The regression uses the existing child-process mock to deterministically force all three stream errors. It does not join a live Google Meet call or depend on BlackHole/audio hardware.
