### PR TITLE
fix(tool-call-repair): preserve visible suffix when XML tool text is incomplete

### DIFF
--- a/packages/tool-call-repair/src/grammar.ts
+++ b/packages/tool-call-repair/src/grammar.ts
@@ -197,6 +197,7 @@ function indexOfAsciiMarkerIgnoreCase(text: string, marker: string, start: numbe
 /** Returns the end offset for a complete XML-ish or bracketed plain-text tool call. */
 export function findXmlishToolCallEnd(text: string): number | null {
   let cursor: number;
+  let allowsOptionalFunctionClose = false;
   const xmlFunction = /^<function=[A-Za-z0-9_.:-]+>/i.exec(text);
   if (xmlFunction) {
     cursor = xmlFunction[0].length;
@@ -205,6 +206,7 @@ export function findXmlishToolCallEnd(text: string): number | null {
     if (!bracketed) {
       return null;
     }
+    allowsOptionalFunctionClose = bracketed[0].startsWith("[tool:");
     cursor = bracketed[0].length;
     cursor = skipHorizontalWhitespace(text, cursor);
     cursor = skipSerializedToolCallTrailingLineBreak(text, cursor);
@@ -225,7 +227,9 @@ export function findXmlishToolCallEnd(text: string): number | null {
       return skipSerializedToolCallTrailingLineBreak(text, cursor + "</function>".length);
     }
     if (!startsWithAsciiMarkerIgnoreCase(text, cursor, "<parameter=")) {
-      return skipSerializedToolCallTrailingLineBreak(text, cursor);
+      return allowsOptionalFunctionClose
+        ? skipSerializedToolCallTrailingLineBreak(text, cursor)
+        : null;
     }
   }
   return null;

--- a/packages/tool-call-repair/src/stream-normalizer.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.ts
@@ -9,6 +9,7 @@ import {
   isPlainTextToolNameChar,
   isXmlishNameChar,
   matchesLiteralPrefix,
+  skipWhitespace,
 } from "./grammar.js";
 
 export type PlainTextToolCallNameMatcher = {
@@ -313,6 +314,58 @@ function stripCompleteSerializedToolCallPrefix(
   return text.slice(consumeJsonToolClosingMarker(text, jsonEnd));
 }
 
+function startsWithAsciiIgnoreCase(text: string, marker: string, start: number): boolean {
+  return text.slice(start, start + marker.length).toLowerCase() === marker;
+}
+
+function indexOfAsciiIgnoreCase(text: string, marker: string, start: number): number {
+  let cursor = start;
+  while (cursor < text.length) {
+    const next = text.indexOf(marker[0] ?? "", cursor);
+    if (next === -1) {
+      return -1;
+    }
+    if (startsWithAsciiIgnoreCase(text, marker, next)) {
+      return next;
+    }
+    cursor = next + 1;
+  }
+  return -1;
+}
+
+function stripIncompletePlainBracketedXmlishToolCallPrefix(
+  text: string,
+  matcher: PlainTextToolCallNameMatcher,
+): string | null {
+  const trimmed = text.trimStart();
+  const bracketed = /^\[([A-Za-z0-9_-]+)\]/.exec(trimmed);
+  if (!bracketed?.[1] || !matcher.hasExactName(bracketed[1])) {
+    return null;
+  }
+  if (findXmlishToolCallEnd(trimmed) !== null) {
+    return null;
+  }
+
+  let cursor = skipWhitespace(trimmed, bracketed[0].length);
+  if (!startsWithAsciiIgnoreCase(trimmed, "<parameter=", cursor)) {
+    return null;
+  }
+  while (cursor < trimmed.length) {
+    const parameterClose = indexOfAsciiIgnoreCase(trimmed, "</parameter>", cursor);
+    if (parameterClose === -1) {
+      return null;
+    }
+    cursor = skipWhitespace(trimmed, parameterClose + "</parameter>".length);
+    if (startsWithAsciiIgnoreCase(trimmed, "</function>", cursor)) {
+      return null;
+    }
+    if (!startsWithAsciiIgnoreCase(trimmed, "<parameter=", cursor)) {
+      return trimmed.slice(cursor);
+    }
+  }
+  return null;
+}
+
 function stripSerializedToolCallPrefixes(
   text: string,
   matcher: PlainTextToolCallNameMatcher,
@@ -523,6 +576,18 @@ function scrubFirstOverCapTextPrefixFromContent(
   const suppressedTextIndexes = new Set<number>();
   let accumulated = "";
   let reachedOverCap = false;
+  const scrubWithVisibleSuffix = (index: number) => {
+    const visibleSuffix = stripIncompletePlainBracketedXmlishToolCallPrefix(accumulated, matcher);
+    return visibleSuffix === null
+      ? null
+      : scrubSuppressedTextIndexesFromContent(
+          content,
+          suppressedTextIndexes,
+          options,
+          visibleSuffix,
+          index,
+        );
+  };
   for (let index = 0; index < content.length; index += 1) {
     const record = asRecord(content[index]);
     if (record?.type !== "text" || typeof record.text !== "string") {
@@ -561,6 +626,10 @@ function scrubFirstOverCapTextPrefixFromContent(
           index,
         );
       }
+      const scrubbed = scrubWithVisibleSuffix(index);
+      if (scrubbed !== null) {
+        return scrubbed;
+      }
       continue;
     }
     if (state === "impossible") {
@@ -575,6 +644,10 @@ function scrubFirstOverCapTextPrefixFromContent(
             index,
           );
         }
+        const scrubbed = scrubWithVisibleSuffix(index);
+        if (scrubbed !== null) {
+          return scrubbed;
+        }
         return scrubSuppressedTextIndexesFromContent(content, suppressedTextIndexes, options);
       }
       accumulated = "";
@@ -583,6 +656,12 @@ function scrubFirstOverCapTextPrefixFromContent(
     }
   }
   if (reachedOverCap) {
+    const lastSuppressedIndex = Array.from(suppressedTextIndexes).at(-1);
+    const scrubbed =
+      lastSuppressedIndex === undefined ? null : scrubWithVisibleSuffix(lastSuppressedIndex);
+    if (scrubbed !== null) {
+      return scrubbed;
+    }
     return scrubSuppressedTextIndexesFromContent(content, suppressedTextIndexes, options);
   }
   return { changed: false, content };
@@ -1158,9 +1237,12 @@ export async function* normalizePlainTextToolCallStreamEvents(
         const bufferState = shouldRescan
           ? getPlainTextToolCallBufferState(appended.scanText, options.matcher)
           : "over-cap";
-        if (bufferState === "impossible") {
-          const visibleText =
-            stripSerializedToolCallPrefixes(appended.scanText, options.matcher) ?? "";
+        const incompleteXmlishVisibleText = shouldRescan
+          ? stripIncompletePlainBracketedXmlishToolCallPrefix(appended.scanText, options.matcher)
+          : null;
+        if (bufferState === "impossible" || incompleteXmlishVisibleText !== null) {
+          const strippedText = stripSerializedToolCallPrefixes(appended.scanText, options.matcher);
+          const visibleText = strippedText ?? incompleteXmlishVisibleText ?? "";
           yield* flushScrubbedBufferedNonTextEvents(true);
           suppressingOverCapTextToolCall = false;
           suppressedTextContentIndex = undefined;

--- a/src/plugin-sdk/provider-stream-shared.test.ts
+++ b/src/plugin-sdk/provider-stream-shared.test.ts
@@ -1638,6 +1638,50 @@ describe("createPlainTextToolCallCompatWrapper", () => {
     expect(JSON.stringify(events)).not.toContain("[tool:read]");
   });
 
+  it("does not strip incomplete bracketed XML parameter text before visible suffixes", async () => {
+    const visibleSuffix = "Visible answer after an incomplete bracketed XML parameter block.";
+    const toolPrefix = ["[read]", "<parameter=path>", `${"x".repeat(256_001)}İ`].join("\n");
+    const closingAndSuffixText = ["</parameter>", visibleSuffix].join("\n");
+    const rawText = [toolPrefix, closingAndSuffixText].join("\n");
+    const baseStreamFn: StreamFn = () =>
+      createEventStream([
+        { type: "text_delta", contentIndex: 0, delta: toolPrefix },
+        { type: "text_delta", contentIndex: 0, delta: closingAndSuffixText },
+        { type: "text_end", contentIndex: 0, content: rawText },
+        {
+          type: "done",
+          reason: "stop",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: rawText }],
+            stopReason: "stop",
+          },
+        },
+      ]);
+    const wrapped = createPlainTextToolCallCompatWrapper(baseStreamFn);
+    const events: unknown[] = [];
+
+    for await (const event of wrapped(
+      {} as never,
+      { tools: [{ name: "read" }] } as never,
+      {},
+    ) as AsyncIterable<unknown>) {
+      events.push(event);
+    }
+
+    expect(events.map((event) => (event as { type?: string }).type)).toEqual([
+      "text_delta",
+      "done",
+    ]);
+    expect(String(requireRecord(events[0], "text event").delta)).toBe(visibleSuffix);
+    const doneMessage = requireRecord(
+      requireRecord(events.at(-1), "done event").message,
+      "done message",
+    );
+    expect(doneMessage.content).toEqual([{ type: "text", text: visibleSuffix }]);
+    expect(JSON.stringify(events)).not.toContain("</parameter>");
+  });
+
   it("preserves XML visible suffix after Unicode payload text", async () => {
     const toolPrefix = ["[tool:read]", "<parameter=path>", `${"x".repeat(256_001)}İ`].join("\n");
     const visibleSuffix = "Visible suffix after Unicode payload.";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users could lose visible assistant text when a streamed response began with an oversized incomplete bracketed XML parameter block such as `[read]` and then continued with a normal visible answer.

## Why This Change Was Made

The repair grammar now keeps optional missing `</function>` handling scoped to legacy `[tool:name]` XML blocks, while the stream normalizer recovers the visible suffix after incomplete plain `[name]` XML parameter text without leaking XML closing markers.

## User Impact

Users now see the assistant's visible answer instead of receiving an empty completion when this malformed stream shape appears.

## Evidence

- Claim proved: an oversized incomplete `[read]` XML parameter prefix followed by visible text streams and finishes with only the visible suffix preserved.
- Runtime proof at `1c9b82504a814992df8db26011f42648b13f7206`: `node --import tsx --input-type=module` ran a redacted provider-returned stream through the real xAI provider wrapper path, importing `wrapXaiProviderStream` from `extensions/xai/stream.ts` and `createAssistantMessageEventStream` from `src/llm/utils/event-stream.ts`.

```json
{
  "proof": "xai provider wrapper real path with local redacted provider stream",
  "eventTypes": ["text_delta", "done"],
  "textDelta": "Visible answer after an incomplete bracketed XML parameter block.",
  "finalContent": [
    {
      "type": "text",
      "text": "Visible answer after an incomplete bracketed XML parameter block."
    }
  ],
  "containsVisibleSuffix": true,
  "containsXmlParameterClose": false,
  "containsPlainToolPrefix": false
}
```

- Focused regression at `1c9b82504a814992df8db26011f42648b13f7206`: `node scripts/run-vitest.mjs src/plugin-sdk/provider-stream-shared.test.ts` passed with 67 tests passing.
- Committed diff hygiene: `git diff --check HEAD~1..HEAD` passed.
- Review proof: `python .agents\skills\autoreview\scripts\autoreview --mode local` passed with no accepted/actionable findings.
- Observed result: both the runtime proof and focused regression emit a `text_delta` and `done` containing `Visible answer after an incomplete bracketed XML parameter block.` and do not include `</parameter>` or `[read]`.