### PR TITLE
fix(memory-host-sdk): use truncateUtf16Safe for qmd stderr truncation

### DIFF
--- a/packages/memory-host-sdk/src/host/qmd-query-parser.ts
+++ b/packages/memory-host-sdk/src/host/qmd-query-parser.ts
@@ -1,4 +1,5 @@
 // Memory Host SDK module implements qmd query parser behavior.
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatErrorMessage } from "./error-utils.js";
 import { normalizeLowercaseStringOrEmpty } from "./string-utils.js";
 
@@ -81,7 +82,7 @@ function isQmdNoResultsLine(line: string): boolean {
 
 /** Bound stderr context included in parse errors. */
 function summarizeQmdStderr(raw: string): string {
-  return raw.length <= 120 ? raw : `${raw.slice(0, 117)}...`;
+  return raw.length <= 120 ? raw : `${truncateUtf16Safe(raw, 117)}...`;
 }
 
 /** Parse and normalize a strict qmd JSON array payload. */


### PR DESCRIPTION
## Summary

- **Problem**: `summarizeQmdStderr()` in `packages/memory-host-sdk/src/host/qmd-query-parser.ts` truncates stderr text with naive `.slice(0, 117)`, which can split UTF-16 surrogate pairs when the output contains emoji or other multi-codepoint characters.
- **Solution**: Replace `.slice(0, 117)` with `truncateUtf16Safe(raw, 117)` — a guarded slice that preserves surrogate pair integrity.
- **What changed**: One call site in `summarizeQmdStderr` + added import.
- **What did NOT change**: No API, config, or behavior change. The truncation length (117 characters) is preserved. The function signature and return type are unchanged.

## Real behavior proof

- **Behavior addressed**: String truncation that may split UTF-16 surrogate pairs in stderr text displayed in qmd parse error messages.
- **Real environment tested**: Local `pnpm tsgo:core` type check — the change is mechanical and `truncateUtf16Safe` correctness is independently verified in `packages/normalization-core/src/utf16-slice.test.ts`.
- **Exact steps or command run after this patch**: `cd packages/memory-host-sdk && npx tsc --noEmit src/host/qmd-query-parser.ts` confirms compilation. The substitution is a direct 1:1 replacement at a single call site.
- **After-fix evidence**: `truncateUtf16Safe` is already used in 13+ merged PRs (#102527, #102525, #102524, #102522, etc.) and in sibling files within the same package (`read-file-shared.ts`, `response-snippet.ts`, `internal.ts`).
- **Observed result after the fix**: Compilation succeeds. For BMP text the output is identical; for text with surrogate pairs at the boundary, the surrogate pair is preserved instead of corrupted.
- **What was not tested**: No real qmd CLI invocation (qmd tool not available locally). The change is mechanically identical to the 13+ already-merged PRs.

## Risk checklist

- **merge-risk**: Low. Single call-site, same pattern merged 13+ times. No new dependencies, no config changes, no API changes.
- **Mitigations**: `truncateUtf16Safe` has standalone unit tests in `normalization-core`. Zero behavioral change for ASCII/BMP text paths.
- Size: XS

## AI-assisted

This PR was generated with Claude Code.