### PR TITLE
fix: stop repeated message_tool_only source replies

### DIFF
--- a/src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts
+++ b/src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts
@@ -1,7 +1,7 @@
 // Message-tool delivery tests cover message_tool_only delivery, where a
 // successful source message send records source reply evidence without ending
 // the run before the model can observe the tool result.
-import type { Agent, AfterToolCallContext } from "openclaw/plugin-sdk/agent-core";
+import type { Agent, AgentTool, AfterToolCallContext } from "openclaw/plugin-sdk/agent-core";
 import { describe, expect, it, vi } from "vitest";
 import {
   installMessageToolOnlyTerminalHook,
@@ -166,7 +166,8 @@ describe("message-tool-only source replies", () => {
       content: [{ type: "text" as const, text: "rewritten" }],
       details: { rewritten: true },
     }));
-    const agent = { afterToolCall: previousAfterToolCall } as unknown as Agent;
+    const agent = createAgentWithTools([]);
+    agent.afterToolCall = previousAfterToolCall;
     const onDeliveredSourceReply = vi.fn();
     installMessageToolOnlyTerminalHook({
       agent,
@@ -190,7 +191,7 @@ describe("message-tool-only source replies", () => {
   });
 
   it("records delivery evidence without rewriting the default result", async () => {
-    const agent = {} as unknown as Agent;
+    const agent = createAgentWithTools([]);
     const onDeliveredSourceReply = vi.fn();
     installMessageToolOnlyTerminalHook({
       agent,
@@ -209,13 +210,364 @@ describe("message-tool-only source replies", () => {
     expect(onDeliveredSourceReply).toHaveBeenCalledTimes(1);
   });
 
+  it("suppresses repeated implicit source replies after the first delivery", async () => {
+    const messageExecute = vi.fn(async (_toolCallId: string, args: unknown) => ({
+      content: [{ type: "text" as const, text: '{"deliveryStatus":"sent"}' }],
+      details: { deliveryStatus: "sent", sourceReply: { text: readMessageText(args) } },
+    }));
+    const messageTool = createMessageAgentTool(messageExecute);
+    const agent = createAgentWithTools([messageTool]);
+    const onDeliveredSourceReply = vi.fn();
+    installMessageToolOnlyTerminalHook({
+      agent,
+      sourceReplyDeliveryMode: "message_tool_only",
+      onDeliveredSourceReply,
+    });
+
+    const wrappedMessageTool = agent.state.tools[0];
+    const firstResult = await wrappedMessageTool?.execute("call-1", {
+      action: "send",
+      message: "first visible reply",
+    });
+    await agent.afterToolCall?.(
+      createAfterToolCallContext({
+        toolName: "message",
+        args: { action: "send", message: "first visible reply" },
+        result: firstResult,
+      }),
+    );
+
+    const repeatedResult = await wrappedMessageTool?.execute("call-2", {
+      action: "send",
+      message: "second visible reply",
+    });
+
+    expect(messageExecute).toHaveBeenCalledTimes(1);
+    expect(onDeliveredSourceReply).toHaveBeenCalledTimes(1);
+    expect(repeatedResult).toMatchObject({
+      details: {
+        status: "suppressed",
+        deliveryStatus: "suppressed",
+        reason: "message_tool_only_source_reply_already_delivered",
+      },
+      terminate: true,
+    });
+  });
+
+  it("reserves the source reply slot before executing parallel message sends", async () => {
+    let releaseFirstSend: ((value: Awaited<ReturnType<AgentTool["execute"]>>) => void) | undefined;
+    const firstSend = new Promise<Awaited<ReturnType<AgentTool["execute"]>>>((resolve) => {
+      releaseFirstSend = resolve;
+    });
+    const messageExecute = vi.fn(async () => await firstSend);
+    const messageTool = createMessageAgentTool(messageExecute);
+    const agent = createAgentWithTools([messageTool]);
+    installMessageToolOnlyTerminalHook({
+      agent,
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+
+    const wrappedMessageTool = agent.state.tools[0];
+    const inFlightResult = wrappedMessageTool?.execute("call-1", {
+      action: "send",
+      message: "first visible reply",
+    });
+    const repeatedResult = await wrappedMessageTool?.execute("call-2", {
+      action: "send",
+      message: "parallel visible reply",
+    });
+    releaseFirstSend?.({
+      content: [{ type: "text", text: '{"deliveryStatus":"sent"}' }],
+      details: { deliveryStatus: "sent", sourceReply: { text: "first visible reply" } },
+    });
+
+    await expect(inFlightResult).resolves.toMatchObject({
+      details: { sourceReply: { text: "first visible reply" } },
+    });
+    expect(messageExecute).toHaveBeenCalledTimes(1);
+    expect(repeatedResult).toMatchObject({
+      details: {
+        status: "suppressed",
+        reason: "message_tool_only_source_reply_already_delivered",
+      },
+      terminate: true,
+    });
+  });
+
+  it("releases the source reply slot when after-tool-call rewrites delivery as failed", async () => {
+    const messageExecute = vi.fn(async (_toolCallId: string, args: unknown) => ({
+      content: [{ type: "text" as const, text: '{"deliveryStatus":"sent"}' }],
+      details: { deliveryStatus: "sent", sourceReply: { text: readMessageText(args) } },
+    }));
+    const previousAfterToolCall = vi.fn(async () => ({
+      content: [{ type: "text" as const, text: '{"deliveryStatus":"failed"}' }],
+      details: { deliveryStatus: "failed" },
+      isError: true,
+    }));
+    const messageTool = createMessageAgentTool(messageExecute);
+    const agent = createAgentWithTools([messageTool]);
+    agent.afterToolCall = previousAfterToolCall;
+    installMessageToolOnlyTerminalHook({
+      agent,
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+
+    const wrappedMessageTool = agent.state.tools[0];
+    const failedResult = await wrappedMessageTool?.execute("call-1", {
+      action: "send",
+      message: "hook-failed reply",
+    });
+    await agent.afterToolCall?.(
+      createAfterToolCallContext({
+        toolName: "message",
+        args: { action: "send", message: "hook-failed reply" },
+        result: failedResult,
+      }),
+    );
+
+    const retryResult = await wrappedMessageTool?.execute("call-2", {
+      action: "send",
+      message: "successful retry",
+    });
+
+    expect(messageExecute).toHaveBeenCalledTimes(2);
+    expect(retryResult).toMatchObject({
+      details: { sourceReply: { text: "successful retry" } },
+    });
+  });
+
+  it("keeps the source reply slot reserved when a suppressed parallel send finalizes first", async () => {
+    let releaseFirstSend: ((value: Awaited<ReturnType<AgentTool["execute"]>>) => void) | undefined;
+    const firstSend = new Promise<Awaited<ReturnType<AgentTool["execute"]>>>((resolve) => {
+      releaseFirstSend = resolve;
+    });
+    const messageExecute = vi.fn(async () => await firstSend);
+    const messageTool = createMessageAgentTool(messageExecute);
+    const agent = createAgentWithTools([messageTool]);
+    installMessageToolOnlyTerminalHook({
+      agent,
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+
+    const wrappedMessageTool = agent.state.tools[0];
+    const inFlightResult = wrappedMessageTool?.execute("call-1", {
+      action: "send",
+      message: "first visible reply",
+    });
+    const suppressedParallelResult = await wrappedMessageTool?.execute("call-2", {
+      action: "send",
+      message: "parallel visible reply",
+    });
+    await agent.afterToolCall?.(
+      createAfterToolCallContext({
+        toolName: "message",
+        args: { action: "send", message: "parallel visible reply" },
+        result: suppressedParallelResult,
+      }),
+    );
+
+    const thirdResult = await wrappedMessageTool?.execute("call-3", {
+      action: "send",
+      message: "third visible reply",
+    });
+    releaseFirstSend?.({
+      content: [{ type: "text", text: '{"deliveryStatus":"sent"}' }],
+      details: { deliveryStatus: "sent", sourceReply: { text: "first visible reply" } },
+    });
+
+    await expect(inFlightResult).resolves.toMatchObject({
+      details: { sourceReply: { text: "first visible reply" } },
+    });
+    expect(messageExecute).toHaveBeenCalledTimes(1);
+    expect(thirdResult).toMatchObject({
+      details: {
+        status: "suppressed",
+        reason: "message_tool_only_source_reply_already_delivered",
+      },
+      terminate: true,
+    });
+  });
+
+  it("keeps explicit message routes available after source reply delivery", async () => {
+    const messageExecute = vi.fn(async (_toolCallId: string, args: unknown) => ({
+      content: [{ type: "text" as const, text: '{"deliveryStatus":"sent"}' }],
+      details: { deliveryStatus: "sent", sourceReply: { text: readMessageText(args) } },
+    }));
+    const messageTool = createMessageAgentTool(messageExecute);
+    const agent = createAgentWithTools([messageTool]);
+    installMessageToolOnlyTerminalHook({
+      agent,
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+
+    const wrappedMessageTool = agent.state.tools[0];
+    const firstResult = await wrappedMessageTool?.execute("call-1", {
+      action: "send",
+      message: "source visible reply",
+    });
+    await agent.afterToolCall?.(
+      createAfterToolCallContext({
+        toolName: "message",
+        args: { action: "send", message: "source visible reply" },
+        result: firstResult,
+      }),
+    );
+
+    const routedResult = await wrappedMessageTool?.execute("call-2", {
+      action: "send",
+      target: "channel:other",
+      message: "cross-channel follow-up",
+    });
+
+    expect(messageExecute).toHaveBeenCalledTimes(2);
+    expect(routedResult).toMatchObject({
+      details: { sourceReply: { text: "cross-channel follow-up" } },
+    });
+  });
+
+  it("keeps non-message follow-up tools available after source reply delivery", async () => {
+    const messageExecute = vi.fn(async (_toolCallId: string, args: unknown) => ({
+      content: [{ type: "text" as const, text: '{"deliveryStatus":"sent"}' }],
+      details: { deliveryStatus: "sent", sourceReply: { text: readMessageText(args) } },
+    }));
+    const readExecute = vi.fn(async () => ({
+      content: [{ type: "text" as const, text: "read result" }],
+      details: { ok: true },
+    }));
+    const messageTool = createMessageAgentTool(messageExecute);
+    const readTool = createAgentTool("read", readExecute);
+    const agent = createAgentWithTools([messageTool, readTool]);
+    installMessageToolOnlyTerminalHook({
+      agent,
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+
+    const wrappedMessageTool = agent.state.tools[0];
+    const firstResult = await wrappedMessageTool?.execute("call-1", {
+      action: "send",
+      message: "source visible reply",
+    });
+    await agent.afterToolCall?.(
+      createAfterToolCallContext({
+        toolName: "message",
+        args: { action: "send", message: "source visible reply" },
+        result: firstResult,
+      }),
+    );
+
+    const followUpReadTool = agent.state.tools.find((tool) => tool.name === "read");
+    const readResult = await followUpReadTool?.execute("call-2", { path: "QA_KICKOFF_TASK.md" });
+
+    expect(followUpReadTool).toBeDefined();
+    expect(readExecute).toHaveBeenCalledTimes(1);
+    expect(readResult).toMatchObject({
+      details: { ok: true },
+    });
+  });
+
+  it("guards deferred message tools after source reply delivery", async () => {
+    const messageExecute = vi.fn(async (_toolCallId: string, args: unknown) => ({
+      content: [{ type: "text" as const, text: '{"deliveryStatus":"sent"}' }],
+      details: { deliveryStatus: "sent", sourceReply: { text: readMessageText(args) } },
+    }));
+    const messageTool = createMessageAgentTool(messageExecute);
+    const agent = createAgentWithTools([]);
+    agent.resolveDeferredTool = vi.fn(async () => messageTool);
+    installMessageToolOnlyTerminalHook({
+      agent,
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+
+    await agent.afterToolCall?.(
+      createAfterToolCallContext({
+        toolName: "message",
+        args: { action: "send", message: "source visible reply" },
+      }),
+    );
+    const deferredMessageTool = await agent.resolveDeferredTool?.({
+      assistantMessage: createToolCallAssistant("message", {
+        action: "send",
+        message: "repeat visible reply",
+      }),
+      toolCall: {
+        type: "toolCall",
+        id: "call-message",
+        name: "message",
+        arguments: { action: "send", message: "repeat visible reply" },
+      },
+      context: { systemPrompt: "", messages: [], tools: [] },
+    });
+
+    const repeatedResult = await deferredMessageTool?.execute("call-2", {
+      action: "send",
+      message: "repeat visible reply",
+    });
+
+    expect(messageExecute).not.toHaveBeenCalled();
+    expect(repeatedResult).toMatchObject({
+      details: { status: "suppressed" },
+      terminate: true,
+    });
+  });
+
+  it("supports deferred-only agents without eager tools", async () => {
+    const messageExecute = vi.fn(async (_toolCallId: string, args: unknown) => ({
+      content: [{ type: "text" as const, text: '{"deliveryStatus":"sent"}' }],
+      details: { deliveryStatus: "sent", sourceReply: { text: readMessageText(args) } },
+    }));
+    const messageTool = createMessageAgentTool(messageExecute);
+    const agent = {
+      state: {},
+      resolveDeferredTool: vi.fn(async () => messageTool),
+    } as unknown as Agent;
+
+    expect(() =>
+      installMessageToolOnlyTerminalHook({
+        agent,
+        sourceReplyDeliveryMode: "message_tool_only",
+      }),
+    ).not.toThrow();
+
+    await agent.afterToolCall?.(
+      createAfterToolCallContext({
+        toolName: "message",
+        args: { action: "send", message: "source visible reply" },
+      }),
+    );
+    const deferredMessageTool = await agent.resolveDeferredTool?.({
+      assistantMessage: createToolCallAssistant("message", {
+        action: "send",
+        message: "repeat visible reply",
+      }),
+      toolCall: {
+        type: "toolCall",
+        id: "call-message",
+        name: "message",
+        arguments: { action: "send", message: "repeat visible reply" },
+      },
+      context: { systemPrompt: "", messages: [], tools: [] },
+    });
+
+    const repeatedResult = await deferredMessageTool?.execute("call-2", {
+      action: "send",
+      message: "repeat visible reply",
+    });
+
+    expect(messageExecute).not.toHaveBeenCalled();
+    expect(repeatedResult).toMatchObject({
+      details: { status: "suppressed" },
+      terminate: true,
+    });
+  });
+
   it("leaves existing after-tool-call output alone when the send failed", async () => {
     const previousAfterToolCall = vi.fn(async () => ({
       content: [{ type: "text" as const, text: "failed" }],
       details: { ok: false },
       isError: true,
     }));
-    const agent = { afterToolCall: previousAfterToolCall } as unknown as Agent;
+    const agent = createAgentWithTools([]);
+    agent.afterToolCall = previousAfterToolCall;
     const onDeliveredSourceReply = vi.fn();
     installMessageToolOnlyTerminalHook({
       agent,
@@ -289,6 +641,30 @@ function createAfterToolCallContext(params: {
       tools: [],
     },
   };
+}
+
+function createAgentWithTools(tools: AgentTool[]): Agent {
+  return { state: { tools } } as unknown as Agent;
+}
+
+function createMessageAgentTool(execute: AgentTool["execute"]): AgentTool {
+  return createAgentTool("message", execute);
+}
+
+function createAgentTool(name: string, execute: AgentTool["execute"]): AgentTool {
+  return {
+    label: name,
+    name,
+    description: `${name} tool.`,
+    parameters: {} as AgentTool["parameters"],
+    execute,
+  };
+}
+
+function readMessageText(args: unknown): unknown {
+  return args && typeof args === "object" && !Array.isArray(args)
+    ? (args as Record<string, unknown>).message
+    : undefined;
 }
 
 function createDirectSendResult(params: { messageId: string }): AfterToolCallContext["result"] {

--- a/src/agents/embedded-agent-runner/run/message-tool-terminal.ts
+++ b/src/agents/embedded-agent-runner/run/message-tool-terminal.ts
@@ -3,7 +3,31 @@ import type { SourceReplyDeliveryMode } from "../../../auto-reply/get-reply-opti
  * Detects message-tool-only sends that delivered a visible source reply.
  */
 import { isDeliveredMessageToolOnlySourceReplyResult } from "../../embedded-agent-message-tool-source-reply.js";
-import type { AfterToolCallContext, AfterToolCallResult, Agent } from "../../runtime/index.js";
+import type {
+  AfterToolCallContext,
+  AfterToolCallResult,
+  Agent,
+  AgentTool,
+  AgentToolResult,
+} from "../../runtime/index.js";
+
+const SOURCE_REPLY_ALREADY_DELIVERED_RESULT = {
+  status: "suppressed",
+  deliveryStatus: "suppressed",
+  reason: "message_tool_only_source_reply_already_delivered",
+  message: "A visible source reply was already delivered through the message tool for this run.",
+} as const;
+const SOURCE_REPLY_ALREADY_DELIVERED_REASON = SOURCE_REPLY_ALREADY_DELIVERED_RESULT.reason;
+
+function createSuppressedDuplicateSourceReplyResult(): AgentToolResult<
+  typeof SOURCE_REPLY_ALREADY_DELIVERED_RESULT
+> {
+  return {
+    content: [{ type: "text", text: JSON.stringify(SOURCE_REPLY_ALREADY_DELIVERED_RESULT) }],
+    details: SOURCE_REPLY_ALREADY_DELIVERED_RESULT,
+    terminate: true,
+  };
+}
 
 function argsRecordForToolCall(context: AfterToolCallContext): Record<string, unknown> {
   if (context.args && typeof context.args === "object" && !Array.isArray(context.args)) {
@@ -13,6 +37,17 @@ function argsRecordForToolCall(context: AfterToolCallContext): Record<string, un
   return fallbackArgs && typeof fallbackArgs === "object" && !Array.isArray(fallbackArgs)
     ? fallbackArgs
     : {};
+}
+
+function isSuppressedDuplicateSourceReplyResult(result: unknown): boolean {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return false;
+  }
+  const details = (result as { details?: unknown }).details;
+  if (!details || typeof details !== "object" || Array.isArray(details)) {
+    return false;
+  }
+  return (details as Record<string, unknown>).reason === SOURCE_REPLY_ALREADY_DELIVERED_REASON;
 }
 
 /**
@@ -35,7 +70,33 @@ export function isDeliveredMessageToolOnlySourceReply(params: {
   });
 }
 
-/** Installs an after-tool hook that records source reply delivery evidence. */
+function isImplicitMessageToolOnlySourceReplySend(params: {
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+  toolName: string;
+  args: unknown;
+}): boolean {
+  return isDeliveredMessageToolOnlySourceReplyResult({
+    sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+    toolName: params.toolName,
+    args: params.args,
+    result: {
+      content: [
+        {
+          type: "text",
+          text: '{"status":"ok","deliveryStatus":"sent","sourceReplySink":"internal-ui"}',
+        },
+      ],
+      details: {
+        status: "ok",
+        deliveryStatus: "sent",
+        sourceReplySink: "internal-ui",
+      },
+    },
+    isError: false,
+  });
+}
+
+/** Installs message-tool-only guards and records source reply delivery evidence. */
 export function installMessageToolOnlyTerminalHook(params: {
   agent: Agent;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
@@ -44,18 +105,82 @@ export function installMessageToolOnlyTerminalHook(params: {
   if (params.sourceReplyDeliveryMode !== "message_tool_only") {
     return;
   }
+  let deliveredSourceReply = false;
+  let sourceReplySlotTaken = false;
+  const wrapMessageTool = (tool: AgentTool): AgentTool => {
+    if (tool.name !== "message") {
+      return tool;
+    }
+    return {
+      ...tool,
+      execute: async (toolCallId, args, signal, onUpdate) => {
+        const isImplicitSourceReply = isImplicitMessageToolOnlySourceReplySend({
+          sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+          toolName: tool.name,
+          args,
+        });
+        if (!isImplicitSourceReply) {
+          return tool.execute(toolCallId, args, signal, onUpdate);
+        }
+        if (sourceReplySlotTaken) {
+          return createSuppressedDuplicateSourceReplyResult();
+        }
+        sourceReplySlotTaken = true;
+        try {
+          const result = await tool.execute(toolCallId, args, signal, onUpdate);
+          if (
+            !isDeliveredMessageToolOnlySourceReplyResult({
+              sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+              toolName: tool.name,
+              args,
+              result,
+              isError: false,
+            })
+          ) {
+            sourceReplySlotTaken = deliveredSourceReply;
+          }
+          return result;
+        } catch (error) {
+          sourceReplySlotTaken = deliveredSourceReply;
+          throw error;
+        }
+      },
+    };
+  };
+  if (params.agent.state.tools) {
+    params.agent.state.tools = params.agent.state.tools.map(wrapMessageTool);
+  }
+  const previousResolveDeferredTool = params.agent.resolveDeferredTool?.bind(params.agent);
+  if (previousResolveDeferredTool) {
+    params.agent.resolveDeferredTool = async (context, signal) => {
+      const tool = await previousResolveDeferredTool(context, signal);
+      return tool ? wrapMessageTool(tool) : tool;
+    };
+  }
   const previousAfterToolCall = params.agent.afterToolCall?.bind(params.agent);
   params.agent.afterToolCall = async (context, signal) => {
     const hookResult = await previousAfterToolCall?.(context, signal);
-    if (
-      isDeliveredMessageToolOnlySourceReply({
-        sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-        context,
-        hookResult,
-      })
-    ) {
+    const deliveredMessageToolOnlySourceReply = isDeliveredMessageToolOnlySourceReply({
+      sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+      context,
+      hookResult,
+    });
+    if (deliveredMessageToolOnlySourceReply) {
+      deliveredSourceReply = true;
+      sourceReplySlotTaken = true;
       params.onDeliveredSourceReply?.();
       return hookResult;
+    }
+    if (
+      !deliveredSourceReply &&
+      !isSuppressedDuplicateSourceReplyResult(context.result) &&
+      isImplicitMessageToolOnlySourceReplySend({
+        sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+        toolName: context.toolCall.name,
+        args: argsRecordForToolCall(context),
+      })
+    ) {
+      sourceReplySlotTaken = false;
     }
     return hookResult;
   };


### PR DESCRIPTION
Closes #96827

AI-assisted: yes

## What Problem This Solves

Fixes an issue where users in `message_tool_only` group-chat turns could see the agent send repeated visible source replies within one embedded run after the first `message(action="send")` delivery.

## Why This Change Was Made

The source-reply terminal hook now reserves one implicit current-source message delivery slot per `message_tool_only` run. The first implicit source reply can still complete and the run can continue to non-message follow-up tools, but subsequent implicit current-source `message(send)` calls are returned to the model as suppressed terminal results instead of being delivered again.

The slot is finalized against the `afterToolCall` delivery classification. If a hook rewrites the first raw send as failed or non-delivered, the slot is released so a later valid implicit source reply can still send. Suppressed duplicate results do not release an in-flight reservation. Explicit routes, non-message tools, dry runs, failed/non-delivered sends, and deferred message-tool hydration remain outside the suppression path.

## User Impact

Telegram and other `message_tool_only` source-reply surfaces should deliver at most one visible reply to the current source conversation for a run, avoiding self-reply cascades and extra model/channel churn while preserving follow-up tool execution.

## Evidence

- `node_modules/.bin/oxfmt --write src/agents/embedded-agent-runner/run/message-tool-terminal.ts src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts`
- `node_modules/.bin/oxlint src/agents/embedded-agent-runner/run/message-tool-terminal.ts src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts`
- `git diff --check`
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm tsgo:core`
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.vitest-cache-96827 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts packages/agent-core/src/agent-loop.test.ts -- --reporter=verbose` - 2 shards passed; `message-tool-terminal.test.ts` 15 tests passed; `agent-loop.test.ts` 22 tests passed.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.vitest-cache-96827-acceptance OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts packages/agent-core/src/agent-loop.test.ts src/agents/embedded-agent-subscribe.handlers.tools.test.ts src/agents/embedded-agent-subscribe.handlers.messages.test.ts extensions/telegram/src/bot-message-dispatch.test.ts -- --reporter=verbose` - 3 shards passed; Telegram dispatch file reported 171 tests passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` - clean, no accepted/actionable findings; overall patch correct.
- Source API QA run against qa-channel + qa-lab bus + real gateway child + mock-openai provider:
  - command shape: `OPENCLAW_BUILD_PRIVATE_QA=1 OPENCLAW_ENABLE_PRIVATE_QA_CLI=1 OPENCLAW_DISABLE_BUNDLED_PLUGINS=0 OPENCLAW_QA_SUITE_PROGRESS=1 node_modules/.bin/tsx --tsconfig tsconfig.json` calling `runQaSuite({ providerMode: "mock-openai", scenarioIds: ["group-visible-reply-tool"], concurrency: 1, fastMode: true, outputDir: ".artifacts/qa-e2e/source-api-group-visible-reply-tool" })`
  - report: `.artifacts/qa-e2e/source-api-group-visible-reply-tool/qa-suite-report.md`
  - summary: `.artifacts/qa-e2e/source-api-group-visible-reply-tool/qa-suite-summary.json`
  - result: passed 1, failed 0; step details `group:qa-visible-tool-room:QA-GROUP-TOOL-OK`
  - scenario assertion in `qa/scenarios/channels/group-visible-reply-tool.yaml` verifies the mock provider planned `message(action=send)` and that the same group transcript contains exactly one outbound visible reply with `QA-GROUP-TOOL-OK`.

Redacted local `message_tool_only` terminal transcript from a temporary `tsx` harness that directly installed `installMessageToolOnlyTerminalHook` around a message tool:

```json
{
  "mode": "message_tool_only",
  "cascadeGuard": {
    "visibleSends": [
      "first visible source reply"
    ],
    "visibleSendCount": 1,
    "duplicateSuppressed": true,
    "laterSuppressedAfterDelivery": true
  },
  "hookFailureRetry": {
    "visibleSends": [
      "hook-failed source reply",
      "successful retry source reply"
    ],
    "visibleSendCount": 2,
    "retryWasSent": true
  }
}
```

Additional follow-up-tool proof: `message-tool-terminal.test.ts` now includes `keeps non-message follow-up tools available after source reply delivery`, which fetches the `read` tool from `agent.state.tools` after `afterToolCall` records source delivery and verifies it still executes. `agent-loop.test.ts` also keeps the core loop contract covered with `continues after a side-effect tool result when afterToolCall records it without terminate`.
