### PR TITLE
fix: cron main-session wakes skipped as disabled without per-agent heartbeat config [AI-assisted]

### DIFF
--- a/src/infra/heartbeat-runner.cron-wake.test.ts
+++ b/src/infra/heartbeat-runner.cron-wake.test.ts
@@ -1,0 +1,110 @@
+// Regression for #101537: cron-sourced main-session wakes were recorded as
+// status=skipped / error="disabled" whenever the target agent had no per-agent
+// heartbeat config (common for the default "main" agent). A cron wake is an
+// explicit deliver-to-main request, not a scheduled heartbeat poll, so the
+// per-agent heartbeat-enabled and interval guards must not gate it. The global
+// heartbeats toggle still applies to cron-sourced wakes.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { runHeartbeatOnce } from "./heartbeat-runner.js";
+import { seedMainSessionStore, withTempHeartbeatSandbox } from "./heartbeat-runner.test-utils.js";
+
+vi.mock("./outbound/deliver.js", () => ({
+  deliverOutboundPayloads: vi.fn().mockResolvedValue([]),
+  deliverOutboundPayloadsInternal: vi.fn().mockResolvedValue([]),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function cronWakeConfig(tmpDir: string, storePath: string): OpenClawConfig {
+  // A second agent with an explicit heartbeat config makes `hasExplicit` true,
+  // so the default "main" agent (no per-agent heartbeat) is treated as
+  // heartbeat-disabled by isHeartbeatEnabledForAgent — reproducing the
+  // status=skipped/error="disabled" outcome from #101537.
+  return {
+    agents: {
+      defaults: { workspace: tmpDir },
+      list: [
+        { id: "main", default: true },
+        { id: "ops", heartbeat: { every: "5m", target: "whatsapp" } },
+      ],
+    },
+    channels: { whatsapp: { allowFrom: ["*"] } },
+    session: { store: storePath },
+  } as OpenClawConfig;
+}
+
+describe("runHeartbeatOnce – cron-sourced wake bypasses heartbeat config gate (#101537)", () => {
+  it("wakes the main agent even when no per-agent heartbeat is configured", async () => {
+    await withTempHeartbeatSandbox(
+      async ({ tmpDir, storePath, replySpy }) => {
+        const cfg = cronWakeConfig(tmpDir, storePath);
+        const sessionKey = await seedMainSessionStore(storePath, cfg, {
+          lastChannel: "whatsapp",
+          lastProvider: "whatsapp",
+          lastTo: "+15551234567",
+        });
+        replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+        const res = await runHeartbeatOnce({
+          cfg,
+          agentId: "main",
+          source: "cron",
+          intent: "immediate",
+          reason: "cron:test-job",
+          sessionKey,
+          heartbeat: { target: "last" },
+          deps: {
+            getReplyFromConfig: replySpy,
+            getQueueSize: () => 0,
+            nowMs: () => 0,
+          },
+        });
+
+        // Before the fix this returned { status: "skipped", reason: "disabled" }
+        // because the main agent has no per-agent heartbeat config.
+        expect(res.status).toBe("ran");
+      },
+      { prefix: "openclaw-hb-cron-wake-" },
+    );
+  });
+
+  it("still skips cron wakes when global heartbeats are disabled", async () => {
+    const { setHeartbeatsEnabled } = await import("./heartbeat-wake.js");
+    await withTempHeartbeatSandbox(
+      async ({ tmpDir, storePath, replySpy }) => {
+        const cfg = cronWakeConfig(tmpDir, storePath);
+        const sessionKey = await seedMainSessionStore(storePath, cfg, {
+          lastChannel: "whatsapp",
+          lastProvider: "whatsapp",
+          lastTo: "+15551234567",
+        });
+        replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+        setHeartbeatsEnabled(false);
+        try {
+          const res = await runHeartbeatOnce({
+            cfg,
+            agentId: "main",
+            source: "cron",
+            intent: "immediate",
+            reason: "cron:test-job",
+            sessionKey,
+            heartbeat: { target: "last" },
+            deps: {
+              getReplyFromConfig: replySpy,
+              getQueueSize: () => 0,
+              nowMs: () => 0,
+            },
+          });
+          expect(res.status).toBe("skipped");
+          expect((res as { reason?: string }).reason).toBe("disabled");
+        } finally {
+          setHeartbeatsEnabled(true);
+        }
+      },
+      { prefix: "openclaw-hb-cron-wake-" },
+    );
+  });
+});

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1447,11 +1447,22 @@ export async function runHeartbeatOnce(opts: {
   if (!areHeartbeatsEnabled()) {
     return { status: "skipped", reason: "disabled" };
   }
-  if (!isHeartbeatEnabledForAgent(cfg, agentId)) {
-    return { status: "skipped", reason: "disabled" };
-  }
-  if (!resolveHeartbeatIntervalMs(cfg, undefined, heartbeat)) {
-    return { status: "skipped", reason: "disabled" };
+  // Cron-sourced wakes are explicit deliver-to-main requests (e.g. a cron job
+  // with sessionTarget "main" and a systemEvent payload), not scheduled
+  // heartbeat polls. An agent without per-agent heartbeat config (common for
+  // the default "main" agent) must still be woken; otherwise the cron run is
+  // recorded as status=skipped/error="disabled" and the main session never
+  // receives the systemEvent. The global heartbeats toggle above still gates
+  // cron wakes. Both the immediate wake (wakeMode "now", timer.ts) and the
+  // queued wake (wakeMode "next-heartbeat", via requestHeartbeat's scheduled
+  // handler) route through this function with source "cron".
+  if (opts.source !== "cron") {
+    if (!isHeartbeatEnabledForAgent(cfg, agentId)) {
+      return { status: "skipped", reason: "disabled" };
+    }
+    if (!resolveHeartbeatIntervalMs(cfg, undefined, heartbeat)) {
+      return { status: "skipped", reason: "disabled" };
+    }
   }
 
   const startedAt = opts.deps?.nowMs?.() ?? Date.now();


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

Closes #101537

## What Problem This Solves

Fixes an issue where cron jobs that deliver a `systemEvent` to the main session (`sessionTarget: "main"`) were recorded as `status=skipped` / `error="disabled"` and never woke the main agent, whenever the target agent had no per-agent heartbeat config. Any workflow relying on cron to auto-continue the main session did not fire; a manual nudge was required.

## Why This Change Was Made

A cron-sourced wake is an explicit deliver-to-main request, not a scheduled heartbeat poll. `runHeartbeatOnce` nonetheless applied the per-agent heartbeat-enabled and heartbeat-interval guards to it, so a `main` agent without per-agent heartbeat config (common for the default `main` agent, in particular when another agent carries an explicit heartbeat config) was treated as heartbeat-disabled and the wake was discarded with `reason="disabled"`.

The fix relaxes those two guards for `source: "cron"` in `runHeartbeatOnce`. The global heartbeats toggle (`areHeartbeatsEnabled()`) still gates cron wakes, so a globally-disabled deployment still skips. Both the immediate wake (`wakeMode: "now"`, `executeMainSessionCronJob` in `src/cron/service/timer.ts`) and the queued wake (`wakeMode: "next-heartbeat"`, via `requestHeartbeat`'s scheduled handler, which calls back into `runHeartbeatOnce` with `source: "cron"`) route through this single chokepoint, so both are covered.

## User Impact

Cron jobs targeting the main session now reliably wake the main agent even when the agent has no per-agent heartbeat configuration. Operators no longer need a manual gateway restart or message to recover a main session that relies on cron-driven system events.

## Evidence

Real source-runtime capture from `runHeartbeatOnce` with a cron-sourced wake (`source: "cron"`) against a `main` agent that has no per-agent heartbeat config. A second `ops` agent carries an explicit heartbeat config, which is what makes `isHeartbeatEnabledForAgent` treat `main` as disabled — reproducing the reported `error="disabled"`.

Observed result before fix (current `main`, `c46e76cff`):

```json
{ "status": "skipped", "reason": "disabled" }
```

Observed result after fix (this branch, `b1dbd79ef`):

```json
{ "status": "ran" }
```

Regression coverage in `src/infra/heartbeat-runner.cron-wake.test.ts`:

- wakes the main agent even when no per-agent heartbeat is configured (asserts `status: "ran"`);
- still skips cron wakes when global heartbeats are disabled (asserts `status: "skipped"` / `reason: "disabled"` — the global toggle still gates cron).

Local run:

```
$ node scripts/run-vitest.mjs src/infra/heartbeat-runner.cron-wake.test.ts
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

## Real behavior proof

- Behavior or issue addressed: cron-sourced main-session wakes recorded as status=skipped / error="disabled" when the target agent has no per-agent heartbeat config
- Environment used for testing: Windows 11, Node v22.23.1, pnpm 11.2.2, repo at c46e76cff (before) / b1dbd79ef (after)
- Steps to reproduce: call runHeartbeatOnce with source="cron" against a main agent that has no per-agent heartbeat config (a second agent carries an explicit heartbeat, which makes isHeartbeatEnabledForAgent treat main as disabled)
- Observed result before fix: { "status": "skipped", "reason": "disabled" }
- Observed result after fix: { "status": "ran" }
- Evidence after fix (terminal capture):
```
$ node scripts/run-vitest.mjs src/infra/heartbeat-runner.cron-wake.proof.test.ts
CRON_WAKE_PROOF_RESULT={"status":"ran","durationMs":1783506015556}
```

## Human Verification

Verified locally on Windows: the real `runHeartbeatOnce` result for a cron-sourced main wake flips from `{ "status": "skipped", "reason": "disabled" }` (current `main`) to `{ "status": "ran" }` (this branch), captured via a source-runtime harness that runs the real function with a real config (before/after captured by temporarily reverting the fix). The committed regression coverage (`heartbeat-runner.cron-wake.test.ts`) passes 2/2 and encodes both the cron-wake-runs and global-disable-still-skips cases.

Not verified: full gateway end-to-end cron run on a live deployment; macOS / Linux / iOS; downstream session delivery beyond the wake-entry chokepoint (the wake itself is fixed; message delivery relies on existing session delivery). `pnpm check:host-env-policy:swift` was skipped on Windows (no Swift). Type-aware lint and full prod-types were not completed locally due to tooling latency on this monorepo; relying on CI for the type-aware lint and prod-types gates.

## Security Impact

- Does this change authentication or authorization? No
- Does this change how secrets are handled? No
- Does this change network boundaries or sandboxing? No
- Does this change any security policy or allowlist? No
- Does this change dependency versions or add dependencies? No

## Compatibility / Migration

Backward compatible for agents that have per-agent heartbeat config (unchanged path). Changes behavior only for cron-sourced wakes to agents WITHOUT per-agent heartbeat config: previously skipped (silent no-op), now they wake. This matches the documented cron contract (`sessionTarget: "main"` + `payload.kind: "systemEvent"` injects the text as a system event and wakes the main agent). The global heartbeats toggle still disables cron wakes when off, so deployments that want suppression can disable heartbeats globally.

## Failure Recovery

Revert commit `b1dbd79ef`. Behavior returns to the pre-existing state (cron main-session wakes skipped as `disabled` when the agent has no per-agent heartbeat config). No config migration needed.

## Risks and Mitigations

- Behavior change: agents without per-agent heartbeat config now receive cron-sourced wakes instead of being silently skipped. This is the documented cron contract; if a deployment relied on the skip as implicit suppression, set the global heartbeats toggle off (still gates cron). The change is narrowed to `source: "cron"` — non-cron heartbeat polls are unaffected.
- Scope: touches `src/infra/heartbeat-runner.ts` (not a CODEOWNERS secops-protected path).
