### PR TITLE
ci: temporarily disable QA smoke again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -922,7 +922,7 @@ jobs:
       contents: read
     name: QA Smoke CI (${{ matrix.name }})
     needs: [preflight]
-    if: needs.preflight.outputs.run_checks_fast == 'true'
+    if: ${{ false }} # Temporarily disabled while QA smoke sharding is repaired.
     runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-16vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 60
     strategy:
@@ -1009,7 +1009,7 @@ jobs:
       contents: read
     name: QA Smoke CI
     needs: [preflight, qa-smoke-ci-shard]
-    if: always() && needs.preflight.outputs.run_checks_fast == 'true'
+    if: ${{ false }} # Temporarily disabled while QA smoke sharding is repaired.
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
## What Problem This Solves

Automatic QA Smoke CI is still using the replacement introduced by #101186 while its shard planning and scenario scope are being cleaned up. Keeping it active consumes three runners and can block unrelated PRs on failures that are not yet trustworthy.

## Why This Change Was Made

Temporarily skip both the shard matrix and its aggregate job at the GitHub Actions job level. The workflow, profile, planner, and required check names remain intact so the clean replacement PR can re-enable them with a two-line revert.

## User Impact

Normal CI continues without automatic QA Smoke execution until the replacement fix is ready. Manual QA Lab commands and the `smoke-ci` profile are unchanged.

## Evidence

- Only the two QA Smoke job-level `if` expressions changed.
- `git diff --check` passed.
- Autoreview intentionally skipped per maintainer request; this PR is the temporary kill switch.

Related: #101186
Related: #101187
