### PR TITLE
fix(browser): suppress unhandled stderr stream errors during Chrome launch

### DIFF
--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -1055,6 +1055,10 @@ export async function launchOpenClawChrome(
       stderrChunks.push(chunk);
     };
     proc.stderr?.on("data", onStderr);
+    // Suppress unhandled stream errors so a broken stderr pipe during Chrome
+    // launch does not crash the runtime.  The process exit / CDP readiness
+    // paths already report the real launch outcome.
+    proc.stderr?.on("error", () => {});
 
     try {
       const readyDeadline =


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the agent runtime can crash with an unhandled `EPIPE`
exception when Chrome's stderr pipe breaks during the launch discovery window.
The `proc.stderr?.on("data", onStderr)` handler at chrome.ts:1057 collects
stderr for launch diagnostics but has no `on("error")` guard. If the Chrome
process exits abruptly while the poll loop is still reading stderr, Node.js
throws an unhandled stream error and kills the runtime.

This is the same class of fix as ~20 recently-merged PRs that added stream
error handlers across the codebase (crestodian, supervisor, waitForChildProcess,
MCP transport, ssh sandbox, ripgrep tool, etc.).

## Why This Change Was Made

The fix adds a no-op `proc.stderr?.on("error", () => {})` immediately after the
data handler, matching the suppress pattern used throughout the codebase.
Stream read errors are non-fatal — the process exit and CDP readiness paths
already report the real launch outcome. Stdout is not consumed (stdio is
`["ignore", "ignore", "pipe"]`), so only stderr needs the guard.

## User Impact

Prevents a rare runtime crash when Chrome fails to start and its stderr pipe
breaks during the CDP readiness poll. No behavior change for normal launches.

## Real behavior proof

**Behavior addressed:** `proc.stderr.on("data")` without `on("error")` causes
Node.js to throw synchronously when the stream emits an error event.

**Real environment tested:** Node.js v22.22.0, Linux x86_64, Google Chrome
126 installed and reachable.

**Proof script output (`node --import tsx proof-chrome-stderr-error.mts`):**

```
[case 1] Fundamental: Readable stream without error handler → THROWS
  ok: emit('error') throws with no handler
[case 2] Fundamental: Readable stream WITH error handler → safe
  ok: emit('error') does NOT throw with handler
[case 3] Chrome scenario: stderr on('data') without on('error') → crash
  ok: stderr emit('error') throws (pre-fix runtime crash)
[case 4] Chrome scenario: stderr on('data') WITH on('error') → safe
  ok: stderr emit('error') does NOT throw (fix applied)
[case 5] Real Chrome can be launched (end-to-end sanity)
  ok: google-chrome is installed (production code path reachable)

=== Summary ===
ALL PROOF ASSERTIONS: 5 passed, 0 failed
```

**Negative control (revert fix → proof case 3 shows crash):**
- Pre-fix: `stderr.emit("error")` throws synchronously — process would crash
- Post-fix: `stderr.emit("error")` is suppressed — no throw

**What was not tested:** A real EPIPE on a live Chrome process pipe during
launch (requires OS-level pipe manipulation at a specific sub-second window
during Chrome startup — inherent to this bug class and not tested by any
of the 20+ merged sibling PRs either).

## Evidence

- **vitest (existing browser/chrome tests):** 6/7 passed, 173/174 tests green.
  The 1 failure (`chrome.loopback-ssrf.integration.test.ts`) is a pre-existing
  SSRF network test failure unrelated to this change.
- **Format:** `oxfmt --check` clean
- **No competing PR:** 3 searches across open/closed for `path:chrome.ts`,
  `chrome stderr stream`, `browser stderr` — all zero results
- **Sibling pattern:** 20+ merged PRs use the same suppress pattern:
  `on("error", () => {})` after `on("data", ...)` on child process streams