### PR TITLE
fix(codex): fail closed on unknown projector statuses and warn on protocol drift

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -4790,4 +4790,197 @@ describe("CodexAppServerEventProjector", () => {
     expect(started.eventName).toBe("sessionStart");
     expect(started.scope).toBe("thread");
   });
+
+  describe.sequential("fail-closed diagnostics", () => {
+    it("treats statusless webSearch completions as completed", async () => {
+      const onAgentEvent = vi.fn();
+      const projector = await createProjector({
+        ...(await createParams()),
+        onAgentEvent,
+      });
+      const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+
+      await projector.handleNotification(
+        forCurrentTurn("item/completed", {
+          item: {
+            id: "web-search-statusless",
+            type: "webSearch",
+            query: "OpenClaw",
+            action: { type: "search", query: "OpenClaw", queries: null },
+          },
+        }),
+      );
+
+      const itemEvent = findAgentEvent(onAgentEvent, {
+        stream: "item",
+        phase: "end",
+        itemId: "web-search-statusless",
+      }).data;
+      expect(itemEvent.status).toBe("completed");
+      expect(warn).not.toHaveBeenCalledWith(
+        "codex app-server unknown item status treated as failed",
+        expect.anything(),
+      );
+    });
+
+    it("treats unknown item statuses as failed", async () => {
+      const onAgentEvent = vi.fn();
+      const projector = await createProjector({
+        ...(await createParams()),
+        onAgentEvent,
+        verboseLevel: "on",
+      });
+      const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+
+      await projector.handleNotification(
+        forCurrentTurn("item/completed", {
+          item: {
+            type: "commandExecution",
+            id: "cmd-unknown-status",
+            command: "echo hi",
+            cwd: "/workspace",
+            processId: null,
+            source: "agent",
+            status: "timedOut",
+            commandActions: [],
+            aggregatedOutput: "ok",
+            exitCode: 0,
+            durationMs: 42,
+          },
+        }),
+      );
+
+      const toolResult = findAgentEvent(onAgentEvent, {
+        stream: "tool",
+        phase: "result",
+        itemId: "cmd-unknown-status",
+        name: "bash",
+      }).data;
+      expect(toolResult.status).toBe("failed");
+      expect(toolResult.isError).toBe(true);
+      expect(warn).toHaveBeenCalledWith(
+        "codex app-server unknown item status treated as failed",
+        expect.objectContaining({ itemId: "cmd-unknown-status", rawStatus: "timedOut" }),
+      );
+    });
+
+    it("warns on turn/plan/updated without correlation ids", async () => {
+      const projector = await createProjector();
+      const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+
+      await projector.handleNotification({
+        method: "turn/plan/updated",
+        params: {
+          explanation: "plan update missing correlation",
+          plan: [{ step: "research" }],
+        },
+      } as ProjectorNotification);
+
+      expect(warn).toHaveBeenCalledWith(
+        "codex app-server notification does not match active turn",
+        expect.objectContaining({
+          method: "turn/plan/updated",
+          expectedThreadId: THREAD_ID,
+          expectedTurnId: TURN_ID,
+          actualThreadId: undefined,
+          actualTurnId: undefined,
+        }),
+      );
+    });
+
+    it("warns on turn/plan/updated for a different turn", async () => {
+      const projector = await createProjector();
+      const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+
+      await projector.handleNotification({
+        method: "turn/plan/updated",
+        params: {
+          threadId: THREAD_ID,
+          turnId: "different-turn",
+          explanation: "plan update for another turn",
+          plan: [{ step: "research" }],
+        },
+      } as ProjectorNotification);
+
+      expect(warn).toHaveBeenCalledWith(
+        "codex app-server notification does not match active turn",
+        expect.objectContaining({
+          method: "turn/plan/updated",
+          expectedThreadId: THREAD_ID,
+          expectedTurnId: TURN_ID,
+          actualThreadId: THREAD_ID,
+          actualTurnId: "different-turn",
+        }),
+      );
+    });
+
+    it("warns on scoped events without thread/turn ids", async () => {
+      const projector = await createProjector();
+      const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+
+      await projector.handleNotification({
+        method: "item/completed",
+        params: {
+          item: { id: "item-no-correlation", type: "message" },
+        },
+      } as ProjectorNotification);
+
+      expect(warn).toHaveBeenCalledWith(
+        "codex app-server notification does not match active turn",
+        expect.objectContaining({
+          method: "item/completed",
+          expectedThreadId: THREAD_ID,
+          expectedTurnId: TURN_ID,
+          actualThreadId: undefined,
+          actualTurnId: undefined,
+        }),
+      );
+    });
+
+    it("warns on unknown notification methods", async () => {
+      const projector = await createProjector();
+      const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+
+      await projector.handleNotification(
+        forCurrentTurn("item/futureMethod" as ProjectorNotification["method"], {
+          item: { id: "future-item", type: "message" },
+        }),
+      );
+
+      expect(warn).toHaveBeenCalledWith(
+        "codex app-server unknown notification method",
+        expect.objectContaining({
+          method: "item/futureMethod",
+          threadId: THREAD_ID,
+          turnId: TURN_ID,
+        }),
+      );
+    });
+
+    it("warns on notifications for a different turn", async () => {
+      const projector = await createProjector();
+      const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+
+      await projector.handleNotification({
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: THREAD_ID,
+          turnId: "different-turn",
+          item: { id: "msg-other-turn", type: "message" },
+          delta: "hello from another turn",
+        },
+      } as ProjectorNotification);
+
+      expect(warn).toHaveBeenCalledWith(
+        "codex app-server notification does not match active turn",
+        expect.objectContaining({
+          method: "item/agentMessage/delta",
+          expectedThreadId: THREAD_ID,
+          expectedTurnId: TURN_ID,
+          actualThreadId: THREAD_ID,
+          actualTurnId: "different-turn",
+        }),
+      );
+    });
+  });
 });

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -69,6 +69,30 @@ export type CodexAppServerToolTelemetry = {
   successfulCronAdds?: number;
 };
 
+// Rate-limited diagnostics for protocol drift at the Codex projector boundary.
+// Codex pin bumps can introduce new statuses, methods, or correlation shapes;
+// per-key cooldowns prevent log floods from a mismatched binary while still
+// surfacing each distinct drift shape at least once.
+const UNKNOWN_STATUS_LOG_COOLDOWN_MS = 5_000;
+const UNKNOWN_METHOD_LOG_COOLDOWN_MS = 5_000;
+const MISMATCHED_NOTIFICATION_LOG_COOLDOWN_MS = 5_000;
+
+function createLogCooldown(intervalMs: number) {
+  const lastLogMsByKey = new Map<string, number>();
+  return (key: string, now = Date.now()): boolean => {
+    const lastLogMs = lastLogMsByKey.get(key) ?? 0;
+    if (now - lastLogMs < intervalMs) {
+      return false;
+    }
+    lastLogMsByKey.set(key, now);
+    return true;
+  };
+}
+
+const unknownStatusCooldown = createLogCooldown(UNKNOWN_STATUS_LOG_COOLDOWN_MS);
+const unknownMethodCooldown = createLogCooldown(UNKNOWN_METHOD_LOG_COOLDOWN_MS);
+const mismatchedNotificationCooldown = createLogCooldown(MISMATCHED_NOTIFICATION_LOG_COOLDOWN_MS);
+
 export type CodexAppServerEventProjectorOptions = {
   nativePostToolUseRelayEnabled?: boolean;
   onNativeToolResultRecorded?: () => void | Promise<void>;
@@ -668,6 +692,21 @@ export class CodexAppServerEventProjector {
         return;
       }
     } else if (!this.isNotificationForTurn(params)) {
+      const actualThreadId = readCodexNotificationThreadId(params);
+      const actualTurnId = readCodexNotificationTurnId(params);
+      if (
+        mismatchedNotificationCooldown(
+          `${notification.method}:${actualThreadId ?? "none"}:${actualTurnId ?? "none"}`,
+        )
+      ) {
+        embeddedAgentLog.warn("codex app-server notification does not match active turn", {
+          method: notification.method,
+          expectedThreadId: this.threadId,
+          expectedTurnId: this.turnId,
+          actualThreadId,
+          actualTurnId,
+        });
+      }
       return;
     }
     this.nativeToolLifecycleProjector.handleNotification(notification);
@@ -723,6 +762,13 @@ export class CodexAppServerEventProjector {
         this.promptErrorSource = "prompt";
         break;
       default:
+        if (unknownMethodCooldown(notification.method)) {
+          embeddedAgentLog.warn("codex app-server unknown notification method", {
+            method: notification.method,
+            threadId: this.threadId,
+            turnId: this.turnId,
+          });
+        }
         break;
     }
   }
@@ -2538,7 +2584,6 @@ function readNonNegativeInteger(record: JsonObject, key: string): number | undef
   return value !== undefined && Number.isInteger(value) && value >= 0 ? value : undefined;
 }
 
-
 function readCodexErrorNotificationMessage(record: JsonObject): string | undefined {
   const error = record.error;
   return isJsonObject(error) ? readString(error, "message") : undefined;
@@ -2685,7 +2730,24 @@ function itemStatus(item: CodexThreadItem): "completed" | "failed" | "running" |
   if (status === "inProgress" || status === "in_progress" || status === "running") {
     return "running";
   }
-  return "completed";
+  if (status === "completed") {
+    return "completed";
+  }
+  // Some Codex item types (e.g. webSearch completions) legitimately omit the
+  // status field. Treat a missing status as completed; only fail closed and log
+  // when an explicit status value is unrecognized, so future pin bumps remain
+  // diagnosable without breaking valid statusless items.
+  if (status === undefined) {
+    return "completed";
+  }
+  if (unknownStatusCooldown(status)) {
+    embeddedAgentLog.warn("codex app-server unknown item status treated as failed", {
+      itemId: item.id,
+      itemType: item.type,
+      rawStatus: status,
+    });
+  }
+  return "failed";
 }
 
 function auditNativeToolTerminalStatus(item: CodexThreadItem): CodexNativeToolAuditStatus {


### PR DESCRIPTION
## What Problem This Solves

Fixes #99269.

The Codex event projector had three fail-open or silent-drop paths that turned future Codex protocol drift into wrong results instead of diagnosable errors:

1. `itemStatus()` mapped any unrecognized item status to `"completed"`.
2. The notification dispatch `default:` case silently ignored unknown methods.
3. Thread/turn correlation mismatches were discarded without logging.

A follow-up concern from review: valid **statusless** items (e.g. `webSearch` completions) must remain `"completed"`, while only an **explicit unknown status value** should fail closed. Correlation checking is now uniformly strict: notifications must carry the active `threadId` and `turnId`, including `turn/plan/updated` and other plan-style notifications.

## Why This Change Was Made

The harness pins `@openai/codex` 0.142.4 but accepts configured binaries down to the 0.125.0 floor, and the pin is bumped regularly. Status drift produces false success for failed tool calls, while silent drops make upgrade regressions look like nondeterministic model behavior.

`webSearch` and similar items legitimately omit the `status` field, so the missing-status path is preserved as `"completed"`.

## User Impact

Operators and developers will now see explicit warnings when the Codex projector encounters an unknown status value, unknown notification method, or unexpected thread/turn correlation. Unknown item statuses are treated as failures instead of successes, preventing the model from continuing on wrong premises. Statusless `webSearch` completions continue to project as completed. Plan updates without valid correlation are surfaced as drift rather than silently accepted.

## Evidence

### Unit-test coverage

Added regression tests in `extensions/codex/src/app-server/event-projector.test.ts`:

- **Statusless `webSearch` completion** is projected as `"completed"` and does **not** log an unknown-status warning.
- Unknown item status (`"timedOut"`) is projected as `"failed"` with `isError: true` and emits the expected warning.
- Unknown notification methods emit the expected warning.
- Notifications for a different turn emit the expected warning with expected/actual thread and turn ids.
- **`turn/plan/updated` without correlation ids** emits an active-turn mismatch warning.
- **`turn/plan/updated` for a different turn** emits an active-turn mismatch warning.
- **Scoped events without thread/turn ids** emit an active-turn mismatch warning.

### Upstream protocol check

Verified upstream Codex item status enum values (`inProgress | completed | failed | declined`) by inspecting the sibling `codex` checkout at `codex-rs/app-server-protocol/src/protocol/v2/item.rs`.

### Unit-test run

```text
$ node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts --reporter=verbose
...
✓ |extension-codex| ... > fail-closed diagnostics > treats statusless webSearch completions as completed
✓ |extension-codex| ... > fail-closed diagnostics > treats unknown item statuses as failed
✓ |extension-codex| ... > fail-closed diagnostics > warns on turn/plan/updated without correlation ids
✓ |extension-codex| ... > fail-closed diagnostics > warns on turn/plan/updated for a different turn
✓ |extension-codex| ... > fail-closed diagnostics > warns on scoped events without thread/turn ids
✓ |extension-codex| ... > fail-closed diagnostics > warns on unknown notification methods
✓ |extension-codex| ... > fail-closed diagnostics > warns on notifications for a different turn

Test Files  1 passed (1)
     Tests  132 passed (132)
```

### Extension boundary checks

- `pnpm lint:plugins:no-extension-src-imports` passes.
- `pnpm lint:extensions:no-relative-outside-package` passes.
- `pnpm lint:extensions:no-plugin-sdk-internal` passes.
- `pnpm lint:extensions:no-src-outside-plugin-sdk` passes.
- `pnpm tsgo:extensions` passes.

### Formatting

`pnpm format:check` passes on the changed files.

## Maintainer acceptance requested

This PR intentionally changes the projector behavior so that **explicit unknown item status values** are treated as failures rather than successes. Statusless items (e.g. `webSearch` completions) remain `completed`. Requesting maintainer review and acceptance of this fail-closed compatibility tradeoff before merge.
