### PR TITLE
[Bug]: web_fetch reports exact-size responses as truncated (#101837)

### DIFF
--- a/src/agents/tools/web-shared.test.ts
+++ b/src/agents/tools/web-shared.test.ts
@@ -129,6 +129,24 @@ describe("readResponseText", () => {
     expect(releaseLock).toHaveBeenCalledTimes(1);
   });
 
+  it("does not mark exact-limit bounded reads as truncated", async () => {
+    const cancel = vi.fn(async () => undefined);
+    const releaseLock = vi.fn();
+    const response = responseFromReader({
+      chunks: ["hello"],
+      cancel,
+      releaseLock,
+    });
+
+    await expect(readResponseText(response, { maxBytes: 5 })).resolves.toEqual({
+      text: "hello",
+      truncated: false,
+      bytesRead: 5,
+    });
+    expect(cancel).not.toHaveBeenCalled();
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
   it("cancels and releases bounded response readers after truncation", async () => {
     const cancel = vi.fn(async () => undefined);
     const releaseLock = vi.fn();

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -272,8 +272,7 @@ export async function readResponseText(
         bytesRead += chunk.byteLength;
         parts.push(chunk);
 
-        if (truncated || bytesRead >= maxBytes) {
-          truncated = true;
+        if (truncated) {
           break;
         }
       }


### PR DESCRIPTION
## Summary

Fixes #101837

`readResponseText` incorrectly marks responses as `truncated: true` when the total bytes read exactly equal `maxBytes`, even though no data was actually omitted.

## Root Cause

In `src/agents/tools/web-shared.ts:275`:
```ts
if (truncated || bytesRead >= maxBytes) {
  truncated = true;
  break;
}
```

When `bytesRead === maxBytes`, the condition fires before confirming whether more data exists. The `truncated` variable was already correctly set at lines 264-268 when an overflow chunk was confirmed.

## Fix

Remove the `|| bytesRead >= maxBytes` check from line 275. If `bytesRead === maxBytes` and the stream is done, the next `reader.read()` returns `{ done: true }` → clean exit with `truncated: false`. If more data exists, the next chunk triggers the overflow logic at line 262 which correctly sets `truncated: true`.

## Evidence

- **2 files changed**: 19 insertions, 2 deletions
- **New test**: "does not mark exact-limit bounded reads as truncated" — 5-byte chunk with `maxBytes: 5` → expects `truncated: false`, reader not cancelled
- **All tests pass**: 24/24 (2 test files)

## Checklist

- [x] One PR = one issue
- [x] Tests added/updated
- [x] All tests pass
- [x] Link to issue in PR body