### PR TITLE
fix(sessions-spawn): reject streamTo with runtime="subagent" instead of silent ignore

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -869,29 +869,20 @@ describe("sessions_spawn tool", () => {
     expect(spawnArgs.resumeSessionId).toBe("7f4a78e0-f6be-43fe-855c-c1c4fd229bc4");
   });
 
-  it("ignores ACP-only fields for subagent spawns", async () => {
+  it("rejects streamTo when runtime is subagent", async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",
     });
 
-    const result = await tool.execute("call-guard", {
-      runtime: "subagent",
-      task: "resume prior work",
-      resumeSessionId: "7f4a78e0-f6be-43fe-855c-c1c4fd229bc4",
-      streamTo: "parent",
-    });
-
-    expectDetailFields(result.details, {
-      status: "accepted",
-      childSessionKey: "agent:main:subagent:1",
-      runId: "run-subagent",
-    });
-    const spawnArgs = mockCallArg(hoisted.spawnSubagentDirectMock, 0, 0, "spawnSubagentDirect");
-    expect(spawnArgs.task).toBe("resume prior work");
-    const spawnContext = mockCallArg(hoisted.spawnSubagentDirectMock, 0, 1, "spawnSubagentDirect");
-    expect(spawnContext.agentSessionKey).toBe("agent:main:main");
-    expect(spawnArgs).not.toHaveProperty("resumeSessionId");
-    expect(spawnArgs).not.toHaveProperty("streamTo");
+    await expect(
+      tool.execute("call-guard", {
+        runtime: "subagent",
+        task: "resume prior work",
+        resumeSessionId: "7f4a78e0-f6be-43fe-855c-c1c4fd229bc4",
+        streamTo: "parent",
+      }),
+    ).rejects.toThrow('streamTo is only supported for runtime="acp"; got runtime="subagent"');
+    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
   });
 
@@ -1016,27 +1007,20 @@ describe("sessions_spawn tool", () => {
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
   });
 
-  it('ignores streamTo when runtime is omitted and defaults to "subagent"', async () => {
+  it('rejects streamTo when runtime is omitted and defaults to "subagent"', async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",
     });
 
-    const result = await tool.execute("call-3b", {
-      task: "analyze file",
-      resumeSessionId: "7f4a78e0-f6be-43fe-855c-c1c4fd229bc4",
-      streamTo: "parent",
-    });
-
-    expectDetailFields(result.details, {
-      status: "accepted",
-      childSessionKey: "agent:main:subagent:1",
-      runId: "run-subagent",
-    });
+    await expect(
+      tool.execute("call-3b", {
+        task: "analyze file",
+        resumeSessionId: "7f4a78e0-f6be-43fe-855c-c1c4fd229bc4",
+        streamTo: "parent",
+      }),
+    ).rejects.toThrow('streamTo is only supported for runtime="acp"; got runtime="subagent"');
+    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
-    const spawnArgs = mockCallArg(hoisted.spawnSubagentDirectMock, 0, 0, "spawnSubagentDirect");
-    expect(spawnArgs.task).toBe("analyze file");
-    expect(spawnArgs).not.toHaveProperty("resumeSessionId");
-    expect(spawnArgs).not.toHaveProperty("streamTo");
   });
 
   it('treats model="default" as no explicit model override', async () => {

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -322,6 +322,11 @@ export function createSessionsSpawnTool(
       const sandbox = params.sandbox === "require" ? "require" : "inherit";
       const context =
         params.context === "fork" || params.context === "isolated" ? params.context : undefined;
+      if (runtime === "subagent" && params.streamTo != null) {
+        throw new ToolInputError(
+          `streamTo is only supported for runtime="acp"; got runtime="subagent". Remove streamTo or switch to runtime="acp".`,
+        );
+      }
       const streamTo = runtime === "acp" && params.streamTo === "parent" ? "parent" : undefined;
       const lightContext = params.lightContext === true;
       const roleContext = requestedAgentId ? { role: requestedAgentId } : {};


### PR DESCRIPTION
## Problem

When `streamTo` is passed alongside `runtime="subagent"` (or when runtime defaults to subagent), the tool silently dropped the field and returned `status:"accepted"`. LLMs relied on the accepted response as confirmation the call was valid, leading to repeated misuse — the stream never arrived, and the model had no feedback loop to self-correct.

Reported in: #63120, #53016, #41780, #43559

## Fix

Throw a `ToolInputError` with a clear, actionable message before any spawn happens:

```
streamTo is only supported for runtime="acp"; got runtime="subagent".
Remove streamTo or switch to runtime="acp".
```

This surfaces at the tool-call layer, so the LLM sees the error in the same turn and can retry without `streamTo` or explicitly switch to `runtime="acp"`.

## Changes

- `src/agents/tools/sessions-spawn-tool.ts` — adds a `ToolInputError` guard when `runtime !== "acp"` and `streamTo` is present
- `src/agents/tools/sessions-spawn-tool.test.ts` — two tests updated from "silently ignored" → "rejects with error"; assertions added that neither spawn path fires on rejected calls

## Tests

```
pnpm vitest run src/agents/tools/sessions-spawn-tool.test.ts
# 106 passed (106) ✓
```

## Notes

- `resumeSessionId` (the other ACP-only field in the same schema block) is not guarded here intentionally — providing it for a subagent spawn already silently no-ops without causing user-visible harm. `streamTo` is the one that causes repeated misuse because the model expects a streaming side-effect.
- Schema description for `streamTo` already says `ACP-only stream target; ignored for runtime="subagent"` — this PR makes the runtime behaviour match the description (i.e., it is no longer silently ignored, it is rejected).