### PR TITLE
fix(whatsapp): use truncateUtf16Safe for session error stringify truncation

### DIFF
--- a/extensions/whatsapp/src/session-errors.ts
+++ b/extensions/whatsapp/src/session-errors.ts
@@ -1,4 +1,6 @@
 // Whatsapp plugin module implements session errors behavior.
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+
 function safeStringify(value: unknown, limit = 800): string {
   try {
     const seen = new WeakSet();
@@ -27,7 +29,7 @@ function safeStringify(value: unknown, limit = 800): string {
     if (!raw) {
       return String(value);
     }
-    return raw.length > limit ? `${raw.slice(0, limit)}…` : raw;
+    return raw.length > limit ? `${truncateUtf16Safe(raw, limit)}…` : raw;
   } catch {
     return String(value);
   }


### PR DESCRIPTION
## What Problem This Solves

One `.slice(0, limit)` truncation site in the WhatsApp session errors module may cut UTF-16 surrogate pairs in half when the serialized error value contains multi-byte characters such as emoji.

## Why This Change Was Made

`extensions/whatsapp/src/session-errors.ts` uses raw `.slice(0, limit)` for error string truncation. Replacing with `truncateUtf16Safe` ensures truncated output is always valid Unicode.

## User Impact

Truncated error strings in WhatsApp session errors remain valid Unicode at existing size limits. No behavioral changes for ASCII-only content.

## Evidence

- Mechanical replacement: `.slice(0, limit)` to `truncateUtf16Safe(raw, limit)`
- No runtime behavior change for ASCII or valid Unicode input

Generated with Claude Code