### PR TITLE
fix(parallel-mcp): use truncateUtf16Safe for error message truncation

### DIFF
--- a/extensions/parallel/src/parallel-mcp-search.runtime.ts
+++ b/extensions/parallel/src/parallel-mcp-search.runtime.ts
@@ -7,6 +7,7 @@ import {
 } from "openclaw/plugin-sdk/provider-http";
 import { withTrustedWebSearchEndpoint } from "openclaw/plugin-sdk/provider-web-search";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 // Free hosted Search MCP. This keyless transport is used only after the user
 // explicitly selects the `parallel-free` web_search provider. Docs:
@@ -154,11 +155,11 @@ export function selectMcpEnvelope(text: string, requestId: string): JsonRpcMessa
  */
 export function extractMcpToolPayload(envelope: JsonRpcMessage): McpToolPayload {
   if ("error" in envelope) {
-    throw new Error(`Parallel MCP error: ${JSON.stringify(envelope.error).slice(0, 500)}`);
+    throw new Error(`Parallel MCP error: ${truncateUtf16Safe(JSON.stringify(envelope.error), 500)}`);
   }
   const result = isRecord(envelope.result) ? envelope.result : {};
   if (result.isError) {
-    throw new Error(`Parallel MCP tool error: ${JSON.stringify(result).slice(0, 500)}`);
+    throw new Error(`Parallel MCP tool error: ${truncateUtf16Safe(JSON.stringify(result), 500)}`);
   }
   if (isRecord(result.structuredContent)) {
     return result.structuredContent;
@@ -177,7 +178,7 @@ export function extractMcpToolPayload(envelope: JsonRpcMessage): McpToolPayload 
     }
   }
   throw new Error(
-    `Parallel MCP returned no parseable content: ${JSON.stringify(result).slice(0, 500)}`,
+    `Parallel MCP returned no parseable content: ${truncateUtf16Safe(JSON.stringify(result), 500)}`,
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

`extensions/parallel/src/parallel-mcp-search.runtime.ts` uses raw `.slice(0, N)` for string truncation at three JSON-RPC error payload truncation sites `JSON.stringify(...).slice(0, 500)`. When the text contains multi-byte Unicode characters such as emoji, a code-unit slice can split a UTF-16 surrogate pair, producing invalid Unicode.

## Why This Change Was Made

Replacing these `.slice(0, N)` calls with `truncateUtf16Safe` ensures the truncated output is always valid Unicode while keeping identical behavior for ASCII-only content.

## User Impact

Truncated text in the affected code path remains valid Unicode at the existing size limits. No behavioral, API, or performance changes for ASCII-only input.

## Evidence

- Mechanical one-to-one replacement: `.slice(0, N)` -> `truncateUtf16Safe(str, N)`
- `truncateUtf16Safe` is already used extensively in the codebase following the same pattern
- No runtime behavior change for the common case (valid Unicode or ASCII input)

Generated with Claude Code