### PR TITLE
fix(together): apply configured request policy to video generation requests

### DIFF
--- a/extensions/together/video-generation-provider.test.ts
+++ b/extensions/together/video-generation-provider.test.ts
@@ -9,6 +9,8 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 const {
   postJsonRequestMock,
   fetchWithTimeoutMock,
+  fetchWithTimeoutGuardedMock,
+  pollProviderOperationJsonMock,
   resolveProviderHttpRequestConfigMock,
   sanitizeConfiguredModelProviderRequestMock,
 } = getProviderHttpMocks();
@@ -349,6 +351,7 @@ describe("together video generation provider", () => {
   });
 
   it("applies configured request policy to Together video requests", async () => {
+    const dispatcherPolicy = { mode: "env-proxy" as const };
     const request = {
       allowPrivateNetwork: true,
       headers: { "X-Proxy": "enabled" },
@@ -362,8 +365,8 @@ describe("together video generation provider", () => {
         baseUrl: params.baseUrl ?? params.defaultBaseUrl,
         allowPrivateNetwork: params.request?.allowPrivateNetwork === true,
         headers,
-        dispatcherPolicy: undefined,
-      };
+        dispatcherPolicy,
+      } as never;
     });
     postJsonRequestMock.mockResolvedValue({
       response: streamedJsonResponse({
@@ -407,7 +410,23 @@ describe("together video generation provider", () => {
     );
     const createRequest = requireFirstPostJsonRequest("Together request");
     expect(createRequest.allowPrivateNetwork).toBe(true);
+    expect(createRequest.dispatcherPolicy).toBe(dispatcherPolicy);
     expect(createRequest.headers).toBeInstanceOf(Headers);
     expect((createRequest.headers as Headers).get("x-proxy")).toBe("enabled");
+    expect(pollProviderOperationJsonMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowPrivateNetwork: true,
+        dispatcherPolicy,
+      }),
+    );
+    const guardedDownloadCall = fetchWithTimeoutGuardedMock.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].endsWith("/together.mp4"),
+    );
+    expect(guardedDownloadCall).toBeDefined();
+    expect(guardedDownloadCall?.[4]).toMatchObject({
+      ssrfPolicy: { allowPrivateNetwork: true },
+      dispatcherPolicy,
+      auditContext: "together-video-download",
+    });
   });
 });

--- a/extensions/together/video-generation-provider.test.ts
+++ b/extensions/together/video-generation-provider.test.ts
@@ -6,7 +6,12 @@ import {
 import { expectExplicitVideoGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
-const { postJsonRequestMock, fetchWithTimeoutMock } = getProviderHttpMocks();
+const {
+  postJsonRequestMock,
+  fetchWithTimeoutMock,
+  resolveProviderHttpRequestConfigMock,
+  sanitizeConfiguredModelProviderRequestMock,
+} = getProviderHttpMocks();
 
 let buildTogetherVideoGenerationProvider: typeof import("./video-generation-provider.js").buildTogetherVideoGenerationProvider;
 
@@ -341,5 +346,68 @@ describe("together video generation provider", () => {
     const body = requireRecord(request.body, "Together request body");
     expect(body.model).toBe("Wan-AI/Wan2.2-I2V-A14B");
     expect(body.reference_images).toHaveLength(1);
+  });
+
+  it("applies configured request policy to Together video requests", async () => {
+    const request = {
+      allowPrivateNetwork: true,
+      headers: { "X-Proxy": "enabled" },
+    };
+    resolveProviderHttpRequestConfigMock.mockImplementationOnce((params) => {
+      const headers = new Headers(params.defaultHeaders);
+      for (const [key, value] of Object.entries(params.request?.headers ?? {})) {
+        headers.set(key, value);
+      }
+      return {
+        baseUrl: params.baseUrl ?? params.defaultBaseUrl,
+        allowPrivateNetwork: params.request?.allowPrivateNetwork === true,
+        headers,
+        dispatcherPolicy: undefined,
+      };
+    });
+    postJsonRequestMock.mockResolvedValue({
+      response: streamedJsonResponse({
+        id: "video_123",
+        status: "in_progress",
+      }),
+      release: vi.fn(async () => {}),
+    });
+    fetchWithTimeoutMock
+      .mockResolvedValueOnce({
+        json: async () => ({
+          id: "video_123",
+          status: "completed",
+          outputs: { video_url: "https://example.com/together.mp4" },
+        }),
+      })
+      .mockResolvedValueOnce({
+        headers: new Headers({ "content-type": "video/mp4" }),
+        arrayBuffer: async () => Buffer.from("mp4-bytes"),
+      });
+
+    const provider = buildTogetherVideoGenerationProvider();
+    await provider.generateVideo({
+      provider: "together",
+      model: "Wan-AI/Wan2.2-T2V-A14B",
+      prompt: "A bicycle weaving through a rainy neon street",
+      cfg: {
+        models: {
+          providers: {
+            together: {
+              request,
+            },
+          },
+        },
+      } as never,
+    });
+
+    expect(sanitizeConfiguredModelProviderRequestMock).toHaveBeenCalledWith(request);
+    expect(resolveProviderHttpRequestConfigMock).toHaveBeenCalledWith(
+      expect.objectContaining({ request }),
+    );
+    const createRequest = requireFirstPostJsonRequest("Together request");
+    expect(createRequest.allowPrivateNetwork).toBe(true);
+    expect(createRequest.headers).toBeInstanceOf(Headers);
+    expect((createRequest.headers as Headers).get("x-proxy")).toBe("enabled");
   });
 });

--- a/extensions/together/video-generation-provider.ts
+++ b/extensions/together/video-generation-provider.ts
@@ -13,6 +13,7 @@ import {
   readProviderJsonResponse,
   resolveProviderOperationTimeoutMs,
   resolveProviderHttpRequestConfig,
+  sanitizeConfiguredModelProviderRequest,
   type ProviderOperationTimeoutMs,
 } from "openclaw/plugin-sdk/provider-http";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
@@ -226,11 +227,11 @@ export function buildTogetherVideoGenerationProvider(): VideoGenerationProvider 
         timeoutMs: req.timeoutMs,
         label: "Together video generation",
       });
+      const providerConfig = req.cfg?.models?.providers?.together;
       const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
         resolveProviderHttpRequestConfig({
           baseUrl: resolveTogetherVideoBaseUrl(req),
           defaultBaseUrl: TOGETHER_VIDEO_BASE_URL,
-          allowPrivateNetwork: false,
           defaultHeaders: {
             Authorization: `Bearer ${auth.apiKey}`,
             "Content-Type": "application/json",
@@ -238,6 +239,7 @@ export function buildTogetherVideoGenerationProvider(): VideoGenerationProvider 
           provider: "together",
           capability: "video",
           transport: "http",
+          request: sanitizeConfiguredModelProviderRequest(providerConfig?.request),
         });
       const body: Record<string, unknown> = {
         model: normalizeOptionalString(req.model) ?? DEFAULT_TOGETHER_VIDEO_MODEL,

--- a/extensions/together/video-generation-provider.ts
+++ b/extensions/together/video-generation-provider.ts
@@ -7,7 +7,9 @@ import {
   assertOkOrThrowHttpError,
   createProviderOperationDeadline,
   createProviderOperationTimeoutResolver,
+  executeProviderOperationWithRetry,
   fetchProviderDownloadResponse,
+  fetchWithTimeoutGuarded,
   pollProviderOperationJson,
   postJsonRequest,
   readProviderJsonResponse,
@@ -37,6 +39,11 @@ const MAX_POLL_ATTEMPTS = 120;
 const TOGETHER_MIN_DURATION_SECONDS = 1;
 const TOGETHER_MAX_DURATION_SECONDS = 10;
 const DEFAULT_GENERATED_VIDEO_MAX_BYTES = 16 * 1024 * 1024;
+
+type TogetherVideoRequestPolicy = {
+  allowPrivateNetwork: boolean;
+  dispatcherPolicy?: Parameters<typeof postJsonRequest>[0]["dispatcherPolicy"];
+};
 
 type TogetherVideoResponse = {
   id?: string;
@@ -119,13 +126,15 @@ function resolveGeneratedVideoMaxBytes(req: VideoGenerationRequest): number {
   return DEFAULT_GENERATED_VIDEO_MAX_BYTES;
 }
 
-async function pollTogetherVideo(params: {
-  videoId: string;
-  headers: Headers;
-  timeoutMs?: number;
-  baseUrl: string;
-  fetchFn: typeof fetch;
-}): Promise<TogetherVideoResponse> {
+async function pollTogetherVideo(
+  params: {
+    videoId: string;
+    headers: Headers;
+    timeoutMs?: number;
+    baseUrl: string;
+    fetchFn: typeof fetch;
+  } & TogetherVideoRequestPolicy,
+): Promise<TogetherVideoResponse> {
   const deadline = createProviderOperationDeadline({
     timeoutMs: params.timeoutMs,
     label: `Together video generation task ${params.videoId}`,
@@ -140,6 +149,9 @@ async function pollTogetherVideo(params: {
     pollIntervalMs: POLL_INTERVAL_MS,
     requestFailedMessage: "Together video status request failed",
     timeoutMessage: `Together video generation task ${params.videoId} did not finish in time`,
+    allowPrivateNetwork: params.allowPrivateNetwork,
+    dispatcherPolicy: params.dispatcherPolicy,
+    auditContext: "together-video-status",
     isComplete: (payload) => payload.status === "completed",
     getFailureMessage: (payload) =>
       payload.status === "failed"
@@ -148,30 +160,87 @@ async function pollTogetherVideo(params: {
   });
 }
 
-async function downloadTogetherVideo(params: {
-  url: string;
-  timeoutMs?: ProviderOperationTimeoutMs;
-  fetchFn: typeof fetch;
-  maxBytes: number;
-}): Promise<GeneratedVideoAsset> {
-  const response = await fetchProviderDownloadResponse({
+async function fetchTogetherVideoDownload(
+  params: {
+    url: string;
+    init: RequestInit;
+    timeoutMs?: ProviderOperationTimeoutMs;
+    fetchFn: typeof fetch;
+  } & TogetherVideoRequestPolicy,
+) {
+  if (!params.allowPrivateNetwork && !params.dispatcherPolicy) {
+    const response = await fetchProviderDownloadResponse({
+      url: params.url,
+      init: params.init,
+      timeoutMs: params.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      fetchFn: params.fetchFn,
+      provider: "together",
+      requestFailedMessage: "Together generated video download failed",
+    });
+    return {
+      response,
+      release: async () => {},
+    };
+  }
+
+  return await executeProviderOperationWithRetry({
+    provider: "together",
+    stage: "download",
+    operation: async () => {
+      const result = await fetchWithTimeoutGuarded(
+        params.url,
+        params.init,
+        typeof params.timeoutMs === "function"
+          ? params.timeoutMs()
+          : (params.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+        params.fetchFn,
+        {
+          ...(params.allowPrivateNetwork ? { ssrfPolicy: { allowPrivateNetwork: true } } : {}),
+          ...(params.dispatcherPolicy ? { dispatcherPolicy: params.dispatcherPolicy } : {}),
+          auditContext: "together-video-download",
+        },
+      );
+      try {
+        await assertOkOrThrowHttpError(result.response, "Together generated video download failed");
+        return result;
+      } catch (error) {
+        await result.release();
+        throw error;
+      }
+    },
+  });
+}
+
+async function downloadTogetherVideo(
+  params: {
+    url: string;
+    timeoutMs?: ProviderOperationTimeoutMs;
+    fetchFn: typeof fetch;
+    maxBytes: number;
+  } & TogetherVideoRequestPolicy,
+): Promise<GeneratedVideoAsset> {
+  const { response, release } = await fetchTogetherVideoDownload({
     url: params.url,
     init: { method: "GET" },
-    timeoutMs: params.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    timeoutMs: params.timeoutMs,
     fetchFn: params.fetchFn,
-    provider: "together",
-    requestFailedMessage: "Together generated video download failed",
+    allowPrivateNetwork: params.allowPrivateNetwork,
+    dispatcherPolicy: params.dispatcherPolicy,
   });
-  const mimeType = normalizeOptionalString(response.headers.get("content-type")) ?? "video/mp4";
-  const buffer = await readResponseWithLimit(response, params.maxBytes, {
-    onOverflow: ({ maxBytes }) =>
-      new Error(`Together generated video download exceeds ${maxBytes} bytes`),
-  });
-  return {
-    buffer,
-    mimeType,
-    fileName: `video-1.${extensionForMime(mimeType)?.slice(1) ?? "mp4"}`,
-  };
+  try {
+    const mimeType = normalizeOptionalString(response.headers.get("content-type")) ?? "video/mp4";
+    const buffer = await readResponseWithLimit(response, params.maxBytes, {
+      onOverflow: ({ maxBytes }) =>
+        new Error(`Together generated video download exceeds ${maxBytes} bytes`),
+    });
+    return {
+      buffer,
+      mimeType,
+      fileName: `video-1.${extensionForMime(mimeType)?.slice(1) ?? "mp4"}`,
+    };
+  } finally {
+    await release();
+  }
 }
 
 export function buildTogetherVideoGenerationProvider(): VideoGenerationProvider {
@@ -303,6 +372,8 @@ export function buildTogetherVideoGenerationProvider(): VideoGenerationProvider 
           }),
           baseUrl,
           fetchFn,
+          allowPrivateNetwork,
+          dispatcherPolicy,
         });
         const videoUrl = extractTogetherVideoUrl(completed);
         if (!videoUrl) {
@@ -316,6 +387,8 @@ export function buildTogetherVideoGenerationProvider(): VideoGenerationProvider 
           }),
           fetchFn,
           maxBytes: resolveGeneratedVideoMaxBytes(req),
+          allowPrivateNetwork,
+          dispatcherPolicy,
         });
         return {
           videos: [video],


### PR DESCRIPTION
## What Problem This Solves

Together video generation previously ignored `models.providers.together.request` overrides (headers, allowPrivateNetwork, dispatcherPolicy). Users who configured a request policy for Together saw it applied to chat/completion providers but not to video generation, so private-network access, custom headers, and dispatcher routing were dropped on the floor.

## Why This Change Was Made

Mirror the pattern already used by `openai`, `pixverse`, `google` image generation, and Alix-007's recent DashScope/MiniMax/OpenRouter video request-policy PRs: resolve the configured transport policy once and carry it through every HTTP stage of the video operation.

## Changes

- `extensions/together/video-generation-provider.ts`
  - Import `sanitizeConfiguredModelProviderRequest`.
  - Read `req.cfg?.models?.providers?.together`.
  - Forward the sanitized request policy to `resolveProviderHttpRequestConfig`.
  - Remove the hard-coded `allowPrivateNetwork: false` so `request.allowPrivateNetwork` can take effect.
  - Pass the resolved `allowPrivateNetwork` and `dispatcherPolicy` into `pollTogetherVideo` and `downloadTogetherVideo`.
  - Use `pollProviderOperationJson` for status polling with guarded request options.
  - Use a local guarded-download helper (fallback to `fetchProviderDownloadResponse` when no guarded options are needed) so `allowPrivateNetwork` and `dispatcherPolicy` also reach the generated-video download.
- `extensions/together/video-generation-provider.test.ts`
  - Expand the regression test to assert that the configured policy reaches `postJsonRequest`, `pollProviderOperationJson`, and the guarded download path.

## Evidence

```bash
node scripts/run-vitest.mjs extensions/together/video-generation-provider.test.ts
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo
node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/together/video-generation-provider.ts extensions/together/video-generation-provider.test.ts
```

- Vitest: 9/9 passing.
- `tsgo` (source + test): no type errors.
- `oxlint`: clean.

Real behavior proof against a local Together-compatible endpoint, showing the configured `X-Together-Policy` header is sent and private-network access is allowed:

```
[proof] local Together-compatible endpoint at http://127.0.0.1:38321
[server] POST /videos
[server] Authorization: Bearer dummy-together-key
[server] X-Together-Policy: together-policy
[server] GET /videos/video-proof
[server] GET /video.mp4
[proof] generated video count: 1
[proof] video MIME type: video/mp4
[proof] done
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
