### PR TITLE
fix(scripts): report startup help stream errors when pipes fail

### DIFF
--- a/scripts/write-cli-startup-metadata.ts
+++ b/scripts/write-cli-startup-metadata.ts
@@ -382,14 +382,16 @@ async function spawnText(
     failureMessage: string;
     killGraceMs?: number;
     maxOutputBytes?: number;
+    spawnProcess?: typeof spawn;
     timeoutMs: number;
   },
 ): Promise<string> {
   const maxOutputBytes = options.maxOutputBytes ?? COMMAND_HELP_RENDER_MAX_OUTPUT_BYTES;
   const killGraceMs = options.killGraceMs ?? COMMAND_HELP_RENDER_KILL_GRACE_MS;
+  const spawnProcess = options.spawnProcess ?? spawn;
   const useProcessGroup = process.platform !== "win32";
   return await new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, args, {
+    const child = spawnProcess(process.execPath, args, {
       cwd: options.cwd,
       detached: useProcessGroup,
       env: options.env,
@@ -399,6 +401,7 @@ async function spawnText(
     let stderr = "";
     let outputBytes = 0;
     let outputExceeded = false;
+    let outputStreamError: { streamName: "stdout" | "stderr"; error: Error } | undefined;
     let settled = false;
     let timedOut = false;
     let waitingForKillGrace = false;
@@ -483,6 +486,14 @@ async function spawnText(
     };
     const finishClose = (result: { code: number | null; signal: NodeJS.Signals | null }) => {
       settle(() => {
+        if (outputStreamError) {
+          reject(
+            new Error(
+              `${options.failureMessage}: ${outputStreamError.streamName} read error: ${outputStreamError.error.message}`,
+            ),
+          );
+          return;
+        }
         if (result.code === 0 && !timedOut && !outputExceeded) {
           resolve(stdout);
           return;
@@ -522,6 +533,13 @@ async function spawnText(
       signalChild("SIGTERM");
       scheduleKill();
     };
+    const failOutputStream = (streamName: "stdout" | "stderr", error: Error) => {
+      if (outputStreamError) {
+        return;
+      }
+      outputStreamError = { streamName, error };
+      requestStop();
+    };
     const timeout = setTimeout(() => {
       timedOut = true;
       requestStop();
@@ -552,6 +570,12 @@ async function spawnText(
         return;
       }
       stderr += chunk;
+    });
+    child.stdout.once("error", (error: Error) => {
+      failOutputStream("stdout", error);
+    });
+    child.stderr.once("error", (error: Error) => {
+      failOutputStream("stderr", error);
     });
     child.once("error", (error) => {
       settle(() => {

--- a/scripts/write-cli-startup-metadata.ts
+++ b/scripts/write-cli-startup-metadata.ts
@@ -490,6 +490,7 @@ async function spawnText(
           reject(
             new Error(
               `${options.failureMessage}: ${outputStreamError.streamName} read error: ${outputStreamError.error.message}`,
+              { cause: outputStreamError.error },
             ),
           );
           return;
@@ -534,7 +535,9 @@ async function spawnText(
       scheduleKill();
     };
     const failOutputStream = (streamName: "stdout" | "stderr", error: Error) => {
-      if (outputStreamError) {
+      // Keep the first stop cause: killing for a timeout or output cap can make
+      // the stdio pipes fail secondarily while the child is shutting down.
+      if (outputStreamError || timedOut || outputExceeded) {
         return;
       }
       outputStreamError = { streamName, error };

--- a/test/scripts/write-cli-startup-metadata.test.ts
+++ b/test/scripts/write-cli-startup-metadata.test.ts
@@ -1,7 +1,9 @@
 // Write Cli Startup Metadata tests cover write cli startup metadata script behavior.
 import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { PassThrough } from "node:stream";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { resolveWindowsTaskkillPath } from "../../scripts/lib/windows-taskkill.mjs";
@@ -70,6 +72,14 @@ function expectedTaskkillPath(): string {
   return resolveWindowsTaskkillPath();
 }
 
+function createSpawnTextChild() {
+  return Object.assign(new EventEmitter(), {
+    kill: vi.fn(() => true),
+    stderr: new PassThrough(),
+    stdout: new PassThrough(),
+  });
+}
+
 async function waitForProcessExit(
   pid: number,
   timeoutMs = LOAD_SENSITIVE_PROCESS_TIMEOUT_MS,
@@ -134,6 +144,32 @@ describe("write-cli-startup-metadata", () => {
       }),
     ).rejects.toThrow("render failed: output exceeded 1024 bytes");
   });
+
+  it.each(["stdout", "stderr"] as const)(
+    "fails command help rendering when %s emits a stream error",
+    async (streamName) => {
+      const child = createSpawnTextChild();
+      const spawnProcess = vi.fn(() => child as unknown as ReturnType<typeof spawn>);
+
+      const render = __testing.spawnText(["--help"], {
+        cwd: process.cwd(),
+        env: process.env,
+        failureMessage: "render failed",
+        killGraceMs: 25,
+        maxOutputBytes: 1024,
+        spawnProcess,
+        timeoutMs: 5_000,
+      });
+
+      child[streamName].emit("error", new Error(`${streamName} pipe failed`));
+      child.emit("close", null, "SIGTERM");
+
+      await expect(render).rejects.toThrow(
+        `render failed: ${streamName} read error: ${streamName} pipe failed`,
+      );
+      expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    },
+  );
 
   it("signals Windows command help render process trees with taskkill", () => {
     const childKill = vi.fn(() => true);

--- a/test/scripts/write-cli-startup-metadata.test.ts
+++ b/test/scripts/write-cli-startup-metadata.test.ts
@@ -150,6 +150,7 @@ describe("write-cli-startup-metadata", () => {
     async (streamName) => {
       const child = createSpawnTextChild();
       const spawnProcess = vi.fn(() => child as unknown as ReturnType<typeof spawn>);
+      const streamError = new Error(`${streamName} pipe failed`);
 
       const render = __testing.spawnText(["--help"], {
         cwd: process.cwd(),
@@ -161,15 +162,36 @@ describe("write-cli-startup-metadata", () => {
         timeoutMs: 5_000,
       });
 
-      child[streamName].emit("error", new Error(`${streamName} pipe failed`));
+      child[streamName].emit("error", streamError);
       child.emit("close", null, "SIGTERM");
 
-      await expect(render).rejects.toThrow(
-        `render failed: ${streamName} read error: ${streamName} pipe failed`,
-      );
+      await expect(render).rejects.toMatchObject({
+        message: `render failed: ${streamName} read error: ${streamName} pipe failed`,
+        cause: streamError,
+      });
       expect(child.kill).toHaveBeenCalledWith("SIGTERM");
     },
   );
+
+  it("preserves an output-limit failure when shutdown also errors a stream", async () => {
+    const child = createSpawnTextChild();
+    const spawnProcess = vi.fn(() => child as unknown as ReturnType<typeof spawn>);
+    const render = __testing.spawnText(["--help"], {
+      cwd: process.cwd(),
+      env: process.env,
+      failureMessage: "render failed",
+      killGraceMs: 25,
+      maxOutputBytes: 5,
+      spawnProcess,
+      timeoutMs: 5_000,
+    });
+
+    child.stdout.emit("data", "123456");
+    child.stdout.emit("error", new Error("pipe closed during shutdown"));
+    child.emit("close", null, "SIGTERM");
+
+    await expect(render).rejects.toThrow("render failed: output exceeded 5 bytes");
+  });
 
   it("signals Windows command help render process trees with taskkill", () => {
     const childKill = vi.fn(() => true);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers generating CLI startup metadata could lose a clear command-help rendering failure when the spawned help process stdout or stderr pipe emits a read error.

## Why This Change Was Made

`spawnText` now treats stdout and stderr read errors as first-class render errors, routes them through the existing child stop path, and reports the affected stream once the child closes. The change stays inside the startup metadata helper and covers both sibling output streams without changing CLI metadata shape or command selection.

## User Impact

Developers and release automation get an actionable startup metadata generation error instead of an unhandled pipe error or ambiguous child-process termination.

## Evidence

- Claim proved: `spawnText` handles both stdout and stderr stream errors while preserving the existing command output cap and timeout coverage.
- Current-head focused proof at `9d2eab8fed0e8b7521345272003bcd38405b54da`: `node scripts/run-vitest.mjs test/scripts/write-cli-startup-metadata.test.ts` passed.
- Current-head real behavior proof at `9d2eab8fed0e8b7521345272003bcd38405b54da`: `node --import tsx <runtime proof script>` imported `scripts/write-cli-startup-metadata.ts`, called `__testing.spawnText`, used real `node:child_process.spawn`, and triggered real child stdout/stderr pipe read errors from the parent process.

```text
stdout: runtime stdout render failed: stdout read error: stdout pipe failed from runtime proof
stderr: runtime stderr render failed: stderr read error: stderr pipe failed from runtime proof
```

- Committed diff hygiene: `git diff --check HEAD~1..HEAD` passed.
- Review proof: `python .agents/skills/autoreview/scripts/autoreview --mode local` passed with no accepted/actionable findings.
- Observed result: the runtime proof shows both real output streams are routed through the changed helper and return stream-specific render failures instead of escaping as unowned pipe errors.