### PR TITLE
fix(telegram): attribute the bot's own chat-window messages as self

### DIFF
--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -54,7 +54,7 @@ import {
 import { resolveTelegramTransport } from "./fetch.js";
 import { resolveTelegramScopedGroupConfig } from "./group-config-helpers.js";
 import {
-  buildTelegramGroupHistorySelfSender,
+  buildTelegramSelfSenderName,
   recordTelegramGroupHistoryEntry,
 } from "./group-history-window.js";
 import { registerTelegramOutboundGroupHistoryRecorder } from "./outbound-message-context.js";
@@ -261,9 +261,7 @@ export function createTelegramBotCore(
     opts,
   });
   const groupHistories = new Map<string, HistoryEntry[]>();
-  const botHistorySender = buildTelegramGroupHistorySelfSender(
-    account.name ?? opts.botInfo?.first_name ?? opts.botInfo?.username ?? "OpenClaw",
-  );
+  const botHistorySender = buildTelegramSelfSenderName(account.name, opts.botInfo);
   const unregisterOutboundGroupHistoryRecorder = registerTelegramOutboundGroupHistoryRecorder({
     accountId: account.accountId,
     recorder: (record) => {

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -279,7 +279,10 @@ export const registerTelegramHandlers = ({
   const messageCache = createTelegramMessageCache({
     scope: resolveTelegramMessageCacheScope(telegramDeps.resolveStorePath(cfg.session?.store)),
   });
-  const resolvePromptSender = (node: TelegramCachedMessageNode, ctx: TelegramContext): string => {
+  const resolvePromptSender = (
+    node: TelegramCachedMessageNode,
+    ctx: TelegramContext,
+  ): string | undefined => {
     const botInfo = ctx.me ?? opts.botInfo;
     if (botInfo?.id != null && node.senderId === String(botInfo.id)) {
       return buildTelegramSelfSenderName(telegramCfg.name, botInfo);

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -142,7 +142,11 @@ import {
   evaluateTelegramGroupPolicyAccess,
 } from "./group-access.js";
 import { resolveTelegramScopedGroupConfig } from "./group-config-helpers.js";
-import { isTelegramHistoryEntryAfterAmbientWatermark } from "./group-history-window.js";
+import {
+  buildTelegramSelfSenderName,
+  isTelegramHistoryEntryAfterAmbientWatermark,
+  isTelegramSelfSenderName,
+} from "./group-history-window.js";
 import { migrateTelegramGroupConfig } from "./group-migration.js";
 import {
   resolveTelegramCommandIngressAuthorization,
@@ -275,6 +279,17 @@ export const registerTelegramHandlers = ({
   const messageCache = createTelegramMessageCache({
     scope: resolveTelegramMessageCacheScope(telegramDeps.resolveStorePath(cfg.session?.store)),
   });
+  const resolvePromptSender = (node: TelegramCachedMessageNode, ctx: TelegramContext): string => {
+    const botInfo = ctx.me ?? opts.botInfo;
+    if (botInfo?.id != null && node.senderId === String(botInfo.id)) {
+      return buildTelegramSelfSenderName(telegramCfg.name, botInfo);
+    }
+    if (node.senderId === "0" && node.sourceMessage.from?.is_bot === true) {
+      return node.sender;
+    }
+    // Config reloads restart this handler; `(you)` stays reserved for authenticated bot ids.
+    return isTelegramSelfSenderName(node.sender) ? `${node.sender} (Telegram sender)` : node.sender;
+  };
   const messageDispatchReplayGuard = createTelegramMessageDispatchReplayGuard({
     onDiskError: (error) => {
       runtime.error?.(danger(`[telegram] message dispatch dedupe store failed: ${String(error)}`));
@@ -1222,13 +1237,15 @@ export const registerTelegramHandlers = ({
 
   const toReplyChainEntry = (
     node: TelegramCachedMessageNode,
+    ctx: TelegramContext,
     media?: TelegramMediaRef,
   ): TelegramReplyChainEntry => {
     const { sourceMessage: _sourceMessage, ...entry } = node;
+    const projectedEntry = { ...entry, sender: resolvePromptSender(node, ctx) };
     if (!media?.path) {
-      return entry;
+      return projectedEntry;
     }
-    const { mediaRef: _mediaRef, ...entryWithoutProviderMediaRef } = entry;
+    const { mediaRef: _mediaRef, ...entryWithoutProviderMediaRef } = projectedEntry;
     return {
       ...entryWithoutProviderMediaRef,
       mediaPath: media.path,
@@ -1238,12 +1255,13 @@ export const registerTelegramHandlers = ({
 
   const toPromptContextMessage = (
     node: TelegramCachedMessageNode,
+    ctx: TelegramContext,
     flags?: { replyTarget?: boolean },
     media?: TelegramMediaRef,
   ) => ({
     message_id: node.messageId,
     thread_id: node.threadId,
-    sender: node.sender,
+    sender: resolvePromptSender(node, ctx),
     sender_id: node.senderId,
     sender_username: node.senderUsername,
     timestamp_ms: node.timestamp,
@@ -1361,6 +1379,7 @@ export const registerTelegramHandlers = ({
     const cachePromptMessages = Array.from(conversationContextById.values()).map((entry) =>
       toPromptContextMessage(
         entry.node,
+        ctx,
         { replyTarget: entry.isReplyTarget },
         entry.node.messageId ? mediaByMessageId?.get(entry.node.messageId) : undefined,
       ),
@@ -1435,7 +1454,7 @@ export const registerTelegramHandlers = ({
       if (mediaRef) {
         replyMedia.push(mediaRef);
       }
-      replyChain.push(toReplyChainEntry(node, mediaRef));
+      replyChain.push(toReplyChainEntry(node, ctx, mediaRef));
     }
     return { replyMedia, replyChain };
   };

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -284,7 +284,12 @@ export const registerTelegramHandlers = ({
     ctx: TelegramContext,
   ): string | undefined => {
     const botInfo = ctx.me ?? opts.botInfo;
-    if (botInfo?.id != null && node.senderId === String(botInfo.id)) {
+    // Business replies keep the account user in `from`; Telegram authenticates the bot separately.
+    const isAuthenticatedSelf =
+      botInfo?.id != null &&
+      (node.senderId === String(botInfo.id) ||
+        node.sourceMessage.sender_business_bot?.id === botInfo.id);
+    if (isAuthenticatedSelf) {
       return buildTelegramSelfSenderName(telegramCfg.name, botInfo);
     }
     if (node.senderId === "0" && node.sourceMessage.from?.is_bot === true) {

--- a/extensions/telegram/src/bot-message-context.require-mention.test.ts
+++ b/extensions/telegram/src/bot-message-context.require-mention.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 const { buildTelegramMessageContextForTest } =
   await import("./bot-message-context.test-harness.js");
-const { buildTelegramGroupHistorySelfSender } = await import("./group-history-window.js");
+const { buildTelegramSelfSenderName } = await import("./group-history-window.js");
 
 describe("buildTelegramMessageContext requireMention precedence", () => {
   function buildForumMessage(threadId = 99) {
@@ -284,7 +284,7 @@ describe("buildTelegramMessageContext requireMention precedence", () => {
         [
           { sender: "Alice", body: "before self marker", timestamp: 1, messageId: "1" },
           {
-            sender: buildTelegramGroupHistorySelfSender("OpenClaw"),
+            sender: buildTelegramSelfSenderName("OpenClaw"),
             body: "self marker body",
             timestamp: 2,
             messageId: "2",

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -322,17 +322,18 @@ export async function buildTelegramInboundContextPayload(params: {
   const visibleReplyTargetEntry = visibleReplyTarget
     ? replyTargetToChainEntry(visibleReplyTarget)
     : undefined;
-  const visibleReplyTargetById = new Map<string, TelegramReplyChainEntry>(
-    visibleReplyTargetEntry?.messageId
-      ? [[visibleReplyTargetEntry.messageId, visibleReplyTargetEntry]]
-      : [],
-  );
   const rawReplyChain =
     replyChain.length > 0 ? replyChain : visibleReplyTargetEntry ? [visibleReplyTargetEntry] : [];
   const visibleReplyChain = rawReplyChain.flatMap((entry) => {
+    const selectedReplyEntry =
+      entry.messageId === visibleReplyTargetEntry?.messageId ? visibleReplyTargetEntry : undefined;
     const visibleEntry = {
       ...entry,
-      ...(entry.messageId ? visibleReplyTargetById.get(entry.messageId) : undefined),
+      ...selectedReplyEntry,
+      // Preserve authenticated identity while Telegram's selected quote body wins.
+      sender: entry.sender,
+      senderId: entry.senderId,
+      senderUsername: entry.senderUsername,
     };
     if (
       !shouldIncludeGroupSupplementalContext({

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1941,7 +1941,16 @@ describe("dispatchTelegramMessage draft streaming", () => {
   it("streams text-only finals into the answer message", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     const transcriptTimestamp = Date.now() + 1_000;
-    const context = createContext();
+    const context = createContext({
+      primaryCtx: {
+        me: {
+          id: 999,
+          is_bot: true,
+          first_name: "Telegram Bot Name",
+          username: "openclaw_bot",
+        },
+      } as TelegramMessageContext["primaryCtx"],
+    });
     context.ctxPayload.SessionKey = "agent:default:telegram:direct:123";
     mockDefaultSessionEntry();
     readLatestAssistantTextByIdentity.mockResolvedValue({
@@ -1964,6 +1973,15 @@ describe("dispatchTelegramMessage draft streaming", () => {
       messageId: 2001,
     });
     expectRecordFields(mockCallArg(recordOutboundMessageForPromptContext), {
+      account: {
+        accountId: "default",
+        bot: {
+          id: 999,
+          is_bot: true,
+          first_name: "Telegram Bot Name",
+          username: "openclaw_bot",
+        },
+      },
       chatId: "123",
       messageId: 2001,
       text: "Final answer",
@@ -1975,7 +1993,16 @@ describe("dispatchTelegramMessage draft streaming", () => {
   it("records streamed final replies into the prompt context cache", async () => {
     const storePath = `/tmp/openclaw-telegram-stream-context-${process.pid}-${Date.now()}.json`;
     const transcriptTimestamp = Date.now() + 1_000;
-    const context = createContext();
+    const context = createContext({
+      primaryCtx: {
+        me: {
+          id: 999,
+          is_bot: true,
+          first_name: "Telegram Bot Name",
+          username: "openclaw_bot",
+        },
+      } as TelegramMessageContext["primaryCtx"],
+    });
     context.ctxPayload.SessionKey = "agent:default:telegram:direct:123";
     mockDefaultSessionEntry();
     readLatestAssistantTextByIdentity.mockResolvedValue({
@@ -1994,6 +2021,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await dispatchWithContext({
       context,
       cfg: { session: { store: storePath } },
+      telegramCfg: { name: "Configured Agent" },
       telegramDeps: {
         ...telegramDepsForTest,
         recordOutboundMessageForPromptContext: recordOutboundMessageForPromptContextActual,
@@ -2028,13 +2056,20 @@ describe("dispatchTelegramMessage draft streaming", () => {
       replyTargetWindowSize: 2,
     });
 
-    expect(conversationContext.map((entry) => entry.node.messageId)).toContain("1497");
-    expect(conversationContext.map((entry) => entry.node.body)).toContain(
-      "Done already: timeoutSeconds is now 7200s.",
-    );
-    expect(
-      conversationContext.find((entry) => entry.node.messageId === "1497")?.node.timestamp,
-    ).toBe(transcriptTimestamp);
+    const streamedReply = conversationContext.find((entry) => entry.node.messageId === "1497");
+    expect(streamedReply?.node).toMatchObject({
+      body: "Done already: timeoutSeconds is now 7200s.",
+      sender: "Configured Agent (you)",
+      senderId: "0",
+      timestamp: transcriptTimestamp,
+      sourceMessage: {
+        from: {
+          id: 0,
+          is_bot: true,
+          first_name: "Configured Agent (you)",
+        },
+      },
+    });
   });
 
   it("suppresses text-only tool payloads delivered after the final answer", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1846,7 +1846,11 @@ export const dispatchTelegramMessage = async ({
           recordOutboundMessageForPromptContext
         )({
           cfg,
-          account: { accountId: route.accountId },
+          account: {
+            accountId: route.accountId,
+            ...(telegramCfg.name !== undefined ? { name: telegramCfg.name } : {}),
+            ...(context.primaryCtx.me ? { bot: context.primaryCtx.me } : {}),
+          },
           chatId: deliveryBaseOptions.chatId,
           message: { message_id: result.delivery.messageId },
           messageId: result.delivery.messageId,

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -313,7 +313,7 @@ describe("createTelegramBot", () => {
     expect(getOnHandler("message")).toEqual(expect.any(Function));
   });
 
-  it("records outbound prompt-context sends into ambient group history", async () => {
+  it("dedupes outbound prompt-context sends with ambient group history", async () => {
     onSpy.mockClear();
     replySpy.mockClear();
     const cfg = {
@@ -379,6 +379,169 @@ describe("createTelegramBot", () => {
         expect.objectContaining({ body: "Bot just replied", sender: "OpenClaw (you)" }),
       ]),
     );
+    const [conversationContext] = requireArray(
+      payload.UntrustedStructuredContext,
+      "structured context",
+    );
+    const contextPayload = requireRecord(
+      requireRecord(conversationContext, "conversation context").payload,
+      "conversation context payload",
+    );
+    const messages = requireArray(contextPayload.messages, "conversation context messages").map(
+      (message, index) => requireRecord(message, `conversation context message ${index + 1}`),
+    );
+    expect(messages.filter((message) => message.message_id === "700")).toEqual([
+      expect.objectContaining({
+        body: "Bot just replied",
+        sender: "OpenClaw (you)",
+        sender_id: "0",
+      }),
+    ]);
+  });
+
+  it.each([
+    {
+      caseName: "labels a raw bot reply on a cache miss",
+      replyFrom: {
+        id: 999,
+        is_bot: true,
+        first_name: "Provisioning",
+        last_name: "Placeholder",
+        username: "openclaw_bot",
+      },
+      expectedSender: "Configured Agent (you)",
+      omitMe: false,
+    },
+    {
+      caseName: "does not trust a user-controlled self suffix",
+      replyFrom: {
+        id: 888,
+        is_bot: false,
+        first_name: "Alex (you)",
+        username: "alex",
+      },
+      expectedSender: "Alex (you) (Telegram sender)",
+      omitMe: false,
+    },
+    {
+      caseName: "falls back to startup bot metadata when context metadata is missing",
+      replyFrom: {
+        id: 999,
+        is_bot: true,
+        first_name: "Provisioning",
+        last_name: "Placeholder",
+        username: "openclaw_bot",
+      },
+      expectedSender: "Configured Agent (you)",
+      omitMe: true,
+    },
+  ])("$caseName", async ({ replyFrom, expectedSender, omitMe }) => {
+    onSpy.mockClear();
+    replySpy.mockClear();
+    const storePath = `/tmp/openclaw-telegram-self-projection-${process.pid}-${Date.now()}.json`;
+    const cfg = {
+      channels: {
+        telegram: {
+          name: "  Configured Agent  ",
+          dmPolicy: "open",
+          allowFrom: ["*"],
+        },
+      },
+      session: { store: storePath },
+    } satisfies OpenClawConfig;
+    loadConfig.mockReturnValue(cfg);
+    createTelegramBot({
+      token: "tok",
+      config: cfg,
+      botInfo: {
+        id: 999,
+        is_bot: true,
+        first_name: "Telegram Bot Name",
+        username: "openclaw_bot",
+        can_join_groups: true,
+        can_read_all_group_messages: false,
+        can_manage_bots: false,
+        supports_inline_queries: false,
+        supports_join_request_queries: false,
+        can_connect_to_business: false,
+        has_main_web_app: false,
+        has_topics_enabled: false,
+        allows_users_to_create_topics: false,
+      },
+    });
+
+    try {
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+      await handler({
+        ...(omitMe
+          ? {}
+          : {
+              me: {
+                id: 999,
+                is_bot: true,
+                first_name: "Telegram Bot Name",
+                username: "openclaw_bot",
+              },
+            }),
+        getFile: async () => ({ download: async () => new Uint8Array() }),
+        message: {
+          chat: { id: 42, type: "private", first_name: "Pat" },
+          text: "Following up",
+          date: 1_736_380_800,
+          message_id: 801,
+          from: { id: 123, is_bot: false, first_name: "Pat" },
+          reply_to_message: {
+            chat: { id: 42, type: "private", first_name: "Pat" },
+            date: 1_736_380_700,
+            from: replyFrom,
+            message_id: 800,
+            text: "Earlier reply",
+          },
+        },
+      });
+
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      const payload = mockMsgContextArg(
+        replySpy as unknown as MockCallSource,
+        0,
+        0,
+        "replySpy call",
+      );
+      expect(payload.ReplyChain).toEqual([
+        expect.objectContaining({
+          messageId: "800",
+          sender: expectedSender,
+          senderId: String(replyFrom.id),
+          senderUsername: replyFrom.username,
+        }),
+      ]);
+      const [conversationContext] = requireArray(
+        payload.UntrustedStructuredContext,
+        "structured context",
+      );
+      const messages = requireArray(
+        requireRecord(
+          requireRecord(conversationContext, "conversation context").payload,
+          "conversation context payload",
+        ).messages,
+        "conversation context messages",
+      ).map((message, index) =>
+        requireRecord(message, `conversation context message ${index + 1}`),
+      );
+      expect(messages.find((message) => message.message_id === "800")).toMatchObject({
+        sender: expectedSender,
+        sender_id: String(replyFrom.id),
+        sender_username: replyFrom.username,
+      });
+      if (replyFrom.id === 999) {
+        const promptJson = JSON.stringify({ replyChain: payload.ReplyChain, messages });
+        expect(promptJson).not.toContain("Provisioning");
+        expect(promptJson).not.toContain("Placeholder");
+      }
+    } finally {
+      await rm(storePath, { force: true });
+      await rm(`${storePath}.telegram-messages.json`, { force: true });
+    }
   });
 
   it("uses the live allowlist when authorizing callbacks", async () => {
@@ -2579,7 +2742,7 @@ describe("createTelegramBot", () => {
       createTelegramBot({ token: "tok", config });
       const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
       const baseCtx = {
-        me: { id: 999, username: "openclaw_bot" },
+        me: { id: 999, is_bot: true, first_name: "OpenClaw", username: "openclaw_bot" },
         getFile: async () => ({ download: async () => new Uint8Array() }),
       };
       const chatId = 7773;
@@ -2639,7 +2802,7 @@ describe("createTelegramBot", () => {
           body: visibleReply,
           is_reply_target: true,
           message_id: "736",
-          sender: "OpenClaw",
+          sender: "OpenClaw (you)",
         }),
       ]);
       expect(messages.filter((message) => message.body === visibleReply)).toHaveLength(1);
@@ -3019,7 +3182,7 @@ describe("createTelegramBot", () => {
       });
       const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
       const baseCtx = {
-        me: { id: 999, username: "openclaw_bot" },
+        me: { id: 999, is_bot: true, first_name: "OpenClaw", username: "openclaw_bot" },
         getFile: async () => ({ download: async () => new Uint8Array() }),
       };
       const chat = { id: chatId, type: "group", title: "Ops" };
@@ -3086,7 +3249,7 @@ describe("createTelegramBot", () => {
     };
     expect(payload.ReplyChain?.map((entry) => entry.messageId)).toEqual(["102", "101"]);
     expect(payload.ReplyChain?.[1]).toMatchObject({
-      sender: "OpenClaw",
+      sender: "OpenClaw (you)",
       body: "Done, here is the image",
     });
     if (expectHydrated) {
@@ -3108,7 +3271,7 @@ describe("createTelegramBot", () => {
     );
     const messagesById = new Map(messages.map((message) => [message.message_id, message]));
     expect(messagesById.get("101")).toMatchObject({
-      sender: "OpenClaw",
+      sender: "OpenClaw (you)",
       body: "Done, here is the image",
       is_reply_target: true,
     });

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -394,7 +394,6 @@ describe("createTelegramBot", () => {
       expect.objectContaining({
         body: "Bot just replied",
         sender: "OpenClaw (you)",
-        sender_id: "0",
       }),
     ]);
   });
@@ -412,6 +411,8 @@ describe("createTelegramBot", () => {
       expectedSender: "Configured Agent (you)",
       omitMe: false,
       senderBusinessBot: undefined,
+      chatId: 42,
+      replyMessageId: 800,
     },
     {
       caseName: "does not trust a user-controlled self suffix",
@@ -424,6 +425,8 @@ describe("createTelegramBot", () => {
       expectedSender: "Alex (you) (Telegram sender)",
       omitMe: false,
       senderBusinessBot: undefined,
+      chatId: 43,
+      replyMessageId: 810,
     },
     {
       caseName: "authenticates the sender bot for a Telegram Business reply",
@@ -441,6 +444,8 @@ describe("createTelegramBot", () => {
         first_name: "Telegram Bot Name",
         username: "openclaw_bot",
       },
+      chatId: 44,
+      replyMessageId: 820,
     },
     {
       caseName: "falls back to startup bot metadata when context metadata is missing",
@@ -454,116 +459,123 @@ describe("createTelegramBot", () => {
       expectedSender: "Configured Agent (you)",
       omitMe: true,
       senderBusinessBot: undefined,
+      chatId: 45,
+      replyMessageId: 830,
     },
-  ])("$caseName", async ({ replyFrom, expectedSender, omitMe, senderBusinessBot }) => {
-    onSpy.mockClear();
-    replySpy.mockClear();
-    const storePath = `/tmp/openclaw-telegram-self-projection-${process.pid}-${Date.now()}.json`;
-    const cfg = {
-      channels: {
-        telegram: {
-          name: "  Configured Agent  ",
-          dmPolicy: "open",
-          allowFrom: ["*"],
-        },
-      },
-      session: { store: storePath },
-    } satisfies OpenClawConfig;
-    loadConfig.mockReturnValue(cfg);
-    createTelegramBot({
-      token: "tok",
-      config: cfg,
-      botInfo: {
-        id: 999,
-        is_bot: true,
-        first_name: "Telegram Bot Name",
-        username: "openclaw_bot",
-        can_join_groups: true,
-        can_read_all_group_messages: false,
-        can_manage_bots: false,
-        supports_inline_queries: false,
-        supports_join_request_queries: false,
-        can_connect_to_business: false,
-        has_main_web_app: false,
-        has_topics_enabled: false,
-        allows_users_to_create_topics: false,
-      },
-    });
-
-    try {
-      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
-      await handler({
-        ...(omitMe
-          ? {}
-          : {
-              me: {
-                id: 999,
-                is_bot: true,
-                first_name: "Telegram Bot Name",
-                username: "openclaw_bot",
-              },
-            }),
-        getFile: async () => ({ download: async () => new Uint8Array() }),
-        message: {
-          chat: { id: 42, type: "private", first_name: "Pat" },
-          text: "Following up",
-          date: 1_736_380_800,
-          message_id: 801,
-          from: { id: 123, is_bot: false, first_name: "Pat" },
-          reply_to_message: {
-            chat: { id: 42, type: "private", first_name: "Pat" },
-            date: 1_736_380_700,
-            from: replyFrom,
-            ...(senderBusinessBot ? { sender_business_bot: senderBusinessBot } : {}),
-            message_id: 800,
-            text: "Earlier reply",
+  ])(
+    "$caseName",
+    async ({ replyFrom, expectedSender, omitMe, senderBusinessBot, chatId, replyMessageId }) => {
+      onSpy.mockClear();
+      replySpy.mockClear();
+      const storePath = `/tmp/openclaw-telegram-self-projection-${process.pid}-${chatId}.json`;
+      const cfg = {
+        channels: {
+          telegram: {
+            name: "  Configured Agent  ",
+            dmPolicy: "open",
+            allowFrom: ["*"],
           },
         },
+        session: { store: storePath },
+      } satisfies OpenClawConfig;
+      loadConfig.mockReturnValue(cfg);
+      createTelegramBot({
+        token: "tok",
+        config: cfg,
+        botInfo: {
+          id: 999,
+          is_bot: true,
+          first_name: "Telegram Bot Name",
+          username: "openclaw_bot",
+          can_join_groups: true,
+          can_read_all_group_messages: false,
+          can_manage_bots: false,
+          supports_inline_queries: false,
+          supports_join_request_queries: false,
+          can_connect_to_business: false,
+          has_main_web_app: false,
+          has_topics_enabled: false,
+          allows_users_to_create_topics: false,
+        },
       });
 
-      expect(replySpy).toHaveBeenCalledTimes(1);
-      const payload = mockMsgContextArg(
-        replySpy as unknown as MockCallSource,
-        0,
-        0,
-        "replySpy call",
-      );
-      expect(payload.ReplyChain).toEqual([
-        expect.objectContaining({
-          messageId: "800",
+      try {
+        const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+        await handler({
+          ...(omitMe
+            ? {}
+            : {
+                me: {
+                  id: 999,
+                  is_bot: true,
+                  first_name: "Telegram Bot Name",
+                  username: "openclaw_bot",
+                },
+              }),
+          getFile: async () => ({ download: async () => new Uint8Array() }),
+          message: {
+            chat: { id: chatId, type: "private", first_name: "Pat" },
+            text: "Following up",
+            date: 1_736_380_800,
+            message_id: replyMessageId + 1,
+            from: { id: 123, is_bot: false, first_name: "Pat" },
+            reply_to_message: {
+              chat: { id: chatId, type: "private", first_name: "Pat" },
+              date: 1_736_380_700,
+              from: replyFrom,
+              ...(senderBusinessBot ? { sender_business_bot: senderBusinessBot } : {}),
+              message_id: replyMessageId,
+              text: "Earlier reply",
+            },
+          },
+        });
+
+        expect(replySpy).toHaveBeenCalledTimes(1);
+        const payload = mockMsgContextArg(
+          replySpy as unknown as MockCallSource,
+          0,
+          0,
+          "replySpy call",
+        );
+        expect(payload.ReplyChain).toEqual([
+          expect.objectContaining({
+            messageId: String(replyMessageId),
+            sender: expectedSender,
+            senderId: String(replyFrom.id),
+            senderUsername: replyFrom.username,
+          }),
+        ]);
+        const [conversationContext] = requireArray(
+          payload.UntrustedStructuredContext,
+          "structured context",
+        );
+        const messages = requireArray(
+          requireRecord(
+            requireRecord(conversationContext, "conversation context").payload,
+            "conversation context payload",
+          ).messages,
+          "conversation context messages",
+        ).map((message, index) =>
+          requireRecord(message, `conversation context message ${index + 1}`),
+        );
+        expect(
+          messages.find((message) => message.message_id === String(replyMessageId)),
+        ).toMatchObject({
           sender: expectedSender,
-          senderId: String(replyFrom.id),
-          senderUsername: replyFrom.username,
-        }),
-      ]);
-      const [conversationContext] = requireArray(
-        payload.UntrustedStructuredContext,
-        "structured context",
-      );
-      const messages = requireArray(
-        requireRecord(
-          requireRecord(conversationContext, "conversation context").payload,
-          "conversation context payload",
-        ).messages,
-        "conversation context messages",
-      ).map((message, index) =>
-        requireRecord(message, `conversation context message ${index + 1}`),
-      );
-      expect(messages.find((message) => message.message_id === "800")).toMatchObject({
-        sender: expectedSender,
-        sender_id: String(replyFrom.id),
-        sender_username: replyFrom.username,
-      });
-      if (replyFrom.id === 999 || senderBusinessBot?.id === 999) {
-        const promptJson = JSON.stringify({ replyChain: payload.ReplyChain, messages });
-        expect(promptJson).not.toContain("Provisioning");
-        expect(promptJson).not.toContain("Placeholder");
+          sender_id: String(replyFrom.id),
+          sender_username: replyFrom.username,
+        });
+        if (replyFrom.id === 999 || senderBusinessBot?.id === 999) {
+          const promptJson = JSON.stringify({ replyChain: payload.ReplyChain, messages });
+          expect(promptJson).not.toContain("Provisioning");
+          expect(promptJson).not.toContain("Placeholder");
+        }
+      } finally {
+        await rm(storePath, { force: true });
+        await rm(`${storePath}.telegram-messages.json`, { force: true });
       }
-    } finally {
-      await rm(storePath, { force: true });
-      await rm(`${storePath}.telegram-messages.json`, { force: true });
-    }
-  });
+    },
+  );
 
   it("uses the live allowlist when authorizing callbacks", async () => {
     onSpy.mockClear();

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -411,6 +411,7 @@ describe("createTelegramBot", () => {
       },
       expectedSender: "Configured Agent (you)",
       omitMe: false,
+      senderBusinessBot: undefined,
     },
     {
       caseName: "does not trust a user-controlled self suffix",
@@ -422,6 +423,24 @@ describe("createTelegramBot", () => {
       },
       expectedSender: "Alex (you) (Telegram sender)",
       omitMe: false,
+      senderBusinessBot: undefined,
+    },
+    {
+      caseName: "authenticates the sender bot for a Telegram Business reply",
+      replyFrom: {
+        id: 777,
+        is_bot: false,
+        first_name: "Business Account",
+        username: "business_account",
+      },
+      expectedSender: "Configured Agent (you)",
+      omitMe: false,
+      senderBusinessBot: {
+        id: 999,
+        is_bot: true,
+        first_name: "Telegram Bot Name",
+        username: "openclaw_bot",
+      },
     },
     {
       caseName: "falls back to startup bot metadata when context metadata is missing",
@@ -434,8 +453,9 @@ describe("createTelegramBot", () => {
       },
       expectedSender: "Configured Agent (you)",
       omitMe: true,
+      senderBusinessBot: undefined,
     },
-  ])("$caseName", async ({ replyFrom, expectedSender, omitMe }) => {
+  ])("$caseName", async ({ replyFrom, expectedSender, omitMe, senderBusinessBot }) => {
     onSpy.mockClear();
     replySpy.mockClear();
     const storePath = `/tmp/openclaw-telegram-self-projection-${process.pid}-${Date.now()}.json`;
@@ -494,6 +514,7 @@ describe("createTelegramBot", () => {
             chat: { id: 42, type: "private", first_name: "Pat" },
             date: 1_736_380_700,
             from: replyFrom,
+            ...(senderBusinessBot ? { sender_business_bot: senderBusinessBot } : {}),
             message_id: 800,
             text: "Earlier reply",
           },
@@ -533,7 +554,7 @@ describe("createTelegramBot", () => {
         sender_id: String(replyFrom.id),
         sender_username: replyFrom.username,
       });
-      if (replyFrom.id === 999) {
+      if (replyFrom.id === 999 || senderBusinessBot?.id === 999) {
         const promptJson = JSON.stringify({ replyChain: payload.ReplyChain, messages });
         expect(promptJson).not.toContain("Provisioning");
         expect(promptJson).not.toContain("Placeholder");

--- a/extensions/telegram/src/group-history-window.ts
+++ b/extensions/telegram/src/group-history-window.ts
@@ -5,14 +5,26 @@ import type {
   TelegramPromptContextEntry,
 } from "./bot-message-context.types.js";
 
-const TELEGRAM_GROUP_HISTORY_SELF_SUFFIX = " (you)";
+const TELEGRAM_SELF_SENDER_SUFFIX = " (you)";
 
-export function buildTelegramGroupHistorySelfSender(name: string): string {
-  return `${name}${TELEGRAM_GROUP_HISTORY_SELF_SUFFIX}`;
+export function buildTelegramSelfSenderName(
+  configuredName?: string,
+  telegramIdentity?: { first_name?: string; username?: string },
+): string {
+  const name =
+    configuredName?.trim() ||
+    telegramIdentity?.first_name?.trim() ||
+    telegramIdentity?.username?.trim() ||
+    "OpenClaw";
+  return `${name}${TELEGRAM_SELF_SENDER_SUFFIX}`;
+}
+
+export function isTelegramSelfSenderName(name: string | undefined): name is string {
+  return name?.endsWith(TELEGRAM_SELF_SENDER_SUFFIX) === true;
 }
 
 function isTelegramGroupHistorySelfEntry(entry: HistoryEntry): boolean {
-  return entry.sender.endsWith(TELEGRAM_GROUP_HISTORY_SELF_SUFFIX);
+  return isTelegramSelfSenderName(entry.sender);
 }
 
 function telegramPromptMessageKey(message: Record<string, unknown>): string | undefined {

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -447,10 +447,18 @@ function mergeCachedMessageNode(
   mode: TelegramMessageObservationMode,
 ): TelegramCachedMessageNode {
   const threadId = parseCachedThreadId(incoming.threadId ?? existing.threadId);
-  const sourceMessage =
+  const mergedSourceMessage =
     mode === "authoritative"
       ? mergeAuthoritativeTelegramSourceMessage(existing.sourceMessage, incoming.sourceMessage)
       : mergeTelegramSourceMessage(existing.sourceMessage, incoming.sourceMessage);
+  const syntheticOutboundFrom =
+    existing.senderId === "0" && incoming.sourceMessage.sender_chat
+      ? existing.sourceMessage.from
+      : undefined;
+  // sender_chat pairs with a fake `from`; preserve our outbound-only id=0 sentinel.
+  const sourceMessage = syntheticOutboundFrom
+    ? ({ ...mergedSourceMessage, from: syntheticOutboundFrom } as Message)
+    : mergedSourceMessage;
   return normalizeRequiredMessageNode(sourceMessage, threadId !== undefined ? { threadId } : {});
 }
 

--- a/extensions/telegram/src/outbound-message-context.test.ts
+++ b/extensions/telegram/src/outbound-message-context.test.ts
@@ -132,6 +132,42 @@ describe("recordOutboundMessageForPromptContext", () => {
     });
   });
 
+  it("preserves the sending bot identity for Telegram Business messages", async () => {
+    const cached = await recordAndRead({
+      account: { accountId: "default", name: "Configured Agent" },
+      chatId: 42,
+      message: {
+        chat: { id: 42, type: "private" },
+        date: 1_736_380_700,
+        from: {
+          id: 777,
+          is_bot: false,
+          first_name: "Business Account",
+          username: "business_account",
+        },
+        sender_business_bot: {
+          id: 999,
+          is_bot: true,
+          first_name: "Telegram Bot Name",
+          username: "openclaw_bot",
+        },
+        message_id: 702,
+        text: "Business reply",
+      },
+      messageId: 702,
+      text: "Business reply",
+    });
+
+    expect(cached).toMatchObject({
+      sender: "Configured Agent (you)",
+      senderId: "777",
+      senderUsername: "business_account",
+      sourceMessage: {
+        sender_business_bot: { id: 999, is_bot: true, username: "openclaw_bot" },
+      },
+    });
+  });
+
   it("uses the synthetic sender identity for a finalized streamed message without from", async () => {
     const initial = await recordAndRead({
       account: { accountId: "default", name: "StreamBot" },

--- a/extensions/telegram/src/outbound-message-context.test.ts
+++ b/extensions/telegram/src/outbound-message-context.test.ts
@@ -190,9 +190,9 @@ describe("recordOutboundMessageForPromptContext", () => {
     });
   });
 
-  it("retains synthetic self identity across channel post echoes without from", async () => {
+  it("ignores Telegram's fake sender identity across channel post echoes", async () => {
     const initial = await recordAndRead({
-      account: { accountId: "default", name: "ChannelBot" },
+      account: { accountId: "default" },
       chatId: -1001,
       message: {
         message_id: 1498,
@@ -202,7 +202,7 @@ describe("recordOutboundMessageForPromptContext", () => {
       messageId: 1498,
       text: "Channel announcement",
     });
-    expect(initial).toMatchObject({ sender: "ChannelBot (you)", senderId: "0" });
+    expect(initial).toMatchObject({ sender: "OpenClaw (you)", senderId: "0" });
 
     const cache = createPromptContextCache();
     await cache.record({
@@ -224,10 +224,10 @@ describe("recordOutboundMessageForPromptContext", () => {
       messageId: "1498",
     });
     expect(merged).toMatchObject({
-      sender: "ChannelBot (you)",
+      sender: "OpenClaw (you)",
       senderId: "0",
       sourceMessage: {
-        from: { id: 0, is_bot: true, first_name: "ChannelBot (you)" },
+        from: { id: 0, is_bot: true, first_name: "OpenClaw (you)" },
         sender_chat: { id: -1001, type: "channel", title: "Announcements" },
       },
     });

--- a/extensions/telegram/src/outbound-message-context.test.ts
+++ b/extensions/telegram/src/outbound-message-context.test.ts
@@ -1,0 +1,199 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  createPluginStateKeyedStoreForTests,
+  createPluginStateSyncKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createTelegramMessageCache,
+  resetTelegramMessageCacheBucketsForTest,
+  resolveTelegramMessageCacheScope,
+} from "./message-cache.js";
+import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
+import { clearTelegramRuntime, setTelegramRuntime } from "./runtime.js";
+import type { TelegramRuntime } from "./runtime.types.js";
+
+const cfg = {
+  session: { store: "/tmp/openclaw-telegram-outbound-context-test.json" },
+} satisfies OpenClawConfig;
+
+function installTelegramStateRuntimeForTest(): void {
+  setTelegramRuntime({
+    state: {
+      openKeyedStore: ((options) =>
+        createPluginStateKeyedStoreForTests(
+          "telegram",
+          options,
+        )) as TelegramRuntime["state"]["openKeyedStore"],
+      openSyncKeyedStore: ((options) =>
+        createPluginStateSyncKeyedStoreForTests(
+          "telegram",
+          options,
+        )) as TelegramRuntime["state"]["openSyncKeyedStore"],
+    },
+    channel: {},
+  } as TelegramRuntime);
+}
+
+async function recordAndRead(
+  params: Omit<Parameters<typeof recordOutboundMessageForPromptContext>[0], "cfg">,
+) {
+  await recordOutboundMessageForPromptContext({ cfg, ...params });
+  const cache = createPromptContextCache();
+  return await cache.get({
+    accountId: params.account.accountId,
+    chatId: params.chatId,
+    messageId: String(params.messageId),
+  });
+}
+
+function createPromptContextCache() {
+  return createTelegramMessageCache({
+    scope: resolveTelegramMessageCacheScope(resolveStorePath(cfg.session.store)),
+  });
+}
+
+describe("recordOutboundMessageForPromptContext", () => {
+  beforeEach(() => {
+    resetPluginStateStoreForTests();
+    resetTelegramMessageCacheBucketsForTest();
+    installTelegramStateRuntimeForTest();
+  });
+
+  afterEach(() => {
+    clearTelegramRuntime();
+    resetTelegramMessageCacheBucketsForTest();
+    resetPluginStateStoreForTests();
+  });
+
+  it("uses the configured self name and drops stale Telegram display-name fields", async () => {
+    const cached = await recordAndRead({
+      account: { accountId: "default", name: "  Configured Agent  " },
+      chatId: 42,
+      message: {
+        chat: { id: 42, type: "private" },
+        date: 1_736_380_700,
+        from: {
+          id: 999,
+          is_bot: true,
+          first_name: "Provisioning",
+          last_name: "Placeholder",
+          username: "openclaw_bot",
+        },
+        message_id: 700,
+        text: "Bot just replied",
+      },
+      messageId: 700,
+      text: "Bot just replied",
+    });
+
+    expect(cached).toMatchObject({
+      sender: "Configured Agent (you)",
+      senderId: "999",
+      senderUsername: "openclaw_bot",
+      sourceMessage: {
+        from: {
+          id: 999,
+          is_bot: true,
+          first_name: "Configured Agent (you)",
+          username: "openclaw_bot",
+        },
+      },
+    });
+    expect(cached?.sourceMessage.from).not.toHaveProperty("last_name");
+  });
+
+  it("falls back to the Telegram bot name when no configured name exists", async () => {
+    const cached = await recordAndRead({
+      account: { accountId: "default", name: "" },
+      chatId: 42,
+      message: {
+        chat: { id: 42, type: "private" },
+        date: 1_736_380_700,
+        from: {
+          id: 999,
+          is_bot: true,
+          first_name: "Atlas",
+          username: "atlas_bot",
+        },
+        message_id: 701,
+        text: "Bot just replied",
+      },
+      messageId: 701,
+      text: "Bot just replied",
+    });
+
+    expect(cached).toMatchObject({
+      sender: "Atlas (you)",
+      senderId: "999",
+      senderUsername: "atlas_bot",
+    });
+  });
+
+  it("uses the synthetic sender identity for a finalized streamed message without from", async () => {
+    const initial = await recordAndRead({
+      account: { accountId: "default", name: "StreamBot" },
+      chatId: 42,
+      message: { message_id: 1497 },
+      messageId: 1497,
+      text: "Final streamed reply",
+    });
+
+    expect(initial).toMatchObject({
+      sender: "StreamBot (you)",
+      senderId: "0",
+      sourceMessage: {
+        from: {
+          id: 0,
+          is_bot: true,
+          first_name: "StreamBot (you)",
+        },
+      },
+    });
+  });
+
+  it("retains synthetic self identity across channel post echoes without from", async () => {
+    const initial = await recordAndRead({
+      account: { accountId: "default", name: "ChannelBot" },
+      chatId: -1001,
+      message: {
+        message_id: 1498,
+        from: { id: 777_000, is_bot: false, first_name: "Telegram" },
+        sender_chat: { id: -1001, title: "Announcements" },
+      },
+      messageId: 1498,
+      text: "Channel announcement",
+    });
+    expect(initial).toMatchObject({ sender: "ChannelBot (you)", senderId: "0" });
+
+    const cache = createPromptContextCache();
+    await cache.record({
+      accountId: "default",
+      chatId: -1001,
+      msg: {
+        message_id: 1498,
+        date: 1_736_380_900,
+        chat: { id: -1001, type: "supergroup", title: "Announcements" },
+        from: { id: 777_000, is_bot: false, first_name: "Telegram" },
+        sender_chat: { id: -1001, type: "channel", title: "Announcements" },
+        text: "Channel announcement",
+      },
+    });
+
+    const merged = await cache.get({
+      accountId: "default",
+      chatId: -1001,
+      messageId: "1498",
+    });
+    expect(merged).toMatchObject({
+      sender: "ChannelBot (you)",
+      senderId: "0",
+      sourceMessage: {
+        from: { id: 0, is_bot: true, first_name: "ChannelBot (you)" },
+        sender_chat: { id: -1001, type: "channel", title: "Announcements" },
+      },
+    });
+  });
+});

--- a/extensions/telegram/src/outbound-message-context.ts
+++ b/extensions/telegram/src/outbound-message-context.ts
@@ -125,7 +125,7 @@ function buildOutboundCacheMessage(params: {
   const stableSender = params.message.sender_chat ? undefined : rawSender;
   const selfSenderName = buildTelegramSelfSenderName(
     params.account.name,
-    params.account.bot ?? rawSender,
+    params.account.bot ?? stableSender,
   );
   return {
     ...params.message,

--- a/extensions/telegram/src/outbound-message-context.ts
+++ b/extensions/telegram/src/outbound-message-context.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-payload";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import { buildTelegramSelfSenderName } from "./group-history-window.js";
 import { createTelegramMessageCache, resolveTelegramMessageCacheScope } from "./message-cache.js";
 
 type TelegramPromptContextChannelData = {
@@ -14,7 +15,14 @@ type TelegramOutboundPromptContextMessage = {
   message_id?: number;
   chat?: { id?: string | number; type?: string; title?: string; username?: string };
   date?: number;
-  from?: { id?: number; is_bot?: boolean; first_name?: string; username?: string };
+  from?: {
+    id?: number;
+    is_bot?: boolean;
+    first_name?: string;
+    last_name?: string;
+    username?: string;
+  };
+  sender_chat?: { id?: number; title?: string; username?: string };
   openclaw_prompt_context_timestamp_ms?: number;
   text?: string;
   caption?: string;
@@ -24,6 +32,7 @@ type TelegramOutboundPromptContextMessage = {
 type TelegramOutboundPromptContextAccount = {
   accountId: string;
   name?: string;
+  bot?: { first_name?: string; username?: string };
 };
 
 export function resolveTelegramPromptContextTimestampMs(
@@ -109,6 +118,12 @@ function buildOutboundCacheMessage(params: {
 }): TelegramOutboundPromptContextMessage {
   const chat = params.message.chat ?? {};
   const text = params.message.text ?? params.message.caption ?? params.text;
+  const rawSender = params.message.from;
+  const stableSender = params.message.sender_chat ? undefined : rawSender;
+  const selfSenderName = buildTelegramSelfSenderName(
+    params.account.name,
+    params.account.bot ?? rawSender,
+  );
   return {
     ...params.message,
     message_id: params.messageId,
@@ -125,10 +140,13 @@ function buildOutboundCacheMessage(params: {
       ...(chat.title ? { title: chat.title } : {}),
       ...(chat.username ? { username: chat.username } : {}),
     },
-    from: params.message.from ?? {
-      id: 0,
+    // Every message entering here came from this bot. Keep only Telegram's real
+    // id/username; sender_chat uses a synthetic compatibility user.
+    from: {
+      id: stableSender?.id ?? 0,
       is_bot: true,
-      first_name: params.account.name ?? "OpenClaw",
+      first_name: selfSenderName,
+      ...(stableSender?.username ? { username: stableSender.username } : {}),
     },
     ...(text ? { text } : {}),
     ...(params.messageThreadId !== undefined ? { message_thread_id: params.messageThreadId } : {}),

--- a/extensions/telegram/src/outbound-message-context.ts
+++ b/extensions/telegram/src/outbound-message-context.ts
@@ -11,18 +11,21 @@ type TelegramPromptContextChannelData = {
   promptContextTimestampMs?: unknown;
 };
 
+type TelegramOutboundPromptContextUser = {
+  id?: number;
+  is_bot?: boolean;
+  first_name?: string;
+  last_name?: string;
+  username?: string;
+};
+
 type TelegramOutboundPromptContextMessage = {
   message_id?: number;
   chat?: { id?: string | number; type?: string; title?: string; username?: string };
   date?: number;
-  from?: {
-    id?: number;
-    is_bot?: boolean;
-    first_name?: string;
-    last_name?: string;
-    username?: string;
-  };
+  from?: TelegramOutboundPromptContextUser;
   sender_chat?: { id?: number; title?: string; username?: string };
+  sender_business_bot?: TelegramOutboundPromptContextUser;
   openclaw_prompt_context_timestamp_ms?: number;
   text?: string;
   caption?: string;


### PR DESCRIPTION
Fixes #102267
Supersedes #102291

## What Problem This Solves

Telegram conversation-context windows could present the agent's own prior replies as another participant. The defect affected ordinary sends, streamed finals without Bot API sender metadata, reply-chain hydration, channel-post echoes, and Telegram Business replies.

## Why This Change Was Made

The maintainer rewrite keeps the invariant inside the Telegram plugin:

- outbound prompt-context records receive one canonical self sender name from configured account identity, authenticated Telegram bot metadata, or the OpenClaw fallback
- prompt projection trusts the reserved `(you)` suffix only when the cached sender matches the authenticated bot id, Telegram's `sender_business_bot`, or OpenClaw's canonical synthetic outbound sentinel
- Telegram's fake `sender_chat` compatibility user cannot become the agent identity
- reply-target hydration and channel-post cache merges preserve authenticated identity while retaining the original body and Telegram sender metadata
- untrusted users whose display name ends in `(you)` are explicitly disambiguated

## User Impact

The agent now sees its own cached Telegram replies as `Name (you)` across direct chats, groups, streamed replies, channel echoes, and Business connections. Other participants keep their Telegram identity, so recap and reply-chain grounding no longer treats the agent as a stranger or lets a display name spoof self attribution.

## Evidence

- Exact prepared head: `3e10d7cc1195f1f0f3b4fcbe8da0049b7e98bd75`
- Blacksmith Testbox through Crabbox: `tbx_01kx5m5sw31ymt958awemkfjbk`; whole-tree assertion passed, focused Telegram tests passed 291/291, extension package-boundary compile passed 120/120, and `check:changed` passed the extension and extension-test lanes
- Exact-head CI: [run 29082008959](https://github.com/openclaw/openclaw/actions/runs/29082008959), all selected build, lint, type, boundary, and test jobs passed
- Final full-branch autoreview: clean, no actionable findings, correctness 0.91
- The contributor's real Telegram trace established the original symptom and configured-name behavior. A fresh maintainer burner run was attempted but blocked before credential, box, or session acquisition because the QA credential store could not be unlocked; no artifact was published.

The maintainer commit preserves credit with `Co-authored-by: Gorkem Erdogan <gorkem.erdogan@outlook.com>`.
