### PR TITLE
fix: preserve Telegram bare URL query separators

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -452,9 +452,27 @@ describe("markdownToTelegramHtml", () => {
     );
   });
 
+  it("keeps bare URL query separators out of inline link hrefs", () => {
+    const input = "https://example.com/wp-admin/post.php?post=100&action=edit";
+    const expected = "https://example.com/wp-admin/post.php?post=100&amp;action=edit";
+
+    expect(markdownToTelegramHtml(input)).toBe(expected);
+    expect(markdownToTelegramRichHtml(input)).toBe(expected);
+    expect(
+      markdownToTelegramChunks(input, 4096)
+        .map((chunk) => chunk.html)
+        .join(""),
+    ).toBe(expected);
+  });
+
   it("properly nests link inside bold", () => {
     const res = markdownToTelegramHtml("**bold [link](https://example.com) text**");
     expect(res).toBe('<b>bold <a href="https://example.com">link</a> text</b>');
+  });
+
+  it("keeps labelled URL query links as inline Telegram links", () => {
+    const res = markdownToTelegramHtml("[edit](https://example.com/page?post=100&action=edit)");
+    expect(res).toBe('<a href="https://example.com/page?post=100&amp;action=edit">edit</a>');
   });
 
   it("properly nests bold wrapping a link with trailing text", () => {

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -74,6 +74,11 @@ function buildTelegramLink(link: MarkdownLinkSpan, text: string) {
   if (isAutoLinkedFileRef(href, label)) {
     return null;
   }
+  // Bare query URLs are safer as decoded text; Telegram detects them as URL
+  // entities without exposing an escaped inline-link href to clients.
+  if (/^https?:\/\//i.test(href) && href.includes("&") && label === href) {
+    return null;
+  }
   const safeHref = escapeHtmlAttr(href);
   return {
     start: link.start,

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -356,6 +356,7 @@ const TELEGRAM_RICH_ATTR_HTML_TAG_PATTERNS = new Map([
     /^(?=.*\ssrc="https?:\/\/[^"]+")(?:\s+src="https?:\/\/[^"]+"|\s+title="[^"]*"|\s+tg-spoiler)*\s*\/?\s*$/,
   ],
 ]);
+const TELEGRAM_HTML_TEXT_URL_PATTERN = /\bhttps?:\/\/[^\s<>"']+/gi;
 let fileReferencePattern: RegExp | undefined;
 let orphanedTldPattern: RegExp | undefined;
 
@@ -678,6 +679,20 @@ function wrapSegmentFileRefs(
   if (!text || codeDepth > 0 || preDepth > 0 || anchorDepth > 0) {
     return text;
   }
+  TELEGRAM_HTML_TEXT_URL_PATTERN.lastIndex = 0;
+  let result = "";
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = TELEGRAM_HTML_TEXT_URL_PATTERN.exec(text)) !== null) {
+    result += wrapPlainTextFileRefs(text.slice(lastIndex, match.index));
+    result += match[0];
+    lastIndex = TELEGRAM_HTML_TEXT_URL_PATTERN.lastIndex;
+  }
+  result += wrapPlainTextFileRefs(text.slice(lastIndex));
+  return result;
+}
+
+function wrapPlainTextFileRefs(text: string): string {
   const wrappedStandalone = text.replace(getFileReferencePattern(), wrapStandaloneFileRef);
   return wrappedStandalone.replace(getOrphanedTldPattern(), (match, prefix: string, tld: string) =>
     prefix === ">" ? match : `${prefix}<code>${escapeHtml(tld)}</code>`,

--- a/extensions/telegram/src/format.wrap-md.test.ts
+++ b/extensions/telegram/src/format.wrap-md.test.ts
@@ -306,6 +306,16 @@ describe("edge cases", () => {
     }
   });
 
+  it("preserves file-like paths inside bare query URLs", () => {
+    const url = "https://github.com/openclaw/openclaw/blob/main/README.md?plain=1&x=2";
+    const result = markdownToTelegramHtml(`${url} and CHANGELOG.md`);
+    expect(result).toContain(
+      "https://github.com/openclaw/openclaw/blob/main/README.md?plain=1&amp;x=2",
+    );
+    expect(result).not.toContain("<code>README.md</code>?plain=1");
+    expect(result).toContain("and <code>CHANGELOG.md</code>");
+  });
+
   it("handles wrapFileRefs: false (plain text output)", () => {
     const result = markdownToTelegramHtml("README.md", { wrapFileRefs: false });
     // buildTelegramLink returns null, so no <a> tag; wrapFileRefs: false skips <code>


### PR DESCRIPTION
Closes #102162

## What Problem This Solves

Fixes an issue where Telegram users receiving a bare URL with multiple query parameters could see or open an inline-link destination containing a literal `&amp;` when the agent reply was rendered through Telegram HTML/rich formatting.

This affected ordinary model replies such as `https://example.com/wp-admin/post.php?post=100&action=edit` when Telegram linkification turned the visible bare URL into an inline HTML link.

## Why This Change Was Made

Telegram now leaves bare HTTP(S) URLs containing raw query separators as decoded text instead of wrapping them in an inline `<a href="...">` marker; labelled Markdown links still use inline-link markup and keep attribute escaping. This keeps the fix local to the Telegram formatter rather than changing the shared Markdown renderer or Slack formatting behavior.

Risk note: this touches Telegram channel formatting, so the regression tests cover the plain Markdown, rich HTML, and chunked Telegram render paths, plus the labelled-link non-regression; Slack formatter and shared renderer tests were also run to check sibling behavior.

## User Impact

Telegram users should receive bare multi-parameter URLs that preserve the intended raw `&` separator after Telegram parses the HTML text, so tapping the URL does not lose the later query parameters. Users can still send labelled Markdown links as before.

## Evidence

Before on current main (`4bf70be01a`), the real Telegram formatter produced an inline link whose href and visible label both contained `&amp;`:

```text
<a href="https://example.com/wp-admin/post.php?post=100&amp;action=edit">https://example.com/wp-admin/post.php?post=100&amp;action=edit</a>
```

After this change, the same real formatter entry points keep the bare URL as Telegram HTML text, while labelled links still render as anchors:

```text
markdownToTelegramHtml: https://example.com/wp-admin/post.php?post=100&amp;action=edit
markdownToTelegramRichHtml: https://example.com/wp-admin/post.php?post=100&amp;action=edit
markdownToTelegramChunks: https://example.com/wp-admin/post.php?post=100&amp;action=edit
labelled link: <a href="https://example.com/page?post=100&amp;action=edit">edit</a>
```

Telegram Bot API documentation for HTML parse mode says `&` in text must be sent as `&amp;`, and the MessageEntity contract distinguishes normal `url` entities from `text_link` inline links. A live `getMe` check against the configured Telegram Bot API token returned HTTP 200 with `ok: true`; no token or bot identifier is included here.

Commands run:

```text
node --import tsx -e 'import { markdownToTelegramHtml, markdownToTelegramRichHtml, markdownToTelegramChunks } from "./extensions/telegram/src/format.ts"; const input="https://example.com/wp-admin/post.php?post=100&action=edit"; console.log(JSON.stringify({html: markdownToTelegramHtml(input), rich: markdownToTelegramRichHtml(input), chunked: markdownToTelegramChunks(input,4096).map((chunk)=>chunk.html).join("")}));'
node scripts/run-vitest.mjs extensions/telegram/src/format.test.ts extensions/telegram/src/format.wrap-md.test.ts packages/markdown-core/src/render-aware-chunking.test.ts extensions/slack/src/format.test.ts
./node_modules/.bin/oxfmt --check --threads=1 extensions/telegram/src/format.ts extensions/telegram/src/format.test.ts
pnpm tsgo:extensions
autoreview --mode local
pnpm openclaw agent --local --model deepseek/deepseek-v4-pro --session-key agent:default:issue-102162-telegram-url-proof --message 'Reply with exactly this URL and no extra text: https://example.com/wp-admin/post.php?post=100&action=edit' --json --timeout 180
pnpm openclaw message send --channel telegram --target 123456789 --message 'https://example.com/wp-admin/post.php?post=100&action=edit' --dry-run --json
```

Focused test result: 3 Vitest shards passed, covering 129 tests total. `pnpm tsgo:extensions` passed. Autoreview reported no accepted/actionable findings.

The DeepSeek local agent run succeeded through the embedded OpenClaw harness with provider `deepseek`, model `deepseek-v4-pro`, and final visible text exactly `https://example.com/wp-admin/post.php?post=100&action=edit`.

What was not tested: I did not send to a real Telegram chat or tap the client open-link prompt because this checkout has a bot token but no configured safe target chat. Manual follow-up proof is: send the same bare URL through Telegram with `channels.telegram.richMessages: true`, open it in Telegram Desktop or mobile, and confirm the prompt/tap destination shows `?post=100&action=edit` with a raw `&` separator rather than `&amp;action=edit`.

AI-assisted: AI-assisted; code, tests, and proof output were reviewed before submission.
