### PR TITLE
fix(gmail-setup): use truncateUtf16Safe for gmail setup output truncation

### DIFF
--- a/src/hooks/gmail-setup-utils.ts
+++ b/src/hooks/gmail-setup-utils.ts
@@ -1,6 +1,7 @@
 // Gmail setup utilities write helper files and normalize Gmail setup settings.
 import fs from "node:fs";
 import path from "node:path";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveExecutable } from "../infra/executable-path.js";
 import { runCommandWithTimeout, type SpawnResult } from "../process/exec.js";
@@ -24,7 +25,7 @@ function trimOutput(value: string): string {
   if (trimmed.length <= MAX_OUTPUT_CHARS) {
     return trimmed;
   }
-  return `${trimmed.slice(0, MAX_OUTPUT_CHARS)}…`;
+  return `${truncateUtf16Safe(trimmed, MAX_OUTPUT_CHARS)}…`;
 }
 
 function formatCommandResultInternal(


### PR DESCRIPTION
## What Problem This Solves

The Gmail setup utility uses a raw UTF-16 code-unit slice to truncate command output at 800 chars. An emoji crossing the boundary could produce an unpaired surrogate in error messages or debug output.

## Why This Change Was Made

Replace `.slice(0, MAX_OUTPUT_CHARS)` with `truncateUtf16Safe` in `trimOutput`. The existing limit and ellipsis suffix remain unchanged.

## Files Changed

| File | Change |
|------|--------|
| `src/hooks/gmail-setup-utils.ts` | Replace raw `.slice(0,N)` with `truncateUtf16Safe` in `trimOutput`. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)