### PR TITLE
fix(auto-reply): keep fallback reason truncation UTF-16 safe

### DIFF
--- a/src/auto-reply/fallback-state.test.ts
+++ b/src/auto-reply/fallback-state.test.ts
@@ -113,6 +113,15 @@ describe("fallback-state", () => {
     expect(resolved.reasonSummary).toContain("Claude Max usage limit reached");
   });
 
+  it("keeps truncated transient error details UTF-16 safe", () => {
+    const detail = "x".repeat(68);
+    const resolved = resolveDemoFallbackTransition({
+      attempts: [{ ...baseAttempt, error: `429 ${detail}😀tail` }],
+    });
+
+    expect(resolved.reasonSummary).toBe(`HTTP 429: ${detail}…`);
+  });
+
   it("refreshes reason when fallback remains active with same model pair", () => {
     const resolved = resolveDemoFallbackTransition({
       attempts: [{ ...baseAttempt, reason: "timeout" }],

--- a/src/auto-reply/fallback-state.ts
+++ b/src/auto-reply/fallback-state.ts
@@ -1,5 +1,6 @@
-/** Formats model-fallback notice state for UI/status messages and persisted transition tracking. */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+/** Formats model-fallback notice state for UI/status messages and persisted transition tracking. */
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatRawAssistantErrorForUi } from "../agents/embedded-agent-helpers.js";
 import { areRuntimeModelRefsEquivalent } from "../agents/model-runtime-aliases.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -29,7 +30,7 @@ function truncateFallbackReasonPart(value: string, max = FALLBACK_REASON_PART_MA
   if (text.length <= max) {
     return text;
   }
-  return `${text.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
+  return `${truncateUtf16Safe(text, max - 1).trimEnd()}…`;
 }
 
 function formatFallbackAttemptErrorPreview(attempt: RuntimeFallbackAttempt): string | undefined {

--- a/src/auto-reply/fallback-state.ts
+++ b/src/auto-reply/fallback-state.ts
@@ -1,5 +1,5 @@
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 /** Formats model-fallback notice state for UI/status messages and persisted transition tracking. */
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatRawAssistantErrorForUi } from "../agents/embedded-agent-helpers.js";
 import { areRuntimeModelRefsEquivalent } from "../agents/model-runtime-aliases.js";


### PR DESCRIPTION
## What Problem This Solves

Model fallback reasons are capped at 80 UTF-16 code units before being shown in fallback notices and retained in transition state. The previous raw prefix slice could end between the halves of an emoji or another supplementary character.

## Why This Change Was Made

The shared fallback reason formatter now uses `truncateUtf16Safe` while preserving the existing ellipsis budget, whitespace normalization, transient-detail policy, and cap. The regression exercises the real formatted HTTP 429 detail path through fallback transition resolution.

## User Impact

Long fallback explanations remain valid Unicode in notices and persisted reason state. Short reasons, the 80-unit budget, and provider-error exposure policy are unchanged.

## Evidence

- Focused fallback-state suite passed.
- Exact regression places an emoji on the formatted transient-error boundary and asserts the complete safe summary.
- Focused oxfmt and oxlint passed; `git diff --check` passed.
- Fresh exact-head autoreview found no accepted or actionable findings (0.99 confidence).
