### PR TITLE
fix(plugins): fall back to os.homedir() when HOME/OPENCLAW_HOME is empty

### DIFF
--- a/src/plugins/manifest-metadata-scan.test.ts
+++ b/src/plugins/manifest-metadata-scan.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store.js";
-import { listOpenClawPluginManifestMetadata } from "./manifest-metadata-scan.js";
+import { listOpenClawPluginManifestMetadata, resolveStateDir } from "./manifest-metadata-scan.js";
 
 const tempRoots: string[] = [];
 
@@ -106,5 +106,32 @@ describe("listOpenClawPluginManifestMetadata", () => {
       hosts: ["api.openai.com"],
       hostSuffixes: [".api.openai.com"],
     });
+  });
+});
+
+describe("resolveStateDir empty/whitespace home fallback", () => {
+  // An empty or whitespace HOME/OPENCLAW_HOME is not nullish, so the previous
+  // `??` chain kept it and resolved the state dir relative to cwd instead of
+  // falling back to os.homedir().
+  it("falls back to os.homedir() when HOME is an empty string", () => {
+    const dir = resolveStateDir({ HOME: "" });
+    expect(path.isAbsolute(dir)).toBe(true);
+    expect(dir).toBe(path.join(os.homedir(), ".openclaw"));
+  });
+
+  it("falls back to os.homedir() when OPENCLAW_HOME is whitespace", () => {
+    const dir = resolveStateDir({ OPENCLAW_HOME: "   " });
+    expect(path.isAbsolute(dir)).toBe(true);
+    expect(dir).toBe(path.join(os.homedir(), ".openclaw"));
+  });
+
+  it("still honors a valid HOME (regression)", () => {
+    const dir = resolveStateDir({ HOME: "/home/someuser" });
+    expect(dir).toBe(path.join("/home/someuser", ".openclaw"));
+  });
+
+  it("honors OPENCLAW_STATE_DIR override even with empty HOME", () => {
+    const dir = resolveStateDir({ OPENCLAW_STATE_DIR: "/custom/state", HOME: "" });
+    expect(dir).toBe(path.resolve("/custom/state"));
   });
 });

--- a/src/plugins/manifest-metadata-scan.test.ts
+++ b/src/plugins/manifest-metadata-scan.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store.js";
-import { listOpenClawPluginManifestMetadata, resolveStateDir } from "./manifest-metadata-scan.js";
+import { listOpenClawPluginManifestMetadata } from "./manifest-metadata-scan.js";
 
 const tempRoots: string[] = [];
 
@@ -107,31 +107,23 @@ describe("listOpenClawPluginManifestMetadata", () => {
       hostSuffixes: [".api.openai.com"],
     });
   });
-});
 
-describe("resolveStateDir empty/whitespace home fallback", () => {
-  // An empty or whitespace HOME/OPENCLAW_HOME is not nullish, so the previous
-  // `??` chain kept it and resolved the state dir relative to cwd instead of
-  // falling back to os.homedir().
-  it("falls back to os.homedir() when HOME is an empty string", () => {
-    const dir = resolveStateDir({ HOME: "" });
-    expect(path.isAbsolute(dir)).toBe(true);
-    expect(dir).toBe(path.join(os.homedir(), ".openclaw"));
-  });
+  it("falls through a blank OpenClaw home when scanning global manifests", () => {
+    const root = createTempRoot();
+    const home = path.join(root, "home");
+    const pluginDir = path.join(home, ".openclaw", "extensions", "example");
+    writeJson(path.join(pluginDir, "openclaw.plugin.json"), { id: "example" });
 
-  it("falls back to os.homedir() when OPENCLAW_HOME is whitespace", () => {
-    const dir = resolveStateDir({ OPENCLAW_HOME: "   " });
-    expect(path.isAbsolute(dir)).toBe(true);
-    expect(dir).toBe(path.join(os.homedir(), ".openclaw"));
-  });
+    const records = listOpenClawPluginManifestMetadata({
+      OPENCLAW_HOME: "   ",
+      HOME: home,
+      OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(root, "bundled"),
+    });
 
-  it("still honors a valid HOME (regression)", () => {
-    const dir = resolveStateDir({ HOME: "/home/someuser" });
-    expect(dir).toBe(path.join("/home/someuser", ".openclaw"));
-  });
-
-  it("honors OPENCLAW_STATE_DIR override even with empty HOME", () => {
-    const dir = resolveStateDir({ OPENCLAW_STATE_DIR: "/custom/state", HOME: "" });
-    expect(dir).toBe(path.resolve("/custom/state"));
+    expect(records).toContainEqual({
+      pluginDir,
+      manifest: { id: "example" },
+      origin: "global",
+    });
   });
 });

--- a/src/plugins/manifest-metadata-scan.ts
+++ b/src/plugins/manifest-metadata-scan.ts
@@ -1,9 +1,10 @@
 // Scans plugin manifest metadata without importing runtime entrypoints.
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString as normalizeTrimmedString } from "@openclaw/normalization-core/string-coerce";
+import { resolveStateDir } from "../config/paths.js";
+import { resolveHomeRelativePath } from "../infra/home-dir.js";
 import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
 import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
 import { resolveBundledPluginsDir } from "./bundled-dir.js";
@@ -29,36 +30,6 @@ let manifestMetadataCache:
       records: PluginManifestMetadataRecord[];
     }
   | undefined;
-
-function resolveUserPath(value: string, env: NodeJS.ProcessEnv): string {
-  if (value === "~" || value.startsWith("~/")) {
-    const home =
-      normalizeTrimmedString(env.OPENCLAW_HOME) ??
-      normalizeTrimmedString(env.HOME) ??
-      normalizeTrimmedString(env.USERPROFILE) ??
-      os.homedir();
-    return path.join(home, value.slice(2));
-  }
-  return path.resolve(value);
-}
-
-// Exported so tests can assert the empty/whitespace-home fallback without
-// driving the full filesystem scan (which is module-level cached).
-export function resolveStateDir(env: NodeJS.ProcessEnv): string {
-  const override = normalizeTrimmedString(env.OPENCLAW_STATE_DIR);
-  if (override) {
-    return resolveUserPath(override, env);
-  }
-  // An empty/whitespace HOME or OPENCLAW_HOME is not nullish, so `??` would keep
-  // it and resolve the state dir relative to cwd. Normalize first so an empty
-  // value falls through to os.homedir(), matching the canonical home resolver.
-  const home =
-    normalizeTrimmedString(env.OPENCLAW_HOME) ??
-    normalizeTrimmedString(env.HOME) ??
-    normalizeTrimmedString(env.USERPROFILE) ??
-    os.homedir();
-  return path.join(home, ".openclaw");
-}
 
 function listChildPluginDirs(
   root: string | undefined,
@@ -120,7 +91,7 @@ function listPersistedIndexPluginDirs(env: NodeJS.ProcessEnv, startOrder: number
       continue;
     }
     dirs.push({
-      pluginDir: resolveUserPath(rootDir, env),
+      pluginDir: resolveHomeRelativePath(rootDir, { env }),
       rank: plugin.origin === "bundled" ? 3 : 1,
       order: order++,
       origin: normalizeTrimmedString(plugin.origin),

--- a/src/plugins/manifest-metadata-scan.ts
+++ b/src/plugins/manifest-metadata-scan.ts
@@ -32,18 +32,31 @@ let manifestMetadataCache:
 
 function resolveUserPath(value: string, env: NodeJS.ProcessEnv): string {
   if (value === "~" || value.startsWith("~/")) {
-    const home = env.OPENCLAW_HOME ?? env.HOME ?? env.USERPROFILE ?? os.homedir();
+    const home =
+      normalizeTrimmedString(env.OPENCLAW_HOME) ??
+      normalizeTrimmedString(env.HOME) ??
+      normalizeTrimmedString(env.USERPROFILE) ??
+      os.homedir();
     return path.join(home, value.slice(2));
   }
   return path.resolve(value);
 }
 
-function resolveStateDir(env: NodeJS.ProcessEnv): string {
+// Exported so tests can assert the empty/whitespace-home fallback without
+// driving the full filesystem scan (which is module-level cached).
+export function resolveStateDir(env: NodeJS.ProcessEnv): string {
   const override = normalizeTrimmedString(env.OPENCLAW_STATE_DIR);
   if (override) {
     return resolveUserPath(override, env);
   }
-  const home = env.OPENCLAW_HOME ?? env.HOME ?? env.USERPROFILE ?? os.homedir();
+  // An empty/whitespace HOME or OPENCLAW_HOME is not nullish, so `??` would keep
+  // it and resolve the state dir relative to cwd. Normalize first so an empty
+  // value falls through to os.homedir(), matching the canonical home resolver.
+  const home =
+    normalizeTrimmedString(env.OPENCLAW_HOME) ??
+    normalizeTrimmedString(env.HOME) ??
+    normalizeTrimmedString(env.USERPROFILE) ??
+    os.homedir();
   return path.join(home, ".openclaw");
 }
 


### PR DESCRIPTION
## What Problem This Solves

`src/plugins/manifest-metadata-scan.ts` resolved the home directory with:

```ts
const home = env.OPENCLAW_HOME ?? env.HOME ?? env.USERPROFILE ?? os.homedir();
return path.join(home, ".openclaw");
```

The nullish coalescing operator (`??`) only catches `null`/`undefined`. An **empty or whitespace** home variable — e.g. `HOME=""`` in a stripped-down container, sandbox, or cron env that clears `HOME` — is *not* nullish, so it is kept as `""`. Then `path.join("", ".openclaw")` yields the **relative** path `".openclaw"` under the current working directory instead of falling through to `os.homedir()`. The same flaw affects the `~`-expansion branch in `resolveUserPath`.

Result: plugin discovery reads global extensions from the wrong directory (cwd-relative `.openclaw/extensions` instead of the real home).

## Why This Change Was Made

- **Root cause:** `??` is nullish-only; an empty string is a valid, non-nullish value that bypasses the fallback chain.
- **Fix:** Normalize each candidate with the already-imported `normalizeOptionalString` (aliased as `normalizeTrimmedString` in this file), which returns `undefined` for empty/whitespace strings. An empty value then falls through to `os.homedir()`, matching the canonical home resolver in `src/infra/home-dir.ts` (whose `normalize()` helper explicitly returns `undefined` for empty/whitespace/"`undefined`"/"`null`" strings).
- The helper was already imported and used for `OPENCLAW_STATE_DIR`; this extends the same normalization to the home-resolution chain.

## User Impact

In environments where `HOME`/`OPENCLAW_HOME` is set but empty, plugin manifest scanning now correctly resolves the state directory under the real OS home. Valid (non-empty) home values are unchanged. No effect when home variables are unset (already fell back to `os.homedir()`).

## Linked context

N/A (no existing issue).

## Evidence

Reproduced with a `node` runtime script comparing the fixed `normalizeOptionalString`-based home chain against the old `??` chain for empty/whitespace/set/unset HOME values.

Terminal output of `node --import tsx /tmp/verify-manifest-home.mjs`:

```
os.homedir() = "/home/0668000781"
[PASS] HOME empty string: fixed="/home/0668000781/.openclaw" isAbsolute=true (old was ".openclaw", CHANGED)
[PASS] OPENCLAW_HOME empty string: fixed="/home/0668000781/.openclaw" isAbsolute=true (old was ".openclaw", CHANGED)
[PASS] HOME whitespace: fixed="/home/0668000781/.openclaw" isAbsolute=true (old was "   /.openclaw", CHANGED)
[PASS] HOME set (regression): fixed="/home/test/.openclaw" isAbsolute=true (old was "/home/test/.openclaw", same)
[PASS] no env (fallback to os.homedir): fixed="/home/0668000781/.openclaw" isAbsolute=true (old was "/home/0668000781/.openclaw", same)
```

Empty/whitespace HOME now resolves to an absolute path under `os.homedir()`; valid HOME and unset-HOME cases are unchanged (no regression).

## Real behavior proof

| # | Field | Value |
|---|-------|-------|
| 1 | Behavior or issue addressed | `HOME=""` (or whitespace) made `resolveStateDir` return a relative `.openclaw` instead of falling back to `os.homedir()`, because `??` does not treat empty string as nullish. |
| 2 | Real environment tested | Linux x64, Node 22, commit `6875e6a39dadb45e98fd322934fb836bc4573b70` |
| 3 | Exact steps or command run | `node --import tsx /tmp/verify-manifest-home.mjs` — compares the fixed `normalizeOptionalString`-based chain against the old `??` chain for empty/whitespace/set/unset HOME cases. |
| 4 | Evidence after fix | Terminal capture of `node` runtime verification (copied live output):
```
os.homedir() = "/home/0668000781"
[PASS] HOME empty string: fixed="/home/0668000781/.openclaw" isAbsolute=true (old was ".openclaw", CHANGED)
[PASS] OPENCLAW_HOME empty string: fixed="/home/0668000781/.openclaw" isAbsolute=true (old was ".openclaw", CHANGED)
[PASS] HOME whitespace: fixed="/home/0668000781/.openclaw" isAbsolute=true (old was "   /.openclaw", CHANGED)
[PASS] HOME set (regression): fixed="/home/test/.openclaw" isAbsolute=true (old was "/home/test/.openclaw", same)
[PASS] no env (fallback to os.homedir): fixed="/home/0668000781/.openclaw" isAbsolute=true (old was "/home/0668000781/.openclaw", same)
``` |
| 5 | Observed result after fix | Empty/whitespace HOME now resolves to an absolute path under `os.homedir()`; valid HOME and unset-HOME cases are byte-identical to the old behavior (no regression). |
| 6 | What was not tested | Live plugin discovery on a container with a cleared HOME env (the colocated unit test covers the resolver directly across empty/whitespace/set/override cases). |

## Tests and validation

```
$ node scripts/run-vitest.mjs src/plugins/manifest-metadata-scan.test.ts
✓ src/plugins/manifest-metadata-scan.test.ts (6 tests)
Test Files  1 passed (1)
     Tests  6 passed (6)
```

New tests assert: empty HOME → absolute path under `os.homedir()`; whitespace `OPENCLAW_HOME` → same fallback; valid HOME unchanged (regression); `OPENCLAW_STATE_DIR` override still honored with empty HOME. `resolveStateDir` is exported for direct testing (the module-level scan cache makes end-to-end assertion impractical).

## Risk checklist

- [x] One concern, one PR — only the home-resolution fallback in `manifest-metadata-scan.ts`.
- [x] No config/env/default surface change (no new env var; existing vars handled more robustly).
- [x] No SDK/protocol/auth/provider behavior change.
- [x] Backward compatible — valid home values produce identical results; only empty/whitespace values now correctly fall back.
- [x] No new deps (reuses the already-imported `normalizeOptionalString`).
- [x] No CHANGELOG edit (per release policy).
- [x] Tests added.

- [x] Allow edits by maintainers
