### PR TITLE
fix(macos): open dashboard for existing gateways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **macOS existing Gateway launch:** skip provider and Crestodian onboarding when a configured Gateway connects successfully, mark setup complete, and open the dashboard immediately. (#102642)
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **macOS existing Gateway launch:** skip provider and Crestodian onboarding when a configured Gateway connects successfully, mark setup complete, and open the dashboard immediately. (#102642)
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -17323,7 +17323,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 294,
+      "line": 302,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Close Canvas",
       "surface": "apple",
@@ -17331,7 +17331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 294,
+      "line": 302,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
       "source": "Open Canvas",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -134,17 +134,23 @@ struct OpenClawApp: App {
     }
 
     private var isGatewaySleeping: Bool {
-        if self.state.isPaused { return false }
+        if self.state.isPaused {
+            return false
+        }
         switch self.state.connectionMode {
         case .unconfigured:
             return true
         case .remote:
-            if case .connected = self.controlChannel.state { return false }
+            if case .connected = self.controlChannel.state {
+                return false
+            }
             return true
         case .local:
             switch self.gatewayManager.status {
             case .running, .starting, .attachedExisting:
-                if case .connected = self.controlChannel.state { return false }
+                if case .connected = self.controlChannel.state {
+                    return false
+                }
                 return true
             case .failed, .stopped:
                 return true
@@ -155,7 +161,9 @@ struct OpenClawApp: App {
     @MainActor
     private func installStatusItemMouseHandler(for item: NSStatusItem) {
         guard let button = item.button else { return }
-        if button.subviews.contains(where: { $0 is StatusItemMouseHandlerView }) { return }
+        if button.subviews.contains(where: { $0 is StatusItemMouseHandlerView }) {
+            return
+        }
 
         WebChatManager.shared.onPanelVisibilityChanged = { [self] visible in
             self.isPanelVisible = visible
@@ -363,7 +371,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         AppActivationPolicy.apply(showDockIcon: self.state?.showDockIcon ?? false)
         if let state {
-            Task {
+            let shouldWaitForConnection = state.connectionMode != .unconfigured
+            if !shouldWaitForConnection {
+                self.scheduleFirstRunOnboardingIfNeeded(gatewayConnected: false)
+            }
+            Task { @MainActor in
                 // Validate PATH selection before local startup. Existing installs may not
                 // have the validation cache yet, and a stale external CLI must not win.
                 if state.connectionMode == .local {
@@ -372,6 +384,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 await ConnectionModeCoordinator.shared.apply(
                     mode: state.connectionMode,
                     paused: state.isPaused)
+                guard shouldWaitForConnection else { return }
+                self.scheduleFirstRunOnboardingIfNeeded(
+                    gatewayConnected: ControlChannel.shared.state == .connected)
             }
         }
         TerminationSignalWatcher.shared.start()
@@ -385,7 +400,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Task { await HealthStore.shared.refresh(onDemand: true) }
         Task { await PortGuardian.shared.sweep(mode: AppStateStore.shared.connectionMode) }
         Task { await PeekabooBridgeHostCoordinator.shared.setEnabled(AppStateStore.shared.peekabooBridgeEnabled) }
-        self.scheduleFirstRunOnboardingIfNeeded()
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             CLIInstallPrompter.shared.checkAndPromptIfNeeded(reason: "launch")
         }
@@ -439,15 +453,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @MainActor
-    private func scheduleFirstRunOnboardingIfNeeded() {
-        if AppStateStore.shared.connectionMode != .unconfigured,
-           AppStateStore.shared.onboardingSeen
-        {
+    static func shouldOpenDashboardInsteadOfOnboarding(
+        connectionMode: AppState.ConnectionMode,
+        onboardingSeen: Bool,
+        hasStoredConnectionMode: Bool,
+        gatewayConnected: Bool) -> Bool
+    {
+        connectionMode != .unconfigured && !onboardingSeen && !hasStoredConnectionMode && gatewayConnected
+    }
+
+    private func scheduleFirstRunOnboardingIfNeeded(gatewayConnected: Bool) {
+        let connectionMode = AppStateStore.shared.connectionMode
+        let onboardingSeen = AppStateStore.shared.onboardingSeen
+        // A stored app mode means onboarding already selected a Gateway; reconnecting
+        // must not turn an interrupted first-run flow into a completed installation.
+        let hasStoredConnectionMode = UserDefaults.standard.object(forKey: connectionModeKey) != nil
+        let shouldOpenDashboard = Self.shouldOpenDashboardInsteadOfOnboarding(
+            connectionMode: connectionMode,
+            onboardingSeen: onboardingSeen,
+            hasStoredConnectionMode: hasStoredConnectionMode,
+            gatewayConnected: gatewayConnected)
+        if connectionMode != .unconfigured, onboardingSeen || shouldOpenDashboard {
             OnboardingController.markComplete()
+            if shouldOpenDashboard {
+                self.openDashboardAction()
+            }
             return
         }
         let seenVersion = UserDefaults.standard.integer(forKey: onboardingVersionKey)
-        let shouldShow = seenVersion < currentOnboardingVersion || !AppStateStore.shared.onboardingSeen
+        let shouldShow = seenVersion < currentOnboardingVersion || !onboardingSeen
         guard shouldShow else { return }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
             OnboardingController.shared.show()

--- a/apps/macos/Tests/OpenClawIPCTests/MenuContentSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MenuContentSmokeTests.swift
@@ -80,4 +80,36 @@ struct MenuContentSmokeTests {
         #expect(shouldUseDefaultHandling)
         #expect(!didOpenDashboard)
     }
+
+    @Test func `connected configured gateway opens dashboard instead of onboarding`() {
+        for mode in [AppState.ConnectionMode.local, .remote] {
+            let shouldOpen = AppDelegate.shouldOpenDashboardInsteadOfOnboarding(
+                connectionMode: mode,
+                onboardingSeen: false,
+                hasStoredConnectionMode: false,
+                gatewayConnected: true)
+
+            #expect(shouldOpen)
+        }
+    }
+
+    @Test func `disconnected configured gateway keeps onboarding recovery`() {
+        let shouldOpen = AppDelegate.shouldOpenDashboardInsteadOfOnboarding(
+            connectionMode: .remote,
+            onboardingSeen: false,
+            hasStoredConnectionMode: false,
+            gatewayConnected: false)
+
+        #expect(!shouldOpen)
+    }
+
+    @Test func `connected gateway from interrupted onboarding keeps onboarding`() {
+        let shouldOpen = AppDelegate.shouldOpenDashboardInsteadOfOnboarding(
+            connectionMode: .local,
+            onboardingSeen: false,
+            hasStoredConnectionMode: true,
+            gatewayConnected: true)
+
+        #expect(!shouldOpen)
+    }
 }

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -33,6 +33,11 @@ has no macOS app asset, use the newest one that does, or build from source with
 4. Complete provider setup and the macOS permission checklist.
 5. Send the onboarding test message.
 
+If the app finds an existing Gateway configuration and connects successfully,
+it treats that Gateway as already set up, skips provider onboarding, and opens
+the dashboard. If the configured Gateway cannot connect, onboarding remains
+available for recovery.
+
 For the CLI/Gateway setup path, use [Getting started](/start/getting-started).
 For permission recovery, use [macOS permissions](/platforms/mac/permissions).
 


### PR DESCRIPTION
Closes #102642

## What Problem This Solves

The macOS app could show provider/Crestodian onboarding even when its existing OpenClaw configuration already selected a working local or remote Gateway. Launch scheduled onboarding independently of asynchronous Gateway connection setup, so fresh app-local preferences won that race.

## Why This Change Was Made

Configured launches now wait for the canonical connection-mode coordinator. A successful authenticated connection from config-derived state completes onboarding and opens the dashboard; a failed connection keeps recovery onboarding available.

The app-local connection-mode preference distinguishes a genuinely existing configuration from an interrupted onboarding flow. That preserves unfinished setup instead of silently marking it complete after reconnect.

## User Impact

Opening the macOS app against an already configured, reachable Gateway goes directly to the web dashboard. New installs, unreachable Gateways, and interrupted onboarding continue through setup/recovery.

## Evidence

- `swift test --package-path apps/macos --filter MenuContentSmokeTests`: 10 tests passed on macOS, including configured-connected, disconnected-recovery, and interrupted-onboarding cases.
- Remote changed gate passed on Blacksmith Testbox `tbx_01kx358mr7whpkdc71nbbbnqjj`.
- Developer ID-signed, source-blind runtime proof against an isolated authenticated Gateway: fresh app-local state exposed only the `OpenClaw` dashboard and persisted onboarding completion; stored interrupted-onboarding state remained incomplete and exposed `Welcome to OpenClaw`.
- Repository-configured SwiftFormat lint and `git diff --check` passed.
- Fresh autoreview passed with no findings after preserving interrupted-onboarding behavior.

AI-assisted implementation and review.
