### PR TITLE
fix(active-memory): use truncateUtf16Safe for log value truncation

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -4812,13 +4812,14 @@ describe("active-memory plugin", () => {
     ).not.toEqual([]);
   });
 
-  it("caps active-memory log field lengths", async () => {
+  it("caps active-memory log field lengths without splitting surrogate pairs", async () => {
     api.pluginConfig = {
       agents: ["main"],
       logging: true,
     };
     plugin.register(api as unknown as OpenClawPluginApi);
-    const hugeSession = `agent:main:${"x".repeat(500)}`;
+    const sessionPrefix = `agent:main:${"x".repeat(288)}`;
+    const hugeSession = `${sessionPrefix}😀tail`;
 
     await hooks.before_prompt_build(
       { prompt: "what wings should i order? long log value", messages: [] },
@@ -4836,7 +4837,8 @@ describe("active-memory plugin", () => {
     const startLine = infoLines.find((line: string) => line.includes(" start timeoutMs="));
     const line = requireNonEmptyString(startLine, "active memory start log line missing");
     expect(line.length).toBeLessThan(500);
-    expect(line).toContain("...");
+    expect(line).toContain(`session=${sessionPrefix}...`);
+    expect(line).not.toMatch(/[\uD800-\uDFFF]/u);
   });
 
   it("uses a canonical agent session key when only sessionId is available", async () => {

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -1434,7 +1434,7 @@ function toSingleLineLogValue(value: unknown): string {
     .replace(/\s+/g, " ")
     .trim();
   return singleLine.length > MAX_LOG_VALUE_CHARS
-    ? `${singleLine.slice(0, MAX_LOG_VALUE_CHARS)}...`
+    ? `${truncateUtf16Safe(singleLine, MAX_LOG_VALUE_CHARS)}...`
     : singleLine;
 }
 

--- a/extensions/codex/src/app-server/dynamic-tool-execution.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.ts
@@ -2,7 +2,6 @@
  * Timeout, terminal-release, and diagnostic helpers for Codex dynamic tool
  * calls.
  */
-import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   embeddedAgentLog,
   formatToolExecutionErrorMessage,
@@ -62,7 +61,7 @@ function normalizeLogField(value: unknown): string | undefined {
     return undefined;
   }
   return normalized.length > LOG_FIELD_MAX_LENGTH
-    ? `${truncateUtf16Safe(normalized, LOG_FIELD_MAX_LENGTH - 3)}...`
+    ? `${normalized.slice(0, LOG_FIELD_MAX_LENGTH - 3)}...`
     : normalized;
 }
 

--- a/extensions/codex/src/app-server/dynamic-tool-execution.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.ts
@@ -2,6 +2,7 @@
  * Timeout, terminal-release, and diagnostic helpers for Codex dynamic tool
  * calls.
  */
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   embeddedAgentLog,
   formatToolExecutionErrorMessage,
@@ -61,7 +62,7 @@ function normalizeLogField(value: unknown): string | undefined {
     return undefined;
   }
   return normalized.length > LOG_FIELD_MAX_LENGTH
-    ? `${normalized.slice(0, LOG_FIELD_MAX_LENGTH - 3)}...`
+    ? `${truncateUtf16Safe(normalized, LOG_FIELD_MAX_LENGTH - 3)}...`
     : normalized;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Active Memory sanitizes session identifiers, model references, and failure messages into bounded single-line log values. The existing 300-code-unit cap used `slice`, so an astral character crossing the boundary could leave malformed UTF-16 in those logs.

## Why This Change Was Made

Replace the final fixed-width slice with the existing shared `truncateUtf16Safe` utility. New local logic is unnecessary: the utility preserves the established cap while dropping only a high surrogate that would otherwise be split.

The follow-up regression improves the existing public hook-level log-limit test. It supplies a real session key with an emoji straddling the 300-code-unit boundary and verifies the complete session field plus the absence of unpaired surrogates in the emitted start log.

## User Impact

Active Memory diagnostics remain single-line and bounded, but no longer contain malformed Unicode at the length limit. No config, recall, cache, or API behavior changes.

## Evidence

- `node ../../node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extension-active-memory.config.ts extensions/active-memory/index.test.ts -t 'caps active-memory log field lengths'` — 1 passed, 156 skipped.
- `oxfmt` completed for the changed test.
- `git diff --check` passed.
- Relevant callers and sibling log rendering were inspected; every `toSingleLineLogValue` consumer benefits from the same canonical boundary.
- Exact tested head: `94fb898bd4d1aca94648d717687973bc745ec0ac`.

## Risk

Low. One internal log renderer now uses the shared truncation invariant; text not splitting a surrogate pair is unchanged.

## AI-assisted

This PR was generated with Claude Code and improved/reviewed by a maintainer agent.
