### PR TITLE
fix(channel): bump wecom plugin pin to 2026.7.2 to fix concurrent-message session stuck (#102401)

### DIFF
--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -35,9 +35,9 @@
           }
         },
         "install": {
-          "npmSpec": "@wecom/wecom-openclaw-plugin@2026.5.7",
+          "npmSpec": "@wecom/wecom-openclaw-plugin@2026.7.2",
           "defaultChoice": "npm",
-          "expectedIntegrity": "sha512-TCkP9as00WfEhgFWG8YL/rcmaWGIshAki2HQh83nTRccGfVBCoGjrEboTTqq3yDmK9koWTV11zi8u8A4dNtvug=="
+          "expectedIntegrity": "sha512-7kqdBIOF3SgDDoBoFtO6jxnxofbYSgbKdxZDNabD0y0jg2xKcVqlXZOOJ9+XQho/QOtIFrnRH2IRnPukFEYwJg=="
         }
       }
     },

--- a/src/auto-reply/reply/commands-plugins.install.test.ts
+++ b/src/auto-reply/reply/commands-plugins.install.test.ts
@@ -344,12 +344,12 @@ describe("handleCommands /plugins install", () => {
       ok: true,
       pluginId: "wecom-openclaw-plugin",
       targetDir: "/tmp/wecom-openclaw-plugin",
-      version: "2026.5.7",
+      version: "2026.7.2",
       extensions: ["index.js"],
       npmResolution: {
         name: "@wecom/wecom-openclaw-plugin",
-        version: "2026.5.7",
-        resolvedSpec: "@wecom/wecom-openclaw-plugin@2026.5.7",
+        version: "2026.7.2",
+        resolvedSpec: "@wecom/wecom-openclaw-plugin@2026.7.2",
       },
     });
     persistPluginInstallMock.mockResolvedValue({});
@@ -362,15 +362,15 @@ describe("handleCommands /plugins install", () => {
 
       expect(result?.reply?.text).toContain('Installed plugin "wecom-openclaw-plugin"');
       expectObjectFields(mockFirstObjectArg(installPluginFromNpmSpecMock), {
-        spec: "@wecom/wecom-openclaw-plugin@2026.5.7",
+        spec: "@wecom/wecom-openclaw-plugin@2026.7.2",
         expectedPluginId: "wecom-openclaw-plugin",
         trustedSourceLinkedOfficialInstall: true,
       });
       expectPersistedInstall("wecom-openclaw-plugin", {
         source: "npm",
-        spec: "@wecom/wecom-openclaw-plugin@2026.5.7",
+        spec: "@wecom/wecom-openclaw-plugin@2026.7.2",
         installPath: "/tmp/wecom-openclaw-plugin",
-        version: "2026.5.7",
+        version: "2026.7.2",
       });
     });
   });
@@ -1048,12 +1048,12 @@ describe("handleCommands /plugins install", () => {
       ok: true,
       pluginId: "wecom-openclaw-plugin",
       targetDir: "/tmp/wecom-openclaw-plugin",
-      version: "2026.5.7",
+      version: "2026.7.2",
       extensions: ["index.js"],
       npmResolution: {
         name: "@wecom/wecom-openclaw-plugin",
-        version: "2026.5.7",
-        resolvedSpec: "@wecom/wecom-openclaw-plugin@2026.5.7",
+        version: "2026.7.2",
+        resolvedSpec: "@wecom/wecom-openclaw-plugin@2026.7.2",
       },
     });
     persistPluginInstallMock.mockResolvedValue({});
@@ -1079,9 +1079,9 @@ describe("handleCommands /plugins install", () => {
         source: "npm",
         spec: "@wecom/wecom-openclaw-plugin@latest",
         installPath: "/tmp/wecom-openclaw-plugin",
-        version: "2026.5.7",
+        version: "2026.7.2",
         resolvedName: "@wecom/wecom-openclaw-plugin",
-        resolvedVersion: "2026.5.7",
+        resolvedVersion: "2026.7.2",
       });
     });
   });

--- a/src/channels/plugins/catalog.test.ts
+++ b/src/channels/plugins/catalog.test.ts
@@ -27,7 +27,7 @@ describe("channel plugin catalog", () => {
     expect(wecom?.id).toBe("wecom");
     expect(wecom?.pluginId).toBe("wecom-openclaw-plugin");
     expect(wecom?.trustedSourceLinkedOfficialInstall).toBe(true);
-    expect(wecom?.install?.npmSpec).toBe("@wecom/wecom-openclaw-plugin@2026.5.7");
+    expect(wecom?.install?.npmSpec).toBe("@wecom/wecom-openclaw-plugin@2026.7.2");
 
     const yuanbao = getChannelPluginCatalogEntry("yuanbao", options);
     expect(yuanbao?.id).toBe("yuanbao");

--- a/src/channels/plugins/contracts/channel-catalog.contract.test.ts
+++ b/src/channels/plugins/contracts/channel-catalog.contract.test.ts
@@ -40,7 +40,7 @@ describeOfficialFallbackChannelCatalogContract({
 
 describeChannelCatalogEntryContract({
   channelId: "wecom",
-  npmSpec: "@wecom/wecom-openclaw-plugin@2026.5.7",
+  npmSpec: "@wecom/wecom-openclaw-plugin@2026.7.2",
   alias: "wework",
 });
 

--- a/src/cli/plugin-install-plan.test.ts
+++ b/src/cli/plugin-install-plan.test.ts
@@ -90,28 +90,28 @@ describe("plugin install plan helpers", () => {
 
     expect(result).toEqual({
       pluginId: "wecom-openclaw-plugin",
-      npmSpec: "@wecom/wecom-openclaw-plugin@2026.5.7",
+      npmSpec: "@wecom/wecom-openclaw-plugin@2026.7.2",
       expectedIntegrity:
-        "sha512-TCkP9as00WfEhgFWG8YL/rcmaWGIshAki2HQh83nTRccGfVBCoGjrEboTTqq3yDmK9koWTV11zi8u8A4dNtvug==",
+        "sha512-7kqdBIOF3SgDDoBoFtO6jxnxofbYSgbKdxZDNabD0y0jg2xKcVqlXZOOJ9+XQho/QOtIFrnRH2IRnPukFEYwJg==",
     });
   });
 
   it("skips official external plan for explicit npm selectors", () => {
     expect(resolveCatalogOfficialExternalInstallPlan("wecom-openclaw-plugin@beta")).toBeNull();
     expect(
-      resolveCatalogOfficialExternalInstallPlan("@wecom/wecom-openclaw-plugin@2026.5.7"),
+      resolveCatalogOfficialExternalInstallPlan("@wecom/wecom-openclaw-plugin@2026.7.2"),
     ).toBeNull();
   });
 
   it("trusts exact official external npm packages without remapping the spec", () => {
     const result = resolveCatalogOfficialExternalNpmPackageTrust(
-      "@wecom/wecom-openclaw-plugin@2026.5.7",
+      "@wecom/wecom-openclaw-plugin@2026.7.2",
     );
 
     expect(result).toEqual({
       pluginId: "wecom-openclaw-plugin",
       expectedIntegrity:
-        "sha512-TCkP9as00WfEhgFWG8YL/rcmaWGIshAki2HQh83nTRccGfVBCoGjrEboTTqq3yDmK9koWTV11zi8u8A4dNtvug==",
+        "sha512-7kqdBIOF3SgDDoBoFtO6jxnxofbYSgbKdxZDNabD0y0jg2xKcVqlXZOOJ9+XQho/QOtIFrnRH2IRnPukFEYwJg==",
       trustedSourceLinkedOfficialInstall: true,
     });
   });

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -1964,10 +1964,10 @@ describe("plugins cli install", () => {
 
     await runPluginsCommand(["plugins", "install", "wecom"]);
 
-    expect(npmInstallCall().spec).toBe("@wecom/wecom-openclaw-plugin@2026.5.7");
+    expect(npmInstallCall().spec).toBe("@wecom/wecom-openclaw-plugin@2026.7.2");
     expect(npmInstallCall().expectedPluginId).toBe("wecom-openclaw-plugin");
     expect(npmInstallCall().expectedIntegrity).toBe(
-      "sha512-TCkP9as00WfEhgFWG8YL/rcmaWGIshAki2HQh83nTRccGfVBCoGjrEboTTqq3yDmK9koWTV11zi8u8A4dNtvug==",
+      "sha512-7kqdBIOF3SgDDoBoFtO6jxnxofbYSgbKdxZDNabD0y0jg2xKcVqlXZOOJ9+XQho/QOtIFrnRH2IRnPukFEYwJg==",
     );
     expect(npmInstallCall().trustedSourceLinkedOfficialInstall).toBe(true);
   });
@@ -2003,15 +2003,15 @@ describe("plugins cli install", () => {
     installHooksFromNpmSpec.mockResolvedValue({
       ok: false,
       error:
-        "aborted: npm package integrity drift detected for @wecom/wecom-openclaw-plugin@2026.5.7",
+        "aborted: npm package integrity drift detected for @wecom/wecom-openclaw-plugin@2026.7.2",
     });
 
     await expect(runPluginsCommand(["plugins", "install", "wecom"])).rejects.toThrow("__exit__:1");
 
     expect(npmInstallCall().trustedSourceLinkedOfficialInstall).toBe(true);
-    expect(hookNpmInstallCall().spec).toBe("@wecom/wecom-openclaw-plugin@2026.5.7");
+    expect(hookNpmInstallCall().spec).toBe("@wecom/wecom-openclaw-plugin@2026.7.2");
     expect(hookNpmInstallCall().expectedIntegrity).toBe(
-      "sha512-TCkP9as00WfEhgFWG8YL/rcmaWGIshAki2HQh83nTRccGfVBCoGjrEboTTqq3yDmK9koWTV11zi8u8A4dNtvug==",
+      "sha512-7kqdBIOF3SgDDoBoFtO6jxnxofbYSgbKdxZDNabD0y0jg2xKcVqlXZOOJ9+XQho/QOtIFrnRH2IRnPukFEYwJg==",
     );
   });
 

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -2293,7 +2293,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       successfulInstall({
         pluginId: "wecom",
         npmSpec: "@wecom/wecom-openclaw-plugin",
-        version: "2026.4.23",
+        version: "2026.7.2",
         resolution: {
           integrity: "sha512-third-party",
         },
@@ -2305,7 +2305,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         pluginId: "wecom",
         meta: { label: "WeCom" },
         install: {
-          npmSpec: "@wecom/wecom-openclaw-plugin@2026.4.23",
+          npmSpec: "@wecom/wecom-openclaw-plugin@2026.7.2",
         },
       },
     ]);
@@ -2322,12 +2322,12 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     expect(mocks.installPluginFromClawHub).not.toHaveBeenCalled();
     const installArg = mockCallArg(mocks.installPluginFromNpmSpec);
     expectRecordFields(installArg, {
-      spec: "@wecom/wecom-openclaw-plugin@2026.4.23",
+      spec: "@wecom/wecom-openclaw-plugin@2026.7.2",
       expectedPluginId: "wecom",
     });
     expect(installArg).not.toHaveProperty("trustedSourceLinkedOfficialInstall", true);
     expect(result.changes).toEqual([
-      'Installed missing configured plugin "wecom" from @wecom/wecom-openclaw-plugin@2026.4.23.',
+      'Installed missing configured plugin "wecom" from @wecom/wecom-openclaw-plugin@2026.7.2.',
     ]);
   });
 

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -1904,7 +1904,7 @@ describe("official external plugin catalog", () => {
     expect(resolveOfficialExternalPluginId(wecomByChannel)).toBe("wecom-openclaw-plugin");
     expect(resolveOfficialExternalPluginId(wecomByPlugin)).toBe("wecom-openclaw-plugin");
     expect(resolveOfficialExternalPluginInstall(wecomByChannel)?.npmSpec).toBe(
-      "@wecom/wecom-openclaw-plugin@2026.5.7",
+      "@wecom/wecom-openclaw-plugin@2026.7.2",
     );
     expect(resolveOfficialExternalPluginId(yuanbaoByChannel)).toBe("openclaw-plugin-yuanbao");
     expect(resolveOfficialExternalPluginInstall(yuanbaoByChannel)?.npmSpec).toBe(

--- a/test/official-channel-catalog.test.ts
+++ b/test/official-channel-catalog.test.ts
@@ -141,10 +141,10 @@ describe("buildOfficialChannelCatalog", () => {
         aliases: ["qywx", "wework", "enterprise-wechat"],
       },
       install: {
-        npmSpec: "@wecom/wecom-openclaw-plugin@2026.5.7",
+        npmSpec: "@wecom/wecom-openclaw-plugin@2026.7.2",
         defaultChoice: "npm",
         expectedIntegrity:
-          "sha512-TCkP9as00WfEhgFWG8YL/rcmaWGIshAki2HQh83nTRccGfVBCoGjrEboTTqq3yDmK9koWTV11zi8u8A4dNtvug==",
+          "sha512-7kqdBIOF3SgDDoBoFtO6jxnxofbYSgbKdxZDNabD0y0jg2xKcVqlXZOOJ9+XQho/QOtIFrnRH2IRnPukFEYwJg==",
       },
     });
     expect(


### PR DESCRIPTION
Closes #102401

## Summary

WeCom channel users sending multiple consecutive messages while one instruction is still processing caused permanent session stalls requiring restart. This PR bumps the official WeCom plugin catalog pin from `2026.5.7` to `2026.7.2` to pick up the upstream per-chat serialization fix.
- Problem: WeCom `2026.5.7` removed per-chat `enqueueWeComChatTask` serialization, causing concurrent same-chat messages to bypass `ForegroundReplyFence` and leave earlier replies stuck at `finish=false`
- Solution: Update catalog pin to `2026.7.2` which restores `enqueueWeComChatTask(accountId:chatId)` per-chat queueing
- What changed: `scripts/lib/official-external-channel-catalog.json` (npmSpec + integrity hash), plus 8 test files aligning version and integrity assertions with the new catalog entry
- What did NOT change: OpenClaw core queueing, session management, or any non-WeCom channel behavior

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- Fixes #102401
- Related #94678 (closed, same root cause: concurrent WeCom deliveries stuck at finish=false)
- Related #95758 (closed, same root cause: stalled embedded runs from concurrent WeCom dispatches)
- Related #95533 (partial overlap: WeCom dual-stream text+file deadlock)
- [x] This PR fixes a bug or regression

## Motivation

The pinned version `2026.5.7` has a critical concurrency regression: `monitor.js` commented out `enqueueWeComChatTask` and used direct `await processWeComMessageNow(entry)`. When two same-chat messages arrive concurrently, they bypass the per-session reply guard, triggering `ForegroundReplyFence` suppression that leaves the earlier reply stream at `finish=false` and permanently blocks the session. The upstream fix in `2026.7.2` restores per-chat serialization via `enqueueWeComChatTask(accountId:chatId)`. No OpenClaw core changes are needed — the fix boundary is the external plugin catalog.

## Real behavior proof

- Behavior addressed: Concurrent same-chat WeCom messages no longer cause session stalls; messages are serialized per chat and each reply completes normally
- Real environment tested: Linux, Node 24, branch `fix/wecom-plugin-pin-102401` rebased onto main `138675aeeb`
- Exact steps or command run after this patch:
node scripts/run-vitest.mjs src/cli/plugin-install-plan.test.ts node scripts/run-vitest.mjs src/cli/plugins-cli.install.test.ts node scripts/run-vitest.mjs src/channels/plugins/catalog.test.ts node scripts/run-vitest.mjs src/channels/plugins/contracts/channel-catalog.contract.test.ts node scripts/run-vitest.mjs src/plugins/official-external-plugin-catalog.test.ts node scripts/run-vitest.mjs test/official-channel-catalog.test.ts node scripts/run-vitest.mjs src/auto-reply/reply/commands-plugins.install.test.ts node scripts/run-vitest.mjs src/commands/doctor/shared/missing-configured-plugin-install.test.ts


- Evidence after fix:

```console
$ npm view @wecom/wecom-openclaw-plugin@2026.7.2 dist.integrity
sha512-7kqdBIOF3SgDDoBoFtO6jxnxofbYSgbKdxZDNabD0y0jg2xKcVqlXZOOJ9+XQho/QOtIFrnRH2IRnPukFEYwJg==
Package diff (upstream fix in monitor.js):

--- 2026.5.7  monitor.js  838-848
+++ 2026.7.2  monitor.js  846-856
-                // Queue logic temporarily disabled, process directly
-                // const { status } = enqueueWeComChatTask({...});
-                await processWeComMessageNow(entry);
+                // Serialize per accountId:chatId to ensure sequential processing,
+                // preventing concurrent ForegroundReplyFence suppression.
+                const { status } = enqueueWeComChatTask({
+                    accountId: entry.account.accountId,
+                    chatId: entry.chatId,
+                    task: () => processWeComMessageNow(entry),
+                });
+                if (status === "queued") {
+                    runtime.log?.(`[wecom] Chat task queued for chat=${entry.chatId}`);
+                }
Observed result after fix:
All 8 test files with WeCom catalog references now assert @wecom/wecom-openclaw-plugin@2026.7.2 and the new integrity hash
No remaining references to 2026.5.7 or the old integrity hash in any test file
Catalog generation produces the correct npmSpec and integrity values
What was not tested: Live WeCom bot concurrent-message proof (requires a real WeCom enterprise environment with bot mode). Test coverage validates catalog wiring and integrity enforcement only.
Root Cause
WeCom plugin 2026.5.7 removed per-chat serialization (enqueueWeComChatTask) in monitor.js, dispatching messages directly via await processWeComMessageNow(entry). This caused concurrent same-chat messages to enter OpenClaw without serialization, triggering ForegroundReplyFence suppression and leaving earlier streaming replies stuck at finish=false — a permanent session stall until restart.

The regression was introduced during the 2026.5.x release cycle (catalog bump from 2026.4.23 to 2026.5.7 in commit f2cbe9ecc5 by @brokemac79). The 2026.7.2 upstream release restores the per-chat queue.

Regression Test Plan
Existing catalog and installer contract tests cover:

Official external catalog resolution (resolveCatalogOfficialExternalInstallPlan)
Integrity enforcement on npm install (expectedIntegrity validation)
Hook-pack fallback integrity drift detection
Doctor missing-plugin install flow
Channel catalog entry contract validation
No new test logic needed — all existing tests are updated to assert against the new catalog pin.

User-visible / Behavior Changes
WeCom users no longer experience stuck sessions when sending rapid consecutive messages in the same chat. Each message queues per accountId:chatId and processes sequentially. Managed npm installs auto-update on next openclaw plugins install or openclaw doctor run.

Security Impact
 New permissions/capabilities? No
 Secrets/tokens handling changed? No
 New/changed network calls? No
 Command/tool execution surface changed? No
 Data access scope changed? No
Human Verification
Verified scenarios: All 8 test files asserting WeCom catalog npmSpec and integrity hash updated and consistent with official-external-channel-catalog.json
Edge cases checked: plugin-install-plan.test.ts boundary cases (explicit npm selectors, catalog trust resolution) updated alongside the main catalog assertions
What you did NOT verify: Live WeCom bot concurrent-message runtime behavior (requires enterprise WeCom environment)
Compatibility / Migration
 Backward compatible? Yes — existing managed WeCom installs receive the updated plugin on next install/doctor cycle
 Config/env changes? No — catalog pin update only
 Migration needed? No
Best-fix Verdict
Is this change the best way to solve the problem?

Best fix: Yes — the per-chat serialization logic belongs in the external WeCom plugin (owner boundary), not in OpenClaw core. Catalog pin update is the correct fix layer per AGENTS.md: "owner-specific repair/detection/onboarding/auth/defaults/provider behavior lives in owner plugin"
Refactor needed: No
Alternative considered: Adding core-level session serialization for WeCom — rejected because it violates the owner boundary principle and would create a core-to-plugin coupling for one channel's internal dispatch logic
AI Assistance
AI-assisted: Yes
AI model: glm-5.1
Human confirmed understanding of code changes: Yes
AI prompts / session excerpts: Full analysis of historical PR #102434 diff, ClawSweeper review, root-cause cluster (#102401, #94678, #95758, #95533), catalog version chain (2026.4.23 → 2026.5.7 → 2026.7.2), and exhaustive grep of all WeCom version references across 9 test files
Risks and Mitigations
Highest-risk area: Managed WeCom installs receiving a new third-party channel runtime. If 2026.7.2 has unexpected behavioral changes beyond the stated serialization fix, existing WeCom sessions could be affected.
Mitigation: Integrity hash pinning (sha512-7kqdBIOF3Sg...) ensures the exact reviewed tarball is installed — no tampering or silent version drift. The catalog pin update is the standard, low-risk mechanism used for all previous WeCom bumps (2026.4.23 → 2026.5.7 in commit f2cbe9ecc5).
Compatibility impact: Fully backward compatible. No config, env, or migration changes. Existing sessions continue; new installs get the fixed plugin.
