### PR TITLE
fix(browser): make tool description respect defaultProfile for logged-in browser hint

### DIFF
--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -16,6 +16,7 @@ import {
   BROWSER_REQUEST_GATEWAY_SCOPE,
 } from "./src/browser-gateway-contract.js";
 import { BrowserToolSchema } from "./src/browser-tool.schema.js";
+import { describeBrowserTool } from "./src/browser-tool.descriptions.js";
 
 const EAGER_BROWSER_CONTROL_SERVICE_ENV = "OPENCLAW_EAGER_BROWSER_CONTROL_SERVER";
 
@@ -70,25 +71,10 @@ function createLazyBrowserTool(opts?: {
     chatType?: string;
   };
 }): AnyAgentTool {
-  const targetDefault = opts?.sandboxBridgeUrl ? "sandbox" : "host";
-  const hostHint =
-    opts?.allowHostControl === false ? "Host target blocked by policy." : "Host target allowed.";
   return {
     label: "Browser",
     name: "browser",
-    description: [
-      "Control the browser via OpenClaw's browser control server (status/start/stop/profiles/tabs/open/snapshot/screenshot/actions).",
-      "Browser choice: omit profile by default for the isolated OpenClaw-managed browser (`openclaw`).",
-      'For the logged-in user browser, use profile="user". A supported Chromium-based browser (v144+) must be running on the selected host or browser node. Use only when existing logins/cookies matter and the user is present.',
-      'For profile="user" or other existing-session profiles, omit timeoutMs on act:type, evaluate, hover, scrollIntoView, drag, select, and fill; that driver rejects per-call timeout overrides for those actions.',
-      'When a node-hosted browser proxy is available, the tool may auto-route to it. Pin a node with node=<id|name> or target="node".',
-      "When using refs from snapshot (e.g. e12), keep the same tab: prefer passing targetId from the snapshot response into subsequent actions (act/click/type/etc). For tab operations, targetId also accepts tabId handles (t1) and labels from action=tabs.",
-      "For multi-step browser work, login checks, stale refs, duplicate tabs, or Google Meet flows, use the bundled browser-automation skill when it is available.",
-      'For stable, self-resolving refs across calls, use snapshot with refs="aria" (Playwright aria-ref ids). Default refs="role" are role+name-based.',
-      "Use snapshot+act for UI automation. Avoid act:wait by default; use only in exceptional cases when no reliable UI state exists.",
-      `target selects browser location (sandbox|host|node). Default: ${targetDefault}.`,
-      hostHint,
-    ].join(" "),
+    description: describeBrowserTool({ sandboxBridgeUrl: opts?.sandboxBridgeUrl, allowHostControl: opts?.allowHostControl }),
     parameters: BrowserToolSchema,
     execute: async (toolCallId, args, signal, onUpdate) => {
       const { createBrowserTool } = await loadBrowserRegistrationRuntimeModule();

--- a/extensions/browser/src/browser-tool.descriptions.ts
+++ b/extensions/browser/src/browser-tool.descriptions.ts
@@ -1,0 +1,65 @@
+/**
+ * Dynamic browser tool description builder.
+ *
+ * Builds a model-facing description for the browser tool that adapts to the
+ * configured browser profiles. When a CDP direct-attach profile is configured
+ * as the default (with attachOnly and cdpPort set), the description recommends
+ * the configured default profile instead of the hardcoded "profile=user"
+ * existing-session hint that fails on non-default user-data-dir setups.
+ *
+ * Pattern: bash-tools.descriptions.ts — read runtime config, return conditional text.
+ */
+import { getRuntimeConfig } from "./sdk-config.js";
+
+/** Browser profile config shape read from runtime config. */
+interface BrowserToolProfileConfig {
+  cdpPort?: number;
+  driver?: string;
+  attachOnly?: boolean;
+}
+
+export function describeBrowserTool(opts?: {
+  sandboxBridgeUrl?: string;
+  allowHostControl?: boolean;
+}): string {
+  const targetDefault = opts?.sandboxBridgeUrl ? "sandbox" : "host";
+  const hostHint =
+    opts?.allowHostControl === false ? "Host target blocked by policy." : "Host target allowed.";
+
+  const config = getRuntimeConfig();
+  const browserConfig = config.browser as
+    | {
+        defaultProfile?: string;
+        profiles?: Record<string, BrowserToolProfileConfig>;
+      }
+    | undefined;
+  const defaultProfile = browserConfig?.defaultProfile;
+  const profiles = browserConfig?.profiles;
+  const defaultProfileConfig = defaultProfile && profiles ? profiles[defaultProfile] : undefined;
+
+  // A CDP attach-only profile already has login state via direct Chrome DevTools
+  // Protocol attachment. In that case the model should use the configured default
+  // profile rather than the "user" existing-session profile.
+  const isCdpAttachDefault =
+    defaultProfileConfig &&
+    defaultProfileConfig.cdpPort !== undefined &&
+    defaultProfileConfig.attachOnly === true;
+
+  const profileHint = isCdpAttachDefault
+    ? `The configured default profile (\`${defaultProfile}\`) already has logged-in browser state via CDP direct attach. Use it when existing logins or cookies matter.`
+    : 'For the logged-in user browser, use profile="user". A supported Chromium-based browser (v144+) must be running on the selected host or browser node. Use only when existing logins/cookies matter and the user is present.';
+
+  return [
+    "Control the browser via OpenClaw's browser control server (status/start/stop/profiles/tabs/open/snapshot/screenshot/actions).",
+    "Browser choice: omit profile by default for the isolated OpenClaw-managed browser (`openclaw`).",
+    profileHint,
+    'For existing-session profiles, omit timeoutMs on act:type, evaluate, hover, scrollIntoView, drag, select, and fill; that driver rejects per-call timeout overrides for those actions.',
+    'When a node-hosted browser proxy is available, the tool may auto-route to it. Pin a node with node=<id|name> or target="node".',
+    "When using refs from snapshot (e.g. e12), keep the same tab: prefer passing targetId from the snapshot response into subsequent actions (act/click/type/etc). For tab operations, targetId also accepts tabId handles (t1) and labels from action=tabs.",
+    "For multi-step browser work, login checks, stale refs, duplicate tabs, or Google Meet flows, use the bundled browser-automation skill when it is available.",
+    'For stable, self-resolving refs across calls, use snapshot with refs="aria" (Playwright aria-ref ids). Default refs="role" are role+name-based.',
+    "Use snapshot+act for UI automation. Avoid act:wait by default; use only in exceptional cases when no reliable UI state exists.",
+    `target selects browser location (sandbox|host|node). Default: ${targetDefault}.`,
+    hostHint,
+  ].join(" ");
+}

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -467,6 +467,10 @@ function lastNodeInvokeCall(): ReturnType<typeof nodeInvokeCall> {
 }
 
 describe("browser tool description", () => {
+  afterEach(() => {
+    configMocks.loadConfig.mockImplementation(() => ({ browser: {} }));
+  });
+
   it("warns agents about existing-session act timeout limits", () => {
     const tool = createBrowserTool();
 
@@ -474,6 +478,38 @@ describe("browser tool description", () => {
     expect(tool.description).toContain("omit timeoutMs on act:type");
     expect(tool.description).toContain("existing-session profiles");
     expect(tool.description).toContain("browser-automation skill");
+  });
+
+  it("recommends the configured default profile when CDP attach-only is set", () => {
+    configMocks.loadConfig.mockReturnValue({
+      browser: {
+        defaultProfile: "openclaw",
+        profiles: {
+          openclaw: { cdpPort: 9222, attachOnly: true },
+        },
+      },
+    });
+
+    const tool = createBrowserTool();
+
+    expect(tool.description).toContain("default profile (`openclaw`)");
+    expect(tool.description).toContain("CDP direct attach");
+    expect(tool.description).not.toContain('profile="user"');
+  });
+
+  it("still suggests profile=user when defaultProfile lacks CDP attach", () => {
+    configMocks.loadConfig.mockReturnValue({
+      browser: {
+        defaultProfile: "my-profile",
+        profiles: {
+          "my-profile": { attachOnly: false },
+        },
+      },
+    });
+
+    const tool = createBrowserTool();
+
+    expect(tool.description).toContain('profile="user"');
   });
 });
 

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -53,6 +53,7 @@ import {
   trackSessionBrowserTab,
   untrackSessionBrowserTab,
 } from "./browser-tool.runtime.js";
+import { describeBrowserTool } from "./browser-tool.descriptions.js";
 import { DEFAULT_BROWSER_SCREENSHOT_TIMEOUT_MS } from "./browser/constants.js";
 import { normalizeBrowserScreenshot } from "./browser/screenshot.js";
 import { describeBrowserScreenshot, neutralizeMediaDirectives } from "./browser/vision.js";
@@ -486,25 +487,10 @@ export function createBrowserTool(opts?: {
     chatType?: string;
   };
 }): AnyAgentTool {
-  const targetDefault = opts?.sandboxBridgeUrl ? "sandbox" : "host";
-  const hostHint =
-    opts?.allowHostControl === false ? "Host target blocked by policy." : "Host target allowed.";
   return {
     label: "Browser",
     name: "browser",
-    description: [
-      "Control the browser via OpenClaw's browser control server (status/start/stop/profiles/tabs/open/snapshot/screenshot/actions).",
-      "Browser choice: omit profile by default for the isolated OpenClaw-managed browser (`openclaw`).",
-      'For the logged-in user browser, use profile="user". A supported Chromium-based browser (v144+) must be running on the selected host or browser node. Use only when existing logins/cookies matter and the user is present.',
-      'For profile="user" or other existing-session profiles, omit timeoutMs on act:type, evaluate, hover, scrollIntoView, drag, select, and fill; that driver rejects per-call timeout overrides for those actions.',
-      'When a node-hosted browser proxy is available, the tool may auto-route to it. Pin a node with node=<id|name> or target="node".',
-      "When using refs from snapshot (e.g. e12), keep the same tab: prefer passing targetId from the snapshot response into subsequent actions (act/click/type/etc). For tab operations, targetId also accepts tabId handles (t1) and labels from action=tabs.",
-      "For multi-step browser work, login checks, stale refs, duplicate tabs, or Google Meet flows, use the bundled browser-automation skill when it is available.",
-      'For stable, self-resolving refs across calls, use snapshot with refs="aria" (Playwright aria-ref ids). Default refs="role" are role+name-based.',
-      "Use snapshot+act for UI automation. Avoid act:wait by default; use only in exceptional cases when no reliable UI state exists.",
-      `target selects browser location (sandbox|host|node). Default: ${targetDefault}.`,
-      hostHint,
-    ].join(" "),
+    description: describeBrowserTool({ sandboxBridgeUrl: opts?.sandboxBridgeUrl, allowHostControl: opts?.allowHostControl }),
     parameters: BrowserToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;


### PR DESCRIPTION
What Problem This Solves

Fixes #102566. The browser tool description hardcoded a suggestion to use profile="user" even when the operator has configured browser.defaultProfile with a CDP direct-attach profile. In that scenario profile="user" (existing-session driver) fails with "Connection closed" because it cannot handle non-default --user-data-dir Chrome instances, while the CDP attach profile works fine.

Why This Change Was Made

Introduced describeBrowserTool() in a new browser-tool.descriptions.ts that reads runtime config via getRuntimeConfig() and conditionally builds the model-facing tool description:

When defaultProfile is a CDP attach-only profile (cdpPort + attachOnly): recommends the configured default profile instead of profile="user", with a note about CDP direct attach.
Otherwise: keeps the original profile="user" hint for backward compatibility.
This follows the existing pattern used by bash-tools.descriptions.ts for dynamic tool descriptions.

User Impact

Users with browser.defaultProfile: "openclaw" configured as CDP attach-only will no longer see model confusion between the suggested profile="user" (which fails) and their working default profile.

Evidence

Before: tool.description always contained profile="user" regardless of config.
After: tool.description adapts based on browser.defaultProfile.
100 browser tests passing (0 failed, 0 regression):

$ node scripts/run-vitest.mjs run extensions/browser/src/browser-tool.test.ts
 Test Files  1 passed (1)
      Tests  73 passed (73)

$ node scripts/run-vitest.mjs run extensions/browser/src/browser-tool.schema.test.ts \
                                  extensions/browser/src/doctor-browser.test.ts \
                                  extensions/browser/index.test.ts
 Test Files  3 passed (3)
      Tests  23 passed (23)
<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->
