### PR TITLE
fix(feishu): report bot identity retry failures

### DIFF
--- a/extensions/feishu/src/monitor.bot-identity.rejection.test.ts
+++ b/extensions/feishu/src/monitor.bot-identity.rejection.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime-api.js";
+import { startBotIdentityRecovery } from "./monitor.bot-identity.js";
+
+const fetchBotIdentityForMonitorMock = vi.hoisted(() => vi.fn());
+const setFeishuBotIdentityStateMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./monitor.startup.js", () => ({
+  fetchBotIdentityForMonitor: fetchBotIdentityForMonitorMock,
+}));
+
+vi.mock("./monitor.state.js", () => ({
+  setFeishuBotIdentityState: setFeishuBotIdentityStateMock,
+}));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  fetchBotIdentityForMonitorMock.mockReset();
+  setFeishuBotIdentityStateMock.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("Feishu bot identity retry failures", () => {
+  it("reports a rejected background retry without leaking an unhandled rejection", async () => {
+    fetchBotIdentityForMonitorMock.mockRejectedValueOnce(new Error("probe exploded"));
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    } satisfies RuntimeEnv;
+    const unhandled: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandledRejection);
+
+    try {
+      startBotIdentityRecovery({
+        account: {
+          accountId: "person-2",
+          appId: "cli_person_2",
+          appSecret: "secret_person_2", // pragma: allowlist secret
+        } as never,
+        accountId: "person-2",
+        runtime,
+      });
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      const nextTurn = new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      await nextTurn;
+
+      expect(fetchBotIdentityForMonitorMock).toHaveBeenCalledTimes(1);
+      expect(runtime.error).toHaveBeenCalledTimes(1);
+      expect(runtime.error).toHaveBeenCalledWith(
+        "feishu[person-2]: bot identity background retry failed unexpectedly: Error: probe exploded",
+      );
+      expect(setFeishuBotIdentityStateMock).not.toHaveBeenCalled();
+      expect(unhandled).toStrictEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+  });
+
+  it("stops an aborted retry without probing or reporting an error", async () => {
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    } satisfies RuntimeEnv;
+    const controller = new AbortController();
+
+    startBotIdentityRecovery({
+      account: {
+        accountId: "person-2",
+        appId: "cli_person_2",
+        appSecret: "secret_person_2", // pragma: allowlist secret
+      } as never,
+      accountId: "person-2",
+      runtime,
+      abortSignal: controller.signal,
+    });
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(fetchBotIdentityForMonitorMock).not.toHaveBeenCalled();
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(setFeishuBotIdentityStateMock).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/extensions/feishu/src/monitor.bot-identity.ts
+++ b/extensions/feishu/src/monitor.bot-identity.ts
@@ -88,5 +88,9 @@ export function startBotIdentityRecovery(params: {
     );
   }
 
-  void retryBotIdentityProbe(account, accountId, runtime, abortSignal);
+  void retryBotIdentityProbe(account, accountId, runtime, abortSignal).catch((err: unknown) => {
+    (runtime?.error ?? console.error)(
+      `feishu[${accountId}]: bot identity background retry failed unexpectedly: ${String(err)}`,
+    );
+  });
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an unexpected failure during Feishu background bot-identity recovery could escape as an unhandled promise rejection without an operator-visible diagnostic.

## Why This Change Was Made

The Feishu recovery launcher now observes the detached retry task at its ownership boundary and reports unexpected terminal failures through `runtime.error`.

The branch was rewritten as one signed commit on current `main`. The obsolete Telegram acknowledgement edit and redundant Feishu typing-reaction edits from the original branch are not present.

## User Impact

Feishu operators receive one diagnostic if background bot-identity recovery crashes unexpectedly, instead of risking an unhandled rejection. Successful recovery and cancellation behavior are unchanged.

## Evidence

- Exact refreshed head: `064c0f10073ce9664990121399bb48400525407e`
- Focused Feishu identity and rejection/abort tests: 3/3 passed three consecutive runs.
- Targeted oxlint, oxfmt, and `git diff --check`: passed.
- Exact-head autoreview: no P0/P1 findings; patch judged correct with 0.97 confidence.
- Hosted exact-head CI: running. The prior head passed build artifacts and every selected gate except one test-only `no-promise-executor-return` lint finding; this head fixes that expression without changing production code.
- Diff: two Feishu files, `+101/-1`; no config, package, lockfile, workflow, Telegram, or unrelated plugin changes.

Controlled fault injection exercised the real production launcher and runtime logger without module mocks. A throwing `AbortSignal.aborted` getter forced the detached retry to reject at its ownership boundary:

```json
{
  "logs": [
    "feishu[proof-account]: bot open_id unknown; starting background provider refresh (delays: 60s, 120s, 300s, 600s, 900s)",
    "feishu[proof-account]: requireMention group messages stay gated until bot identity recovery succeeds"
  ],
  "errors": [
    "feishu[proof-account]: bot identity background retry failed unexpectedly: Error: controlled retry fault"
  ],
  "unhandled": []
}
```

Normal provider and network failures are intentionally handled lower in `probeFeishu`; this controlled internal fault is the reachable proof for the unexpected-rejection safeguard.

Contributor credit is preserved through the commit co-author trailer.
