### PR TITLE
fix(gateway): hot-reload acp config instead of restarting gateway

### DIFF
--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -132,6 +132,7 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
 ];
 
 const BASE_RELOAD_RULES_TAIL: ReloadRule[] = [
+  { prefix: "acp", kind: "hot", actions: ["reload-plugins"] },
   { prefix: "meta", kind: "none" },
   { prefix: "identity", kind: "none" },
   { prefix: "wizard", kind: "none" },

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -509,6 +509,25 @@ describe("buildGatewayReloadPlan", () => {
     });
   });
 
+  it("hot-reloads plugins for acp config changes instead of restarting", () => {
+    const path = "acp.enabled";
+    const plan = buildGatewayReloadPlan([path]);
+
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartReasons).toStrictEqual([]);
+    expect(plan.reloadPlugins).toBe(true);
+    expect(resolveConfigReloadMetadata(path).kind).toBe("hot");
+  });
+
+  it("hot-reloads plugins for acp.backend config changes", () => {
+    const path = "acp.backend";
+    const plan = buildGatewayReloadPlan([path]);
+
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.reloadPlugins).toBe(true);
+    expect(resolveConfigReloadMetadata(path).kind).toBe("hot");
+  });
+
   it("prefers channel restart prefixes over a broad no-op prefix", () => {
     const changedPaths = [
       "channels.whatsapp.accounts.default.enabled",


### PR DESCRIPTION
## What Problem This Solves

Fixes #102205 — adding `acp` config to `openclaw.json` triggers an infinite
gateway restart loop: gateway auto-enables acpx, detects the acp key as a
config change requiring restart, restarts, and repeats.

## Root Cause

`src/gateway/config-reload-plan.ts` has no reload rule for the `acp` top-level
config key. When `acp` is added or changed, `matchRule("acp")` returns null,
defaulting to `kind: "restart"`. This triggers a full gateway restart even
though acpx runtime can be hot-reloaded via `reload-plugins`.

## Fix

Add `{ prefix: "acp", kind: "hot", actions: ["reload-plugins"] }` to
`BASE_RELOAD_RULES_TAIL`. ACP config changes now hot-reload plugins instead of
restarting the gateway.

1 line in `src/gateway/config-reload-plan.ts`.

## Evidence

### End-to-End Proof — production gateway

**Before (main `4bf70be01a`):**

ACP config change triggers restart loop:

```
config change detected; evaluating reload (…acp)
config change requires gateway restart (acp)
http server listening (14 plugins: acpx, …)    ← first start ok
[restart]
http server listening (13 plugins: …)          ← acpx gone after self-restart
config change detected; evaluating reload (…acp)  ← detects again
config change requires gateway restart (acp)   ← loops forever
```

**After (this PR):**

Same ACP config. Gateway stable with acpx loaded, no self-triggered restart:

```
embedded acpx runtime backend registered lazily
http server listening (14 plugins: acpx, …)    ← acpx loaded, stable
```

Gateway has been stable for 30+ minutes. No "config change requires gateway
restart" since deploying the fix.

### Regression Test

Added 2 tests in `src/gateway/config-reload.test.ts`:
- `"hot-reloads plugins for acp config changes instead of restarting"` —
  verifies `acp.enabled` changes are hot-reloaded with `reloadPlugins: true`
- `"hot-reloads plugins for acp.backend config changes"` — same for
  `acp.backend`

```
node scripts/run-vitest.mjs src/gateway/config-reload.test.ts
Test Files  4 passed (4)  Tests  356 passed (356)
```

- [x] oxfmt + oxlint pass
- [x] git diff --check pass
- [x] Production gateway stable with acpx loaded (14 plugins)
