### PR TITLE
fix(codex): handle stdout/stderr stream errors in sandbox exec processes

### DIFF
--- a/extensions/codex/src/app-server/sandbox-exec-server/processes.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/processes.ts
@@ -119,6 +119,12 @@ async function runProcess(
     appendProcessChunk(managed, managed.tty ? "pty" : "stdout", chunk),
   );
   child.stderr.on("data", (chunk: Buffer) => appendProcessChunk(managed, "stderr", chunk));
+  const onStreamError = (error: Error) => {
+    managed.failure = error.message;
+    emitProcessClosed(managed, null);
+  };
+  child.stdout.on("error", onStreamError);
+  child.stderr.on("error", onStreamError);
   child.once("error", (error) => {
     managed.failure = error.message;
     emitProcessClosed(managed, null);

--- a/extensions/codex/src/app-server/sandbox-exec-server/processes.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/processes.ts
@@ -120,6 +120,7 @@ async function runProcess(
   );
   child.stderr.on("data", (chunk: Buffer) => appendProcessChunk(managed, "stderr", chunk));
   const onStreamError = (error: Error) => {
+    if (managed.failure) return;
     managed.failure = error.message;
     emitProcessClosed(managed, null);
   };


### PR DESCRIPTION
## What Problem This Solves

The sandbox exec process spawner (`processes.ts`) registers `child.stdout.on("data")` and `child.stderr.on("data")` handlers but does not register error handlers on the stdio streams. If a pipe errors (e.g. broken pipe, EPIPE), the error is unhandled — only process-level errors (`child.once("error")`) are caught.

## Why This Change Was Made

Adds `child.stdout.on("error", onStreamError)` and `child.stderr.on("error", onStreamError)` handlers that set `managed.failure` and emit process closed, matching the existing `child.once("error")` behavior.

Same pattern as #101505 (mushuiyu886: codex app-server stdio stream errors) and 5+ other merged PRs.

## Files Changed

| File | Change |
|------|--------|
| `extensions/codex/src/app-server/sandbox-exec-server/processes.ts` | +6 lines: stream error handlers |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>