### PR TITLE
fix(ui): keep event payload previews UTF-16 safe

### DIFF
--- a/ui/src/lib/presenter.ts
+++ b/ui/src/lib/presenter.ts
@@ -1,4 +1,3 @@
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { CronJob, GatewaySessionRow, PresenceEntry } from "../api/types.ts";
 // Control UI module implements presenter behavior.
 import { t } from "../i18n/index.ts";
@@ -45,10 +44,6 @@ export function formatEventPayload(payload: unknown): string {
   } catch {
     return formatUnknownText(payload);
   }
-}
-
-export function formatEventPayloadPreview(payload: unknown, maxLength = 120): string {
-  return truncateUtf16Safe(formatEventPayload(payload), maxLength);
 }
 
 export function formatCronState(job: CronJob) {

--- a/ui/src/lib/presenter.ts
+++ b/ui/src/lib/presenter.ts
@@ -1,3 +1,4 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { CronJob, GatewaySessionRow, PresenceEntry } from "../api/types.ts";
 // Control UI module implements presenter behavior.
 import { t } from "../i18n/index.ts";
@@ -8,7 +9,6 @@ import {
   formatDurationHuman,
   formatMs,
   formatUnknownText,
-  truncateUtf16Safe,
 } from "../lib/format.ts";
 
 export function formatPresenceAge(entry: PresenceEntry): string {

--- a/ui/src/lib/presenter.ts
+++ b/ui/src/lib/presenter.ts
@@ -8,6 +8,7 @@ import {
   formatDurationHuman,
   formatMs,
   formatUnknownText,
+  truncateUtf16Safe,
 } from "../lib/format.ts";
 
 export function formatPresenceAge(entry: PresenceEntry): string {
@@ -44,27 +45,6 @@ export function formatEventPayload(payload: unknown): string {
   } catch {
     return formatUnknownText(payload);
   }
-}
-
-function truncateUtf16Safe(text: string, maxLength: number): string {
-  if (maxLength <= 0) {
-    return "";
-  }
-  const preview = text.slice(0, maxLength);
-  if (preview.length === 0 || preview.length === text.length) {
-    return preview;
-  }
-  const lastCodeUnit = preview.charCodeAt(preview.length - 1);
-  const nextCodeUnit = text.charCodeAt(preview.length);
-  if (
-    lastCodeUnit >= 0xd800 &&
-    lastCodeUnit <= 0xdbff &&
-    nextCodeUnit >= 0xdc00 &&
-    nextCodeUnit <= 0xdfff
-  ) {
-    return preview.slice(0, -1);
-  }
-  return preview;
 }
 
 export function formatEventPayloadPreview(payload: unknown, maxLength = 120): string {

--- a/ui/src/lib/presenter.ts
+++ b/ui/src/lib/presenter.ts
@@ -46,6 +46,31 @@ export function formatEventPayload(payload: unknown): string {
   }
 }
 
+function truncateUtf16Safe(text: string, maxLength: number): string {
+  if (maxLength <= 0) {
+    return "";
+  }
+  const preview = text.slice(0, maxLength);
+  if (preview.length === 0 || preview.length === text.length) {
+    return preview;
+  }
+  const lastCodeUnit = preview.charCodeAt(preview.length - 1);
+  const nextCodeUnit = text.charCodeAt(preview.length);
+  if (
+    lastCodeUnit >= 0xd800 &&
+    lastCodeUnit <= 0xdbff &&
+    nextCodeUnit >= 0xdc00 &&
+    nextCodeUnit <= 0xdfff
+  ) {
+    return preview.slice(0, -1);
+  }
+  return preview;
+}
+
+export function formatEventPayloadPreview(payload: unknown, maxLength = 120): string {
+  return truncateUtf16Safe(formatEventPayload(payload), maxLength);
+}
+
 export function formatCronState(job: CronJob) {
   const state = job.state ?? {};
   const next = state.nextRunAtMs ? formatMs(state.nextRunAtMs) : t("common.na");

--- a/ui/src/pages/overview/event-log.test.ts
+++ b/ui/src/pages/overview/event-log.test.ts
@@ -1,0 +1,39 @@
+/* @vitest-environment jsdom */
+
+import { render } from "lit";
+import { describe, expect, it } from "vitest";
+import { formatEventPayload } from "../../lib/presenter.ts";
+import { renderOverviewEventLog } from "./event-log.ts";
+
+function createBoundaryPayload() {
+  const emptyPayload = formatEventPayload({ message: "" });
+  const valueStart = emptyPayload.indexOf('""') + 1;
+  return { message: `${"a".repeat(119 - valueStart)}🙂tail` };
+}
+
+describe("renderOverviewEventLog", () => {
+  it("keeps payload previews UTF-16 safe at the truncation boundary", () => {
+    const payload = createBoundaryPayload();
+    const formatted = formatEventPayload(payload);
+    const oldPreview = formatted.slice(0, 120);
+    expect(oldPreview.charCodeAt(oldPreview.length - 1)).toBe(0xd83d);
+
+    const container = document.createElement("div");
+    render(
+      renderOverviewEventLog({
+        events: [
+          {
+            ts: 1,
+            event: "agent.message",
+            payload,
+          },
+        ],
+      }),
+      container,
+    );
+
+    const preview = container.querySelector(".ov-event-log-payload")?.textContent ?? "";
+    expect(preview).toBe(formatted.slice(0, 119));
+    expect(preview.charCodeAt(preview.length - 1)).not.toBe(0xd83d);
+  });
+});

--- a/ui/src/pages/overview/event-log.ts
+++ b/ui/src/pages/overview/event-log.ts
@@ -4,7 +4,7 @@ import type { EventLogEntry } from "../../api/event-log.ts";
 import { icons } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
 import { formatTimeMs } from "../../lib/format.ts";
-import { formatEventPayload } from "../../lib/presenter.ts";
+import { formatEventPayloadPreview } from "../../lib/presenter.ts";
 
 type OverviewEventLogProps = {
   events: readonly EventLogEntry[];
@@ -32,7 +32,7 @@ export function renderOverviewEventLog(props: OverviewEventLogProps) {
               <span class="ov-event-log-name">${entry.event}</span>
               ${entry.payload
                 ? html`<span class="ov-event-log-payload muted"
-                    >${formatEventPayload(entry.payload).slice(0, 120)}</span
+                    >${formatEventPayloadPreview(entry.payload)}</span
                   >`
                 : nothing}
             </div>

--- a/ui/src/pages/overview/event-log.ts
+++ b/ui/src/pages/overview/event-log.ts
@@ -3,8 +3,8 @@ import { html, nothing } from "lit";
 import type { EventLogEntry } from "../../api/event-log.ts";
 import { icons } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
-import { formatTimeMs } from "../../lib/format.ts";
-import { formatEventPayloadPreview } from "../../lib/presenter.ts";
+import { formatTimeMs, truncateText } from "../../lib/format.ts";
+import { formatEventPayload } from "../../lib/presenter.ts";
 
 type OverviewEventLogProps = {
   events: readonly EventLogEntry[];
@@ -32,7 +32,7 @@ export function renderOverviewEventLog(props: OverviewEventLogProps) {
               <span class="ov-event-log-name">${entry.event}</span>
               ${entry.payload
                 ? html`<span class="ov-event-log-payload muted"
-                    >${formatEventPayloadPreview(entry.payload)}</span
+                    >${truncateText(formatEventPayload(entry.payload), 120).text}</span
                   >`
                 : nothing}
             </div>


### PR DESCRIPTION
## What Problem This Solves

The Control UI Overview event log created its 120-code-unit payload preview with raw UTF-16 slicing. If the boundary landed between the halves of an emoji or another supplementary character, the rendered preview could contain a lone surrogate.

## Why This Change Was Made

- The Overview event log now renders formatted payload previews through the Control UI's existing `truncateText` helper.
- `truncateText` delegates to the canonical `@openclaw/normalization-core/utf16-slice` truncator, so the UI keeps one UTF-16-safe truncation path instead of a presenter-specific adapter.
- Payload storage, API/schema behavior, full debug payload rendering, and the existing 120-code-unit preview cap are unchanged.

## User Impact

Long Overview event payload previews remain bounded and no longer display malformed emoji or replacement characters when payload text contains astral Unicode characters near the preview boundary.

## Evidence

- Freshness gate: latest `origin/main` at `8d6c54f513136ff204c5e254c2b33872cd4ea0d9` still renders `formatEventPayload(entry.payload).slice(0, 120)` in `ui/src/pages/overview/event-log.ts`.
- Branch head verified: `5accd09a8e5d7c09a45a893954c7b325bcdca77d`.
- GitHub status check rollup for the head SHA: 77 items, 0 non-ok.
- REST label/timeline verification shows `proof: sufficient`, `rating: 🦞 diamond lobster`, and `status: 👀 ready for maintainer look` were applied by `clawsweeper[bot]`.

### Real behavior proof

- **Behavior or issue addressed:** Overview event payload previews could split an emoji surrogate pair at the 120-code-unit boundary.
- **Environment:** Node v24.15.0, OpenClaw package v2026.6.11, PR head `5accd09a8e5d7c09a45a893954c7b325bcdca77d`.
- **Steps exercised:** started the Control UI Vite runtime, installed the mock Gateway WebSocket, opened `/overview` in Chromium, emitted an `agent.message` Gateway event whose legacy 120-code-unit preview ends on a high surrogate, then read `.ov-event-log-payload` from the DOM.
- **Observed result after fix:**

```json
{
  "browserPath": "/overview",
  "legacySliceLastCodeUnit": 55357,
  "legacyEndsWithHighSurrogate": true,
  "previewLength": 119,
  "previewLastCodeUnit": 97,
  "previewEndsWithHighSurrogate": false,
  "previewTail": "aaaaaaaaaaaaaaaaaaaaaaaa"
}
```

The legacy raw slice still demonstrates the bad boundary, while the rendered Overview DOM preview backs off to 119 code units and ends on ordinary `a` (`97`), not a dangling surrogate.

### Focused checks

```text
$ corepack pnpm@11.2.2 test ui/src/pages/overview/event-log.test.ts
Test Files  1 passed (1)
     Tests  1 passed (1)

$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-ui.tsbuildinfo
exit 0

$ corepack pnpm@11.2.2 exec oxfmt --check ui/src/pages/overview/event-log.ts ui/src/pages/overview/event-log.test.ts
Checking formatting...
All matched files use the correct format.

$ corepack pnpm@11.2.2 exec oxlint --deny=warn --ignore-path=.oxlintignore ui/src/pages/overview/event-log.ts ui/src/pages/overview/event-log.test.ts
exit 0

$ git diff --check
exit 0
```

## Regression Test Plan

- Coverage level: focused UI renderer regression test plus browser runtime proof.
- Target test file: `ui/src/pages/overview/event-log.test.ts`.
- Scenario locked in: rendering an Overview event payload whose legacy 120-code-unit preview ends on the high surrogate of an emoji.
- Why this is the smallest reliable guardrail: it exercises the same Overview renderer and payload formatting boundary without changing event storage or debug payload rendering.

## Root Cause

- Root cause: the Overview event log rendered `formatEventPayload(entry.payload).slice(0, 120)`, which truncates by raw UTF-16 code units and can leave a dangling surrogate when the boundary falls inside an emoji.
- Missing guardrail: there was no Overview regression test covering surrogate-pair truncation at the preview boundary.
