### PR TITLE
fix(mattermost): use truncateUtf16Safe for log text and error truncation

### DIFF
--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -12,6 +12,7 @@ import {
 } from "openclaw/plugin-sdk/number-runtime";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 import { isPrivateNetworkOptInEnabled } from "openclaw/plugin-sdk/ssrf-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { ResolvedMattermostAccount } from "../mattermost/accounts.js";
 import { getMattermostRuntime } from "../runtime.js";
 import {
@@ -142,35 +143,37 @@ function isDeletedMattermostCommand(command: { delete_at?: number }): boolean {
 
 function sanitizeCommandLookupError(error: unknown): string {
   const raw = error instanceof Error ? error.message : String(error);
-  return raw
-    .replace(/[\r\n\t]/gu, " ")
-    .replace(/https?:\/\/[^\s)\]}]+/giu, (urlText) => {
-      try {
-        const url = new URL(urlText);
-        if (url.username || url.password) {
-          url.username = "redacted";
-          url.password = "redacted";
-        }
-        for (const key of url.searchParams.keys()) {
-          if (SECRET_LOG_KEYS.has(key.toLowerCase())) {
-            url.searchParams.set(key, "redacted");
+  return truncateUtf16Safe(
+    raw
+      .replace(/[\r\n\t]/gu, " ")
+      .replace(/https?:\/\/[^\s)\]}]+/giu, (urlText) => {
+        try {
+          const url = new URL(urlText);
+          if (url.username || url.password) {
+            url.username = "redacted";
+            url.password = "redacted";
           }
+          for (const key of url.searchParams.keys()) {
+            if (SECRET_LOG_KEYS.has(key.toLowerCase())) {
+              url.searchParams.set(key, "redacted");
+            }
+          }
+          return url.toString();
+        } catch {
+          return urlText;
         }
-        return url.toString();
-      } catch {
-        return urlText;
-      }
-    })
-    .replace(/(^|[^\w-])(Bearer|Token)\s+[A-Za-z0-9._~+/=-]+/giu, "$1$2 [redacted]")
-    .replace(
-      /\b(token|authorization|access_token|refresh_token|client_secret|botToken)\b(\s*["']?\s*(?:=|:)\s*["']?)[^"',\s;}]+/giu,
-      "$1$2[redacted]",
-    )
-    .slice(0, 300);
+      })
+      .replace(/(^|[^\w-])(Bearer|Token)\s+[A-Za-z0-9._~+/=-]+/giu, "$1$2 [redacted]")
+      .replace(
+        /\b(token|authorization|access_token|refresh_token|client_secret|botToken)\b(\s*["']?\s*(?:=|:)\s*["']?)[^"',\s;}]+/giu,
+        "$1$2[redacted]",
+      ),
+    300,
+  );
 }
 
 function sanitizeMattermostLogValue(value: string): string {
-  return value.replace(/[\r\n\t]/gu, " ").slice(0, 200);
+  return truncateUtf16Safe(value.replace(/[\r\n\t]/gu, " "), 200);
 }
 
 async function withCommandLookupTimeout<T>(task: (signal: AbortSignal) => Promise<T>): Promise<T> {


### PR DESCRIPTION
## What Problem This Solves

Two `.slice(0, N)` truncation sites in the Mattermost slash handler may cut UTF-16 surrogate pairs in half when the log text or error message contains multi-byte characters such as emoji.

## Why This Change Was Made

`extensions/mattermost/src/mattermost/slash-http.ts` uses raw `.slice(0, 300)` for error text and `.slice(0, 200)` for log value truncation. Replacing with `truncateUtf16Safe` ensures truncated output is always valid Unicode.

## User Impact

Truncated error and log text in Mattermost remains valid Unicode at existing size limits. No behavioral changes for ASCII-only content.

## Evidence

- Mechanical replacement: `.slice(0, N)` to `truncateUtf16Safe(str, N)` for two sites
- No runtime behavior change for ASCII or valid Unicode input

Generated with Claude Code