### PR TITLE
fix(cron): failure alerts to a channel are dropped when a global webhook failure destination is set

### DIFF
--- a/src/cron/delivery-plan.ts
+++ b/src/cron/delivery-plan.ts
@@ -189,14 +189,19 @@ export function resolveFailureDestination(
     if (hasJobAccountIdField) {
       accountId = jobAccountId;
     }
-    if (hasJobModeField) {
+    // A channel-shaped override without a mode is an announce destination, matching
+    // primary-delivery defaults; inheriting a global webhook mode would feed the
+    // chat target to the webhook URL validator and silently drop the alert.
+    const jobImpliesAnnounce = !hasJobModeField && jobChannel !== undefined;
+    if (hasJobModeField || jobImpliesAnnounce) {
+      const effectiveJobMode = jobImpliesAnnounce ? "announce" : jobMode;
       const globalMode = globalConfig?.mode ?? "announce";
-      const resolvedJobMode = jobMode ?? "announce";
+      const resolvedJobMode = effectiveJobMode ?? "announce";
       if (!jobToExplicitValue && globalMode !== resolvedJobMode) {
         // Do not carry an inherited target across modes; an announce chat is not a webhook URL.
         to = undefined;
       }
-      mode = jobMode;
+      mode = effectiveJobMode;
     }
   }
 

--- a/src/cron/delivery.test.ts
+++ b/src/cron/delivery.test.ts
@@ -235,6 +235,60 @@ describe("resolveFailureDestination", () => {
     });
   });
 
+  it("resolves a channel-shaped job override without mode to announce despite a global webhook default", () => {
+    const plan = resolveFailureDestination(
+      makeCronJob({
+        delivery: {
+          mode: "none",
+          failureDestination: { channel: "slack", to: "#alerts" },
+        },
+      }),
+      { mode: "webhook", to: "https://hook.example/cron" },
+    );
+    expect(plan).toEqual({
+      mode: "announce",
+      channel: "slack",
+      to: "#alerts",
+      accountId: undefined,
+    });
+  });
+
+  it("clears an inherited global webhook URL when a channel-only override implies announce", () => {
+    const plan = resolveFailureDestination(
+      makeCronJob({
+        delivery: {
+          mode: "none",
+          failureDestination: { channel: "slack" },
+        },
+      }),
+      { mode: "webhook", to: "https://hook.example/cron" },
+    );
+    expect(plan).toEqual({
+      mode: "announce",
+      channel: "slack",
+      to: undefined,
+      accountId: undefined,
+    });
+  });
+
+  it("keeps inheriting a global webhook mode for a to-only override without channel or mode", () => {
+    const plan = resolveFailureDestination(
+      makeCronJob({
+        delivery: {
+          mode: "none",
+          failureDestination: { to: "https://other.example/hook" },
+        },
+      }),
+      { mode: "webhook", to: "https://hook.example/cron" },
+    );
+    expect(plan).toEqual({
+      mode: "webhook",
+      channel: undefined,
+      to: "https://other.example/hook",
+      accountId: undefined,
+    });
+  });
+
   it("returns null for webhook mode without destination URL", () => {
     const plan = resolveFailureDestination(
       makeCronJob({


### PR DESCRIPTION
Closes #102235

## What Problem This Solves

Fixes an issue where a cron job with a channel-shaped failure destination and no explicit mode (e.g. `--failure-channel slack --failure-to "#alerts"` with no `--failure-mode`) would silently inherit a global `cron.failureDestination` webhook mode. At failure time the chat target was fed to the webhook URL validator, failed, and the failure alert was dropped with only a "webhook URL is invalid, skipping" log — the operator never learns the job's failures are unreachable.

## Why This Change Was Made

`resolveFailureDestination` only reconciled the mode when the job's `mode` field was present, so a mode-less channel override kept the inherited global `webhook` mode. The fix treats a channel-shaped override without a mode as an announce destination — matching primary-delivery semantics, where `resolveCronDeliveryPlan` defaults a missing mode to `announce` — and reuses the existing cross-mode rule so an inherited global webhook URL is not carried into the announce plan. A to-only override (no channel, no mode) intentionally still inherits the global mode, since a bare `to` with a global webhook default is a webhook URL override.

## User Impact

Cron failure alerts routed with `--failure-channel <channel> --failure-to <target>` (and no `--failure-mode`) now reach the named channel even when a global webhook failure destination is configured. Explicit-mode overrides and to-only URL overrides behave exactly as before.

## Evidence

Three regression tests added in `src/cron/delivery.test.ts`:
- the issue's repro: global `{ mode: "webhook", to: "https://hook..." }` + job `{ channel: "slack", to: "#alerts" }` resolves to `{ mode: "announce", channel: "slack", to: "#alerts" }` (previously `{ mode: "webhook", to: "#alerts" }`, dropped downstream)
- a channel-only override clears the inherited webhook URL instead of announcing to it
- a to-only override still inherits the global webhook mode with the overridden URL

```
pnpm test src/cron/delivery.test.ts
 Test Files  1 passed (1)
      Tests  22 passed (22)

pnpm test src/cron/delivery.failure-notify.test.ts src/cron/delivery-preview.test.ts src/cron/delivery-context.test.ts
 Test Files  3 passed (3)
      Tests  14 passed (14)
```

Note: run locally (Node 22.22.2, macOS) as a contributor checkout; no Crabbox/Testbox access from this environment.
