### PR TITLE
fix(codex): keep dynamic tool output UTF-16 safe

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -733,6 +733,41 @@ describe("createCodexDynamicToolBridge", () => {
     expect(text).toContain("rerun with narrower args");
   });
 
+  it("keeps a whole code point when dynamic tool text crosses the configured boundary", async () => {
+    const maxChars = 180;
+    const totalChars = 400;
+    const noticeText = `...(OpenClaw truncated dynamic tool result: original ${totalChars} chars, showing ${maxChars}; rerun with narrower args.)`;
+    const textBudget = maxChars - noticeText.length - 1;
+    const prefix = "a".repeat(textBudget - 1);
+    const longText = `${prefix}😀${"z".repeat(totalChars - prefix.length - 2)}`;
+    const bridge = createCodexDynamicToolBridge({
+      tools: [
+        createTool({
+          name: "large_lookup",
+          execute: vi.fn(async () => textToolResult(longText)),
+        }),
+      ],
+      signal: new AbortController().signal,
+      hookContext: {
+        agentId: "main",
+        config: {
+          agents: { defaults: { contextLimits: { toolResultMaxChars: maxChars } } },
+        } as never,
+      },
+    });
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-1",
+      namespace: null,
+      tool: "large_lookup",
+      arguments: {},
+    });
+
+    expect(result.contentItems).toEqual([{ type: "inputText", text: `${prefix}\n${noticeText}` }]);
+  });
+
   it("honors normalized per-agent dynamic tool result caps", async () => {
     const bridge = createCodexDynamicToolBridge({
       tools: [

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -43,6 +43,7 @@ import {
 import { emitTrustedDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runtime";
 import type { ImageContent, TextContent } from "openclaw/plugin-sdk/llm";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   asOptionalRecord as readRecord,
   isRecord,
@@ -1359,7 +1360,7 @@ function convertToolContents(
       continue;
     }
     if (notice.length >= maxChars) {
-      output.push({ type: "inputText", text: noticeText.slice(0, maxChars) });
+      output.push({ type: "inputText", text: truncateUtf16Safe(noticeText, maxChars) });
       appendedNotice = true;
       continue;
     }
@@ -1368,7 +1369,7 @@ function convertToolContents(
     const shouldAppendNotice = remainingTextBudget <= 0;
     const text = item.text.slice(0, sliceLength);
     if (shouldAppendNotice) {
-      output.push({ type: "inputText", text: `${text.trimEnd()}${notice}`.slice(0, maxChars) });
+      output.push({ type: "inputText", text: truncateUtf16Safe(`${text.trimEnd()}${notice}`, maxChars) });
       appendedNotice = true;
     } else if (text.length > 0) {
       output.push({ type: "inputText", text });
@@ -1376,7 +1377,7 @@ function convertToolContents(
   }
 
   if (!appendedNotice) {
-    output.push({ type: "inputText", text: noticeText.slice(0, maxChars) });
+    output.push({ type: "inputText", text: truncateUtf16Safe(noticeText, maxChars) });
   }
   return output;
 }

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -43,11 +43,11 @@ import {
 import { emitTrustedDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runtime";
 import type { ImageContent, TextContent } from "openclaw/plugin-sdk/llm";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
-import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   asOptionalRecord as readRecord,
   isRecord,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { CodexDynamicToolsLoading } from "./config.js";
 import { invalidInlineImageText, sanitizeInlineImageDataUrl } from "./image-payload-sanitizer.js";
 import type {
@@ -1367,9 +1367,11 @@ function convertToolContents(
     const sliceLength = Math.min(item.text.length, remainingTextBudget);
     remainingTextBudget -= sliceLength;
     const shouldAppendNotice = remainingTextBudget <= 0;
-    const text = item.text.slice(0, sliceLength);
+    const text = truncateUtf16Safe(item.text, sliceLength);
     if (shouldAppendNotice) {
-      output.push({ type: "inputText", text: truncateUtf16Safe(`${text.trimEnd()}${notice}`, maxChars) });
+      // The notice budget is reserved before slicing text, so the combined
+      // result is already bounded without another boundary-sensitive cut.
+      output.push({ type: "inputText", text: `${text.trimEnd()}${notice}` });
       appendedNotice = true;
     } else if (text.length > 0) {
       output.push({ type: "inputText", text });


### PR DESCRIPTION
## What Problem This Solves

The Codex dynamic-tool bridge capped both its explanatory notice and the actual tool-result payload with raw UTF-16 code-unit slicing. A truncation boundary through an emoji or another supplementary character could therefore emit a lone surrogate.

## Why This Change Was Made

The reviewed implementation uses the shared `truncateUtf16Safe` primitive on every boundary-sensitive string in the capped-output path. It also removes a redundant final slice: the payload budget already reserves the notice length, so slicing the combined string again added a second unsafe boundary without enforcing a tighter limit.

## User Impact

Long Codex dynamic-tool results remain valid Unicode while preserving the existing configured output limit and truncation notice. Short results and ASCII-only output are unchanged.

## Evidence

- Focused dynamic-tools suite: 91 tests passed.
- Regression test places an emoji exactly at the computed tool-result payload boundary and asserts the exact bridged output.
- Focused oxfmt and oxlint passed; `git diff --check` passed.
- Fresh branch autoreview found no accepted or actionable findings (0.98 confidence).
