### PR TITLE
fix(gateway): keep command-list field clamping UTF-16 safe

### DIFF
--- a/src/gateway/server-methods/commands-list-result.ts
+++ b/src/gateway/server-methods/commands-list-result.ts
@@ -1,6 +1,7 @@
 // Command list serialization gathers chat, skill, and plugin commands into the
 // gateway protocol result while clamping names, descriptions, aliases, and args.
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type {
   CommandEntry,
   CommandsListResult,
@@ -36,7 +37,7 @@ type SerializedArg = NonNullable<CommandEntry["args"]>[number];
 type CommandNameSurface = "text" | "native";
 
 function clampString(value: string, maxLength: number): string {
-  return value.length > maxLength ? value.slice(0, maxLength) : value;
+  return value.length > maxLength ? truncateUtf16Safe(value, maxLength) : value;
 }
 
 function trimClampNonEmpty(value: string, maxLength: number): string | null {

--- a/src/gateway/server-methods/commands.test.ts
+++ b/src/gateway/server-methods/commands.test.ts
@@ -517,7 +517,8 @@ describe("commands.list handler", () => {
     const originalCommands = [...mockChatCommands];
     const longToken = "x".repeat(COMMAND_NAME_MAX_LENGTH + 50);
     const aliasBase = "alias".repeat(20);
-    const longDescription = "d".repeat(COMMAND_DESCRIPTION_MAX_LENGTH + 50);
+    const descriptionPrefix = "d".repeat(COMMAND_DESCRIPTION_MAX_LENGTH - 1);
+    const longDescription = `${descriptionPrefix}😀tail`;
     const oversizedArgs = Array.from({ length: COMMAND_ARGS_MAX_ITEMS + 5 }, (_, argIndex) => ({
       name: `${longToken}-${argIndex}`,
       description: longDescription,
@@ -554,37 +555,11 @@ describe("commands.list handler", () => {
       expect((first.description as string).length).toBeLessThanOrEqual(
         COMMAND_DESCRIPTION_MAX_LENGTH,
       );
+      expect(first.description).toBe(descriptionPrefix);
       expect((first.textAliases as unknown[]).length).toBeLessThanOrEqual(COMMAND_ALIAS_MAX_ITEMS);
       expect(first.args as unknown[]).toHaveLength(COMMAND_ARGS_MAX_ITEMS);
       const firstArg = (first.args as Array<Record<string, unknown>>)[0];
       expect(firstArg.choices as unknown[]).toHaveLength(COMMAND_ARG_CHOICES_MAX_ITEMS);
-    } finally {
-      mockChatCommands.length = 0;
-      mockChatCommands.push(...originalCommands);
-    }
-  });
-
-  it("clamps a description without splitting a trailing surrogate pair", () => {
-    const originalCommands = [...mockChatCommands];
-    // U+1F600 is a surrogate pair; place it so it straddles the clamp limit.
-    const description = `${"d".repeat(COMMAND_DESCRIPTION_MAX_LENGTH - 1)}😀`;
-    try {
-      mockChatCommands.length = 0;
-      mockChatCommands.push({
-        key: "surrogate_boundary",
-        nativeName: "surrogate_boundary",
-        description,
-        textAliases: ["/surrogate_boundary"],
-        scope: "both",
-        category: "tools",
-      });
-
-      const clamped = requireCommand(listCommands(), "surrogate_boundary").description as string;
-
-      expect(clamped.length).toBeLessThanOrEqual(COMMAND_DESCRIPTION_MAX_LENGTH);
-      const lastUnit = clamped.charCodeAt(clamped.length - 1);
-      // A raw slice would leave a dangling high surrogate at the boundary.
-      expect(lastUnit >= 0xd800 && lastUnit <= 0xdbff).toBe(false);
     } finally {
       mockChatCommands.length = 0;
       mockChatCommands.push(...originalCommands);

--- a/src/gateway/server-methods/commands.test.ts
+++ b/src/gateway/server-methods/commands.test.ts
@@ -564,6 +564,33 @@ describe("commands.list handler", () => {
     }
   });
 
+  it("clamps a description without splitting a trailing surrogate pair", () => {
+    const originalCommands = [...mockChatCommands];
+    // U+1F600 is a surrogate pair; place it so it straddles the clamp limit.
+    const description = `${"d".repeat(COMMAND_DESCRIPTION_MAX_LENGTH - 1)}😀`;
+    try {
+      mockChatCommands.length = 0;
+      mockChatCommands.push({
+        key: "surrogate_boundary",
+        nativeName: "surrogate_boundary",
+        description,
+        textAliases: ["/surrogate_boundary"],
+        scope: "both",
+        category: "tools",
+      });
+
+      const clamped = requireCommand(listCommands(), "surrogate_boundary").description as string;
+
+      expect(clamped.length).toBeLessThanOrEqual(COMMAND_DESCRIPTION_MAX_LENGTH);
+      const lastUnit = clamped.charCodeAt(clamped.length - 1);
+      // A raw slice would leave a dangling high surrogate at the boundary.
+      expect(lastUnit >= 0xd800 && lastUnit <= 0xdbff).toBe(false);
+    } finally {
+      mockChatCommands.length = 0;
+      mockChatCommands.push(...originalCommands);
+    }
+  });
+
   it("rejects unknown agentId", () => {
     const { ok, error } = callHandler({ agentId: "nonexistent" });
     expect(ok).toBe(false);


### PR DESCRIPTION
## What Problem This Solves

The gateway `commands.list` result clamps command names, descriptions, aliases, argument names/descriptions, and choice values/labels to bounded lengths. The clamp used a raw `value.slice(0, maxLength)`, so when an emoji or other astral code point straddled the limit, the truncation kept a dangling high surrogate. That lone surrogate is then serialized into the gateway protocol payload delivered to every SDK / Control UI client.

## Why This Change Was Made

Route the single `clampString` chokepoint through the shared `truncateUtf16Safe` primitive (`@openclaw/normalization-core/utf16-slice`), which backs off one code unit when the boundary would split a surrogate pair. Every clamped field (name, description, aliases, args, choices) flows through this one helper, so the fix covers all of them at once. Bounds, ordering, and the `length <= maxLength` guarantee are unchanged; the clamp can only get one code unit shorter in the boundary case, never longer.

## User Impact

Command metadata delivered over `commands.list` stays valid Unicode. An emoji at a clamp boundary is dropped whole instead of surfacing as a broken/replacement character in clients.

## Evidence

Real behavior at the 2000-unit description boundary (`"d".repeat(1999) + "😀"`), using the shipped `truncateUtf16Safe`:

- Before (raw slice): length 2000, last unit `0xd83d`, `isWellFormed() = false` (dangling high surrogate)
- After (`truncateUtf16Safe`): length 1999, last unit `0x64`, `isWellFormed() = true`

- Folded the regression into the existing bounds test through the real `buildCommandsListResult` path. It asserts the exact safe prefix when an emoji straddles `COMMAND_DESCRIPTION_MAX_LENGTH`.
- Sanitized AWS Crabbox GREEN: [`run_7839d96ceaa3`](https://crabbox.openclaw.ai/portal/runs/run_7839d96ceaa3) — 52/52 focused tests passed across both gateway projects.
- Sanitized AWS Crabbox RED control: [`run_2558eb9ccc6d`](https://crabbox.openclaw.ai/portal/runs/run_2558eb9ccc6d) — restoring only the pre-fix raw-slice implementation makes the exact-prefix assertion fail in both gateway projects (50 passed, 2 failed).
- Exact-head hosted CI: [all required checks passed](https://github.com/openclaw/openclaw/actions/runs/29024648570), including lint, production/test types, gateway critical quality, and security checks.
- Fresh autoreview: no actionable findings; `git diff --check` clean.

AI-assisted (Claude Code); I reviewed and understand every line.
