### PR TITLE
fix(shared): keep assistant identity value truncation UTF-16 safe

### DIFF
--- a/src/shared/assistant-identity-values.test.ts
+++ b/src/shared/assistant-identity-values.test.ts
@@ -20,6 +20,10 @@ describe("shared/assistant-identity-values", () => {
 
   it("returns an empty string when truncating to a zero-length limit", () => {
     expect(coerceIdentityValue("  OpenClaw  ", 0)).toBe("");
-    expect(coerceIdentityValue("  OpenClaw  ", -1)).toBe("OpenCla");
+    expect(coerceIdentityValue("  OpenClaw  ", -1)).toBe("");
+  });
+
+  it("does not split surrogate pairs at the truncation boundary", () => {
+    expect(coerceIdentityValue(`OpenClaw${"🚀".repeat(5)}`, 11)).toBe("OpenClaw🚀");
   });
 });

--- a/src/shared/assistant-identity-values.ts
+++ b/src/shared/assistant-identity-values.ts
@@ -1,5 +1,6 @@
 // Assistant identity helpers normalize assistant identity labels and metadata.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 
 /** Normalizes optional assistant identity fields and truncates them to the caller's limit. */
 export function coerceIdentityValue(
@@ -13,5 +14,5 @@ export function coerceIdentityValue(
   if (trimmed.length <= maxLength) {
     return trimmed;
   }
-  return trimmed.slice(0, maxLength);
+  return truncateUtf16Safe(trimmed, maxLength);
 }


### PR DESCRIPTION
## What Problem This Solves

`coerceIdentityValue()` in `assistant-identity-values.ts` uses raw `String.prototype.slice(0, maxLength)` to truncate assistant identity labels. When the truncation boundary falls inside a UTF-16 surrogate pair (emoji, CJK extended), the resulting string contains a dangling surrogate that renders as U+FFFD (�) in user-visible assistant names and metadata.

## Why This Change Was Made

Replace `trimmed.slice(0, maxLength)` with `truncateUtf16Safe(trimmed, maxLength)` from `@openclaw/normalization-core/utf16-slice` so the truncation point always falls on a complete code-point boundary. This preserves the existing code-unit cap while avoiding broken emoji in assistant identity values.

## User Impact

- Assistant names and identity labels no longer risk broken emoji when truncated
- No behavior change for ASCII text
- Negative `maxLength` now returns an empty string instead of `slice(0, -1)` (more correct for a truncation limit)

## Evidence

- `node scripts/run-vitest.mjs src/shared/assistant-identity-values.test.ts` — 5 tests passed
- `pnpm exec oxfmt --check` — passed
- `pnpm exec oxlint` — 0 warnings, 0 errors
- `git diff --check` — passed
- Regression: `coerceIdentityValue("OpenClaw🚀🚀🚀🚀🚀", 11)` returns `"OpenClaw🚀"` (not `"OpenClaw🚀\ud83d"` with a dangling surrogate)
