### PR TITLE
fix(state): replace non-null assertion with explicit guard for nextSessionId

### DIFF
--- a/src/auto-reply/reply/queue/state.ts
+++ b/src/auto-reply/reply/queue/state.ts
@@ -209,10 +209,12 @@ export function refreshQueuedFollowupSession(params: {
       return;
     }
     if (shouldRewriteSession && run.sessionId === params.previousSessionId) {
-      run.sessionId = params.nextSessionId!;
-      const nextSessionFile = normalizeOptionalString(params.nextSessionFile);
-      if (nextSessionFile) {
-        run.sessionFile = nextSessionFile;
+      if (params.nextSessionId) {
+        run.sessionId = params.nextSessionId;
+        const nextSessionFile = normalizeOptionalString(params.nextSessionFile);
+        if (nextSessionFile) {
+          run.sessionFile = nextSessionFile;
+        }
       }
     }
     if (shouldRewriteSelection) {


### PR DESCRIPTION
## What Problem This Solves

Removes a non-null assertion (`!`) on `params.nextSessionId` in `refreshQueuedFollowupSession` that could silently produce an undefined session ID if the upstream `shouldRewriteSession` guards are refactored away. TypeScript would not catch this drift.

## Why This Change Was Made

The `!` assertion was safe in current code because `shouldRewriteSession` includes `Boolean(params.nextSessionId)`. But the `Boolean()` call does not narrow the TypeScript type, making the assertion a latent fragility. The fix replaces `params.nextSessionId!` with `if (params.nextSessionId)` — TypeScript narrows the type inside the guard, making the contract compiler-checked. The guard only wraps the session-key rewrite, leaving the independent selection rewrite (provider/model) unaffected.

## User Impact

None. This is a defensive hardening that preserves existing behavior on all paths.

## Evidence

- **Real environment tested**: Linux, Node 22, `fix/remove-nextSessionId-bang-assertion`
- **Exact steps or command run after this patch**:

  ```console
  node --import tsx BUG-002-proof.ts
  ```

- **Evidence after fix**:

  ```console
  === Before session rotation ===
  sessionId: session-old, provider: anthropic

  === After session rotation (with nextSessionId) ===
  sessionId: session-new
  provider:  openai
  model:     gpt-4o
  sessionFile: /tmp/session-new.jsonl

  === No nextSessionId — session unchanged, selection updated ===
  sessionId: session-fixed (unchanged ✅)
  provider:  openai (updated ✅)
  ```

  Two scenarios verified: (1) session rotation with `nextSessionId` correctly rewrites the session key, provider, and model; (2) without `nextSessionId`, the session key stays intact while the selection rewrite (provider/model) still applies. Both match expected behavior under the new `if (params.nextSessionId)` guard.

- **Observed result after fix**: Queued follow-up session retargeting works correctly with and without `nextSessionId`. The `!` assertion is replaced with a compiler-checked guard.
- **What was not tested**: The guard's falsy path (which only fires if `shouldRewriteSession` is refactored to allow a falsy `nextSessionId`).

## Regression Test Plan

```
node scripts/run-vitest.mjs src/auto-reply/reply/queue/state.test.ts
```

---

AI-assisted.
