### PR TITLE
fix(ui): split-view toolbar segments misalign with the panes they label

### DIFF
--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -359,6 +359,17 @@ export class ChatPage extends LitElement {
     }
   };
 
+  private readonly handleToolbarPaneFocus = (paneId: string) => {
+    this.handleFocusPane(paneId);
+    // Tabbing can land on a toolbar segment the clipped track has translated
+    // off-screen; scroll its pane into view so the scroll sync follows and the
+    // focused control becomes visible (no-op when already in view).
+    const pane = Array.from(this.querySelectorAll<ChatPaneElement>("openclaw-chat-pane")).find(
+      (element) => element.paneId === paneId,
+    );
+    pane?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  };
+
   private readonly handleSplitRight = (paneId: string) => {
     const layout = this.layout;
     const pane = layout ? findPane(layout, paneId)?.pane : null;
@@ -421,7 +432,7 @@ export class ChatPage extends LitElement {
       <div
         class="chat-split-toolbar__pane ${active ? "chat-split-toolbar__pane--active" : ""}"
         @pointerdown=${() => this.handleFocusPane(pane.id)}
-        @focusin=${() => this.handleFocusPane(pane.id)}
+        @focusin=${() => this.handleToolbarPaneFocus(pane.id)}
       >
         <label class="chat-pane__session-label">
           <span class="agent-chat__sr-only">${t("chat.splitView.sessionSelect")}</span>

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -398,90 +398,108 @@ export class ChatPage extends LitElement {
     `;
   }
 
-  private renderSplitToolbar(layout: ChatSplitLayout) {
+  private renderSplitToolbarPane(layout: ChatSplitLayout, pane: ChatSplitPane) {
     const sessions = this.context?.sessions?.state.result?.sessions ?? [];
-    const panes = this.narrow
-      ? [findPane(layout, layout.activePaneId)?.pane].filter(
-          (pane): pane is ChatSplitPane => pane != null,
-        )
-      : panesOf(layout);
+    const active = pane.id === layout.activePaneId;
+    const currentSession = sessions.find((row) => row.key === pane.sessionKey);
+    const options = currentSession ? sessions : [{ key: pane.sessionKey }, ...sessions];
     return html`
-      <div class="chat-split-toolbar">
-        ${panes.map((pane) => {
-          const active = pane.id === layout.activePaneId;
-          const currentSession = sessions.find((row) => row.key === pane.sessionKey);
-          const options = currentSession ? sessions : [{ key: pane.sessionKey }, ...sessions];
-          return html`
-            <div
-              class="chat-split-toolbar__pane ${active ? "chat-split-toolbar__pane--active" : ""}"
-              @pointerdown=${() => this.handleFocusPane(pane.id)}
-              @focusin=${() => this.handleFocusPane(pane.id)}
-            >
-              <label class="chat-pane__session-label">
-                <span class="agent-chat__sr-only">${t("chat.splitView.sessionSelect")}</span>
-                <select
-                  class="chat-pane__session-select"
-                  data-session-key=${pane.sessionKey}
-                  aria-label=${t("chat.splitView.sessionSelect")}
-                  .value=${pane.sessionKey}
-                  @change=${(event: Event) => {
-                    const nextSessionKey = (event.target as HTMLSelectElement).value;
-                    if (nextSessionKey && nextSessionKey !== pane.sessionKey) {
-                      this.handlePaneSessionChange(pane.id, nextSessionKey);
-                    }
-                  }}
-                >
-                  ${options.map(
-                    (row) => html`
-                      <option value=${row.key}>
-                        ${resolveSessionDisplayName(
-                          row.key,
-                          sessions.find((session) => session.key === row.key),
-                        )}
-                      </option>
-                    `,
+      <div
+        class="chat-split-toolbar__pane ${active ? "chat-split-toolbar__pane--active" : ""}"
+        @pointerdown=${() => this.handleFocusPane(pane.id)}
+        @focusin=${() => this.handleFocusPane(pane.id)}
+      >
+        <label class="chat-pane__session-label">
+          <span class="agent-chat__sr-only">${t("chat.splitView.sessionSelect")}</span>
+          <select
+            class="chat-pane__session-select"
+            data-session-key=${pane.sessionKey}
+            aria-label=${t("chat.splitView.sessionSelect")}
+            .value=${pane.sessionKey}
+            @change=${(event: Event) => {
+              const nextSessionKey = (event.target as HTMLSelectElement).value;
+              if (nextSessionKey && nextSessionKey !== pane.sessionKey) {
+                this.handlePaneSessionChange(pane.id, nextSessionKey);
+              }
+            }}
+          >
+            ${options.map(
+              (row) => html`
+                <option value=${row.key}>
+                  ${resolveSessionDisplayName(
+                    row.key,
+                    sessions.find((session) => session.key === row.key),
                   )}
-                </select>
-              </label>
-              <div class="chat-pane__actions">
-                ${!this.narrow
-                  ? html`
-                      <openclaw-tooltip .content=${t("chat.splitView.splitDown")}>
-                        <button
-                          class="btn btn--ghost btn--icon"
-                          type="button"
-                          aria-label=${t("chat.splitView.splitDown")}
-                          @click=${() => this.handleSplitDown(pane.id)}
-                        >
-                          ${icons.panelBottomOpen}
-                        </button>
-                      </openclaw-tooltip>
-                      <openclaw-tooltip .content=${t("chat.splitView.splitRight")}>
-                        <button
-                          class="btn btn--ghost btn--icon"
-                          type="button"
-                          aria-label=${t("chat.splitView.splitRight")}
-                          @click=${() => this.handleSplitRight(pane.id)}
-                        >
-                          ${icons.panelRightOpen}
-                        </button>
-                      </openclaw-tooltip>
-                    `
-                  : nothing}
-                <openclaw-tooltip .content=${t("chat.splitView.closePane")}>
+                </option>
+              `,
+            )}
+          </select>
+        </label>
+        <div class="chat-pane__actions">
+          ${!this.narrow
+            ? html`
+                <openclaw-tooltip .content=${t("chat.splitView.splitDown")}>
                   <button
                     class="btn btn--ghost btn--icon"
                     type="button"
-                    aria-label=${t("chat.splitView.closePane")}
-                    @click=${() => this.handleClosePane(pane.id)}
+                    aria-label=${t("chat.splitView.splitDown")}
+                    @click=${() => this.handleSplitDown(pane.id)}
                   >
-                    ${icons.x}
+                    ${icons.panelBottomOpen}
                   </button>
                 </openclaw-tooltip>
-              </div>
+                <openclaw-tooltip .content=${t("chat.splitView.splitRight")}>
+                  <button
+                    class="btn btn--ghost btn--icon"
+                    type="button"
+                    aria-label=${t("chat.splitView.splitRight")}
+                    @click=${() => this.handleSplitRight(pane.id)}
+                  >
+                    ${icons.panelRightOpen}
+                  </button>
+                </openclaw-tooltip>
+              `
+            : nothing}
+          <openclaw-tooltip .content=${t("chat.splitView.closePane")}>
+            <button
+              class="btn btn--ghost btn--icon"
+              type="button"
+              aria-label=${t("chat.splitView.closePane")}
+              @click=${() => this.handleClosePane(pane.id)}
+            >
+              ${icons.x}
+            </button>
+          </openclaw-tooltip>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderSplitToolbar(layout: ChatSplitLayout) {
+    if (this.narrow) {
+      const activePane = findPane(layout, layout.activePaneId)?.pane;
+      return html`
+        <div class="chat-split-toolbar">
+          ${activePane ? this.renderSplitToolbarPane(layout, activePane) : nothing}
+        </div>
+      `;
+    }
+    // Mirror the split view's flex geometry (same column weights, 4px gaps at
+    // divider positions, same container bounds) so header segment edges land
+    // exactly on the pane edges below; see .chat-split-toolbar in split-view.css.
+    return html`
+      <div class="chat-split-toolbar">
+        ${layout.columns.map(
+          (column, columnIndex) => html`
+            ${columnIndex > 0 ? html`<div class="chat-split-toolbar__gap"></div>` : nothing}
+            <div
+              class="chat-split-toolbar__column"
+              style="flex: ${layout.columnWeights[columnIndex]} 1 0"
+            >
+              ${column.panes.map((pane) => this.renderSplitToolbarPane(layout, pane))}
             </div>
-          `;
-        })}
+          `,
+        )}
       </div>
     `;
   }

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -109,6 +109,9 @@ export class ChatPage extends LitElement {
 
   private readonly handleViewportChange = (event: MediaQueryListEvent) => {
     this.narrow = event.matches;
+    // Mode flips remount .chat-split-view with scrollLeft 0 and no scroll
+    // event; drop the mirrored offset so the toolbar track is not left shifted.
+    this.splitScrollLeft = 0;
     if (event.matches) {
       this.clearDropIndicator();
     }

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -50,6 +50,9 @@ export class ChatPage extends LitElement {
   @state() private layout: ChatSplitLayout | undefined;
   @state() private narrow = false;
   @state() private dropIndicator: DropIndicator | null = null;
+  // Horizontal scroll offset of .chat-split-view when its columns overflow;
+  // the fixed toolbar track mirrors it so segments stay over their panes.
+  @state() private splitScrollLeft = 0;
 
   private mediaQuery: MediaQueryList | null = null;
   private sessionsCleanup: (() => void) | null = null;
@@ -341,7 +344,15 @@ export class ChatPage extends LitElement {
   private readonly openSplitView = () => {
     const sessionKey = this.data?.sessionKey?.trim();
     if (sessionKey) {
+      this.splitScrollLeft = 0;
       this.persistLayout(createSplitLayout(sessionKey));
+    }
+  };
+
+  private readonly handleSplitViewScroll = (event: Event) => {
+    const left = (event.currentTarget as HTMLElement).scrollLeft;
+    if (left !== this.splitScrollLeft) {
+      this.splitScrollLeft = left;
     }
   };
 
@@ -486,20 +497,26 @@ export class ChatPage extends LitElement {
     }
     // Mirror the split view's flex geometry (same column weights, 4px gaps at
     // divider positions, same container bounds) so header segment edges land
-    // exactly on the pane edges below; see .chat-split-toolbar in split-view.css.
+    // exactly on the pane edges below; the track follows the split view's
+    // horizontal scroll when columns overflow. See split-view.css.
     return html`
       <div class="chat-split-toolbar">
-        ${layout.columns.map(
-          (column, columnIndex) => html`
-            ${columnIndex > 0 ? html`<div class="chat-split-toolbar__gap"></div>` : nothing}
-            <div
-              class="chat-split-toolbar__column"
-              style="flex: ${layout.columnWeights[columnIndex]} 1 0"
-            >
-              ${column.panes.map((pane) => this.renderSplitToolbarPane(layout, pane))}
-            </div>
-          `,
-        )}
+        <div
+          class="chat-split-toolbar__track"
+          style=${this.splitScrollLeft ? `transform: translateX(${-this.splitScrollLeft}px)` : ""}
+        >
+          ${layout.columns.map(
+            (column, columnIndex) => html`
+              ${columnIndex > 0 ? html`<div class="chat-split-toolbar__gap"></div>` : nothing}
+              <div
+                class="chat-split-toolbar__column"
+                style="flex: ${layout.columnWeights[columnIndex]} 1 0"
+              >
+                ${column.panes.map((pane) => this.renderSplitToolbarPane(layout, pane))}
+              </div>
+            `,
+          )}
+        </div>
       </div>
     `;
   }
@@ -514,7 +531,7 @@ export class ChatPage extends LitElement {
         : nothing;
     }
     return html`
-      <div class="chat-split-view">
+      <div class="chat-split-view" @scroll=${this.handleSplitViewScroll}>
         ${repeat(
           layout.columns,
           (column) => column.id,

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -121,7 +121,8 @@ openclaw-chat-pane {
 
 /* Spans exactly the split view's box (nav edge -> viewport right, ignoring the
    topbar's 12px padding) and mirrors its flex geometry below, so toolbar
-   segment edges land on the pane edges they label. */
+   segment edges land on the pane edges they label. overflow: clip keeps the
+   scroll-synced track from painting over the nav or viewport edge. */
 .chat-split-toolbar {
   position: fixed;
   top: var(--safe-area-top);
@@ -131,10 +132,20 @@ openclaw-chat-pane {
   display: flex;
   align-items: center;
   height: var(--shell-topbar-height);
+  overflow: clip;
 }
 
-/* min-width mirrors .chat-split-view__column so both layers clamp at the same
-   point when many columns compete for space. */
+/* Same box constraints as .chat-split-view's content; chat-page translates it
+   by the split view's scrollLeft so segments track scrolled-away columns. */
+.chat-split-toolbar__track {
+  display: flex;
+  flex: 1 1 0;
+  align-items: center;
+  height: 100%;
+}
+
+/* min-width mirrors .chat-split-view__column so both layers overflow at the
+   same point when many columns compete for space. */
 .chat-split-toolbar__column {
   display: flex;
   flex: 1 1 0;
@@ -232,9 +243,18 @@ openclaw-chat-pane {
    the rail's render breakpoint: the collapsed class stays on the workbench
    while the rail is display:none below 1121px. */
 @media (min-width: 1121px) {
-  .chat-split-view__drop-container:has(.chat-workbench--workspace-collapsed)
-    .chat-open-split-view {
+  .chat-split-view__drop-container:has(.chat-workbench--workspace-collapsed) .chat-open-split-view {
     right: 8px;
+  }
+}
+
+/* 1101-1120px renders the full column toolbar, but the chat card keeps the
+   content gutter there (the zero-gutter workspace rule starts at 1121px);
+   match .content's 20px padding so segments stay on the pane edges. */
+@media (min-width: 1101px) and (max-width: 1120px) {
+  .chat-split-toolbar {
+    right: calc(20px + var(--safe-area-right));
+    left: calc(var(--shell-nav-width) + 20px + var(--safe-area-left));
   }
 }
 

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -126,7 +126,9 @@ openclaw-chat-pane {
 .chat-split-toolbar {
   position: fixed;
   top: var(--safe-area-top);
-  right: var(--safe-area-right);
+  /* The docked terminal reshapes .content with margin-right; the pane edges
+     end there, so the fixed toolbar has to reserve the same space. */
+  right: calc(var(--safe-area-right) + var(--oc-terminal-reserve-right, 0px));
   left: calc(var(--shell-nav-width) + var(--safe-area-left));
   z-index: 41;
   display: flex;
@@ -253,11 +255,15 @@ openclaw-chat-pane {
    match .content's 20px padding so segments stay on the pane edges. */
 @media (min-width: 1101px) and (max-width: 1120px) {
   .chat-split-toolbar {
-    right: calc(20px + var(--safe-area-right));
+    right: calc(20px + var(--safe-area-right) + var(--oc-terminal-reserve-right, 0px));
     left: calc(var(--shell-nav-width) + 20px + var(--safe-area-left));
   }
 }
 
+/* At <=1100px the drawer toggle and search action own the topbar row's edges,
+   so the toolbar is inset to clear them instead of tracking pane edges. This
+   covers the JS narrow mode (<=1099px) plus the pinned 1100px boundary, where
+   the full column toolbar still renders (chat-flow e2e asserts both). */
 @media (max-width: 1100px) {
   .chat-split-toolbar {
     right: calc(62px + var(--safe-area-right));

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -119,15 +119,34 @@ openclaw-chat-pane {
   }
 }
 
+/* Spans exactly the split view's box (nav edge -> viewport right, ignoring the
+   topbar's 12px padding) and mirrors its flex geometry below, so toolbar
+   segment edges land on the pane edges they label. */
 .chat-split-toolbar {
   position: fixed;
   top: var(--safe-area-top);
-  right: calc(58px + var(--safe-area-right));
-  left: calc(var(--shell-nav-width) + 12px + var(--safe-area-left));
+  right: var(--safe-area-right);
+  left: calc(var(--shell-nav-width) + var(--safe-area-left));
   z-index: 41;
   display: flex;
   align-items: center;
   height: var(--shell-topbar-height);
+}
+
+/* min-width mirrors .chat-split-view__column so both layers clamp at the same
+   point when many columns compete for space. */
+.chat-split-toolbar__column {
+  display: flex;
+  flex: 1 1 0;
+  align-items: center;
+  min-width: 320px;
+  height: 100%;
+}
+
+/* Same width as the resizable-divider between columns; keeps segment
+   boundaries flush with the pane dividers below. */
+.chat-split-toolbar__gap {
+  flex: 0 0 4px;
 }
 
 .chat-split-toolbar__pane {
@@ -138,6 +157,13 @@ openclaw-chat-pane {
   min-width: 0;
   height: 100%;
   padding: 0 4px 0 10px;
+}
+
+/* The rightmost segment ends at the viewport edge; give its controls the same
+   breathing room as the 10px lead-in padding. The shell's search action only
+   renders below 1101px, where the inset narrow toolbar applies instead. */
+.chat-split-toolbar__column:last-child .chat-split-toolbar__pane:last-child {
+  padding-right: 10px;
 }
 
 .chat-split-toolbar__pane + .chat-split-toolbar__pane {


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #102511. Resolves a problem where the split-view active-pane indicator (toolbar tint + pane focus ring) still looked "a little bit off": the fixed split toolbar used hardcoded insets (`nav + 12px` left, `58px` right) and equal-width flex entries, while the panes below are laid out from column weights with 4px resizable dividers. The header segments therefore never started or ended where their panes did — edges mismatched by 12–58px at default weights and drifted arbitrarily after resizing.

## Why This Change Was Made

The toolbar now mirrors the split view's geometry exactly instead of approximating it:

- It spans the same box as the split view (nav edge → viewport right, matching the 20px content gutter at 1101–1120px and the docked terminal's `--oc-terminal-reserve-right`).
- Entries are grouped into per-column containers using the same `columnWeights` flex values, with 4px gaps where the dividers sit — identical flexbox math, so edges align pixel-perfect at any weights, including vertically stacked panes sharing their column's header width.
- When columns overflow horizontally (4+ columns), a clipped toolbar track mirrors the split view's `scrollLeft`, and focusing a clipped toolbar control scrolls its pane (and thus the track) into view, so keyboard users never focus an invisible control. The mirrored offset resets on narrow/wide mode flips.
- At ≤1100px the drawer toggle and search action own the topbar row edges, so the previous inset behavior is kept there deliberately (the chat-flow e2e pins that boundary).

## User Impact

The focused pane's header tint and focus ring now share exactly the same edges — flush with the sidebar, the pane dividers, and the viewport — at any pane count, column weight, viewport width, or with a docked terminal. The split view finally reads as one connected surface.

## Evidence

Measured with the mock-gateway harness (`ui/src/test-helpers/control-ui-e2e.ts`): toolbar segment rects are pixel-identical to pane rects at 1440px (default and resized weights), in the 1101–1120px gutter band, with 4 overflowing columns at `scrollLeft` 0 and 110, after keyboard-focusing an off-screen segment, and with a simulated 300px terminal reservation.

Before (tint edges never meet the pane edges; worse after resizing):

![before default](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/split-toolbar-alignment/before-top.png)
![before resized](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/split-toolbar-alignment/before-resized-top.png)

After (segment edges flush with sidebar, dividers, and viewport at any weight):

![after default](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/split-toolbar-alignment/after-top.png)
![after resized](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/split-toolbar-alignment/after-resized-top.png)

Stacked panes share their column's header width; overflowed columns stay in sync while scrolled:

![stacked](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/split-toolbar-alignment/after-stacked.png)
![overflow scrolled](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/split-toolbar-alignment/overflow-scrolled-top.png)

- `pnpm test ui/src/pages/chat/chat-page.test.ts` (11 passed) and the `uses one global toolbar row for split view` chat-flow e2e pass locally.
- `oxfmt` clean; Codex autoreview (branch vs `origin/main`) clean after addressing overflow reachability, gutter-band, terminal-reservation, stale-scroll, and keyboard-focus findings.
- Note: `chat-flow.e2e.test.ts > keeps sidebar session order stable...` fails identically on unmodified `origin/main` in this environment (pre-existing, unrelated to this diff); CI is the arbiter.
