### PR TITLE
docs(signal): document --signal-number, --http-host, --http-port CLI flags

### DIFF
--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -37,7 +37,7 @@ Bare plugin specs try ClawHub first, then npm fallback. Force a source with `ope
     ```bash
     openclaw channels add
     ```
-    The wizard detects whether `signal-cli` is on `PATH` and, when missing, offers to install it: downloads the official native GraalVM build on Linux x86-64, or installs via Homebrew on macOS and other architectures. It then prompts for the bot number and `signal-cli` path.
+    The wizard detects whether `signal-cli` is on `PATH` and, when missing, offers to install it: downloads the official native GraalVM build on Linux x86-64, or installs via Homebrew on macOS and other architectures. It then prompts for the bot number and `signal-cli` path. `openclaw channels add --channel signal` also accepts `--signal-number <e164>` (the bot phone number in E.164 format), `--http-host <host>` (the signal-cli REST daemon host, default `127.0.0.1`), and `--http-port <port>` (the daemon port, default `8080`).
   </Step>
   <Step title="Link or register the account">
     - **QR link (fastest):** `signal-cli link -n "OpenClaw"`, then scan with Signal. See [Path A](#setup-path-a-link-existing-signal-account-qr).

--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -40,6 +40,7 @@ Bare plugin specs try ClawHub first, then npm fallback. Force a source with `ope
     The wizard detects whether `signal-cli` is on `PATH` and, when missing, offers to install it: downloads the official native GraalVM build on Linux x86-64, or installs via Homebrew on macOS and other architectures. It then prompts for the bot number and `signal-cli` path.
 
     For non-interactive setup, `openclaw channels add --channel signal` also accepts `--signal-number <e164>` for the bot phone number, plus `--http-host <host>` and `--http-port <port>` for the Signal daemon endpoint (default `127.0.0.1:8080`).
+
   </Step>
   <Step title="Link or register the account">
     - **QR link (fastest):** `signal-cli link -n "OpenClaw"`, then scan with Signal. See [Path A](#setup-path-a-link-existing-signal-account-qr).

--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -37,7 +37,9 @@ Bare plugin specs try ClawHub first, then npm fallback. Force a source with `ope
     ```bash
     openclaw channels add
     ```
-    The wizard detects whether `signal-cli` is on `PATH` and, when missing, offers to install it: downloads the official native GraalVM build on Linux x86-64, or installs via Homebrew on macOS and other architectures. It then prompts for the bot number and `signal-cli` path. `openclaw channels add --channel signal` also accepts `--signal-number <e164>` (the bot phone number in E.164 format), `--http-host <host>` (the signal-cli REST daemon host, default `127.0.0.1`), and `--http-port <port>` (the daemon port, default `8080`).
+    The wizard detects whether `signal-cli` is on `PATH` and, when missing, offers to install it: downloads the official native GraalVM build on Linux x86-64, or installs via Homebrew on macOS and other architectures. It then prompts for the bot number and `signal-cli` path.
+
+    For non-interactive setup, `openclaw channels add --channel signal` also accepts `--signal-number <e164>` for the bot phone number, plus `--http-host <host>` and `--http-port <port>` for the Signal daemon endpoint (default `127.0.0.1:8080`).
   </Step>
   <Step title="Link or register the account">
     - **QR link (fastest):** `signal-cli link -n "OpenClaw"`, then scan with Signal. See [Path A](#setup-path-a-link-existing-signal-account-qr).


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using `openclaw channels add --channel signal` with CLI flags had no Signal guide explaining what `--signal-number`, `--http-host`, and `--http-port` do.

## Why This Change Was Made

The Signal plugin declares these channel-specific options through `cliAddOptions`, and its setup adapter persists them for non-interactive configuration. The quick-setup guide now names the flags and the established daemon endpoint default without implying that the endpoint is always the container REST API.

## User Impact

Operators can discover the supported non-interactive Signal setup flags and endpoint defaults directly in the Signal guide instead of reading source code.

## Evidence

- `extensions/signal/package.json` declares all three channel-specific flags.
- `extensions/signal/src/setup-core.ts` accepts and persists their inputs.
- `extensions/signal/src/accounts.ts` and `extensions/signal/src/monitor.ts` establish the `127.0.0.1:8080` default.
- `pnpm docs:list`, targeted docs listing, and `git diff --check` pass.
