### PR TITLE
fix(embedded): refresh takeover fence after auto-compaction rewrite

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.test.ts
@@ -493,6 +493,61 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(controller.hasSessionTakeover()).toBe(false);
   });
 
+  // Threshold auto-compaction (Pi-internal) rewrites the transcript in BULK — dropping history
+  // for a summary — outside our per-message persistence + write-lock paths. That is neither an
+  // append nor a linear migration, so the fence rejects it as an external takeover. This is the
+  // failure that killed long runs; the two tests below pin the bug and its fix.
+  async function seedMultiLineSession(sessionFile: string): Promise<void> {
+    await fs.appendFile(
+      sessionFile,
+      '{"type":"message","id":"m1"}\n{"type":"message","id":"m2"}\n{"type":"message","id":"m3"}\n',
+      "utf8",
+    );
+  }
+  // A compaction-shaped rewrite: fewer lines, earlier history replaced by a summary line.
+  const COMPACTED_TRANSCRIPT =
+    '{"type":"session"}\n{"type":"message","id":"summary"}\n{"type":"message","id":"m3"}\n';
+
+  it("rejects a bulk compaction rewrite during a released prompt without a fence refresh", async () => {
+    const sessionFile = await createTempSessionFile();
+    await seedMultiLineSession(sessionFile);
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLock = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    // auto-compaction rewrites the transcript, but nothing tells the fence it was ours
+    await fs.writeFile(sessionFile, COMPACTED_TRANSCRIPT, "utf8");
+
+    await expect(controller.reacquireAfterPrompt()).rejects.toBeInstanceOf(
+      EmbeddedAttemptSessionTakeoverError,
+    );
+    expect(controller.hasSessionTakeover()).toBe(true);
+  });
+
+  it("trusts a bulk compaction rewrite after refreshAfterOwnedSessionWrite", async () => {
+    const sessionFile = await createTempSessionFile();
+    await seedMultiLineSession(sessionFile);
+    const release = vi.fn(async () => {});
+    const acquireSessionWriteLock = vi.fn(async () => ({ release }));
+    const controller = await createEmbeddedAttemptSessionLockController({
+      acquireSessionWriteLock,
+      lockOptions: { ...lockOptions, sessionFile },
+    });
+
+    await controller.releaseForPrompt();
+    await fs.writeFile(sessionFile, COMPACTED_TRANSCRIPT, "utf8");
+    // handleCompactionEnd -> onCompactionRewritePersisted -> refreshAfterOwnedSessionWrite
+    controller.refreshAfterOwnedSessionWrite();
+
+    await expect(controller.reacquireAfterPrompt()).resolves.toBeUndefined();
+    await expect(controller.withSessionWriteLock(() => "finalize")).resolves.toBe("finalize");
+    expect(controller.hasSessionTakeover()).toBe(false);
+  });
+
   it("allows post-prompt writes after the prompt context publishes an owned transcript write", async () => {
     const sessionFile = await createTempSessionFile();
     const releases: string[] = [];
@@ -833,7 +888,9 @@ describe("embedded attempt session lock lifecycle", () => {
     expect(releaseForPrompt).toHaveBeenCalledTimes(1);
     expect(reacquireAfterPrompt).toHaveBeenCalledTimes(1);
     expect(streamFn).toHaveBeenCalledWith("model", "context");
-    expect(events).toEqual(["drain", "release", "stream", "reacquire"]);
+    // Second drain before reacquire: a compaction_end queued during the stream must be
+    // processed (advancing the takeover fence) before the fence is re-checked on reacquire.
+    expect(events).toEqual(["drain", "release", "stream", "drain", "reacquire"]);
   });
 
   it("rewraps provider stream submission after the stream function is rebuilt", async () => {
@@ -880,17 +937,20 @@ describe("embedded attempt session lock lifecycle", () => {
 
     expect(firstStreamFn).toHaveBeenCalledTimes(1);
     expect(secondStreamFn).toHaveBeenCalledTimes(1);
-    expect(waitForSessionEvents).toHaveBeenCalledTimes(2);
+    // Two drains per stream (before release + before reacquire) across two invocations.
+    expect(waitForSessionEvents).toHaveBeenCalledTimes(4);
     expect(releaseForPrompt).toHaveBeenCalledTimes(2);
     expect(reacquireAfterPrompt).toHaveBeenCalledTimes(2);
     expect(events).toEqual([
       "drain",
       "release",
       "first-stream",
+      "drain",
       "reacquire",
       "drain",
       "release",
       "second-stream",
+      "drain",
       "reacquire",
     ]);
   });

--- a/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.session-lock.ts
@@ -916,6 +916,10 @@ export function installPromptSubmissionLockRelease(params: {
       }
       return await originalStreamFn(...args);
     } finally {
+      // Drain queued session events (e.g. a compaction_end that advances the takeover
+      // fence to the rewritten transcript) BEFORE reacquiring, so an auto-compaction that
+      // ran during this released-prompt window is recognized as ours, not an external edit.
+      await params.waitForSessionEvents(params.session);
       await params.reacquireAfterPrompt();
     }
   };

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -3476,6 +3476,11 @@ export async function runEmbeddedAttempt(
           onAssistantMessageStart: params.onAssistantMessageStart,
           onExecutionPhase: params.onExecutionPhase,
           onAgentEvent: params.onAgentEvent,
+          // Pi-internal auto-compaction rewrites the transcript outside our per-message
+          // persistence + write-lock paths, so advance the takeover fence to the rewritten
+          // file on compaction_end — mirrors onMessagePersisted above (attempt.ts:2342).
+          onCompactionRewritePersisted: () =>
+            sessionLockController.refreshAfterOwnedSessionWrite(),
           onHeartbeatToolResponse:
             params.trigger === "heartbeat"
               ? () => {

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -89,6 +89,10 @@ export function handleCompactionEnd(ctx: EmbeddedPiSubscribeContext, evt: Compac
   const hasResult = evt.result != null;
   const wasAborted = Boolean(evt.aborted);
   if (hasResult && !wasAborted) {
+    // Compaction has rewritten the session transcript on disk. Tell the embedded-attempt
+    // takeover fence this rewrite was ours, or the next lock reacquire mistakes the
+    // dropped-history rewrite for an external edit and throws (session-lock takeover).
+    ctx.params.onCompactionRewritePersisted?.();
     ctx.incrementCompactionCount();
     const tokensAfter =
       typeof evt.result === "object" && evt.result

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -57,6 +57,16 @@ export type SubscribeEmbeddedPiSessionParams = {
     data: Record<string, unknown>;
     sessionKey?: string;
   }) => void | Promise<void>;
+  /**
+   * Invoked after a threshold/overflow auto-compaction rewrites the session
+   * transcript. Pi-internal compaction rewrites the session file in bulk —
+   * bypassing both `onMessagePersisted` and `withSessionWriteLock` — so the
+   * embedded-attempt takeover fence never learns the rewrite was ours and
+   * throws `EmbeddedAttemptSessionTakeoverError` on the next lock reacquire.
+   * attempt.ts wires this to `refreshAfterOwnedSessionWrite()` so the fence is
+   * advanced to the post-compaction fingerprint. See attempt.session-lock.ts.
+   */
+  onCompactionRewritePersisted?: () => void;
   onHeartbeatToolResponse?: (response: HeartbeatToolResponse) => void | Promise<void>;
   terminalLifecyclePhase?: "end" | "finishing";
   /** Best-effort hook invoked immediately before the terminal lifecycle event is emitted. */


### PR DESCRIPTION
Threshold/overflow auto-compaction is Pi-internal: it rewrites the session transcript in bulk (drops history for a summary) outside OpenClaw's per-message persistence (`onMessagePersisted`) and `withSessionWriteLock` paths. So the embedded-attempt takeover fence (attempt.session-lock.ts) never learns the rewrite was ours — when the prompt lock was released for model I/O and compaction ran in that window, the next reacquire sees a non-append, non-linear-migration change and throws EmbeddedAttemptSessionTakeoverError, killing the run 100% of the time once compaction fires on a long session.

Fix: advance the fence from the compaction_end signal, reusing the exact primitive already used for owned per-message writes:
- add `onCompactionRewritePersisted` to SubscribeEmbeddedPiSessionParams
- attempt.ts wires it to `sessionLockController.refreshAfterOwnedSessionWrite()` (mirrors the onMessagePersisted wiring)
- handleCompactionEnd invokes it in the real-result branch, after Pi has rewritten the transcript on disk
- installPromptSubmissionLockRelease drains queued session events before the stream-wrapper reacquire, so a compaction that ran during the released-prompt window is refreshed before the fence is re-checked

Regression tests: a bulk compaction-shaped rewrite during a released prompt still throws WITHOUT the refresh (preserves genuine-takeover protection) and is trusted WITH refreshAfterOwnedSessionWrite.

<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

## Evidence

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->
