### PR TITLE
fix(imessage): cap per-chat group-allowlist warn-once cache

### DIFF
--- a/extensions/imessage/src/monitor/group-allowlist-warnings.test.ts
+++ b/extensions/imessage/src/monitor/group-allowlist-warnings.test.ts
@@ -143,4 +143,24 @@ describe("warnGroupAllowlistDropPerChatOnce", () => {
     );
     expect(messages).toHaveLength(0);
   });
+
+  it("bounds warn-once state by least-recently-used account/chat pairs", () => {
+    const messages: string[] = [];
+    const log = (message: string) => messages.push(message);
+    const warn = (chatId: number) =>
+      warnGroupAllowlistDropPerChatOnce({ accountId: "default", chatId, log });
+
+    for (let chatId = 0; chatId < 512; chatId += 1) {
+      expect(warn(chatId)).toBe(true);
+    }
+    expect(warn(0)).toBe(false);
+    expect(warn(512)).toBe(true);
+
+    messages.length = 0;
+    expect(warn(0)).toBe(false);
+    expect(warn(1)).toBe(true);
+    expect(warn(512)).toBe(false);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain("chat_id=1");
+  });
 });

--- a/extensions/imessage/src/monitor/group-allowlist-warnings.ts
+++ b/extensions/imessage/src/monitor/group-allowlist-warnings.ts
@@ -7,13 +7,16 @@
 // during iMessage config migration. See
 // https://github.com/openclaw/openclaw/issues/78749.
 
-import { createDedupeCache } from "openclaw/plugin-sdk/core";
+import { createDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
 
+const PER_CHAT_WARNING_CACHE_MAX_SIZE = 512;
 const startupWarned = new Set<string>();
-// Bounded warn-once cache — perChatWarned grows with every distinct group chat
-// the gateway sees. Cap at 512 to keep long-running iMessage monitor memory
-// stable while still covering active chat sets.
-const perChatWarned = createDedupeCache({ maxSize: 512, ttlMs: 0 });
+// Retain warn-once state for recently active chats without allowing every chat
+// seen over the process lifetime to accumulate indefinitely.
+const perChatWarned = createDedupeCache({
+  maxSize: PER_CHAT_WARNING_CACHE_MAX_SIZE,
+  ttlMs: 0,
+});
 
 /**
  * Fires once per `accountId` at monitor startup when `groupPolicy === "allowlist"`
@@ -55,7 +58,7 @@ export function warnGroupAllowlistMisconfigOnce(params: {
 /**
  * Fires once per `accountId:chat_id` when the runtime allowlist gate drops a
  * group message because that chat_id is not in `channels.imessage.groups`.
- * Bounded by the number of distinct group chats the gateway sees.
+ * Retains up to 512 recently active account/chat pairs; evicted chats may warn again.
  */
 export function warnGroupAllowlistDropPerChatOnce(params: {
   accountId: string;

--- a/extensions/imessage/src/monitor/group-allowlist-warnings.ts
+++ b/extensions/imessage/src/monitor/group-allowlist-warnings.ts
@@ -7,8 +7,13 @@
 // during iMessage config migration. See
 // https://github.com/openclaw/openclaw/issues/78749.
 
+import { createDedupeCache } from "openclaw/plugin-sdk/core";
+
 const startupWarned = new Set<string>();
-const perChatWarned = new Set<string>();
+// Bounded warn-once cache — perChatWarned grows with every distinct group chat
+// the gateway sees. Cap at 512 to keep long-running iMessage monitor memory
+// stable while still covering active chat sets.
+const perChatWarned = createDedupeCache({ maxSize: 512, ttlMs: 0 });
 
 /**
  * Fires once per `accountId` at monitor startup when `groupPolicy === "allowlist"`
@@ -62,10 +67,9 @@ export function warnGroupAllowlistDropPerChatOnce(params: {
     return false;
   }
   const key = `imessage:${params.accountId}:${chat}`;
-  if (perChatWarned.has(key)) {
+  if (perChatWarned.check(key)) {
     return false;
   }
-  perChatWarned.add(key);
   params.log(
     `imessage: dropping group message from chat_id=${chat} (account "${params.accountId}") — ` +
       `not in channels.imessage.groups allowlist. ` +


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the iMessage group-allowlist `perChatWarned` warn-once Set grows without bound for the lifetime of the gateway process. Each distinct group chat that gets dropped by the allowlist gate adds a new `imessage:<accountId>:<chatId>` key that is never evicted.

## Why This Change Was Made

The `perChatWarned` Set was replaced with a `createDedupeCache({ maxSize: 512, ttlMs: 0 })` instance. The `check()` API preserves the existing warn-once semantics (`check` returns `true` for a seen key, records and returns `false` for an unseen key) while capping total memory at 512 entries with LRU eviction. The `startupWarned` Set on the same file is left unchanged — it is naturally bounded by account IDs (single digits).

This follows the same `createDedupeCache` pattern recently applied to telegram, googlechat, and codex warn-once caches.

## User Impact

Operators of long-running iMessage gateways with many distinct group chats will no longer see unbounded memory accumulation from the per-chat allowlist warning cache. The warn-once behavior (one log message per chat) is preserved; when the cache exceeds 512 entries, the oldest entries are evicted and that chat would fire a warning again on the next dropped message.

## Evidence

Pre-submit freshness and competition check:

- Refreshed `upstream/main` before implementation; `extensions/imessage/src/monitor/group-allowlist-warnings.ts` still used raw `perChatWarned = new Set<string>()` with no eviction.
- Searched open PRs for `extensions/imessage/src/monitor/group-allowlist-warnings.ts` path and `perChatWarned` symbol; none owned this fix.

Narrow-focused test proof:

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-imessage.config.ts extensions/imessage/src/monitor/group-allowlist-warnings.test.ts

 Test Files  1 passed (1)
      Tests  9 passed (9)
```

All existing tests pass without modification — `DedupeCache.check()` preserves the same dedupe contract and `DedupeCache.clear()` is compatible with the test reset helper.

Branch-level negative control (old `Set` leaks all 600 entries):

```
// git checkout HEAD~1 -- .../group-allowlist-warnings.ts (restore raw Set)
$ node --import tsx --no-warnings -e "
import { warnGroupAllowlistDropPerChatOnce, resetGroupAllowlistWarningsForTesting }
  from './extensions/imessage/src/monitor/group-allowlist-warnings.js';
resetGroupAllowlistWarningsForTesting();
const log = () => {};
for (let i = 0; i < 600; i++)
  warnGroupAllowlistDropPerChatOnce({ accountId: 'prf', chatId: i, log });
// Old Set: all 600 entries leak → chat 0 still cached
const old = warnGroupAllowlistDropPerChatOnce({ accountId: 'prf', chatId: 0, log });
console.log('BEFORE FIX - chat 0 fires again:', old);
"
BEFORE FIX - chat 0 fires again: false
// false = deduped = all 600 entries still leaked in the unbounded Set
```

Branch-level after fix (capped at 512, old entries evicted):

```
// git checkout HEAD -- .../group-allowlist-warnings.ts (restore createDedupeCache)
$ node --import tsx --no-warnings -e "
import { warnGroupAllowlistDropPerChatOnce, resetGroupAllowlistWarningsForTesting }
  from './extensions/imessage/src/monitor/group-allowlist-warnings.js';
resetGroupAllowlistWarningsForTesting();
const log = () => {};
for (let i = 0; i < 600; i++)
  warnGroupAllowlistDropPerChatOnce({ accountId: 'prf', chatId: i, log });
// After fix: cap at 512 → chat 0 evicted, chat 599 still cached
const early = warnGroupAllowlistDropPerChatOnce({ accountId: 'prf', chatId: 0, log });
const recent = warnGroupAllowlistDropPerChatOnce({ accountId: 'prf', chatId: 599, log });
console.log('AFTER FIX - chat 0 (evicted) fires again:', early);
console.log('AFTER FIX - chat 599 (cached) deduped:', !recent);
"
AFTER FIX - chat 0 (evicted) fires again: true
AFTER FIX - chat 599 (cached) deduped: true
```

The proof uses `node --import tsx` to import the real exported `warnGroupAllowlistDropPerChatOnce` from the patched branch. Negative control (`git checkout HEAD~1`) confirms the old `Set` keeps all 600 entries. After fix, early entries are evicted by the 512-entry cap while recent entries remain cached and deduped.

Additional checks:

```text
pnpm exec oxfmt --check extensions/imessage/src/monitor/group-allowlist-warnings.ts
git diff --check
```

AI-assisted. Real behavior proof collected by human.
