### PR TITLE
feat(write): add append mode to prevent silent data loss

### DIFF
--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -944,8 +944,15 @@ function createSandboxWriteOperations(params: SandboxToolParams) {
       // The bridge writeFile accepts Buffer | string, so we keep the
       // existing file bytes as a Buffer and write the combined payload
       // without a lossy UTF-8 round-trip.
+      //
+      // Stat-then-read is a TOCTOU window between checking existence
+      // and reading; a delete-after-stat can make readFile throw.
+      // Catch that edge so the append creates the file instead of
+      // failing the entire tool call.
       const existing = (await params.bridge.stat({ filePath: absolutePath, cwd: params.root }))
-        ? await params.bridge.readFile({ filePath: absolutePath, cwd: params.root })
+        ? await params.bridge
+            .readFile({ filePath: absolutePath, cwd: params.root })
+            .catch(() => Buffer.alloc(0))
         : Buffer.alloc(0);
       await params.bridge.mkdirp({ filePath: path.dirname(absolutePath), cwd: params.root });
       await params.bridge.writeFile({

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -944,17 +944,9 @@ function createSandboxWriteOperations(params: SandboxToolParams) {
       // The bridge writeFile accepts Buffer | string, so we keep the
       // existing file bytes as a Buffer and write the combined payload
       // without a lossy UTF-8 round-trip.
-      let existing: Buffer;
-      try {
-        existing = await params.bridge.readFile({ filePath: absolutePath, cwd: params.root });
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        if (!/ENOENT|no such file/i.test(msg)) {
-          throw err;
-        }
-        // File does not exist — append creates it.
-        existing = Buffer.alloc(0);
-      }
+      const existing = (await params.bridge.stat({ filePath: absolutePath, cwd: params.root }))
+        ? await params.bridge.readFile({ filePath: absolutePath, cwd: params.root })
+        : Buffer.alloc(0);
       await params.bridge.mkdirp({ filePath: path.dirname(absolutePath), cwd: params.root });
       await params.bridge.writeFile({
         filePath: absolutePath,

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -938,6 +938,27 @@ function createSandboxWriteOperations(params: SandboxToolParams) {
     writeFile: async (absolutePath: string, content: string) => {
       await params.bridge.writeFile({ filePath: absolutePath, cwd: params.root, data: content });
     },
+    appendFile: async (absolutePath: string, content: string) => {
+      // Sandbox bridge does not expose a native append; read-modify-write
+      // through the bridge instead.
+      let existing = "";
+      try {
+        const buf = await params.bridge.readFile({ filePath: absolutePath, cwd: params.root });
+        existing = buf.toString("utf8");
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (!/ENOENT|no such file/i.test(msg)) {
+          throw err;
+        }
+        // File does not exist — append creates it.
+      }
+      await params.bridge.mkdirp({ filePath: path.dirname(absolutePath), cwd: params.root });
+      await params.bridge.writeFile({
+        filePath: absolutePath,
+        cwd: params.root,
+        data: existing + content,
+      });
+    },
     readFile: (absolutePath: string) =>
       params.bridge.readFile({ filePath: absolutePath, cwd: params.root }),
     statFile: (absolutePath: string) =>
@@ -1023,6 +1044,11 @@ function createHostWriteOperations(root: string, options?: { workspaceOnly?: boo
         await fs.mkdir(resolved, { recursive: true });
       },
       writeFile: writeHostFile,
+      appendFile: async (absolutePath: string, content: string) => {
+        const resolved = path.resolve(expandTildeToOsHome(absolutePath));
+        await fs.mkdir(path.dirname(resolved), { recursive: true });
+        await fs.appendFile(resolved, content, "utf-8");
+      },
       readFile: async (absolutePath: string) =>
         fs.readFile(path.resolve(expandTildeToOsHome(absolutePath))),
       statFile: (absolutePath: string) =>
@@ -1045,6 +1071,10 @@ function createHostWriteOperations(root: string, options?: { workspaceOnly?: boo
     },
     writeFile: (absolutePath: string, content: string) =>
       writeWorkspaceFile(root, getRoot, absolutePath, content),
+    appendFile: async (absolutePath: string, content: string) => {
+      const relative = toRelativeWorkspacePath(root, absolutePath);
+      await (await getRoot()).append(relative, content, { mkdir: true });
+    },
     readFile: async (absolutePath: string) => {
       const relative = toRelativeWorkspacePath(root, absolutePath);
       return (await (await getRoot()).read(relative)).buffer;

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -946,13 +946,20 @@ function createSandboxWriteOperations(params: SandboxToolParams) {
       // without a lossy UTF-8 round-trip.
       //
       // Stat-then-read is a TOCTOU window between checking existence
-      // and reading; a delete-after-stat can make readFile throw.
-      // Catch that edge so the append creates the file instead of
-      // failing the entire tool call.
+      // and reading. Only recover when the file was deleted between
+      // stat and readFile (ENOENT / file-not-found). Any other read
+      // failure (permission, I/O, cancellation, bridge error) must
+      // propagate — silently replacing the existing content with only
+      // the appended bytes would destroy data.
       const existing = (await params.bridge.stat({ filePath: absolutePath, cwd: params.root }))
         ? await params.bridge
             .readFile({ filePath: absolutePath, cwd: params.root })
-            .catch(() => Buffer.alloc(0))
+            .catch((err: unknown) => {
+              if (isNotFoundError(err)) {
+                return Buffer.alloc(0);
+              }
+              throw err;
+            })
         : Buffer.alloc(0);
       await params.bridge.mkdirp({ filePath: path.dirname(absolutePath), cwd: params.root });
       await params.bridge.writeFile({

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -939,24 +939,27 @@ function createSandboxWriteOperations(params: SandboxToolParams) {
       await params.bridge.writeFile({ filePath: absolutePath, cwd: params.root, data: content });
     },
     appendFile: async (absolutePath: string, content: string) => {
-      // Sandbox bridge does not expose a native append; read-modify-write
-      // through the bridge instead.
-      let existing = "";
+      // Concatenate existing bytes with appended content through the
+      // Buffer-capable sandbox bridge so non-UTF-8 bytes are preserved.
+      // The bridge writeFile accepts Buffer | string, so we keep the
+      // existing file bytes as a Buffer and write the combined payload
+      // without a lossy UTF-8 round-trip.
+      let existing: Buffer;
       try {
-        const buf = await params.bridge.readFile({ filePath: absolutePath, cwd: params.root });
-        existing = buf.toString("utf8");
+        existing = await params.bridge.readFile({ filePath: absolutePath, cwd: params.root });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         if (!/ENOENT|no such file/i.test(msg)) {
           throw err;
         }
         // File does not exist — append creates it.
+        existing = Buffer.alloc(0);
       }
       await params.bridge.mkdirp({ filePath: path.dirname(absolutePath), cwd: params.root });
       await params.bridge.writeFile({
         filePath: absolutePath,
         cwd: params.root,
-        data: existing + content,
+        data: Buffer.concat([existing, Buffer.from(content, "utf-8")]),
       });
     },
     readFile: (absolutePath: string) =>

--- a/src/agents/sessions/tools/tool-contracts.ts
+++ b/src/agents/sessions/tools/tool-contracts.ts
@@ -84,4 +84,6 @@ export interface ReadToolDetails {
 export interface WriteToolInput {
   path: string;
   content: string;
+  /** Append content to the existing file instead of overwriting it. */
+  append?: boolean;
 }

--- a/src/agents/sessions/tools/write.test.ts
+++ b/src/agents/sessions/tools/write.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
-import { createWriteTool, type WriteOperations } from "./write.js";
+import { createWriteTool, createWriteToolDefinition, type WriteOperations } from "./write.js";
 
 describe("write tool", () => {
   let tmpDir = "";
@@ -154,5 +154,79 @@ describe("write tool", () => {
     const tc1 = result.content[0];
     expect("text" in tc1 ? tc1.text : "").toContain("Successfully wrote");
     await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("new\n");
+  });
+
+  it("advertises append mode in write tool description", () => {
+    const definition = createWriteToolDefinition(tmpDir);
+
+    expect(definition.description).toContain("append");
+    expect(definition.promptSnippet).toContain("append");
+    expect((definition.promptGuidelines ?? []).join("\n")).toContain("append: true");
+  });
+
+  it("appends content when append mode is enabled", async () => {
+    const filePath = await createTempPath("append.txt");
+    await fs.writeFile(filePath, "alpha\n", "utf-8");
+    const tool = createWriteTool(tmpDir);
+
+    const result = await tool.execute(
+      "call-1",
+      { path: filePath, content: "beta\n", append: true },
+      undefined,
+    );
+
+    expect("text" in (result.content[0] ?? {}) ? (result.content[0] as any).text : "").toContain(
+      "Successfully appended",
+    );
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("alpha\nbeta\n");
+  });
+
+  it("creates a new file when appending to a non-existent path", async () => {
+    const filePath = await createTempPath("append-new.txt");
+    const tool = createWriteTool(tmpDir);
+
+    const result = await tool.execute(
+      "call-1",
+      { path: filePath, content: "first line\n", append: true },
+      undefined,
+    );
+
+    expect("text" in (result.content[0] ?? {}) ? (result.content[0] as any).text : "").toContain(
+      "Successfully appended",
+    );
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("first line\n");
+  });
+
+  it("overwrites by default when append is not set", async () => {
+    const filePath = await createTempPath("overwrite.txt");
+    await fs.writeFile(filePath, "old\n", "utf-8");
+    const tool = createWriteTool(tmpDir);
+
+    const result = await tool.execute("call-1", { path: filePath, content: "new\n" }, undefined);
+
+    expect("text" in (result.content[0] ?? {}) ? (result.content[0] as any).text : "").toContain(
+      "Successfully wrote",
+    );
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("new\n");
+  });
+
+  it("returns no-op when overwriting with identical content", async () => {
+    const filePath = await createTempPath("noop.txt");
+    await fs.writeFile(filePath, "same\n", "utf-8");
+    const tool = createWriteTool(tmpDir);
+
+    const result = await tool.execute("call-1", { path: filePath, content: "same\n" }, undefined);
+
+    const tc0 = result.content[0];
+    expect("text" in tc0 ? tc0.text : "").toContain("No changes made");
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("same\n");
+  });
+
+  it("rejects malformed append parameter", async () => {
+    const tool = createWriteTool(tmpDir);
+
+    await expect(
+      tool.execute("call-1", { path: "/tmp/test.txt", content: "hello", append: "true" as any }),
+    ).rejects.toThrow("Invalid append parameter");
   });
 });

--- a/src/agents/sessions/tools/write.test.ts
+++ b/src/agents/sessions/tools/write.test.ts
@@ -22,10 +22,14 @@ describe("write tool", () => {
     return path.join(tmpDir, name);
   }
 
-  function createRecoverableOperations(writeFile: WriteOperations["writeFile"]): WriteOperations {
+  function createRecoverableOperations(
+    writeFile: WriteOperations["writeFile"],
+    appendFile?: WriteOperations["appendFile"],
+  ): WriteOperations {
     return {
       mkdir: (dir) => fs.mkdir(dir, { recursive: true }).then(() => {}),
       writeFile,
+      appendFile,
       readFile: (absolutePath) => fs.readFile(absolutePath),
       statFile: async (absolutePath) => {
         try {
@@ -73,6 +77,59 @@ describe("write tool", () => {
       type: "text",
       text: `Successfully wrote ${"finished\n".length} bytes to ${filePath}`,
     });
+  });
+
+  it("recovers success after appendFile lands but the caller aborts", async () => {
+    // Regression: post-mutation abort check routes append-abort through
+    // recoverSuccessfulWrite with isRecoveredAppendContent so the model
+    // sees "Successfully appended" instead of a false failure.
+    const filePath = await createTempPath("append-abort.txt");
+    await fs.writeFile(filePath, "seed\n", "utf-8");
+    const controller = new AbortController();
+    const tool = createWriteTool(tmpDir, {
+      operations: createRecoverableOperations(
+        async () => {},
+        async (absolutePath, content) => {
+          await fs.appendFile(absolutePath, content, "utf-8");
+          controller.abort();
+        },
+      ),
+    });
+    const result = await tool.execute(
+      "call-1",
+      { path: filePath, content: "more\n", append: true },
+      controller.signal,
+    );
+    expect(
+      "text" in (result.content[0] ?? {}) ? (result.content[0] as { text: string }).text : "",
+    ).toContain("Successfully appended");
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("seed\nmore\n");
+  });
+
+  it("surfaces the abort when appendFile returned but did not actually write", async () => {
+    // Counter-case: appendFile succeeds (no throw) but the backend did not
+    // persist. Without the post-mutation abort check this would silently
+    // report success — readback during recovery must confirm the content
+    // actually landed, or the abort surfaces as a real error.
+    const filePath = await createTempPath("append-noop.txt");
+    await fs.writeFile(filePath, "seed\n", "utf-8");
+    const controller = new AbortController();
+    const tool = createWriteTool(tmpDir, {
+      operations: createRecoverableOperations(
+        async () => {},
+        async () => {
+          controller.abort();
+        },
+      ),
+    });
+    await expect(
+      tool.execute(
+        "call-1",
+        { path: filePath, content: "more\n", append: true },
+        controller.signal,
+      ),
+    ).rejects.toThrow("Operation aborted");
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("seed\n");
   });
 
   it("keeps the original abort when the file already matched before execution", async () => {

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -410,9 +410,10 @@ async function recoverSuccessfulWrite(params: {
  * Byte-safe append recovery check.
  *
  * Avoids UTF-8 round-trips (toString/decode) that would mangle non-UTF-8
- * bytes and cause false recovery rejections for binary files. Uses file
- * sizes from before-stat and byte-level measurement of the readback buffer
- * so the path works for UTF-8 and arbitrary byte streams alike.
+ * bytes. When the readback is a Buffer the suffix bytes are compared
+ * directly against the appended content; when only a string is available
+ * we fall back to size comparison. Either way we also confirm the file
+ * size is exactly pre-append size + appended content size.
  */
 function isRecoveredAppendContent(
   readback: Buffer | string | undefined,
@@ -422,19 +423,32 @@ function isRecoveredAppendContent(
   if (!readback) {
     return false;
   }
+  const appendedBuf = Buffer.from(appendedContent, "utf-8");
+  const appendedSize = appendedBuf.byteLength;
   const afterSize = Buffer.isBuffer(readback)
     ? readback.byteLength
     : Buffer.byteLength(readback, "utf-8");
-  const appendedSize = Buffer.byteLength(appendedContent, "utf-8");
-  // File did not exist before; the readback size must match appended size.
+  // File did not exist before; verify sizes match and suffix bytes match.
   if (precheck.beforeStat === null) {
-    return afterSize === appendedSize;
+    if (afterSize !== appendedSize) {
+      return false;
+    }
+    return Buffer.isBuffer(readback) ? readback.equals(appendedBuf) : readback === appendedContent;
   }
   // File existed before; verify before size + appended == after size.
-  if (precheck.beforeStat?.type === "file") {
-    return afterSize === precheck.beforeStat.size + appendedSize;
+  if (precheck.beforeStat?.type !== "file") {
+    return false;
   }
-  return false;
+  if (afterSize !== precheck.beforeStat.size + appendedSize) {
+    return false;
+  }
+  // Verify the file actually ends with the appended content bytes.
+  if (Buffer.isBuffer(readback)) {
+    const suffix = readback.subarray(-appendedSize);
+    return suffix.equals(appendedBuf);
+  }
+  // String fallback: check suffix match via .endsWith().
+  return readback.endsWith(appendedContent);
 }
 
 export function createWriteToolDefinition(

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -370,12 +370,8 @@ async function recoverSuccessfulWrite(params: {
     return null;
   }
   const readback = await params.ops.readFile(params.absolutePath).catch(() => undefined);
-  const currentContent = Buffer.isBuffer(readback) ? readback.toString("utf8") : readback;
-  if (typeof currentContent !== "string") {
-    return null;
-  }
   if (params.append) {
-    if (!isRecoveredAppendContent(currentContent, params.content, params.precheck)) {
+    if (!isRecoveredAppendContent(readback, params.content, params.precheck)) {
       return null;
     }
     return {
@@ -387,6 +383,10 @@ async function recoverSuccessfulWrite(params: {
       ],
       details: undefined,
     };
+  }
+  const currentContent = Buffer.isBuffer(readback) ? readback.toString("utf8") : readback;
+  if (typeof currentContent !== "string") {
+    return null;
   }
   const changed =
     params.precheck.state === "different" ||
@@ -406,29 +406,35 @@ async function recoverSuccessfulWrite(params: {
   };
 }
 
+/**
+ * Byte-safe append recovery check.
+ *
+ * Avoids UTF-8 round-trips (toString/decode) that would mangle non-UTF-8
+ * bytes and cause false recovery rejections for binary files. Uses file
+ * sizes from before-stat and byte-level measurement of the readback buffer
+ * so the path works for UTF-8 and arbitrary byte streams alike.
+ */
 function isRecoveredAppendContent(
-  currentContent: string,
+  readback: Buffer | string | undefined,
   appendedContent: string,
   precheck: WriteToolPrecheck,
 ): boolean {
-  // If we have the before content, verify the file is exactly before + appended.
-  if (precheck.beforeContent !== undefined) {
-    return currentContent === `${precheck.beforeContent}${appendedContent}`;
-  }
-  // If file didn't exist before, any content that matches the appended content is proof.
-  if (precheck.beforeStat === null) {
-    return currentContent === appendedContent;
-  }
-  // Without before content, approximate check: content ends with appended text
-  // and size grew by the expected amount.
-  if (!precheck.beforeStat || precheck.beforeStat.type !== "file") {
+  if (!readback) {
     return false;
   }
-  return (
-    currentContent.endsWith(appendedContent) &&
-    Buffer.byteLength(currentContent, "utf8") ===
-      precheck.beforeStat.size + Buffer.byteLength(appendedContent, "utf8")
-  );
+  const afterSize = Buffer.isBuffer(readback)
+    ? readback.byteLength
+    : Buffer.byteLength(readback, "utf-8");
+  const appendedSize = Buffer.byteLength(appendedContent, "utf-8");
+  // File did not exist before; the readback size must match appended size.
+  if (precheck.beforeStat === null) {
+    return afterSize === appendedSize;
+  }
+  // File existed before; verify before size + appended == after size.
+  if (precheck.beforeStat?.type === "file") {
+    return afterSize === precheck.beforeStat.size + appendedSize;
+  }
+  return false;
 }
 
 export function createWriteToolDefinition(

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -4,6 +4,7 @@
  * Writes files through queued local or injected operations with readback/idempotency metadata.
  */
 import {
+  appendFile as fsAppendFile,
   mkdir as fsMkdir,
   readFile as fsReadFile,
   stat as fsStat,
@@ -33,6 +34,11 @@ const writeSchema = Type.Object({
     description: "Path to the file to write (relative or absolute)",
   }),
   content: Type.String({ description: "Content to write to the file" }),
+  append: Type.Optional(
+    Type.Boolean({
+      description: "Append content to the end of the file instead of overwriting it",
+    }),
+  ),
 });
 export type { WriteToolInput } from "./tool-contracts.js";
 
@@ -43,6 +49,8 @@ export type { WriteToolInput } from "./tool-contracts.js";
 export interface WriteOperations {
   /** Write content to a file */
   writeFile: (absolutePath: string, content: string) => Promise<void>;
+  /** Append content to a file. Falls back to writeFile if not provided. */
+  appendFile?: (absolutePath: string, content: string) => Promise<void>;
   /** Create directory recursively */
   mkdir: (dir: string) => Promise<void>;
   /** Optional readback used to recover when a write succeeded but the tool aborted before returning */
@@ -53,6 +61,7 @@ export interface WriteOperations {
 
 const defaultWriteOperations: WriteOperations = {
   writeFile: (path, content) => fsWriteFile(path, content, "utf-8"),
+  appendFile: (path, content) => fsAppendFile(path, content, "utf-8"),
   mkdir: (dir) => fsMkdir(dir, { recursive: true }).then(() => {}),
   readFile: (path) => fsReadFile(path),
   statFile: async (path) => {
@@ -91,6 +100,7 @@ type WriteToolFileStat = {
 type WriteToolPrecheck = {
   state: "different" | "same" | "unknown";
   beforeStat?: WriteToolFileStat | null;
+  beforeContent?: string;
 };
 
 const WRITE_PRECHECK_READ_LIMIT_BYTES = 1024 * 1024;
@@ -308,6 +318,7 @@ async function readOriginalWriteState(
     return {
       state: originalText === content ? "same" : "different",
       beforeStat: stat,
+      beforeContent: originalText,
     };
   } catch {
     return { state: "unknown", beforeStat: stat };
@@ -347,6 +358,7 @@ function isWriteRecoveryCandidate(error: unknown, signal: AbortSignal | undefine
 
 async function recoverSuccessfulWrite(params: {
   absolutePath: string;
+  append: boolean;
   content: string;
   error: unknown;
   ops: WriteOperations;
@@ -359,6 +371,23 @@ async function recoverSuccessfulWrite(params: {
   }
   const readback = await params.ops.readFile(params.absolutePath).catch(() => undefined);
   const currentContent = Buffer.isBuffer(readback) ? readback.toString("utf8") : readback;
+  if (typeof currentContent !== "string") {
+    return null;
+  }
+  if (params.append) {
+    if (!isRecoveredAppendContent(currentContent, params.content, params.precheck)) {
+      return null;
+    }
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Successfully appended ${params.content.length} bytes to ${params.path}`,
+        },
+      ],
+      details: undefined,
+    };
+  }
   const changed =
     params.precheck.state === "different" ||
     (params.precheck.state === "unknown" &&
@@ -377,6 +406,31 @@ async function recoverSuccessfulWrite(params: {
   };
 }
 
+function isRecoveredAppendContent(
+  currentContent: string,
+  appendedContent: string,
+  precheck: WriteToolPrecheck,
+): boolean {
+  // If we have the before content, verify the file is exactly before + appended.
+  if (precheck.beforeContent !== undefined) {
+    return currentContent === `${precheck.beforeContent}${appendedContent}`;
+  }
+  // If file didn't exist before, any content that matches the appended content is proof.
+  if (precheck.beforeStat === null) {
+    return currentContent === appendedContent;
+  }
+  // Without before content, approximate check: content ends with appended text
+  // and size grew by the expected amount.
+  if (!precheck.beforeStat || precheck.beforeStat.type !== "file") {
+    return false;
+  }
+  return (
+    currentContent.endsWith(appendedContent) &&
+    Buffer.byteLength(currentContent, "utf8") ===
+      precheck.beforeStat.size + Buffer.byteLength(appendedContent, "utf8")
+  );
+}
+
 export function createWriteToolDefinition(
   cwd: string,
   options?: WriteToolOptions,
@@ -386,13 +440,15 @@ export function createWriteToolDefinition(
     name: "write",
     label: "write",
     description:
-      "Write content to a file. Creates the file if it doesn't exist, overwrites if it does. Automatically creates parent directories.",
-    promptSnippet: "Create or overwrite files",
-    promptGuidelines: ["Use write only for new files or complete rewrites."],
+      "Write content to a file. Creates the file if it doesn't exist, overwrites by default, or appends when append is true. Automatically creates parent directories.",
+    promptSnippet: "Create, overwrite, or append to files",
+    promptGuidelines: [
+      "Use write for new files or complete rewrites; set append: true when preserving existing content and adding to the end of a file.",
+    ],
     parameters: writeSchema,
     async execute(
       toolCallId,
-      { path, content }: { path: string; content: string },
+      input: { path: string; content: string; append?: unknown },
       signal?: AbortSignal,
       onUpdate?,
       ctx?,
@@ -400,6 +456,13 @@ export function createWriteToolDefinition(
       void toolCallId;
       void onUpdate;
       void ctx;
+      const { path, content } = input;
+      if (input.append !== undefined && typeof input.append !== "boolean") {
+        throw new Error(
+          "Invalid append parameter: expected boolean when provided. Supply correct parameters before retrying.",
+        );
+      }
+      const append = input.append === true;
       const absolutePath = resolveToCwd(path, cwd);
       const dir = dirname(absolutePath);
       return withFileMutationQueue(absolutePath, async () => {
@@ -407,8 +470,9 @@ export function createWriteToolDefinition(
         if (signal?.aborted) {
           throw new Error("Operation aborted");
         }
-        // Terminal no-op: file already has identical content.
-        if (precheck.state === "same") {
+        // Terminal no-op only applies to overwrite mode: append must always execute
+        // so intentional duplicate content is preserved.
+        if (!append && precheck.state === "same") {
           return {
             ...textResult(
               `No changes made to ${path}. The file already has identical content.`,
@@ -422,15 +486,21 @@ export function createWriteToolDefinition(
           if (signal?.aborted) {
             throw new Error("Operation aborted");
           }
-          await ops.writeFile(absolutePath, content);
-          if (signal?.aborted) {
-            throw new Error("Operation aborted");
+          if (append) {
+            if (!ops.appendFile) {
+              throw new Error("Append mode is not supported by this write tool backend");
+            }
+            await ops.appendFile(absolutePath, content);
+          } else {
+            await ops.writeFile(absolutePath, content);
           }
           return {
             content: [
               {
                 type: "text" as const,
-                text: `Successfully wrote ${content.length} bytes to ${path}`,
+                text: append
+                  ? `Successfully appended ${content.length} bytes to ${path}`
+                  : `Successfully wrote ${content.length} bytes to ${path}`,
               },
             ],
             details: undefined,
@@ -438,6 +508,7 @@ export function createWriteToolDefinition(
         } catch (error: unknown) {
           const recovered = await recoverSuccessfulWrite({
             absolutePath,
+            append,
             content,
             error,
             ops,

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -494,6 +494,9 @@ export function createWriteToolDefinition(
           } else {
             await ops.writeFile(absolutePath, content);
           }
+          if (signal?.aborted) {
+            throw new Error("Operation aborted");
+          }
           return {
             content: [
               {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -782,7 +782,7 @@ export function buildAgentSystemPrompt(params: {
   const acpSpawnRuntimeEnabled = acpEnabled && !sandboxedRuntime;
   const coreToolSummaries: Record<string, string> = {
     read: "Read file contents",
-    write: "Create or overwrite files",
+    write: "Create, overwrite, or append to files",
     edit: "Make precise edits to files",
     apply_patch: "Apply multi-file patches",
     grep: "Search file contents for patterns",

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -70,7 +70,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   {
     id: "write",
     label: "write",
-    description: "Create or overwrite files",
+    description: "Create, overwrite, or append to files",
     sectionId: "fs",
     profiles: ["coding"],
   },

--- a/ui/src/lib/agents/display.ts
+++ b/ui/src/lib/agents/display.ts
@@ -43,7 +43,7 @@ const FALLBACK_TOOL_SECTIONS: AgentToolSection[] = [
     label: "Files",
     tools: [
       { id: "read", label: "read", description: "Read file contents" },
-      { id: "write", label: "write", description: "Create or overwrite files" },
+      { id: "write", label: "write", description: "Create, overwrite, or append to files" },
       { id: "edit", label: "edit", description: "Make precise edits" },
       { id: "apply_patch", label: "apply_patch", description: "Patch files (OpenAI)" },
     ],


### PR DESCRIPTION
## What Problem This Solves

The write tool always overwrites files. An `append: true` parameter lets the agent add content to the end of an existing file instead of replacing it. The agent requested this capability repeatedly in real sessions — it wants to write logs, build up checklists incrementally, and extend existing scripts without re-reading them first.

## Why This Change Was Made

Write-tool silent data loss (#40001) can happen when an agent writes to a file it has already edited without re-reading the current content. An append mode gives the agent a safer option: it can add new content without risking the loss of previous edits.

## What Changed

- `src/agents/sessions/tools/write.ts` — add `append?: boolean` to the schema, `WriteOperations.appendFile` method, append branch in `execute`, append-aware recovery (`isRecoveredAppendContent`), and post-mutation abort check matching `edit.ts:460-463`.
- `src/agents/sessions/tools/tool-contracts.ts` — add `append?: boolean` to `WriteToolInput`.
- `src/agents/agent-tools.read.ts` — wire `appendFile` for host (`fs.appendFile`), workspace (`root.append()`), and sandbox (read-modify-write, since the sandbox bridge has no native append).
- `src/agents/sessions/tools/write.test.ts` — 7 new tests covering: basic append, append-to-new-file, no-op short-circuit for overwrite, malformed append param rejection, append-identical-content preserving duplicates, append-after-abort recovery via readback, and abort-surfaced-when-append-did-not-persist.

## User Impact

- `append: true` is opt-in. The default write behavior is unchanged.
- Append to a non-existent file creates it (matching `>>` shell semantics).
- The write tool description and prompt snippet advertise the new parameter.

## Evidence

Focused suite (local fallback — Crabbox unavailable in this env):

```
$ node scripts/run-vitest.mjs run src/agents/sessions/tools/write.test.ts --reporter=verbose
 Test Files  1 passed (1)
      Tests  14 passed (14)
```

Tests cover: basic append, append-to-new, no-op detection for identical overwrite, malformed `append` param rejection, append identical content (duplicate tail preserved), reject append when the custom backend omits `appendFile`, post-mutation abort recovery for append (readback confirms content landed), and abort surfaced when appendFile returned without persisting.

