### PR TITLE
fix(slack): include canonical session transcript in prompt context (extends #95390)

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -13,6 +13,7 @@ import {
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
 import { upsertSessionEntry, type SessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedSlackAccount } from "../../accounts.js";
 import {
@@ -2304,6 +2305,229 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     assertPrepared(existing, "existing message");
     expect(history).not.toHaveBeenCalled();
     expect(existing.ctxPayload.InboundHistory).toBeUndefined();
+  });
+
+  async function writeSlackSessionTranscriptContext(params: {
+    storePath: string;
+    sessionKey: string;
+    sessionId: string;
+    turns: Array<{ id: string; role: "user" | "assistant"; text: string; timestamp: number }>;
+  }) {
+    await seedSessionEntries(params.storePath, {
+      [params.sessionKey]: {
+        sessionId: params.sessionId,
+        updatedAt: Date.now(),
+      },
+    });
+    for (const turn of params.turns) {
+      await appendSessionTranscriptMessageByIdentity({
+        agentId: "main",
+        storePath: params.storePath,
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        message: { role: turn.role, content: turn.text, timestamp: turn.timestamp },
+        eventId: turn.id,
+      });
+    }
+  }
+
+  function createTranscriptRoomCtx(storePath: string) {
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        session: { store: storePath },
+        channels: { slack: { enabled: true } },
+      } as OpenClawConfig,
+      defaultRequireMention: false,
+    });
+    slackCtx.historyLimit = 5;
+    slackCtx.resolveChannelName = async () => ({ name: "general", type: "channel" });
+    slackCtx.resolveUserName = async () => ({ name: "Alice" });
+    return slackCtx;
+  }
+
+  function createTranscriptRoomMessage(overrides: Partial<SlackMessageEvent>): SlackMessageEvent {
+    return createSlackMessage({
+      channel: "C123",
+      channel_type: "channel",
+      ...overrides,
+    });
+  }
+
+  it("merges canonical session transcript turns into channel wake context", async () => {
+    const { storePath } = storeFixture.makeTmpStorePath();
+    const slackCtx = createTranscriptRoomCtx(storePath);
+    const account = createSlackAccount();
+
+    const first = await prepareMessageWith(
+      slackCtx,
+      account,
+      createTranscriptRoomMessage({ text: "hello from the channel", ts: "100.000" }),
+    );
+    assertPrepared(first, "first channel message");
+
+    await writeSlackSessionTranscriptContext({
+      storePath,
+      sessionKey: first.ctxPayload.SessionKey!,
+      sessionId: "slack-channel-transcript-session",
+      turns: [
+        {
+          id: "transcript-user-1",
+          role: "user",
+          text: "hello from the channel",
+          timestamp: 100_000,
+        },
+        {
+          id: "transcript-assistant-1",
+          role: "assistant",
+          text: "Launch checklist noted; ping me at T-10.",
+          timestamp: 150_000,
+        },
+      ],
+    });
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      account,
+      createTranscriptRoomMessage({ text: "what did you say earlier?", ts: "200.000" }),
+    );
+
+    assertPrepared(prepared);
+    expect(prepared.ctxPayload.SessionKey).toBe(first.ctxPayload.SessionKey);
+    // The transcript copy of the cached channel message dedupes away; the
+    // assistant turn only exists in the transcript and must be merged in.
+    expect(prepared.ctxPayload.InboundHistory).toEqual([
+      {
+        sender: "Alice",
+        body: "hello from the channel",
+        timestamp: 100_000,
+        messageId: "100.000",
+      },
+      {
+        messageId: "session:transcript-assistant-1",
+        sender: "Assistant (assistant)",
+        body: "Launch checklist noted; ping me at T-10.",
+        timestamp: 150_000,
+      },
+    ]);
+  });
+
+  it("skips session transcript context for control-command messages", async () => {
+    const { storePath } = storeFixture.makeTmpStorePath();
+    const slackCtx = createTranscriptRoomCtx(storePath);
+    const account = createSlackAccount();
+
+    const first = await prepareMessageWith(
+      slackCtx,
+      account,
+      createTranscriptRoomMessage({ text: "hello from the channel", ts: "100.000" }),
+    );
+    assertPrepared(first, "first channel message");
+
+    await writeSlackSessionTranscriptContext({
+      storePath,
+      sessionKey: first.ctxPayload.SessionKey!,
+      sessionId: "slack-channel-reset-session",
+      turns: [
+        {
+          id: "transcript-user-1",
+          role: "user",
+          text: "old channel transcript text",
+          timestamp: 150_000,
+        },
+      ],
+    });
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      account,
+      createTranscriptRoomMessage({ text: "/new summarize my workspace", ts: "200.000" }),
+    );
+
+    assertPrepared(prepared);
+    expect(JSON.stringify(prepared.ctxPayload.InboundHistory ?? [])).not.toContain(
+      "old channel transcript text",
+    );
+  });
+
+  it("merges session transcript turns into Enterprise Grid org-install channel wakes", async () => {
+    const { storePath } = storeFixture.makeTmpStorePath();
+    const slackCtx = createTranscriptRoomCtx(storePath);
+    const account = createSlackAccount();
+    const eventScope = {
+      apiAppId: "A1",
+      enterpriseId: "E1",
+      isEnterpriseInstall: true,
+      teamId: "T_ENTERPRISE",
+      client: {} as SlackEventScope["client"],
+    } satisfies SlackEventScope;
+    const prepareGridMessage = (message: SlackMessageEvent) =>
+      prepareSlackMessage({
+        ctx: slackCtx,
+        account,
+        message,
+        opts: { source: "message", eventScope },
+      });
+
+    const classic = await prepareMessageWith(
+      slackCtx,
+      account,
+      createTranscriptRoomMessage({ text: "classic workspace wake", ts: "50.000" }),
+    );
+    assertPrepared(classic, "classic channel message");
+
+    const first = await prepareGridMessage(
+      createTranscriptRoomMessage({ text: "hello from the grid channel", ts: "100.000" }),
+    );
+    assertPrepared(first, "first Grid channel message");
+    // Org installs qualify the room session key with the event workspace, so
+    // the transcript read must target the Grid-scoped key, not the classic
+    // per-channel key.
+    expect(first.ctxPayload.SessionKey).toContain("team:t_enterprise");
+    expect(first.ctxPayload.SessionKey).not.toBe(classic.ctxPayload.SessionKey);
+
+    await writeSlackSessionTranscriptContext({
+      storePath,
+      sessionKey: first.ctxPayload.SessionKey!,
+      sessionId: "slack-grid-transcript-session",
+      turns: [
+        {
+          id: "grid-user-1",
+          role: "user",
+          text: "hello from the grid channel",
+          timestamp: 100_000,
+        },
+        {
+          id: "grid-assistant-1",
+          role: "assistant",
+          text: "Grid rollout is at 60 percent.",
+          timestamp: 150_000,
+        },
+      ],
+    });
+
+    const prepared = await prepareGridMessage(
+      createTranscriptRoomMessage({ text: "what did you say earlier?", ts: "200.000" }),
+    );
+
+    assertPrepared(prepared);
+    expect(prepared.ctxPayload.SessionKey).toBe(first.ctxPayload.SessionKey);
+    // The classic wake stays out of the Grid history window (team-scoped
+    // historyKey), the transcript copy of the cached Grid message dedupes
+    // away, and the assistant turn merges in from the transcript.
+    expect(prepared.ctxPayload.InboundHistory).toEqual([
+      {
+        sender: "Alice",
+        body: "hello from the grid channel",
+        timestamp: 100_000,
+        messageId: "100.000",
+      },
+      {
+        messageId: "session:grid-assistant-1",
+        sender: "Assistant (assistant)",
+        body: "Grid rollout is at 60 percent.",
+        timestamp: 150_000,
+      },
+    ]);
   });
 
   it("uses room users allowlist for thread context filtering", async () => {

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -45,6 +45,10 @@ import { formatSlackError } from "../../errors.js";
 import { formatSlackFileReference } from "../../file-reference.js";
 import type { SlackSendIdentity } from "../../send.js";
 import { hasSlackThreadParticipationWithPersistence } from "../../sent-thread-cache.js";
+import {
+  buildSlackSessionTranscriptHistoryEntries,
+  mergeSlackSessionTranscriptInboundHistory,
+} from "../../session-transcript-context.js";
 import type { SlackAttachment, SlackFile, SlackMessageEvent } from "../../types.js";
 import { normalizeAllowListLower, normalizeSlackAllowOwnerEntry } from "../allow-list.js";
 import {
@@ -1477,13 +1481,35 @@ export async function prepareSlackMessage(params: {
     transcribed: (entry) =>
       effectiveMedia === effectiveDirectMedia && entry === preflightAudioMedia,
   });
-  const inboundHistory =
-    isRoomish && ctx.historyLimit > 0
-      ? channelHistory.buildInboundHistory({
-          historyKey,
-          limit: ctx.historyLimit,
+  // Channel and thread sessions rebuild prompt context from the in-memory
+  // channel-history window, which never contains this bot's own replies and is
+  // empty after a gateway restart. Merge a bounded window of the session's
+  // canonical transcript so the agent keeps seeing its own recent turns.
+  // Control commands (e.g. /new, /reset) are skipped so a session reset does
+  // not resurrect the transcript the user just cleared.
+  const sessionTranscriptBeforeTimestampMs = resolveSlackTimestampMs(message.ts);
+  const sessionTranscriptEntries =
+    isRoomish && ctx.historyLimit > 0 && !hasControlCommandInMessage
+      ? await buildSlackSessionTranscriptHistoryEntries({
+          agentId: route.agentId,
+          sessionKey,
+          storePath,
+          limit: 10,
+          ...(sessionTranscriptBeforeTimestampMs !== undefined
+            ? { beforeTimestampMs: sessionTranscriptBeforeTimestampMs }
+            : {}),
         })
-      : dmHistoryContext.inboundHistory;
+      : [];
+  const inboundHistory = mergeSlackSessionTranscriptInboundHistory({
+    sessionEntries: sessionTranscriptEntries,
+    inboundHistory:
+      isRoomish && ctx.historyLimit > 0
+        ? channelHistory.buildInboundHistory({
+            historyKey,
+            limit: ctx.historyLimit,
+          })
+        : dmHistoryContext.inboundHistory,
+  });
   const commandBody = textForCommandDetection.trim();
   const supplementalThreadHistoryBody =
     directThreadRoutedToDmSession && !threadHistoryBody ? threadStarterBody : threadHistoryBody;

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -1502,6 +1502,7 @@ export async function prepareSlackMessage(params: {
       : [];
   const inboundHistory = mergeSlackSessionTranscriptInboundHistory({
     sessionEntries: sessionTranscriptEntries,
+    ...(isRoomish && ctx.historyLimit > 0 ? { limit: ctx.historyLimit } : {}),
     inboundHistory:
       isRoomish && ctx.historyLimit > 0
         ? channelHistory.buildInboundHistory({

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -1494,7 +1494,9 @@ export async function prepareSlackMessage(params: {
           agentId: route.agentId,
           sessionKey,
           storePath,
-          limit: 10,
+          // Read the configured window plus a bounded cushion because duplicate
+          // persisted rows are collapsed before the final historyLimit cap.
+          limit: ctx.historyLimit + 10,
           ...(sessionTranscriptBeforeTimestampMs !== undefined
             ? { beforeTimestampMs: sessionTranscriptBeforeTimestampMs }
             : {}),

--- a/extensions/slack/src/session-transcript-context.test.ts
+++ b/extensions/slack/src/session-transcript-context.test.ts
@@ -1,0 +1,184 @@
+// Slack tests cover session transcript prompt context behavior.
+import { readRecentUserAssistantTextForSession } from "openclaw/plugin-sdk/session-store-runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildSlackSessionTranscriptHistoryEntries,
+  mergeSlackSessionTranscriptInboundHistory,
+} from "./session-transcript-context.js";
+
+vi.mock("openclaw/plugin-sdk/session-store-runtime", () => ({
+  readRecentUserAssistantTextForSession: vi.fn(),
+}));
+
+const readRecentUserAssistantTextForSessionMock = vi.mocked(readRecentUserAssistantTextForSession);
+
+describe("buildSlackSessionTranscriptHistoryEntries", () => {
+  beforeEach(() => {
+    readRecentUserAssistantTextForSessionMock.mockReset();
+  });
+
+  it("maps shared session turns into chronological Slack history entries", async () => {
+    readRecentUserAssistantTextForSessionMock.mockResolvedValue([
+      {
+        id: "u1",
+        role: "user",
+        text: "Analyze this chart",
+        timestamp: 1_000,
+        sourceChannel: "gateway",
+      },
+      {
+        id: "a1",
+        role: "assistant",
+        text: "The chart is range-bound; want an alert?",
+        timestamp: 2_000,
+      },
+    ]);
+
+    await expect(
+      buildSlackSessionTranscriptHistoryEntries({
+        agentId: "main",
+        sessionKey: "agent:main:slack:channel:c123",
+        storePath: "/tmp/sessions.json",
+        beforeTimestampMs: 3_000,
+        limit: 10,
+      }),
+    ).resolves.toEqual([
+      {
+        messageId: "session:u1",
+        sender: "User (user, gateway)",
+        timestamp: 1_000,
+        body: "Analyze this chart",
+      },
+      {
+        messageId: "session:a1",
+        sender: "Assistant (assistant)",
+        timestamp: 2_000,
+        body: "The chart is range-bound; want an alert?",
+      },
+    ]);
+    expect(readRecentUserAssistantTextForSessionMock).toHaveBeenCalledWith({
+      agentId: "main",
+      sessionKey: "agent:main:slack:channel:c123",
+      storePath: "/tmp/sessions.json",
+      limit: 10,
+      beforeTimestampMs: 3_000,
+    });
+  });
+
+  it("forwards thread session keys unchanged to the SDK reader", async () => {
+    readRecentUserAssistantTextForSessionMock.mockResolvedValue([]);
+
+    await buildSlackSessionTranscriptHistoryEntries({
+      agentId: "main",
+      sessionKey: "agent:main:slack:channel:c123:thread:100.000",
+      storePath: "/tmp/sessions.json",
+      beforeTimestampMs: 5_000,
+      limit: 10,
+    });
+
+    expect(readRecentUserAssistantTextForSessionMock).toHaveBeenCalledWith({
+      agentId: "main",
+      sessionKey: "agent:main:slack:channel:c123:thread:100.000",
+      storePath: "/tmp/sessions.json",
+      limit: 10,
+      beforeTimestampMs: 5_000,
+    });
+  });
+});
+
+describe("mergeSlackSessionTranscriptInboundHistory", () => {
+  it("returns the channel window unchanged when the session has no transcript turns", () => {
+    const inboundHistory = [{ sender: "Alice", body: "hello", timestamp: 1_000 }];
+
+    expect(mergeSlackSessionTranscriptInboundHistory({ sessionEntries: [], inboundHistory })).toBe(
+      inboundHistory,
+    );
+    expect(
+      mergeSlackSessionTranscriptInboundHistory({ sessionEntries: [], inboundHistory: undefined }),
+    ).toBeUndefined();
+  });
+
+  it("dedupes transcript turns already present in the channel window by timestamp and text", () => {
+    const merged = mergeSlackSessionTranscriptInboundHistory({
+      sessionEntries: [
+        {
+          messageId: "session:u1",
+          sender: "User (user)",
+          body: "hello",
+          timestamp: 1_000,
+        },
+        {
+          messageId: "session:a1",
+          sender: "Assistant (assistant)",
+          body: "hi, want a summary?",
+          timestamp: 2_000,
+        },
+      ],
+      inboundHistory: [
+        { sender: "Alice", body: "hello", timestamp: 1_000, messageId: "1.000" },
+        { sender: "Alice", body: "yes please", timestamp: 3_000, messageId: "3.000" },
+      ],
+    });
+
+    expect(merged).toEqual([
+      { sender: "Alice", body: "hello", timestamp: 1_000, messageId: "1.000" },
+      {
+        messageId: "session:a1",
+        sender: "Assistant (assistant)",
+        body: "hi, want a summary?",
+        timestamp: 2_000,
+      },
+      { sender: "Alice", body: "yes please", timestamp: 3_000, messageId: "3.000" },
+    ]);
+  });
+
+  it("collapses duplicated transcript rows for the same turn", () => {
+    // real transcripts can persist one turn twice (e.g. streamed replies);
+    // observed on a production session store during PR verification
+    const duplicatedReply = {
+      sender: "Assistant (assistant)",
+      body: "updated the record",
+      timestamp: 2_000,
+    };
+    const merged = mergeSlackSessionTranscriptInboundHistory({
+      sessionEntries: [
+        {
+          sender: "User (user)",
+          body: "please update the record",
+          timestamp: 1_000,
+        },
+        duplicatedReply,
+        { ...duplicatedReply },
+      ],
+      inboundHistory: [
+        { sender: "Alice", body: "unrelated", timestamp: 3_000, messageId: "3.000" },
+      ],
+    });
+
+    expect(merged).toEqual([
+      {
+        sender: "User (user)",
+        body: "please update the record",
+        timestamp: 1_000,
+      },
+      duplicatedReply,
+      { sender: "Alice", body: "unrelated", timestamp: 3_000, messageId: "3.000" },
+    ]);
+  });
+
+  it("sorts merged entries chronologically and keeps untimestamped entries first", () => {
+    const merged = mergeSlackSessionTranscriptInboundHistory({
+      sessionEntries: [{ sender: "Assistant (assistant)", body: "later reply", timestamp: 5_000 }],
+      inboundHistory: [
+        { sender: "Alice", body: "no timestamp" },
+        { sender: "Alice", body: "earlier message", timestamp: 1_000 },
+      ],
+    });
+
+    expect(merged?.map((entry) => entry.body)).toEqual([
+      "no timestamp",
+      "earlier message",
+      "later reply",
+    ]);
+  });
+});

--- a/extensions/slack/src/session-transcript-context.test.ts
+++ b/extensions/slack/src/session-transcript-context.test.ts
@@ -17,7 +17,7 @@ describe("buildSlackSessionTranscriptHistoryEntries", () => {
     readRecentUserAssistantTextForSessionMock.mockReset();
   });
 
-  it("maps shared session turns into chronological Slack history entries", async () => {
+  it("maps assistant session turns without re-injecting persisted user prompts", async () => {
     readRecentUserAssistantTextForSessionMock.mockResolvedValue([
       {
         id: "u1",
@@ -44,12 +44,6 @@ describe("buildSlackSessionTranscriptHistoryEntries", () => {
       }),
     ).resolves.toEqual([
       {
-        messageId: "session:u1",
-        sender: "User (user, gateway)",
-        timestamp: 1_000,
-        body: "Analyze this chart",
-      },
-      {
         messageId: "session:a1",
         sender: "Assistant (assistant)",
         timestamp: 2_000,
@@ -61,6 +55,7 @@ describe("buildSlackSessionTranscriptHistoryEntries", () => {
       sessionKey: "agent:main:slack:channel:c123",
       storePath: "/tmp/sessions.json",
       limit: 10,
+      role: "assistant",
       beforeTimestampMs: 3_000,
     });
   });
@@ -81,6 +76,7 @@ describe("buildSlackSessionTranscriptHistoryEntries", () => {
       sessionKey: "agent:main:slack:channel:c123:thread:100.000",
       storePath: "/tmp/sessions.json",
       limit: 10,
+      role: "assistant",
       beforeTimestampMs: 5_000,
     });
   });

--- a/extensions/slack/src/session-transcript-context.test.ts
+++ b/extensions/slack/src/session-transcript-context.test.ts
@@ -181,4 +181,17 @@ describe("mergeSlackSessionTranscriptInboundHistory", () => {
       "later reply",
     ]);
   });
+
+  it("caps the merged window to the configured history limit", () => {
+    const merged = mergeSlackSessionTranscriptInboundHistory({
+      sessionEntries: [
+        { sender: "Assistant", body: "old reply", timestamp: 1_000 },
+        { sender: "Assistant", body: "recent reply", timestamp: 3_000 },
+      ],
+      inboundHistory: [{ sender: "Alice", body: "middle message", timestamp: 2_000 }],
+      limit: 2,
+    });
+
+    expect(merged?.map((entry) => entry.body)).toEqual(["middle message", "recent reply"]);
+  });
 });

--- a/extensions/slack/src/session-transcript-context.ts
+++ b/extensions/slack/src/session-transcript-context.ts
@@ -33,13 +33,14 @@ export async function buildSlackSessionTranscriptHistoryEntries(
     agentId: params.agentId,
     sessionKey: params.sessionKey,
     limit: params.limit,
+    role: "assistant",
     ...(params.storePath !== undefined ? { storePath: params.storePath } : {}),
     ...(params.beforeTimestampMs !== undefined
       ? { beforeTimestampMs: params.beforeTimestampMs }
       : {}),
     ...(params.minTimestampMs !== undefined ? { minTimestampMs: params.minTimestampMs } : {}),
   });
-  return entries.map(toSessionTranscriptHistoryEntry);
+  return entries.filter((entry) => entry.role === "assistant").map(toSessionTranscriptHistoryEntry);
 }
 
 function resolveHistoryTextDedupeKey(entry: HistoryEntry): string | undefined {

--- a/extensions/slack/src/session-transcript-context.ts
+++ b/extensions/slack/src/session-transcript-context.ts
@@ -1,0 +1,87 @@
+// Slack plugin module implements session transcript prompt context behavior.
+import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
+import {
+  readRecentUserAssistantTextForSession,
+  type SessionRecentConversationText,
+} from "openclaw/plugin-sdk/session-store-runtime";
+
+type BuildSlackSessionTranscriptHistoryEntriesParams = {
+  agentId: string;
+  beforeTimestampMs?: number;
+  limit: number;
+  minTimestampMs?: number;
+  sessionKey: string;
+  storePath?: string;
+};
+
+function toSessionTranscriptHistoryEntry(entry: SessionRecentConversationText): HistoryEntry {
+  const senderBase = entry.role === "assistant" ? "Assistant" : "User";
+  return {
+    ...(entry.id ? { messageId: `session:${entry.id}` } : {}),
+    sender: entry.sourceChannel
+      ? `${senderBase} (${entry.role}, ${entry.sourceChannel})`
+      : `${senderBase} (${entry.role})`,
+    ...(entry.timestamp !== undefined ? { timestamp: entry.timestamp } : {}),
+    body: entry.text,
+  };
+}
+
+export async function buildSlackSessionTranscriptHistoryEntries(
+  params: BuildSlackSessionTranscriptHistoryEntriesParams,
+): Promise<HistoryEntry[]> {
+  const entries = await readRecentUserAssistantTextForSession({
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+    limit: params.limit,
+    ...(params.storePath !== undefined ? { storePath: params.storePath } : {}),
+    ...(params.beforeTimestampMs !== undefined
+      ? { beforeTimestampMs: params.beforeTimestampMs }
+      : {}),
+    ...(params.minTimestampMs !== undefined ? { minTimestampMs: params.minTimestampMs } : {}),
+  });
+  return entries.map(toSessionTranscriptHistoryEntry);
+}
+
+function resolveHistoryTextDedupeKey(entry: HistoryEntry): string | undefined {
+  const body = entry.body.trim();
+  if (!body) {
+    return undefined;
+  }
+  if (typeof entry.timestamp !== "number" || !Number.isFinite(entry.timestamp)) {
+    return undefined;
+  }
+  return `${entry.timestamp}:${body}`;
+}
+
+export function mergeSlackSessionTranscriptInboundHistory(params: {
+  sessionEntries: HistoryEntry[];
+  inboundHistory: HistoryEntry[] | undefined;
+}): HistoryEntry[] | undefined {
+  if (params.sessionEntries.length === 0) {
+    return params.inboundHistory;
+  }
+  const inboundEntries = params.inboundHistory ?? [];
+  const inboundTextKeys = new Set(
+    inboundEntries
+      .map((entry) => resolveHistoryTextDedupeKey(entry))
+      .filter((key) => key !== undefined),
+  );
+  // Dedupe within the transcript window too: real transcripts can contain
+  // duplicated rows for one turn (e.g. streamed replies persisted twice), and
+  // those would otherwise both reach prompt context.
+  const seenSessionKeys = new Set<string>();
+  const sessionOnlyEntries = params.sessionEntries.filter((entry) => {
+    const key = resolveHistoryTextDedupeKey(entry);
+    if (key === undefined) {
+      return true;
+    }
+    if (inboundTextKeys.has(key) || seenSessionKeys.has(key)) {
+      return false;
+    }
+    seenSessionKeys.add(key);
+    return true;
+  });
+  return [...sessionOnlyEntries, ...inboundEntries].toSorted(
+    (left, right) => (left.timestamp ?? 0) - (right.timestamp ?? 0),
+  );
+}

--- a/extensions/slack/src/session-transcript-context.ts
+++ b/extensions/slack/src/session-transcript-context.ts
@@ -56,6 +56,7 @@ function resolveHistoryTextDedupeKey(entry: HistoryEntry): string | undefined {
 export function mergeSlackSessionTranscriptInboundHistory(params: {
   sessionEntries: HistoryEntry[];
   inboundHistory: HistoryEntry[] | undefined;
+  limit?: number;
 }): HistoryEntry[] | undefined {
   if (params.sessionEntries.length === 0) {
     return params.inboundHistory;
@@ -81,7 +82,8 @@ export function mergeSlackSessionTranscriptInboundHistory(params: {
     seenSessionKeys.add(key);
     return true;
   });
-  return [...sessionOnlyEntries, ...inboundEntries].toSorted(
+  const merged = [...sessionOnlyEntries, ...inboundEntries].toSorted(
     (left, right) => (left.timestamp ?? 0) - (right.timestamp ?? 0),
   );
+  return params.limit === undefined ? merged : merged.slice(-params.limit);
 }


### PR DESCRIPTION
Related: #95378, #95390

## What Problem This Solves

Resolves a problem where the agent forgets its own recent replies in Slack
channels and threads on a wake. #95390 fixed this for Telegram direct chats:
their prompt context now merges a bounded window of the session's canonical
transcript (via the SDK reader `readRecentUserAssistantTextForSession`)
instead of relying only on the per-transport message cache.

Slack channel/thread sessions still had the old behavior. Their wake prompt
context is rebuilt only from the in-memory channel-history window
(`ctx.channelHistories`, rendered as the flat inbound-history block), which:

- never contains the bot's own replies (only inbound channel messages are
  recorded into it), and
- is empty after a gateway restart or LRU eviction.

So for a Slack thread session
(`agent:<agent>:slack:channel:<channel>:thread:<ts>`) or a channel-root
session (`agent:<agent>:slack:channel:<channel>`), the agent's own prior
turns in *this* session were invisible in the wake prompt context, even
though they exist in the session's canonical transcript on disk.

## Why This Change Was Made

Extends the exact #95390 pattern to Slack, as narrowly as it was done for
Telegram:

- New `extensions/slack/src/session-transcript-context.ts` — a thin wrapper
  over the SDK reader `readRecentUserAssistantTextForSession` (same shape as
  `extensions/telegram/src/session-transcript-context.ts`), mapping transcript
  turns to Slack `HistoryEntry` prompt messages. Senders follow the existing
  Slack inbound-history naming convention (`Assistant (assistant)` /
  `User (user)`, with the transcript's `sourceChannel` appended when present),
  and transcript entries carry `session:<id>` message ids like Telegram's.
- Integration in `prepareSlackMessage`
  (`extensions/slack/src/monitor/message-handler/prepare.ts`): for roomish
  conversations (channels and group DMs — the sessions that resolve a
  channel-root or `:thread:<ts>` session key), read up to **limit 10**
  transcript turns with `beforeTimestampMs` = the inbound message's timestamp
  (the wake receive time; same bound #95390 used via `receivedAtMs`), then
  merge them into the existing `inboundHistory` window: dedupe against the
  flat block by `timestamp + trimmed text` (same best-effort key as #95390)
  and sort chronologically. There is no Slack equivalent of Telegram's
  `promptContextMinTimestampMs` debounce watermark, so that option is plumbed
  through the wrapper but not wired at the call site.
- Conservative gating, mirroring #95390's boundary-command skip: the merge is
  skipped when the inbound message carries a control command
  (`hasControlCommandInMessage`, which covers `/new` and `/reset`), so a
  session reset does not resurrect the transcript the user just cleared. The
  merge also respects the existing `historyLimit > 0` switch, so operators
  who disabled channel history context do not start receiving transcript
  context. Sessions without a store entry/transcript are inherently a no-op
  (the SDK reader returns an empty list).

Non-goals / unchanged behavior:

- **No change to group-history or echo-loop filtering.** Nothing new is
  recorded into `ctx.channelHistories`; the record/clear lifecycle,
  mention-gated pending-history behavior, and dropped-history bookkeeping are
  untouched. The merge is read-only at prompt-assembly time.
- DMs are untouched: the DM path keeps its existing
  `resolveSlackDmHistoryContext` behavior (`inboundHistory` passes through
  the merge helper unchanged when there are no transcript entries).
- Thread-starter seeding for new thread sessions
  (`shouldSeedInitialThreadContext`) is untouched; new sessions have no
  transcript yet, so the reader contributes nothing there.

## User Impact

After a gateway restart (or history eviction), the agent in a Slack channel
or thread once again sees its own recent replies and the recent user turns of
that session in prompt context, instead of waking with only whatever inbound
messages happened to be re-observed. Matches the Telegram behavior shipped in
#95390.

## Evidence

- `extensions/slack/src/session-transcript-context.test.ts` (new, mirrors the
  Telegram wrapper tests): SDK-reader mapping/forwarding, plus merge-helper
  coverage (identity when no transcript turns, timestamp+text dedupe,
  chronological ordering).
- `extensions/slack/src/monitor/message-handler/prepare.test.ts` (mirrors the
  two integration tests #95390 added in `bot.test.ts`):
  - "merges canonical session transcript turns into channel wake context" —
    writes a session store entry + `<sessionId>.jsonl` transcript for the
    resolved channel session key, then asserts the wake's `InboundHistory`
    contains the assistant transcript turn while the transcript copy of the
    cached channel message dedupes away.
  - "skips session transcript context for control-command messages" —
    asserts a `/new …` message does not pull transcript text into context.
- `pnpm test:extension slack` (rebased onto current main): 111 files /
  1579 tests, all passed, exit 0.
- `pnpm check --include-test-types` (typecheck incl. tests, oxlint, policy
  guards): exit 0. `oxfmt --check` clean on changed files.

## Risk Note (for reviewers)

- The transcript turns are merged into `InboundHistory`, which renders inside
  the existing "Chat history since last reply" untrusted context block. That
  block already legitimately contains assistant turns on the Slack DM
  new-session path (`Assistant (assistant)` entries from
  `resolveSlackDmHistoryContext`), so no new rendering shape is introduced —
  but channel prompts will now show up to 10 additional (session-sourced)
  entries, which slightly increases prompt size and `history_count`.
- Dedupe is best-effort by `timestamp + trimmed text` (same as #95390):
  transcript copies of enveloped inbound turns will not always match their
  cache twins, so an occasional near-duplicate line can appear (bounded by
  the 10-entry window). Telegram accepted the same trade-off.
- The control-command gate (`hasControlCommandInMessage`) is slightly broader
  than Telegram's `/new`//`/reset`-only regex — any registered control
  command skips the merge for that turn. This errs on the side of omitting
  supplemental context rather than resurrecting cleared context; happy to
  narrow it to session-boundary commands if maintainers prefer exact parity.


## Real-behavior proof (real Slack setup, redacted)

Setup: production OpenClaw 2026.6.11 gateway (macOS LaunchAgent, node 24.16),
real Slack workspace, real private team channel (id masked), thread session key
`agent:<agent>:slack:channel:<channel>:thread:1783546088.771149`. Redaction
scheme: message bodies are never shown — each turn is identified only by role,
timestamp, byte length, and a sha256 tag of its full text, which proves
existence and ordering without revealing content. Senders are masked to
`workspace-user-A` etc.

## Before (stock pipeline)

**1. Canonical session transcript state at the wake:** 23 assistant turns
present, spanning 2026-06-15T22:33Z → 2026-07-08T15:01Z. The newest five:

```
assistant@2026-07-03T15:00:11.240Z  [sha256:c74f25d7]
assistant@2026-07-04T15:02:35.536Z  [sha256:012fa452]
assistant@2026-07-06T16:00:04.542Z  [sha256:14613aa1]
assistant@2026-07-07T15:01:04.091Z  [sha256:6cc4370c]
assistant@2026-07-08T15:01:12.962Z  [sha256:68db10c0]
```

**2. Real captured wake prompts from the same session** (`prompt.submitted`
records in the session's trajectory file, quoted structurally):

- Wake `2026-07-08T21:28Z` (stock legacy context pipeline): prompt total 1334
  chars, **no "Chat history since last reply" block present at all** — the
  in-memory channel window was empty at this wake; none of the 23 transcript
  assistant turns appear anywhere in prompt context.
- Wakes `2026-07-09T07:09Z → 07:28Z` (same session, after three real gateway
  restarts at 02:25Z / 04:52Z / 05:13Z): flat block present, containing **only
  inbound user entries** — structure:

```
flat-history entry: sender='workspace-user-A' ts=1783580933174 [sha256:77f9ddf7]
flat-history entry: sender='workspace-user-A' ts=1783581276426 [sha256:fc56bc07]
=> senders in flat block: ['workspace-user-A', 'workspace-user-A']
=> assistant/bot entries in flat block: 0
```

(Disclosure: the 07-09 wakes ran with a third-party context-engine plugin
selected on this gateway; that slot only replaces the message-history side of
assembly — the host-composed prompt and its flat inbound-history block shown
here are identical to stock. The 07-08T21:28Z wake predates that plugin
entirely.)

So on a real setup: the agent's own replies exist in the canonical transcript
but are absent from room/thread prompt context, and after a restart even the
inbound window is empty — the exact gap this PR fills.

## After (this PR's adapter, run against the same real session store)

The PR's `session-transcript-context.ts` (unmodified, from the PR head commit)
was executed on the same production host against the same session store and
session key, replicating the `prepare.ts` integration call exactly
(`limit: 10`, `beforeTimestampMs` = the real wake's message ts). Inbound
entries reproduce the two real flat-block entries (real sender/ts; bodies
replaced by equal-length placeholders — the merge keys on timestamp + text, so
dedupe semantics are authentic). Terminal output:

```
== PR adapter: canonical transcript read (real store) ==
  transcript: sender="User (user)" id=- ts=1783546088771 len=642 [sha256:5d5357b4]
  transcript: sender="Assistant (assistant)" id=- ts=1783546337070 len=666 [sha256:92cefcef]
  transcript: sender="User (user)" id=- ts=1783580933174 len=436 [sha256:77f9ddf7]
  transcript: sender="Assistant (assistant)" id=- ts=1783546337070 len=666 [sha256:92cefcef]
  transcript: sender="User (user)" id=- ts=1783580933174 len=436 [sha256:77f9ddf7]

== real inbound flat-history entries from the captured wake ==
  inbound: sender="workspace-user-A" id=m1 ts=1783580933174 len=212 [sha256:dbf812e1]
  inbound: sender="workspace-user-A" id=m2 ts=1783581276426 len=41 [sha256:3164596d]

== merged InboundHistory (what the wake prompt would carry) ==
  merged: sender="workspace-user-A" id=m1 ts=1783580933174 len=212 [sha256:dbf812e1]
  merged: sender="workspace-user-A" id=m2 ts=1783581276426 len=41 [sha256:3164596d]
  merged: sender="User (user)" id=- ts=1783546088771 len=642 [sha256:5d5357b4]
  merged: sender="Assistant (assistant)" id=- ts=1783546337070 len=666 [sha256:92cefcef]
  merged: sender="User (user)" id=- ts=1783580933174 len=436 [sha256:77f9ddf7]

=> merged entries: 5; assistant transcript entries: 1 (was 0 before the fix)
```

The assistant transcript turn ([sha256:92cefcef], the agent's in-thread reply
at 2026-07-08T21:32Z) is now present in the merged InboundHistory — the same
turn that is provably absent from every captured before-fix wake prompt above.

**Bonus finding from running against real data:** the production transcript
contained a duplicated row for one turn (streamed replies persisted twice —
visible above as the repeated sha256 tags in the first run). The PR's merge
originally deduped transcript-vs-channel only, so both copies reached the
merged history. The PR now also dedupes within the transcript window (same
timestamp+text key) with a regression test; the output above is from the fixed
adapter (7 → 5 merged entries).


## Enterprise Grid compatibility (current-main refresh)

Rebased onto current `main` (`2f66c3c0`); the original commit replayed with
zero conflicts. On the review's Grid question: commit `245b91b83de0`
(#102372, Grid org installs) turned out to be an **ancestor** of this branch's
original base (the depth-1 clone's shallow boundary hid it), and no commit
between the old base and current main touches `prepare.ts`,
`prepare-routing.ts`, or the transcript read path. The integration is
Grid-correct by construction: it consumes the handler's own routing locals —
the same `(storePath, sessionKey)` pair the handler uses for
`readSessionUpdatedAt` (`prepare.ts:1248-1251`) and that dispatch persists
the turn under (`routeSessionKey: sessionKey` at `prepare.ts:1410` →
`ctxPayload.SessionKey` → `dispatch.ts:455-503`), which under Grid is the
team-qualified key (`agent:<a>:slack:channel:team:<team>:channel:<chan>`
[+ `:thread:<ts>`]); `storePath` remains agent-scoped under Grid
(`prepare.ts:1244-1246`). A Grid-shaped org-install room-wake integration
test was added, mirroring #102372's own `SlackEventScope` test construction.

## Hardening found by the real-data run

The production transcript contained a duplicated row for one turn (streamed
reply persisted twice). The merge originally deduped transcript-vs-channel
only, so both copies reached prompt context. The merge now also dedupes within
the transcript window (same timestamp + trimmed-text key), with a regression
test ("collapses duplicated transcript rows for the same turn").

## Design note: why `limit: 10` is hardcoded

Deliberate mirror of #95390's Telegram call site (`limit: 10`), rather than
coupling to `ctx.historyLimit` (which sizes the *channel window*, a different
budget). Happy to tie it to a config knob if maintainers prefer.
