### PR TITLE
fix(agents): keep cleanup timeout details UTF-16 safe

### DIFF
--- a/src/agents/run-cleanup-timeout.test.ts
+++ b/src/agents/run-cleanup-timeout.test.ts
@@ -4,6 +4,7 @@ import { runAgentCleanupStep } from "./run-cleanup-timeout.js";
 
 const AGENT_CLEANUP_STEP_TIMEOUT_MS = 10_000;
 const CLEANUP_TIMEOUT_DETAILS_MAX_CHARS = 512;
+const CLEANUP_TIMEOUT_DETAILS_TRUNCATED_SUFFIX = "...[truncated]";
 
 describe("agent cleanup timeout", () => {
   const log = {
@@ -113,6 +114,33 @@ describe("agent cleanup timeout", () => {
         CLEANUP_TIMEOUT_DETAILS_MAX_CHARS +
         1,
     );
+  });
+
+  it("keeps truncated cleanup timeout details UTF-16 safe", async () => {
+    const cleanup = vi.fn(async () => new Promise<never>(() => {}));
+    const prefixLength =
+      CLEANUP_TIMEOUT_DETAILS_MAX_CHARS - CLEANUP_TIMEOUT_DETAILS_TRUNCATED_SUFFIX.length;
+    const detailsPrefix = "a".repeat(prefixLength - 1);
+    const oversizedDetails = `${detailsPrefix}😀${"b".repeat(CLEANUP_TIMEOUT_DETAILS_MAX_CHARS)}`;
+
+    const result = runAgentCleanupStep({
+      runId: "run-trajectory",
+      sessionId: "session-trajectory",
+      step: "agent-trajectory-flush",
+      cleanup,
+      log,
+      timeoutMs: 5,
+      getTimeoutDetails: () => oversizedDetails,
+    });
+
+    await vi.advanceTimersByTimeAsync(5);
+    await expect(result).resolves.toBeUndefined();
+
+    const message = String(log.warn.mock.calls.at(-1)?.[0] ?? "");
+    expect(message).toContain(
+      ` details=${detailsPrefix}${CLEANUP_TIMEOUT_DETAILS_TRUNCATED_SUFFIX}`,
+    );
+    expect(message).not.toContain("�");
   });
 
   it("does not fail cleanup when timeout details throw", async () => {
@@ -257,31 +285,28 @@ describe("agent cleanup timeout", () => {
         OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS: "0x10",
       },
     },
-  ])(
-    "ignores invalid cleanup timeout environment values",
-    async ({ runId, sessionId, env }) => {
-      const cleanup = vi.fn(async () => new Promise<never>(() => {}));
+  ])("ignores invalid cleanup timeout environment values", async ({ runId, sessionId, env }) => {
+    const cleanup = vi.fn(async () => new Promise<never>(() => {}));
 
-      const result = runAgentCleanupStep({
-        runId,
-        sessionId,
-        step: "openclaw-trajectory-flush",
-        cleanup,
-        log,
-        env,
-      });
+    const result = runAgentCleanupStep({
+      runId,
+      sessionId,
+      step: "openclaw-trajectory-flush",
+      cleanup,
+      log,
+      env,
+    });
 
-      await vi.advanceTimersByTimeAsync(AGENT_CLEANUP_STEP_TIMEOUT_MS - 1);
-      expect(log.warn).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(AGENT_CLEANUP_STEP_TIMEOUT_MS - 1);
+    expect(log.warn).not.toHaveBeenCalled();
 
-      await vi.advanceTimersByTimeAsync(1);
-      await expect(result).resolves.toBeUndefined();
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(result).resolves.toBeUndefined();
 
-      expect(log.warn).toHaveBeenCalledWith(
-        `agent cleanup timed out: runId=${runId} sessionId=${sessionId} step=openclaw-trajectory-flush timeoutMs=10000`,
-      );
-    },
-  );
+    expect(log.warn).toHaveBeenCalledWith(
+      `agent cleanup timed out: runId=${runId} sessionId=${sessionId} step=openclaw-trajectory-flush timeoutMs=10000`,
+    );
+  });
 
   it("logs cleanup rejection without throwing", async () => {
     await expect(

--- a/src/agents/run-cleanup-timeout.ts
+++ b/src/agents/run-cleanup-timeout.ts
@@ -4,6 +4,7 @@
  * Bounds cleanup steps so run completion cannot hang forever while preserving late-failure diagnostics.
  */
 import { resolveOptionalIntegerOption } from "@openclaw/normalization-core/number-coercion";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatErrorMessage } from "../infra/errors.js";
 import { parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
 
@@ -47,7 +48,7 @@ function truncateCleanupTimeoutDetails(value: string): string {
     0,
     CLEANUP_TIMEOUT_DETAILS_MAX_CHARS - CLEANUP_TIMEOUT_DETAILS_TRUNCATED_SUFFIX.length,
   );
-  return `${value.slice(0, prefixLength)}${CLEANUP_TIMEOUT_DETAILS_TRUNCATED_SUFFIX}`;
+  return `${truncateUtf16Safe(value, prefixLength)}${CLEANUP_TIMEOUT_DETAILS_TRUNCATED_SUFFIX}`;
 }
 
 function resolveAgentCleanupStepTimeoutMs(params: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agent cleanup timeout warnings could emit malformed diagnostic text when cleanup timeout details were truncated at a UTF-16 surrogate boundary.

## Why This Change Was Made

Cleanup timeout diagnostics now use the shared UTF-16-safe truncation helper before appending the truncation suffix. This keeps the existing 512-character diagnostic bound and does not change cleanup timeout scheduling, timeout values, or late-rejection handling.

## User Impact

Operators and developers can rely on cleanup timeout warning details to remain readable even when oversized diagnostics contain emoji or other surrogate-pair characters at the truncation boundary.

## Evidence

- Validation `final-cleanup-timeout-utf16-unit` (pass, exit_code=0):

  ```text
   RUN  v4.1.9 [local path redacted]

   Test Files  1 passed (1)
        Tests  13 passed (13)
     Duration  1.15s (transform 581ms, setup 571ms, import 57ms, tests 175ms, environment 0ms)
  ```

- Validation `final-cleanup-timeout-utf16-runtime` (pass, exit_code=0):

  ```text
  agent cleanup timed out: runId=runtime-run sessionId=runtime-session step=agent-trajectory-flush timeoutMs=1 details=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...[truncated]
  ```

- Validation `final-diff-check` (pass, exit_code=0):

  ```text
  git diff --check origin/main...HEAD
  ```
