### PR TITLE
test(android): cover discovery and startup gates

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -139,7 +139,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 138,
+      "line": 143,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Searching…",
       "surface": "android",
@@ -147,7 +147,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 238,
+      "line": 243,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -155,7 +155,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 248,
+      "line": 253,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -379,7 +379,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 86,
+      "line": 106,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt",
       "source": "Searching…",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -46,6 +46,11 @@ data class ChatDraft(
   val placement: ChatDraftPlacement,
 )
 
+internal fun shouldStartRuntimeOnForeground(
+  foreground: Boolean,
+  onboardingCompleted: Boolean,
+): Boolean = foreground && onboardingCompleted
+
 /**
  * UI-facing bridge that exposes NodeRuntime and preference state as Compose-friendly StateFlows.
  */
@@ -298,7 +303,12 @@ class MainViewModel(
    */
   fun setForeground(value: Boolean) {
     foreground = value
-    if (value && prefs.onboardingCompleted.value) {
+    if (
+      shouldStartRuntimeOnForeground(
+        foreground = value,
+        onboardingCompleted = prefs.onboardingCompleted.value,
+      )
+    ) {
       queueRuntimeStartup()
     }
     runtimeRef.value?.setForeground(value)

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt
@@ -62,6 +62,26 @@ private fun createContextDnsResolver(context: Context): DnsResolver = DnsResolve
 @Suppress("DEPRECATION")
 private fun createLegacyDnsResolver(): DnsResolver = DnsResolver.getInstance()
 
+internal fun gatewayDiscoveryStatusText(
+  localCount: Int,
+  wideAreaRcode: Int?,
+  wideAreaCount: Int,
+): String {
+  val wide =
+    when (wideAreaRcode) {
+      null -> "Wide: ?"
+      Rcode.NOERROR -> "Wide: $wideAreaCount"
+      Rcode.NXDOMAIN -> "Wide: NXDOMAIN"
+      else -> "Wide: ${Rcode.string(wideAreaRcode)}"
+    }
+
+  return when {
+    localCount == 0 && wideAreaRcode == null -> "Searching for gateways…"
+    localCount == 0 -> wide
+    else -> "Local: $localCount • $wide"
+  }
+}
+
 /**
  * Watches local DNS-SD and optional wide-area DNS-SD for reachable OpenClaw gateways.
  */
@@ -306,27 +326,12 @@ class GatewayDiscovery(
     _gateways.value =
       // Merge local and wide-area results deterministically for stable UI selection.
       (localById.values + unicastById.values).sortedBy { it.name.lowercase() }
-    _statusText.value = buildStatusText()
-  }
-
-  private fun buildStatusText(): String {
-    val localCount = localById.size
-    val wideRcode = lastWideAreaRcode
-    val wideCount = lastWideAreaCount
-
-    val wide =
-      when (wideRcode) {
-        null -> "Wide: ?"
-        Rcode.NOERROR -> "Wide: $wideCount"
-        Rcode.NXDOMAIN -> "Wide: NXDOMAIN"
-        else -> "Wide: ${Rcode.string(wideRcode)}"
-      }
-
-    return when {
-      localCount == 0 && wideRcode == null -> "Searching for gateways…"
-      localCount == 0 -> "$wide"
-      else -> "Local: $localCount • $wide"
-    }
+    _statusText.value =
+      gatewayDiscoveryStatusText(
+        localCount = localById.size,
+        wideAreaRcode = lastWideAreaRcode,
+        wideAreaCount = lastWideAreaCount,
+      )
   }
 
   private fun stableId(

--- a/apps/android/app/src/test/java/ai/openclaw/app/MainViewModelTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/MainViewModelTest.kt
@@ -1,41 +1,10 @@
 package ai.openclaw.app
 
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
-import org.robolectric.annotation.Config
 
-@RunWith(RobolectricTestRunner::class)
-@Config(sdk = [34])
 class MainViewModelTest {
-  @Test
-  fun setForegroundDoesNotStartRuntimeBeforeOnboardingCompletes() {
-    val app = appContext()
-    app.prefs.setOnboardingCompleted(false)
-    val viewModel = MainViewModel(app)
-
-    viewModel.setForeground(true)
-
-    assertFalse(viewModel.runtimeInitialized.value)
-    assertNull(app.peekRuntime())
-  }
-
-  @Test
-  fun setForegroundDoesNotStartRuntimeWhileActivityIsStopped() {
-    val app = appContext()
-    app.prefs.setOnboardingCompleted(true)
-    val viewModel = MainViewModel(app)
-
-    viewModel.setForeground(false)
-
-    assertFalse(viewModel.runtimeInitialized.value)
-    assertNull(app.peekRuntime())
-  }
-
   @Test
   fun foregroundStartupRequiresForegroundAndCompletedOnboarding() {
     assertFalse(
@@ -50,6 +19,12 @@ class MainViewModelTest {
         onboardingCompleted = false,
       ),
     )
+    assertFalse(
+      shouldStartRuntimeOnForeground(
+        foreground = false,
+        onboardingCompleted = false,
+      ),
+    )
     assertTrue(
       shouldStartRuntimeOnForeground(
         foreground = true,
@@ -57,6 +32,4 @@ class MainViewModelTest {
       ),
     )
   }
-
-  private fun appContext(): NodeApp = RuntimeEnvironment.getApplication() as NodeApp
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/MainViewModelTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/MainViewModelTest.kt
@@ -1,0 +1,62 @@
+package ai.openclaw.app
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class MainViewModelTest {
+  @Test
+  fun setForegroundDoesNotStartRuntimeBeforeOnboardingCompletes() {
+    val app = appContext()
+    app.prefs.setOnboardingCompleted(false)
+    val viewModel = MainViewModel(app)
+
+    viewModel.setForeground(true)
+
+    assertFalse(viewModel.runtimeInitialized.value)
+    assertNull(app.peekRuntime())
+  }
+
+  @Test
+  fun setForegroundDoesNotStartRuntimeWhileActivityIsStopped() {
+    val app = appContext()
+    app.prefs.setOnboardingCompleted(true)
+    val viewModel = MainViewModel(app)
+
+    viewModel.setForeground(false)
+
+    assertFalse(viewModel.runtimeInitialized.value)
+    assertNull(app.peekRuntime())
+  }
+
+  @Test
+  fun foregroundStartupRequiresForegroundAndCompletedOnboarding() {
+    assertFalse(
+      shouldStartRuntimeOnForeground(
+        foreground = false,
+        onboardingCompleted = true,
+      ),
+    )
+    assertFalse(
+      shouldStartRuntimeOnForeground(
+        foreground = true,
+        onboardingCompleted = false,
+      ),
+    )
+    assertTrue(
+      shouldStartRuntimeOnForeground(
+        foreground = true,
+        onboardingCompleted = true,
+      ),
+    )
+  }
+
+  private fun appContext(): NodeApp = RuntimeEnvironment.getApplication() as NodeApp
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewayDiscoveryTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewayDiscoveryTest.kt
@@ -1,0 +1,68 @@
+package ai.openclaw.app.gateway
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.xbill.DNS.Rcode
+
+class GatewayDiscoveryTest {
+  @Test
+  fun statusTextFormatsLocalAndWideAreaDiscoveryStates() {
+    val cases =
+      listOf(
+        StatusCase(
+          localCount = 0,
+          wideAreaRcode = null,
+          wideAreaCount = 0,
+          expected = "Searching for gateways…",
+        ),
+        StatusCase(
+          localCount = 0,
+          wideAreaRcode = Rcode.NOERROR,
+          wideAreaCount = 2,
+          expected = "Wide: 2",
+        ),
+        StatusCase(
+          localCount = 1,
+          wideAreaRcode = Rcode.NOERROR,
+          wideAreaCount = 2,
+          expected = "Local: 1 • Wide: 2",
+        ),
+        StatusCase(
+          localCount = 1,
+          wideAreaRcode = null,
+          wideAreaCount = 0,
+          expected = "Local: 1 • Wide: ?",
+        ),
+        StatusCase(
+          localCount = 0,
+          wideAreaRcode = Rcode.NXDOMAIN,
+          wideAreaCount = 0,
+          expected = "Wide: NXDOMAIN",
+        ),
+        StatusCase(
+          localCount = 2,
+          wideAreaRcode = Rcode.SERVFAIL,
+          wideAreaCount = 0,
+          expected = "Local: 2 • Wide: SERVFAIL",
+        ),
+      )
+
+    for (case in cases) {
+      assertEquals(
+        case.expected,
+        gatewayDiscoveryStatusText(
+          localCount = case.localCount,
+          wideAreaRcode = case.wideAreaRcode,
+          wideAreaCount = case.wideAreaCount,
+        ),
+      )
+    }
+  }
+}
+
+private data class StatusCase(
+  val localCount: Int,
+  val wideAreaRcode: Int?,
+  val wideAreaCount: Int,
+  val expected: String,
+)


### PR DESCRIPTION
## What Problem This Solves

Android gateway discovery status formatting and foreground runtime startup gates lacked focused regression coverage. This preserves the useful work from #99206 on current `main` after the contributor branch became conflicting and could not be modified by maintainers.

## Why This Change Was Made

The existing decisions are extracted into package-internal pure helpers, keeping runtime behavior unchanged while making the discovery states and startup predicate directly testable. The current native i18n inventory is refreshed for the moved source lines, and the redundant discovery wrapper from the original branch is removed.

The first replacement-head CI run exposed that constructing the full `MainViewModel` also boots Android Keystore under Robolectric. The startup-gate regression coverage was narrowed to the pure predicate used directly by `setForeground`, avoiding an unrelated Keystore dependency while preserving all four truth-table cases.

## User Impact

No intentional runtime behavior change. Future Android changes are less likely to regress gateway discovery diagnostics or start the node runtime before onboarding and foreground conditions are satisfied.

## Evidence

- `git diff --check` passed.
- Two fresh Codex AutoReview passes reported no accepted/actionable findings, including after the Keystore-free test repair.
- Exact replacement head `7e192452517bc35493f0dffcb0940c15a4a11951` passed Android Play and third-party tests, Android build/lint, native i18n, and the remaining required CI checks: https://github.com/openclaw/openclaw/actions/runs/29016380356
- Sanitized AWS Crabbox run `run_7cda6133a87e` passed native i18n on the prior replacement head; Android Gradle did not start there because that raw image had no Java. Exact-head GitHub CI supplied the Android proof.
- `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 102758` passed before merge.
- Landed as commit `411bf2ad4b59da9fe3ebcd693d17244136e3fb2d`.

Source PR: #99206

Co-authored-by: NianJiuZst <180004567+users.noreply.github.com>
