### PR TITLE
docs(config-channels): replace legacy allow:true with enabled:true

### DIFF
--- a/docs/gateway/config-channels.md
+++ b/docs/gateway/config-channels.md
@@ -277,9 +277,9 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
           reactionNotifications: "own",
           users: ["987654321098765432"],
           channels: {
-            general: { allow: true },
+            general: { enabled: true },
             help: {
-              allow: true,
+              enabled: true,
               requireMention: true,
               users: ["987654321098765432"],
               skills: ["docs"],
@@ -409,7 +409,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
       },
       groupPolicy: "allowlist",
       groups: {
-        "spaces/AAAA": { allow: true, requireMention: true },
+        "spaces/AAAA": { enabled: true, requireMention: true },
       },
       actions: { reactions: true },
       typingIndicator: "message",
@@ -443,9 +443,9 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
       allowFrom: ["U123", "U456", "*"],
       dm: { enabled: true, groupEnabled: false, groupChannels: ["G123"] },
       channels: {
-        C123: { allow: true, requireMention: true, allowBots: false },
+        C123: { enabled: true, requireMention: true, allowBots: false },
         "#general": {
-          allow: true,
+          enabled: true,
           requireMention: true,
           allowBots: false,
           users: ["U123"],


### PR DESCRIPTION
## What Problem This Solves

Five channel config examples across Discord, GoogleChat, and Slack sections in docs/gateway/config-channels.md still show the legacy allow: true field instead of the canonical enabled: true.

## Files Changed

| File | Change |
|------|--------|
| docs/gateway/config-channels.md | 5 lines: allow: true → enabled: true (Discord x2, GoogleChat x1, Slack x2) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>