### PR TITLE
fix(diagnostics-prometheus): use truncateUtf16Safe for error message truncation

### DIFF
--- a/extensions/diagnostics-prometheus/src/service.ts
+++ b/extensions/diagnostics-prometheus/src/service.ts
@@ -7,6 +7,7 @@ import type {
   OpenClawPluginService,
 } from "../api.js";
 import { isInternalDiagnosticEventMetadata, redactSensitiveText } from "../api.js";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 type LabelSet = Record<string, string>;
 
@@ -228,10 +229,12 @@ function createPrometheusMetricStore() {
 
 function safeErrorMessage(err: unknown): string {
   const message = err instanceof Error ? (err.message ?? err.name) : String(err);
-  return redactSensitiveText(message)
-    .replaceAll("\u0000", " ")
-    .replace(/[\r\n\t\u2028\u2029]/gu, " ")
-    .slice(0, 500);
+  return truncateUtf16Safe(
+    redactSensitiveText(message)
+      .replaceAll("\u0000", " ")
+      .replace(/[\r\n\t\u2028\u2029]/gu, " "),
+    500,
+  );
 }
 
 function shouldRecordDiagnosticEvent(metadata: DiagnosticEventMetadata): boolean {


### PR DESCRIPTION
## What Problem This Solves

`extensions/diagnostics-prometheus/src/service.ts` uses raw `.slice(0, N)` for string truncation at error message `redactSensitiveText(...).slice(0, 500)`. When the text contains multi-byte Unicode characters such as emoji, a code-unit slice can split a UTF-16 surrogate pair, producing invalid Unicode.

## Why This Change Was Made

Replacing these `.slice(0, N)` calls with `truncateUtf16Safe` ensures the truncated output is always valid Unicode while keeping identical behavior for ASCII-only content.

## User Impact

Truncated text in the affected code path remains valid Unicode at the existing size limits. No behavioral, API, or performance changes for ASCII-only input.

## Evidence

- Mechanical one-to-one replacement: `.slice(0, N)` -> `truncateUtf16Safe(str, N)`
- `truncateUtf16Safe` is already used extensively in the codebase following the same pattern
- No runtime behavior change for the common case (valid Unicode or ASCII input)

Generated with Claude Code