### PR TITLE
test(plugins): sync release contracts

### DIFF
--- a/extensions/canvas/index.test.ts
+++ b/extensions/canvas/index.test.ts
@@ -3,6 +3,7 @@ import type { AnyAgentTool, OpenClawPluginApi } from "openclaw/plugin-sdk/plugin
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import canvasPlugin from "./index.js";
+import { SHOW_WIDGET_REQUIRED_CLIENT_CAPS } from "./src/tool-schema.js";
 
 const mocks = vi.hoisted(() => {
   const httpHandler = {
@@ -11,6 +12,7 @@ const mocks = vi.hoisted(() => {
     close: vi.fn(async () => {}),
   };
   const toolExecute = vi.fn(async () => ({ content: [{ type: "text", text: "ok" }] }));
+  const widgetToolExecute = vi.fn(async () => ({ content: [{ type: "text", text: "widget" }] }));
   return {
     httpHandler,
     createCanvasHttpRouteHandler: vi.fn(() => httpHandler),
@@ -24,6 +26,14 @@ const mocks = vi.hoisted(() => {
       description: "Canvas",
       parameters: {},
       execute: toolExecute,
+    })),
+    widgetToolExecute,
+    createShowWidgetTool: vi.fn(() => ({
+      label: "Show Widget",
+      name: "show_widget",
+      description: "Show Widget",
+      parameters: {},
+      execute: widgetToolExecute,
     })),
   };
 });
@@ -45,11 +55,18 @@ vi.mock("./src/tool.js", () => ({
   createCanvasTool: mocks.createCanvasTool,
 }));
 
+vi.mock("./src/widget-tool.js", () => ({
+  createShowWidgetTool: mocks.createShowWidgetTool,
+}));
+
 function registerCanvas() {
   const routes: Array<Parameters<OpenClawPluginApi["registerHttpRoute"]>[0]> = [];
   const services: Array<Parameters<OpenClawPluginApi["registerService"]>[0]> = [];
   const resolvers: Array<Parameters<OpenClawPluginApi["registerHostedMediaResolver"]>[0]> = [];
-  const tools: Array<Parameters<OpenClawPluginApi["registerTool"]>[0]> = [];
+  const tools: Array<{
+    tool: Parameters<OpenClawPluginApi["registerTool"]>[0];
+    opts: Parameters<OpenClawPluginApi["registerTool"]>[1];
+  }> = [];
   const cliFeatures: Array<{
     registrar: Parameters<OpenClawPluginApi["registerNodeCliFeature"]>[0];
     opts: Parameters<OpenClawPluginApi["registerNodeCliFeature"]>[1];
@@ -62,7 +79,7 @@ function registerCanvas() {
       registerHttpRoute: (route) => routes.push(route),
       registerService: (service) => services.push(service),
       registerHostedMediaResolver: (resolver) => resolvers.push(resolver),
-      registerTool: (tool) => tools.push(tool),
+      registerTool: (tool, opts) => tools.push({ tool, opts }),
       registerNodeCliFeature: (registrar, opts) => cliFeatures.push({ registrar, opts }),
       registerNodeInvokePolicy: vi.fn(),
     }),
@@ -97,11 +114,13 @@ describe("Canvas plugin entry", () => {
     const { resolvers, tools, cliFeatures } = registerCanvas();
 
     expect(resolvers).toHaveLength(1);
-    expect(tools).toHaveLength(1);
+    expect(tools).toHaveLength(2);
+    expect(tools.map(({ opts }) => opts?.name)).toEqual([undefined, "show_widget"]);
     expect(cliFeatures).toHaveLength(1);
     expect(mocks.resolveCanvasHttpPathToLocalPath).not.toHaveBeenCalled();
     expect(mocks.createDefaultCanvasCliDependencies).not.toHaveBeenCalled();
     expect(mocks.createCanvasTool).not.toHaveBeenCalled();
+    expect(mocks.createShowWidgetTool).not.toHaveBeenCalled();
 
     await expect(resolvers[0]?.("/__openclaw__/canvas/documents/id/index.html")).resolves.toBe(
       "/tmp/canvas-asset",
@@ -118,21 +137,42 @@ describe("Canvas plugin entry", () => {
     expect(mocks.createDefaultCanvasCliDependencies).toHaveBeenCalledTimes(1);
     expect(mocks.registerNodesCanvasCommands).toHaveBeenCalledTimes(1);
 
-    const toolFactory = tools[0];
-    expect(typeof toolFactory).toBe("function");
-    const tool = (toolFactory as Exclude<typeof toolFactory, AnyAgentTool>)({
-      config: {},
-      workspaceDir: "/tmp/workspace",
+    const registeredTools = tools.map(({ tool: toolFactory }) => {
+      expect(typeof toolFactory).toBe("function");
+      const tool = (toolFactory as Exclude<typeof toolFactory, AnyAgentTool>)({
+        config: {},
+        workspaceDir: "/tmp/workspace",
+        sessionId: "session-1",
+        agentId: "agent-1",
+      });
+      expect(Array.isArray(tool)).toBe(false);
+      return tool as AnyAgentTool;
     });
-    expect(Array.isArray(tool)).toBe(false);
-    expect((tool as AnyAgentTool).name).toBe("canvas");
+    expect(registeredTools.map((tool) => tool.name)).toEqual(["canvas", "show_widget"]);
+    expect(registeredTools[1]?.requiredClientCaps).toEqual(SHOW_WIDGET_REQUIRED_CLIENT_CAPS);
     expect(mocks.createCanvasTool).not.toHaveBeenCalled();
+    expect(mocks.createShowWidgetTool).not.toHaveBeenCalled();
 
-    await (tool as AnyAgentTool).execute("tool-call", { action: "hide" });
+    const [canvasTool, showWidgetTool] = registeredTools;
+    await canvasTool?.execute("tool-call", { action: "hide" });
     expect(mocks.createCanvasTool).toHaveBeenCalledWith({
       config: {},
       workspaceDir: "/tmp/workspace",
     });
     expect(mocks.toolExecute).toHaveBeenCalledWith("tool-call", { action: "hide" });
+
+    await showWidgetTool?.execute("widget-call", {
+      title: "Status",
+      widget_code: "<p>ready</p>",
+    });
+    expect(mocks.createShowWidgetTool).toHaveBeenCalledWith({
+      config: {},
+      sessionId: "session-1",
+      agentId: "agent-1",
+    });
+    expect(mocks.widgetToolExecute).toHaveBeenCalledWith("widget-call", {
+      title: "Status",
+      widget_code: "<p>ready</p>",
+    });
   });
 });

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -280,6 +280,7 @@ describe("Codex app-server dynamic tool build", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
     params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
     params.clientCaps = ["tool-events", "inline-widgets"];
     let receivedClientCaps: string[] | undefined;
     setOpenClawCodingToolsFactoryForTests((options) => {

--- a/src/plugins/bundled-plugin-metadata.test.ts
+++ b/src/plugins/bundled-plugin-metadata.test.ts
@@ -36,6 +36,7 @@ const EXPECTED_BUNDLED_STARTUP_PLUGIN_IDS = [
   "bonjour",
   "browser",
   "canvas",
+  "codex-supervisor",
   "device-pair",
   "diagnostics-otel",
   "diagnostics-prometheus",


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation at `e2a112a5565ee40a6caf2a53e004d9efa49038ab` exposed two deterministic Plugin Prerelease failures:

- the bundled startup-plugin baseline omitted `codex-supervisor` after its manifest adopted startup activation;
- the Canvas entrypoint test still expected one registered tool after `show_widget` became the second capability-gated tool.
- the Codex client-capability test omitted the lightweight runtime-plan fixture used by adjacent tests, causing full provider/plugin normalization and a 120-second Plugin Prerelease timeout.

## Why This Change Was Made

The runtime and manifests are correct. This updates the stale contracts and strengthens Canvas coverage: the test now asserts both registrations, the `show_widget` registration name and required client capability, lazy loading for both implementations, and forwarded session/agent context. The Codex test now supplies the same deterministic runtime-plan fixture as neighboring dynamic-tool tests instead of increasing its timeout.

## User Impact

No runtime behavior changes. Plugin prerelease validation no longer blocks release preparation on stale expectations, and future Canvas tool additions must update explicit registration/laziness coverage.

## Evidence

- Failing Plugin Prerelease run: https://github.com/openclaw/openclaw/actions/runs/29015825550
- `checks-node-agentic-plugins` failure: https://github.com/openclaw/openclaw/actions/runs/29015825550/job/86110487147
- extension shard failure: https://github.com/openclaw/openclaw/actions/runs/29015825550/job/86110487263
- Testbox `tbx_01kx3ckertkz7npw090hp9naem`: 89/89 focused tests passed; the formerly hanging Codex file completed in 1.5 seconds; exact three-file `oxfmt` check passed.
- Reproduction without the runtime-plan fixture: focused test spent 112.8 seconds in the capability case; the release shard timed out at 120 seconds.
- Fresh autoreview: no findings; correctness confidence 0.99.
- `git diff --check`: passed.

No docs or changelog change: test-contract repair only.
