### PR TITLE
fix: bound gateway model pricing cache

### DIFF
--- a/src/gateway/model-pricing-cache-state.ts
+++ b/src/gateway/model-pricing-cache-state.ts
@@ -53,18 +53,37 @@ function buildBoundedGatewayModelPricingCache(
   nextPricing: Map<string, CachedModelPricing>,
 ): Map<string, CachedModelPricing> {
   const bounded = new Map<string, CachedModelPricing>();
+  const refreshedEntries: Array<[string, CachedModelPricing]> = [];
   const refreshedKeys = new Set<string>();
   for (const [key] of cachedPricing) {
     const pricing = nextPricing.get(key);
     if (pricing !== undefined) {
       refreshedKeys.add(key);
-      setBoundedGatewayModelPricingEntry(bounded, key, pricing);
+      refreshedEntries.push([key, pricing]);
     }
   }
+  const newEntries: Array<[string, CachedModelPricing]> = [];
   for (const [key, pricing] of nextPricing) {
     if (!refreshedKeys.has(key)) {
-      setBoundedGatewayModelPricingEntry(bounded, key, pricing);
+      newEntries.push([key, pricing]);
     }
+  }
+  const refreshedBudget =
+    newEntries.length >= GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES
+      ? 1
+      : GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES - newEntries.length;
+  const hotRefreshedCount = Math.min(refreshedEntries.length, refreshedBudget);
+  const coldRefreshedCount = refreshedEntries.length - hotRefreshedCount;
+  // Insert cold refreshed rows before new catalog rows, then hot refreshed rows.
+  // The cap trims oldest insertions, so refreshes retain new rows and recent hits.
+  for (const [key, pricing] of refreshedEntries.slice(0, coldRefreshedCount)) {
+    setBoundedGatewayModelPricingEntry(bounded, key, pricing);
+  }
+  for (const [key, pricing] of newEntries) {
+    setBoundedGatewayModelPricingEntry(bounded, key, pricing);
+  }
+  for (const [key, pricing] of refreshedEntries.slice(coldRefreshedCount)) {
+    setBoundedGatewayModelPricingEntry(bounded, key, pricing);
   }
   return bounded;
 }

--- a/src/gateway/model-pricing-cache-state.ts
+++ b/src/gateway/model-pricing-cache-state.ts
@@ -25,6 +25,8 @@ export type CachedModelPricing = {
 
 type GatewayModelPricingHealthSource = GatewayModelPricingHealth["sources"][number]["source"];
 
+const GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES = 4096;
+
 let cachedPricing = new Map<string, CachedModelPricing>();
 let cachedAt = 0;
 const sourceFailures = new Map<
@@ -47,11 +49,56 @@ function modelPricingCacheKey(provider: string, model: string): string {
     : `${providerId}/${modelId}`;
 }
 
+function buildBoundedGatewayModelPricingCache(
+  nextPricing: Map<string, CachedModelPricing>,
+): Map<string, CachedModelPricing> {
+  const bounded = new Map<string, CachedModelPricing>();
+  const refreshedKeys = new Set<string>();
+  for (const [key] of cachedPricing) {
+    const pricing = nextPricing.get(key);
+    if (pricing !== undefined) {
+      refreshedKeys.add(key);
+      setBoundedGatewayModelPricingEntry(bounded, key, pricing);
+    }
+  }
+  for (const [key, pricing] of nextPricing) {
+    if (!refreshedKeys.has(key)) {
+      setBoundedGatewayModelPricingEntry(bounded, key, pricing);
+    }
+  }
+  return bounded;
+}
+
+function setBoundedGatewayModelPricingEntry(
+  bounded: Map<string, CachedModelPricing>,
+  key: string,
+  pricing: CachedModelPricing,
+): void {
+  bounded.set(key, pricing);
+  if (bounded.size <= GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES) {
+    return;
+  }
+  const oldest = bounded.keys().next().value;
+  if (oldest !== undefined) {
+    bounded.delete(oldest);
+  }
+}
+
+function getCachedGatewayModelPricingEntry(key: string): CachedModelPricing | undefined {
+  const pricing = cachedPricing.get(key);
+  if (!pricing) {
+    return undefined;
+  }
+  cachedPricing.delete(key);
+  cachedPricing.set(key, pricing);
+  return pricing;
+}
+
 export function replaceGatewayModelPricingCache(
   nextPricing: Map<string, CachedModelPricing>,
   nextCachedAt = Date.now(),
 ): void {
-  cachedPricing = nextPricing;
+  cachedPricing = buildBoundedGatewayModelPricingCache(nextPricing);
   cachedAt = nextCachedAt;
 }
 
@@ -117,7 +164,7 @@ export function getCachedGatewayModelPricing(params: {
     return undefined;
   }
   const key = modelPricingCacheKey(provider, model);
-  const direct = key ? cachedPricing.get(key) : undefined;
+  const direct = key ? getCachedGatewayModelPricingEntry(key) : undefined;
   if (direct) {
     return direct;
   }
@@ -126,7 +173,7 @@ export function getCachedGatewayModelPricing(params: {
   if (normalizedKey === key) {
     return undefined;
   }
-  return normalizedKey ? cachedPricing.get(normalizedKey) : undefined;
+  return normalizedKey ? getCachedGatewayModelPricingEntry(normalizedKey) : undefined;
 }
 
 export function getGatewayModelPricingCacheMeta(): {

--- a/src/gateway/model-pricing-cache.test.ts
+++ b/src/gateway/model-pricing-cache.test.ts
@@ -3,6 +3,7 @@
 
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { modelKey } from "../agents/model-selection.js";
 import type { normalizeProviderModelIdWithRuntime } from "../agents/provider-model-normalization.runtime.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
@@ -73,6 +74,7 @@ import {
 } from "./model-pricing-cache.js";
 
 type CachedModelPricing = NonNullable<ReturnType<typeof getCachedGatewayModelPricing>>;
+const GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES = 4096;
 
 function requirePricing(
   pricing: ReturnType<typeof getCachedGatewayModelPricing>,
@@ -135,6 +137,24 @@ function requireAbortSignal(signal: RequestInit["signal"] | undefined): AbortSig
   return signal;
 }
 
+function createCachedModelPricing(index: number): CachedModelPricing {
+  return {
+    input: index,
+    output: index + 1,
+    cacheRead: 0,
+    cacheWrite: 0,
+  };
+}
+
+function createCachedModelPricingMap(count: number): Map<string, CachedModelPricing> {
+  return new Map(
+    Array.from({ length: count }, (_, index): [string, CachedModelPricing] => [
+      modelKey("custom", `model-${index}`),
+      createCachedModelPricing(index),
+    ]),
+  );
+}
+
 describe("model-pricing-cache", () => {
   beforeEach(() => {
     clearGatewayModelPricingState();
@@ -150,6 +170,83 @@ describe("model-pricing-cache", () => {
     clearLoadPluginMetadataSnapshotMemo();
     loggingState.rawConsole = null;
     resetLogger();
+  });
+
+  it("bounds replacement cache size and evicts the oldest pricing rows", () => {
+    replaceGatewayModelPricingCache(
+      createCachedModelPricingMap(GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES + 2),
+      123,
+    );
+
+    expect(getGatewayModelPricingCacheMeta()).toEqual({
+      cachedAt: 123,
+      ttlMs: 0,
+      size: GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES,
+    });
+    expect(getCachedGatewayModelPricing({ provider: "custom", model: "model-0" })).toBeUndefined();
+    expect(getCachedGatewayModelPricing({ provider: "custom", model: "model-1" })).toBeUndefined();
+    expect(getCachedGatewayModelPricing({ provider: "custom", model: "model-2" })).toEqual(
+      createCachedModelPricing(2),
+    );
+  });
+
+  it("keeps recently used pricing rows when a refreshed cache exceeds the cap", () => {
+    replaceGatewayModelPricingCache(
+      createCachedModelPricingMap(GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES),
+      123,
+    );
+
+    expect(getCachedGatewayModelPricing({ provider: "custom", model: "model-0" })).toEqual(
+      createCachedModelPricing(0),
+    );
+
+    replaceGatewayModelPricingCache(
+      createCachedModelPricingMap(GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES + 1),
+      456,
+    );
+
+    expect(getGatewayModelPricingCacheMeta().size).toBe(GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES);
+    expect(getCachedGatewayModelPricing({ provider: "custom", model: "model-0" })).toEqual(
+      createCachedModelPricing(0),
+    );
+    expect(getCachedGatewayModelPricing({ provider: "custom", model: "model-1" })).toBeUndefined();
+    expect(
+      getCachedGatewayModelPricing({
+        provider: "custom",
+        model: `model-${GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES}`,
+      }),
+    ).toEqual(createCachedModelPricing(GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES));
+  });
+  it("keeps normalized lookup hits recently used when a refreshed cache exceeds the cap", () => {
+    const normalizedPricing = createCachedModelPricing(42);
+    replaceGatewayModelPricingCache(
+      new Map<string, CachedModelPricing>([
+        [modelKey("google", "gemini-3.1-pro-preview"), normalizedPricing],
+        ...createCachedModelPricingMap(GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES - 1),
+      ]),
+      123,
+    );
+
+    expect(getCachedGatewayModelPricing({ provider: "google", model: "gemini-3-pro" })).toEqual(
+      normalizedPricing,
+    );
+
+    const refreshed = createCachedModelPricingMap(GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES + 1);
+    refreshed.set(modelKey("google", "gemini-3.1-pro-preview"), normalizedPricing);
+    replaceGatewayModelPricingCache(refreshed, 456);
+
+    expect(getGatewayModelPricingCacheMeta().size).toBe(GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES);
+    expect(getCachedGatewayModelPricing({ provider: "google", model: "gemini-3-pro" })).toEqual(
+      normalizedPricing,
+    );
+    expect(getCachedGatewayModelPricing({ provider: "custom", model: "model-0" })).toBeUndefined();
+    expect(getCachedGatewayModelPricing({ provider: "custom", model: "model-1" })).toBeUndefined();
+    expect(
+      getCachedGatewayModelPricing({
+        provider: "custom",
+        model: `model-${GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES}`,
+      }),
+    ).toEqual(createCachedModelPricing(GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES));
   });
 
   it("uses one installed manifest pass for pricing policies and configured web-search refs", async () => {

--- a/src/gateway/model-pricing-cache.test.ts
+++ b/src/gateway/model-pricing-cache.test.ts
@@ -217,6 +217,35 @@ describe("model-pricing-cache", () => {
       }),
     ).toEqual(createCachedModelPricing(GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES));
   });
+
+  it("keeps a small hot overlap when a refreshed catalog adds more than the cap", () => {
+    const hotPricing = createCachedModelPricing(42);
+    replaceGatewayModelPricingCache(
+      new Map<string, CachedModelPricing>([[modelKey("custom", "hot-model"), hotPricing]]),
+      123,
+    );
+
+    expect(getCachedGatewayModelPricing({ provider: "custom", model: "hot-model" })).toEqual(
+      hotPricing,
+    );
+
+    const refreshed = createCachedModelPricingMap(GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES + 1);
+    refreshed.set(modelKey("custom", "hot-model"), hotPricing);
+    replaceGatewayModelPricingCache(refreshed, 456);
+
+    expect(getGatewayModelPricingCacheMeta().size).toBe(GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES);
+    expect(getCachedGatewayModelPricing({ provider: "custom", model: "hot-model" })).toEqual(
+      hotPricing,
+    );
+    expect(getCachedGatewayModelPricing({ provider: "custom", model: "model-0" })).toBeUndefined();
+    expect(
+      getCachedGatewayModelPricing({
+        provider: "custom",
+        model: `model-${GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES}`,
+      }),
+    ).toEqual(createCachedModelPricing(GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES));
+  });
+
   it("keeps normalized lookup hits recently used when a refreshed cache exceeds the cap", () => {
     const normalizedPricing = createCachedModelPricing(42);
     replaceGatewayModelPricingCache(


### PR DESCRIPTION
Closes #101543.

## What Problem This Solves

Fixes an issue where long-running gateway processes could keep growing the model-pricing cache when refreshes see many dynamic provider/plugin model rows, eventually increasing heap pressure and risking OOM.

## Why This Change Was Made

The cache is capped at the shared gateway pricing state boundary so every refresh replacement path is bounded consistently. Lookup hits refresh `Map` insertion order, including normalized-model fallback hits, and replacement construction trims as entries are inserted so the working replacement map stays capped while retaining the most recent pricing rows.

This keeps the state-layer recency-cap approach and avoids the separate timestamp side-map used by #101713, which would add another cache-like structure to prune.

## User Impact

Long-running gateway processes keep pricing-cache memory bounded while normal pricing lookups continue to work for recently used models. Very large catalogs can evict least-recently used pricing rows beyond the 4096-entry cap, so maintainers still need to accept that retention policy.

## Evidence

- Claim proved: the shared gateway pricing state boundary caps replacement payloads at 4096 entries, evicts oldest rows during construction, preserves direct lookup hits, and preserves normalized lookup hits across an over-limit refresh.
- Current branch head: `f2de8292fa42d080a3566789b020dcdb47903434`.
- Runtime transcript: imported `src/gateway/model-pricing-cache-state.ts` with `tsx` at the current head, wrote 4097 catalog rows plus hot rows through `replaceGatewayModelPricingCache`, then read back with `getCachedGatewayModelPricing`. Observed direct size `4096`, direct hot before/after `42 -> 42`, direct cold-oldest evicted `true`, direct newest retained `4096`; normalized size `4096`, normalized hot before/after `84 -> 84`, normalized cold-oldest evicted `true`, normalized newest retained `4096`.
- Focused regression proof: `node scripts/run-vitest.mjs run src/gateway/model-pricing-cache.test.ts` -> passed 1 test file / 26 tests on the current head.
- GitHub current-head checks: `Real behavior proof`, `check-lint`, `check-test-types`, `check-prod-types`, and `check-dependencies` passed on `f2de8292fa42d080a3566789b020dcdb47903434`.
- Diff hygiene: `git diff --check upstream/main..HEAD` -> passed.