### PR TITLE
fix(qqbot): propagate canonical image MIME types

### DIFF
--- a/extensions/qqbot/src/engine/gateway/inbound-attachments.test.ts
+++ b/extensions/qqbot/src/engine/gateway/inbound-attachments.test.ts
@@ -89,8 +89,7 @@ describe("engine/gateway/inbound-attachments", () => {
       "/tmp/openclaw-qqbot-downloads/a.png",
       "/tmp/openclaw-qqbot-downloads/b.png",
     ]);
-    // The raw content_type passes through unchanged.
-    expect(result.imageMediaTypes).toEqual(["image/png", "Image/PNG"]);
+    expect(result.imageMediaTypes).toEqual(["image/png", "image/png"]);
     expect(result.attachmentInfo).toBe("");
   });
 
@@ -103,7 +102,7 @@ describe("engine/gateway/inbound-attachments", () => {
     );
 
     expect(result.imageUrls).toEqual(["https://cdn.example.test/a.png"]);
-    expect(result.imageMediaTypes).toEqual(["Image/PNG"]);
+    expect(result.imageMediaTypes).toEqual(["image/png"]);
     expect(result.attachmentLocalPaths).toEqual([null]);
   });
 

--- a/extensions/qqbot/src/engine/gateway/inbound-attachments.ts
+++ b/extensions/qqbot/src/engine/gateway/inbound-attachments.ts
@@ -1,12 +1,11 @@
 // Qqbot plugin module implements inbound attachments behavior.
+
+import { normalizeMimeType } from "openclaw/plugin-sdk/media-mime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { AudioConvertPort } from "../adapter/audio.port.js";
 import { downloadFile } from "../utils/file-utils.js";
 import { getQQBotMediaDir } from "../utils/platform.js";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-} from "../utils/string-normalize.js";
+import { normalizeOptionalString } from "../utils/string-normalize.js";
 import { transcribeAudio, resolveSTTConfig } from "../utils/stt.js";
 
 // Re-export the port type for convenience.
@@ -118,10 +117,9 @@ export async function processAttachments(
   const processTasks = downloadResults.map(
     async ({ att, attUrl, isVoice, localPath, audioPath }) => {
       const asrReferText = normalizeOptionalString(att.asr_refer_text) ?? "";
-      // MIME types are case-insensitive (RFC 2045) and relays may emit
-      // mixed-case values; compare lowercased but keep the raw content_type
-      // in returned fields.
-      const normalizedContentType = normalizeLowercaseStringOrEmpty(att.content_type);
+      // Canonicalize the type/subtype before both classification and propagation.
+      // Downstream image resolvers intentionally consume canonical MIME values.
+      const normalizedContentType = normalizeMimeType(att.content_type) ?? "";
       const wavUrl =
         isVoice && att.voice_wav_url
           ? att.voice_wav_url.startsWith("//")
@@ -138,7 +136,7 @@ export async function processAttachments(
       if (localPath) {
         if (normalizedContentType.startsWith("image/")) {
           log?.debug?.(`Downloaded attachment to: ${localPath}`);
-          return { localPath, type: "image" as const, contentType: att.content_type, meta };
+          return { localPath, type: "image" as const, contentType: normalizedContentType, meta };
         }
         if (isVoice) {
           log?.debug?.(`Downloaded attachment to: ${localPath}`);
@@ -162,7 +160,7 @@ export async function processAttachments(
           localPath: null,
           type: "image-fallback" as const,
           attUrl,
-          contentType: att.content_type,
+          contentType: normalizedContentType,
           meta,
         };
       }


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #102753. That PR correctly recognizes mixed-case QQBot image MIME types, but it still forwards the raw value (for example, `Image/PNG`) into `MediaType` / `MediaTypes`. The current-turn image resolver accepts canonical lowercase `image/*` values, so an otherwise valid downloaded image can still be omitted from model input.

## Why This Change Was Made

- Canonicalize the QQ attachment type once with the existing narrow `openclaw/plugin-sdk/media-mime` helper.
- Use that canonical value for both image classification and downstream image metadata.
- Preserve QQBot-owned attachment flow and avoid adding a second MIME parser.
- Cover both downloaded-image and remote-fallback paths.

## User Impact

QQBot images reported with mixed-case MIME types remain available to the agent after download or URL fallback instead of being classified as images and then discarded by downstream MIME validation.

## Evidence

- Before: `Image/PNG` is classified as an image but remains `Image/PNG`; `resolveCurrentImageMediaType` rejects it because it is neither lowercase `image/*` nor a generic type eligible for filename inference.
- After: the same attachment is propagated as `image/png` on both successful-download and fallback paths.
- Blacksmith Testbox `tbx_01kx3cqk3b6yh047hsx41qnjtp`: `corepack pnpm test extensions/qqbot/src/engine/gateway/inbound-attachments.test.ts` — 1 file, 7 tests passed.
- Testbox workflow: https://github.com/openclaw/openclaw/actions/runs/29017411553
- Fresh branch autoreview: no accepted or actionable findings.
- `git diff --check` passed.
