### PR TITLE
fix: show iOS chat activity after foreground refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
+- **Apple foreground chat activity:** keep known pending-run ownership and show bounded fallback Writing state when foreground history reports active unanswered work without a chat snapshot, while keeping send, compact, and Talk controls consistently guarded. (#102309, #102308) Thanks @jmcte.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.
 - **OAuth refresh contention diagnostics:** keep local lock paths out of user-facing refresh failures and avoid duplicate failure prefixes while preserving structured provider and profile classification. (#83383) Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
-- **Apple foreground chat activity:** keep known pending-run ownership and show bounded fallback Writing state when foreground history reports active unanswered work without a chat snapshot, while keeping send, compact, and Talk controls consistently guarded. (#102309, #102308) Thanks @jmcte.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.
 - **OAuth refresh contention diagnostics:** keep local lock paths out of user-facing refresh failures and avoid duplicate failure prefixes while preserving structured provider and profile classification. (#83383) Thanks @vincentkoc.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -21771,7 +21771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 440,
+      "line": 442,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Retry Send",
       "surface": "apple",
@@ -21779,7 +21779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 454,
+      "line": 456,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Delete",
       "surface": "apple",
@@ -21787,7 +21787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 485,
+      "line": 487,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Stop Listening",
       "surface": "apple",
@@ -21795,7 +21795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 488,
+      "line": 490,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Listen",
       "surface": "apple",
@@ -21803,7 +21803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 535,
+      "line": 537,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Copy Message",
       "surface": "apple",
@@ -21811,7 +21811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 594,
+      "line": 596,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest",
       "surface": "apple",
@@ -21819,7 +21819,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 605,
+      "line": 607,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest reply",
       "surface": "apple",
@@ -21827,7 +21827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 625,
+      "line": 627,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -21835,7 +21835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1050,
+      "line": 1052,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Loading chat",
       "surface": "apple",
@@ -21843,7 +21843,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1130,
+      "line": 1132,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Dismiss",
       "surface": "apple",
@@ -21875,7 +21875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1481,
+      "line": 1553,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "delivery unconfirmed",
       "surface": "apple",
@@ -21883,7 +21883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1481,
+      "line": 1553,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "queued after route change",
       "surface": "apple",
@@ -21891,7 +21891,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1705,
+      "line": 1651,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before switching chats.",
       "surface": "apple",
@@ -21899,7 +21899,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1761,
+      "line": 1707,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before starting a new chat.",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -21771,7 +21771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 442,
+      "line": 440,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Retry Send",
       "surface": "apple",
@@ -21779,7 +21779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 456,
+      "line": 454,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Delete",
       "surface": "apple",
@@ -21787,7 +21787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 487,
+      "line": 485,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Stop Listening",
       "surface": "apple",
@@ -21795,7 +21795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 490,
+      "line": 488,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Listen",
       "surface": "apple",
@@ -21803,7 +21803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 537,
+      "line": 535,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Copy Message",
       "surface": "apple",
@@ -21811,7 +21811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 596,
+      "line": 594,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest",
       "surface": "apple",
@@ -21819,7 +21819,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 607,
+      "line": 605,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest reply",
       "surface": "apple",
@@ -21827,7 +21827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 627,
+      "line": 625,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -21835,7 +21835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1052,
+      "line": 1050,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Loading chat",
       "surface": "apple",
@@ -21843,7 +21843,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1132,
+      "line": 1130,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Dismiss",
       "surface": "apple",
@@ -21875,7 +21875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1553,
+      "line": 1555,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "delivery unconfirmed",
       "surface": "apple",
@@ -21883,7 +21883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1553,
+      "line": 1555,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "queued after route change",
       "surface": "apple",
@@ -21891,7 +21891,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1651,
+      "line": 1653,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before switching chats.",
       "surface": "apple",
@@ -21899,7 +21899,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1707,
+      "line": 1709,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before starting a new chat.",
       "surface": "apple",

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -573,7 +573,7 @@ struct OpenClawChatComposer: View {
     /// draft is empty, swapping to the send button once the user types.
     @ViewBuilder
     private var cleanTrailingControl: some View {
-        if !self.viewModel.hasDraftToSend, self.viewModel.pendingRunCount == 0, let talkControl {
+        if !self.viewModel.hasDraftToSend, !self.viewModel.hasBlockingRunActivity, let talkControl {
             self.compactTalkButton(talkControl)
         } else {
             self.sendButton

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -370,7 +370,9 @@ public struct OpenClawChatView: View {
             self.messageRow(for: msg)
         }
 
-        if self.viewModel.pendingRunCount > 0 {
+        if self.viewModel.pendingRunCount > 0 ||
+            self.viewModel.hasActiveSessionRunWithoutChatSnapshot
+        {
             ChatTypingIndicatorBubble(
                 style: self.style,
                 assistantName: self.assistantName,

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -370,9 +370,7 @@ public struct OpenClawChatView: View {
             self.messageRow(for: msg)
         }
 
-        if self.viewModel.pendingRunCount > 0 ||
-            self.viewModel.hasActiveSessionRunWithoutChatSnapshot
-        {
+        if self.viewModel.hasBlockingRunActivity {
             ChatTypingIndicatorBubble(
                 style: self.style,
                 assistantName: self.assistantName,
@@ -659,7 +657,7 @@ public struct OpenClawChatView: View {
     }
 
     private var hasVisibleTransientContent: Bool {
-        self.viewModel.pendingRunCount > 0 ||
+        self.viewModel.hasBlockingRunActivity ||
             !self.viewModel.pendingToolCalls.isEmpty ||
             (self.viewModel.streamingAssistantText.map {
                 AssistantTextParser.hasVisibleContent(in: $0, includeThinking: self.showsAssistantTrace)
@@ -718,7 +716,7 @@ public struct OpenClawChatView: View {
             !(self.viewModel.streamingAssistantText.map {
                 AssistantTextParser.hasVisibleContent(in: $0, includeThinking: self.showsAssistantTrace)
             } ?? false) &&
-            self.viewModel.pendingRunCount == 0 &&
+            !self.viewModel.hasBlockingRunActivity &&
             self.viewModel.pendingToolCalls.isEmpty
     }
 
@@ -770,7 +768,7 @@ public struct OpenClawChatView: View {
     private func handleTimelineChange() {
         guard self.hasPerformedInitialScroll else { return }
         if self.viewModel.messages.isEmpty,
-           self.viewModel.pendingRunCount == 0,
+           !self.viewModel.hasBlockingRunActivity,
            self.viewModel.pendingToolCalls.isEmpty,
            self.viewModel.streamingAssistantText == nil
         {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift
@@ -1,4 +1,9 @@
 import Foundation
+import OSLog
+
+private let chatSessionActionsLogger = Logger(
+    subsystem: "ai.openclaw",
+    category: "OpenClawChat")
 
 extension OpenClawChatViewModel {
     public func refreshSessions(limit: Int? = nil) {
@@ -33,6 +38,136 @@ extension OpenClawChatViewModel {
                 return
             }
             await self.fetchSessions(limit: nil, sessionSnapshot: self.currentSessionSnapshot())
+        }
+    }
+
+    /// One-shot session list fetch for search and archived browsing. Falls back
+    /// to locally filtering the cached active list when the gateway is
+    /// unreachable; archived rows exist only server-side, so archived mode
+    /// returns empty offline.
+    public func fetchSessionList(search: String?, archived: Bool) async -> [OpenClawChatSessionEntry] {
+        let normalizedSearch = search?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let query = normalizedSearch?.isEmpty == false ? normalizedSearch : nil
+        do {
+            let res = try await self.transport.listSessions(
+                limit: Self.sessionListFetchLimit,
+                search: query,
+                archived: archived)
+            return OpenClawChatSessionListOrganizer.organize(res.sessions)
+        } catch {
+            // A superseded (cancelled) fetch must not produce fallback rows;
+            // the newer task owns the scoped list. Callers also guard on
+            // Task.isCancelled before applying results.
+            guard !(error is CancellationError), !Task.isCancelled else { return [] }
+            guard !archived else { return [] }
+            guard let query else { return self.sessions }
+            return OpenClawChatSessionListOrganizer.filter(self.sessions, search: query)
+        }
+    }
+
+    public func renameSession(key: String, label: String) {
+        let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        let previous = self.sessions
+        if let index = self.sessions.firstIndex(where: { $0.key == key }) {
+            self.sessions[index].label = trimmed
+            self.sessions[index].displayName = trimmed
+        }
+        Task {
+            do {
+                try await self.transport.patchSession(
+                    key: key,
+                    label: trimmed,
+                    category: nil,
+                    pinned: nil,
+                    archived: nil,
+                    unread: nil)
+                self.refreshSessions()
+            } catch {
+                self.sessions = previous
+                self.errorText = error.localizedDescription
+                chatSessionActionsLogger.error(
+                    "sessions.patch(label) failed \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    public func setSessionPinned(key: String, pinned: Bool) {
+        let previous = self.sessions
+        if let index = self.sessions.firstIndex(where: { $0.key == key }) {
+            self.sessions[index].pinned = pinned
+            self.sessions[index].pinnedAt = pinned ? Date().timeIntervalSince1970 * 1000 : nil
+            self.sessions = OpenClawChatSessionListOrganizer.organize(self.sessions)
+        }
+        Task {
+            do {
+                try await self.transport.patchSession(
+                    key: key,
+                    label: nil,
+                    category: nil,
+                    pinned: pinned,
+                    archived: nil,
+                    unread: nil)
+                self.refreshSessions()
+            } catch {
+                self.sessions = previous
+                self.errorText = error.localizedDescription
+                chatSessionActionsLogger.error(
+                    "sessions.patch(pinned) failed \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    public func setSessionArchived(key: String, archived: Bool) {
+        guard archived else {
+            Task { await self.restoreSession(key: key) }
+            return
+        }
+        let previous = self.sessions
+        self.sessions.removeAll { $0.key == key }
+        Task {
+            do {
+                try await self.transport.patchSession(
+                    key: key,
+                    label: nil,
+                    category: nil,
+                    pinned: nil,
+                    archived: true,
+                    unread: nil)
+                if key == self.sessionKey {
+                    // The archived session rejects new sends; move the user back
+                    // to the main session instead of leaving a dead composer.
+                    self.switchSession(to: self.resolvedMainSessionKey)
+                }
+                self.refreshSessions()
+            } catch {
+                self.sessions = previous
+                self.errorText = error.localizedDescription
+                chatSessionActionsLogger.error(
+                    "sessions.patch(archived) failed \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    /// Restores an archived session. Returns false (with `errorText` set) on
+    /// failure so open-flows can avoid switching into a still-archived session.
+    @discardableResult
+    public func restoreSession(key: String) async -> Bool {
+        do {
+            try await self.transport.patchSession(
+                key: key,
+                label: nil,
+                category: nil,
+                pinned: nil,
+                archived: false,
+                unread: nil)
+            self.refreshSessions()
+            return true
+        } catch {
+            self.errorText = error.localizedDescription
+            chatSessionActionsLogger.error(
+                "sessions.patch(archived=false) failed \(error.localizedDescription, privacy: .public)")
+            return false
         }
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -62,6 +62,7 @@ public final class OpenClawChatViewModel {
     }
 
     public private(set) var pendingRunCount: Int = 0
+    public private(set) var hasActiveSessionRunWithoutChatSnapshot = false
 
     public private(set) var sessionKey: String {
         didSet { self.syncContextUsageFraction() }
@@ -178,6 +179,8 @@ public final class OpenClawChatViewModel {
     private nonisolated(unsafe) var pendingRunTimeoutTasks: [String: Task<Void, Never>] = [:]
     private var nextPendingRunTimeoutArmID: UInt64 = 0
     private var pendingRunTimeoutArmIDs: [String: UInt64] = [:]
+    @ObservationIgnored
+    private nonisolated(unsafe) var activeSessionRunIndicatorTimeoutTask: Task<Void, Never>?
     private let pendingRunTimeoutMs: UInt64 = 120_000
     private static let postSendRefreshDelaysMs: [UInt64] = [
         1500,
@@ -299,7 +302,9 @@ public final class OpenClawChatViewModel {
         self.eventTask = Task { [weak self, transport] in
             let stream = transport.events()
             for await evt in stream {
-                if Task.isCancelled { return }
+                if Task.isCancelled {
+                    return
+                }
                 await MainActor.run { [weak self] in
                     self?.handleTransportEvent(evt)
                 }
@@ -321,6 +326,7 @@ public final class OpenClawChatViewModel {
         self.bootstrapTask?.cancel()
         self.outboxRetryTask?.cancel()
         self.outboxChangesTask?.cancel()
+        self.activeSessionRunIndicatorTimeoutTask?.cancel()
         for (_, task) in self.pendingRunTimeoutTasks {
             task.cancel()
         }
@@ -454,7 +460,9 @@ public final class OpenClawChatViewModel {
             (agentChanged && self.usesMutableAgentRouting) ||
             contractRoutingChanged
         guard bootstrapIdentityChanged else {
-            if contractChanged, self.healthOK { flushOutboxIfNeeded() }
+            if contractChanged, self.healthOK {
+                flushOutboxIfNeeded()
+            }
             return
         }
         // Restart when this key depends on a changed routing value so cleared
@@ -513,7 +521,9 @@ public final class OpenClawChatViewModel {
     }
 
     private func usesMutableContractRouting(for contract: String?) -> Bool {
-        if self.usesMutableAgentRouting { return true }
+        if self.usesMutableAgentRouting {
+            return true
+        }
         let parts = self.sessionKey
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .split(separator: ":", maxSplits: 2, omittingEmptySubsequences: false)
@@ -572,7 +582,7 @@ public final class OpenClawChatViewModel {
     }
 
     public var canSend: Bool {
-        !self.isSubmittingDraft && !self.isSending && self.pendingRunCount == 0 && self.hasDraftToSend
+        !self.isSubmittingDraft && !self.isSending && !self.hasActiveRunBlockingSend && self.hasDraftToSend
     }
 
     public var hasDraftToSend: Bool {
@@ -594,6 +604,10 @@ public final class OpenClawChatViewModel {
             self.isSendingAttachmentDraft ||
             self.attachmentStagingCount > 0 ||
             !self.attachments.isEmpty
+    }
+
+    private var hasActiveRunBlockingSend: Bool {
+        self.pendingRunCount > 0 || self.hasActiveSessionRunWithoutChatSnapshot
     }
 
     /// Applies external owner changes once recording or staging releases them.
@@ -636,6 +650,40 @@ public final class OpenClawChatViewModel {
         guard self.streamingAssistantText != text else { return }
         self.streamingAssistantText = text
         self.markTimelineChanged()
+    }
+
+    private func updateActiveSessionRunWithoutChatSnapshot(_ active: Bool) {
+        guard self.hasActiveSessionRunWithoutChatSnapshot != active else { return }
+        self.hasActiveSessionRunWithoutChatSnapshot = active
+        if active {
+            self.armActiveSessionRunIndicatorTimeout()
+        } else {
+            self.activeSessionRunIndicatorTimeoutTask?.cancel()
+            self.activeSessionRunIndicatorTimeoutTask = nil
+        }
+        self.markTimelineChanged()
+    }
+
+    private func armActiveSessionRunIndicatorTimeout() {
+        self.activeSessionRunIndicatorTimeoutTask?.cancel()
+        let timeoutMs = self.pendingRunTimeoutMs
+        self.activeSessionRunIndicatorTimeoutTask = Task { [weak self] in
+            do {
+                try await Task.sleep(nanoseconds: timeoutMs * 1_000_000)
+            } catch {
+                return
+            }
+            await MainActor.run {
+                self?.updateActiveSessionRunWithoutChatSnapshot(false)
+            }
+        }
+    }
+
+    private func clearActiveSessionRunIndicatorIfLatestUserAnswered() {
+        guard self.hasActiveSessionRunWithoutChatSnapshot,
+              !Self.hasUnansweredLatestUser(in: self.messages)
+        else { return }
+        self.updateActiveSessionRunWithoutChatSnapshot(false)
     }
 
     private func logDiagnostic(_ message: String) {
@@ -757,6 +805,7 @@ public final class OpenClawChatViewModel {
         if canInvalidateOlderHistory {
             self.markHistoryRequestApplied(request)
         }
+        self.clearActiveSessionRunIndicatorIfLatestUserAnswered()
         let appliedThinkingLevel = !self.prefersExplicitThinkingLevel
             ? Self.normalizedThinkingLevel(payload.thinkingLevel)
             : nil
@@ -834,6 +883,7 @@ public final class OpenClawChatViewModel {
 
         self.isApplyingRunSnapshot = true
         defer { self.isApplyingRunSnapshot = false }
+        self.updateActiveSessionRunWithoutChatSnapshot(false)
         self.adoptRun(runId: runId, bufferedText: snapshot.text)
     }
 
@@ -870,6 +920,7 @@ public final class OpenClawChatViewModel {
         self.clearPendingRuns(reason: nil)
         self.pendingToolCallsById = [:]
         self.updateStreamingAssistantText(nil)
+        self.updateActiveSessionRunWithoutChatSnapshot(false)
         self.sessionId = nil
         let historyRequest = self.beginHistoryRequest(captureLatestUserTurn: requestedSessionKey == nil)
         let context = BootstrapContext(
@@ -951,11 +1002,21 @@ public final class OpenClawChatViewModel {
            refresh.supportsInFlightRunState,
            !refresh.hasInFlightRun
         {
-            self.clearPendingRuns(
-                reason: nil,
-                hapticEvent: self.assistantHapticEventAfterLatestUser())
-            self.pendingToolCallsById = [:]
-            self.updateStreamingAssistantText(nil)
+            if refresh.sessionHasActiveRun,
+               Self.hasUnansweredLatestUser(in: self.messages)
+            {
+                self.clearPendingRuns(reason: nil)
+                self.pendingToolCallsById = [:]
+                self.updateStreamingAssistantText(nil)
+                self.updateActiveSessionRunWithoutChatSnapshot(true)
+            } else {
+                self.updateActiveSessionRunWithoutChatSnapshot(false)
+                self.clearPendingRuns(
+                    reason: nil,
+                    hapticEvent: self.assistantHapticEventAfterLatestUser())
+                self.pendingToolCallsById = [:]
+                self.updateStreamingAssistantText(nil)
+            }
         }
         await pollHealthIfNeeded(force: true, sessionSnapshot: context.session)
     }
@@ -1096,7 +1157,9 @@ public final class OpenClawChatViewModel {
                 return (rank, index, command)
             }
             .sorted {
-                if $0.0 != $1.0 { return $0.0 < $1.0 }
+                if $0.0 != $1.0 {
+                    return $0.0 < $1.0
+                }
                 return $0.1 < $1.1
             }
             .map(\.2)
@@ -1163,17 +1226,23 @@ public final class OpenClawChatViewModel {
 
     private func handleLocalSlashCommandIfNeeded(_ command: String, draftInput: String) async -> Bool {
         if command == "/new" {
-            if self.input == draftInput { self.input = "" }
+            if self.input == draftInput {
+                self.input = ""
+            }
             await self.performStartNewSession(worktree: false)
             return true
         }
         if Self.resetTriggers.contains(command) {
-            if self.input == draftInput { self.input = "" }
+            if self.input == draftInput {
+                self.input = ""
+            }
             await self.performReset()
             return true
         }
         if Self.compactTriggers.contains(command) {
-            if self.input == draftInput { self.input = "" }
+            if self.input == draftInput {
+                self.input = ""
+            }
             await self.performCompact()
             return true
         }
@@ -1202,10 +1271,11 @@ public final class OpenClawChatViewModel {
             self.logDiagnostic("chat.ui send ignored reason=sending sessionKey=\(self.sessionKey)")
             return
         }
-        guard self.pendingRuns.isEmpty else {
+        guard !self.hasActiveRunBlockingSend else {
             self.logDiagnostic(
                 "chat.ui send ignored reason=pending sessionKey=\(self.sessionKey) "
-                    + "pending=\(self.pendingRunCount)")
+                    + "pending=\(self.pendingRunCount) "
+                    + "activeWithoutSnapshot=\(self.hasActiveSessionRunWithoutChatSnapshot)")
             return
         }
         let draftInput = self.input
@@ -1380,7 +1450,9 @@ public final class OpenClawChatViewModel {
         self.runMessageScopesByRunID[runId] = currentRunMessageScope()
 
         // Clear input immediately for responsive UX (before network await)
-        if self.input == draftInput { self.input = "" }
+        if self.input == draftInput {
+            self.input = ""
+        }
         let sentAttachmentIDs = Set(draftAttachments.map(\.id))
         self.attachments.removeAll { sentAttachmentIDs.contains($0.id) }
 
@@ -1533,7 +1605,9 @@ public final class OpenClawChatViewModel {
     func fetchSessions(limit: Int?, sessionSnapshot: SessionSnapshot? = nil) async {
         do {
             let res = try await transport.listSessions(limit: limit, search: nil, archived: false)
-            if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) { return }
+            if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) {
+                return
+            }
             let organized = OpenClawChatSessionListOrganizer.organize(res.sessions)
             self.sessions = organized
             self.sessionDefaults = res.defaults
@@ -1546,140 +1620,12 @@ public final class OpenClawChatViewModel {
         }
     }
 
-    /// One-shot session list fetch for search and archived browsing. Falls back
-    /// to locally filtering the cached active list when the gateway is
-    /// unreachable; archived rows exist only server-side, so archived mode
-    /// returns empty offline.
-    public func fetchSessionList(search: String?, archived: Bool) async -> [OpenClawChatSessionEntry] {
-        let normalizedSearch = search?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let query = normalizedSearch?.isEmpty == false ? normalizedSearch : nil
-        do {
-            let res = try await self.transport.listSessions(
-                limit: Self.sessionListFetchLimit,
-                search: query,
-                archived: archived)
-            return OpenClawChatSessionListOrganizer.organize(res.sessions)
-        } catch {
-            // A superseded (cancelled) fetch must not produce fallback rows;
-            // the newer task owns the scoped list. Callers also guard on
-            // Task.isCancelled before applying results.
-            guard !(error is CancellationError), !Task.isCancelled else { return [] }
-            guard !archived else { return [] }
-            guard let query else { return self.sessions }
-            return OpenClawChatSessionListOrganizer.filter(self.sessions, search: query)
-        }
-    }
-
-    public func renameSession(key: String, label: String) {
-        let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-        let previous = self.sessions
-        if let index = self.sessions.firstIndex(where: { $0.key == key }) {
-            self.sessions[index].label = trimmed
-            self.sessions[index].displayName = trimmed
-        }
-        Task {
-            do {
-                try await self.transport.patchSession(
-                    key: key,
-                    label: trimmed,
-                    category: nil,
-                    pinned: nil,
-                    archived: nil,
-                    unread: nil)
-                self.refreshSessions()
-            } catch {
-                self.sessions = previous
-                self.errorText = error.localizedDescription
-                chatUILogger.error(
-                    "sessions.patch(label) failed \(error.localizedDescription, privacy: .public)")
-            }
-        }
-    }
-
-    public func setSessionPinned(key: String, pinned: Bool) {
-        let previous = self.sessions
-        if let index = self.sessions.firstIndex(where: { $0.key == key }) {
-            self.sessions[index].pinned = pinned
-            self.sessions[index].pinnedAt = pinned ? Date().timeIntervalSince1970 * 1000 : nil
-            self.sessions = OpenClawChatSessionListOrganizer.organize(self.sessions)
-        }
-        Task {
-            do {
-                try await self.transport.patchSession(
-                    key: key,
-                    label: nil,
-                    category: nil,
-                    pinned: pinned,
-                    archived: nil,
-                    unread: nil)
-                self.refreshSessions()
-            } catch {
-                self.sessions = previous
-                self.errorText = error.localizedDescription
-                chatUILogger.error(
-                    "sessions.patch(pinned) failed \(error.localizedDescription, privacy: .public)")
-            }
-        }
-    }
-
-    public func setSessionArchived(key: String, archived: Bool) {
-        guard archived else {
-            Task { await self.restoreSession(key: key) }
-            return
-        }
-        let previous = self.sessions
-        self.sessions.removeAll { $0.key == key }
-        Task {
-            do {
-                try await self.transport.patchSession(
-                    key: key,
-                    label: nil,
-                    category: nil,
-                    pinned: nil,
-                    archived: true,
-                    unread: nil)
-                if key == self.sessionKey {
-                    // The archived session rejects new sends; move the user back
-                    // to the main session instead of leaving a dead composer.
-                    self.switchSession(to: self.resolvedMainSessionKey)
-                }
-                self.refreshSessions()
-            } catch {
-                self.sessions = previous
-                self.errorText = error.localizedDescription
-                chatUILogger.error(
-                    "sessions.patch(archived) failed \(error.localizedDescription, privacy: .public)")
-            }
-        }
-    }
-
-    /// Restores an archived session. Returns false (with `errorText` set) on
-    /// failure so open-flows can avoid switching into a still-archived session.
-    @discardableResult
-    public func restoreSession(key: String) async -> Bool {
-        do {
-            try await self.transport.patchSession(
-                key: key,
-                label: nil,
-                category: nil,
-                pinned: nil,
-                archived: false,
-                unread: nil)
-            self.refreshSessions()
-            return true
-        } catch {
-            self.errorText = error.localizedDescription
-            chatUILogger.error(
-                "sessions.patch(archived=false) failed \(error.localizedDescription, privacy: .public)")
-            return false
-        }
-    }
-
     private func fetchModels(sessionSnapshot: SessionSnapshot? = nil) async {
         do {
             let modelChoices = try await transport.listModels()
-            if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) { return }
+            if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) {
+                return
+            }
             self.modelChoices = modelChoices
             self.syncSelectedModel()
             syncThinkingLevelOptions()
@@ -1783,6 +1729,7 @@ public final class OpenClawChatViewModel {
         self.sessionId = nil
         self.pendingToolCallsById = [:]
         self.updateStreamingAssistantText(nil)
+        self.updateActiveSessionRunWithoutChatSnapshot(false)
         self.resetSlashCommandCatalog()
         self.clearPendingRuns(reason: nil)
     }
@@ -1813,7 +1760,7 @@ public final class OpenClawChatViewModel {
 
     func performCompact() async {
         guard !self.isCompacting else { return }
-        guard !self.isSending, self.pendingRuns.isEmpty, !self.isAborting else {
+        guard !self.isSending, !self.hasActiveRunBlockingSend, !self.isAborting else {
             self.errorText = "Wait for the current response before compacting the session."
             return
         }
@@ -2185,10 +2132,12 @@ public final class OpenClawChatViewModel {
         // run's final event already cleared pending state. Same-content turns
         // without this key remain distinct.
         if adoptCorrelatedUserMessage(incoming: sanitized) {
+            self.clearActiveSessionRunIndicatorIfLatestUserAnswered()
             self.applyDeferredExternalStateIfReady()
             return
         }
         if adoptProvisionalFinalMessage(incoming: sanitized) {
+            self.clearActiveSessionRunIndicatorIfLatestUserAnswered()
             return
         }
 
@@ -2196,6 +2145,7 @@ public final class OpenClawChatViewModel {
         replaceMessages(Self.dedupeMessages(reconciled))
         pruneProvisionalFinalMessages()
         pruneRunMessageScopes()
+        self.clearActiveSessionRunIndicatorIfLatestUserAnswered()
         self.applyDeferredExternalStateIfReady()
     }
 
@@ -2234,6 +2184,7 @@ public final class OpenClawChatViewModel {
         }
         if chat.state == "final" || chat.state == "aborted" || chat.state == "error" {
             self.invalidateHistorySnapshots()
+            self.updateActiveSessionRunWithoutChatSnapshot(false)
         }
         self.invalidateRunSnapshots()
         if !isOurRun {
@@ -2368,6 +2319,7 @@ public final class OpenClawChatViewModel {
         switch evt.stream {
         case "assistant":
             if let text = evt.data["text"]?.value as? String {
+                self.updateActiveSessionRunWithoutChatSnapshot(false)
                 self.updateStreamingAssistantText(text)
             }
         case "lifecycle":
@@ -2377,6 +2329,7 @@ public final class OpenClawChatViewModel {
             guard let name = evt.data["name"]?.value as? String else { return }
             guard let toolCallId = evt.data["toolCallId"]?.value as? String else { return }
             if phase == "start" {
+                self.updateActiveSessionRunWithoutChatSnapshot(false)
                 let args = evt.data["args"]
                 self.pendingToolCallsById[toolCallId] = OpenClawChatPendingToolCall(
                     toolCallId: toolCallId,
@@ -2755,7 +2708,12 @@ public final class OpenClawChatViewModel {
 
     @discardableResult
     private func refreshHistoryAfterRun(historyRequest request: HistoryRequest? = nil) async
-        -> (applied: Bool, runSnapshotApplied: Bool, supportsInFlightRunState: Bool, hasInFlightRun: Bool)
+        -> (
+            applied: Bool,
+            runSnapshotApplied: Bool,
+            supportsInFlightRunState: Bool,
+            hasInFlightRun: Bool,
+            sessionHasActiveRun: Bool)
     {
         let request = request ?? self.beginHistoryRequest()
         do {
@@ -2767,6 +2725,7 @@ public final class OpenClawChatViewModel {
                 for: request,
                 preservingOptimisticLocalMessages: true)
             let hasInFlightRun = Self.normalizedRunID(payload.inFlightRun?.runId) != nil
+            let sessionHasActiveRun = payload.sessionInfo?.hasActiveRun == true
             // `hasActiveRun` is session-wide and can be true for an embedded agent run.
             // Its presence capability-gates an authoritative missing chat snapshot, but
             // only `inFlightRun` establishes ownership of the pending chat run.
@@ -2775,10 +2734,11 @@ public final class OpenClawChatViewModel {
                 applied,
                 applied && runSnapshotApplied,
                 supportsInFlightRunState,
-                hasInFlightRun)
+                hasInFlightRun,
+                sessionHasActiveRun)
         } catch {
             chatUILogger.error("refresh history failed \(error.localizedDescription, privacy: .public)")
-            return (false, false, false, false)
+            return (false, false, false, false, false)
         }
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -62,7 +62,7 @@ public final class OpenClawChatViewModel {
     }
 
     public private(set) var pendingRunCount: Int = 0
-    public private(set) var hasActiveSessionRunWithoutChatSnapshot = false
+    private(set) var hasActiveSessionRunWithoutChatSnapshot = false
 
     public private(set) var sessionKey: String {
         didSet { self.syncContextUsageFraction() }
@@ -582,7 +582,7 @@ public final class OpenClawChatViewModel {
     }
 
     public var canSend: Bool {
-        !self.isSubmittingDraft && !self.isSending && !self.hasActiveRunBlockingSend && self.hasDraftToSend
+        !self.isSubmittingDraft && !self.isSending && !self.hasBlockingRunActivity && self.hasDraftToSend
     }
 
     public var hasDraftToSend: Bool {
@@ -606,7 +606,7 @@ public final class OpenClawChatViewModel {
             !self.attachments.isEmpty
     }
 
-    private var hasActiveRunBlockingSend: Bool {
+    var hasBlockingRunActivity: Bool {
         self.pendingRunCount > 0 || self.hasActiveSessionRunWithoutChatSnapshot
     }
 
@@ -1005,10 +1005,12 @@ public final class OpenClawChatViewModel {
             if refresh.sessionHasActiveRun,
                Self.hasUnansweredLatestUser(in: self.messages)
             {
-                self.clearPendingRuns(reason: nil)
                 self.pendingToolCallsById = [:]
                 self.updateStreamingAssistantText(nil)
-                self.updateActiveSessionRunWithoutChatSnapshot(true)
+                // Keep a known run ID authoritative so its stream and terminal
+                // events still route here. Synthesize activity only after the
+                // client has no run identity to preserve.
+                self.updateActiveSessionRunWithoutChatSnapshot(self.pendingRuns.isEmpty)
             } else {
                 self.updateActiveSessionRunWithoutChatSnapshot(false)
                 self.clearPendingRuns(
@@ -1271,7 +1273,7 @@ public final class OpenClawChatViewModel {
             self.logDiagnostic("chat.ui send ignored reason=sending sessionKey=\(self.sessionKey)")
             return
         }
-        guard !self.hasActiveRunBlockingSend else {
+        guard !self.hasBlockingRunActivity else {
             self.logDiagnostic(
                 "chat.ui send ignored reason=pending sessionKey=\(self.sessionKey) "
                     + "pending=\(self.pendingRunCount) "
@@ -1760,7 +1762,7 @@ public final class OpenClawChatViewModel {
 
     func performCompact() async {
         guard !self.isCompacting else { return }
-        guard !self.isSending, !self.hasActiveRunBlockingSend, !self.isAborting else {
+        guard !self.isSending, !self.hasBlockingRunActivity, !self.isAborting else {
             self.errorText = "Wait for the current response before compacting the session."
             return
         }
@@ -2360,6 +2362,7 @@ public final class OpenClawChatViewModel {
         guard isTerminalPhase || isFailure || aborted || isSuccessfulStatus else { return }
 
         self.invalidateHistorySnapshots()
+        self.updateActiveSessionRunWithoutChatSnapshot(false)
 
         if isFailure || aborted {
             self.errorText = Self.agentLifecycleErrorMessage(evt, aborted: aborted)
@@ -2508,6 +2511,15 @@ public final class OpenClawChatViewModel {
         else { return false }
         if refresh.applied, refresh.runSnapshotApplied, refresh.supportsInFlightRunState {
             if refresh.hasInFlightRun {
+                return true
+            }
+            if refresh.sessionHasActiveRun,
+               Self.hasUnansweredLatestUser(in: self.messages)
+            {
+                // A session-level active bit cannot identify a new chat run,
+                // but it is enough to retain the run ID this client already owns.
+                self.pendingToolCallsById = [:]
+                self.updateStreamingAssistantText(nil)
                 return true
             }
             self.clearPendingRun(runId)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift
@@ -222,7 +222,7 @@ public struct OpenClawChatWindowShell: View {
             } label: {
                 Label("Compact Session", systemImage: "arrow.down.right.and.arrow.up.left")
             }
-            .disabled(self.viewModel.pendingRunCount > 0)
+            .disabled(self.viewModel.hasBlockingRunActivity)
 
             Button(role: .destructive) {
                 self.isConfirmingClearHistory = true

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -1205,12 +1205,85 @@ struct ChatViewModelTests {
         #expect(await MainActor.run { !vm.canSend })
     }
 
+    @Test func `foreground user-only active session keeps activity indicator visible`() async throws {
+        let now = Date().timeIntervalSince1970 * 1000
+        let historyCalls = AsyncCounter()
+        let userOnlyHistory = historyPayload(
+            messages: [chatTextMessage(role: "user", text: "quiet task", timestamp: now)],
+            hasActiveRun: true)
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [historyPayload(), userOnlyHistory, userOnlyHistory],
+            requestHistoryHook: { _ in _ = await historyCalls.increment() },
+            sendMessageStatus: "pending")
+
+        try await loadAndWaitBootstrap(vm: vm)
+        await sendUserMessage(vm, text: "quiet task")
+        try await waitUntil("send refresh applies user-only history") {
+            await historyCalls.current() == 2
+        }
+        #expect(await MainActor.run { vm.pendingRunCount == 1 })
+        await MainActor.run { vm.resumeFromForeground() }
+        try await waitUntil("foreground history applies") {
+            await historyCalls.current() == 3
+        }
+        #expect(await MainActor.run { vm.pendingRunCount == 0 })
+        #expect(await MainActor.run { vm.hasActiveSessionRunWithoutChatSnapshot })
+        await MainActor.run { vm.input = "another task" }
+        #expect(await MainActor.run { !vm.canSend })
+        await MainActor.run { vm.send() }
+        await Task.yield()
+        #expect(await transport.sentMessages() == ["quiet task"])
+
+        transport.emit(
+            .sessionMessage(
+                OpenClawSessionMessageEventPayload(
+                    sessionKey: "main",
+                    message: chatTextModelMessage(role: "assistant", text: "done", timestamp: now + 1),
+                    messageId: "msg-done",
+                    messageSeq: 2)))
+        try await waitUntil("assistant session message clears activity indicator") {
+            await MainActor.run { !vm.hasActiveSessionRunWithoutChatSnapshot }
+        }
+    }
+
+    @Test func `session switch clears active session activity indicator`() async throws {
+        let now = Date().timeIntervalSince1970 * 1000
+        let historyCalls = AsyncCounter()
+        let userOnlyHistory = historyPayload(
+            messages: [chatTextMessage(role: "user", text: "quiet task", timestamp: now)],
+            hasActiveRun: true)
+        let (_, vm) = await makeViewModel(
+            historyResponses: [historyPayload(), userOnlyHistory, userOnlyHistory, historyPayload(sessionKey: "other")],
+            requestHistoryHook: { _ in _ = await historyCalls.increment() },
+            sendMessageStatus: "pending")
+
+        try await loadAndWaitBootstrap(vm: vm)
+        await sendUserMessage(vm, text: "quiet task")
+        try await waitUntil("send refresh applies user-only history") {
+            await historyCalls.current() == 2
+        }
+        await MainActor.run { vm.resumeFromForeground() }
+        try await waitUntil("foreground history applies") {
+            await historyCalls.current() == 3
+        }
+        #expect(await MainActor.run { vm.hasActiveSessionRunWithoutChatSnapshot })
+
+        await MainActor.run { vm.switchSession(to: "other") }
+        try await waitUntil("other session bootstrap applies") {
+            await historyCalls.current() == 4
+        }
+        await MainActor.run { vm.input = "new task" }
+        #expect(await MainActor.run { !vm.hasActiveSessionRunWithoutChatSnapshot })
+        #expect(await MainActor.run { vm.canSend })
+    }
+
     @Test func `foreground clears completed run without assistant output`() async throws {
         let activeHistory = historyPayload(
             messages: [chatTextMessage(role: "user", text: "quiet task", timestamp: 1)],
             inFlightRun: OpenClawChatInFlightRun(runId: "run-quiet", text: ""))
         let completedHistory = historyPayload(
-            messages: [chatTextMessage(role: "user", text: "quiet task", timestamp: 1)])
+            messages: [chatTextMessage(role: "user", text: "quiet task", timestamp: 1)],
+            hasActiveRun: false)
         let (_, vm) = await makeViewModel(historyResponses: [activeHistory, completedHistory])
 
         try await loadAndWaitBootstrap(vm: vm)
@@ -1219,6 +1292,26 @@ struct ChatViewModelTests {
         try await waitUntil("silent completed run clears") {
             await MainActor.run { vm.pendingRunCount == 0 }
         }
+        #expect(await MainActor.run { !vm.hasActiveSessionRunWithoutChatSnapshot })
+    }
+
+    @Test func `foreground active session with answered chat does not show activity indicator`() async throws {
+        let answeredHistory = historyPayload(
+            messages: [
+                chatTextMessage(role: "user", text: "done", timestamp: 1),
+                chatTextMessage(role: "assistant", text: "finished", timestamp: 2),
+            ],
+            hasActiveRun: true)
+        let (_, vm) = await makeViewModel(historyResponses: [historyPayload(), answeredHistory])
+
+        try await loadAndWaitBootstrap(vm: vm)
+        await MainActor.run { vm.resumeFromForeground() }
+        try await waitUntil("answered history applies") {
+            await MainActor.run { vm.messages.count == 2 }
+        }
+
+        #expect(await MainActor.run { vm.pendingRunCount == 0 })
+        #expect(await MainActor.run { !vm.hasActiveSessionRunWithoutChatSnapshot })
     }
 
     @Test func `foreground missing snapshot does not clear an in-flight send`() async throws {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -1205,14 +1205,14 @@ struct ChatViewModelTests {
         #expect(await MainActor.run { !vm.canSend })
     }
 
-    @Test func `foreground user-only active session keeps activity indicator visible`() async throws {
+    @Test func `active session history preserves the known pending run`() async throws {
         let now = Date().timeIntervalSince1970 * 1000
         let historyCalls = AsyncCounter()
         let userOnlyHistory = historyPayload(
             messages: [chatTextMessage(role: "user", text: "quiet task", timestamp: now)],
             hasActiveRun: true)
         let (transport, vm) = await makeViewModel(
-            historyResponses: [historyPayload(), userOnlyHistory, userOnlyHistory],
+            historyResponses: [historyPayload(), userOnlyHistory, userOnlyHistory, userOnlyHistory],
             requestHistoryHook: { _ in _ = await historyCalls.increment() },
             sendMessageStatus: "pending")
 
@@ -1222,17 +1222,49 @@ struct ChatViewModelTests {
             await historyCalls.current() == 2
         }
         #expect(await MainActor.run { vm.pendingRunCount == 1 })
+        try await waitUntil("post-send fallback keeps known run ownership", timeoutSeconds: 7.0) {
+            let historyCount = await historyCalls.current()
+            let pendingRunCount = await MainActor.run { vm.pendingRunCount }
+            return historyCount >= 3 && pendingRunCount == 1
+        }
         await MainActor.run { vm.resumeFromForeground() }
         try await waitUntil("foreground history applies") {
-            await historyCalls.current() == 3
+            await historyCalls.current() >= 4
         }
-        #expect(await MainActor.run { vm.pendingRunCount == 0 })
-        #expect(await MainActor.run { vm.hasActiveSessionRunWithoutChatSnapshot })
+        #expect(await MainActor.run { vm.pendingRunCount == 1 })
+        #expect(await MainActor.run { !vm.hasActiveSessionRunWithoutChatSnapshot })
         await MainActor.run { vm.input = "another task" }
         #expect(await MainActor.run { !vm.canSend })
         await MainActor.run { vm.send() }
         await Task.yield()
         #expect(await transport.sentMessages() == ["quiet task"])
+
+        let runId = try await waitForLastSentRunId(transport)
+        emitAgentLifecycleEnd(transport: transport, runId: runId)
+        try await waitUntil("terminal lifecycle clears known run activity") {
+            await MainActor.run {
+                vm.pendingRunCount == 0 && !vm.hasActiveSessionRunWithoutChatSnapshot
+            }
+        }
+    }
+
+    @Test func `foreground synthesizes activity when no run snapshot or local run exists`() async throws {
+        let now = Date().timeIntervalSince1970 * 1000
+        let historyCalls = AsyncCounter()
+        let userOnlyHistory = historyPayload(
+            messages: [chatTextMessage(role: "user", text: "quiet task", timestamp: now)],
+            hasActiveRun: true)
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [userOnlyHistory, userOnlyHistory],
+            requestHistoryHook: { _ in _ = await historyCalls.increment() })
+
+        try await loadAndWaitBootstrap(vm: vm)
+        #expect(await MainActor.run { vm.pendingRunCount == 0 })
+        await MainActor.run { vm.resumeFromForeground() }
+        try await waitUntil("foreground history applies") {
+            await historyCalls.current() == 2
+        }
+        #expect(await MainActor.run { vm.hasActiveSessionRunWithoutChatSnapshot })
 
         transport.emit(
             .sessionMessage(
@@ -1253,24 +1285,19 @@ struct ChatViewModelTests {
             messages: [chatTextMessage(role: "user", text: "quiet task", timestamp: now)],
             hasActiveRun: true)
         let (_, vm) = await makeViewModel(
-            historyResponses: [historyPayload(), userOnlyHistory, userOnlyHistory, historyPayload(sessionKey: "other")],
-            requestHistoryHook: { _ in _ = await historyCalls.increment() },
-            sendMessageStatus: "pending")
+            historyResponses: [userOnlyHistory, userOnlyHistory, historyPayload(sessionKey: "other")],
+            requestHistoryHook: { _ in _ = await historyCalls.increment() })
 
         try await loadAndWaitBootstrap(vm: vm)
-        await sendUserMessage(vm, text: "quiet task")
-        try await waitUntil("send refresh applies user-only history") {
-            await historyCalls.current() == 2
-        }
         await MainActor.run { vm.resumeFromForeground() }
         try await waitUntil("foreground history applies") {
-            await historyCalls.current() == 3
+            await historyCalls.current() == 2
         }
         #expect(await MainActor.run { vm.hasActiveSessionRunWithoutChatSnapshot })
 
         await MainActor.run { vm.switchSession(to: "other") }
         try await waitUntil("other session bootstrap applies") {
-            await historyCalls.current() == 4
+            await historyCalls.current() == 3
         }
         await MainActor.run { vm.input = "new task" }
         #expect(await MainActor.run { !vm.hasActiveSessionRunWithoutChatSnapshot })


### PR DESCRIPTION
Closes #102308

AI-assisted: yes.

## What Problem This Solves

Fixes an issue where iOS users who send a chat message and return to the chat during a long-running session would see an idle-looking transcript when the latest user turn was still unanswered and the session still had active work.

## Why This Change Was Made

The mobile chat view now keeps an already-owned run ID when foreground or post-send history still reports active unanswered work without a chat `inFlightRun` snapshot. That preserves normal stream, tool, lifecycle, timeout, and terminal-event routing. When no local run ID exists, the view renders a bounded fallback activity state until answered history/session messages, a terminal event, session switch, reset, or timeout resolves the ambiguity.

Both known and fallback activity use one presentation/send gate, so the transcript, composer, Talk affordance, and Compact action cannot disagree about whether a response is active.

The follow-up commit also moved existing session action methods into `ChatViewModel+SessionActions.swift` so `ChatViewModel.swift` stays below the SwiftLint `file_length` cap after adding the new active-session state.

## User Impact

iOS users get visible feedback that the assistant is still working after leaving and returning to a chat during a long-running run. Send, Talk, and Compact controls stay guarded against starting conflicting work until the known or fallback activity state clears.

## Evidence

Redacted before evidence:

- Recording: https://github.com/jmcte/openclaw/releases/download/proof-ios-chat-pending-state-2026-07-09/ios-chat-pending-state-minimal.mp4
- Still after returning to the chat: https://github.com/jmcte/openclaw/releases/download/proof-ios-chat-pending-state-2026-07-09/ios-chat-pending-state-minimal-return.jpg
- Still showing the idle-looking state: https://github.com/jmcte/openclaw/releases/download/proof-ios-chat-pending-state-2026-07-09/ios-chat-pending-state-minimal-idle.jpg
- Evidence host release: https://github.com/jmcte/openclaw/releases/tag/proof-ios-chat-pending-state-2026-07-09

Redacted after-fix simulator evidence:

- iOS simulator still showing the returned chat activity indicator and guarded composer: https://github.com/jmcte/openclaw/releases/download/proof-ios-chat-pending-state-2026-07-09/ios-chat-after-fix-active-indicator.png

Local validation:

```text
swift test --filter ChatViewModelTests
Result: 166 tests passed

swift test --filter ChatStreamReplayTests
Result: 7 tests passed

swiftformat --lint apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift --config config/swiftformat
Result: passed

pnpm native:i18n:check
Result: native-app-i18n changed=false

git diff --check
Result: passed

.agents/skills/autoreview/scripts/autoreview --mode local
Result: clean, no accepted/actionable findings

xcodegen generate
xcodebuild -project OpenClawChatProof.xcodeproj -scheme OpenClawChatProof -sdk iphonesimulator -destination 'id=DC0B43DB-F6EB-409D-89CA-E22F9DE252AA' -derivedDataPath /private/tmp/openclaw-ios-chat-proof/DerivedData build
xcrun simctl install DC0B43DB-F6EB-409D-89CA-E22F9DE252AA /private/tmp/openclaw-ios-chat-proof/DerivedData/Build/Products/Debug-iphonesimulator/OpenClawChatProof.app
xcrun simctl launch DC0B43DB-F6EB-409D-89CA-E22F9DE252AA ai.openclaw.proof.chat
xcrun simctl io DC0B43DB-F6EB-409D-89CA-E22F9DE252AA screenshot /private/tmp/openclaw-ios-chat-proof/ios-chat-after-fix-active-indicator.png
Result: after-fix simulator still captured from a temporary proof host importing this PR's OpenClawChatUI.
```

Maintainer follow-up validation on the updated implementation:

```text
swiftformat --lint on the changed Swift surfaces (with existing unrelated whole-file findings excluded)
Result: passed

pnpm native:i18n:check on Blacksmith Testbox tbx_01kx2x3454zj142gk2thbk72r3
Result: passed

autoreview --mode local
Result: one compatibility warning rejected because the property exists only in this unmerged PR; no shipped API is removed
```

CI-specific note:

```text
ChatViewModel.swift effective source lines after the split: 2471
CI SwiftLint file_length cap: 2500
```

Agent transcript logs were not included because they require explicit approval before adding them to a public issue or PR body.
