### PR TITLE
fix(ui): active split pane indicator renders as offset, non-parallel accent lines

### DIFF
--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -38,12 +38,20 @@ openclaw-chat-pane {
   overflow: hidden;
 }
 
+/* Active-pane focus ring. The fixed toolbar and the weighted flex panes have
+   independent x-origins, so paired horizontal accent lines across the two
+   layers always render visibly offset; each layer marks focus on its own. */
 .chat-split-view__pane--active {
-  box-shadow: inset 0 2px 0 var(--accent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 60%, transparent);
 }
 
 .chat-split-view--narrow .chat-split-view__pane {
   min-height: 0;
+}
+
+/* Narrow mode shows only the active pane; a focus ring is pure noise there. */
+.chat-split-view--narrow .chat-split-view__pane--active {
+  box-shadow: none;
 }
 
 .chat-split-view__drop-indicator {
@@ -137,7 +145,7 @@ openclaw-chat-pane {
 }
 
 .chat-split-toolbar__pane--active {
-  box-shadow: inset 0 2px 0 var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
 }
 
 /* Pane controls replace the breadcrumb hierarchy in split mode, while the


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users focusing a pane in the web UI split view would see two accent "selection" lines that looked shifted against each other — one on the split toolbar and one on the pane below, starting at different x-offsets with different lengths, so the indicator read as a rendering glitch rather than a focus marker.

The mismatch is structural: the split toolbar is `position: fixed` with equal-width flex entries (one per pane, flattened across columns), while the panes below are laid out with per-column/pane weights and resizable dividers. Two paired horizontal accent lines drawn on those independent layers can never align, and dragging a divider makes the offset arbitrarily large.

## Why This Change Was Made

Instead of trying to align two lines that live on layers with independent geometry, each layer now marks focus with a self-contained shape: the active toolbar entry gets a subtle accent background tint (matching the app's existing active-tab idiom), and the active pane gets a 1px inset accent focus ring. Narrow mode shows only the active pane, so the ring is suppressed there. No markup, class-name, or behavior changes — CSS only.

## User Impact

The focused split pane is still clearly marked in both the toolbar and the content area, but the indicator now looks intentional at any pane size — no more skewed, non-parallel accent lines after opening or resizing splits.

## Evidence

Captured with the deterministic mock-gateway e2e harness (`ui/src/test-helpers/control-ui-e2e.ts`), left pane active.

Before (two offset accent lines; worse after dragging the divider):

![before default](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/split-pane-active-indicator/before-top.png)
![before resized](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/split-pane-active-indicator/before-resized-top.png)

After (toolbar tint + pane focus ring; stable under resize):

![after default](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/split-pane-active-indicator/after-top.png)
![after resized](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/split-pane-active-indicator/after-resized-top.png)

- `oxfmt --check` clean on the touched file.
- Codex autoreview (branch vs `origin/main`): clean, no actionable findings.
- Existing coverage unaffected: `ui/src/pages/chat/chat-page.test.ts` and `ui/src/e2e/chat-flow.e2e.test.ts` assert the `--active` class wiring, which is unchanged.
