### PR TITLE
fix(tool-policy-audit): use truncateUtf16Safe for audit field truncation

### DIFF
--- a/src/agents/tool-policy-audit.ts
+++ b/src/agents/tool-policy-audit.ts
@@ -1,10 +1,10 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 /**
  * Tool policy audit logging helpers.
  * Emits bounded, sanitized logs when allow/deny policy filters remove tools or
  * block sandbox tool execution.
  */
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { truncateUtf16Safe } from "../utils.js";
 import type { SandboxConfig } from "./sandbox/types.js";
 import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
 import { normalizeToolList, normalizeToolName, type ToolPolicyLike } from "./tool-policy.js";

--- a/src/agents/tool-policy-audit.ts
+++ b/src/agents/tool-policy-audit.ts
@@ -4,6 +4,7 @@
  * block sandbox tool execution.
  */
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { truncateUtf16Safe } from "../utils.js";
 import type { SandboxConfig } from "./sandbox/types.js";
 import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
 import { normalizeToolList, normalizeToolName, type ToolPolicyLike } from "./tool-policy.js";
@@ -145,7 +146,7 @@ function sanitizeAuditField(value: string): string {
   if (sanitized.length <= MAX_AUDIT_FIELD_LENGTH) {
     return sanitized;
   }
-  return `${sanitized.slice(0, MAX_AUDIT_FIELD_LENGTH)}...`;
+  return `${truncateUtf16Safe(sanitized, MAX_AUDIT_FIELD_LENGTH)}...`;
 }
 
 function matchedPolicyRules(params: {

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -778,4 +778,33 @@ describe("tool-policy-pipeline", () => {
     );
     expect(toolPolicyAuditDebug).not.toHaveBeenCalled();
   });
+
+  test("truncates audit fields without splitting surrogate pairs", () => {
+    const tools = [{ name: "exec" }] as unknown as DummyTool[];
+    const labelPrefix = "a".repeat(159);
+
+    applyToolPolicyPipeline({
+      tools: tools as any,
+      toolMeta: () => undefined,
+      warn: () => {},
+      steps: [
+        {
+          policy: { allow: ["read"] },
+          label: `${labelPrefix}😀suffix`,
+        },
+      ],
+    });
+
+    const rule = `${labelPrefix}...`;
+    expect(toolPolicyAuditInfo).toHaveBeenCalledWith(
+      `tool policy removed 1 tool(s) via ${rule}: exec`,
+      {
+        rule,
+        ruleKind: "allow",
+        removedToolCount: 1,
+        removedTools: ["exec"],
+        removedToolsTruncated: false,
+      },
+    );
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

The tool policy audit logger uses naive `.slice(0, MAX_AUDIT_FIELD_LENGTH)` to truncate field values. This can split surrogate pairs mid-character, producing garbled output in audit logs.

## Why This Change Was Made

Replace with `truncateUtf16Safe()` which preserves surrogate pair boundaries.

## Evidence

```
=== BEFORE: naive .slice(0, 23) ===
Result: "tool-audit-field-with-\ud83d"
Last char: "\ud83d"
Is high surrogate (0xD800-0xDBFF): true  ← DANGLING!

=== AFTER: truncateUtf16Safe(0, 23) ===
Result: "tool-audit-field-with-"
Is clean (no broken pair): true  ← CORRECT
```

## Files Changed

| File | Change |
|------|--------|
| `src/agents/tool-policy-audit.ts` | +1 import; `.slice(0,N)` → `truncateUtf16Safe()` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>