### PR TITLE
fix: prevent hidden pre-tool text from confusing channel users

### DIFF
--- a/src/agents/embedded-agent-runner/replay-history.test.ts
+++ b/src/agents/embedded-agent-runner/replay-history.test.ts
@@ -316,6 +316,51 @@ describe("normalizeAssistantReplayContent", () => {
     expect(JSON.stringify(out)).not.toContain("assistant copied inbound metadata omitted");
   });
 
+  it("marks commentary text before tool calls as undelivered in provider replay", () => {
+    const toolCall = { type: "toolCall", id: "call_1", name: "read", arguments: {} };
+    const messages = [
+      userMessage("hi"),
+      bedrockAssistant(
+        [
+          {
+            type: "text",
+            text: "Please confirm the payment details before I continue.",
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "commentary-0",
+              phase: "commentary",
+            }),
+          },
+          toolCall,
+        ],
+        "toolUse",
+      ),
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: [{ type: "text", text: "ok" }],
+        timestamp: 1,
+      } as unknown as AgentMessage,
+      userMessage("yes"),
+    ];
+
+    const out = normalizeAssistantReplayContent(messages);
+
+    expect(out).not.toBe(messages);
+    const normalized = out[1] as AgentMessage & { content: unknown[] };
+    const replayText = (normalized.content[0] as { text?: string }).text ?? "";
+    expect(replayText).toContain("was not delivered to the user/channel");
+    expect(replayText).toContain("Do not assume the user saw or answered it");
+    expect(replayText).toContain("Please confirm the payment details");
+    expect(normalized.content[0]).toHaveProperty(
+      "textSignature",
+      JSON.stringify({ v: 1, id: "commentary-0" }),
+    );
+    expect(normalized.content[1]).toBe(toolCall);
+    expect(out[2]).toBe(messages[2]);
+  });
+
   it("filters openclaw delivery-mirror and gateway-injected assistant messages from replay", () => {
     // Gateway mirror entries are transcript artifacts, not model-authored
     // assistant turns, so they must not be sent back to providers.

--- a/src/agents/embedded-agent-runner/replay-history.test.ts
+++ b/src/agents/embedded-agent-runner/replay-history.test.ts
@@ -318,6 +318,11 @@ describe("normalizeAssistantReplayContent", () => {
 
   it("marks commentary text before tool calls as undelivered in provider replay", () => {
     const toolCall = { type: "toolCall", id: "call_1", name: "read", arguments: {} };
+    const signature = JSON.stringify({
+      v: 1,
+      id: "commentary-0",
+      phase: "commentary",
+    });
     const messages = [
       userMessage("hi"),
       bedrockAssistant(
@@ -325,11 +330,7 @@ describe("normalizeAssistantReplayContent", () => {
           {
             type: "text",
             text: "Please confirm the payment details before I continue.",
-            textSignature: JSON.stringify({
-              v: 1,
-              id: "commentary-0",
-              phase: "commentary",
-            }),
+            textSignature: signature,
           },
           toolCall,
         ],
@@ -359,6 +360,43 @@ describe("normalizeAssistantReplayContent", () => {
     );
     expect(normalized.content[1]).toBe(toolCall);
     expect(out[2]).toBe(messages[2]);
+  });
+
+  it("marks commentary text as undelivered when tool-call turns replay with stop", () => {
+    const toolCall = { type: "toolCall", id: "call_1", name: "read", arguments: {} };
+    const messages = [
+      userMessage("hi"),
+      bedrockAssistant(
+        [
+          {
+            type: "text",
+            text: "I will check that now.",
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "commentary-0",
+              phase: "commentary",
+            }),
+          },
+          toolCall,
+        ],
+        "stop",
+      ),
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: [{ type: "text", text: "ok" }],
+        timestamp: 1,
+      } as unknown as AgentMessage,
+    ];
+
+    const out = normalizeAssistantReplayContent(messages);
+
+    const normalized = out[1] as AgentMessage & { content: unknown[] };
+    const replayText = (normalized.content[0] as { text?: string }).text ?? "";
+    expect(replayText).toContain("was not delivered to the user/channel");
+    expect(replayText).toContain("I will check that now.");
+    expect(normalized.content[1]).toBe(toolCall);
   });
 
   it("filters openclaw delivery-mirror and gateway-injected assistant messages from replay", () => {

--- a/src/agents/embedded-agent-runner/replay-history.ts
+++ b/src/agents/embedded-agent-runner/replay-history.ts
@@ -18,6 +18,7 @@ import {
   hasInterSessionUserProvenance,
   normalizeInputProvenance,
 } from "../../sessions/input-provenance.js";
+import { parseAssistantTextSignature } from "../../shared/chat-message-content.js";
 import { isTranscriptOnlyOpenClawAssistantMessage } from "../../shared/transcript-only-openclaw-assistant.js";
 import { stripStaleAssistantUsageBeforeLatestCompaction } from "../compaction-usage.js";
 import {
@@ -30,6 +31,13 @@ import {
   validateGeminiTurns,
 } from "../embedded-agent-helpers.js";
 import { resolveImageSanitizationLimits } from "../image-sanitization.js";
+import {
+  escapeInternalRuntimeContextDelimiters,
+  INTERNAL_RUNTIME_CONTEXT_BEGIN,
+  INTERNAL_RUNTIME_CONTEXT_END,
+  OPENCLAW_NEXT_TURN_RUNTIME_CONTEXT_HEADER,
+  OPENCLAW_RUNTIME_CONTEXT_NOTICE,
+} from "../internal-runtime-context.js";
 import { isReasoningOnlyLengthAssistantTurn } from "../replay-turn-classification.js";
 import type { AgentMessage } from "../runtime/index.js";
 import {
@@ -85,6 +93,15 @@ type ProviderReplayHookParams = {
   model?: ProviderRuntimeModel;
   sessionId?: string;
 };
+
+const REPLAY_TOOL_CALL_BLOCK_TYPES = new Set([
+  "toolCall",
+  "toolUse",
+  "functionCall",
+  "tool_call",
+  "tool_use",
+  "function_call",
+]);
 
 function createProviderReplayPluginParams(params: ProviderReplayHookParams) {
   const context = {
@@ -222,9 +239,47 @@ function normalizeAssistantReplayTextContent(message: AgentMessage, replayConten
   } as AgentMessage;
 }
 
+function hasReplayToolCallBlock(replayContent: readonly unknown[]): boolean {
+  return replayContent.some((block) => {
+    if (!block || typeof block !== "object") {
+      return false;
+    }
+    const type = (block as { type?: unknown }).type;
+    return typeof type === "string" && REPLAY_TOOL_CALL_BLOCK_TYPES.has(type);
+  });
+}
+
+function isCommentaryTextBlock(block: object): boolean {
+  const record = block as { textSignature?: unknown };
+  return parseAssistantTextSignature(record.textSignature)?.phase === "commentary";
+}
+
+function preserveReplayTextSignatureId(value: unknown): string | undefined {
+  const id = parseAssistantTextSignature(value)?.id;
+  return id ? JSON.stringify({ v: 1, id }) : undefined;
+}
+
+function formatUndeliveredCommentaryReplayContext(text: string): string {
+  return [
+    INTERNAL_RUNTIME_CONTEXT_BEGIN,
+    OPENCLAW_NEXT_TURN_RUNTIME_CONTEXT_HEADER,
+    OPENCLAW_RUNTIME_CONTEXT_NOTICE,
+    "",
+    "A previous assistant text block before a tool call was classified as commentary and was not delivered to the user/channel.",
+    "Do not assume the user saw or answered it. If it matters, ask or send it again in a user-visible final reply after the tool result.",
+    "",
+    "Undelivered assistant commentary:",
+    escapeInternalRuntimeContextDelimiters(text),
+    INTERNAL_RUNTIME_CONTEXT_END,
+  ].join("\n");
+}
+
 function normalizeAssistantReplayBlockContent(message: AgentMessage, replayContent: unknown[]) {
   let touched = false;
   const sanitizedContent: unknown[] = [];
+  const markUndeliveredCommentary =
+    (message as { stopReason?: unknown }).stopReason === "toolUse" &&
+    hasReplayToolCallBlock(replayContent);
   for (const block of replayContent) {
     if (!block || typeof block !== "object") {
       sanitizedContent.push(block);
@@ -236,6 +291,22 @@ function normalizeAssistantReplayBlockContent(message: AgentMessage, replayConte
       continue;
     }
     const strippedText = stripInternalMetadataForDisplay(text);
+    if (markUndeliveredCommentary && isCommentaryTextBlock(block)) {
+      touched = true;
+      const trimmed = strippedText.trim();
+      if (trimmed && !isSilentReplyPayloadText(trimmed, SILENT_REPLY_TOKEN)) {
+        const { textSignature: _droppedTextSignature, ...rest } = block as {
+          textSignature?: unknown;
+        };
+        const textSignature = preserveReplayTextSignatureId(_droppedTextSignature);
+        sanitizedContent.push({
+          ...rest,
+          text: formatUndeliveredCommentaryReplayContext(trimmed),
+          ...(textSignature ? { textSignature } : {}),
+        });
+      }
+      continue;
+    }
     if (strippedText === text) {
       if (!isSilentReplyPayloadText(text.trim(), SILENT_REPLY_TOKEN)) {
         sanitizedContent.push(block);

--- a/src/agents/embedded-agent-runner/replay-history.ts
+++ b/src/agents/embedded-agent-runner/replay-history.ts
@@ -277,9 +277,7 @@ function formatUndeliveredCommentaryReplayContext(text: string): string {
 function normalizeAssistantReplayBlockContent(message: AgentMessage, replayContent: unknown[]) {
   let touched = false;
   const sanitizedContent: unknown[] = [];
-  const markUndeliveredCommentary =
-    (message as { stopReason?: unknown }).stopReason === "toolUse" &&
-    hasReplayToolCallBlock(replayContent);
+  const markUndeliveredCommentary = hasReplayToolCallBlock(replayContent);
   for (const block of replayContent) {
     if (!block || typeof block !== "object") {
       sanitizedContent.push(block);


### PR DESCRIPTION
Closes #101793

## What Problem This Solves

Fixes an issue where users on message channels could miss assistant text that was emitted before a tool call, while the next model turn still replayed that text as if it had been shown to the user.

## Why This Change Was Made

The change keeps commentary-phase pre-tool text private from channel delivery, but marks that text as undelivered in provider replay so the next model turn does not assume the user saw or answered it. The replay marker preserves the original Responses replay id when present, drops the commentary phase metadata, escapes internal context delimiters, and leaves the tool call/tool result sequence intact.

Non-goal: this does not change Signal/Telegram/Desktop delivery policy or mutate stored transcript history.

## User Impact

Agents no longer continue from suppressed pre-tool narration as though it was visible to the user. If the suppressed text matters after the tool result, the agent is prompted to ask again or send it in a user-visible final reply.

## Evidence

- Provider replay probe for `stop` + `toolCall` + commentary text passed with current source:

```json
{
  "probe": "provider-replay-stop-plus-toolcall-commentary",
  "inputStopReason": "stop",
  "inputTextPhase": "commentary",
  "outputTextIncludesUndeliveredMarker": true,
  "outputTextInstructsNotSeen": true,
  "originalCommentaryRetainedForModel": true,
  "outputTextSignature": "{\"v\":1,\"id\":\"msg_live_probe\"}",
  "outputToolCallPreserved": true,
  "outputToolResultPreserved": true,
  "persistedInputUnchanged": true
}
```

- `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs src/agents/embedded-agent-runner/replay-history.test.ts` passed: 1 file, 31 tests.
- `pnpm exec oxfmt --check src/agents/embedded-agent-runner/replay-history.ts src/agents/embedded-agent-runner/replay-history.test.ts` passed.
- `pnpm exec oxlint --type-aware src/agents/embedded-agent-runner/replay-history.ts src/agents/embedded-agent-runner/replay-history.test.ts` passed.
- `git diff --check` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` passed with no accepted/actionable findings.

Agent transcript note: a local candidate session was found, but no redacted transcript section is included because explicit approval is required before adding local session logs to a public PR body.
