### PR TITLE
fix(anthropic): don't crash models list when a configured Sonnet 5 model has no cost

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-52c7a8b045ee89b62266910d1d2db6a379c696ed514aeaa7ca3c6f0dbcc3ff67  plugin-sdk-api-baseline.json
-a703333cefbf3b36cc826965592a8de3542ac91cfe9cd8c5447cb748407fece3  plugin-sdk-api-baseline.jsonl
+6e7f42fbac908f7d80fa6af6ae1d65c6550f1235df19e2170223dd469536a76b  plugin-sdk-api-baseline.json
+19c0e0458c782ce08f7405a789b99c28f93161b1667650890028feef3848d40b  plugin-sdk-api-baseline.jsonl

--- a/extensions/amazon-bedrock-mantle/index.test.ts
+++ b/extensions/amazon-bedrock-mantle/index.test.ts
@@ -86,35 +86,38 @@ describe("amazon-bedrock-mantle provider plugin", () => {
     ).toBeUndefined();
   });
 
-  it("refreshes Sonnet 5 pricing during runtime normalization", async () => {
+  it("restores missing or stale Sonnet 5 pricing during runtime normalization", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(Date.UTC(2026, 8, 1));
     try {
       const provider = await registerSingleProviderPlugin(bedrockMantlePlugin);
-      const normalized = provider.normalizeResolvedModel?.({
+      const model = {
+        id: "anthropic.claude-sonnet-5",
+        name: "Claude Sonnet 5",
+        api: "anthropic-messages",
         provider: "amazon-bedrock-mantle",
-        modelId: "anthropic.claude-sonnet-5",
-        model: {
-          id: "anthropic.claude-sonnet-5",
-          name: "Claude Sonnet 5",
-          api: "anthropic-messages",
-          provider: "amazon-bedrock-mantle",
-          baseUrl: "https://bedrock-mantle.us-east-1.api.aws/anthropic",
-          reasoning: true,
-          input: ["text", "image"],
-          cost: { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 },
-          contextWindow: 1_000_000,
-          maxTokens: 128_000,
-          params: { canonicalModelId: "claude-sonnet-5" },
-        },
-      } as never);
-
-      expect(normalized?.cost).toEqual({
+        baseUrl: "https://bedrock-mantle.us-east-1.api.aws/anthropic",
+        reasoning: true,
+        input: ["text", "image"],
+        contextWindow: 1_000_000,
+        maxTokens: 128_000,
+        params: { canonicalModelId: "claude-sonnet-5" },
+      };
+      const expectedCost = {
         input: 3,
         output: 15,
         cacheRead: 0.3,
         cacheWrite: 3.75,
-      });
+      };
+
+      for (const cost of [undefined, { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 }]) {
+        const normalized = provider.normalizeResolvedModel?.({
+          provider: "amazon-bedrock-mantle",
+          modelId: "anthropic.claude-sonnet-5",
+          model: { ...model, cost },
+        } as never);
+        expect(normalized?.cost).toEqual(expectedCost);
+      }
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/amazon-bedrock-mantle/register.sync.runtime.ts
+++ b/extensions/amazon-bedrock-mantle/register.sync.runtime.ts
@@ -5,7 +5,10 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolvePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
 import type { OpenClawPluginApi, ProviderRuntimeModel } from "openclaw/plugin-sdk/plugin-entry";
-import { resolveClaudeSonnet5ModelIdentity } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  modelCostsEqual,
+  resolveClaudeSonnet5ModelIdentity,
+} from "openclaw/plugin-sdk/provider-model-shared";
 import {
   mergeImplicitMantleProvider,
   resolveImplicitMantleProvider,
@@ -32,12 +35,7 @@ function normalizeMantleResolvedModel(params: {
     return undefined;
   }
   const cost = resolveMantleSonnet5Cost();
-  if (
-    params.model.cost.input === cost.input &&
-    params.model.cost.output === cost.output &&
-    params.model.cost.cacheRead === cost.cacheRead &&
-    params.model.cost.cacheWrite === cost.cacheWrite
-  ) {
+  if (modelCostsEqual(params.model.cost, cost)) {
     return undefined;
   }
   return { ...params.model, cost };

--- a/extensions/anthropic-vertex/index.test.ts
+++ b/extensions/anthropic-vertex/index.test.ts
@@ -146,36 +146,42 @@ describe("anthropic-vertex provider plugin", () => {
     });
   });
 
-  it("refreshes Sonnet 5 pricing during runtime normalization", async () => {
+  it("restores missing or stale Sonnet 5 pricing during runtime normalization", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(Date.UTC(2026, 8, 1));
     try {
       const provider = await registerSingleProviderPlugin(anthropicVertexPlugin);
-      const normalized = provider.normalizeResolvedModel?.({
+      const model = {
+        id: "claude-sonnet-5",
+        name: "Claude Sonnet 5",
+        api: "anthropic-messages",
         provider: "anthropic-vertex",
-        modelId: "claude-sonnet-5",
-        model: {
-          id: "claude-sonnet-5",
-          name: "Claude Sonnet 5",
-          api: "anthropic-messages",
-          provider: "anthropic-vertex",
-          baseUrl: "https://us-aiplatform.googleapis.com",
-          reasoning: true,
-          input: ["text", "image"],
-          cost: { input: 2.2, output: 11, cacheRead: 0.22, cacheWrite: 2.75 },
-          contextWindow: 1_000_000,
-          contextTokens: 1_000_000,
-          maxTokens: 128_000,
-          thinkingLevelMap: { xhigh: "xhigh", max: "max" },
-        },
-      } as never);
-
-      expect(normalized?.cost).toEqual({
+        baseUrl: "https://us-aiplatform.googleapis.com",
+        reasoning: true,
+        input: ["text", "image"],
+        contextWindow: 1_000_000,
+        contextTokens: 1_000_000,
+        maxTokens: 128_000,
+        thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+      };
+      const expectedCost = {
         input: 3.3,
         output: 16.5,
         cacheRead: 0.33,
         cacheWrite: 4.125,
-      });
+      };
+
+      for (const cost of [
+        undefined,
+        { input: 2.2, output: 11, cacheRead: 0.22, cacheWrite: 2.75 },
+      ]) {
+        const normalized = provider.normalizeResolvedModel?.({
+          provider: "anthropic-vertex",
+          modelId: "claude-sonnet-5",
+          model: { ...model, cost },
+        } as never);
+        expect(normalized?.cost).toEqual(expectedCost);
+      }
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/anthropic-vertex/provider-catalog.ts
+++ b/extensions/anthropic-vertex/provider-catalog.ts
@@ -8,6 +8,7 @@ import type {
   ModelProviderConfig,
 } from "openclaw/plugin-sdk/provider-model-shared";
 import {
+  modelCostsEqual,
   resolveClaudeFable5ModelIdentity,
   resolveClaudeMythos5ModelIdentity,
   resolveClaudeSonnet5ModelIdentity,
@@ -172,12 +173,7 @@ export function normalizeAnthropicVertexResolvedModel(
   const cost = sonnet5
     ? resolveSonnet5Cost(resolveAnthropicVertexClientRegion({ baseUrl: model.baseUrl }))
     : undefined;
-  const costMatches =
-    !cost ||
-    (model.cost.input === cost.input &&
-      model.cost.output === cost.output &&
-      model.cost.cacheRead === cost.cacheRead &&
-      model.cost.cacheWrite === cost.cacheWrite);
+  const costMatches = !cost || modelCostsEqual(model.cost, cost);
   if (
     model.reasoning &&
     input === model.input &&

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -696,6 +696,28 @@ describe("anthropic provider replay hooks", () => {
     });
   });
 
+  it("normalizes a Sonnet 5 model without cost metadata instead of crashing", async () => {
+    const provider = await registerSingleProviderPlugin(anthropicPlugin);
+    const resolved = provider.resolveDynamicModel?.({
+      provider: "anthropic",
+      modelId: "claude-sonnet-5",
+      modelRegistry: createModelRegistry([]),
+    } as ProviderResolveDynamicModelContext);
+
+    const costlessModel = {
+      ...(resolved as ProviderRuntimeModel),
+      cost: undefined,
+    } as unknown as ProviderRuntimeModel;
+    const normalized = provider.normalizeResolvedModel?.({
+      provider: "anthropic",
+      modelId: "claude-sonnet-5",
+      model: costlessModel,
+    } as never);
+    // Compare against the resolver's own cost so the assertion survives the
+    // promotional -> standard pricing cutover.
+    expect(normalized?.cost).toEqual((resolved as ProviderRuntimeModel).cost);
+  });
+
   it("resolves Claude Mythos 5 with its direct-only mandatory-adaptive contract", async () => {
     const provider = await registerSingleProviderPlugin(anthropicPlugin);
     const resolved = provider.resolveDynamicModel?.({

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -593,10 +593,10 @@ function applyAnthropicSonnet5Cost(params: {
   }
   const cost = resolveAnthropicSonnet5Cost();
   if (
-    params.model.cost.input === cost.input &&
-    params.model.cost.output === cost.output &&
-    params.model.cost.cacheRead === cost.cacheRead &&
-    params.model.cost.cacheWrite === cost.cacheWrite
+    params.model.cost?.input === cost.input &&
+    params.model.cost?.output === cost.output &&
+    params.model.cost?.cacheRead === cost.cacheRead &&
+    params.model.cost?.cacheWrite === cost.cacheWrite
   ) {
     return undefined;
   }

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -26,6 +26,7 @@ import {
 } from "openclaw/plugin-sdk/provider-auth";
 import {
   cloneFirstTemplateModel,
+  modelCostsEqual,
   NATIVE_ANTHROPIC_REPLAY_HOOKS,
   type ProviderPlugin,
   resolveClaudeFable5ModelIdentity,
@@ -592,12 +593,7 @@ function applyAnthropicSonnet5Cost(params: {
     return undefined;
   }
   const cost = resolveAnthropicSonnet5Cost();
-  if (
-    params.model.cost?.input === cost.input &&
-    params.model.cost?.output === cost.output &&
-    params.model.cost?.cacheRead === cost.cacheRead &&
-    params.model.cost?.cacheWrite === cost.cacheWrite
-  ) {
+  if (modelCostsEqual(params.model.cost, cost)) {
     return undefined;
   }
   return { ...params.model, cost };

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -195,12 +195,12 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
     ),
     publicExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS",
-      10467,
+      10468,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS",
-      5223,
+      5224,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/commands/models.list.e2e.test.ts
+++ b/src/commands/models.list.e2e.test.ts
@@ -35,6 +35,14 @@ const shouldSuppressBuiltInModel = vi.fn().mockReturnValue(false);
 const shouldSuppressBuiltInModelFromManifest = vi.fn().mockReturnValue(false);
 const normalizeProviderResolvedModelWithPlugin = vi.hoisted(() =>
   vi.fn(({ context }) => {
+    if (context?.provider === "anthropic" && context?.modelId === "claude-sonnet-5") {
+      return {
+        ...context.model,
+        input: ["text", "image"],
+        contextWindow: 1_000_000,
+        contextTokens: 1_000_000,
+      };
+    }
     if (
       context?.provider === "anthropic" &&
       context?.modelId === "claude-sonnet-4-5" &&
@@ -493,6 +501,23 @@ describe("models list/status", () => {
         }),
       }),
     );
+  });
+
+  it("models list renders a configured Sonnet 5 table row through provider normalization", async () => {
+    getRuntimeConfig.mockReturnValue({
+      agents: { defaults: { model: "anthropic/claude-sonnet-5" } },
+    });
+    const runtime = makeRuntime();
+
+    await modelsListCommand({}, runtime);
+
+    expect(runtime.error).not.toHaveBeenCalled();
+    const output = runtime.log.mock.calls.map(([line]) => String(line)).join("\n");
+    expect(output).toContain("anthropic/claude-sonnet-5");
+    expect(output).toContain("text+image");
+    const normalizationContext =
+      normalizeProviderResolvedModelWithPlugin.mock.calls.at(-1)?.[0]?.context;
+    expect(normalizationContext?.model).not.toHaveProperty("cost");
   });
 
   it.each(["z.ai", "Z.AI", "z-ai"] as const)(

--- a/src/plugin-sdk/provider-model-shared.test.ts
+++ b/src/plugin-sdk/provider-model-shared.test.ts
@@ -1,10 +1,11 @@
 /**
- * Tests shared provider model id normalization helpers.
+ * Tests shared provider model helpers.
  */
 import { describe, expect, it } from "vitest";
 import {
   ANTHROPIC_BY_MODEL_REPLAY_HOOKS,
   buildProviderReplayFamilyHooks,
+  modelCostsEqual,
   NATIVE_ANTHROPIC_REPLAY_HOOKS,
   OPENAI_COMPATIBLE_REPLAY_HOOKS,
   PASSTHROUGH_GEMINI_REPLAY_HOOKS,
@@ -17,6 +18,8 @@ import {
   supportsClaudeNativeMaxEffort,
   supportsClaudeNativeXhighEffort,
 } from "./provider-model-shared.js";
+
+const EXPECTED_COST = { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 };
 
 function expectFields(value: unknown, expected: Record<string, unknown>): void {
   if (!value || typeof value !== "object") {
@@ -78,6 +81,14 @@ describe("Claude model contracts", () => {
       "medium",
       "high",
     ]);
+  });
+});
+
+describe("modelCostsEqual", () => {
+  it("matches complete flat rates and rejects missing or stale metadata", () => {
+    expect(modelCostsEqual(EXPECTED_COST, EXPECTED_COST)).toBe(true);
+    expect(modelCostsEqual(undefined, EXPECTED_COST)).toBe(false);
+    expect(modelCostsEqual({ ...EXPECTED_COST, output: 15 }, EXPECTED_COST)).toBe(false);
   });
 });
 

--- a/src/plugin-sdk/provider-model-shared.ts
+++ b/src/plugin-sdk/provider-model-shared.ts
@@ -19,6 +19,7 @@ import type { ProviderPlugin } from "../plugins/types.js";
 import type {
   ProviderReasoningOutputModeContext,
   ProviderReplayPolicyContext,
+  ProviderRuntimeModel,
   ProviderSanitizeReplayHistoryContext,
 } from "./plugin-entry.js";
 
@@ -100,6 +101,19 @@ export function normalizeProviderId(
   provider: string,
 ): string {
   return normalizeProviderIdCore(provider);
+}
+
+/** Compare canonical flat rates without assuming display-only models include cost metadata. */
+export function modelCostsEqual(
+  current: ProviderRuntimeModel["cost"] | undefined,
+  expected: ProviderRuntimeModel["cost"],
+): boolean {
+  return (
+    current?.input === expected.input &&
+    current?.output === expected.output &&
+    current?.cacheRead === expected.cacheRead &&
+    current?.cacheWrite === expected.cacheWrite
+  );
 }
 export {
   createMoonshotThinkingWrapper,


### PR DESCRIPTION
## What Problem This Solves

`openclaw models list` could crash when a configured Claude Sonnet 5 row reached provider normalization without cost metadata. Configured-list and discovery rows are intentionally partial projections, so `cost` is not guaranteed at those call sites.

## Why This Change Was Made

Sonnet 5 pricing normalization now uses one missing-cost-safe flat-cost comparator shared by Anthropic, Amazon Bedrock Mantle, and Anthropic Vertex. This fixes all three reachable sibling normalizers at their provider-owned boundary instead of padding display rows with invented runtime fields or catching and hiding normalization failures.

## User Impact

Configured Sonnet 5 models list normally, retaining image capability and context metadata, without requiring provider credentials or cost fields in configuration.

## Evidence

- 95 focused SDK, CLI E2E, and provider tests passed on Blacksmith Testbox.
- `openclaw models list` rendered `anthropic/claude-sonnet-5` as `text+image` with `1000k` context and exited 0 in a credential-free isolated environment.
- Independent source-blind validation passed table and `--plain` runs in two fresh homes.
- `pnpm check:changed`, formatting, Plugin SDK API generation/check, and fresh Codex autoreview passed.

Contributor implementation and regression context by @VACInc; maintainer follow-up broadens the fix across the full sibling surface.
