### PR TITLE
fix(realtime-transcription): bound inbound websocket payloads

### DIFF
--- a/src/realtime-transcription/websocket-session.test.ts
+++ b/src/realtime-transcription/websocket-session.test.ts
@@ -4,7 +4,10 @@ import type { AddressInfo } from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type WebSocket from "ws";
 import { WebSocketServer } from "ws";
-import { createRealtimeTranscriptionWebSocketSession } from "./websocket-session.js";
+import {
+  createRealtimeTranscriptionWebSocketSession,
+  REALTIME_TRANSCRIPTION_WS_MAX_PAYLOAD_BYTES,
+} from "./websocket-session.js";
 
 let cleanup: (() => Promise<void>) | undefined;
 
@@ -402,5 +405,64 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
     const closeError = requireFirstMockArg(onError, "pre-ready close error");
     expect(closeError).toBeInstanceOf(Error);
     expect(closeError.message).toBe("test realtime transcription connection closed before ready");
+  });
+
+  it("delivers a legitimate large inbound frame below the payload cap", async () => {
+    // Well above any real transcript frame yet far under the 16 MiB cap: proves
+    // the bound does not reject legitimate large provider traffic.
+    const largeText = "x".repeat(2 * 1024 * 1024);
+    const server = await createRealtimeServer({
+      initialEvent: { type: "transcript", text: largeText },
+    });
+    const onMessage = vi.fn();
+    const session = createRealtimeTranscriptionWebSocketSession<{ type?: string; text?: string }>({
+      providerId: "test",
+      callbacks: {},
+      url: server.url,
+      readyOnOpen: true,
+      onMessage,
+      sendAudio: (audio, transport) => {
+        transport.sendBinary(audio);
+      },
+    });
+
+    await session.connect();
+    await vi.waitFor(() => {
+      expect(onMessage).toHaveBeenCalledTimes(1);
+    });
+    const event = requireFirstMockArg(onMessage, "large inbound frame");
+    expect(event).toEqual({ type: "transcript", text: largeText });
+    session.close();
+  });
+
+  it("drops an oversized inbound frame before it reaches the provider parser", async () => {
+    // ws rejects a frame above maxPayload with an error + 1009 close, so an
+    // oversized upstream frame never reaches onMessage/JSON parse.
+    const oversized = "x".repeat(REALTIME_TRANSCRIPTION_WS_MAX_PAYLOAD_BYTES + 1);
+    const server = await createRealtimeServer({ initialText: oversized });
+    const onError = vi.fn();
+    const onMessage = vi.fn(() => {
+      throw new Error("oversized frame should not reach provider handler");
+    });
+    const session = createRealtimeTranscriptionWebSocketSession({
+      providerId: "test",
+      callbacks: { onError },
+      url: server.url,
+      readyOnOpen: true,
+      onMessage,
+      sendAudio: (audio, transport) => {
+        transport.sendBinary(audio);
+      },
+    });
+
+    await session.connect();
+    await vi.waitFor(() => {
+      expect(onError).toHaveBeenCalledTimes(1);
+    });
+    expect(onMessage).not.toHaveBeenCalled();
+    const overflowError = requireFirstMockArg(onError, "oversized inbound frame error");
+    expect(overflowError).toBeInstanceOf(Error);
+    expect(overflowError.message).toMatch(/max payload/i);
+    session.close();
   });
 });

--- a/src/realtime-transcription/websocket-session.test.ts
+++ b/src/realtime-transcription/websocket-session.test.ts
@@ -407,8 +407,8 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
     expect(closeError.message).toBe("test realtime transcription connection closed before ready");
   });
 
-  it("delivers a legitimate large inbound frame below the payload cap", async () => {
-    // Well above any real transcript frame yet far under the 16 MiB cap: proves
+  it("delivers a legitimate large inbound message below the payload cap", async () => {
+    // Well above any real transcript message yet far under the 16 MiB cap: proves
     // the bound does not reject legitimate large provider traffic.
     const largeText = "x".repeat(2 * 1024 * 1024);
     const server = await createRealtimeServer({
@@ -430,14 +430,14 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
     await vi.waitFor(() => {
       expect(onMessage).toHaveBeenCalledTimes(1);
     });
-    const event = requireFirstMockArg(onMessage, "large inbound frame");
+    const event = requireFirstMockArg(onMessage, "large inbound message");
     expect(event).toEqual({ type: "transcript", text: largeText });
     session.close();
   });
 
-  it("drops an oversized inbound frame before it reaches the provider parser", async () => {
-    // ws rejects a frame above maxPayload with an error + 1009 close, so an
-    // oversized upstream frame never reaches onMessage/JSON parse.
+  it("drops an oversized inbound message before it reaches the provider parser", async () => {
+    // ws rejects a message above maxPayload with an error + 1009 close, so an
+    // oversized upstream message never reaches onMessage/JSON parse.
     const oversized = "x".repeat(REALTIME_TRANSCRIPTION_WS_MAX_PAYLOAD_BYTES + 1);
     const server = await createRealtimeServer({ initialText: oversized });
     const onError = vi.fn();
@@ -460,8 +460,9 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
       expect(onError).toHaveBeenCalledTimes(1);
     });
     expect(onMessage).not.toHaveBeenCalled();
-    const overflowError = requireFirstMockArg(onError, "oversized inbound frame error");
+    const overflowError = requireFirstMockArg(onError, "oversized inbound message error");
     expect(overflowError).toBeInstanceOf(Error);
+    expect(overflowError).toHaveProperty("code", "WS_ERR_UNSUPPORTED_MESSAGE_LENGTH");
     expect(overflowError.message).toMatch(/max payload/i);
     session.close();
   });

--- a/src/realtime-transcription/websocket-session.ts
+++ b/src/realtime-transcription/websocket-session.ts
@@ -50,6 +50,11 @@ const DEFAULT_CLOSE_TIMEOUT_MS = 5_000;
 const DEFAULT_MAX_RECONNECT_ATTEMPTS = 5;
 const DEFAULT_RECONNECT_DELAY_MS = 1000;
 const DEFAULT_MAX_QUEUED_BYTES = 2 * 1024 * 1024;
+// Bound inbound frames before ws buffers them for JSON parsing. Transcript
+// provider frames are small text/JSON; 16 MiB matches the realtime voice ws cap
+// and caps ws's 100 MiB default. ws emits an error + 1009 close on overflow, so
+// an oversized frame never reaches onMessage/parseMessage.
+export const REALTIME_TRANSCRIPTION_WS_MAX_PAYLOAD_BYTES = 16 * 1024 * 1024;
 
 function rawWsDataToBuffer(data: RawData): Buffer {
   if (Buffer.isBuffer(data)) {
@@ -249,6 +254,7 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
         try {
           this.ws = new WebSocket(this.currentUrl, {
             headers: connection.headers,
+            maxPayload: REALTIME_TRANSCRIPTION_WS_MAX_PAYLOAD_BYTES,
             ...(proxyAgent ? { agent: proxyAgent } : {}),
           });
         } catch (error) {

--- a/src/realtime-transcription/websocket-session.ts
+++ b/src/realtime-transcription/websocket-session.ts
@@ -50,10 +50,9 @@ const DEFAULT_CLOSE_TIMEOUT_MS = 5_000;
 const DEFAULT_MAX_RECONNECT_ATTEMPTS = 5;
 const DEFAULT_RECONNECT_DELAY_MS = 1000;
 const DEFAULT_MAX_QUEUED_BYTES = 2 * 1024 * 1024;
-// Bound inbound frames before ws buffers them for JSON parsing. Transcript
-// provider frames are small text/JSON; 16 MiB matches the realtime voice ws cap
-// and caps ws's 100 MiB default. ws emits an error + 1009 close on overflow, so
-// an oversized frame never reaches onMessage/parseMessage.
+// Bound inbound messages before ws buffers them for JSON parsing. The 16 MiB cap
+// matches realtime voice; ws rejects larger messages with close 1009 before
+// they reach onMessage, replacing its 100 MiB client default.
 export const REALTIME_TRANSCRIPTION_WS_MAX_PAYLOAD_BYTES = 16 * 1024 * 1024;
 
 function rawWsDataToBuffer(data: RawData): Buffer {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a realtime transcription websocket session would buffer an arbitrarily large inbound frame from the upstream provider before parsing it. The generic session (`src/realtime-transcription/websocket-session.ts`) backs every websocket transcription provider (OpenAI, Mistral, xAI, ElevenLabs, Deepgram), so a buggy or hostile upstream could push an unbounded frame straight into `JSON.parse` with no size ceiling.

## Why This Change Was Made

The session now passes `maxPayload` to the `ws` client, matching the existing realtime voice cap. `ws` rejects an over-limit frame with an error and a 1009 close before it assembles the message, so an oversized frame never reaches `onMessage`/`parseMessage`. The 16 MiB cap leaves large headroom over real transcript frames (KB-scale) while replacing `ws`'s 100 MiB default.

## User Impact

Operators running any websocket transcription provider get a bounded failure on a malformed oversized frame instead of unbounded buffering; legitimate transcript traffic is unaffected.

## Evidence

- `pnpm test src/realtime-transcription/websocket-session.test.ts` — 12 passed, incl. two new boundary tests (legit large frame delivered, oversized frame dropped before the parser).
- `tsgo:core` and `tsgo:core:test` clean; `oxlint` on changed files clean.
- Live loopback proof importing the real changed module (`createRealtimeTranscriptionWebSocketSession`) over a real `ws` connection, both boundary sides:

```text
$ tsx proof-live.ts
cap REALTIME_TRANSCRIPTION_WS_MAX_PAYLOAD_BYTES = 16777216 bytes (16 MiB)
legit-2MiB:        frameBytes=2097183     reachedParser=true  onError=none
oversized-16MiB+1: frameBytes=16777217    reachedParser=false onError=Max payload size exceeded
```

<details>
<summary>proof-live.ts</summary>

```ts
import { createServer } from "node:http";
import type { AddressInfo } from "node:net";
import { WebSocketServer } from "ws";
import {
  createRealtimeTranscriptionWebSocketSession,
  REALTIME_TRANSCRIPTION_WS_MAX_PAYLOAD_BYTES,
} from "./src/realtime-transcription/websocket-session.js";

async function startServer(sendFrame: string) {
  const server = createServer();
  const wss = new WebSocketServer({ noServer: true, maxPayload: 64 * 1024 * 1024 });
  server.on("upgrade", (req, socket, head) => {
    wss.handleUpgrade(req, socket, head, (ws) => ws.send(sendFrame));
  });
  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
  const port = (server.address() as AddressInfo).port;
  return { url: `ws://127.0.0.1:${port}` };
}

async function run(label: string, frame: string) {
  const server = await startServer(frame);
  let delivered = false;
  let errored: string | undefined;
  const session = createRealtimeTranscriptionWebSocketSession({
    providerId: "proof",
    callbacks: { onError: (e) => (errored = e.message) },
    url: server.url,
    readyOnOpen: true,
    onMessage: () => (delivered = true),
    sendAudio: () => {},
  });
  await session.connect();
  await new Promise((r) => setTimeout(r, 400));
  session.close();
  console.log(`${label}: frameBytes=${frame.length} reachedParser=${delivered} onError=${errored ?? "none"}`);
}

async function main() {
  console.log(`cap = ${REALTIME_TRANSCRIPTION_WS_MAX_PAYLOAD_BYTES} bytes (16 MiB)`);
  await run("legit-2MiB", JSON.stringify({ type: "transcript", text: "x".repeat(2 * 1024 * 1024) }));
  await run("oversized-16MiB+1", "x".repeat(REALTIME_TRANSCRIPTION_WS_MAX_PAYLOAD_BYTES + 1));
}

void main().then(() => process.exit(0));
```

</details>

AI-assisted: built with Codex
