### PR TITLE
fix(crestodian): use truncateUtf16Safe for config get output truncation

### DIFF
--- a/src/crestodian/operations.ts
+++ b/src/crestodian/operations.ts
@@ -11,6 +11,7 @@ import { buildAgentMainSessionKey, normalizeAgentId } from "../routing/session-k
 import type { RuntimeEnv } from "../runtime.js";
 import type { TuiResult } from "../tui/tui-types.js";
 import { resolveUserPath, shortenHomePath } from "../utils.js";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { appendCrestodianAuditEntry, resolveCrestodianAuditPath } from "./audit.js";
 import type { CrestodianOverview } from "./overview.js";
 
@@ -962,7 +963,7 @@ export async function executeCrestodianOperation(
       const rendered = JSON.stringify(redacted, null, 2) ?? "null";
       runtime.log(
         rendered.length > CONFIG_GET_OUTPUT_MAX_CHARS
-          ? `${operation.path} = ${rendered.slice(0, CONFIG_GET_OUTPUT_MAX_CHARS)}\n… (truncated)`
+          ? `${operation.path} = ${truncateUtf16Safe(rendered, CONFIG_GET_OUTPUT_MAX_CHARS)}\n… (truncated)`
           : `${operation.path} = ${rendered}`,
       );
       return { applied: false };


### PR DESCRIPTION
## What Problem This Solves
The Crestodian operations module uses a raw UTF-16 code-unit slice to truncate config-get output values. An emoji crossing the boundary could produce an unpaired surrogate in diagnostic messages.
## Files Changed
| File | Change |
|------|--------|
| `src/crestodian/operations.ts` | Replace `.slice(0,N)` with `truncateUtf16Safe` in config-get output truncation. |
🤖 Generated with [Claude Code](https://claude.com/claude-code)