### PR TITLE
fix(telegram): preserve bare URL query separators

### DIFF
--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -41,6 +41,10 @@ function escapeHtmlAttr(text: string): string {
   return escapeHtml(text).replace(/"/g, "&quot;");
 }
 
+function escapeTelegramBareLinkLabel(text: string): string {
+  return text.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
 function isTelegramRichLinkHref(href: string): boolean {
   return /^(?:https?:\/\/|tg:\/\/|mailto:|tel:|#)/i.test(href);
 }
@@ -80,6 +84,7 @@ function buildTelegramLink(link: MarkdownLinkSpan, text: string) {
     end: link.end,
     open: `<a href="${safeHref}">`,
     close: "</a>",
+    escapeText: label === href ? escapeTelegramBareLinkLabel : undefined,
   };
 }
 

--- a/extensions/telegram/src/format.wrap-md.test.ts
+++ b/extensions/telegram/src/format.wrap-md.test.ts
@@ -168,6 +168,13 @@ describe("markdownToTelegramHtml - file reference wrapping", () => {
     );
   });
 
+  it("keeps ampersands readable in styled bare URL query labels", () => {
+    const result = markdownToTelegramHtml("Visit **https://example.com/?a=1&b=2**");
+    expect(result).toBe(
+      'Visit <a href="https://example.com/?a=1&amp;b=2"><b>https://example.com/?a=1&b=2</b></a>',
+    );
+  });
+
   it("preserves explicit markdown links even when href looks like a file ref", () => {
     const result = markdownToTelegramHtml("[docs](http://README.md)");
     expect(result).toContain('<a href="http://README.md">docs</a>');

--- a/extensions/telegram/src/format.wrap-md.test.ts
+++ b/extensions/telegram/src/format.wrap-md.test.ts
@@ -161,6 +161,13 @@ describe("markdownToTelegramHtml - file reference wrapping", () => {
     expect(result).toContain('<a href="https://example.com">');
   });
 
+  it("keeps ampersands readable in bare URL query labels", () => {
+    const result = markdownToTelegramHtml("Visit https://example.com/?a=1&b=2");
+    expect(result).toBe(
+      'Visit <a href="https://example.com/?a=1&amp;b=2">https://example.com/?a=1&b=2</a>',
+    );
+  });
+
   it("preserves explicit markdown links even when href looks like a file ref", () => {
     const result = markdownToTelegramHtml("[docs](http://README.md)");
     expect(result).toContain('<a href="http://README.md">docs</a>');

--- a/packages/markdown-core/src/render-aware-chunking.test.ts
+++ b/packages/markdown-core/src/render-aware-chunking.test.ts
@@ -20,6 +20,30 @@ function renderEscapedHtml(ir: MarkdownIR): string {
   });
 }
 
+describe("renderMarkdownWithMarkers", () => {
+  it("uses a link text escaper through nested styles", () => {
+    const ir: MarkdownIR = {
+      text: "a&b",
+      styles: [{ start: 0, end: 3, style: "bold" }],
+      links: [{ start: 0, end: 3, href: "a&b" }],
+    };
+
+    const rendered = renderMarkdownWithMarkers(ir, {
+      styleMarkers: { bold: { open: "<b>", close: "</b>" } },
+      escapeText: (text) => text.replace(/&/g, "&amp;"),
+      buildLink: (link) => ({
+        start: link.start,
+        end: link.end,
+        open: "<a>",
+        close: "</a>",
+        escapeText: (text) => text,
+      }),
+    });
+
+    expect(rendered).toBe("<a><b>a&b</b></a>");
+  });
+});
+
 describe("renderMarkdownIRChunksWithinLimit", () => {
   it("prefers word boundaries when escaping shrinks the render budget", () => {
     const ir = markdownToIR("alpha <<");

--- a/packages/markdown-core/src/render.ts
+++ b/packages/markdown-core/src/render.ts
@@ -200,7 +200,11 @@ export function renderMarkdownWithMarkers(ir: MarkdownIR, options: RenderOptions
       // Open outer spans first (larger end) so LIFO closes stay valid for same-start overlaps.
       for (const item of openingItems) {
         out += item.open;
-        stack.push({ close: item.close, end: item.end, escapeText: item.escapeText });
+        if (item.kind === "link") {
+          stack.push({ close: item.close, end: item.end, escapeText: item.escapeText });
+        } else {
+          stack.push({ close: item.close, end: item.end });
+        }
       }
     }
 

--- a/packages/markdown-core/src/render.ts
+++ b/packages/markdown-core/src/render.ts
@@ -213,7 +213,9 @@ export function renderMarkdownWithMarkers(ir: MarkdownIR, options: RenderOptions
       break;
     }
     if (next > pos) {
-      out += (stack[stack.length - 1]?.escapeText ?? options.escapeText)(text.slice(pos, next));
+      const escapeText =
+        stack.findLast((item) => item.escapeText)?.escapeText ?? options.escapeText;
+      out += escapeText(text.slice(pos, next));
     }
   }
 

--- a/packages/markdown-core/src/render.ts
+++ b/packages/markdown-core/src/render.ts
@@ -16,6 +16,7 @@ export type RenderLink = {
   end: number;
   open: string;
   close: string;
+  escapeText?: (text: string) => string;
 };
 
 /** Renderer hooks for converting Markdown IR into a marker-based target format. */
@@ -117,9 +118,16 @@ export function renderMarkdownWithMarkers(ir: MarkdownIR, options: RenderOptions
 
   const points = [...boundaries].toSorted((a, b) => a - b);
   // Links and styles share one stack so equal-end spans close in exact reverse open order.
-  const stack: { close: string; end: number }[] = [];
+  const stack: { close: string; end: number; escapeText?: (text: string) => string }[] = [];
   type OpeningItem =
-    | { end: number; open: string; close: string; kind: "link"; index: number }
+    | {
+        end: number;
+        open: string;
+        close: string;
+        escapeText?: (text: string) => string;
+        kind: "link";
+        index: number;
+      }
     | {
         end: number;
         open: string;
@@ -150,6 +158,7 @@ export function renderMarkdownWithMarkers(ir: MarkdownIR, options: RenderOptions
           end: link.end,
           open: link.open,
           close: link.close,
+          escapeText: link.escapeText,
           kind: "link",
           index,
         });
@@ -191,7 +200,7 @@ export function renderMarkdownWithMarkers(ir: MarkdownIR, options: RenderOptions
       // Open outer spans first (larger end) so LIFO closes stay valid for same-start overlaps.
       for (const item of openingItems) {
         out += item.open;
-        stack.push({ close: item.close, end: item.end });
+        stack.push({ close: item.close, end: item.end, escapeText: item.escapeText });
       }
     }
 
@@ -200,7 +209,7 @@ export function renderMarkdownWithMarkers(ir: MarkdownIR, options: RenderOptions
       break;
     }
     if (next > pos) {
-      out += options.escapeText(text.slice(pos, next));
+      out += (stack[stack.length - 1]?.escapeText ?? options.escapeText)(text.slice(pos, next));
     }
   }
 


### PR DESCRIPTION
Closes #102162

## What Problem This Solves

Fixes an issue where Telegram users who receive bare URLs with multiple query parameters would see and sometimes open a link containing a literal `&amp;` separator, causing the destination to lose the intended query parameter. The fix now also covers bare URLs nested inside styles such as bold.

## Why This Change Was Made

The Telegram renderer now lets accepted link spans override how their visible label text is escaped. Telegram bare auto-link labels keep raw `&` separators while still escaping `<` and `>`; the anchor `href` remains HTML-attribute escaped, and labelled Markdown links keep the default label escaping.

The shared renderer resolves the nearest active link text escaper across the renderer stack, so nested style frames no longer hide the link's escaping policy.

## User Impact

Telegram messages can safely include bare URLs such as `https://example.com/?a=1&b=2`, including bold-styled bare URLs, without breaking the visible/tappable destination. Existing labelled links and non-link text continue to use the normal Telegram HTML escaping path.

## Evidence

- Before the follow-up, `node scripts/run-vitest.mjs extensions/telegram/src/format.wrap-md.test.ts` reproduced the styled defect: expected a raw `&` in the bold bare-URL label but received `&amp;`.
- `node scripts/run-vitest.mjs extensions/telegram/src/format.wrap-md.test.ts packages/markdown-core/src/render-aware-chunking.test.ts` — passed 2 Vitest shards (45 Telegram tests; 9 markdown-core tests).
- `node_modules/.bin/oxfmt --check packages/markdown-core/src/render.ts packages/markdown-core/src/render-aware-chunking.test.ts extensions/telegram/src/format.ts extensions/telegram/src/format.wrap-md.test.ts` — passed.
- `node_modules/.bin/oxlint packages/markdown-core/src/render.ts packages/markdown-core/src/render-aware-chunking.test.ts extensions/telegram/src/format.ts extensions/telegram/src/format.wrap-md.test.ts` — passed with 0 warnings and 0 errors.
- `git diff --check` — passed.
- Gitleaks scan of the complete PR diff — passed with no leaks found.

## Changes

- Adds an optional per-link text escaping hook to the shared marker renderer.
- Applies the nearest active link escaping hook through nested style frames.
- Uses that hook only for Telegram auto-linked bare URL labels where the label exactly matches the href.
- Adds shared-renderer and Telegram regressions proving styled bare URL labels keep `&` while the href attribute remains safely escaped.

Native Telegram Desktop/mobile tap proof is still not available from this environment; the source-level behavior and renderer output are covered by focused regressions.
