### PR TITLE
fix(secrets): skip gateway RPC for non-gateway exec SecretRefs

### DIFF
--- a/src/cli/command-secret-gateway.test.ts
+++ b/src/cli/command-secret-gateway.test.ts
@@ -623,7 +623,6 @@ describe("resolveCommandSecretRefsViaGateway", () => {
 
   it("keeps local exec SecretRef fallback enabled by default", async () => {
     const { config, markerPath } = await createExecProviderConfig("talk/providers/api-key");
-    callGateway.mockRejectedValueOnce(new Error("gateway closed"));
 
     const result = await resolveCommandSecretRefsViaGateway({
       config,
@@ -632,15 +631,21 @@ describe("resolveCommandSecretRefsViaGateway", () => {
       mode: "read_only_status",
     });
 
+    expect(callGateway).not.toHaveBeenCalled();
     expect(await markerExists(markerPath)).toBe(true);
     expect(readTalkProviderApiKey(result.resolvedConfig)).toBe("exec-local-key");
     expect(result.targetStatesByPath[TALK_TEST_PROVIDER_API_KEY_PATH]).toBe("resolved_local");
-    expectGatewayUnavailableLocalFallbackDiagnostics(result);
+    expect(
+      result.diagnostics.some((entry) =>
+        entry.includes(
+          "memory status: skipped gateway secrets.resolve because configured secrets use exec SecretRefs at talk.providers.acme-speech.apiKey",
+        ),
+      ),
+    ).toBe(true);
   });
 
   it("skips local exec SecretRef fallback when the caller disallows exec providers", async () => {
     const { config, markerPath } = await createExecProviderConfig("talk/providers/api-key");
-    callGateway.mockRejectedValueOnce(new Error("gateway closed"));
 
     const result = await resolveCommandSecretRefsViaGateway({
       config,
@@ -650,6 +655,7 @@ describe("resolveCommandSecretRefsViaGateway", () => {
       allowLocalExecSecretRefs: false,
     });
 
+    expect(callGateway).not.toHaveBeenCalled();
     expect(await markerExists(markerPath)).toBe(false);
     expect(readTalkProviderApiKey(result.resolvedConfig)).toBeUndefined();
     expect(result.targetStatesByPath[TALK_TEST_PROVIDER_API_KEY_PATH]).toBe("unresolved");
@@ -665,7 +671,9 @@ describe("resolveCommandSecretRefsViaGateway", () => {
     ).toBe(true);
     expect(
       result.diagnostics.some((entry) =>
-        entry.includes("attempted local command-secret resolution"),
+        entry.includes(
+          "doctor preview: skipped gateway secrets.resolve because configured secrets use exec SecretRefs at talk.providers.acme-speech.apiKey",
+        ),
       ),
     ).toBe(true);
   });
@@ -746,6 +754,29 @@ describe("resolveCommandSecretRefsViaGateway", () => {
         ).toBe(true);
       },
     );
+  });
+
+  it("skips gateway resolution when non-gateway targets use exec SecretRefs", async () => {
+    const { config, markerPath } = await createExecProviderConfig("talk/providers/api-key");
+
+    const result = await resolveCommandSecretRefsViaGateway({
+      config,
+      commandName: "reply",
+      targetIds: new Set(["talk.providers.*.apiKey"]),
+      mode: "read_only_status",
+    });
+
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(await markerExists(markerPath)).toBe(true);
+    expect(readTalkProviderApiKey(result.resolvedConfig)).toBe("exec-local-key");
+    expect(result.targetStatesByPath[TALK_TEST_PROVIDER_API_KEY_PATH]).toBe("resolved_local");
+    expect(
+      result.diagnostics.some((entry) =>
+        entry.includes(
+          "reply: skipped gateway secrets.resolve because configured secrets use exec SecretRefs at talk.providers.acme-speech.apiKey",
+        ),
+      ),
+    ).toBe(true);
   });
 
   it("falls back to local resolution for web search SecretRefs when gateway is unavailable", async () => {

--- a/src/cli/command-secret-gateway.ts
+++ b/src/cli/command-secret-gateway.ts
@@ -11,6 +11,7 @@ import { callGateway } from "../gateway/call.js";
 import { gatewaySecretInputPathCanWin } from "../gateway/credentials-secret-inputs.js";
 import {
   ALL_GATEWAY_SECRET_INPUT_PATHS,
+  isSupportedGatewaySecretInputPath,
   readGatewaySecretInputValue,
   type SupportedGatewaySecretInputPath,
 } from "../gateway/secret-input-paths.js";
@@ -322,6 +323,32 @@ function targetsRuntimeWebResolution(params: {
     }
   }
   return false;
+}
+
+function collectConfiguredTargetExecRefPaths(params: {
+  config: OpenClawConfig;
+  targetIds: Set<string>;
+  allowedPaths?: ReadonlySet<string>;
+}): string[] {
+  const defaults = params.config.secrets?.defaults;
+  const execRefPaths: string[] = [];
+  for (const target of commandSecretGatewayDeps.discoverConfigSecretTargetsByIds(
+    params.config,
+    params.targetIds,
+  )) {
+    if (params.allowedPaths && !params.allowedPaths.has(target.path)) {
+      continue;
+    }
+    const { ref } = resolveSecretInputRef({
+      value: target.value,
+      refValue: target.refValue,
+      defaults,
+    });
+    if (ref?.source === "exec") {
+      execRefPaths.push(target.path);
+    }
+  }
+  return execRefPaths;
 }
 
 function collectConfiguredTargetRefPaths(params: {
@@ -951,6 +978,33 @@ export async function resolveCommandSecretRefsViaGateway(params: {
       resolutionPolicy,
       reasonDiagnostic: `${params.commandName}: skipped gateway secrets.resolve because gateway credentials use exec SecretRefs at ${gatewayExecSecretRefCredentialPaths.join(", ")}; rerun with --allow-exec to execute configured exec providers.`,
     });
+  }
+
+  // Skip the gateway RPC when non-gateway exec SecretRefs (e.g. model-provider
+  // apiKey) are configured.  The gateway's command-path resolution cannot execute
+  // exec providers, so the RPC would always fail with UNAVAILABLE before falling
+  // back locally — pure overhead and noisy log spam.
+  if (configuredTargetRefPaths.size > 0) {
+    const execRefPaths = collectConfiguredTargetExecRefPaths({
+      config: params.config,
+      targetIds: params.targetIds,
+      allowedPaths: params.allowedPaths,
+    });
+    const nonGatewayExecPaths = execRefPaths.filter((p) => !isSupportedGatewaySecretInputPath(p));
+    if (nonGatewayExecPaths.length > 0) {
+      return await resolveCommandSecretRefsWithoutGateway({
+        config: params.config,
+        commandName: params.commandName,
+        targetIds: params.targetIds,
+        preflightDiagnostics: preflight.diagnostics,
+        mode,
+        allowedPaths: params.allowedPaths,
+        forcedActivePaths: params.forcedActivePaths,
+        optionalActivePaths: params.optionalActivePaths,
+        resolutionPolicy,
+        reasonDiagnostic: `${params.commandName}: skipped gateway secrets.resolve because configured secrets use exec SecretRefs at ${nonGatewayExecPaths.join(", ")}; resolved command secrets locally.`,
+      });
+    }
   }
 
   let payload: GatewaySecretsResolveResult;


### PR DESCRIPTION
## What Problem This Solves

On every agent **reply** turn, the gateway logs a noisy UNAVAILABLE failure for `secrets.resolve` when a model-provider credential uses an **exec** SecretRef. The gateway's command-path resolution cannot execute exec providers, so the RPC always fails before falling back locally — producing ~1 log line per turn.

```
[ws] ⇄ res ✗ secrets.resolve 6ms errorCode=UNAVAILABLE errorMessage=secrets.resolve failed
```

## Why This Change Was Made

The existing code in `resolveCommandSecretRefsViaGateway` already skips the gateway RPC when **gateway-credential** paths (`gateway.auth.*`, `gateway.remote.*`) use exec SecretRefs, because the gateway can't resolve them via the RPC. The same logic applies to model-provider/agent-runtime paths — `collectActiveGatewayExecSecretRefCredentialPaths` only looks at gateway paths, so model-provider exec refs were still triggering the futile RPC.

Fix: add a `collectConfiguredTargetExecRefPaths` helper and check for non-gateway exec SecretRefs before calling the gateway RPC. When any are found, skip the RPC and resolve locally (same pattern as the gateway-credential skip).

## Evidence

All 35 tests in `command-secret-gateway.test.ts` pass.

New test: **"skips gateway resolution when non-gateway targets use exec SecretRefs"**
- Configures a talk provider with exec-backed apiKey
- Verifies `callGateway` is never invoked
- Verifies the exec provider is executed and resolves correctly
- Verifies the diagnostic includes "skipped gateway secrets.resolve because configured secrets use exec SecretRefs"

Updated tests:
- **"keeps local exec SecretRef fallback enabled by default"** — now verifies the gateway RPC is proactively skipped rather than attempted and failed
- **"skips local exec SecretRef fallback when the caller disallows exec providers"** — same proactive skip

## Merge Risk

Low — narrow check added just before the gateway RPC call, reusing existing `collectConfiguredTargetRefPaths` data. The `resolveCommandSecretRefsWithoutGateway` path is already exercised by the gateway-credential exec skip. Non-exec ref paths are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)