### PR TITLE
fix(streaming): use truncateUtf16Safe for streaming text truncation

### DIFF
--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -1,6 +1,7 @@
 // Channel streaming config normalization and progress-draft formatting helpers.
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatToolDetail, resolveToolDisplay } from "../agents/tool-display.js";
 import { formatToolAggregate } from "../auto-reply/tool-meta.js";
 import type {
@@ -1008,7 +1009,7 @@ function compactPlainProgressLine(line: string, maxChars: number): string {
   const head = sliceCodePoints(line, 0, maxChars - 1).trimEnd();
   const boundary = head.search(/\s+\S*$/u);
   if (boundary > Math.floor(maxChars * 0.6)) {
-    return `${head.slice(0, boundary).trimEnd()}…`;
+    return `${truncateUtf16Safe(head, boundary).trimEnd()}…`;
   }
   return `${head}…`;
 }


### PR DESCRIPTION
## What Problem This Solves

The channel streaming module uses a raw UTF-16 code-unit slice to truncate text at word boundaries. An emoji crossing the boundary could produce an unpaired surrogate in streaming output.

## Why This Change Was Made

Replace `.slice(0, boundary)` with `truncateUtf16Safe` in the streaming word-boundary truncation. The existing boundary calculation and ellipsis suffix remain unchanged.

## Files Changed

| File | Change |
|------|--------|
| `src/channels/streaming.ts` | Replace raw `.slice(0,N)` with `truncateUtf16Safe` in word-boundary truncation. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)