### PR TITLE
fix: stop model catalog warning loop during sidecar refresh

### DIFF
--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -41,6 +41,7 @@ import {
   buildConfiguredModelCatalog,
   hasConfiguredProviderModelRows,
 } from "./model-selection-shared.js";
+import { withModelCatalogFileIoLock } from "./models-config-state.js";
 import {
   buildModelsJsonSourceFingerprint,
   prepareOpenClawModelsJsonSource,
@@ -434,7 +435,9 @@ async function loadReadOnlyPersistedModelCatalog(params?: {
     manifestPlugins ??= getMetadataSnapshot().plugins;
     return manifestPlugins;
   };
-  const providers = await loadReadOnlyPersistedProviderRows(agentDir, getMetadataSnapshot);
+  const providers = await withModelCatalogFileIoLock(agentDir, () =>
+    loadReadOnlyPersistedProviderRows(agentDir, getMetadataSnapshot),
+  );
   for (const [providerRaw, providerConfig] of Object.entries(providers)) {
     if (!Array.isArray(providerConfig?.models)) {
       continue;

--- a/src/agents/models-config-state.ts
+++ b/src/agents/models-config-state.ts
@@ -32,6 +32,17 @@ export const MODELS_JSON_STATE = (() => {
   return globalState[MODELS_JSON_STATE_KEY];
 })();
 
+function modelCatalogFileIoKey(agentDir: string): string {
+  return `${agentDir}\0model-catalog-files`;
+}
+
+export async function withModelCatalogFileIoLock<T>(
+  agentDir: string,
+  run: () => Promise<T>,
+): Promise<T> {
+  return await MODELS_JSON_STATE.writeQueue.enqueue(modelCatalogFileIoKey(agentDir), run);
+}
+
 /** Clear models.json write/ready caches for tests. */
 export function resetModelsJsonReadyCacheForTest(): void {
   MODELS_JSON_STATE.writeQueue = new KeyedAsyncQueue();

--- a/src/agents/models-config.file-mode.test.ts
+++ b/src/agents/models-config.file-mode.test.ts
@@ -1,6 +1,8 @@
 // Verifies models.json writes and repairs use private file permissions.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { configureFsSafePython } from "@openclaw/fs-safe/config";
+import { __setFsSafeTestHooksForTest } from "@openclaw/fs-safe/test-hooks";
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import {
@@ -11,6 +13,7 @@ import {
 const tempDirs = new Set<string>();
 
 afterEach(() => {
+  __setFsSafeTestHooksForTest(undefined);
   cleanupTempDirs(tempDirs);
 });
 
@@ -40,5 +43,33 @@ describe("models-config file mode", () => {
 
     const stat = await fs.stat(modelsPath);
     expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it("retries when fs-safe detects a replaced generated catalog directory", async () => {
+    configureFsSafePython({ mode: "off" });
+    const dir = makeTempDir(tempDirs, "models-json-write-boundary-");
+    const catalogPath = path.join(dir, "plugins", "zai", "catalog.json");
+    const contents = '{"providers":{"zai":{"models":[{"id":"glm-5.1"}]}}}\n';
+    let replacementCount = 0;
+
+    __setFsSafeTestHooksForTest({
+      afterPinnedWriteFallbackRename: async (targetPath) => {
+        const isTargetCatalog =
+          path.basename(targetPath) === "catalog.json" &&
+          path.basename(path.dirname(targetPath)) === "zai";
+        if (!isTargetCatalog || replacementCount > 0) {
+          return;
+        }
+        replacementCount += 1;
+        const catalogDir = path.dirname(targetPath);
+        await fs.rename(catalogDir, `${catalogDir}.replaced`);
+        await fs.mkdir(catalogDir, { recursive: true, mode: 0o700 });
+      },
+    });
+
+    await writeModelsFileAtomicForModelsJson(catalogPath, contents);
+
+    expect(replacementCount).toBe(1);
+    await expect(fs.readFile(catalogPath, "utf8")).resolves.toBe(contents);
   });
 });

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -12,6 +12,7 @@ import {
   type OpenClawConfig,
 } from "../config/config.js";
 import { createConfigRuntimeEnv } from "../config/env-vars.js";
+import { FsSafeError } from "../infra/fs-safe.js";
 import { privateFileStore } from "../infra/private-file-store.js";
 import { resolveInstalledManifestRegistryIndexFingerprint } from "../plugins/manifest-registry-installed.js";
 import {
@@ -28,6 +29,7 @@ import {
   MODELS_JSON_STATE,
   type ModelsJsonReadyResult,
   type ModelsJsonReadyState,
+  withModelCatalogFileIoLock,
 } from "./models-config-state.js";
 import { planOpenClawModelsJson } from "./models-config.plan.js";
 import {
@@ -152,7 +154,26 @@ export async function writeModelsFileAtomicForModelsJson(
   targetPath: string,
   contents: string,
 ): Promise<void> {
-  await privateFileStore(path.dirname(targetPath)).writeText(path.basename(targetPath), contents);
+  const rootDir = path.dirname(targetPath);
+  const relativePath = path.basename(targetPath);
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      await fs.mkdir(rootDir, { recursive: true, mode: 0o700 });
+      await privateFileStore(rootDir).writeText(relativePath, contents);
+      return;
+    } catch (error) {
+      // A guarded private-store directory can be replaced during the atomic
+      // write. Retry only that transient boundary shape after re-opening it.
+      const code = (error as NodeJS.ErrnoException | undefined)?.code;
+      const shouldRetry =
+        error instanceof FsSafeError
+          ? error.code === "path-mismatch"
+          : code === "ENOENT" || code === "ENOTDIR";
+      if (!shouldRetry || attempt > 0) {
+        throw error;
+      }
+    }
+  }
 }
 
 async function isGeneratedPluginCatalogFile(targetPath: string): Promise<boolean> {
@@ -340,7 +361,7 @@ export async function buildModelsJsonSourceFingerprint(
 }
 
 async function withModelsJsonWriteLock<T>(targetPath: string, run: () => Promise<T>): Promise<T> {
-  return await MODELS_JSON_STATE.writeQueue.enqueue(targetPath, run);
+  return await withModelCatalogFileIoLock(path.dirname(targetPath), run);
 }
 
 /** Ensures models.json and plugin catalog sidecars are current for an agent. */

--- a/src/agents/models-config.write-serialization.test.ts
+++ b/src/agents/models-config.write-serialization.test.ts
@@ -2,7 +2,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { FsSafeError } from "../infra/fs-safe.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
+import type { InstalledPluginIndexRecord } from "../plugins/installed-plugin-index-types.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { resolveDefaultAgentDir } from "./agent-scope.js";
 import {
@@ -26,6 +29,8 @@ let actualPrivateFileStore:
 installModelsConfigTestHooks();
 
 let ensureOpenClawModelsJson: typeof import("./models-config.js").ensureOpenClawModelsJson;
+let loadModelCatalog: typeof import("./model-catalog.js").loadModelCatalog;
+let resetModelCatalogCacheForTest: typeof import("./model-catalog.js").resetModelCatalogCacheForTest;
 let clearCurrentPluginMetadataSnapshot: typeof import("../plugins/current-plugin-metadata-snapshot.js").clearCurrentPluginMetadataSnapshot;
 let setCurrentPluginMetadataSnapshot: typeof import("../plugins/current-plugin-metadata-snapshot.js").setCurrentPluginMetadataSnapshot;
 
@@ -70,6 +75,27 @@ function createPluginMetadataSnapshot(workspaceDir: string): PluginMetadataSnaps
       indexPluginCount: 0,
       manifestPluginCount: 0,
     },
+  };
+}
+
+function createEnabledInstalledPluginIndexRecord(
+  pluginId: string,
+  rootDir: string,
+): InstalledPluginIndexRecord {
+  return {
+    pluginId,
+    manifestPath: path.join(rootDir, "openclaw.plugin.json"),
+    manifestHash: "test-manifest-hash",
+    rootDir,
+    origin: "global",
+    enabled: true,
+    startup: {
+      sidecar: false,
+      memory: false,
+      deferConfiguredChannelFullLoadUntilAfterListen: false,
+      agentHarnesses: [],
+    },
+    compat: [],
   };
 }
 
@@ -129,6 +155,7 @@ beforeAll(async () => {
     };
   });
   ({ ensureOpenClawModelsJson } = await import("./models-config.js"));
+  ({ loadModelCatalog, resetModelCatalogCacheForTest } = await import("./model-catalog.js"));
   ({ clearCurrentPluginMetadataSnapshot, setCurrentPluginMetadataSnapshot } =
     await import("../plugins/current-plugin-metadata-snapshot.js"));
 });
@@ -256,6 +283,100 @@ describe("models-config write serialization", () => {
       expect(root.providers).toEqual({});
       expect(root).not.toHaveProperty("pluginCatalogs");
       expect(Object.keys(catalog.providers ?? {})).toEqual(["zai"]);
+    });
+  });
+
+  it("retries generated plugin catalog writes once after fs-safe path-mismatch", async () => {
+    await withModelsTempHome(async (home) => {
+      const agentDir = path.join(home, "agent");
+      const catalogPath = path.join(agentDir, "plugins", "zai", PLUGIN_MODEL_CATALOG_FILE);
+      const catalogContents = `${JSON.stringify(
+        {
+          generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+          providers: {
+            zai: {
+              models: [{ id: "glm-5.1", name: "GLM 5.1" }],
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`;
+      planOpenClawModelsJsonMock.mockImplementation(async () => ({
+        action: "write",
+        contents: `${JSON.stringify({ providers: {} })}\n`,
+        pluginCatalogWrites: {
+          [encodePluginModelCatalogRelativePath("zai")]: catalogContents,
+        },
+      }));
+
+      let catalogWriteAttempts = 0;
+      writePrivateStoreTextWriteMock.mockImplementation(
+        async (params: { filePath: string; rootDir: string; content: string | Uint8Array }) => {
+          if (params.filePath === catalogPath) {
+            catalogWriteAttempts += 1;
+            if (catalogWriteAttempts === 1) {
+              throw new FsSafeError("path-mismatch", "directory changed during operation");
+            }
+          }
+          if (!actualPrivateFileStore) {
+            throw new Error("private file store mock not initialized");
+          }
+          return await actualPrivateFileStore(params.rootDir).writeText(
+            path.basename(params.filePath),
+            params.content,
+          );
+        },
+      );
+
+      await ensureOpenClawModelsJson({}, agentDir);
+
+      expect(catalogWriteAttempts).toBe(2);
+      await expect(fs.readFile(catalogPath, "utf8")).resolves.toBe(catalogContents);
+    });
+  });
+
+  it("does not retry non-path-mismatch generated plugin catalog write failures", async () => {
+    await withModelsTempHome(async (home) => {
+      const agentDir = path.join(home, "agent");
+      const catalogPath = path.join(agentDir, "plugins", "zai", PLUGIN_MODEL_CATALOG_FILE);
+      planOpenClawModelsJsonMock.mockImplementation(async () => ({
+        action: "write",
+        contents: `${JSON.stringify({ providers: {} })}\n`,
+        pluginCatalogWrites: {
+          [encodePluginModelCatalogRelativePath("zai")]: `${JSON.stringify(
+            {
+              generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+              providers: { zai: { models: [] } },
+            },
+            null,
+            2,
+          )}\n`,
+        },
+      }));
+
+      let catalogWriteAttempts = 0;
+      writePrivateStoreTextWriteMock.mockImplementation(
+        async (params: { filePath: string; rootDir: string; content: string | Uint8Array }) => {
+          if (params.filePath === catalogPath) {
+            catalogWriteAttempts += 1;
+            throw new FsSafeError("denied-path", "private catalog path denied");
+          }
+          if (!actualPrivateFileStore) {
+            throw new Error("private file store mock not initialized");
+          }
+          return await actualPrivateFileStore(params.rootDir).writeText(
+            path.basename(params.filePath),
+            params.content,
+          );
+        },
+      );
+
+      await expect(ensureOpenClawModelsJson({}, agentDir)).rejects.toMatchObject({
+        code: "denied-path",
+      });
+      expect(catalogWriteAttempts).toBe(1);
+      await expect(fs.access(catalogPath)).rejects.toMatchObject({ code: "ENOENT" });
     });
   });
 
@@ -445,6 +566,113 @@ describe("models-config write serialization", () => {
       }>();
       expect(["Proxy A", "Proxy B with longer name"]).toContain(
         parsed.providers["custom-proxy"]?.models?.[0]?.name,
+      );
+    });
+  }, 60_000);
+
+  it("keeps read-only plugin catalog scans behind sidecar writes", async () => {
+    await withModelsTempHome(async (home) => {
+      const agentDir = resolveDefaultAgentDir({});
+      const catalogPath = path.join(agentDir, "plugins", "zai", PLUGIN_MODEL_CATALOG_FILE);
+      const oldCatalog = `${JSON.stringify(
+        {
+          generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+          providers: {
+            zai: {
+              models: [{ id: "glm-old", name: "GLM Old" }],
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`;
+      const newCatalog = `${JSON.stringify(
+        {
+          generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+          providers: {
+            zai: {
+              models: [{ id: "glm-new", name: "GLM New" }],
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`;
+      await fs.mkdir(path.dirname(catalogPath), { recursive: true });
+      await fs.writeFile(
+        path.join(agentDir, "models.json"),
+        `${JSON.stringify({ providers: {} })}\n`,
+      );
+      await fs.writeFile(catalogPath, oldCatalog);
+
+      const snapshot = createPluginMetadataSnapshot(path.join(home, "workspace"));
+      snapshot.index.plugins = [
+        createEnabledInstalledPluginIndexRecord("zai", path.join(home, "plugins", "zai")),
+      ];
+      snapshot.owners.providers = new Map([["zai", ["zai"]]]);
+      snapshot.owners.modelCatalogProviders = new Map([["zai", ["zai"]]]);
+      setCurrentPluginMetadataSnapshot(snapshot, { config: {} });
+
+      planOpenClawModelsJsonMock.mockImplementation(async () => ({
+        action: "write",
+        contents: `${JSON.stringify({ providers: {} })}\n`,
+        pluginCatalogWrites: {
+          [encodePluginModelCatalogRelativePath("zai")]: newCatalog,
+        },
+      }));
+
+      let markCatalogWriteStarted: () => void = () => {};
+      const catalogWriteStarted = new Promise<void>((resolve) => {
+        markCatalogWriteStarted = resolve;
+      });
+      let releaseCatalogWrite: () => void = () => {};
+      const catalogWriteCanContinue = new Promise<void>((resolve) => {
+        releaseCatalogWrite = resolve;
+      });
+      writePrivateStoreTextWriteMock.mockImplementation(
+        async (params: { filePath: string; rootDir: string; content: string | Uint8Array }) => {
+          if (params.filePath === catalogPath) {
+            markCatalogWriteStarted();
+            await catalogWriteCanContinue;
+          }
+          if (!actualPrivateFileStore) {
+            throw new Error("private file store mock not initialized");
+          }
+          return await actualPrivateFileStore(params.rootDir).writeText(
+            path.basename(params.filePath),
+            params.content,
+          );
+        },
+      );
+
+      const write = ensureOpenClawModelsJson({}, agentDir);
+      await catalogWriteStarted;
+      resetModelCatalogCacheForTest();
+      const readOnly = loadModelCatalog({ config: {} as OpenClawConfig, readOnly: true });
+      const earlyRead = await Promise.race([
+        readOnly.then(() => "settled" as const),
+        new Promise<"pending">((resolve) => {
+          setTimeout(() => resolve("pending"), 25);
+        }),
+      ]);
+
+      expect(earlyRead).toBe("pending");
+      releaseCatalogWrite();
+      await write;
+      const result = await readOnly;
+
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          provider: "zai",
+          id: "glm-new",
+          name: "GLM New",
+        }),
+      );
+      expect(result).not.toContainEqual(
+        expect.objectContaining({
+          provider: "zai",
+          id: "glm-old",
+        }),
       );
     });
   }, 60_000);


### PR DESCRIPTION
Closes #99390

AI-assisted: yes.

## What Problem This Solves

Fixes the model-catalog warning loop where generated plugin catalog sidecar writes can fail while the private fs-safe store is protecting `catalog.json`. The reported failure is `FsSafeError: directory changed during operation`; when it lands at the generated catalog write boundary, the sidecar file can remain unwritten and dynamic provider rows stay stale or unavailable.

## Why This Change Was Made

The fix now covers the owner-side write boundary directly:

- `writeModelsFileAtomicForModelsJson` reopens and retries the private store once when fs-safe reports a transient directory identity swap (`path-mismatch`) or when the same replacement race surfaces as `ENOENT` / `ENOTDIR` during the write.
- Generated plugin sidecar writes and read-only persisted catalog scans for the same agent directory share the existing process-wide model catalog file I/O queue, so readers no longer observe the sidecar tree mid-refresh.

The retry remains narrow: non-transient fs-safe failures such as denied paths still fail without retry. No provider catalog schema, runtime config, plugin SDK surface, dependency, or migration shape changes.

## User Impact

Gateway model-catalog refreshes can recover when a generated plugin catalog directory is replaced during the atomic private-store write. Dynamic provider discovery should be able to publish the refreshed sidecar instead of repeatedly logging the catalog load warning while leaving provider rows stale.

## Evidence

Exact head: `99d145c75fedffff1de4373800a799e6482998e7`.

- `node scripts/run-vitest.mjs src/agents/models-config.file-mode.test.ts` (1 file, 3 tests)
- `node scripts/run-vitest.mjs src/agents/models-config.write-serialization.test.ts` (1 file, 15 tests)
- `node scripts/run-vitest.mjs src/agents/model-catalog.test.ts src/agents/models-config.write-serialization.test.ts src/agents/models-config.file-mode.test.ts src/gateway/server-model-catalog.test.ts src/gateway/server-methods/models.test.ts` (7 files, 111 tests)
- `node_modules/.bin/oxfmt --check --threads=1 src/agents/models-config-state.ts src/agents/models-config.ts src/agents/model-catalog.ts src/agents/models-config.write-serialization.test.ts src/agents/models-config.file-mode.test.ts`
- `node_modules/.bin/oxlint --threads=1 src/agents/models-config-state.ts src/agents/models-config.ts src/agents/model-catalog.ts src/agents/models-config.write-serialization.test.ts src/agents/models-config.file-mode.test.ts`
- `git diff --check`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` reported no accepted/actionable findings.

Deterministic fs-safe boundary proof: `src/agents/models-config.file-mode.test.ts` uses the real `@openclaw/fs-safe` private `fileStore({ private: true })` write path. During the first atomic write of `plugins/zai/catalog.json`, the fs-safe test hook replaces the generated catalog directory after the pinned rename; `writeModelsFileAtomicForModelsJson` then retries and writes the catalog into the replacement directory. The companion serialization tests also verify that `path-mismatch` is retried once and non-transient `denied-path` is not retried.

Proof gap: I did not run a live authenticated Anthropic/systemd gateway reproduction. The new proof is deterministic at the private-store/fs-safe write boundary that prior maintainer review identified as the production failure source.
