### PR TITLE
fix(tool-payload): enforce UTF-8 byte limits for serialized payloads

### DIFF
--- a/packages/tool-call-repair/src/payload.ts
+++ b/packages/tool-call-repair/src/payload.ts
@@ -34,6 +34,7 @@ export type PlainTextToolCallParseOptions = {
 };
 
 const DEFAULT_MAX_PLAIN_TEXT_TOOL_PAYLOAD_BYTES = 256_000;
+const utf8Encoder = new TextEncoder();
 
 type PlainTextToolCallOpening = {
   allowsOptionalXmlishClose?: boolean;
@@ -221,6 +222,15 @@ type XmlishParameterBlockBounds = {
   start: number;
 };
 
+function utf8ByteLengthExceeds(
+  text: string,
+  start: number,
+  end: number,
+  maxBytes: number,
+): boolean {
+  return end - start > maxBytes || utf8Encoder.encode(text.slice(start, end)).byteLength > maxBytes;
+}
+
 function findXmlishParameterBlock(text: string, start: number): XmlishParameterBlockBounds | null {
   const cursor = skipWhitespace(text, start);
   const openMatch = /^<parameter=([A-Za-z0-9_.:-]{1,120})>/i.exec(text.slice(cursor));
@@ -252,7 +262,7 @@ function consumeXmlishParameterBlock(
   if (!bounds) {
     return null;
   }
-  if (bounds.end - bounds.start > maxPayloadBytes) {
+  if (utf8ByteLengthExceeds(text, bounds.start, bounds.end, maxPayloadBytes)) {
     return null;
   }
   return {
@@ -344,7 +354,7 @@ function parseXmlishPlainTextToolCallBlockAt(
     if (!parameter) {
       break;
     }
-    if (parameter.end - opening.end > maxPayloadBytes) {
+    if (utf8ByteLengthExceeds(text, opening.end, parameter.end, maxPayloadBytes)) {
       return null;
     }
     args[parameter.name] = parameter.value;

--- a/packages/tool-call-repair/src/payload.ts
+++ b/packages/tool-call-repair/src/payload.ts
@@ -29,12 +29,25 @@ export type PlainTextToolCallBlock = {
 export type PlainTextToolCallParseOptions = {
   /** Optional allowlist of tool names that may be repaired. */
   allowedToolNames?: Iterable<string>;
-  /** Maximum JSON payload size accepted for one repaired call. */
+  /** Maximum serialized payload size accepted for one repaired call. */
   maxPayloadBytes?: number;
 };
 
 const DEFAULT_MAX_PLAIN_TEXT_TOOL_PAYLOAD_BYTES = 256_000;
 const utf8Encoder = new TextEncoder();
+
+function utf8ByteLengthWithinLimit(
+  text: string,
+  start: number,
+  end: number,
+  maxBytes: number,
+): number | null {
+  if (end - start > maxBytes) {
+    return null;
+  }
+  const byteLength = utf8Encoder.encode(text.slice(start, end)).byteLength;
+  return byteLength <= maxBytes ? byteLength : null;
+}
 
 type PlainTextToolCallOpening = {
   allowsOptionalXmlishClose?: boolean;
@@ -141,7 +154,7 @@ function consumeJsonObject(
     return null;
   }
   const end = findJsonObjectEnd(text, cursor, maxPayloadBytes);
-  if (end === null) {
+  if (end === null || utf8ByteLengthWithinLimit(text, cursor, end, maxPayloadBytes) === null) {
     return null;
   }
   const rawJson = text.slice(cursor, end);
@@ -222,15 +235,6 @@ type XmlishParameterBlockBounds = {
   start: number;
 };
 
-function utf8ByteLengthExceeds(
-  text: string,
-  start: number,
-  end: number,
-  maxBytes: number,
-): boolean {
-  return end - start > maxBytes || utf8Encoder.encode(text.slice(start, end)).byteLength > maxBytes;
-}
-
 function findXmlishParameterBlock(text: string, start: number): XmlishParameterBlockBounds | null {
   const cursor = skipWhitespace(text, start);
   const openMatch = /^<parameter=([A-Za-z0-9_.:-]{1,120})>/i.exec(text.slice(cursor));
@@ -257,15 +261,17 @@ function consumeXmlishParameterBlock(
   text: string,
   start: number,
   maxPayloadBytes: number,
-): { end: number; name: string; value: string } | null {
+): { byteLength: number; end: number; name: string; value: string } | null {
   const bounds = findXmlishParameterBlock(text, start);
   if (!bounds) {
     return null;
   }
-  if (utf8ByteLengthExceeds(text, bounds.start, bounds.end, maxPayloadBytes)) {
+  const byteLength = utf8ByteLengthWithinLimit(text, start, bounds.end, maxPayloadBytes);
+  if (byteLength === null) {
     return null;
   }
   return {
+    byteLength,
     end: bounds.end,
     name: bounds.name,
     value: extractXmlishParameterValue(text, bounds.payloadStart, bounds.closeStart),
@@ -349,12 +355,14 @@ function parseXmlishPlainTextToolCallBlockAt(
   const args: Record<string, unknown> = {};
   let cursor = opening.end;
   let parameterCount = 0;
+  let payloadBytes = 0;
   while (true) {
     const parameter = consumeXmlishParameterBlock(text, cursor, maxPayloadBytes);
     if (!parameter) {
       break;
     }
-    if (utf8ByteLengthExceeds(text, opening.end, parameter.end, maxPayloadBytes)) {
+    payloadBytes += parameter.byteLength;
+    if (payloadBytes > maxPayloadBytes) {
       return null;
     }
     args[parameter.name] = parameter.value;

--- a/src/plugin-sdk/tool-payload.test.ts
+++ b/src/plugin-sdk/tool-payload.test.ts
@@ -256,6 +256,20 @@ describe("parseStandalonePlainTextToolCallBlocks", () => {
     ).toBeNull();
   });
 
+  it("counts serialized JSON payload limits in UTF-8 bytes", () => {
+    const payload = JSON.stringify({ content: "é".repeat(20) });
+    const raw = ["[write]", payload, "[/write]"].join("\n");
+    expect(payload.length).toBeLessThan(48);
+    expect(new TextEncoder().encode(payload).byteLength).toBeGreaterThan(48);
+
+    expect(
+      parseStandalonePlainTextToolCallBlocks(raw, {
+        allowedToolNames: ["write"],
+        maxPayloadBytes: 48,
+      }),
+    ).toBeNull();
+  });
+
   it("respects allowed tool names for Harmony calls", () => {
     const blocks = parseStandalonePlainTextToolCallBlocks(
       'commentary to=write code {"path":"/tmp/file.txt","content":"x"}',

--- a/src/plugin-sdk/tool-payload.test.ts
+++ b/src/plugin-sdk/tool-payload.test.ts
@@ -242,6 +242,20 @@ describe("parseStandalonePlainTextToolCallBlocks", () => {
     ).toBeNull();
   });
 
+  it("counts serialized XML parameter payload limits in UTF-8 bytes", () => {
+    const parameter = ["<parameter=content>", "é".repeat(20), "</parameter>"].join("\n");
+    const raw = ["<function=write>", parameter, "</function>"].join("\n");
+    expect(parameter.length).toBeLessThan(64);
+    expect(new TextEncoder().encode(parameter).byteLength).toBeGreaterThan(64);
+
+    expect(
+      parseStandalonePlainTextToolCallBlocks(raw, {
+        allowedToolNames: ["write"],
+        maxPayloadBytes: 64,
+      }),
+    ).toBeNull();
+  });
+
   it("respects allowed tool names for Harmony calls", () => {
     const blocks = parseStandalonePlainTextToolCallBlocks(
       'commentary to=write code {"path":"/tmp/file.txt","content":"x"}',

--- a/src/plugin-sdk/tool-payload.ts
+++ b/src/plugin-sdk/tool-payload.ts
@@ -22,7 +22,7 @@ export type PlainTextToolCallBlock = {
 export type PlainTextToolCallParseOptions = {
   /** Optional allowlist of tool names that may be accepted. */
   allowedToolNames?: Iterable<string>;
-  /** Maximum JSON payload size accepted for one parsed call. */
+  /** Maximum serialized payload size accepted for one parsed call. */
   maxPayloadBytes?: number;
 };
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where plain-text tool-call repair could accept serialized JSON or XML-style payloads whose UTF-8 size exceeded `maxPayloadBytes` when their text contained multibyte characters. Both parser paths previously relied on UTF-16 code-unit counts at the acceptance boundary.

## Why This Change Was Made

The parser now applies one UTF-8 byte-length helper to both formats. JSON validates the complete serialized object after its structural scan. XML parameters report each disjoint serialized segment's byte length, allowing cumulative enforcement without repeatedly encoding the entire growing prefix.

This preserves the existing parser grammar and public option while making the documented byte limit accurate for every accepted serialization.

## User Impact

Tool-call repair consistently rejects oversized serialized tool arguments for ASCII and multibyte text, preventing over-limit payloads from being promoted into executable tool calls.

## Evidence

- Exact head: `a7db009db708fb3536c4138335e3e90653b36ad4`
- Blacksmith Testbox run: https://github.com/openclaw/openclaw/actions/runs/28998838177
  - `pnpm test src/plugin-sdk/tool-payload.test.ts`
  - 1 file, 24 tests passed.
- Real parser invocation on the exact head:

```powershell
$env:GIT_HEAD = (git rev-parse HEAD)
node --import tsx --input-type=module --eval "import { parseStandalonePlainTextToolCallBlocks } from './src/plugin-sdk/tool-payload.ts'; const parameter = ['<parameter=content>', '\u00e9'.repeat(20), '</parameter>'].join('\n'); const raw = ['<function=write>', parameter, '</function>'].join('\n'); const parserResult = parseStandalonePlainTextToolCallBlocks(raw, { allowedToolNames: ['write'], maxPayloadBytes: 64 }); const proof = { head: process.env.GIT_HEAD, command: 'parseStandalonePlainTextToolCallBlocks multibyte XML parameter', parameterUtf16Length: parameter.length, parameterUtf8Bytes: new TextEncoder().encode(parameter).byteLength, maxPayloadBytes: 64, parserResult }; console.log(JSON.stringify(proof, null, 2)); if (parserResult !== null) { process.exitCode = 1; }"
```

Output:

```json
{
  "head": "a7db009db708fb3536c4138335e3e90653b36ad4",
  "command": "parseStandalonePlainTextToolCallBlocks multibyte XML parameter",
  "parameterUtf16Length": 53,
  "parameterUtf8Bytes": 73,
  "maxPayloadBytes": 64,
  "parserResult": null
}
```

- Targeted oxfmt and `git diff --check` passed.
- Fresh uncommitted autoreview: clean, no accepted/actionable findings (`0.98`).