### PR TITLE
fix(settings): deepMergeSettings recursively merge nested objects instead of shallow-spread

### DIFF
--- a/src/agents/sessions/settings-manager.test.ts
+++ b/src/agents/sessions/settings-manager.test.ts
@@ -29,6 +29,22 @@ describe("SettingsManager runtime overrides", () => {
     });
   });
 
+  it("merges nested retry.provider fields from global and overrides (deepMergeSettings recursion)", () => {
+    const settingsManager = SettingsManager.inMemory({
+      retry: { provider: { timeoutMs: 30_000, maxRetries: 5 } },
+    });
+
+    settingsManager.applyOverrides({
+      retry: { provider: { maxRetryDelayMs: 5_000 } },
+    });
+
+    expect(settingsManager.getProviderRetrySettings()).toEqual({
+      timeoutMs: 30_000,
+      maxRetries: 5,
+      maxRetryDelayMs: 5_000,
+    });
+  });
+
   it("preserves runtime overrides after project setting writes", async () => {
     const settingsManager = SettingsManager.inMemory({
       compaction: { reserveTokens: 16_384 },

--- a/src/agents/sessions/settings-manager.ts
+++ b/src/agents/sessions/settings-manager.ts
@@ -142,7 +142,10 @@ function deepMergeSettings(base: Settings, overrides: Settings): Settings {
       baseValue !== null &&
       !Array.isArray(baseValue)
     ) {
-      (result as Record<string, unknown>)[key] = { ...baseValue, ...overrideValue };
+      (result as Record<string, unknown>)[key] = deepMergeSettings(
+        baseValue as Record<string, unknown>,
+        overrideValue as Record<string, unknown>,
+      );
     } else {
       // For primitives and arrays, override value wins
       (result as Record<string, unknown>)[key] = overrideValue;


### PR DESCRIPTION
## What Problem This Solves

Fixes #102318 — `retry.provider` fields split across settings scopes are silently dropped because `deepMergeSettings` only does a one-level shallow spread for nested objects. When a higher-precedence scope (project/runtime) sets only part of `retry.provider`, the sibling fields from the global scope are lost and silently revert to SDK defaults.

## Why This Change Was Made

The nested-object branch in `deepMergeSettings` (`src/agents/sessions/settings-manager.ts:136-145`) had a comment saying "merge recursively" but the implementation did `{ ...baseValue, ...overrideValue }` — a one-level spread. This was the only place in Settings merging that lost two-level-deep fields, and `retry.provider` is the only two-level nested Settings field today.

The fix is a one-line change: replace the spread with a recursive call to `deepMergeSettings` itself, so nested objects truly merge field-by-field at every level.

## User Impact

Users who split `retry.provider` configuration across scopes (e.g. global `timeoutMs` + `maxRetries`, project `maxRetryDelayMs`) now get all three fields merged as expected, instead of silently losing the global timeout and retry-count settings.

## Evidence

- Source-level root cause verified at `src/agents/sessions/settings-manager.ts:145`
- Added test case: global `retry.provider = { timeoutMs: 30000, maxRetries: 5 }` + `applyOverrides({ retry: { provider: { maxRetryDelayMs: 5000 } } })` → all three fields survive
- Arrays and primitives are unaffected; no other merge behavior changes