### PR TITLE
fix: surface OpenAI chat-completions refusal as assistant text

### DIFF
--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -9,8 +9,13 @@ type DeepPartial<T> = { [P in keyof T]?: DeepPartial<T[P]> };
 type OpenAICompatibleDelta = DeepPartial<ChatCompletionChunk["choices"][number]["delta"]> & {
   reasoning_content?: string;
 };
-type OpenAICompatibleChoice = Omit<DeepPartial<ChatCompletionChunk["choices"][number]>, "delta"> & {
+type OpenAICompatibleChoice = Omit<
+  DeepPartial<ChatCompletionChunk["choices"][number]>,
+  "delta" | "message"
+> & {
   delta?: OpenAICompatibleDelta;
+  // Some OpenAI-compatible endpoints deliver a full message instead of delta.
+  message?: OpenAICompatibleDelta;
 };
 type OpenAICompatibleChatCompletionChunk = Omit<
   DeepPartial<ChatCompletionChunk>,
@@ -137,6 +142,19 @@ function makeRefusalChunk(refusal: string): OpenAICompatibleChatCompletionChunk 
   };
 }
 
+function makeRefusalMessageChunk(refusal: string): OpenAICompatibleChatCompletionChunk {
+  return {
+    id: "chatcmpl-test",
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content: null, refusal },
+        finish_reason: "stop",
+      },
+    ],
+  };
+}
+
 function makeToolCallChunk(
   id: string,
   name: string,
@@ -242,6 +260,19 @@ describe("OpenAI-compatible completions params", () => {
     }).result();
 
     expect(result.content).toStrictEqual([{ type: "text", text: "I can't help with that." }]);
+    expect(result.stopReason).toBe("stop");
+  });
+
+  it("surfaces aggregated chat-completions message.refusal as visible assistant text", async () => {
+    mockChunksRef.chunks = [makeRefusalMessageChunk("Requests like this are not allowed.")];
+
+    const result = await streamOpenAICompletions(model, context, {
+      apiKey: "sk-test",
+    }).result();
+
+    expect(result.content).toStrictEqual([
+      { type: "text", text: "Requests like this are not allowed." },
+    ]);
     expect(result.stopReason).toBe("stop");
   });
 

--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -124,6 +124,19 @@ function makeTextChunk(text: string): OpenAICompatibleChatCompletionChunk {
   };
 }
 
+function makeRefusalChunk(refusal: string): OpenAICompatibleChatCompletionChunk {
+  return {
+    id: "chatcmpl-test",
+    choices: [
+      {
+        index: 0,
+        delta: { role: "assistant", content: null, refusal },
+        finish_reason: "stop",
+      },
+    ],
+  };
+}
+
 function makeToolCallChunk(
   id: string,
   name: string,
@@ -219,6 +232,17 @@ describe("OpenAI-compatible completions params", () => {
     } finally {
       configureAiTransportHost({});
     }
+  });
+
+  it("surfaces chat-completions refusal deltas as visible assistant text", async () => {
+    mockChunksRef.chunks = [makeRefusalChunk("I can't help with that.")];
+
+    const result = await streamOpenAICompletions(model, context, {
+      apiKey: "sk-test",
+    }).result();
+
+    expect(result.content).toStrictEqual([{ type: "text", text: "I can't help with that." }]);
+    expect(result.stopReason).toBe("stop");
   });
 
   it("preserves a valid provider-reported usage cost", async () => {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -461,6 +461,14 @@ export const streamOpenAICompletions: StreamFunction<
             appendPartitionedContent(choice.delta.content, Boolean(foundReasoningField));
           }
 
+          // Chat Completions can put safety/structured-output refusals in a
+          // top-level `refusal` field with content null. Surface that as
+          // visible text so the assistant turn is not empty.
+          const refusalText = typeof choice.delta.refusal === "string" ? choice.delta.refusal : "";
+          if (refusalText.length > 0) {
+            appendPartitionedContent(refusalText, Boolean(foundReasoningField));
+          }
+
           if (choice?.delta?.tool_calls) {
             flushPartitionedContent();
             // The tool-call lane is also a reasoning boundary; seal the thought

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -424,13 +424,19 @@ export const streamOpenAICompletions: StreamFunction<
           hasFinishReason = true;
         }
 
-        if (choice.delta) {
+        // Some OpenAI-compatible endpoints deliver a full `message` instead of
+        // `delta` (including refusal-only turns with content: null). Normalize
+        // the same way the managed agent transport does.
+        const choiceDelta =
+          choice.delta ??
+          (choice as { message?: ChatCompletionChunk["choices"][number]["delta"] }).message;
+        if (choiceDelta) {
           // Some endpoints return reasoning in reasoning_content (llama.cpp),
           // or reasoning (other openai compatible endpoints)
           // Use the first non-empty reasoning field to avoid duplication
           // (e.g., chutes.ai returns both reasoning_content and reasoning with same content)
           const reasoningFields = ["reasoning_content", "reasoning", "reasoning_text"];
-          const deltaFields = choice.delta as Record<string, unknown>;
+          const deltaFields = choiceDelta as Record<string, unknown>;
           const shouldEmitReasoning = Boolean(model.reasoning && options?.reasoningEffort);
           let foundReasoningField: string | null = null;
           for (const field of reasoningFields) {
@@ -454,27 +460,27 @@ export const streamOpenAICompletions: StreamFunction<
             }
           }
           if (
-            choice.delta.content !== null &&
-            choice.delta.content !== undefined &&
-            choice.delta.content.length > 0
+            choiceDelta.content !== null &&
+            choiceDelta.content !== undefined &&
+            choiceDelta.content.length > 0
           ) {
-            appendPartitionedContent(choice.delta.content, Boolean(foundReasoningField));
+            appendPartitionedContent(choiceDelta.content, Boolean(foundReasoningField));
           }
 
           // Chat Completions can put safety/structured-output refusals in a
           // top-level `refusal` field with content null. Surface that as
           // visible text so the assistant turn is not empty.
-          const refusalText = typeof choice.delta.refusal === "string" ? choice.delta.refusal : "";
+          const refusalText = typeof choiceDelta.refusal === "string" ? choiceDelta.refusal : "";
           if (refusalText.length > 0) {
             appendPartitionedContent(refusalText, Boolean(foundReasoningField));
           }
 
-          if (choice?.delta?.tool_calls) {
+          if (choiceDelta.tool_calls) {
             flushPartitionedContent();
             // The tool-call lane is also a reasoning boundary; seal the thought
             // before toolcall_start so thinking_end never trails the action.
             sealNativeReasoningBeforeText();
-            for (const toolCall of choice.delta.tool_calls) {
+            for (const toolCall of choiceDelta.tool_calls) {
               const block = ensureToolCallBlock(toolCall);
               if (!block.id && toolCall.id) {
                 block.id = toolCall.id;
@@ -500,7 +506,7 @@ export const streamOpenAICompletions: StreamFunction<
             }
           }
 
-          const reasoningDetails = (choice.delta as { reasoning_details?: unknown })
+          const reasoningDetails = (choiceDelta as { reasoning_details?: unknown })
             .reasoning_details;
           if (reasoningDetails && Array.isArray(reasoningDetails)) {
             for (const detail of reasoningDetails) {

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2785,6 +2785,101 @@ describe("openai transport stream", () => {
     expect(output.stopReason).toBe("stop");
   });
 
+  it("surfaces chat-completions refusal deltas as visible assistant text", async () => {
+    const model = {
+      id: "gpt-5.5",
+      name: "GPT-5.5",
+      api: "openai-completions" as const,
+      provider: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: false,
+      input: ["text"] as const,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128_000,
+      maxTokens: 4096,
+    } satisfies Model<"openai-completions">;
+    const output = createAssistantOutput(model);
+    const events: CapturedStreamEvent[] = [];
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-refusal-delta",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              delta: { role: "assistant", content: null, refusal: "I can't help with that." },
+              logprobs: null,
+              finish_reason: "stop",
+            },
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push: (event) => events.push(event as CapturedStreamEvent) },
+    );
+
+    expect(output.content).toStrictEqual([{ type: "text", text: "I can't help with that." }]);
+    expect(output.stopReason).toBe("stop");
+    expect(
+      events.some(
+        (event) => event.type === "text_delta" && event.delta === "I can't help with that.",
+      ),
+    ).toBe(true);
+  });
+
+  it("surfaces aggregated chat-completions message.refusal as visible assistant text", async () => {
+    const model = {
+      id: "gpt-5.5",
+      name: "GPT-5.5",
+      api: "openai-completions" as const,
+      provider: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: false,
+      input: ["text"] as const,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128_000,
+      maxTokens: 4096,
+    } satisfies Model<"openai-completions">;
+    const output = createAssistantOutput(model);
+
+    await testing.processOpenAICompletionsStream(
+      streamChunks([
+        {
+          id: "chatcmpl-refusal-message",
+          object: "chat.completion.chunk",
+          created: 1,
+          model: model.id,
+          choices: [
+            {
+              index: 0,
+              // Some OpenAI-compatible endpoints deliver a full message instead of delta.
+              message: {
+                role: "assistant",
+                content: null,
+                refusal: "Requests like this are not allowed.",
+              },
+              logprobs: null,
+              finish_reason: "stop",
+            } as ChatCompletionChunk["choices"][number],
+          ],
+        },
+      ]),
+      output,
+      model,
+      { push() {} },
+    );
+
+    expect(output.content).toStrictEqual([
+      { type: "text", text: "Requests like this are not allowed." },
+    ]);
+    expect(output.stopReason).toBe("stop");
+  });
+
   it("filters DeepSeek DSML content without disturbing native tool calls", async () => {
     const model = createDeepSeekCompletionsModel();
     const output = createAssistantOutput(model);

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2865,7 +2865,7 @@ describe("openai transport stream", () => {
               },
               logprobs: null,
               finish_reason: "stop",
-            } as ChatCompletionChunk["choices"][number],
+            } as unknown as ChatCompletionChunk["choices"][number],
           ],
         },
       ]),

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -3166,6 +3166,18 @@ async function processOpenAICompletionsStream(
         }
       }
     }
+    // Chat Completions can put safety/structured-output refusals in a top-level
+    // `refusal` field with content null. Surface that as visible text so the
+    // assistant turn is not empty (Responses path already routes refusal deltas).
+    const refusalText = typeof choiceDelta.refusal === "string" ? choiceDelta.refusal : "";
+    if (refusalText) {
+      const routedDeltas = hasMirroredReasoning
+        ? reasoningTagTextPartitioner.push(refusalText)
+        : reasoningTagTextPartitioner.pushVisible(refusalText);
+      for (const routedDelta of routedDeltas) {
+        appendPartitionedVisibleDelta(routedDelta);
+      }
+    }
     for (const reasoningDelta of reasoningDeltas) {
       if (reasoningDelta.kind === "thinking" && !emitReasoning) {
         continue;


### PR DESCRIPTION
Fixes #102321

## What Problem This Solves

Fixes an issue where users on openai-completions models would receive a blank assistant turn when the provider returned a safety or structured-output refusal with `content: null` and a top-level `refusal` field.

## Why This Change Was Made

Chat Completions can put the refusal text only in `choice.delta.refusal` / `message.refusal`. The completions stream assemblers already handled `content`, reasoning, and tool calls, but never read `refusal`, so the turn resolved to empty content. The Responses path already surfaces refusal text; this change brings completions parity in both the managed agent transport and the packages/ai provider assembler.

Follow-up on ClawSweeper review: packages/ai now normalizes `choice.delta ?? choice.message` the same way the agent transport does, so aggregated message-only refusal chunks are covered, with matching regression tests. The agent transport message.refusal test cast was also fixed for `check:test-types`.

## User Impact

When a model refuses on the chat-completions API, users now see the refusal text instead of an empty reply.

## Evidence

Focused stream-assembler regressions (agent + packages/ai, delta and message forms):

```text
node scripts/run-vitest.mjs \
  src/agents/openai-transport-stream.test.ts \
  packages/ai/src/providers/openai-completions.test.ts \
  -t "refusal" --maxWorkers=2
# 6 passed
```

packages/ai verbose (post-review message.refusal path):

```text
✓ surfaces chat-completions refusal deltas as visible assistant text
✓ surfaces aggregated chat-completions message.refusal as visible assistant text
```

Also: oxfmt clean; `pnpm check:test-types` path previously failed on the agent message cast — fixed via `as unknown as Choice`.

## Real behavior proof

- Behavior addressed: openai-completions assistant turns that carry only a top-level `refusal` field (content null), delivered as either `delta.refusal` or aggregated `message.refusal`, no longer resolve to empty content; refusal text is shown as normal assistant text on both the managed agent transport and packages/ai streamOpenAICompletions assembler.
- Environment: local macOS Node/Vitest against PR branch rebased on current `origin/main`; production stream functions exercised via exported/test entrypoints (`processOpenAICompletionsStream`, `streamOpenAICompletions` with SDK create mocked to yield real chunk shapes).
- Current-main contrast: before the patch, both assemblers ignored `refusal` (and packages/ai only entered the content path for `choice.delta`), so a chunk with `content: null` + `refusal: "..."` produced `content: []`. After the patch, the same payloads produce a visible text block with the refusal string on both assemblers.
- Exact steps or command run after this patch:
  1. Feed a refusal-only `delta` chunk into agent `processOpenAICompletionsStream`.
  2. Feed a refusal-only aggregated `message` chunk (no `delta`) into the same function.
  3. Feed the same shapes through packages/ai `streamOpenAICompletions` (mocked OpenAI stream).
  4. Assert assistant `content` is `[{ type: "text", text: "<refusal>" }]` and stop reason remains `stop`.
- Evidence after fix: all six focused refusal tests pass, including packages/ai `surfaces aggregated chat-completions message.refusal as visible assistant text`.
- Control check: normal content-only completions chunks still produce text as before; Responses refusal handling is untouched.
- Observed result after fix: refusal-only completions turns yield visible assistant text matching the provider refusal string for both delta and message forms on both assemblers.
- What was not tested: live `api.openai.com` network call that returns a real safety refusal (no `OPENAI_API_KEY` in this environment). Protocol-level behavior is covered by production assembler code paths with provider-shaped chunks.

## AI disclosure

This fix was authored with AI assistance (Grok). Implementation and tests follow the ClawSweeper-recommended narrow parser-parity approach, including the packages/ai `message.refusal` completeness fix from review.
