### PR TITLE
fix(discord): use grapheme-cluster-aware chunk splitting for ZWJ emoji

### DIFF
--- a/extensions/discord/src/chunk.test.ts
+++ b/extensions/discord/src/chunk.test.ts
@@ -134,6 +134,43 @@ describe("chunkDiscordText", () => {
     expect(chunks.join("")).toBe(text);
   });
 
+  it("does not split ZWJ family emoji across chunks", () => {
+    // 👨‍👩‍👧‍👦 is 11 UTF-16 code units across 7 codepoints.  A chunk boundary
+    // at index 4 would fall inside the ZWJ sequence without full-text
+    // grapheme segmentation.
+    const text = "ab👨‍👩‍👧‍👦cd👨‍👩‍👧‍👦ef";
+    const chunks = chunkDiscordText(text, { maxChars: 4, maxLines: 50 });
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join("")).toBe(text);
+    const familyRe = /👨‍👩‍👧‍👦/g;
+    const found = chunks.reduce((s, c) => s + (c.match(familyRe) || []).length, 0);
+    expect(found).toBe(2);
+  });
+
+  it("does not split skin-tone modifier emoji across chunks", () => {
+    // 👋🏿 (waving hand + dark skin tone) is 4 UTF-16 code units
+    // (U+1F44B + U+1F3FF, two surrogate pairs).
+    const text = "a👋🏿b👋🏿c";
+    const chunks = chunkDiscordText(text, { maxChars: 3, maxLines: 50 });
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join("")).toBe(text);
+    const toneRe = /👋🏿/g;
+    const found = chunks.reduce((s, c) => s + (c.match(toneRe) || []).length, 0);
+    expect(found).toBe(2);
+  });
+
+  it("does not split flag sequences across chunks", () => {
+    // 🇯🇵 (Japan) is two regional indicator symbols (U+1F1EF + U+1F1F5,
+    // 4 UTF-16 code units total).
+    const text = "a🇯🇵b🇯🇵c";
+    const chunks = chunkDiscordText(text, { maxChars: 3, maxLines: 50 });
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join("")).toBe(text);
+    const flagRe = /🇯🇵/g;
+    const found = chunks.reduce((s, c) => s + (c.match(flagRe) || []).length, 0);
+    expect(found).toBe(2);
+  });
+
   it("keeps reasoning italics balanced across chunks", () => {
     const body = Array.from({ length: 25 }, (_, i) => `${i + 1}. line`).join("\n");
     const text = `Reasoning:\n_${body}_`;

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -85,14 +85,26 @@ function clampToGraphemeBoundary(text: string, index: number): number {
   if (index <= 0 || index >= text.length) {
     return index;
   }
-  // First adjust to a code-point boundary so text.slice(0, index) doesn't
-  // produce a dangling surrogate, which Intl.Segmenter may treat as an
-  // isolated surrogate — defeating the grapheme check.
-  if (isLowSurrogate(text.charCodeAt(index))) {
-    index -= 1;
+
+  // Segment the full text and find the last grapheme boundary at or before
+  // `index`.  Segmenting only `text.slice(0, index)` would let Intl.Segmenter
+  // treat a truncated ZWJ sequence as a complete final segment, defeating
+  // the grapheme protection.
+  let bound = 0;
+  for (const seg of graphemeSegmenter.segment(text)) {
+    const segEnd = seg.index + seg.segment.length;
+    if (segEnd > index) {
+      // `index` lands inside this grapheme cluster.  If earlier complete
+      // clusters existed, return the last valid boundary (`bound`).
+      // Otherwise this is the first cluster and it already exceeds `index`
+      // — return its end so the caller makes forward progress.
+      return bound > 0 ? bound : segEnd;
+    }
+    bound = segEnd;
   }
-  const segments = Array.from(graphemeSegmenter.segment(text.slice(0, index)));
-  return segments.reduce((acc, s) => acc + s.segment.length, 0);
+
+  // Unreachable: one segment always continues past index.
+  return bound;
 }
 
 function findWhitespaceBreak(window: string) {

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -70,25 +70,29 @@ function closeFenceIfNeeded(text: string, openFence: OpenFence | null) {
   return `${text}${closeLine}`;
 }
 
-function isHighSurrogate(code: number) {
-  return code >= 0xd800 && code <= 0xdbff;
-}
-
 function isLowSurrogate(code: number) {
   return code >= 0xdc00 && code <= 0xdfff;
 }
 
-function clampToCodePointBoundary(text: string, index: number) {
-  const boundary = Math.min(Math.max(0, index), text.length);
-  if (boundary <= 0 || boundary >= text.length) {
-    return boundary;
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+/**
+ * Adjusts a slice boundary to the nearest grapheme cluster boundary at or before
+ * the given index, so that ZWJ emoji sequences (like 👨‍👩‍👧‍👦) and other
+ * multi-codepoint grapheme clusters are never split across Discord message chunks.
+ */
+function clampToGraphemeBoundary(text: string, index: number): number {
+  if (index <= 0 || index >= text.length) {
+    return index;
   }
-  const previous = text.charCodeAt(boundary - 1);
-  const next = text.charCodeAt(boundary);
-  if (isHighSurrogate(previous) && isLowSurrogate(next)) {
-    return boundary > 1 ? boundary - 1 : boundary + 1;
+  // First adjust to a code-point boundary so text.slice(0, index) doesn't
+  // produce a dangling surrogate, which Intl.Segmenter may treat as an
+  // isolated surrogate — defeating the grapheme check.
+  if (isLowSurrogate(text.charCodeAt(index))) {
+    index -= 1;
   }
-  return boundary;
+  const segments = Array.from(graphemeSegmenter.segment(text.slice(0, index)));
+  return segments.reduce((acc, s) => acc + s.segment.length, 0);
 }
 
 function findWhitespaceBreak(window: string) {
@@ -128,7 +132,7 @@ function splitLongLine(
   let remaining = line;
   while (remaining.length > limit) {
     if (opts.preserveWhitespace) {
-      const breakIdx = clampToCodePointBoundary(remaining, limit);
+      const breakIdx = clampToGraphemeBoundary(remaining, limit);
       out.push(remaining.slice(0, breakIdx));
       remaining = remaining.slice(breakIdx);
       continue;
@@ -139,7 +143,7 @@ function splitLongLine(
       breakIdx = findCjkPunctuationBreak(window);
     }
     if (breakIdx <= 0) {
-      breakIdx = clampToCodePointBoundary(remaining, limit);
+      breakIdx = clampToGraphemeBoundary(remaining, limit);
     }
     out.push(remaining.slice(0, breakIdx));
     // Keep the separator for the next segment so words don't get glued together.


### PR DESCRIPTION
## What Problem This Solves

Discord chunking used surrogate-pair-level boundary detection via `isHighSurrogate`/`isLowSurrogate`, which only protects individual emoji as a single surrogate pair (2 UTF-16 code units). Multi-codepoint grapheme clusters — ZWJ sequences like 👨‍👩‍👧‍👦 (11 code units), skin-tone modifiers, or flags — could be split across message chunks, producing broken rendering.

## Why This Change Was Made

- Replaces `clampToCodePointBoundary` with `clampToGraphemeBoundary` using `Intl.Segmenter` (granularity: "grapheme") that segments the **full text** to find the last complete grapheme boundary at or before the index, instead of only the prefix (which treats truncated ZWJ sequences as complete).
- Removes unused `isHighSurrogate` helper.
- Adds regression tests for ZWJ family emoji, skin-tone modifiers, and flag sequences.

## User Impact

- ZWJ emoji sequences (e.g. 👨‍👩‍👧‍👦, 🏃‍♂️), skin-tone modifiers, and flags stay intact across Discord message chunks.
- No change for single-codepoint characters or existing surrogate-pair emoji.
- All 20 existing chunk tests pass.

## Evidence

- `pnpm test extensions/discord/src/chunk.test.ts` — 20 passed
- `pnpm exec oxfmt --check extensions/discord/src/chunk.ts`
- `git diff --check`
- Before/after (full-text vs prefix-based segmentation):
  - Before: prefix `text.slice(0, 4)` on `"ab👨‍👩‍👧‍👦cd"` → `["ab👨", "‍👩‍👧‍👦cd"]` (mid-cluster split)
  - After: full-text walk → `["ab", "👨‍👩‍👧‍👦cd"]` (intact)