### PR TITLE
fix(web-fetch): report exact-limit response bodies as complete, not truncated [AI-assisted]

### DIFF
--- a/src/agents/tools/web-shared.test.ts
+++ b/src/agents/tools/web-shared.test.ts
@@ -147,6 +147,60 @@ describe("readResponseText", () => {
     expect(releaseLock).toHaveBeenCalledTimes(1);
   });
 
+  it("does not mark exact-limit streamed responses as truncated", async () => {
+    const cancel = vi.fn(async () => undefined);
+    const releaseLock = vi.fn();
+    const response = responseFromReader({
+      chunks: ["hello"],
+      cancel,
+      releaseLock,
+    });
+
+    await expect(readResponseText(response, { maxBytes: 5 })).resolves.toEqual({
+      text: "hello",
+      truncated: false,
+      bytesRead: 5,
+    });
+    expect(cancel).not.toHaveBeenCalled();
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not mark multi-chunk exact-limit streamed responses as truncated", async () => {
+    const cancel = vi.fn(async () => undefined);
+    const releaseLock = vi.fn();
+    const response = responseFromReader({
+      chunks: ["hel", "lo"],
+      cancel,
+      releaseLock,
+    });
+
+    await expect(readResponseText(response, { maxBytes: 5 })).resolves.toEqual({
+      text: "hello",
+      truncated: false,
+      bytesRead: 5,
+    });
+    expect(cancel).not.toHaveBeenCalled();
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks responses that exceed the limit as truncated after confirming overflow", async () => {
+    const cancel = vi.fn(async () => undefined);
+    const releaseLock = vi.fn();
+    const response = responseFromReader({
+      chunks: ["hello", "!"],
+      cancel,
+      releaseLock,
+    });
+
+    await expect(readResponseText(response, { maxBytes: 5 })).resolves.toEqual({
+      text: "hello",
+      truncated: true,
+      bytesRead: 5,
+    });
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
   it("does not invoke whole-body fallbacks when maxBytes is set", async () => {
     const arrayBuffer = vi.fn(async () => new TextEncoder().encode("hello").buffer);
     const text = vi.fn(async () => "hello");

--- a/src/agents/tools/web-shared.test.ts
+++ b/src/agents/tools/web-shared.test.ts
@@ -23,14 +23,26 @@ function responseFromReader(params: {
   chunks: string[];
   cancel: () => Promise<void>;
   releaseLock: () => void;
+  readError?: Error;
 }): Response {
   const chunks: Array<ReadableStreamReadResult<Uint8Array>> = params.chunks.map((chunk) => ({
     done: false,
     value: new TextEncoder().encode(chunk),
   }));
-  chunks.push({ done: true, value: undefined });
+  if (!params.readError) {
+    chunks.push({ done: true, value: undefined });
+  }
   const reader = {
-    read: async () => chunks.shift() ?? { done: true, value: undefined },
+    read: async () => {
+      const next = chunks.shift();
+      if (next) {
+        return next;
+      }
+      if (params.readError) {
+        throw params.readError;
+      }
+      return { done: true, value: undefined };
+    },
     cancel: params.cancel,
     releaseLock: params.releaseLock,
   } as ReadableStreamDefaultReader<Uint8Array>;
@@ -216,6 +228,25 @@ describe("readResponseText", () => {
       bytesRead: 5,
     });
     expect(cancel).not.toHaveBeenCalled();
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps exact-limit responses truncated when the confirming read fails", async () => {
+    const cancel = vi.fn(async () => undefined);
+    const releaseLock = vi.fn();
+    const response = responseFromReader({
+      chunks: ["hello"],
+      cancel,
+      releaseLock,
+      readError: new Error("stream failed before EOF"),
+    });
+
+    await expect(readResponseText(response, { maxBytes: 5 })).resolves.toEqual({
+      text: "hello",
+      truncated: true,
+      bytesRead: 5,
+    });
+    expect(cancel).toHaveBeenCalledTimes(1);
     expect(releaseLock).toHaveBeenCalledTimes(1);
   });
 

--- a/src/agents/tools/web-shared.test.ts
+++ b/src/agents/tools/web-shared.test.ts
@@ -201,6 +201,24 @@ describe("readResponseText", () => {
     expect(releaseLock).toHaveBeenCalledTimes(1);
   });
 
+  it("does not mark exact-limit responses as truncated when followed by zero-byte chunks", async () => {
+    const cancel = vi.fn(async () => undefined);
+    const releaseLock = vi.fn();
+    const response = responseFromReader({
+      chunks: ["hello", ""],
+      cancel,
+      releaseLock,
+    });
+
+    await expect(readResponseText(response, { maxBytes: 5 })).resolves.toEqual({
+      text: "hello",
+      truncated: false,
+      bytesRead: 5,
+    });
+    expect(cancel).not.toHaveBeenCalled();
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
   it("does not invoke whole-body fallbacks when maxBytes is set", async () => {
     const arrayBuffer = vi.fn(async () => new TextEncoder().encode("hello").buffer);
     const text = vi.fn(async () => "hello");

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -272,8 +272,17 @@ export async function readResponseText(
         bytesRead += chunk.byteLength;
         parts.push(chunk);
 
-        if (truncated || bytesRead >= maxBytes) {
-          truncated = true;
+        if (truncated) {
+          break;
+        }
+        if (bytesRead >= maxBytes) {
+          // Reached the byte cap. A body that is exactly maxBytes bytes is
+          // complete, not truncated; only report truncation when an
+          // additional read confirms the body continues past the limit.
+          const { done: atEnd } = await reader.read();
+          if (!atEnd) {
+            truncated = true;
+          }
           break;
         }
       }

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -277,12 +277,13 @@ export async function readResponseText(
         }
         if (bytesRead >= maxBytes) {
           // Reached the byte cap. A body that is exactly maxBytes bytes is
-          // complete, not truncated; only mark truncation when a non-empty
-          // chunk confirms the body continues past the limit. Zero-byte
-          // chunks are skipped to match the read loop above.
+          // complete only once EOF confirms it. Keep the conservative result
+          // if that confirming read fails or the body continues.
+          truncated = true;
           while (true) {
             const { done: atEnd, value: extra } = await reader.read();
             if (atEnd) {
+              truncated = false;
               break;
             }
             if (extra && extra.byteLength > 0) {

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -277,11 +277,18 @@ export async function readResponseText(
         }
         if (bytesRead >= maxBytes) {
           // Reached the byte cap. A body that is exactly maxBytes bytes is
-          // complete, not truncated; only report truncation when an
-          // additional read confirms the body continues past the limit.
-          const { done: atEnd } = await reader.read();
-          if (!atEnd) {
-            truncated = true;
+          // complete, not truncated; only mark truncation when a non-empty
+          // chunk confirms the body continues past the limit. Zero-byte
+          // chunks are skipped to match the read loop above.
+          while (true) {
+            const { done: atEnd, value: extra } = await reader.read();
+            if (atEnd) {
+              break;
+            }
+            if (extra && extra.byteLength > 0) {
+              truncated = true;
+              break;
+            }
           }
           break;
         }


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

Closes #101837

## What Problem This Solves

Fixes an issue where `web_fetch` reported a response as truncated ("Response body truncated after `<maxResponseBytes>` bytes") even when the streamed body was exactly `maxResponseBytes` long and no bytes were omitted. The shared `readResponseText` helper marked any read that reached the byte cap as `truncated`, without confirming the body actually continued past the limit. As a result, agents/users saw a misleading truncation warning and complete content was treated as source-truncated for exact-size responses.

## Why This Change Was Made

The boundary check in `readResponseText` (`src/agents/tools/web-shared.ts`) treated `bytesRead >= maxBytes` as truncation. That conflates "we filled the cap" with "there was more data than the cap". The fix separates the two: a real overflow (a chunk that exceeds the cap, already handled by the slice path) still marks `truncated`; reaching the cap exactly now performs a confirm-read loop that skips zero-byte chunks (matching the read loop's empty-chunk semantics) and only marks `truncated` when a non-empty chunk confirms the body continues past the limit. The user-visible `web_fetch` warning and spill behavior consume this flag, so the fix is localized to the shared helper - `web-fetch.ts` already propagates the flag correctly and needs no change.

## User Impact

Agents and users calling `web_fetch` against responses whose body size exactly matches the configured `maxResponseBytes` no longer receive a false "Response body truncated" warning, and that content is no longer treated as source-truncated. Oversized responses are still correctly reported as truncated (behavior unchanged).

## Evidence

**Real behavior proof** - a local HTTP endpoint whose response body is exactly `maxResponseBytes` (5 bytes; `maxBytes: 5`), exercised through a real `fetch` and the real `readResponseText`:

Before fix (current `main`):

```
real HTTP GET http://127.0.0.1:<port>/ -> body=5 bytes, maxBytes=5 => truncated=true bytesRead=5 text="hello"
```

After fix (this branch):

```
real HTTP GET http://127.0.0.1:<port>/ -> body=5 bytes, maxBytes=5 => truncated=false bytesRead=5 text="hello"
```

The exact-size body is now reported complete (`truncated: false`); a body exceeding the limit is still reported truncated.

Regression coverage added to `src/agents/tools/web-shared.test.ts` (all pass on this branch; the exact-limit and zero-byte-after-cap cases fail on `main`):

- exact-limit single-chunk (`["hello"]`, maxBytes 5) -> not truncated
- exact-limit multi-chunk (`["hel","lo"]`, maxBytes 5) -> not truncated
- exact-limit followed by a zero-byte chunk then EOF (`["hello",""]`, maxBytes 5) -> not truncated
- overflow past the limit (`["hello","!"]`, maxBytes 5) -> truncated (confirms real overflow is still detected)

Consumer suites that depend on the truncation flag remain green: `web-fetch.test.ts` (14 passed), `provider-http-errors.test.ts` (13 passed). `pnpm tsgo` (CI typecheck), `oxlint`, and `oxfmt` are clean on the changed files.

## Human Verification

- Confirmed the boundary defect on current `main`: `readResponseText` marks `truncated` when `bytesRead >= maxBytes` without confirming overflow (`src/agents/tools/web-shared.ts`).
- Verified the user-visible behavior change against a real local HTTP endpoint returning exactly `maxResponseBytes` bytes: before fix `truncated=true`, after fix `truncated=false` (captured above).
- Verified before=fail / after=pass via the added regression tests, including the zero-byte-chunk-after-cap case (the confirm-read skips empty chunks before deciding truncation, so a stream that yields an empty chunk after the cap and then EOF is still reported complete).
- Confirmed existing truncation/overflow behavior is preserved: single-chunk overflow via the existing slice path, multi-chunk overflow via the new confirm-read loop.
- Not verified: macOS/iOS not tested; Swift host-env-policy check skipped on Windows; production network `web_fetch` not exercised.

## Compatibility / Migration

No API, config, or CLI changes. The only behavioral change is that exact-size response bodies are no longer falsely flagged as truncated. Callers that branch on `bodyResult.truncated` now correctly see `false` for complete exact-size bodies.

## Failure Recovery

Revert the two commits. No migration or state changes are involved.
