### PR TITLE
refactor(ui): drop the divider line above the sidebar More section

### DIFF
--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1006,11 +1006,10 @@
   transform: rotate(-90deg);
 }
 
-/* "More" holds every nav route the user has not pinned. */
+/* "More" holds every nav route the user has not pinned; the uppercase label
+   is the section separator, so no divider line above it. */
 .nav-section--more {
-  margin-top: 4px;
-  padding-top: 8px;
-  border-top: 1px solid color-mix(in srgb, var(--border) 64%, transparent);
+  margin-top: 12px;
 }
 
 /* Button variant of .nav-item (e.g. "Customize sidebar"). */


### PR DESCRIPTION
## What Problem This Solves

The web sidebar draws a horizontal divider line directly under the pinned nav (with the default pins, directly under "Overview"). The uppercase "MORE" section label right below it already communicates the section break, so the line is redundant visual noise — especially prominent in dark mode, where it reads as a stray rule under the first nav item.

## Why This Change Was Made

Removes the decorative `border-top` from `.nav-section--more` and folds the old `margin-top` + `padding-top` + border into a single `margin-top: 12px`, keeping the gap between the pinned nav and the More section visually unchanged. The line shipped with the original More-section redesign (#100296) as pure decoration; no behavior or layout depends on it. The sidebar footer divider and topbar hairline are untouched.

## User Impact

The sidebar looks cleaner: pinned nav and the More section are separated by whitespace and the "MORE" label alone, with no divider line under the last pinned item. No functional change.

## Evidence

Deterministic mock-gateway Playwright captures (`OPENCLAW_CAPTURE_UI_PROOF=1`, `ui/src/e2e/sidebar-customization.e2e.test.ts`, default pins):

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-more-divider-2026-07/before-sidebar.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-more-divider-2026-07/after-sidebar.png) |

- `ui/src/e2e/sidebar-customization.e2e.test.ts` passes on the changed CSS (2 tests, pin/unpin + persistence + More section flows).
- Only one rule owned the divider; the e2e selectors on `.nav-section--more` target nav items, not the border.
