### PR TITLE
docs(multi-agent): replace legacy allow:true with enabled:true

### DIFF
--- a/docs/concepts/multi-agent.md
+++ b/docs/concepts/multi-agent.md
@@ -246,7 +246,7 @@ Channels supporting multiple accounts: `discord`, `feishu`, `googlechat`, `imess
               guilds: {
                 "123456789012345678": {
                   channels: {
-                    "222222222222222222": { allow: true, requireMention: false },
+                    "222222222222222222": { enabled: true, requireMention: false },
                   },
                 },
               },
@@ -256,7 +256,7 @@ Channels supporting multiple accounts: `discord`, `feishu`, `googlechat`, `imess
               guilds: {
                 "123456789012345678": {
                   channels: {
-                    "333333333333333333": { allow: true, requireMention: false },
+                    "333333333333333333": { enabled: true, requireMention: false },
                   },
                 },
               },


### PR DESCRIPTION
## What Problem This Solves

Two Discord channel config examples in docs/concepts/multi-agent.md still show the legacy allow: true field instead of the canonical enabled: true.

## Files Changed

| File | Change |
|------|--------|
| docs/concepts/multi-agent.md | 2 lines: allow: true → enabled: true |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>