### PR TITLE
fix(xai): preserve caller web-search aborts

### DIFF
--- a/extensions/xai/src/web-search-shared.ts
+++ b/extensions/xai/src/web-search-shared.ts
@@ -80,8 +80,16 @@ function isAbortError(error: unknown): boolean {
   );
 }
 
+function isTimeoutAbortError(error: unknown): boolean {
+  if (!isAbortError(error)) {
+    return false;
+  }
+  const cause = error instanceof Error && "cause" in error ? error.cause : undefined;
+  return cause instanceof Error && cause.name === "TimeoutError";
+}
+
 export function wrapXaiWebSearchError(error: unknown, timeoutSeconds: number): never {
-  if (isAbortError(error)) {
+  if (isTimeoutAbortError(error)) {
     throw new Error(
       `xAI web search timed out after ${timeoutSeconds}s. Increase tools.web.search.timeoutSeconds if queries are complex.`,
       { cause: error },

--- a/extensions/xai/web-search.test.ts
+++ b/extensions/xai/web-search.test.ts
@@ -938,6 +938,12 @@ describe("xai web search config resolution", () => {
 
   it("converts internal xAI timeout aborts into structured tool errors", () => {
     const abort = new DOMException("This operation was aborted", "AbortError");
+    (abort as DOMException & { cause?: unknown }).cause = Object.assign(
+      new Error("request timed out"),
+      {
+        name: "TimeoutError",
+      },
+    );
 
     expect(() => wrapXaiWebSearchError(abort, 60)).toThrow("xAI web search timed out after 60s");
 
@@ -947,6 +953,18 @@ describe("xai web search config resolution", () => {
       expect(error).toBeInstanceOf(Error);
       expect((error as Error).name).toBe("Error");
       expect((error as Error).cause).toBe(abort);
+    }
+  });
+
+  it("preserves caller-driven xAI aborts instead of relabeling them as timeouts", () => {
+    const abort = new DOMException("This operation was aborted", "AbortError");
+
+    expect(() => wrapXaiWebSearchError(abort, 60)).toThrow("This operation was aborted");
+
+    try {
+      wrapXaiWebSearchError(abort, 60);
+    } catch (error) {
+      expect(error).toBe(abort);
     }
   });
 });


### PR DESCRIPTION
## What Problem This Solves

xAI web search treated any `AbortError` as a provider timeout. That made caller-driven cancellation look like `tools.web.search.timeoutSeconds` had expired, even when the request was actually aborted by the caller or a wider run cancellation.

## Why This Change Was Made

`wrapXaiWebSearchError()` now only rewrites aborts whose cause is the guarded-fetch `TimeoutError` into the xAI timeout message. Plain caller-driven aborts are preserved so higher layers still see cancellation rather than a fake provider timeout.

The regression tests now cover both cases: the internal guarded-fetch timeout path still becomes the xAI timeout message, while a caller abort stays as the original abort.

## User Impact

Users and operators no longer see misleading xAI timeout errors when a web search was actually canceled by the caller. Real xAI request timeouts still report the existing timeout guidance.

## Evidence

- Local focused test: `node scripts/run-vitest.mjs extensions/xai/web-search.test.ts`
- Local focused test output:
  - `[test] starting test/vitest/vitest.extension-providers.config.ts`
  - `RUN  v4.1.9 /home/0668000995/10288592/git-hub/codex/openclaw`
  - `Test Files  1 passed (1)`
  - `Tests  47 passed (47)`
  - `Duration  42.14s (transform 33.53s, setup 1.10s, import 40.64s, tests 92ms, environment 0ms)`
  - `[test] passed 1 Vitest shard in 52.14s`
