### PR TITLE
fix(matrix): keep HTTP error and tool-progress truncations UTF-16 safe

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -3184,6 +3184,31 @@ describe("matrix monitor handler draft streaming", () => {
     await finish();
   });
 
+  it("keeps truncated Matrix tool progress UTF-16 safe", async () => {
+    const { dispatch } = createStreamingHarness({
+      streaming: "progress",
+      previewToolProgressEnabled: true,
+      accountConfig: {
+        streaming: {
+          mode: "progress",
+          progress: { label: false, maxLineChars: 500 },
+        },
+      } as never,
+    });
+    const { opts, finish } = await dispatch();
+    const progressPrefix = "x".repeat(298);
+
+    const progressText = `${progressPrefix}🎉tail`;
+    await opts.onItemEvent?.({ progressText });
+    await opts.onItemEvent?.({ progressText });
+
+    await vi.waitFor(() => {
+      expect(sendSingleTextMessageMatrixMock).toHaveBeenCalledTimes(1);
+    });
+    expect(singleTextMessageBody()).toBe(`- \`${progressPrefix}...\``);
+    await finish();
+  });
+
   it("replaces recovered Matrix command progress instead of leaving stale failed text", async () => {
     const { dispatch } = createStreamingHarness({
       streaming: "progress",

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -42,6 +42,7 @@ import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
 import { getSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type {
   CoreConfig,
   MatrixConfig,
@@ -456,7 +457,7 @@ function formatMatrixToolProgressMarkdownCode(text: string): string {
   const clipped =
     text.length <= MATRIX_TOOL_PROGRESS_MAX_CHARS
       ? text
-      : `${text.slice(0, MATRIX_TOOL_PROGRESS_MAX_CHARS - 1).trimEnd()}...`;
+      : `${truncateUtf16Safe(text, MATRIX_TOOL_PROGRESS_MAX_CHARS - 1).trimEnd()}...`;
   const safe = clipped.replaceAll("`", "'");
   return `\`${safe}\``;
 }

--- a/extensions/matrix/src/matrix/sdk/event-helpers.test.ts
+++ b/extensions/matrix/src/matrix/sdk/event-helpers.test.ts
@@ -41,35 +41,12 @@ describe("event-helpers", () => {
     expect(fromText.statusCode).toBe(500);
   });
 
-  it("buildHttpError keeps the 500-char plain-text body truncation UTF-16 safe at emoji boundaries", () => {
-    // 498 ASCII chars + emoji (😀 = U+1F600, UTF-16 surrogate pair) = 500 code units.
-    // A naive .slice(0, 500) would land on the high surrogate and return a dangling
-    // high surrogate (charCode 0xD83D), which downstream string consumers render
-    // as U+FFFD / mojibake. truncateUtf16Safe trims the orphan high surrogate
-    // and returns 499 code units ending cleanly before the emoji.
-    const ascii = "a".repeat(498);
-    const emoji = "😀"; // 2 UTF-16 code units
-    const bodyText = ascii + emoji + "tail";
-    const error = buildHttpError(500, bodyText);
-    expect(error.message.length).toBe(499);
-    expect(error.message).toBe(ascii);
-    expect(error.message.charCodeAt(error.message.length - 1)).not.toBe(0xd83d);
-  });
+  it("keeps truncated HTTP error bodies UTF-16 safe", () => {
+    const parsedPrefix = `{"detail":"${"a".repeat(488)}`;
+    const invalidPrefix = `not-json ${"b".repeat(490)}`;
 
-  it("buildHttpError keeps a non-parseable JSON body truncation UTF-16 safe at emoji boundaries", () => {
-    // 498 ASCII chars + emoji = 500 code units. The try/catch branch falls back
-    // to truncateUtf16Safe(bodyText, 500); before this fix the same dangling
-    // high surrogate would have leaked into the error message.
-    const ascii = "b".repeat(498);
-    const emoji = "🎉"; // 2 UTF-16 code units
-    const bodyText = "not-json " + ascii + emoji + "more";
-    const error = buildHttpError(502, bodyText);
-    // The slice lands on the high surrogate of 🎉, which truncateUtf16Safe
-    // trims — final length is 499 code units (one less than the cap).
-    expect(error.message.length).toBe(499);
-    // Final code unit is the 498th ASCII 'b' (0x62), not a dangling high surrogate.
-    expect(error.message.charCodeAt(error.message.length - 1)).toBe(0x62);
-    expect(error.message).not.toMatch(/�/);
+    expect(buildHttpError(500, `${parsedPrefix}😀"}`).message).toBe(parsedPrefix);
+    expect(buildHttpError(502, `${invalidPrefix}🎉tail`).message).toBe(invalidPrefix);
   });
 
   it("serializes Matrix events and resolves state key from available sources", () => {

--- a/extensions/matrix/src/matrix/sdk/event-helpers.test.ts
+++ b/extensions/matrix/src/matrix/sdk/event-helpers.test.ts
@@ -41,6 +41,37 @@ describe("event-helpers", () => {
     expect(fromText.statusCode).toBe(500);
   });
 
+  it("buildHttpError keeps the 500-char plain-text body truncation UTF-16 safe at emoji boundaries", () => {
+    // 498 ASCII chars + emoji (😀 = U+1F600, UTF-16 surrogate pair) = 500 code units.
+    // A naive .slice(0, 500) would land on the high surrogate and return a dangling
+    // high surrogate (charCode 0xD83D), which downstream string consumers render
+    // as U+FFFD / mojibake. truncateUtf16Safe trims the orphan high surrogate
+    // and returns 499 code units ending cleanly before the emoji.
+    const ascii = "a".repeat(498);
+    const emoji = "😀"; // 2 UTF-16 code units
+    const bodyText = ascii + emoji + "tail";
+    const error = buildHttpError(500, bodyText);
+    expect(error.message.length).toBe(499);
+    expect(error.message).toBe(ascii);
+    expect(error.message.charCodeAt(error.message.length - 1)).not.toBe(0xd83d);
+  });
+
+  it("buildHttpError keeps a non-parseable JSON body truncation UTF-16 safe at emoji boundaries", () => {
+    // 498 ASCII chars + emoji = 500 code units. The try/catch branch falls back
+    // to truncateUtf16Safe(bodyText, 500); before this fix the same dangling
+    // high surrogate would have leaked into the error message.
+    const ascii = "b".repeat(498);
+    const emoji = "🎉"; // 2 UTF-16 code units
+    const bodyText = "not-json " + ascii + emoji + "more";
+    const error = buildHttpError(502, bodyText);
+    // The slice lands on the high surrogate of 🎉, which truncateUtf16Safe
+    // trims — final length is 499 code units (one less than the cap).
+    expect(error.message.length).toBe(499);
+    // Final code unit is the 498th ASCII 'b' (0x62), not a dangling high surrogate.
+    expect(error.message.charCodeAt(error.message.length - 1)).toBe(0x62);
+    expect(error.message).not.toMatch(/�/);
+  });
+
   it("serializes Matrix events and resolves state key from available sources", () => {
     const viaGetter = {
       getId: () => "$1",

--- a/extensions/matrix/src/matrix/sdk/event-helpers.ts
+++ b/extensions/matrix/src/matrix/sdk/event-helpers.ts
@@ -1,5 +1,5 @@
-import type { MatrixEvent } from "matrix-js-sdk/lib/matrix.js";
 // Matrix helper module supports event helpers behavior.
+import type { MatrixEvent } from "matrix-js-sdk/lib/matrix.js";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { MatrixRawEvent } from "./types.js";
 

--- a/extensions/matrix/src/matrix/sdk/event-helpers.ts
+++ b/extensions/matrix/src/matrix/sdk/event-helpers.ts
@@ -1,5 +1,6 @@
-// Matrix helper module supports event helpers behavior.
 import type { MatrixEvent } from "matrix-js-sdk/lib/matrix.js";
+// Matrix helper module supports event helpers behavior.
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { MatrixRawEvent } from "./types.js";
 
 type MatrixEventContentMode = "current" | "original";
@@ -90,10 +91,10 @@ export function buildHttpError(
       if (typeof parsed.error === "string" && parsed.error.trim()) {
         message = parsed.error.trim();
       } else {
-        message = bodyText.slice(0, 500);
+        message = truncateUtf16Safe(bodyText, 500);
       }
     } catch {
-      message = bodyText.slice(0, 500);
+      message = truncateUtf16Safe(bodyText, 500);
     }
   }
   return Object.assign(new Error(message), { statusCode });


### PR DESCRIPTION
## What Problem This Solves

Matrix truncates HTTP error bodies and long tool-progress lines by UTF-16 code-unit offsets. A raw `String.prototype.slice` can stop after the high surrogate of an astral character, leaving malformed text for logs and chat rendering.

## Why This Change Was Made

Both Matrix-owned boundaries now use the existing `truncateUtf16Safe` helper from `openclaw/plugin-sdk/text-utility-runtime`:

- `buildHttpError` keeps its 500-unit cap for parsed responses without a usable `error` and for invalid JSON bodies.
- Matrix tool-progress formatting keeps its existing 299-unit prefix, trailing whitespace trim, and `...` suffix.

The implementation stays inside the Matrix plugin and does not change config, protocol, public APIs, or normal short-text behavior.

## User Impact

Long Matrix HTTP errors and configured long progress lines no longer acquire a dangling surrogate when an emoji crosses the truncation boundary. ASCII, BMP-only text, and text below the existing limits remain unchanged.

## Evidence

- Corrected both HTTP fixtures so the emoji's high surrogate is exactly at code-unit index 499. The tests cover valid JSON without a usable Matrix error and the invalid-JSON fallback.
- Added production-path draft-delivery coverage for Matrix tool progress with `maxLineChars: 500`, which makes the Matrix-owned 299-unit cap reachable after shared progress compaction.
- Focused fallback run after two transient Testbox provisioning 502s: `node scripts/run-vitest.mjs extensions/matrix/src/matrix/sdk/event-helpers.test.ts extensions/matrix/src/matrix/monitor/handler.test.ts` — 2 files, 126 tests passed.
- `git diff --check` — passed.
- Fresh structured autoreview — clean, no accepted/actionable findings; confidence 0.99.

The earlier submitted fixtures did not cross their claimed boundaries: one contained a complete surrogate pair inside the cap, and the other placed the emoji after the cap. The reviewed head replaces them with exact assertions and covers the previously untested tool-progress owner path.
