### PR TITLE
fix(cron): keep bounded diagnostics UTF-16 safe

### DIFF
--- a/src/cron/run-diagnostics.test.ts
+++ b/src/cron/run-diagnostics.test.ts
@@ -31,6 +31,29 @@ describe("cron run diagnostics", () => {
     expect(diagnostics?.summary).toHaveLength(2_000);
   });
 
+  it("keeps bounded diagnostic text valid at UTF-16 boundaries", () => {
+    const diagnostics = normalizeCronRunDiagnostics({
+      summary: `${"s".repeat(1_998)}😀tail`,
+      entries: [
+        {
+          ts: 1,
+          source: "exec",
+          severity: "error",
+          message: `${"m".repeat(998)}😀tail`,
+        },
+      ],
+    });
+
+    expect(diagnostics?.summary).toBe(`${"s".repeat(1_998)}…`);
+    expect(diagnostics?.entries[0]).toEqual({
+      ts: 1,
+      source: "exec",
+      severity: "error",
+      message: `${"m".repeat(998)}…`,
+      truncated: true,
+    });
+  });
+
   it("preserves later terminal diagnostics when capping entries", () => {
     const diagnostics = normalizeCronRunDiagnostics({
       entries: [

--- a/src/cron/run-diagnostics.ts
+++ b/src/cron/run-diagnostics.ts
@@ -1,5 +1,6 @@
 /** Builds bounded, redacted diagnostics for cron run logs and UI surfaces. */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { isToolAllowedByPolicyName } from "../agents/tool-policy-match.js";
 import { normalizeToolName as normalizePolicyToolName } from "../agents/tool-policy.js";
 import { getReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
@@ -101,7 +102,7 @@ function normalizeDiagnosticMessage(value: unknown): { message?: string; truncat
   if (redacted.length <= MAX_ENTRY_CHARS) {
     return { message: redacted };
   }
-  return { message: `${redacted.slice(0, MAX_ENTRY_CHARS - 1)}…`, truncated: true };
+  return { message: `${truncateUtf16Safe(redacted, MAX_ENTRY_CHARS - 1)}…`, truncated: true };
 }
 
 function trimSummary(value: string | undefined): string | undefined {
@@ -112,7 +113,7 @@ function trimSummary(value: string | undefined): string | undefined {
   if (normalized.length <= MAX_SUMMARY_CHARS) {
     return normalized;
   }
-  return `${normalized.slice(0, MAX_SUMMARY_CHARS - 1)}…`;
+  return `${truncateUtf16Safe(normalized, MAX_SUMMARY_CHARS - 1)}…`;
 }
 
 /** Returns the operator-facing summary for persisted cron diagnostics. */


### PR DESCRIPTION
## What Problem This Solves

Cron run diagnostics bounded entry messages and summaries with raw UTF-16 code-unit slicing. A limit that landed between the halves of an emoji or another supplementary character could persist and display a lone surrogate.

## Why This Change Was Made

Both bounded diagnostic surfaces now use the shared `truncateUtf16Safe` primitive before appending their existing ellipsis. This preserves the current caps, redaction, truncation metadata, and short-text behavior without adding another code path.

## User Impact

Long cron diagnostic entries and summaries remain valid Unicode in run logs and operator-facing control surfaces. Existing bounds and ASCII behavior are unchanged.

## Evidence

- Focused `src/cron/run-diagnostics.test.ts` suite passed.
- Exact regression assertions cover the 1,000-unit entry cap and 2,000-unit summary cap with an emoji on each split boundary.
- Focused oxfmt and oxlint passed; `git diff --check` passed.
- Fresh branch autoreview found no accepted or actionable findings (0.99 confidence).
