### PR TITLE
fix(tool-payload): reject oversized XML payloads when text is multibyte

### DIFF
--- a/packages/tool-call-repair/src/payload.ts
+++ b/packages/tool-call-repair/src/payload.ts
@@ -34,6 +34,7 @@ export type PlainTextToolCallParseOptions = {
 };
 
 const DEFAULT_MAX_PLAIN_TEXT_TOOL_PAYLOAD_BYTES = 256_000;
+const utf8Encoder = new TextEncoder();
 
 type PlainTextToolCallOpening = {
   allowsOptionalXmlishClose?: boolean;
@@ -221,6 +222,15 @@ type XmlishParameterBlockBounds = {
   start: number;
 };
 
+function utf8ByteLengthExceeds(
+  text: string,
+  start: number,
+  end: number,
+  maxBytes: number,
+): boolean {
+  return end - start > maxBytes || utf8Encoder.encode(text.slice(start, end)).byteLength > maxBytes;
+}
+
 function findXmlishParameterBlock(text: string, start: number): XmlishParameterBlockBounds | null {
   const cursor = skipWhitespace(text, start);
   const openMatch = /^<parameter=([A-Za-z0-9_.:-]{1,120})>/i.exec(text.slice(cursor));
@@ -252,7 +262,7 @@ function consumeXmlishParameterBlock(
   if (!bounds) {
     return null;
   }
-  if (bounds.end - bounds.start > maxPayloadBytes) {
+  if (utf8ByteLengthExceeds(text, bounds.start, bounds.end, maxPayloadBytes)) {
     return null;
   }
   return {
@@ -344,7 +354,7 @@ function parseXmlishPlainTextToolCallBlockAt(
     if (!parameter) {
       break;
     }
-    if (parameter.end - opening.end > maxPayloadBytes) {
+    if (utf8ByteLengthExceeds(text, opening.end, parameter.end, maxPayloadBytes)) {
       return null;
     }
     args[parameter.name] = parameter.value;

--- a/src/plugin-sdk/tool-payload.test.ts
+++ b/src/plugin-sdk/tool-payload.test.ts
@@ -242,6 +242,20 @@ describe("parseStandalonePlainTextToolCallBlocks", () => {
     ).toBeNull();
   });
 
+  it("counts serialized XML parameter payload limits in UTF-8 bytes", () => {
+    const parameter = ["<parameter=content>", "é".repeat(20), "</parameter>"].join("\n");
+    const raw = ["<function=write>", parameter, "</function>"].join("\n");
+    expect(parameter.length).toBeLessThan(64);
+    expect(new TextEncoder().encode(parameter).byteLength).toBeGreaterThan(64);
+
+    expect(
+      parseStandalonePlainTextToolCallBlocks(raw, {
+        allowedToolNames: ["write"],
+        maxPayloadBytes: 64,
+      }),
+    ).toBeNull();
+  });
+
   it("respects allowed tool names for Harmony calls", () => {
     const blocks = parseStandalonePlainTextToolCallBlocks(
       'commentary to=write code {"path":"/tmp/file.txt","content":"x"}',


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where plugin/tool-payload callers parsing XML-ish plain-text tool calls could accept serialized parameter blocks that exceeded `maxPayloadBytes` when the payload used multibyte text.

## Why This Change Was Made

The XML-ish parser now measures parameter blocks and cumulative function payloads using UTF-8 byte length, matching the byte-oriented `maxPayloadBytes` contract. The helper keeps the existing fast code-unit rejection path for blocks that are already larger than the limit, and only encodes bounded slices when multibyte text needs byte-accurate accounting.

## User Impact

Oversized model-emitted XML-ish tool-call payloads are rejected consistently for ASCII and multibyte text, so plugin SDK callers do not accept payloads that exceed their configured byte cap.

## Evidence

- Claim proved: XML-ish plain-text tool-call parsing rejects multibyte parameter payloads whose UTF-8 byte length exceeds `maxPayloadBytes` while preserving existing XML payload parsing behavior.
- Current-head proof at `0db0f2b3fbbe5319a3a314e5aae1467be706865c`: `node scripts/run-vitest.mjs src/plugin-sdk/tool-payload.test.ts` passed, with 1 test file and 23 tests passing.
- Committed diff hygiene: `git diff --check HEAD~1..HEAD` passed.
- Review proof: `python .agents\skills\autoreview\scripts\autoreview --mode local` reported no accepted/actionable findings for the final diff.
- Observed result: the regression case with `"é".repeat(20)` has a string length below 64 but a UTF-8 byte length above 64, and `parseStandalonePlainTextToolCallBlocks(..., { maxPayloadBytes: 64 })` returns `null`.