### PR TITLE
fix(agent-core): stop canceled parallel tools from starting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Parallel tool cancellation:** prevent prepared tool calls from starting after a later parallel preflight aborts the run, avoiding tool side effects after cancellation. (#102276) Thanks @harjothkhara.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.
 - **OAuth refresh contention diagnostics:** keep local lock paths out of user-facing refresh failures and avoid duplicate failure prefixes while preserving structured provider and profile classification. (#83383) Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Parallel tool cancellation:** prevent prepared tool calls from starting after a later parallel preflight aborts the run, avoiding tool side effects after cancellation. (#102276) Thanks @harjothkhara.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.
 - **OAuth refresh contention diagnostics:** keep local lock paths out of user-facing refresh failures and avoid duplicate failure prefixes while preserving structured provider and profile classification. (#83383) Thanks @vincentkoc.

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -1183,6 +1183,83 @@ describe("agentLoop tool termination", () => {
     expect(events.at(-1)).toMatchObject({ type: "agent_end" });
   });
 
+  it("does not start prepared parallel tools after the run aborts mid-batch", async () => {
+    const controller = new AbortController();
+    const executed: string[] = [];
+    const afterToolCall = vi.fn(async () => undefined);
+    const streamFn: StreamFn = () => {
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        stream.push({
+          type: "done",
+          reason: "toolUse",
+          message: makeAssistantMessage([
+            { type: "toolCall", id: "call-paid", name: "paid", arguments: {} },
+            { type: "toolCall", id: "call-gated", name: "gated", arguments: {} },
+          ]),
+        });
+        stream.end();
+      });
+      return stream;
+    };
+    const events: AgentEvent[] = [];
+
+    await runAgentLoop(
+      [{ role: "user", content: "abort during parallel tool preparation", timestamp: 1 }],
+      {
+        systemPrompt: "",
+        messages: [],
+        tools: [makeTool("paid", executed), makeTool("gated", executed)],
+      },
+      {
+        ...config,
+        toolExecution: "parallel",
+        beforeToolCall: async ({ toolCall }) => {
+          if (toolCall.name === "gated") {
+            await Promise.resolve();
+            controller.abort(new Error("user aborted"));
+          }
+          return undefined;
+        },
+        afterToolCall,
+      },
+      (event) => {
+        events.push(event);
+      },
+      controller.signal,
+      streamFn,
+    );
+
+    const endEvents = events.filter(
+      (event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+        event.type === "tool_execution_end",
+    );
+
+    expect(executed).toEqual([]);
+    expect(afterToolCall).not.toHaveBeenCalled();
+    expect(endEvents).toHaveLength(2);
+    expect(endEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          toolName: "paid",
+          isError: true,
+          executionStarted: false,
+          result: expect.objectContaining({
+            content: [{ type: "text", text: "Operation aborted" }],
+          }),
+        }),
+        expect.objectContaining({
+          toolName: "gated",
+          isError: true,
+          executionStarted: false,
+          result: expect.objectContaining({
+            content: [{ type: "text", text: "Operation aborted" }],
+          }),
+        }),
+      ]),
+    );
+  });
+
   it("does not request another model turn when an async turn hook aborts the run", async () => {
     const controller = new AbortController();
     let streamCalls = 0;

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -793,6 +793,7 @@ type ImmediateToolCallOutcome = {
 type ExecutedToolCallOutcome = {
   result: AgentToolResult<unknown>;
   isError: boolean;
+  executionStarted: boolean;
 };
 
 type FinalizedToolCallOutcome = {
@@ -985,6 +986,14 @@ async function executePreparedToolCall(
   signal: AbortSignal | undefined,
   emit: AgentEventSink,
 ): Promise<ExecutedToolCallOutcome> {
+  if (signal?.aborted) {
+    return {
+      result: createErrorToolResult("Operation aborted"),
+      isError: true,
+      executionStarted: false,
+    };
+  }
+
   const updateEvents: Promise<void>[] = [];
   let acceptingUpdates = true;
 
@@ -1015,13 +1024,14 @@ async function executePreparedToolCall(
     );
     acceptingUpdates = false;
     await Promise.all(updateEvents);
-    return { result, isError: false };
+    return { result, isError: false, executionStarted: true };
   } catch (error) {
     acceptingUpdates = false;
     await Promise.all(updateEvents);
     return {
       result: createErrorToolResult(error instanceof Error ? error.message : String(error)),
       isError: true,
+      executionStarted: true,
     };
   } finally {
     acceptingUpdates = false;
@@ -1039,7 +1049,7 @@ async function finalizeExecutedToolCall(
   let result = executed.result;
   let isError = executed.isError;
 
-  if (config.afterToolCall) {
+  if (executed.executionStarted && config.afterToolCall) {
     try {
       const afterResult = await config.afterToolCall(
         {
@@ -1070,7 +1080,7 @@ async function finalizeExecutedToolCall(
     toolCall: prepared.toolCall,
     result,
     isError,
-    executionStarted: true,
+    executionStarted: executed.executionStarted,
     ...(prepared.tool.hideFromChannelProgress === true ? { hideFromChannelProgress: true } : {}),
   };
 }

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -986,6 +986,8 @@ async function executePreparedToolCall(
   signal: AbortSignal | undefined,
   emit: AgentEventSink,
 ): Promise<ExecutedToolCallOutcome> {
+  // Parallel batches prepare every call first. A later preflight abort must not
+  // let an earlier prepared, side-effectful tool start afterward.
   if (signal?.aborted) {
     return {
       result: createErrorToolResult("Operation aborted"),


### PR DESCRIPTION
Closes #102252

## What Problem This Solves

Fixes an issue where users canceling a run during a parallel tool batch could still have an already-prepared paid tool start afterward when another tool was still in its pre-execution hook.

## Why This Change Was Made

The agent loop now re-checks the abort signal immediately before a prepared tool is allowed to execute. If the run was canceled after preparation but before execution, the prepared call is finalized as aborted with `executionStarted: false`, and post-tool hooks are not invoked for work that never actually started.

This keeps the cancellation boundary in agent-core instead of relying on every individual paid tool to honor abort signals correctly.

AI-assisted implementation.

## User Impact

Canceling a run during parallel tool preparation no longer starts stale prepared tool work afterward. This prevents unnecessary provider calls for tools that may dispatch paid jobs when `execute` begins.

## Evidence

- Current head: `231812d76644c1908b5aa8a4b1de298293e863b6` (`fix(agent-core): skip prepared tools after abort`).
- Focused regression proof: bundled Node `scripts/run-vitest.mjs packages/agent-core/src/agent-loop.test.ts -- --reporter=verbose` passed: 1 file, 23 tests.
- The new regression drives real `runAgentLoop` with two parallel tool calls, aborts from the second call's `beforeToolCall`, and asserts the already-prepared first call never executes, emits `executionStarted: false`, and does not run `afterToolCall`.
- Post-fix real behavior proof outside Vitest: from the PR source checkout at `231812d76644c1908b5aa8a4b1de298293e863b6`, I ran a standalone `tsx` harness that imports the source checkout's real `packages/agent-core/src/agent-loop.ts` and `createAssistantMessageEventStream`, then drives the canceled parallel batch directly. The `paid_style_tool` is a local paid-boundary stub: if paid-style dispatch begins, its `execute` counter increments.

```text
$ node --import tsx /private/tmp/openclaw-102276-proof.mts
OPENCLAW_102276_REAL_BEHAVIOR_PROOF
{
  "scenario": "source-checkout runAgentLoop parallel batch abort, outside Vitest",
  "runAborted": true,
  "paidStyleToolExecuteInvocations": 0,
  "gatedToolExecuteInvocations": 0,
  "afterToolCallInvocations": 0,
  "toolExecutionEnd": [
    {
      "toolName": "gated_tool",
      "isError": true,
      "executionStarted": false,
      "text": [
        "Operation aborted"
      ]
    },
    {
      "toolName": "paid_style_tool",
      "isError": true,
      "executionStarted": false,
      "text": [
        "Operation aborted"
      ]
    }
  ],
  "finalMessage": {
    "role": "assistant",
    "content": [
      {
        "type": "text",
        "text": ""
      }
    ],
    "api": "proof-api",
    "provider": "proof-provider",
    "model": "proof-model",
    "usage": {
      "input": 0,
      "output": 0,
      "cacheRead": 0,
      "cacheWrite": 0,
      "totalTokens": 0,
      "cost": {
        "input": 0,
        "output": 0,
        "cacheRead": 0,
        "cacheWrite": 0,
        "total": 0
      }
    },
    "stopReason": "aborted",
    "errorMessage": "proof user abort",
    "timestamp": 1783540162496
  }
}
PASS=true
```

- The real-behavior output shows the canceled parallel batch does not invoke the already-prepared paid-style tool: `paidStyleToolExecuteInvocations` is `0`, `afterToolCallInvocations` is `0`, and both finalized tool calls have `executionStarted: false`.
- Whitespace proof: `git diff --check` and `git diff --cached --check` passed.
- Structured review: bundled Python `.agents/skills/autoreview/scripts/autoreview --mode local` passed clean with no accepted/actionable findings.
