### PR TITLE
fix(ui): preserve sidebar session list on Gateway disconnect

### DIFF
--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -10,8 +10,9 @@ import {
   applicationContext,
   type ApplicationContext,
   type ApplicationGateway,
+  type ApplicationGatewaySnapshot,
 } from "../app/context.ts";
-import type { SessionCapability } from "../lib/sessions/index.ts";
+import type { SessionCapability, SessionState } from "../lib/sessions/index.ts";
 import "./app-sidebar.ts";
 
 const PROVIDER_ELEMENT_NAME = "test-app-sidebar-context-provider";
@@ -33,26 +34,44 @@ if (!customElements.get(PROVIDER_ELEMENT_NAME)) {
 type SidebarLifecycleState = HTMLElement & {
   sessionRowsByAgent: Record<string, SessionsListResult["sessions"]>;
   sessionCreatedOrder: Map<string, number>;
+  sessionsAgentId: string | null;
+  sessionsResult: SessionsListResult | null;
   updateComplete: Promise<boolean>;
 };
 
-function createGateway(client: GatewayBrowserClient): ApplicationGateway {
-  return {
-    snapshot: {
-      client,
-      connected: true,
-      reconnecting: false,
-      hello: null,
-      assistantAgentId: "main",
-      sessionKey: "agent:main:main",
-      lastError: null,
-      lastErrorCode: null,
+function createGatewayHarness(client: GatewayBrowserClient) {
+  let snapshot: ApplicationGatewaySnapshot = {
+    client,
+    connected: true,
+    reconnecting: false,
+    hello: null,
+    assistantAgentId: "main",
+    sessionKey: "agent:main:main",
+    lastError: null,
+    lastErrorCode: null,
+  };
+  const listeners = new Set<(next: ApplicationGatewaySnapshot) => void>();
+  const gateway = {
+    get snapshot() {
+      return snapshot;
     },
-    subscribe: () => () => undefined,
+    subscribe(listener: (next: ApplicationGatewaySnapshot) => void) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
   } as unknown as ApplicationGateway;
+  return {
+    gateway,
+    publish(patch: Partial<ApplicationGatewaySnapshot>) {
+      snapshot = { ...snapshot, ...patch };
+      for (const listener of listeners) {
+        listener(snapshot);
+      }
+    },
+  };
 }
 
-function createSessions(agentId: string, keys: string[]): SessionCapability {
+function createSessionState(agentId: string, keys: string[]): SessionState {
   const result = {
     ts: 1,
     path: "",
@@ -69,17 +88,54 @@ function createSessions(agentId: string, keys: string[]): SessionCapability {
     })),
   } satisfies SessionsListResult;
   return {
-    state: {
-      result,
-      agentId,
-      modelOverrides: {},
-      loading: false,
-      error: null,
-      deletedSessions: [],
+    result,
+    agentId,
+    modelOverrides: {},
+    loading: false,
+    error: null,
+    deletedSessions: [],
+  };
+}
+
+function createSessionsHarness(agentId: string, keys: string[]) {
+  let state = createSessionState(agentId, keys);
+  let canonicalListRevision = 1;
+  const listeners = new Set<(next: SessionState) => void>();
+  const sessions = {
+    get state() {
+      return state;
     },
-    subscribe: () => () => undefined,
+    get canonicalListRevision() {
+      return canonicalListRevision;
+    },
+    subscribe(listener: (next: SessionState) => void) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
     subscribeCreated: () => () => undefined,
   } as unknown as SessionCapability;
+  const publish = (patch: Partial<SessionState>) => {
+    state = { ...state, ...patch };
+    for (const listener of listeners) {
+      listener(state);
+    }
+  };
+  return {
+    sessions,
+    publish,
+    publishList(patch: Partial<SessionState>) {
+      canonicalListRevision += 1;
+      publish(patch);
+    },
+  };
+}
+
+function createGateway(client: GatewayBrowserClient): ApplicationGateway {
+  return createGatewayHarness(client).gateway;
+}
+
+function createSessions(agentId: string, keys: string[]): SessionCapability {
+  return createSessionsHarness(agentId, keys).sessions;
 }
 
 function createContext(
@@ -101,6 +157,18 @@ function createContext(
   } as unknown as ApplicationContext<RouteId>;
 }
 
+async function mountSidebar(gateway: ApplicationGateway, sessions: SessionCapability) {
+  const provider = document.createElement(PROVIDER_ELEMENT_NAME) as AppSidebarContextProvider;
+  const sidebar = document.createElement(
+    "openclaw-app-sidebar",
+  ) as unknown as SidebarLifecycleState;
+  provider.setContext(createContext(gateway, sessions));
+  provider.append(sidebar);
+  document.body.append(provider);
+  await sidebar.updateComplete;
+  return { provider, sidebar };
+}
+
 afterEach(() => {
   document.body.replaceChildren();
 });
@@ -109,14 +177,10 @@ describe("AppSidebar session source lifecycle", () => {
   it("resets cached rows and creation order when the sessions source changes", async () => {
     const client = {} as GatewayBrowserClient;
     const gateway = createGateway(client);
-    const provider = document.createElement(PROVIDER_ELEMENT_NAME) as AppSidebarContextProvider;
-    const sidebar = document.createElement(
-      "openclaw-app-sidebar",
-    ) as unknown as SidebarLifecycleState;
-    provider.setContext(createContext(gateway, createSessions("first", ["first-a", "first-b"])));
-    provider.append(sidebar);
-    document.body.append(provider);
-    await sidebar.updateComplete;
+    const { provider, sidebar } = await mountSidebar(
+      gateway,
+      createSessions("first", ["first-a", "first-b"]),
+    );
 
     expect(Object.keys(sidebar.sessionRowsByAgent)).toEqual(["first"]);
     expect([...sidebar.sessionCreatedOrder]).toEqual([
@@ -133,5 +197,78 @@ describe("AppSidebar session source lifecycle", () => {
       ["second-b", 0],
       ["second-a", 1],
     ]);
+    expect(sidebar.sessionsAgentId).toBe("second");
+    expect(sidebar.sessionsResult?.sessions.map((row) => row.key)).toEqual([
+      "second-b",
+      "second-a",
+    ]);
+  });
+
+  it("preserves the scoped result through a disconnect on the same Gateway client", async () => {
+    const client = {} as GatewayBrowserClient;
+    const gateway = createGatewayHarness(client);
+    const sessions = createSessionsHarness("main", ["main-a", "main-b"]);
+    const { sidebar } = await mountSidebar(gateway.gateway, sessions.sessions);
+    const cachedResult = sidebar.sessionsResult;
+
+    gateway.publish({ connected: false, reconnecting: true });
+    sessions.publish({ result: null, agentId: null, loading: false });
+    await sidebar.updateComplete;
+
+    expect(sidebar.sessionsResult).toBe(cachedResult);
+    expect(sidebar.sessionsAgentId).toBe("main");
+    expect(Object.keys(sidebar.sessionRowsByAgent)).toEqual(["main"]);
+    expect([...sidebar.sessionCreatedOrder.keys()]).toEqual(["main-a", "main-b"]);
+
+    gateway.publish({ connected: true, reconnecting: false });
+    const partial = createSessionState("main", ["main-a"]);
+    sessions.publish({ result: partial.result, agentId: partial.agentId });
+    await sidebar.updateComplete;
+
+    expect(sidebar.sessionsResult).toBe(cachedResult);
+    expect(sidebar.sessionsResult?.sessions.map((row) => row.key)).toEqual(["main-a", "main-b"]);
+    expect(sidebar.sessionRowsByAgent.main?.map((row) => row.key)).toEqual(["main-a", "main-b"]);
+
+    const refreshed = createSessionState("main", ["main-c"]);
+    sessions.publishList({ result: refreshed.result, agentId: refreshed.agentId });
+    await sidebar.updateComplete;
+
+    expect(sidebar.sessionsResult?.sessions.map((row) => row.key)).toEqual(["main-c"]);
+    expect(sidebar.sessionsAgentId).toBe("main");
+  });
+
+  it("clears every cached session view when the Gateway client is replaced", async () => {
+    const firstClient = {} as GatewayBrowserClient;
+    const gateway = createGatewayHarness(firstClient);
+    const sessions = createSessionsHarness("main", ["main-a"]);
+    const { sidebar } = await mountSidebar(gateway.gateway, sessions.sessions);
+
+    gateway.publish({
+      client: {} as GatewayBrowserClient,
+      connected: false,
+      reconnecting: true,
+    });
+    await sidebar.updateComplete;
+
+    expect(sidebar.sessionsResult).toBeNull();
+    expect(sidebar.sessionsAgentId).toBeNull();
+    expect(sidebar.sessionRowsByAgent).toEqual({});
+    expect(sidebar.sessionCreatedOrder.size).toBe(0);
+  });
+
+  it("clears every cached session view when the Gateway source is replaced", async () => {
+    const client = {} as GatewayBrowserClient;
+    const gateway = createGatewayHarness(client);
+    const sessions = createSessionsHarness("main", ["main-a"]);
+    const { provider, sidebar } = await mountSidebar(gateway.gateway, sessions.sessions);
+
+    const replacementGateway = createGatewayHarness(client);
+    provider.setContext(createContext(replacementGateway.gateway, sessions.sessions));
+    await sidebar.updateComplete;
+
+    expect(sidebar.sessionsResult).toBeNull();
+    expect(sidebar.sessionsAgentId).toBeNull();
+    expect(sidebar.sessionRowsByAgent).toEqual({});
+    expect(sidebar.sessionCreatedOrder.size).toBe(0);
   });
 });

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -213,6 +213,8 @@ class AppSidebar extends OpenClawLightDomContentsElement {
   private sessionRowsByAgent: Record<string, SessionsListResult["sessions"]> = {};
   private sessionCreatedOrder = new Map<string, number>();
   private sessionsSource: SessionCapability | null = null;
+  private reconnectListRevision: number | null = null;
+  private gatewaySource: ApplicationContext<RouteId>["gateway"] | null = null;
   private gatewayClient: GatewayBrowserClient | null = null;
   private readonly routePreloadTimers = new Map<
     EventTarget,
@@ -225,7 +227,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
       .watch(
         () => this.context?.gateway,
         (gateway, notify) => gateway.subscribe(notify),
-        (gateway) => this.updateGatewayClient(gateway.snapshot),
+        (gateway) => this.synchronizeGateway(gateway),
       )
       .watch(
         () => this.context?.sessions,
@@ -251,6 +253,7 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     this.closeSessionMenu();
     this.closeSessionGroupMenu();
     this.closeSessionSortMenu();
+    this.gatewaySource = null;
     this.gatewayClient = null;
     for (const timer of this.routePreloadTimers.values()) {
       globalThis.clearTimeout(timer);
@@ -259,46 +262,65 @@ class AppSidebar extends OpenClawLightDomContentsElement {
     super.disconnectedCallback();
   }
 
-  private readonly updateSessions = (snapshot: {
-    result: SessionsListResult | null;
-    agentId: string | null;
-    loading: boolean;
-  }) => {
-    this.sessionsResult = snapshot.result;
-    this.sessionsAgentId = snapshot.agentId;
-    this.sessionsLoading = snapshot.loading;
-    if (snapshot.result) {
-      for (const row of snapshot.result.sessions) {
-        if (row.key && !this.sessionCreatedOrder.has(row.key)) {
-          this.sessionCreatedOrder.set(row.key, this.sessionCreatedOrder.size);
+  private readonly updateSessions = (sessions: SessionCapability) => {
+    const snapshot = sessions.state;
+    const gateway = this.context?.gateway;
+    const sameClientDisconnected =
+      gateway !== undefined &&
+      gateway === this.gatewaySource &&
+      gateway.snapshot.client !== null &&
+      gateway.snapshot.client === this.gatewayClient &&
+      !gateway.snapshot.connected;
+    if (sameClientDisconnected && this.reconnectListRevision === null) {
+      this.reconnectListRevision = sessions.canonicalListRevision + 1;
+    }
+    const waitingForReconnectList =
+      this.reconnectListRevision !== null &&
+      sessions.canonicalListRevision < this.reconnectListRevision;
+    if (!sameClientDisconnected && !waitingForReconnectList) {
+      // Keep the result and agent scope paired until the first canonical list
+      // after reconnect; chat startup may publish a partial reconciliation first.
+      this.reconnectListRevision = null;
+      this.sessionsResult = snapshot.result;
+      this.sessionsAgentId = snapshot.agentId;
+      if (snapshot.result) {
+        for (const row of snapshot.result.sessions) {
+          if (row.key && !this.sessionCreatedOrder.has(row.key)) {
+            this.sessionCreatedOrder.set(row.key, this.sessionCreatedOrder.size);
+          }
         }
       }
+      if (snapshot.result && snapshot.agentId) {
+        this.sessionRowsByAgent[normalizeAgentId(snapshot.agentId)] = snapshot.result.sessions;
+      }
     }
-    if (snapshot.result && snapshot.agentId) {
-      this.sessionRowsByAgent[normalizeAgentId(snapshot.agentId)] = snapshot.result.sessions;
-    }
+    this.sessionsLoading = snapshot.loading;
   };
 
   private synchronizeSessions(sessions: SessionCapability) {
     if (sessions !== this.sessionsSource) {
-      this.sessionRowsByAgent = {};
-      this.sessionCreatedOrder.clear();
+      this.clearSessionCache();
       this.sessionsSource = sessions;
     }
-    this.updateSessions(sessions.state);
+    this.updateSessions(sessions);
   }
 
-  private updateGatewayClient(snapshot: {
-    client: GatewayBrowserClient | null;
-    connected: boolean;
-  }) {
-    const client = snapshot.connected ? snapshot.client : null;
-    if (client === this.gatewayClient) {
+  private synchronizeGateway(gateway: ApplicationContext<RouteId>["gateway"]) {
+    const client = gateway.snapshot.client;
+    if (gateway === this.gatewaySource && client === this.gatewayClient) {
       return;
     }
+    this.clearSessionCache();
+    this.gatewaySource = gateway;
+    this.gatewayClient = client;
+  }
+
+  private clearSessionCache() {
+    this.reconnectListRevision = null;
+    this.sessionsResult = null;
+    this.sessionsAgentId = null;
     this.sessionRowsByAgent = {};
     this.sessionCreatedOrder.clear();
-    this.gatewayClient = client;
   }
 
   private renderBrand() {

--- a/ui/src/e2e/session-management.e2e.test.ts
+++ b/ui/src/e2e/session-management.e2e.test.ts
@@ -411,6 +411,75 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
     }
   });
 
+  it("keeps sidebar sessions visible through a same-client Gateway reconnect", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const sessionKey = "agent:main:disconnect-proof";
+    const otherSessionKeys = ["agent:main:other-a", "agent:main:other-b"];
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": sessionsListResponse([
+          sessionRow(sessionKey, "Disconnect proof", Date.parse("2026-07-01T16:00:00.000Z")),
+          sessionRow(otherSessionKeys[0], "Other A", Date.parse("2026-07-01T15:59:00.000Z")),
+          sessionRow(otherSessionKeys[1], "Other B", Date.parse("2026-07-01T15:58:00.000Z")),
+        ]),
+      },
+      sessionKey,
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      const sidebarRow = page.locator(`.sidebar-recent-session[data-session-key="${sessionKey}"]`);
+      await sidebarRow.waitFor({ state: "visible", timeout: 10_000 });
+      const sidebarRows = page.locator(".sidebar-recent-session");
+      await expect.poll(() => sidebarRows.count()).toBe(3);
+      const initialListCount = (await gateway.getRequests("sessions.list")).length;
+
+      await gateway.closeLatest(1006, "disconnect proof");
+      await page.locator(".connection-banner").waitFor({ state: "visible", timeout: 10_000 });
+      await gateway.deferNext("sessions.list");
+      await sidebarRow.waitFor({ state: "visible" });
+      await captureUiProof(page, "sidebar-sessions-during-reconnect.png");
+
+      await expect.poll(() => gateway.getSocketCount(), { timeout: 15_000 }).toBeGreaterThan(1);
+      await expect
+        .poll(async () => (await gateway.getRequests("sessions.list")).length, { timeout: 15_000 })
+        .toBeGreaterThan(initialListCount);
+      await page.locator(".connection-banner").waitFor({ state: "detached", timeout: 15_000 });
+      await sidebarRow.waitFor({ state: "visible" });
+      expect(await sidebarRows.count()).toBe(3);
+      for (const otherKey of otherSessionKeys) {
+        await page
+          .locator(`.sidebar-recent-session[data-session-key="${otherKey}"]`)
+          .waitFor({ state: "visible" });
+      }
+
+      const firstReconnectListCount = (await gateway.getRequests("sessions.list")).length;
+      const refreshedResponse = sessionsListResponse([
+        sessionRow(sessionKey, "Reconnect refreshed", Date.parse("2026-07-01T16:01:00.000Z")),
+        sessionRow(otherSessionKeys[0], "Other A", Date.parse("2026-07-01T15:59:00.000Z")),
+        sessionRow(otherSessionKeys[1], "Other B", Date.parse("2026-07-01T15:58:00.000Z")),
+      ]);
+      // Reconnect can queue a second refresh behind session hydration. Hold both
+      // so each response carries the changed black-box fixture.
+      await gateway.deferNext("sessions.list");
+      await gateway.resolveDeferred("sessions.list", refreshedResponse);
+      await expect.poll(() => sidebarRow.textContent()).toContain("Reconnect refreshed");
+      await expect.poll(() => sidebarRows.count()).toBe(3);
+      await expect
+        .poll(async () => (await gateway.getRequests("sessions.list")).length, { timeout: 10_000 })
+        .toBeGreaterThan(firstReconnectListCount);
+      await gateway.resolveDeferred("sessions.list", refreshedResponse);
+      await expect.poll(() => sidebarRow.textContent()).toContain("Reconnect refreshed");
+    } finally {
+      await context.close();
+    }
+  });
+
   it("renames, deletes, and toggles sidebar session groups", async () => {
     const baseTime = Date.parse("2026-07-01T16:00:00.000Z");
     const context = await browser.newContext({

--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -82,6 +82,40 @@ function sessionChangedEvent(key: string): GatewayEventFrame {
 }
 
 describe("createSessionCapability", () => {
+  it("advances the canonical list revision only for sessions.list publications", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method !== "sessions.list") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      return sessionsResult([{ key: "agent:main:listed", kind: "direct", updatedAt: 2 }], 2);
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const sessions = createSessionCapability({
+      snapshot: {
+        client,
+        connected: true,
+        sessionKey: "agent:main:main",
+        assistantAgentId: "main",
+        hello: null,
+      },
+      subscribe: () => () => undefined,
+      subscribeEvents: () => () => undefined,
+    });
+
+    expect(sessions.canonicalListRevision).toBe(0);
+    sessions.reconcile(
+      { key: "agent:main:startup", kind: "direct", updatedAt: 1 },
+      { modelProvider: null, model: null, contextTokens: null },
+    );
+    expect(sessions.canonicalListRevision).toBe(0);
+
+    await sessions.refresh({ force: true });
+
+    expect(sessions.canonicalListRevision).toBe(1);
+    expect(sessions.state.result?.sessions[0]?.key).toBe("agent:main:listed");
+    sessions.dispose();
+  });
+
   it("starts a fresh list epoch when the same client reconnects", async () => {
     const staleList = deferred<SessionsListResult>();
     const currentList = deferred<SessionsListResult>();

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -147,6 +147,8 @@ type SessionMessageSubscription = {
 
 export type SessionCapability = {
   readonly state: SessionState;
+  /** Advances only when a canonical sessions.list response is published. */
+  readonly canonicalListRevision: number;
   list: (options?: SessionListOptions) => Promise<SessionsListResult | null>;
   reconcile: (
     row: GatewaySessionRow | undefined,
@@ -558,6 +560,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
   };
   let inFlight: Promise<void> | null = null;
   let queuedRefresh: SessionRefreshOptions | null = null;
+  let canonicalListRevision = 0;
   let disposed = false;
   let connectionEpoch = 0;
   let connectionClient = gateway.snapshot.client;
@@ -682,6 +685,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
           }
         }
       }
+      canonicalListRevision += 1;
       publish({
         result: nextResult,
         agentId: requestOptions.agentId?.trim() ? normalizeAgentId(requestOptions.agentId) : null,
@@ -1171,6 +1175,9 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
   return {
     get state() {
       return state;
+    },
+    get canonicalListRevision() {
+      return canonicalListRevision;
     },
     list: requestList,
     reconcile,


### PR DESCRIPTION
## What Problem This Solves

During a retryable Gateway transport disconnect, the Control UI stays mounted but the sidebar drops its session list. The shared session capability correctly publishes a disconnected `null` state; the sidebar was treating that transient transport state as a reason to discard its last rendered rows.

## Why This Change Was Made

The repair keeps ownership explicit:

- A transport reconnect reuses the same application Gateway source and `GatewayBrowserClient`, so the sidebar preserves its last `(result, agentId)` pair, per-agent rows, and creation order while that exact client is disconnected.
- A replacement application Gateway source, client, or session capability clears every sidebar session cache before accepting new data. Rows can therefore never leak across Gateway targets or runtimes.
- The shared session capability remains canonical: it still publishes `null` while disconnected and exposes a monotonic revision that advances only after a successful current-connection `sessions.list` publication. The sidebar waits for that revision before accepting post-reconnect state, so an earlier one-row chat history reconciliation cannot collapse a hydrated multi-row cache.

This replaces the earlier `sidebarEverConnected` approach, which had process-wide lifetime and could retain one Gateway's rows after switching to another client. It also keeps `result` and `agentId` paired instead of preserving one while clearing the other.

## User Impact

The sidebar remains stable through brief Gateway outages and updates from the fresh session list after reconnect. New-session and mutation controls remain governed by the existing disconnected state. Switching Gateway source/client still clears the old list immediately.

## Evidence

- Blacksmith Testbox: `tbx_01kx4hxy69ez4ew0nb0hd46azm`
- `pnpm test ui/src/components/app-sidebar.test.ts`: 4/4 passed
- `pnpm test ui/src/lib/sessions/index.test.ts`: 12/12 passed
- `pnpm test ui/src/e2e/session-management.e2e.test.ts`: 8/8 passed in real Chromium
- `pnpm check:changed`: passed, including production/test type checks, changed-file lint, import-cycle and repository guards
- Fresh structured autoreview: no accepted/actionable findings, 0.96 confidence

The Chromium scenario closes the live mock WebSocket, observes the offline banner while the existing row remains visible, opens a second socket, verifies a new `sessions.list` request, holds both queued reconnect responses, and returns a changed label. The rendered row updates to the changed label, proving continuity and refresh rather than a permanently frozen list.

The focused lifecycle suite separately proves invalidation on replacement session capability, replacement client, and replacement application Gateway source. It also injects a noncanonical one-row reconciliation during reconnect and proves both the visible result and per-agent row cache stay intact until the canonical list revision advances.

## Provenance

The affected sidebar lifecycle was introduced by #100024 in commit `65e12328aa20d2226b932ccb3bc0e2b2a719bf44`. It is present on current `main` but not in the latest release tag.

## Contributor Evidence

Original before/after screenshots supplied by @maweibin:

<img width="1859" height="741" alt="Before disconnect" src="https://github.com/user-attachments/assets/e866ea1b-f07c-4224-b02b-bda70e955bc6" />
<img width="1695" height="835" alt="Before disconnect detail" src="https://github.com/user-attachments/assets/e5c3a8a9-7804-49a4-a556-8a742a85a18e" />
<img width="1580" height="872" alt="Sidebar preserved during reconnect" src="https://github.com/user-attachments/assets/95650f28-524f-4a54-9a0e-0e17e5b53905" />
