### PR TITLE
fix(ollama): use truncateUtf16Safe for malformed NDJSON log truncation

### DIFF
--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1,13 +1,22 @@
 // Ollama tests cover stream runtime plugin behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
+const { fetchWithSsrFGuardMock, ollamaStreamWarnMock } = vi.hoisted(() => ({
   fetchWithSsrFGuardMock: vi.fn(),
+  ollamaStreamWarnMock: vi.fn(),
 }));
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
 }));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>();
+  return {
+    ...actual,
+    createSubsystemLogger: () => ({ warn: ollamaStreamWarnMock }),
+  };
+});
 
 import {
   OLLAMA_INCOMPLETE_STREAM_ERROR,
@@ -73,6 +82,7 @@ function expectIteratorEvent(
 
 afterEach(() => {
   fetchWithSsrFGuardMock.mockReset();
+  ollamaStreamWarnMock.mockReset();
 });
 
 describe("buildOllamaChatRequest", () => {
@@ -1433,9 +1443,12 @@ describe("buildAssistantMessage", () => {
 });
 
 // Helper: build a ReadableStreamDefaultReader from NDJSON lines
-function mockNdjsonReader(lines: string[]): ReadableStreamDefaultReader<Uint8Array> {
+function mockNdjsonReader(
+  lines: string[],
+  options: { trailingNewline?: boolean } = {},
+): ReadableStreamDefaultReader<Uint8Array> {
   const encoder = new TextEncoder();
-  const payload = lines.join("\n") + "\n";
+  const payload = lines.join("\n") + (options.trailingNewline === false ? "" : "\n");
   let consumed = false;
   return {
     read: async () => {
@@ -1466,6 +1479,32 @@ async function expectDoneEventContent(lines: string[], expectedContent: unknown)
 }
 
 describe("parseNdjsonStream", () => {
+  it("does not log a dangling surrogate for a malformed complete line", async () => {
+    const prefix = "x".repeat(119);
+    const reader = mockNdjsonReader([`${prefix}😀tail`]);
+
+    for await (const _chunk of parseNdjsonStream(reader)) {
+      throw new Error("expected malformed line to be skipped");
+    }
+
+    expect(ollamaStreamWarnMock).toHaveBeenCalledExactlyOnceWith(
+      `Skipping malformed NDJSON line: ${prefix}`,
+    );
+  });
+
+  it("does not log a dangling surrogate for malformed trailing data", async () => {
+    const prefix = "x".repeat(119);
+    const reader = mockNdjsonReader([`${prefix}😀tail`], { trailingNewline: false });
+
+    for await (const _chunk of parseNdjsonStream(reader)) {
+      throw new Error("expected malformed trailing data to be skipped");
+    }
+
+    expect(ollamaStreamWarnMock).toHaveBeenCalledExactlyOnceWith(
+      `Skipping malformed trailing data: ${prefix}`,
+    );
+  });
+
   it("parses text-only streaming chunks", async () => {
     const reader = mockNdjsonReader([
       '{"model":"m","created_at":"t","message":{"role":"assistant","content":"Hello"},"done":false}',

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1478,14 +1478,20 @@ async function expectDoneEventContent(lines: string[], expectedContent: unknown)
   });
 }
 
+async function expectNoParsedChunks(reader: ReadableStreamDefaultReader<Uint8Array>) {
+  const chunks = [];
+  for await (const chunk of parseNdjsonStream(reader)) {
+    chunks.push(chunk);
+  }
+  expect(chunks).toEqual([]);
+}
+
 describe("parseNdjsonStream", () => {
   it("does not log a dangling surrogate for a malformed complete line", async () => {
     const prefix = "x".repeat(119);
     const reader = mockNdjsonReader([`${prefix}😀tail`]);
 
-    for await (const _chunk of parseNdjsonStream(reader)) {
-      throw new Error("expected malformed line to be skipped");
-    }
+    await expectNoParsedChunks(reader);
 
     expect(ollamaStreamWarnMock).toHaveBeenCalledExactlyOnceWith(
       `Skipping malformed NDJSON line: ${prefix}`,
@@ -1496,9 +1502,7 @@ describe("parseNdjsonStream", () => {
     const prefix = "x".repeat(119);
     const reader = mockNdjsonReader([`${prefix}😀tail`], { trailingNewline: false });
 
-    for await (const _chunk of parseNdjsonStream(reader)) {
-      throw new Error("expected malformed trailing data to be skipped");
-    }
+    await expectNoParsedChunks(reader);
 
     expect(ollamaStreamWarnMock).toHaveBeenCalledExactlyOnceWith(
       `Skipping malformed trailing data: ${prefix}`,

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -36,6 +36,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   readStringValue,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { OLLAMA_DEFAULT_BASE_URL } from "./defaults.js";
 import { shouldWrapOllamaCompatMoonshotThinking } from "./model-behavior.js";
 import { normalizeOllamaWireModelId } from "./model-id.js";
@@ -52,8 +53,7 @@ import {
 const log = createSubsystemLogger("ollama-stream");
 
 export const OLLAMA_NATIVE_BASE_URL = OLLAMA_DEFAULT_BASE_URL;
-export const OLLAMA_INCOMPLETE_STREAM_ERROR =
-  "Ollama API stream ended without a final response";
+export const OLLAMA_INCOMPLETE_STREAM_ERROR = "Ollama API stream ended without a final response";
 
 const OLLAMA_STREAM_COOPERATIVE_YIELD_INTERVAL_MS = 12;
 const OLLAMA_STREAM_COOPERATIVE_YIELD_MAX_EVENTS = 64;
@@ -1067,7 +1067,7 @@ export async function* parseNdjsonStream(
       try {
         yield parseJsonPreservingUnsafeIntegers(trimmed) as OllamaChatResponse;
       } catch {
-        log.warn(`Skipping malformed NDJSON line: ${trimmed.slice(0, 120)}`);
+        log.warn(`Skipping malformed NDJSON line: ${truncateUtf16Safe(trimmed, 120)}`);
       }
     }
   }
@@ -1076,7 +1076,7 @@ export async function* parseNdjsonStream(
     try {
       yield parseJsonPreservingUnsafeIntegers(buffer.trim()) as OllamaChatResponse;
     } catch {
-      log.warn(`Skipping malformed trailing data: ${buffer.trim().slice(0, 120)}`);
+      log.warn(`Skipping malformed trailing data: ${truncateUtf16Safe(buffer.trim(), 120)}`);
     }
   }
 }


### PR DESCRIPTION
## What Problem This Solves

`parseNdjsonStream()` included malformed Ollama response data in two warning messages using `.slice(0, 120)`. When an emoji or another supplementary Unicode character straddled that UTF-16 boundary, the preview ended with a dangling surrogate and could render as corrupted text.

## Why This Change Was Made

Both malformed-input branches now use the existing `truncateUtf16Safe(..., 120)` helper exported by the plugin SDK. This preserves the existing 120-code-unit bound and warning text while ensuring the preview never ends in half of a surrogate pair.

The focused tests exercise both parser states rather than testing the helper in isolation:

- a complete malformed NDJSON line terminated by a newline;
- malformed trailing data when the stream ends without a newline.

Each input places an emoji exactly across the truncation boundary and asserts the complete warning string.

## User Impact

Ollama diagnostic warnings remain readable when malformed streamed data contains supplementary Unicode near the preview boundary. Valid stream parsing, API behavior, configuration, and dependencies are unchanged.

## Evidence

- `node ../../node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extension-providers.config.ts extensions/ollama/src/stream-runtime.test.ts` — 104 tests passed.
- `oxfmt` and `git diff --check` passed for the touched files.
- Live local Ollama 0.31.2 validation on 2026-07-09: `/api/chat` with `qwen3:0.6b` returned HTTP 200, `Content-Type: application/x-ndjson`, a streamed content record, and a final `done: true` record.
- Ollama's official streaming contract documents newline-delimited JSON with the `application/x-ndjson` content type: https://docs.ollama.com/api/streaming

The live service correctly produced valid NDJSON; malformed-wire behavior was therefore injected at the exported parser boundary in the focused tests. No API, config, or dependency surface changes.

## AI-assisted

This PR was generated with Claude Code and improved/reviewed with Codex.
