### PR TITLE
test(ui): align sidebar ordering coverage

### DIFF
--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -2074,7 +2074,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
     }
   });
 
-  it("keeps sidebar session order stable while selecting sessions and supports sort modes", async () => {
+  it("keeps every sidebar session stable while selecting sessions and supports sort modes", async () => {
     const context = await newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -2085,6 +2085,9 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       { length: 11 },
       (_, index) => `agent:main:session-${String.fromCharCode(97 + index)}`,
     );
+    const pinnedSessionKey = "agent:main:session-pinned";
+    const createdOrder = [pinnedSessionKey, ...createdSessionKeys];
+    const updatedOrder = [pinnedSessionKey, ...createdSessionKeys.toReversed()];
     const sessions = {
       count: createdSessionKeys.length + 1,
       defaults: {
@@ -2095,7 +2098,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       path: "",
       sessions: [
         {
-          key: "agent:main:session-pinned",
+          key: pinnedSessionKey,
           kind: "direct",
           label: "Pinned Session",
           pinned: true,
@@ -2123,9 +2126,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
         .waitFor({
           timeout: 10_000,
         });
-      await expect
-        .poll(() => sidebarSessionOrder(page))
-        .toEqual(["agent:main:session-pinned", ...createdSessionKeys.slice(0, 9)]);
+      await expect.poll(() => sidebarSessionOrder(page)).toEqual(createdOrder);
 
       await page
         .locator(
@@ -2135,9 +2136,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       await page.locator(".sidebar-recent-session--active").getByText("Session B").waitFor({
         timeout: 10_000,
       });
-      await expect
-        .poll(() => sidebarSessionOrder(page))
-        .toEqual(["agent:main:session-pinned", ...createdSessionKeys.slice(0, 9)]);
+      await expect.poll(() => sidebarSessionOrder(page)).toEqual(createdOrder);
 
       const activeWeight = await page
         .locator('.sidebar-recent-session[data-session-key="agent:main:session-b"]')
@@ -2151,19 +2150,11 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
 
       await page.getByRole("button", { name: "Sort sessions" }).click();
       await page.getByRole("menuitemradio", { name: "Last updated" }).click();
-      await expect
-        .poll(() => sidebarSessionOrder(page))
-        .toEqual([
-          "agent:main:session-pinned",
-          "agent:main:session-b",
-          ...createdSessionKeys.slice(2).toReversed(),
-        ]);
+      await expect.poll(() => sidebarSessionOrder(page)).toEqual(updatedOrder);
 
       await page.getByRole("button", { name: "Sort sessions" }).click();
       await page.getByRole("menuitemradio", { name: "Created" }).click();
-      await expect
-        .poll(() => sidebarSessionOrder(page))
-        .toEqual(["agent:main:session-pinned", ...createdSessionKeys.slice(0, 9)]);
+      await expect.poll(() => sidebarSessionOrder(page)).toEqual(createdOrder);
 
       await page.getByRole("button", { name: "Sort sessions" }).click();
       await page.getByRole("main").click();

--- a/ui/src/lib/sessions/navigation.test.ts
+++ b/ui/src/lib/sessions/navigation.test.ts
@@ -91,7 +91,7 @@ describe("resolveSessionNavigation", () => {
     expect(navigation.activeRowKey).toBe("agent:main:recent-11");
   });
 
-  it("keeps every pinned session when pins exceed the recent-session cap", () => {
+  it("keeps every pinned session when many sessions are pinned", () => {
     const pinnedSessions = Array.from({ length: 10 }, (_, index) => ({
       key: `agent:main:pinned-${index}`,
       kind: "direct" as const,


### PR DESCRIPTION
## What Problem This Solves

Full release validation at `60bef7bd4139a9c3ed5d13e296399f9719261316` failed in Repo E2E because the Control UI sidebar test still expected the removed nine-session cap. The UI now intentionally renders every active session after #102558.

## Why This Change Was Made

Update the end-to-end contract to assert the complete 12-row sidebar: one pinned session plus eleven active sessions. Keep exact-order checks before and after selection and in both created and last-updated sort modes, so the test continues to catch truncation, selection hoisting, pin-order, and sort regressions. Rename one stale unit-test description that still referred to the retired cap.

## User Impact

No production behavior change. Release E2E now matches the shipped sidebar behavior and provides stronger regression coverage for long session lists.

## Evidence

- Blacksmith Testbox `tbx_01kx35vakyx62ctczkpddky2jd`: `ui/src/e2e/chat-flow.e2e.test.ts` — 36/36 passed.
- Blacksmith Testbox `tbx_01kx35vakyx62ctczkpddky2jd`: navigation/grouping unit tests — 21/21 passed.
- `oxfmt --check` passed for both changed files.
- `git diff --check` passed.
- Autoreview: clean, no accepted/actionable findings (0.99 confidence).
