### PR TITLE
fix(schema): resolve large local refs in schema arrays

### DIFF
--- a/src/shared/json-schema-defaults.test.ts
+++ b/src/shared/json-schema-defaults.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  findJsonSchemaShapeError,
-  normalizeJsonSchemaForTypeBox,
-} from "./json-schema-defaults.js";
+import { findJsonSchemaShapeError, normalizeJsonSchemaForTypeBox } from "./json-schema-defaults.js";
 
 describe("normalizeJsonSchemaForTypeBox", () => {
   it("combines pattern properties that collide after unicode repair", () => {
@@ -38,10 +35,7 @@ describe("normalizeJsonSchemaForTypeBox", () => {
   );
 
   it("resolves local refs to array entries beyond config path index limits", () => {
-    const prefixItems: (boolean | { type: string })[] = Array.from(
-      { length: 100_002 },
-      () => true,
-    );
+    const prefixItems: (boolean | { type: string })[] = Array.from({ length: 100_002 }, () => true);
     prefixItems[100_001] = { type: "string" };
 
     expect(

--- a/src/shared/json-schema-defaults.test.ts
+++ b/src/shared/json-schema-defaults.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { normalizeJsonSchemaForTypeBox } from "./json-schema-defaults.js";
+import {
+  findJsonSchemaShapeError,
+  normalizeJsonSchemaForTypeBox,
+} from "./json-schema-defaults.js";
 
 describe("normalizeJsonSchemaForTypeBox", () => {
   it("combines pattern properties that collide after unicode repair", () => {
@@ -33,4 +36,17 @@ describe("normalizeJsonSchemaForTypeBox", () => {
       });
     },
   );
+
+  it("resolves local refs to array entries beyond config path index limits", () => {
+    const prefixItems = Array.from({ length: 100_002 }, () => true);
+    prefixItems[100_001] = { type: "string" };
+
+    expect(
+      findJsonSchemaShapeError({
+        type: "array",
+        prefixItems,
+        items: { $ref: "#/prefixItems/100001" },
+      }),
+    ).toBeUndefined();
+  });
 });

--- a/src/shared/json-schema-defaults.test.ts
+++ b/src/shared/json-schema-defaults.test.ts
@@ -38,7 +38,10 @@ describe("normalizeJsonSchemaForTypeBox", () => {
   );
 
   it("resolves local refs to array entries beyond config path index limits", () => {
-    const prefixItems = Array.from({ length: 100_002 }, () => true);
+    const prefixItems: (boolean | { type: string })[] = Array.from(
+      { length: 100_002 },
+      () => true,
+    );
     prefixItems[100_001] = { type: "string" };
 
     expect(

--- a/src/shared/json-schema-defaults.ts
+++ b/src/shared/json-schema-defaults.ts
@@ -2,7 +2,6 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 // JSON schema default helpers fill object values from TypeBox schema defaults.
 import { Compile } from "typebox/compile";
 import type { JsonSchemaObject } from "./json-schema.types.js";
-import { parseConfigPathArrayIndex } from "./path-array-index.js";
 
 type JsonSchemaValue = JsonSchemaObject | boolean;
 type LocalRefResolution =
@@ -79,6 +78,7 @@ const schemaIntegerKeywords = new Set([
   "minProperties",
 ]);
 const schemaBooleanKeywords = new Set(["deprecated", "readOnly", "uniqueItems", "writeOnly"]);
+const JSON_POINTER_ARRAY_INDEX_SEGMENT = /^(0|[1-9]\d*)$/;
 
 function schemaTypeIncludes(schema: Record<string, unknown>, type: string): boolean {
   return schema.type === type || (Array.isArray(schema.type) && schema.type.includes(type));
@@ -255,6 +255,14 @@ function decodePointerSegment(segment: string): string {
   return decodedSegment.replace(/~1/g, "/").replace(/~0/g, "~");
 }
 
+function parseJsonPointerArrayIndex(segment: string): number | undefined {
+  if (!JSON_POINTER_ARRAY_INDEX_SEGMENT.test(segment)) {
+    return undefined;
+  }
+  const index = Number(segment);
+  return Number.isSafeInteger(index) ? index : undefined;
+}
+
 function resolveLocalAnchor(
   schema: JsonSchemaValue,
   anchor: string,
@@ -347,7 +355,7 @@ function resolveLocalRef(
     let currentResourceBaseId = resourceBaseId;
     for (const segment of ref.slice(2).split("/").map(decodePointerSegment)) {
       if (Array.isArray(current)) {
-        const index = parseConfigPathArrayIndex(segment);
+        const index = parseJsonPointerArrayIndex(segment);
         if (index === undefined) {
           return { found: false };
         }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where JSON Schema validators/defaulting would reject a valid local `$ref` into a large schema array when the referenced array index exceeded OpenClaw's config path sparse-write limit.

## Why This Change Was Made

JSON Pointer array indexes and OpenClaw config path array indexes have different ownership and limits. This keeps JSON Pointer parsing local to the schema helper, preserving canonical non-negative array-token parsing without applying the config writer's `100000` sparse-write cap.

## User Impact

Plugin/config schema validation can now resolve valid local refs such as `#/prefixItems/100001` instead of reporting them as unresolved only because they are above the config path write limit.

## Evidence

- Claim proved: plugin/config schema shape validation resolves canonical JSON Pointer refs into large schema arrays when the referenced array index is above OpenClaw's config sparse-write limit.
- Dependency-ready proof lane: `E:\code\openclaw-cxb-102195-proof-lane` on PR head `9dde5a080eebe3df18ec51aa5f88c9a7f82bc2cd`, with `node_modules` present after `pnpm install --frozen-lockfile`; `package.json`, `pnpm-lock.yaml`, and `pnpm-workspace.yaml` had no diff after install.
- Focused regression proof: `node scripts/run-vitest.mjs src/shared/json-schema-defaults.test.ts` passed at `9dde5a080eebe3df18ec51aa5f88c9a7f82bc2cd` in the proof lane: 1 test file passed, 5 tests passed.
- Real schema-path proof: `node --import tsx --input-type=module` probe importing `findJsonSchemaShapeError` from `src/shared/json-schema-defaults.ts` resolved `#/prefixItems/100001` for a `prefixItems` array of length `100002` and printed `{"unresolvedRefError":false,"prefixItemsLength":100002}`.
- Diff hygiene: `git diff --check` passed at `9dde5a080eebe3df18ec51aa5f88c9a7f82bc2cd` in the proof lane.
- CI proof: GitHub Actions on this PR head passed `check-test-types`, `check-lint`, the focused fast check shards, and `Real behavior proof`.