### PR TITLE
fix: tasks.list re-sorts the whole registry on every Control UI poll

### DIFF
--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -29,6 +29,7 @@ type TaskResponsePayload = {
   task?: Record<string, unknown>;
   found?: boolean;
   cancelled?: boolean;
+  nextCursor?: string;
 };
 
 let stateDir: string;
@@ -199,6 +200,44 @@ describe("tasks gateway handlers", () => {
     expect(ids?.indexOf(oldButJustFinished.taskId)).toBeLessThan(
       ids?.indexOf(newerQuietTask.taskId) ?? -1,
     );
+  });
+
+  it("preserves activity ordering across cursor pages", async () => {
+    const created = [500, 100, 700, 300, 500].map((lastEventAt, index) =>
+      createTaskRecord({
+        runtime: "cli",
+        requesterSessionKey: "agent:main:main",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        runId: `run-page-${index}`,
+        task: `Paged task ${index}`,
+        status: "succeeded",
+        deliveryStatus: "not_applicable",
+        lastEventAt,
+      }),
+    );
+    const expectedIds = created
+      .toSorted((left, right) => {
+        const updatedDiff = (right.lastEventAt ?? 0) - (left.lastEventAt ?? 0);
+        if (updatedDiff !== 0) {
+          return updatedDiff;
+        }
+        return left.taskId < right.taskId ? -1 : left.taskId > right.taskId ? 1 : 0;
+      })
+      .map((task) => task.taskId);
+
+    const page1 = await runTaskHandler("tasks.list", { limit: 2 });
+    expect(page1.calls[0]?.[0]).toBe(true);
+    expect(page1.payload?.tasks?.map((task) => task.id)).toEqual(expectedIds.slice(0, 2));
+    expect(page1.payload?.nextCursor).toBe("2");
+
+    const page2 = await runTaskHandler("tasks.list", { limit: 2, cursor: "2" });
+    expect(page2.payload?.tasks?.map((task) => task.id)).toEqual(expectedIds.slice(2, 4));
+    expect(page2.payload?.nextCursor).toBe("4");
+
+    const page3 = await runTaskHandler("tasks.list", { limit: 2, cursor: "4" });
+    expect(page3.payload?.tasks?.map((task) => task.id)).toEqual(expectedIds.slice(4));
+    expect(page3.payload?.nextCursor).toBeUndefined();
   });
 
   it("treats explicit task agentId as authoritative over the session-key fallback", async () => {

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -13,7 +13,7 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { cancelDetachedTaskRunById } from "../../tasks/detached-task-runtime.js";
-import { getTaskById, listTaskRecords } from "../../tasks/runtime-internal.js";
+import { getTaskById, listTaskRecordsUnsorted } from "../../tasks/runtime-internal.js";
 import type { TaskRecord, TaskStatus } from "../../tasks/task-registry.types.js";
 import { mapTaskSummary, taskUpdatedAt } from "./task-summary.js";
 import type { GatewayRequestHandlers } from "./types.js";
@@ -109,10 +109,11 @@ export const tasksHandlers: GatewayRequestHandlers = {
     }
     const statusFilter = normalizeTaskStatusFilter(params.status);
     const limit = Math.min(params.limit ?? DEFAULT_TASKS_LIST_LIMIT, MAX_TASKS_LIST_LIMIT);
-    // The registry lists newest-created first; the ledger view pages by last
-    // activity so an old long-running task that just finished still surfaces
-    // on the first page instead of hiding behind newer-created records.
-    const filtered = listTaskRecords()
+    // The ledger view pages by last activity so an old long-running task that
+    // just finished still surfaces on the first page instead of hiding behind
+    // newer-created records. Start from a cloned insertion-order snapshot so
+    // this sort does not first pay for the registry's discarded createdAt sort.
+    const filtered = listTaskRecordsUnsorted()
       .filter((task) => {
         if (statusFilter && !statusFilter.has(task.status)) {
           return false;

--- a/src/tasks/runtime-internal.ts
+++ b/src/tasks/runtime-internal.ts
@@ -11,6 +11,7 @@ export {
   hasActiveTaskForChildSessionKey,
   listFreshTasksForOwnerKey,
   listTaskRecords,
+  listTaskRecordsUnsorted,
   listTasksForFlowId,
   listTasksForOwnerKey,
   linkTaskToFlowById,

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -2407,6 +2407,13 @@ export async function cancelTaskById(params: {
   }
 }
 
+// Callers that provide their own order use this cloned snapshot to avoid paying
+// for listTaskRecords' createdAt sort before immediately discarding that order.
+export function listTaskRecordsUnsorted(): TaskRecord[] {
+  ensureTaskRegistryReady();
+  return snapshotTaskRecords(tasks);
+}
+
 export function listTaskRecords(): TaskRecord[] {
   ensureTaskRegistryReady();
   return [...tasks.values()]


### PR DESCRIPTION
## What Problem This Solves

`tasks.list` called `listTaskRecords()`, which cloned and sorted the whole registry by `createdAt`. The Gateway handler then immediately discarded that order, sorted the same records by last activity, and sliced a bounded page. The Control UI issues two such requests per refresh, so busy gateways repeatedly paid for an unnecessary full sort.

Closes #101716.

## Why This Change Was Made

The final maintainer rewrite removes only the discarded first sort:

- `listTaskRecordsUnsorted()` returns the same isolated cloned snapshot without created-time sorting or insertion-index bookkeeping.
- `tasks.list` retains its existing deterministic `updatedAt` descending, `taskId` ascending order, filters, offset cursor, page bounds, and response shape.
- Existing callers of `listTaskRecords()` keep their newest-created contract.

An earlier version also introduced randomized quickselect. That machinery was removed: it added roughly 60 lines and probabilistic runtime behavior to optimize the cheaper second sort while complicating pagination reasoning. The smaller fix is faster and preserves one canonical ordering path.

## User Impact

Task-ledger and Control UI refreshes avoid the redundant registry-wide sort as retained task counts grow. Visible ordering, filters, pagination, and protocol behavior remain unchanged.

## Evidence

Exact rewritten head: `18d92577651422ebc7bb31b4fe34f2f499d81a72`.

- GitHub CI [run 29063036342](https://github.com/openclaw/openclaw/actions/runs/29063036342): all selected jobs passed, including lint, production and test types, build artifacts, guards, and all Node shards.
- The exact Gateway test file passed 8/8 in CI and 16/16 across both configured Testbox projects on `tbx_01kx4vtwe4vbh5qy2qccajajjz`.
- The remote changed gate passed core and core-test typechecks, changed-file lint, import-cycle checks, boundaries, and selected guards.
- A 10,000-record exact-path Testbox benchmark measured 3.025 ms median before versus 0.987 ms after, a 3.06x speedup while retaining the complete deterministic activity sort.
- Fresh Codex autoreview: no findings, confidence 0.86.

The original contributor head remained untrusted. Only the fully reviewed and rewritten immutable head was explicitly approved for Testbox execution, and the lease was stopped after proof.

Co-authored-by: 曾文锋0668000834 <zeng.wenfeng@xydigit.com>
