### PR TITLE
fix(gateway): replace ReDoS-vulnerable data URL regex with linear parsing (#102393)

### DIFF
--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -586,6 +586,31 @@ describe("createManagedOutgoingImageBlocks", () => {
     await expectPathMissing(path.join(stateDir, "media", "outgoing", "records"));
   });
 
+  it("rejects semicolon-heavy malformed data urls in bounded time (ReDoS regression)", async () => {
+    const semicolons = ";".repeat(64);
+    const malformed = `data:image/png${semicolons}`;
+
+    const start = performance.now();
+    await expect(
+      createManagedOutgoingImageBlocks({
+        sessionKey: "agent:main:main",
+        mediaUrls: [malformed],
+        stateDir,
+      }),
+    ).rejects.toThrow("Invalid image data URL");
+    expect(performance.now() - start).toBeLessThan(100);
+  });
+
+  it("rejects malformed data urls with a later ;base64, marker after a payload comma", async () => {
+    await expect(
+      createManagedOutgoingImageBlocks({
+        sessionKey: "agent:main:main",
+        mediaUrls: ["data:image/png;base64,garbage;base64,iVBORw0KGgo="],
+        stateDir,
+      }),
+    ).rejects.toThrow("Invalid image data URL");
+  });
+
   it("rewrites local image sources into managed display blocks without leaking the source path", async () => {
     const sourcePath = path.join(stateDir, "workspace", "fixtures", "dot.png");
     await fs.mkdir(path.dirname(sourcePath), { recursive: true });

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -279,22 +279,37 @@ function parseImageDataUrl(
   if (!trimmed.startsWith("data:")) {
     return { kind: "not-data-url" };
   }
-  const match = /^data:([^;,]+)(?:;[^,]*)*;base64,([A-Za-z0-9+/=\s]+)$/i.exec(trimmed);
-  if (!match) {
+
+  const afterPrefix = trimmed.slice("data:".length);
+  const commaIdx = afterPrefix.indexOf(",");
+  if (commaIdx < 0 || !/;base64$/i.test(afterPrefix.slice(0, commaIdx))) {
     throw new Error("Invalid image data URL");
   }
-  const contentType = match[1]?.trim().toLowerCase() ?? "";
+
+  const mimeAndParams = afterPrefix.slice(0, commaIdx);
+  const semicolonIdx = mimeAndParams.indexOf(";");
+  const contentType = (semicolonIdx < 0 ? mimeAndParams : mimeAndParams.slice(0, semicolonIdx))
+    .trim()
+    .toLowerCase();
+
+  const base64Part = afterPrefix.slice(commaIdx + 1);
+  if (!/^[A-Za-z0-9+/=\s]+$/.test(base64Part)) {
+    throw new Error("Invalid image data URL");
+  }
+
   if (!contentType.startsWith("image/")) {
     return { kind: "non-image-data-url" };
   }
-  if (estimateBase64DecodedByteLength(match[2]) > limits.maxBytes) {
+
+  if (estimateBase64DecodedByteLength(base64Part) > limits.maxBytes) {
     throw createManagedImageAttachmentError(
       `Managed image attachment ${JSON.stringify(alt)} exceeds the ${formatLimitMiB(limits.maxBytes)} byte limit`,
     );
   }
+
   return {
     kind: "image-data-url",
-    buffer: Buffer.from(match[2].replace(/\s+/g, ""), "base64"),
+    buffer: Buffer.from(base64Part.replace(/\s+/g, ""), "base64"),
     contentType,
   };
 }


### PR DESCRIPTION

Closes #102393

## What Problem This Solves

Fixes an issue where a model-emitted malformed `data:` image URL containing
repeated semicolons (e.g. `data:image/png;;;...`) would consume 2+ seconds on the
gateway event loop during managed outgoing image preparation. With 40 semicolons
the parser did not return before the 5-second process guard killed the child
process. This is a ReDoS (Regular Expression Denial of Service) vulnerability in
the gateway reply path triggered by `mediaUrl` / `mediaUrls` from model replies.

## Why This Change Was Made

Replaced the nested-repeat regex in `parseImageDataUrl` with a linear
first-comma-anchored parser. The original regex `(?:;[^,]*)*` allowed the inner
character class `[^,]*` to consume semicolons, causing the engine to partition
semicolon runs in exponentially many ways before failing on the missing
`;base64,` marker.

The new parser splits at the **first comma** (per RFC 2397: it separates
metadata from payload), then validates that the metadata segment ends with
`;base64` and that the payload contains only valid base64 characters. This
matches the same `indexOf`-based pattern used by 10+ data URL call sites
across the codebase (e.g. `media-core`'s `parseInlineImageDataUrl`) and
correctly rejects malformed inputs where a later `;base64,` marker appears
after payload text.

This is a focused fix: no dependencies were added, no public APIs or config
changed, and all existing error messages and types are preserved.

## User Impact

Gateway operators no longer face event-loop stalls when model replies include
malformed `data:` image URLs. The fix is transparent to all valid data URLs and
has no user-visible behavior change.

## Evidence

### Unit tests — 152 passed across 4 gateway shards

```
 ✓ |gateway-core|   (38 tests) 1188ms
 ✓ |gateway-server| (38 tests) 1039ms
 ✓ |gateway-client| (38 tests) 1186ms
 ✓ |gateway-methods| (38 tests) 1131ms

 Test Files  4 passed (4)
      Tests  152 passed (152)
```

Two new regression tests were added:

- `rejects semicolon-heavy malformed data urls in bounded time (ReDoS regression)` —
  rejects a 64-semicolon malformed URL in < 100ms (original: 443ms at 32, >5s at 40)
- `rejects malformed data urls with a later ;base64, marker after a payload comma` —
  rejects `data:image/png;base64,garbage;base64,iVBORw0KGgo=` per Codex review

### Real behavior proof — exercises actual patched createManagedOutgoingImageBlocks

A proof script (`real-behavior-proof.mjs`) imports the actual
`createManagedOutgoingImageBlocks` from the patched source and exercises it
with malformed and valid data URLs. Run with `npx tsx real-behavior-proof.mjs`:

```
=== Real Behavior Proof: ReDoS Fix for #102393 ===
Exercising actual createManagedOutgoingImageBlocks (patched parser)

[  0.70ms] PASS 64   semicolons → Invalid image data URL
[  0.05ms] PASS 128  semicolons → Invalid image data URL
[  0.03ms] PASS 256  semicolons → Invalid image data URL
[  0.02ms] PASS 512  semicolons → Invalid image data URL
[  0.13ms] PASS payload comma before later ;base64, → Invalid image data URL
[   OK  ] PASS valid tiny PNG → 1 block(s), mimeType=image/png

=== 6 passed, 0 failed ===
```

For context, the original regex measured 443ms at 32 semicolons (16× per +4)
and would exceed 5 seconds at 40. The patched parser completes in < 1ms at any
length, including 512 semicolons, and correctly accepts valid image data URLs.


---

This PR is AI-assisted. Analysis, implementation, and testing were performed using AI tools (opencode) with review by the author.
