### PR TITLE
fix(signal): handle stdout/stderr stream errors in daemon stdio transport

### DIFF
--- a/extensions/signal/src/daemon.test.ts
+++ b/extensions/signal/src/daemon.test.ts
@@ -1,7 +1,8 @@
 // Signal tests cover daemon plugin behavior.
+import { EventEmitter } from "node:events";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { testApi } from "./daemon.js";
 
 describe("signal daemon args", () => {
@@ -21,6 +22,58 @@ describe("signal daemon args", () => {
       "127.0.0.1:8080",
       "--no-receive-stdout",
     ]);
+  });
+});
+
+describe("signal daemon stdio stream error handling", () => {
+  it("routes stdout 'error' events to the error callback instead of throwing", () => {
+    const stream = new EventEmitter() as NodeJS.ReadableStream;
+    const log = vi.fn();
+    const error = vi.fn();
+    testApi.bindSignalCliOutput({ stream, log, error });
+
+    // Before the fix this would propagate as an unhandled EventEmitter error
+    // and crash the gateway process.
+    expect(() => {
+      stream.emit("error", new Error("write EPIPE"));
+    }).not.toThrow();
+
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining("signal-cli stdio error: Error: write EPIPE"),
+    );
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("routes stderr 'error' events to the error callback instead of throwing", () => {
+    const stream = new EventEmitter() as NodeJS.ReadableStream;
+    const error = vi.fn();
+    testApi.bindSignalCliOutput({ stream, log: vi.fn(), error });
+
+    expect(() => {
+      stream.emit("error", new Error("read EIO"));
+    }).not.toThrow();
+
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining("signal-cli stdio error: Error: read EIO"),
+    );
+  });
+
+  it("does not interfere with normal data events after an error", () => {
+    const stream = new EventEmitter() as NodeJS.ReadableStream;
+    const log = vi.fn();
+    const error = vi.fn();
+    testApi.bindSignalCliOutput({ stream, log, error });
+
+    stream.emit("error", new Error("transient"));
+    stream.emit("data", Buffer.from("INFO  DaemonCommand - started\n"));
+
+    expect(log).toHaveBeenCalledWith("signal-cli: INFO  DaemonCommand - started");
+  });
+
+  it("is a no-op for a null stream", () => {
+    expect(() => {
+      testApi.bindSignalCliOutput({ stream: null, log: vi.fn(), error: vi.fn() });
+    }).not.toThrow();
   });
 });
 

--- a/extensions/signal/src/daemon.ts
+++ b/extensions/signal/src/daemon.ts
@@ -73,6 +73,14 @@ function bindSignalCliOutput(params: {
       }
     }
   });
+  // Without this handler an 'error' event on the stream (broken pipe, abrupt
+  // child termination, fd close while data is buffered) becomes an unhandled
+  // Node.js EventEmitter error and crashes the gateway process. The child
+  // 'exit'/'close' listeners on spawnSignalDaemon already cover the process
+  // lifecycle; the stream error only needs to be logged, not re-throw.
+  params.stream?.on("error", (err) => {
+    params.error(`signal-cli stdio error: ${String(err)}`);
+  });
 }
 
 function resolveSignalCliConfigPath(raw: string): string {
@@ -178,4 +186,5 @@ export const testApi = {
   buildDaemonArgs,
   classifySignalCliLogLine,
   resolveSignalCliConfigPath,
+  bindSignalCliOutput,
 } as const;


### PR DESCRIPTION
## What Problem This Solves

`bindSignalCliOutput` in `extensions/signal/src/daemon.ts` attaches `'data'`
listeners to the long-lived `signal-cli` child process stdout and stderr, but
registers no `'error'` listener on either stream.

Node.js EventEmitter throws an unhandled `'error'` event as an uncaught
exception when no `'error'` listener is registered. If `signal-cli`'s stdout
or stderr emits `'error'` — common causes are a broken pipe after abrupt child
termination, an fd closed while data is still buffered, or a read EIO after
the child's file descriptors are torn down — the gateway process crashes.

The child `'error'` listener at `spawnSignalDaemon` line 160 only catches
spawn failures (e.g. `ENOENT`/`EACCES`); it does not cover stream-level errors
after the process has started. `child.on("exit")`/`child.on("close")` cover the
process lifecycle, but those events do not prevent a prior stream `'error'` from
being unhandled.

This fix adds an `'error'` handler to `bindSignalCliOutput` that routes the
error message to the caller-supplied `error` logger and lets the
`'exit'`/`'close'` lifecycle listeners complete the shutdown sequence as
before. This mirrors the pattern iMessage uses for its stdio RPC transport
(`extensions/imessage/src/client.ts:135-137`).

## Why This Change Was Made

The missing handler is a class-A Node.js crash path: any broken-pipe on a
stream with listeners but no `'error'` handler is fatal to the process. The fix
is a single `stream?.on("error", ...)` call in the shared binding helper, so
both stdout and stderr are covered by one change. No existing behavior is
altered: the data classifier, log routing, and process shutdown sequence are
unchanged.

`bindSignalCliOutput` is also promoted to `testApi` to allow direct regression
coverage without spawning a real `signal-cli` process.

## User Impact

**Before:** An abrupt `signal-cli` termination, broken pipe, or fd error on
stdout/stderr after process start crashes the OpenClaw gateway process with an
unhandled `Error: write EPIPE` (or similar). Users lose the entire gateway
session — all in-flight turns, pending deliveries, and open WebSocket
connections are torn down.

**After:** The stream error is logged (`signal-cli stdio error: …`) and the
normal `'exit'`/`'close'` lifecycle path handles the process shutdown. The
gateway does not crash.

## Evidence

Branch: `fix/signal-daemon-stdio-stream-errors`  
Base: `upstream/main` (`c69724ef3b508eb42189d1731c1bcd85027ddb22`)  
Node: v22.22.0 — macOS Darwin 24.3.0 arm64

### Regression test (direct stream mock — no real signal-cli required)

```
$ node scripts/run-vitest.mjs extensions/signal/src/daemon.test.ts --reporter=verbose

 ✓ signal daemon stdio stream error handling > routes stdout 'error' events to the error callback instead of throwing 4ms
 ✓ signal daemon stdio stream error handling > routes stderr 'error' events to the error callback instead of throwing 0ms
 ✓ signal daemon stdio stream error handling > does not interfere with normal data events after an error 1ms
 ✓ signal daemon stdio stream error handling > is a no-op for a null stream 1ms
 ✓ signal daemon args > expands home-relative configPath before passing it to signal-cli 83ms
 ✓ signal daemon log classification > keeps routine signal-cli warnings out of error state 1ms
 ✓ signal daemon log classification > keeps recoverable prekey decrypt receive failures out of error state 1ms
 ✓ signal daemon log classification > still surfaces signal-cli failures as errors 1ms

 Test Files  1 passed (1)
      Tests  8 passed (8)
   Duration  461ms
```

### Real behavior proof

Behavior addressed: an `'error'` event on a `signal-cli` stdio stream must be
caught and logged, not crash the gateway process.

Real environment tested: local OpenClaw source checkout, Node.js v22.22.0,
using the real `bindSignalCliOutput` export via the `testApi` surface. No live
`signal-cli` process was required; the stream is an `EventEmitter` that emits
`'error'` directly.

Exact command run after this patch:

```bash
node --import tsx --input-type=module <<'EOF'
import { EventEmitter } from "node:events";
import { testApi } from "./extensions/signal/src/daemon.ts";

const errors = [];
const stream = new EventEmitter();
testApi.bindSignalCliOutput({ stream, log: () => {}, error: (msg) => errors.push(msg) });

let threw = false;
process.once("uncaughtException", () => { threw = true; });
stream.emit("error", new Error("write EPIPE"));
await new Promise(r => setTimeout(r, 10));
console.log(JSON.stringify({ threw, errors, listener_count: stream.listenerCount("error") }));
EOF
```

Evidence after fix:

```json
{"threw":false,"errors":["signal-cli stdio error: Error: write EPIPE"],"listener_count":1}
```

Observed result after fix: `threw: false` — the unhandled-exception path was
NOT triggered. The error was routed to the `errors` array by the registered
`'error'` listener. Gateway process stays alive.

What was not tested: live `signal-cli` binary with a real broken-pipe scenario
(requires a local Signal account and signal-cli install). The regression tests
and inline proof cover the entire `bindSignalCliOutput` error path without a
live binary.

### Format check

```
$ git diff --check
(no output — clean)
```

### Diff summary

```
extensions/signal/src/daemon.ts      |  9 ++++++ (prod: 1 handler + 1 testApi export)
extensions/signal/src/daemon.test.ts | 55 +++++  (4 new regression cases)
2 files changed, 63 insertions(+), 1 deletion(-)
```

- [x] AI-assisted (Cursor / Claude Sonnet 4.6)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
