### PR TITLE
fix(cron): mirror runner env proxy in model preflight

### DIFF
--- a/src/cron/isolated-agent/model-preflight.runtime.test.ts
+++ b/src/cron/isolated-agent/model-preflight.runtime.test.ts
@@ -1,12 +1,26 @@
 // Runtime model preflight tests cover provider/model checks before cron execution.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
+const {
+  fetchWithSsrFGuardMock,
+  shouldUseEnvHttpProxyForUrlMock,
+  withTrustedEnvProxyGuardedFetchModeMock,
+} = vi.hoisted(() => ({
   fetchWithSsrFGuardMock: vi.fn(),
+  shouldUseEnvHttpProxyForUrlMock: vi.fn(() => false),
+  withTrustedEnvProxyGuardedFetchModeMock: vi.fn((params: Record<string, unknown>) => ({
+    ...params,
+    mode: "trusted_env_proxy",
+  })),
 }));
 
 vi.mock("../../infra/net/fetch-guard.js", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+  withTrustedEnvProxyGuardedFetchMode: withTrustedEnvProxyGuardedFetchModeMock,
+}));
+
+vi.mock("../../infra/net/proxy-env.js", () => ({
+  shouldUseEnvHttpProxyForUrl: shouldUseEnvHttpProxyForUrlMock,
 }));
 
 import {
@@ -25,9 +39,10 @@ function requireFetchPreflightRequest(): {
   url?: string;
   timeoutMs?: number;
   auditContext?: string;
+  mode?: string;
 } {
   const request = fetchWithSsrFGuardMock.mock.calls[0]?.[0] as
-    | { url?: string; timeoutMs?: number; auditContext?: string }
+    | { url?: string; timeoutMs?: number; auditContext?: string; mode?: string }
     | undefined;
   if (!request) {
     throw new Error("Expected cron model preflight fetch request");
@@ -38,6 +53,9 @@ function requireFetchPreflightRequest(): {
 describe("preflightCronModelProvider", () => {
   beforeEach(() => {
     fetchWithSsrFGuardMock.mockReset();
+    shouldUseEnvHttpProxyForUrlMock.mockReset();
+    shouldUseEnvHttpProxyForUrlMock.mockReturnValue(false);
+    withTrustedEnvProxyGuardedFetchModeMock.mockClear();
     resetCronModelProviderPreflightCacheForTest();
   });
 
@@ -170,5 +188,60 @@ describe("preflightCronModelProvider", () => {
     expect(first.status).toBe("unavailable");
     expect(second).toEqual({ status: "available" });
     expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses trusted-env-proxy mode when the env proxy applies, mirroring the runner", async () => {
+    // Proxy-routed local vhosts (e.g. `inference.local`) need the env proxy;
+    // STRICT pinning would EAI_AGAIN. The runner uses env proxy, so the
+    // preflight must mirror it or it false-negatives and skips every run.
+    shouldUseEnvHttpProxyForUrlMock.mockReturnValue(true);
+    mockReachableResponse(200);
+
+    const result = await preflightCronModelProvider({
+      cfg: {
+        models: {
+          providers: {
+            openshell: {
+              api: "openai-completions",
+              baseUrl: "http://inference.local/v1",
+              models: [],
+            },
+          },
+        },
+      },
+      provider: "openshell",
+      model: "qwen3",
+    });
+
+    expect(result).toEqual({ status: "available" });
+    expect(withTrustedEnvProxyGuardedFetchModeMock).toHaveBeenCalledTimes(1);
+    const request = requireFetchPreflightRequest();
+    expect(request.url).toBe("http://inference.local/v1/models");
+    expect(request.mode).toBe("trusted_env_proxy");
+  });
+
+  it("keeps strict mode when the env proxy does not apply", async () => {
+    mockReachableResponse(200);
+
+    const result = await preflightCronModelProvider({
+      cfg: {
+        models: {
+          providers: {
+            vllm: {
+              api: "openai-completions",
+              baseUrl: "http://127.0.0.1:8000/v1",
+              models: [],
+            },
+          },
+        },
+      },
+      provider: "vllm",
+      model: "llama",
+    });
+
+    expect(result).toEqual({ status: "available" });
+    expect(withTrustedEnvProxyGuardedFetchModeMock).not.toHaveBeenCalled();
+    const request = requireFetchPreflightRequest();
+    expect(request.mode).toBeUndefined();
   });
 });

--- a/src/cron/isolated-agent/model-preflight.runtime.ts
+++ b/src/cron/isolated-agent/model-preflight.runtime.ts
@@ -3,7 +3,11 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { ModelProviderConfig } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { fetchWithSsrFGuard } from "../../infra/net/fetch-guard.js";
+import {
+  fetchWithSsrFGuard,
+  withTrustedEnvProxyGuardedFetchMode,
+} from "../../infra/net/fetch-guard.js";
+import { shouldUseEnvHttpProxyForUrl } from "../../infra/net/proxy-env.js";
 import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 
 const PREFLIGHT_CACHE_TTL_MS = 5 * 60_000;
@@ -161,13 +165,23 @@ async function probeLocalProviderEndpoint(params: {
   api: PreflightApi;
   baseUrl: string;
 }): Promise<void> {
-  const { response, release } = await fetchWithSsrFGuard({
-    url: buildProbeUrl(params.api, params.baseUrl),
+  // Mirror the model runner's proxy selection (provider-transport-fetch) so
+  // the preflight predicts the same reachability. Env proxy resolves
+  // proxy-routed local vhosts (e.g. `inference.local`) that STRICT DNS pinning
+  // cannot; without it the preflight false-negatives and skips every run.
+  // The hostname allowlist + allowPrivateNetwork policy still apply.
+  const url = buildProbeUrl(params.api, params.baseUrl);
+  const useEnvProxy = shouldUseEnvHttpProxyForUrl(url);
+  const baseOptions = {
+    url,
     init: { method: "GET" },
     policy: buildLocalProviderSsrFPolicy(params.baseUrl),
     timeoutMs: PREFLIGHT_TIMEOUT_MS,
     auditContext: "cron-model-provider-preflight",
-  });
+  };
+  const { response, release } = await fetchWithSsrFGuard(
+    useEnvProxy ? withTrustedEnvProxyGuardedFetchMode(baseOptions) : baseOptions,
+  );
   try {
     // Any HTTP response means the local endpoint is alive. Auth/model errors
     // still belong to the normal model runner where fallback and diagnostics


### PR DESCRIPTION
https://github.com/NVIDIA/NemoClaw/pull/5129 worked around this by patching OpenClaw's built dist in its Dockerfile. This PR fixes it at the source in OpenClaw directly.

## What Problem This Solves

Fixes an issue where cron jobs against a **local model provider** that is only
reachable through the configured env HTTP proxy would see **every scheduled run
silently skipped**.

The cron model preflight probes the local provider endpoint before the runner
starts. It probed with strict DNS pinning, but the actual model runner
(`provider-transport-fetch`) reaches that same endpoint through the env HTTP
proxy. For proxy-routed local vhosts (e.g. `http://inference.local/v1`), strict
DNS pinning cannot resolve the hostname (it fails with `EAI_AGAIN`), so the
preflight reports the endpoint as unavailable and skips the run.

## Why This Change Was Made

The preflight now mirrors the runner's proxy selection so it predicts the same
reachability the runner will actually get.

The SSRF guard is unchanged: the probe still uses the configured provider's
exact hostname allowlist plus `allowPrivateNetwork`, so the trusted-env-proxy
upgrade only changes how the hostname is resolved, not which hosts are
permitted.

## User Impact

Operators with cron jobs pointed at a local model provider reachable only via an
env HTTP proxy (e.g. a proxy-routed `inference.local` vhost) no longer have
every scheduled run skipped by a false-negative preflight. The preflight now
reports the endpoint as reachable, so cron runs proceed to the model runner like
any other provider. Hosts that do not need the env proxy are unaffected.

## Evidence

Real behavior proof through a local env HTTP proxy. A real local HTTP forward
proxy (CONNECT-tunnel, like a real corporate/sandbox proxy) routes the
non-DNS-resolvable vhost `inference.local` to a real local OpenAI-compatible
provider (llama.cpp at `127.0.0.1:8084`). Real `HTTP_PROXY` env is set, and the
real `preflightCronModelProvider` is called with no mocks of
`shouldUseEnvHttpProxyForUrl`. Same setup run on both branches.

Nothing to redact: `inference.local` is a synthetic non-resolvable vhost,
`127.0.0.1:8084` is a local llama.cpp server, and the `/v1/models` GET carries
no credentials (the preflight ignores auth).

### Before (origin/main, 6418e196b1)

```json
13:00:36 [fetch-timeout] fetch timeout after 2500ms (elapsed 2502ms) operation=fetchWithSsrFGuard url=http://inference.local/v1/models
{
  "gitHead": "6418e196b1",
  "provider": "my-provider",
  "model": "unsloth/Qwen-AgentWorld-35B-A3B-GGUF:IQ3_XXS",
  "baseUrl": "http://inference.local/v1",
  "upstream": "127.0.0.1:8084",
  "shouldUseEnvHttpProxyForUrl": true,
  "httpProxy": "http://127.0.0.1:43731",
  "elapsedMs": 5006,
  "preflightResult": {
    "status": "unavailable",
    "provider": "my-provider",
    "model": "unsloth/Qwen-AgentWorld-35B-A3B-GGUF:IQ3_XXS",
    "baseUrl": "http://inference.local/v1",
    "retryAfterMs": 300000,
    "reason": "Agent cron job uses my-provider/unsloth/Qwen-AgentWorld-35B-A3B-GGUF:IQ3_XXS but the local provider endpoint is not reachable at http://inference.local/v1. Skipping this cron run; OpenClaw will retry the provider preflight on a later scheduled run. Last error: Error: getaddrinfo ENOTFOUND inference.local"
  }
}
```

`shouldUseEnvHttpProxyForUrl` is true, but `main` probes with STRICT pinned DNS,
so it cannot resolve `inference.local` (ENOTFOUND) and returns unavailable. The
skip is cached for 5 minutes, so every scheduled run is skipped.

### After (tbc/fix-cron, 76e78cd5ae)

```json
{
  "gitHead": "76e78cd5ae",
  "provider": "my-provider",
  "model": "unsloth/Qwen-AgentWorld-35B-A3B-GGUF:IQ3_XXS",
  "baseUrl": "http://inference.local/v1",
  "upstream": "127.0.0.1:8084",
  "shouldUseEnvHttpProxyForUrl": true,
  "httpProxy": "http://127.0.0.1:40913",
  "elapsedMs": 65,
  "preflightResult": {
    "status": "available"
  }
}
```

Same proxy env, but the preflight now mirrors the runner's
`withTrustedEnvProxyGuardedFetchMode`, so it reaches the real provider through
the proxy in 68ms and returns available. The cron run proceeds like any other
provider.

