### PR TITLE
fix(agent-runner-memory): use truncateUtf16Safe for memory flush error truncation

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -476,7 +476,7 @@ describe("runMemoryFlushIfNeeded", () => {
     const visibleErrorPayloads: Array<{ text?: string; isError?: boolean }> = [];
     const token = "sk-abcdefghijklmnopqrstuv";
     runWithModelFallbackMock.mockRejectedValueOnce(
-      new Error(`provider failed with Authorization: Bearer ${token} ${"x".repeat(800)}`),
+      new Error(`provider failed with Authorization: Bearer ${token} ${"🚀".repeat(400)}`),
     );
 
     await runMemoryFlushIfNeeded({
@@ -501,54 +501,7 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(payload?.text).toMatch(/^⚠️ provider failed with Authorization: Bearer /);
     expect(payload?.text).not.toContain(token);
     expect(payload?.text?.length).toBeLessThanOrEqual(600);
-    expect(payload?.text?.endsWith("…")).toBe(true);
-  });
-
-  it("keeps persisted and visible memory-flush errors UTF-16 safe at their caps", async () => {
-    const storePath = path.join(rootDir, "sessions.json");
-    const sessionEntry: SessionEntry = {
-      sessionId: "session",
-      updatedAt: Date.now(),
-      totalTokens: 80_000,
-      compactionCount: 1,
-    };
-    await writeTestSessionStore(storePath, "main", sessionEntry);
-    const visibleErrorPayloads: ReplyPayload[] = [];
-    const message = `${"a".repeat(198)}🚀${"b".repeat(395)}🚀${"c".repeat(20)}`;
-    runWithModelFallbackMock.mockRejectedValueOnce(new Error(message));
-
-    await runMemoryFlushIfNeeded({
-      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
-      followupRun: createTestFollowupRun(),
-      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
-      defaultModel: "anthropic/claude-opus-4-7",
-      agentCfgContextTokens: 100_000,
-      resolvedVerboseLevel: "off",
-      sessionEntry,
-      sessionStore: { main: sessionEntry },
-      sessionKey: "main",
-      storePath,
-      isHeartbeat: false,
-      replyOperation: createReplyOperation(),
-      onVisibleErrorPayloads: (payloads) => {
-        visibleErrorPayloads.push(...payloads);
-      },
-    });
-
-    const persisted = JSON.parse(await fs.readFile(storePath, "utf8")) as {
-      main: SessionEntry;
-    };
-    const persistedError = persisted.main.memoryFlushLastFailureError;
-    const visibleError = visibleErrorPayloads[0]?.text;
-    const loneSurrogate =
-      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u;
-
-    expect(persistedError).toBe(`${"a".repeat(198)}…`);
-    expect(persistedError?.length).toBeLessThanOrEqual(200);
-    expect(persistedError).not.toMatch(loneSurrogate);
-    expect(visibleError).toBe(`⚠️ ${"a".repeat(198)}🚀${"b".repeat(395)}…`);
-    expect(visibleError?.length).toBeLessThanOrEqual(600);
-    expect(visibleError).not.toMatch(loneSurrogate);
+    expect(payload?.text?.endsWith("🚀…")).toBe(true);
   });
 
   it("does not surface user-abort errors as visible payloads (regression: #80755)", async () => {
@@ -583,7 +536,7 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(visibleErrorPayloads).toEqual([]);
   });
 
-  it("increments memoryFlushFailureCount on non-abort flush failure", async () => {
+  it("increments and UTF-16-safely persists a capped non-abort flush failure", async () => {
     const storePath = path.join(rootDir, "sessions.json");
     const sessionEntry: SessionEntry = {
       sessionId: "session",
@@ -592,7 +545,8 @@ describe("runMemoryFlushIfNeeded", () => {
       compactionCount: 1,
     };
     await writeTestSessionStore(storePath, "main", sessionEntry);
-    runWithModelFallbackMock.mockRejectedValueOnce(new Error("provider crashed during flush"));
+    const failureMessage = `${"a".repeat(198)}🚀tail`;
+    runWithModelFallbackMock.mockRejectedValueOnce(new Error(failureMessage));
 
     const result = await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
@@ -613,7 +567,7 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(result.outcome).toBe("failed");
     expect(persisted.main.memoryFlushFailureCount).toBe(1);
     expect(persisted.main.memoryFlushLastFailedAt).toBe(1_700_000_000_000);
-    expect(persisted.main.memoryFlushLastFailureError).toContain("provider crashed during flush");
+    expect(persisted.main.memoryFlushLastFailureError).toBe(`${"a".repeat(198)}…`);
     expect(emitAgentEventMock).toHaveBeenCalledWith(
       expect.objectContaining({
         stream: "lifecycle",

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -504,6 +504,53 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(payload?.text?.endsWith("…")).toBe(true);
   });
 
+  it("keeps persisted and visible memory-flush errors UTF-16 safe at their caps", async () => {
+    const storePath = path.join(rootDir, "sessions.json");
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 80_000,
+      compactionCount: 1,
+    };
+    await writeTestSessionStore(storePath, "main", sessionEntry);
+    const visibleErrorPayloads: ReplyPayload[] = [];
+    const message = `${"a".repeat(198)}🚀${"b".repeat(395)}🚀${"c".repeat(20)}`;
+    runWithModelFallbackMock.mockRejectedValueOnce(new Error(message));
+
+    await runMemoryFlushIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun(),
+      sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
+      defaultModel: "anthropic/claude-opus-4-7",
+      agentCfgContextTokens: 100_000,
+      resolvedVerboseLevel: "off",
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      storePath,
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+      onVisibleErrorPayloads: (payloads) => {
+        visibleErrorPayloads.push(...payloads);
+      },
+    });
+
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf8")) as {
+      main: SessionEntry;
+    };
+    const persistedError = persisted.main.memoryFlushLastFailureError;
+    const visibleError = visibleErrorPayloads[0]?.text;
+    const loneSurrogate =
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u;
+
+    expect(persistedError).toBe(`${"a".repeat(198)}…`);
+    expect(persistedError?.length).toBeLessThanOrEqual(200);
+    expect(persistedError).not.toMatch(loneSurrogate);
+    expect(visibleError).toBe(`⚠️ ${"a".repeat(198)}🚀${"b".repeat(395)}…`);
+    expect(visibleError?.length).toBeLessThanOrEqual(600);
+    expect(visibleError).not.toMatch(loneSurrogate);
+  });
+
   it("does not surface user-abort errors as visible payloads (regression: #80755)", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "session",

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -6,6 +6,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { estimateMessagesTokens } from "../../agents/compaction.js";
 import { classifyCompactionReason } from "../../agents/embedded-agent-runner/compact-reasons.js";
@@ -364,7 +365,7 @@ function buildMemoryFlushErrorPayload(err: unknown): ReplyPayload | undefined {
   return {
     text:
       visibleText.length > MAX_VISIBLE_MEMORY_FLUSH_ERROR_CHARS
-        ? `${visibleText.slice(0, MAX_VISIBLE_MEMORY_FLUSH_ERROR_CHARS - 1)}…`
+        ? `${truncateUtf16Safe(visibleText, MAX_VISIBLE_MEMORY_FLUSH_ERROR_CHARS - 1)}…`
         : visibleText,
     isError: true,
   };
@@ -373,7 +374,7 @@ function buildMemoryFlushErrorPayload(err: unknown): ReplyPayload | undefined {
 function truncateMemoryFlushErrorMessage(err: unknown): string {
   const message = normalizeOptionalString(formatErrorMessage(err)) || String(err);
   return message.length > MAX_FLUSH_ERROR_LENGTH
-    ? `${message.slice(0, MAX_FLUSH_ERROR_LENGTH - 1)}…`
+    ? `${truncateUtf16Safe(message, MAX_FLUSH_ERROR_LENGTH - 1)}…`
     : message;
 }
 


### PR DESCRIPTION
## What Problem This Solves

The production UTF-16-safe memory-flush truncation fix already landed through #102823. This PR now retains the unique regression coverage needed to keep both shipped boundaries from returning to raw surrogate-splitting slices:

- the 600-code-unit user-visible memory-flush error payload; and
- the 200-code-unit persisted memory-flush failure message.

Relative to current `main`, the repaired branch is a test-only `+6/-5` delta in the existing agent-runner memory integration test module.

## Why This Change Was Made

The two existing behavior tests now place emoji directly across their real truncation boundaries instead of checking only long ASCII text or an uncapped generic error. This proves the existing production helper keeps complete surrogate pairs while preserving redaction, length caps, ellipses, failure counters, timestamps, and persisted session state.

The branch also removes a redundant 47-line combined test in favor of strengthening those two owner-path regressions. It does not reapply or change the production fix from #102823.

## User Impact

No additional runtime behavior changes beyond #102823. The retained tests prevent future regressions that could corrupt emoji or other supplementary-plane characters in visible or persisted memory-flush errors.

## Evidence

Final exact head: `6b7095f05add4ff013a48aa5981bee1667511065` (valid GitHub-verified maintainer signature; original contributor credit preserved).

- Current-main tree comparison: `src/auto-reply/reply/agent-runner-memory.ts` is byte-identical; only `src/auto-reply/reply/agent-runner-memory.test.ts` differs (`+6/-5`).
- Visible 600-unit boundary: a secret-bearing provider failure with 400 rocket emoji must stay redacted, remain at or below 600 code units, and end with the complete `🚀…` suffix.
- Persisted 200-unit boundary: a failure containing 198 ASCII code units followed by `🚀tail` must persist exactly 198 ASCII code units plus `…`, while retaining the failure count and timestamp assertions.
- Sanitized AWS GREEN proof: [Crabbox `run_b8a5f2bc7e95`](https://crabbox.openclaw.ai/portal/runs/run_b8a5f2bc7e95), 47/47 focused-module tests passed on the exact hosted head with public networking, no Tailscale, no hydration, and no instance profile.
- Exact RED control: [Crabbox `run_10558da929c0`](https://crabbox.openclaw.ai/portal/runs/run_10558da929c0). Replacing only the two safe production truncations with their former raw slices made exactly the two strengthened tests fail; the harness emitted `EXPECTED_RED_CONFIRMED test_exit=1 failures=2`.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/29027946216): 66 passed, 0 failed, 0 pending.
- Fresh autoreview: no accepted/actionable findings, overall confidence 0.99.
- Static proof: `oxfmt --write src/auto-reply/reply/agent-runner-memory.test.ts`; `git diff --check`.

Known proof gaps: none for this test-only current-main delta.

## Files Changed

| File | Change |
|------|--------|
| `src/auto-reply/reply/agent-runner-memory.test.ts` | Strengthen the two existing visible/persisted boundary regressions and remove the redundant combined test. |
