### PR TITLE
fix(slack): omit reply_to_id for non-reply inbound messages (#102457)

### DIFF
--- a/extensions/slack/src/threading-tool-context.test.ts
+++ b/extensions/slack/src/threading-tool-context.test.ts
@@ -213,6 +213,42 @@ describe("buildSlackThreadingToolContext", () => {
     expect(result.replyToMode).toBe("first");
   });
 
+  it("anchors to CurrentMessageId when ReplyToId is omitted for a non-reply message (first mode)", () => {
+    const result = buildSlackThreadingToolContext({
+      cfg: {
+        channels: { slack: { replyToMode: "first" } },
+      } as OpenClawConfig,
+      accountId: null,
+      context: {
+        ChatType: "channel",
+        To: "channel:C1",
+        CurrentMessageId: "1771999998.834199",
+        // ReplyToId intentionally omitted: the gated resolver drops it for
+        // non-reply messages, but the message-tool anchor must survive.
+      },
+    });
+
+    expect(result.currentThreadTs).toBe("1771999998.834199");
+    expect(result.replyToMode).toBe("first");
+  });
+
+  it("anchors to CurrentMessageId when ReplyToId is omitted for a non-reply message (batched mode)", () => {
+    const result = buildSlackThreadingToolContext({
+      cfg: {
+        channels: { slack: { replyToMode: "batched" } },
+      } as OpenClawConfig,
+      accountId: null,
+      context: {
+        ChatType: "channel",
+        To: "channel:C1",
+        CurrentMessageId: "1771999998.834199",
+      },
+    });
+
+    expect(result.currentThreadTs).toBe("1771999998.834199");
+    expect(result.replyToMode).toBe("batched");
+  });
+
   it("keeps configured channel behavior when not in a thread", () => {
     const cfg = {
       channels: {

--- a/extensions/slack/src/threading-tool-context.ts
+++ b/extensions/slack/src/threading-tool-context.ts
@@ -25,7 +25,12 @@ export function buildSlackThreadingToolContext(params: {
   const transportThreadTs = normalizeSlackThreadTsCandidate(params.context.TransportThreadId);
   const replyToThreadTs = normalizeSlackThreadTsCandidate(params.context.ReplyToId);
   const currentMessageTs = normalizeSlackThreadTsCandidate(params.context.CurrentMessageId);
-  const currentThreadTs = messageThreadTs ?? transportThreadTs ?? replyToThreadTs;
+  // Anchor message-tool sends under the triggering message even when the
+  // inbound reply_to_id is intentionally omitted for non-reply messages. The
+  // current-message ts is the correct anchor; ReplyToId only carries a distinct
+  // value for genuine thread replies.
+  const currentThreadTs =
+    messageThreadTs ?? transportThreadTs ?? replyToThreadTs ?? currentMessageTs;
   const hasExplicitThreadTarget =
     messageThreadTs != null ||
     transportThreadTs != null ||

--- a/extensions/slack/src/threading.test.ts
+++ b/extensions/slack/src/threading.test.ts
@@ -86,7 +86,7 @@ describe("resolveSlackThreadTargets", () => {
 
     expect(context.isThreadReply).toBe(false);
     expect(context.messageThreadId).toBe("123");
-    expect(context.replyToId).toBe("123");
+    expect(context.replyToId).toBeUndefined();
   });
 
   it("sets messageThreadId for DM assistant thread-root messages regardless of replyToMode", () => {
@@ -107,7 +107,7 @@ describe("resolveSlackThreadTargets", () => {
       // thread_ts == ts in a DM: Agents & Assistants root — preserve thread
       // context so tool calls (subagent results) thread correctly.
       expect(context.messageThreadId).toBe("123");
-      expect(context.replyToId).toBe("123");
+      expect(context.replyToId).toBeUndefined();
     }
   });
 
@@ -129,7 +129,7 @@ describe("resolveSlackThreadTargets", () => {
 
       expect(context.isThreadReply).toBe(false);
       expect(context.messageThreadId).toBe("123");
-      expect(context.replyToId).toBe("123");
+      expect(context.replyToId).toBeUndefined();
     }
   });
 
@@ -151,7 +151,7 @@ describe("resolveSlackThreadTargets", () => {
       // thread_ts == ts in a channel: auto-created top-level thread_ts should
       // NOT force threaded mode — only DM assistant threads get the override.
       expect(context.messageThreadId).toBeUndefined();
-      expect(context.replyToId).toBe("123");
+      expect(context.replyToId).toBeUndefined();
     }
   });
 
@@ -168,6 +168,38 @@ describe("resolveSlackThreadTargets", () => {
 
     expect(context.isThreadReply).toBe(true);
     expect(context.messageThreadId).toBe("456");
+    expect(context.replyToId).toBe("456");
+  });
+});
+
+describe("resolveSlackThreadContext replyToId gating", () => {
+  it("omits replyToId for a standalone message with no thread_ts", () => {
+    const context = resolveSlackThreadContext({
+      replyToMode: "all",
+      message: { type: "message", channel: "C1", ts: "123" },
+    });
+
+    expect(context.isThreadReply).toBe(false);
+    expect(context.replyToId).toBeUndefined();
+  });
+
+  it("omits replyToId for a thread-root message where thread_ts equals ts", () => {
+    const context = resolveSlackThreadContext({
+      replyToMode: "off",
+      message: { type: "message", channel: "C1", ts: "123", thread_ts: "123" },
+    });
+
+    expect(context.isThreadReply).toBe(false);
+    expect(context.replyToId).toBeUndefined();
+  });
+
+  it("sets replyToId to thread_ts for a genuine threaded reply", () => {
+    const context = resolveSlackThreadContext({
+      replyToMode: "off",
+      message: { type: "message", channel: "C1", ts: "789", thread_ts: "456" },
+    });
+
+    expect(context.isThreadReply).toBe(true);
     expect(context.replyToId).toBe("456");
   });
 });

--- a/extensions/slack/src/threading.ts
+++ b/extensions/slack/src/threading.ts
@@ -21,7 +21,7 @@ export function resolveSlackThreadContext(params: {
   const hasThreadTs = typeof incomingThreadTs === "string" && incomingThreadTs.length > 0;
   const isThreadReply =
     hasThreadTs && (incomingThreadTs !== messageTs || Boolean(params.message.parent_user_id));
-  const replyToId = incomingThreadTs ?? messageTs;
+  const replyToId = isThreadReply ? incomingThreadTs : undefined;
   // Preserve thread context for Slack Agents & Assistants DM root messages
   // where thread_ts == ts. Non-DM self-thread roots must stay unset because
   // downstream tool threading treats MessageThreadId as an explicit thread


### PR DESCRIPTION
## Summary

In the Slack channel plugin, `resolveSlackThreadContext` computed `replyToId` as `incomingThreadTs ?? messageTs` without checking the `isThreadReply` flag it derives one line above, so the inbound `reply_to_id` prompt-metadata field equaled `message_id` for every message that is not a genuine thread reply.

This PR gates `reply_to_id` to non-reply messages **and** preserves the separate message-tool thread anchor that also read `ReplyToId`, so the metadata fix does not regress Slack auto-threading.

Fixes #102457.

## What Problem This Solves

`reply_to_id` should identify the message a reply responds to, and be omitted when the message is not a reply. Before this fix it was wrong for the majority of Slack traffic:

- **Standalone message** (no `thread_ts`): `replyToId` fell through the `??` to `messageTs`, equaling `message_id`.
- **Thread-root message** (`thread_ts == ts`, including the Slack Agents/Assistants DM root case): `replyToId` became `incomingThreadTs`, which equals `messageTs`, again equaling `message_id`.
- Only a **genuine reply** (`thread_ts` different from `ts`) was correct.

That corrupts a semantic signal in untrusted prompt metadata that both the model and internal logic read (e.g. `chatWindowCoversReplyContext`).

## Why This Change Was Made — and the anchor it must preserve

`resolveSlackThreadContext` already derives `isThreadReply`; its sibling `resolveSlackThreadTargets` already gates on it. The inbound `replyToId` formula simply never applied the same gate.

However, `replyToId` is **not** consumed only by prompt metadata: `buildSlackThreadingToolContext` also derived `currentThreadTs` from `ReplyToId` (`messageThreadTs ?? transportThreadTs ?? replyToThreadTs`). For a standalone triggering message in `first`/`batched` reply modes, that fallback was the only thread anchor, so naively gating `replyToId` would make message-tool sends post at the channel root instead of threading under the triggering message.

The fix therefore has two parts:
1. **Gate the prompt-facing value** — `replyToId = isThreadReply ? incomingThreadTs : undefined`.
2. **Keep the anchor** — `buildSlackThreadingToolContext` now falls back to the already-available `CurrentMessageId` (`... ?? replyToThreadTs ?? currentMessageTs`). `CurrentMessageId` is the semantically correct anchor for the current message; `ReplyToId` only carries a distinct value for genuine replies. For every existing input (non-null `ReplyToId`) the resolved `currentThreadTs` is unchanged — the new fallback only engages once `ReplyToId` is gated out.

## Changes

- `extensions/slack/src/threading.ts`: `replyToId = isThreadReply ? incomingThreadTs : undefined`.
- `extensions/slack/src/threading-tool-context.ts`: anchor `currentThreadTs` on `CurrentMessageId` as the final fallback so message-tool auto-threading survives the gated `reply_to_id`.
- `extensions/slack/src/threading.test.ts`, `extensions/slack/src/threading-tool-context.test.ts`: added focused `replyToId` gating tests and message-tool anchor regression tests; corrected prior assertions that had frozen the buggy `replyToId == message_id` value.

## User Impact

Every Slack integration: non-reply inbound messages get `reply_to_id` omitted instead of falsely equal to `message_id`, and message-tool sends still auto-thread under the triggering message in `first`/`batched` modes. Genuine threaded replies are unaffected.

## Evidence

### 1. Resolver-level before/after (standalone script, real code)

```
# BEFORE (origin/main — replyToId = incomingThreadTs ?? messageTs)
standalone (no thread_ts)     | isThreadReply=false reply_to_id="1751234567.123456"
thread-root (thread_ts==ts)   | isThreadReply=false reply_to_id="1751234567.123456"
genuine reply (thread_ts!=ts) | isThreadReply=true  reply_to_id="1751234567.123456"

# AFTER (this PR)
standalone (no thread_ts)     | isThreadReply=false reply_to_id=undefined
thread-root (thread_ts==ts)   | isThreadReply=false reply_to_id=undefined
genuine reply (thread_ts!=ts) | isThreadReply=true  reply_to_id="1751234567.123456"
```

### 2. Full-chain anchor preservation (resolver → tool-context, real code)

Driving `resolveSlackThreadContext` then `buildSlackThreadingToolContext` for a standalone `first`-mode message, `origin/main` vs this PR:

```
# BEFORE (origin/main)
prompt-facing reply_to_id (resolver)  = "1751234567.123456"   # bug: equals message_id
tool-context currentThreadTs (anchor) = "1751234567.123456"

# AFTER (this PR)
prompt-facing reply_to_id (resolver)  = undefined             # fixed: omitted for non-reply
tool-context currentThreadTs (anchor) = "1751234567.123456"   # anchor preserved — no regression
```

`reply_to_id` is now correctly omitted while `currentThreadTs` keeps anchoring message-tool sends under the triggering message.

### 3. Regression tests

```
 Test Files  2 passed (2)
      Tests  34 passed (34)
```

Includes new `replyToId gating` tests and `anchors to CurrentMessageId when ReplyToId is omitted` tests covering the message-tool path. `oxlint` on the changed files passes clean.

## AI-assisted

This PR was AI-assisted (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
