### PR TITLE
fix(ui): focus new chats and declutter sidebar footer

### DIFF
--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -1,0 +1,117 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it, vi } from "vitest";
+import { shouldHandleNewChatShortcut } from "./app-host.ts";
+
+function keydownTarget(target: EventTarget, init: KeyboardEventInit): KeyboardEvent {
+  let event: KeyboardEvent | null = null;
+  target.addEventListener(
+    "keydown",
+    (next) => {
+      event = next as KeyboardEvent;
+    },
+    { once: true },
+  );
+  target.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, cancelable: true, ...init }));
+  if (!event) {
+    throw new Error("expected keydown event");
+  }
+  return event;
+}
+
+function createShell() {
+  const Shell = customElements.get("openclaw-app-shell");
+  if (!Shell) {
+    throw new Error("openclaw-app-shell was not registered");
+  }
+  return new Shell() as HTMLElement & {
+    activeSessionKey: string;
+    context: unknown;
+    createSessionFromShortcut: () => Promise<void>;
+  };
+}
+
+describe("OpenClaw app shell shortcuts", () => {
+  it("handles Cmd/Ctrl+N outside editable targets only", () => {
+    expect(
+      shouldHandleNewChatShortcut(keydownTarget(document.body, { key: "n", metaKey: true })),
+    ).toBe(true);
+    expect(
+      shouldHandleNewChatShortcut(keydownTarget(document.body, { key: "N", ctrlKey: true })),
+    ).toBe(true);
+    expect(
+      shouldHandleNewChatShortcut(
+        keydownTarget(document.body, { key: "n", ctrlKey: true, shiftKey: true }),
+      ),
+    ).toBe(false);
+
+    const input = document.createElement("input");
+    document.body.append(input);
+    expect(shouldHandleNewChatShortcut(keydownTarget(input, { key: "n", metaKey: true }))).toBe(
+      false,
+    );
+
+    const editor = document.createElement("div");
+    editor.setAttribute("contenteditable", "");
+    document.body.append(editor);
+    expect(shouldHandleNewChatShortcut(keydownTarget(editor, { key: "n", ctrlKey: true }))).toBe(
+      false,
+    );
+
+    const dialog = document.createElement("dialog");
+    const button = document.createElement("button");
+    dialog.append(button);
+    document.body.append(dialog);
+    expect(shouldHandleNewChatShortcut(keydownTarget(button, { key: "n", metaKey: true }))).toBe(
+      false,
+    );
+  });
+
+  it("creates a focused chat session from the existing shell session flow", async () => {
+    const create = vi.fn(async () => "agent:main:new");
+    const setSessionKey = vi.fn();
+    const navigate = vi.fn();
+    const shell = createShell();
+    shell.activeSessionKey = "agent:main:old";
+    shell.context = {
+      agentSelection: { state: { selectedId: "main" } },
+      gateway: {
+        snapshot: {
+          assistantAgentId: "main",
+          connected: true,
+          hello: null,
+          sessionKey: "agent:main:old",
+        },
+        setSessionKey,
+      },
+      navigate,
+      sessions: {
+        create,
+        state: {
+          agentId: "main",
+          deletedSessions: [],
+          error: null,
+          loading: false,
+          modelOverrides: {},
+          result: {
+            count: 1,
+            defaults: {},
+            hasMore: false,
+            sessions: [{ key: "agent:main:old", hasActiveRun: false }],
+          },
+        },
+      },
+    };
+
+    await shell.createSessionFromShortcut();
+
+    expect(create).toHaveBeenCalledWith({
+      agentId: "main",
+      currentSessionKey: "agent:main:old",
+    });
+    expect(setSessionKey).toHaveBeenCalledWith("agent:main:new");
+    expect(navigate).toHaveBeenCalledWith("chat", {
+      search: "?session=agent%3Amain%3Anew&focusComposer=1",
+    });
+  });
+});

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -26,7 +26,7 @@ import { t } from "../i18n/index.ts";
 import { copyToClipboard } from "../lib/clipboard.ts";
 import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
 import { isWorkboardEnabledInConfigSnapshot } from "../lib/plugin-activation.ts";
-import { searchForSession } from "../lib/sessions/index.ts";
+import { resolveSessionNavigation, searchForSession } from "../lib/sessions/index.ts";
 import { resolveAgentIdFromSessionKey } from "../lib/sessions/session-key.ts";
 import { normalizeLowercaseStringOrEmpty, normalizeOptionalString } from "../lib/string-coerce.ts";
 import { renderDevicePairSetup } from "../pages/nodes/view-pairing.ts";
@@ -50,6 +50,17 @@ type ShellRouteState = {
 // Stable references so the sidebar's enabledRouteIds property does not churn
 // on every shell render.
 const ROUTE_IDS_WITHOUT_WORKBOARD = APP_ROUTE_IDS.filter((routeId) => routeId !== "workboard");
+const NEW_CHAT_SHORTCUT_EDITABLE_SELECTOR = [
+  "input",
+  "textarea",
+  "select",
+  "[contenteditable]:not([contenteditable='false'])",
+  "[role='textbox']",
+  ".cm-editor",
+  ".monaco-editor",
+  "dialog",
+  "[role='dialog']",
+].join(",");
 
 function selectShellRouteState(routerState: RouterState<RouteId>): ShellRouteState {
   const match = selectRenderedRouteMatch(routerState.matches[0], routerState.pendingMatches[0]);
@@ -85,6 +96,21 @@ function resolveAgentLabel(sessionKey: string, agentsList: AgentsListResult | nu
 function resolveOnboardingMode(): boolean {
   const raw = new URLSearchParams(globalThis.location?.search ?? "").get("onboarding");
   return raw !== null && /^(?:1|true|yes|on)$/iu.test(raw.trim());
+}
+
+function isEditableNewChatShortcutTarget(target: EventTarget | null): boolean {
+  return target instanceof Element && Boolean(target.closest(NEW_CHAT_SHORTCUT_EDITABLE_SELECTOR));
+}
+
+export function shouldHandleNewChatShortcut(event: KeyboardEvent): boolean {
+  return (
+    !event.defaultPrevented &&
+    (event.metaKey || event.ctrlKey) &&
+    !event.altKey &&
+    !event.shiftKey &&
+    event.key.toLowerCase() === "n" &&
+    !isEditableNewChatShortcutTarget(event.target)
+  );
 }
 
 /**
@@ -413,6 +439,7 @@ class OpenClawShell extends LitElement {
     super.connectedCallback();
     this.startSubscriptions();
     this.addEventListener(COMMAND_PALETTE_TARGET_EVENT, this.handleCommandPaletteTarget);
+    document.addEventListener("keydown", this.handleGlobalNewChatKeydown);
   }
 
   override updated() {
@@ -480,6 +507,7 @@ class OpenClawShell extends LitElement {
 
   override disconnectedCallback() {
     this.removeEventListener(COMMAND_PALETTE_TARGET_EVENT, this.handleCommandPaletteTarget);
+    document.removeEventListener("keydown", this.handleGlobalNewChatKeydown);
     this.stopAgentsSubscription?.();
     this.stopAgentsSubscription = undefined;
     this.stopConfigSubscription?.();
@@ -563,6 +591,45 @@ class OpenClawShell extends LitElement {
     event.preventDefault();
     this.closeNavDrawer({ restoreFocus: true });
   };
+
+  private readonly handleGlobalNewChatKeydown = (event: KeyboardEvent) => {
+    if (!shouldHandleNewChatShortcut(event)) {
+      return;
+    }
+    event.preventDefault();
+    void this.createSessionFromShortcut();
+  };
+
+  private async createSessionFromShortcut() {
+    const context = this.context;
+    if (!context || !context.gateway.snapshot.connected || context.sessions.state.loading) {
+      return;
+    }
+    const currentSessionKey =
+      this.activeSessionKey.trim() || context.gateway.snapshot.sessionKey.trim();
+    const navigation = resolveSessionNavigation({
+      result: context.sessions.state.result,
+      resultAgentId: context.sessions.state.agentId,
+      sessionKey: currentSessionKey,
+      assistantAgentId:
+        context.agentSelection.state.selectedId ?? context.gateway.snapshot.assistantAgentId,
+      hello: context.gateway.snapshot.hello,
+    });
+    if (navigation.selectedSession?.hasActiveRun === true) {
+      return;
+    }
+    const nextSessionKey = await context.sessions.create({
+      currentSessionKey: navigation.currentSessionKey,
+      agentId: navigation.selectedAgentId,
+    });
+    if (!nextSessionKey) {
+      return;
+    }
+    context.gateway.setSessionKey(nextSessionKey);
+    this.navigate("chat", {
+      search: searchForSession(nextSessionKey, { focusComposer: true }),
+    });
+  }
 
   private readonly openPalette = () => {
     this.commandPalette?.openPalette();

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -1,0 +1,79 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "./app-sidebar.ts";
+
+type TestSidebar = HTMLElement & {
+  canPairDevice: boolean;
+  themeMode: "system" | "light" | "dark";
+  updateComplete: Promise<boolean>;
+};
+
+function createSidebar(): TestSidebar {
+  const Sidebar = customElements.get("openclaw-app-sidebar");
+  if (!Sidebar) {
+    throw new Error("openclaw-app-sidebar was not registered");
+  }
+  const sidebar = new Sidebar() as TestSidebar;
+  sidebar.canPairDevice = true;
+  document.body.append(sidebar);
+  return sidebar;
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("app sidebar footer", () => {
+  it("keeps only More, Settings, and Mobile actions fixed in the footer", async () => {
+    const sidebar = createSidebar();
+
+    await sidebar.updateComplete;
+
+    const footerActions = [
+      ...sidebar.querySelectorAll<HTMLElement>(".sidebar-footer-bar .sidebar-footer-icon"),
+    ];
+    expect(footerActions.map((action) => action.getAttribute("aria-label"))).toEqual([
+      "More",
+      "Settings",
+      "Pair mobile device",
+    ]);
+    expect(sidebar.querySelector(".sidebar-footer-bar a[href='https://docs.openclaw.ai']")).toBe(
+      null,
+    );
+    expect(sidebar.querySelector("openclaw-theme-mode-toggle")).toBeNull();
+  });
+
+  it("moves docs and theme controls into the footer More menu", async () => {
+    const sidebar = createSidebar();
+    sidebar.themeMode = "dark";
+    const themeChange = vi.fn();
+    sidebar.addEventListener("theme-change", themeChange);
+    await sidebar.updateComplete;
+
+    sidebar.querySelector<HTMLButtonElement>(".sidebar-footer-more")?.click();
+    await sidebar.updateComplete;
+
+    const menu = sidebar.querySelector<HTMLElement>(".sidebar-footer-menu");
+    expect(menu?.querySelector("a[href='https://docs.openclaw.ai']")).not.toBeNull();
+    expect(menu?.querySelector(".sidebar-session-menu__check")).toBeNull();
+    const activeTheme = menu?.querySelector<HTMLElement>(
+      ".sidebar-footer-theme-toggle__button[aria-pressed='true']",
+    );
+    expect(activeTheme?.getAttribute("aria-label")).toContain("Dark");
+    expect(menu?.querySelector(".sidebar-footer-menu__action-icon svg")).not.toBeNull();
+
+    const themeButtons = [
+      ...(menu?.querySelectorAll<HTMLButtonElement>(".sidebar-footer-theme-toggle__button") ?? []),
+    ];
+    const lightOption = themeButtons.find((button) =>
+      button.getAttribute("aria-label")?.includes("Light"),
+    );
+    expect(lightOption).toBeDefined();
+    lightOption?.click();
+
+    expect(themeChange).toHaveBeenCalledOnce();
+    const event = themeChange.mock.calls[0]?.[0] as CustomEvent;
+    expect(event.detail.mode).toBe("light");
+  });
+});

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -23,7 +23,6 @@ import {
   type ApplicationNavigationOptions,
 } from "../app/context.ts";
 import { controlUiPublicAssetPath } from "../app/public-assets.ts";
-import "./theme-mode-toggle.ts";
 import "./tooltip.ts";
 import type { ThemeMode } from "../app/theme.ts";
 import { t } from "../i18n/index.ts";
@@ -93,6 +92,9 @@ type SidebarSessionGroupMenuState = {
 type SidebarSessionSortMode = "created" | "updated";
 
 const SIDEBAR_SESSION_GROUPING_STORAGE_KEY = "openclaw:sidebar:sessions:grouping";
+const SIDEBAR_FOOTER_MENU_WIDTH = 232;
+const SIDEBAR_FOOTER_MENU_MAX_HEIGHT = 140;
+const SIDEBAR_FOOTER_MENU_VERTICAL_OFFSET = 116;
 
 // Command palette shortcut hint (see command-palette.ts keydown handling).
 const PALETTE_SHORTCUT = /Mac|iP(hone|ad|od)/i.test(globalThis.navigator?.platform ?? "")
@@ -111,6 +113,16 @@ const SIDEBAR_SESSION_SORT_OPTIONS = [
 ] as const satisfies ReadonlyArray<{
   mode: SidebarSessionSortMode;
   labelKey: "chat.sidebar.sortCreated" | "chat.sidebar.sortUpdated";
+}>;
+
+const SIDEBAR_FOOTER_THEME_OPTIONS = [
+  { mode: "system", labelKey: "common.system", icon: "monitor" },
+  { mode: "light", labelKey: "common.light", icon: "sun" },
+  { mode: "dark", labelKey: "common.dark", icon: "moon" },
+] as const satisfies ReadonlyArray<{
+  mode: ThemeMode;
+  labelKey: "common.system" | "common.light" | "common.dark";
+  icon: IconName;
 }>;
 
 function shouldHandleNavigationClick(event: MouseEvent): boolean {
@@ -159,6 +171,7 @@ class AppSidebar extends LitElement {
   @state() private sessionSortMode: SidebarSessionSortMode = "created";
   @state() private sessionsGrouping: SidebarSessionsGrouping = loadStoredSidebarSessionsGrouping();
   @state() private sessionSortMenuPosition: { x: number; y: number } | null = null;
+  @state() private footerMoreMenuPosition: { x: number; y: number } | null = null;
   @state() private sessionsResult: SessionsListResult | null = null;
   @state() private sessionsAgentId: string | null = null;
   @state() private sessionsLoading = false;
@@ -172,6 +185,7 @@ class AppSidebar extends LitElement {
   private sessionMenuTrigger: HTMLElement | null = null;
   private sessionGroupMenuTrigger: HTMLElement | null = null;
   private sessionSortMenuTrigger: HTMLElement | null = null;
+  private footerMoreMenuTrigger: HTMLElement | null = null;
   private sessionRowsByAgent: Record<string, SessionsListResult["sessions"]> = {};
   private sessionCreatedOrder = new Map<string, number>();
   private gatewayClient: GatewayBrowserClient | null = null;
@@ -191,6 +205,7 @@ class AppSidebar extends LitElement {
     this.closeSessionMenu();
     this.closeSessionGroupMenu();
     this.closeSessionSortMenu();
+    this.closeFooterMoreMenu();
     this.stopSessionsSubscription?.();
     this.stopSessionsSubscription = undefined;
     this.stopSessionCreatedSubscription?.();
@@ -514,6 +529,7 @@ class AppSidebar extends LitElement {
     this.closeCustomizeMenu();
     this.closeSessionGroupMenu();
     this.closeSessionSortMenu();
+    this.closeFooterMoreMenu();
     this.sessionMenuTrigger = trigger;
     this.sessionGroupSubmenuOpen = false;
     const clampedX = Math.max(8, Math.min(x, window.innerWidth - menuWidth - 8));
@@ -548,6 +564,7 @@ class AppSidebar extends LitElement {
     this.closeCustomizeMenu();
     this.closeSessionMenu();
     this.closeSessionSortMenu();
+    this.closeFooterMoreMenu();
     this.sessionGroupMenuTrigger = trigger;
     this.sessionGroupMenu = {
       group,
@@ -580,6 +597,7 @@ class AppSidebar extends LitElement {
     this.closeCustomizeMenu();
     this.closeSessionMenu();
     this.closeSessionGroupMenu();
+    this.closeFooterMoreMenu();
     this.sessionSortMenuTrigger = trigger;
     this.sessionSortMenuPosition = {
       x: Math.max(8, Math.min(x, window.innerWidth - menuWidth - 8)),
@@ -596,6 +614,34 @@ class AppSidebar extends LitElement {
     const trigger = this.sessionSortMenuTrigger;
     this.sessionSortMenuTrigger = null;
     this.sessionSortMenuPosition = null;
+    document.removeEventListener("pointerdown", this.handleDocumentPointerDown, true);
+    document.removeEventListener("keydown", this.handleDocumentKeydown, true);
+    if (options.restoreFocus) {
+      trigger?.focus();
+    }
+  }
+
+  private openFooterMoreMenu(x: number, y: number, trigger: HTMLElement | null = null) {
+    this.closeCustomizeMenu();
+    this.closeSessionMenu();
+    this.closeSessionGroupMenu();
+    this.closeSessionSortMenu();
+    this.footerMoreMenuTrigger = trigger;
+    this.footerMoreMenuPosition = {
+      x: Math.max(8, Math.min(x, window.innerWidth - SIDEBAR_FOOTER_MENU_WIDTH - 8)),
+      y: Math.max(8, Math.min(y, window.innerHeight - SIDEBAR_FOOTER_MENU_MAX_HEIGHT - 8)),
+    };
+    document.addEventListener("pointerdown", this.handleDocumentPointerDown, true);
+    document.addEventListener("keydown", this.handleDocumentKeydown, true);
+    void this.updateComplete.then(() => {
+      this.querySelector<HTMLElement>(".sidebar-footer-menu__item")?.focus();
+    });
+  }
+
+  private closeFooterMoreMenu(options: { restoreFocus?: boolean } = {}) {
+    const trigger = this.footerMoreMenuTrigger;
+    this.footerMoreMenuTrigger = null;
+    this.footerMoreMenuPosition = null;
     document.removeEventListener("pointerdown", this.handleDocumentPointerDown, true);
     document.removeEventListener("keydown", this.handleDocumentKeydown, true);
     if (options.restoreFocus) {
@@ -725,15 +771,19 @@ class AppSidebar extends LitElement {
   private readonly handleDocumentPointerDown = (event: PointerEvent) => {
     const path = event.composedPath();
     const menu = this.querySelector(
-      ".sidebar-customize-menu, .sidebar-session-menu, .sidebar-session-sort-menu",
+      ".sidebar-customize-menu, .sidebar-session-menu, .sidebar-session-sort-menu, .sidebar-footer-menu",
     );
     if (menu && path.includes(menu)) {
+      return;
+    }
+    if (this.footerMoreMenuTrigger && path.includes(this.footerMoreMenuTrigger)) {
       return;
     }
     this.closeCustomizeMenu();
     this.closeSessionMenu();
     this.closeSessionGroupMenu();
     this.closeSessionSortMenu();
+    this.closeFooterMoreMenu();
   };
 
   private readonly handleDocumentKeydown = (event: KeyboardEvent) => {
@@ -743,6 +793,7 @@ class AppSidebar extends LitElement {
       this.closeSessionMenu({ restoreFocus: true });
       this.closeSessionGroupMenu({ restoreFocus: true });
       this.closeSessionSortMenu({ restoreFocus: true });
+      this.closeFooterMoreMenu({ restoreFocus: true });
     }
   };
 
@@ -801,6 +852,73 @@ class AppSidebar extends LitElement {
           <span class="nav-item__icon" aria-hidden="true">${icons.refresh}</span>
           <span class="sidebar-customize-menu__text">${t("nav.customizeReset")}</span>
         </button>
+      </div>
+    `;
+  }
+
+  private renderFooterMoreMenu() {
+    const position = this.footerMoreMenuPosition;
+    if (!position) {
+      return nothing;
+    }
+    return html`
+      <div
+        class="sidebar-session-menu sidebar-footer-menu"
+        role="group"
+        aria-label=${t("nav.more")}
+        style="left: ${position.x}px; top: ${position.y}px;"
+      >
+        <div class="sidebar-footer-menu__row">
+          <span class="sidebar-footer-menu__label">${t("common.theme")}</span>
+          <div class="sidebar-footer-theme-toggle" role="group" aria-label=${t("common.colorMode")}>
+            ${SIDEBAR_FOOTER_THEME_OPTIONS.map((option) => {
+              const label = t(option.labelKey);
+              const active = option.mode === this.themeMode;
+              const tooltip = t("common.colorModeOption", { mode: label });
+              return html`
+                <openclaw-tooltip .content=${tooltip}>
+                  <button
+                    type="button"
+                    class="sidebar-footer-theme-toggle__button ${active
+                      ? "sidebar-footer-theme-toggle__button--active"
+                      : ""}"
+                    aria-label=${tooltip}
+                    aria-pressed=${String(active)}
+                    @click=${(event: Event) => {
+                      if (active) {
+                        return;
+                      }
+                      this.dispatchEvent(
+                        new CustomEvent("theme-change", {
+                          detail: {
+                            mode: option.mode,
+                            element: event.currentTarget as HTMLElement,
+                          },
+                          bubbles: true,
+                          composed: true,
+                        }),
+                      );
+                    }}
+                  >
+                    ${icons[option.icon]}
+                  </button>
+                </openclaw-tooltip>
+              `;
+            })}
+          </div>
+        </div>
+        <a
+          class="sidebar-session-menu__item sidebar-footer-menu__item sidebar-footer-menu__link"
+          href="https://docs.openclaw.ai"
+          target=${EXTERNAL_LINK_TARGET}
+          rel=${buildExternalLinkRel()}
+          @click=${() => this.closeFooterMoreMenu()}
+        >
+          <span class="sidebar-footer-menu__label">${t("common.docs")}</span>
+          <span class="sidebar-footer-menu__action-icon" aria-hidden="true">
+            ${icons.arrowUpRight}
+          </span>
+        </a>
       </div>
     `;
   }
@@ -1648,6 +1766,29 @@ class AppSidebar extends LitElement {
                 ></span>
               </openclaw-tooltip>
               <span class="sidebar-footer-bar__spacer"></span>
+              <openclaw-tooltip .content=${t("nav.more")}>
+                <button
+                  class="sidebar-footer-icon sidebar-footer-more"
+                  type="button"
+                  aria-label=${t("nav.more")}
+                  aria-expanded=${String(this.footerMoreMenuPosition !== null)}
+                  @click=${(event: MouseEvent) => {
+                    const trigger = event.currentTarget as HTMLElement;
+                    if (this.footerMoreMenuPosition) {
+                      this.closeFooterMoreMenu({ restoreFocus: true });
+                      return;
+                    }
+                    const rect = trigger.getBoundingClientRect();
+                    this.openFooterMoreMenu(
+                      rect.right - SIDEBAR_FOOTER_MENU_WIDTH,
+                      rect.top - SIDEBAR_FOOTER_MENU_VERTICAL_OFFSET,
+                      trigger,
+                    );
+                  }}
+                >
+                  ${icons.moreHorizontal}
+                </button>
+              </openclaw-tooltip>
               <openclaw-tooltip .content=${titleForRoute("config")}>
                 <a
                   href=${pathForRoute("config", this.basePath)}
@@ -1671,19 +1812,6 @@ class AppSidebar extends LitElement {
                 </a>
               </openclaw-tooltip>
               <openclaw-tooltip
-                .content=${t("chat.docsOpensInNewTab", { label: t("common.docs") })}
-              >
-                <a
-                  class="sidebar-footer-icon"
-                  href="https://docs.openclaw.ai"
-                  target=${EXTERNAL_LINK_TARGET}
-                  rel=${buildExternalLinkRel()}
-                  aria-label=${t("common.docs")}
-                >
-                  ${icons.book}
-                </a>
-              </openclaw-tooltip>
-              <openclaw-tooltip
                 .content=${this.canPairDevice
                   ? t("nodes.pairing.button")
                   : t("nodes.pairing.adminRequired")}
@@ -1698,14 +1826,11 @@ class AppSidebar extends LitElement {
                   ${icons.smartphone}
                 </button>
               </openclaw-tooltip>
-              <span class="sidebar-mode-switch">
-                <openclaw-theme-mode-toggle .mode=${this.themeMode}></openclaw-theme-mode-toggle>
-              </span>
             </div>
           </div>
         </div>
         ${this.renderCustomizeMenu()} ${this.renderSessionMenu()} ${this.renderSessionGroupMenu()}
-        ${this.renderSessionSortMenu()}
+        ${this.renderSessionSortMenu()} ${this.renderFooterMoreMenu()}
       </aside>
     `;
   }

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -349,10 +349,13 @@ class AppSidebar extends LitElement {
     };
   }
 
-  private readonly selectSession = (sessionKey: string) => {
+  private readonly selectSession = (
+    sessionKey: string,
+    options: { focusComposer?: boolean } = {},
+  ) => {
     this.context?.gateway.setSessionKey(sessionKey);
     this.onNavigate?.("chat", {
-      search: searchForSession(sessionKey),
+      search: searchForSession(sessionKey, options),
     });
   };
 
@@ -404,7 +407,7 @@ class AppSidebar extends LitElement {
       ...(worktree ? { worktree: true } : {}),
     });
     if (nextSessionKey) {
-      this.selectSession(nextSessionKey);
+      this.selectSession(nextSessionKey, { focusComposer: true });
     }
   };
 

--- a/ui/src/components/icons.ts
+++ b/ui/src/components/icons.ts
@@ -389,6 +389,12 @@ export const icons = {
       <path d="M15 3h6v6M10 14L21 3" stroke-linecap="round" stroke-linejoin="round" />
     </svg>
   `,
+  arrowUpRight: html`
+    <svg viewBox="0 0 24 24">
+      <path d="M7 7h10v10" />
+      <path d="M7 17 17 7" />
+    </svg>
+  `,
   send: html`
     <svg viewBox="0 0 24 24">
       <path d="m22 2-7 20-4-9-9-4Z" />

--- a/ui/src/lib/sessions/navigation.test.ts
+++ b/ui/src/lib/sessions/navigation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
-import { resolveSessionNavigation } from "./navigation.ts";
+import { resolveSessionNavigation, searchForSession } from "./navigation.ts";
 
 function sessionsResult(sessions: GatewaySessionRow[]): SessionsListResult {
   return {
@@ -13,6 +13,13 @@ function sessionsResult(sessions: GatewaySessionRow[]): SessionsListResult {
 }
 
 describe("resolveSessionNavigation", () => {
+  it("adds composer focus to session search params only when requested", () => {
+    expect(searchForSession("agent:main:new")).toBe("?session=agent%3Amain%3Anew");
+    expect(searchForSession("agent:main:new", { focusComposer: true })).toBe(
+      "?session=agent%3Amain%3Anew&focusComposer=1",
+    );
+  });
+
   it("keeps the selected session in its sorted slot instead of hoisting it", () => {
     const rows = Array.from({ length: 5 }, (_, index) => ({
       key: `agent:main:recent-${index}`,

--- a/ui/src/lib/sessions/navigation.ts
+++ b/ui/src/lib/sessions/navigation.ts
@@ -273,6 +273,13 @@ export function resolveSessionNavigation(input: SessionNavigationInput): Session
   };
 }
 
-export function searchForSession(sessionKey: string): string {
-  return `?session=${encodeURIComponent(sessionKey)}`;
+export function searchForSession(
+  sessionKey: string,
+  options: { focusComposer?: boolean } = {},
+): string {
+  const search = new URLSearchParams({ session: sessionKey });
+  if (options.focusComposer) {
+    search.set("focusComposer", "1");
+  }
+  return `?${search.toString()}`;
 }

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -23,6 +23,7 @@ type RenderedPane = HTMLElement & {
   sessionKey: string;
   active: boolean;
   chrome: "none" | "pane";
+  focusComposer: boolean;
 };
 
 function setLayout(page: ChatPage, layout: ChatSplitLayout | undefined) {
@@ -113,6 +114,16 @@ describe("chat page split layout host", () => {
     expect(pane?.active).toBe(true);
   });
 
+  it("passes route composer focus requests to the active pane", async () => {
+    const page = new ChatPage();
+    page.data = { sessionKey: "main", focusComposer: true };
+    document.body.append(page);
+    await page.updateComplete;
+
+    const pane = page.querySelector<RenderedPane>("openclaw-chat-pane");
+    expect(pane?.focusComposer).toBe(true);
+  });
+
   it("renders keyed panes and a divider for a two-column split", async () => {
     const page = new ChatPage();
     page.data = { sessionKey: "main" };
@@ -127,6 +138,17 @@ describe("chat page split layout host", () => {
     expect(panes.map((pane) => pane.active)).toEqual([false, true]);
     expect(dividers).toHaveLength(1);
     expect(dividers[0].orientation).toBe("vertical");
+  });
+
+  it("passes split route composer focus requests only to the active pane", async () => {
+    const page = new ChatPage();
+    page.data = { sessionKey: "main", focusComposer: true };
+    document.body.append(page);
+    setLayout(page, createSplitLayout("main"));
+    await page.updateComplete;
+
+    const panes = [...page.querySelectorAll<RenderedPane>("openclaw-chat-pane")];
+    expect(panes.map((pane) => pane.focusComposer)).toEqual([false, true]);
   });
 
   it("renders only the active pane from a preserved split on narrow viewports", async () => {

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -33,6 +33,7 @@ import {
 type ChatRouteData = {
   sessionKey: string;
   draft?: string;
+  focusComposer?: boolean;
 };
 
 const NARROW_SPLIT_QUERY = "(max-width: 1099px)";
@@ -239,15 +240,20 @@ export class ChatPage extends LitElement {
     patchSettings({ chatSplitLayout: layout });
   }
 
-  private updateRoute(sessionKey: string, replace = false) {
+  private updateRoute(
+    sessionKey: string,
+    options: { focusComposer?: boolean; replace?: boolean } = {},
+  ) {
     if (this.data?.sessionKey === sessionKey) {
       return;
     }
-    const options = { search: searchForSession(sessionKey) };
-    if (replace) {
-      this.context.replace("chat", options);
+    const navigationOptions = {
+      search: searchForSession(sessionKey, { focusComposer: options.focusComposer }),
+    };
+    if (options.replace) {
+      this.context.replace("chat", navigationOptions);
     } else {
-      this.context.navigate("chat", options);
+      this.context.navigate("chat", navigationOptions);
     }
   }
 
@@ -268,7 +274,7 @@ export class ChatPage extends LitElement {
       }
       const next = insertPane(createSinglePaneLayout(currentSessionKey), "p1", trimmed, zone.edge);
       this.persistLayout(next);
-      this.updateRoute(trimmed, true);
+      this.updateRoute(trimmed, { replace: true });
       return;
     }
     const pane = findPane(layout, paneId)?.pane;
@@ -281,11 +287,11 @@ export class ChatPage extends LitElement {
       }
       const active = setActivePane(layout, paneId);
       this.persistLayout(setPaneSession(active, paneId, trimmed));
-      this.updateRoute(trimmed, true);
+      this.updateRoute(trimmed, { replace: true });
       return;
     }
     this.persistLayout(insertPane(layout, paneId, trimmed, zone.edge));
-    this.updateRoute(trimmed, true);
+    this.updateRoute(trimmed, { replace: true });
   }
 
   private readonly handleFocusPane = (paneId: string) => {
@@ -298,7 +304,7 @@ export class ChatPage extends LitElement {
       return;
     }
     this.persistLayout(setActivePane(layout, paneId));
-    this.updateRoute(pane.sessionKey, true);
+    this.updateRoute(pane.sessionKey, { replace: true });
   };
 
   private readonly handlePaneSessionChange = (
@@ -312,7 +318,7 @@ export class ChatPage extends LitElement {
     }
     const layout = this.layout;
     if (!layout) {
-      this.updateRoute(trimmed, options?.replace);
+      this.updateRoute(trimmed, options);
       return;
     }
     const pane = findPane(layout, paneId)?.pane;
@@ -321,7 +327,7 @@ export class ChatPage extends LitElement {
     }
     this.persistLayout(setPaneSession(layout, paneId, trimmed));
     if (layout.activePaneId === paneId) {
-      this.updateRoute(trimmed, options?.replace);
+      this.updateRoute(trimmed, options);
     }
   };
 
@@ -359,13 +365,13 @@ export class ChatPage extends LitElement {
     const next = closePane(layout, paneId);
     this.persistLayout(next);
     if (!next && survivingPane) {
-      this.updateRoute(survivingPane.sessionKey, true);
+      this.updateRoute(survivingPane.sessionKey, { replace: true });
       return;
     }
     if (next) {
       const activePane = findPane(next, next.activePaneId)?.pane;
       if (activePane) {
-        this.updateRoute(activePane.sessionKey, true);
+        this.updateRoute(activePane.sessionKey, { replace: true });
       }
     }
   };
@@ -383,6 +389,7 @@ export class ChatPage extends LitElement {
         .active=${active}
         .chrome=${"pane"}
         .draft=${active ? this.data?.draft : undefined}
+        .focusComposer=${active && this.data?.focusComposer === true}
         .onFocusPane=${this.handleFocusPane}
         .onPaneSessionChange=${this.handlePaneSessionChange}
         .onSplitRight=${canSplit ? this.handleSplitRight : undefined}
@@ -481,6 +488,7 @@ export class ChatPage extends LitElement {
                 .active=${true}
                 .chrome=${"none"}
                 .draft=${this.data?.draft}
+                .focusComposer=${this.data?.focusComposer === true}
                 .onFocusPane=${this.handleFocusPane}
                 .onPaneSessionChange=${this.handlePaneSessionChange}
                 .onOpenSplitView=${this.narrow ? undefined : this.openSplitView}

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -83,7 +83,7 @@ import { scheduleChatScroll } from "./scroll.ts";
 import { clearChatMessagesFromCache } from "./session-message-cache.ts";
 
 type ChatPageContext = ApplicationContext;
-type PaneSessionChangeOptions = { replace?: boolean };
+type PaneSessionChangeOptions = { focusComposer?: boolean; replace?: boolean };
 
 const CHAT_OPEN_DETAILS_SELECTOR =
   ".chat-controls__inline-select[open], .context-usage details[open], .agent-chat__talk-select[open], .agent-chat__attach-menu[open]";
@@ -107,6 +107,7 @@ class ChatPane extends LitElement {
   @property({ attribute: false }) active = false;
   @property({ attribute: false }) chrome: "none" | "pane" = "none";
   @property({ attribute: false }) draft?: string;
+  @property({ attribute: false }) focusComposer = false;
   @property({ attribute: false }) onFocusPane?: (paneId: string) => void;
   @property({ attribute: false }) onPaneSessionChange?: (
     paneId: string,
@@ -123,6 +124,7 @@ class ChatPane extends LitElement {
   private connectedClient: GatewayBrowserClient | null = null;
   private connectionGeneration = 0;
   private nativeDraftCleanup: (() => void) | null = null;
+  private pendingComposerFocusSessionKey: string | null = null;
   private readonly unreadPatchGuard = new SessionUnreadPatchGuard();
 
   private markSessionRead(row: GatewaySessionRow | undefined) {
@@ -287,9 +289,33 @@ class ChatPane extends LitElement {
       return false;
     }
     this.chatState.captureCreatedSessionComposer(nextSessionKey);
-    this.onPaneSessionChange?.(this.paneId, nextSessionKey);
+    this.onPaneSessionChange?.(this.paneId, nextSessionKey, { focusComposer: true });
     return true;
   };
+
+  private requestComposerFocus(sessionKey: string) {
+    this.pendingComposerFocusSessionKey = sessionKey;
+    void this.focusComposerAfterUpdate(sessionKey);
+  }
+
+  private async focusComposerAfterUpdate(sessionKey: string) {
+    await this.updateComplete;
+    if (
+      !this.isConnected ||
+      !this.active ||
+      this.pendingComposerFocusSessionKey !== sessionKey ||
+      this.state?.sessionKey !== sessionKey
+    ) {
+      return;
+    }
+    this.pendingComposerFocusSessionKey = null;
+    const textarea = this.querySelector<HTMLTextAreaElement>(
+      ".agent-chat__composer-combobox > textarea",
+    );
+    if (textarea && !textarea.disabled) {
+      textarea.focus({ preventScroll: true });
+    }
+  }
 
   private syncActiveBindings() {
     this.nativeDraftCleanup?.();
@@ -476,7 +502,15 @@ class ChatPane extends LitElement {
       if (nextSessionKey && nextSessionKey !== this.state.sessionKey) {
         this.switchPaneSession(nextSessionKey);
       }
-      this.chatState.restoreCreatedSessionComposer(nextSessionKey);
+      const restoredCreatedComposer = this.chatState.restoreCreatedSessionComposer(nextSessionKey);
+      if (restoredCreatedComposer && nextSessionKey) {
+        this.requestComposerFocus(nextSessionKey);
+      }
+      if (this.focusComposer && nextSessionKey) {
+        this.requestComposerFocus(nextSessionKey);
+      }
+    } else if (changedProperties.has("focusComposer") && this.focusComposer && this.state) {
+      this.requestComposerFocus(this.state.sessionKey);
     }
     if (changedProperties.has("active") || changedProperties.has("sessionKey")) {
       this.syncActiveBindings();

--- a/ui/src/pages/chat/route.ts
+++ b/ui/src/pages/chat/route.ts
@@ -13,11 +13,19 @@ function draftFromLocation(location: RouteLocation): string | undefined {
   return draft || undefined;
 }
 
+function focusComposerFromLocation(location: RouteLocation): boolean {
+  return new URLSearchParams(location.search).get("focusComposer") === "1";
+}
+
 export const page = definePage({
   id: "chat",
   path: "/chat",
   loaderDeps: (_context: ApplicationContext, location: RouteLocation) =>
-    `${sessionKeyFromLocation(location) ?? ""}\u0000${draftFromLocation(location) ?? ""}`,
+    [
+      sessionKeyFromLocation(location) ?? "",
+      draftFromLocation(location) ?? "",
+      focusComposerFromLocation(location) ? "focus" : "",
+    ].join("\u0000"),
   loader: async (_context: ApplicationContext, { location }) => {
     const sessionKey = sessionKeyFromLocation(location);
     if (!sessionKey) {
@@ -26,6 +34,7 @@ export const page = definePage({
     return {
       sessionKey,
       draft: draftFromLocation(location),
+      focusComposer: focusComposerFromLocation(location),
     };
   },
   component: () =>

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -989,6 +989,106 @@
   border-top: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
 }
 
+.sidebar-footer-menu {
+  min-width: 232px;
+  padding: 8px;
+}
+
+.sidebar-footer-menu__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  min-height: 38px;
+  padding: 0 8px;
+  border-radius: var(--radius-md);
+}
+
+.sidebar-footer-menu__label {
+  font-size: 14px;
+  color: var(--text);
+}
+
+.sidebar-footer-menu__link {
+  justify-content: space-between;
+  min-height: 38px;
+  text-decoration: none;
+}
+
+.sidebar-footer-menu__link:hover .sidebar-footer-menu__action-icon,
+.sidebar-footer-menu__link:focus-visible .sidebar-footer-menu__action-icon {
+  color: var(--text);
+}
+
+.sidebar-footer-menu__action-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  color: var(--muted);
+}
+
+.sidebar-footer-menu__action-icon svg {
+  width: 17px;
+  height: 17px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.8px;
+}
+
+.sidebar-footer-theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px;
+  border: 1px solid color-mix(in srgb, var(--border-strong) 70%, transparent);
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--bg) 70%, transparent);
+}
+
+.sidebar-footer-theme-toggle__button {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition:
+    color var(--duration-fast) ease,
+    background var(--duration-fast) ease;
+}
+
+.sidebar-footer-theme-toggle__button:hover,
+.sidebar-footer-theme-toggle__button:focus-visible {
+  color: var(--text);
+}
+
+.sidebar-footer-theme-toggle__button:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.sidebar-footer-theme-toggle__button--active {
+  color: var(--text);
+  background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
+}
+
+.sidebar-footer-theme-toggle__button svg {
+  width: 16px;
+  height: 16px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.75px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
 .sidebar-session-menu {
   position: fixed;
   z-index: 121;
@@ -1368,72 +1468,6 @@
 
 .sidebar--collapsed .sidebar-footer-bar__spacer {
   display: none;
-}
-
-/* Color mode segmented toggle, sidebar footer edition: quiet enough to sit
-   between plain icon buttons (no pill chrome until a segment is active). */
-.sidebar-mode-switch {
-  display: inline-flex;
-  margin-left: 2px;
-}
-
-.theme-mode-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
-}
-
-.theme-mode-toggle__btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 26px;
-  height: 26px;
-  padding: 0;
-  border: 1px solid transparent;
-  border-radius: var(--radius-md);
-  background: transparent;
-  color: var(--muted);
-  cursor: pointer;
-  transition:
-    color var(--duration-fast) ease,
-    background var(--duration-fast) ease,
-    border-color var(--duration-fast) ease;
-}
-
-.theme-mode-toggle__btn:hover {
-  color: var(--text);
-  background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
-}
-
-.theme-mode-toggle__btn:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
-}
-
-.theme-mode-toggle__btn--active {
-  color: var(--accent);
-  background: var(--accent-subtle);
-  border-color: color-mix(in srgb, var(--accent) 25%, transparent);
-}
-
-.theme-mode-toggle__btn svg {
-  width: 14px;
-  height: 14px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 1.75px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
-
-/* Rail mode: the footer stacks vertically, so the segments do too. */
-.sidebar--collapsed .sidebar-mode-switch {
-  margin-left: 0;
-}
-
-.sidebar--collapsed .theme-mode-toggle {
-  flex-direction: column;
 }
 
 .shell--nav-collapsed .shell-nav {


### PR DESCRIPTION
## What Problem This Solves
Starting a new Control UI chat required an extra click before typing, and the fixed sidebar footer exposed secondary Docs/theme controls alongside daily Config/Mobile actions.

## Why This Change Was Made
Checked main plus related open PR #84827 before implementing the chat shortcut/focus behavior. #84827 covers guarded /, N, Esc, and Cmd/Ctrl+K shortcuts, but not Cmd/Ctrl+N or new-chat composer focus.

This PR proposes routing new-chat creation through the existing session creation/navigation flow while carrying a focus request to the active chat pane. It also moves Docs and theme selection behind the footer More overflow, keeps Settings and Mobile as direct footer actions, and uses the existing sidebar dropdown item style for the overflow panel.

The global shortcut is ignored from inputs, textareas, select controls, contenteditable editors, textbox roles, common code editors, and dialogs.

## User Impact
Users can start typing immediately after creating a chat from the sidebar, chat pane, or Cmd/Ctrl+N/Ctrl+N outside editable controls. The sidebar footer is quieter for daily use while Docs and theme remain one click behind More. Existing session selection, split panes, active-run guards, external Docs behavior, and mobile behavior are preserved.

## Visual Evidence
Proposed sidebar footer overflow:

![Proposed sidebar footer overflow](https://github.com/vyctorbrzezowski/openclaw/releases/download/pr-102156-assets/sidebar-footer-menu.png)

Proposed new-chat composer focus:

![Proposed new-chat composer focus](https://github.com/vyctorbrzezowski/openclaw/releases/download/pr-102156-assets/new-chat-composer-focus.png)

## Evidence
- `node scripts/run-vitest.mjs ui/src/app/app-host.test.ts ui/src/components/app-sidebar.test.ts ui/src/pages/chat/chat-page.test.ts ui/src/lib/sessions/navigation.test.ts ui/src/lib/sessions/index.test.ts --reporter=verbose`
- `node scripts/run-oxlint.mjs ui/src/app/app-host.ts ui/src/app/app-host.test.ts ui/src/components/app-sidebar.ts ui/src/components/app-sidebar.test.ts ui/src/components/icons.ts ui/src/lib/sessions/navigation.ts ui/src/lib/sessions/navigation.test.ts ui/src/pages/chat/route.ts ui/src/pages/chat/chat-page.ts ui/src/pages/chat/chat-page.test.ts ui/src/pages/chat/chat-pane.ts`
- `pnpm exec oxfmt --check --threads=1 ui/src/app/app-host.ts ui/src/app/app-host.test.ts ui/src/components/app-sidebar.ts ui/src/components/app-sidebar.test.ts ui/src/components/icons.ts ui/src/lib/sessions/navigation.ts ui/src/lib/sessions/navigation.test.ts ui/src/pages/chat/route.ts ui/src/pages/chat/chat-page.ts ui/src/pages/chat/chat-page.test.ts ui/src/pages/chat/chat-pane.ts`
- `pnpm tsgo:test:ui`
- `git diff --check`
- Browser smoke: footer shows More, Settings, and Pair mobile device; More opens Theme and Docs; Docs uses an arrow-up-right icon and the standard sidebar dropdown item styling.
