### PR TITLE
fix(llm): avoid retrying permanent provider errors

### DIFF
--- a/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
@@ -329,7 +329,10 @@ describe("handleAssistantFailover", () => {
       }
     });
 
-    it("allows short Retry-After intervals to use same-model retry", async () => {
+    it.each([
+      ["30 seconds", 30],
+      ["100 ms", 0.1],
+    ])("allows short Retry-After interval %s to use same-model retry", async (delay, seconds) => {
       const maybeRetrySameModelRateLimit = vi.fn(async () => true);
       const maybeEscalateRateLimitProfileFallback = vi.fn();
       const advanceAuthProfile = vi.fn(async () => true);
@@ -341,7 +344,7 @@ describe("handleAssistantFailover", () => {
           billingFailure: false,
           rateLimitFailure: true,
           lastAssistant: {
-            errorMessage: "429 rate_limit_exceeded; Retry-After: 30 seconds",
+            errorMessage: `429 rate_limit_exceeded; Retry-After: ${delay}`,
           } as Params["lastAssistant"],
           maybeRetrySameModelRateLimit,
           maybeEscalateRateLimitProfileFallback,
@@ -355,7 +358,7 @@ describe("handleAssistantFailover", () => {
       }
       expect(outcome.retryKind).toBe("same_model_rate_limit");
       expect(maybeRetrySameModelRateLimit).toHaveBeenCalledTimes(1);
-      expect(maybeRetrySameModelRateLimit).toHaveBeenCalledWith({ retryAfterSeconds: 30 });
+      expect(maybeRetrySameModelRateLimit).toHaveBeenCalledWith({ retryAfterSeconds: seconds });
       expect(maybeEscalateRateLimitProfileFallback).not.toHaveBeenCalled();
       expect(advanceAuthProfile).not.toHaveBeenCalled();
     });

--- a/src/agents/embedded-agent-runner/run/assistant-failover.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.ts
@@ -4,6 +4,11 @@
 import { sanitizeForLog } from "../../../../packages/terminal-core/src/ansi.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { AssistantMessage } from "../../../llm/types.js";
+import {
+  hasRetryAfterValue,
+  MAX_SHORT_WINDOW_RETRY_AFTER_SECONDS,
+  parseRetryAfterSeconds,
+} from "../../../llm/utils/retry-after.js";
 import type { AuthProfileFailureReason } from "../../auth-profiles.js";
 import {
   formatAssistantErrorText,
@@ -44,42 +49,6 @@ const SHORT_RATE_LIMIT_WINDOW_RE =
   /\b(?:requests per minute|tokens per minute|per-minute|rpm|tpm)\b/i;
 const SHORT_WINDOW_RATE_LIMIT_RE =
   /\b(?:requests per minute|tokens per minute|per-minute|rpm|tpm|model_cooldown)\b|请求过于频繁|调用频率|频率限制/i;
-const RETRY_AFTER_VALUE_RE = /\bretry[- ]after\b\s*:?\s*(?:in\s*)?([^\r\n;]+)/i;
-const RETRY_AFTER_SECONDS_RE =
-  /^(\d+(?:\.\d+)?)(?:\s*(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m))?\b/i;
-const MAX_SHORT_WINDOW_RETRY_AFTER_SECONDS = 60;
-
-function parseRetryAfterSeconds(message: string): number | null {
-  const valueText = RETRY_AFTER_VALUE_RE.exec(message)?.[1]?.trim();
-  if (!valueText) {
-    return null;
-  }
-  const secondsMatch = RETRY_AFTER_SECONDS_RE.exec(valueText);
-  if (secondsMatch?.[1]) {
-    const value = Number(secondsMatch[1]);
-    if (!Number.isFinite(value) || value < 0) {
-      return null;
-    }
-    const unit = secondsMatch[2]?.toLowerCase();
-    if (
-      unit?.startsWith("m") &&
-      unit !== "ms" &&
-      !unit.startsWith("msec") &&
-      !unit.startsWith("millisecond")
-    ) {
-      return value * 60;
-    }
-    if (unit === "ms" || unit?.startsWith("msec") || unit?.startsWith("millisecond")) {
-      return value / 1000;
-    }
-    return value;
-  }
-  const retryAtMs = Date.parse(valueText);
-  if (!Number.isFinite(retryAtMs)) {
-    return null;
-  }
-  return Math.max(0, (retryAtMs - Date.now()) / 1000);
-}
 
 function resolveShortWindowRateLimitRetry(
   message: string | undefined,
@@ -95,7 +64,7 @@ function resolveShortWindowRateLimitRetry(
   const shortRetryAfter =
     retryAfterSeconds !== null && retryAfterSeconds <= MAX_SHORT_WINDOW_RETRY_AFTER_SECONDS;
   const hasShortWindowSignal = SHORT_RATE_LIMIT_WINDOW_RE.test(raw);
-  if (RETRY_AFTER_VALUE_RE.test(raw) && retryAfterSeconds === null && !hasShortWindowSignal) {
+  if (hasRetryAfterValue(raw) && retryAfterSeconds === null && !hasShortWindowSignal) {
     return null;
   }
   if (LONG_WINDOW_RATE_LIMIT_RE.test(raw) && !hasShortWindowSignal && !shortRetryAfter) {

--- a/src/llm/utils/retry-after.ts
+++ b/src/llm/utils/retry-after.ts
@@ -1,0 +1,42 @@
+const RETRY_AFTER_VALUE_PATTERN = /\bretry[- ]after\b\s*:?\s*(?:in\s*)?([^\r\n;]+)/i;
+const RETRY_AFTER_DELAY_PATTERN =
+  /^(-?\d+(?:\.\d+)?)(?:\s*(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d))?\b/i;
+
+export const MAX_SHORT_WINDOW_RETRY_AFTER_SECONDS = 60;
+
+export function hasRetryAfterValue(message: string): boolean {
+  return RETRY_AFTER_VALUE_PATTERN.test(message);
+}
+
+export function parseRetryAfterSeconds(message: string): number | null {
+  const valueText = RETRY_AFTER_VALUE_PATTERN.exec(message)?.[1]?.trim();
+  if (!valueText) {
+    return null;
+  }
+  const delayMatch = RETRY_AFTER_DELAY_PATTERN.exec(valueText);
+  if (delayMatch?.[1]) {
+    const value = Number(delayMatch[1]);
+    if (!Number.isFinite(value) || value < 0) {
+      return null;
+    }
+    const unit = delayMatch[2]?.toLowerCase();
+    if (unit === "ms" || unit?.startsWith("msec") || unit?.startsWith("millisecond")) {
+      return value / 1000;
+    }
+    if (unit?.startsWith("h")) {
+      return value * 60 * 60;
+    }
+    if (unit?.startsWith("d")) {
+      return value * 60 * 60 * 24;
+    }
+    if (unit?.startsWith("m")) {
+      return value * 60;
+    }
+    return value;
+  }
+  const retryAtMs = Date.parse(valueText);
+  if (!Number.isFinite(retryAtMs)) {
+    return null;
+  }
+  return Math.max(0, (retryAtMs - Date.now()) / 1000);
+}

--- a/src/llm/utils/retry.test.ts
+++ b/src/llm/utils/retry.test.ts
@@ -37,6 +37,21 @@ describe("isRetryableAssistantError", () => {
     expect(isRetryableAssistantError(errorMessage("Monthly usage limit reached"))).toBe(false);
   });
 
+  it.each([
+    "model gpt-5.5-preview-0429 not found",
+    "Image dimensions 1504x1504 exceed the maximum allowed size",
+    "invalid api key sk-proj-abc502xyz",
+  ])("does not retry permanent errors with incidental status digits: %s", (text) => {
+    expect(isRetryableAssistantError(errorMessage(text))).toBe(false);
+  });
+
+  it.each([
+    "429 You exceeded your daily request limit. Please try again in 24 hours.",
+    "rate limit reached for requests. Retry after 6h.",
+  ])("does not retry long-window rate limits: %s", (text) => {
+    expect(isRetryableAssistantError(errorMessage(text))).toBe(false);
+  });
+
   it("retries transient billing-service failures", () => {
     expect(
       isRetryableAssistantError(

--- a/src/llm/utils/retry.test.ts
+++ b/src/llm/utils/retry.test.ts
@@ -69,4 +69,20 @@ describe("isRetryableAssistantError", () => {
       ),
     ).toBe(true);
   });
+
+  it.each([
+    "429 rate_limit_exceeded; Retry-After: 100 ms",
+    "429 rate_limit_exceeded; Retry-After: 60000 milliseconds",
+    "429 rate_limit_exceeded; Retry-After: 1 minute",
+  ])("retries explicit short Retry-After windows: %s", (text) => {
+    expect(isRetryableAssistantError(errorMessage(text))).toBe(true);
+  });
+
+  it.each([
+    "429 rate_limit_exceeded; Retry-After: 100",
+    "429 rate_limit_exceeded; Retry-After: 60001 ms",
+    "429 rate_limit_exceeded; Retry-After: 2 minutes",
+  ])("does not retry long Retry-After windows: %s", (text) => {
+    expect(isRetryableAssistantError(errorMessage(text))).toBe(false);
+  });
 });

--- a/src/llm/utils/retry.ts
+++ b/src/llm/utils/retry.ts
@@ -10,18 +10,58 @@ const NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN = buildProviderErrorPattern([
   "Monthly usage limit reached",
   "available balance",
   "insufficient_quota",
+  "insufficient[_ -]?quota",
+  "current quota",
+  "daily request limit",
+  "weekly request limit",
+  "monthly request limit",
+  "tokens per day",
+  "requests per day",
+  "subscription",
   "out of budget",
 ]);
+
+const PERMANENT_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
+  "model\\b.*\\bnot(?:[_\\-\\s])?found",
+  "model\\b.*\\bdoes not exist",
+  "invalid[_\\-\\s]?api[_\\-\\s]?key",
+  "\\bunauthorized\\b",
+  "authentication failed",
+  "image dimensions?.*\\bexceed",
+]);
+
+const LONG_WINDOW_RATE_LIMIT_PATTERN = buildProviderErrorPattern([
+  "daily",
+  "weekly",
+  "monthly",
+  "tokens per day",
+  "requests per day",
+  "usage limit",
+  "subscription",
+  "current quota",
+  "insufficient[_ -]?quota",
+]);
+
+const SHORT_WINDOW_RATE_LIMIT_PATTERN = buildProviderErrorPattern([
+  "requests per minute",
+  "tokens per minute",
+  "per-minute",
+  "\\brpm\\b",
+  "\\btpm\\b",
+]);
+
+const LONG_RETRY_AFTER_PATTERN =
+  /\bretry[- ]after\b\s*:?\s*(?:in\s*)?(?:(?:6[1-9]|[7-9]\d|[1-9]\d{2,})(?:\s*(?:seconds?|secs?|s))?|\d+(?:\.\d+)?\s*(?:minutes?|mins?|m|hours?|hrs?|h|days?|d))\b/i;
 
 const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
   "overloaded",
   "rate.?limit",
   "too many requests",
-  "429",
-  "500",
-  "502",
-  "503",
-  "504",
+  "\\b429\\b",
+  "\\b500\\b",
+  "\\b502\\b",
+  "\\b503\\b",
+  "\\b504\\b",
   "service.?unavailable",
   "server.?error",
   "internal.?error",
@@ -49,12 +89,26 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
   "please retry your request",
 ]);
 
+function isNonRetryableAssistantErrorText(message: string): boolean {
+  if (
+    NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN.test(message) ||
+    PERMANENT_PROVIDER_ERROR_PATTERN.test(message)
+  ) {
+    return true;
+  }
+  if (LONG_RETRY_AFTER_PATTERN.test(message)) {
+    return true;
+  }
+  const hasShortWindowSignal = SHORT_WINDOW_RATE_LIMIT_PATTERN.test(message);
+  return LONG_WINDOW_RATE_LIMIT_PATTERN.test(message) && !hasShortWindowSignal;
+}
+
 /** Classify transient provider/transport failures for outer retry policy. */
 export function isRetryableAssistantError(message: AssistantMessage): boolean {
   if (message.stopReason !== "error" || !message.errorMessage) {
     return false;
   }
-  if (NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN.test(message.errorMessage)) {
+  if (isNonRetryableAssistantErrorText(message.errorMessage)) {
     return false;
   }
   return RETRYABLE_PROVIDER_ERROR_PATTERN.test(message.errorMessage);

--- a/src/llm/utils/retry.ts
+++ b/src/llm/utils/retry.ts
@@ -50,8 +50,10 @@ const SHORT_WINDOW_RATE_LIMIT_PATTERN = buildProviderErrorPattern([
   "\\btpm\\b",
 ]);
 
-const LONG_RETRY_AFTER_PATTERN =
-  /\bretry[- ]after\b\s*:?\s*(?:in\s*)?(?:(?:6[1-9]|[7-9]\d|[1-9]\d{2,})(?:\s*(?:seconds?|secs?|s))?|\d+(?:\.\d+)?\s*(?:minutes?|mins?|m|hours?|hrs?|h|days?|d))\b/i;
+const RETRY_AFTER_VALUE_PATTERN = /\bretry[- ]after\b\s*:?\s*(?:in\s*)?([^\r\n;]+)/i;
+const RETRY_AFTER_DELAY_PATTERN =
+  /^(\d+(?:\.\d+)?)(?:\s*(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d))?\b/i;
+const MAX_SHORT_WINDOW_RETRY_AFTER_SECONDS = 60;
 
 const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
   "overloaded",
@@ -89,6 +91,39 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
   "please retry your request",
 ]);
 
+function parseRetryAfterSeconds(message: string): number | null {
+  const valueText = RETRY_AFTER_VALUE_PATTERN.exec(message)?.[1]?.trim();
+  if (!valueText) {
+    return null;
+  }
+  const delayMatch = RETRY_AFTER_DELAY_PATTERN.exec(valueText);
+  if (delayMatch?.[1]) {
+    const value = Number(delayMatch[1]);
+    if (!Number.isFinite(value) || value < 0) {
+      return null;
+    }
+    const unit = delayMatch[2]?.toLowerCase();
+    if (unit === "ms" || unit?.startsWith("msec") || unit?.startsWith("millisecond")) {
+      return value / 1000;
+    }
+    if (unit?.startsWith("h")) {
+      return value * 60 * 60;
+    }
+    if (unit?.startsWith("d")) {
+      return value * 60 * 60 * 24;
+    }
+    if (unit?.startsWith("m")) {
+      return value * 60;
+    }
+    return value;
+  }
+  const retryAtMs = Date.parse(valueText);
+  if (!Number.isFinite(retryAtMs)) {
+    return null;
+  }
+  return Math.max(0, (retryAtMs - Date.now()) / 1000);
+}
+
 function isNonRetryableAssistantErrorText(message: string): boolean {
   if (
     NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN.test(message) ||
@@ -96,7 +131,8 @@ function isNonRetryableAssistantErrorText(message: string): boolean {
   ) {
     return true;
   }
-  if (LONG_RETRY_AFTER_PATTERN.test(message)) {
+  const retryAfterSeconds = parseRetryAfterSeconds(message);
+  if (retryAfterSeconds !== null && retryAfterSeconds > MAX_SHORT_WINDOW_RETRY_AFTER_SECONDS) {
     return true;
   }
   const hasShortWindowSignal = SHORT_WINDOW_RATE_LIMIT_PATTERN.test(message);

--- a/src/llm/utils/retry.ts
+++ b/src/llm/utils/retry.ts
@@ -1,4 +1,5 @@
 import type { AssistantMessage } from "../types.js";
+import { MAX_SHORT_WINDOW_RETRY_AFTER_SECONDS, parseRetryAfterSeconds } from "./retry-after.js";
 
 function buildProviderErrorPattern(patterns: readonly string[]): RegExp {
   return new RegExp(patterns.join("|"), "i");
@@ -50,11 +51,6 @@ const SHORT_WINDOW_RATE_LIMIT_PATTERN = buildProviderErrorPattern([
   "\\btpm\\b",
 ]);
 
-const RETRY_AFTER_VALUE_PATTERN = /\bretry[- ]after\b\s*:?\s*(?:in\s*)?([^\r\n;]+)/i;
-const RETRY_AFTER_DELAY_PATTERN =
-  /^(\d+(?:\.\d+)?)(?:\s*(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d))?\b/i;
-const MAX_SHORT_WINDOW_RETRY_AFTER_SECONDS = 60;
-
 const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
   "overloaded",
   "rate.?limit",
@@ -90,39 +86,6 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
   "try your request again",
   "please retry your request",
 ]);
-
-function parseRetryAfterSeconds(message: string): number | null {
-  const valueText = RETRY_AFTER_VALUE_PATTERN.exec(message)?.[1]?.trim();
-  if (!valueText) {
-    return null;
-  }
-  const delayMatch = RETRY_AFTER_DELAY_PATTERN.exec(valueText);
-  if (delayMatch?.[1]) {
-    const value = Number(delayMatch[1]);
-    if (!Number.isFinite(value) || value < 0) {
-      return null;
-    }
-    const unit = delayMatch[2]?.toLowerCase();
-    if (unit === "ms" || unit?.startsWith("msec") || unit?.startsWith("millisecond")) {
-      return value / 1000;
-    }
-    if (unit?.startsWith("h")) {
-      return value * 60 * 60;
-    }
-    if (unit?.startsWith("d")) {
-      return value * 60 * 60 * 24;
-    }
-    if (unit?.startsWith("m")) {
-      return value * 60;
-    }
-    return value;
-  }
-  const retryAtMs = Date.parse(valueText);
-  if (!Number.isFinite(retryAtMs)) {
-    return null;
-  }
-  return Math.max(0, (retryAtMs - Date.now()) / 1000);
-}
 
 function isNonRetryableAssistantErrorText(message: string): boolean {
   if (


### PR DESCRIPTION
Closes #102250

## What Problem This Solves

Fixes an issue where users hitting permanent provider errors could have the session auto-retry path resend the same full context up to three more times when the error text happened to contain retry-looking status digits, such as model ids ending in `0429`, image dimensions like `1504x1504`, or API keys containing `502`.

## Why This Change Was Made

The retry classifier now treats HTTP retry status codes as standalone tokens, filters known permanent provider failures before retry matching, and parses `Retry-After` values with units before classifying a rate-limit window as too long for session auto-retry. Long-window quota/reset errors stay out of the retry loop, while short-window RPM/TPM throttles and explicit millisecond/second retry windows continue to retry.

The `Retry-After` parser and short-window ceiling are shared by the session retry classifier and the embedded assistant failover rate-limit path, so the two retry surfaces no longer carry mirrored parsing policy.

AI-assisted implementation.

## User Impact

Permanent model-not-found, image-dimension, invalid-key, and long-window quota failures fail promptly instead of spending extra retry attempts and re-sending large context that cannot succeed. Short provider retry windows, including explicit millisecond `Retry-After` values, still get the normal session retry behavior.

## Evidence

- Current head: `432f178f66` (`refactor(llm): share retry-after parsing`).
- Focused retry + sibling failover proof: `node scripts/run-vitest.mjs src/llm/utils/retry.test.ts src/agents/embedded-agent-runner/run/assistant-failover.test.ts -- --reporter=verbose` passed: 2 shards, 44 tests.
- Shared-parser coverage: the focused proof includes short/long `Retry-After` windows for `isRetryableAssistantError`, assistant failover date-window rejection, and assistant failover same-model retry for both `30 seconds` and `100 ms`.
- Whitespace proof: `git diff --check` and `git diff --cached --check` passed.
- Structured review: bundled Python `.agents/skills/autoreview/scripts/autoreview --mode local` passed clean with no accepted/actionable findings.
- Redacted session retry-surface proof ran against `AgentSession`'s `isRetryableError` path with no provider credentials or secrets:

```text
{"name":"permanent model-not-found with incidental 0429","retryable":false,"expectedRetry":false,"pass":true}
{"name":"permanent auth failure with incidental 502","retryable":false,"expectedRetry":false,"pass":true}
{"name":"short provider retry window in milliseconds","retryable":true,"expectedRetry":true,"pass":true}
{"name":"long provider retry window in bare seconds","retryable":false,"expectedRetry":false,"pass":true}
```
