### PR TITLE
fix(qqbot): use truncateUtf16Safe for debug log URL/key truncation

### DIFF
--- a/extensions/qqbot/src/engine/utils/image-size.test.ts
+++ b/extensions/qqbot/src/engine/utils/image-size.test.ts
@@ -4,12 +4,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const adapterMocks = vi.hoisted(() => ({
   fetchMedia: vi.fn(),
+  debugLog: vi.fn(),
 }));
 
 vi.mock("../adapter/index.js", () => ({
   getPlatformAdapter: () => ({
     fetchMedia: (...args: unknown[]) => adapterMocks.fetchMedia(...args),
   }),
+}));
+
+vi.mock("./log.js", () => ({
+  debugLog: (...args: unknown[]) => adapterMocks.debugLog(...args),
 }));
 
 import { getImageSizeFromUrl, parseImageSize } from "./image-size.js";
@@ -39,6 +44,7 @@ function buildPngHeader(width: number, height: number): Buffer {
 describe("getImageSizeFromUrl", () => {
   beforeEach(() => {
     adapterMocks.fetchMedia.mockReset();
+    adapterMocks.debugLog.mockReset();
   });
 
   describe("fetchMedia options contract", () => {
@@ -139,6 +145,27 @@ describe("getImageSizeFromUrl", () => {
       const size = await getImageSizeFromUrl("https://cdn.example.com/notimage.html");
 
       expect(size).toBeNull();
+    });
+
+    it("logs fetched URLs without splitting surrogate pairs", async () => {
+      adapterMocks.fetchMedia.mockResolvedValueOnce({
+        buffer: buildPngHeader(800, 600),
+        contentType: "image/png",
+      });
+      const base = "https://cdn.example.com/";
+      const urlPrefix = `${base}${"x".repeat(59 - base.length)}`;
+
+      await getImageSizeFromUrl(`${urlPrefix}😀.png`);
+
+      expect(adapterMocks.debugLog).toHaveBeenCalledWith(
+        `[image-size] Got size from URL: 800x600 - ${urlPrefix}...`,
+      );
+
+      adapterMocks.fetchMedia.mockRejectedValueOnce(new Error("probe failed"));
+      await getImageSizeFromUrl(`${urlPrefix}😀.png`);
+      expect(adapterMocks.debugLog).toHaveBeenLastCalledWith(
+        `[image-size] Error fetching ${urlPrefix}...: probe failed`,
+      );
     });
   });
 });

--- a/extensions/qqbot/src/engine/utils/image-size.ts
+++ b/extensions/qqbot/src/engine/utils/image-size.ts
@@ -194,7 +194,9 @@ export async function getImageSizeFromUrl(
       clearTimeout(timeoutId);
     }
   } catch (err) {
-    debugLog(`[image-size] Error fetching ${truncateUtf16Safe(url, 60)}...: ${formatErrorMessage(err)}`);
+    debugLog(
+      `[image-size] Error fetching ${truncateUtf16Safe(url, 60)}...: ${formatErrorMessage(err)}`,
+    );
     return null;
   }
 }

--- a/extensions/qqbot/src/engine/utils/image-size.ts
+++ b/extensions/qqbot/src/engine/utils/image-size.ts
@@ -5,6 +5,7 @@
  */
 
 import { Buffer } from "node:buffer";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { getPlatformAdapter } from "../adapter/index.js";
 import type { SsrfPolicyConfig } from "../adapter/types.js";
 import { formatErrorMessage } from "./format.js";
@@ -185,7 +186,7 @@ export async function getImageSizeFromUrl(
       const size = parseImageSize(buffer);
       if (size) {
         debugLog(
-          `[image-size] Got size from URL: ${size.width}x${size.height} - ${url.slice(0, 60)}...`,
+          `[image-size] Got size from URL: ${size.width}x${size.height} - ${truncateUtf16Safe(url, 60)}...`,
         );
       }
       return size;
@@ -193,7 +194,7 @@ export async function getImageSizeFromUrl(
       clearTimeout(timeoutId);
     }
   } catch (err) {
-    debugLog(`[image-size] Error fetching ${url.slice(0, 60)}...: ${formatErrorMessage(err)}`);
+    debugLog(`[image-size] Error fetching ${truncateUtf16Safe(url, 60)}...: ${formatErrorMessage(err)}`);
     return null;
   }
 }

--- a/extensions/qqbot/src/engine/utils/upload-cache.test.ts
+++ b/extensions/qqbot/src/engine/utils/upload-cache.test.ts
@@ -1,11 +1,21 @@
 // Qqbot tests cover upload cache plugin behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  debugLog: vi.fn(),
+}));
+
+vi.mock("./log.js", () => ({
+  debugLog: (...args: unknown[]) => mocks.debugLog(...args),
+}));
+
 import { computeFileHash, getCachedFileInfo, setCachedFileInfo } from "./upload-cache.js";
 
 describe("qqbot upload-cache", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+    mocks.debugLog.mockReset();
   });
 
   it("reuses cached file info before expiry", () => {
@@ -31,5 +41,22 @@ describe("qqbot upload-cache", () => {
     setCachedFileInfo(hash, "group", "target-overflow", 1, "file-info-overflow", "uuid", 3600);
 
     expect(getCachedFileInfo(hash, "group", "target-overflow", 1)).toBeNull();
+  });
+
+  it("logs cache keys without splitting surrogate pairs", () => {
+    const hash = computeFileHash("qqbot-surrogate-key");
+    const keyPrefix = `${hash}:group:`;
+
+    setCachedFileInfo(hash, "group", "😀target", 1, "file-info", "uuid-safe", 3600);
+    expect(getCachedFileInfo(hash, "group", "😀target", 1)).toBe("file-info");
+
+    expect(mocks.debugLog).toHaveBeenNthCalledWith(
+      1,
+      `[upload-cache] Cache SET: key=${keyPrefix}..., ttl=3540s, uuid=uuid-safe`,
+    );
+    expect(mocks.debugLog).toHaveBeenNthCalledWith(
+      2,
+      `[upload-cache] Cache HIT: key=${keyPrefix}..., fileUuid=uuid-safe`,
+    );
   });
 });

--- a/extensions/qqbot/src/engine/utils/upload-cache.ts
+++ b/extensions/qqbot/src/engine/utils/upload-cache.ts
@@ -8,8 +8,8 @@ import {
   isFutureDateTimestampMs,
   resolveExpiresAtMsFromDurationSeconds,
 } from "openclaw/plugin-sdk/number-runtime";
-import type { ChatScope } from "../types.js";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import type { ChatScope } from "../types.js";
 import { debugLog } from "./log.js";
 
 interface CacheEntry {
@@ -56,7 +56,9 @@ export function getCachedFileInfo(
     return null;
   }
 
-  debugLog(`[upload-cache] Cache HIT: key=${truncateUtf16Safe(key, 40)}..., fileUuid=${entry.fileUuid}`);
+  debugLog(
+    `[upload-cache] Cache HIT: key=${truncateUtf16Safe(key, 40)}..., fileUuid=${entry.fileUuid}`,
+  );
   return entry.fileInfo;
 }
 

--- a/extensions/qqbot/src/engine/utils/upload-cache.ts
+++ b/extensions/qqbot/src/engine/utils/upload-cache.ts
@@ -9,6 +9,7 @@ import {
   resolveExpiresAtMsFromDurationSeconds,
 } from "openclaw/plugin-sdk/number-runtime";
 import type { ChatScope } from "../types.js";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { debugLog } from "./log.js";
 
 interface CacheEntry {
@@ -55,7 +56,7 @@ export function getCachedFileInfo(
     return null;
   }
 
-  debugLog(`[upload-cache] Cache HIT: key=${key.slice(0, 40)}..., fileUuid=${entry.fileUuid}`);
+  debugLog(`[upload-cache] Cache HIT: key=${truncateUtf16Safe(key, 40)}..., fileUuid=${entry.fileUuid}`);
   return entry.fileInfo;
 }
 
@@ -100,6 +101,6 @@ export function setCachedFileInfo(
   });
 
   debugLog(
-    `[upload-cache] Cache SET: key=${key.slice(0, 40)}..., ttl=${effectiveTtl}s, uuid=${fileUuid}`,
+    `[upload-cache] Cache SET: key=${truncateUtf16Safe(key, 40)}..., ttl=${effectiveTtl}s, uuid=${fileUuid}`,
   );
 }


### PR DESCRIPTION
## What Problem This Solves

QQBot emits bounded debug previews for probed image URLs and upload-cache keys. Those local 60- and 40-code-unit caps used `slice`, so a surrogate pair crossing either boundary could leave malformed UTF-16 before the shared debug logger applied its larger global cap.

## Why This Change Was Made

Use the existing `truncateUtf16Safe` utility at each small, context-specific preview boundary. The URL and cache-key limits, ellipses, cache semantics, network behavior, and global debug sanitization remain unchanged.

The follow-up tests exercise every changed call site: successful and failed image probes assert exact URL previews, while real cache set/hit calls assert exact key previews with a target identifier whose emoji straddles the cache-key boundary.

## User Impact

Opt-in QQBot debug logs remain bounded but no longer contain malformed Unicode at these preview limits. Image probing, media upload caching, API routes, and configuration are unchanged.

## Evidence

- `node ../../node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extension-messaging.config.ts extensions/qqbot/src/engine/utils/image-size.test.ts extensions/qqbot/src/engine/utils/upload-cache.test.ts` — 2 files and 17 tests passed.
- `oxfmt` completed on all changed files.
- `git diff --check` passed.
- Source review covered image probe callers, direct and chunked upload-cache callers, QQBot debug sanitization, key construction, scope types, and existing SSRF/cache tests.

## Risk

Low. Four internal debug-preview expressions now share the established UTF-16 truncation invariant; runtime API and cache behavior are unaffected.

## AI-assisted

This PR was generated with Claude Code and improved/reviewed by a maintainer agent.
