### PR TITLE
fix(infra): stop post-test ENOENT in session-cost checks

### DIFF
--- a/src/infra/session-cost-usage.stream-errors.test.ts
+++ b/src/infra/session-cost-usage.stream-errors.test.ts
@@ -3,6 +3,7 @@
 import nodeFs from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { PassThrough } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
@@ -38,13 +39,13 @@ describe("session cost usage stream errors", () => {
       "utf-8",
     );
 
-    const originalCreateReadStream = nodeFs.createReadStream;
-    vi.spyOn(nodeFs, "createReadStream").mockImplementationOnce((...args: unknown[]) => {
-      const stream = originalCreateReadStream.apply(nodeFs, args as never);
+    vi.spyOn(nodeFs, "createReadStream").mockImplementationOnce(() => {
+      const stream = new PassThrough();
+      stream.write(`${JSON.stringify({ type: "session", version: 1, id: "sess-stream-error" })}\n`);
       process.nextTick(() => {
-        stream.emit("error", new Error("stream read failed"));
+        stream.destroy(new Error("stream read failed"));
       });
-      return stream;
+      return stream as unknown as nodeFs.ReadStream;
     });
 
     const logs = await loadSessionLogs({ sessionFile });
@@ -73,14 +74,15 @@ describe("session cost usage stream errors", () => {
       const cachePath = path.join(sessionsDir, ".usage-cost-cache.json");
       const cacheBefore = await fs.readFile(cachePath, "utf-8");
 
-      await fs.appendFile(sessionFile, `${usageEntry("2026-07-06T12:01:00.000Z", 20)}\n`, "utf-8");
-      const originalCreateReadStream = nodeFs.createReadStream;
-      vi.spyOn(nodeFs, "createReadStream").mockImplementationOnce((...args: unknown[]) => {
-        const stream = originalCreateReadStream.apply(nodeFs, args as never);
+      const appendedEntry = `${usageEntry("2026-07-06T12:01:00.000Z", 20)}\n`;
+      await fs.appendFile(sessionFile, appendedEntry, "utf-8");
+      vi.spyOn(nodeFs, "createReadStream").mockImplementationOnce(() => {
+        const stream = new PassThrough();
+        stream.write(appendedEntry);
         process.nextTick(() => {
-          stream.emit("error", new Error("stream read failed"));
+          stream.destroy(new Error("stream read failed"));
         });
-        return stream;
+        return stream as unknown as nodeFs.ReadStream;
       });
 
       await expect(refreshCostUsageCache()).rejects.toThrow("stream read failed");


### PR DESCRIPTION
Related: #101062
Related: #102082

## What Problem This Solves

Fixes an issue where unrelated pull requests could fail the `checks-node-compact-small-5` shard after all tests passed because the session-cost stream-error regression test left a real file stream opening while its temporary directory was removed.

## Why This Change Was Made

Replace both mocked real file streams with in-memory `PassThrough` streams that provide partial input and then fail through `destroy(error)`. This follows the Node stream lifecycle contract, removes the pending file-open race, and leaves production session-cost behavior unchanged.

The first stabilization pattern was contributed by Agent Jack in `#102082` commit `926a6eb205`; this focused change preserves that credit and applies the same correction to the adjacent durable-cache regression test.

## User Impact

No runtime behavior changes. CI no longer intermittently reports a post-test `ENOENT` from this regression test, and both best-effort and strict cache stream-error paths retain deterministic coverage.

## Evidence

- Before: [run 29010470619, attempt 1, job 86092626040](https://github.com/openclaw/openclaw/actions/runs/29010470619/attempts/1/job/86092626040) passed all 229 tests, then Vitest reported the deleted transcript path as an unhandled `ENOENT`.
- Prior-art CI: after the same in-memory-stream correction for the first test, [run 28968876538, job 85959205112](https://github.com/openclaw/openclaw/actions/runs/28968876538/job/85959205112) passed `checks-node-compact-small-5`.
- Blacksmith Testbox `tbx_01kx381mq54s3atqr7pm7ayv6m`: focused test repeated 25 times successfully.
- Blacksmith Testbox: `pnpm test src/infra/session-cost-usage.stream-errors.test.ts src/infra/session-cost-usage.test.ts` -> 2 files, 70 tests passed.
- Blacksmith Testbox: path-scoped `pnpm check:changed` -> core-test typecheck, lint, and repository guards passed.
- `oxfmt --check src/infra/session-cost-usage.stream-errors.test.ts` and `git diff --check` passed.
- Fresh Codex autoreview: no accepted/actionable findings.

AI-assisted with Codex; implementation, failure provenance, upstream stream contract, and validation reviewed by the maintainer.
