### PR TITLE
fix(agents): use truncateUtf16Safe for duplicate message debug log truncation

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.messages.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.messages.ts
@@ -3,6 +3,7 @@
  * streams, reply directives, and pending tool media attachment handoff.
  */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { createInlineCodeState } from "../../packages/markdown-core/src/code-spans.js";
@@ -1306,7 +1307,7 @@ export function handleMessageEnd(
           )
         ) {
           ctx.log.debug(
-            `Skipping message_end block reply - already sent via messaging tool: ${text.slice(0, 50)}...`,
+            `Skipping message_end block reply - already sent via messaging tool: ${truncateUtf16Safe(text, 50)}...`,
           );
         } else {
           const alreadyDeliveredFinalText = Boolean(

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -1,5 +1,6 @@
 /**
  * Subscribes to embedded-agent sessions and streams formatted replies/events.
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
  */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { InlineCodeState } from "../../packages/markdown-core/src/code-spans.js";
@@ -1057,7 +1058,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
           messagingToolSentTextsNormalized,
         ));
     if (isMessagingDuplicate) {
-      log.debug(`Skipping block reply - already sent via messaging tool: ${chunk.slice(0, 50)}...`);
+      log.debug(`Skipping block reply - already sent via messaging tool: ${truncateUtf16Safe(chunk, 50)}...`);
       if (prefixReplayCandidate) {
         markBlockReplyTextHandled();
       }


### PR DESCRIPTION
## What Problem This Solves

Two `.slice(0, 50)` truncation sites in embedded agent message handling debug logs may cut UTF-16 surrogate pairs in half when the message text contains multi-byte characters such as emoji.

## Why This Change Was Made

`src/agents/embedded-agent-subscribe.handlers.messages.ts` and `src/agents/embedded-agent-subscribe.ts` use raw `.slice(0, 50)` for debug log text truncation. Replacing with `truncateUtf16Safe` ensures the logged text is always valid Unicode.

## User Impact

Debug log output for duplicate message detection remains valid Unicode at existing size limits. No behavioral or API changes.

## Evidence

- Mechanical replacement: `.slice(0, 50)` to `truncateUtf16Safe(str, 50)` for two sites
- No runtime behavior change for ASCII or valid Unicode input

Generated with Claude Code