### PR TITLE
fix(llm): session auto-retry no longer retries permanent provider errors

### DIFF
--- a/src/llm/utils/retry.test.ts
+++ b/src/llm/utils/retry.test.ts
@@ -54,4 +54,52 @@ describe("isRetryableAssistantError", () => {
       ),
     ).toBe(true);
   });
+
+  it("does not retry permanent model-not-found errors", () => {
+    expect(isRetryableAssistantError(errorMessage("model gpt-5.5-preview-0429 not found"))).toBe(
+      false,
+    );
+    expect(isRetryableAssistantError(errorMessage("404 model not found: openai/gpt-unknown"))).toBe(
+      false,
+    );
+  });
+
+  it("does not retry permanent image-dimension errors", () => {
+    expect(
+      isRetryableAssistantError(
+        errorMessage(
+          '400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.1.content.1.image: At least one of the image dimensions exceed max allowed size for many-image requests: 2000 pixels"}}',
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not retry permanent auth errors", () => {
+    expect(isRetryableAssistantError(errorMessage("invalid api key sk-proj-abc502xyz"))).toBe(
+      false,
+    );
+    expect(isRetryableAssistantError(errorMessage("api key has been revoked"))).toBe(false);
+  });
+
+  it("does not retry long-window rate limits", () => {
+    expect(
+      isRetryableAssistantError(
+        errorMessage("429 You exceeded your daily request limit. Please try again in 24 hours."),
+      ),
+    ).toBe(false);
+    expect(
+      isRetryableAssistantError(errorMessage("rate limit reached for requests. Retry after 6h.")),
+    ).toBe(false);
+  });
+
+  it("does not match bare status-code substrings inside ids, dimensions, or keys", () => {
+    // "0429" inside a model id should not match \b429\b.
+    expect(isRetryableAssistantError(errorMessage("model xyz-0429 is loading"))).toBe(false);
+    // "1504" inside image dimensions should not match \b504\b.
+    expect(
+      isRetryableAssistantError(errorMessage("Image dimensions 1504x1504 are unsupported")),
+    ).toBe(false);
+    // "502" inside an api key should not match \b502\b.
+    expect(isRetryableAssistantError(errorMessage("using key sk-xyz502abc")), "502").toBe(false);
+  });
 });

--- a/src/llm/utils/retry.ts
+++ b/src/llm/utils/retry.ts
@@ -1,3 +1,9 @@
+import { isImageDimensionErrorMessage } from "../../agents/embedded-agent-helpers/errors.js";
+import {
+  isAuthPermanentErrorMessage,
+  isPeriodicUsageLimitErrorMessage,
+} from "../../agents/embedded-agent-helpers/failover-matches.js";
+import { isModelNotFoundErrorMessage } from "../../agents/live-model-errors.js";
 import type { AssistantMessage } from "../types.js";
 
 function buildProviderErrorPattern(patterns: readonly string[]): RegExp {
@@ -17,11 +23,11 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
   "overloaded",
   "rate.?limit",
   "too many requests",
-  "429",
-  "500",
-  "502",
-  "503",
-  "504",
+  String.raw`\b429\b`,
+  String.raw`\b500\b`,
+  String.raw`\b502\b`,
+  String.raw`\b503\b`,
+  String.raw`\b504\b`,
   "service.?unavailable",
   "server.?error",
   "internal.?error",
@@ -49,12 +55,66 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
   "please retry your request",
 ]);
 
+/**
+ * Detect rate-limit messages whose reset window is too long for the session
+ * auto-retry backoff (2s/4s/8s by default). Retrying a daily/weekly/hourly
+ * limit inside a ~14s window just re-sends the full context uselessly.
+ */
+const LONG_RETRY_WINDOW_HINT_RE =
+  /\b(?:retry|try again|please try again)(?:\s+(?:after|in))?\s+\d+\s*(?:hour|hours|h|day|days|d|week|weeks|w|month|months)\b/i;
+
+/**
+ * Detect periodic request limits ("daily request limit", "hourly usage limit")
+ * that cannot clear within the short session auto-retry window.
+ */
+const PERIODIC_REQUEST_LIMIT_RE =
+  /\b(?:daily|hourly|weekly|monthly)(?:\/(?:daily|hourly|weekly|monthly))*\s+(?:request\s+)?(?:usage\s+)?limit\b/i;
+
+function hasLongRetryWindowHint(errorMessage: string): boolean {
+  return LONG_RETRY_WINDOW_HINT_RE.test(errorMessage);
+}
+
+function hasPeriodicRequestLimitHint(errorMessage: string): boolean {
+  return PERIODIC_REQUEST_LIMIT_RE.test(errorMessage);
+}
+
+/**
+ * Detect permanent provider errors that should never be retried: revoked or
+ * invalid credentials, missing models, image schema rejections, and periodic
+ * usage limits. These fail identically on every retry and re-sending the full
+ * turn context wastes tokens and latency.
+ */
+function isNonRetryablePermanentError(errorMessage: string): boolean {
+  if (isAuthPermanentErrorMessage(errorMessage)) {
+    return true;
+  }
+  if (isModelNotFoundErrorMessage(errorMessage)) {
+    return true;
+  }
+  if (isImageDimensionErrorMessage(errorMessage)) {
+    return true;
+  }
+  if (isPeriodicUsageLimitErrorMessage(errorMessage)) {
+    return true;
+  }
+  if (hasPeriodicRequestLimitHint(errorMessage)) {
+    return true;
+  }
+  if (hasLongRetryWindowHint(errorMessage)) {
+    return true;
+  }
+  return false;
+}
+
 /** Classify transient provider/transport failures for outer retry policy. */
 export function isRetryableAssistantError(message: AssistantMessage): boolean {
   if (message.stopReason !== "error" || !message.errorMessage) {
     return false;
   }
   if (NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN.test(message.errorMessage)) {
+    return false;
+  }
+  if (isNonRetryablePermanentError(message.errorMessage)) {
     return false;
   }
   return RETRYABLE_PROVIDER_ERROR_PATTERN.test(message.errorMessage);


### PR DESCRIPTION
Closes #102250

## What Problem This Solves

Fixes an issue where OpenClaw's session auto-retry classifier would retry permanent provider errors up to three times, re-sending the full turn context (including any large image payloads) each time. A model id containing a digit run like `0429`, image dimensions like `1504x1504`, or an API key containing `502` could be misclassified as a transient status-code error and retried. Long-window rate limits such as "daily request limit" were also retried inside a ~14 second backoff window that could never clear them.

## Why This Change Was Made

`src/llm/utils/retry.ts` now anchors status-code tokens on word boundaries (`\b429\b`, `\b500\b`, etc.) so only standalone HTTP status codes trigger retry classification. It also reuses the existing embedded-runner error classifiers to exclude permanent failures before applying the retry pattern: model-not-found errors, image-dimension rejections, permanent auth errors, and periodic/long-window rate limits. These errors fail identically on every retry, so re-sending the full context wastes tokens and latency.

## User Impact

Users running sessions against providers that return permanent errors (unknown model, invalid image size, revoked key, daily rate limits, etc.) will see the turn fail immediately instead of making up to three doomed provider calls. This reduces unexpected token usage and speeds up failure feedback.

## Evidence

Focused unit tests in `src/llm/utils/retry.test.ts` cover the reported cases and their siblings:

- Permanent model-not-found messages are non-retryable.
- Permanent image-dimension rejections are non-retryable.
- Invalid API keys containing digit substrings like `502` are non-retryable.
- Long-window rate limits ("daily request limit", "Retry after 6h") are non-retryable.
- Short-window rate limits and explicit retry guidance remain retryable.
- Bare status-code substrings inside ids, dimensions, and keys do not trigger retry.

Local validation:

```
$ node scripts/run-vitest.mjs src/llm/utils/retry.test.ts
 ✓ |unit| src/llm/utils/retry.test.ts (11 tests) 114ms
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

```
$ npx oxlint --tsconfig config/tsconfig/oxlint.json src/llm/utils/retry.ts src/llm/utils/retry.test.ts
Found 0 warnings and 0 errors.
```

```
$ npx oxfmt --check src/llm/utils/retry.ts src/llm/utils/retry.test.ts
All matched files use the correct format.
```

```
$ npx madge --circular --extensions ts,tsx src/llm/utils/retry.ts
✔ No circular dependency found!
```
