### PR TITLE
fix(signal): log signal-cli daemon stdout/stderr stream errors

### DIFF
--- a/extensions/signal/src/daemon.test.ts
+++ b/extensions/signal/src/daemon.test.ts
@@ -1,6 +1,7 @@
-// Signal tests cover daemon plugin behavior.
 import os from "node:os";
 import path from "node:path";
+// Signal tests cover daemon plugin behavior.
+import { PassThrough } from "node:stream";
 import { describe, expect, it } from "vitest";
 import { testApi } from "./daemon.js";
 
@@ -44,5 +45,64 @@ describe("signal daemon log classification", () => {
   it("still surfaces signal-cli failures as errors", () => {
     expect(testApi.classifySignalCliLogLine("ERROR DaemonCommand - startup failed")).toBe("error");
     expect(testApi.classifySignalCliLogLine("SEVERE Manager - database exception")).toBe("error");
+  });
+});
+
+describe("signal daemon stream errors", () => {
+  it("logs stdout stream errors via the error callback", () => {
+    const stdout = new PassThrough();
+    const logs: string[] = [];
+    const errors: string[] = [];
+    testApi.bindSignalCliOutput({
+      stream: stdout,
+      log: (message) => logs.push(message),
+      error: (message) => errors.push(message),
+    });
+    const streamError = new Error("stdout pipe broken");
+    stdout.emit("error", streamError);
+    expect(errors).toContain("signal-cli stream error: stdout pipe broken");
+    expect(logs).toEqual([]);
+  });
+
+  it("logs stderr stream errors via the error callback", () => {
+    const stderr = new PassThrough();
+    const logs: string[] = [];
+    const errors: string[] = [];
+    testApi.bindSignalCliOutput({
+      stream: stderr,
+      log: (message) => logs.push(message),
+      error: (message) => errors.push(message),
+    });
+    const streamError = new Error("stderr pipe broken");
+    stderr.emit("error", streamError);
+    expect(errors).toContain("signal-cli stream error: stderr pipe broken");
+    expect(logs).toEqual([]);
+  });
+
+  it("keeps handling data after a stream error without throwing", () => {
+    const stdout = new PassThrough();
+    const logs: string[] = [];
+    const errors: string[] = [];
+    testApi.bindSignalCliOutput({
+      stream: stdout,
+      log: (message) => logs.push(message),
+      error: (message) => errors.push(message),
+    });
+    stdout.emit("error", new Error("transient pipe hiccup"));
+    stdout.emit("data", Buffer.from("INFO Daemon - ready\n"));
+    expect(errors).toContain("signal-cli stream error: transient pipe hiccup");
+    expect(logs).toContain("signal-cli: INFO Daemon - ready");
+  });
+
+  it("tolerates a null or undefined stream without subscribing", () => {
+    const errors: string[] = [];
+    expect(() =>
+      testApi.bindSignalCliOutput({
+        stream: null,
+        log: () => {},
+        error: (message) => errors.push(message),
+      }),
+    ).not.toThrow();
+    expect(errors).toEqual([]);
   });
 });

--- a/extensions/signal/src/daemon.ts
+++ b/extensions/signal/src/daemon.ts
@@ -73,6 +73,11 @@ function bindSignalCliOutput(params: {
       }
     }
   });
+  // Pipe errors surface here before child exit; log them so the daemon's
+  // error sink stays consistent without racing the exit/close handlers.
+  params.stream?.on("error", (err) => {
+    params.error(`signal-cli stream error: ${err instanceof Error ? err.message : String(err)}`);
+  });
 }
 
 function resolveSignalCliConfigPath(raw: string): string {
@@ -175,6 +180,7 @@ export function spawnSignalDaemon(opts: SignalDaemonOpts): SignalDaemonHandle {
 }
 
 export const testApi = {
+  bindSignalCliOutput,
   buildDaemonArgs,
   classifySignalCliLogLine,
   resolveSignalCliConfigPath,


### PR DESCRIPTION
## What Problem This Solves

`bindSignalCliOutput` in `extensions/signal/src/daemon.ts` spawns the signal-cli daemon with `stdio: ["ignore", "pipe", "pipe"]` and binds `data` events on `child.stdout` and `child.stderr` to classify log output, but it does not attach `error` listeners to either stream. If a pipe breaks while the daemon is running (for example, the daemon process is killed externally or the fd is closed), the error becomes an unhandled stream error and can crash the agent runtime.

## Why This Change Was Made

Node Readable streams can emit `error` independently of the child process `error` and `exit` events. For a long-lived daemon process, unhandled stream errors are a reliability risk. The same pattern was fixed in imessage's `listenForIMessageCliStreamErrors` (PR #101401). The fix adds an `error` listener on each stream that routes through the daemon's existing `error()` callback — the daemon is long-lived, so stream errors are logged rather than rejecting the spawn promise. The existing `child.on("error")` and `child.once("exit")` handlers own process termination.

## User Impact

- Signal daemon stdout/stderr stream errors are now logged via the daemon's `error()` callback instead of crashing the agent runtime.
- The daemon continues running until the process-level exit/error handlers fire.
- Existing success paths and daemon lifecycle behavior are unchanged.

## Evidence

- Added `error` event handler on the stream in `bindSignalCliOutput` (`extensions/signal/src/daemon.ts`).
- Added `describe("signal daemon stream errors")` regression block in `extensions/signal/src/daemon.test.ts` — 4 tests covering stdout pipe error, stderr pipe error, data-after-error processing, and null-stream tolerance.
- `git diff --check` — passed.

Local proof only. Testbox was intentionally not used because Blacksmith is unavailable.
