### PR TITLE
fix(doctor): normalize legacy Google provider config to current catalog schema

### DIFF
--- a/extensions/google/doctor-contract-api.test.ts
+++ b/extensions/google/doctor-contract-api.test.ts
@@ -28,7 +28,7 @@ describe("google doctor contract", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
 
     const result = normalizeCompatibilityConfig({ cfg: config });
 
@@ -58,7 +58,7 @@ describe("google doctor contract", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
 
     const result = normalizeCompatibilityConfig({ cfg: config });
 
@@ -90,7 +90,7 @@ describe("google doctor contract", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
 
     const result = normalizeCompatibilityConfig({ cfg: config });
 
@@ -121,7 +121,7 @@ describe("google doctor contract", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
 
     const result = normalizeCompatibilityConfig({ cfg: config });
 
@@ -157,7 +157,7 @@ describe("google doctor contract", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
 
     const result = normalizeCompatibilityConfig({ cfg: config });
 
@@ -186,7 +186,7 @@ describe("google doctor contract", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
 
     const result = normalizeCompatibilityConfig({ cfg: config });
 
@@ -204,7 +204,7 @@ describe("google doctor contract", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
 
     const result = normalizeCompatibilityConfig({ cfg: config });
 
@@ -229,7 +229,7 @@ describe("google doctor contract", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
 
     normalizeCompatibilityConfig({ cfg: config });
 

--- a/extensions/google/doctor-contract-api.test.ts
+++ b/extensions/google/doctor-contract-api.test.ts
@@ -1,0 +1,242 @@
+// Google tests cover doctor contract config compatibility.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { describe, expect, it } from "vitest";
+import { normalizeCompatibilityConfig } from "./doctor-contract-api.js";
+
+function readGoogleProvider(config: OpenClawConfig): Record<string, unknown> | undefined {
+  return (config.models?.providers as Record<string, unknown> | undefined)?.["google"] as
+    | Record<string, unknown>
+    | undefined;
+}
+
+describe("google doctor contract", () => {
+  it("backfills missing api", () => {
+    const config = {
+      models: {
+        providers: {
+          google: {
+            models: [
+              {
+                id: "gemini-2.5-flash",
+                name: "Gemini 2.5 Flash",
+                input: ["text", "image"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 1048576,
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = normalizeCompatibilityConfig({ cfg: config });
+
+    expect(result.changes).toEqual([
+      "Set models.providers.google.api = google-generative-ai (was missing).",
+    ]);
+    expect(readGoogleProvider(result.config)?.api).toBe("google-generative-ai");
+    expect(readGoogleProvider(config)?.api).toBeUndefined();
+  });
+
+  it("coerces input modalities to text and image", () => {
+    const config = {
+      models: {
+        providers: {
+          google: {
+            api: "google-generative-ai",
+            models: [
+              {
+                id: "gemini-2.5-flash",
+                name: "Gemini 2.5 Flash",
+                input: ["text", "image", "audio", "video"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 1048576,
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = normalizeCompatibilityConfig({ cfg: config });
+
+    expect(result.changes).toEqual([
+      "Coerced models.providers.google.models[0].input to [text, image] (removed unsupported modalities).",
+    ]);
+    const models = (
+      readGoogleProvider(result.config)?.models as Array<Record<string, unknown>>
+    )?.[0];
+    expect(models?.input).toEqual(["text", "image"]);
+  });
+
+  it("backfills missing cost.cacheWrite", () => {
+    const config = {
+      models: {
+        providers: {
+          google: {
+            api: "google-generative-ai",
+            models: [
+              {
+                id: "gemini-2.5-flash",
+                name: "Gemini 2.5 Flash",
+                input: ["text", "image"],
+                cost: { input: 0, output: 0, cacheRead: 0 },
+                contextWindow: 1048576,
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = normalizeCompatibilityConfig({ cfg: config });
+
+    expect(result.changes).toEqual([
+      "Added models.providers.google.models[0].cost.cacheWrite = 0 (was missing).",
+    ]);
+    const models = (
+      readGoogleProvider(result.config)?.models as Array<Record<string, unknown>>
+    )?.[0];
+    expect((models?.cost as Record<string, unknown>)?.cacheWrite).toBe(0);
+  });
+
+  it("repairs all three legacy fields in one pass", () => {
+    const config = {
+      models: {
+        providers: {
+          google: {
+            models: [
+              {
+                id: "gemini-2.5-flash",
+                name: "Gemini 2.5 Flash",
+                input: ["text", "image", "audio", "video"],
+                cost: { input: 0, output: 0, cacheRead: 0 },
+                contextWindow: 1048576,
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = normalizeCompatibilityConfig({ cfg: config });
+
+    expect(result.changes).toEqual([
+      "Set models.providers.google.api = google-generative-ai (was missing).",
+      "Coerced models.providers.google.models[0].input to [text, image] (removed unsupported modalities).",
+      "Added models.providers.google.models[0].cost.cacheWrite = 0 (was missing).",
+    ]);
+    const provider = readGoogleProvider(result.config);
+    expect(provider?.api).toBe("google-generative-ai");
+    const models = (provider?.models as Array<Record<string, unknown>>)?.[0];
+    expect(models?.input).toEqual(["text", "image"]);
+    expect((models?.cost as Record<string, unknown>)?.cacheWrite).toBe(0);
+  });
+
+  it("preserves existing apiKey and baseUrl", () => {
+    const config = {
+      models: {
+        providers: {
+          google: {
+            apiKey: "fake",
+            baseUrl: "https://custom.example.test",
+            models: [
+              {
+                id: "gemini-2.5-flash",
+                name: "Gemini 2.5 Flash",
+                input: ["text", "image", "audio", "video"],
+                cost: { input: 0, output: 0, cacheRead: 0 },
+                contextWindow: 1048576,
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = normalizeCompatibilityConfig({ cfg: config });
+
+    const provider = readGoogleProvider(result.config);
+    expect(provider?.apiKey).toBe("fake");
+    expect(provider?.baseUrl).toBe("https://custom.example.test");
+    expect(provider?.api).toBe("google-generative-ai");
+  });
+
+  it("leaves already-valid Google config unchanged", () => {
+    const config = {
+      models: {
+        providers: {
+          google: {
+            api: "google-generative-ai",
+            models: [
+              {
+                id: "gemini-2.5-flash",
+                name: "Gemini 2.5 Flash",
+                input: ["text", "image"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 1048576,
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = normalizeCompatibilityConfig({ cfg: config });
+
+    expect(result.changes).toEqual([]);
+    expect(result.config).toBe(config);
+  });
+
+  it("leaves config without Google provider unchanged", () => {
+    const config = {
+      models: {
+        providers: {
+          openai: {
+            api: "openai",
+            models: [],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = normalizeCompatibilityConfig({ cfg: config });
+
+    expect(result.changes).toEqual([]);
+  });
+
+  it("does not mutate the input config", () => {
+    const config = {
+      models: {
+        providers: {
+          google: {
+            models: [
+              {
+                id: "gemini-2.5-flash",
+                name: "Gemini 2.5 Flash",
+                input: ["text", "image", "audio", "video"],
+                cost: { input: 0, output: 0, cacheRead: 0 },
+                contextWindow: 1048576,
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    normalizeCompatibilityConfig({ cfg: config });
+
+    const models = (
+      (config.models?.providers as Record<string, unknown>)?.google as Record<string, unknown>
+    )?.models as Array<Record<string, unknown>>;
+    expect(models[0]?.input).toEqual(["text", "image", "audio", "video"]);
+    expect((models[0]?.cost as Record<string, unknown>)?.cacheWrite).toBeUndefined();
+  });
+});

--- a/extensions/google/doctor-contract-api.ts
+++ b/extensions/google/doctor-contract-api.ts
@@ -1,5 +1,121 @@
 // Google API module exposes the plugin public contract.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { DoctorSessionRouteStateOwner } from "openclaw/plugin-sdk/runtime-doctor";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+type LegacyConfigRule = {
+  path: string[];
+  message: string;
+  match: (value: unknown) => boolean;
+};
+
+export const legacyConfigRules: LegacyConfigRule[] = [];
+
+/**
+ * Normalize legacy Google provider config to satisfy the current catalog schema.
+ *
+ * Older Google provider blocks may lack `api`, include unsupported input modalities
+ * (audio, video), and miss `cost.cacheWrite`. This backfills those fields so the
+ * provider stays available instead of being silently dropped by catalog validation.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/102138
+ */
+export function normalizeCompatibilityConfig({ cfg }: { cfg: OpenClawConfig }): {
+  config: OpenClawConfig;
+  changes: string[];
+} {
+  const changes: string[] = [];
+  const rawModels = cfg.models;
+  if (!isRecord(rawModels)) {
+    return { config: cfg, changes };
+  }
+  const rawProviders = rawModels.providers;
+  if (!isRecord(rawProviders)) {
+    return { config: cfg, changes };
+  }
+  const rawGoogle = rawProviders.google;
+  if (!isRecord(rawGoogle)) {
+    return { config: cfg, changes };
+  }
+
+  let googleChanged = false;
+  const nextGoogle = { ...rawGoogle } as Record<string, unknown>;
+
+  // Backfill api if missing.
+  if (typeof nextGoogle.api !== "string" || !nextGoogle.api.trim()) {
+    nextGoogle.api = "google-generative-ai";
+    googleChanged = true;
+    changes.push("Set models.providers.google.api = google-generative-ai (was missing).");
+  }
+
+  // Coerce model input modalities and cost.cacheWrite.
+  if (Array.isArray(nextGoogle.models)) {
+    const nextGoogleModels = nextGoogle.models.map((model, index) => {
+      if (!isRecord(model)) {
+        return model;
+      }
+      let modelChanged = false;
+      const nextModel = { ...model } as Record<string, unknown>;
+
+      // Coerce input to ["text", "image"] (remove audio, video).
+      if (Array.isArray(nextModel.input)) {
+        const filtered = (nextModel.input as string[]).filter(
+          (m: string) => m === "text" || m === "image",
+        );
+        if (filtered.length !== (nextModel.input as string[]).length) {
+          nextModel.input = filtered;
+          modelChanged = true;
+          changes.push(
+            `Coerced models.providers.google.models[${index}].input to [text, image] (removed unsupported modalities).`,
+          );
+        }
+      }
+
+      // Backfill cost.cacheWrite.
+      if (isRecord(nextModel.cost)) {
+        const cost = { ...nextModel.cost } as Record<string, unknown>;
+        if (!("cacheWrite" in cost) || typeof cost.cacheWrite !== "number") {
+          cost.cacheWrite = 0;
+          modelChanged = true;
+          changes.push(
+            `Added models.providers.google.models[${index}].cost.cacheWrite = 0 (was missing).`,
+          );
+        }
+        if (modelChanged) {
+          nextModel.cost = cost;
+        }
+      }
+
+      return modelChanged ? nextModel : model;
+    });
+
+    if (nextGoogleModels.some((m, i) => m !== nextGoogle.models[i])) {
+      nextGoogle.models = nextGoogleModels;
+      googleChanged = true;
+    }
+  }
+
+  if (!googleChanged) {
+    return { config: cfg, changes };
+  }
+
+  return {
+    config: {
+      ...cfg,
+      models: {
+        ...rawModels,
+        providers: {
+          ...rawProviders,
+          google: nextGoogle,
+        },
+      },
+    } as OpenClawConfig,
+    changes,
+  };
+}
 
 export const sessionRouteStateOwners: DoctorSessionRouteStateOwner[] = [
   {

--- a/extensions/google/doctor-contract-api.ts
+++ b/extensions/google/doctor-contract-api.ts
@@ -1,18 +1,19 @@
 // Google API module exposes the plugin public contract.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { DoctorSessionRouteStateOwner } from "openclaw/plugin-sdk/runtime-doctor";
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
+import { asNullableRecord as asRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 type LegacyConfigRule = {
-  path: string[];
+  path: Array<string | number>;
   message: string;
   match: (value: unknown) => boolean;
 };
 
 export const legacyConfigRules: LegacyConfigRule[] = [];
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
 
 /**
  * Normalize legacy Google provider config to satisfy the current catalog schema.
@@ -28,46 +29,50 @@ export function normalizeCompatibilityConfig({ cfg }: { cfg: OpenClawConfig }): 
   changes: string[];
 } {
   const changes: string[] = [];
-  const rawModels = cfg.models;
-  if (!isRecord(rawModels)) {
+  const rawModels = asRecord(cfg.models);
+  if (!rawModels) {
     return { config: cfg, changes };
   }
-  const rawProviders = rawModels.providers;
-  if (!isRecord(rawProviders)) {
+  const rawProviders = asRecord(rawModels.providers);
+  if (!rawProviders) {
     return { config: cfg, changes };
   }
-  const rawGoogle = rawProviders.google;
-  if (!isRecord(rawGoogle)) {
+  const rawGoogle = asRecord(rawProviders.google);
+  if (!rawGoogle) {
     return { config: cfg, changes };
   }
 
-  let googleChanged = false;
-  const nextGoogle = { ...rawGoogle } as Record<string, unknown>;
+  const nextConfig = structuredClone(cfg);
+  const nextModels = asRecord(nextConfig.models) ?? {};
+  nextConfig.models = nextModels as OpenClawConfig["models"];
+  const nextProviders = asRecord(nextModels.providers) ?? {};
+  nextModels.providers = nextProviders;
+  const nextGoogle = asRecord(nextProviders.google) ?? {};
+  nextProviders.google = nextGoogle;
 
   // Backfill api if missing.
-  if (typeof nextGoogle.api !== "string" || !nextGoogle.api.trim()) {
+  if (!isString(nextGoogle.api) || !nextGoogle.api.trim()) {
     nextGoogle.api = "google-generative-ai";
-    googleChanged = true;
     changes.push("Set models.providers.google.api = google-generative-ai (was missing).");
   }
 
   // Coerce model input modalities and cost.cacheWrite.
-  if (Array.isArray(nextGoogle.models)) {
-    const nextGoogleModels = nextGoogle.models.map((model, index) => {
-      if (!isRecord(model)) {
+  const models = nextGoogle.models;
+  if (Array.isArray(models)) {
+    const nextModelsArr = models.map((model, index) => {
+      const m = asRecord(model);
+      if (!m) {
         return model;
       }
-      let modelChanged = false;
-      const nextModel = { ...model } as Record<string, unknown>;
+      const nextModel = { ...m } as Record<string, unknown>;
 
       // Coerce input to ["text", "image"] (remove audio, video).
       if (Array.isArray(nextModel.input)) {
         const filtered = (nextModel.input as string[]).filter(
-          (m: string) => m === "text" || m === "image",
+          (v: string) => v === "text" || v === "image",
         );
         if (filtered.length !== (nextModel.input as string[]).length) {
           nextModel.input = filtered;
-          modelChanged = true;
           changes.push(
             `Coerced models.providers.google.models[${index}].input to [text, image] (removed unsupported modalities).`,
           );
@@ -75,46 +80,27 @@ export function normalizeCompatibilityConfig({ cfg }: { cfg: OpenClawConfig }): 
       }
 
       // Backfill cost.cacheWrite.
-      if (isRecord(nextModel.cost)) {
-        const cost = { ...nextModel.cost } as Record<string, unknown>;
-        if (!("cacheWrite" in cost) || typeof cost.cacheWrite !== "number") {
-          cost.cacheWrite = 0;
-          modelChanged = true;
-          changes.push(
-            `Added models.providers.google.models[${index}].cost.cacheWrite = 0 (was missing).`,
-          );
-        }
-        if (modelChanged) {
-          nextModel.cost = cost;
-        }
+      const cost = asRecord(nextModel.cost);
+      if (cost && (!("cacheWrite" in cost) || typeof cost.cacheWrite !== "number")) {
+        cost.cacheWrite = 0;
+        changes.push(
+          `Added models.providers.google.models[${index}].cost.cacheWrite = 0 (was missing).`,
+        );
       }
 
-      return modelChanged ? nextModel : model;
+      return nextModel;
     });
 
-    if (nextGoogleModels.some((m, i) => m !== nextGoogle.models[i])) {
-      nextGoogle.models = nextGoogleModels;
-      googleChanged = true;
+    if (nextModelsArr.some((m, i) => m !== models[i])) {
+      nextGoogle.models = nextModelsArr;
     }
   }
 
-  if (!googleChanged) {
+  if (!changes.length) {
     return { config: cfg, changes };
   }
 
-  return {
-    config: {
-      ...cfg,
-      models: {
-        ...rawModels,
-        providers: {
-          ...rawProviders,
-          google: nextGoogle,
-        },
-      },
-    } as OpenClawConfig,
-    changes,
-  };
+  return { config: nextConfig, changes };
 }
 
 export const sessionRouteStateOwners: DoctorSessionRouteStateOwner[] = [


### PR DESCRIPTION
## What Problem This Solves

Fixes #102138 — legacy `models.providers.google` blocks silently fail catalog
validation, making all `google/*` models unavailable with 120s idle timeouts.

## Root Cause

Older Google provider config blocks lack three fields required by current schema:
1. Missing `api: "google-generative-ai"`
2. `input` includes unsupported `audio`/`video` modalities
3. Missing `cost.cacheWrite`

## Fix

Add `normalizeCompatibilityConfig` in the Google plugin doctor contract:
1. Backfill `api = "google-generative-ai"` if missing
2. Coerce model `input` to `["text", "image"]`
3. Backfill `cost.cacheWrite = 0` if missing

Uses `structuredClone` pattern consistent with other plugin doctor contracts.

## Evidence

### End-to-End Proof: `openclaw doctor --fix`

```
BEFORE: api=none, input=[text,image,audio,video], cacheWrite=none
AFTER:  api=google-generative-ai, input=[text,image], cacheWrite=0
```

Doctor detected and repaired all three fields in one pass.

### Regression Test

Added `extensions/google/doctor-contract-api.test.ts` (8 tests):
- `backfills missing api` — verifies `api = "google-generative-ai"` is set when missing
- `coerces input modalities to text and image` — verifies audio/video removed
- `backfills missing cost.cacheWrite` — verifies `cacheWrite = 0` added
- `repairs all three legacy fields in one pass` — combined scenario
- `preserves existing apiKey and baseUrl` — verifies existing fields survive
- `leaves already-valid Google config unchanged` — idempotency
- `leaves config without Google provider unchanged` — no-op for non-Google configs
- `does not mutate the input config` — immutability guarantee

### Source-Level Proof

```
normalizeCompatibilityConfig(cfg) →
  api: google-generative-ai
  input: [text, image]
  cacheWrite: 0
```

- [x] oxfmt + oxlint pass
- [x] doctor e2e test pass (8/8)
- [x] CI: check-prod-types + check-additional-extension-package-boundary pass
