### PR TITLE
fix(migrate-claude): use truncateUtf16Safe for skill description truncation

### DIFF
--- a/extensions/migrate-claude/provider.test.ts
+++ b/extensions/migrate-claude/provider.test.ts
@@ -133,7 +133,11 @@ describe("Claude migration provider", () => {
         },
       }),
     );
-    await writeFile(path.join(source, ".claude", "commands", "ship.md"), "Ship $ARGUMENTS\n");
+    const commandDescriptionPrefix = "a".repeat(179);
+    await writeFile(
+      path.join(source, ".claude", "commands", "ship.md"),
+      `${commandDescriptionPrefix}😀tail\n`,
+    );
     await writeFile(path.join(source, ".claude", "skills", "Review", "SKILL.md"), "# Review\n");
 
     const config = {
@@ -169,9 +173,13 @@ describe("Claude migration provider", () => {
     expect(await fs.readFile(path.join(workspaceDir, "AGENTS.md"), "utf8")).toContain(
       "Imported from Claude: project CLAUDE.md",
     );
-    await expect(
-      fs.access(path.join(workspaceDir, "skills", "claude-command-ship", "SKILL.md")),
-    ).resolves.toBeUndefined();
+    const generatedSkill = await fs.readFile(
+      path.join(workspaceDir, "skills", "claude-command-ship", "SKILL.md"),
+      "utf8",
+    );
+    expect(generatedSkill.split("\n").find((line) => line.startsWith("description: "))).toBe(
+      `description: ${JSON.stringify(commandDescriptionPrefix)}`,
+    );
     await expect(
       fs.access(path.join(workspaceDir, "skills", "review", "SKILL.md")),
     ).resolves.toBeUndefined();

--- a/extensions/migrate-claude/skills.ts
+++ b/extensions/migrate-claude/skills.ts
@@ -9,6 +9,7 @@ import {
   MIGRATION_REASON_TARGET_EXISTS,
 } from "openclaw/plugin-sdk/migration";
 import type { MigrationItem } from "openclaw/plugin-sdk/plugin-entry";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { exists, readText, sanitizeName } from "./helpers.js";
 import type { ClaudeSource } from "./source.js";
 import type { PlannedTargets } from "./targets.js";
@@ -153,7 +154,7 @@ function generatedCommandSkillContent(params: {
   return [
     "---",
     `name: ${params.skillName}`,
-    `description: ${JSON.stringify(description.slice(0, 180))}`,
+    `description: ${JSON.stringify(truncateUtf16Safe(description, 180))}`,
     "disable-model-invocation: true",
     "---",
     "",


### PR DESCRIPTION
## What Problem This Solves

Claude command migration generates a YAML `description` from the command's first paragraph. A raw 180-unit UTF-16 slice could leave a dangling surrogate, producing malformed generated skill metadata when an emoji crossed the boundary.

## Why This Change Was Made

Use the shared public plugin-SDK truncation primitive at the existing 180-unit bound. Source discovery, paragraph normalization, JSON/YAML quoting, and the imported command body are unchanged.

## User Impact

Generated skills from long Claude commands retain valid Unicode metadata. The existing description size and all ASCII output remain unchanged.

## Evidence

- Added an exact apply-path regression that reads the generated `SKILL.md` and asserts its description line at the surrogate boundary.
- Focused Claude migration provider suite: 5 passed.
- Focused `oxfmt`, `oxlint`, and `git diff --check` passed.
- Fresh autoreview clean (0.99).

Generated with Claude Code; reviewed and improved by an OpenClaw maintainer agent.
