### PR TITLE
fix: transient failures no longer trigger false 12h OpenAI cooldown on expired access tokens

### DIFF
--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -1198,6 +1198,24 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
     expect(store.usageStats?.["openai:default"]?.cooldownUntil).toBe(now + 43_200_000);
   });
 
+  it("skips WHAM probe for locally expired OAuth access tokens", async () => {
+    const now = 1_700_000_000_000;
+    const store = makeStore({});
+    const profile = store.profiles["openai:default"];
+    if (profile?.type !== "oauth") {
+      throw new Error("expected OpenAI OAuth fixture");
+    }
+    profile.expires = now - 1;
+    mockWhamResponse(401);
+
+    await markCodexFailureAt({ store, now });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    const stats = store.usageStats?.["openai:default"];
+    expect(stats?.cooldownUntil).toBe(now + 30_000);
+    expect(stats?.cooldownReason).toBe("rate_limit");
+  });
+
   it("maps HTTP 403 to a 24h cooldown", async () => {
     const now = 1_700_000_000_000;
     const store = makeStore({});

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -124,6 +124,9 @@ function shouldProbeWhamForFailure(
   return (
     profile?.type === "oauth" &&
     Boolean(profile.access) &&
+    // Expired access tokens are routine and refreshable; probing with one
+    // guarantees a 401 that looks like a 12h token-family outage.
+    isFutureDateTimestampMs(profile.expires) &&
     normalizedProvider === "openai" &&
     (reason === "rate_limit" ||
       reason === "empty_response" ||


### PR DESCRIPTION
Closes #102471

## What Problem This Solves

Fixes an issue where OpenAI ChatGPT OAuth users would see the provider go dark for 12 hours (and get told to re-authenticate) after a single transient failure, whenever the failure happened while their stored access token had routinely expired. In fallback-configured setups this surfaces as recurring half-day OpenAI "outages" with the fallback model silently taking over.

## Why This Change Was Made

`markAuthProfileFailure` fires a live WHAM usage probe with the stored access token and never refreshes it; a locally expired token guarantees an HTTP 401, which the probe maps to a 12h `wham_token_expired` cooldown. An expired-by-clock access token is routine and refreshable, not a health signal, so `shouldProbeWhamForFailure` now also requires the token to be unexpired — a skipped probe leaves the normal 30s/1m/5m transient cooldown in place and the next attempt refreshes normally. A 401 with a locally valid token still means server-side revocation and keeps the intentional 12h cooldown. One-condition prod change; no config or behavior surface otherwise.

## User Impact

No more false 12-hour OpenAI cooldowns and unnecessary re-login prompts from transient failures that coincide with routine access-token expiry.

## Evidence

- Regression test: expired token + `rate_limit` → probe fetch never called, cooldown 30s with reason `rate_limit` (`usage.test.ts`). Negative proof: with only the test added and no prod change, it fails (fetch called with the expired bearer token, 78 passed / 1 failed).
- Existing 401-with-valid-token 12h test unchanged and green.
- `node scripts/run-vitest.mjs` — `usage.test.ts` 79 passed, `auth-profiles.markauthprofilefailure.test.ts` 14 passed; `pnpm tsgo:core` exit 0.
- Changed-lane gate: Blacksmith Testbox `tbx_01kx2t3m46bchejzg97esna88g`, `pnpm check:changed` exit 0.
- Autoreview (codex/gpt-5.5): clean.


## Review Follow-up (ClawSweeper round 1)

**Real behavior proof added** — production `markAuthProfileFailure` against a real on-disk agent SQLite store, hitting the **live** `chatgpt.com/backend-api/wham/usage` endpoint. The profile holds a deliberately fake, locally-expired access token (redaction-safe by construction; nothing real is transmitted). Same scenario both sides:

- `main` @ `f246fa39012` — the probe fires with the expired bearer token, the live endpoint returns a real 401, and the profile is parked:
  ```
  [repro] cooldown length: ~720 minutes
  [repro] RESULT: FALSE OUTAGE — live WHAM probe 401 on an expired-but-refreshable token parked the profile for 12h
  ```
- this branch, identical store and failure:
  ```
  [repro] cooldown length: ~1 minutes
  [repro] RESULT: SAFE — probe skipped for locally expired token; normal transient cooldown
  ```

Also rebased onto current `main` (past #102493's `usage.test.ts` isolation changes); focused suites re-run green after rebase: `usage.test.ts` + `auth-profiles.markauthprofilefailure.test.ts` — 93 passed.
