### PR TITLE
fix(codex-supervisor): handle stdout/stderr stream errors in JSON-RPC client

### DIFF
--- a/extensions/codex-supervisor/src/json-rpc-client.ts
+++ b/extensions/codex-supervisor/src/json-rpc-client.ts
@@ -195,6 +195,8 @@ class StdioCodexJsonRpcConnection extends BaseCodexJsonRpcConnection {
       this.stderrTail.splice(0, Math.max(0, this.stderrTail.length - 40));
     });
     this.proc.stdin.once("error", (error) => this.fail(error));
+    this.proc.stdout.on("error", (error) => this.fail(error));
+    this.proc.stderr.on("error", (error) => this.fail(error));
     this.proc.once("error", (error) => this.fail(error));
     this.proc.once("close", () =>
       this.fail(


### PR DESCRIPTION
## What Problem This Solves

The `StdioCodexJsonRpcConnection` registers `data` handlers on `proc.stdout` and `proc.stderr`, plus error handlers on `proc.stdin` and the process itself (`proc.once("error")`), but does not register error handlers on the stdout or stderr streams. If either stream errors (e.g. pipe broken, EPIPE), the error is unhandled and the JSON-RPC connection may hang silently.

## Why This Change Was Made

Adds `this.proc.stdout.on("error", ...)` and `this.proc.stderr.on("error", ...)` that call `this.fail(error)`, matching the existing stdin and process-level error handling.

Same stream error handler pattern as #101505, #101597, #101401, #101088, #102385, and #102386.

## Files Changed

| File | Change |
|------|--------|
| `extensions/codex-supervisor/src/json-rpc-client.ts` | +2 lines: stdout/stderr error handlers |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>