### PR TITLE
fix(queue): shared queue drains skip falsy items when processing one item

### DIFF
--- a/src/utils/queue-helpers.test.ts
+++ b/src/utils/queue-helpers.test.ts
@@ -151,6 +151,33 @@ describe("drainCollectQueueStep", () => {
 });
 
 describe("drainNextQueueItem", () => {
+  it("drains falsy queued items instead of treating them as empty", async () => {
+    const items = [0, 1];
+    const delivered: number[] = [];
+
+    const drained = await drainNextQueueItem(items, async (item) => {
+      delivered.push(item);
+    });
+
+    expect(drained).toBe(true);
+    expect(delivered).toEqual([0]);
+    expect(items).toEqual([1]);
+  });
+
+  it("removes NaN after draining it", async () => {
+    const items = [Number.NaN, 1];
+    const delivered: number[] = [];
+
+    const drained = await drainNextQueueItem(items, async (item) => {
+      delivered.push(item);
+    });
+
+    expect(drained).toBe(true);
+    expect(delivered).toHaveLength(1);
+    expect(Number.isNaN(delivered[0])).toBe(true);
+    expect(items).toEqual([1]);
+  });
+
   it("keeps overflow survivors when the queue mutates during an awaited drain", async () => {
     type Item = { id: string };
     const queue = {

--- a/src/utils/queue-helpers.ts
+++ b/src/utils/queue-helpers.ts
@@ -168,7 +168,7 @@ export function beginQueueDrain<T extends { draining: boolean }>(
 
 export function removeQueuedItemsByRef<T>(items: T[], processed: readonly T[]): void {
   for (const item of processed) {
-    const idx = items.indexOf(item);
+    const idx = items.findIndex((queued) => queued === item || Object.is(queued, item));
     if (idx !== -1) {
       items.splice(idx, 1);
     }
@@ -180,10 +180,10 @@ export async function drainNextQueueItem<T>(
   items: T[],
   run: (item: T) => Promise<void>,
 ): Promise<boolean> {
-  const next = items[0];
-  if (!next) {
+  if (items.length === 0) {
     return false;
   }
+  const next = items[0];
   await run(next);
   removeQueuedItemsByRef(items, [next]);
   return true;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where shared queue helper consumers would treat a valid falsy queued item, such as `0`, as an empty queue when draining one item. It also ensures `NaN` can be removed after it is processed instead of remaining in the queue.

## Why This Change Was Made

The queue helper now detects emptiness from `items.length` before reading the next item, and processed-item removal uses SameValue-aware matching while preserving normal strict-reference behavior. This keeps the fix inside the shared helper without changing queue caps, overflow policy, or caller-specific behavior.

AI-assisted.

## User Impact

Queue helper users can process and remove all valid queued values consistently. Existing object-based queue behavior remains unchanged.

## Evidence

- Claim proved: shared one-item queue drains process falsy queued values and remove `NaN` after processing.
- Current-head proof at `cac706a90c1703945e59310c1e846c61ed3c0e2f`: `node scripts/run-vitest.mjs src/utils/queue-helpers.test.ts` passed with 1 test file and 12 tests.
- Committed diff hygiene: `git diff --check HEAD~1..HEAD` passed.
- Review proof: `python .agents\skills\autoreview\scripts\autoreview --mode commit --commit HEAD` passed with no accepted/actionable findings.
- Duplicate search: no open issues or open/closed PRs found for `drainNextQueueItem`/`removeQueuedItemsByRef` falsy or `NaN` queue handling.