### PR TITLE
fix(channels): ignore blocked object keys in account lists

### DIFF
--- a/src/channels/plugins/account-helpers.test.ts
+++ b/src/channels/plugins/account-helpers.test.ts
@@ -75,6 +75,14 @@ describe("createAccountListHelpers", () => {
       expect(listConfiguredAccountIds(cfg({ "": {}, a: {} }))).toEqual(["a"]);
     });
 
+    it("filters out blocked object keys", () => {
+      const accounts = JSON.parse(
+        '{"__proto__":{},"constructor":{},"prototype":{},"work":{}}',
+      ) as Record<string, unknown>;
+
+      expect(listConfiguredAccountIds(cfg(accounts))).toEqual(["work"]);
+    });
+
     it("returns account keys", () => {
       expect(listConfiguredAccountIds(cfg({ work: {}, personal: {} }))).toEqual([
         "work",

--- a/src/channels/plugins/account-helpers.ts
+++ b/src/channels/plugins/account-helpers.ts
@@ -68,7 +68,9 @@ export function createAccountListHelpers<
     if (!accounts || typeof accounts !== "object") {
       return [];
     }
-    const ids = Object.keys(accounts as Record<string, unknown>).filter(Boolean);
+    const ids = Object.keys(accounts as Record<string, unknown>).filter((id) =>
+      Boolean(normalizeOptionalAccountId(id)),
+    );
     const normalizeConfiguredAccountId = options?.normalizeAccountId;
     if (!normalizeConfiguredAccountId) {
       return ids;


### PR DESCRIPTION
# fix(channels): ignore blocked object keys in account lists

## What Problem This Solves

Fixes an issue where malformed or imported channel account config could treat blocked object keys such as `__proto__`, `constructor`, or `prototype` as real configured channel accounts.

`createAccountListHelpers().listConfiguredAccountIds()` guarded only against empty keys, so this config shape could leak `constructor` into a plugin's account list:

```json
{
  "channels": {
    "discord": {
      "accounts": {
        "constructor": {},
        "work": {}
      }
    }
  }
}
```

That account list is not only display data. Gateway uses `plugin.config.listAccountIds(cfg)` when starting channel accounts and when building runtime snapshots. Later account resolution normalizes ids through the shared account-id rules, where `constructor` is rejected and falls back to `default`. That creates a mismatch: the visible/runtime account key can be `constructor`, while the resolved account data comes from the default account.

## Why This Change Was Made

The shared account id normalizer already rejects prototype-like object keys. Account enumeration should obey the same contract before exposing ids to Gateway lifecycle and status paths.

This PR changes `listConfiguredAccountIds()` to filter configured account keys through `normalizeOptionalAccountId()` before returning them. That keeps normal account ids unchanged while preventing invalid object keys from entering channel account startup and snapshot flows.

Account key | Before | After
--- | --- | ---
`work` | listed | listed
`personal` | listed | listed
`constructor` | listed incorrectly | ignored
`prototype` | listed incorrectly | ignored
JSON own `__proto__` | listed incorrectly | ignored

## User Impact

Users and operators will no longer see blocked object keys appear as configured channel accounts in channel status, runtime snapshots, or automatic account startup flows.

If a config file is generated, merged, or imported with keys like `constructor`, OpenClaw now ignores those invalid account entries consistently with the existing account id validation rules instead of treating them as runnable channel accounts.

## Evidence

Verified against branch `fix/filter-blocked-account-ids`.

### Before (broken)

`src/channels/plugins/account-helpers.ts` listed configured account ids with only an empty-string filter:

```ts
Object.keys(accounts as Record<string, unknown>).filter(Boolean)
```

For a config account map containing `constructor`, `prototype`, JSON own `__proto__`, and `work`, the helper could return blocked object keys as configured account ids.

### After (fixed)

`listConfiguredAccountIds()` now filters each raw key through the existing account id validator:

```ts
const ids = Object.keys(accounts as Record<string, unknown>).filter((id) =>
  Boolean(normalizeOptionalAccountId(id)),
);
```

This matches the existing account id contract:

- `src/routing/account-id.ts:30` rejects canonical ids when `isBlockedObjectKey(canonical)` is true.
- `src/infra/prototype-keys.ts` defines the blocked keys as `__proto__`, `prototype`, and `constructor`.

### Runtime path proof

Gateway consumes the plugin account list directly:

- `src/gateway/server-channels.ts:449` uses `plugin.config.listAccountIds(cfg)` for channel account startup.
- `src/gateway/server-channels.ts:1033` uses `plugin.config.listAccountIds(cfg)` for runtime snapshots.
- `src/gateway/server-channels.ts:1040` then resolves and projects each listed id into account snapshot state.

That means filtering the shared account list prevents invalid keys from reaching both account startup and status/snapshot projection.

### Regression guard

```ts
const accounts = JSON.parse(
  '{"__proto__":{},"constructor":{},"prototype":{},"work":{}}',
) as Record<string, unknown>;

expect(listConfiguredAccountIds(cfg(accounts))).toEqual(["work"]);
```

This asserts:

- JSON own `__proto__` is ignored.
- `constructor` is ignored.
- `prototype` is ignored.
- A normal configured account, `work`, is still returned.

## Tests and Validation

Focused regression test:

```text
$ node scripts/run-vitest.mjs src/channels/plugins/account-helpers.test.ts
```

Result:

```text
Test Files  1 passed (1)
Tests       36 passed (36)
```

Whitespace check:

```text
$ git diff --check
```

Result: passed with no output.

## Risk Checklist

- User-visible behavior: Yes. Invalid account keys are no longer shown or started as channel accounts.
- Config/env/migration behavior: No migration or config shape change. Existing invalid keys are ignored by account enumeration, matching the current account id validator.
- Security/auth/secrets/network/tool execution: No. This does not touch credentials, network calls, tool execution, or secret resolution.
- Plugins/providers/channels/SDK: Low channel/plugin helper impact. The change is in shared channel account enumeration; no public SDK surface or plugin contract is added.
- Highest-risk area: Existing configs that intentionally used `constructor`, `prototype`, or `__proto__` as account ids. Those ids are already invalid under the shared account id contract, so ignoring them makes enumeration consistent with resolution.
- Mitigation: Focused regression test covers blocked object keys and keeps a normal `work` account listed.

Closes: N/A
