### PR TITLE
chore(ui): guard one-button theme mode cycle

### DIFF
--- a/ui/src/components/theme-mode-toggle.browser.test.ts
+++ b/ui/src/components/theme-mode-toggle.browser.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import type { ThemeMode } from "../app/theme.ts";
+import type { ThemeModeChangeDetail } from "./theme-mode-toggle.ts";
+import "./theme-mode-toggle.ts";
+
+type ThemeModeToggleElement = HTMLElement & {
+  mode: ThemeMode;
+  updateComplete: Promise<boolean>;
+};
+
+describe("theme mode toggle", () => {
+  it("defaults to system and cycles one button through every mode", async () => {
+    const toggle = document.createElement("openclaw-theme-mode-toggle") as ThemeModeToggleElement;
+    const modes: ThemeMode[] = [];
+    toggle.addEventListener("theme-change", ((event: CustomEvent<ThemeModeChangeDetail>) => {
+      modes.push(event.detail.mode);
+      toggle.mode = event.detail.mode;
+    }) as EventListener);
+    document.body.append(toggle);
+
+    try {
+      await toggle.updateComplete;
+      expect(toggle.mode).toBe("system");
+      expect(toggle.querySelectorAll("button")).toHaveLength(1);
+      expect(toggle.querySelector("button")?.getAttribute("aria-label")).toBe("Color mode: System");
+
+      for (const expected of ["light", "dark", "system"] satisfies ThemeMode[]) {
+        toggle.querySelector<HTMLButtonElement>("button")?.click();
+        await toggle.updateComplete;
+        expect(toggle.mode).toBe(expected);
+        expect(toggle.querySelectorAll("button")).toHaveLength(1);
+      }
+
+      expect(modes).toEqual(["light", "dark", "system"]);
+      expect(toggle.querySelector("button")?.getAttribute("aria-label")).toBe("Color mode: System");
+    } finally {
+      toggle.remove();
+    }
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The Control UI's one-button color-mode cycle was restored by #101017, but the component had no focused regression coverage. A later UI refactor could silently bring back the three-button selector or break the `System → Light → Dark → System` sequence.

## Why This Change Was Made

Adds a focused browser test for the existing theme-mode component. The test requires a single button, the `System` default, the full three-state cycle, emitted mode changes, and the restored accessible label.

## User Impact

No runtime behavior changes. This protects the current compact one-button theme control from regressing.

## Evidence

- Blacksmith Testbox through Crabbox `tbx_01kx2qmfxbd656fgxphbghmj4x`: `corepack pnpm test ui/src/components/theme-mode-toggle.browser.test.ts` — 1 test passed.
- Same Testbox: `pnpm check:changed` — core test typecheck, lint, and guards passed.
- Existing-profile Chrome against the deterministic Control UI mock: one `Color mode` button; clean default `System`; clicks produced `Light → Dark → System`; refresh preserved `Light`.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` — clean, no accepted/actionable findings.
