### PR TITLE
fix(parallel): use truncateUtf16Safe for MCP error JSON truncation

### DIFF
--- a/extensions/parallel/src/parallel-mcp-search.runtime.test.ts
+++ b/extensions/parallel/src/parallel-mcp-search.runtime.test.ts
@@ -78,6 +78,28 @@ function headerOf(call: EndpointCall, name: string): string | undefined {
   return (call.init.headers as Record<string, string>)[name];
 }
 
+function boundaryJsonPayload(base: Record<string, unknown>): {
+  payload: Record<string, unknown>;
+  truncatedJson: string;
+} {
+  const empty = { ...base, detail: "" };
+  const jsonPrefix = JSON.stringify(empty).slice(0, -2);
+  const detailPrefix = "x".repeat(499 - jsonPrefix.length);
+  return {
+    payload: { ...base, detail: `${detailPrefix}😀tail` },
+    truncatedJson: `${jsonPrefix}${detailPrefix}`,
+  };
+}
+
+function thrownMessage(run: () => unknown): string {
+  try {
+    run();
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  throw new Error("Expected call to throw.");
+}
+
 describe("iterMcpMessages", () => {
   it("parses a single JSON object body", () => {
     expect(iterMcpMessages('{"id":"a","result":{}}')).toEqual([{ id: "a", result: {} }]);
@@ -149,20 +171,26 @@ describe("extractMcpToolPayload", () => {
   });
 
   it("throws on a JSON-RPC error", () => {
-    expect(() => extractMcpToolPayload({ error: { code: -1, message: "boom" } })).toThrow(
-      /Parallel MCP error/,
+    const { payload, truncatedJson } = boundaryJsonPayload({ code: -1, message: "boom" });
+
+    expect(thrownMessage(() => extractMcpToolPayload({ error: payload }))).toBe(
+      `Parallel MCP error: ${truncatedJson}`,
     );
   });
 
   it("throws on a tool-level isError", () => {
-    expect(() =>
-      extractMcpToolPayload({ result: { isError: true, content: [{ type: "text", text: "{}" }] } }),
-    ).toThrow(/Parallel MCP tool error/);
+    const { payload, truncatedJson } = boundaryJsonPayload({ isError: true });
+
+    expect(thrownMessage(() => extractMcpToolPayload({ result: payload }))).toBe(
+      `Parallel MCP tool error: ${truncatedJson}`,
+    );
   });
 
   it("throws when there is no parseable content", () => {
-    expect(() => extractMcpToolPayload({ result: { content: [] } })).toThrow(
-      /no parseable content/,
+    const { payload, truncatedJson } = boundaryJsonPayload({ content: [] });
+
+    expect(thrownMessage(() => extractMcpToolPayload({ result: payload }))).toBe(
+      `Parallel MCP returned no parseable content: ${truncatedJson}`,
     );
   });
 });

--- a/extensions/parallel/src/parallel-mcp-search.runtime.ts
+++ b/extensions/parallel/src/parallel-mcp-search.runtime.ts
@@ -7,6 +7,7 @@ import {
 } from "openclaw/plugin-sdk/provider-http";
 import { withTrustedWebSearchEndpoint } from "openclaw/plugin-sdk/provider-web-search";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 // Free hosted Search MCP. This keyless transport is used only after the user
 // explicitly selects the `parallel-free` web_search provider. Docs:
@@ -154,11 +155,13 @@ export function selectMcpEnvelope(text: string, requestId: string): JsonRpcMessa
  */
 export function extractMcpToolPayload(envelope: JsonRpcMessage): McpToolPayload {
   if ("error" in envelope) {
-    throw new Error(`Parallel MCP error: ${JSON.stringify(envelope.error).slice(0, 500)}`);
+    throw new Error(
+      `Parallel MCP error: ${truncateUtf16Safe(JSON.stringify(envelope.error), 500)}`,
+    );
   }
   const result = isRecord(envelope.result) ? envelope.result : {};
   if (result.isError) {
-    throw new Error(`Parallel MCP tool error: ${JSON.stringify(result).slice(0, 500)}`);
+    throw new Error(`Parallel MCP tool error: ${truncateUtf16Safe(JSON.stringify(result), 500)}`);
   }
   if (isRecord(result.structuredContent)) {
     return result.structuredContent;
@@ -177,7 +180,7 @@ export function extractMcpToolPayload(envelope: JsonRpcMessage): McpToolPayload 
     }
   }
   throw new Error(
-    `Parallel MCP returned no parseable content: ${JSON.stringify(result).slice(0, 500)}`,
+    `Parallel MCP returned no parseable content: ${truncateUtf16Safe(JSON.stringify(result), 500)}`,
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

The free Parallel MCP client includes bounded JSON details in three thrown errors: protocol-level JSON-RPC failures, tool results with `isError`, and successful envelopes without parseable content. All three used `slice(0, 500)`, so externally supplied error data could leave a dangling UTF-16 surrogate at the boundary.

## Why This Change Was Made

Use the existing `truncateUtf16Safe` utility at each error-rendering boundary. This preserves the exact prefixes and 500-code-unit cap without changing MCP parsing or transport behavior.

The follow-up tests drive all three branches through `extractMcpToolPayload`. Each builds its real JSON shape with an emoji crossing code unit 500 and asserts the complete thrown message, not merely helper output.

This matches the MCP contract's distinct protocol-error and tool-error forms: tool-level failures use `isError` in the call result, while exceptional protocol failures use JSON-RPC error envelopes. See the [official MCP tool-result documentation](https://csharp.sdk.modelcontextprotocol.io/api/ModelContextProtocol.Protocol.CallToolResult.html) and [Parallel Search MCP documentation](https://docs.parallel.ai/integrations/mcp/search-mcp).

## User Impact

Parallel free-search failures remain bounded and diagnostic, but no longer contain malformed Unicode at the error limit. No provider selection, request, response, config, or cache behavior changes.

## Evidence

- `node ../../node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extension-misc.config.ts extensions/parallel/src/parallel-mcp-search.runtime.test.ts` — 18 tests passed.
- `oxfmt` completed on the runtime and test.
- `git diff --check` passed.
- Live public endpoint proof on 2026-07-09: `https://search.parallel.ai/mcp` accepted the implemented 2025-06-18 initialize request with HTTP 200 and a negotiated session, accepted `notifications/initialized` with HTTP 202, and returned a successful JSON-RPC `tools/call` response for `web_search` with `content`, `isError: false`, results, usage, and session data.
- Official-source review confirmed the error forms exercised by the three regressions.

## Risk

Low. Three existing error strings now share the established UTF-16 truncation invariant; successful MCP behavior is unchanged.

## AI-assisted

This PR was generated with Claude Code and improved/reviewed by a maintainer agent.
