### PR TITLE
fix(msteams): keep post-tool replies from merging into streamed preambles

### DIFF
--- a/extensions/msteams/src/reply-stream-controller.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.test.ts
@@ -120,6 +120,22 @@ describe("createTeamsReplyStreamController", () => {
     expect(ctrl.preparePayload({ text: "Second segment" })).toEqual({ text: "Second segment" });
   });
 
+  it("uses fallback when post-tool partial text arrives after the stream is finalized", async () => {
+    const stream = makeStream();
+    const ctrl = makeController({ stream });
+
+    ctrl.onPartialReply({ text: "I'll check the CRM." });
+    expect(ctrl.preparePayload({ text: "I'll check the CRM." })).toBeUndefined();
+    await expect(ctrl.finalize()).resolves.toBeUndefined();
+
+    const emitCountAfterFinalize = stream.emit.mock.calls.length;
+    const finalText = "There are **190 contacts** in RForce.";
+    ctrl.onPartialReply({ text: finalText });
+
+    expect(stream.emit).toHaveBeenCalledTimes(emitCountAfterFinalize);
+    expect(ctrl.preparePayload({ text: finalText })).toEqual({ text: finalText });
+  });
+
   it("delivers all later segments across 3+ tool call rounds", () => {
     const stream = makeStream();
     const ctrl = makeController({ stream });
@@ -273,6 +289,25 @@ describe("createTeamsReplyStreamController", () => {
 
     expect(ctrl.preparePayload({ text: "complete final answer" })).toBeUndefined();
     expect(stream.emit).toHaveBeenCalledWith("complete final answer");
+  });
+
+  it("uses block delivery for progress-mode text after the stream is finalized", async () => {
+    const stream = makeStream();
+    const ctrl = createTeamsReplyStreamController({
+      conversationType: "personal",
+      context: makeContext(stream),
+      feedbackLoopEnabled: false,
+      msteamsConfig: { streaming: { mode: "progress" } } as never,
+    });
+
+    expect(ctrl.preparePayload({ text: "I will check." })).toBeUndefined();
+    await expect(ctrl.finalize()).resolves.toBeUndefined();
+
+    const emitCountAfterFinalize = stream.emit.mock.calls.length;
+    expect(ctrl.preparePayload({ text: "The result is ready." })).toEqual({
+      text: "The result is ready.",
+    });
+    expect(stream.emit).toHaveBeenCalledTimes(emitCountAfterFinalize);
   });
 
   it("falls back to normal delivery when progress final streaming fails", () => {

--- a/extensions/msteams/src/reply-stream-controller.ts
+++ b/extensions/msteams/src/reply-stream-controller.ts
@@ -83,6 +83,7 @@ export function createTeamsReplyStreamController(params: {
 
   let tokensEmitted = false;
   let streamFinalizationPending = false;
+  let streamRetired = false;
   let canceledLocally = false;
   // Set when `stream.emit/close` fails for a non-cancel reason after we've
   // already started streaming. Differentiates "user pressed Stop" from "the
@@ -162,6 +163,7 @@ export function createTeamsReplyStreamController(params: {
         !stream ||
         !payload.text ||
         wasCanceled() ||
+        streamRetired ||
         streamMode !== "partial" ||
         streamFinalizationPending
       ) {
@@ -270,6 +272,12 @@ export function createTeamsReplyStreamController(params: {
       if (wasCanceled()) {
         return undefined;
       }
+      // The SDK stream is a single preview-card lifecycle. Once OpenClaw has
+      // handed a streamed segment to close(), later post-tool segments must use
+      // normal block delivery instead of appending to the closed preview.
+      if (streamRetired) {
+        return payload;
+      }
       // Partial mode with tokens already streamed: stream carries the text;
       // strip text from the payload (keep media if any) so block delivery
       // doesn't duplicate. Exception: if a non-cancel stream failure was
@@ -279,6 +287,7 @@ export function createTeamsReplyStreamController(params: {
         const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
         pendingFinalPayload = fallbackPayloadForSuppressedFinal(payload);
         streamFinalizationPending = true;
+        streamRetired = true;
         tokensEmitted = false;
         return hasMedia ? { ...payload, text: undefined } : undefined;
       }
@@ -292,6 +301,7 @@ export function createTeamsReplyStreamController(params: {
           stream.emit(payload.text);
           pendingFinalPayload = fallbackPayloadForSuppressedFinal(payload);
           streamFinalizationPending = true;
+          streamRetired = true;
           const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
           return hasMedia ? { ...payload, text: undefined } : undefined;
         } catch (err) {


### PR DESCRIPTION
Closes #102274

## What Problem This Solves

Fixes an issue where Microsoft Teams DM users could receive a corrupted reply when an agent streamed a text preamble, ran a tool, and then produced a later text segment. The later segment could be written back into the already-finalized streaming preview instead of being delivered as its own normal Teams message, producing a merged or sliced bubble.

## Why This Change Was Made

The Teams reply stream controller now treats the SDK stream as a single preview-card lifecycle: once a streamed segment is handed to `close()`, later post-tool text bypasses native streaming and uses normal block delivery. Risk note: this touches Teams streaming state, so the regression tests cover both partial streaming and progress-mode finalization while preserving the existing cancel, media fallback, and dispatcher paths.

## User Impact

Teams DM replies that include tool calls no longer merge a post-tool answer into the streamed preamble. Users should see the initial streamed segment finalized normally and later tool-result text delivered intact instead of sliced mid-word.

## Evidence

Before fix, I kept the new regression test and temporarily reverted only the production change. The focused test failed because post-finalize `onPartialReply` wrote to the stream again:

```text
FAIL  extensions/msteams/src/reply-stream-controller.test.ts > createTeamsReplyStreamController > uses fallback when post-tool partial text arrives after the stream is finalized
AssertionError: expected "vi.fn()" to be called 2 times, but got 3 times
```

Premise checked against the installed Teams SDK source: `@microsoft/teams.apps` `HttpStream.emit()` queues message activities, `flush()` appends message text into the stream buffer, and `close()` returns the cached close result once `_result` is set. That makes the SDK stream a one-preview lifecycle rather than a reusable post-close sink.

After fix:

```text
node scripts/run-vitest.mjs extensions/msteams/src/reply-stream-controller.test.ts -t "stream is finalized"
Test Files  1 passed (1)
Tests  2 passed | 37 skipped (39)

node scripts/run-vitest.mjs extensions/msteams/src/reply-stream-controller.test.ts
Test Files  1 passed (1)
Tests  39 passed (39)

node scripts/run-vitest.mjs extensions/msteams/src/reply-dispatcher.test.ts
Test Files  1 passed (1)
Tests  31 passed (31)

./node_modules/.bin/oxfmt --check --threads=1 extensions/msteams/src/reply-stream-controller.ts extensions/msteams/src/reply-stream-controller.test.ts
All matched files use the correct format.

git diff --check
# no output

.agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
```

I did not run a live Microsoft Teams DM client proof in this checkout; the covered failure is before network delivery and is proven at the controller/SDK stream boundary.

AI-assisted.
