### PR TITLE
fix: keep isolated cron setup running when workspace state is inaccessible

### DIFF
--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -176,6 +176,57 @@ describe("ensureAgentWorkspace", () => {
     expect(legacyStateStat.isDirectory()).toBe(true);
   });
 
+  it("continues setup without writing state when canonical setup state is inaccessible", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    await writeWorkspaceFile({
+      dir: tempDir,
+      name: DEFAULT_IDENTITY_FILENAME,
+      content: "configured identity\n",
+    });
+    await writeWorkspaceFile({
+      dir: tempDir,
+      name: DEFAULT_USER_FILENAME,
+      content: "configured user\n",
+    });
+
+    const statePath = path.join(tempDir, ...WORKSPACE_STATE_PATH_SEGMENTS);
+    const originalReadFile = fs.readFile.bind(fs);
+    const originalOpen = fs.open.bind(fs);
+    const originalRename = fs.rename.bind(fs);
+    const readSpy = vi.spyOn(fs, "readFile").mockImplementation((async (filePath, options) => {
+      if (filePath === statePath) {
+        throw Object.assign(new Error(`EPERM: operation not permitted, open '${statePath}'`), {
+          code: "EPERM",
+        });
+      }
+      return await originalReadFile(filePath, options as never);
+    }) as typeof fs.readFile);
+    const openSpy = vi.spyOn(fs, "open").mockImplementation((async (filePath, flags, mode) => {
+      if (filePath === statePath) {
+        throw new Error(`unexpected write to inaccessible setup state: ${statePath}`);
+      }
+      return await originalOpen(filePath, flags as never, mode as never);
+    }) as typeof fs.open);
+    const renameSpy = vi.spyOn(fs, "rename").mockImplementation((async (oldPath, newPath) => {
+      if (newPath === statePath) {
+        throw new Error(`unexpected replacement of inaccessible setup state: ${statePath}`);
+      }
+      return await originalRename(oldPath, newPath);
+    }) as typeof fs.rename);
+
+    try {
+      await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+      await expectPathMissing(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
+      expect(readSpy).toHaveBeenCalledWith(statePath, "utf-8");
+      expect(openSpy).not.toHaveBeenCalledWith(statePath, expect.anything(), expect.anything());
+      expect(renameSpy).not.toHaveBeenCalledWith(expect.anything(), statePath);
+    } finally {
+      readSpy.mockRestore();
+      openSpy.mockRestore();
+      renameSpy.mockRestore();
+    }
+  });
+
   it("refuses to re-seed a recently attested workspace after the directory disappears", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -55,6 +55,7 @@ const WORKSPACE_ONBOARDING_PROFILE_FILENAMES = [
 const TRANSIENT_WORKSPACE_READ_CODES = new Set(["EAGAIN", "EWOULDBLOCK", "EINTR"]);
 const TRANSIENT_WORKSPACE_READ_ERRNOS = new Set([-11, -4]);
 const TRANSIENT_WORKSPACE_READ_MESSAGE = /Unknown system error -(?:11|4)\b/i;
+const WORKSPACE_SETUP_STATE_ACCESS_DENIED_CODES = new Set(["EACCES", "EPERM"]);
 
 const workspaceTemplateCache = new Map<string, Promise<string>>();
 let gitAvailabilityPromise: Promise<boolean> | null = null;
@@ -451,6 +452,7 @@ async function reconcileWorkspaceBootstrapCompletionState(params: {
   bootstrapPath: string;
   statePath: string;
   state: WorkspaceSetupState;
+  canPersistState: boolean;
   bootstrapExists?: boolean;
 }): Promise<WorkspaceBootstrapCompletionReconcileResult> {
   const bootstrapExists = params.bootstrapExists ?? (await pathExists(params.bootstrapPath));
@@ -462,6 +464,9 @@ async function reconcileWorkspaceBootstrapCompletionState(params: {
   }
 
   if (params.state.bootstrapSeededAt && !bootstrapExists) {
+    if (!params.canPersistState) {
+      return { repaired: false, bootstrapExists: false, state: params.state };
+    }
     const completedState: WorkspaceSetupState = {
       ...params.state,
       setupCompletedAt: new Date().toISOString(),
@@ -485,6 +490,9 @@ async function reconcileWorkspaceBootstrapCompletionState(params: {
     bootstrapSeededAt: params.state.bootstrapSeededAt ?? now,
     setupCompletedAt: now,
   };
+  if (!params.canPersistState) {
+    return { repaired: false, bootstrapExists, state: params.state };
+  }
   await writeWorkspaceSetupState(params.statePath, repairedState);
   try {
     await fs.rm(params.bootstrapPath, { force: true });
@@ -719,6 +727,13 @@ function needsWorkspaceSetupStateRewrite(raw: string, state: WorkspaceSetupState
   );
 }
 
+function isWorkspaceSetupStateAccessDeniedError(err: unknown): boolean {
+  const anyErr = err as { code?: string };
+  return (
+    typeof anyErr.code === "string" && WORKSPACE_SETUP_STATE_ACCESS_DENIED_CODES.has(anyErr.code)
+  );
+}
+
 async function readWorkspaceSetupStateFile(statePath: string): Promise<{
   raw: string;
   state: WorkspaceSetupState;
@@ -738,11 +753,22 @@ async function readWorkspaceSetupStateFile(statePath: string): Promise<{
 
 async function readWorkspaceSetupStateForDir(
   dir: string,
-  opts?: { persistLegacyMigration?: boolean },
+  opts?: { onCanonicalStateInaccessible?: () => void; persistLegacyMigration?: boolean },
 ): Promise<WorkspaceSetupState> {
   const resolvedDir = resolveUserPath(dir);
   const statePath = resolveWorkspaceStatePath(resolvedDir);
-  const canonical = await readWorkspaceSetupStateFile(statePath);
+  let canonicalStateInaccessible = false;
+  let canonical: Awaited<ReturnType<typeof readWorkspaceSetupStateFile>>;
+  try {
+    canonical = await readWorkspaceSetupStateFile(statePath);
+  } catch (err) {
+    if (!isWorkspaceSetupStateAccessDeniedError(err)) {
+      throw err;
+    }
+    canonicalStateInaccessible = true;
+    opts?.onCanonicalStateInaccessible?.();
+    canonical = null;
+  }
   if (canonical) {
     if (
       opts?.persistLegacyMigration &&
@@ -766,7 +792,9 @@ async function readWorkspaceSetupStateForDir(
     return { version: WORKSPACE_STATE_VERSION };
   }
   if (opts?.persistLegacyMigration && hasWorkspaceSetupStateMarker(legacy.state)) {
-    await writeWorkspaceSetupState(statePath, legacy.state);
+    if (!canonicalStateInaccessible) {
+      await writeWorkspaceSetupState(statePath, legacy.state);
+    }
   }
   return legacy.state;
 }
@@ -907,6 +935,10 @@ export async function ensureAgentWorkspace(params?: {
   const heartbeatPath = path.join(dir, DEFAULT_HEARTBEAT_FILENAME);
   const bootstrapPath = path.join(dir, DEFAULT_BOOTSTRAP_FILENAME);
   const statePath = resolveWorkspaceStatePath(dir);
+  let canonicalSetupStateInaccessible = false;
+  const markCanonicalSetupStateInaccessible = () => {
+    canonicalSetupStateInaccessible = true;
+  };
 
   const isBrandNewWorkspace = await (async () => {
     const templatePaths = [agentsPath, soulPath, toolsPath, identityPath, userPath, heartbeatPath];
@@ -936,6 +968,7 @@ export async function ensureAgentWorkspace(params?: {
   if (recentAttestationPath && !isBrandNewWorkspace) {
     const bootstrapExists = await pathExists(bootstrapPath);
     const state = await readWorkspaceSetupStateForDir(dir, {
+      onCanonicalStateInaccessible: markCanonicalSetupStateInaccessible,
       persistLegacyMigration: true,
     });
     const hasSetupState = hasWorkspaceSetupStateMarker(state);
@@ -993,6 +1026,7 @@ export async function ensureAgentWorkspace(params?: {
   }
 
   let state = await readWorkspaceSetupStateForDir(dir, {
+    onCanonicalStateInaccessible: markCanonicalSetupStateInaccessible,
     persistLegacyMigration: true,
   });
   let stateDirty = false;
@@ -1011,6 +1045,7 @@ export async function ensureAgentWorkspace(params?: {
     const repair = await reconcileWorkspaceBootstrapCompletionState({
       dir,
       bootstrapPath,
+      canPersistState: !canonicalSetupStateInaccessible,
       statePath,
       state,
       bootstrapExists,
@@ -1054,7 +1089,9 @@ export async function ensureAgentWorkspace(params?: {
   }
 
   if (stateDirty) {
-    await writeWorkspaceSetupState(statePath, state);
+    if (!canonicalSetupStateInaccessible) {
+      await writeWorkspaceSetupState(statePath, state);
+    }
   }
   await ensureGitRepo(dir, isBrandNewWorkspace);
   await maybeWriteWorkspaceAttestation(attestationPath, dir);


### PR DESCRIPTION
## Root cause
`readWorkspaceSetupStateFile()` reads the canonical `openclaw-workspace-state.json` in `src/agents/workspace.ts`, but on `origin/main` it only suppresses `ENOENT`; `EPERM`/`EACCES` is rethrown. During isolated cron setup, that aborts the run before the agent-turn payload executes, matching the failing Home Solar Generation Monitor error: `EPERM: operation not permitted, open '/Users/aaroneden/.openclaw/openclaw-workspace-state.json'`.

## Fix
Treat access-denied reads of canonical workspace setup-state metadata as recoverable absence for the setup pass, and avoid writing setup-state back to that inaccessible path during the same pass. Other workspace setup errors remain fatal.

## Sibling occurrences
`rg "readWorkspaceSetupStateFile|readWorkspaceSetupStateForDir|writeWorkspaceSetupState\\(|openclaw-workspace-state\\.json|workspace-state\\.json" src packages scripts --glob '*.ts'` found the canonical setup-state reader/writer only in `src/agents/workspace.ts`; other hits were test fixtures or legacy state setup.

## Test
Added a regression in `src/agents/workspace.test.ts` that forces the canonical `openclaw-workspace-state.json` read to return `EPERM` and asserts setup continues without writing that inaccessible state file.

RED on unmodified `origin/main` plus the regression:
`pnpm test -- src/agents/workspace.test.ts -t "continues setup without writing state when canonical setup state is inaccessible"` failed with `Error: EPERM: operation not permitted, open '/Users/aaroneden/.openclaw/tmp/openclaw-workspace-5n0bKn/openclaw-workspace-state.json'`.

GREEN after the fix:
- `pnpm test -- src/agents/workspace.test.ts -t "continues setup without writing state when canonical setup state is inaccessible"` passed.
- `pnpm test -- src/agents/workspace.test.ts` passed, 56 tests.
- `pnpm exec oxfmt --check src/agents/workspace.ts src/agents/workspace.test.ts` passed.
- `pnpm lint` passed.
- `pnpm check:test-types` passed.
- `pnpm check` passed.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm check:changed` passed.

Note: repository-wide `pnpm format:check` currently fails on 190 pre-existing files, while the two changed files pass direct `oxfmt --check`.
