### PR TITLE
fix(openai): use truncateUtf16Safe for image generation log truncation

### DIFF
--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -12,6 +12,7 @@ import {
   toImageDataUrl,
 } from "openclaw/plugin-sdk/image-generation";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/logging-core";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveClosestSize } from "openclaw/plugin-sdk/media-generation-runtime";
 import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import { MAX_IMAGE_BYTES } from "openclaw/plugin-sdk/media-runtime";
@@ -104,7 +105,7 @@ function sanitizeLogValue(value: unknown): string {
     return "unknown";
   }
   return cleaned.length > LOG_VALUE_MAX_CHARS
-    ? `${cleaned.slice(0, LOG_VALUE_MAX_CHARS)}...`
+    ? `${truncateUtf16Safe(cleaned, LOG_VALUE_MAX_CHARS)}...`
     : cleaned;
 }
 


### PR DESCRIPTION
## What Problem This Solves
The OpenAI image generation provider uses a raw UTF-16 code-unit slice to truncate cleaned error text in logs. An emoji crossing the boundary could produce an unpaired surrogate in diagnostic output.
## Files Changed
| File | Change |
|------|--------|
| `extensions/openai/image-generation-provider.ts` | Replace `.slice(0,N)` with `truncateUtf16Safe` in error-log truncation. |
🤖 Generated with [Claude Code](https://claude.com/claude-code)