### PR TITLE
fix(crestodian): run approval-intent classifier on utilityModel

### DIFF
--- a/src/crestodian/approval-intent.test.ts
+++ b/src/crestodian/approval-intent.test.ts
@@ -68,6 +68,12 @@ describe("classifyCrestodianApprovalIntent", () => {
       ),
     ).resolves.toBe("approve");
     expect(deps.completeWithPreparedSimpleCompletionModel).toHaveBeenCalledOnce();
+    expect(deps.prepareSimpleCompletionModelForAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        useUtilityModel: true,
+        allowMissingApiKeyModes: ["aws-sdk"],
+      }),
+    );
   });
 
   it("fails closed to other on unexpected model output", async () => {

--- a/src/crestodian/approval-intent.ts
+++ b/src/crestodian/approval-intent.ts
@@ -96,11 +96,14 @@ export async function classifyCrestodianApprovalIntent(
       return "other";
     }
     const cfg = snapshot.runtimeConfig ?? snapshot.config;
+    // Same short utility tier as other simple-completion classifiers: ambiguous
+    // approve/decline answers are ~8 tokens and must not bill the flagship model.
     const prepared = await (
       deps.prepareSimpleCompletionModelForAgent ?? prepareSimpleCompletionModelForAgent
     )({
       cfg,
       agentId: resolveDefaultAgentId(cfg),
+      useUtilityModel: true,
       allowMissingApiKeyModes: ["aws-sdk"],
     });
     if ("error" in prepared) {


### PR DESCRIPTION
Closes #102360

## What Problem This Solves

Fixes an issue where users completing Crestodian interactive approval/config flows would bill the agent's flagship model for a fixed ~8-token approve/decline/other classification whenever the closed-list matcher could not resolve their reply.

## Why This Change Was Made

Pass the existing `useUtilityModel: true` flag into `prepareSimpleCompletionModelForAgent` for the Crestodian approval-intent classifier, matching the rest of the simple-completion classifier family (e.g. conversation label generation). No new config, no fallback stack, no docs/schema churn.

## User Impact

Ambiguous Crestodian approval replies that need a model judgment now run on the configured `utilityModel` (or the existing primary fallback when none is set), reducing cost for a bounded one-word classification.

## Evidence

Focused unit coverage:

- `node scripts/run-vitest.mjs src/crestodian/approval-intent.test.ts` → 7/7 passed
- `node scripts/run-vitest.mjs src/crestodian/ src/agents/simple-completion-runtime.selection.test.ts` → 12 files / 77 tests passed

`pnpm build` and `pnpm check` both passed on this branch. Autoreview (`branch` vs `origin/main`) reported no accepted/actionable findings.

## Real behavior proof

- Behavior addressed: Crestodian approval-intent model path must prepare the utility model tier, not the flagship primary, for ambiguous approval replies.
- Environment: local macOS checkout of openclaw/openclaw at branch `grok/crestodian-approval-utility-model` (`6840346063c2fced2f9446754ef65f3522776d05`); Node unit harness with injected prepare/complete deps (no live provider keys).
- Current-main contrast: On main, `classifyCrestodianApprovalIntent` calls `prepareSimpleCompletionModelForAgent` without `useUtilityModel`, so selection falls through to `resolveAgentEffectiveModelPrimary` (flagship). After this patch, prepare is invoked with `useUtilityModel: true`.
- Exact steps or command run after this patch:
  1. `node scripts/run-vitest.mjs src/crestodian/approval-intent.test.ts`
  2. Direct runtime probe of the patched classifier with mocks, asserting prepare args.
- Evidence after fix: ambiguous message `"alright, ship that change"` returns `approve`, and prepare args are:
  ```json
  {
    "agentId": "main",
    "useUtilityModel": true,
    "allowMissingApiKeyModes": ["aws-sdk"]
  }
  ```
  Focused test asserts the same `objectContaining({ useUtilityModel: true, ... })` call shape.
- Control check: closed-list `"yes"` still short-circuits with no model call (existing test `short-circuits closed-list answers without a model call`).
- Observed result after fix: model path selects utility tier; fail-closed `other` behavior for prepare/completion errors is unchanged.
- What was not tested: live Crestodian TUI/gateway turn with real provider billing logs; full-repo `pnpm test` suite (Crabbox/Testbox unavailable; crestodian directory tests run instead).

## AI disclosure

This fix was authored with AI assistance (Grok). Human review of the diff, verification commands, and PR text is still required before merge.
