### PR TITLE
fix(feishu): use trimmed replyToMessageId in replyInThread check

### DIFF
--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -461,7 +461,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
             to: ctx.to,
             card,
             replyToMessageId,
-            replyInThread: ctx.threadId != null && !ctx.replyToId,
+            replyInThread: ctx.threadId != null && !replyToMessageId,
             accountId: ctx.accountId ?? undefined,
           }),
       }),


### PR DESCRIPTION
## What Problem This Solves

`replyInThread` in the Feishu card send-path used the raw `ctx.replyToId` instead of the already-normalized `replyToMessageId`. When `replyToId` is a whitespace-only string, `!ctx.replyToId` is `false` (whitespace is truthy), so cards break out of the message thread.

`resolveFeishuMediaReplyMode` at L263 was already fixed for the same bug — this was the second instance that was missed.

## Why This Change Was Made

`replyToMessageId` was computed ~80 lines above via `resolveReplyToMessageId` which calls `.trim()` and returns `undefined` for whitespace-only values. Reuse it instead of the raw field.

## User Impact

Feishu cards and interactive replies sent when `replyToId` is present but blank now thread correctly instead of appearing outside the conversation.

## Evidence

- `node scripts/run-vitest.mjs extensions/feishu/src/outbound.test.ts` — 60 passed, zero regression.
- Sibling already fixed: `resolveFeishuMediaReplyMode` L261-263 uses `trimmedReplyToId` for the same check.

AI-assisted: built with Codex