### PR TITLE
fix: avoid retrying permanent provider errors

### DIFF
--- a/src/llm/utils/retry.test.ts
+++ b/src/llm/utils/retry.test.ts
@@ -25,6 +25,18 @@ function errorMessage(message: string): AssistantMessage {
 
 describe("isRetryableAssistantError", () => {
   it.each([
+    "model gpt-5.5-preview-0429 not found",
+    "Image dimensions 1504x1504 exceed the maximum allowed size",
+    "invalid api key sk-proj-abc502xyz",
+    "Provider returned error: 404 model gpt-5.5-preview-0429 not found",
+    "Provider returned error: HTTP 400 image dimensions 1504x1504 exceed the maximum allowed size",
+    "Provider returned error: 401 invalid api key sk-proj-abc502xyz",
+    "Provider returned error: 403 Forbidden",
+  ])("keeps permanent provider errors non-retryable: %s", (text) => {
+    expect(isRetryableAssistantError(errorMessage(text))).toBe(false);
+  });
+
+  it.each([
     "An error occurred while processing your request. You can retry your request.",
     "The system encountered an unexpected error. Try your request again.",
     "Temporary provider failure; please retry your request.",
@@ -43,6 +55,15 @@ describe("isRetryableAssistantError", () => {
         errorMessage("503 billing service unavailable; please retry your request"),
       ),
     ).toBe(true);
+  });
+
+  it.each([
+    "Provider returned error: 429 too many requests",
+    "Provider returned error: HTTP 500 internal server error",
+    "Provider returned error: 502 bad gateway",
+    "Provider returned error: 504 gateway timeout",
+  ])("retries transient provider status errors: %s", (text) => {
+    expect(isRetryableAssistantError(errorMessage(text))).toBe(true);
   });
 
   it("retries short-window quota exhaustion", () => {

--- a/src/llm/utils/retry.ts
+++ b/src/llm/utils/retry.ts
@@ -5,23 +5,31 @@ function buildProviderErrorPattern(patterns: readonly string[]): RegExp {
 }
 
 const NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN = buildProviderErrorPattern([
+  "\\b(?:HTTP\\s*)?(?:400|401|403|404)\\b",
   "GoUsageLimitError",
   "FreeUsageLimitError",
   "Monthly usage limit reached",
   "available balance",
   "insufficient_quota",
   "out of budget",
+  "invalid[\\s_-]*api[\\s_-]*key",
+  "unauthorized",
+  "forbidden",
+  "permission.?denied",
+  "model.?not.?found",
+  "unsupported.?model",
+  "image.?dimensions",
 ]);
 
 const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
   "overloaded",
   "rate.?limit",
   "too many requests",
-  "429",
-  "500",
-  "502",
-  "503",
-  "504",
+  "\\b429\\b",
+  "\\b500\\b",
+  "\\b502\\b",
+  "\\b503\\b",
+  "\\b504\\b",
   "service.?unavailable",
   "server.?error",
   "internal.?error",


### PR DESCRIPTION
Closes #102250

AI-assisted: yes. I reviewed the change and understand the runtime behavior.

## What Problem This Solves

Fixes an issue where users hitting permanent provider failures could have the same full-context request retried up to three extra times when the error text contained retry-like status fragments.

## Why This Change Was Made

Permanent 400/401/403/404/auth/model/image-dimension failures are classified before transient retry hints, and retryable status matching is anchored so unrelated substrings do not trigger retries.

## User Impact

Avoids doomed repeated provider calls for failures that cannot succeed, reducing wasted latency and token/provider cost during failed agent turns.

## Evidence

- `pnpm exec oxfmt --check src/llm/utils/retry.ts src/llm/utils/retry.test.ts` -> passed
- `node scripts/run-vitest.mjs src/llm/utils/retry.test.ts` -> 1 file, 17 tests passed
- `git diff --check` -> passed

Signed-off-by: Ho Lim <subhoya@gmail.com>
