### PR TITLE
fix(web_fetch): exact-size responses no longer reported as truncated

### DIFF
--- a/src/agents/tools/web-shared.test.ts
+++ b/src/agents/tools/web-shared.test.ts
@@ -147,6 +147,24 @@ describe("readResponseText", () => {
     expect(releaseLock).toHaveBeenCalledTimes(1);
   });
 
+  it("does not mark exact-size bodies as truncated", async () => {
+    const cancel = vi.fn(async () => undefined);
+    const releaseLock = vi.fn();
+    const response = responseFromReader({
+      chunks: ["hello", " world"],
+      cancel,
+      releaseLock,
+    });
+
+    await expect(readResponseText(response, { maxBytes: 11 })).resolves.toEqual({
+      text: "hello world",
+      truncated: false,
+      bytesRead: 11,
+    });
+    expect(cancel).not.toHaveBeenCalled();
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
   it("does not invoke whole-body fallbacks when maxBytes is set", async () => {
     const arrayBuffer = vi.fn(async () => new TextEncoder().encode("hello").buffer);
     const text = vi.fn(async () => "hello");

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -272,8 +272,7 @@ export async function readResponseText(
         bytesRead += chunk.byteLength;
         parts.push(chunk);
 
-        if (truncated || bytesRead >= maxBytes) {
-          truncated = true;
+        if (truncated) {
           break;
         }
       }


### PR DESCRIPTION
## What Problem This Solves

`web_fetch` incorrectly marks responses as `truncated: true` when the streamed body totals exactly `maxResponseBytes`. Users and downstream logic cannot distinguish a complete, exact-size response from one that was actually cut off.

## Why This Change Was Made

The bounded reader in `readResponseText` set `truncated = true` as soon as `bytesRead` reached the limit, even though no bytes were omitted. Truncation is now only declared after an additional read confirms overflow beyond the cap.

## User Impact

Exact-size responses now report `truncated: false`, so callers can rely on the flag to mean "content was actually removed" rather than "content reached the configured limit."

## Evidence

Focused test run for the changed module:

```
node scripts/run-vitest.mjs src/agents/tools/web-shared.test.ts
```

Result: 12 tests passed.

Fixes #101837