### PR TITLE
fix(ui): keep workboard capture text truncation UTF-16 safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Control UI Workboard session capture:** preserve complete emoji and other supplementary Unicode characters when truncating captured titles and notes. (#102544) Thanks @maweibin.
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI Workboard session capture:** preserve complete emoji and other supplementary Unicode characters when truncating captured titles and notes. (#102544) Thanks @maweibin.
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.

--- a/ui/src/lib/workboard/index.ts
+++ b/ui/src/lib/workboard/index.ts
@@ -2909,7 +2909,7 @@ function clampSessionCaptureText(value: string): string {
   if (compact.length <= SESSION_CAPTURE_TEXT_MAX_CHARS) {
     return compact;
   }
-  return `${compact.slice(0, SESSION_CAPTURE_TEXT_MAX_CHARS - 3).trimEnd()}...`;
+  return `${truncateUtf16Safe(compact, SESSION_CAPTURE_TEXT_MAX_CHARS - 3).trimEnd()}...`;
 }
 
 function clampSessionCaptureTitle(value: string): string {
@@ -2917,7 +2917,7 @@ function clampSessionCaptureTitle(value: string): string {
   if (compact.length <= WORKBOARD_CAPTURE_TITLE_MAX_CHARS) {
     return compact;
   }
-  return `${compact.slice(0, WORKBOARD_CAPTURE_TITLE_MAX_CHARS - 3).trimEnd()}...`;
+  return `${truncateUtf16Safe(compact, WORKBOARD_CAPTURE_TITLE_MAX_CHARS - 3).trimEnd()}...`;
 }
 
 function sessionTitle(session: GatewaySessionRow, recentUserText: string | null): string {

--- a/ui/src/pages/workboard/data.test.ts
+++ b/ui/src/pages/workboard/data.test.ts
@@ -3440,18 +3440,21 @@ describe("workboard controller", () => {
     );
   });
 
-  it("clamps long session labels before creating captured cards", async () => {
+  it("clamps captured session fields without splitting surrogate pairs", async () => {
     const host = {};
-    const longLabel = "x".repeat(220);
+    const titlePrefix = "x".repeat(176);
+    const textPrefix = "y".repeat(696);
     const client = createClient((method) => {
       if (method === "workboard.cards.list") {
         return { cards: [], statuses: ["todo"] };
       }
       if (method === "chat.history") {
-        return { messages: [] };
+        return {
+          messages: [{ role: "user", content: [{ type: "text", text: `${textPrefix}😀tail` }] }],
+        };
       }
       if (method === "workboard.cards.create") {
-        return { card: { ...sampleCard, title: `${"x".repeat(177)}...` } };
+        return { card: { ...sampleCard, title: `${titlePrefix}...` } };
       }
       return {};
     });
@@ -3459,14 +3462,17 @@ describe("workboard controller", () => {
     await captureSessionToWorkboard({
       host,
       client: client as never,
-      session: { ...sampleSession, label: longLabel },
+      session: { ...sampleSession, label: `${titlePrefix}😀tail` },
     });
 
     expect(client.request).toHaveBeenNthCalledWith(
       3,
       "workboard.cards.create",
       expect.objectContaining({
-        title: `${"x".repeat(177)}...`,
+        title: `${titlePrefix}...`,
+        notes: [`Session: ${sampleSession.key}`, "", `Recent user prompt: ${textPrefix}...`].join(
+          "\n",
+        ),
       }),
     );
   });


### PR DESCRIPTION
## What Problem This Solves

Workboard session-capture titles and notes used raw UTF-16 code-unit slices. If a length boundary landed between an emoji's surrogate halves, the captured card contained malformed text.

## Why This Change Was Made

Both capture clamps now use the shared `truncateUtf16Safe` helper already owned by the Workboard module. The reviewed patch keeps the private helpers private and covers them through `captureSessionToWorkboard` instead of a helper-only probe.

## User Impact

Long captured session labels, user prompts, and assistant notes remain valid Unicode at the Workboard limits. Short text and ASCII truncation behavior are unchanged.

## Evidence

- Added a public-path regression that creates a Workboard card with an emoji straddling both the 177-code-unit title prefix and 697-code-unit note prefix.
- Focused `ui/src/pages/workboard/data.test.ts` run — 1 passed, 179 skipped.
- Exact create-request assertions verify the title and notes contain the complete-code-point prefixes plus the existing ellipses.
- Fresh autoreview — clean, 0.99 confidence.

AI-assisted: Claude Code
