### PR TITLE
Fix LINE webhook retryable acknowledgement

### DIFF
--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -42,9 +42,13 @@ openclaw plugins install ./path/to/local/line-plugin
 https://gateway-host/line/webhook
 ```
 
-The Gateway answers LINE's webhook verification (GET) and acknowledges signed
-inbound events (POST) immediately after signature and payload validation; agent
-processing continues asynchronously.
+The Gateway answers LINE's webhook verification (GET) immediately. For signed
+inbound events (POST), it returns success only after every event is either
+accepted by the durable reply lane or completes without an agent dispatch;
+agent processing then continues asynchronously. Enable
+[Webhook redelivery](https://developers.line.biz/en/docs/messaging-api/receiving-messages/#redelivery)
+in the LINE Developers Console so LINE retries a non-success response caused by
+an early validation, media, routing, or reply-lane admission failure.
 If you need a custom path, set `channels.line.webhookPath` or
 `channels.line.accounts.<id>.webhookPath` and update the URL accordingly.
 

--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -50,8 +50,9 @@ inbound events (POST), it returns success only after every event is either
 accepted by the durable reply lane or completes without an agent dispatch;
 agent processing then continues asynchronously. OpenClaw stops waiting after
 1.5 seconds so it can return a non-success response before LINE's 2-second
-request timeout; any already-started processing may still finish, and replay
-deduplication prevents the redelivery from running an accepted event twice. See LINE's
+request timeout. If that deadline expires before acceptance, OpenClaw aborts
+the pending dispatch and releases its replay claim so redelivery can retry;
+replay deduplication prevents an accepted event from running twice. See LINE's
 [Webhook redelivery documentation](https://developers.line.biz/en/docs/messaging-api/receiving-messages/#redelivery)
 for the upstream retry contract.
 If you need a custom path, set `channels.line.webhookPath` or

--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -36,7 +36,10 @@ openclaw plugins install ./path/to/local/line-plugin
 2. Create (or pick) a Provider and add a **Messaging API** channel.
 3. Copy the **Channel access token** and **Channel secret** from the channel settings.
 4. Enable **Use webhook** in the Messaging API settings.
-5. Set the webhook URL to your gateway endpoint (HTTPS required):
+5. Enable **Webhook redelivery**. LINE disables redelivery by default; when it
+   is enabled, LINE retries webhook requests that do not receive a `2xx`
+   response.
+6. Set the webhook URL to your gateway endpoint (HTTPS required):
 
 ```text
 https://gateway-host/line/webhook
@@ -45,10 +48,12 @@ https://gateway-host/line/webhook
 The Gateway answers LINE's webhook verification (GET) immediately. For signed
 inbound events (POST), it returns success only after every event is either
 accepted by the durable reply lane or completes without an agent dispatch;
-agent processing then continues asynchronously. Enable
-[Webhook redelivery](https://developers.line.biz/en/docs/messaging-api/receiving-messages/#redelivery)
-in the LINE Developers Console so LINE retries a non-success response caused by
-an early validation, media, routing, or reply-lane admission failure.
+agent processing then continues asynchronously. OpenClaw stops waiting after
+1.5 seconds so it can return a non-success response before LINE's 2-second
+request timeout; any already-started processing may still finish, and replay
+deduplication prevents the redelivery from running an accepted event twice. See LINE's
+[Webhook redelivery documentation](https://developers.line.biz/en/docs/messaging-api/receiving-messages/#redelivery)
+for the upstream retry contract.
 If you need a custom path, set `channels.line.webhookPath` or
 `channels.line.accounts.<id>.webhookPath` and update the URL accordingly.
 

--- a/extensions/line/runtime-api.ts
+++ b/extensions/line/runtime-api.ts
@@ -117,6 +117,10 @@ export type {
   ResolvedLineAccount,
 } from "./src/types.js";
 export { createLineNodeWebhookHandler, readLineWebhookRequestBody } from "./src/webhook-node.js";
+export type {
+  LineWebhookDispatchCallbacks,
+  LineWebhookDispatchHandler,
+} from "./src/webhook-ack.js";
 export {
   createLineWebhookMiddleware,
   type LineWebhookOptions,

--- a/extensions/line/runtime-api.ts
+++ b/extensions/line/runtime-api.ts
@@ -118,6 +118,7 @@ export type {
 } from "./src/types.js";
 export { createLineNodeWebhookHandler, readLineWebhookRequestBody } from "./src/webhook-node.js";
 export type {
+  LineWebhookAcceptanceDispatchHandler,
   LineWebhookDispatchCallbacks,
   LineWebhookDispatchHandler,
 } from "./src/webhook-ack.js";

--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -344,12 +344,17 @@ describe("handleLineWebhookEvents", () => {
       releaseProcessing = resolve;
     });
     const onEventAccepted = vi.fn();
-    const processMessage: LineWebhookContext["processMessage"] = vi.fn(async (message) => {
+    const processMessage = vi.fn<LineWebhookContext["processMessage"]>(async (message) => {
       await message.onEventAccepted?.();
       await processing;
     });
     const event = createTestMessageEvent({
-      message: { id: "m-accepted-before-settle", type: "text", text: "hello" },
+      message: {
+        id: "m-accepted-before-settle",
+        type: "text",
+        text: "hello",
+        quoteToken: "test-token-placeholder",
+      },
       source: { type: "group", groupId: "group-accepted", userId: "user-accepted" },
       webhookEventId: "evt-accepted-before-settle",
     });
@@ -377,19 +382,29 @@ describe("handleLineWebhookEvents", () => {
       releaseFirstProcessing = resolve;
     });
     const onEventAccepted = vi.fn();
-    const processMessage: LineWebhookContext["processMessage"] = vi.fn(async (message) => {
+    const processMessage = vi.fn<LineWebhookContext["processMessage"]>(async (message) => {
       await message.onEventAccepted?.();
       if (processMessage.mock.calls.length === 1) {
         await firstProcessing;
       }
     });
     const firstEvent = createTestMessageEvent({
-      message: { id: "m-batch-first", type: "text", text: "first" },
+      message: {
+        id: "m-batch-first",
+        type: "text",
+        text: "first",
+        quoteToken: "test-token-placeholder",
+      },
       source: { type: "group", groupId: "group-batch", userId: "user-batch" },
       webhookEventId: "evt-batch-first",
     });
     const secondEvent = createTestMessageEvent({
-      message: { id: "m-batch-second", type: "text", text: "second" },
+      message: {
+        id: "m-batch-second",
+        type: "text",
+        text: "second",
+        quoteToken: "test-token-placeholder",
+      },
       source: { type: "group", groupId: "group-batch-other", userId: "user-batch" },
       webhookEventId: "evt-batch-second",
     });
@@ -417,19 +432,29 @@ describe("handleLineWebhookEvents", () => {
       releaseFirstProcessing = resolve;
     });
     const onEventAccepted = vi.fn();
-    const processMessage: LineWebhookContext["processMessage"] = vi.fn(async (message) => {
+    const processMessage = vi.fn<LineWebhookContext["processMessage"]>(async (message) => {
       await message.onEventAccepted?.();
       if (processMessage.mock.calls.length === 1) {
         await firstProcessing;
       }
     });
     const firstEvent = createTestMessageEvent({
-      message: { id: "m-group-first", type: "text", text: "first" },
+      message: {
+        id: "m-group-first",
+        type: "text",
+        text: "first",
+        quoteToken: "test-token-placeholder",
+      },
       source: { type: "group", groupId: "group-serial", userId: "user-serial" },
       webhookEventId: "evt-group-first",
     });
     const secondEvent = createTestMessageEvent({
-      message: { id: "m-group-second", type: "text", text: "second" },
+      message: {
+        id: "m-group-second",
+        type: "text",
+        text: "second",
+        quoteToken: "test-token-placeholder",
+      },
       source: { type: "group", groupId: "group-serial", userId: "user-serial" },
       webhookEventId: "evt-group-second",
     });
@@ -454,6 +479,59 @@ describe("handleLineWebhookEvents", () => {
     expect(onEventAccepted.mock.calls.map(([event]) => event)).toEqual([firstEvent, secondEvent]);
   });
 
+  it("serializes direct events from the same user until earlier admission", async () => {
+    let allowFirstAdmission: (() => void) | undefined;
+    const firstAdmission = new Promise<void>((resolve) => {
+      allowFirstAdmission = resolve;
+    });
+    const onEventAccepted = vi.fn();
+    const processMessage = vi.fn<LineWebhookContext["processMessage"]>(async (message) => {
+      if (processMessage.mock.calls.length === 1) {
+        await firstAdmission;
+      }
+      await message.onEventAccepted?.();
+    });
+    const firstEvent = createTestMessageEvent({
+      message: {
+        id: "m-dm-first",
+        type: "text",
+        text: "first",
+        quoteToken: "test-token-placeholder",
+      },
+      source: { type: "user", userId: "user-serial" },
+      webhookEventId: "evt-dm-first",
+    });
+    const secondEvent = createTestMessageEvent({
+      message: {
+        id: "m-dm-second",
+        type: "text",
+        text: "second",
+        quoteToken: "test-token-placeholder",
+      },
+      source: { type: "user", userId: "user-serial" },
+      webhookEventId: "evt-dm-second",
+    });
+    const task = handleLineWebhookEvents(
+      [firstEvent, secondEvent],
+      createLineWebhookTestContext({
+        processMessage,
+        dmPolicy: "open",
+        onEventAccepted,
+      }),
+    );
+
+    await vi.waitFor(() => expect(processMessage).toHaveBeenCalledOnce());
+    expect(onEventAccepted).not.toHaveBeenCalled();
+    if (!allowFirstAdmission) {
+      throw new Error("Expected first LINE direct admission release callback");
+    }
+    allowFirstAdmission();
+    await task;
+
+    expect(processMessage).toHaveBeenCalledTimes(2);
+    expect(onEventAccepted.mock.calls.map(([event]) => event)).toEqual([firstEvent, secondEvent]);
+  });
+
   it("preserves later group history after an earlier turn is durably adopted", async () => {
     let releaseFirstProcessing: (() => void) | undefined;
     const firstProcessing = new Promise<void>((resolve) => {
@@ -462,7 +540,7 @@ describe("handleLineWebhookEvents", () => {
     const groupHistories = new Map<string, HistoryEntry[]>([
       ["group-history-ordered", [{ sender: "user:earlier", body: "earlier", timestamp: 1 }]],
     ]);
-    const processMessage: LineWebhookContext["processMessage"] = vi.fn(async (message) => {
+    const processMessage = vi.fn<LineWebhookContext["processMessage"]>(async (message) => {
       await message.onEventAccepted?.();
       await firstProcessing;
     });
@@ -477,7 +555,12 @@ describe("handleLineWebhookEvents", () => {
       webhookEventId: "evt-history-first",
     });
     const secondEvent = createTestMessageEvent({
-      message: { id: "m-history-second", type: "text", text: "second" },
+      message: {
+        id: "m-history-second",
+        type: "text",
+        text: "second",
+        quoteToken: "test-token-placeholder",
+      },
       source: { type: "group", groupId: "group-history-ordered", userId: "user-history" },
       webhookEventId: "evt-history-second",
     });
@@ -516,7 +599,7 @@ describe("handleLineWebhookEvents", () => {
       ["group-history-requests", [{ sender: "user:earlier", body: "earlier", timestamp: 1 }]],
     ]);
     const conversationAcceptanceTails = new Map<string, Promise<void>>();
-    const processMessage: LineWebhookContext["processMessage"] = vi.fn(async (message) => {
+    const processMessage = vi.fn<LineWebhookContext["processMessage"]>(async (message) => {
       await firstAdmission;
       await message.onEventAccepted?.();
       await firstProcessing;
@@ -532,7 +615,12 @@ describe("handleLineWebhookEvents", () => {
       webhookEventId: "evt-request-history-first",
     });
     const secondEvent = createTestMessageEvent({
-      message: { id: "m-request-history-second", type: "text", text: "second" },
+      message: {
+        id: "m-request-history-second",
+        type: "text",
+        text: "second",
+        quoteToken: "test-token-placeholder",
+      },
       source: { type: "group", groupId: "group-history-requests", userId: "user-history" },
       webhookEventId: "evt-request-history-second",
     });
@@ -566,6 +654,52 @@ describe("handleLineWebhookEvents", () => {
     }
     releaseFirstProcessing();
     await firstRequest;
+  });
+
+  it("blocks later same-group events when an earlier event fails before acceptance", async () => {
+    buildLineMessageContextMock.mockRejectedValueOnce(new Error("first admission failed"));
+    const processMessage = vi.fn();
+    const onEventAccepted = vi.fn();
+    const firstEvent = createTestMessageEvent({
+      message: {
+        id: "m-ordered-failure-first",
+        type: "text",
+        text: "first",
+        quoteToken: "test-token-placeholder",
+      },
+      source: { type: "group", groupId: "group-ordered-failure", userId: "user-order" },
+      webhookEventId: "evt-ordered-failure-first",
+    });
+    const secondEvent = createTestMessageEvent({
+      message: {
+        id: "m-ordered-failure-second",
+        type: "text",
+        text: "second",
+        quoteToken: "test-token-placeholder",
+      },
+      source: { type: "group", groupId: "group-ordered-failure", userId: "user-order" },
+      webhookEventId: "evt-ordered-failure-second",
+    });
+    const context = createLineWebhookTestContext({
+      processMessage,
+      groupPolicy: "open",
+      requireMention: false,
+      onEventAccepted,
+      replayCache: createLineWebhookReplayCache(),
+      conversationAcceptanceTails: new Map(),
+    });
+
+    await expect(handleLineWebhookEvents([firstEvent, secondEvent], context)).rejects.toThrow(
+      "first admission failed",
+    );
+    expect(buildLineMessageContextMock).toHaveBeenCalledOnce();
+    expect(processMessage).not.toHaveBeenCalled();
+    expect(onEventAccepted).not.toHaveBeenCalled();
+
+    await handleLineWebhookEvents([firstEvent, secondEvent], context);
+    expect(buildLineMessageContextMock).toHaveBeenCalledTimes(3);
+    expect(processMessage).toHaveBeenCalledTimes(2);
+    expect(onEventAccepted.mock.calls.map(([event]) => event)).toEqual([firstEvent, secondEvent]);
   });
 
   beforeEach(() => {
@@ -1003,37 +1137,13 @@ describe("handleLineWebhookEvents", () => {
     expect(processMessage).toHaveBeenCalledTimes(1);
   });
 
-  it("commits in-flight failures so concurrent duplicates do not retry", async () => {
-    let rejectFirst: ((err: Error) => void) | undefined;
-    const firstDone = new Promise<void>((_, reject) => {
-      rejectFirst = reject;
-    });
-    const processMessage = vi.fn(async () => {
-      await firstDone;
-    });
-    const event = createReplayMessageEvent({
-      messageId: "m-inflight-fail",
-      groupId: "group-inflight",
-      userId: "user-inflight",
-      webhookEventId: "evt-inflight-fail-1",
-      isRedelivery: true,
-    });
-    const { firstRun, secondRun } = await startInflightReplayDuplicate({ event, processMessage });
-    const firstFailure = expect(firstRun).rejects.toThrow("transient inflight failure");
-    rejectFirst?.(new Error("transient inflight failure"));
-
-    await firstFailure;
-    await expect(secondRun).resolves.toBeUndefined();
-    expect(processMessage).toHaveBeenCalledTimes(1);
-  });
-
   it("acknowledges an in-flight redelivery after durable adoption", async () => {
     let releaseFirst: (() => void) | undefined;
     const firstDone = new Promise<void>((resolve) => {
       releaseFirst = resolve;
     });
     const onEventAccepted = vi.fn();
-    const processMessage: LineWebhookContext["processMessage"] = vi.fn(async (message) => {
+    const processMessage = vi.fn<LineWebhookContext["processMessage"]>(async (message) => {
       await message.onEventAccepted?.();
       await firstDone;
     });
@@ -1065,7 +1175,7 @@ describe("handleLineWebhookEvents", () => {
     await firstRun;
   });
 
-  it("mirrors in-flight retryable replay failures so concurrent duplicates also fail", async () => {
+  it("mirrors in-flight pre-acceptance failures so concurrent duplicates also fail", async () => {
     let rejectFirst: ((err: Error) => void) | undefined;
     const firstDone = new Promise<void>((_, reject) => {
       rejectFirst = reject;
@@ -1083,10 +1193,42 @@ describe("handleLineWebhookEvents", () => {
     const { firstRun, secondRun } = await startInflightReplayDuplicate({ event, processMessage });
     const firstFailure = expect(firstRun).rejects.toThrow("transient inflight failure");
     const secondFailure = expect(secondRun).rejects.toThrow("transient inflight failure");
-    rejectFirst?.(new LineRetryableWebhookError("transient inflight failure"));
+    rejectFirst?.(new Error("transient inflight failure"));
 
     await Promise.all([firstFailure, secondFailure]);
     expect(processMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the replay claim when the acceptance callback rejects", async () => {
+    const onEventAccepted = vi
+      .fn<(event: webhook.Event) => void | Promise<void>>()
+      .mockRejectedValueOnce(new Error("acceptance callback failed"))
+      .mockResolvedValueOnce(undefined);
+    const processMessage = vi.fn<LineWebhookContext["processMessage"]>(async (message) => {
+      await message.onEventAccepted?.();
+    });
+    const event = createReplayMessageEvent({
+      messageId: "m-acceptance-callback-failure",
+      groupId: "group-acceptance-callback-failure",
+      userId: "user-acceptance-callback-failure",
+      webhookEventId: "evt-acceptance-callback-failure",
+      isRedelivery: true,
+    });
+    const context = createLineWebhookTestContext({
+      processMessage,
+      groupPolicy: "open",
+      requireMention: false,
+      onEventAccepted,
+      replayCache: createLineWebhookReplayCache(),
+    });
+
+    await expect(handleLineWebhookEvents([event], context)).rejects.toThrow(
+      "acceptance callback failed",
+    );
+    await handleLineWebhookEvents([event], context);
+
+    expect(processMessage).toHaveBeenCalledTimes(2);
+    expect(onEventAccepted).toHaveBeenCalledTimes(2);
   });
 
   it("deduplicates redeliveries by LINE message id when webhookEventId changes", async () => {
@@ -1390,8 +1532,8 @@ describe("handleLineWebhookEvents", () => {
       replayCache: createLineWebhookReplayCache(),
     });
 
-    await expect(handleLineWebhookEvents([event], context)).rejects.toBeInstanceOf(
-      LineRetryableWebhookError,
+    await expect(handleLineWebhookEvents([event], context)).rejects.toThrow(
+      "failed to download media for image-failed-1",
     );
     expect(buildLineMessageContextMock).not.toHaveBeenCalled();
     expect(processMessage).not.toHaveBeenCalled();
@@ -1414,7 +1556,7 @@ describe("handleLineWebhookEvents", () => {
 
   it("retries ordinary pre-acceptance failures instead of committing their replay claim", async () => {
     buildLineMessageContextMock.mockRejectedValueOnce(new Error("temporary context failure"));
-    const processMessage: LineWebhookContext["processMessage"] = vi.fn(async (message) => {
+    const processMessage = vi.fn<LineWebhookContext["processMessage"]>(async (message) => {
       await message.onEventAccepted?.();
     });
     const onEventAccepted = vi.fn();
@@ -1445,6 +1587,7 @@ describe("handleLineWebhookEvents", () => {
         id: "image-too-large-1",
         type: "image",
         contentProvider: { type: "line" },
+        quoteToken: "test-token-placeholder",
       },
       source: { type: "user", userId: "user-image-too-large" },
       webhookEventId: "evt-image-too-large",

--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -1412,6 +1412,31 @@ describe("handleLineWebhookEvents", () => {
     expect(onEventAccepted).toHaveBeenCalledWith(event);
   });
 
+  it("retries ordinary pre-acceptance failures instead of committing their replay claim", async () => {
+    buildLineMessageContextMock.mockRejectedValueOnce(new Error("temporary context failure"));
+    const processMessage: LineWebhookContext["processMessage"] = vi.fn(async (message) => {
+      await message.onEventAccepted?.();
+    });
+    const onEventAccepted = vi.fn();
+    const event = createReplayMessageEvent({
+      messageId: "ordinary-pre-acceptance-failure",
+      groupId: "ordinary-pre-acceptance-group",
+      userId: "ordinary-pre-acceptance-user",
+      webhookEventId: "ordinary-pre-acceptance-event",
+      isRedelivery: true,
+    });
+    const context = createOpenGroupReplayContext(processMessage, createLineWebhookReplayCache());
+    context.onEventAccepted = onEventAccepted;
+
+    await expect(handleLineWebhookEvents([event], context)).rejects.toThrow(
+      "temporary context failure",
+    );
+    await handleLineWebhookEvents([event], context);
+
+    expect(processMessage).toHaveBeenCalledOnce();
+    expect(onEventAccepted).toHaveBeenCalledWith(event);
+  });
+
   it("keeps configured media-size-limit events processable as attachment unavailable", async () => {
     downloadLineMediaMock.mockRejectedValueOnce(new Error("Media exceeds configured limit"));
     const processMessage = vi.fn();
@@ -1484,7 +1509,7 @@ describe("handleLineWebhookEvents", () => {
     expect(processMessage).not.toHaveBeenCalled();
   });
 
-  it("keeps replay cache committed after a non-retryable event failure", async () => {
+  it("reopens replay after an ordinary event failure before durable acceptance", async () => {
     const processMessage = vi
       .fn()
       .mockRejectedValueOnce(new Error("transient failure"))
@@ -1501,8 +1526,8 @@ describe("handleLineWebhookEvents", () => {
     await expect(handleLineWebhookEvents([event], context)).rejects.toThrow("transient failure");
     await handleLineWebhookEvents([event], context);
 
-    expect(buildLineMessageContextMock).toHaveBeenCalledTimes(1);
-    expect(processMessage).toHaveBeenCalledTimes(1);
+    expect(buildLineMessageContextMock).toHaveBeenCalledTimes(2);
+    expect(processMessage).toHaveBeenCalledTimes(2);
     expect(context.runtime.error).toHaveBeenCalledWith(
       "line: event handler failed: Error: transient failure",
     );

--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -226,6 +226,7 @@ function createLineWebhookTestContext(params: {
   groupAllowFrom?: LineAccountConfig["groupAllowFrom"];
   requireMention?: boolean;
   groupHistories?: Map<string, HistoryEntry[]>;
+  conversationAcceptanceTails?: Map<string, Promise<void>>;
   onEventAccepted?: (event: webhook.Event) => void | Promise<void>;
   replayCache?: ReturnType<typeof createLineWebhookReplayCache>;
   accessGroups?: Record<string, { type: "message.senders"; members: Record<string, string[]> }>;
@@ -260,6 +261,9 @@ function createLineWebhookTestContext(params: {
     processMessage: params.processMessage,
     ...(params.onEventAccepted ? { onEventAccepted: params.onEventAccepted } : {}),
     ...(params.groupHistories ? { groupHistories: params.groupHistories } : {}),
+    ...(params.conversationAcceptanceTails
+      ? { conversationAcceptanceTails: params.conversationAcceptanceTails }
+      : {}),
     ...(params.replayCache ? { replayCache: params.replayCache } : {}),
   };
 }
@@ -407,7 +411,7 @@ describe("handleLineWebhookEvents", () => {
     await task;
   });
 
-  it("serializes same-group events until earlier processing settles", async () => {
+  it("admits same-group events before earlier processing settles", async () => {
     let releaseFirstProcessing: (() => void) | undefined;
     const firstProcessing = new Promise<void>((resolve) => {
       releaseFirstProcessing = resolve;
@@ -439,8 +443,8 @@ describe("handleLineWebhookEvents", () => {
       }),
     );
 
-    await vi.waitFor(() => expect(onEventAccepted).toHaveBeenCalledOnce());
-    expect(processMessage).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(onEventAccepted).toHaveBeenCalledTimes(2));
+    expect(processMessage).toHaveBeenCalledTimes(2);
     if (!releaseFirstProcessing) {
       throw new Error("Expected first LINE processing release callback");
     }
@@ -450,47 +454,118 @@ describe("handleLineWebhookEvents", () => {
     expect(onEventAccepted.mock.calls.map(([event]) => event)).toEqual([firstEvent, secondEvent]);
   });
 
-  it("preserves callback order until each event reaches reply-lane admission", async () => {
-    let releaseFirstAdmission: (() => void) | undefined;
-    const firstAdmission = new Promise<void>((resolve) => {
-      releaseFirstAdmission = resolve;
+  it("preserves later group history after an earlier turn is durably adopted", async () => {
+    let releaseFirstProcessing: (() => void) | undefined;
+    const firstProcessing = new Promise<void>((resolve) => {
+      releaseFirstProcessing = resolve;
     });
-    const onEventAccepted = vi.fn();
+    const groupHistories = new Map<string, HistoryEntry[]>([
+      ["group-history-ordered", [{ sender: "user:earlier", body: "earlier", timestamp: 1 }]],
+    ]);
     const processMessage: LineWebhookContext["processMessage"] = vi.fn(async (message) => {
-      if (processMessage.mock.calls.length === 1) {
-        await firstAdmission;
-      }
       await message.onEventAccepted?.();
+      await firstProcessing;
     });
     const firstEvent = createTestMessageEvent({
-      message: { id: "m-ordered-first", type: "text", text: "first" },
-      source: { type: "group", groupId: "group-ordered", userId: "user-ordered" },
-      webhookEventId: "evt-ordered-first",
+      message: {
+        id: "m-history-first",
+        type: "text",
+        text: "first",
+        mention: { mentionees: [{ isSelf: true }] },
+      } as MessageEvent["message"],
+      source: { type: "group", groupId: "group-history-ordered", userId: "user-history" },
+      webhookEventId: "evt-history-first",
     });
     const secondEvent = createTestMessageEvent({
-      message: { id: "m-ordered-second", type: "text", text: "second" },
-      source: { type: "group", groupId: "group-ordered", userId: "user-ordered" },
-      webhookEventId: "evt-ordered-second",
+      message: { id: "m-history-second", type: "text", text: "second" },
+      source: { type: "group", groupId: "group-history-ordered", userId: "user-history" },
+      webhookEventId: "evt-history-second",
     });
     const task = handleLineWebhookEvents(
       [firstEvent, secondEvent],
       createLineWebhookTestContext({
         processMessage,
         groupPolicy: "open",
-        requireMention: false,
-        onEventAccepted,
+        requireMention: true,
+        groupHistories,
       }),
     );
 
-    await vi.waitFor(() => expect(processMessage).toHaveBeenCalledOnce());
-    expect(onEventAccepted).not.toHaveBeenCalled();
-    if (!releaseFirstAdmission) {
-      throw new Error("Expected first LINE event admission release callback");
+    await vi.waitFor(() => {
+      expect(groupHistories.get("group-history-ordered")).toEqual([
+        expect.objectContaining({ sender: "user:user-history", body: "second" }),
+      ]);
+    });
+    if (!releaseFirstProcessing) {
+      throw new Error("Expected first LINE processing release callback");
     }
-    releaseFirstAdmission();
+    releaseFirstProcessing();
     await task;
+  });
 
-    expect(onEventAccepted.mock.calls.map(([event]) => event)).toEqual([firstEvent, secondEvent]);
+  it("orders group-history mutations across concurrent webhook requests", async () => {
+    let allowFirstAdmission: (() => void) | undefined;
+    const firstAdmission = new Promise<void>((resolve) => {
+      allowFirstAdmission = resolve;
+    });
+    let releaseFirstProcessing: (() => void) | undefined;
+    const firstProcessing = new Promise<void>((resolve) => {
+      releaseFirstProcessing = resolve;
+    });
+    const groupHistories = new Map<string, HistoryEntry[]>([
+      ["group-history-requests", [{ sender: "user:earlier", body: "earlier", timestamp: 1 }]],
+    ]);
+    const conversationAcceptanceTails = new Map<string, Promise<void>>();
+    const processMessage: LineWebhookContext["processMessage"] = vi.fn(async (message) => {
+      await firstAdmission;
+      await message.onEventAccepted?.();
+      await firstProcessing;
+    });
+    const firstEvent = createTestMessageEvent({
+      message: {
+        id: "m-request-history-first",
+        type: "text",
+        text: "first",
+        mention: { mentionees: [{ isSelf: true }] },
+      } as MessageEvent["message"],
+      source: { type: "group", groupId: "group-history-requests", userId: "user-history" },
+      webhookEventId: "evt-request-history-first",
+    });
+    const secondEvent = createTestMessageEvent({
+      message: { id: "m-request-history-second", type: "text", text: "second" },
+      source: { type: "group", groupId: "group-history-requests", userId: "user-history" },
+      webhookEventId: "evt-request-history-second",
+    });
+    const context = createLineWebhookTestContext({
+      processMessage,
+      groupPolicy: "open",
+      requireMention: true,
+      groupHistories,
+      conversationAcceptanceTails,
+    });
+
+    const firstRequest = handleLineWebhookEvents([firstEvent], context);
+    await vi.waitFor(() => expect(processMessage).toHaveBeenCalledOnce());
+    const secondRequest = handleLineWebhookEvents([secondEvent], context);
+    await Promise.resolve();
+    expect(groupHistories.get("group-history-requests")).toEqual([
+      expect.objectContaining({ sender: "user:earlier", body: "earlier" }),
+    ]);
+
+    if (!allowFirstAdmission) {
+      throw new Error("Expected first LINE admission release callback");
+    }
+    allowFirstAdmission();
+    await secondRequest;
+    expect(groupHistories.get("group-history-requests")).toEqual([
+      expect.objectContaining({ sender: "user:user-history", body: "second" }),
+    ]);
+
+    if (!releaseFirstProcessing) {
+      throw new Error("Expected first LINE processing release callback");
+    }
+    releaseFirstProcessing();
+    await firstRequest;
   });
 
   beforeEach(() => {

--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -228,6 +228,7 @@ function createLineWebhookTestContext(params: {
   groupHistories?: Map<string, HistoryEntry[]>;
   conversationAcceptanceTails?: Map<string, Promise<void>>;
   onEventAccepted?: (event: webhook.Event) => void | Promise<void>;
+  abortSignal?: AbortSignal;
   replayCache?: ReturnType<typeof createLineWebhookReplayCache>;
   accessGroups?: Record<string, { type: "message.senders"; members: Record<string, string[]> }>;
 }): Parameters<typeof handleLineWebhookEvents>[1] {
@@ -260,6 +261,7 @@ function createLineWebhookTestContext(params: {
     mediaMaxBytes: 1,
     processMessage: params.processMessage,
     ...(params.onEventAccepted ? { onEventAccepted: params.onEventAccepted } : {}),
+    ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
     ...(params.groupHistories ? { groupHistories: params.groupHistories } : {}),
     ...(params.conversationAcceptanceTails
       ? { conversationAcceptanceTails: params.conversationAcceptanceTails }
@@ -1511,8 +1513,8 @@ describe("handleLineWebhookEvents", () => {
     expect(processMessage).toHaveBeenCalledTimes(1);
   });
 
-  it("retries media materialization failures before reply-lane acceptance", async () => {
-    downloadLineMediaMock.mockRejectedValueOnce(new Error("expired content"));
+  it("retries transient media materialization failures before reply-lane acceptance", async () => {
+    downloadLineMediaMock.mockRejectedValueOnce(new Error("connection reset"));
     const processMessage = vi.fn();
     const onEventAccepted = vi.fn();
     const event = createTestMessageEvent({
@@ -1604,6 +1606,35 @@ describe("handleLineWebhookEvents", () => {
     expect(processMessage).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps permanent LINE media failures processable as attachment unavailable", async () => {
+    downloadLineMediaMock.mockRejectedValueOnce({
+      name: "HTTPFetchError",
+      status: 404,
+      statusText: "Not Found",
+    });
+    const processMessage = vi.fn();
+    const event = createTestMessageEvent({
+      message: {
+        id: "image-expired-1",
+        type: "image",
+        contentProvider: { type: "line" },
+        quoteToken: "test-token-placeholder",
+      },
+      source: { type: "user", userId: "user-image-expired" },
+      webhookEventId: "evt-image-expired",
+    });
+
+    await handleLineWebhookEvents(
+      [event],
+      createLineWebhookTestContext({ processMessage, dmPolicy: "open" }),
+    );
+
+    expect(buildLineMessageContextMock).toHaveBeenCalledWith(
+      expect.objectContaining({ allMedia: [], mediaUnavailable: true }),
+    );
+    expect(processMessage).toHaveBeenCalledTimes(1);
+  });
+
   it("allows non-text group messages through when requireMention is set (cannot detect mention)", async () => {
     // Image message -- LINE only carries mention metadata on text messages.
     downloadLineMediaMock.mockResolvedValueOnce({
@@ -1674,6 +1705,52 @@ describe("handleLineWebhookEvents", () => {
     expect(context.runtime.error).toHaveBeenCalledWith(
       "line: event handler failed: Error: transient failure",
     );
+  });
+
+  it("releases replay ownership when webhook acceptance is aborted", async () => {
+    let releaseFirstProcessing: (() => void) | undefined;
+    const firstProcessing = new Promise<void>((resolve) => {
+      releaseFirstProcessing = resolve;
+    });
+    const processMessage = vi.fn<LineWebhookContext["processMessage"]>(async (message) => {
+      if (processMessage.mock.calls.length === 1) {
+        await firstProcessing;
+      }
+      await message.onEventAccepted?.();
+    });
+    const event = createReplayMessageEvent({
+      messageId: "m-aborted-claim",
+      groupId: "group-aborted-claim",
+      userId: "user-aborted-claim",
+      webhookEventId: "evt-aborted-claim",
+      isRedelivery: true,
+    });
+    const replayCache = createLineWebhookReplayCache();
+    const abortController = new AbortController();
+    const firstContext = createOpenGroupReplayContext(processMessage, replayCache);
+    firstContext.abortSignal = abortController.signal;
+    const firstRequest = handleLineWebhookEvents([event], firstContext);
+
+    await vi.waitFor(() => expect(processMessage).toHaveBeenCalledOnce());
+    abortController.abort(new Error("webhook deadline elapsed"));
+    await expect(firstRequest).rejects.toThrow("webhook deadline elapsed");
+
+    const retryContext = createOpenGroupReplayContext(processMessage, replayCache);
+    await handleLineWebhookEvents([event], retryContext);
+    expect(processMessage).toHaveBeenCalledTimes(2);
+
+    if (!releaseFirstProcessing) {
+      throw new Error("Expected aborted LINE processing release callback");
+    }
+    releaseFirstProcessing();
+    await vi.waitFor(() =>
+      expect(firstContext.runtime.error).toHaveBeenCalledWith(
+        expect.stringContaining("webhook deadline elapsed"),
+      ),
+    );
+
+    await handleLineWebhookEvents([event], retryContext);
+    expect(processMessage).toHaveBeenCalledTimes(2);
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -226,6 +226,7 @@ function createLineWebhookTestContext(params: {
   groupAllowFrom?: LineAccountConfig["groupAllowFrom"];
   requireMention?: boolean;
   groupHistories?: Map<string, HistoryEntry[]>;
+  onEventAccepted?: (event: webhook.Event) => void | Promise<void>;
   replayCache?: ReturnType<typeof createLineWebhookReplayCache>;
   accessGroups?: Record<string, { type: "message.senders"; members: Record<string, string[]> }>;
 }): Parameters<typeof handleLineWebhookEvents>[1] {
@@ -257,6 +258,7 @@ function createLineWebhookTestContext(params: {
     runtime: createRuntime(),
     mediaMaxBytes: 1,
     processMessage: params.processMessage,
+    ...(params.onEventAccepted ? { onEventAccepted: params.onEventAccepted } : {}),
     ...(params.groupHistories ? { groupHistories: params.groupHistories } : {}),
     ...(params.replayCache ? { replayCache: params.replayCache } : {}),
   };
@@ -330,6 +332,165 @@ describe("handleLineWebhookEvents", () => {
     vi.doUnmock("./send.js");
     vi.doUnmock("./bot-message-context.js");
     vi.resetModules();
+  });
+
+  it("signals reply-lane acceptance before message processing settles", async () => {
+    let releaseProcessing: (() => void) | undefined;
+    const processing = new Promise<void>((resolve) => {
+      releaseProcessing = resolve;
+    });
+    const onEventAccepted = vi.fn();
+    const processMessage: LineWebhookContext["processMessage"] = vi.fn(async (message) => {
+      await message.onEventAccepted?.();
+      await processing;
+    });
+    const event = createTestMessageEvent({
+      message: { id: "m-accepted-before-settle", type: "text", text: "hello" },
+      source: { type: "group", groupId: "group-accepted", userId: "user-accepted" },
+      webhookEventId: "evt-accepted-before-settle",
+    });
+    const task = handleLineWebhookEvents(
+      [event],
+      createLineWebhookTestContext({
+        processMessage,
+        groupPolicy: "open",
+        requireMention: false,
+        onEventAccepted,
+      }),
+    );
+
+    await vi.waitFor(() => expect(onEventAccepted).toHaveBeenCalledOnce());
+    if (!releaseProcessing) {
+      throw new Error("Expected LINE message processing release callback");
+    }
+    releaseProcessing();
+    await task;
+  });
+
+  it("admits independent callback events before earlier processing settles", async () => {
+    let releaseFirstProcessing: (() => void) | undefined;
+    const firstProcessing = new Promise<void>((resolve) => {
+      releaseFirstProcessing = resolve;
+    });
+    const onEventAccepted = vi.fn();
+    const processMessage: LineWebhookContext["processMessage"] = vi.fn(async (message) => {
+      await message.onEventAccepted?.();
+      if (processMessage.mock.calls.length === 1) {
+        await firstProcessing;
+      }
+    });
+    const firstEvent = createTestMessageEvent({
+      message: { id: "m-batch-first", type: "text", text: "first" },
+      source: { type: "group", groupId: "group-batch", userId: "user-batch" },
+      webhookEventId: "evt-batch-first",
+    });
+    const secondEvent = createTestMessageEvent({
+      message: { id: "m-batch-second", type: "text", text: "second" },
+      source: { type: "group", groupId: "group-batch-other", userId: "user-batch" },
+      webhookEventId: "evt-batch-second",
+    });
+    const task = handleLineWebhookEvents(
+      [firstEvent, secondEvent],
+      createLineWebhookTestContext({
+        processMessage,
+        groupPolicy: "open",
+        requireMention: false,
+        onEventAccepted,
+      }),
+    );
+
+    await vi.waitFor(() => expect(onEventAccepted).toHaveBeenCalledTimes(2));
+    if (!releaseFirstProcessing) {
+      throw new Error("Expected first LINE message processing release callback");
+    }
+    releaseFirstProcessing();
+    await task;
+  });
+
+  it("serializes same-group events until earlier processing settles", async () => {
+    let releaseFirstProcessing: (() => void) | undefined;
+    const firstProcessing = new Promise<void>((resolve) => {
+      releaseFirstProcessing = resolve;
+    });
+    const onEventAccepted = vi.fn();
+    const processMessage: LineWebhookContext["processMessage"] = vi.fn(async (message) => {
+      await message.onEventAccepted?.();
+      if (processMessage.mock.calls.length === 1) {
+        await firstProcessing;
+      }
+    });
+    const firstEvent = createTestMessageEvent({
+      message: { id: "m-group-first", type: "text", text: "first" },
+      source: { type: "group", groupId: "group-serial", userId: "user-serial" },
+      webhookEventId: "evt-group-first",
+    });
+    const secondEvent = createTestMessageEvent({
+      message: { id: "m-group-second", type: "text", text: "second" },
+      source: { type: "group", groupId: "group-serial", userId: "user-serial" },
+      webhookEventId: "evt-group-second",
+    });
+    const task = handleLineWebhookEvents(
+      [firstEvent, secondEvent],
+      createLineWebhookTestContext({
+        processMessage,
+        groupPolicy: "open",
+        requireMention: false,
+        onEventAccepted,
+      }),
+    );
+
+    await vi.waitFor(() => expect(onEventAccepted).toHaveBeenCalledOnce());
+    expect(processMessage).toHaveBeenCalledOnce();
+    if (!releaseFirstProcessing) {
+      throw new Error("Expected first LINE processing release callback");
+    }
+    releaseFirstProcessing();
+    await task;
+
+    expect(onEventAccepted.mock.calls.map(([event]) => event)).toEqual([firstEvent, secondEvent]);
+  });
+
+  it("preserves callback order until each event reaches reply-lane admission", async () => {
+    let releaseFirstAdmission: (() => void) | undefined;
+    const firstAdmission = new Promise<void>((resolve) => {
+      releaseFirstAdmission = resolve;
+    });
+    const onEventAccepted = vi.fn();
+    const processMessage: LineWebhookContext["processMessage"] = vi.fn(async (message) => {
+      if (processMessage.mock.calls.length === 1) {
+        await firstAdmission;
+      }
+      await message.onEventAccepted?.();
+    });
+    const firstEvent = createTestMessageEvent({
+      message: { id: "m-ordered-first", type: "text", text: "first" },
+      source: { type: "group", groupId: "group-ordered", userId: "user-ordered" },
+      webhookEventId: "evt-ordered-first",
+    });
+    const secondEvent = createTestMessageEvent({
+      message: { id: "m-ordered-second", type: "text", text: "second" },
+      source: { type: "group", groupId: "group-ordered", userId: "user-ordered" },
+      webhookEventId: "evt-ordered-second",
+    });
+    const task = handleLineWebhookEvents(
+      [firstEvent, secondEvent],
+      createLineWebhookTestContext({
+        processMessage,
+        groupPolicy: "open",
+        requireMention: false,
+        onEventAccepted,
+      }),
+    );
+
+    await vi.waitFor(() => expect(processMessage).toHaveBeenCalledOnce());
+    expect(onEventAccepted).not.toHaveBeenCalled();
+    if (!releaseFirstAdmission) {
+      throw new Error("Expected first LINE event admission release callback");
+    }
+    releaseFirstAdmission();
+    await task;
+
+    expect(onEventAccepted.mock.calls.map(([event]) => event)).toEqual([firstEvent, secondEvent]);
   });
 
   beforeEach(() => {
@@ -791,6 +952,68 @@ describe("handleLineWebhookEvents", () => {
     expect(processMessage).toHaveBeenCalledTimes(1);
   });
 
+  it("acknowledges an in-flight redelivery after durable adoption", async () => {
+    let releaseFirst: (() => void) | undefined;
+    const firstDone = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const onEventAccepted = vi.fn();
+    const processMessage: LineWebhookContext["processMessage"] = vi.fn(async (message) => {
+      await message.onEventAccepted?.();
+      await firstDone;
+    });
+    const event = createReplayMessageEvent({
+      messageId: "m-inflight-adopted",
+      groupId: "group-inflight",
+      userId: "user-inflight",
+      webhookEventId: "evt-inflight-adopted",
+      isRedelivery: true,
+    });
+    const context = createLineWebhookTestContext({
+      processMessage,
+      groupPolicy: "open",
+      requireMention: false,
+      onEventAccepted,
+      replayCache: createLineWebhookReplayCache(),
+    });
+
+    const firstRun = handleLineWebhookEvents([event], context);
+    await vi.waitFor(() => expect(onEventAccepted).toHaveBeenCalledOnce());
+    await handleLineWebhookEvents([event], context);
+
+    expect(onEventAccepted).toHaveBeenCalledTimes(2);
+    expect(processMessage).toHaveBeenCalledTimes(1);
+    if (!releaseFirst) {
+      throw new Error("Expected first LINE replay processing release callback");
+    }
+    releaseFirst();
+    await firstRun;
+  });
+
+  it("mirrors in-flight retryable replay failures so concurrent duplicates also fail", async () => {
+    let rejectFirst: ((err: Error) => void) | undefined;
+    const firstDone = new Promise<void>((_, reject) => {
+      rejectFirst = reject;
+    });
+    const processMessage = vi.fn(async () => {
+      await firstDone;
+    });
+    const event = createReplayMessageEvent({
+      messageId: "m-inflight-fail",
+      groupId: "group-inflight",
+      userId: "user-inflight",
+      webhookEventId: "evt-inflight-fail-1",
+      isRedelivery: true,
+    });
+    const { firstRun, secondRun } = await startInflightReplayDuplicate({ event, processMessage });
+    const firstFailure = expect(firstRun).rejects.toThrow("transient inflight failure");
+    const secondFailure = expect(secondRun).rejects.toThrow("transient inflight failure");
+    rejectFirst?.(new LineRetryableWebhookError("transient inflight failure"));
+
+    await Promise.all([firstFailure, secondFailure]);
+    expect(processMessage).toHaveBeenCalledTimes(1);
+  });
+
   it("deduplicates redeliveries by LINE message id when webhookEventId changes", async () => {
     const processMessage = vi.fn();
     const event = {
@@ -1071,9 +1294,10 @@ describe("handleLineWebhookEvents", () => {
     expect(processMessage).toHaveBeenCalledTimes(1);
   });
 
-  it("reports failed media materialization to the message-context owner", async () => {
+  it("retries media materialization failures before reply-lane acceptance", async () => {
     downloadLineMediaMock.mockRejectedValueOnce(new Error("expired content"));
     const processMessage = vi.fn();
+    const onEventAccepted = vi.fn();
     const event = createTestMessageEvent({
       message: {
         id: "image-failed-1",
@@ -1083,6 +1307,47 @@ describe("handleLineWebhookEvents", () => {
       },
       source: { type: "user", userId: "user-image-failed" },
       webhookEventId: "evt-image-failed",
+    });
+    const context = createLineWebhookTestContext({
+      processMessage,
+      dmPolicy: "open",
+      onEventAccepted,
+      replayCache: createLineWebhookReplayCache(),
+    });
+
+    await expect(handleLineWebhookEvents([event], context)).rejects.toBeInstanceOf(
+      LineRetryableWebhookError,
+    );
+    expect(buildLineMessageContextMock).not.toHaveBeenCalled();
+    expect(processMessage).not.toHaveBeenCalled();
+    expect(onEventAccepted).not.toHaveBeenCalled();
+
+    downloadLineMediaMock.mockResolvedValueOnce({
+      path: "/tmp/line-media/retried-image.jpg",
+      contentType: "image/jpeg",
+      size: 1234,
+    });
+    await handleLineWebhookEvents([event], context);
+    expect(buildLineMessageContextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allMedia: [{ path: "/tmp/line-media/retried-image.jpg", contentType: "image/jpeg" }],
+      }),
+    );
+    expect(processMessage).toHaveBeenCalledTimes(1);
+    expect(onEventAccepted).toHaveBeenCalledWith(event);
+  });
+
+  it("keeps configured media-size-limit events processable as attachment unavailable", async () => {
+    downloadLineMediaMock.mockRejectedValueOnce(new Error("Media exceeds configured limit"));
+    const processMessage = vi.fn();
+    const event = createTestMessageEvent({
+      message: {
+        id: "image-too-large-1",
+        type: "image",
+        contentProvider: { type: "line" },
+      },
+      source: { type: "user", userId: "user-image-too-large" },
+      webhookEventId: "evt-image-too-large",
     });
 
     await handleLineWebhookEvents(
@@ -1098,6 +1363,11 @@ describe("handleLineWebhookEvents", () => {
 
   it("allows non-text group messages through when requireMention is set (cannot detect mention)", async () => {
     // Image message -- LINE only carries mention metadata on text messages.
+    downloadLineMediaMock.mockResolvedValueOnce({
+      path: "/tmp/line-media/mentioned-image.jpg",
+      contentType: "image/jpeg",
+      size: 1234,
+    });
     const event = createTestMessageEvent({
       message: {
         id: "m-mention-img",

--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -588,6 +588,44 @@ describe("handleLineWebhookEvents", () => {
     await task;
   });
 
+  it("preserves group history when durable acceptance rejects", async () => {
+    const groupHistories = new Map<string, HistoryEntry[]>([
+      ["group-history-retry", [{ sender: "user:earlier", body: "earlier", timestamp: 1 }]],
+    ]);
+    const processMessage = vi.fn<LineWebhookContext["processMessage"]>(async (message) => {
+      await message.onEventAccepted?.();
+    });
+    const event = createTestMessageEvent({
+      message: {
+        id: "m-history-retry",
+        type: "text",
+        text: "retry me",
+        quoteToken: "test-token-placeholder",
+      },
+      source: { type: "group", groupId: "group-history-retry", userId: "user-history" },
+      webhookEventId: "evt-history-retry",
+    });
+
+    await expect(
+      handleLineWebhookEvents(
+        [event],
+        createLineWebhookTestContext({
+          processMessage,
+          groupPolicy: "open",
+          requireMention: false,
+          groupHistories,
+          onEventAccepted: async () => {
+            throw new Error("acceptance failed");
+          },
+        }),
+      ),
+    ).rejects.toThrow("acceptance failed");
+
+    expect(groupHistories.get("group-history-retry")).toEqual([
+      { sender: "user:earlier", body: "earlier", timestamp: 1 },
+    ]);
+  });
+
   it("orders group-history mutations across concurrent webhook requests", async () => {
     let allowFirstAdmission: (() => void) | undefined;
     const firstAdmission = new Promise<void>((resolve) => {
@@ -1514,7 +1552,11 @@ describe("handleLineWebhookEvents", () => {
   });
 
   it("retries transient media materialization failures before reply-lane acceptance", async () => {
-    downloadLineMediaMock.mockRejectedValueOnce(new Error("connection reset"));
+    downloadLineMediaMock.mockRejectedValueOnce({
+      name: "HTTPFetchError",
+      status: 408,
+      statusText: "Request Timeout",
+    });
     const processMessage = vi.fn();
     const onEventAccepted = vi.fn();
     const event = createTestMessageEvent({

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -66,12 +66,18 @@ function isDownloadableLineMessageType(
   return LINE_DOWNLOADABLE_MESSAGE_TYPES.has(messageType);
 }
 
+function isLineMediaSizeLimitError(err: unknown): boolean {
+  const message = String(err).toLowerCase();
+  return message.includes("exceeds") && message.includes("limit");
+}
+
 interface LineHandlerContext {
   cfg: OpenClawConfig;
   account: ResolvedLineAccount;
   runtime: RuntimeEnv;
   mediaMaxBytes: number;
   processMessage: (ctx: LineInboundContext) => Promise<void>;
+  onEventAccepted?: (event: WebhookEvent) => void | Promise<void>;
   replayCache?: LineWebhookReplayCache;
   groupHistories?: Map<string, HistoryEntry[]>;
   historyLimit?: number;
@@ -429,7 +435,7 @@ function resolveEventRawText(event: MessageEvent | PostbackEvent): string {
 }
 
 async function handleMessageEvent(event: MessageEvent, context: LineHandlerContext): Promise<void> {
-  const { cfg, account, runtime, mediaMaxBytes, processMessage } = context;
+  const { cfg, account, mediaMaxBytes, processMessage } = context;
   const message = event.message;
 
   const decision = await shouldProcessLineEvent(event, context);
@@ -473,12 +479,13 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
         contentType: media.contentType,
       });
     } catch (err) {
-      mediaUnavailable = true;
-      const errMsg = String(err);
-      if (errMsg.includes("exceeds") && errMsg.includes("limit")) {
+      if (isLineMediaSizeLimitError(err)) {
+        mediaUnavailable = true;
         logVerbose(`line: media exceeds size limit for message ${message.id}`);
       } else {
-        runtime.error?.(danger(`line: failed to download media: ${errMsg}`));
+        throw new LineRetryableWebhookError(`failed to download media for ${message.id}`, {
+          cause: err,
+        });
       }
     }
   }
@@ -499,7 +506,10 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
     return;
   }
 
-  await processMessage(messageContext);
+  await processMessage({
+    ...messageContext,
+    onEventAccepted: () => context.onEventAccepted?.(event),
+  });
 
   if (isGroup && context.groupHistories) {
     const historyKey = groupId ?? roomId;
@@ -557,77 +567,156 @@ async function handlePostbackEvent(
     return;
   }
 
-  await context.processMessage(postbackContext);
+  await context.processMessage({
+    ...postbackContext,
+    onEventAccepted: () => context.onEventAccepted?.(event),
+  });
+}
+
+type LineWebhookEventTask = {
+  acceptance: Promise<void>;
+  completion: Promise<void>;
+};
+
+function resolveLineWebhookConversationKey(event: WebhookEvent): string | undefined {
+  const { groupId, roomId } = getLineSourceInfo(event.source);
+  if (groupId) {
+    return `group:${groupId}`;
+  }
+  if (roomId) {
+    return `room:${roomId}`;
+  }
+  return undefined;
+}
+
+function startLineWebhookEvent(
+  event: WebhookEvent,
+  context: LineHandlerContext,
+): LineWebhookEventTask {
+  let eventAccepted = false;
+  let acceptanceSettled = false;
+  let resolveAcceptance!: () => void;
+  let rejectAcceptance!: (error: unknown) => void;
+  const acceptance = new Promise<void>((resolve, reject) => {
+    resolveAcceptance = resolve;
+    rejectAcceptance = reject;
+  });
+  const resolveEventAcceptance = () => {
+    if (acceptanceSettled) {
+      return;
+    }
+    acceptanceSettled = true;
+    resolveAcceptance();
+  };
+  const rejectEventAcceptance = (error: unknown) => {
+    if (acceptanceSettled) {
+      return;
+    }
+    acceptanceSettled = true;
+    rejectAcceptance(error);
+  };
+  const replayCandidate = getLineReplayCandidate(event, context);
+  const acceptEvent = async () => {
+    if (eventAccepted) {
+      return;
+    }
+    eventAccepted = true;
+    await context.onEventAccepted?.(event);
+    // The reply lane now owns this event durably. Resolve replay claims here,
+    // rather than after the full turn, so a redelivered batch can retry its
+    // other events without waiting for this turn to settle.
+    if (replayCandidate) {
+      await replayCandidate.cache.commit(replayCandidate.key);
+    }
+    resolveEventAcceptance();
+  };
+  const eventContext = { ...context, onEventAccepted: acceptEvent };
+  const completion = (async () => {
+    const replaySkip = replayCandidate ? await claimLineReplayEvent(replayCandidate) : null;
+    if (replaySkip?.skip) {
+      if (replaySkip.inFlightResult) {
+        try {
+          await replaySkip.inFlightResult;
+          await acceptEvent();
+        } catch (err) {
+          context.runtime.error?.(danger(`line: replayed in-flight event failed: ${String(err)}`));
+          throw err;
+        }
+      } else {
+        await acceptEvent();
+      }
+      return;
+    }
+    try {
+      switch (event.type) {
+        case "message":
+          await handleMessageEvent(event, eventContext);
+          break;
+        case "follow":
+          await handleFollowEvent(event, eventContext);
+          break;
+        case "unfollow":
+          await handleUnfollowEvent(event, eventContext);
+          break;
+        case "join":
+          await handleJoinEvent(event, eventContext);
+          break;
+        case "leave":
+          await handleLeaveEvent(event, eventContext);
+          break;
+        case "postback":
+          await handlePostbackEvent(event, eventContext);
+          break;
+        default:
+          logVerbose(`line: unhandled event type: ${(event as WebhookEvent).type}`);
+      }
+      await acceptEvent();
+    } catch (err) {
+      if (replayCandidate) {
+        if (!eventAccepted && err instanceof LineRetryableWebhookError) {
+          replayCandidate.cache.release(replayCandidate.key, { error: err });
+        } else if (!eventAccepted) {
+          await replayCandidate.cache.commit(replayCandidate.key);
+        }
+      }
+      context.runtime.error?.(danger(`line: event handler failed: ${String(err)}`));
+      throw err;
+    }
+  })();
+  void completion.then(resolveEventAcceptance, rejectEventAcceptance);
+  return { acceptance, completion };
 }
 
 export async function handleLineWebhookEvents(
   events: WebhookEvent[],
   context: LineHandlerContext,
 ): Promise<void> {
-  let firstError: unknown;
+  const acceptances: Promise<void>[] = [];
+  const completions: Promise<void>[] = [];
+  const conversationCompletions = new Map<string, Promise<void>>();
   for (const event of events) {
-    const replayCandidate = getLineReplayCandidate(event, context);
-    const replaySkip = replayCandidate ? await claimLineReplayEvent(replayCandidate) : null;
-    if (replaySkip?.skip) {
-      if (replaySkip.inFlightResult) {
-        try {
-          await replaySkip.inFlightResult;
-        } catch (err) {
-          context.runtime.error?.(danger(`line: replayed in-flight event failed: ${String(err)}`));
-          firstError ??= err;
-        }
-      }
-      continue;
+    const conversationKey = resolveLineWebhookConversationKey(event);
+    const previousCompletion = conversationKey
+      ? conversationCompletions.get(conversationKey)
+      : undefined;
+    const task = (async () => {
+      await previousCompletion;
+      return startLineWebhookEvent(event, context);
+    })();
+    const acceptance = task.then(async (started) => await started.acceptance);
+    const completion = task.then(async (started) => await started.completion);
+    // Keep shared group-history state in event order, but let independent
+    // conversations reach durable reply-lane admission concurrently.
+    if (conversationKey) {
+      conversationCompletions.set(
+        conversationKey,
+        completion.catch(() => undefined),
+      );
     }
-    try {
-      switch (event.type) {
-        case "message":
-          await handleMessageEvent(event, context);
-          break;
-        case "follow":
-          await handleFollowEvent(event, context);
-          break;
-        case "unfollow":
-          await handleUnfollowEvent(event, context);
-          break;
-        case "join":
-          await handleJoinEvent(event, context);
-          break;
-        case "leave":
-          await handleLeaveEvent(event, context);
-          break;
-        case "postback":
-          await handlePostbackEvent(event, context);
-          break;
-        default:
-          logVerbose(`line: unhandled event type: ${(event as WebhookEvent).type}`);
-      }
-      if (replayCandidate) {
-        await replayCandidate.cache.commit(replayCandidate.key);
-      }
-    } catch (err) {
-      if (replayCandidate) {
-        await replayCandidate.cache.commit(replayCandidate.key);
-      }
-      context.runtime.error?.(danger(`line: event handler failed: ${String(err)}`));
-      firstError ??= err;
-    }
+    void completion.catch(() => {});
+    acceptances.push(acceptance);
+    completions.push(completion);
   }
-  if (firstError) {
-    throw toLintErrorObject(firstError, "Non-Error thrown");
-  }
-}
-
-function toLintErrorObject(value: unknown, fallbackMessage: string): Error {
-  if (value instanceof Error) {
-    return value;
-  }
-  if (typeof value === "string") {
-    return new Error(value);
-  }
-  const error = new Error(fallbackMessage, { cause: value });
-  if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.assign(error, value);
-  }
-  return error;
+  await Promise.all(acceptances);
+  await Promise.all(completions);
 }

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -75,14 +75,15 @@ function isPermanentLineMediaDownloadError(err: unknown): boolean {
   if (!err || typeof err !== "object" || !("status" in err)) {
     return false;
   }
-  // @line/bot-sdk exposes HTTPFetchError.status. Retrying non-429 4xx
-  // responses cannot recover this event's media, so keep its text path usable.
+  // @line/bot-sdk exposes HTTPFetchError.status. Retrying non-timeout/non-rate-limit
+  // 4xx responses cannot recover this event's media, so keep its text path usable.
   const status = (err as { status?: unknown }).status;
   return (
     typeof status === "number" &&
     Number.isInteger(status) &&
     status >= 400 &&
     status < 500 &&
+    status !== 408 &&
     status !== 429
   );
 }
@@ -93,7 +94,7 @@ interface LineHandlerContext {
   runtime: RuntimeEnv;
   mediaMaxBytes: number;
   processMessage: (ctx: LineInboundContext) => Promise<void>;
-  onEventAccepted?: (event: WebhookEvent) => void | Promise<void>;
+  onEventAccepted?: (event: WebhookEvent, finalizeAcceptance?: () => void) => void | Promise<void>;
   abortSignal?: AbortSignal;
   replayCache?: LineWebhookReplayCache;
   groupHistories?: Map<string, HistoryEntry[]>;
@@ -452,7 +453,10 @@ function resolveEventRawText(event: MessageEvent | PostbackEvent): string {
   return "";
 }
 
-async function handleMessageEvent(event: MessageEvent, context: LineHandlerContext): Promise<void> {
+async function handleMessageEvent(
+  event: MessageEvent,
+  context: LineHandlerContext,
+): Promise<(() => void) | undefined> {
   const { cfg, account, mediaMaxBytes, processMessage, runtime } = context;
   const message = event.message;
 
@@ -545,16 +549,12 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
   await processMessage({
     ...messageContext,
     onEventAccepted: async () => {
-      // Same-group webhook events start after this durable adoption. Clear
-      // their pending history here so a later event cannot be erased when
-      // this Agent turn eventually completes.
-      clearGroupHistory();
-      await context.onEventAccepted?.(event);
+      await context.onEventAccepted?.(event, clearGroupHistory);
     },
   });
   // Legacy/test handlers that do not call onEventAccepted still need the
-  // original post-processing history cleanup before their event settles.
-  clearGroupHistory();
+  // original history cleanup when completion becomes acceptance.
+  return clearGroupHistory;
 }
 
 async function handleFollowEvent(event: FollowEvent, _context: LineHandlerContext): Promise<void> {
@@ -674,9 +674,10 @@ function startLineWebhookEvent(
   } else {
     context.abortSignal?.addEventListener("abort", abortEvent, { once: true });
   }
-  const acceptEvent = async () => {
+  const acceptEvent = async (finalizeAcceptance?: () => void) => {
     throwIfAborted();
     if (eventAccepted) {
+      finalizeAcceptance?.();
       return;
     }
     eventAcceptance ??= (async () => {
@@ -689,6 +690,9 @@ function startLineWebhookEvent(
         await replayCandidate.cache.commit(replayCandidate.key);
         replayClaimOwned = false;
       }
+      // Finalize owner state only after upstream acceptance and replay commit,
+      // but before later same-conversation events observe this acceptance.
+      finalizeAcceptance?.();
       eventAccepted = true;
       resolveEventAcceptance();
     })();
@@ -700,7 +704,11 @@ function startLineWebhookEvent(
       throw error;
     }
   };
-  const eventContext = { ...context, onEventAccepted: acceptEvent };
+  const eventContext = {
+    ...context,
+    onEventAccepted: (_event: WebhookEvent, finalizeAcceptance?: () => void) =>
+      acceptEvent(finalizeAcceptance),
+  };
   const completion = (async () => {
     try {
       throwIfAborted();
@@ -723,9 +731,10 @@ function startLineWebhookEvent(
         }
         return;
       }
+      let finalizeAcceptance: (() => void) | undefined;
       switch (event.type) {
         case "message":
-          await handleMessageEvent(event, eventContext);
+          finalizeAcceptance = await handleMessageEvent(event, eventContext);
           break;
         case "follow":
           await handleFollowEvent(event, eventContext);
@@ -745,7 +754,7 @@ function startLineWebhookEvent(
         default:
           logVerbose(`line: unhandled event type: ${(event as WebhookEvent).type}`);
       }
-      await acceptEvent();
+      await acceptEvent(finalizeAcceptance);
     } catch (err) {
       if (replayClaimOwned && !eventAccepted) {
         // Every error here propagates to the webhook response before durable

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -687,12 +687,10 @@ function startLineWebhookEvent(
       }
       await acceptEvent();
     } catch (err) {
-      if (replayCandidate) {
-        if (!eventAccepted && err instanceof LineRetryableWebhookError) {
-          replayCandidate.cache.release(replayCandidate.key, { error: err });
-        } else if (!eventAccepted) {
-          await replayCandidate.cache.commit(replayCandidate.key);
-        }
+      if (replayCandidate && !eventAccepted) {
+        // Every error here propagates to the webhook response before durable
+        // adoption. Leave the replay claim available so LINE can redeliver it.
+        replayCandidate.cache.release(replayCandidate.key, { error: err });
       }
       context.runtime.error?.(danger(`line: event handler failed: ${String(err)}`));
       throw err;

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -484,7 +484,7 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
         mediaUnavailable = true;
         logVerbose(`line: media exceeds size limit for message ${message.id}`);
       } else {
-        throw new LineRetryableWebhookError(`failed to download media for ${message.id}`, {
+        throw new Error(`failed to download media for ${message.id}`, {
           cause: err,
         });
       }
@@ -594,12 +594,15 @@ type LineWebhookEventTask = {
 };
 
 function resolveLineWebhookConversationKey(event: WebhookEvent): string | undefined {
-  const { groupId, roomId } = getLineSourceInfo(event.source);
+  const { userId, groupId, roomId } = getLineSourceInfo(event.source);
   if (groupId) {
     return `group:${groupId}`;
   }
   if (roomId) {
     return `room:${roomId}`;
+  }
+  if (userId) {
+    return `user:${userId}`;
   }
   return undefined;
 }
@@ -609,6 +612,7 @@ function startLineWebhookEvent(
   context: LineHandlerContext,
 ): LineWebhookEventTask {
   let eventAccepted = false;
+  let eventAcceptance: Promise<void> | undefined;
   let acceptanceSettled = false;
   let resolveAcceptance!: () => void;
   let rejectAcceptance!: (error: unknown) => void;
@@ -635,15 +639,24 @@ function startLineWebhookEvent(
     if (eventAccepted) {
       return;
     }
-    eventAccepted = true;
-    await context.onEventAccepted?.(event);
-    // The reply lane now owns this event durably. Resolve replay claims here,
-    // rather than after the full turn, so a redelivered batch can retry its
-    // other events without waiting for this turn to settle.
-    if (replayCandidate) {
-      await replayCandidate.cache.commit(replayCandidate.key);
+    eventAcceptance ??= (async () => {
+      await context.onEventAccepted?.(event);
+      // The reply lane now owns this event durably. Resolve replay claims here,
+      // rather than after the full turn, so a redelivered batch can retry its
+      // other events without waiting for this turn to settle.
+      if (replayCandidate) {
+        await replayCandidate.cache.commit(replayCandidate.key);
+      }
+      eventAccepted = true;
+      resolveEventAcceptance();
+    })();
+    try {
+      await eventAcceptance;
+    } catch (error) {
+      // Let a later call retry the acceptance work after the claim is released.
+      eventAcceptance = undefined;
+      throw error;
     }
-    resolveEventAcceptance();
   };
   const eventContext = { ...context, onEventAccepted: acceptEvent };
   const completion = (async () => {
@@ -720,13 +733,17 @@ export async function handleLineWebhookEvents(
     const acceptance = task.then(async (started) => await started.acceptance);
     const completion = task.then(async (started) => await started.completion);
     if (conversationKey) {
-      const acceptanceTail = acceptance.catch(() => undefined);
-      conversationAcceptances.set(conversationKey, acceptanceTail);
-      void acceptanceTail.finally(() => {
+      let acceptanceTail: Promise<void>;
+      acceptanceTail = acceptance.finally(() => {
         if (conversationAcceptances.get(conversationKey) === acceptanceTail) {
           conversationAcceptances.delete(conversationKey);
         }
       });
+      conversationAcceptances.set(conversationKey, acceptanceTail);
+      // Preserve rejection for the next same-conversation event so it cannot
+      // overtake a failed predecessor. This observer only prevents an
+      // unhandled rejection after the tail has performed its cleanup.
+      void acceptanceTail.catch(() => undefined);
     }
     void completion.catch(() => {});
     acceptances.push(acceptance);

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -71,6 +71,22 @@ function isLineMediaSizeLimitError(err: unknown): boolean {
   return message.includes("exceeds") && message.includes("limit");
 }
 
+function isPermanentLineMediaDownloadError(err: unknown): boolean {
+  if (!err || typeof err !== "object" || !("status" in err)) {
+    return false;
+  }
+  // @line/bot-sdk exposes HTTPFetchError.status. Retrying non-429 4xx
+  // responses cannot recover this event's media, so keep its text path usable.
+  const status = (err as { status?: unknown }).status;
+  return (
+    typeof status === "number" &&
+    Number.isInteger(status) &&
+    status >= 400 &&
+    status < 500 &&
+    status !== 429
+  );
+}
+
 interface LineHandlerContext {
   cfg: OpenClawConfig;
   account: ResolvedLineAccount;
@@ -78,6 +94,7 @@ interface LineHandlerContext {
   mediaMaxBytes: number;
   processMessage: (ctx: LineInboundContext) => Promise<void>;
   onEventAccepted?: (event: WebhookEvent) => void | Promise<void>;
+  abortSignal?: AbortSignal;
   replayCache?: LineWebhookReplayCache;
   groupHistories?: Map<string, HistoryEntry[]>;
   conversationAcceptanceTails?: Map<string, Promise<void>>;
@@ -436,7 +453,7 @@ function resolveEventRawText(event: MessageEvent | PostbackEvent): string {
 }
 
 async function handleMessageEvent(event: MessageEvent, context: LineHandlerContext): Promise<void> {
-  const { cfg, account, mediaMaxBytes, processMessage } = context;
+  const { cfg, account, mediaMaxBytes, processMessage, runtime } = context;
   const message = event.message;
 
   const decision = await shouldProcessLineEvent(event, context);
@@ -483,6 +500,9 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
       if (isLineMediaSizeLimitError(err)) {
         mediaUnavailable = true;
         logVerbose(`line: media exceeds size limit for message ${message.id}`);
+      } else if (isPermanentLineMediaDownloadError(err)) {
+        mediaUnavailable = true;
+        runtime.error?.(danger(`line: media is unavailable: ${String(err)}`));
       } else {
         throw new Error(`failed to download media for ${message.id}`, {
           cause: err,
@@ -612,6 +632,7 @@ function startLineWebhookEvent(
   context: LineHandlerContext,
 ): LineWebhookEventTask {
   let eventAccepted = false;
+  let replayClaimOwned = false;
   let eventAcceptance: Promise<void> | undefined;
   let acceptanceSettled = false;
   let resolveAcceptance!: () => void;
@@ -635,17 +656,38 @@ function startLineWebhookEvent(
     rejectAcceptance(error);
   };
   const replayCandidate = getLineReplayCandidate(event, context);
+  const throwIfAborted = () => context.abortSignal?.throwIfAborted();
+  const releaseReplayClaim = (error: unknown) => {
+    if (!replayCandidate || !replayClaimOwned || eventAccepted) {
+      return;
+    }
+    replayClaimOwned = false;
+    replayCandidate.cache.release(replayCandidate.key, { error });
+  };
+  const abortEvent = () => {
+    const error = context.abortSignal?.reason ?? new Error("LINE webhook acceptance aborted");
+    releaseReplayClaim(error);
+    rejectEventAcceptance(error);
+  };
+  if (context.abortSignal?.aborted) {
+    abortEvent();
+  } else {
+    context.abortSignal?.addEventListener("abort", abortEvent, { once: true });
+  }
   const acceptEvent = async () => {
+    throwIfAborted();
     if (eventAccepted) {
       return;
     }
     eventAcceptance ??= (async () => {
       await context.onEventAccepted?.(event);
+      throwIfAborted();
       // The reply lane now owns this event durably. Resolve replay claims here,
       // rather than after the full turn, so a redelivered batch can retry its
       // other events without waiting for this turn to settle.
-      if (replayCandidate) {
+      if (replayCandidate && replayClaimOwned) {
         await replayCandidate.cache.commit(replayCandidate.key);
+        replayClaimOwned = false;
       }
       eventAccepted = true;
       resolveEventAcceptance();
@@ -660,22 +702,27 @@ function startLineWebhookEvent(
   };
   const eventContext = { ...context, onEventAccepted: acceptEvent };
   const completion = (async () => {
-    const replaySkip = replayCandidate ? await claimLineReplayEvent(replayCandidate) : null;
-    if (replaySkip?.skip) {
-      if (replaySkip.inFlightResult) {
-        try {
-          await replaySkip.inFlightResult;
-          await acceptEvent();
-        } catch (err) {
-          context.runtime.error?.(danger(`line: replayed in-flight event failed: ${String(err)}`));
-          throw err;
-        }
-      } else {
-        await acceptEvent();
-      }
-      return;
-    }
     try {
+      throwIfAborted();
+      const replaySkip = replayCandidate ? await claimLineReplayEvent(replayCandidate) : null;
+      replayClaimOwned = Boolean(replayCandidate && !replaySkip?.skip);
+      throwIfAborted();
+      if (replaySkip?.skip) {
+        if (replaySkip.inFlightResult) {
+          try {
+            await replaySkip.inFlightResult;
+            await acceptEvent();
+          } catch (err) {
+            context.runtime.error?.(
+              danger(`line: replayed in-flight event failed: ${String(err)}`),
+            );
+            throw err;
+          }
+        } else {
+          await acceptEvent();
+        }
+        return;
+      }
       switch (event.type) {
         case "message":
           await handleMessageEvent(event, eventContext);
@@ -700,13 +747,15 @@ function startLineWebhookEvent(
       }
       await acceptEvent();
     } catch (err) {
-      if (replayCandidate && !eventAccepted) {
+      if (replayClaimOwned && !eventAccepted) {
         // Every error here propagates to the webhook response before durable
         // adoption. Leave the replay claim available so LINE can redeliver it.
-        replayCandidate.cache.release(replayCandidate.key, { error: err });
+        releaseReplayClaim(err);
       }
       context.runtime.error?.(danger(`line: event handler failed: ${String(err)}`));
       throw err;
+    } finally {
+      context.abortSignal?.removeEventListener("abort", abortEvent);
     }
   })();
   void completion.then(resolveEventAcceptance, rejectEventAcceptance);

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -80,6 +80,7 @@ interface LineHandlerContext {
   onEventAccepted?: (event: WebhookEvent) => void | Promise<void>;
   replayCache?: LineWebhookReplayCache;
   groupHistories?: Map<string, HistoryEntry[]>;
+  conversationAcceptanceTails?: Map<string, Promise<void>>;
   historyLimit?: number;
 }
 
@@ -506,12 +507,11 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
     return;
   }
 
-  await processMessage({
-    ...messageContext,
-    onEventAccepted: () => context.onEventAccepted?.(event),
-  });
-
-  if (isGroup && context.groupHistories) {
+  let groupHistoryCleared = false;
+  const clearGroupHistory = () => {
+    if (groupHistoryCleared || !isGroup || !context.groupHistories) {
+      return;
+    }
     const historyKey = groupId ?? roomId;
     if (historyKey && context.groupHistories.has(historyKey)) {
       createChannelHistoryWindow({ historyMap: context.groupHistories }).clear({
@@ -519,7 +519,22 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
         limit: context.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
       });
     }
-  }
+    groupHistoryCleared = true;
+  };
+
+  await processMessage({
+    ...messageContext,
+    onEventAccepted: async () => {
+      // Same-group webhook events start after this durable adoption. Clear
+      // their pending history here so a later event cannot be erased when
+      // this Agent turn eventually completes.
+      clearGroupHistory();
+      await context.onEventAccepted?.(event);
+    },
+  });
+  // Legacy/test handlers that do not call onEventAccepted still need the
+  // original post-processing history cleanup before their event settles.
+  clearGroupHistory();
 }
 
 async function handleFollowEvent(event: FollowEvent, _context: LineHandlerContext): Promise<void> {
@@ -693,25 +708,27 @@ export async function handleLineWebhookEvents(
 ): Promise<void> {
   const acceptances: Promise<void>[] = [];
   const completions: Promise<void>[] = [];
-  const conversationCompletions = new Map<string, Promise<void>>();
+  const conversationAcceptances =
+    context.conversationAcceptanceTails ?? new Map<string, Promise<void>>();
   for (const event of events) {
     const conversationKey = resolveLineWebhookConversationKey(event);
-    const previousCompletion = conversationKey
-      ? conversationCompletions.get(conversationKey)
+    const previousAcceptance = conversationKey
+      ? conversationAcceptances.get(conversationKey)
       : undefined;
     const task = (async () => {
-      await previousCompletion;
+      await previousAcceptance;
       return startLineWebhookEvent(event, context);
     })();
     const acceptance = task.then(async (started) => await started.acceptance);
     const completion = task.then(async (started) => await started.completion);
-    // Keep shared group-history state in event order, but let independent
-    // conversations reach durable reply-lane admission concurrently.
     if (conversationKey) {
-      conversationCompletions.set(
-        conversationKey,
-        completion.catch(() => undefined),
-      );
+      const acceptanceTail = acceptance.catch(() => undefined);
+      conversationAcceptances.set(conversationKey, acceptanceTail);
+      void acceptanceTail.finally(() => {
+        if (conversationAcceptances.get(conversationKey) === acceptanceTail) {
+          conversationAcceptances.delete(conversationKey);
+        }
+      });
     }
     void completion.catch(() => {});
     acceptances.push(acceptance);

--- a/extensions/line/src/bot-message-context.ts
+++ b/extensions/line/src/bot-message-context.ts
@@ -606,4 +606,7 @@ export async function buildLinePostbackContext(params: {
 
 type LineMessageContext = NonNullable<Awaited<ReturnType<typeof buildLineMessageContext>>>;
 type LinePostbackContext = NonNullable<Awaited<ReturnType<typeof buildLinePostbackContext>>>;
-export type LineInboundContext = LineMessageContext | LinePostbackContext;
+export type LineInboundContext = (LineMessageContext | LinePostbackContext) & {
+  /** Signals that this event is durably owned by the reply lane. */
+  onEventAccepted?: () => void | Promise<void>;
+};

--- a/extensions/line/src/bot.ts
+++ b/extensions/line/src/bot.ts
@@ -12,6 +12,7 @@ import { resolveLineAccount } from "./accounts.js";
 import { createLineWebhookReplayCache, handleLineWebhookEvents } from "./bot-handlers.js";
 import type { LineInboundContext } from "./bot-message-context.js";
 import type { ResolvedLineAccount } from "./types.js";
+import type { LineWebhookDispatchCallbacks } from "./webhook-ack.js";
 
 interface LineBotOptions {
   channelAccessToken: string;
@@ -24,7 +25,10 @@ interface LineBotOptions {
 }
 
 interface LineBot {
-  handleWebhook: (body: webhook.CallbackRequest) => Promise<void>;
+  handleWebhook: (
+    body: webhook.CallbackRequest,
+    callbacks?: LineWebhookDispatchCallbacks,
+  ) => Promise<void>;
   account: ResolvedLineAccount;
 }
 
@@ -47,7 +51,10 @@ export function createLineBot(opts: LineBotOptions): LineBot {
   const replayCache = createLineWebhookReplayCache();
   const groupHistories = new Map<string, HistoryEntry[]>();
 
-  const handleWebhook = async (body: webhook.CallbackRequest): Promise<void> => {
+  const handleWebhook = async (
+    body: webhook.CallbackRequest,
+    callbacks?: LineWebhookDispatchCallbacks,
+  ): Promise<void> => {
     if (!body.events || body.events.length === 0) {
       return;
     }
@@ -61,6 +68,7 @@ export function createLineBot(opts: LineBotOptions): LineBot {
       replayCache,
       groupHistories,
       historyLimit: cfg.messages?.groupChat?.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
+      onEventAccepted: callbacks?.onEventAccepted,
     });
   };
 

--- a/extensions/line/src/bot.ts
+++ b/extensions/line/src/bot.ts
@@ -30,6 +30,7 @@ interface LineBot {
     callbacks?: LineWebhookDispatchCallbacks,
   ) => Promise<void>;
   account: ResolvedLineAccount;
+  webhookAcknowledgement: "after_event_acceptance";
 }
 
 export function createLineBot(opts: LineBotOptions): LineBot {
@@ -77,5 +78,6 @@ export function createLineBot(opts: LineBotOptions): LineBot {
   return {
     handleWebhook,
     account,
+    webhookAcknowledgement: "after_event_acceptance",
   };
 }

--- a/extensions/line/src/bot.ts
+++ b/extensions/line/src/bot.ts
@@ -72,6 +72,7 @@ export function createLineBot(opts: LineBotOptions): LineBot {
       conversationAcceptanceTails,
       historyLimit: cfg.messages?.groupChat?.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
       onEventAccepted: callbacks?.onEventAccepted,
+      abortSignal: callbacks?.abortSignal,
     });
   };
 

--- a/extensions/line/src/bot.ts
+++ b/extensions/line/src/bot.ts
@@ -50,6 +50,7 @@ export function createLineBot(opts: LineBotOptions): LineBot {
     });
   const replayCache = createLineWebhookReplayCache();
   const groupHistories = new Map<string, HistoryEntry[]>();
+  const conversationAcceptanceTails = new Map<string, Promise<void>>();
 
   const handleWebhook = async (
     body: webhook.CallbackRequest,
@@ -67,6 +68,7 @@ export function createLineBot(opts: LineBotOptions): LineBot {
       processMessage,
       replayCache,
       groupHistories,
+      conversationAcceptanceTails,
       historyLimit: cfg.messages?.groupChat?.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
       onEventAccepted: callbacks?.onEventAccepted,
     });

--- a/extensions/line/src/channel.sendPayload.test.ts
+++ b/extensions/line/src/channel.sendPayload.test.ts
@@ -622,25 +622,22 @@ describe("line outbound sendPayload", () => {
     );
   });
 
-  it("declares receive ack policies for immediate LINE webhook acknowledgement", async () => {
+  it("declares receive ack policies for reply-lane accepted LINE webhook events", async () => {
     const proofResults = await verifyChannelMessageReceiveAckPolicyAdapterProofs({
       adapterName: "line",
       adapter: linePlugin.message!,
       proofs: {
-        after_receive_record: () => {
-          expect(linePlugin.message?.receive?.defaultAckPolicy).toBe("after_receive_record");
+        after_agent_dispatch: () => {
+          expect(linePlugin.message?.receive?.defaultAckPolicy).toBe("after_agent_dispatch");
           expect(linePlugin.message?.receive?.supportedAckPolicies).toContain(
-            "after_receive_record",
+            "after_agent_dispatch",
           );
         },
       },
     });
 
-    expect(proofResults.find((result) => result.policy === "after_receive_record")?.status).toBe(
-      "verified",
-    );
     expect(proofResults.find((result) => result.policy === "after_agent_dispatch")?.status).toBe(
-      "not_declared",
+      "verified",
     );
   });
 });

--- a/extensions/line/src/monitor.lifecycle.test.ts
+++ b/extensions/line/src/monitor.lifecycle.test.ts
@@ -19,7 +19,7 @@ const {
   registerWebhookTargetWithPluginRouteMock,
   unregisterHttpMock,
 } = vi.hoisted(() => ({
-  createLineBotMock: vi.fn(() => ({
+  createLineBotMock: vi.fn((_options?: unknown) => ({
     account: { accountId: "default" },
     handleWebhook: vi.fn<LineHandleWebhook>(),
   })),

--- a/extensions/line/src/monitor.lifecycle.test.ts
+++ b/extensions/line/src/monitor.lifecycle.test.ts
@@ -2,6 +2,7 @@
 import crypto from "node:crypto";
 import { EventEmitter } from "node:events";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import type { webhook } from "@line/bot-sdk";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { createMockIncomingRequest } from "openclaw/plugin-sdk/test-env";
@@ -14,6 +15,7 @@ type LineHandleWebhook = (...args: unknown[]) => Promise<void>;
 const {
   createLineBotMock,
   createLineNodeWebhookHandlerMock,
+  getLineRuntimeMock,
   registerWebhookTargetWithPluginRouteMock,
   unregisterHttpMock,
 } = vi.hoisted(() => ({
@@ -24,6 +26,7 @@ const {
   createLineNodeWebhookHandlerMock: vi.fn<() => LineNodeWebhookHandler>(() =>
     vi.fn<LineNodeWebhookHandler>(async () => {}),
   ),
+  getLineRuntimeMock: vi.fn(),
   registerWebhookTargetWithPluginRouteMock: vi.fn(),
   unregisterHttpMock: vi.fn(),
 }));
@@ -116,6 +119,10 @@ vi.mock("./markdown-to-line.js", () => ({
   processLineMessage: vi.fn(),
 }));
 
+vi.mock("./runtime.js", () => ({
+  getLineRuntime: getLineRuntimeMock,
+}));
+
 vi.mock("./reply-chunks.js", () => ({
   sendLineReplyChunks: vi.fn(),
 }));
@@ -151,6 +158,7 @@ describe("monitorLineProvider lifecycle", () => {
     vi.doUnmock("./webhook-node.js");
     vi.doUnmock("./auto-reply-delivery.js");
     vi.doUnmock("./markdown-to-line.js");
+    vi.doUnmock("./runtime.js");
     vi.doUnmock("./reply-chunks.js");
     vi.doUnmock("./send.js");
     vi.doUnmock("./template-messages.js");
@@ -167,6 +175,7 @@ describe("monitorLineProvider lifecycle", () => {
     createLineNodeWebhookHandlerMock
       .mockReset()
       .mockImplementation(() => innerLineWebhookHandlerMock);
+    getLineRuntimeMock.mockReset();
     unregisterHttpMock.mockReset();
     registerWebhookTargetWithPluginRouteMock.mockReset().mockImplementation((params) => {
       const withLeadingSlash = params.target.path.startsWith("/")
@@ -400,7 +409,7 @@ describe("monitorLineProvider lifecycle", () => {
     monitor.stop();
   });
 
-  it("acknowledges shared-path POST requests before matched event processing completes", async () => {
+  it("acknowledges shared-path POST requests after reply-lane acceptance", async () => {
     const monitor = await monitorLineProvider({
       channelAccessToken: "token",
       channelSecret: "secret", // pragma: allowlist secret
@@ -413,12 +422,20 @@ describe("monitorLineProvider lifecycle", () => {
     const bot = createLineBotMock.mock.results[0]?.value as {
       handleWebhook: ReturnType<typeof vi.fn<LineHandleWebhook>>;
     };
-    bot.handleWebhook.mockImplementation(
-      () =>
-        new Promise<void>((resolve) => {
-          releaseWebhook = resolve;
-        }),
-    );
+    bot.handleWebhook.mockImplementation(async (body, callbacks) => {
+      const onEventAccepted = (
+        callbacks as {
+          onEventAccepted?: (event: webhook.Event) => void | Promise<void>;
+        }
+      )?.onEventAccepted;
+      const event = (body as webhook.CallbackRequest).events?.[0];
+      if (event) {
+        await onEventAccepted?.(event);
+      }
+      await new Promise<void>((resolve) => {
+        releaseWebhook = resolve;
+      });
+    });
 
     const route = requireRegisteredRoute();
     const payload = JSON.stringify({ events: [{ type: "message" }] });
@@ -482,6 +499,105 @@ describe("monitorLineProvider lifecycle", () => {
 
     firstMonitor.stop();
     secondMonitor.stop();
+  });
+
+  it("does not consume a reply token before requesting webhook redelivery", async () => {
+    const { replyMessageLine } = await import("./send.js");
+    const inboundRun = vi.fn(async () => {
+      throw new Error("reply lane unavailable");
+    });
+    getLineRuntimeMock.mockReturnValue({
+      channel: {
+        inbound: { run: inboundRun },
+        session: { recordInboundSession: vi.fn() },
+        reply: { dispatchReplyWithBufferedBlockDispatcher: vi.fn() },
+      },
+    });
+    const runtime = { error: vi.fn() } as unknown as RuntimeEnv;
+    const monitor = await monitorLineProvider({
+      channelAccessToken: "token",
+      channelSecret: "secret", // pragma: allowlist secret
+      accountId: "default",
+      config: {} as OpenClawConfig,
+      runtime,
+    });
+    const botOptions = createLineBotMock.mock.calls[0]?.[0] as
+      | {
+          onMessage?: (context: unknown) => Promise<void>;
+        }
+      | undefined;
+    if (!botOptions?.onMessage) {
+      throw new Error("Expected LINE bot message handler");
+    }
+
+    await expect(
+      botOptions.onMessage({
+        accountId: "default",
+        ctxPayload: {
+          From: "line:group:retry",
+          MessageSid: "retry-message",
+          BodyForAgent: "hello",
+        },
+        isGroup: true,
+        replyToken: "test",
+        route: { accountId: "default", agentId: "default", sessionKey: "agent:default:line:retry" },
+        turn: { storePath: "/tmp/line-retry.json" },
+      }),
+    ).rejects.toThrow("line event failed before reply-lane adoption");
+
+    expect(inboundRun).toHaveBeenCalledOnce();
+    expect(replyMessageLine).not.toHaveBeenCalled();
+    monitor.stop();
+  });
+
+  it("keeps shared in-flight slots until reply-lane acceptance", async () => {
+    const monitor = await monitorLineProvider({
+      channelAccessToken: "token",
+      channelSecret: "secret", // pragma: allowlist secret
+      accountId: "default",
+      config: {} as OpenClawConfig,
+      runtime: {} as RuntimeEnv,
+    });
+    let releaseAcceptance: (() => void) | undefined;
+    const acceptance = new Promise<void>((resolve) => {
+      releaseAcceptance = resolve;
+    });
+    const bot = createLineBotMock.mock.results[0]?.value as {
+      handleWebhook: ReturnType<typeof vi.fn<LineHandleWebhook>>;
+    };
+    bot.handleWebhook.mockImplementation(async (body, callbacks) => {
+      await acceptance;
+      const event = (body as webhook.CallbackRequest).events?.[0];
+      await (
+        callbacks as { onEventAccepted?: (event: webhook.Event) => void | Promise<void> }
+      )?.onEventAccepted?.(event as webhook.Event);
+    });
+
+    const route = requireRegisteredRoute();
+    const payload = JSON.stringify({ events: [{ type: "message" }] });
+    const signature = crypto.createHmac("SHA256", "secret").update(payload).digest("base64");
+    const createSignedRequest = () =>
+      Object.assign(createMockIncomingRequest([payload]), {
+        method: "POST",
+        headers: { "x-line-signature": signature },
+      }) as unknown as IncomingMessage;
+    const heldRequests = Array.from({ length: WEBHOOK_IN_FLIGHT_DEFAULTS.maxInFlightPerKey }, () =>
+      route.handler(createSignedRequest(), createRouteResponse()),
+    );
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+
+    const overflowResponse = createRouteResponse();
+    await route.handler(createSignedRequest(), overflowResponse);
+
+    expect(overflowResponse.statusCode).toBe(429);
+    if (!releaseAcceptance) {
+      throw new Error("Expected reply-lane acceptance release callback");
+    }
+    releaseAcceptance();
+    await Promise.all(heldRequests);
+    monitor.stop();
   });
 
   it("rejects webhook requests above the shared in-flight limit before body handling", async () => {

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -1,6 +1,10 @@
 // Line plugin module implements monitor behavior.
 import type { webhook } from "@line/bot-sdk";
 import { hasFinalInboundReplyDispatch } from "openclaw/plugin-sdk/channel-inbound";
+import {
+  createMessageReceiveContext,
+  type MessageReceiveContext,
+} from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { chunkMarkdownText } from "openclaw/plugin-sdk/reply-runtime";
 import {
@@ -23,6 +27,7 @@ import {
 } from "openclaw/plugin-sdk/webhook-request-guards";
 import { resolveDefaultLineAccountId } from "./accounts.js";
 import { deliverLineAutoReply } from "./auto-reply-delivery.js";
+import { LineRetryableWebhookError } from "./bot-handlers.js";
 import { createLineBot } from "./bot.js";
 import { processLineMessage } from "./markdown-to-line.js";
 import { resolveLineDurableReplyOptions } from "./monitor-durable.js";
@@ -43,6 +48,7 @@ import {
 } from "./send.js";
 import { buildTemplateMessageFromPayload } from "./template-messages.js";
 import type { LineChannelData, ResolvedLineAccount } from "./types.js";
+import { waitForLineWebhookDispatchAcceptance } from "./webhook-ack.js";
 import { createLineNodeWebhookHandler, readLineWebhookRequestBody } from "./webhook-node.js";
 import { parseLineWebhookBody, validateLineSignature } from "./webhook-utils.js";
 
@@ -146,6 +152,14 @@ export async function monitorLineProvider(
       }
 
       const { ctxPayload, replyToken, route } = ctx;
+      let eventAccepted = false;
+      const acceptEvent = async () => {
+        if (eventAccepted) {
+          return;
+        }
+        eventAccepted = true;
+        await ctx.onEventAccepted?.();
+      };
 
       const shouldShowLoading = Boolean(ctx.userId && !ctx.isGroup);
 
@@ -161,10 +175,9 @@ export async function monitorLineProvider(
           })
         : null;
 
-      const displayName = await displayNamePromise;
-      logVerbose(`line: received message from ${displayName} (${ctxPayload.From})`);
-
       try {
+        const displayName = await displayNamePromise;
+        logVerbose(`line: received message from ${displayName} (${ctxPayload.From})`);
         const textLimit = 5000;
         let replyTokenUsed = false;
         const core = getLineRuntime();
@@ -172,6 +185,7 @@ export async function monitorLineProvider(
           channel: "line",
           accountId: route.accountId,
           raw: ctx,
+          onTurnAdopted: acceptEvent,
           adapter: {
             ingest: () => ({
               id: ctxPayload.MessageSid ?? `${ctxPayload.From}:${Date.now()}`,
@@ -258,6 +272,9 @@ export async function monitorLineProvider(
             }),
           },
         });
+        if (!turnResult.dispatched) {
+          await acceptEvent();
+        }
         const dispatchResult = turnResult.dispatched ? turnResult.dispatchResult : undefined;
         if (!hasFinalInboundReplyDispatch(dispatchResult)) {
           logVerbose(`line: no response generated for message from ${ctxPayload.From}`);
@@ -265,6 +282,13 @@ export async function monitorLineProvider(
       } catch (err) {
         runtime.error?.(danger(`line: auto-reply failed: ${String(err)}`));
 
+        if (!eventAccepted) {
+          // Returning a non-2xx response asks LINE to redeliver this event.
+          // Its reply token is one-use, so do not consume it before the retry.
+          throw new LineRetryableWebhookError("line event failed before reply-lane adoption", {
+            cause: err,
+          });
+        }
         if (replyToken) {
           try {
             await replyMessageLine(
@@ -328,6 +352,7 @@ export async function monitorLineProvider(
           return;
         }
 
+        let receiveContext: MessageReceiveContext<webhook.CallbackRequest> | undefined;
         try {
           const signatureHeader = req.headers["x-line-signature"];
           const signature =
@@ -376,22 +401,33 @@ export async function monitorLineProvider(
             return;
           }
 
-          requestLifecycle.release();
-          res.statusCode = 200;
-          res.setHeader("Content-Type", "application/json");
-          res.end(JSON.stringify({ status: "ok" }));
+          receiveContext = createMessageReceiveContext({
+            id: `${Date.now()}:line:webhook`,
+            channel: "line",
+            accountId: match.target.accountId,
+            message: body,
+            ackPolicy: "after_agent_dispatch",
+            onAck: () => {
+              res.statusCode = 200;
+              res.setHeader("Content-Type", "application/json");
+              res.end(JSON.stringify({ status: "ok" }));
+            },
+          });
 
-          if (body.events && body.events.length > 0) {
-            logVerbose(`line: received ${body.events.length} webhook events`);
-            void Promise.resolve()
-              .then(() => match.target.bot.handleWebhook(body))
-              .catch((err: unknown) => {
-                match.target.runtime.error?.(
-                  danger(`line webhook dispatch failed: ${String(err)}`),
-                );
-              });
+          if (!body.events || body.events.length === 0) {
+            await receiveContext.ack();
+            return;
           }
+
+          logVerbose(`line: received ${body.events.length} webhook events`);
+          await waitForLineWebhookDispatchAcceptance({
+            body,
+            dispatch: match.target.bot.handleWebhook,
+            runtime: match.target.runtime,
+          });
+          await receiveContext.ack();
         } catch (err) {
+          await receiveContext?.nack(err);
           if (isRequestBodyLimitError(err, "PAYLOAD_TOO_LARGE")) {
             res.statusCode = 413;
             res.setHeader("Content-Type", "application/json");

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -326,6 +326,7 @@ export async function monitorLineProvider(
       channelSecret: target.channelSecret,
       bot: target.bot,
       runtime: target.runtime,
+      acknowledgement: "after_event_acceptance",
     });
   const { unregister: unregisterHttp } = registerWebhookTargetWithPluginRoute({
     targetsByPath: lineWebhookTargets,

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -326,7 +326,6 @@ export async function monitorLineProvider(
       channelSecret: target.channelSecret,
       bot: target.bot,
       runtime: target.runtime,
-      acknowledgement: "after_event_acceptance",
     });
   const { unregister: unregisterHttp } = registerWebhookTargetWithPluginRoute({
     targetsByPath: lineWebhookTargets,

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -27,7 +27,6 @@ import {
 } from "openclaw/plugin-sdk/webhook-request-guards";
 import { resolveDefaultLineAccountId } from "./accounts.js";
 import { deliverLineAutoReply } from "./auto-reply-delivery.js";
-import { LineRetryableWebhookError } from "./bot-handlers.js";
 import { createLineBot } from "./bot.js";
 import { processLineMessage } from "./markdown-to-line.js";
 import { resolveLineDurableReplyOptions } from "./monitor-durable.js";
@@ -48,7 +47,11 @@ import {
 } from "./send.js";
 import { buildTemplateMessageFromPayload } from "./template-messages.js";
 import type { LineChannelData, ResolvedLineAccount } from "./types.js";
-import { waitForLineWebhookDispatchAcceptance } from "./webhook-ack.js";
+import {
+  LINE_WEBHOOK_RESPONSE_DEADLINE_MS,
+  assertLineWebhookResponseDeadline,
+  waitForLineWebhookDispatchAcceptance,
+} from "./webhook-ack.js";
 import { createLineNodeWebhookHandler, readLineWebhookRequestBody } from "./webhook-node.js";
 import { parseLineWebhookBody, validateLineSignature } from "./webhook-utils.js";
 
@@ -153,12 +156,21 @@ export async function monitorLineProvider(
 
       const { ctxPayload, replyToken, route } = ctx;
       let eventAccepted = false;
+      let eventAcceptance: Promise<void> | undefined;
       const acceptEvent = async () => {
         if (eventAccepted) {
           return;
         }
-        eventAccepted = true;
-        await ctx.onEventAccepted?.();
+        eventAcceptance ??= (async () => {
+          await ctx.onEventAccepted?.();
+          eventAccepted = true;
+        })();
+        try {
+          await eventAcceptance;
+        } catch (error) {
+          eventAcceptance = undefined;
+          throw error;
+        }
       };
 
       const shouldShowLoading = Boolean(ctx.userId && !ctx.isGroup);
@@ -285,7 +297,7 @@ export async function monitorLineProvider(
         if (!eventAccepted) {
           // Returning a non-2xx response asks LINE to redeliver this event.
           // Its reply token is one-use, so do not consume it before the retry.
-          throw new LineRetryableWebhookError("line event failed before reply-lane adoption", {
+          throw new Error("line event failed before reply-lane adoption", {
             cause: err,
           });
         }
@@ -352,6 +364,7 @@ export async function monitorLineProvider(
           return;
         }
 
+        const responseDeadlineAt = Date.now() + LINE_WEBHOOK_RESPONSE_DEADLINE_MS;
         let receiveContext: MessageReceiveContext<webhook.CallbackRequest> | undefined;
         try {
           const signatureHeader = req.headers["x-line-signature"];
@@ -373,8 +386,12 @@ export async function monitorLineProvider(
           const rawBody = await readLineWebhookRequestBody(
             req,
             LINE_WEBHOOK_PREAUTH_MAX_BODY_BYTES,
-            LINE_WEBHOOK_PREAUTH_BODY_TIMEOUT_MS,
+            Math.max(
+              1,
+              Math.min(LINE_WEBHOOK_PREAUTH_BODY_TIMEOUT_MS, responseDeadlineAt - Date.now()),
+            ),
           );
+          assertLineWebhookResponseDeadline(responseDeadlineAt);
           const match = resolveSingleWebhookTarget(targets, (target) =>
             validateLineSignature(rawBody, signature, target.channelSecret),
           );
@@ -423,6 +440,7 @@ export async function monitorLineProvider(
           await waitForLineWebhookDispatchAcceptance({
             body,
             dispatch: match.target.bot.handleWebhook,
+            responseDeadlineAt,
             runtime: match.target.runtime,
           });
           await receiveContext.ack();

--- a/extensions/line/src/outbound.ts
+++ b/extensions/line/src/outbound.ts
@@ -446,7 +446,7 @@ export const lineMessageAdapter = defineChannelMessageAdapter({
     },
   },
   receive: {
-    defaultAckPolicy: "after_receive_record",
-    supportedAckPolicies: ["after_receive_record"],
+    defaultAckPolicy: "after_agent_dispatch",
+    supportedAckPolicies: ["after_agent_dispatch"],
   },
 });

--- a/extensions/line/src/webhook-ack.ts
+++ b/extensions/line/src/webhook-ack.ts
@@ -21,9 +21,11 @@ export type LineWebhookDispatchCallbacks = {
   onEventAccepted: (event: webhook.Event) => void | Promise<void>;
 };
 
-export type LineWebhookDispatchHandler = (
+export type LineWebhookDispatchHandler = (body: webhook.CallbackRequest) => Promise<void>;
+
+export type LineWebhookAcceptanceDispatchHandler = (
   body: webhook.CallbackRequest,
-  callbacks?: LineWebhookDispatchCallbacks,
+  callbacks: LineWebhookDispatchCallbacks,
 ) => Promise<void>;
 
 function logLineWebhookDispatchError(runtime: RuntimeEnv | undefined, err: unknown): void {
@@ -37,7 +39,7 @@ function logLineWebhookDispatchError(runtime: RuntimeEnv | undefined, err: unkno
  */
 export async function waitForLineWebhookDispatchAcceptance(params: {
   body: webhook.CallbackRequest;
-  dispatch: LineWebhookDispatchHandler;
+  dispatch: LineWebhookAcceptanceDispatchHandler;
   responseDeadlineAt?: number;
   runtime?: RuntimeEnv;
 }): Promise<void> {

--- a/extensions/line/src/webhook-ack.ts
+++ b/extensions/line/src/webhook-ack.ts
@@ -19,6 +19,8 @@ export function assertLineWebhookResponseDeadline(responseDeadlineAt: number): v
 export type LineWebhookDispatchCallbacks = {
   /** Called once when one webhook event is durably owned or needs no dispatch. */
   onEventAccepted: (event: webhook.Event) => void | Promise<void>;
+  /** Aborted when ingress can no longer acknowledge pre-acceptance work safely. */
+  abortSignal: AbortSignal;
 };
 
 export type LineWebhookDispatchHandler = (body: webhook.CallbackRequest) => Promise<void>;
@@ -30,6 +32,16 @@ export type LineWebhookAcceptanceDispatchHandler = (
 
 function logLineWebhookDispatchError(runtime: RuntimeEnv | undefined, err: unknown): void {
   runtime?.error?.(danger(`line webhook dispatch failed: ${String(err)}`));
+}
+
+export function dispatchLineWebhookInBackground(params: {
+  body: webhook.CallbackRequest;
+  dispatch: LineWebhookDispatchHandler;
+  runtime?: RuntimeEnv;
+}): void {
+  void Promise.resolve()
+    .then(() => params.dispatch(params.body))
+    .catch((error: unknown) => logLineWebhookDispatchError(params.runtime, error));
 }
 
 /**
@@ -52,6 +64,7 @@ export async function waitForLineWebhookDispatchAcceptance(params: {
     params.responseDeadlineAt ?? Date.now() + LINE_WEBHOOK_RESPONSE_DEADLINE_MS;
   assertLineWebhookResponseDeadline(responseDeadlineAt);
   const acceptedEvents = new Set<webhook.Event>();
+  const dispatchAbort = new AbortController();
   let settled = false;
   let acceptanceDeadline: ReturnType<typeof setTimeout> | undefined;
   let resolveAcceptance!: () => void;
@@ -71,6 +84,7 @@ export async function waitForLineWebhookDispatchAcceptance(params: {
       return;
     }
     settled = true;
+    dispatchAbort.abort(error);
     clearAcceptanceDeadline();
     rejectAcceptancePromise(error);
   };
@@ -95,6 +109,7 @@ export async function waitForLineWebhookDispatchAcceptance(params: {
   const dispatch = Promise.resolve().then(() => {
     assertLineWebhookResponseDeadline(responseDeadlineAt);
     return params.dispatch(params.body, {
+      abortSignal: dispatchAbort.signal,
       onEventAccepted: (event) => {
         if (settled || !expectedEvents.has(event)) {
           return;

--- a/extensions/line/src/webhook-ack.ts
+++ b/extensions/line/src/webhook-ack.ts
@@ -2,6 +2,20 @@
 import type { webhook } from "@line/bot-sdk";
 import { danger, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 
+// LINE classifies responses after 2s as request_timeout. Fail before that
+// limit to release ingress capacity; this deadline never acknowledges an event.
+export const LINE_WEBHOOK_RESPONSE_DEADLINE_MS = 1_500;
+
+function createLineWebhookResponseDeadlineError(): Error {
+  return new Error("LINE webhook response deadline elapsed before acceptance");
+}
+
+export function assertLineWebhookResponseDeadline(responseDeadlineAt: number): void {
+  if (Date.now() >= responseDeadlineAt) {
+    throw createLineWebhookResponseDeadlineError();
+  }
+}
+
 export type LineWebhookDispatchCallbacks = {
   /** Called once when one webhook event is durably owned or needs no dispatch. */
   onEventAccepted: (event: webhook.Event) => void | Promise<void>;
@@ -12,7 +26,7 @@ export type LineWebhookDispatchHandler = (
   callbacks?: LineWebhookDispatchCallbacks,
 ) => Promise<void>;
 
-export function logLineWebhookDispatchError(runtime: RuntimeEnv | undefined, err: unknown): void {
+function logLineWebhookDispatchError(runtime: RuntimeEnv | undefined, err: unknown): void {
   runtime?.error?.(danger(`line webhook dispatch failed: ${String(err)}`));
 }
 
@@ -24,6 +38,7 @@ export function logLineWebhookDispatchError(runtime: RuntimeEnv | undefined, err
 export async function waitForLineWebhookDispatchAcceptance(params: {
   body: webhook.CallbackRequest;
   dispatch: LineWebhookDispatchHandler;
+  responseDeadlineAt?: number;
   runtime?: RuntimeEnv;
 }): Promise<void> {
   const expectedEvents = new Set(params.body.events ?? []);
@@ -31,42 +46,72 @@ export async function waitForLineWebhookDispatchAcceptance(params: {
     return;
   }
 
+  const responseDeadlineAt =
+    params.responseDeadlineAt ?? Date.now() + LINE_WEBHOOK_RESPONSE_DEADLINE_MS;
+  assertLineWebhookResponseDeadline(responseDeadlineAt);
   const acceptedEvents = new Set<webhook.Event>();
   let settled = false;
+  let acceptanceDeadline: ReturnType<typeof setTimeout> | undefined;
   let resolveAcceptance!: () => void;
   let rejectAcceptancePromise!: (error: unknown) => void;
   const acceptance = new Promise<void>((resolve, reject) => {
     resolveAcceptance = resolve;
     rejectAcceptancePromise = reject;
   });
-  const acceptRemainingEvents = () => {
-    if (settled) {
-      return;
+  const clearAcceptanceDeadline = () => {
+    if (acceptanceDeadline) {
+      clearTimeout(acceptanceDeadline);
+      acceptanceDeadline = undefined;
     }
-    settled = true;
-    resolveAcceptance();
   };
   const rejectAcceptance = (error: unknown) => {
     if (settled) {
       return;
     }
     settled = true;
+    clearAcceptanceDeadline();
     rejectAcceptancePromise(error);
   };
-  const dispatch = Promise.resolve().then(() =>
-    params.dispatch(params.body, {
+  const acceptRemainingEvents = () => {
+    if (settled) {
+      return;
+    }
+    try {
+      assertLineWebhookResponseDeadline(responseDeadlineAt);
+    } catch (error) {
+      rejectAcceptance(error);
+      return;
+    }
+    settled = true;
+    clearAcceptanceDeadline();
+    resolveAcceptance();
+  };
+  acceptanceDeadline = setTimeout(
+    () => rejectAcceptance(createLineWebhookResponseDeadlineError()),
+    Math.max(0, responseDeadlineAt - Date.now()),
+  );
+  const dispatch = Promise.resolve().then(() => {
+    assertLineWebhookResponseDeadline(responseDeadlineAt);
+    return params.dispatch(params.body, {
       onEventAccepted: (event) => {
         if (settled || !expectedEvents.has(event)) {
+          return;
+        }
+        try {
+          assertLineWebhookResponseDeadline(responseDeadlineAt);
+        } catch (error) {
+          rejectAcceptance(error);
           return;
         }
         acceptedEvents.add(event);
         if (acceptedEvents.size === expectedEvents.size) {
           settled = true;
+          clearAcceptanceDeadline();
           resolveAcceptance();
         }
       },
-    }),
-  );
+    });
+  });
   void dispatch.then(
     () => acceptRemainingEvents(),
     (error: unknown) => {

--- a/extensions/line/src/webhook-ack.ts
+++ b/extensions/line/src/webhook-ack.ts
@@ -1,0 +1,81 @@
+// Line plugin module implements webhook acknowledgement helpers.
+import type { webhook } from "@line/bot-sdk";
+import { danger, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+
+export type LineWebhookDispatchCallbacks = {
+  /** Called once when one webhook event is durably owned or needs no dispatch. */
+  onEventAccepted: (event: webhook.Event) => void | Promise<void>;
+};
+
+export type LineWebhookDispatchHandler = (
+  body: webhook.CallbackRequest,
+  callbacks?: LineWebhookDispatchCallbacks,
+) => Promise<void>;
+
+export function logLineWebhookDispatchError(runtime: RuntimeEnv | undefined, err: unknown): void {
+  runtime?.error?.(danger(`line webhook dispatch failed: ${String(err)}`));
+}
+
+/**
+ * Wait until every callback event is either handed to the durable reply lane
+ * or completes without one. A completed legacy handler is safe fallback only
+ * because all of its events have already settled.
+ */
+export async function waitForLineWebhookDispatchAcceptance(params: {
+  body: webhook.CallbackRequest;
+  dispatch: LineWebhookDispatchHandler;
+  runtime?: RuntimeEnv;
+}): Promise<void> {
+  const expectedEvents = new Set(params.body.events ?? []);
+  if (expectedEvents.size === 0) {
+    return;
+  }
+
+  const acceptedEvents = new Set<webhook.Event>();
+  let settled = false;
+  let resolveAcceptance!: () => void;
+  let rejectAcceptancePromise!: (error: unknown) => void;
+  const acceptance = new Promise<void>((resolve, reject) => {
+    resolveAcceptance = resolve;
+    rejectAcceptancePromise = reject;
+  });
+  const acceptRemainingEvents = () => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    resolveAcceptance();
+  };
+  const rejectAcceptance = (error: unknown) => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    rejectAcceptancePromise(error);
+  };
+  const dispatch = Promise.resolve().then(() =>
+    params.dispatch(params.body, {
+      onEventAccepted: (event) => {
+        if (settled || !expectedEvents.has(event)) {
+          return;
+        }
+        acceptedEvents.add(event);
+        if (acceptedEvents.size === expectedEvents.size) {
+          settled = true;
+          resolveAcceptance();
+        }
+      },
+    }),
+  );
+  void dispatch.then(
+    () => acceptRemainingEvents(),
+    (error: unknown) => {
+      const acceptedBeforeFailure = settled;
+      rejectAcceptance(error);
+      if (acceptedBeforeFailure) {
+        logLineWebhookDispatchError(params.runtime, error);
+      }
+    },
+  );
+  await acceptance;
+}

--- a/extensions/line/src/webhook-node.test.ts
+++ b/extensions/line/src/webhook-node.test.ts
@@ -37,12 +37,16 @@ const SECRET = "secret";
 it("bounds stalled LINE webhook acceptance before the upstream response deadline", async () => {
   vi.useFakeTimers();
   try {
+    let dispatchSignal: AbortSignal | undefined;
     const body = {
       events: [{ type: "message" }],
     } as unknown as webhook.CallbackRequest;
     const acceptance = waitForLineWebhookDispatchAcceptance({
       body,
-      dispatch: async () => await new Promise<void>(() => {}),
+      dispatch: async (_body, callbacks) => {
+        dispatchSignal = callbacks.abortSignal;
+        await new Promise<void>(() => {});
+      },
       runtime: createRuntimeMock(),
     });
     const rejection = expect(acceptance).rejects.toThrow(
@@ -51,6 +55,7 @@ it("bounds stalled LINE webhook acceptance before the upstream response deadline
 
     await vi.advanceTimersByTimeAsync(1_500);
     await rejection;
+    expect(dispatchSignal?.aborted).toBe(true);
   } finally {
     vi.useRealTimers();
   }
@@ -159,13 +164,21 @@ async function invokeWebhook(params: {
   onEvents?: ReturnType<typeof vi.fn>;
   autoSign?: boolean;
   runtime?: RuntimeEnv;
+  waitsForEventAcceptance?: boolean;
 }) {
   const onEventsMock = params.onEvents ?? vi.fn(async () => {});
-  const middleware = createLineWebhookMiddleware({
-    channelSecret: SECRET,
-    onEvents: onEventsMock as never,
-    runtime: params.runtime,
-  });
+  const middleware = params.waitsForEventAcceptance
+    ? createLineWebhookMiddleware({
+        channelSecret: SECRET,
+        onEvents: onEventsMock as never,
+        runtime: params.runtime,
+        acknowledgement: "after_event_acceptance",
+      })
+    : createLineWebhookMiddleware({
+        channelSecret: SECRET,
+        onEvents: onEventsMock as never,
+        runtime: params.runtime,
+      });
 
   const headers = { ...params.headers };
   const autoSign = params.autoSign ?? true;
@@ -224,7 +237,10 @@ async function invokeNodePostContract(params: {
   const runtime = createRuntimeMock();
   const handler = createLineNodeWebhookHandler({
     channelSecret: SECRET,
-    bot: { handleWebhook: dispatched },
+    bot: {
+      handleWebhook: dispatched,
+      webhookAcknowledgement: "after_event_acceptance",
+    },
     runtime,
     readBody: async () => params.rawBody,
   });
@@ -262,6 +278,7 @@ async function invokeMiddlewarePostContract(params: {
     autoSign: params.signed,
     onEvents,
     runtime,
+    waitsForEventAcceptance: true,
   });
   return {
     body: res.json.mock.calls.at(-1)?.[0],
@@ -545,7 +562,7 @@ describe("createLineNodeWebhookHandler", () => {
     const runtime = createRuntimeMock();
     const handler = createLineNodeWebhookHandler({
       channelSecret: SECRET,
-      bot,
+      bot: { ...bot, webhookAcknowledgement: "after_event_acceptance" },
       runtime,
       readBody: async () => rawBody,
     });
@@ -620,41 +637,33 @@ describe("createLineNodeWebhookHandler", () => {
     expect(bot.handleWebhook).not.toHaveBeenCalled();
   });
 
-  it("preserves completion acknowledgement for callback-less handlers", async () => {
-    vi.useFakeTimers();
-    try {
-      const rawBody = JSON.stringify({ events: [{ type: "message" }] });
-      let finishDispatch: (() => void) | undefined;
-      const bot = {
-        handleWebhook: vi.fn(
-          async () =>
-            await new Promise<void>((resolve) => {
-              finishDispatch = resolve;
-            }),
-        ),
-      };
-      const handler = createLineNodeWebhookHandler({
-        channelSecret: SECRET,
-        bot,
-        runtime: createRuntimeMock(),
-        readBody: async () => rawBody,
-      });
-      const { res } = createRes();
-      const request = runSignedPost({ handler, rawBody, secret: SECRET, res });
+  it("preserves immediate acknowledgement for callback-less handlers", async () => {
+    const rawBody = JSON.stringify({ events: [{ type: "message" }] });
+    let finishDispatch: (() => void) | undefined;
+    const bot = {
+      handleWebhook: vi.fn(
+        async () =>
+          await new Promise<void>((resolve) => {
+            finishDispatch = resolve;
+          }),
+      ),
+    };
+    const handler = createLineNodeWebhookHandler({
+      channelSecret: SECRET,
+      bot,
+      runtime: createRuntimeMock(),
+      readBody: async () => rawBody,
+    });
+    const { res } = createRes();
 
-      await vi.waitFor(() => expect(bot.handleWebhook).toHaveBeenCalledTimes(1));
-      await vi.advanceTimersByTimeAsync(1_500);
-      expect(res.headersSent).toBe(false);
-      if (!finishDispatch) {
-        throw new Error("Expected callback-less LINE handler to start");
-      }
-      finishDispatch();
-      await request;
+    await runSignedPost({ handler, rawBody, secret: SECRET, res });
 
-      expect(res.statusCode).toBe(200);
-    } finally {
-      vi.useRealTimers();
+    expect(res.statusCode).toBe(200);
+    expect(bot.handleWebhook).toHaveBeenCalledTimes(1);
+    if (!finishDispatch) {
+      throw new Error("Expected callback-less LINE handler to start");
     }
+    finishDispatch();
   });
 });
 
@@ -765,40 +774,32 @@ describe("createLineWebhookMiddleware", () => {
     expect(onEvents).not.toHaveBeenCalled();
   });
 
-  it("preserves completion acknowledgement for callback-less handlers", async () => {
-    vi.useFakeTimers();
-    try {
-      const rawBody = JSON.stringify({ events: [{ type: "message" }] });
-      let finishDispatch: (() => void) | undefined;
-      const onEvents = vi.fn(
-        async () =>
-          await new Promise<void>((resolve) => {
-            finishDispatch = resolve;
-          }),
-      );
-      const middleware = createLineWebhookMiddleware({
-        channelSecret: SECRET,
-        onEvents,
-      });
-      const req = createMiddlewareRequest({
-        headers: { "x-line-signature": sign(rawBody, SECRET) },
-        body: rawBody,
-      });
-      const res = createMiddlewareRes();
-      const request = middleware(req, res, vi.fn() as NextFunction);
+  it("preserves immediate acknowledgement for callback-less handlers", async () => {
+    const rawBody = JSON.stringify({ events: [{ type: "message" }] });
+    let finishDispatch: (() => void) | undefined;
+    const onEvents = vi.fn(
+      async () =>
+        await new Promise<void>((resolve) => {
+          finishDispatch = resolve;
+        }),
+    );
+    const middleware = createLineWebhookMiddleware({
+      channelSecret: SECRET,
+      onEvents,
+    });
+    const req = createMiddlewareRequest({
+      headers: { "x-line-signature": sign(rawBody, SECRET) },
+      body: rawBody,
+    });
+    const res = createMiddlewareRes();
 
-      await vi.waitFor(() => expect(onEvents).toHaveBeenCalledTimes(1));
-      await vi.advanceTimersByTimeAsync(1_500);
-      expect(res.status).not.toHaveBeenCalled();
-      if (!finishDispatch) {
-        throw new Error("Expected callback-less LINE middleware handler to start");
-      }
-      finishDispatch();
-      await request;
+    await middleware(req, res, vi.fn() as NextFunction);
 
-      expect(res.status).toHaveBeenCalledWith(200);
-    } finally {
-      vi.useRealTimers();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(onEvents).toHaveBeenCalledTimes(1);
+    if (!finishDispatch) {
+      throw new Error("Expected callback-less LINE middleware handler to start");
     }
+    finishDispatch();
   });
 });

--- a/extensions/line/src/webhook-node.test.ts
+++ b/extensions/line/src/webhook-node.test.ts
@@ -313,7 +313,7 @@ describe("LINE webhook shared POST contract", () => {
   );
 
   it.each(sharedWebhookPostContractCases)(
-    "$name acknowledges signed events before failed background processing is logged",
+    "$name returns a retryable failure when dispatch rejects before acceptance",
     async ({ invoke }) => {
       const result = await invoke({
         failWith: new Error("transient failure"),
@@ -321,12 +321,10 @@ describe("LINE webhook shared POST contract", () => {
         signed: true,
       });
 
-      expect(result.status).toBe(200);
-      expect(result.body).toEqual({ status: "ok" });
+      expect(result.status).toBe(500);
+      expect(result.body).toEqual({ error: "Internal server error" });
       expect(result.dispatched).toHaveBeenCalledTimes(1);
-      await vi.waitFor(() => {
-        expect(result.runtimeError).toHaveBeenCalledTimes(1);
-      });
+      expect(result.runtimeError).toHaveBeenCalledTimes(1);
     },
   );
 });
@@ -453,10 +451,18 @@ describe("createLineNodeWebhookHandler", () => {
     let releaseAuthenticated: (() => void) | undefined;
     const bot = {
       handleWebhook: vi.fn(
-        async () =>
+        async (
+          body,
+          callbacks?: { onEventAccepted?: (event: webhook.Event) => void | Promise<void> },
+        ) => {
+          const event = body.events?.[0];
+          if (event) {
+            await callbacks?.onEventAccepted?.(event);
+          }
           await new Promise<void>((resolve) => {
             releaseAuthenticated = resolve;
-          }),
+          });
+        },
       ),
     };
     const onRequestAuthenticated = vi.fn();
@@ -485,6 +491,81 @@ describe("createLineNodeWebhookHandler", () => {
       throw new Error("Expected LINE authenticated request release callback to be initialized");
     }
     releaseAuthenticated();
+  });
+
+  it("does not acknowledge a delayed pre-dispatch rejection", async () => {
+    const rawBody = JSON.stringify({ events: [{ type: "message" }] });
+    const bot = {
+      handleWebhook: vi.fn(async () => {
+        await Promise.resolve();
+        throw new Error("routing failed");
+      }),
+    };
+    const runtime = createRuntimeMock();
+    const handler = createLineNodeWebhookHandler({
+      channelSecret: SECRET,
+      bot,
+      runtime,
+      readBody: async () => rawBody,
+    });
+
+    const { res } = createRes();
+    await runSignedPost({ handler, rawBody, secret: SECRET, res });
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toBe(JSON.stringify({ error: "Internal server error" }));
+    expect(runtime.error).toHaveBeenCalled();
+  });
+
+  it("waits for every event in a multi-event callback to be accepted", async () => {
+    const rawBody = JSON.stringify({
+      events: [{ type: "message" }, { type: "follow" }],
+    });
+    let acceptSecondEvent: (() => void) | undefined;
+    let releaseProcessing: (() => void) | undefined;
+    const bot = {
+      handleWebhook: vi.fn(
+        async (
+          body,
+          callbacks?: { onEventAccepted?: (event: webhook.Event) => void | Promise<void> },
+        ) => {
+          const [firstEvent, secondEvent] = body.events ?? [];
+          if (!firstEvent || !secondEvent) {
+            throw new Error("Expected two LINE webhook events");
+          }
+          await callbacks?.onEventAccepted?.(firstEvent);
+          await new Promise<void>((resolve) => {
+            acceptSecondEvent = resolve;
+          });
+          await callbacks?.onEventAccepted?.(secondEvent);
+          await new Promise<void>((resolve) => {
+            releaseProcessing = resolve;
+          });
+        },
+      ),
+    };
+    const handler = createLineNodeWebhookHandler({
+      channelSecret: SECRET,
+      bot,
+      runtime: createRuntimeMock(),
+      readBody: async () => rawBody,
+    });
+
+    const { res } = createRes();
+    const request = runSignedPost({ handler, rawBody, secret: SECRET, res });
+    await vi.waitFor(() => expect(bot.handleWebhook).toHaveBeenCalledTimes(1));
+    expect(res.headersSent).toBe(false);
+    if (!acceptSecondEvent) {
+      throw new Error("Expected second LINE event acceptance callback");
+    }
+    acceptSecondEvent();
+    await request;
+
+    expect(res.statusCode).toBe(200);
+    if (!releaseProcessing) {
+      throw new Error("Expected LINE handler to continue after acknowledgement");
+    }
+    releaseProcessing();
   });
 
   it("returns 400 for invalid JSON payload even when signature is valid", async () => {

--- a/extensions/line/src/webhook-node.test.ts
+++ b/extensions/line/src/webhook-node.test.ts
@@ -1,10 +1,12 @@
 // Line tests cover webhook node plugin behavior.
 import crypto from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import type { webhook } from "@line/bot-sdk";
 import type { NextFunction, Request, Response } from "express";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { createMockIncomingRequest } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
+import { waitForLineWebhookDispatchAcceptance } from "./webhook-ack.js";
 import { createLineNodeWebhookHandler, readLineWebhookRequestBody } from "./webhook-node.js";
 import { createLineWebhookMiddleware } from "./webhook.js";
 
@@ -31,6 +33,44 @@ function createRes() {
 }
 
 const SECRET = "secret";
+
+it("bounds stalled LINE webhook acceptance before the upstream response deadline", async () => {
+  vi.useFakeTimers();
+  try {
+    const body = {
+      events: [{ type: "message" }],
+    } as unknown as webhook.CallbackRequest;
+    const acceptance = waitForLineWebhookDispatchAcceptance({
+      body,
+      dispatch: async () => await new Promise<void>(() => {}),
+      runtime: createRuntimeMock(),
+    });
+    const rejection = expect(acceptance).rejects.toThrow(
+      "LINE webhook response deadline elapsed before acceptance",
+    );
+
+    await vi.advanceTimersByTimeAsync(1_500);
+    await rejection;
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+it("does not dispatch after the LINE webhook response deadline", async () => {
+  const dispatch = vi.fn(async () => {});
+  const body = {
+    events: [{ type: "message" }],
+  } as unknown as webhook.CallbackRequest;
+
+  await expect(
+    waitForLineWebhookDispatchAcceptance({
+      body,
+      dispatch,
+      responseDeadlineAt: Date.now() - 1,
+    }),
+  ).rejects.toThrow("LINE webhook response deadline elapsed before acceptance");
+  expect(dispatch).not.toHaveBeenCalled();
+});
 
 type ParsedLineWebhookPayload = {
   events: unknown;
@@ -394,13 +434,14 @@ describe("createLineNodeWebhookHandler", () => {
     expect(bot.handleWebhook).not.toHaveBeenCalled();
   });
 
-  it("uses strict pre-auth limits for signed POST requests", async () => {
+  it("bounds signed POST body reads by the LINE response deadline", async () => {
     const rawBody = JSON.stringify({ events: [{ type: "message" }] });
     const bot = { handleWebhook: vi.fn(async () => {}) };
     const runtime = createRuntimeMock();
     const readBody = vi.fn(async (_req: IncomingMessage, maxBytes: number, timeoutMs?: number) => {
       expect(maxBytes).toBe(64 * 1024);
-      expect(timeoutMs).toBe(5_000);
+      expect(timeoutMs).toBeGreaterThan(0);
+      expect(timeoutMs).toBeLessThanOrEqual(1_500);
       return rawBody;
     });
     const handler = createLineNodeWebhookHandler({

--- a/extensions/line/src/webhook-node.test.ts
+++ b/extensions/line/src/webhook-node.test.ts
@@ -450,6 +450,7 @@ describe("createLineNodeWebhookHandler", () => {
       runtime,
       readBody,
       maxBodyBytes: 1024 * 1024,
+      acknowledgement: "after_event_acceptance",
     });
 
     const { res } = createRes();
@@ -514,6 +515,7 @@ describe("createLineNodeWebhookHandler", () => {
       runtime,
       readBody: async () => rawBody,
       onRequestAuthenticated,
+      acknowledgement: "after_event_acceptance",
     });
 
     const { res } = createRes();
@@ -590,6 +592,7 @@ describe("createLineNodeWebhookHandler", () => {
       bot,
       runtime: createRuntimeMock(),
       readBody: async () => rawBody,
+      acknowledgement: "after_event_acceptance",
     });
 
     const { res } = createRes();
@@ -618,6 +621,43 @@ describe("createLineNodeWebhookHandler", () => {
 
     expect(res.statusCode).toBe(400);
     expect(bot.handleWebhook).not.toHaveBeenCalled();
+  });
+
+  it("preserves completion acknowledgement for callback-less handlers", async () => {
+    vi.useFakeTimers();
+    try {
+      const rawBody = JSON.stringify({ events: [{ type: "message" }] });
+      let finishDispatch: (() => void) | undefined;
+      const bot = {
+        handleWebhook: vi.fn(
+          async () =>
+            await new Promise<void>((resolve) => {
+              finishDispatch = resolve;
+            }),
+        ),
+      };
+      const handler = createLineNodeWebhookHandler({
+        channelSecret: SECRET,
+        bot,
+        runtime: createRuntimeMock(),
+        readBody: async () => rawBody,
+      });
+      const { res } = createRes();
+      const request = runSignedPost({ handler, rawBody, secret: SECRET, res });
+
+      await vi.waitFor(() => expect(bot.handleWebhook).toHaveBeenCalledTimes(1));
+      await vi.advanceTimersByTimeAsync(1_500);
+      expect(res.headersSent).toBe(false);
+      if (!finishDispatch) {
+        throw new Error("Expected callback-less LINE handler to start");
+      }
+      finishDispatch();
+      await request;
+
+      expect(res.statusCode).toBe(200);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -726,5 +766,42 @@ describe("createLineWebhookMiddleware", () => {
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json).toHaveBeenCalledWith({ error: "Invalid webhook payload" });
     expect(onEvents).not.toHaveBeenCalled();
+  });
+
+  it("preserves completion acknowledgement for callback-less handlers", async () => {
+    vi.useFakeTimers();
+    try {
+      const rawBody = JSON.stringify({ events: [{ type: "message" }] });
+      let finishDispatch: (() => void) | undefined;
+      const onEvents = vi.fn(
+        async () =>
+          await new Promise<void>((resolve) => {
+            finishDispatch = resolve;
+          }),
+      );
+      const middleware = createLineWebhookMiddleware({
+        channelSecret: SECRET,
+        onEvents,
+      });
+      const req = createMiddlewareRequest({
+        headers: { "x-line-signature": sign(rawBody, SECRET) },
+        body: rawBody,
+      });
+      const res = createMiddlewareRes();
+      const request = middleware(req, res, vi.fn() as NextFunction);
+
+      await vi.waitFor(() => expect(onEvents).toHaveBeenCalledTimes(1));
+      await vi.advanceTimersByTimeAsync(1_500);
+      expect(res.status).not.toHaveBeenCalled();
+      if (!finishDispatch) {
+        throw new Error("Expected callback-less LINE middleware handler to start");
+      }
+      finishDispatch();
+      await request;
+
+      expect(res.status).toHaveBeenCalledWith(200);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/extensions/line/src/webhook-node.test.ts
+++ b/extensions/line/src/webhook-node.test.ts
@@ -446,11 +446,10 @@ describe("createLineNodeWebhookHandler", () => {
     });
     const handler = createLineNodeWebhookHandler({
       channelSecret: "secret",
-      bot,
+      bot: { ...bot, webhookAcknowledgement: "after_event_acceptance" },
       runtime,
       readBody,
       maxBodyBytes: 1024 * 1024,
-      acknowledgement: "after_event_acceptance",
     });
 
     const { res } = createRes();
@@ -511,11 +510,10 @@ describe("createLineNodeWebhookHandler", () => {
     const runtime = createRuntimeMock();
     const handler = createLineNodeWebhookHandler({
       channelSecret: SECRET,
-      bot,
+      bot: { ...bot, webhookAcknowledgement: "after_event_acceptance" },
       runtime,
       readBody: async () => rawBody,
       onRequestAuthenticated,
-      acknowledgement: "after_event_acceptance",
     });
 
     const { res } = createRes();
@@ -589,10 +587,9 @@ describe("createLineNodeWebhookHandler", () => {
     };
     const handler = createLineNodeWebhookHandler({
       channelSecret: SECRET,
-      bot,
+      bot: { ...bot, webhookAcknowledgement: "after_event_acceptance" },
       runtime: createRuntimeMock(),
       readBody: async () => rawBody,
-      acknowledgement: "after_event_acceptance",
     });
 
     const { res } = createRes();

--- a/extensions/line/src/webhook-node.ts
+++ b/extensions/line/src/webhook-node.ts
@@ -12,6 +12,8 @@ import {
   requestBodyErrorToText,
 } from "openclaw/plugin-sdk/webhook-request-guards";
 import {
+  LINE_WEBHOOK_RESPONSE_DEADLINE_MS,
+  assertLineWebhookResponseDeadline,
   type LineWebhookDispatchHandler,
   waitForLineWebhookDispatchAcceptance,
 } from "./webhook-ack.js";
@@ -66,6 +68,7 @@ export function createLineNodeWebhookHandler(params: {
       return;
     }
 
+    const responseDeadlineAt = Date.now() + LINE_WEBHOOK_RESPONSE_DEADLINE_MS;
     let receiveContext: MessageReceiveContext<webhook.CallbackRequest> | undefined;
     try {
       const signatureHeader = req.headers["x-line-signature"];
@@ -87,8 +90,12 @@ export function createLineNodeWebhookHandler(params: {
       const rawBody = await readBody(
         req,
         Math.min(maxBodyBytes, LINE_WEBHOOK_PREAUTH_MAX_BODY_BYTES),
-        LINE_WEBHOOK_PREAUTH_BODY_TIMEOUT_MS,
+        Math.max(
+          1,
+          Math.min(LINE_WEBHOOK_PREAUTH_BODY_TIMEOUT_MS, responseDeadlineAt - Date.now()),
+        ),
       );
+      assertLineWebhookResponseDeadline(responseDeadlineAt);
 
       if (!validateLineSignature(rawBody, signature, params.channelSecret)) {
         logVerbose("line: webhook signature validation failed");
@@ -130,6 +137,7 @@ export function createLineNodeWebhookHandler(params: {
       await waitForLineWebhookDispatchAcceptance({
         body,
         dispatch: params.bot.handleWebhook,
+        responseDeadlineAt,
         runtime: params.runtime,
       });
       await receiveContext.ack();

--- a/extensions/line/src/webhook-node.ts
+++ b/extensions/line/src/webhook-node.ts
@@ -14,6 +14,7 @@ import {
 import {
   LINE_WEBHOOK_RESPONSE_DEADLINE_MS,
   assertLineWebhookResponseDeadline,
+  type LineWebhookAcceptanceDispatchHandler,
   type LineWebhookDispatchHandler,
   waitForLineWebhookDispatchAcceptance,
 } from "./webhook-ack.js";
@@ -36,14 +37,28 @@ export async function readLineWebhookRequestBody(
 
 type ReadBodyFn = (req: IncomingMessage, maxBytes: number, timeoutMs?: number) => Promise<string>;
 
-export function createLineNodeWebhookHandler(params: {
+type LineNodeWebhookHandlerParams = {
   channelSecret: string;
-  bot: { handleWebhook: LineWebhookDispatchHandler };
   runtime: RuntimeEnv;
   readBody?: ReadBodyFn;
   maxBodyBytes?: number;
   onRequestAuthenticated?: () => void;
-}): (req: IncomingMessage, res: ServerResponse) => Promise<void> {
+} & (
+  | {
+      /** Preserve the existing API contract by acknowledging after dispatch completes. */
+      acknowledgement?: "after_dispatch";
+      bot: { handleWebhook: LineWebhookDispatchHandler };
+    }
+  | {
+      /** Acknowledge once every event is durably adopted, before processing completes. */
+      acknowledgement: "after_event_acceptance";
+      bot: { handleWebhook: LineWebhookAcceptanceDispatchHandler };
+    }
+);
+
+export function createLineNodeWebhookHandler(
+  params: LineNodeWebhookHandlerParams,
+): (req: IncomingMessage, res: ServerResponse) => Promise<void> {
   const maxBodyBytes = params.maxBodyBytes ?? LINE_WEBHOOK_MAX_BODY_BYTES;
   const readBody = params.readBody ?? readLineWebhookRequestBody;
 
@@ -68,7 +83,10 @@ export function createLineNodeWebhookHandler(params: {
       return;
     }
 
-    const responseDeadlineAt = Date.now() + LINE_WEBHOOK_RESPONSE_DEADLINE_MS;
+    const waitsForEventAcceptance = params.acknowledgement === "after_event_acceptance";
+    const responseDeadlineAt = waitsForEventAcceptance
+      ? Date.now() + LINE_WEBHOOK_RESPONSE_DEADLINE_MS
+      : undefined;
     let receiveContext: MessageReceiveContext<webhook.CallbackRequest> | undefined;
     try {
       const signatureHeader = req.headers["x-line-signature"];
@@ -90,12 +108,16 @@ export function createLineNodeWebhookHandler(params: {
       const rawBody = await readBody(
         req,
         Math.min(maxBodyBytes, LINE_WEBHOOK_PREAUTH_MAX_BODY_BYTES),
-        Math.max(
-          1,
-          Math.min(LINE_WEBHOOK_PREAUTH_BODY_TIMEOUT_MS, responseDeadlineAt - Date.now()),
-        ),
+        responseDeadlineAt === undefined
+          ? LINE_WEBHOOK_PREAUTH_BODY_TIMEOUT_MS
+          : Math.max(
+              1,
+              Math.min(LINE_WEBHOOK_PREAUTH_BODY_TIMEOUT_MS, responseDeadlineAt - Date.now()),
+            ),
       );
-      assertLineWebhookResponseDeadline(responseDeadlineAt);
+      if (responseDeadlineAt !== undefined) {
+        assertLineWebhookResponseDeadline(responseDeadlineAt);
+      }
 
       if (!validateLineSignature(rawBody, signature, params.channelSecret)) {
         logVerbose("line: webhook signature validation failed");
@@ -134,12 +156,16 @@ export function createLineNodeWebhookHandler(params: {
       }
 
       logVerbose(`line: received ${body.events.length} webhook events`);
-      await waitForLineWebhookDispatchAcceptance({
-        body,
-        dispatch: params.bot.handleWebhook,
-        responseDeadlineAt,
-        runtime: params.runtime,
-      });
+      if (params.acknowledgement === "after_event_acceptance") {
+        await waitForLineWebhookDispatchAcceptance({
+          body,
+          dispatch: params.bot.handleWebhook,
+          responseDeadlineAt,
+          runtime: params.runtime,
+        });
+      } else {
+        await params.bot.handleWebhook(body);
+      }
       await receiveContext.ack();
     } catch (err) {
       await receiveContext?.nack(err);

--- a/extensions/line/src/webhook-node.ts
+++ b/extensions/line/src/webhook-node.ts
@@ -14,6 +14,7 @@ import {
 import {
   LINE_WEBHOOK_RESPONSE_DEADLINE_MS,
   assertLineWebhookResponseDeadline,
+  dispatchLineWebhookInBackground,
   type LineWebhookAcceptanceDispatchHandler,
   type LineWebhookDispatchHandler,
   waitForLineWebhookDispatchAcceptance,
@@ -45,8 +46,8 @@ type LineNodeWebhookHandlerParams = {
   onRequestAuthenticated?: () => void;
   bot:
     | {
-        /** Preserve the existing API contract by acknowledging after dispatch completes. */
-        webhookAcknowledgement?: "after_dispatch";
+        /** Preserve the existing API contract by acknowledging before background dispatch. */
+        webhookAcknowledgement?: "before_dispatch";
         handleWebhook: LineWebhookDispatchHandler;
       }
     | {
@@ -142,7 +143,7 @@ export function createLineNodeWebhookHandler(
         id: `${Date.now()}:line:webhook`,
         channel: "line",
         message: body,
-        ackPolicy: "after_agent_dispatch",
+        ackPolicy: waitsForEventAcceptance ? "after_agent_dispatch" : "after_receive_record",
         onAck: () => {
           res.statusCode = 200;
           res.setHeader("Content-Type", "application/json");
@@ -164,7 +165,13 @@ export function createLineNodeWebhookHandler(
           runtime: params.runtime,
         });
       } else {
-        await params.bot.handleWebhook(body);
+        await receiveContext.ack();
+        dispatchLineWebhookInBackground({
+          body,
+          dispatch: params.bot.handleWebhook,
+          runtime: params.runtime,
+        });
+        return;
       }
       await receiveContext.ack();
     } catch (err) {

--- a/extensions/line/src/webhook-node.ts
+++ b/extensions/line/src/webhook-node.ts
@@ -43,18 +43,18 @@ type LineNodeWebhookHandlerParams = {
   readBody?: ReadBodyFn;
   maxBodyBytes?: number;
   onRequestAuthenticated?: () => void;
-} & (
-  | {
-      /** Preserve the existing API contract by acknowledging after dispatch completes. */
-      acknowledgement?: "after_dispatch";
-      bot: { handleWebhook: LineWebhookDispatchHandler };
-    }
-  | {
-      /** Acknowledge once every event is durably adopted, before processing completes. */
-      acknowledgement: "after_event_acceptance";
-      bot: { handleWebhook: LineWebhookAcceptanceDispatchHandler };
-    }
-);
+  bot:
+    | {
+        /** Preserve the existing API contract by acknowledging after dispatch completes. */
+        webhookAcknowledgement?: "after_dispatch";
+        handleWebhook: LineWebhookDispatchHandler;
+      }
+    | {
+        /** Acknowledge once every event is durably adopted, before processing completes. */
+        webhookAcknowledgement: "after_event_acceptance";
+        handleWebhook: LineWebhookAcceptanceDispatchHandler;
+      };
+};
 
 export function createLineNodeWebhookHandler(
   params: LineNodeWebhookHandlerParams,
@@ -83,7 +83,7 @@ export function createLineNodeWebhookHandler(
       return;
     }
 
-    const waitsForEventAcceptance = params.acknowledgement === "after_event_acceptance";
+    const waitsForEventAcceptance = params.bot.webhookAcknowledgement === "after_event_acceptance";
     const responseDeadlineAt = waitsForEventAcceptance
       ? Date.now() + LINE_WEBHOOK_RESPONSE_DEADLINE_MS
       : undefined;
@@ -156,7 +156,7 @@ export function createLineNodeWebhookHandler(
       }
 
       logVerbose(`line: received ${body.events.length} webhook events`);
-      if (params.acknowledgement === "after_event_acceptance") {
+      if (params.bot.webhookAcknowledgement === "after_event_acceptance") {
         await waitForLineWebhookDispatchAcceptance({
           body,
           dispatch: params.bot.handleWebhook,

--- a/extensions/line/src/webhook-node.ts
+++ b/extensions/line/src/webhook-node.ts
@@ -11,6 +11,10 @@ import {
   readRequestBodyWithLimit,
   requestBodyErrorToText,
 } from "openclaw/plugin-sdk/webhook-request-guards";
+import {
+  type LineWebhookDispatchHandler,
+  waitForLineWebhookDispatchAcceptance,
+} from "./webhook-ack.js";
 import { parseLineWebhookBody, validateLineSignature } from "./webhook-utils.js";
 
 const LINE_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
@@ -30,13 +34,9 @@ export async function readLineWebhookRequestBody(
 
 type ReadBodyFn = (req: IncomingMessage, maxBytes: number, timeoutMs?: number) => Promise<string>;
 
-function logLineWebhookDispatchError(runtime: RuntimeEnv | undefined, err: unknown): void {
-  runtime?.error?.(danger(`line webhook dispatch failed: ${String(err)}`));
-}
-
 export function createLineNodeWebhookHandler(params: {
   channelSecret: string;
-  bot: { handleWebhook: (body: webhook.CallbackRequest) => Promise<void> };
+  bot: { handleWebhook: LineWebhookDispatchHandler };
   runtime: RuntimeEnv;
   readBody?: ReadBodyFn;
   maxBodyBytes?: number;
@@ -113,7 +113,7 @@ export function createLineNodeWebhookHandler(params: {
         id: `${Date.now()}:line:webhook`,
         channel: "line",
         message: body,
-        ackPolicy: "after_receive_record",
+        ackPolicy: "after_agent_dispatch",
         onAck: () => {
           res.statusCode = 200;
           res.setHeader("Content-Type", "application/json");
@@ -121,16 +121,18 @@ export function createLineNodeWebhookHandler(params: {
         },
       });
 
-      if (receiveContext.shouldAckAfter("receive_record")) {
+      if (!body.events || body.events.length === 0) {
         await receiveContext.ack();
+        return;
       }
 
-      if (body.events && body.events.length > 0) {
-        logVerbose(`line: received ${body.events.length} webhook events`);
-        void Promise.resolve()
-          .then(() => params.bot.handleWebhook(body))
-          .catch((err: unknown) => logLineWebhookDispatchError(params.runtime, err));
-      }
+      logVerbose(`line: received ${body.events.length} webhook events`);
+      await waitForLineWebhookDispatchAcceptance({
+        body,
+        dispatch: params.bot.handleWebhook,
+        runtime: params.runtime,
+      });
+      await receiveContext.ack();
     } catch (err) {
       await receiveContext?.nack(err);
       if (isRequestBodyLimitError(err, "PAYLOAD_TOO_LARGE")) {

--- a/extensions/line/src/webhook.ts
+++ b/extensions/line/src/webhook.ts
@@ -8,6 +8,7 @@ import {
 import { danger, logVerbose, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import {
   LINE_WEBHOOK_RESPONSE_DEADLINE_MS,
+  type LineWebhookAcceptanceDispatchHandler,
   type LineWebhookDispatchHandler,
   waitForLineWebhookDispatchAcceptance,
 } from "./webhook-ack.js";
@@ -15,11 +16,24 @@ import { parseLineWebhookBody, validateLineSignature } from "./webhook-utils.js"
 
 const LINE_WEBHOOK_MAX_RAW_BODY_BYTES = 64 * 1024;
 
-export interface LineWebhookOptions {
+type LineWebhookOptionsBase = {
   channelSecret: string;
-  onEvents: LineWebhookDispatchHandler;
   runtime?: RuntimeEnv;
-}
+};
+
+export type LineWebhookOptions = LineWebhookOptionsBase &
+  (
+    | {
+        /** Preserve the existing API contract by acknowledging after dispatch completes. */
+        acknowledgement?: "after_dispatch";
+        onEvents: LineWebhookDispatchHandler;
+      }
+    | {
+        /** Acknowledge once every event is durably adopted, before processing completes. */
+        acknowledgement: "after_event_acceptance";
+        onEvents: LineWebhookAcceptanceDispatchHandler;
+      }
+  );
 
 function readRawBody(req: Request): string | null {
   const rawBody =
@@ -41,12 +55,15 @@ function parseWebhookBody(rawBody?: string | null): webhook.CallbackRequest | nu
 export function createLineWebhookMiddleware(
   options: LineWebhookOptions,
 ): (req: Request, res: Response, _next: NextFunction) => Promise<void> {
-  const { channelSecret, onEvents, runtime } = options;
+  const { channelSecret, runtime } = options;
 
   return async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
     // This compatibility middleware receives an already captured raw body, so
     // its budget starts here. Gateway-owned Node routes start before body read.
-    const responseDeadlineAt = Date.now() + LINE_WEBHOOK_RESPONSE_DEADLINE_MS;
+    const responseDeadlineAt =
+      options.acknowledgement === "after_event_acceptance"
+        ? Date.now() + LINE_WEBHOOK_RESPONSE_DEADLINE_MS
+        : undefined;
     let receiveContext: MessageReceiveContext<webhook.CallbackRequest> | undefined;
     try {
       const signature = req.headers["x-line-signature"];
@@ -96,12 +113,16 @@ export function createLineWebhookMiddleware(
       }
 
       logVerbose(`line: received ${body.events.length} webhook events`);
-      await waitForLineWebhookDispatchAcceptance({
-        body,
-        dispatch: onEvents,
-        responseDeadlineAt,
-        runtime,
-      });
+      if (options.acknowledgement === "after_event_acceptance") {
+        await waitForLineWebhookDispatchAcceptance({
+          body,
+          dispatch: options.onEvents,
+          responseDeadlineAt,
+          runtime,
+        });
+      } else {
+        await options.onEvents(body);
+      }
       await receiveContext.ack();
     } catch (err) {
       await receiveContext?.nack(err);
@@ -113,12 +134,9 @@ export function createLineWebhookMiddleware(
   };
 }
 
-export interface StartLineWebhookOptions {
-  channelSecret: string;
-  onEvents: LineWebhookDispatchHandler;
-  runtime?: RuntimeEnv;
+export type StartLineWebhookOptions = LineWebhookOptions & {
   path?: string;
-}
+};
 
 export function startLineWebhook(options: StartLineWebhookOptions): {
   path: string;
@@ -133,11 +151,7 @@ export function startLineWebhook(options: StartLineWebhookOptions): {
     );
   }
   const path = options.path ?? "/line/webhook";
-  const middleware = createLineWebhookMiddleware({
-    channelSecret,
-    onEvents: options.onEvents,
-    runtime: options.runtime,
-  });
+  const middleware = createLineWebhookMiddleware({ ...options, channelSecret });
 
   return { path, handler: middleware };
 }

--- a/extensions/line/src/webhook.ts
+++ b/extensions/line/src/webhook.ts
@@ -6,13 +6,17 @@ import {
   type MessageReceiveContext,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { danger, logVerbose, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import {
+  type LineWebhookDispatchHandler,
+  waitForLineWebhookDispatchAcceptance,
+} from "./webhook-ack.js";
 import { parseLineWebhookBody, validateLineSignature } from "./webhook-utils.js";
 
 const LINE_WEBHOOK_MAX_RAW_BODY_BYTES = 64 * 1024;
 
 export interface LineWebhookOptions {
   channelSecret: string;
-  onEvents: (body: webhook.CallbackRequest) => Promise<void>;
+  onEvents: LineWebhookDispatchHandler;
   runtime?: RuntimeEnv;
 }
 
@@ -31,10 +35,6 @@ function parseWebhookBody(rawBody?: string | null): webhook.CallbackRequest | nu
     return null;
   }
   return parseLineWebhookBody(rawBody);
-}
-
-function logLineWebhookDispatchError(runtime: RuntimeEnv | undefined, err: unknown): void {
-  runtime?.error?.(danger(`line webhook dispatch failed: ${String(err)}`));
 }
 
 export function createLineWebhookMiddleware(
@@ -80,22 +80,24 @@ export function createLineWebhookMiddleware(
         id: `${Date.now()}:line:webhook`,
         channel: "line",
         message: body,
-        ackPolicy: "after_receive_record",
+        ackPolicy: "after_agent_dispatch",
         onAck: () => {
           res.status(200).json({ status: "ok" });
         },
       });
 
-      if (receiveContext.shouldAckAfter("receive_record")) {
+      if (!body.events || body.events.length === 0) {
         await receiveContext.ack();
+        return;
       }
 
-      if (body.events && body.events.length > 0) {
-        logVerbose(`line: received ${body.events.length} webhook events`);
-        void Promise.resolve()
-          .then(() => onEvents(body))
-          .catch((err: unknown) => logLineWebhookDispatchError(runtime, err));
-      }
+      logVerbose(`line: received ${body.events.length} webhook events`);
+      await waitForLineWebhookDispatchAcceptance({
+        body,
+        dispatch: onEvents,
+        runtime,
+      });
+      await receiveContext.ack();
     } catch (err) {
       await receiveContext?.nack(err);
       runtime?.error?.(danger(`line webhook error: ${String(err)}`));
@@ -108,7 +110,7 @@ export function createLineWebhookMiddleware(
 
 export interface StartLineWebhookOptions {
   channelSecret: string;
-  onEvents: (body: webhook.CallbackRequest) => Promise<void>;
+  onEvents: LineWebhookDispatchHandler;
   runtime?: RuntimeEnv;
   path?: string;
 }

--- a/extensions/line/src/webhook.ts
+++ b/extensions/line/src/webhook.ts
@@ -8,6 +8,7 @@ import {
 import { danger, logVerbose, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import {
   LINE_WEBHOOK_RESPONSE_DEADLINE_MS,
+  dispatchLineWebhookInBackground,
   type LineWebhookAcceptanceDispatchHandler,
   type LineWebhookDispatchHandler,
   waitForLineWebhookDispatchAcceptance,
@@ -24,8 +25,8 @@ type LineWebhookOptionsBase = {
 export type LineWebhookOptions = LineWebhookOptionsBase &
   (
     | {
-        /** Preserve the existing API contract by acknowledging after dispatch completes. */
-        acknowledgement?: "after_dispatch";
+        /** Preserve the existing API contract by acknowledging before background dispatch. */
+        acknowledgement?: "before_dispatch";
         onEvents: LineWebhookDispatchHandler;
       }
     | {
@@ -101,7 +102,10 @@ export function createLineWebhookMiddleware(
         id: `${Date.now()}:line:webhook`,
         channel: "line",
         message: body,
-        ackPolicy: "after_agent_dispatch",
+        ackPolicy:
+          options.acknowledgement === "after_event_acceptance"
+            ? "after_agent_dispatch"
+            : "after_receive_record",
         onAck: () => {
           res.status(200).json({ status: "ok" });
         },
@@ -121,7 +125,9 @@ export function createLineWebhookMiddleware(
           runtime,
         });
       } else {
-        await options.onEvents(body);
+        await receiveContext.ack();
+        dispatchLineWebhookInBackground({ body, dispatch: options.onEvents, runtime });
+        return;
       }
       await receiveContext.ack();
     } catch (err) {

--- a/extensions/line/src/webhook.ts
+++ b/extensions/line/src/webhook.ts
@@ -7,6 +7,7 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 import { danger, logVerbose, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import {
+  LINE_WEBHOOK_RESPONSE_DEADLINE_MS,
   type LineWebhookDispatchHandler,
   waitForLineWebhookDispatchAcceptance,
 } from "./webhook-ack.js";
@@ -43,6 +44,9 @@ export function createLineWebhookMiddleware(
   const { channelSecret, onEvents, runtime } = options;
 
   return async (req: Request, res: Response, _next: NextFunction): Promise<void> => {
+    // This compatibility middleware receives an already captured raw body, so
+    // its budget starts here. Gateway-owned Node routes start before body read.
+    const responseDeadlineAt = Date.now() + LINE_WEBHOOK_RESPONSE_DEADLINE_MS;
     let receiveContext: MessageReceiveContext<webhook.CallbackRequest> | undefined;
     try {
       const signature = req.headers["x-line-signature"];
@@ -95,6 +99,7 @@ export function createLineWebhookMiddleware(
       await waitForLineWebhookDispatchAcceptance({
         body,
         dispatch: onEvents,
+        responseDeadlineAt,
         runtime,
       });
       await receiveContext.ack();


### PR DESCRIPTION
## What Problem This Solves

LINE webhook handlers acknowledged signed event requests before knowing whether local dispatch even started. If the handler rejected immediately, OpenClaw still returned 200, so LINE would not redeliver a retryable webhook even though the event was not accepted.

The same early-ACK shape existed in the standalone Express middleware, the Node webhook handler, and the shared multi-account monitor route.

## Why This Change Was Made

This change introduces a bounded dispatch-acceptance step for LINE webhooks. Each entrypoint starts event handling, waits one event-loop turn to surface startup-time rejection as a 500 response, then acknowledges with 200 once dispatch is accepted. If processing continues asynchronously, later failures are still logged in the background instead of holding the provider HTTP response for the full agent turn.

The LINE message adapter now defaults to `after_agent_dispatch` while preserving shipped `after_receive_record` support. The exported Node/Express handlers and shared monitor route have a real `after_receive_record` path for compatibility, and unsupported policy inputs normalize to the default dispatch-acceptance behavior instead of hanging.

## User Impact

Immediate LINE webhook dispatch failures can now trigger provider redelivery instead of being swallowed behind a 200 response. Normal successful turns still ACK quickly after local dispatch starts, avoiding long webhook waits while the agent run continues. Existing consumers that inspect or choose `after_receive_record` remain compatible.

## Evidence

- `node scripts/run-vitest.mjs extensions/line/src/webhook-node.test.ts extensions/line/src/channel.sendPayload.test.ts extensions/line/src/monitor.lifecycle.test.ts` (60 tests passed)
- `node scripts/run-vitest.mjs extensions/line/src/bot-handlers.test.ts` (28 tests passed)
- Local HTTP transcript through `createLineNodeWebhookHandler`:
  - slow dispatch: `status=200`, body `{"status":"ok"}`, response returned before the pending handler was released
  - immediate dispatch failure: `status=500`, body `{"error":"Internal server error"}`
- `git diff --check -- extensions/line/src/webhook-ack.ts extensions/line/src/webhook.ts extensions/line/src/webhook-node.ts extensions/line/src/outbound.ts extensions/line/src/webhook-node.test.ts extensions/line/src/channel.sendPayload.test.ts extensions/line/src/monitor.ts extensions/line/src/monitor.lifecycle.test.ts docs/channels/line.md`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean after preserving `after_receive_record` support and narrowing/normalizing the exposed ACK policy)

Remote Testbox proof was not run from this checkout because the local Crabbox wrapper selected binary `0.18.0`, while `blacksmith-testbox` requires Crabbox `>=0.22.0`.
