### PR TITLE
fix: mark empty tool-error turns non-deliverable

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -88,6 +88,7 @@ import {
   codexDynamicToolsFingerprint,
   startOrResumeThread as startOrResumeThreadImpl,
 } from "./thread-lifecycle.js";
+import { CODEX_NON_DELIVERABLE_TERMINAL_TURN_REASON } from "./trajectory.js";
 
 function startOrResumeThread(
   params: Omit<Parameters<typeof startOrResumeThreadImpl>[0], "bindingStore">,
@@ -1538,6 +1539,8 @@ describe("runCodexAppServerAttempt", () => {
   });
 
   it("returns only a tool error for a declined native command without assistant text", async () => {
+    vi.stubEnv("OPENCLAW_TRAJECTORY", "1");
+    vi.stubEnv("OPENCLAW_TRAJECTORY_DIR", path.join(tempDir, "trajectory"));
     const harness = createStartedThreadHarness();
     const params = createParams(
       path.join(tempDir, "session-declined-native-command.jsonl"),
@@ -1602,6 +1605,29 @@ describe("runCodexAppServerAttempt", () => {
       mutatingAction: true,
     });
     expect(result.lastToolError?.actionFingerprint).toContain("pnpm test extensions/codex");
+
+    const trajectoryEvents = (
+      await fs.readFile(path.join(tempDir, "trajectory", "session-1.jsonl"), "utf8")
+    )
+      .trim()
+      .split("\n")
+      .map(
+        (line) =>
+          JSON.parse(line) as {
+            data?: {
+              status?: string;
+              terminalError?: string;
+            };
+            type?: string;
+          },
+      );
+    const modelCompleted = trajectoryEvents.find((event) => event.type === "model.completed");
+    const sessionEnded = trajectoryEvents.find((event) => event.type === "session.ended");
+    expect(modelCompleted?.data?.terminalError).toBe(CODEX_NON_DELIVERABLE_TERMINAL_TURN_REASON);
+    expect(sessionEnded?.data).toMatchObject({
+      status: "error",
+      terminalError: CODEX_NON_DELIVERABLE_TERMINAL_TURN_REASON,
+    });
   });
 
   it("keeps forced message dynamic tool when toolsAllow omits it", () => {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1537,6 +1537,73 @@ describe("runCodexAppServerAttempt", () => {
     expect(snapshotJson).toContain("without a matching tool.result");
   });
 
+  it("returns only a tool error for a declined native command without assistant text", async () => {
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session-declined-native-command.jsonl"),
+      path.join(tempDir, "workspace-declined-native-command"),
+    );
+
+    const declinedCommand = {
+      type: "commandExecution" as const,
+      id: "cmd-declined",
+      command: "pnpm test extensions/codex",
+      cwd: "/workspace",
+      processId: null,
+      source: "agent",
+      status: "declined" as const,
+      commandActions: [],
+      aggregatedOutput: null,
+      exitCode: null,
+      durationMs: null,
+    };
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "item/started",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { ...declinedCommand, status: "inProgress" },
+      },
+    });
+    await harness.notify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: declinedCommand,
+      },
+    });
+    await harness.notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          items: [declinedCommand],
+          error: null,
+          startedAt: null,
+          completedAt: null,
+          durationMs: null,
+        },
+      },
+    });
+
+    const result = await run;
+
+    expect(result.promptError).toBeNull();
+    expect(result.assistantTexts).toEqual([]);
+    expect(result.lastAssistant).toBeUndefined();
+    expect(result.lastToolError).toMatchObject({
+      toolName: "bash",
+      error: "codex native tool blocked",
+      mutatingAction: true,
+    });
+    expect(result.lastToolError?.actionFingerprint).toContain("pnpm test extensions/codex");
+  });
+
   it("keeps forced message dynamic tool when toolsAllow omits it", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1630,6 +1630,105 @@ describe("runCodexAppServerAttempt", () => {
     });
   });
 
+  it("records aborted declined native command trajectories as non-deliverable", async () => {
+    vi.stubEnv("OPENCLAW_TRAJECTORY", "1");
+    vi.stubEnv("OPENCLAW_TRAJECTORY_DIR", path.join(tempDir, "trajectory-aborted"));
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "session-aborted-declined-native-command.jsonl"),
+      path.join(tempDir, "workspace-aborted-declined-native-command"),
+    );
+
+    const declinedCommand = {
+      type: "commandExecution" as const,
+      id: "cmd-aborted-declined",
+      command: "pnpm test extensions/codex",
+      cwd: "/workspace",
+      processId: null,
+      source: "agent",
+      status: "declined" as const,
+      commandActions: [],
+      aggregatedOutput: null,
+      exitCode: null,
+      durationMs: null,
+    };
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "item/started",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { ...declinedCommand, status: "inProgress" },
+      },
+    });
+    await harness.notify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: declinedCommand,
+      },
+    });
+    await harness.notify({
+      method: "rawResponseItem/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          id: "abort-marker",
+          type: "message",
+          role: "developer",
+          content: [
+            {
+              type: "input_text",
+              text:
+                "<turn_aborted>The previous turn was interrupted on purpose. " +
+                "Any running unified exec processes may still be running in the background. " +
+                "If any tools/commands were aborted, they may have partially executed.</turn_aborted>",
+            },
+          ],
+        },
+      },
+    });
+
+    const result = await run;
+
+    expect(result.aborted).toBe(true);
+    expect(result.assistantTexts).toEqual([]);
+    expect(result.lastToolError).toMatchObject({
+      toolName: "bash",
+      error: "codex native tool blocked",
+      mutatingAction: true,
+    });
+    const trajectoryEvents = (
+      await fs.readFile(path.join(tempDir, "trajectory-aborted", "session-1.jsonl"), "utf8")
+    )
+      .trim()
+      .split("\n")
+      .map(
+        (line) =>
+          JSON.parse(line) as {
+            data?: {
+              aborted?: boolean;
+              status?: string;
+              terminalError?: string;
+            };
+            type?: string;
+          },
+      );
+    const modelCompleted = trajectoryEvents.find((event) => event.type === "model.completed");
+    const sessionEnded = trajectoryEvents.find((event) => event.type === "session.ended");
+    expect(modelCompleted?.data).toMatchObject({
+      aborted: true,
+      terminalError: CODEX_NON_DELIVERABLE_TERMINAL_TURN_REASON,
+    });
+    expect(sessionEnded?.data).toMatchObject({
+      status: "error",
+      terminalError: CODEX_NON_DELIVERABLE_TERMINAL_TURN_REASON,
+    });
+  });
+
   it("keeps forced message dynamic tool when toolsAllow omits it", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -259,6 +259,7 @@ import {
   normalizeCodexTrajectoryError,
   recordCodexTrajectoryCompletion,
   recordCodexTrajectoryContext,
+  resolveCodexTrajectoryTerminal,
 } from "./trajectory.js";
 import {
   buildCodexUserPromptMessage,
@@ -3511,6 +3512,12 @@ export async function runCodexAppServerAttempt(
         );
       }
     }
+    const codexTrajectoryTerminal = resolveCodexTrajectoryTerminal({
+      result,
+      aborted: finalAborted,
+      timedOut: effectiveTimedOut,
+      promptError: finalPromptError,
+    });
     recordCodexTrajectoryCompletion(trajectoryRecorder, {
       attempt: params,
       result,
@@ -3518,18 +3525,17 @@ export async function runCodexAppServerAttempt(
       turnId: activeTurnId,
       timedOut: effectiveTimedOut,
       yieldDetected,
+      aborted: finalAborted,
+      promptError: finalPromptError,
     });
     trajectoryRecorder?.recordEvent("session.ended", {
-      status: finalPromptError
-        ? "error"
-        : finalAborted || effectiveTimedOut
-          ? "interrupted"
-          : "success",
+      status: codexTrajectoryTerminal.status,
       threadId: thread.threadId,
       turnId: activeTurnId,
       timedOut: effectiveTimedOut,
       yieldDetected,
       promptError: normalizeCodexTrajectoryError(finalPromptError),
+      terminalError: codexTrajectoryTerminal.terminalError,
     });
     markTrajectoryEndRecorded();
     const terminalAssistantText = collectTerminalAssistantText(result);

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -3515,6 +3515,7 @@ export async function runCodexAppServerAttempt(
     const codexTrajectoryTerminal = resolveCodexTrajectoryTerminal({
       result,
       aborted: finalAborted,
+      externalAbort: explicitCancellationObserved,
       timedOut: effectiveTimedOut,
       promptError: finalPromptError,
     });
@@ -3526,6 +3527,7 @@ export async function runCodexAppServerAttempt(
       timedOut: effectiveTimedOut,
       yieldDetected,
       aborted: finalAborted,
+      externalAbort: explicitCancellationObserved,
       promptError: finalPromptError,
     });
     trajectoryRecorder?.recordEvent("session.ended", {

--- a/extensions/codex/src/app-server/trajectory.test.ts
+++ b/extensions/codex/src/app-server/trajectory.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  CODEX_NON_DELIVERABLE_TERMINAL_TURN_REASON,
   createCodexTrajectoryRecorder,
   recordCodexTrajectoryCompletion,
   recordCodexTrajectoryContext,
@@ -436,6 +437,49 @@ describe("Codex trajectory recorder", () => {
       assistantTexts: ["final answer"],
     });
     expect(events[1].data.truncated).toBeUndefined();
+  });
+
+  it("marks aborted empty completions as non-deliverable", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const attempt = {
+      sessionFile,
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      runId: "run-1",
+      provider: "codex",
+      modelId: "gpt-5.4",
+      model: { api: "responses" },
+    } as never;
+    const recorder = createCodexTrajectoryRecorder({
+      cwd: tmpDir,
+      attempt,
+      env: {},
+    });
+
+    recordCodexTrajectoryCompletion(expectTrajectoryRecorder(recorder), {
+      attempt,
+      threadId: "thread-1",
+      turnId: "turn-1",
+      timedOut: false,
+      aborted: true,
+      result: {
+        aborted: true,
+        promptError: null,
+        assistantTexts: [],
+        messagesSnapshot: [],
+        toolMetas: [],
+      } as never,
+    });
+    await recorder?.flush();
+
+    const parsed = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, "session.trajectory.jsonl"), "utf8"),
+    );
+    expect(parsed.data).toMatchObject({
+      aborted: true,
+      terminalError: CODEX_NON_DELIVERABLE_TERMINAL_TURN_REASON,
+    });
   });
 
   it("redacts secrets before preserving usage in truncated completion events", async () => {

--- a/extensions/codex/src/app-server/trajectory.ts
+++ b/extensions/codex/src/app-server/trajectory.ts
@@ -41,12 +41,20 @@ const COOKIE_PAIR_RE = /\b([A-Za-z][A-Za-z0-9_.-]{1,64})=([A-Za-z0-9+/._~%=-]{16
 const TRAJECTORY_RUNTIME_FILE_MAX_BYTES = 50 * 1024 * 1024;
 const TRAJECTORY_RUNTIME_EVENT_MAX_BYTES = 256 * 1024;
 const TRAJECTORY_RUNTIME_OVERSIZE_PRESERVED_DATA_KEYS = ["usage", "promptCache"] as const;
+export const CODEX_NON_DELIVERABLE_TERMINAL_TURN_REASON = "non_deliverable_terminal_turn";
 
 type CodexTrajectoryOpenFlagConstants = Pick<
   typeof nodeFs.constants,
   "O_APPEND" | "O_CREAT" | "O_TRUNC" | "O_WRONLY"
 > &
   Partial<Pick<typeof nodeFs.constants, "O_NOFOLLOW">>;
+
+type CodexTrajectoryTerminalStatus = "success" | "error" | "interrupted";
+
+type CodexTrajectoryTerminal = {
+  status: CodexTrajectoryTerminalStatus;
+  terminalError?: typeof CODEX_NON_DELIVERABLE_TERMINAL_TURN_REASON;
+};
 
 /** Resolves secure append flags for trajectory runtime files. */
 export function resolveCodexTrajectoryAppendFlags(
@@ -66,6 +74,52 @@ export function resolveCodexTrajectoryPointerFlags(
     constants.O_WRONLY |
     (typeof noFollow === "number" ? noFollow : 0)
   );
+}
+
+function hasNonEmptyString(values?: readonly string[]): boolean {
+  return (values ?? []).some((value) => value.trim().length > 0);
+}
+
+function hasCodexTrajectoryDeliveryEvidence(result: EmbeddedRunAttemptResult): boolean {
+  return (
+    hasNonEmptyString(result.assistantTexts) ||
+    result.didSendViaMessagingTool ||
+    result.didDeliverSourceReplyViaMessageTool === true ||
+    result.didSendDeterministicApprovalPrompt === true ||
+    hasNonEmptyString(result.messagingToolSentTexts) ||
+    hasNonEmptyString(result.messagingToolSentMediaUrls) ||
+    (result.messagingToolSentTargets?.length ?? 0) > 0 ||
+    (result.messagingToolSourceReplyPayloads?.length ?? 0) > 0 ||
+    (result.toolMediaUrls?.length ?? 0) > 0 ||
+    result.hasToolMediaBlockReply === true ||
+    result.heartbeatToolResponse !== undefined ||
+    (result.clientToolCalls?.length ?? 0) > 0 ||
+    result.yieldDetected === true ||
+    (result.acceptedSessionSpawns?.length ?? 0) > 0 ||
+    (result.successfulCronAdds ?? 0) > 0 ||
+    result.toolMetas?.some((entry) => entry.asyncStarted === true) === true
+  );
+}
+
+export function resolveCodexTrajectoryTerminal(params: {
+  result: EmbeddedRunAttemptResult;
+  aborted: boolean;
+  timedOut: boolean;
+  promptError?: unknown;
+}): CodexTrajectoryTerminal {
+  if (params.promptError) {
+    return { status: "error" };
+  }
+  if (params.aborted || params.timedOut) {
+    return { status: "interrupted" };
+  }
+  if (params.result.lastToolError && !hasCodexTrajectoryDeliveryEvidence(params.result)) {
+    return {
+      status: "error",
+      terminalError: CODEX_NON_DELIVERABLE_TERMINAL_TURN_REASON,
+    };
+  }
+  return { status: "success" };
 }
 
 async function safeAppendTrajectoryFile(filePath: string, line: string): Promise<void> {
@@ -276,18 +330,27 @@ export function recordCodexTrajectoryCompletion(
     turnId: string;
     timedOut: boolean;
     yieldDetected?: boolean;
+    aborted?: boolean;
+    promptError?: unknown;
   },
 ): void {
   if (!recorder) {
     return;
   }
+  const terminal = resolveCodexTrajectoryTerminal({
+    result: params.result,
+    aborted: params.aborted ?? params.result.aborted,
+    timedOut: params.timedOut,
+    promptError: params.promptError ?? params.result.promptError,
+  });
   recorder.recordEvent("model.completed", {
     threadId: params.threadId,
     turnId: params.turnId,
     timedOut: params.timedOut,
     yieldDetected: params.yieldDetected ?? false,
-    aborted: params.result.aborted,
-    promptError: normalizeCodexTrajectoryError(params.result.promptError),
+    aborted: params.aborted ?? params.result.aborted,
+    promptError: normalizeCodexTrajectoryError(params.promptError ?? params.result.promptError),
+    terminalError: terminal.terminalError,
     usage: params.result.attemptUsage,
     assistantTexts: params.result.assistantTexts,
     messagesSnapshot: params.result.messagesSnapshot,

--- a/extensions/codex/src/app-server/trajectory.ts
+++ b/extensions/codex/src/app-server/trajectory.ts
@@ -104,16 +104,20 @@ function hasCodexTrajectoryDeliveryEvidence(result: EmbeddedRunAttemptResult): b
 export function resolveCodexTrajectoryTerminal(params: {
   result: EmbeddedRunAttemptResult;
   aborted: boolean;
+  externalAbort?: boolean;
   timedOut: boolean;
   promptError?: unknown;
 }): CodexTrajectoryTerminal {
   if (params.promptError) {
     return { status: "error" };
   }
-  if (params.aborted || params.timedOut) {
+  if ((params.aborted && params.externalAbort === true) || params.timedOut) {
     return { status: "interrupted" };
   }
-  if (params.result.lastToolError && !hasCodexTrajectoryDeliveryEvidence(params.result)) {
+  if (
+    (params.aborted || params.result.lastToolError) &&
+    !hasCodexTrajectoryDeliveryEvidence(params.result)
+  ) {
     return {
       status: "error",
       terminalError: CODEX_NON_DELIVERABLE_TERMINAL_TURN_REASON,
@@ -331,6 +335,7 @@ export function recordCodexTrajectoryCompletion(
     timedOut: boolean;
     yieldDetected?: boolean;
     aborted?: boolean;
+    externalAbort?: boolean;
     promptError?: unknown;
   },
 ): void {
@@ -340,6 +345,7 @@ export function recordCodexTrajectoryCompletion(
   const terminal = resolveCodexTrajectoryTerminal({
     result: params.result,
     aborted: params.aborted ?? params.result.aborted,
+    externalAbort: params.externalAbort ?? params.result.externalAbort,
     timedOut: params.timedOut,
     promptError: params.promptError ?? params.result.promptError,
   });

--- a/extensions/codex/src/app-server/trajectory.ts
+++ b/extensions/codex/src/app-server/trajectory.ts
@@ -97,7 +97,7 @@ function hasCodexTrajectoryDeliveryEvidence(result: EmbeddedRunAttemptResult): b
     result.yieldDetected === true ||
     (result.acceptedSessionSpawns?.length ?? 0) > 0 ||
     (result.successfulCronAdds ?? 0) > 0 ||
-    result.toolMetas?.some((entry) => entry.asyncStarted === true) === true
+    (result.toolMetas?.some((entry) => entry.asyncStarted === true) ?? false)
   );
 }
 

--- a/src/agents/embedded-agent-runner/run/attempt-trajectory-status.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-trajectory-status.test.ts
@@ -55,6 +55,20 @@ describe("attempt trajectory status", () => {
       status: "error",
       terminalError: NON_DELIVERABLE_TERMINAL_TURN_REASON,
     });
+
+    expect(
+      resolveAttemptTrajectoryTerminal(
+        baseParams({
+          lastToolError: {
+            toolName: "bash",
+            error: "codex native tool blocked",
+          },
+        }),
+      ),
+    ).toEqual({
+      status: "error",
+      terminalError: NON_DELIVERABLE_TERMINAL_TURN_REASON,
+    });
   });
 
   it("does not treat streamed partial payloads as completed length-limited output", () => {
@@ -146,6 +160,39 @@ describe("attempt trajectory status", () => {
       status: "error",
       terminalError: NON_DELIVERABLE_TERMINAL_TURN_REASON,
     });
+  });
+
+  it("does not treat a tool error alone as user-visible terminal progress", () => {
+    expect(
+      resolveAttemptTrajectoryTerminal(
+        baseParams({
+          lastToolError: {
+            toolName: "bash",
+            error: "codex native tool blocked",
+          },
+          lastAssistantStopReason: "toolUse",
+        }),
+      ),
+    ).toEqual({
+      status: "error",
+      terminalError: NON_DELIVERABLE_TERMINAL_TURN_REASON,
+    });
+  });
+
+  it("keeps committed delivery as progress when a tool error is also present", () => {
+    expect(
+      resolveAttemptTrajectoryTerminal(
+        baseParams({
+          didSendViaMessagingTool: true,
+          messagingToolSentTexts: ["Delivered through the message tool."],
+          lastToolError: {
+            toolName: "message",
+            error: "delivery failed for a second target",
+          },
+          lastAssistantStopReason: "toolUse",
+        }),
+      ),
+    ).toEqual({ status: "success" });
   });
 
   it("keeps synthesized terminal payloads as success", () => {

--- a/src/agents/embedded-agent-runner/run/attempt-trajectory-status.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-trajectory-status.ts
@@ -122,7 +122,6 @@ export function resolveAttemptTrajectoryTerminal(
     params.heartbeatToolResponse !== undefined ||
     (params.clientToolCalls?.length ?? 0) > 0 ||
     params.yieldDetected === true ||
-    params.lastToolError !== undefined ||
     hasAsyncStartedToolActivity(params.toolMetas);
 
   if (params.lastAssistantStopReason === "toolUse" && !hasExplicitTerminalDelivery) {

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -5748,7 +5748,6 @@ export async function runEmbeddedAttempt(
         yieldDetected,
         didSendDeterministicApprovalPrompt: didSendDeterministicApprovalPromptNow,
         heartbeatToolResponse,
-        lastToolError,
         toolMediaUrls: pendingToolMediaReply?.mediaUrls,
         toolAudioAsVoice: pendingToolMediaReply?.audioAsVoice,
         toolTrustedLocalMedia: pendingToolMediaReply?.trustedLocalMedia,


### PR DESCRIPTION
Related: #99645

## What Problem This Solves

Fixes an issue where users on chat-style surfaces could receive no visible answer when a Codex-native command approval was declined and the attempt only recorded a tool error. That empty user-addressed turn could be classified as successful terminal progress instead of a non-deliverable terminal failure.

## Why This Change Was Made

The attempt terminal classifier now requires real delivery/progress evidence, such as assistant text, committed message delivery, synthesized payloads, heartbeat responses, accepted session spawns, client tool calls, yields, or async-started tool activity. A bare `lastToolError` still remains available to payload and retry logic, but it no longer proves that the user received a terminal answer.

Codex app-server trajectory finalization now applies the same non-deliverable rule for empty tool-error completions. Explicit external aborts and timeouts still record interrupted, but internally aborted empty turns without delivery evidence record `non_deliverable_terminal_turn` instead of success/interrupted without a typed terminal error.

Codex contract checked: `openai/codex@ad2012d` shows command approval responses carry `decision` values in `codex-rs/app-server-protocol/src/protocol/v2/item.rs:1329`, declined command executions are rejected/approval-denied outcomes in `codex-rs/analytics/src/reducer.rs:2262`, and malformed app-server command approval responses default to `Decline` in `codex-rs/app-server/src/bespoke_event_handling.rs:1963`.

## User Impact

Users and operators should no longer see an empty declined-native-tool turn recorded as a successful completed session solely because the attempt had a tool error. Real message delivery with a later tool error is still treated as terminal progress, so multi-target or partially delivered turns do not regress.

AI-assisted: yes, implemented with Codex.

## Evidence

- Real after-fix declined Codex-native approval proof using actual `codex app-server --stdio`, model `codex/gpt-5.5`, app-server `approvalPolicy: "untrusted"`, and an isolated OpenClaw local-agent run:

  ```console
  $ OPENCLAW_STATE_DIR="$proof_root/state-real" \
    OPENCLAW_CONFIG_PATH="$proof_root/state/openclaw-real-gpt55.json" \
    OPENCLAW_TRAJECTORY=1 \
    OPENCLAW_TRAJECTORY_DIR="$proof_root/traj-real-gpt55" \
    OPENCLAW_NO_UPDATE_NOTIFIER=1 \
    OPENCLAW_TEST_FAST=1 \
    COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
    pnpm openclaw agent --local \
      --message "Use the native bash tool to run exactly: python3 -c 'print(\"approval-denied-proof\")'. Do not answer until after the tool result." \
      --model codex/gpt-5.5 \
      --session-key agent:main:proof-99645-real-gpt55 \
      --json
  ```

  Redacted OpenClaw JSON output from the real run:

  ```json
  {
    "payloads": [{ "text": "Bash failed: `run python3 inline script` (workspace)" }],
    "meta": {
      "aborted": true,
      "agentMeta": { "provider": "codex", "model": "gpt-5.5" }
    }
  }
  ```

  Redacted trajectory excerpt from the same real run:

  ```jsonl
  {"type":"tool.call","toolCallId":"call_CjAMlDS7zpWGoDFfx5BN8hFN","arguments":{"command":"/bin/zsh -lc \"python3 -c 'print(\\\"approval-denied-proof\\\")'\"","cwd":"$proof_root/workspace"}}
  {"type":"tool.result","status":"blocked","toolCallId":"call_CjAMlDS7zpWGoDFfx5BN8hFN","isError":true,"result":{"status":"declined","exitCode":null,"durationMs":null}}
  {"type":"model.completed","aborted":true,"terminalError":"non_deliverable_terminal_turn","promptError":null,"assistantTexts":[]}
  {"type":"session.ended","status":"error","terminalError":"non_deliverable_terminal_turn","promptError":null}
  ```

- Deterministic local-agent CLI proof for the completed declined-command shape using a stdio Codex app-server protocol fixture with no `agentMessage`:

  ```jsonl
  {"type":"tool.result","status":"blocked","isError":true}
  {"type":"model.completed","aborted":false,"terminalError":"non_deliverable_terminal_turn","promptError":null,"assistantTexts":[]}
  {"type":"session.ended","status":"error","terminalError":"non_deliverable_terminal_turn","promptError":null}
  {"type":"model.fallback_step","fallbackDetail":"codex/gpt-5.4-codex ended without a visible assistant reply"}
  ```

- Codex app-server protocol result-shape proof for declined native commands with no assistant text:

  ```console
  $ OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.vitest-cache-99645-codex pnpm exec vitest run --config test/vitest/vitest.extension-codex-app-server-attempt.config.ts -t "declined native command"

   Test Files  1 passed (1)
        Tests  2 passed | 117 skipped (119)
     Duration  29.42s
  ```

  The committed tests send `item/started` + `item/completed` for a Codex `commandExecution` with `status: "declined"`, complete one turn normally and another through the raw abort marker, and assert `assistantTexts: []`, `lastToolError.error === "codex native tool blocked"`, `model.completed.terminalError === "non_deliverable_terminal_turn"`, and `session.ended.status === "error"`.

- Core terminal classifier proof for that result shape:

  ```console
  $ OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.vitest-cache-99645-core node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-trajectory-status.test.ts

   Test Files  1 passed (1)
        Tests  21 passed (21)
     Duration  349ms
  ```

  The new core regression cases assert tool-error-only attempts end with `status: "error"` and `terminalError: "non_deliverable_terminal_turn"`, while committed delivery plus a later tool error still ends with `status: "success"`.

- Codex trajectory recorder regression proof:

  ```console
  $ OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.vitest-cache-99645-trajectory node scripts/run-vitest.mjs extensions/codex/src/app-server/trajectory.test.ts

   Test Files  1 passed (1)
        Tests  13 passed (13)
     Duration  21.29s
  ```

- `pnpm exec oxfmt --check extensions/codex/src/app-server/trajectory.ts extensions/codex/src/app-server/trajectory.test.ts extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/run/attempt-trajectory-status.ts src/agents/embedded-agent-runner/run/attempt-trajectory-status.test.ts` passed.
- `git diff --check` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` passed with no accepted/actionable findings.
- Crabbox/Testbox proof was unavailable on this host: `crabbox` was not installed and `node scripts/crabbox-wrapper.mjs run --help` failed its selected-binary sanity check, so validation used focused local Vitest, deterministic local-agent CLI proof, and the real `codex app-server --stdio` local-agent proof above after `pnpm install --frozen-lockfile` completed successfully.
