### PR TITLE
perf(memory): reduce host SDK chunking allocations

### DIFF
--- a/packages/memory-host-sdk/src/host/internal.ts
+++ b/packages/memory-host-sdk/src/host/internal.ts
@@ -145,7 +145,9 @@ async function collectMemoryFilesFromDir(
       entry.kind === "file" &&
       isAllowedMemoryFilePath(entry.path, multimodal),
   });
-  files.push(...scan.entries.map((entry) => entry.path));
+  for (const entry of scan.entries) {
+    files.push(entry.path);
+  }
 }
 
 export async function listMemoryFiles(
@@ -428,28 +430,37 @@ export function chunkMarkdown(
       return;
     }
     let acc = 0;
-    const kept: Array<{ line: string; lineNo: number }> = [];
+    let startIndex = current.length;
     for (let i = current.length - 1; i >= 0; i -= 1) {
       const entry = current[i];
       if (!entry) {
         continue;
       }
       acc += estimateStringChars(entry.line) + 1;
-      kept.unshift(entry);
+      startIndex = i;
       if (acc >= overlapChars) {
         break;
       }
     }
-    current = kept;
+    current = current.slice(startIndex);
     currentChars = acc;
+  };
+
+  const appendSegment = (segment: string, lineNo: number) => {
+    const lineSize = estimateStringChars(segment) + 1;
+    if (currentChars + lineSize > maxChars && current.length > 0) {
+      flush();
+      carryOverlap();
+    }
+    current.push({ line: segment, lineNo });
+    currentChars += lineSize;
   };
 
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i] ?? "";
     const lineNo = i + 1;
-    const segments: string[] = [];
     if (line.length === 0) {
-      segments.push("");
+      appendSegment("", lineNo);
     } else {
       // First pass: slice at maxChars (preserves original behaviour for Latin).
       // Second pass: if a segment's *weighted* size still exceeds the budget
@@ -465,23 +476,14 @@ export function chunkMarkdown(
             if (lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff && end < coarse.length) {
               end += 1;
             }
-            segments.push(coarse.slice(j, end));
+            appendSegment(coarse.slice(j, end), lineNo);
             j = end;
           }
         } else {
-          segments.push(coarse);
+          appendSegment(coarse, lineNo);
         }
         start += coarse.length;
       }
-    }
-    for (const segment of segments) {
-      const lineSize = estimateStringChars(segment) + 1;
-      if (currentChars + lineSize > maxChars && current.length > 0) {
-        flush();
-        carryOverlap();
-      }
-      current.push({ line: segment, lineNo });
-      currentChars += lineSize;
     }
   }
   flush();


### PR DESCRIPTION
﻿## Summary
- avoid an intermediate path array while collecting memory files
- avoid per-line segment arrays while chunking markdown
- replace overlap carry `unshift` usage with an indexed slice
- rebased onto current `origin/main` (`4bf70be01a`) to remove stale-base merge-order noise

## Real behavior / performance proof
Compared `origin/main` and this PR head in one Node process using a temporary real filesystem memory workspace:
- workspace: `MEMORY.md` plus 600 `memory/*.md` files and 600 `extra-memory/*.md` files
- `listMemoryFiles`: 15 iterations over the temp workspace
- `chunkMarkdown`: 250 iterations over 900 mixed CJK/English lines with `{ tokens: 80, overlap: 20 }`
- behavior check compares file count/hash and chunk count/hash across before/after

```json
{
  "node": "v24.16.0",
  "repoBase": "origin/main",
  "prHead": "agent/safe-optimizations",
  "workspaceFilesExpected": 1201,
  "before": {
    "label": "origin/main",
    "files": 1201,
    "filesHash": "2377395a3452a564",
    "listMs": 9553.2,
    "listHeapDeltaKb": -34,
    "chunks": 900,
    "chunkHash": "88298d32db1b48e5",
    "chunkMs": 2595.4,
    "chunkHeapDeltaKb": 835
  },
  "after": {
    "label": "PR head",
    "files": 1201,
    "filesHash": "2377395a3452a564",
    "listMs": 8792.4,
    "listHeapDeltaKb": 278,
    "chunks": 900,
    "chunkHash": "88298d32db1b48e5",
    "chunkMs": 2593,
    "chunkHeapDeltaKb": -204
  },
  "behaviorEqual": true,
  "listSpeedupPct": 8,
  "chunkSpeedupPct": 0.1
}
```

Interpretation:
- `behaviorEqual: true` proves preserved file listing and markdown chunking output on the exercised real paths.
- `listMemoryFiles` improved by 8.0% in this run.
- `chunkMarkdown` output is unchanged and runtime is effectively neutral/slightly faster; the value of that change is reduced transient allocation from removing the per-line `segments` array and overlap `unshift` path.

## Validation
```text
$ pnpm exec vitest run --config test/vitest/vitest.unit-fast.config.ts packages/memory-host-sdk/src/host/internal.test.ts
Test Files  1 passed (1)
Tests       10 passed (10)

$ pnpm tsgo:test:packages
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.packages.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-packages.tsbuildinfo

$ pnpm exec oxfmt --check packages/memory-host-sdk/src/host/internal.ts
Checking formatting...
All matched files use the correct format.
```

## Data model / migration compatibility
No persistent data model, schema, vector metadata format, embedding content, hash format, or migration behavior is changed. The diff only changes loop structure in `collectMemoryFilesFromDir` and `chunkMarkdown`; proof above shows identical file-list and chunk-output hashes against `origin/main`.
