### PR TITLE
fix(agents): keep provider error detail truncation UTF-16 safe

### DIFF
--- a/src/agents/provider-http-errors.test.ts
+++ b/src/agents/provider-http-errors.test.ts
@@ -6,12 +6,30 @@ import {
   createProviderHttpError,
   extractProviderErrorDetail,
   extractProviderRequestId,
+  formatProviderErrorPayload,
   ProviderHttpError,
   readProviderBinaryResponse,
   readProviderJsonResponse,
   readProviderTextResponse,
   readResponseTextLimited,
 } from "./provider-http-errors.js";
+
+function hasLoneSurrogate(s: string): boolean {
+  for (let i = 0; i < s.length; i += 1) {
+    const c = s.charCodeAt(i);
+    if (c >= 0xd800 && c <= 0xdbff) {
+      if (i + 1 >= s.length || s.charCodeAt(i + 1) < 0xdc00 || s.charCodeAt(i + 1) > 0xdfff) {
+        return true;
+      }
+    }
+    if (c >= 0xdc00 && c <= 0xdfff) {
+      if (i === 0 || s.charCodeAt(i - 1) < 0xd800 || s.charCodeAt(i - 1) > 0xdbff) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
 
 function createStreamingBinaryResponse(params: {
   chunkCount: number;
@@ -134,6 +152,21 @@ describe("provider error utils", () => {
     ).rejects.toThrow(
       "OAuth token exchange failed (400): AADSTS7000215: Invalid client secret provided. [code=invalid_request]",
     );
+  });
+
+  it("does not split UTF-16 surrogate pairs when truncating provider error details", async () => {
+    const message = "a".repeat(218) + "😀" + "suffix";
+    const response = new Response(
+      JSON.stringify({
+        error: { message, code: "utf16_test" },
+      }),
+      { status: 400 },
+    );
+
+    await expect(assertOkOrThrowProviderError(response, "Provider API error")).rejects.toThrow();
+    const detail = formatProviderErrorPayload({ error: { message, code: "utf16_test" } });
+    expect(detail).toContain("utf16_test");
+    expect(hasLoneSurrogate(detail ?? "")).toBe(false);
   });
 
   it("keeps HTTP status metadata when error body reads fail", async () => {

--- a/src/agents/provider-http-errors.test.ts
+++ b/src/agents/provider-http-errors.test.ts
@@ -6,30 +6,12 @@ import {
   createProviderHttpError,
   extractProviderErrorDetail,
   extractProviderRequestId,
-  formatProviderErrorPayload,
   ProviderHttpError,
   readProviderBinaryResponse,
   readProviderJsonResponse,
   readProviderTextResponse,
   readResponseTextLimited,
 } from "./provider-http-errors.js";
-
-function hasLoneSurrogate(s: string): boolean {
-  for (let i = 0; i < s.length; i += 1) {
-    const c = s.charCodeAt(i);
-    if (c >= 0xd800 && c <= 0xdbff) {
-      if (i + 1 >= s.length || s.charCodeAt(i + 1) < 0xdc00 || s.charCodeAt(i + 1) > 0xdfff) {
-        return true;
-      }
-    }
-    if (c >= 0xdc00 && c <= 0xdfff) {
-      if (i === 0 || s.charCodeAt(i - 1) < 0xd800 || s.charCodeAt(i - 1) > 0xdbff) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
 
 function createStreamingBinaryResponse(params: {
   chunkCount: number;
@@ -155,7 +137,8 @@ describe("provider error utils", () => {
   });
 
   it("does not split UTF-16 surrogate pairs when truncating provider error details", async () => {
-    const message = "a".repeat(218) + "😀" + "suffix";
+    const safePrefix = "a".repeat(218);
+    const message = `${safePrefix}😀suffix`;
     const response = new Response(
       JSON.stringify({
         error: { message, code: "utf16_test" },
@@ -163,10 +146,9 @@ describe("provider error utils", () => {
       { status: 400 },
     );
 
-    await expect(assertOkOrThrowProviderError(response, "Provider API error")).rejects.toThrow();
-    const detail = formatProviderErrorPayload({ error: { message, code: "utf16_test" } });
-    expect(detail).toContain("utf16_test");
-    expect(hasLoneSurrogate(detail ?? "")).toBe(false);
+    await expect(assertOkOrThrowProviderError(response, "Provider API error")).rejects.toThrow(
+      `Provider API error (400): ${safePrefix}… [code=utf16_test]`,
+    );
   });
 
   it("keeps HTTP status metadata when error body reads fail", async () => {

--- a/src/agents/provider-http-errors.ts
+++ b/src/agents/provider-http-errors.ts
@@ -4,6 +4,7 @@
  * Transport adapters use this module to turn provider-specific response bodies,
  * request ids, and binary payload guardrails into stable OpenClaw error shapes.
  */
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 export { asFiniteNumber } from "../../packages/normalization-core/src/number-coercion.js";
 import { normalizeOptionalString as trimToUndefined } from "../../packages/normalization-core/src/string-coerce.js";
 import { readResponseWithLimit } from "../infra/http-body.js";
@@ -25,7 +26,7 @@ export function asObject(value: unknown): Record<string, unknown> | undefined {
 
 /** Trims provider error details to a log- and prompt-safe preview length. */
 export function truncateErrorDetail(detail: string, limit = 220): string {
-  return detail.length <= limit ? detail : `${detail.slice(0, limit - 1)}…`;
+  return detail.length <= limit ? detail : `${truncateUtf16Safe(detail, limit - 1)}…`;
 }
 
 /** Redacts secrets before preserving a bounded provider error body preview. */


### PR DESCRIPTION
## Summary
`truncateErrorDetail` in `src/agents/provider-http-errors.ts` used raw `detail.slice(0, limit - 1)` to produce provider error previews. When an emoji (a UTF-16 surrogate pair) sits exactly on the boundary, this leaves a dangling high surrogate. Replace it with `truncateUtf16Safe` so provider error messages stay surrogate-safe.

## Changes
- `provider-http-errors.ts`: import `truncateUtf16Safe` and use it for error detail truncation.
- `provider-http-errors.test.ts`: add regression test that places 😀 at the default 220-char boundary and asserts no lone surrogates.

## Real behavior proof
Fixture: `"a".repeat(218) + "😀" + "suffix"` with default `limit=220`.

```bash
node --import tsx /tmp/proof-provider-http-errors.mts
```

```
message length: 226
old has lone surrogate: true
new has lone surrogate: false
```

## Test
```bash
node scripts/run-vitest.mjs src/agents/provider-http-errors.test.ts
```

```
Test Files  1 passed (1)
Tests  14 passed (14)
```

## Notes
- Continues the UTF-16 / response bounding campaign in the agents provider-error path.
- No competing open PR targets `provider-http-errors.ts` for UTF-16 hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)