### PR TITLE
fix(discord): keep gateway close reasons UTF-16 safe

### DIFF
--- a/extensions/discord/src/monitor/gateway-plugin.test.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.test.ts
@@ -102,6 +102,25 @@ describe("createDiscordGatewayPlugin", () => {
     });
   }
 
+  function containsLoneSurrogate(value: string): boolean {
+    for (let index = 0; index < value.length; index += 1) {
+      const code = value.charCodeAt(index);
+      if (code >= 0xd800 && code <= 0xdbff) {
+        const next = value.charCodeAt(index + 1);
+        if (!(next >= 0xdc00 && next <= 0xdfff)) {
+          return true;
+        }
+      }
+      if (code >= 0xdc00 && code <= 0xdfff) {
+        const previous = value.charCodeAt(index - 1);
+        if (!(previous >= 0xd800 && previous <= 0xdbff)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   it("omits GuildVoiceStates by default for text-only Discord configs", () => {
     expect(resolveDiscordGatewayIntents() & GatewayIntents.GuildVoiceStates).toBe(0);
   });
@@ -354,5 +373,36 @@ describe("createDiscordGatewayPlugin", () => {
     expect(logs).toContain("reason=policy violation");
     expect(logs).toContain("lastErrorCode=WS_ERR_TOO_MANY_BUFFERED_PARTS");
     expect(logs).toContain("hint=possible ws receiver buffered-parts limit");
+  });
+
+  it("keeps gateway close reason logs UTF-16 safe", () => {
+    const socket = new EventEmitter() as EventEmitter & { binaryType?: string };
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+    const plugin = createPlugin(
+      {
+        webSocketCtor: function WebSocketCtor() {
+          return socket;
+        } as unknown as NonNullable<
+          Parameters<typeof createDiscordGatewayPlugin>[0]["testing"]
+        >["webSocketCtor"],
+      },
+      {},
+      runtime,
+    );
+    const createdSocket = (
+      plugin as unknown as { createWebSocket: (url: string) => typeof socket }
+    ).createWebSocket("wss://gateway.discord.gg");
+
+    createdSocket.emit("close", 1008, Buffer.from(`${"A".repeat(239)}🧪 tail`));
+
+    const logs = runtime.log.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(logs).toContain("discord: gateway websocket closed");
+    expect(logs).toContain("code=1008");
+    expect(containsLoneSurrogate(logs)).toBe(false);
+    expect(logs).not.toContain("�");
   });
 });

--- a/extensions/discord/src/monitor/gateway-plugin.test.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.test.ts
@@ -102,25 +102,6 @@ describe("createDiscordGatewayPlugin", () => {
     });
   }
 
-  function containsLoneSurrogate(value: string): boolean {
-    for (let index = 0; index < value.length; index += 1) {
-      const code = value.charCodeAt(index);
-      if (code >= 0xd800 && code <= 0xdbff) {
-        const next = value.charCodeAt(index + 1);
-        if (!(next >= 0xdc00 && next <= 0xdfff)) {
-          return true;
-        }
-      }
-      if (code >= 0xdc00 && code <= 0xdfff) {
-        const previous = value.charCodeAt(index - 1);
-        if (!(previous >= 0xd800 && previous <= 0xdbff)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
   it("omits GuildVoiceStates by default for text-only Discord configs", () => {
     expect(resolveDiscordGatewayIntents() & GatewayIntents.GuildVoiceStates).toBe(0);
   });
@@ -399,10 +380,10 @@ describe("createDiscordGatewayPlugin", () => {
 
     createdSocket.emit("close", 1008, Buffer.from(`${"A".repeat(239)}🧪 tail`));
 
-    const logs = runtime.log.mock.calls.map((call) => String(call[0])).join("\n");
-    expect(logs).toContain("discord: gateway websocket closed");
-    expect(logs).toContain("code=1008");
-    expect(containsLoneSurrogate(logs)).toBe(false);
-    expect(logs).not.toContain("�");
+    const log = String(runtime.log.mock.calls.at(-1)?.[0]);
+    expect(log).toContain("discord: gateway websocket closed");
+    expect(log).toContain("code=1008");
+    expect(log).toContain(`reason=${"A".repeat(239)}...`);
+    expect(log).toContain("hint=possible ws receiver buffered-parts limit");
   });
 });

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -11,6 +11,7 @@ import {
 } from "openclaw/plugin-sdk/proxy-capture";
 import { danger, warn } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import * as ws from "ws";
 import * as discordGateway from "../internal/gateway.js";
 import { createDiscordDnsLookup } from "../network-config.js";
@@ -110,7 +111,7 @@ function formatDiscordGatewayCloseReason(reason: Buffer): string {
   if (text.length <= DISCORD_GATEWAY_CLOSE_REASON_LOG_MAX_CHARS) {
     return text;
   }
-  return `${text.slice(0, DISCORD_GATEWAY_CLOSE_REASON_LOG_MAX_CHARS)}...`;
+  return `${truncateUtf16Safe(text, DISCORD_GATEWAY_CLOSE_REASON_LOG_MAX_CHARS)}...`;
 }
 
 function formatDiscordGatewayTransportErrorLog(params: {


### PR DESCRIPTION
## What Problem This Solves

Discord gateway close reasons are capped at 240 UTF-16 code units before being written to the runtime warning log. The formatter used raw slicing, which could retain a lone high surrogate when the limit crossed an emoji or another astral character.

## Why This Change Was Made

`formatDiscordGatewayCloseReason` now uses `truncateUtf16Safe` from the supported `openclaw/plugin-sdk/text-utility-runtime` facade. Buffer decoding, whitespace normalization, log conditions, capture behavior, and gateway lifecycle remain unchanged.

The maintainer fixup replaced a manual surrogate scanner with a stronger exact assertion: the production WebSocket close path must log 239 ASCII characters followed immediately by the existing `...` suffix. That assertion fails against the previous malformed output.

## User Impact

Abnormal Discord gateway close diagnostics remain readable when a truncation boundary crosses an astral character. Connection, reconnect, identify, and message delivery behavior do not change.

## Evidence

- Production-path test constructs the Discord gateway plugin, injects the existing WebSocket test seam, emits `close(1008, Buffer)`, and inspects the emitted runtime warning.
- The exact reason prefix, close code, and receiver-limit hint are asserted.
- Targeted oxfmt and `git diff --check`: pass.
- Fresh maintainer autoreview: clean, confidence 0.99.
- Exact-head CI run `28991617622`, OpenGrep run `28991617608`, and CodeQL run `28991617585` on `143d723f24776b8bca6ffbe68a361b75539af5c8`: success.

AI-assisted: yes. Maintainer-reviewed and tightened.
