### PR TITLE
auto-reply: pass through provider periodic usage-limit reset copy

### DIFF
--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -30,6 +30,7 @@ import { stableStringify } from "../stable-stringify.js";
 import {
   isBillingErrorMessage,
   isOverloadedErrorMessage,
+  isPeriodicUsageLimitErrorMessage,
   isRateLimitErrorMessage,
   isTimeoutErrorMessage,
 } from "./failover-matches.js";
@@ -95,7 +96,7 @@ const HTTP_ERROR_HINTS = [
   "permission",
 ];
 const RATE_LIMIT_SPECIFIC_HINT_RE =
-  /\bmin(ute)?s?\b|\bhours?\b|\bseconds?\b|\btry again in\b|\breset\b|\bplan\b|\bquota\b/i;
+  /\bmin(ute)?s?\b|\bhours?\b|\bseconds?\b|\btry again in\b|\bresets?\b|\bplan\b|\bquota\b/i;
 const MODEL_CAPACITY_ERROR_RE = /\b(?:selected\s+)?model\s+(?:is\s+)?at capacity\b/i;
 const NON_ERROR_PROVIDER_PAYLOAD_MAX_LENGTH = 16_384;
 const NON_ERROR_PROVIDER_PAYLOAD_PREFIX_RE = /^codex\s*error(?:\s+\d{3})?[:\s-]+/i;
@@ -130,7 +131,10 @@ export function formatRateLimitOrOverloadedErrorCopy(raw: string): string | unde
   if (MODEL_CAPACITY_ERROR_RE.test(raw)) {
     return MODEL_CAPACITY_ERROR_USER_MESSAGE;
   }
-  const isRateLimit = isRateLimitErrorMessage(raw);
+  // Periodic (daily/weekly/monthly) usage-limit copy doesn't match the generic
+  // rate-limit text patterns, but it still carries actionable provider reset
+  // wording (e.g. "resets 6pm (UTC)") that's worth preserving (#102598).
+  const isRateLimit = isRateLimitErrorMessage(raw) || isPeriodicUsageLimitErrorMessage(raw);
   if (isRateLimit) {
     const providerMessage = extractProviderRateLimitMessage(raw);
     if (providerMessage) {

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -7329,6 +7329,35 @@ describe("runAgentTurnWithFallback", () => {
     }
   });
 
+  it.each(NON_DIRECT_FAILURE_SURFACE_CASES)(
+    "surfaces periodic usage-limit cooldown copy instead of silencing it in $label chats",
+    async (testCase) => {
+      // Regression for #102598: periodic (daily/weekly/monthly) usage-limit copy doesn't
+      // match isRateLimitErrorMessage's text patterns, so the typed FailoverError.reason
+      // must be consulted or this gets misclassified as a generic failure and silenced.
+      state.runEmbeddedAgentMock.mockRejectedValueOnce(
+        new FailoverError("You've hit your weekly limit \u00b7 resets 6pm (UTC)", {
+          reason: "rate_limit",
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+        }),
+      );
+
+      const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+      const result = await runAgentTurnWithFallback(
+        createMinimalRunAgentTurnParams({
+          sessionCtx: createNonDirectFailureSessionCtx(testCase),
+        }),
+      );
+
+      expect(result.kind).toBe("final");
+      if (result.kind === "final") {
+        expect(result.payload.text).not.toBe(SILENT_REPLY_TOKEN);
+        expect(result.payload.text).not.toBe(GENERIC_RUN_FAILURE_TEXT);
+      }
+    },
+  );
+
   it("preserves neutral billing guidance after fallback exhaustion", async () => {
     state.runWithModelFallbackMock.mockRejectedValueOnce(
       Object.assign(new Error("All models failed (1): openai/gpt-5.5: billing"), {

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -173,6 +173,12 @@ vi.mock("../../agents/embedded-agent-helpers.js", async () => {
       if (/model\s+(?:is\s+)?at capacity/i.test(message)) {
         return "⚠️ Selected model is at capacity. Try a different model, or wait and retry.";
       }
+      // Periodic (daily/weekly/monthly) usage-limit copy carries the provider's own reset
+      // wording (e.g. "resets 6pm (UTC)") and should pass through, mirroring the real
+      // extractProviderRateLimitMessage behavior (#102598).
+      if (/\b(?:daily|weekly|monthly)\s+(?:usage\s+)?limit/i.test(message)) {
+        return `⚠️ ${message}`;
+      }
       if (/rate.limit|too many requests|429/i.test(message)) {
         return "⚠️ API rate limit reached. Please try again later.";
       }
@@ -7354,6 +7360,10 @@ describe("runAgentTurnWithFallback", () => {
       if (result.kind === "final") {
         expect(result.payload.text).not.toBe(SILENT_REPLY_TOKEN);
         expect(result.payload.text).not.toBe(GENERIC_RUN_FAILURE_TEXT);
+        // The provider's actual reset wording should pass through instead of the generic
+        // "try again in a few minutes" copy, which is misleading for a ~10h weekly limit.
+        expect(result.payload.text).toContain("resets 6pm (UTC)");
+        expect(result.payload.text).not.toContain("try again in a few minutes");
       }
     },
   );

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -42,6 +42,7 @@ import {
   isRateLimitErrorMessage,
   isTransientHttpError,
 } from "../../agents/embedded-agent-helpers.js";
+import { isPeriodicUsageLimitErrorMessage } from "../../agents/embedded-agent-helpers/failover-matches.js";
 import { sanitizeUserFacingText } from "../../agents/embedded-agent-helpers/sanitize-user-facing-text.js";
 import { isMessagingToolSendAction } from "../../agents/embedded-agent-messaging.js";
 import { mergeEmbeddedAgentRunResultForModelFallbackExhaustion } from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
@@ -685,7 +686,18 @@ function buildRateLimitCooldownMessage(err: unknown): string {
     return BILLING_ERROR_USER_MESSAGE;
   }
   if (!isFallbackSummaryError(err)) {
-    return "⚠️ All models are temporarily rate-limited. Please try again in a few minutes.";
+    // A raw (non-FallbackSummaryError) FailoverError has no numeric cooldown. For periodic
+    // (daily/weekly/monthly) usage limits specifically, the provider's own message already
+    // carries the actual reset wording (e.g. "resets 6pm (UTC)") — prefer that over the
+    // generic "try again in a few minutes" copy, which is misleading for ~10h+ limits
+    // (#102598). Plain transient rate-limit/overload errors keep the generic copy.
+    const periodicLimitCopy = isPeriodicUsageLimitErrorMessage(message)
+      ? formatRateLimitOrOverloadedErrorCopy(message)
+      : undefined;
+    return (
+      periodicLimitCopy ??
+      "⚠️ All models are temporarily rate-limited. Please try again in a few minutes."
+    );
   }
   const expiry = err.soonestCooldownExpiry;
   const now = Date.now();

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1150,7 +1150,13 @@ export function buildKnownAgentRunFailureReplyPayload(params: {
   const isPureTransientSummary = isFallbackSummary
     ? isPureTransientRateLimitSummary(params.err)
     : false;
-  const isRateLimit = isFallbackSummary ? isPureTransientSummary : isRateLimitErrorMessage(message);
+  const isRateLimit = isFallbackSummary
+    ? isPureTransientSummary
+    : isRateLimitErrorMessage(message) ||
+      // Typed FailoverError.reason catches periodic (daily/weekly/monthly) usage-limit
+      // copy that isRateLimitErrorMessage's text patterns don't match (issue #102598).
+      (isFailoverError(params.err) &&
+        (params.err.reason === "rate_limit" || params.err.reason === "overloaded"));
   const rateLimitOrOverloadedCopy =
     !isFallbackSummary || isPureTransientSummary
       ? formatRateLimitOrOverloadedErrorCopy(message)
@@ -3446,7 +3452,10 @@ async function runAgentTurnWithFallbackInternal(
         : false;
       const isRateLimit = isFallbackSummary
         ? isPureTransientSummary
-        : isRateLimitErrorMessage(message);
+        : isRateLimitErrorMessage(message) ||
+          // Typed FailoverError.reason catches periodic (daily/weekly/monthly) usage-limit
+          // copy that isRateLimitErrorMessage's text patterns don't match (issue #102598).
+          (isFailoverError(err) && (err.reason === "rate_limit" || err.reason === "overloaded"));
       const rateLimitOrOverloadedCopy =
         !isFallbackSummary || isPureTransientSummary
           ? formatRateLimitOrOverloadedErrorCopy(message)


### PR DESCRIPTION
## What Problem This Solves
Fixes #102598. Periodic (weekly/monthly) usage-limit failures from providers were silently swallowed or replaced with generic copy in group chats, losing the provider's actual reset-time wording (e.g. "resets 6pm (UTC)").

## Why This Change Was Made
The issue's primary fix (already landed in 8fa63b5e) made `auto-reply` honor the typed `FailoverError.reason` for periodic usage-limit copy. This PR addresses the two secondary copy-quality gaps the issue explicitly called out as "worth fixing in the same pass":

1. `buildRateLimitCooldownMessage` fell back to generic "temporarily rate-limited... try again in a few minutes" text for raw (non-`FallbackSummaryError`) `FailoverError`s, discarding the provider's real periodic-limit wording. It now prefers `formatRateLimitOrOverloadedErrorCopy` when the message is a periodic usage-limit error, and only uses the generic fallback for plain rate-limit errors.
2. `RATE_LIMIT_SPECIFIC_HINT_RE` used `\breset\b`, which does not match "resets" due to the word boundary. Fixed to `\bresets?\b` so provider text like "resets 6pm (UTC)" is correctly extracted. Also widened `formatRateLimitOrOverloadedErrorCopy`'s `isRateLimit` check to include periodic usage-limit messages.

## User Impact
Users in group chats now see the provider's actual periodic usage-limit reset time/copy instead of generic rate-limit boilerplate, matching 1:1 chat behavior.

## Evidence
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts`: 240/240 passed
- `node scripts/run-vitest.mjs src/agents/embedded-agent-helpers/failover-matches.test.ts`: 31/31 passed
- `node scripts/run-vitest.mjs src/agents/embedded-agent-helpers`: 201/201 passed
