### PR TITLE
fix(qa-lab): keep capture preview truncation UTF-16 safe

### DIFF
--- a/extensions/qa-lab/web/src/ui-render.test.ts
+++ b/extensions/qa-lab/web/src/ui-render.test.ts
@@ -1,6 +1,6 @@
 // Qa Lab UI render tests cover evidence gallery affordances.
 import { describe, expect, it } from "vitest";
-import { renderQaLabUi, type UiState } from "./ui-render.js";
+import { redactCaptureScalar, renderQaLabUi, type UiState } from "./ui-render.js";
 
 function evidenceState(overrides: Partial<UiState> = {}): UiState {
   return {
@@ -409,5 +409,36 @@ describe("QA Lab UI evidence render", () => {
 
     expect(html).toContain("[redacted]");
     expect(html).not.toContain("secret-token");
+  });
+});
+
+describe("redactCaptureScalar", () => {
+  it("keeps long capture previews UTF-16 safe when an emoji crosses the head boundary", () => {
+    const prefix = "a".repeat(279);
+    const value = `${prefix}😀${"b".repeat(200)}`;
+
+    const result = redactCaptureScalar(value);
+
+    expect(result).toContain(prefix);
+    expect(result).toContain("…");
+    expect(result).not.toContain("😀");
+    // A naive .slice(0, 280) would leave a dangling high surrogate at index 279.
+    expect(
+      Array.from(result).every((c) => c.charCodeAt(0) < 0xd800 || c.charCodeAt(0) > 0xdbff),
+    ).toBe(true);
+  });
+
+  it("keeps long capture previews UTF-16 safe when an emoji crosses the tail boundary", () => {
+    const suffix = "z".repeat(79);
+    const value = `${"a".repeat(350)}😀${suffix}`;
+
+    const result = redactCaptureScalar(value);
+
+    expect(result).toContain(suffix);
+    expect(result).toContain("…");
+    expect(result).not.toContain("😀");
+    expect(
+      Array.from(result).every((c) => c.charCodeAt(0) < 0xd800 || c.charCodeAt(0) > 0xdbff),
+    ).toBe(true);
   });
 });

--- a/extensions/qa-lab/web/src/ui-render.ts
+++ b/extensions/qa-lab/web/src/ui-render.ts
@@ -7,6 +7,31 @@ import type {
   QaEvidenceProducerContextFile,
 } from "../../shared/evidence-gallery-types.js";
 
+/** Slices a UTF-16 string without returning dangling surrogate halves at either edge. */
+function sliceUtf16Safe(input: string, start: number, end?: number): string {
+  const len = input.length;
+  let from = start < 0 ? Math.max(len + start, 0) : Math.min(start, len);
+  let to = end === undefined ? len : end < 0 ? Math.max(len + end, 0) : Math.min(end, len);
+  if (to <= from) {
+    return "";
+  }
+  const isHighSurrogate = (codeUnit: number) => codeUnit >= 0xd800 && codeUnit <= 0xdbff;
+  const isLowSurrogate = (codeUnit: number) => codeUnit >= 0xdc00 && codeUnit <= 0xdfff;
+  if (from > 0 && from < len) {
+    const codeUnit = input.charCodeAt(from);
+    if (isLowSurrogate(codeUnit) && isHighSurrogate(input.charCodeAt(from - 1))) {
+      from += 1;
+    }
+  }
+  if (to > 0 && to < len) {
+    const codeUnit = input.charCodeAt(to - 1);
+    if (isHighSurrogate(codeUnit) && isLowSurrogate(input.charCodeAt(to))) {
+      to -= 1;
+    }
+  }
+  return input.slice(from, to);
+}
+
 /* ===== Shared types (unchanged from the bus protocol) ===== */
 
 type Conversation = {
@@ -560,7 +585,7 @@ function isSensitiveCaptureField(label: string): boolean {
   );
 }
 
-function redactCaptureScalar(value: string, label?: string): string {
+export function redactCaptureScalar(value: string, label?: string): string {
   const trimmed = value.trim();
   if (!trimmed) {
     return "";
@@ -572,7 +597,7 @@ function redactCaptureScalar(value: string, label?: string): string {
     return "[redacted]";
   }
   if (trimmed.length > 400) {
-    return `${trimmed.slice(0, 280)}\n…\n${trimmed.slice(-80)}`;
+    return `${sliceUtf16Safe(trimmed, 0, 280)}\n…\n${sliceUtf16Safe(trimmed, -80)}`;
   }
   return trimmed;
 }


### PR DESCRIPTION
Fixes an unsafe UTF-16 truncation in the QA Lab web UI capture preview path.

## What Problem This Solves

`extensions/qa-lab/web/src/ui-render.ts` truncates long captured scalar values for display using raw `.slice(0, 280)` for the head and `.slice(-80)` for the tail. If the captured text contains a supplementary Unicode character (e.g. an emoji) that straddles either boundary, the preview ends up with a dangling surrogate half.

## Why This Change Was Made

Replaced the two raw `.slice()` calls with a local `sliceUtf16Safe` helper that mirrors the implementation in `@openclaw/normalization-core/utf16-slice`. Keeping the helper local avoids importing any plugin SDK barrel into the QA Lab web bundle, so no Node.js built-ins are pulled into the Vite browser build. The scalar redactor is exported so the regression tests can exercise the exact truncation path without rendering the full UI.

## User Impact

QA Lab capture previews remain valid and readable when captured request/response bodies or fields contain emoji or other non-BMP characters.

## Evidence

- Focused regression test: `node scripts/run-vitest.mjs extensions/qa-lab/web/src/ui-render.test.ts --run` passes (9/9 tests).
- The new tests place an emoji immediately after the 279-code-unit head boundary and immediately before the 79-code-unit tail boundary, asserting that the result contains no dangling high/low surrogates.
- `git diff --check` passes.
- `pnpm exec oxfmt --check` passes for the touched files.
- `node scripts/plugin-sdk-surface-report.mjs --check` passes (no plugin SDK surface budget change).
- `pnpm qa:lab:build` completes successfully after the change and produces a smaller bundle:

```text
$ pnpm qa:lab:build
$ vite build --config extensions/qa-lab/web/vite.config.ts
vite v8.1.3 building client environment for production...
✓ 17 modules transformed.
rendering chunks...
computing gzip size...
extensions/qa-lab/web/dist/index.html                   0.44 kB │ gzip:  0.27 kB
extensions/qa-lab/web/dist/assets/index-BlQ-kj4N.css   57.47 kB │ gzip:  9.70 kB
extensions/qa-lab/web/dist/assets/index-CiCf4MpC.js   145.48 kB │ gzip: 33.77 kB

✓ built in 219ms
```