### PR TITLE
fix(discord): use truncateUtf16Safe for deploy error body truncation

### DIFF
--- a/extensions/discord/src/monitor/provider.deploy-errors.ts
+++ b/extensions/discord/src/monitor/provider.deploy-errors.ts
@@ -1,4 +1,5 @@
 // Discord provider module implements model/runtime integration.
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { inspect } from "node:util";
 import {
   parseStrictFiniteNumber,
@@ -346,7 +347,7 @@ export function formatDiscordDeployErrorDetails(err: unknown): string {
     }
     if (bodyText) {
       const maxLen = 800;
-      const trimmed = bodyText.length > maxLen ? `${bodyText.slice(0, maxLen)}...` : bodyText;
+      const trimmed = bodyText.length > maxLen ? `${truncateUtf16Safe(bodyText, maxLen)}...` : bodyText;
       details.push(`body=${trimmed}`);
     }
   }

--- a/extensions/discord/src/monitor/provider.deploy-errors.ts
+++ b/extensions/discord/src/monitor/provider.deploy-errors.ts
@@ -1,5 +1,4 @@
 // Discord provider module implements model/runtime integration.
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { inspect } from "node:util";
 import {
   parseStrictFiniteNumber,
@@ -7,6 +6,7 @@ import {
 } from "openclaw/plugin-sdk/number-runtime";
 import { formatDurationSeconds } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { RateLimitError } from "../internal/discord.js";
 
 const DISCORD_DEPLOY_REJECTED_ENTRY_LIMIT = 3;
@@ -347,7 +347,8 @@ export function formatDiscordDeployErrorDetails(err: unknown): string {
     }
     if (bodyText) {
       const maxLen = 800;
-      const trimmed = bodyText.length > maxLen ? `${truncateUtf16Safe(bodyText, maxLen)}...` : bodyText;
+      const trimmed =
+        bodyText.length > maxLen ? `${truncateUtf16Safe(bodyText, maxLen)}...` : bodyText;
       details.push(`body=${trimmed}`);
     }
   }

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -1040,6 +1040,15 @@ describe("monitorDiscordProvider", () => {
     expect(details).toBe(" (retryAfter=3.2s, scope=route)");
   });
 
+  it("keeps truncated Discord deploy response bodies UTF-16 safe", () => {
+    const prefix = "a".repeat(798);
+    const details = providerTesting.formatDiscordDeployErrorDetails({
+      rawBody: `${prefix}😀tail`,
+    });
+
+    expect(details).toBe(` (body="${prefix}...)`);
+  });
+
   it("formats rejected Discord deploy entries with command details", () => {
     const details = providerTesting.formatDiscordDeployErrorDetails({
       status: 400,


### PR DESCRIPTION
## What Problem This Solves

Discord deploy error logging truncates body text with naive .slice(0, maxLen), risking surrogate pair splitting in error messages.

## Files Changed

| File | Change |
|------|--------|
| extensions/discord/src/monitor/provider.deploy-errors.ts | +1 import; .slice(0,N) → truncateUtf16Safe() |

🤖 Generated with [Claude Code](https://claude.com/claude-code)