### PR TITLE
fix(qqbot): treat inbound attachment content types case-insensitively

### DIFF
--- a/extensions/qqbot/src/engine/gateway/inbound-attachments.test.ts
+++ b/extensions/qqbot/src/engine/gateway/inbound-attachments.test.ts
@@ -73,6 +73,57 @@ describe("engine/gateway/inbound-attachments", () => {
     expect(result.attachmentLocalPaths).toEqual([null]);
   });
 
+  it("classifies image content types case-insensitively when download succeeds", async () => {
+    downloadFileMock.mockResolvedValue("/tmp/openclaw-qqbot-downloads/a.png");
+
+    const result = await processAttachments(
+      [
+        { content_type: "image/png", url: "https://cdn.example.test/a.png", filename: "a.png" },
+        { content_type: "Image/PNG", url: "https://cdn.example.test/b.png", filename: "b.png" },
+      ],
+      { accountId: "qq", cfg: {}, audioConvert },
+    );
+
+    expect(result.imageUrls).toEqual([
+      "/tmp/openclaw-qqbot-downloads/a.png",
+      "/tmp/openclaw-qqbot-downloads/a.png",
+    ]);
+    // The raw content_type passes through unchanged.
+    expect(result.imageMediaTypes).toEqual(["image/png", "Image/PNG"]);
+    expect(result.attachmentInfo).toBe("");
+  });
+
+  it("uses the remote image URL for a mixed-case image content type when download fails", async () => {
+    downloadFileMock.mockResolvedValue(null);
+
+    const result = await processAttachments(
+      [{ content_type: "Image/PNG", url: "//cdn.example.test/a.png", filename: "a.png" }],
+      { accountId: "qq", cfg: {}, audioConvert },
+    );
+
+    expect(result.imageUrls).toEqual(["https://cdn.example.test/a.png"]);
+    expect(result.imageMediaTypes).toEqual(["Image/PNG"]);
+    expect(result.attachmentLocalPaths).toEqual([null]);
+  });
+
+  it("does not classify a mixed-case non-image content type as an image", async () => {
+    downloadFileMock.mockResolvedValue("/tmp/openclaw-qqbot-downloads/doc.pdf");
+
+    const result = await processAttachments(
+      [
+        {
+          content_type: "Application/PDF",
+          url: "https://cdn.example.test/doc.pdf",
+          filename: "doc.pdf",
+        },
+      ],
+      { accountId: "qq", cfg: {}, audioConvert },
+    );
+
+    expect(result.imageUrls).toEqual([]);
+    expect(result.attachmentInfo).toBe("\n[Attachment: /tmp/openclaw-qqbot-downloads/doc.pdf]");
+  });
+
   it("prefers voice_wav_url for voice downloads and transcribes with configured STT", async () => {
     downloadFileMock.mockResolvedValue("/tmp/openclaw-qqbot-downloads/voice.wav");
     resolveSTTConfigMock.mockReturnValue({

--- a/extensions/qqbot/src/engine/gateway/inbound-attachments.test.ts
+++ b/extensions/qqbot/src/engine/gateway/inbound-attachments.test.ts
@@ -74,7 +74,8 @@ describe("engine/gateway/inbound-attachments", () => {
   });
 
   it("classifies image content types case-insensitively when download succeeds", async () => {
-    downloadFileMock.mockResolvedValue("/tmp/openclaw-qqbot-downloads/a.png");
+    downloadFileMock.mockResolvedValueOnce("/tmp/openclaw-qqbot-downloads/a.png");
+    downloadFileMock.mockResolvedValueOnce("/tmp/openclaw-qqbot-downloads/b.png");
 
     const result = await processAttachments(
       [
@@ -86,7 +87,7 @@ describe("engine/gateway/inbound-attachments", () => {
 
     expect(result.imageUrls).toEqual([
       "/tmp/openclaw-qqbot-downloads/a.png",
-      "/tmp/openclaw-qqbot-downloads/a.png",
+      "/tmp/openclaw-qqbot-downloads/b.png",
     ]);
     // The raw content_type passes through unchanged.
     expect(result.imageMediaTypes).toEqual(["image/png", "Image/PNG"]);

--- a/extensions/qqbot/src/engine/gateway/inbound-attachments.ts
+++ b/extensions/qqbot/src/engine/gateway/inbound-attachments.ts
@@ -3,7 +3,10 @@ import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { AudioConvertPort } from "../adapter/audio.port.js";
 import { downloadFile } from "../utils/file-utils.js";
 import { getQQBotMediaDir } from "../utils/platform.js";
-import { normalizeOptionalString } from "../utils/string-normalize.js";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "../utils/string-normalize.js";
 import { transcribeAudio, resolveSTTConfig } from "../utils/stt.js";
 
 // Re-export the port type for convenience.
@@ -115,6 +118,10 @@ export async function processAttachments(
   const processTasks = downloadResults.map(
     async ({ att, attUrl, isVoice, localPath, audioPath }) => {
       const asrReferText = normalizeOptionalString(att.asr_refer_text) ?? "";
+      // MIME types are case-insensitive (RFC 2045) and relays may emit
+      // mixed-case values; compare lowercased but keep the raw content_type
+      // in returned fields.
+      const normalizedContentType = normalizeLowercaseStringOrEmpty(att.content_type);
       const wavUrl =
         isVoice && att.voice_wav_url
           ? att.voice_wav_url.startsWith("//")
@@ -129,7 +136,7 @@ export async function processAttachments(
       };
 
       if (localPath) {
-        if (att.content_type?.startsWith("image/")) {
+        if (normalizedContentType.startsWith("image/")) {
           log?.debug?.(`Downloaded attachment to: ${localPath}`);
           return { localPath, type: "image" as const, contentType: att.content_type, meta };
         }
@@ -150,7 +157,7 @@ export async function processAttachments(
         return { localPath, type: "other" as const, filename: att.filename, meta };
       }
       log?.error(`Failed to download: ${attUrl}`);
-      if (att.content_type?.startsWith("image/")) {
+      if (normalizedContentType.startsWith("image/")) {
         return {
           localPath: null,
           type: "image-fallback" as const,

--- a/extensions/qqbot/src/engine/utils/audio.test.ts
+++ b/extensions/qqbot/src/engine/utils/audio.test.ts
@@ -97,6 +97,12 @@ describe("engine/utils/audio", () => {
       expect(isVoiceAttachment({ filename: "msg.slac" })).toBe(true);
     });
 
+    it("treats content_type case-insensitively", () => {
+      expect(isVoiceAttachment({ content_type: "Voice" })).toBe(true);
+      expect(isVoiceAttachment({ content_type: "Audio/Silk" })).toBe(true);
+      expect(isVoiceAttachment({ content_type: "Image/PNG" })).toBe(false);
+    });
+
     it("rejects non-voice attachments", () => {
       expect(isVoiceAttachment({ content_type: "image/png" })).toBe(false);
       expect(isVoiceAttachment({ filename: "photo.jpg" })).toBe(false);

--- a/extensions/qqbot/src/engine/utils/audio.ts
+++ b/extensions/qqbot/src/engine/utils/audio.ts
@@ -118,7 +118,10 @@ export async function convertSilkToWav(
 
 /** Check whether an attachment is a voice file (by MIME type or extension). */
 export function isVoiceAttachment(att: { content_type?: string; filename?: string }): boolean {
-  if (att.content_type === "voice" || att.content_type?.startsWith("audio/")) {
+  // MIME types are case-insensitive (RFC 2045) and relays may emit
+  // mixed-case values; compare lowercased like the extension check below.
+  const contentType = normalizeLowercase(att.content_type);
+  if (contentType === "voice" || contentType.startsWith("audio/")) {
     return true;
   }
   const ext = att.filename ? normalizeLowercase(path.extname(att.filename)) : "";

--- a/extensions/qqbot/src/engine/utils/audio.ts
+++ b/extensions/qqbot/src/engine/utils/audio.ts
@@ -118,8 +118,9 @@ export async function convertSilkToWav(
 
 /** Check whether an attachment is a voice file (by MIME type or extension). */
 export function isVoiceAttachment(att: { content_type?: string; filename?: string }): boolean {
-  // MIME types are case-insensitive (RFC 2045) and relays may emit
-  // mixed-case values; compare lowercased like the extension check below.
+  // MIME types are case-insensitive (RFC 2045) and relays may emit mixed-case
+  // values; the bare "voice" platform sentinel gets the same treatment.
+  // Compare lowercased like the extension check below.
   const contentType = normalizeLowercase(att.content_type);
   if (contentType === "voice" || contentType.startsWith("audio/")) {
     return true;


### PR DESCRIPTION
## Summary

**Prompt request:** Make QQ Bot inbound attachment classification treat content types case-insensitively per RFC 2045, while returning the raw `content_type` values unchanged.

**Proof target:** Show that mixed-case image and voice content types now classify identically to their lowercase forms (image display, remote-URL fallback on failed download, voice download and transcription routing), and that non-media types are still not promoted.

## What Problem This Solves

Fixes an issue where QQ Bot inbound attachments with a mixed-case `content_type` (such as `Image/PNG` or `Audio/Silk`) were silently misclassified. MIME types are **case-insensitive per RFC 2045**, but the qqbot inbound pipeline compared the raw value against lowercase literals at three sites:

- `extensions/qqbot/src/engine/gateway/inbound-attachments.ts` (download-success branch): `att.content_type?.startsWith("image/")` — a mixed-case image fell out of the image path into a generic `[Attachment: ...]` note, so the agent never received it as an image.
- `extensions/qqbot/src/engine/gateway/inbound-attachments.ts` (download-failure branch): the same comparison — a mixed-case image lost its remote-URL fallback and was reported as a plain failed download.
- `extensions/qqbot/src/engine/utils/audio.ts` `isVoiceAttachment`: `content_type === "voice" || startsWith("audio/")` — a mixed-case voice attachment (with no rescuing filename extension) skipped the voice download and transcription routing entirely and was treated as a generic file.

The same `isVoiceAttachment` already lowercases the filename-extension side of its check via `normalizeLowercase`; the `content_type` side was the missed half. This is the qqbot sibling of merged #102431, which fixed the same content-type case-sensitivity class in the msteams plugin on the same RFC 2045 reasoning.

## Why This Change Was Made

- **Root cause:** raw `content_type` values were compared against lowercase literals, while relay payloads may emit mixed-case MIME types.
- **Fix:** normalize with the plugin's existing `normalizeLowercaseStringOrEmpty` helper at the three comparison sites. Lowercasing is compare-only: the returned fields (`contentType`, media-type passthrough, filename fallback) keep the raw value, and lowercase inputs keep their existing behavior. MIME types are case-insensitive by spec, so lowercasing the comparison can only add matches, never remove one.
- The bare `voice` value in the same check is a QQ-specific content marker rather than a MIME type; it is normalized the same way for the same relay-variability reason.
- Scope is limited to inbound attachment classification in the qqbot plugin.

## User Impact

QQ Bot inbound images with mixed-case content types are now delivered to the agent as images (including the remote-URL fallback when the download fails), and mixed-case voice attachments route through voice download and transcription instead of being treated as generic files. Lowercase content types behave exactly as before.

## Evidence

Boundary-capture of the production classification pipeline: `node --import tsx` drives the real `processAttachments` (download → classify) and the real `isVoiceAttachment`, with only the external media fetch replaced by a minimal adapter that performs a real HTTP GET against a local server (real bytes, real file writes through the production `downloadFile`). Fixtures: mixed-case image with successful download, mixed-case image with failed (404) download, extension-less mixed-case voice attachment, and a mixed-case PDF as negative control.

Before (unmodified base branch):

```
imageUrls: []
imageMediaTypes: []
voiceAttachmentPaths: []
attachmentInfo:
  [Attachment: <media-dir>/a_<id>.png]              <- Image/PNG demoted to generic note
  [Attachment: missing.jpg] (download failed)        <- Image/JPEG lost its URL fallback
  [Attachment: <media-dir>/voice-message_<id>]      <- Audio/Silk treated as generic file
  [Attachment: <media-dir>/doc_<id>.pdf]

isVoiceAttachment: "voice" -> true, "Voice" -> false, "Audio/Silk" -> false,
                   "audio/amr" -> true, "Image/PNG" -> false
```

After (this PR):

```
imageUrls: ["<media-dir>/a_<id>.png", "https://cdn.example.test/missing.jpg"]
imageMediaTypes: ["Image/PNG", "Image/JPEG"]         <- raw casing passes through unchanged
voiceAttachmentPaths: ["<media-dir>/voice-message_<id>"]
voiceTranscripts: ["[Voice message - transcription unavailable because STT is not configured]"]
attachmentInfo:
  [Attachment: <media-dir>/doc_<id>.pdf]            <- PDF negative control stays generic

isVoiceAttachment: "voice" -> true, "Voice" -> true, "Audio/Silk" -> true,
                   "audio/amr" -> true, "Image/PNG" -> false
```

## Real behavior proof

| # | Field | Value |
|---|-------|-------|
| 1 | Behavior or issue addressed | Mixed-case inbound `content_type` values (`Image/PNG`, `Audio/Silk`) were misclassified: images dropped out of the image path (both download-success and URL-fallback branches) and voice attachments skipped voice download and transcription routing. |
| 2 | Real environment tested | Linux x64, Node 22, commit `c28d69c2c8d930c7d5f09395f8448d5e54597fb0` |
| 3 | Exact steps or command run | `OPENCLAW_HOME=$(mktemp -d) node --import tsx <proof script>` — imports the production `processAttachments` and `isVoiceAttachment`, wires the audio-convert port exactly like the production bridge assembly, serves attachment bytes from a local HTTP server through the platform-adapter seam, and prints the resulting classification. Run once against the unmodified base branch and once against this PR's HEAD. |
| 4 | Evidence after fix | Terminal capture above (After block): mixed-case image classified as image with the raw media type passed through, failed download falls back to the remote URL, extension-less `Audio/Silk` enters the voice transcription path, `Application/PDF` stays a generic attachment. |
| 5 | Observed result after fix | Mixed-case content types classify identically to their lowercase forms; returned `content_type` values keep their original casing; non-media types are not promoted. |
| 6 | What was not tested | Live QQ platform traffic with a real mixed-case relay payload (no credentialled QQ bot available); the external CDN fetch was served by a local HTTP server through the plugin's platform-adapter seam. The colocated unit tests cover the same branches directly and are supplemental to the capture above. |

## Tests and validation

```
$ node scripts/run-vitest.mjs extensions/qqbot/src/engine/gateway/inbound-attachments.test.ts extensions/qqbot/src/engine/utils/audio.test.ts
 Test Files  2 passed (2)
      Tests  47 passed (47)
```

New tests cover: mixed-case image classification on the download-success branch (with lowercase regression in the same run and raw passthrough asserted), the remote-URL fallback on the download-failure branch, `isVoiceAttachment` mixed-case recognition (`Voice`, `Audio/Silk`) with a non-audio rejection, and a mixed-case non-image type that must not be promoted.

## Risk checklist

- [x] One concern, one PR — content-type case-insensitivity in qqbot inbound classification only.
- [x] No config, env, or default surface change.
- [x] Backward compatible — lowercase inputs produce identical results; comparisons only gain matches, and returned values are unchanged.
- [x] No new deps, no new helpers (uses the plugin's existing normalize helper).
- [x] No CHANGELOG edit (per release policy).
- [x] Tests added.

- [x] Allow edits by maintainers
