### PR TITLE
fix(agents): suppress unhandled stdout/stderr stream errors in local bash exec

### DIFF
--- a/src/agents/sessions/tools/bash.stream-errors.test.ts
+++ b/src/agents/sessions/tools/bash.stream-errors.test.ts
@@ -1,0 +1,142 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createLocalBashOperations } from "./bash.js";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+vi.mock("../../shell-utils.js", () => ({
+  getBashShellConfig: vi.fn(() => ({ shell: "/bin/bash", args: ["-c"] })),
+  getShellEnv: vi.fn(() => ({ PATH: "/usr/bin" })),
+  killProcessTree: vi.fn(),
+}));
+
+vi.mock("../../utils/child-process.js", () => ({
+  waitForChildProcess: vi.fn(() => Promise.resolve(0)),
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+type MockChild = ChildProcessWithoutNullStreams & {
+  stdin: PassThrough;
+  stdout: PassThrough;
+  stderr: PassThrough;
+};
+
+function createChild(): MockChild {
+  let killed = false;
+  const child = Object.assign(new EventEmitter(), {
+    stdin: new PassThrough(),
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+  }) as unknown as MockChild;
+  Object.defineProperty(child, "killed", { get: () => killed });
+  child.kill = vi.fn(() => {
+    killed = true;
+    return true;
+  });
+  return child;
+}
+
+function mockSpawn(child: MockChild) {
+  vi.mocked(spawn).mockReturnValue(child);
+}
+
+describe("bash stream errors", () => {
+  it.each(["stdout", "stderr"] as const)(
+    "does not throw when %s stream errors after data listener is attached",
+    async (stream) => {
+      const child = createChild();
+      mockSpawn(child);
+
+      const ops = createLocalBashOperations();
+      const execPromise = ops.exec("echo ok", "/tmp", {
+        onData: () => {},
+        env: {},
+      });
+
+      // Let the spawn settle so data/error listeners are registered.
+      await vi.waitFor(() => expect(spawn).toHaveBeenCalledOnce());
+
+      // Emitting a stream error should not crash the process — the error
+      // handler we added suppresses it.  If no handler were registered,
+      // Node.js would throw an unhandled 'error' event.
+      expect(() => {
+        child[stream].emit("error", new Error(`${stream} EPIPE`));
+      }).not.toThrow();
+
+      // The execution should eventually settle via waitForChildProcess.
+      await expect(execPromise).resolves.toEqual({ exitCode: 0 });
+    },
+  );
+
+  it("survives stdout error then stderr error without crashing", async () => {
+    const child = createChild();
+    mockSpawn(child);
+
+    const chunks: Buffer[] = [];
+    const ops = createLocalBashOperations();
+    const execPromise = ops.exec("echo ok", "/tmp", {
+      onData: (chunk) => chunks.push(chunk),
+      env: {},
+    });
+
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledOnce());
+
+    // Both streams error — neither should throw.
+    expect(() => {
+      child.stdout.emit("error", new Error("stdout broken"));
+      child.stderr.emit("error", new Error("stderr broken"));
+    }).not.toThrow();
+
+    await expect(execPromise).resolves.toEqual({ exitCode: 0 });
+  });
+
+  it("still receives data on the surviving stream after the peer errors", async () => {
+    const child = createChild();
+    mockSpawn(child);
+
+    const chunks: Buffer[] = [];
+    const ops = createLocalBashOperations();
+    const execPromise = ops.exec("echo ok", "/tmp", {
+      onData: (chunk) => chunks.push(chunk),
+      env: {},
+    });
+
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledOnce());
+
+    // stderr errors first, stdout keeps delivering.
+    child.stderr.emit("error", new Error("stderr broken"));
+    child.stdout.emit("data", Buffer.from("still-alive\n"));
+
+    await expect(execPromise).resolves.toEqual({ exitCode: 0 });
+    expect(chunks.some((c) => c.toString().includes("still-alive"))).toBe(true);
+  });
+
+  it("completes normally when streams never error", async () => {
+    const child = createChild();
+    mockSpawn(child);
+
+    const chunks: Buffer[] = [];
+    const ops = createLocalBashOperations();
+    const execPromise = ops.exec("echo ok", "/tmp", {
+      onData: (chunk) => chunks.push(chunk),
+      env: {},
+    });
+
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledOnce());
+
+    // Normal data flow — no errors.
+    child.stdout.emit("data", Buffer.from("hello\n"));
+    child.stderr.emit("data", Buffer.from(""));
+
+    // Simulate waitForChildProcess resolving.
+    await expect(execPromise).resolves.toEqual({ exitCode: 0 });
+    expect(chunks.length).toBeGreaterThan(0);
+  });
+});

--- a/src/agents/sessions/tools/bash.ts
+++ b/src/agents/sessions/tools/bash.ts
@@ -82,6 +82,10 @@ export function createLocalBashOperations(options?: { shellPath?: string }): Bas
         // Stream stdout and stderr.
         child.stdout?.on("data", onData);
         child.stderr?.on("data", onData);
+        // Stream read errors on stdout/stderr are non-fatal; the child process
+        // error/exit/close handlers in waitForChildProcess report the real outcome.
+        child.stdout?.on("error", () => {});
+        child.stderr?.on("error", () => {});
         // Handle abort signal by killing the entire process tree.
         const onAbort = () => {
           if (child.pid) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the agent runtime can crash with an unhandled `EPIPE`
exception when a local bash child process's stdout or stderr pipe breaks
while the agent is still reading output. The `child.stdout?.on("data", ...)`
handlers in `createLocalBashOperations` were registered without corresponding
`on("error")` guards, so Node.js emits the stream error as an unhandled
exception that kills the process.

This is the same class of fix as ~20 recently-merged PRs that added stream
error handlers across the codebase (ssh sandbox, ripgrep tool, supervisor,
waitForChildProcess, MCP transport, Docker exec, etc.).

## Why This Change Was Made

`waitForChildProcess` (called a few lines later) already has internal no-op
`onStreamError` handlers, consistent with the contract that stream read errors
are non-fatal and the child process `error`/`exit`/`close` handlers report
the real outcome. This fix mirrors that contract at the point where the
`on("data")` listeners are first attached, closing the gap before
`waitForChildProcess` takes over.

## User Impact

Prevents a rare agent-runtime crash when a local bash command's pipe breaks
during output collection. No user-visible behavior change for normal execution.

## Real behavior proof

**Behavior addressed:** `child.stdout/stderr.on("data")` without `on("error")`
causes Node.js to throw synchronously when the stream emits an error event.

**Real environment tested:** Node.js v22.22.0, Linux x86_64, real production
`createLocalBashOperations` with real `echo` command (case 3), plus isolated
stream contract proof (cases 1-2, 4-5).

**Proof script output (`node --import tsx proof-bash-stream-error.mts`):**

```
[case 1] Readable stream without error listener THROWS synchronously
  ok: Readable.emit('error') throws sync (Node.js default)
[case 2] Readable stream WITH error listener does NOT throw
  ok: Readable.emit('error') does NOT throw (handler suppresses)
[case 3] createLocalBashOperations: real command executes normally
  ok: exitCode = 0
  ok: stdout contains 'hello-proof'
[case 4] negative control: child stdout with on('data') but NO on('error') → THROW
  ok: stdout emit('error') throws (pre-fix crash)
  ok: stderr emit('error') throws (pre-fix crash)
[case 5] post-fix: child stdout with on('data') AND on('error') → SAFE
  ok: stdout emit('error') does NOT throw (fix applied)
  ok: stderr emit('error') does NOT throw (fix applied)

=== Summary ===
ALL PROOF ASSERTIONS: 8 passed, 0 failed
```

**Negative control (revert fix → vitest):**

```
# pre-fix (origin/main bash.ts):
Test Files  1 failed (1)
Tests  4 failed | 1 passed (5)
  ─ stderr EPIPE → uncaught exception crashes test runner

# post-fix:
Test Files  1 passed (1)
Tests  5 passed (5)
```

**What was not tested:** A real EPIPE on a live child process pipe (requires
OS-level pipe manipulation that is inherently race-dependent). The stream
error contract is a Node.js runtime guarantee tested via synthetic emit and
the production function path is covered by vitest with PassThrough streams.

## Evidence

- **vitest (both test files):** 2 passed, 9 tests total, 0 failures
- **Existing bash.test.ts regression:** 1 passed, 4/4 tests green (no
  regression from the fix)
- **Format:** `oxfmt --check` clean on both changed files
- **No competing PR:** full `gh search prs` across open/closed for
  `bash.ts stdout stderr`, `agents sessions tools bash`, `agent bash stream
  error` — all returned zero results
- **Sibling pattern:** `waitForChildProcess` in
  `src/agents/utils/child-process.ts:100-103` uses the same no-op
  `onStreamError` contract; `src/agents/sandbox/ssh.ts:707-709` uses the same
  `on("data")` + `on("error")` pattern on child stdout/stderr