### PR TITLE
fix: add missing default cases to switch statements

### DIFF
--- a/extensions/amazon-bedrock/stream.runtime.ts
+++ b/extensions/amazon-bedrock/stream.runtime.ts
@@ -602,6 +602,9 @@ function handleContentBlockStop(
       delete (block as Block).partialJson;
       stream.push({ type: "toolcall_end", contentIndex: index, toolCall: block, partial: output });
       break;
+    default:
+      // Unknown block types are silently dropped.
+      break;
   }
 }
 

--- a/extensions/voice-call/src/media-stream.ts
+++ b/extensions/voice-call/src/media-stream.ts
@@ -278,7 +278,7 @@ export class MediaStreamHandler {
           case "mark":
             break;
           default:
-            console.warn(`[MediaStream] Unknown Twilio event: ${message.event}`);
+            console.warn(`[MediaStream] Unknown Twilio event: ${String(message.event)}`);
             break;
         }
       } catch (error) {

--- a/extensions/voice-call/src/media-stream.ts
+++ b/extensions/voice-call/src/media-stream.ts
@@ -277,6 +277,9 @@ export class MediaStreamHandler {
           case "clear":
           case "mark":
             break;
+          default:
+            console.warn(`[MediaStream] Unknown Twilio event: ${message.event}`);
+            break;
         }
       } catch (error) {
         console.error("[MediaStream] Error processing message:", error);

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -339,7 +339,11 @@ async function processUpdate(params: ZaloUpdateProcessingParams): Promise<void> 
       );
       break;
     default:
-      logVerbose(core, runtime, `[${account.accountId}] Unknown Zalo event type: ${event_name}`);
+      logVerbose(
+        core,
+        runtime,
+        `[${account.accountId}] Unknown Zalo event type: ${String(event_name)}`,
+      );
       break;
   }
 }

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -338,6 +338,9 @@ async function processUpdate(params: ZaloUpdateProcessingParams): Promise<void> 
         `[${account.accountId}] Received unsupported message type from ${message.from.id}`,
       );
       break;
+    default:
+      logVerbose(core, runtime, `[${account.accountId}] Unknown Zalo event type: ${event_name}`);
+      break;
   }
 }
 

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -273,6 +273,8 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
       profilePath = resolveCompletionProfilePath("powershell");
       sourceLine = formatCompletionSourceLine("powershell", cachePath);
       break;
+    default:
+      throw new Error(`Unsupported shell: ${shell}`);
   }
 
   try {

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -274,7 +274,7 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
       sourceLine = formatCompletionSourceLine("powershell", cachePath);
       break;
     default:
-      throw new Error(`Unsupported shell: ${shell}`);
+      throw new Error(`Unsupported shell: ${String(shell)}`);
   }
 
   try {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -4747,6 +4747,9 @@ export const chatHandlers: GatewayRequestHandlers = {
                 });
               }
               break;
+            default:
+              // Unknown deliver reply kinds are silently dropped.
+              break;
           }
         },
       });


### PR DESCRIPTION
## What Problem This Solves

Switch statements without `default:` cases can silently ignore unexpected values, making debugging difficult and potentially causing data loss or undefined behavior when new values are encountered.

## Summary

Adds missing `default:` cases to 5 switch statements across the codebase.

## Changes

| File | Change |
|------|--------|
| `src/cli/completion-runtime.ts:276` | Add `default: throw` for unknown shell types |
| `extensions/zalo/src/monitor.ts:341` | Add `default:` with verbose log for unknown Zalo event types |
| `extensions/amazon-bedrock/stream.runtime.ts:604` | Add `default:` for unknown block types |
| `extensions/voice-call/src/media-stream.ts:279` | Add `default:` with warning log for unknown Twilio events |
| `src/gateway/server-methods/chat.ts:4750` | Add `default:` for unknown deliver reply kinds |

## Evidence

- completion-runtime.ts: Unknown shell would leave `profilePath`/`sourceLine` undefined, causing a downstream error; now throws explicitly.
- zalo/monitor.ts: Unknown Zalo event types were silently dropped; now logged via existing `logVerbose`.
- bedrock/stream.runtime.ts: Unknown block types were silently ignored in stream finalization; now has explicit default.
- voice-call/media-stream.ts: Unknown Twilio events were silently dropped in try/catch; now logged via `console.warn`.
- chat.ts: Unknown deliver reply kinds silently ignored; now has explicit default.

## Test Plan

- No behavioral change for existing known values.
- Build should succeed.

🤖 Generated with Claude Code
