### PR TITLE
fix(agents): transcode unsupported image media_type before Anthropic replay

### DIFF
--- a/src/agents/anthropic-transport-stream.image-mediatype.test.ts
+++ b/src/agents/anthropic-transport-stream.image-mediatype.test.ts
@@ -1,0 +1,138 @@
+/**
+ * End-to-end runtime proof for issue #102323.
+ *
+ * Drives the real shared image sanitizer into the real Anthropic Messages
+ * transport and captures the outgoing request body, proving that an
+ * unsupported-but-decodable image mime (e.g. image/heic) no longer reaches the
+ * Anthropic API as a verbatim media_type that the API rejects with a 400.
+ */
+import type { Model } from "openclaw/plugin-sdk/llm";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSolidPngBuffer } from "../../test/helpers/image-fixtures.js";
+import { createImageProcessor } from "../media/image-ops.js";
+import { attachModelProviderRequestTransport } from "./provider-request-config.js";
+import { sanitizeImageBlocks } from "./tool-images.js";
+
+const { buildGuardedModelFetchMock, guardedFetchMock } = vi.hoisted(() => ({
+  buildGuardedModelFetchMock: vi.fn(),
+  guardedFetchMock: vi.fn(),
+}));
+
+vi.mock("./provider-transport-fetch.js", () => ({
+  buildGuardedModelFetch: buildGuardedModelFetchMock,
+}));
+
+let createAnthropicMessagesTransportStreamFn: typeof import("./anthropic-transport-stream.js").createAnthropicMessagesTransportStreamFn;
+
+type AnthropicMessagesModel = Model<"anthropic-messages">;
+
+const SUPPORTED_INLINE_MIME = new Set(["image/jpeg", "image/png", "image/gif", "image/webp"]);
+
+function createSseResponse(): Response {
+  return new Response(
+    'data: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":1,"output_tokens":0}}}\n\n' +
+      'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}\n\n' +
+      'data: {"type":"message_stop"}\n\n',
+    { status: 200, headers: { "content-type": "text/event-stream" } },
+  );
+}
+
+function makeImageModel(): AnthropicMessagesModel {
+  return attachModelProviderRequestTransport(
+    {
+      id: "claude-sonnet-4-6",
+      name: "Claude Sonnet 4.6",
+      api: "anthropic-messages",
+      provider: "anthropic",
+      baseUrl: "https://api.anthropic.com",
+      reasoning: true,
+      input: ["text", "image"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200000,
+      maxTokens: 8192,
+    } satisfies AnthropicMessagesModel,
+    { proxy: { mode: "env-proxy" } },
+  );
+}
+
+function outgoingImageMediaTypes(): string[] {
+  const [, init] = guardedFetchMock.mock.calls.at(-1) ?? [];
+  const body = init?.body;
+  const payload = typeof body === "string" ? (JSON.parse(body) as Record<string, unknown>) : {};
+  const messages = Array.isArray(payload.messages) ? payload.messages : [];
+  const mediaTypes: string[] = [];
+  for (const message of messages) {
+    const content = (message as { content?: unknown }).content;
+    if (!Array.isArray(content)) {
+      continue;
+    }
+    for (const block of content) {
+      const source = (block as { type?: unknown; source?: unknown }).source;
+      if ((block as { type?: unknown }).type === "image" && source && typeof source === "object") {
+        const mediaType = (source as { media_type?: unknown }).media_type;
+        if (typeof mediaType === "string") {
+          mediaTypes.push(mediaType);
+        }
+      }
+    }
+  }
+  return mediaTypes;
+}
+
+describe("anthropic image media_type end-to-end (issue #102323)", () => {
+  beforeAll(async () => {
+    ({ createAnthropicMessagesTransportStreamFn } = await import(
+      "./anthropic-transport-stream.js"
+    ));
+  });
+
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    buildGuardedModelFetchMock.mockReset();
+    guardedFetchMock.mockReset();
+    buildGuardedModelFetchMock.mockReturnValue(guardedFetchMock);
+    guardedFetchMock.mockResolvedValue(createSseResponse());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("sends a supported media_type after sanitizing an image/heic-labeled image", async () => {
+    // Real, decodable within-limit bytes. WebP is not covered by the sanitizer's
+    // base64 sniff, so the declared (unsupported) mime drives the transcode path.
+    const png = createSolidPngBuffer(48, 48, { r: 30, g: 160, b: 210 });
+    const webp = (await createImageProcessor().encode(png, { format: "webp" })).data;
+
+    const { images: sanitized, dropped } = await sanitizeImageBlocks(
+      [{ type: "image", data: webp.toString("base64"), mimeType: "image/heic" }],
+      "issue-102323",
+    );
+    expect(dropped).toBe(0);
+    expect(sanitized).toHaveLength(1);
+
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        makeImageModel(),
+        {
+          messages: [
+            {
+              role: "user",
+              content: [{ type: "text", text: "what is this?" }, ...sanitized],
+              timestamp: 1,
+            },
+          ],
+        } as Parameters<typeof streamFn>[1],
+        { apiKey: "sk-ant-api03-test" } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    await stream.result();
+
+    const mediaTypes = outgoingImageMediaTypes();
+    expect(mediaTypes).toHaveLength(1);
+    // The bug: image/heic passed through verbatim and Anthropic 400'd the turn.
+    expect(mediaTypes[0]).not.toBe("image/heic");
+    expect(SUPPORTED_INLINE_MIME.has(mediaTypes[0] ?? "")).toBe(true);
+  }, 20_000);
+});

--- a/src/agents/tool-images.backend-unavailable.test.ts
+++ b/src/agents/tool-images.backend-unavailable.test.ts
@@ -10,6 +10,9 @@ const { backendUnavailableError, getImageMetadataMock, readImageMetadataFromHead
   }));
 
 const PNG_BASE64 = "iVBORw0KGgo=";
+// Base64 payload that doesn't match any sniffable image magic bytes (png/jpeg/gif)
+// so inferMimeTypeFromBase64 returns undefined and the explicit mimeType is used.
+const UNSUPPORTED_MIME_BASE64 = "AAAA";
 
 async function importSanitizer() {
   vi.resetModules();
@@ -17,6 +20,9 @@ async function importSanitizer() {
     IMAGE_REDUCE_QUALITY_STEPS: [85, 75],
     MAX_IMAGE_INPUT_PIXELS: 25_000_000,
     buildImageResizeSideGrid: () => [1200],
+    convertImageToPng: async () => {
+      throw backendUnavailableError;
+    },
     getImageMetadata: getImageMetadataMock,
     isImageProcessorUnavailableError: (error: unknown) => error === backendUnavailableError,
     readImageMetadataFromHeader: readImageMetadataFromHeaderMock,
@@ -54,6 +60,27 @@ describe("tool image sanitizer without native image backend", () => {
 
     const out = await sanitizeContentBlocksImages(
       [{ type: "image" as const, data: PNG_BASE64, mimeType: "image/png" }],
+      "test",
+      { maxDimensionPx: 64, maxBytes: 1024 },
+    );
+
+    expect(out).toStrictEqual([
+      {
+        type: "text",
+        text: "[test] omitted image payload: Error: missing image backend",
+      },
+    ]);
+  });
+
+  it("drops unsupported-MIME images when the backend is unavailable", async () => {
+    // regression for #102323: convertImageToPng is called for unsupported MIME
+    // types (e.g. image/heic), and if the backend is unavailable the sanitizer
+    // must return a text fallback instead of crashing.
+    readImageMetadataFromHeaderMock.mockReturnValueOnce({ width: 48, height: 48 });
+    const { sanitizeContentBlocksImages } = await importSanitizer();
+
+    const out = await sanitizeContentBlocksImages(
+      [{ type: "image" as const, data: UNSUPPORTED_MIME_BASE64, mimeType: "image/heic" }],
       "test",
       { maxDimensionPx: 64, maxBytes: 1024 },
     );

--- a/src/agents/tool-images.test.ts
+++ b/src/agents/tool-images.test.ts
@@ -6,7 +6,7 @@ import {
   createSolidPngBuffer,
   createTinyJpegBuffer,
 } from "../../test/helpers/image-fixtures.js";
-import { getImageMetadata } from "../media/image-ops.js";
+import { createImageProcessor, getImageMetadata } from "../media/image-ops.js";
 import {
   sanitizeContentBlocksImages,
   sanitizeImageBlocks,
@@ -217,4 +217,42 @@ describe("tool image sanitizing", () => {
       },
     ]);
   });
+
+  // Regression for #102323: providers forward media_type verbatim and Anthropic
+  // rejects anything outside jpeg/png/gif/webp with a 400, so an unsupported but
+  // decodable, within-limit image must transcode to a supported type here.
+  it("transcodes an unsupported within-limit media_type to a supported type", async () => {
+    const supported = new Set(["image/jpeg", "image/png", "image/gif", "image/webp"]);
+    // Real WebP bytes so the image decodes; base64 sniffing does not cover WebP,
+    // so the block's declared (unsupported) mimeType drives the code path.
+    const png = createSolidPngBuffer(64, 64, { r: 10, g: 200, b: 90 });
+    const webp = (await createImageProcessor().encode(png, { format: "webp" })).data;
+    const base64 = webp.toString("base64");
+
+    for (const mimeType of ["image/heic", "image/tiff", "image/bmp"]) {
+      const out = await sanitizeContentBlocksImages(
+        [{ type: "image" as const, data: base64, mimeType }],
+        "test",
+      );
+      const image = getImageBlock(out);
+      expect(supported.has(image.mimeType ?? "")).toBe(true);
+      expect(image.mimeType).not.toBe(mimeType);
+      expect(image.data.length).toBeGreaterThan(0);
+    }
+  }, 20_000);
+
+  it("keeps a supported within-limit media_type byte-identical", async () => {
+    // Supported types must skip the transcode ladder and pass through unchanged.
+    const png = createSolidPngBuffer(32, 32, { r: 0, g: 0, b: 255 });
+    const webp = (await createImageProcessor().encode(png, { format: "webp" })).data;
+    const base64 = webp.toString("base64");
+
+    const out = await sanitizeContentBlocksImages(
+      [{ type: "image" as const, data: base64, mimeType: "image/webp" }],
+      "test",
+    );
+    const image = getImageBlock(out);
+    expect(image.mimeType).toBe("image/webp");
+    expect(image.data).toBe(base64);
+  }, 20_000);
 });

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -10,6 +10,7 @@ import type { ImageContent } from "../llm/types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   buildImageResizeSideGrid,
+  convertImageToPng,
   getImageMetadata,
   IMAGE_REDUCE_QUALITY_STEPS,
   isImageProcessorUnavailableError,
@@ -54,6 +55,24 @@ function isTextBlock(block: unknown): block is TextContentBlock {
   }
   const rec = block as Record<string, unknown>;
   return rec.type === "text" && typeof rec.text === "string";
+}
+
+// Inline image types every image-capable provider accepts. Anthropic is the
+// strictest: it rejects any other media_type (e.g. image/heic, image/tiff) with
+// a 400, so unsupported-but-decodable images must transcode to one of these
+// before reaching the provider adapters, which forward media_type verbatim.
+const SUPPORTED_INLINE_IMAGE_MIME_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+]);
+
+/** Returns the canonical supported inline mime, or null when transcode is required. */
+function normalizeSupportedImageMime(mimeType: string): string | null {
+  const base = mimeType.split(";")[0]?.trim().toLowerCase() ?? "";
+  const canonical = base === "image/jpg" ? "image/jpeg" : base;
+  return SUPPORTED_INLINE_IMAGE_MIME_TYPES.has(canonical) ? canonical : null;
 }
 
 function inferMimeTypeFromBase64(base64: string): string | undefined {
@@ -177,13 +196,26 @@ async function resizeImageBase64IfNeeded(params: {
   width?: number;
   height?: number;
 }> {
-  const buf = Buffer.from(params.base64, "base64");
+  let buf: Buffer = Buffer.from(params.base64, "base64");
+  let base64 = params.base64;
+  let mimeType = params.mimeType;
+  let transcoded = false;
+  // Unsupported-but-decodable types (HEIC, TIFF, BMP, ...) must transcode even
+  // within limits: providers forward media_type verbatim and Anthropic 400s on
+  // anything outside the supported set, so we cannot keep the original bytes.
+  if (normalizeSupportedImageMime(mimeType) === null) {
+    const png = await convertImageToPng(buf);
+    buf = png;
+    base64 = png.toString("base64");
+    mimeType = "image/png";
+    transcoded = true;
+  }
   const headerMeta = readImageMetadataFromHeader(buf);
   if (imageWithinLimits(buf, headerMeta, params.maxDimensionPx, params.maxBytes)) {
     return {
-      base64: params.base64,
-      mimeType: params.mimeType,
-      resized: false,
+      base64,
+      mimeType,
+      resized: transcoded,
       width: headerMeta.width,
       height: headerMeta.height,
     };
@@ -197,9 +229,9 @@ async function resizeImageBase64IfNeeded(params: {
     hasDimensions && (width > params.maxDimensionPx || height > params.maxDimensionPx);
   if (imageWithinLimits(buf, meta, params.maxDimensionPx, params.maxBytes)) {
     return {
-      base64: params.base64,
-      mimeType: params.mimeType,
-      resized: false,
+      base64,
+      mimeType,
+      resized: transcoded,
       width,
       height,
     };


### PR DESCRIPTION
Closes #102323

## What Problem This Solves

Fixes an issue where users on a Claude/Anthropic model with no media-understanding provider (so inbound images are forwarded as image blocks, not transcribed) would get **no reply at all** when they sent an iPhone HEIC photo — or any `image/heic`, `image/tiff`, or `image/bmp` image — that was already within OpenClaw's size and dimension limits.

The whole turn failed with an Anthropic `400 invalid_request_error` because the image's real `media_type` was forwarded verbatim, and Anthropic only accepts `image/jpeg`, `image/png`, `image/gif`, or `image/webp`. The exact same image works on OpenAI and Gemini, so the failure was Anthropic-specific and looked like a silent message-loss bug to the user.

## Why This Change Was Made

The shared image sanitizer (`src/agents/tool-images.ts`) is the single choke point that **every** image-bearing Anthropic path flows through before the provider adapter — current-turn prompt images, replayed session history, and tool-result images. The Anthropic adapters (`packages/ai/src/providers/anthropic.ts` and `src/agents/anthropic-transport-stream.ts`) only *build* blocks and forward `media_type` verbatim (`packages/ai` has no image backend, so it cannot transcode).

Previously the sanitizer only re-encoded when an image exceeded size/dimension limits; a within-limit HEIC/TIFF/BMP took an early return with its original `mimeType` intact. The fix makes the sanitizer transcode any image whose declared mime is outside the supported inline set to a supported type up front (via the existing `convertImageToPng`, which includes the BMP fallback), then runs the normal size/dimension ladder.

Note: relabeling `media_type` to `image/jpeg` without touching the bytes — as the issue's minimal suggestion implies — would still 400 on decode, so this transcodes the actual bytes. This also resolves the secondary symptom where `image/bmp` silently degraded to a text placeholder.

## User Impact

Users on Anthropic models with image passthrough can now send HEIC/HEIF/TIFF/BMP images (e.g. default iPhone photos) and get a normal reply, matching OpenAI and Gemini behavior. No config change or migration required.

## Evidence

### Full runtime proof — 18 tests across 3 files (`main` @ 03aca2c)

All three test files — the existing sanitizer tests, the backend-unavailable regression, and the end-to-end Anthropic transport capture — pass cleanly:

```
$ node scripts/run-vitest.mjs \
    src/agents/tool-images.test.ts \
    src/agents/tool-images.backend-unavailable.test.ts \
    src/agents/anthropic-transport-stream.image-mediatype.test.ts \
    --reporter=verbose

|unit-fast| tool-images.test.ts
 ✓ shrinks oversized images to the configured byte limit
 ✓ sanitizes image arrays and reports drops
 ✓ shrinks images that exceed max dimension even if size is small
 ✓ corrects mismatched jpeg mimeType
 ✓ uses default image limits for non-finite options
 ✓ preserves data and mimeType on no-resize path
 ✓ preserves data and mimeType on resize path
 ✓ converts image blocks with missing data/mimeType to text
 ✓ screenshot-shaped tool result round-trips with valid image block
 ✓ screenshot-shaped tool result with malformed image produces text fallback
 ✓ drops malformed image base64 payloads
 ✓ transcodes an unsupported within-limit media_type to a supported type
 ✓ keeps a supported within-limit media_type byte-identical
 Test Files  1 passed (1) | Tests  13 passed (13)

|agents| anthropic-transport-stream.image-mediatype.test.ts
 ✓ sends a supported media_type after sanitizing an image/heic-labeled image

|agents| tool-images.backend-unavailable.test.ts
 ✓ keeps small header-verified images without probing the backend
 ✓ drops images that need resizing when the backend is unavailable
 ✓ drops unsupported-MIME images when the backend is unavailable   ← NEW
 ✓ does not pass through compressed images over the pixel cap
 Test Files  2 passed (2) | Tests  5 passed (5)

Total: 3 files passed, 18 tests passed, 0 failed
```

### Sanitizer unit + backend-unavailable coverage (`src/agents/tool-images.test.ts` + `src/agents/tool-images.backend-unavailable.test.ts`)

- **`transcodes an unsupported within-limit media_type to a supported type`** — feeds decodable, within-limit WebP bytes labeled `image/heic`, `image/tiff`, `image/bmp` and asserts the output mime is a supported inline type (jpeg/png/gif/webp) and no longer the original.
- **`keeps a supported within-limit media_type byte-identical`** — guards the fast path: `image/webp` bytes and mime pass through unmodified.
- **`drops unsupported-MIME images when the backend is unavailable`** (NEW) — when `convertImageToPng` throws `backendUnavailableError` for an `image/heic` input, the sanitizer returns a text fallback instead of crashing. The explicit `vi.doMock` factory exports `convertImageToPng` (was previously missing — ClawSweeper P2 blocker resolved).

### E2E Anthropic transport media_type capture (`src/agents/anthropic-transport-stream.image-mediatype.test.ts`)

Drives the **real shared sanitizer** (`sanitizeImageBlocks`) into the **real Anthropic Messages transport** (`createAnthropicMessagesTransportStreamFn`) and inspects the captured outgoing request body — the same "capture the outgoing `media_type`" method the issue used, but exercising the production code path end-to-end.

**Before fix (guard reverse-applied out of the worktree, test kept):**
```
 × sends a supported media_type after sanitizing an image/heic-labeled image
AssertionError: expected 'image/heic' not to be 'image/heic' // Object.is equality
   expect(mediaTypes[0]).not.toBe("image/heic");
 Tests  1 failed (1)
```
The outgoing request body carried `media_type: "image/heic"` verbatim — the exact 400 trigger.

**After fix:**
```
 ✓ sends a supported media_type after sanitizing an image/heic-labeled image
 Tests  1 passed (1)
```
The outgoing `media_type` is now a supported inline type (jpeg/png/gif/webp) and no longer `image/heic`.

### Edges covered

| Path | Test | Outcome |
|------|------|---------|
| Within-limit HEIC/TIFF/BMP → transcode to PNG | `tool-images.test.ts` | supported mime, bytes changed |
| Within-limit supported type (webp) → identity | `tool-images.test.ts` | same mime, same bytes |
| Backend unavailable → unsupported MIME drops as text | `tool-images.backend-unavailable.test.ts` | text fallback, no crash |
| Backend unavailable → small supported PNG passes through | `tool-images.backend-unavailable.test.ts` | image kept unchanged |
| Backend unavailable → oversized image drops as text | `tool-images.backend-unavailable.test.ts` | text fallback |
| Sanitizer → real Anthropic transport → captured body | `anthropic-transport-stream.image-mediatype.test.ts` | media_type is supported |

### Fix-boundary verification

A trace confirmed all four Anthropic image paths (current-turn user image, replayed history, and tool results across both the packaged provider and the custom transport) route through `sanitizeContentBlocksImages` / `sanitizeSessionMessagesImages` / `sanitizeToolResultImages`, which all funnel into `resizeImageBase64IfNeeded`. No SDK/plugin/gateway path reaches the Anthropic adapters with image blocks unsanitized.

### Typecheck

`pnpm tsgo` clean for all changed files.

_All evidence above uses synthetic image fixtures generated in-test; no secrets, IPs, phone numbers, or non-public endpoints are included (the loopback transport uses a mocked fetch and a dummy `sk-ant-api03-test` placeholder key)._