### PR TITLE
Fix Telegram durable partial final handling

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2899,7 +2899,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       try {
         await dispatcherOptions.deliver({ text: "visible final text" }, { kind: "final" });
       } catch (err) {
-        dispatcherOptions.onError?.(err, { kind: "final" });
+        await dispatcherOptions.onError?.(err, { kind: "final" });
       }
       return { queuedFinal: false };
     });
@@ -2925,7 +2925,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       try {
         await dispatcherOptions.deliver({ text: "undelivered final text" }, { kind: "final" });
       } catch (err) {
-        dispatcherOptions.onError?.(err, { kind: "final" });
+        await dispatcherOptions.onError?.(err, { kind: "final" });
       }
       return { queuedFinal: false };
     });

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2915,6 +2915,34 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("keeps no-send durable final failures retryable for spooled replay", async () => {
+    const durableError = new Error("telegram first chunk failed");
+    deliverInboundReplyWithMessageSendContext.mockResolvedValue({
+      status: "failed",
+      error: durableError,
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      try {
+        await dispatcherOptions.deliver({ text: "undelivered final text" }, { kind: "final" });
+      } catch (err) {
+        dispatcherOptions.onError?.(err, { kind: "final" });
+      }
+      return { queuedFinal: false };
+    });
+
+    const result = await dispatchWithContext({
+      context: createContext(),
+      retryDispatchErrors: true,
+      suppressFailureFallback: true,
+      streamMode: "off",
+    });
+
+    expect(result).toMatchObject({ kind: "failed-retryable" });
+    expect((result as { error?: unknown }).error).toBeInstanceOf(Error);
+    expect(durableError).not.toMatchObject({ sentBeforeError: true, visibleReplySent: true });
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("keeps tool progress visible after a partial-streamed intermediate block", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2888,6 +2888,33 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("does not fallback or retry after durable final delivery already showed partial output", async () => {
+    const durableError = new Error("telegram second chunk failed");
+    deliverInboundReplyWithMessageSendContext.mockResolvedValue({
+      status: "failed",
+      error: durableError,
+      sentBeforeError: true,
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      try {
+        await dispatcherOptions.deliver({ text: "visible final text" }, { kind: "final" });
+      } catch (err) {
+        dispatcherOptions.onError?.(err, { kind: "final" });
+      }
+      return { queuedFinal: false };
+    });
+
+    const result = await dispatchWithContext({
+      context: createContext(),
+      retryDispatchErrors: true,
+      streamMode: "off",
+    });
+
+    expect(result).toEqual({ kind: "completed" });
+    expect(durableError).toMatchObject({ sentBeforeError: true, visibleReplySent: true });
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("keeps tool progress visible after a partial-streamed intermediate block", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -164,6 +164,30 @@ const silentReplyDispatchLogger = createSubsystemLogger("telegram/silent-reply-d
 /** Minimum chars before sending first streaming message (improves push notification UX) */
 const DRAFT_MIN_INITIAL_CHARS = 30;
 
+function isVisibleDurableReplyFailure(error: unknown, sentBeforeError?: true): boolean {
+  return (
+    sentBeforeError === true ||
+    (typeof error === "object" &&
+      error !== null &&
+      !Array.isArray(error) &&
+      ((error as { sentBeforeError?: unknown }).sentBeforeError === true ||
+        (error as { visibleReplySent?: unknown }).visibleReplySent === true))
+  );
+}
+
+function markVisibleDurableReplyFailure(error: unknown): unknown {
+  // Partial durable final sends are visible to users; preserve that marker so
+  // dispatch state suppresses duplicate fallback/retry while still surfacing failure.
+  if (typeof error === "object" && error !== null && Object.isExtensible(error)) {
+    Object.assign(error, { sentBeforeError: true, visibleReplySent: true });
+    return error;
+  }
+
+  const visibleError = new Error("visible durable reply delivery failed", { cause: error });
+  Object.assign(visibleError, { sentBeforeError: true, visibleReplySent: true });
+  return visibleError;
+}
+
 type DraftPartialTextUpdate = {
   text: string;
   delta?: string;
@@ -1786,6 +1810,11 @@ export const dispatchTelegramMessage = async ({
           }),
         });
         if (durable.status === "failed") {
+          if (isVisibleDurableReplyFailure(durable.error, durable.sentBeforeError)) {
+            deliveryState.markDelivered();
+            markProgressFinalDelivered();
+            throw markVisibleDurableReplyFailure(durable.error);
+          }
           throw durable.error;
         }
         if (durable.status === "handled_visible") {


### PR DESCRIPTION
## What Problem This Solves

Telegram durable final delivery can return `status: "failed"` with `sentBeforeError: true` when the first chunk of a final reply was already visible but a later chunk failed. The Telegram dispatch path threw that error without preserving the visible-send state, so spooled replay/error handling could treat the turn as if no final answer was delivered and retry or send fallback text after the user had already seen part of the final reply.

## Why This Change Was Made

The durable delivery contract already marks partial sends with `sentBeforeError` / `visibleReplySent`. This change makes Telegram honor that contract in its custom durable-final path by marking the final answer as delivered before surfacing the error. Pure durable failures still use the existing failure path.

Regression coverage now exercises both sides of the state boundary: partial-visible durable failures complete without duplicate fallback/retry, while pure no-send durable failures remain retryable for spooled replay.

## User Impact

Users no longer receive duplicate fallback text or replayed Telegram turns after a durable final reply was partially visible. Real no-send durable failures still fail normally and remain retryable where appropriate.

## Evidence

- `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.test.ts` (173 tests passed)
- Fault-injected durable-send regression coverage:
  - partial-visible final failure (`sentBeforeError: true`) completes without fallback/retry and annotates visible-send metadata
  - pure no-send final failure remains `failed-retryable` with no fallback when spooled replay suppresses fallback
- `git diff --check -- extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/bot-message-dispatch.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean, no accepted/actionable findings)

Remote Testbox proof was not run from this checkout because the local Crabbox wrapper selected binary `0.18.0`, while `blacksmith-testbox` requires Crabbox `>=0.22.0`.
