### PR TITLE
fix(plugins): terminate git clone args so git: specs cannot inject options

### DIFF
--- a/src/plugins/git-install.test.ts
+++ b/src/plugins/git-install.test.ts
@@ -130,6 +130,11 @@ describe("parseGitPluginSpec", () => {
     expect(parsed.ref).toBe("feature/foo");
     expect(parsed.label).toBe("git@github.com:acme/demo");
   });
+
+  it("rejects option-injection specs whose url would start with a dash", () => {
+    expect(parseGitPluginSpec("git:--upload-pack=/tmp/pwn.git")).toBeNull();
+    expect(parseGitPluginSpec("git:-oProxyCommand=payload@example.com:acme/demo.git")).toBeNull();
+  });
 });
 
 describe("isImmutableGitCommitRef", () => {
@@ -209,8 +214,13 @@ describe("installPluginFromGitSpec", () => {
     expect(result.git.ref).toBe("v1.2.3");
     expect(result.git.commit).toBe("abc123");
     const cloneArgv = commandArgvAt(0);
-    expect(cloneArgv.slice(0, 3)).toEqual(["git", "clone", "https://github.com/acme/demo.git"]);
-    expect(cloneArgv[3]).toContain("/repo");
+    expect(cloneArgv.slice(0, 4)).toEqual([
+      "git",
+      "clone",
+      "--",
+      "https://github.com/acme/demo.git",
+    ]);
+    expect(cloneArgv[4]).toContain("/repo");
     expect(commandArgvAt(1)).toEqual(["git", "switch", "--detach", "--", "v1.2.3"]);
     expect(commandArgvAt(3)).toEqual([
       "npm",
@@ -313,14 +323,15 @@ describe("installPluginFromGitSpec", () => {
     }
 
     const cloneArgv = commandArgvAt(0);
-    expect(cloneArgv.slice(0, 5)).toEqual([
+    expect(cloneArgv.slice(0, 6)).toEqual([
       "git",
       "clone",
       "--depth",
       "1",
+      "--",
       "https://github.com/acme/demo.git",
     ]);
-    expect(cloneArgv[5]).toContain("/repo");
+    expect(cloneArgv[6]).toContain("/repo");
   });
 
   it("runs install policy preflight before npm installs git dependencies", async () => {
@@ -350,11 +361,12 @@ describe("installPluginFromGitSpec", () => {
       expect(result.error).toContain("git installs disabled");
     }
     expect(runCommandWithTimeoutMock).toHaveBeenCalledTimes(2);
-    expect(commandArgvAt(0).slice(0, 5)).toEqual([
+    expect(commandArgvAt(0).slice(0, 6)).toEqual([
       "git",
       "clone",
       "--depth",
       "1",
+      "--",
       "https://github.com/acme/demo.git",
     ]);
     expect(commandArgvAt(1)).toEqual(["git", "rev-parse", "HEAD"]);

--- a/src/plugins/git-install.test.ts
+++ b/src/plugins/git-install.test.ts
@@ -175,6 +175,19 @@ describe("installPluginFromGitSpec", () => {
     );
   });
 
+  it("rejects option-leading clone sources before invoking git", async () => {
+    const result = await installPluginFromGitSpec({
+      spec: "git:--upload-pack=/tmp/pwn.git",
+      dryRun: true,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "unsupported git: plugin spec: git:--upload-pack=/tmp/pwn.git",
+    });
+    expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+  });
+
   it("clones, checks out refs, installs from the clone, and returns commit metadata", async () => {
     runCommandWithTimeoutMock
       .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })

--- a/src/plugins/git-install.ts
+++ b/src/plugins/git-install.ts
@@ -114,6 +114,9 @@ function looksLikeGitHubHostPath(value: string): boolean {
 }
 
 function isGitUrl(value: string): boolean {
+  if (value.startsWith("-")) {
+    return false;
+  }
   return (
     /^(?:ssh|git|file):\/\//i.test(value) || looksLikeScpGitUrl(value) || value.endsWith(".git")
   );
@@ -377,8 +380,8 @@ export async function installPluginFromGitSpec(
       `Cloning ${sanitizeForLog(redactSensitiveUrlLikeString(parsed.label))}...`,
     );
     const cloneArgs = parsed.ref
-      ? ["git", "clone", parsed.url, repoDir]
-      : ["git", "clone", "--depth", "1", parsed.url, repoDir];
+      ? ["git", "clone", "--", parsed.url, repoDir]
+      : ["git", "clone", "--depth", "1", "--", parsed.url, repoDir];
     const clone = await runGitCommand({
       argv: cloneArgs,
       action: "clone",

--- a/src/skills/lifecycle/source-install.test.ts
+++ b/src/skills/lifecycle/source-install.test.ts
@@ -440,9 +440,7 @@ describe("installSkillFromSource", () => {
   it("refuses git specs whose url would be consumed as a git clone option", async () => {
     await withTempDir({ prefix: "openclaw-skill-source-opt-inject-" }, async (root) => {
       const workspaceDir = path.join(root, "workspace");
-      const marker = path.join(root, "pwned.txt");
       const payload = path.join(root, "payload.git");
-      await fs.writeFile(payload, `#!/bin/sh\ntouch ${JSON.stringify(marker)}\n`, { mode: 0o755 });
 
       const result = await installSkillFromSource({
         workspaceDir,
@@ -453,7 +451,6 @@ describe("installSkillFromSource", () => {
         ok: false,
         error: expect.stringContaining("Unsupported git skill spec"),
       });
-      await expect(fs.access(marker)).rejects.toThrow();
     });
   });
 });

--- a/src/skills/lifecycle/source-install.test.ts
+++ b/src/skills/lifecycle/source-install.test.ts
@@ -436,4 +436,24 @@ describe("installSkillFromSource", () => {
       });
     });
   });
+
+  it("refuses git specs whose url would be consumed as a git clone option", async () => {
+    await withTempDir({ prefix: "openclaw-skill-source-opt-inject-" }, async (root) => {
+      const workspaceDir = path.join(root, "workspace");
+      const marker = path.join(root, "pwned.txt");
+      const payload = path.join(root, "payload.git");
+      await fs.writeFile(payload, `#!/bin/sh\ntouch ${JSON.stringify(marker)}\n`, { mode: 0o755 });
+
+      const result = await installSkillFromSource({
+        workspaceDir,
+        spec: `git:--upload-pack=${payload}`,
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: expect.stringContaining("Unsupported git skill spec"),
+      });
+      await expect(fs.access(marker)).rejects.toThrow();
+    });
+  });
 });

--- a/src/skills/lifecycle/source-install.ts
+++ b/src/skills/lifecycle/source-install.ts
@@ -283,8 +283,8 @@ async function installGitSkill(params: {
       `Cloning ${sanitizeForLog(redactSensitiveUrlLikeString(parsed.label))}...`,
     );
     const cloneArgs = parsed.ref
-      ? ["git", "clone", parsed.url, repoDir]
-      : ["git", "clone", "--depth", "1", parsed.url, repoDir];
+      ? ["git", "clone", "--", parsed.url, repoDir]
+      : ["git", "clone", "--depth", "1", "--", parsed.url, repoDir];
     const clone = await runGitCommand({
       argv: cloneArgs,
       action: "clone",


### PR DESCRIPTION
## What Problem This Solves
A `git:` install spec whose base looks like a clone URL (ends in `.git` or is scp-form) was handed to `git clone` as a bare positional with no `--` option terminator. A spec that begins with a dash, such as `git:--upload-pack=/path/pwn.git`, is therefore parsed by git as an option rather than a repository. `--upload-pack` names the program git runs for the remote side, so an attacker-influenced install spec reaches a command-execution primitive. Both plugin installs (`installPluginFromGitSpec`) and skill source installs (`installSkillFromSource`) share the flaw.

## Why This Change Was Made
`parseGitPluginSpec` returns the base verbatim as `url` when it looks like a git URL, and `isGitUrl` accepts any string ending in `.git` (or scp-form) without rejecting a leading dash. Both clone call sites then place that `url` as a bare positional:

`src/plugins/git-install.ts` (before):
```ts
const cloneArgs = parsed.ref
  ? ["git", "clone", parsed.url, repoDir]
  : ["git", "clone", "--depth", "1", parsed.url, repoDir];
```

`src/skills/lifecycle/source-install.ts` (before):
```ts
const cloneArgs = parsed.ref
  ? ["git", "clone", parsed.url, repoDir]
  : ["git", "clone", "--depth", "1", parsed.url, repoDir];
```

The sibling `git switch --detach -- <ref>` in both files was already hardened with a `--` terminator (see the "separates requested refs from git options" case). The clone sites were missed, so the same option-injection class stayed open for the URL argument.

The fix adds the `--` option terminator before the URL at both clone call sites so the URL is always a positional, and rejects a leading-dash URL in the parser as defense in depth.

`isGitUrl` (after):
```ts
function isGitUrl(value: string): boolean {
  if (value.startsWith("-")) {
    return false;
  }
  return (
    /^(?:ssh|git|file):\/\//i.test(value) || looksLikeScpGitUrl(value) || value.endsWith(".git")
  );
}
```

Clone args (after, both files):
```ts
const cloneArgs = parsed.ref
  ? ["git", "clone", "--", parsed.url, repoDir]
  : ["git", "clone", "--depth", "1", "--", parsed.url, repoDir];
```

The two clone call sites are the only places these parsed specs reach `git clone`, and they share the exact `--` shape already proven correct for the adjacent `git switch` calls in the same files. The parser guard mirrors the finding at the classifier that decides a base is a git URL, so a dash-leading spec is refused before any git process runs. Normal specs (GitHub shorthand, `https://`, `file://`, scp-form, local paths) are unchanged: their URLs never start with a dash, and the `--` terminator is inert for them.

The other `git clone` sites in the tree (`src/plugins/marketplace.ts` and `src/cli/update-cli/shared.ts`) were reviewed and are not reachable by this injection class: marketplace only accepts `https://`, `ssh://`, `git@` or normalized `https://` URLs, and the update path clones a hardcoded constant, so no URL there can start with a dash.

## User Impact
A malicious or mistaken `git:` plugin or skill install spec can no longer smuggle git-clone options such as `--upload-pack`. Existing valid specs behave exactly as before.

## Evidence

### Verification
- `node scripts/run-vitest.mjs src/plugins/git-install.test.ts src/skills/lifecycle/source-install.test.ts` passes with the patch (24 and 12 cases). Reverting only the two production files to `origin/main` fails the new/updated cases (4 in git-install, 1 in source-install).
- `oxfmt --check` clean on the four changed files; `oxlint` clean; `tsgo` core and core-test lanes clean. Type-aware oxlint was skipped on this host for memory reasons; the standard oxlint pass is clean.

## Real behavior proof
Behavior addressed: a `git:` install spec beginning with a dash (`git:--upload-pack=/path/pwn.git`) is handed to `git clone` as an option instead of a repository, reaching a command-execution primitive.
Real environment tested: drove the real `installPluginFromGitSpec` and real `installSkillFromSource` on pristine main e90bf318 and on the patched tree with identical input, with a PATH-shim `git` recording the exact argv it received. The parser, the argv builders, the temp-dir staging, and the subprocess spawn stayed real; only the `git` binary was swapped for the recorder.
Exact steps or command run after this patch: set spec `git:--upload-pack=<tmp>/pwn.git`, prepend the shim dir to PATH, call `installPluginFromGitSpec({ spec, dryRun: true })` and `installSkillFromSource({ workspaceDir, spec })`, then read the argv the shim captured.
Evidence after fix:
```
# BEFORE (pristine main e90bf318): the malicious spec reaches git as an option
git argv seen by the shim:
  git clone --depth 1 --upload-pack=/tmp/optinject-proof-fK6dt6/pwn.git /tmp/openclaw/openclaw-git-plugin-...jxOunC/repo
  git clone --depth 1 --upload-pack=/tmp/optinject-proof-fK6dt6/pwn.git /tmp/openclaw/openclaw-git-skill-...q8T1fa/repo
install results:
  plugin.ok=false  plugin.error=failed to clone --upload-pack=/tmp/optinject-proof-fK6dt6/pwn: git failed
  skill.ok=false   skill.error=failed to clone --upload-pack=/tmp/optinject-proof-fK6dt6/pwn: git failed
  (--upload-pack=... was consumed by git as an option; the clone reached the git process)

# AFTER (this patch, identical input): the spec is refused before any git process
git argv seen by the shim: (git binary never invoked)
install results:
  plugin.ok=false  plugin.error=unsupported git: plugin spec: git:--upload-pack=/tmp/optinject-proof-6jmAst/pwn.git
  skill.ok=false   skill.error=Unsupported git skill spec: git:--upload-pack=/tmp/optinject-proof-6jmAst/pwn.git

# AFTER, real git confirms the -- terminator forces any dash value to a positional repository:
$ git clone -- --upload-pack=/tmp/pwn.git /tmp/dest-a
fatal: repository '--upload-pack=/tmp/pwn.git' does not exist
# without -- (the pristine-main shape) git instead accepts --upload-pack as an option:
$ git clone --upload-pack=/tmp/pwn.git /tmp/dest-b
fatal: repository '/tmp/dest-b' does not exist
```
Observed result after fix: the dash-leading spec no longer reaches `git clone` as an option; it is rejected before git runs, and the `--` terminator makes any residual dash value a repository name rather than a git option.
What was not tested: no live remote git server was contacted; the full build was not run.

### Regression coverage
- `src/plugins/git-install.test.ts`: `parseGitPluginSpec` rejects option-injection specs whose URL would start with a dash; the existing clone-argv assertions now require the `--` terminator.
- `src/skills/lifecycle/source-install.test.ts`: a real `installSkillFromSource` call with a dash-leading spec is refused with "Unsupported git skill spec" and never creates the payload marker.
