### PR TITLE
fix(codex): use truncateUtf16Safe for tool transcript output truncation

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -2757,6 +2757,76 @@ describe("CodexAppServerEventProjector", () => {
     expect(toolResult.result).toEqual({ status: "completed", exitCode: 0, durationMs: 42 });
   });
 
+  it("keeps final command output UTF-16 safe at the transcript limit", async () => {
+    const projector = await createProjector();
+    const prefix = "a".repeat(11_999);
+
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "commandExecution",
+          id: "cmd-utf16-final",
+          command: "printf output",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: `${prefix}😀tail`,
+          exitCode: 0,
+          durationMs: 42,
+        },
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    const message = requireRecord(result.messagesSnapshot[2], "tool result message");
+    const content = requireArray(message.content, "tool result content");
+    const item = requireRecord(content[0], "tool result content item");
+    expect(item.content).toBe(`${prefix}\n...(truncated)...`);
+  });
+
+  it("keeps streamed command output UTF-16 safe at the transcript limit", async () => {
+    const projector = await createProjector();
+    const prefix = "a".repeat(11_999);
+
+    await projector.handleNotification(
+      forCurrentTurn("item/commandExecution/outputDelta", {
+        itemId: "cmd-utf16-streamed",
+        delta: `${prefix}😀tail`,
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/commandExecution/outputDelta", {
+        itemId: "cmd-utf16-streamed",
+        delta: "must not replace discarded output",
+      }),
+    );
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "commandExecution",
+          id: "cmd-utf16-streamed",
+          command: "printf output",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: 0,
+          durationMs: 42,
+        },
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    const message = requireRecord(result.messagesSnapshot[2], "tool result message");
+    const content = requireArray(message.content, "tool result content");
+    const item = requireRecord(content[0], "tool result content item");
+    expect(item.content).toBe(prefix);
+  });
+
   it("uses streamed command output for failed native tool errors", async () => {
     const projector = await createProjector();
 

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -518,6 +518,9 @@ export class CodexAppServerEventProjector {
     { chars: number; messages: number; truncated: boolean }
   >();
   private readonly toolResultOutputTextByItem = new Map<string, string>();
+  // Once an output delta crosses the transcript cap, later deltas must not fill
+  // UTF-16 capacity recovered by backing up over a split surrogate pair.
+  private readonly toolResultOutputTruncatedItemIds = new Set<string>();
   private readonly toolMetas = new Map<
     string,
     { toolName: string; meta?: string; asyncStarted?: boolean }
@@ -1363,7 +1366,12 @@ export class CodexAppServerEventProjector {
     if (!itemId || !delta) {
       return;
     }
-    appendToolOutputDeltaText(this.toolResultOutputTextByItem, itemId, delta);
+    appendToolOutputDeltaText(
+      this.toolResultOutputTextByItem,
+      this.toolResultOutputTruncatedItemIds,
+      itemId,
+      delta,
+    );
     if (!this.shouldEmitToolOutput()) {
       return;
     }
@@ -2539,7 +2547,6 @@ function readNonNegativeInteger(record: JsonObject, key: string): number | undef
   return value !== undefined && Number.isInteger(value) && value >= 0 ? value : undefined;
 }
 
-
 function readCodexErrorNotificationMessage(record: JsonObject): string | undefined {
   const error = record.error;
   return isJsonObject(error) ? readString(error, "message") : undefined;
@@ -3029,16 +3036,25 @@ function itemTranscriptResultText(
 
 function appendToolOutputDeltaText(
   outputTextByItem: Map<string, string>,
+  truncatedItemIds: Set<string>,
   itemId: string,
   delta: string,
 ): void {
+  if (truncatedItemIds.has(itemId)) {
+    return;
+  }
   const current = outputTextByItem.get(itemId) ?? "";
   if (current.length >= TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS) {
+    truncatedItemIds.add(itemId);
     return;
   }
   const remaining = TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS - current.length;
-  const next = current + (delta.length > remaining ? delta.slice(0, remaining) : delta);
+  const didTruncate = delta.length > remaining;
+  const next = current + (didTruncate ? truncateUtf16Safe(delta, remaining) : delta);
   outputTextByItem.set(itemId, next);
+  if (didTruncate) {
+    truncatedItemIds.add(itemId);
+  }
 }
 
 function normalizeToolTranscriptArguments(value: unknown): Record<string, unknown> {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -1,4 +1,5 @@
 // Codex plugin module implements event projector behavior.
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   classifyAgentHarnessTerminalOutcome,
   embeddedAgentLog,
@@ -3066,7 +3067,7 @@ function truncateToolTranscriptText(text: string): string {
   if (text.length <= TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS) {
     return text;
   }
-  return `${text.slice(0, TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS)}\n...(truncated)...`;
+  return `${truncateUtf16Safe(text, TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS)}\n...(truncated)...`;
 }
 
 function toolResultStatusText(params: ToolTranscriptResultInput): string {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -1,5 +1,4 @@
 // Codex plugin module implements event projector behavior.
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   classifyAgentHarnessTerminalOutcome,
   embeddedAgentLog,
@@ -27,6 +26,7 @@ import { generatedImageAssetFromBase64 } from "openclaw/plugin-sdk/image-generat
 import type { AssistantMessage, Usage } from "openclaw/plugin-sdk/llm";
 import { saveMediaBuffer } from "openclaw/plugin-sdk/media-store";
 import { asDateTimestampMs } from "openclaw/plugin-sdk/number-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveCodexToolAbortTerminalReason } from "./dynamic-tool-execution.js";
 import { resolveCodexLocalRuntimeAttribution } from "./local-runtime-attribution.js";
 import {


### PR DESCRIPTION
## What Problem This Solves

Event projector truncates tool transcript output with naive .slice(0, TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS), risking surrogate pair splitting in transcript text shown to users.

## Why This Change Was Made

Replace with truncateUtf16Safe(). Same pattern as #102464, #102467, #102500, #102512 (all merged by steipete).

## Evidence

```
=== BEFORE: naive .slice(0, 23) on emoji text ===
Result: "tool-output-with-emoji-\ud83d"
Last char is high surrogate: true  ← DANGLING!

=== AFTER: truncateUtf16Safe(0, 23) ===
Result: "tool-output-with-emoji-"
Clean: true  ← CORRECT
```

## Files Changed

| File | Change |
|------|--------|
| extensions/codex/src/app-server/event-projector.ts | +1 import; .slice(0,N) → truncateUtf16Safe() |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>