### PR TITLE
fix(skills): skill workshop apply hangs despite auto approval

### DIFF
--- a/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
+++ b/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
@@ -4,6 +4,7 @@
  * plugin hook decisions.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../config/config.js";
 import { setEmbeddedMode } from "../infra/embedded-mode.js";
 import {
   EmbeddedPluginApprovalBroker,
@@ -93,6 +94,7 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
   });
 
   afterEach(() => {
+    clearRuntimeConfigSnapshot();
     setEmbeddedPluginApprovalBroker(null);
     setEmbeddedMode(false);
     setActivePluginRegistry(createEmptyPluginRegistry());
@@ -665,6 +667,30 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
     expect(result).toEqual({
       blocked: false,
       params: { action: "reject", proposal_id: "weather-20260530-a1b2c3d4e5" },
+    });
+    expect(mockCallGatewayTool).not.toHaveBeenCalled();
+    expect(runBeforeToolCallMock).not.toHaveBeenCalled();
+  });
+
+  it("uses runtime config for skill_workshop auto mode when hook context config is absent", async () => {
+    (hookRunner.hasHooks as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    setRuntimeConfigSnapshot({
+      skills: {
+        workshop: {
+          approvalPolicy: "auto",
+        },
+      },
+    });
+
+    const result = await runBeforeToolCallHook({
+      toolName: "skill_workshop",
+      params: { action: "apply", proposal_id: "weather-20260530-a1b2c3d4e5" },
+      ctx: { agentId: "main", sessionKey: "main" },
+    });
+
+    expect(result).toEqual({
+      blocked: false,
+      params: { action: "apply", proposal_id: "weather-20260530-a1b2c3d4e5" },
     });
     expect(mockCallGatewayTool).not.toHaveBeenCalled();
     expect(runBeforeToolCallMock).not.toHaveBeenCalled();

--- a/src/skills/workshop/policy.test.ts
+++ b/src/skills/workshop/policy.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
 import { PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH } from "../../infra/plugin-approvals.js";
 import {
   createOpenClawTestState,
@@ -19,6 +20,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  clearRuntimeConfigSnapshot();
   await testState.cleanup();
   await tempDirs.cleanup();
 });
@@ -168,5 +170,46 @@ describe("resolveSkillWorkshopToolApproval", () => {
     expect(withoutWorkspace?.requireApproval?.description).toBe(
       "Apply a pending workspace skill proposal into live workspace skills.",
     );
+  });
+
+  it("uses runtime config when lifecycle hook config is absent", async () => {
+    setRuntimeConfigSnapshot({
+      skills: {
+        workshop: {
+          approvalPolicy: "auto",
+        },
+      },
+    });
+
+    await expect(
+      resolveSkillWorkshopToolApproval({
+        toolName: "skill_workshop",
+        toolParams: { action: "apply", proposal_id: "weather-20260530-a1b2c3d4e5" },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("keeps explicit lifecycle hook config ahead of runtime config", async () => {
+    setRuntimeConfigSnapshot({
+      skills: {
+        workshop: {
+          approvalPolicy: "auto",
+        },
+      },
+    });
+
+    const result = await resolveSkillWorkshopToolApproval({
+      toolName: "skill_workshop",
+      toolParams: { action: "reject", proposal_id: "weather-20260530-a1b2c3d4e5" },
+      config: {
+        skills: {
+          workshop: {
+            approvalPolicy: "pending",
+          },
+        },
+      },
+    });
+
+    expect(result?.requireApproval?.title).toBe("Reject workspace skill proposal");
   });
 });

--- a/src/skills/workshop/policy.test.ts
+++ b/src/skills/workshop/policy.test.ts
@@ -1,5 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearRuntimeConfigSnapshot,
+  getRuntimeConfig,
+  setRuntimeConfigSnapshot,
+} from "../../config/config.js";
 import { PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH } from "../../infra/plugin-approvals.js";
 import {
   createOpenClawTestState,
@@ -104,9 +108,7 @@ describe("resolveSkillWorkshopToolApproval", () => {
     });
     const approvalDescription = result?.requireApproval?.description ?? "";
 
-    expect(approvalDescription.length).toBeLessThanOrEqual(
-      PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH,
-    );
+    expect(approvalDescription.length).toBeLessThanOrEqual(PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH);
     expect(approvalDescription).toContain(`Proposal ID: ${proposal.record.id}`);
     expect(approvalDescription).toContain(`Description: ${description}`);
     expect(approvalDescription).toContain("Support files: 0");
@@ -187,6 +189,31 @@ describe("resolveSkillWorkshopToolApproval", () => {
         toolParams: { action: "apply", proposal_id: "weather-20260530-a1b2c3d4e5" },
       }),
     ).resolves.toBeUndefined();
+  });
+
+  it("keeps approval pending when runtime config loading throws", async () => {
+    const sharedAgentDir = testState.agentDir("shared");
+    await testState.writeConfig({
+      agents: {
+        list: [
+          { id: "alpha", agentDir: sharedAgentDir },
+          { id: "beta", agentDir: sharedAgentDir },
+        ],
+      },
+    });
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      expect(() => getRuntimeConfig()).toThrow(/duplicate agentDir/i);
+      const result = await resolveSkillWorkshopToolApproval({
+        toolName: "skill_workshop",
+        toolParams: { action: "quarantine", proposal_id: "weather-20260530-a1b2c3d4e5" },
+      });
+
+      expect(result?.requireApproval?.title).toBe("Quarantine workspace skill proposal");
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it("keeps explicit lifecycle hook config ahead of runtime config", async () => {

--- a/src/skills/workshop/policy.ts
+++ b/src/skills/workshop/policy.ts
@@ -1,6 +1,7 @@
 // Workshop policy helpers validate generated skill drafts against workspace policy.
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH } from "../../infra/plugin-approvals.js";
 import type { PluginHookBeforeToolCallResult } from "../../plugins/hook-before-tool-call-result.js";
@@ -141,6 +142,19 @@ function lifecycleApprovalTimeoutReason(proposalId?: string): string {
   ].join(" ");
 }
 
+function resolveApprovalConfig(config?: OpenClawConfig): OpenClawConfig | undefined {
+  if (config) {
+    return config;
+  }
+  // Explicit hook config wins. Missing hook config may happen on agent paths;
+  // unreadable runtime config keeps the default pending approval gate.
+  try {
+    return getRuntimeConfig();
+  } catch {
+    return undefined;
+  }
+}
+
 /** Returns approval policy for skill workshop lifecycle tool calls. */
 export async function resolveSkillWorkshopToolApproval(params: {
   toolName: string;
@@ -155,7 +169,7 @@ export async function resolveSkillWorkshopToolApproval(params: {
   if (!action) {
     return undefined;
   }
-  const config = resolveSkillWorkshopConfig(params.config);
+  const config = resolveSkillWorkshopConfig(resolveApprovalConfig(params.config));
   if (config.approvalPolicy === "auto") {
     return undefined;
   }


### PR DESCRIPTION
Closes #102508

## What Problem This Solves

Fixes an issue where users who set Skill Workshop approval to auto could still see agent-initiated `skill_workshop apply`, `reject`, or `quarantine` calls wait for approval and time out when the before-tool-call context did not include a config object.

AI-assisted.

## Why This Change Was Made

The Skill Workshop lifecycle approval resolver now keeps explicit hook config authoritative and falls back to the current runtime config only when hook config is absent. If runtime config cannot be read, it preserves the default pending policy so an error cannot bypass the approval boundary.

## User Impact

Users in trusted environments can apply, reject, or quarantine Skill Workshop proposals through agent chat without an unnecessary approval timeout when `skills.workshop.approvalPolicy` is set to `auto`. Explicit pending policy remains authoritative, and unreadable runtime config still requires approval.

## Evidence

Before the fix, `resolveSkillWorkshopToolApproval` passed an absent hook config directly to `resolveSkillWorkshopConfig`, which selected the default pending policy instead of the configured runtime auto policy.

Focused regression proof at exact head `c1f638afc4a92fe9a913acc41ecf71e7516fc074` covers:

- missing hook config with runtime auto policy;
- explicit pending hook config taking precedence over runtime auto policy;
- runtime-config read failure preserving pending approval;
- the embedded before-tool-call path proceeding without a broker request in auto mode.

Focused validation completed before the clean replay:

```shell
node scripts/run-vitest.mjs src/skills/workshop/policy.test.ts
# 1 file passed, 6 tests passed

node scripts/run-vitest.mjs src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
# 1 file passed, 17 tests passed

git diff --check
# passed
```

Fresh branch-wide GPT-5.5 xhigh autoreview: no accepted or actionable findings.

Exact-head hosted CI: [run 29104444826, attempt 2](https://github.com/openclaw/openclaw/actions/runs/29104444826) is fully green. Attempt 1 hit an unrelated gateway-watch flake in `build-artifacts`; the unchanged exact head passed on rerun. [Real behavior proof](https://github.com/openclaw/openclaw/actions/runs/29104442797) is green.

Known proof gap: no safe live TUI or webchat proposal-to-broker flow was available.
