### PR TITLE
fix(anthropic): expose native effort ladder for mandatory-adaptive Claude 5 on claude-cli

### DIFF
--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -622,8 +622,18 @@ describe("anthropic provider replay hooks", () => {
         modelId: "claude-fable-5",
       } as never),
     ).toEqual({
-      levels: [{ id: "off" }],
-      defaultLevel: "off",
+      levels: [
+        { id: "off" },
+        { id: "minimal" },
+        { id: "low" },
+        { id: "medium" },
+        { id: "high" },
+        { id: "xhigh" },
+        { id: "adaptive" },
+        { id: "max" },
+      ],
+      defaultLevel: "high",
+      preserveWhenCatalogReasoningFalse: true,
     });
     expect(
       provider
@@ -743,8 +753,18 @@ describe("anthropic provider replay hooks", () => {
         modelId: "claude-mythos-5",
       } as never),
     ).toEqual({
-      levels: [{ id: "off" }],
-      defaultLevel: "off",
+      levels: [
+        { id: "off" },
+        { id: "minimal" },
+        { id: "low" },
+        { id: "medium" },
+        { id: "high" },
+        { id: "xhigh" },
+        { id: "adaptive" },
+        { id: "max" },
+      ],
+      defaultLevel: "high",
+      preserveWhenCatalogReasoningFalse: true,
     });
   });
 

--- a/extensions/anthropic/provider-policy-api.test.ts
+++ b/extensions/anthropic/provider-policy-api.test.ts
@@ -164,8 +164,18 @@ describe("anthropic provider policy public artifact", () => {
           modelId,
         }),
       ).toEqual({
-        levels: [{ id: "off" }],
-        defaultLevel: "off",
+        levels: [
+          { id: "off" },
+          { id: "minimal" },
+          { id: "low" },
+          { id: "medium" },
+          { id: "high" },
+          { id: "xhigh" },
+          { id: "adaptive" },
+          { id: "max" },
+        ],
+        defaultLevel: "high",
+        preserveWhenCatalogReasoningFalse: true,
       });
     },
   );

--- a/extensions/anthropic/provider-policy-api.ts
+++ b/extensions/anthropic/provider-policy-api.ts
@@ -4,12 +4,9 @@
  */
 import {
   resolveClaudeModelIdentity,
-  resolveClaudeFable5ModelIdentity,
-  resolveClaudeMythos5ModelIdentity,
   resolveClaudeThinkingProfile,
 } from "openclaw/plugin-sdk/provider-model-shared";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-types";
-import { CLAUDE_CLI_OFF_THINKING_PROFILE } from "./cli-shared.js";
 import {
   applyAnthropicConfigDefaults,
   normalizeAnthropicProviderConfigForProvider,
@@ -37,16 +34,10 @@ export function resolveThinkingProfile(params: {
   });
   switch (params.provider.trim().toLowerCase()) {
     case "anthropic":
-      return resolveClaudeThinkingProfile(contractModelId, undefined, {
-        includeNativeMax: true,
-      });
+    // Claude Code honors --effort for mandatory-adaptive Claude 5 models
+    // (verified on Claude Code 2.1.202), so the CLI backend gets the same
+    // native effort ladder as the direct Anthropic API.
     case "claude-cli":
-      if (
-        resolveClaudeFable5ModelIdentity({ id: contractModelId }) ||
-        resolveClaudeMythos5ModelIdentity({ id: contractModelId })
-      ) {
-        return CLAUDE_CLI_OFF_THINKING_PROFILE;
-      }
       return resolveClaudeThinkingProfile(contractModelId, undefined, {
         includeNativeMax: true,
       });

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -900,8 +900,11 @@ export function buildAnthropicProvider(): ProviderPlugin {
     resolveReasoningOutputMode: () => "native",
     resolveThinkingProfile: ({ provider, modelId, params }) => {
       const contractModelId = resolveClaudeModelIdentity({ id: modelId, params });
+      // The Claude CLI backend runs Claude Code itself, which honors --effort
+      // for mandatory-adaptive Claude 5 models (verified on Claude Code 2.1.202),
+      // so it gets the native ladder alongside the direct Anthropic API.
       return isAnthropicMandatoryClaude5Model(contractModelId) &&
-        normalizeLowercaseStringOrEmpty(provider) !== PROVIDER_ID
+        ![PROVIDER_ID, CLAUDE_CLI_BACKEND_ID].includes(normalizeLowercaseStringOrEmpty(provider))
         ? CLAUDE_CLI_OFF_THINKING_PROFILE
         : resolveClaudeThinkingProfile(contractModelId, undefined, {
             includeNativeMax: [PROVIDER_ID, CLAUDE_CLI_BACKEND_ID].includes(


### PR DESCRIPTION
Related: #101453

## What Problem This Solves

Fixes an issue where users running Claude Fable 5 or Claude Mythos 5 through the **`claude-cli` backend** would only see **`off`** in the thinking-level menu (`/think`), with no `low`/`medium`/`high`/`xhigh`/`max` selectable — while the same models on the native `anthropic` provider expose the full effort ladder. Effort control was silently unavailable for subscription (Claude Code CLI) users on these models.

## Why This Change Was Made

The off-only profile (`CLAUDE_CLI_OFF_THINKING_PROFILE`) is an opt-out for "Claude CLI routes unsupported by Claude Code" — but the `claude-cli` backend *is* Claude Code, which honors `--effort` for mandatory-adaptive Claude 5 models, and the backend already maps every thinking level onto `--effort` (`mapClaudeCliThinkingLevelToEffort`). This PR exempts `CLAUDE_CLI_BACKEND_ID` from the off-lock in the two places that resolve thinking profiles (the runtime `resolveThinkingProfile` hook and the lightweight provider-policy path), mirroring how `includeNativeMax` in the same resolver already treats `claude-cli` as native-capable. Non-goal: all other providers (Bedrock, Vertex, OpenRouter, …) keep the off-lock unchanged.

## User Impact

Users on the `claude-cli` backend can now select every effort level for Fable 5 and Mythos 5 (default `high`), matching the native Anthropic API experience. No configuration changes required.

## Evidence

Claude Code CLI `2.1.202` honors `--effort` for `claude-fable-5` at every level (subscription OAuth):

```console
$ claude --model claude-fable-5 --effort high  -p "Reply with exactly one word: pong"  → pong  [exit 0]
$ claude --model claude-fable-5 --effort max   -p "..."                                 → pong  [exit 0]
$ claude --model claude-fable-5 --effort xhigh -p "..."                                 → pong  [exit 0]
$ claude --model claude-fable-5 --effort low   -p "..."                                 → pong  [exit 0]

$ claude --model claude-fable-5 --effort banana -p "ping"
Warning: Unknown --effort value 'banana' — ignoring it and using the default effort.
Valid values: low, medium, high, xhigh, max.
```

So the off-lock's compatibility premise no longer holds for the CLI route. (Mythos 5 was not directly testable — invite-gated — but it rides the identical CLI `--effort` mechanism.)

Local validation on this branch:
- `vitest run extensions/anthropic/provider-policy-api.test.ts extensions/anthropic/index.test.ts` — **49/49 passed** (updated expectations included)
- `oxfmt --check` and `oxlint` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
