### PR TITLE
fix(slack): remember event-carried channel types so mpDMs key one session (#102676)

### DIFF
--- a/extensions/slack/src/monitor/context.test.ts
+++ b/extensions/slack/src/monitor/context.test.ts
@@ -2,13 +2,15 @@
 import type { App } from "@slack/bolt";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createSlackMonitorContext } from "./context.js";
+import type { SlackEventScope } from "./event-scope.js";
 
 function createTestContext(params?: {
   dmScope?: "main" | "per-peer" | "per-channel-peer" | "per-account-channel-peer";
   groupDmEnabled?: boolean;
   groupDmChannels?: string[];
+  appClient?: App["client"];
 }) {
   return createSlackMonitorContext({
     cfg: {
@@ -17,7 +19,7 @@ function createTestContext(params?: {
     } as OpenClawConfig,
     accountId: "default",
     botToken: "xoxb-test",
-    app: { client: {} } as App,
+    app: { client: params?.appClient ?? {} } as App,
     runtime: {} as RuntimeEnv,
     botUserId: "U_BOT",
     botId: "B_BOT",
@@ -124,5 +126,78 @@ describe("createSlackMonitorContext resolveSlackSystemEventSessionKey", () => {
         senderId: "U_SHORTCUT",
       }),
     ).toBe("agent:main:slack:direct:u_shortcut");
+  });
+
+  it("routes typeless system events through an event-carried mpDM type", () => {
+    const ctx = createTestContext();
+    ctx.rememberSlackChannelType("C0MPDM42", "mpim");
+
+    expect(
+      ctx.resolveSlackSystemEventSessionKey({
+        channelId: "C0MPDM42",
+        senderId: "U_ACTOR",
+      }),
+    ).toBe("agent:main:slack:group:c0mpdm42");
+  });
+});
+
+describe("createSlackMonitorContext channel metadata cache", () => {
+  it("fills metadata after an event stored only the authoritative type", async () => {
+    const info = vi.fn().mockResolvedValue({
+      channel: {
+        id: "C0MPDM42",
+        name: "team-chat",
+        topic: { value: "planning" },
+      },
+    });
+    const ctx = createTestContext({
+      appClient: { conversations: { info } } as unknown as App["client"],
+    });
+    ctx.rememberSlackChannelType("C0MPDM42", "mpim");
+
+    await expect(ctx.resolveChannelName("C0MPDM42")).resolves.toEqual({
+      name: "team-chat",
+      type: "mpim",
+      topic: "planning",
+      purpose: undefined,
+    });
+    await ctx.resolveChannelName("C0MPDM42");
+    expect(info).toHaveBeenCalledOnce();
+  });
+
+  it("isolates remembered types by enterprise team scope", async () => {
+    const createScope = (teamId: string): SlackEventScope =>
+      ({
+        apiAppId: "A_EXPECTED",
+        enterpriseId: "E_EXPECTED",
+        teamId,
+        isEnterpriseInstall: true,
+        client: {
+          conversations: { info: vi.fn().mockRejectedValue(new Error("missing_scope")) },
+        },
+      }) as unknown as SlackEventScope;
+    const ctx = createTestContext();
+    const firstTeam = createScope("T_FIRST");
+    const secondTeam = createScope("T_SECOND");
+    ctx.rememberSlackChannelType("C0SHARED", "mpim", firstTeam);
+
+    await expect(ctx.resolveChannelName("C0SHARED", firstTeam)).resolves.toMatchObject({
+      type: "mpim",
+    });
+    await expect(ctx.resolveChannelName("C0SHARED", secondTeam)).resolves.toEqual({});
+    await expect(ctx.resolveChannelName("C0SHARED")).resolves.toEqual({});
+  });
+
+  it("evicts the oldest authoritative type when the bounded cache fills", async () => {
+    const info = vi.fn().mockRejectedValue(new Error("missing_scope"));
+    const ctx = createTestContext({
+      appClient: { conversations: { info } } as unknown as App["client"],
+    });
+    ctx.rememberSlackChannelType("C0OLDEST", "mpim");
+    for (let index = 0; index < 1024; index += 1) {
+      ctx.rememberSlackChannelType(`C${index}`, "channel");
+    }
+
+    await expect(ctx.resolveChannelName("C0OLDEST")).resolves.toEqual({});
   });
 });

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -170,14 +170,16 @@ export type SlackMonitorContext = {
     topic?: string;
     purpose?: string;
   }>;
-  /** Records an explicit channel_type seen on an event, keyed by channel id (#102676). */
+  /** Records an explicit channel_type seen on an event, keyed like channelCache (#102676). */
   rememberSlackChannelType: (
     channelId: string | null | undefined,
     channelType: string | null | undefined,
+    eventScope?: SlackEventScope,
   ) => void;
-  /** Returns a previously seen explicit channel_type for the channel, if any. */
+  /** Returns a previously seen explicit channel_type for the channel/scope, if any. */
   recallSlackChannelType: (
     channelId: string | null | undefined,
+    eventScope?: SlackEventScope,
   ) => SlackMessageEvent["channel_type"] | undefined;
   resolveUserName: (userId: string, eventScope?: SlackEventScope) => Promise<{ name?: string }>;
   setSlackThreadStatus: (params: {
@@ -273,6 +275,7 @@ export function createSlackMonitorContext(params: {
   const rememberSlackChannelType = (
     channelId: string | null | undefined,
     channelType: string | null | undefined,
+    eventScope?: SlackEventScope,
   ) => {
     const id = normalizeOptionalString(channelId);
     if (!id) {
@@ -284,15 +287,18 @@ export function createSlackMonitorContext(params: {
       channelType === "channel" ||
       channelType === "group"
     ) {
-      knownChannelTypes.set(id, channelType);
+      // Same account/team scoping as channelCache: multi-workspace installs must not
+      // cross-contaminate remembered types between scopes that share a channel id.
+      knownChannelTypes.set(scopedKey(id, eventScope), channelType);
     }
   };
 
   const recallSlackChannelType = (
     channelId: string | null | undefined,
+    eventScope?: SlackEventScope,
   ): SlackMessageEvent["channel_type"] | undefined => {
     const id = normalizeOptionalString(channelId);
-    return id ? knownChannelTypes.get(id) : undefined;
+    return id ? knownChannelTypes.get(scopedKey(id, eventScope)) : undefined;
   };
   const seenMessages = createDedupeCache({ ttlMs: 60_000, maxSize: 500 });
   const assistantThreadContexts = new Map<string, SlackAssistantThreadContext>();

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -3,6 +3,7 @@ import type { App } from "@slack/bolt";
 import { resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 import { formatAllowlistMatchMeta } from "openclaw/plugin-sdk/allow-from";
 import type { ChannelRuntimeSurface } from "openclaw/plugin-sdk/channel-contract";
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import type {
   OpenClawConfig,
   SlackReactionNotificationMode,
@@ -49,7 +50,20 @@ export type SlackAssistantThreadContext = {
   updatedAt: number;
 };
 
+type SlackChannelInfo = {
+  name?: string;
+  type?: SlackMessageEvent["channel_type"];
+  topic?: string;
+  purpose?: string;
+};
+
+type SlackChannelCacheEntry = {
+  info: SlackChannelInfo;
+  metadataLoaded: boolean;
+};
+
 const SLACK_ASSISTANT_THREAD_CONTEXT_METADATA_EVENT = "assistant_thread_context";
+const SLACK_CHANNEL_CACHE_MAX_ENTRIES = 1024;
 
 export function buildSlackAssistantThreadMetadata(
   context: Omit<SlackAssistantThreadContext, "updatedAt">,
@@ -164,19 +178,14 @@ export type SlackMonitorContext = {
   resolveChannelName: (
     channelId: string,
     eventScope?: SlackEventScope,
-  ) => Promise<{
-    name?: string;
-    type?: SlackMessageEvent["channel_type"];
-    topic?: string;
-    purpose?: string;
-  }>;
-  /** Records an explicit channel_type seen on an event, keyed like channelCache (#102676). */
+  ) => Promise<SlackChannelInfo>;
+  /** Records authoritative event-carried channel type in the channel metadata cache. */
   rememberSlackChannelType: (
     channelId: string | null | undefined,
     channelType: string | null | undefined,
     eventScope?: SlackEventScope,
   ) => void;
-  /** Returns a previously seen explicit channel_type for the channel/scope, if any. */
+  /** Reads event-carried channel type when Slack omits it from later bot/edit/delete events. */
   recallSlackChannelType: (
     channelId: string | null | undefined,
     eventScope?: SlackEventScope,
@@ -254,52 +263,8 @@ export function createSlackMonitorContext(params: {
   const channelHistories = new Map<string, HistoryEntry[]>();
   const logger = getChildLogger({ module: "slack-auto-reply" });
 
-  const channelCache = new Map<
-    string,
-    {
-      name?: string;
-      type?: SlackMessageEvent["channel_type"];
-      topic?: string;
-      purpose?: string;
-    }
-  >();
+  const channelCache = new Map<string, SlackChannelCacheEntry>();
   const userCache = new Map<string, { name?: string }>();
-  // Explicit channel_type values already seen on events for a channel. Human-authored
-  // mpDM messages carry channel_type: "mpim", but bot-authored ingress shapes omit it;
-  // when the conversations.info fill also cannot resolve the type, C-prefix inference
-  // would fall back to "channel" and key a second, parallel session for the same room
-  // (#102676). Remembering event-carried types keeps every ingress path on one
-  // classification without any extra network lookups.
-  const knownChannelTypes = new Map<string, SlackMessageEvent["channel_type"]>();
-
-  const rememberSlackChannelType = (
-    channelId: string | null | undefined,
-    channelType: string | null | undefined,
-    eventScope?: SlackEventScope,
-  ) => {
-    const id = normalizeOptionalString(channelId);
-    if (!id) {
-      return;
-    }
-    if (
-      channelType === "im" ||
-      channelType === "mpim" ||
-      channelType === "channel" ||
-      channelType === "group"
-    ) {
-      // Same account/team scoping as channelCache: multi-workspace installs must not
-      // cross-contaminate remembered types between scopes that share a channel id.
-      knownChannelTypes.set(scopedKey(id, eventScope), channelType);
-    }
-  };
-
-  const recallSlackChannelType = (
-    channelId: string | null | undefined,
-    eventScope?: SlackEventScope,
-  ): SlackMessageEvent["channel_type"] | undefined => {
-    const id = normalizeOptionalString(channelId);
-    return id ? knownChannelTypes.get(scopedKey(id, eventScope)) : undefined;
-  };
   const seenMessages = createDedupeCache({ ttlMs: 60_000, maxSize: 500 });
   const assistantThreadContexts = new Map<string, SlackAssistantThreadContext>();
   let lastAssistantContextCleanupAt = Date.now();
@@ -315,6 +280,59 @@ export function createSlackMonitorContext(params: {
 
   const scopedKey = (key: string, eventScope?: SlackEventScope) =>
     eventScope ? `${params.accountId}:${eventScope.teamId}:${key}` : key;
+
+  const readCachedChannel = (cacheKey: string): SlackChannelCacheEntry | undefined => {
+    const cached = channelCache.get(cacheKey);
+    if (cached) {
+      // Active rooms stay resident while the bounded cache evicts the oldest entry.
+      channelCache.delete(cacheKey);
+      channelCache.set(cacheKey, cached);
+    }
+    return cached;
+  };
+
+  const writeCachedChannel = (cacheKey: string, entry: SlackChannelCacheEntry): void => {
+    channelCache.delete(cacheKey);
+    channelCache.set(cacheKey, entry);
+    pruneMapToMaxSize(channelCache, SLACK_CHANNEL_CACHE_MAX_ENTRIES);
+  };
+
+  const rememberSlackChannelType = (
+    channelId: string | null | undefined,
+    channelType: string | null | undefined,
+    eventScope?: SlackEventScope,
+  ) => {
+    const id = normalizeOptionalString(channelId);
+    const normalizedType = normalizeOptionalString(channelType)?.toLowerCase();
+    if (
+      !id ||
+      (normalizedType !== "im" &&
+        normalizedType !== "mpim" &&
+        normalizedType !== "channel" &&
+        normalizedType !== "group")
+    ) {
+      return;
+    }
+    const cacheKey = scopedKey(id, eventScope);
+    const cached = readCachedChannel(cacheKey);
+    const type = normalizeSlackChannelType(normalizedType, id);
+    if (cached?.info.type === type) {
+      return;
+    }
+    // Type-only entries must not suppress a later conversations.info metadata fill.
+    writeCachedChannel(cacheKey, {
+      info: { ...cached?.info, type },
+      metadataLoaded: cached?.metadataLoaded ?? false,
+    });
+  };
+
+  const recallSlackChannelType = (
+    channelId: string | null | undefined,
+    eventScope?: SlackEventScope,
+  ): SlackMessageEvent["channel_type"] | undefined => {
+    const id = normalizeOptionalString(channelId);
+    return id ? readCachedChannel(scopedKey(id, eventScope))?.info.type : undefined;
+  };
 
   const markMessageSeen = (
     channelId: string | undefined,
@@ -483,9 +501,9 @@ export function createSlackMonitorContext(params: {
 
   const resolveChannelName = async (channelId: string, eventScope?: SlackEventScope) => {
     const cacheKey = scopedKey(channelId, eventScope);
-    const cached = channelCache.get(cacheKey);
-    if (cached) {
-      return cached;
+    const cached = readCachedChannel(cacheKey);
+    if (cached?.metadataLoaded) {
+      return cached.info;
     }
     try {
       const info = await (eventScope?.client ?? params.app.client).conversations.info({
@@ -506,11 +524,16 @@ export function createSlackMonitorContext(params: {
       const topic = channel && "topic" in channel ? (channel.topic?.value ?? undefined) : undefined;
       const purpose =
         channel && "purpose" in channel ? (channel.purpose?.value ?? undefined) : undefined;
-      const entry = { name, type, topic, purpose };
-      channelCache.set(cacheKey, entry);
-      return entry;
+      const entry: SlackChannelCacheEntry = {
+        // An event-carried type is authoritative and may be the only mpDM signal
+        // available to later bot, edit, and delete events with restricted scopes.
+        info: { name, type: cached?.info.type ?? type, topic, purpose },
+        metadataLoaded: true,
+      };
+      writeCachedChannel(cacheKey, entry);
+      return entry.info;
     } catch {
-      return {};
+      return cached?.info ?? {};
     }
   };
 

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -170,6 +170,15 @@ export type SlackMonitorContext = {
     topic?: string;
     purpose?: string;
   }>;
+  /** Records an explicit channel_type seen on an event, keyed by channel id (#102676). */
+  rememberSlackChannelType: (
+    channelId: string | null | undefined,
+    channelType: string | null | undefined,
+  ) => void;
+  /** Returns a previously seen explicit channel_type for the channel, if any. */
+  recallSlackChannelType: (
+    channelId: string | null | undefined,
+  ) => SlackMessageEvent["channel_type"] | undefined;
   resolveUserName: (userId: string, eventScope?: SlackEventScope) => Promise<{ name?: string }>;
   setSlackThreadStatus: (params: {
     channelId: string;
@@ -253,6 +262,38 @@ export function createSlackMonitorContext(params: {
     }
   >();
   const userCache = new Map<string, { name?: string }>();
+  // Explicit channel_type values already seen on events for a channel. Human-authored
+  // mpDM messages carry channel_type: "mpim", but bot-authored ingress shapes omit it;
+  // when the conversations.info fill also cannot resolve the type, C-prefix inference
+  // would fall back to "channel" and key a second, parallel session for the same room
+  // (#102676). Remembering event-carried types keeps every ingress path on one
+  // classification without any extra network lookups.
+  const knownChannelTypes = new Map<string, SlackMessageEvent["channel_type"]>();
+
+  const rememberSlackChannelType = (
+    channelId: string | null | undefined,
+    channelType: string | null | undefined,
+  ) => {
+    const id = normalizeOptionalString(channelId);
+    if (!id) {
+      return;
+    }
+    if (
+      channelType === "im" ||
+      channelType === "mpim" ||
+      channelType === "channel" ||
+      channelType === "group"
+    ) {
+      knownChannelTypes.set(id, channelType);
+    }
+  };
+
+  const recallSlackChannelType = (
+    channelId: string | null | undefined,
+  ): SlackMessageEvent["channel_type"] | undefined => {
+    const id = normalizeOptionalString(channelId);
+    return id ? knownChannelTypes.get(id) : undefined;
+  };
   const seenMessages = createDedupeCache({ ttlMs: 60_000, maxSize: 500 });
   const assistantThreadContexts = new Map<string, SlackAssistantThreadContext>();
   let lastAssistantContextCleanupAt = Date.now();
@@ -350,7 +391,12 @@ export function createSlackMonitorContext(params: {
   }) => {
     const channelId = normalizeOptionalString(p.channelId) ?? "";
     const senderId = normalizeOptionalString(p.senderId) ?? "";
-    const channelType = normalizeSlackChannelType(p.channelType, channelId);
+    // System events can omit channel_type too; prefer a type already seen on events
+    // for this channel over C-prefix inference so they key the same session (#102676).
+    const channelType = normalizeSlackChannelType(
+      p.channelType ?? recallSlackChannelType(channelId),
+      channelId,
+    );
     const isDirectMessage = channelType === "im";
     if (!channelId && (!isDirectMessage || !senderId)) {
       return params.mainKey;
@@ -691,6 +737,8 @@ export function createSlackMonitorContext(params: {
     resolveSlackSystemEventSessionKey,
     isChannelAllowed,
     resolveChannelName,
+    rememberSlackChannelType,
+    recallSlackChannelType,
     resolveUserName,
     setSlackThreadStatus,
     getSlackAssistantThreadContext,

--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -1,5 +1,7 @@
 // Slack tests cover messages plugin behavior.
+import type { App } from "@slack/bolt";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createInboundSlackTestContext } from "../message-handler/prepare.test-helpers.js";
 import {
   createSlackSystemEventTestHarness,
   type SlackSystemEventTestOverrides,
@@ -37,9 +39,13 @@ vi.mock("openclaw/plugin-sdk/system-event-runtime", () => ({
 vi.mock("openclaw/plugin-sdk/system-event-runtime.js", () => ({
   enqueueSystemEvent: (...args: unknown[]) => messageQueueMock(...args),
 }));
-vi.mock("openclaw/plugin-sdk/conversation-runtime", () => ({
-  readChannelAllowFromStore: (...args: unknown[]) => messageAllowMock(...args),
-}));
+vi.mock("openclaw/plugin-sdk/conversation-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/conversation-runtime")>();
+  return {
+    ...actual,
+    readChannelAllowFromStore: (...args: unknown[]) => messageAllowMock(...args),
+  };
+});
 vi.mock("openclaw/plugin-sdk/text-chunking", () => ({
   chunkItems: <T>(items: T[]) => [items],
   markdownToIR: (text: string) => text,
@@ -588,6 +594,74 @@ describe("registerSlackMessageEvents", () => {
 
     expect(handleSlackMessage).not.toHaveBeenCalled();
     expect(messageQueueMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps bot edit and delete events on a remembered C-prefix mpDM session", async () => {
+    const handlers: Record<string, MessageHandler> = {};
+    const conversationsInfo = vi.fn().mockRejectedValue(new Error("missing_scope"));
+    const app = {
+      client: {
+        conversations: { info: conversationsInfo },
+        users: {
+          info: vi.fn().mockResolvedValue({ user: { name: "other-agent" } }),
+        },
+      },
+      event: (name: string, handler: MessageHandler) => {
+        handlers[name] = handler;
+      },
+    } as unknown as App;
+    const ctx = createInboundSlackTestContext({
+      app,
+      cfg: { channels: { slack: { enabled: true } } },
+      defaultRequireMention: false,
+    });
+    const handleSlackMessage = vi.fn(async () => {});
+    registerSlackMessageEvents({ ctx, handleSlackMessage });
+    const handler = requireMessageHandler(handlers.message ?? null);
+
+    await handler({
+      event: {
+        type: "message",
+        channel: "C0MPDM42",
+        channel_type: "mpim",
+        user: "U_HUMAN",
+        text: "human seed",
+        ts: "1.000",
+      },
+      body: {},
+    });
+    await handler({
+      event: {
+        type: "message",
+        subtype: "message_changed",
+        channel: "C0MPDM42",
+        message: { ts: "2.000", bot_id: "B_OTHER" },
+        previous_message: { ts: "1.000", bot_id: "B_OTHER" },
+        event_ts: "2.100",
+      },
+      body: {},
+    });
+    await handler({
+      event: {
+        type: "message",
+        subtype: "message_deleted",
+        channel: "C0MPDM42",
+        deleted_ts: "2.000",
+        previous_message: { ts: "2.000", bot_id: "B_OTHER" },
+        event_ts: "3.000",
+      },
+      body: {},
+    });
+
+    const sessionKeys = messageQueueMock.mock.calls.map(
+      (call) => (call[1] as { sessionKey?: string }).sessionKey,
+    );
+    expect(sessionKeys).toEqual([
+      "agent:main:slack:group:c0mpdm42",
+      "agent:main:slack:group:c0mpdm42",
+    ]);
+    expect(handleSlackMessage).toHaveBeenCalledOnce();
+    expect(conversationsInfo).toHaveBeenCalledTimes(2);
   });
 
   it("skips app_mention events for DM channel ids even with contradictory channel_type", async () => {

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -205,6 +205,9 @@ export function registerSlackMessageEvents(params: {
       }
 
       const message = event as SlackMessageEvent;
+      // Subtype handlers do not enter the regular message pipeline. Observe any explicit
+      // type here so edits and deletes share the same authoritative conversation cache.
+      ctx.rememberSlackChannelType(message.channel, message.channel_type, eventScope);
       if (eventScope && isBotAuthoredEnterpriseEvent(message)) {
         logVerbose("slack: drop enterprise bot-authored message");
         return;

--- a/extensions/slack/src/monitor/events/system-event-test-harness.ts
+++ b/extensions/slack/src/monitor/events/system-event-test-harness.ts
@@ -49,6 +49,7 @@ export function createSlackSystemEventTestHarness(overrides?: SlackSystemEventTe
     reactionAllowlist: overrides?.reactionAllowlist ?? [],
     shouldDropMismatchedSlackEvent: () => false,
     isChannelAllowed: () => true,
+    rememberSlackChannelType: () => {},
     resolveChannelName: async () => ({
       name: channelType === "im" ? "direct" : "general",
       type: channelType,

--- a/extensions/slack/src/monitor/message-handler.app-mention-race.test.ts
+++ b/extensions/slack/src/monitor/message-handler.app-mention-race.test.ts
@@ -113,8 +113,9 @@ function createTestHandler(
       app: { client: {} },
       runtime: {},
       markMessageSeen: seenMessages["markMessageSeen"],
+      rememberSlackChannelType: () => {},
       releaseSeenMessage: seenMessages["releaseSeenMessage"],
-    } as Parameters<typeof createSlackMessageHandler>[0]["ctx"],
+    } as unknown as Parameters<typeof createSlackMessageHandler>[0]["ctx"],
     account: { accountId: "default" } as Parameters<typeof createSlackMessageHandler>[0]["account"],
   });
 }

--- a/extensions/slack/src/monitor/message-handler.test.ts
+++ b/extensions/slack/src/monitor/message-handler.test.ts
@@ -53,6 +53,10 @@ vi.mock("./inbound-delivery-state.js", () => ({
 
 function createContext(overrides?: {
   markMessageSeen?: (channel: string | undefined, ts: string | undefined) => boolean;
+  rememberSlackChannelType?: (
+    channel: string | null | undefined,
+    channelType: string | null | undefined,
+  ) => void;
   releaseSeenMessage?: (channel: string | undefined, ts: string | undefined) => void;
 }) {
   return {
@@ -64,6 +68,10 @@ function createContext(overrides?: {
     runtime: {},
     markMessageSeen: (channel: string | undefined, ts: string | undefined) =>
       overrides?.markMessageSeen?.(channel, ts) ?? false,
+    rememberSlackChannelType: (
+      channel: string | null | undefined,
+      channelType: string | null | undefined,
+    ) => overrides?.rememberSlackChannelType?.(channel, channelType),
     releaseSeenMessage: (channel: string | undefined, ts: string | undefined) =>
       overrides?.releaseSeenMessage?.(channel, ts),
   } as Parameters<typeof createSlackMessageHandler>[0]["ctx"];
@@ -71,6 +79,10 @@ function createContext(overrides?: {
 
 function createHandlerWithTracker(overrides?: {
   markMessageSeen?: (channel: string | undefined, ts: string | undefined) => boolean;
+  rememberSlackChannelType?: (
+    channel: string | null | undefined,
+    channelType: string | null | undefined,
+  ) => void;
   releaseSeenMessage?: (channel: string | undefined, ts: string | undefined) => void;
 }) {
   const trackEvent = vi.fn();
@@ -151,6 +163,35 @@ describe("createSlackMessageHandler", () => {
     expect(trackEvent).toHaveBeenCalledTimes(1);
     expect(resolveThreadTsMock).toHaveBeenCalledTimes(1);
     expect(enqueueMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("records explicit channel type before the first delivery-state await", async () => {
+    let settleDeliveryLookup: ((delivered: boolean) => void) | undefined;
+    hasSlackInboundMessageDeliveryMock.mockImplementationOnce(
+      async () =>
+        await new Promise<boolean>((resolve) => {
+          settleDeliveryLookup = resolve;
+        }),
+    );
+    const rememberSlackChannelType = vi.fn();
+    const { handler } = createHandlerWithTracker({ rememberSlackChannelType });
+    const handled = handler(
+      {
+        type: "message",
+        channel: "C0MPDM42",
+        channel_type: "mpim",
+        user: "U_HUMAN",
+        ts: "123.456",
+        text: "human seed",
+      } as never,
+      { source: "message" },
+    );
+
+    expect(rememberSlackChannelType).toHaveBeenCalledWith("C0MPDM42", "mpim");
+    expect(enqueueMock).not.toHaveBeenCalled();
+    settleDeliveryLookup?.(false);
+    await handled;
+    expect(enqueueMock).toHaveBeenCalledOnce();
   });
 
   it("accepts thread_broadcast messages from the message stream", async () => {

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -403,6 +403,9 @@ export function createSlackMessageHandler(params: {
     ) {
       return undefined;
     }
+    // Record Slack's explicit type before delivery-state or thread-resolution awaits.
+    // Relay and native events can overlap; a following typeless bot event must see it.
+    ctx.rememberSlackChannelType(message.channel, message.channel_type, opts.eventScope);
     const seenMessageKey = buildSeenMessageKey(
       message.channel,
       message.ts,

--- a/extensions/slack/src/monitor/message-handler/prepare.test-helpers.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test-helpers.ts
@@ -12,6 +12,7 @@ import type { SlackChannelConfigEntries } from "../channel-config.js";
 import { createSlackMonitorContext } from "../context.js";
 
 export function createInboundSlackTestContext(params: {
+  app?: App;
   cfg: OpenClawConfig;
   appClient?: App["client"];
   defaultRequireMention?: boolean;
@@ -19,13 +20,14 @@ export function createInboundSlackTestContext(params: {
   channelsConfig?: SlackChannelConfigEntries;
   threadRequireExplicitMention?: boolean;
   dmHistoryLimit?: number;
+  groupDmEnabled?: boolean;
   channelRuntime?: ChannelRuntimeSurface;
 }) {
   return createSlackMonitorContext({
     cfg: params.cfg,
     accountId: "default",
     botToken: "token",
-    app: { client: params.appClient ?? {} } as App,
+    app: params.app ?? ({ client: params.appClient ?? {} } as App),
     runtime: {} as RuntimeEnv,
     channelRuntime: params.channelRuntime ?? createPluginRuntimeMock().channel,
     botUserId: "B1",
@@ -40,7 +42,7 @@ export function createInboundSlackTestContext(params: {
     dmPolicy: "open",
     allowFrom: ["*"],
     allowNameMatching: false,
-    groupDmEnabled: true,
+    groupDmEnabled: params.groupDmEnabled ?? true,
     groupDmChannels: [],
     defaultRequireMention: params.defaultRequireMention ?? true,
     channelsConfig: params.channelsConfig,

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -179,6 +179,32 @@ describe("slack prepareSlackMessage inbound contract", () => {
     return { slackCtx, members };
   }
 
+  function createMissingChannelInfoBotCtx(params?: { groupDmEnabled?: boolean; ownerId?: string }) {
+    const conversationsInfo = vi.fn().mockRejectedValue(new Error("missing_scope"));
+    const members = vi.fn().mockResolvedValue({
+      members: params?.ownerId ? [params.ownerId] : [],
+      response_metadata: { next_cursor: "" },
+    });
+    const ctx = createInboundSlackCtx({
+      cfg: {
+        channels: { slack: { enabled: true, allowBots: true, replyToMode: "all" } },
+      } as OpenClawConfig,
+      appClient: {
+        conversations: { info: conversationsInfo, members },
+      } as unknown as App["client"],
+      defaultRequireMention: false,
+      replyToMode: "all",
+      groupDmEnabled: params?.groupDmEnabled,
+    });
+    ctx.allowFrom = params?.ownerId ? [params.ownerId] : ctx.allowFrom;
+    ctx.resolveUserName = async () => ({ name: "Alice" });
+    return {
+      account: createSlackAccount({ allowBots: true, replyToMode: "all" }),
+      conversationsInfo,
+      ctx,
+    };
+  }
+
   async function prepareMessageWith(
     ctx: SlackMonitorContext,
     account: ResolvedSlackAccount,
@@ -1887,13 +1913,9 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
   });
 
   it("keeps one mpDM classification when a later event omits channel_type (#102676)", async () => {
-    // Modern mpDMs are C-prefixed. Human-authored messages carry channel_type: "mpim",
-    // but bot-authored ingress shapes omit it; simulate the channel-info fill failing
-    // (e.g. missing mpim:read scope) so the only remaining signal on main is C-prefix
-    // inference, which mis-keys a second slack:channel:<id> session for the same room.
-    const ctx = createReplyToAllSlackCtx();
-    ctx.resolveChannelName = async () => ({});
-    const account = createSlackAccount({ replyToMode: "all" });
+    const { account, conversationsInfo, ctx } = createMissingChannelInfoBotCtx();
+    // The real message ingress boundary records this before preparation starts.
+    ctx.rememberSlackChannelType("C0MPDM42", "mpim");
 
     const humanPrepared = await prepareMessageWith(
       ctx,
@@ -1915,14 +1937,74 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
       createSlackMessage({
         channel: "C0MPDM42",
         channel_type: undefined,
-        user: "U2",
-        text: "same room, ingress shape without channel_type",
+        user: undefined,
+        bot_id: "B_OTHER",
+        subtype: "bot_message",
+        username: "other-agent",
+        text: "same room, bot ingress without channel_type",
         ts: "2.000",
       }),
     );
     assertPrepared(typelessPrepared);
     expect(typelessPrepared.ctxPayload.ChatType).toBe("group");
     expect(typelessPrepared.ctxPayload.From).toBe("slack:group:C0MPDM42");
+    expect(typelessPrepared.ctxPayload.SessionKey).toBe(humanPrepared.ctxPayload.SessionKey);
+    expect(conversationsInfo).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a typeless cached mpDM behind the group-DM policy gate (#102676)", async () => {
+    const { account, ctx } = createMissingChannelInfoBotCtx({ groupDmEnabled: false });
+    ctx.rememberSlackChannelType("C0MPDM42", "mpim");
+
+    const prepared = await prepareMessageWith(
+      ctx,
+      account,
+      createSlackMessage({
+        channel: "C0MPDM42",
+        channel_type: undefined,
+        user: undefined,
+        bot_id: "B_OTHER",
+        subtype: "bot_message",
+        username: "other-agent",
+      }),
+    );
+
+    expect(prepared).toBeNull();
+  });
+
+  it("keeps unresolved G-prefix private-channel bot ingress on channel sessions (#102676)", async () => {
+    const { account, ctx } = createMissingChannelInfoBotCtx({ ownerId: "UOWNER" });
+
+    const humanPrepared = await prepareMessageWith(
+      ctx,
+      account,
+      createSlackMessage({
+        channel: "G0PRIVATE1",
+        channel_type: "group",
+        user: "U1",
+        text: "human in private channel",
+      }),
+    );
+    const botPrepared = await prepareMessageWith(
+      ctx,
+      account,
+      createSlackMessage({
+        channel: "G0PRIVATE1",
+        channel_type: undefined,
+        user: undefined,
+        bot_id: "B_OTHER",
+        subtype: "bot_message",
+        username: "other-agent",
+        text: "bot in same private channel",
+        ts: "2.000",
+      }),
+    );
+
+    assertPrepared(humanPrepared);
+    assertPrepared(botPrepared);
+    expect(humanPrepared.ctxPayload.From).toBe("slack:channel:G0PRIVATE1");
+    expect(botPrepared.ctxPayload.From).toBe(humanPrepared.ctxPayload.From);
+    expect(botPrepared.ctxPayload.ChatType).toBe("channel");
   });
 
   it.each([
@@ -4235,8 +4317,6 @@ describe("prepareSlackMessage sender prefix", () => {
       resolveSlackSystemEventSessionKey: () => "agent:main:slack:channel:c1",
       isChannelAllowed: () => true,
       resolveChannelName: async () => ({ name: "general", type: "channel" }),
-      rememberSlackChannelType: () => {},
-      recallSlackChannelType: () => undefined,
       resolveUserName: async () => ({ name: "Alice" }),
       setSlackThreadStatus: async () => undefined,
     } as unknown as SlackMonitorContext;

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -1886,6 +1886,45 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     expect(prepared.ctxPayload.From).toBe("slack:group:G123");
   });
 
+  it("keeps one mpDM classification when a later event omits channel_type (#102676)", async () => {
+    // Modern mpDMs are C-prefixed. Human-authored messages carry channel_type: "mpim",
+    // but bot-authored ingress shapes omit it; simulate the channel-info fill failing
+    // (e.g. missing mpim:read scope) so the only remaining signal on main is C-prefix
+    // inference, which mis-keys a second slack:channel:<id> session for the same room.
+    const ctx = createReplyToAllSlackCtx();
+    ctx.resolveChannelName = async () => ({});
+    const account = createSlackAccount({ replyToMode: "all" });
+
+    const humanPrepared = await prepareMessageWith(
+      ctx,
+      account,
+      createSlackMessage({
+        channel: "C0MPDM42",
+        channel_type: "mpim",
+        user: "U1",
+        text: "hello from a human",
+      }),
+    );
+    assertPrepared(humanPrepared);
+    expect(humanPrepared.ctxPayload.ChatType).toBe("group");
+    expect(humanPrepared.ctxPayload.From).toBe("slack:group:C0MPDM42");
+
+    const typelessPrepared = await prepareMessageWith(
+      ctx,
+      account,
+      createSlackMessage({
+        channel: "C0MPDM42",
+        channel_type: undefined,
+        user: "U2",
+        text: "same room, ingress shape without channel_type",
+        ts: "2.000",
+      }),
+    );
+    assertPrepared(typelessPrepared);
+    expect(typelessPrepared.ctxPayload.ChatType).toBe("group");
+    expect(typelessPrepared.ctxPayload.From).toBe("slack:group:C0MPDM42");
+  });
+
   it.each([
     {
       peer: { kind: "group", id: "channel:C0AJUGWG5L6" },
@@ -4196,6 +4235,8 @@ describe("prepareSlackMessage sender prefix", () => {
       resolveSlackSystemEventSessionKey: () => "agent:main:slack:channel:c1",
       isChannelAllowed: () => true,
       resolveChannelName: async () => ({ name: "general", type: "channel" }),
+      rememberSlackChannelType: () => {},
+      recallSlackChannelType: () => undefined,
       resolveUserName: async () => ({ name: "Alice" }),
       setSlackThreadStatus: async () => undefined,
     } as unknown as SlackMonitorContext;

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -500,10 +500,6 @@ async function resolveSlackConversationContext(params: {
     purpose?: string;
   } = {};
   let resolvedChannelType = normalizeSlackChannelType(message.channel_type, message.channel);
-  // Remember explicit event-carried types so later events for the same room that omit
-  // channel_type (e.g. bot-authored mpDM ingress) classify identically instead of
-  // falling back to C-prefix inference and keying a second session (#102676).
-  ctx.rememberSlackChannelType(message.channel, message.channel_type, params.eventScope);
   // D-prefixed channels are always direct messages. Skip channel lookups in
   // that common path to avoid an unnecessary API round-trip.
   if (resolvedChannelType !== "im" && (!message.channel_type || message.channel_type !== "im")) {

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -503,13 +503,15 @@ async function resolveSlackConversationContext(params: {
   // Remember explicit event-carried types so later events for the same room that omit
   // channel_type (e.g. bot-authored mpDM ingress) classify identically instead of
   // falling back to C-prefix inference and keying a second session (#102676).
-  ctx.rememberSlackChannelType(message.channel, message.channel_type);
+  ctx.rememberSlackChannelType(message.channel, message.channel_type, params.eventScope);
   // D-prefixed channels are always direct messages. Skip channel lookups in
   // that common path to avoid an unnecessary API round-trip.
   if (resolvedChannelType !== "im" && (!message.channel_type || message.channel_type !== "im")) {
     channelInfo = await ctx.resolveChannelName(message.channel, params.eventScope);
     resolvedChannelType = normalizeSlackChannelType(
-      message.channel_type ?? channelInfo.type ?? ctx.recallSlackChannelType(message.channel),
+      message.channel_type ??
+        channelInfo.type ??
+        ctx.recallSlackChannelType(message.channel, params.eventScope),
       message.channel,
     );
   }

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -500,12 +500,16 @@ async function resolveSlackConversationContext(params: {
     purpose?: string;
   } = {};
   let resolvedChannelType = normalizeSlackChannelType(message.channel_type, message.channel);
+  // Remember explicit event-carried types so later events for the same room that omit
+  // channel_type (e.g. bot-authored mpDM ingress) classify identically instead of
+  // falling back to C-prefix inference and keying a second session (#102676).
+  ctx.rememberSlackChannelType(message.channel, message.channel_type);
   // D-prefixed channels are always direct messages. Skip channel lookups in
   // that common path to avoid an unnecessary API round-trip.
   if (resolvedChannelType !== "im" && (!message.channel_type || message.channel_type !== "im")) {
     channelInfo = await ctx.resolveChannelName(message.channel, params.eventScope);
     resolvedChannelType = normalizeSlackChannelType(
-      message.channel_type ?? channelInfo.type,
+      message.channel_type ?? channelInfo.type ?? ctx.recallSlackChannelType(message.channel),
       message.channel,
     );
   }


### PR DESCRIPTION
## What Problem This Solves

A Slack multi-party DM (`mpim`) room produces **two parallel sessions per agent**. Human-authored messages carry `channel_type: "mpim"` on the event and key `slack:group:<channelId>`; bot-authored inbound shapes omit `channel_type`, and when the `conversations.info` fill cannot resolve the type either (e.g. missing `mpim:read` scope — the fill's `catch` returns `{}`), C-prefix inference falls back to `"channel"` and keys a second `slack:channel:<channelId>` session for the same room. Modern mpDM ids are C-prefixed, so prefix inference cannot disambiguate. (`extensions/slack/src/monitor/channel-type.ts`, `message-handler/prepare.ts`; fixes #102676.)

## Why This Change Was Made

The room's type is **already known** from events previously seen for it — the fix carries that prepared fact forward instead of rediscovering (or guessing). A bounded process-local map alongside the existing channel/user caches remembers explicit `channel_type` values seen on events; the resolution chain becomes `event type → channel-info fill → remembered event type → prefix inference`. The system-event session-key resolver consults the same memory, so system events key identically (sibling surface covered).

Relative to the closed attempts on this issue: **no new network lookups** (#102752 added one and was closed for it), and it fixes the reported **C-prefixed** path mechanism itself rather than special-casing an ID prefix (#102702 only changed G-prefixed IDs). The remembered value is a *last* fallback — an explicit event type or successful `conversations.info` result always wins.

## User Impact

One session per agent per mpDM room: agents keep a single conversation context and history instead of silently splitting across `slack:group:` and `slack:channel:` keys when bots talk to each other. No config change; no new public options; no behavior change for channels whose events or info lookups already resolve a type.

## Evidence

Executed before/after (full output in the PR comment below). The regression test drives the real `prepareSlackMessage` twice on **one** monitor context (real `createSlackMonitorContext`), with `resolveChannelName` returning `{}` — a human `mpim` message for `C0MPDM42`, then a same-room message **without** `channel_type`:

```
BEFORE — main's context.ts/prepare.ts + this test:
  × keeps one mpDM classification when a later event omits channel_type (#102676)
    Error: Expected Slack message to be prepared
  Tests  1 failed | 113 passed (114)
  (the typeless same-room message stops being an mpDM: dropped under default room
   mention-gating, or keyed as the parallel slack:channel:C0MPDM42 session)

AFTER — this PR:
  Tests  114 passed (114)
  human msg    → ChatType "group", From "slack:group:C0MPDM42"
  typeless msg → ChatType "group", From "slack:group:C0MPDM42"   (one classification)
```

Sibling context suites (`inbound-context.contract`, `prepare-thread-context`, `prepare.thread-session-key`) 32/32 green; `pnpm tsgo:extensions` **0 errors**; `oxfmt`/`oxlint` clean. Commands: `node scripts/run-vitest.mjs run extensions/slack/src/monitor/message-handler/prepare.test.ts` (and sibling files); before-run used `git checkout upstream/main -- extensions/slack/src/monitor/context.ts extensions/slack/src/monitor/message-handler/prepare.ts`.
