### PR TITLE
fix-model-list-utf16-truncation

### DIFF
--- a/src/commands/models/list.format.test.ts
+++ b/src/commands/models/list.format.test.ts
@@ -1,0 +1,44 @@
+// Model list formatting tests cover fixed-width terminal cell helpers.
+import { describe, expect, it } from "vitest";
+import { truncate } from "./list.format.js";
+
+function hasLoneSurrogate(value: string): boolean {
+  for (let i = 0; i < value.length; i += 1) {
+    const codeUnit = value.charCodeAt(i);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(i + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return true;
+      }
+    }
+    if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      const previous = value.charCodeAt(i - 1);
+      if (!(previous >= 0xd800 && previous <= 0xdbff)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+describe("truncate", () => {
+  it("preserves existing ASCII truncation with an ellipsis suffix", () => {
+    expect(truncate("abcdefghi", 6)).toBe("abc...");
+  });
+
+  it("keeps ellipsis-suffixed truncation on a UTF-16 boundary", () => {
+    const grin = String.fromCodePoint(0x1f600);
+    const result = truncate(`ab${grin}cde`, 6);
+
+    expect(result).toBe("ab...");
+    expect(hasLoneSurrogate(result)).toBe(false);
+  });
+
+  it("keeps tiny truncation budgets on a UTF-16 boundary", () => {
+    const grin = String.fromCodePoint(0x1f600);
+    const result = truncate(grin, 1);
+
+    expect(result).toBe("");
+    expect(hasLoneSurrogate(result)).toBe(false);
+  });
+});

--- a/src/commands/models/list.format.ts
+++ b/src/commands/models/list.format.ts
@@ -1,4 +1,5 @@
 /** Formatting helpers for model-list terminal tables. */
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { isRich as isRichTerminal, theme } from "../../../packages/terminal-core/src/theme.js";
 
 /** Enables rich formatting only for non-machine-readable output. */
@@ -43,7 +44,7 @@ export const truncate = (value: string, max: number) => {
     return value;
   }
   if (max <= 3) {
-    return value.slice(0, max);
+    return truncateUtf16Safe(value, max);
   }
-  return `${value.slice(0, max - 3)}...`;
+  return `${truncateUtf16Safe(value, max - 3)}...`;
 };


### PR DESCRIPTION
Use this PR title:

```text
fix(models): avoid broken emoji when model table rows are truncated
```

PR body:

```markdown
## What Problem This Solves

Fixes an issue where users viewing model table output would see broken emoji or other supplementary Unicode characters when long model names were truncated.

## Why This Change Was Made

Model table truncation now keeps UTF-16 boundaries intact while preserving the existing fixed-width table behavior and ASCII `...` suffix. This only affects terminal table rendering for model-list style output; JSON and plain output remain unchanged.

## User Impact

Users can expect truncated model table rows to remain readable and well-formed, including model names that contain emoji or other non-BMP Unicode characters.

## Evidence

- RED: `node scripts/run-vitest.mjs src/commands/models/list.format.test.ts` failed before the fix with dangling surrogate output.
- GREEN: `node scripts/run-vitest.mjs src/commands/models/list.format.test.ts` passed after the fix.
- Focused regression proof: `node scripts/run-vitest.mjs src/commands/models/list.format.test.ts src/commands/models/list.table.test.ts` passed.
- `git diff --check` passed.

Known proof gap: Blacksmith Testbox/Crabbox proof could not run because no `crabbox` binary is installed/discoverable in this environment.
```