### PR TITLE
fix(realtime-transcription): preserve reconnect backoff attempts

### DIFF
--- a/src/realtime-transcription/websocket-session.test.ts
+++ b/src/realtime-transcription/websocket-session.test.ts
@@ -20,6 +20,7 @@ afterEach(async () => {
 
 async function createRealtimeServer(params?: {
   closeOnConnection?: boolean;
+  closeAfterInitialEventMs?: number;
   initialEvent?: unknown;
   initialText?: string;
   onUpgrade?: (headers: Record<string, string | string[] | undefined>) => void;
@@ -41,6 +42,11 @@ async function createRealtimeServer(params?: {
       }
       if (params?.initialEvent) {
         ws.send(JSON.stringify(params.initialEvent));
+        if (params.closeAfterInitialEventMs !== undefined) {
+          setTimeout(() => {
+            ws.close(1011, "flap after ready");
+          }, params.closeAfterInitialEventMs);
+        }
       }
       if (params?.initialText) {
         ws.send(params.initialText);
@@ -402,5 +408,52 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
     const closeError = requireFirstMockArg(onError, "pre-ready close error");
     expect(closeError).toBeInstanceOf(Error);
     expect(closeError.message).toBe("test realtime transcription connection closed before ready");
+  });
+
+  it("backs off and stops reconnecting when ready websocket sessions keep flapping", async () => {
+    const openedAt: number[] = [];
+    const onError = vi.fn();
+    const server = await createRealtimeServer({
+      closeAfterInitialEventMs: 1,
+      initialEvent: { type: "session.updated" },
+      onUpgrade: () => {
+        openedAt.push(Date.now());
+      },
+    });
+    const session = createRealtimeTranscriptionWebSocketSession<{ type?: string }>({
+      providerId: "test",
+      callbacks: { onError },
+      url: server.url,
+      maxReconnectAttempts: 3,
+      reconnectDelayMs: 20,
+      reconnectLimitMessage: "test realtime transcription reconnect limit reached",
+      onMessage: (event, transport) => {
+        if (event.type === "session.updated") {
+          transport.markReady();
+        }
+      },
+      sendAudio: (audio, transport) => {
+        transport.sendBinary(audio);
+      },
+    });
+
+    await session.connect();
+    await vi.waitFor(
+      () => {
+        expect(onError).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: "test realtime transcription reconnect limit reached",
+          }),
+        );
+      },
+      { timeout: 1000 },
+    );
+
+    expect(openedAt).toHaveLength(4);
+    const gaps = openedAt.slice(1).map((opened, index) => opened - openedAt[index]);
+    expect(gaps[0]).toBeGreaterThanOrEqual(15);
+    expect(gaps[1]).toBeGreaterThanOrEqual(35);
+    expect(gaps[2]).toBeGreaterThanOrEqual(70);
+    session.close();
   });
 });

--- a/src/realtime-transcription/websocket-session.ts
+++ b/src/realtime-transcription/websocket-session.ts
@@ -259,7 +259,6 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
         this.ws.on("open", () => {
           opened = true;
           this.connected = true;
-          this.reconnectAttempts = 0;
           this.captureLocalOpen();
           try {
             this.options.onOpen?.(this.transport);


### PR DESCRIPTION
## What Problem This Solves

Fixes #102251.

Realtime transcription websocket sessions reset `reconnectAttempts` every time a socket reaches the raw `open` event. A flapping upstream that opens, reaches provider readiness, and then drops can therefore reconnect forever at the base delay instead of consuming the configured reconnect cap.

## Why This Change Was Made

The reconnect cap and exponential delay both depend on `reconnectAttempts`, so the counter must not be reset by each reconnecting socket open. The session still resets the counter at the beginning of a new user-initiated `connect()` call, but ready-then-close flaps now keep consuming attempts until the configured limit is reached.

This stays in the shared websocket helper used by the bundled realtime transcription providers and does not change provider-specific APIs, configuration, or audio framing.

## User Impact

Users on OpenAI, Mistral, xAI, ElevenLabs, or Deepgram realtime transcription no longer get an unbounded reconnect loop when an upstream websocket repeatedly flaps after readiness. The session backs off and emits the existing reconnect-limit error after the configured attempt cap.

## Evidence

- Added a focused regression test with a real local `ws` `WebSocketServer`: each connection sends `{"type":"session.updated"}`, the provider path calls `transport.markReady()`, then the server closes the socket to simulate a ready-after-flap upstream.
- The regression asserts exactly one initial open plus three reconnects with growing delay lower bounds, then observes `test realtime transcription reconnect limit reached`.
- `PATH=/Users/xjch/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/xjch/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin node scripts/run-vitest.mjs src/realtime-transcription/websocket-session.test.ts`
  - PASS: 1 test file, 11 tests
- `PATH=/Users/xjch/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/xjch/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin node scripts/run-oxlint.mjs src/realtime-transcription/websocket-session.ts src/realtime-transcription/websocket-session.test.ts`
  - PASS
- `git diff --check`
  - PASS
- `pnpm check:changed -- src/realtime-transcription/websocket-session.ts src/realtime-transcription/websocket-session.test.ts`
  - BLOCKED before project checks: `scripts/crabbox-wrapper.mjs` reports `selected binary failed basic --version/--help sanity checks` for the local `crabbox` binary. The same tool-level failure occurs when invoking the wrapper directly.
