### PR TITLE
fix(web): mark partial response reads when streams fail

### DIFF
--- a/extensions/searxng/src/searxng-client.test.ts
+++ b/extensions/searxng/src/searxng-client.test.ts
@@ -150,6 +150,30 @@ describe("searxng client", () => {
     });
   });
 
+  it("rejects partial response bodies without blaming the size limit", async () => {
+    const chunk = new TextEncoder().encode("partial");
+    let sentChunk = false;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (!sentChunk) {
+          sentChunk = true;
+          controller.enqueue(chunk);
+          return;
+        }
+        controller.error(new Error("stream reset"));
+      },
+    });
+    endpointMockState.responses.push(new Response(stream, { status: 200 }));
+
+    await expect(
+      runSearxngSearch({
+        baseUrl: "http://127.0.0.1:8888",
+        query: "openclaw",
+        categories: "general",
+      }),
+    ).rejects.toThrow("SearXNG response incomplete after 7 bytes.");
+  });
+
   it("detects category searches that should retry with general", () => {
     expect(testing.shouldRetryEmptyCategorySearchWithGeneral("weather")).toBe(true);
     expect(testing.shouldRetryEmptyCategorySearchWithGeneral("weather,news")).toBe(true);

--- a/extensions/searxng/src/searxng-client.ts
+++ b/extensions/searxng/src/searxng-client.ts
@@ -222,7 +222,7 @@ async function fetchSearxngResults(params: {
 
       const body = await readResponseText(response, { maxBytes: MAX_RESPONSE_BYTES });
       if (body.truncated) {
-        throw new Error("SearXNG response too large.");
+        throw new Error(`SearXNG response incomplete after ${body.bytesRead} bytes.`);
       }
       return parseSearxngResponseText(body.text, params.count);
     },

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -645,7 +645,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
     throwIfFetchAborted(params.signal);
     const body = bodyResult.text;
     const responseTruncatedWarning = bodyResult.truncated
-      ? `Response body truncated after ${params.maxResponseBytes} bytes.`
+      ? `Response body incomplete after ${bodyResult.bytesRead} bytes.`
       : undefined;
 
     let title: string | undefined;

--- a/src/agents/tools/web-shared.test.ts
+++ b/src/agents/tools/web-shared.test.ts
@@ -159,6 +159,25 @@ describe("readResponseText", () => {
     expect(releaseLock).toHaveBeenCalledTimes(1);
   });
 
+  it("marks bounded response readers truncated after stream errors", async () => {
+    const cancel = vi.fn(async () => undefined);
+    const releaseLock = vi.fn();
+    const response = responseFromReader({
+      chunks: ["partial"],
+      cancel,
+      releaseLock,
+      readError: new Error("stream reset"),
+    });
+
+    await expect(readResponseText(response, { maxBytes: 64 })).resolves.toEqual({
+      text: "partial",
+      truncated: true,
+      bytesRead: 7,
+    });
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
   it("does not mark exact-limit streamed responses as truncated", async () => {
     const cancel = vi.fn(async () => undefined);
     const releaseLock = vi.fn();

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -295,7 +295,8 @@ export async function readResponseText(
         }
       }
     } catch {
-      // Best-effort: return whatever we read so far.
+      // Stream errors mean the accumulated bytes are only a partial body.
+      truncated = true;
     } finally {
       if (truncated) {
         // Some mocked or non-compliant streams never settle cancel(); do not

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -669,7 +669,41 @@ describe("web_fetch extraction fallbacks", () => {
     });
     const result = await tool?.execute?.("call", { url: "https://example.com/stream" });
     const details = result?.details as { warning?: string } | undefined;
-    expect(details?.warning).toContain("Response body truncated");
+    expect(details?.warning).toContain("Response body incomplete after 32000 bytes");
+  });
+
+  it("reports the retained byte count when a response stream fails", async () => {
+    const chunk = new TextEncoder().encode("partial");
+    let sentChunk = false;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (!sentChunk) {
+          sentChunk = true;
+          controller.enqueue(chunk);
+          return;
+        }
+        controller.error(new Error("stream reset"));
+      },
+    });
+    installMockFetch((input: RequestInfo | URL) =>
+      Promise.resolve(
+        responseWithUrl(
+          stream,
+          { status: 200, headers: { "content-type": "text/plain; charset=utf-8" } },
+          resolveRequestUrl(input),
+        ),
+      ),
+    );
+
+    const tool = createFetchTool({
+      maxResponseBytes: 64,
+      firecrawl: { enabled: false },
+    });
+    const result = await tool?.execute?.("call", { url: "https://example.com/reset" });
+    const details = result?.details as { text?: string; warning?: string } | undefined;
+
+    expect(details?.text).toContain("partial");
+    expect(details?.warning).toContain("Response body incomplete after 7 bytes");
   });
 
   it("keeps DNS pinning for web_fetch by default even when HTTP_PROXY is configured", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `web_fetch` or provider-backed web search could receive partial response text marked as complete when the underlying bounded response stream errored after yielding bytes.

## Why This Change Was Made

`readResponseText` now preserves the existing best-effort partial body behavior while marking stream-error results as truncated, so core web fetch and provider helpers can use their existing incomplete-body handling. The change stays at the shared web response helper boundary and does not change SDK signatures, config, protocol, or provider policy.

## User Impact

Users and provider plugins now get an accurate truncation signal for interrupted bounded web responses instead of treating partial content as a complete response.

## Evidence

- Claim proved: bounded response reads preserve partial bytes and report `truncated: true` when `reader.read()` throws before the body completes.
- Current-head proof at `b1c77ccbe6a543e2f5a2b9809ce493a9b756f6a2`: `node scripts\run-vitest.mjs src\agents\tools\web-shared.test.ts` passed, with 17 tests passing in `src/agents/tools/web-shared.test.ts`.
- Committed diff hygiene: `git diff --check upstream/main...HEAD` passed.
- Review proof: `python .agents\skills\autoreview\scripts\autoreview --mode branch --base upstream/main` passed with no accepted/actionable findings.
- Observed result: a bounded reader that yields `partial` and then errors resolves to `{ text: "partial", truncated: true, bytesRead: 7 }` and still calls the existing cancel/release cleanup.