### PR TITLE
fix(mcp): suppress PassThrough stderr stream errors in stdio transport

### DIFF
--- a/src/agents/mcp-stdio-transport.test.ts
+++ b/src/agents/mcp-stdio-transport.test.ts
@@ -246,4 +246,24 @@ describe("OpenClawStdioClientTransport", () => {
     child.stderr.write("server diagnostic");
     expect(transport.stderr?.read()?.toString()).toBe("server diagnostic");
   });
+
+  it("suppresses PassThrough stderr stream errors without crashing", async () => {
+    const child = new MockChildProcess();
+    spawnMock.mockReturnValue(child);
+
+    const transport = new OpenClawStdioClientTransport({ command: "npx", stderr: "pipe" });
+    const onerror = vi.fn();
+    Object.assign(transport, { onerror });
+    const started = transport.start();
+    child.emit("spawn");
+    await started;
+
+    const stderrStream = transport.stderr;
+    expect(stderrStream).toBeInstanceOf(PassThrough);
+
+    // Emitting an error on the PassThrough stderrStream should not throw
+    // or trigger the transport's onerror (that's for subprocess stream errors).
+    expect(() => stderrStream?.emit("error", new Error("pass-through error"))).not.toThrow();
+    expect(onerror).not.toHaveBeenCalled();
+  });
 });

--- a/src/agents/mcp-stdio-transport.ts
+++ b/src/agents/mcp-stdio-transport.ts
@@ -41,6 +41,9 @@ export class OpenClawStdioClientTransport implements Transport {
   constructor(private readonly serverParams: OpenClawStdioServerParameters) {
     if (serverParams.stderr === "pipe" || serverParams.stderr === "overlapped") {
       this.stderrStream = new PassThrough();
+      // Suppress PassThrough errors; subprocess stderr errors are reported
+      // through the transport's onerror callback.
+      this.stderrStream.on("error", () => {});
     }
   }
 

--- a/src/agents/mcp-transport.ts
+++ b/src/agents/mcp-transport.ts
@@ -50,6 +50,10 @@ function attachStderrLogging(serverName: string, transport: OpenClawStdioClientT
     }
   };
   stderr.on("data", onData);
+  stderr.on("error", () => {
+    // Stderr stream errors are benign — the subprocess stderr errors
+    // are already reported through the transport's onerror callback.
+  });
   return () => {
     if (typeof stderr.off === "function") {
       stderr.off("data", onData);


### PR DESCRIPTION
## What Problem This Solves

The `stderrStream` PassThrough in `OpenClawStdioClientTransport` and the stderr stream consumer in `attachStderrLogging` did not handle `error` events. If the PassThrough or its consumer encountered a stream-level error (destroyed stream), the error could propagate as an unhandled exception.

## Why This Change Was Made

Subprocess stderr errors are already reported through the transport `onerror` callback (see #99803). These PassThrough-level errors are benign and should be silently suppressed rather than crashing the process.

## User Impact

Prevents potential unhandled stream error crashes when an MCP subprocess stderr PassThrough stream encounters a non-critical error during or after subprocess termination.

## Evidence

- `pnpm test src/agents/mcp-stdio-transport.test.ts` — 10/10 passed (includes new regression test)
- `pnpm test src/agents/mcp-transport.test.ts` — 10/10 passed

## Tests and Validation

Added test `suppresses PassThrough stderr stream errors without crashing` that verifies:
- Emitting an error on the stderrStream PassThrough does not throw
- The transport onerror callback is NOT invoked (it is reserved for subprocess-level errors)

Co-Authored-By: Claude <noreply@anthropic.com>