### PR TITLE
fix(backup): write backup archive with owner-only 0o600 permissions

### DIFF
--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -1315,4 +1315,27 @@ describe("createBackupArchive", () => {
       },
     );
   });
+
+  it("writes the published archive with owner-only 0o600 permissions", async () => {
+    await withOpenClawTestState(
+      {
+        layout: "state-only",
+        prefix: "openclaw-backup-mode-",
+        scenario: "minimal",
+      },
+      async (state) => {
+        const outputDir = state.path("backups");
+        await fs.mkdir(outputDir, { recursive: true });
+
+        const result = await createBackupArchive({
+          output: outputDir,
+          includeWorkspace: false,
+          nowMs: Date.UTC(2026, 4, 9, 12, 0, 0),
+        });
+
+        const stat = await fs.stat(result.archivePath);
+        expect(stat.mode & 0o777).toBe(0o600);
+      },
+    );
+  });
 });

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -1316,26 +1316,42 @@ describe("createBackupArchive", () => {
     );
   });
 
-  it("writes the published archive with owner-only 0o600 permissions", async () => {
-    await withOpenClawTestState(
-      {
-        layout: "state-only",
-        prefix: "openclaw-backup-mode-",
-        scenario: "minimal",
-      },
-      async (state) => {
-        const outputDir = state.path("backups");
-        await fs.mkdir(outputDir, { recursive: true });
+  describe.runIf(process.platform !== "win32")("archive permissions", () => {
+    it.each([
+      ["hard link", false],
+      ["copy fallback", true],
+    ] as const)("publishes via %s with owner-only 0o600 permissions", async (_name, forceCopy) => {
+      const linkSpy = forceCopy
+        ? vi
+            .spyOn(fs, "link")
+            .mockRejectedValue(
+              Object.assign(new Error("hard links unsupported"), { code: "EPERM" }),
+            )
+        : undefined;
+      try {
+        await withOpenClawTestState(
+          {
+            layout: "state-only",
+            prefix: "openclaw-backup-mode-",
+            scenario: "minimal",
+          },
+          async (state) => {
+            const outputDir = state.path("backups");
+            await fs.mkdir(outputDir, { recursive: true });
 
-        const result = await createBackupArchive({
-          output: outputDir,
-          includeWorkspace: false,
-          nowMs: Date.UTC(2026, 4, 9, 12, 0, 0),
-        });
+            const result = await createBackupArchive({
+              output: outputDir,
+              includeWorkspace: false,
+              nowMs: Date.UTC(2026, 4, 9, 12, 0, 0),
+            });
 
-        const stat = await fs.stat(result.archivePath);
-        expect(stat.mode & 0o777).toBe(0o600);
-      },
-    );
+            const stat = await fs.stat(result.archivePath);
+            expect(stat.mode & 0o777).toBe(0o600);
+          },
+        );
+      } finally {
+        linkSpy?.mockRestore();
+      }
+    });
   });
 });

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -191,7 +191,7 @@ async function writeArchiveStreamToFile(params: {
 }): Promise<void> {
   // Own both stream lifecycles so a tar read error closes the output handle
   // before retry cleanup touches the partial archive.
-  await pipeline(params.archiveStream, createWriteStream(params.archivePath));
+  await pipeline(params.archiveStream, createWriteStream(params.archivePath, { mode: 0o600 }));
 }
 
 async function writeTarArchiveWithRetry(params: {

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -191,7 +191,12 @@ async function writeArchiveStreamToFile(params: {
 }): Promise<void> {
   // Own both stream lifecycles so a tar read error closes the output handle
   // before retry cleanup touches the partial archive.
-  await pipeline(params.archiveStream, createWriteStream(params.archivePath, { mode: 0o600 }));
+  // Exclusive creation guarantees the 0600 mode belongs to a fresh inode and
+  // refuses a pre-existing temp path instead of following a symlink.
+  await pipeline(
+    params.archiveStream,
+    createWriteStream(params.archivePath, { flags: "wx", mode: 0o600 }),
+  );
 }
 
 async function writeTarArchiveWithRetry(params: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw backup` writes its `.tar.gz` archive world-readable (0644), so any other local user can read every credential out of the published backup. The archive bundles `auth.json` (OAuth access and refresh tokens), `openclaw.json` (provider API keys), and the state database, all in one file that lands group- and world-readable.

The intermediate SQLite snapshot inside the flow is already hardened to `0o600` (`src/infra/backup-create.ts:732`), so the module already treats these bytes as secret, but that mitigation never reached the final archive that actually leaves the machine.

## Why This Change Was Made

Root cause is `src/infra/backup-create.ts:194`. The single shared archive writer creates the output stream with no `mode`, so the file is created 0644 (minus umask):

```ts
// before
await pipeline(params.archiveStream, createWriteStream(params.archivePath));
```

`publishTempArchive` then hard-links (`fs.link`, :357) or copies (`fs.copyFile`, :371) that temp file to the final output path, and both carry the 0644 mode through to the published artifact.

The fix creates the stream owner-only from the start:

```ts
// after
await pipeline(params.archiveStream, createWriteStream(params.archivePath, { mode: 0o600 }));
```

`createWriteStream` opens the file with `O_CREAT` and this mode, so there is no world-readable window. `writeArchiveStreamToFile` is the one funnel every archive write (initial attempt and every `.retry-N` retry) passes through before publish, so hardening it once covers all callers. `fs.link` shares the inode (same mode) and `fs.copyFile` copies the source mode, so the single write-site change reaches both publish paths without touching `publishTempArchive`. This mirrors the existing `0o600` chmod already applied to the SQLite snapshot in the same module. Only the file mode changes; archive contents, layout, and verification are untouched.

## User Impact

Backups created by `openclaw backup` are now owner-only (`-rw-------`). Operators on shared or multi-user hosts no longer leak OAuth tokens, provider API keys, and state to other local accounts through a world-readable backup file. Existing archives are unaffected; the new mode applies to newly created backups.

## Evidence

Drove the real `createBackupArchive` production entry point on a real on-disk OpenClaw state tree seeded with a provider API key in `openclaw.json`, on pristine `origin/main` 735dbd2 and on the patched tree, then `ls -l` on the produced archive and extracted its bytes with `tar -xzO | grep`. State discovery, the tar archiver, and the publish path all stayed real; nothing was faked.

Steps: seed `openclaw.json` with `sk-PROOF-SECRET-TOKEN-0123456789`, run `createBackupArchive({ output, includeWorkspace: false })`, then `ls -l <archive>` and `tar -xzOf <archive> | grep -c <secret>`.

```
# BEFORE (pristine main 735dbd2)
ls -l archive: -rw-r--r-- 1 root root 20919 Jul  9 03:46 .../backups/2026-05-09T12-00-00.000+00-00-openclaw-backup.tar.gz
archived files containing the raw API key: 1
# AFTER (this patch, identical inputs)
ls -l archive: -rw------- 1 root root 20918 Jul  9 03:46 .../backups/2026-05-09T12-00-00.000+00-00-openclaw-backup.tar.gz
archived files containing the raw API key: 1
```

Before the change the produced archive is `-rw-r--r--` (readable by every local user) while carrying the raw API key inside it; after the change the same archive is `-rw-------`, owner-only, so the credential is no longer exposed to other local users.

Regression and checks:
- `node scripts/run-vitest.mjs src/infra/backup-create.test.ts`: 42 passed, including the new `writes the published archive with owner-only 0o600 permissions`.
- The new test fails on pristine `origin/main` (`expected 420 to be 384`, i.e. 0o644 vs 0o600) and passes with the patch.
- `oxfmt --check`, `oxlint`, and `tsgo -p tsconfig.core.json` / `-p test/tsconfig/tsconfig.core.test.json` are clean on the changed files.

Not covered: no live provider request and no full build were run; the `fs.copyFile` publish fallback (only reached when the target filesystem rejects hard links) was not driven end to end, though it provably preserves the source `0o600` mode.
