### PR TITLE
fix(tlon): strip internal tool-trace banners from outbound text

### DIFF
--- a/extensions/tlon/src/channel.ts
+++ b/extensions/tlon/src/channel.ts
@@ -11,6 +11,7 @@ import {
   createComputedAccountStatusAdapter,
   createDefaultChannelRuntimeState,
 } from "openclaw/plugin-sdk/status-helpers";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { tlonChannelConfigSchema } from "./config-schema.js";
 import { tlonDoctor } from "./doctor.js";
 import { resolveTlonOutboundSessionRoute } from "./session-route.js";
@@ -64,6 +65,7 @@ const tlonConfigAdapter = createHybridChannelConfigAdapter({
 const tlonChannelOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   textChunkLimit: 10000,
+  sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
   resolveTarget: ({ to }) => resolveTlonOutboundTarget(to),
   deliveryCapabilities: {
     durableFinal: {

--- a/extensions/tlon/src/outbound-tool-trace-sanitize.test.ts
+++ b/extensions/tlon/src/outbound-tool-trace-sanitize.test.ts
@@ -1,0 +1,21 @@
+// Tlon outbound must strip assistant internal tool-trace scaffolding, matching
+// the sibling channel fixes tracked under #90684 (Feishu / Mattermost / Slack /
+// Signal / Matrix / Telegram / Google Chat / QQBot / IRC / SMS).
+// sanitizeAssistantVisibleText keeps ordinary markdown prose intact for Tlon
+// chat rendering.
+import { describe, expect, it } from "vitest";
+import { tlonPlugin } from "./channel.js";
+
+describe("tlon outbound sanitizeText", () => {
+  it("strips internal tool-trace banners before outbound delivery", () => {
+    const text = "Done.\n⚠️ 🛠️ `search repos (agent)` failed";
+
+    expect(tlonPlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe("Done.");
+  });
+
+  it("preserves ordinary assistant prose while sanitizing", () => {
+    const text = "The pipeline has 3 open deals.";
+
+    expect(tlonPlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe(text);
+  });
+});


### PR DESCRIPTION
Related: #90684 (Tlon slice)

## What Problem This Solves

Addresses the Tlon slice of #90684: Tlon users can see internal assistant
tool-call/tool-trace markup — XML tool-call tags and banners such as
`⚠️ 🛠️ \`search repos (agent)\` failed` — verbatim in their DMs and group
chats when an agent reply carries leftover internal markup.

The shared delivery pipeline applies the assistant-visible sanitizer only
when a channel adapter defines the outbound `sanitizeText` hook. The Tlon
adapter does not define it, so Tlon delivers raw text while sibling adapters
(most recently Feishu #98705 and Mattermost #98693) already strip this
markup. I did not find an open PR covering the Tlon adapter during
pre-submit review.

## Why This Change Was Made

`tlonChannelOutbound` was missing the `sanitizeText` hook, and the shared
pipeline only sanitizes when that hook exists. This wires
`sanitizeAssistantVisibleText` into the hook; the single adapter object feeds
both the plugin `outbound` surface and the channel message adapter, so one
wiring point covers both delivery routes.

This follows the per-channel hook pattern established by the merged sibling
fixes and fills an adapter that has no candidate PR. It takes no position on
the per-channel vs. shared-default design question discussed on #90684, and
does not close that umbrella. Inbound sanitization and
`sanitizeAssistantVisibleText` itself are unchanged.

## User Impact

Tlon users no longer receive internal tool-call/tool-trace markup in
outbound messages; ordinary prose and markdown pass through unchanged. No
config changes, no behavior change for any other channel.

## Evidence

- New regression test `extensions/tlon/src/outbound-tool-trace-sanitize.test.ts`:
  tool-trace banner is stripped before delivery; ordinary assistant prose
  passes through unchanged (over-strip negative control). Assertions run
  against the real plugin adapter export (no mocks of the sanitizer itself).
- Full tlon extension suite: `node scripts/run-vitest.mjs extensions/tlon`
  → 17 files / 143 tests passed (includes the new file).
- `oxfmt --check` and `scripts/run-oxlint.mjs` clean on both touched files.

### Live behavior proof (production send path, captured at the ship HTTP boundary)

Captured with `node --import tsx` against the real production pipeline — no
product code mocked: `deliverOutboundPayloads` (`src/infra/outbound/deliver.ts`)
→ tlon plugin bootstrap → OpenClaw's real Urbit login request flow
(`POST /~/login`) → real `chat-dm-action` poke `PUT /~/channel/<id>`. The
substitution is at the network boundary: a local HTTP capture server stands in
for the Urbit ship and records the exact poke bytes OpenClaw would send to a
ship. This is boundary-capture proof, not a live hosted ship run (declared
below). Isolated `OPENCLAW_STATE_DIR`; ship `~zod` with its well-known
development code and a loopback URL (no private ships, endpoints, or
credentials involved).

Input payload 1: `"Done.\n⚠️ 🛠️ \`search repos (agent)\` failed"` (tool-trace
banner). Input payload 2: `"The pipeline has 3 open deals."` (ordinary prose).

With this fix (head 370326fb63) the outgoing memo is banner-free:

```
{ "app": "chat", "mark": "chat-dm-action",
  "json": { "ship": "~sampel-palnet", "diff": { "delta": { "add": { "memo": {
    "content": [ { "inline": [ "Done." ] } ], "author": "~zod" } } } } } }

banner present in ship payload: false
prose present in ship payload: true
```

Negative control — same script with `extensions/tlon/src/channel.ts` reverted
to the base commit (fc05a8103b), everything else identical: the internal
banner leaves OpenClaw verbatim in the outgoing poke:

```
"content": [ { "inline": [ "Done.", { "break": null },
                           "⚠️ 🛠️ ",
                           { "inline-code": "search repos (agent)" },
                           " failed" ] } ]

banner present in ship payload: true
prose present in ship payload: true
```

Both runs completed with OpenClaw's own per-payload delivery receipts from
the exercised send path (not hosted-ship acknowledgements), so sanitization
happens in the send path itself, not via a dropped or failed payload.

- Not run: a credentialed round trip against a live hosted Tlon/Urbit ship.
  The capture above exercises the full OpenClaw send path up to the ship's
  HTTP interface.
