### PR TITLE
test: fix cross-file mock leakage making auth-profiles suite nondeterministically red

### DIFF
--- a/src/agents/auth-profiles/external-oauth.test.ts
+++ b/src/agents/auth-profiles/external-oauth.test.ts
@@ -12,9 +12,10 @@ import type { AuthProfileStore, OAuthCredential } from "./types.js";
 const resolveExternalAuthProfilesWithPluginsMock = vi.fn<
   (params: unknown) => ProviderExternalAuthProfile[]
 >(() => []);
-const readCodexCliCredentialsCachedMock = vi.hoisted(() =>
-  vi.fn<(_options?: unknown) => OAuthCredential | null>(() => null),
-);
+const readCodexCliCredentialsCachedMock = vi.hoisted(() => {
+  vi.resetModules();
+  return vi.fn<(_options?: unknown) => OAuthCredential | null>(() => null);
+});
 
 vi.mock("../cli-credentials.js", () => ({
   readClaudeCliCredentialsCached: () => null,

--- a/src/agents/auth-profiles/oauth-common-mocks.test-support.ts
+++ b/src/agents/auth-profiles/oauth-common-mocks.test-support.ts
@@ -3,15 +3,18 @@
  * Provides hoisted provider-runtime, CLI credential, doctor, and external CLI
  * sync mocks so OAuth tests can stay focused on store behavior.
  */
-import { vi } from "vitest";
+import { afterAll, vi } from "vitest";
 import type { OAuthCredential } from "./types.js";
 
-const oauthProviderRuntimeMocks = vi.hoisted(() => ({
-  refreshProviderOAuthCredentialWithPluginMock: vi.fn(
-    async (_params?: { context?: unknown }) => undefined,
-  ),
-  formatProviderAuthProfileApiKeyWithPluginMock: vi.fn(() => undefined),
-}));
+const oauthProviderRuntimeMocks = vi.hoisted(() => {
+  vi.resetModules();
+  return {
+    refreshProviderOAuthCredentialWithPluginMock: vi.fn(
+      async (_params?: { context?: unknown }) => undefined,
+    ),
+    formatProviderAuthProfileApiKeyWithPluginMock: vi.fn(() => undefined),
+  };
+});
 
 /** Return hoisted provider-runtime OAuth mocks for per-test setup. */
 export function getOAuthProviderRuntimeMocks() {
@@ -51,3 +54,11 @@ vi.mock("./external-cli-sync.js", () => ({
   shouldReplaceStoredOAuthCredential: (existing: unknown, incoming: unknown) =>
     existing !== incoming,
 }));
+
+afterAll(() => {
+  vi.doUnmock("../cli-credentials.js");
+  vi.doUnmock("../../plugins/provider-runtime.runtime.js");
+  vi.doUnmock("./doctor.js");
+  vi.doUnmock("./external-cli-sync.js");
+  vi.resetModules();
+});

--- a/src/agents/auth-profiles/oauth-external-auth-passthrough.test-support.ts
+++ b/src/agents/auth-profiles/oauth-external-auth-passthrough.test-support.ts
@@ -3,10 +3,15 @@
  * Keeps tests that exercise local stores isolated from runtime external auth
  * overlays and persistence decisions.
  */
-import { vi } from "vitest";
+import { afterAll, vi } from "vitest";
 
 vi.mock("./external-auth.js", () => ({
   listRuntimeExternalAuthProfiles: () => [],
   overlayExternalAuthProfiles: <T>(store: T) => store,
   syncPersistedExternalCliAuthProfiles: <T>(store: T) => store,
 }));
+
+afterAll(() => {
+  vi.doUnmock("./external-auth.js");
+  vi.resetModules();
+});

--- a/src/agents/auth-profiles/oauth-file-lock-passthrough.test-support.ts
+++ b/src/agents/auth-profiles/oauth-file-lock-passthrough.test-support.ts
@@ -3,7 +3,7 @@
  * Avoids real interprocess locking so store operations remain deterministic in
  * single-process Vitest cases.
  */
-import { vi } from "vitest";
+import { afterAll, vi } from "vitest";
 
 vi.mock("../../infra/file-lock.js", () => ({
   resetFileLockStateForTest: () => undefined,
@@ -14,3 +14,9 @@ vi.mock("../../plugin-sdk/file-lock.js", () => ({
   resetFileLockStateForTest: () => undefined,
   withFileLock: async <T>(_filePath: string, _options: unknown, run: () => Promise<T>) => run(),
 }));
+
+afterAll(() => {
+  vi.doUnmock("../../infra/file-lock.js");
+  vi.doUnmock("../../plugin-sdk/file-lock.js");
+  vi.resetModules();
+});

--- a/src/agents/auth-profiles/oauth.fallback-to-main-agent.test.ts
+++ b/src/agents/auth-profiles/oauth.fallback-to-main-agent.test.ts
@@ -18,11 +18,14 @@ import {
   saveAuthProfileStore,
 } from "./store.js";
 import type { AuthProfileStore } from "./types.js";
-const { getOAuthApiKeyMock } = vi.hoisted(() => ({
-  getOAuthApiKeyMock: vi.fn(async () => {
-    throw new Error("invalid_grant");
-  }),
-}));
+const { getOAuthApiKeyMock } = vi.hoisted(() => {
+  vi.resetModules();
+  return {
+    getOAuthApiKeyMock: vi.fn(async () => {
+      throw new Error("invalid_grant");
+    }),
+  };
+});
 
 vi.mock("../../llm/oauth.js", () => ({
   getOAuthApiKey: getOAuthApiKeyMock,
@@ -52,6 +55,7 @@ afterAll(() => {
   vi.doUnmock("../cli-credentials.js");
   vi.doUnmock("../../plugins/provider-runtime.runtime.js");
   vi.doUnmock("../../plugins/provider-runtime.js");
+  vi.resetModules();
 });
 
 function createUsableOAuthExpiry(): number {

--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -29,11 +29,14 @@ let hasAvailableAuthForProvider: typeof import("../model-auth.js").hasAvailableA
 let markAuthProfileSuccess: typeof import("./profiles.js").markAuthProfileSuccess;
 type GetOAuthApiKey = typeof import("../../llm/oauth.js").getOAuthApiKey;
 
-const { getOAuthApiKeyMock } = vi.hoisted(() => ({
-  getOAuthApiKeyMock: vi.fn<GetOAuthApiKey>(async () => {
-    throw new Error("Failed to extract accountId from token");
-  }),
-}));
+const { getOAuthApiKeyMock } = vi.hoisted(() => {
+  vi.resetModules();
+  return {
+    getOAuthApiKeyMock: vi.fn<GetOAuthApiKey>(async () => {
+      throw new Error("Failed to extract accountId from token");
+    }),
+  };
+});
 
 const { readCodexCliCredentialsCachedMock } = vi.hoisted(() => ({
   readCodexCliCredentialsCachedMock: vi.fn<(_options?: unknown) => OAuthCredential | null>(
@@ -86,6 +89,7 @@ afterAll(() => {
   vi.doUnmock("../cli-credentials.js");
   vi.doUnmock("../../plugins/provider-runtime.runtime.js");
   vi.doUnmock("../../plugins/provider-runtime.js");
+  vi.resetModules();
 });
 
 async function readPersistedStore(agentDir: string): Promise<AuthProfileStore> {

--- a/src/agents/auth-profiles/oauth.test.ts
+++ b/src/agents/auth-profiles/oauth.test.ts
@@ -8,6 +8,10 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import type { AuthProfileStore } from "./types.js";
 
+vi.hoisted(() => {
+  vi.resetModules();
+});
+
 vi.mock("../cli-credentials.js", () => ({
   readClaudeCliCredentialsCached: () => null,
   readCodexCliCredentialsCached: () => null,
@@ -111,6 +115,7 @@ beforeAll(loadOAuthModuleForTest);
 afterAll(() => {
   vi.doUnmock("../cli-credentials.js");
   vi.doUnmock("../../plugins/provider-runtime.runtime.js");
+  vi.resetModules();
 });
 
 function createUsableOAuthExpiry(): number {

--- a/src/agents/auth-profiles/order.test.ts
+++ b/src/agents/auth-profiles/order.test.ts
@@ -12,6 +12,7 @@ import { saveAuthProfileStore } from "./store.js";
 import type { AuthProfileStore } from "./types.js";
 
 const pluginMetadataMocks = vi.hoisted(() => {
+  vi.resetModules();
   const snapshot = {
     plugins: [
       {

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -3,7 +3,7 @@
  * Covers unusable-window helpers, provider bypasses, WHAM probes, and store
  * persistence hooks without contacting real providers.
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { MAX_DATE_TIMESTAMP_MS } from "../../shared/number-coercion.js";
 import type { AuthProfileStore, ProfileUsageStats } from "./types.js";
@@ -39,6 +39,12 @@ beforeEach(() => {
   authProfileUsageTesting.setDepsForTest({
     updateAuthProfileStoreWithLock: storeMocks.updateAuthProfileStoreWithLock,
   });
+});
+
+afterEach(() => {
+  authProfileUsageTesting.setDepsForTest(null);
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
 });
 
 function makeStore(usageStats: AuthProfileStore["usageStats"]): AuthProfileStore {


### PR DESCRIPTION
Closes #102472

## What Problem This Solves

Fixes an issue where the `src/agents/auth-profiles` test directory was nondeterministically red (16-23 failures with shifting victim files) while every file passed in isolation, masking real regressions and forcing per-file unrelatedness proofs during PR work (#102438).

## Why This Change Was Made

Six leakage sources, all fixed at the leaking file rather than with defensive resets in victims: the throwing `getOAuthApiKey` mock in `oauth.openai-codex-refresh-fallback.test.ts` stayed in the cached `oauth.js`/`model-auth.js` module graph after `doUnmock`; the shared `oauth-common-mocks` and passthrough test-support helpers installed hoisted mocks with no teardown; `order.test.ts` and `external-oauth.test.ts` installed mocks over already-cached module graphs; and `usage.test.ts` stubbed `fetch`/deps in `beforeEach` without `afterEach` cleanup. Fixes are `vi.resetModules()` before installing hoisted mocks, `afterAll` unmock+reset in shared test-support files, and proper `afterEach` teardown — per the repo test rules (clean mocks/globals/module state, `--isolate=false` safe). Test files and test-support helpers only; zero production changes, zero tests skipped or deleted.

## User Impact

None at runtime. Maintainers get a stable, trustworthy auth-profiles suite in directory and full runs.

## Evidence

- Before (clean `main` @ `1d4d8474da8`): directory run 23 failed / 871 passed, victim set varies between runs.
- After: `node scripts/run-vitest.mjs src/agents/auth-profiles` green 3 consecutive runs (72 files, 903 tests each) plus a shuffled-order run (`--sequence.shuffle.files --sequence.seed 102472`) also green.
- Autoreview (codex/gpt-5.5): clean, no actionable findings.
