### PR TITLE
fix(gateway-protocol): accept fractional timestamps in exec approvals allowlist schema

### DIFF
--- a/packages/gateway-protocol/src/exec-approvals-validators.test.ts
+++ b/packages/gateway-protocol/src/exec-approvals-validators.test.ts
@@ -45,6 +45,33 @@ describe("exec approvals protocol validators", () => {
     ).toBe(true);
   });
 
+  it("accepts fractional timestamps from Mac App node snapshots", () => {
+    const file = {
+      version: 1 as const,
+      agents: {
+        main: {
+          allowlist: [
+            {
+              id: "entry-1",
+              pattern: "/usr/bin/python3",
+              lastUsedAt: 1775154056736.789,
+              lastUsedCommand: "python3 -c 'print(123)'",
+            },
+          ],
+        },
+      },
+    };
+
+    expect(validateExecApprovalsSetParams({ file, baseHash: "abc123" })).toBe(true);
+    expect(
+      validateExecApprovalsNodeSetParams({
+        nodeId: "mac-node-1",
+        file,
+        baseHash: "abc123",
+      }),
+    ).toBe(true);
+  });
+
   it("accepts the shipped Windows node approval contract", () => {
     expect(
       validateExecApprovalsNodeSnapshot({

--- a/packages/gateway-protocol/src/schema/exec-approvals.ts
+++ b/packages/gateway-protocol/src/schema/exec-approvals.ts
@@ -16,7 +16,7 @@ export const ExecApprovalsAllowlistEntrySchema = Type.Object(
     source: Type.Optional(Type.Literal("allow-always")),
     commandText: Type.Optional(Type.String()),
     argPattern: Type.Optional(Type.String()),
-    lastUsedAt: Type.Optional(Type.Integer({ minimum: 0 })),
+    lastUsedAt: Type.Optional(Type.Number({ minimum: 0 })),
     lastUsedCommand: Type.Optional(Type.String()),
     lastResolvedPath: Type.Optional(Type.String()),
   },


### PR DESCRIPTION
## What Problem This Solves

The Mac App stores `lastUsedAt` as `Double` from `Date().timeIntervalSince1970 * 1000`, which can produce fractional milliseconds (e.g., `1775154056736.789`). The Gateway Protocol schema previously required `Type.Integer({ minimum: 0 })` for this field, causing the Gateway to reject valid Mac App approval snapshots with the error `node returned invalid exec approvals payload`. This blocks Mac node operators from inspecting or updating execution approvals through the CLI.

## Why This Change Was Made

Changed `lastUsedAt` in `ExecApprovalsAllowlistEntrySchema` from `Type.Integer({ minimum: 0 })` to `Type.Number({ minimum: 0 })`. This accepts both integer and fractional non-negative timestamps while preserving the `minimum: 0` security constraint that rejects negative values.

The runtime type `ExecAllowlistEntry.lastUsedAt?: number` in `src/infra/exec-approvals.types.ts` and the UI type `ExecApprovalsAllowlistEntry.lastUsedAt?: number` in `ui/src/lib/nodes/index.ts` already use TypeScript `number`, which encompasses both integer and float, so no runtime type changes are needed. The Gateway-side `Date.now()` calls that set `lastUsedAt` continue to produce integer values; only the Mac App produces fractional ones.

## User Impact

- Mac App nodes with `lastUsedAt` fractional timestamps will no longer be rejected by the Gateway
- `openclaw approvals get --node <mac-node> --json` will succeed instead of returning `node returned invalid exec approvals payload`
- Existing integer timestamps remain valid (backward compatible)
- Security constraint preserved: negative values still rejected by `minimum: 0`

## Evidence

### Before fix

The `ExecApprovalsAllowlistEntrySchema` uses `Type.Integer({ minimum: 0 })` which rejects fractional timestamps:

```
Integer timestamp 1775154056736 >= 0: true  → ACCEPTED by Type.Integer
Fractional timestamp 1775154056736.789 >= 0: true  → REJECTED by Type.Integer (not an integer)
```

Gateway returns: `node returned invalid exec approvals payload`

### After fix

Changed to `Type.Number({ minimum: 0 })`:

```
Integer timestamp 1775154056736 >= 0: true  → ACCEPTED by Type.Number ✓
Fractional timestamp 1775154056736.789 >= 0: true  → ACCEPTED by Type.Number ✓
Negative timestamp -1 >= 0: false  → REJECTED by Type.Number (minimum:0) ✓
```

**Evidence type**: Terminal output / schema validation logic verification
**Setup**: Node 22 on Linux, OpenClaw main at 5154fe08fa0

New test `accepts fractional timestamps from Mac App node snapshots` added to `exec-approvals-validators.test.ts` validates that `validateExecApprovalsSetParams` and `validateExecApprovalsNodeSetParams` both accept `lastUsedAt: 1775154056736.789`.

🤖 / 🛠️ Generated with AI assistance

Fixes #102673
