### PR TITLE
fix(sdk): normalized gateway event ids drop zero seq and ts values

### DIFF
--- a/packages/sdk/src/normalize.test.ts
+++ b/packages/sdk/src/normalize.test.ts
@@ -32,3 +32,30 @@ describe("normalizeGatewayEvent terminal tool item status", () => {
     );
   });
 });
+
+describe("normalizeGatewayEvent id", () => {
+  it("keeps zero seq and ts components in the normalized event id", () => {
+    const event = normalizeGatewayEvent({
+      event: "agent",
+      seq: 0,
+      payload: {
+        runId: "r1",
+        sessionKey: "main",
+        ts: 0,
+        stream: "lifecycle",
+        data: { phase: "start" },
+      },
+    });
+
+    expect(event.id).toBe("0:agent:r1:main:0");
+  });
+
+  it("still drops absent parts from the normalized event id", () => {
+    const event = normalizeGatewayEvent({
+      event: "health",
+      payload: { ts: 123 },
+    });
+
+    expect(event.id).toBe("local:health:123");
+  });
+});

--- a/packages/sdk/src/normalize.ts
+++ b/packages/sdk/src/normalize.ts
@@ -177,7 +177,11 @@ export function normalizeGatewayEvent(event: GatewayEvent): OpenClawEvent {
   const taskId = readString(payload.taskId);
   const agentId = readString(payload.agentId);
   const ts = readNumber(payload.ts) ?? Date.now();
-  const idParts = [event.seq ?? "local", event.event, runId, sessionKey, ts].filter(Boolean);
+  // Gateway seq starts at 0 and ts may be 0; only absent parts are dropped so
+  // zero values keep contributing to the replay/dedupe identity.
+  const idParts = [event.seq ?? "local", event.event, runId, sessionKey, ts].filter(
+    (part) => part !== undefined,
+  );
 
   return {
     version: 1,


### PR DESCRIPTION
Closes #101768

## What Problem This Solves

Fixes an issue where SDK consumers relying on normalized gateway event IDs would get unstable or colliding IDs when an event carries a protocol-valid `seq: 0` (or `ts: 0`): the zero components were silently dropped from the ID, weakening event replay/dedupe identity.

## Why This Change Was Made

`normalizeGatewayEvent()` built the event ID with `.filter(Boolean)`, which removes `0` alongside genuinely absent parts. The gateway protocol allows `seq` starting at `0` (`EventFrameSchema` uses `Type.Integer({ minimum: 0 })`), so the filter now drops only `undefined` parts and keeps zero values. Absent `seq` still maps to the `"local"` placeholder, and absent `runId`/`sessionKey` are still omitted, so IDs for non-zero events are unchanged.

## User Impact

SDK consumers deduping or replaying normalized gateway events (e.g. `OpenClawClient`'s `seen.has(event.id)` dedupe) now get a distinct, stable ID for zero-sequence events instead of an ID that collides with the seq-less form. No visible change for any event with non-zero components.

## Evidence

Two regression tests added in `packages/sdk/src/normalize.test.ts`:
- `seq: 0` with `payload.ts: 0` produces `"0:agent:r1:main:0"` (zero components preserved)
- an event without `seq`/`runId`/`sessionKey` still produces `"local:health:123"` (absent parts dropped, placeholder unchanged)

```
pnpm test packages/sdk
 Test Files  3 passed (3)
      Tests  48 passed (48)
```

Consumer check: normalized IDs are used only as opaque dedupe keys in `packages/sdk/src/client.ts`; nothing parses the ID format.

Note: run locally (Node 22.22.2, macOS) as a contributor checkout; no Crabbox/Testbox access from this environment.
