### PR TITLE
fix(msteams): keep post-tool replies from mid-word streaming merges

### DIFF
--- a/extensions/msteams/src/reply-stream-controller.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.test.ts
@@ -120,6 +120,53 @@ describe("createTeamsReplyStreamController", () => {
     expect(ctrl.preparePayload({ text: "Second segment" })).toEqual({ text: "Second segment" });
   });
 
+  it("does not mid-word-slice post-tool partials after the stream is finalized (#102274)", async () => {
+    // Regression of #56071 after the #76262 controller rebase: finalize closed
+    // the preview card but left emittedTextLength at the preamble length, so a
+    // longer post-tool segment was sliced mid-word into the same bubble.
+    const stream = makeStream();
+    const ctrl = makeController({ stream });
+    const preamble = "I'll check the CRM.";
+    const finalText = "There are **190 contacts** in RForce.";
+    const corruptSlice = finalText.slice(preamble.length); // "tacts** in RForce."
+
+    ctrl.onPartialReply({ text: preamble });
+    expect(stream.emit).toHaveBeenCalledWith(preamble);
+    expect(ctrl.preparePayload({ text: preamble })).toBeUndefined();
+    await expect(ctrl.finalize()).resolves.toBeUndefined();
+
+    const emitCountAfterFinalize = stream.emit.mock.calls.length;
+    ctrl.onPartialReply({ text: finalText });
+
+    const postFinalizeEmits = stream.emit.mock.calls
+      .slice(emitCountAfterFinalize)
+      .map((call) => call[0]);
+    expect(postFinalizeEmits).not.toContain(corruptSlice);
+    expect(stream.emit).toHaveBeenCalledTimes(emitCountAfterFinalize);
+    expect(ctrl.preparePayload({ text: finalText })).toEqual({ text: finalText });
+  });
+
+  it("does not mid-word-slice when a new post-tool segment restarts cumulative text (#102274)", () => {
+    // If the pipeline restarts cumulative text for the next assistant message
+    // before preparePayload retires the stream, a length-only delta cursor would
+    // still slice the new segment at the preamble offset.
+    const stream = makeStream();
+    const ctrl = makeController({ stream });
+    const preamble = "I'll check the CRM.";
+    const finalText = "There are **190 contacts** in RForce.";
+    const corruptSlice = finalText.slice(preamble.length);
+
+    ctrl.onPartialReply({ text: preamble });
+    ctrl.onPartialReply({ text: finalText });
+
+    const emitted = stream.emit.mock.calls.map((call) => call[0]);
+    expect(emitted).not.toContain(corruptSlice);
+    // Full new segment is emitted after a cursor reset (appending sink then holds
+    // preamble + complete final rather than a mid-word merge).
+    expect(emitted).toContain(finalText);
+    expect(ctrl.preparePayload({ text: finalText })).toBeUndefined();
+  });
+
   it("delivers all later segments across 3+ tool call rounds", () => {
     const stream = makeStream();
     const ctrl = makeController({ stream });
@@ -273,6 +320,25 @@ describe("createTeamsReplyStreamController", () => {
 
     expect(ctrl.preparePayload({ text: "complete final answer" })).toBeUndefined();
     expect(stream.emit).toHaveBeenCalledWith("complete final answer");
+  });
+
+  it("uses block delivery for progress-mode text after the stream is finalized (#102274)", async () => {
+    const stream = makeStream();
+    const ctrl = createTeamsReplyStreamController({
+      conversationType: "personal",
+      context: makeContext(stream),
+      feedbackLoopEnabled: false,
+      msteamsConfig: { streaming: { mode: "progress" } } as never,
+    });
+
+    expect(ctrl.preparePayload({ text: "I will check." })).toBeUndefined();
+    await expect(ctrl.finalize()).resolves.toBeUndefined();
+
+    const emitCountAfterFinalize = stream.emit.mock.calls.length;
+    expect(ctrl.preparePayload({ text: "The result is ready." })).toEqual({
+      text: "The result is ready.",
+    });
+    expect(stream.emit).toHaveBeenCalledTimes(emitCountAfterFinalize);
   });
 
   it("falls back to normal delivery when progress final streaming fails", () => {

--- a/extensions/msteams/src/reply-stream-controller.ts
+++ b/extensions/msteams/src/reply-stream-controller.ts
@@ -83,6 +83,11 @@ export function createTeamsReplyStreamController(params: {
 
   let tokensEmitted = false;
   let streamFinalizationPending = false;
+  // After the first streamed segment is handed to close()/finalization, the
+  // SDK stream is a single preview-card lifecycle. Later post-tool segments
+  // must use block delivery instead of reusing a stale delta cursor (#102274,
+  // regression of #56071 after the #76262 controller rebase).
+  let streamRetired = false;
   let canceledLocally = false;
   // Set when `stream.emit/close` fails for a non-cancel reason after we've
   // already started streaming. Differentiates "user pressed Stop" from "the
@@ -99,6 +104,17 @@ export function createTeamsReplyStreamController(params: {
   // an appending sink produces "chunk1 + chunk2 + chunk3..." duplication. We
   // track the length of text we've already emitted and forward only the delta.
   let emittedTextLength = 0;
+  // Last cumulative text successfully emitted for the current segment. Used to
+  // detect tool-boundary segment restarts where the pipeline starts a new
+  // cumulative string that does not extend the preamble (#102274).
+  let lastStreamedText = "";
+
+  const retireStreamForLaterSegments = (): void => {
+    streamRetired = true;
+    emittedTextLength = 0;
+    lastStreamedText = "";
+    tokensEmitted = false;
+  };
 
   const wasCanceled = () => canceledLocally || Boolean(stream?.canceled);
 
@@ -162,6 +178,7 @@ export function createTeamsReplyStreamController(params: {
         !stream ||
         !payload.text ||
         wasCanceled() ||
+        streamRetired ||
         streamMode !== "partial" ||
         streamFinalizationPending
       ) {
@@ -171,6 +188,25 @@ export function createTeamsReplyStreamController(params: {
       // appending sink. Without this, "Here's a" → "Here's a sonnet" → ...
       // gets emitted as full repeats and the SDK concatenates the lot.
       const fullText = payload.text;
+      // Tool / segment boundary: the pipeline restarts cumulative text for the
+      // next assistant message. It no longer extends the previously streamed
+      // preamble, so the old offset would mid-word-slice the new segment
+      // (e.g. "I'll check the CRM." + "There are...".slice(19) → "...CRM.tacts").
+      // Reset the delta cursor so the full new segment is emitted rather than
+      // a stale mid-word slice. When the first segment already retired the
+      // stream (preparePayload/finalize path), the gate above skips this.
+      // Do not treat edit-in-place shortening (new text is a prefix of the old
+      // cumulative) as a segment restart — that path is handled by the length
+      // guard below.
+      if (
+        lastStreamedText.length > 0 &&
+        fullText !== lastStreamedText &&
+        !fullText.startsWith(lastStreamedText) &&
+        !lastStreamedText.startsWith(fullText)
+      ) {
+        emittedTextLength = 0;
+        lastStreamedText = "";
+      }
       // If the pipeline ever sends shorter text than we've emitted (e.g.
       // edit-in-place semantics), skip rather than emit a negative slice.
       if (fullText.length <= emittedTextLength) {
@@ -180,6 +216,7 @@ export function createTeamsReplyStreamController(params: {
       try {
         stream.emit(delta);
         emittedTextLength = fullText.length;
+        lastStreamedText = fullText;
         tokensEmitted = true;
       } catch (err) {
         if (isStreamCancelledError(err)) {
@@ -270,6 +307,11 @@ export function createTeamsReplyStreamController(params: {
       if (wasCanceled()) {
         return undefined;
       }
+      // Stream already closed a prior segment for this turn. Later post-tool
+      // payloads deliver as normal block messages (#102274 / #56071).
+      if (streamRetired) {
+        return payload;
+      }
       // Partial mode with tokens already streamed: stream carries the text;
       // strip text from the payload (keep media if any) so block delivery
       // doesn't duplicate. Exception: if a non-cancel stream failure was
@@ -279,7 +321,9 @@ export function createTeamsReplyStreamController(params: {
         const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
         pendingFinalPayload = fallbackPayloadForSuppressedFinal(payload);
         streamFinalizationPending = true;
-        tokensEmitted = false;
+        // Retire after the first streamed segment so markDispatchIdle/finalize
+        // cannot reopen the partial path with a stale emittedTextLength.
+        retireStreamForLaterSegments();
         return hasMedia ? { ...payload, text: undefined } : undefined;
       }
       // Progress mode (or partial mode that received no tokens — e.g. a
@@ -292,6 +336,7 @@ export function createTeamsReplyStreamController(params: {
           stream.emit(payload.text);
           pendingFinalPayload = fallbackPayloadForSuppressedFinal(payload);
           streamFinalizationPending = true;
+          retireStreamForLaterSegments();
           const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
           return hasMedia ? { ...payload, text: undefined } : undefined;
         } catch (err) {
@@ -313,6 +358,11 @@ export function createTeamsReplyStreamController(params: {
       if (!stream || !streamFinalizationPending || wasCanceled()) {
         return undefined;
       }
+      // Belt-and-suspenders: finalize always retires the stream for later
+      // segments even if preparePayload did not (e.g. progress-mode emit path).
+      streamRetired = true;
+      emittedTextLength = 0;
+      lastStreamedText = "";
       // Emit a final MessageActivity carrying the AI-generated marker and (if
       // enabled) the feedback channelData. The SDK's HttpStream merges this
       // into the closing activity it sends to Teams, so streamed replies still


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Microsoft Teams DM users with default partial streaming would see a single corrupted bubble after a tool-using reply: the post-tool answer was mid-word-sliced at the preamble length and appended onto the streamed preamble (for example `I'll check the CRM.` + `There are **190 contacts**...` became `I'll check the CRM.tacts** in RForce.`).

## Why This Change Was Made

The Teams reply stream controller keeps a delta cursor (`emittedTextLength`) for the SDK's appending stream, but did not retire or reset that cursor at tool/segment boundaries after the #76262 controller rebase. This restores the #56071 segment-boundary contract: finalize/retire the first streamed segment, detect cumulative-text restarts, and deliver later post-tool text via block delivery (or a full-segment emit after cursor reset) instead of slicing against the preamble.

## User Impact

Teams personal/DM tool-using replies under default `streaming.mode=partial` keep a readable preamble and a complete final answer instead of one mid-word-merged bubble. Group/channel block delivery is unchanged.

## Evidence

Focused controller + dispatcher tests, plus a local controller harness replaying the issue's preamble/final pair:

- `node scripts/run-vitest.mjs extensions/msteams/src/reply-stream-controller.test.ts` → 40 passed
- `node scripts/run-vitest.mjs extensions/msteams/src/reply-dispatcher.test.ts` → 31 passed
- Autoreview (branch vs `origin/main`): clean, no accepted/actionable findings

## Real behavior proof

- Behavior addressed: post-tool Teams partial streaming no longer mid-word-slices the final answer at the preamble offset after finalize
- Environment: local macOS checkout of openclaw `main` + branch `grok/msteams-post-tool-stream-slice-102274` @ `5576cbf7c`; Node vitest harness and a direct controller import via `tsx`
- Current-main contrast: on main, after streaming a preamble and finalizing, a longer post-tool partial is sliced at `preamble.length` (issue example: `...CRM.` + `tacts** in RForce.`)
- Exact steps or command run after this patch:
  1. Stream preamble `I will check the CRM.` via `onPartialReply`
  2. `preparePayload` + `finalize`
  3. `onPartialReply` with final `There are **190 contacts** in RForce.`
  4. `preparePayload` for the final text
- Evidence after fix:
  ```
  after preamble emits: ["I will check the CRM."]
  prepare1: undefined
  post-finalize partial emits: []
  prepare2: { text: 'There are **190 contacts** in RForce.' }
  corruptSliceWouldHaveBeen: "cts** in RForce."
  corrupt_emitted: NO_ok
  ```
- Control check: regression tests assert the corrupt slice `finalText.slice(preamble.length)` is never emitted after finalize; existing cumulative-delta and edit-in-place shorter-text cases still pass
- Observed result after fix: post-finalize partials do not emit into the retired stream; final text is returned intact for block delivery
- What was not tested: live Microsoft Teams personal DM against a real tenant (no credentials in this environment)

Fixes #102274

## AI disclosure

This fix was authored with AI assistance (Grok). Implementation, tests, and proof were produced and verified in a local openclaw checkout.
