### PR TITLE
fix(google-meet): use truncateUtf16Safe for log value truncation

### DIFF
--- a/extensions/google-meet/src/realtime.process.test.ts
+++ b/extensions/google-meet/src/realtime.process.test.ts
@@ -5,9 +5,10 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { RealtimeTranscriptionProviderPlugin } from "openclaw/plugin-sdk/realtime-transcription";
+import type { RealtimeVoiceProviderPlugin } from "openclaw/plugin-sdk/realtime-voice";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveGoogleMeetConfig } from "./config.js";
-import { startCommandAgentAudioBridge } from "./realtime.js";
+import { formatGoogleMeetRealtimeVoiceModelLog, startCommandAgentAudioBridge } from "./realtime.js";
 
 const tempDirs: string[] = [];
 const spawnedChildren: ChildProcess[] = [];
@@ -127,5 +128,19 @@ describe("startCommandAgentAudioBridge real process stream errors", () => {
         inputProcess.pid ?? "unknown"
       } outputPid=${outputProcess.pid ?? "unknown"}`,
     );
+  });
+});
+
+describe("Google Meet realtime model logs", () => {
+  it("keeps a whole code point when a provider id crosses the log boundary", () => {
+    const prefix = "a".repeat(179);
+    const log = formatGoogleMeetRealtimeVoiceModelLog({
+      strategy: "native",
+      provider: { id: `${prefix}😀tail` } as RealtimeVoiceProviderPlugin,
+      providerConfig: {},
+      audioFormat: "pcm16-24khz",
+    });
+
+    expect(log).toContain(`provider=${prefix} model=provider-default`);
   });
 });

--- a/extensions/google-meet/src/realtime.ts
+++ b/extensions/google-meet/src/realtime.ts
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import type { Writable } from "node:stream";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { PluginRuntime, RuntimeLogger } from "openclaw/plugin-sdk/plugin-runtime";
 import {
   getRealtimeTranscriptionProvider,
@@ -380,7 +381,7 @@ function readLogString(value: unknown): string | undefined {
 }
 
 function formatLogValue(value: string | undefined): string {
-  const normalized = value?.replace(/\s+/g, "_").slice(0, 180);
+  const normalized = value ? truncateUtf16Safe(value.replace(/\s+/g, "_"), 180) : undefined;
   return normalized || "unknown";
 }
 

--- a/extensions/google-meet/src/realtime.ts
+++ b/extensions/google-meet/src/realtime.ts
@@ -3,7 +3,6 @@ import { spawn } from "node:child_process";
 import type { Writable } from "node:stream";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { PluginRuntime, RuntimeLogger } from "openclaw/plugin-sdk/plugin-runtime";
 import {
   getRealtimeTranscriptionProvider,
@@ -41,6 +40,7 @@ import {
   type TalkEventInput,
   type TalkSessionController,
 } from "openclaw/plugin-sdk/realtime-voice";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   consultOpenClawAgentForGoogleMeet,
   handleGoogleMeetRealtimeConsultToolCall,


### PR DESCRIPTION
## What Problem This Solves

Google Meet normalizes realtime provider, model, strategy, and audio-format values into bounded diagnostics. A raw 180-unit UTF-16 slice could leave a dangling surrogate when an emoji crossed that boundary.

## Why This Change Was Made

Use the shared public plugin-SDK truncation primitive at the existing limit. Value selection, whitespace normalization, fallback labels, and log structure are unchanged.

## User Impact

Long Google Meet realtime diagnostics remain valid Unicode. Provider selection and audio behavior are unchanged.

## Evidence

- Added an exact exported-formatter regression with a provider id crossing the 180-unit boundary.
- Focused realtime process/log suite: 2 passed.
- Focused `oxfmt`, `oxlint`, and `git diff --check` passed.
- Fresh autoreview clean (0.99).

Generated with Claude Code; reviewed and improved by an OpenClaw maintainer agent.
