### PR TITLE
fix(plugins): honor subagent model-override opt-in in interactive sessions

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -258,7 +258,7 @@ See [MCP](/cli/mcp#openclaw-as-an-mcp-client-registry) and
 - `plugins.entries.<id>.env`: plugin-scoped env var map.
 - `plugins.entries.<id>.hooks.allowPromptInjection`: when `false`, core blocks `before_prompt_build` and ignores prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride`. Applies to native plugin hooks and supported bundle-provided hook directories.
 - `plugins.entries.<id>.hooks.allowConversationAccess`: when `true`, trusted non-bundled plugins may read raw conversation content from typed hooks such as `llm_input`, `llm_output`, `before_model_resolve`, `before_agent_reply`, `before_agent_run`, `before_agent_finalize`, and `agent_end`.
-- `plugins.entries.<id>.subagent.allowModelOverride`: explicitly trust this plugin to request per-run `provider` and `model` overrides for background subagent runs.
+- `plugins.entries.<id>.subagent.allowModelOverride`: explicitly trust this plugin to request per-run `provider` and `model` overrides for subagent runs, including runs spawned from interactive sessions.
 - `plugins.entries.<id>.subagent.allowedModels`: optional allowlist of canonical `provider/model` targets for trusted subagent overrides. Use `"*"` only when you intentionally want to allow any model.
 - `plugins.entries.<id>.llm.allowModelOverride`: explicitly trust this plugin to request model overrides for `api.runtime.llm.complete`.
 - `plugins.entries.<id>.llm.allowedModels`: optional allowlist of canonical `provider/model` targets for trusted plugin LLM completion overrides. Use `"*"` only when you intentionally want to allow any model.

--- a/docs/plugins/architecture-internals.md
+++ b/docs/plugins/architecture-internals.md
@@ -573,7 +573,7 @@ Notes:
 - Returns `{ text: undefined }` when no transcription output is produced (for example skipped/unsupported input).
 - `api.runtime.stt.transcribeAudioFile(...)` remains as a compatibility alias.
 
-Plugins can also launch background subagent runs through `api.runtime.subagent`:
+Plugins can also launch asynchronous subagent runs through `api.runtime.subagent`:
 
 ```ts
 const result = await api.runtime.subagent.run({
@@ -591,7 +591,7 @@ Notes:
 - `provider` and `model` are optional per-run overrides, not persistent session changes.
 - `toolsAlsoAllow` accepts exact, uniquely owned tool names registered by the calling plugin. Core and ambiguous names are rejected. It is additive to the normal profile, but operator allowlists and denies remain authoritative.
 - OpenClaw only honors those override fields for trusted callers.
-- For plugin-owned fallback runs, operators must opt in with `plugins.entries.<id>.subagent.allowModelOverride: true`.
+- Unless the calling Gateway client already has override authority (admin scope), operators must opt in with `plugins.entries.<id>.subagent.allowModelOverride: true`. The opt-in covers every execution context: interactive-session runs and clientless background runs alike.
 - Use `plugins.entries.<id>.subagent.allowedModels` to restrict trusted plugins to specific canonical `provider/model` targets, or `"*"` to allow any target explicitly.
 - Untrusted plugin subagent runs still work, but override requests are rejected instead of silently falling back.
 - Plugin-created subagent sessions are tagged with the creating plugin id. Fallback `api.runtime.subagent.deleteSession(...)` may delete those owned sessions only; arbitrary session deletion still requires an admin-scoped Gateway request.

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -321,7 +321,7 @@ two-party event loops that do not go through the shared inbound reply runner.
     ```
 
     <Warning>
-    Model overrides (`provider`/`model`) require operator opt-in via `plugins.entries.<id>.subagent.allowModelOverride: true` in config. Untrusted plugins can still run subagents, but override requests are rejected.
+    Unless the calling Gateway client already has override authority (admin scope), model overrides (`provider`/`model`) require operator opt-in via `plugins.entries.<id>.subagent.allowModelOverride: true` in config — in every execution context, including runs spawned from interactive sessions. Use `plugins.entries.<id>.subagent.allowedModels` to bound the targets. Untrusted plugins can still run subagents, but override requests are rejected.
     </Warning>
 
     `toolsAlsoAllow` adds exact, uniquely owned tools registered by the calling plugin to the worker's normal tool surface. The runtime rejects core tools and names shared with another plugin. Profiles and operator tool policies still apply, including explicit allowlists and denies.

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -623,7 +623,11 @@ describe("generateAndAppendDreamNarrative", () => {
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
     const subagent = createMockSubagent("");
     subagent.run.mockRejectedValue(
-      new Error("provider/model override is not authorized for this plugin subagent run."),
+      new Error(
+        'plugin "memory-core" is not trusted for provider/model override requests. ' +
+          "See https://docs.openclaw.ai/plugins/sdk-runtime#api-runtime-subagent and search for: " +
+          "plugins.entries.<id>.subagent.allowModelOverride",
+      ),
     );
     const logger = createMockLogger();
 

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1500,7 +1500,7 @@ export const FIELD_HELP: Record<string, string> = {
   "plugins.entries.*.subagent":
     "Per-plugin subagent runtime controls for model override trust and allowlists. Keep this unset unless a plugin must explicitly steer subagent model selection.",
   "plugins.entries.*.subagent.allowModelOverride":
-    "Explicitly allows this plugin to request provider/model overrides in background subagent runs. Keep false unless the plugin is trusted to steer model selection.",
+    "Explicitly allows this plugin to request provider/model overrides in subagent runs, including runs spawned from interactive sessions. Keep false unless the plugin is trusted to steer model selection.",
   "plugins.entries.*.subagent.allowedModels":
     'Allowed override targets for trusted plugin subagent runs as canonical "provider/model" refs. Use "*" only when you intentionally allow any model.',
   "plugins.entries.*.llm":

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -194,6 +194,18 @@ function createTestContext(label: string): GatewayRequestContext {
   return { label } as unknown as GatewayRequestContext;
 }
 
+function createRequestScope(label: string, scopes: string[]): PluginRuntimeGatewayRequestScope {
+  return {
+    context: createTestContext(label),
+    client: {
+      connect: {
+        scopes,
+      },
+    } as GatewayRequestOptions["client"],
+    isWebchatConnect: () => false,
+  };
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -1103,15 +1115,7 @@ describe("loadGatewayPlugins", () => {
   test("does not inherit admin scope for trusted plugin gateway requests", async () => {
     loadOpenClawPlugins.mockReturnValue(addLoadedPlugin(createRegistry([]), { id: "google-meet" }));
     loadGatewayStartupPluginsForTest();
-    const scope = {
-      context: createTestContext("plugin-gateway-request-admin-caller"),
-      client: {
-        connect: {
-          scopes: ["operator.admin"],
-        },
-      } as GatewayRequestOptions["client"],
-      isWebchatConnect: () => false,
-    } satisfies PluginRuntimeGatewayRequestScope;
+    const scope = createRequestScope("plugin-gateway-request-admin-caller", ["operator.admin"]);
     const runtime = runtimeModule.createPluginRuntime();
 
     await gatewayRequestScopeModule.withPluginRuntimeGatewayRequestScope(scope, () =>
@@ -1209,15 +1213,7 @@ describe("loadGatewayPlugins", () => {
   test("forwards provider and model overrides when the request scope is authorized", async () => {
     const serverPlugins = serverPluginsModule;
     const runtime = await createSubagentRuntime(serverPlugins);
-    const scope = {
-      context: createTestContext("request-scope-forward-overrides"),
-      client: {
-        connect: {
-          scopes: ["operator.admin"],
-        },
-      } as GatewayRequestOptions["client"],
-      isWebchatConnect: () => false,
-    } satisfies PluginRuntimeGatewayRequestScope;
+    const scope = createRequestScope("request-scope-forward-overrides", ["operator.admin"]);
 
     await gatewayRequestScopeModule.withPluginRuntimeGatewayRequestScope(scope, () =>
       runtime.run({
@@ -1457,9 +1453,7 @@ describe("loadGatewayPlugins", () => {
         model: "claude-haiku-4-5",
         deliver: false,
       }),
-    ).rejects.toThrow(
-      "provider/model override requires plugin identity in fallback subagent runs.",
-    );
+    ).rejects.toThrow("provider/model override requires plugin identity for plugin subagent runs.");
   });
 
   test("allows trusted fallback provider/model overrides when plugin config is explicit", async () => {
@@ -1491,6 +1485,7 @@ describe("loadGatewayPlugins", () => {
     expect(params.sessionKey).toBe("s-trusted-override");
     expect(params.provider).toBe("anthropic");
     expect(params.model).toBe("claude-haiku-4-5");
+    expect(getLastDispatchedClientInternal().allowModelOverride).toBe(true);
   });
 
   test("tags plugin fallback subagent runs with the creating plugin id", async () => {
@@ -1525,8 +1520,67 @@ describe("loadGatewayPlugins", () => {
         }),
       ),
     ).rejects.toThrow(
-      'plugin "voice-call" is not trusted for fallback provider/model override requests. See https://docs.openclaw.ai/plugins/sdk-runtime#api-runtime-subagent and search for: plugins.entries.<id>.subagent.allowModelOverride',
+      'plugin "voice-call" is not trusted for provider/model override requests. See https://docs.openclaw.ai/plugins/sdk-runtime#api-runtime-subagent and search for: plugins.entries.<id>.subagent.allowModelOverride',
     );
+  });
+
+  test("allows trusted plugin overrides when a non-admin client is in scope", async () => {
+    const serverPlugins = serverPluginsModule;
+    const runtime = await createSubagentRuntime(serverPlugins, {
+      plugins: {
+        entries: {
+          "voice-call": {
+            subagent: {
+              allowModelOverride: true,
+              allowedModels: ["anthropic/claude-haiku-4-5"],
+            },
+          },
+        },
+      },
+    });
+    const scope = createRequestScope("interactive-trusted-override", ["operator.write"]);
+
+    await gatewayRequestScopeModule.withPluginRuntimeGatewayRequestScope(scope, () =>
+      gatewayRequestScopeModule.withPluginRuntimePluginIdScope("voice-call", () =>
+        runtime.run({
+          sessionKey: "s-interactive-trusted-override",
+          message: "use trusted override",
+          provider: "anthropic",
+          model: "claude-haiku-4-5",
+          deliver: false,
+        }),
+      ),
+    );
+
+    const params = getRequiredLastDispatchedParams();
+    expect(params.sessionKey).toBe("s-interactive-trusted-override");
+    expect(params.provider).toBe("anthropic");
+    expect(params.model).toBe("claude-haiku-4-5");
+    // The reused scoped client (not a synthetic admin client) must carry the
+    // merged override authority so the downstream `agent` gate accepts it.
+    expect(getLastDispatchedClientScopes()).toEqual(["operator.write"]);
+    expect(getLastDispatchedClientInternal().allowModelOverride).toBe(true);
+    expect(getLastDispatchedClientInternal().pluginRuntimeOwnerId).toBe("voice-call");
+  });
+
+  test("rejects untrusted plugin overrides when a non-admin client is in scope", async () => {
+    const serverPlugins = serverPluginsModule;
+    const runtime = await createSubagentRuntime(serverPlugins);
+    const scope = createRequestScope("interactive-untrusted-override", ["operator.write"]);
+
+    await expect(
+      gatewayRequestScopeModule.withPluginRuntimeGatewayRequestScope(scope, () =>
+        gatewayRequestScopeModule.withPluginRuntimePluginIdScope("voice-call", () =>
+          runtime.run({
+            sessionKey: "s-interactive-untrusted-override",
+            message: "use untrusted override",
+            provider: "anthropic",
+            model: "claude-haiku-4-5",
+            deliver: false,
+          }),
+        ),
+      ),
+    ).rejects.toThrow('plugin "voice-call" is not trusted for provider/model override requests.');
   });
 
   test("allows trusted fallback model-only overrides when the model ref is canonical", async () => {
@@ -1699,15 +1753,7 @@ describe("loadGatewayPlugins", () => {
   test("allows session deletion when the request scope already has admin", async () => {
     const serverPlugins = serverPluginsModule;
     const runtime = await createSubagentRuntime(serverPlugins);
-    const scope = {
-      context: createTestContext("request-scope-delete-session"),
-      client: {
-        connect: {
-          scopes: ["operator.admin"],
-        },
-      } as GatewayRequestOptions["client"],
-      isWebchatConnect: () => false,
-    } satisfies PluginRuntimeGatewayRequestScope;
+    const scope = createRequestScope("request-scope-delete-session", ["operator.admin"]);
 
     await expect(
       gatewayRequestScopeModule.withPluginRuntimeGatewayRequestScope(scope, () =>
@@ -1724,15 +1770,7 @@ describe("loadGatewayPlugins", () => {
   test("keeps plugin owner metadata on admin-scoped plugin session cleanup", async () => {
     const serverPlugins = serverPluginsModule;
     const runtime = await createSubagentRuntime(serverPlugins);
-    const scope = {
-      context: createTestContext("request-scope-plugin-delete-session"),
-      client: {
-        connect: {
-          scopes: ["operator.admin"],
-        },
-      } as GatewayRequestOptions["client"],
-      isWebchatConnect: () => false,
-    } satisfies PluginRuntimeGatewayRequestScope;
+    const scope = createRequestScope("request-scope-plugin-delete-session", ["operator.admin"]);
 
     await expect(
       gatewayRequestScopeModule.withPluginRuntimeGatewayRequestScope(scope, () =>

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -194,13 +194,18 @@ function createTestContext(label: string): GatewayRequestContext {
   return { label } as unknown as GatewayRequestContext;
 }
 
-function createRequestScope(label: string, scopes: string[]): PluginRuntimeGatewayRequestScope {
+function createRequestScope(
+  label: string,
+  scopes: string[],
+  internal?: Record<string, unknown>,
+): PluginRuntimeGatewayRequestScope {
   return {
     context: createTestContext(label),
     client: {
       connect: {
         scopes,
       },
+      ...(internal ? { internal } : {}),
     } as GatewayRequestOptions["client"],
     isWebchatConnect: () => false,
   };
@@ -1574,6 +1579,30 @@ describe("loadGatewayPlugins", () => {
           runtime.run({
             sessionKey: "s-interactive-untrusted-override",
             message: "use untrusted override",
+            provider: "anthropic",
+            model: "claude-haiku-4-5",
+            deliver: false,
+          }),
+        ),
+      ),
+    ).rejects.toThrow('plugin "voice-call" is not trusted for provider/model override requests.');
+  });
+
+  test("does not honor an inherited internal override flag as caller authority", async () => {
+    const serverPlugins = serverPluginsModule;
+    const runtime = await createSubagentRuntime(serverPlugins);
+    // A parent policy-authorized dispatch leaves allowModelOverride on the
+    // scope client; nested plugin overrides must still consult the policy.
+    const scope = createRequestScope("interactive-inherited-flag", ["operator.write"], {
+      allowModelOverride: true,
+    });
+
+    await expect(
+      gatewayRequestScopeModule.withPluginRuntimeGatewayRequestScope(scope, () =>
+        gatewayRequestScopeModule.withPluginRuntimePluginIdScope("voice-call", () =>
+          runtime.run({
+            sessionKey: "s-inherited-flag-override",
+            message: "use inherited authority",
             provider: "anthropic",
             model: "claude-haiku-4-5",
             deliver: false,

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -197,10 +197,6 @@ function hasAdminScope(client: GatewayRequestOptions["client"] | undefined): boo
   return scopes.includes(ADMIN_SCOPE);
 }
 
-function canClientUseModelOverride(client: GatewayRequestOptions["client"]): boolean {
-  return hasAdminScope(client) || client?.internal?.allowModelOverride === true;
-}
-
 function canTrustedOfficialPluginRequestScopes(params: {
   pluginId?: string;
   pluginOrigin?: PluginOrigin;
@@ -368,9 +364,7 @@ export async function dispatchGatewayMethodInProcessRaw(
       ? {
           ...(options?.agentRunTracking ? { agentRunTracking: options.agentRunTracking } : {}),
           ...(pluginRuntimeOwnerId ? { pluginRuntimeOwnerId } : {}),
-          ...(options?.runtimePluginToolGrant
-            ? { runtimePluginToolGrant: options.runtimePluginToolGrant }
-            : {}),
+          runtimePluginToolGrant: options?.runtimePluginToolGrant,
           ...(allowModelOverride ? { allowModelOverride: true } : {}),
         }
       : undefined,
@@ -532,11 +526,11 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
         toolsAlsoAllow: params.toolsAlsoAllow,
       });
       const overrideRequested = Boolean(params.provider || params.model);
-      // Fail closed: overrides need caller authority (admin scope / internal
-      // flag) or the operator's per-plugin opt-in, in any execution context,
-      // so untrusted plugins cannot steer model selection (#48277).
+      // Fail closed: plugin overrides need genuine admin scope or the operator's
+      // per-plugin opt-in; an internal allowModelOverride flag inherited from a
+      // parent dispatch never counts, so allowedModels bounds nested spawns (#48277).
       let policyModelOverride = false;
-      if (overrideRequested && !canClientUseModelOverride(scope?.client ?? null)) {
+      if (overrideRequested && !hasAdminScope(scope?.client)) {
         const policyAuth = authorizePluginModelOverride({
           pluginId: scope?.pluginId,
           provider: params.provider,

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -117,7 +117,9 @@ export function setPluginSubagentOverridePolicies(cfg: OpenClawConfig): void {
   pluginSubagentPolicyState.policies = policies;
 }
 
-function authorizeFallbackModelOverride(params: {
+// Evaluates the operator's per-plugin opt-in (plugins.entries.<id>.subagent.*)
+// for a requested subagent model override; fails closed without plugin identity.
+function authorizePluginModelOverride(params: {
   pluginId?: string;
   provider?: string;
   model?: string;
@@ -127,7 +129,7 @@ function authorizeFallbackModelOverride(params: {
   if (!pluginId) {
     return {
       allowed: false,
-      reason: "provider/model override requires plugin identity in fallback subagent runs.",
+      reason: "provider/model override requires plugin identity for plugin subagent runs.",
     };
   }
   const policy = pluginSubagentPolicyState.policies[pluginId];
@@ -135,7 +137,7 @@ function authorizeFallbackModelOverride(params: {
     return {
       allowed: false,
       reason:
-        `plugin "${pluginId}" is not trusted for fallback provider/model override requests. ` +
+        `plugin "${pluginId}" is not trusted for provider/model override requests. ` +
         "See https://docs.openclaw.ai/plugins/sdk-runtime#api-runtime-subagent and search for: " +
         "plugins.entries.<id>.subagent.allowModelOverride",
     };
@@ -152,12 +154,12 @@ function authorizeFallbackModelOverride(params: {
   if (policy.allowedModels.size === 0) {
     return { allowed: true };
   }
-  const requestedModelRef = resolveRequestedFallbackModelRef(params);
+  const requestedModelRef = resolveRequestedOverrideModelRef(params);
   if (!requestedModelRef) {
     return {
       allowed: false,
       reason:
-        "fallback provider/model overrides that use an allowlist must resolve to a canonical provider/model target.",
+        "provider/model overrides that use an allowlist must resolve to a canonical provider/model target.",
     };
   }
   if (policy.allowedModels.has(requestedModelRef)) {
@@ -169,7 +171,7 @@ function authorizeFallbackModelOverride(params: {
   };
 }
 
-function resolveRequestedFallbackModelRef(params: {
+function resolveRequestedOverrideModelRef(params: {
   provider?: string;
   model?: string;
 }): string | null {
@@ -228,7 +230,8 @@ function resolveRuntimeNodeInvokeSyntheticScopes(params: {
 }
 
 type DispatchGatewayMethodInProcessOptions = {
-  allowSyntheticModelOverride?: boolean;
+  /** Carry policy-authorized model-override authority into the dispatched request's client. */
+  allowModelOverride?: boolean;
   allowSyntheticCronRunContinuation?: boolean;
   agentRunTracking?: "plugin_subagent";
   disableSyntheticClient?: boolean;
@@ -343,8 +346,9 @@ export async function dispatchGatewayMethodInProcessRaw(
     typeof options?.pluginRuntimeOwnerId === "string" && options.pluginRuntimeOwnerId.trim()
       ? options.pluginRuntimeOwnerId.trim()
       : undefined;
+  const allowModelOverride = options?.allowModelOverride === true;
   const syntheticClient = createSyntheticPluginRuntimeClient({
-    allowModelOverride: options?.allowSyntheticModelOverride === true,
+    allowModelOverride,
     agentRunTracking: options?.agentRunTracking,
     cronRunContinuation: options?.allowSyntheticCronRunContinuation === true,
     ...(pluginRuntimeOwnerId ? { pluginRuntimeOwnerId } : {}),
@@ -353,13 +357,21 @@ export async function dispatchGatewayMethodInProcessRaw(
       : {}),
     scopes: options?.syntheticScopes,
   });
+  // Policy-authorized override authority rides the dispatched request's client.
+  // The merge copies the client so the grant cannot leak to the live connection.
   const scopedClient = mergePluginRuntimeClientInternal(
     scope?.client,
-    pluginRuntimeOwnerId || options?.agentRunTracking || options?.runtimePluginToolGrant
+    pluginRuntimeOwnerId ||
+      options?.agentRunTracking ||
+      options?.runtimePluginToolGrant ||
+      allowModelOverride
       ? {
           ...(options?.agentRunTracking ? { agentRunTracking: options.agentRunTracking } : {}),
           ...(pluginRuntimeOwnerId ? { pluginRuntimeOwnerId } : {}),
-          runtimePluginToolGrant: options?.runtimePluginToolGrant,
+          ...(options?.runtimePluginToolGrant
+            ? { runtimePluginToolGrant: options.runtimePluginToolGrant }
+            : {}),
+          ...(allowModelOverride ? { allowModelOverride: true } : {}),
         }
       : undefined,
   );
@@ -520,23 +532,20 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
         toolsAlsoAllow: params.toolsAlsoAllow,
       });
       const overrideRequested = Boolean(params.provider || params.model);
-      const hasRequestScopeClient = Boolean(scope?.client);
-      let allowOverride = hasRequestScopeClient && canClientUseModelOverride(scope?.client ?? null);
-      let allowSyntheticModelOverride = false;
-      if (overrideRequested && !allowOverride && !hasRequestScopeClient) {
-        const fallbackAuth = authorizeFallbackModelOverride({
+      // Fail closed: overrides need caller authority (admin scope / internal
+      // flag) or the operator's per-plugin opt-in, in any execution context,
+      // so untrusted plugins cannot steer model selection (#48277).
+      let policyModelOverride = false;
+      if (overrideRequested && !canClientUseModelOverride(scope?.client ?? null)) {
+        const policyAuth = authorizePluginModelOverride({
           pluginId: scope?.pluginId,
           provider: params.provider,
           model: params.model,
         });
-        if (!fallbackAuth.allowed) {
-          throw new Error(fallbackAuth.reason);
+        if (!policyAuth.allowed) {
+          throw new Error(policyAuth.reason);
         }
-        allowOverride = true;
-        allowSyntheticModelOverride = true;
-      }
-      if (overrideRequested && !allowOverride) {
-        throw new Error("provider/model override is not authorized for this plugin subagent run.");
+        policyModelOverride = true;
       }
       const payload = await dispatchGatewayMethod<{ runId?: string }>(
         "agent",
@@ -544,8 +553,8 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
           sessionKey: params.sessionKey,
           message: params.message,
           deliver: params.deliver ?? false,
-          ...(allowOverride && params.provider && { provider: params.provider }),
-          ...(allowOverride && params.model && { model: params.model }),
+          ...(params.provider && { provider: params.provider }),
+          ...(params.model && { model: params.model }),
           ...(params.extraSystemPrompt && { extraSystemPrompt: params.extraSystemPrompt }),
           ...(params.lane && { lane: params.lane }),
           ...(params.cwd && { cwd: params.cwd }),
@@ -557,7 +566,7 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
           idempotencyKey: params.idempotencyKey || randomUUID(),
         },
         {
-          allowSyntheticModelOverride,
+          allowModelOverride: policyModelOverride,
           agentRunTracking: "plugin_subagent",
           ...(pluginId ? { pluginRuntimeOwnerId: pluginId } : {}),
           ...(runtimePluginToolGrant ? { runtimePluginToolGrant } : {}),


### PR DESCRIPTION
Closes #102167

## What Problem This Solves

Fixes an issue where a plugin calling `api.runtime.subagent.run(...)` with a `provider`/`model` override from an interactive session (webchat/Control UI, TUI, ACP, or any gateway-client-scoped turn) was rejected with "provider/model override is not authorized" even when the operator had explicitly trusted the plugin via `plugins.entries.<id>.subagent.allowModelOverride: true`. The opt-in was only consulted for clientless background runs, so cost-tiered plugin workflows (e.g. cheap evidence-gathering subagent workers feeding a more capable main session) could not guarantee the worker model from chat sessions — and the documented config knob appeared broken because docs never said it was background-only.

## Why This Change Was Made

Plugin-requested subagent overrides are now authorized by exactly two things, in every execution context: genuine admin scope on the calling client, or the operator's per-plugin opt-in (`allowModelOverride` + `allowedModels`). A policy-authorized override rides the dispatched request's client as a copied internal flag so the downstream `agent` gate honors it without leaking authority to the caller's live connection — and that internal flag is deliberately **not** accepted back as caller authority, so an inherited flag on the request scope can never bypass the policy for nested spawns (`allowedModels` bounds the whole spawn tree; this also closes a pre-existing bypass on the background path, where nested spawns under a synthetic flagged client skipped the allowlist). This aligns the subagent surface with `api.runtime.llm.complete`, whose equivalent per-plugin trust config already applies in every context. Defaults are unchanged and fail closed: no config → deny, now with an actionable pointer to the config key.

## User Impact

Operators can trust a plugin to steer subagent model selection once, and it works the same in interactive and background contexts. Plugin authors can build guaranteed-model subagent workers reachable from chat sessions without granting the driving client admin scope.

**Compatibility note (intentional semantic widening of a shipped key):** on shipped releases (e.g. v2026.6.11) the help text scoped `subagent.allowModelOverride` to "background subagent runs" and the runtime enforced that. After this change, operators who already set the opt-in for background jobs also authorize overrides from interactive turns on upgrade, with no config change. The grant stays plugin-scoped (HTTP/webchat callers never gain model control themselves) and `allowedModels`-bounded; help text and docs were rewritten in this PR to state the widened scope. Flagging explicitly for release notes: config/default surface changed — 1 key widened, 0 added, 0 removed. Second intentional behavior change: nested plugin spawns under internally flagged clients (background synthetic runs, `openai-http`/voice-ingress-triggered runs) previously inherited blanket override authority; they now consult the per-plugin policy like any other plugin call.

## Evidence

- New tests in `src/gateway/server-plugins.test.ts`: trusted plugin + non-admin client → override forwarded and the dispatched client carries `internal.allowModelOverride: true` on unchanged `operator.write` scopes (proves the downstream gate path); untrusted plugin + non-admin client → rejected with the config-pointer error; **inherited internal flag on the scope client + untrusted plugin → still rejected** (pins the non-transitivity of minted authority). Existing fallback-path and admin-client tests updated for the reworded messages and kept green.
- Focused suites: `pnpm test src/gateway/server-plugins.test.ts extensions/memory-core/src/dreaming-narrative.test.ts` → 178 tests passed post-hardening.
- Changed-files gate: `pnpm check:changed` on Blacksmith Testbox → exit 0 (lint, import cycles, repo guards): https://github.com/openclaw/openclaw/actions/runs/28939856076 (first commit) and https://github.com/openclaw/openclaw/actions/runs/28942275771 (hardening commit), both exit 0.
- Multi-agent review pass on this diff (8 finder angles, per-candidate adversarial verification): the privilege-transitivity finding was verified PLAUSIBLE (mechanism confirmed at every static link, reachability timing-dependent on lane drain context) and is fixed by the second commit; confirmed cleanup findings (merge-guard doubling, doc self-contradiction, comment budget, test fixture duplication) are applied.
- Named follow-up (out of scope here): consolidate the duplicated per-plugin model-override policy engines (`subagent.*` in `src/gateway/server-plugins.ts` vs `llm.*` in `src/plugins/runtime/runtime-llm.runtime.ts`), including unifying allowlist canonicalization on `modelKey()` — the two copies already drift on double-prefix suppression.
