### PR TITLE
fix(heartbeat): preserve agent identity in global-scope heartbeat context

### DIFF
--- a/src/infra/heartbeat-runner.identity.test.ts
+++ b/src/infra/heartbeat-runner.identity.test.ts
@@ -1,12 +1,88 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { resolveStorePath } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { runHeartbeatOnce } from "./heartbeat-runner.js";
 import { installHeartbeatRunnerTestRuntime } from "./heartbeat-runner.test-harness.js";
-import { seedMainSessionStore, withTempHeartbeatSandbox } from "./heartbeat-runner.test-utils.js";
+import {
+  seedMainSessionStore,
+  seedSessionStore,
+  withTempHeartbeatSandbox,
+} from "./heartbeat-runner.test-utils.js";
 
 installHeartbeatRunnerTestRuntime({ includeSlack: true });
 
 describe("runHeartbeatOnce identity", () => {
+  it.each([
+    { isolatedSession: false, expectedSessionKey: "global" },
+    { isolatedSession: true, expectedSessionKey: "global:heartbeat" },
+  ])(
+    "keeps a secondary global heartbeat in its agent store (isolated=$isolatedSession)",
+    async ({ isolatedSession, expectedSessionKey }) => {
+      await withTempHeartbeatSandbox(async ({ tmpDir, replySpy }) => {
+        const storeTemplate = path.join(tmpDir, "agents", "{agentId}", "sessions.json");
+        const cfg: OpenClawConfig = {
+          agents: {
+            defaults: {
+              workspace: tmpDir,
+              heartbeat: { every: "5m", target: "last", isolatedSession },
+            },
+            list: [{ id: "main", default: true }, { id: "historian2" }],
+          },
+          session: { scope: "global", dmScope: "per-channel-peer", store: storeTemplate },
+        };
+        const mainStorePath = resolveStorePath(storeTemplate, { agentId: "main" });
+        const historianStorePath = resolveStorePath(storeTemplate, { agentId: "historian2" });
+        await Promise.all([
+          fs.mkdir(path.dirname(mainStorePath), { recursive: true }),
+          fs.mkdir(path.dirname(historianStorePath), { recursive: true }),
+        ]);
+        await seedSessionStore(mainStorePath, "global", {
+          lastChannel: "slack",
+          lastProvider: "slack",
+          lastTo: "channel:MAIN",
+        });
+        await seedSessionStore(historianStorePath, "global", {
+          lastChannel: "slack",
+          lastProvider: "slack",
+          lastTo: "channel:HISTORIAN",
+        });
+        const mainStoreBefore = await fs.readFile(mainStorePath, "utf-8");
+        replySpy.mockResolvedValue({ text: "needs attention" });
+        const sendSlack = vi.fn().mockResolvedValue({ messageId: "m1", channelId: "HISTORIAN" });
+
+        await runHeartbeatOnce({
+          cfg,
+          agentId: "historian2",
+          deps: {
+            getReplyFromConfig: replySpy,
+            slack: sendSlack,
+            getQueueSize: () => 0,
+          },
+        });
+
+        expect(replySpy).toHaveBeenCalledTimes(1);
+        expect(replySpy.mock.calls[0]?.[0]).toMatchObject({
+          AgentId: "historian2",
+          SessionKey: expectedSessionKey,
+        });
+        expect(sendSlack).toHaveBeenCalledWith(
+          "channel:HISTORIAN",
+          "needs attention",
+          expect.any(Object),
+        );
+        expect(await fs.readFile(mainStorePath, "utf-8")).toBe(mainStoreBefore);
+        const historianStore = JSON.parse(await fs.readFile(historianStorePath, "utf-8")) as Record<
+          string,
+          unknown
+        >;
+        expect(historianStore.global).toBeDefined();
+        expect(historianStore["global:heartbeat"] !== undefined).toBe(isolatedSession);
+      });
+    },
+  );
+
   it.each([
     { name: "alert", replyText: "needs attention", showOk: false },
     { name: "heartbeat ok", replyText: "HEARTBEAT_OK", showOk: true },
@@ -41,6 +117,7 @@ describe("runHeartbeatOnce identity", () => {
         },
       });
 
+      expect(replySpy.mock.calls[0]?.[0]).toMatchObject({ AgentId: "main" });
       expect(sendSlack).toHaveBeenCalledTimes(1);
       expect(sendSlack.mock.calls[0]?.[2]).toMatchObject({
         identity: { name: "Pulse", emoji: "📟" },

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -573,9 +573,10 @@ function resolveHeartbeatSession(
   const resolvedAgentId = normalizeAgentId(agentId ?? resolveDefaultAgentId(cfg));
   const mainSessionKey =
     scope === "global" ? "global" : resolveAgentMainSessionKey({ cfg, agentId: resolvedAgentId });
-  const storeAgentId = scope === "global" ? resolveDefaultAgentId(cfg) : resolvedAgentId;
   const storePath = resolveStorePath(sessionCfg?.store, {
-    agentId: storeAgentId,
+    // A literal `global` row is global only inside the selected agent's store.
+    // Falling back here leaks the default agent's route into secondary heartbeats.
+    agentId: resolvedAgentId,
   });
   const store = loadSessionStore(storePath);
   const mainEntry = store[mainSessionKey];
@@ -1855,6 +1856,7 @@ export async function runHeartbeatOnce(opts: {
     MessageThreadId: delivery.threadId,
     Provider: hasExecCompletion ? "exec-event" : hasCronEvents ? "cron-event" : "heartbeat",
     SessionKey: runSessionKey,
+    AgentId: agentId,
   };
   if (!visibility.showAlerts && !visibility.showOk && !visibility.useIndicator) {
     emitHeartbeatEvent({


### PR DESCRIPTION
## What Problem This Solves

With `session.scope: "global"`, a heartbeat selected for a secondary agent could use the default agent's session store and lose the selected agent identity in the reply context. That could make the heartbeat read the wrong workspace and `HEARTBEAT.md` even though the operator targeted the secondary agent.

Fixes #99912. Supersedes the partial approaches in #99941 and #100980.

## Why This Change Was Made

Global scope intentionally preserves the persisted/public session key (`global` or `global:heartbeat`), so the key alone cannot identify the selected agent. The focused fix carries the selected agent explicitly at the two existing owner boundaries:

- resolve the global heartbeat session from the selected agent's store;
- put the selected `AgentId` in the heartbeat message context while preserving the persisted session key.

This is deliberately limited to heartbeat identity and store selection. It does not introduce a second runtime-key model, new queue ownership, protocol changes, or compatibility state.

## User Impact

Secondary-agent heartbeats under global session scope now use the configured agent's workspace, heartbeat instructions, route, and session store. Default-agent and non-global behavior are unchanged. No configuration or migration is required.

## Evidence

Exact improved head: `152ef7eb3a922214690b34d09f0e25a341935865`

### Focused and broad Testbox gate

Blacksmith Testbox lease `tbx_01kx4bg934qvzmxnxcxh6mdab5` (`swift-lobster`):

```console
pnpm test src/infra/heartbeat-runner.identity.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts
# 2 files, 47 tests passed

pnpm check:changed
# core and coreTests lanes passed: type checks, lint, repository guards

pnpm build
# passed
```

Gate timing: 4m14.814s, exit 0.

The new regression table covers `isolatedSession=false` and `true`, separate `{agentId}` stores with distinct routes, the selected context/route, no default-agent store mutation, and correct isolated-row behavior.

### Real Gateway end-to-end proof

The exact head was built and run as a real Gateway on the same Testbox, with two configured agents, distinct workspaces and heartbeat files, `session.scope=global`, `dmScope=per-channel-peer`, a real `openclaw system event --mode now --session-key agent:historian2:main` CLI call, and the repository mock OpenAI HTTP endpoint. Fresh processes were used for both modes:

```json
{"sessionScope":"global","dmScope":"per-channel-peer","isolatedSession":false,"requestedSessionKey":"agent:historian2:main","modelSawHeartbeatMarker":true,"modelSawHistorianWorkspace":true,"modelSawMainHeartbeatMarker":false,"modelSawMainWorkspace":false}
{"sessionScope":"global","dmScope":"per-channel-peer","isolatedSession":true,"requestedSessionKey":"agent:historian2:main","modelSawHeartbeatMarker":true,"modelSawHistorianWorkspace":true,"modelSawMainHeartbeatMarker":false,"modelSawMainWorkspace":false}
```

Live timing: 37.973s, exit 0. A source-blind behavior validator passed all 3 contract clauses and anti-cheat probes.

### Review

- Fresh final Codex autoreview: clean, no accepted/actionable findings (correctness confidence 0.82).
- `git diff --check`: passed.
- No screenshot is useful for this non-visual routing bug; the captured model-request markers are the direct runtime proof.

## Compatibility / Security

- No config, environment, protocol, permission, or migration changes.
- The public/persisted global key remains unchanged.
- Data access is narrowed to the already-selected agent's store/workspace instead of falling back to the default agent.

## AI Assistance

- AI-assisted maintainer rewrite and validation: yes.
- Original contributor understanding/attestation remains represented by the retained co-author credit.
