### PR TITLE
fix(msteams): deliver post-tool text segment separately, not sliced into the preamble [AI-assisted]

### DIFF
--- a/extensions/msteams/src/reply-stream-controller.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.test.ts
@@ -152,6 +152,29 @@ describe("createTeamsReplyStreamController", () => {
     });
   });
 
+  it("does not slice a post-tool text segment at the preamble offset (#102274)", () => {
+    // Regression of #56071 (dropped by the #76262 rebase): when the pipeline
+    // sends a NEW text segment's cumulative text after a tool call, that text
+    // does not extend the streamed preamble. Slicing it at the preamble's
+    // emitted length merges it mid-word into the prior bubble.
+    const stream = makeStream();
+    const ctrl = makeController({ stream });
+
+    // Preamble streamed before the tool call (19 chars).
+    ctrl.onPartialReply({ text: "I'll check the CRM." });
+    // Tool boundary: the pipeline sends the new segment's cumulative text,
+    // which does NOT start with the preamble.
+    ctrl.onPartialReply({ text: "There are 190 contacts in RForce." });
+
+    // The streamed bubble must contain only the preamble. The post-tool
+    // segment is delivered as a separate message, not sliced-and-merged.
+    expect(stream.emit).toHaveBeenCalledTimes(1);
+    expect(stream.emit).toHaveBeenNthCalledWith(1, "I'll check the CRM.");
+    expect(ctrl.preparePayload({ text: "There are 190 contacts in RForce." })).toEqual({
+      text: "There are 190 contacts in RForce.",
+    });
+  });
+
   it("drops the payload after the stream is canceled (e.g. user Stop)", () => {
     // After the user presses Stop in Teams, the streamed prefix is already
     // visible. Returning the full payload here would render as a SECOND

--- a/extensions/msteams/src/reply-stream-controller.ts
+++ b/extensions/msteams/src/reply-stream-controller.ts
@@ -99,6 +99,9 @@ export function createTeamsReplyStreamController(params: {
   // an appending sink produces "chunk1 + chunk2 + chunk3..." duplication. We
   // track the length of text we've already emitted and forward only the delta.
   let emittedTextLength = 0;
+  // Last cumulative text emitted, used to detect when a tool boundary starts
+  // a new text segment whose cumulative text does not extend the prior one.
+  let lastEmittedText = "";
 
   const wasCanceled = () => canceledLocally || Boolean(stream?.canceled);
 
@@ -176,10 +179,24 @@ export function createTeamsReplyStreamController(params: {
       if (fullText.length <= emittedTextLength) {
         return;
       }
+      // A new text segment after a tool call does not extend the previously
+      // emitted cumulative text. Emitting it sliced at the stale offset would
+      // merge it mid-word into the prior streamed bubble (#102274, a regression
+      // of #56071 dropped by the #76262 rebase). Finalize the prior stream and
+      // reset so the new segment is delivered as a separate message via
+      // preparePayload instead of being sliced against the prior offset.
+      if (lastEmittedText && !fullText.startsWith(lastEmittedText)) {
+        streamFinalizationPending = true;
+        tokensEmitted = false;
+        emittedTextLength = 0;
+        lastEmittedText = "";
+        return;
+      }
       const delta = fullText.slice(emittedTextLength);
       try {
         stream.emit(delta);
         emittedTextLength = fullText.length;
+        lastEmittedText = fullText;
         tokensEmitted = true;
       } catch (err) {
         if (isStreamCancelledError(err)) {


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

Closes #102274

## What Problem This Solves

Fixes an issue where MS Teams DM streaming (default `partial` mode) corrupts replies that emit a text preamble before a tool call. When the agent writes a short preamble, runs a tool, then produces the final answer, the post-tool text segment is sliced at the preamble's stale byte offset and merged mid-word into the streamed bubble, producing garbled output and losing the second segment as a separate message. This is a regression of #56071 ("reset stream state after tool calls"), dropped by the #76262 SDK rebase that restructured the controller into its current `emittedTextLength` shape.

## Why This Change Was Made

`createTeamsReplyStreamController`'s `onPartialReply` converts the pipeline's cumulative text into deltas by tracking `emittedTextLength`. It assumes the cumulative text only ever grows within a single segment. Across a tool call a NEW segment begins, and its cumulative text does NOT start with the streamed preamble - but `emittedTextLength` is never reset at that boundary, so the new segment is sliced at the preamble's length and emitted into the same stream (merge). The fix detects the segment boundary in `onPartialReply`: when the incoming cumulative text does not extend the previously-emitted text (i.e. a new segment), it finalizes the prior stream and resets the offset/state so the new segment is delivered as a separate message via `preparePayload` (block fallback) - restoring #56071's behavior in the post-rebase structure. Single-segment cumulative growth, edit-in-place shorter text, and the existing finalize-pending paths are unchanged.

## User Impact

Agents using MS Teams in DMs with default streaming no longer deliver garbled, mid-word-merged replies when they emit a preamble before a tool call. The preamble and the post-tool answer render as separate, complete messages. Group/channel (block delivery) and non-tool replies are unaffected.

## Evidence

**Real behavior proof** - the real `createTeamsReplyStreamController` driven with the issue's exact sequence (19-char preamble, then a post-tool segment), capturing the streamed bubble text and the second segment's delivery:

Before fix (current `main`):

```
preamble="I'll check the CRM." (19 chars) | post-tool segment="There are 190 contacts in RForce."
=> streamed bubble="I'll check the CRM.cts in RForce." | emit calls=2 | second-segment delivery=undefined
```

The post-tool segment is sliced at offset 19 (`...con|tacts...` -> `cts in RForce.`) and merged mid-word into the preamble; the second segment is then dropped (`undefined`).

After fix (this branch):

```
preamble="I'll check the CRM." (19 chars) | post-tool segment="There are 190 contacts in RForce."
=> streamed bubble="I'll check the CRM." | emit calls=1 | second-segment delivery={"text":"There are 190 contacts in RForce."}
```

The streamed bubble is the clean preamble only; the post-tool segment is delivered as a separate message.

Regression coverage added to `extensions/msteams/src/reply-stream-controller.test.ts`:

- `does not slice a post-tool text segment at the preamble offset (#102274)` - drives the preamble + divergent post-tool segment directly through `onPartialReply` and asserts the streamed bubble contains only the preamble and the second segment is delivered separately (fails on `main`, passes on this branch).

The existing segment/fallback tests (`allows fallback delivery for second text segment after tool calls`, `uses fallback even when onPartialReply fires after stream finalization is pending`, `delivers all later segments across 3+ tool call rounds`) remain green (38 passed). `pnpm tsgo`, `oxlint`, and `oxfmt` are clean on the changed files.

## Human Verification

- Confirmed the regression on current `main`: `onPartialReply` slices a post-tool segment at the prior `emittedTextLength` and merges it into the streamed bubble (`extensions/msteams/src/reply-stream-controller.ts`).
- Verified the user-visible behavior change against the real controller with the issue's exact preamble + post-tool sequence: before fix the bubble is garbled (`"I'll check the CRM.cts in RForce."`) and the second segment is lost; after fix the bubble is the clean preamble and the second segment is delivered as a separate message (captured above).
- Verified the segment-boundary detection does not affect single-segment cumulative growth (delta conversion), edit-in-place shorter text (length guard), or the finalize-pending early-return path - all covered by existing tests.
- Confirmed `#56071`'s intent (finalize + reset at the tool boundary so the post-tool segment is a separate message) is restored in the post-`#76262` structure.
- Not verified: live MS Teams DM delivery against a real bot (the controller is exercised directly via its public API with a mock stream, which is the exact code path the pipeline drives); macOS/iOS not tested; Swift host-env-policy check skipped on Windows.

## Compatibility / Migration

No API, config, or CLI changes. The only behavioral change is that a post-tool text segment in MS Teams DM streaming is delivered as a separate message instead of being sliced-and-merged into the preamble bubble. This restores the pre-`#76262` (#56071) behavior.

## Failure Recovery

Revert the single commit. No migration or state changes are involved.
