### PR TITLE
fix: normalize unsupported Anthropic inline images

### DIFF
--- a/packages/ai/src/host.ts
+++ b/packages/ai/src/host.ts
@@ -106,6 +106,13 @@ export interface OpenAIStrictToolSettingOptions {
   supportsStrictMode?: boolean;
 }
 
+export type AiInlineTextBlock = { type: "text"; text: string };
+export type AiInlineImageBlock = { type: "image"; data: string; mimeType: string };
+export type AiInlineContentBlock = AiInlineTextBlock | AiInlineImageBlock;
+type AnthropicInlineContentNormalizer = (
+  content: readonly AiInlineContentBlock[],
+) => Promise<AiInlineContentBlock[]>;
+
 /** Narrow host ports consumed by the built-in provider adapters. */
 export interface AiTransportHost {
   /**
@@ -123,6 +130,8 @@ export interface AiTransportHost {
   redactSecrets<T>(value: T): T;
   /** Redacts secret-bearing text in tool payload strings. */
   redactToolPayloadText(text: string): string;
+  /** Normalizes Anthropic inline image blocks before provider payload construction. */
+  normalizeAnthropicInlineContentBlocks?: AnthropicInlineContentNormalizer;
   /**
    * Resolves the host strict-tool default for OpenAI-compatible routes.
    * undefined lets the request omit the strict flag entirely.
@@ -201,11 +210,16 @@ function queueCustomApiRegistration(registry: ApiRegistry, api: Api, streamFn: S
   return false;
 }
 
-const inertAiTransportHost: AiTransportHost = {
+type ActiveAiTransportHost = Omit<AiTransportHost, "normalizeAnthropicInlineContentBlocks"> & {
+  normalizeAnthropicInlineContentBlocks: AnthropicInlineContentNormalizer;
+};
+
+const inertAiTransportHost: ActiveAiTransportHost = {
   buildModelFetch: () => undefined,
   resolveSecretSentinel: (value) => value,
   redactSecrets: (value) => value,
   redactToolPayloadText: (text) => text,
+  normalizeAnthropicInlineContentBlocks: async (content) => [...content],
   resolveOpenAIStrictToolSetting: (_model, options) =>
     options?.supportsStrictMode ? false : undefined,
   plugin: {
@@ -241,13 +255,16 @@ const inertAiTransportHost: AiTransportHost = {
   logWarn: () => {},
 };
 
-let activeAiTransportHost = inertAiTransportHost;
+let activeAiTransportHost: ActiveAiTransportHost = inertAiTransportHost;
 
 /** Installs host implementations for the transport policy ports. */
 export function configureAiTransportHost(host: Partial<AiTransportHost>): void {
   activeAiTransportHost = {
     ...inertAiTransportHost,
     ...host,
+    normalizeAnthropicInlineContentBlocks:
+      host.normalizeAnthropicInlineContentBlocks ??
+      inertAiTransportHost.normalizeAnthropicInlineContentBlocks,
     plugin: { ...inertAiTransportHost.plugin, ...host.plugin },
   };
   const transportHost = activeAiTransportHost;
@@ -276,7 +293,7 @@ export function configureAiTransportHost(host: Partial<AiTransportHost>): void {
 }
 
 /** Returns the active transport host (inert defaults unless configured). */
-export function getAiTransportHost(): AiTransportHost {
+export function getAiTransportHost(): ActiveAiTransportHost {
   return activeAiTransportHost;
 }
 

--- a/packages/ai/src/internal/anthropic-inline-images.test.ts
+++ b/packages/ai/src/internal/anthropic-inline-images.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { estimateBase64DecodedBytesMock } = vi.hoisted(() => ({
+  estimateBase64DecodedBytesMock: vi.fn(),
+}));
+
+vi.mock("@openclaw/media-core/base64", () => ({
+  estimateBase64DecodedBytes: estimateBase64DecodedBytesMock,
+}));
+
+import { configureAiTransportHost } from "../host.js";
+import {
+  createAnthropicInlineImageBudget,
+  normalizeAnthropicInlineContent,
+} from "./anthropic-inline-images.js";
+
+describe("Anthropic inline image request budget", () => {
+  beforeEach(() => {
+    estimateBase64DecodedBytesMock.mockReset();
+    configureAiTransportHost({
+      normalizeAnthropicInlineContentBlocks: async (content) => [...content],
+    });
+  });
+
+  afterEach(() => {
+    configureAiTransportHost({});
+  });
+
+  it("accounts for normalized images across separate payload-builder calls", async () => {
+    estimateBase64DecodedBytesMock.mockReturnValue(16 * 1024 * 1024);
+    const budget = createAnthropicInlineImageBudget();
+    const content = [{ type: "image" as const, data: "image", mimeType: "image/jpeg" }];
+
+    for (let index = 0; index < 4; index += 1) {
+      await expect(normalizeAnthropicInlineContent(content, budget)).resolves.toEqual(content);
+    }
+    await expect(normalizeAnthropicInlineContent(content, budget)).rejects.toThrow(
+      "64 MB aggregate decoded safety limit",
+    );
+  });
+
+  it("rejects oversized output from an embedding host", async () => {
+    estimateBase64DecodedBytesMock.mockReturnValueOnce(1).mockReturnValueOnce(64 * 1024 * 1024 + 1);
+    await expect(
+      normalizeAnthropicInlineContent(
+        [{ type: "image", data: "image", mimeType: "image/jpeg" }],
+        createAnthropicInlineImageBudget(),
+      ),
+    ).rejects.toThrow("64 MB aggregate decoded safety limit");
+  });
+
+  it("normalizes image batches incrementally", async () => {
+    estimateBase64DecodedBytesMock.mockReturnValue(1);
+    const batchSizes: number[] = [];
+    configureAiTransportHost({
+      normalizeAnthropicInlineContentBlocks: async (content) => {
+        batchSizes.push(content.length);
+        return [...content];
+      },
+    });
+
+    await normalizeAnthropicInlineContent(
+      [
+        { type: "image", data: "first", mimeType: "image/jpeg" },
+        { type: "text", text: "between" },
+        { type: "image", data: "second", mimeType: "image/png" },
+      ],
+      createAnthropicInlineImageBudget(),
+    );
+
+    expect(batchSizes).toEqual([1, 1]);
+  });
+});

--- a/packages/ai/src/internal/anthropic-inline-images.ts
+++ b/packages/ai/src/internal/anthropic-inline-images.ts
@@ -1,0 +1,63 @@
+import type { ImageContent, TextContent } from "@openclaw/llm-core";
+import { estimateBase64DecodedBytes } from "@openclaw/media-core/base64";
+import { getAiTransportHost } from "../host.js";
+
+const ANTHROPIC_IMAGE_MEDIA_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"] as const;
+export type AnthropicImageMediaType = (typeof ANTHROPIC_IMAGE_MEDIA_TYPES)[number];
+const ANTHROPIC_IMAGE_MEDIA_TYPE_SET = new Set<string>(ANTHROPIC_IMAGE_MEDIA_TYPES);
+// Resource-safety ceiling above Anthropic's direct request envelope; route-specific
+// API limits remain provider policy rather than a shared payload-conversion rule.
+const ANTHROPIC_INLINE_IMAGES_DECODE_SAFETY_BYTES = 64 * 1024 * 1024;
+
+export type AnthropicInlineImageBudget = { totalBytes: number };
+
+export function createAnthropicInlineImageBudget(): AnthropicInlineImageBudget {
+  return { totalBytes: 0 };
+}
+
+export function resolveAnthropicImageMediaType(value: string): AnthropicImageMediaType {
+  if (ANTHROPIC_IMAGE_MEDIA_TYPE_SET.has(value)) {
+    return value as AnthropicImageMediaType;
+  }
+  throw new Error(`Unsupported Anthropic image media type after normalization: ${value}`);
+}
+
+export async function normalizeAnthropicInlineContent(
+  content: readonly (TextContent | ImageContent)[],
+  budget: AnthropicInlineImageBudget,
+): Promise<Array<TextContent | ImageContent>> {
+  if (!content.some((block) => block.type === "image")) {
+    return content.filter((block): block is TextContent => block.type === "text");
+  }
+  const inputBytes = content.reduce(
+    (total, block) =>
+      block.type === "image" ? total + estimateBase64DecodedBytes(block.data) : total,
+    0,
+  );
+  if (budget.totalBytes + inputBytes > ANTHROPIC_INLINE_IMAGES_DECODE_SAFETY_BYTES) {
+    throw new Error("Anthropic inline images exceed the 64 MB aggregate decoded safety limit.");
+  }
+  const normalized: Array<TextContent | ImageContent> = [];
+  for (const block of content) {
+    if (block.type !== "image") {
+      normalized.push(block);
+      continue;
+    }
+    const normalizedBlocks = await getAiTransportHost().normalizeAnthropicInlineContentBlocks([
+      block,
+    ]);
+    const outputBytes = normalizedBlocks.reduce(
+      (total, normalizedBlock) =>
+        normalizedBlock.type === "image"
+          ? total + estimateBase64DecodedBytes(normalizedBlock.data)
+          : total,
+      0,
+    );
+    if (budget.totalBytes + outputBytes > ANTHROPIC_INLINE_IMAGES_DECODE_SAFETY_BYTES) {
+      throw new Error("Anthropic inline images exceed the 64 MB aggregate decoded safety limit.");
+    }
+    budget.totalBytes += outputBytes;
+    normalized.push(...normalizedBlocks);
+  }
+  return normalized;
+}

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -78,6 +78,21 @@ function makeSonnet5PrefillContext(): Context {
   };
 }
 
+function tinyJpegBase64(): string {
+  return Buffer.from([
+    0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
+  ]).toString("base64");
+}
+
+function configureTestAnthropicImageNormalizer(): void {
+  configureAiTransportHost({
+    normalizeAnthropicInlineContentBlocks: async (content) =>
+      content.map((block) =>
+        block.type === "image" ? { ...block, mimeType: "image/jpeg" } : block,
+      ),
+  });
+}
+
 describe("Anthropic provider", () => {
   beforeEach(() => {
     anthropicMockState.configs = [];
@@ -1237,6 +1252,139 @@ describe("Anthropic provider", () => {
       { type: "text", text: expect.stringContaining('{"type":"resource"') },
       { type: "text", text: "after image" },
     ]);
+  });
+
+  it("normalizes unsupported user image blocks before Anthropic payloads", async () => {
+    configureTestAnthropicImageNormalizer();
+    let capturedPayload: unknown;
+    const imageData = tinyJpegBase64();
+    const stream = streamAnthropic(
+      makeAnthropicModel({ input: ["text", "image"] }),
+      {
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "look" },
+              { type: "image", mimeType: "image/heic", data: imageData },
+            ],
+            timestamp: 0,
+          },
+        ],
+      },
+      {
+        apiKey: "test-api-key",
+        onPayload: (payload) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+    expect(result.stopReason).toBe("error");
+    const [userMessage] = (capturedPayload as { messages: [Record<string, unknown>] }).messages;
+    const imageBlock = (userMessage.content as Array<Record<string, unknown>>)[1];
+    expect(imageBlock).toMatchObject({
+      type: "image",
+      source: { type: "base64", media_type: "image/jpeg", data: imageData },
+    });
+  });
+
+  it("keeps non-vision image downgrade behavior without invoking normalization", async () => {
+    configureAiTransportHost({
+      normalizeAnthropicInlineContentBlocks: async () => {
+        throw new Error("non-vision images should be downgraded before normalization");
+      },
+    });
+    let capturedPayload: unknown;
+    const stream = streamAnthropic(
+      makeAnthropicModel({ input: ["text"] }),
+      {
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "look" },
+              { type: "image", mimeType: "image/heic", data: "not-base64" },
+            ],
+            timestamp: 0,
+          },
+        ],
+      },
+      {
+        apiKey: "test-api-key",
+        onPayload: (payload) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+    expect(result.stopReason).toBe("error");
+    const [userMessage] = (capturedPayload as { messages: [Record<string, unknown>] }).messages;
+    expect(userMessage.content).toMatchObject([
+      { type: "text", text: "look" },
+      { type: "text", text: "(image omitted: model does not support images)" },
+    ]);
+  });
+
+  it("normalizes unsupported tool result image blocks before Anthropic payloads", async () => {
+    configureTestAnthropicImageNormalizer();
+    let capturedPayload: unknown;
+    const imageData = tinyJpegBase64();
+    const stream = streamAnthropic(
+      makeAnthropicModel({ input: ["text", "image"] }),
+      {
+        messages: [
+          {
+            role: "assistant",
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-6",
+            stopReason: "toolUse",
+            timestamp: 0,
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            content: [{ type: "toolCall", id: "tool_1", name: "screenshot", arguments: {} }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "tool_1",
+            toolName: "screenshot",
+            content: [{ type: "image", data: imageData, mimeType: "image/tiff" }],
+            isError: false,
+            timestamp: 0,
+          },
+        ],
+      } as unknown as Context,
+      {
+        apiKey: "test-api-key",
+        onPayload: (payload) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+    expect(result.stopReason).toBe("error");
+    const [, userMessage] = (
+      capturedPayload as { messages: [Record<string, unknown>, Record<string, unknown>] }
+    ).messages;
+    const [toolResult] = userMessage.content as [Record<string, unknown>];
+    const imageBlock = (toolResult.content as Array<Record<string, unknown>>)[1];
+    expect(imageBlock).toMatchObject({
+      type: "image",
+      source: { type: "base64", media_type: "image/jpeg", data: imageData },
+    });
   });
 
   it("does not emit Anthropic image blocks or placeholders for payload-less tool media", async () => {

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -11,6 +11,12 @@ import type {
 } from "@anthropic-ai/sdk/resources/messages.js";
 import { getEnvApiKey } from "../env-api-keys.js";
 import { getAiTransportHost, resolveAiTransportHeaderSentinels } from "../host.js";
+import {
+  createAnthropicInlineImageBudget,
+  normalizeAnthropicInlineContent,
+  resolveAnthropicImageMediaType,
+  type AnthropicInlineImageBudget,
+} from "../internal/anthropic-inline-images.js";
 import { calculateCost, clampThinkingLevel } from "../model-utils.js";
 import type {
   AnthropicMessagesCompat,
@@ -153,10 +159,11 @@ const toClaudeCodeName = (name: string) => ccToolLookup.get(name.toLowerCase()) 
 /**
  * Convert content blocks to Anthropic API format
  */
-function convertContentBlocks(
+async function convertContentBlocks(
   content: readonly unknown[],
   isError: boolean,
-):
+  imageBudget: AnthropicInlineImageBudget,
+): Promise<
   | string
   | Array<
       | { type: "text"; text: string }
@@ -168,7 +175,8 @@ function convertContentBlocks(
             data: string;
           };
         }
-    > {
+    >
+> {
   const text = extractToolResultText(content);
   const mediaPlaceholder = describeToolResultMediaPlaceholder(content);
   const hasImages = content.some(isImageWithMediaPayload);
@@ -206,16 +214,25 @@ function convertContentBlocks(
     if (!isImageWithMediaPayload(record)) {
       continue;
     }
+    const [normalizedImage] = await normalizeAnthropicInlineContent(
+      [
+        {
+          type: "image" as const,
+          data: typeof record.data === "string" ? record.data : "",
+          mimeType: typeof record.mimeType === "string" ? record.mimeType : "image/jpeg",
+        },
+      ],
+      imageBudget,
+    );
+    if (normalizedImage?.type !== "image") {
+      continue;
+    }
     blocks.push({
       type: "image" as const,
       source: {
         type: "base64" as const,
-        media_type: (typeof record.mimeType === "string" ? record.mimeType : "image/jpeg") as
-          | "image/jpeg"
-          | "image/png"
-          | "image/gif"
-          | "image/webp",
-        data: record.data,
+        media_type: resolveAnthropicImageMediaType(normalizedImage.mimeType),
+        data: normalizedImage.data,
       },
     });
   }
@@ -437,7 +454,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
         isOAuth = created.isOAuthToken;
         serverSideFallback = created.serverSideFallback;
       }
-      const builtParams = buildParams(
+      const builtParams = await buildParams(
         model,
         requestContext,
         isOAuth,
@@ -1160,16 +1177,16 @@ function createClient(
   return { client, isOAuthToken: false, serverSideFallback };
 }
 
-function buildParams(
+async function buildParams(
   model: Model<"anthropic-messages">,
   context: Context,
   isOAuthTokenResult: boolean,
   options?: AnthropicOptions,
   serverSideFallback = false,
-): {
+): Promise<{
   params: MessageCreateParamsStreaming;
   toolProjection?: AnthropicToolProjection;
-} {
+}> {
   const mandatoryAdaptiveThinking = requiresClaudeAdaptiveThinking(model);
   const replayThinkingEnabled = mandatoryAdaptiveThinking || options?.thinkingEnabled === true;
   const { cacheControl } = getCacheControl(model, options?.cacheRetention);
@@ -1193,7 +1210,7 @@ function buildParams(
   );
   const params: MessageCreateParamsStreaming = {
     model: model.id,
-    messages: convertMessages(
+    messages: await convertMessages(
       context.messages,
       model,
       isOAuthTokenResult,
@@ -1297,7 +1314,7 @@ function normalizeToolCallId(id: string): string {
   return id.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
 }
 
-function convertMessages(
+async function convertMessages(
   messages: Message[],
   model: Model<"anthropic-messages">,
   isOAuthTokenValue: boolean,
@@ -1305,8 +1322,9 @@ function convertMessages(
   messageCacheControlLimit = 4,
   replayThinkingEnabled = true,
   allowEmptySignature = false,
-): MessageParam[] {
+): Promise<MessageParam[]> {
   const params: MessageParam[] = [];
+  const imageBudget = createAnthropicInlineImageBudget();
   // Param indexes for transient runtime-context carriers — excluded from
   // cache_control breakpoint selection so the deepest breakpoint anchors on the
   // last stable user turn, not the volatile carrier appended after it.
@@ -1337,7 +1355,8 @@ function convertMessages(
           });
         }
       } else {
-        const blocks: ContentBlockParam[] = msg.content.map((item) => {
+        const normalizedContent = await normalizeAnthropicInlineContent(msg.content, imageBudget);
+        const blocks: ContentBlockParam[] = normalizedContent.map((item) => {
           if (item.type === "text") {
             return {
               type: "text",
@@ -1348,7 +1367,7 @@ function convertMessages(
             type: "image",
             source: {
               type: "base64",
-              media_type: item.mimeType as "image/jpeg" | "image/png" | "image/gif" | "image/webp",
+              media_type: resolveAnthropicImageMediaType(item.mimeType),
               data: item.data,
             },
           };
@@ -1450,7 +1469,7 @@ function convertMessages(
       toolResults.push({
         type: "tool_result",
         tool_use_id: msg.toolCallId,
-        content: convertContentBlocks(msg.content, msg.isError),
+        content: await convertContentBlocks(msg.content, msg.isError, imageBudget),
         is_error: msg.isError,
       });
 
@@ -1463,7 +1482,7 @@ function convertMessages(
         toolResults.push({
           type: "tool_result",
           tool_use_id: nextMsg.toolCallId,
-          content: convertContentBlocks(nextMsg.content, nextMsg.isError),
+          content: await convertContentBlocks(nextMsg.content, nextMsg.isError, imageBudget),
           is_error: nextMsg.isError,
         });
         j++;

--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -6,7 +6,11 @@ import type { Model } from "@openclaw/llm-core";
  */
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { configureAiTransportHost, getAiTransportHost } from "../host.js";
+import {
+  configureAiTransportHost,
+  getAiTransportHost,
+  type AiInlineContentBlock,
+} from "../host.js";
 
 const { buildGuardedModelFetchMock, guardedFetchMock } = vi.hoisted(() => ({
   buildGuardedModelFetchMock: vi.fn(),
@@ -14,6 +18,16 @@ const { buildGuardedModelFetchMock, guardedFetchMock } = vi.hoisted(() => ({
 }));
 
 const coreTransportHost = getAiTransportHost();
+
+function configureTestAnthropicImageNormalizer(): void {
+  configureAiTransportHost({
+    ...getAiTransportHost(),
+    normalizeAnthropicInlineContentBlocks: async (content) =>
+      content.map((block) =>
+        block.type === "image" ? { ...block, mimeType: "image/jpeg" } : block,
+      ),
+  });
+}
 
 function resolveTestEndpointClass(baseUrl?: string): string {
   const trimmed = baseUrl?.trim();
@@ -3485,6 +3499,118 @@ describe("anthropic transport stream", () => {
       },
     ]);
     expect(toolResult.is_error).toBe(false);
+  });
+
+  it("normalizes unsupported user image blocks before Anthropic transport payloads", async () => {
+    configureTestAnthropicImageNormalizer();
+    const imageData = Buffer.from([
+      0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
+    ]).toString("base64");
+
+    await runTransportStream(
+      makeAnthropicTransportModel({ input: ["text", "image"] }),
+      {
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "look" },
+              { type: "image", data: imageData, mimeType: "image/heic" },
+            ],
+          },
+        ],
+      } as AnthropicStreamContext,
+      { apiKey: "test-api-key" } as AnthropicStreamOptions,
+    );
+
+    const userMessage = findRecord(
+      latestAnthropicRequest().payload.messages,
+      (record) => record.role === "user",
+    );
+    const imageBlock = findRecord(userMessage.content, (record) => record.type === "image");
+    expect(imageBlock).toMatchObject({
+      type: "image",
+      source: { type: "base64", media_type: "image/jpeg", data: imageData },
+    });
+  });
+
+  it("preserves an omission placeholder for non-vision image-only turns", async () => {
+    const normalizer = vi.fn(async (content: readonly AiInlineContentBlock[]) => [...content]);
+    configureAiTransportHost({
+      ...getAiTransportHost(),
+      normalizeAnthropicInlineContentBlocks: normalizer,
+    });
+
+    const result = await runTransportStream(
+      makeAnthropicTransportModel({ input: ["text"] }),
+      {
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "image", data: "not-base64", mimeType: "image/heic" }],
+          },
+        ],
+      } as AnthropicStreamContext,
+      { apiKey: "test-api-key" } as AnthropicStreamOptions,
+    );
+
+    expect(result.stopReason).toBe("stop");
+    expect(normalizer).not.toHaveBeenCalled();
+    const userMessage = findRecord(
+      latestAnthropicRequest().payload.messages,
+      (record) => record.role === "user",
+    );
+    expect(JSON.stringify(userMessage.content)).toContain("image omitted");
+  });
+
+  it("normalizes unsupported tool result images before Anthropic transport payloads", async () => {
+    configureTestAnthropicImageNormalizer();
+    const imageData = Buffer.from("tool-image").toString("base64");
+
+    await runTransportStream(
+      makeAnthropicTransportModel({ input: ["text", "image"] }),
+      {
+        messages: [
+          {
+            role: "assistant",
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-6",
+            stopReason: "toolUse",
+            timestamp: 0,
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            content: [{ type: "toolCall", id: "tool_1", name: "screenshot", arguments: {} }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "tool_1",
+            toolName: "screenshot",
+            content: [{ type: "image", data: imageData, mimeType: "image/tiff" }],
+            isError: false,
+            timestamp: 0,
+          },
+        ],
+      } as AnthropicStreamContext,
+      { apiKey: "test-api-key" } as AnthropicStreamOptions,
+    );
+
+    const userMessage = findRecord(
+      latestAnthropicRequest().payload.messages,
+      (record) => record.role === "user",
+    );
+    const toolResult = findRecord(userMessage.content, (record) => record.type === "tool_result");
+    const imageBlock = findRecord(toolResult.content, (record) => record.type === "image");
+    expect(imageBlock).toMatchObject({
+      type: "image",
+      source: { type: "base64", media_type: "image/jpeg", data: imageData },
+    });
   });
 
   it("serializes structured non-image blocks in tool results as JSON text", async () => {

--- a/packages/ai/src/transports/anthropic-transport-stream.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.ts
@@ -1,9 +1,11 @@
 import type {
   AssistantMessageDiagnostic,
   Context,
+  ImageContent,
   Model,
   SimpleStreamOptions,
   StreamFn,
+  TextContent,
   ThinkingLevel,
   Usage,
 } from "@openclaw/llm-core";
@@ -15,6 +17,12 @@ import { toErrorObject } from "@openclaw/normalization-core/error-coercion";
  */
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { getAiTransportHost } from "../host.js";
+import {
+  createAnthropicInlineImageBudget,
+  normalizeAnthropicInlineContent,
+  resolveAnthropicImageMediaType,
+  type AnthropicInlineImageBudget,
+} from "../internal/anthropic-inline-images.js";
 import {
   ANTHROPIC_OMITTED_REASONING_TEXT,
   ANTHROPIC_SERVER_SIDE_FALLBACK_BETA,
@@ -362,7 +370,13 @@ function toClaudeCodeName(name: string): string {
   return CLAUDE_CODE_TOOL_LOOKUP.get(normalizeLowercaseStringOrEmpty(name)) ?? name;
 }
 
-function convertContentBlocks(content: readonly unknown[], model: { input: readonly string[] }) {
+const NON_VISION_USER_IMAGE_PLACEHOLDER = "(image omitted: model does not support images)";
+
+async function convertContentBlocks(
+  content: readonly unknown[],
+  model: { input: readonly string[] },
+  imageBudget: AnthropicInlineImageBudget,
+) {
   const text = extractToolResultText(content);
   const mediaPlaceholder = describeToolResultMediaPlaceholder(content);
   const hasImages = model.input.includes("image") && content.some(isImageWithMediaPayload);
@@ -390,12 +404,25 @@ function convertContentBlocks(content: readonly unknown[], model: { input: reado
     if (!isImageWithMediaPayload(record)) {
       continue;
     }
+    const [normalizedImage] = await normalizeAnthropicInlineContent(
+      [
+        {
+          type: "image" as const,
+          data: typeof record.data === "string" ? record.data : "",
+          mimeType: typeof record.mimeType === "string" ? record.mimeType : "image/png",
+        },
+      ],
+      imageBudget,
+    );
+    if (normalizedImage?.type !== "image") {
+      continue;
+    }
     blocks.push({
       type: "image" as const,
       source: {
         type: "base64",
-        media_type: typeof record.mimeType === "string" ? record.mimeType : "image/png",
-        data: record.data,
+        media_type: resolveAnthropicImageMediaType(normalizedImage.mimeType),
+        data: normalizedImage.data,
       },
     });
   }
@@ -409,7 +436,7 @@ function normalizeToolCallId(id: string): string {
   return id.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
 }
 
-function convertAnthropicMessages(
+async function convertAnthropicMessages(
   messages: Context["messages"],
   model: AnthropicTransportModel,
   isOAuthToken: boolean,
@@ -418,8 +445,9 @@ function convertAnthropicMessages(
     cacheBreakpointOptOutMessageIndexes: Set<number>;
     replayThinkingEnabled?: boolean;
   },
-): Array<Record<string, unknown>> {
+): Promise<Array<Record<string, unknown>>> {
   const params: Array<Record<string, unknown>> = [];
+  const imageBudget = createAnthropicInlineImageBudget();
   const allowReasoningContentReplay = options.allowReasoningContentReplay === true;
   const replayThinkingEnabled = options.replayThinkingEnabled !== false;
   const transformedMessages = transformTransportMessages(messages, model, normalizeToolCallId);
@@ -446,13 +474,23 @@ function convertAnthropicMessages(
         }
         continue;
       }
+      const normalizedContent = model.input.includes("image")
+        ? await normalizeAnthropicInlineContent(
+            msg.content as readonly (TextContent | ImageContent)[],
+            imageBudget,
+          )
+        : msg.content.map((item) =>
+            item.type === "image"
+              ? { type: "text" as const, text: NON_VISION_USER_IMAGE_PLACEHOLDER }
+              : item,
+          );
       const blocks: Array<
         | { type: "text"; text: string }
         | {
             type: "image";
             source: { type: "base64"; media_type: string; data: string };
           }
-      > = msg.content.map((item) =>
+      > = normalizedContent.map((item) =>
         item.type === "text"
           ? {
               type: "text",
@@ -462,7 +500,7 @@ function convertAnthropicMessages(
               type: "image",
               source: {
                 type: "base64",
-                media_type: item.mimeType,
+                media_type: resolveAnthropicImageMediaType(item.mimeType),
                 data: item.data,
               },
             },
@@ -580,7 +618,7 @@ function convertAnthropicMessages(
         {
           type: "tool_result",
           tool_use_id: toolResult.toolCallId,
-          content: convertContentBlocks(toolResult.content, model),
+          content: await convertContentBlocks(toolResult.content, model, imageBudget),
           is_error: toolResult.isError,
         },
       ];
@@ -593,7 +631,7 @@ function convertAnthropicMessages(
         toolResults.push({
           type: "tool_result",
           tool_use_id: nextMsg.toolCallId,
-          content: convertContentBlocks(nextMsg.content, model),
+          content: await convertContentBlocks(nextMsg.content, model, imageBudget),
           is_error: nextMsg.isError,
         });
         j += 1;
@@ -1011,15 +1049,15 @@ function createAnthropicTransportClient(params: {
   };
 }
 
-function buildAnthropicParams(
+async function buildAnthropicParams(
   model: AnthropicTransportModel,
   context: Context,
   isOAuthToken: boolean,
   options: AnthropicTransportOptions | undefined,
-): {
+): Promise<{
   params: Record<string, unknown>;
   toolProjection?: AnthropicToolProjection;
-} {
+}> {
   const mandatoryAdaptiveThinking = requiresClaudeAdaptiveThinking(model);
   const replayThinkingEnabled = mandatoryAdaptiveThinking || options?.thinkingEnabled === true;
   const maxTokens = resolveAnthropicMessagesMaxTokens({
@@ -1042,7 +1080,7 @@ function buildAnthropicParams(
   // Transient runtime-context carrier indexes skip cache anchoring so the breakpoint
   // stays on the last stable user turn; conversion-to-policy must not splice messages.
   const cacheBreakpointOptOutMessageIndexes = new Set<number>();
-  const messages = convertAnthropicMessages(context.messages, model, isOAuthToken, {
+  const messages = await convertAnthropicMessages(context.messages, model, isOAuthToken, {
     allowReasoningContentReplay: supportsReasoningContentReplay(model),
     cacheBreakpointOptOutMessageIndexes,
     replayThinkingEnabled,
@@ -1261,7 +1299,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
           apiKey,
           options: transportOptions,
         });
-        const builtParams = buildAnthropicParams(
+        const builtParams = await buildAnthropicParams(
           model,
           requestContext,
           isOAuthToken,

--- a/src/llm/ai-transport-host.ts
+++ b/src/llm/ai-transport-host.ts
@@ -9,6 +9,7 @@ import {
 } from "../agents/provider-transport-fetch.js";
 import { redactSecrets, redactToolPayloadText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { normalizeAnthropicInlineContentBlocks } from "../media/anthropic-inline-images.js";
 import { swapSecretSentinelsInText } from "../secrets/sentinel.js";
 
 const transportLogBySubsystem = new Map<string, ReturnType<typeof createSubsystemLogger>>();
@@ -36,6 +37,7 @@ configureAiTransportHost({
   },
   redactSecrets,
   redactToolPayloadText,
+  normalizeAnthropicInlineContentBlocks,
   resolveOpenAIStrictToolSetting,
   resolveModelRequestTimeoutMs: (model) => resolveModelRequestTimeoutMs(model, undefined),
   logDebug: (subsystem, build) => {

--- a/src/media/anthropic-inline-images.test.ts
+++ b/src/media/anthropic-inline-images.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { convertImageToJpegMock, convertImageToPngMock, detectMimeMock } = vi.hoisted(() => ({
+  convertImageToJpegMock: vi.fn(),
+  convertImageToPngMock: vi.fn(),
+  detectMimeMock: vi.fn(),
+}));
+
+vi.mock("@openclaw/media-core/mime", () => ({
+  detectMime: detectMimeMock,
+  normalizeMimeType: (value?: string | null) => value?.split(";", 1)[0]?.trim().toLowerCase(),
+}));
+
+vi.mock("./image-ops.js", () => ({
+  convertImageToJpeg: convertImageToJpegMock,
+  convertImageToPng: convertImageToPngMock,
+}));
+
+import { normalizeAnthropicInlineContentBlocks } from "./anthropic-inline-images.js";
+
+describe("normalizeAnthropicInlineContentBlocks", () => {
+  beforeEach(() => {
+    convertImageToJpegMock.mockReset();
+    convertImageToJpegMock.mockResolvedValue(Buffer.from("converted-jpeg"));
+    convertImageToPngMock.mockReset();
+    convertImageToPngMock.mockResolvedValue(Buffer.from("converted-png"));
+    detectMimeMock.mockReset();
+  });
+
+  it("converts detected unsupported bytes despite a supported declaration", async () => {
+    detectMimeMock.mockResolvedValue("image/tiff");
+    const tiffData = Buffer.from("tiff-bytes").toString("base64");
+
+    await expect(
+      normalizeAnthropicInlineContentBlocks([
+        { type: "image", data: tiffData, mimeType: "image/jpeg" },
+      ]),
+    ).resolves.toEqual([
+      {
+        type: "image",
+        data: Buffer.from("converted-jpeg").toString("base64"),
+        mimeType: "image/jpeg",
+      },
+    ]);
+    expect(convertImageToJpegMock).toHaveBeenCalledOnce();
+  });
+
+  it("uses a supported declaration when byte detection is inconclusive", async () => {
+    detectMimeMock.mockResolvedValue(undefined);
+    const opaqueData = Buffer.from("not-a-recognized-image-header").toString("base64");
+
+    await expect(
+      normalizeAnthropicInlineContentBlocks([
+        { type: "image", data: opaqueData, mimeType: "image/png" },
+      ]),
+    ).resolves.toEqual([{ type: "image", data: opaqueData, mimeType: "image/png" }]);
+    expect(convertImageToJpegMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized image data before MIME detection or decoding", async () => {
+    const maxBytes = 10 * 1024 * 1024;
+    const encodedLength = Math.ceil(((maxBytes + 1) * 4) / 3);
+
+    await expect(
+      normalizeAnthropicInlineContentBlocks([
+        { type: "image", data: "A".repeat(encodedLength), mimeType: "image/tiff" },
+      ]),
+    ).rejects.toThrow("10 MB decoded safety limit");
+    expect(detectMimeMock).not.toHaveBeenCalled();
+    expect(convertImageToJpegMock).not.toHaveBeenCalled();
+  });
+
+  it("routes detected BMP bytes through the fallback-capable PNG converter", async () => {
+    detectMimeMock.mockResolvedValue("image/bmp");
+    const bmpData = Buffer.from("bmp-bytes").toString("base64");
+
+    await expect(
+      normalizeAnthropicInlineContentBlocks([
+        { type: "image", data: bmpData, mimeType: "image/bmp" },
+      ]),
+    ).resolves.toEqual([
+      {
+        type: "image",
+        data: Buffer.from("converted-png").toString("base64"),
+        mimeType: "image/png",
+      },
+    ]);
+    expect(convertImageToPngMock).toHaveBeenCalledOnce();
+    expect(convertImageToJpegMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects converted images that exceed the outgoing size limit", async () => {
+    detectMimeMock.mockResolvedValue("image/tiff");
+    convertImageToJpegMock.mockResolvedValue(Buffer.alloc(10 * 1024 * 1024 + 1));
+
+    await expect(
+      normalizeAnthropicInlineContentBlocks([
+        {
+          type: "image",
+          data: Buffer.from("small-tiff").toString("base64"),
+          mimeType: "image/tiff",
+        },
+      ]),
+    ).rejects.toThrow("Normalized Anthropic inline image exceeds the 10 MB decoded safety limit");
+  });
+});

--- a/src/media/anthropic-inline-images.ts
+++ b/src/media/anthropic-inline-images.ts
@@ -1,0 +1,86 @@
+import { canonicalizeBase64, estimateBase64DecodedBytes } from "@openclaw/media-core/base64";
+import { detectMime, normalizeMimeType } from "@openclaw/media-core/mime";
+import { convertImageToJpeg, convertImageToPng } from "./image-ops.js";
+
+const ANTHROPIC_SUPPORTED_IMAGE_MIMES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+] as const;
+// Match OpenClaw's decoded inbound-image hard cap before any copy or native decode.
+const ANTHROPIC_INLINE_IMAGE_DECODE_SAFETY_BYTES = 10 * 1024 * 1024;
+
+type AnthropicSupportedImageMime = (typeof ANTHROPIC_SUPPORTED_IMAGE_MIMES)[number];
+type AnthropicInlineTextBlock = { type: "text"; text: string };
+type AnthropicInlineImageBlock = { type: "image"; data: string; mimeType: string };
+type AnthropicInlineBlock = AnthropicInlineTextBlock | AnthropicInlineImageBlock;
+type NormalizedAnthropicInlineImageBlock = Omit<AnthropicInlineImageBlock, "mimeType"> & {
+  mimeType: AnthropicSupportedImageMime;
+};
+type NormalizedAnthropicInlineBlock =
+  | AnthropicInlineTextBlock
+  | NormalizedAnthropicInlineImageBlock;
+
+const ANTHROPIC_SUPPORTED_IMAGE_MIME_SET = new Set<string>(ANTHROPIC_SUPPORTED_IMAGE_MIMES);
+
+function isAnthropicSupportedImageMime(
+  value: string | undefined,
+): value is AnthropicSupportedImageMime {
+  return typeof value === "string" && ANTHROPIC_SUPPORTED_IMAGE_MIME_SET.has(value);
+}
+
+async function normalizeAnthropicInlineImage(block: AnthropicInlineImageBlock): Promise<{
+  data: string;
+  mimeType: AnthropicSupportedImageMime;
+}> {
+  const canonicalData = canonicalizeBase64(block.data) ?? block.data.trim();
+  const buffer = Buffer.from(canonicalData, "base64");
+  const declaredMime = normalizeMimeType(block.mimeType);
+  const detectedMime = normalizeMimeType(await detectMime({ buffer }));
+  if (isAnthropicSupportedImageMime(detectedMime)) {
+    return { data: canonicalData, mimeType: detectedMime };
+  }
+  if (!detectedMime && isAnthropicSupportedImageMime(declaredMime)) {
+    return { data: canonicalData, mimeType: declaredMime };
+  }
+
+  const convertToPng = detectedMime === "image/bmp";
+  const normalizedBuffer = convertToPng
+    ? await convertImageToPng(buffer)
+    : await convertImageToJpeg(buffer);
+  if (normalizedBuffer.byteLength > ANTHROPIC_INLINE_IMAGE_DECODE_SAFETY_BYTES) {
+    throw new Error("Normalized Anthropic inline image exceeds the 10 MB decoded safety limit.");
+  }
+  return {
+    data: normalizedBuffer.toString("base64"),
+    mimeType: convertToPng ? "image/png" : "image/jpeg",
+  };
+}
+
+export async function normalizeAnthropicInlineContentBlocks(
+  content: readonly AnthropicInlineBlock[],
+): Promise<NormalizedAnthropicInlineBlock[]> {
+  for (const block of content) {
+    if (block.type !== "image") {
+      continue;
+    }
+    const bytes = estimateBase64DecodedBytes(block.data);
+    if (bytes > ANTHROPIC_INLINE_IMAGE_DECODE_SAFETY_BYTES) {
+      throw new Error("Anthropic inline image exceeds the 10 MB decoded safety limit.");
+    }
+  }
+
+  const normalized: NormalizedAnthropicInlineBlock[] = [];
+  for (const block of content) {
+    if (block.type !== "image") {
+      normalized.push(block);
+      continue;
+    }
+    normalized.push({
+      ...block,
+      ...(await normalizeAnthropicInlineImage(block)),
+    });
+  }
+  return normalized;
+}

--- a/src/media/image-ops.ts
+++ b/src/media/image-ops.ts
@@ -116,13 +116,22 @@ export async function resizeToJpeg(params: ResizeToJpegParams): Promise<Buffer> 
   }
 }
 
-/** Converts HEIC/HEIF-like image bytes into JPEG through the shared image processor. */
-export async function convertHeicToJpeg(buffer: Buffer): Promise<Buffer> {
+async function encodeImageToJpeg(buffer: Buffer, operation: string): Promise<Buffer> {
   try {
     return (await createImageProcessor().encode(buffer, { format: "jpeg" })).data;
   } catch (error) {
-    return wrapRastermillUnavailable("convertHeicToJpeg", error);
+    return wrapRastermillUnavailable(operation, error);
   }
+}
+
+/** Converts image bytes into JPEG through the shared image processor. */
+export async function convertImageToJpeg(buffer: Buffer): Promise<Buffer> {
+  return await encodeImageToJpeg(buffer, "convertImageToJpeg");
+}
+
+/** Converts HEIC/HEIF-like image bytes into JPEG through the shared image processor. */
+export async function convertHeicToJpeg(buffer: Buffer): Promise<Buffer> {
+  return await encodeImageToJpeg(buffer, "convertHeicToJpeg");
 }
 
 /** Converts image bytes to PNG, including BMP fallback unsupported by Rastermill's Photon gate. */


### PR DESCRIPTION
## What Problem This Solves

Closes #102323. Anthropic accepts only JPEG, PNG, GIF, and WebP image blocks, but OpenClaw could forward within-limit HEIC, TIFF, or BMP MIME values and bytes unchanged. Anthropic rejected the whole turn, so the user received no reply.

## Why This Change Was Made

- Normalize user and tool-result images at both current package-owned Anthropic payload builders: the packaged provider and Anthropic transport.
- Keep `@openclaw/ai` independent of Rastermill through one optional, source-compatible host port with an inert identity default; OpenClaw core injects the byte-aware implementation.
- Detect actual bytes before trusting declared MIME. Preserve supported formats, convert TIFF/HEIC-like inputs to JPEG, and use the existing Photon-capable PNG fallback for BMP.
- Preserve non-vision fast paths and explicit omission placeholders without decoding dropped images.
- Bound work before and after conversion at OpenClaw's 10 MB decoded-image safety ceiling. Account normalized images incrementally against one 64 MB request-scope safety budget before retaining each converted result.
- Keep existing HEIC conversion error identity while adding a generic JPEG encoder for this provider boundary.

The host capability is accepted as the permanent package/core seam: it is optional for published package consumers, while the runtime getter always supplies the inert fallback.

## User Impact

Supported-size HEIC/TIFF/BMP images now reach Anthropic in a supported encoded format instead of failing the turn. Existing JPEG/PNG/GIF/WebP and text-only behavior remains unchanged. Oversized or aggregate-abusive inline payloads fail locally before unbounded decode/conversion work.

## Evidence

- Official contract: current `@anthropic-ai/sdk` restricts base64 image media types to JPEG, PNG, GIF, and WebP.
- `node scripts/run-vitest.mjs <package host/provider/transport and core normalizer tests>` — 204 tests passed on exact rebased head `50acd5c74db`.
- Real official Anthropic API proof: a repository image converted locally to TIFF entered OpenClaw as `image/tiff`, normalized through the core host, and completed on `claude-haiku-4-5` with `stopReason: stop`, 4 output tokens, and no error. Temporary image/script and credential window were removed afterward.
- `node scripts/check-changed.mjs -- <eleven touched files>` — core/core-test typecheck, full core lint, format, import cycles, dependency/API/database guards passed on Node 24.18 using the documented local fallback after repeated Blacksmith status API failures.
- `node scripts/build-all.mjs` — full AI/packages/unified build, runtime postbuild, 140 Plugin SDK export checks, and Control UI build passed.
- AutoReview: all in-scope security/compatibility findings were accepted and fixed (pre-decode bounds, non-vision image-only turns, BMP fallback, post-conversion bounds, route-policy separation, request-scope accounting, incremental conversion). Final review clean.
- `git diff --check` passed.

Original fix by @TUARAN; replacement commit preserves `Co-authored-by: TUARAN <729922845@qq.com>`.
