### PR TITLE
fix(microsoft-foundry): keep connection test error truncation UTF-16 safe

### DIFF
--- a/extensions/microsoft-foundry/onboard.connection.test.ts
+++ b/extensions/microsoft-foundry/onboard.connection.test.ts
@@ -70,4 +70,40 @@ describe("testFoundryConnection", () => {
       "Connection Test",
     );
   });
+
+  it.each([
+    {
+      status: 400,
+      expectedPrefix:
+        "Endpoint is reachable but returned 400 Bad Request - check your deployment name and API version.\n",
+      expectedSuffix: "",
+    },
+    {
+      status: 503,
+      expectedPrefix: "Warning: test request returned 503. ",
+      expectedSuffix: "\nProceeding anyway - you can fix the endpoint later.",
+    },
+  ])(
+    "keeps $status error-body previews UTF-16 safe",
+    async ({ status, expectedPrefix, expectedSuffix }) => {
+      const note = vi.fn();
+      const prefix = "x".repeat(199);
+      hoisted.fetchWithSsrFGuard.mockResolvedValue({
+        response: new Response(`${prefix}😀tail`, { status }),
+        release: async () => {},
+      });
+
+      await testFoundryConnection({
+        ctx: { prompter: { note } } as never,
+        endpoint: "https://example.openai.azure.com",
+        modelId: "gpt-4o",
+        api: DEFAULT_API,
+      });
+
+      expect(note).toHaveBeenCalledExactlyOnceWith(
+        `${expectedPrefix}${prefix}${expectedSuffix}`,
+        "Connection Test",
+      );
+    },
+  );
 });

--- a/extensions/microsoft-foundry/onboard.ts
+++ b/extensions/microsoft-foundry/onboard.ts
@@ -7,6 +7,7 @@ import {
   normalizeOptionalString,
   normalizeStringifiedOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   azLoginDeviceCode,
   azLoginDeviceCodeWithOptions,
@@ -613,7 +614,7 @@ export async function testFoundryConnection(params: {
           FOUNDRY_CONNECTION_TEST_ERROR_BODY_LIMIT_BYTES,
         ).catch(() => "");
         await params.ctx.prompter.note(
-          `Endpoint is reachable but returned 400 Bad Request - check your deployment name and API version.\n${body.slice(0, 200)}`,
+          `Endpoint is reachable but returned 400 Bad Request - check your deployment name and API version.\n${truncateUtf16Safe(body, 200)}`,
           "Connection Test",
         );
       } else if (!res.ok) {
@@ -622,7 +623,7 @@ export async function testFoundryConnection(params: {
           FOUNDRY_CONNECTION_TEST_ERROR_BODY_LIMIT_BYTES,
         ).catch(() => "");
         await params.ctx.prompter.note(
-          `Warning: test request returned ${res.status}. ${body.slice(0, 200)}\nProceeding anyway - you can fix the endpoint later.`,
+          `Warning: test request returned ${res.status}. ${truncateUtf16Safe(body, 200)}\nProceeding anyway - you can fix the endpoint later.`,
           "Connection Test",
         );
       } else {


### PR DESCRIPTION
## What Problem This Solves

Microsoft Foundry's connection test includes a bounded response-body preview when the endpoint returns HTTP 400 or another non-success status. Both branches used raw `.slice(0, 200)`, so supplementary Unicode crossing that UTF-16 boundary could leave a dangling surrogate in the operator-facing note.

## Why This Change Was Made

Both sibling error branches now use the existing plugin-SDK `truncateUtf16Safe` helper at the same 200-code-unit limit. The regression suite drives the exported `testFoundryConnection` path for HTTP 400 and 503, places an emoji across the exact boundary, and asserts each complete prompter note.

## User Impact

Foundry connection-test diagnostics stay valid and readable for Unicode error bodies. Response byte limits, cancellation, status handling, auth, endpoint selection, and the decision to continue after a failed probe are unchanged.

## Evidence

- `node ../../node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extension-providers.config.ts extensions/microsoft-foundry/onboard.connection.test.ts` — 3 tests passed.
- `oxfmt`, focused `oxlint`, and `git diff --check` passed for the touched files.
- Live Microsoft Azure proof on 2026-07-09: an unauthenticated request to `https://management.azure.com/` returned HTTP 400, `application/json`, and the documented structured error envelope.
- Microsoft Foundry's official REST guidance identifies structured error bodies and 400/503 status handling: https://learn.microsoft.com/en-us/azure/ai-services/reference/rest-api-resources

The live request validates the external error contract; the exact Unicode boundary is injected deterministically at the Foundry connection-test boundary.

## AI-assisted

This PR was generated with Claude Code and improved/reviewed with Codex.
