### PR TITLE
fix(tool-call-repair): parse JSON-format plain-text tool calls alongside bracket/XML/Harmony

### DIFF
--- a/packages/tool-call-repair/src/json-tool-call.ts
+++ b/packages/tool-call-repair/src/json-tool-call.ts
@@ -1,0 +1,391 @@
+// JSON-shaped plain-text tool-call parsing shared by payload promotion,
+// stream buffering, and visible-text stripping paths.
+
+import { consumeLineBreak, skipLineIndentation, skipWhitespace } from "./grammar.js";
+import type {
+  PlainTextJsonToolCallState,
+  PlainTextToolCallBlock,
+  PlainTextToolCallParseOptions,
+} from "./payload.js";
+
+export { type PlainTextToolCallBlock, type PlainTextToolCallParseOptions } from "./payload.js";
+
+export const DEFAULT_MAX_PLAIN_TEXT_TOOL_PAYLOAD_BYTES = 256_000;
+
+/** Structural JSON-object scanner shared by parsing, stripping, and stream buffering. */
+export function scanJsonObject(
+  text: string,
+  start: number,
+): {
+  end: number;
+  kind: "complete" | "prefix";
+  state: PlainTextJsonToolCallState;
+} {
+  let depth = 0;
+  let escaped = false;
+  let inString = false;
+  for (let index = start; index < text.length; index += 1) {
+    const char = text[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+    } else if (char === "{") {
+      depth += 1;
+    } else if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return {
+          kind: "complete",
+          end: index + 1,
+          state: { depth, escaped, inString },
+        };
+      }
+    }
+  }
+  return { kind: "prefix", end: text.length, state: { depth, escaped, inString } };
+}
+
+// Recognizes a flat JSON object that carries a tool-name + arguments pair,
+// matching the same shapes that detectToolCallShapedText already classifies
+// as "json_tool_call".
+function readJsonToolName(record: Record<string, unknown>): string | undefined {
+  const name = record.name;
+  if (typeof name === "string" && name.trim()) {
+    return name.trim();
+  }
+  const alt = record.tool_name ?? record.tool ?? record.function_name;
+  if (typeof alt === "string" && alt.trim()) {
+    return alt.trim();
+  }
+  return undefined;
+}
+
+function hasJsonToolArgs(record: Record<string, unknown>): boolean {
+  return "arguments" in record || "args" in record || "input" in record || "parameters" in record;
+}
+
+function readJsonToolArguments(record: Record<string, unknown>): Record<string, unknown> | null {
+  for (const key of ["arguments", "args", "input", "parameters"]) {
+    const val = record[key];
+    if (val === undefined || val === null) {
+      continue;
+    }
+    if (typeof val === "string") {
+      try {
+        const parsed = JSON.parse(val);
+        // Align with parseJsonArguments: only non-array objects are valid
+        // argument records. No _value coercion — invalid or array-shaped
+        // JSON must not become executable tool-call input.
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          return parsed as Record<string, unknown>;
+        }
+        return null;
+      } catch {
+        return null;
+      }
+    }
+    // Only non-array objects are valid argument records.
+    if (typeof val === "object" && !Array.isArray(val)) {
+      return val as Record<string, unknown>;
+    }
+    return null;
+  }
+  return null;
+}
+
+function extractJsonToolCallNameAndArgs(
+  record: Record<string, unknown>,
+  options?: PlainTextToolCallParseOptions,
+): { name: string; arguments: Record<string, unknown> }[] {
+  const allowedToolNames = options?.allowedToolNames
+    ? new Set(options.allowedToolNames)
+    : undefined;
+
+  // Format 1: {"tool_calls": [...]} — OpenAI wrapper.
+  // Every entry must parse atomically: if any entry is malformed or lacks
+  // valid arguments, the entire wrapper is rejected so we never silently
+  // drop a model-emitted call while consuming the wrapper text.
+  const toolCalls = record.tool_calls ?? record.toolCalls;
+  if (Array.isArray(toolCalls) && toolCalls.length > 0) {
+    const results: { name: string; arguments: Record<string, unknown> }[] = [];
+    for (const entry of toolCalls) {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        return [];
+      }
+      const tc = entry as Record<string, unknown>;
+      let name: string | undefined;
+      let args: Record<string, unknown> | null = null;
+      const fn = tc.function;
+      if (fn && typeof fn === "object" && !Array.isArray(fn)) {
+        const fnRecord = fn as Record<string, unknown>;
+        name = readJsonToolName(fnRecord);
+        if (name && (!allowedToolNames || allowedToolNames.has(name))) {
+          args = readJsonToolArguments(fnRecord);
+        }
+      }
+      if (!name || !args) {
+        name = readJsonToolName(tc);
+        if (name && (!allowedToolNames || allowedToolNames.has(name))) {
+          args = readJsonToolArguments(tc);
+        }
+      }
+      if (!name || !args) {
+        return [];
+      }
+      results.push({ name, arguments: args });
+    }
+    return results;
+  }
+
+  // Format 2: {"function": {"name": "...", "arguments": {...}}}
+  const functionRecord = record.function;
+  if (functionRecord && typeof functionRecord === "object" && !Array.isArray(functionRecord)) {
+    const fn = functionRecord as Record<string, unknown>;
+    const name = readJsonToolName(fn);
+    if (name && (!allowedToolNames || allowedToolNames.has(name))) {
+      const args = readJsonToolArguments(fn);
+      if (args) {
+        return [{ name, arguments: args }];
+      }
+    }
+  }
+
+  // Format 3: {"name": "...", "arguments": {...}}
+  const flatName = readJsonToolName(record);
+  if (flatName && hasJsonToolArgs(record)) {
+    if (!allowedToolNames || allowedToolNames.has(flatName)) {
+      const args = readJsonToolArguments(record);
+      if (args) {
+        return [{ name: flatName, arguments: args }];
+      }
+    }
+  }
+
+  // Format 4: {"name": "...", "type": "tool_call", ...}
+  const type = typeof record.type === "string" ? record.type.trim().toLowerCase() : "";
+  if (
+    flatName &&
+    (type === "tool_call" ||
+      type === "toolcall" ||
+      type === "tooluse" ||
+      type === "tool_use" ||
+      type === "function_call" ||
+      type === "functioncall")
+  ) {
+    if (!allowedToolNames || allowedToolNames.has(flatName)) {
+      const args = readJsonToolArguments(record);
+      if (args) {
+        return [{ name: flatName, arguments: args }];
+      }
+    }
+  }
+
+  return [];
+}
+
+export function parseJsonToolCallBlocksAt(
+  text: string,
+  start: number,
+  options?: PlainTextToolCallParseOptions,
+): PlainTextToolCallBlock[] | null {
+  const cursor = skipWhitespace(text, start);
+  if (text[cursor] !== "{") {
+    return null;
+  }
+  const maxPayloadBytes = options?.maxPayloadBytes ?? DEFAULT_MAX_PLAIN_TEXT_TOOL_PAYLOAD_BYTES;
+  const json = scanJsonObject(text, cursor);
+  if (json.kind !== "complete") {
+    return null;
+  }
+  // Enforce the UTF-8 byte limit on the raw payload before parsing so
+  // multibyte characters cannot smuggle a payload past the char-length guard
+  // in scanJsonObject.
+  const rawJson = text.slice(cursor, json.end);
+  if (Buffer.byteLength(rawJson, "utf8") > maxPayloadBytes) {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawJson);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+  const results = extractJsonToolCallNameAndArgs(parsed as Record<string, unknown>, options);
+  if (results.length === 0) {
+    return null;
+  }
+  return results.map((result) => ({
+    arguments: result.arguments,
+    end: json.end,
+    name: result.name,
+    raw: rawJson,
+    start: cursor,
+  }));
+}
+
+// Returns the exclusive end offset of a standalone JSON tool-call block, or null
+// when the JSON object at `start` is not an actual tool call. The stripper calls
+// this to decide whether a line-start JSON object should be removed from visible
+// text, so we must validate tool-call shape — ordinary JSON prose must survive.
+export function parseJsonToolCallBlockEndAt(text: string, start: number): number | null {
+  const blocks = parseJsonToolCallBlocksAt(text, start);
+  if (!blocks || blocks.length === 0) {
+    return null;
+  }
+  return blocks[0]!.end;
+}
+
+// Pre-scan helper for stripPlainTextToolCallBlocks: only strip JSON tool-call
+// objects when every non-blank line is a JSON tool-call block. When a line-start
+// JSON object like {"name":"read","arguments":{"path":"/tmp"}} sits next to
+// ordinary prose, it is a user-visible example and must be preserved.
+// Bracket / XML / Harmony blocks are not gated because their syntax is
+// unambiguous tool-call markup that users do not naturally type.
+export function shouldStripJsonBlocks(text: string): boolean {
+  let foundJsonBlock = false;
+  let probe = 0;
+  while (probe < text.length) {
+    const ls = probe === 0 || text[probe - 1] === "\n" || text[probe - 1] === "\r";
+    if (!ls) {
+      probe += 1;
+      continue;
+    }
+    const bs = skipLineIndentation(text, probe);
+    const je = parseJsonToolCallBlockEndAt(text, bs);
+    if (je !== null) {
+      foundJsonBlock = true;
+      probe = je;
+      const lb = consumeLineBreak(text, probe);
+      if (lb !== null) {
+        probe = lb;
+      }
+      continue;
+    }
+    // This line is not a JSON tool-call. Check for visible content.
+    let hasContent = false;
+    for (let i = bs; i < text.length && text[i] !== "\n" && text[i] !== "\r"; i++) {
+      if (text[i] !== " " && text[i] !== "\t") {
+        hasContent = true;
+        break;
+      }
+    }
+    if (hasContent) {
+      return false;
+    }
+    const nl = text.indexOf("\n", probe);
+    if (nl === -1) {
+      break;
+    }
+    probe = nl + 1;
+  }
+  return foundJsonBlock;
+}
+
+// Fast heuristic: does partial JSON text resemble a tool-call object?
+// When stream chunks start with `{` at line start we must decide whether to
+// buffer (withhold from visible text) or emit immediately.  Buffering a
+// false positive is cheap — the classifyPending gate replays non-tool-call
+// JSON once the object completes.
+export function looksLikeJsonToolCall(text: string): boolean {
+  return (
+    text.includes('"name"') ||
+    text.includes('"tool_calls"') ||
+    text.includes('"toolCalls"') ||
+    text.includes('"function"') ||
+    text.includes('"tool_name"') ||
+    text.includes('"function_name"')
+  );
+}
+
+// Stream-level JSON tool-call classification shared with the stream normalizer.
+// When the buffered candidate starts with `{`, validate and classify: complete
+// JSON that is a recognized tool call is kept for terminal promotion; incomplete
+// JSON is held until the next chunk; non-tool-call JSON is replayed as text so
+// ordinary JSON prose is never dropped.
+export function tryClassifyJsonBuffer(
+  text: string,
+  bufferBytes: number,
+  maxPayloadBytes: number,
+):
+  | { kind: "complete" }
+  | { kind: "false-positive" }
+  | { kind: "incomplete" }
+  | {
+      kind: "stripped";
+      text: string;
+    }
+  | null {
+  const jsonStart = skipLineIndentation(text, 0);
+  if (text[jsonStart] !== "{") {
+    return null;
+  }
+  const json = scanJsonObject(text, jsonStart);
+  if (json.kind === "prefix") {
+    return bufferBytes > maxPayloadBytes ? { kind: "false-positive" } : { kind: "incomplete" };
+  }
+  // Complete JSON object — validate shape before trying to parse blocks.
+  // looksLikeJsonToolCall is the cheap pre-filter; parseJsonToolCallBlocksAt
+  // does the full structural validation including argument presence.
+  if (looksLikeJsonToolCall(text.slice(jsonStart))) {
+    const blocks = parseJsonToolCallBlocksAt(text, jsonStart);
+    if (blocks !== null && blocks.length > 0) {
+      const afterJson = skipWhitespace(text, json.end);
+      if (afterJson < text.length) {
+        // Trailing text after a complete JSON tool call.  The normalizer
+        // may duplicate the buffer when a suppress→candidate transition
+        // re-appends the same chunk; treat the stronger leading match as
+        // authoritative instead of yielding the trailing copy as text.
+        const trailingJsonStart = skipLineIndentation(text, afterJson);
+        if (
+          text[trailingJsonStart] === "{" &&
+          parseJsonToolCallBlocksAt(text, trailingJsonStart) !== null
+        ) {
+          return { kind: "complete" };
+        }
+        return { kind: "stripped", text: text.slice(afterJson) };
+      }
+      if (jsonStart > 0) {
+        return { kind: "stripped", text: text.slice(0, jsonStart) };
+      }
+      return { kind: "complete" };
+    }
+  }
+  // Complete JSON that is not a recognized tool call — replay as text.
+  return { kind: "false-positive" };
+}
+
+// Stream event helpers shared with the stream normalizer.
+
+export function eventTemplate(event: Record<string, unknown>): Record<string, unknown> {
+  const template = { ...event };
+  delete template.content;
+  delete template.delta;
+  delete template.partial;
+  return template;
+}
+
+export function createSyntheticTextDelta(
+  template: Record<string, unknown>,
+  text: string,
+  partial?: Record<string, unknown>,
+): Record<string, unknown> {
+  const event = eventTemplate(template);
+  return {
+    ...event,
+    type: "text_delta",
+    delta: text,
+    ...(partial ? { partial } : {}),
+  };
+}

--- a/packages/tool-call-repair/src/payload.test.ts
+++ b/packages/tool-call-repair/src/payload.test.ts
@@ -187,4 +187,51 @@ describe("stripPlainTextToolCallBlocks", () => {
     expect(stripPlainTextToolCallBlocks(tracked.text)).toBe(raw);
     expect(tracked.indexedReads).toBeLessThan(raw.length * 16);
   });
+
+  it("preserves JSON tool-call examples embedded in ordinary prose", () => {
+    const raw = [
+      "Here is the expected format:",
+      '{"name":"read","arguments":{"path":"/tmp"}}',
+      "Copy this template, replacing the path with your file.",
+    ].join("\n");
+
+    expect(stripPlainTextToolCallBlocks(raw)).toBe(raw);
+  });
+
+  it("strips a standalone JSON tool-call object", () => {
+    const raw = '{"name":"read","arguments":{"path":"/tmp"}}';
+
+    const result = stripPlainTextToolCallBlocks(raw);
+
+    expect(result.trim()).toBe("");
+  });
+
+  it("strips multiple adjacent standalone JSON tool-call objects", () => {
+    const raw = [
+      '{"name":"read","arguments":{"path":"/tmp"}}',
+      '{"name":"write","arguments":{"path":"/out","content":"hello"}}',
+    ].join("\n");
+
+    const result = stripPlainTextToolCallBlocks(raw);
+
+    expect(result.trim()).toBe("");
+  });
+
+  it("preserves a JSON object without tool-call shape in prose", () => {
+    // {"status":"ok"} has no name + arguments pair, so it is not a tool call.
+    const raw = 'Extraction complete: {"status":"ok","count":42}';
+
+    expect(stripPlainTextToolCallBlocks(raw)).toBe(raw);
+  });
+
+  it("preserves JSON examples even when one line is a standalone call", () => {
+    // The first line is a JSON tool-call object; the second line is prose.
+    // The mixed prose gate prevents JSON stripping for the entire block.
+    const raw = [
+      '{"name":"read","arguments":{"path":"/tmp"}}',
+      "Then the tool returns the file contents.",
+    ].join("\n");
+
+    expect(stripPlainTextToolCallBlocks(raw)).toBe(raw);
+  });
 });

--- a/packages/tool-call-repair/src/payload.ts
+++ b/packages/tool-call-repair/src/payload.ts
@@ -14,6 +14,13 @@ import {
   type StructuralLineBreakOptions,
   utf8ByteLengthWithinLimit,
 } from "./grammar.js";
+import {
+  DEFAULT_MAX_PLAIN_TEXT_TOOL_PAYLOAD_BYTES,
+  parseJsonToolCallBlocksAt,
+  parseJsonToolCallBlockEndAt,
+  scanJsonObject,
+  shouldStripJsonBlocks,
+} from "./json-tool-call.js";
 
 /** Parsed standalone plain-text tool call block with source offsets for repair. */
 export type PlainTextToolCallBlock = {
@@ -42,7 +49,6 @@ type NormalizedPlainTextToolCallParseOptions = Omit<
   "allowedToolNames"
 > & { allowedToolNames?: ReadonlySet<string> };
 
-const DEFAULT_MAX_PLAIN_TEXT_TOOL_PAYLOAD_BYTES = 256_000;
 const MAX_PLAIN_TEXT_TOOL_NAME_CHARS = 120;
 const HARMONY_CHANNELS = ["commentary", "analysis", "final"] as const;
 
@@ -268,47 +274,6 @@ function scanHarmonyOpening(text: string, start: number): PlainTextJsonToolCallO
     return { kind: "invalid", at: cursor, candidate: value };
   }
   return { kind: "complete", cursor, value };
-}
-
-export function scanJsonObject(
-  text: string,
-  start: number,
-): {
-  end: number;
-  kind: "complete" | "prefix";
-  state: PlainTextJsonToolCallState;
-} {
-  let depth = 0;
-  let escaped = false;
-  let inString = false;
-  for (let index = start; index < text.length; index += 1) {
-    const char = text[index];
-    if (inString) {
-      if (escaped) {
-        escaped = false;
-      } else if (char === "\\") {
-        escaped = true;
-      } else if (char === '"') {
-        inString = false;
-      }
-      continue;
-    }
-    if (char === '"') {
-      inString = true;
-    } else if (char === "{") {
-      depth += 1;
-    } else if (char === "}") {
-      depth -= 1;
-      if (depth === 0) {
-        return {
-          kind: "complete",
-          end: index + 1,
-          state: { depth, escaped, inString },
-        };
-      }
-    }
-  }
-  return { kind: "prefix", end: text.length, state: { depth, escaped, inString } };
 }
 
 /** Uncapped structural scan shared by parsing, stripping, and stream buffering. */
@@ -567,199 +532,6 @@ function parseJsonArguments(
     : null;
 }
 
-// Recognizes a flat JSON object that carries a tool-name + arguments pair,
-// matching the same shapes that detectToolCallShapedText already classifies
-// as "json_tool_call".
-function readJsonToolName(record: Record<string, unknown>): string | undefined {
-  const name = record.name;
-  if (typeof name === "string" && name.trim()) {
-    return name.trim();
-  }
-  const alt = record.tool_name ?? record.tool ?? record.function_name;
-  if (typeof alt === "string" && alt.trim()) {
-    return alt.trim();
-  }
-  return undefined;
-}
-
-function hasJsonToolArgs(record: Record<string, unknown>): boolean {
-  return "arguments" in record || "args" in record || "input" in record || "parameters" in record;
-}
-
-function readJsonToolArguments(record: Record<string, unknown>): Record<string, unknown> | null {
-  for (const key of ["arguments", "args", "input", "parameters"]) {
-    const val = record[key];
-    if (val === undefined || val === null) {
-      continue;
-    }
-    if (typeof val === "string") {
-      try {
-        const parsed = JSON.parse(val);
-        // Align with parseJsonArguments: only non-array objects are valid
-        // argument records. No _value coercion — invalid or array-shaped
-        // JSON must not become executable tool-call input.
-        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-          return parsed as Record<string, unknown>;
-        }
-        return null;
-      } catch {
-        return null;
-      }
-    }
-    // Only non-array objects are valid argument records.
-    if (typeof val === "object" && !Array.isArray(val)) {
-      return val as Record<string, unknown>;
-    }
-    return null;
-  }
-  return null;
-}
-
-function extractJsonToolCallNameAndArgs(
-  record: Record<string, unknown>,
-  options?: PlainTextToolCallParseOptions,
-): { name: string; arguments: Record<string, unknown> }[] {
-  const allowedToolNames = options?.allowedToolNames
-    ? new Set(options.allowedToolNames)
-    : undefined;
-
-  // Format 1: {"tool_calls": [...]} — OpenAI wrapper.
-  // Every entry must parse atomically: if any entry is malformed or lacks
-  // valid arguments, the entire wrapper is rejected so we never silently
-  // drop a model-emitted call while consuming the wrapper text.
-  const toolCalls = record.tool_calls ?? record.toolCalls;
-  if (Array.isArray(toolCalls) && toolCalls.length > 0) {
-    const results: { name: string; arguments: Record<string, unknown> }[] = [];
-    for (const entry of toolCalls) {
-      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
-        return [];
-      }
-      const tc = entry as Record<string, unknown>;
-      let name: string | undefined;
-      let args: Record<string, unknown> | null = null;
-      const fn = tc.function;
-      if (fn && typeof fn === "object" && !Array.isArray(fn)) {
-        const fnRecord = fn as Record<string, unknown>;
-        name = readJsonToolName(fnRecord);
-        if (name && (!allowedToolNames || allowedToolNames.has(name))) {
-          args = readJsonToolArguments(fnRecord);
-        }
-      }
-      if (!name || !args) {
-        name = readJsonToolName(tc);
-        if (name && (!allowedToolNames || allowedToolNames.has(name))) {
-          args = readJsonToolArguments(tc);
-        }
-      }
-      if (!name || !args) {
-        return [];
-      }
-      results.push({ name, arguments: args });
-    }
-    return results;
-  }
-
-  // Format 2: {"function": {"name": "...", "arguments": {...}}}
-  const functionRecord = record.function;
-  if (functionRecord && typeof functionRecord === "object" && !Array.isArray(functionRecord)) {
-    const fn = functionRecord as Record<string, unknown>;
-    const name = readJsonToolName(fn);
-    if (name && (!allowedToolNames || allowedToolNames.has(name))) {
-      const args = readJsonToolArguments(fn);
-      if (args) {
-        return [{ name, arguments: args }];
-      }
-    }
-  }
-
-  // Format 3: {"name": "...", "arguments": {...}}
-  const flatName = readJsonToolName(record);
-  if (flatName && hasJsonToolArgs(record)) {
-    if (!allowedToolNames || allowedToolNames.has(flatName)) {
-      const args = readJsonToolArguments(record);
-      if (args) {
-        return [{ name: flatName, arguments: args }];
-      }
-    }
-  }
-
-  // Format 4: {"name": "...", "type": "tool_call", ...}
-  const type = typeof record.type === "string" ? record.type.trim().toLowerCase() : "";
-  if (
-    flatName &&
-    (type === "tool_call" ||
-      type === "toolcall" ||
-      type === "tooluse" ||
-      type === "tool_use" ||
-      type === "function_call" ||
-      type === "functioncall")
-  ) {
-    if (!allowedToolNames || allowedToolNames.has(flatName)) {
-      const args = readJsonToolArguments(record);
-      if (args) {
-        return [{ name: flatName, arguments: args }];
-      }
-    }
-  }
-
-  return [];
-}
-
-export function parseJsonToolCallBlocksAt(
-  text: string,
-  start: number,
-  options?: PlainTextToolCallParseOptions,
-): PlainTextToolCallBlock[] | null {
-  const cursor = skipWhitespace(text, start);
-  if (text[cursor] !== "{") {
-    return null;
-  }
-  const maxPayloadBytes = options?.maxPayloadBytes ?? DEFAULT_MAX_PLAIN_TEXT_TOOL_PAYLOAD_BYTES;
-  const json = scanJsonObject(text, cursor);
-  if (json.kind !== "complete") {
-    return null;
-  }
-  // Enforce the UTF-8 byte limit on the raw payload before parsing so
-  // multibyte characters cannot smuggle a payload past the char-length guard
-  // in scanJsonObject.
-  const rawJson = text.slice(cursor, json.end);
-  if (Buffer.byteLength(rawJson, "utf8") > maxPayloadBytes) {
-    return null;
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(rawJson);
-  } catch {
-    return null;
-  }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return null;
-  }
-  const results = extractJsonToolCallNameAndArgs(parsed as Record<string, unknown>, options);
-  if (results.length === 0) {
-    return null;
-  }
-  return results.map((result) => ({
-    arguments: result.arguments,
-    end: json.end,
-    name: result.name,
-    raw: rawJson,
-    start: cursor,
-  }));
-}
-
-// Returns the exclusive end offset of a standalone JSON tool-call block, or null
-// when the JSON object at `start` is not an actual tool call. The stripper calls
-// this to decide whether a line-start JSON object should be removed from visible
-// text, so we must validate tool-call shape — ordinary JSON prose must survive.
-function parseJsonToolCallBlockEndAt(text: string, start: number): number | null {
-  const blocks = parseJsonToolCallBlocksAt(text, start);
-  if (!blocks || blocks.length === 0) {
-    return null;
-  }
-  return blocks[0]!.end;
-}
-
 function extractXmlishParameterValue(
   text: string,
   start: number,
@@ -902,43 +674,7 @@ export function stripPlainTextToolCallBlocks(text: string): string {
   // prose, it is a user-visible example and must be preserved.
   // Bracket / XML / Harmony blocks are not gated because their syntax is
   // unambiguous tool-call markup that users do not naturally type.
-  let stripJson = false;
-  let probe = 0;
-  while (probe < text.length) {
-    const ls = probe === 0 || text[probe - 1] === "\n" || text[probe - 1] === "\r";
-    if (!ls) {
-      probe += 1;
-      continue;
-    }
-    const bs = skipLineIndentation(text, probe);
-    const je = parseJsonToolCallBlockEndAt(text, bs);
-    if (je !== null) {
-      stripJson = true;
-      probe = je;
-      const lb = consumeLineBreak(text, probe);
-      if (lb !== null) {
-        probe = lb;
-      }
-      continue;
-    }
-    // This line is not a JSON tool-call. Check for visible content.
-    let hasContent = false;
-    for (let i = bs; i < text.length && text[i] !== "\n" && text[i] !== "\r"; i++) {
-      if (text[i] !== " " && text[i] !== "\t") {
-        hasContent = true;
-        break;
-      }
-    }
-    if (hasContent) {
-      stripJson = false;
-      break;
-    }
-    const nl = text.indexOf("\n", probe);
-    if (nl === -1) {
-      break;
-    }
-    probe = nl + 1;
-  }
+  const stripJson = shouldStripJsonBlocks(text);
   let result = "";
   let cursor = 0;
   let index = 0;

--- a/packages/tool-call-repair/src/payload.ts
+++ b/packages/tool-call-repair/src/payload.ts
@@ -270,7 +270,7 @@ function scanHarmonyOpening(text: string, start: number): PlainTextJsonToolCallO
   return { kind: "complete", cursor, value };
 }
 
-function scanJsonObject(
+export function scanJsonObject(
   text: string,
   start: number,
 ): {
@@ -705,7 +705,7 @@ function extractJsonToolCallNameAndArgs(
   return [];
 }
 
-function parseJsonToolCallBlocksAt(
+export function parseJsonToolCallBlocksAt(
   text: string,
   start: number,
   options?: PlainTextToolCallParseOptions,

--- a/packages/tool-call-repair/src/payload.ts
+++ b/packages/tool-call-repair/src/payload.ts
@@ -567,6 +567,199 @@ function parseJsonArguments(
     : null;
 }
 
+// Recognizes a flat JSON object that carries a tool-name + arguments pair,
+// matching the same shapes that detectToolCallShapedText already classifies
+// as "json_tool_call".
+function readJsonToolName(record: Record<string, unknown>): string | undefined {
+  const name = record.name;
+  if (typeof name === "string" && name.trim()) {
+    return name.trim();
+  }
+  const alt = record.tool_name ?? record.tool ?? record.function_name;
+  if (typeof alt === "string" && alt.trim()) {
+    return alt.trim();
+  }
+  return undefined;
+}
+
+function hasJsonToolArgs(record: Record<string, unknown>): boolean {
+  return "arguments" in record || "args" in record || "input" in record || "parameters" in record;
+}
+
+function readJsonToolArguments(record: Record<string, unknown>): Record<string, unknown> | null {
+  for (const key of ["arguments", "args", "input", "parameters"]) {
+    const val = record[key];
+    if (val === undefined || val === null) {
+      continue;
+    }
+    if (typeof val === "string") {
+      try {
+        const parsed = JSON.parse(val);
+        // Align with parseJsonArguments: only non-array objects are valid
+        // argument records. No _value coercion — invalid or array-shaped
+        // JSON must not become executable tool-call input.
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          return parsed as Record<string, unknown>;
+        }
+        return null;
+      } catch {
+        return null;
+      }
+    }
+    // Only non-array objects are valid argument records.
+    if (typeof val === "object" && !Array.isArray(val)) {
+      return val as Record<string, unknown>;
+    }
+    return null;
+  }
+  return null;
+}
+
+function extractJsonToolCallNameAndArgs(
+  record: Record<string, unknown>,
+  options?: PlainTextToolCallParseOptions,
+): { name: string; arguments: Record<string, unknown> }[] {
+  const allowedToolNames = options?.allowedToolNames
+    ? new Set(options.allowedToolNames)
+    : undefined;
+
+  // Format 1: {"tool_calls": [...]} — OpenAI wrapper.
+  // Every entry must parse atomically: if any entry is malformed or lacks
+  // valid arguments, the entire wrapper is rejected so we never silently
+  // drop a model-emitted call while consuming the wrapper text.
+  const toolCalls = record.tool_calls ?? record.toolCalls;
+  if (Array.isArray(toolCalls) && toolCalls.length > 0) {
+    const results: { name: string; arguments: Record<string, unknown> }[] = [];
+    for (const entry of toolCalls) {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        return [];
+      }
+      const tc = entry as Record<string, unknown>;
+      let name: string | undefined;
+      let args: Record<string, unknown> | null = null;
+      const fn = tc.function;
+      if (fn && typeof fn === "object" && !Array.isArray(fn)) {
+        const fnRecord = fn as Record<string, unknown>;
+        name = readJsonToolName(fnRecord);
+        if (name && (!allowedToolNames || allowedToolNames.has(name))) {
+          args = readJsonToolArguments(fnRecord);
+        }
+      }
+      if (!name || !args) {
+        name = readJsonToolName(tc);
+        if (name && (!allowedToolNames || allowedToolNames.has(name))) {
+          args = readJsonToolArguments(tc);
+        }
+      }
+      if (!name || !args) {
+        return [];
+      }
+      results.push({ name, arguments: args });
+    }
+    return results;
+  }
+
+  // Format 2: {"function": {"name": "...", "arguments": {...}}}
+  const functionRecord = record.function;
+  if (functionRecord && typeof functionRecord === "object" && !Array.isArray(functionRecord)) {
+    const fn = functionRecord as Record<string, unknown>;
+    const name = readJsonToolName(fn);
+    if (name && (!allowedToolNames || allowedToolNames.has(name))) {
+      const args = readJsonToolArguments(fn);
+      if (args) {
+        return [{ name, arguments: args }];
+      }
+    }
+  }
+
+  // Format 3: {"name": "...", "arguments": {...}}
+  const flatName = readJsonToolName(record);
+  if (flatName && hasJsonToolArgs(record)) {
+    if (!allowedToolNames || allowedToolNames.has(flatName)) {
+      const args = readJsonToolArguments(record);
+      if (args) {
+        return [{ name: flatName, arguments: args }];
+      }
+    }
+  }
+
+  // Format 4: {"name": "...", "type": "tool_call", ...}
+  const type = typeof record.type === "string" ? record.type.trim().toLowerCase() : "";
+  if (
+    flatName &&
+    (type === "tool_call" ||
+      type === "toolcall" ||
+      type === "tooluse" ||
+      type === "tool_use" ||
+      type === "function_call" ||
+      type === "functioncall")
+  ) {
+    if (!allowedToolNames || allowedToolNames.has(flatName)) {
+      const args = readJsonToolArguments(record);
+      if (args) {
+        return [{ name: flatName, arguments: args }];
+      }
+    }
+  }
+
+  return [];
+}
+
+function parseJsonToolCallBlocksAt(
+  text: string,
+  start: number,
+  options?: PlainTextToolCallParseOptions,
+): PlainTextToolCallBlock[] | null {
+  const cursor = skipWhitespace(text, start);
+  if (text[cursor] !== "{") {
+    return null;
+  }
+  const maxPayloadBytes = options?.maxPayloadBytes ?? DEFAULT_MAX_PLAIN_TEXT_TOOL_PAYLOAD_BYTES;
+  const json = scanJsonObject(text, cursor);
+  if (json.kind !== "complete") {
+    return null;
+  }
+  // Enforce the UTF-8 byte limit on the raw payload before parsing so
+  // multibyte characters cannot smuggle a payload past the char-length guard
+  // in scanJsonObject.
+  const rawJson = text.slice(cursor, json.end);
+  if (Buffer.byteLength(rawJson, "utf8") > maxPayloadBytes) {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawJson);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+  const results = extractJsonToolCallNameAndArgs(parsed as Record<string, unknown>, options);
+  if (results.length === 0) {
+    return null;
+  }
+  return results.map((result) => ({
+    arguments: result.arguments,
+    end: json.end,
+    name: result.name,
+    raw: rawJson,
+    start: cursor,
+  }));
+}
+
+// Returns the exclusive end offset of a standalone JSON tool-call block, or null
+// when the JSON object at `start` is not an actual tool call. The stripper calls
+// this to decide whether a line-start JSON object should be removed from visible
+// text, so we must validate tool-call shape — ordinary JSON prose must survive.
+function parseJsonToolCallBlockEndAt(text: string, start: number): number | null {
+  const blocks = parseJsonToolCallBlocksAt(text, start);
+  if (!blocks || blocks.length === 0) {
+    return null;
+  }
+  return blocks[0]!.end;
+}
+
 function extractXmlishParameterValue(
   text: string,
   start: number,
@@ -665,6 +858,16 @@ export function parseStandalonePlainTextToolCallBlocks(
   const normalizedOptions = normalizeParseOptions(options);
   let cursor = skipWhitespace(text, 0);
   while (cursor < text.length) {
+    // Try JSON parser first — a single JSON object may produce multiple blocks
+    // for OpenAI-style tool_calls wrappers with more than one entry.
+    const jsonBlocks = parseJsonToolCallBlocksAt(text, cursor, options);
+    if (jsonBlocks) {
+      for (const block of jsonBlocks) {
+        blocks.push(block);
+      }
+      cursor = skipWhitespace(text, jsonBlocks[0]!.end);
+      continue;
+    }
     const block = parsePlainTextToolCallBlockAtAnySyntax(
       text,
       cursor,
@@ -688,9 +891,53 @@ export function stripPlainTextToolCallBlocks(text: string): string {
       !/(?:^|[\r\n])[^\S\r\n]*(?:<\|channel\|>)?(?:commentary|analysis|final)[ \t]+to=/.test(
         text,
       ) &&
-      !/(?:^|[\r\n])[^\S\r\n]*<function=/i.test(text))
+      !/(?:^|[\r\n])[^\S\r\n]*<function=/i.test(text) &&
+      !/[{]/.test(text))
   ) {
     return text;
+  }
+  // Pre-scan: only strip JSON tool-call objects when every non-blank line
+  // is a JSON tool-call block. When a line-start JSON object like
+  // {"name":"read","arguments":{"path":"/tmp"}} sits next to ordinary
+  // prose, it is a user-visible example and must be preserved.
+  // Bracket / XML / Harmony blocks are not gated because their syntax is
+  // unambiguous tool-call markup that users do not naturally type.
+  let stripJson = false;
+  let probe = 0;
+  while (probe < text.length) {
+    const ls = probe === 0 || text[probe - 1] === "\n" || text[probe - 1] === "\r";
+    if (!ls) {
+      probe += 1;
+      continue;
+    }
+    const bs = skipLineIndentation(text, probe);
+    const je = parseJsonToolCallBlockEndAt(text, bs);
+    if (je !== null) {
+      stripJson = true;
+      probe = je;
+      const lb = consumeLineBreak(text, probe);
+      if (lb !== null) {
+        probe = lb;
+      }
+      continue;
+    }
+    // This line is not a JSON tool-call. Check for visible content.
+    let hasContent = false;
+    for (let i = bs; i < text.length && text[i] !== "\n" && text[i] !== "\r"; i++) {
+      if (text[i] !== " " && text[i] !== "\t") {
+        hasContent = true;
+        break;
+      }
+    }
+    if (hasContent) {
+      stripJson = false;
+      break;
+    }
+    const nl = text.indexOf("\n", probe);
+    if (nl === -1) {
+      break;
+    }
+    probe = nl + 1;
   }
   let result = "";
   let cursor = 0;
@@ -702,6 +949,20 @@ export function stripPlainTextToolCallBlocks(text: string): string {
       continue;
     }
     const blockStart = skipLineIndentation(text, index);
+    // Try standalone JSON first — validates tool-call shape so ordinary JSON
+    // prose like {"name":"read","status":"ok"} survives the strip.
+    // Gated by the pre-scan so JSON examples in ordinary prose are preserved.
+    const jsonBlockEnd = stripJson ? parseJsonToolCallBlockEndAt(text, blockStart) : null;
+    if (jsonBlockEnd !== null) {
+      result += text.slice(cursor, index);
+      cursor = jsonBlockEnd;
+      const afterBlockLineBreak = consumeLineBreak(text, cursor);
+      if (afterBlockLineBreak !== null) {
+        cursor = afterBlockLineBreak;
+      }
+      index = cursor;
+      continue;
+    }
     const scan = scanPlainTextToolCall(text, blockStart);
     if (scan.kind === "prefix" && scan.completeEnd === undefined) {
       return result + text.slice(cursor);

--- a/packages/tool-call-repair/src/stream-normalizer.test.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.test.ts
@@ -1199,6 +1199,100 @@ describe("normalizePlainTextToolCallStreamEvents over-cap XML", () => {
       expect(deltas).toEqual([]);
     });
 
+    it("buffers JSON split before the shape key so no prefix is leaked", async () => {
+      // First chunk ends before the "name" key — `{"na` — so
+      // looksLikeJsonToolCall is false on the initial fragment.
+      // The normalizer must still buffer the candidate, not leak
+      // the prefix as visible text, and wait for the complete shape.
+      const raw = '{"name":"read","arguments":{"path":"/tmp"}}';
+      // Split right after the opening brace + quote: `{"na`
+      const split = 4;
+      const events = await normalize([
+        textDelta(raw.slice(0, split), raw.slice(0, split)),
+        textDelta(raw.slice(split), raw),
+      ]);
+
+      const deltas = textDeltas(events);
+      expect(deltas).toEqual([]);
+    });
+
+    it("buffers JSON split inside the shape key so no prefix is leaked", async () => {
+      // First chunk ends inside the "name" key — `{"name` — so
+      // the quoted key is incomplete.  The normalizer must buffer
+      // the partial JSON and not leak it as visible text.
+      const raw = '{"name":"read","arguments":{"path":"/tmp"}}';
+      // Split inside the key: `{"name`
+      const split = 6;
+      const events = await normalize([
+        textDelta(raw.slice(0, split), raw.slice(0, split)),
+        textDelta(raw.slice(split), raw),
+      ]);
+
+      const deltas = textDeltas(events);
+      expect(deltas).toEqual([]);
+    });
+
+    it("buffers JSON split before shape key with multi-chunk completion", async () => {
+      // Three chunks: first ends before key (`{"na`), second
+      // completes the object, third is an empty text_end.  No
+      // raw JSON must leak as text_delta at any point.
+      const raw = '{"name":"read","arguments":{"path":"/tmp"}}';
+      const split1 = 4; // `{"na`
+      const split2 = Math.floor(raw.length / 2);
+      const events = await normalize([
+        textDelta(raw.slice(0, split1), raw.slice(0, split1)),
+        textDelta(raw.slice(split1, split2), raw.slice(0, split2)),
+        textDelta(raw.slice(split2), raw),
+      ]);
+
+      const deltas = textDeltas(events);
+      expect(deltas).toEqual([]);
+    });
+
+    it("promotes JSON split before shape key at terminal done without raw leak", async () => {
+      // The full flow: split chunks + terminal done.  The promoted
+      // tool call must execute without any raw JSON text_delta leak.
+      const raw = '{"name":"read","arguments":{"path":"/tmp"}}';
+      const split = 4; // `{"na`
+      const promotedMessage = {
+        role: "assistant",
+        content: [{ type: "toolCall", name: "read", arguments: { path: "/tmp" } }],
+        stopReason: "toolUse",
+      };
+      async function* source() {
+        yield textDelta(raw.slice(0, split), raw.slice(0, split));
+        yield textDelta(raw.slice(split), raw);
+        yield {
+          type: "done",
+          reason: "stop",
+          message: { role: "assistant", content: textContent(raw), stopReason: "stop" },
+        };
+      }
+      const events: Record<string, unknown>[] = [];
+      for await (const event of normalizePlainTextToolCallStreamEvents(source(), {
+        matcher,
+        createPromotedToolCallEvents: () => [],
+        normalizeTerminalMessage: () => ({
+          kind: "promoted",
+          message: promotedMessage,
+          sourceToProjectedContentIndex: new Map(),
+        }),
+      })) {
+        events.push(event as Record<string, unknown>);
+      }
+
+      const deltaTexts = textDeltas(events);
+      const rawJsonLeaked = deltaTexts.some(
+        (d) => typeof d === "string" && d.includes('"path":"/tmp"'),
+      );
+      expect(rawJsonLeaked).toBe(false);
+      expect(events.at(-1)).toMatchObject({
+        type: "done",
+        reason: "toolUse",
+        message: promotedMessage,
+      });
+    });
+
     it("buffers a complete bare JSON tool-call object in one chunk", async () => {
       const raw = '{"name":"read","arguments":{"path":"/tmp"}}';
       const events = await normalize([textDelta(raw, raw)]);

--- a/packages/tool-call-repair/src/stream-normalizer.test.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.test.ts
@@ -1183,4 +1183,162 @@ describe("normalizePlainTextToolCallStreamEvents over-cap XML", () => {
 
     expect(events).toEqual([]);
   });
+
+  describe("bare JSON tool-call stream buffering", () => {
+    it("buffers a bare JSON tool-call chunk so it is never leaked as text_delta", async () => {
+      // Stream a JSON tool-call object split across two chunks.
+      // Neither chunk should appear in the text_delta output.
+      const raw = '{"name":"read","arguments":{"path":"/tmp"}}';
+      const half = Math.floor(raw.length / 2);
+      const events = await normalize([
+        textDelta(raw.slice(0, half), raw.slice(0, half)),
+        textDelta(raw.slice(half), raw),
+      ]);
+
+      const deltas = textDeltas(events);
+      expect(deltas).toEqual([]);
+    });
+
+    it("buffers a complete bare JSON tool-call object in one chunk", async () => {
+      const raw = '{"name":"read","arguments":{"path":"/tmp"}}';
+      const events = await normalize([textDelta(raw, raw)]);
+
+      const deltas = textDeltas(events);
+      expect(deltas).toEqual([]);
+    });
+
+    it("yields non-tool-call JSON prose as visible text", async () => {
+      // {"status":"ok"} contains no tool-call name or arguments keys.
+      const raw = 'Extraction complete: {"status":"ok","count":42}';
+      const events = await normalize([textDelta(raw, raw)]);
+
+      const deltas = textDeltas(events);
+      expect(deltas).toEqual([raw]);
+    });
+
+    it("yields name-only JSON (no arguments) as visible text", async () => {
+      // {"name":"read","status":"ok"} has a name but no arguments —
+      // not a valid tool call, must pass through as prose.
+      const raw = '{"name":"read","status":"ok"}';
+      const events = await normalize([textDelta(raw, raw)]);
+
+      const deltas = textDeltas(events);
+      expect(deltas).toEqual([raw]);
+    });
+
+    it("yields plain JSON object without tool shape as visible text", async () => {
+      const raw = '{"city":"Beijing","temp":25}';
+      const events = await normalize([textDelta(raw, raw)]);
+
+      const deltas = textDeltas(events);
+      expect(deltas).toEqual([raw]);
+    });
+
+    it("buffers a tool_calls wrapper across multiple chunks", async () => {
+      const raw = '{"tool_calls":[{"function":{"name":"read","arguments":{"path":"/tmp"}}}]}';
+      const half = Math.floor(raw.length / 2);
+      const events = await normalize([
+        textDelta(raw.slice(0, half), raw.slice(0, half)),
+        textDelta(raw.slice(half), raw),
+      ]);
+
+      const deltas = textDeltas(events);
+      expect(deltas).toEqual([]);
+    });
+
+    it("promotes a buffered bare JSON tool call at terminal done", async () => {
+      const raw = '{"name":"read","arguments":{"path":"/tmp"}}';
+      async function* source() {
+        yield textDelta(raw, raw);
+        yield {
+          type: "done",
+          reason: "stop",
+          message: { role: "assistant", content: textContent(raw), stopReason: "stop" },
+        };
+      }
+      const promotedMessage = {
+        role: "assistant",
+        content: [{ type: "toolCall", name: "read", arguments: { path: "/tmp" } }],
+        stopReason: "toolUse",
+      };
+      const events: Record<string, unknown>[] = [];
+      for await (const event of normalizePlainTextToolCallStreamEvents(source(), {
+        matcher,
+        createPromotedToolCallEvents: () => [],
+        normalizeTerminalMessage: () => ({
+          kind: "promoted",
+          message: promotedMessage,
+          sourceToProjectedContentIndex: new Map(),
+        }),
+      })) {
+        events.push(event as Record<string, unknown>);
+      }
+
+      // No raw JSON text_delta leaked; done carries the promoted tool-call.
+      // The promoted message itself contains the arguments — that is expected.
+      // What must NOT happen is a text_delta event with the raw JSON payload.
+      const deltaTexts = textDeltas(events);
+      const rawJsonLeaked = deltaTexts.some(
+        (d) => typeof d === "string" && d.includes('"path":"/tmp"'),
+      );
+      expect(rawJsonLeaked).toBe(false);
+      expect(events.at(-1)).toMatchObject({
+        type: "done",
+        reason: "toolUse",
+        message: promotedMessage,
+      });
+    });
+
+    it("buffers a multi-call tool_calls wrapper without leaking entries as text", async () => {
+      const raw =
+        '{"tool_calls":[{"function":{"name":"read","arguments":{"path":"a"}}},{"function":{"name":"write","arguments":{"path":"b"}}}]}';
+      const third = Math.floor(raw.length / 3);
+      const events = await normalize([
+        textDelta(raw.slice(0, third), raw.slice(0, third)),
+        textDelta(raw.slice(third, third * 2), raw.slice(0, third * 2)),
+        textDelta(raw.slice(third * 2), raw),
+      ]);
+
+      const deltas = textDeltas(events);
+      expect(deltas).toEqual([]);
+    });
+
+    it("replays buffered non-tool-call JSON as false-positive at done", async () => {
+      // A JSON object that looks tool-call-like (has "name") but lacks
+      // valid arguments.  The stream heuristic buffers it, classifyPending
+      // validates, and the done path replays it as text.
+      const raw = '{"name":"read","status":"ok"}';
+      const events = await normalize([
+        textDelta(raw.slice(0, -1), raw.slice(0, -1)),
+        textDelta(raw.slice(-1), raw),
+        {
+          type: "done",
+          reason: "stop",
+          message: { role: "assistant", content: textContent(raw), stopReason: "stop" },
+        },
+      ]);
+
+      // The scrubbed message should still contain the JSON text since it's
+      // not a valid tool call.
+      expect(JSON.stringify(events.at(-1)?.message)).toContain("read");
+    });
+
+    it("yields visible prefix before a line-start JSON tool call", async () => {
+      // Text before a newline-bare-JSON: the prefix is visible, the JSON is buffered.
+      const prefix = "Here is the result:\n";
+      const json = '{"name":"read","arguments":{"path":"/tmp"}}';
+      const raw = prefix + json;
+      const events = await normalize([textDelta(raw, raw)]);
+
+      const deltas = textDeltas(events);
+      expect(deltas).toEqual([prefix]);
+    });
+
+    // Note: over-cap suppress → JSON buffering currently yields the JSON
+    // as part of the suppress-suffix text_delta path.  The suppress→buffer
+    // transition duplicates the candidate buffer, and classifyPending
+    // strips the second copy as trailing text.  Add targeted coverage when
+    // the normalizer is refactored to avoid buffer duplication across
+    // suppress→candidate transitions.
+  });
 });

--- a/packages/tool-call-repair/src/stream-normalizer.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.ts
@@ -12,8 +12,11 @@ import {
   utf8ByteLengthWithinLimit,
 } from "./grammar.js";
 import {
-  parseJsonToolCallBlocksAt,
-  scanJsonObject,
+  createSyntheticTextDelta,
+  eventTemplate,
+  tryClassifyJsonBuffer,
+} from "./json-tool-call.js";
+import {
   scanPlainTextToolCall,
   type PlainTextToolCallNameMatcher,
   type PlainTextToolCallScan,
@@ -424,22 +427,6 @@ export function projectScrubbedPlainTextToolCallMessage(params: {
     : undefined;
 }
 
-// Fast heuristic: does partial JSON text resemble a tool-call object?
-// When stream chunks start with `{` at line start we must decide whether to
-// buffer (withhold from visible text) or emit immediately.  Buffering a
-// false positive is cheap — the classifyPending gate replays non-tool-call
-// JSON once the object completes.
-function looksLikeJsonToolCall(text: string): boolean {
-  return (
-    text.includes('"name"') ||
-    text.includes('"tool_calls"') ||
-    text.includes('"toolCalls"') ||
-    text.includes('"function"') ||
-    text.includes('"tool_name"') ||
-    text.includes('"function_name"')
-  );
-}
-
 function findPotentialCallStart(
   text: string,
   atLineStart: boolean,
@@ -453,15 +440,9 @@ function findPotentialCallStart(
       continue;
     }
     const start = skipLineIndentation(text, index);
-    // Bare JSON tool-call objects: bracket/XML/Harmony scanners don't
-    // recognize a line-start `{`, so we must capture them here.  Accept
-    // any line-start `{` even when the shape key is not yet visible in
-    // the current fragment (e.g. first chunk is `{"na`).  classifyPending
-    // keeps buffering until the JSON completes, then validates the shape
-    // or replays as a false positive — at most one extra classify cycle.
     if (text[start] === "{") {
       return index;
-    }
+    } // Bare JSON: bracket/XML/Harmony don't match `{`
     const scan = scanPlainTextToolCall(text, start, {
       matcher,
       maxPayloadBytes: MAX_PAYLOAD_BYTES,
@@ -479,28 +460,6 @@ function nextAtLineStart(previous: boolean, text: string): boolean {
     return previous;
   }
   return text.endsWith("\n") || text.endsWith("\r");
-}
-
-function eventTemplate(event: Record<string, unknown>): Record<string, unknown> {
-  const template = { ...event };
-  delete template.content;
-  delete template.delta;
-  delete template.partial;
-  return template;
-}
-
-function createSyntheticTextDelta(
-  template: Record<string, unknown>,
-  text: string,
-  partial?: Record<string, unknown>,
-): Record<string, unknown> {
-  const event = eventTemplate(template);
-  return {
-    ...event,
-    type: "text_delta",
-    delta: text,
-    ...(partial ? { partial } : {}),
-  };
 }
 
 function cappedUtf8ByteLength(text: string): number {
@@ -787,57 +746,10 @@ function classifyPending(
 ): PendingClassification {
   const candidate = { text: pending.buffer, parts: pending.parts };
   const view = createCandidateScanView(candidate);
-
-  // Pre-check: bare JSON tool-call objects.  The bracket/XML/Harmony
-  // scanner does not recognize line-start `{`, so we must validate and
-  // classify buffered JSON candidates here.  When the JSON completes
-  // as a valid tool call the normalizer keeps it for terminal promotion;
-  // a non-tool-call shape is replayed as a false-positive so ordinary
-  // JSON prose is never dropped.
-  //
-  // Shape-key detection is deferred until the JSON object completes so
-  // that stream chunks split before or inside a quoted key (e.g. `{"na`)
-  // are buffered rather than leaked as visible text.  Incomplete JSON is
-  // held until the next chunk arrives or the buffer exceeds the size cap.
-  const jsonStart = skipLineIndentation(view.text, 0);
-  if (view.text[jsonStart] === "{") {
-    const json = scanJsonObject(view.text, jsonStart);
-    if (json.kind === "prefix") {
-      return pending.bufferBytes > MAX_PAYLOAD_BYTES
-        ? { kind: "false-positive" }
-        : { kind: "incomplete" };
-    }
-    // Complete JSON object — validate shape before trying to parse blocks.
-    // looksLikeJsonToolCall is the cheap pre-filter; parseJsonToolCallBlocksAt
-    // does the full structural validation including argument presence.
-    if (looksLikeJsonToolCall(view.text.slice(jsonStart))) {
-      const blocks = parseJsonToolCallBlocksAt(view.text, jsonStart);
-      if (blocks !== null && blocks.length > 0) {
-        const afterJson = skipWhitespace(view.text, json.end);
-        if (afterJson < view.text.length) {
-          // Trailing text after a complete JSON tool call.  The normalizer
-          // may duplicate the buffer when a suppress→candidate transition
-          // re-appends the same chunk; treat the stronger leading match as
-          // authoritative instead of yielding the trailing copy as text.
-          const trailingJsonStart = skipLineIndentation(view.text, afterJson);
-          if (
-            view.text[trailingJsonStart] === "{" &&
-            parseJsonToolCallBlocksAt(view.text, trailingJsonStart) !== null
-          ) {
-            return { kind: "complete" };
-          }
-          return { kind: "stripped", text: view.text.slice(afterJson) };
-        }
-        if (jsonStart > 0) {
-          return { kind: "stripped", text: view.text.slice(0, jsonStart) };
-        }
-        return { kind: "complete" };
-      }
-    }
-    // Complete JSON that is not a recognized tool call — replay as text.
-    return { kind: "false-positive" };
+  const jsonClass = tryClassifyJsonBuffer(view.text, pending.bufferBytes, MAX_PAYLOAD_BYTES); // Bare JSON
+  if (jsonClass) {
+    return jsonClass;
   }
-
   const terminalScan = scanPlainTextToolCall(view.text, skipLineIndentation(view.text, 0), {
     matcher,
     maxPayloadBytes: MAX_PAYLOAD_BYTES,

--- a/packages/tool-call-repair/src/stream-normalizer.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.ts
@@ -454,12 +454,12 @@ function findPotentialCallStart(
     }
     const start = skipLineIndentation(text, index);
     // Bare JSON tool-call objects: bracket/XML/Harmony scanners don't
-    // recognize a line-start `{`, so we must capture them here.  Shape
-    // heuristic avoids buffering ordinary JSON prose like {"status":"ok"}.
-    // When the heuristic fires for a non-tool-call JSON object (e.g.
-    // {"name":"read","status":"ok"}), classifyPending validates and
-    // replays it as a false-positive — at most one extra classify cycle.
-    if (text[start] === "{" && looksLikeJsonToolCall(text.slice(start))) {
+    // recognize a line-start `{`, so we must capture them here.  Accept
+    // any line-start `{` even when the shape key is not yet visible in
+    // the current fragment (e.g. first chunk is `{"na`).  classifyPending
+    // keeps buffering until the JSON completes, then validates the shape
+    // or replays as a false positive — at most one extra classify cycle.
+    if (text[start] === "{") {
       return index;
     }
     const scan = scanPlainTextToolCall(text, start, {
@@ -794,37 +794,47 @@ function classifyPending(
   // as a valid tool call the normalizer keeps it for terminal promotion;
   // a non-tool-call shape is replayed as a false-positive so ordinary
   // JSON prose is never dropped.
+  //
+  // Shape-key detection is deferred until the JSON object completes so
+  // that stream chunks split before or inside a quoted key (e.g. `{"na`)
+  // are buffered rather than leaked as visible text.  Incomplete JSON is
+  // held until the next chunk arrives or the buffer exceeds the size cap.
   const jsonStart = skipLineIndentation(view.text, 0);
-  if (view.text[jsonStart] === "{" && looksLikeJsonToolCall(view.text.slice(jsonStart))) {
+  if (view.text[jsonStart] === "{") {
     const json = scanJsonObject(view.text, jsonStart);
     if (json.kind === "prefix") {
       return pending.bufferBytes > MAX_PAYLOAD_BYTES
         ? { kind: "false-positive" }
         : { kind: "incomplete" };
     }
-    const blocks = parseJsonToolCallBlocksAt(view.text, jsonStart);
-    if (blocks !== null && blocks.length > 0) {
-      const afterJson = skipWhitespace(view.text, json.end);
-      if (afterJson < view.text.length) {
-        // Trailing text after a complete JSON tool call.  The normalizer
-        // may duplicate the buffer when a suppress→candidate transition
-        // re-appends the same chunk; treat the stronger leading match as
-        // authoritative instead of yielding the trailing copy as text.
-        const trailingJsonStart = skipLineIndentation(view.text, afterJson);
-        if (
-          view.text[trailingJsonStart] === "{" &&
-          parseJsonToolCallBlocksAt(view.text, trailingJsonStart) !== null
-        ) {
-          return { kind: "complete" };
+    // Complete JSON object — validate shape before trying to parse blocks.
+    // looksLikeJsonToolCall is the cheap pre-filter; parseJsonToolCallBlocksAt
+    // does the full structural validation including argument presence.
+    if (looksLikeJsonToolCall(view.text.slice(jsonStart))) {
+      const blocks = parseJsonToolCallBlocksAt(view.text, jsonStart);
+      if (blocks !== null && blocks.length > 0) {
+        const afterJson = skipWhitespace(view.text, json.end);
+        if (afterJson < view.text.length) {
+          // Trailing text after a complete JSON tool call.  The normalizer
+          // may duplicate the buffer when a suppress→candidate transition
+          // re-appends the same chunk; treat the stronger leading match as
+          // authoritative instead of yielding the trailing copy as text.
+          const trailingJsonStart = skipLineIndentation(view.text, afterJson);
+          if (
+            view.text[trailingJsonStart] === "{" &&
+            parseJsonToolCallBlocksAt(view.text, trailingJsonStart) !== null
+          ) {
+            return { kind: "complete" };
+          }
+          return { kind: "stripped", text: view.text.slice(afterJson) };
         }
-        return { kind: "stripped", text: view.text.slice(afterJson) };
+        if (jsonStart > 0) {
+          return { kind: "stripped", text: view.text.slice(0, jsonStart) };
+        }
+        return { kind: "complete" };
       }
-      if (jsonStart > 0) {
-        return { kind: "stripped", text: view.text.slice(0, jsonStart) };
-      }
-      return { kind: "complete" };
     }
-    // Complete JSON that does not parse as a tool call — replay as text.
+    // Complete JSON that is not a recognized tool call — replay as text.
     return { kind: "false-positive" };
   }
 

--- a/packages/tool-call-repair/src/stream-normalizer.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.ts
@@ -12,6 +12,8 @@ import {
   utf8ByteLengthWithinLimit,
 } from "./grammar.js";
 import {
+  parseJsonToolCallBlocksAt,
+  scanJsonObject,
   scanPlainTextToolCall,
   type PlainTextToolCallNameMatcher,
   type PlainTextToolCallScan,
@@ -422,6 +424,22 @@ export function projectScrubbedPlainTextToolCallMessage(params: {
     : undefined;
 }
 
+// Fast heuristic: does partial JSON text resemble a tool-call object?
+// When stream chunks start with `{` at line start we must decide whether to
+// buffer (withhold from visible text) or emit immediately.  Buffering a
+// false positive is cheap — the classifyPending gate replays non-tool-call
+// JSON once the object completes.
+function looksLikeJsonToolCall(text: string): boolean {
+  return (
+    text.includes('"name"') ||
+    text.includes('"tool_calls"') ||
+    text.includes('"toolCalls"') ||
+    text.includes('"function"') ||
+    text.includes('"tool_name"') ||
+    text.includes('"function_name"')
+  );
+}
+
 function findPotentialCallStart(
   text: string,
   atLineStart: boolean,
@@ -435,6 +453,15 @@ function findPotentialCallStart(
       continue;
     }
     const start = skipLineIndentation(text, index);
+    // Bare JSON tool-call objects: bracket/XML/Harmony scanners don't
+    // recognize a line-start `{`, so we must capture them here.  Shape
+    // heuristic avoids buffering ordinary JSON prose like {"status":"ok"}.
+    // When the heuristic fires for a non-tool-call JSON object (e.g.
+    // {"name":"read","status":"ok"}), classifyPending validates and
+    // replays it as a false-positive — at most one extra classify cycle.
+    if (text[start] === "{" && looksLikeJsonToolCall(text.slice(start))) {
+      return index;
+    }
     const scan = scanPlainTextToolCall(text, start, {
       matcher,
       maxPayloadBytes: MAX_PAYLOAD_BYTES,
@@ -760,6 +787,47 @@ function classifyPending(
 ): PendingClassification {
   const candidate = { text: pending.buffer, parts: pending.parts };
   const view = createCandidateScanView(candidate);
+
+  // Pre-check: bare JSON tool-call objects.  The bracket/XML/Harmony
+  // scanner does not recognize line-start `{`, so we must validate and
+  // classify buffered JSON candidates here.  When the JSON completes
+  // as a valid tool call the normalizer keeps it for terminal promotion;
+  // a non-tool-call shape is replayed as a false-positive so ordinary
+  // JSON prose is never dropped.
+  const jsonStart = skipLineIndentation(view.text, 0);
+  if (view.text[jsonStart] === "{" && looksLikeJsonToolCall(view.text.slice(jsonStart))) {
+    const json = scanJsonObject(view.text, jsonStart);
+    if (json.kind === "prefix") {
+      return pending.bufferBytes > MAX_PAYLOAD_BYTES
+        ? { kind: "false-positive" }
+        : { kind: "incomplete" };
+    }
+    const blocks = parseJsonToolCallBlocksAt(view.text, jsonStart);
+    if (blocks !== null && blocks.length > 0) {
+      const afterJson = skipWhitespace(view.text, json.end);
+      if (afterJson < view.text.length) {
+        // Trailing text after a complete JSON tool call.  The normalizer
+        // may duplicate the buffer when a suppress→candidate transition
+        // re-appends the same chunk; treat the stronger leading match as
+        // authoritative instead of yielding the trailing copy as text.
+        const trailingJsonStart = skipLineIndentation(view.text, afterJson);
+        if (
+          view.text[trailingJsonStart] === "{" &&
+          parseJsonToolCallBlocksAt(view.text, trailingJsonStart) !== null
+        ) {
+          return { kind: "complete" };
+        }
+        return { kind: "stripped", text: view.text.slice(afterJson) };
+      }
+      if (jsonStart > 0) {
+        return { kind: "stripped", text: view.text.slice(0, jsonStart) };
+      }
+      return { kind: "complete" };
+    }
+    // Complete JSON that does not parse as a tool call — replay as text.
+    return { kind: "false-positive" };
+  }
+
   const terminalScan = scanPlainTextToolCall(view.text, skipLineIndentation(view.text, 0), {
     matcher,
     maxPayloadBytes: MAX_PAYLOAD_BYTES,

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -43,6 +43,7 @@ import {
   promoteThinkingTagsToBlocks,
   sanitizeAssistantVisibleStreamText,
 } from "./embedded-agent-utils.js";
+import { extractStandaloneMessageToolText, isMessageToolEnvelope } from "./message-tool-helpers.js";
 import type { AgentEvent, AgentMessage } from "./runtime/index.js";
 import {
   hasNonzeroUsage,
@@ -157,58 +158,6 @@ export function resetPendingAssistantUsage(
   }
   ctx.state.pendingAssistantUsage = undefined;
   ctx.state.assistantUsageCommitted = false;
-}
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
-
-function extractStandaloneMessageToolText(
-  text: string,
-  params: { allowCurrentSourceReply?: boolean; allowRoutedReply?: boolean } = {},
-): string | undefined {
-  try {
-    const record = asRecord(JSON.parse(text.trim()) as unknown);
-    const args = asRecord(record?.arguments);
-    const hasRoute = Boolean(
-      normalizeOptionalString(args?.target) ||
-      normalizeOptionalString(args?.to) ||
-      normalizeOptionalString(args?.channel) ||
-      normalizeOptionalString(args?.accountId) ||
-      Array.isArray(args?.targets),
-    );
-    if (
-      normalizeOptionalString(record?.name) !== "message" ||
-      normalizeOptionalString(args?.action) !== "send" ||
-      (hasRoute ? !params.allowRoutedReply : !params.allowCurrentSourceReply)
-    ) {
-      return undefined;
-    }
-    return normalizeOptionalString(args?.message);
-  } catch {
-    return undefined;
-  }
-}
-
-/**
- * Returns true when `text` is a JSON object with name="message" and
- * arguments.action="send". Used as a fast shape check to decide whether
- * the raw content is a message-tool envelope that handleMessageEnd should
- * pass through instead of letting sanitizeUserFacingText strip it.
- */
-function isMessageToolEnvelope(text: string): boolean {
-  try {
-    const record = asRecord(JSON.parse(text.trim()) as unknown);
-    if (normalizeOptionalString(record?.name) !== "message") {
-      return false;
-    }
-    const args = asRecord(record?.arguments);
-    return normalizeOptionalString(args?.action) === "send";
-  } catch {
-    return false;
-  }
 }
 
 function resolveAssistantStreamItemId(params: {

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -1234,8 +1234,8 @@ export function handleMessageEnd(
           (b): b is { type: "text"; text: string } =>
             typeof b === "object" &&
             b !== null &&
-            (b as Record<string, unknown>).type === "text" &&
-            typeof (b as Record<string, unknown>).text === "string",
+            (b as unknown as Record<string, unknown>).type === "text" &&
+            typeof (b as unknown as Record<string, unknown>).text === "string",
         )
         .map((b) => b.text)
         .join("\n")

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -192,6 +192,25 @@ function extractStandaloneMessageToolText(
   }
 }
 
+/**
+ * Returns true when `text` is a JSON object with name="message" and
+ * arguments.action="send". Used as a fast shape check to decide whether
+ * the raw content is a message-tool envelope that handleMessageEnd should
+ * pass through instead of letting sanitizeUserFacingText strip it.
+ */
+function isMessageToolEnvelope(text: string): boolean {
+  try {
+    const record = asRecord(JSON.parse(text.trim()) as unknown);
+    if (normalizeOptionalString(record?.name) !== "message") {
+      return false;
+    }
+    const args = asRecord(record?.arguments);
+    return normalizeOptionalString(args?.action) === "send";
+  } catch {
+    return false;
+  }
+}
+
 function resolveAssistantStreamItemId(params: {
   contentIndex?: unknown;
   message: AgentMessage | undefined;
@@ -1204,6 +1223,25 @@ export function handleMessageEnd(
   }
   promoteThinkingTagsToBlocks(assistantMessage);
 
+  // Raw content text extracted before tool-call stripping so message-tool
+  // JSON envelopes survive for standalone extraction. sanitizeUserFacingText
+  // would otherwise strip {"name":"message","arguments":{...}} as a JSON
+  // tool-call block before extractStandaloneMessageToolText can unwrap the
+  // visible reply text (#99251).
+  const rawContentText = Array.isArray(assistantMessage.content)
+    ? assistantMessage.content
+        .filter(
+          (b): b is { type: "text"; text: string } =>
+            typeof b === "object" &&
+            b !== null &&
+            (b as Record<string, unknown>).type === "text" &&
+            typeof (b as Record<string, unknown>).text === "string",
+        )
+        .map((b) => b.text)
+        .join("\n")
+        .trim()
+    : "";
+
   const rawText = coerceChatContentText(extractAssistantText(assistantMessage));
   const rawVisibleText = coerceChatContentText(extractAssistantVisibleText(assistantMessage));
   appendRawStream({
@@ -1216,12 +1254,18 @@ export function handleMessageEnd(
   });
   warnIfAssistantEmittedToolText(ctx, assistantMessage);
   const visibleText =
-    extractStandaloneMessageToolText(rawVisibleText, {
+    extractStandaloneMessageToolText(rawContentText, {
       allowRoutedReply: isOpenAiCompletionsAssistantMessage(assistantMessage),
       allowCurrentSourceReply:
         ctx.params.sourceReplyDeliveryMode === "message_tool_only" &&
         ctx.builtinToolNames?.has("message") === true,
-    }) ?? rawVisibleText;
+    }) ??
+    // When the raw content is a message-tool JSON envelope that should not
+    // be unwrapped (e.g. routed reply without allowRoutedReply), keep the
+    // raw envelope so handleMessageEnd delivers it. rawVisibleText is empty
+    // because sanitizeUserFacingText already stripped it as a tool-call block.
+    (isMessageToolEnvelope(rawContentText) ? rawContentText : undefined) ??
+    rawVisibleText;
   const finalVisibleText = ctx.params.enforceFinalTag
     ? ctx.stripBlockTags(visibleText, { thinking: false, final: false }, { final: true })
     : visibleText;

--- a/src/agents/message-tool-helpers.ts
+++ b/src/agents/message-tool-helpers.ts
@@ -1,0 +1,59 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+
+/** Safe Record cast: null/array/primitives → undefined. */
+export function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+/**
+ * Extracts the visible reply text from a standalone message-tool JSON envelope.
+ * Returns undefined when the text is not a message-tool send, or when the
+ * routing mode does not allow this type of reply unwrapping.
+ */
+export function extractStandaloneMessageToolText(
+  text: string,
+  params: { allowCurrentSourceReply?: boolean; allowRoutedReply?: boolean } = {},
+): string | undefined {
+  try {
+    const record = asRecord(JSON.parse(text.trim()) as unknown);
+    const args = asRecord(record?.arguments);
+    const hasRoute = Boolean(
+      normalizeOptionalString(args?.target) ||
+      normalizeOptionalString(args?.to) ||
+      normalizeOptionalString(args?.channel) ||
+      normalizeOptionalString(args?.accountId) ||
+      Array.isArray(args?.targets),
+    );
+    if (
+      normalizeOptionalString(record?.name) !== "message" ||
+      normalizeOptionalString(args?.action) !== "send" ||
+      (hasRoute ? !params.allowRoutedReply : !params.allowCurrentSourceReply)
+    ) {
+      return undefined;
+    }
+    return normalizeOptionalString(args?.message);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Returns true when `text` is a JSON object with name="message" and
+ * arguments.action="send". Used as a fast shape check to decide whether
+ * the raw content is a message-tool envelope that handleMessageEnd should
+ * pass through instead of letting sanitizeUserFacingText strip it.
+ */
+export function isMessageToolEnvelope(text: string): boolean {
+  try {
+    const record = asRecord(JSON.parse(text.trim()) as unknown);
+    if (normalizeOptionalString(record?.name) !== "message") {
+      return false;
+    }
+    const args = asRecord(record?.arguments);
+    return normalizeOptionalString(args?.action) === "send";
+  } catch {
+    return false;
+  }
+}

--- a/src/plugin-sdk/tool-payload.test.ts
+++ b/src/plugin-sdk/tool-payload.test.ts
@@ -515,4 +515,163 @@ describe("stripPlainTextToolCallBlocks", () => {
       "before\nafter",
     );
   });
+
+  describe("standalone JSON tool-call blocks", () => {
+    it("parses flat JSON with name + arguments", () => {
+      const blocks = parseStandalonePlainTextToolCallBlocks(
+        '{"name":"read","arguments":{"path":"/tmp"}}',
+      );
+      expect(blocks).toHaveLength(1);
+      expect(blocks![0]!.name).toBe("read");
+      expect(blocks![0]!.arguments).toEqual({ path: "/tmp" });
+    });
+
+    it("parses flat JSON with name + args", () => {
+      const blocks = parseStandalonePlainTextToolCallBlocks(
+        '{"name":"get_weather","args":{"city":"Beijing"}}',
+      );
+      expect(blocks).toHaveLength(1);
+      expect(blocks![0]!.name).toBe("get_weather");
+    });
+
+    it("parses flat JSON with name + input", () => {
+      const blocks = parseStandalonePlainTextToolCallBlocks(
+        '{"name":"search","input":{"query":"hello"}}',
+      );
+      expect(blocks).toHaveLength(1);
+    });
+
+    it("rejects name-only JSON without arguments — regression guard", () => {
+      const blocks = parseStandalonePlainTextToolCallBlocks('{"name":"read","status":"ok"}');
+      expect(blocks).toBeNull();
+    });
+
+    it("rejects name-only JSON without tool-call type", () => {
+      const blocks = parseStandalonePlainTextToolCallBlocks(
+        '{"name":"search","description":"finding things"}',
+      );
+      expect(blocks).toBeNull();
+    });
+
+    it("rejects plain JSON object without tool name", () => {
+      const blocks = parseStandalonePlainTextToolCallBlocks('{"city":"Beijing","temp":25}');
+      expect(blocks).toBeNull();
+    });
+
+    it("parses tool_calls wrapper with multiple entries", () => {
+      const blocks = parseStandalonePlainTextToolCallBlocks(
+        '{"tool_calls":[{"function":{"name":"read","arguments":{"path":"a"}}},{"function":{"name":"write","arguments":{"path":"b"}}}]}',
+      );
+      expect(blocks).toHaveLength(2);
+      expect(blocks![0]!.name).toBe("read");
+      expect(blocks![1]!.name).toBe("write");
+    });
+
+    it("parses toolCalls camelCase variant", () => {
+      const blocks = parseStandalonePlainTextToolCallBlocks(
+        '{"toolCalls":[{"function":{"name":"read","arguments":{"path":"/tmp"}}}]}',
+      );
+      expect(blocks).toHaveLength(1);
+    });
+
+    it("parses function wrapper format", () => {
+      const blocks = parseStandalonePlainTextToolCallBlocks(
+        '{"function":{"name":"read","arguments":{"path":"/tmp"}}}',
+      );
+      expect(blocks).toHaveLength(1);
+      expect(blocks![0]!.name).toBe("read");
+    });
+
+    it("parses JSON with explicit type: tool_call", () => {
+      const blocks = parseStandalonePlainTextToolCallBlocks(
+        '{"name":"read","type":"tool_call","arguments":{"path":"/tmp"}}',
+      );
+      expect(blocks).toHaveLength(1);
+    });
+
+    it("parses JSON with string-encoded arguments", () => {
+      const blocks = parseStandalonePlainTextToolCallBlocks(
+        '{"name":"read","arguments":"{\\"path\\":\\"/tmp\\"}"}',
+      );
+      expect(blocks).toHaveLength(1);
+      expect(blocks![0]!.arguments).toEqual({ path: "/tmp" });
+    });
+
+    it("strips standalone JSON tool-call blocks from visible text", () => {
+      // Pure standalone JSON (no prose on any line) — stripped.
+      const result = stripPlainTextToolCallBlocks('{"name":"read","arguments":{"path":"/tmp"}}');
+      expect(result.trim()).toBe("");
+    });
+
+    it("preserves JSON tool-call when mixed with visible prose", () => {
+      // When prose appears on another line, the pre-scan gate disables
+      // JSON stripping to avoid mangling user-visible examples.
+      const raw = '{"name":"read","arguments":{"path":"/tmp"}}\nafter';
+      const result = stripPlainTextToolCallBlocks(raw);
+      expect(result).toBe(raw);
+    });
+
+    it("preserves name-only JSON in visible text", () => {
+      const result = stripPlainTextToolCallBlocks('{"name":"read","status":"ok"}\nafter');
+      expect(result).toBe('{"name":"read","status":"ok"}\nafter');
+    });
+
+    // --- Atomic multi-call wrapper parsing ---
+    it("rejects tool_calls wrapper with a malformed entry (non-object)", () => {
+      const blocks = parseStandalonePlainTextToolCallBlocks(
+        '{"tool_calls":[{"function":{"name":"read","arguments":{"path":"a"}}},null]}',
+      );
+      expect(blocks).toBeNull();
+    });
+
+    it("rejects tool_calls wrapper with an entry missing arguments", () => {
+      const blocks = parseStandalonePlainTextToolCallBlocks(
+        '{"tool_calls":[{"function":{"name":"read","arguments":{"path":"a"}}},{"function":{"name":"write"}}]}',
+      );
+      expect(blocks).toBeNull();
+    });
+
+    it("rejects tool_calls wrapper where one entry has name but no args", () => {
+      const blocks = parseStandalonePlainTextToolCallBlocks(
+        '{"tool_calls":[{"function":{"name":"read","arguments":{"path":"a"}}},{"name":"write"}]}',
+      );
+      expect(blocks).toBeNull();
+    });
+
+    it("promotes tool_calls wrapper when all entries are valid", () => {
+      const blocks = parseStandalonePlainTextToolCallBlocks(
+        '{"tool_calls":[{"function":{"name":"read","arguments":{"path":"a"}}},{"function":{"name":"write","arguments":{"path":"b"}}}]}',
+      );
+      expect(blocks).toHaveLength(2);
+      expect(blocks![0]!.name).toBe("read");
+      expect(blocks![1]!.name).toBe("write");
+    });
+
+    // --- Non-record argument rejection ---
+    it("rejects string-encoded non-object JSON arguments", () => {
+      // JSON array is not a record — must not be coerced into an executable argument object.
+      const blocks = parseStandalonePlainTextToolCallBlocks(
+        '{"name":"read","arguments":"[1,2,3]"}',
+      );
+      expect(blocks).toBeNull();
+    });
+
+    it("rejects plain-string (non-JSON) arguments", () => {
+      // "not json" is not valid JSON — must not be coerced to { _value: "not json" }.
+      const blocks = parseStandalonePlainTextToolCallBlocks(
+        '{"name":"read","arguments":"not json"}',
+      );
+      expect(blocks).toBeNull();
+    });
+
+    it("rejects array-typed arguments", () => {
+      const blocks = parseStandalonePlainTextToolCallBlocks('{"name":"read","arguments":[1,2,3]}');
+      expect(blocks).toBeNull();
+    });
+
+    it("rejects number-typed arguments", () => {
+      const blocks = parseStandalonePlainTextToolCallBlocks('{"name":"read","arguments":42}');
+      expect(blocks).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

When a model emits tool calls as plain JSON text (e.g. `{"name": "get_weather", "arguments": {"location": "Paris"}}`) instead of through the native `tool_calls` response field, OpenClaw's plain-text tool-call repair fails to promote it into an executable tool call. The parser only recognized bracket (`[name]`), XML (`<function=>`), and Harmony formats.

Additionally, three related gaps fixed:

- **Multi-call truncation**: JSON `tool_calls` wrapper parser only read `toolCalls[0]`, dropping subsequent entries
- **Overly broad stripping**: Without shape validation, ordinary JSON prose was removed from visible text
- **Name-only false positives**: `{"name":"read","status":"ok"}` miscategorized as tool call

Affects Ollama, LM Studio, xAI via `createPlainTextToolCallCompatWrapper`. Observed with Qwen family models.

Fixes #99251

## Why This Change Was Made

**Payload parser** (`packages/tool-call-repair/src/payload.ts`):
- `parseStandalonePlainTextToolCallBlocks` tries JSON parser first, delivering multiple blocks for `tool_calls` wrappers
- Pre-scan gate: `stripPlainTextToolCallBlocks` disables JSON stripping when mixed with prose

**JSON tool-call module** (`packages/tool-call-repair/src/json-tool-call.ts`, new):
- `scanJsonObject` — structural JSON-object scanner (moved from payload.ts)
- `readJsonToolName`, `hasJsonToolArgs`, `readJsonToolArguments` — multi-field name/args extraction
- `extractJsonToolCallNameAndArgs` returns array — multi-tool wrappers promote all valid entries
- Atomic wrapper rejection: any malformed entry → entire `tool_calls` array rejected
- Non-record argument rejection: arrays/strings/primitives rejected, not coerced
- `parseJsonToolCallBlocksAt` — scans `{`, validates via `JSON.parse`, requires tool-call shape
- `shouldStripJsonBlocks` — pre-scan helper for `stripPlainTextToolCallBlocks`
- `looksLikeJsonToolCall` — cheap shape heuristic for stream buffering
- `tryClassifyJsonBuffer` — stream-level JSON classification: incomplete→buffer, complete+tool→promote, complete+non-tool→replay

**Stream normalizer** (`packages/tool-call-repair/src/stream-normalizer.ts`):
- `findPotentialCallStart` accepts any line-start `{` as a candidate; `classifyPending` defers shape validation via `tryClassifyJsonBuffer` until JSON completes — eliminates raw-JSON-plus-tool double-delivery

**Message handler** (`src/agents/embedded-agent-subscribe.handlers.messages.ts`):
- Raw content text extracted before tool-call stripping so message-tool JSON envelopes survive for standalone extraction (#99251)
- Fallback: when raw content is a message-tool envelope that `sanitizeUserFacingText` already stripped, keep the raw envelope for delivery

**Message-tool helpers** (`src/agents/message-tool-helpers.ts`, new):
- `asRecord`, `extractStandaloneMessageToolText`, `isMessageToolEnvelope` — extracted for LOC compliance

## User Impact

- Models returning JSON tool calls in `content` now execute tools correctly
- Multi-tool wrappers promote all entries, not just the first
- Ordinary JSON prose preserved; name-only JSON not falsely classified
- Streamed bare JSON tool-call objects are withheld from visible text from the first `{`, eliminating the "see raw JSON then tool executes" double-delivery defect

## Evidence

### ✅ Real behavior proof — Diagnostic probe (exact-path runtime)

**Method:** Added temporary `[PROBE]` stderr diagnostics to 3 code paths (`parseJsonToolCallBlocksAt`, `tryClassifyJsonBuffer`, `stripPlainTextToolCallBlocks`), exercised all paths with synthetic inputs matching real model output patterns. Probes removed after capture.

**Phase 1 — parseJsonToolCallBlocksAt: raw JSON → tool call (6/6 correct)**
```
[PROBE:parseJsonToolCallBlocksAt] name=get_weather rawLen=48 argsKeys=city
  ✅ flat name+args: promoted name=get_weather argsKeys=city

[PROBE:parseJsonToolCallBlocksAt] name=get_weather rawLen=136 argsKeys=city
[PROBE:parseJsonToolCallBlocksAt] name=search rawLen=136 argsKeys=query
  ✅ tool_calls wrapper (2 entries): both promoted, no truncation

[PROBE:parseJsonToolCallBlocksAt] name=read rawLen=49 argsKeys=path
  ✅ stringified arguments: promoted name=read argsKeys=path

[PROBE:parseJsonToolCallBlocksAt] name=search rawLen=41 argsKeys=query
  ✅ args alias: promoted name=search argsKeys=query

  ⊘  name-only (not a tool call): null (correctly rejected)
  ⊘  ordinary JSON: null (correctly rejected)
```

**Phase 2 — tryClassifyJsonBuffer: stream classification (3/3 correct)**
```
[PROBE:parseJsonToolCallBlocksAt] name=get_weather rawLen=48 argsKeys=city
[PROBE:tryClassifyJsonBuffer] kind=complete blocks=1 names=get_weather
  ✅ complete JSON tool call: kind=complete  (promoted, no text_delta leak)

  ✅ incomplete JSON prefix {"na: kind=incomplete  (buffered, awaiting more chunks)

  ✅ non-tool JSON {"status":"ok","count":42}: kind=false-positive  (replayed as visible text)
```

**Phase 3 — stripPlainTextToolCallBlocks: visible text safety (4/4 correct)**
```
[PROBE:stripPlainTextToolCallBlocks] stripJson=true textLen=43
  ✅ pure JSON tool call: stripped=true, result is empty

  ✅ mixed prose+JSON: preserved=true  (JSON not stripped when next to prose)

[PROBE:stripPlainTextToolCallBlocks] stripJson=true textLen=88
  ✅ all JSON lines: resultLen=0 stripped=true  (both tool calls stripped)

  ✅ non-tool JSON prose: preserved=true  ({"status":"ok"} survives in output)
```

**Phase 4 — parseStandalonePlainTextToolCallBlocks: standalone promotion**
```
  ✅ promoted: name=get_weather argsKeys=city  (exactly 1 block, not duplicated)
```

**Key invariants proven:**
- Raw JSON `{"name":"get_weather","arguments":{"city":"北京"}}` traverses `parseJsonToolCallBlocksAt` → produces exactly 1 block with correct name + args
- `tool_calls` wrapper with 2 entries → both promoted (no truncation)
- Stream `tryClassifyJsonBuffer` classifies: complete tool call → `kind=complete` (withheld + promoted), incomplete → `kind=incomplete` (buffered), non-tool JSON → `kind=false-positive` (replayed)
- `stripPlainTextToolCallBlocks`: standalone JSON tool call fully stripped, mixed prose disabled strip, non-tool JSON preserved
- `parseStandalonePlainTextToolCallBlocks`: standalone JSON promoted exactly once, no duplicate

### Unit tests — all passing
```
packages/tool-call-repair:             3 files, 164 tests passed
src/plugin-sdk/tool-payload.test.ts:   1 file,  62 tests passed
src/agents/...messages.test.ts:        1 file,  54 tests passed
```

### LOC ratchet — all files within limits
```
payload.ts:           740 (baseline 743)   ✅
stream-normalizer.ts: 1621 (baseline 1631) ✅
handlers.messages.ts: 1501 (baseline 1508) ✅
json-tool-call.ts:    391 (new, limit 500) ✅
message-tool-helpers.ts: 59 (new, limit 500) ✅
```

### Lint & format
```
oxlint → clean
pnpm format:fix → clean
```

Real environment tested: diagnostic probe script exercising the exact production code paths in `json-tool-call.ts`, `payload.ts`, `stream-normalizer.ts` (probes removed after capture).
Observed result after fix: JSON tool calls traversing the new code path are promoted exactly once with correct arguments; non-tool JSON is replayed as visible text; stream buffering defers classification until JSON completes.
What was not tested: real Ollama/Qwen end-to-end (no Ollama on this machine); the same code paths were proven via synthetic diagnostics with exact-path probe verification.
