### PR TITLE
fix(feishu): treat outbound media content types case-insensitively

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -437,6 +437,84 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(callData<{ msg_type?: string }>(messageCreateMock).msg_type).toBe("image");
   });
 
+  it("routes mixed-case image content types to msg_type=image (MIME is case-insensitive)", async () => {
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: Buffer.from("remote-image"),
+      fileName: "download",
+      kind: "image",
+      contentType: "Image/PNG",
+    });
+
+    await sendMediaFeishu({
+      cfg: emptyConfig,
+      to: "user:ou_target",
+      mediaUrl: "https://example.com/image",
+    });
+
+    expect(imageCreateMock).toHaveBeenCalledTimes(1);
+    expect(callData<{ msg_type?: string }>(messageCreateMock).msg_type).toBe("image");
+  });
+
+  it("routes lowercase image content types to msg_type=image (regression)", async () => {
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: Buffer.from("remote-image"),
+      fileName: "download",
+      kind: "image",
+      contentType: "image/png",
+    });
+
+    await sendMediaFeishu({
+      cfg: emptyConfig,
+      to: "user:ou_target",
+      mediaUrl: "https://example.com/image",
+    });
+
+    expect(imageCreateMock).toHaveBeenCalledTimes(1);
+    expect(callData<{ msg_type?: string }>(messageCreateMock).msg_type).toBe("image");
+  });
+
+  it("keeps voice intent for mixed-case audio content types instead of degrading to file", async () => {
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: Buffer.from("remote-voice"),
+      fileName: "voicemail",
+      kind: "audio",
+      contentType: "Audio/Ogg",
+    });
+
+    const result = await sendMediaFeishu({
+      cfg: emptyConfig,
+      to: "user:ou_target",
+      mediaUrl: "https://example.com/voicemail",
+      audioAsVoice: true,
+    });
+
+    expect(runFfmpegMock).not.toHaveBeenCalled();
+    expect(callData<{ file_type?: string }>(fileCreateMock).file_type).toBe("opus");
+    expect(callData<{ msg_type?: string }>(messageCreateMock).msg_type).toBe("audio");
+    expect(result.voiceIntentDegradedToFile).not.toBe(true);
+  });
+
+  it("routes mixed-case video content types to msg_type=media with an mp4 probe input", async () => {
+    runFfprobeMock.mockResolvedValueOnce("8.9\n");
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: Buffer.from("remote-video"),
+      fileName: "download",
+      kind: "video",
+      contentType: "Video/MP4",
+    });
+
+    await sendMediaFeishu({
+      cfg: emptyConfig,
+      to: "user:ou_target",
+      mediaUrl: "https://example.com/video",
+    });
+
+    expect(callData<{ file_type?: string }>(fileCreateMock).file_type).toBe("mp4");
+    const ffprobeArgs = mockCallArg<string[]>(runFfprobeMock, 0, 0);
+    expect(ffprobeArgs.at(-1)).toMatch(/input\.mp4$/);
+    expect(callData<{ msg_type?: string }>(messageCreateMock).msg_type).toBe("media");
+  });
+
   it("preserves Feishu diagnostics when media sends reject before response checks", async () => {
     messageCreateMock.mockRejectedValueOnce(
       Object.assign(new Error("Request failed with status code 400"), {

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -657,8 +657,9 @@ function resolveFeishuOutboundMediaKind(params: { fileName: string; contentType?
   fileType?: "opus" | "mp4" | "pdf" | "doc" | "xls" | "ppt" | "stream";
   msgType: "image" | "file" | "audio" | "media";
 } {
-  const { fileName, contentType } = params;
+  const { fileName } = params;
   const ext = normalizeLowercaseStringOrEmpty(path.extname(fileName));
+  const contentType = normalizeLowercaseStringOrEmpty(params.contentType);
   const mimeKind = mediaKindFromMime(contentType);
 
   const isImageExt = [".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".ico", ".tiff"].includes(
@@ -832,10 +833,11 @@ async function probeMediaDurationMs(params: {
       { rootDir: resolvePreferredOpenClawTmpDir(), prefix: "feishu-media-probe-" },
       async (workspace) => {
         const ext = normalizeLowercaseStringOrEmpty(path.extname(params.fileName));
+        const contentType = normalizeLowercaseStringOrEmpty(params.contentType);
         const inferredExt =
           ext && ext.length <= 12
             ? ext
-            : mediaKindFromMime(params.contentType) === "video"
+            : mediaKindFromMime(contentType) === "video"
               ? ".mp4"
               : ".ogg";
         const inputPath = await workspace.write(`input${inferredExt}`, params.buffer);


### PR DESCRIPTION
## What Problem This Solves

Feishu outbound media routing compares the media `contentType` without normalizing case, so it treats MIME types as case-sensitive. MIME types are case-insensitive (RFC 2045 §5.1), and the `contentType` here originates from an upstream HTTP `Content-Type` header (via `loadWebMedia`), which can arrive in any case.

In `extensions/feishu/src/media.ts`, `resolveFeishuOutboundMediaKind()` decides the Feishu `msg_type` for every outbound media send, and every one of its content-type checks is case-sensitive:

- `mediaKindFromMime(contentType)` — a raw (non-normalizing) classifier, so `Image/PNG` is not recognized as an image and the send degrades to a plain **file** attachment.
- `contentType === "audio/ogg" | "audio/opus"` — a direct equality, so `Audio/Ogg` misses the audio branch. With `audioAsVoice`, this trips `voiceIntentDegradedToFile`: a voice message silently degrades to a file.
- `contentType === "video/mp4" | ...` — same, so `Video/MP4` misses the video branch.

A second site, `probeMediaDurationMs()`, has the same raw `mediaKindFromMime(params.contentType) === "video"` check, so a mixed-case video probes with the wrong container extension.

The same file already normalizes the same `params.contentType` with `normalizeLowercaseStringOrEmpty` at its sibling helpers `isFeishuNativeVoiceAudio()` and `isLikelyTranscodableAudio()` — these two routing sites were simply missed.

## Why This Change Was Made

This is the feishu sibling of two already-merged fixes applying the same RFC 2045 rule:

- #102431 `fix(msteams): ...` — content-type case-insensitivity
- #102753 `fix(qqbot): treat inbound attachment content types case-insensitively`

The fix case-normalizes `contentType` once at the top of each of the two routing functions using the file's own `normalizeLowercaseStringOrEmpty`, matching the existing sibling helpers. This is a case-sensitivity fix only — it lowercases, matching the siblings; it does not add MIME parameter stripping. Normalizing here (rather than only swapping in the normalizing `kindFromMime` wrapper) is required because the audio and video branches route via direct string equality, not via `mediaKindFromMime` — a wrapper swap alone would leave the voice-degrade path unfixed.

This change is limited to the two mixed-case comparison sites in feishu's outbound media routing. It deliberately does not modify the core `mediaKindFromMime` helper, whose raw-vs-normalizing split (`kindFromMime` wraps it with `normalizeMimeType`) is intentional; any other channel's sibling is left to a separate change.

## User Impact

On Feishu, media whose HTTP `Content-Type` header uses non-lowercase casing now routes correctly:
- images send as images instead of file attachments;
- voice-intent audio stays a voice message instead of degrading to a file;
- videos send as media with the correct probe container.

Lowercase content types are unaffected. No config, schema, or API changes.

## Evidence

Real-behavior boundary capture — drives the production `sendMediaFeishu` → `resolveFeishuOutboundMediaKind` routing decision under `node --import tsx`; only the true external boundaries (Feishu SDK client, account config, target normalization, HTTP media loader, ffmpeg/ffprobe) are faked. A live Feishu tenant is infeasible in this environment.

```
                          contentType        before (unfixed)                          after (fixed)
mixed-case image          "Image/PNG"        msg_type=file  (file_type=stream)          msg_type=image
mixed-case voice audio    "Audio/Ogg"        msg_type=file  voiceIntentDegradedToFile=1 msg_type=audio  degraded=false
mixed-case video          "Video/MP4"        msg_type=file  (file_type=stream)          msg_type=media  (mp4 probe)
lowercase image (regr.)   "image/png"        msg_type=image                             msg_type=image  (unchanged)
```

Unit tests (`extensions/feishu/src/media.test.ts`, 4 added) drive the same routing end-to-end through `sendMediaFeishu`: mixed-case image → `image`, mixed-case `audioAsVoice` audio → `audio` (no degrade), mixed-case video → `media` with an `input.mp4` probe, plus a lowercase-image regression. Reverting the production change fails exactly the three mixed-case tests and leaves the lowercase one green.

Local: full feishu extension suite green; `oxfmt` clean; extension typecheck clean. Full `check:changed` (extension prod + extension tests lanes) runs on CI.
