### PR TITLE
fix(run-diagnostics): use truncateUtf16Safe for diagnostic truncation

### DIFF
--- a/src/cron/run-diagnostics.ts
+++ b/src/cron/run-diagnostics.ts
@@ -1,5 +1,6 @@
 /** Builds bounded, redacted diagnostics for cron run logs and UI surfaces. */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { isToolAllowedByPolicyName } from "../agents/tool-policy-match.js";
 import { normalizeToolName as normalizePolicyToolName } from "../agents/tool-policy.js";
 import { getReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
@@ -101,7 +102,7 @@ function normalizeDiagnosticMessage(value: unknown): { message?: string; truncat
   if (redacted.length <= MAX_ENTRY_CHARS) {
     return { message: redacted };
   }
-  return { message: `${redacted.slice(0, MAX_ENTRY_CHARS - 1)}…`, truncated: true };
+  return { message: `${truncateUtf16Safe(redacted, MAX_ENTRY_CHARS - 1)}…`, truncated: true };
 }
 
 function trimSummary(value: string | undefined): string | undefined {
@@ -112,7 +113,7 @@ function trimSummary(value: string | undefined): string | undefined {
   if (normalized.length <= MAX_SUMMARY_CHARS) {
     return normalized;
   }
-  return `${normalized.slice(0, MAX_SUMMARY_CHARS - 1)}…`;
+  return `${truncateUtf16Safe(normalized, MAX_SUMMARY_CHARS - 1)}…`;
 }
 
 /** Returns the operator-facing summary for persisted cron diagnostics. */


### PR DESCRIPTION
## What Problem This Solves

Cron run diagnostics use raw UTF-16 code-unit slices in `normalizeDiagnosticMessage` (1000-char limit) and `trimSummary` (120-char limit). A diagnostic value containing an emoji at the cutoff could produce an unpaired surrogate in persistence or UI surfaces.

## Why This Change Was Made

Replace both raw `.slice(0, N-1)` calls with `truncateUtf16Safe`. The existing limits, redaction order, and ellipsis suffixes remain unchanged.

## User Impact

Cron run diagnostic messages and summaries remain valid Unicode when tool output or error text contains emoji or other supplementary characters at the truncation boundary.

## Evidence

- `npx vitest run src/cron/run-diagnostics.test.ts` — 1 file, 12 tests passed.

## Files Changed

| File | Change |
|------|--------|
| `src/cron/run-diagnostics.ts` | Replace two raw `.slice(0,N)` calls with `truncateUtf16Safe` in `normalizeDiagnosticMessage` and `trimSummary`. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)