### PR TITLE
fix(msteams): emit native cjs runtime entrypoints

### DIFF
--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -59,7 +59,8 @@
       "pluginApi": ">=2026.7.2"
     },
     "build": {
-      "openclawVersion": "2026.7.2"
+      "openclawVersion": "2026.7.2",
+      "runtimeFormat": "cjs"
     },
     "release": {
       "publishToClawHub": true,

--- a/scripts/lib/plugin-npm-runtime-build.d.mts
+++ b/scripts/lib/plugin-npm-runtime-build.d.mts
@@ -2,8 +2,8 @@
 export function listPublishablePluginPackageDirs(params?: Record<string, unknown>): string[];
 /** List package-local runtime output files expected from a runtime build plan. */
 export function listPluginNpmRuntimeBuildOutputs(plan: unknown): string[];
-/** Resolve the package-local runtime build plan for one publishable plugin package. */
-export function resolvePluginNpmRuntimeBuildPlan(params: unknown): {
+export type PluginNpmRuntimeBuildFormat = "esm" | "cjs";
+export type PluginNpmRuntimeBuildPlan = {
   runtimeBuildOutputs: string[];
   packageFiles: string[];
   packagePeerMetadata: {
@@ -27,34 +27,20 @@ export function resolvePluginNpmRuntimeBuildPlan(params: unknown): {
     [k: string]: string;
   };
   outDir: string;
+  runtimeFormat: PluginNpmRuntimeBuildFormat;
   runtimeExtensions: string[];
   runtimeSetupEntry: string | undefined;
-} | null;
+};
+/** Resolve the package-local runtime build plan for one publishable plugin package. */
+export function resolvePluginNpmRuntimeBuildPlan(params: unknown): PluginNpmRuntimeBuildPlan | null;
 /** Build package-local runtime files and static assets for one plugin package. */
-export function buildPluginNpmRuntime(params: unknown): Promise<{
-  assetBuildCommand: string | null;
-  copiedStaticAssets: string[];
-  runtimeBuildOutputs: string[];
-  packageFiles: unknown[];
-  packagePeerMetadata: {
-    peerDependencies: {
-      openclaw: string;
-    };
-    peerDependenciesMeta: unknown;
-  };
-  repoRoot: string;
-  packageDir: unknown;
-  pluginDir: string;
-  packageJson: unknown;
-  rootPackageJson: unknown;
-  sourceEntries: unknown[];
-  entry: {
-    [k: string]: string;
-  };
-  outDir: string;
-  runtimeExtensions: unknown;
-  runtimeSetupEntry: string | undefined;
-} | null>;
+export function buildPluginNpmRuntime(params: unknown): Promise<
+  | (PluginNpmRuntimeBuildPlan & {
+      assetBuildCommand: string | null;
+      copiedStaticAssets: string[];
+    })
+  | null
+>;
 export function parseArgs(argv: unknown):
   | {
       help: boolean;

--- a/scripts/lib/plugin-npm-runtime-build.mjs
+++ b/scripts/lib/plugin-npm-runtime-build.mjs
@@ -37,9 +37,17 @@ function isTypeScriptEntry(entry) {
   return /\.(?:c|m)?ts$/u.test(entry);
 }
 
-function toPackageRuntimeEntry(entry) {
+function resolveRuntimeBuildFormat(packageJson) {
+  return packageJson.openclaw?.build?.runtimeFormat === "cjs" ? "cjs" : "esm";
+}
+
+function runtimeBuildExtension(runtimeFormat) {
+  return runtimeFormat === "cjs" ? ".cjs" : ".js";
+}
+
+function toPackageRuntimeEntry(entry, runtimeFormat = "esm") {
   const normalized = normalizePackageEntry(entry).replace(/^\.\//u, "");
-  return `./dist/${normalized.replace(/\.[^.]+$/u, ".js")}`;
+  return `./dist/${normalized.replace(/\.[^.]+$/u, runtimeBuildExtension(runtimeFormat))}`;
 }
 
 function collectExternalDependencyNames(packageJson) {
@@ -115,9 +123,39 @@ export function listPublishablePluginPackageDirs(params = {}) {
 
 /** List package-local runtime output files expected from a runtime build plan. */
 export function listPluginNpmRuntimeBuildOutputs(plan) {
+  const extension = runtimeBuildExtension(plan.runtimeFormat);
   return Object.keys(plan.entry)
-    .map((entryKey) => `./dist/${entryKey}.js`)
+    .map((entryKey) => `./dist/${entryKey}${extension}`)
     .toSorted((left, right) => left.localeCompare(right));
+}
+
+function rewriteCommonJsRuntimeSpecifiers(plan) {
+  if (plan.runtimeFormat !== "cjs") {
+    return;
+  }
+  const specifierRewrites = new Map(
+    plan.runtimeBuildOutputs.map((output) => {
+      const cjsSpecifier = output.replace(/^\.\/dist\//u, "./");
+      return [cjsSpecifier.replace(/\.cjs$/u, ".js"), cjsSpecifier];
+    }),
+  );
+
+  for (const output of plan.runtimeBuildOutputs) {
+    const outputPath = path.join(plan.packageDir, output.replace(/^\.\//u, ""));
+    let text = fs.readFileSync(outputPath, "utf8");
+    const original = text;
+    // Source entries stay .js for the root bundled build; package-local CJS
+    // artifacts must point at their generated .cjs sidecars instead.
+    for (const [fromSpecifier, toSpecifier] of specifierRewrites) {
+      text = text.replaceAll(
+        `specifier: ${JSON.stringify(fromSpecifier)}`,
+        `specifier: ${JSON.stringify(toSpecifier)}`,
+      );
+    }
+    if (text !== original) {
+      fs.writeFileSync(outputPath, text, "utf8");
+    }
+  }
 }
 
 /** Resolve package `files` entries needed for runtime build outputs and plugin metadata. */
@@ -209,6 +247,7 @@ export function resolvePluginNpmRuntimeBuildPlan(params) {
     return null;
   }
 
+  const runtimeFormat = resolveRuntimeBuildFormat(packageJson);
   const packageEntries = collectPluginSourceEntries(packageJson).map(normalizePackageEntry);
   const requiresRuntimeBuild = packageEntries.some(isTypeScriptEntry);
   if (!requiresRuntimeBuild) {
@@ -238,15 +277,16 @@ export function resolvePluginNpmRuntimeBuildPlan(params) {
     sourceEntries,
     entry,
     outDir: path.join(packageDir, "dist"),
+    runtimeFormat,
     runtimeExtensions: (Array.isArray(packageJson.openclaw?.extensions)
       ? packageJson.openclaw.extensions
       : []
     )
       .map(normalizePackageEntry)
       .filter(Boolean)
-      .map(toPackageRuntimeEntry),
+      .map((runtimeEntry) => toPackageRuntimeEntry(runtimeEntry, runtimeFormat)),
     runtimeSetupEntry: normalizePackageEntry(packageJson.openclaw?.setupEntry)
-      ? toPackageRuntimeEntry(packageJson.openclaw.setupEntry)
+      ? toPackageRuntimeEntry(packageJson.openclaw.setupEntry, runtimeFormat)
       : undefined,
   };
   return {
@@ -274,11 +314,13 @@ export async function buildPluginNpmRuntime(params) {
     },
     entry: plan.entry,
     env,
-    fixedExtension: false,
+    fixedExtension: plan.runtimeFormat === "cjs",
+    format: plan.runtimeFormat,
     logLevel: params.logLevel ?? "info",
     outDir: plan.outDir,
     platform: "node",
   });
+  rewriteCommonJsRuntimeSpecifiers(plan);
   const assetBuildCommand = runPackageAssetBuild(plan);
   const missingStaticAssets = listMissingPackageStaticAssetSources(plan);
   if (missingStaticAssets.length > 0) {

--- a/test/plugin-npm-runtime-build.test.ts
+++ b/test/plugin-npm-runtime-build.test.ts
@@ -1,7 +1,9 @@
 // Plugin npm runtime build tests validate plugin runtime package builds.
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  buildPluginNpmRuntime,
   listPublishablePluginPackageDirs,
   resolvePluginNpmRuntimeBuildPlan,
 } from "../scripts/lib/plugin-npm-runtime-build.mjs";
@@ -101,9 +103,80 @@ describe("plugin npm runtime build planning", () => {
       expect(plan.entry["doctor-contract-api"]).toBe(
         path.join(repoRoot, "extensions", pluginDir, "doctor-contract-api.ts"),
       );
-      expect(plan.runtimeBuildOutputs).toContain("./dist/doctor-contract-api.js");
+      const extension = plan.runtimeFormat === "cjs" ? ".cjs" : ".js";
+      expect(plan.runtimeBuildOutputs).toContain(`./dist/doctor-contract-api${extension}`);
       expect(plan.packageFiles).toContain("dist/**");
     }
+  });
+
+  it("plans msteams startup runtime surfaces as native CommonJS entrypoints", () => {
+    const plan = expectPluginNpmRuntimeBuildPlan(
+      resolvePluginNpmRuntimeBuildPlan({
+        repoRoot,
+        packageDir: path.join(repoRoot, "extensions", "msteams"),
+      }),
+    );
+
+    expect(plan.runtimeFormat).toBe("cjs");
+    expect(plan.runtimeExtensions).toEqual(["./dist/index.cjs"]);
+    expect(plan.runtimeSetupEntry).toBe("./dist/setup-entry.cjs");
+    expect(plan.runtimeBuildOutputs).toEqual(
+      expect.arrayContaining([
+        "./dist/channel-plugin-api.cjs",
+        "./dist/doctor-contract-api.cjs",
+        "./dist/index.cjs",
+        "./dist/runtime-api.cjs",
+        "./dist/secret-contract-api.cjs",
+        "./dist/setup-entry.cjs",
+        "./dist/setup-plugin-api.cjs",
+      ]),
+    );
+  });
+
+  it("builds msteams startup runtime surfaces as CommonJS files", async () => {
+    const result = await buildPluginNpmRuntime({
+      repoRoot,
+      packageDir: "extensions/msteams",
+      logLevel: "silent",
+    });
+    const plan = expectPluginNpmRuntimeBuildPlan(result);
+
+    expect(plan.runtimeFormat).toBe("cjs");
+    expect(plan.runtimeExtensions).toEqual(["./dist/index.cjs"]);
+    expect(plan.runtimeSetupEntry).toBe("./dist/setup-entry.cjs");
+
+    const entrypoints = [
+      "dist/index.cjs",
+      "dist/channel-plugin-api.cjs",
+      "dist/runtime-api.cjs",
+      "dist/setup-plugin-api.cjs",
+      "dist/secret-contract-api.cjs",
+    ];
+    const missing = entrypoints.filter(
+      (relativePath) => !existsSync(path.join(repoRoot, "extensions/msteams", relativePath)),
+    );
+    expect(missing).toEqual([]);
+
+    for (const relativePath of entrypoints) {
+      const text = readFileSync(path.join(repoRoot, "extensions/msteams", relativePath), "utf8");
+      expect(text).not.toMatch(/^import\s/u);
+      expect(text).toMatch(/(?:require\(|exports\.)/u);
+    }
+
+    const indexText = readFileSync(
+      path.join(repoRoot, "extensions/msteams/dist/index.cjs"),
+      "utf8",
+    );
+    expect(indexText).toContain('specifier: "./channel-plugin-api.cjs"');
+    expect(indexText).toContain('specifier: "./secret-contract-api.cjs"');
+    expect(indexText).toContain('specifier: "./runtime-api.cjs"');
+
+    const setupEntryText = readFileSync(
+      path.join(repoRoot, "extensions/msteams/dist/setup-entry.cjs"),
+      "utf8",
+    );
+    expect(setupEntryText).toContain('specifier: "./setup-plugin-api.cjs"');
+    expect(setupEntryText).toContain('specifier: "./secret-contract-api.cjs"');
   });
 
   it("builds Tencent setup metadata for installed-package migrations", () => {


### PR DESCRIPTION
Closes #102365

## What Problem This Solves

Fixes an issue where publishable official plugins could not emit native CommonJS runtime entrypoints when their installed-package startup surfaces needed `.cjs` sidecars. The concrete affected surface is the msteams plugin package runtime build.

## Why This Change Was Made

The package runtime builder keeps the existing ESM default and honors internal package build metadata only for packages that opt into native CJS runtime output. msteams opts in so its package-local runtime and setup metadata point at `.cjs` sidecars, while its source entry files keep `.js` specifiers for the root bundled build. The script declaration file now exposes the same plan/result shape as the implementation, including `runtimeFormat`, so typed tests and consumers see the updated contract.

## User Impact

msteams publishable runtime builds now produce native `.cjs` startup, setup, runtime, plugin, and secret entrypoints instead of forcing `.js` ESM output. Existing plugins keep the default ESM package output unless they explicitly opt into CJS.

## Evidence

## Real behavior proof

Behavior addressed: Publishable msteams runtime builds could not emit native CJS entrypoints or package metadata that points at `.cjs` runtime/setup sidecars.

Real environment tested: Azure Crabbox raw Linux lease `amber-krill` / `cbx_904913d6a004` (`provider=azure`, `type=Standard_D32ads_v6`, remote workdir `/work/crabbox/cbx_904913d6a004/bug-053-plugin-runtime-cjs`). The proof ran after rebasing on current `upstream/main`; final pushed PR head is `7ed6d71279a2bf201847d8be100cd6495e0801d0` on top of `03cab29505254de6d9aca4ebfc81f5b28b645600`.

Exact steps or command run after this patch:
```shell
# Azure exact-head proof after resetting the remote checkout to the pushed PR head.
crabbox run --provider azure --id amber-krill --no-sync --timing-json --capture-on-fail --script-stdin
# script phases: context, pnpm test test/plugin-npm-runtime-build.test.ts, pnpm check:test-types,
# and a node proof that rebuilds extensions/msteams and prints MSTEAMS_CJS_PROOF.

git diff --check upstream/main...HEAD
TMPDIR=<outside-repo> AUTOREVIEW_CODEX_USE_LOCAL_TOML=1 \
  .agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main
```

Evidence after fix:
```shell
CRABBOX_PHASE:context
7ed6d71279a2bf201847d8be100cd6495e0801d0
node v22.23.1
pnpm 11.2.2

CRABBOX_PHASE:tests
[test] passed 1 Vitest shard in 3.15s  # test/plugin-npm-runtime-build.test.ts, 6 tests

CRABBOX_PHASE:types
$ pnpm tsgo:test
$ pnpm tsgo:core:test && pnpm tsgo:extensions:test && pnpm tsgo:test:root
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.root.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-root.tsbuildinfo

MSTEAMS_CJS_PROOF={"runtimeFormat":"cjs","runtimeExtensions":["./dist/index.cjs"],"runtimeSetupEntry":"./dist/setup-entry.cjs","missing":[],"indexSpecifiers":["./channel-plugin-api.cjs","./secret-contract-api.cjs","./runtime-api.cjs"],"setupSpecifiers":["./setup-plugin-api.cjs","./secret-contract-api.cjs"]}

run summary sync=0s command=38.63s total=38.695s sync_skipped=true exit=0
EVIDENCE_FILE=.crabbox/evidence/pr-102366-plugin-runtime-cjs-exact-7ed6d7-20260711T151949Z.txt

git diff --check upstream/main...HEAD  # passed locally with no output

autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.87)
```

Observed result after fix: The package-runtime build test and explicit Azure proof create `dist/index.cjs`, `dist/channel-plugin-api.cjs`, `dist/runtime-api.cjs`, `dist/setup-plugin-api.cjs`, `dist/secret-contract-api.cjs`, and `dist/setup-entry.cjs` for msteams, verify no expected files are missing, and verify generated `index.cjs` and `setup-entry.cjs` point at `.cjs` internal sidecars.

What was not tested: No live Microsoft Teams bot startup/profile rerun was performed. A full `pnpm build` was not rerun on the amended head; the focused test, test typecheck lane, generated artifact proof, local whitespace check, and autoreview were run on the final pushed head.
