### PR TITLE
fix(infra): keep gateway restart-handoff reason truncation UTF-16 safe

### DIFF
--- a/scripts/proof-restart-handoff-utf16-boundary.mts
+++ b/scripts/proof-restart-handoff-utf16-boundary.mts
@@ -1,0 +1,35 @@
+// Proof: raw slice(0, N) splits a surrogate pair in restart-handoff reasons,
+// while the surrogate-safe helper used by normalizeText does not.
+
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+
+const MAX_REASON_LENGTH = 200;
+const prefix = "a".repeat(199);
+const reason = `${prefix}😀suffix`;
+
+const legacy = reason.slice(0, MAX_REASON_LENGTH);
+const fixed = reason.length > MAX_REASON_LENGTH
+  ? truncateUtf16Safe(reason, MAX_REASON_LENGTH)
+  : reason;
+
+function hasLoneSurrogate(value: string): boolean {
+  return /[\uD800-\uDFFF]/.test(value.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/gu, ""));
+}
+
+console.log(`input length   : ${reason.length}`);
+console.log(`legacy length  : ${legacy.length}`);
+console.log(`fixed length   : ${fixed.length}`);
+console.log(`legacy lone surrogate: ${hasLoneSurrogate(legacy)}`);
+console.log(`fixed lone surrogate : ${hasLoneSurrogate(fixed)}`);
+
+if (!hasLoneSurrogate(legacy)) {
+  console.error("FAIL: expected legacy slice to emit a lone surrogate");
+  process.exit(1);
+}
+
+if (hasLoneSurrogate(fixed) || fixed.length > MAX_REASON_LENGTH) {
+  console.error("FAIL: expected fixed truncation to stay bounded and surrogate-safe");
+  process.exit(1);
+}
+
+console.log("PASS: legacy splits surrogate pair; fixed truncation is safe.");

--- a/src/infra/restart-handoff.test.ts
+++ b/src/infra/restart-handoff.test.ts
@@ -24,6 +24,10 @@ import type { GatewayRestartHandoff } from "./restart-handoff.js";
 const tempDirs: string[] = [];
 type GatewayRestartHandoffDatabase = Pick<OpenClawStateKyselyDatabase, "gateway_restart_handoff">;
 
+function hasLoneSurrogate(value: string): boolean {
+  return /[\uD800-\uDFFF]/.test(value.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/gu, ""));
+}
+
 function createHandoffEnv(): NodeJS.ProcessEnv {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-restart-handoff-"));
   tempDirs.push(dir);
@@ -240,6 +244,33 @@ describe("gateway restart handoff", () => {
     insertHandoffRow(env, { intentId: "too-long", createdAt: 1_000, expiresAt: 61_001 });
 
     expect(readGatewayRestartHandoffSync(env, 1_001)).toBeNull();
+  });
+
+  it("does not split UTF-16 surrogate pairs when truncating long reasons", () => {
+    const env = createHandoffEnv();
+    const prefix = "a".repeat(199);
+    const reason = `${prefix}😀suffix`;
+
+    const handoff = expectWrittenHandoff({
+      env,
+      pid: 12_345,
+      reason,
+      restartKind: "full-process",
+      supervisorMode: "external",
+      createdAt: 1_000,
+    });
+
+    expect(handoff.reason).toBeDefined();
+    expect(handoff.reason!.length).toBeLessThanOrEqual(200);
+    expect(hasLoneSurrogate(handoff.reason!)).toBe(false);
+
+    const row = readHandoffRow(env);
+    expect(row?.reason).toBe(handoff.reason);
+    expect(hasLoneSurrogate(row?.reason ?? "")).toBe(false);
+
+    const persisted = readGatewayRestartHandoffSync(env, 1_500);
+    expect(persisted?.reason).toBe(handoff.reason);
+    expect(hasLoneSurrogate(persisted?.reason ?? "")).toBe(false);
   });
 
   it("overwrites the previous pending handoff row", () => {

--- a/src/infra/restart-handoff.ts
+++ b/src/infra/restart-handoff.ts
@@ -1,5 +1,6 @@
 // Persists short-lived gateway restart handoff metadata.
 import { randomUUID } from "node:crypto";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
@@ -108,7 +109,10 @@ function normalizePid(pid: number | undefined): number | null {
 
 function normalizeText(value: unknown, maxLength: number): string | undefined {
   const text = typeof value === "string" ? value.trim() : "";
-  return text ? text.slice(0, maxLength) : undefined;
+  if (!text) {
+    return undefined;
+  }
+  return text.length > maxLength ? truncateUtf16Safe(text, maxLength) : text;
 }
 
 function normalizeCreatedAt(value: number | undefined): number {


### PR DESCRIPTION
## What Problem This Solves

Gateway restart-handoff reasons are capped at MAX_REASON_LENGTH (200) UTF-16 code units. The existing normalizeText helper uses a raw text.slice(0, maxLength), which can stop between an emoji's surrogate halves and leave malformed text in the persisted handoff row and any status surface that reads it back.

## Why This Change Was Made

Route that boundary through the repository's canonical truncateUtf16Safe helper. The behavior remains unchanged for ordinary text and only backs up by one code unit when the cap would split a surrogate pair.

## User Impact

Long restart reasons that end near a multi-code-unit emoji no longer inject a dangling surrogate into the gateway restart handoff store or diagnostic output.

## Scope

Three files (src/infra/restart-handoff.ts, src/infra/restart-handoff.test.ts, scripts/proof-restart-handoff-utf16-boundary.mts); no config, protocol, dependency, or compatibility change. AI-assisted.

## Real behavior proof

**Behavior addressed**: normalizeText in src/infra/restart-handoff.ts caps the reason field at 200 UTF-16 code units; raw .slice(0, 200) could split an emoji surrogate pair.

**Real environment tested**: Local Linux checkout at head 71300a2e9d, Node v22.22.0, repository tsx.

**Exact steps or command run after this patch**:

```bash
node --import tsx scripts/proof-restart-handoff-utf16-boundary.mts
```

**Evidence after fix**:

```text
input length   : 207
legacy length  : 200
fixed length   : 199
legacy lone surrogate: true
fixed lone surrogate : false
PASS: legacy splits surrogate pair; fixed truncation is safe.
```

The regression test in src/infra/restart-handoff.test.ts writes a handoff whose reason is 199 a characters + 😀 + suffix, then asserts the stored row and the read-back handoff contain no lone surrogates and stay within the 200-code-unit bound:

```bash
node --import tsx node_modules/vitest/vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/restart-handoff.test.ts
```

```text
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

**Observed result after fix**: The fixed truncation backs off before the emoji, producing 199 code units with no lone surrogate. The persisted SQLite row and the synchronous read-back both match the in-memory value and pass the surrogate check.

## Maintainer verification

- Exact head: 71300a2e9d
- Local focused test: pass
- Local lint: pass