### PR TITLE
fix(codex-supervisor): ship CLI metadata entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Codex session fleet:** add an opt-in Codex app-server session catalog across the Gateway, paired nodes, CLI, macOS node, and Control UI. (#102586)
 - **Android chat agent selector:** switch the active agent directly from the live chat screen while keeping chat, Talk mode, and home canvas on the same canonical session. (#80422) Thanks @bcperry.
 - **Gateway host status:** show the connected Gateway's host, network address, OS, runtime, uptime, CPU, memory, and disk details in Control UI Settings. (#100478)
 - **iOS offline chat:** pre-paint recent sessions and canonical transcripts from a protected, bounded per-gateway cache, keep sending disabled offline, and purge cached conversation text when pairing is reset. (#100194)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Codex session fleet:** add an opt-in Codex app-server session catalog across the Gateway, paired nodes, CLI, macOS node, and Control UI. (#102586)
 - **Android chat agent selector:** switch the active agent directly from the live chat screen while keeping chat, Talk mode, and home canvas on the same canonical session. (#80422) Thanks @bcperry.
 - **Gateway host status:** show the connected Gateway's host, network address, OS, runtime, uptime, CPU, memory, and disk details in Control UI Settings. (#100478)
 - **iOS offline chat:** pre-paint recent sessions and canonical transcripts from a protected, bounded per-gateway cache, keep sending disabled offline, and purge cached conversation text when pairing is reset. (#100194)

--- a/extensions/codex-supervisor/cli-metadata.test.ts
+++ b/extensions/codex-supervisor/cli-metadata.test.ts
@@ -1,0 +1,53 @@
+// Codex Supervisor tests cover lightweight CLI discovery and lazy registration.
+import { Command } from "commander";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  registerCodexSupervisorCli: vi.fn(),
+}));
+
+vi.mock("./src/cli.js", () => ({
+  registerCodexSupervisorCli: mocks.registerCodexSupervisorCli,
+}));
+
+import entry from "./cli-metadata.js";
+
+describe("codex-supervisor CLI metadata entry", () => {
+  it("advertises codex and loads its registrar only when invoked", async () => {
+    const registerCli = vi.fn();
+    const api = createTestPluginApi({
+      id: "codex-supervisor",
+      name: "Codex Supervisor",
+      registerCli,
+    });
+
+    entry.register(api);
+
+    expect(registerCli).toHaveBeenCalledWith(expect.any(Function), {
+      descriptors: [
+        {
+          name: "codex",
+          description: "Inspect Codex sessions across the Gateway and paired nodes",
+          hasSubcommands: true,
+        },
+      ],
+    });
+    expect(mocks.registerCodexSupervisorCli).not.toHaveBeenCalled();
+
+    const registrar = registerCli.mock.calls[0]?.[0];
+    if (typeof registrar !== "function") {
+      throw new Error("expected codex-supervisor CLI registrar");
+    }
+    const program = new Command();
+    await registrar({
+      program,
+      parentPath: [],
+      config: {},
+      workspaceDir: undefined,
+      logger: api.logger,
+    });
+
+    expect(mocks.registerCodexSupervisorCli).toHaveBeenCalledWith(program);
+  });
+});

--- a/extensions/codex-supervisor/cli-metadata.ts
+++ b/extensions/codex-supervisor/cli-metadata.ts
@@ -1,0 +1,27 @@
+// Codex Supervisor CLI metadata stays lightweight until the command runs.
+import { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+
+export function registerCodexSupervisorCliMetadata(api: OpenClawPluginApi): void {
+  api.registerCli(
+    async ({ program }) => {
+      const { registerCodexSupervisorCli } = await import("./src/cli.js");
+      registerCodexSupervisorCli(program);
+    },
+    {
+      descriptors: [
+        {
+          name: "codex",
+          description: "Inspect Codex sessions across the Gateway and paired nodes",
+          hasSubcommands: true,
+        },
+      ],
+    },
+  );
+}
+
+export default definePluginEntry({
+  id: "codex-supervisor",
+  name: "Codex Supervisor",
+  description: "Supervise Codex app-server sessions from OpenClaw.",
+  register: registerCodexSupervisorCliMetadata,
+});

--- a/extensions/codex-supervisor/index.ts
+++ b/extensions/codex-supervisor/index.ts
@@ -3,7 +3,7 @@
  * OpenClaw agents.
  */
 import { buildJsonPluginConfigSchema, definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
-import { registerCodexSupervisorCli } from "./src/cli.js";
+import { registerCodexSupervisorCliMetadata } from "./cli-metadata.js";
 import {
   CodexSupervisorPluginConfigSchema,
   resolveCodexSupervisorPluginConfig,
@@ -46,15 +46,7 @@ export default definePluginEntry({
       api.registerNodeInvokePolicy(policy);
     }
     registerCodexSessionCatalogGateway({ api, supervisor: catalogSupervisor });
-    api.registerCli(({ program }) => registerCodexSupervisorCli(program), {
-      descriptors: [
-        {
-          name: "codex",
-          description: "Inspect Codex sessions across the Gateway and paired nodes",
-          hasSubcommands: true,
-        },
-      ],
-    });
+    registerCodexSupervisorCliMetadata(api);
     for (const tool of createCodexSupervisorTools({
       supervisor,
       policy: {

--- a/extensions/codex-supervisor/openclaw.plugin.json
+++ b/extensions/codex-supervisor/openclaw.plugin.json
@@ -2,7 +2,8 @@
   "id": "codex-supervisor",
   "enabledByDefault": false,
   "activation": {
-    "onStartup": true
+    "onStartup": true,
+    "onCommands": ["codex"]
   },
   "name": "Codex Supervisor",
   "description": "Supervise Codex app-server sessions from OpenClaw.",

--- a/src/plugins/bundled-plugin-metadata.test.ts
+++ b/src/plugins/bundled-plugin-metadata.test.ts
@@ -36,6 +36,7 @@ const EXPECTED_BUNDLED_STARTUP_PLUGIN_IDS = [
   "bonjour",
   "browser",
   "canvas",
+  "codex-supervisor",
   "device-pair",
   "diagnostics-otel",
   "diagnostics-prometheus",
@@ -576,6 +577,14 @@ describe("bundled plugin metadata", () => {
 
     expect(entry?.manifest.commandAliases).toStrictEqual([{ name: "voicecall" }]);
     expect(entry?.manifest.activation?.onCommands).toStrictEqual(["voicecall"]);
+  });
+
+  it("scopes Codex Supervisor CLI activation to the codex command", () => {
+    const entry = listRepoBundledPluginManifests().find(
+      ({ manifest }) => manifest.id === "codex-supervisor",
+    );
+
+    expect(entry?.manifest.activation?.onCommands).toStrictEqual(["codex"]);
   });
 
   it("keeps empty-config Gateway startup narrower than declared startup sidecars", () => {

--- a/test/scripts/bundled-plugin-build-entries.test.ts
+++ b/test/scripts/bundled-plugin-build-entries.test.ts
@@ -68,6 +68,16 @@ describe("bundled plugin build entries", () => {
     expect(pickEntries(entries, Object.keys(expectedEntries))).toStrictEqual(expectedEntries);
   });
 
+  it("keeps Codex Supervisor CLI metadata in bundled build and pack entries", () => {
+    const entries = listBundledPluginBuildEntries();
+    const artifacts = listBundledPluginPackArtifacts();
+
+    expect(entries["extensions/codex-supervisor/cli-metadata"]).toBe(
+      "extensions/codex-supervisor/cli-metadata.ts",
+    );
+    expect(artifacts).toContain("dist/extensions/codex-supervisor/cli-metadata.js");
+  });
+
   it("filters bundled plugin build entries for bounded script lanes", () => {
     const entries = listBundledPluginBuildEntries({
       env: {


### PR DESCRIPTION
## What Problem This Solves

The Codex session fleet landed in #102586, but an installed npm package could not discover `openclaw codex`: bundled root-command discovery reads a lightweight `cli-metadata` entry, while Codex Supervisor only registered the command from its full runtime entry.

## Why This Change Was Made

- Add a dedicated, lazy `cli-metadata` entry for the `codex` command.
- Reuse one registration helper from both metadata and full runtime paths.
- Declare `codex` command ownership in the plugin manifest.
- Cover build and pack inventory so future installed packages cannot omit the metadata entry.

## User Impact

With `codex-supervisor` enabled, installed CLI packages now expose `openclaw codex sessions` as documented. Gateway and node runtime behavior is unchanged.

## Evidence

- Local source-installed command: `node --import tsx src/entry.ts codex sessions --help`
- Focused local tests: 18 tooling + 36 plugin metadata + 2 extension tests passed
- Blacksmith Testbox `tbx_01kx3c7dn87d1ztr0reh0d2f5t`: 74 focused tests passed
- Full Blacksmith `pnpm build`: passed in 96.839s
- Actions run: https://github.com/openclaw/openclaw/actions/runs/29016915918
- Structured autoreview: no actionable findings, confidence 0.86

Follow-up to #102586 and #102503.
