### PR TITLE
docs(status): document missing --timeout flag

### DIFF
--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -21,6 +21,7 @@ openclaw status --usage
 | `--deep`                | Runs live probes (WhatsApp Web + Telegram + Discord + Slack + Signal). Also enables the security audit.         |
 | `--usage`               | Prints normalized provider usage windows as `X% left`.                                                          |
 | `--json`                | Machine-readable output.                                                                                        |
+| `--timeout <ms>`        | Probe timeout in milliseconds (default: `10000`).                                                               |
 | `--verbose` / `--debug` | Also print the raw Gateway target resolution before the report.                                                 |
 
 Plain `openclaw status` stays on the fast read-only path and marks memory as


### PR DESCRIPTION
## What Problem This Solves

`docs/cli/status.md` was missing documentation for the `--timeout <ms>` flag that exists in `src/cli/program/register.status-health-sessions.ts`. Users reading the docs had no way to discover this flag or its default value.

## Why This Change Was Made

The `--timeout` flag exists in the code but had no documentation entry in the flag table:

| Flag | Code line | Purpose |
|------|-----------|---------|
| `--timeout <ms>` | 120 | Probe timeout in milliseconds (default: `10000`) |

## Evidence

### Code — flag registration in `src/cli/program/register.status-health-sessions.ts:120`

```ts
.option("--timeout <ms>", "Probe timeout in milliseconds", "10000")
```

### CLI help output confirms

```text
$ node openclaw.mjs status --help

--timeout <ms>   Probe timeout in milliseconds (default: 10000)
```

## User Impact

Users reading the status docs can now discover the `--timeout` flag. Editorial-only change — no code behavior affected.
