### PR TITLE
fix(llm-slug-generator): use truncateUtf16Safe for session content truncation

### DIFF
--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -6,6 +6,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   resolveDefaultAgentId,
   resolveAgentWorkspaceDir,
@@ -88,7 +89,7 @@ export async function generateSlugViaLLM(params: {
     const prompt = `Based on this conversation, generate a short 1-2 word filename slug (lowercase, hyphen-separated, no file extension).
 
 Conversation summary:
-${params.sessionContent.slice(0, 2000)}
+${truncateUtf16Safe(params.sessionContent, 2000)}
 
 Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", "bug-fix"`;
 
@@ -126,12 +127,13 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
           return null;
         }
         // Clean up the response - extract just the slug
-        const slug = normalizeLowercaseStringOrEmpty(text)
-          .replace(/[^a-z0-9-]/g, "-")
-          .replace(/-+/g, "-")
-          .replace(/^-+|-+$/g, "")
-          .slice(0, 30)
-          .replace(/^-+|-+$/g, ""); // Max 30 chars
+        const slug = truncateUtf16Safe(
+          normalizeLowercaseStringOrEmpty(text)
+            .replace(/[^a-z0-9-]/g, "-")
+            .replace(/-+/g, "-")
+            .replace(/^-+|-+$/g, ""),
+          30,
+        ).replace(/^-+|-+$/g, ""); // Max 30 chars
 
         return slug || null;
       }


### PR DESCRIPTION
## What Problem This Solves
The LLM slug generator uses raw UTF-16 code-unit slices in two places: session content truncation (2000 chars) and slug output truncation (30 chars). An emoji crossing either boundary could produce an unpaired surrogate.
## Files Changed
| File | Change |
|------|--------|
| `src/hooks/llm-slug-generator.ts` | Replace two raw `.slice(0,N)` calls with `truncateUtf16Safe` in session content and slug output truncation. |
🤖 Generated with [Claude Code](https://claude.com/claude-code)