### PR TITLE
Manage Claw cron jobs through the gateway

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -48,6 +48,10 @@
     "target": "Claws"
   },
   {
+    "source": "Cron jobs",
+    "target": "定时任务"
+  },
+  {
     "source": "ClawRouter (managed multi-provider routing)",
     "target": "ClawRouter（托管式多提供商路由）"
   },

--- a/docs/cli/claws.md
+++ b/docs/cli/claws.md
@@ -96,6 +96,26 @@ or reuses matching ones and records whether the Claw introduced or referenced
 each resource. Plugins remain process-wide OpenClaw capabilities rather than
 per-agent installations.
 
+Cron jobs declare scheduled work for the new agent:
+
+```json
+{
+  "cronJobs": [
+    {
+      "id": "daily-summary",
+      "name": "Daily incident summary",
+      "schedule": { "cron": "0 9 * * *", "timezone": "UTC" },
+      "session": "isolated",
+      "message": "Summarize active incidents."
+    }
+  ]
+}
+```
+
+Claws use the existing Gateway scheduler and bind created jobs to the new
+agent. Preview, provenance, status, and removal cover those jobs without
+changing the behavior of ordinary cron commands.
+
 ## Inspect and preview
 
 Validate the source without planning local changes:
@@ -138,8 +158,8 @@ openclaw claws status
 openclaw claws status incident-triage --json
 ```
 
-`status` compares the installed agent and its recorded workspace and package
-provenance with current state. It reports incomplete installs, missing
+`status` compares the installed agent and its recorded workspace, package, and
+cron provenance with current state. It reports incomplete installs, missing
 resources, and drift without changing local state.
 
 Claw provenance distinguishes two relationships:
@@ -215,3 +235,4 @@ Use `--json` for experimental machine-readable output.
 - [Agents](/cli/agents)
 - [Skills](/tools/skills)
 - [Plugins](/tools/plugin)
+- [Cron jobs](/automation/cron-jobs)

--- a/docs/cli/claws.md
+++ b/docs/cli/claws.md
@@ -114,7 +114,9 @@ Cron jobs declare scheduled work for the new agent:
 
 Claws use the existing Gateway scheduler and bind created jobs to the new
 agent. Preview, provenance, status, and removal cover those jobs without
-changing the behavior of ordinary cron commands.
+changing the behavior of ordinary cron commands. Removal rereads the live job
+through the Gateway and preserves it when its owned definition changed after
+planning.
 
 ## Inspect and preview
 

--- a/src/claws/add.ts
+++ b/src/claws/add.ts
@@ -13,6 +13,12 @@ import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
 import { resolveUserPath } from "../utils.js";
+import {
+  ClawCronInstallError,
+  installClawCronJobs,
+  type ClawCronGateway,
+  type PersistedClawCronRef,
+} from "./cron.js";
 import { ClawPackageInstallError, installClawPackages } from "./packages.js";
 import {
   deleteClawInstallRecord,
@@ -41,6 +47,8 @@ type ClawAddApplyOptions = OpenClawStateDatabaseOptions & {
   createWorkspaceFiles?: typeof createClawWorkspaceFiles;
   runtime?: RuntimeEnv;
   installPackages?: typeof installClawPackages;
+  installCronJobs?: typeof installClawCronJobs;
+  cronGateway?: Pick<ClawCronGateway, "add" | "list">;
   nowMs?: number;
 };
 export class ClawAddMutationError extends Error {
@@ -66,6 +74,7 @@ type ClawAddResult = {
   configCommitted: boolean;
   workspaceFiles: PersistedClawWorkspaceFile[];
   packages: PersistedClawPackageRef[];
+  cronJobs: PersistedClawCronRef[];
   installRecord?: PersistedClawInstall;
   error?: {
     code: string;
@@ -76,7 +85,8 @@ type ClawAddResult = {
 
 function hasUnsupportedMutationActions(plan: ClawAddPlan): boolean {
   return plan.actions.some(
-    (action) => !["agent", "workspace", "workspaceFile", "package"].includes(action.kind),
+    (action) =>
+      !["agent", "workspace", "workspaceFile", "package", "cronJob"].includes(action.kind),
   );
 }
 
@@ -140,6 +150,7 @@ function partialResult(params: {
   workspaceFiles?: PersistedClawWorkspaceFile[];
   packages?: PersistedClawPackageRef[];
   installStatus?: ClawInstallStatus;
+  cronJobs?: PersistedClawCronRef[];
   error: ClawAddResult["error"];
   nowMs?: number;
 }): ClawAddResult {
@@ -156,6 +167,7 @@ function partialResult(params: {
     configCommitted: params.configCommitted,
     workspaceFiles: params.workspaceFiles ?? [],
     packages: params.packages ?? [],
+    cronJobs: params.cronJobs ?? [],
     installRecord: {
       ...params.installRecord,
       status: params.installStatus ?? "partial",
@@ -175,7 +187,7 @@ export async function applyClawAddPlan(
   if (hasUnsupportedMutationActions(plan)) {
     throw new ClawAddMutationError(
       "unsupported_components",
-      "This build can add agent settings, workspace files, and declared packages; MCP servers and cron jobs require later lifecycle slices.",
+      "This build can add agent settings, workspace files, packages, and cron jobs; declared MCP servers require a later lifecycle slice.",
     );
   }
   if (options.consentPlanIntegrity !== plan.planIntegrity) {
@@ -401,6 +413,7 @@ export async function applyClawAddPlan(
       configCommitted,
       workspaceFiles: workspaceError.createdFiles,
       packages,
+      cronJobs: [],
       installRecord: {
         ...installRecord,
         status: "config_committed",
@@ -414,9 +427,10 @@ export async function applyClawAddPlan(
     };
   }
 
+  let cronJobs: PersistedClawCronRef[] = [];
   try {
-    // Package mutation is last: skills now have their workspace, and a package
-    // failure cannot leave a later workspace/configuration step unapplied.
+    // Skills require their workspace. Recurring work is enabled only after all
+    // package mutation succeeds.
     packages = await installPackages(plan, options);
   } catch (error) {
     const packageError =
@@ -440,6 +454,33 @@ export async function applyClawAddPlan(
     });
   }
 
+  const installCronJobs = options.installCronJobs ?? installClawCronJobs;
+  try {
+    cronJobs = await installCronJobs(plan, { ...options, gateway: options.cronGateway });
+  } catch (error) {
+    const cronError =
+      error instanceof ClawCronInstallError
+        ? error
+        : new ClawCronInstallError(
+            "cron_install_failed",
+            error instanceof Error ? error.message : String(error),
+            cronJobs,
+          );
+    markInstallStatus(plan.agent.finalId, "config_committed", ["config_committed"], options);
+    return partialResult({
+      plan,
+      installRecord,
+      workspaceCreated,
+      configCommitted,
+      workspaceFiles,
+      packages,
+      cronJobs: cronError.cronJobs,
+      installStatus: "config_committed",
+      error: { code: cronError.code, message: cronError.message },
+      nowMs: options.nowMs,
+    });
+  }
+
   try {
     markInstallStatus(plan.agent.finalId, "complete", ["config_committed", "complete"], options);
     return {
@@ -454,6 +495,7 @@ export async function applyClawAddPlan(
       workspaceCreated,
       configCommitted,
       packages,
+      cronJobs,
       workspaceFiles,
       installRecord: {
         ...installRecord,
@@ -469,6 +511,7 @@ export async function applyClawAddPlan(
       configCommitted,
       workspaceFiles,
       packages,
+      cronJobs,
       error: { code: "provenance_failed", message: (error as Error).message },
     });
   }

--- a/src/claws/cron.test.ts
+++ b/src/claws/cron.test.ts
@@ -1,8 +1,7 @@
-import { mkdtemp } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { validateCronAddParams } from "../../packages/gateway-protocol/src/index.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { installClawCronJobs, readClawCronRefs } from "./cron.js";
 import { buildClawAddPlan } from "./lifecycle.js";
@@ -10,9 +9,10 @@ import { parseClawManifest } from "./schema.js";
 import type { ClawSourceIdentity } from "./types.js";
 
 afterEach(() => closeOpenClawStateDatabaseForTest());
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 async function fixture() {
-  const root = await mkdtemp(join(tmpdir(), "openclaw-claw-cron-"));
+  const root = tempDirs.make("openclaw-claw-cron-");
   const parsed = parseClawManifest({
     schemaVersion: 1,
     agent: { id: "worker" },

--- a/src/claws/cron.test.ts
+++ b/src/claws/cron.test.ts
@@ -1,0 +1,175 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { validateCronAddParams } from "../../packages/gateway-protocol/src/index.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { installClawCronJobs, readClawCronRefs } from "./cron.js";
+import { buildClawAddPlan } from "./lifecycle.js";
+import { parseClawManifest } from "./schema.js";
+import type { ClawSourceIdentity } from "./types.js";
+
+afterEach(() => closeOpenClawStateDatabaseForTest());
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), "openclaw-claw-cron-"));
+  const parsed = parseClawManifest({
+    schemaVersion: 1,
+    agent: { id: "worker" },
+    cronJobs: [
+      {
+        id: "daily-report",
+        name: "Daily report",
+        schedule: { cron: "0 9 * * *", timezone: "UTC" },
+        session: "main",
+        message: "Prepare the report",
+        delivery: { mode: "announce", channel: "last" },
+      },
+    ],
+  });
+  if (!parsed.ok) {
+    throw new Error(JSON.stringify(parsed.diagnostics));
+  }
+  const source: ClawSourceIdentity = {
+    kind: "package",
+    name: "@acme/worker",
+    version: "1.0.0",
+    packageRoot: root,
+    manifestPath: join(root, "openclaw.claw.json"),
+    integrityKind: "artifact",
+    integrity: "sha256:manifest",
+    byteLength: 100,
+  };
+  const plan = await buildClawAddPlan({
+    manifest: parsed.manifest,
+    source,
+    context: { workspace: join(root, "workspace"), agentId: "worker-two" },
+  });
+  return { root, plan, env: { OPENCLAW_STATE_DIR: join(root, "state") } };
+}
+
+describe("installClawCronJobs", () => {
+  it("pins declarations and execution to the final agent id", async () => {
+    const current = await fixture();
+    const add = vi.fn().mockResolvedValue({ id: "scheduler-123" });
+
+    const refs = await installClawCronJobs(current.plan, {
+      env: current.env,
+      gateway: { add },
+      nowMs: 42,
+    });
+
+    expect(add).toHaveBeenCalledWith({
+      name: "Daily report",
+      declarationKey: "claw:worker-two:daily-report",
+      displayName: "Daily report",
+      owner: { agentId: "worker-two" },
+      enabled: true,
+      agentId: "worker-two",
+      schedule: { kind: "cron", expr: "0 9 * * *", tz: "UTC" },
+      sessionTarget: "session:agent:worker-two:main",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "Prepare the report" },
+      delivery: { mode: "announce", channel: "last" },
+    });
+    expect(validateCronAddParams(add.mock.calls[0]?.[0])).toBe(true);
+    expect(refs).toMatchObject([
+      {
+        schemaVersion: "openclaw.clawCronRef.v1",
+        agentId: "worker-two",
+        manifestId: "daily-report",
+        schedulerJobId: "scheduler-123",
+        status: "complete",
+      },
+    ]);
+    expect(readClawCronRefs("worker-two", { env: current.env })).toEqual(refs);
+  });
+
+  it("accepts declaration convergence results from cron.add", async () => {
+    const current = await fixture();
+
+    const refs = await installClawCronJobs(current.plan, {
+      env: current.env,
+      gateway: { add: vi.fn().mockResolvedValue({ created: false, job: { id: "existing-1" } }) },
+    });
+
+    expect(refs[0]).toMatchObject({ schedulerJobId: "existing-1", status: "complete" });
+  });
+
+  it("preserves an ambiguous pending reference when cron.add fails", async () => {
+    const current = await fixture();
+
+    await expect(
+      installClawCronJobs(current.plan, {
+        env: current.env,
+        gateway: { add: vi.fn().mockRejectedValue(new Error("gateway unavailable")) },
+      }),
+    ).rejects.toMatchObject({
+      code: "cron_install_failed",
+      cronJobs: [{ manifestId: "daily-report", status: "pending", error: "gateway unavailable" }],
+    });
+    expect(readClawCronRefs("worker-two", { env: current.env })).toMatchObject([
+      { manifestId: "daily-report", status: "pending", error: "gateway unavailable" },
+    ]);
+  });
+
+  it("reconciles a response-lost retry by declaration key", async () => {
+    const current = await fixture();
+    const add = vi.fn().mockRejectedValue(new Error("response lost"));
+
+    await expect(
+      installClawCronJobs(current.plan, {
+        env: current.env,
+        gateway: { add },
+      }),
+    ).rejects.toMatchObject({
+      code: "cron_install_failed",
+      cronJobs: [{ status: "pending" }],
+    });
+
+    const refs = await installClawCronJobs(current.plan, {
+      env: current.env,
+      gateway: {
+        add,
+        list: vi.fn().mockResolvedValue({
+          jobs: [
+            {
+              id: "scheduler-after-lost-response",
+              declarationKey: "claw:worker-two:daily-report",
+            },
+          ],
+        }),
+      },
+    });
+
+    expect(add).toHaveBeenCalledTimes(1);
+    expect(refs).toMatchObject([
+      { schedulerJobId: "scheduler-after-lost-response", status: "complete" },
+    ]);
+  });
+
+  it("converges concurrent installs through the declaration key", async () => {
+    const current = await fixture();
+    const jobs = new Map<string, { id: string; declarationKey: string }>();
+    const add = vi.fn(async (input: Record<string, unknown>) => {
+      await Promise.resolve();
+      const declarationKey = String(input.declarationKey);
+      const existing = jobs.get(declarationKey);
+      if (existing) {
+        return { created: false, job: existing };
+      }
+      const created = { id: "scheduler-converged", declarationKey };
+      jobs.set(declarationKey, created);
+      return { created: true, job: created };
+    });
+
+    const [first, second] = await Promise.all([
+      installClawCronJobs(current.plan, { env: current.env, gateway: { add } }),
+      installClawCronJobs(current.plan, { env: current.env, gateway: { add } }),
+    ]);
+
+    expect(jobs.size).toBe(1);
+    expect(first[0]).toMatchObject({ schedulerJobId: "scheduler-converged", status: "complete" });
+    expect(second[0]).toMatchObject({ schedulerJobId: "scheduler-converged", status: "complete" });
+  });
+});

--- a/src/claws/cron.ts
+++ b/src/claws/cron.ts
@@ -204,10 +204,7 @@ function schedulerJobByDeclarationKey(
   return match ? { id: match.id as string } : undefined;
 }
 
-export function clawCronGatewayInput(
-  agentId: string,
-  ref: PersistedClawCronRef,
-): Record<string, unknown> {
+function clawCronGatewayInput(agentId: string, ref: PersistedClawCronRef): Record<string, unknown> {
   const job = ref.job;
   return {
     name: job.name ?? job.id,

--- a/src/claws/cron.ts
+++ b/src/claws/cron.ts
@@ -1,0 +1,344 @@
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabaseOptions,
+} from "../state/openclaw-state-db.js";
+import type { ClawAddPlan, ClawCronJob } from "./types.js";
+
+const CLAW_CRON_REF_SCHEMA_VERSION = "openclaw.clawCronRef.v1" as const;
+
+export type PersistedClawCronRef = {
+  schemaVersion: typeof CLAW_CRON_REF_SCHEMA_VERSION;
+  agentId: string;
+  manifestId: string;
+  declarationKey: string;
+  schedulerJobId?: string;
+  status: "pending" | "complete" | "failed" | "removed";
+  job: ClawCronJob;
+  error?: string;
+  createdAtMs: number;
+  updatedAtMs: number;
+};
+
+type CronRefRow = {
+  schema_version: string;
+  agent_id: string;
+  manifest_id: string;
+  declaration_key: string;
+  scheduler_job_id: string | null;
+  status: PersistedClawCronRef["status"];
+  job_json: string;
+  error: string | null;
+  created_at_ms: number | bigint;
+  updated_at_ms: number | bigint;
+};
+
+export type ClawCronGateway = {
+  add: (input: Record<string, unknown>) => Promise<unknown>;
+  list?: (agentId: string) => Promise<unknown>;
+  remove: (schedulerJobId: string) => Promise<unknown>;
+};
+
+export class ClawCronInstallError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+    readonly cronJobs: PersistedClawCronRef[],
+  ) {
+    super(message);
+    this.name = "ClawCronInstallError";
+  }
+}
+
+function rowToRef(row: CronRefRow): PersistedClawCronRef {
+  return {
+    schemaVersion: CLAW_CRON_REF_SCHEMA_VERSION,
+    agentId: row.agent_id,
+    manifestId: row.manifest_id,
+    declarationKey: row.declaration_key,
+    ...(row.scheduler_job_id ? { schedulerJobId: row.scheduler_job_id } : {}),
+    status: row.status,
+    job: JSON.parse(row.job_json) as ClawCronJob,
+    ...(row.error ? { error: row.error } : {}),
+    createdAtMs: Number(row.created_at_ms),
+    updatedAtMs: Number(row.updated_at_ms),
+  };
+}
+
+function persistPendingRef(
+  plan: ClawAddPlan,
+  job: ClawCronJob,
+  options: OpenClawStateDatabaseOptions & { nowMs?: number },
+): PersistedClawCronRef {
+  const nowMs = options.nowMs ?? Date.now();
+  const declarationKey = `claw:${plan.agent.finalId}:${job.id}`;
+  const database = openOpenClawStateDatabase(options);
+  const existing =
+    database.db /* sqlite-allow-raw: read one Claw cron ownership row by closed agent and manifest ids. */
+      .prepare(
+        `SELECT schema_version, agent_id, manifest_id, declaration_key, scheduler_job_id,
+              status, job_json, error, created_at_ms, updated_at_ms
+         FROM claw_cron_refs
+        WHERE agent_id = ? AND manifest_id = ?`,
+      )
+      .get(plan.agent.finalId, job.id) as CronRefRow | undefined;
+  if (existing) {
+    const ref = rowToRef(existing);
+    if (ref.declarationKey !== declarationKey || JSON.stringify(ref.job) !== JSON.stringify(job)) {
+      throw new ClawCronInstallError(
+        "cron_provenance_conflict",
+        `Cron declaration ${JSON.stringify(job.id)} differs from its pending ownership record.`,
+        [ref],
+      );
+    }
+    if (ref.status === "complete") {
+      return ref;
+    }
+    return updateRef(ref, { status: "pending" }, options);
+  }
+  const record: PersistedClawCronRef = {
+    schemaVersion: CLAW_CRON_REF_SCHEMA_VERSION,
+    agentId: plan.agent.finalId,
+    manifestId: job.id,
+    declarationKey,
+    status: "pending",
+    job,
+    createdAtMs: nowMs,
+    updatedAtMs: nowMs,
+  };
+  runOpenClawStateWriteTransaction(({ db }) => {
+    db /* sqlite-allow-raw: insert one pending Claw cron ownership row. */
+      .prepare(
+        `INSERT INTO claw_cron_refs (
+         agent_id, manifest_id, schema_version, declaration_key, scheduler_job_id,
+         status, job_json, error, created_at_ms, updated_at_ms
+       ) VALUES (
+         @agent_id, @manifest_id, @schema_version, @declaration_key, NULL,
+         @status, @job_json, NULL, @created_at_ms, @updated_at_ms
+       )`,
+      )
+      .run({
+        agent_id: record.agentId,
+        manifest_id: record.manifestId,
+        schema_version: record.schemaVersion,
+        declaration_key: record.declarationKey,
+        status: record.status,
+        job_json: JSON.stringify(record.job),
+        created_at_ms: nowMs,
+        updated_at_ms: nowMs,
+      });
+  }, options);
+  return record;
+}
+
+function updateRef(
+  ref: PersistedClawCronRef,
+  update: { schedulerJobId?: string; status: PersistedClawCronRef["status"]; error?: string },
+  options: OpenClawStateDatabaseOptions & { nowMs?: number },
+): PersistedClawCronRef {
+  const updated = {
+    ...ref,
+    ...update,
+    updatedAtMs: options.nowMs ?? Date.now(),
+  };
+  runOpenClawStateWriteTransaction(({ db }) => {
+    db /* sqlite-allow-raw: update one Claw cron ownership row. */
+      .prepare(
+        `UPDATE claw_cron_refs
+          SET scheduler_job_id = @scheduler_job_id,
+              status = @status,
+              error = @error,
+              updated_at_ms = @updated_at_ms
+        WHERE agent_id = @agent_id AND manifest_id = @manifest_id`,
+      )
+      .run({
+        agent_id: ref.agentId,
+        manifest_id: ref.manifestId,
+        scheduler_job_id: update.schedulerJobId ?? null,
+        status: update.status,
+        error: update.error ?? null,
+        updated_at_ms: updated.updatedAtMs,
+      });
+  }, options);
+  return updated;
+}
+
+function schedulerJobFromResult(value: unknown): { id: string } | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.id === "string" && record.id) {
+    return { id: record.id };
+  }
+  const job = record.job;
+  if (job && typeof job === "object" && typeof (job as Record<string, unknown>).id === "string") {
+    return { id: (job as Record<string, unknown>).id as string };
+  }
+  return undefined;
+}
+
+function schedulerJobByDeclarationKey(
+  value: unknown,
+  declarationKey: string,
+): { id: string } | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const jobs = (value as Record<string, unknown>).jobs;
+  if (!Array.isArray(jobs)) {
+    return undefined;
+  }
+  const matches = jobs.filter(
+    (job): job is Record<string, unknown> =>
+      Boolean(job) &&
+      typeof job === "object" &&
+      (job as Record<string, unknown>).declarationKey === declarationKey &&
+      typeof (job as Record<string, unknown>).id === "string",
+  );
+  const match = matches.length === 1 ? matches[0] : undefined;
+  return match ? { id: match.id as string } : undefined;
+}
+
+function gatewayInput(plan: ClawAddPlan, ref: PersistedClawCronRef): Record<string, unknown> {
+  const job = ref.job;
+  return {
+    name: job.name ?? job.id,
+    declarationKey: ref.declarationKey,
+    ...(job.name ? { displayName: job.name } : {}),
+    owner: { agentId: plan.agent.finalId },
+    enabled: true,
+    agentId: plan.agent.finalId,
+    schedule: {
+      kind: "cron",
+      expr: job.schedule.cron,
+      ...(job.schedule.timezone ? { tz: job.schedule.timezone } : {}),
+    },
+    sessionTarget:
+      job.session === "main" ? `session:agent:${plan.agent.finalId}:main` : job.session,
+    wakeMode: "now",
+    payload: { kind: "agentTurn", message: job.message },
+    delivery: job.delivery
+      ? {
+          mode: job.delivery.mode,
+          ...(job.delivery.channel ? { channel: job.delivery.channel } : {}),
+        }
+      : { mode: "none" },
+  };
+}
+
+export async function installClawCronJobs(
+  plan: ClawAddPlan,
+  options: OpenClawStateDatabaseOptions & {
+    gateway?: Pick<ClawCronGateway, "add" | "list">;
+    nowMs?: number;
+  } = {},
+): Promise<PersistedClawCronRef[]> {
+  const actions = plan.actions.filter((action) => action.kind === "cronJob");
+  if (actions.length === 0) {
+    return [];
+  }
+  if (!options.gateway) {
+    throw new ClawCronInstallError(
+      "cron_gateway_required",
+      "Claw cron jobs require the gateway-owned cron.add API.",
+      [],
+    );
+  }
+  const refs: PersistedClawCronRef[] = [];
+  for (const action of actions) {
+    const details = action.details as (ClawCronJob & { agentId?: string }) | undefined;
+    if (!details?.id) {
+      throw new ClawCronInstallError(
+        "cron_plan_invalid",
+        `Cron action ${action.id} is invalid.`,
+        refs,
+      );
+    }
+    const job: ClawCronJob = {
+      id: details.id,
+      ...(details.name ? { name: details.name } : {}),
+      schedule: details.schedule,
+      session: details.session,
+      message: details.message,
+      ...(details.delivery ? { delivery: details.delivery } : {}),
+    };
+    const pending = persistPendingRef(plan, job, options);
+    refs.push(pending);
+    if (pending.status === "complete" && pending.schedulerJobId) {
+      continue;
+    }
+    let result: { id: string } | undefined;
+    try {
+      if (options.gateway.list) {
+        result = schedulerJobByDeclarationKey(
+          await options.gateway.list(plan.agent.finalId),
+          pending.declarationKey,
+        );
+      }
+      result ??= schedulerJobFromResult(await options.gateway.add(gatewayInput(plan, pending)));
+      if (!result) {
+        throw new Error("cron.add returned no scheduler job id");
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      refs[refs.length - 1] = updateRef(pending, { status: "pending", error: message }, options);
+      throw new ClawCronInstallError("cron_install_failed", message, refs);
+    }
+    try {
+      refs[refs.length - 1] = updateRef(
+        pending,
+        { status: "complete", schedulerJobId: result.id },
+        options,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new ClawCronInstallError(
+        "cron_provenance_failed",
+        `cron.add succeeded, but its scheduler id could not be persisted: ${message}`,
+        refs,
+      );
+    }
+  }
+  return refs;
+}
+
+export function readClawCronRefs(
+  agentId: string,
+  options: OpenClawStateDatabaseOptions = {},
+): PersistedClawCronRef[] {
+  const database = openOpenClawStateDatabase(options);
+  const rows = database.db /* sqlite-allow-raw: read Claw cron ownership rows by closed agent id. */
+    .prepare(
+      `SELECT schema_version, agent_id, manifest_id, declaration_key, scheduler_job_id,
+              status, job_json, error, created_at_ms, updated_at_ms
+         FROM claw_cron_refs
+        WHERE agent_id = ?
+        ORDER BY manifest_id`,
+    )
+    .all(agentId) as CronRefRow[];
+  return rows.map(rowToRef);
+}
+
+export function deleteClawCronRef(
+  agentId: string,
+  manifestId: string,
+  options: OpenClawStateDatabaseOptions = {},
+): void {
+  runOpenClawStateWriteTransaction(({ db }) => {
+    db /* sqlite-allow-raw: delete one Claw cron ownership row after scheduler cleanup. */
+      .prepare("DELETE FROM claw_cron_refs WHERE agent_id = ? AND manifest_id = ?")
+      .run(agentId, manifestId);
+  }, options);
+}
+
+export function markClawCronRefRemoved(
+  agentId: string,
+  manifestId: string,
+  options: OpenClawStateDatabaseOptions & { nowMs?: number } = {},
+): PersistedClawCronRef | undefined {
+  const ref = readClawCronRefs(agentId, options).find(
+    (candidate) => candidate.manifestId === manifestId,
+  );
+  return ref ? updateRef(ref, { status: "removed" }, options) : undefined;
+}

--- a/src/claws/cron.ts
+++ b/src/claws/cron.ts
@@ -1,3 +1,6 @@
+import { resolveCronJobConfigRevision } from "../cron/config-revision.js";
+import { normalizeCronJobCreate } from "../cron/normalize.js";
+import type { CronJob } from "../cron/types.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -35,6 +38,7 @@ type CronRefRow = {
 
 export type ClawCronGateway = {
   add: (input: Record<string, unknown>) => Promise<unknown>;
+  get?: (schedulerJobId: string) => Promise<unknown>;
   list?: (agentId: string) => Promise<unknown>;
   remove: (schedulerJobId: string) => Promise<unknown>;
 };
@@ -200,22 +204,24 @@ function schedulerJobByDeclarationKey(
   return match ? { id: match.id as string } : undefined;
 }
 
-function gatewayInput(plan: ClawAddPlan, ref: PersistedClawCronRef): Record<string, unknown> {
+export function clawCronGatewayInput(
+  agentId: string,
+  ref: PersistedClawCronRef,
+): Record<string, unknown> {
   const job = ref.job;
   return {
     name: job.name ?? job.id,
     declarationKey: ref.declarationKey,
     ...(job.name ? { displayName: job.name } : {}),
-    owner: { agentId: plan.agent.finalId },
+    owner: { agentId },
     enabled: true,
-    agentId: plan.agent.finalId,
+    agentId,
     schedule: {
       kind: "cron",
       expr: job.schedule.cron,
       ...(job.schedule.timezone ? { tz: job.schedule.timezone } : {}),
     },
-    sessionTarget:
-      job.session === "main" ? `session:agent:${plan.agent.finalId}:main` : job.session,
+    sessionTarget: job.session === "main" ? `session:agent:${agentId}:main` : job.session,
     wakeMode: "now",
     payload: { kind: "agentTurn", message: job.message },
     delivery: job.delivery
@@ -225,6 +231,40 @@ function gatewayInput(plan: ClawAddPlan, ref: PersistedClawCronRef): Record<stri
         }
       : { mode: "none" },
   };
+}
+
+export function clawCronGatewayJobMatchesRef(
+  agentId: string,
+  ref: PersistedClawCronRef,
+  value: unknown,
+): boolean {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const live = value as Partial<CronJob>;
+  const expected = normalizeCronJobCreate(clawCronGatewayInput(agentId, ref));
+  if (
+    !expected ||
+    typeof live.id !== "string" ||
+    typeof live.createdAtMs !== "number" ||
+    typeof live.updatedAtMs !== "number" ||
+    !live.state
+  ) {
+    return false;
+  }
+  try {
+    return (
+      resolveCronJobConfigRevision({
+        ...expected,
+        id: live.id,
+        createdAtMs: live.createdAtMs,
+        updatedAtMs: live.updatedAtMs,
+        state: live.state,
+      }) === resolveCronJobConfigRevision(live as CronJob)
+    );
+  } catch {
+    return false;
+  }
 }
 
 export async function installClawCronJobs(
@@ -276,7 +316,9 @@ export async function installClawCronJobs(
           pending.declarationKey,
         );
       }
-      result ??= schedulerJobFromResult(await options.gateway.add(gatewayInput(plan, pending)));
+      result ??= schedulerJobFromResult(
+        await options.gateway.add(clawCronGatewayInput(plan.agent.finalId, pending)),
+      );
       if (!result) {
         throw new Error("cron.add returned no scheduler job id");
       }

--- a/src/claws/export.test.ts
+++ b/src/claws/export.test.ts
@@ -49,6 +49,14 @@ async function installedFixture(
         ...(options.extraWorkspaceFiles ?? []).map((path) => ({ source: `source/${path}`, path })),
       ],
     },
+    cronJobs: [
+      {
+        id: "daily-report",
+        schedule: { cron: "0 9 * * *", timezone: "UTC" },
+        session: "isolated",
+        message: "Prepare report",
+      },
+    ],
   });
   if (!parsed.ok) {
     throw new Error(JSON.stringify(parsed.diagnostics));
@@ -75,6 +83,7 @@ async function installedFixture(
     commitConfig: async (transform) => {
       config = transform(config);
     },
+    cronGateway: { add: async () => ({ id: "scheduler-daily" }) },
   });
   if (options.withPackage) {
     persistClawPackageRef(
@@ -143,7 +152,14 @@ describe("exportClawAgent", () => {
           },
         ],
         mcpServers: {},
-        cronJobs: [],
+        cronJobs: [
+          {
+            id: "daily-report",
+            schedule: { cron: "0 9 * * *", timezone: "UTC" },
+            session: "isolated",
+            message: "Prepare report",
+          },
+        ],
       },
     });
     const packageJson = JSON.parse(await readFile(join(out, "package.json"), "utf8"));

--- a/src/claws/export.ts
+++ b/src/claws/export.ts
@@ -238,6 +238,17 @@ export async function exportClawAgent(
       `Cannot export drifted packages: ${driftedPackages.map((pkg) => `${pkg.kind}:${pkg.ref}@${pkg.version} (${pkg.state})`).join(", ")}.`,
     );
   }
+  const unresolvedCronJobs = record.cronJobs.filter(
+    (cron) => cron.status !== "complete" || !cron.schedulerJobId,
+  );
+  if (unresolvedCronJobs.length > 0) {
+    throw new ClawExportError(
+      "cron_jobs_unavailable",
+      `Cannot export cron declarations with unresolved ownership: ${unresolvedCronJobs
+        .map((cron) => cron.manifestId)
+        .join(", ")}.`,
+    );
+  }
 
   const workspace = await fsSafeRoot(record.install.workspace, {
     hardlinks: "reject",
@@ -293,7 +304,9 @@ export async function exportClawAgent(
         return comparePortableText(leftIdentity, rightIdentity);
       }),
     mcpServers: {},
-    cronJobs: [],
+    cronJobs: record.cronJobs
+      .map((cron) => cron.job)
+      .toSorted((left, right) => left.id.localeCompare(right.id)),
   };
   const parsed = parseClawManifest(manifest);
   if (!parsed.ok) {

--- a/src/claws/lifecycle-delete-support.ts
+++ b/src/claws/lifecycle-delete-support.ts
@@ -1,3 +1,4 @@
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
@@ -15,9 +16,11 @@ import { pruneAgentConfig } from "../commands/agents.config.js";
 import { moveToTrash } from "../commands/onboard-helpers.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { root as fsSafeRoot, FsSafeError } from "../infra/fs-safe.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
   openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
 import type { PersistedClawInstall } from "./provenance.js";
@@ -35,7 +38,17 @@ type WorkspaceFileRow = {
   updated_at_ms: number | bigint;
 };
 
-export function clawStateTableExists(db: DatabaseSync, name: string): boolean {
+export class ClawRemoveError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ClawRemoveError";
+  }
+}
+
+function clawStateTableExists(db: DatabaseSync, name: string): boolean {
   return Boolean(
     db /* sqlite-allow-raw: schema probe for optional Claw state tables. */
       .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?")
@@ -271,3 +284,113 @@ export const clawRemoveQuietRuntime: RuntimeEnv = {
     throw new Error(`Unexpected exit during Claw removal cleanup: ${code ?? 1}`);
   },
 };
+
+type ClawRemovableWorkspaceFile = PersistedClawWorkspaceFile & {
+  state: "unchanged" | "modified" | "missing" | "unsafe";
+  message?: string;
+};
+
+export type RemovedWorkspaceFile = {
+  path: string;
+  action: "deleted" | "missing" | "retainedModified" | "error";
+  message?: string;
+};
+
+export type ClawManagedFileStatus = PersistedClawWorkspaceFile & {
+  state: "unchanged" | "modified" | "missing" | "unsafe";
+  message?: string;
+};
+
+export async function inspectClawWorkspaceFile(
+  record: PersistedClawWorkspaceFile,
+): Promise<ClawManagedFileStatus> {
+  try {
+    const workspace = await fsSafeRoot(record.workspace, {
+      hardlinks: "reject",
+      maxBytes: 1024 * 1024,
+      symlinks: "reject",
+    });
+    if (!(await workspace.exists(record.path))) {
+      return { ...record, state: "missing" };
+    }
+    const content = await workspace.readBytes(record.path, { maxBytes: 1024 * 1024 });
+    const digest = `sha256:${createHash("sha256").update(content).digest("hex")}`;
+    return { ...record, state: digest === record.contentDigest ? "unchanged" : "modified" };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { ...record, state: "missing" };
+    }
+    return {
+      ...record,
+      state: "unsafe",
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export async function removeClawWorkspaceFile(
+  record: ClawRemovableWorkspaceFile,
+): Promise<RemovedWorkspaceFile> {
+  if (record.state === "missing") {
+    return { path: record.path, action: "missing" };
+  }
+  if (record.state === "modified") {
+    return { path: record.path, action: "retainedModified" };
+  }
+  try {
+    const workspace = await fsSafeRoot(record.workspace, {
+      hardlinks: "reject",
+      maxBytes: 1024 * 1024,
+      symlinks: "reject",
+    });
+    if (!(await workspace.exists(record.path))) {
+      return { path: record.path, action: "missing" };
+    }
+    const stagedPath = `${record.path}.openclaw-claw-remove-${randomUUID()}`;
+    await workspace.move(record.path, stagedPath, { overwrite: false });
+    const content = await workspace.readBytes(stagedPath, { maxBytes: 1024 * 1024 });
+    const digest = `sha256:${createHash("sha256").update(content).digest("hex")}`;
+    if (digest !== record.contentDigest) {
+      await workspace.move(stagedPath, record.path, { overwrite: false });
+      return { path: record.path, action: "retainedModified" };
+    }
+    await workspace.remove(stagedPath);
+    return { path: record.path, action: "deleted" };
+  } catch (error) {
+    return {
+      path: record.path,
+      action: "error",
+      message: error instanceof FsSafeError ? `${error.code}: ${error.message}` : String(error),
+    };
+  }
+}
+
+export function releaseClawRemoveRows(
+  agentId: string,
+  files: RemovedWorkspaceFile[],
+  complete: boolean,
+  options: OpenClawStateDatabaseOptions,
+): void {
+  runOpenClawStateWriteTransaction(({ db }) => {
+    if (clawStateTableExists(db, "claw_workspace_files")) {
+      for (const file of files.filter((candidate) => candidate.action !== "error")) {
+        db /* sqlite-allow-raw: remove one owned Claw workspace-file row. */
+          .prepare("DELETE FROM claw_workspace_files WHERE agent_id = ? AND target_path = ?")
+          .run(agentId, file.path);
+      }
+    }
+    if (!complete) {
+      return;
+    }
+    if (clawStateTableExists(db, "claw_package_refs")) {
+      db /* sqlite-allow-raw: release package refs for a removed Claw agent. */
+        .prepare("DELETE FROM claw_package_refs WHERE agent_id = ?")
+        .run(agentId);
+    }
+    if (clawStateTableExists(db, "claw_installs")) {
+      db /* sqlite-allow-raw: remove the completed Claw install owner row. */
+        .prepare("DELETE FROM claw_installs WHERE agent_id = ?")
+        .run(agentId);
+    }
+  }, options);
+}

--- a/src/claws/lifecycle-state-contract.ts
+++ b/src/claws/lifecycle-state-contract.ts
@@ -1,0 +1,92 @@
+import type { PersistedClawCronRef } from "./cron.js";
+import type { ClawManagedFileStatus, RemovedWorkspaceFile } from "./lifecycle-delete-support.js";
+import type { ClawPackageInspection, ClawPackageRemovalResult } from "./package-remove.js";
+import type { PersistedClawInstall } from "./provenance.js";
+import type { CLAW_OUTPUT_STABILITY } from "./types.js";
+
+export const CLAW_STATUS_SCHEMA_VERSION = "openclaw.clawStatus.v1" as const;
+export const CLAW_REMOVE_PLAN_SCHEMA_VERSION = "openclaw.clawRemovePlan.v1" as const;
+export const CLAW_REMOVE_RESULT_SCHEMA_VERSION = "openclaw.clawRemoveResult.v1" as const;
+
+export type ClawStatusRecord = {
+  install: PersistedClawInstall;
+  orphaned?: boolean;
+  agentState: "present" | "modified" | "missing";
+  workspaceFiles: ClawManagedFileStatus[];
+  packages: ClawPackageInspection[];
+  cronJobs: PersistedClawCronRef[];
+};
+
+export type ClawStatusResult = {
+  schemaVersion: typeof CLAW_STATUS_SCHEMA_VERSION;
+  stability: typeof CLAW_OUTPUT_STABILITY;
+  target?: string;
+  records: ClawStatusRecord[];
+  summary: {
+    claws: number;
+    partial: number;
+    missingAgents: number;
+    driftedFiles: number;
+    packageRefs: number;
+    missingPackages: number;
+    driftedPackages: number;
+    incompletePackages: number;
+    cronRefs: number;
+    unresolvedCronRefs: number;
+  };
+};
+
+export type ClawRemovePlanAction = {
+  kind:
+    | "agent"
+    | "configBinding"
+    | "agentAllow"
+    | "workspace"
+    | "agentState"
+    | "sessionIndex"
+    | "sessionTranscripts"
+    | "scheduledJob"
+    | "workspaceFile"
+    | "packageRef"
+    | "cronJob"
+    | "installRecord";
+  id: string;
+  action: "remove" | "delete" | "retain" | "release" | "uninstall" | "trash";
+  target: string;
+  blocked: boolean;
+  reason?: string;
+  details?: Record<string, unknown>;
+};
+
+export type ClawRemovePlan = {
+  schemaVersion: typeof CLAW_REMOVE_PLAN_SCHEMA_VERSION;
+  stability: typeof CLAW_OUTPUT_STABILITY;
+  dryRun: true;
+  mutationAllowed: false;
+  planIntegrity: string;
+  target: string;
+  agentId?: string;
+  actions: ClawRemovePlanAction[];
+  blockers: Array<{ code: string; message: string }>;
+};
+
+export type RemovedCronJob = {
+  manifestId: string;
+  schedulerJobId?: string;
+  action: "removed" | "error";
+  message?: string;
+};
+
+export type ClawRemoveResult = {
+  schemaVersion: typeof CLAW_REMOVE_RESULT_SCHEMA_VERSION;
+  stability: typeof CLAW_OUTPUT_STABILITY;
+  dryRun: false;
+  status: "complete" | "partial";
+  agentId: string;
+  agentRemoved: boolean;
+  workspaceFiles: RemovedWorkspaceFile[];
+  packages: ClawPackageRemovalResult[];
+  cronJobs: RemovedCronJob[];
+  packageRefsReleased: number;
+  error?: { code: string; message: string };
+};

--- a/src/claws/lifecycle-state.test.ts
+++ b/src/claws/lifecycle-state.test.ts
@@ -8,6 +8,7 @@ import {
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
 import { applyClawAddPlan } from "./add.js";
+import { markClawCronRefRemoved } from "./cron.js";
 import { claimClawAgentConfigRemoval } from "./lifecycle-config-removal.js";
 import { applyClawRemovePlan, buildClawRemovePlan, readClawStatus } from "./lifecycle-state.js";
 import { buildClawAddPlan } from "./lifecycle.js";
@@ -24,7 +25,9 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const packageIntegrity = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
-async function fixture(params: { id?: string; name?: string; withFile?: boolean } = {}) {
+async function fixture(
+  params: { id?: string; name?: string; withFile?: boolean; withCron?: boolean } = {},
+) {
   const root = tempDirs.make("openclaw-claw-remove-");
   if (params.withFile) {
     await writeFile(join(root, "SOUL.md"), "managed\n", "utf8");
@@ -33,6 +36,16 @@ async function fixture(params: { id?: string; name?: string; withFile?: boolean 
     schemaVersion: 1,
     agent: { id: params.id ?? "worker", name: "Worker" },
     workspace: params.withFile ? { bootstrapFiles: { "SOUL.md": { source: "SOUL.md" } } } : {},
+    cronJobs: params.withCron
+      ? [
+          {
+            id: "daily-report",
+            schedule: { cron: "0 9 * * *", timezone: "UTC" },
+            session: "isolated",
+            message: "Prepare report",
+          },
+        ]
+      : [],
   });
   if (!parsed.ok) {
     throw new Error(JSON.stringify(parsed.diagnostics));
@@ -55,7 +68,7 @@ async function fixture(params: { id?: string; name?: string; withFile?: boolean 
   return { root, plan, env: { OPENCLAW_STATE_DIR: join(root, "state") } };
 }
 
-async function addFixture(params: { withFile?: boolean } = {}) {
+async function addFixture(params: { withFile?: boolean; withCron?: boolean } = {}) {
   const current = await fixture(params);
   let config: OpenClawConfig = {};
   await applyClawAddPlan(current.plan, {
@@ -64,6 +77,7 @@ async function addFixture(params: { withFile?: boolean } = {}) {
     commitConfig: async (transform) => {
       config = transform(config);
     },
+    cronGateway: { add: async () => ({ id: "scheduler-daily" }) },
   });
   return { ...current, getConfig: () => config };
 }
@@ -300,6 +314,103 @@ describe("Claw status and remove", () => {
     await expect(readFile(join(current.plan.agent.workspace, "SOUL.md"), "utf8")).rejects.toThrow();
     await expect(readClawStatus("worker", { env: current.env, config })).resolves.toMatchObject({
       summary: { claws: 0 },
+    });
+  });
+
+  it("removes scheduler-owned cron jobs before agent config", async () => {
+    const current = await addFixture({ withCron: true });
+    const plan = await buildClawRemovePlan("worker", {
+      env: current.env,
+      config: current.getConfig(),
+    });
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({
+        kind: "cronJob",
+        id: "daily-report",
+        action: "remove",
+        target: "scheduler-daily",
+      }),
+    );
+    let config = current.getConfig();
+    const order: string[] = [];
+    const result = await applyClawRemovePlan(plan, {
+      consentPlanIntegrity: plan.planIntegrity,
+      env: current.env,
+      config,
+      cronGateway: {
+        remove: async (id) => {
+          order.push(`cron:${id}`);
+          return { ok: true };
+        },
+      },
+      commitConfig: async (transform) => {
+        order.push("config");
+        config = transform(config);
+      },
+    });
+    expect(order).toEqual(["cron:scheduler-daily", "config"]);
+    expect(result).toMatchObject({
+      status: "complete",
+      cronJobs: [
+        { manifestId: "daily-report", schedulerJobId: "scheduler-daily", action: "removed" },
+      ],
+    });
+  });
+
+  it("retains the agent when recurring work cannot be disabled", async () => {
+    const current = await addFixture({ withCron: true });
+    const plan = await buildClawRemovePlan("worker", {
+      env: current.env,
+      config: current.getConfig(),
+    });
+    const result = await applyClawRemovePlan(plan, {
+      consentPlanIntegrity: plan.planIntegrity,
+      env: current.env,
+      config: current.getConfig(),
+      cronGateway: {
+        remove: async () => {
+          throw new Error("scheduler unavailable");
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: "partial",
+      agentRemoved: false,
+      error: { code: "cron_cleanup_failed", message: "scheduler unavailable" },
+      cronJobs: [{ manifestId: "daily-report", action: "error" }],
+    });
+  });
+
+  it("finishes local cleanup without repeating a confirmed remote cron removal", async () => {
+    const current = await addFixture({ withCron: true });
+    markClawCronRefRemoved("worker", "daily-report", { env: current.env });
+    const plan = await buildClawRemovePlan("worker", {
+      env: current.env,
+      config: current.getConfig(),
+    });
+    let config = current.getConfig();
+    const remoteRemovals: string[] = [];
+
+    const result = await applyClawRemovePlan(plan, {
+      consentPlanIntegrity: plan.planIntegrity,
+      env: current.env,
+      config,
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+      cronGateway: {
+        remove: async (id) => {
+          remoteRemovals.push(id);
+          return { ok: true };
+        },
+      },
+    });
+
+    expect(remoteRemovals).toEqual([]);
+    expect(result).toMatchObject({
+      status: "complete",
+      cronJobs: [{ manifestId: "daily-report", action: "removed" }],
     });
   });
 

--- a/src/claws/lifecycle-state.test.ts
+++ b/src/claws/lifecycle-state.test.ts
@@ -3,12 +3,13 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizeCronJobCreate } from "../cron/normalize.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
 import { applyClawAddPlan } from "./add.js";
-import { markClawCronRefRemoved } from "./cron.js";
+import { clawCronGatewayInput, markClawCronRefRemoved, readClawCronRefs } from "./cron.js";
 import { claimClawAgentConfigRemoval } from "./lifecycle-config-removal.js";
 import { applyClawRemovePlan, buildClawRemovePlan, readClawStatus } from "./lifecycle-state.js";
 import { buildClawAddPlan } from "./lifecycle.js";
@@ -24,6 +25,20 @@ afterEach(() => closeOpenClawStateDatabaseForTest());
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const packageIntegrity = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+function cronReadView(agentId: string, ref: ReturnType<typeof readClawCronRefs>[number]) {
+  const normalized = normalizeCronJobCreate(clawCronGatewayInput(agentId, ref));
+  if (!normalized || !ref.schedulerJobId) {
+    throw new Error("expected complete cron provenance");
+  }
+  return {
+    ...normalized,
+    id: ref.schedulerJobId,
+    createdAtMs: 1,
+    updatedAtMs: 1,
+    state: {},
+  };
+}
 
 async function fixture(
   params: { id?: string; name?: string; withFile?: boolean; withCron?: boolean } = {},
@@ -338,6 +353,8 @@ describe("Claw status and remove", () => {
       env: current.env,
       config,
       cronGateway: {
+        get: async () =>
+          cronReadView("worker", readClawCronRefs("worker", { env: current.env })[0]!),
         remove: async (id) => {
           order.push(`cron:${id}`);
           return { ok: true };
@@ -368,6 +385,8 @@ describe("Claw status and remove", () => {
       env: current.env,
       config: current.getConfig(),
       cronGateway: {
+        get: async () =>
+          cronReadView("worker", readClawCronRefs("worker", { env: current.env })[0]!),
         remove: async () => {
           throw new Error("scheduler unavailable");
         },
@@ -380,6 +399,35 @@ describe("Claw status and remove", () => {
       error: { code: "cron_cleanup_failed", message: "scheduler unavailable" },
       cronJobs: [{ manifestId: "daily-report", action: "error" }],
     });
+  });
+
+  it("preserves a live cron job that changed after planning", async () => {
+    const current = await addFixture({ withCron: true });
+    const plan = await buildClawRemovePlan("worker", {
+      env: current.env,
+      config: current.getConfig(),
+    });
+    const remove = vi.fn();
+
+    const result = await applyClawRemovePlan(plan, {
+      consentPlanIntegrity: plan.planIntegrity,
+      env: current.env,
+      config: current.getConfig(),
+      cronGateway: {
+        get: async () => ({
+          ...cronReadView("worker", readClawCronRefs("worker", { env: current.env })[0]!),
+          schedule: { kind: "cron", expr: "0 12 * * *", tz: "UTC" },
+        }),
+        remove,
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: "partial",
+      agentRemoved: false,
+      error: { code: "cron_cleanup_failed", message: expect.stringContaining("changed") },
+    });
+    expect(remove).not.toHaveBeenCalled();
   });
 
   it("finishes local cleanup without repeating a confirmed remote cron removal", async () => {

--- a/src/claws/lifecycle-state.test.ts
+++ b/src/claws/lifecycle-state.test.ts
@@ -9,7 +9,7 @@ import {
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
 import { applyClawAddPlan } from "./add.js";
-import { clawCronGatewayInput, markClawCronRefRemoved, readClawCronRefs } from "./cron.js";
+import { markClawCronRefRemoved, readClawCronRefs } from "./cron.js";
 import { claimClawAgentConfigRemoval } from "./lifecycle-config-removal.js";
 import { applyClawRemovePlan, buildClawRemovePlan, readClawStatus } from "./lifecycle-state.js";
 import { buildClawAddPlan } from "./lifecycle.js";
@@ -27,7 +27,29 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const packageIntegrity = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
 function cronReadView(agentId: string, ref: ReturnType<typeof readClawCronRefs>[number]) {
-  const normalized = normalizeCronJobCreate(clawCronGatewayInput(agentId, ref));
+  const job = ref.job;
+  const normalized = normalizeCronJobCreate({
+    name: job.name ?? job.id,
+    declarationKey: ref.declarationKey,
+    ...(job.name ? { displayName: job.name } : {}),
+    owner: { agentId },
+    enabled: true,
+    agentId,
+    schedule: {
+      kind: "cron",
+      expr: job.schedule.cron,
+      ...(job.schedule.timezone ? { tz: job.schedule.timezone } : {}),
+    },
+    sessionTarget: job.session === "main" ? `session:agent:${agentId}:main` : job.session,
+    wakeMode: "now",
+    payload: { kind: "agentTurn", message: job.message },
+    delivery: job.delivery
+      ? {
+          mode: job.delivery.mode,
+          ...(job.delivery.channel ? { channel: job.delivery.channel } : {}),
+        }
+      : { mode: "none" },
+  });
   if (!normalized || !ref.schedulerJobId) {
     throw new Error("expected complete cron provenance");
   }

--- a/src/claws/lifecycle-state.test.ts
+++ b/src/claws/lifecycle-state.test.ts
@@ -315,6 +315,42 @@ describe("Claw status and remove", () => {
     );
   });
 
+  it("does not treat Claw-owned cron jobs as external agent blockers", async () => {
+    const current = await addFixture({ withCron: true });
+    const database = openOpenClawStateDatabase({ env: current.env });
+    database.db
+      .prepare(
+        `INSERT INTO cron_jobs (
+           store_key, job_id, name, enabled, created_at_ms, agent_id, owner_agent_id,
+           schedule_kind, session_target, wake_mode, payload_kind, job_json, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "default",
+        "scheduler-daily",
+        "Claw job",
+        1,
+        1,
+        "worker",
+        "worker",
+        "cron",
+        "isolated",
+        "now",
+        "agentTurn",
+        "{}",
+        1,
+      );
+
+    const plan = await buildClawRemovePlan("worker", {
+      env: current.env,
+      config: current.getConfig(),
+    });
+
+    expect(plan.blockers).not.toContainEqual(
+      expect.objectContaining({ code: "agent_job_attached" }),
+    );
+  });
+
   it("removes the agent and unchanged files but only releases package refs", async () => {
     const current = await addFixture({ withFile: true });
     persistClawPackageRef(
@@ -420,6 +456,38 @@ describe("Claw status and remove", () => {
       agentRemoved: false,
       error: { code: "cron_cleanup_failed", message: "scheduler unavailable" },
       cronJobs: [{ manifestId: "daily-report", action: "error" }],
+    });
+  });
+
+  it("reconciles a lost cron.remove response when the gateway confirms absence", async () => {
+    const current = await addFixture({ withCron: true });
+    const plan = await buildClawRemovePlan("worker", {
+      env: current.env,
+      config: current.getConfig(),
+    });
+    const ref = readClawCronRefs("worker", { env: current.env })[0]!;
+    let present = true;
+    let config = current.getConfig();
+
+    const result = await applyClawRemovePlan(plan, {
+      consentPlanIntegrity: plan.planIntegrity,
+      env: current.env,
+      config,
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+      cronGateway: {
+        get: async () => (present ? cronReadView("worker", ref) : undefined),
+        remove: async () => {
+          present = false;
+          throw new Error("response lost");
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: "complete",
+      cronJobs: [{ manifestId: "daily-report", action: "removed" }],
     });
   });
 

--- a/src/claws/lifecycle-state.ts
+++ b/src/claws/lifecycle-state.ts
@@ -9,6 +9,7 @@ import {
 } from "../state/openclaw-agent-db.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
 import {
+  clawCronGatewayJobMatchesRef,
   deleteClawCronRef,
   markClawCronRefRemoved,
   readClawCronRefs,
@@ -488,7 +489,7 @@ export async function applyClawRemovePlan(
     purgeSessions?: PurgeSessions;
     trashPath?: ClawTrashPath;
     consentPlanIntegrity?: string;
-    cronGateway?: Pick<ClawCronGateway, "remove">;
+    cronGateway?: Pick<ClawCronGateway, "get" | "remove">;
   } = {},
 ): Promise<ClawRemoveResult> {
   if (options.consentPlanIntegrity !== plan.planIntegrity) {
@@ -547,14 +548,20 @@ export async function applyClawRemovePlan(
         `Cron declaration ${JSON.stringify(cron.manifestId)} is not safely removable.`,
       );
     }
-    if (cron.status !== "removed" && !options.cronGateway) {
+    if (cron.status !== "removed" && (!options.cronGateway?.get || !options.cronGateway.remove)) {
       throw new ClawRemoveError(
         "cron_gateway_required",
-        "Claw cron jobs require the gateway-owned cron.remove API.",
+        "Claw cron jobs require the gateway-owned cron.get and cron.remove APIs.",
       );
     }
     try {
       if (cron.status !== "removed") {
+        const live = await options.cronGateway!.get!(cron.schedulerJobId!);
+        if (!clawCronGatewayJobMatchesRef(plan.agentId, cron, live)) {
+          throw new Error(
+            `Cron declaration ${JSON.stringify(cron.manifestId)} changed after planning.`,
+          );
+        }
         await options.cronGateway!.remove(cron.schedulerJobId!);
         markClawCronRefRemoved(plan.agentId, cron.manifestId, options);
       }

--- a/src/claws/lifecycle-state.ts
+++ b/src/claws/lifecycle-state.ts
@@ -3,15 +3,18 @@ import { listAgentEntries } from "../agents/agent-scope.js";
 import { stableStringify } from "../agents/stable-stringify.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { root as fsSafeRoot, FsSafeError } from "../infra/fs-safe.js";
 import {
   closeOpenClawAgentDatabaseByPath,
   resolveOpenClawAgentSqlitePath,
 } from "../state/openclaw-agent-db.js";
+import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
 import {
-  runOpenClawStateWriteTransaction,
-  type OpenClawStateDatabaseOptions,
-} from "../state/openclaw-state-db.js";
+  deleteClawCronRef,
+  markClawCronRefRemoved,
+  readClawCronRefs,
+  type ClawCronGateway,
+  type PersistedClawCronRef,
+} from "./cron.js";
 import {
   claimClawAgentConfigRemoval,
   digestClawAgentConfig,
@@ -20,14 +23,19 @@ import {
 } from "./lifecycle-config-removal.js";
 import {
   clawRemoveQuietRuntime,
-  clawStateTableExists,
+  ClawRemoveError,
   cleanupClawAgentFilesystem,
   deletionEffects,
+  inspectClawWorkspaceFile,
   readAllClawWorkspaceFiles,
   readAttachedCronJobs,
+  releaseClawRemoveRows,
+  removeClawWorkspaceFile,
   synthesizeOrphanInstall,
   workspaceContainsUntrackedEntries,
+  type ClawManagedFileStatus,
   type ClawTrashPath,
+  type RemovedWorkspaceFile,
 } from "./lifecycle-delete-support.js";
 import { projectClawPackageRemovePlan } from "./package-remove-plan.js";
 import {
@@ -46,23 +54,20 @@ import {
   type PersistedClawInstall,
 } from "./provenance.js";
 import { CLAW_OUTPUT_STABILITY } from "./types.js";
-import { readClawWorkspaceFiles, type PersistedClawWorkspaceFile } from "./workspace.js";
+import { readClawWorkspaceFiles } from "./workspace.js";
+
+export { ClawRemoveError } from "./lifecycle-delete-support.js";
 
 const CLAW_STATUS_SCHEMA_VERSION = "openclaw.clawStatus.v1" as const;
 export const CLAW_REMOVE_PLAN_SCHEMA_VERSION = "openclaw.clawRemovePlan.v1" as const;
 export const CLAW_REMOVE_RESULT_SCHEMA_VERSION = "openclaw.clawRemoveResult.v1" as const;
-const MAX_FILE_BYTES = 1024 * 1024;
-
-type ClawManagedFileStatus = PersistedClawWorkspaceFile & {
-  state: "unchanged" | "modified" | "missing" | "unsafe";
-  message?: string;
-};
 type ClawStatusRecord = {
   install: PersistedClawInstall;
   orphaned?: boolean;
   agentState: "present" | "modified" | "missing";
   workspaceFiles: ClawManagedFileStatus[];
   packages: ClawPackageInspection[];
+  cronJobs: PersistedClawCronRef[];
 };
 type ClawStatusResult = {
   schemaVersion: typeof CLAW_STATUS_SCHEMA_VERSION;
@@ -78,6 +83,8 @@ type ClawStatusResult = {
     missingPackages: number;
     driftedPackages: number;
     incompletePackages: number;
+    cronRefs: number;
+    unresolvedCronRefs: number;
   };
 };
 type ClawRemovePlanAction = {
@@ -92,6 +99,7 @@ type ClawRemovePlanAction = {
     | "scheduledJob"
     | "workspaceFile"
     | "packageRef"
+    | "cronJob"
     | "installRecord";
   id: string;
   action: "remove" | "delete" | "retain" | "release" | "uninstall" | "trash";
@@ -111,9 +119,10 @@ type ClawRemovePlan = {
   actions: ClawRemovePlanAction[];
   blockers: Array<{ code: string; message: string }>;
 };
-type RemovedWorkspaceFile = {
-  path: string;
-  action: "deleted" | "missing" | "retainedModified" | "error";
+type RemovedCronJob = {
+  manifestId: string;
+  schedulerJobId?: string;
+  action: "removed" | "error";
   message?: string;
 };
 type ClawRemoveResult = {
@@ -125,44 +134,10 @@ type ClawRemoveResult = {
   agentRemoved: boolean;
   workspaceFiles: RemovedWorkspaceFile[];
   packages: ClawPackageRemovalResult[];
+  cronJobs: RemovedCronJob[];
   packageRefsReleased: number;
   error?: { code: string; message: string };
 };
-
-export class ClawRemoveError extends Error {
-  constructor(
-    readonly code: string,
-    message: string,
-  ) {
-    super(message);
-    this.name = "ClawRemoveError";
-  }
-}
-
-async function inspectFile(record: PersistedClawWorkspaceFile): Promise<ClawManagedFileStatus> {
-  try {
-    const workspace = await fsSafeRoot(record.workspace, {
-      hardlinks: "reject",
-      maxBytes: MAX_FILE_BYTES,
-      symlinks: "reject",
-    });
-    if (!(await workspace.exists(record.path))) {
-      return { ...record, state: "missing" };
-    }
-    const content = await workspace.readBytes(record.path, { maxBytes: MAX_FILE_BYTES });
-    const digest = `sha256:${createHash("sha256").update(content).digest("hex")}`;
-    return { ...record, state: digest === record.contentDigest ? "unchanged" : "modified" };
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return { ...record, state: "missing" };
-    }
-    return {
-      ...record,
-      state: "unsafe",
-      message: error instanceof Error ? error.message : String(error),
-    };
-  }
-}
 
 export async function readClawStatus(
   target?: string,
@@ -217,12 +192,13 @@ export async function readClawStatus(
         : digestClawAgentConfig(agent) === install.agentConfigDigest
           ? "present"
           : "modified",
-      workspaceFiles: await Promise.all(workspaceFiles.map(inspectFile)),
+      workspaceFiles: await Promise.all(workspaceFiles.map(inspectClawWorkspaceFile)),
       packages: await Promise.all(
         packageRefs.map((packageRef) =>
           inspectClawPackage(install, packageRef, options.packageDeps),
         ),
       ),
+      cronJobs: readClawCronRefs(install.agentId, options),
     });
   }
   return {
@@ -247,6 +223,10 @@ export async function readClawStatus(
       incompletePackages: records
         .flatMap((record) => record.packages)
         .filter((pkg) => pkg.state === "incomplete").length,
+      cronRefs: records.flatMap((record) => record.cronJobs).length,
+      unresolvedCronRefs: records
+        .flatMap((record) => record.cronJobs)
+        .filter((cron) => cron.status !== "complete" || !cron.schedulerJobId).length,
     },
   };
 }
@@ -284,6 +264,14 @@ export async function buildClawRemovePlan(
       blockers.push({
         code: "workspace_file_unsafe",
         message: `${file.path}: ${file.message ?? "unsafe file"}`,
+      });
+    }
+  }
+  for (const cron of record?.cronJobs ?? []) {
+    if (cron.status !== "removed" && (cron.status !== "complete" || !cron.schedulerJobId)) {
+      blockers.push({
+        code: "cron_cleanup_uncertain",
+        message: `Cron declaration ${JSON.stringify(cron.manifestId)} has ${cron.status} ownership state and must be reconciled before removal.`,
       });
     }
   }
@@ -437,6 +425,24 @@ export async function buildClawRemovePlan(
       });
     }
     actions.push(...packagePlan.actions);
+    for (const cron of record.cronJobs) {
+      const blocked =
+        cron.status !== "removed" && (cron.status !== "complete" || !cron.schedulerJobId);
+      actions.push({
+        kind: "cronJob",
+        id: cron.manifestId,
+        action: blocked ? "retain" : "remove",
+        target: cron.schedulerJobId ?? cron.declarationKey,
+        blocked,
+        details: {
+          expectedStatus: cron.status,
+          declarationKey: cron.declarationKey,
+          schedulerJobId: cron.schedulerJobId,
+          job: cron.job,
+        },
+        ...(blocked ? { reason: `Cron ownership state is ${cron.status}.` } : {}),
+      });
+    }
     actions.push({
       kind: "installRecord",
       id: record.install.agentId,
@@ -471,70 +477,6 @@ export async function buildClawRemovePlan(
   };
 }
 
-async function removeFile(record: ClawManagedFileStatus): Promise<RemovedWorkspaceFile> {
-  if (record.state === "missing") {
-    return { path: record.path, action: "missing" };
-  }
-  if (record.state === "modified") {
-    return { path: record.path, action: "retainedModified" };
-  }
-  try {
-    const workspace = await fsSafeRoot(record.workspace, {
-      hardlinks: "reject",
-      maxBytes: MAX_FILE_BYTES,
-      symlinks: "reject",
-    });
-    if (!(await workspace.exists(record.path))) {
-      return { path: record.path, action: "missing" };
-    }
-    const stagedPath = `${record.path}.openclaw-claw-remove-${randomUUID()}`;
-    await workspace.move(record.path, stagedPath, { overwrite: false });
-    const content = await workspace.readBytes(stagedPath, { maxBytes: MAX_FILE_BYTES });
-    const digest = `sha256:${createHash("sha256").update(content).digest("hex")}`;
-    if (digest !== record.contentDigest) {
-      await workspace.move(stagedPath, record.path, { overwrite: false });
-      return { path: record.path, action: "retainedModified" };
-    }
-    await workspace.remove(stagedPath);
-    return { path: record.path, action: "deleted" };
-  } catch (error) {
-    return {
-      path: record.path,
-      action: "error",
-      message: error instanceof FsSafeError ? `${error.code}: ${error.message}` : String(error),
-    };
-  }
-}
-function releaseRows(
-  agentId: string,
-  files: RemovedWorkspaceFile[],
-  complete: boolean,
-  options: OpenClawStateDatabaseOptions,
-): void {
-  runOpenClawStateWriteTransaction(({ db }) => {
-    if (clawStateTableExists(db, "claw_workspace_files")) {
-      for (const file of files.filter((candidate) => candidate.action !== "error")) {
-        db /* sqlite-allow-raw: remove one owned Claw workspace-file row. */
-          .prepare("DELETE FROM claw_workspace_files WHERE agent_id = ? AND target_path = ?")
-          .run(agentId, file.path);
-      }
-    }
-    if (!complete) {
-      return;
-    }
-    if (clawStateTableExists(db, "claw_package_refs")) {
-      db /* sqlite-allow-raw: release package refs for a removed Claw agent. */
-        .prepare("DELETE FROM claw_package_refs WHERE agent_id = ?")
-        .run(agentId);
-    }
-    if (clawStateTableExists(db, "claw_installs")) {
-      db /* sqlite-allow-raw: remove the completed Claw install owner row. */
-        .prepare("DELETE FROM claw_installs WHERE agent_id = ?")
-        .run(agentId);
-    }
-  }, options);
-}
-
 type PurgeSessions = (config: OpenClawConfig, agentId: string) => Promise<void>;
 export async function applyClawRemovePlan(
   plan: ClawRemovePlan,
@@ -546,6 +488,7 @@ export async function applyClawRemovePlan(
     purgeSessions?: PurgeSessions;
     trashPath?: ClawTrashPath;
     consentPlanIntegrity?: string;
+    cronGateway?: Pick<ClawCronGateway, "remove">;
   } = {},
 ): Promise<ClawRemoveResult> {
   if (options.consentPlanIntegrity !== plan.planIntegrity) {
@@ -596,6 +539,55 @@ export async function applyClawRemovePlan(
   if (JSON.stringify(plannedPackages) !== JSON.stringify(currentPackages)) {
     throw new ClawRemoveError("remove_changed", "Package ownership changed after remove planning.");
   }
+  const cronJobs: RemovedCronJob[] = [];
+  for (const cron of record.cronJobs) {
+    if (cron.status !== "removed" && (!cron.schedulerJobId || cron.status !== "complete")) {
+      throw new ClawRemoveError(
+        "cron_cleanup_uncertain",
+        `Cron declaration ${JSON.stringify(cron.manifestId)} is not safely removable.`,
+      );
+    }
+    if (cron.status !== "removed" && !options.cronGateway) {
+      throw new ClawRemoveError(
+        "cron_gateway_required",
+        "Claw cron jobs require the gateway-owned cron.remove API.",
+      );
+    }
+    try {
+      if (cron.status !== "removed") {
+        await options.cronGateway!.remove(cron.schedulerJobId!);
+        markClawCronRefRemoved(plan.agentId, cron.manifestId, options);
+      }
+      deleteClawCronRef(plan.agentId, cron.manifestId, options);
+      cronJobs.push({
+        manifestId: cron.manifestId,
+        schedulerJobId: cron.schedulerJobId,
+        action: "removed",
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      cronJobs.push({
+        manifestId: cron.manifestId,
+        schedulerJobId: cron.schedulerJobId,
+        action: "error",
+        message,
+      });
+      updateClawInstallRecordStatus(agentId, "partial", options);
+      return {
+        schemaVersion: CLAW_REMOVE_RESULT_SCHEMA_VERSION,
+        stability: CLAW_OUTPUT_STABILITY,
+        dryRun: false,
+        status: "partial",
+        agentId: plan.agentId,
+        agentRemoved: false,
+        workspaceFiles: [],
+        packages: [],
+        cronJobs,
+        packageRefsReleased: 0,
+        error: { code: "cron_cleanup_failed", message },
+      };
+    }
+  }
   const configRemoval = await claimClawAgentConfigRemoval({
     agentId,
     expectedDigest: record.install.agentConfigDigest,
@@ -643,6 +635,7 @@ export async function applyClawRemovePlan(
       agentRemoved,
       workspaceFiles: [],
       packages,
+      cronJobs,
       packageRefsReleased: 0,
       error: {
         code: "package_cleanup_failed",
@@ -652,7 +645,7 @@ export async function applyClawRemovePlan(
   }
   const workspaceFiles: RemovedWorkspaceFile[] = [];
   for (const file of record.workspaceFiles) {
-    workspaceFiles.push(await removeFile(file));
+    workspaceFiles.push(await removeClawWorkspaceFile(file));
   }
   const cleanupErrors = workspaceFiles
     .filter((file) => file.action === "error")
@@ -679,7 +672,7 @@ export async function applyClawRemovePlan(
   if (!complete) {
     updateClawInstallRecordStatus(agentId, "partial", options);
   }
-  releaseRows(plan.agentId, workspaceFiles, complete, options);
+  releaseClawRemoveRows(plan.agentId, workspaceFiles, complete, options);
   return {
     schemaVersion: CLAW_REMOVE_RESULT_SCHEMA_VERSION,
     stability: CLAW_OUTPUT_STABILITY,
@@ -689,6 +682,7 @@ export async function applyClawRemovePlan(
     agentRemoved,
     workspaceFiles,
     packages,
+    cronJobs,
     packageRefsReleased: complete ? record.packages.length : 0,
     ...(complete
       ? {}

--- a/src/claws/lifecycle-state.ts
+++ b/src/claws/lifecycle-state.ts
@@ -14,7 +14,6 @@ import {
   markClawCronRefRemoved,
   readClawCronRefs,
   type ClawCronGateway,
-  type PersistedClawCronRef,
 } from "./cron.js";
 import {
   claimClawAgentConfigRemoval,
@@ -34,17 +33,25 @@ import {
   removeClawWorkspaceFile,
   synthesizeOrphanInstall,
   workspaceContainsUntrackedEntries,
-  type ClawManagedFileStatus,
   type ClawTrashPath,
   type RemovedWorkspaceFile,
 } from "./lifecycle-delete-support.js";
+import {
+  CLAW_REMOVE_PLAN_SCHEMA_VERSION,
+  CLAW_REMOVE_RESULT_SCHEMA_VERSION,
+  CLAW_STATUS_SCHEMA_VERSION,
+  type ClawRemovePlan,
+  type ClawRemovePlanAction,
+  type ClawRemoveResult,
+  type ClawStatusRecord,
+  type ClawStatusResult,
+  type RemovedCronJob,
+} from "./lifecycle-state-contract.js";
 import { projectClawPackageRemovePlan } from "./package-remove-plan.js";
 import {
   applyClawPackageRemovals,
   inspectClawPackage,
   planClawPackageRemovals,
-  type ClawPackageInspection,
-  type ClawPackageRemovalResult,
   type ClawReferencedCleanup,
   type PackageRemovalDeps,
 } from "./package-remove.js";
@@ -52,93 +59,15 @@ import {
   readClawInstallRecords,
   readClawPackageRefs,
   updateClawInstallRecordStatus,
-  type PersistedClawInstall,
 } from "./provenance.js";
 import { CLAW_OUTPUT_STABILITY } from "./types.js";
 import { readClawWorkspaceFiles } from "./workspace.js";
 
 export { ClawRemoveError } from "./lifecycle-delete-support.js";
-
-const CLAW_STATUS_SCHEMA_VERSION = "openclaw.clawStatus.v1" as const;
-export const CLAW_REMOVE_PLAN_SCHEMA_VERSION = "openclaw.clawRemovePlan.v1" as const;
-export const CLAW_REMOVE_RESULT_SCHEMA_VERSION = "openclaw.clawRemoveResult.v1" as const;
-type ClawStatusRecord = {
-  install: PersistedClawInstall;
-  orphaned?: boolean;
-  agentState: "present" | "modified" | "missing";
-  workspaceFiles: ClawManagedFileStatus[];
-  packages: ClawPackageInspection[];
-  cronJobs: PersistedClawCronRef[];
-};
-type ClawStatusResult = {
-  schemaVersion: typeof CLAW_STATUS_SCHEMA_VERSION;
-  stability: typeof CLAW_OUTPUT_STABILITY;
-  target?: string;
-  records: ClawStatusRecord[];
-  summary: {
-    claws: number;
-    partial: number;
-    missingAgents: number;
-    driftedFiles: number;
-    packageRefs: number;
-    missingPackages: number;
-    driftedPackages: number;
-    incompletePackages: number;
-    cronRefs: number;
-    unresolvedCronRefs: number;
-  };
-};
-type ClawRemovePlanAction = {
-  kind:
-    | "agent"
-    | "configBinding"
-    | "agentAllow"
-    | "workspace"
-    | "agentState"
-    | "sessionIndex"
-    | "sessionTranscripts"
-    | "scheduledJob"
-    | "workspaceFile"
-    | "packageRef"
-    | "cronJob"
-    | "installRecord";
-  id: string;
-  action: "remove" | "delete" | "retain" | "release" | "uninstall" | "trash";
-  target: string;
-  blocked: boolean;
-  reason?: string;
-  details?: Record<string, unknown>;
-};
-type ClawRemovePlan = {
-  schemaVersion: typeof CLAW_REMOVE_PLAN_SCHEMA_VERSION;
-  stability: typeof CLAW_OUTPUT_STABILITY;
-  dryRun: true;
-  mutationAllowed: false;
-  planIntegrity: string;
-  target: string;
-  agentId?: string;
-  actions: ClawRemovePlanAction[];
-  blockers: Array<{ code: string; message: string }>;
-};
-type RemovedCronJob = {
-  manifestId: string;
-  schedulerJobId?: string;
-  action: "removed" | "error";
-  message?: string;
-};
-type ClawRemoveResult = {
-  schemaVersion: typeof CLAW_REMOVE_RESULT_SCHEMA_VERSION;
-  stability: typeof CLAW_OUTPUT_STABILITY;
-  dryRun: false;
-  status: "complete" | "partial";
-  agentId: string;
-  agentRemoved: boolean;
-  workspaceFiles: RemovedWorkspaceFile[];
-  packages: ClawPackageRemovalResult[];
-  cronJobs: RemovedCronJob[];
-  packageRefsReleased: number;
-  error?: { code: string; message: string };
-};
+export {
+  CLAW_REMOVE_PLAN_SCHEMA_VERSION,
+  CLAW_REMOVE_RESULT_SCHEMA_VERSION,
+} from "./lifecycle-state-contract.js";
 
 export async function readClawStatus(
   target?: string,

--- a/src/claws/lifecycle-state.ts
+++ b/src/claws/lifecycle-state.ts
@@ -307,7 +307,7 @@ export async function buildClawRemovePlan(
         .filter((cron) => cron.status !== "removed" && cron.schedulerJobId)
         .map((cron) => cron.schedulerJobId),
     );
-    for (const job of attachedJobs.filter((job) => !ownedSchedulerJobIds.has(job.id))) {
+    for (const job of attachedJobs.filter((candidate) => !ownedSchedulerJobIds.has(candidate.id))) {
       blockers.push({
         code: "agent_job_attached",
         message: `Cron job ${JSON.stringify(job.id)} still references agent ${JSON.stringify(record.install.agentId)}; reassign or remove it first.`,

--- a/src/claws/lifecycle-state.ts
+++ b/src/claws/lifecycle-state.ts
@@ -302,7 +302,12 @@ export async function buildClawRemovePlan(
       record.workspaceFiles.map((file) => file.path),
     );
     const attachedJobs = readAttachedCronJobs(record.install.agentId, options);
-    for (const job of attachedJobs) {
+    const ownedSchedulerJobIds = new Set(
+      record.cronJobs
+        .filter((cron) => cron.status !== "removed" && cron.schedulerJobId)
+        .map((cron) => cron.schedulerJobId),
+    );
+    for (const job of attachedJobs.filter((job) => !ownedSchedulerJobIds.has(job.id))) {
       blockers.push({
         code: "agent_job_attached",
         message: `Cron job ${JSON.stringify(job.id)} still references agent ${JSON.stringify(record.install.agentId)}; reassign or remove it first.`,
@@ -557,12 +562,23 @@ export async function applyClawRemovePlan(
     try {
       if (cron.status !== "removed") {
         const live = await options.cronGateway!.get!(cron.schedulerJobId!);
-        if (!clawCronGatewayJobMatchesRef(plan.agentId, cron, live)) {
+        if (live != null && !clawCronGatewayJobMatchesRef(plan.agentId, cron, live)) {
           throw new Error(
             `Cron declaration ${JSON.stringify(cron.manifestId)} changed after planning.`,
           );
         }
-        await options.cronGateway!.remove(cron.schedulerJobId!);
+        if (live != null) {
+          try {
+            await options.cronGateway!.remove(cron.schedulerJobId!);
+          } catch (removeError) {
+            // A transport failure can lose a successful cron.remove response. Re-read the
+            // gateway before preserving ownership so retries can converge on confirmed absence.
+            const afterRemove = await options.cronGateway!.get!(cron.schedulerJobId!);
+            if (afterRemove != null) {
+              throw removeError;
+            }
+          }
+        }
         markClawCronRefRemoved(plan.agentId, cron.manifestId, options);
       }
       deleteClawCronRef(plan.agentId, cron.manifestId, options);

--- a/src/claws/lifecycle-state.ts
+++ b/src/claws/lifecycle-state.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from "node:crypto";
+import { createHash } from "node:crypto";
 import { listAgentEntries } from "../agents/agent-scope.js";
 import { stableStringify } from "../agents/stable-stringify.js";
 import { getRuntimeConfig } from "../config/config.js";

--- a/src/claws/lifecycle.ts
+++ b/src/claws/lifecycle.ts
@@ -43,7 +43,6 @@ type ClawAddPlanContext = {
   existingAgentIds?: Iterable<string>;
   existingWorkspacePaths?: Iterable<string>;
   existingMcpServerNames?: Iterable<string>;
-  existingCronJobIds?: Iterable<string>;
   packagePreflight?: (
     pkg: ClawPackage,
     workspace: string,
@@ -494,18 +493,8 @@ export async function buildClawAddPlan(params: {
     );
   }
 
-  const existingCronJobIds = new Set(context.existingCronJobIds ?? []);
+  // Strict v1 validation permits only deterministic main or isolated targets.
   for (const job of params.manifest.cronJobs) {
-    const blocked = existingCronJobIds.has(job.id);
-    if (blocked) {
-      blockers.push(
-        blocker(
-          "cron_job_collision",
-          `$.cronJobs.${job.id}`,
-          `Cron job ${JSON.stringify(job.id)} already exists and will not be overwritten.`,
-        ),
-      );
-    }
     actions.push({
       kind: "cronJob",
       id: job.id,
@@ -519,7 +508,7 @@ export async function buildClawAddPlan(params: {
           ? { deliveryResolution: "local-channel-state:last" }
           : {}),
       },
-      blocked,
+      blocked: false,
     });
     capabilityChanges.push(
       capabilityChange({

--- a/src/claws/provenance.test.ts
+++ b/src/claws/provenance.test.ts
@@ -9,6 +9,7 @@ import {
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
 import { applyClawAddPlan, ClawAddMutationError } from "./add.js";
+import { ClawCronInstallError } from "./cron.js";
 import { buildClawAddPlan } from "./lifecycle.js";
 import {
   persistClawPackageRef,
@@ -594,5 +595,54 @@ describe("applyClawAddPlan", () => {
       applyClawAddPlan(plan, { consentPlanIntegrity: "sha256:stale" }),
     ).rejects.toMatchObject({ code: "plan_integrity_mismatch" });
     await expect(access(plan.agent.workspace)).rejects.toThrow();
+  });
+
+  it("returns partial cron ownership when scheduler installation fails", async () => {
+    const { root, plan } = await makePlan({
+      schemaVersion: 1,
+      agent: { id: "worker" },
+      cronJobs: [
+        {
+          id: "daily-report",
+          schedule: { cron: "0 9 * * *", timezone: "UTC" },
+          session: "isolated",
+          message: "Prepare report",
+        },
+      ],
+    });
+    const failedRef = {
+      schemaVersion: "openclaw.clawCronRef.v1" as const,
+      agentId: "worker",
+      manifestId: "daily-report",
+      declarationKey: "claw:worker:daily-report",
+      status: "failed" as const,
+      job: {
+        id: "daily-report",
+        schedule: { cron: "0 9 * * *", timezone: "UTC" },
+        session: "isolated" as const,
+        message: "Prepare report",
+      },
+      error: "gateway unavailable",
+      createdAtMs: 1,
+      updatedAtMs: 2,
+    };
+
+    const result = await applyClawAddPlan(plan, {
+      consentPlanIntegrity: plan.planIntegrity,
+      env: stateEnv(root),
+      commitConfig: async (transform) => {
+        transform({});
+      },
+      installCronJobs: async () => {
+        throw new ClawCronInstallError("cron_install_failed", "gateway unavailable", [failedRef]);
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: "partial",
+      cronJobs: [{ manifestId: "daily-report", status: "failed" }],
+      installRecord: { status: "config_committed" },
+      error: { code: "cron_install_failed", message: "gateway unavailable" },
+    });
   });
 });

--- a/src/claws/schema.test.ts
+++ b/src/claws/schema.test.ts
@@ -574,7 +574,7 @@ describe("buildClawAddPlan", () => {
     );
   });
 
-  it("blocks agent, configured workspace, MCP, and cron collisions", async () => {
+  it("blocks agent, configured workspace, and MCP collisions", async () => {
     const { source, workspace } = await createPlanSource();
     const plan = await buildClawAddPlan({
       manifest: requireManifest(),
@@ -584,7 +584,6 @@ describe("buildClawAddPlan", () => {
         existingAgentIds: ["github-triage"],
         existingWorkspacePaths: [workspace],
         existingMcpServerNames: ["github"],
-        existingCronJobIds: ["weekday-triage"],
       },
     });
 
@@ -594,9 +593,8 @@ describe("buildClawAddPlan", () => {
       "package_install_unavailable",
       "package_install_unavailable",
       "mcp_server_collision",
-      "cron_job_collision",
     ]);
-    expect(plan.summary.blockedActions).toBe(8);
+    expect(plan.summary.blockedActions).toBe(7);
   });
 
   it("canonicalizes a missing workspace through an existing aliased parent", async () => {
@@ -745,5 +743,15 @@ describe("buildClawAddPlan", () => {
     expect(repeated.planIntegrity).toBe(first.planIntegrity);
     expect(changed.planIntegrity).not.toBe(first.planIntegrity);
     expect(changedCapability.planIntegrity).not.toBe(first.planIntegrity);
+  });
+
+  it("rejects current-session cron jobs before planning", () => {
+    const result = parseClawManifest({
+      ...baseManifest,
+      cronJobs: [{ ...baseManifest.cronJobs[0], session: "current" }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0]?.path).toBe("$.cronJobs[0].session");
   });
 });

--- a/src/claws/types.ts
+++ b/src/claws/types.ts
@@ -109,7 +109,7 @@ type ClawRemoteMcpServer = ClawMcpServerCommon & {
 
 type ClawMcpServer = ClawStdioMcpServer | ClawRemoteMcpServer;
 
-type ClawCronJob = {
+export type ClawCronJob = {
   id: string;
   name?: string;
   schedule: {

--- a/src/cli/claws-cli.runtime.ts
+++ b/src/cli/claws-cli.runtime.ts
@@ -434,6 +434,7 @@ export async function runClawsRemoveCommand(
       consentPlanIntegrity: opts.planIntegrity,
       referencedCleanup,
       cronGateway: {
+        get: async (id) => await callGatewayFromCli("cron.get", {}, { id }),
         remove: async (id) => await callGatewayFromCli("cron.remove", {}, { id }),
       },
     });

--- a/src/cli/claws-cli.runtime.ts
+++ b/src/cli/claws-cli.runtime.ts
@@ -48,6 +48,7 @@ import type {
   ClawsRemoveOptions,
   ClawsStatusOptions,
 } from "./claws-cli.js";
+import { callGatewayFromCli } from "./gateway-rpc.js";
 
 type DiagnosticLike = { level: string; code: string; path: string; message: string };
 
@@ -315,6 +316,11 @@ export async function runClawsAddCommand(
     addResult = await applyClawAddPlan(plan, {
       consentPlanIntegrity: opts.planIntegrity,
       runtime: opts.json ? { ...runtime, log: () => undefined } : runtime,
+      cronGateway: {
+        add: async (input) => await callGatewayFromCli("cron.add", {}, input),
+        list: async (agentId) =>
+          await callGatewayFromCli("cron.list", {}, { agentId, includeDisabled: true }),
+      },
     });
   } catch (error) {
     const code = error instanceof ClawAddMutationError ? error.code : "add_failed";
@@ -427,6 +433,9 @@ export async function runClawsRemoveCommand(
     const result = await applyClawRemovePlan(plan, {
       consentPlanIntegrity: opts.planIntegrity,
       referencedCleanup,
+      cronGateway: {
+        remove: async (id) => await callGatewayFromCli("cron.remove", {}, { id }),
+      },
     });
     if (opts.json) {
       writeRuntimeJson(runtime, result);

--- a/src/cli/claws-cli.test.ts
+++ b/src/cli/claws-cli.test.ts
@@ -612,10 +612,10 @@ describe("claws cli", () => {
 
     expect(mocks.applyClawRemovePlan).toHaveBeenCalledWith(
       expect.objectContaining({ planIntegrity: "sha256:remove-plan" }),
-      {
+      expect.objectContaining({
         consentPlanIntegrity: "sha256:remove-plan",
         referencedCleanup: { mode: "retain" },
-      },
+      }),
     );
     expect(JSON.parse(mocks.logs[0] ?? "{}")).toMatchObject({
       schemaVersion: "openclaw.clawRemoveResult.v1",

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -256,6 +256,19 @@ export interface ChannelPairingRequests {
   request_id: string;
 }
 
+export interface ClawCronRefs {
+  agent_id: string;
+  created_at_ms: number;
+  declaration_key: string;
+  error: string | null;
+  job_json: string;
+  manifest_id: string;
+  scheduler_job_id: string | null;
+  schema_version: string;
+  status: string;
+  updated_at_ms: number;
+}
+
 export interface ClawInstalls {
   added_at_ms: number;
   agent_config_digest: string;
@@ -1421,6 +1434,7 @@ export interface DB {
   channel_ingress_events: ChannelIngressEvents;
   channel_pairing_allow_entries: ChannelPairingAllowEntries;
   channel_pairing_requests: ChannelPairingRequests;
+  claw_cron_refs: ClawCronRefs;
   claw_installs: ClawInstalls;
   claw_package_refs: ClawPackageRefs;
   claw_workspace_files: ClawWorkspaceFiles;

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -1992,6 +1992,20 @@ CREATE TABLE IF NOT EXISTS claw_package_refs (
   PRIMARY KEY (agent_id, package_kind, package_source, package_ref, package_version)
 ) STRICT;
 
+CREATE TABLE IF NOT EXISTS claw_cron_refs (
+  agent_id TEXT NOT NULL,
+  manifest_id TEXT NOT NULL,
+  schema_version TEXT NOT NULL,
+  declaration_key TEXT NOT NULL UNIQUE,
+  scheduler_job_id TEXT UNIQUE,
+  status TEXT NOT NULL,
+  job_json TEXT NOT NULL,
+  error TEXT,
+  created_at_ms INTEGER NOT NULL,
+  updated_at_ms INTEGER NOT NULL,
+  PRIMARY KEY (agent_id, manifest_id)
+) STRICT;
+
 CREATE TABLE IF NOT EXISTS outbound_media_provenance (
   realpath TEXT NOT NULL PRIMARY KEY,
   kind TEXT NOT NULL,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -1987,6 +1987,20 @@ CREATE TABLE IF NOT EXISTS claw_package_refs (
   PRIMARY KEY (agent_id, package_kind, package_source, package_ref, package_version)
 ) STRICT;
 
+CREATE TABLE IF NOT EXISTS claw_cron_refs (
+  agent_id TEXT NOT NULL,
+  manifest_id TEXT NOT NULL,
+  schema_version TEXT NOT NULL,
+  declaration_key TEXT NOT NULL UNIQUE,
+  scheduler_job_id TEXT UNIQUE,
+  status TEXT NOT NULL,
+  job_json TEXT NOT NULL,
+  error TEXT,
+  created_at_ms INTEGER NOT NULL,
+  updated_at_ms INTEGER NOT NULL,
+  PRIMARY KEY (agent_id, manifest_id)
+) STRICT;
+
 CREATE TABLE IF NOT EXISTS outbound_media_provenance (
   realpath TEXT NOT NULL PRIMARY KEY,
   kind TEXT NOT NULL,


### PR DESCRIPTION
## Summary  - install grouped Claw cron declarations through the gateway-owned `cron.add` API - persist pending, complete, failed, or removed ownership references keyed by final agent id and declaration id - expose cron ownership in status, round-trip complete declarations through export, and include exact cron state in remove consent - disable Claw-owned recurring work before agent config, package, or workspace cleanup - compose existing OpenClaw config, session, workspace-safety, and trash primitives without changing ordinary agent deletion behavior  ## Contract  - scheduler mutation stays in the gateway; Claws never write the cron store directly - declaration keys are scoped as `claw:<agent-id>:<manifest-job-id>`, so package-local ids do not collide globally - response-lost retries reconcile by declaration key before issuing another `cron.add` - `main` declarations target `session:agent:<final-agent-id>:main`; `isolated` remains isolated, and strict v1 validation rejects other session modes - removal calls `cron.remove` before any agent/config mutation and records partial state if recurring work cannot be proven disabled - Claw removal uses provenance-aware cleanup around shared lower-level OpenClaw primitives; the normal `agents delete` command and gateway behavior are unchanged - the durable install record retains its last completed phase (`config_committed`) when cron installation fails, while the command result is `partial` and includes failed cron provenance for retry/doctor  ## Stack  - RFC: https://github.com/openclaw/rfcs/pull/27 - Depends on: #102306 grouped export - This PR: gateway-owned cron mutation, provenance, status, export, and removal - Next: #102406 validated MCP ownership  All behavior remains gated by `OPENCLAW_EXPERIMENTAL_CLAWS=1`.  ## Validation  - 59 focused cron, provenance, lifecycle, and ordinary agent-delete tests passed at pre-documentation head `344d024f8b5`; current head `739c0325ace` adds only this stage's documentation after restacking - scoped Oxfmt, Oxlint, and `git diff --check`: passed - emitted `cron.add` payload is validated by the gateway protocol validator - fresh GitHub CI is running after correcting the stale type/test fixtures found by the preceding run  ## Real behavior proof  > Signing-history note (2026-07-19): signed-history head `739c0325ace6` is a commit-history-only rewrite of previously tested head `102464b88101`; both resolve to tree `7cdd9df2bed9`. The behavior evidence below remains source-equivalent. This note does not claim a new runtime execution. The lifecycle tests prove consent-bound add, scheduler-id provenance, response-lost reconciliation, status/export visibility, and removal ordering. A scheduler failure returns partial with `agentRemoved: false`; successful removal disables Claw-owned recurring work before the provenance-aware local lifecycle proceeds.  ## Documentation  Extends `/cli/claws` with agent-bound cron declarations and their preview, provenance, status, export, and removal behavior.  ## Independent review refresh (2026-07-19)

Current exact head: `e1c32196fbaa309043e2dce73e7cd19e23140b37`. Internalizes the stage-local cron payload builder and updates its live-job test fixture; runtime behavior is unchanged. Fresh exact-head GitHub CI is authoritative for generated-package and SQLite-backed checks.