### PR TITLE
fix(inworld): use truncateUtf16Safe for error body and parse error truncation

### DIFF
--- a/extensions/inworld/tts.test.ts
+++ b/extensions/inworld/tts.test.ts
@@ -228,6 +228,14 @@ describe("inworldTTS", () => {
     );
   });
 
+  it("keeps truncated HTTP error bodies UTF-16 safe", async () => {
+    queueGuardedResponse(new Response(`${"e".repeat(399)}😀tail`, { status: 400 }));
+
+    await expect(inworldTTS({ text: "test", apiKey: "test-key" })).rejects.toMatchObject({
+      message: `Inworld TTS API error (400): ${"e".repeat(399)}…`,
+    });
+  });
+
   it("throws on in-stream errors", async () => {
     const body = JSON.stringify({
       error: { code: 3, message: "Invalid voice ID" },
@@ -249,11 +257,11 @@ describe("inworldTTS", () => {
   });
 
   it("throws descriptive error on non-JSON line in stream", async () => {
-    queueGuardedResponse(new Response("<html>Rate limited</html>", { status: 200 }));
+    queueGuardedResponse(new Response(`${"p".repeat(79)}😀tail`, { status: 200 }));
 
-    await expect(inworldTTS({ text: "test", apiKey: "test-key" })).rejects.toThrow(
-      "Inworld TTS stream parse error: unexpected non-JSON line:",
-    );
+    await expect(inworldTTS({ text: "test", apiKey: "test-key" })).rejects.toMatchObject({
+      message: `Inworld TTS stream parse error: unexpected non-JSON line: ${"p".repeat(79)}`,
+    });
   });
 
   it("sends correct request body with defaults", async () => {

--- a/extensions/inworld/tts.ts
+++ b/extensions/inworld/tts.ts
@@ -3,6 +3,7 @@ import { MAX_AUDIO_BYTES } from "openclaw/plugin-sdk/media-runtime";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import type { SpeechVoiceOption } from "openclaw/plugin-sdk/speech-core";
 import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 const DEFAULT_INWORLD_BASE_URL = "https://api.inworld.ai";
 export const DEFAULT_INWORLD_VOICE_ID = "Sarah";
@@ -57,7 +58,7 @@ async function readInworldErrorBodySnippet(response: Response): Promise<string> 
 
   const collapsed = buffer.toString("utf8").replace(/\s+/g, " ").trim();
   if (collapsed.length > INWORLD_ERROR_BODY_MAX_CHARS) {
-    return `${collapsed.slice(0, INWORLD_ERROR_BODY_MAX_CHARS)}…`;
+    return `${truncateUtf16Safe(collapsed, INWORLD_ERROR_BODY_MAX_CHARS)}…`;
   }
   return collapsed;
 }
@@ -176,7 +177,7 @@ export async function inworldTTS(params: {
         parsed = JSON.parse(trimmed) as typeof parsed;
       } catch {
         throw new Error(
-          `Inworld TTS stream parse error: unexpected non-JSON line: ${trimmed.slice(0, 80)}`,
+          `Inworld TTS stream parse error: unexpected non-JSON line: ${truncateUtf16Safe(trimmed, 80)}`,
         );
       }
 


### PR DESCRIPTION
## What Problem This Solves

The Inworld speech plugin bounded HTTP error bodies and malformed NDJSON lines with raw UTF-16 slicing. Emoji at the 400- or 80-code-unit boundary could produce malformed diagnostic text.

## Why This Change Was Made

Use the existing plugin-SDK `truncateUtf16Safe` helper at both diagnostic boundaries while retaining the byte caps, whitespace normalization, character limits, and ellipsis policy.

## User Impact

Inworld TTS failures now produce valid Unicode diagnostics. Requests, streaming audio parsing, byte limits, voice behavior, authentication, and configuration are unchanged.

## Evidence

- `node ../../node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/inworld/tts.test.ts` — 28 passed
- exact HTTP error-body assertion at the 400-unit emoji boundary
- exact malformed-line assertion at the 80-unit emoji boundary
- `oxfmt`, focused `oxlint`, `git diff --check`
- fresh branch autoreview: clean, no actionable findings

No live credentialed call is needed because request construction and upstream response handling are unchanged; focused tests drive real `Response` bodies through both error paths.

## Risk

Low. Two presentation-only substitutions using an established shared helper; no API, config, dependency, or state change.

## AI-assisted

Initial patch generated with Claude Code; maintainer review added exact public-path regression coverage.
