### PR TITLE
fix: iOS reconnects stop requesting approval after capability loss

### DIFF
--- a/src/gateway/node-connect-reconcile.test.ts
+++ b/src/gateway/node-connect-reconcile.test.ts
@@ -267,14 +267,39 @@ describe("reconcileNodePairingOnConnect", () => {
     expect(result.shouldClearPendingPairings).toBe(true);
   });
 
-  it("requires a fresh pairing request when paired node permissions change", async () => {
+  it("requires a fresh pairing request when paired node permissions widen", async () => {
     const requestPairing = makePendingPairingRequest("req-permissions");
 
     const result = await reconcileNodePairingOnConnect({
       cfg: {} as never,
       connectParams: makeNodeConnectParams({
         commands: [],
+        permissions: { camera: true, notifications: true },
+      }),
+      pairedNode: makePairedNode({
+        commands: [],
         permissions: { camera: true, notifications: false },
+      }),
+      requestPairing,
+    });
+
+    expectNodePairingRequest(requestPairing, {
+      commands: [],
+      permissions: { camera: true, notifications: true },
+    });
+    expect(result.effectiveCommands).toEqual([]);
+    expect(result.effectivePermissions).toEqual({ camera: true, notifications: false });
+    expect(result.pendingPairing?.request.requestId).toBe("req-permissions");
+  });
+
+  it("accepts false-only permission metadata without reapproval", async () => {
+    const requestPairing = vi.fn();
+
+    const result = await reconcileNodePairingOnConnect({
+      cfg: {} as never,
+      connectParams: makeNodeConnectParams({
+        commands: [],
+        permissions: { camera: true, notifications: false, watchReachable: false },
       }),
       pairedNode: makePairedNode({
         commands: [],
@@ -283,17 +308,17 @@ describe("reconcileNodePairingOnConnect", () => {
       requestPairing,
     });
 
-    expectNodePairingRequest(requestPairing, {
-      commands: [],
-      permissions: { camera: true, notifications: false },
+    expect(requestPairing).not.toHaveBeenCalled();
+    expect(result.effectivePermissions).toEqual({
+      camera: true,
+      notifications: false,
+      watchReachable: false,
     });
-    expect(result.effectiveCommands).toEqual([]);
-    expect(result.effectivePermissions).toEqual({ camera: true, notifications: false });
-    expect(result.pendingPairing?.request.requestId).toBe("req-permissions");
+    expect(result.shouldClearPendingPairings).toBe(true);
   });
 
-  it("applies declared capability and permission downgrades to the live surface", async () => {
-    const requestPairing = makePendingPairingRequest("req-downgrade");
+  it("applies declared capability and permission downgrades without reapproval", async () => {
+    const requestPairing = vi.fn();
 
     const result = await reconcileNodePairingOnConnect({
       cfg: {} as never,
@@ -310,14 +335,11 @@ describe("reconcileNodePairingOnConnect", () => {
       requestPairing,
     });
 
-    expectNodePairingRequest(requestPairing, {
-      caps: ["camera"],
-      commands: [],
-      permissions: { camera: false },
-    });
+    expect(requestPairing).not.toHaveBeenCalled();
     expect(result.effectiveCaps).toEqual(["camera"]);
     expect(result.effectiveCommands).toEqual([]);
     expect(result.effectivePermissions).toEqual({ camera: false });
-    expect(result.pendingPairing?.request.requestId).toBe("req-downgrade");
+    expect(result.pendingPairing).toBeUndefined();
+    expect(result.shouldClearPendingPairings).toBe(true);
   });
 });

--- a/src/gateway/node-connect-reconcile.ts
+++ b/src/gateway/node-connect-reconcile.ts
@@ -2,11 +2,7 @@
 // Computes approved runtime surfaces and pending pairing upgrades on reconnect.
 import type { ConnectParams } from "../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  normalizeNodeApprovalSurfaceList,
-  sameNodeApprovalSurfaceSet,
-  sameNodePermissionSurface,
-} from "../infra/node-pairing-surface.js";
+import { normalizeNodeApprovalSurfaceList } from "../infra/node-pairing-surface.js";
 import type {
   NodePairingPairedNode,
   NodePairingRequestInput,
@@ -85,6 +81,15 @@ function intersectPermissionSurface(params: {
     }
   }
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function hasPermissionUpgrade(params: {
+  approved: Record<string, boolean> | undefined;
+  declared: Record<string, boolean> | undefined;
+}): boolean {
+  return Object.entries(params.declared ?? {}).some(
+    ([key, declaredValue]) => declaredValue && params.approved?.[key] !== true,
+  );
 }
 
 function buildNodePairingRequestInput(params: {
@@ -171,11 +176,13 @@ export async function reconcileNodePairingOnConnect(params: {
   const approvedCaps = normalizeNodeApprovalSurfaceList(params.pairedNode.caps);
   const approvedPermissions = normalizePermissionMap(params.pairedNode.permissions);
   const hasCommandUpgrade = declared.some((command) => !approvedCommands.includes(command));
-  const hasCapabilityChange = !sameNodeApprovalSurfaceSet(params.pairedNode.caps, declaredCaps);
-  const hasPermissionChange = !sameNodePermissionSurface(
-    params.pairedNode.permissions,
-    declaredPermissions,
+  const hasCapabilityUpgrade = declaredCaps.some(
+    (capability) => !approvedCaps.includes(capability),
   );
+  const permissionUpgrade = hasPermissionUpgrade({
+    approved: approvedPermissions,
+    declared: declaredPermissions,
+  });
   const effectiveApprovedDeclaredCaps = intersectApprovalSurfaceList({
     approved: approvedCaps,
     declared: declaredCaps,
@@ -189,16 +196,16 @@ export async function reconcileNodePairingOnConnect(params: {
     declared: declaredPermissions,
   });
 
-  // A reconnect may use only the intersection of old approval and new
-  // declaration until the upgraded caps/commands/permissions are approved.
-  if (hasCommandUpgrade || hasCapabilityChange || hasPermissionChange) {
+  // Availability and permission loss only narrow the live surface. Reapproval
+  // is required when a reconnect widens authority beyond the durable approval.
+  if (hasCommandUpgrade || hasCapabilityUpgrade || permissionUpgrade) {
     const pendingPairing = await params.requestPairing(
       buildNodePairingRequestInput({
         nodeId,
         connectParams: params.connectParams,
         caps: declaredCaps,
         commands: declared,
-        permissions: declaredPermissions ?? (hasPermissionChange ? {} : undefined),
+        permissions: declaredPermissions ?? (permissionUpgrade ? {} : undefined),
         remoteIp: params.reportedClientIp,
       }),
     );

--- a/src/gateway/server.node-pairing-authz.test.ts
+++ b/src/gateway/server.node-pairing-authz.test.ts
@@ -529,6 +529,52 @@ describe("gateway node pairing authorization", () => {
   });
 
   describeWithGatewayServer("paired node reconnects", (getStarted) => {
+    test("keeps iOS approval when a transient permission becomes unavailable", async () => {
+      const pairedNode = await pairDeviceIdentity({
+        name: "ios-transient-permission",
+        role: "node",
+        scopes: [],
+        clientId: GATEWAY_CLIENT_NAMES.IOS_APP,
+        clientMode: GATEWAY_CLIENT_MODES.NODE,
+      });
+      const initialPermissions = { camera: true, watchReachable: true };
+      const initial = await requestNodePairing({
+        nodeId: pairedNode.identity.deviceId,
+        platform: "ios",
+        deviceFamily: "iPhone",
+        commands: [],
+        permissions: initialPermissions,
+      });
+      await approveNodePairing(initial.request.requestId, {
+        callerScopes: ["operator.pairing", "operator.write"],
+      });
+
+      const nodeClient = await connectGatewayClient({
+        url: `ws://127.0.0.1:${getStarted().port}`,
+        token: "secret",
+        role: "node",
+        clientName: GATEWAY_CLIENT_NAMES.IOS_APP,
+        clientDisplayName: "iPhone",
+        clientVersion: "1.0.0",
+        platform: "ios",
+        deviceFamily: "iPhone",
+        mode: GATEWAY_CLIENT_MODES.NODE,
+        scopes: [],
+        commands: [],
+        permissions: { camera: true, watchReachable: false },
+        deviceIdentity: pairedNode.identity,
+      });
+      await nodeClient.stopAndWait();
+
+      const pairing = await listNodePairing();
+      expect(pairing.pending.some((entry) => entry.nodeId === pairedNode.identity.deviceId)).toBe(
+        false,
+      );
+      await expect(findPairedNode(pairedNode.identity.deviceId)).resolves.toMatchObject({
+        permissions: initialPermissions,
+      });
+    });
+
     test("clears stale reapproval when a node returns to its approved surface", async () => {
       const pairedNode = await pairDeviceIdentity({
         name: "node-reverted-reapproval",

--- a/src/gateway/test-helpers.e2e.ts
+++ b/src/gateway/test-helpers.e2e.ts
@@ -46,6 +46,7 @@ export async function connectGatewayClient(params: {
   scopes?: string[];
   caps?: string[];
   commands?: string[];
+  permissions?: Record<string, boolean>;
   instanceId?: string;
   deviceIdentity?: DeviceIdentity;
   onEvent?: (evt: { event?: string; payload?: unknown }) => void;
@@ -108,6 +109,7 @@ export async function connectGatewayClient(params: {
       scopes,
       caps: params.caps,
       commands: params.commands,
+      permissions: params.permissions,
       instanceId: params.instanceId,
       deviceIdentity,
       onEvent: params.onEvent,


### PR DESCRIPTION
Closes #98038

## What Problem This Solves

Fixes an issue where approved iOS devices could be sent back to the approval flow after reconnecting when transient device capabilities or permissions became unavailable, including Apple Watch reachability changes.

## Why This Change Was Made

Treats an existing pairing approval as the maximum authority granted to the device. Reconnection now requires approval only when the device requests a new command, capability, or enabled permission; losing a previously declared capability or permission only narrows the live session and does not mutate the durable approval.

## User Impact

Previously approved iPhones can reconnect after ordinary availability changes without repeated approval prompts. New authority still requires explicit approval.

## Evidence

- Blacksmith Testbox `tbx_01kx35rs5ramy75wvs0jn0v4kt`: focused Gateway pairing/reconnect tests, 6 files and 66 tests passed.
- Blacksmith Testbox `tbx_01kx35rs5ramy75wvs0jn0v4kt`: `check:changed` passed, including typechecks, lint, import-cycle checks, and policy guards.
- Regression coverage proves both sides of the invariant: permission/capability upgrades create a pending approval, while permission/capability loss reconnects without one and leaves the stored approval unchanged.
- Fresh Codex autoreview reported no accepted or actionable findings.

The proof exercises the same Gateway WebSocket connect and pairing path used by iOS; no physical-device run was performed.
