### PR TITLE
perf(tasks): eliminate redundant O(n log n) sort in tasks.list RPC

### DIFF
--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -13,7 +13,7 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { cancelDetachedTaskRunById } from "../../tasks/detached-task-runtime.js";
-import { getTaskById, listTaskRecords } from "../../tasks/runtime-internal.js";
+import { getTaskById, listTaskRecordsUnsorted } from "../../tasks/runtime-internal.js";
 import type { TaskRecord, TaskStatus } from "../../tasks/task-registry.types.js";
 import { mapTaskSummary, taskUpdatedAt } from "./task-summary.js";
 import type { GatewayRequestHandlers } from "./types.js";
@@ -112,7 +112,10 @@ export const tasksHandlers: GatewayRequestHandlers = {
     // The registry lists newest-created first; the ledger view pages by last
     // activity so an old long-running task that just finished still surfaces
     // on the first page instead of hiding behind newer-created records.
-    const filtered = listTaskRecords()
+    // Use listTaskRecordsUnsorted() to avoid a redundant O(n log n) sort:
+    // listTaskRecords() sorts by createdAt, but tasks.list needs updatedAt order,
+    // so we do a single filter+sort pass here instead of sorting twice.
+    const filtered = listTaskRecordsUnsorted()
       .filter((task) => {
         if (statusFilter && !statusFilter.has(task.status)) {
           return false;

--- a/src/tasks/runtime-internal.ts
+++ b/src/tasks/runtime-internal.ts
@@ -11,6 +11,7 @@ export {
   hasActiveTaskForChildSessionKey,
   listFreshTasksForOwnerKey,
   listTaskRecords,
+  listTaskRecordsUnsorted,
   listTasksForFlowId,
   listTasksForOwnerKey,
   linkTaskToFlowById,

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -2415,6 +2415,16 @@ export function listTaskRecords(): TaskRecord[] {
     .map(({ insertionIndex: _, ...task }) => task);
 }
 
+/**
+ * Returns a shallow-cloned, unsorted snapshot of all task records.
+ * Callers that need their own sort order (e.g. by updatedAt) should use this
+ * instead of `listTaskRecords()` to avoid a redundant O(n log n) sort.
+ */
+export function listTaskRecordsUnsorted(): TaskRecord[] {
+  ensureTaskRegistryReady();
+  return [...tasks.values()].map(cloneTaskRecord);
+}
+
 export function hasActiveTaskForChildSessionKey(params: {
   sessionKey: string;
   excludeTaskId?: string;


### PR DESCRIPTION
## Summary

Fixes #101716

Every `tasks.list` RPC call was performing **two** full in-memory sort passes over the entire task registry, plus two full clone/spread allocations.

## Root Cause

`tasks.ts` called `listTaskRecords()`, which internally does:
```ts
[...tasks.values()]
  .map((task, insertionIndex) => Object.assign({}, cloneTaskRecord(task), { insertionIndex }))
  .toSorted(compareTasksNewestFirst)   // ← Sort 1: by createdAt
  .map(({ insertionIndex: _, ...task }) => task)
```

Then `tasks.ts` immediately discarded that sort and did its own:
```ts
.toSorted((left, right) => {
  const updatedDiff = taskUpdatedAt(right) - taskUpdatedAt(left);  // ← Sort 2: by updatedAt
  ...
})
```

The `createdAt` sort from `listTaskRecords()` was wasted work — `tasks.list` only needs `updatedAt` order.

On gateways with thousands of accumulated tasks, this caused O(n log n) CPU cost + temporary allocation pressure on every Control UI poll.

## Fix

Added `listTaskRecordsUnsorted()` to `task-registry.ts`:
```ts
export function listTaskRecordsUnsorted(): TaskRecord[] {
  ensureTaskRegistryReady();
  return [...tasks.values()].map(cloneTaskRecord);
}
```

Exported via `runtime-internal.ts` and used in `tasks.ts` instead of `listTaskRecords()`.

Result: **one** filter + sort pass per `tasks.list` RPC instead of two.

## Non-Impact

- `listTaskRecords()` is unchanged — all existing callers that rely on `createdAt` order are unaffected
- `tasks.list` sort order (by `updatedAt`) is identical to before
- Pagination cursors are unchanged

## Files Changed

| File | Change |
|------|--------|
| `src/tasks/task-registry.ts` | Add `listTaskRecordsUnsorted()` |
| `src/tasks/runtime-internal.ts` | Export `listTaskRecordsUnsorted` |
| `src/gateway/server-methods/tasks.ts` | Use `listTaskRecordsUnsorted()` + explanatory comment |