### PR TITLE
fix: don't mark exact-size web_fetch responses as truncated (#101837)

### DIFF
--- a/src/agents/tools/web-shared.test.ts
+++ b/src/agents/tools/web-shared.test.ts
@@ -147,6 +147,42 @@ describe("readResponseText", () => {
     expect(releaseLock).toHaveBeenCalledTimes(1);
   });
 
+  it("does not mark exact-size responses as truncated", async () => {
+    const cancel = vi.fn(async () => undefined);
+    const releaseLock = vi.fn();
+    const response = responseFromReader({
+      chunks: ["exact"],
+      cancel,
+      releaseLock,
+    });
+
+    await expect(readResponseText(response, { maxBytes: 5 })).resolves.toEqual({
+      text: "exact",
+      truncated: false,
+      bytesRead: 5,
+    });
+    expect(cancel).not.toHaveBeenCalled();
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks response as truncated when more data follows after hitting the byte limit", async () => {
+    const cancel = vi.fn(async () => undefined);
+    const releaseLock = vi.fn();
+    const response = responseFromReader({
+      chunks: ["exact", "more"],
+      cancel,
+      releaseLock,
+    });
+
+    await expect(readResponseText(response, { maxBytes: 5 })).resolves.toEqual({
+      text: "exact",
+      truncated: true,
+      bytesRead: 5,
+    });
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
   it("does not invoke whole-body fallbacks when maxBytes is set", async () => {
     const arrayBuffer = vi.fn(async () => new TextEncoder().encode("hello").buffer);
     const text = vi.fn(async () => "hello");

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -273,6 +273,14 @@ export async function readResponseText(
         parts.push(chunk);
 
         if (truncated || bytesRead >= maxBytes) {
+          // Exact-size responses are complete, not truncated.
+          // Peek one more read to confirm whether the stream has ended.
+          if (!truncated) {
+            const peek = await reader.read();
+            if (peek.done) {
+              break;
+            }
+          }
           truncated = true;
           break;
         }


### PR DESCRIPTION
## Summary

Fixes #101837: `web_fetch` reports exact-size responses as truncated when the streamed response body is exactly `maxResponseBytes` bytes.

*(Recreated from clean `upstream/main` — the previous PR #102099 had a stale fork base with unrelated commits. Apologies for the noise!)*

## Root Cause

`readResponseText` in `src/agents/tools/web-shared.ts` set `truncated = true` when `bytesRead >= maxBytes` without checking whether the stream had actually ended. A response body that happened to be exactly the byte limit was treated the same as a genuinely oversized response.

## Fix

After hitting the byte limit, peek one additional `reader.read()` call:
- If `done: true` → the stream ended naturally, response is **complete** (not truncated)
- If `done: false` → there is more data, response is genuinely **truncated**

## Evidence

### Real behavior proof — exact-size responses are no longer truncated

Before (current main): exact-size response → truncated:

```
readResponseText(exact5ByteStream, { maxBytes: 5 })
→ { text: "exact", truncated: true, bytesRead: 5 }   // ❌ wrong
```

After (PR branch): exact-size response → complete:

```
readResponseText(exact5ByteStream, { maxBytes: 5 })
→ { text: "exact", truncated: false, bytesRead: 5 }  // ✅ correct
```

Overflow still detected correctly:

```
readResponseText(streamWithMoreData, { maxBytes: 5 })
→ { text: "exact", truncated: true, bytesRead: 5 }   // ✅ still correct
```

### Vitest

```
✓ src/agents/tools/web-shared.test.ts (26 tests)
  ✓ releases bounded response readers after complete reads
  ✓ cancels and releases bounded response readers after truncation
  ✓ does not mark exact-size responses as truncated          ← new
  ✓ marks response as truncated when more data follows       ← new
```

## Files changed
- `src/agents/tools/web-shared.ts`: 1 peek read after hitting byte limit
- `src/agents/tools/web-shared.test.ts`: 2 regression tests (exact-size + post-limit)

Closes #101837

🤖 Generated with [Claude Code](https://claude.com/claude-code)