### PR TITLE
fix(logging): keep bounded log text UTF-16 safe

### DIFF
--- a/src/logging/diagnostic-log-events.test.ts
+++ b/src/logging/diagnostic-log-events.test.ts
@@ -143,6 +143,23 @@ describe("diagnostic log events", () => {
     expect(Object.hasOwn(event, "argsJson")).toBe(false);
   });
 
+  it("keeps bounded diagnostic messages UTF-16 safe", async () => {
+    const received: Array<Extract<DiagnosticEventPayload, { type: "log.record" }>> = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => {
+      if (event.type === "log.record") {
+        received.push(event);
+      }
+    });
+    const prefix = "x".repeat(4_095);
+
+    getChildLogger({ subsystem: "diagnostic" }).info(`${prefix}😀tail`);
+    await flushDiagnosticEvents();
+    unsubscribe();
+
+    // The post-redaction bound keeps the first dot from the initial truncation marker.
+    expect(received.at(-1)?.message).toBe(`${prefix}....(truncated)`);
+  });
+
   it("drops sensitive, blocked, and excess log attribute keys without copying large objects", async () => {
     const received: Array<Extract<DiagnosticEventPayload, { type: "log.record" }>> = [];
     const unsubscribe = onInternalDiagnosticEvent((evt) => {

--- a/src/logging/logger-redaction-behavior.test.ts
+++ b/src/logging/logger-redaction-behavior.test.ts
@@ -192,6 +192,18 @@ describe("file log redaction", () => {
     expect(record.message).toBe("request completed");
   });
 
+  it("keeps bounded file-log messages UTF-16 safe", () => {
+    const logPath = logPathTracker.nextPath();
+    setLoggerOverride({ level: "info", file: logPath });
+    const prefix = "x".repeat(4_095);
+
+    getLogger().info(`${prefix}😀tail`);
+
+    const [line] = fs.readFileSync(logPath, "utf8").trim().split("\n");
+    const record = JSON.parse(line ?? "{}") as Record<string, unknown>;
+    expect(record.message).toBe(`${prefix}...(truncated)`);
+  });
+
   it("retries hostname resolution after an empty value and caches the first real value", () => {
     const logPath = logPathTracker.nextPath();
     setLoggerOverride({ level: "info", file: logPath });

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { Logger as TsLogger } from "tslog";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { OpenClawConfig } from "../config/types.js";
 import {
   emitDiagnosticEvent,
@@ -90,7 +91,7 @@ let cachedHostname: string | null = null;
 type DiagnosticLogAttributes = Record<string, string | number | boolean>;
 
 function clampDiagnosticLogText(value: string, maxChars: number): string {
-  return value.length > maxChars ? `${value.slice(0, maxChars)}...(truncated)` : value;
+  return value.length > maxChars ? `${truncateUtf16Safe(value, maxChars)}...(truncated)` : value;
 }
 
 function sanitizeDiagnosticLogText(value: string, maxChars: number): string {

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -2,8 +2,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { Logger as TsLogger } from "tslog";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { Logger as TsLogger } from "tslog";
 import type { OpenClawConfig } from "../config/types.js";
 import {
   emitDiagnosticEvent,
@@ -218,7 +218,7 @@ function getSortedNumericLogArgs(logObj: TsLogRecord): unknown[] {
 }
 
 function clampFileLogText(value: string, maxChars: number): string {
-  return value.length > maxChars ? `${value.slice(0, maxChars)}...(truncated)` : value;
+  return value.length > maxChars ? `${truncateUtf16Safe(value, maxChars)}...(truncated)` : value;
 }
 
 function normalizeFileLogContextValue(value: unknown): string | undefined {


### PR DESCRIPTION
## What Problem This Solves

Bounded logger text used raw UTF-16 code-unit slices. A boundary inside an emoji could leave an unpaired surrogate in diagnostic events or JSONL file-log messages.

## Why This Change Was Made

The diagnostic and file-log clamps in `src/logging/logger.ts` now share the existing UTF-16-safe truncation helper. Review expanded the original one-sided diagnostic fix to the sibling file-log path in the same owner module.

## User Impact

Long diagnostic messages, diagnostic attributes, file-log messages, and promoted file-log context remain valid Unicode at their existing size limits. Markers, limits, redaction order, and short-message behavior are unchanged.

## Evidence

- Added public transport-level regressions for an emoji straddling the 4,096-code-unit diagnostic and file-log boundaries.
- `vitest.logging.config.ts` focused run — 2 files passed; 2 tests passed, 15 skipped.
- The first attempt exposed and preserved the existing two-stage diagnostic clamp marker behavior; the exact regression reflects the production output.
- Fresh autoreview — clean, 0.98 confidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
