### PR TITLE
fix(telegram): wrap bare URLs on HTML text path so query-string & survives (#102162)

### DIFF
--- a/extensions/telegram/src/format.bare-url.test.ts
+++ b/extensions/telegram/src/format.bare-url.test.ts
@@ -1,0 +1,70 @@
+// Regression coverage for #102162: bare URLs on the Telegram HTML text path
+// (textMode: "html") must be wrapped in explicit anchors so the query-string
+// `&` lives in the href — which Telegram decodes when navigating — instead of a
+// literal `&amp;` in auto-linked visible text that breaks multi-parameter URLs.
+import { describe, expect, it } from "vitest";
+import {
+  linkifyBareTelegramHtmlUrls,
+  markdownToTelegramHtml,
+  normalizeTelegramOutboundRichHtml,
+  renderTelegramHtmlText,
+} from "./format.js";
+
+const MULTI_PARAM_URL = "https://example.com/wp-admin/post.php?post=100&action=edit";
+const MULTI_PARAM_HREF = "https://example.com/wp-admin/post.php?post=100&amp;action=edit";
+const ANCHORED = `<a href="${MULTI_PARAM_HREF}">${MULTI_PARAM_HREF}</a>`;
+
+describe("bare URL linkification on the Telegram HTML text path (#102162)", () => {
+  it("wraps a bare multi-parameter URL so & rides in the href, not visible text", () => {
+    expect(renderTelegramHtmlText(MULTI_PARAM_URL, { textMode: "html" })).toBe(ANCHORED);
+  });
+
+  it("wraps bare URLs embedded in surrounding text", () => {
+    expect(renderTelegramHtmlText(`See ${MULTI_PARAM_URL} now`, { textMode: "html" })).toBe(
+      `See ${ANCHORED} now`,
+    );
+  });
+
+  it("also wraps on the rich outbound normalization path", () => {
+    expect(normalizeTelegramOutboundRichHtml(MULTI_PARAM_URL).html).toBe(ANCHORED);
+    // Idempotent when the caller already HTML-escaped the ampersand.
+    expect(normalizeTelegramOutboundRichHtml(MULTI_PARAM_HREF).html).toBe(ANCHORED);
+  });
+
+  it("leaves the markdown path (which already linkifies) unchanged", () => {
+    expect(markdownToTelegramHtml(MULTI_PARAM_URL)).toBe(ANCHORED);
+  });
+
+  it("does not double-wrap a URL that is already an anchor", () => {
+    const html = `<a href="${MULTI_PARAM_HREF}">click</a>`;
+    expect(linkifyBareTelegramHtmlUrls(html)).toBe(html);
+  });
+
+  it("does not linkify URLs inside <code> or <pre>", () => {
+    const code = `<code>${MULTI_PARAM_HREF}</code>`;
+    expect(linkifyBareTelegramHtmlUrls(code)).toBe(code);
+    const pre = `<pre>${MULTI_PARAM_HREF}</pre>`;
+    expect(linkifyBareTelegramHtmlUrls(pre)).toBe(pre);
+  });
+
+  it("does not linkify a URL inside an escaped (unsupported) tag's attribute", () => {
+    const escapedImg = '&lt;img src="https://example.com/diagram.png"&gt;';
+    expect(linkifyBareTelegramHtmlUrls(escapedImg)).toBe(escapedImg);
+  });
+
+  it("keeps trailing sentence punctuation outside the link", () => {
+    const url = "https://example.com/a?x=1&y=2";
+    const href = "https://example.com/a?x=1&amp;y=2";
+    expect(renderTelegramHtmlText(`Go to ${url}.`, { textMode: "html" })).toBe(
+      `Go to <a href="${href}">${href}</a>.`,
+    );
+  });
+
+  it("stops the link at an escaped angle bracket following the URL", () => {
+    // `https://x.example` then an escaped `<br>` that is not part of the URL.
+    const input = "https://x.example&lt;br&gt;";
+    expect(linkifyBareTelegramHtmlUrls(input)).toBe(
+      '<a href="https://x.example">https://x.example</a>&lt;br&gt;',
+    );
+  });
+});

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -731,6 +731,108 @@ export function wrapFileReferencesInHtml(html: string): string {
   return result;
 }
 
+// A bare `http(s)` URL run inside already-escaped Telegram HTML. `&` appears as
+// `&amp;` (a legitimate part of the run), while a literal `<`, `>`, or `"` can
+// never occur in a URL, so they bound the match; escaped angle brackets
+// (`&lt;`/`&gt;`) are trimmed separately below.
+const TELEGRAM_BARE_URL_PATTERN = /https?:\/\/[^\s<>"']+/gi;
+// HTML entities that cannot be part of a URL and therefore terminate a bare-URL run.
+const TELEGRAM_URL_TERMINATING_ENTITY_PATTERN = /&(?:lt|gt|quot|#\d+|#x[0-9a-fA-F]+);/;
+
+function wrapBareUrlInTelegramAnchor(rawUrl: string): string {
+  // Stop the link at the first escaped `<`/`>`/`"`; keep the remainder as text.
+  const terminating = TELEGRAM_URL_TERMINATING_ENTITY_PATTERN.exec(rawUrl);
+  let url = terminating ? rawUrl.slice(0, terminating.index) : rawUrl;
+  const rest = terminating ? rawUrl.slice(terminating.index) : "";
+  // Keep trailing sentence punctuation outside the link (mirrors markdown linkify).
+  let suffix = "";
+  const trailing = /[.,!?]+$/.exec(url);
+  if (trailing) {
+    suffix = trailing[0];
+    url = url.slice(0, url.length - suffix.length);
+  }
+  if (!/^https?:\/\/\S/i.test(url)) {
+    return rawUrl;
+  }
+  // `url` is already HTML-escaped, so `&amp;` is valid both as the href value
+  // (Telegram decodes it back to `&` when navigating) and as the visible label.
+  return `<a href="${url}">${url}</a>${suffix}${rest}`;
+}
+
+// Escaped (unsupported) HTML tags survive as `&lt;...&gt;` plain text; their
+// attribute URLs (e.g. an escaped `<img src="...">`) must not be linked.
+const TELEGRAM_ESCAPED_TAG_SPAN_PATTERN = /(&lt;\/?[a-zA-Z][^]*?&gt;)/;
+
+function wrapSegmentBareUrls(
+  text: string,
+  codeDepth: number,
+  preDepth: number,
+  anchorDepth: number,
+): string {
+  if (!text || codeDepth > 0 || preDepth > 0 || anchorDepth > 0) {
+    return text;
+  }
+  return text
+    .split(TELEGRAM_ESCAPED_TAG_SPAN_PATTERN)
+    .map((piece, index) => {
+      // Odd indices are the captured escaped-tag spans; leave them untouched.
+      if (index % 2 === 1) {
+        return piece;
+      }
+      TELEGRAM_BARE_URL_PATTERN.lastIndex = 0;
+      return piece.replace(TELEGRAM_BARE_URL_PATTERN, wrapBareUrlInTelegramAnchor);
+    })
+    .join("");
+}
+
+/**
+ * Wraps bare `http(s)` URLs that reach the Telegram HTML text path unlinked
+ * (textMode: "html") in explicit `<a>` anchors. Without this, Telegram's client
+ * auto-links the visible text, and an escaped `&amp;` in a query string is
+ * navigated to literally — dropping later parameters and sending the tap to the
+ * wrong destination (#102162). URLs already inside <a>, <code>, or <pre> are
+ * left untouched, and href attributes live inside tag tokens, so they are never
+ * re-wrapped.
+ */
+export function linkifyBareTelegramHtmlUrls(html: string): string {
+  let codeDepth = 0;
+  let preDepth = 0;
+  let anchorDepth = 0;
+  let result = "";
+  let lastIndex = 0;
+
+  HTML_TAG_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = HTML_TAG_PATTERN.exec(html)) !== null) {
+    const tagStart = match.index;
+    const tagEnd = HTML_TAG_PATTERN.lastIndex;
+    const isClosing = match[1] === "</";
+    const tagName = normalizeLowercaseStringOrEmpty(match[2]);
+
+    result += wrapSegmentBareUrls(
+      html.slice(lastIndex, tagStart),
+      codeDepth,
+      preDepth,
+      anchorDepth,
+    );
+
+    if (tagName === "code") {
+      codeDepth = isClosing ? Math.max(0, codeDepth - 1) : codeDepth + 1;
+    } else if (tagName === "pre") {
+      preDepth = isClosing ? Math.max(0, preDepth - 1) : preDepth + 1;
+    } else if (tagName === "a") {
+      anchorDepth = isClosing ? Math.max(0, anchorDepth - 1) : anchorDepth + 1;
+    }
+
+    result += html.slice(tagStart, tagEnd);
+    lastIndex = tagEnd;
+  }
+
+  result += wrapSegmentBareUrls(html.slice(lastIndex), codeDepth, preDepth, anchorDepth);
+
+  return result;
+}
+
 export function renderTelegramHtmlText(
   text: string,
   options: { textMode?: "markdown" | "html"; tableMode?: MarkdownTableMode } = {},
@@ -749,15 +851,17 @@ export function normalizeTelegramOutboundRichHtml(
   const tableNormalized = normalizeTelegramRichHtmlTables(html);
   // This is the Bot API 10.1 rich-message wire contract. A second send-side
   // sanitizer would let raw tables or silent drops drift between send funnels.
-  const safeHtml = limitTelegramRichHtmlNesting(
-    materializeTelegramRichHtmlLineBreaks(
-      normalizeTelegramRichLiteralWhitespaceEscapes(
-        isolateTelegramRichMediaBlocks(
-          escapeUnsupportedTelegramHtml(tableNormalized.html, TELEGRAM_RICH_HTML_TAG_SUPPORT),
+  const safeHtml = linkifyBareTelegramHtmlUrls(
+    limitTelegramRichHtmlNesting(
+      materializeTelegramRichHtmlLineBreaks(
+        normalizeTelegramRichLiteralWhitespaceEscapes(
+          isolateTelegramRichMediaBlocks(
+            escapeUnsupportedTelegramHtml(tableNormalized.html, TELEGRAM_RICH_HTML_TAG_SUPPORT),
+          ),
         ),
       ),
+      TELEGRAM_RICH_NESTING_LIMIT,
     ),
-    TELEGRAM_RICH_NESTING_LIMIT,
   );
   return {
     html: safeHtml,
@@ -766,9 +870,11 @@ export function normalizeTelegramOutboundRichHtml(
 }
 
 function escapeUnsupportedTelegramHtmlWithTableFallback(html: string): string {
-  return escapeUnsupportedTelegramHtml(
-    normalizeTelegramLegacyHtmlTables(html),
-    TELEGRAM_LEGACY_HTML_TAG_SUPPORT,
+  return linkifyBareTelegramHtmlUrls(
+    escapeUnsupportedTelegramHtml(
+      normalizeTelegramLegacyHtmlTables(html),
+      TELEGRAM_LEGACY_HTML_TAG_SUPPORT,
+    ),
   );
 }
 


### PR DESCRIPTION
## What this fixes

Closes #102162.

Bare `http(s)` URLs sent through the Telegram **HTML text path** (`textMode: "html"`) are delivered as escaped plain text instead of anchors. `escapeUnsupportedTelegramHtml` correctly turns `&` into `&amp;` so the payload is valid HTML, but nothing wraps the URL in an `<a>` tag. Telegram's client then auto-links the **visible** text and navigates to the literal `&amp;`, so a multi-parameter URL like:

```
https://example.com/wp-admin/post.php?post=100&action=edit
```

is opened as `...post=100&amp;action=edit` — the `action` parameter is lost and the tap lands on the wrong page. This affects any bare URL with more than one query parameter.

## Root cause

The **markdown** path already linkifies bare URLs (markdown-it `linkify` → link span → `buildTelegramLink`), so the `&` ends up in the `href`, which Telegram decodes correctly when navigating. Two HTML-text funnels never got that treatment and shipped the URL as bare escaped text:

- `renderTelegramHtmlText(text, { textMode: "html" })` → `escapeUnsupportedTelegramHtmlWithTableFallback` (used e.g. by the `parseMode: "HTML"` outbound adapter and reply/caption paths)
- `normalizeTelegramOutboundRichHtml` (the `richMessages: true` path)

Both were confirmed by exercising the formatter directly on the reported URL: each returned `https://…?post=100&amp;action=edit` with no `<a>` wrapper.

## The fix

`linkifyBareTelegramHtmlUrls(html)` walks the already-escaped HTML token by token (reusing the existing tag-tracking approach from `wrapFileReferencesInHtml`) and wraps bare URLs found in plain-text regions in `<a href="URL">URL</a>`. Because the text is already HTML-escaped, `&amp;` is valid both as the `href` value (Telegram decodes it to `&` for navigation) and as the visible label.

It is applied at the two HTML-text funnels above. Guards:

- URLs already inside `<a>`, `<code>`, or `<pre>` are left untouched (depth tracking).
- `href` attributes live inside tag tokens, so they are never re-wrapped.
- URLs inside **escaped** (unsupported) tags — e.g. `&lt;img src="https://…"&gt;` — are skipped, so an escaped tag's attribute is not turned into a nested anchor.
- Trailing sentence punctuation (`. , ! ?`) and escaped angle brackets after a URL stay outside the link.

The markdown path is unchanged (it already produced anchors).

## Tests

New `extensions/telegram/src/format.bare-url.test.ts` (9 cases): the core fix on both funnels, no-double-wrap on existing anchors, no linkify inside `<code>`/`<pre>` or escaped-tag attributes, markdown parity, trailing punctuation, and the escaped-angle-bracket boundary.

Full Telegram format/send/rich suites pass (266 existing + 9 new = 275), including the pre-existing "escapes HTML media tags on the text path" test that guards the escaped-`<img>` case.
