### PR TITLE
fix: align tool-result chars-per-token estimate with normal text (4 chars/token)

### DIFF
--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
@@ -266,13 +266,13 @@ describe("preemptive-compaction", () => {
       prompt: "continue",
     });
 
-    expect(estimatedPromptTokens).toBeGreaterThan(80_000);
+    expect(estimatedPromptTokens).toBeGreaterThan(40_000);
 
     const result = shouldPreemptivelyCompactBeforePrompt({
       messages,
       systemPrompt: "sys",
       prompt: "continue",
-      contextTokenBudget: 96_000,
+      contextTokenBudget: 64_000,
       reserveTokens: 20_000,
     });
 
@@ -301,8 +301,8 @@ describe("preemptive-compaction", () => {
   });
 
   it("prechecks a regression-sized synthetic tool-heavy transcript as over budget", () => {
-    const toolResultCharsPerMessage = Math.ceil(427_000 / 120);
-    const generalCharsPerMessage = Math.ceil((503_000 - 427_000) / 121);
+    const toolResultCharsPerMessage = Math.ceil(560_000 / 120);
+    const generalCharsPerMessage = Math.ceil((700_000 - 560_000) / 121);
     const messages: AgentMessage[] = [];
     for (let index = 0; index < 241; index += 1) {
       if (index % 2 === 0) {

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
@@ -24,7 +24,7 @@ export const PREEMPTIVE_OVERFLOW_ERROR_TEXT =
   "Context overflow: prompt too large for the model (precheck).";
 
 const ESTIMATED_CHARS_PER_TOKEN = 4;
-const TOOL_RESULT_CHARS_PER_TOKEN = 2;
+const TOOL_RESULT_CHARS_PER_TOKEN = 4;
 const JSON_PAYLOAD_CHARS_PER_TOKEN = 3;
 const MESSAGE_BOUNDARY_OVERHEAD_TOKENS = 12;
 const CONTENT_BLOCK_OVERHEAD_TOKENS = 6;

--- a/src/agents/embedded-agent-runner/tool-result-char-estimator.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-char-estimator.test.ts
@@ -28,7 +28,7 @@ describe("tool-result-char-estimator", () => {
 
     const cache = createMessageCharEstimateCache();
     const chars = estimateMessageCharsCached(malformed, cache);
-    expect(chars).toBe(30);
+    expect(chars).toBe(15);
   });
 
   it("estimates text content when toolResult content includes null entries", () => {
@@ -41,7 +41,7 @@ describe("tool-result-char-estimator", () => {
 
     const cache = createMessageCharEstimateCache();
     const chars = estimateMessageCharsCached(malformed, cache);
-    expect(chars).toBe(12);
+    expect(chars).toBe(6);
   });
 
   it("getToolResultText skips malformed text blocks", () => {
@@ -65,7 +65,7 @@ describe("tool-result-char-estimator", () => {
 
     const cache = createMessageCharEstimateCache();
     const chars = estimateMessageCharsCached(msg, cache);
-    expect(chars).toBe(22);
+    expect(chars).toBe(11);
   });
 
   it("estimates a large bashExecution near its rendered size", () => {

--- a/src/agents/embedded-agent-runner/tool-result-char-estimator.ts
+++ b/src/agents/embedded-agent-runner/tool-result-char-estimator.ts
@@ -11,7 +11,7 @@ import {
 } from "../runtime/index.js";
 
 export const CHARS_PER_TOKEN_ESTIMATE = 4;
-export const TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE = 2;
+export const TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE = 4;
 const IMAGE_CHAR_ESTIMATE = 8_000;
 
 export type MessageCharEstimateCache = WeakMap<AgentMessage, number>;

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
@@ -251,7 +251,7 @@ describe("installToolResultContextGuard", () => {
   it("drops oversized tool-result details when truncating once", async () => {
     const agent = makeGuardableAgent();
     const contextForNextCall = [
-      makeToolResultWithDetails("call_big", "x".repeat(900), "d".repeat(8_000)),
+      makeToolResultWithDetails("call_big", "x".repeat(2_500), "d".repeat(8_000)),
     ];
 
     const transformed = (await applyGuardToContext(agent, contextForNextCall)) as AgentMessage[];
@@ -321,7 +321,7 @@ describe("installToolResultContextGuard", () => {
     const transformed = (await applyGuardToContext(
       agent,
       contextForNextCall,
-      100_000,
+      30_000,
     )) as AgentMessage[];
 
     expectOpenClawTruncation(getToolResultText(transformed[0]));


### PR DESCRIPTION
## Summary

Fixes #101929: `context-overflow-midturn-precheck` over-estimates prompt tokens ~2.3–2.6× on tool-result-heavy turns.

*(Recreated from clean `upstream/main` — previous PR #102092 had a stale fork base with unrelated commits. Apologies for the noise!)*

## Root Cause

The midturn precheck estimator used `TOOL_RESULT_CHARS_PER_TOKEN = 2` for tool-result text — half the `ESTIMATED_CHARS_PER_TOKEN = 4` used for normal text. Combined with the safety margin (1.2×), this caused tool-result text to be estimated at 2.4× its actual token cost, triggering destructive `truncate_tool_results_only` recovery on turns well within the context window.

## Fix

Change `TOOL_RESULT_CHARS_PER_TOKEN` and `TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE` from `2` to `4`, aligning with the normal-text estimate.

## Evidence

### Real behavior proof — arithmetic validation

Reporter's scenario (`toolResultReducibleChars=234607`, budget 200k, reserve 50k):

```
Before (2 chars/token): 234607/2 × 1.2 ≈ 140,764 tokens from tool results
                        Total estimate ≈ 162k vs 63k billed → 2.56× overcount
                        → route: truncate_tool_results_only (false positive)

After  (4 chars/token): 234607/4 × 1.2 ≈  70,382 tokens from tool results
                        Total estimate ≈  92k vs promptBudgetBeforeReserve=150k
                        → route: fits (correct)
```

### Vitest

```
✓ src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts (16 tests)
✓ src/agents/embedded-agent-runner/tool-result-char-estimator.test.ts (10 tests)
✓ src/agents/embedded-agent-runner/tool-result-context-guard.test.ts (40 tests)
✓ src/agents/embedded-agent-runner/tool-result-truncation.test.ts (50 tests)

Test Files  5 passed (5)
     Tests  126 passed (126)
```

## Files changed
- `src/agents/embedded-agent-runner/run/preemptive-compaction.ts`: `TOOL_RESULT_CHARS_PER_TOKEN 2 → 4`
- `src/agents/embedded-agent-runner/tool-result-char-estimator.ts`: `TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE 2 → 4`
- Test files updated for corrected ratio

Closes #101929

🤖 Generated with [Claude Code](https://claude.com/claude-code)