### PR TITLE
fix(feishu): preserve text before media attachments

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -2229,6 +2229,57 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  it("preserves final text and media after partial streaming start fails", async () => {
+    const errorMock = vi.fn();
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const origPush = streamingInstances.push.bind(streamingInstances);
+    streamingInstances.push = (...args: StreamingSessionStub[]) => {
+      if (streamingInstances.length === 0) {
+        args[0].start = vi
+          .fn()
+          .mockRejectedValue(new Error("Create card request failed with HTTP 400"));
+      }
+      return origPush(...args);
+    };
+
+    try {
+      const { result, options } = createDispatcherHarness({
+        runtime: { log: vi.fn(), error: errorMock } as never,
+      });
+
+      await result.replyOptions.onPartialReply?.({
+        text: "Feishu MEDIA regression proof",
+      });
+      await options.deliver(
+        {
+          text:
+            "Feishu MEDIA regression proof\n" +
+            "If this fix works, this text and the image both appear.",
+          mediaUrl: "/tmp/openclaw-feishu-proof/media.png",
+          mediaUrls: ["/tmp/openclaw-feishu-proof/media.png"],
+        },
+        { kind: "final" },
+      );
+
+      expect(errorMock.mock.calls.map(([message]) => String(message)).join("\n")).toContain(
+        "streaming start failed",
+      );
+      expect(sendStructuredCardFeishuMock).toHaveBeenCalledTimes(1);
+      expectMockArgFields(sendStructuredCardFeishuMock, "structured card params", {
+        text:
+          "Feishu MEDIA regression proof\n" +
+          "If this fix works, this text and the image both appear.",
+      });
+      expect(sendMediaFeishuMock).toHaveBeenCalledTimes(1);
+      expectMockArgFields(sendMediaFeishuMock, "media send params", {
+        mediaUrl: "/tmp/openclaw-feishu-proof/media.png",
+      });
+    } finally {
+      streamingInstances.push = origPush;
+      nowSpy.mockRestore();
+    }
+  });
+
   it("backs off streaming retries after start() throws (HTTP 400)", async () => {
     const errorMock = vi.fn();
     let shouldFailStart = true;

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -1466,6 +1466,59 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  it("closes final streaming text before sending regular media attachments", async () => {
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    await options.deliver(
+      {
+        text: "Daily sales summary\nRevenue is up 12%.",
+        mediaUrls: ["https://example.com/dashboard.png"],
+      },
+      { kind: "final" },
+    );
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledWith(
+      "Daily sales summary\nRevenue is up 12%.",
+      { note: "Agent: agent" },
+    );
+    expect(sendMediaFeishuMock).toHaveBeenCalledTimes(1);
+    expectMockArgFields(sendMediaFeishuMock, "media send params", {
+      mediaUrl: "https://example.com/dashboard.png",
+    });
+    await expect(result.ensureNoVisibleReplyFallback("dispatch-complete")).resolves.toBe(false);
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to text before media when final streaming close has no visible content", async () => {
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    result.replyOptions.onPartialReply?.({ text: "Dashboard caption" });
+    streamingInstances[0].close = vi.fn(async () => {
+      streamingInstances[0].active = false;
+      return false;
+    });
+
+    await options.deliver(
+      {
+        text: "Dashboard caption",
+        mediaUrls: ["https://example.com/dashboard.png"],
+      },
+      { kind: "final" },
+    );
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expectMockArgFields(sendMessageFeishuMock, "message send params", {
+      text: "Dashboard caption",
+    });
+    expect(sendMediaFeishuMock).toHaveBeenCalledTimes(1);
+    await expect(result.ensureNoVisibleReplyFallback("dispatch-complete")).resolves.toBe(false);
+  });
+
   it("passes replyInThread to sendMessageFeishu for plain text", async () => {
     useNonStreamingAutoAccount();
     const { options } = createDispatcherHarness({

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -2280,6 +2280,40 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     }
   });
 
+  it("falls back to a static card when block streaming card start fails", async () => {
+    const errorMock = vi.fn();
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const origPush = streamingInstances.push.bind(streamingInstances);
+    streamingInstances.push = (...args: StreamingSessionStub[]) => {
+      if (streamingInstances.length === 0) {
+        args[0].start = vi
+          .fn()
+          .mockRejectedValue(new Error("Create card request failed with HTTP 400"));
+      }
+      return origPush(...args);
+    };
+
+    try {
+      const { options } = createDispatcherHarness({
+        runtime: { log: vi.fn(), error: errorMock } as never,
+      });
+
+      await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "block" });
+
+      expect(errorMock.mock.calls.map(([message]) => String(message)).join("\n")).toContain(
+        "streaming start failed",
+      );
+      expect(sendStructuredCardFeishuMock).toHaveBeenCalledTimes(1);
+      expectMockArgFields(sendStructuredCardFeishuMock, "structured card params", {
+        text: "```ts\nconst x = 1\n```",
+      });
+      expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    } finally {
+      streamingInstances.push = origPush;
+      nowSpy.mockRestore();
+    }
+  });
+
   it("backs off streaming retries after start() throws (HTTP 400)", async () => {
     const errorMock = vi.fn();
     let shouldFailStart = true;

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -527,7 +527,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     runtime.channel.text.chunkTextWithMode.mockReturnValue(["final text", " overflow"]);
 
     const { result, options } = createDispatcherHarness({ runtime: createRuntimeLogger() });
-    result.replyOptions.onPartialReply?.({ text: "partial" });
+    await result.replyOptions.onPartialReply?.({ text: "partial" });
     await options.deliver({ text: "final text overflow" }, { kind: "final" });
     await options.onIdle?.();
 
@@ -906,7 +906,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     const { result, options } = createDispatcherHarness({
       runtime: createRuntimeLogger(),
     });
-    result.replyOptions.onPartialReply?.({ text: "Working on it..." });
+    await result.replyOptions.onPartialReply?.({ text: "Working on it..." });
     await options.deliver({ text: "⚠️ Exec failed", isError: true }, { kind: "final" });
     await options.onIdle?.();
 
@@ -970,7 +970,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
 
     await options.onReplyStart?.();
-    result.replyOptions.onPartialReply?.({ text: "```md\nidle streamed reply\n```" });
+    await result.replyOptions.onPartialReply?.({ text: "```md\nidle streamed reply\n```" });
     await options.onIdle?.();
     await options.deliver({ text: "```md\nidle streamed reply\n```" }, { kind: "final" });
 
@@ -1022,8 +1022,8 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       runtime: createRuntimeLogger(),
     });
 
-    result.replyOptions.onPartialReply?.({ text: "plain" });
-    result.replyOptions.onPartialReply?.({ text: "plain streamed answer" });
+    await result.replyOptions.onPartialReply?.({ text: "plain" });
+    await result.replyOptions.onPartialReply?.({ text: "plain streamed answer" });
     await options.onIdle?.();
 
     expect(streamingInstances).toHaveLength(1);
@@ -1151,7 +1151,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       runtime: createRuntimeLogger(),
     });
     await options.onReplyStart?.();
-    result.replyOptions.onPartialReply?.({ text: "hello" });
+    await result.replyOptions.onPartialReply?.({ text: "hello" });
     await options.deliver({ text: "lo world" }, { kind: "block" });
     await options.onIdle?.();
 
@@ -1178,7 +1178,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       runtime: createRuntimeLogger(),
     });
     await options.onReplyStart?.();
-    result.replyOptions.onPartialReply?.({ text: "```md\npartial\n```" });
+    await result.replyOptions.onPartialReply?.({ text: "```md\npartial\n```" });
     await options.deliver({ text: "```md\npartial\n```" }, { kind: "block" });
     await options.onIdle?.();
 
@@ -1205,11 +1205,11 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       runtime: createRuntimeLogger(),
     });
     await options.onReplyStart?.();
-    result.replyOptions.onPartialReply?.({
+    await result.replyOptions.onPartialReply?.({
       text: "Preparing the lookup plan with enough text to count as one block.",
     });
-    result.replyOptions.onPartialReply?.({ text: "Found" });
-    result.replyOptions.onPartialReply?.({ text: "Found the answer." });
+    await result.replyOptions.onPartialReply?.({ text: "Found" });
+    await result.replyOptions.onPartialReply?.({ text: "Found the answer." });
     await options.onIdle?.();
 
     expect(streamingInstances).toHaveLength(1);
@@ -1237,7 +1237,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       runtime: createRuntimeLogger(),
     });
     await options.onReplyStart?.();
-    result.replyOptions.onPartialReply?.({
+    await result.replyOptions.onPartialReply?.({
       text: "<thinking>private chain of thought</thinking>\nvisible answer",
     });
     await options.onIdle?.();
@@ -1298,7 +1298,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       runtime: createRuntimeLogger(),
     });
 
-    result.replyOptions.onPartialReply?.({ text: "spoken reply" });
+    await result.replyOptions.onPartialReply?.({ text: "spoken reply" });
     await options.deliver(
       {
         text: "spoken reply",
@@ -1326,7 +1326,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       runtime: createRuntimeLogger(),
     });
 
-    result.replyOptions.onPartialReply?.({ text: "caption from stream" });
+    await result.replyOptions.onPartialReply?.({ text: "caption from stream" });
     await options.deliver(
       {
         mediaUrl: "https://example.com/image.png",
@@ -1497,7 +1497,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       runtime: createRuntimeLogger(),
     });
 
-    result.replyOptions.onPartialReply?.({ text: "Dashboard caption" });
+    await result.replyOptions.onPartialReply?.({ text: "Dashboard caption" });
     streamingInstances[0].close = vi.fn(async () => {
       streamingInstances[0].active = false;
       return false;
@@ -1598,11 +1598,11 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
 
     await options.onReplyStart?.();
-    result.replyOptions.onReasoningStream?.({ text: "thinking step 1" });
-    result.replyOptions.onReasoningStream?.({
+    await result.replyOptions.onReasoningStream?.({ text: "thinking step 1" });
+    await result.replyOptions.onReasoningStream?.({
       text: "thinking step 1\nstep 2",
     });
-    result.replyOptions.onPartialReply?.({ text: "answer part" });
+    await result.replyOptions.onPartialReply?.({ text: "answer part" });
     result.replyOptions.onReasoningEnd?.();
     await options.deliver({ text: "answer part final" }, { kind: "final" });
     await options.onIdle?.();
@@ -1676,7 +1676,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
 
     await options.onReplyStart?.();
-    result.replyOptions.onReasoningStream?.({ text: "deep thought" });
+    await result.replyOptions.onReasoningStream?.({ text: "deep thought" });
     result.replyOptions.onReasoningEnd?.();
     await options.onIdle?.();
 
@@ -1696,8 +1696,8 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
 
     await options.onReplyStart?.();
-    result.replyOptions.onReasoningStream?.({ text: "" });
-    result.replyOptions.onPartialReply?.({ text: "```ts\ncode\n```" });
+    await result.replyOptions.onReasoningStream?.({ text: "" });
+    await result.replyOptions.onPartialReply?.({ text: "```ts\ncode\n```" });
     await options.deliver({ text: "```ts\ncode\n```" }, { kind: "final" });
     await options.onIdle?.();
 
@@ -1714,7 +1714,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
 
     await options.onReplyStart?.();
-    result.replyOptions.onReasoningStream?.({ text: "thought" });
+    await result.replyOptions.onReasoningStream?.({ text: "thought" });
     result.replyOptions.onReasoningEnd?.();
     await options.deliver({ text: "```ts\nfinal answer\n```" }, { kind: "final" });
     await options.onIdle?.();
@@ -1827,7 +1827,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
     await options.onReplyStart?.();
     result.replyOptions.onToolStart?.({ name: "web_search" });
-    result.replyOptions.onPartialReply?.({ text: "final answer" });
+    await result.replyOptions.onPartialReply?.({ text: "final answer" });
     await options.onIdle?.();
 
     const updateTexts = streamingUpdateTexts();
@@ -1858,7 +1858,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       args: { command: "pnpm test -- --watch=false" },
       detailMode: "raw",
     });
-    result.replyOptions.onPartialReply?.({ text: "final answer" });
+    await result.replyOptions.onPartialReply?.({ text: "final answer" });
     await options.onIdle?.();
 
     const updateTexts = streamingUpdateTexts();
@@ -1882,7 +1882,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
     await options.onReplyStart?.();
     result.replyOptions.onToolStart?.({ name: "message" });
-    result.replyOptions.onPartialReply?.({ text: "final answer" });
+    await result.replyOptions.onPartialReply?.({ text: "final answer" });
     await options.onIdle?.();
 
     const updateTexts = streamingUpdateTexts();

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -274,7 +274,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const deliveredFinalTexts = new Set<string>();
   let sentIndependentBlockText = false;
   let partialUpdateQueue: Promise<void> = Promise.resolve();
-  let streamingStartPromise: Promise<void> | null = null;
+  let streamingStartPromise: Promise<boolean> | null = null;
   let streamingClosedForReply = false;
   let streamingCloseErroredForReply = false;
   let visibleReplySent = false;
@@ -316,10 +316,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
   const flushStreamingCardUpdate = (combined: string) => {
     partialUpdateQueue = partialUpdateQueue.then(async () => {
-      if (streamingStartPromise) {
-        await streamingStartPromise;
-      }
-      if (streaming?.isActive()) {
+      const streamingStarted = streamingStartPromise ? await streamingStartPromise : true;
+      if (streamingStarted && streaming?.isActive()) {
         await streaming.update(combined);
       }
     });
@@ -342,6 +340,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       lastPartial = nextText;
     }
     const mode = options?.mode ?? "snapshot";
+    if (mode === "snapshot" && hasStreamingFinalText) {
+      return;
+    }
     if (mode === "delta") {
       streamText = `${streamText}${nextText}`;
     } else {
@@ -371,14 +372,15 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     flushStreamingCardUpdate(buildCombinedStreamText(reasoningText, streamText));
   };
 
-  const startStreaming = () => {
-    if (
-      !streamingEnabled ||
-      streamingStartPromise ||
-      streaming ||
-      isStreamingStartBackedOff(account.accountId)
-    ) {
-      return;
+  const startStreaming = (): Promise<boolean> => {
+    if (!streamingEnabled || isStreamingStartBackedOff(account.accountId)) {
+      return Promise.resolve(false);
+    }
+    if (streaming?.isActive()) {
+      return Promise.resolve(true);
+    }
+    if (streamingStartPromise) {
+      return streamingStartPromise;
     }
     streamingStartPromise = (async () => {
       const creds =
@@ -386,7 +388,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           ? { appId: account.appId, appSecret: account.appSecret, domain: account.domain }
           : null;
       if (!creds) {
-        return;
+        return false;
       }
 
       streaming = new FeishuStreamingSession(createFeishuClient(account), creds, (message) =>
@@ -407,6 +409,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           note: cardNote,
         });
         streamingStartBackoffUntilByAccount.delete(account.accountId);
+        return streaming.isActive();
       } catch (error) {
         rememberStreamingStartFailure(account.accountId);
         params.runtime.error?.(
@@ -416,8 +419,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         );
         streaming = null;
         streamingStartPromise = null;
+        return false;
       }
     })();
+    return streamingStartPromise;
   };
 
   const resetStreamingState = () => {
@@ -487,8 +492,11 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     if (!hasStreamingSession && (options?.startIfNeeded === false || renderMode !== "card")) {
       return;
     }
-    startStreaming();
-    flushStreamingCardUpdate(buildCombinedStreamText(reasoningText, streamText));
+    void startStreaming().then((streamingStarted) => {
+      if (streamingStarted) {
+        flushStreamingCardUpdate(buildCombinedStreamText(reasoningText, streamText));
+      }
+    });
   };
 
   const sendChunkedTextReply = async (paramsLocal: {
@@ -720,50 +728,50 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
         if (shouldDeliverText) {
           if (info?.kind === "block") {
+            const sendIndependentBlockText = async () => {
+              if (!coreBlockStreamingEnabled) {
+                return;
+              }
+              const isFirstBlock = !sentIndependentBlockText;
+              await sendChunkedTextReply({
+                text,
+                useCard: false,
+                infoKind: "block",
+                sendChunk: async ({ chunk, isFirst }) => {
+                  await sendMessageFeishu({
+                    cfg,
+                    to: sendTarget,
+                    text: chunk,
+                    replyToMessageId: sendReplyToMessageId,
+                    replyInThread: effectiveReplyInThread,
+                    allowTopLevelReplyFallback,
+                    accountId,
+                    ...(isFirstBlock && isFirst && mentionTargets?.length
+                      ? { mentions: mentionTargets }
+                      : {}),
+                  });
+                },
+              });
+              sentIndependentBlockText = true;
+              if (hasMedia) {
+                await sendMediaReplies(payload);
+              }
+            };
             // Drop internal block chunks unless we can safely consume them as
             // streaming-card fallback content or send them as independent
             // messages for true progressive delivery.
             if (!useStreamingCard) {
-              if (coreBlockStreamingEnabled) {
-                // Reuse normal text chunking, but notify mentions only on the first visible chunk.
-                const isFirstBlock = !sentIndependentBlockText;
-                await sendChunkedTextReply({
-                  text,
-                  useCard: false,
-                  infoKind: "block",
-                  sendChunk: async ({ chunk, isFirst }) => {
-                    await sendMessageFeishu({
-                      cfg,
-                      to: sendTarget,
-                      text: chunk,
-                      replyToMessageId: sendReplyToMessageId,
-                      replyInThread: effectiveReplyInThread,
-                      allowTopLevelReplyFallback,
-                      accountId,
-                      ...(isFirstBlock && isFirst && mentionTargets?.length
-                        ? { mentions: mentionTargets }
-                        : {}),
-                    });
-                  },
-                });
-                sentIndependentBlockText = true;
-                if (hasMedia) {
-                  await sendMediaReplies(payload);
-                }
-              }
+              await sendIndependentBlockText();
               return;
             }
-            startStreaming();
-            if (streamingStartPromise) {
-              await streamingStartPromise;
+            if (!(await startStreaming())) {
+              await sendIndependentBlockText();
+              return;
             }
           }
 
           if (info?.kind === "final" && useStreamingCard) {
-            startStreaming();
-            if (streamingStartPromise) {
-              await streamingStartPromise;
-            }
+            await startStreaming();
           }
 
           const shouldStreamText = info?.kind === "block" || info?.kind === "final";
@@ -887,7 +895,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       disableBlockStreaming:
         typeof account.config?.blockStreaming === "boolean" ? !account.config.blockStreaming : true,
       onPartialReply: streamingEnabled
-        ? (payload: ReplyPayload) => {
+        ? async (payload: ReplyPayload) => {
             if (!payload.text) {
               return;
             }
@@ -898,7 +906,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             if (!cleaned) {
               return;
             }
-            startStreaming();
+            if (!(await startStreaming())) {
+              return;
+            }
             queueStreamingUpdate(cleaned, {
               dedupeWithLastPartial: true,
               mode: "snapshot",
@@ -906,11 +916,13 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           }
         : undefined,
       onReasoningStream: reasoningPreviewEnabled
-        ? (payload: ReplyPayload) => {
+        ? async (payload: ReplyPayload) => {
             if (!payload.text) {
               return;
             }
-            startStreaming();
+            if (!(await startStreaming())) {
+              return;
+            }
             queueReasoningUpdate(formatReasoningMessage(payload.text));
           }
         : undefined,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -656,7 +656,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           skippedFinalReason = null;
         }
         if (streamingEnabled && renderMode === "card") {
-          startStreaming();
+          await startStreaming();
         }
         await Promise.resolve(typingCallbacks?.onReplyStart?.());
       },

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -728,9 +728,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
         if (shouldDeliverText) {
           if (info?.kind === "block") {
-            const sendIndependentBlockText = async () => {
+            const sendIndependentBlockText = async (): Promise<boolean> => {
               if (!coreBlockStreamingEnabled) {
-                return;
+                return false;
               }
               const isFirstBlock = !sentIndependentBlockText;
               await sendChunkedTextReply({
@@ -756,6 +756,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               if (hasMedia) {
                 await sendMediaReplies(payload);
               }
+              return true;
             };
             // Drop internal block chunks unless we can safely consume them as
             // streaming-card fallback content or send them as independent
@@ -765,8 +766,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               return;
             }
             if (!(await startStreaming())) {
-              await sendIndependentBlockText();
-              return;
+              if (await sendIndependentBlockText()) {
+                return;
+              }
             }
           }
 

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -433,7 +433,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     hasStreamingFinalText = false;
   };
 
-  const closeStreaming = async (options?: { markClosedForReply?: boolean }) => {
+  const closeStreaming = async (options?: { markClosedForReply?: boolean }): Promise<boolean> => {
+    let contentVisible = false;
     try {
       if (streamingStartPromise) {
         await streamingStartPromise;
@@ -443,7 +444,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         statusLine = "";
         const text = buildCombinedStreamText(reasoningText, streamText);
         const finalNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
-        const contentVisible = await streaming.close(text, { note: finalNote });
+        contentVisible = await streaming.close(text, { note: finalNote });
         // Track the raw streamed text so the duplicate-final check in deliver()
         // can skip the redundant text delivery that arrives after onIdle closes
         // the streaming card.
@@ -457,6 +458,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           }
         }
       }
+      return contentVisible;
     } finally {
       resetStreamingState();
     }
@@ -779,6 +781,31 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               snapshotBaseText = "";
               lastSnapshotTextLength = text.length;
               flushStreamingCardUpdate(buildCombinedStreamText(reasoningText, streamText));
+            }
+            if (info?.kind === "final" && hasMedia) {
+              const closedVisibleText = await closeStreaming();
+              if (!closedVisibleText && text) {
+                // Media success only proves the attachment is visible; preserve
+                // final prose when the streaming card accepted no text content.
+                await sendChunkedTextReply({
+                  text,
+                  useCard: false,
+                  infoKind: "final",
+                  sendChunk: async ({ chunk }) => {
+                    await sendMessageFeishu({
+                      cfg,
+                      to: sendTarget,
+                      text: chunk,
+                      replyToMessageId: sendReplyToMessageId,
+                      replyInThread: effectiveReplyInThread,
+                      allowTopLevelReplyFallback,
+                      accountId,
+                    });
+                  },
+                });
+              }
+              await sendMediaReplies(payload);
+              return;
             }
             // Send media even when streaming handled the text
             if (hasMedia) {

--- a/src/auto-reply/reply/block-reply-pipeline.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.test.ts
@@ -198,6 +198,22 @@ describe("createBlockReplyPipeline dedup with threading", () => {
     ]);
   });
 
+  it("aborts the stream when block delivery fails", async () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {
+        throw new Error("send failed");
+      },
+      timeoutMs: 5000,
+    });
+
+    pipeline.enqueue({ text: "streamed text" });
+    await pipeline.flush({ force: true });
+
+    expect(pipeline.didStream()).toBe(false);
+    expect(pipeline.isAborted()).toBe(true);
+    expect(pipeline.hasSentPayload({ text: "streamed text" })).toBe(false);
+  });
+
   it("keeps separate deliveries for distinct rich-only payloads", async () => {
     const sent: Array<{ presentation?: unknown }> = [];
     const pipeline = createBlockReplyPipeline({

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -217,6 +217,7 @@ export function createBlockReplyPipeline(params: {
           }
           return;
         }
+        aborted = true;
         logVerbose(`block reply delivery failed: ${String(err)}`);
       })
       .finally(() => {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1713,6 +1713,62 @@ describe("dispatchReplyFromConfig", () => {
     );
   });
 
+  it("reports dispatcher-backed block delivery failure to streaming callers", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    let blockQueued = 0;
+    let blockFailed = 0;
+    let finalQueued = 0;
+    dispatcher.sendBlockReply = vi.fn(() => {
+      blockQueued += 1;
+      blockFailed += 1;
+      return true;
+    });
+    dispatcher.sendFinalReply = vi.fn(() => {
+      finalQueued += 1;
+      return true;
+    });
+    dispatcher.getQueuedCounts = vi.fn(() => ({
+      tool: 0,
+      block: blockQueued,
+      final: finalQueued,
+    }));
+    dispatcher.getFailedCounts = vi.fn(() => ({
+      tool: 0,
+      block: blockFailed,
+      final: 0,
+    }));
+    let blockDeliveryError: unknown;
+    const replyResolver = async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      try {
+        await requireBlockReplyHandler(opts?.onBlockReply)(
+          { text: "streamed block" },
+          { timeoutMs: 5000 },
+        );
+      } catch (err) {
+        blockDeliveryError = err;
+      }
+      return { text: "final after failed stream" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "feishu",
+        Surface: "feishu",
+        SessionKey: "agent:main:feishu:direct:ou_test",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(blockDeliveryError).toBeInstanceOf(Error);
+    expect(String(blockDeliveryError)).toContain("block reply delivery failed");
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "final after failed stream" }),
+    );
+  });
+
   it("mirrors the delivered ownerless Slack text after dispatcher hook rewrites", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -3265,6 +3265,12 @@ export async function dispatchReplyFromConfig(
       (params.replyOptions?.suppressDefaultToolProgressMessages === true ||
         options.allowWhenToolSummariesHidden === true);
     let hasPendingDirectBlockReplyDelivery = false;
+    const readSettledDispatcherCount = (kind: ReplyDispatchKind): number => {
+      const queued = dispatcher.getQueuedCounts()[kind] ?? 0;
+      const cancelled = dispatcher.getCancelledCounts?.()[kind] ?? 0;
+      const failed = readDispatcherFailedCounts(dispatcher)[kind] ?? 0;
+      return Math.max(0, queued - cancelled - failed);
+    };
     const waitForPendingDirectBlockReplyDelivery = async (abortSignal?: AbortSignal) => {
       if (!hasPendingDirectBlockReplyDelivery) {
         return;
@@ -3274,6 +3280,18 @@ export async function dispatchReplyFromConfig(
       // callbacks and final completion where external ordering is visible.
       hasPendingDirectBlockReplyDelivery = false;
       await waitForReplyDispatcherIdle(dispatcher, abortSignal);
+    };
+    const confirmQueuedBlockReplyDelivery = async (
+      beforeSettledBlockCount: number,
+      abortSignal?: AbortSignal,
+    ) => {
+      await waitForReplyDispatcherIdle(dispatcher, abortSignal);
+      if (abortSignal?.aborted || isDispatchOperationAborted()) {
+        throw new DispatchReplyOperationAbortedError();
+      }
+      if (readSettledDispatcherCount("block") <= beforeSettledBlockCount) {
+        throw new Error("block reply delivery failed before streaming acknowledgement");
+      }
     };
     const shouldForwardProgressCallback = (options?: {
       allowWhenToolSummariesHidden?: boolean;
@@ -3794,9 +3812,17 @@ export async function dispatchReplyFromConfig(
                         );
                       } else {
                         markInboundDedupeReplayUnsafe();
+                        const beforeSettledBlockCount = readSettledDispatcherCount("block");
                         const delivered = dispatcher.sendBlockReply(normalizedPayload);
                         if (delivered) {
                           hasPendingDirectBlockReplyDelivery = true;
+                          if (context?.timeoutMs !== undefined) {
+                            hasPendingDirectBlockReplyDelivery = false;
+                            await confirmQueuedBlockReplyDelivery(
+                              beforeSettledBlockCount,
+                              context.abortSignal,
+                            );
+                          }
                         }
                       }
                     };


### PR DESCRIPTION
Closes #102390

## What Problem This Solves

Fixes an issue where Feishu users would lose the assistant's visible text when a final reply contained both prose and a `MEDIA:` image attachment while streaming cards were active. The affected chat could show only the no-visible-reply fallback or an attachment without the intended explanation.

## Why This Change Was Made

The Feishu reply dispatcher now closes the final streaming text card before sending regular media attachments, so the text is committed as visible content before the attachment path runs. If the streaming close accepts no text content, the dispatcher falls back to a normal text reply before sending media; voice-media duplicate-text suppression stays on the existing path.

A real Feishu repro showed two more gaps. First, dispatcher-backed streaming block replies were being treated as delivered as soon as they were queued. If async channel delivery later failed, the block pipeline could still dedupe the final answer and leave the turn with no visible reply. The core reply path now waits for dispatcher-backed block delivery to settle when streaming callers need an acknowledgement, and the block pipeline aborts on delivery errors so the final payload remains available as fallback.

Second, a live retry hit `Create card request failed with HTTP 400` while starting the Feishu streaming card. That start failure was swallowed by the preview path, leaving no active streaming session while the turn could still complete without a visible final. The Feishu dispatcher now treats streaming start as an explicit success/failure state: partial/reasoning previews only mutate streaming state after a successful start, final text+media falls back to the normal static card/media path after a start failure, block-card replies fall back to static cards if independent block delivery was not actually sent, and late partial snapshots cannot append after a final has been committed.

## User Impact

Feishu replies that combine a text body with an image attachment now preserve both parts of the answer. If streaming close, streaming block delivery, or streaming-card startup fails, OpenClaw keeps or re-enters the final reply path instead of silently deduping the answer away and showing the no-visible-reply fallback.

## Evidence

- `node scripts/run-vitest.mjs src/auto-reply/reply/block-reply-pipeline.test.ts src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/reply/agent-runner-payloads.test.ts extensions/feishu/src/reply-dispatcher.test.ts` (core 350 tests, Feishu 90 tests)
- `node scripts/run-vitest.mjs extensions/feishu/src/reply-dispatcher.test.ts` (Feishu 90 tests)
- `./node_modules/.bin/oxlint extensions/feishu/src/reply-dispatcher.ts extensions/feishu/src/reply-dispatcher.test.ts`
- `git diff --check`
- Local Feishu proof image exists and parses as a valid PNG. A live retry before `ed94079`/`8a22d60` still returned the no-visible fallback; logs showed the model produced the expected text+`MEDIA:` final, then Feishu streaming startup failed with `Create card request failed with HTTP 400`, and no final was queued. Commits `ed94079` and `8a22d60` add streaming-start-failure and block-card-fallback coverage for that live gap.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main` is clean after `92e40e3`: no accepted/actionable findings reported.