### PR TITLE
fix(settings): deep-merge nested settings objects across scopes (#102318)

### DIFF
--- a/src/agents/sessions/settings-manager.test.ts
+++ b/src/agents/sessions/settings-manager.test.ts
@@ -1,4 +1,7 @@
 /** Tests session settings manager runtime overrides. */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { SettingsManager } from "./settings-manager.js";
 
@@ -45,5 +48,66 @@ describe("SettingsManager runtime overrides", () => {
 
     expect(settingsManager.getPackages()).toEqual(["npm:@openclaw/example"]);
     expect(settingsManager.getCompactionReserveTokens()).toBe(50_000);
+  });
+});
+
+describe("SettingsManager nested settings merge", () => {
+  it("merges nested retry.provider fields set in global and project scopes", () => {
+    const root = mkdtempSync(join(tmpdir(), "settings-scope-merge-"));
+    const agentDir = join(root, "agent");
+    const cwd = join(root, "project");
+    mkdirSync(agentDir, { recursive: true });
+    mkdirSync(join(cwd, ".openclaw"), { recursive: true });
+    // Global scope sets two provider fields; project scope sets only a third.
+    writeFileSync(
+      join(agentDir, "settings.json"),
+      JSON.stringify({ retry: { provider: { timeoutMs: 30_000, maxRetries: 5 } } }),
+    );
+    writeFileSync(
+      join(cwd, ".openclaw", "settings.json"),
+      JSON.stringify({ retry: { provider: { maxRetryDelayMs: 5_000 } } }),
+    );
+
+    try {
+      const settingsManager = SettingsManager.create(cwd, agentDir);
+
+      // The project scope's partial provider object must not erase the global
+      // provider siblings; all three fields survive field-by-field.
+      expect(settingsManager.getProviderRetrySettings()).toEqual({
+        timeoutMs: 30_000,
+        maxRetries: 5,
+        maxRetryDelayMs: 5_000,
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("merges nested retry.provider fields from runtime overrides onto base scope", () => {
+    const settingsManager = SettingsManager.inMemory({
+      retry: { provider: { timeoutMs: 30_000, maxRetries: 5 } },
+    });
+
+    settingsManager.applyOverrides({ retry: { provider: { maxRetryDelayMs: 5_000 } } });
+
+    expect(settingsManager.getProviderRetrySettings()).toEqual({
+      timeoutMs: 30_000,
+      maxRetries: 5,
+      maxRetryDelayMs: 5_000,
+    });
+  });
+
+  it("keeps override-wins semantics for overlapping nested fields", () => {
+    const settingsManager = SettingsManager.inMemory({
+      retry: { provider: { timeoutMs: 30_000, maxRetries: 5 } },
+    });
+
+    settingsManager.applyOverrides({ retry: { provider: { maxRetries: 9 } } });
+
+    expect(settingsManager.getProviderRetrySettings()).toEqual({
+      timeoutMs: 30_000,
+      maxRetries: 9,
+      maxRetryDelayMs: 60_000,
+    });
   });
 });

--- a/src/agents/sessions/settings-manager.ts
+++ b/src/agents/sessions/settings-manager.ts
@@ -142,7 +142,10 @@ function deepMergeSettings(base: Settings, overrides: Settings): Settings {
       baseValue !== null &&
       !Array.isArray(baseValue)
     ) {
-      (result as Record<string, unknown>)[key] = { ...baseValue, ...overrideValue };
+      (result as Record<string, unknown>)[key] = deepMergeSettings(
+        baseValue as Settings,
+        overrideValue as Settings,
+      );
     } else {
       // For primitives and arrays, override value wins
       (result as Record<string, unknown>)[key] = overrideValue;


### PR DESCRIPTION
## Summary

`deepMergeSettings` in `src/agents/sessions/settings-manager.ts` claimed to merge nested settings objects recursively, but the nested-object branch used a one-level spread (`{ ...baseValue, ...overrideValue }`). As a result, a higher-precedence settings scope that set only **one** `retry.provider` field replaced the entire `retry.provider` object from a lower-precedence scope, silently dropping its sibling fields.

Fixes #102318.

## What Problem This Solves

When `retry.provider` fields are split across settings scopes, the higher-precedence scope erases the sibling fields set by a lower-precedence scope:

- Global `settings.json`: `{ "retry": { "provider": { "timeoutMs": 30000, "maxRetries": 5 } } }`
- Project `.openclaw/settings.json`: `{ "retry": { "provider": { "maxRetryDelayMs": 5000 } } }`
- Effective `getProviderRetrySettings()` returned `{ maxRetryDelayMs: 5000 }` — the global `timeoutMs` and `maxRetries` were lost and silently reverted to SDK defaults.

Those values flow into the provider request path (`src/agents/sessions/sdk.ts` → `streamSimple`), so dropped fields change live provider request timeout and retry-count behavior for any user who splits `retry.provider` fields across scopes.

## Why This Change Was Made

The comment on the branch says "merge recursively," but `{ ...baseValue, ...overrideValue }` only merges one level deep. `retry.provider` is the only two-level-deep setting in the `Settings` shape today, so it is the field that observably loses siblings. All three scope-merge paths (global, project, runtime overrides) route through this one shared helper, so the fix is at a single location. Arrays and primitives are untouched and keep override-wins semantics, so no other nested setting changes behavior.

## Changes

- `src/agents/sessions/settings-manager.ts`: the nested-object branch now recurses via `deepMergeSettings(baseValue, overrideValue)` instead of a one-level spread.
- `src/agents/sessions/settings-manager.test.ts`: added focused regression coverage.

## User Impact

Users who set `retry.provider` fields in different scopes (e.g. global timeout/retries + project-specific delay) now get all fields merged field-by-field, so their configured provider request timeout and retry count are honored instead of silently reverting to SDK defaults.

## Evidence

### 1. Real setup transcript (standalone, not a test harness)

A standalone script wrote real global (`agentDir/settings.json`) and project (`cwd/.openclaw/settings.json`) files, constructed the production `SettingsManager.create(cwd, agentDir)`, and printed `getProviderRetrySettings()`. Run once against `origin/main` and once with this patch (same script, same inputs):

```
# BEFORE (origin/main — line 145 one-level spread)
GLOBAL settings.json  retry.provider = {"timeoutMs":30000,"maxRetries":5}
PROJECT settings.json retry.provider = {"maxRetryDelayMs":5000}
effective getProviderRetrySettings() = {"maxRetryDelayMs":5000}

# AFTER (this PR — line 145 recurses)
GLOBAL settings.json  retry.provider = {"timeoutMs":30000,"maxRetries":5}
PROJECT settings.json retry.provider = {"maxRetryDelayMs":5000}
effective getProviderRetrySettings() = {"timeoutMs":30000,"maxRetries":5,"maxRetryDelayMs":5000}
```

Before the fix the global `timeoutMs` and `maxRetries` are dropped; after the fix all three fields survive.

### 2. Regression tests

`src/agents/sessions/settings-manager.test.ts` exercises the real `SettingsManager` over on-disk global + project files, the runtime-override path, and overlapping override-wins semantics.

Before the fix (reproduces the bug):
```
AssertionError: expected { timeoutMs: undefined, …(2) } to deeply equal { timeoutMs: 30000, …(2) }
- Expected
+ Received
  {
    "maxRetries": 9,
    "maxRetryDelayMs": 60000,
-   "timeoutMs": 30000,
+   "timeoutMs": undefined,
  }
 Test Files  2 failed (2)
      Tests  6 failed | 4 passed (10)
```

After the fix:
```
 ✓ SettingsManager nested settings merge > merges nested retry.provider fields set in global and project scopes
 ✓ SettingsManager nested settings merge > merges nested retry.provider fields from runtime overrides onto base scope
 ✓ SettingsManager nested settings merge > keeps override-wins semantics for overlapping nested fields
 Test Files  2 passed (2)
      Tests  10 passed (10)
```

`oxlint` on the changed files passes clean, and full PR CI is green.

## AI-assisted

This PR was AI-assisted (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
