### PR TITLE
fix(infra): log error from restart sentinel clear instead of silent catch

### DIFF
--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -224,7 +224,9 @@ export async function clearRestartSentinel(env: NodeJS.ProcessEnv = process.env)
       },
       { env },
     );
-  } catch {}
+  } catch (err: unknown) {
+    console.error("[openclaw] Failed to clear restart sentinel:", err);
+  }
   await removeLegacyRestartSentinel(env);
 }
 


### PR DESCRIPTION
## What Problem This Solves

The `clearRestartSentinel` function silently swallows errors when deleting the `gateway_restart_sentinel` SQLite record via an empty `catch {}` block. If this deletion fails (database busy, permissions), the sentinel remains in the database and can cause the gateway to incorrectly trigger recovery logic on the next restart.

## Why This Change Was Made

A stale restart sentinel can cause the gateway to re-run recovery actions that were already completed. Logging the error ensures operators can diagnose the issue without changing the no-throw contract of `clearRestartSentinel`.

## Evidence

**Before (current main):**

Empty `catch {}` hides all errors:
```typescript
} catch {}
```

**After (this PR):**

Error is logged via `console.error`:
```typescript
} catch (err: unknown) {
  console.error("[openclaw] Failed to clear restart sentinel:", err);
}
```

**Test results:**
```
Test Files  1 passed (1)
     Tests  27 passed (27)
```

**Type-check:** No errors for the changed file.

**Before/after output:**
```
=== Before (main) ===
[BEFORE] Sentinel clear completed (but error was swallowed)

=== After (fix) ===
[AFTER] [openclaw] Failed to clear restart sentinel: Error: SQLite busy: database is locked
[AFTER] Sentinel clear completed (error was logged)
```

**Commands run:**
```bash
# Tests
pnpm test:serial src/infra/restart-sentinel.test.ts

# Type-check
npx tsc --noEmit --pretty 2>&1 | grep restart-sentinel || echo "No errors"
```

## User Impact

Low — the error is now logged instead of silently swallowed. The function still never throws, so callers remain unaffected.

## Risk Checklist

- Changes user-facing behavior? No
- Changes config/default surfaces? No
- Changes plugin/provider/channel behavior? No
- Changes security/authorization behavior? No
- Requires migration? No

---

Co-Authored-By: Claude <noreply@anthropic.com>