### PR TITLE
fix(google): repair legacy provider catalog config

### DIFF
--- a/extensions/google/config-compat.test.ts
+++ b/extensions/google/config-compat.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { migrateGoogleLegacyProviderConfig } from "./config-compat.js";
+
+describe("migrateGoogleLegacyProviderConfig", () => {
+  it("repairs legacy Google provider catalog schema fields and preserves SecretRefs", () => {
+    const apiKey = { source: "file", provider: "filemain", id: "/google_apiKey" };
+    const config = {
+      models: {
+        providers: {
+          google: {
+            baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+            apiKey,
+            models: [
+              {
+                id: "gemini-2.5-pro",
+                input: ["text", "image", "audio", "video"],
+                cost: { input: 1.25, output: 10, cacheRead: 0 },
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const result = migrateGoogleLegacyProviderConfig(config as never);
+    const google = result.config.models?.providers?.google;
+
+    expect(result.changes).toEqual([
+      "Updated legacy Google provider config at models.providers.google.",
+    ]);
+    expect(google?.api).toBe("google-generative-ai");
+    expect(google?.apiKey).toBe(apiKey);
+    expect(google?.models?.[0]?.input).toEqual(["text", "image"]);
+    expect(google?.models?.[0]?.cost).toEqual({
+      input: 1.25,
+      output: 10,
+      cacheRead: 0,
+      cacheWrite: 0,
+    });
+  });
+
+  it("repairs legacy Google Vertex provider blocks", () => {
+    const config = {
+      models: {
+        providers: {
+          "google-vertex": {
+            baseUrl: "https://us-central1-aiplatform.googleapis.com/v1/projects/demo",
+            models: [
+              {
+                id: "gemini-2.5-flash",
+                input: ["audio"],
+                cost: { input: 0, output: 0, cacheRead: 0 },
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const result = migrateGoogleLegacyProviderConfig(config as never);
+    const vertex = result.config.models?.providers?.["google-vertex"];
+
+    expect(result.changes).toEqual([
+      "Updated legacy Google provider config at models.providers.google-vertex.",
+    ]);
+    expect(vertex?.api).toBe("google-vertex");
+    expect(vertex?.models?.[0]?.input).toEqual(["text"]);
+    expect(vertex?.models?.[0]?.cost?.cacheWrite).toBe(0);
+  });
+
+  it("does not rewrite explicitly non-Google provider API configs", () => {
+    const config = {
+      models: {
+        providers: {
+          google: {
+            api: "openai-chat",
+            baseUrl: "https://example.test/v1",
+            models: [
+              {
+                id: "custom-model",
+                input: ["text", "audio"],
+                cost: { input: 1, output: 1, cacheRead: 0 },
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const result = migrateGoogleLegacyProviderConfig(config as never);
+
+    expect(result.config).toBe(config);
+    expect(result.changes).toEqual([]);
+  });
+});

--- a/extensions/google/config-compat.ts
+++ b/extensions/google/config-compat.ts
@@ -1,0 +1,171 @@
+// Google config compatibility repairs for legacy provider catalog rows.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { isGoogleVertexBaseUrl } from "./src/google-api-base-url.js";
+
+type JsonRecord = Record<string, unknown>;
+type GoogleProviderId = "google" | "google-vertex";
+
+const PROVIDER_API_BY_ID: Record<GoogleProviderId, string> = {
+  google: "google-generative-ai",
+  "google-vertex": "google-vertex",
+};
+const PROVIDER_PATH_BY_ID: Record<GoogleProviderId, string> = {
+  google: "models.providers.google",
+  "google-vertex": "models.providers.google-vertex",
+};
+const CATALOG_INPUT_VALUES = new Set(["text", "image"]);
+const COST_FIELDS = ["input", "output", "cacheRead", "cacheWrite"] as const;
+
+function shouldRepairProvider(providerId: GoogleProviderId, provider: JsonRecord): boolean {
+  const expectedApi = PROVIDER_API_BY_ID[providerId];
+  const api = normalizeOptionalString(provider.api);
+  if (api !== undefined && api !== expectedApi) {
+    return false;
+  }
+  if (providerId === "google-vertex" && api === undefined) {
+    return !provider.baseUrl || isGoogleVertexBaseUrl(normalizeOptionalString(provider.baseUrl));
+  }
+  return true;
+}
+
+function normalizeCatalogInput(input: unknown): { input: string[]; changed: boolean } | undefined {
+  if (!Array.isArray(input)) {
+    return undefined;
+  }
+
+  const next: string[] = [];
+  let changed = false;
+  for (const value of input) {
+    if (typeof value === "string" && CATALOG_INPUT_VALUES.has(value)) {
+      if (!next.includes(value)) {
+        next.push(value);
+      } else {
+        changed = true;
+      }
+      continue;
+    }
+    changed = true;
+  }
+
+  if (!changed) {
+    return undefined;
+  }
+  return { input: next.length > 0 ? next : ["text"], changed: true };
+}
+
+function normalizeCatalogCost(cost: unknown): { cost: JsonRecord; changed: boolean } | undefined {
+  if (!isRecord(cost)) {
+    return undefined;
+  }
+
+  let next: JsonRecord | undefined;
+  for (const field of COST_FIELDS) {
+    const value = cost[field];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      continue;
+    }
+    next ??= { ...cost };
+    next[field] = 0;
+  }
+
+  return next ? { cost: next, changed: true } : undefined;
+}
+
+function normalizeProviderModels(provider: JsonRecord): {
+  models: unknown[];
+  changed: boolean;
+} {
+  if (!Array.isArray(provider.models)) {
+    return { models: [], changed: false };
+  }
+
+  let changed = false;
+  const models = provider.models.map((model) => {
+    if (!isRecord(model)) {
+      return model;
+    }
+
+    let nextModel: JsonRecord | undefined;
+    const input = normalizeCatalogInput(model.input);
+    if (input?.changed) {
+      nextModel ??= { ...model };
+      nextModel.input = input.input;
+    }
+
+    const cost = normalizeCatalogCost(model.cost);
+    if (cost?.changed) {
+      nextModel ??= { ...model };
+      nextModel.cost = cost.cost;
+    }
+
+    if (nextModel) {
+      changed = true;
+      return nextModel;
+    }
+    return model;
+  });
+
+  return { models, changed };
+}
+
+function migrateProvider(
+  providerId: GoogleProviderId,
+  provider: unknown,
+): { provider: JsonRecord; changed: boolean } | undefined {
+  if (!isRecord(provider) || !shouldRepairProvider(providerId, provider)) {
+    return undefined;
+  }
+
+  const expectedApi = PROVIDER_API_BY_ID[providerId];
+  let nextProvider: JsonRecord | undefined;
+  if (!normalizeOptionalString(provider.api)) {
+    nextProvider = { ...provider, api: expectedApi };
+  }
+
+  const models = normalizeProviderModels(provider);
+  if (models.changed) {
+    nextProvider ??= { ...provider };
+    nextProvider.models = models.models;
+  }
+
+  return nextProvider ? { provider: nextProvider, changed: true } : undefined;
+}
+
+/** Migrate legacy Google provider blocks to the current model-catalog schema. */
+export function migrateGoogleLegacyProviderConfig(cfg: OpenClawConfig): {
+  config: OpenClawConfig;
+  changes: string[];
+} {
+  const providers = cfg.models?.providers;
+  if (!providers) {
+    return { config: cfg, changes: [] };
+  }
+
+  let nextProviders: typeof providers | undefined;
+  const changes: string[] = [];
+  for (const providerId of Object.keys(PROVIDER_API_BY_ID) as GoogleProviderId[]) {
+    const migrated = migrateProvider(providerId, providers[providerId]);
+    if (!migrated?.changed) {
+      continue;
+    }
+    nextProviders ??= { ...providers };
+    nextProviders[providerId] = migrated.provider as (typeof providers)[typeof providerId];
+    changes.push(`Updated legacy Google provider config at ${PROVIDER_PATH_BY_ID[providerId]}.`);
+  }
+
+  if (!nextProviders) {
+    return { config: cfg, changes: [] };
+  }
+
+  return {
+    config: {
+      ...cfg,
+      models: {
+        ...cfg.models,
+        providers: nextProviders,
+      },
+    },
+    changes,
+  };
+}

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -695,6 +695,7 @@
     }
   },
   "configContracts": {
+    "compatibilityMigrationPaths": ["models.providers.google", "models.providers.google-vertex"],
     "compatibilityRuntimePaths": ["tools.web.search.apiKey"]
   },
   "configSchema": {

--- a/extensions/google/setup-api.test.ts
+++ b/extensions/google/setup-api.test.ts
@@ -87,6 +87,7 @@ describe("google setup entry", () => {
   it("registers setup runtime providers declared by the manifest", () => {
     const providerIds: string[] = [];
     const cliBackendIds: string[] = [];
+    let configMigrationCount = 0;
 
     setupEntry.register({
       registerProvider(provider: ProviderPlugin) {
@@ -95,10 +96,14 @@ describe("google setup entry", () => {
       registerCliBackend(backend: CliBackendPlugin) {
         cliBackendIds.push(backend.id);
       },
+      registerConfigMigration() {
+        configMigrationCount += 1;
+      },
     } as never);
 
     expect(providerIds).toEqual(["google-vertex"]);
     expect(cliBackendIds).toEqual(["google-gemini-cli"]);
+    expect(configMigrationCount).toBe(1);
   });
 });
 

--- a/extensions/google/setup-api.ts
+++ b/extensions/google/setup-api.ts
@@ -1,6 +1,7 @@
 // Google API module exposes the plugin public contract.
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { buildGoogleGeminiCliBackend } from "./cli-backend.js";
+import { migrateGoogleLegacyProviderConfig } from "./config-compat.js";
 import { createGoogleVertexProvider } from "./provider-contract-api.js";
 
 export default definePluginEntry({
@@ -10,5 +11,6 @@ export default definePluginEntry({
   register(api) {
     api.registerProvider(createGoogleVertexProvider());
     api.registerCliBackend(buildGoogleGeminiCliBackend());
+    api.registerConfigMigration((config) => migrateGoogleLegacyProviderConfig(config));
   },
 });


### PR DESCRIPTION
Closes #102138

## What Problem This Solves

Fixes an issue where users with an older `models.providers.google` or `models.providers.google-vertex` block could lose access to their configured Gemini models after an upgrade because the provider catalog row no longer matched the current schema.

## Why This Change Was Made

The Google setup entry now registers a compatibility migration for legacy provider blocks, and the plugin manifest declares the provider config paths that should load that migration. The migration preserves existing secret references while backfilling the current provider API value, narrowing catalog inputs to supported text/image entries, and adding missing `cost.cacheWrite` values.

## User Impact

Users with legacy Google provider config can run doctor/config compatibility repair and keep their existing credentials instead of manually editing protected provider fields to make Gemini models visible again.

## Evidence

- `node scripts/run-vitest.mjs extensions/google/config-compat.test.ts extensions/google/setup-api.test.ts` passed.
- `node scripts/run-vitest.mjs src/commands/doctor/shared/legacy-config-migrations.runtime.models.test.ts src/agents/sessions/model-registry.test.ts src/agents/models-config.providers.normalize-keys.test.ts src/agents/models-config.merge.test.ts src/agents/model-selection.test.ts` passed.
- `pnpm check:test-types` passed.
- `git diff --check` passed.

## Real behavior proof

**Behavior addressed:** Legacy Google provider config is migrated into a provider catalog shape that the current registry accepts.
**Environment tested:** Local Linux workspace, Node 22.22.0, current branch `fix/102138-google-provider-migration`.
**Steps run after the patch:** Called the real doctor compatibility migration, real models config planner, and real model registry loader from source with the issue's legacy provider shape.
**Evidence after fix:**

```text
[agents/model-registry] model catalog load issue: Invalid models.json schema:
  - providers.google.models.0.input.2: must be equal to constant
  - providers.google.models.0.input.2: must be equal to constant
  - providers.google.models.0.input.2: must match a schema in anyOf
  - providers.google.models.0.input.3: must be equal to constant
  - providers.google.models.0.input.3: must be equal to constant
  - providers.google.models.0.input.3: must match a schema in anyOf
  - providers.google.models.0.cost.cacheWrite: must have required properties cacheWrite

File: /tmp/openclaw-google-proof-flcSkn/models.json
{
  "before": {
    "action": "write",
    "error": [
      "Invalid models.json schema:",
      "  - providers.google.models.0.input.2: must be equal to constant",
      "  - providers.google.models.0.input.2: must be equal to constant",
      "  - providers.google.models.0.input.2: must match a schema in anyOf",
      "  - providers.google.models.0.input.3: must be equal to constant",
      "  - providers.google.models.0.input.3: must be equal to constant"
    ],
    "found": false
  },
  "migration": {
    "changes": [
      "Updated legacy Google provider config at models.providers.google."
    ],
    "api": "google-generative-ai",
    "input": [
      "text",
      "image"
    ],
    "cost": {
      "input": 1.25,
      "output": 10,
      "cacheRead": 0,
      "cacheWrite": 0
    },
    "sameSecretRef": true
  },
  "after": {
    "action": "write",
    "error": null,
    "found": true,
    "provider": "google",
    "id": "gemini-2.5-pro",
    "input": [
      "text",
      "image"
    ],
    "cost": {
      "input": 1.25,
      "output": 10,
      "cacheRead": 0,
      "cacheWrite": 0
    }
  }
}
```

**Observed result after the fix:** Before migration, the real registry rejected the legacy catalog row and did not find `google/gemini-2.5-pro`; after migration and normal models config planning, registry loading had no error and found the model with text/image input and `cost.cacheWrite` present.
**Not tested:** A live credentialed Gemini request was not run; this proof covers the local compatibility migration, serialized model catalog planning, and registry load path.

## Root Cause

Legacy Google provider blocks could pass persisted config parsing while still emitting catalog rows that the current registry schema rejects for missing provider API, unsupported audio/video catalog inputs, and missing `cost.cacheWrite`.

## Regression Test Plan

- Added `extensions/google/config-compat.test.ts` coverage for the reported Google block, Google Vertex repair, SecretRef preservation, and explicit non-Google API opt-out.
- Updated `extensions/google/setup-api.test.ts` to assert the setup entry registers the config migration.

## User-visible / Behavior Changes

Doctor/config compatibility repair can now upgrade legacy Google provider blocks so configured Gemini models remain visible to model selection and registry loading.

## Security Impact

- New permissions? No.
- Secrets handling changed? No. Existing SecretRefs are preserved in config and still flow through the existing secret marker serialization path.
- New network calls? No.
