### PR TITLE
fix(read): reject non-positive offsets

### DIFF
--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -4,6 +4,7 @@ import { Buffer } from "node:buffer";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { Value } from "typebox/value";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import { withEnvAsync } from "../../../test-utils/env.js";
@@ -150,18 +151,33 @@ describe("read tool", () => {
     expect(textContent(result)).toBe("alpha\n\n[2 more lines in file. Use offset=2 to continue.]");
   });
 
-  it("rejects non-positive offsets instead of reading from the first line", async () => {
+  it.each([0, -1, 1.5])("rejects invalid offset %s before accessing the file", async (offset) => {
+    const access = vi.fn(async () => {});
+    const detectImageMimeType = vi.fn(async () => null);
+    const readFile = vi.fn(async () => Buffer.from("alpha\nbeta\ngamma"));
     const tool = createReadToolDefinition("/workspace", {
       operations: {
-        access: async () => {},
-        detectImageMimeType: async () => null,
-        readFile: async () => Buffer.from("alpha\nbeta\ngamma"),
+        access,
+        detectImageMimeType,
+        readFile,
       },
     });
 
     await expect(
-      tool.execute("call-1", { path: "notes.txt", offset: 0 }, undefined, undefined, {} as never),
+      tool.execute("call-1", { path: "notes.txt", offset }, undefined, undefined, {} as never),
     ).rejects.toThrow("Offset must be an integer at least 1");
+    expect(access).not.toHaveBeenCalled();
+    expect(detectImageMimeType).not.toHaveBeenCalled();
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it("declares offsets as positive integers in the tool schema", () => {
+    const tool = createReadToolDefinition("/workspace");
+
+    expect(Value.Check(tool.parameters, { path: "notes.txt", offset: 1 })).toBe(true);
+    for (const offset of [0, -1, 1.5]) {
+      expect(Value.Check(tool.parameters, { path: "notes.txt", offset })).toBe(false);
+    }
   });
 
   it("uses the shared Windows decoder for local filesystem reads", async () => {

--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -150,6 +150,20 @@ describe("read tool", () => {
     expect(textContent(result)).toBe("alpha\n\n[2 more lines in file. Use offset=2 to continue.]");
   });
 
+  it("rejects non-positive offsets instead of reading from the first line", async () => {
+    const tool = createReadToolDefinition("/workspace", {
+      operations: {
+        access: async () => {},
+        detectImageMimeType: async () => null,
+        readFile: async () => Buffer.from("alpha\nbeta\ngamma"),
+      },
+    });
+
+    await expect(
+      tool.execute("call-1", { path: "notes.txt", offset: 0 }, undefined, undefined, {} as never),
+    ).rejects.toThrow("Offset must be an integer at least 1");
+  });
+
   it("uses the shared Windows decoder for local filesystem reads", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-read-encoding-"));
     const filePath = path.join(tempDir, "legacy.txt");
@@ -214,6 +228,6 @@ describe("read tool", () => {
     );
 
     expect(decodeWindowsTextFileBufferMock).not.toHaveBeenCalled();
-    expect(textContent(result)).toBe("/workspace/legacy.txt:c4e3bac3");
+    expect(textContent(result)).toBe(`${path.resolve("/workspace", "legacy.txt")}:c4e3bac3`);
   });
 });

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -332,8 +332,11 @@ export function createReadToolDefinition(
                 ops.decodeText?.({ buffer, absolutePath }) ?? buffer.toString("utf8");
               const allLines = textContent.split("\n");
               const totalFileLines = allLines.length;
+              if (offset !== undefined && (!Number.isSafeInteger(offset) || offset < 1)) {
+                throw new Error("Offset must be an integer at least 1");
+              }
               // Apply offset if specified. Convert from 1-indexed input to 0-indexed array access.
-              const startLine = offset ? Math.max(0, offset - 1) : 0;
+              const startLine = offset === undefined ? 0 : offset - 1;
               const startLineDisplay = startLine + 1;
               // Check if offset is out of bounds.
               if (startLine >= allLines.length) {

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -39,7 +39,7 @@ import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateHead } from "
 const readSchema = Type.Object({
   path: Type.String({ description: "Path to the file to read (relative or absolute)" }),
   offset: Type.Optional(
-    Type.Number({ description: "Line number to start reading from (1-indexed)" }),
+    Type.Integer({ minimum: 1, description: "Line number to start reading from (1-indexed)" }),
   ),
   limit: Type.Optional(Type.Number({ description: "Maximum number of lines to read" })),
 });
@@ -272,6 +272,9 @@ export function createReadToolDefinition(
     ) {
       void toolCallId;
       void onUpdate;
+      if (offset !== undefined && (!Number.isSafeInteger(offset) || offset < 1)) {
+        throw new Error("Offset must be an integer at least 1");
+      }
       return new Promise<{
         content: (TextContent | ImageContent)[];
         details: ReadToolDetails | undefined;
@@ -332,9 +335,6 @@ export function createReadToolDefinition(
                 ops.decodeText?.({ buffer, absolutePath }) ?? buffer.toString("utf8");
               const allLines = textContent.split("\n");
               const totalFileLines = allLines.length;
-              if (offset !== undefined && (!Number.isSafeInteger(offset) || offset < 1)) {
-                throw new Error("Offset must be an integer at least 1");
-              }
               // Apply offset if specified. Convert from 1-indexed input to 0-indexed array access.
               const startLine = offset === undefined ? 0 : offset - 1;
               const startLineDisplay = startLine + 1;


### PR DESCRIPTION
## What Problem This Solves
Fixes an issue where callers using the read session tool with `offset: 0` could read from the first line even though the tool schema defines `offset` as a 1-indexed line number.

## Why This Change Was Made
The read tool now validates any provided offset before converting it to a zero-based slice index. Omitted offsets still start at the beginning, and positive offsets keep the existing read behavior; the fix stays within the session read tool boundary.

## User Impact
Developers and agents now get a clear validation error for invalid non-positive read offsets instead of a silent first-line read that contradicts the documented argument contract.

## Evidence
- Claim proved: the real session read tool rejects non-positive offsets against an actual file while preserving omitted and positive offset behavior.
- Current-head real behavior proof at `993abd14d7576b78e68367a61bb5b22580791bcc`: `node --import tsx --input-type=module -` ran a stdin script that imported `createReadToolDefinition` from `src/agents/sessions/tools/read.ts`, wrote a real `notes.txt`, and invoked `execute(...)` for omitted, positive, and zero offsets.

```text
HEAD 993abd14d7576b78e68367a61bb5b22580791bcc
REAL_FILE notes.txt
FILE_BYTES alpha\nbeta\ngamma
CASE omitted-offset: ok
alpha
beta
gamma
CASE positive-offset: ok
beta

[1 more lines in file. Use offset=3 to continue.]
CASE zero-offset: error
Offset must be an integer at least 1
```

- Focused regression proof: `node scripts/run-vitest.mjs src/agents/sessions/tools/read.test.ts` passed with 1 file and 8 tests.
- Committed diff hygiene: `git diff --check upstream/main...HEAD` passed.
- Review proof: `python .agents\skills\autoreview\scripts\autoreview --mode branch --base upstream/main` passed with no accepted/actionable findings.
- Observed result: `offset: 0` now returns `Offset must be an integer at least 1`; omitted offsets read from the first line, and `offset: 2, limit: 1` reads `beta` with the existing continuation hint.