### PR TITLE
fix(memory-host): use truncateUtf16Safe for QMD stderr context truncation

### DIFF
--- a/packages/memory-host-sdk/src/host/qmd-query-parser.test.ts
+++ b/packages/memory-host-sdk/src/host/qmd-query-parser.test.ts
@@ -60,6 +60,15 @@ complete`,
     expect(parseQmdQueryJson("", "[qmd] warning: no results found\n")).toStrictEqual([]);
   });
 
+  it("keeps bounded stderr context UTF-16 safe", () => {
+    const prefix = "a".repeat(116);
+    const stderr = `${prefix}😀${"b".repeat(120)}`;
+
+    expect(() => parseQmdQueryJson("", stderr)).toThrow(
+      `qmd query returned invalid JSON: stdout empty (stderr: ${prefix}...)`,
+    );
+  });
+
   it("does not treat arbitrary non-marker text as no-results output", () => {
     expect(() =>
       parseQmdQueryJson("warning: search completed; no results found for this query", ""),

--- a/packages/memory-host-sdk/src/host/qmd-query-parser.ts
+++ b/packages/memory-host-sdk/src/host/qmd-query-parser.ts
@@ -1,4 +1,5 @@
 // Memory Host SDK module implements qmd query parser behavior.
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatErrorMessage } from "./error-utils.js";
 import { normalizeLowercaseStringOrEmpty } from "./string-utils.js";
 
@@ -81,7 +82,7 @@ function isQmdNoResultsLine(line: string): boolean {
 
 /** Bound stderr context included in parse errors. */
 function summarizeQmdStderr(raw: string): string {
-  return raw.length <= 120 ? raw : `${raw.slice(0, 117)}...`;
+  return raw.length <= 120 ? raw : `${truncateUtf16Safe(raw, 117)}...`;
 }
 
 /** Parse and normalize a strict qmd JSON array payload. */


### PR DESCRIPTION
## What Problem This Solves

QMD stderr excerpts were truncated with a raw UTF-16 slice. When the cutoff landed between an emoji's surrogate halves, the resulting error text contained an unpaired surrogate.

## Why This Change Was Made

Use the repository's existing `truncateUtf16Safe` boundary helper at the QMD parser's owned stderr limit, preserving the same maximum and suffix while keeping output valid Unicode.

## User Impact

QMD parse errors remain readable when stderr contains emoji or other supplementary Unicode characters at the truncation boundary.

## Evidence

- Added public parser regression coverage with an emoji crossing the 117-code-unit boundary.
- `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/qmd-query-parser.test.ts` — 9 tests passed.
- Fresh autoreview: clean, no accepted/actionable findings (0.99).

## Files Changed

| File | Change |
|------|--------|
| `packages/memory-host-sdk/src/host/qmd-query-parser.ts` | Replace the unsafe stderr slice with `truncateUtf16Safe`. |
| `packages/memory-host-sdk/src/host/qmd-query-parser.test.ts` | Add boundary regression coverage. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
