### PR TITLE
fix(google): bound Gemini batch file content reads to prevent OOM

### DIFF
--- a/extensions/google/embedding-batch.ts
+++ b/extensions/google/embedding-batch.ts
@@ -12,6 +12,7 @@ import {
 import {
   createProviderHttpError,
   readProviderJsonResponse,
+  readResponseTextLimited,
 } from "openclaw/plugin-sdk/provider-http";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { GeminiEmbeddingClient, GeminiTextEmbeddingRequest } from "./embedding-provider.js";
@@ -54,6 +55,7 @@ type GeminiBatchOutputLine = {
 };
 
 const GEMINI_BATCH_MAX_REQUESTS = 50000;
+const GEMINI_BATCH_FILE_CONTENT_MAX_BYTES = 64 * 1024 * 1024;
 function hashText(text: string): string {
   return crypto.createHash("sha256").update(text).digest("hex");
 }
@@ -220,7 +222,7 @@ async function fetchGeminiFileContent(params: {
       if (!res.ok) {
         throw await createProviderHttpError(res, "gemini batch file content failed");
       }
-      return await res.text();
+      return await readResponseTextLimited(res, GEMINI_BATCH_FILE_CONTENT_MAX_BYTES);
     },
   });
 }


### PR DESCRIPTION
## Summary

- `fetchGeminiFileContent` in `extensions/google/embedding-batch.ts` called unbounded `res.text()` to download Gemini batch embedding output files
- A large batch result could cause Node.js to buffer the entire response body in memory, leading to an out-of-memory crash
- Replaced with `readResponseTextLimited(res, GEMINI_BATCH_FILE_CONTENT_MAX_BYTES)` at 64 MiB cap

## Linked context

Follows the same bounded-response-read pattern introduced by PRs #97784 (msteams), #97782 (feishu), and #97693 (discord).

## Real behavior proof

**Behavior or issue addressed:** Unbounded `res.text()` in `fetchGeminiFileContent` could OOM on large batch outputs.

**Real environment tested:** Branch `fix/google-embedding-batch-bound-response-read`; all 403 tests pass (29 files); full build passes.

**Exact steps or command run after this patch:**
- `pnpm test extensions/google` — 403 passed, 29 files
- `pnpm build` — full build passes

**Evidence after fix:** `readResponseTextLimited` streams response chunks and cancels the reader when the 64 MiB cap is reached.

**What was not tested:** Live Gemini batch endpoint (requires real credentials).

## Tests and validation

```
pnpm test extensions/google  # 403 passed (29 files)
pnpm build                   # full build passes
```

## Risk checklist

- [x] Does not affect user-facing behavior
- [x] Does not change config surfaces
- [x] Does not change plugin SDK API
- [x] No new dependencies
- [x] No security impact

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)