### PR TITLE
fix(ui): close session sort menu on second click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI session sorting:** close the sidebar Group by / Sort by menu when its trigger is clicked again.
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI session sorting:** close the sidebar Group by / Sort by menu when its trigger is clicked again.
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -614,16 +614,21 @@ class AppSidebar extends LitElement {
     }
   }
 
-  private openSessionSortMenu(x: number, y: number, trigger: HTMLElement | null = null) {
+  private toggleSessionSortMenu(trigger: HTMLElement) {
+    if (this.sessionSortMenuPosition) {
+      this.closeSessionSortMenu();
+      return;
+    }
     const menuWidth = 200;
     const menuMaxHeight = 280;
+    const rect = trigger.getBoundingClientRect();
     this.closeCustomizeMenu();
     this.closeSessionMenu();
     this.closeSessionGroupMenu();
     this.sessionSortMenuTrigger = trigger;
     this.sessionSortMenuPosition = {
-      x: Math.max(8, Math.min(x, window.innerWidth - menuWidth - 8)),
-      y: Math.max(8, Math.min(y, window.innerHeight - menuMaxHeight - 8)),
+      x: Math.max(8, Math.min(rect.right, window.innerWidth - menuWidth - 8)),
+      y: Math.max(8, Math.min(rect.bottom + 4, window.innerHeight - menuMaxHeight - 8)),
     };
     document.addEventListener("pointerdown", this.handleDocumentPointerDown, true);
     document.addEventListener("keydown", this.handleDocumentKeydown, true);
@@ -764,6 +769,9 @@ class AppSidebar extends LitElement {
 
   private readonly handleDocumentPointerDown = (event: PointerEvent) => {
     const path = event.composedPath();
+    if (this.sessionSortMenuTrigger && path.includes(this.sessionSortMenuTrigger)) {
+      return;
+    }
     const menu = this.querySelector(
       ".sidebar-customize-menu, .sidebar-session-menu, .sidebar-session-sort-menu",
     );
@@ -1496,8 +1504,7 @@ class AppSidebar extends LitElement {
                           aria-expanded=${String(this.sessionSortMenuPosition !== null)}
                           @click=${(event: MouseEvent) => {
                             const trigger = event.currentTarget as HTMLElement;
-                            const rect = trigger.getBoundingClientRect();
-                            this.openSessionSortMenu(rect.right, rect.bottom + 4, trigger);
+                            this.toggleSessionSortMenu(trigger);
                           }}
                         >
                           ${icons.listFilter}

--- a/ui/src/e2e/session-management.e2e.test.ts
+++ b/ui/src/e2e/session-management.e2e.test.ts
@@ -445,9 +445,16 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
       });
 
       // Group by "None" flattens the category sections into the plain list.
-      await page.getByRole("button", { name: "Sort sessions" }).click();
+      const sortSessionsButton = page.getByRole("button", { name: "Sort sessions" });
+      await sortSessionsButton.click();
       await page.getByRole("menuitemradio", { name: "None" }).waitFor({ state: "visible" });
       await captureUiProof(page, "sidebar-groupby-sort-menu.png");
+      await sortSessionsButton.click();
+      await expect.poll(() => sortSessionsButton.getAttribute("aria-expanded")).toBe("false");
+      await expect.poll(() => page.getByRole("menuitemradio", { name: "None" }).count()).toBe(0);
+      await captureUiProof(page, "sidebar-groupby-sort-menu-closed.png");
+
+      await sortSessionsButton.click();
       await page.getByRole("menuitemradio", { name: "None" }).click();
       await expect.poll(() => groups.count()).toBe(1);
       await expect.poll(() => groups.first().locator(".sidebar-recent-session").count()).toBe(3);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users clicking the sidebar session Group by / Sort by trigger a second time would see the menu remain open.

## Why This Change Was Made

The trigger now owns explicit toggle behavior while the document pointer handler treats that active trigger as part of the menu interaction. Option selection, Escape, and outside-click dismissal keep their existing behavior.

## User Impact

Users can click the session filter button once to show the menu and again to dismiss it.

AI-assisted implementation; reviewed and understood by the maintainer.

## Evidence

- Before fix: the focused browser regression failed because `aria-expanded` remained `true` after the second trigger click.
- After fix: `corepack pnpm test:ui:e2e -- ui/src/e2e/session-management.e2e.test.ts` — 4/4 passed on Blacksmith Testbox `tbx_01kx2q4mrw00wpnyy40cmy9ccb` after the final rebase.
- Visual browser proof captured and inspected both states: first click showed the menu; second click restored the sidebar with the menu gone.
- `corepack pnpm check:changed` — passed on the same Testbox.
- `corepack pnpm build` — passed on the same Testbox.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` — clean; no accepted/actionable findings.
