### PR TITLE
fix(config): reject invalid heartbeat activeHours without cadence

### DIFF
--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -263,6 +263,56 @@ describe("normalizeCompatibilityConfigValues", () => {
     expect(res.changes.some((change) => change.includes("workspace"))).toBe(false);
   });
 
+  it("removes invalid heartbeat active-hours windows so saved config can load", () => {
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        agents: {
+          defaults: {
+            heartbeat: {
+              every: "30m",
+              activeHours: { start: "99:99", end: "17:00" },
+            },
+          },
+          list: [
+            {
+              id: "ops",
+              heartbeat: {
+                prompt: "Check alerts",
+                activeHours: { start: "09:00", end: "not-a-time" },
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(res.config.agents?.defaults?.heartbeat).toEqual({ every: "30m" });
+    expect(res.config.agents?.list?.[0]?.heartbeat).toEqual({ prompt: "Check alerts" });
+    expect(res.changes).toContain(
+      "Removed invalid agents.defaults.heartbeat.activeHours; heartbeats will use unrestricted hours until it is reconfigured.",
+    );
+    expect(res.changes).toContain(
+      "Removed invalid agents.list[0].heartbeat.activeHours; heartbeats will use unrestricted hours until it is reconfigured.",
+    );
+    expect(validateConfigObject(res.config).ok).toBe(true);
+  });
+
+  it("preserves valid heartbeat active-hours windows", () => {
+    const config = legacyConfig({
+      agents: {
+        defaults: {
+          heartbeat: {
+            activeHours: { start: "09:00", end: "24:00", timezone: "user" },
+          },
+        },
+      },
+    });
+    const res = normalizeCompatibilityConfigValues(config);
+
+    expect(res.config).toEqual(config);
+    expect(res.changes.some((change) => change.includes("activeHours"))).toBe(false);
+  });
+
   it("removes bindings for missing configured agents", () => {
     const res = normalizeCompatibilityConfigValues({
       agents: {

--- a/src/commands/doctor/shared/legacy-config-core-migrate.ts
+++ b/src/commands/doctor/shared/legacy-config-core-migrate.ts
@@ -1,5 +1,6 @@
 // Core doctor compatibility migration pipeline for current config objects.
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { HeartbeatSchema } from "../../../config/zod-schema.agent-runtime.js";
 import { runPluginSetupConfigMigrations } from "../../../plugins/setup-registry.js";
 import { migrateLegacySecretRefEnvMarkers } from "../../../secrets/legacy-secretref-env-marker.js";
 import { applyChannelDoctorCompatibilityMigrations } from "./channel-legacy-config-migrate.js";
@@ -9,6 +10,73 @@ import { normalizeBaseCompatibilityConfigValues } from "./legacy-config-compatib
 import { normalizeLegacyOpenAICodexModelsAddMetadata } from "./legacy-config-core-normalizers.js";
 import { stripRetiredTuningKnobs } from "./legacy-config-migrations.runtime.retired-media.js";
 import { migrateReservedMcpServerNames } from "./reserved-mcp-server-name-migrate.js";
+
+function repairInvalidHeartbeatActiveHours(cfg: OpenClawConfig, changes: string[]): OpenClawConfig {
+  const repairHeartbeat = (
+    heartbeat: unknown,
+    path: string,
+  ): { value: unknown; changed: boolean } => {
+    if (!heartbeat || typeof heartbeat !== "object" || Array.isArray(heartbeat)) {
+      return { value: heartbeat, changed: false };
+    }
+    const record = heartbeat as Record<string, unknown>;
+    if (!Object.hasOwn(record, "activeHours")) {
+      return { value: heartbeat, changed: false };
+    }
+    const result = HeartbeatSchema.safeParse({ activeHours: record.activeHours });
+    if (result.success) {
+      return { value: heartbeat, changed: false };
+    }
+
+    const { activeHours: _activeHours, ...rest } = record;
+    changes.push(
+      `Removed invalid ${path}.activeHours; heartbeats will use unrestricted hours until it is reconfigured.`,
+    );
+    return { value: rest, changed: true };
+  };
+
+  const defaultsHeartbeat = repairHeartbeat(
+    cfg.agents?.defaults?.heartbeat,
+    "agents.defaults.heartbeat",
+  );
+  const agents = cfg.agents?.list;
+  let listChanged = false;
+  const nextAgents = Array.isArray(agents)
+    ? agents.map((agent, index) => {
+        if (!agent || typeof agent !== "object") {
+          return agent;
+        }
+        const repaired = repairHeartbeat(
+          (agent as Record<string, unknown>).heartbeat,
+          `agents.list[${index}].heartbeat`,
+        );
+        if (!repaired.changed) {
+          return agent;
+        }
+        listChanged = true;
+        return { ...agent, heartbeat: repaired.value };
+      })
+    : agents;
+
+  if (!defaultsHeartbeat.changed && !listChanged) {
+    return cfg;
+  }
+  return {
+    ...cfg,
+    agents: {
+      ...cfg.agents,
+      ...(defaultsHeartbeat.changed
+        ? {
+            defaults: {
+              ...cfg.agents?.defaults,
+              heartbeat: defaultsHeartbeat.value,
+            },
+          }
+        : {}),
+      ...(listChanged ? { list: nextAgents as typeof agents } : {}),
+    },
+  } as OpenClawConfig;
+}
 
 function repairNullAgentWorkspaces(cfg: OpenClawConfig, changes: string[]): OpenClawConfig {
   const agents = cfg.agents?.list;
@@ -93,6 +161,7 @@ export function normalizeCompatibilityConfigValues(
     changes.push(...secretRefMarkers.changes);
   }
   next = normalizeLegacyOpenAICodexModelsAddMetadata(next, changes);
+  next = repairInvalidHeartbeatActiveHours(next, changes);
   next = repairNullAgentWorkspaces(next, changes);
   next = pruneBindingsForMissingAgents(next, changes);
 

--- a/src/config/zod-schema.agent-defaults.test.ts
+++ b/src/config/zod-schema.agent-defaults.test.ts
@@ -454,6 +454,22 @@ describe("agent defaults schema", () => {
     expect(agent.heartbeat?.timeoutSeconds).toBe(45);
   });
 
+  it("rejects invalid heartbeat activeHours without an explicit cadence", () => {
+    expectSchemaFailurePath(
+      AgentDefaultsSchema.safeParse({
+        heartbeat: { activeHours: { start: "99:99", end: "17:00" } },
+      }),
+      "heartbeat.activeHours.start",
+    );
+    expectSchemaFailurePath(
+      AgentEntrySchema.safeParse({
+        id: "ops",
+        heartbeat: { activeHours: { start: "09:00", end: "not-a-time" } },
+      }),
+      "heartbeat.activeHours.end",
+    );
+  });
+
   it("accepts per-agent TTS overrides", () => {
     const agent = AgentEntrySchema.parse({
       id: "reader",

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -92,17 +92,16 @@ export const HeartbeatSchema = z
   })
   .strict()
   .superRefine((val, ctx) => {
-    if (!val.every) {
-      return;
-    }
-    try {
-      parseDurationMs(val.every, { defaultUnit: "m" });
-    } catch {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["every"],
-        message: "invalid duration (use ms, s, m, h)",
-      });
+    if (val.every) {
+      try {
+        parseDurationMs(val.every, { defaultUnit: "m" });
+      } catch {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["every"],
+          message: "invalid duration (use ms, s, m, h)",
+        });
+      }
     }
 
     const active = val.activeHours;


### PR DESCRIPTION
Closes #102317

## What Problem This Solves

Fixes an issue where users configuring heartbeat active hours could provide malformed `start` or `end` times and have the config accepted when they relied on the default heartbeat cadence. In that case, the invalid window could be treated as unrestricted at runtime instead of limiting heartbeat runs to the intended hours.

## Why This Change Was Made

The heartbeat schema now validates `activeHours.start` and `activeHours.end` whenever `activeHours` is present, while keeping `heartbeat.every` duration validation limited to cases where an explicit cadence is configured. This keeps the existing default cadence and runtime active-hours behavior unchanged; the risk is rejecting previously accepted malformed config, which is covered by focused schema tests for both defaults and per-agent heartbeat settings.

## User Impact

Users get the same `invalid time (use "HH:MM" 24h format)` validation error for malformed heartbeat active-hours windows whether or not they set `heartbeat.every`. Valid heartbeat configs and the default 30m cadence continue to work as before.

## Evidence

Before the fix on current `upstream/main`, importing the real schemas and parsing malformed active-hours config showed the gap:

```text
defaults bad start without every: success=true
agent bad end without every: success=true
defaults bad start with every: success=false
heartbeat.activeHours.start: invalid time (use "HH:MM" 24h format)
```

After the fix, the same real-schema probe rejects both no-cadence malformed windows:

```text
defaults bad start without every: success=false
heartbeat.activeHours.start: invalid time (use "HH:MM" 24h format)
agent bad end without every: success=false
heartbeat.activeHours.end: invalid time (use "HH:MM" 24h format)
defaults bad start with every: success=false
heartbeat.activeHours.start: invalid time (use "HH:MM" 24h format)
```

Focused validation run locally in the linked worktree:

```text
node scripts/run-vitest.mjs src/config/zod-schema.agent-defaults.test.ts src/infra/heartbeat-active-hours.test.ts
Test Files  2 passed (2)
Tests  39 passed (39)
```

Additional local checks:

```text
git diff --check
autoreview --mode local
autoreview clean: no accepted/actionable findings reported
```

I did not run full local `pnpm build && pnpm check && pnpm test` in this linked worktree; GitHub CI should provide the broader repository proof.

AI-assisted: yes; implementation and proof were reviewed manually before opening this PR.

## Maintainer follow-up (July 30, 2026)

ClawSweeper's compatibility finding is addressed on the contributor branch:

- rebased onto current `main`
- preserved the original validation commit and author
- added `openclaw doctor --fix` recovery for saved invalid windows
- recovery removes only the invalid `activeHours` object, preserving the rest of the heartbeat config
- the repaired config retains the previously permissive, unrestricted-hours behavior until the operator reconfigures the window

Focused exact-tree validation:

```text
node scripts/run-vitest.mjs src/config/zod-schema.agent-defaults.test.ts src/commands/doctor-legacy-config.migrations.test.ts
Test Files  2 passed (2)
Tests  121 passed (121)

oxlint: clean
git diff --check: clean
autoreview: clean, no accepted/actionable findings
```
