### PR TITLE
fix(browser): use truncateUtf16Safe for element text preview truncation

### DIFF
--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -634,7 +634,7 @@ async function findCursorInteractiveElements(
           }
           el.setAttribute("${attr}", String(out.length));
           out.push({
-            text: String(el.textContent || "").replace(/\\s+/g, " ").trim().slice(0, 101),
+            text: truncateUtf16Safe(String(el.textContent || "").replace(/\\s+/g, " ").trim(), 101),
             tagName,
             hasCursorPointer,
             hasOnClick,


### PR DESCRIPTION
## What Problem This Solves

`extensions/browser/src/browser/cdp.ts` uses raw `.slice(0, N)` for string truncation at element textContent preview `el.textContent.slice(0, 101)`. When the text contains multi-byte Unicode characters such as emoji, a code-unit slice can split a UTF-16 surrogate pair, producing invalid Unicode.

## Why This Change Was Made

Replacing these `.slice(0, N)` calls with `truncateUtf16Safe` ensures the truncated output is always valid Unicode while keeping identical behavior for ASCII-only content.

## User Impact

Truncated text in the affected code path remains valid Unicode at the existing size limits. No behavioral, API, or performance changes for ASCII-only input.

## Evidence

- Mechanical one-to-one replacement: `.slice(0, N)` -> `truncateUtf16Safe(str, N)`
- `truncateUtf16Safe` is already used extensively in the codebase following the same pattern
- No runtime behavior change for the common case (valid Unicode or ASCII input)

Generated with Claude Code