### PR TITLE
docs(slack): replace legacy allow:true with enabled:true in channel config examples

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -986,7 +986,7 @@ Current Slack message actions include `send`, `upload-file`, `download-file`, `r
         slack: {
           groupPolicy: "allowlist",
           channels: {
-            C12345678: { allow: true, requireMention: true },
+            C12345678: { enabled: true, requireMention: true },
           },
         },
       },
@@ -1001,7 +1001,7 @@ Current Slack message actions include `send`, `upload-file`, `download-file`, `r
         slack: {
           groupPolicy: "allowlist",
           channels: {
-            "#eng-my-channel": { allow: true, requireMention: true },
+            "#eng-my-channel": { enabled: true, requireMention: true },
           },
         },
       },


### PR DESCRIPTION
## What Problem This Solves

Two Slack channel config examples in `docs/channels/slack.md` still show the legacy `allow: true` field. The runtime was migrated to canonical `enabled: true` (per AGENTS.md: "Runtime reads canonical config only. No silent compat for old/malformed config keys"). The `allow` key is only handled by `openclaw doctor --fix`.

## Why This Change Was Made

Replace `allow: true` with `enabled: true` in two Slack channel config code examples so users following the docs use the canonical field name.

## Files Changed

| File | Change |
|------|--------|
| `docs/channels/slack.md` | 2 lines: `allow: true` → `enabled: true` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>