### PR TITLE
fix(google): add regex anchors and prefix boundaries in google-shared model id checks

### DIFF
--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -612,15 +612,15 @@ export function getDisabledGoogleThinkingConfig<T extends GoogleApiType>(
 }
 
 export function isGemma4Model<T extends GoogleApiType>(model: Model<T>): boolean {
-  return /^gemma-?4\b/.test(model.id.toLowerCase());
+  return /(?:^|\/)gemma-?4\b/.test(model.id.toLowerCase());
 }
 
 function isGemini3ProModel<T extends GoogleApiType>(model: Model<T>): boolean {
-  return /^(?:google\/)?gemini-3(?:\.\d+)?-pro/.test(model.id.toLowerCase());
+  return /^(?:google\/)?gemini-3(?:\.\d+)?-pro\b/.test(model.id.toLowerCase());
 }
 
 function isGemini3FlashModel<T extends GoogleApiType>(model: Model<T>): boolean {
-  return /^(?:google\/)?gemini-3(?:\.\d+)?-flash/.test(model.id.toLowerCase());
+  return /^(?:google\/)?gemini-3(?:\.\d+)?-flash\b/.test(model.id.toLowerCase());
 }
 
 function getGoogleThinkingLevel<T extends GoogleApiType>(
@@ -671,7 +671,7 @@ function getGoogleBudget<T extends GoogleApiType>(
     return customBudgets[effort];
   }
 
-  if (model.id.includes("gemini-2.5-pro")) {
+  if (/\bgemini-2\.5-pro$/.test(model.id)) {
     const budgets: Record<ClampedGoogleThinkingLevel, number> = {
       minimal: 128,
       low: 2048,
@@ -681,7 +681,7 @@ function getGoogleBudget<T extends GoogleApiType>(
     return budgets[effort];
   }
 
-  if (config?.useFlashLiteBudgets && model.id.includes("gemini-2.5-flash-lite")) {
+  if (config?.useFlashLiteBudgets && /\bgemini-2\.5-flash-lite$/.test(model.id)) {
     const budgets: Record<ClampedGoogleThinkingLevel, number> = {
       minimal: 512,
       low: 2048,
@@ -691,7 +691,7 @@ function getGoogleBudget<T extends GoogleApiType>(
     return budgets[effort];
   }
 
-  if (model.id.includes("gemini-2.5-flash")) {
+  if (/\bgemini-2\.5-flash$/.test(model.id)) {
     const budgets: Record<ClampedGoogleThinkingLevel, number> = {
       minimal: 128,
       low: 2048,

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -612,15 +612,15 @@ export function getDisabledGoogleThinkingConfig<T extends GoogleApiType>(
 }
 
 export function isGemma4Model<T extends GoogleApiType>(model: Model<T>): boolean {
-  return /gemma-?4/.test(model.id.toLowerCase());
+  return /^gemma-?4\b/.test(model.id.toLowerCase());
 }
 
 function isGemini3ProModel<T extends GoogleApiType>(model: Model<T>): boolean {
-  return /gemini-3(?:\.\d+)?-pro/.test(model.id.toLowerCase());
+  return /^(?:google\/)?gemini-3(?:\.\d+)?-pro/.test(model.id.toLowerCase());
 }
 
 function isGemini3FlashModel<T extends GoogleApiType>(model: Model<T>): boolean {
-  return /gemini-3(?:\.\d+)?-flash/.test(model.id.toLowerCase());
+  return /^(?:google\/)?gemini-3(?:\.\d+)?-flash/.test(model.id.toLowerCase());
 }
 
 function getGoogleThinkingLevel<T extends GoogleApiType>(
@@ -671,7 +671,7 @@ function getGoogleBudget<T extends GoogleApiType>(
     return customBudgets[effort];
   }
 
-  if (model.id.includes("2.5-pro")) {
+  if (model.id.includes("gemini-2.5-pro")) {
     const budgets: Record<ClampedGoogleThinkingLevel, number> = {
       minimal: 128,
       low: 2048,
@@ -681,7 +681,7 @@ function getGoogleBudget<T extends GoogleApiType>(
     return budgets[effort];
   }
 
-  if (config?.useFlashLiteBudgets && model.id.includes("2.5-flash-lite")) {
+  if (config?.useFlashLiteBudgets && model.id.includes("gemini-2.5-flash-lite")) {
     const budgets: Record<ClampedGoogleThinkingLevel, number> = {
       minimal: 512,
       low: 2048,
@@ -691,7 +691,7 @@ function getGoogleBudget<T extends GoogleApiType>(
     return budgets[effort];
   }
 
-  if (model.id.includes("2.5-flash")) {
+  if (model.id.includes("gemini-2.5-flash")) {
     const budgets: Record<ClampedGoogleThinkingLevel, number> = {
       minimal: 128,
       low: 2048,


### PR DESCRIPTION
## What Problem This Solves

Several model ID checks in `packages/ai/src/providers/google-shared.ts` use unanchored regexes or bare substring matching, allowing non-Gemini model IDs to incorrectly match:

- `isGemma4Model`: `/gemma-?4/` matches `"my-gemma4-proxy"` or `"not-gemma4"`
- `isGemini3ProModel` / `isGemini3FlashModel`: unanchored regex matches `"custom-gemini-3-pro-v2"` or `"not-gemini-3-flash"`
- Thinking budget checks: `.includes("2.5-pro")` matches `"my-2.5-pro-custom"` or any model id containing that substring

## Why This Change Was Made

1. `isGemma4Model`: add `^` anchor + `\b` word boundary → `/^gemma-?4\b/`
2. `isGemini3ProModel` / `isGemini3FlashModel`: add `^` anchor with optional `google/` prefix → `/^(?:google\/)?gemini-3(?:\.\d+)?-(pro|flash)/`
3. Thinking budget checks: use full `gemini-2.5-{pro,flash-lite,flash}` prefix instead of bare version substring

## Files Changed

| File | Change |
|------|--------|
| `packages/ai/src/providers/google-shared.ts` | 6 lines: 3 regex anchors + 3 substring prefix fixes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>