### PR TITLE
fix(utils): drain falsy queue items

### DIFF
--- a/src/utils/queue-helpers.test.ts
+++ b/src/utils/queue-helpers.test.ts
@@ -151,6 +151,33 @@ describe("drainCollectQueueStep", () => {
 });
 
 describe("drainNextQueueItem", () => {
+  it("drains falsy queued items instead of treating them as empty", async () => {
+    const items = [0, 1];
+    const delivered: number[] = [];
+
+    const drained = await drainNextQueueItem(items, async (item) => {
+      delivered.push(item);
+    });
+
+    expect(drained).toBe(true);
+    expect(delivered).toEqual([0]);
+    expect(items).toEqual([1]);
+  });
+
+  it("removes NaN after draining it", async () => {
+    const items = [Number.NaN, 1];
+    const delivered: number[] = [];
+
+    const drained = await drainNextQueueItem(items, async (item) => {
+      delivered.push(item);
+    });
+
+    expect(drained).toBe(true);
+    expect(delivered).toHaveLength(1);
+    expect(Number.isNaN(delivered[0])).toBe(true);
+    expect(items).toEqual([1]);
+  });
+
   it("keeps overflow survivors when the queue mutates during an awaited drain", async () => {
     type Item = { id: string };
     const queue = {

--- a/src/utils/queue-helpers.ts
+++ b/src/utils/queue-helpers.ts
@@ -168,7 +168,7 @@ export function beginQueueDrain<T extends { draining: boolean }>(
 
 export function removeQueuedItemsByRef<T>(items: T[], processed: readonly T[]): void {
   for (const item of processed) {
-    const idx = items.indexOf(item);
+    const idx = items.findIndex((queued) => queued === item || Object.is(queued, item));
     if (idx !== -1) {
       items.splice(idx, 1);
     }
@@ -180,10 +180,10 @@ export async function drainNextQueueItem<T>(
   items: T[],
   run: (item: T) => Promise<void>,
 ): Promise<boolean> {
-  const next = items[0];
-  if (!next) {
+  if (items.length === 0) {
     return false;
   }
+  const next = items[0];
   await run(next);
   removeQueuedItemsByRef(items, [next]);
   return true;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers using the shared queue drain helper could have falsy queued values treated as an empty queue, leaving valid queued work unprocessed.

## Why This Change Was Made

The queue helper now uses queue length to detect emptiness, so queued values such as `0` are still delivered. The same helper boundary also removes processed values with `===`/`Object.is` matching so `NaN` cannot be processed repeatedly after it is drained.

## User Impact

Queue owners can rely on the shared helper to drain every queued item by position and identity semantics instead of JavaScript truthiness, avoiding skipped falsy work and repeated `NaN` drains in numeric queues.

## Evidence

- Claim proved: `drainNextQueueItem` drains falsy queued items and removes processed `NaN` values without leaving them in the queue.
- Current-head proof at `dce66b9819153978bd4e2d276030626c1305138c`: `node scripts/run-vitest.mjs src/utils/queue-helpers.test.ts` passed in `E:\code\openclaw-lane-e` with 1 file and 12 tests passing.
- Committed diff hygiene: `git diff --check HEAD~1..HEAD` passed.
- Review proof: `python .agents\skills\autoreview\scripts\autoreview --mode local` passed with no accepted/actionable findings.
- Observed result: the focused tests show `0` is delivered and removed, and `NaN` is delivered once and removed from the queue.