### PR TITLE
fix(openai): surface chat-completions refusal text

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2728,6 +2728,86 @@ describe("openai transport stream", () => {
     expect(output.responseId).toBe("resp_azure_text");
   });
 
+  it("surfaces refusal-only OpenAI-compatible delta chunks as visible text", async () => {
+    const model = {
+      id: "glm-5",
+      name: "GLM-5",
+      api: "openai-completions",
+      provider: "vllm",
+      baseUrl: "http://localhost:8000/v1",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128000,
+      maxTokens: 4096,
+    } satisfies Model<"openai-completions">;
+    const output = createAssistantOutput(model);
+
+    async function* mockStream() {
+      yield {
+        id: "chatcmpl-vllm",
+        object: "chat.completion.chunk" as const,
+        created: 1775425651,
+        model: "glm-5",
+        choices: [
+          {
+            index: 0,
+            delta: { role: "assistant" as const, refusal: "I can't help with that." },
+            logprobs: null,
+            finish_reason: "stop" as const,
+          },
+        ],
+      };
+    }
+
+    await testing.processOpenAICompletionsStream(mockStream(), output, model, { push() {} });
+
+    expect(output.content).toStrictEqual([{ type: "text", text: "I can't help with that." }]);
+    expect(output.stopReason).toBe("stop");
+  });
+
+  it("surfaces refusal-only aggregated OpenAI-compatible messages as visible text", async () => {
+    const model = {
+      id: "glm-5",
+      name: "GLM-5",
+      api: "openai-completions",
+      provider: "vllm",
+      baseUrl: "http://localhost:8000/v1",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128000,
+      maxTokens: 4096,
+    } satisfies Model<"openai-completions">;
+    const output = createAssistantOutput(model);
+
+    async function* mockStream() {
+      yield {
+        id: "chatcmpl-vllm",
+        object: "chat.completion" as const,
+        created: 1775425651,
+        model: "glm-5",
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant" as const,
+              content: null,
+              refusal: "I can't help with that.",
+            },
+            logprobs: null,
+            finish_reason: "stop" as const,
+          },
+        ],
+      };
+    }
+
+    await testing.processOpenAICompletionsStream(mockStream(), output, model, { push() {} });
+
+    expect(output.content).toStrictEqual([{ type: "text", text: "I can't help with that." }]);
+    expect(output.stopReason).toBe("stop");
+  });
+
   it("skips null and non-object OpenAI-compatible stream chunks", async () => {
     const model = {
       id: "glm-5",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -3166,6 +3166,9 @@ async function processOpenAICompletionsStream(
         }
       }
     }
+    if (typeof choiceDelta.refusal === "string" && choiceDelta.refusal.length > 0) {
+      appendFilteredVisibleTextDelta(choiceDelta.refusal);
+    }
     for (const reasoningDelta of reasoningDeltas) {
       if (reasoningDelta.kind === "thinking" && !emitReasoning) {
         continue;


### PR DESCRIPTION
## Summary
- surface `choice.delta.refusal` in `processOpenAICompletionsStream`
- also surface aggregated `choice.message.refusal` payloads from OpenAI-compatible chat-completions APIs
- add regression coverage for both stream chunk and aggregated message refusal-only responses

## Testing
- `pnpm vitest run src/agents/openai-transport-stream.test.ts`

Fixes #102321
