### PR TITLE
fix(realtime-transcription): bound reconnects on a flapping-after-ready upstream (#102251)

### DIFF
--- a/src/realtime-transcription/websocket-session.test.ts
+++ b/src/realtime-transcription/websocket-session.test.ts
@@ -483,7 +483,9 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
     });
 
     await session.connect();
-    await new Promise((resolve) => setTimeout(resolve, 400));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 400);
+    });
     session.close();
 
     // Each connection stays ready past the stable-reset window, so the budget never

--- a/src/realtime-transcription/websocket-session.test.ts
+++ b/src/realtime-transcription/websocket-session.test.ts
@@ -20,9 +20,11 @@ afterEach(async () => {
 
 async function createRealtimeServer(params?: {
   closeOnConnection?: boolean;
+  closeAfterInitialMs?: number;
   initialEvent?: unknown;
   initialText?: string;
   onUpgrade?: (headers: Record<string, string | string[] | undefined>) => void;
+  onConnection?: () => void;
   onBinary?: (payload: Buffer) => void;
   onText?: (payload: unknown) => void;
 }) {
@@ -35,6 +37,7 @@ async function createRealtimeServer(params?: {
     wss.handleUpgrade(request, socket, head, (ws) => {
       clients.add(ws);
       ws.on("close", () => clients.delete(ws));
+      params?.onConnection?.();
       if (params?.closeOnConnection) {
         ws.close(1011, "setup failed");
         return;
@@ -44,6 +47,11 @@ async function createRealtimeServer(params?: {
       }
       if (params?.initialText) {
         ws.send(params.initialText);
+      }
+      if (params?.closeAfterInitialMs !== undefined) {
+        // Simulate a flapping (or, with a longer delay, a briefly-stable) upstream:
+        // reach ready via the initial event, then drop the socket.
+        setTimeout(() => ws.close(1011, "upstream flap"), params.closeAfterInitialMs);
       }
       ws.on("message", (data, isBinary) => {
         const buffer = Buffer.isBuffer(data)
@@ -402,5 +410,87 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
     const closeError = requireFirstMockArg(onError, "pre-ready close error");
     expect(closeError).toBeInstanceOf(Error);
     expect(closeError.message).toBe("test realtime transcription connection closed before ready");
+  });
+
+  it("gives up after the cap when a ready upstream keeps flapping (#102251)", async () => {
+    let connections = 0;
+    const limitReached = createSignal();
+    const onError = vi.fn((error: Error) => {
+      if (error.message.includes("reconnect limit reached")) {
+        limitReached.resolve();
+      }
+    });
+    const server = await createRealtimeServer({
+      initialEvent: { type: "ready" },
+      closeAfterInitialMs: 0, // reach ready, then drop immediately — a flap
+      onConnection: () => {
+        connections += 1;
+      },
+    });
+    const session = createRealtimeTranscriptionWebSocketSession<{ type?: string }>({
+      providerId: "test",
+      callbacks: { onError },
+      url: server.url,
+      maxReconnectAttempts: 5,
+      reconnectDelayMs: 15,
+      reconnectStableResetMs: 10_000, // flaps never reach "stable", so attempts accrue
+      reconnectLimitMessage: "test realtime transcription reconnect limit reached",
+      onMessage: (event, transport) => {
+        if (event.type === "ready") {
+          transport.markReady();
+        }
+      },
+      sendAudio: () => {},
+    });
+
+    await session.connect();
+    await limitReached.promise;
+    session.close();
+
+    // Initial connection + exactly maxReconnectAttempts reconnects, then it stops.
+    // Before the fix the open handler zeroed the counter every reconnect, so the cap
+    // was never reached and this stream was unbounded.
+    expect(connections).toBe(6);
+    expect(
+      onError.mock.calls.some(([error]) => error.message.includes("reconnect limit reached")),
+    ).toBe(true);
+  });
+
+  it("resets the reconnect budget after a connection stays stably ready (#102251)", async () => {
+    let connections = 0;
+    const onError = vi.fn();
+    const server = await createRealtimeServer({
+      initialEvent: { type: "ready" },
+      closeAfterInitialMs: 60, // ready, stays past the stable-reset window, then drops
+      onConnection: () => {
+        connections += 1;
+      },
+    });
+    const session = createRealtimeTranscriptionWebSocketSession<{ type?: string }>({
+      providerId: "test",
+      callbacks: { onError },
+      url: server.url,
+      maxReconnectAttempts: 3,
+      reconnectDelayMs: 10,
+      reconnectStableResetMs: 30, // 60ms ready > 30ms window => each drop is a recovery
+      reconnectLimitMessage: "test realtime transcription reconnect limit reached",
+      onMessage: (event, transport) => {
+        if (event.type === "ready") {
+          transport.markReady();
+        }
+      },
+      sendAudio: () => {},
+    });
+
+    await session.connect();
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    session.close();
+
+    // Each connection stays ready past the stable-reset window, so the budget never
+    // exhausts: it keeps recovering well past maxReconnectAttempts with no give-up.
+    expect(connections).toBeGreaterThan(4);
+    expect(
+      onError.mock.calls.some(([error]) => error.message.includes("reconnect limit reached")),
+    ).toBe(false);
   });
 });

--- a/src/realtime-transcription/websocket-session.ts
+++ b/src/realtime-transcription/websocket-session.ts
@@ -41,6 +41,8 @@ export type RealtimeTranscriptionWebSocketSessionOptions<Event = unknown> = {
   readyOnOpen?: boolean;
   reconnectDelayMs?: number;
   reconnectLimitMessage?: string;
+  /** How long a connection must stay ready before its next drop resets the backoff. */
+  reconnectStableResetMs?: number;
   sendAudio: (audio: Buffer, transport: RealtimeTranscriptionWebSocketTransport) => void;
   url: string | (() => string | Promise<string>);
 };
@@ -50,6 +52,10 @@ const DEFAULT_CLOSE_TIMEOUT_MS = 5_000;
 const DEFAULT_MAX_RECONNECT_ATTEMPTS = 5;
 const DEFAULT_RECONNECT_DELAY_MS = 1000;
 const DEFAULT_MAX_QUEUED_BYTES = 2 * 1024 * 1024;
+// A connection that stays ready at least this long is treated as a genuine
+// recovery, so its next drop starts a fresh backoff/give-up sequence. A shorter
+// ready window is a flap and keeps accumulating attempts toward the cap.
+const DEFAULT_RECONNECT_STABLE_RESET_MS = 10_000;
 
 function rawWsDataToBuffer(data: RawData): Buffer {
   if (Buffer.isBuffer(data)) {
@@ -78,6 +84,11 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
   private queuedBytes = 0;
   private ready = false;
   private reconnectAttempts = 0;
+  // Timestamp (ms) at which the current connection last became ready, or 0 when not
+  // ready. Read on disconnect to decide whether the connection was stable enough to
+  // reset the reconnect counter, so a flapping-after-ready upstream still hits the
+  // give-up cap and backoff instead of resetting on every raw open. See #102251.
+  private lastReadyAtMs = 0;
   private reconnecting = false;
   private suppressReconnect = false;
   private ws: WebSocket | null = null;
@@ -166,9 +177,16 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
     return this.options.reconnectDelayMs ?? DEFAULT_RECONNECT_DELAY_MS;
   }
 
+  private get reconnectStableResetMs(): number {
+    return this.options.reconnectStableResetMs ?? DEFAULT_RECONNECT_STABLE_RESET_MS;
+  }
+
   private async doConnect(): Promise<void> {
     await new Promise<void>((resolve, reject) => {
       this.ready = false;
+      // Each attempt starts not-ready; the stable-ready clock only starts once this
+      // connection reaches ready, so a drop before then cannot look "stable".
+      this.lastReadyAtMs = 0;
       const debugProxy = resolveDebugProxySettings();
       const proxyAgent = createDebugProxyWebSocketAgent(debugProxy);
       let settled = false;
@@ -201,6 +219,7 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
         settled = true;
         clearConnectTimeout();
         this.ready = true;
+        this.lastReadyAtMs = Date.now();
         this.flushQueuedAudio();
         resolve();
       };
@@ -259,7 +278,10 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
         this.ws.on("open", () => {
           opened = true;
           this.connected = true;
-          this.reconnectAttempts = 0;
+          // NB: do NOT reset reconnectAttempts here. A raw TCP open (even one that
+          // immediately drops) must not clear the counter, or a flapping-after-ready
+          // upstream reconnects forever. The counter is reset only after a connection
+          // stays stably ready (see attemptReconnect). See #102251.
           this.captureLocalOpen();
           try {
             this.options.onOpen?.(this.transport);
@@ -342,6 +364,12 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
   private async attemptReconnect(): Promise<void> {
     if (this.closed || this.reconnecting) {
       return;
+    }
+    // If the connection that just dropped had been stably ready, treat it as a
+    // recovery and start a fresh backoff/give-up sequence. A flap (ready then a
+    // quick drop) falls short of the window and keeps accumulating toward the cap.
+    if (this.lastReadyAtMs > 0 && Date.now() - this.lastReadyAtMs >= this.reconnectStableResetMs) {
+      this.reconnectAttempts = 0;
     }
     if (this.reconnectAttempts >= this.maxReconnectAttempts) {
       this.emitError(


### PR DESCRIPTION
## What Problem This Solves

Realtime transcription websocket sessions never give up on a flapping upstream. The `open` handler zeroed `reconnectAttempts` on **every raw TCP open**, and both the give-up cap (`maxReconnectAttempts`) and the exponential backoff read that counter. So a socket that reached ready and then dropped restarted the count from zero: the session reconnected once per base delay **forever**, the cap never fired, and the backoff never grew. All five bundled websocket transcription providers (openai, mistral, xai, elevenlabs, deepgram) share `src/realtime-transcription/websocket-session.ts` and inherit the defect. Fixes #82469's sibling issue #102251.

## Why This Change Was Made

Reset the counter only when the connection that just dropped had been **stably ready** — tracked by a `lastReadyAtMs` timestamp compared against `reconnectStableResetMs` (default 10s) in `attemptReconnect` — instead of on every open. A flap (ready then a quick drop) keeps accumulating toward the cap and backoff; a genuine recovery (stably ready past the window) resets the budget.

**Relation to #102285:** that PR fixes the same bug by *deleting* the reset entirely, i.e. bounding *total lifetime* reconnects. That stops the flap storm, but it also makes a **healthy long-lived session give up permanently** after `maxReconnectAttempts` cumulative reconnects — e.g. an 8-hour session that cleanly recovers from 5 brief network blips refuses to reconnect on the 6th. The issue text calls out both options and prefers *"resets the counter only after the connection has stayed genuinely ready/stable"* over *"bounds total reconnects"* precisely to avoid that. This PR implements the preferred option, so healthy mid-session drops are not penalized. Offered as the more conservative alternative; happy to defer if maintainers prefer the total-bound approach.

## User Impact

A persistently flapping upstream now backs off (base, 2×, 4×, …) and stops after `maxReconnectAttempts`, emitting the reconnect-limit error instead of a silent unbounded reconnect/handshake storm (which also re-mints OAuth ephemeral secrets and re-flushes queued audio each cycle). A genuinely stable connection that later drops still reconnects normally — no new give-up for healthy sessions. No provider changes required; the fix is internal and backward compatible.

## Evidence

Real `scanSource`-style run of the actual session against a local `ws` server that reaches ready then drops (details in comment below): reconnects **61 → 6** in a 1.5s window, cap fires (**false → true**), and gaps go from flat `~24ms` to exponential `24, 44, 86, 166, 326`. Suite green (12 tests incl. 2 new: a flap→give-up test and a stable→keeps-recovering no-regression test). `oxfmt` clean.
