### PR TITLE
fix(skills): correct invalid install kinds in xurl and github [AI]

### DIFF
--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -16,13 +16,6 @@ metadata:
               "bins": ["gh"],
               "label": "Install GitHub CLI (brew)",
             },
-            {
-              "id": "apt",
-              "kind": "apt",
-              "package": "gh",
-              "bins": ["gh"],
-              "label": "Install GitHub CLI (apt)",
-            },
           ],
       },
   }

--- a/skills/xurl/SKILL.md
+++ b/skills/xurl/SKILL.md
@@ -18,7 +18,7 @@ metadata:
             },
             {
               "id": "npm",
-              "kind": "npm",
+              "kind": "node",
               "package": "@xdevplatform/xurl",
               "bins": ["xurl"],
               "label": "Install xurl (npm)",


### PR DESCRIPTION
Related: #57555
Related: steipete/agent-scripts#27

## What Problem This Solves

Fixes an issue where users installing the `xurl` or `github` skills through
openclaw would be offered no working (or a misleading) install option,
because the skill metadata declares an install `kind` openclaw doesn't
support and silently drops.

- **xurl**: its npm installer is declared `kind: "npm"`. `npm` is not a
  supported kind, so `openclaw skills info xurl` never offers it — on a
  machine without Homebrew, xurl has no install path at all.
- **github**: its second installer is declared `kind: "apt"`, also
  unsupported, so it never appears — dead, misleading metadata implying a
  Linux-native path that never runs.

Found via [skillsaw](https://skillsaw.org/rules/openclaw-metadata/)'s
`openclaw-metadata` rule.

## Why This Change Was Made

The installer resolves `spec.kind` against `brew`/`node`/`go`/`uv`/`download`
(`src/skills/lifecycle/install.ts`), with a `default: "unsupported installer"`;
`src/skills/types.ts` is the authoritative union. Anything else is dropped.

- **xurl**: `npm` isn't a kind — it's the default `skills.install.nodeManager`.
  npm-backed installs use `kind: "node"` with a `package` field, so this
  changes only `kind` (id/package/bins unchanged).
- **github**: there is no supported system-package kind to convert `apt` to,
  and the existing `brew` installer is already cross-platform (Homebrew runs
  on Linux), so the dead entry is removed rather than rewritten. Improving
  install paths for Linux users without Homebrew is a separate product
  decision, tracked in #57555 — explicitly out of scope here.

## User Impact

- `openclaw skills info xurl` now offers a working npm install
  (`npm install -g @xdevplatform/xurl`) on any system with a node manager,
  not just Homebrew hosts.
- `github` install options are now honest: only the installer that actually
  runs (brew, cross-platform) is shown. No functional path is lost.

## Evidence

Verified against openclaw 2026.6.11 in a throwaway container by copying the
edited skills over the bundled copies and running `openclaw skills info`.

**xurl — before (`kind: "npm"`):** npm installer dropped; only brew offered.
**xurl — after (`kind: "node"`):**
```json
"install": [
  { "id": "npm", "kind": "node", "label": "Install @xdevplatform/xurl (npm)", "bins": ["xurl"] }
]
```

**github — before:** apt entry dropped; only brew offered (identical to
after — confirming the apt entry was already dead).
**github — after (apt removed):** parses cleanly, brew installer intact:
```json
"install": [
  { "id": "brew", "kind": "brew", "label": "Install GitHub CLI (brew)", "bins": ["gh"] }
]
```

AI-assisted.
