### PR TITLE
fix(config): warn when transcript byte guard is inactive

### DIFF
--- a/src/config/compaction-warnings.ts
+++ b/src/config/compaction-warnings.ts
@@ -33,7 +33,7 @@ export function collectInactiveActiveTranscriptByteGuardWarnings(
   return [
     {
       path: INACTIVE_MAX_ACTIVE_TRANSCRIPT_BYTES_PATH,
-      message: formatInactiveByteGuardMessage(maxActiveTranscriptBytes),
+      message: formatInactiveByteGuardMessage(maxActiveTranscriptBytes ?? parsed),
     },
   ];
 }

--- a/src/config/compaction-warnings.ts
+++ b/src/config/compaction-warnings.ts
@@ -1,0 +1,39 @@
+// Shared warnings for compaction settings that validate but cannot affect runtime behavior.
+import { parseNonNegativeByteSize } from "./byte-size.js";
+import type { ConfigValidationIssue, OpenClawConfig } from "./types.js";
+
+export const INACTIVE_MAX_ACTIVE_TRANSCRIPT_BYTES_CHECK_ID =
+  "core/doctor/active-transcript-byte-guard";
+export const INACTIVE_MAX_ACTIVE_TRANSCRIPT_BYTES_PATH =
+  "agents.defaults.compaction.maxActiveTranscriptBytes";
+export const INACTIVE_MAX_ACTIVE_TRANSCRIPT_BYTES_REQUIREMENT =
+  "requires-truncate-after-compaction";
+export const INACTIVE_MAX_ACTIVE_TRANSCRIPT_BYTES_FIX_HINT =
+  "Set agents.defaults.compaction.truncateAfterCompaction to true, or unset agents.defaults.compaction.maxActiveTranscriptBytes / set it to 0.";
+
+function formatInactiveByteGuardMessage(value: number | string): string {
+  return `maxActiveTranscriptBytes is set to ${String(
+    value,
+  )}, but the active-transcript byte guard is inactive because agents.defaults.compaction.truncateAfterCompaction is not true. Enable truncateAfterCompaction to rotate compacted transcripts, or unset maxActiveTranscriptBytes / set it to 0.`;
+}
+
+/** Collect non-fatal warnings for compaction settings that are accepted but inactive. */
+export function collectInactiveActiveTranscriptByteGuardWarnings(
+  cfg: OpenClawConfig,
+): ConfigValidationIssue[] {
+  const compaction = cfg.agents?.defaults?.compaction;
+  if (!compaction || compaction.truncateAfterCompaction === true) {
+    return [];
+  }
+  const maxActiveTranscriptBytes = compaction.maxActiveTranscriptBytes;
+  const parsed = parseNonNegativeByteSize(maxActiveTranscriptBytes);
+  if (typeof parsed !== "number" || parsed <= 0) {
+    return [];
+  }
+  return [
+    {
+      path: INACTIVE_MAX_ACTIVE_TRANSCRIPT_BYTES_PATH,
+      message: formatInactiveByteGuardMessage(maxActiveTranscriptBytes),
+    },
+  ];
+}

--- a/src/config/config.compaction-settings.test.ts
+++ b/src/config/config.compaction-settings.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import { applyCompactionDefaults } from "./defaults.js";
 import type { OpenClawConfig } from "./types.js";
+import { validateConfigObjectWithPlugins } from "./validation.js";
 
 function materializeCompactionConfig(
   compaction: NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]>["compaction"],
@@ -93,5 +94,50 @@ describe("config compaction settings", () => {
     });
 
     expect(compaction?.qualityGuard?.maxRetries).toBe(99);
+  });
+
+  it("warns when active transcript byte guard is inactive without transcript rotation", () => {
+    const result = validateConfigObjectWithPlugins(
+      {
+        agents: {
+          defaults: {
+            compaction: {
+              maxActiveTranscriptBytes: "20mb",
+            },
+          },
+        },
+      },
+      { pluginValidation: "skip" },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.warnings).toContainEqual({
+      path: "agents.defaults.compaction.maxActiveTranscriptBytes",
+      message: expect.stringContaining("active-transcript byte guard is inactive"),
+    });
+  });
+
+  it.each([
+    { maxActiveTranscriptBytes: "20mb", truncateAfterCompaction: true },
+    { maxActiveTranscriptBytes: 0 },
+    { maxActiveTranscriptBytes: "0" },
+  ])("does not warn for active or disabled byte guard %#", (compaction) => {
+    const result = validateConfigObjectWithPlugins(
+      {
+        agents: {
+          defaults: {
+            compaction,
+          },
+        },
+      },
+      { pluginValidation: "skip" },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.warnings).not.toContainEqual(
+      expect.objectContaining({
+        path: "agents.defaults.compaction.maxActiveTranscriptBytes",
+      }),
+    );
   });
 });

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -53,6 +53,7 @@ import {
   collectChannelSchemaMetadataWithOwnership,
 } from "./channel-config-metadata.js";
 import { shouldSuppressMissingCodexPluginDiagnostics } from "./codex-plugin-diagnostics.js";
+import { collectInactiveActiveTranscriptByteGuardWarnings } from "./compaction-warnings.js";
 import { materializeRuntimeConfig } from "./materialize.js";
 import type { OpenClawConfig, ConfigValidationIssue } from "./types.js";
 import { coerceSecretRef } from "./types.secrets.js";
@@ -1202,16 +1203,18 @@ function validateConfigObjectWithPluginsBase(
         manifestRegistry: registryInfo?.registry,
       })
     : base.config;
+  const warnings: ConfigValidationIssue[] = [
+    ...collectInactiveActiveTranscriptByteGuardWarnings(config),
+  ];
   if (opts.pluginValidation === "skip") {
     return {
       ok: true,
       config,
-      warnings: [],
+      warnings,
     };
   }
 
   const issues: ConfigValidationIssue[] = [];
-  const warnings: ConfigValidationIssue[] = [];
   const hasExplicitPluginsConfig = isRecord(raw) && Object.hasOwn(raw, "plugins");
   const explicitPluginReferences = collectExplicitPluginReferences(raw);
 

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1812,6 +1812,98 @@ describe("doctor health contributions", () => {
     });
   });
 
+  it("reports inactive active-transcript byte guard as a default doctor lint finding", async () => {
+    const contributionChecks = await resolveDoctorContributionHealthChecks();
+    const check = contributionChecks.find(
+      (entry) => entry.id === "core/doctor/active-transcript-byte-guard",
+    );
+    expect(check).toBeDefined();
+    expect(check).not.toMatchObject({ defaultEnabled: false });
+
+    const ctx = {
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              maxActiveTranscriptBytes: "20mb",
+            },
+          },
+        },
+      },
+      mode: "lint" as const,
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    };
+
+    await expect(runDoctorLintChecks(ctx, { checks: [check!] })).resolves.toMatchObject({
+      checksRun: 1,
+      checksSkipped: 0,
+      findings: [
+        expect.objectContaining({
+          checkId: "core/doctor/active-transcript-byte-guard",
+          path: "agents.defaults.compaction.maxActiveTranscriptBytes",
+          requirement: "requires-truncate-after-compaction",
+          fixHint: expect.stringContaining("truncateAfterCompaction"),
+        }),
+      ],
+    });
+  });
+
+  it("does not report active-transcript byte guard finding when transcript rotation is enabled", async () => {
+    const contributionChecks = await resolveDoctorContributionHealthChecks();
+    const check = contributionChecks.find(
+      (entry) => entry.id === "core/doctor/active-transcript-byte-guard",
+    );
+
+    const ctx = {
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              truncateAfterCompaction: true,
+              maxActiveTranscriptBytes: "20mb",
+            },
+          },
+        },
+      },
+      mode: "lint" as const,
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    };
+
+    await expect(runDoctorLintChecks(ctx, { checks: [check!] })).resolves.toMatchObject({
+      checksRun: 1,
+      findings: [],
+    });
+  });
+
+  it("shows inactive active-transcript byte guard in doctor output", async () => {
+    const contribution = requireDoctorContribution("doctor:active-transcript-byte-guard");
+    const ctx = {
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              maxActiveTranscriptBytes: "20mb",
+            },
+          },
+        },
+      },
+      cfgForPersistence: {},
+      configResult: { cfg: {} },
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(false),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: {},
+      configPath: "/tmp/fake-openclaw.json",
+    } as unknown as DoctorContributionRunContext;
+
+    await contribution.run(ctx);
+
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringContaining("active-transcript byte guard is inactive"),
+      "Compaction",
+    );
+  });
+
   it("keeps legacy plugin dependency lint opt-in and read-only", async () => {
     const previousStateDir = process.env.OPENCLAW_STATE_DIR;
     const tempDir = fs.mkdtempSync(nodePath.join(os.tmpdir(), "openclaw-legacy-plugin-deps-lint-"));

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -7,6 +7,12 @@ import {
   isLegacyParentWritableUpdateDoctorPass,
   UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV,
 } from "../commands/doctor/shared/update-phase.js";
+import {
+  collectInactiveActiveTranscriptByteGuardWarnings,
+  INACTIVE_MAX_ACTIVE_TRANSCRIPT_BYTES_CHECK_ID,
+  INACTIVE_MAX_ACTIVE_TRANSCRIPT_BYTES_FIX_HINT,
+  INACTIVE_MAX_ACTIVE_TRANSCRIPT_BYTES_REQUIREMENT,
+} from "../config/compaction-warnings.js";
 import { resolveIsNixMode } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { buildGatewayConnectionDetails } from "../gateway/call.js";
@@ -954,6 +960,27 @@ async function runToolResultCapHealth(ctx: DoctorHealthFlowContext): Promise<voi
   if (lines.length > 0) {
     note(lines.join("\n"), "Tool result cap");
   }
+}
+
+function collectActiveTranscriptByteGuardFindings(cfg: OpenClawConfig): readonly HealthFinding[] {
+  return collectInactiveActiveTranscriptByteGuardWarnings(cfg).map((warning) => ({
+    checkId: INACTIVE_MAX_ACTIVE_TRANSCRIPT_BYTES_CHECK_ID,
+    severity: "warning",
+    message: warning.message,
+    path: warning.path,
+    target: "agents.defaults.compaction",
+    requirement: INACTIVE_MAX_ACTIVE_TRANSCRIPT_BYTES_REQUIREMENT,
+    fixHint: INACTIVE_MAX_ACTIVE_TRANSCRIPT_BYTES_FIX_HINT,
+  }));
+}
+
+async function runActiveTranscriptByteGuardHealth(ctx: DoctorHealthFlowContext): Promise<void> {
+  const warnings = collectInactiveActiveTranscriptByteGuardWarnings(ctx.cfg);
+  if (warnings.length === 0) {
+    return;
+  }
+  const { note } = await loadNoteModule();
+  note(warnings.map((warning) => `- ${warning.path}: ${warning.message}`).join("\n"), "Compaction");
 }
 
 async function runSystemdLingerHealth(ctx: DoctorHealthFlowContext): Promise<void> {
@@ -2011,6 +2038,17 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
         detect: async (ctx) => collectToolResultCapFindings(ctx.cfg),
       },
       run: runToolResultCapHealth,
+    }),
+    createDoctorHealthContribution({
+      id: "doctor:active-transcript-byte-guard",
+      label: "Active transcript byte guard",
+      healthChecks: {
+        id: INACTIVE_MAX_ACTIVE_TRANSCRIPT_BYTES_CHECK_ID,
+        description:
+          "Detect maxActiveTranscriptBytes settings that are inactive without transcript rotation.",
+        detect: async (ctx) => collectActiveTranscriptByteGuardFindings(ctx.cfg),
+      },
+      run: runActiveTranscriptByteGuardHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:provider-catalog-projection",


### PR DESCRIPTION
Closes #100529

AI-assisted: yes. I reviewed the change and understand the runtime behavior.

## What Problem This Solves

Fixes an issue where `agents.defaults.compaction.maxActiveTranscriptBytes` could validate successfully even when `truncateAfterCompaction` was not enabled, leaving the active-transcript byte guard inactive without an operator-facing warning.

## Why This Change Was Made

The config validator and Doctor now share a small detector that reports this accepted-but-inactive setting without changing runtime semantics.

## User Impact

Operators get an actionable warning instead of assuming the transcript byte guard is active, reducing silent no-op configuration around transcript growth controls.

## Evidence

- `pnpm exec oxfmt --check src/config/compaction-warnings.ts src/config/validation.ts src/config/config.compaction-settings.test.ts src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts` -> passed
- `node scripts/run-vitest.mjs src/config/config.compaction-settings.test.ts src/flows/doctor-health-contributions.test.ts` -> 2 shards, 99 tests passed
- `git diff --check` -> passed

Signed-off-by: Ho Lim <subhoya@gmail.com>
