### PR TITLE
fix(web-search): reject impossible Perplexity dates

### DIFF
--- a/src/agents/tools/web-search-provider-common.ts
+++ b/src/agents/tools/web-search-provider-common.ts
@@ -232,7 +232,7 @@ function isValidIsoDate(value: string): boolean {
 
 export function isoToPerplexityDate(iso: string): string | undefined {
   const match = iso.match(ISO_DATE_PATTERN);
-  if (!match) {
+  if (!match || !isValidIsoDate(iso)) {
     return undefined;
   }
   const [, year, month, day] = match;

--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -87,6 +87,7 @@ describe("web_search date normalization", () => {
 
   it("rejects invalid ISO dates", () => {
     expect(isoToPerplexityDate("1/15/2024")).toBeUndefined();
+    expect(isoToPerplexityDate("2024-02-30")).toBeUndefined();
     expect(isoToPerplexityDate("invalid")).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running Perplexity-backed `web_search` with date filters could pass impossible ISO calendar dates such as `2024-02-30`, and OpenClaw would convert them into provider date parameters instead of rejecting the invalid filter.

## Why This Change Was Made

The shared Perplexity date conversion now reuses the existing ISO calendar-date validator before formatting dates for Perplexity. This keeps the fix inside the web-search helper boundary and leaves the existing valid ISO and Perplexity date formats unchanged.

## User Impact

Users get consistent date-filter validation before a Perplexity web search is dispatched, avoiding confusing provider requests for impossible dates.

## Evidence

- Claim proved: impossible ISO dates are rejected by the Perplexity date conversion while valid dates still format normally.
- Current-head proof at `564f1b960bb496fcd7c7fdf040dc7d7080a88350`: `node scripts/run-vitest.mjs src/agents/tools/web-search.test.ts` passed in `E:/code/openclaw-lane-perplexity` with 1 test file and 23 tests passing.
- Committed diff hygiene: `git diff --check HEAD~1..HEAD` passed.
- Review proof: `python .agents/skills/autoreview/scripts/autoreview --mode local` passed with no accepted/actionable findings.
- Observed result: `isoToPerplexityDate("2024-02-30")` now returns `undefined`; valid ISO dates such as `2024-01-15` continue to convert to Perplexity's `M/D/YYYY` format.