### PR TITLE
fix(telegram): use truncateUtf16Safe for raw update log truncation

### DIFF
--- a/extensions/telegram/src/bot-core.raw-update-log.test.ts
+++ b/extensions/telegram/src/bot-core.raw-update-log.test.ts
@@ -1,8 +1,8 @@
 // Telegram tests cover bot core.raw update log plugin behavior.
 import { describe, expect, it } from "vitest";
-import { stringifyTelegramRawUpdateForLog } from "./raw-update-log.js";
+import { formatTelegramRawUpdateForLog } from "./raw-update-log.js";
 
-describe("stringifyTelegramRawUpdateForLog", () => {
+describe("formatTelegramRawUpdateForLog", () => {
   it("redacts private Telegram raw update fields before verbose logging", () => {
     const update = {
       update_id: 98765,
@@ -45,7 +45,7 @@ describe("stringifyTelegramRawUpdateForLog", () => {
       },
     };
 
-    const rawLog = stringifyTelegramRawUpdateForLog(update);
+    const rawLog = formatTelegramRawUpdateForLog(update);
 
     expect(rawLog).toContain('"update_id":98765');
     expect(rawLog).toContain('"message_id":44');
@@ -138,7 +138,7 @@ describe("stringifyTelegramRawUpdateForLog", () => {
       },
     };
 
-    const rawLog = stringifyTelegramRawUpdateForLog(update);
+    const rawLog = formatTelegramRawUpdateForLog(update);
 
     expect(rawLog).toContain('"update_id":45678');
     expect(rawLog).toContain('"message_id":99');
@@ -176,7 +176,7 @@ describe("stringifyTelegramRawUpdateForLog", () => {
 
   it("truncates long raw update strings without splitting UTF-16 surrogate pairs", () => {
     const prefix = "a".repeat(499);
-    const rawLog = stringifyTelegramRawUpdateForLog({
+    const rawLog = formatTelegramRawUpdateForLog({
       update_id: 123,
       diagnostic: `${prefix}\uD83D\uDE80tail`,
     });
@@ -187,5 +187,13 @@ describe("stringifyTelegramRawUpdateForLog", () => {
     expect(parsed.diagnostic).not.toContain("\uDE80");
     expect(rawLog).not.toContain("\\ud83d");
     expect(rawLog).not.toContain("\\ude80");
+  });
+
+  it("truncates the complete raw update log without splitting surrogate pairs", () => {
+    const keyPrefix = "x".repeat(7997);
+    const rawLog = formatTelegramRawUpdateForLog({ [`${keyPrefix}😀tail`]: 1 });
+
+    expect(rawLog).toBe(`{"${keyPrefix}...`);
+    expect(rawLog).not.toMatch(/[\uD800-\uDFFF]/u);
   });
 });

--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -18,7 +18,6 @@ import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
 import { DEFAULT_GROUP_HISTORY_LIMIT, type HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import { danger, logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
-import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { createNonExitingRuntime, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -57,7 +56,7 @@ import {
 } from "./group-history-window.js";
 import { TELEGRAM_TEXT_CHUNK_LIMIT } from "./outbound-adapter.js";
 import { registerTelegramOutboundGroupHistoryRecorder } from "./outbound-message-context.js";
-import { stringifyTelegramRawUpdateForLog } from "./raw-update-log.js";
+import { formatTelegramRawUpdateForLog } from "./raw-update-log.js";
 import { TELEGRAM_RICH_TEXT_LIMIT } from "./rich-message.js";
 import { createTelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
@@ -242,15 +241,11 @@ export function createTelegramBotCore(
   bot.use(botRuntime.sequentialize(getTelegramSequentialKey));
 
   const rawUpdateLogger = createSubsystemLogger("gateway/channels/telegram/raw-update");
-  const MAX_RAW_UPDATE_CHARS = 8000;
 
   bot.use(async (ctx, next) => {
     if (shouldLogVerbose()) {
       try {
-        const raw = stringifyTelegramRawUpdateForLog(ctx.update);
-        const preview =
-          raw.length > MAX_RAW_UPDATE_CHARS ? `${truncateUtf16Safe(raw, MAX_RAW_UPDATE_CHARS)}...` : raw;
-        rawUpdateLogger.debug(`telegram update: ${preview}`);
+        rawUpdateLogger.debug(`telegram update: ${formatTelegramRawUpdateForLog(ctx.update)}`);
       } catch (err) {
         rawUpdateLogger.debug(`telegram update log failed: ${String(err)}`);
       }

--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -18,6 +18,7 @@ import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
 import { DEFAULT_GROUP_HISTORY_LIMIT, type HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import { danger, logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { createNonExitingRuntime, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -248,7 +249,7 @@ export function createTelegramBotCore(
       try {
         const raw = stringifyTelegramRawUpdateForLog(ctx.update);
         const preview =
-          raw.length > MAX_RAW_UPDATE_CHARS ? `${raw.slice(0, MAX_RAW_UPDATE_CHARS)}...` : raw;
+          raw.length > MAX_RAW_UPDATE_CHARS ? `${truncateUtf16Safe(raw, MAX_RAW_UPDATE_CHARS)}...` : raw;
         rawUpdateLogger.debug(`telegram update: ${preview}`);
       } catch (err) {
         rawUpdateLogger.debug(`telegram update log failed: ${String(err)}`);

--- a/extensions/telegram/src/raw-update-log.ts
+++ b/extensions/telegram/src/raw-update-log.ts
@@ -3,6 +3,7 @@ import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 const MAX_RAW_UPDATE_STRING = 500;
 const MAX_RAW_UPDATE_ARRAY = 20;
+const MAX_RAW_UPDATE_CHARS = 8000;
 const REDACTED_TELEGRAM_FIELD = "[redacted]";
 const TELEGRAM_RAW_UPDATE_ALWAYS_REDACT_KEYS = new Set([
   "added_to_attachment_menu",
@@ -74,7 +75,7 @@ function isTelegramUserObject(value: Record<string, unknown>): boolean {
   );
 }
 
-export function stringifyTelegramRawUpdateForLog(update: unknown): string {
+export function formatTelegramRawUpdateForLog(update: unknown): string {
   const seen = new WeakSet<object>();
   const transform = (value: unknown, key = "", parentKey?: string): unknown => {
     if (shouldRedactTelegramRawUpdateValue(key, parentKey)) {
@@ -109,5 +110,8 @@ export function stringifyTelegramRawUpdateForLog(update: unknown): string {
     }
     return value;
   };
-  return JSON.stringify(transform(update ?? null));
+  const raw = JSON.stringify(transform(update ?? null));
+  return raw.length > MAX_RAW_UPDATE_CHARS
+    ? `${truncateUtf16Safe(raw, MAX_RAW_UPDATE_CHARS)}...`
+    : raw;
 }


### PR DESCRIPTION
## What Problem This Solves

Telegram verbose logging first redacts and serializes an inbound update, then caps the complete log payload at 8,000 UTF-16 code units. That final cap lived separately in `bot-core` and used `slice`, so a surrogate pair crossing the boundary could produce malformed log text even though individual string fields were already safe.

## Why This Change Was Made

Move the complete-payload cap into the existing raw-update log formatter and apply the shared `truncateUtf16Safe` utility there. The formatter now owns redaction, field bounds, serialization, and final log framing as one policy surface; `bot-core` only emits the formatted result.

The regression extends the existing privacy/log formatter suite with an update whose serialized key crosses the 8,000-code-unit boundary. It asserts the complete output and proves there is no dangling surrogate.

## User Impact

Verbose Telegram raw-update logs remain redacted and bounded, but no longer contain malformed UTF-16 at the outer limit. Telegram transport, update handling, authorization, replies, and config are unchanged.

## Evidence

- `node ../../node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/bot-core.raw-update-log.test.ts` — 4 tests passed.
- `oxfmt` completed on all changed files.
- `git diff --check` passed.
- Existing redaction tests still pass alongside both the per-field and complete-payload surrogate-boundary regressions.
- Per the Telegram plugin review guide, live Telegram proof is not required for this isolated verbose-log formatter change; no transport, streaming, topic, callback, authorization, or reply-context behavior changed.

## Risk

Low. The same limits and ellipsis remain; policy moved to its existing formatter owner and valid non-boundary output is unchanged.

## AI-assisted

This PR was generated with Claude Code and refactored/reviewed by a maintainer agent.
