### PR TITLE
fix(agents): keep truncation surrogate-safe

### DIFF
--- a/src/agents/bash-process-references.test.ts
+++ b/src/agents/bash-process-references.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { listActiveProcessSessionReferences } from "./bash-process-references.js";
+import { addSession, deleteSession } from "./bash-process-registry.js";
+import { createProcessSessionFixture } from "./bash-process-registry.test-helpers.js";
+
+describe("bash-process-references truncation", () => {
+  it("keeps surrogate pairs intact when truncating session names", () => {
+    const command = `echo ${"😀".repeat(200)}`;
+    addSession(
+      createProcessSessionFixture({
+        id: "emoji-proc",
+        command,
+        backgrounded: true,
+        startedAt: 1,
+      }),
+    );
+
+    try {
+      const [reference] = listActiveProcessSessionReferences({
+        scopeKey: undefined,
+      });
+      expect(reference).toBeUndefined();
+      const scoped = listActiveProcessSessionReferences({ scopeKey: "scope-a", now: 2 });
+      expect(scoped).toEqual([]);
+    } finally {
+      deleteSession("emoji-proc");
+    }
+  });
+
+  it("keeps surrogate pairs intact for scoped background session labels", () => {
+    const command = `python ${"😀".repeat(200)}`;
+    const session = createProcessSessionFixture({
+      id: "emoji-proc-scoped",
+      command,
+      backgrounded: true,
+      startedAt: 1,
+    });
+    session.scopeKey = "scope-a";
+    addSession(session);
+
+    try {
+      const [reference] = listActiveProcessSessionReferences({ scopeKey: "scope-a", now: 2 });
+      expect(reference?.name).not.toContain("�");
+      expect(reference?.name.length).toBeLessThanOrEqual(140);
+    } finally {
+      deleteSession("emoji-proc-scoped");
+    }
+  });
+});

--- a/src/agents/bash-process-references.test.ts
+++ b/src/agents/bash-process-references.test.ts
@@ -4,31 +4,8 @@ import { addSession, deleteSession } from "./bash-process-registry.js";
 import { createProcessSessionFixture } from "./bash-process-registry.test-helpers.js";
 
 describe("bash-process-references truncation", () => {
-  it("keeps surrogate pairs intact when truncating session names", () => {
-    const command = `echo ${"😀".repeat(200)}`;
-    addSession(
-      createProcessSessionFixture({
-        id: "emoji-proc",
-        command,
-        backgrounded: true,
-        startedAt: 1,
-      }),
-    );
-
-    try {
-      const [reference] = listActiveProcessSessionReferences({
-        scopeKey: undefined,
-      });
-      expect(reference).toBeUndefined();
-      const scoped = listActiveProcessSessionReferences({ scopeKey: "scope-a", now: 2 });
-      expect(scoped).toEqual([]);
-    } finally {
-      deleteSession("emoji-proc");
-    }
-  });
-
-  it("keeps surrogate pairs intact for scoped background session labels", () => {
-    const command = `python ${"😀".repeat(200)}`;
+  it("keeps scoped session labels valid when the limit bisects an emoji", () => {
+    const command = `${"a".repeat(136)}😀xyz`;
     const session = createProcessSessionFixture({
       id: "emoji-proc-scoped",
       command,
@@ -40,8 +17,7 @@ describe("bash-process-references truncation", () => {
 
     try {
       const [reference] = listActiveProcessSessionReferences({ scopeKey: "scope-a", now: 2 });
-      expect(reference?.name).not.toContain("�");
-      expect(reference?.name.length).toBeLessThanOrEqual(140);
+      expect(reference?.name).toBe(`${"a".repeat(136)}...`);
     } finally {
       deleteSession("emoji-proc-scoped");
     }

--- a/src/agents/bash-process-references.ts
+++ b/src/agents/bash-process-references.ts
@@ -1,3 +1,4 @@
+import { truncateUtf16Safe } from "../utils.js";
 /**
  * Compact references for active background bash sessions.
  * These references are surfaced in agent context so follow-up turns can
@@ -28,9 +29,9 @@ function truncate(value: string, maxChars: number): string {
     return value;
   }
   if (maxChars <= 1) {
-    return value.slice(0, maxChars);
+    return truncateUtf16Safe(value, maxChars);
   }
-  return `${value.slice(0, Math.max(0, maxChars - 3))}...`;
+  return `${truncateUtf16Safe(value, Math.max(0, maxChars - 3))}...`;
 }
 
 /** List active background process sessions for one scope key, newest first. */

--- a/src/agents/bash-process-references.ts
+++ b/src/agents/bash-process-references.ts
@@ -1,9 +1,9 @@
-import { truncateUtf16Safe } from "../utils.js";
 /**
  * Compact references for active background bash sessions.
  * These references are surfaced in agent context so follow-up turns can
  * reconnect to prior long-running work.
  */
+import { truncateUtf16Safe } from "../utils.js";
 import { listRunningSessions } from "./bash-process-registry.js";
 import { deriveSessionName } from "./bash-tools.shared.js";
 

--- a/src/agents/tools/web-fetch-utils.test.ts
+++ b/src/agents/tools/web-fetch-utils.test.ts
@@ -22,7 +22,6 @@ describe("web-fetch-utils htmlToMarkdown entity decoding", () => {
   });
 
   it("decodes &amp; last so an escaped entity is not double-decoded", () => {
-    // "&amp;#39;" is the correct HTML encoding of the literal text "&#39;" and must survive intact.
     expect(htmlToMarkdown(`<p>Tom &amp;#39;s pub</p>`).text).toBe("Tom &#39;s pub");
   });
 
@@ -31,12 +30,8 @@ describe("web-fetch-utils htmlToMarkdown entity decoding", () => {
   });
 
   it("preserves the prior contract: uppercase named entities decode, malformed numeric stays literal", () => {
-    // web_fetch historically matched named entities case-insensitively, so
-    // uppercase forms must keep decoding rather than leaking through as text.
     expect(htmlToMarkdown(`<p>a &AMP; b</p>`).text).toBe("a & b");
     expect(htmlToMarkdown(`<p>x &QUOT;y&QUOT;</p>`).text).toBe('x "y"');
-    // A malformed numeric reference is not an entity and must survive as text,
-    // not be consumed by a lenient parseInt (e.g. "&#39x;" must not become "'").
     expect(htmlToMarkdown(`<p>&#39x; end</p>`).text).toBe("&#39x; end");
   });
 
@@ -47,5 +42,10 @@ describe("web-fetch-utils htmlToMarkdown entity decoding", () => {
     expect(result.truncated).toBe(true);
     expect(result.text).toBe(prefix);
     expect(result.text).not.toContain(String.fromCharCode(0xd83d));
+  });
+
+  it("truncates extracted text without splitting surrogate pairs", () => {
+    expect(truncateText("😀abc", 1)).toEqual({ text: "", truncated: true });
+    expect(truncateText("😀😀x", 3)).toEqual({ text: "😀", truncated: true });
   });
 });

--- a/src/agents/tools/web-fetch-utils.test.ts
+++ b/src/agents/tools/web-fetch-utils.test.ts
@@ -22,6 +22,7 @@ describe("web-fetch-utils htmlToMarkdown entity decoding", () => {
   });
 
   it("decodes &amp; last so an escaped entity is not double-decoded", () => {
+    // "&amp;#39;" is the correct HTML encoding of the literal text "&#39;" and must survive intact.
     expect(htmlToMarkdown(`<p>Tom &amp;#39;s pub</p>`).text).toBe("Tom &#39;s pub");
   });
 
@@ -30,8 +31,12 @@ describe("web-fetch-utils htmlToMarkdown entity decoding", () => {
   });
 
   it("preserves the prior contract: uppercase named entities decode, malformed numeric stays literal", () => {
+    // web_fetch historically matched named entities case-insensitively, so
+    // uppercase forms must keep decoding rather than leaking through as text.
     expect(htmlToMarkdown(`<p>a &AMP; b</p>`).text).toBe("a & b");
     expect(htmlToMarkdown(`<p>x &QUOT;y&QUOT;</p>`).text).toBe('x "y"');
+    // A malformed numeric reference is not an entity and must survive as text,
+    // not be consumed by a lenient parseInt (e.g. "&#39x;" must not become "'").
     expect(htmlToMarkdown(`<p>&#39x; end</p>`).text).toBe("&#39x; end");
   });
 
@@ -42,10 +47,5 @@ describe("web-fetch-utils htmlToMarkdown entity decoding", () => {
     expect(result.truncated).toBe(true);
     expect(result.text).toBe(prefix);
     expect(result.text).not.toContain(String.fromCharCode(0xd83d));
-  });
-
-  it("truncates extracted text without splitting surrogate pairs", () => {
-    expect(truncateText("😀abc", 1)).toEqual({ text: "", truncated: true });
-    expect(truncateText("😀😀x", 3)).toEqual({ text: "😀", truncated: true });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Agent-facing background-process labels are capped at 140 UTF-16 code units. Their outer formatter used raw slicing before the `...` suffix and could retain a lone high surrogate when a long command verb crossed the cut.

## Why This Change Was Made

The existing outer label formatter now uses the canonical `truncateUtf16Safe` helper. Process execution, registry state, scope isolation, command parsing, and the 140-unit policy are unchanged.

The maintainer fixup also corrected the regression proof. The original emoji argument was shortened by `deriveSessionName` before the outer cap, so it never exercised the changed code; another test asserted only that an unscoped session stayed absent. The replacement uses a long single-token command that crosses the actual 137-unit cut and asserts the exact final label. Unrelated tests for already-safe web-fetch behavior were removed.

## User Impact

Reconnectable background-process metadata remains valid UTF-16 when a compact label boundary crosses an emoji or another astral character.

## Evidence

- Exact production-boundary assertion through `listActiveProcessSessionReferences`.
- Targeted oxfmt and `git diff --check`: pass.
- Fresh maintainer local-diff autoreview: clean, confidence 0.98.
- Fresh full-branch autoreview: clean, confidence 0.99.
- Exact-head CI run `28991774236`, OpenGrep run `28991774230`, CodeQL Critical Quality run `28991774226`, and CodeQL run `28991774348` on `cecd014b51357df49dd6f760b6870dd67bc0252d`: success.

AI-assisted: yes. Maintainer-reviewed and tightened.
