### PR TITLE
fix(openai): use truncateUtf16Safe for image gen log value truncation

### DIFF
--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -1510,6 +1510,24 @@ describe("openai image generation provider", () => {
     );
   });
 
+  it("does not split a surrogate pair when truncating Codex OAuth image auth log values", async () => {
+    mockCodexAuthOnly();
+    mockCodexImageStream({ imageData: "codex-image" });
+
+    const provider = buildOpenAIImageGenerationProvider();
+    await provider.generateImage({
+      provider: "openai",
+      model: `${"a".repeat(255)}😀tail`,
+      prompt: "Draw using configured Codex auth",
+      cfg: {},
+      authStore: createCodexOAuthAuthStore(),
+    });
+
+    expect(logInfoMock).toHaveBeenCalledWith(
+      `image auth selected: provider=openai mode=oauth transport=codex-responses requestedModel=${"a".repeat(255)}... responsesModel=gpt-5.5 timeoutMs=180000`,
+    );
+  });
+
   it("parses Codex completed response output image payloads", async () => {
     mockCodexAuthOnly();
     mockCodexCompletedImageStream({

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -32,6 +32,7 @@ import {
   sanitizeConfiguredModelProviderRequest,
 } from "openclaw/plugin-sdk/provider-http";
 import { isPrivateNetworkOptInEnabled } from "openclaw/plugin-sdk/ssrf-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   canonicalizeCodexResponsesBaseUrl,
   isOpenAICodexBaseUrl,
@@ -104,7 +105,7 @@ function sanitizeLogValue(value: unknown): string {
     return "unknown";
   }
   return cleaned.length > LOG_VALUE_MAX_CHARS
-    ? `${cleaned.slice(0, LOG_VALUE_MAX_CHARS)}...`
+    ? `${truncateUtf16Safe(cleaned, LOG_VALUE_MAX_CHARS)}...`
     : cleaned;
 }
 


### PR DESCRIPTION
## What Problem This Solves

The OpenAI image provider bounds model and auth-mode values before logging its Codex Responses auth-selection diagnostic. A raw UTF-16 code-unit slice could leave a dangling surrogate when an emoji crossed the existing 256-unit boundary.

## Why This Change Was Made

Use the shared plugin-SDK `truncateUtf16Safe` primitive at the existing limit. The sanitization and logging owner remain unchanged, and the fix does not add a second code path or change Codex request/response behavior.

## User Impact

Long OpenAI image-generation log values remain valid Unicode. ASCII behavior, the 256-unit bound, auth routing, and image-generation requests are unchanged.

## Evidence

- Added an exact public-provider-path regression with a surrogate pair crossing the 256-unit boundary.
- Focused OpenAI provider suite: 67 passed.
- Focused `oxfmt`, `oxlint`, and `git diff --check` passed.
- Fresh autoreview clean (0.99).
- Direct Codex source inspection confirmed image generation is a stable Responses API item and this patch only affects OpenClaw's local auth-selection log.

Generated with Claude Code; reviewed and improved by an OpenClaw maintainer agent.
