### PR TITLE
fix(queue-helpers): use truncateUtf16Safe for queue overflow summary truncation

### DIFF
--- a/src/utils/queue-helpers.ts
+++ b/src/utils/queue-helpers.ts
@@ -5,6 +5,8 @@
  * debounce drains, and force individual collection when cross-channel ordering matters.
  */
 /** Mutable summary state for a capped queue. */
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+
 type QueueSummaryState = {
   dropPolicy: "summarize" | "old" | "new";
   droppedCount: number;
@@ -75,7 +77,7 @@ function elideQueueText(text: string, limit = 140): string {
   if (text.length <= limit) {
     return text;
   }
-  return `${text.slice(0, Math.max(0, limit - 1)).trimEnd()}…`;
+  return `${truncateUtf16Safe(text, Math.max(0, limit - 1)).trimEnd()}…`;
 }
 
 /** Normalize whitespace and elide one dropped item for queue summaries. */


### PR DESCRIPTION
## What Problem This Solves

The queue overflow summary helper uses a raw UTF-16 code-unit slice to truncate dropped item text. When the truncation boundary falls between an emoji's surrogate halves, the summary text contains an unpaired surrogate.

## Why This Change Was Made

Replace `.slice(0, limit-1)` with `truncateUtf16Safe` in `summarizeDroppedItem`. The existing limit, trimming, and ellipsis suffix remain unchanged.

## Files Changed

| File | Change |
|------|--------|
| `src/utils/queue-helpers.ts` | Replace raw `.slice(0,N)` with `truncateUtf16Safe` in `summarizeDroppedItem`. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)