### PR TITLE
Calm Slack native progress task states

### DIFF
--- a/extensions/slack/src/progress-blocks.test.ts
+++ b/extensions/slack/src/progress-blocks.test.ts
@@ -36,7 +36,11 @@ function planUpdate(title: string) {
   return { type: "plan_update", title };
 }
 
-function taskUpdate(id: unknown, title: string, status: "in_progress" | "complete" | "error") {
+function taskUpdate(
+  id: unknown,
+  title: string,
+  status: "pending" | "in_progress" | "complete" | "error",
+) {
   return { type: "task_update", id, title, status };
 }
 
@@ -188,8 +192,8 @@ describe("native Slack progress stream chunks", () => {
       }),
     ).toEqual([
       planUpdate("tool two"),
-      taskUpdate("item_1", "tool one", "in_progress"),
-      taskUpdate("item_2", "tool two", "in_progress"),
+      taskUpdate("item_1", "tool one", "pending"),
+      taskUpdate("item_2", "tool two", "pending"),
     ]);
   });
 
@@ -213,7 +217,7 @@ describe("native Slack progress stream chunks", () => {
       taskUpdate(
         "tool_1",
         "Exec — run tests in /Users/example/P…aw/packages/very/deep/path/example",
-        "in_progress",
+        "pending",
       ),
     ]);
   });
@@ -258,12 +262,12 @@ describe("native Slack progress stream chunks", () => {
     expectTaskUpdate(chunksWithTitle?.[1], {
       id: "tool_1",
       title: "Exec 10 — run 10",
-      status: "in_progress",
+      status: "pending",
     });
     expectTaskUpdate(chunksWithTitle?.at(-1), {
       id: "tool_50",
       title: "Exec 59 — run 59",
-      status: "in_progress",
+      status: "pending",
     });
 
     const chunksWithoutTitle = buildSlackProgressStreamStartChunks({
@@ -274,12 +278,12 @@ describe("native Slack progress stream chunks", () => {
     expectTaskUpdate(chunksWithoutTitle?.[1], {
       id: "tool_1",
       title: "Exec 10 — run 10",
-      status: "in_progress",
+      status: "pending",
     });
     expectTaskUpdate(chunksWithoutTitle?.at(-1), {
       id: "tool_50",
       title: "Exec 59 — run 59",
-      status: "in_progress",
+      status: "pending",
     });
   });
 
@@ -290,7 +294,7 @@ describe("native Slack progress stream chunks", () => {
       }),
     ).toEqual([
       planUpdate("Exec — run tests"),
-      taskUpdate("exec_1", "Exec — run tests", "in_progress"),
+      taskUpdate("exec_1", "Exec — run tests", "pending"),
     ]);
   });
 
@@ -315,8 +319,8 @@ describe("native Slack progress stream chunks", () => {
       }),
     ).toEqual([
       planUpdate("Exec — run tests"),
-      taskUpdate("item_1", "prepare the workspace", "in_progress"),
-      taskUpdate("exec_2", "Exec — run tests", "in_progress"),
+      taskUpdate("item_1", "prepare the workspace", "pending"),
+      taskUpdate("exec_2", "Exec — run tests", "pending"),
     ]);
   });
 
@@ -345,8 +349,8 @@ describe("native Slack progress stream chunks", () => {
       }),
     ).toEqual([
       planUpdate("Shelling..."),
-      taskUpdate(expect.stringMatching(/^cmd_1_[a-f0-9]{8}$/u), "🛠️ Exec", "in_progress"),
-      taskUpdate(expect.stringMatching(/^cmd_2_[a-f0-9]{8}$/u), "🛠️ Exec", "in_progress"),
+      taskUpdate(expect.stringMatching(/^cmd_1_[a-f0-9]{8}$/u), "🛠️ Exec", "pending"),
+      taskUpdate(expect.stringMatching(/^cmd_2_[a-f0-9]{8}$/u), "🛠️ Exec", "pending"),
     ]);
   });
 
@@ -408,8 +412,8 @@ describe("native Slack progress stream chunks", () => {
       }),
     ).toEqual([
       planUpdate("Shelling"),
-      taskUpdate("item_1", "tool one", "in_progress"),
-      taskUpdate("item_2", "tool two", "in_progress"),
+      taskUpdate("item_1", "tool one", "pending"),
+      taskUpdate("item_2", "tool two", "pending"),
     ]);
   });
 

--- a/extensions/slack/src/progress-blocks.ts
+++ b/extensions/slack/src/progress-blocks.ts
@@ -14,7 +14,7 @@ const SLACK_PROGRESS_CHUNK_TEXT_MAX = 256;
 const SLACK_PROGRESS_TASK_TITLE_MAX = 120;
 const SLACK_PROGRESS_PLAN_FALLBACK_TITLE = "Thinking";
 
-type SlackPlanTaskStatus = "in_progress" | "complete" | "error";
+type SlackPlanTaskStatus = "pending" | "in_progress" | "complete" | "error";
 
 type SlackPlanTask = {
   id: string;
@@ -94,6 +94,12 @@ function lineTaskTitle(line: ChannelProgressDraftLine, maxLineChars: number): st
 function lineTaskStatus(line: ChannelProgressDraftLine): SlackPlanTaskStatus {
   const normalized = line.status?.replace(/\s+/g, " ").trim().toLowerCase();
   if (!normalized) {
+    return "pending";
+  }
+  if (normalized === "pending" || normalized === "requested") {
+    return "pending";
+  }
+  if (normalized === "in_progress" || normalized === "in progress" || normalized === "running") {
     return "in_progress";
   }
   if (
@@ -186,7 +192,7 @@ function buildSlackProgressStreamChunks(params: {
       id: task.id,
       title: task.title,
       status:
-        task.status === "in_progress"
+        task.status === "pending" || task.status === "in_progress"
           ? (params.finalInProgressStatus ?? (params.completeInProgress ? "complete" : task.status))
           : task.status,
     })),


### PR DESCRIPTION
## Summary
- Use Slack native task-card `pending` state for progress lines that do not have a terminal/running status yet
- Preserve `in_progress` for explicit running statuses, `complete` for successful completions, and `error` for failed/non-zero command exits
- Keep finalization behavior that marks unfinished pending/in-progress tasks complete when the turn succeeds

## Test plan
- [x] `pnpm exec vitest run extensions/slack/src/progress-blocks.test.ts`
- [x] `pnpm exec oxlint extensions/slack/src/progress-blocks.ts extensions/slack/src/progress-blocks.test.ts`
- [x] `git diff --check`
