### PR TITLE
fix(ui): keep streamed talk voice-turn transcripts readable

### DIFF
--- a/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
@@ -197,6 +197,74 @@ describeControlUiE2e("Control UI browser Talk", () => {
     }
   });
 
+  it("renders streamed relay assistant transcript deltas as readable text", async () => {
+    const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    const context = await browser.newContext({ permissions: ["microphone"] });
+    const page = await context.newPage();
+    const relaySessionId = "relay-e2e-transcript";
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "talk.client.create": {
+          provider: "openai",
+          transport: "gateway-relay",
+          relaySessionId,
+          audio: {
+            inputEncoding: "pcm16",
+            inputSampleRateHz: 16_000,
+            outputEncoding: "pcm16",
+            outputSampleRateHz: 24_000,
+          },
+        },
+        "talk.session.appendAudio": {},
+        "talk.session.close": {},
+      },
+    });
+    await installTalkBrowserFixtures(page);
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await page.setViewportSize({ width: 1366, height: 900 });
+      await page.getByRole("button", { name: "Start voice input" }).click();
+      await gateway.waitForRequest("talk.client.create");
+      await gateway.emitGatewayEvent("talk.event", { relaySessionId, type: "ready" });
+      await gateway.emitGatewayEvent("talk.event", {
+        relaySessionId,
+        type: "transcript",
+        role: "user",
+        text: "Hey, what model are you using?",
+        final: true,
+      });
+      // Assistant audio transcripts stream as verbatim fragments that can split
+      // words ("I","'m"," Chat","G","PT"); regression coverage for #102556 where
+      // the merge injected spaces mid-word and the turn collapsed while streaming.
+      const assistantText =
+        "I'm ChatGPT, a conversational AI model designed to help answer questions, brainstorm ideas, and chat about pretty much anything you want to talk about today.";
+      for (const char of assistantText) {
+        await gateway.emitGatewayEvent("talk.event", {
+          relaySessionId,
+          type: "transcript",
+          role: "assistant",
+          text: char,
+          final: false,
+        });
+      }
+
+      const assistantTurnText = page.locator(
+        ".agent-chat__voice-turn--assistant .agent-chat__voice-turn-text",
+      );
+      await expect.poll(() => assistantTurnText.textContent()).toBe(assistantText);
+
+      const turnBounds = await page.locator(".agent-chat__voice-turn--assistant").boundingBox();
+      expect(turnBounds).not.toBeNull();
+      // A collapsed turn renders one character per line (tall, sliver-wide box).
+      expect(turnBounds?.width ?? 0).toBeGreaterThanOrEqual(500);
+      expect(turnBounds?.height ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(120);
+    } finally {
+      await context.close();
+      await browser.close();
+    }
+  });
+
   it("keeps blocked microphone guidance readable in a narrow viewport", async () => {
     const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext();

--- a/ui/src/pages/chat/realtime-talk-conversation.test.ts
+++ b/ui/src/pages/chat/realtime-talk-conversation.test.ts
@@ -49,6 +49,85 @@ describe("realtime Talk conversation", () => {
     ]);
   });
 
+  it("concatenates streamed assistant deltas verbatim without injecting spaces", () => {
+    let state = createRealtimeTalkConversationState();
+
+    const deltas = ["I", "'m", " Chat", "G", "PT", ",", " a", " con", "vers", "ational", " AI"];
+    for (const [index, delta] of deltas.entries()) {
+      state = updateRealtimeTalkConversation(state, {
+        role: "assistant",
+        text: delta,
+        final: false,
+        nowMs: index + 1,
+      });
+    }
+
+    expect(state.entries).toMatchObject([
+      { role: "assistant", text: "I'm ChatGPT, a conversational AI", isStreaming: true },
+    ]);
+  });
+
+  it("keeps per-character assistant deltas readable", () => {
+    let state = createRealtimeTalkConversationState();
+
+    for (const [index, char] of "Hello there.".split("").entries()) {
+      state = updateRealtimeTalkConversation(state, {
+        role: "assistant",
+        text: char,
+        final: false,
+        nowMs: index + 1,
+      });
+    }
+
+    expect(state.entries).toMatchObject([
+      { role: "assistant", text: "Hello there.", isStreaming: true },
+    ]);
+  });
+
+  it("replaces streamed assistant text with the authoritative final transcript", () => {
+    let state = createRealtimeTalkConversationState();
+
+    for (const delta of ["I'm Chat", "GPT."]) {
+      state = updateRealtimeTalkConversation(state, {
+        role: "assistant",
+        text: delta,
+        final: false,
+        nowMs: 1,
+      });
+    }
+    state = updateRealtimeTalkConversation(state, {
+      role: "assistant",
+      text: "I'm ChatGPT, nice to meet you.",
+      final: true,
+      nowMs: 2,
+    });
+
+    expect(state.entries).toMatchObject([
+      { role: "assistant", text: "I'm ChatGPT, nice to meet you.", isStreaming: false },
+    ]);
+  });
+
+  it("appends a final assistant fragment that only carries the transcript tail", () => {
+    let state = createRealtimeTalkConversationState();
+
+    state = updateRealtimeTalkConversation(state, {
+      role: "assistant",
+      text: "Sure, the lights are ",
+      final: false,
+      nowMs: 1,
+    });
+    state = updateRealtimeTalkConversation(state, {
+      role: "assistant",
+      text: "off now.",
+      final: true,
+      nowMs: 2,
+    });
+
+    expect(state.entries).toMatchObject([
+      { role: "assistant", text: "Sure, the lights are off now.", isStreaming: false },
+    ]);
+  });
+
   it("keeps a late final rewrite in the original user bubble", () => {
     let state = createRealtimeTalkConversationState();
 

--- a/ui/src/pages/chat/realtime-talk-conversation.test.ts
+++ b/ui/src/pages/chat/realtime-talk-conversation.test.ts
@@ -28,24 +28,24 @@ describe("realtime Talk conversation", () => {
     ]);
   });
 
-  it("inserts spacing after punctuation-ended transcript fragments", () => {
+  it("inserts spacing after punctuation-ended user transcript fragments", () => {
     let state = createRealtimeTalkConversationState();
 
     state = updateRealtimeTalkConversation(state, {
-      role: "assistant",
+      role: "user",
       text: "Ready.",
       final: false,
       nowMs: 1,
     });
     state = updateRealtimeTalkConversation(state, {
-      role: "assistant",
+      role: "user",
       text: "What next?",
       final: false,
       nowMs: 2,
     });
 
     expect(state.entries).toMatchObject([
-      { role: "assistant", text: "Ready. What next?", isStreaming: true },
+      { role: "user", text: "Ready. What next?", isStreaming: true },
     ]);
   });
 
@@ -67,10 +67,10 @@ describe("realtime Talk conversation", () => {
     ]);
   });
 
-  it("keeps per-character assistant deltas readable", () => {
+  it("keeps per-character assistant deltas verbatim across punctuation boundaries", () => {
     let state = createRealtimeTalkConversationState();
 
-    for (const [index, char] of "Hello there.".split("").entries()) {
+    for (const [index, char] of "Version 1.2 is on docs.openclaw.ai today.".split("").entries()) {
       state = updateRealtimeTalkConversation(state, {
         role: "assistant",
         text: char,
@@ -80,7 +80,7 @@ describe("realtime Talk conversation", () => {
     }
 
     expect(state.entries).toMatchObject([
-      { role: "assistant", text: "Hello there.", isStreaming: true },
+      { role: "assistant", text: "Version 1.2 is on docs.openclaw.ai today.", isStreaming: true },
     ]);
   });
 

--- a/ui/src/pages/chat/realtime-talk-conversation.ts
+++ b/ui/src/pages/chat/realtime-talk-conversation.ts
@@ -112,7 +112,10 @@ function upsertRealtimeConversationEntry(
     return upsertRealtimeConversationEntry(state, role, null, text, isFinal, nowMs);
   }
   const entry = state.entries[targetIndex];
-  const updatedText = mergeRealtimeTranscriptText(entry.text, text, isFinal);
+  const updatedText =
+    role === "assistant"
+      ? mergeAssistantTranscriptText(entry.text, text, isFinal)
+      : mergeRealtimeTranscriptText(entry.text, text, isFinal);
   const entries =
     entry.text === updatedText && entry.isStreaming === !isFinal
       ? state.entries
@@ -199,6 +202,39 @@ function shouldStartNewRealtimeUserEntry(
     }
   }
   return true;
+}
+
+// Assistant transcripts are verbatim fragment streams (providers concatenate
+// deltas into the transcript), unlike user ASR updates that re-send or rewrite
+// utterances. The user-side word-boundary spacing heuristic must not run here:
+// model deltas split inside words, so it would mangle "ChatGPT" into "Chat G PT".
+function mergeAssistantTranscriptText(
+  existing: string,
+  incoming: string,
+  isFinal: boolean,
+): string {
+  if (existing.trim() === "") {
+    return incoming.trimStart();
+  }
+  if (!isFinal) {
+    return `${existing}${assistantFragmentSeparator(existing, incoming)}${incoming}`;
+  }
+  // Final shape differs by provider: OpenAI-style finals carry the full
+  // transcript (replace), Google Live finals carry only the last fragment
+  // (append). Replace only when incoming restates what already streamed.
+  if (incoming === existing || incoming.startsWith(existing)) {
+    return incoming;
+  }
+  if (looksLikeTranscriptReplacement(existing, incoming)) {
+    return incoming;
+  }
+  return `${existing}${assistantFragmentSeparator(existing, incoming)}${incoming}`;
+}
+
+// Space only sentence-boundary joins ("Ready." + "What next?"): TTS phrases can
+// arrive as separate fragments without whitespace. Mid-word joins stay verbatim.
+function assistantFragmentSeparator(existing: string, incoming: string): string {
+  return /[.!?…]$/.test(existing) && /^[\p{L}\p{N}]/u.test(incoming) ? " " : "";
 }
 
 function mergeRealtimeTranscriptText(existing: string, incoming: string, isFinal: boolean): string {

--- a/ui/src/pages/chat/realtime-talk-conversation.ts
+++ b/ui/src/pages/chat/realtime-talk-conversation.ts
@@ -204,10 +204,11 @@ function shouldStartNewRealtimeUserEntry(
   return true;
 }
 
-// Assistant transcripts are verbatim fragment streams (providers concatenate
-// deltas into the transcript), unlike user ASR updates that re-send or rewrite
-// utterances. The user-side word-boundary spacing heuristic must not run here:
-// model deltas split inside words, so it would mangle "ChatGPT" into "Chat G PT".
+// Assistant transcripts are verbatim fragment streams: providers concatenate
+// deltas into the exact transcript (OpenAI audio-transcript deltas, Google Live
+// outputTranscription chunks). Never synthesize characters between fragments —
+// the user-side ASR spacing heuristic would mangle "ChatGPT" into "Chat G PT"
+// and "Version 1.2" into "Version 1. 2".
 function mergeAssistantTranscriptText(
   existing: string,
   incoming: string,
@@ -217,7 +218,7 @@ function mergeAssistantTranscriptText(
     return incoming.trimStart();
   }
   if (!isFinal) {
-    return `${existing}${assistantFragmentSeparator(existing, incoming)}${incoming}`;
+    return `${existing}${incoming}`;
   }
   // Final shape differs by provider: OpenAI-style finals carry the full
   // transcript (replace), Google Live finals carry only the last fragment
@@ -228,13 +229,7 @@ function mergeAssistantTranscriptText(
   if (looksLikeTranscriptReplacement(existing, incoming)) {
     return incoming;
   }
-  return `${existing}${assistantFragmentSeparator(existing, incoming)}${incoming}`;
-}
-
-// Space only sentence-boundary joins ("Ready." + "What next?"): TTS phrases can
-// arrive as separate fragments without whitespace. Mid-word joins stay verbatim.
-function assistantFragmentSeparator(existing: string, incoming: string): string {
-  return /[.!?…]$/.test(existing) && /^[\p{L}\p{N}]/u.test(incoming) ? " " : "";
+  return `${existing}${incoming}`;
 }
 
 function mergeRealtimeTranscriptText(existing: string, incoming: string, isFinal: boolean): string {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1534,9 +1534,11 @@ openclaw-chat-page {
   background: transparent;
 }
 
+/* Flex row, not grid: WebKit (Mac/iOS WKWebView) never re-runs shrink-to-fit
+   intrinsic sizing for a grid flex-item while streamed transcript text grows,
+   freezing the turn at first-delta width and wrapping one character per line. */
 .agent-chat__voice-turn {
-  display: grid;
-  grid-template-columns: minmax(56px, max-content) minmax(0, 1fr) 12px;
+  display: flex;
   gap: 8px;
   align-items: baseline;
   max-width: min(100%, 780px);
@@ -1556,7 +1558,9 @@ openclaw-chat-page {
 }
 
 .agent-chat__voice-turn-speaker {
-  min-width: 0;
+  flex: 0 0 auto;
+  min-width: 56px;
+  max-width: 200px;
   overflow: hidden;
   color: var(--muted);
   font-size: 12px;
@@ -1566,6 +1570,7 @@ openclaw-chat-page {
 }
 
 .agent-chat__voice-turn-text {
+  flex: 1 1 auto;
   min-width: 0;
   overflow-wrap: anywhere;
   color: var(--text);
@@ -1575,6 +1580,7 @@ openclaw-chat-page {
 }
 
 .agent-chat__voice-turn-stream {
+  flex: 0 0 auto;
   width: 6px;
   height: 6px;
   border-radius: 999px;


### PR DESCRIPTION
## What Problem This Solves

Fixes #102556.

During a realtime Talk session in the macOS app (Control UI inside WKWebView), the streaming assistant voice turn rendered one character per line: the turn box froze at the width of the first transcript delta (~114px) and grew thousands of pixels tall. Independently, the streamed transcript text itself was corrupted with injected spaces ("Chat G PT", "con vers ational").

## Why This Change Was Made

Two independent bugs stacked on the same surface:

1. **WebKit-only layout collapse.** `.agent-chat__voice-turn` was a CSS grid sized shrink-to-fit as a flex item of the voice-turns column. WebKit (Mac/iOS WKWebView) never re-runs the grid flex item's intrinsic sizing while streamed text grows, so the turn kept the width computed for the first one-character delta and every subsequent character wrapped to its own line. Chromium recomputes correctly, which is why existing browser tests never caught it. Converting the turn to a flex row (same visual: speaker | text | streaming dot, baseline-aligned, hugging content up to 780px) sidesteps the WebKit invalidation bug in both engines; probed grid variants (`auto` track, plain `1fr`) stayed collapsed. Side effect: the fixed 12px third grid column is no longer reserved on finished turns that have no streaming dot.

2. **Assistant transcript merge mangling (all engines).** `mergeRealtimeTranscriptText` applied a word-boundary spacing heuristic designed for user ASR re-statements to assistant audio-transcript deltas. Assistant deltas are verbatim fragments that split inside words (OpenAI `response.output_audio_transcript.delta`, Google Live `outputTranscription`; the server-side Google provider concatenates them verbatim in `extensions/google/realtime-voice-provider.ts`), so the heuristic injected a space between letter-adjacent fragments. Assistant entries now merge as strictly verbatim fragment streams (no synthesized characters, which would corrupt content like "Version 1.2" or "docs.openclaw.ai" at punctuation boundaries), and finals handle both provider shapes: OpenAI-style full-transcript finals replace, Google-Live-style tail-fragment finals append. User ASR merge heuristics are unchanged; user transcripts from shipped providers arrive with leading whitespace or as re-statements, which the existing path handles.

## User Impact

Talk mode transcripts in the macOS/iOS app and all browsers render as normal wrapped text while streaming, and words are no longer broken apart ("I'm ChatGPT, a conversational AI model ..." instead of a one-character-per-line column of "I ' m C h a t G P T ...").

Before (WebKit): https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/talk-voice-turn-wrapping/before-webkit-collapsed.png
After (WebKit): https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/talk-voice-turn-wrapping/after-webkit-fixed.png

## Evidence

- Reproduced against the real Control UI (vite dev server + mock gateway, `gateway-relay` Talk session, per-character assistant transcript deltas) in Playwright WebKit 26.5: assistant turn measured **114x5238px with a 3px text column** before the fix; **780x56px** after. Chromium measures identically after the fix (780x56) and the user turn keeps hugging its content (273px).
- Transcript merge unit-proofed: per-token deltas `["I","'m"," Chat","G","PT",...]` previously merged to `"I'm Chat G PT, a con vers ational ..."`, now `"I'm ChatGPT, a conversational AI"`.
- New regression tests:
  - `ui/src/pages/chat/realtime-talk-conversation.test.ts`: verbatim per-token and per-character assistant delta merging (including punctuation boundaries like "Version 1.2 is on docs.openclaw.ai"), OpenAI-style authoritative final replacement, Google-Live-style tail-fragment final append (9/9 pass).
  - `ui/src/e2e/browser-talk-start-stop.e2e.test.ts`: drives a full `gateway-relay` Talk session through the mock gateway with per-character assistant deltas and asserts the rendered voice-turn text is unmangled plus sane turn geometry (3/3 pass).
- Existing talk conversation + talk e2e suites pass; the punctuation-spacing heuristic test now exercises the user ASR path, which keeps that behavior.
