### PR TITLE
fix: normalize Anthropic unsupported inline images

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -1,5 +1,6 @@
 import type { Model } from "openclaw/plugin-sdk/llm";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSolidPngBuffer } from "../../test/helpers/image-fixtures.js";
 import { attachModelProviderRequestTransport } from "./provider-request-config.js";
 
 const { buildGuardedModelFetchMock, guardedFetchMock } = vi.hoisted(() => ({
@@ -133,6 +134,7 @@ function makeAnthropicTransportModel(
     name?: string;
     provider?: string;
     baseUrl?: string;
+    input?: string[];
     reasoning?: boolean;
     maxTokens?: number;
     thinkingLevelMap?: AnthropicMessagesModel["thinkingLevelMap"];
@@ -148,7 +150,7 @@ function makeAnthropicTransportModel(
       provider: params.provider ?? "anthropic",
       baseUrl: params.baseUrl ?? "https://api.anthropic.com",
       reasoning: params.reasoning ?? true,
-      input: ["text"],
+      input: params.input ?? ["text"],
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       contextWindow: 200000,
       maxTokens: params.maxTokens ?? 8192,
@@ -1855,6 +1857,39 @@ describe("anthropic transport stream", () => {
       },
     ]);
     expect(toolResult.is_error).toBe(false);
+  });
+
+  it("normalizes unsupported image MIME types before Anthropic transport payloads", async () => {
+    const png = await createSolidPngBuffer(8, 8, { r: 0x60, g: 0x90, b: 0xc0 });
+
+    await runTransportStream(
+      makeAnthropicTransportModel({ input: ["text", "image"] }),
+      {
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "image", data: png.toString("base64"), mimeType: "image/tiff" }],
+          },
+        ],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    const userMessage = findRecord(
+      latestAnthropicRequest().payload.messages,
+      (record) => record.role === "user",
+    );
+    expect(userMessage.content).toMatchObject([
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/jpeg",
+        },
+      },
+    ]);
   });
 
   it("cancels stalled SSE body reads when the abort signal fires mid-stream", async () => {

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -4,6 +4,7 @@ import { calculateCost } from "../llm/model-utils.js";
 import type { AnthropicOptions } from "../llm/providers/anthropic.js";
 import type { Context, Model, SimpleStreamOptions, ThinkingLevel } from "../llm/types.js";
 import { parseStreamingJson } from "../llm/utils/json-parse.js";
+import { normalizeImageForAnthropic } from "../media/anthropic-inline-images.js";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../shared/assistant-error-format.js";
 import {
   applyAnthropicPayloadPolicyToParams,
@@ -253,7 +254,7 @@ function fromClaudeCodeName(name: string, tools: Context["tools"] | undefined): 
   return name;
 }
 
-function convertContentBlocks(
+async function convertContentBlocks(
   content: Array<
     { type: "text"; text: string } | { type: "image"; data: string; mimeType: string }
   >,
@@ -280,12 +281,13 @@ function convertContentBlocks(
         hasTextBlock = true;
       }
     } else {
+      const normalizedImage = await normalizeImageForAnthropic(block);
       blocks.push({
         type: "image" as const,
         source: {
           type: "base64",
-          media_type: block.mimeType,
-          data: block.data,
+          media_type: normalizedImage.mimeType,
+          data: normalizedImage.data,
         },
       });
     }
@@ -300,7 +302,7 @@ function normalizeToolCallId(id: string): string {
   return id.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
 }
 
-function convertAnthropicMessages(
+async function convertAnthropicMessages(
   messages: Context["messages"],
   model: AnthropicTransportModel,
   isOAuthToken: boolean,
@@ -327,20 +329,24 @@ function convertAnthropicMessages(
             type: "image";
             source: { type: "base64"; media_type: string; data: string };
           }
-      > = msg.content.map((item) =>
-        item.type === "text"
-          ? {
+      > = await Promise.all(
+        msg.content.map(async (item) => {
+          if (item.type === "text") {
+            return {
               type: "text",
               text: sanitizeTransportPayloadText(item.text),
-            }
-          : {
-              type: "image",
-              source: {
-                type: "base64",
-                media_type: item.mimeType,
-                data: item.data,
-              },
+            };
+          }
+          const normalizedImage = await normalizeImageForAnthropic(item);
+          return {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: normalizedImage.mimeType,
+              data: normalizedImage.data,
             },
+          };
+        }),
       );
       let filteredBlocks = model.input.includes("image")
         ? blocks
@@ -440,7 +446,7 @@ function convertAnthropicMessages(
         {
           type: "tool_result",
           tool_use_id: toolResult.toolCallId,
-          content: convertContentBlocks(toolResult.content),
+          content: await convertContentBlocks(toolResult.content),
           is_error: toolResult.isError,
         },
       ];
@@ -453,7 +459,7 @@ function convertAnthropicMessages(
         toolResults.push({
           type: "tool_result",
           tool_use_id: nextMsg.toolCallId,
-          content: convertContentBlocks(nextMsg.content),
+          content: await convertContentBlocks(nextMsg.content),
           is_error: nextMsg.isError,
         });
         j += 1;
@@ -799,7 +805,7 @@ function createAnthropicTransportClient(params: {
   };
 }
 
-function buildAnthropicParams(
+async function buildAnthropicParams(
   model: AnthropicTransportModel,
   context: Context,
   isOAuthToken: boolean,
@@ -824,7 +830,7 @@ function buildAnthropicParams(
   const params: Record<string, unknown> = {
     model: resolveAnthropicRequestModelId(model),
     messages: ensureNonEmptyAnthropicMessages(
-      convertAnthropicMessages(context.messages, model, isOAuthToken, {
+      await convertAnthropicMessages(context.messages, model, isOAuthToken, {
         allowReasoningContentReplay: supportsReasoningContentReplay(model),
       }),
     ),
@@ -975,7 +981,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
           apiKey,
           options: transportOptions,
         });
-        let params = buildAnthropicParams(model, context, isOAuthToken, transportOptions);
+        let params = await buildAnthropicParams(model, context, isOAuthToken, transportOptions);
         const nextParams = await transportOptions.onPayload?.(params, model);
         if (nextParams !== undefined) {
           params = nextParams as Record<string, unknown>;

--- a/src/llm/providers/anthropic.test.ts
+++ b/src/llm/providers/anthropic.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createSolidPngBuffer } from "../../../test/helpers/image-fixtures.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../agents/system-prompt-cache-boundary.js";
 import type { Context, Model } from "../types.js";
 
@@ -247,6 +248,45 @@ describe("Anthropic provider", () => {
       {
         type: "text",
         text: "Dynamic suffix",
+      },
+    ]);
+  });
+
+  it("normalizes unsupported inline image MIME types before Anthropic payloads", async () => {
+    let capturedPayload: unknown;
+    const png = await createSolidPngBuffer(8, 8, { r: 0x20, g: 0x40, b: 0x80 });
+    const stream = streamSimpleAnthropic(
+      makeAnthropicModel({ input: ["text", "image"] }),
+      {
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "image", data: png.toString("base64"), mimeType: "image/tiff" }],
+            timestamp: 0,
+          },
+        ],
+      },
+      {
+        apiKey: "sk-ant-provider",
+        onPayload: (payload) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(
+      (capturedPayload as { messages: Array<{ content: unknown[] }> }).messages[0]?.content,
+    ).toMatchObject([
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/jpeg",
+        },
       },
     ]);
   });

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -11,6 +11,7 @@ import {
   splitSystemPromptCacheBoundary,
   stripSystemPromptCacheBoundary,
 } from "../../agents/system-prompt-cache-boundary.js";
+import { normalizeImageForAnthropic } from "../../media/anthropic-inline-images.js";
 import { getEnvApiKey } from "../env-api-keys.js";
 import { calculateCost, clampThinkingLevel } from "../model-utils.js";
 import type {
@@ -115,7 +116,7 @@ const fromClaudeCodeName = (name: string, tools?: Tool[]) => {
 /**
  * Convert content blocks to Anthropic API format
  */
-function convertContentBlocks(content: (TextContent | ImageContent)[]):
+async function convertContentBlocks(content: (TextContent | ImageContent)[]): Promise<
   | string
   | Array<
       | { type: "text"; text: string }
@@ -127,7 +128,8 @@ function convertContentBlocks(content: (TextContent | ImageContent)[]):
             data: string;
           };
         }
-    > {
+    >
+> {
   // If only text blocks, return as concatenated string for simplicity
   const hasImages = content.some((c) => c.type === "image");
   if (!hasImages) {
@@ -135,22 +137,25 @@ function convertContentBlocks(content: (TextContent | ImageContent)[]):
   }
 
   // If we have images, convert to content block array
-  const blocks = content.map((block) => {
-    if (block.type === "text") {
+  const blocks = await Promise.all(
+    content.map(async (block) => {
+      if (block.type === "text") {
+        return {
+          type: "text" as const,
+          text: sanitizeSurrogates(block.text),
+        };
+      }
+      const normalizedImage = await normalizeImageForAnthropic(block);
       return {
-        type: "text" as const,
-        text: sanitizeSurrogates(block.text),
+        type: "image" as const,
+        source: {
+          type: "base64" as const,
+          media_type: normalizedImage.mimeType,
+          data: normalizedImage.data,
+        },
       };
-    }
-    return {
-      type: "image" as const,
-      source: {
-        type: "base64" as const,
-        media_type: block.mimeType as "image/jpeg" | "image/png" | "image/gif" | "image/webp",
-        data: block.data,
-      },
-    };
-  });
+    }),
+  );
 
   // If only images (no text), add placeholder text block
   const hasText = blocks.some((b) => b.type === "text");
@@ -495,7 +500,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
         client = created.client;
         isOAuth = created.isOAuthToken;
       }
-      let params = buildParams(model, context, isOAuth, options);
+      let params = await buildParams(model, context, isOAuth, options);
       const nextParams = await options?.onPayload?.(params, model);
       if (nextParams !== undefined) {
         params = nextParams as MessageCreateParamsStreaming;
@@ -932,16 +937,16 @@ function createClient(
   return { client, isOAuthToken: false };
 }
 
-function buildParams(
+async function buildParams(
   model: Model<"anthropic-messages">,
   context: Context,
   isOAuthTokenResult: boolean,
   options?: AnthropicOptions,
-): MessageCreateParamsStreaming {
+): Promise<MessageCreateParamsStreaming> {
   const { cacheControl } = getCacheControl(model, options?.cacheRetention);
   const params: MessageCreateParamsStreaming = {
     model: model.id,
-    messages: convertMessages(context.messages, model, isOAuthTokenResult, cacheControl),
+    messages: await convertMessages(context.messages, model, isOAuthTokenResult, cacheControl),
     max_tokens: options?.maxTokens ?? model.maxTokens,
     stream: true,
   };
@@ -1036,12 +1041,12 @@ function normalizeToolCallId(id: string): string {
   return id.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
 }
 
-function convertMessages(
+async function convertMessages(
   messages: Message[],
   model: Model<"anthropic-messages">,
   isOAuthTokenValue: boolean,
   cacheControl?: CacheControlEphemeral,
-): MessageParam[] {
+): Promise<MessageParam[]> {
   const params: MessageParam[] = [];
 
   // Transform messages for cross-provider compatibility
@@ -1059,22 +1064,25 @@ function convertMessages(
           });
         }
       } else {
-        const blocks: ContentBlockParam[] = msg.content.map((item) => {
-          if (item.type === "text") {
+        const blocks: ContentBlockParam[] = await Promise.all(
+          msg.content.map(async (item) => {
+            if (item.type === "text") {
+              return {
+                type: "text",
+                text: sanitizeSurrogates(item.text),
+              };
+            }
+            const normalizedImage = await normalizeImageForAnthropic(item);
             return {
-              type: "text",
-              text: sanitizeSurrogates(item.text),
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: normalizedImage.mimeType,
+                data: normalizedImage.data,
+              },
             };
-          }
-          return {
-            type: "image",
-            source: {
-              type: "base64",
-              media_type: item.mimeType as "image/jpeg" | "image/png" | "image/gif" | "image/webp",
-              data: item.data,
-            },
-          };
-        });
+          }),
+        );
         const filteredBlocks = blocks.filter((b) => {
           if (b.type === "text") {
             return b.text.trim().length > 0;
@@ -1156,7 +1164,7 @@ function convertMessages(
       toolResults.push({
         type: "tool_result",
         tool_use_id: msg.toolCallId,
-        content: convertContentBlocks(msg.content),
+        content: await convertContentBlocks(msg.content),
         is_error: msg.isError,
       });
 
@@ -1167,7 +1175,7 @@ function convertMessages(
         toolResults.push({
           type: "tool_result",
           tool_use_id: nextMsg.toolCallId,
-          content: convertContentBlocks(nextMsg.content),
+          content: await convertContentBlocks(nextMsg.content),
           is_error: nextMsg.isError,
         });
         j++;

--- a/src/media/anthropic-inline-images.test.ts
+++ b/src/media/anthropic-inline-images.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { createSolidPngBuffer } from "../../test/helpers/image-fixtures.js";
+import { normalizeImageForAnthropic } from "./anthropic-inline-images.js";
+
+describe("normalizeImageForAnthropic", () => {
+  it("passes through supported Anthropic image MIME types", async () => {
+    const png = await createSolidPngBuffer(8, 8, { r: 0x10, g: 0x20, b: 0x30 });
+    const normalized = await normalizeImageForAnthropic({
+      data: png.toString("base64"),
+      mimeType: "image/png",
+    });
+
+    expect(normalized).toEqual({
+      data: png.toString("base64"),
+      mimeType: "image/png",
+    });
+  });
+
+  it("transcodes unsupported image MIME types to an Anthropic-supported format", async () => {
+    const png = await createSolidPngBuffer(8, 8, { r: 0x40, g: 0x80, b: 0xc0 });
+    const normalized = await normalizeImageForAnthropic({
+      data: png.toString("base64"),
+      mimeType: "image/tiff",
+    });
+
+    expect(normalized.mimeType).toBe("image/jpeg");
+    expect(normalized.data).not.toBe(png.toString("base64"));
+  });
+});

--- a/src/media/anthropic-inline-images.ts
+++ b/src/media/anthropic-inline-images.ts
@@ -1,0 +1,57 @@
+import { createImageProcessor } from "./image-ops.js";
+import { normalizeMimeType } from "./input-files.js";
+
+const ANTHROPIC_INLINE_IMAGE_MIMES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+] as const;
+const ANTHROPIC_INLINE_IMAGE_MIME_SET = new Set<string>(ANTHROPIC_INLINE_IMAGE_MIMES);
+const ANTHROPIC_INLINE_IMAGE_MAX_BYTES = 4.5 * 1024 * 1024;
+
+function maxBinaryBytesForBase64Budget(maxBase64Bytes: number): number {
+  return Math.floor(maxBase64Bytes / 4) * 3;
+}
+
+export type AnthropicInlineImageMimeType = (typeof ANTHROPIC_INLINE_IMAGE_MIMES)[number];
+
+export function isAnthropicInlineImageMimeType(
+  mimeType: string | undefined,
+): mimeType is AnthropicInlineImageMimeType {
+  return mimeType !== undefined && ANTHROPIC_INLINE_IMAGE_MIME_SET.has(mimeType);
+}
+
+export async function normalizeImageForAnthropic(
+  image: Readonly<{ data: string; mimeType: string }>,
+): Promise<{ data: string; mimeType: AnthropicInlineImageMimeType }> {
+  const normalizedMime = normalizeMimeType(image.mimeType);
+  if (isAnthropicInlineImageMimeType(normalizedMime)) {
+    return { data: image.data, mimeType: normalizedMime };
+  }
+
+  const output = await createImageProcessor().encode(Buffer.from(image.data, "base64"), {
+    format: "auto",
+    limits: {
+      maxWidth: 2000,
+      maxHeight: 2000,
+    },
+    maxBytes: maxBinaryBytesForBase64Budget(ANTHROPIC_INLINE_IMAGE_MAX_BYTES),
+    opaque: { format: "jpeg", quality: 85 },
+    transparent: { format: "png" },
+    search: {
+      quality: [85, 70, 55, 40],
+      compressionLevel: [6, 9],
+    },
+  });
+  const outputMime = normalizeMimeType(output.mimeType);
+  if (!isAnthropicInlineImageMimeType(outputMime)) {
+    throw new Error(
+      `Unsupported Anthropic inline image MIME after normalization: ${output.mimeType}`,
+    );
+  }
+  return {
+    data: output.data.toString("base64"),
+    mimeType: outputMime,
+  };
+}


### PR DESCRIPTION
Summary

- normalize unsupported inline image MIME types to an Anthropic-supported format before the Anthropic provider and custom transport build request payloads
- share the normalization logic in `src/media/anthropic-inline-images.ts` so user-image and tool-result image paths follow the same transcode boundary
- add focused regressions for the shared helper, Anthropic provider payloads, and Anthropic transport payloads

Verification

- `node scripts/run-vitest.mjs src/media/anthropic-inline-images.test.ts src/llm/providers/anthropic.test.ts src/agents/anthropic-transport-stream.test.ts`
- `node --import ./node_modules/tsx/dist/loader.mjs /private/tmp/openclaw-issue-102323-proof.ts`

Real behavior proof

Behavior addressed: within-limit TIFF images sent through OpenClaw's Anthropic provider and custom Anthropic transport now transcode to an Anthropic-supported inline image MIME instead of forwarding `image/tiff` verbatim.
Real environment tested: real `streamSimpleAnthropic()` from `src/llm/providers/anthropic.ts` and real `createAnthropicMessagesTransportStreamFn()` from `src/agents/anthropic-transport-stream.ts`, both executed from this patched checkout against a real local loopback HTTP server at `127.0.0.1` that captured the outgoing Anthropic request body and returned Anthropic-style SSE responses.
Exact steps or command run after this patch: `node --import ./node_modules/tsx/dist/loader.mjs /private/tmp/openclaw-issue-102323-proof.ts`
Evidence after fix:
```json
{
  "generatedInput": {
    "format": "image/tiff",
    "bytes": 4160,
    "pngSourceBytes": 79,
    "loopbackBaseUrl": "http://127.0.0.1:65058"
  },
  "provider": {
    "path": "/v1/messages",
    "mediaType": "image/jpeg",
    "stopReason": "stop",
    "errorMessage": ""
  },
  "transport": {
    "path": "/v1/messages",
    "mediaType": "image/jpeg",
    "stopReason": "stop",
    "errorMessage": ""
  }
}
```
Observed result after fix: the same real TIFF input reached both Anthropic request builders as `image/jpeg`, and both the provider and transport completed with `stopReason: "stop"` instead of an unsupported-media request failure.
What was not tested: live `api.anthropic.com` was not called; HEIC and BMP were not separately rerun in the loopback proof; I did not run a full app or end-to-end channel flow beyond the focused provider/transport paths above.

Closes #102323
