### PR TITLE
fix(gateway): use truncateUtf16Safe for hook console value truncation

### DIFF
--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -5,6 +5,7 @@ import {
   resolveTimestampMsToIsoString,
 } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { sanitizeInboundSystemTags } from "../../auto-reply/reply/inbound-text.js";
 import type { CliDeps } from "../../cli/deps.types.js";
 import { getRuntimeConfig } from "../../config/io.js";
@@ -68,7 +69,7 @@ function sanitizeHookConsoleValue(value: string | undefined): string | undefined
     const code = char.charCodeAt(0);
     return code < 32 || code === 127 ? " " : char;
   }).join("");
-  return withoutControlChars.replace(/\s+/gu, " ").trim().slice(0, 500);
+  return truncateUtf16Safe(withoutControlChars.replace(/\s+/gu, " ").trim(), 500);
 }
 
 function formatHookRunWarningConsoleMessage(params: {


### PR DESCRIPTION
## Summary|Replace unsafe .slice(0,500) with truncateUtf16Safe in sanitizeHookConsoleValue.|## Real behavior proof|**Behavior addressed**: Hook console truncation can cut surrogate pairs.|**Real environment tested**: Node.js v24.14.0, Windows 10 Enterprise LTSC|**After-fix evidence**: truncateUtf16Safe prevents surrogate split.|**Observed result after the fix**: Safe truncation.|**What was not tested**: N/A.|## Risk checklist|- [x] Backwards compatible|## Current review state|- [x] Self-review completed