### PR TITLE
fix(qa): normalize malformed JSON errors

### DIFF
--- a/extensions/qa-lab/src/bus-server.test.ts
+++ b/extensions/qa-lab/src/bus-server.test.ts
@@ -172,6 +172,19 @@ describe("qa-bus server", () => {
     });
   });
 
+  it("returns a controlled error when a v1 POST body contains malformed JSON", async () => {
+    const state = createQaBusState();
+    const bus = await startQaBusServer({ state });
+    stops.push(bus["stop"]);
+
+    const response = await postQaBusRawJson(bus.baseUrl, "/v1/reset", "{");
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Malformed JSON body",
+    });
+  });
+
   it("keeps oversized numeric poll and search fields bounded", async () => {
     const state = createQaBusState();
     const bus = await startQaBusServer({ state });

--- a/extensions/qa-lab/src/bus-server.ts
+++ b/extensions/qa-lab/src/bus-server.ts
@@ -26,6 +26,18 @@ const QA_HTTP_JSON_BODY_TIMEOUT_MS = 5_000;
 const QA_BUS_POLL_TIMEOUT_MAX_MS = 30_000;
 const QA_BUS_POLL_LIMIT_MAX = 500;
 const QA_BUS_SEARCH_LIMIT_MAX = 100;
+const QA_MALFORMED_JSON_BODY_MESSAGE = "Malformed JSON body";
+
+class QaMalformedJsonBodyError extends Error {
+  constructor() {
+    super(QA_MALFORMED_JSON_BODY_MESSAGE);
+    this.name = "QaMalformedJsonBodyError";
+  }
+}
+
+export function isQaMalformedJsonBodyError(error: unknown): error is Error {
+  return error instanceof QaMalformedJsonBodyError;
+}
 
 export async function readQaJsonBody(req: IncomingMessage): Promise<unknown> {
   const text = (
@@ -34,7 +46,14 @@ export async function readQaJsonBody(req: IncomingMessage): Promise<unknown> {
       timeoutMs: QA_HTTP_JSON_BODY_TIMEOUT_MS,
     })
   ).trim();
-  return text ? (JSON.parse(text) as unknown) : {};
+  if (!text) {
+    return {};
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new QaMalformedJsonBodyError();
+  }
 }
 
 export function writeJson(res: ServerResponse, statusCode: number, body: unknown) {

--- a/extensions/qa-lab/src/lab-server.test.ts
+++ b/extensions/qa-lab/src/lab-server.test.ts
@@ -6,12 +6,12 @@ import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readQaJsonBody } from "./bus-server.js";
+import { resolveUiAssetVersion } from "./lab-server-ui.js";
 import {
   startQaLabServer,
   writeQaLabServerError,
   type QaLabServerStartParams,
 } from "./lab-server.js";
-import { resolveUiAssetVersion } from "./lab-server-ui.js";
 
 const qaChannelMock = vi.hoisted(() => ({
   resolveAccount: vi.fn(),
@@ -637,6 +637,26 @@ describe("qa-lab server", () => {
 
     expect(res.statusCode).toBe(413);
     expect(JSON.parse(res.body)).toEqual({ error: "Payload too large" });
+  });
+
+  it("returns controlled errors for malformed JSON body reads", async () => {
+    const lab = await startQaLabServerForTest();
+    cleanups.push(async () => {
+      await lab.stop();
+    });
+
+    const response = await fetch(`${lab.baseUrl}/api/inbound/message`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: "{",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Malformed JSON body",
+    });
   });
 
   it("anchors direct self-check runs under the explicit repo root by default", async () => {

--- a/extensions/qa-lab/src/lab-server.ts
+++ b/extensions/qa-lab/src/lab-server.ts
@@ -10,6 +10,7 @@ import {
 import {
   closeQaHttpServer,
   handleQaBusRequest,
+  isQaMalformedJsonBodyError,
   readQaJsonBody,
   writeError,
   writeJson,
@@ -74,6 +75,10 @@ export type {
 
 export function writeQaLabServerError(res: Parameters<typeof writeError>[0], error: unknown): void {
   if (writeQaRequestBodyLimitError(res, error)) {
+    return;
+  }
+  if (isQaMalformedJsonBodyError(error)) {
+    writeError(res, 400, error.message);
     return;
   }
   if (error instanceof QaEvidenceGalleryError) {


### PR DESCRIPTION
## What Problem This Solves

Malformed JSON request bodies reached two different QA HTTP error paths. QA Bus could leak the raw `JSON.parse` failure shape, while QA Lab classified the same client error as an internal 500. This fixes #102055.

This is a maintainer-owned replacement for #102079. GitHub's signed fork-update API rejected the rebased contributor branch because the stale fork-to-main tree payload exceeded its 45 MB limit.

## Why This Change Was Made

The shared body reader now converts only `JSON.parse` failures into a private malformed-body error and exposes a narrow predicate for the server boundary. QA Bus returns a stable 400 JSON response directly; QA Lab maps only that marker to 400 while preserving existing status handling for payload limits, timeouts, and unknown 500 failures.

The replacement is one current-main commit with `ZengWen-DT` preserved as co-author.

## User Impact

QA Bus and QA Lab now return the same stable 400 response for malformed JSON instead of leaking parser details or reporting a server failure. Oversized and unrelated failures keep their existing behavior.

## Evidence

- Fresh branch autoreview: clean, patch correct, confidence 0.97.
- Real HTTP-path regressions cover both Bus and Lab; the existing 413 path remains covered.
- Formatting: `oxfmt --check` passed for all four touched files.
- Static hygiene: `git diff --check origin/main...HEAD` passed.
- Exact-head isolated proof and hosted CI will be attached before merge.

Supersedes #102079 while preserving contributor credit.
