### PR TITLE
fix(ui): macOS app shows the OpenClaw brand icon twice at the top-left

### DIFF
--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -1657,13 +1657,6 @@ class AppSidebar extends LitElement {
       this.activeRouteId !== undefined && isSettingsNavigationRoute(this.activeRouteId);
     return html`
       <aside class="sidebar ${this.collapsed ? "sidebar--collapsed" : ""}">
-        <!-- macOS app only (CSS-gated on html.openclaw-native-macos): use the
-             otherwise-empty native titlebar strip instead of a sidebar row. -->
-        <img
-          class="sidebar-native-brand"
-          src="${controlUiPublicAssetPath("favicon.svg", this.basePath)}"
-          alt="OpenClaw"
-        />
         <div class="sidebar-shell">
           ${this.renderBrand()}
           <div class="sidebar-shell__body">

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -479,30 +479,6 @@
   flex-direction: column;
 }
 
-/* macOS app only: the native window hides its titlebar and injects
-   html.openclaw-native-macos plus --openclaw-native-titlebar-height (see
-   DashboardWindowController.installNativeChromeScript), leaving an empty
-   strip next to the traffic lights. The brand mark sits there instead of
-   spending a sidebar row; web builds never show it (breadcrumb has the name). */
-.sidebar-native-brand {
-  display: none;
-}
-
-@media (min-width: 700px) {
-  html.openclaw-native-macos .sidebar:not(.sidebar--collapsed) .sidebar-native-brand {
-    /* 84px clears the native traffic-light cluster (drag region starts at 78px).
-       The mark is a transparent SVG; any box-shadow/background reads as a
-       misplaced card behind the mascot, so it renders bare. */
-    position: absolute;
-    top: 0;
-    left: 84px;
-    display: block;
-    width: 22px;
-    height: 22px;
-    margin-top: calc((var(--openclaw-native-titlebar-height, 50px) - 22px) / 2);
-  }
-}
-
 .sidebar-shell__footer {
   padding: 12px 0 0;
   border-top: 1px solid color-mix(in srgb, var(--border) 80%, transparent);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the macOS app window showed the OpenClaw claw mark twice at the top-left: once in the native titlebar strip next to the traffic lights, and again in the sidebar header right below it.

The titlebar brand mark was added in #100648 when the sidebar brand row was removed, so the mark had a home in the otherwise-empty titlebar strip. Commit 8295a12a837 ("improve(ui): move shell controls into side rails") later reinstated the sidebar brand row (logo + "OpenClaw" wordmark + search + collapse toggle) without removing the titlebar mark, leaving both visible in the Mac app.

## Why This Change Was Made

The sidebar brand row is now the canonical brand surface, so the macOS-only `sidebar-native-brand` element and its CSS gate are deleted outright — no conditional hiding, one fewer platform-special path. The native titlebar strip goes back to holding only the traffic lights, which is standard macOS chrome. The Swift-injected `.sidebar-shell` top padding (`DashboardWindowController.installNativeChromeScript`) is untouched and still clears the traffic-light strip.

## User Impact

macOS app users see a single OpenClaw mark in the sidebar header instead of a doubled icon. Web builds are unaffected (the removed element was CSS-hidden outside the native macOS window).

## Evidence

Rendered via the Control UI e2e mock-gateway harness with the macOS native chrome injection replicated (`openclaw-native-macos` class + titlebar CSS, traffic lights mocked for context), matching how `DashboardWindowController` styles the real window.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/macos-titlebar-brand-dedupe/before.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/macos-titlebar-brand-dedupe/after.png) |

- Pure deletion: −31 LOC (`ui/src/components/app-sidebar.ts` −7, `ui/src/styles/layout.css` −24), no remaining `sidebar-native-brand` references repo-wide.
- `pnpm check:changed` (Blacksmith Testbox): green.
- Autoreview (Codex, gpt-5.5): clean — "patch is correct (0.99)", no actionable findings.
