### PR TITLE
fix(telegram): label cached outbound messages as self

### DIFF
--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -51,7 +51,7 @@ import {
 import { resolveTelegramTransport } from "./fetch.js";
 import { resolveTelegramScopedGroupConfig } from "./group-config-helpers.js";
 import {
-  buildTelegramGroupHistorySelfSender,
+  buildTelegramHistorySelfSender,
   recordTelegramGroupHistoryEntry,
 } from "./group-history-window.js";
 import { TELEGRAM_TEXT_CHUNK_LIMIT } from "./outbound-adapter.js";
@@ -264,7 +264,7 @@ export function createTelegramBotCore(
       DEFAULT_GROUP_HISTORY_LIMIT,
   );
   const groupHistories = new Map<string, HistoryEntry[]>();
-  const botHistorySender = buildTelegramGroupHistorySelfSender(
+  const botHistorySender = buildTelegramHistorySelfSender(
     account.name ?? opts.botInfo?.first_name ?? opts.botInfo?.username ?? "OpenClaw",
   );
   const unregisterOutboundGroupHistoryRecorder = registerTelegramOutboundGroupHistoryRecorder({

--- a/extensions/telegram/src/bot-message-context.require-mention.test.ts
+++ b/extensions/telegram/src/bot-message-context.require-mention.test.ts
@@ -24,7 +24,7 @@ vi.mock("openclaw/plugin-sdk/runtime-config-snapshot", async () => {
 
 const { buildTelegramMessageContextForTest } =
   await import("./bot-message-context.test-harness.js");
-const { buildTelegramGroupHistorySelfSender } = await import("./group-history-window.js");
+const { buildTelegramHistorySelfSender } = await import("./group-history-window.js");
 
 describe("buildTelegramMessageContext requireMention precedence", () => {
   function buildForumMessage(threadId = 99) {
@@ -309,7 +309,7 @@ describe("buildTelegramMessageContext requireMention precedence", () => {
         [
           { sender: "Alice", body: "before self marker", timestamp: 1, messageId: "1" },
           {
-            sender: buildTelegramGroupHistorySelfSender("OpenClaw"),
+            sender: buildTelegramHistorySelfSender("OpenClaw"),
             body: "self marker body",
             timestamp: 2,
             messageId: "2",

--- a/extensions/telegram/src/group-history-window.ts
+++ b/extensions/telegram/src/group-history-window.ts
@@ -7,7 +7,7 @@ import type {
 
 const TELEGRAM_GROUP_HISTORY_SELF_SUFFIX = " (you)";
 
-export function buildTelegramGroupHistorySelfSender(name: string): string {
+export function buildTelegramHistorySelfSender(name: string): string {
   return `${name}${TELEGRAM_GROUP_HISTORY_SELF_SUFFIX}`;
 }
 

--- a/extensions/telegram/src/outbound-message-context.test.ts
+++ b/extensions/telegram/src/outbound-message-context.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { buildOutboundCacheMessage } from "./outbound-message-context.js";
+
+describe("buildOutboundCacheMessage", () => {
+  it("uses the configured self identity instead of the Telegram profile name", () => {
+    const cacheMessage = buildOutboundCacheMessage({
+      account: { accountId: "default", name: "Configured Agent" },
+      chatId: 42,
+      message: {
+        chat: { id: 42, type: "private" },
+        date: 1_736_380_700,
+        from: { id: 999, is_bot: true, first_name: "Provisioning Placeholder" },
+        message_id: 700,
+        text: "Bot just replied",
+      },
+      messageId: 700,
+      text: "Bot just replied",
+    });
+
+    expect(cacheMessage.from).toEqual({
+      id: 999,
+      is_bot: true,
+      first_name: "Configured Agent (you)",
+    });
+  });
+});

--- a/extensions/telegram/src/outbound-message-context.ts
+++ b/extensions/telegram/src/outbound-message-context.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-payload";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import { buildTelegramHistorySelfSender } from "./group-history-window.js";
 import { createTelegramMessageCache, resolveTelegramMessageCacheScope } from "./message-cache.js";
 
 type TelegramPromptContextChannelData = {
@@ -98,7 +99,7 @@ function inferTelegramChatType(chatId: string | number): "private" | "supergroup
   return String(chatId).startsWith("-") ? "supergroup" : "private";
 }
 
-function buildOutboundCacheMessage(params: {
+export function buildOutboundCacheMessage(params: {
   account: TelegramOutboundPromptContextAccount;
   chatId: string | number;
   message: TelegramOutboundPromptContextMessage;
@@ -109,6 +110,10 @@ function buildOutboundCacheMessage(params: {
 }): TelegramOutboundPromptContextMessage {
   const chat = params.message.chat ?? {};
   const text = params.message.text ?? params.message.caption ?? params.text;
+  const rawSender = params.message.from;
+  const selfSender = buildTelegramHistorySelfSender(
+    params.account.name ?? rawSender?.first_name ?? rawSender?.username ?? "OpenClaw",
+  );
   return {
     ...params.message,
     message_id: params.messageId,
@@ -125,10 +130,11 @@ function buildOutboundCacheMessage(params: {
       ...(chat.title ? { title: chat.title } : {}),
       ...(chat.username ? { username: chat.username } : {}),
     },
-    from: params.message.from ?? {
-      id: 0,
+    from: {
+      ...rawSender,
+      id: rawSender?.id ?? 0,
       is_bot: true,
-      first_name: params.account.name ?? "OpenClaw",
+      first_name: selfSender,
     },
     ...(text ? { text } : {}),
     ...(params.messageThreadId !== undefined ? { message_thread_id: params.messageThreadId } : {}),


### PR DESCRIPTION
## What Problem This Solves

Fixes #102267. Telegram DM chat-window recaps could label an agent own earlier reply with the raw Bot API profile name, making self-authored text look like an unrelated participant.

## Why This Change Was Made

Outbound prompt-context messages are known to be bot-authored, but their cached sender previously preferred the Telegram send response from fields. The shared outbound cache builder now preserves the bot id and username while replacing the display name with the configured account identity plus the existing (you) marker. The group-only helper was renamed to reflect its shared history identity contract.

## User Impact

Telegram agents can recognize their own cached replies in direct-message recaps. Provisioning placeholders or stale Telegram profile names no longer leak into model-facing conversation context as apparent third-party senders. Group history keeps the same self-label behavior.

## Evidence

- Reporter live Telegram DM proof: https://github.com/openclaw/openclaw/issues/102267#issuecomment-4918258057
- Regression: node scripts/run-vitest.mjs extensions/telegram/src/outbound-message-context.test.ts extensions/telegram/src/bot-message-context.require-mention.test.ts (2 files, 14 tests passed)
- Static: node scripts/run-oxlint.mjs on all five changed files (passed)
- git diff --check (passed)
- Broader local bot.test.ts: 95/96 passed; the unrelated plugin-owned callback policy test failed and reproduces when run alone. GitHub CI is the clean exact-head authority for that existing failure.