### PR TITLE
fix: auth bookkeeping no longer reverts rotated OpenAI OAuth credentials

### DIFF
--- a/src/agents/auth-profiles/oauth-manager.test.ts
+++ b/src/agents/auth-profiles/oauth-manager.test.ts
@@ -561,6 +561,153 @@ describe("createOAuthManager", () => {
     });
   });
 
+  it("force-persists a refreshed credential after a same-identity CAS race", async () => {
+    await withOAuthTempRoot("oauth-manager-cas-same-identity-", async (tempRoot) => {
+      const agentDir = path.join(tempRoot, "agents", "main", "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      const profileId = "openai:oauth";
+      const expired = createCredential({
+        access: "expired-access",
+        refresh: "expired-refresh",
+        expires: Date.now() - 60_000,
+        accountId: "acct-123",
+      });
+      saveAuthProfileStore(
+        {
+          version: 1,
+          profiles: {
+            [profileId]: expired,
+          },
+        },
+        agentDir,
+        { filterExternalAuthProfiles: false },
+      );
+
+      const manager = createOAuthManager({
+        buildApiKey: async (_provider, credential) => credential.access,
+        refreshCredential: vi.fn(async () => {
+          saveAuthProfileStore(
+            {
+              version: 1,
+              profiles: {
+                [profileId]: createCredential({
+                  access: "stale-race-access",
+                  refresh: "consumed-race-refresh",
+                  expires: Date.now() + 10 * 60_000,
+                  accountId: "acct-123",
+                }),
+              },
+            },
+            agentDir,
+            { filterExternalAuthProfiles: false },
+          );
+          return {
+            access: "rotated-access",
+            refresh: "rotated-refresh",
+            expires: Date.now() + 60_000,
+          };
+        }),
+        readBootstrapCredential: () => null,
+        isRefreshTokenReusedError: () => false,
+      });
+
+      const result = await manager.resolveOAuthAccess({
+        store: ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+          allowKeychainPrompt: false,
+        }),
+        profileId,
+        credential: expired,
+        agentDir,
+      });
+
+      expect(result?.apiKey).toBe("rotated-access");
+      const persisted = ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+        allowKeychainPrompt: false,
+      });
+      expect(persisted.profiles[profileId]).toMatchObject({
+        type: "oauth",
+        access: "rotated-access",
+        refresh: "rotated-refresh",
+        accountId: "acct-123",
+      });
+    });
+  });
+
+  it("uses a different-identity stored credential after a CAS race", async () => {
+    await withOAuthTempRoot("oauth-manager-cas-different-identity-", async (tempRoot) => {
+      const mainAgentDir = path.join(tempRoot, "agents", "main", "agent");
+      const agentDir = path.join(tempRoot, "agents", "sub", "agent");
+      await fs.mkdir(mainAgentDir, { recursive: true });
+      await fs.mkdir(agentDir, { recursive: true });
+      const profileId = "openai:oauth";
+      const expired = createCredential({
+        access: "expired-access",
+        refresh: "expired-refresh",
+        expires: Date.now() - 60_000,
+        accountId: "acct-123",
+      });
+      const relogged = createCredential({
+        access: "relogged-access",
+        refresh: "relogged-refresh",
+        expires: Date.now() + 10 * 60_000,
+        accountId: "acct-456",
+      });
+      saveAuthProfileStore(
+        {
+          version: 1,
+          profiles: {
+            [profileId]: expired,
+          },
+        },
+        agentDir,
+        { filterExternalAuthProfiles: false },
+      );
+
+      const manager = createOAuthManager({
+        buildApiKey: async (_provider, credential) => credential.access,
+        refreshCredential: vi.fn(async () => {
+          saveAuthProfileStore(
+            {
+              version: 1,
+              profiles: {
+                [profileId]: relogged,
+              },
+            },
+            agentDir,
+            { filterExternalAuthProfiles: false },
+          );
+          return {
+            access: "rotated-access",
+            refresh: "rotated-refresh",
+            expires: Date.now() + 60_000,
+          };
+        }),
+        readBootstrapCredential: () => null,
+        isRefreshTokenReusedError: () => false,
+      });
+
+      const result = await manager.resolveOAuthAccess({
+        store: ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+          allowKeychainPrompt: false,
+        }),
+        profileId,
+        credential: expired,
+        agentDir,
+      });
+
+      expect(result?.apiKey).toBe("relogged-access");
+      const persisted = ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+        allowKeychainPrompt: false,
+      });
+      expect(persisted.profiles[profileId]).toMatchObject({
+        type: "oauth",
+        access: "relogged-access",
+        refresh: "relogged-refresh",
+        accountId: "acct-456",
+      });
+    });
+  });
+
   it("fails closed after managed refresh failure", async () => {
     await withOAuthAgentDirs("oauth-manager-refresh-fail-closed-", async ({ agentDir }) => {
       const profileId = "openai:user@example.com";

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -19,6 +19,7 @@ import {
 } from "./oauth-refresh-lock-errors.js";
 import {
   areOAuthCredentialsEquivalent,
+  hasMatchingOAuthIdentity,
   hasUsableOAuthCredential,
   isSafeToAdoptBootstrapOAuthIdentity,
   isSafeToAdoptMainStoreOAuthIdentity,
@@ -466,6 +467,41 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     return result !== null && saved;
   }
 
+  async function resolveOAuthCredentialAfterPersistMiss(params: {
+    agentDir?: string;
+    profileId: string;
+    refreshed: OAuthCredential;
+  }): Promise<OAuthCredential | null> {
+    const currentStore = loadStoredOAuthRefreshStore(params.agentDir);
+    const current = currentStore.profiles[params.profileId];
+    if (current?.type !== "oauth" || current.provider !== params.refreshed.provider) {
+      return null;
+    }
+    if (!hasMatchingOAuthIdentity(current, params.refreshed)) {
+      return hasUsableOAuthCredential(current) ? current : null;
+    }
+
+    let saved = false;
+    const result = await updateAuthProfileStoreWithLock({
+      agentDir: params.agentDir,
+      updater: (store) => {
+        const existing = store.profiles[params.profileId];
+        if (existing?.type !== "oauth" || existing.provider !== params.refreshed.provider) {
+          return false;
+        }
+        // Refresh tokens rotate server-side before persist. Same-identity CAS
+        // losers must win the store or the token family is bricked.
+        if (hasMatchingOAuthIdentity(existing, params.refreshed)) {
+          store.profiles[params.profileId] = { ...params.refreshed };
+          saved = true;
+          return true;
+        }
+        return false;
+      },
+    });
+    return result !== null && saved ? params.refreshed : null;
+  }
+
   async function doRefreshOAuthTokenWithLock(params: {
     profileId: string;
     provider: string;
@@ -617,7 +653,23 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
           credential: refreshedCredentials,
         });
         if (!persisted) {
-          throw new Error("Failed to persist refreshed OAuth credential");
+          const recovered = await resolveOAuthCredentialAfterPersistMiss({
+            agentDir: ownerAgentDir,
+            profileId: params.profileId,
+            refreshed: refreshedCredentials,
+          });
+          if (!recovered) {
+            throw new Error("Failed to persist refreshed OAuth credential");
+          }
+          if (recovered !== refreshedCredentials) {
+            return {
+              apiKey: await adapter.buildApiKey(recovered.provider, recovered, {
+                cfg: params.cfg,
+                agentDir: params.agentDir,
+              }),
+              credential: recovered,
+            };
+          }
         }
         if (ownerAgentDir) {
           const mainPath = resolveAuthStorePath(undefined);

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -472,16 +472,10 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     profileId: string;
     refreshed: OAuthCredential;
   }): Promise<OAuthCredential | null> {
-    const currentStore = loadStoredOAuthRefreshStore(params.agentDir);
-    const current = currentStore.profiles[params.profileId];
-    if (current?.type !== "oauth" || current.provider !== params.refreshed.provider) {
-      return null;
-    }
-    if (!hasMatchingOAuthIdentity(current, params.refreshed)) {
-      return hasUsableOAuthCredential(current) ? current : null;
-    }
-
-    let saved = false;
+    // Single locked pass decides both outcomes so no relog can slip between a
+    // pre-read and the update: same identity persists the rotation, different
+    // identity adopts the stored (re-logged) credential for this call.
+    let adopted: OAuthCredential | null = null;
     const result = await updateAuthProfileStoreWithLock({
       agentDir: params.agentDir,
       updater: (store) => {
@@ -493,13 +487,14 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
         // losers must win the store or the token family is bricked.
         if (hasMatchingOAuthIdentity(existing, params.refreshed)) {
           store.profiles[params.profileId] = { ...params.refreshed };
-          saved = true;
+          adopted = params.refreshed;
           return true;
         }
+        adopted = hasUsableOAuthCredential(existing) ? existing : null;
         return false;
       },
     });
-    return result !== null && saved ? params.refreshed : null;
+    return result === null ? null : adopted;
   }
 
   async function doRefreshOAuthTokenWithLock(params: {

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -8,6 +8,7 @@ import {
   normalizeProviderId,
 } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
 import { normalizeAuthProfileCredential } from "./credential-normalize.js";
 import { dedupeProfileIds, listProfilesForProvider } from "./profile-list.js";
@@ -22,6 +23,8 @@ export {
   listProfilesForProvider,
   resolveSubscriptionAuthModeForProfiles,
 } from "./profile-list.js";
+
+const authProfileProfilesLog = createSubsystemLogger("agent/embedded");
 
 // Auth profile order/lastGood keys may be stored as aliases. Resolve through
 // auth provider normalization before updating per-provider state.
@@ -286,11 +289,15 @@ export async function markAuthProfileSuccess(params: {
     store.usageStats = updated.usageStats;
     return;
   }
-  const profile = store.profiles[profileId];
-  if (!profile || resolveProviderIdForAuth(profile.provider) !== providerKey) {
-    return;
+  if (updated === null) {
+    authProfileProfilesLog.warn(
+      "dropped auth profile bookkeeping after locked store update failed",
+      {
+        event: "auth_profile_bookkeeping_dropped",
+        kind: "success",
+        profileId,
+        tags: ["auth_profiles", "persistence"],
+      },
+    );
   }
-  store.lastGood = { ...store.lastGood, [providerKey]: profileId };
-  updateSuccessfulUsageStatsEntry(store, profileId, lastUsed);
-  saveAuthProfileStore(store, agentDir);
 }

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -31,12 +31,12 @@ vi.mock("./store.js", () => ({
 }));
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  storeMocks.saveAuthProfileStore.mockReset();
+  storeMocks.updateAuthProfileStoreWithLock.mockReset();
   fetchMock.mockReset();
   vi.stubGlobal("fetch", fetchMock);
-  storeMocks.updateAuthProfileStoreWithLock.mockResolvedValue(null);
+  storeMocks.updateAuthProfileStoreWithLock.mockResolvedValue({ version: 1, profiles: {} });
   authProfileUsageTesting.setDepsForTest({
-    saveAuthProfileStore: storeMocks.saveAuthProfileStore,
     updateAuthProfileStoreWithLock: storeMocks.updateAuthProfileStoreWithLock,
   });
 });
@@ -60,6 +60,16 @@ function makeStore(usageStats: AuthProfileStore["usageStats"]): AuthProfileStore
     },
     usageStats,
   };
+}
+
+function mockLockedUpdateForStore(store: AuthProfileStore): void {
+  storeMocks.updateAuthProfileStoreWithLock.mockImplementationOnce(
+    async (lockParams: { updater: (store: AuthProfileStore) => boolean }) => {
+      const freshStore = structuredClone(store);
+      lockParams.updater(freshStore);
+      return freshStore;
+    },
+  );
 }
 
 function expectProfileErrorStateCleared(
@@ -671,6 +681,7 @@ describe("clearAuthProfileCooldown", () => {
         failureCounts: { billing: 3, rate_limit: 2 },
       },
     });
+    mockLockedUpdateForStore(store);
 
     await clearAuthProfileCooldown({ store, profileId: "anthropic:default" });
 
@@ -689,6 +700,7 @@ describe("clearAuthProfileCooldown", () => {
         lastFailureAt,
       },
     });
+    mockLockedUpdateForStore(store);
 
     await clearAuthProfileCooldown({ store, profileId: "anthropic:default" });
 
@@ -699,6 +711,7 @@ describe("clearAuthProfileCooldown", () => {
 
   it("no-ops for unknown profile id", async () => {
     const store = makeStore(undefined);
+    mockLockedUpdateForStore(store);
     await clearAuthProfileCooldown({ store, profileId: "nonexistent" });
     expect(store.usageStats).toBeUndefined();
   });
@@ -717,6 +730,7 @@ describe("markAuthProfileFailure — active windows do not extend on retry", () 
     cfg?: OpenClawConfig;
   }): Promise<void> {
     const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(params.now);
+    mockLockedUpdateForStore(params.store);
     try {
       await markAuthProfileFailure({
         store: params.store,
@@ -905,6 +919,7 @@ describe("markAuthProfileBlockedUntil", () => {
         blockedUntil: laterBlockedUntil,
       },
     });
+    mockLockedUpdateForStore(store);
     try {
       await markAuthProfileBlockedUntil({
         store,
@@ -922,6 +937,7 @@ describe("markAuthProfileBlockedUntil", () => {
   it("ignores blocked-until updates when the process clock is invalid", async () => {
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(Number.NaN);
     const store = makeStore({});
+    mockLockedUpdateForStore(store);
     try {
       await markAuthProfileBlockedUntil({
         store,
@@ -939,6 +955,7 @@ describe("markAuthProfileBlockedUntil", () => {
 
   it("ignores blocked-until updates outside the valid Date range", async () => {
     const store = makeStore({});
+    mockLockedUpdateForStore(store);
 
     await markAuthProfileBlockedUntil({
       store,
@@ -976,6 +993,46 @@ describe("markAuthProfileFailure — detail-less provider failures", () => {
   });
 });
 
+describe("markAuthProfileFailure — locked update failure", () => {
+  it("drops bookkeeping without an unlocked full-store save", async () => {
+    const store = makeStore(undefined);
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const previousTestConsole = process.env.OPENCLAW_TEST_CONSOLE;
+    const previousLogLevel = process.env.OPENCLAW_LOG_LEVEL;
+    storeMocks.updateAuthProfileStoreWithLock.mockResolvedValueOnce(null);
+    process.env.OPENCLAW_TEST_CONSOLE = "1";
+    process.env.OPENCLAW_LOG_LEVEL = "warn";
+    try {
+      await markAuthProfileFailure({
+        store,
+        profileId: "anthropic:default",
+        reason: "rate_limit",
+      });
+      expect(store.usageStats).toBeUndefined();
+      expect(storeMocks.saveAuthProfileStore).not.toHaveBeenCalled();
+      expect(
+        consoleWarn.mock.calls.some(([line]) =>
+          String(line).includes(
+            "dropped auth profile bookkeeping after locked store update failed",
+          ),
+        ),
+      ).toBe(true);
+    } finally {
+      if (previousTestConsole === undefined) {
+        delete process.env.OPENCLAW_TEST_CONSOLE;
+      } else {
+        process.env.OPENCLAW_TEST_CONSOLE = previousTestConsole;
+      }
+      if (previousLogLevel === undefined) {
+        delete process.env.OPENCLAW_LOG_LEVEL;
+      } else {
+        process.env.OPENCLAW_LOG_LEVEL = previousLogLevel;
+      }
+      consoleWarn.mockRestore();
+    }
+  });
+});
+
 describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
   function mockWhamResponse(status: number, body?: unknown): void {
     fetchMock.mockResolvedValueOnce(
@@ -990,17 +1047,11 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
     store: ReturnType<typeof makeStore>;
     now: number;
     reason?: "rate_limit" | "no_error_details" | "unknown";
-    useLock?: boolean;
+    mockLock?: boolean;
   }): Promise<void> {
     const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(params.now);
-    if (params.useLock) {
-      storeMocks.updateAuthProfileStoreWithLock.mockImplementationOnce(
-        async (lockParams: { updater: (store: AuthProfileStore) => boolean }) => {
-          const freshStore = structuredClone(params.store);
-          const changed = lockParams.updater(freshStore);
-          return changed ? freshStore : null;
-        },
-      );
+    if (params.mockLock !== false) {
+      mockLockedUpdateForStore(params.store);
     }
     try {
       await markAuthProfileFailure({
@@ -1124,7 +1175,7 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
       },
     );
 
-    await markCodexFailureAt({ store, now, reason: "no_error_details" });
+    await markCodexFailureAt({ store, now, reason: "no_error_details", mockLock: false });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(store.usageStats).toBeUndefined();
@@ -1192,7 +1243,7 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
       },
     });
 
-    await markCodexFailureAt({ store, now, useLock: true });
+    await markCodexFailureAt({ store, now });
 
     expect(store.usageStats?.["openai:default"]?.cooldownUntil).toBe(existingCooldownUntil);
   });
@@ -1244,6 +1295,7 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
     vi.useFakeTimers();
     vi.setSystemTime(now);
     try {
+      mockLockedUpdateForStore(store);
       await markAuthProfileFailure({
         store,
         profileId: "anthropic:default",
@@ -1276,6 +1328,7 @@ describe("markAuthProfileFailure — per-model cooldown metadata", () => {
   }): Promise<void> {
     vi.useFakeTimers();
     vi.setSystemTime(params.now);
+    mockLockedUpdateForStore(params.store);
     try {
       await markAuthProfileFailure({
         store: params.store,
@@ -1360,6 +1413,7 @@ describe("markAuthProfileFailure — per-model cooldown metadata", () => {
         lastFailureAt: now - 1000,
       },
     });
+    mockLockedUpdateForStore(store);
     await markAuthProfileFailure({
       store,
       profileId: "github-copilot:github",
@@ -1384,6 +1438,7 @@ describe("markAuthProfileFailure — per-model cooldown metadata", () => {
         lastFailureAt: now - 1000,
       },
     });
+    mockLockedUpdateForStore(store);
     await markAuthProfileFailure({
       store,
       profileId: "github-copilot:github",

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -19,7 +19,7 @@ import { notifyAuthProfileFailureHook, setAuthProfileFailureHook } from "./failu
 import { logAuthProfileFailureStateChange } from "./state-observation.js";
 
 const authProfileUsageLog = createSubsystemLogger("agent/embedded");
-import { saveAuthProfileStore, updateAuthProfileStoreWithLock } from "./store.js";
+import { updateAuthProfileStoreWithLock } from "./store.js";
 import type {
   AuthProfileBlockedSource,
   AuthProfileCredential,
@@ -41,7 +41,6 @@ export {
 } from "./usage-state.js";
 
 const authProfileUsageDeps = {
-  saveAuthProfileStore,
   updateAuthProfileStoreWithLock,
 };
 
@@ -51,16 +50,22 @@ export { setAuthProfileFailureHook };
 export const testing = {
   setDepsForTest(
     overrides: Partial<{
-      saveAuthProfileStore: typeof saveAuthProfileStore;
       updateAuthProfileStoreWithLock: typeof updateAuthProfileStoreWithLock;
     }> | null,
   ) {
-    authProfileUsageDeps.saveAuthProfileStore =
-      overrides?.saveAuthProfileStore ?? saveAuthProfileStore;
     authProfileUsageDeps.updateAuthProfileStoreWithLock =
       overrides?.updateAuthProfileStoreWithLock ?? updateAuthProfileStoreWithLock;
   },
 };
+
+function logDroppedAuthProfileBookkeeping(kind: string, profileId: string): void {
+  authProfileUsageLog.warn("dropped auth profile bookkeeping after locked store update failed", {
+    event: "auth_profile_bookkeeping_dropped",
+    kind,
+    profileId,
+    tags: ["auth_profiles", "persistence"],
+  });
+}
 
 const FAILURE_REASON_PRIORITY: AuthProfileFailureReason[] = [
   "auth_permanent",
@@ -815,59 +820,8 @@ export async function markAuthProfileFailure(params: {
     }
     return;
   }
-  if (!store.profiles[profileId]) {
-    return;
-  }
-
-  const currentWhamResult =
-    whamResult && isSameWhamCredential(profile, store.profiles[profileId]) ? whamResult : null;
-  if (reason === "no_error_details" && !currentWhamResult) {
-    return;
-  }
-
-  const now = Date.now();
-  const providerKey = normalizeProviderId(store.profiles[profileId]?.provider ?? "");
-  const cfgResolved = resolveAuthCooldownConfig({
-    cfg,
-    providerId: providerKey,
-  });
-
-  previousStats = store.usageStats?.[profileId];
-  const computed = computeNextProfileUsageStats({
-    existing: previousStats ?? {},
-    now,
-    reason,
-    cfgResolved,
-    modelId,
-  });
-  nextStats = currentWhamResult
-    ? applyWhamCooldownResult({
-        existing: previousStats ?? {},
-        computed,
-        now,
-        whamResult: currentWhamResult,
-      })
-    : computed;
-  updateUsageStatsEntry(store, profileId, () => nextStats ?? computed);
-  authProfileUsageDeps.saveAuthProfileStore(store, agentDir);
-  logAuthProfileFailureStateChange({
-    runId,
-    profileId,
-    provider: store.profiles[profileId]?.provider ?? profile.provider,
-    reason,
-    previous: previousStats,
-    next: nextStats,
-    now,
-  });
-  try {
-    notifyAuthProfileFailureHook();
-  } catch (err) {
-    // Hook errors must not break failure recording; log and continue.
-    authProfileUsageLog.warn("auth profile failure hook threw", {
-      event: "auth_profile_failure_hook_error",
-      tags: ["error_handling", "auth_profiles"],
-      error: err instanceof Error ? err.message : String(err),
-    });
+  if (updated === null) {
+    logDroppedAuthProfileBookkeeping("failure", profileId);
   }
 }
 
@@ -961,33 +915,9 @@ export async function markAuthProfileBlockedUntil(params: {
     }
     return;
   }
-  if (!store.profiles[profileId]) {
-    return;
+  if (updated === null) {
+    logDroppedAuthProfileBookkeeping("blocked_until", profileId);
   }
-
-  const now = asDateTimestampMs(Date.now());
-  if (now === undefined) {
-    return;
-  }
-  previousStats = store.usageStats?.[profileId];
-  nextStats = buildBlockedProfileUsageStats({
-    previousStats,
-    blockedUntil,
-    source,
-    modelId,
-    now,
-  });
-  updateUsageStatsEntry(store, profileId, () => nextStats as ProfileUsageStats);
-  authProfileUsageDeps.saveAuthProfileStore(store, agentDir);
-  logAuthProfileFailureStateChange({
-    runId,
-    profileId,
-    provider: store.profiles[profileId]?.provider ?? profile.provider,
-    reason: "rate_limit",
-    previous: previousStats,
-    next: nextStats,
-    now,
-  });
 }
 
 /**
@@ -1035,11 +965,8 @@ export async function clearAuthProfileCooldown(params: {
     store.usageStats = updated.usageStats;
     return;
   }
-  if (!store.usageStats?.[profileId]) {
-    return;
+  if (updated === null) {
+    logDroppedAuthProfileBookkeeping("clear_cooldown", profileId);
   }
-
-  updateUsageStatsEntry(store, profileId, (existing) => resetUsageStats(existing));
-  authProfileUsageDeps.saveAuthProfileStore(store, agentDir);
 }
 export { testing as __testing };


### PR DESCRIPTION
Closes #102430

## What Problem This Solves

Fixes an issue where users running an OpenAI (ChatGPT OAuth) primary model with a fallback model configured would have their OpenAI login invalidated and be forced to re-run device-code sign-in every few days. OpenAI refresh tokens are rotating/single-use; two internal races could put an already-consumed refresh token back into the auth store, and the next refresh attempt then tripped reuse detection and revoked the whole token family (`401 Your authentication token has been invalidated`). Same symptom family as #99120, which removed the external-CLI stale-credential replay; this closes the remaining internal last-write-wins paths.

## Why This Change Was Made

Auth-profile bookkeeping (`markAuthProfileFailure`, `markAuthProfileSuccess`, `markAuthProfileBlockedUntil`, `clearAuthProfileCooldown`) only mutates usage state, but on a locked-update failure it fell back to an unlocked full-store save of the caller's run-start snapshot — rewriting every provider's credentials last-write-wins. Bookkeeping is best-effort: the fallback saves are deleted and a failed locked update is now logged and dropped. Separately, when a successful OAuth refresh lost the persist CAS, the rotated credential was discarded while the server had already consumed the old token; the CAS miss now re-checks under the store lock — a same-identity race force-persists the rotated credential (the only live token in its family), and a different-identity race (concurrent re-login) keeps the stored credential and uses it for the current call. Non-goal: the pre-existing cross-file test-isolation leakage in the auth-profiles suite and the WHAM cooldown probe are untouched.

## User Impact

OpenAI ChatGPT OAuth logins no longer get invalidated by concurrent runs or fallback-model bookkeeping; recurring forced re-logins for fallback-configured setups stop. No config or behavior surface changes otherwise.

## Evidence

- Regression tests added: locked-update failure drops bookkeeping without any unlocked full-store save (`usage.test.ts`); same-identity CAS race persists the rotated credential end-to-end through `resolveOAuthAccess`; different-identity CAS race preserves the re-logged credential (`oauth-manager.test.ts`).
- Focused proof: `node scripts/run-vitest.mjs` — `usage.test.ts` 78 passed, `oauth-manager.test.ts` 22 passed, `auth-profiles.markauthprofilefailure.test.ts` 14 passed, `order.test.ts` 18 passed.
- Changed-lane gate: Blacksmith Testbox `tbx_01kx2nzb04swk65228c145rc1b`, `pnpm check:changed` exit 0 (includes tsgo lanes, lint, import cycles).
- Pre-existing unrelated failures: the full `src/agents/auth-profiles` directory run fails from cross-file mock/env leakage on clean `main` too (23 failures on `main` @ 1d4d8474da8 vs 16 on this branch, shifting victim files); all 6 affected files pass 40/40 when run as a focused set on this branch. Not touched here.
- Structured review: autoreview (codex/gpt-5.5) on the branch diff — clean, no actionable findings.


## Review Follow-up (ClawSweeper round 1)

- **Recovery-race fix** (`ebcac2a70d0`): the CAS-miss helper now decides both outcomes inside a single locked store update — same-identity persists the rotation, different-identity adopts the stored (re-logged) credential for the current call. The unlocked pre-read is deleted, so no relog can land between read and update. Focused suite re-run: `oauth-manager.test.ts` 22/22; autoreview (codex/gpt-5.5) re-run clean.
- **Real behavior proof** (no mocks, production modules against a real on-disk agent SQLite store, contention from a competing `BEGIN IMMEDIATE` held via `node:sqlite`, fake tokens only):
  - `main` @ 1d4d8474da8 — bookkeeping fallback crashes the caller unhandled under sustained contention:
    ```
    Error: database is locked
        at runSqliteImmediateTransactionSync (src/infra/sqlite-transaction.ts:95:6)
        at runOpenClawAgentWriteTransaction (src/state/openclaw-agent-db.ts:288:18)
        at writePersistedAuthProfileStoreRaw (src/agents/auth-profiles/sqlite.ts:199:3)
        at Object.saveAuthProfileStore (src/agents/auth-profiles/store.ts:1052:5)
        at markAuthProfileFailure (src/agents/auth-profiles/usage.ts:852:24)
    ```
    Under transient contention (lock clears between the locked attempt and the fallback), that same `usage.ts:852` save silently rewrites the full credential map from the run-start snapshot — the rollback covered by the regression tests.
  - This branch, identical scenario:
    ```
    [agent/embedded] dropped auth profile bookkeeping after locked store update failed
    [repro] persisted OpenAI refresh token: REFRESH-TOKEN-V2-ROTATED
    [repro] RESULT: SAFE — rotated credential preserved
    ```
