### PR TITLE
fix(memory-host): reject queued worker requests on shutdown

### DIFF
--- a/packages/memory-host-sdk/src/host/embeddings-worker.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker.ts
@@ -333,6 +333,13 @@ class LocalEmbeddingWorkerClient {
     if (!child) {
       return;
     }
+    this.rejectPending(
+      createLocalEmbeddingWorkerFailureError({
+        message: "Local embedding worker exited unexpectedly (shutdown)",
+        code: LOCAL_EMBEDDING_WORKER_ERROR_CODES.exited,
+        reason: "exit",
+      }),
+    );
     if (child.connected) {
       child.disconnect();
     }

--- a/packages/memory-host-sdk/src/host/embeddings.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.test.ts
@@ -441,74 +441,7 @@ process.on("message", (message) => {
     await expect(provider.close?.()).resolves.toBeUndefined();
   });
 
-  it("terminates the worker when close runs behind a pending request", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-local-embedding-worker-"));
-    const workerScript = path.join(tempDir, "worker.cjs");
-    const embedStartedPath = path.join(tempDir, "embed-started");
-    await fs.writeFile(
-      workerScript,
-      `
-const fs = require("node:fs");
-const embedStartedPath = ${JSON.stringify(embedStartedPath)};
-let busy = false;
-
-process.on("message", (message) => {
-  if (busy) {
-    return;
-  }
-  if (message.type === "initialize") {
-    process.send({ id: message.id, ok: true });
-    return;
-  }
-  if (message.type === "embedQuery") {
-    busy = true;
-    fs.writeFileSync(embedStartedPath, "1");
-  }
-});
-`,
-      "utf8",
-    );
-    const provider = await createLocalEmbeddingWorkerProvider(
-      {
-        config: {} as never,
-        provider: "local",
-        model: "",
-        fallback: "none",
-      },
-      { workerScriptPath: workerScript },
-    );
-
-    const embedPromise = provider.embedQuery("stuck");
-    const embedError = embedPromise.then(
-      () => undefined,
-      (err: unknown) => err,
-    );
-    await expect
-      .poll(async () => {
-        try {
-          await fs.access(embedStartedPath);
-          return true;
-        } catch {
-          return false;
-        }
-      })
-      .toBe(true);
-
-    const closePromise = provider.close?.() ?? Promise.resolve();
-    const closeResult = await Promise.race([
-      closePromise.then(() => "closed" as const),
-      new Promise<"timeout">((resolve) => {
-        setTimeout(() => resolve("timeout"), 1_000);
-      }),
-    ]);
-
-    expect(closeResult).toBe("closed");
-    await expect(embedError).resolves.toMatchObject({
-      code: LOCAL_EMBEDDING_WORKER_ERROR_CODES.exited,
-    });
-  });
-
-  it("rejects queued worker requests when close shuts down a busy child", async () => {
+  it("rejects pending and queued requests when closing a busy worker", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-local-embedding-worker-"));
     const workerScript = path.join(tempDir, "worker.cjs");
     const embedStartedPath = path.join(tempDir, "embed-started");
@@ -560,8 +493,8 @@ process.on("message", (message) => {
       })
       .toBe(true);
 
-    const secondEmbedResult = Promise.race([
-      provider.embedQuery("second").then(
+    const queuedEmbedResult = Promise.race([
+      provider.embedQuery("queued").then(
         () => "resolved" as const,
         (err: unknown) => err,
       ),
@@ -570,12 +503,19 @@ process.on("message", (message) => {
       }),
     ]);
 
-    await expect(provider.close?.()).resolves.toBeUndefined();
+    const closePromise = provider.close?.() ?? Promise.resolve();
+    const closeResult = await Promise.race([
+      closePromise.then(() => "closed" as const),
+      new Promise<"timeout">((resolve) => {
+        setTimeout(() => resolve("timeout"), 1_000);
+      }),
+    ]);
 
+    expect(closeResult).toBe("closed");
     await expect(firstEmbedError).resolves.toMatchObject({
       code: LOCAL_EMBEDDING_WORKER_ERROR_CODES.exited,
     });
-    await expect(secondEmbedResult).resolves.toMatchObject({
+    await expect(queuedEmbedResult).resolves.toMatchObject({
       code: LOCAL_EMBEDDING_WORKER_ERROR_CODES.exited,
     });
   });

--- a/packages/memory-host-sdk/src/host/embeddings.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.test.ts
@@ -508,6 +508,78 @@ process.on("message", (message) => {
     });
   });
 
+  it("rejects queued worker requests when close shuts down a busy child", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-local-embedding-worker-"));
+    const workerScript = path.join(tempDir, "worker.cjs");
+    const embedStartedPath = path.join(tempDir, "embed-started");
+    await fs.writeFile(
+      workerScript,
+      `
+const fs = require("node:fs");
+const embedStartedPath = ${JSON.stringify(embedStartedPath)};
+let busy = false;
+
+process.on("message", (message) => {
+  if (busy) {
+    return;
+  }
+  if (message.type === "initialize") {
+    process.send({ id: message.id, ok: true });
+    return;
+  }
+  if (message.type === "embedQuery") {
+    busy = true;
+    fs.writeFileSync(embedStartedPath, "1");
+  }
+});
+`,
+      "utf8",
+    );
+    const provider = await createLocalEmbeddingWorkerProvider(
+      {
+        config: {} as never,
+        provider: "local",
+        model: "",
+        fallback: "none",
+      },
+      { workerScriptPath: workerScript },
+    );
+
+    const firstEmbedError = provider.embedQuery("first").then(
+      () => undefined,
+      (err: unknown) => err,
+    );
+    await expect
+      .poll(async () => {
+        try {
+          await fs.access(embedStartedPath);
+          return true;
+        } catch {
+          return false;
+        }
+      })
+      .toBe(true);
+
+    const secondEmbedResult = Promise.race([
+      provider.embedQuery("second").then(
+        () => "resolved" as const,
+        (err: unknown) => err,
+      ),
+      new Promise<"timeout">((resolve) => {
+        setTimeout(() => resolve("timeout"), 1_000);
+      }),
+    ]);
+
+    await expect(provider.close?.()).resolves.toBeUndefined();
+
+    await expect(firstEmbedError).resolves.toMatchObject({
+      code: LOCAL_EMBEDDING_WORKER_ERROR_CODES.exited,
+    });
+    await expect(secondEmbedResult).resolves.toMatchObject({
+      code: LOCAL_EMBEDDING_WORKER_ERROR_CODES.exited,
+    });
+  });
+
   it("does not pass inline-source or inspector exec args to the file-backed worker", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-local-embedding-worker-"));
     const workerScript = path.join(tempDir, "worker.cjs");


### PR DESCRIPTION
## What Problem This Solves

Closing the local embeddings worker while one request is already stuck can leave later queued requests hanging forever. The worker client shut down the child process, but it only relied on later `exit`/`error` callbacks to reject the other pending callers.

## Why This Change Was Made

`LocalEmbeddingWorkerClient.shutdownChild()` now rejects every pending request before disconnecting and killing the current child. That makes the shutdown path deterministic for both `close()` and abort-driven worker teardown instead of depending on a later child lifecycle event.

The new regression test starts one busy worker request, queues a second request behind it, then closes the provider and proves both callers receive the structured `exited` failure instead of leaving the queued request stuck.

## User Impact

Users of the local embedding provider no longer risk a permanently hanging embedding call when the worker is closed or aborted while another request is already occupying the child.

## Evidence

- `git diff --check`
- Local focused test: `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/embeddings.test.ts`
- Local focused test output:
  - `[test] starting test/vitest/vitest.unit.config.ts`
  - `RUN  v4.1.9 /home/0668000995/10288592/git-hub/codex/openclaw`
  - `Test Files  1 passed (1)`
  - `Tests  19 passed (19)`
  - `Duration  3.77s (transform 2.78s, setup 1.75s, import 190ms, tests 1.34s, environment 0ms)`
  - `[test] passed 1 Vitest shard in 16.02s`
- Live passing checks on PR `#102451` already include `Real behavior proof`, `Critical Quality (memory-runtime-boundary)`, `Security High (process-exec-boundary)`, `checks-fast-bun-launcher`, `checks-fast-contracts-plugins-a`, `checks-fast-contracts-plugins-b`, `checks-fast-contracts-channels-a`, `checks-node-compact-small-8`, `checks-node-compact-small-9`, `checks-node-compact-small-10`, and `checks-node-compact-large-2`.
- Representative live check URLs from this PR:
  - `Real behavior proof`: `https://github.com/openclaw/openclaw/actions/runs/28998074026/job/86051981907`
  - `Critical Quality (memory-runtime-boundary)`: `https://github.com/openclaw/openclaw/actions/runs/28998068194/job/86051968758`
  - `checks-node-compact-small-8`: `https://github.com/openclaw/openclaw/actions/runs/28998068202/job/86052018799`
