### PR TITLE
fix(gateway): use truncateUtf16Safe for config path display truncation

### DIFF
--- a/src/gateway/server-methods/config.test.ts
+++ b/src/gateway/server-methods/config.test.ts
@@ -132,6 +132,19 @@ describe("config.openFile", () => {
     });
   });
 
+  it("does not split surrogate pairs when truncating the failed config path", async () => {
+    const pathPrefix = `/tmp/${"a".repeat(111)}`;
+    await withEnvAsync({ OPENCLAW_CONFIG_PATH: `${pathPrefix}😀tail.json` }, async () => {
+      mockExecFileError(new Error("open failed"));
+
+      const { logGateway } = await invokeConfigOpenFile();
+
+      expect(logGateway.warn).toHaveBeenCalledWith(
+        `config.openFile failed path=${pathPrefix}...: open failed`,
+      );
+    });
+  });
+
   it("returns actionable headless environment error when xdg-open reports no method available", async () => {
     await withEnvAsync({ OPENCLAW_CONFIG_PATH: "/tmp/config.json" }, async () => {
       mockExecFileError(new Error("xdg-open: no method available for opening '/tmp/config.json'"));

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -8,6 +8,7 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   ErrorCodes,
   errorShape,
@@ -356,7 +357,7 @@ function sanitizeLookupPathForLog(path: string): string {
     const code = char.charCodeAt(0);
     return code < 0x20 || code === 0x7f ? "?" : char;
   }).join("");
-  return sanitized.length > 120 ? `${sanitized.slice(0, 117)}...` : sanitized;
+  return sanitized.length > 120 ? `${truncateUtf16Safe(sanitized, 117)}...` : sanitized;
 }
 
 function escapePowerShellSingleQuotedString(value: string): string {


### PR DESCRIPTION
## What Problem This Solves

The config path sanitizer uses naive .slice(0, 117) which can split surrogate pairs when sanitized paths contain emoji or other multi-codepoint characters.

## Why This Change Was Made

Replace with truncateUtf16Safe(). Same pattern as #102464, #102467, #102500 (all merged).

## Files Changed

| File | Change |
|------|--------|
| src/gateway/server-methods/config.ts | +1 import; .slice(0,117) → truncateUtf16Safe() |

🤖 Generated with [Claude Code](https://claude.com/claude-code)