### PR TITLE
fix(tool-payload): reject oversized XML parameters by byte length

### DIFF
--- a/packages/tool-call-repair/src/payload.ts
+++ b/packages/tool-call-repair/src/payload.ts
@@ -34,6 +34,7 @@ export type PlainTextToolCallParseOptions = {
 };
 
 const DEFAULT_MAX_PLAIN_TEXT_TOOL_PAYLOAD_BYTES = 256_000;
+const utf8Encoder = new TextEncoder();
 
 type PlainTextToolCallOpening = {
   allowsOptionalXmlishClose?: boolean;
@@ -252,7 +253,8 @@ function consumeXmlishParameterBlock(
   if (!bounds) {
     return null;
   }
-  if (bounds.end - bounds.start > maxPayloadBytes) {
+  const rawBlock = text.slice(bounds.start, bounds.end);
+  if (utf8Encoder.encode(rawBlock).byteLength > maxPayloadBytes) {
     return null;
   }
   return {
@@ -344,7 +346,8 @@ function parseXmlishPlainTextToolCallBlockAt(
     if (!parameter) {
       break;
     }
-    if (parameter.end - opening.end > maxPayloadBytes) {
+    const rawPayload = text.slice(opening.end, parameter.end);
+    if (utf8Encoder.encode(rawPayload).byteLength > maxPayloadBytes) {
       return null;
     }
     args[parameter.name] = parameter.value;

--- a/src/plugin-sdk/tool-payload.test.ts
+++ b/src/plugin-sdk/tool-payload.test.ts
@@ -242,6 +242,20 @@ describe("parseStandalonePlainTextToolCallBlocks", () => {
     ).toBeNull();
   });
 
+  it("counts serialized XML parameter payload limits in UTF-8 bytes", () => {
+    const parameter = ["<parameter=content>", "é".repeat(20), "</parameter>"].join("\n");
+    const raw = ["<function=write>", parameter, "</function>"].join("\n");
+    expect(parameter.length).toBeLessThan(64);
+    expect(new TextEncoder().encode(parameter).byteLength).toBeGreaterThan(64);
+
+    expect(
+      parseStandalonePlainTextToolCallBlocks(raw, {
+        allowedToolNames: ["write"],
+        maxPayloadBytes: 64,
+      }),
+    ).toBeNull();
+  });
+
   it("respects allowed tool names for Harmony calls", () => {
     const blocks = parseStandalonePlainTextToolCallBlocks(
       'commentary to=write code {"path":"/tmp/file.txt","content":"x"}',


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where serialized XML-style tool calls with multibyte parameter text could pass `maxPayloadBytes` even when the UTF-8 payload exceeded the configured byte limit.

## Why This Change Was Made

The XML parameter parser now checks the raw serialized parameter block and cumulative XML payload using UTF-8 byte length, matching the byte-based limit exposed by the parser option and the JSON payload path. The change stays inside the tool-call repair parser and keeps the existing public helper shape unchanged.

## User Impact

Developers and plugin-facing callers can rely on `maxPayloadBytes` to cap serialized XML parameter payloads by bytes, including non-ASCII content, before they are promoted into structured tool calls.

## Evidence

- Claim proved: XML-style plain-text tool-call parsing rejects non-ASCII parameter payloads whose UTF-8 bytes exceed `maxPayloadBytes`.
- Current-head proof at d4ac29f447f91872f7c8e6635b1403e3f6df9547: `node scripts/run-vitest.mjs src/plugin-sdk/tool-payload.test.ts` passed with 1 file / 23 tests passed.
- Committed diff hygiene: `git diff --check HEAD~1..HEAD` passed.
- Review proof: `python .agents\skills\autoreview\scripts\autoreview --mode local` passed with no accepted/actionable findings.
- Duplicate search: open GitHub issue/PR searches for `maxPayloadBytes XML parameter bytes`, `tool payload XML maxPayloadBytes`, `tool-call-repair maxPayloadBytes`, and `tool-call-repair xmlish parameter` returned no open matches.