### PR TITLE
refactor(xai): localize internal declarations

### DIFF
--- a/extensions/xai/src/code-execution-config.ts
+++ b/extensions/xai/src/code-execution-config.ts
@@ -1,7 +1,7 @@
 // Xai helper module supports code execution config behavior.
 import { isXaiToolEnabled, type XaiToolAuthContext } from "./tool-auth-shared.js";
 
-export type CodeExecutionConfig = {
+type CodeExecutionConfig = {
   enabled?: boolean;
   model?: string;
   maxTurns?: number;

--- a/extensions/xai/web-search-provider-shared.ts
+++ b/extensions/xai/web-search-provider-shared.ts
@@ -4,7 +4,7 @@ import {
   type WebSearchProviderPlugin,
 } from "openclaw/plugin-sdk/provider-web-search-config-contract";
 
-export const XAI_WEB_SEARCH_CREDENTIAL_PATH = "plugins.entries.xai.config.webSearch.apiKey";
+const XAI_WEB_SEARCH_CREDENTIAL_PATH = "plugins.entries.xai.config.webSearch.apiKey";
 
 export function buildXaiWebSearchProviderBase(): Omit<
   WebSearchProviderPlugin,

--- a/extensions/xai/xai-oauth.ts
+++ b/extensions/xai/xai-oauth.ts
@@ -18,13 +18,13 @@ import { applyXaiConfig, XAI_DEFAULT_MODEL_REF } from "./onboard.js";
 import { xaiUserAgent } from "./src/xai-user-agent.js";
 
 const PROVIDER_ID = "xai";
-export const XAI_OAUTH_METHOD_ID = "oauth";
-export const XAI_OAUTH_CHOICE_ID = "xai-oauth";
-export const XAI_DEVICE_CODE_METHOD_ID = "device-code";
-export const XAI_DEVICE_CODE_CHOICE_ID = "xai-device-code";
+const XAI_OAUTH_METHOD_ID = "oauth";
+const XAI_OAUTH_CHOICE_ID = "xai-oauth";
+const XAI_DEVICE_CODE_METHOD_ID = "device-code";
+const XAI_DEVICE_CODE_CHOICE_ID = "xai-device-code";
 export const XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
 export const XAI_OAUTH_SCOPE = "openid profile email offline_access grok-cli:access api:access";
-export const XAI_OAUTH_ISSUER = "https://auth.x.ai";
+const XAI_OAUTH_ISSUER = "https://auth.x.ai";
 export const XAI_OAUTH_DISCOVERY_URL = `${XAI_OAUTH_ISSUER}/.well-known/openid-configuration`;
 const XAI_LEGACY_OAUTH_TOKEN_ENDPOINT = `${XAI_OAUTH_ISSUER}/oauth/token`;
 


### PR DESCRIPTION
## What Problem This Solves

The xAI plugin exported seven declarations that are only used inside their defining modules. Keeping those implementation details exported enlarges the apparent plugin surface and makes dead-code and API ownership analysis noisier.

## Why This Change Was Made

Localize the unused type and constants while preserving every runtime value, public function, and explicitly consumed xAI export. This is a maintainer-requested cleanup from the ongoing cross-surface dead-code sweep.

## User Impact

No user-visible behavior changes. The xAI plugin has a smaller, more accurate internal module surface.

## Evidence

- Refreshed codebase-memory MCP graph on current main and verified exact repository references for all seven declarations.
- `OPENCLAW_TESTBOX=1 pnpm check:changed` passed on the changed extension lanes.
- `pnpm test:serial extensions/xai`: 22 files passed, 214 tests passed.
- `pnpm build` passed.
- Fresh local and branch autoreview passes reported no actionable findings.
- Testbox: `tbx_01kx3bja6r91xjpy9tc79k9vrr`
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29016273933

AI-assisted: yes. The diff, repository references, tests, build, and review output were inspected before submission.
