### PR TITLE
improve(agents): tail-load compacted session transcripts on startup

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -339,6 +339,7 @@ vi.mock("../../sessions/index.js", () => {
     ModelRegistry,
     SessionManager: {
       open: (...args: unknown[]) => hoisted.sessionManagerOpenMock(...args),
+      openCompactedTail: (...args: unknown[]) => hoisted.sessionManagerOpenMock(...args),
     },
   };
 });

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2259,7 +2259,7 @@ export async function runEmbeddedAttempt(
 
       await prewarmSessionFile(params.sessionFile);
       const preparedUserTurnMessage = await params.userTurnTranscriptRecorder?.resolveMessage();
-      sessionManager = guardSessionManager(SessionManager.open(params.sessionFile), {
+      sessionManager = guardSessionManager(SessionManager.openCompactedTail(params.sessionFile), {
         agentId: sessionAgentId,
         sessionKey: params.sessionKey,
         config: params.config,

--- a/src/agents/embedded-agent-runner/session-manager-init.ts
+++ b/src/agents/embedded-agent-runner/session-manager-init.ts
@@ -116,6 +116,7 @@ export async function prepareSessionManagerForRun(params: {
     leafId?: string | null;
     wasRecoveredFromCorruptHeader?: () => boolean;
     clearPreservedOpaqueFileEntries?: () => void;
+    prepareForFullFileRewrite?: () => void;
     getSerializedFileLinesForRewrite?: () => string[];
     syncSnapshotAfterHeaderRewrite?: (expectedContent?: string) => void;
   };
@@ -139,8 +140,14 @@ export async function prepareSessionManagerForRun(params: {
     if (sm.wasRecoveredFromCorruptHeader?.() || preservesForkedBranch) {
       // Fork transcripts can intentionally select a user-only or empty branch.
       // Keep their copied tree so the first run appends at the preserved cursor.
-      header.id = params.sessionId;
-      header.cwd = params.cwd;
+      sm.prepareForFullFileRewrite?.();
+      const rewriteHeader = sm.fileEntries.find(
+        (entry): entry is SessionHeaderEntry => entry.type === "session",
+      );
+      if (rewriteHeader) {
+        rewriteHeader.id = params.sessionId;
+        rewriteHeader.cwd = params.cwd;
+      }
       sm.sessionId = params.sessionId;
       sm.cwd = params.cwd;
       const content = await writeJsonlLines(
@@ -174,14 +181,24 @@ export async function prepareSessionManagerForRun(params: {
 
   if (params.hadSessionFile && header) {
     const headerChanged = header.id !== params.sessionId || header.cwd !== params.cwd;
-    header.id = params.sessionId;
-    header.cwd = params.cwd;
-    sm.sessionId = params.sessionId;
-    sm.cwd = params.cwd;
     if (!headerChanged) {
+      header.id = params.sessionId;
+      header.cwd = params.cwd;
+      sm.sessionId = params.sessionId;
+      sm.cwd = params.cwd;
       sm.flushed = true;
       return;
     }
+    sm.prepareForFullFileRewrite?.();
+    const rewriteHeader = sm.fileEntries.find(
+      (entry): entry is SessionHeaderEntry => entry.type === "session",
+    );
+    if (rewriteHeader) {
+      rewriteHeader.id = params.sessionId;
+      rewriteHeader.cwd = params.cwd;
+    }
+    sm.sessionId = params.sessionId;
+    sm.cwd = params.cwd;
     const content = await writeJsonlLines(
       params.sessionFile,
       sm.getSerializedFileLinesForRewrite?.() ?? sm.fileEntries.map(serializeJsonlLine),

--- a/src/agents/embedded-agent-runner/transcript-rewrite.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.ts
@@ -200,6 +200,7 @@ export function rewriteTranscriptEntriesInSessionManager(params: {
     };
   }
 
+  params.sessionManager.prepareForFullFileRewrite();
   const branch = params.sessionManager.getBranch();
   if (branch.length === 0) {
     return {

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -159,6 +159,134 @@ describe("SessionManager.open", () => {
     expect(SessionManager.continueRecent(longCwd, dir).getSessionFile()).toBe(sessionFile);
   });
 
+  it("opens large compacted run transcripts from the bounded replay tail", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "large-compacted-session.jsonl");
+    const header = buildSessionHeader(dir, "large-compacted-session");
+    const oldEntries = Array.from({ length: 1_000 }, (_, index) => ({
+      type: "message",
+      id: `old-user-${index}`,
+      parentId: index === 0 ? null : `old-user-${index - 1}`,
+      timestamp: `2026-06-04T00:${String(Math.floor(index / 60)).padStart(2, "0")}:${String(
+        index % 60,
+      ).padStart(2, "0")}.000Z`,
+      message: { role: "user", content: `old prompt ${index}`, timestamp: index },
+    }));
+    const largePrefix = {
+      type: "custom",
+      id: "large-prefix",
+      parentId: "old-user-999",
+      timestamp: "2026-06-04T00:00:02.000Z",
+      customType: "test:padding",
+      data: { padding: "x".repeat(33 * 1024 * 1024) },
+    };
+    const keptUser = {
+      type: "message",
+      id: "kept-user",
+      parentId: "large-prefix",
+      timestamp: "2026-06-04T00:00:03.000Z",
+      message: { role: "user", content: "kept prompt", timestamp: 3 },
+    };
+    const keptAssistant = {
+      type: "message",
+      id: "kept-assistant",
+      parentId: "kept-user",
+      timestamp: "2026-06-04T00:00:04.000Z",
+      message: buildAssistantMessage("kept answer"),
+    };
+    const compaction = {
+      type: "compaction",
+      id: "compaction-1",
+      parentId: "kept-assistant",
+      timestamp: "2026-06-04T00:00:05.000Z",
+      summary: "older turns summarized",
+      firstKeptEntryId: "kept-user",
+      tokensBefore: 123,
+    };
+    const afterUser = {
+      type: "message",
+      id: "after-user",
+      parentId: "compaction-1",
+      timestamp: "2026-06-04T00:00:06.000Z",
+      message: { role: "user", content: "after compaction", timestamp: 6 },
+    };
+    const transcriptEntries = [
+      header,
+      ...oldEntries,
+      largePrefix,
+      keptUser,
+      keptAssistant,
+      compaction,
+      afterUser,
+    ];
+    await fs.writeFile(
+      sessionFile,
+      `${transcriptEntries.map((entry) => JSON.stringify(entry)).join("\n")}\n`,
+      "utf8",
+    );
+    expect((await fs.stat(sessionFile)).size).toBeGreaterThan(32 * 1024 * 1024);
+
+    const fullManager = SessionManager.open(sessionFile, dir, dir);
+    expect(fullManager.getEntries()).toHaveLength(1_005);
+    expect(fullManager.getEntries().map((entry) => entry.id)).toContain("large-prefix");
+
+    const tailManager = SessionManager.openCompactedTail(sessionFile, dir, dir);
+    expect(tailManager.getEntries().map((entry) => entry.id)).toEqual([
+      "kept-user",
+      "kept-assistant",
+      "compaction-1",
+      "after-user",
+    ]);
+
+    const messages = tailManager.buildSessionContext().messages;
+    expect(messages.map((message) => message.role)).toEqual([
+      "compactionSummary",
+      "user",
+      "assistant",
+      "user",
+    ]);
+    expect(JSON.stringify(messages)).toContain("kept prompt");
+    expect(JSON.stringify(messages)).toContain("after compaction");
+    expect(JSON.stringify(messages)).not.toContain("old prompt");
+
+    await prepareSessionManagerForRun({
+      sessionManager: tailManager,
+      sessionFile,
+      hadSessionFile: true,
+      sessionId: "rewritten-session",
+      cwd: "/tmp/task-repo",
+    });
+    expect((await fs.stat(sessionFile)).size).toBeGreaterThan(32 * 1024 * 1024);
+    const rewrittenHeader = JSON.parse(
+      (await fs.readFile(sessionFile, "utf8")).split("\n")[0] ?? "{}",
+    ) as { id?: unknown; cwd?: unknown };
+    expect(rewrittenHeader).toMatchObject({
+      id: "rewritten-session",
+      cwd: "/tmp/task-repo",
+    });
+    const fullAfterHeaderRewrite = SessionManager.open(sessionFile, dir, "/tmp/task-repo");
+    expect(fullAfterHeaderRewrite.getEntries().map((entry) => entry.id)).toContain("large-prefix");
+
+    tailManager.appendMessage(buildAssistantMessage("new answer"));
+    const lastLine = (await fs.readFile(sessionFile, "utf8")).trim().split("\n").at(-1);
+    const appended = JSON.parse(lastLine ?? "{}") as { parentId?: unknown; message?: unknown };
+    expect(appended.parentId).toBe("after-user");
+    expect(appended.message).toMatchObject({ role: "assistant" });
+
+    const removed = tailManager.removeTrailingEntries(
+      (entry) =>
+        entry.type === "message" &&
+        entry.message.role === "assistant" &&
+        JSON.stringify(entry.message).includes("new answer"),
+    );
+    expect(removed).toBe(1);
+    expect((await fs.stat(sessionFile)).size).toBeGreaterThan(32 * 1024 * 1024);
+
+    const fullAfterRewrite = SessionManager.open(sessionFile, dir, dir);
+    expect(fullAfterRewrite.getEntries().map((entry) => entry.id)).toContain("large-prefix");
+    expect(JSON.stringify(fullAfterRewrite.getEntries())).not.toContain("new answer");
+  });
+
   it("does not continue a different cwd from a colliding session directory", async () => {
     const dir = await makeTempDir();
     const cwdA = "/home/alice/dev/client/app";

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -9,6 +9,7 @@ import { withOwnedSessionTranscriptWrites } from "../../config/sessions/transcri
 import * as Logger from "../../logger.js";
 import { isTranscriptOnlyOpenClawAssistantMessage } from "../../shared/transcript-only-openclaw-assistant.js";
 import { prepareSessionManagerForRun } from "../embedded-agent-runner/session-manager-init.js";
+import { rewriteTranscriptEntriesInSessionManager } from "../embedded-agent-runner/transcript-rewrite.js";
 import { repairSessionFileIfNeeded } from "../session-file-repair.js";
 import {
   CURRENT_SESSION_VERSION,
@@ -249,6 +250,22 @@ describe("SessionManager.open", () => {
     expect(JSON.stringify(messages)).toContain("after compaction");
     expect(JSON.stringify(messages)).not.toContain("old prompt");
 
+    const contextRewrite = rewriteTranscriptEntriesInSessionManager({
+      sessionManager: tailManager,
+      replacements: [
+        {
+          entryId: "kept-user",
+          message: { role: "user", content: "kept prompt rewritten", timestamp: 3 },
+        },
+      ],
+    });
+    expect(contextRewrite.changed).toBe(true);
+    const fullAfterContextRewrite = SessionManager.open(sessionFile, dir, dir);
+    const contextRewriteBranch = fullAfterContextRewrite.getBranch();
+    expect(contextRewriteBranch.map((entry) => entry.id)).toContain("large-prefix");
+    expect(JSON.stringify(contextRewriteBranch)).toContain("kept prompt rewritten");
+    expect(JSON.stringify(contextRewriteBranch)).toContain("after compaction");
+
     await prepareSessionManagerForRun({
       sessionManager: tailManager,
       sessionFile,
@@ -267,10 +284,12 @@ describe("SessionManager.open", () => {
     const fullAfterHeaderRewrite = SessionManager.open(sessionFile, dir, "/tmp/task-repo");
     expect(fullAfterHeaderRewrite.getEntries().map((entry) => entry.id)).toContain("large-prefix");
 
+    const appendParentId = tailManager.getBranch().at(-1)?.id;
+    expect(typeof appendParentId).toBe("string");
     tailManager.appendMessage(buildAssistantMessage("new answer"));
     const lastLine = (await fs.readFile(sessionFile, "utf8")).trim().split("\n").at(-1);
     const appended = JSON.parse(lastLine ?? "{}") as { parentId?: unknown; message?: unknown };
-    expect(appended.parentId).toBe("after-user");
+    expect(appended.parentId).toBe(appendParentId);
     expect(appended.message).toMatchObject({ role: "assistant" });
 
     const removed = tailManager.removeTrailingEntries(

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -528,7 +528,8 @@ function isCurrentSessionHeader(header: SessionHeader | undefined): header is Se
 function tailEntriesRequireEarlierCursor(entries: readonly FileEntry[]): boolean {
   return entries.some(
     (entry) =>
-      isIndexedSessionEntry(entry) && !Object.hasOwn(entry as Record<string, unknown>, "parentId"),
+      isIndexedSessionEntry(entry) &&
+      !Object.hasOwn(entry as unknown as Record<string, unknown>, "parentId"),
   );
 }
 

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -28,7 +28,9 @@ import {
 } from "../../config/sessions/transcript-jsonl.js";
 import {
   isSessionTranscriptSideAppendEntry,
+  scanSessionTranscriptTree,
   selectSessionTranscriptLeafControlledPath,
+  selectSessionTranscriptTreePathNodes,
 } from "../../config/sessions/transcript-tree.js";
 import {
   canAdvanceOwnedSessionEntryCache,
@@ -53,6 +55,7 @@ export { CURRENT_SESSION_VERSION };
 
 const SESSION_HEADER_READ_CHUNK_BYTES = 4096;
 const MAX_SESSION_HEADER_BYTES = 64 * 1024;
+const COMPACTED_TAIL_SESSION_LOAD_MAX_BYTES = 2 * 1024 * 1024;
 
 export interface SessionHeader {
   type: "session";
@@ -442,10 +445,13 @@ export function loadEntriesFromFile(filePath: string): FileEntry[] {
   return hasReadableSessionHeader(entries) ? entries : [];
 }
 
-function loadEntriesFromFileWithSnapshot(filePath: string): {
+type LoadedSessionFile = {
   entries: FileEntry[];
   snapshot: SessionFileSnapshot | undefined;
-} {
+  compactedTail?: true;
+};
+
+function loadEntriesFromFileWithSnapshot(filePath: string): LoadedSessionFile {
   const resolvedPath = resolve(filePath);
   for (let attempt = 0; attempt < 3; attempt += 1) {
     let beforeReadSnapshot: SessionFileSnapshot;
@@ -483,6 +489,114 @@ function loadEntriesFromFileWithSnapshot(filePath: string): {
 
   sessionEntriesCache.delete(resolvedPath);
   throw new Error(`session file changed repeatedly while loading: ${resolvedPath}`);
+}
+
+function readTailEntriesFromFileSnapshot(
+  filePath: string,
+  snapshot: SessionFileSnapshot,
+): FileEntry[] | undefined {
+  const bytesToRead = Math.min(COMPACTED_TAIL_SESSION_LOAD_MAX_BYTES, Number(snapshot.size));
+  if (bytesToRead <= 0 || snapshot.size <= BigInt(bytesToRead)) {
+    return undefined;
+  }
+
+  const readStart = snapshot.size - BigInt(bytesToRead);
+  const fd = openSync(filePath, "r");
+  try {
+    const buffer = Buffer.allocUnsafe(bytesToRead);
+    const bytesRead = readSync(fd, buffer, 0, bytesToRead, readStart);
+    if (bytesRead <= 0) {
+      return undefined;
+    }
+
+    let text = buffer.toString("utf8", 0, bytesRead);
+    const firstNewline = text.indexOf("\n");
+    if (firstNewline < 0) {
+      return undefined;
+    }
+    text = text.slice(firstNewline + 1);
+    return text.trim() ? parseJsonlEntries(text) : undefined;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function isCurrentSessionHeader(header: SessionHeader | undefined): header is SessionHeader {
+  return header?.version === CURRENT_SESSION_VERSION;
+}
+
+function tailEntriesRequireEarlierCursor(entries: readonly FileEntry[]): boolean {
+  return entries.some(
+    (entry) =>
+      isIndexedSessionEntry(entry) && !Object.hasOwn(entry as Record<string, unknown>, "parentId"),
+  );
+}
+
+function isCompactedTailReplayComplete(entries: readonly FileEntry[]): boolean {
+  const bodyEntries = entries.filter((entry) => entry.type !== "session");
+  if (bodyEntries.length === 0 || tailEntriesRequireEarlierCursor(bodyEntries)) {
+    return false;
+  }
+
+  const tree = scanSessionTranscriptTree(bodyEntries);
+  if (tree.hasInvalidLeafControl || !tree.hasLeafUpdate || tree.leafId === null) {
+    return false;
+  }
+
+  const path = selectSessionTranscriptTreePathNodes(tree, tree.leafId);
+  const branchEntries = path
+    .map((node) => node.entry)
+    .filter((entry): entry is SessionEntry => isIndexedSessionEntry(entry));
+  const latestCompactionIndex = branchEntries.findLastIndex((entry) => entry.type === "compaction");
+  const latestCompaction = branchEntries[latestCompactionIndex];
+  if (latestCompaction?.type !== "compaction") {
+    return false;
+  }
+
+  return branchEntries
+    .slice(0, latestCompactionIndex + 1)
+    .some((entry) => entry.id === latestCompaction.firstKeptEntryId);
+}
+
+function loadCompactedTailEntriesFromFileWithSnapshot(filePath: string): LoadedSessionFile | null {
+  const resolvedPath = resolve(filePath);
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    let beforeReadSnapshot: SessionFileSnapshot;
+    try {
+      beforeReadSnapshot = readSessionFileSnapshot(resolvedPath);
+    } catch {
+      sessionEntriesCache.delete(resolvedPath);
+      return null;
+    }
+    if (
+      beforeReadSnapshot.size <= MAX_CACHED_SESSION_BYTES ||
+      beforeReadSnapshot.size <= BigInt(COMPACTED_TAIL_SESSION_LOAD_MAX_BYTES)
+    ) {
+      return null;
+    }
+
+    const header = readSessionHeaderFromFile(resolvedPath);
+    if (!isCurrentSessionHeader(header)) {
+      return null;
+    }
+
+    const tailEntries = readTailEntriesFromFileSnapshot(resolvedPath, beforeReadSnapshot);
+    if (!tailEntries) {
+      return null;
+    }
+
+    const entries = [header, ...tailEntries];
+    if (!isCompactedTailReplayComplete(entries)) {
+      return null;
+    }
+
+    const afterReadSnapshot = readSessionFileSnapshotIfExists(resolvedPath);
+    if (afterReadSnapshot && isSameSessionFileSnapshot(beforeReadSnapshot, afterReadSnapshot)) {
+      return { entries, snapshot: afterReadSnapshot, compactedTail: true };
+    }
+  }
+
+  return null;
 }
 
 interface SessionFileSnapshot {
@@ -1497,6 +1611,7 @@ export class SessionManager {
   private promptReleasedSideBranchParentId: string | null | undefined;
   private recoveredCorruptHeader = false;
   private sessionFileSnapshot: SessionFileSnapshot | undefined;
+  private loadedFromCompactedTail = false;
 
   private constructor(
     cwd: string,
@@ -1506,6 +1621,7 @@ export class SessionManager {
     loadedSessionFile?: {
       entries: FileEntry[];
       snapshot: SessionFileSnapshot | undefined;
+      compactedTail?: true;
     },
   ) {
     this.cwd = cwd;
@@ -1535,10 +1651,12 @@ export class SessionManager {
     loaded: {
       entries: FileEntry[];
       snapshot: SessionFileSnapshot | undefined;
+      compactedTail?: true;
     },
   ): void {
     this.sessionFile = resolve(sessionFile);
     this.sessionFileSnapshot = undefined;
+    this.loadedFromCompactedTail = loaded.compactedTail === true;
     this.recoveredCorruptHeader = false;
     if (existsSync(this.sessionFile)) {
       const partitioned = partitionSessionFileEntries(loaded.entries);
@@ -1595,6 +1713,7 @@ export class SessionManager {
   newSession(options?: NewSessionOptions): string | undefined {
     this.recoveredCorruptHeader = false;
     this.sessionFileSnapshot = undefined;
+    this.loadedFromCompactedTail = false;
     this.sessionId = options?.id ?? createSessionId();
     const timestamp = new Date().toISOString();
     const header: SessionHeader = {
@@ -1940,6 +2059,10 @@ export class SessionManager {
     return this.getPersistedFileEntries().map(serializeJsonlLine);
   }
 
+  prepareForFullFileRewrite(): void {
+    this.ensureFullFileLoadedForRewrite();
+  }
+
   clearPreservedOpaqueFileEntries(): void {
     this.opaqueFileEntries = [];
     this.opaqueParentsById.clear();
@@ -2012,6 +2135,7 @@ export class SessionManager {
     predicate: (entry: SessionEntry) => boolean,
     options?: { preserveTrailing?: (entry: SessionEntry) => boolean },
   ): number {
+    this.ensureFullFileLoadedForRewrite();
     let preservedStart = this.fileEntries.length;
     while (preservedStart > 1) {
       const entry = this.fileEntries[preservedStart - 1];
@@ -2116,6 +2240,15 @@ export class SessionManager {
     this.appendParentId = replacementParentId;
     this.rewriteFile();
     return removedEntries.length;
+  }
+
+  private ensureFullFileLoadedForRewrite(): void {
+    if (!this.loadedFromCompactedTail || !this.sessionFile) {
+      return;
+    }
+    // Tail loading is only safe for append-only run startup. Any rewrite must
+    // operate on the complete file so older transcript history is preserved.
+    this.setLoadedSessionFile(this.sessionFile, loadEntriesFromFileWithSnapshot(this.sessionFile));
   }
 
   private persistRecord(
@@ -2976,10 +3109,43 @@ export class SessionManager {
    * @param cwdOverride Optional cwd override instead of the session header cwd.
    */
   static open(path: string, sessionDir?: string, cwdOverride?: string): SessionManager {
+    return SessionManager.openLoaded(
+      path,
+      sessionDir,
+      cwdOverride,
+      loadEntriesFromFileWithSnapshot(path),
+    );
+  }
+
+  /**
+   * Open a run transcript from its compacted replay tail when the tail proves complete.
+   *
+   * Falls back to the full loader for migrations, corrupt/legacy rows, missing
+   * compaction boundaries, or any tail that cannot preserve provider replay.
+   */
+  static openCompactedTail(
+    path: string,
+    sessionDir?: string,
+    cwdOverride?: string,
+  ): SessionManager {
+    return SessionManager.openLoaded(
+      path,
+      sessionDir,
+      cwdOverride,
+      loadCompactedTailEntriesFromFileWithSnapshot(path) ?? loadEntriesFromFileWithSnapshot(path),
+    );
+  }
+
+  private static openLoaded(
+    path: string,
+    sessionDir: string | undefined,
+    cwdOverride: string | undefined,
+    initialLoad: LoadedSessionFile,
+  ): SessionManager {
     // Re-stat before construction so the single parsed load cannot become
     // stale while deriving cwd/session metadata. Stable warm opens pay only
     // the extra stat; changed files retry through the normal loader.
-    const loaded = revalidateLoadedSessionFile(path, loadEntriesFromFileWithSnapshot(path));
+    const loaded = revalidateLoadedSessionFile(path, initialLoad);
     const header = loaded.entries.find((e) => e.type === "session");
     const cwd = cwdOverride ?? header?.cwd ?? process.cwd();
     // If no sessionDir provided, derive from file's parent directory


### PR DESCRIPTION
AI-assisted: yes. I reviewed the change and understand the runtime behavior.

## What Problem This Solves

Addresses the embedded attempt startup path from #99190: long-running compacted session transcripts could still be fully read and parsed during run startup even when the active replay path was bounded by a compaction entry.

This PR intentionally does **not** close #99190 because the broader `readTranscriptFileState` full-file hot path remains outside this diff.

## Why This Change Was Made

`SessionManager.openCompactedTail()` takes an opt-in bounded tail path for current-version transcripts larger than 32 MiB when the tail proves a complete compacted replay boundary.

This update also forces `rewriteTranscriptEntriesInSessionManager()` to call the existing full-file rewrite guard before mutating a session manager. That closes the review blocker where foreground context-engine maintenance could rewrite a tail-loaded manager and persist only the compacted suffix.

## User Impact

Eligible compacted startup reads are capped to a 2 MiB tail window while rewrite, migration, repair, truncation, and inspection paths preserve full-file semantics before mutation.

## Evidence

Local proof script on this branch created a 33.17 MiB compacted transcript with 1,005 full entries and then opened it through the compacted-tail path before rewriting a context-engine-visible entry:

```text
session_file_mb=33.17
full_open_entries=1005 full_open_ms=69.44
tail_open_entries=4 tail_open_ms=2.89
rewrite_changed=true rewritten_entries=1
prefix_preserved=true
rewritten_prompt_visible=true
tail_suffix_preserved=true
session_file_mb_after_rewrite=33.17
```

The key safety checks are `prefix_preserved=true`, `rewritten_prompt_visible=true`, and `tail_suffix_preserved=true`: context-engine-style rewrites now reload the full file before mutation instead of rewriting from only the compacted suffix.

Validation run locally after rebasing onto `upstream/main`:

- `node scripts/run-vitest.mjs run src/agents/sessions/session-manager.test.ts src/agents/embedded-agent-runner/transcript-rewrite.test.ts` -> 2 files, 66 tests passed
- `./node_modules/.bin/oxfmt --check src/agents/embedded-agent-runner/transcript-rewrite.ts src/agents/sessions/session-manager.test.ts` -> passed
- `./node_modules/.bin/oxlint src/agents/embedded-agent-runner/transcript-rewrite.ts src/agents/sessions/session-manager.test.ts` -> passed
- `pnpm check:test-types` -> passed
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs --base upstream/main --timed` -> passed after final rebase (core/coreTests lanes)
- `git diff --check` -> passed

Signed-off-by: Ho Lim <subhoya@gmail.com>

