### PR TITLE
fix: show confirm dialog for macOS dashboard deletes

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -191,6 +191,31 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
 
     // MARK: - WKUIDelegate
 
+    /// Bridges JavaScript `window.confirm` calls in the embedded Control UI to a
+    /// native confirmation sheet; without this callback, WebKit treats every
+    /// confirm as Cancel and destructive dashboard actions silently stop.
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptConfirmPanelWithMessage message: String,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping @MainActor @Sendable (Bool) -> Void)
+    {
+        guard webView === self.webView || self.linkBrowser.owns(webView) else {
+            completionHandler(false)
+            return
+        }
+        let alert = Self.makeJavaScriptConfirmAlert(
+            message: message,
+            host: frame.request.url?.host)
+        if let window {
+            alert.beginSheetModal(for: window) { response in
+                completionHandler(Self.javaScriptConfirmResult(for: response))
+            }
+            return
+        }
+        completionHandler(Self.javaScriptConfirmResult(for: alert.runModal()))
+    }
+
     /// Bridges `<input type="file">` clicks in the embedded Control UI to a native
     /// `NSOpenPanel`; without a `WKUIDelegate`, WebKit silently drops the request
     /// and "Choose image" / file-picker buttons do nothing.
@@ -247,6 +272,26 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
             break
         }
         return nil
+    }
+
+    private static func makeJavaScriptConfirmAlert(message: String, host: String?) -> NSAlert {
+        let alert = NSAlert()
+        alert.messageText = "OpenClaw Dashboard"
+        if let host, !host.isEmpty {
+            alert.informativeText = "\(host) is asking:\n\n\(message)"
+        } else {
+            alert.informativeText = message
+        }
+        alert.addButton(withTitle: "OK")
+        alert.addButton(withTitle: "Cancel")
+        return alert
+    }
+
+    private static func javaScriptConfirmResult(
+        for response: NSApplication.ModalResponse)
+        -> Bool
+    {
+        response == .alertFirstButtonReturn
     }
 
     @available(*, unavailable)
@@ -1092,6 +1137,14 @@ extension DashboardWindowController {
     func _testFocusLinkBrowser() -> Bool {
         guard let webView = self.linkBrowser.activeWebView else { return false }
         return self.window?.makeFirstResponder(webView) == true
+    }
+
+    static func _testJavaScriptConfirmAlert(message: String, host: String?) -> NSAlert {
+        self.makeJavaScriptConfirmAlert(message: message, host: host)
+    }
+
+    static func _testJavaScriptConfirmResult(for response: NSApplication.ModalResponse) -> Bool {
+        self.javaScriptConfirmResult(for: response)
     }
 }
 #endif

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -659,6 +659,22 @@ struct DashboardWindowSmokeTests {
         #expect(controller._testAllowsBackForwardGestures)
     }
 
+    @Test func `dashboard javascript confirm alert maps actions`() {
+        let alert = DashboardWindowController._testJavaScriptConfirmAlert(
+            message: "Delete 1 session?",
+            host: "127.0.0.1")
+
+        #expect(alert.messageText == "OpenClaw Dashboard")
+        #expect(alert.informativeText.contains("127.0.0.1 is asking:"))
+        #expect(alert.informativeText.contains("Delete 1 session?"))
+        #expect(alert.buttons.map(\.title) == ["OK", "Cancel"])
+        #expect(DashboardWindowController._testJavaScriptConfirmResult(
+            for: .alertFirstButtonReturn))
+        #expect(!DashboardWindowController._testJavaScriptConfirmResult(
+            for: .alertSecondButtonReturn))
+        #expect(!DashboardWindowController._testJavaScriptConfirmResult(for: .cancel))
+    }
+
     @Test func `dashboard failure state opens in dashboard window`() throws {
         let url = try #require(URL(string: "http://127.0.0.1:18789/control/"))
         let controller = DashboardWindowController(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening the Dashboard from the macOS app could select a session and click Delete selected, but no confirmation appeared and the session stayed in place.

The Control UI already asks for confirmation with `window.confirm` before deleting selected sessions. In the embedded macOS dashboard WebView, that confirm request was not bridged to a native panel, so WebKit treated it like Cancel.

## Why This Change Was Made

The macOS dashboard now implements the WKWebView JavaScript confirm delegate and shows an `NSAlert` sheet for dashboard confirm requests. OK maps to the WebView confirm completion handler as `true`, while Cancel and dismissed alerts map to `false`.

This keeps the fix at the native dashboard boundary and does not change Control UI deletion semantics, gateway APIs, or session state behavior.

## User Impact

macOS users can delete selected sessions from the embedded Dashboard again: the native confirmation appears, confirming proceeds with the existing delete flow, and canceling still prevents the deletion.

## Evidence

- Final commit changes only `DashboardWindowController.swift` and `DashboardWindowSmokeTests.swift`, 66 insertions total.
- Live macOS Dashboard smoke: launched an ad-hoc signed isolated OpenClaw app against a local mock `/control/` dashboard page, clicked Delete selected, accepted the native OK confirm, verified the page changed to `Deleted smoke-session-99286`, and verified the mock server recorded the delete event.
- Local caveats: `swiftformat` is not installed in this environment, and the Control UI Vitest binary was unavailable under local `ui/node_modules`; no dependency install was performed for this native macOS-only patch.

## Validation

- `git diff --check HEAD~1..HEAD` - passed.
- `swift test --package-path apps/macos --filter DashboardWindowSmokeTests` - passed, 9 tests, including the new JavaScript confirm alert/result mapping coverage.
- Live macOS Dashboard smoke - passed with the native OK confirm path and recorded delete event described above.

## Risk

Low. This adds the missing native confirm delegate for the embedded macOS dashboard and keeps Cancel/dismiss mapped to `false`. The live smoke used a local mock dashboard page to exercise the WebView confirm boundary; CI should still run the repository's normal macOS and Control UI checks.

## Out of scope

- Changing Control UI session deletion behavior.
- Changing gateway APIs or session state semantics.
- Adding the requested follow-up copy-to-clipboard affordance for truncated session keys.

## Issue linkage

Closes #99286

AI-assisted contribution; I reviewed the final diff and validation evidence before opening.
