### PR TITLE
feat(telegram): open the dashboard in a Telegram Mini App

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-14ff327d9f8d7d823d2391b857441a7b2e7092db4ae07b4c3b93f5972969ee53  plugin-sdk-api-baseline.json
-533532f5fc00832ca36e708031923ad0a9ec246e178e0027ab5eb235960ff2a8  plugin-sdk-api-baseline.jsonl
+f9b18b8c984425898ea364952a3c73bd57fe201558df5dc92664a098195ee31a  plugin-sdk-api-baseline.json
+278523eb82c0ee6b8a1ef99e34eb379f53564f5d976c9e4ec0b2e7ce637877a2  plugin-sdk-api-baseline.jsonl

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -117,6 +117,7 @@ Requirements:
 - `gateway.tailscale.mode: "serve"` or `"funnel"` for the published HTTPS Mini App URL.
 - Your numeric Telegram user ID must be in the selected account's effective `allowFrom` or in `commands.ownerAllowFrom`.
 - Use a DM. In groups, `/dashboard` replies with `open this in a DM with the bot` and sends no button.
+- Docker installs: Serve/Funnel modes require the gateway to bind loopback next to `tailscaled`, which bridge networking with published ports cannot satisfy. Run the gateway container with `network_mode: host` and mount the host `tailscaled` socket (`/var/run/tailscale`) plus the `tailscale` CLI into the container.
 
 The Mini App is a Tailscale-only v1 path and does not support Telegram Web iframe.
 

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -108,6 +108,18 @@ Token resolution is account-aware: `tokenFile` beats `botToken` beats env, and c
   </Accordion>
 </AccordionGroup>
 
+## Dashboard Mini App
+
+Run `/dashboard` in a DM with the bot to open the OpenClaw dashboard inside Telegram.
+
+Requirements:
+
+- `gateway.tailscale.mode: "serve"` or `"funnel"` for the published HTTPS Mini App URL.
+- Your numeric Telegram user ID must be in the selected account's effective `allowFrom` or in `commands.ownerAllowFrom`.
+- Use a DM. In groups, `/dashboard` replies with `open this in a DM with the bot` and sends no button.
+
+The Mini App is a Tailscale-only v1 path and does not support Telegram Web iframe.
+
 ## Access control and activation
 
 ### Group bot identity

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -920,6 +920,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Headings:
   - H2: Quick setup
   - H2: Telegram side settings
+  - H2: Dashboard Mini App
   - H2: Access control and activation
   - H3: Group bot identity
   - H2: Runtime behavior
@@ -9939,6 +9940,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Headings:
   - H2: Fast path (recommended)
   - H2: Auth basics (local vs remote)
+  - H2: Open in Telegram
   - H2: If you see "unauthorized" / 1008
   - H2: Related
 

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -27,15 +27,15 @@ For the plugin authoring guide, see [Plugin SDK overview](/plugins/sdk-overview)
 
 ## Plugin entry
 
-| Subpath                        | Key exports                                                                                                                                                            |
-| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `plugin-sdk/plugin-entry`      | `definePluginEntry`                                                                                                                                                    |
-| `plugin-sdk/core`              | `defineChannelPluginEntry`, `createChatChannelPlugin`, `createChannelPluginBase`, `defineSetupPluginEntry`, `buildChannelConfigSchema`, `buildJsonChannelConfigSchema` |
-| `plugin-sdk/provider-entry`    | `defineSingleProviderPluginEntry`                                                                                                                                      |
-| `plugin-sdk/migration`         | Migration provider item helpers such as `createMigrationItem`, reason constants, item status markers, redaction helpers, and `summarizeMigrationItems`                 |
-| `plugin-sdk/migration-runtime` | Runtime migration helpers such as `copyMigrationFileItem`, `resolvePlannedMigrationTargets`, `withCachedMigrationConfigRuntime`, and `writeMigrationReport`            |
-| `plugin-sdk/health`            | Doctor health-check registration, detection, repair, selection, severity, and finding types for bundled health consumers                                               |
-| `plugin-sdk/config-schema`     | Deprecated. Root `openclaw.json` Zod schema (`OpenClawSchema`); define plugin-local schemas instead and validate with `plugin-sdk/json-schema-runtime`                 |
+| Subpath                        | Key exports                                                                                                                                                                                             |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `plugin-sdk/plugin-entry`      | `definePluginEntry`                                                                                                                                                                                     |
+| `plugin-sdk/core`              | `defineChannelPluginEntry`, `createChatChannelPlugin`, `createChannelPluginBase`, `defineSetupPluginEntry`, `buildChannelConfigSchema`, `buildJsonChannelConfigSchema`, `resolveTailscalePublishedHost` |
+| `plugin-sdk/provider-entry`    | `defineSingleProviderPluginEntry`                                                                                                                                                                       |
+| `plugin-sdk/migration`         | Migration provider item helpers such as `createMigrationItem`, reason constants, item status markers, redaction helpers, and `summarizeMigrationItems`                                                  |
+| `plugin-sdk/migration-runtime` | Runtime migration helpers such as `copyMigrationFileItem`, `resolvePlannedMigrationTargets`, `withCachedMigrationConfigRuntime`, and `writeMigrationReport`                                             |
+| `plugin-sdk/health`            | Doctor health-check registration, detection, repair, selection, severity, and finding types for bundled health consumers                                                                                |
+| `plugin-sdk/config-schema`     | Deprecated. Root `openclaw.json` Zod schema (`OpenClawSchema`); define plugin-local schemas instead and validate with `plugin-sdk/json-schema-runtime`                                                  |
 
 ### Deprecated compatibility and test helpers
 
@@ -304,7 +304,7 @@ usage endpoint failed or returned no usable usage data.
     | `plugin-sdk/agent-config-primitives` | Deprecated agent runtime config-schema primitives; import schema primitives from a maintained plugin-owned surface |
     | `plugin-sdk/boolean-param` | Loose boolean param reader |
     | `plugin-sdk/dangerous-name-runtime` | Dangerous-name matching resolution helpers |
-    | `plugin-sdk/device-bootstrap` | Device bootstrap and pairing token helpers |
+    | `plugin-sdk/device-bootstrap` | Device bootstrap and pairing token helpers, including `BOOTSTRAP_HANDOFF_OPERATOR_SCOPES` |
     | `plugin-sdk/extension-shared` | Shared passive-channel, status, and ambient proxy helper primitives |
     | `plugin-sdk/models-provider-runtime` | `/models` command/provider reply helpers |
     | `plugin-sdk/skill-commands-runtime` | Skill command listing helpers |

--- a/docs/web/dashboard.md
+++ b/docs/web/dashboard.md
@@ -57,6 +57,7 @@ Requirements:
 - `gateway.tailscale.mode: "serve"` or `"funnel"` so Telegram gets an HTTPS Mini App URL.
 - The Telegram sender must be the bot owner: a numeric Telegram user ID in `commands.ownerAllowFrom` or the selected account's effective `channels.telegram.allowFrom`.
 - Run `/dashboard` in a DM with the bot. Group invocations only tell you to open the command in DM and do not include a button.
+- Docker installs: Serve/Funnel modes require the gateway to bind loopback next to `tailscaled`, which bridge networking with published ports cannot satisfy. Run the gateway container with `network_mode: host` and mount the host `tailscaled` socket (`/var/run/tailscale`) plus the `tailscale` CLI into the container.
 
 The Mini App performs a one-time owner handoff and redirects to Control UI with a short-lived bootstrap token. It does not expose a shared gateway token in the URL.
 

--- a/docs/web/dashboard.md
+++ b/docs/web/dashboard.md
@@ -48,6 +48,23 @@ The Control UI is an **admin surface** (chat, config, exec approvals). Do not ex
 - **Identity-bearing modes**: Tailscale Serve satisfies Control UI/WebSocket auth via identity headers when `gateway.auth.allowTailscale: true`; a non-loopback identity-aware reverse proxy satisfies `gateway.auth.mode: "trusted-proxy"`. Neither needs a pasted shared secret for the WebSocket.
 - **Not localhost**: use Tailscale Serve, a non-loopback shared-secret bind, a non-loopback identity-aware reverse proxy with `gateway.auth.mode: "trusted-proxy"`, or an SSH tunnel. HTTP APIs still use shared-secret auth unless you intentionally run private-ingress `gateway.auth.mode: "none"` or trusted-proxy HTTP auth. See [Web surfaces](/web).
 
+## Open in Telegram
+
+Telegram bots can open the dashboard as a Telegram Mini App with `/dashboard`.
+
+Requirements:
+
+- `gateway.tailscale.mode: "serve"` or `"funnel"` so Telegram gets an HTTPS Mini App URL.
+- The Telegram sender must be the bot owner: a numeric Telegram user ID in `commands.ownerAllowFrom` or the selected account's effective `channels.telegram.allowFrom`.
+- Run `/dashboard` in a DM with the bot. Group invocations only tell you to open the command in DM and do not include a button.
+
+The Mini App performs a one-time owner handoff and redirects to Control UI with a short-lived bootstrap token. It does not expose a shared gateway token in the URL.
+
+Non-goals for v1:
+
+- Telegram Web iframe is unsupported.
+- Tailscale Serve/Funnel is the only supported published URL path.
+
 <a id="if-you-see-unauthorized-1008"></a>
 
 ## If you see "unauthorized" / 1008

--- a/extensions/telegram/index.ts
+++ b/extensions/telegram/index.ts
@@ -1,5 +1,6 @@
 // Telegram plugin entrypoint registers its OpenClaw integration.
 import { defineBundledChannelEntry } from "openclaw/plugin-sdk/channel-entry-contract";
+import { registerTelegramMiniApp } from "./miniapp-api.js";
 
 export default defineBundledChannelEntry({
   id: "telegram",
@@ -22,4 +23,5 @@ export default defineBundledChannelEntry({
     specifier: "./account-inspect-api.js",
     exportName: "inspectTelegramReadOnlyAccount",
   },
+  registerFull: registerTelegramMiniApp,
 });

--- a/extensions/telegram/miniapp-api.ts
+++ b/extensions/telegram/miniapp-api.ts
@@ -1,0 +1,9 @@
+// Telegram Mini App registerFull entrypoint.
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { registerTelegramMiniAppCommand } from "./src/miniapp/command.js";
+import { registerTelegramMiniAppRoutes } from "./src/miniapp/routes.js";
+
+export function registerTelegramMiniApp(api: OpenClawPluginApi): void {
+  registerTelegramMiniAppRoutes(api);
+  registerTelegramMiniAppCommand(api);
+}

--- a/extensions/telegram/src/miniapp/command.test.ts
+++ b/extensions/telegram/src/miniapp/command.test.ts
@@ -56,7 +56,7 @@ describe("createTelegramMiniAppDashboardCommand", () => {
     resolveTelegramMiniAppUrls.mockResolvedValue({
       pageUrl: "https://host.tailnet.ts.net/__openclaw_tg_miniapp/",
       controlUiUrl: "https://host.tailnet.ts.net/openclaw",
-      gatewayUrl: "wss://host.tailnet.ts.net/openclaw",
+      gatewayUrl: "wss://host.tailnet.ts.net",
     });
     const command = createTelegramMiniAppDashboardCommand(
       createTestPluginApi({

--- a/extensions/telegram/src/miniapp/command.test.ts
+++ b/extensions/telegram/src/miniapp/command.test.ts
@@ -1,6 +1,6 @@
 import type { PluginCommandContext } from "openclaw/plugin-sdk/plugin-entry";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import { describe, expect, it, vi } from "vitest";
-import { createTestPluginApi } from "../../../../src/plugin-sdk/plugin-test-api.js";
 
 const resolveTelegramMiniAppUrls = vi.hoisted(() => vi.fn());
 

--- a/extensions/telegram/src/miniapp/command.test.ts
+++ b/extensions/telegram/src/miniapp/command.test.ts
@@ -1,0 +1,99 @@
+import type { PluginCommandContext } from "openclaw/plugin-sdk/plugin-entry";
+import { describe, expect, it, vi } from "vitest";
+import { createTestPluginApi } from "../../../../src/plugin-sdk/plugin-test-api.js";
+
+const resolveTelegramMiniAppUrls = vi.hoisted(() => vi.fn());
+
+vi.mock("./url.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./url.js")>()),
+  resolveTelegramMiniAppUrls,
+}));
+
+const { createTelegramMiniAppDashboardCommand } = await import("./command.js");
+
+function commandContext(overrides: Partial<PluginCommandContext>): PluginCommandContext {
+  return {
+    channel: "telegram",
+    isAuthorizedSender: true,
+    commandBody: "/dashboard",
+    config: {},
+    requestConversationBinding: async () => ({ status: "error", message: "unused" }),
+    detachConversationBinding: async () => ({ removed: false }),
+    getCurrentConversationBinding: async () => null,
+    ...overrides,
+  };
+}
+
+describe("createTelegramMiniAppDashboardCommand", () => {
+  it("returns a DM-only message for group invocations", async () => {
+    const command = createTelegramMiniAppDashboardCommand(
+      createTestPluginApi({
+        config: {
+          channels: {
+            telegram: {
+              accounts: {
+                ops: { allowFrom: ["123"] },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    await expect(
+      command.handler(
+        commandContext({
+          from: "telegram:group:-100",
+          sessionKey: "telegram:group:-100",
+          senderIsOwner: true,
+        }),
+      ),
+    ).resolves.toEqual({ text: "open this in a DM with the bot" });
+    expect(resolveTelegramMiniAppUrls).not.toHaveBeenCalled();
+  });
+
+  it("returns a web app button for owner DM invocations", async () => {
+    resolveTelegramMiniAppUrls.mockResolvedValue({
+      pageUrl: "https://host.tailnet.ts.net/__openclaw_tg_miniapp/",
+      controlUiUrl: "https://host.tailnet.ts.net/openclaw",
+      gatewayUrl: "wss://host.tailnet.ts.net/openclaw",
+    });
+    const command = createTelegramMiniAppDashboardCommand(
+      createTestPluginApi({
+        config: {
+          channels: {
+            telegram: {
+              accounts: {
+                ops: { allowFrom: ["123"] },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    const result = await command.handler(
+      commandContext({
+        from: "telegram:123",
+        sessionKey: "telegram:direct:123",
+        senderIsOwner: false,
+        accountId: "ops",
+      }),
+    );
+
+    expect(result.text).toBe("Open OpenClaw dashboard.");
+    expect(result.presentation?.blocks).toEqual([
+      {
+        type: "buttons",
+        buttons: [
+          {
+            label: "Open dashboard",
+            webApp: {
+              url: "https://host.tailnet.ts.net/__openclaw_tg_miniapp/?accountId=ops",
+            },
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/extensions/telegram/src/miniapp/command.ts
+++ b/extensions/telegram/src/miniapp/command.ts
@@ -59,6 +59,8 @@ function currentConfig(api: OpenClawPluginApi): OpenClawConfig {
 }
 
 function isTelegramDirectCommand(ctx: PluginCommandContext): boolean {
+  // Parses OpenClaw's canonical telegram:<id> / telegram:group:<id> from/sessionKey encoding.
+  // DM-only because Telegram permits web_app inline buttons only in private chats.
   const from = ctx.from?.trim() ?? "";
   const sessionKey = ctx.sessionKey?.trim() ?? "";
   if (from.startsWith("telegram:group:") || sessionKey.includes(":telegram:group:")) {

--- a/extensions/telegram/src/miniapp/command.ts
+++ b/extensions/telegram/src/miniapp/command.ts
@@ -1,0 +1,76 @@
+// Telegram Mini App /dashboard command.
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type {
+  OpenClawPluginApi,
+  OpenClawPluginCommandDefinition,
+  PluginCommandContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { isTelegramMiniAppOwner } from "./owner.js";
+import { resolveTelegramMiniAppUrls, TELEGRAM_MINIAPP_URL_ERROR } from "./url.js";
+
+export function registerTelegramMiniAppCommand(api: OpenClawPluginApi): void {
+  api.registerCommand(createTelegramMiniAppDashboardCommand(api));
+}
+
+export function createTelegramMiniAppDashboardCommand(
+  api: OpenClawPluginApi,
+): OpenClawPluginCommandDefinition {
+  return {
+    name: "dashboard",
+    description: "Open the OpenClaw dashboard",
+    channels: ["telegram"],
+    requireAuth: true,
+    exposeSenderIsOwner: true,
+    handler: async (ctx) => {
+      if (!isTelegramDirectCommand(ctx)) {
+        return { text: "open this in a DM with the bot" };
+      }
+      const cfg = currentConfig(api);
+      const accountId = normalizeAccountId(ctx.accountId ?? DEFAULT_ACCOUNT_ID);
+      const userId = resolveTelegramDirectUserId(ctx);
+      if (!(await isTelegramMiniAppOwner({ cfg, accountId, userId }))) {
+        return { text: "Restricted to the bot owner." };
+      }
+      let pageUrl: URL;
+      try {
+        pageUrl = new URL((await resolveTelegramMiniAppUrls({ cfg })).pageUrl);
+      } catch {
+        return { text: TELEGRAM_MINIAPP_URL_ERROR };
+      }
+      pageUrl.searchParams.set("accountId", accountId);
+      return {
+        text: "Open OpenClaw dashboard.",
+        presentation: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [{ label: "Open dashboard", webApp: { url: pageUrl.toString() } }],
+            },
+          ],
+        },
+      };
+    },
+  };
+}
+
+function currentConfig(api: OpenClawPluginApi): OpenClawConfig {
+  return (api.runtime.config?.current?.() ?? api.config) as OpenClawConfig;
+}
+
+function isTelegramDirectCommand(ctx: PluginCommandContext): boolean {
+  const from = ctx.from?.trim() ?? "";
+  const sessionKey = ctx.sessionKey?.trim() ?? "";
+  if (from.startsWith("telegram:group:") || sessionKey.includes(":telegram:group:")) {
+    return false;
+  }
+  return /^telegram:\d+$/.test(from) || sessionKey.includes(":telegram:direct:");
+}
+
+function resolveTelegramDirectUserId(ctx: PluginCommandContext): string {
+  const senderId = ctx.senderId?.trim() ?? "";
+  if (/^\d+$/.test(senderId)) {
+    return senderId;
+  }
+  return /^telegram:(\d+)$/.exec(ctx.from?.trim() ?? "")?.[1] ?? "";
+}

--- a/extensions/telegram/src/miniapp/init-data.test.ts
+++ b/extensions/telegram/src/miniapp/init-data.test.ts
@@ -1,0 +1,69 @@
+import crypto from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { validateTelegramMiniAppInitData } from "./init-data.js";
+
+const BOT_TOKEN = "fixture";
+const AUTH_DATE = 1_800_000_000;
+const INIT_DATA = signedInitData({});
+
+describe("validateTelegramMiniAppInitData", () => {
+  it("accepts a signed Telegram init-data fixture", () => {
+    expect(
+      validateTelegramMiniAppInitData({
+        initData: INIT_DATA,
+        botToken: BOT_TOKEN,
+        nowMs: AUTH_DATE * 1000 + 10_000,
+      }),
+    ).toEqual({
+      hash: fixtureHash(INIT_DATA),
+      authDateMs: AUTH_DATE * 1000,
+      userId: "123456",
+    });
+  });
+
+  it("rejects tampered, expired, and missing-user init data", () => {
+    expect(
+      validateTelegramMiniAppInitData({
+        initData: INIT_DATA.replace("Ayaan", "Mallory"),
+        botToken: BOT_TOKEN,
+        nowMs: AUTH_DATE * 1000 + 10_000,
+      }),
+    ).toBeNull();
+    expect(
+      validateTelegramMiniAppInitData({
+        initData: INIT_DATA,
+        botToken: BOT_TOKEN,
+        nowMs: AUTH_DATE * 1000 + 301_000,
+      }),
+    ).toBeNull();
+    expect(
+      validateTelegramMiniAppInitData({
+        initData: signedInitData({ user: "" }),
+        botToken: BOT_TOKEN,
+        nowMs: AUTH_DATE * 1000,
+      }),
+    ).toBeNull();
+  });
+});
+
+function signedInitData(overrides: Record<string, string>): string {
+  const params = new URLSearchParams({
+    auth_date: String(AUTH_DATE),
+    query_id: "AAE-test",
+    user: JSON.stringify({ id: 123456, first_name: "Ayaan" }),
+    ...overrides,
+  });
+  const entries = [...params.entries()].map(([key, value]) => `${key}=${value}`).toSorted();
+  const secret = crypto.createHmac("sha256", "WebAppData").update(BOT_TOKEN).digest();
+  const hash = crypto.createHmac("sha256", secret).update(entries.join("\n")).digest("hex");
+  params.set("hash", hash);
+  return params.toString();
+}
+
+function fixtureHash(initData: string): string {
+  const hash = new URLSearchParams(initData).get("hash");
+  if (!hash) {
+    throw new Error("expected fixture hash");
+  }
+  return hash;
+}

--- a/extensions/telegram/src/miniapp/init-data.ts
+++ b/extensions/telegram/src/miniapp/init-data.ts
@@ -67,11 +67,10 @@ function parseTelegramMiniAppUser(raw: string): { id: string } | null {
   }
 }
 
+// Attacker-controlled input never short-circuits on length: both sides are
+// reduced to fixed-length SHA-256 digests before the constant-time compare.
 function timingSafeHexEqual(left: string, right: string): boolean {
-  const leftBuffer = Buffer.from(left, "hex");
-  const rightBuffer = Buffer.from(right, "hex");
-  if (leftBuffer.length !== rightBuffer.length) {
-    return false;
-  }
-  return crypto.timingSafeEqual(leftBuffer, rightBuffer);
+  const leftDigest = crypto.createHash("sha256").update(left).digest();
+  const rightDigest = crypto.createHash("sha256").update(right).digest();
+  return crypto.timingSafeEqual(leftDigest, rightDigest);
 }

--- a/extensions/telegram/src/miniapp/init-data.ts
+++ b/extensions/telegram/src/miniapp/init-data.ts
@@ -1,0 +1,77 @@
+// Telegram Mini App init-data validation.
+import crypto from "node:crypto";
+
+const INIT_DATA_MAX_AGE_MS = 300_000;
+
+export type TelegramMiniAppInitData = {
+  hash: string;
+  authDateMs: number;
+  userId: string;
+};
+
+export function validateTelegramMiniAppInitData(params: {
+  initData: string;
+  botToken: string;
+  nowMs?: number;
+}): TelegramMiniAppInitData | null {
+  const initData = params.initData.trim();
+  const botToken = params.botToken.trim();
+  if (!initData || !botToken) {
+    return null;
+  }
+
+  const parsed = new URLSearchParams(initData);
+  const receivedHash = parsed.get("hash")?.trim() ?? "";
+  const authDateRaw = parsed.get("auth_date")?.trim() ?? "";
+  const userRaw = parsed.get("user")?.trim() ?? "";
+  if (!receivedHash || !authDateRaw || !userRaw) {
+    return null;
+  }
+
+  const authDateSeconds = Number(authDateRaw);
+  if (!Number.isInteger(authDateSeconds) || authDateSeconds <= 0) {
+    return null;
+  }
+  const authDateMs = authDateSeconds * 1000;
+  const ageMs = (params.nowMs ?? Date.now()) - authDateMs;
+  if (ageMs < 0 || ageMs > INIT_DATA_MAX_AGE_MS) {
+    return null;
+  }
+
+  const entries = [...parsed.entries()]
+    .filter(([key]) => key !== "hash")
+    .map(([key, value]) => `${key}=${value}`)
+    .toSorted();
+  const secret = crypto.createHmac("sha256", "WebAppData").update(botToken).digest();
+  const computedHash = crypto.createHmac("sha256", secret).update(entries.join("\n")).digest("hex");
+  if (!timingSafeHexEqual(computedHash, receivedHash)) {
+    return null;
+  }
+
+  const user = parseTelegramMiniAppUser(userRaw);
+  if (!user?.id || !/^\d+$/.test(user.id)) {
+    return null;
+  }
+  return { hash: receivedHash, authDateMs, userId: user.id };
+}
+
+function parseTelegramMiniAppUser(raw: string): { id: string } | null {
+  try {
+    const parsed = JSON.parse(raw) as { id?: unknown };
+    if (typeof parsed.id === "number" && Number.isSafeInteger(parsed.id) && parsed.id > 0) {
+      return { id: String(parsed.id) };
+    }
+    return typeof parsed.id === "string" && /^\d+$/.test(parsed.id) ? { id: parsed.id } : null;
+  } catch {
+    return null;
+  }
+}
+
+function timingSafeHexEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left, "hex");
+  const rightBuffer = Buffer.from(right, "hex");
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(leftBuffer, rightBuffer);
+}

--- a/extensions/telegram/src/miniapp/owner.test.ts
+++ b/extensions/telegram/src/miniapp/owner.test.ts
@@ -1,0 +1,43 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { describe, expect, it } from "vitest";
+import { isTelegramMiniAppOwner } from "./owner.js";
+
+describe("isTelegramMiniAppOwner", () => {
+  it("accepts numeric owners from account allowFrom and commands.ownerAllowFrom", async () => {
+    const cfg = {
+      commands: { ownerAllowFrom: ["telegram:200"] },
+      channels: {
+        telegram: {
+          allowFrom: ["100"],
+          accounts: {
+            ops: { allowFrom: ["300"] },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    await expect(
+      isTelegramMiniAppOwner({ cfg, accountId: "default", userId: "100" }),
+    ).resolves.toBe(true);
+    await expect(isTelegramMiniAppOwner({ cfg, accountId: "ops", userId: "300" })).resolves.toBe(
+      true,
+    );
+    await expect(isTelegramMiniAppOwner({ cfg, accountId: "ops", userId: "200" })).resolves.toBe(
+      true,
+    );
+  });
+
+  it("rejects non-numeric and wildcard owners", async () => {
+    const cfg = {
+      commands: { ownerAllowFrom: ["*", "telegram:owner"] },
+      channels: { telegram: { allowFrom: ["*"] } },
+    } satisfies OpenClawConfig;
+
+    await expect(
+      isTelegramMiniAppOwner({ cfg, accountId: "default", userId: "100" }),
+    ).resolves.toBe(false);
+    await expect(
+      isTelegramMiniAppOwner({ cfg, accountId: "default", userId: "-100" }),
+    ).resolves.toBe(false);
+  });
+});

--- a/extensions/telegram/src/miniapp/owner.ts
+++ b/extensions/telegram/src/miniapp/owner.ts
@@ -15,6 +15,8 @@ export async function isTelegramMiniAppOwner(params: {
   }
   const account = mergeTelegramAccountConfig(params.cfg, params.accountId);
   const allowFrom = [...(account.allowFrom ?? []), ...(params.cfg.commands?.ownerAllowFrom ?? [])];
+  // Dashboard access is stricter than core senderIsOwner: wildcard and username
+  // allowFrom entries never grant the numeric-id match that mints an operator credential.
   const expanded = await expandTelegramAllowFromWithAccessGroups({
     cfg: params.cfg,
     accountId: params.accountId,

--- a/extensions/telegram/src/miniapp/owner.ts
+++ b/extensions/telegram/src/miniapp/owner.ts
@@ -1,0 +1,25 @@
+// Telegram Mini App owner checks.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { expandTelegramAllowFromWithAccessGroups } from "../access-groups.js";
+import { mergeTelegramAccountConfig } from "../accounts.js";
+import { isNumericTelegramSenderUserId, normalizeTelegramAllowFromEntry } from "../allow-from.js";
+
+export async function isTelegramMiniAppOwner(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  userId: string;
+}): Promise<boolean> {
+  const userId = params.userId.trim();
+  if (!isNumericTelegramSenderUserId(userId)) {
+    return false;
+  }
+  const account = mergeTelegramAccountConfig(params.cfg, params.accountId);
+  const allowFrom = [...(account.allowFrom ?? []), ...(params.cfg.commands?.ownerAllowFrom ?? [])];
+  const expanded = await expandTelegramAllowFromWithAccessGroups({
+    cfg: params.cfg,
+    accountId: params.accountId,
+    allowFrom,
+    senderId: userId,
+  });
+  return expanded.some((entry) => normalizeTelegramAllowFromEntry(entry) === userId);
+}

--- a/extensions/telegram/src/miniapp/page.test.ts
+++ b/extensions/telegram/src/miniapp/page.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { renderTelegramMiniAppPage } from "./page.js";
+
+describe("renderTelegramMiniAppPage", () => {
+  it("builds the dashboard redirect from the authenticated payload", () => {
+    const html = renderTelegramMiniAppPage({ accountId: "ops", scriptNonce: "nonce" });
+
+    expect(html).toContain('const accountId = "ops";');
+    expect(html).toContain("new URL(payload.controlUiUrl)");
+    expect(html).not.toContain("const controlUiUrl =");
+  });
+});

--- a/extensions/telegram/src/miniapp/page.ts
+++ b/extensions/telegram/src/miniapp/page.ts
@@ -4,11 +4,9 @@ export const TELEGRAM_MINIAPP_EXPIRED_MESSAGE =
 
 export function renderTelegramMiniAppPage(params: {
   accountId: string;
-  controlUiUrl: string;
   scriptNonce: string;
 }): string {
   const accountId = JSON.stringify(params.accountId);
-  const controlUiUrl = JSON.stringify(params.controlUiUrl);
   const nonce = escapeHtml(params.scriptNonce);
   return `<!doctype html>
 <html lang="en">
@@ -33,7 +31,6 @@ export function renderTelegramMiniAppPage(params: {
   </main>
   <script nonce="${nonce}">
     const accountId = ${accountId};
-    const controlUiUrl = ${controlUiUrl};
     const status = document.getElementById("status");
     const showExpired = () => {
       status.textContent = ${JSON.stringify(TELEGRAM_MINIAPP_EXPIRED_MESSAGE)};
@@ -55,7 +52,7 @@ export function renderTelegramMiniAppPage(params: {
         }
         return await response.json();
       }).then((payload) => {
-        const next = new URL(controlUiUrl);
+        const next = new URL(payload.controlUiUrl);
         next.hash = "gatewayUrl=" + encodeURIComponent(payload.gatewayUrl) +
           "&bootstrapToken=" + encodeURIComponent(payload.bootstrapToken);
         location.replace(next.toString());

--- a/extensions/telegram/src/miniapp/page.ts
+++ b/extensions/telegram/src/miniapp/page.ts
@@ -1,0 +1,84 @@
+// Telegram Mini App bootstrap page.
+export const TELEGRAM_MINIAPP_EXPIRED_MESSAGE =
+  "This link expired. Reopen the dashboard from your bot chat.";
+
+export function renderTelegramMiniAppPage(params: {
+  accountId: string;
+  controlUiUrl: string;
+  scriptNonce: string;
+}): string {
+  const accountId = JSON.stringify(params.accountId);
+  const controlUiUrl = JSON.stringify(params.controlUiUrl);
+  const nonce = escapeHtml(params.scriptNonce);
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <title>OpenClaw</title>
+  <style>
+    :root { color-scheme: light dark; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: Canvas; color: CanvasText; }
+    main { width: min(28rem, calc(100vw - 2rem)); }
+    h1 { font-size: 1.25rem; margin: 0 0 0.5rem; }
+    p { margin: 0; line-height: 1.5; }
+  </style>
+  <script src="https://telegram.org/js/telegram-web-app.js"></script>
+</head>
+<body>
+  <main>
+    <h1>OpenClaw</h1>
+    <p id="status">Opening dashboard...</p>
+  </main>
+  <script nonce="${nonce}">
+    const accountId = ${accountId};
+    const controlUiUrl = ${controlUiUrl};
+    const status = document.getElementById("status");
+    const showExpired = () => {
+      status.textContent = ${JSON.stringify(TELEGRAM_MINIAPP_EXPIRED_MESSAGE)};
+    };
+    const webApp = window.Telegram && window.Telegram.WebApp;
+    const initData = webApp && typeof webApp.initData === "string" ? webApp.initData : "";
+    if (!initData) {
+      showExpired();
+    } else {
+      webApp.ready();
+      fetch("auth", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ initData, accountId }),
+        credentials: "same-origin"
+      }).then(async (response) => {
+        if (!response.ok) {
+          throw new Error("auth failed");
+        }
+        return await response.json();
+      }).then((payload) => {
+        const next = new URL(controlUiUrl);
+        next.hash = "gatewayUrl=" + encodeURIComponent(payload.gatewayUrl) +
+          "&bootstrapToken=" + encodeURIComponent(payload.bootstrapToken);
+        location.replace(next.toString());
+      }).catch(showExpired);
+    }
+  </script>
+</body>
+</html>`;
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      default:
+        return "&#39;";
+    }
+  });
+}

--- a/extensions/telegram/src/miniapp/routes.test.ts
+++ b/extensions/telegram/src/miniapp/routes.test.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { Readable } from "node:stream";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestPluginApi } from "../../../../src/plugin-sdk/plugin-test-api.js";
 import type { OpenClawPluginHttpRouteParams } from "../../../../src/plugins/types.js";
 
@@ -13,7 +13,7 @@ const resolveTelegramMiniAppUrls = vi.hoisted(() =>
   vi.fn(async () => ({
     pageUrl: "https://host.tailnet.ts.net/__openclaw_tg_miniapp/",
     controlUiUrl: "https://host.tailnet.ts.net/openclaw",
-    gatewayUrl: "wss://host.tailnet.ts.net/openclaw",
+    gatewayUrl: "wss://host.tailnet.ts.net",
   })),
 );
 
@@ -108,6 +108,25 @@ function signedInitData(userId: string, nonce: string): string {
 }
 
 describe("registerTelegramMiniAppRoutes", () => {
+  beforeEach(() => {
+    issueDeviceBootstrapToken.mockClear();
+    resolveTelegramMiniAppUrls.mockClear();
+  });
+
+  it("serves the page without resolving published URLs", async () => {
+    const route = createRoute({});
+    const res = await callRoute({
+      route,
+      method: "GET",
+      url: "/__openclaw_tg_miniapp/?accountId=ops",
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('const accountId = "ops";');
+    expect(res.body).toContain("new URL(payload.controlUiUrl)");
+    expect(resolveTelegramMiniAppUrls).not.toHaveBeenCalled();
+  });
+
   it("mints a control-ui bootstrap token for a valid owner request", async () => {
     const route = createRoute(config());
     const res = await callRoute({
@@ -124,7 +143,8 @@ describe("registerTelegramMiniAppRoutes", () => {
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body)).toEqual({
       bootstrapToken: "issued",
-      gatewayUrl: "wss://host.tailnet.ts.net/openclaw",
+      controlUiUrl: "https://host.tailnet.ts.net/openclaw",
+      gatewayUrl: "wss://host.tailnet.ts.net",
     });
     expect(issueDeviceBootstrapToken).toHaveBeenCalledWith({
       profile: {
@@ -136,7 +156,6 @@ describe("registerTelegramMiniAppRoutes", () => {
   });
 
   it("rejects replayed init-data without minting again", async () => {
-    issueDeviceBootstrapToken.mockClear();
     const route = createRoute(config());
     const initData = signedInitData("123456", "replay");
     await callRoute({
@@ -162,7 +181,6 @@ describe("registerTelegramMiniAppRoutes", () => {
   });
 
   it("reserves validated init-data before minting", async () => {
-    issueDeviceBootstrapToken.mockClear();
     const route = createRoute(config());
     const initData = signedInitData("123456", "concurrent");
 
@@ -185,7 +203,7 @@ describe("registerTelegramMiniAppRoutes", () => {
       }),
     ]);
 
-    expect(responses.map((res) => res.statusCode).toSorted()).toEqual([200, 401]);
+    expect(responses.map((res) => res.statusCode).toSorted((a, b) => a - b)).toEqual([200, 401]);
     expect(issueDeviceBootstrapToken).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/telegram/src/miniapp/routes.test.ts
+++ b/extensions/telegram/src/miniapp/routes.test.ts
@@ -2,9 +2,11 @@ import crypto from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { Readable } from "node:stream";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createTestPluginApi } from "../../../../src/plugin-sdk/plugin-test-api.js";
-import type { OpenClawPluginHttpRouteParams } from "../../../../src/plugins/types.js";
+
+type OpenClawPluginHttpRouteParams = Parameters<OpenClawPluginApi["registerHttpRoute"]>[0];
 
 const issueDeviceBootstrapToken = vi.hoisted(() =>
   vi.fn(async () => ({ token: "issued", expiresAtMs: Date.now() + 600_000 })),

--- a/extensions/telegram/src/miniapp/routes.test.ts
+++ b/extensions/telegram/src/miniapp/routes.test.ts
@@ -1,0 +1,224 @@
+import crypto from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { describe, expect, it, vi } from "vitest";
+import { createTestPluginApi } from "../../../../src/plugin-sdk/plugin-test-api.js";
+import type { OpenClawPluginHttpRouteParams } from "../../../../src/plugins/types.js";
+
+const issueDeviceBootstrapToken = vi.hoisted(() =>
+  vi.fn(async () => ({ token: "issued", expiresAtMs: Date.now() + 600_000 })),
+);
+const resolveTelegramMiniAppUrls = vi.hoisted(() =>
+  vi.fn(async () => ({
+    pageUrl: "https://host.tailnet.ts.net/__openclaw_tg_miniapp/",
+    controlUiUrl: "https://host.tailnet.ts.net/openclaw",
+    gatewayUrl: "wss://host.tailnet.ts.net/openclaw",
+  })),
+);
+
+vi.mock("openclaw/plugin-sdk/device-bootstrap", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/device-bootstrap")>()),
+  issueDeviceBootstrapToken,
+}));
+
+vi.mock("./url.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./url.js")>()),
+  resolveTelegramMiniAppUrls,
+}));
+
+const { registerTelegramMiniAppRoutes } = await import("./routes.js");
+
+const BOT_TOKEN = "fixture";
+
+class MockResponse {
+  statusCode = 200;
+  headers: Record<string, string> = {};
+  body = "";
+
+  writeHead(statusCode: number, headers: Record<string, string>) {
+    this.statusCode = statusCode;
+    this.headers = { ...this.headers, ...headers };
+    return this;
+  }
+
+  end(body?: string) {
+    this.body = body ?? "";
+    return this;
+  }
+}
+
+function createRoute(cfg: OpenClawConfig): OpenClawPluginHttpRouteParams {
+  let route: OpenClawPluginHttpRouteParams | null = null;
+  const api = createTestPluginApi({
+    config: cfg,
+    registerHttpRoute(params) {
+      route = params;
+    },
+  });
+  registerTelegramMiniAppRoutes(api);
+  if (!route) {
+    throw new Error("expected miniapp route registration");
+  }
+  return route;
+}
+
+async function callRoute(params: {
+  route: OpenClawPluginHttpRouteParams;
+  method: string;
+  url: string;
+  body?: string;
+  contentType?: string;
+  ip?: string;
+}) {
+  const req = Readable.from(params.body ? [params.body] : []) as IncomingMessage;
+  req.method = params.method;
+  req.url = params.url;
+  req.headers = params.contentType ? { "content-type": params.contentType } : {};
+  Object.defineProperty(req, "socket", {
+    value: { remoteAddress: params.ip ?? "203.0.113.10" },
+  });
+  const res = new MockResponse() as ServerResponse & MockResponse;
+  await params.route.handler(req, res);
+  return res;
+}
+
+function config(allowFrom: string[] = ["123456"]): OpenClawConfig {
+  return {
+    channels: {
+      telegram: {
+        botToken: BOT_TOKEN,
+        allowFrom,
+      },
+    },
+    gateway: { tailscale: { mode: "funnel" } },
+  };
+}
+
+function signedInitData(userId: string, nonce: string): string {
+  const params = new URLSearchParams({
+    auth_date: String(Math.floor(Date.now() / 1000)),
+    query_id: nonce,
+    user: JSON.stringify({ id: Number(userId), first_name: "Ayaan" }),
+  });
+  const entries = [...params.entries()].map(([key, value]) => `${key}=${value}`).toSorted();
+  const secret = crypto.createHmac("sha256", "WebAppData").update(BOT_TOKEN).digest();
+  params.set("hash", crypto.createHmac("sha256", secret).update(entries.join("\n")).digest("hex"));
+  return params.toString();
+}
+
+describe("registerTelegramMiniAppRoutes", () => {
+  it("mints a control-ui bootstrap token for a valid owner request", async () => {
+    const route = createRoute(config());
+    const res = await callRoute({
+      route,
+      method: "POST",
+      url: "/__openclaw_tg_miniapp/auth",
+      contentType: "application/json; charset=utf-8",
+      body: JSON.stringify({
+        initData: signedInitData("123456", "success"),
+        accountId: "default",
+      }),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({
+      bootstrapToken: "issued",
+      gatewayUrl: "wss://host.tailnet.ts.net/openclaw",
+    });
+    expect(issueDeviceBootstrapToken).toHaveBeenCalledWith({
+      profile: {
+        roles: ["operator"],
+        scopes: ["operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
+        purpose: "control-ui",
+      },
+    });
+  });
+
+  it("rejects replayed init-data without minting again", async () => {
+    issueDeviceBootstrapToken.mockClear();
+    const route = createRoute(config());
+    const initData = signedInitData("123456", "replay");
+    await callRoute({
+      route,
+      method: "POST",
+      url: "/__openclaw_tg_miniapp/auth",
+      contentType: "application/json",
+      body: JSON.stringify({ initData }),
+      ip: "203.0.113.20",
+    });
+    const replay = await callRoute({
+      route,
+      method: "POST",
+      url: "/__openclaw_tg_miniapp/auth",
+      contentType: "application/json",
+      body: JSON.stringify({ initData }),
+      ip: "203.0.113.20",
+    });
+
+    expect(replay.statusCode).toBe(401);
+    expect(replay.body).toBe("This link expired. Reopen the dashboard from your bot chat.");
+    expect(issueDeviceBootstrapToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("reserves validated init-data before minting", async () => {
+    issueDeviceBootstrapToken.mockClear();
+    const route = createRoute(config());
+    const initData = signedInitData("123456", "concurrent");
+
+    const responses = await Promise.all([
+      callRoute({
+        route,
+        method: "POST",
+        url: "/__openclaw_tg_miniapp/auth",
+        contentType: "application/json",
+        body: JSON.stringify({ initData }),
+        ip: "203.0.113.21",
+      }),
+      callRoute({
+        route,
+        method: "POST",
+        url: "/__openclaw_tg_miniapp/auth",
+        contentType: "application/json",
+        body: JSON.stringify({ initData }),
+        ip: "203.0.113.22",
+      }),
+    ]);
+
+    expect(responses.map((res) => res.statusCode).toSorted()).toEqual([200, 401]);
+    expect(issueDeviceBootstrapToken).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects non-owner Mini App auth requests", async () => {
+    const route = createRoute(config(["999999"]));
+    const res = await callRoute({
+      route,
+      method: "POST",
+      url: "/__openclaw_tg_miniapp/auth",
+      contentType: "application/json",
+      body: JSON.stringify({ initData: signedInitData("123456", "non-owner") }),
+      ip: "203.0.113.30",
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toBe("Restricted to the bot owner.");
+  });
+
+  it("rate-limits repeated auth requests by IP", async () => {
+    const route = createRoute(config());
+    let last: MockResponse | null = null;
+    for (let i = 0; i < 11; i += 1) {
+      last = await callRoute({
+        route,
+        method: "POST",
+        url: "/__openclaw_tg_miniapp/auth",
+        contentType: "application/json",
+        body: JSON.stringify({ initData: signedInitData("123456", `rate-${i}`) }),
+        ip: "203.0.113.40",
+      });
+    }
+
+    expect(last?.statusCode).toBe(429);
+    expect(last?.body).toBe("Too many requests");
+  });
+});

--- a/extensions/telegram/src/miniapp/routes.ts
+++ b/extensions/telegram/src/miniapp/routes.ts
@@ -34,7 +34,7 @@ export function registerTelegramMiniAppRoutes(api: OpenClawPluginApi): void {
     handler: async (req, res) => {
       const url = new URL(req.url ?? "", "http://openclaw.local");
       if (url.pathname === TELEGRAM_MINIAPP_PATH_PREFIX) {
-        await handlePage(api, req, res, url);
+        await handlePage(req, res, url);
         return true;
       }
       if (url.pathname === AUTH_PATH) {
@@ -47,22 +47,9 @@ export function registerTelegramMiniAppRoutes(api: OpenClawPluginApi): void {
   });
 }
 
-async function handlePage(
-  api: OpenClawPluginApi,
-  req: IncomingMessage,
-  res: ServerResponse,
-  url: URL,
-): Promise<void> {
+async function handlePage(req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {
   if (req.method !== "GET") {
     sendText(res, 405, "Method not allowed");
-    return;
-  }
-  const cfg = currentConfig(api);
-  let urls;
-  try {
-    urls = await resolveTelegramMiniAppUrls({ cfg });
-  } catch {
-    sendText(res, 503, TELEGRAM_MINIAPP_URL_ERROR);
     return;
   }
   const accountId = normalizeAccountId(url.searchParams.get("accountId") ?? DEFAULT_ACCOUNT_ID);
@@ -72,7 +59,6 @@ async function handlePage(
     200,
     renderTelegramMiniAppPage({
       accountId,
-      controlUiUrl: urls.controlUiUrl,
       scriptNonce: nonce,
     }),
     nonce,
@@ -88,7 +74,7 @@ async function handleAuth(
     sendText(res, 405, "Method not allowed");
     return;
   }
-  const contentType = String(req.headers["content-type"] ?? "").toLowerCase();
+  const contentType = (req.headers["content-type"] ?? "").toLowerCase();
   if (contentType.split(";")[0]?.trim() !== "application/json") {
     sendText(res, 415, "Unsupported media type");
     return;
@@ -144,6 +130,7 @@ async function handleAuth(
   });
   sendJson(res, 200, {
     bootstrapToken: issued.token,
+    controlUiUrl: urls.controlUiUrl,
     gatewayUrl: urls.gatewayUrl,
   });
 }

--- a/extensions/telegram/src/miniapp/routes.ts
+++ b/extensions/telegram/src/miniapp/routes.ts
@@ -1,0 +1,249 @@
+// Telegram Mini App HTTP routes.
+import crypto from "node:crypto";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  BOOTSTRAP_HANDOFF_OPERATOR_SCOPES,
+  issueDeviceBootstrapToken,
+} from "openclaw/plugin-sdk/device-bootstrap";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { resolveTelegramAccount } from "../accounts.js";
+import { validateTelegramMiniAppInitData } from "./init-data.js";
+import { isTelegramMiniAppOwner } from "./owner.js";
+import { renderTelegramMiniAppPage, TELEGRAM_MINIAPP_EXPIRED_MESSAGE } from "./page.js";
+import {
+  resolveTelegramMiniAppUrls,
+  TELEGRAM_MINIAPP_PATH_PREFIX,
+  TELEGRAM_MINIAPP_URL_ERROR,
+} from "./url.js";
+
+const AUTH_PATH = `${TELEGRAM_MINIAPP_PATH_PREFIX}auth`;
+const MAX_BODY_BYTES = 4096;
+const REPLAY_CACHE_LIMIT = 1000;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 10;
+const replayCache = new Map<string, number>();
+const rateLimit = new Map<string, { count: number; resetAtMs: number }>();
+
+export function registerTelegramMiniAppRoutes(api: OpenClawPluginApi): void {
+  api.registerHttpRoute({
+    path: TELEGRAM_MINIAPP_PATH_PREFIX,
+    match: "prefix",
+    auth: "plugin",
+    handler: async (req, res) => {
+      const url = new URL(req.url ?? "", "http://openclaw.local");
+      if (url.pathname === TELEGRAM_MINIAPP_PATH_PREFIX) {
+        await handlePage(api, req, res, url);
+        return true;
+      }
+      if (url.pathname === AUTH_PATH) {
+        await handleAuth(api, req, res);
+        return true;
+      }
+      sendText(res, 404, "Not found");
+      return true;
+    },
+  });
+}
+
+async function handlePage(
+  api: OpenClawPluginApi,
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: URL,
+): Promise<void> {
+  if (req.method !== "GET") {
+    sendText(res, 405, "Method not allowed");
+    return;
+  }
+  const cfg = currentConfig(api);
+  let urls;
+  try {
+    urls = await resolveTelegramMiniAppUrls({ cfg });
+  } catch {
+    sendText(res, 503, TELEGRAM_MINIAPP_URL_ERROR);
+    return;
+  }
+  const accountId = normalizeAccountId(url.searchParams.get("accountId") ?? DEFAULT_ACCOUNT_ID);
+  const nonce = crypto.randomBytes(16).toString("base64url");
+  sendHtml(
+    res,
+    200,
+    renderTelegramMiniAppPage({
+      accountId,
+      controlUiUrl: urls.controlUiUrl,
+      scriptNonce: nonce,
+    }),
+    nonce,
+  );
+}
+
+async function handleAuth(
+  api: OpenClawPluginApi,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  if (req.method !== "POST") {
+    sendText(res, 405, "Method not allowed");
+    return;
+  }
+  const contentType = String(req.headers["content-type"] ?? "").toLowerCase();
+  if (contentType.split(";")[0]?.trim() !== "application/json") {
+    sendText(res, 415, "Unsupported media type");
+    return;
+  }
+  const ip = req.socket.remoteAddress ?? "unknown";
+  if (!consumeRateLimit(ip)) {
+    sendText(res, 429, "Too many requests");
+    return;
+  }
+
+  const body = await readJsonBody(req);
+  if (body === "too-large") {
+    sendText(res, 413, "Payload too large");
+    return;
+  }
+  if (!body) {
+    sendText(res, 401, TELEGRAM_MINIAPP_EXPIRED_MESSAGE);
+    return;
+  }
+  const accountId = normalizeAccountId(body.accountId ?? DEFAULT_ACCOUNT_ID);
+  const cfg = currentConfig(api);
+  const account = resolveTelegramAccount({ cfg, accountId });
+  const validated = validateTelegramMiniAppInitData({
+    initData: body.initData,
+    botToken: account.token,
+  });
+  if (!validated) {
+    sendText(res, 401, TELEGRAM_MINIAPP_EXPIRED_MESSAGE);
+    return;
+  }
+  if (!(await isTelegramMiniAppOwner({ cfg, accountId, userId: validated.userId }))) {
+    sendText(res, 403, "Restricted to the bot owner.");
+    return;
+  }
+
+  let urls;
+  try {
+    urls = await resolveTelegramMiniAppUrls({ cfg });
+  } catch {
+    sendText(res, 503, TELEGRAM_MINIAPP_URL_ERROR);
+    return;
+  }
+  if (!rememberReplay(validated.hash, validated.authDateMs + 300_000)) {
+    sendText(res, 401, TELEGRAM_MINIAPP_EXPIRED_MESSAGE);
+    return;
+  }
+  const issued = await issueDeviceBootstrapToken({
+    profile: {
+      roles: ["operator"],
+      scopes: BOOTSTRAP_HANDOFF_OPERATOR_SCOPES,
+      purpose: "control-ui",
+    },
+  });
+  sendJson(res, 200, {
+    bootstrapToken: issued.token,
+    gatewayUrl: urls.gatewayUrl,
+  });
+}
+
+function currentConfig(api: OpenClawPluginApi): OpenClawConfig {
+  return (api.runtime.config?.current?.() ?? api.config) as OpenClawConfig;
+}
+
+async function readJsonBody(
+  req: IncomingMessage,
+): Promise<{ initData: string; accountId?: string } | "too-large" | null> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of req) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buffer.length;
+    if (total > MAX_BODY_BYTES) {
+      return "too-large";
+    }
+    chunks.push(buffer);
+  }
+  try {
+    const parsed = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+      initData?: unknown;
+      accountId?: unknown;
+    };
+    if (typeof parsed.initData !== "string") {
+      return null;
+    }
+    return {
+      initData: parsed.initData,
+      ...(typeof parsed.accountId === "string" ? { accountId: parsed.accountId } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function consumeRateLimit(ip: string): boolean {
+  const now = Date.now();
+  const current = rateLimit.get(ip);
+  if (!current || current.resetAtMs <= now) {
+    rateLimit.set(ip, { count: 1, resetAtMs: now + RATE_LIMIT_WINDOW_MS });
+    return true;
+  }
+  current.count += 1;
+  return current.count <= RATE_LIMIT_MAX;
+}
+
+function rememberReplay(hash: string, expiresAtMs: number): boolean {
+  pruneReplayCache();
+  if (replayCache.has(hash)) {
+    return false;
+  }
+  replayCache.set(hash, expiresAtMs);
+  while (replayCache.size > REPLAY_CACHE_LIMIT) {
+    const first = replayCache.keys().next().value;
+    if (!first) {
+      return true;
+    }
+    replayCache.delete(first);
+  }
+  return true;
+}
+
+function pruneReplayCache(): void {
+  const now = Date.now();
+  for (const [hash, expiresAtMs] of replayCache) {
+    if (expiresAtMs <= now) {
+      replayCache.delete(hash);
+    }
+  }
+}
+
+function securityHeaders(extra?: Record<string, string>): Record<string, string> {
+  return {
+    "Cache-Control": "no-store",
+    "Referrer-Policy": "no-referrer",
+    "X-Robots-Tag": "noindex",
+    ...extra,
+  };
+}
+
+function sendHtml(res: ServerResponse, status: number, body: string, nonce: string): void {
+  res.writeHead(
+    status,
+    securityHeaders({
+      "Content-Type": "text/html; charset=utf-8",
+      "Content-Security-Policy": `default-src 'none'; script-src 'nonce-${nonce}' https://telegram.org; connect-src 'self'; style-src 'unsafe-inline'; base-uri 'none'; frame-ancestors 'none'`,
+    }),
+  );
+  res.end(body);
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, securityHeaders({ "Content-Type": "application/json; charset=utf-8" }));
+  res.end(JSON.stringify(body));
+}
+
+function sendText(res: ServerResponse, status: number, body: string): void {
+  res.writeHead(status, securityHeaders({ "Content-Type": "text/plain; charset=utf-8" }));
+  res.end(body);
+}

--- a/extensions/telegram/src/miniapp/url.test.ts
+++ b/extensions/telegram/src/miniapp/url.test.ts
@@ -1,0 +1,56 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { describe, expect, it, vi } from "vitest";
+import { resolveTelegramMiniAppUrls, TELEGRAM_MINIAPP_URL_ERROR } from "./url.js";
+
+describe("resolveTelegramMiniAppUrls", () => {
+  it("resolves HTTPS page and WSS gateway URLs from Tailscale Serve", async () => {
+    const runCommand = vi.fn(async () => ({
+      code: 0,
+      stdout: JSON.stringify({ Self: { DNSName: "host.tailnet.ts.net." } }),
+    }));
+    const cfg = {
+      gateway: {
+        tailscale: { mode: "serve" },
+        controlUi: { basePath: "/openclaw/" },
+      },
+    } satisfies OpenClawConfig;
+
+    await expect(resolveTelegramMiniAppUrls({ cfg, runCommand })).resolves.toEqual({
+      pageUrl: "https://host.tailnet.ts.net/__openclaw_tg_miniapp/",
+      controlUiUrl: "https://host.tailnet.ts.net/openclaw",
+      gatewayUrl: "wss://host.tailnet.ts.net/openclaw",
+    });
+    expect(runCommand).toHaveBeenCalledWith(["tailscale", "status", "--json"], {
+      timeoutMs: 5000,
+    });
+  });
+
+  it("uses service MagicDNS for Tailscale Serve service names", async () => {
+    const runCommand = vi.fn(async () => ({
+      code: 0,
+      stdout: JSON.stringify({ Self: { DNSName: "host.tailnet.ts.net" } }),
+    }));
+    const cfg = {
+      gateway: {
+        tailscale: { mode: "serve", serviceName: "svc:openclaw" },
+      },
+    } satisfies OpenClawConfig;
+
+    await expect(resolveTelegramMiniAppUrls({ cfg, runCommand })).resolves.toMatchObject({
+      pageUrl: "https://openclaw.tailnet.ts.net/__openclaw_tg_miniapp/",
+      gatewayUrl: "wss://openclaw.tailnet.ts.net",
+    });
+  });
+
+  it("fails loud when Tailscale mode is off or MagicDNS cannot resolve", async () => {
+    await expect(resolveTelegramMiniAppUrls({ cfg: {} })).rejects.toThrow(
+      TELEGRAM_MINIAPP_URL_ERROR,
+    );
+    await expect(
+      resolveTelegramMiniAppUrls({
+        cfg: { gateway: { tailscale: { mode: "funnel" } } },
+        runCommand: async () => ({ code: 1, stdout: "" }),
+      }),
+    ).rejects.toThrow(TELEGRAM_MINIAPP_URL_ERROR);
+  });
+});

--- a/extensions/telegram/src/miniapp/url.test.ts
+++ b/extensions/telegram/src/miniapp/url.test.ts
@@ -18,7 +18,7 @@ describe("resolveTelegramMiniAppUrls", () => {
     await expect(resolveTelegramMiniAppUrls({ cfg, runCommand })).resolves.toEqual({
       pageUrl: "https://host.tailnet.ts.net/__openclaw_tg_miniapp/",
       controlUiUrl: "https://host.tailnet.ts.net/openclaw",
-      gatewayUrl: "wss://host.tailnet.ts.net",
+      gatewayUrl: "wss://host.tailnet.ts.net/openclaw",
     });
     expect(runCommand).toHaveBeenCalledWith(["tailscale", "status", "--json"], {
       timeoutMs: 5000,

--- a/extensions/telegram/src/miniapp/url.test.ts
+++ b/extensions/telegram/src/miniapp/url.test.ts
@@ -18,7 +18,7 @@ describe("resolveTelegramMiniAppUrls", () => {
     await expect(resolveTelegramMiniAppUrls({ cfg, runCommand })).resolves.toEqual({
       pageUrl: "https://host.tailnet.ts.net/__openclaw_tg_miniapp/",
       controlUiUrl: "https://host.tailnet.ts.net/openclaw",
-      gatewayUrl: "wss://host.tailnet.ts.net/openclaw",
+      gatewayUrl: "wss://host.tailnet.ts.net",
     });
     expect(runCommand).toHaveBeenCalledWith(["tailscale", "status", "--json"], {
       timeoutMs: 5000,

--- a/extensions/telegram/src/miniapp/url.ts
+++ b/extensions/telegram/src/miniapp/url.ts
@@ -43,7 +43,10 @@ export async function resolveTelegramMiniAppUrls(params: {
   return {
     pageUrl: `https://${publishedHost}${TELEGRAM_MINIAPP_PATH_PREFIX}`,
     controlUiUrl,
-    gatewayUrl: `wss://${publishedHost}`,
+    // The Control UI serves its WebSocket endpoint under the same base path as
+    // the HTTP app (ui/src/app/settings.ts deriveDefaultGatewayUrl); a bare
+    // host URL breaks gateway.controlUi.basePath installs.
+    gatewayUrl: `wss://${publishedHost}${controlUiPath}`,
   };
 }
 

--- a/extensions/telegram/src/miniapp/url.ts
+++ b/extensions/telegram/src/miniapp/url.ts
@@ -1,5 +1,5 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 // Telegram Mini App published URL resolution.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   resolveTailnetHostWithRunner,
   resolveTailscalePublishedHost,
@@ -43,7 +43,7 @@ export async function resolveTelegramMiniAppUrls(params: {
   return {
     pageUrl: `https://${publishedHost}${TELEGRAM_MINIAPP_PATH_PREFIX}`,
     controlUiUrl,
-    gatewayUrl: `wss://${publishedHost}${controlUiPath}`,
+    gatewayUrl: `wss://${publishedHost}`,
   };
 }
 

--- a/extensions/telegram/src/miniapp/url.ts
+++ b/extensions/telegram/src/miniapp/url.ts
@@ -1,0 +1,57 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+// Telegram Mini App published URL resolution.
+import {
+  resolveTailnetHostWithRunner,
+  resolveTailscalePublishedHost,
+  type TailscaleStatusCommandRunner,
+} from "openclaw/plugin-sdk/core";
+import { runCommandWithTimeout } from "openclaw/plugin-sdk/process-runtime";
+
+export const TELEGRAM_MINIAPP_PATH_PREFIX = "/__openclaw_tg_miniapp/";
+export const TELEGRAM_MINIAPP_URL_ERROR =
+  "Mini App needs an HTTPS gateway URL. Set `gateway.tailscale.mode: serve` or `funnel`, then retry.";
+
+export type TelegramMiniAppUrls = {
+  pageUrl: string;
+  controlUiUrl: string;
+  gatewayUrl: string;
+};
+
+export async function resolveTelegramMiniAppUrls(params: {
+  cfg: OpenClawConfig;
+  runCommand?: TailscaleStatusCommandRunner;
+}): Promise<TelegramMiniAppUrls> {
+  const mode = params.cfg.gateway?.tailscale?.mode ?? "off";
+  if (mode !== "serve" && mode !== "funnel") {
+    throw new Error(TELEGRAM_MINIAPP_URL_ERROR);
+  }
+
+  const tailnetHost = await resolveTailnetHostWithRunner(
+    params.runCommand ?? runCommandWithTimeout,
+  );
+  const publishedHost = resolveTailscalePublishedHost({
+    tailscaleMode: mode,
+    tailnetHost,
+    serviceName: params.cfg.gateway?.tailscale?.serviceName,
+  });
+  if (!publishedHost) {
+    throw new Error(TELEGRAM_MINIAPP_URL_ERROR);
+  }
+
+  const controlUiPath = normalizeControlUiBasePath(params.cfg.gateway?.controlUi?.basePath);
+  const controlUiUrl = `https://${publishedHost}${controlUiPath}`;
+  return {
+    pageUrl: `https://${publishedHost}${TELEGRAM_MINIAPP_PATH_PREFIX}`,
+    controlUiUrl,
+    gatewayUrl: `wss://${publishedHost}${controlUiPath}`,
+  };
+}
+
+function normalizeControlUiBasePath(value: unknown): string {
+  const raw = typeof value === "string" ? value.trim() : "";
+  if (!raw || raw === "/") {
+    return "";
+  }
+  const withLeading = raw.startsWith("/") ? raw : `/${raw}`;
+  return withLeading.replace(/\/+$/, "");
+}

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -195,12 +195,12 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
     ),
     publicExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS",
-      10471,
+      10474,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS",
-      5225,
+      5226,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -1809,6 +1809,191 @@ export function registerControlUiAndPairingSuite(): void {
     }
   });
 
+  test("silently approves control ui operator bootstrap tokens with control-ui purpose", async () => {
+    const { issueDeviceBootstrapToken } = await import("../infra/device-bootstrap.js");
+    const { getPairedDevice, listDevicePairing, verifyDeviceToken } =
+      await import("../infra/device-pairing.js");
+    const { BOOTSTRAP_HANDOFF_OPERATOR_SCOPES } =
+      await import("../shared/device-bootstrap-profile.js");
+    testState.gatewayControlUi = { allowedOrigins: ["https://localhost"] };
+    const { server, port, prevToken } = await startControlUiServer("secret");
+
+    const { identityPath, identity } = await createOperatorIdentityFixture(
+      "openclaw-bootstrap-control-ui-",
+    );
+
+    try {
+      const issued = await issueDeviceBootstrapToken({
+        profile: {
+          roles: ["operator"],
+          scopes: BOOTSTRAP_HANDOFF_OPERATOR_SCOPES,
+          purpose: "control-ui",
+        },
+      });
+      const wsBootstrap = await openWs(port, {
+        origin: "https://localhost",
+        "x-forwarded-for": "203.0.113.50",
+      });
+      const initial = await connectReq(wsBootstrap, {
+        skipDefaultAuth: true,
+        bootstrapToken: issued.token,
+        role: "operator",
+        scopes: [...BOOTSTRAP_HANDOFF_OPERATOR_SCOPES],
+        client: CONTROL_UI_CLIENT,
+        deviceIdentityPath: identityPath,
+      });
+      expect(initial.ok).toBe(true);
+      const payload = initial.payload as
+        | {
+            type?: string;
+            auth?: {
+              deviceToken?: string;
+              role?: string;
+              scopes?: string[];
+            };
+          }
+        | undefined;
+      expect(payload?.type).toBe("hello-ok");
+      expect(payload?.auth?.role).toBe("operator");
+      expect(payload?.auth?.scopes).toEqual([...BOOTSTRAP_HANDOFF_OPERATOR_SCOPES]);
+      const deviceToken = payload?.auth?.deviceToken;
+      if (!deviceToken) {
+        throw new Error("expected control ui operator device token");
+      }
+      wsBootstrap.close();
+
+      const pending = (await listDevicePairing()).pending.filter(
+        (entry) => entry.deviceId === identity.deviceId,
+      );
+      expect(pending).toEqual([]);
+      const paired = await getPairedDevice(identity.deviceId);
+      expect(paired?.roles).toEqual(["operator"]);
+      expect(paired?.approvedScopes).toEqual([...BOOTSTRAP_HANDOFF_OPERATOR_SCOPES]);
+      await expect(
+        verifyDeviceToken({
+          deviceId: identity.deviceId,
+          token: deviceToken,
+          role: "operator",
+          scopes: [...BOOTSTRAP_HANDOFF_OPERATOR_SCOPES],
+        }),
+      ).resolves.toEqual({ ok: true });
+
+      const wsReplay = await openWs(port, {
+        origin: "https://localhost",
+        "x-forwarded-for": "203.0.113.50",
+      });
+      const replay = await connectReq(wsReplay, {
+        skipDefaultAuth: true,
+        bootstrapToken: issued.token,
+        role: "operator",
+        scopes: [...BOOTSTRAP_HANDOFF_OPERATOR_SCOPES],
+        client: CONTROL_UI_CLIENT,
+        deviceIdentityPath: identityPath,
+      });
+      expect(replay.ok).toBe(false);
+      expect((replay.error?.details as { code?: string } | undefined)?.code).toBe(
+        ConnectErrorDetailCodes.AUTH_BOOTSTRAP_TOKEN_INVALID,
+      );
+      wsReplay.close();
+    } finally {
+      await server.close();
+      restoreGatewayToken(prevToken);
+    }
+  });
+
+  test("requires pairing for control ui bootstrap token without control-ui purpose", async () => {
+    const { issueDeviceBootstrapToken } = await import("../infra/device-bootstrap.js");
+    const { getPairedDevice, listDevicePairing } = await import("../infra/device-pairing.js");
+    const { BOOTSTRAP_HANDOFF_OPERATOR_SCOPES } =
+      await import("../shared/device-bootstrap-profile.js");
+    testState.gatewayControlUi = { allowedOrigins: ["https://localhost"] };
+    const { server, port, prevToken } = await startControlUiServer("secret");
+
+    const { identityPath, identity } = await createOperatorIdentityFixture(
+      "openclaw-bootstrap-control-ui-missing-purpose-",
+    );
+
+    try {
+      const issued = await issueDeviceBootstrapToken({
+        profile: {
+          roles: ["operator"],
+          scopes: BOOTSTRAP_HANDOFF_OPERATOR_SCOPES,
+        },
+      });
+      const wsBootstrap = await openWs(port, {
+        origin: "https://localhost",
+        "x-forwarded-for": "203.0.113.51",
+      });
+      const initial = await connectReq(wsBootstrap, {
+        skipDefaultAuth: true,
+        bootstrapToken: issued.token,
+        role: "operator",
+        scopes: ["operator.read"],
+        client: CONTROL_UI_CLIENT,
+        deviceIdentityPath: identityPath,
+      });
+      expect(initial.ok).toBe(false);
+      expect(initial.error?.message ?? "").toContain("pairing required");
+
+      const pending = (await listDevicePairing()).pending.filter(
+        (entry) => entry.deviceId === identity.deviceId,
+      );
+      expect(pending).toHaveLength(1);
+      expect(pending[0]?.role).toBe("operator");
+      expect(await getPairedDevice(identity.deviceId)).toBeNull();
+      wsBootstrap.close();
+    } finally {
+      await server.close();
+      restoreGatewayToken(prevToken);
+    }
+  });
+
+  test("requires pairing for control ui node bootstrap tokens", async () => {
+    const { issueDeviceBootstrapToken } = await import("../infra/device-bootstrap.js");
+    const { getPairedDevice, listDevicePairing } = await import("../infra/device-pairing.js");
+    testState.gatewayControlUi = { allowedOrigins: ["https://localhost"] };
+    const { server, port, prevToken } = await startControlUiServer("secret");
+
+    const { identityPath, identity } = await createOperatorIdentityFixture(
+      "openclaw-bootstrap-control-ui-node-profile-",
+    );
+
+    try {
+      const issued = await issueDeviceBootstrapToken({
+        profile: {
+          roles: ["node"],
+          scopes: [],
+          purpose: "control-ui",
+        },
+      });
+      const wsBootstrap = await openWs(port, {
+        origin: "https://localhost",
+        "x-forwarded-for": "203.0.113.52",
+      });
+      const initial = await connectReq(wsBootstrap, {
+        skipDefaultAuth: true,
+        bootstrapToken: issued.token,
+        role: "node",
+        scopes: [],
+        client: CONTROL_UI_CLIENT,
+        deviceIdentityPath: identityPath,
+      });
+      expect(initial.ok).toBe(false);
+      expect(initial.error?.message ?? "").toContain("pairing required");
+
+      const pending = (await listDevicePairing()).pending.filter(
+        (entry) => entry.deviceId === identity.deviceId,
+      );
+      expect(pending).toHaveLength(1);
+      expect(pending[0]?.role).toBe("node");
+      expect(await getPairedDevice(identity.deviceId)).toBeNull();
+      wsBootstrap.close();
+    } finally {
+      await server.close();
+      restoreGatewayToken(prevToken);
+    }
+  });
+
   test("auto-approves local-direct node pairing, then queues operator scope approval", async () => {
     const { getPairedDevice, listDevicePairing } = await import("../infra/device-pairing.js");
     const { server, port, prevToken } = await startControlUiServer("secret");

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -93,6 +93,7 @@ import { rawDataToString } from "../../../infra/ws.js";
 import { logRejectedLargePayload } from "../../../logging/diagnostic-payload.js";
 import type { createSubsystemLogger } from "../../../logging/subsystem.js";
 import {
+  BOOTSTRAP_HANDOFF_OPERATOR_SCOPES,
   isPairingSetupBootstrapProfile,
   resolveBootstrapProfileScopesForRole,
   resolveBootstrapProfileScopesForRoles,
@@ -355,6 +356,31 @@ function isSetupCodeMobileBootstrapClient(client: {
     return /^(?:ios|ipados)(?:\s|$)/.test(platform) && /^(?:iphone|ipad|ios)$/.test(deviceFamily);
   }
   return false;
+}
+
+function isControlUiOperatorBootstrapProfile(params: {
+  profile: DeviceBootstrapProfile | null;
+  requestedScopes: readonly string[];
+}): params is { profile: DeviceBootstrapProfile; requestedScopes: readonly string[] } {
+  const { profile, requestedScopes } = params;
+  if (!profile || profile.purpose !== "control-ui") {
+    return false;
+  }
+  if (profile.roles.length !== 1 || profile.roles[0] !== "operator") {
+    return false;
+  }
+  if (
+    !profile.scopes.every((scope) =>
+      (BOOTSTRAP_HANDOFF_OPERATOR_SCOPES as readonly string[]).includes(scope),
+    )
+  ) {
+    return false;
+  }
+  return roleScopesAllow({
+    role: "operator",
+    requestedScopes,
+    allowedScopes: profile.scopes,
+  });
 }
 
 function resolveTrustedProxyControlUiScopes(params: {
@@ -1421,13 +1447,14 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
               authMethod === "bootstrap-token" &&
               bootstrapTokenCandidate &&
               reason === "not-paired" &&
-              role === "node" &&
-              scopes.length === 0 &&
               !existingPairedDevice &&
-              !isControlUi &&
-              !isBrowserOperatorUi &&
-              !isWebchat &&
-              connectParams.client.mode === GATEWAY_CLIENT_MODES.NODE
+              ((role === "node" &&
+                scopes.length === 0 &&
+                !isControlUi &&
+                !isBrowserOperatorUi &&
+                !isWebchat &&
+                connectParams.client.mode === GATEWAY_CLIENT_MODES.NODE) ||
+                (isControlUi && role === "operator"))
                 ? await getBoundDeviceBootstrapProfile({
                     token: bootstrapTokenCandidate,
                     deviceId: device.id,
@@ -1437,21 +1464,45 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
             const allowSetupCodeMobileBootstrapPairing =
               boundBootstrapProfile !== null &&
               isPairingSetupBootstrapProfile(boundBootstrapProfile) &&
+              role === "node" &&
+              scopes.length === 0 &&
+              !isControlUi &&
+              !isBrowserOperatorUi &&
+              !isWebchat &&
+              connectParams.client.mode === GATEWAY_CLIENT_MODES.NODE &&
               isSetupCodeMobileBootstrapClient(connectParams.client);
+            const setupCodeMobileBootstrapProfile = allowSetupCodeMobileBootstrapPairing
+              ? boundBootstrapProfile
+              : null;
+            const allowControlUiOperatorBootstrapPairing = isControlUiOperatorBootstrapProfile({
+              profile: boundBootstrapProfile,
+              requestedScopes: scopes,
+            });
+            const controlUiOperatorBootstrapProfile = allowControlUiOperatorBootstrapPairing
+              ? boundBootstrapProfile
+              : null;
             // This is the native QR/setup-code onboarding seam. Mobile clients
             // must prove their canonical client id and platform/family metadata
             // agree before the Gateway can skip owner approval and hand off the
             // bounded operator token below. Admin/pairing still require an explicit owner flow.
-            const bootstrapPairingRoles = allowSetupCodeMobileBootstrapPairing
-              ? uniqueStrings([role, ...boundBootstrapProfile.roles])
-              : undefined;
-            const bootstrapPairingScopes =
-              allowSetupCodeMobileBootstrapPairing && bootstrapPairingRoles
-                ? resolveBootstrapProfileScopesForRoles(
-                    bootstrapPairingRoles,
-                    boundBootstrapProfile.scopes,
+            const bootstrapPairingRoles = setupCodeMobileBootstrapProfile
+              ? uniqueStrings([role, ...setupCodeMobileBootstrapProfile.roles])
+              : controlUiOperatorBootstrapProfile
+                ? ["operator"]
+                : undefined;
+            const bootstrapPairingScopes = setupCodeMobileBootstrapProfile
+              ? resolveBootstrapProfileScopesForRoles(
+                  bootstrapPairingRoles ?? [],
+                  setupCodeMobileBootstrapProfile.scopes,
+                )
+              : controlUiOperatorBootstrapProfile
+                ? resolveBootstrapProfileScopesForRole(
+                    "operator",
+                    controlUiOperatorBootstrapProfile.scopes,
                   )
                 : undefined;
+            const bootstrapApprovalProfile =
+              setupCodeMobileBootstrapProfile ?? controlUiOperatorBootstrapProfile;
             const pairing = await requestDevicePairing({
               deviceId: device.id,
               publicKey: devicePublicKey,
@@ -1467,7 +1518,8 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
                   ? false
                   : allowSilentLocalPairing ||
                     allowSilentTrustedCidrsNodePairing ||
-                    allowSetupCodeMobileBootstrapPairing,
+                    allowSetupCodeMobileBootstrapPairing ||
+                    allowControlUiOperatorBootstrapPairing,
             });
             const context = buildRequestContext();
             // A replacement request obsoletes older pending requestIds; tell approval
@@ -1503,24 +1555,23 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
               return replacementPending?.requestId;
             };
             if (pairing.request.silent === true) {
-              approved =
-                allowSetupCodeMobileBootstrapPairing && boundBootstrapProfile
-                  ? await approveBootstrapDevicePairing(
-                      pairing.request.requestId,
-                      boundBootstrapProfile,
-                      { accessMetadata: clientAccessMetadata },
-                    )
-                  : await approveDevicePairing(pairing.request.requestId, {
-                      callerScopes: scopes,
-                      accessMetadata: clientAccessMetadata,
-                      // Same-host local approvals are prune-eligible "silent";
-                      // trusted-CIDR approvals cross hosts and must never be
-                      // auto-pruned, so they carry their own provenance.
-                      approvedVia: allowSilentLocalPairing ? "silent" : "trusted-cidr",
-                    });
+              approved = bootstrapApprovalProfile
+                ? await approveBootstrapDevicePairing(
+                    pairing.request.requestId,
+                    bootstrapApprovalProfile,
+                    { accessMetadata: clientAccessMetadata },
+                  )
+                : await approveDevicePairing(pairing.request.requestId, {
+                    callerScopes: scopes,
+                    accessMetadata: clientAccessMetadata,
+                    // Same-host local approvals are prune-eligible "silent";
+                    // trusted-CIDR approvals cross hosts and must never be
+                    // auto-pruned, so they carry their own provenance.
+                    approvedVia: allowSilentLocalPairing ? "silent" : "trusted-cidr",
+                  });
               if (approved?.status === "approved") {
-                if (allowSetupCodeMobileBootstrapPairing && boundBootstrapProfile) {
-                  handoffBootstrapProfile = boundBootstrapProfile;
+                if (bootstrapApprovalProfile) {
+                  handoffBootstrapProfile = bootstrapApprovalProfile;
                 }
                 logGateway.info(
                   `device pairing auto-approved device=${approved.device.deviceId} role=${approved.device.role ?? "unknown"}`,

--- a/src/infra/device-bootstrap.test.ts
+++ b/src/infra/device-bootstrap.test.ts
@@ -161,6 +161,37 @@ describe("device bootstrap tokens", () => {
     await expect(getDeviceBootstrapTokenProfile({ baseDir, token: "invalid" })).resolves.toBeNull();
   });
 
+  it("persists bootstrap profile purpose through binding", async () => {
+    const baseDir = await createTempDir();
+    const issued = await issueDeviceBootstrapToken({
+      baseDir,
+      profile: {
+        roles: ["operator"],
+        scopes: ["operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
+        purpose: "control-ui",
+      },
+    });
+
+    await expect(
+      verifyBootstrapToken(baseDir, issued.token, {
+        role: "operator",
+        scopes: ["operator.read"],
+      }),
+    ).resolves.toEqual({ ok: true });
+    await expect(
+      getBoundDeviceBootstrapProfile({
+        baseDir,
+        token: issued.token,
+        deviceId: "device-123",
+        publicKey: "public-key-123",
+      }),
+    ).resolves.toEqual({
+      roles: ["operator"],
+      scopes: ["operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
+      purpose: "control-ui",
+    });
+  });
+
   it("persists bootstrap redemption state across verification reloads", async () => {
     const baseDir = await createTempDir();
     const issued = await issueDeviceBootstrapToken({

--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -218,6 +218,7 @@ export {
 export { KeyedAsyncQueue, enqueueKeyedTask } from "./keyed-async-queue.js";
 export { createDedupeCache, resolveGlobalDedupeCache } from "../infra/dedupe.js";
 export { generateSecureToken, generateSecureUuid } from "../infra/secure-random.js";
+export { resolveTailscalePublishedHost } from "../shared/tailscale-status.js";
 export {
   buildMemorySystemPromptAddition,
   delegateCompactionToRuntime,

--- a/src/plugin-sdk/device-bootstrap.ts
+++ b/src/plugin-sdk/device-bootstrap.ts
@@ -12,4 +12,5 @@ export {
   PAIRING_SETUP_BOOTSTRAP_PROFILE,
   type DeviceBootstrapProfile,
   type DeviceBootstrapProfileInput,
+  type DeviceBootstrapPurpose,
 } from "../shared/device-bootstrap-profile.js";

--- a/src/plugin-sdk/device-bootstrap.ts
+++ b/src/plugin-sdk/device-bootstrap.ts
@@ -7,6 +7,7 @@ export {
   revokeDeviceBootstrapToken,
 } from "../infra/device-bootstrap.js";
 export {
+  BOOTSTRAP_HANDOFF_OPERATOR_SCOPES,
   normalizeDeviceBootstrapProfile,
   PAIRING_SETUP_BOOTSTRAP_PROFILE,
   type DeviceBootstrapProfile,

--- a/src/shared/device-bootstrap-profile.test.ts
+++ b/src/shared/device-bootstrap-profile.test.ts
@@ -7,6 +7,7 @@ import {
   isNodePairingSetupBootstrapProfile,
   isPairingSetupBootstrapProfile,
   normalizeDeviceBootstrapHandoffProfile,
+  normalizeDeviceBootstrapProfile,
   resolveBootstrapProfileScopesForRole,
   resolveBootstrapProfileScopesForRoles,
 } from "./device-bootstrap-profile.js";
@@ -64,12 +65,23 @@ describe("device bootstrap profile", () => {
           "operator.talk.secrets",
           "operator.write",
         ],
-        purpose: " control-ui ",
+        purpose: "control-ui",
       }),
     ).toEqual({
       roles: ["node", "operator"],
       scopes: ["operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
       purpose: "control-ui",
+    });
+  });
+
+  test("drops unknown bootstrap purpose codes", () => {
+    expect(
+      normalizeDeviceBootstrapProfile(
+        JSON.parse('{"roles":["operator"],"scopes":["operator.read"],"purpose":"status"}'),
+      ),
+    ).toEqual({
+      roles: ["operator"],
+      scopes: ["operator.read"],
     });
   });
 

--- a/src/shared/device-bootstrap-profile.test.ts
+++ b/src/shared/device-bootstrap-profile.test.ts
@@ -64,10 +64,12 @@ describe("device bootstrap profile", () => {
           "operator.talk.secrets",
           "operator.write",
         ],
+        purpose: " control-ui ",
       }),
     ).toEqual({
       roles: ["node", "operator"],
       scopes: ["operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
+      purpose: "control-ui",
     });
   });
 

--- a/src/shared/device-bootstrap-profile.ts
+++ b/src/shared/device-bootstrap-profile.ts
@@ -1,18 +1,21 @@
 // Device bootstrap profile helpers build profile claims for device onboarding.
 import { normalizeDeviceAuthRole, normalizeDeviceAuthScopes } from "./device-auth.js";
 
+/** Closed purpose codes carried by specialized bootstrap tokens. */
+export type DeviceBootstrapPurpose = "control-ui";
+
 /** Normalized roles/scopes carried by a bootstrap token during device handoff. */
 export type DeviceBootstrapProfile = {
   roles: string[];
   scopes: string[];
-  purpose?: string;
+  purpose?: DeviceBootstrapPurpose;
 };
 
 /** Caller-provided bootstrap profile before role/scope normalization and bounding. */
 export type DeviceBootstrapProfileInput = {
   roles?: readonly string[];
   scopes?: readonly string[];
-  purpose?: string;
+  purpose?: DeviceBootstrapPurpose;
 };
 
 /** Operator scopes allowed to cross the short-lived bootstrap handoff boundary. */
@@ -121,7 +124,7 @@ function normalizeBootstrapRoles(roles: readonly string[] | undefined): string[]
 export function normalizeDeviceBootstrapProfile(
   input: DeviceBootstrapProfileInput | undefined,
 ): DeviceBootstrapProfile {
-  const purpose = typeof input?.purpose === "string" ? input.purpose.trim() : "";
+  const purpose = input?.purpose === "control-ui" ? input.purpose : undefined;
   return {
     roles: normalizeBootstrapRoles(input?.roles),
     scopes: normalizeDeviceAuthScopes(input?.scopes ? [...input.scopes] : []),

--- a/src/shared/device-bootstrap-profile.ts
+++ b/src/shared/device-bootstrap-profile.ts
@@ -5,12 +5,14 @@ import { normalizeDeviceAuthRole, normalizeDeviceAuthScopes } from "./device-aut
 export type DeviceBootstrapProfile = {
   roles: string[];
   scopes: string[];
+  purpose?: string;
 };
 
 /** Caller-provided bootstrap profile before role/scope normalization and bounding. */
 export type DeviceBootstrapProfileInput = {
   roles?: readonly string[];
   scopes?: readonly string[];
+  purpose?: string;
 };
 
 /** Operator scopes allowed to cross the short-lived bootstrap handoff boundary. */
@@ -97,6 +99,7 @@ export function normalizeDeviceBootstrapHandoffProfile(
   return {
     roles: profile.roles,
     scopes: resolveBootstrapProfileScopesForRoles(profile.roles, profile.scopes),
+    ...(profile.purpose ? { purpose: profile.purpose } : {}),
   };
 }
 
@@ -118,8 +121,10 @@ function normalizeBootstrapRoles(roles: readonly string[] | undefined): string[]
 export function normalizeDeviceBootstrapProfile(
   input: DeviceBootstrapProfileInput | undefined,
 ): DeviceBootstrapProfile {
+  const purpose = typeof input?.purpose === "string" ? input.purpose.trim() : "";
   return {
     roles: normalizeBootstrapRoles(input?.roles),
     scopes: normalizeDeviceAuthScopes(input?.scopes ? [...input.scopes] : []),
+    ...(purpose ? { purpose } : {}),
   };
 }

--- a/ui/src/api/gateway.node.test.ts
+++ b/ui/src/api/gateway.node.test.ts
@@ -126,6 +126,7 @@ vi.mock("../lib/nodes/index.ts", async (importOriginal) => ({
 }));
 
 const {
+  CONTROL_UI_BOOTSTRAP_OPERATOR_SCOPES,
   CONTROL_UI_OPERATOR_SCOPES,
   GatewayBrowserClient,
   GatewayRequestError,
@@ -138,7 +139,7 @@ type ConnectFrame = {
   id?: string;
   method?: string;
   params?: {
-    auth?: { token?: string; password?: string; deviceToken?: string };
+    auth?: { token?: string; bootstrapToken?: string; password?: string; deviceToken?: string };
     maxProtocol?: number;
     minProtocol?: number;
     caps?: string[];
@@ -420,6 +421,25 @@ describe("GatewayBrowserClient", () => {
       GATEWAY_CLIENT_CAPS.INLINE_WIDGETS,
     ]);
     expect(connectFrame.params?.scopes).toEqual([...CONTROL_UI_OPERATOR_SCOPES]);
+  });
+
+  it("requests handoff scopes with bootstrap token auth", async () => {
+    const client = new GatewayBrowserClient({
+      url: "wss://gateway.example",
+      bootstrapToken: "boot-1",
+    });
+
+    const { connectFrame } = await startConnect(client);
+
+    expect(connectFrame.params?.auth?.token).toBeUndefined();
+    expect(connectFrame.params?.auth?.bootstrapToken).toBe("boot-1");
+    expect(connectFrame.params?.scopes).toEqual([...CONTROL_UI_BOOTSTRAP_OPERATOR_SCOPES]);
+    const [, signedPayload] = requireFirstSignCall();
+    expectSignedPayloadFields(signedPayload, {
+      scopes: [...CONTROL_UI_BOOTSTRAP_OPERATOR_SCOPES],
+      token: "boot-1",
+      nonce: "nonce-1",
+    });
   });
 
   it("adds the current Control UI protocol to bare protocol mismatch errors", () => {

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -213,6 +213,7 @@ type Pending = {
 
 type SelectedConnectAuth = {
   authToken?: string;
+  authBootstrapToken?: string;
   authDeviceToken?: string;
   authPassword?: string;
   resolvedDeviceToken?: string;
@@ -231,8 +232,16 @@ export const CONTROL_UI_OPERATOR_SCOPES = [
   "operator.pairing",
 ] as const;
 
+export const CONTROL_UI_BOOTSTRAP_OPERATOR_SCOPES = [
+  "operator.approvals",
+  "operator.read",
+  "operator.talk.secrets",
+  "operator.write",
+] as const;
+
 export type GatewayConnectAuth = {
   token?: string;
+  bootstrapToken?: string;
   deviceToken?: string;
   password?: string;
 };
@@ -290,6 +299,7 @@ type DeviceTokenRetryDecision = {
 export type GatewayBrowserClientOptions = {
   url: string;
   token?: string;
+  bootstrapToken?: string;
   password?: string;
   clientName?: GatewayClientName;
   clientVersion?: string;
@@ -342,6 +352,7 @@ type GatewayConnectTiming = {
   hasDeviceIdentity?: boolean;
   hasDevice?: boolean;
   hasAuthToken?: boolean;
+  hasBootstrapToken?: boolean;
   hasDeviceToken?: boolean;
   hasPassword?: boolean;
   errorCode?: string;
@@ -365,11 +376,13 @@ function buildGatewayConnectAuth(
   selectedAuth: SelectedConnectAuth,
 ): GatewayConnectAuth | undefined {
   const authToken = selectedAuth.authToken;
-  if (!(authToken || selectedAuth.authPassword)) {
+  const bootstrapToken = selectedAuth.authBootstrapToken;
+  if (!(authToken || bootstrapToken || selectedAuth.authPassword)) {
     return undefined;
   }
   return {
     token: authToken,
+    bootstrapToken,
     deviceToken: selectedAuth.authDeviceToken ?? selectedAuth.resolvedDeviceToken,
     password: selectedAuth.authPassword,
   };
@@ -432,6 +445,9 @@ function formatBrowserWebSocketConstructorError(err: unknown, url: string): Gate
 }
 
 function resolveControlUiConnectScopes(selectedAuth: SelectedConnectAuth): string[] {
+  if (selectedAuth.authBootstrapToken) {
+    return [...CONTROL_UI_BOOTSTRAP_OPERATOR_SCOPES];
+  }
   const isUsingStoredDeviceToken =
     Boolean(selectedAuth.storedToken) &&
     (selectedAuth.resolvedDeviceToken === selectedAuth.storedToken ||
@@ -759,6 +775,7 @@ export class GatewayBrowserClient {
       hasDeviceIdentity: Boolean(plan.deviceIdentity),
       hasDevice: Boolean(plan.device),
       hasAuthToken: Boolean(plan.selectedAuth.authToken),
+      hasBootstrapToken: Boolean(plan.selectedAuth.authBootstrapToken),
       hasDeviceToken: Boolean(
         plan.selectedAuth.authDeviceToken ?? plan.selectedAuth.resolvedDeviceToken,
       ),
@@ -832,7 +849,7 @@ export class GatewayBrowserClient {
       client,
       role,
       scopes,
-      authToken: selectedAuth.authToken,
+      authToken: selectedAuth.authBootstrapToken ?? selectedAuth.authToken,
       connectNonce,
     });
     this.emitConnectTiming(generation, "connect-plan-ready", {
@@ -840,6 +857,7 @@ export class GatewayBrowserClient {
       hasDeviceIdentity: Boolean(deviceIdentity),
       hasDevice: Boolean(device),
       hasAuthToken: Boolean(selectedAuth.authToken),
+      hasBootstrapToken: Boolean(selectedAuth.authBootstrapToken),
       hasDeviceToken: Boolean(selectedAuth.authDeviceToken ?? selectedAuth.resolvedDeviceToken),
       hasPassword: Boolean(selectedAuth.authPassword),
     });
@@ -868,6 +886,7 @@ export class GatewayBrowserClient {
     this.pendingDeviceTokenRetry = false;
     this.deviceTokenRetryBudgetUsed = false;
     this.pendingStartupReconnectDelayMs = null;
+    this.opts.bootstrapToken = undefined;
     if (hello?.auth?.deviceToken && plan.deviceIdentity) {
       this.storeDeviceAuthToken({
         deviceId: plan.deviceIdentity.deviceId,
@@ -1094,6 +1113,7 @@ export class GatewayBrowserClient {
 
   private selectConnectAuth(params: { role: string; deviceId: string }): SelectedConnectAuth {
     const explicitGatewayToken = this.opts.token?.trim() || undefined;
+    const explicitBootstrapToken = this.opts.bootstrapToken?.trim() || undefined;
     const authPassword = this.opts.password?.trim() || undefined;
     const storedEntry = loadDeviceAuthToken({
       deviceId: params.deviceId,
@@ -1113,6 +1133,15 @@ export class GatewayBrowserClient {
     const resolvedDeviceToken = !(explicitGatewayToken || authPassword)
       ? (storedToken ?? undefined)
       : undefined;
+    if (explicitBootstrapToken) {
+      return {
+        authBootstrapToken: explicitBootstrapToken,
+        authPassword,
+        storedToken: storedToken ?? undefined,
+        storedScopes: storedEntry?.scopes ?? undefined,
+        canFallbackToShared: false,
+      };
+    }
     const authToken = explicitGatewayToken ?? resolvedDeviceToken;
     return {
       authToken,

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -255,7 +255,11 @@ export function bootstrapApplication(): ApplicationRuntime {
   }
 
   const settings = startup.settings;
-  const gateway = createApplicationGateway(settings, startup.password ?? "");
+  const gateway = createApplicationGateway(
+    settings,
+    startup.password ?? "",
+    startup.pendingBootstrapToken ?? "",
+  );
   const agents = createAgentCapability(gateway);
   const agentIdentity = createAgentIdentityCapability(gateway);
   const agentSelection = createAgentSelectionCapability(gateway);
@@ -284,6 +288,7 @@ export function bootstrapApplication(): ApplicationRuntime {
       ? {
           gatewayUrl: startup.pendingGatewayUrl,
           token: startup.pendingGatewayToken ?? "",
+          bootstrapToken: startup.pendingBootstrapToken ?? "",
         }
       : null;
   let lastConfigRefreshClient: GatewayBrowserClient | null = null;
@@ -324,6 +329,7 @@ export function bootstrapApplication(): ApplicationRuntime {
     gateway.connect({
       gatewayUrl: pending.gatewayUrl,
       token: pending.token,
+      bootstrapToken: pending.bootstrapToken,
     });
   };
   const cancelPendingGatewayConnection = () => {

--- a/ui/src/app/gateway-store.test.ts
+++ b/ui/src/app/gateway-store.test.ts
@@ -36,7 +36,7 @@ class FakeGatewayClient {
 
 function createStore() {
   const clients: FakeGatewayClient[] = [];
-  const gateway = createApplicationGateway(loadSettings(), "", (opts) => {
+  const gateway = createApplicationGateway(loadSettings(), "", "", (opts) => {
     const client = new FakeGatewayClient(opts);
     clients.push(client);
     return client as unknown as GatewayBrowserClient;

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -24,12 +24,14 @@ const defaultClientFactory: GatewayClientFactory = (opts) => new GatewayBrowserC
 export function createApplicationGateway(
   initialSettings: ReturnType<typeof loadSettings>,
   initialPassword = "",
+  initialBootstrapToken = "",
   createClient: GatewayClientFactory = defaultClientFactory,
 ): ApplicationGateway {
   let settings = initialSettings;
   let connection: ApplicationGatewayConnection = {
     gatewayUrl: settings.gatewayUrl,
     token: settings.token,
+    bootstrapToken: initialBootstrapToken,
     password: initialPassword,
   };
   let snapshot: ApplicationGatewaySnapshot = {
@@ -112,6 +114,9 @@ export function createApplicationGateway(
     const nextClient = createClient({
       url: nextConnection.gatewayUrl,
       token: nextConnection.token.trim() ? nextConnection.token : undefined,
+      bootstrapToken: nextConnection.bootstrapToken.trim()
+        ? nextConnection.bootstrapToken
+        : undefined,
       password: nextConnection.password.trim() ? nextConnection.password : undefined,
       clientName: "openclaw-control-ui",
       clientVersion: "dev",
@@ -121,6 +126,7 @@ export function createApplicationGateway(
         if (client !== nextClient) {
           return;
         }
+        connection = { ...connection, bootstrapToken: "" };
         settings = loadSettings();
         const sessionDefaults = readSessionDefaults(hello);
         const sessionKey = resolveSessionKey(snapshot.sessionKey, hello);

--- a/ui/src/app/gateway.ts
+++ b/ui/src/app/gateway.ts
@@ -20,6 +20,7 @@ export type ApplicationGatewaySnapshot = {
 export type ApplicationGatewayConnection = {
   gatewayUrl: string;
   token: string;
+  bootstrapToken: string;
   password: string;
 };
 

--- a/ui/src/app/overlays.test.ts
+++ b/ui/src/app/overlays.test.ts
@@ -46,7 +46,7 @@ function createGatewayHarness(
     get snapshot() {
       return snapshot;
     },
-    connection: { gatewayUrl: "ws://gateway.test", password: "", token: "" },
+    connection: { gatewayUrl: "ws://gateway.test", password: "", token: "", bootstrapToken: "" },
     eventLog: [],
     connect() {},
     setSessionKey() {},

--- a/ui/src/app/settings.node.test.ts
+++ b/ui/src/app/settings.node.test.ts
@@ -6,6 +6,7 @@ import {
   loadGatewaySessionSelection,
   loadLocalUserIdentity,
   loadSettings,
+  resolveApplicationStartupSettings,
   saveSettings,
   type UiSettings,
 } from "./settings.ts";
@@ -64,6 +65,43 @@ function makeSettings(gatewayUrl: string, overrides: Partial<UiSettings> = {}): 
     ...overrides,
   };
 }
+
+describe("resolveApplicationStartupSettings", () => {
+  beforeEach(() => {
+    vi.stubGlobal("window", {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("strips fragment bootstrap tokens without persisting them", () => {
+    const startup = resolveApplicationStartupSettings(makeSettings("wss://gateway.example"), {
+      pathname: "/",
+      search: "",
+      hash: "#gatewayUrl=wss%3A%2F%2Fgateway.example&bootstrapToken=boot-123&session=main",
+    });
+
+    expect(startup.pendingGatewayUrl).toBeNull();
+    expect(startup.pendingGatewayToken).toBeNull();
+    expect(startup.pendingBootstrapToken).toBe("boot-123");
+    expect(startup.settings.token).toBe("");
+    expect(startup.location).toEqual({ pathname: "/", search: "", hash: "#session=main" });
+  });
+
+  it("carries fragment bootstrap tokens with changed gateway URLs", () => {
+    const startup = resolveApplicationStartupSettings(makeSettings("wss://gateway-a.example"), {
+      pathname: "/dash",
+      search: "",
+      hash: "#gatewayUrl=wss%3A%2F%2Fgateway-b.example&bootstrapToken=boot-456",
+    });
+
+    expect(startup.pendingGatewayUrl).toBe("wss://gateway-b.example");
+    expect(startup.pendingGatewayToken).toBeNull();
+    expect(startup.pendingBootstrapToken).toBe("boot-456");
+    expect(startup.location).toEqual({ pathname: "/dash", search: "", hash: "" });
+  });
+});
 
 describe("loadSettings default gateway URL derivation", () => {
   beforeEach(() => {

--- a/ui/src/app/settings.ts
+++ b/ui/src/app/settings.ts
@@ -137,6 +137,7 @@ type ApplicationStartupSettings = {
   password: string | null;
   pendingGatewayUrl: string | null;
   pendingGatewayToken: string | null;
+  pendingBootstrapToken: string | null;
   queryTokenUsed: boolean;
   location: ApplicationStartupLocation;
   changed: boolean;
@@ -157,6 +158,7 @@ export function resolveApplicationStartupSettings(
   let password: string | null = null;
   let pendingGatewayUrl: string | null = null;
   let pendingGatewayToken: string | null = null;
+  let pendingBootstrapToken: string | null = null;
   let queryTokenUsed = false;
 
   const updateSettings = (patch: Partial<UiSettings>) => {
@@ -197,6 +199,7 @@ export function resolveApplicationStartupSettings(
       password,
       pendingGatewayUrl,
       pendingGatewayToken,
+      pendingBootstrapToken,
       queryTokenUsed,
       location,
       changed,
@@ -216,6 +219,8 @@ export function resolveApplicationStartupSettings(
   const hashToken = hashParams.get("token");
   const hasTokenParam = hashToken != null || queryToken != null;
   const token = normalizeOptionalString(hashToken ?? queryToken);
+  const hasBootstrapTokenParam = hashParams.has("bootstrapToken");
+  const bootstrapToken = normalizeOptionalString(hashParams.get("bootstrapToken"));
   const session = normalizeOptionalString(params.get("session") ?? hashParams.get("session"));
   const shouldResetSessionForToken = Boolean(token && !session && !gatewayUrlChanged);
   let shouldCleanUrl = false;
@@ -238,6 +243,12 @@ export function resolveApplicationStartupSettings(
       updateSettings({ token });
     }
     hashParams.delete("token");
+    shouldCleanUrl = true;
+  }
+
+  if (hasBootstrapTokenParam) {
+    pendingBootstrapToken = bootstrapToken ?? null;
+    hashParams.delete("bootstrapToken");
     shouldCleanUrl = true;
   }
 
@@ -265,6 +276,8 @@ export function resolveApplicationStartupSettings(
     pendingGatewayUrl = gatewayUrlChanged ? nextGatewayUrl : null;
     if (!gatewayUrlChanged) {
       pendingGatewayToken = null;
+    } else if (pendingBootstrapToken) {
+      pendingGatewayToken = null;
     }
     params.delete("gatewayUrl");
     hashParams.delete("gatewayUrl");
@@ -282,6 +295,7 @@ export function resolveApplicationStartupSettings(
     password,
     pendingGatewayUrl,
     pendingGatewayToken,
+    pendingBootstrapToken,
     queryTokenUsed,
     location: shouldCleanUrl
       ? {

--- a/ui/src/components/command-palette.test.ts
+++ b/ui/src/components/command-palette.test.ts
@@ -53,7 +53,7 @@ function createGateway(connected: boolean): GatewayHarness {
     get snapshot() {
       return snapshot;
     },
-    connection: { gatewayUrl: "ws://localhost", token: "", password: "" },
+    connection: { gatewayUrl: "ws://localhost", token: "", bootstrapToken: "", password: "" },
     eventLog: [],
     connect: () => undefined,
     setSessionKey: () => undefined,

--- a/ui/src/pages/skill-workshop/proposals.test.ts
+++ b/ui/src/pages/skill-workshop/proposals.test.ts
@@ -47,7 +47,7 @@ function createFixture(
       get snapshot() {
         return snapshot;
       },
-      connection: { gatewayUrl: "", token: "", password: "" },
+      connection: { gatewayUrl: "", token: "", bootstrapToken: "", password: "" },
       eventLog: [],
       connect: vi.fn(),
       setSessionKey: vi.fn(),


### PR DESCRIPTION
## What Problem This Solves

OpenClaw ships a web dashboard (Control UI), but Telegram users have no way to open it from chat. Telegram Mini Apps require an HTTPS URL, and nothing today provisions one or authenticates the webview session — the `webApp` presentation button shipped in v2026.6.11 renders fine but is unusable end to end without manual tunnel + pairing gymnastics. Asking users to expose their gateway to the public internet is not an acceptable default.

Closes #102632. Supersedes the approach in #74176 (closed).

## Why This Change Was Made

Telegram's HTTPS requirement is a client-side URL-scheme rule: the webview on the user's device loads the URL; Telegram's servers never fetch it. That means the gateway's existing Tailscale exposure (`gateway.tailscale.mode: "serve"`) already provides a valid HTTPS URL (`https://<host>.ts.net`, Let's Encrypt cert) that is reachable **only inside the user's tailnet** — a Mini App dashboard with zero public exposure. `funnel` remains the opt-in public fallback. No new tunnel infrastructure and **zero new config keys**.

Flow: owner sends `/dashboard` in a DM → owner-gated command replies with a `web_app` button → Telegram opens a tiny plugin-served bootstrap page → the page POSTs `Telegram.WebApp.initData` to a Telegram-plugin route → the plugin validates the initData HMAC (bot-token-derived key, 300 s freshness, replay cache, rate limit) and checks the numeric user id against the owner allowlist → mints a short-lived, single-use, purpose-tagged (`control-ui`) operator device-bootstrap token bounded to the existing handoff scopes → the page redirects into the Control UI with `#bootstrapToken=` → the gateway silently approves the browser device pairing **only** for `control-ui`-purpose operator bootstrap tokens (mirroring the existing QR/setup-code mobile seam) → authenticated dashboard session; subsequent opens reuse the stored device token.

Boundary notes:
- All Telegram-specific logic (initData validation, owner mapping, bot token) lives in `extensions/telegram`. Core gains only a generic, purpose-gated widening of the existing bootstrap silent-approval seam plus two deliberate plugin-SDK exports (`BOOTSTRAP_HANDOFF_OPERATOR_SCOPES`, `resolveTailscalePublishedHost`).
- The Mini App session is bounded to `BOOTSTRAP_HANDOFF_OPERATOR_SCOPES` (`operator.approvals/read/talk.secrets/write`) — no `operator.admin`/`operator.pairing`. Tokens without `purpose: "control-ui"` keep today's explicit-pairing behavior, so arbitrary plugins minting plain bootstrap tokens cannot silently pair a browser.
- Owner check is deliberately stricter than chat-level `senderIsOwner`: numeric Telegram user ids only; wildcard `*` allowlists never grant dashboard access.
- Fail-loud UX: `tailscale.mode: off` → actionable error in chat; non-owner → 403; stale initData → 401; group chat → "open this in a DM" (Telegram only allows `web_app` buttons in private chats).

## User Impact

Telegram owners can open their OpenClaw dashboard inside Telegram with one tap, authenticated, with no manual pairing and no public internet exposure when using `gateway.tailscale.mode: "serve"` (phone on the tailnet). `funnel` works for phones without Tailscale. Non-goals (documented): Telegram Web (the Control UI keeps `X-Frame-Options: DENY`), non-Tailscale tunnels.

## Evidence

- Unit/integration coverage: initData HMAC fixtures (accept/tampered/stale/missing-user), owner resolution incl. wildcard rejection, mode-aware URL resolution with mocked Tailscale runner, auth-route mint gating (replay, rate limit, non-owner 403, body/content-type caps), `/dashboard` DM/owner gating, gateway control-ui auth suite additions (silent approve happy path; node-only profile and missing purpose still require pairing; reused token rejected), UI `#bootstrapToken` parse/strip/connect tests.
- Testbox (Blacksmith through Crabbox, lease `tbx_01kx3cf3dv2gprdane7qjj0f17`): `pnpm check:changed` fully green; `pnpm test:changed` had 3 failing shards, all proven unrelated to this branch: `src/plugins/bundled-plugin-metadata.test.ts` fails on pristine `origin/main` (#102586 set `codex-supervisor` `activation.onStartup: true` two hours before this run without updating `EXPECTED_BUNDLED_STARTUP_PLUGIN_IDS` — reproducible via `git show origin/main:extensions/codex-supervisor/openclaw.plugin.json`), and `src/gateway/session-utils.search.test.ts` / `src/agents/model-fallback.probe.test.ts` pass locally on this branch and touch surfaces this PR does not modify. Not fixing unrelated main breakage here per repo policy.
- `pnpm tsgo`, `pnpm check:test-types`, `pnpm build`, `pnpm plugin-sdk:api:check` all exit 0 locally; repo autoreview script clean.
- Live phone proof (maintainer, done): deployed this branch (`634995d5ebb`) to a production Docker install (homelab, host tailscaled, `gateway.tailscale.mode: "serve"`). `/dashboard` DM → `web_app` button → Mini App opened the authenticated dashboard on a real phone over the tailnet. Server path independently proven with a bot-token-signed `initData` POST: 200 + purpose-tagged bootstrap token + correct `https://`/`wss://` published URLs. Finding folded into docs (`2922ae1d081`): Docker bridge networking cannot satisfy the serve-mode loopback-bind guard; containerized gateways need `network_mode: host` + the host tailscaled socket and CLI mounted. `funnel` not exercised live; it shares the same URL-resolution and handoff path.

