### PR TITLE
fix(macos): prevent AppKit automatic termination in menu bar app

### DIFF
--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -356,6 +356,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             NSApp.terminate(nil)
             return
         }
+        // Prevent AppKit automatic termination. The menu bar app has no
+        // persistent visible window, so AppKit may terminate the process
+        // ~0.5s after launch in remote mode when no window is opened.
+        NSProcessInfo.processInfo.disableAutomaticTermination("Menu bar app stays resident")
         self.state = AppStateStore.shared
         if let state {
             MacNodeModeCoordinator.prepareNodeIdentityProfile(


### PR DESCRIPTION
Fixes #89162

## What Problem This Solves

The macOS menu bar app auto-terminates ~0.5s after launch in remote mode. AppKit sees no persistent visible window and terminates the process, even though the menu bar status item is active and the app should remain resident.

Reproduced on macOS 26.5 with notarized builds 2026.5.20 and 2026.5.28.

## Why This Change Was Made

The `@main` SwiftUI `MenuBarExtra` app does not count as a visible window for AppKit's automatic termination heuristic. Adding `NSProcessInfo.processInfo.disableAutomaticTermination()` in `applicationDidFinishLaunching` tells AppKit the app should stay resident regardless of window state.

This is a common pattern for menu bar / status item apps on macOS.

## User Impact

**Before:** App launches, initializes fully, then exits ~0.5s later with no menu bar icon visible.
**After:** App stays resident and the menu bar icon remains visible.

## Evidence

- Source inspection confirms no `disableAutomaticTermination` call exists on current main
- The fix is a single line addition in `apps/macos/Sources/OpenClaw/MenuBar.swift`
- `git diff --check` passes