### PR TITLE
fix(whatsapp): keep echo tracker log truncation UTF-16 safe

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/echo.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/echo.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from "vitest";
+import { createEchoTracker } from "./echo.js";
+
+describe("createEchoTracker", () => {
+  it("keeps verbose previews UTF-16 safe without changing the tracked text", () => {
+    const logVerbose = vi.fn();
+    const tracker = createEchoTracker({ logVerbose });
+    const prefix = "x".repeat(49);
+    const text = `${prefix}😀tail`;
+
+    tracker.rememberText(text, { logVerboseMessage: true });
+
+    expect(logVerbose).toHaveBeenCalledExactlyOnceWith(
+      `Added to echo detection set (size now: 1): ${prefix}...`,
+    );
+    expect(tracker.has(text)).toBe(true);
+  });
+});

--- a/extensions/whatsapp/src/auto-reply/monitor/echo.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/echo.ts
@@ -1,4 +1,5 @@
 // Whatsapp plugin module implements echo behavior.
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 export type EchoTracker = {
   rememberText: (
     text: string | undefined,
@@ -48,7 +49,7 @@ export function createEchoTracker(params: {
     }
     if (opts.logVerboseMessage) {
       params.logVerbose?.(
-        `Added to echo detection set (size now: ${recentlySent.size}): ${text.slice(0, 50)}...`,
+        `Added to echo detection set (size now: ${recentlySent.size}): ${truncateUtf16Safe(text, 50)}...`,
       );
     }
     trim();


### PR DESCRIPTION
## What Problem This Solves

WhatsApp's echo tracker included the first 50 UTF-16 code units of a sent message in verbose diagnostics using raw `.slice(0, 50)`. An emoji or another supplementary Unicode character crossing that boundary left a dangling surrogate in the log preview.

## Why This Change Was Made

The WhatsApp-owned logger now uses the existing plugin-SDK `truncateUtf16Safe` helper at the same 50-code-unit bound. The regression test drives the public echo-tracker behavior, places an emoji across the exact boundary, asserts the complete log message, and verifies that the unmodified full text remains in the echo-detection set.

## User Impact

Verbose WhatsApp diagnostics stay valid and readable for emoji-bearing messages. Echo matching, storage, limits, configuration, and message delivery are unchanged.

## Evidence

- `node ../../node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extension-whatsapp.config.ts extensions/whatsapp/src/auto-reply/monitor/echo.test.ts` — 1 test passed.
- `oxfmt`, focused `oxlint`, and `git diff --check` passed for the touched files.
- The behavioral assertion proves both the exact UTF-16-safe preview and unchanged full-text echo tracking.

No external WhatsApp call is required for this isolated verbose-log formatting path; the channel transport and delivery path are not changed.

## AI-assisted

This PR was generated with Claude Code and improved/reviewed with Codex.
