### PR TITLE
fix: stream control UI assistant deltas live

### DIFF
--- a/src/agents/embedded-agent-subscribe.before-terminal-delivery.test.ts
+++ b/src/agents/embedded-agent-subscribe.before-terminal-delivery.test.ts
@@ -8,8 +8,6 @@ import {
 } from "./embedded-agent-subscribe.e2e-harness.js";
 
 function hasAssistantEvent(calls: Array<unknown[]>): boolean {
-  // The gate buffers assistant stream events; tests use this helper to assert
-  // nothing leaks before the terminal decision resolves.
   return calls.some((call) => {
     const event = call[0] as { stream?: string } | undefined;
     return event?.stream === "assistant";
@@ -38,12 +36,12 @@ describe("subscribeEmbeddedAgentSession before terminal delivery", () => {
       blockReplyBreak: "message_end",
     });
 
-    emitMessageStartAndEndForAssistantText({
+    emitAssistantTextDeltaAndEnd({
       emit,
       text: "First answer.",
     });
     expect(onBlockReply).not.toHaveBeenCalled();
-    expect(hasAssistantEvent(onAgentEvent.mock.calls)).toBe(false);
+    expect(hasAssistantEvent(onAgentEvent.mock.calls)).toBe(true);
 
     emit({
       type: "agent_end",
@@ -67,7 +65,12 @@ describe("subscribeEmbeddedAgentSession before terminal delivery", () => {
       }),
     );
     expect(onBlockReply).not.toHaveBeenCalled();
-    expect(hasAssistantEvent(onAgentEvent.mock.calls)).toBe(false);
+    await vi.waitFor(() =>
+      expect(onAgentEvent).toHaveBeenLastCalledWith({
+        stream: "assistant",
+        data: { text: "", delta: "", replace: true },
+      }),
+    );
     expect(hasLifecycleEndEvent(onAgentEvent.mock.calls)).toBe(false);
   });
 
@@ -118,7 +121,7 @@ describe("subscribeEmbeddedAgentSession before terminal delivery", () => {
     expect(onBlockReply).not.toHaveBeenCalled();
   });
 
-  it("defers assistant stream and partial replies until the terminal gate continues", async () => {
+  it("streams provisional assistant events while deferring partial replies", async () => {
     const onAgentEvent = vi.fn();
     const onPartialReply = vi.fn();
     const onBeforeTerminalDelivery = vi.fn(async () => undefined);
@@ -134,7 +137,7 @@ describe("subscribeEmbeddedAgentSession before terminal delivery", () => {
       emit,
       text: "Visible stream.",
     });
-    expect(hasAssistantEvent(onAgentEvent.mock.calls)).toBe(false);
+    expect(hasAssistantEvent(onAgentEvent.mock.calls)).toBe(true);
     expect(onPartialReply).not.toHaveBeenCalled();
 
     emit({
@@ -150,7 +153,9 @@ describe("subscribeEmbeddedAgentSession before terminal delivery", () => {
     });
 
     await subscription.waitForPendingEvents();
-    expect(hasAssistantEvent(onAgentEvent.mock.calls)).toBe(true);
+    expect(
+      onAgentEvent.mock.calls.filter((call) => (call[0] as { stream?: string }).stream === "assistant"),
+    ).toHaveLength(1);
     expect(onPartialReply).toHaveBeenCalled();
     expect(hasLifecycleEndEvent(onAgentEvent.mock.calls)).toBe(true);
   });

--- a/src/agents/embedded-agent-subscribe.before-terminal-delivery.test.ts
+++ b/src/agents/embedded-agent-subscribe.before-terminal-delivery.test.ts
@@ -154,7 +154,9 @@ describe("subscribeEmbeddedAgentSession before terminal delivery", () => {
 
     await subscription.waitForPendingEvents();
     expect(
-      onAgentEvent.mock.calls.filter((call) => (call[0] as { stream?: string }).stream === "assistant"),
+      onAgentEvent.mock.calls.filter(
+        (call) => (call[0] as { stream?: string }).stream === "assistant",
+      ),
     ).toHaveLength(1);
     expect(onPartialReply).toHaveBeenCalled();
     expect(hasLifecycleEndEvent(onAgentEvent.mock.calls)).toBe(true);

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
@@ -80,9 +80,9 @@ function createContext(
     flushBlockReplyBuffer: vi.fn(),
     emitBlockReply,
     emitAssistantStreamData: vi.fn(),
-    flushDeferredAssistantEvents: vi.fn(),
+    flushDeferredAssistantPartialReplies: vi.fn(),
     flushDeferredBlockReplies: vi.fn(),
-    clearDeferredAssistantEvents: vi.fn(),
+    clearDeferredAssistantPartialReplies: vi.fn(),
     clearDeferredBlockReplies: vi.fn(),
     resolveCompactionRetry: vi.fn(),
     maybeResolveCompactionWait: vi.fn(),
@@ -961,9 +961,9 @@ describe("handleAgentEnd", () => {
       expect(logger.error).toHaveBeenCalledWith(
         "[hooks] before_agent_finalize handler from test-plugin failed: timed out after 15000ms",
       );
-      expect(ctx.clearDeferredAssistantEvents).not.toHaveBeenCalled();
+      expect(ctx.clearDeferredAssistantPartialReplies).not.toHaveBeenCalled();
       expect(ctx.clearDeferredBlockReplies).not.toHaveBeenCalled();
-      expect(ctx.flushDeferredAssistantEvents).toHaveBeenCalledTimes(1);
+      expect(ctx.flushDeferredAssistantPartialReplies).toHaveBeenCalledTimes(1);
       expect(ctx.flushDeferredBlockReplies).toHaveBeenCalledTimes(1);
       expect(ctx.flushBlockReplyBuffer).toHaveBeenCalledWith({ final: true });
       expect(ctx.resolveCompactionRetry).toHaveBeenCalledTimes(1);

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.ts
@@ -302,7 +302,7 @@ export function handleAgentEnd(
 
   const deliverTerminal = () => {
     ctx.state.deferBlockReplyDelivery = false;
-    ctx.flushDeferredAssistantEvents();
+    ctx.flushDeferredAssistantPartialReplies();
     ctx.flushDeferredBlockReplies();
     const flushBlockReplyBufferResult = ctx.flushBlockReplyBuffer({ final: true });
     finalizeAgentEnd();
@@ -342,8 +342,13 @@ export function handleAgentEnd(
   };
 
   const suppressTerminalDelivery = () => {
-    ctx.clearDeferredAssistantEvents();
+    ctx.clearDeferredAssistantPartialReplies();
     ctx.clearDeferredBlockReplies();
+    if (ctx.state.emittedAssistantUpdate) {
+      // A finalizer revision starts a new model attempt. Retract the provisional live snapshot
+      // without sending the rejected draft through irreversible partial-reply channels.
+      ctx.emitAssistantStreamData({ text: "", delta: "", replace: true });
+    }
     finalizeAgentEnd();
   };
 

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -60,8 +60,8 @@ type AssistantStreamData = {
   phase?: AssistantPhase;
 };
 
-/** Deferred assistant stream event plus whether it should emit partial replies. */
-type AssistantStreamDelivery = {
+/** Assistant payload deferred only for irreversible partial-reply callbacks. */
+type AssistantPartialReplyDelivery = {
   data: AssistantStreamData;
   emitPartialReply: boolean;
 };
@@ -130,7 +130,7 @@ export type EmbeddedAgentSubscribeState = {
   lastDeliveredBlockReplyText?: string;
   deferBlockReplyDelivery: boolean;
   deferredBlockReplies: BlockReplyPayload[];
-  deferredAssistantEvents: AssistantStreamDelivery[];
+  deferredAssistantPartialReplies: AssistantPartialReplyDelivery[];
   toolExecutionSinceLastBlockReply: boolean;
   reasoningStreamOpen: boolean;
   assistantMessageIndex: number;
@@ -267,9 +267,9 @@ export type EmbeddedAgentSubscribeContext = {
     payload: BlockReplyPayload,
     options?: { assistantMessageIndex?: number; consumePendingToolMedia?: boolean },
   ) => void;
-  flushDeferredAssistantEvents: () => void;
+  flushDeferredAssistantPartialReplies: () => void;
   flushDeferredBlockReplies: () => void;
-  clearDeferredAssistantEvents: () => void;
+  clearDeferredAssistantPartialReplies: () => void;
   clearDeferredBlockReplies: () => void;
 };
 

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -202,7 +202,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     lastDeliveredBlockReplyText: undefined,
     deferBlockReplyDelivery: typeof params.onBeforeTerminalDelivery === "function",
     deferredBlockReplies: [],
-    deferredAssistantEvents: [],
+    deferredAssistantPartialReplies: [],
     toolExecutionSinceLastBlockReply: false,
     reasoningStreamOpen: false,
     assistantMessageIndex: 0,
@@ -275,10 +275,9 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
   const partialReplyDirectiveAccumulator = createStreamingDirectiveAccumulator();
   const shouldAllowSilentTurnText = (text: string | undefined) =>
     Boolean(text && isSilentReplyText(text, SILENT_REPLY_TOKEN));
-  const emitAssistantStreamDataSafely = (
-    delivery: EmbeddedAgentSubscribeContext["state"]["deferredAssistantEvents"][number],
+  const emitAssistantAgentEventSafely = (
+    data: EmbeddedAgentSubscribeContext["state"]["deferredAssistantPartialReplies"][number]["data"],
   ) => {
-    const { data } = delivery;
     emitAgentEvent({
       runId: params.runId,
       stream: "assistant",
@@ -295,7 +294,11 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
           }),
       });
     }
-    if (delivery.emitPartialReply && params.onPartialReply && state.shouldEmitPartialReplies) {
+  };
+  const emitAssistantPartialReplySafely = (
+    data: EmbeddedAgentSubscribeContext["state"]["deferredAssistantPartialReplies"][number]["data"],
+  ) => {
+    if (params.onPartialReply && state.shouldEmitPartialReplies) {
       runBestEffortCallback({
         label: "assistant partial reply",
         log,
@@ -304,27 +307,33 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     }
   };
   const emitAssistantStreamData = (
-    data: EmbeddedAgentSubscribeContext["state"]["deferredAssistantEvents"][number]["data"],
+    data: EmbeddedAgentSubscribeContext["state"]["deferredAssistantPartialReplies"][number]["data"],
     options?: { emitPartialReply?: boolean },
   ) => {
     const delivery = { data, emitPartialReply: options?.emitPartialReply === true };
+    // Agent events are provisional and replaceable, so live consumers can render them while
+    // finalizers run. Only irreversible channel partial replies stay behind the terminal gate.
+    emitAssistantAgentEventSafely(data);
+    if (!delivery.emitPartialReply) {
+      return;
+    }
     if (state.deferBlockReplyDelivery) {
-      state.deferredAssistantEvents.push(delivery);
+      state.deferredAssistantPartialReplies.push(delivery);
       return;
     }
-    emitAssistantStreamDataSafely(delivery);
+    emitAssistantPartialReplySafely(data);
   };
-  const flushDeferredAssistantEvents = () => {
-    if (state.deferredAssistantEvents.length === 0) {
+  const flushDeferredAssistantPartialReplies = () => {
+    if (state.deferredAssistantPartialReplies.length === 0) {
       return;
     }
-    const deferred = state.deferredAssistantEvents.splice(0);
+    const deferred = state.deferredAssistantPartialReplies.splice(0);
     for (const delivery of deferred) {
-      emitAssistantStreamDataSafely(delivery);
+      emitAssistantPartialReplySafely(delivery.data);
     }
   };
-  const clearDeferredAssistantEvents = () => {
-    state.deferredAssistantEvents.length = 0;
+  const clearDeferredAssistantPartialReplies = () => {
+    state.deferredAssistantPartialReplies.length = 0;
   };
   const deferredToolMediaReplies = new WeakSet<BlockReplyPayload>();
   const emitBlockReplySafely = (
@@ -1308,7 +1317,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     state.pendingToolTrustedLocalMedia = false;
     state.visibleBlockReplyCount = 0;
     state.deferBlockReplyDelivery = typeof params.onBeforeTerminalDelivery === "function";
-    clearDeferredAssistantEvents();
+    clearDeferredAssistantPartialReplies();
     clearDeferredBlockReplies();
     state.pendingAssistantReplyDirectives = undefined;
     state.deterministicApprovalPromptPending = false;
@@ -1357,9 +1366,9 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     flushBlockReplyBuffer,
     emitAssistantStreamData,
     emitBlockReply,
-    flushDeferredAssistantEvents,
+    flushDeferredAssistantPartialReplies,
     flushDeferredBlockReplies,
-    clearDeferredAssistantEvents,
+    clearDeferredAssistantPartialReplies,
     clearDeferredBlockReplies,
     emitReasoningStream,
     consumeReplyDirectives,

--- a/src/gateway/live-chat-projector.ts
+++ b/src/gateway/live-chat-projector.ts
@@ -20,17 +20,18 @@ const MAX_LIVE_CHAT_BUFFER_CHARS = 500_000;
 /** Normalizes assistant event payloads that contain a snapshot, a delta, or both. */
 export function resolveAssistantLiveChatInput(
   data: unknown,
-): { text: string; delta: string } | undefined {
+): { text: string; delta: string; replace: boolean } | undefined {
   if (!data || typeof data !== "object") {
     return undefined;
   }
-  const record = data as { text?: unknown; delta?: unknown };
+  const record = data as { text?: unknown; delta?: unknown; replace?: unknown };
   if (typeof record.text !== "string" && typeof record.delta !== "string") {
     return undefined;
   }
   return {
     text: typeof record.text === "string" ? record.text : "",
     delta: typeof record.delta === "string" ? record.delta : "",
+    replace: record.replace === true,
   };
 }
 
@@ -46,8 +47,12 @@ export function resolveMergedAssistantText(params: {
   previousText: string;
   nextText: string;
   nextDelta: string;
+  replace?: boolean;
 }): string {
-  const { previousText, nextText, nextDelta } = params;
+  const { previousText, nextText, nextDelta, replace } = params;
+  if (replace) {
+    return capLiveAssistantBuffer(nextText);
+  }
   if (nextText && previousText) {
     if (nextText.startsWith(previousText) && nextText.length > previousText.length) {
       return capLiveAssistantBuffer(nextText);

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -1338,6 +1338,34 @@ describe("agent event handler", () => {
     nowSpy.mockRestore();
   });
 
+  it("broadcasts an explicit empty replacement immediately", () => {
+    let now = 11_600;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const { broadcast, nodeSendToSession, chatRunState, handler } = createHarness();
+    registerNamedChatRun(chatRunState, "empty-replacement");
+
+    emitAgentEvent(handler, "run-empty-replacement", "assistant", { text: "Rejected draft" });
+
+    now = 11_601;
+    emitAgentEvent(
+      handler,
+      "run-empty-replacement",
+      "assistant",
+      { text: "", delta: "", replace: true },
+      { seq: 2 },
+    );
+
+    const chatCalls = chatBroadcastCalls(broadcast);
+    expect(chatCalls).toHaveLength(2);
+    expect(chatCalls[1]?.[1]).toMatchObject({
+      deltaText: "",
+      replace: true,
+      message: { content: [{ text: "" }] },
+    });
+    expect(sessionChatCalls(nodeSendToSession)).toHaveLength(2);
+    nowSpy.mockRestore();
+  });
+
   it("flushes throttled shorter replacement deltas before final", () => {
     let now = 11_700;
     const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);

--- a/src/gateway/server-chat.stream-text-merge.test.ts
+++ b/src/gateway/server-chat.stream-text-merge.test.ts
@@ -74,6 +74,17 @@ describe("server chat stream text merge", () => {
     expect(replacement).not.toContain(prior);
   });
 
+  it("clears the live buffer for an explicit empty replacement", () => {
+    expect(
+      resolveMergedAssistantText({
+        previousText: "Rejected draft",
+        nextText: "",
+        nextDelta: "",
+        replace: true,
+      }),
+    ).toBe("");
+  });
+
   it("would concatenate superseded text if replacement incorrectly included delta", () => {
     const prior = "coordination draft";
     const buggy = resolveMergedAssistantText({

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -280,7 +280,13 @@ type BroadcastDelta = { deltaText: string; replace?: true };
 function resolveBroadcastDelta(params: {
   text: string;
   previousBroadcastText: string | undefined;
+  replace?: boolean;
 }): BroadcastDelta | undefined {
+  if (params.replace) {
+    return params.text === params.previousBroadcastText
+      ? undefined
+      : { deltaText: params.text, replace: true };
+  }
   if (!params.text) {
     return undefined;
   }
@@ -885,7 +891,7 @@ export function createAgentEventHandler({
     seq: number,
     text: string,
     delta?: unknown,
-    opts?: { controlUiVisible?: boolean },
+    opts?: { controlUiVisible?: boolean; replace?: boolean },
   ) => {
     const run = chatRunState.getOrCreate(clientRunId);
     const previousRawText = run.rawBuffer ?? "";
@@ -893,8 +899,9 @@ export function createAgentEventHandler({
       previousText: previousRawText,
       nextText: text,
       nextDelta: typeof delta === "string" ? delta : "",
+      replace: opts?.replace,
     });
-    if (!mergedRawText) {
+    if (!mergedRawText && !opts?.replace) {
       return;
     }
     const now = Date.now();
@@ -906,19 +913,21 @@ export function createAgentEventHandler({
     const projected = projectLiveAssistantBufferedText(normalizedText);
     const mergedText = projected.text;
     run.buffer = mergedText;
-    if (projected.suppress) {
+    const clearsVisibleText = opts?.replace === true && mergedText.length === 0;
+    if (projected.suppress && !clearsVisibleText) {
       return;
     }
     if (shouldHideHeartbeatChatOutput(clientRunId, sourceRunId)) {
       return;
     }
     const last = run.deltaSentAt ?? 0;
-    if (now - last < 150) {
+    if (!opts?.replace && now - last < 150) {
       return;
     }
     const broadcastDelta = resolveBroadcastDelta({
       text: mergedText,
       previousBroadcastText: run.deltaLastBroadcastText,
+      replace: opts?.replace,
     });
     if (!broadcastDelta) {
       return;
@@ -1621,6 +1630,7 @@ export function createAgentEventHandler({
           assistantLiveChatInput.delta,
           {
             controlUiVisible: isControlUiVisible,
+            replace: assistantLiveChatInput.replace,
           },
         );
       }


### PR DESCRIPTION
## What Problem This Solves

Control UI/WebChat consume assistant snapshots from the live agent event bus. Embedded runs currently put those replaceable events behind the same `before_agent_finalize` terminal gate as irreversible channel replies, so assistant text arrives only after the run ends whenever a finalizer is installed.

## Design

- Emit replaceable assistant agent events immediately. These events are provisional UI state, not committed channel delivery.
- Keep `onPartialReply` and block replies behind the terminal gate, preserving the existing safety contract for Telegram and other irreversible surfaces.
- When `before_agent_finalize` requests a revision, emit an empty `replace: true` snapshot before the next model attempt. This retracts the rejected draft while retaining the reasoning/tool timeline.
- Propagate explicit replacements through the Gateway live-chat projector, including empty replacements, so Control UI/WebChat and direct agent-event consumers converge on the same state.
- Apply the policy at the subscription boundary. Direct runs and queued followups need no caller-specific flags.

No provider changes or protocol schema changes are required; this uses the existing assistant snapshot and `replace` semantics.

## Safety Boundary

The UI may render provisional text while a finalizer is running. A rejecting finalizer retracts that text before retry. Irreversible partial/block reply callbacks never receive the rejected draft.

## Evidence

- Focused Vitest run: 6 files, 245 tests passed across terminal-gate lifecycle and Gateway agent-event projection.
- `git diff --check` passed.
- The regression suite covers live provisional delivery, deferred partial replies, revision retraction, explicit empty replacement, and replacement delivery without throttle delay.
- Live Control UI/WebChat proof is still pending.
