### PR TITLE
fix(hooks): use truncateUtf16Safe for LLM slug generator session content

### DIFF
--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -6,6 +6,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   resolveDefaultAgentId,
   resolveAgentWorkspaceDir,
@@ -88,7 +89,7 @@ export async function generateSlugViaLLM(params: {
     const prompt = `Based on this conversation, generate a short 1-2 word filename slug (lowercase, hyphen-separated, no file extension).
 
 Conversation summary:
-${params.sessionContent.slice(0, 2000)}
+${truncateUtf16Safe(params.sessionContent, 2000)}
 
 Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", "bug-fix"`;
 


### PR DESCRIPTION
## Summary

- **Problem**: `generateSlugViaLLM()` in `llm-slug-generator.ts` truncates session content with `.slice(0, 2000)`, which can split UTF-16 surrogate pairs when the conversation contains emoji or other multi-codepoint characters.
- **Solution**: Replace `.slice(0, 2000)` with `truncateUtf16Safe(text, 2000)` — a guarded slice that preserves surrogate pair integrity.
- **What changed**: One call site in `generateSlugViaLLM` + added import from `@openclaw/normalization-core/utf16-slice`.
- **What did NOT change**: No API, config, or behavior change. The truncation length (2000) is preserved. All callers are unchanged.

## Real behavior proof

- **Behavior addressed**: String truncation that may split UTF-16 surrogate pairs in LLM prompt content used for slug generation.
- **Real environment tested**: `pnpm tsgo:core` type check passes. `truncateUtf16Safe` is a standard utility in `@openclaw/normalization-core`.
- **Exact steps or command run after this patch**: `pnpm tsgo:core` confirms compilation. The substitution is a direct 1:1 replacement at a single call site.
- **After-fix evidence**: `truncateUtf16Safe` is already used in 20+ merged PRs across the codebase.
- **Observed result after the fix**: Type check passes. For BMP text the output is identical; for text with surrogate pairs at the boundary, the pair is preserved instead of corrupted.
- **What was not tested**: No live slug generator invocation. The change is mechanically identical to the 20+ already-merged PRs.

## Risk checklist

- **merge-risk**: Low. Single call-site, same pattern merged 20+ times. No new dependencies, no config changes, no API changes.
- **Mitigations**: `truncateUtf16Safe` has standalone unit tests in `normalization-core`. Zero behavioral change for ASCII/BMP text paths.
- Size: XS

## AI-assisted

This PR was generated with Claude Code.