### PR TITLE
fix(agent-core,memory-core): keep compaction summary and memory snippet truncation UTF-16 safe

### DIFF
--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -31,6 +31,8 @@ import {
   removeGroundedShortTermCandidates,
   repairShortTermPromotionArtifacts,
   testing,
+  truncatePromotedSnippet,
+  truncateShortTermSnippet,
 } from "./short-term-promotion.js";
 
 describe("short-term promotion", () => {
@@ -3587,5 +3589,42 @@ describe("short-term promotion", () => {
         expect(memoryText).toContain("Some small existing content.");
       });
     });
+  });
+});
+
+describe("truncateShortTermSnippet", () => {
+  it("returns the original snippet when within the char limit", () => {
+    expect(truncateShortTermSnippet("short")).toBe("short");
+  });
+
+  it("truncates oversize snippets to the cap", () => {
+    const input = "x".repeat(900);
+    const result = truncateShortTermSnippet(input);
+    expect(result.length).toBeLessThanOrEqual(800);
+  });
+
+  it("does not split a surrogate pair at the cap boundary", () => {
+    const input = `${"y".repeat(799)}🚀`;
+    const result = truncateShortTermSnippet(input);
+    expect(result).not.toContain("�");
+  });
+});
+
+describe("truncatePromotedSnippet", () => {
+  it("returns the original snippet when within token limit", () => {
+    const result = truncatePromotedSnippet("short snippet", 100);
+    expect(result).toBe("short snippet");
+  });
+
+  it("truncates and appends ellipsis", () => {
+    const input = "x".repeat(500);
+    const result = truncatePromotedSnippet(input, 10);
+    expect(result.endsWith("...")).toBe(true);
+  });
+
+  it("does not split a surrogate pair at the boundary", () => {
+    const input = `aa🚀. ${"b".repeat(300)}`;
+    const result = truncatePromotedSnippet(input, 15);
+    expect(result).not.toContain("�");
   });
 });

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -31,8 +31,6 @@ import {
   removeGroundedShortTermCandidates,
   repairShortTermPromotionArtifacts,
   testing,
-  truncatePromotedSnippet,
-  truncateShortTermSnippet,
 } from "./short-term-promotion.js";
 
 describe("short-term promotion", () => {
@@ -3590,41 +3588,70 @@ describe("short-term promotion", () => {
       });
     });
   });
-});
+  describe("UTF-16 snippet bounds", () => {
+    it("stores a complete-code-point short-term recall snippet", async () => {
+      await withTempWorkspace(async (workspaceDir) => {
+        const prefix = "y".repeat(testing.SHORT_TERM_RECALL_MAX_SNIPPET_CHARS - 1);
+        await recordShortTermRecalls({
+          workspaceDir,
+          query: "utf16 recall",
+          results: [
+            {
+              path: "memory/2026-04-03.md",
+              source: "memory",
+              startLine: 1,
+              endLine: 1,
+              score: 0.9,
+              snippet: `${prefix}🚀tail`,
+            },
+          ],
+        });
 
-describe("truncateShortTermSnippet", () => {
-  it("returns the original snippet when within the char limit", () => {
-    expect(truncateShortTermSnippet("short")).toBe("short");
-  });
+        const entries = Object.values(await readRecallStoreEntries(workspaceDir));
+        expect(entries).toHaveLength(1);
+        expect(readEntrySnippet(entries[0])).toBe(prefix);
+      });
+    });
 
-  it("truncates oversize snippets to the cap", () => {
-    const input = "x".repeat(900);
-    const result = truncateShortTermSnippet(input);
-    expect(result.length).toBeLessThanOrEqual(800);
-  });
+    it("writes a complete-code-point promoted MEMORY.md snippet", async () => {
+      await withTempWorkspace(async (workspaceDir) => {
+        const prefix = "a".repeat(7);
+        const snippet = `${prefix}🚀tail`;
+        await writeDailyMemoryNote(workspaceDir, "2026-04-03", [snippet]);
+        await recordShortTermRecalls({
+          workspaceDir,
+          query: "utf16 promotion",
+          results: [
+            {
+              path: "memory/2026-04-03.md",
+              source: "memory",
+              startLine: 1,
+              endLine: 1,
+              score: 0.9,
+              snippet,
+            },
+          ],
+        });
+        const ranked = await rankShortTermPromotionCandidates({
+          workspaceDir,
+          minScore: 0,
+          minRecallCount: 0,
+          minUniqueQueries: 0,
+        });
 
-  it("does not split a surrogate pair at the cap boundary", () => {
-    const input = `${"y".repeat(799)}🚀`;
-    const result = truncateShortTermSnippet(input);
-    expect(result).not.toContain("�");
-  });
-});
+        await applyShortTermPromotions({
+          workspaceDir,
+          candidates: ranked,
+          minScore: 0,
+          minRecallCount: 0,
+          minUniqueQueries: 0,
+          maxPromotedSnippetTokens: 2,
+        });
 
-describe("truncatePromotedSnippet", () => {
-  it("returns the original snippet when within token limit", () => {
-    const result = truncatePromotedSnippet("short snippet", 100);
-    expect(result).toBe("short snippet");
-  });
-
-  it("truncates and appends ellipsis", () => {
-    const input = "x".repeat(500);
-    const result = truncatePromotedSnippet(input, 10);
-    expect(result.endsWith("...")).toBe(true);
-  });
-
-  it("does not split a surrogate pair at the boundary", () => {
-    const input = `aa🚀. ${"b".repeat(300)}`;
-    const result = truncatePromotedSnippet(input, 15);
-    expect(result).not.toContain("�");
+        const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
+        expect(memoryText).toContain(`- ${prefix}... [`);
+        expect(memoryText).not.toContain("🚀");
+      });
+    });
   });
 });

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -2,7 +2,6 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import {
@@ -17,6 +16,7 @@ import {
   normalizeStringEntries,
   uniqueStrings,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   deriveConceptTags,
   MAX_CONCEPT_TAGS,
@@ -356,7 +356,7 @@ function normalizeSnippet(raw: string): string {
   return trimmed.replace(/\s+/g, " ");
 }
 
-export function truncateShortTermSnippet(snippet: string): string {
+function truncateShortTermSnippet(snippet: string): string {
   if (snippet.length <= SHORT_TERM_RECALL_MAX_SNIPPET_CHARS) {
     return snippet;
   }
@@ -2347,7 +2347,7 @@ function resolvePromotedSnippetCharLimit(maxTokens: number): number {
   return tokenLimit * PROMOTED_SNIPPET_CHARS_PER_TOKEN_ESTIMATE;
 }
 
-export function truncatePromotedSnippet(snippet: string, maxTokens: number): string {
+function truncatePromotedSnippet(snippet: string, maxTokens: number): string {
   const limit = resolvePromotedSnippetCharLimit(maxTokens);
   if (limit === 0 || snippet.length <= limit) {
     return snippet;
@@ -2365,7 +2365,7 @@ export function truncatePromotedSnippet(snippet: string, maxTokens: number): str
       : wordBoundary >= Math.floor(limit * 0.65)
         ? wordBoundary
         : limit;
-  return `${truncateUtf16Safe(hardLimit, cutAt).trimEnd()}...`;
+  return `${hardLimit.slice(0, cutAt).trimEnd()}...`;
 }
 
 function formatPromotedSnippetForMemory(rawSnippet: string, maxTokens: number): string {

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -2,6 +2,7 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import {
@@ -355,11 +356,11 @@ function normalizeSnippet(raw: string): string {
   return trimmed.replace(/\s+/g, " ");
 }
 
-function truncateShortTermSnippet(snippet: string): string {
+export function truncateShortTermSnippet(snippet: string): string {
   if (snippet.length <= SHORT_TERM_RECALL_MAX_SNIPPET_CHARS) {
     return snippet;
   }
-  return snippet.slice(0, SHORT_TERM_RECALL_MAX_SNIPPET_CHARS).trimEnd();
+  return truncateUtf16Safe(snippet, SHORT_TERM_RECALL_MAX_SNIPPET_CHARS).trimEnd();
 }
 
 function enforceShortTermRecallSnippetCap(store: ShortTermRecallStore): void {
@@ -2346,12 +2347,12 @@ function resolvePromotedSnippetCharLimit(maxTokens: number): number {
   return tokenLimit * PROMOTED_SNIPPET_CHARS_PER_TOKEN_ESTIMATE;
 }
 
-function truncatePromotedSnippet(snippet: string, maxTokens: number): string {
+export function truncatePromotedSnippet(snippet: string, maxTokens: number): string {
   const limit = resolvePromotedSnippetCharLimit(maxTokens);
   if (limit === 0 || snippet.length <= limit) {
     return snippet;
   }
-  const hardLimit = snippet.slice(0, limit);
+  const hardLimit = truncateUtf16Safe(snippet, limit);
   const sentenceBoundary = Math.max(
     hardLimit.lastIndexOf(". "),
     hardLimit.lastIndexOf("! "),
@@ -2364,7 +2365,7 @@ function truncatePromotedSnippet(snippet: string, maxTokens: number): string {
       : wordBoundary >= Math.floor(limit * 0.65)
         ? wordBoundary
         : limit;
-  return `${hardLimit.slice(0, cutAt).trimEnd()}...`;
+  return `${truncateUtf16Safe(hardLimit, cutAt).trimEnd()}...`;
 }
 
 function formatPromotedSnippetForMemory(rawSnippet: string, maxTokens: number): string {

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -96,6 +96,7 @@
   },
   "dependencies": {
     "@openclaw/ai": "workspace:*",
+    "@openclaw/normalization-core": "workspace:*",
     "typebox": "1.3.3"
   }
 }

--- a/packages/agent-core/src/harness/compaction/utils.test.ts
+++ b/packages/agent-core/src/harness/compaction/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Message } from "../../../../llm-core/src/index.js";
-import { serializeConversation } from "./utils.js";
+import { serializeConversation, truncateForSummary } from "./utils.js";
 
 describe("serializeConversation", () => {
   it.each([
@@ -32,5 +32,24 @@ describe("serializeConversation", () => {
     ] as unknown as Message[];
 
     expect(serializeConversation(messages)).toBe(`[Tool result]: ${expected}`);
+  });
+});
+
+describe("truncateForSummary", () => {
+  it("returns the original text when it fits within maxChars", () => {
+    expect(truncateForSummary("hello", 100)).toBe("hello");
+  });
+
+  it("truncates long text with a summary notice", () => {
+    const input = "x".repeat(200);
+    const result = truncateForSummary(input, 100);
+    expect(result.length).toBeLessThan(input.length);
+    expect(result).toContain("more characters truncated");
+  });
+
+  it("does not split a surrogate pair at the truncation boundary", () => {
+    const input = `aa🚀${"b".repeat(200)}`;
+    const result = truncateForSummary(input, 80);
+    expect(result).not.toContain("�");
   });
 });

--- a/packages/agent-core/src/harness/compaction/utils.test.ts
+++ b/packages/agent-core/src/harness/compaction/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Message } from "../../../../llm-core/src/index.js";
-import { serializeConversation, truncateForSummary } from "./utils.js";
+import { serializeConversation } from "./utils.js";
 
 describe("serializeConversation", () => {
   it.each([
@@ -33,23 +33,18 @@ describe("serializeConversation", () => {
 
     expect(serializeConversation(messages)).toBe(`[Tool result]: ${expected}`);
   });
-});
 
-describe("truncateForSummary", () => {
-  it("returns the original text when it fits within maxChars", () => {
-    expect(truncateForSummary("hello", 100)).toBe("hello");
-  });
+  it("keeps truncated tool results UTF-16 safe and reports the exact omitted count", () => {
+    const prefix = "a".repeat(1_999);
+    const messages = [
+      {
+        role: "toolResult",
+        content: [{ type: "toolResult", content: `${prefix}🚀tail` }],
+      },
+    ] as unknown as Message[];
 
-  it("truncates long text with a summary notice", () => {
-    const input = "x".repeat(200);
-    const result = truncateForSummary(input, 100);
-    expect(result.length).toBeLessThan(input.length);
-    expect(result).toContain("more characters truncated");
-  });
-
-  it("does not split a surrogate pair at the truncation boundary", () => {
-    const input = `aa🚀${"b".repeat(200)}`;
-    const result = truncateForSummary(input, 80);
-    expect(result).not.toContain("�");
+    expect(serializeConversation(messages)).toBe(
+      `[Tool result]: ${prefix}\n\n[... 6 more characters truncated]`,
+    );
   });
 });

--- a/packages/agent-core/src/harness/compaction/utils.ts
+++ b/packages/agent-core/src/harness/compaction/utils.ts
@@ -102,7 +102,7 @@ function safeJsonStringify(value: unknown): string {
   }
 }
 
-export function truncateForSummary(text: string, maxChars: number): string {
+function truncateForSummary(text: string, maxChars: number): string {
   if (text.length <= maxChars) {
     return text;
   }

--- a/packages/agent-core/src/harness/compaction/utils.ts
+++ b/packages/agent-core/src/harness/compaction/utils.ts
@@ -1,4 +1,5 @@
 // Agent Core helper module supports utils behavior.
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { Message } from "../../../../llm-core/src/index.js";
 import type { AgentMessage } from "../../types.js";
 
@@ -101,12 +102,13 @@ function safeJsonStringify(value: unknown): string {
   }
 }
 
-function truncateForSummary(text: string, maxChars: number): string {
+export function truncateForSummary(text: string, maxChars: number): string {
   if (text.length <= maxChars) {
     return text;
   }
-  const truncatedChars = text.length - maxChars;
-  return `${text.slice(0, maxChars)}\n\n[... ${truncatedChars} more characters truncated]`;
+  const sliced = truncateUtf16Safe(text, maxChars);
+  const truncatedChars = text.length - sliced.length;
+  return `${sliced}\n\n[... ${truncatedChars} more characters truncated]`;
 }
 
 /** Extract text that compaction both estimates and includes in summary prompts. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1864,6 +1864,9 @@ importers:
       '@openclaw/ai':
         specifier: workspace:*
         version: link:../ai
+      '@openclaw/normalization-core':
+        specifier: workspace:*
+        version: link:../normalization-core
       typebox:
         specifier: 1.3.3
         version: 1.3.3


### PR DESCRIPTION
## What Problem This Solves

Compaction and short-term memory snippets could split a UTF-16 surrogate pair when a length boundary landed inside an emoji or another supplementary Unicode character.

## Why This Change Was Made

Compaction now uses the shared normalization helper and reports the omitted count from the actual safe prefix. Memory-core reaches the same helper through the supported plugin SDK facade. The reviewed fix keeps helpers private and tests the public serialization, recall-store, and promotion paths rather than exporting internals for tests.

## User Impact

Compaction summaries and memory snippets remain valid Unicode at truncation boundaries. The output and limits for ASCII and already-short text remain unchanged.

## Evidence

- `node scripts/run-vitest.mjs packages/agent-core/src/harness/compaction/utils.test.ts` — 3 passed.
- Focused memory-core extension run for `UTF-16 snippet bounds` — 2 passed, 91 skipped.
- Regression assertions cover exact serialized output, exact omitted count, persisted recall snippets, and promoted `MEMORY.md` content.
- Source-blind `node --import tsx` runtime probe exercised actual compaction serialization plus SQLite-backed recall persistence and promotion output: all three reported `hasUnpairedSurrogate: false`; exact safe prefixes and omitted count matched.
- Fresh autoreview: clean; patch judged correct with 0.98 confidence.
- Agent-core now declares its direct normalization-core workspace dependency; memory-core uses `openclaw/plugin-sdk/text-utility-runtime`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
