### PR TITLE
feat(telegram): show quiet-tool progress draft in partial streaming mode

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2407,11 +2407,51 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
-  it("does not coalesce answer partial fragments with tool progress drafts", async () => {
+  it("shows quiet tool progress in partial mode after the quiet threshold", async () => {
+    vi.useFakeTimers();
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    let releaseRun: (() => void) | undefined;
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+      await new Promise<void>((resolve) => {
+        releaseRun = resolve;
+      });
+      return { queuedFinal: false };
+    });
+
+    try {
+      const run = dispatchWithContext({
+        context: createContext(),
+        streamMode: "partial",
+        telegramCfg: { streaming: { mode: "partial" } },
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(119_999);
+      expect(answerDraftStream.updatePreview).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
+        telegramProgressPreview("Cracking\n\n🛠️ Exec", "<b>Cracking</b>\n<b>🛠️ Exec</b>"),
+      );
+
+      releaseRun?.();
+      await run;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("replaces a quiet tool progress draft with partial answer prose", async () => {
+    vi.useFakeTimers();
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    let releaseAnswer: (() => void) | undefined;
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
         await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await new Promise<void>((resolve) => {
+          releaseAnswer = resolve;
+        });
         await replyOptions?.onPartialReply?.({ text: "Done ", delta: "Done " });
         await replyOptions?.onPartialReply?.({ text: "Done answer", delta: "answer" });
         await dispatcherOptions.deliver({ text: "Done answer." }, { kind: "final" });
@@ -2419,17 +2459,125 @@ describe("dispatchTelegramMessage draft streaming", () => {
       },
     );
 
+    try {
+      const run = dispatchWithContext({
+        context: createContext(),
+        streamMode: "partial",
+        telegramCfg: { streaming: { mode: "partial" } },
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(mockCallArg(answerDraftStream.updatePreview).text).toContain("Exec");
+      releaseAnswer?.();
+      await run;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
+    expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Done ");
+    expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Done answer");
+    expect(answerDraftStream.update).toHaveBeenLastCalledWith("Done answer.");
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("does not show quiet tool progress when partial prose appears before threshold", async () => {
+    vi.useFakeTimers();
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    let releaseRun: (() => void) | undefined;
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await replyOptions?.onPartialReply?.({ text: "Working answer" });
+        await new Promise<void>((resolve) => {
+          releaseRun = resolve;
+        });
+        await dispatcherOptions.deliver({ text: "Working answer" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    try {
+      const run = dispatchWithContext({
+        context: createContext(),
+        streamMode: "partial",
+        telegramCfg: { streaming: { mode: "partial" } },
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(answerDraftStream.updatePreview).not.toHaveBeenCalled();
+      releaseRun?.();
+      await run;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(answerDraftStream.update).toHaveBeenCalledWith("Working answer");
+  });
+
+  it("throttles quiet tool progress refreshes after the fallback renders", async () => {
+    vi.useFakeTimers();
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    let startSecondTool: (() => void) | undefined;
+    let releaseRun: (() => void) | undefined;
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+      await new Promise<void>((resolve) => {
+        startSecondTool = resolve;
+      });
+      await replyOptions?.onToolStart?.({ name: "write", phase: "start" });
+      await new Promise<void>((resolve) => {
+        releaseRun = resolve;
+      });
+      return { queuedFinal: false };
+    });
+
+    try {
+      const run = dispatchWithContext({
+        context: createContext(),
+        streamMode: "partial",
+        telegramCfg: { streaming: { mode: "partial" } },
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
+      startSecondTool?.();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(29_999);
+      expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(answerDraftStream.updatePreview).toHaveBeenCalledTimes(2);
+      expect(answerDraftStream.updatePreview.mock.calls.at(-1)?.[0]?.text).toContain("Write");
+
+      releaseRun?.();
+      await run;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("sends fast-mode auto progress when partial quiet gating suppresses the draft", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onToolResult?.({
+        text: "Still checking the workspace",
+        channelData: { openclawProgressKind: "fast-mode-auto" },
+      });
+      return { queuedFinal: false };
+    });
+
     await dispatchWithContext({
       context: createContext(),
       streamMode: "partial",
       telegramCfg: { streaming: { mode: "partial" } },
     });
 
-    expect(mockCallArg(answerDraftStream.updatePreview).text).toContain("Exec");
-    expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Done ");
-    expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Done answer");
-    expect(answerDraftStream.update).toHaveBeenLastCalledWith("Done answer.");
-    expect(deliverReplies).not.toHaveBeenCalled();
+    expect(answerDraftStream.updatePreview).not.toHaveBeenCalled();
+    expectDeliveredReply(0, { text: "Still checking the workspace" });
   });
 
   it("does not hide text-only tool output after answer streaming starts", async () => {
@@ -2888,7 +3036,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
-  it("keeps tool progress visible after a partial-streamed intermediate block", async () => {
+  it("keeps quiet tool progress hidden after a partial-streamed intermediate block", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
@@ -2903,28 +3051,13 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await dispatchWithContext({ context: createContext() });
 
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Site A shows X.");
-    expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Site A shows X.");
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      expect.objectContaining({ text: expect.stringMatching(/🛠️ Exec<\/b>$/) }),
-    );
-    expect(answerDraftStream.update).toHaveBeenNthCalledWith(3, "Final answer");
-    // The tool-progress window repositions before the final (deferred delete),
-    // never an immediate clear/delete.
-    expect(answerDraftStream.rotateToNewMessageDeferringDelete).toHaveBeenCalledTimes(1);
-    // The reposition rewinds the stream BEFORE any deliverer cleanup clear(),
-    // so that clear finds no live message id and never deletes the window.
-    if (answerDraftStream.clear.mock.invocationCallOrder.length > 0) {
-      expect(
-        answerDraftStream.rotateToNewMessageDeferringDelete.mock.invocationCallOrder[0],
-      ).toBeLessThan(answerDraftStream.clear.mock.invocationCallOrder[0]);
-    }
-    const progressResetOrder = answerDraftStream.forceNewMessage.mock.invocationCallOrder[0];
-    const progressUpdateOrder = answerDraftStream.updatePreview.mock.invocationCallOrder[0];
-    expect(progressResetOrder).toBeLessThan(progressUpdateOrder);
+    expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Final answer");
+    expect(answerDraftStream.updatePreview).not.toHaveBeenCalled();
+    expect(answerDraftStream.rotateToNewMessageDeferringDelete).not.toHaveBeenCalled();
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
-  it("preserves streamed text blocks that follow tool progress before the final answer", async () => {
+  it("preserves streamed text blocks when quiet tool progress never renders", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
@@ -2939,21 +3072,10 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await dispatchWithContext({ context: createContext() });
 
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Site A shows X.");
-    expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
-      expect.objectContaining({ text: expect.stringMatching(/🛠️ Exec<\/b>$/) }),
-    );
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Site B shows Y.");
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(3, "Final answer");
-    // The tool-progress window repositions (deferred delete) rather than an
-    // immediate clear when the following text block takes over the lane.
-    expect(answerDraftStream.rotateToNewMessageDeferringDelete).toHaveBeenCalledTimes(1);
-    // The reposition rewinds the stream BEFORE any deliverer cleanup clear(),
-    // so that clear finds no live message id and never deletes the window.
-    if (answerDraftStream.clear.mock.invocationCallOrder.length > 0) {
-      expect(
-        answerDraftStream.rotateToNewMessageDeferringDelete.mock.invocationCallOrder[0],
-      ).toBeLessThan(answerDraftStream.clear.mock.invocationCallOrder[0]);
-    }
+    expect(answerDraftStream.updatePreview).not.toHaveBeenCalled();
+    expect(answerDraftStream.rotateToNewMessageDeferringDelete).not.toHaveBeenCalled();
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
@@ -2978,16 +3100,29 @@ describe("dispatchTelegramMessage draft streaming", () => {
   });
 
   it("rotates a tool-progress-only answer draft before streaming the final answer", async () => {
+    vi.useFakeTimers();
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    let releaseFinal: (() => void) | undefined;
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
         await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await new Promise<void>((resolve) => {
+          releaseFinal = resolve;
+        });
         await dispatcherOptions.deliver({ text: "Branch is up to date" }, { kind: "final" });
         return { queuedFinal: true };
       },
     );
 
-    await dispatchWithContext({ context: createContext() });
+    try {
+      const run = dispatchWithContext({ context: createContext() });
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(120_000);
+      releaseFinal?.();
+      await run;
+    } finally {
+      vi.useRealTimers();
+    }
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
       expect.objectContaining({ text: expect.stringMatching(/🛠️ Exec<\/b>$/) }),
@@ -3011,17 +3146,30 @@ describe("dispatchTelegramMessage draft streaming", () => {
   });
 
   it("clears a tool-progress-only draft across assistant boundaries before final text", async () => {
+    vi.useFakeTimers();
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    let releaseFinal: (() => void) | undefined;
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
         await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await new Promise<void>((resolve) => {
+          releaseFinal = resolve;
+        });
         await replyOptions?.onAssistantMessageStart?.();
         await dispatcherOptions.deliver({ text: "Branch is up to date" }, { kind: "final" });
         return { queuedFinal: true };
       },
     );
 
-    await dispatchWithContext({ context: createContext() });
+    try {
+      const run = dispatchWithContext({ context: createContext() });
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(120_000);
+      releaseFinal?.();
+      await run;
+    } finally {
+      vi.useRealTimers();
+    }
 
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
       expect.objectContaining({ text: expect.stringMatching(/🛠️ Exec<\/b>$/) }),
@@ -5850,20 +5998,33 @@ describe("dispatchTelegramMessage draft streaming", () => {
   });
 
   it("does not suppress text-only blocks after a tool-progress draft", async () => {
+    vi.useFakeTimers();
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    let releaseBlock: (() => void) | undefined;
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
         await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await new Promise<void>((resolve) => {
+          releaseBlock = resolve;
+        });
         await dispatcherOptions.deliver({ text: "block after progress" }, { kind: "block" });
         return { queuedFinal: true };
       },
     );
 
-    await dispatchWithContext({
-      context: createContext(),
-      streamMode: "partial",
-      telegramCfg: { streaming: { mode: "partial" } },
-    });
+    try {
+      const run = dispatchWithContext({
+        context: createContext(),
+        streamMode: "partial",
+        telegramCfg: { streaming: { mode: "partial" } },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(120_000);
+      releaseBlock?.();
+      await run;
+    } finally {
+      vi.useRealTimers();
+    }
 
     expect(mockCallArg(answerDraftStream.updatePreview).text).toContain("Exec");
     expect(answerDraftStream.update).toHaveBeenLastCalledWith("block after progress");

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -164,6 +164,11 @@ const silentReplyDispatchLogger = createSubsystemLogger("telegram/silent-reply-d
 
 /** Minimum chars before sending first streaming message (improves push notification UX) */
 const DRAFT_MIN_INITIAL_CHARS = 30;
+// Partial streaming stays prose-first. A tool-only turn gets one activity draft
+// after two quiet minutes, then refreshes no faster than every 30s.
+// Visible output or preview.toolProgress:false turns this fallback off.
+const QUIET_TOOL_PROGRESS_AFTER_MS = 120_000;
+const QUIET_TOOL_PROGRESS_REFRESH_MIN_MS = 30_000;
 
 type DraftPartialTextUpdate = {
   text: string;
@@ -1046,6 +1051,9 @@ export const dispatchTelegramMessage = async ({
   const durableReasoningPayloadsEnabled =
     resolvedReasoningLevel === "on" || Boolean(reasoningLane.stream);
   const streamToolProgressEnabled = resolveChannelStreamingPreviewToolProgress(telegramCfg);
+  const quietToolProgressEnabled =
+    streamMode === "partial" && canStreamAnswerDraft && streamToolProgressEnabled;
+  const deliveryState = createLaneDeliveryStateTracker();
   let lastAnswerPartialText = "";
   let activeAnswerDraftIsToolProgressOnly = false;
   let activeAnswerBlockAssistantMessageIndex: number | undefined;
@@ -1093,6 +1101,10 @@ export const dispatchTelegramMessage = async ({
   const progressSummaryStartedAt = Date.now();
   const progressSummary = createTelegramProgressSummaryTracker();
   let progressSummaryDelivered = false;
+  let quietToolProgressTimer: ReturnType<typeof setTimeout> | undefined;
+  let quietToolProgressPendingLine: ChannelProgressDraftCompositorLine | undefined;
+  let quietToolProgressLastRenderTime = 0;
+  let quietToolProgressRendered = false;
   const progressDraft = createChannelProgressDraftCompositor({
     entry: telegramCfg,
     mode: streamMode,
@@ -1139,14 +1151,83 @@ export const dispatchTelegramMessage = async ({
       !finalAnswerDeliveryStarted &&
       !finalAnswerDelivered,
     );
+  const hasVisibleChannelOutput = () =>
+    (answerLane.hasStreamedMessage && !quietToolProgressRendered) ||
+    reasoningLane.hasStreamedMessage ||
+    deliveryState.snapshot().delivered;
+  const clearQuietToolProgressTimer = () => {
+    if (!quietToolProgressTimer) {
+      return;
+    }
+    clearTimeout(quietToolProgressTimer);
+    quietToolProgressTimer = undefined;
+  };
+  const suppressQuietToolProgress = () => {
+    clearQuietToolProgressTimer();
+    quietToolProgressPendingLine = undefined;
+    quietToolProgressRendered = false;
+  };
   const pushStreamToolProgress = async (
     line?: string | ChannelProgressDraftLine,
-    options?: { toolName?: string; startImmediately?: boolean },
+    options?: { toolName?: string; startImmediately?: boolean; quietPartialRender?: boolean },
   ) => {
+    if (streamMode === "partial" && options?.quietPartialRender !== true) {
+      return false;
+    }
     if (!canPushStreamToolProgress()) {
       return false;
     }
     return await progressDraft.pushToolProgress(line, options);
+  };
+  const renderQuietToolProgress = async () => {
+    clearQuietToolProgressTimer();
+    const line = quietToolProgressPendingLine;
+    if (!quietToolProgressEnabled || !line || hasVisibleChannelOutput()) {
+      return false;
+    }
+    const rendered = await pushStreamToolProgress(line, { quietPartialRender: true });
+    if (rendered) {
+      quietToolProgressRendered = true;
+      quietToolProgressLastRenderTime = Date.now();
+    }
+    return rendered;
+  };
+  const scheduleQuietToolProgressRender = (delayMs: number) => {
+    if (quietToolProgressTimer) {
+      return;
+    }
+    quietToolProgressTimer = setTimeout(() => {
+      void enqueueDraftLaneEvent(async () => {
+        await renderQuietToolProgress();
+      });
+    }, delayMs);
+  };
+  const noteQuietToolProgress = async (
+    line: ChannelProgressDraftCompositorLine | undefined,
+    toolName: string | undefined,
+  ) => {
+    if (
+      !quietToolProgressEnabled ||
+      !line ||
+      !streamToolProgressEnabled ||
+      !isChannelProgressDraftWorkToolName(toolName)
+    ) {
+      return false;
+    }
+    quietToolProgressPendingLine = line;
+    if (hasVisibleChannelOutput()) {
+      return false;
+    }
+    if (!quietToolProgressRendered) {
+      scheduleQuietToolProgressRender(QUIET_TOOL_PROGRESS_AFTER_MS);
+      return false;
+    }
+    const elapsedMs = Date.now() - quietToolProgressLastRenderTime;
+    if (elapsedMs >= QUIET_TOOL_PROGRESS_REFRESH_MIN_MS) {
+      return await renderQuietToolProgress();
+    }
+    scheduleQuietToolProgressRender(QUIET_TOOL_PROGRESS_REFRESH_MIN_MS - elapsedMs);
+    return false;
   };
   const pushStreamReasoningProgress = async (payload: {
     text?: string;
@@ -1452,6 +1533,7 @@ export const dispatchTelegramMessage = async ({
       if (streamMode === "progress") {
         return;
       }
+      suppressQuietToolProgress();
       resetAnswerToolProgressDraft();
       suppressProgressDraftState();
     }
@@ -1529,7 +1611,6 @@ export const dispatchTelegramMessage = async ({
   const replyQuoteEntities = Array.isArray(ctxPayload.ReplyToQuoteEntities)
     ? ctxPayload.ReplyToQuoteEntities
     : undefined;
-  const deliveryState = createLaneDeliveryStateTracker();
   const beginDeliveryCorrelation = () =>
     beginTelegramInboundEventDeliveryCorrelation(
       ctxPayload.SessionKey,
@@ -2744,21 +2825,25 @@ export const dispatchTelegramMessage = async ({
                         progressSummary.closeCommentaryBurst();
                       }
                     }
-                    const progressPromise = pushStreamToolProgress(
-                      buildChannelProgressDraftLineForEntry(
-                        telegramCfg,
-                        {
-                          event: "tool",
-                          itemId: payload.itemId,
-                          toolCallId: payload.toolCallId,
-                          name: toolName,
-                          phase: payload.phase,
-                          args: payload.args,
-                        },
-                        payload.detailMode ? { detailMode: payload.detailMode } : undefined,
-                      ),
-                      { toolName, startImmediately: true },
+                    const progressLine = buildChannelProgressDraftLineForEntry(
+                      telegramCfg,
+                      {
+                        event: "tool",
+                        itemId: payload.itemId,
+                        toolCallId: payload.toolCallId,
+                        name: toolName,
+                        phase: payload.phase,
+                        args: payload.args,
+                      },
+                      payload.detailMode ? { detailMode: payload.detailMode } : undefined,
                     );
+                    const progressPromise =
+                      streamMode === "partial"
+                        ? noteQuietToolProgress(progressLine, toolName)
+                        : pushStreamToolProgress(progressLine, {
+                            toolName,
+                            startImmediately: true,
+                          });
                     if (statusReactionController && toolName) {
                       await statusReactionController.setTool(toolName);
                     }
@@ -2835,7 +2920,7 @@ export const dispatchTelegramMessage = async ({
                     if (
                       !updatedDraft &&
                       isFastModeAutoProgressPayload(payload) &&
-                      !canPushStreamToolProgress()
+                      (streamMode === "partial" || !canPushStreamToolProgress())
                     ) {
                       await sendPayload(payload);
                     }
@@ -2910,6 +2995,7 @@ export const dispatchTelegramMessage = async ({
       dispatchError = err;
       runtime.error?.(danger(`telegram dispatch failed: ${String(err)}`));
     } finally {
+      suppressQuietToolProgress();
       progressDraft.cancel();
       await draftLaneEventQueue;
       await finalizeSkippedDuplicateAnswerBlockDraft();


### PR DESCRIPTION
Fixes #102587

## What Problem This Solves

With Telegram's default `streaming.mode: "partial"`, a turn doing long tool work streams nothing — partial mode only previews assistant prose, and a tool-grinding turn produces none. Users watch a typing indicator for 20+ minutes and conclude the bot is dead (observed twice in production on 2026-07-09; group members explicitly asked "is it dead?" while the agent was healthy).

## Why This Change Was Made

`streaming.mode: "progress"` already renders a rolling activity draft but is opt-in config with no session command. This change gives `partial` mode a bounded fallback instead of changing defaults: when a turn has tool activity but no visible channel output for 2 minutes, one activity draft appears (same compositor line rendering `progress` mode uses), refreshing on later tool starts no faster than every 30 s. As soon as answer prose streams, the normal partial draft takes over and the fallback is suppressed; room-event turns, `off`/`block`/`progress` modes, and `preview.toolProgress: false` are unaffected. No new config keys — two documented constants.

Scope note: Telegram-only by design; Discord/other edit-capable channels are a follow-up once this shape proves out (#102587 tracks the generic complement to #102468).

## User Impact

A long tool-heavy turn in a default-configured Telegram chat now shows "what it's doing" after two quiet minutes instead of pure silence. Short turns and prose-streaming turns look exactly as before.

## Evidence

- `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.test.ts` → 176 passed (new: threshold render, prose transition without duplication, pre-threshold visible output suppression, refresh throttle, room-event silence, fast-mode auto-progress regression)
- Full extension sweep `node scripts/run-vitest.mjs extensions/telegram` → 132 files / 2455 tests passed
- Affected-test grep sweep → 3 shards / 237 tests passed
- tsgo core + extensions lanes green; oxfmt clean; `git diff --check` clean
- Structured autoreview: one finding (fast-mode auto-progress payload dropped in partial mode) accepted, fixed, and regression-covered; final review clean
