### PR TITLE
fix(codex): handle stdout/stderr stream errors in CLI session exec resume

### DIFF
--- a/extensions/codex/src/node-cli-sessions.ts
+++ b/extensions/codex/src/node-cli-sessions.ts
@@ -296,6 +296,8 @@ async function runCodexExecResume(params: {
     child.stdin.end(params.prompt);
     const exitCode = await new Promise<number | null>((resolve, reject) => {
       child.on("error", reject);
+      child.stdout.on("error", reject);
+      child.stderr.on("error", reject);
       child.on("exit", (code) => resolve(code));
     }).finally(() => {
       clearTimeout(timeout);


### PR DESCRIPTION
## What Problem This Solves

The Codex CLI session exec resume handler spawns a child process and pipes `stdout`/`stderr` for data collection, but does not register error handlers on the stdio streams. If a stream errors (e.g. pipe broken, EPIPE), the Promise never settles because only process-level errors (`child.on("error")`) are caught.

Unhandled stream errors can cause uncaught exceptions or leave the Promise hanging indefinitely.

## Why This Change Was Made

Adds `child.stdout.on("error", reject)` and `child.stderr.on("error", reject)` inside the Promise constructor alongside the existing `child.on("error", reject)` to catch stream-level errors.

This follows the same established pattern used by:
- mushuiyu886 #101505: `fix(codex): handle app-server stdio stream errors`
- Alix-007 #101597: `fix(matrix): handle stdout/stderr stream errors in dependency commands`
- cxbAsDev #101401: `fix(imessage): handle CLI child stdout/stderr stream errors`
- masatohoshino #101088: `fix(discord): handle ffmpeg stderr stream errors in voice playback`

## Files Changed

| File | Change |
|------|--------|
| `extensions/codex/src/node-cli-sessions.ts` | +2 lines: `child.stdout.on("error", reject)` + `child.stderr.on("error", reject)` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>