### PR TITLE
fix: web_fetch reports exact-size responses as truncated

### DIFF
--- a/src/agents/tools/web-shared.test.ts
+++ b/src/agents/tools/web-shared.test.ts
@@ -129,6 +129,42 @@ describe("readResponseText", () => {
     expect(releaseLock).toHaveBeenCalledTimes(1);
   });
 
+  it("returns an exact-maxBytes body as complete", async () => {
+    const cancel = vi.fn(async () => undefined);
+    const releaseLock = vi.fn();
+    const response = responseFromReader({
+      chunks: ["hello", " world"],
+      cancel,
+      releaseLock,
+    });
+
+    await expect(readResponseText(response, { maxBytes: 11 })).resolves.toEqual({
+      text: "hello world",
+      truncated: false,
+      bytesRead: 11,
+    });
+    expect(cancel).not.toHaveBeenCalled();
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  it("truncates when a further chunk follows an exact-maxBytes read", async () => {
+    const cancel = vi.fn(async () => undefined);
+    const releaseLock = vi.fn();
+    const response = responseFromReader({
+      chunks: ["hello", " world", "!"],
+      cancel,
+      releaseLock,
+    });
+
+    await expect(readResponseText(response, { maxBytes: 11 })).resolves.toEqual({
+      text: "hello world",
+      truncated: true,
+      bytesRead: 11,
+    });
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
   it("cancels and releases bounded response readers after truncation", async () => {
     const cancel = vi.fn(async () => undefined);
     const releaseLock = vi.fn();

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -272,10 +272,12 @@ export async function readResponseText(
         bytesRead += chunk.byteLength;
         parts.push(chunk);
 
-        if (truncated || bytesRead >= maxBytes) {
-          truncated = true;
+        if (truncated) {
           break;
         }
+        // bytesRead === maxBytes alone is not proof of truncation: the body may
+        // end exactly at the cap. Keep reading so EOF returns a complete result;
+        // any further non-empty chunk hits the remaining<=0 branch above.
       }
     } catch {
       // Best-effort: return whatever we read so far.


### PR DESCRIPTION
Closes #101837

## What Problem This Solves

Fixes an issue where users calling `web_fetch` against a response whose streamed body is exactly `maxResponseBytes` bytes would see a misleading "Response body truncated after N bytes" warning, even though no bytes were omitted. The false flag also flowed into spill handling, treating complete content as source-truncated.

## Why This Change Was Made

The bounded stream reader in `src/agents/tools/web-shared.ts` marked a read as truncated as soon as `bytesRead >= maxBytes`, without confirming another byte actually exists. The fix keeps reading at the exact-limit boundary: EOF now returns `truncated: false`, while any further non-empty chunk takes the existing overflow branch and reports truncation as before. Oversized-body behavior (including reader cancellation) is unchanged.

## User Impact

Responses that are exactly the configured byte limit are now returned as complete — no spurious truncation warning and no incorrect spill/truncation handling. Oversized responses are still truncated and flagged exactly as before.

## Evidence

Two regression tests added in `src/agents/tools/web-shared.test.ts`:
- an exact-`maxBytes` body (EOF at the cap) resolves with `truncated: false` and no reader cancellation
- a body with a further chunk past the cap still resolves with `truncated: true` and cancels the reader

```
pnpm test src/agents/tools/web-shared.test.ts
 Test Files  1 passed (1)
      Tests  13 passed (13)

pnpm test src/agents/tools/web-fetch.test.ts
 Test Files  1 passed (1)
      Tests  14 passed (14)
```

Note: run locally (Node 22.22.2, macOS) as a contributor checkout; no Crabbox/Testbox access from this environment.
