### PR TITLE
fix(ui-eventlog): use truncateUtf16Safe for event payload truncation

### DIFF
--- a/ui/src/pages/overview/event-log.ts
+++ b/ui/src/pages/overview/event-log.ts
@@ -4,6 +4,7 @@ import type { EventLogEntry } from "../../api/event-log.ts";
 import { icons } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
 import { formatTimeMs } from "../../lib/format.ts";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatEventPayload } from "../../lib/presenter.ts";
 
 type OverviewEventLogProps = {
@@ -32,7 +33,7 @@ export function renderOverviewEventLog(props: OverviewEventLogProps) {
               <span class="ov-event-log-name">${entry.event}</span>
               ${entry.payload
                 ? html`<span class="ov-event-log-payload muted"
-                    >${formatEventPayload(entry.payload).slice(0, 120)}</span
+                    >${truncateUtf16Safe(formatEventPayload(entry.payload), 120)}</span
                   >`
                 : nothing}
             </div>


### PR DESCRIPTION
## What Problem This Solves

One `.slice(0, 120)` truncation site in the Event Log UI may cut UTF-16 surrogate pairs in half when the event payload text contains multi-byte characters such as emoji.

## Why This Change Was Made

`ui/src/pages/overview/event-log.ts` uses raw `.slice(0, 120)` for event payload display truncation. Replacing with `truncateUtf16Safe` ensures truncated output is always valid Unicode.

## User Impact

Truncated event payload text in the overview UI remains valid Unicode at existing size limits. No behavioral changes for ASCII-only content.

## Evidence

- Mechanical replacement: `.slice(0, 120)` to `truncateUtf16Safe`
- `truncateUtf16Safe` is already used in other UI files
- No runtime behavior change for ASCII or valid Unicode input

Generated with Claude Code