### PR TITLE
fix(imessage): keep CLI stderr tails UTF-16 safe

### DIFF
--- a/extensions/imessage/src/cli-output.test.ts
+++ b/extensions/imessage/src/cli-output.test.ts
@@ -17,4 +17,10 @@ describe("iMessage CLI output bounds", () => {
 
     expect(result).toBe("recent-error");
   });
+
+  it("does not split a surrogate pair at the tail boundary", () => {
+    const input = `🚀${"x".repeat(100)}`;
+    const result = appendIMessageCliStderrTail(input, "", 80);
+    expect(result).not.toContain("�");
+  });
 });

--- a/extensions/imessage/src/cli-output.test.ts
+++ b/extensions/imessage/src/cli-output.test.ts
@@ -19,8 +19,9 @@ describe("iMessage CLI output bounds", () => {
   });
 
   it("does not split a surrogate pair at the tail boundary", () => {
-    const input = `🚀${"x".repeat(100)}`;
-    const result = appendIMessageCliStderrTail(input, "", 80);
-    expect(result).not.toContain("�");
+    const input = `x🚀${"y".repeat(10)}`;
+
+    expect(input.slice(-11)).toBe(`\ude80${"y".repeat(10)}`);
+    expect(appendIMessageCliStderrTail("", input, 11)).toBe("y".repeat(10));
   });
 });

--- a/extensions/imessage/src/cli-output.ts
+++ b/extensions/imessage/src/cli-output.ts
@@ -1,6 +1,6 @@
 // Imessage plugin module implements cli output behavior.
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
-import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 const IMESSAGE_CLI_STDOUT_MAX_CHARS = 8 * 1024 * 1024;
 const IMESSAGE_CLI_STDERR_TAIL_CHARS = 64 * 1024;

--- a/extensions/imessage/src/cli-output.ts
+++ b/extensions/imessage/src/cli-output.ts
@@ -1,5 +1,6 @@
 // Imessage plugin module implements cli output behavior.
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 
 const IMESSAGE_CLI_STDOUT_MAX_CHARS = 8 * 1024 * 1024;
 const IMESSAGE_CLI_STDERR_TAIL_CHARS = 64 * 1024;
@@ -50,5 +51,5 @@ export function appendIMessageCliStderrTail(
   maxChars = IMESSAGE_CLI_STDERR_TAIL_CHARS,
 ): string {
   const next = current + chunkToString(chunk);
-  return next.length > maxChars ? next.slice(-maxChars) : next;
+  return next.length > maxChars ? sliceUtf16Safe(next, -maxChars) : next;
 }


### PR DESCRIPTION
## What Problem This Solves

The iMessage CLI stderr accumulator retained its bounded tail with a raw negative UTF-16 slice. If the retained suffix began between the halves of an emoji or another supplementary character, error output could start with a lone low surrogate.

## Why This Change Was Made

The shared `appendIMessageCliStderrTail` owner now uses `sliceUtf16Safe` for its suffix. That one change covers both iMessage CLI execution paths while preserving the existing cap and recent-error semantics.

## User Impact

Bounded iMessage CLI error details remain valid Unicode. Stderr within the limit and ASCII-only tails are unchanged.

## Evidence

- Focused iMessage CLI output suite passed.
- The improved regression demonstrates the old raw suffix starts with a lone low surrogate and asserts the exact safe suffix.
- Focused oxfmt and oxlint passed; `git diff --check` passed.
- Fresh branch autoreview found no accepted or actionable findings (0.96 confidence).
