### PR TITLE
fix(active-memory): keep bounded search queries UTF-16 safe

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -5097,6 +5097,31 @@ describe("active-memory plugin", () => {
     expect(prompt).not.toContain("Recent conversation tail:");
   });
 
+  it("keeps a whole code point when the bounded search query crosses an emoji", async () => {
+    api.pluginConfig = {
+      agents: ["main"],
+      queryMode: "message",
+    };
+    plugin.register(api as unknown as OpenClawPluginApi);
+    const prefix = "a".repeat(479);
+
+    await hooks.before_prompt_build(
+      {
+        prompt: `${prefix}😀tail`,
+        messages: [],
+      },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:main",
+        messageProvider: "webchat",
+      },
+    );
+
+    const query = lastEmbeddedPrompt().match(/Bounded memory search query:\n([^\n]*)/u)?.[1];
+    expect(query).toBe(prefix);
+  });
+
   it("sends a bounded latest-message query instead of channel metadata to memory search", async () => {
     api.pluginConfig = {
       agents: ["main"],

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -2711,7 +2711,7 @@ function normalizeSearchQueryText(text: string): string {
 function clampSearchQuery(text: string): string {
   const normalized = text.replace(/\s+/g, " ").trim();
   return normalized.length > MAX_ACTIVE_MEMORY_SEARCH_QUERY_CHARS
-    ? normalized.slice(0, MAX_ACTIVE_MEMORY_SEARCH_QUERY_CHARS).trim()
+    ? truncateUtf16Safe(normalized, MAX_ACTIVE_MEMORY_SEARCH_QUERY_CHARS).trim()
     : normalized;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Active Memory bounds the normalized latest-message search query to 480 UTF-16 units before placing it in the memory-search prompt. A raw slice could leave a dangling surrogate when an emoji crossed that boundary.

## Why This Change Was Made

Rebuilt the PR on current `main`, removed the log-value hunk already landed in #102551, and applied the existing shared UTF-16-safe truncator only to the remaining search-query owner.

## User Impact

Long Active Memory search queries remain valid Unicode at the same 480-unit limit. Query mode, filtering, prompt structure, and ASCII behavior are unchanged.

## Evidence

- Added an exact `before_prompt_build` regression that inspects the bounded search query at the surrogate boundary.
- Focused Active Memory suite: 158 passed.
- Focused `oxfmt`, `oxlint`, and `git diff --check` passed.
- Fresh autoreview clean (0.99).

Co-authored-by: lizeyu-xydt <li.zeyu@xydigit.com>
