### PR TITLE
fix(macos): keep Settings below native titlebar controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **macOS Control UI Settings:** keep the Settings back control below the native window buttons and titlebar drag region.
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **macOS Control UI Settings:** keep the Settings back control below the native window buttons and titlebar drag region.
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -206,7 +206,10 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
           --openclaw-native-titlebar-height: 50px;
         }
         @media (min-width: 700px) {
-          html.openclaw-native-macos .sidebar-shell {
+          /* Both desktop navigation surfaces must clear AppKit's window controls
+             and drag regions or their first interactive row becomes unreachable. */
+          html.openclaw-native-macos .sidebar-shell,
+          html.openclaw-native-macos .settings-sidebar__header {
             padding-top: max(14px, var(--openclaw-native-titlebar-height)) !important;
           }
         }

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -43,6 +43,20 @@ struct DashboardWindowSmokeTests {
         #expect(dashboardLogString(for: url) == "http://127.0.0.1:18789/control/")
     }
 
+    @Test func `dashboard native chrome clears both desktop sidebars`() throws {
+        let url = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+        let controller = DashboardWindowController(
+            url: url,
+            auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
+        let chromeScript = try #require(controller._testUserScripts.first {
+            $0.source.contains("openclaw-native-macos-chrome")
+        })
+
+        #expect(chromeScript.source.contains(".sidebar-shell"))
+        #expect(chromeScript.source.contains(".settings-sidebar__header"))
+        #expect(chromeScript.source.contains("--openclaw-native-titlebar-height"))
+    }
+
     @Test func `dashboard failure state opens in dashboard window`() throws {
         let url = try #require(URL(string: "http://127.0.0.1:18789/control/"))
         let controller = DashboardWindowController(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening Control UI Settings inside the macOS app would see the native window controls overlap the Back to app control.

## Why This Change Was Made

The Settings takeover now gives its header the same native titlebar clearance as the normal sidebar. This keeps the first interactive row below both the traffic lights and the AppKit drag regions instead of moving the action into a non-clickable titlebar surface.

## User Impact

Mac app users can see and use Back to app without interference from the native close, minimize, and zoom controls.

AI-assisted: implemented and reviewed with Codex.

## Evidence

- Browser geometry at a 1200×800 desktop viewport using the live Control UI stylesheet: without native titlebar presentation, Back occupied `y=14…46`; with the native presentation, it occupied `y=50…82`, clearing the titlebar interaction band ending at `y=46` while retaining the ESC hint.
- `swift test --package-path apps/macos --filter DashboardWindowSmokeTests` — 9 tests passed, including the new native chrome selector regression.
- Blacksmith Testbox through Crabbox `tbx_01kx36rqmphcsrp5104hmtx45w`: `corepack pnpm check:changed` passed on the exact branch content.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — no accepted or actionable findings; patch correct at 0.98 confidence.
