### PR TITLE
fix(memory-wiki): use truncateUtf16Safe for terminal string truncation

### DIFF
--- a/extensions/memory-wiki/src/cli.ts
+++ b/extensions/memory-wiki/src/cli.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import type { Command } from "commander";
 import { callGatewayFromCli } from "openclaw/plugin-sdk/gateway-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   isRecord,
   normalizeStringEntries,
@@ -180,7 +181,7 @@ function isResolvedMemoryWikiConfig(
 function sanitizeGatewayStringForTerminal(value: string): string {
   const truncated =
     value.length > GATEWAY_TERMINAL_STRING_MAX_CHARS
-      ? value.slice(0, GATEWAY_TERMINAL_STRING_MAX_CHARS)
+      ? truncateUtf16Safe(value, GATEWAY_TERMINAL_STRING_MAX_CHARS)
       : value;
   const sanitized = truncated
     .replace(ANSI_ESCAPE_SEQUENCE_PATTERN, "")


### PR DESCRIPTION
## What Problem This Solves

One `.slice(0, N)` truncation site in the Memory Wiki CLI may cut UTF-16 surrogate pairs in half when the terminal display string contains multi-byte characters such as emoji.

## Why This Change Was Made

`extensions/memory-wiki/src/cli.ts` uses raw `.slice(0, GATEWAY_TERMINAL_STRING_MAX_CHARS)` for gateway string truncation. Replacing with `truncateUtf16Safe` ensures terminal output is always valid Unicode.

## User Impact

Truncated terminal display strings in Memory Wiki CLI remain valid Unicode at existing size limits. No behavioral changes for ASCII-only content.

## Evidence

- Mechanical replacement: `.slice(0, N)` to `truncateUtf16Safe`
- No runtime behavior change for ASCII or valid Unicode input

Generated with Claude Code