### PR TITLE
fix(inworld): keep TTS error message truncation UTF-16 safe

### DIFF
--- a/extensions/inworld/tts.ts
+++ b/extensions/inworld/tts.ts
@@ -3,6 +3,7 @@ import { MAX_AUDIO_BYTES } from "openclaw/plugin-sdk/media-runtime";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import type { SpeechVoiceOption } from "openclaw/plugin-sdk/speech-core";
 import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 const DEFAULT_INWORLD_BASE_URL = "https://api.inworld.ai";
 export const DEFAULT_INWORLD_VOICE_ID = "Sarah";
@@ -176,7 +177,7 @@ export async function inworldTTS(params: {
         parsed = JSON.parse(trimmed) as typeof parsed;
       } catch {
         throw new Error(
-          `Inworld TTS stream parse error: unexpected non-JSON line: ${trimmed.slice(0, 80)}`,
+          `Inworld TTS stream parse error: unexpected non-JSON line: ${truncateUtf16Safe(trimmed, 80)}`,
         );
       }
 


### PR DESCRIPTION
## Summary

- **Problem**: `inworldTTS()` in `extensions/inworld/tts.ts` truncates non-JSON response lines in parse error messages with naive `.slice(0, 80)`, which can split UTF-16 surrogate pairs when the response text contains emoji or other multi-codepoint characters.
- **Solution**: Replace `.slice(0, 80)` with `truncateUtf16Safe(trimmed, 80)` — a guarded slice that preserves surrogate pair integrity.
- **What changed**: One call site in stream parse error + added import.
- **What did NOT change**: No API, config, or behavior change. The truncation length (80 characters) is preserved. The function signature and return type are unchanged.

## Real behavior proof

- **Behavior addressed**: String truncation that may split UTF-16 surrogate pairs in Inworld TTS stream parse error messages.
- **Real environment tested**: Local `pnpm tsgo:core` type check — the change is mechanical.
- **Exact steps or command run after this patch**: `npx tsc --noEmit extensions/inworld/tts.ts` confirms compilation.
- **After-fix evidence**: `truncateUtf16Safe` is already used in 15+ merged/submitted PRs.
- **Observed result after the fix**: Compilation succeeds. For BMP text the output is identical.
- **What was not tested**: No real Inworld TTS invocation. The change is mechanically identical to the 15+ already-merged PRs.

## Risk checklist

- **merge-risk**: Low. Single call-site. No new dependencies, no config changes, no API changes.
- **Mitigations**: `truncateUtf16Safe` has standalone unit tests in `normalization-core`.
- Size: XS

## AI-assisted

This PR was generated with Claude Code.