### PR TITLE
Fix silent context-engine maintenance task delivery status

### DIFF
--- a/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
@@ -654,7 +654,7 @@ describe("runContextEngineMaintenance", () => {
           requesterSessionKey: sessionKey,
           taskKind: TURN_MAINTENANCE_TASK_KIND,
           notifyPolicy: "silent",
-          deliveryStatus: "pending",
+          deliveryStatus: "not_applicable",
         });
 
         if (!releaseForeground) {
@@ -1494,6 +1494,21 @@ describe("runContextEngineMaintenance", () => {
         await waitForAssertion(() => expect(maintain).toHaveBeenCalledTimes(1));
         expect(sendMessageMock).not.toHaveBeenCalled();
         expect(peekSystemEvents(sessionKey)).toStrictEqual([]);
+
+        const tasks = listTasksForOwnerKey(sessionKey).filter(
+          (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
+        );
+        expect(tasks).toHaveLength(1);
+        await waitForAssertion(() =>
+          expect(getTaskById(tasks[0].taskId)?.status).toBe("succeeded"),
+        );
+        const task = requireRecord(getTaskById(tasks[0].taskId), "maintenance task");
+        expectRecordFields(task, {
+          status: "succeeded",
+          notifyPolicy: "silent",
+          deliveryStatus: "not_applicable",
+        });
+        expect(task.parentFlowId).toBeUndefined();
       } finally {
         vi.useRealTimers();
       }

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
@@ -9,10 +9,7 @@ import {
 } from "../../process/command-queue.js";
 import * as commandQueueModule from "../../process/command-queue.js";
 import { createQueuedTaskRun as createQueuedTaskRunOrNull } from "../../tasks/task-executor.js";
-import {
-  getTaskFlowById,
-  resetTaskFlowRegistryForTests,
-} from "../../tasks/task-flow-registry.js";
+import { getTaskFlowById, resetTaskFlowRegistryForTests } from "../../tasks/task-flow-registry.js";
 import {
   getTaskById,
   listTasksForOwnerKey,

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
@@ -9,7 +9,10 @@ import {
 } from "../../process/command-queue.js";
 import * as commandQueueModule from "../../process/command-queue.js";
 import { createQueuedTaskRun as createQueuedTaskRunOrNull } from "../../tasks/task-executor.js";
-import { resetTaskFlowRegistryForTests } from "../../tasks/task-flow-registry.js";
+import {
+  getTaskFlowById,
+  resetTaskFlowRegistryForTests,
+} from "../../tasks/task-flow-registry.js";
 import {
   getTaskById,
   listTasksForOwnerKey,
@@ -1567,6 +1570,14 @@ describe("runContextEngineMaintenance", () => {
             "Background task update: Context engine turn maintenance.",
           ),
         );
+        const [task] = listTasksForOwnerKey(sessionKey).filter(
+          (candidate) => candidate.taskKind === TURN_MAINTENANCE_TASK_KIND,
+        );
+        const parentFlowId = task?.parentFlowId;
+        if (!parentFlowId) {
+          throw new Error("Expected visible maintenance to have a task flow");
+        }
+        expect(getTaskFlowById(parentFlowId)?.status).toBe("running");
 
         if (!releaseMaintenance) {
           throw new Error("Expected maintenance release callback to be initialized");
@@ -1578,6 +1589,7 @@ describe("runContextEngineMaintenance", () => {
             "Background task done: Context engine turn maintenance",
           ),
         );
+        expect(getTaskFlowById(parentFlowId)?.status).toBe("succeeded");
       } finally {
         vi.useRealTimers();
       }
@@ -1624,6 +1636,14 @@ describe("runContextEngineMaintenance", () => {
             "Background task failed: Context engine turn maintenance",
           ),
         );
+        const [task] = listTasksForOwnerKey(sessionKey).filter(
+          (candidate) => candidate.taskKind === TURN_MAINTENANCE_TASK_KIND,
+        );
+        const parentFlowId = task?.parentFlowId;
+        if (!parentFlowId) {
+          throw new Error("Expected failed maintenance to have a task flow");
+        }
+        expect(getTaskFlowById(parentFlowId)?.status).toBe("failed");
       } finally {
         vi.useRealTimers();
       }

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
@@ -1567,7 +1567,7 @@ describe("runContextEngineMaintenance", () => {
             "Background task update: Context engine turn maintenance.",
           ),
         );
-        const [task] = listTasksForOwnerKey(sessionKey).filter(
+        const task = listTasksForOwnerKey(sessionKey).find(
           (candidate) => candidate.taskKind === TURN_MAINTENANCE_TASK_KIND,
         );
         const parentFlowId = task?.parentFlowId;
@@ -1633,7 +1633,7 @@ describe("runContextEngineMaintenance", () => {
             "Background task failed: Context engine turn maintenance",
           ),
         );
-        const [task] = listTasksForOwnerKey(sessionKey).filter(
+        const task = listTasksForOwnerKey(sessionKey).find(
           (candidate) => candidate.taskKind === TURN_MAINTENANCE_TASK_KIND,
         );
         const parentFlowId = task?.parentFlowId;

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.ts
@@ -247,7 +247,7 @@ function buildTurnMaintenanceTaskDescriptor(params: { sessionKey: string }) {
     label: TURN_MAINTENANCE_TASK_LABEL,
     task: TURN_MAINTENANCE_TASK_TASK,
     notifyPolicy: "silent",
-    deliveryStatus: "pending",
+    deliveryStatus: "not_applicable",
     preferMetadata: true,
   });
 }

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.ts
@@ -247,6 +247,8 @@ function buildTurnMaintenanceTaskDescriptor(params: { sessionKey: string }) {
     label: TURN_MAINTENANCE_TASK_LABEL,
     task: TURN_MAINTENANCE_TASK_TASK,
     notifyPolicy: "silent",
+    // Fast maintenance stays silent and must not create a one-task flow.
+    // Long-running and failed workers promote it to pending before notifying.
     deliveryStatus: "not_applicable",
     preferMetadata: true,
   });

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.ts
@@ -22,7 +22,6 @@ import {
   createQueuedTaskRun,
   failTaskRunByRunId,
   recordTaskRunProgressByRunId,
-  setDetachedTaskDeliveryStatusByRunId,
   startTaskRunByRunId,
 } from "../../tasks/detached-task-runtime.js";
 import {
@@ -231,11 +230,15 @@ function markDeferredTurnMaintenanceTaskScheduleFailure(params: {
   });
 }
 
-function buildTurnMaintenanceTaskDescriptor(params: { sessionKey: string }) {
-  const runId = `turn-maint:${params.sessionKey}:${Date.now().toString(36)}:${randomUUID().slice(
-    0,
-    8,
-  )}`;
+function buildTurnMaintenanceTaskDescriptor(params: {
+  sessionKey: string;
+  runId?: string;
+  notifyPolicy?: "silent" | "done_only" | "state_changes";
+  deliveryStatus?: "not_applicable" | "pending";
+}) {
+  const runId =
+    params.runId ??
+    `turn-maint:${params.sessionKey}:${Date.now().toString(36)}:${randomUUID().slice(0, 8)}`;
   return createQueuedTaskRun({
     runtime: "acp",
     taskKind: TURN_MAINTENANCE_TASK_KIND,
@@ -246,10 +249,10 @@ function buildTurnMaintenanceTaskDescriptor(params: { sessionKey: string }) {
     runId,
     label: TURN_MAINTENANCE_TASK_LABEL,
     task: TURN_MAINTENANCE_TASK_TASK,
-    notifyPolicy: "silent",
+    notifyPolicy: params.notifyPolicy ?? "silent",
     // Fast maintenance stays silent and must not create a one-task flow.
     // Long-running and failed workers promote it to pending before notifying.
-    deliveryStatus: "not_applicable",
+    deliveryStatus: params.deliveryStatus ?? "not_applicable",
     preferMetadata: true,
   });
 }
@@ -259,45 +262,12 @@ function promoteTurnMaintenanceTaskVisibility(params: {
   runId: string;
   notifyPolicy: "done_only" | "state_changes";
 }) {
-  const task = findTaskByRunIdForOwner({
-    runId: params.runId,
-    callerOwnerKey: params.sessionKey,
-  });
-  if (!task) {
-    return createQueuedTaskRun({
-      runtime: "acp",
-      taskKind: TURN_MAINTENANCE_TASK_KIND,
-      sourceId: TURN_MAINTENANCE_TASK_KIND,
-      requesterSessionKey: params.sessionKey,
-      ownerKey: params.sessionKey,
-      scopeKind: "session",
-      runId: params.runId,
-      label: TURN_MAINTENANCE_TASK_LABEL,
-      task: TURN_MAINTENANCE_TASK_TASK,
-      notifyPolicy: params.notifyPolicy,
-      deliveryStatus: "pending",
-      preferMetadata: true,
-    });
-  }
-  setDetachedTaskDeliveryStatusByRunId({
-    runId: params.runId,
-    runtime: "acp",
+  return buildTurnMaintenanceTaskDescriptor({
     sessionKey: params.sessionKey,
+    runId: params.runId,
+    notifyPolicy: params.notifyPolicy,
     deliveryStatus: "pending",
   });
-  if (task.notifyPolicy !== params.notifyPolicy) {
-    updateTaskNotifyPolicyForOwner({
-      taskId: task.taskId,
-      callerOwnerKey: params.sessionKey,
-      notifyPolicy: params.notifyPolicy,
-    });
-  }
-  return (
-    findTaskByRunIdForOwner({
-      runId: params.runId,
-      callerOwnerKey: params.sessionKey,
-    }) ?? task
-  );
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where fast, silent context-engine turn maintenance created a deliverable background-task flow even though it completed without a user-facing message. Those unnecessary one-task flows could remain in task status and flow surfaces after routine maintenance.

## Why This Change Was Made

Silent maintenance now starts with delivery marked not applicable, so fast completion keeps only its task audit record and skips one-task-flow creation. If maintenance runs longer than ten seconds or fails, the existing task is promoted through the canonical queued-task path; that restores pending delivery and creates the synchronized one-task flow before any visible progress or failure notification.

## User Impact

Routine fast context maintenance stays silent without cluttering task-flow surfaces. Long-running maintenance still reports progress and completion, and failed maintenance still reports its error with a normal flow handle.

## Evidence

- Sanitized direct AWS Crabbox (`provider=aws`, `cbx_46f531263e30`, run `run_8721baa14e79`) on final head `493cde8831e48666888659504ac94ec6c76e9312`: 86/86 focused tests passed across context-engine maintenance, task executor, task commands, and CLI routing; targeted oxfmt and oxlint also passed.
- The deterministic maintenance fixture covers fast success with no flow or message, greater-than-ten-second progress plus successful flow completion, and quick failure with a failed flow.
- Fresh isolated autoreview on final head `493cde8831e48666888659504ac94ec6c76e9312`: clean, confidence 0.98.
- Exact-head hosted CI: [run 29024771937](https://github.com/openclaw/openclaw/actions/runs/29024771937).
