### PR TITLE
fix(tts-local-cli): handle stdout/stderr stream errors in speech provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Local CLI TTS child streams:** fail and terminate synthesis when the audio pipe breaks while containing diagnostic-stream errors, preventing process crashes and truncated audio. (#102347) Thanks @zw-xysk.
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Local CLI TTS child streams:** fail and terminate synthesis when the audio pipe breaks while containing diagnostic-stream errors, preventing process crashes and truncated audio. (#102347) Thanks @zw-xysk.
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.

--- a/extensions/tts-local-cli/speech-provider-stream-error.test.ts
+++ b/extensions/tts-local-cli/speech-provider-stream-error.test.ts
@@ -40,7 +40,7 @@ function createMockChild(): MockChild {
   stdin.end = () => {};
   stdin.write = () => {};
   child.stdin = stdin;
-  child.kill = (signal?: string) => {
+  child.kill = () => {
     child.killed = true;
     return true;
   };

--- a/extensions/tts-local-cli/speech-provider-stream-error.test.ts
+++ b/extensions/tts-local-cli/speech-provider-stream-error.test.ts
@@ -1,7 +1,5 @@
-// Regression coverage for stdout/stderr stream error handling in the CLI TTS provider.
-// Uses a mocked spawn to emit controlled stream errors — the existing test file
-// exercises the provider through real child processes.
 import { EventEmitter } from "node:events";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const spawnMock = vi.hoisted(() => vi.fn());
@@ -18,33 +16,38 @@ vi.mock("openclaw/plugin-sdk/media-runtime", () => ({
 import { buildCliSpeechProvider } from "./speech-provider.js";
 
 type MockChild = EventEmitter & {
-  killed: boolean;
-  pid: number;
-  stdout: EventEmitter & { destroy: (err?: Error) => void };
-  stderr: EventEmitter & { destroy: (err?: Error) => void };
+  stdout: EventEmitter;
+  stderr: EventEmitter;
   stdin: EventEmitter & { end: () => void; write: (data: string) => void };
-  kill: (signal?: string) => boolean;
+  kill: ReturnType<typeof vi.fn<(signal?: NodeJS.Signals) => boolean>>;
 };
 
 function createMockChild(): MockChild {
   const child = new EventEmitter() as MockChild;
-  child.killed = false;
-  child.pid = 1234;
-  const stdout = new EventEmitter() as EventEmitter & { destroy: (err?: Error) => void };
-  stdout.destroy = () => {};
-  child.stdout = stdout;
-  const stderr = new EventEmitter() as EventEmitter & { destroy: (err?: Error) => void };
-  stderr.destroy = () => {};
-  child.stderr = stderr;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
   const stdin = new EventEmitter() as EventEmitter & { end: () => void; write: () => void };
   stdin.end = () => {};
   stdin.write = () => {};
   child.stdin = stdin;
-  child.kill = () => {
-    child.killed = true;
-    return true;
-  };
+  child.kill = vi.fn(() => true);
   return child;
+}
+
+const TEST_CFG = {} as OpenClawConfig;
+
+async function synthesize(child: MockChild) {
+  spawnMock.mockReturnValue(child);
+  const promise = buildCliSpeechProvider().synthesize({
+    text: "hello",
+    cfg: TEST_CFG,
+    providerConfig: { command: "/fake/tts", outputFormat: "wav", timeoutMs: 5000 },
+    providerOverrides: {},
+    timeoutMs: 5000,
+    target: "audio-file",
+  });
+  await vi.waitUntil(() => spawnMock.mock.calls.length > 0, { timeout: 2000 });
+  return { promise };
 }
 
 describe("CLI TTS provider stream error handling", () => {
@@ -54,58 +57,24 @@ describe("CLI TTS provider stream error handling", () => {
 
   it("rejects on stdout stream error instead of silently returning truncated audio", async () => {
     const child = createMockChild();
-    spawnMock.mockReturnValue(child);
+    const { promise } = await synthesize(child);
 
-    const promise = buildCliSpeechProvider().synthesize({
-      text: "hello",
-      cfg: {} as any,
-      providerConfig: {
-        command: "/fake/tts",
-        args: ["--out", "{{OutputPath}}"],
-        timeoutMs: 5000,
-      },
-      providerOverrides: {},
-      timeoutMs: 5000,
-      target: "audio-file",
-    });
-
-    // synthesize does async work (tempWorkspace) before calling runCli/spawn.
-    // Wait until spawn has been called and listeners are attached.
-    await vi.waitUntil(() => spawnMock.mock.calls.length > 0, { timeout: 2000 });
-
-    // Simulate stdout pipe breaking mid-generation — the critical scenario:
-    // without the fix, this error is unhandled and crashes the process.
-    // With the fix, the provider rejects cleanly.
     child.stdout.emit("error", new Error("EPIPE: audio stream broken"));
+    child.emit("close", null, "SIGTERM");
 
     await expect(promise).rejects.toThrow("CLI TTS stdout stream error");
-    expect(child.killed).toBe(true);
+    expect(child.kill).toHaveBeenCalledOnce();
   });
 
-  it("does not crash on stderr stream error", async () => {
+  it("keeps synthesized audio when only the diagnostic stream errors", async () => {
     const child = createMockChild();
-    spawnMock.mockReturnValue(child);
+    const { promise } = await synthesize(child);
 
-    const promise = buildCliSpeechProvider().synthesize({
-      text: "hello",
-      cfg: {} as any,
-      providerConfig: {
-        command: "/fake/tts",
-        args: ["--out", "{{OutputPath}}"],
-        timeoutMs: 5000,
-      },
-      providerOverrides: {},
-      timeoutMs: 5000,
-      target: "audio-file",
-    });
-
-    await vi.waitUntil(() => spawnMock.mock.calls.length > 0, { timeout: 2000 });
-
-    // stderr errors must not throw — diagnostic stream failures are benign
-    expect(() => child.stderr.emit("error", new Error("EPIPE: diag broken"))).not.toThrow();
-
-    // Clean up: resolve the promise to avoid unhandled rejection
+    child.stdout.emit("data", Buffer.from("audio"));
+    child.stderr.emit("error", new Error("EPIPE: diagnostics stream broken"));
     child.emit("close", 0);
-    await promise.catch(() => {});
+
+    await expect(promise).resolves.toMatchObject({ audioBuffer: Buffer.from("audio") });
+    expect(child.kill).not.toHaveBeenCalled();
   });
 });

--- a/extensions/tts-local-cli/speech-provider-stream-error.test.ts
+++ b/extensions/tts-local-cli/speech-provider-stream-error.test.ts
@@ -1,0 +1,111 @@
+// Regression coverage for stdout/stderr stream error handling in the CLI TTS provider.
+// Uses a mocked spawn to emit controlled stream errors — the existing test file
+// exercises the provider through real child processes.
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  spawn: spawnMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/media-runtime", () => ({
+  runFfmpeg: vi.fn(),
+}));
+
+import { buildCliSpeechProvider } from "./speech-provider.js";
+
+type MockChild = EventEmitter & {
+  killed: boolean;
+  pid: number;
+  stdout: EventEmitter & { destroy: (err?: Error) => void };
+  stderr: EventEmitter & { destroy: (err?: Error) => void };
+  stdin: EventEmitter & { end: () => void; write: (data: string) => void };
+  kill: (signal?: string) => boolean;
+};
+
+function createMockChild(): MockChild {
+  const child = new EventEmitter() as MockChild;
+  child.killed = false;
+  child.pid = 1234;
+  const stdout = new EventEmitter() as EventEmitter & { destroy: (err?: Error) => void };
+  stdout.destroy = () => {};
+  child.stdout = stdout;
+  const stderr = new EventEmitter() as EventEmitter & { destroy: (err?: Error) => void };
+  stderr.destroy = () => {};
+  child.stderr = stderr;
+  const stdin = new EventEmitter() as EventEmitter & { end: () => void; write: () => void };
+  stdin.end = () => {};
+  stdin.write = () => {};
+  child.stdin = stdin;
+  child.kill = (signal?: string) => {
+    child.killed = true;
+    return true;
+  };
+  return child;
+}
+
+describe("CLI TTS provider stream error handling", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects on stdout stream error instead of silently returning truncated audio", async () => {
+    const child = createMockChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = buildCliSpeechProvider().synthesize({
+      text: "hello",
+      cfg: {} as any,
+      providerConfig: {
+        command: "/fake/tts",
+        args: ["--out", "{{OutputPath}}"],
+        timeoutMs: 5000,
+      },
+      providerOverrides: {},
+      timeoutMs: 5000,
+      target: "audio-file",
+    });
+
+    // synthesize does async work (tempWorkspace) before calling runCli/spawn.
+    // Wait until spawn has been called and listeners are attached.
+    await vi.waitUntil(() => spawnMock.mock.calls.length > 0, { timeout: 2000 });
+
+    // Simulate stdout pipe breaking mid-generation — the critical scenario:
+    // without the fix, this error is unhandled and crashes the process.
+    // With the fix, the provider rejects cleanly.
+    child.stdout.emit("error", new Error("EPIPE: audio stream broken"));
+
+    await expect(promise).rejects.toThrow("CLI TTS stdout stream error");
+    expect(child.killed).toBe(true);
+  });
+
+  it("does not crash on stderr stream error", async () => {
+    const child = createMockChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = buildCliSpeechProvider().synthesize({
+      text: "hello",
+      cfg: {} as any,
+      providerConfig: {
+        command: "/fake/tts",
+        args: ["--out", "{{OutputPath}}"],
+        timeoutMs: 5000,
+      },
+      providerOverrides: {},
+      timeoutMs: 5000,
+      target: "audio-file",
+    });
+
+    await vi.waitUntil(() => spawnMock.mock.calls.length > 0, { timeout: 2000 });
+
+    // stderr errors must not throw — diagnostic stream failures are benign
+    expect(() => child.stderr.emit("error", new Error("EPIPE: diag broken"))).not.toThrow();
+
+    // Clean up: resolve the promise to avoid unhandled rejection
+    child.emit("close", 0);
+    await promise.catch(() => {});
+  });
+});

--- a/extensions/tts-local-cli/speech-provider.ts
+++ b/extensions/tts-local-cli/speech-provider.ts
@@ -218,7 +218,18 @@ async function runCli(params: {
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];
     proc.stdout.on("data", (c) => stdoutChunks.push(c));
+    // stdout carries synthesized audio data. A stream error means the audio
+    // pipe broke mid-generation — reject so the caller does not silently
+    // receive truncated audio when the child later exits zero.
+    proc.stdout.on("error", (e) => {
+      clearTimeout(timer);
+      proc.kill();
+      reject(new Error(`CLI TTS stdout stream error: ${e.message}`));
+    });
     proc.stderr.on("data", (c) => stderrChunks.push(c));
+    // stderr carries diagnostic logs only. Stream errors here are benign and
+    // should not crash the provider or affect audio output.
+    proc.stderr.on("error", () => {});
 
     proc.on("error", (e) => {
       clearTimeout(timer);

--- a/extensions/tts-local-cli/speech-provider.ts
+++ b/extensions/tts-local-cli/speech-provider.ts
@@ -204,16 +204,42 @@ async function runCli(params: {
   const args = baseArgs.map((a) => applyTemplate(a, ctx));
 
   return new Promise((resolve, reject) => {
-    let timedOut = false;
-    const timer = setTimeout(() => {
-      timedOut = true;
-      proc.kill();
-      // Escalate to SIGKILL if child ignores SIGTERM
-      setTimeout(() => proc.kill("SIGKILL"), 5000).unref();
-    }, params.timeoutMs);
-
     const env = params.env ? { ...process.env, ...params.env } : process.env;
     const proc = spawn(cmd, args, { cwd: params.cwd, env, stdio: ["pipe", "pipe", "pipe"] });
+    let settled = false;
+    let failure: Error | undefined;
+    let forceKillTimer: NodeJS.Timeout | undefined;
+
+    const clearTimers = () => {
+      clearTimeout(timer);
+      clearTimeout(forceKillTimer);
+    };
+    const rejectOnce = (error: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimers();
+      reject(error);
+    };
+    const terminate = () => {
+      proc.kill();
+      forceKillTimer = setTimeout(() => proc.kill("SIGKILL"), 5000);
+      forceKillTimer.unref();
+    };
+    const terminateFor = (error: Error) => {
+      // Keep one terminal cause across stream, process, and close events. Node
+      // may emit several of them for the same failed child lifecycle.
+      if (settled || failure) {
+        return;
+      }
+      failure = error;
+      clearTimeout(timer);
+      terminate();
+    };
+    const timer = setTimeout(() => {
+      terminateFor(new Error(`CLI TTS timed out after ${params.timeoutMs}ms`));
+    }, params.timeoutMs);
 
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];
@@ -222,9 +248,7 @@ async function runCli(params: {
     // pipe broke mid-generation — reject so the caller does not silently
     // receive truncated audio when the child later exits zero.
     proc.stdout.on("error", (e) => {
-      clearTimeout(timer);
-      proc.kill();
-      reject(new Error(`CLI TTS stdout stream error: ${e.message}`));
+      terminateFor(new Error(`CLI TTS stdout stream error: ${e.message}`));
     });
     proc.stderr.on("data", (c) => stderrChunks.push(c));
     // stderr carries diagnostic logs only. Stream errors here are benign and
@@ -232,29 +256,33 @@ async function runCli(params: {
     proc.stderr.on("error", () => {});
 
     proc.on("error", (e) => {
-      clearTimeout(timer);
-      reject(new Error(`CLI TTS failed: ${e.message}`));
+      rejectOnce(failure ?? new Error(`CLI TTS failed: ${e.message}`));
     });
 
     proc.on("close", (code) => {
-      clearTimeout(timer);
-      if (timedOut) {
-        return reject(new Error(`CLI TTS timed out after ${params.timeoutMs}ms`));
+      if (settled) {
+        clearTimers();
+        return;
+      }
+      if (failure) {
+        return rejectOnce(failure);
       }
       if (code !== 0) {
         const stderr = Buffer.concat(stderrChunks).toString("utf8");
-        return reject(new Error(`CLI TTS exit ${code}: ${stderr}`));
+        return rejectOnce(new Error(`CLI TTS exit ${code}: ${stderr}`));
       }
 
       const audioFile = findAudioFile(params.outputDir, params.filePrefix);
       if (audioFile) {
         if (!existsSync(audioFile)) {
-          return reject(new Error(`CLI TTS: output file not found at ${audioFile}`));
+          return rejectOnce(new Error(`CLI TTS: output file not found at ${audioFile}`));
         }
         const format = detectFormat(audioFile);
         if (!format) {
-          return reject(new Error(`CLI TTS: unknown format for ${audioFile}`));
+          return rejectOnce(new Error(`CLI TTS: unknown format for ${audioFile}`));
         }
+        settled = true;
+        clearTimers();
         return resolve({
           buffer: readFileSync(audioFile),
           actualFormat: format,
@@ -265,9 +293,11 @@ async function runCli(params: {
       const stdout = Buffer.concat(stdoutChunks);
       if (stdout.length > 0) {
         // Assume WAV for stdout output; could be MP3 but caller should convert if needed
+        settled = true;
+        clearTimers();
         return resolve({ buffer: stdout, actualFormat: "wav" });
       }
-      reject(new Error("CLI TTS produced no output"));
+      rejectOnce(new Error("CLI TTS produced no output"));
     });
 
     proc.stdin?.on("error", () => {}); // suppress EPIPE if child ignores stdin


### PR DESCRIPTION
## What Problem This Solves

The Local CLI speech provider collected piped child stdout and stderr without stream `error` listeners. A broken stdout pipe could therefore crash the process or, if handled as a benign diagnostic failure, allow incomplete audio to be returned. Stderr carries diagnostics rather than audio and needs containment without changing synthesis success.

## Why This Change Was Made

This revision treats the child process as one lifecycle instead of adding unrelated event callbacks:

- stdout stream failure records the first terminal cause, requests child termination, and preserves the existing SIGTERM-to-SIGKILL escalation;
- timeout, process `error`, and `close` settle the promise once without overriding the original cause;
- rejection waits for child shutdown, so temporary synthesis workspace cleanup cannot race a still-running writer;
- stderr stream errors are contained because they do not invalidate audio received through stdout or a generated file;
- the original 111-line mock scaffold was reduced while strengthening its success assertion.

This keeps the previous timeout and exit behavior intact and remains compatible with the pending output-bound work in #101510.

## User Impact

Local CLI TTS now fails cleanly instead of crashing or returning truncated audio when its audio pipe breaks. A diagnostic stderr pipe failure alone no longer prevents valid audio from being delivered.

## Evidence

- Crabbox `run_c698f42e9f79`: Linux Node 24 focused suite, 2 files / 9 tests passed on the rebased head.
- Crabbox `run_3557d7af40d4`: real child CLI plus real system ffmpeg generated WAV and converted a non-empty Opus voice note.
- Source-blind behavior contract: 4 passed, 0 failed, 0 blocked after installing the required ffmpeg package in the disposable host.
- Fresh autoreview: no accepted/actionable findings; correctness confidence 0.96.
- Node child-process contract checked: `close` follows process `error` or exit and may race other terminal events, so settlement is explicitly guarded.

Thanks @zw-xysk for the original report and fix direction.
