### PR TITLE
fix(voice-call): guard answered conversation calls when realtime config is absent

### DIFF
--- a/extensions/voice-call/src/manager.notify.test.ts
+++ b/extensions/voice-call/src/manager.notify.test.ts
@@ -1,6 +1,13 @@
 // Voice Call tests cover manager.notify plugin behavior.
 import { describe, expect, it, vi } from "vitest";
-import { createManagerHarness, FakeProvider } from "./manager.test-harness.js";
+import { VoiceCallConfigSchema, type VoiceCallConfig } from "./config.js";
+import { CallManager } from "./manager.js";
+import {
+  createManagerHarness,
+  createTestStorePath,
+  FakeProvider,
+  installVoiceCallStateRuntimeForTests,
+} from "./manager.test-harness.js";
 
 class FailFirstPlayTtsProvider extends FakeProvider {
   private failed = false;
@@ -190,6 +197,29 @@ describe("CallManager notify and mapping", () => {
     await answerCall(manager, callId, "evt-conversation-plivo");
 
     expectFirstPlayTtsText(provider, "Hello from conversation");
+  });
+
+  it("does not crash on answered conversation call when realtime config is absent", async () => {
+    installVoiceCallStateRuntimeForTests();
+    const parsed = VoiceCallConfigSchema.parse({
+      enabled: true,
+      provider: "plivo",
+      fromNumber: "+15550000000",
+    });
+    const config = { ...parsed, realtime: undefined } as unknown as VoiceCallConfig;
+    const manager = new CallManager(config, createTestStorePath());
+    const provider = new FakeProvider("plivo");
+    await manager.initialize(provider, "https://example.com/voice/webhook");
+
+    const callId = await initiateCallWithMessage(
+      manager,
+      "+15550000015",
+      "Hello without realtime",
+      "conversation",
+    );
+    await answerCall(manager, callId, "evt-conversation-no-realtime");
+
+    expectFirstPlayTtsText(provider, "Hello without realtime");
   });
 
   it("speaks initial message on answered for conversation mode when Twilio streaming is disabled", async () => {

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -413,7 +413,9 @@ export class CallManager {
     // is actually available; otherwise speak immediately on answered.
     const mode = (call.metadata?.mode as string | undefined) ?? "conversation";
     if (mode === "conversation") {
-      if (this.config.realtime.enabled) {
+      // Guard absent realtime config (e.g. direct test/runtime construction);
+      // normalized configs always include defaults, but this path is public.
+      if (this.config.realtime?.enabled) {
         return;
       }
       const shouldWaitForStreamConnect =


### PR DESCRIPTION
Closes #100294

## What Problem This Solves

Fixes an issue where inbound or outbound voice calls in conversation mode would crash the answered-call handler with `TypeError: Cannot read properties of undefined (reading 'enabled')` when the voice-call plugin was configured without a `realtime` object. The crash leaves the call hanging in an answered state with no initial greeting and no listening start.

## Why This Change Was Made

`extensions/voice-call/src/manager.ts:416` read `this.config.realtime.enabled` without optional chaining. Every other reference in the voice-call codebase already uses `config.realtime?.enabled`. The change adds the missing optional-chain guard so an absent `realtime` section is treated as disabled, and the manager proceeds to speak the initial message and start listening as expected. A focused regression test constructs a `CallManager` with `realtime` removed and asserts that answering a conversation call still plays the greeting.

## User Impact

Voice-call setups that do not enable realtime voice-to-voice mode no longer crash on answer; the initial greeting and listening flow start normally.

## Evidence

### Real behavior reproduction

I ran a standalone runtime script that uses the production `CallManager` + `MockProvider`, constructs a config with `realtime` removed, initiates a conversation call, and fires a `call.answered` event.

**Before the fix (current `main` behavior):** the answered handler throws and the call never reaches the greeting/listening state.

```
[voice-call] Outbound call initiated: callId=ec5888b4-30ce-4b3a-a197-e124adbabe36 ... mode=conversation ...
initiated callId=ec5888b4-30ce-4b3a-a197-e124adbabe36 providerCallId=mock-ec5888b4-30ce-4b3a-a197-e124adbabe36
[voice-call] Starting max duration timer (300s) for call ec5888b4-30ce-4b3a-a197-e124adbabe36
Unhandled error: TypeError: Cannot read properties of undefined (reading 'enabled')
    at CallManager.maybeSpeakInitialMessageOnAnswered (extensions/voice-call/src/manager.ts:416:32)
    at Object.onCallAnswered (extensions/voice-call/src/manager.ts:376:14)
    at processEvent (extensions/voice-call/src/manager/events.ts:289:11)
    at CallManager.processEvent (extensions/voice-call/src/manager.ts:386:12)
```

**After the fix:** the answered event is handled, the initial message is spoken, and the call transitions to `listening`.

```
[voice-call] Outbound call initiated: callId=0eb890d2-70cc-445a-bd1f-79eda0d946a4 ... mode=conversation ...
initiated callId=0eb890d2-70cc-445a-bd1f-79eda0d946a4 providerCallId=mock-0eb890d2-70cc-445a-bd1f-79eda0d946a4
[voice-call] Starting max duration timer (300s) for call 0eb890d2-70cc-445a-bd1f-79eda0d946a4
[voice-call] Speaking initial message for call 0eb890d2-70cc-445a-bd1f-79eda0d946a4 (mode: conversation)
call.answered processed without throwing
call state: listening
```

The reproduction uses the built-in mock provider so no live telephony credentials are needed; the crash path is the same `CallManager` code exercised by real providers.

### Regression tests

```bash
node scripts/run-vitest.mjs extensions/voice-call/src/manager.notify.test.ts --run
Test Files  1 passed (1)
     Tests  15 passed (15)
```

The new test `does not crash on answered conversation call when realtime config is absent` fails before the optional-chaining change and passes after it.

### Static checks

- `git diff --check` passes.
- `pnpm exec oxfmt --check extensions/voice-call/src/manager.ts extensions/voice-call/src/manager.notify.test.ts` passes.
- Full CI run on the PR head is green (run `28994196591`).

### Scope note

Normal runtime config resolution does supply a default `realtime` object, so the omitted-object state is most readily reached through direct `CallManager` construction or legacy/embedded configs. The guard is defensive and aligns the manager read with every other `realtime?.enabled` access in the voice-call codebase.


[trigger: ClawSweeper re-review]
