### PR TITLE
feat(session-lock): opt-in diagnostics for embedded session fence takeovers

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.diagnostics.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.diagnostics.test.ts
@@ -1,0 +1,122 @@
+// Coverage for the opt-in session-fence takeover diagnostics. A takeover throws
+// EmbeddedAttemptSessionTakeoverError with only the file path; these diagnostics
+// add, behind `session-lock` debug logging, the reason + fingerprints needed to
+// tell a benign concurrent writer from a real external editor.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { debugMock, isEnabledMock } = vi.hoisted(() => ({
+  debugMock: vi.fn(),
+  isEnabledMock: vi.fn(() => true),
+}));
+
+vi.mock("../../../logging/subsystem.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../logging/subsystem.js")>();
+  const logger = {
+    subsystem: "session-lock",
+    isEnabled: isEnabledMock,
+    trace: vi.fn(),
+    debug: debugMock,
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    raw: vi.fn(),
+    child: vi.fn(),
+  };
+  return { ...actual, createSubsystemLogger: vi.fn(() => logger) };
+});
+
+const {
+  createEmbeddedAttemptSessionLockController,
+  EmbeddedAttemptSessionTakeoverError,
+  resetEmbeddedAttemptSessionFileOwnersForTest,
+} = await import("./attempt.session-lock.js");
+
+const lockOptions = {
+  sessionFile: "/tmp/session.jsonl",
+  timeoutMs: 60_000,
+  staleMs: 1_800_000,
+  maxHoldMs: 300_000,
+};
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  debugMock.mockClear();
+  isEnabledMock.mockReturnValue(true);
+  resetEmbeddedAttemptSessionFileOwnersForTest();
+  for (const dir of tempDirs.splice(0)) {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+async function createTempSessionFile(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-lock-diagnostics-"));
+  tempDirs.push(dir);
+  const sessionFile = path.join(dir, "session.jsonl");
+  await fs.writeFile(sessionFile, '{"type":"session"}\n', "utf8");
+  return sessionFile;
+}
+
+async function triggerExternalTakeover(): Promise<{ sessionFile: string; error: unknown }> {
+  const sessionFile = await createTempSessionFile();
+  const release = vi.fn(async () => {});
+  const controller = await createEmbeddedAttemptSessionLockController({
+    acquireSessionWriteLock: vi.fn(async () => ({ release })),
+    lockOptions: { ...lockOptions, sessionFile },
+  });
+  await controller.releaseForPrompt();
+  // A different process appends to the session file while the prompt lock is released.
+  await fs.appendFile(sessionFile, '{"type":"message","id":"external-takeover"}\n', "utf8");
+  let error: unknown;
+  try {
+    await controller.withSessionWriteLock(() => "late-write");
+  } catch (caught) {
+    error = caught;
+  }
+  await controller.acquireForCleanup().then((lock) => lock.release());
+  return { sessionFile, error };
+}
+
+describe("session-fence takeover diagnostics", () => {
+  it("emits a structured diagnostic identifying the tripped check on takeover", async () => {
+    const { sessionFile, error } = await triggerExternalTakeover();
+
+    expect(error).toBeInstanceOf(EmbeddedAttemptSessionTakeoverError);
+    expect(debugMock).toHaveBeenCalledTimes(1);
+    const [message, meta] = debugMock.mock.calls[0] ?? [];
+    expect(message).toBe("embedded session fence takeover: unexplained-session-file-change");
+    expect(meta).toMatchObject({
+      reason: "unexplained-session-file-change",
+      sessionFile,
+      fenceActive: true,
+    });
+    const typedMeta = meta as { currentFingerprint: unknown; expectedFingerprint: unknown };
+    expect(typedMeta.currentFingerprint).toMatchObject({ exists: true, size: expect.any(String) });
+    expect(typedMeta.expectedFingerprint).toMatchObject({ exists: true });
+  });
+
+  it("stays silent when session-lock debug logging is disabled (zero overhead)", async () => {
+    isEnabledMock.mockReturnValue(false);
+    const { error } = await triggerExternalTakeover();
+    // The takeover still fires — only the diagnostic is gated.
+    expect(error).toBeInstanceOf(EmbeddedAttemptSessionTakeoverError);
+    expect(debugMock).not.toHaveBeenCalled();
+  });
+
+  it("does not emit a diagnostic when no takeover occurs", async () => {
+    const sessionFile = await createTempSessionFile();
+    const release = vi.fn(async () => {});
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock: vi.fn(async () => ({ release })),
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+    await controller.releaseForPrompt();
+    await controller.reacquireAfterPrompt();
+    await controller.dispose();
+    expect(debugMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -15,6 +15,7 @@ import {
   withOwnedSessionTranscriptWrites,
 } from "../../../config/sessions/transcript-write-context.js";
 import { toErrorObject } from "../../../infra/errors.js";
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
 import { resolveGlobalSingleton } from "../../../shared/global-singleton.js";
 import { isTranscriptOnlyOpenClawAssistantMessage } from "../../../shared/transcript-only-openclaw-assistant.js";
 import { isSessionWriteLockAcquireError } from "../../session-write-lock-error.js";
@@ -127,6 +128,36 @@ type SessionFileFingerprint =
     };
 
 export type TrustedSessionFileSnapshot = Extract<SessionFileFingerprint, { exists: true }>;
+
+// Opt-in diagnostics for session-fence takeovers. A takeover means the session
+// `.jsonl` changed under a released prompt lock in a way the fence cannot explain
+// as an owned in-process write, so the embedded attempt is torn down. The record
+// is emitted on the `session-lock` subsystem at debug level, so enable debug
+// logging (`OPENCLAW_LOG_LEVEL=debug`, `logging.level: "debug"`, or
+// `--log-level debug`) to see which check tripped, the fingerprints involved, and
+// the owned-write history — the context needed to tell a benign concurrent writer
+// from a real external editor.
+const sessionLockLog = createSubsystemLogger("session-lock");
+
+function describeSessionFileFingerprint(
+  fingerprint: SessionFileFingerprint | undefined,
+): Record<string, string | boolean> | null {
+  if (!fingerprint) {
+    return null;
+  }
+  if (!fingerprint.exists) {
+    return { exists: false };
+  }
+  // Fields are bigint; stringify so the diagnostic survives any JSON transport.
+  return {
+    exists: true,
+    dev: fingerprint.dev.toString(),
+    ino: fingerprint.ino.toString(),
+    size: fingerprint.size.toString(),
+    mtimeNs: fingerprint.mtimeNs.toString(),
+    ctimeNs: fingerprint.ctimeNs.toString(),
+  };
+}
 
 const MAX_BENIGN_SESSION_FENCE_ADVANCE_BYTES = 1024 * 1024;
 const MAX_BENIGN_SESSION_FENCE_REWRITE_BYTES = 8 * 1024 * 1024;
@@ -1224,6 +1255,27 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     pruneOwnedSessionFileWriteHistory(sessionFileFenceKey, history);
   }
 
+  // Records a fence takeover and, when session-lock debug logging is enabled,
+  // emits the diagnostic that identifies which check tripped and the file state
+  // that could not be reconciled. Behaviour is unchanged from the bare flag set.
+  function markSessionTakeover(reason: string, current?: SessionFileFingerprint): void {
+    takeoverDetected = true;
+    if (!sessionLockLog.isEnabled("debug")) {
+      return;
+    }
+    const ownedWrites = ownedSessionFileWrites.get(sessionFileFenceKey)?.writes ?? [];
+    sessionLockLog.debug(`embedded session fence takeover: ${reason}`, {
+      reason,
+      sessionFile: params.lockOptions.sessionFile,
+      fenceActive,
+      fenceGeneration,
+      expectedFingerprint: describeSessionFileFingerprint(fenceFingerprint),
+      currentFingerprint: describeSessionFileFingerprint(current),
+      ownedWriteCount: ownedWrites.length,
+      lastOwnedWriteGeneration: ownedWrites.at(-1)?.generation ?? null,
+    });
+  }
+
   function activateFence(generation: number): void {
     fenceActive = true;
     setFenceGeneration(generation);
@@ -1279,7 +1331,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     try {
       mergeResult = await params.mergePromptReleasedSessionEntries(change.entries);
     } catch (error) {
-      takeoverDetected = true;
+      markSessionTakeover("prompt-released-merge-callback-error", current);
       throw error;
     }
     const refreshedSnapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
@@ -1287,7 +1339,10 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       ? { exists: true as const, ...mergeResult.sessionFileSnapshot }
       : current;
     if (!sameSessionFileFingerprint(expectedFingerprint, refreshedSnapshot.fingerprint)) {
-      takeoverDetected = true;
+      markSessionTakeover(
+        "prompt-released-merge-fingerprint-mismatch",
+        refreshedSnapshot.fingerprint,
+      );
       throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
     }
     return {
@@ -1313,12 +1368,12 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     try {
       await params.reloadPromptReleasedSessionFile();
     } catch (error) {
-      takeoverDetected = true;
+      markSessionTakeover("prompt-released-reload-callback-error");
       throw error;
     }
     const snapshot = await readSessionFileFenceSnapshot(params.lockOptions.sessionFile);
     if (!sameSessionFileFingerprint(expectedFingerprint, snapshot.fingerprint)) {
-      takeoverDetected = true;
+      markSessionTakeover("prompt-released-reload-fingerprint-mismatch", snapshot.fingerprint);
       throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
     }
     return snapshot;
@@ -1369,7 +1424,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       return { lock: await acquireLock(), owned: true };
     } catch (err) {
       if (isSessionWriteLockAcquireError(err)) {
-        takeoverDetected = true;
+        markSessionTakeover("write-lock-acquire-error");
       }
       throw err;
     }
@@ -1438,7 +1493,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       if (unseenOwnedWrites.some((write) => write.requiresReload)) {
         const reloadedSnapshot = await reloadPromptReleasedSessionFile(current);
         if (!reloadedSnapshot) {
-          takeoverDetected = true;
+          markSessionTakeover("owned-write-reload-failed", current);
           throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
         }
         fenceFingerprint = reloadedSnapshot.fingerprint;
@@ -1458,7 +1513,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
         expectedPublishedEntries ? { expectedPublishedEntries } : undefined,
       );
       if (params.mergePromptReleasedSessionEntries && !mergedChange) {
-        takeoverDetected = true;
+        markSessionTakeover("owned-write-merge-rejected", current);
         throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
       }
       const mergedFingerprint = mergedChange?.snapshot.fingerprint ?? current;
@@ -1504,7 +1559,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
     if (changeKind && params.mergePromptReleasedSessionEntries) {
       const mergedChange = await mergePromptReleasedSessionChange(fenceSnapshot, current);
       if (!mergedChange) {
-        takeoverDetected = true;
+        markSessionTakeover("transcript-change-merge-rejected", current);
         throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
       }
       fenceSnapshot = mergedChange.snapshot;
@@ -1520,7 +1575,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       return;
     }
 
-    takeoverDetected = true;
+    markSessionTakeover("unexplained-session-file-change", current);
     throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
   }
 
@@ -1570,7 +1625,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       expectedPublishedEntries ? { expectedPublishedEntries } : undefined,
     );
     if (params.mergePromptReleasedSessionEntries && !mergedChange) {
-      takeoverDetected = true;
+      markSessionTakeover("owned-publish-merge-rejected", current);
       throw new EmbeddedAttemptSessionTakeoverError(params.lockOptions.sessionFile);
     }
     const publishedEntries = mergedChange
@@ -1729,7 +1784,7 @@ export async function createEmbeddedAttemptSessionLockController(params: {
       return await acquireLock();
     } catch (err) {
       if (isSessionWriteLockAcquireError(err)) {
-        takeoverDetected = true;
+        markSessionTakeover("cleanup-lock-acquire-error");
         return undefined;
       }
       throw err;


### PR DESCRIPTION
## What Problem This Solves

Opt-in observability for embedded-attempt **session fence takeovers**.

When a session `.jsonl` changes under a released prompt lock in a way the fence cannot explain as an owned in-process write, the controller tears the attempt down by throwing `EmbeddedAttemptSessionTakeoverError` — which carries only the file path. Across the **10 takeover throw sites** in `attempt.session-lock.ts` there was previously **no diagnostic at all** (the file has no logger). In production this makes a takeover effectively opaque: the only way to learn *which* check tripped and *what* file state could not be reconciled was to patch the installed bundle and add logging by hand.

The gap is real. A released-prompt takeover can fire when a legitimate in-process writer (e.g. an outbound delivery-queue transcript append) races the fence window, and without the fingerprints and owned-write history it looks identical to a genuine external editor.

## What Changed

Every takeover-detection point now goes through a small `markSessionTakeover(reason, current?)` helper. **Behaviour is unchanged** — it sets the same `takeoverDetected` flag and the same error is still thrown. When `session-lock` debug logging is enabled it additionally emits one structured record:

- `reason` — which check tripped (`unexplained-session-file-change`, `owned-write-merge-rejected`, `write-lock-acquire-error`, …)
- `sessionFile`, `fenceActive`, `fenceGeneration`
- `expectedFingerprint` vs `currentFingerprint` (dev/ino/size/mtimeNs/ctimeNs, stringified so the record survives any JSON transport)
- `ownedWriteCount` and `lastOwnedWriteGeneration`

It is gated behind `isEnabled("debug")`, so there is **zero overhead when the subsystem is not in debug**. No new env var — it uses the existing `session-lock` subsystem logger.

## Evidence

**Live diagnostic output.** Exercising a real external-append takeover (append to the session file while the prompt lock is released, then take the write lock) now emits, via the `session-lock` logger:

```
embedded session fence takeover: unexplained-session-file-change
{
  "reason": "unexplained-session-file-change",
  "sessionFile": ".../session.jsonl",
  "fenceActive": true,
  "fenceGeneration": 1,
  "expectedFingerprint": { "exists": true, "dev": "16777231", "ino": "200684408", "size": "19", "mtimeNs": "1783519408483846902", "ctimeNs": "1783519408483846902" },
  "currentFingerprint":  { "exists": true, "dev": "16777231", "ino": "200684408", "size": "63", "mtimeNs": "1783519408484811232", "ctimeNs": "1783519408484811232" },
  "ownedWriteCount": 0,
  "lastOwnedWriteGeneration": null
}
```

The record immediately tells the story: **same inode**, size grew `19 → 63` (a plain append), `ownedWriteCount: 0` — an unpublished writer advanced the file. That is exactly the signal needed to distinguish a benign in-process append (which would carry an owned-write generation) from a real external editor.

**Tests.** New `attempt.session-lock.diagnostics.test.ts`:
- emits the structured diagnostic (reason + fingerprints) on a real takeover,
- stays silent when `session-lock` debug logging is disabled (zero overhead),
- stays silent when no takeover occurs.

The full existing `attempt.session-lock.test.ts` suite (222 tests) passes unchanged, confirming the flag/throw behaviour is untouched. `oxlint` and a scoped `tsgo --noEmit` are clean on the changed files.
