### PR TITLE
fix(models): align model list truncation by terminal width

### DIFF
--- a/src/commands/models/list.format.test.ts
+++ b/src/commands/models/list.format.test.ts
@@ -43,6 +43,10 @@ describe("truncate", () => {
     expect(result).toBe("");
     expect(hasLoneSurrogate(result)).toBe(false);
   });
+
+  it("sanitizes terminal controls before measuring visible width", () => {
+    expect(truncate("ab\u001B]2;hidden\u0007cd", 6)).toBe("abcd");
+  });
 });
 
 describe("pad", () => {

--- a/src/commands/models/list.format.test.ts
+++ b/src/commands/models/list.format.test.ts
@@ -1,0 +1,53 @@
+// Model list formatting tests cover fixed-width terminal cell helpers.
+import { describe, expect, it } from "vitest";
+import { visibleWidth } from "../../../packages/terminal-core/src/ansi.js";
+import { pad, truncate } from "./list.format.js";
+
+function hasLoneSurrogate(value: string): boolean {
+  for (let i = 0; i < value.length; i += 1) {
+    const codeUnit = value.charCodeAt(i);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(i + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return true;
+      }
+    }
+    if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      const previous = value.charCodeAt(i - 1);
+      if (!(previous >= 0xd800 && previous <= 0xdbff)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+describe("truncate", () => {
+  it("preserves existing ASCII truncation with an ellipsis suffix", () => {
+    expect(truncate("abcdefghi", 6)).toBe("abc...");
+  });
+
+  it("keeps ellipsis-suffixed truncation on a terminal-width boundary", () => {
+    const grin = String.fromCodePoint(0x1f600);
+    const result = truncate(`ab${grin}cde`, 6);
+
+    expect(result).toBe("ab...");
+    expect(visibleWidth(result)).toBe(5);
+    expect(hasLoneSurrogate(result)).toBe(false);
+  });
+
+  it("keeps tiny truncation budgets on a UTF-16 boundary", () => {
+    const grin = String.fromCodePoint(0x1f600);
+    const result = truncate(grin, 1);
+
+    expect(result).toBe("");
+    expect(hasLoneSurrogate(result)).toBe(false);
+  });
+});
+
+describe("pad", () => {
+  it("pads to terminal visible width rather than string length", () => {
+    expect(pad("表", 2)).toBe("表");
+    expect(pad("表", 3)).toBe("表 ");
+  });
+});

--- a/src/commands/models/list.format.test.ts
+++ b/src/commands/models/list.format.test.ts
@@ -3,25 +3,6 @@ import { describe, expect, it } from "vitest";
 import { visibleWidth } from "../../../packages/terminal-core/src/ansi.js";
 import { pad, truncate } from "./list.format.js";
 
-function hasLoneSurrogate(value: string): boolean {
-  for (let i = 0; i < value.length; i += 1) {
-    const codeUnit = value.charCodeAt(i);
-    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
-      const next = value.charCodeAt(i + 1);
-      if (!(next >= 0xdc00 && next <= 0xdfff)) {
-        return true;
-      }
-    }
-    if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
-      const previous = value.charCodeAt(i - 1);
-      if (!(previous >= 0xd800 && previous <= 0xdbff)) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 describe("truncate", () => {
   it("preserves existing ASCII truncation with an ellipsis suffix", () => {
     expect(truncate("abcdefghi", 6)).toBe("abc...");
@@ -33,15 +14,13 @@ describe("truncate", () => {
 
     expect(result).toBe("ab...");
     expect(visibleWidth(result)).toBe(5);
-    expect(hasLoneSurrogate(result)).toBe(false);
   });
 
-  it("keeps tiny truncation budgets on a UTF-16 boundary", () => {
+  it("drops an over-wide grapheme when the budget is too small", () => {
     const grin = String.fromCodePoint(0x1f600);
     const result = truncate(grin, 1);
 
     expect(result).toBe("");
-    expect(hasLoneSurrogate(result)).toBe(false);
   });
 
   it("sanitizes terminal controls before measuring visible width", () => {

--- a/src/commands/models/list.format.ts
+++ b/src/commands/models/list.format.ts
@@ -1,12 +1,18 @@
 /** Formatting helpers for model-list terminal tables. */
+import { truncateToVisibleWidth, visibleWidth } from "../../../packages/terminal-core/src/ansi.js";
 import { isRich as isRichTerminal, theme } from "../../../packages/terminal-core/src/theme.js";
+
+const TRUNCATED_SUFFIX = "...";
 
 /** Enables rich formatting only for non-machine-readable output. */
 export const isRich = (opts?: { json?: boolean; plain?: boolean }) =>
   isRichTerminal() && !opts?.json && !opts?.plain;
 
-/** Pads a table cell to a fixed width. */
-export const pad = (value: string, size: number) => value.padEnd(size);
+/** Pads a table cell to a fixed terminal visible width. */
+export const pad = (value: string, size: number) => {
+  const remaining = size - visibleWidth(value);
+  return remaining > 0 ? `${value}${" ".repeat(remaining)}` : value;
+};
 
 /** Applies terminal color based on a model-list tag. */
 export const formatTag = (tag: string, rich: boolean) => {
@@ -37,13 +43,13 @@ export const formatTag = (tag: string, rich: boolean) => {
   return theme.muted(tag);
 };
 
-/** Truncates model-list cells with an ASCII ellipsis. */
+/** Truncates model-list cells to terminal visible width with an ASCII ellipsis. */
 export const truncate = (value: string, max: number) => {
-  if (value.length <= max) {
+  if (visibleWidth(value) <= max) {
     return value;
   }
-  if (max <= 3) {
-    return value.slice(0, max);
+  if (max <= TRUNCATED_SUFFIX.length) {
+    return truncateToVisibleWidth(value, max);
   }
-  return `${value.slice(0, max - 3)}...`;
+  return `${truncateToVisibleWidth(value, max - TRUNCATED_SUFFIX.length)}${TRUNCATED_SUFFIX}`;
 };

--- a/src/commands/models/list.format.ts
+++ b/src/commands/models/list.format.ts
@@ -1,5 +1,6 @@
 /** Formatting helpers for model-list terminal tables. */
 import { truncateToVisibleWidth, visibleWidth } from "../../../packages/terminal-core/src/ansi.js";
+import { sanitizeTerminalText } from "../../../packages/terminal-core/src/safe-text.js";
 import { isRich as isRichTerminal, theme } from "../../../packages/terminal-core/src/theme.js";
 
 const TRUNCATED_SUFFIX = "...";
@@ -45,11 +46,12 @@ export const formatTag = (tag: string, rich: boolean) => {
 
 /** Truncates model-list cells to terminal visible width with an ASCII ellipsis. */
 export const truncate = (value: string, max: number) => {
-  if (visibleWidth(value) <= max) {
-    return value;
+  const sanitized = sanitizeTerminalText(value);
+  if (visibleWidth(sanitized) <= max) {
+    return sanitized;
   }
   if (max <= TRUNCATED_SUFFIX.length) {
-    return truncateToVisibleWidth(value, max);
+    return truncateToVisibleWidth(sanitized, max);
   }
-  return `${truncateToVisibleWidth(value, max - TRUNCATED_SUFFIX.length)}${TRUNCATED_SUFFIX}`;
+  return `${truncateToVisibleWidth(sanitized, max - TRUNCATED_SUFFIX.length)}${TRUNCATED_SUFFIX}`;
 };

--- a/src/commands/models/list.table.test.ts
+++ b/src/commands/models/list.table.test.ts
@@ -1,5 +1,6 @@
 // Model list table tests cover terminal table rendering for model list output.
 import { describe, expect, it, vi } from "vitest";
+import { visibleWidth } from "../../../packages/terminal-core/src/ansi.js";
 import { printModelTable } from "./list.table.js";
 import type { ModelRow } from "./list.types.js";
 
@@ -27,5 +28,31 @@ describe("printModelTable", () => {
       ["Model                                      Input      Ctx         Local Auth  Tags"],
       ["openai/gpt-5.5                             text+image 272k/400k   no    yes   "],
     ]);
+  });
+
+  it("keeps fixed-width rows aligned when model keys contain wide graphemes", () => {
+    const runtime = { log: vi.fn(), error: vi.fn() };
+    const wideKey = `${"a".repeat(41)}表`;
+    const rows: ModelRow[] = [
+      {
+        key: wideKey,
+        name: wideKey,
+        input: "text",
+        contextWindow: 128_000,
+        contextTokens: undefined,
+        local: false,
+        available: true,
+        tags: [],
+        missing: false,
+      },
+    ];
+
+    printModelTable(rows, runtime as never);
+
+    const [header, row] = runtime.log.mock.calls.map(([line]) => line);
+    expect(typeof header).toBe("string");
+    expect(typeof row).toBe("string");
+    expect(visibleWidth(header as string)).toBeGreaterThan(42);
+    expect(visibleWidth((row as string).slice(0, (row as string).indexOf("text")))).toBe(43);
   });
 });

--- a/src/commands/models/list.table.test.ts
+++ b/src/commands/models/list.table.test.ts
@@ -52,7 +52,12 @@ describe("printModelTable", () => {
     const [header, row] = runtime.log.mock.calls.map(([line]) => line);
     expect(typeof header).toBe("string");
     expect(typeof row).toBe("string");
-    expect(visibleWidth(header as string)).toBeGreaterThan(42);
-    expect(visibleWidth((row as string).slice(0, (row as string).indexOf("text")))).toBe(43);
+    const headerInputIndex = (header as string).indexOf("Input");
+    const rowInputIndex = (row as string).indexOf("text");
+    expect(headerInputIndex).toBeGreaterThan(0);
+    expect(rowInputIndex).toBeGreaterThan(0);
+    expect(visibleWidth((row as string).slice(0, rowInputIndex))).toBe(
+      visibleWidth((header as string).slice(0, headerInputIndex)),
+    );
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing `openclaw models list` or `openclaw models scan` table output could see misaligned columns when truncated model names contain emoji, CJK, or other wide graphemes.

## Why This Change Was Made

Model table formatting now treats column budgets as terminal visible cell widths, reusing the existing terminal-core width and grapheme-aware truncation helpers. This keeps fixed-width table rendering aligned while still avoiding split surrogate pairs; JSON and plain output are unchanged.

## User Impact

Users can expect model table rows to stay readable and aligned when model names contain wide Unicode characters.

## Evidence

- RED: `node scripts/run-vitest.mjs src/commands/models/list.table.test.ts` failed before the visible-width padding fix because the `Input` column started one terminal cell too far right for a wide model key.
- GREEN: `node scripts/run-vitest.mjs src/commands/models/list.format.test.ts src/commands/models/list.table.test.ts` passed on `codex/model-list-terminal-width`.
- `git diff --check HEAD~1..HEAD` passed.

Known proof gap: Blacksmith Testbox/Crabbox proof could not run in the local Codex environment because no `crabbox` binary was installed/discoverable.