### PR TITLE
fix(ui): keep clampText/truncateText surrogate-safe at emoji boundaries

### DIFF
--- a/ui/src/lib/format.test.ts
+++ b/ui/src/lib/format.test.ts
@@ -274,70 +274,21 @@ describe("formatTokens", () => {
   });
 });
 
-describe("clampText surrogate-safe truncation", () => {
-  it("does not split an emoji across the truncation boundary", () => {
-    // 121 UTF-16 units: 119 'a's then an emoji (surrogate pair at 119-120).
-    // With max = 120, naive slice(0, 119) keeps only the emoji's high surrogate.
-    const value = `${"a".repeat(119)}\u{1F600}`;
-    expect(value.length).toBe(121);
+describe("text truncation", () => {
+  it("keeps clampText output valid when the ellipsis boundary bisects an emoji", () => {
+    expect(clampText(`${"a".repeat(118)}😀x`, 120)).toBe(`${"a".repeat(118)}…`);
+  });
 
-    const result = clampText(value, 120);
-
-    // The emoji should be entirely dropped, leaving the 119 'a's + "…"
-    expect(result).toBe(`${"a".repeat(119)}…`);
-    // No dangling surrogates
-    for (let i = 0; i < result.length; i++) {
-      const cu = result.charCodeAt(i);
-      if (cu >= 0xd800 && cu <= 0xdbff) {
-        expect(result.charCodeAt(i + 1) >= 0xdc00 && result.charCodeAt(i + 1) <= 0xdfff).toBe(true);
-      }
-      if (cu >= 0xdc00 && cu <= 0xdfff) {
-        expect(
-          i > 0 && result.charCodeAt(i - 1) >= 0xd800 && result.charCodeAt(i - 1) <= 0xdbff,
-        ).toBe(true);
-      }
-    }
+  it("keeps truncateText output valid when the boundary bisects an emoji", () => {
+    expect(truncateText(`${"a".repeat(120)}😀`, 121)).toEqual({
+      text: "a".repeat(120),
+      truncated: true,
+      total: 122,
+    });
   });
 
   it("leaves short text unchanged", () => {
     expect(clampText("hello", 120)).toBe("hello");
-  });
-
-  it("appends ellipsis when truncated", () => {
-    expect(clampText("x".repeat(200), 120)).toMatch(/…$/);
-  });
-});
-
-describe("truncateText surrogate-safe truncation", () => {
-  it("does not split an emoji across the truncation boundary", () => {
-    // 121 UTF-16 units: 120 'a's then an emoji at index 120.
-    const value = `${"a".repeat(120)}\u{1F600}`;
-    expect(value.length).toBe(122);
-
-    const result = truncateText(value, 121);
-
-    expect(result.truncated).toBe(true);
-    // The emoji should be dropped entirely
-    expect(result.text).not.toContain("\u{1F600}");
-    // No dangling surrogates
-    for (let i = 0; i < result.text.length; i++) {
-      const cu = result.text.charCodeAt(i);
-      if (cu >= 0xd800 && cu <= 0xdbff) {
-        expect(
-          result.text.charCodeAt(i + 1) >= 0xdc00 && result.text.charCodeAt(i + 1) <= 0xdfff,
-        ).toBe(true);
-      }
-      if (cu >= 0xdc00 && cu <= 0xdfff) {
-        expect(
-          i > 0 &&
-            result.text.charCodeAt(i - 1) >= 0xd800 &&
-            result.text.charCodeAt(i - 1) <= 0xdbff,
-        ).toBe(true);
-      }
-    }
-  });
-
-  it("returns truncated: false for short text", () => {
     expect(truncateText("hello", 120)).toEqual({
       text: "hello",
       truncated: false,
@@ -345,10 +296,8 @@ describe("truncateText surrogate-safe truncation", () => {
     });
   });
 
-  it("reports correct total for truncated text", () => {
-    const result = truncateText("x".repeat(200), 120);
-    expect(result.truncated).toBe(true);
-    expect(result.total).toBe(200);
-    expect(result.text.length).toBeLessThan(200);
+  it("preserves ordinary truncation behavior", () => {
+    expect(clampText("abc", 2)).toBe("a…");
+    expect(truncateText("abc", 2)).toEqual({ text: "ab", truncated: true, total: 3 });
   });
 });

--- a/ui/src/lib/format.test.ts
+++ b/ui/src/lib/format.test.ts
@@ -1,6 +1,7 @@
 // Control UI tests cover format behavior.
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  clampText,
   formatDateTimeMs,
   formatDateMs,
   formatCompactTokenCount,
@@ -11,6 +12,7 @@ import {
   formatUnknownText,
   parseSessionKeyParts,
   setUiTimeFormatPreference,
+  truncateText,
 } from "./format.ts";
 import { stripThinkingTags } from "./strip-thinking-tags.ts";
 
@@ -269,5 +271,84 @@ describe("formatTokens", () => {
     expect(formatTokens(12_345)).toBe("12k");
     expect(formatTokens(5_500)).toBe("5.5k");
     expect(formatTokens(null)).toBe("0");
+  });
+});
+
+describe("clampText surrogate-safe truncation", () => {
+  it("does not split an emoji across the truncation boundary", () => {
+    // 121 UTF-16 units: 119 'a's then an emoji (surrogate pair at 119-120).
+    // With max = 120, naive slice(0, 119) keeps only the emoji's high surrogate.
+    const value = `${"a".repeat(119)}\u{1F600}`;
+    expect(value.length).toBe(121);
+
+    const result = clampText(value, 120);
+
+    // The emoji should be entirely dropped, leaving the 119 'a's + "…"
+    expect(result).toBe(`${"a".repeat(119)}…`);
+    // No dangling surrogates
+    for (let i = 0; i < result.length; i++) {
+      const cu = result.charCodeAt(i);
+      if (cu >= 0xd800 && cu <= 0xdbff) {
+        expect(result.charCodeAt(i + 1) >= 0xdc00 && result.charCodeAt(i + 1) <= 0xdfff).toBe(true);
+      }
+      if (cu >= 0xdc00 && cu <= 0xdfff) {
+        expect(
+          i > 0 && result.charCodeAt(i - 1) >= 0xd800 && result.charCodeAt(i - 1) <= 0xdbff,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("leaves short text unchanged", () => {
+    expect(clampText("hello", 120)).toBe("hello");
+  });
+
+  it("appends ellipsis when truncated", () => {
+    expect(clampText("x".repeat(200), 120)).toMatch(/…$/);
+  });
+});
+
+describe("truncateText surrogate-safe truncation", () => {
+  it("does not split an emoji across the truncation boundary", () => {
+    // 121 UTF-16 units: 120 'a's then an emoji at index 120.
+    const value = `${"a".repeat(120)}\u{1F600}`;
+    expect(value.length).toBe(122);
+
+    const result = truncateText(value, 121);
+
+    expect(result.truncated).toBe(true);
+    // The emoji should be dropped entirely
+    expect(result.text).not.toContain("\u{1F600}");
+    // No dangling surrogates
+    for (let i = 0; i < result.text.length; i++) {
+      const cu = result.text.charCodeAt(i);
+      if (cu >= 0xd800 && cu <= 0xdbff) {
+        expect(
+          result.text.charCodeAt(i + 1) >= 0xdc00 && result.text.charCodeAt(i + 1) <= 0xdfff,
+        ).toBe(true);
+      }
+      if (cu >= 0xdc00 && cu <= 0xdfff) {
+        expect(
+          i > 0 &&
+            result.text.charCodeAt(i - 1) >= 0xd800 &&
+            result.text.charCodeAt(i - 1) <= 0xdbff,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("returns truncated: false for short text", () => {
+    expect(truncateText("hello", 120)).toEqual({
+      text: "hello",
+      truncated: false,
+      total: 5,
+    });
+  });
+
+  it("reports correct total for truncated text", () => {
+    const result = truncateText("x".repeat(200), 120);
+    expect(result.truncated).toBe(true);
+    expect(result.total).toBe(200);
+    expect(result.text.length).toBeLessThan(200);
   });
 });

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -1,5 +1,6 @@
 // Control UI module implements format behavior.
 import { asDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatDurationHuman } from "../../../src/infra/format-time/format-duration.ts";
 import { formatRelativeTimestamp } from "../../../src/infra/format-time/format-relative.ts";
 import { t } from "../i18n/index.ts";
@@ -110,7 +111,7 @@ export function clampText(value: string, max = 120): string {
   if (value.length <= max) {
     return value;
   }
-  return `${value.slice(0, Math.max(0, max - 1))}…`;
+  return `${truncateUtf16Safe(value, Math.max(0, max - 1))}…`;
 }
 
 export function truncateText(
@@ -125,7 +126,7 @@ export function truncateText(
     return { text: value, truncated: false, total: value.length };
   }
   return {
-    text: value.slice(0, Math.max(0, max)),
+    text: truncateUtf16Safe(value, Math.max(0, max)),
     truncated: true,
     total: value.length,
   };


### PR DESCRIPTION
## What Problem This Solves

The shared Control UI `clampText` and `truncateText` helpers used raw UTF-16 code-unit slicing. If a limit fell between an astral character's surrogate halves, rendered markdown, tool/activity previews, skill descriptions, or execution-approval text could contain a lone surrogate.

## Why This Change Was Made

Both shared formatters now delegate their cut to the repository's canonical `truncateUtf16Safe` helper. Short text, ordinary ASCII truncation, ellipsis placement, and `truncateText` metadata remain unchanged.

The maintainer fixup also corrected the original `clampText` fixture: its emoji began immediately after the old end-exclusive slice boundary, so that test passed before the production fix. The replacement places the high surrogate inside the cut and asserts exact output; 64 lines of manual surrogate scanning were removed.

## User Impact

Control UI truncation no longer produces malformed text when a boundary crosses an emoji or another astral character.

## Evidence

- Exact `clampText` regression: 118 ASCII units followed by an emoji and one trailing character at a 120-unit display cap produces 118 ASCII units plus the ellipsis.
- Exact `truncateText` regression: 120 ASCII units followed by an emoji at a 121-unit cap produces 120 ASCII units and retains the original total of 122.
- Short-text and ordinary ASCII behavior remain covered.
- Targeted oxfmt and `git diff --check`: pass.
- Fresh maintainer autoreview: clean, confidence 0.98.
- Exact-head CI run `28991500251` on `ed138d7b03edd2d4513cfad57a584a376284ea9c`: success (57 checks).

AI-assisted: yes. Maintainer-reviewed and tightened.
