### PR TITLE
fix(browser): return JSON-RPC errors for malformed CDP client frames in relay bridge

### DIFF
--- a/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
@@ -368,4 +368,59 @@ describe("ExtensionRelayBridge", () => {
     expect(socket.closed).toBe(true);
     expect(bridge.extensionConnected).toBe(false);
   });
+
+  it("responds with JSON-RPC parse error for malformed JSON frames", async () => {
+    const bridge = new ExtensionRelayBridge();
+    const { handlers } = wireExtension(bridge);
+    sendHello(handlers);
+
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+    cdp.onMessage("not valid json {");
+    await flush();
+
+    const frames = client.frames();
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toMatchObject({
+      id: null,
+      error: { code: -32700, message: "Parse error" },
+    });
+  });
+
+  it("responds with JSON-RPC invalid-request error when method is missing", async () => {
+    const bridge = new ExtensionRelayBridge();
+    const { handlers } = wireExtension(bridge);
+    sendHello(handlers);
+
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+    cdp.onMessage(JSON.stringify({ id: 42, params: {} }));
+    await flush();
+
+    const frames = client.frames();
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toMatchObject({
+      id: 42,
+      error: { code: -32600, message: "Invalid request" },
+    });
+  });
+
+  it("preserves sessionId in invalid-request error response", async () => {
+    const bridge = new ExtensionRelayBridge();
+    const { handlers } = wireExtension(bridge);
+    sendHello(handlers);
+
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+    cdp.onMessage(JSON.stringify({ id: 7, sessionId: "session-1" }));
+    await flush();
+
+    const frames = client.frames();
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toMatchObject({
+      id: 7,
+      sessionId: "session-1",
+      error: { code: -32600, message: "Invalid request" },
+    });
+  });
 });

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -74,7 +74,7 @@ type ExtensionIdentity = {
   extensionVersion: string;
 };
 
-function toErrorPayload(id: number, sessionId: string | undefined, message: string, code = -32000) {
+function toErrorPayload(id: number | null, sessionId: string | undefined, message: string, code = -32000) {
   return JSON.stringify({ id, ...(sessionId ? { sessionId } : {}), error: { code, message } });
 }
 
@@ -498,9 +498,13 @@ export class ExtensionRelayBridge {
       try {
         request = JSON.parse(raw) as CdpRequest;
       } catch {
+        client.socket.send(toErrorPayload(null, undefined, "Parse error", -32700));
         return;
       }
       if (typeof request?.id !== "number" || typeof request?.method !== "string") {
+        const id = typeof request?.id === "number" ? request.id : null;
+        const sessionId = typeof request?.sessionId === "string" ? request.sessionId : undefined;
+        client.socket.send(toErrorPayload(id, sessionId, "Invalid request", -32600));
         return;
       }
       void this.handleCdpRequest(client, request);

--- a/scripts/proofs/cdp-relay-malformed-frame-proof.ts
+++ b/scripts/proofs/cdp-relay-malformed-frame-proof.ts
@@ -1,0 +1,207 @@
+/**
+ * Real behavior proof: browser relay returns JSON-RPC errors for malformed
+ * CDP client frames.
+ *
+ * Starts a loopback relay server, connects a real ws CDP client, sends
+ * malformed frames, and records responses with wall-clock timing.
+ *
+ * Usage: npx tsx scripts/proofs/cdp-relay-malformed-frame-proof.ts
+ */
+import http from "node:http";
+import { WebSocketServer, WebSocket } from "ws";
+import {
+  ExtensionRelayBridge,
+  type BridgeSocket,
+} from "../../extensions/browser/src/browser/extension-relay/relay-bridge.js";
+
+const HOST = "127.0.0.1";
+
+function toBridgeSocket(ws: WebSocket): BridgeSocket {
+  return {
+    send: (data: string) => {
+      if (ws.readyState === ws.OPEN) ws.send(data);
+    },
+    close: (code?: number, reason?: string) => {
+      try {
+        ws.close(code, reason);
+      } catch {
+        /* closing */
+      }
+    },
+  };
+}
+
+function bindSocket(
+  ws: WebSocket,
+  handlers: { onMessage: (raw: string) => void; onClose: () => void },
+): void {
+  ws.on("message", (data) => {
+    const raw =
+      typeof data === "string"
+        ? data
+        : Buffer.from(data as ArrayBuffer).toString("utf8");
+    handlers.onMessage(raw);
+  });
+  ws.on("close", handlers.onClose);
+}
+
+async function sendAndWait(
+  ws: WebSocket,
+  frame: string,
+  label: string,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`${label}: timeout after 2s`)),
+      2000,
+    );
+    ws.once("message", (data) => {
+      clearTimeout(timer);
+      resolve(
+        typeof data === "string"
+          ? data
+          : Buffer.from(data as ArrayBuffer).toString("utf8"),
+      );
+    });
+    ws.send(frame);
+  });
+}
+
+async function main() {
+  const bridge = new ExtensionRelayBridge();
+
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200).end("ok");
+  });
+
+  const wss = new WebSocketServer({ noServer: true });
+
+  server.on("upgrade", (req, socket, head) => {
+    const path = (req.url ?? "/").split("?")[0];
+    if (path === "/cdp") {
+      wss.handleUpgrade(req, socket, head, (ws) => {
+        bindSocket(ws, bridge.attachCdpClientSocket(toBridgeSocket(ws)));
+      });
+      return;
+    }
+    socket.write("HTTP/1.1 404 Not Found\r\n\r\n");
+    socket.destroy();
+  });
+
+  await new Promise<void>((resolve) =>
+    server.listen(0, HOST, () => resolve()),
+  );
+  const addr = server.address() as { port: number };
+  const cdpUrl = `ws://${HOST}:${addr.port}/cdp`;
+
+  console.log(`relay server listening on ${cdpUrl}`);
+  console.log(`Node ${process.version}, ${process.platform} ${process.arch}`);
+
+  // --- Proof 1: malformed JSON → parse error -32700 ---
+  {
+    const ws = new WebSocket(cdpUrl);
+    await new Promise<void>((resolve) => ws.once("open", () => resolve()));
+
+    const start = performance.now();
+    const response = await sendAndWait(ws, "not valid json {", "malformed JSON");
+    const elapsed = Math.round(performance.now() - start);
+
+    const parsed = JSON.parse(response);
+    console.log(`\n=== Malformed JSON (parse error -32700) ===`);
+    console.log(`Sent:     not valid json {`);
+    console.log(`Received: ${response}`);
+    console.log(`Elapsed:  ${elapsed}ms`);
+    console.assert(
+      parsed.id === null,
+      "FAIL: id must be null for parse error",
+    );
+    console.assert(
+      parsed.error?.code === -32700,
+      "FAIL: error code must be -32700",
+    );
+    console.assert(
+      parsed.error?.message === "Parse error",
+      "FAIL: error message mismatch",
+    );
+    console.log("PASS: parse error response correct");
+
+    ws.close();
+  }
+
+  // --- Proof 2: invalid request (missing method) → -32600 ---
+  {
+    const ws = new WebSocket(cdpUrl);
+    await new Promise<void>((resolve) => ws.once("open", () => resolve()));
+
+    const start = performance.now();
+    const response = await sendAndWait(
+      ws,
+      JSON.stringify({ id: 42, params: {} }),
+      "invalid request",
+    );
+    const elapsed = Math.round(performance.now() - start);
+
+    const parsed = JSON.parse(response);
+    console.log(`\n=== Invalid Request (missing method, -32600) ===`);
+    console.log(`Sent:     {"id":42,"params":{}}`);
+    console.log(`Received: ${response}`);
+    console.log(`Elapsed:  ${elapsed}ms`);
+    console.assert(parsed.id === 42, "FAIL: id must be preserved");
+    console.assert(
+      parsed.error?.code === -32600,
+      "FAIL: error code must be -32600",
+    );
+    console.assert(
+      parsed.error?.message === "Invalid request",
+      "FAIL: error message mismatch",
+    );
+    console.log("PASS: invalid request error response correct");
+
+    ws.close();
+  }
+
+  // --- Proof 3: invalid request with sessionId preserved ---
+  {
+    const ws = new WebSocket(cdpUrl);
+    await new Promise<void>((resolve) => ws.once("open", () => resolve()));
+
+    const start = performance.now();
+    const response = await sendAndWait(
+      ws,
+      JSON.stringify({ id: 7, sessionId: "session-1" }),
+      "invalid request with sessionId",
+    );
+    const elapsed = Math.round(performance.now() - start);
+
+    const parsed = JSON.parse(response);
+    console.log(`\n=== Invalid Request with sessionId (-32600) ===`);
+    console.log(`Sent:     {"id":7,"sessionId":"session-1"}`);
+    console.log(`Received: ${response}`);
+    console.log(`Elapsed:  ${elapsed}ms`);
+    console.assert(parsed.id === 7, "FAIL: id must be preserved");
+    console.assert(
+      parsed.sessionId === "session-1",
+      "FAIL: sessionId must be preserved for correct session routing",
+    );
+    console.assert(
+      parsed.error?.code === -32600,
+      "FAIL: error code must be -32600",
+    );
+    console.log("PASS: sessionId preserved in error response");
+
+    ws.close();
+  }
+
+  console.log(`\n✓ All assertions passed. Real behavior proof complete.`);
+  console.log(
+    `✓ Neither malformed JSON nor invalid request frames cause silent timeouts.`,
+  );
+
+  server.close();
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(`FAIL: ${String(err)}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes #102057 — the browser extension relay bridge silently drops malformed CDP client frames, leaving clients (e.g. Playwright `connectOverCDP`) waiting until their own timeout instead of receiving a timely protocol error.

## Why This Change Was Made

`attachCdpClientSocket.onMessage` had two silent return paths:
1. `JSON.parse` failure → no response sent
2. Missing `id` (number) or `method` (string) → no response sent

This change returns proper JSON-RPC 2.0 error responses at both boundaries:
- Parse error (`-32700`): `{id: null, error: {code: -32700, message: "Parse error"}}`
- Invalid request (`-32600`): preserves original `id` and `sessionId` for correct session routing

## User Impact

CDP automation clients now receive immediate protocol errors for malformed frames instead of hanging until their own timeout.

## Evidence

- 13 tests pass (10 existing + 3 new regression tests for malformed JSON, missing method, and sessionId preservation)
- `toErrorPayload` signature widened from `id: number` to `id: number | null` to support parse error semantics
- `sessionId` is correctly preserved in invalid-request error responses (unlike competing PR #102071 which omits it)

Co-Authored-By: Claude <noreply@anthropic.com>