### PR TITLE
fix(agents): use truncateUtf16Safe for raw args preview truncation

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -982,7 +982,7 @@ export function handleToolExecutionStart(
         const argsType = typeof args;
         const rawArgsPreview = readStringValue(args);
         const argsPreview = sanitizeForConsole(
-          rawArgsPreview?.slice(0, TOOL_START_WARNING_RAW_PREVIEW_MAX_CHARS),
+          rawArgsPreview ? truncateUtf16Safe(rawArgsPreview, TOOL_START_WARNING_RAW_PREVIEW_MAX_CHARS) : undefined,
           TOOL_START_WARNING_PREVIEW_MAX_CHARS,
         );
         const safeRunId = sanitizeForConsole(runId) ?? "-";


### PR DESCRIPTION
## What Problem This Solves

`src/agents/embedded-agent-subscribe.handlers.tools.ts` uses raw `.slice(0, N)` for string truncation at raw args preview `rawArgsPreview?.slice(0, TOOL_START_WARNING_RAW_PREVIEW_MAX_CHARS)`. When the text contains multi-byte Unicode characters such as emoji, a code-unit slice can split a UTF-16 surrogate pair, producing invalid Unicode.

## Why This Change Was Made

Replacing these `.slice(0, N)` calls with `truncateUtf16Safe` ensures the truncated output is always valid Unicode while keeping identical behavior for ASCII-only content.

## User Impact

Truncated text in the affected code path remains valid Unicode at the existing size limits. No behavioral, API, or performance changes for ASCII-only input.

## Evidence

- Mechanical one-to-one replacement: `.slice(0, N)` -> `truncateUtf16Safe(str, N)`
- `truncateUtf16Safe` is already used extensively in the codebase following the same pattern
- No runtime behavior change for the common case (valid Unicode or ASCII input)

Generated with Claude Code