### PR TITLE
fix(security-scanner): use truncateUtf16Safe for evidence truncation

### DIFF
--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -1,6 +1,7 @@
 // Skill security scanner inspects skill files and manifests for unsafe patterns.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { hasErrnoCode } from "../../infra/errors.js";
 import { isPathInside } from "../../security/scan-paths.js";
 
@@ -275,7 +276,7 @@ function truncateEvidence(evidence: string, maxLen = 120): string {
   if (evidence.length <= maxLen) {
     return evidence;
   }
-  return `${evidence.slice(0, maxLen)}…`;
+  return `${truncateUtf16Safe(evidence, maxLen)}…`;
 }
 
 function isBenignMemberExecMatch(line: string, match: RegExpExecArray): boolean {


### PR DESCRIPTION
## What Problem This Solves

The skill security scanner uses a raw UTF-16 code-unit slice to truncate finding evidence at 120 characters. An emoji crossing the boundary could produce an unpaired surrogate in scan reports.

## Why This Change Was Made

Replace `.slice(0, maxLen)` with `truncateUtf16Safe` in `truncateEvidence`. The existing default limit and ellipsis suffix remain unchanged.

## Files Changed

| File | Change |
|------|--------|
| `src/skills/security/scanner.ts` | Replace raw `.slice(0,N)` with `truncateUtf16Safe` in `truncateEvidence`. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)