### PR TITLE
fix(agent-core): use truncateUtf16Safe for harness truncate output

### DIFF
--- a/packages/agent-core/src/harness/utils/truncate.ts
+++ b/packages/agent-core/src/harness/utils/truncate.ts
@@ -1,4 +1,6 @@
 // Agent Core module implements truncate behavior.
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+
 export const DEFAULT_MAX_LINES = 2000;
 export const DEFAULT_MAX_BYTES = 50 * 1024; // 50KB
 export const GREP_MAX_LINE_LENGTH = 500; // Max chars per grep match line
@@ -382,5 +384,5 @@ export function truncateLine(
       }
     }
   }
-  return { text: `${line.slice(0, cut)}... [truncated]`, wasTruncated: true };
+  return { text: `${truncateUtf16Safe(line, cut)}... [truncated]`, wasTruncated: true };
 }


### PR DESCRIPTION
## What Problem This Solves
The agent-core harness truncation utility uses a raw UTF-16 code-unit slice to truncate lines in truncated content output. An emoji crossing the boundary could produce an unpaired surrogate in tool-output diagnostics.
## Files Changed
| File | Change |
|------|--------|
| `packages/agent-core/src/harness/utils/truncate.ts` | Replace `.slice(0,cut)` with `truncateUtf16Safe` in truncated-text output. |
🤖 Generated with [Claude Code](https://claude.com/claude-code)