### PR TITLE
fix(codex): remote app servers can read OpenClaw skills

### DIFF
--- a/extensions/codex/src/app-server/remote-skills.ts
+++ b/extensions/codex/src/app-server/remote-skills.ts
@@ -1,0 +1,168 @@
+/** Materializes OpenClaw skills for Codex app-servers running on a remote workspace mirror. */
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  embeddedAgentLog,
+  type EmbeddedRunAttemptParams,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import { syncSkillsToWorkspace } from "openclaw/plugin-sdk/skills-runtime";
+import { mapCodexAppServerRemoteWorkspacePath } from "./dynamic-tool-build.js";
+
+const CODEX_REMOTE_SKILLS_DIR = path.join(".openclaw", "codex");
+
+type SkillsSnapshot = EmbeddedRunAttemptParams["skillsSnapshot"];
+
+type MaterializedSkillsCacheEntry = {
+  fingerprint: string;
+  prompt: Promise<string>;
+};
+
+const materializedSkillsByWorkspace = new Map<string, MaterializedSkillsCacheEntry>();
+
+function escapeXml(value: string): string {
+  return value.replace(/&/gu, "&amp;").replace(/</gu, "&lt;").replace(/>/gu, "&gt;");
+}
+
+function skillsSnapshotFingerprint(
+  snapshot: NonNullable<SkillsSnapshot>,
+  remoteWorkspaceRoot: string,
+): string {
+  return JSON.stringify({
+    remoteWorkspaceRoot,
+    version: snapshot.version ?? null,
+    promptFormatVersion: snapshot.promptFormatVersion ?? null,
+    prompt: snapshot.prompt,
+    skills: snapshot.resolvedSkills?.map((skill) => ({
+      name: skill.name,
+      filePath: skill.filePath,
+    })),
+  });
+}
+
+async function makeSkillDirectoriesWritable(root: string): Promise<void> {
+  let stats: Awaited<ReturnType<typeof fs.lstat>>;
+  try {
+    stats = await fs.lstat(root);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+  if (!stats.isDirectory() || stats.isSymbolicLink()) {
+    return;
+  }
+  await fs.chmod(root, 0o755);
+  for (const entry of await fs.readdir(root, { withFileTypes: true })) {
+    if (entry.isDirectory() && !entry.isSymbolicLink()) {
+      await makeSkillDirectoriesWritable(path.join(root, entry.name));
+    }
+  }
+}
+
+async function makeSkillTreeReadOnly(root: string): Promise<void> {
+  const stats = await fs.lstat(root);
+  if (stats.isSymbolicLink()) {
+    return;
+  }
+  if (!stats.isDirectory()) {
+    const executable = (stats.mode & 0o111) !== 0;
+    await fs.chmod(root, executable ? 0o555 : 0o444);
+    return;
+  }
+  for (const entry of await fs.readdir(root)) {
+    await makeSkillTreeReadOnly(path.join(root, entry));
+  }
+  await fs.chmod(root, 0o555);
+}
+
+function rewriteSkillLocations(
+  prompt: string,
+  paths: Array<{ skillName: string; remoteReadPath: string }>,
+): string {
+  const pathByEscapedName = new Map(
+    paths.map((entry) => [escapeXml(entry.skillName), escapeXml(entry.remoteReadPath)]),
+  );
+  return prompt.replace(/<skill>[\s\S]*?<\/skill>/giu, (block) => {
+    const name = block.match(/<name>([\s\S]*?)<\/name>/iu)?.[1];
+    const remoteReadPath = name ? pathByEscapedName.get(name) : undefined;
+    return remoteReadPath
+      ? block.replace(/<location>[\s\S]*?<\/location>/iu, `<location>${remoteReadPath}</location>`)
+      : block;
+  });
+}
+
+async function materializeCodexRemoteSkills(params: {
+  snapshot: NonNullable<SkillsSnapshot>;
+  localWorkspaceRoot: string;
+  remoteWorkspaceRoot: string;
+  config: EmbeddedRunAttemptParams["config"];
+  agentId: string;
+}): Promise<string> {
+  const targetWorkspaceDir = path.join(params.localWorkspaceRoot, CODEX_REMOTE_SKILLS_DIR);
+  const targetSkillsDir = path.join(targetWorkspaceDir, "skills");
+  await makeSkillDirectoriesWritable(targetSkillsDir);
+  const paths = await syncSkillsToWorkspace({
+    sourceWorkspaceDir: params.localWorkspaceRoot,
+    targetWorkspaceDir,
+    config: params.config,
+    skillFilter: params.snapshot.resolvedSkills?.map((skill) => skill.name),
+    agentId: params.agentId,
+  });
+  await makeSkillTreeReadOnly(targetSkillsDir);
+  return rewriteSkillLocations(
+    params.snapshot.prompt,
+    paths.map((entry) => ({
+      skillName: entry.skillName,
+      remoteReadPath: mapCodexAppServerRemoteWorkspacePath({
+        value: entry.readPath,
+        localWorkspaceRoot: params.localWorkspaceRoot,
+        remoteWorkspaceRoot: params.remoteWorkspaceRoot,
+      }),
+    })),
+  );
+}
+
+export async function resolveCodexRemoteSkillsPrompt(params: {
+  attempt: EmbeddedRunAttemptParams;
+  localWorkspaceRoot: string;
+  remoteWorkspaceRoot?: string;
+  agentId: string;
+}): Promise<string | undefined> {
+  const snapshot = params.attempt.skillsSnapshot;
+  if (!snapshot?.prompt?.trim() || !params.remoteWorkspaceRoot) {
+    return snapshot?.prompt;
+  }
+
+  const fingerprint = skillsSnapshotFingerprint(snapshot, params.remoteWorkspaceRoot);
+  const existing = materializedSkillsByWorkspace.get(params.localWorkspaceRoot);
+  if (existing?.fingerprint === fingerprint) {
+    return await existing.prompt;
+  }
+
+  const prompt = materializeCodexRemoteSkills({
+    snapshot,
+    localWorkspaceRoot: params.localWorkspaceRoot,
+    remoteWorkspaceRoot: params.remoteWorkspaceRoot,
+    config: params.attempt.config,
+    agentId: params.agentId,
+  }).catch((error: unknown) => {
+    const current = materializedSkillsByWorkspace.get(params.localWorkspaceRoot);
+    if (current?.fingerprint === fingerprint) {
+      materializedSkillsByWorkspace.delete(params.localWorkspaceRoot);
+    }
+    embeddedAgentLog.warn("failed to materialize skills for remote Codex app-server", {
+      workspaceDir: params.localWorkspaceRoot,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return snapshot.prompt;
+  });
+  materializedSkillsByWorkspace.set(params.localWorkspaceRoot, { fingerprint, prompt });
+  return await prompt;
+}
+
+export const testing = {
+  makeSkillDirectoriesWritable,
+  makeSkillTreeReadOnly,
+  rewriteSkillLocations,
+};

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -224,6 +224,7 @@ import {
 } from "./protocol.js";
 import { resolveCodexProviderWebSearchSupport } from "./provider-capabilities.js";
 import { readCodexRateLimitsRevision, readRecentCodexRateLimits } from "./rate-limit-cache.js";
+import { resolveCodexRemoteSkillsPrompt } from "./remote-skills.js";
 import { releaseCodexSandboxExecServerEnvironment } from "./sandbox-exec-server.js";
 import {
   isCodexAppServerNativeAuthProfile,
@@ -998,9 +999,15 @@ export async function runCodexAppServerAttempt(
     params,
     workspacePromptContext: workspaceBootstrapContext.promptContext,
   });
+  const skillsPrompt = await resolveCodexRemoteSkillsPrompt({
+    attempt: params,
+    localWorkspaceRoot: resolvedWorkspace,
+    remoteWorkspaceRoot: appServer.remoteWorkspaceRoot,
+    agentId: sessionAgentId,
+  });
   const skillsCollaborationInstructions = renderCodexSkillsCollaborationInstructions({
     attempt: params,
-    skillsPrompt: params.skillsSnapshot?.prompt,
+    skillsPrompt,
   });
   let promptText = params.prompt;
   let promptContextRange: CodexProjectedContextRange | undefined;
@@ -1425,7 +1432,7 @@ export async function runCodexAppServerAttempt(
     workspaceDir: effectiveWorkspace,
     developerInstructions: buildRenderedCodexDeveloperInstructions(),
     workspaceBootstrapContext,
-    skillsPrompt: skillsCollaborationInstructions ? (params.skillsSnapshot?.prompt ?? "") : "",
+    skillsPrompt: skillsCollaborationInstructions ? (skillsPrompt ?? "") : "",
     tools: toolBridge.availableSpecs,
   });
   const trajectoryRecorder = createCodexTrajectoryRecorder({

--- a/src/plugin-sdk/skills-runtime.ts
+++ b/src/plugin-sdk/skills-runtime.ts
@@ -1,6 +1,4 @@
-/**
- * Runtime SDK subpath for skill snapshot invalidation and refresh listeners.
- */
+/** Runtime SDK subpath for skill refresh and workspace materialization. */
 export {
   bumpSkillsSnapshotVersion,
   getSkillsSnapshotVersion,
@@ -8,3 +6,4 @@ export {
   shouldRefreshSnapshotForVersion,
   type SkillsChangeEvent,
 } from "../skills/runtime/refresh-state.js";
+export { syncSkillsToWorkspace } from "../skills/loading/workspace.js";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running Codex through a remote app-server could see OpenClaw skills in the prompt but Codex could not read their `SKILL.md` files because the advertised paths existed only on the gateway host.

## Why This Change Was Made

Remote Codex attempts now reuse OpenClaw’s resolved skill catalog, materialize every selected skill into one generated directory inside the mirrored workspace, preserve executability while marking the copied tree read-only, and rewrite prompt locations to the corresponding remote workspace paths. Local app-server behavior is unchanged.

## User Impact

Remote Codex sessions can read bundled, plugin, managed, personal, project, workspace, and configured-extra skills through one synchronized catalog instead of receiving gateway-local paths.

## Evidence

Before: the gateway advertised paths such as `/home/node/.openclaw/plugin-skills/slack/SKILL.md`, which did not exist on the remote Codex host.

Focused tests and live verification will be added after PR creation so review can proceed while validation runs.

AI-assisted: yes. I reviewed and understand the implementation.