### PR TITLE
fix(acp): handle Gateway replace deltas in translator, not byte-offset slices

### DIFF
--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -621,9 +621,7 @@ describe("acp translator stop reason mapping", () => {
   });
 
   it("emits the full revised text on a replace delta, not a byte-offset slice", async () => {
-    const sessionUpdate = vi.fn(async (_params?: Record<string, unknown>) => {}) as (
-      params: Record<string, unknown>,
-    ) => Promise<void>;
+    const sessionUpdate = vi.fn(async (_params?: Record<string, unknown>) => {});
     const connection = createAcpConnection();
     connection.sessionUpdate = sessionUpdate as typeof connection.sessionUpdate;
     const sessionStore = createInMemorySessionStore();
@@ -707,9 +705,7 @@ describe("acp translator stop reason mapping", () => {
   });
 
   it("emits the full revised text on a replace delta for a shorter revision", async () => {
-    const sessionUpdate = vi.fn(async (_params?: Record<string, unknown>) => {}) as (
-      params: Record<string, unknown>,
-    ) => Promise<void>;
+    const sessionUpdate = vi.fn(async (_params?: Record<string, unknown>) => {});
     const connection = createAcpConnection();
     connection.sessionUpdate = sessionUpdate as typeof connection.sessionUpdate;
     const sessionStore = createInMemorySessionStore();

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -621,9 +621,11 @@ describe("acp translator stop reason mapping", () => {
   });
 
   it("emits the full revised text on a replace delta, not a byte-offset slice", async () => {
-    const sessionUpdateCalls: Record<string, unknown>[] = [];
+    const sessionUpdateCalls: Array<{
+      update?: { sessionUpdate?: string; content?: { text?: string } };
+    }> = [];
     const sessionUpdate = vi.fn(async (params: Record<string, unknown>) => {
-      sessionUpdateCalls.push(params);
+      sessionUpdateCalls.push(params as (typeof sessionUpdateCalls)[number]);
     });
     const connection = createAcpConnection();
     connection.sessionUpdate = sessionUpdate as typeof connection.sessionUpdate;
@@ -708,9 +710,11 @@ describe("acp translator stop reason mapping", () => {
   });
 
   it("emits the full revised text on a replace delta for a shorter revision", async () => {
-    const sessionUpdateCalls: Record<string, unknown>[] = [];
+    const sessionUpdateCalls: Array<{
+      update?: { sessionUpdate?: string; content?: { text?: string } };
+    }> = [];
     const sessionUpdate = vi.fn(async (params: Record<string, unknown>) => {
-      sessionUpdateCalls.push(params);
+      sessionUpdateCalls.push(params as (typeof sessionUpdateCalls)[number]);
     });
     const connection = createAcpConnection();
     connection.sessionUpdate = sessionUpdate as typeof connection.sessionUpdate;

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -620,6 +620,173 @@ describe("acp translator stop reason mapping", () => {
     await expect(promptPromise).resolves.toEqual({ stopReason: "end_turn" });
   });
 
+  it("emits the full revised text on a replace delta, not a byte-offset slice", async () => {
+    const sessionUpdate = vi.fn(() => Promise.resolve());
+    const connection = createAcpConnection();
+    connection.sessionUpdate = sessionUpdate as typeof connection.sessionUpdate;
+    const sessionStore = createInMemorySessionStore();
+    const sessionId = "session-1";
+    const sessionKey = "agent:main:main";
+    sessionStore.createSession({
+      sessionId,
+      sessionKey,
+      cwd: "/tmp",
+    });
+
+    let runId: string | undefined;
+    const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === "chat.send") {
+        runId = params?.idempotencyKey as string | undefined;
+        return new Promise<never>(() => {});
+      }
+      return {};
+    }) as GatewayClient["request"];
+    const agent = new AcpGatewayAgent(connection, createAcpGateway(request), {
+      sessionStore,
+    });
+    const promptPromise = promptAgent(agent, sessionId);
+    await vi.waitFor(() => {
+      expect(runId).toBeTypeOf("string");
+    });
+
+    // Append delta: "Hello world"
+    await agent.handleGatewayEvent(
+      createChatEvent({
+        runId,
+        sessionKey,
+        seq: 1,
+        state: "delta",
+        message: {
+          content: [{ type: "text", text: "Hello world" }],
+        },
+      }),
+    );
+    await Promise.resolve();
+
+    const appendChunks = sessionUpdate.mock.calls
+      .map((call) => call[0])
+      .filter((p) => p?.update?.sessionUpdate === "agent_message_chunk");
+    expect(appendChunks).toHaveLength(1);
+    expect(appendChunks[0].update.content.text).toBe("Hello world");
+
+    // Replace delta: "Hello world" → "Goodbye world" (non-append revision)
+    await agent.handleGatewayEvent(
+      createChatEvent({
+        runId,
+        sessionKey,
+        seq: 2,
+        state: "delta",
+        replace: true,
+        message: {
+          content: [{ type: "text", text: "Goodbye world" }],
+        },
+      }),
+    );
+    await Promise.resolve();
+
+    const allChunks = sessionUpdate.mock.calls
+      .map((call) => call[0])
+      .filter((p) => p?.update?.sessionUpdate === "agent_message_chunk");
+    expect(allChunks).toHaveLength(2);
+    // The replace delta must emit the FULL new text, not a byte-offset slice.
+    // "Goodbye world".slice(11) would be "d" (corrupted), but the fix emits all 13 chars.
+    expect(allChunks[1].update.content.text).toBe("Goodbye world");
+
+    // Cleanup: send a final event to settle the prompt.
+    await agent.handleGatewayEvent(
+      createChatEvent({
+        runId,
+        sessionKey,
+        seq: 3,
+        state: "final",
+      }),
+    );
+    await expect(promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+  });
+
+  it("emits the full revised text on a replace delta for a shorter revision", async () => {
+    const sessionUpdate = vi.fn(() => Promise.resolve());
+    const connection = createAcpConnection();
+    connection.sessionUpdate = sessionUpdate as typeof connection.sessionUpdate;
+    const sessionStore = createInMemorySessionStore();
+    const sessionId = "session-1";
+    const sessionKey = "agent:main:main";
+    sessionStore.createSession({
+      sessionId,
+      sessionKey,
+      cwd: "/tmp",
+    });
+
+    let runId: string | undefined;
+    const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === "chat.send") {
+        runId = params?.idempotencyKey as string | undefined;
+        return new Promise<never>(() => {});
+      }
+      return {};
+    }) as GatewayClient["request"];
+    const agent = new AcpGatewayAgent(connection, createAcpGateway(request), {
+      sessionStore,
+    });
+    const promptPromise = promptAgent(agent, sessionId);
+    await vi.waitFor(() => {
+      expect(runId).toBeTypeOf("string");
+    });
+
+    // Append delta: "Hello world!" (12 chars)
+    await agent.handleGatewayEvent(
+      createChatEvent({
+        runId,
+        sessionKey,
+        seq: 1,
+        state: "delta",
+        message: {
+          content: [{ type: "text", text: "Hello world!" }],
+        },
+      }),
+    );
+    await Promise.resolve();
+
+    const appendChunks = sessionUpdate.mock.calls
+      .map((call) => call[0])
+      .filter((p) => p?.update?.sessionUpdate === "agent_message_chunk");
+    expect(appendChunks).toHaveLength(1);
+    expect(appendChunks[0].update.content.text).toBe("Hello world!");
+
+    // Replace delta: "Hello world!" → "Hi" (shorter revision)
+    await agent.handleGatewayEvent(
+      createChatEvent({
+        runId,
+        sessionKey,
+        seq: 2,
+        state: "delta",
+        replace: true,
+        message: {
+          content: [{ type: "text", text: "Hi" }],
+        },
+      }),
+    );
+    await Promise.resolve();
+
+    const allChunks = sessionUpdate.mock.calls
+      .map((call) => call[0])
+      .filter((p) => p?.update?.sessionUpdate === "agent_message_chunk");
+    expect(allChunks).toHaveLength(2);
+    // Before the fix, "Hi".length (2) <= sentSoFar (12) would return early and
+    // emit nothing. After the fix, the full "Hi" is emitted.
+    expect(allChunks[1].update.content.text).toBe("Hi");
+
+    await agent.handleGatewayEvent(
+      createChatEvent({
+        runId,
+        sessionKey,
+        seq: 3,
+        state: "final",
+      }),
+    );
+    await expect(promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+  });
+
   it("does not let a stale disconnect deadline reject a newer prompt on the same session", async () => {
     vi.useFakeTimers();
     try {

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -621,7 +621,7 @@ describe("acp translator stop reason mapping", () => {
   });
 
   it("emits the full revised text on a replace delta, not a byte-offset slice", async () => {
-    const sessionUpdate = vi.fn(() => Promise.resolve());
+    const sessionUpdate = vi.fn<[Record<string, unknown>], Promise<void>>(async () => {});
     const connection = createAcpConnection();
     connection.sessionUpdate = sessionUpdate as typeof connection.sessionUpdate;
     const sessionStore = createInMemorySessionStore();
@@ -705,7 +705,7 @@ describe("acp translator stop reason mapping", () => {
   });
 
   it("emits the full revised text on a replace delta for a shorter revision", async () => {
-    const sessionUpdate = vi.fn(() => Promise.resolve());
+    const sessionUpdate = vi.fn<[Record<string, unknown>], Promise<void>>(async () => {});
     const connection = createAcpConnection();
     connection.sessionUpdate = sessionUpdate as typeof connection.sessionUpdate;
     const sessionStore = createInMemorySessionStore();

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -621,7 +621,10 @@ describe("acp translator stop reason mapping", () => {
   });
 
   it("emits the full revised text on a replace delta, not a byte-offset slice", async () => {
-    const sessionUpdate = vi.fn(async (_params?: Record<string, unknown>) => {});
+    const sessionUpdateCalls: Record<string, unknown>[] = [];
+    const sessionUpdate = vi.fn(async (params: Record<string, unknown>) => {
+      sessionUpdateCalls.push(params);
+    });
     const connection = createAcpConnection();
     connection.sessionUpdate = sessionUpdate as typeof connection.sessionUpdate;
     const sessionStore = createInMemorySessionStore();
@@ -663,9 +666,9 @@ describe("acp translator stop reason mapping", () => {
     );
     await Promise.resolve();
 
-    const appendChunks = sessionUpdate.mock.calls
-      .map((call) => call[0])
-      .filter((p) => p?.update?.sessionUpdate === "agent_message_chunk");
+    const appendChunks = sessionUpdateCalls.filter(
+      (p) => p?.update?.sessionUpdate === "agent_message_chunk",
+    );
     expect(appendChunks).toHaveLength(1);
     expect(appendChunks[0].update.content.text).toBe("Hello world");
 
@@ -684,9 +687,9 @@ describe("acp translator stop reason mapping", () => {
     );
     await Promise.resolve();
 
-    const allChunks = sessionUpdate.mock.calls
-      .map((call) => call[0])
-      .filter((p) => p?.update?.sessionUpdate === "agent_message_chunk");
+    const allChunks = sessionUpdateCalls.filter(
+      (p) => p?.update?.sessionUpdate === "agent_message_chunk",
+    );
     expect(allChunks).toHaveLength(2);
     // The replace delta must emit the FULL new text, not a byte-offset slice.
     // "Goodbye world".slice(11) would be "d" (corrupted), but the fix emits all 13 chars.
@@ -705,7 +708,10 @@ describe("acp translator stop reason mapping", () => {
   });
 
   it("emits the full revised text on a replace delta for a shorter revision", async () => {
-    const sessionUpdate = vi.fn(async (_params?: Record<string, unknown>) => {});
+    const sessionUpdateCalls: Record<string, unknown>[] = [];
+    const sessionUpdate = vi.fn(async (params: Record<string, unknown>) => {
+      sessionUpdateCalls.push(params);
+    });
     const connection = createAcpConnection();
     connection.sessionUpdate = sessionUpdate as typeof connection.sessionUpdate;
     const sessionStore = createInMemorySessionStore();
@@ -747,9 +753,9 @@ describe("acp translator stop reason mapping", () => {
     );
     await Promise.resolve();
 
-    const appendChunks = sessionUpdate.mock.calls
-      .map((call) => call[0])
-      .filter((p) => p?.update?.sessionUpdate === "agent_message_chunk");
+    const appendChunks = sessionUpdateCalls.filter(
+      (p) => p?.update?.sessionUpdate === "agent_message_chunk",
+    );
     expect(appendChunks).toHaveLength(1);
     expect(appendChunks[0].update.content.text).toBe("Hello world!");
 
@@ -768,9 +774,9 @@ describe("acp translator stop reason mapping", () => {
     );
     await Promise.resolve();
 
-    const allChunks = sessionUpdate.mock.calls
-      .map((call) => call[0])
-      .filter((p) => p?.update?.sessionUpdate === "agent_message_chunk");
+    const allChunks = sessionUpdateCalls.filter(
+      (p) => p?.update?.sessionUpdate === "agent_message_chunk",
+    );
     expect(allChunks).toHaveLength(2);
     // Before the fix, "Hi".length (2) <= sentSoFar (12) would return early and
     // emit nothing. After the fix, the full "Hi" is emitted.

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -672,7 +672,7 @@ describe("acp translator stop reason mapping", () => {
       (p) => p?.update?.sessionUpdate === "agent_message_chunk",
     );
     expect(appendChunks).toHaveLength(1);
-    expect(appendChunks[0].update.content.text).toBe("Hello world");
+    expect(appendChunks[0]!.update!.content!.text).toBe("Hello world");
 
     // Replace delta: "Hello world" → "Goodbye world" (non-append revision)
     await agent.handleGatewayEvent(
@@ -695,7 +695,7 @@ describe("acp translator stop reason mapping", () => {
     expect(allChunks).toHaveLength(2);
     // The replace delta must emit the FULL new text, not a byte-offset slice.
     // "Goodbye world".slice(11) would be "d" (corrupted), but the fix emits all 13 chars.
-    expect(allChunks[1].update.content.text).toBe("Goodbye world");
+    expect(allChunks[1]!.update!.content!.text).toBe("Goodbye world");
 
     // Cleanup: send a final event to settle the prompt.
     await agent.handleGatewayEvent(
@@ -761,7 +761,7 @@ describe("acp translator stop reason mapping", () => {
       (p) => p?.update?.sessionUpdate === "agent_message_chunk",
     );
     expect(appendChunks).toHaveLength(1);
-    expect(appendChunks[0].update.content.text).toBe("Hello world!");
+    expect(appendChunks[0]!.update!.content!.text).toBe("Hello world!");
 
     // Replace delta: "Hello world!" → "Hi" (shorter revision)
     await agent.handleGatewayEvent(
@@ -784,7 +784,7 @@ describe("acp translator stop reason mapping", () => {
     expect(allChunks).toHaveLength(2);
     // Before the fix, "Hi".length (2) <= sentSoFar (12) would return early and
     // emit nothing. After the fix, the full "Hi" is emitted.
-    expect(allChunks[1].update.content.text).toBe("Hi");
+    expect(allChunks[1]!.update!.content!.text).toBe("Hi");
 
     await agent.handleGatewayEvent(
       createChatEvent({

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -621,7 +621,9 @@ describe("acp translator stop reason mapping", () => {
   });
 
   it("emits the full revised text on a replace delta, not a byte-offset slice", async () => {
-    const sessionUpdate = vi.fn<[Record<string, unknown>], Promise<void>>(async () => {});
+    const sessionUpdate = vi.fn(async (_params?: Record<string, unknown>) => {}) as (
+      params: Record<string, unknown>,
+    ) => Promise<void>;
     const connection = createAcpConnection();
     connection.sessionUpdate = sessionUpdate as typeof connection.sessionUpdate;
     const sessionStore = createInMemorySessionStore();
@@ -705,7 +707,9 @@ describe("acp translator stop reason mapping", () => {
   });
 
   it("emits the full revised text on a replace delta for a shorter revision", async () => {
-    const sessionUpdate = vi.fn<[Record<string, unknown>], Promise<void>>(async () => {});
+    const sessionUpdate = vi.fn(async (_params?: Record<string, unknown>) => {}) as (
+      params: Record<string, unknown>,
+    ) => Promise<void>;
     const connection = createAcpConnection();
     connection.sessionUpdate = sessionUpdate as typeof connection.sessionUpdate;
     const sessionStore = createInMemorySessionStore();

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -1141,7 +1141,10 @@ export class AcpGatewayAgent implements Agent {
       // Gateway chat events can carry the latest full assistant snapshot on both
       // incremental updates and the terminal final event. Process the snapshot
       // first so ACP clients never drop the last visible assistant text.
-      await this.handleDeltaEvent(pending.sessionId, messageData);
+      // When the Gateway signals a non-append revision (replace), the delta
+      // must be the full new text, not a byte-offset slice of the prior text.
+      const replace = state === "delta" ? (payload.replace as boolean | undefined) : undefined;
+      await this.handleDeltaEvent(pending.sessionId, messageData, replace);
       if (state === "delta") {
         return;
       }
@@ -1167,6 +1170,7 @@ export class AcpGatewayAgent implements Agent {
   private async handleDeltaEvent(
     sessionId: string,
     messageData: Record<string, unknown>,
+    replace?: boolean,
   ): Promise<void> {
     const content = messageData.content as GatewayChatContentBlock[] | undefined;
     const pending = this.pendingPrompts.get(sessionId);
@@ -1179,7 +1183,7 @@ export class AcpGatewayAgent implements Agent {
       .map((block) => block.thinking ?? "")
       .join("\n")
       .trimEnd();
-    const sentThoughtSoFar = pending.sentThoughtLength ?? 0;
+    const sentThoughtSoFar = replace ? 0 : (pending.sentThoughtLength ?? 0);
     if (fullThought && fullThought.length > sentThoughtSoFar) {
       const newThought = fullThought.slice(sentThoughtSoFar);
       pending.sentThoughtLength = fullThought.length;
@@ -1202,7 +1206,7 @@ export class AcpGatewayAgent implements Agent {
       .map((block) => block.text ?? "")
       .join("\n")
       .trimEnd();
-    const sentSoFar = pending.sentTextLength ?? 0;
+    const sentSoFar = replace ? 0 : (pending.sentTextLength ?? 0);
     if (!fullText || fullText.length <= sentSoFar) {
       return;
     }


### PR DESCRIPTION
## What Problem This Solves

The ACP translator in `src/acp/translator.ts` assumes Gateway assistant text only ever grows as an append-only prefix. When the model revises in-progress output so the new text is **not** a prefix extension, the translator slices the new full text at the old byte length. This produces corrupted output:

- **Divergent revision** "Hello world" → "Goodbye world": the delta becomes `"Goodbye world".slice(11)` = `"d"`, so the ACP client renders "Hello world" + "d" = "Hello worldd" — a stale prefix with a nonsensical tail.
- **Shorter revision** "Hello world!" → "Hi": `"Hi".length (2) <= sentSoFar (12)` returns early, so the client never sees "Hi" and stays stuck on the stale longer text.

The Gateway already signals non-append revisions via `replace: true` on the chat event payload (per `packages/gateway-protocol/src/schema/logs-chat.ts:150`), but the translator ignored it entirely.

Fixes #102322

## Why This Change Was Made

The root cause is two-fold:

1. `handleChatEvent` never passed the `replace` flag from `payload.replace` into `handleDeltaEvent`.
2. `handleDeltaEvent` used `pending.sentTextLength` / `pending.sentThoughtLength` to compute a byte-offset slice (`fullText.slice(sentSoFar)`), which is only correct for strict append-only frames.

**Fix** (2 files, +174/-3 lines):

- `src/acp/translator.ts`: Extract `replace` from the payload (delta frames only) and pass it to `handleDeltaEvent`. When `replace` is true, reset sentLength tracking to 0 so the full revised text (and thought) is emitted.
- `src/acp/translator.stop-reason.test.ts`: 2 regression tests covering divergent revision and shorter revision scenarios.

The `replace` flag is only used for delta frames (`state === "delta"`); final frames continue to use the existing tracking (after a replace delta, sentLength matches the revised text, so the final frame's delta produces an empty slice — no duplicate emission).

## Evidence

All 105 ACP test files pass (828 tests, zero failures or regressions):

```
$ npx vitest run src/acp/ --no-coverage

 Test Files  105 passed (105)
      Tests  828 passed (828)
   Start at  16:41:14
   Duration  55.29s
```

New regression tests specifically exercise the two failure modes:

```
$ npx vitest run src/acp/translator.stop-reason.test.ts --no-coverage

 Test Files  1 passed (1)
      Tests  20 passed (20)
   Start at  16:36:01
   Duration  1.35s
```

**"emits the full revised text on a replace delta, not a byte-offset slice"**
- Sends append delta "Hello world", then replace delta "Goodbye world"
- Asserts the second `agent_message_chunk` contains the full "Goodbye world" (13 chars), not a corrupted byte-offset slice
- Before fix: would emit "d" (offset 11 slice), client renders "Hello worldd"

**"emits the full revised text on a replace delta for a shorter revision"**
- Sends append delta "Hello world!" (12 chars), then replace delta "Hi" (2 chars)
- Asserts the second chunk emits "Hi"
- Before fix: `fullText.length (2) <= sentSoFar (12)` → return early, client stuck on stale text

## Merge Risk

Low — 7 lines added in production code (one `replace` flag extraction, two `replace ? 0 : ...` tracking resets), 167 lines in regression tests. No changes to session handling, prompt lifecycle, or Gateway protocol. The `replace` flag was already defined in the protocol schema and already produced by the Gateway.

- [x] Backwards compatible — normal append deltas are unchanged (replace is undefined/false)
- [x] Existing tests pass — 828/828
- [x] Focused fix — single file, three logical changes