### PR TITLE
fix: bind bun x exec approvals to the inner command like bunx

### DIFF
--- a/src/infra/exec-allow-always-persistence.test.ts
+++ b/src/infra/exec-allow-always-persistence.test.ts
@@ -369,6 +369,30 @@ describe("resolveAllowAlwaysPersistenceDecision", () => {
     });
   });
 
+  it("keeps bun option-value hidden-x carriers one-shot", async () => {
+    const dir = makeTempDir();
+    for (const executable of ["bun", "sh", "echo"]) {
+      makeExecutable(dir, executable);
+    }
+    const env = makePathEnv(dir);
+    const command = "bun -c x sh -c 'echo warmup-ok'";
+    const plan = await planShellAuthorization({ command, cwd: dir, env });
+
+    const decision = resolveAllowAlwaysPersistenceDecision({
+      segments: plannedSegments(plan),
+      commandText: command,
+      cwd: dir,
+      env,
+      platform: process.platform,
+      authorizationPlan: plan,
+    });
+
+    expect(decision).toEqual({
+      kind: "one-shot",
+      reasons: expect.arrayContaining(["no-reusable-pattern"]),
+    });
+  });
+
   it("keeps chained package-manager shell carriers one-shot", async () => {
     const dir = makeTempDir();
     for (const executable of ["pnpm", "npm", "sh", "echo"]) {

--- a/src/infra/exec-allow-always-persistence.test.ts
+++ b/src/infra/exec-allow-always-persistence.test.ts
@@ -369,13 +369,36 @@ describe("resolveAllowAlwaysPersistenceDecision", () => {
     });
   });
 
-  it("keeps bun option-value hidden-x carriers one-shot", async () => {
+  it("keeps bun x carriers behind space-valued globals one-shot", async () => {
     const dir = makeTempDir();
     for (const executable of ["bun", "sh", "echo"]) {
       makeExecutable(dir, executable);
     }
     const env = makePathEnv(dir);
     const command = "bun -c x sh -c 'echo warmup-ok'";
+    const plan = await planShellAuthorization({ command, cwd: dir, env });
+
+    const decision = resolveAllowAlwaysPersistenceDecision({
+      segments: plannedSegments(plan),
+      commandText: command,
+      cwd: dir,
+      env,
+      platform: process.platform,
+      authorizationPlan: plan,
+    });
+
+    expect(decision).toEqual({
+      kind: "one-shot",
+      reasons: expect.arrayContaining(["no-reusable-pattern"]),
+    });
+  });
+
+  it("keeps bun space-valued cwd selector forms out of inner persistence", async () => {
+    const dir = makeTempDir();
+    makeExecutable(dir, "bun");
+    makeExecutable(dir, "tsx");
+    const env = makePathEnv(dir);
+    const command = "bun --cwd ./pkg x tsx ./run.ts";
     const plan = await planShellAuthorization({ command, cwd: dir, env });
 
     const decision = resolveAllowAlwaysPersistenceDecision({

--- a/src/infra/exec-allow-always-persistence.test.ts
+++ b/src/infra/exec-allow-always-persistence.test.ts
@@ -189,6 +189,30 @@ describe("resolveAllowAlwaysPersistenceDecision", () => {
     });
   });
 
+  it("persists bun x approvals against the inner executable", async () => {
+    const dir = makeTempDir();
+    makeExecutable(dir, "bun");
+    const tsxPath = makeExecutable(dir, "tsx");
+    const env = makePathEnv(dir);
+    const command = "bun x tsx ./run.ts";
+    const plan = await planShellAuthorization({ command, cwd: dir, env });
+
+    const decision = resolveAllowAlwaysPersistenceDecision({
+      segments: plannedSegments(plan),
+      commandText: command,
+      cwd: dir,
+      env,
+      platform: process.platform,
+      authorizationPlan: plan,
+    });
+
+    expect(decision).toEqual({
+      kind: "patterns",
+      commandText: command,
+      patterns: [expect.objectContaining({ pattern: tsxPath })],
+    });
+  });
+
   it("persists chained package-manager exec approvals against the final inner executable", async () => {
     const dir = makeTempDir();
     for (const executable of ["pnpm", "npm"]) {
@@ -304,6 +328,30 @@ describe("resolveAllowAlwaysPersistenceDecision", () => {
     }
     const env = makePathEnv(dir);
     const command = "npm x sh -c 'echo warmup-ok'";
+    const plan = await planShellAuthorization({ command, cwd: dir, env });
+
+    const decision = resolveAllowAlwaysPersistenceDecision({
+      segments: plannedSegments(plan),
+      commandText: command,
+      cwd: dir,
+      env,
+      platform: process.platform,
+      authorizationPlan: plan,
+    });
+
+    expect(decision).toEqual({
+      kind: "one-shot",
+      reasons: expect.arrayContaining(["no-reusable-pattern"]),
+    });
+  });
+
+  it("keeps bun x shell carriers one-shot", async () => {
+    const dir = makeTempDir();
+    for (const executable of ["bun", "sh", "echo"]) {
+      makeExecutable(dir, executable);
+    }
+    const env = makePathEnv(dir);
+    const command = "bun x sh -c 'echo warmup-ok'";
     const plan = await planShellAuthorization({ command, cwd: dir, env });
 
     const decision = resolveAllowAlwaysPersistenceDecision({

--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -1055,7 +1055,7 @@ $0 \\"$1\\"" touch {marker}`,
     ).toBe(true);
   });
 
-  it("rejects stale bun allow-always entries when option values hide x", async () => {
+  it("rejects stale bun allow-always entries when a space-valued global puts x in dispatch position", async () => {
     if (process.platform === "win32") {
       return;
     }
@@ -1087,7 +1087,7 @@ $0 \\"$1\\"" touch {marker}`,
     ).toBe(true);
   });
 
-  it("rejects stale bun allow-always entries when unknown options hide x", async () => {
+  it("rejects stale bun allow-always entries when unknown globals precede x", async () => {
     if (process.platform === "win32") {
       return;
     }
@@ -1508,6 +1508,18 @@ $0 \\"$1\\"" touch {marker}`,
       platform: process.platform,
     });
     expect(bunInner.allowlistSatisfied).toBe(true);
+
+    // "--cwd ./pkg" makes "./pkg" bun's selected command, not "x", so the
+    // inner-executable entry must not authorize this form.
+    const bunCwdSelector = await evaluateShellAllowlistWithAuthorization({
+      command: "bun --cwd ./pkg x tsx ./run.ts",
+      allowlist: [{ pattern: tsxPath, source: "allow-always" }],
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(bunCwdSelector.allowlistSatisfied).toBe(false);
   });
 
   it("prevents allow-always bypass for sandbox-exec wrapper chains", async () => {

--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -1055,6 +1055,38 @@ $0 \\"$1\\"" touch {marker}`,
     ).toBe(true);
   });
 
+  it("rejects stale bun allow-always entries when option values hide x", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const bunPath = makeExecutable(dir, "bun");
+    makeExecutable(dir, "sh");
+    makeExecutable(dir, "id");
+    const env = makePathEnv(dir);
+    const safeBins = resolveSafeBins(undefined);
+
+    const result = await evaluateShellAllowlistWithAuthorization({
+      command: "bun -c x sh -c 'id > marker'",
+      allowlist: [{ pattern: bunPath, source: "allow-always" }],
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+
+    expect(result.allowlistSatisfied).toBe(false);
+    expect(result.segmentAllowlistEntries).toEqual([null]);
+    expect(
+      requiresExecApproval({
+        ask: "on-miss",
+        security: "allowlist",
+        analysisOk: result.analysisOk,
+        allowlistSatisfied: result.allowlistSatisfied,
+      }),
+    ).toBe(true);
+  });
+
   it("rejects stale bun allow-always entries when unknown options hide x", async () => {
     if (process.platform === "win32") {
       return;

--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -1023,6 +1023,70 @@ $0 \\"$1\\"" touch {marker}`,
     ).toBe(true);
   });
 
+  it("rejects stale bun allow-always entries for x shell carriers", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const bunPath = makeExecutable(dir, "bun");
+    makeExecutable(dir, "sh");
+    makeExecutable(dir, "id");
+    const env = makePathEnv(dir);
+    const safeBins = resolveSafeBins(undefined);
+
+    const result = await evaluateShellAllowlistWithAuthorization({
+      command: "bun x sh -c 'id > marker'",
+      allowlist: [{ pattern: bunPath, source: "allow-always" }],
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+
+    expect(result.allowlistSatisfied).toBe(false);
+    expect(result.segmentAllowlistEntries).toEqual([null]);
+    expect(
+      requiresExecApproval({
+        ask: "on-miss",
+        security: "allowlist",
+        analysisOk: result.analysisOk,
+        allowlistSatisfied: result.allowlistSatisfied,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects stale bun allow-always entries when unknown options hide x", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const bunPath = makeExecutable(dir, "bun");
+    makeExecutable(dir, "sh");
+    makeExecutable(dir, "id");
+    const env = makePathEnv(dir);
+    const safeBins = resolveSafeBins(undefined);
+
+    const result = await evaluateShellAllowlistWithAuthorization({
+      command: "bun --unknown-global-option x sh -c 'id > marker'",
+      allowlist: [{ pattern: bunPath, source: "allow-always" }],
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+
+    expect(result.allowlistSatisfied).toBe(false);
+    expect(result.segmentAllowlistEntries).toEqual([null]);
+    expect(
+      requiresExecApproval({
+        ask: "on-miss",
+        security: "allowlist",
+        analysisOk: result.analysisOk,
+        allowlistSatisfied: result.allowlistSatisfied,
+      }),
+    ).toBe(true);
+  });
+
   it("rejects stale package-manager allow-always entries for chained shell carriers", async () => {
     if (process.platform === "win32") {
       return;
@@ -1391,6 +1455,27 @@ $0 \\"$1\\"" touch {marker}`,
       platform: process.platform,
     });
     expect(yarnInner.allowlistSatisfied).toBe(true);
+
+    const bunPath = makeExecutable(dir, "bun");
+    const bunStaleOuter = await evaluateShellAllowlistWithAuthorization({
+      command: "bun x tsx ./run.ts",
+      allowlist: [{ pattern: bunPath, source: "allow-always" }],
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(bunStaleOuter.allowlistSatisfied).toBe(false);
+
+    const bunInner = await evaluateShellAllowlistWithAuthorization({
+      command: "bun x tsx ./run.ts",
+      allowlist: [{ pattern: tsxPath, source: "allow-always" }],
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(bunInner.allowlistSatisfied).toBe(true);
   });
 
   it("prevents allow-always bypass for sandbox-exec wrapper chains", async () => {

--- a/src/infra/package-manager-exec-wrapper.test.ts
+++ b/src/infra/package-manager-exec-wrapper.test.ts
@@ -14,17 +14,33 @@ describe("resolveKnownPackageManagerExecInvocation", () => {
       );
     });
 
-    it("unwraps bun x behind known global options and double-dash tails", () => {
+    it("unwraps bun x when the dispatch selector picks x", () => {
       expect(
         resolveKnownPackageManagerExecInvocation(["bun", "--silent", "x", "tsx", "./run.ts"]),
       ).toEqual({ kind: "unwrapped", argv: ["tsx", "./run.ts"] });
       expect(
-        resolveKnownPackageManagerExecInvocation(["bun", "--cwd", "./pkg", "x", "tsx", "./run.ts"]),
+        resolveKnownPackageManagerExecInvocation(["bun", "--cwd=./pkg", "x", "tsx", "./run.ts"]),
       ).toEqual({ kind: "unwrapped", argv: ["tsx", "./run.ts"] });
       expect(
         resolveKnownPackageManagerExecInvocation(["bun", "x", "--", "tsx", "./run.ts"]),
       ).toEqual({ kind: "unwrapped", argv: ["tsx", "./run.ts"] });
     });
+
+    it.each(["-c", "--config", "--cwd", "--env-file", "--unknown-global-option"])(
+      "selects the token after the space-valued global %s like bun dispatch does",
+      (flag) => {
+        // A literal "x" in value position is what bun's selector dispatches
+        // to bunx, so the tail unwraps to the inner command.
+        expect(
+          resolveKnownPackageManagerExecInvocation(["bun", flag, "x", "sh", "-c", "id > marker"]),
+        ).toEqual({ kind: "unwrapped", argv: ["sh", "-c", "id > marker"] });
+        // A non-"x" token after the global is the selected command (bun runs
+        // it as an ordinary invocation), so no package-exec unwrapping.
+        expect(
+          resolveKnownPackageManagerExecInvocation(["bun", flag, "./pkg", "x", "tsx", "./run.ts"]),
+        ).toEqual({ kind: "not-exec" });
+      },
+    );
 
     it("keeps non-exec bun invocations out of unwrapping", () => {
       expect(resolveKnownPackageManagerExecInvocation(["bun", "run", "build"])).toEqual({
@@ -46,26 +62,11 @@ describe("resolveKnownPackageManagerExecInvocation", () => {
         kind: "unsafe-exec",
       });
       expect(
-        resolveKnownPackageManagerExecInvocation(["bun", "--unknown-global-option", "x", "sh"]),
-      ).toEqual({ kind: "unsafe-exec" });
-      expect(
         resolveKnownPackageManagerExecInvocation(["bun", "x", "--call", "sh -c 'id'"]),
       ).toEqual({ kind: "unsafe-exec" });
-    });
-
-    it.each(["-c", "--config", "--cwd", "--env-file"])(
-      "fails closed when the %s option value hides x",
-      (flag) => {
-        expect(
-          resolveKnownPackageManagerExecInvocation(["bun", flag, "x", "sh", "-c", "id > marker"]),
-        ).toEqual({ kind: "unsafe-exec" });
-      },
-    );
-
-    it("still unwraps when valued options use inline values", () => {
-      expect(
-        resolveKnownPackageManagerExecInvocation(["bun", "--cwd=./pkg", "x", "tsx", "./run.ts"]),
-      ).toEqual({ kind: "unwrapped", argv: ["tsx", "./run.ts"] });
+      expect(resolveKnownPackageManagerExecInvocation(["bun", "--", "x", "tsx"])).toEqual({
+        kind: "unsafe-exec",
+      });
     });
   });
 });

--- a/src/infra/package-manager-exec-wrapper.test.ts
+++ b/src/infra/package-manager-exec-wrapper.test.ts
@@ -26,21 +26,30 @@ describe("resolveKnownPackageManagerExecInvocation", () => {
       ).toEqual({ kind: "unwrapped", argv: ["tsx", "./run.ts"] });
     });
 
-    it.each(["-c", "--config", "--cwd", "--env-file", "--unknown-global-option"])(
-      "selects the token after the space-valued global %s like bun dispatch does",
+    it.each(["-c", "--config", "--cwd", "--env-file"])(
+      "fails closed when dispatch after the space-valued global %s is model-dependent",
       (flag) => {
-        // A literal "x" in value position is what bun's selector dispatches
-        // to bunx, so the tail unwraps to the inner command.
+        // A literal "x" in value position is the subcommand under one
+        // dispatch model and the option value under the other.
         expect(
           resolveKnownPackageManagerExecInvocation(["bun", flag, "x", "sh", "-c", "id > marker"]),
-        ).toEqual({ kind: "unwrapped", argv: ["sh", "-c", "id > marker"] });
-        // A non-"x" token after the global is the selected command (bun runs
-        // it as an ordinary invocation), so no package-exec unwrapping.
+        ).toEqual({ kind: "unsafe-exec" });
+        // Consuming the value selects "x"; skipping dash tokens selects the
+        // value token instead.
         expect(
           resolveKnownPackageManagerExecInvocation(["bun", flag, "./pkg", "x", "tsx", "./run.ts"]),
-        ).toEqual({ kind: "not-exec" });
+        ).toEqual({ kind: "unsafe-exec" });
       },
     );
+
+    it("fails closed on unknown globals only when x can be selected", () => {
+      expect(
+        resolveKnownPackageManagerExecInvocation(["bun", "--unknown-global-option", "x", "sh"]),
+      ).toEqual({ kind: "unsafe-exec" });
+      expect(
+        resolveKnownPackageManagerExecInvocation(["bun", "--unknown-global-option", "run", "dev"]),
+      ).toEqual({ kind: "not-exec" });
+    });
 
     it("keeps non-exec bun invocations out of unwrapping", () => {
       expect(resolveKnownPackageManagerExecInvocation(["bun", "run", "build"])).toEqual({

--- a/src/infra/package-manager-exec-wrapper.test.ts
+++ b/src/infra/package-manager-exec-wrapper.test.ts
@@ -24,6 +24,12 @@ describe("resolveKnownPackageManagerExecInvocation", () => {
       expect(
         resolveKnownPackageManagerExecInvocation(["bun", "x", "--", "tsx", "./run.ts"]),
       ).toEqual({ kind: "unwrapped", argv: ["tsx", "./run.ts"] });
+      expect(resolveKnownPackageManagerExecInvocation(["bun", "", "x", "tsx", "./run.ts"])).toEqual(
+        { kind: "unwrapped", argv: ["tsx", "./run.ts"] },
+      );
+      expect(
+        resolveKnownPackageManagerExecInvocation(["bun", "--foo=bar", "x", "tsx", "./run.ts"]),
+      ).toEqual({ kind: "unwrapped", argv: ["tsx", "./run.ts"] });
     });
 
     it.each(["-c", "--config", "--cwd", "--env-file"])(

--- a/src/infra/package-manager-exec-wrapper.test.ts
+++ b/src/infra/package-manager-exec-wrapper.test.ts
@@ -1,0 +1,56 @@
+// Tests package-manager exec wrapper resolution for inner-command approval binding.
+import { describe, expect, it } from "vitest";
+import { resolveKnownPackageManagerExecInvocation } from "./package-manager-exec-wrapper.js";
+
+describe("resolveKnownPackageManagerExecInvocation", () => {
+  describe("bun", () => {
+    it("unwraps bun x to the inner command with bunx parity", () => {
+      expect(resolveKnownPackageManagerExecInvocation(["bun", "x", "tsx", "./run.ts"])).toEqual({
+        kind: "unwrapped",
+        argv: ["tsx", "./run.ts"],
+      });
+      expect(resolveKnownPackageManagerExecInvocation(["bun", "x", "tsx", "./run.ts"])).toEqual(
+        resolveKnownPackageManagerExecInvocation(["bunx", "tsx", "./run.ts"]),
+      );
+    });
+
+    it("unwraps bun x behind known global options and double-dash tails", () => {
+      expect(
+        resolveKnownPackageManagerExecInvocation(["bun", "--silent", "x", "tsx", "./run.ts"]),
+      ).toEqual({ kind: "unwrapped", argv: ["tsx", "./run.ts"] });
+      expect(
+        resolveKnownPackageManagerExecInvocation(["bun", "--cwd", "./pkg", "x", "tsx", "./run.ts"]),
+      ).toEqual({ kind: "unwrapped", argv: ["tsx", "./run.ts"] });
+      expect(
+        resolveKnownPackageManagerExecInvocation(["bun", "x", "--", "tsx", "./run.ts"]),
+      ).toEqual({ kind: "unwrapped", argv: ["tsx", "./run.ts"] });
+    });
+
+    it("keeps non-exec bun invocations out of unwrapping", () => {
+      expect(resolveKnownPackageManagerExecInvocation(["bun", "run", "build"])).toEqual({
+        kind: "not-exec",
+      });
+      expect(resolveKnownPackageManagerExecInvocation(["bun", "./x.ts"])).toEqual({
+        kind: "not-exec",
+      });
+      expect(resolveKnownPackageManagerExecInvocation(["bun", "install"])).toEqual({
+        kind: "not-exec",
+      });
+      expect(resolveKnownPackageManagerExecInvocation(["bun", "exec", "echo ok"])).toEqual({
+        kind: "not-exec",
+      });
+    });
+
+    it("fails closed on ambiguous bun x forms", () => {
+      expect(resolveKnownPackageManagerExecInvocation(["bun", "x"])).toEqual({
+        kind: "unsafe-exec",
+      });
+      expect(
+        resolveKnownPackageManagerExecInvocation(["bun", "--unknown-global-option", "x", "sh"]),
+      ).toEqual({ kind: "unsafe-exec" });
+      expect(
+        resolveKnownPackageManagerExecInvocation(["bun", "x", "--call", "sh -c 'id'"]),
+      ).toEqual({ kind: "unsafe-exec" });
+    });
+  });
+});

--- a/src/infra/package-manager-exec-wrapper.test.ts
+++ b/src/infra/package-manager-exec-wrapper.test.ts
@@ -52,5 +52,20 @@ describe("resolveKnownPackageManagerExecInvocation", () => {
         resolveKnownPackageManagerExecInvocation(["bun", "x", "--call", "sh -c 'id'"]),
       ).toEqual({ kind: "unsafe-exec" });
     });
+
+    it.each(["-c", "--config", "--cwd", "--env-file"])(
+      "fails closed when the %s option value hides x",
+      (flag) => {
+        expect(
+          resolveKnownPackageManagerExecInvocation(["bun", flag, "x", "sh", "-c", "id > marker"]),
+        ).toEqual({ kind: "unsafe-exec" });
+      },
+    );
+
+    it("still unwraps when valued options use inline values", () => {
+      expect(
+        resolveKnownPackageManagerExecInvocation(["bun", "--cwd=./pkg", "x", "tsx", "./run.ts"]),
+      ).toEqual({ kind: "unwrapped", argv: ["tsx", "./run.ts"] });
+    });
   });
 });

--- a/src/infra/package-manager-exec-wrapper.ts
+++ b/src/infra/package-manager-exec-wrapper.ts
@@ -386,6 +386,8 @@ function unwrapBunExecInvocation(argv: string[]): string[] | null {
   if (tail[0] === "--") {
     return tail.length > 1 ? tail.slice(1) : null;
   }
+  // Tail parsing delegates to the shared bunx path so "bun x" and "bunx"
+  // accept and reject identical forms (unknown tail options fail closed).
   return unwrapDirectPackageExecInvocation(["bunx", ...tail]);
 }
 

--- a/src/infra/package-manager-exec-wrapper.ts
+++ b/src/infra/package-manager-exec-wrapper.ts
@@ -31,6 +31,8 @@ const NPM_EXEC_SUBCOMMANDS = new Set(["exec", "x"]);
 // invocations and "exec" is a shell-string carrier, so neither may unwrap.
 const BUN_EXEC_SUBCOMMANDS = new Set(["x"]);
 
+// "--cwd" unwraps like the npm/pnpm "-C" cwd options do: inner binding stays
+// on the delegated executable, matching the sibling wrapper cases' contract.
 const BUN_OPTIONS_WITH_VALUE = new Set(["--config", "--cwd", "--env-file", "-c"]);
 
 const BUN_FLAG_OPTIONS = new Set(["--bun", "--silent", "-b"]);

--- a/src/infra/package-manager-exec-wrapper.ts
+++ b/src/infra/package-manager-exec-wrapper.ts
@@ -27,6 +27,14 @@ const NPM_EXEC_FLAG_OPTIONS = new Set([
 
 const NPM_EXEC_SUBCOMMANDS = new Set(["exec", "x"]);
 
+// Only "x" is package exec for bun; "run"/file operands are runtime script
+// invocations and "exec" is a shell-string carrier, so neither may unwrap.
+const BUN_EXEC_SUBCOMMANDS = new Set(["x"]);
+
+const BUN_OPTIONS_WITH_VALUE = new Set(["--config", "--cwd", "--env-file", "-c"]);
+
+const BUN_FLAG_OPTIONS = new Set(["--bun", "--silent", "-b"]);
+
 export const PNPM_OPTIONS_WITH_VALUE = new Set([
   "--config",
   "--dir",
@@ -345,6 +353,42 @@ function unwrapNpmExecInvocation(argv: string[]): string[] | null {
   return unwrapDirectPackageExecInvocation(["npx", ...tail]);
 }
 
+function unwrapBunExecInvocation(argv: string[]): string[] | null {
+  let idx = 1;
+  while (idx < argv.length) {
+    const token = argv[idx]?.trim() ?? "";
+    if (!token) {
+      idx += 1;
+      continue;
+    }
+    if (!token.startsWith("-")) {
+      if (!BUN_EXEC_SUBCOMMANDS.has(token)) {
+        return null;
+      }
+      idx += 1;
+      break;
+    }
+    const flag = normalizeOptionFlag(token);
+    if (BUN_OPTIONS_WITH_VALUE.has(flag)) {
+      idx += token.includes("=") ? 1 : 2;
+      continue;
+    }
+    if (BUN_FLAG_OPTIONS.has(flag)) {
+      idx += 1;
+      continue;
+    }
+    return null;
+  }
+  if (idx >= argv.length) {
+    return null;
+  }
+  const tail = argv.slice(idx);
+  if (tail[0] === "--") {
+    return tail.length > 1 ? tail.slice(1) : null;
+  }
+  return unwrapDirectPackageExecInvocation(["bunx", ...tail]);
+}
+
 function unwrapYarnDlxInvocation(argv: string[]): string[] | null {
   let idx = 0;
   while (idx < argv.length) {
@@ -441,6 +485,21 @@ export function resolveKnownPackageManagerExecInvocation(
     case "bunx": {
       const unwrapped = unwrapDirectPackageExecInvocation(argv);
       return unwrapped ? { kind: "unwrapped", argv: unwrapped } : { kind: "unsafe-exec" };
+    }
+    case "bun": {
+      const unwrapped = unwrapBunExecInvocation(argv);
+      if (unwrapped) {
+        return { kind: "unwrapped", argv: unwrapped };
+      }
+      const firstSubcommand = firstSubcommandAfterOptions(argv, {
+        optionsWithValue: BUN_OPTIONS_WITH_VALUE,
+        flagOptions: BUN_FLAG_OPTIONS,
+      });
+      return BUN_EXEC_SUBCOMMANDS.has(firstSubcommand ?? "")
+        ? { kind: "unsafe-exec" }
+        : firstSubcommand === null && containsSubcommandToken(argv.slice(1), BUN_EXEC_SUBCOMMANDS)
+          ? { kind: "unsafe-exec" }
+          : { kind: "not-exec" };
     }
     case "pnpm": {
       const unwrapped = unwrapPnpmExecInvocation(argv);

--- a/src/infra/package-manager-exec-wrapper.ts
+++ b/src/infra/package-manager-exec-wrapper.ts
@@ -31,6 +31,42 @@ const NPM_EXEC_SUBCOMMANDS = new Set(["exec", "x"]);
 // invocations and "exec" is a shell-string carrier, so neither may unwrap.
 const BUN_EXEC_SUBCOMMANDS = new Set(["x"]);
 
+// Shared with node-host script-operand hardening (invoke-system-run-plan),
+// which models bun as consuming a separate value for these globals.
+export const BUN_OPTIONS_WITH_VALUE = new Set([
+  "--backend",
+  "--bunfig",
+  "--conditions",
+  "--config",
+  "--console-depth",
+  "--cwd",
+  "--define",
+  "--elide-lines",
+  "--env-file",
+  "--extension-order",
+  "--filter",
+  "--hot",
+  "--inspect",
+  "--inspect-brk",
+  "--inspect-wait",
+  "--install",
+  "--jsx-factory",
+  "--jsx-fragment",
+  "--jsx-import-source",
+  "--loader",
+  "--origin",
+  "--port",
+  "--preload",
+  "--smol",
+  "--tsconfig-override",
+  "-c",
+  "-e",
+  "-p",
+  "-r",
+]);
+
+const BUN_FLAG_OPTIONS = new Set(["--bun", "--silent", "-b"]);
+
 export const PNPM_OPTIONS_WITH_VALUE = new Set([
   "--config",
   "--dir",
@@ -349,11 +385,40 @@ function unwrapNpmExecInvocation(argv: string[]): string[] | null {
   return unwrapDirectPackageExecInvocation(["npx", ...tail]);
 }
 
-// Mirrors Bun's root dispatch: the command selector skips dash-prefixed
-// tokens without consuming space-separated option values, so the first
-// non-dash token decides whether "x" (bunx) runs. A space-valued global like
-// "--cwd ./pkg" therefore makes "./pkg" the selected command, not "x".
+// Two dispatch models exist for a bun global option with a space-separated
+// value: bun's root selector has been observed to skip dash tokens without
+// consuming values, while this repo's shipped script-operand model
+// (node-host invoke-system-run-plan) consumes values for the known globals in
+// BUN_OPTIONS_WITH_VALUE. Unwrap only when both models select the same "x"
+// token; any form whose dispatch depends on the model fails closed.
 function resolveBunExecInvocation(argv: string[]): PackageManagerExecInvocation {
+  const conservative = (fromIdx: number): PackageManagerExecInvocation =>
+    containsSubcommandToken(argv.slice(fromIdx), BUN_EXEC_SUBCOMMANDS)
+      ? { kind: "unsafe-exec" }
+      : { kind: "not-exec" };
+
+  // Selector model A: skip every dash token without consuming values.
+  let selectedA: { token: string; idx: number } | null = null;
+  for (let idx = 1; idx < argv.length; idx += 1) {
+    const token = argv[idx]?.trim() ?? "";
+    if (!token) {
+      continue;
+    }
+    if (token === "--") {
+      // Neither model defines selection past "--"; fail closed if x follows.
+      return conservative(idx + 1);
+    }
+    if (token.startsWith("-")) {
+      continue;
+    }
+    selectedA = { token, idx };
+    break;
+  }
+
+  // Selector model B: known valued globals consume their separate value,
+  // known flags skip; an unknown dash token has unknown arity in this model,
+  // so selection cannot proceed deterministically.
+  let selectedB: { token: string; idx: number } | null = null;
   let idx = 1;
   while (idx < argv.length) {
     const token = argv[idx]?.trim() ?? "";
@@ -362,29 +427,44 @@ function resolveBunExecInvocation(argv: string[]): PackageManagerExecInvocation 
       continue;
     }
     if (token === "--") {
-      // Whether Bun's selector still picks a subcommand after "--" is not a
-      // contract we can rely on; fail closed if an exec token follows.
-      return containsSubcommandToken(argv.slice(idx + 1), BUN_EXEC_SUBCOMMANDS)
-        ? { kind: "unsafe-exec" }
-        : { kind: "not-exec" };
+      return conservative(idx + 1);
     }
     if (token.startsWith("-")) {
-      idx += 1;
-      continue;
+      if (token.includes("=")) {
+        idx += 1;
+        continue;
+      }
+      const flag = normalizeOptionFlag(token);
+      if (BUN_OPTIONS_WITH_VALUE.has(flag)) {
+        idx += 2;
+        continue;
+      }
+      if (BUN_FLAG_OPTIONS.has(flag)) {
+        idx += 1;
+        continue;
+      }
+      return conservative(idx + 1);
     }
-    if (!BUN_EXEC_SUBCOMMANDS.has(token)) {
-      return { kind: "not-exec" };
-    }
-    const tail = argv.slice(idx + 1);
-    if (tail[0] === "--") {
-      return tail.length > 1 ? { kind: "unwrapped", argv: tail.slice(1) } : { kind: "unsafe-exec" };
-    }
-    // Tail parsing delegates to the shared bunx path so "bun x" and "bunx"
-    // accept and reject identical forms (unknown tail options fail closed).
-    const unwrapped = unwrapDirectPackageExecInvocation(["bunx", ...tail]);
-    return unwrapped ? { kind: "unwrapped", argv: unwrapped } : { kind: "unsafe-exec" };
+    selectedB = { token, idx };
+    break;
   }
-  return { kind: "not-exec" };
+
+  const xA = selectedA !== null && BUN_EXEC_SUBCOMMANDS.has(selectedA.token);
+  const xB = selectedB !== null && BUN_EXEC_SUBCOMMANDS.has(selectedB.token);
+  if (!xA && !xB) {
+    return { kind: "not-exec" };
+  }
+  if (!xA || !xB || selectedA === null || selectedB === null || selectedA.idx !== selectedB.idx) {
+    return { kind: "unsafe-exec" };
+  }
+  const tail = argv.slice(selectedA.idx + 1);
+  if (tail[0] === "--") {
+    return tail.length > 1 ? { kind: "unwrapped", argv: tail.slice(1) } : { kind: "unsafe-exec" };
+  }
+  // Tail parsing delegates to the shared bunx path so "bun x" and "bunx"
+  // accept and reject identical forms (unknown tail options fail closed).
+  const unwrapped = unwrapDirectPackageExecInvocation(["bunx", ...tail]);
+  return unwrapped ? { kind: "unwrapped", argv: unwrapped } : { kind: "unsafe-exec" };
 }
 
 function unwrapYarnDlxInvocation(argv: string[]): string[] | null {

--- a/src/infra/package-manager-exec-wrapper.ts
+++ b/src/infra/package-manager-exec-wrapper.ts
@@ -31,12 +31,6 @@ const NPM_EXEC_SUBCOMMANDS = new Set(["exec", "x"]);
 // invocations and "exec" is a shell-string carrier, so neither may unwrap.
 const BUN_EXEC_SUBCOMMANDS = new Set(["x"]);
 
-// "--cwd" unwraps like the npm/pnpm "-C" cwd options do: inner binding stays
-// on the delegated executable, matching the sibling wrapper cases' contract.
-const BUN_OPTIONS_WITH_VALUE = new Set(["--config", "--cwd", "--env-file", "-c"]);
-
-const BUN_FLAG_OPTIONS = new Set(["--bun", "--silent", "-b"]);
-
 export const PNPM_OPTIONS_WITH_VALUE = new Set([
   "--config",
   "--dir",
@@ -355,6 +349,10 @@ function unwrapNpmExecInvocation(argv: string[]): string[] | null {
   return unwrapDirectPackageExecInvocation(["npx", ...tail]);
 }
 
+// Mirrors Bun's root dispatch: the command selector skips dash-prefixed
+// tokens without consuming space-separated option values, so the first
+// non-dash token decides whether "x" (bunx) runs. A space-valued global like
+// "--cwd ./pkg" therefore makes "./pkg" the selected command, not "x".
 function resolveBunExecInvocation(argv: string[]): PackageManagerExecInvocation {
   let idx = 1;
   while (idx < argv.length) {
@@ -363,43 +361,28 @@ function resolveBunExecInvocation(argv: string[]): PackageManagerExecInvocation 
       idx += 1;
       continue;
     }
-    if (!token.startsWith("-")) {
-      if (!BUN_EXEC_SUBCOMMANDS.has(token)) {
-        return { kind: "not-exec" };
-      }
-      const tail = argv.slice(idx + 1);
-      if (tail[0] === "--") {
-        return tail.length > 1
-          ? { kind: "unwrapped", argv: tail.slice(1) }
-          : { kind: "unsafe-exec" };
-      }
-      // Tail parsing delegates to the shared bunx path so "bun x" and "bunx"
-      // accept and reject identical forms (unknown tail options fail closed).
-      const unwrapped = unwrapDirectPackageExecInvocation(["bunx", ...tail]);
-      return unwrapped ? { kind: "unwrapped", argv: unwrapped } : { kind: "unsafe-exec" };
+    if (token === "--") {
+      // Whether Bun's selector still picks a subcommand after "--" is not a
+      // contract we can rely on; fail closed if an exec token follows.
+      return containsSubcommandToken(argv.slice(idx + 1), BUN_EXEC_SUBCOMMANDS)
+        ? { kind: "unsafe-exec" }
+        : { kind: "not-exec" };
     }
-    const flag = normalizeOptionFlag(token);
-    if (BUN_OPTIONS_WITH_VALUE.has(flag)) {
-      if (token.includes("=")) {
-        idx += 1;
-        continue;
-      }
-      // Bun's root dispatch does not consume space-separated option values when
-      // locating the subcommand, so a value token of "x" may actually dispatch
-      // bunx. Fail closed instead of guessing either parse.
-      if (BUN_EXEC_SUBCOMMANDS.has(argv[idx + 1]?.trim() ?? "")) {
-        return { kind: "unsafe-exec" };
-      }
-      idx += 2;
-      continue;
-    }
-    if (BUN_FLAG_OPTIONS.has(flag)) {
+    if (token.startsWith("-")) {
       idx += 1;
       continue;
     }
-    return containsSubcommandToken(argv.slice(idx + 1), BUN_EXEC_SUBCOMMANDS)
-      ? { kind: "unsafe-exec" }
-      : { kind: "not-exec" };
+    if (!BUN_EXEC_SUBCOMMANDS.has(token)) {
+      return { kind: "not-exec" };
+    }
+    const tail = argv.slice(idx + 1);
+    if (tail[0] === "--") {
+      return tail.length > 1 ? { kind: "unwrapped", argv: tail.slice(1) } : { kind: "unsafe-exec" };
+    }
+    // Tail parsing delegates to the shared bunx path so "bun x" and "bunx"
+    // accept and reject identical forms (unknown tail options fail closed).
+    const unwrapped = unwrapDirectPackageExecInvocation(["bunx", ...tail]);
+    return unwrapped ? { kind: "unwrapped", argv: unwrapped } : { kind: "unsafe-exec" };
   }
   return { kind: "not-exec" };
 }

--- a/src/infra/package-manager-exec-wrapper.ts
+++ b/src/infra/package-manager-exec-wrapper.ts
@@ -353,7 +353,7 @@ function unwrapNpmExecInvocation(argv: string[]): string[] | null {
   return unwrapDirectPackageExecInvocation(["npx", ...tail]);
 }
 
-function unwrapBunExecInvocation(argv: string[]): string[] | null {
+function resolveBunExecInvocation(argv: string[]): PackageManagerExecInvocation {
   let idx = 1;
   while (idx < argv.length) {
     const token = argv[idx]?.trim() ?? "";
@@ -363,32 +363,43 @@ function unwrapBunExecInvocation(argv: string[]): string[] | null {
     }
     if (!token.startsWith("-")) {
       if (!BUN_EXEC_SUBCOMMANDS.has(token)) {
-        return null;
+        return { kind: "not-exec" };
       }
-      idx += 1;
-      break;
+      const tail = argv.slice(idx + 1);
+      if (tail[0] === "--") {
+        return tail.length > 1
+          ? { kind: "unwrapped", argv: tail.slice(1) }
+          : { kind: "unsafe-exec" };
+      }
+      // Tail parsing delegates to the shared bunx path so "bun x" and "bunx"
+      // accept and reject identical forms (unknown tail options fail closed).
+      const unwrapped = unwrapDirectPackageExecInvocation(["bunx", ...tail]);
+      return unwrapped ? { kind: "unwrapped", argv: unwrapped } : { kind: "unsafe-exec" };
     }
     const flag = normalizeOptionFlag(token);
     if (BUN_OPTIONS_WITH_VALUE.has(flag)) {
-      idx += token.includes("=") ? 1 : 2;
+      if (token.includes("=")) {
+        idx += 1;
+        continue;
+      }
+      // Bun's root dispatch does not consume space-separated option values when
+      // locating the subcommand, so a value token of "x" may actually dispatch
+      // bunx. Fail closed instead of guessing either parse.
+      if (BUN_EXEC_SUBCOMMANDS.has(argv[idx + 1]?.trim() ?? "")) {
+        return { kind: "unsafe-exec" };
+      }
+      idx += 2;
       continue;
     }
     if (BUN_FLAG_OPTIONS.has(flag)) {
       idx += 1;
       continue;
     }
-    return null;
+    return containsSubcommandToken(argv.slice(idx + 1), BUN_EXEC_SUBCOMMANDS)
+      ? { kind: "unsafe-exec" }
+      : { kind: "not-exec" };
   }
-  if (idx >= argv.length) {
-    return null;
-  }
-  const tail = argv.slice(idx);
-  if (tail[0] === "--") {
-    return tail.length > 1 ? tail.slice(1) : null;
-  }
-  // Tail parsing delegates to the shared bunx path so "bun x" and "bunx"
-  // accept and reject identical forms (unknown tail options fail closed).
-  return unwrapDirectPackageExecInvocation(["bunx", ...tail]);
+  return { kind: "not-exec" };
 }
 
 function unwrapYarnDlxInvocation(argv: string[]): string[] | null {
@@ -489,19 +500,7 @@ export function resolveKnownPackageManagerExecInvocation(
       return unwrapped ? { kind: "unwrapped", argv: unwrapped } : { kind: "unsafe-exec" };
     }
     case "bun": {
-      const unwrapped = unwrapBunExecInvocation(argv);
-      if (unwrapped) {
-        return { kind: "unwrapped", argv: unwrapped };
-      }
-      const firstSubcommand = firstSubcommandAfterOptions(argv, {
-        optionsWithValue: BUN_OPTIONS_WITH_VALUE,
-        flagOptions: BUN_FLAG_OPTIONS,
-      });
-      return BUN_EXEC_SUBCOMMANDS.has(firstSubcommand ?? "")
-        ? { kind: "unsafe-exec" }
-        : firstSubcommand === null && containsSubcommandToken(argv.slice(1), BUN_EXEC_SUBCOMMANDS)
-          ? { kind: "unsafe-exec" }
-          : { kind: "not-exec" };
+      return resolveBunExecInvocation(argv);
     }
     case "pnpm": {
       const unwrapped = unwrapPnpmExecInvocation(argv);

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -628,6 +628,14 @@ describe("hardenApprovedExecutionPaths", () => {
       expectedArgvIndex: 2,
     },
     {
+      name: "bun x tsx file",
+      argv: ["bun", "x", "tsx", "./run.ts"],
+      scriptName: "run.ts",
+      initialBody: 'console.log("SAFE");\n',
+      expectedArgvIndex: 3,
+      binNames: ["bun", "tsx"],
+    },
+    {
       name: "npm exec tsx file",
       argv: ["npm", "exec", "--", "tsx", "./run.ts"],
       scriptName: "run.ts",

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -24,6 +24,7 @@ import { readFileWindowFullySync } from "../infra/file-read.js";
 import { sameFileIdentity } from "../infra/fs-safe-advanced.js";
 import { parseInlineOptionToken } from "../infra/inline-option-token.js";
 import {
+  BUN_OPTIONS_WITH_VALUE,
   normalizePackageManagerExecToken,
   PNPM_CASE_SENSITIVE_OPTIONS_WITH_VALUE,
   PNPM_DLX_OPTIONS_WITH_VALUE,
@@ -86,38 +87,6 @@ const BUN_SUBCOMMANDS = new Set([
   "update",
   "upgrade",
   "x",
-]);
-
-const BUN_OPTIONS_WITH_VALUE = new Set([
-  "--backend",
-  "--bunfig",
-  "--conditions",
-  "--config",
-  "--console-depth",
-  "--cwd",
-  "--define",
-  "--elide-lines",
-  "--env-file",
-  "--extension-order",
-  "--filter",
-  "--hot",
-  "--inspect",
-  "--inspect-brk",
-  "--inspect-wait",
-  "--install",
-  "--jsx-factory",
-  "--jsx-fragment",
-  "--jsx-import-source",
-  "--loader",
-  "--origin",
-  "--port",
-  "--preload",
-  "--smol",
-  "--tsconfig-override",
-  "-c",
-  "-e",
-  "-p",
-  "-r",
 ]);
 
 const DENO_RUN_OPTIONS_WITH_VALUE = new Set([


### PR DESCRIPTION
Related: #102035

## What Problem This Solves

Resolves an inconsistency where exec approvals for `bun x <pkg>` bind to the
outer wrapper string while the equivalent `bunx <pkg>` binds to the inner
command. PR #102035 bound durable package-manager exec approvals to the inner
trust target for npm / npx / pnpm / yarn / bunx, but
`resolveKnownPackageManagerExecInvocation` has no `bun` case, so `bun x <pkg>`
falls through to `not-package-manager`.

Concretely, on current main:

- `bunx tsx ./run.ts` unwraps: allow-always persists against the inner `tsx`
  and later invocations match on `tsx`.
- The equivalent `bun x tsx ./run.ts` does not unwrap: allow-always cannot
  persist at all (`bun` is an interpreter-like executable, so the decision
  falls to one-shot), and a pre-existing outer `bun` allowlist entry matches
  the whole invocation without inner binding.

This is a consistency gap, not an approval bypass: the un-unwrapped form still
requires approval (the whole outer string is the trust target).

## Why This Change Was Made

Adds a `case "bun"` that unwraps only when the dispatched subcommand is
unambiguous. Two models exist for how a space-valued bun global (for example
`--cwd ./pkg`) interacts with subcommand selection: bun's root selector has
been observed to skip dash tokens without consuming their values, while this
repo's shipped script-operand hardening (`src/node-host/invoke-system-run-plan.ts`)
models bun as consuming a separate value for the known globals. The resolver
computes the selected command under both models and unwraps only when both
select the same `x` token — plain flags (`--silent`, `--bun`) and inline
values (`--cwd=./pkg`) qualify; the tail then unwraps through the shared bunx
parser (`unwrapDirectPackageExecInvocation`), with an explicit `--` separator
handled the way the npm `x` alias handles it, so `bun x` and `bunx` bind the
same inner trust targets for the forms both accept. Every form whose dispatch
depends on the model fails closed as `unsafe-exec` — a space-valued global
whose value is literally `x` (`bun -c x sh ...`), a space-valued global ahead
of `x` (`bun --cwd ./pkg x ...`), unknown globals ahead of a possible `x`,
bare `bun x`, shell-call tails (`-c` / `--call`), and `--` ahead of the
selector — so neither a wrong inner binding nor a stale outer-`bun` fallback
match is possible for those forms. The known-globals table is the shipped
node-host one, now exported from this module and imported by
invoke-system-run-plan so there is a single source.

This change is limited to `bun x`. Other bun invocations — `bun run
<script>`, `bun <file>`, and `bun exec` (a shell-string carrier rather than a
package runner) — keep their previous classification: for the affected
approval consumers they continue to fall back to ordinary outer-command
handling.

## User Impact

Approving `bun x <pkg>` with allow-always now persists and matches against the
inner command, the same as `bunx <pkg>`, npm, pnpm, and yarn exec forms.
Matching the treatment the other wrappers already received, a durable
allowlist entry for the outer `bun` binary no longer matches `bun x ...`
invocations whole; the inner command is the trust target.

## Evidence

Boundary capture driving the real resolver, authorization plan, and allowlist
matching (`node --import tsx`, real executables on a temp `PATH`, no mocks).

Before (base `9614129c2b`):

```
["bunx","tsx","./run.ts"] -> {"kind":"unwrapped","argv":["tsx","./run.ts"]}
["bun","x","tsx","./run.ts"] -> {"kind":"not-package-manager"}
["bun","-c","x","sh","-c","id > marker"] -> {"kind":"not-package-manager"}
["bun","--cwd","./pkg","x","tsx","./run.ts"] -> {"kind":"not-package-manager"}
"bunx tsx ./run.ts" -> allow-always persists {"pattern":".../tsx"}
"bun x tsx ./run.ts" -> {"kind":"one-shot","reasons":["no-reusable-pattern"]}
"bun x tsx ./run.ts" + inner tsx entry -> allowlistSatisfied=false
"bun x tsx ./run.ts" + outer bun entry -> allowlistSatisfied=true
"bun -c x sh -c 'id > marker'" + outer bun entry -> allowlistSatisfied=true
```

After (this PR):

```
["bun","x","tsx","./run.ts"] -> {"kind":"unwrapped","argv":["tsx","./run.ts"]}
["bun","run","build"] -> {"kind":"not-exec"}
["bun","-c","x","sh","-c","id > marker"] -> {"kind":"unsafe-exec"}
["bun","--cwd","./pkg","x","tsx","./run.ts"] -> {"kind":"unsafe-exec"}
"bun x tsx ./run.ts" -> allow-always persists {"pattern":".../tsx"}
"bun x sh -c 'id > marker'" -> {"kind":"one-shot","reasons":["no-reusable-pattern"]}
"bun x tsx ./run.ts" + inner tsx entry -> allowlistSatisfied=true
"bun x tsx ./run.ts" + outer bun entry -> allowlistSatisfied=false
"bun -c x sh -c 'id > marker'" + outer bun entry -> allowlistSatisfied=false
"bun --cwd ./pkg x tsx ./run.ts" + inner tsx entry -> allowlistSatisfied=false
```

Tests (all green locally via `node scripts/run-vitest.mjs`, 139 tests across
the touched shards):

- `src/infra/package-manager-exec-wrapper.test.ts` (new): bunx-parity unwrap,
  flag and inline-value and double-dash tails, non-exec forms (`bun run` /
  `bun ./x.ts` / `bun install` / `bun exec`), and model-dependent forms
  failing closed: each space-valued global (`-c` / `--config` / `--cwd` /
  `--env-file`) with `x` in value position and with `x` after a value token,
  unknown globals ahead of `x`, bare `bun x`, `--call` tails, and `--`.
- `src/infra/exec-allow-always-persistence.test.ts`: persists `bun x` approvals
  against the inner executable; keeps `bun x` shell carriers and
  space-valued-global forms one-shot (no durable pattern in either direction).
- `src/infra/exec-approvals-allow-always.test.ts`: rejects stale outer `bun`
  entries for `bun x` carriers and space-valued-global forms; matches
  inner-executable entries for `bun x` while refusing inner matching for
  `bun --cwd ./pkg x ...`, alongside the existing package-manager parity
  cases.
- `src/node-host/invoke-system-run-plan.test.ts`: `bun x tsx file` mutable
  operand fixture next to the existing `bunx tsx file` case.

`oxfmt --check` and the typecheck lanes pass on the touched files locally;
the remaining lint and check lanes run in CI.
