### PR TITLE
fix(telegram): add chunkMode and blockStreamingCoalesce to config schema

### DIFF
--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -283,6 +283,8 @@ export const TelegramAccountSchemaBase = z
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),
     direct: z.record(z.string(), TelegramDirectSchema.optional()).optional(),
     textChunkLimit: z.number().int().positive().optional(),
+    chunkMode: TextChunkModeSchema.optional(),
+    blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     richMessages: z.boolean().optional(),
     streaming: TelegramPreviewStreamingConfigSchema.optional(),
     mediaMaxMb: z.number().positive().optional(),


### PR DESCRIPTION
Fixes #102580

## What Problem This Solves

Setting the documented `channels.telegram.chunkMode` or `blockStreamingCoalesce` keys caused the gateway to crash-loop on startup with `must not have additional properties` validation errors, resulting in ~13 minutes of downtime.

## Why This Change Was Made

Both `chunkMode` and `blockStreamingCoalesce` are already supported by the Telegram outbound delivery path and documented in `docs/channels/telegram.md`, but were missing from the zod schema definition in `TelegramAccountSchemaBase`.

## Evidence

- `git diff --check` clean
- Single file change: 2 lines added to `src/config/zod-schema.providers-core.ts`
- Both keys already exist for other channels (Signal, Slack, Discord) in the same file