### PR TITLE
fix(slack): omit reply_to_id for standalone messages

### DIFF
--- a/extensions/slack/src/action-runtime.test.ts
+++ b/extensions/slack/src/action-runtime.test.ts
@@ -1,6 +1,7 @@
 // Slack tests cover action runtime plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SlackActionContext } from "./action-runtime.js";
 import { handleSlackAction, slackActionRuntime } from "./action-runtime.js";
 import { parseSlackBlocksInput } from "./blocks-input.js";
 import { buildSlackThreadingToolContext } from "./threading-tool-context.js";
@@ -143,7 +144,7 @@ describe("handleSlackAction", () => {
 
   async function sendSecondMessageAndExpectNoThread(params: {
     cfg: OpenClawConfig;
-    context: ReturnType<typeof createReplyToFirstContext>;
+    context: SlackActionContext;
   }) {
     await handleSlackAction(
       { action: "sendMessage", to: "channel:C123", content: "Second" },
@@ -774,6 +775,59 @@ describe("handleSlackAction", () => {
 
     expectLastSlackSend("First", cfg, "1111111111.111111");
     await sendSecondMessageAndExpectNoThread({ cfg, context });
+  });
+
+  it("replyToMode=first threads standalone message-tool sends without ReplyToId", async () => {
+    const cfg = slackConfig({ replyToMode: "first" });
+    const hasRepliedRef = { value: false };
+    const context = buildSlackThreadingToolContext({
+      cfg,
+      accountId: null,
+      hasRepliedRef,
+      context: {
+        ChatType: "channel",
+        To: "channel:C123",
+        CurrentMessageId: "1111111111.111111",
+      },
+    });
+
+    await handleSlackAction(
+      { action: "sendMessage", to: "channel:C123", content: "First" },
+      cfg,
+      context,
+    );
+
+    expectLastSlackSend("First", cfg, "1111111111.111111");
+    await sendSecondMessageAndExpectNoThread({ cfg, context });
+  });
+
+  it("does not use standalone current-message anchors for different channels", async () => {
+    const cfg = slackConfig({ replyToMode: "first" });
+    const hasRepliedRef = { value: false };
+    const context = buildSlackThreadingToolContext({
+      cfg,
+      accountId: null,
+      hasRepliedRef,
+      context: {
+        ChatType: "channel",
+        To: "channel:C123",
+        CurrentMessageId: "1111111111.111111",
+      },
+    });
+
+    await handleSlackAction(
+      { action: "sendMessage", to: "channel:C999", content: "Other channel" },
+      cfg,
+      context,
+    );
+
+    expectSlackSendCall(0, "channel:C999", "Other channel", {
+      cfg,
+      mediaUrl: undefined,
+      threadTs: undefined,
+      blocks: undefined,
+    });
+    expect(hasRepliedRef.value).toBe(false);
   });
 
   it("replyToMode=first normalizes channel target when accounting explicit threadTs", async () => {

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -1804,7 +1804,7 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
 
       expectMainScopedDmClassification(prepared, { includeFromCheck: testCase.name !== "raw im" });
       expect(prepared!.ctxPayload.MessageThreadId).toBe("1.000");
-      expect(prepared!.ctxPayload.ReplyToId).toBe("1.000");
+      expect(prepared!.ctxPayload.ReplyToId).toBeUndefined();
     }
   });
 
@@ -1817,6 +1817,7 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
 
     assertPrepared(prepared);
     expect(prepared.ctxPayload.MessageThreadId).toBe("1.000");
+    expect(prepared.ctxPayload.ReplyToId).toBeUndefined();
   });
 
   it("classifies MPIM group DMs as group chat context", async () => {
@@ -3800,7 +3801,7 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     expect(prepared.ctxPayload.WasMentioned).toBe(true);
   });
 
-  it("preserves single-use reply mode metadata on seeded top-level roots", async () => {
+  it("preserves seeded top-level roots without reply_to_id self-references", async () => {
     const { storePath } = storeFixture.makeTmpStorePath();
     const rootTs = "1777244692.409919";
 
@@ -3835,7 +3836,7 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
         "agent:main:slack:channel:c0ahzfcas1k:thread:1777244692.409919",
       );
       expect(prepared.ctxPayload.MessageThreadId).toBeUndefined();
-      expect(prepared.ctxPayload.ReplyToId).toBe(rootTs);
+      expect(prepared.ctxPayload.ReplyToId).toBeUndefined();
     }
   });
 });

--- a/extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts
@@ -350,6 +350,7 @@ describe("thread-level session keys", () => {
 
     expect(routing.sessionKey).toBe("agent:main:slack:channel:c123");
     expect(routing.threadContext.messageThreadId).toBeUndefined();
+    expect(routing.threadContext.replyToId).toBeUndefined();
   });
 
   it("does not seed top-level group DM mentions into thread sessions", () => {

--- a/extensions/slack/src/threading-tool-context.test.ts
+++ b/extensions/slack/src/threading-tool-context.test.ts
@@ -213,6 +213,28 @@ describe("buildSlackThreadingToolContext", () => {
     expect(result.replyToMode).toBe("first");
   });
 
+  it("uses CurrentMessageId as a non-explicit anchor when ReplyToId is omitted", () => {
+    const result = buildSlackThreadingToolContext({
+      cfg: {
+        channels: {
+          slack: {
+            replyToMode: "first",
+          },
+        },
+      } as OpenClawConfig,
+      accountId: null,
+      context: {
+        ChatType: "channel",
+        To: "channel:C123",
+        CurrentMessageId: "1771999998.834199",
+      },
+    });
+
+    expect(result.currentThreadTs).toBe("1771999998.834199");
+    expect(result.replyToMode).toBe("first");
+    expect(result.sameChannelThreadRequired).toBe(false);
+  });
+
   it("keeps configured channel behavior when not in a thread", () => {
     const cfg = {
       channels: {

--- a/extensions/slack/src/threading-tool-context.ts
+++ b/extensions/slack/src/threading-tool-context.ts
@@ -25,7 +25,7 @@ export function buildSlackThreadingToolContext(params: {
   const transportThreadTs = normalizeSlackThreadTsCandidate(params.context.TransportThreadId);
   const replyToThreadTs = normalizeSlackThreadTsCandidate(params.context.ReplyToId);
   const currentMessageTs = normalizeSlackThreadTsCandidate(params.context.CurrentMessageId);
-  const currentThreadTs = messageThreadTs ?? transportThreadTs ?? replyToThreadTs;
+  const currentThreadTs = messageThreadTs ?? transportThreadTs ?? replyToThreadTs ?? currentMessageTs;
   const hasExplicitThreadTarget =
     messageThreadTs != null ||
     transportThreadTs != null ||

--- a/extensions/slack/src/threading.test.ts
+++ b/extensions/slack/src/threading.test.ts
@@ -86,7 +86,7 @@ describe("resolveSlackThreadTargets", () => {
 
     expect(context.isThreadReply).toBe(false);
     expect(context.messageThreadId).toBe("123");
-    expect(context.replyToId).toBe("123");
+    expect(context.replyToId).toBeUndefined();
   });
 
   it("sets messageThreadId for DM assistant thread-root messages regardless of replyToMode", () => {
@@ -107,7 +107,7 @@ describe("resolveSlackThreadTargets", () => {
       // thread_ts == ts in a DM: Agents & Assistants root — preserve thread
       // context so tool calls (subagent results) thread correctly.
       expect(context.messageThreadId).toBe("123");
-      expect(context.replyToId).toBe("123");
+      expect(context.replyToId).toBeUndefined();
     }
   });
 
@@ -129,7 +129,7 @@ describe("resolveSlackThreadTargets", () => {
 
       expect(context.isThreadReply).toBe(false);
       expect(context.messageThreadId).toBe("123");
-      expect(context.replyToId).toBe("123");
+      expect(context.replyToId).toBeUndefined();
     }
   });
 
@@ -151,7 +151,7 @@ describe("resolveSlackThreadTargets", () => {
       // thread_ts == ts in a channel: auto-created top-level thread_ts should
       // NOT force threaded mode — only DM assistant threads get the override.
       expect(context.messageThreadId).toBeUndefined();
-      expect(context.replyToId).toBe("123");
+      expect(context.replyToId).toBeUndefined();
     }
   });
 

--- a/extensions/slack/src/threading.ts
+++ b/extensions/slack/src/threading.ts
@@ -21,7 +21,7 @@ export function resolveSlackThreadContext(params: {
   const hasThreadTs = typeof incomingThreadTs === "string" && incomingThreadTs.length > 0;
   const isThreadReply =
     hasThreadTs && (incomingThreadTs !== messageTs || Boolean(params.message.parent_user_id));
-  const replyToId = incomingThreadTs ?? messageTs;
+  const replyToId = isThreadReply ? incomingThreadTs : undefined;
   // Preserve thread context for Slack Agents & Assistants DM root messages
   // where thread_ts == ts. Non-DM self-thread roots must stay unset because
   // downstream tool threading treats MessageThreadId as an explicit thread


### PR DESCRIPTION
Closes #102457

## What Problem This Solves

Fixes an issue where Slack standalone messages could include `reply_to_id` equal to their own `message_id` in the agent's conversation metadata. That made ordinary top-level messages and self-thread root messages look like replies to themselves instead of non-replies.

## Why This Change Was Made

Slack inbound threading now only sets prompt-facing `replyToId` when the inbound event is a genuine Slack thread reply. The Slack tool context still uses the current message id as a non-explicit same-channel thread anchor, so configured message-tool auto-threading for `first`, `batched`, and `all` modes continues to work without leaking a self-referential `reply_to_id` into prompt metadata. Risk note: Slack thread/session routing is sensitive, so the focused tests cover the resolver, message preparation, routing metadata, shared inbound metadata, same-channel message-tool threading, and the cross-channel guard.

## User Impact

Agents no longer receive misleading Slack `reply_to_id` metadata for standalone messages. Real Slack thread replies still carry the parent timestamp, and configured Slack reply/threading behavior remains available for normal replies and message-tool sends.

## Evidence

Before on current `upstream/main` (`6620aba25a`), the resolver self-referenced non-replies:

```text
top-level no thread_ts: isThreadReply=false; messageTs=1751234567.123456; replyToId=1751234567.123456; messageThreadId=<undefined>
self thread root: isThreadReply=false; messageTs=1751234567.123456; replyToId=1751234567.123456; messageThreadId=<undefined>
genuine reply: isThreadReply=true; messageTs=1751234568.000000; replyToId=1751234567.123456; messageThreadId=1751234567.123456
```

After this change, only genuine replies keep `replyToId`:

```text
top-level no thread_ts: isThreadReply=false; messageTs=1751234567.123456; replyToId=<undefined>; messageThreadId=<undefined>
self thread root: isThreadReply=false; messageTs=1751234567.123456; replyToId=<undefined>; messageThreadId=<undefined>
genuine reply: isThreadReply=true; messageTs=1751234568.000000; replyToId=1751234567.123456; messageThreadId=1751234567.123456
```

Focused local validation:

```text
node scripts/run-vitest.mjs extensions/slack/src/threading.test.ts extensions/slack/src/threading-tool-context.test.ts extensions/slack/src/action-runtime.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts src/auto-reply/reply/inbound-meta.test.ts
[test] passed 2 Vitest shards in 13.47s
```

The focused suite includes regressions for standalone Slack message-tool auto-threading without `ReplyToId` and for avoiding thread injection when the tool sends to a different channel.

Additional checks:

```text
git diff --check
# passed

.agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
```

CI on the initial PR revision completed green. The updated commit is expected to rerun CI, and the local focused suite plus `git diff --check` passed after the test type fix.

This was not tested against a live Slack workspace because the reported bug and the repair are in local inbound normalization and message-tool thread selection before any Slack client-visible delivery path.

AI-assisted.

