### PR TITLE
fix(agents-errors): use truncateUtf16Safe for error log truncation

### DIFF
--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -1582,7 +1582,7 @@ export function formatAssistantErrorText(
 
   // Never return raw unhandled errors - log for debugging but return safe message
   if (raw.length > 600) {
-    log.warn(`Long error truncated: ${raw.slice(0, 200)}`);
+    log.warn(`Long error truncated: ${truncateUtf16Safe(raw, 200)}`);
   }
   return raw.length > 600 ? `${truncateUtf16Safe(raw, 600)}…` : raw;
 }


### PR DESCRIPTION
## What Problem This Solves

One `.slice(0, 200)` truncation site was missed when `truncateUtf16Safe` was introduced to the same function on the next line. The raw error text logged in a warning may contain multi-byte characters such as emoji.

## Why This Change Was Made

`src/agents/embedded-agent-helpers/errors.ts` uses raw `.slice(0, 200)` for error log text truncation. Replacing it with `truncateUtf16Safe` ensures the logged text is always valid Unicode.

## User Impact

Debug log output for long errors remains valid Unicode at the existing size limit. No behavioral or API changes.

## Evidence

- Mechanical one-to-one replacement: `.slice(0, 200)` -> `truncateUtf16Safe(raw, 200)`
- The same file already uses `truncateUtf16Safe` on the very next line for the return value, so the import is already present
- No runtime behavior change for ASCII or valid Unicode input

Generated with Claude Code