### PR TITLE
fix(cron): channel failure alerts drop when global webhook failure destination is set

### DIFF
--- a/src/cron/delivery-plan.ts
+++ b/src/cron/delivery-plan.ts
@@ -189,14 +189,19 @@ export function resolveFailureDestination(
     if (hasJobAccountIdField) {
       accountId = jobAccountId;
     }
-    if (hasJobModeField) {
+    // A channel-shaped override without mode is announce (same default as primary
+    // delivery). Inheriting a global webhook mode would feed the chat target to the
+    // webhook URL validator and silently drop the failure alert (#102235).
+    const jobImpliesAnnounce = !hasJobModeField && jobChannel !== undefined;
+    if (hasJobModeField || jobImpliesAnnounce) {
+      const effectiveJobMode = jobImpliesAnnounce ? "announce" : jobMode;
       const globalMode = globalConfig?.mode ?? "announce";
-      const resolvedJobMode = jobMode ?? "announce";
+      const resolvedJobMode = effectiveJobMode ?? "announce";
       if (!jobToExplicitValue && globalMode !== resolvedJobMode) {
         // Do not carry an inherited target across modes; an announce chat is not a webhook URL.
         to = undefined;
       }
-      mode = jobMode;
+      mode = effectiveJobMode;
     }
   }
 

--- a/src/cron/delivery-plan.ts
+++ b/src/cron/delivery-plan.ts
@@ -189,13 +189,12 @@ export function resolveFailureDestination(
     if (hasJobAccountIdField) {
       accountId = jobAccountId;
     }
-    // A channel-shaped override without mode is announce (same default as primary
-    // delivery). Inheriting a global webhook mode would feed the chat target to the
-    // webhook URL validator and silently drop the failure alert (#102235).
+    // Naming a channel makes this an announce route even when mode is omitted;
+    // inheriting webhook here would reinterpret the chat target as a URL.
     const jobImpliesAnnounce = !hasJobModeField && jobChannel !== undefined;
     if (hasJobModeField || jobImpliesAnnounce) {
       const effectiveJobMode = jobImpliesAnnounce ? "announce" : jobMode;
-      const globalMode = globalConfig?.mode ?? "announce";
+      const globalMode = mode ?? "announce";
       const resolvedJobMode = effectiveJobMode ?? "announce";
       if (!jobToExplicitValue && globalMode !== resolvedJobMode) {
         // Do not carry an inherited target across modes; an announce chat is not a webhook URL.

--- a/src/cron/delivery.test.ts
+++ b/src/cron/delivery.test.ts
@@ -235,6 +235,60 @@ describe("resolveFailureDestination", () => {
     });
   });
 
+  it("resolves a channel-shaped job override without mode to announce despite a global webhook default (#102235)", () => {
+    const plan = resolveFailureDestination(
+      makeCronJob({
+        delivery: {
+          mode: "none",
+          failureDestination: { channel: "slack", to: "#alerts" },
+        },
+      }),
+      { mode: "webhook", to: "https://hook.example/cron" },
+    );
+    expect(plan).toEqual({
+      mode: "announce",
+      channel: "slack",
+      to: "#alerts",
+      accountId: undefined,
+    });
+  });
+
+  it("clears an inherited global webhook URL when a channel-only override implies announce (#102235)", () => {
+    const plan = resolveFailureDestination(
+      makeCronJob({
+        delivery: {
+          mode: "none",
+          failureDestination: { channel: "slack" },
+        },
+      }),
+      { mode: "webhook", to: "https://hook.example/cron" },
+    );
+    expect(plan).toEqual({
+      mode: "announce",
+      channel: "slack",
+      to: undefined,
+      accountId: undefined,
+    });
+  });
+
+  it("keeps inheriting a global webhook mode for a to-only override without channel or mode", () => {
+    const plan = resolveFailureDestination(
+      makeCronJob({
+        delivery: {
+          mode: "none",
+          failureDestination: { to: "https://other.example/hook" },
+        },
+      }),
+      { mode: "webhook", to: "https://hook.example/cron" },
+    );
+    expect(plan).toEqual({
+      mode: "webhook",
+      channel: undefined,
+      to: "https://other.example/hook",
+      accountId: undefined,
+    });
+  });
+
   it("returns null for webhook mode without destination URL", () => {
     const plan = resolveFailureDestination(
       makeCronJob({

--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -141,6 +141,69 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
     });
   });
 
+  it("announces channel-shaped failure destinations without mode under a global webhook default (#102235)", () => {
+    const logger = {
+      warn: vi.fn(),
+    };
+    // Job shape from CLI `--failure-channel slack --failure-to #alerts` with no `--failure-mode`.
+    const job = {
+      id: "cron-channel-fd-no-mode",
+      name: "channel fd no mode",
+      enabled: true,
+      createdAtMs: 1,
+      updatedAtMs: 1,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "hello" },
+      delivery: {
+        mode: "none",
+        failureDestination: {
+          channel: "slack",
+          to: "#alerts",
+        },
+      },
+      state: {},
+    } satisfies CronJob;
+
+    dispatchGatewayCronFinishedNotifications({
+      evt: {
+        jobId: job.id,
+        action: "finished",
+        status: "error",
+        error: "boom",
+      },
+      job,
+      deps: {} as CliDeps,
+      logger,
+      resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
+      // Global default like `cron.failureDestination = { mode: "webhook", to: "https://..." }`.
+      globalFailureDestination: {
+        mode: "webhook",
+        to: "https://hook.example/cron",
+      },
+    });
+
+    // After the fix: channel-shaped job FD without mode is announce, not inherited webhook.
+    expect(mocks.sendFailureNotificationAnnounce).toHaveBeenCalledTimes(1);
+    expect(mocks.sendFailureNotificationAnnounce.mock.calls[0]?.[4]).toEqual({
+      channel: "slack",
+      to: "#alerts",
+      accountId: undefined,
+      sessionKey: undefined,
+      inheritSessionThread: false,
+    });
+    expect(mocks.sendFailureNotificationAnnounce.mock.calls[0]?.[5]).toBe(
+      '⚠️ Cron job "channel fd no mode" failed: boom',
+    );
+    // Must not treat "#alerts" as a webhook URL and drop the alert.
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: job.id }),
+      "cron: failure destination webhook URL is invalid, skipping",
+    );
+    expect(mocks.fetchWithSsrFGuard).not.toHaveBeenCalled();
+  });
+
   it("redacts command action-required summaries before webhook completion delivery", async () => {
     const logger = { warn: vi.fn() };
     const sensitiveSummary =

--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -2,6 +2,7 @@
 // including URL redaction for invalid webhook destinations.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CliDeps } from "../cli/deps.types.js";
+import { makeCronJob } from "../cron/delivery.test-helpers.js";
 import type { CronJob } from "../cron/types.js";
 
 const mocks = vi.hoisted(() => ({
@@ -142,29 +143,15 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
   });
 
   it("announces channel-shaped failure destinations without mode under a global webhook default (#102235)", () => {
-    const logger = {
-      warn: vi.fn(),
-    };
-    // Job shape from CLI `--failure-channel slack --failure-to #alerts` with no `--failure-mode`.
-    const job = {
+    const logger = { warn: vi.fn() };
+    const job = makeCronJob({
       id: "cron-channel-fd-no-mode",
       name: "channel fd no mode",
-      enabled: true,
-      createdAtMs: 1,
-      updatedAtMs: 1,
-      schedule: { kind: "every", everyMs: 60_000 },
-      sessionTarget: "isolated",
-      wakeMode: "next-heartbeat",
-      payload: { kind: "agentTurn", message: "hello" },
       delivery: {
         mode: "none",
-        failureDestination: {
-          channel: "slack",
-          to: "#alerts",
-        },
+        failureDestination: { channel: "slack", to: "#alerts" },
       },
-      state: {},
-    } satisfies CronJob;
+    });
 
     dispatchGatewayCronFinishedNotifications({
       evt: {
@@ -177,26 +164,26 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
       deps: {} as CliDeps,
       logger,
       resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
-      // Global default like `cron.failureDestination = { mode: "webhook", to: "https://..." }`.
       globalFailureDestination: {
         mode: "webhook",
         to: "https://hook.example/cron",
       },
     });
 
-    // After the fix: channel-shaped job FD without mode is announce, not inherited webhook.
-    expect(mocks.sendFailureNotificationAnnounce).toHaveBeenCalledTimes(1);
-    expect(mocks.sendFailureNotificationAnnounce.mock.calls[0]?.[4]).toEqual({
-      channel: "slack",
-      to: "#alerts",
-      accountId: undefined,
-      sessionKey: undefined,
-      inheritSessionThread: false,
-    });
-    expect(mocks.sendFailureNotificationAnnounce.mock.calls[0]?.[5]).toBe(
+    expect(mocks.sendFailureNotificationAnnounce).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "main",
+      job.id,
+      {
+        channel: "slack",
+        to: "#alerts",
+        accountId: undefined,
+        sessionKey: undefined,
+        inheritSessionThread: false,
+      },
       '⚠️ Cron job "channel fd no mode" failed: boom',
     );
-    // Must not treat "#alerts" as a webhook URL and drop the alert.
     expect(logger.warn).not.toHaveBeenCalledWith(
       expect.objectContaining({ jobId: job.id }),
       "cron: failure destination webhook URL is invalid, skipping",

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -367,7 +367,8 @@ function expectFailureAnnounceCall(params: {
   jobId: string;
   channel: string;
   to?: string;
-  sessionKey: string;
+  sessionKey?: string;
+  inheritSessionThread?: false;
   message: string;
 }) {
   expect(sendFailureNotificationAnnounceMock).toHaveBeenCalledTimes(1);
@@ -383,6 +384,7 @@ function expectFailureAnnounceCall(params: {
     to: params.to,
     accountId: undefined,
     sessionKey: params.sessionKey,
+    ...(params.inheritSessionThread === false ? { inheritSessionThread: false } : {}),
   });
   expect(args[5]).toBe(params.message);
 }
@@ -1822,7 +1824,6 @@ describe("gateway server cron", () => {
       cronEnabled: false,
     });
 
-    // Global webhook default that must not poison channel-shaped job failure routes.
     await writeCronConfig({
       cron: {
         failureDestination: {
@@ -1840,7 +1841,6 @@ describe("gateway server cron", () => {
       fetchWithSsrFGuardMock.mockClear();
       cronIsolatedRun.mockResolvedValueOnce({ status: "error", summary: "delivery failed" });
 
-      // Job shape from CLI `--failure-channel slack --failure-to #alerts` with no `--failure-mode`.
       const jobId = await addWebhookCronJob({
         ws,
         name: "channel fd no mode",
@@ -1861,22 +1861,14 @@ describe("gateway server cron", () => {
       await runCronJobForce(ws, jobId);
       await finished;
 
-      expect(sendFailureNotificationAnnounceMock).toHaveBeenCalledTimes(1);
-      const call = sendFailureNotificationAnnounceMock.mock.calls.at(0);
-      if (!call) {
-        throw new Error("expected failure announcement call");
-      }
-      const args = call as unknown as [unknown, unknown, string, string, unknown, string];
-      expect(args[3]).toBe(jobId);
-      expect(args[4]).toEqual({
+      expectFailureAnnounceCall({
+        jobId,
         channel: "slack",
         to: "#alerts",
-        accountId: undefined,
         sessionKey: undefined,
         inheritSessionThread: false,
+        message: '⚠️ Cron job "channel fd no mode" failed: unknown error',
       });
-      expect(args[5]).toBe('⚠️ Cron job "channel fd no mode" failed: unknown error');
-      // Must not treat "#alerts" as a webhook URL (no SSRF fetch / invalid-URL webhook path).
       expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
     } finally {
       await cleanupCronTestRun({ ws, server, prevSkipCron });

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -1816,6 +1816,73 @@ describe("gateway server cron", () => {
     }
   }, 45_000);
 
+  test("announces channel-shaped failure destinations without mode under a global webhook default (#102235)", async () => {
+    const { prevSkipCron } = await setupCronTestRun({
+      tempPrefix: "openclaw-gw-cron-fd-channel-no-mode-",
+      cronEnabled: false,
+    });
+
+    // Global webhook default that must not poison channel-shaped job failure routes.
+    await writeCronConfig({
+      cron: {
+        failureDestination: {
+          mode: "webhook",
+          to: "https://hook.example/cron",
+        },
+      },
+    });
+
+    const { server, ws } = await startServerWithClient();
+    await connectOk(ws);
+
+    try {
+      sendFailureNotificationAnnounceMock.mockClear();
+      fetchWithSsrFGuardMock.mockClear();
+      cronIsolatedRun.mockResolvedValueOnce({ status: "error", summary: "delivery failed" });
+
+      // Job shape from CLI `--failure-channel slack --failure-to #alerts` with no `--failure-mode`.
+      const jobId = await addWebhookCronJob({
+        ws,
+        name: "channel fd no mode",
+        sessionTarget: "isolated",
+        delivery: {
+          mode: "none",
+          failureDestination: {
+            channel: "slack",
+            to: "#alerts",
+          },
+        },
+      });
+
+      const finished = waitForCronEvent(
+        ws,
+        (payload) => payload?.jobId === jobId && payload?.action === "finished",
+      );
+      await runCronJobForce(ws, jobId);
+      await finished;
+
+      expect(sendFailureNotificationAnnounceMock).toHaveBeenCalledTimes(1);
+      const call = sendFailureNotificationAnnounceMock.mock.calls.at(0);
+      if (!call) {
+        throw new Error("expected failure announcement call");
+      }
+      const args = call as unknown as [unknown, unknown, string, string, unknown, string];
+      expect(args[3]).toBe(jobId);
+      expect(args[4]).toEqual({
+        channel: "slack",
+        to: "#alerts",
+        accountId: undefined,
+        sessionKey: undefined,
+        inheritSessionThread: false,
+      });
+      expect(args[5]).toBe('⚠️ Cron job "channel fd no mode" failed: unknown error');
+      // Must not treat "#alerts" as a webhook URL (no SSRF fetch / invalid-URL webhook path).
+      expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+    } finally {
+      await cleanupCronTestRun({ ws, server, prevSkipCron });
+    }
+  }, 45_000);
+
   test("prefers sessionTarget session context for failure announcements over creator sessionKey", async () => {
     const { prevSkipCron } = await setupCronTestRun({
       tempPrefix: "openclaw-gw-cron-failure-session-target-",


### PR DESCRIPTION
Closes #102235

## What Problem This Solves

A job can provide a channel-shaped failure destination such as `{ channel: "slack", to: "#alerts" }` without an explicit mode. When the global `cron.failureDestination` uses webhook mode, the resolver currently inherits that mode, treats `#alerts` as a webhook URL, rejects it, and silently drops the alert.

## Why This Change Was Made

`resolveFailureDestination` is the shared owner for the merged global/job route. It now treats an explicit job channel with omitted mode as announce, clears an inherited webhook URL when that implicit mode switch has no explicit job target, and continues to let a to-only override inherit a valid global webhook mode. The dispatcher still fails closed for invalid explicit webhook URLs; there is no fallback that can mask a bad URL.

The maintainer rewrite also removed inaccurate CLI provenance and reduced duplicate test setup. Contributor credit is retained for @wuqxuan and the equivalent earlier fix from @hakanbaysal in #102247.

## User Impact

Cron failure alerts configured for a channel are no longer lost merely because the global failure destination is a webhook and the job omitted its mode.

## Evidence

Exact reviewed head: `47c147df41ad3f78d2e9aa2a4c7837f0b5a3a0bb`

- Blacksmith Testbox through Crabbox `tbx_01kx4vy3fcn74s3ed1pecky4xx`: 74 focused tests passed across cron resolution, both Gateway Vitest projects, and a real Gateway `cron.add` followed by forced failed `cron.run`.
- Negative control on the same Testbox, with only `src/cron/delivery-plan.ts` restored to base `25eaa53a8ac`: four focused tests fail because neither the direct dispatcher nor the real Gateway reaches the announce helper.
- Patched behavior: announce helper called once for Slack `#alerts`; `inheritSessionThread` is false; no webhook fetch is attempted.
- Compatibility control: a to-only job override still inherits the global webhook mode and URL semantics.
- Remote `pnpm check:changed`: passed core/coreTests type checks, lint, import-cycle analysis, and repository guards.
- Fresh autoreview: clean, patch correct, confidence 0.93.
- Exact-head GitHub CI: [run 29063537211](https://github.com/openclaw/openclaw/actions/runs/29063537211) passed.

Live Slack network delivery was not performed because no explicitly authorized test destination was in scope. The Gateway integration reaches the same announce-helper boundary used by the existing cron delivery tests.

## AI disclosure

The original contribution used AI assistance. The maintainer rewrite was independently source-audited, negative-control tested, remotely validated, and autoreviewed.
