### PR TITLE
refactor(ui): localize internal declarations

### DIFF
--- a/ui/src/app-navigation.ts
+++ b/ui/src/app-navigation.ts
@@ -62,7 +62,7 @@ export function sidebarMoreRoutes(pinned: readonly SidebarNavRoute[]): SidebarNa
   return SIDEBAR_NAV_ROUTES.filter((routeId) => !pinned.includes(routeId));
 }
 
-export type SettingsNavigationGroup = {
+type SettingsNavigationGroup = {
   /** i18n key for the group heading; null renders the group without a label. */
   labelKey: string | null;
   routes: readonly NavigationRouteId[];

--- a/ui/src/components/settings-sidebar.ts
+++ b/ui/src/components/settings-sidebar.ts
@@ -11,7 +11,7 @@ import { pathForRoute, type RouteId } from "../app-route-paths.ts";
 import { t } from "../i18n/index.ts";
 import { icons } from "./icons.ts";
 
-export type SettingsSidebarProps = {
+type SettingsSidebarProps = {
   basePath: string;
   activeRouteId: RouteId;
   connected: boolean;

--- a/ui/src/lib/sessions/drag.ts
+++ b/ui/src/lib/sessions/drag.ts
@@ -1,6 +1,6 @@
 // Private MIME keeps stray text and file drags from becoming session actions.
 export const SESSION_DRAG_MIME = "application/x-openclaw-session-key";
-export const SESSION_GROUP_DRAG_MIME = "application/x-openclaw-session-group";
+const SESSION_GROUP_DRAG_MIME = "application/x-openclaw-session-group";
 
 export function writeSessionDragData(dataTransfer: DataTransfer, sessionKey: string): void {
   dataTransfer.setData(SESSION_DRAG_MIME, sessionKey);

--- a/ui/src/pages/chat/realtime-talk-level.ts
+++ b/ui/src/pages/chat/realtime-talk-level.ts
@@ -1,4 +1,4 @@
-export type RealtimeTalkLevelListener = (level: number) => void;
+type RealtimeTalkLevelListener = (level: number) => void;
 
 export class RealtimeTalkLevelSignal {
   private listeners = new Set<RealtimeTalkLevelListener>();


### PR DESCRIPTION
## What Problem This Solves

Four Control UI declarations were exported even though every use is confined to the defining module. That unnecessarily broadens the internal module surface and leaves false-positive dead-code candidates.

## Why This Change Was Made

Keep module APIs narrow by removing only the unused export modifiers. Runtime behavior and public UI exports are unchanged.

## User Impact

None. This is an internal TypeScript surface cleanup.

## Evidence

- Exact repository-wide symbol searches and explicit barrel inspection found no external imports.
- Refreshed codebase-memory graph: 283,344 nodes / 1,149,079 edges.
- Testbox changed-path gate passed on the final rebased tree.
- Full Control UI suite passed: 148 files, 2,391 tests.
- Full build passed.
- Fresh local and branch autoreviews reported no actionable findings.