### PR TITLE
fix(settings): deep merge nested retry provider fields

### DIFF
--- a/src/agents/sessions/settings-manager.test.ts
+++ b/src/agents/sessions/settings-manager.test.ts
@@ -1,6 +1,19 @@
 /** Tests session settings manager runtime overrides. */
 import { describe, expect, it } from "vitest";
-import { SettingsManager } from "./settings-manager.js";
+import {
+  InMemorySettingsStorage,
+  SettingsManager,
+  type Settings,
+  type SettingsScope,
+} from "./settings-manager.js";
+
+function writeSettings(
+  storage: InMemorySettingsStorage,
+  scope: SettingsScope,
+  settings: Partial<Settings>,
+): void {
+  storage.withLock(scope, () => JSON.stringify(settings, null, 2));
+}
 
 describe("SettingsManager runtime overrides", () => {
   it("preserves compaction overrides after global setting writes", async () => {
@@ -45,5 +58,44 @@ describe("SettingsManager runtime overrides", () => {
 
     expect(settingsManager.getPackages()).toEqual(["npm:@openclaw/example"]);
     expect(settingsManager.getCompactionReserveTokens()).toBe(50_000);
+  });
+});
+
+describe("SettingsManager nested scope merge", () => {
+  it("merges retry.provider fields split across global and project scopes", () => {
+    const storage = new InMemorySettingsStorage();
+    writeSettings(storage, "global", {
+      retry: { provider: { timeoutMs: 30_000, maxRetries: 5 } },
+    });
+    writeSettings(storage, "project", {
+      retry: { provider: { maxRetryDelayMs: 5_000 } },
+    });
+
+    const settingsManager = SettingsManager.fromStorage(storage);
+
+    expect(settingsManager.getProviderRetrySettings()).toEqual({
+      timeoutMs: 30_000,
+      maxRetries: 5,
+      maxRetryDelayMs: 5_000,
+    });
+  });
+
+  it("merges retry.provider fields split across persisted and runtime overrides", () => {
+    const settingsManager = SettingsManager.inMemory({
+      retry: { provider: { timeoutMs: 30_000, maxRetries: 5 } },
+    });
+
+    settingsManager.applyOverrides({
+      retry: { provider: { maxRetryDelayMs: 5_000 } },
+    });
+    settingsManager.applyOverrides({
+      retry: { provider: { timeoutMs: 45_000 } },
+    });
+
+    expect(settingsManager.getProviderRetrySettings()).toEqual({
+      timeoutMs: 45_000,
+      maxRetries: 5,
+      maxRetryDelayMs: 5_000,
+    });
   });
 });

--- a/src/agents/sessions/settings-manager.ts
+++ b/src/agents/sessions/settings-manager.ts
@@ -121,35 +121,36 @@ export interface Settings {
   httpIdleTimeoutMs?: number; // HTTP header/body idle timeout in milliseconds; 0 disables it
 }
 
-/** Deep merge settings: project/overrides take precedence, nested objects merge recursively */
-function deepMergeSettings(base: Settings, overrides: Settings): Settings {
-  const result: Settings = { ...base };
+type SettingsObject = Record<string, unknown>;
 
-  for (const key of Object.keys(overrides) as (keyof Settings)[]) {
-    const overrideValue = overrides[key];
-    const baseValue = base[key];
+function isMergeableSettingsObject(value: unknown): value is SettingsObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Deep merge settings: project/overrides take precedence, nested objects merge recursively */
+function deepMergeSettings<T extends object>(base: T, overrides: Partial<T>): T {
+  const baseRecord = base as SettingsObject;
+  const overrideRecord = overrides as SettingsObject;
+  const result: SettingsObject = { ...baseRecord };
+
+  for (const key of Object.keys(overrideRecord)) {
+    const overrideValue = overrideRecord[key];
+    const baseValue = baseRecord[key];
 
     if (overrideValue === undefined) {
       continue;
     }
 
     // For nested objects, merge recursively
-    if (
-      typeof overrideValue === "object" &&
-      overrideValue !== null &&
-      !Array.isArray(overrideValue) &&
-      typeof baseValue === "object" &&
-      baseValue !== null &&
-      !Array.isArray(baseValue)
-    ) {
-      (result as Record<string, unknown>)[key] = { ...baseValue, ...overrideValue };
+    if (isMergeableSettingsObject(overrideValue) && isMergeableSettingsObject(baseValue)) {
+      result[key] = deepMergeSettings(baseValue, overrideValue);
     } else {
       // For primitives and arrays, override value wins
-      (result as Record<string, unknown>)[key] = overrideValue;
+      result[key] = overrideValue;
     }
   }
 
-  return result;
+  return result as T;
 }
 
 export type SettingsScope = "global" | "project";


### PR DESCRIPTION
## What Problem This Solves

When `retry.provider` fields are split across settings scopes, `deepMergeSettings` used a one-level spread for nested objects even though the helper promises recursive merging. A project scope that sets only `retry.provider.maxRetryDelayMs` can replace the whole global `retry.provider` object and silently drop `timeoutMs` and `maxRetries`, causing provider requests to fall back to SDK defaults for timeout/retry behavior.

Closes #102318.

## Solution

- Recursively merge non-array settings objects in `deepMergeSettings`.
- Preserve existing primitive and array behavior: higher-precedence values still replace lower-precedence values.
- Add focused coverage for `retry.provider` split across global/project scopes and persisted/runtime overrides.

## Evidence

Before this fix, the source-level repro in #102318 produced:

```json
{"maxRetryDelayMs":5000}
```

for a global provider retry config of `{"timeoutMs":30000,"maxRetries":5}` plus a project override of `{"maxRetryDelayMs":5000}`.

After this fix, the new regression tests assert the effective provider retry settings preserve all three fields:

```json
{"timeoutMs":30000,"maxRetries":5,"maxRetryDelayMs":5000}
```

Validation run locally:

- `node scripts/test-projects.mjs src/agents/sessions/settings-manager.test.ts`
- `pnpm tsgo:prod`
- `pnpm check:test-types`
- `pnpm exec oxfmt --check src/agents/sessions/settings-manager.ts src/agents/sessions/settings-manager.test.ts`
- `git diff --check`

## Impact

Provider retry timeout/count settings no longer disappear when users split retry configuration across global, project, and runtime scopes. This keeps retry behavior predictable instead of unintentionally reverting to default retry count or timeout behavior.

## AI assistance

Implemented with AI assistance; reviewed and validated locally.

Signed-off-by: Ho Lim <subhoya@gmail.com>
