### PR TITLE
fix(cron-cli): hint when a channel id is passed to cron --channel

### DIFF
--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -14,6 +14,7 @@ import { parseStrictPositiveIntOrUndefined } from "../program/helpers.js";
 import { resolveCronCreateScheduleFromArgs } from "./schedule-options.js";
 import {
   getCronChannelOptions,
+  warnUnrecognizedCronChannelType,
   coerceCronDeliveryPreviews,
   enrichCronJsonWithStatus,
   handleCronCliError,
@@ -142,7 +143,11 @@ export function registerCronAddCommand(cron: Command) {
       .option("--deliver", "Deprecated (use --announce). Fallback-delivers final text to a chat.")
       .option("--no-deliver", "Disable runner fallback delivery")
       .option("--webhook <url>", "POST the finished payload to a webhook URL")
-      .option("--channel <channel>", `Delivery channel (${getCronChannelOptions()})`, "last")
+      .option(
+        "--channel <type>",
+        `Delivery channel type (${getCronChannelOptions()}); the channel id goes in --to`,
+        "last",
+      )
       .option(
         "--to <dest>",
         "Delivery destination (E.164, Telegram chatId, or Discord channel/user)",
@@ -189,6 +194,12 @@ export function registerCronAddCommand(cron: Command) {
               typeof cmd?.getOptionValueSource === "function"
                 ? (name: string) => cmd.getOptionValueSource(name)
                 : () => undefined;
+
+            // Hint (non-blocking) when a channel id was passed as a channel type;
+            // only for user-supplied values, not the "last" default.
+            if (optionSource("channel") === "cli") {
+              warnUnrecognizedCronChannelType(opts.channel, { option: "--channel", dest: "--to" });
+            }
 
             const hasAnnounce = Boolean(opts.announce) || opts.deliver === true;
             const hasNoDeliver = opts.deliver === false;

--- a/src/cli/cron-cli/register.cron-channel-validation.test.ts
+++ b/src/cli/cron-cli/register.cron-channel-validation.test.ts
@@ -1,0 +1,224 @@
+// Cron channel-type hint tests: a channel id passed to --channel /
+// --failure-alert-channel (which name a channel TYPE) warns at add/edit time,
+// without blocking - the Gateway stays authoritative for whether it can route.
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { defaultRuntime } from "../../runtime.js";
+
+const hoisted = vi.hoisted(() => ({
+  callGatewayFromCli: vi.fn(),
+  listChannelPluginsMock: vi.fn(),
+}));
+
+vi.mock("../gateway-rpc.js", async () => {
+  const actual = await vi.importActual<typeof import("../gateway-rpc.js")>("../gateway-rpc.js");
+  return {
+    ...actual,
+    callGatewayFromCli: (...args: Parameters<typeof actual.callGatewayFromCli>) =>
+      hoisted.callGatewayFromCli(...args),
+  };
+});
+
+vi.mock("../../channels/plugins/index.js", () => ({
+  listChannelPlugins: hoisted.listChannelPluginsMock,
+}));
+
+const { registerCronAddCommand } = await import("./register.cron-add.js");
+const { registerCronEditCommand } = await import("./register.cron-edit.js");
+
+const CHANNEL_WARNING = "is not a recognized channel type";
+
+function createAddProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  registerCronAddCommand(program);
+  return program;
+}
+
+function createEditProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  registerCronEditCommand(program);
+  return program;
+}
+
+function expectNoChannelWarning(spy: ReturnType<typeof vi.spyOn>): void {
+  const warned = spy.mock.calls.some(
+    (call: unknown[]) => typeof call[0] === "string" && call[0].includes(CHANNEL_WARNING),
+  );
+  expect(warned).toBe(false);
+}
+
+describe("cron --channel type hint", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    hoisted.callGatewayFromCli.mockReset();
+    // enabled:true suppresses the unrelated "scheduler disabled" warning.
+    hoisted.callGatewayFromCli.mockResolvedValue({ ok: true, enabled: true });
+    // The thin CLI client loads no channel plugin runtimes; recognition relies on
+    // the bundled channel catalog (slack/telegram/... are known without this mock).
+    hoisted.listChannelPluginsMock.mockReset();
+    hoisted.listChannelPluginsMock.mockReturnValue([]);
+    vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => {});
+    errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+  });
+
+  // Restore between tests so re-spied runtime.error does not accumulate calls
+  // across cases (a stacked spy would carry a prior test's warning).
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("warns but still submits `cron edit --channel <channel-id>` with a --to hint", async () => {
+    await createEditProgram().parseAsync(["edit", "job-1", "--channel", "C0BFYTH0BSP"], {
+      from: "user",
+    });
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"C0BFYTH0BSP" is not a recognized channel type for --channel'),
+    );
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("pass it with --to instead"));
+    // Non-blocking: the value still reaches the Gateway, which is authoritative.
+    expect(hoisted.callGatewayFromCli).toHaveBeenCalledWith("cron.update", expect.anything(), {
+      id: "job-1",
+      patch: { delivery: { channel: "C0BFYTH0BSP" } },
+    });
+  });
+
+  it("warns on `cron edit --failure-alert-channel <channel-id>` with a --failure-alert-to hint", async () => {
+    await createEditProgram().parseAsync(
+      ["edit", "job-1", "--failure-alert-channel", "C0BFYTH0BSP"],
+      { from: "user" },
+    );
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '"C0BFYTH0BSP" is not a recognized channel type for --failure-alert-channel',
+      ),
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("pass it with --failure-alert-to instead"),
+    );
+    expect(hoisted.callGatewayFromCli).toHaveBeenCalledWith("cron.update", expect.anything(), {
+      id: "job-1",
+      patch: { failureAlert: { channel: "c0bfyth0bsp" } },
+    });
+  });
+
+  it("does not warn for a bundled channel type on `cron edit --channel slack`", async () => {
+    await createEditProgram().parseAsync(["edit", "job-1", "--channel", "slack"], { from: "user" });
+
+    expectNoChannelWarning(errorSpy);
+    expect(hoisted.callGatewayFromCli).toHaveBeenCalledWith("cron.update", expect.anything(), {
+      id: "job-1",
+      patch: { delivery: { channel: "slack" } },
+    });
+  });
+
+  it("recognizes bundled channel types case-insensitively (--failure-alert-channel Slack)", async () => {
+    await createEditProgram().parseAsync(["edit", "job-1", "--failure-alert-channel", "Slack"], {
+      from: "user",
+    });
+
+    expectNoChannelWarning(errorSpy);
+    expect(hoisted.callGatewayFromCli).toHaveBeenCalledWith("cron.update", expect.anything(), {
+      id: "job-1",
+      patch: { failureAlert: { channel: "slack" } },
+    });
+  });
+
+  it("recognizes a loaded external (non-bundled) channel plugin id without warning", async () => {
+    hoisted.listChannelPluginsMock.mockReturnValue([{ id: "acme" }]);
+
+    await createEditProgram().parseAsync(["edit", "job-1", "--channel", "acme"], { from: "user" });
+
+    expectNoChannelWarning(errorSpy);
+    expect(hoisted.callGatewayFromCli).toHaveBeenCalledWith("cron.update", expect.anything(), {
+      id: "job-1",
+      patch: { delivery: { channel: "acme" } },
+    });
+  });
+
+  it("does not warn on `cron edit` with no channel flag", async () => {
+    await createEditProgram().parseAsync(["edit", "job-1", "--enable"], { from: "user" });
+
+    expectNoChannelWarning(errorSpy);
+    expect(hoisted.callGatewayFromCli).toHaveBeenCalledWith("cron.update", expect.anything(), {
+      id: "job-1",
+      patch: { enabled: true },
+    });
+  });
+
+  it("warns but still submits `cron add --channel <channel-id>`", async () => {
+    await createAddProgram().parseAsync(
+      [
+        "add",
+        "My Job",
+        "--every",
+        "10m",
+        "--message",
+        "hi",
+        "--agent",
+        "a1",
+        "--announce",
+        "--channel",
+        "C0BFYTH0BSP",
+      ],
+      { from: "user" },
+    );
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"C0BFYTH0BSP" is not a recognized channel type for --channel'),
+    );
+    expect(hoisted.callGatewayFromCli).toHaveBeenCalledWith(
+      "cron.add",
+      expect.anything(),
+      expect.objectContaining({
+        delivery: expect.objectContaining({ channel: "C0BFYTH0BSP" }),
+      }),
+    );
+  });
+
+  it("does not warn for a bundled channel type on `cron add --channel slack`", async () => {
+    await createAddProgram().parseAsync(
+      [
+        "add",
+        "My Job",
+        "--every",
+        "10m",
+        "--message",
+        "hi",
+        "--agent",
+        "a1",
+        "--announce",
+        "--channel",
+        "slack",
+      ],
+      { from: "user" },
+    );
+
+    expectNoChannelWarning(errorSpy);
+    expect(hoisted.callGatewayFromCli).toHaveBeenCalledWith(
+      "cron.add",
+      expect.anything(),
+      expect.objectContaining({
+        delivery: expect.objectContaining({ channel: "slack" }),
+      }),
+    );
+  });
+
+  it("does not warn on `cron add` with the default channel (no --channel)", async () => {
+    await createAddProgram().parseAsync(
+      ["add", "My Job", "--every", "10m", "--message", "hi", "--agent", "a1"],
+      { from: "user" },
+    );
+
+    expectNoChannelWarning(errorSpy);
+    expect(hoisted.callGatewayFromCli).toHaveBeenCalledWith(
+      "cron.add",
+      expect.anything(),
+      expect.objectContaining({ name: "My Job" }),
+    );
+  });
+});

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -16,6 +16,7 @@ import {
 } from "./schedule-options.js";
 import {
   getCronChannelOptions,
+  warnUnrecognizedCronChannelType,
   parseCronCommandArgv,
   parseCronCommandEnv,
   parseCronFallbacks,
@@ -161,7 +162,10 @@ export function registerCronEditCommand(cron: Command) {
       .option("--deliver", "Deprecated (use --announce). Fallback-delivers final text to a chat.")
       .option("--no-deliver", "Disable runner fallback delivery")
       .option("--webhook <url>", "POST the finished payload to a webhook URL")
-      .option("--channel <channel>", `Delivery channel (${getCronChannelOptions()})`)
+      .option(
+        "--channel <type>",
+        `Delivery channel type (${getCronChannelOptions()}); the channel id goes in --to`,
+      )
       .option(
         "--to <dest>",
         "Delivery destination (E.164, Telegram chatId, or Discord channel/user)",
@@ -181,8 +185,8 @@ export function registerCronEditCommand(cron: Command) {
       .option("--no-failure-alert", "Disable failure alerts for this job")
       .option("--failure-alert-after <n>", "Alert after N consecutive job errors")
       .option(
-        "--failure-alert-channel <channel>",
-        `Failure alert channel (${getCronChannelOptions()})`,
+        "--failure-alert-channel <type>",
+        `Failure alert channel type (${getCronChannelOptions()}); the channel id goes in --failure-alert-to`,
       )
       .option("--failure-alert-to <dest>", "Failure alert destination")
       .option("--failure-alert-cooldown <duration>", "Minimum time between alerts (e.g. 1h, 30m)")
@@ -225,6 +229,18 @@ export function registerCronEditCommand(cron: Command) {
           ].filter(Boolean).length;
           if (deliveryModeFlagCount > 1) {
             throw new Error("Choose at most one of --announce, --no-deliver, or --webhook.");
+          }
+          // Hint (non-blocking) when a channel id was passed as a channel type, so
+          // it surfaces here instead of only as a runtime channel_not_found
+          // delivery error. --clear-* flags leave these unset.
+          if (typeof opts.channel === "string") {
+            warnUnrecognizedCronChannelType(opts.channel, { option: "--channel", dest: "--to" });
+          }
+          if (typeof opts.failureAlertChannel === "string") {
+            warnUnrecognizedCronChannelType(opts.failureAlertChannel, {
+              option: "--failure-alert-channel",
+              dest: "--failure-alert-to",
+            });
           }
           const patch: Record<string, unknown> = {};
           if (typeof opts.name === "string") {

--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -415,14 +415,24 @@ describe("parseAt", () => {
 });
 
 describe("getCronChannelOptions", () => {
-  it("falls back to a generic channel placeholder when no plugins are loaded", () => {
+  it("lists 'last' plus bundled channel types even with no plugins loaded", () => {
     hoisted.listChannelPluginsMock.mockReturnValue([]);
-    expect(getCronChannelOptions()).toBe("last|<channel-id>");
+    const options = getCronChannelOptions();
+    // The thin CLI client never loads channel plugin runtimes, so the bundled
+    // channel catalog is the source that keeps help/validation truthful there.
+    expect(options.startsWith("last|")).toBe(true);
+    for (const type of ["slack", "telegram", "discord"]) {
+      expect(options.split("|")).toContain(type);
+    }
+    expect(options).not.toContain("<channel-id>");
   });
 
-  it("lists discovered channel plugin ids when plugins are available", () => {
-    hoisted.listChannelPluginsMock.mockReturnValue([{ id: "quietchat" }, { id: "forum" }]);
-    expect(getCronChannelOptions()).toBe("last|quietchat|forum");
+  it("appends loaded external channel plugin ids without duplicating bundled ones", () => {
+    hoisted.listChannelPluginsMock.mockReturnValue([{ id: "acme" }, { id: "slack" }]);
+    const parts = getCronChannelOptions().split("|");
+    expect(parts).toContain("acme");
+    // "slack" is bundled, so a loaded plugin with the same id must not duplicate.
+    expect(parts.filter((part) => part === "slack")).toHaveLength(1);
   });
 });
 

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -8,6 +8,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { colorize, isRich, theme } from "../../../packages/terminal-core/src/theme.js";
+import { CHANNEL_IDS, normalizeChatChannelId } from "../../channels/ids.js";
 import { listChannelPlugins } from "../../channels/plugins/index.js";
 import { parseAbsoluteTimeMs } from "../../cron/parse.js";
 import { resolveCronStaggerMs } from "../../cron/stagger.js";
@@ -63,13 +64,72 @@ export function parseCronCommandEnv(values: unknown): Record<string, string> | u
   return env;
 }
 
-export const getCronChannelOptions = () => {
-  // Keep help truthful even before the plugin registry is bootstrapped.
-  const pluginIds = listChannelPlugins()
-    .map((plugin) => plugin.id)
-    .filter(Boolean);
-  return pluginIds.length > 0 ? ["last", ...pluginIds].join("|") : "last|<channel-id>";
-};
+// Delivery/failure-alert `--channel` flags name a channel plugin TYPE (slack,
+// telegram, ...) plus the synthetic "last", never a channel id. Slack calls an
+// id like "C0BFYTH0BSP" a "channel ID", so users pass it here by mistake; the id
+// belongs in --to. Known types come from the generated bundled-channel catalog
+// (CHANNEL_IDS, available even in the thin CLI client that never loads channel
+// plugin runtimes) plus any loaded channel plugins (populated in the Gateway /
+// in-process contexts). The `cron` CLI deliberately skips plugin/config load, so
+// this set can miss an installed custom channel; it is a hint source only, never
+// a hard gate (the Gateway stays authoritative for routing).
+function listKnownCronChannelTypes(): string[] {
+  const types: string[] = ["last"];
+  const seen = new Set(types);
+  for (const id of [...CHANNEL_IDS, ...listChannelPlugins().map((plugin) => plugin.id)]) {
+    if (id && !seen.has(id)) {
+      seen.add(id);
+      types.push(id);
+    }
+  }
+  return types;
+}
+
+export const getCronChannelOptions = () => listKnownCronChannelTypes().join("|");
+
+// Recognizes bundled channel ids/aliases and any loaded plugin id. Returns false
+// for a value that no known channel type matches (e.g. a Slack channel id).
+function isRecognizedCronChannelType(value: string): boolean {
+  if (value.toLowerCase() === "last") {
+    return true;
+  }
+  // Bundled channel ids and their aliases resolve without any plugin runtime.
+  if (normalizeChatChannelId(value)) {
+    return true;
+  }
+  const normalized = value.toLowerCase();
+  return listChannelPlugins().some((plugin) => (plugin.id ?? "").toLowerCase() === normalized);
+}
+
+/**
+ * Warns (without blocking) when a `--channel` / `--failure-alert-channel` value
+ * looks like a channel id rather than a channel type, so the likely mistake
+ * surfaces immediately at `cron add/edit` instead of only as a runtime
+ * `channel_not_found` delivery failure.
+ *
+ * This is a hint, not a gate: the `cron` CLI does not load plugin/config state,
+ * so an installed custom channel may be unrecognized here. We never reject the
+ * value - the Gateway remains authoritative for whether the channel can route.
+ */
+export function warnUnrecognizedCronChannelType(
+  rawValue: unknown,
+  flags: { option: string; dest: string },
+  runtime: RuntimeEnv = defaultRuntime,
+): void {
+  const value = normalizeOptionalString(rawValue);
+  if (!value || isRecognizedCronChannelType(value)) {
+    return;
+  }
+  runtime.error(
+    theme.warn(
+      `warning: "${value}" is not a recognized channel type for ${flags.option} ` +
+        `(known: ${listKnownCronChannelTypes().join("|")}). ` +
+        `If you meant a channel id, pass it with ${flags.dest} instead ` +
+        `(e.g. a Slack "C0..." id goes in ${flags.dest}, not ${flags.option}). ` +
+        `Proceeding; delivery will fail if the channel cannot route.`,
+    ),
+  );
+}
 
 function toLocalIsoTime(value: unknown): string | undefined {
   return typeof value === "number" && Number.isFinite(value)


### PR DESCRIPTION
Fixes #102596

> AI-assisted PR (Claude Code). Author understands the change; validation below. Independent `codex review --base origin/main` run locally: clean (no actionable findings).

## What Problem This Solves

Fixes an issue where `openclaw cron add` / `cron edit` silently accept a channel **id** in the `--channel` / `--failure-alert-channel` flags, which name a channel **type** (`last | slack | telegram | discord | ...`), not an id - the channel id belongs in `--to` / `--failure-alert-to`. Because Slack labels an id like `C0EXAMPLE01` a "channel ID", users naturally pass it to `--channel`. The job is written, then delivery fails much later at runtime with `OutboundDeliveryError: channel_not_found` and no hint about the real mistake. The flag help even rendered a misleading `last|<channel-id>` placeholder, nudging users to pass an id. This cost real production debugging time.

## Why This Change Was Made

Give immediate, actionable feedback at `cron add`/`edit` time instead of a cryptic runtime delivery failure, and stop the help text from steering users wrong.

The fix is a **non-blocking hint**, deliberately not a hard reject. The built-in `cron` command runs with `loadPlugins: "never"` (see `command-catalog.ts`), so at add/edit time neither channel plugin runtimes nor config are loaded - `listChannelPlugins()` is empty there. A hard client-side allowlist would therefore reject a configured custom/external channel that the Gateway can actually route (an independent Codex review flagged exactly this as a compatibility regression). Forcing a plugin/config load would defeat cron's deliberate fast path. So when a value is not recognized (against the generated bundled channel catalog `CHANNEL_IDS`, plus any loaded plugins), we print a clear warning pointing at `--to` / `--failure-alert-to` and still submit to the Gateway, which stays authoritative for routing. A valid channel is never rejected.

Changes (all in `src/cli/cron-cli/`):
- `shared.ts` - `warnUnrecognizedCronChannelType()` (non-blocking) + `listKnownCronChannelTypes()` sourced from the bundled catalog + loaded plugins; `getCronChannelOptions()` now renders real channel types instead of `last|<channel-id>`.
- `register.cron-add.ts` / `register.cron-edit.ts` - hint on `--channel` (add/edit) and `--failure-alert-channel` (edit); flag help now reads as a channel TYPE and points the id at `--to` / `--failure-alert-to`.

## User Impact

`openclaw cron add`/`edit` now warn immediately when a value looks like a channel id rather than a channel type, e.g.:

```
$ openclaw cron edit <job> --failure-alert-channel C0EXAMPLE01
warning: "C0EXAMPLE01" is not a recognized channel type for --failure-alert-channel
(known: last|...|slack|telegram|...). If you meant a channel id, pass it with
--failure-alert-to instead (e.g. a Slack "C0..." id goes in --failure-alert-to,
not --failure-alert-channel). Proceeding; delivery will fail if the channel cannot route.
```

Recognized types (`--channel slack`, aliases, `last`, loaded plugin ids) and omitting the flag are silent and behave exactly as before. Nothing is blocked, so no configured channel is ever rejected client-side. No config/schema/protocol changes.

## Evidence

- New tests `src/cli/cron-cli/register.cron-channel-validation.test.ts` (9 cases): a channel id passed to `--channel` / `--failure-alert-channel` (add and edit) warns with the correct `--to` / `--failure-alert-to` hint **and still submits** to the gateway (non-blocking); bundled types (`slack`), case-insensitive matches (`Slack`), a loaded external plugin id (`acme`), and omitting the flag produce no warning. Updated `shared.test.ts` for the new `getCronChannelOptions()` source.
- `pnpm test src/cli/cron-cli` - green (11 + 74 tests across configs).
- `pnpm tsgo:core`, `pnpm tsgo:test:src`, `pnpm check:import-cycles`, `pnpm build`, `pnpm format:check`, `oxlint` on changed files - all green.
- Independent `codex review --base origin/main` (local) - clean: "No actionable correctness issues... Gateway validation remains authoritative, and the new warnings are non-blocking."
- Manual CLI (real built binary, valid config):
  - `cron edit <job> --failure-alert-channel C0EXAMPLE01` -> warning with `--failure-alert-to` hint, then proceeds to the gateway (non-blocking).
  - `cron add "T" --every 10m --message hi --agent a1 --announce --channel C0EXAMPLE01` -> warning with `--to` hint, still submits.
  - `cron edit <job> --channel slack` -> no warning, proceeds.
  - `cron edit --help` -> `--channel <type>` / `--failure-alert-channel <type>` now list real channel types.

