### PR TITLE
fix(auto-reply): keep ACP steer output UTF-16 safe

### DIFF
--- a/src/auto-reply/reply/bash-command.ts
+++ b/src/auto-reply/reply/bash-command.ts
@@ -1,5 +1,4 @@
 /** Handles /bash and ! shell command chat shortcuts. */
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -55,7 +54,7 @@ function formatSessionSnippet(sessionId: string) {
   if (trimmed.length <= 12) {
     return trimmed;
   }
-  return `${truncateUtf16Safe(trimmed, 8)}…`;
+  return `${trimmed.slice(0, 8)}…`;
 }
 
 function formatOutputBlock(text: string) {

--- a/src/auto-reply/reply/bash-command.ts
+++ b/src/auto-reply/reply/bash-command.ts
@@ -1,4 +1,5 @@
 /** Handles /bash and ! shell command chat shortcuts. */
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -54,7 +55,7 @@ function formatSessionSnippet(sessionId: string) {
   if (trimmed.length <= 12) {
     return trimmed;
   }
-  return `${trimmed.slice(0, 8)}…`;
+  return `${truncateUtf16Safe(trimmed, 8)}…`;
 }
 
 function formatOutputBlock(text: string) {

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -1621,6 +1621,28 @@ describe("/acp command", () => {
     expect(result?.reply?.text).toContain("Applied steering.");
   });
 
+  it("keeps bounded ACP steer output UTF-16 safe", async () => {
+    const prefix = "a".repeat(799);
+    hoisted.callGatewayMock.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "sessions.resolve") {
+        return { key: defaultAcpSessionKey };
+      }
+      return { ok: true };
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue(createAcpSessionEntry());
+    hoisted.runTurnMock.mockImplementation(async function* () {
+      yield { type: "text_delta", text: `${prefix}😀tail` };
+      yield { type: "done" };
+    });
+
+    const result = await runDiscordAcpCommand(
+      `/acp steer --session ${defaultAcpSessionKey} tighten logging`,
+    );
+
+    expect(result?.reply?.text).toContain(`\n${prefix}…`);
+    expect(result?.reply?.text).not.toContain("😀");
+  });
+
   it("resolves bound Telegram topic ACP sessions for /acp steer without explicit target", async () => {
     hoisted.sessionBindingResolveByConversationMock.mockImplementation(
       (ref: { channel?: string; accountId?: string; conversationId?: string }) =>

--- a/src/auto-reply/reply/commands-acp/lifecycle.ts
+++ b/src/auto-reply/reply/commands-acp/lifecycle.ts
@@ -5,6 +5,7 @@ import {
   resolveAcpThreadSessionDetailLines,
 } from "@openclaw/acp-core/runtime/session-identifiers";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { getAcpSessionManager } from "../../../acp/control-plane/manager.js";
 import { resolveAcpSessionResolutionError } from "../../../acp/control-plane/manager.utils.js";
 import {
@@ -787,7 +788,7 @@ async function runAcpSteer(params: {
       if (event.text) {
         output += event.text;
         if (output.length > ACP_STEER_OUTPUT_LIMIT) {
-          output = `${output.slice(0, ACP_STEER_OUTPUT_LIMIT)}…`;
+          output = `${truncateUtf16Safe(output, ACP_STEER_OUTPUT_LIMIT)}…`;
         }
       }
     },


### PR DESCRIPTION
## What Problem This Solves

ACP steer acknowledgements buffer model-provided output up to 800 UTF-16 code units. The previous raw prefix slice could leave an unpaired surrogate when that limit fell inside an emoji or other supplementary character.

## Why This Change Was Made

The steer-output owner now uses the shared UTF-16-safe truncation helper before appending its existing ellipsis. Maintainer review removed the proposed bash-session change because bash session IDs come from a fixed ASCII slug alphabet, so that path cannot hit this bug.

## User Impact

Long `/acp steer` output remains well-formed while preserving the existing output limit and acknowledgement format.

## Evidence

- Command-level regression through `/acp steer`: 1 passed, 60 skipped.
- The test places an emoji across the 800-code-unit cutoff and verifies the delivered reply contains the safe prefix plus ellipsis.
- Targeted oxfmt and `git diff --check` pass.

## AI-assisted

The original patch was generated with Claude Code and then narrowed and tested during maintainer review.
