### PR TITLE
fix(context): show transcript conversation in /context map

### DIFF
--- a/docs/concepts/context.md
+++ b/docs/concepts/context.md
@@ -77,12 +77,15 @@ Top tools (schema size):
 
 ### `/context map`
 
-Sends an image generated from the latest cached run report. Before a normal message has produced a run report in the session, `/context map` returns an unavailable message instead of rendering an estimate. Rectangle area is proportional to tracked prompt characters:
+Sends an image generated from the latest cached run report plus the session transcript. Before a normal message has produced a run report in the session, `/context map` returns an unavailable message instead of rendering an estimate. Rectangle area is proportional to tracked prompt characters:
 
+- conversation transcript (user messages, assistant replies, tool results, compaction summaries), plus per-turn runtime context and hook prompt additions that reach only the model
 - injected workspace files
 - base system prompt text
 - skill prompt entries
 - tool JSON schemas
+
+The conversation group grows as the session does, so the map changes turn over turn; after compaction it collapses into a summaries tile.
 
 `/context list`, `/context detail`, and `/context json` can still inspect an on-demand estimate when no run report is cached.
 

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -4507,6 +4507,10 @@ export async function runEmbeddedAttempt(
               runtimeContextChars: promptSubmission.runtimeOnly
                 ? (runtimeSystemContext?.length ?? 0)
                 : (runtimeContextForHook?.length ?? 0),
+              // promptForSession is what persists to the transcript; hook
+              // prepend/append context reaches only the model, so record the
+              // delta or transcript-based context accounting undercounts it.
+              modelOnlyPromptChars: Math.max(0, promptForModel.length - promptForSession.length),
             };
           }
           const systemPromptForHook = systemPromptText;

--- a/src/auto-reply/reply/commands-context-report.test.ts
+++ b/src/auto-reply/reply/commands-context-report.test.ts
@@ -328,7 +328,45 @@ describe("buildContextReply", () => {
     }
   });
 
-  it("counts room events as event context in context maps", async () => {
+  it("includes transcript conversation size in context maps", async () => {
+    await withTranscript(
+      [
+        { role: "user", content: "abcd", timestamp: 1 },
+        { role: "assistant", content: [{ type: "text", text: "efghij" }], timestamp: 2 },
+        {
+          role: "toolResult",
+          content: [{ type: "text", text: "klmno" }],
+          timestamp: 3,
+          toolCallId: "call-1",
+          toolName: "read",
+        },
+      ],
+      async (sessionFile) => {
+        const result = await buildContextReply(
+          makeParams("/context map", false, {
+            contextTokens: 8_192,
+            totalTokens: 900,
+            sessionId: "session",
+            sessionFile,
+          }),
+        );
+        if (!result.mediaUrl) {
+          throw new Error("missing context map media path");
+        }
+        try {
+          const png = await readFile(result.mediaUrl);
+          expect(result.text).toContain("Conversation: 20 chars (~5 tok)");
+          expect(result.trustedLocalMedia).toBe(true);
+          expect(result.sensitiveMedia).toBe(true);
+          expect(png.subarray(0, 8)).toEqual(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]));
+        } finally {
+          await unlink(result.mediaUrl);
+        }
+      },
+    );
+  });
+
+  it("counts model-only turn context but not the persisted current-turn prompt", async () => {
     const result = await buildContextReply(
       makeParams("/context map", false, {
         contextTokens: 8_192,
@@ -337,6 +375,7 @@ describe("buildContextReply", () => {
           kind: "room_event",
           promptChars: 11,
           runtimeContextChars: 17,
+          modelOnlyPromptChars: 5,
         },
       }),
     );
@@ -344,7 +383,8 @@ describe("buildContextReply", () => {
       throw new Error("missing context map media path");
     }
     try {
-      expect(result.text).toContain("Tracked: 10,548 chars");
+      expect(result.text).toContain("Tracked: 10,542 chars");
+      expect(result.text).toContain("Conversation: 22 chars (~6 tok)");
     } finally {
       await unlink(result.mediaUrl);
     }

--- a/src/auto-reply/reply/commands-context-report.ts
+++ b/src/auto-reply/reply/commands-context-report.ts
@@ -7,6 +7,10 @@ import {
   resolveBootstrapMaxChars,
   resolveBootstrapTotalMaxChars,
 } from "../../agents/embedded-agent-helpers/bootstrap.js";
+import {
+  createMessageCharEstimateCache,
+  estimateMessageCharsCached,
+} from "../../agents/embedded-agent-runner/tool-result-char-estimator.js";
 import type { AgentMessage } from "../../agents/runtime/index.js";
 import { buildSystemPromptReport } from "../../agents/system-prompt-report.js";
 import {
@@ -182,12 +186,55 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
         ].join("\n"),
       };
     }
+    const sessionId = targetSessionEntry?.sessionId?.trim();
+    const messages = sessionId
+      ? (readSessionMessages(
+          sessionId,
+          params.storePath,
+          targetSessionEntry?.sessionFile,
+        ) as AgentMessage[])
+      : [];
+    const estimateCache = createMessageCharEstimateCache();
+    const conversationTotals = messages.reduce(
+      (totals, message) => {
+        const chars = estimateMessageCharsCached(message, estimateCache);
+        if (chars === 0) {
+          return totals;
+        }
+        if (message.role === "user") {
+          totals.user += chars;
+        } else if (message.role === "assistant") {
+          totals.assistant += chars;
+        } else if (message.role === "toolResult") {
+          totals.toolResults += chars;
+        } else if (message.role === "branchSummary" || message.role === "compactionSummary") {
+          totals.summaries += chars;
+        } else {
+          totals.other += chars;
+        }
+        return totals;
+      },
+      { user: 0, assistant: 0, toolResults: 0, summaries: 0, other: 0 },
+    );
+    const conversation = [
+      { name: "User", value: conversationTotals.user },
+      { name: "Assistant", value: conversationTotals.assistant },
+      { name: "Tool results", value: conversationTotals.toolResults },
+      { name: "Summaries", value: conversationTotals.summaries },
+      { name: "Other", value: conversationTotals.other },
+      // Runtime context and hook prompt additions reach only the model, never
+      // the transcript; without these leaves the map undercounts model-visible
+      // context. The persisted turn prompt is already counted above.
+      { name: "Runtime context", value: report.currentTurn?.runtimeContextChars ?? 0 },
+      { name: "Model-only prompt", value: report.currentTurn?.modelOnlyPromptChars ?? 0 },
+    ].filter((leaf) => leaf.value > 0);
     const treemap = await renderContextTreemapPng({
       report,
       session: {
         cachedContextTokens: cachedContextUsageTokens ?? null,
         contextWindowTokens: session.contextTokens,
       },
+      conversation,
     });
     return {
       text: treemap.caption,

--- a/src/auto-reply/reply/context-treemap.ts
+++ b/src/auto-reply/reply/context-treemap.ts
@@ -334,7 +334,11 @@ function treemapGroup(params: { name: string; color: Rgba; leaves: TreemapLeaf[]
   return { ...params, value: totalValue(params.leaves) };
 }
 
-function buildGroups(report: SessionSystemPromptReport): TreemapGroup[] {
+function buildGroups(params: {
+  report: SessionSystemPromptReport;
+  conversation: TreemapLeaf[];
+}): TreemapGroup[] {
+  const { report } = params;
   const injectedTotal = report.injectedWorkspaceFiles.reduce(
     (sum, file) => sum + file.injectedChars,
     0,
@@ -345,17 +349,11 @@ function buildGroups(report: SessionSystemPromptReport): TreemapGroup[] {
   const tools = report.tools.entries
     .map((tool) => ({ name: tool.name, value: tool.schemaChars ?? 0 }))
     .filter((tool) => tool.value > 0);
-  const currentTurnLeaves = report.currentTurn
-    ? [
-        { name: "Model prompt", value: report.currentTurn.promptChars },
-        { name: "Runtime context", value: report.currentTurn.runtimeContextChars },
-      ].filter((leaf) => leaf.value > 0)
-    : [];
   const groups = [
     treemapGroup({
-      name: report.currentTurn?.kind === "room_event" ? "Room event" : "Current turn",
-      color: rgba(72, 135, 197),
-      leaves: currentTurnLeaves,
+      name: "Conversation",
+      color: rgba(201, 82, 96),
+      leaves: params.conversation,
     }),
     treemapGroup({
       name: "Workspace files",
@@ -455,8 +453,10 @@ function drawLegend(canvas: PngCanvas, groups: TreemapGroup[], rect: Rect, total
 export async function renderContextTreemapPng(params: {
   report: SessionSystemPromptReport;
   session: ContextTreemapSessionStats;
+  conversation: TreemapLeaf[];
 }): Promise<{ path: string; trackedChars: number; caption: string }> {
-  const groups = buildGroups(params.report);
+  const groups = buildGroups({ report: params.report, conversation: params.conversation });
+  const conversationChars = totalValue(params.conversation);
   const trackedChars = totalValue(groups);
   const canvas = new PngCanvas();
   canvas.fill(rgba(238, 241, 245));
@@ -507,6 +507,7 @@ export async function renderContextTreemapPng(params: {
     "Context treemap",
     `Source: ${params.report.source}`,
     `Tracked: ${formatInt(trackedChars)} chars (~${formatInt(estimateTokensFromChars(trackedChars))} tok)`,
+    `Conversation: ${formatInt(conversationChars)} chars (~${formatInt(estimateTokensFromChars(conversationChars))} tok)`,
     params.session.cachedContextTokens == null
       ? "Actual cached context: unavailable"
       : `Actual cached context: ${formatInt(params.session.cachedContextTokens)} tok`,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -744,6 +744,9 @@ export type SessionSystemPromptReport = {
     kind?: "user_request" | "room_event";
     promptChars: number;
     runtimeContextChars: number;
+    // Hook prepend/append context sent to the model but absent from the
+    // persisted transcript prompt; consumers add it on top of transcript sums.
+    modelOnlyPromptChars?: number;
   };
   injectedWorkspaceFiles: Array<{
     name: string;


### PR DESCRIPTION
## What Problem This Solves

`/context map` rendered only static prompt composition from the cached run report: system prompt, workspace files, tool schemas, and skills. The conversation transcript, which is the part of context that grows between turns, had no treemap group, so the image and caption never changed between turns and did not represent actual context usage.

Release note: `/context map` now includes transcript conversation usage in the treemap and caption.

## Why This Change Was Made

Users expect the map to reflect current context usage as of the latest turn, consistent with the exact token totals that `/status` reports.

## User Impact

`/context map` on any channel now includes a Conversation group with User, Assistant, Tool results, Summaries, Runtime context, and Model-only prompt leaves. Transcript messages are sized with the embedded runner's own context estimator in `src/agents/embedded-agent-runner/tool-result-char-estimator.ts`; the Runtime context leaf comes from `systemPromptReport.currentTurn.runtimeContextChars` because runtime context is injected transiently per turn (`installRuntimeContextMessageForPrompt` removes it after the prompt) and never reaches the transcript. The Model-only prompt leaf covers hook prepend/append context that makes `promptForModel` diverge from the persisted `promptForSession`: the embedded runner now records the delta as the additive optional field `currentTurn.modelOnlyPromptChars` (`src/agents/embedded-agent-runner/run/attempt.ts`).

The caption now includes `Conversation: N chars (~M tok)`. The Current turn prompt tile is removed from `src/auto-reply/reply/context-treemap.ts`: the turn's prompt is persisted to the transcript on both normal and runtime-only turns, so the Conversation group already counts it and keeping the tile would double-count. `report.currentTurn` stays in the type and in `/context detail`. After compaction, conversation usage collapses into the Summaries leaf.

Aside from the additive optional `modelOnlyPromptChars` report field, this is display-only. It adds no new config or data collection, and reuses `readSessionMessages` plus `estimateMessageCharsCached` in `src/auto-reply/reply/commands-context-report.ts`.

## Evidence

Unit/typecheck:

- `node scripts/run-vitest.mjs run src/auto-reply/reply/commands-context-report.test.ts`: 14/14 passed.
- `pnpm tsgo:core`: exit 0. `pnpm tsgo:core:test`: exit 0.
- New test `includes transcript conversation size in context maps` proves the Conversation caption and PNG media output. `counts model-only turn context but not the persisted current-turn prompt` pins the non-duplicating current-turn contract, including the model-only prompt delta.

Real behavior proof (real setup): started the gateway from this branch against a state dir seeded with a real agent session (created by a real embedded model run, `source: "run"` report + transcript), then sent the command through the real webchat pipeline:

```
$ openclaw gateway call chat.send --params '{"sessionKey":"agent:main:main","message":"/context map", ...}'
{ "runId": "proof-ctx-map-1", "status": "started" }

$ openclaw gateway call chat.history --params '{"sessionKey":"agent:main:main","limit":4}'
--- user : /context map
--- assistant : Context treemap
Source: run
Tracked: 47,650 chars (~11,913 tok)
Conversation: 17,976 chars (~4,494 tok)
Actual cached context: 22,367 tok
```

The rendered 1280x860 PNG shows the Conversation group as the largest tile (38%, Tool results + Assistant leaves) alongside Workspace files, Skills, System prompt, and Tool schemas, with the exact-token footer (`47 650 CH / 11 913 TOK / ACTUAL CTX 22 367 TOK / WINDOW 272 000 TOK`).
