### PR TITLE
fix(mistral): use truncateUtf16Safe for error text truncation

### DIFF
--- a/packages/ai/src/providers/mistral.test.ts
+++ b/packages/ai/src/providers/mistral.test.ts
@@ -7,6 +7,7 @@ import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../utils/system-prompt-cache-bound
 const mistralMockState = vi.hoisted(() => ({
   configs: [] as unknown[],
   payloads: [] as unknown[],
+  streamError: new Error("stop before network") as unknown,
 }));
 
 vi.mock("@mistralai/mistralai", async () => {
@@ -27,7 +28,7 @@ vi.mock("@mistralai/mistralai", async () => {
       chat = {
         stream: vi.fn(async (payload: unknown) => {
           mistralMockState.payloads.push(payload);
-          throw new Error("stop before network");
+          throw mistralMockState.streamError;
         }),
       };
     },
@@ -77,6 +78,7 @@ describe("Mistral provider", () => {
   beforeEach(() => {
     mistralMockState.configs = [];
     mistralMockState.payloads = [];
+    mistralMockState.streamError = new Error("stop before network");
   });
 
   afterEach(() => {
@@ -93,6 +95,20 @@ describe("Mistral provider", () => {
 
     expect(result.stopReason).toBe("error");
     expect((mistralMockState.payloads[0] as { stop?: unknown }).stop).toEqual(["STOP"]);
+  });
+
+  it("keeps truncated Mistral error bodies UTF-16 safe with an exact omitted count", async () => {
+    const prefix = "a".repeat(3_999);
+    mistralMockState.streamError = Object.assign(new Error("invalid request"), {
+      statusCode: 400,
+      body: `${prefix}😀tail`,
+    });
+
+    const result = await streamMistral(makeMistralModel(), context, {
+      apiKey: "sk-mistral-provider",
+    }).result();
+
+    expect(result.errorMessage).toBe(`Mistral API error (400): ${prefix}... [truncated 6 chars]`);
   });
 
   it("routes the Mistral HTTPClient through the host guarded fetch", async () => {

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -1,6 +1,5 @@
 // Mistral provider adapts Mistral streams and tool calls to the runtime.
 import { HTTPClient, Mistral, type Fetcher } from "@mistralai/mistralai";
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type {
   ChatCompletionStreamRequest,
   ChatCompletionStreamRequestMessage,
@@ -8,6 +7,7 @@ import type {
   ContentChunk,
   FunctionTool,
 } from "@mistralai/mistralai/models/components";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { getEnvApiKey } from "../env-api-keys.js";
 import { getAiTransportHost } from "../host.js";
 import { calculateCost, clampThinkingLevel } from "../model-utils.js";
@@ -296,7 +296,8 @@ function truncateErrorText(text: string, maxChars: number): string {
   if (text.length <= maxChars) {
     return text;
   }
-  return `${truncateUtf16Safe(text, maxChars)}... [truncated ${text.length - maxChars} chars]`;
+  const truncated = truncateUtf16Safe(text, maxChars);
+  return `${truncated}... [truncated ${text.length - truncated.length} chars]`;
 }
 
 function safeJsonStringify(value: unknown): string {

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -1,5 +1,6 @@
 // Mistral provider adapts Mistral streams and tool calls to the runtime.
 import { HTTPClient, Mistral, type Fetcher } from "@mistralai/mistralai";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type {
   ChatCompletionStreamRequest,
   ChatCompletionStreamRequestMessage,
@@ -295,7 +296,7 @@ function truncateErrorText(text: string, maxChars: number): string {
   if (text.length <= maxChars) {
     return text;
   }
-  return `${text.slice(0, maxChars)}... [truncated ${text.length - maxChars} chars]`;
+  return `${truncateUtf16Safe(text, maxChars)}... [truncated ${text.length - maxChars} chars]`;
 }
 
 function safeJsonStringify(value: unknown): string {


### PR DESCRIPTION
## What Problem This Solves

Mistral HTTP error bodies were shortened with a raw UTF-16 code-unit slice. A boundary inside an emoji could produce an unpaired surrogate in the user-visible provider error and make the omitted-character count inaccurate.

## Why This Change Was Made

The provider now uses the shared UTF-16-safe truncation helper and computes the omitted count from the actual safe prefix. This preserves the existing 4,000-code-unit cap and error format.

## User Impact

Long Mistral error bodies remain valid Unicode and report the exact number of omitted UTF-16 code units. Short errors and ASCII-only errors are unchanged.

## Evidence

- Added a public-path regression test through `streamMistral(...).result()` using the installed SDK's `statusCode` and string `body` error contract.
- Focused provider run for `keeps truncated Mistral error bodies UTF-16 safe with an exact omitted count` — 1 passed, 10 skipped.
- Inspected `@mistralai/mistralai` installed source and declarations for `MistralError`/`SDKError` before adjusting the adapter.
- Fresh autoreview — clean, 0.99 confidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
