### PR TITLE
fix(diagnostics-prometheus): use truncateUtf16Safe for error message truncation

### DIFF
--- a/extensions/diagnostics-prometheus/src/service.test.ts
+++ b/extensions/diagnostics-prometheus/src/service.test.ts
@@ -674,6 +674,7 @@ describe("diagnostics-prometheus service", () => {
       ) => void
     > = [];
     const emitted: unknown[] = [];
+    const error = vi.fn();
     const exporter = createDiagnosticsPrometheusExporter();
     const unsubscribe = vi.fn();
 
@@ -683,7 +684,7 @@ describe("diagnostics-prometheus service", () => {
       logger: {
         info: vi.fn(),
         warn: vi.fn(),
-        error: vi.fn(),
+        error,
         debug: vi.fn(),
       },
       internalDiagnostics: {
@@ -719,6 +720,28 @@ describe("diagnostics-prometheus service", () => {
     ]);
     expect(exporter.render()).toContain(
       'openclaw_model_tokens_total{agent="unknown",channel="unknown",model="gpt-5.4",provider="openai",token_type="input"} 12',
+    );
+
+    const prefix = "x".repeat(499);
+    const usage = {} as Extract<DiagnosticEventPayload, { type: "model.usage" }>["usage"];
+    Object.defineProperty(usage, "input", {
+      get() {
+        throw new Error(`${prefix}😀`);
+      },
+    });
+    listeners[0](
+      {
+        ...baseEvent(),
+        type: "model.usage",
+        provider: "openai",
+        model: "gpt-5.4",
+        usage,
+      },
+      trusted,
+      {},
+    );
+    expect(error).toHaveBeenCalledWith(
+      `diagnostics-prometheus: event handler failed (model.usage): ${prefix}`,
     );
 
     exporter.service.stop?.();

--- a/extensions/diagnostics-prometheus/src/service.ts
+++ b/extensions/diagnostics-prometheus/src/service.ts
@@ -1,5 +1,6 @@
 // Diagnostics Prometheus plugin module implements service behavior.
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type {
   DiagnosticEventMetadata,
   DiagnosticEventPayload,
@@ -228,10 +229,12 @@ function createPrometheusMetricStore() {
 
 function safeErrorMessage(err: unknown): string {
   const message = err instanceof Error ? (err.message ?? err.name) : String(err);
-  return redactSensitiveText(message)
-    .replaceAll("\u0000", " ")
-    .replace(/[\r\n\t\u2028\u2029]/gu, " ")
-    .slice(0, 500);
+  return truncateUtf16Safe(
+    redactSensitiveText(message)
+      .replaceAll("\u0000", " ")
+      .replace(/[\r\n\t\u2028\u2029]/gu, " "),
+    500,
+  );
 }
 
 function shouldRecordDiagnosticEvent(metadata: DiagnosticEventMetadata): boolean {


### PR DESCRIPTION
## What Problem This Solves

The Prometheus diagnostics service bounded sanitized event-handler errors with `slice(0, 500)`. When an error contained an astral character across that boundary, the log could end with an unpaired UTF-16 surrogate.

## Why This Change Was Made

Use the existing `truncateUtf16Safe` utility at the final rendering boundary. The established redaction, null-byte removal, control-character normalization, and 500-code-unit limit remain unchanged.

The follow-up test exercises the public service lifecycle: it captures the registered diagnostics listener, makes the real `model.usage` recorder throw a boundary-straddling error through a property getter, and checks the complete logger output. This proves the changed call site rather than only the shared helper.

## User Impact

Prometheus exporter event-handler failures remain bounded and sanitized, but their logs no longer contain malformed UTF-16 when an emoji or another surrogate pair crosses the limit. No config, API, metric, or dependency behavior changes.

## Evidence

- `node scripts/run-vitest.mjs extensions/diagnostics-prometheus/src/service.test.ts` — 17 tests passed.
- `oxfmt` completed for the changed test.
- `git diff --check` passed.
- The regression asserts the exact public logger message after the subscribed diagnostics callback catches a real recorder exception at the 500-code-unit boundary.

## Risk

Low. One rendering boundary now uses the shared truncation invariant; ASCII and BMP output within the existing limit is unchanged.

## AI-assisted

This PR was generated with Claude Code and improved/reviewed by a maintainer agent.
