### PR TITLE
fix(qa-matrix): keep room scenario preview truncation UTF-16 safe

### DIFF
--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts
@@ -2,6 +2,7 @@
 import { randomUUID } from "node:crypto";
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { MatrixQaObservedEvent } from "../../substrate/events.js";
 import {
   MATRIX_QA_BLOCK_ROOM_KEY,
@@ -347,8 +348,12 @@ async function runMatrixStreamingPreviewScenario(
   return {
     artifacts: {
       driverEventId,
-      previewFormattedBodyPreview: preview.event.formattedBody?.slice(0, 200),
-      previewBodyPreview: preview.event.body?.slice(0, 200),
+      previewFormattedBodyPreview: preview.event.formattedBody
+        ? truncateUtf16Safe(preview.event.formattedBody, 200)
+        : undefined,
+      previewBodyPreview: preview.event.body
+        ? truncateUtf16Safe(preview.event.body, 200)
+        : undefined,
       previewEventId: preview.event.eventId,
       previewMentions: preview.event.mentions,
       reply: finalReply,
@@ -422,7 +427,7 @@ function truncateMatrixQaToolProgressBody(body: string | undefined) {
   if (!body) {
     return "<none>";
   }
-  return body.length <= 240 ? body : `${body.slice(0, 237)}...`;
+  return body.length <= 240 ? body : `${truncateUtf16Safe(body, 237)}...`;
 }
 
 function describeMatrixQaToolProgressCandidate(event: MatrixQaObservedEvent) {
@@ -672,9 +677,13 @@ async function runMatrixToolProgressScenario(
       return {
         artifacts: {
           driverEventId,
-          previewBodyPreview: progressAfterFinal.event.body?.slice(0, 200),
+          previewBodyPreview: progressAfterFinal.event.body
+            ? truncateUtf16Safe(progressAfterFinal.event.body, 200)
+            : undefined,
           previewEventId: progressPreviewEventId,
-          previewFormattedBodyPreview: progressAfterFinal.event.formattedBody?.slice(0, 200),
+          previewFormattedBodyPreview: progressAfterFinal.event.formattedBody
+            ? truncateUtf16Safe(progressAfterFinal.event.formattedBody, 200)
+            : undefined,
           previewMentions: progressAfterFinal.event.mentions,
           reply: finalReply,
           token: params.finalText,
@@ -836,9 +845,13 @@ async function runMatrixToolProgressScenario(
   return {
     artifacts: {
       driverEventId,
-      previewBodyPreview: progress.event.body?.slice(0, 200),
+      previewBodyPreview: progress.event.body
+        ? truncateUtf16Safe(progress.event.body, 200)
+        : undefined,
       previewEventId: previewRootEventId,
-      previewFormattedBodyPreview: progress.event.formattedBody?.slice(0, 200),
+      previewFormattedBodyPreview: progress.event.formattedBody
+        ? truncateUtf16Safe(progress.event.formattedBody, 200)
+        : undefined,
       previewMentions: progress.event.mentions,
       reply: finalReply,
       token: params.finalText,

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts
@@ -272,6 +272,10 @@ function buildMatrixStreamingPreviewFinalText(prefix: string) {
   ].join(" ");
 }
 
+function truncateMatrixQaArtifactPreview(value: string | undefined) {
+  return value === undefined ? undefined : truncateUtf16Safe(value, 200);
+}
+
 async function runMatrixStreamingPreviewScenario(
   context: MatrixQaScenarioContext,
   params: {
@@ -348,12 +352,8 @@ async function runMatrixStreamingPreviewScenario(
   return {
     artifacts: {
       driverEventId,
-      previewFormattedBodyPreview: preview.event.formattedBody
-        ? truncateUtf16Safe(preview.event.formattedBody, 200)
-        : undefined,
-      previewBodyPreview: preview.event.body
-        ? truncateUtf16Safe(preview.event.body, 200)
-        : undefined,
+      previewFormattedBodyPreview: truncateMatrixQaArtifactPreview(preview.event.formattedBody),
+      previewBodyPreview: truncateMatrixQaArtifactPreview(preview.event.body),
       previewEventId: preview.event.eventId,
       previewMentions: preview.event.mentions,
       reply: finalReply,
@@ -677,13 +677,11 @@ async function runMatrixToolProgressScenario(
       return {
         artifacts: {
           driverEventId,
-          previewBodyPreview: progressAfterFinal.event.body
-            ? truncateUtf16Safe(progressAfterFinal.event.body, 200)
-            : undefined,
+          previewBodyPreview: truncateMatrixQaArtifactPreview(progressAfterFinal.event.body),
           previewEventId: progressPreviewEventId,
-          previewFormattedBodyPreview: progressAfterFinal.event.formattedBody
-            ? truncateUtf16Safe(progressAfterFinal.event.formattedBody, 200)
-            : undefined,
+          previewFormattedBodyPreview: truncateMatrixQaArtifactPreview(
+            progressAfterFinal.event.formattedBody,
+          ),
           previewMentions: progressAfterFinal.event.mentions,
           reply: finalReply,
           token: params.finalText,
@@ -845,13 +843,9 @@ async function runMatrixToolProgressScenario(
   return {
     artifacts: {
       driverEventId,
-      previewBodyPreview: progress.event.body
-        ? truncateUtf16Safe(progress.event.body, 200)
-        : undefined,
+      previewBodyPreview: truncateMatrixQaArtifactPreview(progress.event.body),
       previewEventId: previewRootEventId,
-      previewFormattedBodyPreview: progress.event.formattedBody
-        ? truncateUtf16Safe(progress.event.formattedBody, 200)
-        : undefined,
+      previewFormattedBodyPreview: truncateMatrixQaArtifactPreview(progress.event.formattedBody),
       previewMentions: progress.event.mentions,
       reply: finalReply,
       token: params.finalText,

--- a/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
@@ -2288,6 +2288,8 @@ describe("matrix live qa scenarios", () => {
           eventId: "$quiet-preview",
           sender: "@sut:matrix-qa.test",
           type: "m.room.message",
+          body: "",
+          formattedBody: "",
         },
         since: "driver-sync-preview",
       }))
@@ -2337,11 +2339,15 @@ describe("matrix live qa scenarios", () => {
     });
     const artifacts = result.artifacts as {
       driverEventId?: unknown;
+      previewBodyPreview?: unknown;
       previewEventId?: unknown;
+      previewFormattedBodyPreview?: unknown;
       reply?: { eventId?: unknown };
     };
     expect(artifacts.driverEventId).toBe("$quiet-stream-trigger");
+    expect(artifacts.previewBodyPreview).toBe("");
     expect(artifacts.previewEventId).toBe("$quiet-preview");
+    expect(artifacts.previewFormattedBodyPreview).toBe("");
     expect(artifacts.reply?.eventId).toBe("$quiet-final");
 
     expectSentTextMessage(sendTextMessage, {
@@ -2357,6 +2363,8 @@ describe("matrix live qa scenarios", () => {
 
   it("captures partial preview text messages before the finalized Matrix reply", async () => {
     const previewEventId = "$partial-preview";
+    const previewBody = `${"b".repeat(199)}😀tail`;
+    const previewFormattedBody = `${"f".repeat(199)}😀tail`;
     const fallbackFinalText = "MATRIX_QA_PARTIAL_STREAM_PREVIEW_COMPLETE";
     const { sendTextMessage } = mockMatrixQaRoomClient({
       driverEventId: "$partial-stream-trigger",
@@ -2365,7 +2373,8 @@ describe("matrix live qa scenarios", () => {
           event: matrixQaMessageEvent({
             kind: "message",
             eventId: previewEventId,
-            body: "partial preview",
+            body: previewBody,
+            formattedBody: previewFormattedBody,
           }),
           since: "driver-sync-preview",
         },
@@ -2393,11 +2402,15 @@ describe("matrix live qa scenarios", () => {
     const result = await runMatrixQaScenario(scenario, matrixQaScenarioContext());
     const artifacts = result.artifacts as {
       driverEventId?: unknown;
+      previewBodyPreview?: unknown;
       previewEventId?: unknown;
+      previewFormattedBodyPreview?: unknown;
       reply?: { eventId?: unknown };
     };
     expect(artifacts.driverEventId).toBe("$partial-stream-trigger");
+    expect(artifacts.previewBodyPreview).toBe("b".repeat(199));
     expect(artifacts.previewEventId).toBe("$partial-preview");
+    expect(artifacts.previewFormattedBodyPreview).toBe("f".repeat(199));
     expect(artifacts.reply?.eventId).toBe("$partial-final");
 
     expectSentTextMessage(sendTextMessage, {
@@ -2767,7 +2780,7 @@ describe("matrix live qa scenarios", () => {
     const updateEvent = matrixQaMessageEvent({
       kind: "notice",
       eventId: "$tool-progress-timeout-update",
-      body: "Working...\nstill deciding",
+      body: `${"x".repeat(236)}😀tail`,
       relatesTo: {
         relType: "m.replace",
         eventId: previewEvent.eventId,
@@ -2794,8 +2807,16 @@ describe("matrix live qa scenarios", () => {
 
     const scenario = requireMatrixQaScenario("matrix-room-tool-progress-preview");
 
-    await expect(runMatrixQaScenario(scenario, context)).rejects.toThrow(
-      /observed preview candidates:[\s\S]*\$tool-progress-timeout-update/,
+    const error = await runMatrixQaScenario(scenario, context).then(
+      () => undefined,
+      (candidate: unknown) => candidate,
+    );
+    expect(error).toBeInstanceOf(Error);
+    const candidateLine = (error as Error).message
+      .split("\n")
+      .find((line) => line.startsWith("$tool-progress-timeout-update"));
+    expect(candidateLine).toBe(
+      `$tool-progress-timeout-update kind=notice relation=m.replace:$tool-progress-timeout-preview body=${JSON.stringify(`${"x".repeat(236)}...`)}`,
     );
   });
 


### PR DESCRIPTION
## What Problem This Solves

Matrix QA stores bounded body and formatted-body previews in scenario artifacts and timeout diagnostics. Raw UTF-16 slicing could leave a dangling surrogate when an emoji crossed the 200- or 237-code-unit boundary, producing invalid evidence text.

## Why This Change Was Made

Use the shared `truncateUtf16Safe` helper for every room-scenario preview boundary. A local artifact-preview helper keeps all 200-unit call sites consistent and preserves the prior distinction between an absent value and an empty string.

## User Impact

QA Matrix evidence remains valid text around emoji boundaries. Transport behavior, Matrix events, final replies, limits, and configuration are unchanged.

## Evidence

- `node ../../node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/qa-matrix/src/runners/contract/scenarios.test.ts` — 74 passed
- `oxfmt` on both changed files
- focused `oxlint` on both changed files
- `git diff --check`
- fresh branch autoreview: clean, no actionable findings

Regression coverage asserts exact 200-unit body/formatted-body artifact output, preserves empty strings, and asserts the exact 237-unit timeout diagnostic line. No live Matrix run is needed because the change only formats already-observed evidence; event selection, network I/O, and delivery are untouched.

## Risk

Low. This replaces unsafe presentation-only slices with the shared normalization helper and reduces production LOC. No API, config, dependency, or state change.

## AI-assisted

Initial patch generated with Claude Code; maintainer review refactored the call sites and added public-path regression coverage.
