### PR TITLE
feat: add TokenLab provider

### DIFF
--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -177,7 +177,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Official external packages
 
-70 plugins
+71 plugins
 
 - **[acpx](/plugins/reference/acpx)** (`@openclaw/acpx`) - npm; ClawHub. OpenClaw ACP runtime backend with plugin-owned session and transport management.
 
@@ -302,6 +302,8 @@ Each entry lists the package, distribution route, and description.
 - **[tlon](/plugins/reference/tlon)** (`@openclaw/tlon`) - npm; ClawHub. OpenClaw Tlon/Urbit channel plugin for chat workflows.
 
 - **[tokenjuice](/plugins/reference/tokenjuice)** (`@openclaw/tokenjuice`) - npm; ClawHub: `clawhub:@openclaw/tokenjuice`. Compacts exec and bash tool results with tokenjuice reducers.
+
+- **[tokenlab](/plugins/reference/tokenlab)** (`@openclaw/tokenlab-provider`) - npm; ClawHub: `clawhub:@openclaw/tokenlab-provider`. OpenClaw TokenLab provider plugin.
 
 - **[twitch](/plugins/reference/twitch)** (`@openclaw/twitch`) - npm; ClawHub. OpenClaw Twitch channel plugin for chat and moderation workflows.
 

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -15,5 +15,5 @@ This page is generated from `extensions/*/package.json` and
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 133
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 134
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference/imessage.md
+++ b/docs/plugins/reference/imessage.md
@@ -16,7 +16,7 @@ Adds the iMessage channel surface for sending and receiving OpenClaw messages.
 
 ## Surface
 
-channels: imessage
+channels: imessage; skills
 
 ## Related docs
 

--- a/docs/plugins/reference/tokenlab.md
+++ b/docs/plugins/reference/tokenlab.md
@@ -1,0 +1,23 @@
+---
+summary: "OpenClaw TokenLab provider plugin."
+read_when:
+  - You are installing, configuring, or auditing the tokenlab plugin
+title: "Tokenlab plugin"
+---
+
+# Tokenlab plugin
+
+OpenClaw TokenLab provider plugin.
+
+## Distribution
+
+- Package: `@openclaw/tokenlab-provider`
+- Install route: npm; ClawHub: `clawhub:@openclaw/tokenlab-provider`
+
+## Surface
+
+providers: tokenlab
+
+## Related docs
+
+- [tokenlab](/providers/tokenlab)

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -75,6 +75,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [StepFun](/providers/stepfun)
 - [Synthetic](/providers/synthetic)
 - [Tencent Cloud (TokenHub / TokenPlan)](/providers/tencent)
+- [TokenLab](/providers/tokenlab)
 - [Together AI](/providers/together)
 - [Venice (Venice AI, privacy-focused)](/providers/venice)
 - [Vercel AI Gateway](/providers/vercel-ai-gateway)

--- a/docs/providers/models.md
+++ b/docs/providers/models.md
@@ -44,6 +44,7 @@ Pick a provider, authenticate, then set the default model as `provider/model`.
 - [Runway](/providers/runway)
 - [StepFun](/providers/stepfun)
 - [Synthetic](/providers/synthetic)
+- [TokenLab](/providers/tokenlab)
 - [Venice (Venice AI)](/providers/venice)
 - [Vercel AI Gateway](/providers/vercel-ai-gateway)
 - [xAI](/providers/xai)

--- a/docs/providers/tokenlab.md
+++ b/docs/providers/tokenlab.md
@@ -1,0 +1,137 @@
+---
+summary: "TokenLab setup (auth + model selection)"
+title: "TokenLab"
+read_when:
+  - You want to use TokenLab with OpenClaw
+  - You need the API key env var or CLI auth choice
+---
+
+[TokenLab](https://tokenlab.sh) provides a multi-provider AI API with
+OpenAI-compatible chat and native endpoint formats.
+
+| Property | Value                        |
+| -------- | ---------------------------- |
+| Provider | `tokenlab`                   |
+| Auth     | `TOKENLAB_API_KEY`           |
+| API      | OpenAI-compatible            |
+| Base URL | `https://api.tokenlab.sh/v1` |
+
+## Install plugin
+
+Install the official plugin, then restart Gateway:
+
+```bash
+openclaw plugins install @openclaw/tokenlab-provider
+openclaw gateway restart
+```
+
+## Getting started
+
+<Steps>
+  <Step title="Get your API key">
+    Create an API key in TokenLab at [tokenlab.sh](https://tokenlab.sh).
+  </Step>
+  <Step title="Run onboarding">
+    ```bash
+    openclaw onboard --auth-choice tokenlab-api-key
+    ```
+
+    Prompts for your API key and sets `tokenlab/gpt-5.5` as the default model.
+
+  </Step>
+  <Step title="Verify models are available">
+    ```bash
+    openclaw models list --provider tokenlab
+    ```
+
+    To inspect the plugin's static catalog without a running Gateway:
+
+    ```bash
+    openclaw models list --all --provider tokenlab
+    ```
+
+  </Step>
+</Steps>
+
+<AccordionGroup>
+  <Accordion title="Non-interactive setup">
+    For scripted or headless installations, pass all flags directly:
+
+    ```bash
+    openclaw onboard --non-interactive \
+      --mode local \
+      --auth-choice tokenlab-api-key \
+      --tokenlab-api-key "$TOKENLAB_API_KEY" \
+      --skip-health \
+      --accept-risk
+    ```
+
+  </Accordion>
+</AccordionGroup>
+
+<Warning>
+If Gateway runs as a daemon (launchd/systemd), make sure `TOKENLAB_API_KEY` is
+available to that process (for example, in `~/.openclaw/.env` or via
+`env.shellEnv`).
+</Warning>
+
+## Endpoint formats
+
+OpenClaw executes TokenLab models through the OpenAI-compatible chat route at
+`https://api.tokenlab.sh/v1`.
+
+TokenLab also exposes native endpoint formats for clients that support them:
+
+- OpenAI Responses: `https://api.tokenlab.sh/v1/responses`
+- Anthropic Messages: `https://api.tokenlab.sh` as the Anthropic SDK base URL
+- Gemini generateContent: `https://api.tokenlab.sh/v1beta/models/{model}:generateContent`
+
+Use these native formats outside OpenClaw when you need provider-specific
+behavior such as Claude extended thinking or Gemini-native request bodies.
+
+## Built-in catalog
+
+| Model ref                           | Name                     | Input       | Context   | Max output | Notes                     |
+| ----------------------------------- | ------------------------ | ----------- | --------- | ---------- | ------------------------- |
+| `tokenlab/gpt-5.5`                  | GPT-5.5                  | text, image | 1,000,000 | 128,000    | Default model; reasoning  |
+| `tokenlab/gpt-5.5-pro`              | GPT-5.5 Pro              | text, image | 1,050,000 | 128,000    | Stronger GPT path         |
+| `tokenlab/gpt-5.4`                  | GPT-5.4                  | text, image | 400,000   | 128,000    | Reasoning                 |
+| `tokenlab/gpt-5.4-mini`             | GPT-5.4 Mini             | text, image | 400,000   | 128,000    | Lower-cost GPT path       |
+| `tokenlab/claude-sonnet-5`          | Claude Sonnet 5          | text, image | 1,000,000 | 128,000    | Claude family default     |
+| `tokenlab/claude-opus-4-8`          | Claude Opus 4.8          | text, image | 1,000,000 | 128,000    | Strong Claude path        |
+| `tokenlab/claude-fable-5`           | Claude Fable 5           | text, image | 1,000,000 | 128,000    | Creative Claude path      |
+| `tokenlab/gemini-3.5-flash`         | Gemini 3.5 Flash         | text, image | 1,048,576 | 65,536     | Gemini flash path         |
+| `tokenlab/gemini-3.1-flash-lite`    | Gemini 3.1 Flash Lite    | text, image | 1,048,576 | 65,536     | Low-cost Gemini path      |
+| `tokenlab/grok-4.3`                 | Grok 4.3                 | text, image | 1,000,000 | 131,072    | Reasoning                 |
+| `tokenlab/grok-4-fast`              | Grok 4 Fast              | text, image | 2,000,000 | 16,384     | Fast Grok path            |
+| `tokenlab/deepseek-v4-pro`          | DeepSeek V4 Pro          | text        | 1,000,000 | 384,000    | DeepSeek pro path         |
+| `tokenlab/deepseek-v4-flash`        | DeepSeek V4 Flash        | text        | 1,000,000 | 384,000    | DeepSeek fast path        |
+| `tokenlab/glm-5.2`                  | GLM-5.2                  | text        | 1,000,000 | 128,000    | Tools disabled in catalog |
+| `tokenlab/qwen3.7-max`              | Qwen3.7 Max              | text        | 991,808   | 65,536     | Tools disabled in catalog |
+| `tokenlab/kimi-k2.7-code`           | Kimi K2.7 Code           | text, image | 262,144   | 131,072    | Coding model              |
+| `tokenlab/kimi-k2.7-code-highspeed` | Kimi K2.7 Code Highspeed | text, image | 262,144   | 131,072    | Faster Kimi coding path   |
+| `tokenlab/minimax-m3`               | MiniMax M3               | text        | 1,048,576 | 524,288    | Long-context path         |
+
+## Config example
+
+```json5
+{
+  env: { TOKENLAB_API_KEY: "sk-..." },
+  agents: {
+    defaults: {
+      model: { primary: "tokenlab/gpt-5.5" },
+    },
+  },
+}
+```
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Model selection" href="/concepts/model-providers" icon="layers">
+    Choosing providers, model refs, and failover behavior.
+  </Card>
+  <Card title="Configuration reference" href="/gateway/configuration-reference" icon="gear">
+    Full config reference for agents, models, and providers.
+  </Card>
+</CardGroup>

--- a/extensions/tokenlab/README.md
+++ b/extensions/tokenlab/README.md
@@ -1,0 +1,17 @@
+# OpenClaw TokenLab Provider
+
+Official OpenClaw provider plugin for TokenLab through its OpenAI-compatible API.
+
+Install from OpenClaw:
+
+```bash
+openclaw plugins install @openclaw/tokenlab-provider
+openclaw gateway restart
+```
+
+Configure a TokenLab API key, then select models with refs such as
+`tokenlab/gpt-5.5`, `tokenlab/claude-sonnet-5`, or `tokenlab/gemini-3.5-flash`.
+
+TokenLab also exposes native Responses, Anthropic Messages, and Gemini
+generateContent formats. This plugin uses the OpenAI-compatible chat route for
+OpenClaw model execution.

--- a/extensions/tokenlab/api.ts
+++ b/extensions/tokenlab/api.ts
@@ -1,0 +1,9 @@
+// TokenLab API module exposes the plugin public contract.
+export {
+  buildTokenLabModelDefinition,
+  TOKENLAB_BASE_URL,
+  TOKENLAB_DEFAULT_MODEL_REF,
+  TOKENLAB_MODEL_CATALOG,
+} from "./models.js";
+export { buildTokenLabProvider } from "./provider-catalog.js";
+export { applyTokenLabConfig } from "./onboard.js";

--- a/extensions/tokenlab/index.test.ts
+++ b/extensions/tokenlab/index.test.ts
@@ -1,0 +1,46 @@
+// TokenLab tests cover index plugin behavior.
+import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { describe, expect, it } from "vitest";
+import plugin from "./index.js";
+
+function requireCatalogProvider(
+  result:
+    | {
+        provider: {
+          baseUrl?: string;
+          models?: Array<{ id: string; compat?: { supportsTools?: boolean } }>;
+        };
+      }
+    | { providers: Record<string, unknown> }
+    | null
+    | undefined,
+): { baseUrl?: string; models?: Array<{ id: string; compat?: { supportsTools?: boolean } }> } {
+  if (!result || !("provider" in result)) {
+    throw new Error("single provider catalog result missing");
+  }
+  return result.provider;
+}
+
+describe("tokenlab provider plugin", () => {
+  it("registers TokenLab as an OpenAI-compatible provider", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    expect(provider.id).toBe("tokenlab");
+    expect(provider.label).toBe("TokenLab");
+    expect(provider.envVars).toEqual(["TOKENLAB_API_KEY"]);
+    expect(provider.auth?.map((method) => method.id)).toEqual(["api-key"]);
+
+    const result = await provider.staticCatalog?.run({
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({}),
+    } as never);
+    const catalogProvider = requireCatalogProvider(result);
+    expect(catalogProvider.baseUrl).toBe("https://api.tokenlab.sh/v1");
+    expect(catalogProvider.models?.map((model) => model.id)).toContain("gpt-5.5");
+    expect(catalogProvider.models?.map((model) => model.id)).toContain("qwen3.7-max");
+    expect(
+      catalogProvider.models?.find((model) => model.id === "qwen3.7-max")?.compat?.supportsTools,
+    ).toBe(false);
+  });
+});

--- a/extensions/tokenlab/index.ts
+++ b/extensions/tokenlab/index.ts
@@ -1,0 +1,62 @@
+// TokenLab plugin entrypoint registers its OpenClaw integration.
+import { readConfiguredProviderCatalogEntries } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
+import { buildProviderToolCompatFamilyHooks } from "openclaw/plugin-sdk/provider-tools";
+import { TOKENLAB_DEFAULT_MODEL_REF } from "./models.js";
+import { applyTokenLabConfig } from "./onboard.js";
+import { buildTokenLabProvider } from "./provider-catalog.js";
+
+const PROVIDER_ID = "tokenlab";
+
+export default defineSingleProviderPluginEntry({
+  id: PROVIDER_ID,
+  name: "TokenLab Provider",
+  description: "Bundled TokenLab provider plugin",
+  provider: {
+    label: "TokenLab",
+    docsPath: "/providers/tokenlab",
+    envVars: ["TOKENLAB_API_KEY"],
+    auth: [
+      {
+        methodId: "api-key",
+        label: "TokenLab API key",
+        hint: "OpenAI-compatible chat plus native Responses, Anthropic Messages, and Gemini formats",
+        optionKey: "tokenlabApiKey",
+        flagName: "--tokenlab-api-key",
+        envVar: "TOKENLAB_API_KEY",
+        promptMessage: "Enter TokenLab API key",
+        defaultModel: TOKENLAB_DEFAULT_MODEL_REF,
+        applyConfig: (cfg) => applyTokenLabConfig(cfg),
+        noteTitle: "TokenLab",
+        noteMessage: [
+          "Manage API keys at https://tokenlab.sh",
+          "OpenClaw uses TokenLab's OpenAI-compatible chat route.",
+          "TokenLab also exposes native /v1/responses, Anthropic Messages, and Gemini generateContent formats for clients that support them.",
+        ].join("\n"),
+        wizard: {
+          choiceId: "tokenlab-api-key",
+          choiceLabel: "TokenLab API key",
+          groupId: PROVIDER_ID,
+          groupLabel: "TokenLab",
+          groupHint: "Multi-provider AI gateway",
+        },
+      },
+    ],
+    catalog: {
+      buildProvider: buildTokenLabProvider,
+      buildStaticProvider: buildTokenLabProvider,
+      allowExplicitBaseUrl: true,
+    },
+    augmentModelCatalog: ({ config }) =>
+      readConfiguredProviderCatalogEntries({
+        config,
+        providerId: PROVIDER_ID,
+      }),
+    ...buildProviderReplayFamilyHooks({
+      family: "openai-compatible",
+      dropReasoningFromHistory: false,
+    }),
+    ...buildProviderToolCompatFamilyHooks("openai"),
+  },
+});

--- a/extensions/tokenlab/models.ts
+++ b/extensions/tokenlab/models.ts
@@ -1,0 +1,22 @@
+// TokenLab plugin module implements models behavior.
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+
+const TOKENLAB_MANIFEST_PROVIDER = buildManifestModelProviderConfig({
+  providerId: "tokenlab",
+  catalog: manifest.modelCatalog.providers.tokenlab,
+});
+
+export const TOKENLAB_BASE_URL = TOKENLAB_MANIFEST_PROVIDER.baseUrl;
+export const TOKENLAB_MODEL_CATALOG: ModelDefinitionConfig[] = TOKENLAB_MANIFEST_PROVIDER.models;
+export const TOKENLAB_DEFAULT_MODEL_REF = "tokenlab/gpt-5.5";
+
+export function buildTokenLabModelDefinition(model: ModelDefinitionConfig): ModelDefinitionConfig {
+  return {
+    ...model,
+    api: "openai-completions",
+    input: [...model.input],
+    cost: { ...model.cost },
+  };
+}

--- a/extensions/tokenlab/npm-shrinkwrap.json
+++ b/extensions/tokenlab/npm-shrinkwrap.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/tokenlab-provider",
+  "version": "2026.6.11",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@openclaw/tokenlab-provider",
+      "version": "2026.6.11"
+    }
+  }
+}

--- a/extensions/tokenlab/onboard.ts
+++ b/extensions/tokenlab/onboard.ts
@@ -1,0 +1,35 @@
+// TokenLab setup module handles plugin onboarding behavior.
+import {
+  applyAgentDefaultModelPrimary,
+  applyProviderConfigWithModelCatalog,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import {
+  buildTokenLabModelDefinition,
+  TOKENLAB_BASE_URL,
+  TOKENLAB_DEFAULT_MODEL_REF,
+  TOKENLAB_MODEL_CATALOG,
+} from "./models.js";
+
+function applyTokenLabProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  const models = { ...cfg.agents?.defaults?.models };
+  models[TOKENLAB_DEFAULT_MODEL_REF] = {
+    ...models[TOKENLAB_DEFAULT_MODEL_REF],
+    alias: models[TOKENLAB_DEFAULT_MODEL_REF]?.alias ?? "TokenLab",
+  };
+
+  return applyProviderConfigWithModelCatalog(cfg, {
+    agentModels: models,
+    providerId: "tokenlab",
+    api: "openai-completions",
+    baseUrl: TOKENLAB_BASE_URL,
+    catalogModels: TOKENLAB_MODEL_CATALOG.map(buildTokenLabModelDefinition),
+  });
+}
+
+export function applyTokenLabConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return applyAgentDefaultModelPrimary(
+    applyTokenLabProviderConfig(cfg),
+    TOKENLAB_DEFAULT_MODEL_REF,
+  );
+}

--- a/extensions/tokenlab/openclaw.plugin.json
+++ b/extensions/tokenlab/openclaw.plugin.json
@@ -1,0 +1,314 @@
+{
+  "id": "tokenlab",
+  "name": "TokenLab",
+  "description": "OpenClaw TokenLab provider plugin.",
+  "activation": {
+    "onStartup": false
+  },
+  "enabledByDefault": true,
+  "providers": ["tokenlab"],
+  "providerEndpoints": [
+    {
+      "endpointClass": "tokenlab-native",
+      "hosts": ["api.tokenlab.sh"]
+    }
+  ],
+  "providerRequest": {
+    "providers": {
+      "tokenlab": {
+        "family": "tokenlab"
+      }
+    }
+  },
+  "setup": {
+    "providers": [
+      {
+        "id": "tokenlab",
+        "envVars": ["TOKENLAB_API_KEY"]
+      }
+    ]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "tokenlab",
+      "method": "api-key",
+      "choiceId": "tokenlab-api-key",
+      "appGuidedSecret": true,
+      "choiceLabel": "TokenLab API key",
+      "choiceHint": "OpenAI-compatible chat plus native Responses, Anthropic Messages, and Gemini formats",
+      "groupId": "tokenlab",
+      "groupLabel": "TokenLab",
+      "groupHint": "Multi-provider AI gateway",
+      "optionKey": "tokenlabApiKey",
+      "cliFlag": "--tokenlab-api-key",
+      "cliOption": "--tokenlab-api-key <key>",
+      "cliDescription": "TokenLab API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  },
+  "modelCatalog": {
+    "providers": {
+      "tokenlab": {
+        "baseUrl": "https://api.tokenlab.sh/v1",
+        "api": "openai-completions",
+        "models": [
+          {
+            "id": "gpt-5.5",
+            "name": "GPT-5.5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 1.5,
+              "output": 9,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "gpt-5.5-pro",
+            "name": "GPT-5.5 Pro",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1050000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 30,
+              "output": 180,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "gpt-5.4",
+            "name": "GPT-5.4",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 400000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 0.75,
+              "output": 4.5,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "gpt-5.4-mini",
+            "name": "GPT-5.4 Mini",
+            "input": ["text", "image"],
+            "contextWindow": 400000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 0.225,
+              "output": 1.35,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "claude-sonnet-5",
+            "name": "Claude Sonnet 5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 1.3,
+              "output": 6.5,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "claude-opus-4-8",
+            "name": "Claude Opus 4.8",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 3.25,
+              "output": 16.25,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "claude-fable-5",
+            "name": "Claude Fable 5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 6.5,
+              "output": 32.5,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "gemini-3.5-flash",
+            "name": "Gemini 3.5 Flash",
+            "input": ["text", "image"],
+            "contextWindow": 1048576,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.75,
+              "output": 4.5,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "gemini-3.1-flash-lite",
+            "name": "Gemini 3.1 Flash Lite",
+            "input": ["text", "image"],
+            "contextWindow": 1048576,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.125,
+              "output": 0.75,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "grok-4.3",
+            "name": "Grok 4.3",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 131072,
+            "cost": {
+              "input": 1.25,
+              "output": 2.5,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "grok-4-fast",
+            "name": "Grok 4 Fast",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 2000000,
+            "maxTokens": 16384,
+            "cost": {
+              "input": 0.2,
+              "output": 0.5,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "deepseek-v4-pro",
+            "name": "DeepSeek V4 Pro",
+            "input": ["text"],
+            "contextWindow": 1000000,
+            "maxTokens": 384000,
+            "cost": {
+              "input": 0.44117647,
+              "output": 0.88235294,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "deepseek-v4-flash",
+            "name": "DeepSeek V4 Flash",
+            "input": ["text"],
+            "contextWindow": 1000000,
+            "maxTokens": 384000,
+            "cost": {
+              "input": 0.14705882,
+              "output": 0.29411765,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "glm-5.2",
+            "name": "GLM-5.2",
+            "input": ["text"],
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 1.17647059,
+              "output": 4.11764706,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsTools": false
+            }
+          },
+          {
+            "id": "qwen3.7-max",
+            "name": "Qwen3.7 Max",
+            "input": ["text"],
+            "contextWindow": 991808,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 1.76470588,
+              "output": 5.29411764,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsTools": false
+            }
+          },
+          {
+            "id": "kimi-k2.7-code",
+            "name": "Kimi K2.7 Code",
+            "input": ["text", "image"],
+            "contextWindow": 262144,
+            "maxTokens": 131072,
+            "cost": {
+              "input": 0.95,
+              "output": 4,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "kimi-k2.7-code-highspeed",
+            "name": "Kimi K2.7 Code Highspeed",
+            "input": ["text", "image"],
+            "contextWindow": 262144,
+            "maxTokens": 131072,
+            "cost": {
+              "input": 1.9,
+              "output": 8,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "minimax-m3",
+            "name": "MiniMax M3",
+            "input": ["text"],
+            "contextWindow": 1048576,
+            "maxTokens": 524288,
+            "cost": {
+              "input": 0.3,
+              "output": 1.2,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          }
+        ]
+      }
+    },
+    "discovery": {
+      "tokenlab": "static"
+    }
+  }
+}

--- a/extensions/tokenlab/package.json
+++ b/extensions/tokenlab/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@openclaw/tokenlab-provider",
+  "version": "2026.6.11",
+  "description": "OpenClaw TokenLab provider plugin.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/openclaw"
+  },
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "install": {
+      "clawhubSpec": "clawhub:@openclaw/tokenlab-provider",
+      "npmSpec": "@openclaw/tokenlab-provider",
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.6.8"
+    },
+    "compat": {
+      "pluginApi": ">=2026.6.11"
+    },
+    "build": {
+      "openclawVersion": "2026.6.11",
+      "bundledDist": false
+    },
+    "release": {
+      "publishToClawHub": true,
+      "publishToNpm": true
+    }
+  }
+}

--- a/extensions/tokenlab/provider-catalog.ts
+++ b/extensions/tokenlab/provider-catalog.ts
@@ -1,0 +1,15 @@
+// TokenLab provider module implements model/runtime integration.
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  buildTokenLabModelDefinition,
+  TOKENLAB_BASE_URL,
+  TOKENLAB_MODEL_CATALOG,
+} from "./models.js";
+
+export function buildTokenLabProvider(): ModelProviderConfig {
+  return {
+    baseUrl: TOKENLAB_BASE_URL,
+    api: "openai-completions",
+    models: TOKENLAB_MODEL_CATALOG.map(buildTokenLabModelDefinition),
+  };
+}

--- a/extensions/tokenlab/provider-discovery.ts
+++ b/extensions/tokenlab/provider-discovery.ts
@@ -1,0 +1,18 @@
+// TokenLab provider module implements model/runtime integration.
+import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
+import { buildTokenLabProvider } from "./provider-catalog.js";
+
+const tokenLabProviderDiscovery: ProviderPlugin = {
+  id: "tokenlab",
+  label: "TokenLab",
+  docsPath: "/providers/tokenlab",
+  auth: [],
+  staticCatalog: {
+    order: "simple",
+    run: async () => ({
+      provider: buildTokenLabProvider(),
+    }),
+  },
+};
+
+export default tokenLabProviderDiscovery;

--- a/extensions/tokenlab/tsconfig.json
+++ b/extensions/tokenlab/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "!dist/extensions/synology-chat/**",
     "!dist/extensions/tavily/**",
     "!dist/extensions/tencent/**",
+    "!dist/extensions/tokenlab/**",
     "!dist/extensions/tokenjuice/**",
     "!dist/extensions/tlon/**",
     "!dist/extensions/twitch/**",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1652,6 +1652,12 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/tokenlab:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/tts-local-cli:
     devDependencies:
       '@openclaw/plugin-sdk':


### PR DESCRIPTION
## Summary
- add TokenLab as an OpenClaw provider plugin with a curated frontier model catalog
- document setup with `TOKENLAB_API_KEY` and default OpenAI-compatible `/v1` chat usage
- call out TokenLab native endpoints for clients that support Responses, Anthropic Messages, and Gemini `generateContent`
- regenerate the plugin inventory/reference docs

## Validation
- `pnpm plugins:inventory:gen`
- `pnpm plugins:inventory:check`
- `pnpm test:extensions:package-boundary:compile -- extensions/tokenlab`
- `pnpm test:extension tokenlab`
- `pnpm exec oxfmt --check extensions/tokenlab docs/providers/tokenlab.md docs/providers/index.md docs/providers/models.md docs/plugins/plugin-inventory.md docs/plugins/reference.md docs/plugins/reference/tokenlab.md docs/plugins/reference/imessage.md package.json`
- `git diff --check`