### PR TITLE
fix(fallback-state): use truncateUtf16Safe for fallback reason truncation

### DIFF
--- a/src/auto-reply/fallback-state.test.ts
+++ b/src/auto-reply/fallback-state.test.ts
@@ -236,6 +236,26 @@ describe("fallback-state", () => {
     },
   );
 
+  it("keeps fallback reason UTF-16 safe at the boundary", () => {
+    // Place emoji at position 78 so it straddles the slice(0,79) boundary
+    const prefix = "HTTP 503: ";
+    const emoji = "🎉";
+    const resolved = resolveDemoFallbackTransition({
+      attempts: [
+        {
+          provider: "demo-primary",
+          model: "demo-primary/model-a",
+          error: `${prefix}${"x".repeat(78 - prefix.length)}${emoji}after-truncation`,
+        },
+      ],
+    });
+
+    // The result must not end with an unpaired surrogate
+    expect(resolved.reasonSummary).not.toMatch(/[\uD800-\uDFFF]$/u);
+    // Should be truncated (80-char boundary exceeded)
+    expect(resolved.reasonSummary).toContain("…");
+  });
+
   it("still reports fallback when the OpenAI Codex runtime switches model ids", () => {
     expect(
       buildFallbackNotice({

--- a/src/auto-reply/fallback-state.ts
+++ b/src/auto-reply/fallback-state.ts
@@ -1,5 +1,6 @@
 /** Formats model-fallback notice state for UI/status messages and persisted transition tracking. */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatRawAssistantErrorForUi } from "../agents/embedded-agent-helpers.js";
 import { areRuntimeModelRefsEquivalent } from "../agents/model-runtime-aliases.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -29,7 +30,7 @@ function truncateFallbackReasonPart(value: string, max = FALLBACK_REASON_PART_MA
   if (text.length <= max) {
     return text;
   }
-  return `${text.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
+  return `${truncateUtf16Safe(text, Math.max(0, max - 1)).trimEnd()}…`;
 }
 
 function formatFallbackAttemptErrorPreview(attempt: RuntimeFallbackAttempt): string | undefined {


### PR DESCRIPTION
## What Problem This Solves

The fallback-state notice formatter uses raw UTF-16 code-unit slices to truncate model-fallback error messages at the 80-character boundary. When a fallback error message contains an emoji or other supplementary character at the cutoff, the raw slice can produce an unpaired surrogate in the user-visible fallback notice.

## Why This Change Was Made

Replace the raw `.slice(0, max)` in `truncateFallbackReasonPart` with `truncateUtf16Safe`, which preserves surrogate pair boundaries. The existing 80-character limit, whitespace normalization, and ellipsis suffix remain unchanged. This follows the same pattern used by 20+ files across the codebase.

## User Impact

Model fallback notices (shown in chat and status surfaces) remain valid Unicode when long error messages contain emoji or other supplementary characters that cross the truncation boundary.

## Evidence

- Added regression coverage with an emoji straddling the 80-char truncation boundary.
- `npx vitest run src/auto-reply/fallback-state.test.ts` — 1 file, 16 tests passed.
- The new test verifies no unpaired surrogate ends the truncated output and the ellipsis is present.

## Files Changed

| File | Change |
|------|--------|
| `src/auto-reply/fallback-state.ts` | Replace raw `.slice(0, max)` with `truncateUtf16Safe` in `truncateFallbackReasonPart`. |
| `src/auto-reply/fallback-state.test.ts` | Add UTF-16 boundary regression coverage. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)