### PR TITLE
fix: collapse sidebar after returning from drawer layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI sidebar collapse:** clear stale drawer state after returning to the desktop layout so the collapse button responds on the first click.
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI sidebar collapse:** clear stale drawer state after returning to the desktop layout so the collapse button responds on the first click.
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -553,8 +553,12 @@ class OpenClawShell extends LitElement {
       this.navDrawerOpen = true;
       return;
     }
+    // A drawer that survived a breakpoint change is visually expanded even
+    // when the persisted desktop preference says collapsed.
+    const nextNavCollapsed = this.navDrawerOpen || !this.navCollapsed;
+    this.closeNavDrawer();
     context.navigation.update({
-      navCollapsed: !this.navCollapsed,
+      navCollapsed: nextNavCollapsed,
     });
   }
 

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -190,6 +190,23 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       await expect.poll(() => page.locator(".topbar-brand").isVisible()).toBe(false);
       await captureUiProof(page, "05-expanded-tablet-drawer.png");
 
+      // Widening with the drawer open must not leave its stale state blocking
+      // the desktop collapse control.
+      await page.setViewportSize({ height: 900, width: 1440 });
+      await sidebar.getByRole("button", { name: "Collapse sidebar" }).click();
+      await expect
+        .poll(() => page.locator(".shell").getAttribute("class"))
+        .toContain("shell--nav-collapsed");
+      await expect
+        .poll(() => page.locator(".shell").getAttribute("class"))
+        .not.toContain("shell--nav-drawer-open");
+      await captureUiProof(page, "06-desktop-collapse-after-drawer.png");
+
+      await page.setViewportSize({ height: 900, width: 900 });
+      await drawerButton.click();
+      await expect
+        .poll(() => page.locator(".shell").getAttribute("class"))
+        .toContain("shell--nav-drawer-open");
       await page.keyboard.press("Escape");
       await expect
         .poll(() => page.locator(".shell").getAttribute("class"))


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who opened the navigation drawer at a narrow viewport and then returned to the desktop layout would see the sidebar collapse button do nothing on its first click.

## Why This Change Was Made

The desktop navigation toggle now reconciles any drawer state that survived a breakpoint change before persisting the desktop collapse preference. The existing desktop-only toggle behavior remains unchanged.

## User Impact

The Control UI sidebar collapses on the first click after moving from the tablet drawer layout back to desktop.

## Evidence

- Reproduced in the existing Chrome profile: open the drawer at 900 px, widen to 1440 px, then click **Collapse sidebar**; the sidebar remained expanded before this fix.
- Regression test failed before the fix because `.shell` retained `shell--nav-drawer-open` and never gained `shell--nav-collapsed`.
- Blacksmith Testbox `tbx_01kx2r3eyyb8zk2cxeeydvk3vm`: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/sidebar-customization.e2e.test.ts` — 2 tests passed. The scenario captures `06-desktop-collapse-after-drawer.png` after the corrected transition.
- Same Testbox: `corepack pnpm check:changed` — passed core/core-test typechecks, changed-file lint, and repository policy guards.
- Fresh `autoreview --mode local`: no accepted or actionable findings; patch correctness 0.95.
