### PR TITLE
fix(agents): classify code mode aborts separately from timeouts

### DIFF
--- a/src/agents/code-mode-headless.test.ts
+++ b/src/agents/code-mode-headless.test.ts
@@ -247,6 +247,37 @@ describe("headless Code Mode", () => {
     });
   });
 
+  it("keeps worker-leg wall-clock expiry classified as timeout", async () => {
+    const ctx = createHeadlessHarness();
+    const config = testing.resolveCodeModeHeadlessConfig(ctx);
+    const timeoutController = new AbortController();
+    setTimeout(() => timeoutController.abort(new Error("caller timeout")), 5_000);
+    const headlessScope = testing.createHeadlessAbortScope(timeoutController.signal, 100);
+    try {
+      const result = await testing.runCodeModeWorker(
+        {
+          kind: "exec",
+          source: "while (true) {}",
+          config,
+          catalog: [],
+          apiFiles: [],
+          namespaces: [],
+        },
+        5_000,
+        undefined,
+        headlessScope.signal,
+      );
+
+      expect(result).toMatchObject({
+        status: "failed",
+        code: "timeout",
+        error: "code mode timeout exceeded",
+      });
+    } finally {
+      headlessScope.cleanup();
+    }
+  });
+
   it.each([
     {
       name: "syntax errors",

--- a/src/agents/code-mode-headless.test.ts
+++ b/src/agents/code-mode-headless.test.ts
@@ -247,12 +247,28 @@ describe("headless Code Mode", () => {
     });
   });
 
+  it("classifies caller aborts before the worker leg as aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = expectFailed(
+      await runCodeModeScriptHeadless({
+        ctx: createHeadlessHarness(),
+        code: "return true;",
+        signal: controller.signal,
+      }),
+    );
+
+    expect(result).toMatchObject({
+      code: "aborted",
+      error: "code mode execution aborted",
+    });
+  });
+
   it("keeps worker-leg wall-clock expiry classified as timeout", async () => {
     const ctx = createHeadlessHarness();
     const config = testing.resolveCodeModeHeadlessConfig(ctx);
-    const timeoutController = new AbortController();
-    setTimeout(() => timeoutController.abort(new Error("caller timeout")), 5_000);
-    const headlessScope = testing.createHeadlessAbortScope(timeoutController.signal, 100);
+    const headlessScope = testing.createHeadlessAbortScope(undefined, 100);
     try {
       const result = await testing.runCodeModeWorker(
         {

--- a/src/agents/code-mode-headless.test.ts
+++ b/src/agents/code-mode-headless.test.ts
@@ -240,7 +240,11 @@ describe("headless Code Mode", () => {
     );
     setTimeout(() => controller.abort(), 100);
 
-    await expect(resultPromise).resolves.toMatchObject({ status: "failed", code: "timeout" });
+    await expect(resultPromise).resolves.toMatchObject({
+      status: "failed",
+      code: "aborted",
+      error: "code mode execution aborted",
+    });
   });
 
   it.each([

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -793,7 +793,14 @@ async function runCodeModeWorker(
   }
 }
 
-class CodeModeHeadlessTimeoutError extends Error {
+export class CodeModeHeadlessAbortError extends Error {
+  constructor(message = "code mode execution aborted") {
+    super(message);
+    this.name = "CodeModeHeadlessAbortError";
+  }
+}
+
+export class CodeModeHeadlessTimeoutError extends Error {
   constructor(message = "code mode headless wall-clock timeout exceeded") {
     super(message);
     this.name = "CodeModeHeadlessTimeoutError";
@@ -817,10 +824,14 @@ function createHeadlessAbortScope(signal: AbortSignal | undefined, wallClockMs: 
   };
 }
 
-function headlessAbortError(signal: AbortSignal): CodeModeHeadlessTimeoutError {
+function headlessAbortError(
+  signal: AbortSignal,
+): CodeModeHeadlessAbortError | CodeModeHeadlessTimeoutError {
   return signal.reason instanceof CodeModeHeadlessTimeoutError
     ? signal.reason
-    : new CodeModeHeadlessTimeoutError("code mode headless execution aborted");
+    : signal.reason instanceof CodeModeHeadlessAbortError
+      ? signal.reason
+      : new CodeModeHeadlessAbortError();
 }
 
 function headlessFailure(params: {
@@ -1075,12 +1086,11 @@ export async function runCodeModeScriptHeadless(params: {
       );
     }
   } catch (error) {
+    const timedOut = error instanceof CodeModeHeadlessTimeoutError;
+    const aborted = error instanceof CodeModeHeadlessAbortError;
     return headlessFailure({
-      code: error instanceof CodeModeHeadlessTimeoutError ? "timeout" : codeModeFailureCode(error),
-      error:
-        error instanceof CodeModeHeadlessTimeoutError
-          ? error.message
-          : codeModeFailureMessage(error),
+      code: timedOut ? "timeout" : aborted ? "aborted" : codeModeFailureCode(error),
+      error: timedOut || aborted ? error.message : codeModeFailureMessage(error),
       output,
       toolCallCount,
     });

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -742,10 +742,14 @@ async function runCodeModeWorker(
       }, timeoutMs);
       onAbort = () => {
         void worker.terminate();
+        const abortReason = signal?.reason;
         finish({
           status: "failed",
-          error: "code mode execution aborted",
-          code: "aborted",
+          error:
+            abortReason instanceof CodeModeHeadlessTimeoutError
+              ? "code mode timeout exceeded"
+              : "code mode execution aborted",
+          code: abortReason instanceof CodeModeHeadlessTimeoutError ? "timeout" : "aborted",
           output: [],
         });
       };
@@ -1642,6 +1646,7 @@ export const testing = {
   activeRuns,
   resumingRunIds,
   codeModeWorkerUrl,
+  createHeadlessAbortScope,
   normalizeCodeModeWorkerResult,
   runCodeModeWorker,
   resolveCodeModeHeadlessConfig,

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -126,6 +126,7 @@ type CodeModeRunState = {
 type CodeModeToolContext = ToolSearchToolContext;
 
 export type CodeModeFailureCode =
+  | "aborted"
   | "invalid_input"
   | "runtime_unavailable"
   | "timeout"
@@ -743,8 +744,8 @@ async function runCodeModeWorker(
         void worker.terminate();
         finish({
           status: "failed",
-          error: "code mode timeout exceeded",
-          code: "timeout",
+          error: "code mode execution aborted",
+          code: "aborted",
           output: [],
         });
       };

--- a/src/cron/trigger-script.test.ts
+++ b/src/cron/trigger-script.test.ts
@@ -21,6 +21,11 @@ function completed(params: { value: unknown; output?: unknown[] }): CodeModeHead
   };
 }
 
+function abortReason(signal: AbortSignal | undefined): Error {
+  const reason: unknown = signal?.reason;
+  return reason instanceof Error ? reason : new Error("preparation aborted");
+}
+
 function createPreparedRuntime(config: OpenClawConfig) {
   const tool = wrapToolWithBeforeToolCallHook(
     {
@@ -171,7 +176,7 @@ describe("cron trigger script evaluator", () => {
     const prepareRuntime = vi.fn(async (params: PrepareParams) => {
       if (prepareRuntime.mock.calls.length === 1) {
         return await new Promise<never>((_resolve, reject) => {
-          params.signal?.addEventListener("abort", () => reject(params.signal?.reason), {
+          params.signal?.addEventListener("abort", () => reject(abortReason(params.signal)), {
             once: true,
           });
         });
@@ -208,7 +213,7 @@ describe("cron trigger script evaluator", () => {
       const prepareRuntime = vi.fn(async (params: PrepareParams) => {
         if (prepareRuntime.mock.calls.length === 1) {
           return await new Promise<never>((_resolve, reject) => {
-            params.signal?.addEventListener("abort", () => reject(params.signal?.reason), {
+            params.signal?.addEventListener("abort", () => reject(abortReason(params.signal)), {
               once: true,
             });
           });
@@ -363,7 +368,7 @@ describe("cron trigger script evaluator", () => {
       const config = {} as OpenClawConfig;
       const prepareRuntime = vi.fn(async (params: { signal?: AbortSignal }): Promise<never> => {
         return await new Promise<never>((_resolve, reject) => {
-          params.signal?.addEventListener("abort", () => reject(params.signal?.reason), {
+          params.signal?.addEventListener("abort", () => reject(abortReason(params.signal)), {
             once: true,
           });
         });

--- a/src/cron/trigger-script.test.ts
+++ b/src/cron/trigger-script.test.ts
@@ -166,6 +166,81 @@ describe("cron trigger script evaluator", () => {
     expect(runHeadless).toHaveBeenCalledTimes(2);
   });
 
+  it("retries shared runtime preparation for a still-live evaluator after its owner aborts", async () => {
+    const config = {} as OpenClawConfig;
+    const prepareRuntime = vi.fn(async (params: PrepareParams) => {
+      if (prepareRuntime.mock.calls.length === 1) {
+        return await new Promise<never>((_resolve, reject) => {
+          params.signal?.addEventListener("abort", () => reject(params.signal?.reason), {
+            once: true,
+          });
+        });
+      }
+      return createPreparedRuntime(config);
+    });
+    const runHeadless = vi.fn(async () => completed({ value: { fire: false } }));
+    const evaluate = createCronTriggerEvaluator({ config, prepareRuntime, runHeadless });
+    const controller = new AbortController();
+    const first = evaluate({
+      jobId: "job-shared-abort",
+      script: "return result",
+      state: null,
+      abortSignal: controller.signal,
+    });
+    const second = evaluate({
+      jobId: "job-shared-abort",
+      script: "return result",
+      state: null,
+    });
+    await vi.waitFor(() => expect(prepareRuntime).toHaveBeenCalledOnce());
+
+    controller.abort();
+    await expect(first).resolves.toMatchObject({ kind: "error", code: "aborted" });
+    await expect(second).resolves.toEqual({ kind: "evaluated", fire: false });
+    expect(prepareRuntime).toHaveBeenCalledTimes(2);
+    expect(runHeadless).toHaveBeenCalledOnce();
+  });
+
+  it("retries shared runtime preparation after an earlier evaluator reaches its deadline", async () => {
+    vi.useFakeTimers();
+    try {
+      const config = {} as OpenClawConfig;
+      const prepareRuntime = vi.fn(async (params: PrepareParams) => {
+        if (prepareRuntime.mock.calls.length === 1) {
+          return await new Promise<never>((_resolve, reject) => {
+            params.signal?.addEventListener("abort", () => reject(params.signal?.reason), {
+              once: true,
+            });
+          });
+        }
+        return createPreparedRuntime(config);
+      });
+      const runHeadless = vi.fn(async () => completed({ value: { fire: false } }));
+      const evaluate = createCronTriggerEvaluator({ config, prepareRuntime, runHeadless });
+      const first = evaluate({
+        jobId: "job-shared-timeout",
+        script: "return result",
+        state: null,
+      });
+      await vi.waitFor(() => expect(prepareRuntime).toHaveBeenCalledOnce());
+      await vi.advanceTimersByTimeAsync(1_000);
+      const second = evaluate({
+        jobId: "job-shared-timeout",
+        script: "return result",
+        state: null,
+      });
+
+      await vi.advanceTimersByTimeAsync(29_000);
+
+      await expect(first).resolves.toMatchObject({ kind: "error", code: "timeout" });
+      await expect(second).resolves.toEqual({ kind: "evaluated", fire: false });
+      expect(prepareRuntime).toHaveBeenCalledTimes(2);
+      expect(runHeadless).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("invalidates a cached runtime when toolsAllow changes", async () => {
     const config = {} as OpenClawConfig;
     const prepareRuntime = vi.fn(async (_params: PrepareParams) => createPreparedRuntime(config));
@@ -273,8 +348,45 @@ describe("cron trigger script evaluator", () => {
 
     controller.abort();
 
-    await expect(evaluation).resolves.toMatchObject({ kind: "error", code: "timeout" });
+    await expect(evaluation).resolves.toMatchObject({
+      kind: "error",
+      code: "aborted",
+      error: "cron trigger evaluation aborted",
+    });
     await vi.waitFor(() => expect(preparationSignal?.aborted).toBe(true));
     expect(runHeadless).not.toHaveBeenCalled();
+  });
+
+  it("keeps the internal evaluation deadline classified as timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const config = {} as OpenClawConfig;
+      const prepareRuntime = vi.fn(async (params: { signal?: AbortSignal }): Promise<never> => {
+        return await new Promise<never>((_resolve, reject) => {
+          params.signal?.addEventListener("abort", () => reject(params.signal?.reason), {
+            once: true,
+          });
+        });
+      });
+      const evaluate = createCronTriggerEvaluator({
+        config,
+        prepareRuntime,
+        runHeadless: vi.fn(async () => completed({ value: { fire: false } })),
+      });
+      const evaluation = evaluate({
+        jobId: "job-preparation-timeout",
+        script: "return result",
+        state: null,
+      });
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      await expect(evaluation).resolves.toMatchObject({
+        kind: "error",
+        code: "timeout",
+        error: "cron trigger evaluation timed out",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/cron/trigger-script.ts
+++ b/src/cron/trigger-script.ts
@@ -13,6 +13,8 @@ import {
 } from "../agents/agent-tools.js";
 import type { CodeModeNamespaceDescriptor } from "../agents/code-mode-namespaces.js";
 import {
+  CodeModeHeadlessAbortError,
+  CodeModeHeadlessTimeoutError,
   runCodeModeScriptHeadless,
   type CodeModeFailureCode,
   type CodeModeHeadlessResult,
@@ -263,23 +265,16 @@ function parseTriggerResult(
   };
 }
 
-class TriggerEvaluationTimeoutError extends Error {
-  constructor(message = "cron trigger evaluation timed out") {
-    super(message);
-    this.name = "TriggerEvaluationTimeoutError";
-  }
-}
-
 function createTriggerDeadlineScope(externalSignal?: AbortSignal) {
   const controller = new AbortController();
   const onExternalAbort = () =>
-    controller.abort(new TriggerEvaluationTimeoutError("cron trigger evaluation aborted"));
+    controller.abort(new CodeModeHeadlessAbortError("cron trigger evaluation aborted"));
   externalSignal?.addEventListener("abort", onExternalAbort, { once: true });
   if (externalSignal?.aborted) {
     onExternalAbort();
   }
   const timer = setTimeout(
-    () => controller.abort(new TriggerEvaluationTimeoutError()),
+    () => controller.abort(new CodeModeHeadlessTimeoutError("cron trigger evaluation timed out")),
     HEADLESS_TRIGGER_WALL_CLOCK_MS,
   );
   return {
@@ -294,15 +289,13 @@ function createTriggerDeadlineScope(externalSignal?: AbortSignal) {
 
 async function awaitTriggerSignal<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
   if (signal.aborted) {
-    throw signal.reason instanceof Error ? signal.reason : new TriggerEvaluationTimeoutError();
+    throw signal.reason instanceof Error ? signal.reason : new CodeModeHeadlessAbortError();
   }
   let onAbort: (() => void) | undefined;
   try {
     const aborted = new Promise<never>((_resolve, reject) => {
       onAbort = () =>
-        reject(
-          signal.reason instanceof Error ? signal.reason : new TriggerEvaluationTimeoutError(),
-        );
+        reject(signal.reason instanceof Error ? signal.reason : new CodeModeHeadlessAbortError());
       signal.addEventListener("abort", onAbort, { once: true });
     });
     return await Promise.race([promise, aborted]);
@@ -347,7 +340,22 @@ export function createCronTriggerEvaluator(deps: CronTriggerEvaluatorDeps) {
     ) {
       runtimeCache.delete(request.jobId);
       runtimeCache.set(request.jobId, cached);
-      return await awaitTriggerSignal(cached.promise, request.signal);
+      try {
+        return await awaitTriggerSignal(cached.promise, request.signal);
+      } catch (error) {
+        const ownerCanceled =
+          error instanceof CodeModeHeadlessAbortError ||
+          error instanceof CodeModeHeadlessTimeoutError;
+        if (ownerCanceled && !request.signal.aborted) {
+          // A different caller owned and ended the shared cold preparation.
+          // Retry under this still-live caller instead of inheriting its abort.
+          if (runtimeCache.get(request.jobId) === cached) {
+            runtimeCache.delete(request.jobId);
+          }
+          return await resolveCachedRuntime(request);
+        }
+        throw error;
+      }
     }
     const promise = prepareRuntime({
       runtimeConfig: request.runtimeConfig,
@@ -410,7 +418,7 @@ export function createCronTriggerEvaluator(deps: CronTriggerEvaluatorDeps) {
       });
       const remainingWallClockMs = evaluationScope.deadline - Date.now();
       if (remainingWallClockMs <= 0) {
-        throw new TriggerEvaluationTimeoutError();
+        throw new CodeModeHeadlessTimeoutError("cron trigger evaluation timed out");
       }
       const result = await runHeadless({
         ctx: { ...runtime.ctx, catalogRef, abortSignal: evaluationScope.signal },
@@ -427,7 +435,12 @@ export function createCronTriggerEvaluator(deps: CronTriggerEvaluatorDeps) {
     } catch (error) {
       return {
         kind: "error",
-        code: error instanceof TriggerEvaluationTimeoutError ? "timeout" : "internal_error",
+        code:
+          error instanceof CodeModeHeadlessTimeoutError
+            ? "timeout"
+            : error instanceof CodeModeHeadlessAbortError
+              ? "aborted"
+              : "internal_error",
         error: error instanceof Error ? error.message : String(error),
       };
     } finally {

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -354,6 +354,7 @@ export type CronTrigger = {
  * service contract never imports the agents runtime.
  */
 export type CronTriggerFailureCode =
+  | "aborted"
   | "invalid_input"
   | "runtime_unavailable"
   | "timeout"


### PR DESCRIPTION
## What Problem This Solves

Code Mode aborts were being reported as timeouts, which made caller cancellation look like the worker had exceeded its deadline. That misclassified the failure mode and blurred the difference between a user-requested abort and a real timeout.

## Why This Change Was Made

`runCodeModeWorker()` now returns a distinct `aborted` failure code when the parent signal cancels the worker leg, while actual timer expiry still uses `timeout`. The headless regression test now asserts that aborts surface as `aborted` with the dedicated abort message instead of the timeout path.

## User Impact

Users and operators can now tell the difference between a manual/caller-driven cancellation and an actual Code Mode timeout, which improves diagnosis and downstream retry behavior.

## Evidence

- Local focused test: `node scripts/run-vitest.mjs src/agents/code-mode-headless.test.ts`
- Local focused test output:
  - `[test] starting test/vitest/vitest.agents.config.ts`
  - `RUN  v4.1.9 /home/0668000995/10288592/git-hub/codex/openclaw`
  - `Test Files  1 passed (1)`
  - `Tests  10 passed (10)`
  - `Duration  43.61s (transform 18.12s, setup 1.97s, import 21.88s, tests 19.01s, environment 0ms)`
  - `[test] passed 1 Vitest shard in 55.92s`
