### PR TITLE
fix(macos): remove stale .sidebar-shell__header rule from injected dashboard CSS

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -209,10 +209,6 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
           html.openclaw-native-macos .sidebar-shell {
             padding-top: max(14px, var(--openclaw-native-titlebar-height)) !important;
           }
-          html.openclaw-native-macos .sidebar-shell__header {
-            padding-left: 10px !important;
-            padding-right: 8px !important;
-          }
         }
         """
         let script = """


### PR DESCRIPTION
## What Problem This Solves

The macOS dashboard window injects native-chrome CSS into the web UI (`installNativeChromeScript`). One of the injected rules targets `.sidebar-shell__header`, but that class no longer exists anywhere in `ui/src` — the sidebar template renders only `sidebar-shell`, `sidebar-shell__body`, and `sidebar-shell__footer` (`ui/src/components/app-sidebar.ts:1660`). The rule is dead weight shipped into every dashboard page load.

## Why This Change Was Made

Stale injected CSS makes the native-chrome contract look larger than it is and misleads future readers into thinking the web UI still has a sidebar header element the Mac app styles. Pure dead-code deletion.

## User Impact

None visible. The load-bearing `.sidebar-shell` padding-top rule (clears the macOS traffic-light strip) is untouched.

## Evidence

- `grep -rn "sidebar-shell__header" ui/src` → no matches; only occurrence in the repo was the injected CSS string in `apps/macos/Sources/OpenClaw/DashboardWindowController.swift`.
- `ui/src/components/app-sidebar.ts:1660` renders `sidebar-shell` / `__body` / `__footer` only.
- Diff is a 4-line deletion inside a CSS string literal; `git diff --check` clean.
