### PR TITLE
fix: add missing switch default case and empty catch comment

### DIFF
--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -118,7 +118,9 @@ function prepareEditArguments(input: unknown): EditToolInput {
       if (Array.isArray(parsed)) {
         args.edits = parsed;
       }
-    } catch {}
+    } catch {
+      // Not a JSON string — model did not use the edits-as-string format.
+    }
   }
 
   const legacy = args as LegacyEditToolInput;

--- a/src/mcp/channel-bridge.ts
+++ b/src/mcp/channel-bridge.ts
@@ -579,7 +579,13 @@ export class OpenClawChannelBridge {
           type: "plugin_approval_resolved",
           raw,
         });
+        return;
       }
+      default:
+        // Unknown gateway event types are silently dropped.
+        if (this.verbose) {
+          console.warn(`[mcp-channel-bridge] unknown gateway event: ${event.event}`);
+        }
     }
   }
 


### PR DESCRIPTION
## Summary

- Add missing `default:` case to `handleGatewayEvent()` switch in `channel-bridge.ts`
- Add missing `return;` to `plugin.approval.resolved` case (previously fell through)
- Add clarifying comment to empty `JSON.parse` catch in `edit.ts`

## What Problem This Solves

1. The `handleGatewayEvent()` switch in `channel-bridge.ts` had no `default:` case — unknown gateway event types were silently dropped without any warning, making debugging difficult.
2. The `plugin.approval.resolved` case was missing `return;`, causing fall-through to the end of the switch instead of early return — a latent bug.
3. The empty `catch {}` in `edit.ts:120` had no comment explaining why the exception is intentionally swallowed.

## Evidence

- `channel-bridge.ts`: Switch now has explicit `default:` with verbose warning + `plugin.approval.resolved` returns early
- `edit.ts`: Empty catch now has comment clarifying intent

## Test Plan

- [x] Existing tests pass
- [x] Build succeeds

Closes N/A

🤖 Generated with Claude Code
