### PR TITLE
fix(codex,tui,cli): keep retained text UTF-16 safe

### DIFF
--- a/extensions/codex/src/app-server/context-engine-projection.test.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.test.ts
@@ -157,6 +157,17 @@ describe("projectContextEngineAssemblyForCodex", () => {
     expect(result.promptText.length).toBeLessThan(25_000);
   });
 
+  it("reports the exact text dropped when a text-part boundary crosses an emoji", () => {
+    const prefix = "x".repeat(5_999);
+    const result = projectContextEngineAssemblyForCodex({
+      assembledMessages: [textMessage("assistant", `${prefix}😀tail`)],
+      originalHistoryMessages: [],
+      prompt: "next",
+    });
+
+    expect(result.promptText).toContain(`[assistant]\n${prefix}\n[truncated 6 chars]`);
+  });
+
   it("keeps recent context when the rendered conversation overflows", () => {
     const result = projectContextEngineAssemblyForCodex({
       assembledMessages: [

--- a/extensions/codex/src/app-server/context-engine-projection.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.ts
@@ -4,6 +4,7 @@
  */
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { redactSensitiveFieldValue, redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
+import { sliceUtf16Safe, truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 type CodexContextProjection = {
   developerInstructionAddition?: string;
@@ -485,9 +486,11 @@ function resolveTextPartMaxChars(maxRenderedContextChars: number): number {
 }
 
 function truncateText(text: string, maxChars: number): string {
-  return text.length > maxChars
-    ? `${text.slice(0, maxChars)}\n[truncated ${text.length - maxChars} chars]`
-    : text;
+  if (text.length <= maxChars) {
+    return text;
+  }
+  const truncated = truncateUtf16Safe(text, maxChars);
+  return `${truncated}\n[truncated ${text.length - truncated.length} chars]`;
 }
 
 function truncateOlderContext(text: string, maxChars: number): string {
@@ -507,20 +510,5 @@ function truncateOlderContext(text: string, maxChars: number): string {
     return marker.slice(0, maxChars);
   }
   tailChars = maxChars - marker.length;
-  return `${marker}${sliceTailFromCodePointBoundary(text, tailChars).trimStart()}`;
-}
-
-// Keep the kept tail at a code-point boundary so a UTF-16 surrogate pair is
-// never split at the cut: a tail start that lands on a low surrogate would
-// orphan it into U+FFFD, corrupting the first character. Dropping that unit
-// stays within maxChars (it only removes a char), so the bound still holds.
-function sliceTailFromCodePointBoundary(text: string, tailChars: number): string {
-  let start = text.length - tailChars;
-  if (start > 0 && start < text.length) {
-    const code = text.charCodeAt(start);
-    if (code >= 0xdc00 && code <= 0xdfff) {
-      start += 1;
-    }
-  }
-  return text.slice(start);
+  return `${marker}${sliceUtf16Safe(text, -tailChars).trimStart()}`;
 }

--- a/src/agents/cli-runner/session-history.test.ts
+++ b/src/agents/cli-runner/session-history.test.ts
@@ -864,6 +864,18 @@ describe("buildCliSessionHistoryPrompt", () => {
     expect(prompt).not.toContain("x".repeat(80));
   });
 
+  it("keeps a whole code point when the retained history tail starts inside an emoji", () => {
+    const prompt = buildCliSessionHistoryPrompt({
+      messages: [{ role: "user", content: "prefix😀tail" }],
+      prompt: "next",
+      maxHistoryChars: 5,
+    });
+
+    expect(prompt).toContain(
+      "<conversation_history>\n[OpenClaw reseed history truncated; older turns dropped]\ntail\n</conversation_history>",
+    );
+  });
+
   it("scales automatic reseed history caps from Claude context tiers", () => {
     expect(resolveAutoCliSessionReseedHistoryChars(0)).toBe(MAX_CLI_SESSION_RESEED_HISTORY_CHARS);
     expect(resolveAutoCliSessionReseedHistoryChars(32_000)).toBe(
@@ -978,6 +990,18 @@ describe("buildCliSessionHistoryPrompt", () => {
     expect(prompt).toContain("POST_SUMMARY_USER_DROPPED");
     expect(prompt).toContain("POST_SUMMARY_ASSISTANT_DROPPED");
     expect(prompt).toContain("<next_user_message>\nnext ask\n</next_user_message>");
+  });
+
+  it("keeps a whole code point at an oversize compaction-summary boundary", () => {
+    const prompt = buildCliSessionHistoryPrompt({
+      messages: [{ role: "compactionSummary", summary: `aa😀${"z".repeat(100)}` }],
+      prompt: "next",
+      maxHistoryChars: 80,
+    });
+
+    expect(prompt).toContain(
+      "<conversation_history>\n[OpenClaw reseed history truncated; older turns dropped]\nCompaction summary: aa\n</conversation_history>",
+    );
   });
 
   it("honors the cap when the summary block plus marker crosses it", () => {

--- a/src/agents/cli-runner/session-history.ts
+++ b/src/agents/cli-runner/session-history.ts
@@ -4,6 +4,7 @@
  */
 import fsp from "node:fs/promises";
 import path from "node:path";
+import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
@@ -214,8 +215,8 @@ export function buildCliSessionHistoryPrompt(params: {
       0,
       maxHistoryChars - truncationMarker.length - separatorBudget - tailBudget,
     );
-    const summaryTruncated = renderedSummary.slice(0, summaryBudget).trimEnd();
-    const tailTruncated = tailBudget > 0 ? tailRaw.slice(-tailBudget).trimStart() : "";
+    const summaryTruncated = truncateUtf16Safe(renderedSummary, summaryBudget).trimEnd();
+    const tailTruncated = tailBudget > 0 ? sliceUtf16Safe(tailRaw, -tailBudget).trimStart() : "";
     return [truncationMarker, summaryTruncated, tailTruncated].filter(Boolean).join("\n");
   };
 
@@ -242,7 +243,7 @@ export function buildCliSessionHistoryPrompt(params: {
         // reserved tail budget instead of being dropped wholesale.
         renderedHistory = renderTruncatedSummaryWithTail(summaryRendered);
       } else if (tailRaw.length > remainingBudget) {
-        renderedHistory = `${summaryBlock}${truncationMarker}\n${tailRaw.slice(-remainingBudget).trimStart()}`;
+        renderedHistory = `${summaryBlock}${truncationMarker}\n${sliceUtf16Safe(tailRaw, -remainingBudget).trimStart()}`;
       } else {
         renderedHistory = `${summaryBlock}${tailRaw}`;
       }
@@ -253,7 +254,7 @@ export function buildCliSessionHistoryPrompt(params: {
     // (older turns dropped, recent tail retained).
     renderedHistory =
       tailRaw.length > maxHistoryChars
-        ? `${truncationMarker}\n${tailRaw.slice(-maxHistoryChars).trimStart()}`
+        ? `${truncationMarker}\n${sliceUtf16Safe(tailRaw, -maxHistoryChars).trimStart()}`
         : tailRaw;
   }
 

--- a/src/tui/tui-local-shell.test.ts
+++ b/src/tui/tui-local-shell.test.ts
@@ -165,6 +165,35 @@ describe("createLocalShellRunner", () => {
     expect(harness.messages.some((m) => m.includes("FATAL"))).toBe(true);
   });
 
+  it("keeps a whole code point when the combined output tail starts inside an emoji", async () => {
+    const stdout = new EventEmitter();
+    const stderr = new EventEmitter();
+    const spawnCommand = vi.fn(() => ({
+      stdout,
+      stderr,
+      on: (event: string, callback: (...args: unknown[]) => void) => {
+        if (event === "close") {
+          setImmediate(() => {
+            stdout.emit("data", Buffer.from("x😀"));
+            stderr.emit("data", Buffer.from("tail"));
+            callback(0, null);
+          });
+        }
+      },
+    }));
+    const harness = createShellHarness({
+      spawnCommand: spawnCommand as unknown as typeof import("node:child_process").spawn,
+      maxOutputChars: 6,
+    });
+
+    const run = harness.runLocalShellLine("!unicode");
+    harness.getLastSelector()?.onSelect?.({ value: "yes", label: "Yes" });
+    await run;
+
+    expect(harness.messages).toContain("[local] tail");
+    expect(harness.messages.join("\n")).not.toMatch(/[\uD800-\uDFFF]/u);
+  });
+
   it("refuses to retarget local commands after the working directory is deleted", async () => {
     const harness = createShellHarness({ getCwd: () => undefined });
 

--- a/src/tui/tui-local-shell.ts
+++ b/src/tui/tui-local-shell.ts
@@ -1,6 +1,7 @@
 // Launches and manages the local shell process used by TUI local mode.
 import { spawn } from "node:child_process";
 import type { Component, OverlayHandle, SelectItem } from "@earendil-works/pi-tui";
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { tryProcessCwd } from "../infra/safe-cwd.js";
 import { createSearchableSelectList } from "./components/selectors.js";
 
@@ -114,7 +115,7 @@ export function createLocalShellRunner(deps: LocalShellDeps) {
 
     const appendWithCap = (text: string, chunk: string) => {
       const combined = text + chunk;
-      return combined.length > maxChars ? combined.slice(-maxChars) : combined;
+      return combined.length > maxChars ? sliceUtf16Safe(combined, -maxChars) : combined;
     };
 
     await new Promise<void>((resolve) => {
@@ -143,9 +144,10 @@ export function createLocalShellRunner(deps: LocalShellDeps) {
         // Keep the tail (consistent with the streaming appendWithCap above) so a
         // large stdout cannot evict stderr: the failure reason (FATAL etc.) at the
         // end is what the operator needs most when output overflows the cap.
-        const combined = (stdout + (stderr ? (stdout ? "\n" : "") + stderr : ""))
-          .slice(-maxChars)
-          .trimEnd();
+        const combined = sliceUtf16Safe(
+          stdout + (stderr ? (stdout ? "\n" : "") + stderr : ""),
+          -maxChars,
+        ).trimEnd();
 
         if (combined) {
           for (const lineLocal of combined.split("\n")) {


### PR DESCRIPTION
## What Problem This Solves

Three retained-text boundaries could split a UTF-16 surrogate pair: Codex context text-part truncation, CLI session-history head/tail retention, and TUI local-shell output tails. A split emoji could therefore leave malformed text in a Codex prompt, reseed prompt, or operator-visible shell result.

## Why This Change Was Made

Rebuilt the PR on current `main`, removed the Telegram hunk already superseded by the centralized raw-update formatter, and used the shared normalization primitives for the three remaining owners. The Codex projection also deletes its private tail-boundary implementation in favor of the same shared helper.

## User Impact

Long Codex context, CLI reseed history, and TUI shell output remain valid Unicode at their existing limits. Retention direction, size budgets, marker text, and ASCII behavior are unchanged.

## Evidence

- Codex projection suite: 21 passed, including an exact 6,000-unit text-part boundary assertion.
- CLI session-history suite: 26 passed, including exact retained-head and retained-tail boundaries.
- TUI local-shell suite: 6 passed, including the combined stdout/stderr tail boundary.
- Focused `oxfmt`, `oxlint`, and `git diff --check` passed.
- Fresh autoreview clean (0.96).
- Direct Codex source inspection confirmed `turn/start` sums Unicode scalar counts against `MAX_USER_INPUT_TEXT_CHARS`; this patch preserves OpenClaw's conservative existing budget and only prevents invalid UTF-16 projection output.

Co-authored-by: 陈志强0668000989 <chen.zhiqiang1@xydigit.com>
