### PR TITLE
fix: expose wedged overflow sessions to recovery tooling

### DIFF
--- a/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
@@ -2361,36 +2361,74 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
   });
 
   it("surfaces a visible blocked payload for Codex promptError overflow without assistant text", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-overflow-blocked-"));
+    const storePath = path.join(dir, "sessions.json");
     const promptError = new Error(
       "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.",
     );
     const terminalLifecycleMeta: Array<Record<string, unknown>> = [];
-    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
-      makeAttemptResult({
-        promptError,
-        promptErrorSource: "prompt",
-        assistantTexts: [],
-        attemptUsage: { input: 0, output: 0, total: 0 },
-        setTerminalLifecycleMeta: (meta) => {
-          terminalLifecycleMeta.push(meta);
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        "test-key": {
+          sessionId: "test-session",
+          updatedAt: 1,
         },
       }),
+      "utf8",
     );
 
-    const result = await runEmbeddedAgent(overflowBaseRunParams);
+    try {
+      mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError,
+          promptErrorSource: "prompt",
+          assistantTexts: [],
+          attemptUsage: { input: 0, output: 0, total: 0 },
+          setTerminalLifecycleMeta: (meta) => {
+            terminalLifecycleMeta.push(meta);
+          },
+        }),
+      );
 
-    expect(mockedIsLikelyContextOverflowError).toHaveBeenCalledWith(promptError.message);
-    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
-    expect(result.payloads?.[0]).toMatchObject({
-      isError: true,
-      text: expect.stringContaining("Context overflow"),
-    });
-    expect(result.payloads?.[0]?.text).toContain("/reset");
-    expect(result.payloads?.[0]?.text).toContain("/new");
-    expect(result.meta.error?.kind).toBe("context_overflow");
-    expect(result.meta.livenessState).toBe("blocked");
-    expect(result.meta.finalAssistantVisibleText).toBe(result.payloads?.[0]?.text);
-    expect(terminalLifecycleMeta.at(-1)).toMatchObject({ livenessState: "blocked" });
+      const result = await runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        config: {
+          session: {
+            store: storePath,
+          },
+        } as RunEmbeddedAgentParams["config"],
+      });
+
+      expect(mockedIsLikelyContextOverflowError).toHaveBeenCalledWith(promptError.message);
+      expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
+      expect(result.payloads?.[0]).toMatchObject({
+        isError: true,
+        text: expect.stringContaining("Context overflow"),
+      });
+      expect(result.payloads?.[0]?.text).toContain("/reset");
+      expect(result.payloads?.[0]?.text).toContain("/new");
+      expect(result.meta.error?.kind).toBe("context_overflow");
+      expect(result.meta.livenessState).toBe("blocked");
+      expect(result.meta.finalAssistantVisibleText).toBe(result.payloads?.[0]?.text);
+      expect(terminalLifecycleMeta.at(-1)).toMatchObject({ livenessState: "blocked" });
+      const stored = JSON.parse(await fs.readFile(storePath, "utf8"))["test-key"];
+      expect(stored.lastBlockedRun).toMatchObject({
+        state: "blocked",
+        source: "embedded-agent",
+        reason: "context_overflow",
+        runId: "run-1",
+        sessionId: "test-session",
+        sessionFile: "/tmp/session.json",
+        provider: "anthropic",
+        model: "test-model",
+        message: promptError.message,
+        suggestedAction: "reset_or_new",
+      });
+      expect(stored.lastBlockedRun.blockedAt).toEqual(expect.any(Number));
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
   });
 
   it("does not reset compaction attempt budget after successful tool-result truncation", async () => {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -348,6 +348,58 @@ async function resetNoRealConversationTokenSnapshot(params: {
   }
 }
 
+async function persistOverflowBlockedRunMarker(params: {
+  config?: RunEmbeddedAgentParams["config"];
+  sessionKey?: string;
+  agentId?: string;
+  runId?: string;
+  sessionId?: string;
+  sessionFile?: string;
+  provider: string;
+  model: string;
+  reason: "context_overflow" | "compaction_failure";
+  message: string;
+}): Promise<void> {
+  if (!params.sessionKey) {
+    return;
+  }
+  const blockedAt = Date.now();
+  const storePath = resolveStorePath(params.config?.session?.store, { agentId: params.agentId });
+  try {
+    await updateSessionEntry(
+      {
+        storePath,
+        sessionKey: params.sessionKey,
+      },
+      async () => ({
+        lastBlockedRun: {
+          state: "blocked",
+          source: "embedded-agent",
+          reason: params.reason,
+          blockedAt,
+          runId: params.runId,
+          sessionId: params.sessionId,
+          sessionFile: params.sessionFile,
+          provider: params.provider,
+          model: params.model,
+          message: params.message,
+          suggestedAction: "reset_or_new",
+        },
+        updatedAt: blockedAt,
+      }),
+      {
+        skipMaintenance: true,
+        takeCacheOwnership: true,
+      },
+    );
+  } catch (err) {
+    log.warn(
+      `[context-overflow-recovery] failed to persist blocked marker for ` +
+        `${params.sessionKey}: ${String(err)}`,
+    );
+  }
+}
+
 function resolveAttemptDispatchApiKey(params: {
   apiKeyInfo: ApiKeyInfo | null;
   runtimeAuthState: RuntimeAuthState | null;
@@ -3008,6 +3060,18 @@ async function runEmbeddedAgentInternal(
               `[context-overflow-recovery] exhausted provider overflow recovery for ${provider}/${modelId}; ` +
                 `livenessState=blocked suggestedAction=reset_or_new kind=${kind}`,
             );
+            await persistOverflowBlockedRunMarker({
+              config: params.config,
+              sessionKey: resolvedSessionKey,
+              agentId: sessionAgentId,
+              runId: params.runId,
+              sessionId: sessionIdUsed,
+              sessionFile: activeSessionFile,
+              provider,
+              model: modelId,
+              reason: kind,
+              message: errorText,
+            });
             setTerminalLifecycleMeta({
               replayInvalid: resolveReplayInvalidForAttempt(),
               livenessState: "blocked",

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -228,6 +228,20 @@ export type RestartRecoveryRun = {
   lifecycleGeneration: string;
 };
 
+export type SessionBlockedRun = {
+  state: "blocked";
+  source: "embedded-agent";
+  reason: "context_overflow" | "compaction_failure";
+  blockedAt: number;
+  runId?: string;
+  sessionId?: string;
+  sessionFile?: string;
+  provider?: string;
+  model?: string;
+  message?: string;
+  suggestedAction?: "reset_or_new";
+};
+
 export type SessionEntry = {
   /**
    * Last delivered heartbeat payload (used to suppress duplicate heartbeat notifications).
@@ -296,6 +310,8 @@ export type SessionEntry = {
   abortedLastRun?: boolean;
   /** Interrupted run generations whose late lifecycle events must be ignored. */
   restartRecoveryRuns?: RestartRecoveryRun[];
+  /** Last embedded-agent blocked run marker for operator recovery tooling. */
+  lastBlockedRun?: SessionBlockedRun;
   /** Durable guard state for automatic subagent orphan recovery. */
   subagentRecovery?: SubagentRecoveryState;
   /** Quota cascade protection and state-aware failover status. */

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -36,6 +36,7 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "systemSent",
   "abortedLastRun",
   "restartRecoveryRuns",
+  "lastBlockedRun",
   "goal",
   "pendingSkillSuggestion",
   "skillCaptureSignalHashes",


### PR DESCRIPTION
Closes #101868

## What Problem This Solves

Fixes an issue where autonomous embedded-agent sessions could exhaust context-overflow recovery and only expose the blocked state through transient run metadata and logs, leaving operator tooling without a durable session marker to detect and recover the wedged session.

## Why This Change Was Made

This implements the lower-risk recovery option from the issue: keep the existing visible `/reset` or `/new` guidance and blocked terminal result, but persist a `lastBlockedRun` marker on the session entry when context-overflow recovery gives up. The marker records the run, provider/model, session file, reason, timestamp, and reset/new recovery action, without adding auto-rotation or replay behavior.

The new core session field is also reserved from plugin `sessionEntrySlotKey` projection so plugin-owned mirrors cannot collide with it.

## User Impact

Operators and recovery tooling can now inspect the persisted session entry to find the latest embedded-agent overflow-blocked run instead of scraping process logs or relying on transient run snapshots. Existing users still see the same context-overflow recovery message and manual `/reset` or `/new` path.

## Evidence

- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.vitest-cache-101868-full OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.overflow-compaction.test.ts -- --hookTimeout=300000 --reporter=verbose` -> 50 passed.
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.vitest-cache-101868-plugin OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs src/plugins/contracts/session-entry-projection.contract.test.ts -- --testNamePattern "rejects sessionEntrySlotKey values" --reporter=verbose` -> 2 passed, 11 skipped.
- `pnpm --silent exec oxfmt --check src/agents/embedded-agent-runner/run.ts src/agents/embedded-agent-runner/run.overflow-compaction.test.ts src/config/sessions/types.ts src/plugins/session-entry-slot-keys.ts` -> passed.
- `node scripts/run-oxlint.mjs src/agents/embedded-agent-runner/run.ts src/agents/embedded-agent-runner/run.overflow-compaction.test.ts src/config/sessions/types.ts src/plugins/session-entry-slot-keys.ts` -> passed.
- `git diff --check` -> passed.

- Real behavior proof with production `runEmbeddedAgent` path and a temporary local `proof-harness` returning `request_too_large`, using temporary `OPENCLAW_HOME` / `OPENCLAW_STATE_DIR` and `plugins.enabled=false` to avoid user plugin state: blocked payload returned and `lastBlockedRun` persisted in the real session store.

```json
{
  "attempts": 1,
  "payloads": [
    {
      "text": "Context overflow: prompt too large for the model. Try /reset (or /new) to start a fresh session, or use a larger-context model.",
      "isError": true
    }
  ],
  "meta": {
    "livenessState": "blocked",
    "errorKind": "context_overflow",
    "replayInvalid": false
  },
  "persistedMarker": {
    "state": "blocked",
    "source": "embedded-agent",
    "reason": "context_overflow",
    "hasBlockedAt": true,
    "runId": "proof-run-101868",
    "sessionId": "proof-session",
    "sessionFileMatches": true,
    "provider": "proof-provider",
    "model": "proof-model",
    "message": "request_too_large: proof prompt exceeds model context window",
    "suggestedAction": "reset_or_new"
  },
  "storePathUnderTempState": true
}
```
