### PR TITLE
fix(cron): suppress same-target failure notice after partial announce delivery

### DIFF
--- a/src/cron/delivery.failure-notify.test.ts
+++ b/src/cron/delivery.failure-notify.test.ts
@@ -37,7 +37,8 @@ vi.mock("../logging.js", () => ({
   })),
 }));
 
-const { sendFailureNotificationAnnounce } = await import("./delivery.js");
+const { sendCronAnnouncePayloadStrict, sendFailureNotificationAnnounce } =
+  await import("./delivery.js");
 
 type DeliveryRequest = {
   abortSignal?: unknown;
@@ -226,5 +227,102 @@ describe("sendFailureNotificationAnnounce", () => {
     expect(warnMeta.channel).toBe("telegram");
     expect(warnMeta.to).toBe("123");
     expect(warnMessage).toBe("cron: failure destination announce failed");
+  });
+
+  it("logs partial delivery of the failure notice without failing", async () => {
+    mocks.deliverOutboundPayloads.mockImplementation(
+      async (params: { onPayloadDeliveryOutcome?: (outcome: unknown) => void }) => {
+        params.onPayloadDeliveryOutcome?.({
+          index: 0,
+          status: "failed",
+          error: new Error("chunk 2 send failed"),
+          sentBeforeError: true,
+          stage: "platform_send",
+        });
+        return [{ ok: true }];
+      },
+    );
+
+    await expect(
+      sendFailureNotificationAnnounce(
+        {} as never,
+        {} as never,
+        "main",
+        "job-1",
+        { channel: "telegram", to: "123" },
+        "Cron failed",
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(mocks.warn).toHaveBeenCalledTimes(1);
+    const [warnMeta, warnMessage] = firstWarnCall();
+    expect(warnMeta.err).toBe("chunk 2 send failed");
+    expect(warnMessage).toBe("cron: failure destination announce partially failed");
+  });
+});
+
+describe("sendCronAnnouncePayloadStrict", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveDeliveryTarget.mockResolvedValue({
+      ok: true,
+      channel: "slack",
+      to: "C123",
+      mode: "explicit",
+    });
+    mocks.deliverOutboundPayloads.mockResolvedValue([{ ok: true }]);
+  });
+
+  const sendStrict = () =>
+    sendCronAnnouncePayloadStrict({
+      deps: {} as never,
+      cfg: {} as never,
+      agentId: "main",
+      jobId: "job-1",
+      target: { channel: "slack", to: "C123" },
+      message: "weekly report",
+      abortSignal: new AbortController().signal,
+    });
+
+  it("returns sent when delivery fully succeeds", async () => {
+    await expect(sendStrict()).resolves.toEqual({ status: "sent" });
+  });
+
+  it("returns a partial_failed outcome instead of throwing when content reached the target", async () => {
+    mocks.deliverOutboundPayloads.mockImplementation(
+      async (params: { onPayloadDeliveryOutcome?: (outcome: unknown) => void }) => {
+        params.onPayloadDeliveryOutcome?.({
+          index: 0,
+          status: "failed",
+          error: new Error("chunk 2 send failed"),
+          sentBeforeError: true,
+          stage: "platform_send",
+        });
+        return [{ ok: true }];
+      },
+    );
+
+    const outcome = await sendStrict();
+    expect(outcome.status).toBe("partial_failed");
+    if (outcome.status === "partial_failed") {
+      expect(String(outcome.error)).toContain("chunk 2 send failed");
+    }
+  });
+
+  it("throws when nothing reached the target", async () => {
+    mocks.deliverOutboundPayloads.mockImplementation(
+      async (params: { onPayloadDeliveryOutcome?: (outcome: unknown) => void }) => {
+        params.onPayloadDeliveryOutcome?.({
+          index: 0,
+          status: "failed",
+          error: new Error("send failed"),
+          sentBeforeError: false,
+          stage: "platform_send",
+        });
+        return [];
+      },
+    );
+
+    await expect(sendStrict()).rejects.toThrow("send failed");
   });
 });

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -43,6 +43,15 @@ export type CronAnnounceTarget = {
 
 type SuccessfulDeliveryTarget = Extract<DeliveryTargetResolution, { ok: true }>;
 
+/**
+ * Closed outcome for strict announce sends: `partial_failed` means visible
+ * content reached the target before the send error, so callers must not treat
+ * the target as un-notified (e.g. by re-announcing a failure there).
+ */
+export type CronAnnounceSendOutcome =
+  | { status: "sent" }
+  | { status: "partial_failed"; error: unknown };
+
 async function resolveCronAnnounceDelivery(params: {
   cfg: OpenClawConfig;
   agentId: string;
@@ -105,9 +114,9 @@ async function deliverCronAnnouncePayload(params: {
   };
   message: string;
   abortSignal: AbortSignal;
-}): Promise<void> {
-  // Cron delivery is durable and non-best-effort for primary announces; partial
-  // channel failure must surface as a cron run failure.
+}): Promise<CronAnnounceSendOutcome> {
+  // Cron delivery is durable and non-best-effort for primary announces; a send
+  // where nothing reached the target must surface as a cron run failure.
   const send = await sendDurableMessageBatch({
     cfg: params.cfg,
     channel: params.delivery.resolvedTarget.channel,
@@ -121,12 +130,20 @@ async function deliverCronAnnouncePayload(params: {
     deps: createOutboundSendDeps(params.deps),
     signal: params.abortSignal,
   });
-  if (send.status === "failed" || send.status === "partial_failed") {
+  if (send.status === "failed") {
     throw send.error;
   }
+  if (send.status === "partial_failed") {
+    return { status: "partial_failed", error: send.error };
+  }
+  return { status: "sent" };
 }
 
-/** Sends a cron announce payload and throws if target resolution or delivery fails. */
+/**
+ * Sends a cron announce payload. Throws when target resolution fails or when
+ * nothing reached the target; partial delivery returns a closed outcome so
+ * callers can surface the error without re-announcing to the same target.
+ */
 export async function sendCronAnnouncePayloadStrict(params: {
   deps: CliDeps;
   cfg: OpenClawConfig;
@@ -135,12 +152,12 @@ export async function sendCronAnnouncePayloadStrict(params: {
   target: CronAnnounceTarget;
   message: string;
   abortSignal: AbortSignal;
-}): Promise<void> {
+}): Promise<CronAnnounceSendOutcome> {
   const delivery = await resolveCronAnnounceDelivery(params);
   if (!delivery.ok) {
     throw delivery.error;
   }
-  await deliverCronAnnouncePayload({
+  return await deliverCronAnnouncePayload({
     deps: params.deps,
     cfg: params.cfg,
     delivery,
@@ -177,13 +194,24 @@ export async function sendFailureNotificationAnnounce(
   }, FAILURE_NOTIFICATION_TIMEOUT_MS);
 
   try {
-    await deliverCronAnnouncePayload({
+    const outcome = await deliverCronAnnouncePayload({
       deps,
       cfg,
       delivery,
       message,
       abortSignal: abortController.signal,
     });
+    if (outcome.status === "partial_failed") {
+      // The notice reached the target; log the partial error instead of failing.
+      cronDeliveryLogger.warn(
+        {
+          err: formatErrorMessage(outcome.error),
+          channel: delivery.resolvedTarget.channel,
+          to: delivery.resolvedTarget.to,
+        },
+        "cron: failure destination announce partially failed",
+      );
+    }
   } catch (err) {
     cronDeliveryLogger.warn(
       {

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -158,6 +158,8 @@ export type DispatchCronDeliveryState = {
   result?: RunCronAgentTurnResult;
   delivered: boolean;
   deliveryAttempted: boolean;
+  /** A failed direct delivery still sent visible content to the target first. */
+  sentBeforeError: boolean;
   cronRunSessionCleanupAttempted: boolean;
   summary?: string;
   outputText?: string;
@@ -1006,12 +1008,14 @@ export async function dispatchCronDelivery(
 
   let delivered = verifiedMessageToolDelivery;
   let deliveryAttempted = verifiedMessageToolDelivery;
+  let sentBeforeError = false;
   let directCronSessionCleanupAttempted = false;
   let deferredDeletingSessionMirror: DirectCronTranscriptMirror | undefined;
   const buildDeliveryState = (result?: RunCronAgentTurnResult): DispatchCronDeliveryState => ({
     ...(result ? { result } : {}),
     delivered,
     deliveryAttempted,
+    sentBeforeError,
     cronRunSessionCleanupAttempted: directCronSessionCleanupAttempted,
     summary,
     outputText,
@@ -1193,7 +1197,6 @@ export async function dispatchCronDelivery(
       // Track bestEffort partial failures so we can log them and avoid
       // marking the job as delivered when payloads were silently dropped.
       let hadPartialFailure = false;
-      let partialDeliverySucceededBeforeFailure = false;
       // `onPayload` fires after send hooks render the outbound payload, but before
       // platform send. The mirror only consumes this array after full delivery succeeds.
       const attemptedPayloadsForMirror: NormalizedOutboundPayload[] = [];
@@ -1236,7 +1239,9 @@ export async function dispatchCronDelivery(
           throw send.error;
         }
         if (send.status === "partial_failed") {
-          partialDeliverySucceededBeforeFailure = send.results.length > 0;
+          // partial_failed implies some platform results exist: visible content
+          // reached the target before the error (durable send contract).
+          sentBeforeError = send.results.length > 0;
           if (!params.deliveryBestEffort) {
             throw send.error;
           }
@@ -1260,7 +1265,7 @@ export async function dispatchCronDelivery(
           to: delivery.to,
           threadId: stringifyRouteThreadId(delivery.threadId),
           error: err,
-          partialDelivered: partialDeliverySucceededBeforeFailure,
+          partialDelivered: sentBeforeError,
         });
         await queueCronAwarenessSystemEvent({
           cfg: params.cfgWithAgentDefaults,

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -662,6 +662,7 @@ function resetRunOutcomeMocks(): void {
           !sourceDeliveryOutcome?.satisfiesSourceDelivery &&
           resolvedDelivery.ok),
       ),
+      sentBeforeError: false,
       cronRunSessionCleanupAttempted: false,
       summary,
       outputText,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -302,6 +302,7 @@ function buildCronDeliveryTrace(params: {
   sourceDeliveryOutcome: SourceDeliveryOutcome;
   fallbackUsed: boolean;
   delivered: boolean;
+  sentBeforeError?: boolean;
 }): CronDeliveryTrace {
   // Trace both intended and resolved targets so run logs can explain fallback
   // delivery without leaking provider-specific raw routing internals.
@@ -327,6 +328,9 @@ function buildCronDeliveryTrace(params: {
     ...(messageToolSentTo.length > 0 ? { messageToolSentTo } : {}),
     fallbackUsed: params.fallbackUsed,
     delivered: params.delivered,
+    // Only meaningful for failed deliveries: a later retry that fully delivers
+    // clears the run error, so the flag would be stale audit noise there.
+    ...(params.sentBeforeError && !params.delivered ? { sentBeforeError: true } : {}),
   };
 }
 
@@ -1395,6 +1399,7 @@ async function finalizeCronRun(params: {
       deliveryResult.deliveryAttempted &&
       !sourceDeliveryOutcome.satisfiesSourceDelivery,
     delivered: deliveryResult.delivered,
+    sentBeforeError: deliveryResult.sentBeforeError,
   });
   if (deliveryResult.result) {
     const resultWithDeliveryMeta: RunCronAgentTurnResult = {

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -1149,6 +1149,7 @@ async function finishPreparedManualRun(
             error: coreResult.error,
             diagnostics: coreResult.diagnostics,
             delivered: coreResult.delivered,
+            sentBeforeError: coreResult.delivery?.sentBeforeError,
             provider: coreResult.provider,
             startedAt,
             endedAt,

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -116,6 +116,7 @@ type TimedCronRunOutcome = CronRunOutcome &
     taskRunId?: string;
     delivered?: boolean;
     deliveryAttempted?: boolean;
+    delivery?: CronDeliveryTrace;
     isolatedAgentSetupTimeout?: IsolatedAgentSetupTimeoutSignal;
     activeJobMarker?: CronActiveJobMarker;
     startedAt: number;
@@ -620,6 +621,8 @@ function resolveDeliveryState(params: {
   job: CronJob;
   runStatus: CronRunStatus;
   delivered?: boolean;
+  /** Announce sent visible content before erroring; see CronDeliveryTrace.sentBeforeError. */
+  sentBeforeError?: boolean;
   error?: string;
   globalFailureDestination?: CronConfig["failureDestination"];
 }): {
@@ -656,6 +659,9 @@ function resolveDeliveryState(params: {
           : { delivered: true, status: "delivered" },
       };
     }
+    // A partially delivered announce suppresses the same-target failure notice
+    // (dispatchCronFailureDestinationNotifications), so without an alternate
+    // destination no failure notification is requested for this run.
     if (params.delivered === false) {
       return {
         delivered: false,
@@ -663,17 +669,22 @@ function resolveDeliveryState(params: {
         error: params.error,
         failureNotification: alternateFailureNotificationRequested
           ? failureNotification
-          : {
-              delivered: false,
-              status: "not-delivered",
-              ...(params.error ? { error: params.error } : {}),
-            },
+          : params.sentBeforeError
+            ? { status: "not-requested" }
+            : {
+                delivered: false,
+                status: "not-delivered",
+                ...(params.error ? { error: params.error } : {}),
+              },
       };
     }
     return {
       status: "unknown",
       error: params.error,
-      failureNotification: { status: "unknown" },
+      failureNotification:
+        params.sentBeforeError && !alternateFailureNotificationRequested
+          ? { status: "not-requested" }
+          : { status: "unknown" },
     };
   }
   if (params.delivered === true) {
@@ -703,6 +714,7 @@ export function applyJobResult(
     error?: string;
     diagnostics?: CronRunOutcome["diagnostics"];
     delivered?: boolean;
+    sentBeforeError?: boolean;
     provider?: string;
     startedAt: number;
     endedAt: number;
@@ -749,6 +761,7 @@ export function applyJobResult(
     job,
     runStatus: result.status,
     delivered: result.delivered,
+    sentBeforeError: result.sentBeforeError,
     error: result.error,
     globalFailureDestination: state.deps.cronConfig?.failureDestination,
   });
@@ -1113,6 +1126,7 @@ function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOu
         error: result.error,
         diagnostics: result.diagnostics,
         delivered: result.delivered,
+        sentBeforeError: result.delivery?.sentBeforeError,
         provider: result.provider,
         startedAt: result.startedAt,
         endedAt: result.endedAt,
@@ -1148,6 +1162,7 @@ function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOu
     error: result.error,
     diagnostics: result.diagnostics,
     delivered: result.delivered,
+    sentBeforeError: result.delivery?.sentBeforeError,
     provider: result.provider,
     startedAt: result.startedAt,
     endedAt: result.endedAt,

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -121,6 +121,12 @@ export type CronDeliveryTrace = {
   messageToolSentTo?: CronDeliveryTraceMessageTarget[];
   fallbackUsed?: boolean;
   delivered?: boolean;
+  /**
+   * True when a failed announce still sent visible content to the resolved
+   * target before erroring. Suppresses the same-target failure re-announce so
+   * recipients who already saw output do not get a false "job failed" notice.
+   */
+  sentBeforeError?: boolean;
 };
 
 /** Last failed-run notification delivery state stored on job state and run logs. */

--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -141,6 +141,134 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
     });
   });
 
+  it("skips the primary-target failure notice when the announce partially delivered", () => {
+    const logger = { warn: vi.fn() };
+    const job = {
+      id: "cron-partial-announce",
+      name: "partial announce",
+      enabled: true,
+      createdAtMs: 1,
+      updatedAtMs: 1,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "command", argv: ["echo", "ok"] },
+      delivery: {
+        mode: "announce",
+        channel: "slack",
+        to: "C123",
+      },
+      state: {},
+    } satisfies CronJob;
+
+    dispatchGatewayCronFinishedNotifications({
+      evt: {
+        jobId: job.id,
+        action: "finished",
+        status: "error",
+        error: "chunk 2 send failed",
+        delivery: { delivered: false, sentBeforeError: true },
+      },
+      job,
+      deps: {} as CliDeps,
+      logger,
+      resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
+    });
+
+    expect(mocks.sendFailureNotificationAnnounce).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      { jobId: job.id },
+      "cron: skipped failure notice to primary target; announce partially delivered before the send error",
+    );
+  });
+
+  it("announces failure to the primary target when nothing was delivered", () => {
+    const logger = { warn: vi.fn() };
+    const job = {
+      id: "cron-failed-announce",
+      name: "failed announce",
+      enabled: true,
+      createdAtMs: 1,
+      updatedAtMs: 1,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "command", argv: ["echo", "ok"] },
+      delivery: {
+        mode: "announce",
+        channel: "slack",
+        to: "C123",
+      },
+      state: {},
+    } satisfies CronJob;
+
+    dispatchGatewayCronFinishedNotifications({
+      evt: {
+        jobId: job.id,
+        action: "finished",
+        status: "error",
+        error: "send failed",
+        delivery: { delivered: false },
+      },
+      job,
+      deps: {} as CliDeps,
+      logger,
+      resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
+    });
+
+    expect(mocks.sendFailureNotificationAnnounce).toHaveBeenCalledTimes(1);
+    expect(mocks.sendFailureNotificationAnnounce.mock.calls[0]?.[4]).toMatchObject({
+      channel: "slack",
+      to: "C123",
+    });
+  });
+
+  it("keeps explicit failure destinations notified when the announce partially delivered", () => {
+    const logger = { warn: vi.fn() };
+    const job = {
+      id: "cron-partial-announce-failure-dest",
+      name: "partial announce failure dest",
+      enabled: true,
+      createdAtMs: 1,
+      updatedAtMs: 1,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "command", argv: ["echo", "ok"] },
+      delivery: {
+        mode: "announce",
+        channel: "slack",
+        to: "C123",
+        failureDestination: {
+          mode: "announce",
+          channel: "slack",
+          to: "C-alerts",
+        },
+      },
+      state: {},
+    } satisfies CronJob;
+
+    dispatchGatewayCronFinishedNotifications({
+      evt: {
+        jobId: job.id,
+        action: "finished",
+        status: "error",
+        error: "chunk 2 send failed",
+        delivery: { delivered: false, sentBeforeError: true },
+      },
+      job,
+      deps: {} as CliDeps,
+      logger,
+      resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
+    });
+
+    expect(mocks.sendFailureNotificationAnnounce).toHaveBeenCalledTimes(1);
+    expect(mocks.sendFailureNotificationAnnounce.mock.calls[0]?.[4]).toMatchObject({
+      channel: "slack",
+      to: "C-alerts",
+    });
+  });
+
   it("redacts command action-required summaries before webhook completion delivery", async () => {
     const logger = { warn: vi.fn() };
     const sensitiveSummary =

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -452,6 +452,17 @@ function dispatchCronFailureDestinationNotifications(params: {
   if (primaryPlan.mode !== "announce" || !primaryPlan.requested) {
     return;
   }
+  if (params.evt.delivery?.sentBeforeError) {
+    // The announce already sent visible content to this primary target before
+    // the send error; a "job failed" notice there would false-alarm recipients
+    // who just received the report (#102367). Explicit failure destinations
+    // (handled above) still fire because they route elsewhere.
+    params.logger.warn(
+      { jobId: params.evt.jobId },
+      "cron: skipped failure notice to primary target; announce partially delivered before the send error",
+    );
+    return;
+  }
 
   const { agentId, cfg: runtimeConfig } = params.resolveCronAgent(params.job.agentId);
   void sendFailureNotificationAnnounce(

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -19,6 +19,7 @@ const {
   loadConfigMock,
   fetchWithSsrFGuardMock,
   sendCronAnnouncePayloadStrictMock,
+  sendFailureNotificationAnnounceMock,
   runCronIsolatedAgentTurnMock,
   cleanupBrowserSessionsForLifecycleEndMock,
   getGlobalHookRunnerMock,
@@ -36,7 +37,12 @@ const {
   >(async () => ({ status: "ran", durationMs: 1 })),
   loadConfigMock: vi.fn(),
   fetchWithSsrFGuardMock: vi.fn(),
-  sendCronAnnouncePayloadStrictMock: vi.fn(async () => {}),
+  sendCronAnnouncePayloadStrictMock: vi.fn<
+    (
+      ...args: unknown[]
+    ) => Promise<{ status: "sent" } | { status: "partial_failed"; error: unknown }>
+  >(async () => ({ status: "sent" as const })),
+  sendFailureNotificationAnnounceMock: vi.fn(async () => {}),
   runCronIsolatedAgentTurnMock: vi.fn<RunCronIsolatedAgentTurnMock>(async () => ({
     status: "ok",
     summary: "ok",
@@ -167,6 +173,7 @@ vi.mock("../cron/delivery.js", async () => {
   return {
     ...actual,
     sendCronAnnouncePayloadStrict: sendCronAnnouncePayloadStrictMock,
+    sendFailureNotificationAnnounce: sendFailureNotificationAnnounceMock,
   };
 });
 
@@ -293,6 +300,7 @@ describe("buildGatewayCronService", () => {
     loadConfigMock.mockClear();
     fetchWithSsrFGuardMock.mockClear();
     sendCronAnnouncePayloadStrictMock.mockClear();
+    sendFailureNotificationAnnounceMock.mockClear();
     runCronIsolatedAgentTurnMock.mockClear();
     cleanupBrowserSessionsForLifecycleEndMock.mockClear();
     runCronChangedMock.mockClear();
@@ -736,6 +744,104 @@ describe("buildGatewayCronService", () => {
       const message = typeof announcePayload.message === "string" ? announcePayload.message : "";
       expect(message).toContain("token=***");
       expect(message).not.toContain("opaque-secret-value");
+    } finally {
+      state.cron.stop();
+    }
+  });
+
+  it("marks partial announce delivery as run error without a same-target failure notice", async () => {
+    const cfg = createCronConfig("server-cron-command-announce-partial");
+    loadConfigMock.mockReturnValue(cfg);
+    sendCronAnnouncePayloadStrictMock.mockResolvedValueOnce({
+      status: "partial_failed",
+      error: new Error("chunk 2 send failed"),
+    });
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+    try {
+      const job = await state.cron.add({
+        name: "announce-partial-command",
+        enabled: true,
+        deleteAfterRun: false,
+        schedule: { kind: "at", at: new Date(1).toISOString() },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: {
+          kind: "command",
+          argv: [process.execPath, "-e", "process.stdout.write('weekly report\\n')"],
+        },
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "123",
+        },
+      });
+
+      runCronChangedMock.mockClear();
+      await state.cron.run(job.id, "force");
+
+      const event = runCronChangedMock.mock.calls
+        .map((_, index) =>
+          requireRecord(
+            callArg(runCronChangedMock, index, 0, "cron_changed event"),
+            "cron_changed event",
+          ),
+        )
+        .find((hookEvent) => hookEvent.action === "finished");
+      expect(event?.status).toBe("error");
+      expect(event?.error).toContain("chunk 2 send failed");
+      expect(event?.delivered).toBe(false);
+      // The announce already reached the primary target; no failure re-announce.
+      expect(sendFailureNotificationAnnounceMock).not.toHaveBeenCalled();
+    } finally {
+      state.cron.stop();
+    }
+  });
+
+  it("still announces failure to the primary target when nothing was delivered", async () => {
+    const cfg = createCronConfig("server-cron-command-announce-failed");
+    loadConfigMock.mockReturnValue(cfg);
+    sendCronAnnouncePayloadStrictMock.mockRejectedValueOnce(new Error("send failed"));
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+    try {
+      const job = await state.cron.add({
+        name: "announce-failed-command",
+        enabled: true,
+        deleteAfterRun: false,
+        schedule: { kind: "at", at: new Date(1).toISOString() },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: {
+          kind: "command",
+          argv: [process.execPath, "-e", "process.stdout.write('weekly report\\n')"],
+        },
+        delivery: {
+          mode: "announce",
+          channel: "telegram",
+          to: "123",
+        },
+      });
+
+      await state.cron.run(job.id, "force");
+
+      await vi.waitFor(() => {
+        expect(sendFailureNotificationAnnounceMock).toHaveBeenCalledTimes(1);
+      });
+      const target = requireRecord(
+        callArg(sendFailureNotificationAnnounceMock, 0, 4, "failure notice target"),
+        "failure notice target",
+      );
+      expect(target.channel).toBe("telegram");
+      expect(target.to).toBe("123");
     } finally {
       state.cron.stop();
     }

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -564,8 +564,29 @@ export function buildGatewayCronService(params: {
         };
       }
       const { agentId, cfg: runtimeConfig } = resolveCronAgent(job.agentId);
+      const deliveryFailureResult = (error: string, sentBeforeError: boolean) => ({
+        ...result,
+        status: job.delivery?.bestEffort ? result.status : ("error" as const),
+        error: job.delivery?.bestEffort ? result.error : error,
+        deliveryAttempted: true,
+        delivered: false,
+        delivery: {
+          ...deliveryTrace,
+          delivered: false,
+          ...(sentBeforeError ? { sentBeforeError: true } : {}),
+          resolved: {
+            channel: plan.channel,
+            to: plan.to,
+            accountId: plan.accountId,
+            threadId: plan.threadId,
+            source: "explicit" as const,
+            ok: false,
+            error,
+          },
+        },
+      });
       try {
-        await sendCronAnnouncePayloadStrict({
+        const send = await sendCronAnnouncePayloadStrict({
           deps: params.deps,
           cfg: runtimeConfig,
           agentId,
@@ -579,6 +600,11 @@ export function buildGatewayCronService(params: {
           message,
           abortSignal: abortSignal ?? new AbortController().signal,
         });
+        if (send.status === "partial_failed") {
+          const error = formatErrorMessage(send.error);
+          cronLogger.warn({ jobId: job.id, err: error }, "cron: command delivery partially failed");
+          return deliveryFailureResult(error, true);
+        }
         return {
           ...result,
           deliveryAttempted: true,
@@ -591,26 +617,7 @@ export function buildGatewayCronService(params: {
       } catch (err) {
         const error = formatErrorMessage(err);
         cronLogger.warn({ jobId: job.id, err: error }, "cron: command delivery failed");
-        return {
-          ...result,
-          status: job.delivery?.bestEffort ? result.status : "error",
-          error: job.delivery?.bestEffort ? result.error : error,
-          deliveryAttempted: true,
-          delivered: false,
-          delivery: {
-            ...deliveryTrace,
-            delivered: false,
-            resolved: {
-              channel: plan.channel,
-              to: plan.to,
-              accountId: plan.accountId,
-              threadId: plan.threadId,
-              source: "explicit" as const,
-              ok: false,
-              error,
-            },
-          },
-        };
+        return deliveryFailureResult(error, false);
       }
     },
     cleanupTimedOutAgentRun: async ({ job, execution }) => {


### PR DESCRIPTION
## What Problem This Solves

A cron `--announce` job whose report actually reached the channel could still post a `Cron job "<name>" failed: <error>` notice to that same channel when the durable send reported `partial_failed` (visible content sent before the error). Recipients saw a successful report immediately followed by a false failure alarm.

This addresses the source-backed half of #102367 (false failure reporting + same-target failure re-announce). The intermittent duplicate `chat.postMessage` trigger reported there remains open and is intentionally out of scope for this PR.

## Why This Change Was Made

`deliverCronAnnouncePayload` threw on `partial_failed` exactly like a full failure (`src/cron/delivery.ts`), so the command-cron catch flipped the run to `error` and the gateway failure fallback (`src/gateway/server-cron-notifications.ts`) could not distinguish "nothing was delivered" from "delivered, then errored" — and re-announced the failure to the very target that had just received the report.

Fix shape:

- `sendCronAnnouncePayloadStrict` now returns a closed outcome: `{ status: "sent" } | { status: "partial_failed"; error }`, throwing only when nothing reached the target. The throw-on-partial behavior dates to the 2026-05-09 delivery API consolidation (a4b17d65a8), not a product decision.
- The command-cron path keeps marking the run as `error` on partial delivery (strict non-best-effort announce semantics are preserved) but records `sentBeforeError: true` on the existing `CronDeliveryTrace`, which already rides the finished cron event.
- The failure-notification dispatcher skips only the primary-target fallback notice when `sentBeforeError` is set. Explicit `failureDestination` routes and webhooks still fire.
- `resolveDeliveryState` records the failure notification as `not-requested` (instead of `not-delivered`) for this case so job state matches the suppression.
- Sibling surface: the isolated-agent delivery path already tracked `partialDeliverySucceededBeforeFailure` internally; it now surfaces the same `sentBeforeError` fact through `DispatchCronDeliveryState` into its delivery trace, so isolated announce jobs get the same suppression.

## User Impact

No more false `Cron job "<name>" failed` posts into a channel that just received the announce output. Runs with genuinely partial delivery still surface as errors in cron state, run logs, failure-alert backoff, and non-primary failure destinations. The `--best-effort-deliver` workaround from the issue is no longer needed for this symptom.

## Evidence

- `pnpm test src/cron src/gateway/server-cron.test.ts src/gateway/server-cron-notifications.test.ts src/gateway/server.cron.test.ts src/gateway/server-cron-lazy.test.ts` — 128 files / 1370 tests green.
- `pnpm tsgo`, `pnpm check:test-types`, `check:changed` lanes green (run locally on macOS; Testbox/Crabbox delegation was unavailable on this machine — no `crabbox` binary installed).
- New regression tests:
  - `src/cron/delivery.failure-notify.test.ts`: strict send outcome contract (sent / partial returns / full failure throws) and partial failure-notice logging.
  - `src/gateway/server-cron-notifications.test.ts`: primary-target notice suppressed on `sentBeforeError`, still sent when nothing delivered, explicit failure destinations unaffected.
  - `src/gateway/server-cron.test.ts`: end-to-end command cron — partial announce → run `error` with no failure re-announce; full announce failure → fallback notice to the primary target preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
