### PR TITLE
fix(talk): use UTF-16 safe truncation in fast-context-runtime

### DIFF
--- a/src/talk/fast-context-runtime.ts
+++ b/src/talk/fast-context-runtime.ts
@@ -9,6 +9,7 @@ import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coerc
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { getActiveMemorySearchManager } from "../plugins/memory-runtime.js";
+import { truncateUtf16Safe } from "../utils.js";
 import type { RealtimeVoiceAgentConsultResult } from "./agent-consult-runtime.js";
 import { parseRealtimeVoiceAgentConsultArgs } from "./agent-consult-tool.js";
 
@@ -67,8 +68,9 @@ function normalizeSnippet(text: string): string {
     return normalized;
   }
   // Keep individual memory snippets bounded so several hits still fit in a
-  // short realtime response prompt.
-  return `${normalized.slice(0, MAX_SNIPPET_CHARS - 1).trimEnd()}...`;
+  // short realtime response prompt. Use UTF-16 safe truncation to avoid
+  // splitting emoji surrogate pairs.
+  return `${truncateUtf16Safe(normalized, MAX_SNIPPET_CHARS - 1).trimEnd()}...`;
 }
 
 function buildSearchQuery(args: unknown): string {


### PR DESCRIPTION
## What Problem This Solves

The `normalizeSnippet` function in `src/talk/fast-context-runtime.ts:71` uses unsafe `.slice(0, N)` to truncate text for LLM prompts. This can split emoji surrogate pairs when the truncation boundary falls in the middle of a surrogate pair, producing malformed UTF-16 text.

This is the same issue identified in PR #102477, but in a different code path (fast-context runtime for realtime voice).

## Why This Change Was Made

PR #102477 identified this pattern and introduced `truncateUtf16Safe` as the safe alternative. However, the fix was not applied to all affected locations. This PR fixes one of the remaining locations.

## User Impact

Prevents edge-case corruption of emoji-rich memory/session snippets when they are truncated for realtime voice context prompts. No visible impact expected since this is preventive.

## Evidence

- Type check passes: `pnpm tsgo:core --noEmit`
- The fix follows the exact same pattern as other `truncateUtf16Safe` usages in the codebase (see `src/shared/utf16-slice.ts`)
- Related: PR #102477 which identified this issue