### PR TITLE
feat(providers): refresh direct catalogs for Qwen 3.7, North Mini Code, and Mistral Small 4

### DIFF
--- a/extensions/cohere/index.test.ts
+++ b/extensions/cohere/index.test.ts
@@ -89,6 +89,18 @@ describe("Cohere provider plugin", () => {
             maxTokensField: "max_tokens",
           },
         }),
+        expect.objectContaining({
+          id: "north-mini-code-1-0",
+          contextWindow: 256000,
+          maxTokens: 64000,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          compat: {
+            supportsStore: false,
+            supportsUsageInStreaming: false,
+            maxTokensField: "max_tokens",
+          },
+        }),
       ],
     });
   });

--- a/extensions/cohere/openclaw.plugin.json
+++ b/extensions/cohere/openclaw.plugin.json
@@ -30,6 +30,24 @@
               "supportsUsageInStreaming": false,
               "maxTokensField": "max_tokens"
             }
+          },
+          {
+            "id": "north-mini-code-1-0",
+            "name": "North Mini Code 1.0",
+            "input": ["text"],
+            "contextWindow": 256000,
+            "maxTokens": 64000,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsUsageInStreaming": false,
+              "maxTokensField": "max_tokens"
+            }
           }
         ]
       }

--- a/extensions/mistral/model-definitions.test.ts
+++ b/extensions/mistral/model-definitions.test.ts
@@ -68,8 +68,20 @@ describe("mistral model definitions", () => {
     const smallLatest = catalogModelById(models, "mistral-small-latest");
     expect(smallLatest.reasoning).toBe(true);
     expect(smallLatest.input).toEqual(["text", "image"]);
-    expect(smallLatest.contextWindow).toBe(128000);
+    expect(smallLatest.contextWindow).toBe(256000);
     expect(smallLatest.maxTokens).toBe(16384);
+
+    const small2603 = catalogModelById(models, "mistral-small-2603");
+    expect(small2603.reasoning).toBe(true);
+    expect(small2603.input).toEqual(["text"]);
+    expect(small2603.contextWindow).toBe(256000);
+    expect(small2603.maxTokens).toBe(16384);
+    expect(small2603.cost).toEqual({
+      input: 0.15,
+      output: 0.6,
+      cacheRead: 0.015,
+      cacheWrite: 0,
+    });
 
     const pixtralLarge = catalogModelById(models, "pixtral-large-latest");
     expect(pixtralLarge.input).toEqual(["text", "image"]);

--- a/extensions/mistral/openclaw.plugin.json
+++ b/extensions/mistral/openclaw.plugin.json
@@ -106,16 +106,30 @@
             }
           },
           {
+            "id": "mistral-small-2603",
+            "name": "Mistral Small 4",
+            "input": ["text"],
+            "reasoning": true,
+            "contextWindow": 256000,
+            "maxTokens": 16384,
+            "cost": {
+              "input": 0.15,
+              "output": 0.6,
+              "cacheRead": 0.015,
+              "cacheWrite": 0
+            }
+          },
+          {
             "id": "mistral-small-latest",
             "name": "Mistral Small (latest)",
             "input": ["text", "image"],
             "reasoning": true,
-            "contextWindow": 128000,
+            "contextWindow": 256000,
             "maxTokens": 16384,
             "cost": {
-              "input": 0.1,
-              "output": 0.3,
-              "cacheRead": 0.01,
+              "input": 0.15,
+              "output": 0.6,
+              "cacheRead": 0.015,
               "cacheWrite": 0
             }
           },

--- a/extensions/qwen/api.ts
+++ b/extensions/qwen/api.ts
@@ -8,6 +8,8 @@ export {
   isQwen36PlusSupportedBaseUrl,
   isQwenCodingPlanBaseUrl,
   QWEN_36_PLUS_MODEL_ID,
+  QWEN_37_MAX_MODEL_ID,
+  QWEN_37_PLUS_MODEL_ID,
   QWEN_BASE_URL,
   QWEN_CN_BASE_URL,
   QWEN_DEFAULT_COST,

--- a/extensions/qwen/models.ts
+++ b/extensions/qwen/models.ts
@@ -19,6 +19,10 @@ export const QWEN_OAUTH_BASE_URL = "https://portal.qwen.ai/v1";
 
 export const QWEN_DEFAULT_MODEL_ID = "qwen3.5-plus";
 export const QWEN_36_PLUS_MODEL_ID = "qwen3.6-plus";
+export const QWEN_37_MAX_MODEL_ID = "qwen3.7-max";
+export const QWEN_37_PLUS_MODEL_ID = "qwen3.7-plus";
+
+const QWEN_37_MODEL_IDS = new Set([QWEN_37_MAX_MODEL_ID, QWEN_37_PLUS_MODEL_ID]);
 export const QWEN_DEFAULT_COST = {
   input: 0,
   output: 0,
@@ -43,6 +47,24 @@ export const QWEN_MODEL_CATALOG: ReadonlyArray<ModelDefinitionConfig> = [
     name: QWEN_36_PLUS_MODEL_ID,
     reasoning: false,
     input: ["text", "image"],
+    cost: QWEN_DEFAULT_COST,
+    contextWindow: 1_000_000,
+    maxTokens: 65_536,
+  },
+  {
+    id: QWEN_37_MAX_MODEL_ID,
+    name: QWEN_37_MAX_MODEL_ID,
+    reasoning: false,
+    input: ["text"],
+    cost: QWEN_DEFAULT_COST,
+    contextWindow: 1_000_000,
+    maxTokens: 65_536,
+  },
+  {
+    id: QWEN_37_PLUS_MODEL_ID,
+    name: QWEN_37_PLUS_MODEL_ID,
+    reasoning: false,
+    input: ["text"],
     cost: QWEN_DEFAULT_COST,
     contextWindow: 1_000_000,
     maxTokens: 65_536,
@@ -137,7 +159,9 @@ export function buildQwenModelCatalogForBaseUrl(
 ): ReadonlyArray<ModelDefinitionConfig> {
   return isQwen36PlusSupportedBaseUrl(baseUrl)
     ? QWEN_MODEL_CATALOG
-    : QWEN_MODEL_CATALOG.filter((model) => model.id !== QWEN_36_PLUS_MODEL_ID);
+    : QWEN_MODEL_CATALOG.filter(
+        (model) => model.id !== QWEN_36_PLUS_MODEL_ID && !QWEN_37_MODEL_IDS.has(model.id),
+      );
 }
 
 export function isNativeQwenBaseUrl(baseUrl: string | undefined): boolean {
@@ -183,7 +207,10 @@ export function buildQwenDefaultModelDefinition(): ModelDefinitionConfig {
 }
 
 export function buildQwenOAuthModelCatalog(): ReadonlyArray<ModelDefinitionConfig> {
-  return QWEN_MODEL_CATALOG.map((model) => ({ ...model, maxTokens: 65_536 }));
+  return QWEN_MODEL_CATALOG.filter((model) => !QWEN_37_MODEL_IDS.has(model.id)).map((model) => ({
+    ...model,
+    maxTokens: 65_536,
+  }));
 }
 
 /** @deprecated Use QWEN_BASE_URL. */

--- a/extensions/qwen/openclaw.plugin.json
+++ b/extensions/qwen/openclaw.plugin.json
@@ -77,6 +77,42 @@
           "baseUrlHosts": ["coding.dashscope.aliyuncs.com", "coding-intl.dashscope.aliyuncs.com"],
           "providerConfigApiIn": ["qwen", "modelstudio"]
         }
+      },
+      {
+        "provider": "qwen",
+        "model": "qwen3.7-max",
+        "reason": "qwen3.7-max is not supported on the Qwen Coding Plan endpoint; use a Standard pay-as-you-go Qwen endpoint.",
+        "when": {
+          "baseUrlHosts": ["coding.dashscope.aliyuncs.com", "coding-intl.dashscope.aliyuncs.com"],
+          "providerConfigApiIn": ["qwen", "modelstudio"]
+        }
+      },
+      {
+        "provider": "modelstudio",
+        "model": "qwen3.7-max",
+        "reason": "qwen3.7-max is not supported on the Qwen Coding Plan endpoint; use a Standard pay-as-you-go Qwen endpoint.",
+        "when": {
+          "baseUrlHosts": ["coding.dashscope.aliyuncs.com", "coding-intl.dashscope.aliyuncs.com"],
+          "providerConfigApiIn": ["qwen", "modelstudio"]
+        }
+      },
+      {
+        "provider": "qwen",
+        "model": "qwen3.7-plus",
+        "reason": "qwen3.7-plus is not supported on the Qwen Coding Plan endpoint; use a Standard pay-as-you-go Qwen endpoint.",
+        "when": {
+          "baseUrlHosts": ["coding.dashscope.aliyuncs.com", "coding-intl.dashscope.aliyuncs.com"],
+          "providerConfigApiIn": ["qwen", "modelstudio"]
+        }
+      },
+      {
+        "provider": "modelstudio",
+        "model": "qwen3.7-plus",
+        "reason": "qwen3.7-plus is not supported on the Qwen Coding Plan endpoint; use a Standard pay-as-you-go Qwen endpoint.",
+        "when": {
+          "baseUrlHosts": ["coding.dashscope.aliyuncs.com", "coding-intl.dashscope.aliyuncs.com"],
+          "providerConfigApiIn": ["qwen", "modelstudio"]
+        }
       }
     ],
     "providers": {

--- a/extensions/qwen/provider-catalog.test.ts
+++ b/extensions/qwen/provider-catalog.test.ts
@@ -6,6 +6,8 @@ import {
   QWEN_BASE_URL,
   QWEN_STANDARD_GLOBAL_BASE_URL,
   QWEN_DEFAULT_MODEL_ID,
+  QWEN_37_MAX_MODEL_ID,
+  QWEN_37_PLUS_MODEL_ID,
 } from "./api.js";
 
 type QwenProvider = ReturnType<typeof buildQwenProvider>;
@@ -36,6 +38,16 @@ describe("qwen provider catalog", () => {
     expect(getQwenModelIds(coding)).not.toContain("qwen3.6-plus");
     expect(getQwenModelIds(codingTrailingDot)).not.toContain("qwen3.6-plus");
     expect(getQwenModelIds(standard)).toContain("qwen3.6-plus");
+  });
+
+  it("only advertises qwen3.7 models on Standard endpoints", () => {
+    const coding = buildQwenProvider({ baseUrl: QWEN_BASE_URL });
+    const standard = buildQwenProvider({ baseUrl: QWEN_STANDARD_GLOBAL_BASE_URL });
+
+    expect(getQwenModelIds(coding)).not.toContain(QWEN_37_MAX_MODEL_ID);
+    expect(getQwenModelIds(coding)).not.toContain(QWEN_37_PLUS_MODEL_ID);
+    expect(getQwenModelIds(standard)).toContain(QWEN_37_MAX_MODEL_ID);
+    expect(getQwenModelIds(standard)).toContain(QWEN_37_PLUS_MODEL_ID);
   });
 
   it("opts native Qwen baseUrls into streaming usage only inside the extension", () => {


### PR DESCRIPTION
## What Problem This Solves

Closes #102460.

The official Qwen and Cohere plugins do not expose several current popular models, while the Mistral plugin still describes `mistral-small-latest` with the previous generation's context and pricing. Users must add custom model entries or accept incorrect cost/context reporting.

## Why This Change Was Made

- **Qwen**: `qwen3.7-max` and `qwen3.7-plus` are the recommended text generation models per [Alibaba Model Studio docs](https://docs.qwencloud.com/developer-guides/getting-started/text-generation-models) but absent from the catalog. Added to Standard catalog only (excluded from Coding Plan and OAuth, same as qwen3.6-plus).
- **Cohere**: North Mini Code 1.0 (`north-mini-code-1-0`) is a free, open-weight agentic coding model per [Cohere docs](https://docs.cohere.com/v2/docs/north-mini-code-1.0) but not available in the compatibility API catalog.
- **Mistral**: Mistral Small 4 replaced the previous generation with 256K context and $0.15/$0.60 pricing per [Mistral docs](https://docs.mistral.ai/models/model-cards/mistral-small-4-0-26-03). The pinned `mistral-small-2603` entry provides a stable reference point.

## User Impact

- **Affected**: Direct Qwen, Cohere, and Mistral users.
- **Before**: Missing model entries block selection; stale Mistral Small latest metadata shows wrong context (128K) and pricing ($0.10/$0.30).
- **After**: `qwen3.7-max` and `qwen3.7-plus` available on Standard endpoints; `north-mini-code-1-0` available in Cohere catalog; Mistral Small latest aligned with Small 4 specs; pinned `mistral-small-2603` added.
- No config, env var, auth flow, endpoint, or default model changes.

## Evidence

### Files Changed (8 files, +140/-7)

| File | Change |
|------|--------|
| `extensions/qwen/models.ts` | Add qwen3.7-max/qwen3.7-plus entries + Coding Plan/OAuth filters |
| `extensions/qwen/api.ts` | Export new model ID constants |
| `extensions/qwen/openclaw.plugin.json` | Add Coding Plan endpoint suppressions |
| `extensions/qwen/provider-catalog.test.ts` | Add "3.7 models on Standard only" test |
| `extensions/cohere/openclaw.plugin.json` | Add north-mini-code-1-0 entry |
| `extensions/cohere/index.test.ts` | Update catalog assertion |
| `extensions/mistral/openclaw.plugin.json` | Update small-latest context/pricing + add small-2603 |
| `extensions/mistral/model-definitions.test.ts` | Update small-latest + small-2603 assertions |

### Test Results

```
Qwen  (4/4) ✓  builds the bundled Qwen provider defaults
              ✓  only advertises qwen3.6-plus on Standard endpoints
              ✓  only advertises qwen3.7 models on Standard endpoints
              ✓  opts native Qwen baseUrls into streaming usage

Cohere (3/3) ✓  registers the manifest-owned API key onboarding flow
              ✓  exposes the static Cohere catalog
              ✓  uses Cohere's OpenAI-compatible completions payload fields

Mistral (4/4) ✓  uses current OpenClaw pricing for the bundled default model
              ✓  prices cached Mistral input tokens at ten percent
              ✓  charges nonzero cost for cached-token usage
              ✓  publishes a curated set of current Mistral catalog models
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)