### PR TITLE
fix(thinking): honor compat.supportedReasoningEfforts for custom models

### DIFF
--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -573,7 +573,7 @@ describe("listThinkingLevels", () => {
     ).toBe(true);
   });
 
-  it("does not let catalog xhigh compat override binary thinking providers", () => {
+  it("honors catalog compat supportedReasoningEfforts alongside binary thinking providers", () => {
     providerRuntimeMocks.resolveProviderBinaryThinking.mockReturnValue(true);
     const catalog = [
       {
@@ -584,8 +584,8 @@ describe("listThinkingLevels", () => {
       },
     ];
 
-    expect(listThinkingLevels("zai", "glm-4.7", catalog)).toEqual(["off", "low"]);
-    expect(listThinkingLevelLabels("zai", "glm-4.7", catalog)).toEqual(["off", "on"]);
+    expect(listThinkingLevels("zai", "glm-4.7", catalog)).toEqual(["off", "low", "xhigh"]);
+    expect(listThinkingLevelLabels("zai", "glm-4.7", catalog)).toEqual(["off", "on", "xhigh"]);
   });
 
   it("maps stale unsupported levels to the largest profile level", () => {

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -241,6 +241,17 @@ export function resolveThinkingProfile(params: {
   if (binaryDecision !== true && catalogSupportsXHigh(context.compat)) {
     appendProfileLevel(profile, "xhigh");
   }
+  // Models with explicit compat.supportedReasoningEfforts may declare
+  // multi-level support even when the provider defaults to binary (on/off)
+  // thinking. Append any additional supported levels from compat metadata.
+  if (Array.isArray(context.compat?.supportedReasoningEfforts)) {
+    for (const effort of context.compat.supportedReasoningEfforts) {
+      const normalized = normalizeThinkLevel(effort ?? "");
+      if (normalized && !profile.levels.some((e) => e.id === normalized)) {
+        appendProfileLevel(profile, normalized);
+      }
+    }
+  }
   const policyContext = {
     provider: context.normalizedProvider,
     modelId: context.modelKey || context.modelId,


### PR DESCRIPTION
Fixes #102779

## What Problem This Solves

Custom `openai-completions` models with `reasoning:true` and `compat.supportedReasoningEfforts` were restricted to binary (off/low) thinking levels when the provider defaulted to binary mode. While CLI `--thinking medium` worked, session-level `/think medium` and the TUI/WebUI thinking pickers rejected explicitly supported levels.

## Why This Change Was Made

The thinking profile resolver (`resolveThinkingProfile`) built a binary (off/low) profile when the provider signaled binary thinking, and only added `xhigh` from compat metadata. It did not process other `compat.supportedReasoningEfforts` levels (e.g. `medium`, `high`) at all. This change adds all explicitly declared `supportedReasoningEfforts` to the profile.

## Evidence

- `pnpm test src/auto-reply/thinking.test.ts`: 65/65 passed
- Updated test: "honors catalog compat supportedReasoningEfforts alongside binary thinking providers"
- `git diff --check` clean
- 2 files changed (thinking.ts + test)