### PR TITLE
fix(settings): deep-merge nested settings so split-scope fields are not dropped (#102318)

### DIFF
--- a/src/agents/sessions/settings-manager.test.ts
+++ b/src/agents/sessions/settings-manager.test.ts
@@ -46,4 +46,22 @@ describe("SettingsManager runtime overrides", () => {
     expect(settingsManager.getPackages()).toEqual(["npm:@openclaw/example"]);
     expect(settingsManager.getCompactionReserveTokens()).toBe(50_000);
   });
+
+  it("preserves sibling retry.provider fields when a higher scope sets only one (#102318)", () => {
+    const settingsManager = SettingsManager.inMemory({
+      retry: { provider: { timeoutMs: 30_000, maxRetries: 5 } },
+    });
+
+    // A higher-precedence scope that sets only one nested field must not erase the
+    // siblings; a shallow merge dropped timeoutMs/maxRetries back to SDK defaults.
+    settingsManager.applyOverrides({
+      retry: { provider: { maxRetryDelayMs: 1_000 } },
+    });
+
+    expect(settingsManager.getProviderRetrySettings()).toEqual({
+      timeoutMs: 30_000,
+      maxRetries: 5,
+      maxRetryDelayMs: 1_000,
+    });
+  });
 });

--- a/src/agents/sessions/settings-manager.ts
+++ b/src/agents/sessions/settings-manager.ts
@@ -122,34 +122,42 @@ export interface Settings {
 }
 
 /** Deep merge settings: project/overrides take precedence, nested objects merge recursively */
-function deepMergeSettings(base: Settings, overrides: Settings): Settings {
-  const result: Settings = { ...base };
+function isMergeablePlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
-  for (const key of Object.keys(overrides) as (keyof Settings)[]) {
+// Recursively merges plain objects so nested fields set in different scopes combine
+// instead of an override's nested object wholesale-replacing the base's. A shallow
+// merge here silently drops sibling fields set in a lower-precedence scope — e.g. a
+// project scope that sets only `retry.provider.maxRetryDelayMs` would erase the global
+// `retry.provider.timeoutMs`/`maxRetries`, reverting them to SDK defaults (#102318).
+// Arrays and primitives are replaced (override wins), matching prior behavior.
+function deepMergePlainObjects(
+  base: Record<string, unknown>,
+  overrides: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...base };
+
+  for (const key of Object.keys(overrides)) {
     const overrideValue = overrides[key];
-    const baseValue = base[key];
-
     if (overrideValue === undefined) {
       continue;
     }
-
-    // For nested objects, merge recursively
-    if (
-      typeof overrideValue === "object" &&
-      overrideValue !== null &&
-      !Array.isArray(overrideValue) &&
-      typeof baseValue === "object" &&
-      baseValue !== null &&
-      !Array.isArray(baseValue)
-    ) {
-      (result as Record<string, unknown>)[key] = { ...baseValue, ...overrideValue };
-    } else {
-      // For primitives and arrays, override value wins
-      (result as Record<string, unknown>)[key] = overrideValue;
-    }
+    const baseValue = base[key];
+    result[key] =
+      isMergeablePlainObject(overrideValue) && isMergeablePlainObject(baseValue)
+        ? deepMergePlainObjects(baseValue, overrideValue)
+        : overrideValue;
   }
 
   return result;
+}
+
+function deepMergeSettings(base: Settings, overrides: Settings): Settings {
+  return deepMergePlainObjects(
+    base as Record<string, unknown>,
+    overrides as Record<string, unknown>,
+  ) as Settings;
 }
 
 export type SettingsScope = "global" | "project";


### PR DESCRIPTION
## What Problem This Solves

When `retry.provider` fields are split across settings scopes, a higher-precedence scope that sets only one field silently erases the siblings set by a lower-precedence scope. `deepMergeSettings` (`src/agents/sessions/settings-manager.ts`) is named "deep" and its comment says "merge recursively", but for a nested object present in both scopes it does a **shallow** `{ ...baseValue, ...overrideValue }` — so the override's nested object wholesale-replaces the base's. A global `settings.json` with `retry.provider.timeoutMs` + `maxRetries` plus a project `.openclaw/settings.json` with only `retry.provider.maxRetryDelayMs` yields an effective provider retry config that has **lost `timeoutMs` and `maxRetries`**, reverting live provider request timeout and retry-count to SDK defaults. Fixes #102318.

## Why This Change Was Made

Make the merge genuinely recursive (`deepMergePlainObjects`), matching the function's own documented intent. Arrays and primitives still replace (override wins), so **single-level** objects behave exactly as before — only 2+-level nesting (the bug case) changes. `retry.provider` fields from different scopes now combine instead of clobbering.

## User Impact

Operators who layer provider retry/timeout config across global and project scopes get the merged result they intend, instead of silently losing fields to SDK defaults (which changes live request timeout and retry-count behavior). No change for any single-level setting.

## Evidence

Real `SettingsManager` merge (global `retry.provider` + a runtime override that sets only `maxRetryDelayMs`):
```
before (main, shallow):  { "maxRetryDelayMs": 1000 }                                  ← timeoutMs/maxRetries dropped
after  (this PR, deep):  { "timeoutMs": 30000, "maxRetries": 5, "maxRetryDelayMs": 1000 }
```
Added a regression test through `getProviderRetrySettings()`. `tsgo:core` 0 errors; `settings-manager.test.ts` green (3 tests: 2 existing + 1 new — existing compaction-merge tests confirm single-level objects are unaffected).
