### PR TITLE
feat(feishu): embed image media in card sends

### DIFF
--- a/extensions/feishu/src/channel.runtime.ts
+++ b/extensions/feishu/src/channel.runtime.ts
@@ -8,6 +8,7 @@ import {
   listFeishuDirectoryGroupsLive as listFeishuDirectoryGroupsLiveImpl,
   listFeishuDirectoryPeersLive as listFeishuDirectoryPeersLiveImpl,
 } from "./directory.js";
+import { uploadImageMediaFeishu as uploadImageMediaFeishuImpl } from "./media.js";
 import { feishuOutbound as feishuOutboundImpl } from "./outbound.js";
 import {
   createPinFeishu as createPinFeishuImpl,
@@ -43,6 +44,7 @@ export const feishuChannelRuntime = {
   getFeishuMemberInfo: getFeishuMemberInfoImpl,
   editMessageFeishu: editMessageFeishuImpl,
   getMessageFeishu: getMessageFeishuImpl,
+  uploadImageMediaFeishu: uploadImageMediaFeishuImpl,
   sendCardFeishu: sendCardFeishuImpl,
   sendMessageFeishu: sendMessageFeishuImpl,
 };

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -22,6 +22,7 @@ const getFeishuMemberInfoMock = vi.hoisted(() => vi.fn());
 const listFeishuDirectoryPeersLiveMock = vi.hoisted(() => vi.fn());
 const listFeishuDirectoryGroupsLiveMock = vi.hoisted(() => vi.fn());
 const feishuOutboundSendMediaMock = vi.hoisted(() => vi.fn());
+const uploadImageMediaFeishuMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./probe.js", () => ({
   probeFeishu: probeFeishuMock,
@@ -49,6 +50,7 @@ vi.mock("./channel.runtime.js", () => ({
     removeReactionFeishu: removeReactionFeishuMock,
     sendCardFeishu: sendCardFeishuMock,
     sendMessageFeishu: sendMessageFeishuMock,
+    uploadImageMediaFeishu: uploadImageMediaFeishuMock,
     feishuOutbound: {
       sendText: vi.fn(),
       sendMedia: feishuOutboundSendMediaMock,
@@ -544,25 +546,47 @@ describe("feishuPlugin actions", () => {
     });
   });
 
-  it("rejects card JSON sent with media", async () => {
-    await expect(
-      feishuPlugin.actions?.handleAction?.({
-        action: "send",
-        params: {
-          to: "chat:oc_group_1",
-          message: JSON.stringify({
-            elements: [{ tag: "markdown", content: "Card body" }],
-          }),
-          media: "/tmp/image.png",
-        },
-        cfg,
-        accountId: undefined,
-        toolContext: {},
-        mediaLocalRoots: ["/tmp"],
-      } as never),
-    ).rejects.toThrow("Feishu send does not support card with media.");
+  it("embeds image media in card JSON messages", async () => {
+    uploadImageMediaFeishuMock.mockResolvedValueOnce({ imageKey: "img_key_1" });
+    sendCardFeishuMock.mockResolvedValueOnce({ messageId: "om_card", chatId: "oc_group_1" });
 
-    expect(sendCardFeishuMock).not.toHaveBeenCalled();
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        message: JSON.stringify({
+          elements: [{ tag: "markdown", content: "Card body" }],
+        }),
+        media: "/tmp/image.png",
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+      mediaLocalRoots: ["/tmp"],
+    } as never);
+
+    expect(uploadImageMediaFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      mediaUrl: "/tmp/image.png",
+      accountId: undefined,
+      mediaLocalRoots: ["/tmp"],
+    });
+    const sendCardArgs = requireRecord(
+      mockCallArg(sendCardFeishuMock, 0, 0, "sendCardFeishu"),
+      "send card args",
+    );
+    const card = requireRecord(sendCardArgs.card, "card");
+    expect(card.body).toEqual({
+      elements: [
+        { tag: "markdown", content: "Card body" },
+        {
+          tag: "img",
+          img_key: "img_key_1",
+          alt: { tag: "plain_text", content: "image" },
+          mode: "fit_horizontal",
+        },
+      ],
+    });
     expect(feishuOutboundSendMediaMock).not.toHaveBeenCalled();
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
   });

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -98,6 +98,29 @@ function readFeishuMediaParam(params: Record<string, unknown>): string | undefin
   return media.trim() ? media : undefined;
 }
 
+function appendFeishuCardImage(
+  card: Record<string, unknown>,
+  imageKey: string,
+): Record<string, unknown> {
+  const body = isRecord(card.body) ? { ...card.body } : {};
+  const elements = Array.isArray(body.elements) ? [...body.elements] : [];
+  return {
+    ...card,
+    body: {
+      ...body,
+      elements: [
+        ...elements,
+        {
+          tag: "img",
+          img_key: imageKey,
+          alt: { tag: "plain_text", content: "image" },
+          mode: "fit_horizontal",
+        },
+      ],
+    },
+  };
+}
+
 function readBooleanParam(params: Record<string, unknown>, keys: string[]): boolean | undefined {
   for (const key of keys) {
     const value = params[key];
@@ -845,9 +868,6 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
                     : resolveInteractiveTextFallback({ text, interactive }),
                 })
               : textCard;
-            if (card && mediaUrl) {
-              throw new Error(`Feishu ${ctx.action} does not support card with media.`);
-            }
             if (!card && !text && !mediaUrl) {
               throw new Error(`Feishu ${ctx.action} requires text/message, media, or card.`);
             }
@@ -864,10 +884,20 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
                   "Feishu card buttons that trigger text or commands must use structured interaction envelopes.",
                 );
               }
+              let cardToSend = card;
+              if (mediaUrl) {
+                const { imageKey } = await runtime.uploadImageMediaFeishu({
+                  cfg: ctx.cfg,
+                  mediaUrl,
+                  accountId: ctx.accountId ?? undefined,
+                  mediaLocalRoots: ctx.mediaLocalRoots,
+                });
+                cardToSend = appendFeishuCardImage(card, imageKey);
+              }
               result = await runtime.sendCardFeishu({
                 cfg: ctx.cfg,
                 to,
-                card,
+                card: cardToSend,
                 accountId: ctx.accountId ?? undefined,
                 replyToMessageId,
                 replyInThread,

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -398,7 +398,7 @@ export async function saveMessageResourceFeishu(params: {
   }
 }
 
-type UploadImageResult = {
+export type UploadImageResult = {
   imageKey: string;
 };
 
@@ -417,7 +417,7 @@ export type SendMediaResult = {
  * Upload an image to Feishu and get an image_key for sending.
  * Supports: JPEG, PNG, WEBP, GIF, TIFF, BMP, ICO
  */
-async function uploadImageFeishu(params: {
+export async function uploadImageFeishu(params: {
   cfg: ClawdbotConfig;
   image: Buffer | string; // Buffer or file path
   imageType?: "message" | "avatar";
@@ -450,6 +450,33 @@ async function uploadImageFeishu(params: {
       errorPrefix: "Feishu image upload failed",
     }),
   };
+}
+
+export async function uploadImageMediaFeishu(params: {
+  cfg: ClawdbotConfig;
+  mediaUrl: string;
+  accountId?: string;
+  /** Allowed roots for local path reads; required for local filePath to work. */
+  mediaLocalRoots?: readonly string[];
+}): Promise<UploadImageResult> {
+  const account = resolveFeishuRuntimeAccount({ cfg: params.cfg, accountId: params.accountId });
+  if (!account.configured) {
+    throw new Error(`Feishu account "${account.accountId}" not configured`);
+  }
+
+  const mediaMaxBytes = (account.config?.mediaMaxMb ?? 30) * 1024 * 1024;
+  const loaded = await getFeishuRuntime().media.loadWebMedia(params.mediaUrl, {
+    maxBytes: mediaMaxBytes,
+    optimizeImages: false,
+    localRoots: params.mediaLocalRoots?.length ? params.mediaLocalRoots : undefined,
+  });
+  const fileName = loaded.fileName ?? "image";
+  const routing = resolveFeishuOutboundMediaKind({ fileName, contentType: loaded.contentType });
+  if (routing.msgType !== "image") {
+    throw new Error("Feishu card media only supports image attachments.");
+  }
+
+  return uploadImageFeishu({ cfg: params.cfg, image: loaded.buffer, accountId: params.accountId });
 }
 
 /**


### PR DESCRIPTION
## Summary
- Allow Feishu card sends to include image media by uploading the media and embedding it as a card `img` element.
- Keep card + non-image media unsupported with a clear error from the image-only upload path.
- Add channel action coverage for native card JSON plus image media so it sends one interactive card instead of rejecting or sending separately.

## Validation
- `git diff --check`
- Local syntax check: `node --check openclaw.mjs`
- Attempted `pnpm vitest run extensions/feishu/src/channel.test.ts`; in this constrained OpenClaw session the runner repeatedly spent several minutes bundling the workspace and did not complete before interruption/restart.
- Equivalent local plugin dist behavior was validated end-to-end with `message.send`, producing a single Feishu interactive card with images: `om_x100b6bc787a46898c35156d459c3d11`.
- Raw Feishu API validation for the same card-image approach succeeded: `om_x100b6bc4ae9124b8c2d946793d4bee6`.

Fixes #102435
