### PR TITLE
fix(qqbot): use configured bot display name in ref index, not accountId

### DIFF
--- a/extensions/qqbot/src/engine/gateway/gateway.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway.ts
@@ -83,7 +83,7 @@ export async function startGateway(ctx: CoreGatewayContext): Promise<void> {
     setRefIndex(refIdx, {
       content: meta.text ?? "",
       senderId: account.accountId,
-      senderName: account.accountId,
+      senderName: account.name ?? account.accountId,
       timestamp: Date.now(),
       isBot: true,
       ...(attachments.length > 0 ? { attachments } : {}),


### PR DESCRIPTION
## What Problem This Solves

`setRefIndex` in the QQ Bot gateway writes the bot's account ID into `senderName` instead of the configured display name. The `ResolvedQQBotAccount` type has a `name` field for this purpose, and the sibling `event-dispatcher.ts` correctly uses `ev.author.username` (a display name) when processing user messages — the bot-path just used the wrong field.

## Why This Change Was Made

Downstream, `formatSenderLabelFrom` checks `name.includes(id)` to decide whether to append the raw ID. When `senderName === senderId`, the guard triggers every time, so the bot appears as a bare ID (`app_123456`) in quoted-reply and multi-bot contexts. One line, falls back to `account.accountId` when no display name is configured.

## User Impact

QQ bots with a configured display name now show that name in quoted replies and conversation history the AI model sees, instead of a raw application ID.

## Evidence

- `node scripts/run-vitest.mjs extensions/qqbot/src/engine/gateway/` — 129 tests passed across 14 files, zero regression.
- Sibling: `extensions/qqbot/src/engine/gateway/event-dispatcher.ts:88,111,162` already uses `ev.author.username` for `senderName`.
- Type: `extensions/qqbot/src/types.ts:19` — `name?: string` on `ResolvedQQBotAccount`.

AI-assisted: built with Codex
