### PR TITLE
fix(logging): use truncateUtf16Safe in diagnostic stability and session context

### DIFF
--- a/src/logging/diagnostic-session-context.test.ts
+++ b/src/logging/diagnostic-session-context.test.ts
@@ -103,6 +103,14 @@ describe("diagnostic session context", () => {
     expect(readLastAssistantFromSessionFile(filePath)).toBe("newer");
   });
 
+  it("keeps bounded quoted fields UTF-16 safe", () => {
+    const prefix = "a".repeat(136);
+
+    expect(
+      formatCronSessionDiagnosticFields({ cronJobName: `${prefix}😀${"b".repeat(140)}` }),
+    ).toBe(`cronJob="${prefix}..."`);
+  });
+
   it("ignores missing transcript tail files", () => {
     expect(readLastAssistantFromSessionFile(path.join(tempDir!, "missing.jsonl"))).toBeUndefined();
   });

--- a/src/logging/diagnostic-session-context.ts
+++ b/src/logging/diagnostic-session-context.ts
@@ -1,6 +1,7 @@
 // Diagnostic session context helpers capture session metadata for support bundles.
 import fs from "node:fs";
 import path from "node:path";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveStateDir } from "../config/paths.js";
 import { loadCronJobsStoreSync, resolveCronJobsStorePath } from "../cron/store.js";
 
@@ -19,7 +20,7 @@ function quoteLogField(value: string): string {
   const oneLine = value.replace(/\s+/g, " ").trim();
   const truncated =
     oneLine.length > MAX_QUOTED_FIELD_CHARS
-      ? `${oneLine.slice(0, Math.max(0, MAX_QUOTED_FIELD_CHARS - 3))}...`
+      ? `${truncateUtf16Safe(oneLine, Math.max(0, MAX_QUOTED_FIELD_CHARS - 3))}...`
       : oneLine;
   return `"${truncated.replace(/["\\]/g, "\\$&")}"`;
 }

--- a/src/logging/diagnostic-stability-bundle.test.ts
+++ b/src/logging/diagnostic-stability-bundle.test.ts
@@ -163,6 +163,21 @@ describe("diagnostic stability bundles", () => {
     expect(raw).not.toContain("stack");
   });
 
+  it("keeps bounded failure messages UTF-16 safe", () => {
+    const prefix = "a".repeat(499);
+    const result = writeDiagnosticStabilityBundleForFailureSync(
+      "gateway.restart_startup_failed",
+      new Error(`${prefix}😀${"b".repeat(500)}`),
+      { stateDir: tempDir },
+    );
+
+    expect(result.status).toBe("written");
+    if (result.status !== "written") {
+      return;
+    }
+    expect(readBundle(result.path).error?.message).toBe(`${prefix}...`);
+  });
+
   it("registers a fatal hook only while installed", () => {
     startDiagnosticStabilityRecorder();
     emitDiagnosticEvent({ type: "webhook.received", channel: "telegram" });

--- a/src/logging/diagnostic-stability-bundle.ts
+++ b/src/logging/diagnostic-stability-bundle.ts
@@ -1,9 +1,9 @@
 // Diagnostic stability bundle helpers collect stable diagnostic data for comparison.
 import fs from "node:fs";
 import path from "node:path";
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import process from "node:process";
 import v8 from "node:v8";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveStateDir } from "../config/paths.js";
 import type {
   DiagnosticMemoryPressureEvent,

--- a/src/logging/diagnostic-stability-bundle.ts
+++ b/src/logging/diagnostic-stability-bundle.ts
@@ -1,6 +1,7 @@
 // Diagnostic stability bundle helpers collect stable diagnostic data for comparison.
 import fs from "node:fs";
 import path from "node:path";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import process from "node:process";
 import v8 from "node:v8";
 import { resolveStateDir } from "../config/paths.js";
@@ -207,7 +208,7 @@ function readErrorMessage(error: unknown): string | undefined {
     return undefined;
   }
   return sanitized.length > MAX_SAFE_ERROR_MESSAGE_LENGTH
-    ? `${sanitized.slice(0, MAX_SAFE_ERROR_MESSAGE_LENGTH)}...`
+    ? `${truncateUtf16Safe(sanitized, MAX_SAFE_ERROR_MESSAGE_LENGTH)}...`
     : sanitized;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Diagnostic stability bundles and session-context fields truncated arbitrary error text with raw UTF-16 slices. An emoji crossing either cutoff could leave an unpaired surrogate in logs or the generated stability bundle.

## Why This Change Was Made

Use the repository's existing `truncateUtf16Safe` helper at both diagnostic-owner boundaries while preserving the current limits, quoting, and suffixes.

## User Impact

Session diagnostics and failure bundles remain valid Unicode when long errors contain supplementary characters at a cutoff.

## Evidence

- Added session-field coverage at the 137-code-unit boundary.
- Added generated stability-bundle coverage at the 500-code-unit boundary.
- Focused diagnostics suites: 2 files, 16 tests passed.
- Fresh autoreview: clean, no accepted/actionable findings (0.99).

## Files Changed

| File | Change |
|------|--------|
| `src/logging/diagnostic-stability-bundle.ts` | Use UTF-16-safe truncation for persisted error messages. |
| `src/logging/diagnostic-session-context.ts` | Use UTF-16-safe truncation for quoted log fields. |
| `src/logging/diagnostic-stability-bundle.test.ts` | Add generated-bundle boundary proof. |
| `src/logging/diagnostic-session-context.test.ts` | Add session-field boundary proof. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
