### PR TITLE
fix(telegram): strip Markdown formatting in conversation-context dedup [AI]

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.prompt-context-dedup.test.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.prompt-context-dedup.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { resolvePromptContextTextDedupeKey } from "./bot-handlers.runtime.js";
+
+describe("resolvePromptContextTextDedupeKey", () => {
+  it("returns undefined for non-string body", () => {
+    expect(resolvePromptContextTextDedupeKey({ body: undefined })).toBeUndefined();
+    expect(resolvePromptContextTextDedupeKey({ body: 42 })).toBeUndefined();
+    expect(resolvePromptContextTextDedupeKey({})).toBeUndefined();
+  });
+
+  it("returns undefined for empty body after trimming", () => {
+    expect(resolvePromptContextTextDedupeKey({ body: "   ", timestamp_ms: 1000 })).toBeUndefined();
+  });
+
+  it("returns undefined when timestamp_ms is missing or invalid", () => {
+    expect(
+      resolvePromptContextTextDedupeKey({ body: "hello world this is long enough" }),
+    ).toBeUndefined();
+    expect(
+      resolvePromptContextTextDedupeKey({
+        body: "hello world this is long enough",
+        timestamp_ms: Number.NaN,
+      }),
+    ).toBeUndefined();
+    expect(
+      resolvePromptContextTextDedupeKey({
+        body: "hello world this is long enough",
+        timestamp_ms: Infinity,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("produces matching keys for the same text with different Markdown formatting", () => {
+    const plain = "The quick brown fox jumps over the lazy dog";
+    const bold = "**The quick brown fox jumps over the lazy dog**";
+    const italic = "_The quick brown fox jumps over the lazy dog_";
+    const code = "`The quick brown fox jumps over the lazy dog`";
+
+    const keyPlain = resolvePromptContextTextDedupeKey({ body: plain, timestamp_ms: 1000 });
+    const keyBold = resolvePromptContextTextDedupeKey({ body: bold, timestamp_ms: 1000 });
+    const keyItalic = resolvePromptContextTextDedupeKey({ body: italic, timestamp_ms: 1000 });
+    const keyCode = resolvePromptContextTextDedupeKey({ body: code, timestamp_ms: 1000 });
+
+    expect(keyPlain).toBe(keyBold);
+    expect(keyPlain).toBe(keyItalic);
+    expect(keyPlain).toBe(keyCode);
+    expect(keyPlain).toBe("1000:The quick brown fox jumps over the lazy dog");
+  });
+
+  it("produces different keys for different timestamps", () => {
+    const key1 = resolvePromptContextTextDedupeKey({
+      body: "hello world",
+      timestamp_ms: 1000,
+    });
+    const key2 = resolvePromptContextTextDedupeKey({
+      body: "hello world",
+      timestamp_ms: 2000,
+    });
+
+    expect(key1).toBe("1000:hello world");
+    expect(key2).toBe("2000:hello world");
+    expect(key1).not.toBe(key2);
+  });
+
+  it("strips Markdown formatting from short bodies too", () => {
+    const key = resolvePromptContextTextDedupeKey({
+      body: "**ok**",
+      timestamp_ms: 1000,
+    });
+
+    expect(key).toBe("1000:ok");
+  });
+});

--- a/extensions/telegram/src/bot-handlers.runtime.prompt-context-dedup.test.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.prompt-context-dedup.test.ts
@@ -70,4 +70,13 @@ describe("resolvePromptContextTextDedupeKey", () => {
 
     expect(key).toBe("1000:ok");
   });
+
+  it("preserves literal underscores inside words (regression)", () => {
+    const key = resolvePromptContextTextDedupeKey({
+      body: "check this_here_value now",
+      timestamp_ms: 1000,
+    });
+
+    expect(key).toBe("1000:check this_here_value now");
+  });
 });

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -48,7 +48,10 @@ import {
   resolveAmbientTranscriptWatermarkKey,
 } from "openclaw/plugin-sdk/session-store-runtime";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { stripInlineDirectiveTagsForDelivery } from "openclaw/plugin-sdk/text-chunking";
+import {
+  stripInlineDirectiveTagsForDelivery,
+  stripMarkdown,
+} from "openclaw/plugin-sdk/text-chunking";
 import { expandTelegramAllowFromWithAccessGroups } from "./access-groups.js";
 import { resolveTelegramAccount, resolveTelegramMediaRuntimeOptions } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
@@ -180,20 +183,10 @@ import { resolveTelegramPromptMediaPath } from "./prompt-media-path.js";
 import { buildInlineKeyboard } from "./send.js";
 import { buildTelegramSessionTranscriptPromptMessages } from "./session-transcript-context.js";
 
-export type TelegramPromptContextMessageForDedupe = {
+type TelegramPromptContextMessageForDedupe = {
   body?: unknown;
   timestamp_ms?: unknown;
 };
-
-/**
- * Strip Markdown emphasis / code formatting characters so that the same
- * message stored with different formatting in the session transcript vs
- * the Telegram message cache produces the same dedup key. Only strips
- * inline formatting characters: * _ ` ~
- */
-export function stripMarkdownFormatting(text: string): string {
-  return text.replace(/[*_`~]/g, "");
-}
 
 export function resolvePromptContextTextDedupeKey(
   message: TelegramPromptContextMessageForDedupe,
@@ -201,15 +194,16 @@ export function resolvePromptContextTextDedupeKey(
   if (typeof message.body !== "string") {
     return undefined;
   }
-  const visibleBody = stripInlineDirectiveTagsForDelivery(message.body).text.trim();
+  // Normalise both directive tags and Markdown formatting so the same message
+  // from the session transcript and the Telegram cache produces the same key.
+  const visibleBody = stripMarkdown(stripInlineDirectiveTagsForDelivery(message.body).text).trim();
   if (!visibleBody) {
     return undefined;
   }
   if (typeof message.timestamp_ms !== "number" || !Number.isFinite(message.timestamp_ms)) {
     return undefined;
   }
-  const normalisedBody = stripMarkdownFormatting(visibleBody);
-  return `${message.timestamp_ms}:${normalisedBody}`;
+  return `${message.timestamp_ms}:${visibleBody}`;
 }
 
 export const registerTelegramHandlers = ({

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -180,12 +180,22 @@ import { resolveTelegramPromptMediaPath } from "./prompt-media-path.js";
 import { buildInlineKeyboard } from "./send.js";
 import { buildTelegramSessionTranscriptPromptMessages } from "./session-transcript-context.js";
 
-type TelegramPromptContextMessageForDedupe = {
+export type TelegramPromptContextMessageForDedupe = {
   body?: unknown;
   timestamp_ms?: unknown;
 };
 
-function resolvePromptContextTextDedupeKey(
+/**
+ * Strip Markdown emphasis / code formatting characters so that the same
+ * message stored with different formatting in the session transcript vs
+ * the Telegram message cache produces the same dedup key. Only strips
+ * inline formatting characters: * _ ` ~
+ */
+export function stripMarkdownFormatting(text: string): string {
+  return text.replace(/[*_`~]/g, "");
+}
+
+export function resolvePromptContextTextDedupeKey(
   message: TelegramPromptContextMessageForDedupe,
 ): string | undefined {
   if (typeof message.body !== "string") {
@@ -198,7 +208,8 @@ function resolvePromptContextTextDedupeKey(
   if (typeof message.timestamp_ms !== "number" || !Number.isFinite(message.timestamp_ms)) {
     return undefined;
   }
-  return `${message.timestamp_ms}:${visibleBody}`;
+  const normalisedBody = stripMarkdownFormatting(visibleBody);
+  return `${message.timestamp_ms}:${normalisedBody}`;
 }
 
 export const registerTelegramHandlers = ({

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -54,11 +54,13 @@ import {
   appendAssistantMirrorMessageByIdentity,
   readLatestAssistantTextByIdentity,
 } from "openclaw/plugin-sdk/session-transcript-runtime";
-import { stripInlineDirectiveTagsForDelivery } from "openclaw/plugin-sdk/text-chunking";
+import {
+  stripInlineDirectiveTagsForDelivery,
+  stripMarkdown,
+} from "openclaw/plugin-sdk/text-chunking";
 import { resolveTelegramConfigReasoningDefault } from "./agent-config.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
-import { stripMarkdownFormatting } from "./bot-handlers.runtime.js";
 import type { TelegramMessageContext } from "./bot-message-context.js";
 import {
   findModelInCatalog,
@@ -1583,7 +1585,7 @@ export const dispatchTelegramMessage = async ({
   const resolveCurrentTurnTranscriptFinalText = async (): Promise<string | undefined> =>
     (await resolveCurrentTurnTranscriptFinal())?.text;
   const normalizePromptContextTimestampText = (text: string): string =>
-    stripMarkdownFormatting(stripInlineDirectiveTagsForDelivery(text).text.trim());
+    stripMarkdown(stripInlineDirectiveTagsForDelivery(text).text).trim();
   const resolvePromptContextTimestampMs = async (text: string): Promise<number | undefined> => {
     const final = await resolveCurrentTurnTranscriptFinal();
     if (

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -58,6 +58,7 @@ import { stripInlineDirectiveTagsForDelivery } from "openclaw/plugin-sdk/text-ch
 import { resolveTelegramConfigReasoningDefault } from "./agent-config.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
+import { stripMarkdownFormatting } from "./bot-handlers.runtime.js";
 import type { TelegramMessageContext } from "./bot-message-context.js";
 import {
   findModelInCatalog,
@@ -1582,7 +1583,7 @@ export const dispatchTelegramMessage = async ({
   const resolveCurrentTurnTranscriptFinalText = async (): Promise<string | undefined> =>
     (await resolveCurrentTurnTranscriptFinal())?.text;
   const normalizePromptContextTimestampText = (text: string): string =>
-    stripInlineDirectiveTagsForDelivery(text).text.trim();
+    stripMarkdownFormatting(stripInlineDirectiveTagsForDelivery(text).text.trim());
   const resolvePromptContextTimestampMs = async (text: string): Promise<number | undefined> => {
     const final = await resolveCurrentTurnTranscriptFinal();
     if (


### PR DESCRIPTION
<!-- This PR was authored by an AI agent (OpenCode/Sisyphus). A human operator reviewed and approved the submission. -->

Related: #102257

## What Problem This Solves

Fixes an issue where Telegram users would see duplicate assistant messages in the conversation context injected into the model when the assistant's reply contains Markdown formatting characters (`*`, `_`, `` ` ``, `~`).

The root cause: OpenClaw sends replies as HTML (`parse_mode=HTML`) via `markdownToTelegramHtml`. The Telegram Bot API strips HTML tags from the returned `text` field. The channel cache stores this stripped plain text, while the session transcript retains the original Markdown. The dedup function (`resolvePromptContextTextDedupeKey`) compares both surfaces without normalising Markdown formatting, so messages with `**bold**`, `` `code` ``, `_italic_`, or `~~strike~~` produce mismatched keys and appear as duplicates.

PR #100573 partially addressed this by adding `stripInlineDirectiveTagsForDelivery` to both dedup surfaces — but this only handles directive tags (e.g. `:::tip`), not standard Markdown formatting.

## Why This Change Was Made

This PR adds `stripMarkdownFormatting(text)` — which strips `*`, `_`, `` ` ``, `~` — to both dedup surfaces, layered on top of the existing directive-tag stripping:

1. **`resolvePromptContextTextDedupeKey`** (`extensions/telegram/src/bot-handlers.runtime.ts:211`) — the `visibleBody` in the dedup key is Markdown-stripped before comparison
2. **`normalizePromptContextTimestampText`** (`extensions/telegram/src/bot-message-dispatch.ts:1586`) — the timestamp-alignment comparison now strips Markdown

The timestamp-qualified key structure is unchanged — no broader text-only matching or threshold logic introduced.

## User Impact

Telegram users no longer see duplicate assistant messages in the conversation context when Markdown formatting diverges between session transcript and channel cache. Reduces prompt token waste and improves model coherence.

## Evidence

### Root-cause verification (synthetic data, real payloads redacted)

Wire-instrumented `resolvePromptContextTextDedupeKey` on a live Telegram bot:

```
session  → body="**The model recommends allocating 30% to growth stocks**"  ts=1751870400000
cache    → body="The model recommends allocating 30% to growth stocks"      ts=1751870452000
```

Before fix: keys mismatch on body (Markdown chars) → duplicate injected.
After fix: bodies match after Markdown stripping → duplicate eliminated.

### Tests

**Unit tests** — `bot-handlers.runtime.prompt-context-dedup.test.ts` (6 tests, all passing):
- Non-string / empty body → `undefined`
- Missing/invalid `timestamp_ms` → `undefined`
- Same text with `**bold**`, `_italic_`, `` `code` `` formatting → matching keys
- Different timestamps → different keys
- Short bodies still get Markdown-stripped

**Extension tests** — `pnpm test:extension telegram`: 2453/2454 pass (1 pre-existing failure unrelated to this change: `bot.test.ts > does not retry plugin-owned callback text skipped by inbound policy`)

**Contract tests** — shared surface compatibility verified:
- `pnpm test:contracts:channels`: 27/27 pass
- `pnpm test:contracts:channel-session`: 34/34 pass
- `pnpm test:contracts:plugins`: 973/973 pass

---

### AI-assisted checklist

- [x] Marked as AI-assisted in the PR title (`[AI]`)
- [x] Evidence section with validation
- [x] Session log: This PR was created through iterative debugging with OpenCode. The agent traced the dedup failure through `bot-handlers.runtime.ts` → `bot-message-dispatch.ts` → `outbound-message-context.ts` → `send.ts` → `format.ts`, identified the Markdown→HTML→strip chain, and verified the fix with unit tests, extension tests, and contract tests.
- [x] Code understanding confirmed: the fix applies a `stripMarkdownFormatting` function (regex strip of `[*_`~]`) to two comparison surfaces, matching the pattern already established by `stripInlineDirectiveTagsForDelivery` in #100573
