### PR TITLE
fix(gateway): keep ws-log shortId edge truncation UTF-16 safe

### DIFF
--- a/scripts/proof-gateway-ws-log-shortid-utf16-boundary.mts
+++ b/scripts/proof-gateway-ws-log-shortid-utf16-boundary.mts
@@ -1,0 +1,46 @@
+// Proof: shortId's legacy raw slices split surrogate pairs at the edges;
+// sliceUtf16Safe keeps both edges valid UTF-16.
+
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+
+function legacyShortId(value: string): string {
+  const s = value.trim();
+  if (s.length <= 24) {
+    return s;
+  }
+  return `${s.slice(0, 12)}…${s.slice(-4)}`;
+}
+
+function fixedShortId(value: string): string {
+  const s = value.trim();
+  if (s.length <= 24) {
+    return s;
+  }
+  return `${sliceUtf16Safe(s, 0, 12)}…${sliceUtf16Safe(s, -4)}`;
+}
+
+function hasLoneSurrogate(value: string): boolean {
+  return /[\uD800-\uDFFF]/.test(value.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/gu, ""));
+}
+
+const input = `${"a".repeat(11)}😀${"b".repeat(20)}`;
+const legacy = legacyShortId(input);
+const fixed = fixedShortId(input);
+
+console.log(`input length         : ${input.length}`);
+console.log(`legacy shortId       : ${legacy}`);
+console.log(`fixed  shortId       : ${fixed}`);
+console.log(`legacy lone surrogate: ${hasLoneSurrogate(legacy)}`);
+console.log(`fixed  lone surrogate: ${hasLoneSurrogate(fixed)}`);
+
+if (!hasLoneSurrogate(legacy)) {
+  console.error("FAIL: expected legacy shortId to emit a lone surrogate");
+  process.exit(1);
+}
+
+if (hasLoneSurrogate(fixed)) {
+  console.error("FAIL: expected fixed shortId to stay surrogate-safe");
+  process.exit(1);
+}
+
+console.log("PASS: shortId keeps surrogate pairs intact.");

--- a/src/gateway/ws-log.test.ts
+++ b/src/gateway/ws-log.test.ts
@@ -21,6 +21,11 @@ describe("gateway ws log helpers", () => {
       input: " short ",
       expected: "short",
     },
+    {
+      name: "does not split a surrogate pair at the start edge",
+      input: `${"a".repeat(11)}😀${"b".repeat(20)}`,
+      expected: `${"a".repeat(11)}…${"b".repeat(4)}`,
+    },
   ])("shortId $name", ({ input, expected }) => {
     expect(shortId(input)).toBe(expected);
   });

--- a/src/gateway/ws-log.ts
+++ b/src/gateway/ws-log.ts
@@ -1,7 +1,7 @@
 // Gateway WebSocket log formatting.
 // Redacts and compacts request/response/event metadata for console diagnostics.
 import { readStringValue } from "@openclaw/normalization-core/string-coerce";
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import chalk from "chalk";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { isVerbose } from "../globals.js";
@@ -104,12 +104,12 @@ export function shouldLogWs(): boolean {
 export function shortId(value: string): string {
   const s = value.trim();
   if (UUID_RE.test(s)) {
-    return `${s.slice(0, 8)}…${s.slice(-4)}`;
+    return `${sliceUtf16Safe(s, 0, 8)}…${sliceUtf16Safe(s, -4)}`;
   }
   if (s.length <= 24) {
     return s;
   }
-  return `${s.slice(0, 12)}…${s.slice(-4)}`;
+  return `${sliceUtf16Safe(s, 0, 12)}…${sliceUtf16Safe(s, -4)}`;
 }
 
 /** Formats and redacts arbitrary values before they are written to gateway logs. */


### PR DESCRIPTION
## What Problem This Solves

shortId in src/gateway/ws-log.ts compacts long identifiers using raw slice(0, N) and slice(-N). When an id contains a supplementary-plane character (e.g. emoji) at either edge, the raw slices can split a UTF-16 surrogate pair and emit a lone surrogate into gateway logs.

## Why This Change Was Made

Route both edges through the repository's canonical sliceUtf16Safe helper, which already powers the adjacent formatForLog truncation. The compact preview now stays within the original code-unit budgets while keeping both edges valid UTF-16.

## User Impact

Gateway WebSocket log identifiers no longer risk carrying malformed surrogate halves when ids contain multi-code-unit characters.

## Scope

Three files (src/gateway/ws-log.ts, src/gateway/ws-log.test.ts, scripts/proof-gateway-ws-log-shortid-utf16-boundary.mts); no config, protocol, dependency, or compatibility change. AI-assisted.

## Evidence

Focused test run:

```bash
node --import tsx node_modules/vitest/vitest.mjs run --config test/vitest/vitest.gateway-core.config.ts src/gateway/ws-log.test.ts
```

Result: Test Files  1 passed (1) / Tests 17 passed (17).

Real-behavior proof:

```bash
node --import tsx scripts/proof-gateway-ws-log-shortid-utf16-boundary.mts
```

Output shows the legacy raw-slice path emits a lone surrogate at the leading edge, while the fixed shortId keeps both edges intact.

## Maintainer verification

- Exact head: 48ace53e96
- Local focused test: pass
- Local lint: pass