### PR TITLE
fix(agents): use truncateUtf16Safe for runner error text truncation

### DIFF
--- a/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
@@ -116,6 +116,24 @@ describe("overflow compaction in run loop", () => {
     expect(result.meta.error).toBeUndefined();
   });
 
+  it("keeps a whole code point at the context-overflow diagnostic boundary", async () => {
+    const marker = "request_too_large: ";
+    const prefix = `${marker}${"a".repeat(199 - marker.length)}`;
+    mockOverflowRetrySuccess({
+      runEmbeddedAttempt: mockedRunEmbeddedAttempt,
+      compactDirect: mockedCompactDirect,
+      overflowMessage: `${prefix}😀tail`,
+    });
+
+    await runEmbeddedAgent(baseParams);
+
+    const diagnostic = mockedLog.warn.mock.calls
+      .map(([entry]) => String(entry))
+      .find((entry) => entry.startsWith("[context-overflow-diag]"));
+    expect(diagnostic).toBeDefined();
+    expect(diagnostic?.endsWith(`error=${prefix}`)).toBe(true);
+  });
+
   it("keeps fallback unsafe when an overflow retry follows a mutating attempt", async () => {
     const overflowError = makeOverflowError();
     mockedRunEmbeddedAttempt

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -8,6 +8,7 @@ import {
   MAX_TIMER_TIMEOUT_MS,
 } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { sanitizeForLog } from "../../../packages/terminal-core/src/ansi.js";
 import { FAST_MODE_AUTO_PROGRESS_KIND, type ReplyPayload } from "../../auto-reply/reply-payload.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
@@ -2719,7 +2720,7 @@ async function runEmbeddedAgentInternal(
                 `observedTokens=${observedOverflowTokens ?? "unknown"} ` +
                 `preflightEstimatedTokens=${preflightEstimatedPromptTokens ?? "unknown"} ` +
                 `compactionTokens=${overflowTokenCountForCompaction ?? "unknown"} ` +
-                `error=${errorText.slice(0, 200)}`,
+                `error=${truncateUtf16Safe(errorText, 200)}`,
             );
             const isCompactionFailure = isCompactionFailureError(errorText);
             const hadAttemptLevelCompaction = attemptCompactionCount > 0;


### PR DESCRIPTION
## What Problem This Solves

The embedded agent runner includes a bounded 200-unit provider error in its context-overflow diagnostic. A raw UTF-16 slice could leave a dangling surrogate when an emoji crossed that boundary.

## Why This Change Was Made

Use normalization-core's shared UTF-16-safe truncation primitive at the existing diagnostic boundary. Overflow detection, token extraction, compaction decisions, retry behavior, and the original error remain unchanged.

## User Impact

Context-overflow diagnostics remain valid Unicode without changing recovery behavior.

## Evidence

- Added an exact real runner-loop regression with an emoji crossing the 200-unit diagnostic boundary.
- Focused overflow-compaction suite: 30 passed.
- Focused `oxfmt`, `oxlint`, and `git diff --check` passed.
- Fresh autoreview clean (0.99).

Generated with Claude Code; reviewed and improved by an OpenClaw maintainer agent.
