### PR TITLE
fix(anthropic): normalize unsupported inline image media types before payload

### DIFF
--- a/packages/ai/src/host.ts
+++ b/packages/ai/src/host.ts
@@ -11,6 +11,10 @@ export interface OpenAIStrictToolSettingOptions {
   supportsStrictMode?: boolean;
 }
 
+export type AiInlineTextBlock = { type: "text"; text: string };
+export type AiInlineImageBlock = { type: "image"; data: string; mimeType: string };
+export type AiInlineContentBlock = AiInlineTextBlock | AiInlineImageBlock;
+
 /** Narrow host ports consumed by the built-in provider adapters. */
 export interface AiTransportHost {
   /**
@@ -28,6 +32,13 @@ export interface AiTransportHost {
   redactSecrets<T>(value: T): T;
   /** Redacts secret-bearing text in tool payload strings. */
   redactToolPayloadText(text: string): string;
+  /**
+   * Normalizes Anthropic inline image blocks before provider payload construction.
+   * Host owns media decode/transcode so the package stays free of image backends.
+   */
+  normalizeAnthropicInlineContentBlocks(
+    content: readonly AiInlineContentBlock[],
+  ): Promise<AiInlineContentBlock[]>;
   /**
    * Resolves the host strict-tool default for OpenAI-compatible routes.
    * undefined lets the request omit the strict flag entirely.
@@ -51,6 +62,8 @@ const inertAiTransportHost: AiTransportHost = {
   resolveSecretSentinel: (value) => value,
   redactSecrets: (value) => value,
   redactToolPayloadText: (text) => text,
+  // Without a host media stack, pass blocks through; OpenClaw installs a real normalizer.
+  normalizeAnthropicInlineContentBlocks: async (content) => [...content],
   resolveOpenAIStrictToolSetting: (_model, options) =>
     options?.supportsStrictMode ? false : undefined,
   logDebug: () => {},

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -76,6 +76,22 @@ function makeSonnet5PrefillContext(): Context {
   };
 }
 
+function tinyJpegBase64(): string {
+  return Buffer.from([
+    0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
+  ]).toString("base64");
+}
+
+function configureTestAnthropicImageNormalizer(): void {
+  // Test double: host owns media decode/transcode; prove the adapter calls it.
+  configureAiTransportHost({
+    normalizeAnthropicInlineContentBlocks: async (content) =>
+      content.map((block) =>
+        block.type === "image" ? { ...block, mimeType: "image/jpeg" } : block,
+      ),
+  });
+}
+
 describe("Anthropic provider", () => {
   beforeEach(() => {
     anthropicMockState.configs = [];
@@ -232,6 +248,151 @@ describe("Anthropic provider", () => {
         text: "You are Claude Code, Anthropic's official CLI for Claude.",
         cache_control: { type: "ephemeral" },
       },
+    ]);
+  });
+
+  it("normalizes unsupported user image blocks before Anthropic payloads", async () => {
+    configureTestAnthropicImageNormalizer();
+    let capturedPayload: unknown;
+    const imageData = tinyJpegBase64();
+    const stream = streamAnthropic(
+      makeAnthropicModel({ input: ["text", "image"] }),
+      {
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "look" },
+              { type: "image", mimeType: "image/heic", data: imageData },
+            ],
+            timestamp: 0,
+          },
+        ],
+      },
+      {
+        apiKey: "sk-ant-provider",
+        onPayload: (payload) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    const userMessage = (capturedPayload as { messages: Array<Record<string, unknown>> })
+      .messages[0];
+    const imageBlock = (userMessage.content as Array<Record<string, unknown>>)[1];
+    expect(imageBlock).toMatchObject({
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: "image/jpeg",
+        data: imageData,
+      },
+    });
+  });
+
+  it("normalizes unsupported tool result image blocks before Anthropic payloads", async () => {
+    configureTestAnthropicImageNormalizer();
+    let capturedPayload: unknown;
+    const imageData = tinyJpegBase64();
+    const stream = streamAnthropic(
+      makeAnthropicModel({ input: ["text", "image"] }),
+      {
+        messages: [
+          {
+            role: "assistant",
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-6",
+            stopReason: "toolUse",
+            timestamp: 0,
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            content: [{ type: "toolCall", id: "tool_1", name: "screenshot", arguments: {} }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "tool_1",
+            toolName: "screenshot",
+            content: [{ type: "image", data: imageData, mimeType: "image/tiff" }],
+            isError: false,
+            timestamp: 0,
+          },
+        ],
+      },
+      {
+        apiKey: "sk-ant-provider",
+        onPayload: (payload) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    const userMessage = (capturedPayload as { messages: Array<Record<string, unknown>> })
+      .messages[1];
+    const toolResult = (userMessage.content as Array<Record<string, unknown>>)[0];
+    const imageBlock = (toolResult.content as Array<Record<string, unknown>>)[1];
+    expect(imageBlock).toMatchObject({
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: "image/jpeg",
+        data: imageData,
+      },
+    });
+  });
+
+  it("keeps non-vision user image downgrade behavior without decoding dropped images", async () => {
+    configureAiTransportHost({
+      normalizeAnthropicInlineContentBlocks: async () => {
+        throw new Error("non-vision images should be downgraded before normalization");
+      },
+    });
+    let capturedPayload: unknown;
+    const stream = streamAnthropic(
+      makeAnthropicModel({ input: ["text"] }),
+      {
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "look" },
+              { type: "image", mimeType: "image/heic", data: "not-base64" },
+            ],
+            timestamp: 0,
+          },
+        ],
+      },
+      {
+        apiKey: "sk-ant-provider",
+        onPayload: (payload) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    const userMessage = (capturedPayload as { messages: Array<Record<string, unknown>> })
+      .messages[0];
+    expect(userMessage.content).toMatchObject([
+      { type: "text", text: "look" },
+      { type: "text", text: "(image omitted: model does not support images)" },
     ]);
   });
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -18,6 +18,7 @@ import type {
   AssistantMessageEvent,
   CacheRetention,
   Context,
+  ImageContent,
   Message,
   Model,
   ModelThinkingLevel,
@@ -95,6 +96,16 @@ import { transformMessages } from "./transform-messages.js";
 
 const ANTHROPIC_CACHE_CONTROL_LIMIT = 4;
 const EMPTY_ERROR_TOOL_RESULT_TEXT = "[tool error with no output]";
+const ANTHROPIC_IMAGE_MEDIA_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"] as const;
+type AnthropicImageMediaType = (typeof ANTHROPIC_IMAGE_MEDIA_TYPES)[number];
+const ANTHROPIC_IMAGE_MEDIA_TYPE_SET = new Set<string>(ANTHROPIC_IMAGE_MEDIA_TYPES);
+
+function resolveAnthropicImageMediaType(value: string): AnthropicImageMediaType {
+  if (ANTHROPIC_IMAGE_MEDIA_TYPE_SET.has(value)) {
+    return value as AnthropicImageMediaType;
+  }
+  throw new Error(`Unsupported Anthropic image media type after normalization: ${value}`);
+}
 
 function getCacheControl(
   model: Model<"anthropic-messages">,
@@ -144,13 +155,22 @@ const ccToolLookup = new Map(claudeCodeTools.map((t) => [t.toLowerCase(), t]));
 // Convert tool name to CC canonical casing if it matches (case-insensitive)
 const toClaudeCodeName = (name: string) => ccToolLookup.get(name.toLowerCase()) ?? name;
 
+async function normalizeInlineContentBlocks(
+  content: readonly (TextContent | ImageContent)[],
+): Promise<Array<TextContent | ImageContent>> {
+  if (!content.some((block) => block.type === "image")) {
+    return content.filter((block): block is TextContent => block.type === "text");
+  }
+  return await getAiTransportHost().normalizeAnthropicInlineContentBlocks(content);
+}
+
 /**
  * Convert content blocks to Anthropic API format
  */
-function convertContentBlocks(
+async function convertContentBlocks(
   content: readonly unknown[],
   isError: boolean,
-):
+): Promise<
   | string
   | Array<
       | { type: "text"; text: string }
@@ -162,7 +182,8 @@ function convertContentBlocks(
             data: string;
           };
         }
-    > {
+    >
+> {
   const text = extractToolResultText(content);
   const mediaPlaceholder = describeToolResultMediaPlaceholder(content);
   const hasImages =
@@ -205,16 +226,22 @@ function convertContentBlocks(
     if (record.type !== "image") {
       continue;
     }
+    const [normalizedImage] = await normalizeInlineContentBlocks([
+      {
+        type: "image" as const,
+        data: typeof record.data === "string" ? record.data : "",
+        mimeType: typeof record.mimeType === "string" ? record.mimeType : "image/jpeg",
+      },
+    ]);
+    if (normalizedImage?.type !== "image") {
+      continue;
+    }
     blocks.push({
       type: "image" as const,
       source: {
         type: "base64" as const,
-        media_type: (typeof record.mimeType === "string" ? record.mimeType : "image/jpeg") as
-          | "image/jpeg"
-          | "image/png"
-          | "image/gif"
-          | "image/webp",
-        data: typeof record.data === "string" ? record.data : "",
+        media_type: resolveAnthropicImageMediaType(normalizedImage.mimeType),
+        data: normalizedImage.data,
       },
     });
   }
@@ -578,7 +605,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
         isOAuth = created.isOAuthToken;
         serverSideFallback = created.serverSideFallback;
       }
-      const builtParams = buildParams(
+      const builtParams = await buildParams(
         model,
         requestContext,
         isOAuth,
@@ -1291,16 +1318,16 @@ function createClient(
   return { client, isOAuthToken: false, serverSideFallback };
 }
 
-function buildParams(
+async function buildParams(
   model: Model<"anthropic-messages">,
   context: Context,
   isOAuthTokenResult: boolean,
   options?: AnthropicOptions,
   serverSideFallback = false,
-): {
+): Promise<{
   params: MessageCreateParamsStreaming;
   toolProjection?: AnthropicToolProjection;
-} {
+}> {
   const mandatoryAdaptiveThinking = requiresClaudeAdaptiveThinking(model);
   const replayThinkingEnabled = mandatoryAdaptiveThinking || options?.thinkingEnabled === true;
   const { cacheControl } = getCacheControl(model, options?.cacheRetention);
@@ -1325,7 +1352,7 @@ function buildParams(
   );
   const params: MessageCreateParamsStreaming = {
     model: model.id,
-    messages: convertMessages(
+    messages: await convertMessages(
       context.messages,
       model,
       isOAuthTokenResult,
@@ -1428,14 +1455,14 @@ function normalizeToolCallId(id: string): string {
   return id.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
 }
 
-function convertMessages(
+async function convertMessages(
   messages: Message[],
   model: Model<"anthropic-messages">,
   isOAuthTokenValue: boolean,
   cacheControl?: CacheControlEphemeral,
   messageCacheControlLimit = 4,
   replayThinkingEnabled = true,
-): MessageParam[] {
+): Promise<MessageParam[]> {
   const params: MessageParam[] = [];
   // Param indexes for transient runtime-context carriers — excluded from
   // cache_control breakpoint selection so the deepest breakpoint anchors on the
@@ -1464,7 +1491,8 @@ function convertMessages(
           });
         }
       } else {
-        const blocks: ContentBlockParam[] = msg.content.map((item) => {
+        const normalizedContent = await normalizeInlineContentBlocks(msg.content);
+        const blocks: ContentBlockParam[] = normalizedContent.map((item) => {
           if (item.type === "text") {
             return {
               type: "text",
@@ -1475,7 +1503,7 @@ function convertMessages(
             type: "image",
             source: {
               type: "base64",
-              media_type: item.mimeType as "image/jpeg" | "image/png" | "image/gif" | "image/webp",
+              media_type: resolveAnthropicImageMediaType(item.mimeType),
               data: item.data,
             },
           };
@@ -1574,7 +1602,7 @@ function convertMessages(
       toolResults.push({
         type: "tool_result",
         tool_use_id: msg.toolCallId,
-        content: convertContentBlocks(msg.content, msg.isError),
+        content: await convertContentBlocks(msg.content, msg.isError),
         is_error: msg.isError,
       });
 
@@ -1584,7 +1612,7 @@ function convertMessages(
         toolResults.push({
           type: "tool_result",
           tool_use_id: nextMsg.toolCallId,
-          content: convertContentBlocks(nextMsg.content, nextMsg.isError),
+          content: await convertContentBlocks(nextMsg.content, nextMsg.isError),
           is_error: nextMsg.isError,
         });
         j++;

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -3220,6 +3220,71 @@ describe("anthropic transport stream", () => {
     expect(toolResult.is_error).toBe(false);
   });
 
+  it("normalizes unsupported user image blocks to jpeg before Anthropic transport payloads", async () => {
+    // JPEG magic bytes mislabeled as HEIC: normalizer must rewrite media_type.
+    const imageData = Buffer.from([
+      0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
+    ]).toString("base64");
+
+    await runTransportStream(
+      makeAnthropicTransportModel({ input: ["text", "image"] }),
+      {
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "look" },
+              { type: "image", data: imageData, mimeType: "image/heic" },
+            ],
+          },
+        ],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    const userMessage = findRecord(
+      latestAnthropicRequest().payload.messages,
+      (record) => record.role === "user",
+    );
+    const imageBlock = findRecord(userMessage.content, (record) => record.type === "image");
+    expect(imageBlock).toMatchObject({
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: "image/jpeg",
+        data: imageData,
+      },
+    });
+  });
+
+  it("keeps non-vision transport downgrade behavior without decoding dropped images", async () => {
+    await runTransportStream(
+      makeAnthropicTransportModel({ input: ["text"] }),
+      {
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "look" },
+              { type: "image", data: "not-base64", mimeType: "image/heic" },
+            ],
+          },
+        ],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    const userMessage = findRecord(
+      latestAnthropicRequest().payload.messages,
+      (record) => record.role === "user",
+    );
+    expect(userMessage.content).toMatchObject([{ type: "text", text: "look" }]);
+  });
+
   it("cancels stalled SSE body reads when the abort signal fires mid-stream", async () => {
     const controller = new AbortController();
     const abortReason = new Error("anthropic test abort");

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -62,6 +62,7 @@ import type {
   ThinkingLevel,
 } from "../llm/types.js";
 import "../llm/ai-transport-host.js";
+import { normalizeAnthropicInlineContentBlocks } from "../media/anthropic-inline-images.js";
 import { looksLikeSecretSentinel, resolveSecretSentinel } from "../secrets/sentinel.js";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../shared/assistant-error-format.js";
 import {
@@ -339,7 +340,7 @@ function toClaudeCodeName(name: string): string {
   return CLAUDE_CODE_TOOL_LOOKUP.get(normalizeLowercaseStringOrEmpty(name)) ?? name;
 }
 
-function convertContentBlocks(content: readonly unknown[]) {
+async function convertContentBlocks(content: readonly unknown[]) {
   const text = extractToolResultText(content);
   const mediaPlaceholder = describeToolResultMediaPlaceholder(content);
   const hasImages =
@@ -372,12 +373,22 @@ function convertContentBlocks(content: readonly unknown[]) {
     if (record.type !== "image") {
       continue;
     }
+    const [normalizedImage] = await normalizeAnthropicInlineContentBlocks([
+      {
+        type: "image" as const,
+        data: typeof record.data === "string" ? record.data : "",
+        mimeType: typeof record.mimeType === "string" ? record.mimeType : "image/png",
+      },
+    ]);
+    if (normalizedImage?.type !== "image") {
+      continue;
+    }
     blocks.push({
       type: "image" as const,
       source: {
         type: "base64",
-        media_type: typeof record.mimeType === "string" ? record.mimeType : "image/png",
-        data: typeof record.data === "string" ? record.data : "",
+        media_type: normalizedImage.mimeType,
+        data: normalizedImage.data,
       },
     });
   }
@@ -391,7 +402,7 @@ function normalizeToolCallId(id: string): string {
   return id.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
 }
 
-function convertAnthropicMessages(
+async function convertAnthropicMessages(
   messages: Context["messages"],
   model: AnthropicTransportModel,
   isOAuthToken: boolean,
@@ -400,7 +411,7 @@ function convertAnthropicMessages(
     cacheBreakpointOptOutMessageIndexes: Set<number>;
     replayThinkingEnabled?: boolean;
   },
-): Array<Record<string, unknown>> {
+): Promise<Array<Record<string, unknown>>> {
   const params: Array<Record<string, unknown>> = [];
   const allowReasoningContentReplay = options.allowReasoningContentReplay === true;
   const replayThinkingEnabled = options.replayThinkingEnabled !== false;
@@ -425,13 +436,17 @@ function convertAnthropicMessages(
         }
         continue;
       }
+      // Non-vision models drop images before decode so unsupported MIME never hits the host.
+      const normalizedContent = model.input.includes("image")
+        ? await normalizeAnthropicInlineContentBlocks(msg.content)
+        : msg.content;
       const blocks: Array<
         | { type: "text"; text: string }
         | {
             type: "image";
             source: { type: "base64"; media_type: string; data: string };
           }
-      > = msg.content.map((item) =>
+      > = normalizedContent.map((item) =>
         item.type === "text"
           ? {
               type: "text",
@@ -559,7 +574,7 @@ function convertAnthropicMessages(
         {
           type: "tool_result",
           tool_use_id: toolResult.toolCallId,
-          content: convertContentBlocks(toolResult.content),
+          content: await convertContentBlocks(toolResult.content),
           is_error: toolResult.isError,
         },
       ];
@@ -572,7 +587,7 @@ function convertAnthropicMessages(
         toolResults.push({
           type: "tool_result",
           tool_use_id: nextMsg.toolCallId,
-          content: convertContentBlocks(nextMsg.content),
+          content: await convertContentBlocks(nextMsg.content),
           is_error: nextMsg.isError,
         });
         j += 1;
@@ -989,15 +1004,15 @@ function createAnthropicTransportClient(params: {
   };
 }
 
-function buildAnthropicParams(
+async function buildAnthropicParams(
   model: AnthropicTransportModel,
   context: Context,
   isOAuthToken: boolean,
   options: AnthropicTransportOptions | undefined,
-): {
+): Promise<{
   params: Record<string, unknown>;
   toolProjection?: AnthropicToolProjection;
-} {
+}> {
   const mandatoryAdaptiveThinking = requiresClaudeAdaptiveThinking(model);
   const replayThinkingEnabled = mandatoryAdaptiveThinking || options?.thinkingEnabled === true;
   const maxTokens = resolveAnthropicMessagesMaxTokens({
@@ -1019,7 +1034,7 @@ function buildAnthropicParams(
   // Transient runtime-context carrier indexes skip cache anchoring so the breakpoint
   // stays on the last stable user turn; conversion-to-policy must not splice messages.
   const cacheBreakpointOptOutMessageIndexes = new Set<number>();
-  const messages = convertAnthropicMessages(context.messages, model, isOAuthToken, {
+  const messages = await convertAnthropicMessages(context.messages, model, isOAuthToken, {
     allowReasoningContentReplay: supportsReasoningContentReplay(model),
     cacheBreakpointOptOutMessageIndexes,
     replayThinkingEnabled,
@@ -1237,7 +1252,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
           apiKey,
           options: transportOptions,
         });
-        const builtParams = buildAnthropicParams(
+        const builtParams = await buildAnthropicParams(
           model,
           requestContext,
           isOAuthToken,

--- a/src/llm/ai-transport-host.ts
+++ b/src/llm/ai-transport-host.ts
@@ -6,6 +6,7 @@ import { resolveOpenAIStrictToolSetting } from "../agents/openai-strict-tool-set
 import { buildGuardedModelFetch } from "../agents/provider-transport-fetch.js";
 import { redactSecrets, redactToolPayloadText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { normalizeAnthropicInlineContentBlocks } from "../media/anthropic-inline-images.js";
 import { swapSecretSentinelsInText } from "../secrets/sentinel.js";
 
 const transportLogBySubsystem = new Map<string, ReturnType<typeof createSubsystemLogger>>();
@@ -33,6 +34,7 @@ configureAiTransportHost({
   },
   redactSecrets,
   redactToolPayloadText,
+  normalizeAnthropicInlineContentBlocks,
   resolveOpenAIStrictToolSetting,
   logDebug: (subsystem, build) => {
     const log = transportLog(subsystem);

--- a/src/media/anthropic-inline-images.test.ts
+++ b/src/media/anthropic-inline-images.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const convertImageToJpegMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./image-ops.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./image-ops.js")>();
+  return {
+    ...actual,
+    convertImageToJpeg: (...args: unknown[]) => convertImageToJpegMock(...args),
+  };
+});
+
+import { normalizeAnthropicInlineContentBlocks } from "./anthropic-inline-images.js";
+
+const TINY_JPEG = Buffer.from([
+  0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
+]);
+
+describe("normalizeAnthropicInlineContentBlocks", () => {
+  afterEach(() => {
+    convertImageToJpegMock.mockReset();
+  });
+
+  it("keeps already-supported mime types without re-encoding", async () => {
+    const data = TINY_JPEG.toString("base64");
+    const out = await normalizeAnthropicInlineContentBlocks([
+      { type: "text", text: "caption" },
+      { type: "image", data, mimeType: "image/png" },
+    ]);
+
+    expect(convertImageToJpegMock).not.toHaveBeenCalled();
+    expect(out).toEqual([
+      { type: "text", text: "caption" },
+      { type: "image", data, mimeType: "image/png" },
+    ]);
+  });
+
+  it("rewrites media_type from detected magic when declaration is unsupported", async () => {
+    // JPEG bytes labeled HEIC: detectMime should accept without convertImageToJpeg.
+    const data = TINY_JPEG.toString("base64");
+    const out = await normalizeAnthropicInlineContentBlocks([
+      { type: "image", data, mimeType: "image/heic" },
+    ]);
+
+    expect(convertImageToJpegMock).not.toHaveBeenCalled();
+    expect(out).toEqual([{ type: "image", data, mimeType: "image/jpeg" }]);
+  });
+
+  it("transcodes unsupported bytes to jpeg when magic is not provider-supported", async () => {
+    const source = Buffer.from("not-a-real-image-payload");
+    const converted = Buffer.from("jpeg-bytes");
+    convertImageToJpegMock.mockResolvedValueOnce(converted);
+
+    const out = await normalizeAnthropicInlineContentBlocks([
+      {
+        type: "image",
+        data: source.toString("base64"),
+        mimeType: "image/tiff",
+      },
+    ]);
+
+    expect(convertImageToJpegMock).toHaveBeenCalledTimes(1);
+    expect(out).toEqual([
+      {
+        type: "image",
+        data: converted.toString("base64"),
+        mimeType: "image/jpeg",
+      },
+    ]);
+  });
+});

--- a/src/media/anthropic-inline-images.ts
+++ b/src/media/anthropic-inline-images.ts
@@ -1,0 +1,78 @@
+/**
+ * Anthropic Messages accepts only jpeg/png/gif/webp for inline base64 images.
+ * Normalize declared MIME (and bytes when needed) before payload construction so
+ * HEIC/TIFF and mislabeled supported bytes do not 400 the whole turn.
+ */
+import { canonicalizeBase64 } from "@openclaw/media-core/base64";
+import { detectMime, normalizeMimeType } from "@openclaw/media-core/mime";
+import { convertImageToJpeg } from "./image-ops.js";
+
+const ANTHROPIC_SUPPORTED_IMAGE_MIMES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+] as const;
+
+type AnthropicSupportedImageMime = (typeof ANTHROPIC_SUPPORTED_IMAGE_MIMES)[number];
+
+type AnthropicInlineTextBlock = { type: "text"; text: string };
+type AnthropicInlineImageBlock = { type: "image"; data: string; mimeType: string };
+type AnthropicInlineBlock = AnthropicInlineTextBlock | AnthropicInlineImageBlock;
+type NormalizedAnthropicInlineImageBlock = Omit<AnthropicInlineImageBlock, "mimeType"> & {
+  mimeType: AnthropicSupportedImageMime;
+};
+type NormalizedAnthropicInlineBlock =
+  | AnthropicInlineTextBlock
+  | NormalizedAnthropicInlineImageBlock;
+
+const ANTHROPIC_SUPPORTED_IMAGE_MIME_SET = new Set<string>(ANTHROPIC_SUPPORTED_IMAGE_MIMES);
+
+function isAnthropicSupportedImageMime(
+  value: string | undefined,
+): value is AnthropicSupportedImageMime {
+  return typeof value === "string" && ANTHROPIC_SUPPORTED_IMAGE_MIME_SET.has(value);
+}
+
+async function normalizeAnthropicInlineImage(block: AnthropicInlineImageBlock): Promise<{
+  data: string;
+  mimeType: AnthropicSupportedImageMime;
+}> {
+  const canonicalData = canonicalizeBase64(block.data) ?? block.data.trim();
+  const declaredMime = normalizeMimeType(block.mimeType);
+  // Supported declaration: keep bytes as-is (no re-encode tax on common paths).
+  if (isAnthropicSupportedImageMime(declaredMime)) {
+    return { data: canonicalData, mimeType: declaredMime };
+  }
+
+  const buffer = Buffer.from(canonicalData, "base64");
+  // Mislabeled but already-supported bytes (e.g. JPEG snuck in as image/heic).
+  const detectedMime = normalizeMimeType(await detectMime({ buffer, headerMime: block.mimeType }));
+  if (isAnthropicSupportedImageMime(detectedMime)) {
+    return { data: canonicalData, mimeType: detectedMime };
+  }
+
+  // Real HEIC/TIFF/etc.: re-encode to JPEG so media_type matches the bytes.
+  const normalizedBuffer = await convertImageToJpeg(buffer);
+  return {
+    data: normalizedBuffer.toString("base64"),
+    mimeType: "image/jpeg",
+  };
+}
+
+/** Normalize text/image content blocks for Anthropic Messages inline image rules. */
+export async function normalizeAnthropicInlineContentBlocks(
+  content: readonly AnthropicInlineBlock[],
+): Promise<NormalizedAnthropicInlineBlock[]> {
+  return await Promise.all(
+    content.map(async (block) => {
+      if (block.type !== "image") {
+        return block;
+      }
+      return {
+        ...block,
+        ...(await normalizeAnthropicInlineImage(block)),
+      };
+    }),
+  );
+}

--- a/src/media/image-ops.ts
+++ b/src/media/image-ops.ts
@@ -145,10 +145,19 @@ export async function resizeToJpeg(params: ResizeToJpegParams): Promise<Buffer> 
   }
 }
 
+/** Converts image bytes into JPEG through the shared image processor. */
+export async function convertImageToJpeg(buffer: Buffer): Promise<Buffer> {
+  try {
+    return (await createImageProcessor().encode(buffer, { format: "jpeg" })).data;
+  } catch (error) {
+    return wrapRastermillUnavailable("convertImageToJpeg", error);
+  }
+}
+
 /** Converts HEIC/HEIF-like image bytes into JPEG through the shared image processor. */
 export async function convertHeicToJpeg(buffer: Buffer): Promise<Buffer> {
   try {
-    return (await createImageProcessor().encode(buffer, { format: "jpeg" })).data;
+    return await convertImageToJpeg(buffer);
   } catch (error) {
     return wrapRastermillUnavailable("convertHeicToJpeg", error);
   }


### PR DESCRIPTION
Fixes #102323

## What Problem This Solves

Fixes an issue where users sending within-limit HEIC/TIFF (or otherwise unsupported) images to Claude/Anthropic would get a 400 and no reply, because OpenClaw forwarded the real `media_type` into Anthropic Messages image blocks. The same bytes succeed on OpenAI and Gemini.

## Why This Change Was Made

Anthropic accepts only `image/jpeg`, `image/png`, `image/gif`, and `image/webp`. Gateway/media-understanding already normalized HEIC on some paths, but packaged Anthropic adapter and custom Messages transport still cast MIME at the type layer with no runtime conversion.

This adds one host-owned normalizer that detects supported magic, otherwise re-encodes to JPEG, and runs it before payload construction for user and tool-result images on both Anthropic surfaces.

## User Impact

Anthropic vision turns with iPhone HEIC / TIFF / mislabeled supported bytes should no longer die with provider 400; models that do not support images keep the existing omit/placeholder behavior.

## Evidence

Focused Vitest after patch:

```text
node scripts/run-vitest.mjs packages/ai/src/providers/anthropic.test.ts \
  src/media/anthropic-inline-images.test.ts \
  src/agents/anthropic-transport-stream.test.ts
→ 178 tests passed (71 + 3 + 104)

Filtered behavior cases:
- normalizes unsupported user/tool image blocks before Anthropic payloads
- rewrites media_type from detected JPEG magic when labeled image/heic
- transcodes unsupported bytes via convertImageToJpeg
- non-vision paths still omit images without host decode
```

Also: `node scripts/run-oxlint.mjs` on touched files → 0 findings; branch autoreview clean.

## Real behavior proof

- Behavior addressed: Anthropic Messages payload must not emit unsupported `media_type` (e.g. `image/heic`) for inline base64 images; bytes and MIME must be provider-legal.
- Environment: macOS local openclaw checkout; Node 24; `node scripts/run-vitest.mjs` (unit/media/agents shards).
- Current-main contrast: on main, `packages/ai/src/providers/anthropic.ts` and `src/agents/anthropic-transport-stream.ts` pass `mimeType` through as `media_type` (TS cast only). A HEIC-labeled block reaches the request as `media_type: "image/heic"`.
- Exact steps or command run after this patch:
  1. Build a user message with JPEG magic bytes and `mimeType: "image/heic"`.
  2. Drive packaged `streamAnthropic` / custom transport with `onPayload` / guarded fetch capture.
  3. Assert outgoing image `source.media_type` is `image/jpeg` (or other supported type), never `image/heic`.
- Evidence after fix: focused tests above pass; transport stream captures `media_type: "image/jpeg"` for the HEIC-labeled JPEG case; media unit proves magic rewrite without re-encode and transcode path for true unsupported bytes.
- Control check: already-supported MIME path does not call `convertImageToJpeg`; non-vision models omit images before normalization (no decode of dropped images).
- Observed result after fix: unsupported declared MIME is corrected or re-encoded before Anthropic payload construction on both adapter and transport paths.
- What was not tested: live authenticated call to `api.anthropic.com` with a real HEIC file (no paid API key in this run); end-to-end channel delivery of HEIC attachments.

## AI disclosure

This PR was authored with AI assistance (Grok). Implementation follows ClawSweeper’s shared normalizer + dual-path guidance for #102323.
