### PR TITLE
fix(google): restore image tool results for prefixed Gemini 2 models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Google Chat request deadlines:** bound control calls to 30 seconds while giving media transfers size-aware total budgets and a separate 30-second stalled-body guard, preventing hung Chat API requests without breaking large attachment uploads. (#102227) Thanks @hugenshen.
+- **Google Gemini prefixed model IDs:** recognize `google/gemini-*` and `models/gemini-*` when selecting multimodal function-response behavior, preserving the Gemini 2 image fallback without regressing Gemini 3 inline image responses. (#102382) Thanks @LiLan0125.
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -2706,6 +2706,33 @@ describe("google transport stream", () => {
     },
   );
 
+  it.each(["google/gemini-3.1-pro-preview", "models/gemini-3.1-pro-preview"])(
+    "keeps image parts inside function responses for prefixed Gemini 3 model %s",
+    (modelId) => {
+      const params = buildGoogleGenerativeAiParams(
+        buildGeminiModel({ id: modelId, input: ["text", "image"] }),
+        {
+          messages: [
+            { role: "user", content: "Take a screenshot.", timestamp: 0 },
+            googleToolCallAssistantTurn({
+              model: modelId,
+              name: "screenshot",
+              args: {},
+            }),
+            googleToolResultMessage("screenshot"),
+          ],
+        } as never,
+      );
+
+      const functionResponse = (params.contents[2] as GoogleTestContentTurn).parts[0]
+        ?.functionResponse as { parts?: unknown };
+      expect(params.contents.map((content) => content.role)).toEqual(["user", "model", "user"]);
+      expect(functionResponse.parts).toEqual([
+        { inlineData: { mimeType: "image/png", data: "png-bytes" } },
+      ]);
+    },
+  );
+
   it.each([
     ["gemini-2.5-flash-lite", "minimal", 512],
     ["gemini-2.5-flash-lite", "low", 2048],

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -2658,13 +2658,19 @@ describe("google transport stream", () => {
   });
 
   it.each([
-    ["image first", ["screenshot", "weather"]],
-    ["image last", ["weather", "screenshot"]],
+    ["bare Gemini 2.5 image first", "gemini-2.5-flash", ["screenshot", "weather"]],
+    ["bare Gemini 2.5 image last", "gemini-2.5-flash", ["weather", "screenshot"]],
+    [
+      "provider-prefixed Gemini 2.5 image first",
+      "google/gemini-2.5-pro",
+      ["screenshot", "weather"],
+    ],
+    ["models-prefixed Gemini 2.5 image last", "models/gemini-2.5-pro", ["weather", "screenshot"]],
   ] as const)(
-    "keeps parallel function responses immediate and retains the deferred %s result",
-    (_label, resultOrder) => {
+    "keeps parallel function responses immediate and retains the deferred result for %s",
+    (_label, modelId, resultOrder) => {
       const params = buildGoogleGenerativeAiParams(
-        buildGeminiModel({ id: "gemini-2.5-flash", input: ["text", "image"] }),
+        buildGeminiModel({ id: modelId, input: ["text", "image"] }),
         {
           messages: [
             { role: "user", content: "Screenshot the page and check the weather.", timestamp: 0 },

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -165,7 +165,7 @@ function requiresToolCallThoughtSignature(modelId: string): boolean {
 }
 
 function supportsMultimodalFunctionResponse(modelId: string): boolean {
-  const match = normalizeLowercaseStringOrEmpty(modelId).match(/^gemini(?:-live)?-(\d+)/);
+  const match = normalizeLowercaseStringOrEmpty(modelId).match(/(?:^|\/)gemini(?:-live)?-(\d+)/);
   if (!match) {
     return true;
   }

--- a/packages/ai/src/providers/google-shared.parallel-image-repro.test.ts
+++ b/packages/ai/src/providers/google-shared.parallel-image-repro.test.ts
@@ -35,12 +35,18 @@ function functionResponseNames(parts: readonly Part[] | undefined): string[] {
 
 describe("google-shared convertMessages — parallel tool results with an image (Gemini < 3)", () => {
   it.each([
-    ["image first", ["screenshot", "weather"]],
-    ["image last", ["weather", "screenshot"]],
+    ["bare Gemini 2.5 image first", "gemini-2.5-flash", ["screenshot", "weather"]],
+    ["bare Gemini 2.5 image last", "gemini-2.5-flash", ["weather", "screenshot"]],
+    [
+      "provider-prefixed Gemini 2.5 image first",
+      "google/gemini-2.5-pro",
+      ["screenshot", "weather"],
+    ],
+    ["models-prefixed Gemini 2.5 image last", "models/gemini-2.5-pro", ["weather", "screenshot"]],
   ] as const)(
-    "keeps the response run immediate and retains a deferred %s result",
-    (_label, resultOrder) => {
-      const model = makeVisionModel("gemini-2.5-flash");
+    "keeps the response run immediate and retains a deferred result for %s",
+    (_label, modelId, resultOrder) => {
+      const model = makeVisionModel(modelId);
       const toolResults = {
         screenshot: {
           role: "toolResult",

--- a/packages/ai/src/providers/google-shared.parallel-image-repro.test.ts
+++ b/packages/ai/src/providers/google-shared.parallel-image-repro.test.ts
@@ -90,4 +90,32 @@ describe("google-shared convertMessages — parallel tool results with an image 
       expect(contents.slice(3).some((c) => countFunctionResponses(c.parts) > 0)).toBe(false);
     },
   );
+
+  it.each(["google/gemini-3.1-pro-preview", "models/gemini-3.1-pro-preview"])(
+    "keeps image parts inside function responses for prefixed Gemini 3 model %s",
+    (modelId) => {
+      const model = makeVisionModel(modelId);
+      const contents = convertMessagesForTest(model, {
+        messages: [
+          { role: "user", content: "Take a screenshot." },
+          makeGoogleAssistantMessage(model.id, [
+            { type: "toolCall", id: "call_1", name: "screenshot", arguments: {} },
+          ]),
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "screenshot",
+            content: [{ type: "image", mimeType: "image/png", data: "AAAA" }],
+            isError: false,
+            timestamp: 0,
+          },
+        ],
+      } as unknown as Context);
+
+      expect(contents.map((content) => content.role)).toEqual(["user", "model", "user"]);
+      expect(contents[2]?.parts?.[0]?.functionResponse?.parts).toEqual([
+        { inlineData: { mimeType: "image/png", data: "AAAA" } },
+      ]);
+    },
+  );
 });

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -140,7 +140,7 @@ export function requiresToolCallId(modelId: string): boolean {
 }
 
 function getGeminiMajorVersion(modelId: string): number | undefined {
-  const match = modelId.toLowerCase().match(/^gemini(?:-live)?-(\d+)/);
+  const match = modelId.toLowerCase().match(/(?:^|\/)gemini(?:-live)?-(\d+)/);
   if (!match) {
     return undefined;
   }


### PR DESCRIPTION
Closes #102320

## What Problem This Solves

Fixes an issue where users of Gemini 2.x models addressed as `google/gemini-*` or `models/gemini-*` would have image tool results encoded in unsupported `functionResponse.parts`. Google could reject that request shape instead of receiving the image through OpenClaw's existing separate image-turn fallback.

## Why This Change Was Made

The bundled Google transport and reusable `@openclaw/ai` converter now detect Gemini major versions at a model-path segment boundary. This keeps bare and prefixed Gemini 2.x ids on the same fallback path while preserving Gemini 3 multimodal function responses and existing behavior for non-Gemini Google-hosted models.

## User Impact

Image-returning tools now produce the supported request shape for prefixed Gemini 2.x model routes. Gemini 3 routes continue to keep image parts nested in the function response.

## Evidence

- Blacksmith Testbox-through-Crabbox lease `tbx_01kx3ezqrcz7164z8ahd3rhdmn`: `corepack pnpm test extensions/google/transport-stream.test.ts packages/ai/src/providers/google-shared.parallel-image-repro.test.ts packages/ai/src/providers/google-shared.convert.test.ts` passed 107 assertions (89 extension tests and 18 package tests).
- After the final rebase on the landed Google Chat deadline fix, exact published head `9fc6d7515ff22306b43484e0662cb57a2525a4cc` passed the same 107 assertions again through the permitted local fallback; the production patch remained the same two one-line substitutions.
- The same remote lane passed `pnpm check:changed`, including core, core-test, extension, and extension-test typechecks; core and extension lint; dependency guards; import-cycle checks; and changed-surface policy guards.
- `git diff --check` passed. Fresh whole-branch Codex autoreview reported no findings with 0.98 confidence.
- Regression coverage proves `google/` and `models/` prefixed Gemini 2.x ids emit a separate image turn, while matching prefixed Gemini 3 controls retain image data in `functionResponse.parts`.
- The pinned `@google/genai@2.10.0` contract accepts Vertex model ids such as `google/gemini-*` and Gemini API resource ids such as `models/gemini-*`. Google's current function-calling documentation limits multimodal function responses to Gemini 3 and newer: [Vertex AI function calling](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/tools/function-calling), [Gemini API function calling](https://ai.google.dev/gemini-api/docs/generate-content/function-calling), and [Gemini Models API](https://ai.google.dev/api/models).

Live Google or Vertex HTTP proof was not run: the credential-safe Testbox lane had neither `GEMINI_API_KEY` nor `GOOGLE_API_KEY`. The production request-building paths and both capability branches are covered remotely, but this run did not directly observe Google's response on the wire.
