### PR TITLE
fix(cron): persist startup catch-up deferrals

### DIFF
--- a/src/cron/public-job.ts
+++ b/src/cron/public-job.ts
@@ -1,0 +1,25 @@
+/** Public cron job projections shared by Gateway reads, events, and hooks. */
+import type { CronEvent } from "./service.js";
+import type { CronJob } from "./types.js";
+
+export function publicCronJobState(job: Pick<CronJob, "state">): CronJob["state"] {
+  const { pendingCatchupDeferral: _pendingCatchupDeferral, ...state } = job.state;
+  return state;
+}
+
+export function publicCronJobSnapshot(job: CronJob): CronJob {
+  return {
+    ...job,
+    state: publicCronJobState(job),
+  };
+}
+
+export function publicCronEventSnapshot(evt: CronEvent): CronEvent {
+  if (!evt.job) {
+    return evt;
+  }
+  return {
+    ...evt,
+    job: publicCronJobSnapshot(evt.job),
+  };
+}

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -821,7 +821,6 @@ function createMockState(now: number, opts?: { defaultAgentId?: string }): CronS
       nowMs: () => now,
       defaultAgentId: opts?.defaultAgentId,
     },
-    pendingCatchupDeferralJobIds: new Set<string>(),
   } as unknown as CronServiceState;
 }
 
@@ -1308,18 +1307,16 @@ describe("recomputeNextRuns", () => {
       sessionTarget: "main",
       wakeMode: "now",
       payload: { kind: "systemEvent", text: "tick" },
-      state: { nextRunAtMs: deferred },
+      state: { nextRunAtMs: deferred, pendingCatchupDeferral: true },
     };
-    const pendingCatchupDeferralJobIds = new Set([job.id]);
     const state = {
       ...createMockState(now),
-      pendingCatchupDeferralJobIds,
       store: { version: 1 as const, jobs: [job] },
     } as CronServiceState;
 
     expect(recomputeNextRunsForMaintenance(state)).toBe(false);
     expect(job.state.nextRunAtMs).toBe(deferred);
-    expect(pendingCatchupDeferralJobIds.has(job.id)).toBe(true);
+    expect(job.state.pendingCatchupDeferral).toBe(true);
 
     expect(
       recomputeNextRunsForMaintenance(state, {
@@ -1327,11 +1324,11 @@ describe("recomputeNextRuns", () => {
         repairFutureCronNextRunAtMs: true,
       }),
     ).toBe(true);
-    expect(pendingCatchupDeferralJobIds.has(job.id)).toBe(false);
+    expect(job.state.pendingCatchupDeferral).toBeUndefined();
     expect(job.state.nextRunAtMs).toBe(deferred);
   });
 
-  it("drops startup catch-up deferral ids for jobs no longer relevant to maintenance", () => {
+  it("drops startup catch-up deferrals for disabled jobs", () => {
     const now = Date.parse("2026-05-05T12:00:00.000Z");
     const deferred = Date.parse("2026-05-05T12:02:00.000Z");
     const disabledJob: CronJob = {
@@ -1344,18 +1341,40 @@ describe("recomputeNextRuns", () => {
       sessionTarget: "main",
       wakeMode: "now",
       payload: { kind: "systemEvent", text: "tick" },
-      state: { nextRunAtMs: deferred },
+      state: { nextRunAtMs: deferred, pendingCatchupDeferral: true },
     };
-    const pendingCatchupDeferralJobIds = new Set([disabledJob.id, "removed-deferral"]);
     const state = {
       ...createMockState(now),
-      pendingCatchupDeferralJobIds,
       store: { version: 1 as const, jobs: [disabledJob] },
     } as CronServiceState;
 
     expect(recomputeNextRunsForMaintenance(state)).toBe(true);
-    expect([...pendingCatchupDeferralJobIds]).toEqual([]);
+    expect(disabledJob.state.pendingCatchupDeferral).toBeUndefined();
     expect(disabledJob.state.nextRunAtMs).toBeUndefined();
+  });
+
+  it("drops a startup catch-up deferral with no deferred slot", () => {
+    const now = Date.parse("2026-05-05T12:00:00.000Z");
+    const job: CronJob = {
+      id: "missing-startup-deferral-slot",
+      name: "missing startup deferral slot",
+      enabled: true,
+      createdAtMs: Date.parse("2026-05-05T00:00:00.000Z"),
+      updatedAtMs: Date.parse("2026-05-05T00:00:00.000Z"),
+      schedule: { kind: "cron", expr: "0 0 21 * * *", tz: "Asia/Shanghai", staggerMs: 0 },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "tick" },
+      state: { pendingCatchupDeferral: true },
+    };
+    const state = {
+      ...createMockState(now),
+      store: { version: 1 as const, jobs: [job] },
+    } as CronServiceState;
+
+    expect(recomputeNextRunsForMaintenance(state)).toBe(true);
+    expect(job.state.pendingCatchupDeferral).toBeUndefined();
+    expect(job.state.nextRunAtMs).toBeGreaterThan(now);
   });
 
   it("preserves cron retry backoff nextRunAtMs values during maintenance", () => {

--- a/src/cron/service.startup-overflow-clobber.test.ts
+++ b/src/cron/service.startup-overflow-clobber.test.ts
@@ -121,9 +121,7 @@ describe("CronService startup catch-up repair scoping", () => {
     await start(firstState);
 
     const deferredSlot = startNow + 5_000;
-    expect(
-      firstState.store?.jobs.find((job) => job.id === "daily-overflow")?.state,
-    ).toMatchObject({
+    expect(firstState.store?.jobs.find((job) => job.id === "daily-overflow")?.state).toMatchObject({
       nextRunAtMs: deferredSlot,
       pendingCatchupDeferral: true,
     });
@@ -136,9 +134,7 @@ describe("CronService startup catch-up repair scoping", () => {
     const restartedState = createState();
     await start(restartedState);
 
-    const afterRestart = restartedState.store?.jobs.find(
-      (job) => job.id === "daily-overflow",
-    );
+    const afterRestart = restartedState.store?.jobs.find((job) => job.id === "daily-overflow");
     expect(afterRestart?.state).toMatchObject({
       nextRunAtMs: deferredSlot,
       pendingCatchupDeferral: true,
@@ -147,9 +143,7 @@ describe("CronService startup catch-up repair scoping", () => {
     now = deferredSlot + 5;
     await onTimer(restartedState);
 
-    const completed = restartedState.store?.jobs.find(
-      (job) => job.id === "daily-overflow",
-    );
+    const completed = restartedState.store?.jobs.find((job) => job.id === "daily-overflow");
     expect(completed?.state.lastRunStatus).toBe("ok");
     expect(completed?.state.pendingCatchupDeferral).toBeUndefined();
 

--- a/src/cron/service.startup-overflow-clobber.test.ts
+++ b/src/cron/service.startup-overflow-clobber.test.ts
@@ -76,7 +76,7 @@ describe("CronService startup catch-up repair scoping", () => {
 
     expect(deferred?.state.nextRunAtMs).toBe(startNow + 5_000);
     expect(deferred?.state.nextRunAtMs).not.toBe(tomorrowNaturalSlot);
-    expect(state.pendingCatchupDeferralJobIds.has("daily-overflow")).toBe(true);
+    expect(deferred?.state.pendingCatchupDeferral).toBe(true);
 
     await status(state);
     expect(deferred?.state.nextRunAtMs).toBe(startNow + 5_000);
@@ -87,9 +87,73 @@ describe("CronService startup catch-up repair scoping", () => {
     const completed = state.store?.jobs.find((job) => job.id === "daily-overflow");
     expect(completed?.state.lastRunStatus).toBe("ok");
     expect(completed?.state.nextRunAtMs).toBe(tomorrowNaturalSlot);
-    expect(state.pendingCatchupDeferralJobIds.has("daily-overflow")).toBe(false);
+    expect(completed?.state.pendingCatchupDeferral).toBeUndefined();
 
     state.stopped = true;
+    await store.cleanup();
+  });
+
+  it("keeps an overflow catch-up deferral across a second restart", async () => {
+    const store = await makeStorePath();
+    const startNow = Date.parse("2025-12-13T17:00:00.000Z");
+    let now = startNow;
+    const jobs = [
+      createHourlyCronJob("hourly-0", Date.parse("2025-12-13T03:00:00.000Z")),
+      createHourlyCronJob("hourly-1", Date.parse("2025-12-13T04:00:00.000Z")),
+      createHourlyCronJob("hourly-2", Date.parse("2025-12-13T05:00:00.000Z")),
+      createHourlyCronJob("hourly-3", Date.parse("2025-12-13T06:00:00.000Z")),
+      createHourlyCronJob("hourly-4", Date.parse("2025-12-13T07:00:00.000Z")),
+      createDailyCronJob("daily-overflow", Date.parse("2025-12-13T09:00:00.000Z")),
+    ];
+    await saveCronStore(store.storePath, { version: 1, jobs });
+
+    const createState = () =>
+      createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+      });
+    const firstState = createState();
+    await start(firstState);
+
+    const deferredSlot = startNow + 5_000;
+    expect(
+      firstState.store?.jobs.find((job) => job.id === "daily-overflow")?.state,
+    ).toMatchObject({
+      nextRunAtMs: deferredSlot,
+      pendingCatchupDeferral: true,
+    });
+    if (firstState.timer) {
+      clearTimeout(firstState.timer);
+    }
+    firstState.stopped = true;
+
+    now = startNow + 3_000;
+    const restartedState = createState();
+    await start(restartedState);
+
+    const afterRestart = restartedState.store?.jobs.find(
+      (job) => job.id === "daily-overflow",
+    );
+    expect(afterRestart?.state).toMatchObject({
+      nextRunAtMs: deferredSlot,
+      pendingCatchupDeferral: true,
+    });
+
+    now = deferredSlot + 5;
+    await onTimer(restartedState);
+
+    const completed = restartedState.store?.jobs.find(
+      (job) => job.id === "daily-overflow",
+    );
+    expect(completed?.state.lastRunStatus).toBe("ok");
+    expect(completed?.state.pendingCatchupDeferral).toBeUndefined();
+
+    restartedState.stopped = true;
     await store.cleanup();
   });
 

--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -239,7 +239,6 @@ export function createMockCronStateForJobs(params: {
     schedulingPaused: false,
     schedulerStarted: false,
     restartRecoveryPending: false,
-    pendingCatchupDeferralJobIds: new Set<string>(),
     activeManualRunJobIds: new Set<string>(),
     manualSetupTimeoutNotified: false,
     timer: null,

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -590,6 +590,10 @@ function normalizeJobTickState(params: { state: CronServiceState; job: CronJob; 
   }
 
   if (!isJobEnabled(job)) {
+    if (job.state.pendingCatchupDeferral !== undefined) {
+      job.state.pendingCatchupDeferral = undefined;
+      changed = true;
+    }
     if (job.state.nextRunAtMs !== undefined) {
       job.state.nextRunAtMs = undefined;
       changed = true;
@@ -737,19 +741,6 @@ export function recomputeNextRunsForMaintenance(
       nowMs,
       deferredAutoDisableNotifications: opts?.deferredAutoDisableNotifications,
     });
-  const deferralIds = state.pendingCatchupDeferralJobIds;
-  // Drop deferral markers for jobs that no longer exist in the store or
-  // are disabled. They will not fire, so no deferral is needed.
-  if (state.store && deferralIds.size > 0) {
-    const relevantDeferralIds = new Set(
-      state.store.jobs.filter((job) => isJobEnabled(job)).map((job) => job.id),
-    );
-    for (const jobId of deferralIds) {
-      if (!relevantDeferralIds.has(jobId)) {
-        deferralIds.delete(jobId);
-      }
-    }
-  }
   return walkSchedulableJobs(
     state,
     ({ job, nowMs: now }) => {
@@ -757,10 +748,10 @@ export function recomputeNextRunsForMaintenance(
 
       // Clear stale deferral markers once the deferred staggered slot arrives.
       // After the slot fires, future repair is safe for this job again.
-      if (deferralIds.has(job.id)) {
+      if (job.state.pendingCatchupDeferral === true) {
         const nextRun = job.state.nextRunAtMs;
-        if (hasScheduledNextRunAtMs(nextRun) && now >= nextRun) {
-          deferralIds.delete(job.id);
+        if (!hasScheduledNextRunAtMs(nextRun) || now >= nextRun) {
+          job.state.pendingCatchupDeferral = undefined;
           changed = true;
         }
       }
@@ -771,7 +762,7 @@ export function recomputeNextRunsForMaintenance(
         }
       } else if (
         repairFutureCronNextRunAtMs &&
-        !deferralIds.has(job.id) &&
+        job.state.pendingCatchupDeferral !== true &&
         shouldRepairFutureCronNextRunAtMs({ state, job, nowMs: now })
       ) {
         if (recomputeJob(job, now)) {

--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -1217,13 +1217,13 @@ describe("cron service ops persist rollback", () => {
     if (state.timer) {
       clearTimeout(state.timer);
     }
-    state.pendingCatchupDeferralJobIds.add(job.id);
+    job.state.pendingCatchupDeferral = true;
 
     vi.spyOn(cronStoreModule, "saveCronJobsStore").mockRejectedValueOnce(new Error("disk full"));
 
     await expect(remove(state, job.id)).rejects.toThrow("disk full");
 
-    expect(state.pendingCatchupDeferralJobIds.has(job.id)).toBe(true);
+    expect(state.store?.jobs[0]?.state.pendingCatchupDeferral).toBe(true);
     expect(state.store?.jobs.map((entry) => entry.id)).toEqual([job.id]);
   });
 

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -211,9 +211,6 @@ export type CronServiceState = {
   schedulingPaused: boolean;
   schedulerStarted: boolean;
   restartRecoveryPending: boolean;
-  /** Prevents maintenance reads from advancing deferred startup catch-up slots.
-   * Entries are removed when the deferred job runs or becomes irrelevant. */
-  pendingCatchupDeferralJobIds: Set<string>;
   activeManualRunJobIds: Set<string>;
   manualSetupTimeoutNotified: boolean;
   /** Serializes mutating service operations so store writes and timers stay ordered. */
@@ -241,7 +238,6 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
     schedulingPaused: false,
     schedulerStarted: false,
     restartRecoveryPending: false,
-    pendingCatchupDeferralJobIds: new Set<string>(),
     activeManualRunJobIds: new Set<string>(),
     manualSetupTimeoutNotified: false,
     op: Promise.resolve(),

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -22,7 +22,6 @@ type PersistOptions = {
 export type CronRollbackSnapshot = {
   store: CronStoreFile | null;
   durableNextRunAtMsByJobId: Map<string, number | undefined>;
-  pendingCatchupDeferralJobIds: Set<string>;
 };
 
 function durableNextRunsFromJobs(jobs: readonly CronJob[]) {
@@ -305,7 +304,6 @@ export function snapshotStoreForRollback(state: CronServiceState): CronRollbackS
   return {
     store: state.store ? structuredClone(state.store) : null,
     durableNextRunAtMsByJobId: new Map(state.durableNextRunAtMsByJobId),
-    pendingCatchupDeferralJobIds: new Set(state.pendingCatchupDeferralJobIds),
   };
 }
 
@@ -332,7 +330,6 @@ export async function persistOrRestore(
   } catch (err) {
     state.store = snapshot.store;
     state.durableNextRunAtMsByJobId = snapshot.durableNextRunAtMsByJobId;
-    state.pendingCatchupDeferralJobIds = snapshot.pendingCatchupDeferralJobIds;
     throw err;
   }
   for (const notify of opts.postPersistAutoDisableNotifications ?? []) {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1169,8 +1169,8 @@ function applyOutcomeToStoredJob(
       endedAt: result.endedAt,
       triggerEval: result.triggerEval,
     });
-    state.pendingCatchupDeferralJobIds.delete(job.id);
-    return undefined;
+    job.state.pendingCatchupDeferral = undefined;
+    return;
   }
 
   const shouldDelete = applyJobResult(state, job, {
@@ -1184,7 +1184,7 @@ function applyOutcomeToStoredJob(
     endedAt: result.endedAt,
   });
   applyTriggerRunResult(job, result);
-  state.pendingCatchupDeferralJobIds.delete(job.id);
+  job.state.pendingCatchupDeferral = undefined;
 
   emitJobFinished(state, job, result, result.startedAt);
 
@@ -2023,12 +2023,12 @@ async function applyStartupCatchupOutcomes(
           }
           if (typeof deferred.delayMs === "number") {
             job.state.nextRunAtMs = baseNow + deferred.delayMs + offset - staggerMs;
-            state.pendingCatchupDeferralJobIds.add(jobId);
+            job.state.pendingCatchupDeferral = true;
             offset += staggerMs;
             continue;
           }
           job.state.nextRunAtMs = baseNow + offset;
-          state.pendingCatchupDeferralJobIds.add(jobId);
+          job.state.pendingCatchupDeferral = true;
           offset += staggerMs;
         }
       }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1170,7 +1170,7 @@ function applyOutcomeToStoredJob(
       triggerEval: result.triggerEval,
     });
     job.state.pendingCatchupDeferral = undefined;
-    return;
+    return undefined;
   }
 
   const shouldDelete = applyJobResult(state, job, {

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -306,6 +306,8 @@ type CronCommandPayloadPatch = {
 /** Mutable runtime state persisted beside the immutable cron job spec. */
 export type CronJobState = {
   nextRunAtMs?: number;
+  /** Startup overflow catch-up slot that must survive maintenance and restarts. */
+  pendingCatchupDeferral?: boolean;
   runningAtMs?: number;
   lastRunAtMs?: number;
   /** Preferred execution outcome field. */

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -14,6 +14,7 @@ import {
   sendCronAnnouncePayloadStrict,
   sendFailureNotificationAnnounce,
 } from "../cron/delivery.js";
+import { publicCronEventSnapshot, publicCronJobSnapshot } from "../cron/public-job.js";
 import type { CronEvent } from "../cron/service.js";
 import { resolveCronDeliverySessionKey } from "../cron/session-target.js";
 import type { CronJob, CronMessageChannel } from "../cron/types.js";
@@ -67,39 +68,42 @@ function redactOptionalWebhookUrl(url: unknown): string | undefined {
 }
 
 function redactCommandCronEventForExternalDelivery(evt: CronEvent, job?: CronJob): CronEvent {
+  const publicEvt = publicCronEventSnapshot(evt);
   if (job?.payload.kind !== "command") {
-    return evt;
+    return publicEvt;
   }
-  const summary = redactCronCommandSummaryForExternalDelivery(evt.summary);
-  const diagnosticsSummary = redactCronCommandSummaryForExternalDelivery(evt.diagnostics?.summary);
-  const diagnosticsEntries = evt.diagnostics?.entries.map((entry) => ({
+  const summary = redactCronCommandSummaryForExternalDelivery(publicEvt.summary);
+  const diagnosticsSummary = redactCronCommandSummaryForExternalDelivery(
+    publicEvt.diagnostics?.summary,
+  );
+  const diagnosticsEntries = publicEvt.diagnostics?.entries.map((entry) => ({
     ...entry,
     message: redactCronCommandSummaryForExternalDelivery(entry.message) ?? entry.message,
   }));
   const diagnosticsEntriesChanged = diagnosticsEntries?.some(
-    (entry, index) => entry.message !== evt.diagnostics?.entries[index]?.message,
+    (entry, index) => entry.message !== publicEvt.diagnostics?.entries[index]?.message,
   );
-  const embeddedJobState = evt.job?.state;
+  const embeddedJobState = publicEvt.job?.state;
   const stripEmbeddedJobDiagnostics = Boolean(
     embeddedJobState &&
     ("lastDiagnostics" in embeddedJobState || "lastDiagnosticSummary" in embeddedJobState),
   );
   if (
     summary === evt.summary &&
-    diagnosticsSummary === evt.diagnostics?.summary &&
+    diagnosticsSummary === publicEvt.diagnostics?.summary &&
     !diagnosticsEntriesChanged &&
     !stripEmbeddedJobDiagnostics
   ) {
-    return evt;
+    return publicEvt;
   }
-  const redacted: CronEvent = { ...evt };
+  const redacted: CronEvent = { ...publicEvt };
   if (summary !== undefined) {
     redacted.summary = summary;
   } else {
     delete redacted.summary;
   }
-  if (evt.diagnostics) {
-    redacted.diagnostics = { ...evt.diagnostics };
+  if (publicEvt.diagnostics) {
+    redacted.diagnostics = { ...publicEvt.diagnostics };
     if (diagnosticsSummary !== undefined) {
       redacted.diagnostics.summary = diagnosticsSummary;
     } else {
@@ -109,12 +113,12 @@ function redactCommandCronEventForExternalDelivery(evt: CronEvent, job?: CronJob
       redacted.diagnostics.entries = diagnosticsEntries;
     }
   }
-  if (stripEmbeddedJobDiagnostics && evt.job) {
-    const state = { ...evt.job.state };
+  if (stripEmbeddedJobDiagnostics && publicEvt.job) {
+    const state = { ...publicEvt.job.state };
     delete state.lastDiagnostics;
     delete state.lastDiagnosticSummary;
     redacted.job = {
-      ...evt.job,
+      ...publicEvt.job,
       state,
     };
   }
@@ -176,18 +180,19 @@ function buildCronFailureWebhookPayload(params: { evt: CronEvent; job: CronJob }
 }
 
 function buildCronFinishedWebhookPayload(evt: CronEvent) {
-  if (evt.status !== "error") {
-    return evt;
+  const publicEvt = publicCronEventSnapshot(evt);
+  if (publicEvt.status !== "error") {
+    return publicEvt;
   }
-  const { summary: _summary, diagnostics: _diagnostics, ...payload } = evt;
-  if (evt.job) {
-    const state = { ...evt.job.state };
+  const { summary: _summary, diagnostics: _diagnostics, ...payload } = publicEvt;
+  if (publicEvt.job) {
+    const state = { ...publicEvt.job.state };
     delete state.lastDiagnostics;
     delete state.lastDiagnosticSummary;
     return {
       ...payload,
       job: {
-        ...evt.job,
+        ...publicEvt.job,
         state,
       },
     };
@@ -424,7 +429,10 @@ function dispatchCronFailureDestinationNotifications(params: {
   const job = params.job;
   const failureDest = resolveFailureDestination(job, params.globalFailureDestination);
   const deliverySessionKey = resolveCronDeliverySessionKey(job);
-  const failurePayload = buildCronFailureWebhookPayload({ evt: params.evt, job });
+  const failurePayload = buildCronFailureWebhookPayload({
+    evt: publicCronEventSnapshot(params.evt),
+    job: publicCronJobSnapshot(job),
+  });
 
   if (failureDest) {
     if (failureDest.mode === "webhook" && failureDest.to) {

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -24,6 +24,7 @@ import { resolveCronStoredDeliveryContext } from "../cron/delivery-context.js";
 import { resolveCronDeliveryPlan, sendCronAnnouncePayloadStrict } from "../cron/delivery.js";
 import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
 import { resolveCronJobBoundSessionKeys } from "../cron/job-session-bindings.js";
+import { publicCronEventSnapshot, publicCronJobSnapshot } from "../cron/public-job.js";
 import { CronService, type CronEvent } from "../cron/service.js";
 import {
   resolveCronDeliverySessionKey,
@@ -727,7 +728,8 @@ export function buildGatewayCronService(params: {
       // Any job/store change can alter session automation bindings, including
       // in-place enable flips during runs; run/schedule events bump too (cheap).
       bumpSessionAutomationVersion();
-      params.broadcast("cron", evt, { dropIfSlow: true });
+      const publicEvt = publicCronEventSnapshot(evt);
+      params.broadcast("cron", publicEvt, { dropIfSlow: true });
       // Build hook event from CronEvent. The job snapshot is carried on the
       // internal event so it's available even for "removed" actions where
       // getJob() would return undefined. `delivery` and `usage` are
@@ -737,7 +739,8 @@ export function buildGatewayCronService(params: {
       // convenience fields (sessionTarget, agentId) are always populated
       // when the job is known.
       const jobSnapshot = evt.job ?? cron.getJob(evt.jobId);
-      const pluginJob = jobSnapshot ? toPluginCronJob(jobSnapshot) : undefined;
+      const publicJobSnapshot = jobSnapshot ? publicCronJobSnapshot(jobSnapshot) : undefined;
+      const pluginJob = publicJobSnapshot ? toPluginCronJob(publicJobSnapshot) : undefined;
       const hookSummary =
         isCommandCronJob(jobSnapshot) && typeof evt.summary === "string"
           ? redactCronCommandSummaryForExternalDelivery(evt.summary)
@@ -749,7 +752,7 @@ export function buildGatewayCronService(params: {
         // Top-level routing fields so plugins don't have to dig into job.
         sessionTarget: jobSnapshot?.sessionTarget,
         agentId: jobSnapshot?.agentId,
-        ...pickDefined(evt, [
+        ...pickDefined(publicEvt, [
           "runAtMs",
           "durationMs",
           "status",
@@ -783,7 +786,7 @@ export function buildGatewayCronService(params: {
       if (evt.action === "finished") {
         const job = evt.job ?? cron.getJob(evt.jobId);
         dispatchGatewayCronFinishedNotifications({
-          evt,
+          evt: publicEvt,
           job,
           deps: params.deps,
           logger: cronLogger,

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -86,10 +86,7 @@ class CronJobConfigRevisionConflictError extends Error {
 }
 
 function publicCronJobState(job: CronJob): CronJob["state"] {
-  const {
-    pendingCatchupDeferral: _pendingCatchupDeferral,
-    ...state
-  } = job.state;
+  const { pendingCatchupDeferral: _pendingCatchupDeferral, ...state } = job.state;
   return state;
 }
 

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -85,10 +85,19 @@ class CronJobConfigRevisionConflictError extends Error {
   }
 }
 
+function publicCronJobState(job: CronJob): CronJob["state"] {
+  const {
+    pendingCatchupDeferral: _pendingCatchupDeferral,
+    ...state
+  } = job.state;
+  return state;
+}
+
 function cronJobReadView(job: CronJob) {
   return {
     ...job,
     configRevision: resolveCronJobConfigRevision(job),
+    state: publicCronJobState(job),
     nextRunAtMs: job.state.nextRunAtMs,
     lastRunAtMs: job.state.lastRunAtMs,
     lastRunStatus: job.state.lastRunStatus ?? job.state.lastStatus,

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -23,6 +23,7 @@ import {
 import { resolveCronDeliveryPreviews } from "../../cron/delivery-preview.js";
 import { assertCronDeliveryInputNonBlankFields } from "../../cron/delivery-target-validation.js";
 import { normalizeCronJobCreate, normalizeCronJobPatch } from "../../cron/normalize.js";
+import { publicCronJobState } from "../../cron/public-job.js";
 import { applyJobPatch } from "../../cron/service/jobs.js";
 import {
   isInvalidCronSessionTargetIdError,
@@ -83,11 +84,6 @@ class CronJobConfigRevisionConflictError extends Error {
   ) {
     super("cron job definition no longer matches the loaded version");
   }
-}
-
-function publicCronJobState(job: CronJob): CronJob["state"] {
-  const { pendingCatchupDeferral: _pendingCatchupDeferral, ...state } = job.state;
-  return state;
 }
 
 function cronJobReadView(job: CronJob) {

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -168,6 +168,9 @@ function createCronContext(currentJobs?: CronJob | CronJob[]) {
 }
 
 type CronMethod = keyof typeof cronHandlers;
+type CronJobReadView = CronJob & {
+  nextRunAtMs?: number;
+};
 
 async function invokeCron(
   method: CronMethod,
@@ -586,7 +589,7 @@ describe("cron method validation", () => {
     });
 
     const { respond } = await invokeCronGet({ id: "cron-42" }, job);
-    const payload = respond.mock.calls[0]?.[1] as CronJob | undefined;
+    const payload = respond.mock.calls[0]?.[1] as CronJobReadView | undefined;
 
     expect(payload?.state).toEqual({ nextRunAtMs: 2000 });
     expect(payload?.nextRunAtMs).toBe(2000);
@@ -763,7 +766,7 @@ describe("cron method validation", () => {
     );
 
     const { respond } = await invokeCron("cron.list", { includeDisabled: true }, { context });
-    const payload = respond.mock.calls[0]?.[1] as { jobs?: CronJob[] } | undefined;
+    const payload = respond.mock.calls[0]?.[1] as { jobs?: CronJobReadView[] } | undefined;
     const listedJob = payload?.jobs?.[0];
 
     expect(listedJob?.state).toEqual({ nextRunAtMs: 2000 });

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -576,6 +576,23 @@ describe("cron method validation", () => {
     expectCronReadSuccess(respond, job);
   });
 
+  it("hides internal catch-up deferral state from cron.get responses", async () => {
+    const job = createCronJob({
+      id: "cron-42",
+      state: {
+        nextRunAtMs: 2000,
+        pendingCatchupDeferral: true,
+      },
+    });
+
+    const { respond } = await invokeCronGet({ id: "cron-42" }, job);
+    const payload = respond.mock.calls[0]?.[1] as CronJob | undefined;
+
+    expect(payload?.state).toEqual({ nextRunAtMs: 2000 });
+    expect(payload?.nextRunAtMs).toBe(2000);
+    expect(payload?.state).not.toHaveProperty("pendingCatchupDeferral");
+  });
+
   it("hides caller-scoped cron.get for a foreign agent", async () => {
     const job = createCronJob({ id: "cron-42", agentId: "ops" });
 
@@ -733,6 +750,25 @@ describe("cron method validation", () => {
     );
 
     expect(firstPayload.snapshotRevision).toBe(secondPayload.snapshotRevision);
+  });
+
+  it("hides internal catch-up deferral state from full cron.list responses", async () => {
+    const context = createCronContext(
+      createCronJob({
+        state: {
+          nextRunAtMs: 2000,
+          pendingCatchupDeferral: true,
+        },
+      }),
+    );
+
+    const { respond } = await invokeCron("cron.list", { includeDisabled: true }, { context });
+    const payload = respond.mock.calls[0]?.[1] as { jobs?: CronJob[] } | undefined;
+    const listedJob = payload?.jobs?.[0];
+
+    expect(listedJob?.state).toEqual({ nextRunAtMs: 2000 });
+    expect(listedJob?.nextRunAtMs).toBe(2000);
+    expect(listedJob?.state).not.toHaveProperty("pendingCatchupDeferral");
   });
 
   it("rejects caller-scoped cron.list for a foreign explicit agentId", async () => {

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -549,6 +549,51 @@ describe("gateway server cron", () => {
     }
   });
 
+  test("hides internal catch-up deferral marker from cron event job snapshots", async () => {
+    const now = Date.now();
+    const { prevSkipCron } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-event-public-state-",
+      cronEnabled: false,
+      jobs: [
+        {
+          id: "deferred-public-event",
+          name: "deferred public event",
+          enabled: true,
+          createdAtMs: now - 60_000,
+          updatedAtMs: now - 60_000,
+          schedule: { kind: "every", everyMs: 60_000 },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "systemEvent", text: "hello" },
+          state: {
+            nextRunAtMs: now + 5_000,
+            pendingCatchupDeferral: true,
+          },
+        },
+      ],
+    });
+    const cronEvents = createCronEventCollector();
+    const cronState = await createDirectCronState({ broadcast: cronEvents["broadcast"] });
+
+    try {
+      const updatedEvent = cronEvents.wait(
+        (payload) => payload.jobId === "deferred-public-event" && payload.action === "updated",
+      );
+      const updateRes = await directCronReq(cronState, "cron.update", {
+        id: "deferred-public-event",
+        patch: { displayName: "Deferred Public Event" },
+      });
+      expect(updateRes.ok).toBe(true);
+
+      const payload = await updatedEvent;
+      const state = (payload.job as { state?: Record<string, unknown> } | undefined)?.state;
+      expect(state).toMatchObject({ nextRunAtMs: now + 5_000 });
+      expect(state).not.toHaveProperty("pendingCatchupDeferral");
+    } finally {
+      await cleanupCronTestRun({ cronState, prevSkipCron });
+    }
+  });
+
   test("routes forced cron runs to the configured session", async () => {
     const { prevSkipCron } = await setupCronTestRun({
       tempPrefix: "openclaw-gw-cron-route-",


### PR DESCRIPTION
## What Problem This Solves

Fixes #102236. A startup overflow catch-up slot could be persisted to SQLite while its protection marker existed only in memory. Restarting again before that slot fired let maintenance advance the job to its next natural cron slot, silently losing the deferred run.

## Why This Change Was Made

The deferral marker now lives on `CronJobState` as `pendingCatchupDeferral`, so the existing `state_json` persistence and rollback paths own the slot and marker together. The process-local Set and its parallel rollback bookkeeping are removed. Maintenance clears the persisted marker when the slot arrives, when no valid deferred slot remains, or when the job is disabled; execution also clears it after an outcome. Existing rows need no migration because an absent field means no pending deferral.

## User Impact

Overflow system-event cron jobs keep their staggered startup catch-up run across repeated gateway restarts instead of silently skipping to the next natural schedule. Unrelated stale future cron slots are still repaired normally.

## Evidence

- Real SQLite restart path: one service starts and persists an overflow deferral, a fresh service starts 3 seconds later against the same store, the original 5-second slot survives, executes once, and clears its marker.
- `node scripts/run-vitest.mjs src/cron/service.startup-overflow-clobber.test.ts src/cron/service.jobs.test.ts src/cron/service/ops.test.ts`: 3 files, 107 tests passed.
- `node scripts/run-vitest.mjs src/cron/service.restart-catchup.test.ts src/cron/service/timer.regression.test.ts`: 2 files, 81 tests passed.
- Oxlint passed for all nine changed files.
- `git diff --check` passed.