### PR TITLE
fix(ui): keep hidden agent sessions out of configured-only lists

### DIFF
--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -251,6 +251,67 @@ describe("createSessionCapability", () => {
     ).toBe(result);
   });
 
+  it("refreshes instead of inserting hidden sessions after configured-only lists", async () => {
+    const visibleKey = "agent:main:main";
+    const hiddenKey = "agent:local:hidden";
+    let eventListener: ((event: GatewayEventFrame) => void) | undefined;
+    const request = vi.fn(async (method: string) => {
+      if (method !== "sessions.list") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      return sessionsResult(
+        [
+          {
+            key: visibleKey,
+            kind: "direct",
+            updatedAt: 1,
+            sessionId: "visible-session",
+          },
+        ],
+        1,
+      );
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const sessions = createSessionCapability({
+      snapshot: {
+        client,
+        connected: true,
+        sessionKey: visibleKey,
+        assistantAgentId: "main",
+        hello: null,
+      },
+      subscribe: () => () => undefined,
+      subscribeEvents: (listener: (event: GatewayEventFrame) => void) => {
+        eventListener = listener;
+        return () => undefined;
+      },
+    });
+
+    await sessions.refresh({ force: true });
+    expect(request).toHaveBeenCalledWith(
+      "sessions.list",
+      expect.objectContaining({ configuredAgentsOnly: true }),
+    );
+
+    eventListener?.({
+      type: "event",
+      event: "sessions.changed",
+      payload: {
+        session: {
+          key: hiddenKey,
+          kind: "direct",
+          updatedAt: 2,
+          sessionId: "hidden-session",
+          label: "Hidden",
+        },
+      },
+    });
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    expect(sessions.state.result?.sessions.map((row) => row.key)).toEqual([visibleKey]);
+    sessions.dispose();
+  });
+
   it("refreshes stale active rows after a terminal session message", async () => {
     const key = "agent:main:main";
     const request = vi

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -286,6 +286,16 @@ function buildSessionListParams(options: SessionListOptions = {}): Record<string
   return params;
 }
 
+function sessionListEventScopeOptions(options: SessionListOptions = {}): SessionListOptions {
+  return {
+    ...options,
+    includeGlobal: options.includeGlobal ?? SESSION_LIST_PARAMS.includeGlobal,
+    includeUnknown: options.includeUnknown ?? SESSION_LIST_PARAMS.includeUnknown,
+    configuredAgentsOnly:
+      options.configuredAgentsOnly ?? SESSION_LIST_PARAMS.configuredAgentsOnly,
+  };
+}
+
 async function requestSessionList(
   client: SessionRequestClient,
   options: SessionListOptions = {},
@@ -618,7 +628,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       return;
     }
     const { append = false, force: _force, backgroundHydrate = false, ...requestOptions } = options;
-    lastListOptions = requestOptions;
+    lastListOptions = sessionListEventScopeOptions(requestOptions);
     if (!backgroundHydrate) {
       publish({ ...state, loading: true, error: null, deletedSessions: [] });
     }


### PR DESCRIPTION
# fix(ui): keep hidden agent sessions out of configured-only lists

## What Problem This Solves

Fixes an issue where users viewing the Control UI session list could briefly see sessions from hidden or unconfigured agent stores when a broad `sessions.changed` event arrived after the list had been loaded with the default configured-agent filter.

The default Control UI session list requests `configuredAgentsOnly: true`, so the backend correctly excludes sessions from unconfigured agent stores. However, the event reconciliation path tracked only the raw caller options. For the default list, that raw options object is empty, so the UI treated broad session events as safe to merge into the current list even though the actual backend list was configured-only.

Example:

| Step | Expected | Previous behavior |
| --- | --- | --- |
| Control UI loads sessions with default options | Backend list includes only configured agents | Correct |
| Gateway emits `sessions.changed` for `agent:local:hidden` | UI should refresh or ignore the hidden row | UI could insert the hidden row |
| User refreshes the page/list | Hidden row disappears | The list appears inconsistent |

## Why This Change Was Made

The fix makes the event reconciliation scope use the same effective list defaults as `sessions.list`. Default `includeGlobal`, `includeUnknown`, and `configuredAgentsOnly` values are now preserved in the stored list options used by event handling.

This keeps the fast incremental reconciliation path for broad, unfiltered lists, while forcing a refresh when the current list has a configured-agent filter that a broad event cannot safely evaluate client-side.

## User Impact

Users no longer see hidden or unconfigured agent sessions appear in the Control UI session list after live session updates.

This removes a confusing UI state where an unexpected session could appear from a background event and then disappear after refresh, making the session list match the backend filter consistently.

## Evidence

### Current behavior proof

The default list params include configured-agent filtering:

- `ui/src/lib/sessions/index.ts` defines `SESSION_LIST_PARAMS` with `configuredAgentsOnly: true`.
- `requestSessionList()` sends those effective defaults to `sessions.list`.

Before this change, `createSessionCapability.load()` saved only the raw `requestOptions` into `lastListOptions`. For a default refresh, that meant `{}`. Then `canReconcileSessionEvent()` only blocked incremental reconciliation when `configuredAgentsOnly === true`, so the default configured-only list was incorrectly treated as safe for broad event insertion.

### Before

```text
Initial sessions.list params:
  configuredAgentsOnly: true

Initial visible list:
  ["agent:main:main"]

Incoming sessions.changed event:
  session.key = "agent:local:hidden"
  session.kind = "direct"
  session.updatedAt = 2
  session.sessionId = "hidden-session"

Previous UI behavior:
  Event could be reconciled into the current list because lastListOptions was {}
  Visible list could become:
    ["agent:local:hidden", "agent:main:main"]
```

### After

```text
Initial sessions.list params:
  configuredAgentsOnly: true

Stored event scope:
  configuredAgentsOnly: true

Incoming sessions.changed event:
  session.key = "agent:local:hidden"

Fixed UI behavior:
  Event is not incrementally inserted into the configured-only list.
  UI refreshes through sessions.list and keeps the backend-filtered result:
    ["agent:main:main"]
```

### Regression guard

Added a focused test covering the exact path:

- Default `sessions.refresh({ force: true })` sends `configuredAgentsOnly: true`.
- A broad `sessions.changed` event for `agent:local:hidden` is emitted.
- The capability refreshes instead of inserting the hidden row.
- Final UI state still contains only `agent:main:main`.

## Tests and Validation

```bash
OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs ui/src/lib/sessions/index.test.ts
```

Result:

```text
[test] starting test/vitest/vitest.ui.config.ts
[test] passed 1 Vitest shard
```

Also checked:

```bash
git diff --check -- ui/src/lib/sessions/index.ts ui/src/lib/sessions/index.test.ts
```

## Risk Checklist

- User-visible behavior: Yes. Control UI session lists stay consistent with configured-agent filtering after live updates.
- Config/env/migration behavior: No.
- Protocol/API behavior: No. This only changes client-side event reconciliation scope.
- Security/auth/secrets/network/tool execution: No.
- Plugins/providers/channels/SDK: No.
- Highest-risk area: Low. The change makes event handling respect the same defaults already used by `sessions.list`.
- Mitigation: Focused regression test proves hidden-session events no longer pollute default configured-only lists.

Closes: N/A
