### PR TITLE
fix(crestodian): use truncateUtf16Safe for text truncation

### DIFF
--- a/packages/tool-call-repair/src/stream-normalizer.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.ts
@@ -1,4 +1,5 @@
 // Tool Call Repair helper module supports stream normalizer behavior.
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   consumeJsonToolClosingMarker,
   END_TOOL_REQUEST,
@@ -411,7 +412,7 @@ function truncateSuppressedTextToolCallBuffer(text: string): string {
     return text;
   }
   return (
-    text.slice(0, TEXT_TOOL_CALL_BUFFER_MAX_CHARS) +
+    truncateUtf16Safe(text, TEXT_TOOL_CALL_BUFFER_MAX_CHARS) +
     text.slice(-TEXT_TOOL_CALL_SUPPRESSED_TAIL_CHARS)
   );
 }

--- a/src/crestodian/assistant-prompts.ts
+++ b/src/crestodian/assistant-prompts.ts
@@ -1,4 +1,5 @@
 // Crestodian assistant prompts drive the conversational custodian with typed-command output.
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { CrestodianOverview } from "./overview.js";
 
 /**
@@ -108,7 +109,7 @@ function formatHistory(history: CrestodianAssistantTurn[] | undefined): string[]
     ...recent.map((turn) => {
       const text =
         turn.text.length > HISTORY_TURN_MAX_CHARS
-          ? `${turn.text.slice(0, HISTORY_TURN_MAX_CHARS)}…`
+          ? `${truncateUtf16Safe(turn.text, HISTORY_TURN_MAX_CHARS)}…`
           : turn.text;
       return `${turn.role === "user" ? "User" : "Crestodian"}: ${text}`;
     }),

--- a/src/plugins/openai-compatible-embedding-provider.ts
+++ b/src/plugins/openai-compatible-embedding-provider.ts
@@ -1,5 +1,6 @@
 // Builds OpenAI-compatible embedding provider entries for plugins.
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { readProviderJsonResponse } from "../agents/provider-http-errors.js";
 import { normalizeSecretInputString } from "../config/types.secrets.js";
 import { resolveConfiguredSecretInputString } from "../gateway/resolve-configured-secret-input-string.js";
@@ -341,7 +342,7 @@ async function readEmbeddingErrorBodySnippet(response: Response): Promise<string
   }
   const text = new TextDecoder().decode(concatBytes(chunks, totalLength));
   if (text.length > EMBEDDING_ERROR_BODY_MAX_CHARS) {
-    return `${text.slice(0, EMBEDDING_ERROR_BODY_MAX_CHARS)}${EMBEDDING_ERROR_TRUNCATED_SUFFIX}`;
+    return `${truncateUtf16Safe(text, EMBEDDING_ERROR_BODY_MAX_CHARS)}${EMBEDDING_ERROR_TRUNCATED_SUFFIX}`;
   }
   return truncated ? `${text}${EMBEDDING_ERROR_TRUNCATED_SUFFIX}` : text;
 }


### PR DESCRIPTION
## What Problem This Solves

One `.slice(0, N)` truncation site may cut UTF-16 surrogate pairs in half when the text contains multi-byte characters such as emoji.

## Why This Change Was Made

Replacing `.slice(0, N)` with `truncateUtf16Safe` ensures truncated output is always valid Unicode.

## User Impact

Truncated text remains valid Unicode at existing size limits. No behavioral changes for ASCII-only content.

Generated with Claude Code