### PR TITLE
fix(realtime-transcription): stop resetting reconnect counter on every socket open

### DIFF
--- a/src/realtime-transcription/websocket-session.test.ts
+++ b/src/realtime-transcription/websocket-session.test.ts
@@ -20,6 +20,7 @@ afterEach(async () => {
 
 async function createRealtimeServer(params?: {
   closeOnConnection?: boolean;
+  closeConnectionsAfterIndex?: number;
   initialEvent?: unknown;
   initialText?: string;
   onUpgrade?: (headers: Record<string, string | string[] | undefined>) => void;
@@ -29,13 +30,24 @@ async function createRealtimeServer(params?: {
   const server = createServer();
   const wss = new WebSocketServer({ noServer: true, maxPayload: 1024 * 1024 });
   const clients = new Set<WebSocket>();
+  const clientsInOrder: WebSocket[] = [];
+  let connectionIndex = 0;
 
   server.on("upgrade", (request, socket, head) => {
     params?.onUpgrade?.(request.headers);
     wss.handleUpgrade(request, socket, head, (ws) => {
+      const index = connectionIndex++;
       clients.add(ws);
-      ws.on("close", () => clients.delete(ws));
-      if (params?.closeOnConnection) {
+      clientsInOrder[index] = ws;
+      ws.on("close", () => {
+        clients.delete(ws);
+        clientsInOrder[index] = null as unknown as WebSocket;
+      });
+      if (
+        params?.closeOnConnection ||
+        (params?.closeConnectionsAfterIndex !== undefined &&
+          index > params.closeConnectionsAfterIndex)
+      ) {
         ws.close(1011, "setup failed");
         return;
       }
@@ -75,7 +87,15 @@ async function createRealtimeServer(params?: {
     });
   };
   const port = (server.address() as AddressInfo).port;
-  return { url: `ws://127.0.0.1:${port}` };
+  return {
+    url: `ws://127.0.0.1:${port}`,
+    closeConnection: (index: number) => {
+      const ws = clientsInOrder[index];
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.close(1000, "test closed");
+      }
+    },
+  };
 }
 
 function createSignal() {
@@ -402,5 +422,45 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
     const closeError = requireFirstMockArg(onError, "pre-ready close error");
     expect(closeError).toBeInstanceOf(Error);
     expect(closeError.message).toBe("test realtime transcription connection closed before ready");
+  });
+
+  it("gives up after maxReconnectAttempts on a flapping ready upstream", async () => {
+    let upgradeCount = 0;
+    const server = await createRealtimeServer({
+      closeConnectionsAfterIndex: 0,
+      onUpgrade: () => {
+        upgradeCount += 1;
+      },
+    });
+    const onError = vi.fn();
+    const session = createRealtimeTranscriptionWebSocketSession({
+      providerId: "test",
+      callbacks: { onError },
+      url: server.url,
+      readyOnOpen: true,
+      reconnectDelayMs: 10,
+      maxReconnectAttempts: 3,
+      reconnectLimitMessage: "test reconnect limit reached",
+      sendAudio: (audio, transport) => {
+        transport.sendBinary(audio);
+      },
+    });
+
+    await session.connect();
+    expect(session.isConnected()).toBe(true);
+    expect(upgradeCount).toBe(1);
+
+    server.closeConnection(0);
+
+    await vi.waitFor(() => {
+      expect(onError).toHaveBeenCalledTimes(1);
+    });
+    const limitError = requireFirstMockArg(onError, "reconnect limit error");
+    expect(limitError).toBeInstanceOf(Error);
+    expect(limitError.message).toBe("test reconnect limit reached");
+    // Initial connection + 3 reconnect attempts; without the fix the counter
+    // resets on every socket open and the loop never terminates.
+    expect(upgradeCount).toBe(1 + 3);
+    session.close();
   });
 });

--- a/src/realtime-transcription/websocket-session.ts
+++ b/src/realtime-transcription/websocket-session.ts
@@ -259,7 +259,6 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
         this.ws.on("open", () => {
           opened = true;
           this.connected = true;
-          this.reconnectAttempts = 0;
           this.captureLocalOpen();
           try {
             this.options.onOpen?.(this.transport);


### PR DESCRIPTION
## What Problem This Solves

Fixes #102251. In `src/realtime-transcription/websocket-session.ts`, the reconnect counter (`reconnectAttempts`) was reset to 0 on every `ws.on("open")`. For a flapping upstream that accepts the websocket but drops it shortly after, each reconnect opened a new socket and reset the counter, so:
- the exponential backoff stayed at the base delay forever, and
- `maxReconnectAttempts` was never reached.

This produced an unbounded reconnect stream against a persistently flapping realtime-transcription provider.

## Why This Change Was Made

Removed the counter reset from the `open` handler. The counter is now only reset at the start of a fresh `connect()` call; it persists across socket opens so the cap and exponential backoff apply to consecutive failed reconnects.

## User Impact

Realtime transcription sessions now back off (base, 2×, 4×, 8×, 16×) and stop after `maxReconnectAttempts` consecutive failures, instead of reconnecting once per second indefinitely.

## Evidence

- Added a regression test that brings up a server, lets the first connection reach ready, then drops it and rejects every subsequent connection. It asserts the session emits the configured reconnect-limit error after exactly `maxReconnectAttempts` attempts.
- Local focused run: `node scripts/run-vitest.mjs src/realtime-transcription/websocket-session.test.ts --run` passes (11/11 tests).

```text
$ node scripts/run-vitest.mjs src/realtime-transcription/websocket-session.test.ts --run
[test] starting test/vitest/vitest.unit-fast-fake-timers.config.ts
 RUN  v4.1.9
 ✓ |unit-fast-fake-timers| src/realtime-transcription/websocket-session.test.ts (11 tests) 327ms
 Test Files  1 passed (1)
      Tests  11 passed (11)
[test] passed 1 Vitest shard in 12.89s
```
