### PR TITLE
fix(runtime): guard JSON.stringify against circular/poisonous values in tool output

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -84,7 +84,7 @@ function createRuntimeIo(): Pick<OutputRuntimeEnv, "log" | "error" | "writeStdou
       try {
         writeStdout(JSON.stringify(value, null, space > 0 ? space : undefined));
       } catch {
-        writeStdout(JSON.stringify(String(value)));
+        writeStdout(JSON.stringify("[unserializable value]"));
       }
     },
   };
@@ -120,6 +120,6 @@ export function writeRuntimeJson(
   try {
     runtime.log(JSON.stringify(value, null, space > 0 ? space : undefined));
   } catch {
-    runtime.log(JSON.stringify(String(value)));
+    runtime.log(JSON.stringify("[unserializable value]"));
   }
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -81,7 +81,11 @@ function createRuntimeIo(): Pick<OutputRuntimeEnv, "log" | "error" | "writeStdou
     },
     writeStdout,
     writeJson: (value: unknown, space = 2) => {
-      writeStdout(JSON.stringify(value, null, space > 0 ? space : undefined));
+      try {
+        writeStdout(JSON.stringify(value, null, space > 0 ? space : undefined));
+      } catch {
+        writeStdout(JSON.stringify(String(value)));
+      }
     },
   };
 }
@@ -113,5 +117,9 @@ export function writeRuntimeJson(
     runtime.writeJson(value, space);
     return;
   }
-  runtime.log(JSON.stringify(value, null, space > 0 ? space : undefined));
+  try {
+    runtime.log(JSON.stringify(value, null, space > 0 ? space : undefined));
+  } catch {
+    runtime.log(JSON.stringify(String(value)));
+  }
 }


### PR DESCRIPTION
## What Problem This Solves

\`writeJson()\` and \`writeRuntimeJson()\` call \`JSON.stringify(value)\` on arbitrary tool return values. Two failure modes:
1. Circular references → \`TypeError: Converting circular structure to JSON\`
2. Null-prototype objects without \`toString\` → \`String(value)\` fallback also throws

Both crash the runtime output path with unhandled exceptions.

## Why This Change Was Made

Wrap both \`JSON.stringify\` calls in try-catch. Fallback to a constant \`"[unserializable value]"\` string to avoid the secondary crash from \`String(value)\`.

## User Impact

Prevents runtime crashes when tools return circular references or null-prototype objects. Output degrades to \`"[unserializable value]"\` instead of crashing.

## Evidence

\`\`\`
V2 (circular): \"[unserializable value]\"
V2 (null-proto): {\"data\":42}
\`\`\`
- Circular refs: caught → const fallback → no crash
- Null-prototype: JSON.stringify succeeds (own data fields) ✅
- Both writeJson() + writeRuntimeJson() guarded (2 call sites)