### PR TITLE
fix(cron): keep startup catch-up deferrals across restarts

### DIFF
--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -821,7 +821,6 @@ function createMockState(now: number, opts?: { defaultAgentId?: string }): CronS
       nowMs: () => now,
       defaultAgentId: opts?.defaultAgentId,
     },
-    pendingCatchupDeferralJobIds: new Set<string>(),
   } as unknown as CronServiceState;
 }
 
@@ -1308,18 +1307,16 @@ describe("recomputeNextRuns", () => {
       sessionTarget: "main",
       wakeMode: "now",
       payload: { kind: "systemEvent", text: "tick" },
-      state: { nextRunAtMs: deferred },
+      state: { nextRunAtMs: deferred, pendingCatchupDeferral: true },
     };
-    const pendingCatchupDeferralJobIds = new Set([job.id]);
     const state = {
       ...createMockState(now),
-      pendingCatchupDeferralJobIds,
       store: { version: 1 as const, jobs: [job] },
     } as CronServiceState;
 
     expect(recomputeNextRunsForMaintenance(state)).toBe(false);
     expect(job.state.nextRunAtMs).toBe(deferred);
-    expect(pendingCatchupDeferralJobIds.has(job.id)).toBe(true);
+    expect(job.state.pendingCatchupDeferral).toBe(true);
 
     expect(
       recomputeNextRunsForMaintenance(state, {
@@ -1327,11 +1324,11 @@ describe("recomputeNextRuns", () => {
         repairFutureCronNextRunAtMs: true,
       }),
     ).toBe(true);
-    expect(pendingCatchupDeferralJobIds.has(job.id)).toBe(false);
+    expect(job.state.pendingCatchupDeferral).toBeUndefined();
     expect(job.state.nextRunAtMs).toBe(deferred);
   });
 
-  it("drops startup catch-up deferral ids for jobs no longer relevant to maintenance", () => {
+  it("drops startup catch-up deferrals for disabled jobs", () => {
     const now = Date.parse("2026-05-05T12:00:00.000Z");
     const deferred = Date.parse("2026-05-05T12:02:00.000Z");
     const disabledJob: CronJob = {
@@ -1344,18 +1341,40 @@ describe("recomputeNextRuns", () => {
       sessionTarget: "main",
       wakeMode: "now",
       payload: { kind: "systemEvent", text: "tick" },
-      state: { nextRunAtMs: deferred },
+      state: { nextRunAtMs: deferred, pendingCatchupDeferral: true },
     };
-    const pendingCatchupDeferralJobIds = new Set([disabledJob.id, "removed-deferral"]);
     const state = {
       ...createMockState(now),
-      pendingCatchupDeferralJobIds,
       store: { version: 1 as const, jobs: [disabledJob] },
     } as CronServiceState;
 
     expect(recomputeNextRunsForMaintenance(state)).toBe(true);
-    expect([...pendingCatchupDeferralJobIds]).toEqual([]);
+    expect(disabledJob.state.pendingCatchupDeferral).toBeUndefined();
     expect(disabledJob.state.nextRunAtMs).toBeUndefined();
+  });
+
+  it("drops a startup catch-up deferral with no deferred slot", () => {
+    const now = Date.parse("2026-05-05T12:00:00.000Z");
+    const job: CronJob = {
+      id: "missing-startup-deferral-slot",
+      name: "missing startup deferral slot",
+      enabled: true,
+      createdAtMs: Date.parse("2026-05-05T00:00:00.000Z"),
+      updatedAtMs: Date.parse("2026-05-05T00:00:00.000Z"),
+      schedule: { kind: "cron", expr: "0 0 21 * * *", tz: "Asia/Shanghai", staggerMs: 0 },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "tick" },
+      state: { pendingCatchupDeferral: true },
+    };
+    const state = {
+      ...createMockState(now),
+      store: { version: 1 as const, jobs: [job] },
+    } as CronServiceState;
+
+    expect(recomputeNextRunsForMaintenance(state)).toBe(true);
+    expect(job.state.pendingCatchupDeferral).toBeUndefined();
+    expect(job.state.nextRunAtMs).toBeGreaterThan(now);
   });
 
   it("preserves cron retry backoff nextRunAtMs values during maintenance", () => {

--- a/src/cron/service.startup-overflow-clobber.test.ts
+++ b/src/cron/service.startup-overflow-clobber.test.ts
@@ -1,6 +1,8 @@
+import { Value } from "typebox/value";
 import { describe, expect, it, vi } from "vitest";
+import { CronJobStateSchema } from "../../packages/gateway-protocol/src/schema.js";
 import { setupCronServiceSuite } from "./service.test-harness.js";
-import { start, status } from "./service/ops.js";
+import { list, listPage, readJob, start, status } from "./service/ops.js";
 import { createCronServiceState } from "./service/state.js";
 import { onTimer } from "./service/timer.js";
 import { saveCronStore } from "./store.js";
@@ -76,10 +78,27 @@ describe("CronService startup catch-up repair scoping", () => {
 
     expect(deferred?.state.nextRunAtMs).toBe(startNow + 5_000);
     expect(deferred?.state.nextRunAtMs).not.toBe(tomorrowNaturalSlot);
-    expect(state.pendingCatchupDeferralJobIds.has("daily-overflow")).toBe(true);
+    expect(deferred?.state.pendingCatchupDeferral).toBe(true);
 
     await status(state);
     expect(deferred?.state.nextRunAtMs).toBe(startNow + 5_000);
+
+    // Public list/get views must not expose the internal marker (schema is closed).
+    const listed = await list(state);
+    const publicJob = listed.find((job) => job.id === "daily-overflow");
+    expect(publicJob?.state.nextRunAtMs).toBe(startNow + 5_000);
+    expect(publicJob?.state).not.toHaveProperty("pendingCatchupDeferral");
+    expect(Value.Check(CronJobStateSchema, publicJob?.state)).toBe(true);
+    const page = await listPage(state);
+    expect(page.jobs.find((job) => job.id === "daily-overflow")?.state).not.toHaveProperty(
+      "pendingCatchupDeferral",
+    );
+    const read = await readJob(state, "daily-overflow");
+    expect(read?.state).not.toHaveProperty("pendingCatchupDeferral");
+    // Store still owns the durable marker for the deferred slot.
+    expect(
+      state.store?.jobs.find((job) => job.id === "daily-overflow")?.state.pendingCatchupDeferral,
+    ).toBe(true);
 
     now = startNow + 5_005;
     await onTimer(state);
@@ -87,9 +106,68 @@ describe("CronService startup catch-up repair scoping", () => {
     const completed = state.store?.jobs.find((job) => job.id === "daily-overflow");
     expect(completed?.state.lastRunStatus).toBe("ok");
     expect(completed?.state.nextRunAtMs).toBe(tomorrowNaturalSlot);
-    expect(state.pendingCatchupDeferralJobIds.has("daily-overflow")).toBe(false);
+    expect(completed?.state.pendingCatchupDeferral).toBeUndefined();
 
     state.stopped = true;
+    await store.cleanup();
+  });
+
+  it("keeps an overflow catch-up deferral across a second restart", async () => {
+    const store = await makeStorePath();
+    const startNow = Date.parse("2025-12-13T17:00:00.000Z");
+    let now = startNow;
+    const jobs = [
+      createHourlyCronJob("hourly-0", Date.parse("2025-12-13T03:00:00.000Z")),
+      createHourlyCronJob("hourly-1", Date.parse("2025-12-13T04:00:00.000Z")),
+      createHourlyCronJob("hourly-2", Date.parse("2025-12-13T05:00:00.000Z")),
+      createHourlyCronJob("hourly-3", Date.parse("2025-12-13T06:00:00.000Z")),
+      createHourlyCronJob("hourly-4", Date.parse("2025-12-13T07:00:00.000Z")),
+      createDailyCronJob("daily-overflow", Date.parse("2025-12-13T09:00:00.000Z")),
+    ];
+    await saveCronStore(store.storePath, { version: 1, jobs });
+
+    const createState = () =>
+      createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+      });
+
+    const firstState = createState();
+    await start(firstState);
+
+    const deferredSlot = startNow + 5_000;
+    expect(firstState.store?.jobs.find((job) => job.id === "daily-overflow")?.state).toMatchObject({
+      nextRunAtMs: deferredSlot,
+      pendingCatchupDeferral: true,
+    });
+    if (firstState.timer) {
+      clearTimeout(firstState.timer);
+    }
+    firstState.stopped = true;
+
+    now = startNow + 3_000;
+    const restartedState = createState();
+    await start(restartedState);
+
+    const afterRestart = restartedState.store?.jobs.find((job) => job.id === "daily-overflow");
+    expect(afterRestart?.state).toMatchObject({
+      nextRunAtMs: deferredSlot,
+      pendingCatchupDeferral: true,
+    });
+
+    now = deferredSlot + 5;
+    await onTimer(restartedState);
+
+    const completed = restartedState.store?.jobs.find((job) => job.id === "daily-overflow");
+    expect(completed?.state.lastRunStatus).toBe("ok");
+    expect(completed?.state.pendingCatchupDeferral).toBeUndefined();
+
+    restartedState.stopped = true;
     await store.cleanup();
   });
 

--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -235,7 +235,6 @@ export function createMockCronStateForJobs(params: {
     running: false,
     stopped: false,
     restartRecoveryPending: false,
-    pendingCatchupDeferralJobIds: new Set<string>(),
     activeManualRunJobIds: new Set<string>(),
     manualSetupTimeoutNotified: false,
     timer: null,

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -590,6 +590,10 @@ function normalizeJobTickState(params: { state: CronServiceState; job: CronJob; 
   }
 
   if (!isJobEnabled(job)) {
+    if (job.state.pendingCatchupDeferral !== undefined) {
+      job.state.pendingCatchupDeferral = undefined;
+      changed = true;
+    }
     if (job.state.nextRunAtMs !== undefined) {
       job.state.nextRunAtMs = undefined;
       changed = true;
@@ -737,30 +741,17 @@ export function recomputeNextRunsForMaintenance(
       nowMs,
       deferredAutoDisableNotifications: opts?.deferredAutoDisableNotifications,
     });
-  const deferralIds = state.pendingCatchupDeferralJobIds;
-  // Drop deferral markers for jobs that no longer exist in the store or
-  // are disabled. They will not fire, so no deferral is needed.
-  if (state.store && deferralIds.size > 0) {
-    const relevantDeferralIds = new Set(
-      state.store.jobs.filter((job) => isJobEnabled(job)).map((job) => job.id),
-    );
-    for (const jobId of deferralIds) {
-      if (!relevantDeferralIds.has(jobId)) {
-        deferralIds.delete(jobId);
-      }
-    }
-  }
   return walkSchedulableJobs(
     state,
     ({ job, nowMs: now }) => {
       let changed = false;
 
-      // Clear stale deferral markers once the deferred staggered slot arrives.
-      // After the slot fires, future repair is safe for this job again.
-      if (deferralIds.has(job.id)) {
+      // Clear stale deferral markers once the deferred staggered slot arrives
+      // or the slot is gone. After that, future repair is safe for this job.
+      if (job.state.pendingCatchupDeferral === true) {
         const nextRun = job.state.nextRunAtMs;
-        if (hasScheduledNextRunAtMs(nextRun) && now >= nextRun) {
-          deferralIds.delete(job.id);
+        if (!hasScheduledNextRunAtMs(nextRun) || now >= nextRun) {
+          job.state.pendingCatchupDeferral = undefined;
           changed = true;
         }
       }
@@ -771,7 +762,7 @@ export function recomputeNextRunsForMaintenance(
         }
       } else if (
         repairFutureCronNextRunAtMs &&
-        !deferralIds.has(job.id) &&
+        job.state.pendingCatchupDeferral !== true &&
         shouldRepairFutureCronNextRunAtMs({ state, job, nowMs: now })
       ) {
         if (recomputeJob(job, now)) {

--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -915,13 +915,13 @@ describe("cron service ops persist rollback", () => {
     if (state.timer) {
       clearTimeout(state.timer);
     }
-    state.pendingCatchupDeferralJobIds.add(job.id);
+    job.state.pendingCatchupDeferral = true;
 
     vi.spyOn(cronStoreModule, "saveCronJobsStore").mockRejectedValueOnce(new Error("disk full"));
 
     await expect(remove(state, job.id)).rejects.toThrow("disk full");
 
-    expect(state.pendingCatchupDeferralJobIds.has(job.id)).toBe(true);
+    expect(state.store?.jobs[0]?.state.pendingCatchupDeferral).toBe(true);
     expect(state.store?.jobs.map((entry) => entry.id)).toEqual([job.id]);
   });
 

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -333,13 +333,27 @@ export async function status(state: CronServiceState) {
   });
 }
 
+/**
+ * Hides internal scheduler markers from public cron list/get views so returned
+ * job.state stays within CronJobStateSchema (additionalProperties: false).
+ */
+function toPublicCronJob(job: CronJob): CronJob {
+  if (job.state.pendingCatchupDeferral === undefined) {
+    return job;
+  }
+  const { pendingCatchupDeferral: _pendingCatchupDeferral, ...publicState } = job.state;
+  return { ...job, state: publicState };
+}
+
 /** Lists cron jobs sorted by next run time, excluding disabled jobs unless requested. */
 export async function list(state: CronServiceState, opts?: { includeDisabled?: boolean }) {
   return await locked(state, async () => {
     await ensureLoadedForRead(state);
     const includeDisabled = opts?.includeDisabled === true;
     const jobs = (state.store?.jobs ?? []).filter((j) => includeDisabled || isJobEnabled(j));
-    return jobs.toSorted((a, b) => (a.state.nextRunAtMs ?? 0) - (b.state.nextRunAtMs ?? 0));
+    return jobs
+      .toSorted((a, b) => (a.state.nextRunAtMs ?? 0) - (b.state.nextRunAtMs ?? 0))
+      .map(toPublicCronJob);
   });
 }
 
@@ -347,7 +361,8 @@ export async function list(state: CronServiceState, opts?: { includeDisabled?: b
 export async function readJob(state: CronServiceState, id: string) {
   return await locked(state, async () => {
     await ensureLoadedForRead(state);
-    return state.store?.jobs.find((job) => job.id === id);
+    const job = state.store?.jobs.find((entry) => entry.id === id);
+    return job ? toPublicCronJob(job) : undefined;
   });
 }
 
@@ -473,7 +488,7 @@ export async function listPage(state: CronServiceState, opts?: CronListPageOptio
     const offset = Math.max(0, Math.min(total, Math.floor(opts?.offset ?? 0)));
     const defaultLimit = total === 0 ? 50 : total;
     const limit = Math.max(1, Math.min(200, Math.floor(opts?.limit ?? defaultLimit)));
-    const jobs = sorted.slice(offset, offset + limit);
+    const jobs = sorted.slice(offset, offset + limit).map(toPublicCronJob);
     const nextOffset = offset + jobs.length;
     return {
       jobs,
@@ -488,7 +503,6 @@ export async function listPage(state: CronServiceState, opts?: CronListPageOptio
 
 type CronRollbackSnapshot = {
   store: CronStoreFile | null;
-  pendingCatchupDeferralJobIds: Set<string>;
 };
 
 // Rolls the live scheduler state back to its pre-mutation snapshot when the
@@ -506,7 +520,6 @@ async function persistOrRestore(
     await persist(state);
   } catch (err) {
     state.store = snapshot.store;
-    state.pendingCatchupDeferralJobIds = snapshot.pendingCatchupDeferralJobIds;
     throw err;
   }
   for (const notify of postPersistAutoDisableNotifications) {
@@ -517,7 +530,6 @@ async function persistOrRestore(
 function snapshotStoreForRollback(state: CronServiceState): CronRollbackSnapshot {
   return {
     store: state.store ? structuredClone(state.store) : null,
-    pendingCatchupDeferralJobIds: new Set(state.pendingCatchupDeferralJobIds),
   };
 }
 

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -204,9 +204,6 @@ export type CronServiceState = {
   running: boolean;
   stopped: boolean;
   restartRecoveryPending: boolean;
-  /** Prevents maintenance reads from advancing deferred startup catch-up slots.
-   * Entries are removed when the deferred job runs or becomes irrelevant. */
-  pendingCatchupDeferralJobIds: Set<string>;
   activeManualRunJobIds: Set<string>;
   manualSetupTimeoutNotified: boolean;
   /** Serializes mutating service operations so store writes and timers stay ordered. */
@@ -231,7 +228,6 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
     running: false,
     stopped: false,
     restartRecoveryPending: false,
-    pendingCatchupDeferralJobIds: new Set<string>(),
     activeManualRunJobIds: new Set<string>(),
     manualSetupTimeoutNotified: false,
     op: Promise.resolve(),

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1139,7 +1139,7 @@ function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOu
       endedAt: result.endedAt,
       triggerEval: result.triggerEval,
     });
-    state.pendingCatchupDeferralJobIds.delete(job.id);
+    job.state.pendingCatchupDeferral = undefined;
     return;
   }
 
@@ -1153,7 +1153,7 @@ function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOu
     endedAt: result.endedAt,
   });
   applyTriggerRunResult(job, result);
-  state.pendingCatchupDeferralJobIds.delete(job.id);
+  job.state.pendingCatchupDeferral = undefined;
 
   emitJobFinished(state, job, result, result.startedAt);
 
@@ -1997,12 +1997,13 @@ async function applyStartupCatchupOutcomes(
           }
           if (typeof deferred.delayMs === "number") {
             job.state.nextRunAtMs = baseNow + deferred.delayMs + offset - staggerMs;
-            state.pendingCatchupDeferralJobIds.add(jobId);
+            // Persist with nextRunAtMs so a second restart still protects the slot.
+            job.state.pendingCatchupDeferral = true;
             offset += staggerMs;
             continue;
           }
           job.state.nextRunAtMs = baseNow + offset;
-          state.pendingCatchupDeferralJobIds.add(jobId);
+          job.state.pendingCatchupDeferral = true;
           offset += staggerMs;
         }
       }

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -300,6 +300,12 @@ type CronCommandPayloadPatch = {
 /** Mutable runtime state persisted beside the immutable cron job spec. */
 export type CronJobState = {
   nextRunAtMs?: number;
+  /**
+   * Internal startup overflow catch-up protection. Persisted in state_json so a
+   * staggered deferred slot survives gateway restart; not part of the public
+   * cron.list / cron.get response schema.
+   */
+  pendingCatchupDeferral?: boolean;
   runningAtMs?: number;
   lastRunAtMs?: number;
   /** Preferred execution outcome field. */


### PR DESCRIPTION
Fixes #102236

## What Problem This Solves

Fixes an issue where operators with more than the restart missed-job budget of non-agentTurn cron jobs would silently lose an overflow catch-up run when the gateway restarted a second time before the staggered deferred slot fired.

## Why This Change Was Made

Startup overflow catch-up protection now lives on the persisted job runtime state (`pendingCatchupDeferral` in `state_json`) instead of a process-local Set, so a fresh process hydrates the same protection before maintenance repair. Public `cron.list` / `cron.get` / listPage views strip the internal marker so responses stay inside the closed `CronJobStateSchema`.

## User Impact

Deferred startup catch-up cron slots survive gateway restarts and still fire shortly after boot instead of being advanced to the next natural schedule and dropped. Public cron list/get clients do not see a new internal state field.

## Evidence

Focused cron service tests against a real on-disk store with two fresh `CronServiceState` instances (simulating restart):

```
node scripts/run-vitest.mjs \
  src/cron/service.startup-overflow-clobber.test.ts \
  src/cron/service.jobs.test.ts \
  src/cron/service/ops.test.ts \
  src/cron/service.restart-catchup.test.ts
# Test Files  4 passed (4)
# Tests  122 passed (122)
```

Local changed gate (typecheck/lint/guards):

```
OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_LOCAL_CHECK=1 CI=1 \
  node scripts/check-changed.mjs --base origin/main
# lanes=core, coreTests — pass
```

## Real behavior proof

- Behavior addressed: cross-restart loss of a startup overflow cron catch-up deferral (staggered `nextRunAtMs` repaired away on second `start()`).
- Environment: macOS local checkout at `86098cde2`; real SQLite cron store via `saveCronStore` + two fresh `createCronServiceState` / `start()` cycles in `src/cron/service.startup-overflow-clobber.test.ts`.
- Current-main contrast: on main, overflow deferral only records `pendingCatchupDeferralJobIds` in process memory; a second process starts with an empty Set and `recomputeNextRunsForMaintenance` advances the staggered slot to the natural cron time. After this patch, `job.state.pendingCatchupDeferral: true` is stored with the slot and survives the second `start()`.
- Exact steps or command run after this patch:
  ```
  node scripts/run-vitest.mjs src/cron/service.startup-overflow-clobber.test.ts \
    -t "keeps an overflow catch-up deferral across a second restart"
  ```
- Evidence after fix:
  - first start: `nextRunAtMs = startNow + 5000` and `pendingCatchupDeferral: true`
  - second start at `startNow + 3000` (fresh state): same deferred slot and marker still present
  - timer at deferred slot: job runs `ok` and marker clears
  - public `list` / `listPage` / `readJob` omit `pendingCatchupDeferral` and pass `Value.Check(CronJobStateSchema, …)`
- Control check: existing test still repairs a stale future cron slot on start when no job was deferred.
- Observed result after fix: the deferred catch-up slot survives the simulated second restart and executes instead of advancing to the next natural daily slot.
- What was not tested: full multi-process OS gateway restart; live operator gateway with production cron volume; agentTurn / every schedules (unaffected by this repair gate).

## AI disclosure

This fix was authored with AI assistance (Grok). Human review of the cron persistence boundary and public schema sanitization is still expected.
