### PR TITLE
fix(qa): stabilize malformed JSON body errors

### DIFF
--- a/extensions/qa-lab/src/bus-server.test.ts
+++ b/extensions/qa-lab/src/bus-server.test.ts
@@ -156,6 +156,19 @@ describe("qa-bus server", () => {
     });
   });
 
+  it("returns a stable error when a v1 POST body has malformed JSON", async () => {
+    const state = createQaBusState();
+    const bus = await startQaBusServer({ state });
+    stops.push(bus["stop"]);
+
+    const response = await postQaBusRawJson(bus.baseUrl, "/v1/reset", "{");
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Malformed JSON body",
+    });
+  });
+
   it("rejects malformed search limits before querying state", async () => {
     const state = createQaBusState();
     const bus = await startQaBusServer({ state });

--- a/extensions/qa-lab/src/bus-server.ts
+++ b/extensions/qa-lab/src/bus-server.ts
@@ -26,6 +26,20 @@ const QA_HTTP_JSON_BODY_TIMEOUT_MS = 5_000;
 const QA_BUS_POLL_TIMEOUT_MAX_MS = 30_000;
 const QA_BUS_POLL_LIMIT_MAX = 500;
 const QA_BUS_SEARCH_LIMIT_MAX = 100;
+const QA_HTTP_MALFORMED_JSON_MESSAGE = "Malformed JSON body";
+
+export class QaMalformedJsonBodyError extends Error {
+  readonly statusCode = 400;
+
+  constructor() {
+    super(QA_HTTP_MALFORMED_JSON_MESSAGE);
+    this.name = "QaMalformedJsonBodyError";
+  }
+}
+
+export function isQaMalformedJsonBodyError(error: unknown): error is QaMalformedJsonBodyError {
+  return error instanceof QaMalformedJsonBodyError;
+}
 
 export async function readQaJsonBody(req: IncomingMessage): Promise<unknown> {
   const text = (
@@ -34,7 +48,14 @@ export async function readQaJsonBody(req: IncomingMessage): Promise<unknown> {
       timeoutMs: QA_HTTP_JSON_BODY_TIMEOUT_MS,
     })
   ).trim();
-  return text ? (JSON.parse(text) as unknown) : {};
+  if (!text) {
+    return {};
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new QaMalformedJsonBodyError();
+  }
 }
 
 export function writeJson(res: ServerResponse, statusCode: number, body: unknown) {

--- a/extensions/qa-lab/src/lab-server.test.ts
+++ b/extensions/qa-lab/src/lab-server.test.ts
@@ -3,15 +3,16 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
+import { Readable } from "node:stream";
 import { setTimeout as sleep } from "node:timers/promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readQaJsonBody } from "./bus-server.js";
+import { resolveUiAssetVersion } from "./lab-server-ui.js";
 import {
   startQaLabServer,
   writeQaLabServerError,
   type QaLabServerStartParams,
 } from "./lab-server.js";
-import { resolveUiAssetVersion } from "./lab-server-ui.js";
 
 const qaChannelMock = vi.hoisted(() => ({
   resolveAccount: vi.fn(),
@@ -637,6 +638,34 @@ describe("qa-lab server", () => {
 
     expect(res.statusCode).toBe(413);
     expect(JSON.parse(res.body)).toEqual({ error: "Payload too large" });
+  });
+
+  it("returns controlled errors for malformed JSON body reads", async () => {
+    const req = Object.assign(Readable.from(["{"]), {
+      headers: {},
+    });
+    const res = {
+      statusCode: 0,
+      body: "",
+      writeHead(statusCode: number) {
+        this.statusCode = statusCode;
+      },
+      end(payload: string) {
+        this.body = payload;
+      },
+    };
+
+    let error: unknown;
+    try {
+      await readQaJsonBody(req as never);
+    } catch (caught) {
+      error = caught;
+    }
+
+    writeQaLabServerError(res as never, error);
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: "Malformed JSON body" });
   });
 
   it("anchors direct self-check runs under the explicit repo root by default", async () => {

--- a/extensions/qa-lab/src/lab-server.ts
+++ b/extensions/qa-lab/src/lab-server.ts
@@ -10,6 +10,7 @@ import {
 import {
   closeQaHttpServer,
   handleQaBusRequest,
+  isQaMalformedJsonBodyError,
   readQaJsonBody,
   writeError,
   writeJson,
@@ -74,6 +75,10 @@ export type {
 
 export function writeQaLabServerError(res: Parameters<typeof writeError>[0], error: unknown): void {
   if (writeQaRequestBodyLimitError(res, error)) {
+    return;
+  }
+  if (isQaMalformedJsonBodyError(error)) {
+    writeError(res, error.statusCode, error.message);
     return;
   }
   if (error instanceof QaEvidenceGalleryError) {


### PR DESCRIPTION
## What Problem This Solves

Fixes #102055.

QA Bus and QA Lab POST endpoints could surface raw `JSON.parse` diagnostics when request bodies contained malformed JSON, which made the response depend on Node's parser wording instead of a stable QA HTTP contract.

## Why This Change Was Made

The shared QA JSON body reader now preserves the existing empty-body behavior, still lets payload-limit errors flow through their existing path, and maps malformed JSON to a named 400 error. QA Lab's top-level error writer handles the same named error so both Lab and Bus HTTP surfaces return the stable response shape.

## User Impact

Malformed QA HTTP request bodies now receive a deterministic 400 response:

```json
{ "error": "Malformed JSON body" }
```

Valid, empty, and oversized request bodies keep their previous behavior.

## Evidence

- `git diff --check`
- `/Users/harjothk/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/run-vitest.mjs extensions/qa-lab/src/bus-server.test.ts extensions/qa-lab/src/lab-server.test.ts -- --reporter=verbose` passed: 2 files, 23 tests
- `/Users/harjothk/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 .agents/skills/autoreview/scripts/autoreview --mode local` passed with no accepted/actionable findings

AI-assisted: yes. I used Codex to implement and review this change, with the final diff limited to the QA body-reader and QA Lab/Bus error handling/tests.
