### PR TITLE
fix(google-meet): bound Calendar v3 events.list request deadline

### DIFF
--- a/extensions/google-meet/src/calendar.test.ts
+++ b/extensions/google-meet/src/calendar.test.ts
@@ -1,0 +1,51 @@
+// Google Meet tests cover Calendar API request behavior.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { listGoogleMeetCalendarEvents } from "./calendar.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("Google Calendar requests", () => {
+  it("aborts a stalled events.list request after 30 seconds", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (!signal) {
+          reject(new Error("expected Calendar request abort signal"));
+          return;
+        }
+        const rejectAbort = () =>
+          reject(
+            signal.reason instanceof Error
+              ? signal.reason
+              : new Error("Calendar request was aborted"),
+          );
+        if (signal.aborted) {
+          rejectAbort();
+          return;
+        }
+        signal.addEventListener("abort", rejectAbort, { once: true });
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = listGoogleMeetCalendarEvents({ accessToken: "test-token" });
+    const rejection = expect(request).rejects.toMatchObject({
+      name: "TimeoutError",
+      message: "request timed out",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    const signal = fetchMock.mock.calls[0]?.[1]?.signal;
+    expect(signal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(signal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(signal?.aborted).toBe(true);
+    await rejection;
+  });
+});

--- a/extensions/google-meet/src/calendar.ts
+++ b/extensions/google-meet/src/calendar.ts
@@ -7,6 +7,7 @@ const GOOGLE_CALENDAR_API_BASE_URL = "https://www.googleapis.com/calendar/v3";
 const GOOGLE_CALENDAR_API_HOST = "www.googleapis.com";
 const GOOGLE_MEET_URL_HOST = "meet.google.com";
 const GOOGLE_CALENDAR_EVENTS_SCOPE = "https://www.googleapis.com/auth/calendar.events.readonly";
+const GOOGLE_CALENDAR_REQUEST_TIMEOUT_MS = 30_000;
 
 type GoogleCalendarEventDate = {
   date?: string;
@@ -189,6 +190,7 @@ async function fetchGoogleCalendarEvents(params: {
     },
     policy: { allowedHostnames: [GOOGLE_CALENDAR_API_HOST] },
     auditContext: "google-meet.calendar.events.list",
+    timeoutMs: GOOGLE_CALENDAR_REQUEST_TIMEOUT_MS,
   });
   try {
     if (!response.ok) {


### PR DESCRIPTION
## What Problem This Solves

Google Meet calendar lookup waited indefinitely if Google Calendar accepted the connection but never returned response headers. This blocked CLI and gateway flows that resolve a Meet URL from the user's Calendar.

## Why This Change Was Made

The Calendar owner now supplies a fixed 30-second deadline to the existing SSRF-guarded fetch. The original optional `timeoutMs` plumbing through three function signatures was removed because no production caller needs a separate deadline and the plugin should have one canonical policy.

The original 190-line loopback harness was replaced with a compact production-signal regression: a mocked stalled fetch receives the real guard's `AbortSignal`, remains active through 29,999 ms, then aborts at 30,000 ms with the production `TimeoutError`.

## User Impact

Calendar-based Google Meet lookup now fails with a bounded timeout instead of hanging the command or gateway request forever. Successful requests and existing function signatures are unchanged.

## Evidence

- Google Calendar's current reference documents `GET https://www.googleapis.com/calendar/v3/calendars/calendarId/events`: https://developers.google.com/workspace/calendar/api/v3/reference/events/list
- Live unauthenticated request to that production endpoint: HTTP 403 in 0.051 seconds, confirming endpoint/network routing without exposing credentials.
- Linux Testbox focused timeout regression: 1/1 passed.
- Linux Testbox full Google Meet suite: 16 files, 200 tests passed.
- Linux Testbox touched-surface `pnpm check:changed`: production/test types, lint, import cycles, and repository guards passed.
- Fresh structured autoreview after the final test fix: clean, no accepted or actionable findings.
- `git diff --check`: passed.

### Known proof gap

No user Calendar credential was used and no live Calendar request was deliberately held open for 30 seconds. The timeout boundary is forced deterministically through the production guarded-fetch signal.
