### PR TITLE
fix(ai): validate image MIME types in data URLs for Mistral, OpenAI, and OpenAI Responses providers

### DIFF
--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -34,6 +34,18 @@ import { buildBaseOptions } from "./simple-options.js";
 import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
+function sanitizeImageMediaType(mimeType: string): string {
+  if (
+    mimeType === "image/jpeg" ||
+    mimeType === "image/png" ||
+    mimeType === "image/gif" ||
+    mimeType === "image/webp"
+  ) {
+    return mimeType;
+  }
+  return "image/png";
+}
+
 const MISTRAL_TOOL_CALL_ID_LENGTH = 9;
 const MAX_MISTRAL_ERROR_BODY_CHARS = 4000;
 
@@ -643,7 +655,7 @@ function toChatMessages(
           if (item.type === "text") {
             return { type: "text", text: sanitizeSurrogates(item.text) };
           }
-          return { type: "image_url", imageUrl: `data:${item.mimeType};base64,${item.data}` };
+          return { type: "image_url", imageUrl: `data:${sanitizeImageMediaType(item.mimeType)};base64,${item.data}` };
         });
       if (content.length > 0) {
         result.push({ role: "user", content });
@@ -720,7 +732,7 @@ function toChatMessages(
       }
       toolContent.push({
         type: "image_url",
-        imageUrl: `data:${part.mimeType};base64,${part.data}`,
+        imageUrl: `data:${sanitizeImageMediaType(part.mimeType)};base64,${part.data}`,
       });
     }
     result.push({

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -86,6 +86,18 @@ function hasToolHistory(messages: Message[]): boolean {
   return false;
 }
 
+function sanitizeImageMediaType(mimeType: string): string {
+  if (
+    mimeType === "image/jpeg" ||
+    mimeType === "image/png" ||
+    mimeType === "image/gif" ||
+    mimeType === "image/webp"
+  ) {
+    return mimeType;
+  }
+  return "image/png";
+}
+
 function isTextContentBlock(block: { type: string }): block is TextContent {
   return block.type === "text";
 }
@@ -1056,7 +1068,7 @@ export function convertMessages(
             return {
               type: "image_url",
               image_url: {
-                url: `data:${item.mimeType};base64,${item.data}`,
+                url: `data:${sanitizeImageMediaType(item.mimeType)};base64,${item.data}`,
               },
             } satisfies ChatCompletionContentPartImage;
           },
@@ -1211,7 +1223,7 @@ export function convertMessages(
               imageBlocks.push({
                 type: "image_url",
                 image_url: {
-                  url: `data:${block.mimeType};base64,${block.data}`,
+                  url: `data:${sanitizeImageMediaType(block.mimeType)};base64,${block.data}`,
                 },
               });
             }

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -65,6 +65,18 @@ import { transformMessages } from "./transform-messages.js";
 
 const EMPTY_TOOL_RESULT_TEXT = "(no output)";
 
+function sanitizeImageMediaType(mimeType: string): string {
+  if (
+    mimeType === "image/jpeg" ||
+    mimeType === "image/png" ||
+    mimeType === "image/gif" ||
+    mimeType === "image/webp"
+  ) {
+    return mimeType;
+  }
+  return "image/png";
+}
+
 function sanitizeToolResultText(text: string, fallback: string): string {
   const sanitized = sanitizeSurrogates(text);
   return sanitized.trim().length > 0 ? sanitized : fallback;
@@ -324,7 +336,7 @@ export function convertResponsesMessages<TApi extends Api>(
           return {
             type: "input_image",
             detail: "auto",
-            image_url: `data:${item.mimeType};base64,${item.data}`,
+            image_url: `data:${sanitizeImageMediaType(item.mimeType)};base64,${item.data}`,
           } satisfies ResponseInputImage;
         });
         if (content.length === 0) {
@@ -440,7 +452,7 @@ export function convertResponsesMessages<TApi extends Api>(
             contentParts.push({
               type: "input_image",
               detail: "auto",
-              image_url: `data:${block.mimeType};base64,${block.data}`,
+              image_url: `data:${sanitizeImageMediaType(block.mimeType)};base64,${block.data}`,
             });
           }
         }


### PR DESCRIPTION
## What Problem This Solves

Unsupported image MIME types (e.g. `image/heic` from iPhone cameras, `image/tiff`) were passed through verbatim in `data:` URLs sent to provider APIs. When the provider does not support that image format, the API rejects the request:

- **Mistral**: `data:image/heic;base64,...` → 400 error
- **OpenAI Chat Completions**: same pattern at 2 call sites  
- **OpenAI Responses**: same pattern at 2 call sites

## Why This Change Was Made

Adds `sanitizeImageMediaType()` helper to each provider that validates against the four universally-supported image types (JPEG, PNG, GIF, WebP) and falls back to `image/png` for unsupported types. Applied at all six image-block construction sites across three providers.

This is the same pattern as #102337 (Anthropic HEIC/TIFF fix), extended to the Mistral, OpenAI, and OpenAI Responses provider paths.

## Files Changed

| File | Change |
|------|--------|
| `packages/ai/src/providers/mistral.ts` | +helper; 2 call sites sanitized |
| `packages/ai/src/providers/openai-completions.ts` | +helper; 2 call sites sanitized |
| `packages/ai/src/providers/openai-responses-shared.ts` | +helper; 2 call sites sanitized |

## Proof

The validation logic is the same as proven in #102337:
- `image/jpeg`, `image/png`, `image/gif`, `image/webp` → pass through unchanged
- `image/heic`, `image/tiff`, `image/bmp`, etc. → fall back to `image/png`
- Case-sensitive (lowercase comparison only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>