### PR TITLE
fix(memory-lancedb): use truncateUtf16Safe for sanitize text truncation

### DIFF
--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -1168,7 +1168,7 @@ export function sanitizeForMemoryCapture(text: string): string {
 
   // Pre-truncate to cap regex work on very large inputs (ReDoS mitigation)
   const MAX_SANITIZE_CHARS = 10_000;
-  let cleaned = text.length > MAX_SANITIZE_CHARS ? text.slice(0, MAX_SANITIZE_CHARS) : text;
+  let cleaned = text.length > MAX_SANITIZE_CHARS ? truncateUtf16Safe(text, MAX_SANITIZE_CHARS) : text;
   let strippedInjectedContext = false;
 
   // Strip leading timestamp prefix


### PR DESCRIPTION
## What Problem This Solves

One missed `.slice(0, N)` truncation site in the memory-lancedb extension may cut UTF-16 surrogate pairs in half when the text content contains multi-byte characters such as emoji. The same file already uses `truncateUtf16Safe` in other places.

## Why This Change Was Made

`extensions/memory-lancedb/index.ts` was partially converted but `text.slice(0, MAX_SANITIZE_CHARS)` on the sanitize path was missed.

## User Impact

Truncated text in memory-lancedb sanitization remains valid Unicode at existing size limits.

## Evidence

- Mechanical replacement with function already imported in the same file
- No runtime behavior change for ASCII or valid Unicode input

Generated with Claude Code