### PR TITLE
fix(chat,cli): keep session snippet and CLI output digest truncation UTF-16 safe

### DIFF
--- a/src/agents/cli-runner/log.ts
+++ b/src/agents/cli-runner/log.ts
@@ -3,6 +3,7 @@
  */
 import crypto from "node:crypto";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { truncateUtf16Safe } from "../../utils.js";
 
 /** Subsystem logger for CLI backend execution diagnostics. */
 export const cliBackendLog = createSubsystemLogger("agent/cli-backend");
@@ -14,6 +15,6 @@ export const LEGACY_CLAUDE_CLI_LOG_OUTPUT_ENV = "OPENCLAW_CLAUDE_CLI_LOG_OUTPUT"
 /** Return a compact byte/hash summary for CLI backend output. */
 export function formatCliBackendOutputDigest(text: string): string {
   const outBytes = Buffer.byteLength(text, "utf8");
-  const outHash = crypto.createHash("sha256").update(text).digest("hex").slice(0, 12);
+  const outHash = truncateUtf16Safe(crypto.createHash("sha256").update(text).digest("hex"), 12);
   return `outBytes=${outBytes} outHash=${outHash}`;
 }

--- a/src/auto-reply/reply/bash-command.ts
+++ b/src/auto-reply/reply/bash-command.ts
@@ -11,7 +11,7 @@ import { isCommandFlagEnabled } from "../../config/commands.flags.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { clampInt } from "../../utils.js";
+import { clampInt, truncateUtf16Safe } from "../../utils.js";
 import type { MsgContext } from "../templating.js";
 import type { ReplyPayload } from "../types.js";
 import { buildDisabledCommandReply } from "./command-gates.js";
@@ -54,7 +54,7 @@ function formatSessionSnippet(sessionId: string) {
   if (trimmed.length <= 12) {
     return trimmed;
   }
-  return `${trimmed.slice(0, 8)}…`;
+  return `${truncateUtf16Safe(trimmed, 8)}…`;
 }
 
 function formatOutputBlock(text: string) {


### PR DESCRIPTION
## What Problem This Solves

Two `src/`-side text-truncation call sites still use raw `String.prototype.slice()` with no UTF-16 surrogate-pair awareness. When an emoji or other supplementary Unicode character lands exactly on the cap, the slice can leave a dangling high surrogate that downstream consumers may treat as malformed text.

| File | Site | Cap | Visibility |
|:---|:---|:---|:---|
| `src/auto-reply/reply/bash-command.ts:57` | `formatSessionSnippet` session ID truncation in bash reply | 8 | user-facing chat output |
| `src/agents/cli-runner/log.ts:17` | `formatCliBackendOutputDigest` SHA-256 hex preview | 12 | CLI backend diagnostics log |

## Why This Change Was Made

Replace the raw `.slice(0, N)` patterns with `truncateUtf16Safe()` from `@openclaw/normalization-core/utf16-slice` (re-exported via `src/utils.js`). The helper preserves the existing cap for ordinary text and only backs up by one code unit when the cap would split a surrogate pair — matching the contract every other UTF-16 fix in this wave uses.

The helper is the canonical one (already imported by 30+ merged sites), so no new helper surface is added.

## User Impact

- **bash-command**: If a bash session ID (e.g. an internal hex key) ends with a multi-byte character exactly at 8 code units, the user-facing snippet in bash status lines could show a broken character. After this fix, the snippet is always valid Unicode at the same 8-char cap.
- **cli-runner/log**: The SHA-256 hex digest is ASCII-only (a-f0-9), so this change is prophylactic — no real surrogate boundary can reach it. Changed for consistency with the rest of the codebase.

No config, environment, default, SDK, protocol, or migration change. No public API change. No new dependency.

## Evidence

### Real behavior proof

A standalone harness drives each production call through `truncateUtf16Safe` and verifies no lone surrogate in the output. The harness also imports exactly as the two PR sites do.

```
$ node --import tsx /tmp/proof-plan-k.mjs

bash-command, cap 8 -> snippet length 9, lone surrogate: false
cli-runner output digest, cap 12 -> hash 52ff49933481, lone surrogate: false

=== PASS: Plan K sites keep output surrogate-safe at the cap ===
```

### Behavior proof

| Before | After |
|---|---|
| `` `${trimmed.slice(0, 8)}…` `` | `` `${truncateUtf16Safe(trimmed, 8)}…` `` |
| `.slice(0, 12)` (hex digest) | `truncateUtf16Safe(..., 12)` |

### Quantitative read-out

| Site | Before cap | After cap | Helper | Tests |
|---|---|---|---|---|
| `bash-command.ts:57` | `8` chars | `8` UTF-16-safe | `truncateUtf16Safe` | no dedicated test (pure helper) |
| `cli-runner/log.ts:17` | `12` chars | `12` UTF-16-safe | `truncateUtf16Safe` | no dedicated test (pure helper) |

### Typecheck

`tsgo:core` passes clean on the rebased head.

### Risk checklist

- [x] No config, environment, default, SDK, protocol, auth, or provider change.
- [x] No new dependency; `truncateUtf16Safe` is already exported from `src/utils.js`.
- [x] No behavior change for non-boundary text (helper backs up only on surrogate-pair splits).
- [x] `bash-command.ts` preserves its existing `if (trimmed.length <= 12) return trimmed;` short-circuit; helper only runs on the truncation branch.
- [x] `cli-runner/log.ts` SHA-256 hex digest is ASCII-only so the helper is prophylactic.
- [x] Sibling pattern already established in 30+ merged UTF-16 PRs across the codebase.
- [x] No public API change; each truncation is module-private.
- [x] No changelog entry required for this diagnostic-only internal behavior.
- [x] Allow edits by maintainers.

## Closes / siblings

- **Siblings — UTF-16 safe truncation wave**: #102087, #102466, #102496, #102085, #102332, #102090, #102266, #102246, #102378, #102464, #102467, #102470, #102483, #102484, #102477, #102442, #102407, #102414, #101934, #102395, #101781, #101946, #101976, #102225, #102066, #102560, #102542, #102565, #102515, plus the ongoing burst at #102551 / #102561 / #102567 / #102570 / #102572 / #102576 / #102583 / #102589 / #102590 / #102591 / #102592 / #102593 / #102599 / #102603 / #102604 / #102605 / #102606 / #102607 / #102608 / #102609, plus #102630 (closed, subset landed by maintainer), plus 30+ open UTF-16 PRs in the current wave.
- **Helper origin**: `truncateUtf16Safe` is defined in `packages/normalization-core/src/utf16-slice.ts` and re-exported by `src/utils.ts:65`.
- **Collision check**: pre-PR grep confirmed no open PR touches `bash-command.ts` or `cli-runner/log.ts` for UTF-16 truncation.
