### PR TITLE
fix(gateway): refresh model availability after OAuth renewal

### DIFF
--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -8,7 +8,7 @@ import {
   resolveDefaultAgentId,
 } from "../../agents/agent-scope.js";
 import {
-  ensureAuthProfileStoreWithoutExternalProfiles,
+  loadAuthProfileStoreWithoutExternalProfiles,
   resolveAuthProfileOrder,
   type AuthProfileCredential,
   type AuthProfileStore,
@@ -170,10 +170,10 @@ function createModelsListProviderAuthChecker(params: {
   workspaceDir: string;
 }): ModelsListProviderAuthChecker {
   const agentDir = resolveAgentDir(params.cfg, params.agentId);
-  const store = ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+  // Auth refreshes can be persisted by another CLI process while the gateway
+  // keeps an older execution snapshot, so browse availability reads SQLite.
+  const store = loadAuthProfileStoreWithoutExternalProfiles(agentDir, {
     allowKeychainPrompt: false,
-    readOnly: true,
-    syncExternalCli: false,
   });
   return createInFlightProviderAuthChecker(
     (provider, modelApi) =>

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -2,6 +2,10 @@
 // validation errors, and protocol response shapes.
 import { describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  replaceRuntimeAuthProfileStoreSnapshots,
+} from "../../agents/auth-profiles.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createDeferred } from "../../test-utils/deferred.js";
 import { withEnvAsync } from "../../test-utils/env.js";
@@ -20,6 +24,21 @@ const withoutOpenAIEnvAuth = async <T>(run: () => Promise<T>): Promise<T> =>
     },
     run,
   );
+
+function createDemoOAuthStore(params: { access: string; expires: number }) {
+  return {
+    version: 1 as const,
+    profiles: {
+      "demo-provider:oauth": {
+        type: "oauth" as const,
+        provider: "demo-provider",
+        access: params.access,
+        refresh: "refresh-token",
+        expires: params.expires,
+      },
+    },
+  };
+}
 
 function requestModelsList(params: {
   view: "configured" | "all";
@@ -488,18 +507,12 @@ describe("models.list", () => {
         agentEnv: "main",
       },
       async (state) => {
-        await state.writeAuthProfiles({
-          version: 1,
-          profiles: {
-            "demo-provider:expired": {
-              type: "oauth",
-              provider: "demo-provider",
-              access: "expired-access",
-              refresh: "refresh-token",
-              expires: Date.now() - 60_000,
-            },
-          },
-        });
+        await state.writeAuthProfiles(
+          createDemoOAuthStore({
+            access: "expired-access",
+            expires: Date.now() - 60_000,
+          }),
+        );
 
         const { request, respond } = requestModelsList({
           view: "all",
@@ -524,6 +537,64 @@ describe("models.list", () => {
           },
           undefined,
         );
+      },
+    );
+  });
+
+  it("uses refreshed persisted OAuth when the runtime auth snapshot is stale", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-models-list-stale-runtime-profile-",
+        agentEnv: "main",
+      },
+      async (state) => {
+        const agentDir = state.agentDir();
+        await state.writeAuthProfiles(
+          createDemoOAuthStore({
+            access: "refreshed-access",
+            expires: Date.now() + 60 * 60_000,
+          }),
+        );
+        replaceRuntimeAuthProfileStoreSnapshots([
+          {
+            agentDir,
+            store: createDemoOAuthStore({
+              access: "expired-access",
+              expires: Date.now() - 60_000,
+            }),
+          },
+        ]);
+
+        try {
+          const { request, respond } = requestModelsList({
+            view: "all",
+            loadGatewayModelCatalog: vi.fn(() =>
+              Promise.resolve([
+                { id: "demo-model", name: "Demo Model", provider: "demo-provider" },
+              ]),
+            ),
+            reqId: "req-models-list-stale-runtime-profile",
+          });
+          await request;
+
+          expect(respond).toHaveBeenCalledWith(
+            true,
+            {
+              models: [
+                {
+                  id: "demo-model",
+                  name: "Demo Model",
+                  provider: "demo-provider",
+                  available: true,
+                },
+              ],
+            },
+            undefined,
+          );
+        } finally {
+          clearRuntimeAuthProfileStoreSnapshots();
+        }
       },
     );
   });


### PR DESCRIPTION
## Summary

- Read persisted auth profiles when computing gateway model availability so OAuth refreshes performed by another CLI process are visible without restarting the gateway.
- Keep model browsing read-only and preserve process-local auth snapshots for prepared agent execution.
- Add regression coverage for a fresh persisted OAuth credential paired with a stale runtime snapshot.

## Verification

- `node scripts/run-vitest.mjs src/gateway/server-methods/models.test.ts --reporter=verbose`
- `node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat-b.test.ts -t "chat.metadata coalesces configured models and text commands" --reporter=verbose`
- `node_modules/.bin/oxfmt --write src/gateway/server-methods/models-list-result.ts src/gateway/server-methods/models.test.ts`
- `git diff --check`
- AWS Crabbox `pnpm check:changed --base b81666ca6af25c86cc099983a4358cdc5ea9ced8`
  - lease: `cbx_1f05b0e6e357`
  - run: `run_8d4a5fccd4f6`
- Codex autoreview: clean, no accepted/actionable findings

## Real behavior proof

Behavior addressed: Control UI model rows remain unavailable after OAuth is refreshed by a separate CLI process because `chat.metadata` reads a stale gateway runtime snapshot.

Real environment tested: macOS source checkout for focused Gateway RPC tests and AWS Linux Crabbox for the exact-base changed gate.

Exact steps or command run after this patch: Ran the focused `models.list` regression suite, the real `chat.metadata` Gateway RPC test, and exact-base `pnpm check:changed`.

Evidence after fix: The regression stores fresh OAuth in SQLite, installs an expired process-local snapshot, and receives `available: true`; the `chat.metadata` RPC test also passes.

Observed result after fix: Model availability follows the refreshed persisted credential without mutating or refreshing the gateway execution snapshot.

What was not tested: A live xAI OAuth refresh against a packaged patched gateway; the provider-independent stale-snapshot contract and the Control UI metadata RPC path were exercised directly.
