### PR TITLE
fix(slack): resolve G-prefix channel type ambiguity for mpDM rooms (#102676)

### DIFF
--- a/extensions/slack/src/monitor/channel-type.test.ts
+++ b/extensions/slack/src/monitor/channel-type.test.ts
@@ -1,0 +1,38 @@
+// Channel type normalization tests for Slack mpDM ambiguity (#102676).
+import { describe, expect, it } from "vitest";
+import { normalizeSlackChannelType } from "./channel-type.js";
+
+describe("normalizeSlackChannelType", () => {
+  it("passes explicit mpim through unchanged", () => {
+    expect(normalizeSlackChannelType("mpim", "G123")).toBe("mpim");
+  });
+
+  it("returns im for D-prefix regardless of input", () => {
+    expect(normalizeSlackChannelType(undefined, "D123")).toBe("im");
+    expect(normalizeSlackChannelType(null, "D123")).toBe("im");
+  });
+
+  it("returns channel for C-prefix with no explicit type", () => {
+    expect(normalizeSlackChannelType(undefined, "C123")).toBe("channel");
+    expect(normalizeSlackChannelType(null, "C123")).toBe("channel");
+  });
+
+  it("returns undefined for G-prefix with no explicit type — cannot distinguish mpim from private channel", () => {
+    // Without channel_type, a G-prefixed channel ID is ambiguous
+    // between an mpDM (correct peer kind "group") and a private
+    // channel. When the API fallback in resolveSlackConversationContext
+    // also fails, signaling ambiguity avoids creating a parallel
+    // slack:channel:<id> session alongside the correct one.
+    expect(normalizeSlackChannelType(undefined, "G123")).toBeUndefined();
+    expect(normalizeSlackChannelType(null, "G123")).toBeUndefined();
+  });
+
+  it("still resolves G-prefix when channel_type is explicit", () => {
+    expect(normalizeSlackChannelType("group", "G123")).toBe("group");
+    expect(normalizeSlackChannelType("channel", "G123")).toBe("channel");
+  });
+
+  it("falls back to channel for unknown prefix without channel_type", () => {
+    expect(normalizeSlackChannelType(undefined, "X999")).toBe("channel");
+  });
+});

--- a/extensions/slack/src/monitor/channel-type.ts
+++ b/extensions/slack/src/monitor/channel-type.ts
@@ -41,6 +41,14 @@ export function normalizeSlackChannelType(
     }
     return normalized;
   }
+  // Without an explicit channel_type, a G-prefixed channel ID is ambiguous
+  // between an mpDM and a private channel.  Signal ambiguity (undefined) so
+  // the caller can default the peer kind to "group" instead of creating a
+  // parallel slack:channel:<id> session alongside the correct
+  // slack:group:<id> one (#102676).
+  if (!normalized && inferred === "group") {
+    return undefined;
+  }
   return inferred ?? "channel";
 }
 

--- a/extensions/slack/src/monitor/monitor.test.ts
+++ b/extensions/slack/src/monitor/monitor.test.ts
@@ -244,7 +244,10 @@ describe("normalizeSlackChannelType", () => {
   it("infers channel types from ids when missing", () => {
     expect(normalizeSlackChannelType(undefined, "C123")).toBe("channel");
     expect(normalizeSlackChannelType(undefined, "D123")).toBe("im");
-    expect(normalizeSlackChannelType(undefined, "G123")).toBe("group");
+    // G-prefix is ambiguous (mpDM vs private channel) without an
+    // explicit channel_type — return undefined so the caller can
+    // default the peer kind to "group" (#102676).
+    expect(normalizeSlackChannelType(undefined, "G123")).toBeUndefined();
   });
 
   it("prefers explicit channel_type values", () => {


### PR DESCRIPTION
## Summary

When a Slack multi-party DM (`mpim`) receives a bot-authored message, the Slack event shape omits `channel_type`. The code's intent is a single consistent classification via `normalizeSlackChannelType` (which maps `mpim` to `"mpim"`), but without an explicit `channel_type`, the prefix-inference fallback (`inferSlackChannelType`) returns `"group"` for `G`-prefixed channel IDs. That makes `isRoom = true` in `resolveSlackConversationContext`, which keys the session as `slack:channel:<id>`. Human messages in the same room carry `channel_type: "mpim"` and correctly key as `slack:group:<id>` — producing **two parallel sessions per agent per room**.

Fixes #102676.

## What Problem This Solves

In a Slack mpDM with multiple agents and bot messages enabled:

- Human-authored messages: `channel_type: "mpim"` → `isGroupDm = true` → session `slack:group:<id>` ✅
- Bot-authored messages: no `channel_type` → `isRoom = true` → session `slack:channel:<id>` ❌

Consequences: split conversation state, `/reset` can't reach the twin, stale-context replies from the twin look like command failures.

## Why This Change Was Made

`G`-prefixed Slack channel IDs are ambiguous between **mpDMs** (correct peer kind `"group"`) and **private channels** (peer kind `"channel"`). Without an explicit `channel_type` from the event or the channel-info API, the prefix alone cannot disambiguate. `resolveSlackConversationContext` already attempts a channel-info API lookup (with `is_mpim` support in `resolveChannelName`), but when that lookup fails or returns empty, the ambiguous prefix-inferred `"group"` makes `isRoom = true` and the session key diverges.

This fix signals ambiguity explicitly: `normalizeSlackChannelType` returns `undefined` for a `G`-prefixed channel ID with no explicit `channel_type`. In `resolveSlackConversationContext`, that makes both `isRoom` and `isGroupDm` false, and `resolveSlackRoutingContext` defaults the peer kind to `"group"` — matching the mpDM session key that human messages already produce.

- Explicit `channel_type` values (`"mpim"`, `"group"`, `"channel"`) are **unaffected** — they route through the existing `if` branch.
- `C`/`D` prefix inference is **unchanged**.
- All existing callers handle `undefined` safely (strict `===` guards, `channelType ?? "channel"` fallbacks).

## Changes

- `extensions/slack/src/monitor/channel-type.ts`: `normalizeSlackChannelType` returns `undefined` for `G`-prefixed IDs with no explicit `channel_type`.
- `extensions/slack/src/monitor/channel-type.test.ts`: new test file covering the G-prefix ambiguity, explicit types, and other prefixes.
- `extensions/slack/src/monitor/monitor.test.ts`: updated the existing `G`-prefix assertion to match the new ambiguity-aware behavior.

## User Impact

mpDM rooms with multiple agents no longer split into dual sessions. Bot-authored messages now key the same `slack:group:<id>` session as human-authored messages, so conversation state stays unified, `/reset` reaches all turns, and stale-context replies from a ghost twin session can no longer appear.

## Evidence

### 1. Real setup transcript (standalone script, real code)

Driving the real `normalizeSlackChannelType` then the `prepare-routing` peer-kind logic on four inbound shapes:

```
human msg: channel_type=mpim, G-prefix     | normalized=mpim      | peer_kind=group
bot msg  : channel_type absent, G-prefix    | normalized=undefined | peer_kind=group
bot msg  : channel_type absent, C-prefix    | normalized=channel   | peer_kind=channel
bot msg  : channel_type absent, D-prefix    | normalized=im        | peer_kind=group
```

Key: the `G`-prefix bot message now resolves to `peer_kind=group` instead of `channel`, matching the human mpDM message. `C`/`D`/explicit `mpim` behavior is unchanged.

### 2. Regression tests

New `normalizeSlackChannelType` test file (6 tests) covers the G-ambiguity case, explicit types, and other prefixes. `monitor.test.ts` updated for the ambiguity-aware behavior. `oxlint` on all changed files passes clean.

## AI-assisted

This PR was AI-assisted (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
