### PR TITLE
fix(compaction): use truncateUtf16Safe for compaction summary truncation

### DIFF
--- a/packages/agent-core/src/harness/compaction/utils.ts
+++ b/packages/agent-core/src/harness/compaction/utils.ts
@@ -1,4 +1,5 @@
 // Agent Core helper module supports utils behavior.
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { Message } from "../../../../llm-core/src/index.js";
 import type { AgentMessage } from "../../types.js";
 
@@ -106,7 +107,7 @@ function truncateForSummary(text: string, maxChars: number): string {
     return text;
   }
   const truncatedChars = text.length - maxChars;
-  return `${text.slice(0, maxChars)}\n\n[... ${truncatedChars} more characters truncated]`;
+  return `${truncateUtf16Safe(text, maxChars)}\n\n[... ${truncatedChars} more characters truncated]`;
 }
 
 /** Extract text that compaction both estimates and includes in summary prompts. */


### PR DESCRIPTION
## What Problem This Solves

Compaction summary text truncation uses naive .slice(0, maxChars) which can split surrogate pairs in text sent to the model as context.

## Files Changed

| File | Change |
|------|--------|
| packages/agent-core/src/harness/compaction/utils.ts | +1 import; .slice(0,N) → truncateUtf16Safe() |

🤖 Generated with [Claude Code](https://claude.com/claude-code)