### PR TITLE
fix(ui-skillworkshop): use truncateUtf16Safe for session label truncation

### DIFF
--- a/ui/src/pages/skill-workshop/skill-workshop-page.ts
+++ b/ui/src/pages/skill-workshop/skill-workshop-page.ts
@@ -7,6 +7,7 @@ import { applicationContext, type ApplicationContext } from "../../app/context.t
 import { loadSettings } from "../../app/settings.ts";
 import "../../components/tooltip.ts";
 import { t } from "../../i18n/index.ts";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveSessionKey, searchForSession } from "../../lib/sessions/index.ts";
 import { normalizeAgentId } from "../../lib/sessions/session-key.ts";
 import { filterSkillWorkshopProposals } from "../../lib/skill-workshop/index.ts";
@@ -88,7 +89,7 @@ async function resolveRevisionSessionKey(
 
   const createdKey = await context.sessions.create({
     agentId,
-    label: `Skill Workshop: ${proposal.slug || proposal.key}`.slice(0, 80),
+    label: truncateUtf16Safe(`Skill Workshop: ${proposal.slug || proposal.key}`, 80),
   });
   const sessionKey = resolveSessionKey(createdKey, gatewayHello).trim();
   if (!sessionKey) {


### PR DESCRIPTION
## What Problem This Solves

One `.slice(0, 80)` truncation site in the Skill Workshop UI may cut UTF-16 surrogate pairs in half when the session label contains multi-byte characters such as emoji.

## Why This Change Was Made

`ui/src/pages/skill-workshop/skill-workshop-page.ts` uses raw `.slice(0, 80)` for session label truncation. Replacing with `truncateUtf16Safe` ensures truncated output is always valid Unicode.

## User Impact

Truncated session labels in Skill Workshop remain valid Unicode at existing size limits. No behavioral changes for ASCII-only content.

## Evidence

### Real behavior proof — terminal output

Test scenario: a session label that exceeds the 80-char limit with emoji near the cut boundary.

Scenario A: Cut falls in the middle of surrogate pair
  Test string: 'A'x79 + 🦪 + 'X' (len=82)
  .slice(0,80) produces dangling high surrogate (0xd83e) -> invalid Unicode
  truncateUtf16Safe backs up one code unit -> valid Unicode

Scenario B: emoji entirely beyond cut point
  Both .slice and truncateUtf16Safe produce identical valid output

Scenario C: Actual Skill Workshop label near 80-char boundary
  Both produce valid output

The critical case is Scenario A: when the 80-char cut falls inside a surrogate pair, .slice(0, 80) produces a dangling high surrogate (0xd83e), which is invalid Unicode. truncateUtf16Safe correctly steps back one code unit to avoid breaking the pair.

Full terminal output and reproduction script are available in the PR worktree.

Generated with Claude Code