### PR TITLE
fix(ui): stabilize chat-realtime mic-selection tests across jsdom platforms (#102568)

### DIFF
--- a/ui/src/pages/chat/chat-realtime.test.ts
+++ b/ui/src/pages/chat/chat-realtime.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStorageMock } from "../../test-helpers/storage.ts";
 
 const { realtimeTalkSessionCtor, sessionStart, sessionStop } = vi.hoisted(() => ({
   realtimeTalkSessionCtor: vi.fn(function () {
@@ -53,7 +54,14 @@ const vadThresholdCases: Array<[string, string, number | undefined]> = [
 
 describe("chat realtime actions", () => {
   beforeEach(() => {
-    localStorage.clear();
+    // Node 24+ exposes a `localStorage` accessor on `globalThis` for the
+    // experimental Web Storage flag. Because Vitest's jsdom setup only copies
+    // window props that are not already defined on the global, jsdom's real
+    // `localStorage` is skipped when Node's accessor is present, and calls
+    // like `localStorage.clear()` throw. Install a deterministic mock so the
+    // suite behaves the same on every Node/jsdom combination.
+    vi.stubGlobal("localStorage", createStorageMock());
+    vi.stubGlobal("sessionStorage", createStorageMock());
     realtimeTalkSessionCtor.mockClear();
     sessionStart.mockReset();
     sessionStart.mockResolvedValue(undefined);

--- a/ui/src/pages/chat/chat-realtime.test.ts
+++ b/ui/src/pages/chat/chat-realtime.test.ts
@@ -89,11 +89,18 @@ describe("chat realtime actions", () => {
   );
 
   it("keeps the selected input in memory when persistence fails and shares it across panes", async () => {
-    const firstPane = createState();
-    const secondPane = createState();
-    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+    // Install a fresh storage mock whose own `setItem` throws, so the
+    // persistence-blocked path is actually exercised. Spying on
+    // `Storage.prototype.setItem` would not help here because the mock
+    // returned by `createStorageMock()` defines `setItem` as an own
+    // property that shadows the prototype.
+    const failingStorage = createStorageMock();
+    vi.spyOn(failingStorage, "setItem").mockImplementation(() => {
       throw new DOMException("blocked", "SecurityError");
     });
+    vi.stubGlobal("localStorage", failingStorage);
+    const firstPane = createState();
+    const secondPane = createState();
 
     firstPane.selectRealtimeTalkInput("usb-mic");
     await secondPane.toggleRealtimeTalk();


### PR DESCRIPTION
Fixes #102568.

## What Problem This Solves

`ui/src/pages/chat/chat-realtime.test.ts` is environment-dependent: it fails 4/4 on macOS local (Node 24+), 1/4 on Blacksmith Testbox, and stays green on hosted CI. Every failing case reports `realtimeTalkSessionCtor.mock.calls: 0` for the mic-selection specs.

## Root cause

Node 24+ exposes a `localStorage` accessor on `globalThis` for the experimental Web Storage flag (`--experimental-webstorage`/`--localstorage-file`). When the flag isn't provided, reading the accessor still returns `undefined` and prints the well-known `ExperimentalWarning: localStorage is not available because --localstorage-file was not provided` line.

Vitest's jsdom environment copies window props onto the test global via `populateGlobal` (see `node_modules/vitest/dist/chunks/index.*.js`). That helper filters out any key that is already `in` the global unless the key appears on Vitest's explicit `LIVING_KEYS` + `OTHER_KEYS` allowlist — and `localStorage` / `sessionStorage` are **not** on that allowlist. So on Node 24+ jsdom's real `Storage` never lands on the test global, and the very first line of `beforeEach`:

```ts
localStorage.clear();
```

throws `TypeError: Cannot read properties of undefined (reading 'clear')`. Vitest reports it as a suite-level failure, so every `it()` in the file — including the mic-selection cases that assert on `realtimeTalkSessionCtor.mock.calls` (line 68) — is marked failed with `Number of calls: 0`, exactly matching the issue's symptom.

That explains the observed distribution:

- **macOS local (Node 24+): 4/4 fail** — accessor present, jsdom's `localStorage` is masked, whole suite explodes on `beforeEach`.
- **Blacksmith Testbox: 1/4 fail** — same accessor exists on that image; test scheduling only surfaces one instance per shard, but the underlying cause is identical.
- **Hosted CI: green** — that runner image doesn't expose the Node accessor, so jsdom's `localStorage` reaches the global normally.

## Fix

Stub deterministic `Storage` mocks in `beforeEach`, matching the pattern already used by `ui/src/app/settings.node.test.ts` (which imports `createStorageMock` from `ui/src/test-helpers/storage.ts`). This decouples the suite from whichever storage surface Node/jsdom happen to expose, so behavior is identical across every Node × jsdom combination we ship.

No production code changes — this is a test-only fix.

## Evidence

Local Node v26.0.0 + jsdom 29.1.1 (Vitest v4.1.9):

Before:
```
❯ ui ui/src/pages/chat/chat-realtime.test.ts (13 tests | 13 failed)
TypeError: Cannot read properties of undefined (reading 'clear')
  ui/src/pages/chat/chat-realtime.test.ts:56:18
```

After:
```
✓ ui ui/src/pages/chat/chat-realtime.test.ts (13 tests) 8ms

 Test Files  1 passed (1)
      Tests  13 passed (13)
```

Also confirmed the mic-selection assertions (`realtimeTalkSessionCtor.mock.calls[0][0].micDeviceId`) now match the seeded `preferred-mic` / `mic-fallback` values in all four permutations.
