### PR TITLE
fix(gateway): keep chat history truncation UTF-16 safe

### DIFF
--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -4,6 +4,7 @@ import { createHash } from "node:crypto";
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { asOptionalRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE } from "../agents/internal-runtime-context.js";
 import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
 import { isHeartbeatOkResponse, isHeartbeatUserMessage } from "../auto-reply/heartbeat-filter.js";
@@ -57,7 +58,7 @@ function truncateChatHistoryText(
     return { text, truncated: false };
   }
   return {
-    text: `${text.slice(0, maxChars)}\n...(truncated)...`,
+    text: `${truncateUtf16Safe(text, maxChars)}\n...(truncated)...`,
     truncated: true,
   };
 }

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -38,6 +38,25 @@ type GatewaySocket = Awaited<ReturnType<GatewayHarness["openWs"]>>;
 let harness: GatewayHarness;
 const autoCleanupTempDirs = useAutoCleanupTempDirTracker(afterEach);
 
+function hasLoneSurrogate(value: string): boolean {
+  for (let i = 0; i < value.length; i += 1) {
+    const codeUnit = value.charCodeAt(i);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(i + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return true;
+      }
+    }
+    if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      const previous = value.charCodeAt(i - 1);
+      if (!(previous >= 0xd800 && previous <= 0xdbff)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 beforeAll(async () => {
   harness = await createGatewaySuiteHarness();
 });
@@ -3804,6 +3823,28 @@ describe("gateway server chat", () => {
       const messages = await fetchHistoryMessages(ws, { maxChars: 7 });
       const serialized = JSON.stringify(messages);
       expect(serialized).toContain("abcdefg\\n...(truncated)...");
+    });
+  });
+
+  test("chat.history keeps RPC maxChars truncation UTF-16 safe", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      const sessionDir = await prepareMainHistoryHarness({ ws, createSessionDir });
+      const sourceText = `${"a".repeat(6)}😀tail`;
+      expect(hasLoneSurrogate(sourceText.slice(0, 7))).toBe(true);
+      await writeMainSessionTranscript(sessionDir, [
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: sourceText }],
+            timestamp: Date.now(),
+          },
+        }),
+      ]);
+
+      const messages = await fetchHistoryMessages(ws, { maxChars: 7 });
+      const text = (messages[0] as { content?: Array<{ text?: string }> }).content?.[0]?.text;
+      expect(text).toBe(`${"a".repeat(6)}\n...(truncated)...`);
+      expect(hasLoneSurrogate(text ?? "")).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

- Make chat history text truncation use the shared UTF-16-safe truncation helper.
- Add a gateway `chat.history` RPC regression that proves `maxChars` no longer returns a lone emoji surrogate.

## What Problem This Solves

Control UI/history display rows are bounded by `chat.history` `maxChars`. The previous projection code used raw UTF-16 `slice(0, maxChars)`, so a budget that landed between the high and low surrogate of an emoji could return an invalid lone surrogate in the projected text block.

## User Impact

Users viewing bounded chat history can now see truncated entries without broken emoji replacement artifacts or malformed text payloads. Existing ASCII truncation behavior and the `\n...(truncated)...` marker are preserved.

## Origin / follow-up

Follow-up to the recently merged Unicode truncation cleanup in #101754. This patch covers the remaining Control UI / chat history projection boundary rather than opening a broad rewrite.

## Competition / linked PR analysis

No same-point open PR was found before patching.

Related open PR scan:

```text
gh pr list --repo openclaw/openclaw --state open --limit 100 --json number,title,author,url --search 'chat history truncation UTF-16 surrogate emoji'
```

Result:

```json
[]
```

## Merge risk

- Why it matters / User impact: `chat.history` is a client-facing gateway RPC used by Control UI/history views, so malformed bounded text can surface directly to users.
- Risk labels considered: availability.
- Risk explanation: gateway projection code is on a display/read path, but this patch only changes how an already-truncated prefix is cut when the boundary falls inside a UTF-16 surrogate pair.
- Why acceptable: the cap, suffix, message shape, RPC validation, and non-truncated behavior stay unchanged; the ASCII maxChars regression test still passes.
- Maintainer-ready confidence: high; the proof covers raw control, current `origin/main` behavior, patched production projection behavior, and the gateway `chat.history` RPC path.
- Patch quality notes: production diff is a one-line helper swap plus import; the patch quality warning is from a test-only lone-surrogate assertion guard, not a runtime default/fallback branch.
- Target test file: `src/gateway/server.chat.gateway-server-chat-b.test.ts`.
- Root cause: The root cause is the display projector's raw JavaScript `slice(0, maxChars)` because it slices UTF-16 code units, so a maxChars boundary inside an emoji pair can produce a dangling high surrogate.
- Why this is root-cause fix: This fixes the root display invariant at the shared chat-history truncation source by replacing the exact unsafe slice with `truncateUtf16Safe`, so every caller through the projector keeps the existing cap while avoiding dangling surrogate halves.
- What did NOT change: This patch does not change stored transcript content, chat history limits, RPC validation, message shape, frontend rendering, provider/channel behavior, or any unrelated truncation sites.
- Architecture / source-of-truth check: The source-of-truth persisted transcript and model-consumed runtime messages remain canonical and unchanged; only the derived display projection returned by `chat.history` is normalized for safe UTF-16 truncation.
- Scenario locked in: A persisted assistant transcript text `aaaaaa😀tail` fetched through `chat.history` with `maxChars: 7` must return `aaaaaa\n...(truncated)...` instead of a high surrogate plus the truncation marker.
- Why this is the smallest reliable guardrail: The gateway harness regression is the smallest reliable guardrail because it crosses the same session transcript ingestion, runtime message projection, and RPC response path that Control UI consumes, while keeping the assertion focused on the UTF-16 boundary.

## Real behavior proof

- Behavior or issue addressed: `chat.history` `maxChars` truncation could split an emoji surrogate pair in the Control UI/history display payload.
- Canonical reachability path: user input text persisted in the session transcript -> transcript ingestion into typed chat runtime message/content blocks -> `chat.history` request with `maxChars` -> gateway display projection effect returned to the Control UI/history client.
- Boundary crossed: the regression test starts the gateway chat harness, writes a real session transcript, fetches history over the gateway RPC/WebSocket helper, and inspects the returned display row.
- Shared helper / provider constraint check: reused the existing shared `@openclaw/normalization-core/utf16-slice` `truncateUtf16Safe` helper; no provider/channel transport or third-party API boundary is involved.
- Real environment tested: local Linux OpenClaw worktree with the repo Vitest wrapper and gateway chat integration harness.
- Exact steps or command run after this patch:

```bash
node --import tsx "$EVIDENCE_DIR/chat-history-surrogate-proof.mjs" > "$EVIDENCE_DIR/chat-history-surrogate-proof.txt"
node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat-b.test.ts -t "chat.history applies RPC maxChars|chat.history keeps RPC maxChars truncation UTF-16 safe" > "$EVIDENCE_DIR/chat-history-rpc-vitest-maxchars.txt"
git diff --check
```

- Evidence after fix:

```text
PASS CONTROL raw slice: length=7 loneSurrogate=true tail=U+61 U+61 U+61 U+61 U+61 U+D83D
PASS BEFORE origin/main chat projector: length=25 loneSurrogate=true tail=U+65 U+64 U+29 U+2E U+2E U+2E
PASS AFTER patched chat projector: length=24 loneSurrogate=false tail=U+65 U+64 U+29 U+2E U+2E U+2E
```

```text
Test Files  1 passed (1)
     Tests  2 passed | 51 skipped (53)
```

`git diff --check` completed with no output.

- Observed result after fix: raw slicing and current `origin/main` both reproduce a lone high surrogate at the same boundary; the patched projector returns `aaaaaa\n...(truncated)...` with no lone surrogate while still marking the row as truncated.
- What was not tested: a browser screenshot was not captured because this change is in the gateway projection payload; the real client-facing payload boundary was tested through `chat.history` RPC instead.
- Fix classification: root-cause behavior fix.

## Review findings addressed

No review findings existed for this follow-up before submission.

## Regression Test Plan

```bash
node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat-b.test.ts -t "chat.history applies RPC maxChars|chat.history keeps RPC maxChars truncation UTF-16 safe"
git diff --check
```

## Risk / Compatibility

Low risk. The same `maxChars` cap and truncation suffix are preserved; the only behavior change is backing off when the exact cap would end on a dangling surrogate half. For ordinary BMP/ASCII text, the returned prefix remains unchanged.

## What was not changed

- No chat history limits or RPC validation were changed.
- No frontend rendering code was changed.
- No provider, channel, or third-party transport behavior was changed.
- No broad sweep of unrelated truncation sites was included.

## Root Cause

`truncateChatHistoryText` built the bounded display text with `text.slice(0, maxChars)`. JavaScript string slicing operates on UTF-16 code units, so it can cut between an emoji's high and low surrogate. The fix keeps the existing cap/marker behavior but uses the shared UTF-16-safe truncation helper for the prefix.
