### PR TITLE
fix(trajectory): make window line sort comparator total-order safe

### DIFF
--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -545,15 +545,14 @@ describe("compareTrajectoryWindowLines total order", () => {
 
   it("is antisymmetric across a mixed set", () => {
     const lines = [goodLater, corruptA, goodEarly, corruptB];
+    const sign = (x: number) => (x > 0 ? 1 : x < 0 ? -1 : 0);
     for (let i = 0; i < lines.length; i++) {
       for (let j = 0; j < lines.length; j++) {
         const cij = compareTrajectoryWindowLines(lines[i], lines[j]);
         const cji = compareTrajectoryWindowLines(lines[j], lines[i]);
-        expect(Number.isNaN(cij)).toBe(false);
         expect(Number.isFinite(cij)).toBe(true);
-        const sign = (x: number) => (x > 0 ? 1 : x < 0 ? -1 : 0);
-        // Use == so +0 and -0 compare equal (sign can return 0 for equal lines).
-        expect(sign(cij) === -sign(cji)).toBe(true);
+        // Opposite signs (sum to 0); avoids +0/-0 Object.is pitfalls of toBe(-x).
+        expect(sign(cij) + sign(cji)).toBe(0);
       }
     }
   });
@@ -564,6 +563,6 @@ describe("compareTrajectoryWindowLines total order", () => {
     expect(sorted[0]).toBe(goodEarly);
     expect(sorted[1]).toBe(goodLater);
     // Both corrupted lines end up at the tail in a deterministic raw-string order.
-    expect(sorted.slice(2)).toEqual([corruptA, corruptB].sort());
+    expect(sorted.slice(2)).toStrictEqual([corruptA, corruptB].sort());
   });
 });

--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -9,7 +9,11 @@ import {
   resolveTrajectoryPointerFilePath,
   resolveTrajectoryPointerOpenFlags,
 } from "./paths.js";
-import { createTrajectoryRuntimeRecorder, toTrajectoryToolDefinitions } from "./runtime.js";
+import {
+  compareTrajectoryWindowLines,
+  createTrajectoryRuntimeRecorder,
+  toTrajectoryToolDefinitions,
+} from "./runtime.js";
 
 type TrajectoryRuntimeRecorder = NonNullable<ReturnType<typeof createTrajectoryRuntimeRecorder>>;
 
@@ -510,5 +514,56 @@ describe("trajectory runtime", () => {
     });
 
     expect(recorder).toBeNull();
+  });
+});
+
+describe("compareTrajectoryWindowLines total order", () => {
+  // parseTrajectoryWindowLine returns Infinity for corrupted/unparseable lines;
+  // the old comparator used subtraction (Infinity - Infinity === NaN), violating
+  // Array.sort's total-order contract. The fix uses relational comparisons so
+  // bad lines sort last and the result is always a finite number.
+  const goodEarly = '{"ts":"2024-01-01T00:00:00Z","seq":1}';
+  const goodLater = '{"ts":"2024-01-03T00:00:00Z","seq":3}';
+  const corruptA = "this is not json";
+  const corruptB = '{"no":"ts"}';
+
+  it("never returns NaN, including for two corrupted lines", () => {
+    const result = compareTrajectoryWindowLines(corruptA, corruptB);
+    expect(Number.isNaN(result)).toBe(false);
+    expect(typeof result).toBe("number");
+  });
+
+  it("sorts corrupted lines after all valid lines", () => {
+    expect(compareTrajectoryWindowLines(corruptA, goodEarly)).toBeGreaterThan(0);
+    expect(compareTrajectoryWindowLines(goodEarly, corruptA)).toBeLessThan(0);
+  });
+
+  it("orders valid lines by timestamp ascending", () => {
+    expect(compareTrajectoryWindowLines(goodEarly, goodLater)).toBeLessThan(0);
+    expect(compareTrajectoryWindowLines(goodLater, goodEarly)).toBeGreaterThan(0);
+  });
+
+  it("is antisymmetric across a mixed set", () => {
+    const lines = [goodLater, corruptA, goodEarly, corruptB];
+    for (let i = 0; i < lines.length; i++) {
+      for (let j = 0; j < lines.length; j++) {
+        const cij = compareTrajectoryWindowLines(lines[i], lines[j]);
+        const cji = compareTrajectoryWindowLines(lines[j], lines[i]);
+        expect(Number.isNaN(cij)).toBe(false);
+        expect(Number.isFinite(cij)).toBe(true);
+        const sign = (x: number) => (x > 0 ? 1 : x < 0 ? -1 : 0);
+        // Use == so +0 and -0 compare equal (sign can return 0 for equal lines).
+        expect(sign(cij) === -sign(cji)).toBe(true);
+      }
+    }
+  });
+
+  it("produces a deterministic sort with corrupted lines last", () => {
+    const lines = [goodLater, corruptA, goodEarly, corruptB];
+    const sorted = [...lines].sort(compareTrajectoryWindowLines);
+    expect(sorted[0]).toBe(goodEarly);
+    expect(sorted[1]).toBe(goodLater);
+    // Both corrupted lines end up at the tail in a deterministic raw-string order.
+    expect(sorted.slice(2)).toEqual([corruptA, corruptB].sort());
   });
 });

--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -546,10 +546,10 @@ describe("compareTrajectoryWindowLines total order", () => {
   it("is antisymmetric across a mixed set", () => {
     const lines = [goodLater, corruptA, goodEarly, corruptB];
     const sign = (x: number) => (x > 0 ? 1 : x < 0 ? -1 : 0);
-    for (let i = 0; i < lines.length; i++) {
-      for (let j = 0; j < lines.length; j++) {
-        const cij = compareTrajectoryWindowLines(lines[i], lines[j]);
-        const cji = compareTrajectoryWindowLines(lines[j], lines[i]);
+    for (const [, left] of lines.entries()) {
+      for (const [, right] of lines.entries()) {
+        const cij = compareTrajectoryWindowLines(left, right);
+        const cji = compareTrajectoryWindowLines(right, left);
         expect(Number.isFinite(cij)).toBe(true);
         // Opposite signs (sum to 0); avoids +0/-0 Object.is pitfalls of toBe(-x).
         expect(sign(cij) + sign(cji)).toBe(0);
@@ -559,10 +559,10 @@ describe("compareTrajectoryWindowLines total order", () => {
 
   it("produces a deterministic sort with corrupted lines last", () => {
     const lines = [goodLater, corruptA, goodEarly, corruptB];
-    const sorted = [...lines].sort(compareTrajectoryWindowLines);
+    const sorted = [...lines].toSorted(compareTrajectoryWindowLines);
     expect(sorted[0]).toBe(goodEarly);
     expect(sorted[1]).toBe(goodLater);
     // Both corrupted lines end up at the tail in a deterministic raw-string order.
-    expect(sorted.slice(2)).toStrictEqual([corruptA, corruptB].sort());
+    expect(sorted.slice(2)).toStrictEqual([corruptA, corruptB].toSorted());
   });
 });

--- a/src/trajectory/runtime.ts
+++ b/src/trajectory/runtime.ts
@@ -289,14 +289,29 @@ function trimJsonlWindow(lines: string[], maxBytes: number): number {
   return bytes;
 }
 
-function compareTrajectoryWindowLines(left: string, right: string): number {
+// Exported for tests asserting the total-order invariant on mixed valid/corrupt
+// lines. Not part of the trajectory runtime recorder public API.
+export function compareTrajectoryWindowLines(left: string, right: string): number {
   const leftEvent = parseTrajectoryWindowLine(left);
   const rightEvent = parseTrajectoryWindowLine(right);
-  const byTs = leftEvent.ts - rightEvent.ts;
-  if (byTs !== 0) {
-    return byTs;
+  // Compare with relational operators instead of subtraction: parseTrajectoryWindowLine
+  // returns Number.POSITIVE_INFINITY for corrupted/unparseable lines, and
+  // Infinity - Infinity is NaN, which violates Array.sort's total-order contract
+  // and yields engine-dependent ordering. Bad lines (Infinity) sort last; ties
+  // fall through to seq, then to the raw line for a deterministic order.
+  if (leftEvent.ts < rightEvent.ts) {
+    return -1;
   }
-  return leftEvent.seq - rightEvent.seq;
+  if (leftEvent.ts > rightEvent.ts) {
+    return 1;
+  }
+  if (leftEvent.seq < rightEvent.seq) {
+    return -1;
+  }
+  if (leftEvent.seq > rightEvent.seq) {
+    return 1;
+  }
+  return left < right ? -1 : left > right ? 1 : 0;
 }
 
 function parseTrajectoryWindowLine(line: string): { ts: number; seq: number } {


### PR DESCRIPTION
## What Problem This Solves

`compareTrajectoryWindowLines` (`src/trajectory/runtime.ts`) sorted the trajectory window with subtraction:

```ts
const byTs = leftEvent.ts - rightEvent.ts;
if (byTs !== 0) return byTs;
return leftEvent.seq - rightEvent.seq;
```

`parseTrajectoryWindowLine` returns `Number.POSITIVE_INFINITY` for corrupted or unparseable JSONL lines (concurrent-write truncation, manual edits, foreign content appended to the file). **`Infinity - Infinity === NaN`**, so whenever two such lines are compared the comparator returns `NaN`. A comparator returning `NaN` violates `Array.sort`'s total-order contract (ES spec), producing engine-dependent, non-deterministic ordering of the trajectory window — even though the `Infinity` sentinel was clearly intended to sort bad lines last consistently.

## Why This Change Was Made

- **Root cause:** Subtraction is the wrong combinator when operands can be `Infinity`; `Infinity - Infinity` is `NaN`, not `0`.
- **Fix:** Compare with relational operators (`<`/`>`). Bad lines still sort last (`Infinity` compares greater than every finite `ts`), timestamp ties fall through to `seq`, and fully-equal lines get a deterministic raw-string tiebreak. The comparator now always returns a finite number in `{-1, 0, 1}`.
- This is the same lesson the sibling sort in `src/agents/tool-search.ts` already follows (it avoids `Infinity` subtraction and provides a total-order tiebreaker).

## User Impact

Trajectory window maintenance (`replaceTrajectoryWindow`) gets a deterministic sort even when the JSONL file contains corrupted lines — a real production state from truncated concurrent writes. No behavior change for well-formed files (finite timestamps sort identically). The corrupted lines are still retained, just consistently ordered at the tail.

## Linked context

N/A (no existing issue).

## Evidence

Reproduced with a `node` runtime script that compares the old subtraction comparator against the fixed relational comparator on a mixed set of valid + corrupted JSONL lines.

Terminal output of `node --import tsx /tmp/verify-trajectory-sort.mjs` before/after the fix:

```
[BEFORE] oldCompare(two corrupt) = NaN (isNaN=true)
[PASS] old comparator returns NaN (reproduces bug)
[AFTER]  compareTrajectoryWindowLines(two corrupt) = -1
[PASS] fixed comparator returns a finite number, not NaN
[PASS] comparator is antisymmetric and never NaN on mixed set
[PASS] earliest good line sorts first
[PASS] corrupted lines sort last
```

The old comparator returns `NaN` (`Infinity - Infinity`) when comparing two corrupted lines, violating `Array.sort`'s total-order contract; the fixed comparator always returns a finite number, is antisymmetric, and sorts corrupted lines last.

## Real behavior proof

| # | Field | Value |
|---|-------|-------|
| 1 | Behavior or issue addressed | `compareTrajectoryWindowLines` returns `NaN` when comparing two corrupted/unparseable lines (`Infinity - Infinity`), violating `Array.sort`'s total-order contract. |
| 2 | Real environment tested | Linux x64, Node 22, commit `7fbb137b8f71a9a100e0319e7cdd66197ee030ac` |
| 3 | Exact steps or command run | `node --import tsx /tmp/verify-trajectory-sort.mjs` — compares the old subtraction comparator against the fixed relational comparator on a mixed set of valid + corrupted lines; checks the result is never `NaN`, is antisymmetric, and sorts corrupted lines last. |
| 4 | Evidence after fix | Terminal capture of `node` runtime verification (copied live output):
```
[BEFORE] oldCompare(two corrupt) = NaN (isNaN=true)
[PASS] old comparator returns NaN (reproduces bug)
[AFTER]  compareTrajectoryWindowLines(two corrupt) = -1
[PASS] fixed comparator returns a finite number, not NaN
[PASS] comparator is antisymmetric and never NaN on mixed set
[PASS] earliest good line sorts first
[PASS] corrupted lines sort last
``` |
| 5 | Observed result after fix | The fixed comparator returns a finite number for every pair (including two corrupted lines, where the old path returned `NaN`); it is antisymmetric across the mixed set, orders valid lines by timestamp ascending, and places corrupted lines at the tail deterministically. |
| 6 | What was not tested | Determinism across multiple JS engines (only Node/V8 exercised here); the colocated unit test asserts the total-order invariant directly. |

## Tests and validation

```
$ node scripts/run-vitest.mjs src/trajectory/runtime.test.ts
✓ src/trajectory/runtime.test.ts (21 tests)
Test Files  1 passed (1)
     Tests  21 passed (21)
```

New tests cover: comparator never returns `NaN` for two corrupted lines, corrupted lines sort after valid ones, valid lines ordered by timestamp ascending, antisymmetry across a mixed set, and a deterministic sort with corrupted lines last. `compareTrajectoryWindowLines` is exported for direct testing.

## Risk checklist

- [x] One concern, one PR — only the trajectory window line sort comparator.
- [x] No config/env/default surface change.
- [x] No SDK/protocol/auth/provider behavior change.
- [x] Backward compatible — well-formed lines sort identically (finite timestamp ordering unchanged); only the previously-undefined NaN case is now well-defined.
- [x] No new deps.
- [x] No CHANGELOG edit (per release policy).
- [x] Tests added.

- [x] Allow edits by maintainers
