### PR TITLE
fix(microsoft-foundry): keep Azure CLI error truncation UTF-16 safe

### DIFF
--- a/extensions/microsoft-foundry/cli.ts
+++ b/extensions/microsoft-foundry/cli.ts
@@ -4,6 +4,7 @@ import {
   normalizeOptionalString,
   normalizeStringifiedOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { AzAccessToken, AzAccount } from "./shared.js";
 import { COGNITIVE_SERVICES_RESOURCE } from "./shared.js";
 
@@ -34,7 +35,7 @@ function summarizeAzErrorMessage(raw: string): string {
   if (/aadsts\d+/i.test(normalized)) {
     return "Azure login failed for the selected tenant. Re-run `az login --use-device-code` and confirm the tenant is correct.";
   }
-  return normalized.slice(0, 300);
+  return truncateUtf16Safe(normalized, 300);
 }
 
 function buildAzCommandError(error: Error, stderr: string, stdout: string): Error {

--- a/extensions/microsoft-foundry/index.test.ts
+++ b/extensions/microsoft-foundry/index.test.ts
@@ -1841,7 +1841,9 @@ describe("microsoft-foundry plugin", () => {
       ) => callback(new Error("az failed"), "", `${prefix}😀tail`),
     );
 
-    await expect(getAccessTokenResultAsync()).rejects.toThrow(`az failed: ${prefix}`);
+    await expect(getAccessTokenResultAsync()).rejects.toMatchObject({
+      message: `az failed: ${prefix}`,
+    });
   });
 
   it("deletes legacy provider-level secret refs", () => {

--- a/extensions/microsoft-foundry/index.test.ts
+++ b/extensions/microsoft-foundry/index.test.ts
@@ -1830,6 +1830,20 @@ describe("microsoft-foundry plugin", () => {
     await expect(getAccessTokenResultAsync()).rejects.toThrow("Azure CLI is not logged in");
   });
 
+  it("keeps bounded Azure CLI error details UTF-16 safe", async () => {
+    const prefix = "x".repeat(299);
+    execFileMock.mockImplementationOnce(
+      (
+        _file: unknown,
+        _args: unknown,
+        _options: unknown,
+        callback: (error: Error | null, stdout: string, stderr: string) => void,
+      ) => callback(new Error("az failed"), "", `${prefix}😀tail`),
+    );
+
+    await expect(getAccessTokenResultAsync()).rejects.toThrow(`az failed: ${prefix}`);
+  });
+
   it("deletes legacy provider-level secret refs", () => {
     const secretRef = {
       source: "env" as const,


### PR DESCRIPTION
## What Problem This Solves

Microsoft Foundry surfaces unexpected Azure CLI stderr/stdout in a bounded authentication error. The fallback path used raw `.slice(0, 300)`, so supplementary Unicode crossing that UTF-16 boundary could leave a dangling surrogate in the operator-facing error.

## Why This Change Was Made

The Foundry-owned error summarizer now uses the existing plugin-SDK `truncateUtf16Safe` helper at the same 300-code-unit limit. Existing classifications for missing Azure CLI, login, subscription, tenant, and AADSTS errors remain unchanged.

The regression test drives the public async token command path with a mocked `execFile` failure and asserts the complete propagated `Error.message` at the exact emoji boundary.

## User Impact

Unexpected Azure CLI authentication details remain valid and readable when they contain supplementary Unicode. Command execution, timeout, classification, auth flow, and configuration are unchanged.

## Evidence

- `node ../../node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extension-providers.config.ts extensions/microsoft-foundry/index.test.ts` — 92 tests passed.
- Focused `oxlint` and `git diff --check` passed for the touched files.
- The regression assertion covers the production `getAccessTokenResultAsync` → `execAzAsync` → `buildAzCommandError` path, not the helper in isolation.

No live Azure request is needed for this local child-process error-formatting boundary; the Azure API and successful CLI paths are unchanged.

## AI-assisted

This PR was generated with Claude Code and improved/reviewed with Codex.
