### PR TITLE
fix(openai): surface chat-completions refusal as visible text

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -10958,6 +10958,94 @@ describe("openai transport stream", () => {
       testing.processOpenAICompletionsStream(mockStream(), output, model, stream),
     ).rejects.toThrow("Exceeded tool-call argument buffer limit");
   });
+
+  it("surfaces refusal from streaming chat-completions delta as visible text", async () => {
+    const model = {
+      id: "gpt-5.4-mini",
+      name: "GPT-5.4 Mini",
+      api: "openai-completions",
+      provider: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200_000,
+      maxTokens: 8192,
+    } satisfies Model<"openai-completions">;
+    const output = createAssistantOutput(model);
+    const stream = { push: vi.fn() };
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-refusal-stream",
+          object: "chat.completion.chunk" as const,
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: { role: "assistant" as const, refusal: "I can't help with that." },
+              logprobs: null,
+              finish_reason: "stop" as const,
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      stream,
+    );
+
+    expect(output.content).toHaveLength(1);
+    expect(output.content[0]).toEqual({ type: "text", text: "I can't help with that." });
+  });
+
+  it("surfaces refusal from aggregated chat-completions message as visible text", async () => {
+    const model = {
+      id: "gpt-5.4-mini",
+      name: "GPT-5.4 Mini",
+      api: "openai-completions",
+      provider: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200_000,
+      maxTokens: 8192,
+    } satisfies Model<"openai-completions">;
+    const output = createAssistantOutput(model);
+    const stream = { push: vi.fn() };
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-refusal-msg",
+          object: "chat.completion.chunk" as const,
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: "assistant" as const,
+                content: null,
+                refusal: "I can't help with that.",
+              },
+              logprobs: null,
+              finish_reason: "stop" as const,
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      stream,
+    );
+
+    expect(output.content).toHaveLength(1);
+    expect(output.content[0]).toEqual({ type: "text", text: "I can't help with that." });
+  });
 });
 
 describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () => {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -3148,9 +3148,17 @@ async function processOpenAICompletionsStream(
           appendRoutedContentDelta(contentDelta);
         }
       }
-    } else if ((choiceDelta as { refusal?: string }).refusal) {
-      // Safety or structured-output refusal surfaced as assistant visible text.
-      appendTextDelta((choiceDelta as { refusal?: string }).refusal!);
+    } else if (
+      !choiceDelta.content &&
+      typeof (choiceDelta as { refusal?: string }).refusal === "string"
+    ) {
+      const refusalText = (choiceDelta as { refusal?: string }).refusal!;
+      const routedDeltas = hasMirroredReasoning
+        ? reasoningTagTextPartitioner.push(refusalText)
+        : reasoningTagTextPartitioner.pushVisible(refusalText);
+      for (const routedDelta of routedDeltas) {
+        appendPartitionedVisibleDelta(routedDelta);
+      }
     }
     for (const reasoningDelta of reasoningDeltas) {
       if (reasoningDelta.kind === "thinking" && !emitReasoning) {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -3148,6 +3148,9 @@ async function processOpenAICompletionsStream(
           appendRoutedContentDelta(contentDelta);
         }
       }
+    } else if ((choiceDelta as { refusal?: string }).refusal) {
+      // Safety or structured-output refusal surfaced as assistant visible text.
+      appendTextDelta((choiceDelta as { refusal?: string }).refusal!);
     }
     for (const reasoningDelta of reasoningDeltas) {
       if (reasoningDelta.kind === "thinking" && !emitReasoning) {

--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -248,6 +248,28 @@ describe("OpenAI-compatible completions params", () => {
     expect(capturedPayload?.tools).toEqual([]);
   });
 
+  it("surfaces chat-completions refusal deltas as visible assistant text", async () => {
+    mockChunksRef.chunks = [
+      {
+        id: "chatcmpl-test",
+        choices: [
+          {
+            index: 0,
+            delta: { role: "assistant", content: null, refusal: "I can't help with that." },
+            finish_reason: "stop",
+          },
+        ],
+      },
+    ];
+
+    const result = await streamOpenAICompletions(model, context, {
+      apiKey: "sk-test",
+    }).result();
+
+    expect(result.content).toStrictEqual([{ type: "text", text: "I can't help with that." }]);
+    expect(result.stopReason).toBe("stop");
+  });
+
   it("does not reread an unreadable tool inventory length", async () => {
     let capturedPayload: Record<string, unknown> | undefined;
     const tools = new Proxy([], {

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -427,6 +427,8 @@ export const streamOpenAICompletions: StreamFunction<
             choice.delta.content.length > 0
           ) {
             appendPartitionedContent(choice.delta.content, Boolean(foundReasoningField));
+          } else if ((choice.delta as { refusal?: string }).refusal) {
+            appendPartitionedContent((choice.delta as { refusal?: string }).refusal!, false);
           }
 
           if (choice?.delta?.tool_calls) {

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -427,8 +427,8 @@ export const streamOpenAICompletions: StreamFunction<
             choice.delta.content.length > 0
           ) {
             appendPartitionedContent(choice.delta.content, Boolean(foundReasoningField));
-          } else if ((choice.delta as { refusal?: string }).refusal) {
-            appendPartitionedContent((choice.delta as { refusal?: string }).refusal!, false);
+          } else if (typeof choice.delta.refusal === "string") {
+            appendPartitionedContent(choice.delta.refusal, Boolean(foundReasoningField));
           }
 
           if (choice?.delta?.tool_calls) {


### PR DESCRIPTION
## What Problem This Solves

When an OpenAI chat-completions response carries a safety or structured-output refusal, the assistant turn resolves to empty content and the user sees nothing. OpenAI returns refusals in a top-level `refusal` field with `content: null` and `finish_reason: "stop"`, but the completions streaming assembler never reads `refusal`, so the refusal text is silently dropped.

## Why This Change Was Made

Two streaming assemblers had the same blind spot:

- `processOpenAICompletionsStream` in `src/agents/openai-transport-stream.ts` — the delta loop reads `content`, reasoning deltas, and `tool_calls` from `choice.delta` but never checks `refusal`
- `streamOpenAICompletions` in `packages/ai/src/providers/openai-completions.ts` — same pattern, drops refusal

The sibling Responses path (same file, lines 1635, 1697-1700, 1878) already routes `refusal` correctly. The fix mirrors that pattern: when `content` is null/absent, check `refusal` and route it as visible assistant text.

## User Impact

For users whose prompts trigger an OpenAI safety refusal on the `openai-completions` API, the assistant reply will now show the refusal text (e.g. "I can't help with that.") instead of a blank empty reply. Users of the Responses API are unaffected (already handled).

## Evidence

**Real proof — streaming delta refusal (after fix):**

Proof run on disposable Node.js, stubbing only the transport input as an async iterable, keeping the `processOpenAICompletionsStream` assembly logic real:

```
$ node --import tsx -e "
import { testing } from './src/agents/openai-transport-stream.js';
const model = { id: 'gpt-5.4-mini', name: 'GPT-5.4 Mini', api: 'openai-completions',
  provider: 'openai', baseUrl: 'https://api.openai.com/v1', reasoning: false, input: ['text'],
  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 200000, maxTokens: 8192 };
const output = { role: 'assistant', content: [], api: 'openai-completions', provider: 'openai',
  model: 'gpt-5.4-mini', usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0,
    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
  stopReason: 'stop', timestamp: Date.now() };

// Test 1: streaming delta with refusal
const o1 = { ...output, content: [] };
await testing.processOpenAICompletionsStream(
  (async function*() {
    yield { id: 'cmpl-1', object: 'chat.completion.chunk', created: 1, model: 'gpt-5.4-mini',
      choices: [{ index: 0, delta: { role: 'assistant', refusal: \"I can't help.\" }, logprobs: null, finish_reason: 'stop' }] };
  })(), o1, model, { push: () => {} });
console.log('Streaming delta:', JSON.stringify(o1.content));

// Test 2: aggregated message with refusal
const o2 = { ...output, content: [] };
await testing.processOpenAICompletionsStream(
  (async function*() {
    yield { id: 'cmpl-2', object: 'chat.completion.chunk', created: 1, model: 'gpt-5.4-mini',
      choices: [{ index: 0, message: { role: 'assistant', content: null, refusal: \"I can't help.\" }, logprobs: null, finish_reason: 'stop' }] };
  })(), o2, model, { push: () => {} });
console.log('Aggregated msg: ', JSON.stringify(o2.content));
"

Streaming delta: [{"type":"text","text":"I can't help."}]
Aggregated msg:  [{"type":"text","text":"I can't help."}]
```

Both forms now surface the refusal as visible assistant text instead of empty content.

**Code change — `src/agents/openai-transport-stream.ts` (after `choiceDelta.content` block):**
```typescript
    } else if (
      !choiceDelta.content &&
      typeof (choiceDelta as { refusal?: string }).refusal === "string"
    ) {
      // Chat Completions can put safety/structured-output refusals in a top-level
      // `refusal` field with content: null. Surface refusal as visible text
      // (Responses path already routes refusal deltas).
      const refusalText = (choiceDelta as { refusal?: string }).refusal!;
      const routedDeltas = hasMirroredReasoning
        ? reasoningTagTextPartitioner.push(refusalText)
        : reasoningTagTextPartitioner.pushVisible(refusalText);
      for (const routedDelta of routedDeltas) {
        appendPartitionedVisibleDelta(routedDelta);
      }
    }
```

**Code change — `packages/ai/src/providers/openai-completions.ts` (after `choice.delta.content` block):**
```typescript
    } else if (typeof choice.delta.refusal === "string") {
      appendPartitionedContent(choice.delta.refusal, Boolean(foundReasoningField));
    }
```

**Test coverage — 3 new tests across 2 files:**

- `src/agents/openai-transport-stream.test.ts`: streaming delta refusal + aggregated message refusal
- `packages/ai/src/providers/openai-completions.test.ts`: streaming delta refusal in the shared assembler

All tests feed a refusal-only chunk and assert `output.content` equals `[{ type: "text", text: "I can't help with that." }]`.

Environment: Linux x86_64, Node v24.13.1, commit 615cab6c0b.

Fixes #102321
