### PR TITLE
fix(inworld): use truncateUtf16Safe for TTS error body truncation

### DIFF
--- a/extensions/inworld/tts.ts
+++ b/extensions/inworld/tts.ts
@@ -1,6 +1,7 @@
 // Inworld plugin module implements tts behavior.
 import { MAX_AUDIO_BYTES } from "openclaw/plugin-sdk/media-runtime";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { SpeechVoiceOption } from "openclaw/plugin-sdk/speech-core";
 import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 
@@ -57,7 +58,7 @@ async function readInworldErrorBodySnippet(response: Response): Promise<string> 
 
   const collapsed = buffer.toString("utf8").replace(/\s+/g, " ").trim();
   if (collapsed.length > INWORLD_ERROR_BODY_MAX_CHARS) {
-    return `${collapsed.slice(0, INWORLD_ERROR_BODY_MAX_CHARS)}…`;
+    return `${truncateUtf16Safe(collapsed, INWORLD_ERROR_BODY_MAX_CHARS)}…`;
   }
   return collapsed;
 }


### PR DESCRIPTION
## What Problem This Solves
The Inworld TTS provider uses a raw UTF-16 code-unit slice to truncate error response body snippets. An emoji crossing the 400-char boundary could produce an unpaired surrogate in thrown error messages.
## Files Changed
| File | Change |
|------|--------|
| `extensions/inworld/tts.ts` | Replace `.slice(0,N)` with `truncateUtf16Safe` in error-body truncation. |
🤖 Generated with [Claude Code](https://claude.com/claude-code)