### PR TITLE
fix(agents): keep tool-result context guard truncation UTF-16 safe

### DIFF
--- a/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
@@ -179,6 +179,23 @@ function recordMockArg(
   return arg as Record<string, unknown>;
 }
 
+function hasLoneSurrogate(s: string): boolean {
+  for (let i = 0; i < s.length; i += 1) {
+    const c = s.charCodeAt(i);
+    if (c >= 0xd800 && c <= 0xdbff) {
+      if (i + 1 >= s.length || s.charCodeAt(i + 1) < 0xdc00 || s.charCodeAt(i + 1) > 0xdfff) {
+        return true;
+      }
+    }
+    if (c >= 0xdc00 && c <= 0xdfff) {
+      if (i === 0 || s.charCodeAt(i - 1) < 0xd800 || s.charCodeAt(i - 1) > 0xdbff) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 describe("formatContextLimitTruncationNotice", () => {
   it("formats truncation wording with a count", () => {
     expect(formatContextLimitTruncationNotice(123)).toBe(
@@ -325,6 +342,26 @@ describe("installToolResultContextGuard", () => {
     )) as AgentMessage[];
 
     expectOpenClawTruncation(getToolResultText(transformed[0]));
+  });
+
+  it("truncates UTF-16 tool results without splitting surrogate pairs", async () => {
+    // With contextWindowTokens=1000, maxSingleToolResultChars=1024 and the
+    // text budget becomes 512. The legacy cut point falls inside the emoji
+    // at index 439, which used to emit a lone high surrogate.
+    const agent = makeGuardableAgent();
+    const text = "a".repeat(439) + "😀" + "b".repeat(1_000);
+    const contextForNextCall = [makeToolResult("call_utf16", text)];
+
+    const transformed = (await applyGuardToContext(
+      agent,
+      contextForNextCall,
+      1_000,
+    )) as AgentMessage[];
+
+    const truncated = getToolResultText(transformed[0]);
+    expectOpenClawTruncation(truncated);
+    expect(hasLoneSurrogate(truncated)).toBe(false);
+    expect(getToolResultText(contextForNextCall[0])).toBe(text);
   });
 
   it("raises a structured mid-turn precheck signal after a new tool result overflows", async () => {

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
@@ -179,23 +179,6 @@ function recordMockArg(
   return arg as Record<string, unknown>;
 }
 
-function hasLoneSurrogate(s: string): boolean {
-  for (let i = 0; i < s.length; i += 1) {
-    const c = s.charCodeAt(i);
-    if (c >= 0xd800 && c <= 0xdbff) {
-      if (i + 1 >= s.length || s.charCodeAt(i + 1) < 0xdc00 || s.charCodeAt(i + 1) > 0xdfff) {
-        return true;
-      }
-    }
-    if (c >= 0xdc00 && c <= 0xdfff) {
-      if (i === 0 || s.charCodeAt(i - 1) < 0xd800 || s.charCodeAt(i - 1) > 0xdbff) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 describe("formatContextLimitTruncationNotice", () => {
   it("formats truncation wording with a count", () => {
     expect(formatContextLimitTruncationNotice(123)).toBe(
@@ -358,9 +341,9 @@ describe("installToolResultContextGuard", () => {
       1_000,
     )) as AgentMessage[];
 
-    const truncated = getToolResultText(transformed[0]);
-    expectOpenClawTruncation(truncated);
-    expect(hasLoneSurrogate(truncated)).toBe(false);
+    expect(getToolResultText(transformed[0])).toBe(
+      "a".repeat(439) + formatContextLimitTruncationNotice(1_002),
+    );
     expect(getToolResultText(contextForNextCall[0])).toBe(text);
   });
 

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.ts
@@ -1,3 +1,4 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 /**
  * Installs context guards for oversized tool-result histories.
  */
@@ -165,7 +166,7 @@ function truncateTextToBudget(text: string, maxChars: number): string {
   }
 
   const omittedChars = text.length - cutPoint;
-  return text.slice(0, cutPoint) + formatContextLimitTruncationNotice(omittedChars);
+  return truncateUtf16Safe(text, cutPoint) + formatContextLimitTruncationNotice(omittedChars);
 }
 
 function replaceToolResultText(msg: AgentMessage, text: string): AgentMessage {

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.ts
@@ -165,8 +165,8 @@ function truncateTextToBudget(text: string, maxChars: number): string {
     cutPoint = newline;
   }
 
-  const omittedChars = text.length - cutPoint;
-  return truncateUtf16Safe(text, cutPoint) + formatContextLimitTruncationNotice(omittedChars);
+  const prefix = truncateUtf16Safe(text, cutPoint);
+  return prefix + formatContextLimitTruncationNotice(text.length - prefix.length);
 }
 
 function replaceToolResultText(msg: AgentMessage, text: string): AgentMessage {


### PR DESCRIPTION
## What Problem This Solves

`truncateTextToBudget` could split an emoji or another supplementary Unicode character when the tool-result context budget ended inside its UTF-16 surrogate pair. The resulting provider context contained a lone surrogate. The truncation notice could also undercount omitted code units if a safe boundary backed up by one.

## Why This Change Was Made

The context guard now truncates through the shared `truncateUtf16Safe` primitive and computes the notice from the actual retained prefix length. This keeps both the serialized text and its omitted-character count accurate without changing the existing context-budget policy.

The focused regression asserts the exact provider-facing output, including the safe prefix and the corrected omitted count, and confirms the original live tool result remains unchanged.

## User Impact

Oversized tool results containing emoji no longer inject malformed UTF-16 into provider replay context, and their truncation notices report the actual number of omitted UTF-16 code units.

## Evidence

- Exact head: `686f644a7c3844056f5b4327d5021986436a7180`
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-result-context-guard.test.ts` — 1 file, 46 tests passed.
- Targeted oxfmt and `git diff --check` passed.
- Fresh uncommitted autoreview: clean, no accepted/actionable findings (`0.98`).

Local narrow test fallback was used because fork-contributor code is not eligible for credential-hydrated Testbox execution before landing review.

AI-assisted; maintainer-reviewed.
