### PR TITLE
fix(browser): avoid UTF-16 unsafe truncation in snapshot helpers

### DIFF
--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -634,7 +634,7 @@ async function findCursorInteractiveElements(
           }
           el.setAttribute("${attr}", String(out.length));
           out.push({
-            text: String(el.textContent || "").replace(/\\s+/g, " ").trim().slice(0, 101),
+            text: String(el.textContent || "").replace(/\\s+/g, " ").trim(),
             tagName,
             hasCursorPointer,
             hasOnClick,

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -80,8 +80,7 @@ async function collectSnapshotUrls(page: Page): Promise<SnapshotUrlEntry[]> {
         const text =
           (anchor.textContent || anchor.getAttribute("aria-label") || "")
             .replace(/\s+/g, " ")
-            .trim()
-            .slice(0, 121) || href;
+            .trim() || href;
         seen.add(href);
         out.push({ text, url: href });
         if (out.length >= 100) {

--- a/extensions/browser/src/browser/routes/agent.snapshot.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.ts
@@ -80,8 +80,7 @@ async function collectChromeMcpSnapshotUrls(
         if (!href || seen.has(href)) continue;
         const text = (anchor.innerText || anchor.textContent || anchor.getAttribute("aria-label") || "")
           .replace(/\\s+/g, " ")
-          .trim()
-          .slice(0, 121) || href;
+          .trim() || href;
         seen.add(href);
         out.push({ text, url: href });
         if (out.length >= 100) break;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where browser snapshot helpers could produce invalid UTF-16 strings when truncating long element text or link labels. The inner browser-side `.slice(0, N)` cuts on raw code-unit offsets and can split surrogate pairs; the outer `truncateUtf16Safe` guard then receives an already-broken string.

## Why This Change Was Made

Removes the redundant `.slice(0, N)` pre-truncation inside the evaluated browser scripts and lets the existing canonical `truncateUtf16Safe(..., 100/120)` helper handle the final boundary on the Node side. This keeps UTF-16 safety in one place and matches the repo guidance that only the canonical helper should own metadata/text boundaries.

## User Impact

Browser snapshots (cursor-interactive elements, link lists, and Chrome MCP link labels) now keep valid UTF-16 when content is near the length cap. No user-facing behavior change for content below the cap.

## Evidence

Local validation on `fix/browser-utf16-truncation`:

```bash
node scripts/run-oxlint.mjs \
  extensions/browser/src/browser/cdp.ts \
  extensions/browser/src/browser/pw-tools-core.snapshot.ts \
  extensions/browser/src/browser/routes/agent.snapshot.ts

node scripts/run-tsgo.mjs -p extensions/browser/tsconfig.json --noEmit

npx oxfmt --check --threads=1 \
  extensions/browser/src/browser/cdp.ts \
  extensions/browser/src/browser/pw-tools-core.snapshot.ts \
  extensions/browser/src/browser/routes/agent.snapshot.ts

node scripts/run-vitest.mjs \
  extensions/browser/src/browser/pw-tools-core.snapshot.test.ts \
  extensions/browser/src/browser/cdp.internal.test.ts \
  extensions/browser/src/browser/routes/agent.snapshot.local-managed.test.ts \
  extensions/browser/src/browser/routes/agent.snapshot.timeout.test.ts
```

- Lint / type-check / format check: passed.
- Focused tests: **46 passed**.
- Full `extensions/browser` suite had one unrelated failure in `cdp-proxy-bypass.test.ts` caused by a non-empty `NO_PROXY` environment variable.
