### PR TITLE
fix(subagents): recover stalled child runs

### DIFF
--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -143,6 +143,7 @@ session to confirm the effective tool list.
 - **Model:** native sub-agents inherit the caller unless you set `agents.defaults.subagents.model` (or per-agent `agents.list[].subagents.model`). ACP runtime spawns use the same configured subagent model when present; otherwise the ACP harness keeps its own default. An explicit `sessions_spawn.model` still wins.
 - **Thinking:** native sub-agents inherit the caller unless you set `agents.defaults.subagents.thinking` (or per-agent `agents.list[].subagents.thinking`). ACP runtime spawns also apply `agents.defaults.models["provider/model"].params.thinking` for the selected model. An explicit `sessions_spawn.thinking` still wins.
 - **Run timeout:** OpenClaw uses `agents.defaults.subagents.runTimeoutSeconds` when set; otherwise it falls back to `0` (no timeout). `sessions_spawn` does not accept per-call timeout overrides.
+- **Stall recovery:** OpenClaw can watch process-local child-run activity with `agents.defaults.subagents.stallNudgeSeconds` and `stallTimeoutSeconds`. A stalled child is nudged once, then killed if no further activity is observed before the kill threshold. Both default to `0` (disabled).
 - **Task delivery:** native sub-agents receive the delegated task in their first visible `[Subagent Task]` message. The sub-agent system prompt carries runtime rules and routing context, not a hidden duplicate of the task.
 
 Accepted native sub-agent spawns include the resolved child model metadata
@@ -394,6 +395,8 @@ worker sub-sub-agents.
         maxChildrenPerAgent: 5, // max active children per agent session (default: 5, range 1-20)
         maxConcurrent: 8, // global concurrency lane cap (default: 8)
         runTimeoutSeconds: 900, // default timeout for sessions_spawn (0 = no timeout)
+        stallNudgeSeconds: 600, // nudge after 10m without child activity (0 = disabled)
+        stallTimeoutSeconds: 900, // kill after 15m without child activity (0 = disabled)
         announceTimeoutMs: 120000, // per-call gateway announce timeout
       },
     },

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
@@ -5,6 +5,7 @@ import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import { resolveConfiguredSubagentSpawnModelSelection } from "./model-selection.js";
 import {
   resolveConfiguredSubagentRunTimeoutSeconds,
+  resolveConfiguredSubagentStallPolicy,
   resolveSubagentModelAndThinkingPlan,
   splitModelRef,
 } from "./subagent-spawn-plan.js";
@@ -245,5 +246,33 @@ describe("subagent spawn model + thinking plan", () => {
         }),
       }),
     ).toBe(0);
+  });
+
+  it("resolves configured stall recovery thresholds", () => {
+    expect(
+      resolveConfiguredSubagentStallPolicy({
+        cfg: createConfig({
+          agents: {
+            defaults: { subagents: { stallNudgeSeconds: 30.9, stallTimeoutSeconds: 90.1 } },
+          },
+        }),
+      }),
+    ).toEqual({
+      stallNudgeSeconds: 30,
+      stallTimeoutSeconds: 90,
+    });
+  });
+
+  it("omits stall recovery thresholds when config omits them", () => {
+    expect(
+      resolveConfiguredSubagentStallPolicy({
+        cfg: createConfig({
+          agents: { defaults: { subagents: { maxConcurrent: 8 } } },
+        }),
+      }),
+    ).toEqual({
+      stallNudgeSeconds: undefined,
+      stallTimeoutSeconds: undefined,
+    });
   });
 });

--- a/src/agents/subagent-control.runtime.ts
+++ b/src/agents/subagent-control.runtime.ts
@@ -2,4 +2,9 @@
  * Runtime seams used by subagent control for queue and embedded-run cancellation.
  */
 export { clearSessionQueues } from "../auto-reply/reply/queue.js";
-export { abortEmbeddedAgentRun, isEmbeddedAgentRunActive } from "./embedded-agent-runner/runs.js";
+export {
+  abortEmbeddedAgentRun,
+  isEmbeddedAgentRunActive,
+  queueEmbeddedAgentMessageWithOutcomeAsync,
+  resolveActiveEmbeddedRunSessionId,
+} from "./embedded-agent-runner/runs.js";

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -178,6 +178,8 @@ export type RegisterSubagentRunParams = {
   agentDir?: string;
   workspaceDir?: string;
   runTimeoutSeconds?: number;
+  stallNudgeSeconds?: number;
+  stallTimeoutSeconds?: number;
   expectsCompletionMessage?: boolean;
   spawnMode?: "run" | "session";
   attachmentsDir?: string;
@@ -762,6 +764,8 @@ export function createSubagentRunManager(params: {
       agentDir: registerParams.agentDir,
       workspaceDir: registerParams.workspaceDir,
       runTimeoutSeconds,
+      stallNudgeSeconds: registerParams.stallNudgeSeconds,
+      stallTimeoutSeconds: registerParams.stallTimeoutSeconds,
       generation,
       createdAt: now,
       startedAt: now,

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -173,6 +173,16 @@ const mocks = vi.hoisted(() => ({
   removeInternalSessionEffectsTranscript: vi.fn(async () => {}),
   resolveAgentTimeoutMs: vi.fn(() => 1_000),
   scheduleOrphanRecovery: vi.fn(),
+  stallAbortEmbeddedAgentRun: vi.fn(() => true),
+  stallClearSessionQueues: vi.fn(() => ({ followupCleared: 0, laneCleared: 0, keys: [] })),
+  stallIsEmbeddedAgentRunActive: vi.fn(() => true),
+  stallQueueEmbeddedAgentMessageWithOutcomeAsync: vi.fn(async (sessionId: string) => ({
+    queued: true,
+    sessionId,
+    target: "embedded_run" as const,
+    gatewayHealth: "live" as const,
+  })),
+  stallResolveActiveEmbeddedRunSessionId: vi.fn(() => undefined as string | undefined),
 }));
 
 vi.mock("../gateway/call.js", () => ({
@@ -281,6 +291,16 @@ describe("subagent registry seam flow", () => {
       onSubagentEnded: mocks.onSubagentEnded,
     });
     mocks.scheduleOrphanRecovery.mockReset();
+    mocks.stallAbortEmbeddedAgentRun.mockReturnValue(true);
+    mocks.stallClearSessionQueues.mockReturnValue({ followupCleared: 0, laneCleared: 0, keys: [] });
+    mocks.stallIsEmbeddedAgentRunActive.mockReturnValue(true);
+    mocks.stallQueueEmbeddedAgentMessageWithOutcomeAsync.mockResolvedValue({
+      queued: true,
+      sessionId: "sess-child",
+      target: "embedded_run",
+      gatewayHealth: "live",
+    });
+    mocks.stallResolveActiveEmbeddedRunSessionId.mockReturnValue(undefined);
     mocks.resolveAgentTimeoutMs.mockReturnValue(1_000);
     mocks.restoreSubagentRunsFromDisk.mockReturnValue(0);
     mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
@@ -303,6 +323,15 @@ describe("subagent registry seam flow", () => {
       resolveAgentTimeoutMs: mocks.resolveAgentTimeoutMs,
       restoreSubagentRunsFromDisk: mocks.restoreSubagentRunsFromDisk,
       runSubagentAnnounceFlow: mocks.runSubagentAnnounceFlow,
+      loadSubagentStallRuntime: async () =>
+        ({
+          abortEmbeddedAgentRun: mocks.stallAbortEmbeddedAgentRun,
+          clearSessionQueues: mocks.stallClearSessionQueues,
+          isEmbeddedAgentRunActive: mocks.stallIsEmbeddedAgentRunActive,
+          queueEmbeddedAgentMessageWithOutcomeAsync:
+            mocks.stallQueueEmbeddedAgentMessageWithOutcomeAsync,
+          resolveActiveEmbeddedRunSessionId: mocks.stallResolveActiveEmbeddedRunSessionId,
+        }) as never,
       ensureContextEnginesInitialized: mocks.ensureContextEnginesInitialized,
       ensureRuntimePluginsLoaded: mocks.ensureRuntimePluginsLoaded,
       resolveContextEngine: mocks.resolveContextEngine,
@@ -3932,6 +3961,106 @@ describe("subagent registry seam flow", () => {
           elapsedMs: 55_000,
         },
         "swept session store observed start outcome",
+      );
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("nudges a live subagent once after configured inactivity", async () => {
+    const startedAt = Date.parse("2026-03-24T12:00:00Z");
+    const nudgedAt = startedAt + 70_000;
+    const childSessionKey = "agent:main:subagent:stall-nudge";
+    mocks.loadSessionStore.mockReturnValue({
+      [childSessionKey]: {
+        sessionId: "sess-stall-nudge",
+        updatedAt: startedAt,
+        status: "running",
+      },
+    });
+    mocks.getAgentRunContext.mockImplementation((runId: string) =>
+      runId === "run-stall-nudge" ? ({ lastActiveAt: startedAt } as never) : undefined,
+    );
+    mod.addSubagentRunForTests({
+      runId: "run-stall-nudge",
+      childSessionKey,
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "stall nudge task",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+      createdAt: startedAt,
+      startedAt,
+      stallNudgeSeconds: 60,
+      stallTimeoutSeconds: 180,
+    });
+
+    vi.setSystemTime(nudgedAt);
+    await mod.testing.sweepOnceForTests();
+
+    expect(mocks.stallQueueEmbeddedAgentMessageWithOutcomeAsync).toHaveBeenCalledWith(
+      "sess-stall-nudge",
+      expect.stringContaining("Your parent session has not observed progress"),
+      { steeringMode: "all" },
+    );
+    expect(mocks.stallAbortEmbeddedAgentRun).not.toHaveBeenCalled();
+    const run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-stall-nudge");
+    expect(run?.stallNudgedAt).toBe(nudgedAt);
+    expect(run?.endedAt).toBeUndefined();
+    expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
+  });
+
+  it("kills a still-idle subagent after the configured stall timeout", async () => {
+    const startedAt = Date.parse("2026-03-24T12:00:00Z");
+    const killedAt = startedAt + 190_000;
+    const childSessionKey = "agent:main:subagent:stall-kill";
+    mocks.loadSessionStore.mockReturnValue({
+      [childSessionKey]: {
+        sessionId: "sess-stall-kill",
+        updatedAt: startedAt,
+        status: "running",
+      },
+    });
+    mocks.getAgentRunContext.mockImplementation((runId: string) =>
+      runId === "run-stall-kill" ? ({ lastActiveAt: startedAt } as never) : undefined,
+    );
+    mod.addSubagentRunForTests({
+      runId: "run-stall-kill",
+      childSessionKey,
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "stall kill task",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+      createdAt: startedAt,
+      startedAt,
+      stallNudgeSeconds: 60,
+      stallTimeoutSeconds: 180,
+      stallNudgedAt: startedAt + 70_000,
+    });
+
+    vi.setSystemTime(killedAt);
+    await mod.testing.sweepOnceForTests();
+
+    expect(mocks.stallAbortEmbeddedAgentRun).toHaveBeenCalledWith("sess-stall-kill");
+    expect(mocks.stallClearSessionQueues).toHaveBeenCalledWith([
+      childSessionKey,
+      "sess-stall-kill",
+    ]);
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-stall-kill");
+      expect(run?.endedAt).toBe(killedAt);
+      expect(run?.endedReason).toBe(SUBAGENT_ENDED_REASON_ERROR);
+      expectRecordFields(
+        run?.outcome,
+        {
+          status: "error",
+          error: "subagent run killed after 190s without activity",
+        },
+        "stalled subagent outcome",
       );
     });
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -114,6 +114,11 @@ export {
   resolveSubagentSessionStatus,
 } from "./subagent-registry-helpers.js";
 const log = createSubsystemLogger("agents/subagent-registry");
+const SUBAGENT_STALL_NUDGE_MESSAGE = [
+  "[OpenClaw runtime event] Your parent session has not observed progress from this subagent run recently.",
+  "If you are still working, send a brief progress update or continue the task.",
+  "If you are stuck, explain the blocker and stop waiting silently.",
+].join("\n");
 
 type SubagentAnnounceModule = Pick<
   typeof import("./subagent-announce.js"),
@@ -122,6 +127,14 @@ type SubagentAnnounceModule = Pick<
 type BrowserCleanupModule = Pick<
   typeof import("../browser-lifecycle-cleanup.js"),
   "cleanupBrowserSessionsForLifecycleEnd"
+>;
+type SubagentStallRuntimeModule = Pick<
+  typeof import("./subagent-control.runtime.js"),
+  | "abortEmbeddedAgentRun"
+  | "clearSessionQueues"
+  | "isEmbeddedAgentRunActive"
+  | "queueEmbeddedAgentMessageWithOutcomeAsync"
+  | "resolveActiveEmbeddedRunSessionId"
 >;
 
 type SubagentRegistryDeps = {
@@ -136,6 +149,7 @@ type SubagentRegistryDeps = {
   resolveAgentTimeoutMs: typeof resolveAgentTimeoutMs;
   restoreSubagentRunsFromDisk: typeof restoreSubagentRunsFromDisk;
   runSubagentAnnounceFlow: SubagentAnnounceModule["runSubagentAnnounceFlow"];
+  loadSubagentStallRuntime: () => Promise<SubagentStallRuntimeModule>;
   ensureContextEnginesInitialized?: () => void;
   ensureRuntimePluginsLoaded?: (
     params: Parameters<typeof ensureRuntimePluginsLoadedFn>[0],
@@ -152,6 +166,9 @@ const subagentAnnounceLoader = createLazyImportLoader<SubagentAnnounceModule>(
 const browserCleanupLoader = createLazyImportLoader<BrowserCleanupModule>(
   () => import("../browser-lifecycle-cleanup.js"),
 );
+const subagentStallRuntimeLoader = createLazyImportLoader<SubagentStallRuntimeModule>(
+  () => import("./subagent-control.runtime.js"),
+);
 
 async function loadSubagentAnnounceModule(): Promise<SubagentAnnounceModule> {
   return await subagentAnnounceLoader.load();
@@ -161,6 +178,10 @@ async function loadCleanupBrowserSessionsForLifecycleEnd(): Promise<
   BrowserCleanupModule["cleanupBrowserSessionsForLifecycleEnd"]
 > {
   return (await browserCleanupLoader.load()).cleanupBrowserSessionsForLifecycleEnd;
+}
+
+async function loadSubagentStallRuntime(): Promise<SubagentStallRuntimeModule> {
+  return await subagentStallRuntimeLoader.load();
 }
 
 const defaultSubagentRegistryDeps: SubagentRegistryDeps = {
@@ -178,6 +199,7 @@ const defaultSubagentRegistryDeps: SubagentRegistryDeps = {
   restoreSubagentRunsFromDisk,
   runSubagentAnnounceFlow: async (params) =>
     (await loadSubagentAnnounceModule()).runSubagentAnnounceFlow(params),
+  loadSubagentStallRuntime,
 };
 
 let subagentRegistryDeps: SubagentRegistryDeps = defaultSubagentRegistryDeps;
@@ -869,6 +891,153 @@ function resolveSubagentWaitTimeoutMs(cfg: OpenClawConfig, runTimeoutSeconds?: n
   });
 }
 
+function normalizePositiveSecondsToMs(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value * 1000)
+    : undefined;
+}
+
+function formatStallRuntimeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function resolveLastActivityAt(
+  entry: SubagentRunRecord,
+  runContext: { lastActiveAt?: unknown } | undefined,
+): number {
+  const lastActiveAt = runContext?.lastActiveAt;
+  return typeof lastActiveAt === "number" && Number.isFinite(lastActiveAt)
+    ? lastActiveAt
+    : (entry.startedAt ?? entry.createdAt);
+}
+
+async function recoverStalledSubagentRun(params: {
+  runId: string;
+  entry: SubagentRunRecord;
+  runContext?: { lastActiveAt?: unknown };
+  storeCache: SubagentSessionStoreCache;
+  now: number;
+}): Promise<{ handled: boolean; mutated: boolean }> {
+  const { entry, now, runId } = params;
+  const nudgeMs = normalizePositiveSecondsToMs(entry.stallNudgeSeconds);
+  const timeoutMs = normalizePositiveSecondsToMs(entry.stallTimeoutSeconds);
+  if (nudgeMs === undefined && timeoutMs === undefined) {
+    return { handled: false, mutated: false };
+  }
+
+  const lastActivityAt = resolveLastActivityAt(entry, params.runContext);
+  const idleMs = now - lastActivityAt;
+  if (idleMs < 0) {
+    return { handled: false, mutated: false };
+  }
+
+  let mutated = false;
+  if (typeof entry.stallNudgedAt === "number" && lastActivityAt > entry.stallNudgedAt) {
+    entry.stallNudgedAt = undefined;
+    entry.stallNudgeError = undefined;
+    mutated = true;
+  }
+
+  const shouldNudge =
+    nudgeMs !== undefined &&
+    idleMs >= nudgeMs &&
+    typeof entry.stallNudgedAt !== "number" &&
+    (timeoutMs === undefined || nudgeMs < timeoutMs);
+  if (shouldNudge) {
+    const runtime = await subagentRegistryDeps.loadSubagentStallRuntime();
+    const sessionEntry = loadSubagentSessionEntry({
+      childSessionKey: entry.childSessionKey,
+      storeCache: params.storeCache,
+    });
+    const sessionId =
+      runtime.resolveActiveEmbeddedRunSessionId(entry.childSessionKey) ?? sessionEntry?.sessionId;
+    entry.stallNudgedAt = now;
+    entry.stallNudgeError = undefined;
+    if (!sessionId) {
+      entry.stallNudgeError = "nudge failed: no active session id";
+    } else {
+      try {
+        const outcome = await runtime.queueEmbeddedAgentMessageWithOutcomeAsync(
+          sessionId,
+          SUBAGENT_STALL_NUDGE_MESSAGE,
+          { steeringMode: "all" },
+        );
+        if (!outcome.queued) {
+          const detail = outcome.errorMessage ? `: ${outcome.errorMessage}` : "";
+          entry.stallNudgeError = `nudge failed: ${outcome.reason}${detail}`;
+        }
+      } catch (error) {
+        entry.stallNudgeError = `nudge failed: ${formatStallRuntimeError(error)}`;
+      }
+    }
+    if (entry.stallNudgeError) {
+      log.warn("subagent stall nudge failed", {
+        runId,
+        childSessionKey: entry.childSessionKey,
+        error: entry.stallNudgeError,
+      });
+    } else {
+      log.warn("subagent stall nudge injected", {
+        runId,
+        childSessionKey: entry.childSessionKey,
+        idleMs,
+      });
+    }
+    return { handled: true, mutated: true };
+  }
+
+  if (timeoutMs === undefined || idleMs < timeoutMs) {
+    return { handled: false, mutated };
+  }
+  if (nudgeMs !== undefined && nudgeMs < timeoutMs && typeof entry.stallNudgedAt !== "number") {
+    return { handled: false, mutated };
+  }
+
+  const runtime = await subagentRegistryDeps.loadSubagentStallRuntime();
+  const sessionEntry = loadSubagentSessionEntry({
+    childSessionKey: entry.childSessionKey,
+    storeCache: params.storeCache,
+  });
+  const sessionId =
+    runtime.resolveActiveEmbeddedRunSessionId(entry.childSessionKey) ?? sessionEntry?.sessionId;
+  const active = sessionId ? runtime.isEmbeddedAgentRunActive(sessionId) : false;
+  const aborted = sessionId ? runtime.abortEmbeddedAgentRun(sessionId) : false;
+  const cleared = runtime.clearSessionQueues([entry.childSessionKey, sessionId]);
+  if (active && !aborted) {
+    log.warn("subagent stall kill deferred; active run could not be aborted", {
+      runId,
+      childSessionKey: entry.childSessionKey,
+      sessionId,
+      idleMs,
+    });
+    return { handled: true, mutated };
+  }
+  if (cleared.followupCleared > 0 || cleared.laneCleared > 0) {
+    log.warn("subagent stall kill cleared queued work", {
+      runId,
+      childSessionKey: entry.childSessionKey,
+      followupCleared: cleared.followupCleared,
+      laneCleared: cleared.laneCleared,
+    });
+  }
+  await completeSubagentRunWithRecovery(
+    {
+      runId,
+      endedAt: now,
+      outcome: {
+        status: "error",
+        error: `subagent run killed after ${Math.floor(idleMs / 1000)}s without activity`,
+      },
+      reason: SUBAGENT_ENDED_REASON_ERROR,
+      sendFarewell: true,
+      accountId: entry.requesterOrigin?.accountId,
+      triggerCleanup: true,
+    },
+    "sweeper-stall-timeout",
+  );
+  return { handled: true, mutated: true };
+}
+
 function startSweeper() {
   if (sweeper) {
     return;
@@ -1043,7 +1212,8 @@ async function sweepSubagentRuns() {
         continue;
       }
       if (typeof entry.endedAt !== "number") {
-        const hasLiveRunContext = Boolean(getAgentRunContext(runId));
+        const runContext = getAgentRunContext(runId) as { lastActiveAt?: unknown } | undefined;
+        const hasLiveRunContext = Boolean(runContext);
         const activeAgeMs = now - (entry.startedAt ?? entry.createdAt);
         if (!hasLiveRunContext && activeAgeMs >= STALE_ACTIVE_SUBAGENT_GRACE_MS) {
           const orphanReason = resolveSubagentRunOrphanReason({
@@ -1110,6 +1280,21 @@ async function sweepSubagentRuns() {
             "sweeper-lost-context",
           );
           continue;
+        }
+        if (hasLiveRunContext) {
+          const recovered = await recoverStalledSubagentRun({
+            runId,
+            entry,
+            runContext,
+            storeCache,
+            now,
+          });
+          if (recovered.mutated) {
+            mutated = true;
+          }
+          if (recovered.handled) {
+            continue;
+          }
         }
       }
 

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -110,6 +110,10 @@ export type SubagentRunRecord = {
   agentDir?: string;
   workspaceDir?: string;
   runTimeoutSeconds?: number;
+  stallNudgeSeconds?: number;
+  stallTimeoutSeconds?: number;
+  stallNudgedAt?: number;
+  stallNudgeError?: string;
   spawnMode?: SpawnSubagentMode;
   /** Monotonic ownership generation within one child session. */
   generation?: number;

--- a/src/agents/subagent-spawn-plan.ts
+++ b/src/agents/subagent-spawn-plan.ts
@@ -50,6 +50,21 @@ export function resolveConfiguredSubagentRunTimeoutSeconds(params: {
     : cfgSubagentTimeout;
 }
 
+function normalizeOptionalSeconds(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.max(0, Math.floor(value))
+    : undefined;
+}
+
+/** Resolves configured subagent stall recovery thresholds. */
+export function resolveConfiguredSubagentStallPolicy(params: { cfg: OpenClawConfig }) {
+  const subagents = params.cfg?.agents?.defaults?.subagents;
+  return {
+    stallNudgeSeconds: normalizeOptionalSeconds(subagents?.stallNudgeSeconds),
+    stallTimeoutSeconds: normalizeOptionalSeconds(subagents?.stallTimeoutSeconds),
+  };
+}
+
 /** Resolves the subagent model plus thinking patch to apply to the spawned session. */
 export function resolveSubagentModelAndThinkingPlan(params: {
   cfg: OpenClawConfig;

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -75,6 +75,7 @@ export {
 import { resolveRequesterOriginForChild } from "./spawn-requester-origin.js";
 import {
   resolveConfiguredSubagentRunTimeoutSeconds,
+  resolveConfiguredSubagentStallPolicy,
   resolveSubagentModelAndThinkingPlan,
   splitModelRef,
 } from "./subagent-spawn-plan.js";
@@ -1129,6 +1130,7 @@ export async function spawnSubagentDirect(
     cfg,
     runTimeoutSeconds: params.runTimeoutSeconds,
   });
+  const stallPolicy = resolveConfiguredSubagentStallPolicy({ cfg });
   let modelApplied = false;
   let threadBindingReady = false;
   let hasBoundThreadDeliveryOrigin = false;
@@ -1668,6 +1670,7 @@ export async function spawnSubagentDirect(
       agentDir: targetAgentDir,
       workspaceDir: spawnedMetadata.workspaceDir,
       runTimeoutSeconds,
+      ...stallPolicy,
       expectsCompletionMessage: shouldAnnounceCompletion,
       spawnMode,
       attachmentsDir: attachmentAbsDir,

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -27,6 +27,7 @@ import type { SpawnedToolContext } from "../spawned-context.js";
 import { resolveAcpSessionsSpawnImageAttachments } from "../subagent-attachments.js";
 import { registerSubagentRun } from "../subagent-registry.js";
 import { resolveSubagentSpawnOwnership } from "../subagent-spawn-ownership.js";
+import { resolveConfiguredSubagentStallPolicy } from "../subagent-spawn-plan.js";
 import {
   SUBAGENT_SPAWN_CONTEXT_MODES,
   SUBAGENT_SPAWN_MODES,
@@ -439,6 +440,7 @@ export function createSessionsSpawnTool(
             ? false
             : expectsCompletionMessage;
           try {
+            const stallPolicy = resolveConfiguredSubagentStallPolicy({ cfg });
             registerSubagentRun({
               runId: childRunId,
               childSessionKey,
@@ -452,6 +454,7 @@ export function createSessionsSpawnTool(
               cleanup: trackedCleanup,
               label: label || undefined,
               runTimeoutSeconds: result.runTimeoutSeconds,
+              ...stallPolicy,
               expectsCompletionMessage: shouldExpectCompletionMessage,
               spawnMode: trackedSpawnMode,
             });

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -480,6 +480,10 @@ export type AgentDefaultsConfig = {
     thinking?: string;
     /** Default run timeout in seconds for spawned sub-agents (0 = no timeout). */
     runTimeoutSeconds?: number;
+    /** Seconds of no observed child-run activity before injecting a stall recovery nudge (0 = disabled). */
+    stallNudgeSeconds?: number;
+    /** Seconds of no observed child-run activity before killing the stalled sub-agent (0 = disabled). */
+    stallTimeoutSeconds?: number;
     /** Gateway timeout in ms for sub-agent announce delivery calls (default: 120000). */
     announceTimeoutMs?: number;
     /** Require explicit agentId in sessions_spawn (no default same-as-caller). Default: false. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -264,6 +264,8 @@ export const AgentDefaultsSchema = z
         model: AgentModelSchema.optional(),
         thinking: z.string().optional(),
         runTimeoutSeconds: z.number().int().min(0).optional(),
+        stallNudgeSeconds: z.number().int().min(0).optional(),
+        stallTimeoutSeconds: z.number().int().min(0).optional(),
         announceTimeoutMs: z.number().int().positive().optional(),
         requireAgentId: z.boolean().optional(),
       })


### PR DESCRIPTION
## What Problem This Solves

Spawned subagents can currently stall indefinitely without a structured recovery path. When a child run stops making progress, the parent session may never receive a useful completion/error result, leaving the task wedged until manual intervention. Issue #39305 asks for an escalating recovery path: nudge the stalled child first, then kill it and report the failure if it remains inactive.

Refs #39305

## Solution

- Add opt-in subagent stall recovery thresholds under `agents.defaults.subagents`.
- Freeze the stall policy on each registered run so later config changes do not alter in-flight recovery behavior.
- Nudge live child runs once after configured inactivity.
- Kill and report stalled runs after the configured timeout so the parent receives a terminal error instead of waiting forever.
- Wire the same policy through native subagent spawning and ACP `sessions_spawn` registry paths.
- Document the new config and add regression tests for nudge, kill, and policy resolution.

## Evidence

Validation run locally before opening/updating the PR:

- `node scripts/run-vitest.mjs src/agents/subagent-registry.test.ts -t "stall"`
- `node scripts/run-vitest.mjs src/agents/subagent-registry.test.ts`
- `node scripts/run-vitest.mjs src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts`
- `git diff --check`
- `pnpm check:no-conflict-markers`
- `pnpm check:base-config-schema`
- `pnpm docs:check-mdx docs/tools/subagents.md`
- `pnpm check:test-types`
- `pnpm tsgo:prod`

After rebasing onto the latest available `main`, I reran the focused changed-area checks:

- `node scripts/run-vitest.mjs src/agents/subagent-registry.test.ts -t "stall"`
- `node scripts/run-vitest.mjs src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts`
- `git diff --check origin/main...HEAD`

## Notes

- `pnpm check:changed` could not run through its default local delegation because the crabbox wrapper failed its selected-binary sanity check. I ran the selected changed-file checks directly instead.
- Running `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 ... pnpm check:changed` also could not use its internal child runner because `corepack` is not present on this host PATH.
