### PR TITLE
fix(telegram): links with '&' query params drop parameters when tapped (#102162) [AI-assisted]

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -46,6 +46,25 @@ describe("markdownToTelegramHtml", () => {
     }
   });
 
+  it("keeps '&' raw in bare auto-link hrefs so multi-param URLs stay navigable (#102162)", () => {
+    // Telegram's Bot API HTML parser does not decode "&amp;" inside <a href>, so
+    // a bare auto-link's query "&" must stay raw in the href or every parameter
+    // after the first "&" is dropped at navigation time.
+    const bare = markdownToTelegramHtml("see https://example.com/p?post=100&action=edit now");
+    expect(bare).toContain('<a href="https://example.com/p?post=100&action=edit">');
+
+    // Labeled markdown links are unchanged: their visible text is the label (no
+    // URL "&"), and #102162 reports they already navigate correctly.
+    const labeled = markdownToTelegramHtml(
+      "see [edit](https://example.com/p?post=100&action=edit)",
+    );
+    expect(labeled).toBe('see <a href="https://example.com/p?post=100&amp;action=edit">edit</a>');
+
+    // Rich HTML mode must keep the bare auto-link href raw too.
+    const rich = markdownToTelegramRichHtml("see https://example.com/p?post=100&action=edit now");
+    expect(rich).toContain('<a href="https://example.com/p?post=100&action=edit">');
+  });
+
   it("preserves supported Telegram HTML in stream markdown rendering", () => {
     const input = [
       "✉️ <b>Morning Email Rollup</b>",

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -41,6 +41,19 @@ function escapeHtmlAttr(text: string): string {
   return escapeHtml(text).replace(/"/g, "&quot;");
 }
 
+/**
+ * Escape a link href for a double-quoted Telegram HTML attribute without
+ * encoding "&". Telegram's Bot API HTML parser does not decode "&amp;" inside
+ * <a href> attributes, so a bare URL such as "?post=100&action=edit" must keep
+ * its "&" separator raw — otherwise Telegram's "Open link" prompt navigates to
+ * "...&amp;action=edit" and silently drops every parameter after the first "&".
+ * Only characters that could break out of the double-quoted attribute are
+ * escaped; a raw "&" is safe inline and keeps the URL navigable.
+ */
+function escapeTelegramLinkHref(href: string): string {
+  return href.replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
 function isTelegramRichLinkHref(href: string): boolean {
   return /^(?:https?:\/\/|tg:\/\/|mailto:|tel:|#)/i.test(href);
 }
@@ -74,7 +87,13 @@ function buildTelegramLink(link: MarkdownLinkSpan, text: string) {
   if (isAutoLinkedFileRef(href, label)) {
     return null;
   }
-  const safeHref = escapeHtmlAttr(href);
+  // Telegram does not decode "&amp;" inside <a href>, so a bare auto-link's
+  // query "&" must stay raw or every parameter after the first "&" is dropped at
+  // navigation time. Scope this to bare auto-links (label === href): labeled
+  // markdown links ([text](url)) keep the original escaped href, since #102162
+  // reports they already navigate correctly and their visible text has no URL "&".
+  const isBareAutoLink = label === href;
+  const safeHref = isBareAutoLink ? escapeTelegramLinkHref(href) : escapeHtmlAttr(href);
   return {
     start: link.start,
     end: link.end,

--- a/scripts/proof/telegram-url-amp-proof.mts
+++ b/scripts/proof/telegram-url-amp-proof.mts
@@ -1,0 +1,75 @@
+// Real behavior proof for #102162: Telegram renders bare URLs containing `&`
+// in their query string with the `&` HTML-escaped to `&amp;`, which Telegram
+// clients display literally and navigate to incorrectly (query params dropped).
+//
+// This script exercises the PRODUCTION formatter code paths
+// (markdownToTelegramHtml legacy + markdownToTelegramRichHtml rich) on a bare
+// URL with a multi-parameter query string, and inspects the emitted anchor HTML
+// to show whether the `&` reaches the href / visible text intact or as `&amp;`.
+//
+// Run: pnpm exec tsx scripts/proof/telegram-url-amp-proof.mts
+
+import {
+  markdownToTelegramHtml,
+  markdownToTelegramRichHtml,
+} from "../../extensions/telegram/src/format.js";
+
+const URL_WITH_AMP = "https://example.com/wp-admin/post.php?post=100&action=edit";
+
+function analyzeAnchor(html: string, label: string): void {
+  // Pull the first <a href="...">...</a> the formatter emitted.
+  const anchorMatch = html.match(/<a\s+href="([^"]*)"[^>]*>([\s\S]*?)<\/a>/);
+  if (!anchorMatch) {
+    console.log(`  [${label}] NO anchor emitted. Full output:`);
+    console.log(`    ${html}`);
+    return;
+  }
+  const hrefAttr = anchorMatch[1] ?? "";
+  const visibleText = anchorMatch[2] ?? "";
+  const hrefHasAmp = hrefAttr.includes("&amp;");
+  const textHasAmp = visibleText.includes("&amp;");
+  console.log(`  [${label}] href attr     : ${hrefAttr}`);
+  console.log(`  [${label}] visible text  : ${visibleText}`);
+  console.log(`  [${label}] href has &amp;     : ${hrefHasAmp ? "YES (BUG)" : "no"}`);
+  console.log(
+    `  [${label}] text has &amp;     : ${textHasAmp ? "yes (ok: Telegram decodes text content)" : "no"}`,
+  );
+  // A navigable link must keep the raw `&` separator after a single decode.
+  const navigable = hrefAttr.includes("post=100&action=edit");
+  console.log(`  [${label}] href navigable    : ${navigable ? "YES" : "NO (broken)"}`);
+}
+
+console.log("=== #102162 Telegram bare-URL amp proof ===");
+console.log(`Input bare URL: ${URL_WITH_AMP}`);
+console.log("(markdown linkify auto-detects the bare URL into a link span)");
+console.log("");
+
+console.log("--- markdownToTelegramHtml (legacy HTML mode, richMessages default) ---");
+const legacy = markdownToTelegramHtml(`See ${URL_WITH_AMP} for details.`);
+console.log(`  emitted html: ${legacy}`);
+analyzeAnchor(legacy, "legacy");
+console.log("");
+
+console.log("--- markdownToTelegramRichHtml (rich HTML mode) ---");
+const rich = markdownToTelegramRichHtml(`See ${URL_WITH_AMP} for details.`);
+console.log(`  emitted html: ${rich}`);
+analyzeAnchor(rich, "rich");
+console.log("");
+
+// Summary verdict — the bug (#102162) is that the <a href> attribute carries
+// the query "&" as "&amp;", which Telegram does not decode, so navigation drops
+// every parameter after the first "&". The bubble's visible text uses
+// "&amp;", which Telegram DOES decode as text content, so only the href matters.
+const extractHref = (html: string): string | null => html.match(/<a\s+href="([^"]*)"/)?.[1] ?? null;
+const legacyHref = extractHref(legacy);
+const richHref = extractHref(rich);
+const hrefNavigable =
+  legacyHref != null &&
+  legacyHref.includes("post=100&action=edit") &&
+  richHref != null &&
+  richHref.includes("post=100&action=edit");
+console.log(
+  hrefNavigable
+    ? "RESULT: FIXED — bare auto-link <a href> keeps the query '&' raw and is navigable."
+    : "RESULT: BUG PRESENT — <a href> encodes '&' as '&amp;' and drops params.",
+);


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

Closes #102162

## What Problem This Solves

Fixes an issue where operators using the Telegram channel would tap a bare URL
in a model reply and land on the wrong page. Any auto-linked bare URL whose
query string contains multiple parameters separated by `&` — e.g.
`https://example.com/wp-admin/post.php?post=100&action=edit` — was sent to the
Telegram client with the `&` HTML-escaped to `&amp;` inside the `<a href>`
attribute. Telegram's Bot API HTML parser does **not** decode `&amp;` in
attribute values, so the "Open link?" prompt and the resulting navigation carry
`&amp;action=edit` literally, and every parameter after the first `&`
(`action=edit`) is dropped. The server then falls back to a default page
instead of the intended destination.

## Why This Change Was Made

`buildTelegramLink` in `extensions/telegram/src/format.ts` escaped every link
href through `escapeHtmlAttr`, which encodes `&` → `&amp;`. That encoding is
technically valid HTML for an attribute, but Telegram's lenient parser treats
it literally, breaking multi-parameter bare URLs.

This change scopes a dedicated `escapeTelegramLinkHref` helper to **bare
auto-links** (where the visible text equals the href, i.e. `label === href`).
It keeps the query `&` raw so the URL stays navigable, and only escapes the
characters that could break out of a double-quoted attribute (`"`, `<`, `>`) —
a raw `&` is safe inline. Labeled markdown links (`[text](url)`) are left on
the original fully-escaped path: their visible text is the label (no URL `&`),
and #102162 reports they already navigate correctly, so their behavior is
unchanged.

The visible bubble text of a bare auto-link still carries `&amp;`, which is
correct: Telegram **does** decode standard entities in text content, so the
bubble renders the URL properly. Only the attribute-decoding path was broken,
so only the href needed changing. The fix is contained to
`extensions/telegram/src/format.ts` — no shared renderer or plugin-sdk change.

## User Impact

Operators tapping a multi-parameter bare URL in a Telegram message now reach
the exact destination the model sent (`?post=100&action=edit`), instead of
having every parameter after the first `&` silently dropped. Labeled
`[text](url)` links and single-parameter URLs are unchanged.

## Evidence

Real behavior proof captured by running the **production** formatter
(`markdownToTelegramHtml` legacy mode + `markdownToTelegramRichHtml` rich mode)
on a bare URL with a multi-parameter query string, via
`pnpm exec tsx scripts/proof/telegram-url-amp-proof.mjs`. This exercises the
actual code path (not a mocked harness) on `current upstream/main`.

**Before the fix** (unpatched `format.ts`) — the `&` is encoded to `&amp;` in
the href, so the link is not navigable:

```
Input bare URL: https://example.com/wp-admin/post.php?post=100&action=edit

--- markdownToTelegramHtml (legacy HTML mode) ---
  emitted html: See <a href="https://example.com/wp-admin/post.php?post=100&amp;action=edit">https://example.com/wp-admin/post.php?post=100&amp;action=edit</a> for details.
  [legacy] href attr     : https://example.com/wp-admin/post.php?post=100&amp;action=edit
  [legacy] href navigable    : NO (broken)

--- markdownToTelegramRichHtml (rich HTML mode) ---
  [rich] href attr     : https://example.com/wp-admin/post.php?post=100&amp;action=edit
  [rich] href navigable    : NO (broken)

RESULT: BUG PRESENT — <a href> encodes '&' as '&amp;' and drops params.
```

**After the fix** — the bare auto-link href keeps the raw `&` separator and is
navigable in both HTML modes (visible text `&amp;` is decoded by Telegram as
text content):

```
--- markdownToTelegramHtml (legacy HTML mode) ---
  emitted html: See <a href="https://example.com/wp-admin/post.php?post=100&action=edit">https://example.com/wp-admin/post.php?post=100&amp;action=edit</a> for details.
  [legacy] href attr     : https://example.com/wp-admin/post.php?post=100&action=edit
  [legacy] text has &amp;     : yes (ok: Telegram decodes text content)
  [legacy] href navigable    : YES

--- markdownToTelegramRichHtml (rich HTML mode) ---
  [rich] href attr     : https://example.com/wp-admin/post.php?post=100&action=edit
  [rich] href navigable    : YES

RESULT: FIXED — bare auto-link <a href> keeps the query '&' raw and is navigable.
```

A labeled link is unchanged (original escaped href):

```
in:  see [edit](https://example.com/p?post=100&action=edit)
out: see <a href="https://example.com/p?post=100&amp;action=edit">edit</a>
```

Regression test added in `extensions/telegram/src/format.test.ts`
(`keeps '&' raw in bare auto-link hrefs so multi-param URLs stay navigable
(#102162)`). Full `extensions/telegram/src/format.test.ts` suite: **69 passed**
(was 68 + 1 new). Scoped typecheck (`tsgo:extensions`, `tsgo:extensions:test`)
and `oxlint` on the changed files are clean.

### Live Telegram client verification

The formatter output above is deterministic: the href is now byte-for-byte the
navigable URL. The remaining behavior — Telegram Desktop/mobile "Open link?"
display and tap-to-open — depends on the Telegram client and cannot be exercised
from this contributor environment (no Telegram bot token or Crabbox e2e runner
available locally or on the remote Linux box). A maintainer can capture that
client-side proof with Mantis by posting:

```text
@openclaw-mantis telegram desktop proof: verify that a Telegram reply containing https://example.com/wp-admin/post.php?post=100&action=edit displays and opens with a raw & separator.
```

## Change Type

- [x] Bug fix
- [ ] Security hardening
- [ ] New feature
- [ ] Refactor / cleanup

## Scope

- [x] `extensions/telegram` (channel formatter)

## Security Impact

- Does this change authentication, authorization, or trust boundaries? **No.**
- Does this change how secrets, tokens, or credentials are handled? **No.**
- Does this change any security boundary (sandbox, network egress, prompt
  isolation)? **No.**
- Does this introduce any new external data ingestion or code execution?
  **No.**
- Does this change logging or telemetry that could leak sensitive data?
  **No.**

This only relaxes HTML-attribute escaping for the `&` character inside bare
auto-link hrefs. It cannot break out of the double-quoted attribute (only `"`
is quote-escaped for that), and hrefs come from already-validated link spans.

## Human Verification

Verified via the real-source `tsx` proof above that the production formatter
emits a navigable href in both legacy and rich HTML modes, before (broken) and
after (fixed). Verified the existing 68 formatter tests still pass (no
regression) plus the new regression test. Edge cases checked: bare auto-linked
URL (raw href), `[label](url)` markdown link (unchanged escaped href), and rich
HTML mode.

**Not tested:** a live Telegram client end-to-end (no bot token / Crabbox runner
in this environment) — see "Live Telegram client verification" above. macOS/iOS
Telegram client variations not exercised.

## Compatibility / Migration

Backward compatible. Bare URLs that previously rendered with `&amp;` in the href
(which Telegram could not navigate) now render with a raw `&` and navigate
correctly. Labeled links and URLs without `&` in the query string are
byte-identical to before. No config or API surface changes.

## Failure Recovery

Revert the single commit. The change is isolated to one branch in
`buildTelegramLink` (`escapeHtmlAttr` → `escapeTelegramLinkHref` for bare
auto-links); reverting restores the prior `&amp;` href behavior.

## Risks and Mitigations

- **Raw `&` in an HTML attribute is technically not strict HTML.** Mitigation:
  Telegram's Bot API HTML parser is lenient and is exactly the reason `&amp;`
  broke (it does not decode entities in attributes). Raw `&` is the pragmatic
  standard for URL query separators in HTML hrefs. The attribute cannot be
  broken out of (only `"` is escaped for boundary safety).
- **Scoping relies on `label === href` to detect bare auto-links.** This matches
  how markdown-it emits auto-link spans (visible text == URL). A labeled link
  whose label happens to equal its URL would also get the raw href, which is the
  correct result for that URL anyway.
