### PR TITLE
fix(reply): surface block-reply coalescer buffered-tail discard after abort

### DIFF
--- a/src/auto-reply/reply/block-reply-coalescer.test.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.test.ts
@@ -1,0 +1,62 @@
+/** Tests the block reply coalescer's final-flush and abort-discard contract. */
+import { describe, expect, it } from "vitest";
+import type { ReplyPayload } from "../types.js";
+import { createBlockReplyCoalescer } from "./block-reply-coalescer.js";
+
+const baseConfig = { minChars: 100, maxChars: 2000, idleMs: 1000, joiner: "" };
+
+describe("createBlockReplyCoalescer final-flush contract", () => {
+  // streaming.md:96 — "final flush always sends remaining text". A forced flush must
+  // emit a buffered tail even when it is shorter than minChars.
+  it("force-flush delivers a sub-minChars buffered tail", async () => {
+    const flushed: string[] = [];
+    const coalescer = createBlockReplyCoalescer({
+      config: baseConfig,
+      shouldAbort: () => false,
+      onFlush: (payload: ReplyPayload) => {
+        if (payload.text) {
+          flushed.push(payload.text);
+        }
+      },
+    });
+
+    coalescer.enqueue({ text: "short tail" });
+    expect(coalescer.hasBuffered()).toBe(true);
+
+    await coalescer.flush({ force: true });
+
+    expect(flushed).toEqual(["short tail"]);
+    expect(coalescer.hasBuffered()).toBe(false);
+  });
+
+  // Regression for #102578: once a prior streamed block timed out (shouldAbort() === true),
+  // a forced final flush cannot send the buffered tail in order, but the drop must be
+  // observable rather than silent. End-to-end content is re-delivered by the finals
+  // fallback (shouldDropFinalPayloads is gated on !isAborted).
+  it("logs, does not silently discard, a buffered tail on force-flush after abort", async () => {
+    let aborted = false;
+    const flushed: string[] = [];
+    const logs: string[] = [];
+    const coalescer = createBlockReplyCoalescer({
+      config: baseConfig,
+      shouldAbort: () => aborted,
+      logVerbose: (message) => logs.push(message),
+      onFlush: (payload: ReplyPayload) => {
+        if (payload.text) {
+          flushed.push(payload.text);
+        }
+      },
+    });
+
+    coalescer.enqueue({ text: "final tail below minChars" });
+    expect(coalescer.hasBuffered()).toBe(true);
+
+    // A prior block send timed out between buffering the tail and finalization.
+    aborted = true;
+    await coalescer.flush({ force: true });
+
+    // Not sent in order, but the discard is surfaced instead of being silent.
+    expect(flushed).toEqual([]);
+    expect(logs.some((message) => message.includes("after abort"))).toBe(true);
+  });
+});

--- a/src/auto-reply/reply/block-reply-coalescer.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.ts
@@ -17,8 +17,9 @@ export function createBlockReplyCoalescer(params: {
   config: BlockStreamingCoalescing;
   shouldAbort: () => boolean;
   onFlush: (payload: ReplyPayload) => Promise<void> | void;
+  logVerbose?: (message: string) => void;
 }): BlockReplyCoalescer {
-  const { config, shouldAbort, onFlush } = params;
+  const { config, shouldAbort, onFlush, logVerbose } = params;
   const minChars = Math.max(1, Math.floor(config.minChars));
   const maxChars = Math.max(minChars, Math.floor(config.maxChars));
   const idleMs = Math.max(0, Math.floor(config.idleMs));
@@ -80,6 +81,14 @@ export function createBlockReplyCoalescer(params: {
   const flush = async (options?: { force?: boolean }) => {
     clearIdleTimer();
     if (shouldAbort()) {
+      // Prior block aborted — buffered tail cannot be sent in order. Surface the
+      // drop instead of losing it silently; finals fallback re-delivers the full reply.
+      // This discard was silent before adding this log — no error, no telemetry.
+      if (bufferText) {
+        logVerbose?.(
+          `block reply coalescer dropped ${bufferText.length} buffered chars after abort; final reply falls back to non-streamed delivery`,
+        );
+      }
       resetBuffer();
       return;
     }

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -228,6 +228,7 @@ export function createBlockReplyPipeline(params: {
     ? createBlockReplyCoalescer({
         config: coalescing,
         shouldAbort: () => aborted,
+        logVerbose,
         onFlush: (payload) => {
           bufferedAssistantMessageIndex = undefined;
           bufferedKeys.clear();


### PR DESCRIPTION
### What Problem This Solves

Issue #102578: with `channels.telegram.streaming.mode="block"`, the block-reply coalescer's `flush` abort branch silently resets buffered text with **no log** — the discard is invisible to operators even in verbose mode. When a prior block send times out, the buffered tail is dropped, but the finals fallback (`shouldDropFinalPayloads` gated on `!isAborted`) already re-delivers the full reply — so no user-visible loss occurs. The only real defect is the silence.

### Why This Change Was Made

Three-part static analysis (coalescer, agent-runner finalizer, payloads-suppression) confirmed that the original reported mechanism — "turn ends within `idleMs`, `stop()` clears timer without flush" — is already covered on `main` by the existing `await blockReplyPipeline.flush({ force: true })` before `stop()` (present since January 2026, commit `fd15704c77`). The remaining hazard is narrower: the coalescer's `shouldAbort()` branch discards the buffer without any observability. This one-line log closes the gap.

The `flushOnEnqueue` schema exposure suggested in the issue is deferred to #102580 and not part of this PR — it belongs in a separate config-surface discussion.

### User Impact

- Operators running with verbose logging will see a diagnostic when a buffered tail is discarded after abort, instead of silence.
- No runtime behavior change — finals fallback still covers re-delivery.

### Evidence

- **Unit**: `pnpm test src/auto-reply/reply/block-reply-coalescer.test.ts src/auto-reply/reply/block-reply-pipeline.test.ts src/auto-reply/reply/block-reply-pipeline.multi-message.test.ts` — 28 tests, 0 failures (local vitest, Linux Node 22.19). Includes one new characterization test (force-flush delivers sub-`minChars` tail) and one regression (aborted force-flush logs, does not silently discard).
- **Typecheck**: `pnpm tsgo:core` green (incremental).
- **Format**: `oxfmt --check` green on all three files.
- **Live proof gap**: No Telegram DM live repro was run — this is an observability-only change; the finals fallback already handles message delivery.

Closes #102578.