### PR TITLE
test(agents): add UTF-16 boundary regression test for long error log preview

### DIFF
--- a/src/agents/embedded-agent-helpers/errors.test.ts
+++ b/src/agents/embedded-agent-helpers/errors.test.ts
@@ -6,8 +6,9 @@ import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../../shared/assista
 import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
 import { formatAssistantErrorText, isLikelyContextOverflowError } from "./errors.js";
 
-const { toolPolicyAuditInfo } = vi.hoisted(() => ({
+const { toolPolicyAuditInfo, warnMock } = vi.hoisted(() => ({
   toolPolicyAuditInfo: vi.fn(),
+  warnMock: vi.fn(),
 }));
 
 vi.mock("../../logging/subsystem.js", () => ({
@@ -15,7 +16,7 @@ vi.mock("../../logging/subsystem.js", () => ({
     debug: vi.fn(),
     error: vi.fn(),
     info: toolPolicyAuditInfo,
-    warn: vi.fn(),
+    warn: warnMock,
   }),
 }));
 
@@ -105,5 +106,50 @@ describe("isLikelyContextOverflowError", () => {
         "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.",
       ),
     ).toBe(true);
+  });
+});
+
+function hasLoneSurrogate(s: string): boolean {
+  for (let i = 0; i < s.length; i += 1) {
+    const c = s.charCodeAt(i);
+    if (c >= 0xd800 && c <= 0xdbff) {
+      if (i + 1 >= s.length || s.charCodeAt(i + 1) < 0xdc00 || s.charCodeAt(i + 1) > 0xdfff) {
+        return true;
+      }
+    }
+    if (c >= 0xdc00 && c <= 0xdfff) {
+      if (i === 0 || s.charCodeAt(i - 1) < 0xd800 || s.charCodeAt(i - 1) > 0xdbff) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+describe("formatAssistantErrorText long-error truncation", () => {
+  beforeEach(() => {
+    warnMock.mockClear();
+  });
+
+  it("does not split UTF-16 surrogate pairs in the logged preview or returned text", () => {
+    // 199 ASCII chars put the high surrogate of the emoji exactly at the
+    // legacy 200-code-unit cut point; the trailing padding keeps total length
+    // above the 600-code-unit truncation threshold.
+    const raw = "a".repeat(199) + "😀" + "b".repeat(500);
+    const msg = makeAssistantMessageFixture({
+      errorMessage: raw,
+      content: [{ type: "text", text: raw }],
+    });
+
+    const friendly = formatAssistantErrorText(msg);
+
+    expect(friendly).toContain("…");
+    expect(hasLoneSurrogate(friendly ?? "")).toBe(false);
+    expect(warnMock).toHaveBeenCalled();
+    const warnCall = warnMock.mock.calls.find((call) =>
+      String(call[0]).includes("Long error truncated"),
+    );
+    expect(warnCall).toBeDefined();
+    expect(hasLoneSurrogate(String(warnCall![0]))).toBe(false);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

`formatAssistantErrorText` already uses `truncateUtf16Safe` for both the debug log preview and the user-facing truncation when an assistant error exceeds 600 UTF-16 code units, but there is no regression test that exercises the 200-code-unit log boundary with a surrogate pair.

## Why This Change Was Made

Add a focused regression test so a future refactor cannot accidentally reintroduce raw `.slice(0, 200)` at this log site without failing CI.

## User Impact

No runtime change; this only hardens test coverage for debug log text handling.

## Scope

One file (`src/agents/embedded-agent-helpers/errors.test.ts`); no config, protocol, dependency, or compatibility change. AI-assisted.

## Real behavior proof

**Behavior addressed**: The existing `formatAssistantErrorText` path logs `Long error truncated: ...` for errors above 600 code units. The log preview is capped at 200 code units and must stay surrogate-safe.

**Real environment tested**: Local Linux checkout at head f7413617a953e98b14a029f673cb0f0e243e78d7, Node v22.22.0, repository vitest wrapper.

**Exact steps or command run after this patch**:

```bash
node scripts/run-vitest.mjs src/agents/embedded-agent-helpers/errors.test.ts
```

**Evidence after fix**:

```text
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

The regression test constructs a 199-ASCII + 😀 + 500-ASCII error so the legacy 200-code-unit cut would split the emoji's surrogate pair, then asserts both the returned friendly text and the logged preview contain no lone surrogates.

## Maintainer verification

- Exact head: f7413617a953e98b14a029f673cb0f0e243e78d7
- Local focused test: `node scripts/run-vitest.mjs src/agents/embedded-agent-helpers/errors.test.ts` — pass
- Local lint: `node scripts/run-oxlint.mjs src/agents/embedded-agent-helpers/errors.test.ts` — pass
