### PR TITLE
fix(ui): square chat rail toggles and center split-view opener in collapsed rail

### DIFF
--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -125,7 +125,9 @@
   align-items: center;
   justify-content: center;
   border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
-  border-radius: var(--radius-sm);
+  /* Match the sibling refresh/collapse buttons (.btn radius) so the rail
+     header buttons share one corner treatment. */
+  border-radius: var(--radius-md);
   background: transparent;
   color: var(--muted);
   cursor: pointer;

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -180,6 +180,9 @@ openclaw-chat-pane {
 .chat-pane__actions .btn--icon,
 .chat-open-split-view.btn--icon {
   width: 28px;
+  /* .btn--icon's min-width: 36px otherwise wins over width and stretches
+     these into 36x28 pills. */
+  min-width: 28px;
   height: 28px;
   min-height: 28px;
   padding: 5px;
@@ -195,6 +198,18 @@ openclaw-chat-pane {
   box-shadow: var(--shadow-sm);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
+}
+
+/* The drop container spans the workspace rail column, so the default 16px
+   inset parks the 28px opener flush against the collapsed 44px rail's left
+   border. Center it in the rail instead ((44 - 28) / 2). Media guard matches
+   the rail's render breakpoint: the collapsed class stays on the workbench
+   while the rail is display:none below 1121px. */
+@media (min-width: 1121px) {
+  .chat-split-view__drop-container:has(.chat-workbench--workspace-collapsed)
+    .chat-open-split-view {
+    right: 8px;
+  }
 }
 
 @media (max-width: 1100px) {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1193,7 +1193,7 @@
   justify-content: center;
   background: color-mix(in srgb, var(--bg-elevated) 88%, transparent);
   border: 1px solid color-mix(in srgb, var(--border-strong) 68%, transparent);
-  border-radius: var(--radius-full);
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition:
     background var(--duration-fast) ease,


### PR DESCRIPTION
## What Problem This Solves

Fixes visual inconsistencies in the Control UI chat page around the collapsed workspace rail (the tiny right sidebar):

- The rail's collapse toggle (and the topbar nav toggle) rendered as full circles while every neighboring icon button in the UI uses the standard rounded-rect corner radius.
- The floating split-view opener at the bottom right rendered as a squat 36x28 pill and overhung the collapsed rail's left border by 8px instead of sitting centered inside the rail column.

## Why This Change Was Made

`.nav-collapse-toggle` used `--radius-full`; it now uses the standard `.btn` radius (`--radius-md`), and the workspace-rail terminal button moves from `--radius-sm` to `--radius-md` so all rail header buttons share one corner treatment. The split-view opener's `width: 28px` was dead CSS (defeated by `.btn--icon`'s `min-width: 36px`), so `min-width: 28px` restores the intended 28x28 square; a breakpoint-guarded rule centers it in the 44px collapsed rail (`right: 8px`), keeping the plain 16px inset when the rail is expanded or not rendered.

## User Impact

Chat page buttons around the workspace rail look consistent: rounded squares instead of mixed circles/pills, and the bottom split-view opener sits centered inside the collapsed rail instead of hanging over its border. No behavior change.

## Evidence

Geometry (Playwright, mock-gateway harness, 1440x900): rail spans x 1396-1440 (44px). Before: opener at x 1388-1424 (36px wide, overhangs rail border at 1396), toggle radius `9999px`. After: opener at x 1404-1432 (28px, 8px insets both sides), toggle radius `10px`. Split-toolbar pane action buttons keep square 28x28.

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/chat-rail-alignment/rail-before.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/chat-rail-alignment/rail-after.png) |

Split-view toolbar after the `min-width` fix: ![toolbar](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/chat-rail-alignment/split-toolbar-after.png)

Validation: CSS-only diff; autoreview (Codex) clean - "patch is correct (0.98)"; `git diff --check` clean.
