### PR TITLE
fix(microsoft-foundry): use truncateUtf16Safe for API error body and CLI error truncation

### DIFF
--- a/extensions/microsoft-foundry/cli.ts
+++ b/extensions/microsoft-foundry/cli.ts
@@ -4,6 +4,7 @@ import {
   normalizeOptionalString,
   normalizeStringifiedOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { AzAccessToken, AzAccount } from "./shared.js";
 import { COGNITIVE_SERVICES_RESOURCE } from "./shared.js";
 
@@ -34,7 +35,7 @@ function summarizeAzErrorMessage(raw: string): string {
   if (/aadsts\d+/i.test(normalized)) {
     return "Azure login failed for the selected tenant. Re-run `az login --use-device-code` and confirm the tenant is correct.";
   }
-  return normalized.slice(0, 300);
+  return truncateUtf16Safe(normalized, 300);
 }
 
 function buildAzCommandError(error: Error, stderr: string, stdout: string): Error {

--- a/extensions/microsoft-foundry/onboard.ts
+++ b/extensions/microsoft-foundry/onboard.ts
@@ -2,6 +2,7 @@
 import type { ProviderAuthContext } from "openclaw/plugin-sdk/core";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   normalizeOptionalString,
@@ -613,7 +614,7 @@ export async function testFoundryConnection(params: {
           FOUNDRY_CONNECTION_TEST_ERROR_BODY_LIMIT_BYTES,
         ).catch(() => "");
         await params.ctx.prompter.note(
-          `Endpoint is reachable but returned 400 Bad Request - check your deployment name and API version.\n${body.slice(0, 200)}`,
+          `Endpoint is reachable but returned 400 Bad Request - check your deployment name and API version.\n${truncateUtf16Safe(body, 200)}`,
           "Connection Test",
         );
       } else if (!res.ok) {


### PR DESCRIPTION
## What Problem This Solves

Two `.slice(0, N)` truncation sites in the Microsoft Foundry extension may cut UTF-16 surrogate pairs in half when the API error body or CLI error message contains multi-byte characters such as emoji.

## Why This Change Was Made

`extensions/microsoft-foundry/onboard.ts` and `cli.ts` use raw `.slice(0, 200)` / `.slice(0, 300)` for error text truncation. Replacing with `truncateUtf16Safe` ensures truncated output is always valid Unicode.

## User Impact

Truncated error messages in Microsoft Foundry remain valid Unicode at existing size limits. No behavioral changes for ASCII-only content.

## Evidence

- Mechanical replacement: `.slice(0, N)` to `truncateUtf16Safe(str, N)` for two sites across two files
- No runtime behavior change for ASCII or valid Unicode input

Generated with Claude Code