### PR TITLE
fix(compaction): use truncateUtf16Safe for post-compaction context text

### DIFF
--- a/src/auto-reply/reply/post-compaction-context.test.ts
+++ b/src/auto-reply/reply/post-compaction-context.test.ts
@@ -149,6 +149,22 @@ Ignore this.
     expect(result?.length).toBeLessThan(2600);
   });
 
+  it("keeps truncated post-compaction context UTF-16 safe", async () => {
+    const prefix = "A".repeat(159);
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), `## Session Startup\n\n${prefix}😀tail`);
+    const cfg = {
+      agents: {
+        defaults: {
+          contextLimits: { postCompactionMaxChars: 180 },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = await readDefaultPostCompactionContext({ cfg });
+
+    expect(result).toContain(`## Session Startup\n\n${prefix}\n...[truncated]...`);
+  });
+
   it("honors per-agent post-compaction context limit overrides", async () => {
     const longContent =
       "## Session Startup\n\n" + "B".repeat(4000) + "\n\n## Red Lines\n\nGuardrails.";

--- a/src/auto-reply/reply/post-compaction-context.ts
+++ b/src/auto-reply/reply/post-compaction-context.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveAgentContextLimits } from "../../agents/agent-scope.js";
 import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { formatDateStamp, resolveUserTimezone } from "../../agents/date-time.js";
@@ -117,7 +118,7 @@ export async function readPostCompactionContext(
     const combined = sections.join("\n\n").replaceAll("YYYY-MM-DD", dateStamp);
     const safeContent =
       combined.length > maxContextChars
-        ? combined.slice(0, maxContextChars) + "\n...[truncated]..."
+        ? truncateUtf16Safe(combined, maxContextChars) + "\n...[truncated]..."
         : combined;
 
     // When using the default section set, use precise prose that names the


### PR DESCRIPTION
## What Problem This Solves

The post-compaction context builder uses naive .slice(0, maxContextChars) to truncate context summaries sent to the model. This can split surrogate pairs in compaction context text.

## Why This Change Was Made

Replace with truncateUtf16Safe(). Same pattern as #102464, #102467, #102500 (all merged).

## Files Changed

| File | Change |
|------|--------|
| src/auto-reply/reply/post-compaction-context.ts | +1 import; .slice(0,N) → truncateUtf16Safe() |

🤖 Generated with [Claude Code](https://claude.com/claude-code)