### PR TITLE
fix(agents): estimate precheck pressure after tool-result projection

### DIFF
--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts
@@ -266,14 +266,14 @@ describe("preemptive-compaction", () => {
       prompt: "continue",
     });
 
-    expect(estimatedPromptTokens).toBeGreaterThan(80_000);
+    expect(estimatedPromptTokens).toBeGreaterThan(40_000);
 
     const result = shouldPreemptivelyCompactBeforePrompt({
       messages,
       systemPrompt: "sys",
       prompt: "continue",
-      contextTokenBudget: 96_000,
-      reserveTokens: 20_000,
+      contextTokenBudget: 60_000,
+      reserveTokens: 10_000,
     });
 
     expect(result.route).not.toBe("fits");
@@ -300,9 +300,64 @@ describe("preemptive-compaction", () => {
     expect(estimatedPromptTokens).toBeGreaterThan(30_000);
   });
 
-  it("prechecks a regression-sized synthetic tool-heavy transcript as over budget", () => {
-    const toolResultCharsPerMessage = Math.ceil(427_000 / 120);
-    const generalCharsPerMessage = Math.ceil((503_000 - 427_000) / 121);
+  it("estimates projected tool-result history before routing mid-turn recovery", () => {
+    const messages: AgentMessage[] = [
+      makeAssistantHistory("prompt already in transcript"),
+      ...Array.from({ length: 20 }, (_, index) =>
+        makeToolResultMessage(
+          "t".repeat(40_000),
+          JSON.stringify({ index, payload: "p".repeat(80) }),
+        ),
+      ),
+    ];
+    const rawTranscriptEstimate = estimateLlmBoundaryTokenPressure({
+      messages,
+      systemPrompt: "system".repeat(200),
+      prompt: "",
+    });
+
+    const result = shouldPreemptivelyCompactBeforePrompt({
+      messages,
+      systemPrompt: "system".repeat(200),
+      prompt: "",
+      contextTokenBudget: 200_000,
+      reserveTokens: 50_000,
+      toolResultMaxChars: 16_000,
+    });
+
+    expect(rawTranscriptEstimate).toBeGreaterThan(result.promptBudgetBeforeReserve);
+    expect(result.pressureSource).toBe("projected_transcript_estimate");
+    expect(result.estimatedPromptTokens).toBeLessThan(result.promptBudgetBeforeReserve);
+    expect(result.route).toBe("fits");
+    expect(result.shouldCompact).toBe(false);
+    expect(result.overflowTokens).toBe(0);
+  });
+
+  it("does not use raw tool-result size to choose truncate-only after projection", () => {
+    const messages: AgentMessage[] = [
+      makeToolResultMessage("t".repeat(300_000)),
+      ...Array.from({ length: 10 }, () => makeAssistantHistory("h".repeat(50_000))),
+    ];
+
+    const result = shouldPreemptivelyCompactBeforePrompt({
+      messages,
+      prompt: "continue",
+      contextTokenBudget: 100_000,
+      reserveTokens: 20_000,
+      toolResultMaxChars: 16_000,
+    });
+
+    expect(result.pressureSource).toBe("projected_transcript_estimate");
+    expect(result.overflowTokens).toBeGreaterThan(0);
+    expect(result.toolResultReducibleChars).toBeGreaterThan(0);
+    expect(result.route).not.toBe("truncate_tool_results_only");
+    expect(result.route).toBe("compact_then_truncate");
+    expect(result.shouldCompact).toBe(true);
+  });
+
+  it("prechecks a genuinely oversized synthetic tool-heavy transcript as over budget", () => {
+    const toolResultCharsPerMessage = Math.ceil(1_000_000 / 120);
+    const generalCharsPerMessage = Math.ceil(300_000 / 121);
     const messages: AgentMessage[] = [];
     for (let index = 0; index < 241; index += 1) {
       if (index % 2 === 0) {
@@ -384,6 +439,10 @@ describe("preemptive-compaction", () => {
       prompt: "hello",
       contextTokenBudget: Math.max(contextTokenBudget, adjustedContextTokenBudget),
       reserveTokens,
+      llmBoundaryTokenPressure: {
+        estimatedPromptTokens,
+        source: "test_rendered_boundary",
+      },
     });
 
     expect(result.route).toBe("truncate_tool_results_only");
@@ -446,6 +505,10 @@ describe("preemptive-compaction", () => {
       prompt: "hello",
       contextTokenBudget: estimatedPromptTokens - desiredOverflowTokens + reserveTokens,
       reserveTokens,
+      llmBoundaryTokenPressure: {
+        estimatedPromptTokens,
+        source: "test_rendered_boundary",
+      },
     });
 
     expect(potential.oversizedReducibleChars).toBeGreaterThan(0);
@@ -474,6 +537,7 @@ describe("preemptive-compaction", () => {
       prompt: "continue",
       contextTokenBudget: 128_000,
       reserveTokens: 20_000,
+      toolResultMaxChars: 100_000,
     });
 
     expect(toolResultTokens).toBeGreaterThanOrEqual(assistantTokens);
@@ -517,7 +581,7 @@ describe("preemptive-compaction", () => {
     expect(aboveCutoff - belowCutoff).toBeLessThanOrEqual(2);
   });
 
-  it("keeps the conservative ratio for non-CJK tool results", () => {
+  it("uses the ordinary text ratio for non-CJK tool results", () => {
     const latinText = "alpha beta gamma delta epsilon ".repeat(1000);
     const toolResultTokens = estimateLlmBoundaryTokenPressure({
       messages: [makeToolResultMessage(latinText)],
@@ -530,8 +594,8 @@ describe("preemptive-compaction", () => {
       prompt: "continue",
     });
 
-    expect(toolResultTokens).toBeGreaterThan(assistantTokens * 1.5);
-    expect(toolResultTokens).toBeLessThan(assistantTokens * 2.5);
+    expect(toolResultTokens).toBeGreaterThanOrEqual(assistantTokens);
+    expect(toolResultTokens).toBeLessThan(assistantTokens * 1.1);
   });
 
   it("applies the CJK-aware ratio to JSON tool-result payloads", () => {

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
@@ -17,14 +17,16 @@ import {
   COMPACTION_SUMMARY_PREFIX,
   COMPACTION_SUMMARY_SUFFIX,
 } from "../../runtime/index.js";
-import { estimateToolResultReductionPotential } from "../tool-result-truncation.js";
+import {
+  estimateToolResultReductionPotential,
+  truncateOversizedToolResultsInMessages,
+} from "../tool-result-truncation.js";
 import type { PreemptiveCompactionRoute } from "./preemptive-compaction.types.js";
 
 export const PREEMPTIVE_OVERFLOW_ERROR_TEXT =
   "Context overflow: prompt too large for the model (precheck).";
 
 const ESTIMATED_CHARS_PER_TOKEN = 4;
-const TOOL_RESULT_CHARS_PER_TOKEN = 2;
 const JSON_PAYLOAD_CHARS_PER_TOKEN = 3;
 const MESSAGE_BOUNDARY_OVERHEAD_TOKENS = 12;
 const CONTENT_BLOCK_OVERHEAD_TOKENS = 6;
@@ -113,9 +115,7 @@ function estimateContentBlockTokenPressure(
 }
 
 function estimateToolResultStringTokenPressure(text: string): number {
-  const conservativeToolResultEstimate = Math.ceil(text.length / TOOL_RESULT_CHARS_PER_TOKEN);
-  const cjkAwareEstimate = estimateStringTokenPressure(text);
-  return Math.max(conservativeToolResultEstimate, cjkAwareEstimate);
+  return estimateStringTokenPressure(text);
 }
 
 function estimateToolResultJsonTokenPressure(value: unknown): number {
@@ -303,6 +303,45 @@ function normalizeLlmBoundaryTokenPressure(
   };
 }
 
+function estimateProjectedTranscriptTokenPressure(params: {
+  messages: AgentMessage[];
+  systemPrompt?: string;
+  prompt: string;
+  contextTokenBudget: number;
+  toolResultMaxChars?: number;
+}): {
+  estimatedPromptTokens: number;
+  projected: boolean;
+  messages: AgentMessage[];
+  projectedToolResultReducibleChars: number;
+} {
+  // Fallback transcript estimates must match the provider prompt projection;
+  // otherwise mid-turn recovery can fire on tool text the model will never see.
+  const projection = truncateOversizedToolResultsInMessages(
+    params.messages,
+    params.contextTokenBudget,
+    params.toolResultMaxChars,
+  );
+  const projected = projection.messages !== params.messages;
+  const projectedToolResultReducibleChars = projected
+    ? estimateToolResultReductionPotential({
+        messages: params.messages,
+        contextWindowTokens: params.contextTokenBudget,
+        maxCharsOverride: params.toolResultMaxChars,
+      }).maxReducibleChars
+    : 0;
+  return {
+    estimatedPromptTokens: estimateLlmBoundaryTokenPressure({
+      messages: projection.messages,
+      systemPrompt: params.systemPrompt,
+      prompt: params.prompt,
+    }),
+    projected,
+    messages: projection.messages,
+    projectedToolResultReducibleChars,
+  };
+}
+
 /**
  * Decides whether a run should compact before submitting the prompt, and
  * whether reducible tool results can avoid or follow compaction. Rendered LLM
@@ -319,30 +358,48 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
   llmBoundaryTokenPressure?: LlmBoundaryTokenPressure;
 }): PreemptiveCompactionDecision {
   let messagesForPressure = params.messages;
+  const contextTokenBudget = Math.max(1, Math.floor(params.contextTokenBudget));
   const llmBoundaryTokenPressure = normalizeLlmBoundaryTokenPressure(
     params.llmBoundaryTokenPressure,
   );
-  let estimatedPromptTokens =
-    llmBoundaryTokenPressure?.estimatedPromptTokens ??
-    estimateLlmBoundaryTokenPressure({
+  let estimatedPromptTokens: number;
+  let pressureSource: string;
+  let projectedToolResultReducibleChars = 0;
+  if (llmBoundaryTokenPressure) {
+    estimatedPromptTokens = llmBoundaryTokenPressure.estimatedPromptTokens;
+    pressureSource = llmBoundaryTokenPressure.source;
+  } else {
+    const transcriptPressure = estimateProjectedTranscriptTokenPressure({
       messages: params.messages,
       systemPrompt: params.systemPrompt,
       prompt: params.prompt,
+      contextTokenBudget,
+      toolResultMaxChars: params.toolResultMaxChars,
     });
-  let pressureSource = llmBoundaryTokenPressure?.source ?? "transcript_estimate";
+    estimatedPromptTokens = transcriptPressure.estimatedPromptTokens;
+    messagesForPressure = transcriptPressure.messages;
+    projectedToolResultReducibleChars = transcriptPressure.projectedToolResultReducibleChars;
+    pressureSource = transcriptPressure.projected
+      ? "projected_transcript_estimate"
+      : "transcript_estimate";
+  }
   if (params.unwindowedMessages && params.unwindowedMessages !== params.messages) {
-    const unwindowedEstimatedPromptTokens = estimateLlmBoundaryTokenPressure({
+    const unwindowedPressure = estimateProjectedTranscriptTokenPressure({
       messages: params.unwindowedMessages,
       systemPrompt: params.systemPrompt,
       prompt: params.prompt,
+      contextTokenBudget,
+      toolResultMaxChars: params.toolResultMaxChars,
     });
-    if (unwindowedEstimatedPromptTokens > estimatedPromptTokens) {
-      estimatedPromptTokens = unwindowedEstimatedPromptTokens;
-      messagesForPressure = params.unwindowedMessages;
-      pressureSource = "unwindowed_transcript_estimate";
+    if (unwindowedPressure.estimatedPromptTokens > estimatedPromptTokens) {
+      estimatedPromptTokens = unwindowedPressure.estimatedPromptTokens;
+      messagesForPressure = unwindowedPressure.messages;
+      projectedToolResultReducibleChars = unwindowedPressure.projectedToolResultReducibleChars;
+      pressureSource = unwindowedPressure.projected
+        ? "unwindowed_projected_transcript_estimate"
+        : "unwindowed_transcript_estimate";
     }
   }
-  const contextTokenBudget = Math.max(1, Math.floor(params.contextTokenBudget));
   const requestedReserveTokens = Math.max(0, Math.floor(params.reserveTokens));
   const minPromptBudget = Math.min(
     MIN_PROMPT_BUDGET_TOKENS,
@@ -357,7 +414,7 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
   const overflowTokens = Math.max(0, estimatedPromptTokens - promptBudgetBeforeReserve);
   const toolResultPotential = estimateToolResultReductionPotential({
     messages: messagesForPressure,
-    contextWindowTokens: params.contextTokenBudget,
+    contextWindowTokens: contextTokenBudget,
     maxCharsOverride: params.toolResultMaxChars,
   });
   const overflowChars = overflowTokens * ESTIMATED_CHARS_PER_TOKEN;
@@ -366,14 +423,18 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
     overflowChars + truncationBufferChars,
     Math.ceil(overflowChars * 1.5),
   );
-  const toolResultReducibleChars = toolResultPotential.maxReducibleChars;
+  const remainingToolResultReducibleChars = toolResultPotential.maxReducibleChars;
+  const toolResultReducibleChars =
+    projectedToolResultReducibleChars + remainingToolResultReducibleChars;
 
   let route: PreemptiveCompactionRoute = "fits";
   if (overflowTokens > 0) {
     // Choose truncate-only only when available reduction comfortably exceeds the overflow.
     if (toolResultReducibleChars <= 0) {
       route = "compact_only";
-    } else if (toolResultReducibleChars >= truncateOnlyThresholdChars) {
+    } else if (projectedToolResultReducibleChars > 0) {
+      route = "compact_then_truncate";
+    } else if (remainingToolResultReducibleChars >= truncateOnlyThresholdChars) {
       route = "truncate_tool_results_only";
     } else {
       route = "compact_then_truncate";

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
@@ -333,6 +333,7 @@ describe("installToolResultContextGuard", () => {
     const agent = makeGuardableAgent();
     const contextForNextCall = [
       makeUser("prompt already in history"),
+      makeAssistant("h".repeat(40_000)),
       makeToolResult("call_big", "x".repeat(80_000)),
     ];
 
@@ -353,6 +354,28 @@ describe("installToolResultContextGuard", () => {
       expect(typeof signal.request.overflowTokens).toBe("number");
       expect(typeof signal.request.toolResultReducibleChars).toBe("number");
     }
+  });
+
+  it("does not raise mid-turn precheck when provider-boundary tool-result projection fits", async () => {
+    const agent = makeGuardableAgent();
+    const contextForNextCall = [
+      makeUser("prompt already in history"),
+      ...Array.from({ length: 20 }, (_, index) =>
+        makeToolResult(`call_${index}`, "x".repeat(40_000)),
+      ),
+    ];
+
+    const transformed = await applyMidTurnPrecheckGuardToContext(agent, contextForNextCall, {
+      contextWindowTokens: 1_000_000,
+      contextTokenBudget: 200_000,
+      reserveTokens: 50_000,
+      toolResultMaxChars: 16_000,
+      prePromptMessageCount: 1,
+      systemPrompt: "system".repeat(200),
+    });
+
+    expect(transformed).toBe(contextForNextCall);
+    expect(getToolResultText(contextForNextCall[1])).toBe("x".repeat(40_000));
   });
 
   it("does not run mid-turn precheck when no new tool result was appended", async () => {
@@ -604,7 +627,11 @@ describe("installContextEngineLoopHook", () => {
       toolResultMaxChars: 16_000,
     });
 
-    const messages = [makeUser("first"), makeToolResult("call_1", "x".repeat(80_000))];
+    const messages = [
+      makeUser("first"),
+      makeAssistant("h".repeat(40_000)),
+      makeToolResult("call_1", "x".repeat(80_000)),
+    ];
 
     await expect(callTransform(agent, messages)).rejects.toBeInstanceOf(MidTurnPrecheckSignal);
     expect(engine.afterTurn).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Closes #101929

AI-assisted: yes. I reviewed the change and understand the runtime behavior.

## What Problem This Solves

Fixes an issue where mid-turn context-overflow precheck could estimate raw tool-result transcript text instead of the provider-boundary projection, causing false context-overflow recovery when the actual submitted prompt would fit.

## Why This Change Was Made

Fallback transcript estimates now run over the same projected tool-result history used at the LLM boundary. Route selection also avoids truncate-only recovery when projected history still exceeds budget after tool-result projection.

## User Impact

Reduces unnecessary compaction/truncation recovery for tool-heavy turns and aligns token pressure estimates with the prompt actually submitted to the model.

## Evidence

- `pnpm exec oxfmt --check src/agents/embedded-agent-runner/run/preemptive-compaction.ts src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts src/agents/embedded-agent-runner/tool-result-context-guard.test.ts` -> passed
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts src/agents/embedded-agent-runner/tool-result-context-guard.test.ts src/agents/embedded-agent-runner/tool-result-truncation.test.ts src/agents/embedded-agent-runner/run/preemptive-compaction.bashexec.test.ts src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts` -> 2 shards, 156 tests passed
- `git diff --check` -> passed

Signed-off-by: Ho Lim <subhoya@gmail.com>
