### PR TITLE
fix(slack): clear room history after replies

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -1338,6 +1338,42 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     }
   });
 
+  it("finalizes room history for open-channel turns after replies", async () => {
+    const slackCtx = createInboundSlackCtx({
+      cfg: { channels: { slack: { enabled: true } } } as OpenClawConfig,
+      defaultRequireMention: false,
+    });
+    slackCtx.historyLimit = 5;
+    slackCtx.resolveUserName = async () => ({ name: "Alice" });
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      createSlackAccount(),
+      createSlackMessage({
+        channel: "C123",
+        channel_type: "channel",
+        text: "new user request",
+        ts: "500.100",
+      }),
+    );
+
+    assertPrepared(prepared);
+    expect(prepared.requireMention).toBe(false);
+    expect(prepared.turn.history).toEqual({
+      isGroup: true,
+      historyKey: prepared.historyKey,
+      historyMap: slackCtx.channelHistories,
+      limit: 5,
+    });
+    expect(slackCtx.channelHistories.get(prepared.historyKey)).toEqual([
+      expect.objectContaining({
+        body: "new user request",
+        messageId: "500.100",
+        sender: "Alice",
+      }),
+    ]);
+  });
+
   it("records skipped no-mention shared images as pending history media", async () => {
     const originalFetch = globalThis.fetch;
     const mockFetch = vi.fn(async () => {

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -1546,7 +1546,7 @@ export async function prepareSlackMessage(params: {
         },
       },
       history:
-        isRoomish && shouldRequireMention
+        isRoomish && ctx.historyLimit > 0
           ? {
               isGroup: true,
               historyKey,


### PR DESCRIPTION
## Summary

- Clear Slack room `channelHistories` after a visible reply is delivered, so the "Chat history since last reply" block resets for open-channel Slack turns too.
- Add a regression test proving open-channel turns now pass the same history finalization metadata that the shared channel turn kernel uses to clear the window.

## Issue/Motivation

Fixes #102687.

Slack room prompts label the rolling context block as "Chat history since last reply", but open-channel turns (`requireMention: false`) recorded inbound messages without providing the shared turn kernel with a history finalizer. After each reply, the in-memory Slack room history therefore kept accumulating until `historyLimit`, unlike sibling channel paths that clear after reply delivery.

## Changes

- Always attach room history finalization metadata when Slack room history is enabled.
- Keep the existing guard off when `historyLimit <= 0`, so disabled history remains disabled.
- Cover the open-channel path with a focused prepare-stage regression test.

## Testing

- `node scripts/run-vitest.mjs extensions/slack/src/monitor/message-handler/prepare.test.ts` — 114 tests passed.
- `corepack pnpm exec oxfmt --check extensions/slack/src/monitor/message-handler/prepare.ts extensions/slack/src/monitor/message-handler/prepare.test.ts` — passed.
- `corepack pnpm exec oxlint extensions/slack/src/monitor/message-handler/prepare.ts extensions/slack/src/monitor/message-handler/prepare.test.ts` — 0 warnings/errors.
- `git diff --check` — passed.
- Diff and commit secret scans — clean.

## What Problem This Solves

Slack open-channel deployments no longer feed already-answered room messages back into later prompts as if they arrived since the last assistant reply. After a visible Slack reply, the shared channel turn finalizer now clears the room history window for the same `historyKey`, matching the prompt title and sibling-channel behavior.

## Evidence

- Regression test added in `extensions/slack/src/monitor/message-handler/prepare.test.ts` asserts an open-channel Slack turn (`requireMention: false`) includes `turn.history` with the room `historyKey`, `historyMap`, and limit.
- The implementation changes only `extensions/slack/src/monitor/message-handler/prepare.ts`, widening the finalizer gate from mention-required rooms to any room with Slack history enabled.
- Local validation: `node scripts/run-vitest.mjs extensions/slack/src/monitor/message-handler/prepare.test.ts` passed all 114 tests.
- Formatting/lint/diff/secret checks listed above passed locally.
