### PR TITLE
fix(browser): remove hardcoded profile="user" suggestion from tool description

### DIFF
--- a/extensions/browser/index.test.ts
+++ b/extensions/browser/index.test.ts
@@ -150,6 +150,8 @@ describe("browser plugin", () => {
     }
 
     expect(tool.name).toBe("browser");
+    expect(tool.description).toContain("action=profiles");
+    expect(tool.description).not.toContain('profile="user"');
     expect(runtimeApiMocks.createBrowserTool).not.toHaveBeenCalled();
     await tool.execute("call-1", { action: "status" });
     expect(runtimeApiMocks.createBrowserTool).toHaveBeenCalledWith({

--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -18,6 +18,7 @@ import {
   BROWSER_REQUEST_GATEWAY_METHOD,
   BROWSER_REQUEST_GATEWAY_SCOPE,
 } from "./src/browser-gateway-contract.js";
+import { describeBrowserTool } from "./src/browser-tool-description.js";
 import { BrowserToolSchema } from "./src/browser-tool.schema.js";
 
 const EAGER_BROWSER_CONTROL_SERVICE_ENV = "OPENCLAW_EAGER_BROWSER_CONTROL_SERVER";
@@ -74,19 +75,7 @@ function createLazyBrowserTool(opts?: {
   return {
     label: "Browser",
     name: "browser",
-    description: [
-      "Control the browser via OpenClaw's browser control server (status/start/stop/profiles/tabs/open/snapshot/screenshot/download/actions).",
-      "Browser choice: omit profile by default for the isolated OpenClaw-managed browser (`openclaw`).",
-      "For a logged-in browser session with existing logins/cookies, use the profile configured via `browser.defaultProfile` (e.g. `openclaw` for CDP attach or `user` for Chrome MCP transport). A supported Chromium-based browser (v144+) must be running on the selected host or browser node. Use only when existing logins/cookies matter and the user is present.",
-      "For existing-session profiles (non-`openclaw`), omit timeoutMs on act:type, evaluate, hover, scrollIntoView, drag, select, and fill; that driver rejects per-call timeout overrides for those actions.",
-      'When a node-hosted browser proxy is available, the tool may auto-route to it. Pin a node with node=<id|name> or target="node".',
-      "When using refs from snapshot (e.g. e12), keep the same tab: prefer passing targetId from the snapshot response into subsequent actions (act/click/type/etc). For tab operations, targetId also accepts tabId handles (t1) and labels from action=tabs.",
-      "For multi-step browser work, login checks, stale refs, duplicate tabs, or Google Meet flows, use the bundled browser-automation skill when it is available.",
-      'For stable, self-resolving refs across calls, use snapshot with refs="aria" (Playwright aria-ref ids). Default refs="role" are role+name-based.',
-      "Use snapshot+act for UI automation. Avoid act:wait by default; use only in exceptional cases when no reliable UI state exists.",
-      `target selects browser location (sandbox|host|node). Default: ${targetDefault}.`,
-      hostHint,
-    ].join(" "),
+    description: describeBrowserTool({ targetDefault, hostHint }),
     parameters: BrowserToolSchema,
     execute: async (toolCallId, args, signal, onUpdate) => {
       const { createBrowserTool } = await loadBrowserRegistrationRuntimeModule();

--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -77,8 +77,8 @@ function createLazyBrowserTool(opts?: {
     description: [
       "Control the browser via OpenClaw's browser control server (status/start/stop/profiles/tabs/open/snapshot/screenshot/download/actions).",
       "Browser choice: omit profile by default for the isolated OpenClaw-managed browser (`openclaw`).",
-      'For the logged-in user browser, use profile="user". A supported Chromium-based browser (v144+) must be running on the selected host or browser node. Use only when existing logins/cookies matter and the user is present.',
-      'For profile="user" or other existing-session profiles, omit timeoutMs on act:type, evaluate, hover, scrollIntoView, drag, select, and fill; that driver rejects per-call timeout overrides for those actions.',
+      "For a logged-in browser session with existing logins/cookies, use the profile configured via `browser.defaultProfile` (e.g. `openclaw` for CDP attach or `user` for Chrome MCP transport). A supported Chromium-based browser (v144+) must be running on the selected host or browser node. Use only when existing logins/cookies matter and the user is present.",
+      "For existing-session profiles (non-`openclaw`), omit timeoutMs on act:type, evaluate, hover, scrollIntoView, drag, select, and fill; that driver rejects per-call timeout overrides for those actions.",
       'When a node-hosted browser proxy is available, the tool may auto-route to it. Pin a node with node=<id|name> or target="node".',
       "When using refs from snapshot (e.g. e12), keep the same tab: prefer passing targetId from the snapshot response into subsequent actions (act/click/type/etc). For tab operations, targetId also accepts tabId handles (t1) and labels from action=tabs.",
       "For multi-step browser work, login checks, stale refs, duplicate tabs, or Google Meet flows, use the bundled browser-automation skill when it is available.",

--- a/extensions/browser/src/browser-tool-description.ts
+++ b/extensions/browser/src/browser-tool-description.ts
@@ -1,0 +1,20 @@
+/** Build the Browser tool guidance shared by lazy registration and runtime execution. */
+export function describeBrowserTool(opts: {
+  targetDefault: "sandbox" | "host";
+  hostHint: string;
+}): string {
+  return [
+    "Control the browser via OpenClaw's browser control server (status/start/stop/profiles/tabs/open/snapshot/screenshot/download/actions).",
+    "Browser choice: omit profile to use the configured default (normally the isolated OpenClaw-managed `openclaw` browser).",
+    "When existing logins/cookies matter, use action=profiles to inspect available profiles, then select the appropriate profile by name. Do not assume a profile name. Use only when the task requires an existing session and the user has authorized it.",
+    "For Chrome MCP existing-session profiles, omit timeoutMs on act:type, evaluate, hover, scrollIntoView, drag, select, and fill; that driver rejects per-call timeout overrides for those actions.",
+    'When a node-hosted browser proxy is available, the tool may auto-route to it. Pin a node with node=<id|name> or target="node".',
+    "When using refs from snapshot (e.g. e12), keep the same tab: prefer passing targetId from the snapshot response into subsequent actions (act/click/type/etc). For tab operations, targetId also accepts tabId handles (t1) and labels from action=tabs.",
+    "For multi-step browser work, login checks, stale refs, duplicate tabs, or Google Meet flows, use the bundled browser-automation skill when it is available.",
+    'For stable, self-resolving refs across calls, use snapshot with refs="aria" (Playwright aria-ref ids). Default refs="role" are role+name-based.',
+    "Use snapshot+act for UI automation. Avoid act:wait by default; use only in exceptional cases when no reliable UI state exists.",
+    "For file chooser uploads, pass the trigger ref with paths in the same upload call when available; use paths-only arming only when a later trigger is intentional. Use inputRef or element to set a file input directly.",
+    `target selects browser location (sandbox|host|node). Default: ${opts.targetDefault}.`,
+    opts.hostHint,
+  ].join(" ");
+}

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -503,7 +503,9 @@ describe("browser tool description", () => {
   it("warns agents about existing-session act timeout limits", () => {
     const tool = createBrowserTool();
 
-    expect(tool.description).toContain("browser.defaultProfile");
+    expect(tool.description).toContain("action=profiles");
+    expect(tool.description).toContain("Do not assume a profile name");
+    expect(tool.description).not.toContain('profile="user"');
     expect(tool.description).toContain("omit timeoutMs on act:type");
     expect(tool.description).toContain("existing-session profiles");
     expect(tool.description).toContain("browser-automation skill");

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -503,7 +503,7 @@ describe("browser tool description", () => {
   it("warns agents about existing-session act timeout limits", () => {
     const tool = createBrowserTool();
 
-    expect(tool.description).toContain('profile="user"');
+    expect(tool.description).toContain("browser.defaultProfile");
     expect(tool.description).toContain("omit timeoutMs on act:type");
     expect(tool.description).toContain("existing-session profiles");
     expect(tool.description).toContain("browser-automation skill");

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -5,6 +5,7 @@
  * maps high-level actions onto browser control client calls.
  */
 import crypto from "node:crypto";
+import { describeBrowserTool } from "./browser-tool-description.js";
 import {
   executeActAction,
   executeConsoleAction,
@@ -514,20 +515,7 @@ export function createBrowserTool(opts?: {
   return {
     label: "Browser",
     name: "browser",
-    description: [
-      "Control the browser via OpenClaw's browser control server (status/start/stop/profiles/tabs/open/snapshot/screenshot/actions).",
-      "Browser choice: omit profile by default for the isolated OpenClaw-managed browser (`openclaw`).",
-      'For the logged-in user browser, use profile="user". A supported Chromium-based browser (v144+) must be running on the selected host or browser node. Use only when existing logins/cookies matter and the user is present.',
-      'For profile="user" or other existing-session profiles, omit timeoutMs on act:type, evaluate, hover, scrollIntoView, drag, select, and fill; that driver rejects per-call timeout overrides for those actions.',
-      'When a node-hosted browser proxy is available, the tool may auto-route to it. Pin a node with node=<id|name> or target="node".',
-      "When using refs from snapshot (e.g. e12), keep the same tab: prefer passing targetId from the snapshot response into subsequent actions (act/click/type/etc). For tab operations, targetId also accepts tabId handles (t1) and labels from action=tabs.",
-      "For multi-step browser work, login checks, stale refs, duplicate tabs, or Google Meet flows, use the bundled browser-automation skill when it is available.",
-      'For stable, self-resolving refs across calls, use snapshot with refs="aria" (Playwright aria-ref ids). Default refs="role" are role+name-based.',
-      "Use snapshot+act for UI automation. Avoid act:wait by default; use only in exceptional cases when no reliable UI state exists.",
-      "For file chooser uploads, pass the trigger ref with paths in the same upload call when available; use paths-only arming only when a later trigger is intentional. Use inputRef or element to set a file input directly.",
-      `target selects browser location (sandbox|host|node). Default: ${targetDefault}.`,
-      hostHint,
-    ].join(" "),
+    description: describeBrowserTool({ targetDefault, hostHint }),
     parameters: BrowserToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;


### PR DESCRIPTION
Fixes #102566.

## What Problem This Solves

The Browser tool told every agent to use `profile="user"` for logged-in browser work. Profile names and trust boundaries are installation- and agent-specific; a configured default may be the isolated `openclaw` browser, while an authorized existing session can have another available name. Hardcoding one profile causes failed automation and encourages the model to guess across agent boundaries.

## Why This Change Was Made

The original PR updated only the lazy registration copy and still described profile choice in terms of assumed built-ins. The maintainer refactor deletes both duplicated descriptions and introduces one canonical renderer used by lazy registration and runtime tool creation.

The shared contract now says:

- omit `profile` for ordinary automation and use the configured default;
- when an authorized task genuinely needs an existing login/session, call `action=profiles`, inspect what is available, and select the appropriate name;
- never assume that a globally named `user` profile exists.

## User Impact

- Ordinary Browser automation keeps using the configured default with no extra discovery step.
- Existing-session work remains available; the agent discovers the right agent-local profile instead of losing functionality or guessing.
- Both tool entry points expose identical guidance, preventing future prompt drift.

## Evidence

- Blacksmith Testbox `tbx_01kx37kjs1c00s05v2c0s93hs4`: 96/96 Browser tool tests passed: https://github.com/openclaw/openclaw/actions/runs/29012539551
- Live user path on Testbox `tbx_01kx3933y0v85z8aey9gxxv9vv`: hydrated OpenAI key, `openai/gpt-5.4`, real Dev Gateway, isolated headless Chrome, and a Gateway-routed agent turn. The run made five tool calls including `browser`, recorded zero tool failures, opened and snapshotted `https://example.com`, and replied exactly `BROWSER_OK: Example Domain`: https://github.com/openclaw/openclaw/actions/runs/29013941371
- Fresh autoreview: no actionable findings, correctness confidence 0.96.
- `oxfmt` and `git diff --check` passed.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/29013159377

Original diagnosis and regression coverage by @Gary-Jia-new.
