### PR TITLE
fix(native-hook-relay): use truncateUtf16Safe for hook display text truncation

### DIFF
--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -1370,6 +1370,32 @@ describe("native hook relay registry", () => {
     expect(String(rawPayload.tool_response)).toContain("[truncated]");
   });
 
+  it("retains payload snapshots without splitting surrogate pairs", async () => {
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["post_tool_use"],
+    });
+
+    await invokeNativeHookRelay({
+      provider: "codex",
+      relayId: relay.relayId,
+      event: "post_tool_use",
+      rawPayload: {
+        tool_response: `${"a".repeat(3_999)}😀tail`,
+      },
+    });
+
+    const [recorded] = testing.getNativeHookRelayInvocationsForTests();
+    const rawPayload = readRecordField(
+      requireRecord(recorded, "native hook relay invocation"),
+      "rawPayload",
+      "invocation raw payload",
+    );
+    expect(rawPayload.tool_response).toBe(`${"a".repeat(3_999)}...[truncated]`);
+  });
+
   it("removes retained invocations when a relay is unregistered", async () => {
     const relay = registerNativeHookRelay({
       provider: "codex",
@@ -3406,6 +3432,20 @@ describe("native hook relay registry", () => {
         ),
       }),
     ).toContain("(1 omitted)");
+  });
+
+  it("truncates PermissionRequest approval previews without splitting surrogate pairs", () => {
+    expect(
+      testing.formatPermissionApprovalDescriptionForTests({
+        provider: "codex",
+        sessionId: "session-1",
+        runId: "run-1",
+        toolName: "exec",
+        toolInput: {
+          command: `${"a".repeat(236)}😀tail`,
+        },
+      }),
+    ).toBe(`Tool: exec\nCommand: ${"a".repeat(236)}...`);
   });
 });
 

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -24,12 +24,12 @@ import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "@openclaw/normalization-core/number-coercion";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { toErrorObject } from "../../infra/errors.js";
 import { resolveOpenClawPackageRootSync } from "../../infra/openclaw-root.js";
 import { privateFileStoreSync } from "../../infra/private-file-store.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import { truncateUtf16Safe } from "../../utils.js";
 import { hasGlobalHooks } from "../../plugins/hook-runner-global.js";
 import { PluginApprovalResolutions } from "../../plugins/types.js";
 import {
@@ -1926,11 +1926,14 @@ function snapshotString(value: string, state: { remainingStringLength: number })
     MAX_NATIVE_HOOK_RELAY_HISTORY_STRING_LENGTH,
     state.remainingStringLength,
   );
-  state.remainingStringLength -= limit;
   if (limit >= value.length) {
+    state.remainingStringLength -= limit;
     return value;
   }
-  return `${truncateUtf16Safe(value, limit)}...[truncated]`;
+  const prefix = truncateUtf16Safe(value, limit);
+  // Charge the retained prefix; a safe boundary may back up one code unit.
+  state.remainingStringLength -= prefix.length;
+  return `${prefix}...[truncated]`;
 }
 
 function normalizeNativeHookInvocation(params: {

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -29,6 +29,7 @@ import { toErrorObject } from "../../infra/errors.js";
 import { resolveOpenClawPackageRootSync } from "../../infra/openclaw-root.js";
 import { privateFileStoreSync } from "../../infra/private-file-store.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { truncateUtf16Safe } from "../../utils.js";
 import { hasGlobalHooks } from "../../plugins/hook-runner-global.js";
 import { PluginApprovalResolutions } from "../../plugins/types.js";
 import {
@@ -1929,7 +1930,7 @@ function snapshotString(value: string, state: { remainingStringLength: number })
   if (limit >= value.length) {
     return value;
   }
-  return `${value.slice(0, limit)}...[truncated]`;
+  return `${truncateUtf16Safe(value, limit)}...[truncated]`;
 }
 
 function normalizeNativeHookInvocation(params: {
@@ -2223,7 +2224,7 @@ function truncateText(value: string, maxLength: number): string {
   if (value.length <= maxLength) {
     return value;
   }
-  return `${value.slice(0, Math.max(0, maxLength - 3))}...`;
+  return `${truncateUtf16Safe(value, Math.max(0, maxLength - 3))}...`;
 }
 
 function resolveOpenClawCliExecutable(): string {

--- a/src/agents/tool-policy-audit.ts
+++ b/src/agents/tool-policy-audit.ts
@@ -4,7 +4,6 @@
  * block sandbox tool execution.
  */
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { truncateUtf16Safe } from "../utils.js";
 import type { SandboxConfig } from "./sandbox/types.js";
 import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
 import { normalizeToolList, normalizeToolName, type ToolPolicyLike } from "./tool-policy.js";
@@ -146,7 +145,7 @@ function sanitizeAuditField(value: string): string {
   if (sanitized.length <= MAX_AUDIT_FIELD_LENGTH) {
     return sanitized;
   }
-  return `${truncateUtf16Safe(sanitized, MAX_AUDIT_FIELD_LENGTH)}...`;
+  return `${sanitized.slice(0, MAX_AUDIT_FIELD_LENGTH)}...`;
 }
 
 function matchedPolicyRules(params: {

--- a/src/agents/tool-policy-audit.ts
+++ b/src/agents/tool-policy-audit.ts
@@ -4,6 +4,7 @@
  * block sandbox tool execution.
  */
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { truncateUtf16Safe } from "../utils.js";
 import type { SandboxConfig } from "./sandbox/types.js";
 import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
 import { normalizeToolList, normalizeToolName, type ToolPolicyLike } from "./tool-policy.js";
@@ -145,7 +146,7 @@ function sanitizeAuditField(value: string): string {
   if (sanitized.length <= MAX_AUDIT_FIELD_LENGTH) {
     return sanitized;
   }
-  return `${sanitized.slice(0, MAX_AUDIT_FIELD_LENGTH)}...`;
+  return `${truncateUtf16Safe(sanitized, MAX_AUDIT_FIELD_LENGTH)}...`;
 }
 
 function matchedPolicyRules(params: {


### PR DESCRIPTION
## What Problem This Solves

The native hook relay uses naive `.slice(0, N)` truncation in two places:
- `truncateText()` helper (4 call sites: tool names, commands, descriptions)
- Inline hook result display (`...[truncated]` suffix)

Both can split surrogate pairs mid-character in hook display output.

## Why This Change Was Made

Replace `.slice(0, N)` with `truncateUtf16Safe()` which preserves surrogate pair boundaries.

## Evidence

```
=== BEFORE: naive slice(0, 23) on emoji text ===
Result: "tool-audit-field-with-\ud83d"
Last char is high surrogate: true  ← DANGLING!

=== AFTER: truncateUtf16Safe respects pair boundaries ===
Result: "tool-audit-field-with-"
Clean (no broken pair): true  ← CORRECT
```

## Files Changed

| File | Change |
|------|--------|
| `src/agents/harness/native-hook-relay.ts` | +1 import; `.slice(0,N)` → `truncateUtf16Safe()` in `truncateText()` + inline truncation |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>