### PR TITLE
fix(tts-local-cli): use truncateUtf16Safe for speech text log truncation

### DIFF
--- a/extensions/tts-local-cli/speech-provider.ts
+++ b/extensions/tts-local-cli/speech-provider.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { runFfmpeg } from "openclaw/plugin-sdk/media-runtime";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { writeExternalFileWithinRoot } from "openclaw/plugin-sdk/security-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type {
   SpeechProviderConfig,
   SpeechProviderPlugin,
@@ -374,7 +375,7 @@ export function buildCliSpeechProvider(): SpeechProviderPlugin {
         throw new Error("CLI TTS not configured");
       }
 
-      log.debug(`synthesize: text=${req.text.slice(0, 50)}...`);
+      log.debug(`synthesize: text=${truncateUtf16Safe(req.text, 50)}...`);
 
       const temp = await tempWorkspace({
         rootDir: resolvePreferredOpenClawTmpDir(),
@@ -447,7 +448,7 @@ export function buildCliSpeechProvider(): SpeechProviderPlugin {
         throw new Error("CLI TTS not configured");
       }
 
-      log.debug(`synthesizeTelephony: text=${req.text.slice(0, 50)}...`);
+      log.debug(`synthesizeTelephony: text=${truncateUtf16Safe(req.text, 50)}...`);
 
       const temp = await tempWorkspace({
         rootDir: resolvePreferredOpenClawTmpDir(),


### PR DESCRIPTION
## Summary|Replace unsafe req.text.slice(0,50) with truncateUtf16Safe in synthesize debug logs.|## Real behavior proof|**Behavior addressed**: Speech text truncation can cut surrogate pairs.|**Real environment tested**: Node.js v24.14.0, Windows 10 Enterprise LTSC|**After-fix evidence**: truncateUtf16Safe prevents surrogate split.|**Observed result after the fix**: Safe speech text truncation.|**What was not tested**: N/A.|## Risk checklist|- [x] Backwards compatible|## Current review state|- [x] Self-review completed