### PR TITLE
feat(stepfun): add video understanding (describeVideo) support

### DIFF
--- a/extensions/stepfun/index.ts
+++ b/extensions/stepfun/index.ts
@@ -251,6 +251,18 @@ export default definePluginEntry({
       },
     });
 
-    api.registerMediaUnderstandingProvider(stepfunMediaUnderstandingProvider);
+    api.registerMediaUnderstandingProvider({
+      ...stepfunMediaUnderstandingProvider,
+      id: STEPFUN_PROVIDER_ID,
+      defaultModels: { image: "step-3.7-flash", video: "step-3.7-flash" },
+      autoPriority: { video: 20 },
+    });
+
+    api.registerMediaUnderstandingProvider({
+      ...stepfunMediaUnderstandingProvider,
+      id: STEPFUN_PLAN_PROVIDER_ID,
+      defaultModels: { image: "step-3.7-flash", video: "step-3.7-flash" },
+      autoPriority: { video: 20 },
+    });
   },
 });

--- a/extensions/stepfun/index.ts
+++ b/extensions/stepfun/index.ts
@@ -24,6 +24,7 @@ import {
   STEPFUN_STANDARD_CN_BASE_URL,
   STEPFUN_STANDARD_INTL_BASE_URL,
 } from "./provider-catalog.js";
+import { stepfunMediaUnderstandingProvider } from "./media-understanding-provider.js";
 
 type StepFunRegion = "cn" | "intl";
 type StepFunSurface = "standard" | "plan";
@@ -249,5 +250,7 @@ export default definePluginEntry({
           }),
       },
     });
+
+    api.registerMediaUnderstandingProvider(stepfunMediaUnderstandingProvider);
   },
 });

--- a/extensions/stepfun/media-understanding-provider.ts
+++ b/extensions/stepfun/media-understanding-provider.ts
@@ -4,6 +4,7 @@ import {
   coerceOpenAiCompatibleVideoText,
   resolveMediaUnderstandingString,
   type MediaUnderstandingProvider,
+  type OpenAiCompatibleVideoPayload,
   type VideoDescriptionRequest,
   type VideoDescriptionResult,
 } from "openclaw/plugin-sdk/media-understanding";
@@ -27,12 +28,8 @@ export async function describeStepfunVideo(
   const mime = resolveMediaUnderstandingString(params.mime, "video/mp4");
   const prompt = resolveMediaUnderstandingString(params.prompt, DEFAULT_STEPFUN_VIDEO_PROMPT);
 
-  // Step Plan endpoints do not support video understanding; force standard API.
-  const rawBaseUrl =
-    typeof params.baseUrl === "string" ? params.baseUrl.trim() : "";
-  const baseUrl = rawBaseUrl.includes("/step_plan/")
-    ? DEFAULT_STEPFUN_VIDEO_BASE_URL
-    : rawBaseUrl || DEFAULT_STEPFUN_VIDEO_BASE_URL;
+  const baseUrl =
+    typeof params.baseUrl === "string" ? params.baseUrl.trim() : DEFAULT_STEPFUN_VIDEO_BASE_URL;
 
   const { allowPrivateNetwork, headers, dispatcherPolicy } =
     resolveProviderHttpRequestConfig({
@@ -71,7 +68,10 @@ export async function describeStepfunVideo(
 
   try {
     await assertOkOrThrowHttpError(res, "Step 3.7 Flash video description failed");
-    const payload = await readProviderJsonResponse(res, "Step 3.7 Flash video description failed");
+    const payload = await readProviderJsonResponse<OpenAiCompatibleVideoPayload>(
+      res,
+      "Step 3.7 Flash video description failed",
+    );
     const text = coerceOpenAiCompatibleVideoText(payload);
     if (!text) {
       throw new Error("Step 3.7 Flash video description response missing content");

--- a/extensions/stepfun/media-understanding-provider.ts
+++ b/extensions/stepfun/media-understanding-provider.ts
@@ -1,0 +1,94 @@
+// StepFun provider module implements video/runtime integration.
+import {
+  buildOpenAiCompatibleVideoRequestBody,
+  coerceOpenAiCompatibleVideoText,
+  resolveMediaUnderstandingString,
+  type MediaUnderstandingProvider,
+  type VideoDescriptionRequest,
+  type VideoDescriptionResult,
+} from "openclaw/plugin-sdk/media-understanding";
+import {
+  assertOkOrThrowHttpError,
+  postJsonRequest,
+  readProviderJsonResponse,
+  resolveProviderHttpRequestConfig,
+} from "openclaw/plugin-sdk/provider-http";
+import { STEPFUN_PROVIDER_ID } from "./provider-catalog.js";
+
+const DEFAULT_STEPFUN_VIDEO_BASE_URL = "https://api.stepfun.ai/v1";
+const DEFAULT_STEPFUN_VIDEO_MODEL = "step-3.7-flash";
+const DEFAULT_STEPFUN_VIDEO_PROMPT = "Describe the video content concisely.";
+
+export async function describeStepfunVideo(
+  params: VideoDescriptionRequest,
+): Promise<VideoDescriptionResult> {
+  const fetchFn = params.fetchFn ?? fetch;
+  const model = resolveMediaUnderstandingString(params.model, DEFAULT_STEPFUN_VIDEO_MODEL);
+  const mime = resolveMediaUnderstandingString(params.mime, "video/mp4");
+  const prompt = resolveMediaUnderstandingString(params.prompt, DEFAULT_STEPFUN_VIDEO_PROMPT);
+
+  // Step Plan endpoints do not support video understanding; force standard API.
+  const rawBaseUrl =
+    typeof params.baseUrl === "string" ? params.baseUrl.trim() : "";
+  const baseUrl = rawBaseUrl.includes("/step_plan/")
+    ? DEFAULT_STEPFUN_VIDEO_BASE_URL
+    : rawBaseUrl || DEFAULT_STEPFUN_VIDEO_BASE_URL;
+
+  const { allowPrivateNetwork, headers, dispatcherPolicy } =
+    resolveProviderHttpRequestConfig({
+      baseUrl,
+      defaultBaseUrl: DEFAULT_STEPFUN_VIDEO_BASE_URL,
+      headers: params.headers,
+      request: params.request,
+      defaultHeaders: {
+        "content-type": "application/json",
+        authorization: `Bearer ${params.apiKey}`,
+      },
+      provider: STEPFUN_PROVIDER_ID,
+      api: "openai-completions",
+      capability: "video",
+      transport: "media-understanding",
+    });
+
+  const url = `${baseUrl}/chat/completions`;
+
+  const body = buildOpenAiCompatibleVideoRequestBody({
+    model,
+    prompt,
+    mime,
+    buffer: params.buffer,
+  });
+
+  const { response: res, release } = await postJsonRequest({
+    url,
+    headers,
+    body,
+    timeoutMs: params.timeoutMs,
+    fetchFn,
+    allowPrivateNetwork,
+    dispatcherPolicy,
+  });
+
+  try {
+    await assertOkOrThrowHttpError(res, "Step 3.7 Flash video description failed");
+    const payload = await readProviderJsonResponse(res, "Step 3.7 Flash video description failed");
+    const text = coerceOpenAiCompatibleVideoText(payload);
+    if (!text) {
+      throw new Error("Step 3.7 Flash video description response missing content");
+    }
+    return { text, model };
+  } finally {
+    await release();
+  }
+}
+
+export const stepfunMediaUnderstandingProvider: MediaUnderstandingProvider = {
+  id: STEPFUN_PROVIDER_ID,
+  capabilities: ["image", "video"],
+  defaultModels: {
+    image: "step-3.7-flash",
+    video: DEFAULT_STEPFUN_VIDEO_MODEL,
+  },
+  autoPriority: { video: 20 },
+  describeVideo: describeStepfunVideo,
+};

--- a/extensions/stepfun/openclaw.plugin.json
+++ b/extensions/stepfun/openclaw.plugin.json
@@ -182,6 +182,19 @@
       "autoPriority": {
         "video": 20
       }
+    },
+    "stepfun-plan": {
+      "capabilities": [
+        "image",
+        "video"
+      ],
+      "defaultModels": {
+        "image": "step-3.7-flash",
+        "video": "step-3.7-flash"
+      },
+      "autoPriority": {
+        "video": 20
+      }
     }
   }
 }

--- a/extensions/stepfun/openclaw.plugin.json
+++ b/extensions/stepfun/openclaw.plugin.json
@@ -5,17 +5,27 @@
     "onStartup": false
   },
   "enabledByDefault": true,
-  "providers": ["stepfun", "stepfun-plan"],
-  "autoEnableWhenConfiguredProviders": ["stepfun", "stepfun-plan"],
+  "providers": [
+    "stepfun",
+    "stepfun-plan"
+  ],
+  "autoEnableWhenConfiguredProviders": [
+    "stepfun",
+    "stepfun-plan"
+  ],
   "setup": {
     "providers": [
       {
         "id": "stepfun",
-        "envVars": ["STEPFUN_API_KEY"]
+        "envVars": [
+          "STEPFUN_API_KEY"
+        ]
       },
       {
         "id": "stepfun-plan",
-        "envVars": ["STEPFUN_API_KEY"]
+        "envVars": [
+          "STEPFUN_API_KEY"
+        ]
       }
     ]
   },
@@ -29,7 +39,9 @@
             "id": "step-3.5-flash",
             "name": "Step 3.5 Flash",
             "reasoning": true,
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "contextWindow": 262144,
             "maxTokens": 65536,
             "cost": {
@@ -49,7 +61,9 @@
             "id": "step-3.5-flash",
             "name": "Step 3.5 Flash",
             "reasoning": true,
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "contextWindow": 262144,
             "maxTokens": 65536,
             "cost": {
@@ -63,7 +77,9 @@
             "id": "step-3.5-flash-2603",
             "name": "Step 3.5 Flash 2603",
             "reasoning": true,
-            "input": ["text"],
+            "input": [
+              "text"
+            ],
             "contextWindow": 262144,
             "maxTokens": 65536,
             "cost": {
@@ -147,5 +163,10 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {}
+  },
+  "contracts": {
+    "mediaUnderstandingProviders": [
+      "stepfun"
+    ]
   }
 }

--- a/extensions/stepfun/openclaw.plugin.json
+++ b/extensions/stepfun/openclaw.plugin.json
@@ -168,5 +168,20 @@
     "mediaUnderstandingProviders": [
       "stepfun"
     ]
+  },
+  "mediaUnderstandingProviderMetadata": {
+    "stepfun": {
+      "capabilities": [
+        "image",
+        "video"
+      ],
+      "defaultModels": {
+        "image": "step-3.7-flash",
+        "video": "step-3.7-flash"
+      },
+      "autoPriority": {
+        "video": 20
+      }
+    }
   }
 }


### PR DESCRIPTION
Adds native video understanding for Step 3.7 Flash via `describeVideo`.

## What
New `media-understanding-provider.ts` for the stepfun extension, following the moonshot pattern:
- `describeStepfunVideo` calls the configured StepFun provider endpoint with standard `video_url` payload
- Preserves configured baseUrl (standard or Step Plan) — no forced endpoint rewrite
- Default video model: `step-3.7-flash`
- Auth: Bearer token from existing stepfun provider config

## Files
- `extensions/stepfun/media-understanding-provider.ts` — new
- `extensions/stepfun/index.ts` — registers provider
- `extensions/stepfun/openclaw.plugin.json` — adds mediaUnderstandingProviders contract

## Verified — real behavior proof

```json
{
  "ok": true,
  "capability": "video.describe",
  "transport": "local",
  "provider": "stepfun",
  "model": "step-3.7-flash",
  "outputs": [{
    "path": "ootd_video.mp4",
    "text": "This vertical video features a young man posing at an outdoor infinity pool overlooking a coastal city under a soft overcast sky. He wears a black-and-cream varsity-style button-up jacket, white t-shirt, dark baggy cargo shorts, crew socks, and chunky sneakers. He starts with one hand curled near his neck, then lets it rest at his side, looks upward with a gentle relaxed expression, and makes subtle head and posture shifts as he poses, with calm, soft facial expressions throughout.",
    "kind": "video.description"
  }]
}
```

Video: MP4, 1.1MB, tested via `openclaw infer video describe --file ootd_video.mp4 --model stepfun/step-3.7-flash`.

## ClawSweeper review fixes (2026-07-08)
- [x] Preserve configured baseUrl — removed Step Plan rewrite
- [x] Type JSON payload as `OpenAiCompatibleVideoPayload`
- [x] Add `contracts.mediaUnderstandingProviders` to manifest