### PR TITLE
fix(agent-core): skip prepared tool execution after abort

### DIFF
--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -1183,6 +1183,98 @@ describe("agentLoop tool termination", () => {
     expect(events.at(-1)).toMatchObject({ type: "agent_end" });
   });
 
+  it("does not execute a prepared parallel tool after a later tool aborts the batch", async () => {
+    const controller = new AbortController();
+    const paidExecute = vi.fn(async (): Promise<AgentToolResult<unknown>> => {
+      return {
+        content: [{ type: "text", text: "charged" }],
+        details: { charged: true },
+      };
+    });
+    const abortingExecute = vi.fn(async (): Promise<AgentToolResult<unknown>> => {
+      return {
+        content: [{ type: "text", text: "should not run" }],
+        details: {},
+      };
+    });
+    const paidTool: AgentTool = {
+      name: "paid_generation",
+      label: "paid_generation",
+      description: "Represents a paid side-effectful tool",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      execute: paidExecute,
+    };
+    const abortingTool: AgentTool = {
+      name: "abort_gate",
+      label: "abort_gate",
+      description: "Aborts during preparation",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      execute: abortingExecute,
+    };
+    const streamFn: StreamFn = () => {
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message = makeAssistantMessage([
+          { type: "toolCall", id: "call-paid", name: paidTool.name, arguments: {} },
+          { type: "toolCall", id: "call-abort", name: abortingTool.name, arguments: {} },
+        ]);
+        stream.push({ type: "done", reason: "toolUse", message });
+        stream.end();
+      });
+      return stream;
+    };
+    const events: AgentEvent[] = [];
+    const preparedToolNames: string[] = [];
+
+    const messages = await runAgentLoop(
+      [{ role: "user", content: "abort mid batch", timestamp: 1 }],
+      {
+        systemPrompt: "",
+        messages: [],
+        tools: [paidTool, abortingTool],
+      },
+      {
+        ...config,
+        beforeToolCall: async ({ toolCall }) => {
+          preparedToolNames.push(toolCall.name);
+          if (toolCall.name === abortingTool.name) {
+            await Promise.resolve();
+            controller.abort(new Error("user aborted"));
+          }
+          return undefined;
+        },
+      },
+      (event) => {
+        events.push(event);
+      },
+      controller.signal,
+      streamFn,
+    );
+
+    expect(preparedToolNames).toEqual([paidTool.name, abortingTool.name]);
+    expect(paidExecute).not.toHaveBeenCalled();
+    expect(abortingExecute).not.toHaveBeenCalled();
+    expect(messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+      "toolResult",
+      "assistant",
+    ]);
+    expect(messages.at(-1)).toMatchObject({ role: "assistant", stopReason: "aborted" });
+
+    const endEvents = events.filter(
+      (event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+        event.type === "tool_execution_end",
+    );
+    expect(
+      Object.fromEntries(endEvents.map((event) => [event.toolName, event.executionStarted])),
+    ).toEqual({
+      [paidTool.name]: false,
+      [abortingTool.name]: false,
+    });
+  });
+
   it("does not request another model turn when an async turn hook aborts the run", async () => {
     const controller = new AbortController();
     let streamCalls = 0;

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -793,6 +793,7 @@ type ImmediateToolCallOutcome = {
 type ExecutedToolCallOutcome = {
   result: AgentToolResult<unknown>;
   isError: boolean;
+  executionStarted: boolean;
 };
 
 type FinalizedToolCallOutcome = {
@@ -985,6 +986,16 @@ async function executePreparedToolCall(
   signal: AbortSignal | undefined,
   emit: AgentEventSink,
 ): Promise<ExecutedToolCallOutcome> {
+  // Parallel batches prepare calls before running them; an abort from a later
+  // preflight must not start an earlier prepared side-effectful tool.
+  if (signal?.aborted) {
+    return {
+      result: createErrorToolResult("Operation aborted"),
+      isError: true,
+      executionStarted: false,
+    };
+  }
+
   const updateEvents: Promise<void>[] = [];
   let acceptingUpdates = true;
 
@@ -1015,13 +1026,14 @@ async function executePreparedToolCall(
     );
     acceptingUpdates = false;
     await Promise.all(updateEvents);
-    return { result, isError: false };
+    return { result, isError: false, executionStarted: true };
   } catch (error) {
     acceptingUpdates = false;
     await Promise.all(updateEvents);
     return {
       result: createErrorToolResult(error instanceof Error ? error.message : String(error)),
       isError: true,
+      executionStarted: true,
     };
   } finally {
     acceptingUpdates = false;
@@ -1039,7 +1051,7 @@ async function finalizeExecutedToolCall(
   let result = executed.result;
   let isError = executed.isError;
 
-  if (config.afterToolCall) {
+  if (executed.executionStarted && config.afterToolCall) {
     try {
       const afterResult = await config.afterToolCall(
         {
@@ -1070,7 +1082,7 @@ async function finalizeExecutedToolCall(
     toolCall: prepared.toolCall,
     result,
     isError,
-    executionStarted: true,
+    executionStarted: executed.executionStarted,
     ...(prepared.tool.hideFromChannelProgress === true ? { hideFromChannelProgress: true } : {}),
   };
 }


### PR DESCRIPTION
Closes #102252

AI-assisted: yes. I reviewed the change and understand the runtime behavior.

## What Problem This Solves

Fixes an issue where a parallel tool batch could still execute a prepared paid or side-effectful tool after the run had already been aborted by another tool preflight.

## Why This Change Was Made

The tool loop now checks the abort signal immediately before `execute` and records `executionStarted: false` when execution is skipped, so `afterToolCall` is not invoked for work that never started.

## User Impact

Prevents cancelled runs from starting a prepared paid/side-effectful tool after abort, while preserving normal behavior for tools that already started before cancellation.

## Evidence

- `pnpm exec oxfmt --check packages/agent-core/src/agent-loop.ts packages/agent-core/src/agent-loop.test.ts` -> passed
- `node scripts/run-vitest.mjs packages/agent-core/src/agent-loop.test.ts` -> 1 file, 23 tests passed
- `git diff --check` -> passed

Signed-off-by: Ho Lim <subhoya@gmail.com>
