### PR TITLE
fix(session-tools): file_path aliases fail for file tools

### DIFF
--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -243,6 +243,23 @@ describe("edit tool", () => {
     await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("after\n");
   });
 
+  it("normalizes file_path aliases before applying edits", async () => {
+    await createTempFile("before\n");
+    const tool = createEditTool(tmpDir);
+    const prepared = tool.prepareArguments?.({
+      file_path: "demo.txt",
+      edits: [{ oldText: "before", newText: "after" }],
+    });
+
+    expect(prepared).toEqual({
+      path: "demo.txt",
+      edits: [{ oldText: "before", newText: "after" }],
+    });
+    expect(Value.Check(tool.parameters, prepared)).toBe(true);
+    await tool.execute("call-file-path", prepared as never, undefined);
+    await expect(fs.readFile(path.join(tmpDir, "demo.txt"), "utf-8")).resolves.toBe("after\n");
+  });
+
   it("renders previews through custom edit operations", async () => {
     // Preview rendering must use injected operations so remote/sandbox files are
     // shown without accidentally reading from the host filesystem.
@@ -275,7 +292,7 @@ describe("edit tool", () => {
     const component = tool.renderCall?.(args, testTheme, context);
     await vi.waitFor(() => expect(context.invalidate).toHaveBeenCalled());
 
-    expect(readFile).toHaveBeenCalledWith(path.join("/workspace", "remote.txt"));
+    expect(readFile).toHaveBeenCalledWith(path.resolve("/workspace", "remote.txt"));
     expect((component as { preview?: { diff?: string } } | undefined)?.preview?.diff).toContain(
       "remote changed",
     );

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -72,6 +72,7 @@ const editSchema = Type.Object(
 export type { EditToolDetails, EditToolInput } from "./tool-contracts.js";
 
 type LegacyEditToolInput = Record<string, unknown> & {
+  file_path?: unknown;
   edits?: unknown;
   oldText?: unknown;
   newText?: unknown;
@@ -110,6 +111,11 @@ function prepareEditArguments(input: unknown): EditToolInput {
   }
 
   const args = { ...(input as Record<string, unknown>) };
+  const legacyPath = typeof args.file_path === "string" ? args.file_path : undefined;
+  if (typeof args.path !== "string" && legacyPath) {
+    args.path = legacyPath;
+  }
+  delete args.file_path;
 
   // Some models (Opus 4.6, GLM-5.1) send edits as a JSON string instead of an array
   if (typeof args.edits === "string") {

--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -103,6 +103,25 @@ describe("read tool", () => {
     );
   });
 
+  it("normalizes file_path aliases before reading files", async () => {
+    const tempDir = tempDirs.make("openclaw-read-file-path-");
+    await fs.writeFile(path.join(tempDir, "notes.txt"), "alpha\nbeta", "utf-8");
+    decodeWindowsTextFileBufferMock.mockReturnValueOnce("alpha\nbeta");
+    const tool = createReadToolDefinition(tempDir);
+    const prepared = tool.prepareArguments?.({ file_path: "notes.txt", limit: 1 });
+
+    expect(prepared).toEqual({ path: "notes.txt", limit: 1 });
+    const result = await tool.execute(
+      "call-file-path",
+      prepared as never,
+      undefined,
+      undefined,
+      {} as never,
+    );
+
+    expect(textContent(result)).toBe("alpha\n\n[1 more lines in file. Use offset=2 to continue.]");
+  });
+
   it("shell-quotes the long-first-line fallback path", async () => {
     // The fallback command is shown to the model; quote the path so suggested
     // follow-up commands cannot execute path text as shell syntax.
@@ -214,6 +233,6 @@ describe("read tool", () => {
     );
 
     expect(decodeWindowsTextFileBufferMock).not.toHaveBeenCalled();
-    expect(textContent(result)).toBe("/workspace/legacy.txt:c4e3bac3");
+    expect(textContent(result)).toBe(`${path.resolve("/workspace", "legacy.txt")}:c4e3bac3`);
   });
 });

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -32,7 +32,7 @@ import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/type
 import { normalizePositiveLimit } from "./limits.js";
 import { resolveReadPath } from "./path-utils.js";
 import { getTextOutput, invalidArgText, replaceTabs, shortenPath, str } from "./render-utils.js";
-import type { ReadToolDetails } from "./tool-contracts.js";
+import type { ReadToolDetails, ReadToolInput } from "./tool-contracts.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateHead } from "./truncate.js";
 
@@ -85,6 +85,19 @@ export interface ReadToolOptions {
 }
 
 type ReadRenderArgs = { path?: string; file_path?: string; offset?: number; limit?: number };
+
+function prepareReadArguments(input: unknown): ReadToolInput {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return input as ReadToolInput;
+  }
+  const args = input as Record<string, unknown>;
+  if (typeof args.path === "string" || typeof args.file_path !== "string") {
+    return input as ReadToolInput;
+  }
+  const { file_path, ...rest } = args;
+  void file_path;
+  return { ...rest, path: args.file_path } as ReadToolInput;
+}
 
 function formatReadLineRange(args: ReadRenderArgs | undefined, theme: Theme): string {
   if (args?.offset === undefined && args?.limit === undefined) {
@@ -263,6 +276,7 @@ export function createReadToolDefinition(
     promptSnippet: "Read file contents",
     promptGuidelines: ["Use read to examine files instead of cat or sed."],
     parameters: readSchema,
+    prepareArguments: prepareReadArguments,
     async execute(
       toolCallId,
       { path, offset, limit }: { path: string; offset?: number; limit?: number },

--- a/src/agents/sessions/tools/write.test.ts
+++ b/src/agents/sessions/tools/write.test.ts
@@ -123,6 +123,17 @@ describe("write tool", () => {
     await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("finished\n");
   });
 
+  it("normalizes file_path aliases before writing files", async () => {
+    await createTempPath("placeholder.txt");
+    const tool = createWriteTool(tmpDir);
+    const prepared = tool.prepareArguments?.({ file_path: "alias.txt", content: "finished\n" });
+
+    expect(prepared).toEqual({ path: "alias.txt", content: "finished\n" });
+    await tool.execute("call-file-path", prepared as never, undefined);
+
+    await expect(fs.readFile(path.join(tmpDir, "alias.txt"), "utf-8")).resolves.toBe("finished\n");
+  });
+
   it("returns terminal no-op when writing identical content to existing file", async () => {
     const filePath = await createTempPath("identical.txt");
     await fs.writeFile(filePath, "hello\n", "utf-8");

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -26,6 +26,7 @@ import {
   shortenPath,
   str,
 } from "./render-utils.js";
+import type { WriteToolInput } from "./tool-contracts.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 
 const writeSchema = Type.Object({
@@ -112,6 +113,19 @@ class WriteCallRenderComponent extends Text {
 }
 
 const WRITE_PARTIAL_FULL_HIGHLIGHT_LINES = 50;
+
+function prepareWriteArguments(input: unknown): WriteToolInput {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return input as WriteToolInput;
+  }
+  const args = input as Record<string, unknown>;
+  if (typeof args.path === "string" || typeof args.file_path !== "string") {
+    return input as WriteToolInput;
+  }
+  const { file_path, ...rest } = args;
+  void file_path;
+  return { ...rest, path: args.file_path } as WriteToolInput;
+}
 
 function highlightSingleLine(line: string, lang: string): string {
   const highlighted = highlightCode(line, lang);
@@ -390,6 +404,7 @@ export function createWriteToolDefinition(
     promptSnippet: "Create or overwrite files",
     promptGuidelines: ["Use write only for new files or complete rewrites."],
     parameters: writeSchema,
+    prepareArguments: prepareWriteArguments,
     async execute(
       toolCallId,
       { path, content }: { path: string; content: string },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agent session file tools would reject model-emitted `file_path` arguments even though the tool renderers already recognized that alias for read, write, and edit operations.

## Why This Change Was Made

The read, write, and edit session tools now normalize `file_path` to the canonical `path` argument during argument preparation before schema validation and execution. The change stays within the existing session file tool boundary and keeps `path` as the canonical runtime field.

## User Impact

Agents can recover from `file_path` file-tool arguments consistently across read, write, and edit instead of surfacing avoidable argument-validation errors.

## Evidence

- Claim proved: at current head `d8fe84d5ec4003f4652f46b65be4d56837f79e13`, the session read, write, and edit runtime tools accept `file_path`-only raw arguments, prepare them into canonical `path` arguments before schema validation, pass runtime validation, execute the operation, and verify the resulting file content/readback.
- Real behavior proof: `corepack pnpm exec tsx .agents/tmp/prove-session-file-path.ts` ran a temporary redacted runtime harness that imported the real `createReadTool`, `createWriteTool`, `createEditTool`, and agent-core `validateToolArguments` path, then executed each tool against a temp workspace.

```text
OpenClaw session file_path proof
head: d8fe84d5ec4003f4652f46b65be4d56837f79e13
proof workspace: <redacted temp dir>

[read]
raw arguments: {"file_path":"read-target.txt","limit":2}
prepared arguments: {"limit":2,"path":"read-target.txt"}
schema validation: passed
execute result: "read proof line 1\nread proof line 2\n\n[1 more lines in file. Use offset=3 to continue.]"

[write]
raw arguments: {"file_path":"created-by-file-path.txt","content":"written via file_path\n"}
prepared arguments: {"content":"written via file_path\n","path":"created-by-file-path.txt"}
schema validation: passed
execute result: "Successfully wrote 22 bytes to created-by-file-path.txt; disk=\"written via file_path\\n\""

[edit]
raw arguments: {"file_path":"edit-target.txt","edits":[{"oldText":"before edit","newText":"after edit"}]}
prepared arguments: {"path":"edit-target.txt","edits":[{"oldText":"before edit","newText":"after edit"}]}
schema validation: passed
execute result: "Successfully replaced 1 block(s) in edit-target.txt.; disk=\"after edit\\nkeep line\\n\""

summary: read/write/edit all accepted file_path-only input, prepared path, passed schema validation, executed, and verified disk/readback output.
```

- Focused regression proof: `node scripts/run-vitest.mjs src/agents/sessions/tools/read.test.ts src/agents/sessions/tools/write.test.ts src/agents/sessions/tools/edit.test.ts` passed with 3 files and 39 tests.
- Committed diff hygiene: `git diff --check HEAD~1..HEAD` passed.
- Review proof: `python .agents\skills\autoreview\scripts\autoreview --mode commit --commit HEAD` passed with no accepted/actionable findings.