### PR TITLE
fix(ui): preserve vadThreshold of 0 instead of silently discarding it

### DIFF
--- a/ui/src/pages/chat/chat-realtime.test.ts
+++ b/ui/src/pages/chat/chat-realtime.test.ts
@@ -19,7 +19,7 @@ import {
   createInitialChatRealtimeState,
   type ChatRealtimeState,
 } from "./chat-realtime.ts";
-import type { RealtimeTalkCallbacks } from "./realtime-talk.ts";
+import type { RealtimeTalkCallbacks, RealtimeTalkLaunchOptions } from "./realtime-talk.ts";
 
 function mediaDevice(kind: MediaDeviceKind, deviceId: string, label: string): MediaDeviceInfo {
   return { kind, deviceId, label, groupId: "", toJSON: () => ({}) } as MediaDeviceInfo;
@@ -41,7 +41,17 @@ function createState(): ChatRealtimeState {
   return state;
 }
 
-describe("chat realtime microphone selection", () => {
+const vadThresholdCases: Array<[string, string, number | undefined]> = [
+  ["zero", "0", 0],
+  ["ordinary value", "0.35", 0.35],
+  ["blank", "", undefined],
+  ["whitespace", "  ", undefined],
+  ["non-number", "loud", undefined],
+  ["below range", "-0.1", undefined],
+  ["above range", "1.1", undefined],
+];
+
+describe("chat realtime actions", () => {
   beforeEach(() => {
     localStorage.clear();
     realtimeTalkSessionCtor.mockClear();
@@ -54,6 +64,21 @@ describe("chat realtime microphone selection", () => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
+
+  it.each(vadThresholdCases)(
+    "normalizes a %s VAD threshold at the launch boundary",
+    async (_label, input, expected) => {
+      const state = createState();
+      state.updateRealtimeTalkOptions({ vadThreshold: input });
+
+      await state.toggleRealtimeTalk();
+
+      const launchOptions = (realtimeTalkSessionCtor.mock.calls as unknown[][])[0]?.[3] as
+        | RealtimeTalkLaunchOptions
+        | undefined;
+      expect(launchOptions?.vadThreshold).toBe(expected);
+    },
+  );
 
   it("keeps the selected input in memory when persistence fails and shares it across panes", async () => {
     const firstPane = createState();

--- a/ui/src/pages/chat/chat-realtime.ts
+++ b/ui/src/pages/chat/chat-realtime.ts
@@ -68,6 +68,15 @@ function createDefaultRealtimeTalkOptions(): RealtimeTalkOptions {
   };
 }
 
+function parseVadThresholdOption(value: string): number | undefined {
+  const normalized = value.trim();
+  if (!normalized) {
+    return undefined;
+  }
+  const threshold = Number(normalized);
+  return Number.isFinite(threshold) && threshold >= 0 && threshold <= 1 ? threshold : undefined;
+}
+
 export function createInitialChatRealtimeState(inputDeviceId = "") {
   return {
     realtimeTalkActive: false,
@@ -187,7 +196,7 @@ export function attachChatRealtimeActions(state: ChatRealtimeState) {
     const launchOptions: RealtimeTalkLaunchOptions = {
       model: options.model.trim() || undefined,
       voice: options.voice.trim() || undefined,
-      vadThreshold: Number(options.vadThreshold) || undefined,
+      vadThreshold: parseVadThresholdOption(options.vadThreshold),
     };
     state.realtimeTalkInputDeviceId = inputDeviceId ?? "";
     state.realtimeTalkActive = true;


### PR DESCRIPTION
## What Problem This Solves

The Control UI realtime Talk launch action normalized the VAD threshold with `Number(value) || undefined`. That discards the valid numeric value `0`, even though the Gateway schema and OpenAI Realtime contract accept thresholds from 0 through 1.

The current visible sensitivity preset menu offers default, `0.65`, `0.5`, and `0.35`; it does not currently expose a zero preset. This fix therefore closes the state/action boundary bug without claiming a user-selectable zero control that does not exist today.

## Why This Change Was Made

The maintainer rewrite replaces falsy numeric coercion with one private, domain-specific parser:

- blank and whitespace-only state omit the launch override;
- `"0"` becomes numeric `0`;
- ordinary preset values remain numeric;
- non-numeric, non-finite, and values outside the documented `0...1` interval are omitted instead of leaking `NaN`, infinity, or invalid thresholds into the Gateway request.

This keeps normalization at the Control UI launch boundary and does not add a shared API, compatibility path, or new configuration surface.

## User Impact

Realtime Talk launch state now preserves a valid zero VAD threshold and cannot turn malformed state into an invalid numeric request. Existing visible presets and default behavior are unchanged.

## Evidence

- Official OpenAI Realtime API reference defines the server-VAD threshold as `0.0` through `1.0`, defaulting to `0.5`: https://platform.openai.com/docs/api-reference/realtime?lang=javascript
- Blacksmith Testbox https://github.com/openclaw/openclaw/actions/runs/29011206362: focused action-boundary suite, 1 file / 13 tests passed on rebased SHA `4eb9899c0391e54dfd6ffa04e8ef4c9392788932`.
- Blacksmith Testbox https://github.com/openclaw/openclaw/actions/runs/29010780993: core/test typechecks, lint, and changed-file repository guards passed before the unrelated rebase.
- Source-blind behavior contract: 5 passed, 0 failed, 0 blocked (zero, ordinary, blank, invalid, and out-of-range state).
- Fresh autoreview: clean, correctness 0.99.
- `git diff --check`: clean.

The root changelog is release-owned. Release-note context and contributor credit are retained here for @maweibin.
