### PR TITLE
fix(qqbot): render safe exec approval previews

### DIFF
--- a/extensions/qqbot/src/bridge/approval/handler-runtime.test.ts
+++ b/extensions/qqbot/src/bridge/approval/handler-runtime.test.ts
@@ -1,0 +1,144 @@
+// Qqbot tests cover native approval presentation behavior.
+import type {
+  ExecApprovalPendingView,
+  PluginApprovalPendingView,
+} from "openclaw/plugin-sdk/approval-handler-runtime";
+import { resolveExecApprovalCommandDisplay } from "openclaw/plugin-sdk/approval-runtime";
+import { describe, expect, it } from "vitest";
+import type { InlineKeyboard } from "../../engine/types.js";
+import { qqbotApprovalNativeRuntime } from "./handler-runtime.js";
+
+type QQBotPendingPayload = {
+  text: string;
+  keyboard: InlineKeyboard;
+};
+
+function createExecView(commandText: string): ExecApprovalPendingView {
+  return {
+    approvalId: "approval-1",
+    approvalKind: "exec",
+    phase: "pending",
+    title: "Exec Approval Required",
+    metadata: [],
+    commandText,
+    commandPreview: "short preview",
+    actions: [
+      {
+        decision: "allow-once",
+        label: "Allow Once",
+        command: "/approve approval-1 allow-once",
+        style: "success",
+      },
+      {
+        decision: "deny",
+        label: "Deny",
+        command: "/approve approval-1 deny",
+        style: "danger",
+      },
+    ],
+    expiresAtMs: Date.now() + 60_000,
+  };
+}
+
+function createPluginView(expiresAtMs: number): PluginApprovalPendingView {
+  return {
+    approvalId: "plugin:approval-1",
+    approvalKind: "plugin",
+    phase: "pending",
+    title: "Install plugin",
+    description: "Approve the requested plugin",
+    metadata: [],
+    pluginId: "example-plugin",
+    toolName: "plugin.install",
+    agentId: "main",
+    severity: "critical",
+    actions: [
+      {
+        decision: "allow-once",
+        label: "Allow Once",
+        command: "/approve plugin:approval-1 allow-once",
+        style: "success",
+      },
+      {
+        decision: "deny",
+        label: "Deny",
+        command: "/approve plugin:approval-1 deny",
+        style: "danger",
+      },
+    ],
+    expiresAtMs,
+  };
+}
+
+describe("qqbotApprovalNativeRuntime", () => {
+  it("renders the sanitized primary command with callback buttons", async () => {
+    const secret = `ghp_${"a".repeat(36)}`;
+    const rawCommand = `printf '${secret}\u200b'\n你好😀`;
+    const commandText = resolveExecApprovalCommandDisplay({ command: rawCommand }).commandText;
+    const view = createExecView(commandText);
+    view.cwd = "/tmp\n![fake](u)";
+    view.agentId = "agent```fake";
+    const payload = (await qqbotApprovalNativeRuntime.presentation.buildPendingPayload({
+      cfg: {} as never,
+      accountId: "default",
+      context: {},
+      request: {
+        id: "approval-1",
+        request: { command: rawCommand, commandPreview: "short preview" },
+        createdAtMs: Date.now(),
+        expiresAtMs: view.expiresAtMs,
+      },
+      approvalKind: "exec",
+      nowMs: Date.now(),
+      view,
+    })) as QQBotPendingPayload;
+
+    expect(commandText).not.toContain(secret);
+    expect(commandText).toContain("\\u{200B}");
+    expect(commandText).toContain("\\u{A}");
+    expect(commandText).toContain("你好😀");
+    expect(payload.text.replace(/[↩\n]/g, "")).toContain(commandText);
+    expect(payload.text).not.toContain(secret);
+    expect(payload.text).not.toContain("short preview");
+    expect(payload.text).not.toContain("/tmp\n![fake]");
+    expect(payload.text).toContain("📁 目录:\n```\n/tmp\\u{A}![fake](u)\n```");
+    expect(payload.text).toContain("🤖 Agent:\n````\nagent```fake\n````");
+    expect(payload.keyboard.content.rows[0]?.buttons.map((button) => button.action.data)).toEqual([
+      "approve:approval-1:allow-once",
+      "approve:approval-1:deny",
+    ]);
+  });
+
+  it("renders a plugin approval's actual remaining lifetime", async () => {
+    const nowMs = 1_000_000;
+    const view = createPluginView(nowMs + 600_000);
+    const payload = (await qqbotApprovalNativeRuntime.presentation.buildPendingPayload({
+      cfg: {} as never,
+      accountId: "default",
+      context: {},
+      request: {
+        id: view.approvalId,
+        request: {
+          title: "stale raw title",
+          description: "stale raw description",
+          severity: "info",
+        },
+        createdAtMs: nowMs,
+        expiresAtMs: view.expiresAtMs,
+      },
+      approvalKind: "plugin",
+      nowMs,
+      view,
+    })) as QQBotPendingPayload;
+
+    expect(payload.text).toContain("🔴 审批请求");
+    expect(payload.text).toContain("📋 Install plugin");
+    expect(payload.text).toContain("📝 Approve the requested plugin");
+    expect(payload.text).not.toContain("stale raw");
+    expect(payload.text).toContain("⏱️ 超时: 600 秒");
+    expect(payload.keyboard.content.rows[0]?.buttons.map((button) => button.action.data)).toEqual([
+      "approve:plugin:approval-1:allow-once",
+      "approve:plugin:approval-1:deny",
+    ]);
+  });
+});

--- a/extensions/qqbot/src/bridge/approval/handler-runtime.ts
+++ b/extensions/qqbot/src/bridge/approval/handler-runtime.ts
@@ -46,10 +46,6 @@ type QQBotPendingPayload = {
   keyboard: InlineKeyboard;
 };
 
-function isExecRequest(request: ApprovalRequest): request is ExecApprovalRequest {
-  return "expiresAtMs" in request;
-}
-
 function resolveQQTarget(request: ApprovalRequest): { type: ChatScope; id: string } | null {
   const sessionConversation = resolveApprovalRequestSessionConversation({
     request: request as never,
@@ -129,17 +125,17 @@ const qqbotApprovalRuntimeSpec: ChannelApprovalNativeRuntimeSpec<
   },
 
   presentation: {
-    buildPendingPayload: ({ request, view }) => {
-      const req = request as ApprovalRequest;
-      const text = isExecRequest(req) ? buildExecApprovalText(req) : buildPluginApprovalText(req);
+    buildPendingPayload: ({ view, nowMs }) => {
+      const text =
+        view.approvalKind === "exec"
+          ? buildExecApprovalText(view, nowMs)
+          : buildPluginApprovalText(view, nowMs);
       const keyboard = buildApprovalKeyboard(
-        req.id,
+        view.approvalId,
         view.actions.map((action) => action.decision),
       );
       getBridgeLogger().debug?.(
-        `[qqbot:approval-runtime] buildPendingPayload requestId=${req.id} kind=${
-          isExecRequest(req) ? "exec" : "plugin"
-        }`,
+        `[qqbot:approval-runtime] buildPendingPayload requestId=${view.approvalId} kind=${view.approvalKind}`,
       );
       return { text, keyboard };
     },

--- a/extensions/qqbot/src/engine/approval/index.test.ts
+++ b/extensions/qqbot/src/engine/approval/index.test.ts
@@ -1,6 +1,28 @@
 // Qqbot tests cover index plugin behavior.
+import type { ExecApprovalPendingView } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { describe, expect, it } from "vitest";
 import { buildApprovalKeyboard, buildExecApprovalText } from "./index.js";
+
+function createExecView(commandText: string): ExecApprovalPendingView {
+  return {
+    approvalId: "approval-1",
+    approvalKind: "exec",
+    phase: "pending",
+    title: "Exec Approval Required",
+    metadata: [],
+    commandText,
+    actions: [],
+    expiresAtMs: Date.now() + 60_000,
+  };
+}
+
+function readCommandBlock(text: string): { body: string; fence: string } {
+  const match = text.match(/(?:^|\n)(`{3,})\n([\s\S]*?)\n\1(?:\n|$)/);
+  if (!match?.[1] || match[2] === undefined) {
+    throw new Error("Expected fenced command preview");
+  }
+  return { fence: match[1], body: match[2] };
+}
 
 describe("buildApprovalKeyboard", () => {
   it("omits allow-always when the decision is unavailable", () => {
@@ -23,16 +45,65 @@ describe("buildApprovalKeyboard", () => {
 });
 
 describe("buildExecApprovalText", () => {
-  it("truncates the command preview on a UTF-16 boundary without splitting surrogate pairs", () => {
+  it("keeps a truncated command UTF-16 well formed", () => {
     const safePrefix = "x".repeat(299);
-    const text = buildExecApprovalText({
-      id: "approval-1",
-      expiresAtMs: Date.now() + 60_000,
-      request: {
-        commandPreview: `${safePrefix}🎉 trailing text`,
-      },
-    });
-    const expectedCommandBlock = ["```", safePrefix, "```"].join("\n");
-    expect(text).toContain(expectedCommandBlock);
+    const text = buildExecApprovalText(createExecView(`${safePrefix}🎉 trailing text`));
+    const { body } = readCommandBlock(text);
+
+    expect(body.replace(/[↩\n]/g, "")).toBe(`${safePrefix}…[truncated]`);
+    expect(body).not.toContain("🎉");
+  });
+
+  it("wraps ASCII and double-width text after 24 graphemes", () => {
+    const ascii = readCommandBlock(buildExecApprovalText(createExecView("x".repeat(25))));
+    const wide = readCommandBlock(
+      buildExecApprovalText(createExecView(`${"表".repeat(24)}😀`)),
+    );
+
+    expect(ascii.body).toBe(`${"x".repeat(24)}↩\nx`);
+    expect(wide.body).toBe(`${"表".repeat(24)}↩\n😀`);
+  });
+
+  it("keeps an extended emoji grapheme intact at the 300-unit cap", () => {
+    const family = "👨‍👩‍👧‍👦";
+    const command = `${"x".repeat(289)}${family}`;
+    const { body } = readCommandBlock(buildExecApprovalText(createExecView(command)));
+
+    expect(body.replace(/[↩\n]/g, "")).toBe(command);
+  });
+
+  it("shows a truncation marker when the first grapheme exceeds the cap", () => {
+    const oversizedGrapheme = `x${"\u0301".repeat(300)}`;
+    const { body } = readCommandBlock(
+      buildExecApprovalText(createExecView(`${oversizedGrapheme}; echo hidden`)),
+    );
+
+    expect(body.replace(/[↩\n]/g, "")).toBe(
+      `${oversizedGrapheme.slice(0, 300)}…[truncated]`,
+    );
+  });
+
+  it("marks a display wrap before a shell comment boundary", () => {
+    const command = `${"x".repeat(22)} \\# harmless ; echo dangerous`;
+    const text = buildExecApprovalText(createExecView(command));
+    const { body } = readCommandBlock(text);
+
+    expect(text).toContain("↩ = display wrap only; not command text");
+    expect(body).toContain(" \\↩\n# harmless ; echo danger↩\nous");
+    expect(body.replace(/[↩\n]/g, "")).toBe(command);
+  });
+
+  it("uses a longer fence when the command contains triple backticks", () => {
+    const command = "echo ```danger```";
+    const { body, fence } = readCommandBlock(buildExecApprovalText(createExecView(command)));
+
+    expect(fence).toBe("````");
+    expect(body).toBe(command);
+  });
+
+  it("reserves the display-wrap marker", () => {
+    const { body } = readCommandBlock(buildExecApprovalText(createExecView("echo ↩")));
+
+    expect(body).toBe("echo \\u{21A9}");
   });
 });

--- a/extensions/qqbot/src/engine/approval/index.ts
+++ b/extensions/qqbot/src/engine/approval/index.ts
@@ -6,6 +6,11 @@
  * - Parse INTERACTION_CREATE button data
  */
 
+import type {
+  ExecApprovalPendingView,
+  PluginApprovalPendingView,
+} from "openclaw/plugin-sdk/approval-handler-runtime";
+import { resolveExecApprovalCommandDisplay } from "openclaw/plugin-sdk/approval-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { ChatScope, InlineKeyboard, KeyboardButton } from "../types.js";
 
@@ -29,7 +34,6 @@ export interface ExecApprovalRequest {
 export interface PluginApprovalRequest {
   id: string;
   request: {
-    timeoutMs?: number;
     severity?: string;
     title: string;
     description?: string;
@@ -57,47 +61,110 @@ interface ParsedApprovalAction {
 
 // ============ Text Builders ============
 
-export function buildExecApprovalText(request: ExecApprovalRequest): string {
-  const expiresIn = Math.max(0, Math.round((request.expiresAtMs - Date.now()) / 1000));
+const COMMAND_PREVIEW_MAX_LENGTH = 300;
+const COMMAND_PREVIEW_GRAPHEMES_PER_LINE = 24;
+const COMMAND_PREVIEW_WRAP_MARKER = "↩";
+const commandPreviewSegmenter =
+  typeof Intl !== "undefined" && "Segmenter" in Intl
+    ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
+    : null;
+
+function splitCommandPreviewGraphemes(commandText: string): string[] {
+  return commandPreviewSegmenter
+    ? Array.from(commandPreviewSegmenter.segment(commandText), ({ segment }) => segment)
+    : Array.from(commandText);
+}
+
+function formatCommandPreview(commandText: string): string {
+  // QQ Desktop does not wrap fenced blocks. The sanitized view has already escaped real command
+  // newlines, so these grapheme-safe line breaks are presentation-only and unambiguous. Limiting
+  // each line to 24 graphemes also bounds common double-width text to roughly 48 columns.
+  const lines = [""];
+  const displayText = commandText.replaceAll(COMMAND_PREVIEW_WRAP_MARKER, "\\u{21A9}");
+  let previewLength = 0;
+  let lineGraphemes = 0;
+  let truncated = false;
+  let wrapped = false;
+  for (const grapheme of splitCommandPreviewGraphemes(displayText)) {
+    if (previewLength + grapheme.length > COMMAND_PREVIEW_MAX_LENGTH) {
+      // A pathological first grapheme cannot fit intact; keep a visible UTF-16-safe prefix instead
+      // of presenting an empty command with active approval buttons.
+      if (previewLength === 0) {
+        lines[0] = truncateUtf16Safe(grapheme, COMMAND_PREVIEW_MAX_LENGTH);
+      }
+      truncated = true;
+      break;
+    }
+    previewLength += grapheme.length;
+    if (lineGraphemes === COMMAND_PREVIEW_GRAPHEMES_PER_LINE) {
+      lines[lines.length - 1] += COMMAND_PREVIEW_WRAP_MARKER;
+      lines.push("");
+      lineGraphemes = 0;
+      wrapped = true;
+    }
+    lines[lines.length - 1] += grapheme;
+    lineGraphemes += 1;
+  }
+  const preview = `${lines.join("\n")}${truncated ? "\n…[truncated]" : ""}`;
+  const longestBacktickRun = Math.max(0, ...(preview.match(/`+/g)?.map((run) => run.length) ?? []));
+  const fence = "`".repeat(Math.max(3, longestBacktickRun + 1));
+  const block = `${fence}\n${preview}\n${fence}`;
+  return wrapped
+    ? `${COMMAND_PREVIEW_WRAP_MARKER} = display wrap only; not command text\n${block}`
+    : block;
+}
+
+function formatApprovalMetadata(value: string): string {
+  const sanitized = resolveExecApprovalCommandDisplay({ command: value }).commandText;
+  return formatCommandPreview(sanitized);
+}
+
+export function buildExecApprovalText(
+  view: ExecApprovalPendingView,
+  nowMs = Date.now(),
+): string {
+  const expiresIn = Math.max(0, Math.round((view.expiresAtMs - nowMs) / 1000));
   const lines: string[] = ["\u{1f510} \u547d\u4ee4\u6267\u884c\u5ba1\u6279", ""];
-  const cmd = request.request.commandPreview ?? request.request.command ?? "";
-  if (cmd) {
-    lines.push(`\`\`\`\n${truncateUtf16Safe(cmd, 300)}\n\`\`\``);
+  if (view.commandText) {
+    lines.push(formatCommandPreview(view.commandText));
   }
-  if (request.request.cwd) {
-    lines.push(`\u{1f4c1} \u76ee\u5f55: ${request.request.cwd}`);
+  if (view.cwd) {
+    lines.push(`\u{1f4c1} \u76ee\u5f55:\n${formatApprovalMetadata(view.cwd)}`);
   }
-  if (request.request.agentId) {
-    lines.push(`\u{1f916} Agent: ${request.request.agentId}`);
+  if (view.agentId) {
+    lines.push(`\u{1f916} Agent:\n${formatApprovalMetadata(view.agentId)}`);
   }
   lines.push("", `\u23f1\ufe0f \u8d85\u65f6: ${expiresIn} \u79d2`);
   return lines.join("\n");
 }
 
-export function buildPluginApprovalText(request: PluginApprovalRequest): string {
-  const timeoutSec = Math.round((request.request.timeoutMs ?? 120_000) / 1000);
+export function buildPluginApprovalText(
+  view: PluginApprovalPendingView,
+  nowMs = Date.now(),
+): string {
+  const expiresIn = Math.max(0, Math.round((view.expiresAtMs - nowMs) / 1000));
   const severityIcon =
-    request.request.severity === "critical"
+    view.severity === "critical"
       ? "\u{1f534}"
-      : request.request.severity === "info"
+      : view.severity === "info"
         ? "\u{1f535}"
         : "\u{1f7e1}";
 
   const lines: string[] = [`${severityIcon} \u5ba1\u6279\u8bf7\u6c42`, ""];
-  lines.push(`\u{1f4cb} ${request.request.title}`);
-  if (request.request.description) {
-    lines.push(`\u{1f4dd} ${request.request.description}`);
+  lines.push(`\u{1f4cb} ${view.title}`);
+  if (view.description) {
+    lines.push(`\u{1f4dd} ${view.description}`);
   }
-  if (request.request.toolName) {
-    lines.push(`\u{1f527} \u5de5\u5177: ${request.request.toolName}`);
+  if (view.toolName) {
+    lines.push(`\u{1f527} \u5de5\u5177: ${view.toolName}`);
   }
-  if (request.request.pluginId) {
-    lines.push(`\u{1f50c} \u63d2\u4ef6: ${request.request.pluginId}`);
+  if (view.pluginId) {
+    lines.push(`\u{1f50c} \u63d2\u4ef6: ${view.pluginId}`);
   }
-  if (request.request.agentId) {
-    lines.push(`\u{1f916} Agent: ${request.request.agentId}`);
+  if (view.agentId) {
+    lines.push(`\u{1f916} Agent: ${view.agentId}`);
   }
-  lines.push("", `\u23f1\ufe0f \u8d85\u65f6: ${timeoutSec} \u79d2`);
+  lines.push("", `\u23f1\ufe0f \u8d85\u65f6: ${expiresIn} \u79d2`);
   return lines.join("\n");
 }
 


### PR DESCRIPTION
## What Problem This Solves

Desktop QQ presents fenced exec-approval command previews as horizontally scrollable content, making long commands difficult to review before approval. This fixes the QQ Bot approval renderer without changing core approval behavior or normal QQ Bot message rendering.

Closes #101979.

## Why This Change Was Made

- Render exec and plugin prompts from shared typed pending views, so the primary sanitized command and current presentation fields win over stale/raw request fields.
- Insert presentation-only wraps after 24 graphemes while preserving the existing 300 UTF-16-unit cap. Every synthetic wrap carries a visible `↩` marker and legend so it cannot be mistaken for shell syntax.
- Keep grapheme clusters intact, including emoji sequences; retain a visible truncation marker even for a pathological first grapheme larger than the cap.
- Use the repository's established `Intl.Segmenter` pattern (also used by terminal-core, Discord, and Feishu). The `Array.from` fallback preserves Unicode code points/surrogate pairs if segmentation is unavailable without adding a QQ-only dependency.
- Choose a Markdown fence longer than any backtick run in displayed content, and sanitize/fence `cwd` and agent metadata before interpolation.
- Preserve QQ Markdown delivery because QQ's documented inline-button flow is attached to Markdown messages.
- Compute remaining exec/plugin lifetime from the view's `expiresAtMs` and the runtime clock instead of a fixed plugin fallback.

## User Impact

Long exec-approval previews are split into bounded, visibly marked display lines on QQ clients; this targets desktop's non-wrapping fenced-block behavior. Approval callback values are unchanged. No configuration or migration is required.

## Evidence

- Exact reviewed head: `ba136cce9c445f1123a51354893bcebcc368462a`
- Surface: production `+98/-35` (net `+63`); tests `+225/-10`. The production growth replaces raw-request presentation with one typed path and pays for the bounded/safe preview formatter.
- Focused sanitized AWS red proof: [run `run_0be82ddf66bf`](https://crabbox.openclaw.ai/portal/runs/run_0be82ddf66bf) deliberately changed the wrap width and produced the expected two regression failures.
- Focused sanitized AWS green proof: [run `run_95a3c290fb17`](https://crabbox.openclaw.ai/portal/runs/run_95a3c290fb17) passed 2 files and 11/11 tests.
- Full QQ Bot sanitized AWS proof: [run `run_87409e994413`](https://crabbox.openclaw.ai/portal/runs/run_87409e994413) passed 75 files and 684/684 tests.
- Native-payload artifact proof: [run `run_0366298f5ceb`](https://crabbox.openclaw.ai/portal/runs/run_0366298f5ceb) passed and emitted redacted mixed-adversarial, oversized-grapheme, and ten-minute plugin-expiry payloads for source-blind inspection.
- Source-blind behavior validation: 10/10 expected clauses and 5/5 anti-cheat probes passed against the redacted payload artifact; 0 failed or blocked. This validates artifact structure only, not real QQ client rendering or delivery.
- Fresh autoreview: clean; no accepted/actionable findings.
- GitHub CI: [exact-head CI run `29035761841`](https://github.com/openclaw/openclaw/actions/runs/29035761841) passed, including extension boundary, lint, prod/test type, build-artifact, security, and compact test lanes.
- Tencent's official QQ Bot plugin recognizes three-or-more-backtick fences and tests four-backtick outer fences: [`media-send.ts`](https://github.com/tencent-connect/openclaw-qqbot/blob/7ceb7f0913d15417c5a74d82442a672ef0382c64/src/utils/media-send.ts#L127-L151), [`code-block-media-tag.test.ts`](https://github.com/tencent-connect/openclaw-qqbot/blob/7ceb7f0913d15417c5a74d82442a672ef0382c64/tests/code-block-media-tag.test.ts#L169-L184).

Focused coverage includes ASCII/CJK/emoji wrapping, extended grapheme preservation at the cap, pathological oversized graphemes, visible truncation, dynamic backtick fences, literal wrap-marker reservation, shell comment/backslash boundary ambiguity, shared-view secret/control-character sanitization, metadata fencing, real plugin expiry, stale raw-field rejection, and unchanged approval callback data.

### Live-client proof gap

Real QQ Desktop/mobile rendering was not run in this maintainer pass: the test host has no QQ app, no configured QQ Bot account/credentials, and no authorized C2C/group target. The source and payload transform are proven, but the upstream client-rendering claim still needs a redacted QQ Desktop capture or an explicit maintainer proof override.
