### PR TITLE
fix(agents-cli): use truncateUtf16Safe for session summary truncation

### DIFF
--- a/src/agents/cli-runner/session-history.ts
+++ b/src/agents/cli-runner/session-history.ts
@@ -13,6 +13,7 @@ import {
   selectSessionTranscriptLeafControlledPath,
 } from "../../config/sessions/transcript-tree.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { isPathInside } from "../../infra/path-guards.js";
 import { resolveSessionAgentIds } from "../agent-scope.js";
@@ -214,7 +215,7 @@ export function buildCliSessionHistoryPrompt(params: {
       0,
       maxHistoryChars - truncationMarker.length - separatorBudget - tailBudget,
     );
-    const summaryTruncated = renderedSummary.slice(0, summaryBudget).trimEnd();
+    const summaryTruncated = truncateUtf16Safe(renderedSummary, summaryBudget).trimEnd();
     const tailTruncated = tailBudget > 0 ? tailRaw.slice(-tailBudget).trimStart() : "";
     return [truncationMarker, summaryTruncated, tailTruncated].filter(Boolean).join("\n");
   };


### PR DESCRIPTION
## What Problem This Solves

One `.slice(0, summaryBudget)` truncation site in the CLI session history module may cut UTF-16 surrogate pairs in half when the rendered summary contains multi-byte characters such as emoji.

## Why This Change Was Made

`src/agents/cli-runner/session-history.ts` uses raw `.slice(0, summaryBudget)` for session summary truncation. Replacing with `truncateUtf16Safe` ensures truncated output is always valid Unicode.

## User Impact

Truncated CLI session history summaries remain valid Unicode at existing size limits. No behavioral changes for ASCII-only content.

## Evidence

- Mechanical replacement: `.slice(0, summaryBudget)` to `truncateUtf16Safe`
- No runtime behavior change for ASCII or valid Unicode input

Generated with Claude Code