### PR TITLE
fix(sms): normalize Twilio RCS addresses

### DIFF
--- a/extensions/sms/src/inbound.test.ts
+++ b/extensions/sms/src/inbound.test.ts
@@ -154,8 +154,17 @@ describe("dispatchSmsInboundEvent", () => {
     });
     const turn = await runParams.adapter.resolveTurn(ingested);
 
+    expect(resolveAgentRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        peer: { kind: "direct", id: "+15551234567" },
+      }),
+    );
     expect(buildContext).toHaveBeenCalledWith(
       expect.objectContaining({
+        from: "sms:+15551234567",
+        sender: expect.objectContaining({ id: "+15551234567" }),
+        conversation: expect.objectContaining({ id: "+15551234567" }),
+        reply: { to: "sms:+15551234567" },
         route: expect.objectContaining({
           routeSessionKey: "agent:main:sms:direct:+15551234567",
           dispatchSessionKey: "agent:main:sms:direct:+15551234567",

--- a/extensions/sms/src/twilio.test.ts
+++ b/extensions/sms/src/twilio.test.ts
@@ -100,6 +100,22 @@ describe("Twilio SMS helpers", () => {
     });
   });
 
+  it.each([
+    ["+1 (555) 123-4567", "+15551234567"],
+    ["RcS:+1 (555) 123-4567", "+15551234567"],
+    ["whatsapp:+15551234567", null],
+    ["signal:+15551234567", null],
+  ] as const)("accepts only supported Twilio inbound From address %s", (from, expected) => {
+    const msg = buildTwilioInboundMessage({
+      From: from,
+      To: "+15557654321",
+      Body: "hello",
+      MessageSid: "SM123",
+    });
+
+    expect(msg?.from ?? null).toBe(expected);
+  });
+
   it("verifies Twilio signatures over sorted form fields", () => {
     const form = {
       Body: "hello",

--- a/extensions/sms/src/twilio.ts
+++ b/extensions/sms/src/twilio.ts
@@ -8,6 +8,7 @@ import {
 } from "openclaw/plugin-sdk/response-limit-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { readRequestBodyWithLimit } from "openclaw/plugin-sdk/webhook-ingress";
+import { looksLikeSmsPhoneNumber, normalizeSmsPhoneNumber } from "./phone.js";
 import type { ResolvedSmsAccount, SmsInboundMessage, SmsSendResult } from "./types.js";
 
 const TWILIO_ACCOUNTS_URL = "https://api.twilio.com/2010-04-01/Accounts";
@@ -38,6 +39,8 @@ type TwilioMessagePayload = {
   from?: string;
   status?: string;
 };
+
+const TWILIO_CHANNEL_ADDRESS_RE = /^([a-z][a-z0-9-]*):(.*)$/i;
 
 export type TwilioIncomingPhoneNumber = {
   sid: string;
@@ -219,8 +222,27 @@ export function verifyTwilioSignature(params: {
   );
 }
 
+function parseTwilioInboundFrom(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const channelAddress = trimmed.match(TWILIO_CHANNEL_ADDRESS_RE);
+  const kind = channelAddress?.[1]?.toLowerCase();
+  if (kind && kind !== "rcs") {
+    return null;
+  }
+  const phoneNumber = normalizeSmsPhoneNumber(channelAddress?.[2] ?? trimmed);
+  if (!looksLikeSmsPhoneNumber(phoneNumber)) {
+    return null;
+  }
+  return phoneNumber;
+}
+
 export function buildTwilioInboundMessage(form: Record<string, string>): SmsInboundMessage | null {
-  const from = firstTrimmedString(form.From);
+  // Signature verification owns the untouched form. Canonicalize only after
+  // that boundary so Twilio channel prefixes never change its signed input.
+  const from = parseTwilioInboundFrom(firstTrimmedString(form.From));
   const to = firstTrimmedString(form.To);
   const body = firstString(form.Body);
   const accountSid = firstTrimmedString(form.AccountSid);

--- a/extensions/sms/src/webhook.test.ts
+++ b/extensions/sms/src/webhook.test.ts
@@ -68,8 +68,17 @@ function createResponse(): TestResponse {
   } as unknown as TestResponse;
 }
 
-function createSignedSmsPayload(messageSid: string): { body: string; signature: string } {
-  const body = `AccountSid=AC123&From=%2B15551234567&To=%2B15557654321&Body=hello&MessageSid=${messageSid}`;
+function createSignedSmsPayload(
+  messageSid: string,
+  overrides: { from?: string; to?: string } = {},
+): { body: string; signature: string } {
+  const body = new URLSearchParams({
+    AccountSid: "AC123",
+    From: overrides.from ?? "+15551234567",
+    To: overrides.to ?? "+15557654321",
+    Body: "hello",
+    MessageSid: messageSid,
+  }).toString();
   return {
     body,
     signature: computeTwilioSignature({
@@ -115,6 +124,37 @@ describe("createSmsWebhookHandler", () => {
     expect(firstRes.statusCode).toBe(200);
     expect(replayRes.statusCode).toBe(200);
     expect(dispatchSmsInboundEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("validates the raw RCS form before canonicalizing its sender", async () => {
+    const messageSid = createMessageSid(9);
+    const { body, signature } = createSignedSmsPayload(messageSid, {
+      from: "RcS:+1 (555) 123-4567",
+      to: "rcs:example-agent",
+    });
+    const handler = createSmsWebhookHandler({
+      cfg: {},
+      account: createAccount(),
+      channelRuntime: {} as SmsChannelRuntime,
+    });
+
+    expect(parseTwilioFormBody(body).From).toBe("RcS:+1 (555) 123-4567");
+
+    const res = createResponse();
+    await handler(createRequest(body, signature), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(dispatchSmsInboundEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        msg: {
+          accountSid: "AC123",
+          from: "+15551234567",
+          to: "rcs:example-agent",
+          body: "hello",
+          messageSid,
+        },
+      }),
+    );
   });
 
   it("prunes only the expired insertion prefix without refreshing replays", () => {


### PR DESCRIPTION
## What Problem This Solves

Twilio RCS inbound messages can identify the consumer with an `rcs:+E164` channel address. The SMS plugin treated that prefix as part of the phone number, which broke allowlist matching, canonical direct-session routing, and reply targeting.

## Why This Change Was Made

Normalization now happens once at the Twilio webhook ingress boundary, after signature validation. The parser accepts bare E.164 SMS addresses and case-insensitive `rcs:` consumer addresses, rejects unrelated channel prefixes, and leaves the raw form values unchanged for Twilio's signature check.

The shared outbound/config phone normalizer is intentionally unchanged. Twilio uses `rcs:` to select channel semantics on outbound requests, so stripping it globally would alter fallback and sender behavior outside this inbound bug.

## User Impact

Signed Twilio RCS webhooks now route the consumer to the same canonical SMS-owned direct session and sender match as the equivalent E.164 address, while SMS/MMS and outbound RCS behavior remain unchanged.

## Evidence

- Focused parser coverage: bare E.164, mixed-case `rcs:`, WhatsApp/unknown-prefix rejection.
- Signed webhook regression: validation sees the original URL-encoded form; normalization occurs only after the signature succeeds.
- Inbound routing assertions cover the canonical sender/session values.
- Exact-head CI run `29133142322`: success.
- Workflow Sanity run `29133142302`: success.
- Fresh Codex autoreview: no accepted or actionable findings.
- A contributor live replay independently demonstrated the observed signed RCS webhook and delivered reply behavior: https://github.com/openclaw/openclaw/pull/102373#issuecomment-4936993996

No deployed exact-head Twilio webhook was used; the exact-head signed-handler integration test covers the security and routing boundary changed here.

AI-assisted.
