### PR TITLE
fix(agents): keep block-reply log preview truncation UTF-16 safe

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.test.ts
@@ -22,6 +22,25 @@ import {
   createOpenAiResponsesTextEvent as createTextUpdateEvent,
 } from "./embedded-agent-subscribe.openai-responses.test-helpers.js";
 
+function hasLoneSurrogate(s: string): boolean {
+  for (let i = 0; i < s.length; i += 1) {
+    const c = s.charCodeAt(i);
+    if (c >= 0xd800 && c <= 0xdbff) {
+      const next = s.charCodeAt(i + 1);
+      if (i + 1 >= s.length || next < 0xdc00 || next > 0xdfff) {
+        return true;
+      }
+    }
+    if (c >= 0xdc00 && c <= 0xdfff) {
+      const prev = s.charCodeAt(i - 1);
+      if (i === 0 || prev < 0xd800 || prev > 0xdbff) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 function createMessageUpdateContext(
   params: {
     onAgentEvent?: ReturnType<typeof vi.fn>;
@@ -1466,6 +1485,38 @@ describe("handleMessageEnd", () => {
     );
     expect(ctx.emitAssistantStreamData).not.toHaveBeenCalled();
     expect(ctx.finalizeAssistantTexts).toHaveBeenCalledWith(expect.objectContaining({ text: "" }));
+  });
+
+  it("does not split UTF-16 surrogate pairs when logging skipped block reply text", () => {
+    const emitBlockReply = vi.fn();
+    // 49 ASCII chars + a 2-code-unit emoji + 10 ASCII chars puts the high
+    // surrogate of the emoji exactly at the legacy 50-code-unit cut point.
+    const longEmojiText = "a".repeat(49) + "😀" + "x".repeat(10);
+    const ctx = createMessageEndContext({
+      emitBlockReply,
+      consumeReplyDirectives: vi.fn((text: string) => (text ? { text } : null)),
+      state: {
+        blockReplyBreak: "message_end",
+        messagingToolSentTextsNormalized: ["a".repeat(49) + "x".repeat(10)],
+      },
+    });
+
+    void handleMessageEnd(ctx, {
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: longEmojiText }],
+      },
+    } as never);
+
+    expect(emitBlockReply).not.toHaveBeenCalled();
+    const debugCall = (ctx.log.debug as { mock?: { calls: unknown[][] } }).mock?.calls.find(
+      (call) => String(call[0]).includes("Skipping message_end block reply"),
+    );
+    expect(debugCall).toBeDefined();
+    const logged = String(debugCall![0]);
+    expect(logged).toContain("...");
+    expect(hasLoneSurrogate(logged)).toBe(false);
   });
 
   it("emits a replacement final assistant event when final_answer appears only at message_end", () => {

--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -4,6 +4,7 @@
  */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { createInlineCodeState } from "../../packages/markdown-core/src/code-spans.js";
 import {
@@ -1306,7 +1307,7 @@ export function handleMessageEnd(
           )
         ) {
           ctx.log.debug(
-            `Skipping message_end block reply - already sent via messaging tool: ${text.slice(0, 50)}...`,
+            `Skipping message_end block reply - already sent via messaging tool: ${truncateUtf16Safe(text, 50)}...`,
           );
         } else {
           const alreadyDeliveredFinalText = Boolean(

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -2,6 +2,7 @@
  * Subscribes to embedded-agent sessions and streams formatted replies/events.
  */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { InlineCodeState } from "../../packages/markdown-core/src/code-spans.js";
 import {
   buildCodeSpanIndex,
@@ -1057,7 +1058,9 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
           messagingToolSentTextsNormalized,
         ));
     if (isMessagingDuplicate) {
-      log.debug(`Skipping block reply - already sent via messaging tool: ${chunk.slice(0, 50)}...`);
+      log.debug(
+        `Skipping block reply - already sent via messaging tool: ${truncateUtf16Safe(chunk, 50)}...`,
+      );
       if (prefixReplayCandidate) {
         markBlockReplyTextHandled();
       }


### PR DESCRIPTION
## What Problem This Solves

Two debug log previews in the embedded-agent block-reply path are truncated to 50 UTF-16 code units using raw `.slice(0, 50)`. When the skipped reply text ends near a multi-code-unit emoji, the cut can land between a surrogate pair and leave a lone surrogate in the log line.

## Why This Change Was Made

Route both truncation sites through the repository's canonical `truncateUtf16Safe` helper. Behavior is unchanged for ordinary text and only backs up by one code unit when the cap would split a surrogate pair.

## User Impact

Long block-reply skip reasons that end near an emoji no longer inject dangling surrogates into agent debug logs or any diagnostic surface that reads them back.

## Scope

Three files (`src/agents/embedded-agent-subscribe.handlers.messages.ts`, `src/agents/embedded-agent-subscribe.handlers.messages.test.ts`, `src/agents/embedded-agent-subscribe.ts`); no config, protocol, dependency, or compatibility change. AI-assisted.

## Real behavior proof

**Behavior addressed**: `handleMessageEnd` in `src/agents/embedded-agent-subscribe.handlers.messages.ts` and the streaming duplicate check in `src/agents/embedded-agent-subscribe.ts` both log `text.slice(0, 50)` previews when suppressing a block reply already delivered via the messaging tool.

**Real environment tested**: Local Linux checkout at head 4c3951a9072ae4851582fe090cecb2d4c553985b, Node v22.22.0, repository vitest wrapper.

**Exact steps or command run after this patch**:

```bash
node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.handlers.messages.test.ts
```

**Evidence after fix**:

```text
 Test Files  1 passed (1)
      Tests  45 passed (45)
```

The regression test constructs a 49-ASCII + 😀 + suffix text so the legacy 50-code-unit cut would split the emoji's surrogate pair, then asserts the logged preview contains no lone surrogate and still ends with `...`.

**Observed result after fix**: `truncateUtf16Safe(text, 50)` backs off before the emoji, producing a 49-code-unit preview with no lone surrogate.

## Maintainer verification

- Exact head: 4c3951a9072ae4851582fe090cecb2d4c553985b
- Local focused test: `node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.handlers.messages.test.ts` — pass
- Local lint: `node scripts/run-oxlint.mjs src/agents/embedded-agent-subscribe.handlers.messages.ts src/agents/embedded-agent-subscribe.handlers.messages.test.ts src/agents/embedded-agent-subscribe.ts` — pass
