### PR TITLE
fix(codex-supervisor): use truncateUtf16Safe for stderr tail truncation

### DIFF
--- a/extensions/codex-supervisor/src/json-rpc-client.ts
+++ b/extensions/codex-supervisor/src/json-rpc-client.ts
@@ -8,6 +8,7 @@ import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import WebSocket from "ws";
 import type { CodexJsonRpcConnection, CodexSupervisorEndpoint } from "./types.js";
 
@@ -199,7 +200,7 @@ class StdioCodexJsonRpcConnection extends BaseCodexJsonRpcConnection {
     this.proc.once("close", () =>
       this.fail(
         new Error(
-          `Codex app-server stdio transport closed. stderr_tail=${this.stderrTail.join("\n").slice(0, 1200)}`,
+          `Codex app-server stdio transport closed. stderr_tail=${truncateUtf16Safe(this.stderrTail.join("\n"), 1200)}`,
         ),
       ),
     );

--- a/extensions/codex-supervisor/src/supervisor.test.ts
+++ b/extensions/codex-supervisor/src/supervisor.test.ts
@@ -909,6 +909,31 @@ describe("connectCodexAppServerEndpoint", () => {
     await expect(waitForFile(marker)).resolves.toBe("closed");
   });
 
+  it("keeps stdio close errors UTF-16 safe at the stderr tail boundary", async () => {
+    const prefix = "x".repeat(1_199);
+    const script = `
+      process.stderr.write(${JSON.stringify(`${prefix}😀`)});
+      process.exit(0);
+    `;
+    let closeError: unknown;
+
+    try {
+      await connectCodexAppServerEndpoint({
+        id: "exits",
+        transport: "stdio-proxy",
+        command: process.execPath,
+        args: ["-e", script],
+      });
+    } catch (error) {
+      closeError = error;
+    }
+
+    expect(closeError).toBeInstanceOf(Error);
+    expect((closeError as Error).message).toBe(
+      `Codex app-server stdio transport closed. stderr_tail=${prefix}`,
+    );
+  });
+
   it("fails a cached stdio connection cleanly after the child exits", async () => {
     const script = `
       const readline = require("node:readline");


### PR DESCRIPTION
## What Problem This Solves

The Codex supervisor bounded child-process stderr with a raw UTF-16 slice when the app-server transport closed. An emoji crossing the 1,200-code-unit cutoff could leave an unpaired surrogate in the surfaced connection error.

## Why This Change Was Made

Use the existing `truncateUtf16Safe` plugin-SDK helper at the stderr-tail owner boundary, preserving the current limit and error shape.

## User Impact

Codex supervisor connection failures remain valid Unicode when app-server diagnostics contain supplementary characters at the cutoff.

## Evidence

- Added a real child-process regression that writes an emoji across the stderr-tail boundary and asserts the exact connection error.
- `node scripts/run-vitest.mjs extensions/codex-supervisor/src/supervisor.test.ts` — 1 file, 32 tests passed.
- Targeted oxfmt and `git diff --check` passed.
- Direct Codex contract check at `db887d03e1f907467e33271572dffb73bceecd6b`: app-server tracing is emitted to stderr in [`codex-rs/app-server/src/lib.rs`](https://github.com/openai/codex/blob/db887d03e1f907467e33271572dffb73bceecd6b/codex-rs/app-server/src/lib.rs#L649-L664).

## Files Changed

| File | Change |
|------|--------|
| `extensions/codex-supervisor/src/json-rpc-client.ts` | Keep the bounded stderr tail UTF-16 safe. |
| `extensions/codex-supervisor/src/supervisor.test.ts` | Add real stdio child-process boundary proof. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
