### PR TITLE
fix(codex): use truncateUtf16Safe in trajectory and client parse log truncation

### DIFF
--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -114,6 +114,12 @@ describe("CodexAppServerClient", () => {
     ).toBe("fatal OPENAI_API_KEY=<redacted> ANTHROPIC_API_KEY='<redacted>' OTHER=value");
   });
 
+  it("keeps malformed-message previews UTF-16 safe at the log boundary", () => {
+    const prefix = "x".repeat(499);
+
+    expect(testing.redactCodexAppServerLinePreview(`${prefix}😀`)).toBe(`${prefix}...`);
+  });
+
   it("recovers app-server messages split by raw newlines inside JSON strings", async () => {
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
     const harness = createClientHarness();

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -4,6 +4,7 @@
  */
 import { createInterface, type Interface as ReadlineInterface } from "node:readline";
 import { embeddedAgentLog, OPENCLAW_VERSION } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveCodexAppServerRuntimeOptions, type CodexAppServerStartOptions } from "./config.js";
 import {
   type CodexAppServerRequestMethod,
@@ -739,7 +740,7 @@ function redactCodexAppServerLinePreview(value: string): string {
       "$1$2$3<redacted>$4",
     );
   return redacted.length > CODEX_APP_SERVER_PARSE_LOG_MAX
-    ? `${redacted.slice(0, CODEX_APP_SERVER_PARSE_LOG_MAX)}...`
+    ? `${truncateUtf16Safe(redacted, CODEX_APP_SERVER_PARSE_LOG_MAX)}...`
     : redacted;
 }
 

--- a/extensions/codex/src/app-server/trajectory.test.ts
+++ b/extensions/codex/src/app-server/trajectory.test.ts
@@ -87,6 +87,29 @@ describe("Codex trajectory recorder", () => {
     expect(fs.existsSync(path.join(tmpDir, "session.trajectory-path.json"))).toBe(true);
   });
 
+  it("keeps recorded string values UTF-16 safe at the trajectory boundary", async () => {
+    const tmpDir = makeTempDir();
+    const recorder = createCodexTrajectoryRecorder({
+      cwd: tmpDir,
+      attempt: {
+        sessionFile: path.join(tmpDir, "session.jsonl"),
+        sessionId: "session-1",
+        model: { api: "responses" },
+      } as never,
+      env: {},
+    });
+    const prefix = "x".repeat(19_999);
+
+    const trajectoryRecorder = expectTrajectoryRecorder(recorder);
+    trajectoryRecorder.recordEvent("model.output", { text: `${prefix}😀` });
+    await trajectoryRecorder.flush();
+
+    const parsed = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, "session.trajectory.jsonl"), "utf8"),
+    );
+    expect(parsed.data.text).toBe(`${prefix}…`);
+  });
+
   it("records canonical OpenAI Codex app-server turns with Codex local attribution", async () => {
     const tmpDir = makeTempDir();
     const sessionFile = path.join(tmpDir, "session.jsonl");

--- a/extensions/codex/src/app-server/trajectory.ts
+++ b/extensions/codex/src/app-server/trajectory.ts
@@ -5,7 +5,6 @@
 import nodeFs from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveUserPath } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type {
   EmbeddedRunAttemptParams,
@@ -15,6 +14,7 @@ import {
   appendRegularFile,
   resolveRegularFileAppendFlags,
 } from "openclaw/plugin-sdk/security-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveCodexLocalRuntimeAttribution } from "./local-runtime-attribution.js";
 import { flattenCodexDynamicToolFunctions, type CodexDynamicToolSpec } from "./protocol.js";
 

--- a/extensions/codex/src/app-server/trajectory.ts
+++ b/extensions/codex/src/app-server/trajectory.ts
@@ -5,6 +5,7 @@
 import nodeFs from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveUserPath } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type {
   EmbeddedRunAttemptParams,
@@ -377,7 +378,7 @@ function sanitizeValue(value: unknown, depth = 0, key = ""): unknown {
       return "<redacted payload>";
     }
     const redacted = redactSensitiveString(value);
-    return redacted.length > 20_000 ? `${redacted.slice(0, 20_000)}…` : redacted;
+    return redacted.length > 20_000 ? `${truncateUtf16Safe(redacted, 20_000)}…` : redacted;
   }
   if (depth >= 6) {
     return "<truncated>";


### PR DESCRIPTION
## What Problem This Solves

Codex app-server malformed-message previews and trajectory string values used raw UTF-16 slices. Arbitrary app-server output containing an emoji at either cutoff could therefore leave an unpaired surrogate in diagnostic logs or trajectory JSON.

## Why This Change Was Made

Use the existing `truncateUtf16Safe` plugin-SDK helper at both Codex-owned diagnostic boundaries. The current 500- and 20,000-code-unit limits, redaction order, and suffixes remain unchanged.

## User Impact

Codex app-server diagnostics and trajectory sidecars remain valid Unicode when supplementary characters cross their size limits.

## Evidence

- Added malformed-message preview coverage at the 500-code-unit boundary.
- Added recorder-level trajectory coverage at the 20,000-code-unit boundary.
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/client.test.ts extensions/codex/src/app-server/trajectory.test.ts` — 2 files, 45 tests passed.
- Targeted oxfmt and `git diff --check` passed.
- Fresh autoreview: clean, no accepted/actionable findings (0.99).
- Direct Codex contract check at `db887d03e1f907467e33271572dffb73bceecd6b`: app-server serializes arbitrary outgoing JSON to stdout in [`stdio.rs`](https://github.com/openai/codex/blob/db887d03e1f907467e33271572dffb73bceecd6b/codex-rs/app-server-transport/src/transport/stdio.rs#L82-L95), command output deltas are arbitrary strings in [`item.rs`](https://github.com/openai/codex/blob/db887d03e1f907467e33271572dffb73bceecd6b/codex-rs/app-server-protocol/src/protocol/v2/item.rs#L1404-L1413), and diagnostics use stderr in [`lib.rs`](https://github.com/openai/codex/blob/db887d03e1f907467e33271572dffb73bceecd6b/codex-rs/app-server/src/lib.rs#L649-L664).

## Files Changed

| File | Change |
|------|--------|
| `extensions/codex/src/app-server/client.ts` | Keep parse-log previews UTF-16 safe. |
| `extensions/codex/src/app-server/client.test.ts` | Add preview boundary regression coverage. |
| `extensions/codex/src/app-server/trajectory.ts` | Keep sanitized trajectory strings UTF-16 safe. |
| `extensions/codex/src/app-server/trajectory.test.ts` | Add recorder-level boundary coverage. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
