### PR TITLE
fix(gateway): accept Mac approval usage timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Mac node approvals:** accept the Mac App's fractional usage timestamps when validating file-backed approval snapshots, restoring CLI policy reads and updates through newer Gateways. (#102673)
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Mac node approvals:** accept the Mac App's fractional usage timestamps when validating file-backed approval snapshots, restoring CLI policy reads and updates through newer Gateways. (#102673)
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.

--- a/packages/gateway-protocol/src/exec-approvals-validators.test.ts
+++ b/packages/gateway-protocol/src/exec-approvals-validators.test.ts
@@ -26,7 +26,9 @@ describe("exec approvals protocol validators", () => {
               source: "allow-always" as const,
               commandText: "python3 -c 'print(123)'",
               argPattern: "-c *",
-              lastUsedAt: 1775154056736,
+              // The Mac App records Date.timeIntervalSince1970, which retains
+              // sub-millisecond precision when converted to milliseconds.
+              lastUsedAt: 1775154056736.5,
               lastUsedCommand: "python3 -c 'print(123)'",
               lastResolvedPath: "/usr/bin/python3",
             },

--- a/packages/gateway-protocol/src/schema/exec-approvals.ts
+++ b/packages/gateway-protocol/src/schema/exec-approvals.ts
@@ -16,7 +16,7 @@ export const ExecApprovalsAllowlistEntrySchema = Type.Object(
     source: Type.Optional(Type.Literal("allow-always")),
     commandText: Type.Optional(Type.String()),
     argPattern: Type.Optional(Type.String()),
-    lastUsedAt: Type.Optional(Type.Integer({ minimum: 0 })),
+    lastUsedAt: Type.Optional(Type.Number({ minimum: 0 })),
     lastUsedCommand: Type.Optional(Type.String()),
     lastResolvedPath: Type.Optional(Type.String()),
   },


### PR DESCRIPTION
Closes #102673

## What Problem This Solves

Fixes an issue where users managing Mac App nodes through a newer Gateway could not read or update execution approvals once the Mac had recorded a fractional `lastUsedAt` timestamp. The supported CLI path failed with `node returned invalid exec approvals payload`.

## Why This Change Was Made

The shipped Mac App stores usage time as a Swift `Double` derived from `Date().timeIntervalSince1970 * 1000`. The protocol now accepts that already-shipped non-negative numeric representation instead of requiring an integer; all other strict snapshot validation remains unchanged.

## User Impact

Operators can again use `openclaw approvals get/set --node <mac-node>` for Mac App nodes with existing allowlist usage metadata. Invalid, negative, or structurally ambiguous approval snapshots remain rejected.

## Evidence

- Before: live Mac App 2026.6.11 with a current-main Gateway returned `node returned invalid exec approvals payload`; the redacted snapshot contained `lastUsedAt: 1783586483176.501`.
- Focused Testbox: `pnpm test packages/gateway-protocol/src/exec-approvals-validators.test.ts` — 6 passed.
- Changed-surface Testbox: `pnpm check:changed` — passed (core production, core tests, docs/changelog lanes).
- Fresh autoreview: clean, no accepted/actionable findings; confidence 0.99.
- AI-assisted change; implementation and live root cause reviewed by the maintainer agent.
