### PR TITLE
fix(memory-core): use truncateUtf16Safe for short-term promotion truncation

### DIFF
--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -11,6 +11,7 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-status";
 import { appendMemoryHostEvent } from "openclaw/plugin-sdk/memory-host-events";
 import { sleep } from "openclaw/plugin-sdk/runtime-env";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeStringEntries,
@@ -2365,7 +2366,7 @@ function truncatePromotedSnippet(snippet: string, maxTokens: number): string {
       : wordBoundary >= Math.floor(limit * 0.65)
         ? wordBoundary
         : limit;
-  return `${hardLimit.slice(0, cutAt).trimEnd()}...`;
+  return `${truncateUtf16Safe(hardLimit, cutAt).trimEnd()}...`;
 }
 
 function formatPromotedSnippetForMemory(rawSnippet: string, maxTokens: number): string {


### PR DESCRIPTION
## What Problem This Solves
The memory-core short-term promotion module uses a raw UTF-16 code-unit slice to truncate promoted snippet text at a hard limit. An emoji crossing the boundary could produce an unpaired surrogate in the dreaming narrative prompt.
## Files Changed
| File | Change |
|------|--------|
| `extensions/memory-core/src/short-term-promotion.ts` | Replace `.slice(0,cutAt)` with `truncateUtf16Safe` in hard-limit truncation. |
🤖 Generated with [Claude Code](https://claude.com/claude-code)