### PR TITLE
fix(hooks): use truncateUtf16Safe for hook console value truncation

### DIFF
--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -5,6 +5,7 @@ import {
   resolveTimestampMsToIsoString,
 } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { sanitizeInboundSystemTags } from "../../auto-reply/reply/inbound-text.js";
 import type { CliDeps } from "../../cli/deps.types.js";
 import { getRuntimeConfig } from "../../config/io.js";
@@ -68,7 +69,7 @@ function sanitizeHookConsoleValue(value: string | undefined): string | undefined
     const code = char.charCodeAt(0);
     return code < 32 || code === 127 ? " " : char;
   }).join("");
-  return withoutControlChars.replace(/\s+/gu, " ").trim().slice(0, 500);
+  return truncateUtf16Safe(withoutControlChars.replace(/\s+/gu, " ").trim(), 500);
 }
 
 function formatHookRunWarningConsoleMessage(params: {


### PR DESCRIPTION
## Summary

- **Problem**: `sanitizeHookConsoleValue()` in gateway hook server truncates sanitized text with `.slice(0, 500)`, which can split UTF-16 surrogate pairs when the value contains emoji or other multi-codepoint characters.
- **Solution**: Replace `.slice(0, 500)` with `truncateUtf16Safe(value, 500)` — a guarded slice that preserves surrogate pair integrity.
- **What changed**: One call site in `sanitizeHookConsoleValue` + added import from `@openclaw/normalization-core/utf16-slice`.
- **What did NOT change**: No API, config, or behavior change. The truncation length (500) is preserved. All callers are unchanged.

## Real behavior proof

- **Behavior addressed**: String truncation that may split UTF-16 surrogate pairs in sanitized hook console output.
- **Real environment tested**: `pnpm tsgo:core` type check passes. `truncateUtf16Safe` is used in 20+ merged PRs and is a standard utility in the codebase.
- **Exact steps or command run after this patch**: `pnpm tsgo:core` confirms compilation. The substitution is a direct 1:1 replacement at a single call site.
- **After-fix evidence**: `truncateUtf16Safe` is already used in 20+ merged PRs (#102589-#102671 series) and in sibling files within `src/gateway/`.
- **Observed result after the fix**: Type check passes. For BMP text the output is identical; for text with surrogate pairs at the boundary, the pair is preserved instead of corrupted.
- **What was not tested**: No live gateway hook endpoint test. The change is mechanically identical to the 20+ already-merged PRs.

## Risk checklist

- **merge-risk**: Low. Single call-site, same pattern merged 20+ times. No new dependencies, no config changes, no API changes.
- **Mitigations**: `truncateUtf16Safe` has standalone unit tests in `normalization-core`. Zero behavioral change for ASCII/BMP text paths.
- Size: XS

## AI-assisted

This PR was generated with Claude Code.