### PR TITLE
fix(control-ui): increase chat history limit from 100 to 500

### DIFF
--- a/ui/src/lib/chat/chat-types.ts
+++ b/ui/src/lib/chat/chat-types.ts
@@ -48,7 +48,7 @@ export type ChatItem =
   | { kind: "stream"; key: string; text: string; startedAt: number; isStreaming: boolean }
   | { kind: "reading-indicator"; key: string };
 
-export const CHAT_HISTORY_RENDER_LIMIT = 100;
+export const CHAT_HISTORY_RENDER_LIMIT = 500;
 export const CHAT_HISTORY_RENDER_CHAR_BUDGET = 240_000;
 
 export type ChatStreamSegment = {

--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -1998,7 +1998,7 @@ describe("loadChatHistory filtering", () => {
 
     expect(request).toHaveBeenCalledWith("chat.startup", {
       sessionKey: "global",
-      limit: 100,
+      limit: 500,
     });
     expect(state.chatMessages).toEqual([
       { role: "assistant", content: [{ type: "text", text: "ready" }] },
@@ -2025,7 +2025,7 @@ describe("loadChatHistory filtering", () => {
 
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "main",
-      limit: 100,
+      limit: 500,
     });
   });
 });
@@ -2487,11 +2487,11 @@ describe("loadChatHistory retry handling", () => {
 
     expect(request).toHaveBeenNthCalledWith(1, "chat.startup", {
       sessionKey: "main",
-      limit: 100,
+      limit: 500,
     });
     expect(request).toHaveBeenNthCalledWith(2, "chat.history", {
       sessionKey: "main",
-      limit: 100,
+      limit: 500,
     });
     expect(state.chatMessages).toEqual([
       { role: "assistant", content: [{ type: "text", text: "fallback" }] },
@@ -2559,7 +2559,7 @@ describe("loadChatHistory retry handling", () => {
 
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "main",
-      limit: 100,
+      limit: 500,
     });
     expect(state.chatMessages).toEqual([
       { role: "assistant", content: [{ type: "text", text: "visible answer" }] },

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -72,7 +72,7 @@ import {
 const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
 const SYNTHETIC_TRANSCRIPT_REPAIR_RESULT =
   "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.";
-const CHAT_HISTORY_REQUEST_LIMIT = 100;
+const CHAT_HISTORY_REQUEST_LIMIT = 500;
 const STARTUP_CHAT_HISTORY_RETRY_TIMEOUT_MS = 60_000;
 const STARTUP_CHAT_HISTORY_DEFAULT_RETRY_MS = 500;
 const STARTUP_CHAT_HISTORY_MAX_RETRY_MS = 5_000;

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -296,7 +296,7 @@ describe("refreshChat", () => {
     expect(host.chatLoading).toBe(true);
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "main",
-      limit: 100,
+      limit: 500,
     });
     expect(request).not.toHaveBeenCalledWith("models.list", { view: "configured" });
     expect(request).not.toHaveBeenCalledWith("sessions.list", expect.anything());
@@ -324,7 +324,7 @@ describe("refreshChat", () => {
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "global",
       agentId: "work",
-      limit: 100,
+      limit: 500,
     });
     expect(request).not.toHaveBeenCalledWith("sessions.list", expect.anything());
   });
@@ -344,7 +344,7 @@ describe("refreshChat", () => {
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "agent:work:main",
       agentId: "work",
-      limit: 100,
+      limit: 500,
     });
     expect(request).not.toHaveBeenCalledWith("sessions.list", expect.anything());
   });
@@ -363,7 +363,7 @@ describe("refreshChat", () => {
     expect(outcome).toBe("resolved");
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "agent:work:dashboard",
-      limit: 100,
+      limit: 500,
     });
     expect(request).not.toHaveBeenCalledWith("sessions.list", expect.anything());
   });
@@ -388,7 +388,7 @@ describe("refreshChat", () => {
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "global",
       agentId: "ops",
-      limit: 100,
+      limit: 500,
     });
     expect(request).not.toHaveBeenCalledWith("sessions.list", expect.anything());
   });
@@ -408,7 +408,7 @@ describe("refreshChat", () => {
     expect(outcome).toBe("resolved");
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "unknown",
-      limit: 100,
+      limit: 500,
     });
     expect(request).not.toHaveBeenCalledWith("sessions.list", expect.anything());
   });
@@ -2861,7 +2861,7 @@ describe("handleSendChat", () => {
     expect(request).toHaveBeenCalledWith("chat.history", {
       sessionKey: "global",
       agentId: "work",
-      limit: 100,
+      limit: 500,
     });
     expect(host.chatMessages).toStrictEqual([]);
     expect(host.chatMessagesBySession?.has("agent:work:main")).toBe(false);

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -899,10 +899,10 @@ describe("buildChatItems", () => {
     expect(groups).toStrictEqual([]);
   });
 
-  it("renders only the last 100 history messages and shows a hidden-count notice", () => {
+  it("renders only the last 500 history messages and shows a hidden-count notice", () => {
     const items = buildChatItems(
       createProps({
-        messages: Array.from({ length: 105 }, (_, index) => ({
+        messages: Array.from({ length: 505 }, (_, index) => ({
           role: index % 2 === 0 ? "user" : "assistant",
           content: `message ${index}`,
           timestamp: index,
@@ -916,10 +916,10 @@ describe("buildChatItems", () => {
     expect(noticeGroup.messages).toHaveLength(1);
     const noticeMessage = messageRecord(noticeGroup);
     expect(noticeMessage.role).toBe("system");
-    expect(noticeMessage.content).toBe("Showing last 100 messages (5 hidden).");
-    expect(groups).toHaveLength(101);
+    expect(noticeMessage.content).toBe("Showing last 500 messages (5 hidden).");
+    expect(groups).toHaveLength(501);
     expect(messageRecord(groups[1]).content).toBe("message 5");
-    expect(messageRecord(groups[groups.length - 1]).content).toBe("message 104");
+    expect(messageRecord(groups[groups.length - 1]).content).toBe("message 504");
   });
 
   it("honors a smaller history render window and preserves the hidden-count notice", () => {


### PR DESCRIPTION
## Summary

Increase both `CHAT_HISTORY_REQUEST_LIMIT` and `CHAT_HISTORY_RENDER_LIMIT` from `100` to `500` in the Control UI WebChat.

## Problem

The Control UI only loads and renders 100 messages when opening a chat session. There is no scroll-to-top pagination to dynamically load older messages from the server (`chat.history` RPC supports `offset` pagination, but the frontend never uses it).

## Fix

Increase both limits to 500:
- **Fetch limit** (`CHAT_HISTORY_REQUEST_LIMIT`): Controls how many messages are requested from the server
- **Render limit** (`CHAT_HISTORY_RENDER_LIMIT`): Controls how many messages are actually displayed

Both must be increased together; otherwise fetching more messages is useless if the renderer still caps at 100.

## Changes

- `ui/src/lib/chat/chat-types.ts`: `CHAT_HISTORY_RENDER_LIMIT` 100 → 500
- `ui/src/pages/chat/chat-history.ts`: `CHAT_HISTORY_REQUEST_LIMIT` 100 → 500
- `ui/src/pages/chat/chat-thread.test.ts`: Update test to assert 500 instead of 100

## Verification

Local build and tests pass. The fix is a straightforward constant change with no behavioral side effects beyond showing more history.

Fixes #102139