### PR TITLE
fix(agent-runner-execution): use truncateUtf16Safe for external run failure detail

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -952,7 +952,7 @@ function formatForwardedExternalRunFailureText(message: string): string {
   }
   const detail =
     sanitized.length > EXTERNAL_RUN_FAILURE_DETAIL_MAX_CHARS
-      ? `${sanitized.slice(0, EXTERNAL_RUN_FAILURE_DETAIL_MAX_CHARS - 1).trimEnd()}…`
+      ? `${truncateUtf16Safe(sanitized, EXTERNAL_RUN_FAILURE_DETAIL_MAX_CHARS - 1).trimEnd()}…`
       : sanitized;
   const suffix = /[.!?]$/u.test(detail) ? "" : ".";
   return `⚠️ Agent failed before reply: ${detail}${suffix} Please try again, or use /new to start a fresh session.`;


### PR DESCRIPTION
## What Problem This Solves

The external run failure detail formatter in `formatForwardedExternalRunFailureText` truncates sanitized error messages with a raw UTF-16 code-unit slice. When an error message contains an emoji at the truncation boundary, the raw slice can produce an unpaired surrogate in the user-visible failure message.

## Why This Change Was Made

Replace `.slice(0, EXTERNAL_RUN_FAILURE_DETAIL_MAX_CHARS - 1)` with `truncateUtf16Safe`. The module already imports `truncateUtf16Safe` for other truncation paths — this extends coverage to the remaining call site. The existing limit, trim, and ellipsis behavior remain unchanged.

## User Impact

Agent failure messages shown to users remain valid Unicode when long error text contains emoji or other supplementary characters at the truncation boundary.

## Evidence

- Existing suite covers the external run failure path.
- `npx vitest run src/auto-reply/reply/agent-runner-execution.test.ts` — 1 file, 234 tests passed.

## Files Changed

| File | Change |
|------|--------|
| `src/auto-reply/reply/agent-runner-execution.ts` | Replace raw `.slice(0,N)` with `truncateUtf16Safe` in `formatForwardedExternalRunFailureText`. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)