### PR TITLE
fix(codex): app inventory error diagnostics stay UTF-16 safe

### DIFF
--- a/extensions/codex/src/app-server/app-inventory-cache.test.ts
+++ b/extensions/codex/src/app-server/app-inventory-cache.test.ts
@@ -217,6 +217,12 @@ describe("Codex app inventory cache", () => {
     );
   });
 
+  it("keeps serialized app/list error messages on a UTF-16 boundary", () => {
+    const error = new Error(`${"x".repeat(499)}🚀tail`);
+
+    expect(serializeCodexAppInventoryError(error).message).toBe(`${"x".repeat(499)}...`);
+  });
+
   it("keeps serialized app/list error data on a UTF-16 boundary", () => {
     const error = Object.assign(new Error("app list failed"), {
       data: { label: `${"x".repeat(499)}🚀tail` },

--- a/extensions/codex/src/app-server/app-inventory-cache.ts
+++ b/extensions/codex/src/app-server/app-inventory-cache.ts
@@ -389,7 +389,7 @@ function sanitizeErrorMessage(message: string): string {
     "$1<redacted>",
   );
   return redacted.length > MAX_SERIALIZED_ERROR_MESSAGE_LENGTH
-    ? `${redacted.slice(0, MAX_SERIALIZED_ERROR_MESSAGE_LENGTH)}...`
+    ? `${truncateUtf16Safe(redacted, MAX_SERIALIZED_ERROR_MESSAGE_LENGTH)}...`
     : redacted;
 }
 

--- a/extensions/codex/src/app-server/app-inventory-cache.ts
+++ b/extensions/codex/src/app-server/app-inventory-cache.ts
@@ -338,6 +338,12 @@ function fingerprintInventoryCacheKey(key: string): string {
   return hash.toString(16).padStart(8, "0");
 }
 
+function truncateSerializedErrorText(value: string): string {
+  return value.length > MAX_SERIALIZED_ERROR_MESSAGE_LENGTH
+    ? `${truncateUtf16Safe(value, MAX_SERIALIZED_ERROR_MESSAGE_LENGTH)}...`
+    : value;
+}
+
 function redactErrorData(value: unknown, depth = 0): JsonValue | undefined {
   if (value === undefined) {
     return undefined;
@@ -360,11 +366,8 @@ function redactErrorData(value: unknown, depth = 0): JsonValue | undefined {
     }
     return redacted;
   }
-  if (typeof value === "string" && value.length > 500) {
-    return `${truncateUtf16Safe(value, 500)}...`;
-  }
   if (typeof value === "string") {
-    return value;
+    return truncateSerializedErrorText(value);
   }
   if (typeof value === "bigint") {
     return value.toString();
@@ -388,9 +391,7 @@ function sanitizeErrorMessage(message: string): string {
     /([?&][^=\s"'<>]*(?:api[_-]?key|authorization|cookie|credential|password|secret|token|tk)[^=\s"'<>]*=)[^&\s"'<>]+/gi,
     "$1<redacted>",
   );
-  return redacted.length > MAX_SERIALIZED_ERROR_MESSAGE_LENGTH
-    ? `${truncateUtf16Safe(redacted, MAX_SERIALIZED_ERROR_MESSAGE_LENGTH)}...`
-    : redacted;
+  return truncateSerializedErrorText(redacted);
 }
 
 function isSensitiveErrorDataKey(key: string): boolean {


### PR DESCRIPTION
## What Problem This Solves

Codex app inventory refresh diagnostics could serialize a long top-level error message with a dangling UTF-16 surrogate when an `app/list` failure crossed the 500-code-unit limit. Nested error-data strings already used safe truncation, but the top-level message did not.

## Why This Change Was Made

- Route both top-level messages and nested error-data strings through one `truncateSerializedErrorText` owner.
- Reuse the existing `truncateUtf16Safe` primitive and preserve the existing 500-unit limit, ellipsis, HTML omission, secret redaction, cache behavior, and protocol.
- Add an exact regression where an emoji straddles the top-level message boundary.

The upstream Codex contract was checked directly: `app/list` is registered as an unserialized request in `codex-rs/app-server-protocol/src/protocol/common.rs:732-735`; its response is `AppsListResponse` in `codex-rs/app-server-protocol/src/protocol/v2/apps.rs:159-168`; and concurrent connector failures become JSON-RPC internal-error strings in `codex-rs/app-server/src/request_processors/apps_processor.rs:164-279`. OpenClaw therefore owns sanitizing those error strings before retaining and logging diagnostics.

## User Impact

Codex app inventory refresh diagnostics remain valid UTF-16 when long upstream errors contain emoji or other astral characters at the truncation boundary. Normal errors and app inventory behavior are unchanged.

## Evidence

Exact head: `87ea557c48f0611b7047f85b1359cbd5802be513`

- Blacksmith Testbox run [28998304437](https://github.com/openclaw/openclaw/actions/runs/28998304437): `app-inventory-cache.test.ts`, 13 passed.
- Targeted `oxfmt` and `git diff --check`: passed.
- Fresh full-diff autoreview: clean, confidence 0.98.
- Direct Codex source inspection also covered the app-server test request helper at `codex-rs/app-server/tests/common/test_app_server.rs:815-819`.

The new regression serializes `${"x".repeat(499)}🚀tail` and asserts `${"x".repeat(499)}...`, proving the truncator backs up before the split surrogate instead of retaining a lone high surrogate.

## Real behavior proof

| Field | Value |
|---|---|
| Behavior addressed | UTF-16-unsafe top-level `app/list` error diagnostic truncation |
| Environment | Blacksmith Testbox, Linux x64, exact PR head |
| Production path | Codex app inventory refresh catch path and exported error serializer |
| Result | 13 focused tests passed; top-level and nested error strings share one safe policy |
| Not tested | Live Codex connector failure against a credentialed app directory; the upstream protocol/source contract and OpenClaw production serializer are exercised directly |

## Risk checklist

- [x] No config, environment, default, SDK, protocol, auth, or provider change.
- [x] No new dependency.
- [x] Existing redaction and size limits remain unchanged.
- [x] No changelog entry required for internal diagnostic serialization.
- [x] Allow edits by maintainers.
