### PR TITLE
fix(subagents): commit superseded-run retirement before irreversible cleanup

### DIFF
--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -798,8 +798,8 @@ export function createSubagentRegistryLifecycleController(params: {
     }
     // Cleanup can yield to attachment, mirror, or announce work. A successor
     // registered while it was suspended owns every session-scoped side effect.
+    // retireSupersededRun owns the persist-before-cleanup transaction.
     await params.retireSupersededRun(runId, entry);
-    params.persist();
     return true;
   };
 
@@ -1698,8 +1698,8 @@ export function createSubagentRegistryLifecycleController(params: {
     }
     const retireSupersededSession = async (currentEntry: SubagentRunRecord) => {
       if (completionReason !== SUBAGENT_ENDED_REASON_KILLED) {
+        // retireSupersededRun owns the persist-before-cleanup transaction.
         await params.retireSupersededRun(completeParams.runId, currentEntry);
-        params.persist();
       }
     };
     sessionSuperseded = sessionSuperseded || newerGenerationOwnsSession(entry);

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -4,6 +4,7 @@ import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { SessionEntry } from "../config/sessions.js";
 import type {
   SessionAccessScope,
@@ -30,6 +31,7 @@ import {
 } from "./subagent-lifecycle-events.js";
 
 const noop = () => {};
+const autoCleanupTempDirs = useAutoCleanupTempDirTracker(afterEach);
 const waitForFast = <T>(callback: () => T | Promise<T>) =>
   vi.waitFor(callback, { timeout: 1_000, interval: 1 });
 
@@ -3664,9 +3666,7 @@ describe("subagent registry seam flow", () => {
         throw new Error("disk full during superseded retirement");
       },
     );
-    const attachmentsRootDir = await fs.mkdtemp(
-      path.join(os.tmpdir(), "openclaw-persist-fail-attachments-"),
-    );
+    const attachmentsRootDir = autoCleanupTempDirs.make("openclaw-persist-fail-attachments-");
     const attachmentsDir = path.join(attachmentsRootDir, "child");
     await fs.mkdir(attachmentsDir, { recursive: true });
     await fs.writeFile(path.join(attachmentsDir, "artifact.txt"), "artifact");
@@ -3730,7 +3730,76 @@ describe("subagent registry seam flow", () => {
     ).toBe(false);
     expect(mocks.removeInternalSessionEffectsTranscript).toHaveBeenCalledWith(oldTranscriptFile);
     await expectPathMissing(attachmentsDir);
-    await fs.rm(attachmentsRootDir, { recursive: true, force: true });
+  });
+
+  it("skips a run removed while an earlier sweep entry yields", async () => {
+    const now = Date.now();
+    let resolveDelete: (() => void) | undefined;
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method !== "sessions.delete") {
+        return {};
+      }
+      return await new Promise<Record<string, unknown>>((resolve) => {
+        resolveDelete = () => resolve({});
+      });
+    });
+    mod.addSubagentRunForTests({
+      runId: "run-sweep-blocker",
+      childSessionKey: "agent:main:subagent:sweep-blocker",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "hold the sweep",
+      cleanup: "delete",
+      createdAt: now - 2,
+      endedAt: now - 1,
+      archiveAtMs: now,
+    });
+    const supersededRunId = "run-removed-during-sweep";
+    const reusedSessionKey = "agent:main:subagent:reused-during-sweep";
+    mod.addSubagentRunForTests({
+      runId: supersededRunId,
+      childSessionKey: reusedSessionKey,
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "old generation",
+      cleanup: "delete",
+      generation: 1,
+      createdAt: now - 2,
+      endedAt: now - 1,
+      endedReason: SUBAGENT_ENDED_REASON_COMPLETE,
+      outcome: { status: "ok" },
+    });
+    mod.addSubagentRunForTests({
+      runId: "run-current-during-sweep",
+      childSessionKey: reusedSessionKey,
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "current generation",
+      cleanup: "keep",
+      generation: 2,
+      createdAt: now,
+      startedAt: now,
+    });
+
+    const sweep = mod.testing.sweepOnceForTests();
+    await waitForFast(() =>
+      expect(mocks.callGateway).toHaveBeenCalledWith(
+        expect.objectContaining({ method: "sessions.delete" }),
+      ),
+    );
+    mod.releaseSubagentRun(supersededRunId);
+    if (!resolveDelete) {
+      throw new Error("expected sessions.delete to be pending");
+    }
+    resolveDelete();
+    await sweep;
+
+    expect(
+      mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .some((entry) => entry.runId === supersededRunId),
+    ).toBe(false);
+    expect(mocks.persistSubagentRunsToDiskOrThrow).not.toHaveBeenCalled();
   });
 
   it("checks the raw completion time before clamping an old run deadline", async () => {

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -3656,16 +3656,12 @@ describe("subagent registry seam flow", () => {
     mocks.getAgentRunContext.mockImplementation((runId: string) =>
       runId === "run-superseded-successor" ? ({} as never) : undefined,
     );
-    // Fail exactly the persist that commits the durable removal: at that point
-    // the retiring run is already deleted from the snapshot, while every earlier
-    // persist still contains it and succeeds. persistFails flips to false to
-    // model a transient failure clearing before the next sweep.
-    let persistFails = true;
-    mocks.persistSubagentRunsToDiskOrThrow.mockImplementation(
+    // Fail exactly the persist that commits the durable removal. The single-use
+    // failure models recovery before the next sweep without leaking mock state.
+    mocks.persistSubagentRunsToDiskOrThrow.mockImplementationOnce(
       (runs: Map<string, import("./subagent-registry.types.js").SubagentRunRecord>) => {
-        if (persistFails && !runs.has(oldRunId)) {
-          throw new Error("disk full during superseded retirement");
-        }
+        expect(runs.has(oldRunId)).toBe(false);
+        throw new Error("disk full during superseded retirement");
       },
     );
     const attachmentsRootDir = await fs.mkdtemp(
@@ -3720,23 +3716,21 @@ describe("subagent registry seam flow", () => {
     expect(
       mod.listSubagentRunsForRequester("agent:main:main").some((e) => e.runId === oldRunId),
     ).toBe(true);
-    expect(mocks.persistSubagentRunsToDiskOrThrow).toHaveBeenCalled();
+    expect(mocks.persistSubagentRunsToDiskOrThrow).toHaveBeenCalledOnce();
     expect(mocks.removeInternalSessionEffectsTranscript).not.toHaveBeenCalled();
     await fs.access(attachmentsDir);
 
     // The transient failure clears; the next sweep must retry and complete the
     // retirement, removing the run and its transcript/attachments.
-    persistFails = false;
     await mod.testing.sweepOnceForTests();
 
+    expect(mocks.persistSubagentRunsToDiskOrThrow).toHaveBeenCalledTimes(2);
     expect(
       mod.listSubagentRunsForRequester("agent:main:main").some((e) => e.runId === oldRunId),
     ).toBe(false);
     expect(mocks.removeInternalSessionEffectsTranscript).toHaveBeenCalledWith(oldTranscriptFile);
     await expectPathMissing(attachmentsDir);
     await fs.rm(attachmentsRootDir, { recursive: true, force: true });
-    // Persistent conditional impl would leak; clearAllMocks does not reset it.
-    mocks.persistSubagentRunsToDiskOrThrow.mockReset();
   });
 
   it("checks the raw completion time before clamping an old run deadline", async () => {

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -3648,6 +3648,97 @@ describe("subagent registry seam flow", () => {
     ).toBe(false);
   });
 
+  it("defers superseded retirement when persist fails, then retries it on the next sweep", async () => {
+    const oldStartedAt = Date.parse("2026-03-24T11:50:00Z");
+    const oldEndedAt = Date.parse("2026-03-24T11:55:00Z");
+    const newStartedAt = Date.parse("2026-03-24T11:58:00Z");
+    const oldRunId = "run-superseded-persist-fail";
+    mocks.getAgentRunContext.mockImplementation((runId: string) =>
+      runId === "run-superseded-successor" ? ({} as never) : undefined,
+    );
+    // Fail exactly the persist that commits the durable removal: at that point
+    // the retiring run is already deleted from the snapshot, while every earlier
+    // persist still contains it and succeeds. persistFails flips to false to
+    // model a transient failure clearing before the next sweep.
+    let persistFails = true;
+    mocks.persistSubagentRunsToDiskOrThrow.mockImplementation(
+      (runs: Map<string, import("./subagent-registry.types.js").SubagentRunRecord>) => {
+        if (persistFails && !runs.has(oldRunId)) {
+          throw new Error("disk full during superseded retirement");
+        }
+      },
+    );
+    const attachmentsRootDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-persist-fail-attachments-"),
+    );
+    const attachmentsDir = path.join(attachmentsRootDir, "child");
+    await fs.mkdir(attachmentsDir, { recursive: true });
+    await fs.writeFile(path.join(attachmentsDir, "artifact.txt"), "artifact");
+    const oldTranscriptFile = "/tmp/internal-agent-runs/run-superseded-persist-fail.jsonl";
+    // A superseded run that already completed normally (no kill reconciliation),
+    // so retirement runs through the generic superseded backstop, not the kill
+    // path. This is the path whose deferred retirement must still be retried.
+    mod.addSubagentRunForTests({
+      runId: oldRunId,
+      childSessionKey: "agent:main:subagent:reused-persist-fail",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "old generation",
+      cleanup: "delete",
+      createdAt: oldStartedAt,
+      startedAt: oldStartedAt,
+      sessionStartedAt: oldStartedAt,
+      endedAt: oldEndedAt,
+      endedReason: SUBAGENT_ENDED_REASON_COMPLETE,
+      outcome: { status: "ok", startedAt: oldStartedAt, endedAt: oldEndedAt },
+      attachmentsDir,
+      attachmentsRootDir,
+      execution: {
+        status: "terminal",
+        startedAt: oldStartedAt,
+        endedAt: oldEndedAt,
+        transcriptFile: oldTranscriptFile,
+      },
+    });
+    mod.addSubagentRunForTests({
+      runId: "run-superseded-successor",
+      childSessionKey: "agent:main:subagent:reused-persist-fail",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "new generation",
+      cleanup: "keep",
+      createdAt: newStartedAt,
+      startedAt: newStartedAt,
+      sessionStartedAt: newStartedAt,
+    });
+
+    await mod.testing.sweepOnceForTests();
+
+    // Durable removal failed, so the run must stay in memory to match the
+    // surviving SQLite row instead of diverging into a ghost on restart, and
+    // the irreversible cleanup must not run until the removal commits.
+    expect(
+      mod.listSubagentRunsForRequester("agent:main:main").some((e) => e.runId === oldRunId),
+    ).toBe(true);
+    expect(mocks.persistSubagentRunsToDiskOrThrow).toHaveBeenCalled();
+    expect(mocks.removeInternalSessionEffectsTranscript).not.toHaveBeenCalled();
+    await fs.access(attachmentsDir);
+
+    // The transient failure clears; the next sweep must retry and complete the
+    // retirement, removing the run and its transcript/attachments.
+    persistFails = false;
+    await mod.testing.sweepOnceForTests();
+
+    expect(
+      mod.listSubagentRunsForRequester("agent:main:main").some((e) => e.runId === oldRunId),
+    ).toBe(false);
+    expect(mocks.removeInternalSessionEffectsTranscript).toHaveBeenCalledWith(oldTranscriptFile);
+    await expectPathMissing(attachmentsDir);
+    await fs.rm(attachmentsRootDir, { recursive: true, force: true });
+    // Persistent conditional impl would leak; clearAllMocks does not reset it.
+    mocks.persistSubagentRunsToDiskOrThrow.mockReset();
+  });
+
   it("checks the raw completion time before clamping an old run deadline", async () => {
     resetTaskRegistryForTests({ persist: false });
     resetTaskFlowRegistryForTests({ persist: false });

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -983,8 +983,24 @@ async function discardSuspendedPendingFinalDelivery(
 
 async function retireSupersededSubagentRun(runId: string, entry: SubagentRunRecord): Promise<void> {
   const transcriptFile = entry.execution?.transcriptFile;
-  clearPendingLifecycleError(runId);
   subagentRuns.delete(runId);
+  // Commit the durable removal before the irreversible transcript/attachment
+  // cleanup. Otherwise a persist failure drops the run from memory while its
+  // SQLite row survives: cross-process reads still see it active and a restart
+  // resurrects a ghost run that waits forever. On failure restore the entry
+  // (cleanup has not run, so it is intact) and let a later sweep retry.
+  try {
+    persistSubagentRunsOrThrow();
+  } catch (error) {
+    subagentRuns.set(runId, entry);
+    log.warn("failed to persist superseded subagent retirement; deferring cleanup", {
+      runId,
+      childSessionKey: entry.childSessionKey,
+      error,
+    });
+    return;
+  }
+  clearPendingLifecycleError(runId);
   const transcriptStillOwned = Array.from(subagentRuns.values()).some(
     (candidate) => candidate.execution?.transcriptFile === transcriptFile,
   );
@@ -1027,7 +1043,12 @@ async function sweepSubagentRuns() {
         pressureDiscardCount: pressureDiscardRunIds.size,
       });
     }
-    for (const [runId, entry] of subagentRuns.entries()) {
+    // Snapshot the entries: retireSupersededSubagentRun re-inserts an entry when
+    // its durable removal fails, and a live Map iterator would re-append and
+    // revisit that key, spinning forever while persistence keeps failing. The
+    // deferred retirement is retried on the next sweep instead.
+    const sweepEntries = [...subagentRuns.entries()];
+    for (const [runId, entry] of sweepEntries) {
       if (isSuspendedPendingFinalDelivery(entry)) {
         const suspendedAgeMs = now - (entry.delivery?.suspendedAt ?? now);
         const expired = suspendedAgeMs >= resolveSuspendedDeliveryExpiryMs(entry);
@@ -1331,6 +1352,15 @@ async function sweepSubagentRuns() {
         entry.cleanupCompletedAt = undefined;
         mutated = true;
         startSubagentAnnounceCleanupFlow(runId, entry);
+        continue;
+      }
+      // Retire a superseded terminal run whose completion-path retirement did not
+      // commit (its persist failed and deferred). A newer generation owns the
+      // session, so this backstop retries retirement until it commits instead of
+      // letting the run linger in memory/on disk. Killed runs retire above.
+      if (typeof entry.endedAt === "number" && findNextSubagentRunCreatedAt(entry) !== undefined) {
+        await retireSupersededSubagentRun(runId, entry);
+        mutated = true;
         continue;
       }
       if (!entry.archiveAtMs && entry.cleanup === "keep" && entry.spawnMode !== "session") {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1049,6 +1049,11 @@ async function sweepSubagentRuns() {
     // deferred retirement is retried on the next sweep instead.
     const sweepEntries = [...subagentRuns.entries()];
     for (const [runId, entry] of sweepEntries) {
+      // Earlier entries can yield to cleanup. Never act on a run that was
+      // removed or replaced while this sweep was suspended.
+      if (subagentRuns.get(runId) !== entry) {
+        continue;
+      }
       if (isSuspendedPendingFinalDelivery(entry)) {
         const suspendedAgeMs = now - (entry.delivery?.suspendedAt ?? now);
         const expired = suspendedAgeMs >= resolveSuspendedDeliveryExpiryMs(entry);


### PR DESCRIPTION
## Summary

**Prompt request:** Persist the superseded-run removal before deleting its transcript/attachments, restore the in-memory entry when that persist fails, and retry the retirement from the sweep until it commits.

**Proof target:** Show that under a genuine SQLite write failure the retiring run stays consistent in memory and on disk with its artifacts intact, and that the deferred retirement is retried and commits once persistence recovers.

## What Problem This Solves

Resolves a problem where a subagent-registry persistence failure during
superseded-run retirement silently diverged runtime state from the durable
store. `retireSupersededSubagentRun` (`src/agents/subagent-registry.ts`)
deleted the live process-wide `subagentRuns` entry **and** irreversibly cleaned
up its transcript/attachments, and only then did its callers persist the
registry snapshot fire-and-forget (`persistSubagentRunsToDisk` swallows all
write errors). If that SQLite full-snapshot write threw (disk full, IO error,
lock), memory had forgotten the run but its `subagent_runs` row survived:

- cross-process reads merge disk+memory, so another worker's `/subagents`
  status kept showing the already-superseded run as active; and
- on restart, `restoreSubagentRunsOnce` reloaded the stale row and resurrected
  it as a ghost run waiting forever for a completion that already happened.

Reachable via the shipped **steer** feature whenever a prior generation's
completion lands after a successor took over the session.

## Why This Change Was Made

The same module already applies the correct discipline in
`completeSubagentRun` (snapshot → `persistOrThrow` → restore-on-failure); the
retirement path was the missed sibling of that idiom. Rather than patching
each caller, this concentrates the transaction at the retirement boundary:

- `retireSupersededSubagentRun` now commits the durable removal
  (`persistSubagentRunsOrThrow`) **before** the irreversible
  transcript/attachment cleanup. On persist failure it re-inserts the entry
  (cleanup has not run, so it is intact), logs, and returns, so memory and disk
  stay consistent and the retirement is retried later.
- The two retirement callers (`retireSupersededCleanupIfNeeded`,
  `retireSupersededSession`) drop their now-redundant fire-and-forget
  `params.persist()`; the boundary owns the transaction for all callers.
- `sweepSubagentRuns` iterates a snapshot of the entries, because the rollback
  re-inserts a key and a live `Map` iterator would re-append and revisit it,
  spinning while persistence keeps failing. (No existing path adds entries
  mid-sweep, so this is otherwise behavior-neutral.)
- **Behavior change, called out explicitly:** the sweep gains a generic
  superseded-retire backstop (terminal run + newer generation owns the same
  session key). The sweep previously re-reached retirement only through the
  kill-reconciliation path, so a retirement deferred by this fix — and any
  normally completed superseded run whose completion-path retirement did not
  commit — would linger in memory and on disk forever. The deferral leaves no
  durable marker on purpose (a marker would add schema surface and could
  itself fail to persist), so the retry is state-derived: retirement is
  idempotent and already the designed end state for exactly this
  terminal+superseded shape, which the kill path retires from the sweep today.
  Live runs are untouched (`endedAt` gate) and killed runs keep using the kill
  path. This can retire a terminal superseded run one sweep earlier than the
  archive/keep branches below it; the outcome matches what the completion
  path's retirement already produces for these runs.

No new config/env/fallback surface, no retry policy, and no change to how a
run is *decided* superseded (`findNextSubagentRunCreatedAt` is untouched).
Roughly half of the added non-test lines are the lifecycle-ordering/iteration
invariant comments the scoped agents guide requires.

## User Impact

A subagent-registry persistence failure during retirement no longer strands a
superseded run as a phantom-active entry across processes, nor resurrects it
as a stuck ghost run on restart; the retirement is retried until it commits.
On success, behavior is unchanged.

## Evidence

Current head: `1a5ae64e49`.

**Real write-failure capture (shipped store/registry code, no JS mocks; not a
full gateway runtime).** A throwaway tsx driver (inlined below) run with
`node --import tsx` in an isolated `OPENCLAW_STATE_DIR`: it seeds a superseded
terminal run plus its successor through the shipped store writer and session
store, restores them via `initSubagentRegistry()` (the same path a process
restart takes), injects a **genuine `SQLITE_READONLY`** into the next real
write transaction by setting `PRAGMA query_only=1` on the cached production
connection, and triggers the real `sweepSubagentRuns` through the registry's
exported sweep hook. Captured at head `1a5ae64e49` (branch base:
`upstream/main` @ `aa27ae9d9f`):

```text
[seeded+restored] memory=["run-proof-superseded-old","run-proof-superseded-successor"] sqlite=["run-proof-superseded-old","run-proof-superseded-successor"] artifacts={"transcript":true,"attachments":true}
[inject] PRAGMA query_only=1 on production cached connection
[agents/subagent-registry] failed to persist superseded subagent retirement; deferring cleanup
[sweep#1 (persist failing)]   memory=[old,successor] sqlite=[old,successor] artifacts={"transcript":true,"attachments":true}
[sweep#1.1 (persist still failing)] same — the deferred retirement is re-attempted and re-deferred each sweep
[sweep#1.2 (persist still failing)] same
[clear] PRAGMA query_only=0
[sweep#2 (persist healthy)]   memory=["run-proof-superseded-successor"] sqlite=["run-proof-superseded-successor"] artifacts={"transcript":false,"attachments":false}
```

While the write fails, the retiring run stays present in **both** memory and
SQLite and its transcript/attachments are untouched (the shipped
`deferring cleanup` warning fires each sweep); once persistence recovers, the
next sweep commits the removal and only then cleans the artifacts. The trailing
announce give-up/credentials lines in the raw capture come from the isolated
environment lacking a gateway and are unrelated to this change.

What this capture proves: the reordered transaction and the sweep retry,
end-to-end, under a real SQLite write failure. What it does not prove: the
exact upstream divergence window. Running the same driver and injection on
unpatched `upstream/main` @ `aa27ae9d9f` shows the sweep never re-attempts
retirement for a normally completed superseded run (no `deferring cleanup`
line; the run lingers across repeated failing sweeps) — the retry gap the
backstop closes — but the whole-connection failure trips
`completeSubagentRun`'s existing snapshot/restore guard before any
retirement-time write, so the divergence window itself (persist failing
exactly at the removal commit, after the completion already committed) is
pinned by the mocked targeted test below, not by the capture.

**Targeted vitest** (`src/agents/subagent-registry.test.ts`, two scenarios;
mocked persist, pinpoint failure injection):

- persist-failure (two-sweep, non-kill path): the mock throws **only** for the
  snapshot write that commits the removal (the first write whose snapshot no
  longer contains the retiring run) → the run stays in the in-memory map,
  transcript/attachment cleanup did not run, and the sweep terminates (no
  spin); the failure then clears and the next sweep retries through the
  backstop → run removed, transcript and attachments cleaned;
- happy path (existing "does not reconcile an old tombstone…"): successful
  retirement still deletes the run and cleans transcript/attachments after the
  durable removal commits.

**Checks:** `pnpm check:changed --base upstream/main` green at head
(typecheck core + core tests, lint, conflict/dup/dependency guards; lanes:
core, coreTests).

<details>
<summary>Proof driver (tsx, run against the real runtime; deleted after capture)</summary>

```ts
import fs from "node:fs";
import path from "node:path";

const stateDir = process.env.OPENCLAW_STATE_DIR;
if (!stateDir || !stateDir.includes("proof")) {
  throw new Error("refusing to run without an isolated OPENCLAW_STATE_DIR scratch dir");
}

const registry = await import("./src/agents/subagent-registry.js");
const store = await import("./src/agents/subagent-registry.store.sqlite.js");
const stateDb = await import("./src/state/openclaw-state-db.js");
const sessionAccessor = await import("./src/config/sessions/session-accessor.js");
const sessionsConfig = await import("./src/config/sessions.js");
const configModule = await import("./src/config/config.js");

const OLD_RUN_ID = "run-proof-superseded-old";
const NEW_RUN_ID = "run-proof-superseded-successor";
const REQUESTER = "agent:main:main";
const CHILD_SESSION = "agent:main:subagent:proof-superseded";

const oldStartedAt = Date.now() - 10 * 60_000;
const oldEndedAt = Date.now() - 8 * 60_000;
const newStartedAt = Date.now() - 5 * 60_000;

const attachmentsRootDir = path.join(stateDir, "proof-artifacts", "attachments-root");
const attachmentsDir = path.join(attachmentsRootDir, "child");
const transcriptDir = path.join(stateDir, "internal-agent-runs");
const transcriptFile = path.join(transcriptDir, `${OLD_RUN_ID}.jsonl`);
fs.mkdirSync(attachmentsDir, { recursive: true });
fs.mkdirSync(transcriptDir, { recursive: true });
fs.writeFileSync(path.join(attachmentsDir, "artifact.txt"), "artifact\n");
fs.writeFileSync(transcriptFile, JSON.stringify({ role: "assistant", text: "done" }) + "\n");

const oldRun = {
  runId: OLD_RUN_ID,
  childSessionKey: CHILD_SESSION,
  requesterSessionKey: REQUESTER,
  requesterDisplayKey: "main",
  task: "old generation (superseded)",
  cleanup: "delete",
  createdAt: oldStartedAt,
  startedAt: oldStartedAt,
  sessionStartedAt: oldStartedAt,
  endedAt: oldEndedAt,
  endedReason: "complete",
  outcome: { status: "ok", startedAt: oldStartedAt, endedAt: oldEndedAt },
  suppressCompletionDelivery: true,
  attachmentsDir,
  attachmentsRootDir,
  execution: { status: "terminal", startedAt: oldStartedAt, endedAt: oldEndedAt, transcriptFile },
} as never;

const newRun = {
  runId: NEW_RUN_ID,
  childSessionKey: CHILD_SESSION,
  requesterSessionKey: REQUESTER,
  requesterDisplayKey: "main",
  task: "new generation (owns session)",
  cleanup: "keep",
  createdAt: newStartedAt,
  startedAt: newStartedAt,
  sessionStartedAt: newStartedAt,
} as never;

const cfg = configModule.getRuntimeConfig();
const sessionStorePath = sessionsConfig.resolveStorePath(cfg.session?.store, { agentId: "main" });
await sessionAccessor.upsertSessionEntry(
  { storePath: sessionStorePath, sessionKey: CHILD_SESSION },
  { sessionId: "proof-superseded-session" },
);
const seeded = new Map<string, never>([
  [OLD_RUN_ID, oldRun],
  [NEW_RUN_ID, newRun],
]);
store.saveSubagentRegistryToSqlite(seeded as never);
registry.initSubagentRegistry();

function report(label: string) {
  const memory = registry.listSubagentRunsForRequester(REQUESTER).map((e) => e.runId).toSorted();
  const disk = [...store.loadSubagentRegistryFromSqlite().keys()].toSorted();
  const files = { transcript: fs.existsSync(transcriptFile), attachments: fs.existsSync(attachmentsDir) };
  console.log(`[${label}] memory=${JSON.stringify(memory)} sqlite=${JSON.stringify(disk)} artifacts=${JSON.stringify(files)}`);
}

report("seeded+restored");
const database = stateDb.openOpenClawStateDatabase();
database.db.exec("PRAGMA query_only=1");
console.log("[inject] PRAGMA query_only=1 on production cached connection");
await registry.testing.sweepOnceForTests();
report("sweep#1 (persist failing)");
const extraFailingSweeps = Number(process.env.PROOF_EXTRA_FAILING_SWEEPS ?? "0");
for (let i = 0; i < extraFailingSweeps; i += 1) {
  await registry.testing.sweepOnceForTests();
  report(`sweep#1.${i + 1} (persist still failing)`);
}
database.db.exec("PRAGMA query_only=0");
console.log("[clear] PRAGMA query_only=0");
await registry.testing.sweepOnceForTests();
report("sweep#2 (persist healthy)");
```

</details>
