### PR TITLE
test(qa): assert Telegram command denial

### DIFF
--- a/qa/scenarios/channels/telegram-repeated-command-authorization.yaml
+++ b/qa/scenarios/channels/telegram-repeated-command-authorization.yaml
@@ -43,17 +43,15 @@ flow:
               - call: waitForTransportReady
                 args: [{ ref: env }, 60000]
               - resetTransport: true
-              - set: deniedStart
-                value:
-                  expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
               - sendInbound:
                   conversation: { id: telegram-command-room, kind: channel }
                   senderId: qa-command-operator
                   senderName: QA Command Operator
                   text: /status@openclaw
-              - waitForNoOutbound:
-                  quietMs: 8000
-                  sinceIndex: { ref: deniedStart }
+              - waitForOutbound:
+                  conversation: { id: telegram-command-room, kind: channel }
+                  textIncludes: You are not authorized to use this command.
+                  timeoutMs: 60000
             finally:
               - call: env.gateway.restartAfterStateMutation
                 args:


### PR DESCRIPTION
## What Problem This Solves

Full release validation at `ff031149f3b13d95d16458d191f18525df9e7e7a` failed twice in the canonical `telegram-repeated-command-authorization` scenario. The scenario expected an unauthorized native command to stay silent, but Telegram’s native-command contract intentionally replies `You are not authorized to use this command.`

## Why This Change Was Made

Assert the explicit denial reply in the correct Telegram conversation, then continue the existing restore-and-repeat flow. This directly proves the operator is blocked while removed from the allowlist and preserves the stronger follow-up proof that `/status`, `/help`, and `/commands` all work after the original allowlist is restored.

## User Impact

No production behavior change. The release QA gate now matches the tested Telegram authorization contract and fails on missing or misrouted denial replies instead of waiting eight seconds for silence.

## Evidence

- Failing release job `86099253970`: both attempts received the expected explicit denial while the prior silence assertion failed; the other 8 canonical scenarios and all 5 secondary Telegram scenarios passed.
- Blacksmith Testbox `tbx_01kx39dekfzbjrqrrxbhfq462f`: 50/50 scenario catalog, canonical scenario, and flow-runner tests passed.
- `oxfmt --check` passed for the scenario YAML.
- `git diff --check` passed.
- Autoreview: clean, no accepted/actionable findings (0.98 confidence).
