### PR TITLE
fix(gateway): keep chat history display text truncation surrogate-safe

### DIFF
--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -4,6 +4,7 @@ import { createHash } from "node:crypto";
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { asOptionalRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE } from "../agents/internal-runtime-context.js";
 import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
 import { isHeartbeatOkResponse, isHeartbeatUserMessage } from "../auto-reply/heartbeat-filter.js";
@@ -57,7 +58,7 @@ function truncateChatHistoryText(
     return { text, truncated: false };
   }
   return {
-    text: `${text.slice(0, maxChars)}\n...(truncated)...`,
+    text: `${truncateUtf16Safe(text, maxChars)}\n...(truncated)...`,
     truncated: true,
   };
 }

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -660,7 +660,6 @@ describe("waitForAgentJob", () => {
     expect(agentJobTesting.getAgentRunCacheSize()).toBe(max);
     agentJobTesting.resetAgentRunCache();
   });
-
 });
 
 describe("augmentChatHistoryWithCanvasBlocks", () => {
@@ -824,6 +823,28 @@ describe("injectTimestamp", () => {
 });
 
 describe("sanitizeChatHistoryMessages", () => {
+  it("truncates display text without splitting surrogate pairs", () => {
+    const prefix = "a".repeat(7);
+    const result = sanitizeChatHistoryMessages(
+      [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: `${prefix}😀tail` }],
+          timestamp: 1,
+        },
+      ],
+      8,
+    );
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: `${prefix}\n...(truncated)...` }],
+        timestamp: 1,
+      },
+    ]);
+  });
+
   it("redacts base64 audio content blocks from chat history", () => {
     const data = Buffer.from("voice-bytes").toString("base64");
     const result = sanitizeChatHistoryMessages([


### PR DESCRIPTION
## What Problem This Solves

Chat-history display projection truncated text with a raw UTF-16 slice. When the configured display boundary fell inside an emoji or another supplementary character, the Control UI/history payload could contain a lone surrogate that rendered as a replacement character.

## Why This Change Was Made

The owning `truncateChatHistoryText` helper now uses the shared normalization-core `truncateUtf16Safe` primitive. This covers assistant text, message previews, thinking text, and other projected display fields while preserving the existing code-unit cap and truncation marker.

A production-path regression drives assistant content through `sanitizeChatHistoryMessages` at a split surrogate boundary and asserts the exact projected payload.

## User Impact

Control UI and chat-history previews no longer display a replacement glyph when emoji or other supplementary Unicode characters cross a display truncation boundary.

## Evidence

- Exact head: `b9e92b96b6015fbb5a464e76d4126cfb9b9f2e23`
- `node scripts/run-vitest.mjs src/gateway/server-methods/server-methods.test.ts` — 1 file, 171 tests passed.
- Targeted oxfmt and `git diff --check` passed.
- Fresh uncommitted autoreview: clean, no accepted/actionable findings (`0.99`).

Local narrow test fallback was used because fork-contributor code is not eligible for credential-hydrated Testbox execution before landing review.

AI-assisted; maintainer-reviewed.
