### PR TITLE
fix(crabbox): retry cold metadata probes so a slow run --help does not block validation

### DIFF
--- a/scripts/crabbox-wrapper.mjs
+++ b/scripts/crabbox-wrapper.mjs
@@ -28,6 +28,11 @@ import { resolvePathEnvKey, resolveWindowsCmdExePath } from "./windows-cmd-helpe
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const CRABBOX_METADATA_PROBE_TIMEOUT_MS = 5_000;
+// A cold Crabbox (first call after an upgrade, or one on a loaded machine) can
+// exceed the snappy default probe timeout while it renders `run --help` or does
+// first-run init. Retry the metadata probes once with this generous timeout so a
+// single slow probe does not hard-fail the wrapper and block all remote validation.
+const CRABBOX_METADATA_PROBE_RETRY_TIMEOUT_MS = 20_000;
 const ignoreRepoBinary = process.env.OPENCLAW_CRABBOX_WRAPPER_IGNORE_REPO_BINARY === "1";
 const repoLocal = ignoreRepoBinary ? null : resolveCrabboxBinary(process.env, process.platform);
 const pathLocal = resolvePathBinary("crabbox", process.env, process.platform);
@@ -360,14 +365,14 @@ function buildBatchCommandLine(command, commandArgs) {
   return `"${[escapedCommand, ...escapedArgs].join(" ")}"`;
 }
 
-function checkedOutput(command, commandArgs) {
+function checkedOutput(command, commandArgs, timeoutMs = resolveMetadataProbeTimeoutMs(process.env)) {
   const invocation = spawnInvocation(command, commandArgs, process.env, process.platform);
   const result = spawnSync(invocation.command, invocation.args, {
     cwd: repoRoot,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
     windowsVerbatimArguments: invocation.windowsVerbatimArguments,
-    timeout: resolveMetadataProbeTimeoutMs(process.env),
+    timeout: timeoutMs,
     killSignal: "SIGKILL",
   });
   const timedOut = result.error?.name === "Error" && result.signal === "SIGKILL";
@@ -376,6 +381,19 @@ function checkedOutput(command, commandArgs) {
     text: `${result.stdout ?? ""}${result.stderr ?? ""}`.trim(),
     stdout: (result.stdout ?? "").trim(),
   };
+}
+
+// Probe Crabbox metadata (`--version` / `run --help`) with one generous retry.
+// A cold Crabbox can be SIGKILLed by the snappy default timeout or emit nothing
+// on the first call, then be instant and clean on the next. Retrying keeps the
+// warm path fast (one ~instant probe) while stopping a single slow probe from
+// tripping the sanity/provider-list guards and blocking all remote validation.
+function probeCrabboxMetadata(command, commandArgs) {
+  const first = checkedOutput(command, commandArgs);
+  if (first.status === 0 && first.text.length > 0) {
+    return first;
+  }
+  return checkedOutput(command, commandArgs, CRABBOX_METADATA_PROBE_RETRY_TIMEOUT_MS);
 }
 
 function parseCrabboxVersion(value) {
@@ -3155,8 +3173,8 @@ function injectFullCheckoutLeaseReclaim(commandArgs) {
   return normalizedArgs;
 }
 
-const version = checkedOutput(binary, ["--version"]);
-const help = checkedOutput(binary, ["run", "--help"]);
+const version = probeCrabboxMetadata(binary, ["--version"]);
+const help = probeCrabboxMetadata(binary, ["run", "--help"]);
 const providers = parseProvidersFromHelp(help.text);
 const displayBinary = binary === "crabbox" ? "crabbox" : relative(repoRoot, binary);
 const provider = selectedProvider(args, providers);

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -227,6 +227,32 @@ function makeSlowVersionCrabbox(helpText: string): string {
   return binDir;
 }
 
+// Fake Crabbox whose `run --help` is slow on every call and, like real Crabbox
+// 0.36, renders the provider help to stderr. Used to prove the wrapper retries a
+// cold/slow metadata probe instead of hard-failing.
+function makeSlowHelpCrabbox(helpText: string, delayMs: number): string {
+  const binDir = mkdtempSync(path.join(tmpdir(), "openclaw-slow-help-crabbox-"));
+  tempDirs.push(binDir);
+  const crabboxPath = path.join(binDir, "crabbox");
+
+  const script = [
+    "#!/usr/bin/env node",
+    "const args = process.argv.slice(2);",
+    "if (args[0] === '--version') {",
+    "  console.log(process.env.OPENCLAW_FAKE_CRABBOX_VERSION || 'crabbox 0.22.1');",
+    "  process.exit(0);",
+    "} else if (args[0] === 'run' && args[1] === '--help') {",
+    `  setTimeout(() => { process.stderr.write(${JSON.stringify(helpText)}); process.exit(0); }, ${delayMs});`,
+    "} else {",
+    "  process.exit(0);",
+    "}",
+  ].join("\n");
+  writeFileSync(crabboxPath, `${script}\n`, "utf8");
+  writeFileSync(`${crabboxPath}.cmd`, windowsNodeCmdShim("crabbox"), "utf8");
+  chmodSync(crabboxPath, 0o755);
+  return binDir;
+}
+
 function testTimingPreload(options: { clockScale?: number; spawnTimeoutMs?: number }): string {
   const key = JSON.stringify(options);
   let preloadPath = timingPreloads.get(key);
@@ -3126,6 +3152,24 @@ describe("scripts/crabbox-wrapper", () => {
     expect(result.status).toBe(2);
     expect(result.stderr).toContain("version=unknown");
     expect(result.stderr).toContain("selected binary failed basic --version/--help sanity checks");
+  });
+
+  it("retries a cold Crabbox whose run --help is slower than the default probe timeout", () => {
+    const helpText = "provider: hetzner, aws, local-container, blacksmith-testbox, or cloudflare\n";
+    // First probe is SIGKILLed at 150ms; the retry gets the full generous timeout
+    // and reads the (600ms) stderr help, so the wrapper must not hard-fail.
+    const result = runWrapper(helpText, ["--version"], {
+      env: { OPENCLAW_TEST_CRABBOX_METADATA_PROBE_TIMEOUT_MS: "150" },
+      extraPathEntries: [makeSlowHelpCrabbox(helpText, 600)],
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain("could not parse provider list");
+    expect(result.stderr).not.toContain("selected binary failed basic --version/--help sanity checks");
+    expect(result.stderr).toContain(
+      "providers=hetzner,aws,local-container,blacksmith-testbox,cloudflare",
+    );
   });
 
   it("parses provider choices from the --provider flag help format", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves an issue where `scripts/crabbox-wrapper.mjs` hard-exits and blocks **all** remote validation — `pnpm check:changed`, remote `pnpm test` lanes, `scripts/pr` gates — when the `crabbox` binary is cold (the first call right after a version bump, or one on a loaded machine), even though the binary is perfectly fine.

At startup the wrapper probes `crabbox --version` and `crabbox run --help` once each, with a snappy 5s timeout, to enumerate the advertised providers before delegating. Crabbox 0.36 renders `run --help` as ~52KB on **stderr**, and a cold binary can exceed 5s rendering it or doing first-run init (and can return nothing on that first call). When the probe is SIGKILLed or comes back empty, one of two guards fires and exits the wrapper with code 2:

- `[crabbox] selected binary failed basic --version/--help sanity checks`, or
- `[crabbox] could not parse provider list from --help; refusing to run with --provider without validation`

Once Crabbox is warm the same probe returns in ~70ms, so the failure is transient — but while it lasts, every remote gate is dead.

## Why This Change Was Made

The probe was a single attempt with an aggressive timeout and no recovery. This adds one generous retry: `probeCrabboxMetadata()` runs the probe with the default 5s timeout and, only if the result is unusable (killed by timeout, or empty), runs it once more with a 20s timeout. The warm path is unchanged (one ~instant probe); only a slow/empty first probe pays for the retry, after which the existing sanity and provider-list guards judge the recovered result — so a genuinely broken or truly-hung binary still fails, just not a merely-cold one.

This is deliberately minimal and preserves the guards' safety intent (they still reject a binary that never responds or never advertises the selected provider). It does not touch provider selection, sandbox enforcement, or the delegated-sync flow.

## User Impact

Maintainers and agents no longer see `pnpm check:changed` / remote test lanes spuriously die with "refusing to run" or "sanity checks failed" the first time they invoke Crabbox after an upgrade or on a busy machine. The wrapper waits out one cold probe and proceeds. No config or flags change; the warm-path latency is identical.

## Evidence

- **Root cause pinned against the real binary:** `crabbox run --help` (0.36.0) exits 0 in ~0.07s **warm**, writing 52KB to stderr and 0 to stdout; the wrapper's parser handles it fine (71 providers). The failures reproduced only when the first probe was killed/empty — i.e. cold — which the retry now covers.
- **Dogfood — the fixed wrapper end-to-end:** ran the validation suite **through** `node scripts/crabbox-wrapper.mjs run` itself. It parsed all 71 providers (`providers=agent-sandbox,anthropic-sandbox-runtime,…,xcp-ng`), warmed a Blacksmith Testbox, delegated-synced, and ran on it — proving the wrapper is usable again ([Actions run](https://github.com/openclaw/openclaw/actions/runs/28939620181)).
- **On that Testbox:** `run-oxlint` on the script clean, `tsgo:core:test` clean, `check:no-conflict-markers` pass, and `test/scripts/crabbox-wrapper.test.ts` **188 passed**.
- **Regression test added:** a fake Crabbox whose `run --help` is slower than the default probe timeout and (like 0.36) writes help to stderr is now recovered by the retry — the wrapper parses providers and exits 0 instead of hard-failing. The existing "times out hung sanity probes" test still asserts a genuinely wedged binary is rejected (its probe stays clamped below both the initial and retry timeouts).
