### PR TITLE
fix(qa-matrix): keep shared reply previews UTF-16 safe

### DIFF
--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-shared.test.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-shared.test.ts
@@ -1,6 +1,9 @@
 // Qa Matrix tests cover scenario runtime shared plugin behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { resolveMatrixQaNoReplyWindowMs } from "./scenario-runtime-shared.js";
+import {
+  buildMatrixReplyArtifact,
+  resolveMatrixQaNoReplyWindowMs,
+} from "./scenario-runtime-shared.js";
 
 describe("matrix scenario runtime shared", () => {
   afterEach(() => {
@@ -18,5 +21,19 @@ describe("matrix scenario runtime shared", () => {
       vi.stubEnv("OPENCLAW_QA_MATRIX_NO_REPLY_WINDOW_MS", value);
       expect(resolveMatrixQaNoReplyWindowMs(30_000)).toBe(8_000);
     }
+  });
+
+  it("keeps reply previews UTF-16 safe without changing empty-body artifacts", () => {
+    const event = {
+      kind: "message" as const,
+      roomId: "!room:matrix-qa.test",
+      eventId: "$event",
+      sender: "@sut:matrix-qa.test",
+      type: "m.room.message",
+    };
+    const prefix = "a".repeat(199);
+
+    expect(buildMatrixReplyArtifact({ ...event, body: `${prefix}😀tail` }).bodyPreview).toBe(prefix);
+    expect(buildMatrixReplyArtifact({ ...event, body: " " }).bodyPreview).toBe("");
   });
 });

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-shared.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-shared.ts
@@ -1,5 +1,6 @@
 // Qa Matrix plugin module implements scenario runtime shared behavior.
 import { randomUUID } from "node:crypto";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { createMatrixQaClient, type MatrixQaRoomObserver } from "../../substrate/client.js";
 import type { MatrixQaObservedEvent } from "../../substrate/events.js";
 import type { MatrixQaFaultProxyObserver } from "../../substrate/fault-proxy.js";
@@ -189,7 +190,7 @@ export function buildMatrixReplyArtifact(
 ): MatrixQaReplyArtifact {
   const replyBody = event.body?.trim();
   return {
-    bodyPreview: replyBody?.slice(0, 200),
+    bodyPreview: replyBody ? truncateUtf16Safe(replyBody, 200) : undefined,
     eventId: event.eventId,
     mentions: event.mentions,
     relatesTo: event.relatesTo,

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-shared.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-shared.ts
@@ -190,7 +190,7 @@ export function buildMatrixReplyArtifact(
 ): MatrixQaReplyArtifact {
   const replyBody = event.body?.trim();
   return {
-    bodyPreview: replyBody ? truncateUtf16Safe(replyBody, 200) : undefined,
+    bodyPreview: replyBody === undefined ? undefined : truncateUtf16Safe(replyBody, 200),
     eventId: event.eventId,
     mentions: event.mentions,
     relatesTo: event.relatesTo,


### PR DESCRIPTION
## What Problem This Solves

The shared Matrix QA reply artifact bounded its trimmed body preview with raw UTF-16 code-unit slicing. A preview boundary through an emoji or another supplementary character could store malformed evidence.

## Why This Change Was Made

`buildMatrixReplyArtifact`, used across room, media, restart, and E2EE scenarios, now calls the public plugin SDK `truncateUtf16Safe` helper. The reviewed branch is rebased onto current main and retains the existing distinction between a missing body (`undefined`) and a present whitespace-only body (`""`).

## User Impact

Matrix QA evidence remains valid Unicode at the 200-unit preview cap. Scenario matching, full observed events, token checks, and empty-body artifact semantics are unchanged.

## Evidence

- Focused shared scenario-runtime suite passed.
- Exact regression covers an emoji crossing the 200-unit boundary and the prior whitespace-only artifact behavior.
- Focused oxfmt and oxlint passed; `git diff --check` passed.
- Fresh branch autoreview found no accepted or actionable findings (0.99 confidence).
