### PR TITLE
fix(agents): retry transient reads and fail closed when sweeping stale session write locks

### DIFF
--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -203,6 +203,7 @@ function cleanedLockForPath(lockPath: string): SessionLockInspection {
     staleReasons: ["dead-pid"],
     removable: true,
     removed: true,
+    unreadable: false,
   };
 }
 

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -381,6 +381,87 @@ describe("acquireSessionWriteLock", () => {
     });
   });
 
+  it("retries a transient read during cleanup so a live lock is not wrongly removed", async () => {
+    await withTempSessionLockFile(async ({ root }) => {
+      const lockPath = path.join(root, "sessions.jsonl.lock");
+      // Valid, live OpenClaw-owned lock whose mtime is old enough that a
+      // payload-less read would fall into the mtime removal grace and delete it.
+      await writeCurrentProcessLock(lockPath);
+      const staleDate = new Date(Date.now() - 120_000);
+      await fs.utimes(lockPath, staleDate, staleDate);
+
+      const realReadFile = fs.readFile.bind(fs);
+      let injectedTransient = false;
+      const spy = vi.spyOn(fs, "readFile").mockImplementation(((
+        target: Parameters<typeof fs.readFile>[0],
+        ...rest: unknown[]
+      ) => {
+        if (!injectedTransient && readFilePathToString(target) === lockPath) {
+          injectedTransient = true;
+          return Promise.reject(Object.assign(new Error("EAGAIN"), { code: "EAGAIN", errno: -11 }));
+        }
+        return (realReadFile as (...args: unknown[]) => Promise<unknown>)(target, ...rest);
+      }) as typeof fs.readFile);
+
+      try {
+        const result = await cleanStaleLockFiles({
+          sessionsDir: root,
+          staleMs: 60_000,
+          removeStale: true,
+          readOwnerProcessArgs: () => ["openclaw"],
+        });
+
+        // The transient error path was exercised, and the retry recovered the
+        // live payload so the lock was preserved (without the retry the null
+        // payload would fall into the mtime grace and be removed).
+        expect(injectedTransient).toBe(true);
+        expect(result.cleaned).toEqual([]);
+        await expect(fs.access(lockPath)).resolves.toBeUndefined();
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+
+  it("does not remove a live lock when transient reads exhaust retries during cleanup", async () => {
+    await withTempSessionLockFile(async ({ root }) => {
+      const lockPath = path.join(root, "sessions.jsonl.lock");
+      await writeCurrentProcessLock(lockPath);
+      const staleDate = new Date(Date.now() - 120_000);
+      await fs.utimes(lockPath, staleDate, staleDate);
+
+      const realReadFile = fs.readFile.bind(fs);
+      let transientReads = 0;
+      const spy = vi.spyOn(fs, "readFile").mockImplementation(((
+        target: Parameters<typeof fs.readFile>[0],
+        ...rest: unknown[]
+      ) => {
+        if (readFilePathToString(target) === lockPath) {
+          transientReads += 1;
+          return Promise.reject(Object.assign(new Error("EAGAIN"), { code: "EAGAIN", errno: -11 }));
+        }
+        return (realReadFile as (...args: unknown[]) => Promise<unknown>)(target, ...rest);
+      }) as typeof fs.readFile);
+
+      try {
+        const result = await cleanStaleLockFiles({
+          sessionsDir: root,
+          staleMs: 60_000,
+          removeStale: true,
+          readOwnerProcessArgs: () => ["openclaw"],
+        });
+
+        // Every read attempt failed transiently, so cleanup could not inspect the
+        // lock and must leave it rather than delete a possibly-live holder's lock.
+        expect(transientReads).toBeGreaterThanOrEqual(3);
+        expect(result.cleaned).toEqual([]);
+        await expect(fs.access(lockPath)).resolves.toBeUndefined();
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+
   it("reclaims malformed lock files once they are old enough", async () => {
     await withTempSessionLockFile(async ({ sessionFile, lockPath }) => {
       await fs.writeFile(lockPath, "{}", "utf8");

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -456,6 +456,18 @@ describe("acquireSessionWriteLock", () => {
         expect(transientReads).toBeGreaterThanOrEqual(3);
         expect(result.cleaned).toEqual([]);
         await expect(fs.access(lockPath)).resolves.toBeUndefined();
+
+        // The preserved lock must still be reported, or it becomes contention with
+        // no operator-visible cause. Staleness is unknown, not false-but-inspected.
+        expect(result.locks).toHaveLength(1);
+        expect(result.locks[0]).toMatchObject({
+          lockPath,
+          unreadable: true,
+          removable: false,
+          removed: false,
+          stale: false,
+          staleReasons: [],
+        });
       } finally {
         spy.mockRestore();
       }

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -41,6 +41,12 @@ export type SessionLockInspection = {
   staleReasons: string[];
   removable: boolean;
   removed: boolean;
+  /**
+   * The lock file could not be read (transient IO errors persisted across retries), so its
+   * contents were never inspected. Staleness is unknown rather than false, and the lock is
+   * never removable; it is reported so operators can see why contention persists.
+   */
+  unreadable: boolean;
 };
 
 export type SessionLockOwnerProcessArgsReader = (pid: number) => string[] | null;
@@ -904,8 +910,24 @@ export async function cleanStaleLockFiles(params: {
     const lockPath = path.join(sessionsDir, entry.name);
     const cleanupRead = await readLockPayloadForCleanup(lockPath);
     if (cleanupRead.status === "unreadable") {
-      // Fail closed: a lock we could not read is not proof of staleness. Leave it
-      // for a later sweep rather than deleting a possibly-live holder's lock.
+      // Fail closed: a lock we could not read is not proof of staleness. Leave it for a
+      // later sweep rather than deleting a possibly-live holder's lock — but still report
+      // it, or the retained lock becomes contention with no operator-visible cause.
+      locks.push({
+        lockPath,
+        pid: null,
+        pidAlive: false,
+        createdAt: null,
+        ageMs: null,
+        stale: false,
+        staleReasons: [],
+        removable: false,
+        removed: false,
+        unreadable: true,
+      });
+      params.log?.warn?.(
+        `session lock file unreadable, preserved: ${lockPath} (transient read errors persisted)`,
+      );
       continue;
     }
     const payload = cleanupRead.payload;
@@ -923,6 +945,7 @@ export async function cleanStaleLockFiles(params: {
       ...inspected,
       removable,
       removed: false,
+      unreadable: false,
     };
 
     if (removeStale && removable) {

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -12,6 +12,7 @@ import { parseSqliteSessionFileMarker } from "../config/sessions/sqlite-marker.j
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createFileLockManager } from "../infra/file-lock-manager.js";
 import { readGatewayProcessArgsSync as readProcessArgsSync } from "../infra/gateway-processes.js";
+import { retryAsync } from "../infra/retry.js";
 import { getProcessStartTime, isPidAlive } from "../shared/pid-alive.js";
 import {
   SessionWriteLockStaleError,
@@ -403,6 +404,53 @@ function parseLockPayload(raw: string): LockFilePayload | null {
     payload.maxHoldMs = parsed.maxHoldMs;
   }
   return payload;
+}
+
+// A transient FS race (EAGAIN/EWOULDBLOCK/EINTR under load) on a lock read must
+// not be mistaken for a stale lock: a null payload reads as missing-pid and,
+// past the mtime grace, `cleanStaleLockFiles` removes the file with no
+// content-identity guard — deleting a valid, live-held lock and breaking session
+// mutual exclusion. Cleanup retries, then fails closed (never removes) if the
+// read still cannot complete. The fs-safe acquire path already throws on these
+// codes, so only the cleanup removal decision needs this guard.
+const TRANSIENT_LOCK_READ_CODES = new Set(["EAGAIN", "EWOULDBLOCK", "EINTR"]);
+const TRANSIENT_LOCK_READ_ERRNOS = new Set([-11, -4]);
+const TRANSIENT_LOCK_READ_MESSAGE = /Unknown system error -(?:11|4)\b/i;
+
+function isTransientLockReadError(error: unknown): boolean {
+  const fsError = error as NodeJS.ErrnoException | undefined;
+  if (fsError?.code && TRANSIENT_LOCK_READ_CODES.has(fsError.code)) {
+    return true;
+  }
+  if (typeof fsError?.errno === "number" && TRANSIENT_LOCK_READ_ERRNOS.has(fsError.errno)) {
+    return true;
+  }
+  return error instanceof Error && TRANSIENT_LOCK_READ_MESSAGE.test(error.message);
+}
+
+// `unreadable` means a transient IO error persisted across retries, so cleanup
+// could not inspect the lock and must not treat it as stale.
+type LockPayloadCleanupRead =
+  | { status: "read"; payload: LockFilePayload | null }
+  | { status: "unreadable" };
+
+async function readLockPayloadForCleanup(lockPath: string): Promise<LockPayloadCleanupRead> {
+  try {
+    const raw = await retryAsync(() => fs.readFile(lockPath, "utf8"), {
+      attempts: 3,
+      minDelayMs: 50,
+      maxDelayMs: 50,
+      shouldRetry: (err) => isTransientLockReadError(err),
+    });
+    return { status: "read", payload: parseLockPayload(raw) };
+  } catch (error) {
+    // A malformed/empty file is still a successful read (payload null,
+    // reclaimable once old); only an unreadable transient IO error fails closed.
+    if (isTransientLockReadError(error)) {
+      return { status: "unreadable" };
+    }
+    return { status: "read", payload: null };
+  }
 }
 
 async function readLockPayload(lockPath: string): Promise<LockFilePayload | null> {
@@ -854,7 +902,13 @@ export async function cleanStaleLockFiles(params: {
       setImmediate(resolve);
     });
     const lockPath = path.join(sessionsDir, entry.name);
-    const payload = await readLockPayload(lockPath);
+    const cleanupRead = await readLockPayloadForCleanup(lockPath);
+    if (cleanupRead.status === "unreadable") {
+      // Fail closed: a lock we could not read is not proof of staleness. Leave it
+      // for a later sweep rather than deleting a possibly-live holder's lock.
+      continue;
+    }
+    const payload = cleanupRead.payload;
     const inspected = inspectLockPayloadForSession({
       payload,
       staleMs,

--- a/src/commands/doctor-session-locks.test.ts
+++ b/src/commands/doctor-session-locks.test.ts
@@ -110,6 +110,84 @@ describe("noteSessionLockHealth", () => {
     await expect(fs.access(freshLock)).resolves.toBeUndefined();
   });
 
+  it("reports a preserved unreadable lock in repair mode instead of hiding it", async () => {
+    const sessionsDir = state.sessionsDir();
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const lockPath = path.join(sessionsDir, "unreadable.jsonl.lock");
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({ pid: process.pid, createdAt: new Date(Date.now() - 120_000).toISOString() }),
+      "utf8",
+    );
+    const staleDate = new Date(Date.now() - 120_000);
+    await fs.utimes(lockPath, staleDate, staleDate);
+
+    const realReadFile = fs.readFile.bind(fs);
+    const spy = vi.spyOn(fs, "readFile").mockImplementation(((
+      target: Parameters<typeof fs.readFile>[0],
+      ...rest: unknown[]
+    ) => {
+      if (String(target) === lockPath) {
+        return Promise.reject(Object.assign(new Error("EAGAIN"), { code: "EAGAIN", errno: -11 }));
+      }
+      return (realReadFile as (...args: unknown[]) => Promise<unknown>)(target, ...rest);
+    }) as typeof fs.readFile);
+
+    try {
+      await noteSessionLockHealth({
+        shouldRepair: true,
+        staleMs: 30_000,
+        readOwnerProcessArgs: () => ["node", "/opt/openclaw/openclaw.mjs", "doctor"],
+      });
+
+      const [message] = firstNoteCall();
+      // Sustained EAGAIN means cleanup never inspected the lock: it must be kept AND
+      // surfaced, and must not claim pid/age/stale facts it never read.
+      expect(message).toContain("unreadable (transient read errors persisted) [preserved]");
+      expect(message).toContain("1 lock file was unreadable and left in place");
+      expect(message).not.toContain("[removed]");
+      await expect(fs.access(lockPath)).resolves.toBeUndefined();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("surfaces an unreadable lock as a health finding and a preserve effect", async () => {
+    const sessionsDir = state.sessionsDir();
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const lockPath = path.join(sessionsDir, "unreadable.jsonl.lock");
+    await fs.writeFile(lockPath, JSON.stringify({ pid: process.pid }), "utf8");
+    const staleDate = new Date(Date.now() - 120_000);
+    await fs.utimes(lockPath, staleDate, staleDate);
+
+    const realReadFile = fs.readFile.bind(fs);
+    const spy = vi.spyOn(fs, "readFile").mockImplementation(((
+      target: Parameters<typeof fs.readFile>[0],
+      ...rest: unknown[]
+    ) => {
+      if (String(target) === lockPath) {
+        return Promise.reject(Object.assign(new Error("EAGAIN"), { code: "EAGAIN", errno: -11 }));
+      }
+      return (realReadFile as (...args: unknown[]) => Promise<unknown>)(target, ...rest);
+    }) as typeof fs.readFile);
+
+    try {
+      const detected = await detectStaleSessionLocks({ staleMs: 30_000 });
+      expect(detected).toHaveLength(1);
+      expect(detected[0]?.unreadable).toBe(true);
+
+      const finding = sessionLockToHealthFinding(detected[0]!);
+      expect(finding.message).toContain("Unreadable session lock file");
+      expect(finding.fixHint).toContain("could not be read");
+
+      expect(sessionLockToRepairEffect(detected[0]!).action).toBe(
+        "would-preserve-unreadable-session-lock",
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   it("detects stale locks without removing them for structured lint", async () => {
     const sessionsDir = state.sessionsDir();
     await fs.mkdir(sessionsDir, { recursive: true });

--- a/src/commands/doctor-session-locks.ts
+++ b/src/commands/doctor-session-locks.ts
@@ -41,6 +41,10 @@ function formatAge(ageMs: number | null): string {
 }
 
 function formatLockLine(lock: SessionLockInspection): string {
+  if (lock.unreadable) {
+    // Nothing was inspected, so pid/age/stale would all report placeholder values as fact.
+    return `- ${shortenHomePath(lock.lockPath)} unreadable (transient read errors persisted) [preserved]`;
+  }
   const pidStatus =
     lock.pid === null ? "pid=missing" : `pid=${lock.pid} (${lock.pidAlive ? "alive" : "dead"})`;
   const ageStatus = `age=${formatAge(lock.ageMs)}`;
@@ -68,12 +72,24 @@ export async function detectStaleSessionLocks(params?: {
       removeStale: false,
       readOwnerProcessArgs: params?.readOwnerProcessArgs,
     });
-    staleLocks.push(...result.locks.filter((lock) => lock.stale));
+    // Unreadable locks are preserved rather than removed, so they need the same operator
+    // surfacing as stale ones — otherwise the retained lock causes contention silently.
+    staleLocks.push(...result.locks.filter((lock) => lock.stale || lock.unreadable));
   }
   return staleLocks.toSorted((a, b) => a.lockPath.localeCompare(b.lockPath));
 }
 
 export function sessionLockToHealthFinding(lock: SessionLockInspection): HealthFinding {
+  if (lock.unreadable) {
+    return {
+      checkId: SESSION_LOCKS_CHECK_ID,
+      severity: "warning",
+      message: `Unreadable session lock file: ${shortenHomePath(lock.lockPath)} (transient read errors persisted)`,
+      path: lock.lockPath,
+      fixHint:
+        'OpenClaw preserved this lock because it could not be read; check filesystem health and permissions, then re-run "openclaw doctor".',
+    };
+  }
   const fixHint = lock.removable
     ? 'Run "openclaw doctor --fix" to remove this stale lock file automatically.'
     : isReportOnlyStaleLock(lock)
@@ -89,11 +105,13 @@ export function sessionLockToHealthFinding(lock: SessionLockInspection): HealthF
 }
 
 export function sessionLockToRepairEffect(lock: SessionLockInspection): HealthRepairEffect {
-  const action = lock.removable
-    ? "would-remove-stale-session-lock"
-    : isReportOnlyStaleLock(lock)
-      ? "would-preserve-report-only-stale-session-lock"
-      : "would-preserve-mtime-gated-stale-session-lock";
+  const action = lock.unreadable
+    ? "would-preserve-unreadable-session-lock"
+    : lock.removable
+      ? "would-remove-stale-session-lock"
+      : isReportOnlyStaleLock(lock)
+        ? "would-preserve-report-only-stale-session-lock"
+        : "would-preserve-mtime-gated-stale-session-lock";
   return {
     kind: "state",
     action,
@@ -141,6 +159,7 @@ export async function noteSessionLockHealth(params?: {
 
   const staleCount = allLocks.filter((lock) => lock.stale).length;
   const removedCount = allLocks.filter((lock) => lock.removed).length;
+  const unreadableCount = allLocks.filter((lock) => lock.unreadable).length;
   const lines: string[] = [
     `- Found ${allLocks.length} session lock file${allLocks.length === 1 ? "" : "s"}.`,
     ...allLocks.toSorted((a, b) => a.lockPath.localeCompare(b.lockPath)).map(formatLockLine),
@@ -149,6 +168,11 @@ export async function noteSessionLockHealth(params?: {
   if (staleCount > 0 && !shouldRepair) {
     lines.push(`- ${staleCount} lock file${staleCount === 1 ? " is" : "s are"} stale.`);
     lines.push('- Run "openclaw doctor --fix" to remove stale lock files automatically.');
+  }
+  if (unreadableCount > 0) {
+    lines.push(
+      `- ${unreadableCount} lock file${unreadableCount === 1 ? " was" : "s were"} unreadable and left in place; check filesystem health if session writes stay blocked.`,
+    );
   }
   if (shouldRepair && removedCount > 0) {
     lines.push(


### PR DESCRIPTION
Related: #100910

## What Problem This Solves

Resolves a problem where the gateway's startup session-lock sweep (and
`openclaw doctor`) can delete a valid, actively-held session write lock, breaking
mutual exclusion on a session's transcript. When cleanup reads a lock file, any
transient filesystem error (EAGAIN/EWOULDBLOCK/EINTR under load) is collapsed to
a "no payload" result, which reads as a missing PID. Past the 30-second mtime
grace the lock is then removed with no content-identity check — so a transient
read on a live lock (held for up to the 5-minute max hold) deletes it, after
which a second writer can acquire a fresh lock while the original holder is still
writing the same JSONL.

## Why This Change Was Made

The cleanup removal decision (`cleanStaleLockFiles`) now reads each lock through
`readLockPayloadForCleanup`, which (1) retries only transient read errors — the
same `{EAGAIN, EWOULDBLOCK, EINTR}` classifier used for workspace bootstrap reads
in #100910 — and (2) **fails closed**: if the read still cannot complete after
retries, the lock is treated as unreadable and left in place rather than removed.
A malformed/empty but readable lock is still a successful read (payload null,
reclaimable once old), so existing stale-reclaim behavior is unchanged. This is
scoped to the cleanup removal decision only: the fs-safe **acquire** path already
throws on these transient codes and guards stale removal with a content-identity
re-check, so it needs no change, and the acquire-timeout diagnostics readers are
intentionally left as simple non-retrying reads.

## User Impact

Operators no longer risk a transient IO blip (a single spike or a short burst)
during gateway startup or `openclaw doctor` silently deleting a live session lock
and letting two writers race on the same transcript. No API, config, or
success-path behavior change; readable malformed locks are still reclaimed once
old.

## Evidence

### Real behavior proof — real `openclaw doctor --fix` run

`node --import tsx` drives the **real `noteSessionLockHealth({ shouldRepair:
true })`** (the exact function `openclaw doctor --fix` runs for its "Session
locks" check) over a **real on-disk `OPENCLAW_STATE_DIR`** whose lock is owned by
a **real live process spawned with an OpenClaw argv**. No mock of
`cleanStaleLockFiles` / ownership resolution / the store — only a single transient
`EAGAIN` is injected at the `fs.readFile` boundary (a real load spike can't be
summoned deterministically). The lock's mtime is aged 120 s past the 30 s grace.

Fixed tree (this PR):

```
=== single-blip — openclaw doctor --fix (real noteSessionLockHealth) ===
◇  Session locks
│  - Found 1 session lock file.
│  - .../agents/proof-agent/sessions/sess-proof.jsonl.lock  pid=1479913 (alive) age=0s stale=no
transient EAGAIN reads injected : 1
lock still present after --fix  : true
RESULT: PASS — live lock preserved

=== sustained-burst (all 3 read attempts fail) ===
transient EAGAIN reads injected : 3
lock still present after --fix  : true
RESULT: PASS — live lock preserved
```

Negative control — upstream `main` (no fix), same real harness — `openclaw doctor
--fix` deletes the live lock:

```
│    [removed]
│  - Removed 1 stale session lock file.
lock still present after --fix  : false
RESULT: FAIL — live lock removed   (both single-blip and sustained-burst)
```

### Focused regression tests

Two deterministic tests run `cleanStaleLockFiles` against a valid, live
OpenClaw-owned lock aged past the grace, injecting transient `EAGAIN`:

```
 ✓ retries a transient read during cleanup so a live lock is not wrongly removed
     // single blip → retry recovers the payload → lock preserved
 ✓ does not remove a live lock when transient reads exhaust retries during cleanup
     // sustained burst → all retries fail → fail closed → lock preserved

 Test Files  1 passed (1)
      Tests  56 passed (56)
```

Reverting the fix fails exactly these two tests (the null payload otherwise falls
into the mtime grace and is removed).

Run: `node scripts/run-vitest.mjs src/agents/session-write-lock.test.ts`; full
changed-lane checks are delegated to CI.

### Follow-up

In the sustained-burst case the preserved lock is skipped from `result.locks`, so
`openclaw doctor` does not currently list it. Surfacing unreadable locks in
doctor/startup diagnostics is a small additive follow-up (touches
`doctor-session-locks.ts` rendering); proposed separately to keep this PR to the
correctness fix.
