### PR TITLE
fix(skills): honor workshop auto approval for agent calls

### DIFF
--- a/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
+++ b/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
@@ -4,6 +4,7 @@
  * plugin hook decisions.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../config/config.js";
 import { setEmbeddedMode } from "../infra/embedded-mode.js";
 import {
   EmbeddedPluginApprovalBroker,
@@ -96,6 +97,7 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
     setEmbeddedPluginApprovalBroker(null);
     setEmbeddedMode(false);
     setActivePluginRegistry(createEmptyPluginRegistry());
+    clearRuntimeConfigSnapshot();
     resetGlobalHookRunner();
   });
 
@@ -665,6 +667,33 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
     expect(result).toEqual({
       blocked: false,
       params: { action: "reject", proposal_id: "weather-20260530-a1b2c3d4e5" },
+    });
+    expect(mockCallGatewayTool).not.toHaveBeenCalled();
+    expect(runBeforeToolCallMock).not.toHaveBeenCalled();
+  });
+
+  it("uses runtime skill_workshop approval policy when hook context has no config", async () => {
+    (hookRunner.hasHooks as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    setRuntimeConfigSnapshot({
+      skills: {
+        workshop: {
+          approvalPolicy: "auto",
+        },
+      },
+    });
+
+    const result = await runBeforeToolCallHook({
+      toolName: "skill_workshop",
+      params: { action: "apply", proposal_id: "weather-20260530-a1b2c3d4e5" },
+      ctx: {
+        agentId: "main",
+        sessionKey: "main",
+      },
+    });
+
+    expect(result).toEqual({
+      blocked: false,
+      params: { action: "apply", proposal_id: "weather-20260530-a1b2c3d4e5" },
     });
     expect(mockCallGatewayTool).not.toHaveBeenCalled();
     expect(runBeforeToolCallMock).not.toHaveBeenCalled();

--- a/src/skills/workshop/policy.test.ts
+++ b/src/skills/workshop/policy.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -20,6 +21,7 @@ beforeEach(async () => {
 afterEach(async () => {
   await testState.cleanup();
   await tempDirs.cleanup();
+  clearRuntimeConfigSnapshot();
 });
 
 describe("resolveSkillWorkshopToolApproval", () => {
@@ -145,5 +147,36 @@ describe("resolveSkillWorkshopToolApproval", () => {
     expect(withoutWorkspace?.requireApproval?.description).toBe(
       "Apply a pending workspace skill proposal into live workspace skills.",
     );
+  });
+
+  it("falls back to runtime config when explicit hook config is unavailable", async () => {
+    setRuntimeConfigSnapshot({
+      skills: {
+        workshop: {
+          approvalPolicy: "auto",
+        },
+      },
+    });
+
+    const autoResult = await resolveSkillWorkshopToolApproval({
+      toolName: "skill_workshop",
+      toolParams: { action: "apply", proposal_id: "weather-20260530-a1b2c3d4e5" },
+    });
+
+    expect(autoResult).toBeUndefined();
+
+    const explicitPendingResult = await resolveSkillWorkshopToolApproval({
+      toolName: "skill_workshop",
+      toolParams: { action: "apply", proposal_id: "weather-20260530-a1b2c3d4e5" },
+      config: {
+        skills: {
+          workshop: {
+            approvalPolicy: "pending",
+          },
+        },
+      },
+    });
+
+    expect(explicitPendingResult?.requireApproval?.title).toBe("Apply workspace skill proposal");
   });
 });

--- a/src/skills/workshop/policy.ts
+++ b/src/skills/workshop/policy.ts
@@ -1,5 +1,6 @@
 // Workshop policy helpers validate generated skill drafts against workspace policy.
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
+import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH } from "../../infra/plugin-approvals.js";
 import type { PluginHookBeforeToolCallResult } from "../../plugins/hook-before-tool-call-result.js";
@@ -154,7 +155,11 @@ export async function resolveSkillWorkshopToolApproval(params: {
   if (!action) {
     return undefined;
   }
-  const config = resolveSkillWorkshopConfig(params.config);
+  let rawConfig = params.config;
+  try {
+    rawConfig ??= getRuntimeConfig();
+  } catch {}
+  const config = resolveSkillWorkshopConfig(rawConfig);
   if (config.approvalPolicy === "auto") {
     return undefined;
   }


### PR DESCRIPTION
Closes #102508

## What Problem This Solves

Fixes an issue where users who set `skills.workshop.approvalPolicy: "auto"` could still hit a Skill Workshop approval wait and timeout when an agent calls `skill_workshop` lifecycle actions from a context whose hook config is not populated.

## Why This Change Was Made

`resolveSkillWorkshopToolApproval` now falls back to the current runtime config only when explicit hook config is unavailable. Explicit hook config still wins, so scoped/session policy remains authoritative when it is present.

Regression coverage now exercises both the resolver directly and the before-tool-call path where `ctx` exists but `ctx.config` does not.

## User Impact

Trusted environments configured with Skill Workshop auto approval can apply, reject, or quarantine proposals through agent tool calls without waiting for a phantom plugin approval. The default `pending` behavior remains unchanged for users who have not opted into auto approval.

## Evidence

- `./node_modules/.bin/oxfmt --check --threads=1 src/skills/workshop/policy.ts src/skills/workshop/policy.test.ts src/agents/agent-tools.before-tool-call.embedded-mode.test.ts`
- `node scripts/run-vitest.mjs src/skills/workshop/policy.test.ts`
- `node scripts/run-vitest.mjs src/agents/agent-tools.before-tool-call.embedded-mode.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main` (clean: no accepted/actionable findings)

