### PR TITLE
fix: hot reload ACP runtime config

### DIFF
--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -116,6 +116,10 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
     actions: ["restart-heartbeat"],
   },
   { prefix: "agent.heartbeat", kind: "hot", actions: ["restart-heartbeat"] },
+  // ACP runtime backends are plugin services. Reload plugins when top-level ACP
+  // policy changes so newly configured backends activate without a process
+  // restart loop.
+  { prefix: "acp", kind: "hot", actions: ["reload-plugins"] },
   { prefix: "cron", kind: "hot", actions: ["restart-cron"] },
   { prefix: "mcp", kind: "hot", actions: ["dispose-mcp-runtimes"] },
   { prefix: "plugins.load", kind: "restart" },

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -314,6 +314,17 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.restartChannels).toEqual(new Set(["telegram"]));
   });
 
+  it("reloads plugins without restarting when ACP runtime config changes", () => {
+    const changedPaths = ["acp.enabled", "acp.backend", "acp.defaultAgent"];
+    const plan = buildGatewayReloadPlan(changedPaths);
+
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartReasons).toStrictEqual([]);
+    expect(plan.reloadPlugins).toBe(true);
+    expect(plan.hotReasons).toEqual(changedPaths);
+    expect(plan.noopPaths).toStrictEqual([]);
+  });
+
   it("keeps installed channel plugin source changes restart-backed", () => {
     const plan = buildGatewayReloadPlan(["plugins.installs.telegram.installPath"]);
 
@@ -1616,6 +1627,50 @@ describe("startGatewayConfigReloader", () => {
     expect(plan.restartGateway).toBe(false);
     expect(plan.reloadPlugins).toBe(true);
     expect(plan.hotReasons).toEqual(["plugins.entries.telegram.enabled"]);
+    expect(hotConfig).toBe(nextConfig);
+
+    await harness.reloader.stop();
+  });
+
+  it("hot-reloads plugins when ACP config is added while the gateway is running", async () => {
+    const previousConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+    };
+    const nextConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      acp: { enabled: true, backend: "acpx", defaultAgent: "claude" },
+    };
+    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValueOnce(
+      makeSnapshot({
+        sourceConfig: nextConfig,
+        runtimeConfig: nextConfig,
+        config: nextConfig,
+        hash: "acp-runtime-1",
+      }),
+    );
+    const harness = createReloaderHarness(readSnapshot, {
+      initialConfig: previousConfig,
+      initialCompareConfig: previousConfig,
+    });
+
+    harness.emitWrite({
+      configPath: "/tmp/openclaw.json",
+      sourceConfig: nextConfig,
+      runtimeConfig: nextConfig,
+      persistedHash: "acp-runtime-1",
+      revision: 1,
+      fingerprint: "runtime-acp-runtime-1",
+      sourceFingerprint: "source-acp-runtime-1",
+      writtenAtMs: Date.now(),
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(harness.onRestart).not.toHaveBeenCalled();
+    const [plan, hotConfig] = getOnlyHotReloadCall(harness);
+    expect(plan.changedPaths).toEqual(["acp"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.reloadPlugins).toBe(true);
+    expect(plan.hotReasons).toEqual(["acp"]);
     expect(hotConfig).toBe(nextConfig);
 
     await harness.reloader.stop();


### PR DESCRIPTION
Closes #102205

AI-assisted.

## What Problem This Solves

Fixes an issue where operators who add ACP runtime config while the Gateway is already running would have that `acp` change classified as requiring a full Gateway restart. In the reported systemd flow, that restart path could repeat and leave the embedded `acpx` backend unavailable after the self-triggered restart.

## Why This Change Was Made

Top-level ACP runtime config controls plugin-owned ACP backend services, so the Gateway reload planner now treats `acp.*` changes as a hot plugin reload instead of a process restart. This keeps the existing plugin activation boundary intact: changing ACP policy reloads plugin services, which lets `acpx` register its backend again without restarting the Gateway process.

## User Impact

Users can add or update ACP config on a running Gateway and expect the Gateway to reload the ACP backend in-process. The Gateway should no longer schedule a process restart just because `acp.enabled`, `acp.backend`, or related ACP runtime policy changed.

## Evidence

Focused regression test:

```text
node scripts/run-vitest.mjs src/gateway/config-reload.test.ts
Test Files  4 passed (4)
Tests  356 passed (356)
```

Live Gateway behavior after the fix, using a temporary local config with no initial `acp` key, then writing `acp.enabled/backend/defaultAgent` while the Gateway was running:

```text
[reload] config change detected; evaluating reload (acp)
[plugins] embedded acpx runtime backend registered lazily
[reload] config hot reload applied (acp)
```

There was no `config change requires gateway restart (acp)` log in that run.

Real local agent proof with DeepSeek:

```text
node dist/entry.js agent --local --agent main --model deepseek/deepseek-v4-pro --message 'Reply with exactly: openclaw-102205-ok' --timeout 180 --json
provider=deepseek model=deepseek-v4-pro status=200
finalAssistantVisibleText: openclaw-102205-ok
stopReason: stop
```

Additional validation:

```text
pnpm build
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
node scripts/run-oxlint.mjs src/gateway/config-reload-plan.ts src/gateway/config-reload.test.ts
node_modules/.bin/oxfmt --check --threads=1 src/gateway/config-reload-plan.ts src/gateway/config-reload.test.ts
git diff --check
```
