### PR TITLE
fix(openai): stringify replayed tool call arguments

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -11685,6 +11685,39 @@ describe("openai transport stream", () => {
   });
 });
 
+describe("sanitizeCompletionsToolCallArguments", () => {
+  it("stringifies raw replay tool call arguments for OpenAI-compatible payloads", () => {
+    const messages = [
+      {
+        role: "assistant",
+        tool_calls: [
+          {
+            id: "call_exec",
+            type: "function",
+            function: {
+              name: "exec",
+              arguments: { command: "echo hei-fra-glm" },
+            },
+          },
+          {
+            id: "call_read",
+            type: "function",
+            function: {
+              name: "read",
+              arguments: '{"path":"README.md"}',
+            },
+          },
+        ],
+      },
+    ];
+
+    testing.sanitizeCompletionsToolCallArguments(messages);
+
+    expect(messages[0]?.tool_calls[0]?.function.arguments).toBe('{"command":"echo hei-fra-glm"}');
+    expect(messages[0]?.tool_calls[1]?.function.arguments).toBe('{"path":"README.md"}');
+  });
+});
+
 describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () => {
   const openRouterModel = {
     id: "deepseek/deepseek-v4-flash",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -4271,6 +4271,35 @@ function sanitizeCompletionsReasoningReplayFields(
   }
 }
 
+function sanitizeCompletionsToolCallArguments(messages: unknown): void {
+  if (!Array.isArray(messages)) {
+    return;
+  }
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") {
+      continue;
+    }
+    const record = msg as Record<string, unknown>;
+    if (record.role !== "assistant" || !Array.isArray(record.tool_calls)) {
+      continue;
+    }
+    for (const toolCall of record.tool_calls) {
+      if (!toolCall || typeof toolCall !== "object") {
+        continue;
+      }
+      const fn = (toolCall as { function?: unknown }).function;
+      if (!fn || typeof fn !== "object") {
+        continue;
+      }
+      const functionRecord = fn as Record<string, unknown>;
+      if (typeof functionRecord.arguments === "string") {
+        continue;
+      }
+      functionRecord.arguments = JSON.stringify(functionRecord.arguments ?? {});
+    }
+  }
+}
+
 export function buildOpenAICompletionsParams(
   model: OpenAIModeModel,
   context: Context,
@@ -4291,6 +4320,7 @@ export function buildOpenAICompletionsParams(
       compat.thinkingFormat === "openrouter" && shouldPreserveOpenRouterReasoningReplay(model),
     preserveReasoningContent: shouldPreserveReasoningContentReplay(model, compat),
   });
+  sanitizeCompletionsToolCallArguments(messages);
   if (compat.strictMessageKeys) {
     messages = stripCompletionMessagesToRoleContent(messages) as typeof messages;
   }
@@ -4516,6 +4546,7 @@ export const testing = {
   enforceCodeModeResponsesToolSurface,
   sanitizeOpenAICodexResponsesParams,
   buildOpenAICompletionsClientConfig,
+  sanitizeCompletionsToolCallArguments,
   processOpenAICompletionsStream,
   processResponsesStream,
   shouldEmitOpenAICompletionsReasoningForModel,


### PR DESCRIPTION
## What Problem This Solves

Fixes #102200.

Ollama cloud models routed through `api: openai-completions` can reject embedded-agent follow-up turns after a tool call because replayed `tool_calls[].function.arguments` may reach the outbound Chat Completions payload as a JSON object. Ollama's OpenAI-compatible endpoint requires `arguments` to be a JSON-encoded string, so the run fails with HTTP 400 instead of completing the second turn.

## Solution

Normalize outbound OpenAI Chat Completions assistant `tool_calls` just before the request params are finalized:

- leave already-string arguments untouched
- stringify raw object arguments from replayed tool-call blocks
- default missing/non-string values through the same JSON encoding path

This keeps the existing provider serializers unchanged while adding a final wire-shape guard for replay paths that already contain OpenAI-style `tool_calls`.

## Evidence

Validation run locally after rebasing onto `upstream/main`:

- `node scripts/test-projects.mjs src/agents/openai-transport-stream.test.ts` -> 1 file, 299 tests passed
- `pnpm tsgo:prod` -> passed
- `pnpm check:test-types` -> passed before rebase; no conflicts during rebase
- `pnpm exec oxfmt --check src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts` -> passed
- `pnpm exec oxlint src/agents/openai-transport-stream.ts src/agents/openai-transport-stream.test.ts` -> passed before rebase; no conflicts during rebase
- `git diff --check` -> passed

## Impact

Prevents a deterministic 400/failover/no-reply path for Ollama cloud tool-using embedded agents on the second turn. The change is a no-op for already-valid string arguments.

Signed-off-by: Ho Lim <subhoya@gmail.com>
