### PR TITLE
fix(runway): apply configured request policy to video generation requests

### DIFF
--- a/extensions/runway/video-generation-provider.test.ts
+++ b/extensions/runway/video-generation-provider.test.ts
@@ -6,7 +6,12 @@ import {
 import { expectExplicitVideoGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
-const { postJsonRequestMock, fetchWithTimeoutMock } = getProviderHttpMocks();
+const {
+  postJsonRequestMock,
+  fetchWithTimeoutMock,
+  resolveProviderHttpRequestConfigMock,
+  sanitizeConfiguredModelProviderRequestMock,
+} = getProviderHttpMocks();
 
 let buildRunwayVideoGenerationProvider: typeof import("./video-generation-provider.js").buildRunwayVideoGenerationProvider;
 
@@ -25,7 +30,13 @@ function firstPostJsonRequest() {
   if (!request || typeof request !== "object") {
     throw new Error("expected Runway create request options");
   }
-  return request as { url?: string; body?: Record<string, unknown> };
+  return request as {
+    url?: string;
+    body?: Record<string, unknown>;
+    headers?: Headers;
+    allowPrivateNetwork?: boolean;
+    dispatcherPolicy?: unknown;
+  };
 }
 
 function firstFetchWithTimeoutCall() {
@@ -141,6 +152,77 @@ describe("runway video generation provider", () => {
     expect(metadata.taskId).toBe("task-1");
     expect(metadata.status).toBe("SUCCEEDED");
     expect(metadata.endpoint).toBe("/v1/text_to_video");
+  });
+
+  it("applies configured request policy to Runway video requests", async () => {
+    const requestPolicy = {
+      allowPrivateNetwork: true,
+      headers: { "X-Runway-Policy": "runway-policy" },
+    };
+    const dispatcherPolicy = { mode: "env-proxy" as const };
+    resolveProviderHttpRequestConfigMock.mockImplementationOnce((params) => {
+      const headers = new Headers(params.defaultHeaders);
+      for (const [key, value] of Object.entries(params.request?.headers ?? {})) {
+        headers.set(key, value);
+      }
+      return {
+        baseUrl: params.baseUrl ?? params.defaultBaseUrl,
+        allowPrivateNetwork: params.request?.allowPrivateNetwork === true,
+        headers,
+        dispatcherPolicy,
+      } as never;
+    });
+    postJsonRequestMock.mockResolvedValue({
+      response: streamedJsonResponse({ id: "task-policy" }),
+      release: vi.fn(async () => {}),
+    });
+    fetchWithTimeoutMock
+      .mockResolvedValueOnce(
+        streamedJsonResponse({
+          id: "task-policy",
+          status: "SUCCEEDED",
+          output: ["https://example.com/out.mp4"],
+        }),
+      )
+      .mockResolvedValueOnce({
+        arrayBuffer: async () => Buffer.from("mp4-bytes"),
+        headers: new Headers({ "content-type": "video/mp4" }),
+      });
+
+    const provider = buildRunwayVideoGenerationProvider();
+    await provider.generateVideo({
+      provider: "runway",
+      model: "gen4.5",
+      prompt: "a tiny lobster DJ under neon lights",
+      cfg: {
+        models: {
+          providers: {
+            runway: {
+              baseUrl: "https://api.dev.runwayml.com",
+              models: [],
+              request: requestPolicy,
+            },
+          },
+        },
+      },
+      durationSeconds: 4,
+      aspectRatio: "16:9",
+    });
+
+    expect(sanitizeConfiguredModelProviderRequestMock).toHaveBeenCalledWith(requestPolicy);
+    expect(resolveProviderHttpRequestConfigMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "runway",
+        capability: "video",
+        transport: "http",
+        request: requestPolicy,
+      }),
+    );
+    const request = firstPostJsonRequest();
+    expect(request.allowPrivateNetwork).toBe(true);
+    expect(request.dispatcherPolicy).toBe(dispatcherPolicy);
+    expect(request.headers).toBeInstanceOf(Headers);
+    expect((request.headers as Headers).get("x-runway-policy")).toBe("runway-policy");
   });
 
   it("rejects generated video downloads that exceed the configured media cap", async () => {

--- a/extensions/runway/video-generation-provider.test.ts
+++ b/extensions/runway/video-generation-provider.test.ts
@@ -9,6 +9,7 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 const {
   postJsonRequestMock,
   fetchWithTimeoutMock,
+  fetchWithTimeoutGuardedMock,
   resolveProviderHttpRequestConfigMock,
   sanitizeConfiguredModelProviderRequestMock,
 } = getProviderHttpMocks();
@@ -223,6 +224,24 @@ describe("runway video generation provider", () => {
     expect(request.dispatcherPolicy).toBe(dispatcherPolicy);
     expect(request.headers).toBeInstanceOf(Headers);
     expect((request.headers as Headers).get("x-runway-policy")).toBe("runway-policy");
+    const guardedCalls = fetchWithTimeoutGuardedMock.mock.calls.filter(
+      (call) => typeof call[0] === "string",
+    );
+    expect(guardedCalls.length).toBeGreaterThanOrEqual(2);
+    const pollCall = guardedCalls.find((call) => String(call[0]).includes("/v1/tasks/task-policy"));
+    const downloadCall = guardedCalls.find((call) => String(call[0]).endsWith("/out.mp4"));
+    expect(pollCall).toBeDefined();
+    expect(downloadCall).toBeDefined();
+    expect(pollCall?.[4]).toMatchObject({
+      ssrfPolicy: { allowPrivateNetwork: true },
+      dispatcherPolicy,
+      auditContext: "runway-video-status",
+    });
+    expect(downloadCall?.[4]).toMatchObject({
+      ssrfPolicy: { allowPrivateNetwork: true },
+      dispatcherPolicy,
+      auditContext: "runway-video-download",
+    });
   });
 
   it("rejects generated video downloads that exceed the configured media cap", async () => {

--- a/extensions/runway/video-generation-provider.ts
+++ b/extensions/runway/video-generation-provider.ts
@@ -6,8 +6,10 @@ import {
   assertOkOrThrowHttpError,
   createProviderOperationDeadline,
   createProviderOperationTimeoutResolver,
+  executeProviderOperationWithRetry,
   fetchProviderDownloadResponse,
   fetchProviderOperationResponse,
+  fetchWithTimeoutGuarded,
   postJsonRequest,
   readProviderJsonResponse,
   resolveProviderOperationTimeoutMs,
@@ -38,6 +40,11 @@ const POLL_INTERVAL_MS = 5_000;
 const MAX_POLL_ATTEMPTS = 120;
 const MAX_DURATION_SECONDS = 10;
 const DEFAULT_GENERATED_VIDEO_MAX_BYTES = 16 * 1024 * 1024;
+
+type RunwayVideoRequestPolicy = {
+  allowPrivateNetwork: boolean;
+  dispatcherPolicy?: Parameters<typeof postJsonRequest>[0]["dispatcherPolicy"];
+};
 
 type RunwayTaskStatus = "PENDING" | "RUNNING" | "THROTTLED" | "SUCCEEDED" | "FAILED" | "CANCELLED";
 
@@ -269,82 +276,180 @@ function buildCreateBody(req: VideoGenerationRequest): Record<string, unknown> {
   };
 }
 
-async function pollRunwayTask(params: {
-  taskId: string;
-  headers: Headers;
-  timeoutMs?: number;
-  baseUrl: string;
-  fetchFn: typeof fetch;
-}): Promise<RunwayTaskDetailResponse> {
+async function pollRunwayTask(
+  params: {
+    taskId: string;
+    headers: Headers;
+    timeoutMs?: number;
+    baseUrl: string;
+    fetchFn: typeof fetch;
+  } & RunwayVideoRequestPolicy,
+): Promise<RunwayTaskDetailResponse> {
   const deadline = createProviderOperationDeadline({
     timeoutMs: params.timeoutMs,
     label: `Runway video generation task ${params.taskId}`,
   });
+  const timeoutMs = createProviderOperationTimeoutResolver({
+    deadline,
+    defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
+  });
+  const guardedOptions =
+    !params.allowPrivateNetwork && !params.dispatcherPolicy
+      ? undefined
+      : {
+          ...(params.allowPrivateNetwork ? { ssrfPolicy: { allowPrivateNetwork: true } } : {}),
+          ...(params.dispatcherPolicy ? { dispatcherPolicy: params.dispatcherPolicy } : {}),
+          auditContext: "runway-video-status",
+        };
+  const taskUrl = `${params.baseUrl}/v1/tasks/${params.taskId}`;
+  const taskInit = {
+    method: "GET",
+    headers: params.headers,
+  };
   for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt += 1) {
-    const response = await fetchProviderOperationResponse({
-      stage: "poll",
-      url: `${params.baseUrl}/v1/tasks/${params.taskId}`,
-      init: {
-        method: "GET",
-        headers: params.headers,
-      },
-      timeoutMs: createProviderOperationTimeoutResolver({
-        deadline,
-        defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
-      }),
-      fetchFn: params.fetchFn,
-      provider: "runway",
-      requestFailedMessage: "Runway video status request failed",
-    });
-    const payload = await readRunwayJsonResponse<RunwayTaskDetailResponse>(
-      response,
-      "Runway video status request failed",
-    );
-    const status = readRunwayTaskStatus(payload);
-    switch (status) {
-      case "SUCCEEDED":
-        return payload;
-      case "FAILED":
-      case "CANCELLED":
-        throw new Error(
-          readRunwayFailureMessage(payload.failure) ||
-            `Runway video generation ${normalizeLowercaseStringOrEmpty(status)}`,
-        );
-      default:
-        await waitProviderOperationPollInterval({ deadline, pollIntervalMs: POLL_INTERVAL_MS });
-        break;
+    const { response, release } = guardedOptions
+      ? await executeProviderOperationWithRetry({
+          provider: "runway",
+          stage: "poll",
+          operation: async () => {
+            const result = await fetchWithTimeoutGuarded(
+              taskUrl,
+              taskInit,
+              typeof timeoutMs === "function" ? timeoutMs() : timeoutMs,
+              params.fetchFn,
+              guardedOptions,
+            );
+            try {
+              await assertOkOrThrowHttpError(result.response, "Runway video status request failed");
+              return result;
+            } catch (error) {
+              await result.release();
+              throw error;
+            }
+          },
+        })
+      : {
+          response: await fetchProviderOperationResponse({
+            stage: "poll",
+            url: taskUrl,
+            init: taskInit,
+            timeoutMs,
+            fetchFn: params.fetchFn,
+            provider: "runway",
+            requestFailedMessage: "Runway video status request failed",
+          }),
+          release: async () => {},
+        };
+    try {
+      const payload = await readRunwayJsonResponse<RunwayTaskDetailResponse>(
+        response,
+        "Runway video status request failed",
+      );
+      const status = readRunwayTaskStatus(payload);
+      switch (status) {
+        case "SUCCEEDED":
+          return payload;
+        case "FAILED":
+        case "CANCELLED":
+          throw new Error(
+            readRunwayFailureMessage(payload.failure) ||
+              `Runway video generation ${normalizeLowercaseStringOrEmpty(status)}`,
+          );
+        default:
+          await waitProviderOperationPollInterval({ deadline, pollIntervalMs: POLL_INTERVAL_MS });
+          break;
+      }
+    } finally {
+      await release();
     }
   }
   throw new Error(`Runway video generation task ${params.taskId} did not finish in time`);
 }
 
-async function downloadRunwayVideos(params: {
-  urls: string[];
-  timeoutMs?: ProviderOperationTimeoutMs;
-  fetchFn: typeof fetch;
-  maxBytes: number;
-}): Promise<GeneratedVideoAsset[]> {
-  const videos: GeneratedVideoAsset[] = [];
-  for (const [index, url] of params.urls.entries()) {
+async function fetchRunwayDownloadResponse(
+  params: {
+    url: string;
+    init: RequestInit;
+    timeoutMs?: ProviderOperationTimeoutMs;
+    fetchFn: typeof fetch;
+  } & RunwayVideoRequestPolicy,
+) {
+  if (!params.allowPrivateNetwork && !params.dispatcherPolicy) {
     const response = await fetchProviderDownloadResponse({
-      url,
-      init: { method: "GET" },
+      url: params.url,
+      init: params.init,
       timeoutMs: params.timeoutMs ?? DEFAULT_TIMEOUT_MS,
       fetchFn: params.fetchFn,
       provider: "runway",
       requestFailedMessage: "Runway generated video download failed",
     });
-    const mimeType = normalizeOptionalString(response.headers.get("content-type")) ?? "video/mp4";
-    const buffer = await readResponseWithLimit(response, params.maxBytes, {
-      onOverflow: ({ maxBytes }) =>
-        new Error(`Runway generated video download exceeds ${maxBytes} bytes`),
+    return {
+      response,
+      release: async () => {},
+    };
+  }
+
+  return await executeProviderOperationWithRetry({
+    provider: "runway",
+    stage: "download",
+    operation: async () => {
+      const result = await fetchWithTimeoutGuarded(
+        params.url,
+        params.init,
+        typeof params.timeoutMs === "function"
+          ? params.timeoutMs()
+          : (params.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+        params.fetchFn,
+        {
+          ...(params.allowPrivateNetwork ? { ssrfPolicy: { allowPrivateNetwork: true } } : {}),
+          ...(params.dispatcherPolicy ? { dispatcherPolicy: params.dispatcherPolicy } : {}),
+          auditContext: "runway-video-download",
+        },
+      );
+      try {
+        await assertOkOrThrowHttpError(result.response, "Runway generated video download failed");
+        return result;
+      } catch (error) {
+        await result.release();
+        throw error;
+      }
+    },
+  });
+}
+
+async function downloadRunwayVideos(
+  params: {
+    urls: string[];
+    timeoutMs?: ProviderOperationTimeoutMs;
+    fetchFn: typeof fetch;
+    maxBytes: number;
+  } & RunwayVideoRequestPolicy,
+): Promise<GeneratedVideoAsset[]> {
+  const videos: GeneratedVideoAsset[] = [];
+  for (const [index, url] of params.urls.entries()) {
+    const { response, release } = await fetchRunwayDownloadResponse({
+      url,
+      init: { method: "GET" },
+      timeoutMs: params.timeoutMs,
+      fetchFn: params.fetchFn,
+      allowPrivateNetwork: params.allowPrivateNetwork,
+      dispatcherPolicy: params.dispatcherPolicy,
     });
-    videos.push({
-      buffer,
-      mimeType,
-      fileName: `video-${index + 1}.${extensionForMime(mimeType)?.slice(1) ?? "mp4"}`,
-      metadata: { sourceUrl: url },
-    });
+    try {
+      const mimeType = normalizeOptionalString(response.headers.get("content-type")) ?? "video/mp4";
+      const buffer = await readResponseWithLimit(response, params.maxBytes, {
+        onOverflow: ({ maxBytes }) =>
+          new Error(`Runway generated video download exceeds ${maxBytes} bytes`),
+      });
+      videos.push({
+        buffer,
+        mimeType,
+        fileName: `video-${index + 1}.${extensionForMime(mimeType)?.slice(1) ?? "mp4"}`,
+        metadata: { sourceUrl: url },
+      });
+    } finally {
+      await release();
+    }
   }
   return videos;
 }
@@ -447,6 +552,8 @@ export function buildRunwayVideoGenerationProvider(): VideoGenerationProvider {
           }),
           baseUrl,
           fetchFn,
+          allowPrivateNetwork,
+          dispatcherPolicy,
         });
         const outputUrls = readRunwayOutputUrls(completed);
         const videos = await downloadRunwayVideos({
@@ -457,6 +564,8 @@ export function buildRunwayVideoGenerationProvider(): VideoGenerationProvider {
           }),
           fetchFn,
           maxBytes: resolveGeneratedVideoMaxBytes(req),
+          allowPrivateNetwork,
+          dispatcherPolicy,
         });
         return {
           videos,

--- a/extensions/runway/video-generation-provider.ts
+++ b/extensions/runway/video-generation-provider.ts
@@ -12,6 +12,7 @@ import {
   readProviderJsonResponse,
   resolveProviderOperationTimeoutMs,
   resolveProviderHttpRequestConfig,
+  sanitizeConfiguredModelProviderRequest,
   waitProviderOperationPollInterval,
   type ProviderOperationTimeoutMs,
 } from "openclaw/plugin-sdk/provider-http";
@@ -398,6 +399,7 @@ export function buildRunwayVideoGenerationProvider(): VideoGenerationProvider {
         timeoutMs: req.timeoutMs,
         label: "Runway video generation",
       });
+      const providerConfig = req.cfg?.models?.providers?.runway;
       const requestBody = buildCreateBody(req);
       const endpoint = resolveEndpoint(req);
       const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
@@ -412,6 +414,7 @@ export function buildRunwayVideoGenerationProvider(): VideoGenerationProvider {
           provider: "runway",
           capability: "video",
           transport: "http",
+          request: sanitizeConfiguredModelProviderRequest(providerConfig?.request),
         });
       const { response, release } = await postJsonRequest({
         url: `${baseUrl}${endpoint}`,


### PR DESCRIPTION
## What Problem This Solves

Runway video generation previously ignored `models.providers.runway.request` overrides (headers, allowPrivateNetwork, dispatcherPolicy). Users who configured a request policy for Runway saw it applied to chat/completion providers but not to video generation, so private-network access, custom headers, and dispatcher routing were dropped on the floor.

## Why This Change Was Made

Mirror the pattern already used by `openai`, `pixverse`, `google` image generation, and Alix-007's recent DashScope/MiniMax/OpenRouter video request-policy PRs: resolve the configured transport policy once and carry it through every HTTP stage of the video operation.

## Changes

- `extensions/runway/video-generation-provider.ts`
  - Import `sanitizeConfiguredModelProviderRequest`.
  - Read `req.cfg?.models?.providers?.runway`.
  - Forward the sanitized request policy to `resolveProviderHttpRequestConfig`.
  - Pass the resolved `allowPrivateNetwork` and `dispatcherPolicy` into `pollRunwayTask` and `downloadRunwayVideos`.
  - Use guarded fetch helpers for status polling and generated-video download when the resolved policy includes `allowPrivateNetwork` or `dispatcherPolicy`, falling back to the existing unguarded helpers when no guarded options are needed.
- `extensions/runway/video-generation-provider.test.ts`
  - Expand the regression test to assert that configured headers, `allowPrivateNetwork`, and `dispatcherPolicy` reach create, poll, and download stages.
  - Fix test type errors caught by `check-test-types`.

## Evidence

```bash
node scripts/run-vitest.mjs extensions/runway/video-generation-provider.test.ts
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo
node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/runway/video-generation-provider.ts extensions/runway/video-generation-provider.test.ts
```

- Vitest: 10/10 passing.
- `tsgo` (source + test): no type errors.
- `oxlint`: clean.

Real behavior proof against a local Runway-compatible endpoint, showing the configured `X-Runway-Policy` header is sent and private-network access is allowed:

```
[proof] local Runway-compatible endpoint at http://127.0.0.1:37479
[server] POST /v1/text_to_video
[server] Authorization: Bearer dummy-runway-key
[server] X-Runway-Policy: runway-policy
[server] GET /v1/tasks/task-proof
[server] GET /video.mp4
[proof] generated video count: 1
[proof] video MIME type: video/mp4
[proof] done
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
