### PR TITLE
fix(cron): prevent double dispatch after disable/enable cycle during in-flight run

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -8,6 +8,7 @@ import {
 import { resolveCronTriggerMinIntervalMs } from "../../config/cron-limits.js";
 import type { CronConfig } from "../../config/types.cron.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
+import { isCronJobActive } from "../active-jobs.js";
 import { resolveCronDeliveryPlan } from "../delivery-plan.js";
 import { parseAbsoluteTimeMs } from "../parse.js";
 import {
@@ -634,7 +635,8 @@ function normalizeJobTickState(params: { state: CronServiceState; job: CronJob; 
     }
     if (
       job.state.runningAtMs !== undefined &&
-      !isQueuedForceCronRun(state, job.id, job.state.runningAtMs)
+      !isQueuedForceCronRun(state, job.id, job.state.runningAtMs) &&
+      !isCronJobActive(job.id)
     ) {
       job.state.runningAtMs = undefined;
       changed = true;
@@ -1364,12 +1366,24 @@ function mergeCronFailureAlert(
   return next;
 }
 
+/**
+ * Covers both durable reservations and the process marker that survives mutable job state.
+ * Every timer/manual admission path must use this or disable/re-enable can duplicate a run.
+ */
+export function hasActiveCronRun(job: Pick<CronJob, "id" | "state">) {
+  return (
+    typeof job.state.queuedAtMs === "number" ||
+    typeof job.state.runningAtMs === "number" ||
+    isCronJobActive(job.id)
+  );
+}
+
 /** Returns whether a cron job should execute at `nowMs`, honoring force mode and active runs. */
 export function isJobDue(job: CronJob, nowMs: number, opts: { forced: boolean }) {
   if (!job.state) {
     job.state = {};
   }
-  if (typeof job.state.queuedAtMs === "number" || typeof job.state.runningAtMs === "number") {
+  if (hasActiveCronRun(job)) {
     return false;
   }
   if (opts.forced) {

--- a/src/cron/service/ops.regression.test.ts
+++ b/src/cron/service/ops.regression.test.ts
@@ -22,8 +22,9 @@ import {
   tryBeginGatewayRootWorkAdmission,
 } from "../../process/gateway-work-admission.js";
 import { CommandLane } from "../../process/lanes.js";
+import { isCronJobActive } from "../active-jobs.js";
 import { loadCronStore, saveCronStore } from "../store.js";
-import { enqueueRun, remove, run, start } from "./ops.js";
+import { enqueueRun, remove, run, start, update } from "./ops.js";
 import type { CronEvent } from "./state.js";
 import { createCronServiceState } from "./state.js";
 import { onTimer } from "./timer.test-support.js";
@@ -834,6 +835,112 @@ describe("cron service ops regressions", () => {
     expect(state.store?.jobs.some((entry) => entry.id === job.id)).toBe(false);
 
     clearCommandLane(CommandLane.Cron);
+  });
+
+  it("#102238 keeps a timer tick from duplicating a re-enabled active run", async () => {
+    const store = opsRegressionFixtures.makeStorePath();
+    const now = Date.parse("2026-07-09T12:00:00.000Z");
+    const job = createDueIsolatedJob({
+      id: "disable-enable-timer",
+      nowMs: now,
+      nextRunAtMs: now - 60_000,
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+    const firstRunGate = createDeferred<void>();
+    let dispatchCount = 0;
+    let inFlight = 0;
+    let peakInFlight = 0;
+    const state = createCronServiceState({
+      cronEnabled: true,
+      cronConfig: { maxConcurrentRuns: 2 },
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => {
+        dispatchCount += 1;
+        inFlight += 1;
+        peakInFlight = Math.max(peakInFlight, inFlight);
+        if (dispatchCount === 1) {
+          await firstRunGate.promise;
+        }
+        inFlight -= 1;
+        return { status: "ok" as const, summary: "done" };
+      }),
+    });
+
+    const firstRun = run(state, job.id, "force");
+    try {
+      await vi.waitFor(() => {
+        expect(dispatchCount).toBe(1);
+        expect(isCronJobActive(job.id)).toBe(true);
+      });
+      await update(state, job.id, { enabled: false });
+      await update(state, job.id, { enabled: true });
+
+      await onTimer(state);
+
+      expect(dispatchCount).toBe(1);
+      expect(peakInFlight).toBe(1);
+    } finally {
+      firstRunGate.resolve();
+      await firstRun;
+    }
+
+    await expect(run(state, job.id, "force")).resolves.toEqual({ ok: true, ran: true });
+    expect(dispatchCount).toBe(2);
+  });
+
+  it("#102238 rejects a second manual run after disabling and re-enabling", async () => {
+    const store = opsRegressionFixtures.makeStorePath();
+    const now = Date.parse("2026-07-09T12:00:00.000Z");
+    const job = createDueIsolatedJob({
+      id: "disable-enable-manual",
+      nowMs: now,
+      nextRunAtMs: now - 60_000,
+    });
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+    const firstRunGate = createDeferred<void>();
+    let dispatchCount = 0;
+    const state = createCronServiceState({
+      cronEnabled: true,
+      cronConfig: { maxConcurrentRuns: 2 },
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => {
+        dispatchCount += 1;
+        if (dispatchCount === 1) {
+          await firstRunGate.promise;
+        }
+        return { status: "ok" as const, summary: "done" };
+      }),
+    });
+
+    const firstRun = run(state, job.id, "force");
+    try {
+      await vi.waitFor(() => expect(dispatchCount).toBe(1));
+      await update(state, job.id, { enabled: false });
+      await update(state, job.id, { enabled: true });
+
+      await expect(run(state, job.id, "force")).resolves.toEqual({
+        ok: true,
+        ran: false,
+        reason: "already-running",
+      });
+      expect(dispatchCount).toBe(1);
+    } finally {
+      firstRunGate.resolve();
+      await firstRun;
+    }
+
+    await expect(run(state, job.id, "force")).resolves.toEqual({ ok: true, ran: true });
+    expect(dispatchCount).toBe(2);
   });
 
   it.each([

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -12,6 +12,7 @@ import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.pa
 import {
   clearCronJobActive,
   isCronActiveJobMarkerCurrent,
+  isCronJobActive,
   markCronJobActive,
   type CronActiveJobMarker,
 } from "../active-jobs.js";
@@ -29,6 +30,7 @@ import {
   computeJobNextRunAtMs,
   createJob,
   findJobOrThrow,
+  hasActiveCronRun,
   hasScheduledNextRunAtMs,
   isJobEnabled,
   isJobDue,
@@ -506,7 +508,11 @@ function finalizeUpdatedJob(params: {
     } else {
       nextJob.state.nextRunAtMs = undefined;
       nextJob.state.queuedAtMs = undefined;
-      nextJob.state.runningAtMs = undefined;
+      // Preserve only genuine execution. Queued reservations must clear so a
+      // disabled job can accept a later force run with the same timestamp.
+      if (!isCronJobActive(nextJob.id)) {
+        nextJob.state.runningAtMs = undefined;
+      }
     }
   } else if (isJobEnabled(nextJob) && !hasScheduledNextRunAtMs(nextJob.state.nextRunAtMs)) {
     nextJob.state.nextRunAtMs = computeJobNextRunAtMs(nextJob, now);
@@ -876,7 +882,7 @@ async function inspectManualRunPreflight(
       await skipInvalidPersistedManualRun({ state, job, mode, runId, terminalTracker, error });
       return { ok: true, ran: false, reason: "invalid-spec" as const };
     }
-    if (typeof job.state.queuedAtMs === "number" || typeof job.state.runningAtMs === "number") {
+    if (hasActiveCronRun(job)) {
       return { ok: true, ran: false, reason: "already-running" as const };
     }
     const now = state.deps.nowMs();
@@ -955,7 +961,7 @@ async function prepareManualRun(
       });
       return { ok: true, ran: false, reason: "invalid-spec" as const };
     }
-    if (typeof job.state.queuedAtMs === "number" || typeof job.state.runningAtMs === "number") {
+    if (hasActiveCronRun(job)) {
       return { ok: true, ran: false, reason: "already-running" as const };
     }
     const reservationAt = state.deps.nowMs();

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -74,6 +74,7 @@ import {
   computeJobPreviousRunAtMs,
   computeJobNextRunAtMs,
   errorBackoffMs,
+  hasActiveCronRun,
   hasScheduledNextRunAtMs,
   isJobEnabled,
   nextWakeAtMs,
@@ -1824,7 +1825,7 @@ function isRunnableJob(params: {
   if (params.skipJobIds?.has(job.id)) {
     return false;
   }
-  if (typeof job.state.queuedAtMs === "number" || typeof job.state.runningAtMs === "number") {
+  if (hasActiveCronRun(job)) {
     return false;
   }
   const lastRunStatus = resolveJobLastRunStatus(job);


### PR DESCRIPTION
Fixes #102238

## What Problem This Solves

Fixes an issue where disabling and re-enabling a cron job during an active run could allow the same job to execute concurrently. A natural scheduler tick or a second manual force-run could overlap the original execution when concurrency was greater than one.

## Why This Change Was Made

Timer selection and both manual-run admission phases now share one active-run predicate covering durable queue/run reservations and the process execution marker. Disabling a job clears queued work but preserves a genuine in-process execution marker; disabled maintenance clears inactive abandoned markers normally.

This rewrites the original PR on current main. It keeps the contributor's core insight, adds the missed manual-run sibling, and avoids retaining inactive markers until the two-hour stale timeout.

## User Impact

Operators can disable and re-enable a running cron job without accidentally duplicating its messages or side effects. A second force run reports `already-running` while the first execution is active. After completion, later legitimate force runs continue to work.

## Evidence

- Two deterministic regressions use `cron.maxConcurrentRuns: 2` so the global cap cannot mask overlap:
  - force run → disable → enable → timer tick: one dispatch, peak concurrency one.
  - force run → disable → enable → second force: returns `already-running`, one dispatch.
  - both tests then prove a later force run succeeds after completion.
- Focused service suite: 19/19 passed locally.
- Stress: 30 consecutive focused suite runs, 570/570 tests, zero failures.
- Scheduler/admission sibling matrix: 7 files, 118/118 tests passed, including manual admission, timer regression, active-marker generation, and due-slot recomputation.
- Blacksmith Testbox `check:changed`: core production/test types, lint, format, plugin boundaries, import cycles, database-first guard, and related checks passed.
- Autoreview: clean; no accepted/actionable findings, correctness confidence 0.90.
- Source-blind behavior validation was attempted but blocked before gateway launch because the documented source-checkout CLI auto-built and dirtied a tracked bundled asset. No runtime claim relies on that blocked lane.

Co-authored-by credit is preserved for @zw-xysk. AI-assisted maintainer rewrite; I reviewed the active marker, manual admission, timer, disable/update, stale cleanup, and sibling scheduling paths.
