### PR TITLE
docs(config-channels): fix googlechat groups allow -> enabled to match schema

### DIFF
--- a/docs/gateway/config-channels.md
+++ b/docs/gateway/config-channels.md
@@ -409,7 +409,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
       },
       groupPolicy: "allowlist",
       groups: {
-        "spaces/AAAA": { allow: true, requireMention: true },
+        "spaces/AAAA": { enabled: true, requireMention: true },
       },
       actions: { reactions: true },
       typingIndicator: "message",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `docs/gateway/config-channels.md:412` documented the Google Chat groups entry as `{ allow: true }`, but the canonical `GoogleChatGroupSchema` rejects unknown keys, causing a validation error for anyone copy-pasting the example.

## Why This Change Was Made

`docs/channels/googlechat.md:176` already uses `enabled: true` correctly — this fix aligns the reference page with the schema and the dedicated doc.

## User Impact

Operators copying the Google Chat config example from `config-channels.md` will no longer encounter a silent validation failure.

## Evidence

**Doc (wrong)** — `docs/gateway/config-channels.md:412`:
```json5
groups: {
  "spaces/AAAA": { allow: true, requireMention: true },
},
```

**Schema** — `src/config/zod-schema.providers-googlechat.ts:89-97`:
```ts
export const GoogleChatGroupSchema = z
  .object({
    enabled: z.boolean().optional(),
    requireMention: z.boolean().optional(),
    botLoopProtection: ChannelBotLoopProtectionSchema.optional(),
    users: z.array(z.union([z.string(), z.number()])).optional(),
    systemPrompt: z.string().optional(),
  })
  .strict();  // ← rejects unknown keys like "allow"
```

**Same channel, correct usage** — `docs/channels/googlechat.md:176`:
```json5
groups: {
  "spaces/AAAA": {
    enabled: true,       // ← correct
    requireMention: true,
    users: ["users/1234567890"],
    systemPrompt: "Short answers only.",
  },
},
```