### PR TITLE
fix(config): enforce own-key semantics in write preparation

### DIFF
--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -774,10 +774,7 @@ describe("config io write", () => {
     });
   });
 
-  it("writeConfigFile drops keys that exist only on the next-config prototype", async () => {
-    // Production path: writeConfigFile → resolvePersistCandidateForWrite → createMergePatch.
-    // A nextConfig that inherits `commands` must not adopt the inherited value; the own-key
-    // check deletes it instead of persisting the prototype payload.
+  it("drops keys that exist only on the next-config prototype", async () => {
     await withSuiteHome(async (home) => {
       const configPath = path.join(home, ".openclaw", "openclaw.json");
       await fs.mkdir(path.dirname(configPath), { recursive: true });
@@ -801,22 +798,19 @@ describe("config io write", () => {
         logger: silentLogger,
       });
 
-      const nextConfig = Object.create({
-        commands: { ownerDisplay: "raw" },
-      }) as Record<string, unknown>;
-      nextConfig.gateway = { mode: "local", port: 19001 };
+      const nextConfig = Object.assign(
+        Object.create({ commands: { ownerDisplay: "raw" } }) as Record<string, unknown>,
+        { gateway: { mode: "local", port: 19001 } },
+      );
 
       await io.writeConfigFile(nextConfig as OpenClawConfig);
 
-      const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
-        gateway?: { mode?: string; port?: number };
-        commands?: unknown;
-        meta?: unknown;
-      };
+      const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as Record<
+        string,
+        unknown
+      >;
       expect(persisted.gateway).toEqual({ mode: "local", port: 19001 });
       expect(Object.hasOwn(persisted, "commands")).toBe(false);
-      // Write path stamps meta; collision must not resurrect the prototype commands payload.
-      expect(persisted.commands).toBeUndefined();
     });
   });
 

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -774,6 +774,52 @@ describe("config io write", () => {
     });
   });
 
+  it("writeConfigFile drops keys that exist only on the next-config prototype", async () => {
+    // Production path: writeConfigFile → resolvePersistCandidateForWrite → createMergePatch.
+    // A nextConfig that inherits `commands` must not adopt the inherited value; the own-key
+    // check deletes it instead of persisting the prototype payload.
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        `${JSON.stringify(
+          {
+            gateway: { mode: "local", port: 18789 },
+            commands: { ownerDisplay: "hash" },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf-8",
+      );
+
+      const io = createConfigIO({
+        configPath,
+        env: { OPENCLAW_TEST_FAST: "1" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+
+      const nextConfig = Object.create({
+        commands: { ownerDisplay: "raw" },
+      }) as Record<string, unknown>;
+      nextConfig.gateway = { mode: "local", port: 19001 };
+
+      await io.writeConfigFile(nextConfig as OpenClawConfig);
+
+      const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
+        gateway?: { mode?: string; port?: number };
+        commands?: unknown;
+        meta?: unknown;
+      };
+      expect(persisted.gateway).toEqual({ mode: "local", port: 19001 });
+      expect(Object.hasOwn(persisted, "commands")).toBe(false);
+      // Write path stamps meta; collision must not resurrect the prototype commands payload.
+      expect(persisted.commands).toBeUndefined();
+    });
+  });
+
   it("does not log an overwrite audit entry when creating config for the first time", async () => {
     await withSuiteHome(async (home) => {
       const warn = vi.fn();

--- a/src/config/io.write-prepare.test.ts
+++ b/src/config/io.write-prepare.test.ts
@@ -5,7 +5,6 @@ import {
   applyUnsetPathsForWrite,
   createMergePatch,
   formatConfigValidationFailure,
-  projectSourceOntoRuntimeShape,
   restoreEnvRefsFromMap,
   resolvePersistCandidateForWrite,
   resolveWriteEnvSnapshotForPath,
@@ -31,46 +30,6 @@ describe("config io write prepare", () => {
       safe: { mode: "cloud" },
       collision: null,
     });
-  });
-
-  it("preserves authored keys whose names match Object.prototype members", () => {
-    const source = {
-      commands: {
-        toString: { enabled: true },
-      },
-    };
-    // Runtime inherits a record-shaped `toString`. Own-key checks must keep the
-    // authored value instead of projecting through the prototype record.
-    const runtime = {
-      commands: Object.create({
-        toString: { fromProto: true },
-      }) as Record<string, unknown>,
-    };
-
-    expect(projectSourceOntoRuntimeShape(source, runtime)).toEqual(source);
-  });
-
-  it("persists caller changes without adopting inherited peer keys", () => {
-    const nextConfig = Object.create({
-      collision: { mode: "inherited-next" },
-    }) as Record<string, unknown>;
-    nextConfig.gateway = { mode: "local", port: 19001 };
-
-    const persisted = resolvePersistCandidateForWrite({
-      runtimeConfig: {
-        gateway: { mode: "local", port: 18789 },
-        collision: { mode: "owned-runtime" },
-      },
-      sourceConfig: {
-        gateway: { mode: "local", port: 18789 },
-      },
-      nextConfig,
-    });
-
-    expect(persisted).toEqual({
-      gateway: { mode: "local", port: 19001 },
-    });
-    expect(Object.hasOwn(persisted as object, "collision")).toBe(false);
   });
 
   it("persists caller changes onto resolved config without leaking runtime defaults", () => {

--- a/src/config/io.write-prepare.test.ts
+++ b/src/config/io.write-prepare.test.ts
@@ -2,8 +2,10 @@
 import { describe, expect, it } from "vitest";
 import {
   collectChangedPaths,
-  formatConfigValidationFailure,
   applyUnsetPathsForWrite,
+  createMergePatch,
+  formatConfigValidationFailure,
+  projectSourceOntoRuntimeShape,
   restoreEnvRefsFromMap,
   resolvePersistCandidateForWrite,
   resolveWriteEnvSnapshotForPath,
@@ -12,6 +14,65 @@ import {
 import type { OpenClawConfig } from "./types.js";
 
 describe("config io write prepare", () => {
+  it("ignores prototype-chain keys when building merge patches", () => {
+    // Discriminating fixture: `collision` is own on base and only inherited on
+    // target. With `key in target` the old code treated the inherited value as
+    // present and emitted it in the patch; Object.hasOwn deletes the own key.
+    const base = {
+      safe: { mode: "local" },
+      collision: { mode: "owned-base" },
+    };
+    const target = Object.create({
+      collision: { mode: "inherited-target" },
+    }) as Record<string, unknown>;
+    target.safe = { mode: "cloud" };
+
+    expect(createMergePatch(base, target)).toEqual({
+      safe: { mode: "cloud" },
+      collision: null,
+    });
+  });
+
+  it("preserves authored keys whose names match Object.prototype members", () => {
+    const source = {
+      commands: {
+        toString: { enabled: true },
+      },
+    };
+    // Runtime inherits a record-shaped `toString`. Own-key checks must keep the
+    // authored value instead of projecting through the prototype record.
+    const runtime = {
+      commands: Object.create({
+        toString: { fromProto: true },
+      }) as Record<string, unknown>,
+    };
+
+    expect(projectSourceOntoRuntimeShape(source, runtime)).toEqual(source);
+  });
+
+  it("persists caller changes without adopting inherited peer keys", () => {
+    const nextConfig = Object.create({
+      collision: { mode: "inherited-next" },
+    }) as Record<string, unknown>;
+    nextConfig.gateway = { mode: "local", port: 19001 };
+
+    const persisted = resolvePersistCandidateForWrite({
+      runtimeConfig: {
+        gateway: { mode: "local", port: 18789 },
+        collision: { mode: "owned-runtime" },
+      },
+      sourceConfig: {
+        gateway: { mode: "local", port: 18789 },
+      },
+      nextConfig,
+    });
+
+    expect(persisted).toEqual({
+      gateway: { mode: "local", port: 19001 },
+    });
+    expect(Object.hasOwn(persisted as object, "collision")).toBe(false);
+  });
+
   it("persists caller changes onto resolved config without leaking runtime defaults", () => {
     const persisted = resolvePersistCandidateForWrite({
       runtimeConfig: {
@@ -1044,6 +1105,25 @@ describe("config io write prepare", () => {
         { id: "a", token: "${TOKEN_A}" },
       ],
     });
+  });
+
+  it("ignores prototype-chain keys when collecting changed paths", () => {
+    // Same one-sided collision as the merge-patch fixture: own on base, only
+    // inherited on target. Old `in` checks walked into collision.mode; hasOwn
+    // reports the top-level own-key removal instead.
+    const base = {
+      safe: { mode: "local" },
+      collision: { mode: "owned-base" },
+    };
+    const target = Object.create({
+      collision: { mode: "inherited-target" },
+    }) as Record<string, unknown>;
+    target.safe = { mode: "cloud" };
+
+    const changedPaths = new Set<string>();
+    collectChangedPaths(base, target, "", changedPaths);
+
+    expect([...changedPaths].toSorted()).toEqual(["collision", "safe.mode"]);
   });
 
   it("does not overwrite identity-restored escaped refs with positional map entries", () => {

--- a/src/config/io.write-prepare.ts
+++ b/src/config/io.write-prepare.ts
@@ -71,7 +71,7 @@ export function projectSourceOntoRuntimeShape(source: unknown, runtime: unknown)
 
   const next: Record<string, unknown> = {};
   for (const [key, sourceValue] of Object.entries(source)) {
-    if (!Object.hasOwn(runtime, key)) {
+    if (!(key in runtime)) {
       next[key] = cloneUnknown(sourceValue);
       continue;
     }

--- a/src/config/io.write-prepare.ts
+++ b/src/config/io.write-prepare.ts
@@ -37,8 +37,8 @@ export function createMergePatch(base: unknown, target: unknown): unknown {
   const patch: Record<string, unknown> = {};
   const keys = new Set([...Object.keys(base), ...Object.keys(target)]);
   for (const key of keys) {
-    const hasBase = key in base;
-    const hasTarget = key in target;
+    const hasBase = Object.hasOwn(base, key);
+    const hasTarget = Object.hasOwn(target, key);
     if (!hasTarget) {
       patch[key] = null;
       continue;
@@ -71,7 +71,7 @@ export function projectSourceOntoRuntimeShape(source: unknown, runtime: unknown)
 
   const next: Record<string, unknown> = {};
   for (const [key, sourceValue] of Object.entries(source)) {
-    if (!(key in runtime)) {
+    if (!Object.hasOwn(runtime, key)) {
       next[key] = cloneUnknown(sourceValue);
       continue;
     }
@@ -1155,8 +1155,8 @@ export function collectChangedPaths(
     const keys = new Set([...Object.keys(base), ...Object.keys(target)]);
     for (const key of keys) {
       const childPath = path ? `${path}.${key}` : key;
-      const hasBase = key in base;
-      const hasTarget = key in target;
+      const hasBase = Object.hasOwn(base, key);
+      const hasTarget = Object.hasOwn(target, key);
       if (!hasTarget || !hasBase) {
         output.add(childPath);
         continue;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

`collectChangedPaths` enumerates own keys with `Object.keys`, but used the `in`
operator to decide whether each peer contained a key. Because `in` walks the
prototype chain, an own key on one peer and an inherited-only key on the other
was misclassified as a nested edit instead of a top-level add or removal.

The submitted patch also covered `createMergePatch`. That source fix landed
independently on current `main` in #101694; this PR retains a direct regression
test so the two write-preparation helpers keep the same own-key invariant.

## Why This Change Was Made

`Object.hasOwn(obj, key)` matches the helpers' existing own-key traversal. The
maintainer refactor removed a non-discriminating runtime-shape projection case
and redundant coverage, leaving the smallest complete behavior proof at the
correct owner boundary.

## User Impact

**Before:** Config write preparation could descend into values inherited from a
custom prototype and report the wrong changed path.

**After:** Prototype-only peer keys are treated as absent. Config persistence
does not resurrect inherited values, and changed paths identify the correct
top-level add or removal.

## Evidence

- Direct regressions cover `createMergePatch` and `collectChangedPaths` with a
  one-sided own/inherited collision.
- A production-path regression calls `createConfigIO().writeConfigFile` against
  a real temporary `openclaw.json` and proves an inherited `commands` value is
  not persisted.
- Blacksmith Testbox `tbx_01kxc9bc4h98s2rp4qfj0d3wrg`, Actions run
  `29212818274`: 123 focused tests passed.
- The same Testbox passed touched-file formatting and all `check:changed`
  core/coreTests lanes.
- `git diff --check` passed.
- Fresh autoreview returned no actionable findings (0.93 confidence).

Known gap: no interactive configure-TUI run. The production config-file write
path is exercised directly, so a TUI run would not cross an additional boundary
for this internal helper fix.

- [x] AI-assisted (Cursor / Grok, maintainer refactor by Codex)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
