### PR TITLE
fix(msteams): bound team group lookup cache

### DIFF
--- a/extensions/msteams/src/graph-thread.test.ts
+++ b/extensions/msteams/src/graph-thread.test.ts
@@ -123,6 +123,37 @@ describe("resolveTeamGroupId", () => {
     const result = await resolveTeamGroupId("tok", "team-fallback");
     expect(result).toBe("team-fallback");
   });
+
+  it("caps cache at 500 entries — evicts oldest on overflow", async () => {
+    vi.mocked(fetchGraphJson).mockResolvedValue({ id: "group-guid" } as never);
+
+    const token = "test-token";
+    for (let i = 0; i < 500; i++) {
+      await resolveTeamGroupId(token, `team-${i}`);
+    }
+    expect(_teamGroupIdCacheForTest.size).toBe(500);
+    expect(_teamGroupIdCacheForTest.has("team-0")).toBe(true);
+    expect(_teamGroupIdCacheForTest.has("team-499")).toBe(true);
+
+    vi.mocked(fetchGraphJson).mockClear();
+    await resolveTeamGroupId(token, "team-500");
+    expect(fetchGraphJson).toHaveBeenCalledTimes(1);
+    expect(_teamGroupIdCacheForTest.size).toBe(500);
+    expect(_teamGroupIdCacheForTest.has("team-0")).toBe(false);
+    expect(_teamGroupIdCacheForTest.has("team-500")).toBe(true);
+
+    vi.mocked(fetchGraphJson).mockClear();
+    await resolveTeamGroupId(token, "team-0");
+    expect(fetchGraphJson).toHaveBeenCalledTimes(1);
+    expect(_teamGroupIdCacheForTest.size).toBe(500);
+    expect(_teamGroupIdCacheForTest.has("team-1")).toBe(false);
+    expect(_teamGroupIdCacheForTest.has("team-500")).toBe(true);
+
+    // team-500 remains cached after team-0 is reinserted at the insertion-order tail.
+    vi.mocked(fetchGraphJson).mockClear();
+    await resolveTeamGroupId(token, "team-500");
+    expect(fetchGraphJson).toHaveBeenCalledTimes(0);
+  });
 });
 
 describe("fetchChannelMessage", () => {

--- a/extensions/msteams/src/graph-thread.ts
+++ b/extensions/msteams/src/graph-thread.ts
@@ -1,4 +1,5 @@
 // Msteams plugin module implements graph thread behavior.
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
@@ -15,9 +16,11 @@ export type GraphThreadMessage = {
   createdDateTime?: string;
 };
 
-// TTL cache for team ID -> group GUID mapping.
+// Successful lookups use a 10-minute TTL and a 500-entry insertion-order cap.
+// Pruning after insert evicts the oldest team IDs before this process cache grows unbounded.
 const teamGroupIdCache = new Map<string, { groupId: string; expiresAt: number }>();
 const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const TEAM_GROUP_ID_CACHE_MAX_ENTRIES = 500;
 
 function resolveTeamGroupIdCacheExpiresAt(nowRaw = Date.now()): number | undefined {
   const now = asDateTimestampMs(nowRaw);
@@ -84,6 +87,7 @@ export async function resolveTeamGroupId(
         groupId,
         expiresAt,
       });
+      pruneMapToMaxSize(teamGroupIdCache, TEAM_GROUP_ID_CACHE_MAX_ENTRIES);
     }
 
     return groupId;


### PR DESCRIPTION
## What Problem This Solves

Microsoft Teams team/group lookups accumulated one cache entry per distinct lookup until TTL expiry. High-cardinality or adversarial traffic could therefore grow the process-local map without a hard bound.

This is a maintainer-owned replacement for #101964. GitHub's signed fork-update API rejected the rebased contributor branch because the stale fork-to-main tree payload exceeded its 45 MB limit.

## Why This Change Was Made

Cap the existing TTL cache at 500 entries with the shared `pruneMapToMaxSize` helper after every successful insertion. The behavior stays single-path: cached hits, misses, null fallbacks, and TTL semantics are unchanged; only the oldest excess entries are removed.

The regression exercises the real `resolveTeamGroupId` path through 501 distinct successful lookups, proves the cache remains at 500, confirms the oldest entry is evicted, and verifies a later lookup fetches and reinserts it. The patch is preserved as one maintainer commit with `sunlit-deng` as co-author.

## User Impact

Long-running Teams gateways now keep this lookup cache bounded instead of retaining an arbitrary number of tenant/team combinations until expiry.

## Evidence

- Fresh branch autoreview: clean, no actionable findings, confidence 0.99.
- Formatting: `oxfmt --check` passed for both touched files.
- Static hygiene: `git diff --check origin/main...HEAD` passed.
- Exact-head isolated AWS proof and hosted CI will be attached before merge.

Supersedes #101964 while preserving contributor credit.
