### PR TITLE
fix(crestodian): route approval-intent classifier through utilityModel instead of flagship

### DIFF
--- a/src/crestodian/approval-intent.test.ts
+++ b/src/crestodian/approval-intent.test.ts
@@ -86,4 +86,15 @@ describe("classifyCrestodianApprovalIntent", () => {
       "other",
     );
   });
+
+  it("routes ambiguous-message classification through the utility model tier", async () => {
+    const deps = completionDeps("approve");
+    await classifyCrestodianApprovalIntent(
+      { message: "alright, ship that change", proposal: "set config gateway.port to 19001" },
+      deps,
+    );
+    expect(deps.prepareSimpleCompletionModelForAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ useUtilityModel: true }),
+    );
+  });
 });

--- a/src/crestodian/approval-intent.ts
+++ b/src/crestodian/approval-intent.ts
@@ -101,6 +101,7 @@ export async function classifyCrestodianApprovalIntent(
     )({
       cfg,
       agentId: resolveDefaultAgentId(cfg),
+      useUtilityModel: true,
       allowMissingApiKeyModes: ["aws-sdk"],
     });
     if ("error" in prepared) {


### PR DESCRIPTION
## What Problem This Solves

Fixes #102360 — the Crestodian approval-intent classifier resolves the agent's flagship model for a fixed 8-token approve/decline/other label, instead of using the configured `utilityModel`. It is the only member of the simple-completion family that omits `useUtilityModel: true`, so every ambiguous approval reply is billed at flagship pricing.

## Why This Change Was Made

The sibling label-generator in `src/auto-reply/reply/conversation-label-generator.ts:63` already passes `useUtilityModel: true` for an equivalently small bounded task. The classifier at `src/crestodian/approval-intent.ts:100` was missing only this flag.

When no `utilityModel` is configured, `resolveSimpleCompletionSelectionForAgent` falls through to the same primary model, so this is zero-behavior for those users and a pure cost saving for those who set a utilityModel.

## User Impact

Users who configure an agent with a distinct `utilityModel` (e.g. flagship Opus + utility Haiku) now get the approval-intent classifier routed to the cheaper tier, matching the label-generator behavior.

## Evidence

- Source-level root cause: `src/crestodian/approval-intent.ts:100-104` (the only simple-completion caller without `useUtilityModel: true`)
- Sibling reference: `src/auto-reply/reply/conversation-label-generator.ts:63` (correct pattern)
- Test added: verifies `prepareSimpleCompletionModelForAgent` is called with `useUtilityModel: true`