### PR TITLE
fix(nodes): restore Mac app allowlist execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **macOS node exec approvals:** forward validated shell payloads to companion nodes while retaining canonical Gateway approval binding, restoring allowlisted `exec host=node` commands. (#102528)
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **macOS node exec approvals:** forward validated shell payloads to companion nodes while retaining canonical Gateway approval binding, restoring allowlisted `exec host=node` commands. (#102528)
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -59,6 +59,7 @@ type PreparedNodeRun = {
   plan: SystemRunApprovalPlan;
   argv: string[];
   rawCommand: string;
+  transportRawCommand: string;
   cwd: string | undefined;
   agentId: string | undefined;
   sessionKey: string | undefined;
@@ -451,6 +452,7 @@ export async function prepareNodeSystemRun(params: {
     plan: prepared.plan,
     argv: prepared.plan.argv,
     rawCommand: prepared.plan.commandText,
+    transportRawCommand: prepared.plan.commandText,
     cwd: prepared.plan.cwd ?? params.request.workdir,
     agentId: prepared.plan.agentId ?? params.request.agentId,
     sessionKey: prepared.plan.sessionKey ?? params.request.sessionKey,
@@ -489,6 +491,9 @@ function buildLocalPreparedNodeRun(params: {
     plan,
     argv: plan.argv,
     rawCommand: plan.commandText,
+    // Legacy macOS nodes parse the bound shell payload for allowlist matching.
+    // Analysis and approval binding remain anchored to the canonical plan text.
+    transportRawCommand: plan.commandPreview ?? plan.commandText,
     cwd: plan.cwd ?? params.request.workdir,
     agentId: plan.agentId ?? params.request.agentId,
     sessionKey: plan.sessionKey ?? params.request.sessionKey,

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -2147,7 +2147,7 @@ describe("executeNodeHostCommand", () => {
       const call = requireGatewayCommand("system.run");
       expect(call.callOptions).toEqual({ scopes: ["operator.write", "operator.approvals"] });
       const runParams = requireRunParams(call);
-      expect(runParams.rawCommand).toBe(expectedPlan.commandText);
+      expect(runParams.rawCommand).toBe(expectedPlan.commandPreview);
       expect(runParams.systemRunPlan).toEqual(expectedPlan);
     });
   });

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -398,7 +398,7 @@ export async function executeNodeHostCommand(
               buildNodeSystemRunInvoke({
                 target,
                 command: prepared.argv,
-                rawCommand: prepared.rawCommand,
+                rawCommand: prepared.transportRawCommand,
                 cwd: prepared.cwd,
                 agentId: prepared.agentId,
                 sessionKey: prepared.sessionKey,
@@ -467,7 +467,7 @@ export async function executeNodeHostCommand(
   const invoke = buildNodeSystemRunInvoke({
     target,
     command: prepared.argv,
-    rawCommand: prepared.rawCommand,
+    rawCommand: prepared.transportRawCommand,
     cwd: prepared.cwd,
     agentId: prepared.agentId,
     sessionKey: prepared.sessionKey,

--- a/src/gateway/node-invoke-system-run-approval.test.ts
+++ b/src/gateway/node-invoke-system-run-approval.test.ts
@@ -389,6 +389,60 @@ describe("sanitizeSystemRunParamsForForwarding", () => {
     expect(forwarded.sessionKey).toBe("agent:main:main");
   });
 
+  test("forwards a validated shell preview for legacy node allowlist matching", () => {
+    const argv = ["/bin/sh", "-lc", "/bin/hostname"];
+    const record = makeRecord('/bin/sh -lc "/bin/hostname"', argv);
+    record.request.systemRunPlan = {
+      argv,
+      cwd: null,
+      commandText: '/bin/sh -lc "/bin/hostname"',
+      commandPreview: "/bin/hostname",
+      agentId: "main",
+      sessionKey: "agent:main:main",
+    };
+    record.request.systemRunBinding = systemRunApprovalBinding(argv, {
+      agentId: "main",
+      sessionKey: "agent:main:main",
+    });
+
+    const result = sanitizeApprovedRun({
+      rawParams: {
+        command: argv,
+        rawCommand: "/bin/hostname",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+      },
+      record,
+    });
+
+    const forwarded = expectAllowOnceForwardingResult(result);
+    expect(forwarded.command).toEqual(argv);
+    expect(forwarded.rawCommand).toBe("/bin/hostname");
+  });
+
+  test("keeps canonical wrapper text when the plan preview does not match argv", () => {
+    const argv = ["/bin/sh", "-lc", "/bin/hostname"];
+    const commandText = '/bin/sh -lc "/bin/hostname"';
+    const record = makeRecord(commandText, argv);
+    record.request.systemRunPlan = {
+      argv,
+      cwd: null,
+      commandText,
+      commandPreview: "/usr/bin/whoami",
+      agentId: null,
+      sessionKey: null,
+    };
+    record.request.systemRunBinding = systemRunApprovalBinding(argv);
+
+    const result = sanitizeApprovedRun({
+      rawParams: { command: argv, rawCommand: commandText },
+      record,
+    });
+
+    const forwarded = expectAllowOnceForwardingResult(result);
+    expect(forwarded.rawCommand).toBe(commandText);
+  });
+
   test("rejects env overrides when approval record lacks env binding", () => {
     const result = sanitizeApprovedRun({
       rawParams: {

--- a/src/gateway/node-invoke-system-run-approval.ts
+++ b/src/gateway/node-invoke-system-run-approval.ts
@@ -6,6 +6,7 @@ import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
 } from "../../packages/gateway-protocol/src/client-info.js";
+import type { SystemRunApprovalPlan } from "../infra/exec-approvals.js";
 import { resolveSystemRunApprovalRuntimeContext } from "../infra/system-run-approval-context.js";
 import { resolveSystemRunCommandRequest } from "../infra/system-run-command.js";
 import type { ExecApprovalRecord } from "./exec-approval-manager.js";
@@ -216,6 +217,20 @@ function pickSystemRunParams(raw: Record<string, unknown>): Record<string, unkno
   return next;
 }
 
+function resolveForwardedRawCommand(plan: SystemRunApprovalPlan): string {
+  const preview = normalizeNullableString(plan.commandPreview);
+  if (!preview) {
+    return plan.commandText;
+  }
+  // Legacy nodes need the shell payload for local allowlist parsing. Forward it
+  // only when it is an exact preview of the already-bound canonical argv.
+  const resolved = resolveSystemRunCommandRequest({
+    command: plan.argv,
+    rawCommand: preview,
+  });
+  return resolved.ok && resolved.previewText === preview ? preview : plan.commandText;
+}
+
 /**
  * Gate `system.run` approval flags (`approved`, `approvalDecision`) behind a real
  * `exec.approval.*` record. This prevents users with only `operator.write` from
@@ -360,11 +375,7 @@ export function sanitizeSystemRunParamsForForwarding(opts: {
   if (runtimeContext.plan) {
     next.command = [...runtimeContext.plan.argv];
     next.systemRunPlan = runtimeContext.plan;
-    if (runtimeContext.commandText) {
-      next.rawCommand = runtimeContext.commandText;
-    } else {
-      delete next.rawCommand;
-    }
+    next.rawCommand = resolveForwardedRawCommand(runtimeContext.plan);
     if (runtimeContext.cwd) {
       next.cwd = runtimeContext.cwd;
     } else {


### PR DESCRIPTION
Closes #102528

## What Problem This Solves

Fixes an issue where users running commands on macOS companion nodes in allowlist mode would receive `SYSTEM_RUN_DENIED: allowlist miss` even when every executable was explicitly approved.

## Why This Change Was Made

The Gateway now keeps canonical command text for security analysis and approval binding while carrying a separately validated shell payload for legacy node transport. Approved replays forward that payload only when it matches the canonical plan argv; mismatched previews fall back to canonical wrapper text.

## User Impact

Gateway agents can execute explicitly allowlisted commands on Mac app nodes, including chained commands whose executables are all approved, without weakening approval-plan, audit-suppression, or replay binding.

## Evidence

- Live before: four connected macOS companion nodes all rejected `/bin/hostname && /usr/bin/sw_vers -productVersion` with `SYSTEM_RUN_DENIED: allowlist miss`.
- Live after on exact commit `67dc7e689255432a9ccccb4338bca5535c4932fe`: embedded Gateway agent saw four nodes and completed 5 tool calls with 0 failures. Returned hostnames: `clawmac.local`, `megaclaw`, `steipete-macstudio.local`, and `steipete-mbp-4.local`; reported macOS versions 26.5.2, 27.0, 26.5.2, and 26.5.2.
- Gateway health after source build/restart: `ok: true`; running from the exact commit above.
- Testbox: `corepack pnpm test src/agents/bash-tools.exec-host-node.test.ts src/gateway/node-invoke-system-run-approval.test.ts` — 165 assertions passed across agent and Gateway projects. Run: https://github.com/openclaw/openclaw/actions/runs/29002804800
- `oxfmt --check` on all five touched TypeScript files.
- Fresh structured Codex autoreview: no accepted/actionable findings; overall correctness 0.97.
