### PR TITLE
fix(auto-reply): honor compat reasoning efforts for openai-completions session thinking

### DIFF
--- a/src/auto-reply/thinking.shared.ts
+++ b/src/auto-reply/thinking.shared.ts
@@ -35,6 +35,7 @@ export type ThinkingCatalogEntry = {
   params?: Record<string, unknown>;
   compat?: {
     thinkingFormat?: string;
+    supportsReasoningEffort?: boolean;
     supportedReasoningEfforts?: readonly string[] | null;
   } | null;
 };

--- a/src/auto-reply/thinking.shared.ts
+++ b/src/auto-reply/thinking.shared.ts
@@ -37,6 +37,7 @@ export type ThinkingCatalogEntry = {
     thinkingFormat?: string;
     supportsReasoningEffort?: boolean;
     supportedReasoningEfforts?: readonly string[] | null;
+    reasoningEffortMap?: Record<string, string>;
   } | null;
 };
 

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -758,6 +758,46 @@ describe("listThinkingLevels", () => {
     ).toBe("low");
   });
 
+  it("treats an empty supportedReasoningEfforts array like an omitted one", () => {
+    const catalog = [
+      {
+        provider: "free",
+        id: "gpt-5.5",
+        api: "openai-completions",
+        reasoning: true,
+        compat: { supportedReasoningEfforts: [] },
+      },
+    ];
+
+    // The profile falls back to the generic base shape because an empty array is
+    // treated as "not provided" by the canonical request resolver. Fallback
+    // clamping still delegates to that resolver, which uses model-id defaults for
+    // a gpt-5.5 id and therefore accepts xhigh.
+    expect(listThinkingLevels("free", "gpt-5.5", catalog)).toEqual([
+      "off",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+    ]);
+    expect(
+      resolveSupportedThinkingLevel({
+        provider: "free",
+        model: "gpt-5.5",
+        level: "medium",
+        catalog,
+      }),
+    ).toBe("medium");
+    expect(
+      resolveSupportedThinkingLevel({
+        provider: "free",
+        model: "gpt-5.5",
+        level: "xhigh",
+        catalog,
+      }),
+    ).toBe("xhigh");
+  });
+
   it("does not let catalog xhigh compat override binary thinking providers", () => {
     providerRuntimeMocks.resolveProviderBinaryThinking.mockReturnValue(true);
     const catalog = [

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -684,6 +684,80 @@ describe("listThinkingLevels", () => {
     ).toBe("medium");
   });
 
+  it("uses the canonical request resolver for subset-effort fallback on openai-completions", () => {
+    const catalog = [
+      {
+        provider: "free",
+        id: "gpt-5.5",
+        api: "openai-completions",
+        reasoning: true,
+        compat: { supportedReasoningEfforts: ["medium", "high"] },
+      },
+    ];
+
+    // Request resolver falls low -> medium when medium is supported.
+    expect(
+      resolveSupportedThinkingLevel({
+        provider: "free",
+        model: "gpt-5.5",
+        level: "low",
+        catalog,
+      }),
+    ).toBe("medium");
+
+    // Request resolver falls minimal -> medium when medium is supported.
+    expect(
+      resolveSupportedThinkingLevel({
+        provider: "free",
+        model: "gpt-5.5",
+        level: "minimal",
+        catalog,
+      }),
+    ).toBe("medium");
+
+    // xhigh falls back to high.
+    expect(
+      resolveSupportedThinkingLevel({
+        provider: "free",
+        model: "gpt-5.5",
+        level: "xhigh",
+        catalog,
+      }),
+    ).toBe("high");
+  });
+
+  it("preserves reasoningEffortMap parity for subset-effort fallback", () => {
+    const catalog = [
+      {
+        provider: "groq",
+        id: "qwen/qwen3-32b",
+        api: "openai-completions",
+        reasoning: true,
+        compat: {
+          supportedReasoningEfforts: ["none", "default"],
+          reasoningEffortMap: {
+            off: "none",
+            low: "default",
+            medium: "default",
+            high: "default",
+            xhigh: "default",
+          },
+        },
+      },
+    ];
+
+    // Request resolver maps minimal -> default (supported); inverse map returns
+    // the closest canonical key, which is low.
+    expect(
+      resolveSupportedThinkingLevel({
+        provider: "groq",
+        model: "qwen/qwen3-32b",
+        level: "minimal",
+        catalog,
+      }),
+    ).toBe("low");
+  });
+
   it("does not let catalog xhigh compat override binary thinking providers", () => {
     providerRuntimeMocks.resolveProviderBinaryThinking.mockReturnValue(true);
     const catalog = [

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -647,6 +647,28 @@ describe("listThinkingLevels", () => {
     expect(listThinkingLevels("free", "gpt-5.5", catalog)).toEqual(["off"]);
   });
 
+  it("treats flag-only explicit reasoning-effort disable as off-only", () => {
+    const catalog = [
+      {
+        provider: "free",
+        id: "gpt-5.5",
+        api: "openai-completions",
+        reasoning: true,
+        compat: { supportsReasoningEffort: false },
+      },
+    ];
+
+    expect(listThinkingLevels("free", "gpt-5.5", catalog)).toEqual(["off"]);
+    expect(
+      resolveSupportedThinkingLevel({
+        provider: "free",
+        model: "gpt-5.5",
+        level: "medium",
+        catalog,
+      }),
+    ).toBe("off");
+  });
+
   it("honors reasoningEffortMap for provider-native OpenAI-compatible effort labels", () => {
     const catalog = [
       {

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -647,6 +647,43 @@ describe("listThinkingLevels", () => {
     expect(listThinkingLevels("free", "gpt-5.5", catalog)).toEqual(["off"]);
   });
 
+  it("honors reasoningEffortMap for provider-native OpenAI-compatible effort labels", () => {
+    const catalog = [
+      {
+        provider: "groq",
+        id: "qwen/qwen3-32b",
+        api: "openai-completions",
+        reasoning: true,
+        compat: {
+          supportedReasoningEfforts: ["none", "default"],
+          reasoningEffortMap: {
+            off: "none",
+            low: "default",
+            medium: "default",
+            high: "default",
+            xhigh: "default",
+          },
+        },
+      },
+    ];
+
+    expect(listThinkingLevels("groq", "qwen/qwen3-32b", catalog)).toEqual([
+      "off",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+    expect(
+      resolveSupportedThinkingLevel({
+        provider: "groq",
+        model: "qwen/qwen3-32b",
+        level: "medium",
+        catalog,
+      }),
+    ).toBe("medium");
+  });
+
   it("does not let catalog xhigh compat override binary thinking providers", () => {
     providerRuntimeMocks.resolveProviderBinaryThinking.mockReturnValue(true);
     const catalog = [

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -596,6 +596,57 @@ describe("listThinkingLevels", () => {
     ).toBe(true);
   });
 
+  it("honors catalog compat reasoning efforts for openai-completions custom providers", () => {
+    const catalog = [
+      {
+        provider: "free",
+        id: "gpt-5.5",
+        name: "free gpt-5.5",
+        api: "openai-completions",
+        reasoning: true,
+        compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh"] },
+      },
+    ];
+
+    expect(listThinkingLevels("free", "gpt-5.5", catalog)).toEqual([
+      "off",
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ]);
+    expect(
+      isThinkingLevelSupported({
+        provider: "free",
+        model: "gpt-5.5",
+        level: "medium",
+        catalog,
+      }),
+    ).toBe(true);
+    expect(
+      resolveSupportedThinkingLevel({
+        provider: "free",
+        model: "gpt-5.5",
+        level: "medium",
+        catalog,
+      }),
+    ).toBe("medium");
+  });
+
+  it("treats explicit compat reasoning-effort disable as off-only for openai-completions", () => {
+    const catalog = [
+      {
+        provider: "free",
+        id: "gpt-5.5",
+        api: "openai-completions",
+        reasoning: false,
+        compat: { supportsReasoningEffort: false, supportedReasoningEfforts: [] },
+      },
+    ];
+
+    expect(listThinkingLevels("free", "gpt-5.5", catalog)).toEqual(["off"]);
+  });
+
   it("does not let catalog xhigh compat override binary thinking providers", () => {
     providerRuntimeMocks.resolveProviderBinaryThinking.mockReturnValue(true);
     const catalog = [

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -126,6 +126,11 @@ function buildOpenAICompatThinkingProfile(params: {
   const supportedEfforts = new Set(
     efforts.filter((value): value is string => typeof value === "string"),
   );
+  if (supportedEfforts.size === 0) {
+    // Empty array is treated as "not provided" by the canonical request resolver,
+    // which then falls back to model-id defaults. Match that parity here.
+    return undefined;
+  }
   const levels = new Map<ThinkLevel, RankedThinkingLevelOption>([
     ["off", { id: "off", label: "off", rank: THINKING_LEVEL_RANKS.off }],
   ]);

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -111,6 +111,35 @@ function catalogSupportsXHigh(compat: ThinkingCatalogEntry["compat"]): boolean {
   return efforts.some((effort) => normalizeThinkLevel(effort) === "xhigh");
 }
 
+function buildOpenAICompatThinkingProfile(params: {
+  compat: ThinkingCatalogEntry["compat"];
+  defaultLevel?: ThinkLevel | null;
+}): ResolvedThinkingProfile | undefined {
+  const efforts = params.compat?.supportedReasoningEfforts;
+  if (!Array.isArray(efforts)) {
+    return undefined;
+  }
+  if (params.compat?.supportsReasoningEffort === false) {
+    return buildOffOnlyThinkingProfile();
+  }
+  const levels = new Map<ThinkLevel, RankedThinkingLevelOption>([
+    ["off", { id: "off", label: "off", rank: THINKING_LEVEL_RANKS.off }],
+  ]);
+  for (const raw of efforts) {
+    const effort = normalizeThinkLevel(raw);
+    if (effort && effort !== "off" && !levels.has(effort)) {
+      levels.set(effort, { id: effort, label: effort, rank: THINKING_LEVEL_RANKS[effort] });
+    }
+  }
+  if (levels.size <= 1) {
+    return buildOffOnlyThinkingProfile();
+  }
+  const sorted = [...levels.values()].toSorted((a, b) => a.rank - b.rank);
+  const defaultLevel =
+    params.defaultLevel && levels.has(params.defaultLevel) ? params.defaultLevel : undefined;
+  return { levels: sorted, defaultLevel };
+}
+
 function normalizeProfileLevel(
   level: ProviderThinkingProfile["levels"][number],
 ): RankedThinkingLevelOption | undefined {
@@ -223,6 +252,29 @@ export function resolveThinkingProfile(params: {
   }
   if (context.reasoning === false) {
     return buildOffOnlyThinkingProfile();
+  }
+
+  // OpenAI-compatible transports advertise exact accepted reasoning efforts via
+  // compat.supportedReasoningEfforts. Use that contract for custom providers on
+  // this transport so session-level thinking controls stay consistent with the
+  // request-time reasoning-effort normalization path.
+  if (context.api === "openai-completions") {
+    const compatProfile = buildOpenAICompatThinkingProfile({
+      compat: context.compat,
+      defaultLevel:
+        resolveProviderDefaultThinkingLevel({
+          provider: context.normalizedProvider,
+          context: providerContext,
+        }) ??
+        resolveThinkingDefaultForModelFallback({
+          provider: context.normalizedProvider,
+          model: context.modelId,
+          catalog: params.catalog,
+        }),
+    });
+    if (compatProfile) {
+      return compatProfile;
+    }
   }
 
   const defaultLevel = resolveProviderDefaultThinkingLevel({

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -1,3 +1,4 @@
+import { resolveOpenAIReasoningEffortForModel } from "@openclaw/ai/internal/openai";
 // Thinking/reasoning level catalog helpers for auto-reply model controls.
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { resolveClaudeThinkingProfile } from "../plugins/provider-claude-thinking.js";
@@ -159,6 +160,63 @@ function buildOpenAICompatThinkingProfile(params: {
   const defaultLevel =
     params.defaultLevel && levels.has(params.defaultLevel) ? params.defaultLevel : undefined;
   return { levels: sorted, defaultLevel };
+}
+
+function resolveOpenAICompatSupportedThinkingLevel(params: {
+  context: ReturnType<typeof resolveThinkingPolicyContext>;
+  level: ThinkLevel;
+}): ThinkLevel | undefined {
+  const { context, level } = params;
+  if (!context.normalizedProvider || !context.modelId) {
+    return undefined;
+  }
+  const compat = context.compat;
+  if (!compat || typeof compat !== "object") {
+    return undefined;
+  }
+  const effortMap =
+    compat.reasoningEffortMap && typeof compat.reasoningEffortMap === "object"
+      ? compat.reasoningEffortMap
+      : undefined;
+  const resolvedEffort = resolveOpenAIReasoningEffortForModel({
+    model: {
+      provider: context.normalizedProvider,
+      id: context.modelId,
+      api: context.api,
+      compat,
+    },
+    effort: level,
+    fallbackMap: effortMap,
+  });
+  if (resolvedEffort === undefined) {
+    return "off";
+  }
+  // Direct canonical match.
+  const direct = normalizeThinkLevel(resolvedEffort);
+  if (direct) {
+    return direct;
+  }
+  // Inverse reasoning-effort map: choose the key that matches the requested
+  // level if possible, otherwise the closest rank.
+  if (effortMap) {
+    const candidates = Object.entries(effortMap)
+      .filter(([, value]) => value === resolvedEffort)
+      .map(([key]) => normalizeThinkLevel(key))
+      .filter((lvl): lvl is ThinkLevel => lvl !== undefined);
+    if (candidates.length > 0) {
+      if (candidates.includes(level)) {
+        return level;
+      }
+      const requestedRank = THINKING_LEVEL_RANKS[level];
+      const closest = candidates.toSorted(
+        (a, b) =>
+          Math.abs(THINKING_LEVEL_RANKS[a] - requestedRank) -
+          Math.abs(THINKING_LEVEL_RANKS[b] - requestedRank),
+      )[0];
+      return closest;
+    }
+  }
+  return undefined;
 }
 
 function normalizeProfileLevel(
@@ -454,11 +512,27 @@ export function resolveSupportedThinkingLevel(params: {
   catalog?: ThinkingCatalogEntry[];
   agentRuntime?: string | null;
 }): ThinkLevel {
+  const context = resolveThinkingPolicyContext(params);
   const profile = resolveThinkingProfile({
     provider: params.provider,
     model: params.model,
     catalog: params.catalog,
     agentRuntime: params.agentRuntime,
   });
+  if (profile.levels.some((entry) => entry.id === params.level)) {
+    return params.level;
+  }
+  // For OpenAI-compatible transports, delegate fallback to the canonical request
+  // resolver so session-level clamping matches the reasoning_effort that would be
+  // sent at request time.
+  if (context.api === "openai-completions") {
+    const compatLevel = resolveOpenAICompatSupportedThinkingLevel({
+      context,
+      level: params.level,
+    });
+    if (compatLevel !== undefined) {
+      return compatLevel;
+    }
+  }
   return resolveSupportedThinkingLevelFromProfile(profile, params.level);
 }

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -122,13 +122,34 @@ function buildOpenAICompatThinkingProfile(params: {
   if (params.compat?.supportsReasoningEffort === false) {
     return buildOffOnlyThinkingProfile();
   }
+  const supportedEfforts = new Set(
+    efforts.filter((value): value is string => typeof value === "string"),
+  );
   const levels = new Map<ThinkLevel, RankedThinkingLevelOption>([
     ["off", { id: "off", label: "off", rank: THINKING_LEVEL_RANKS.off }],
   ]);
-  for (const raw of efforts) {
+  function addCanonicalLevel(level: ThinkLevel) {
+    if (level === "off" || levels.has(level)) {
+      return;
+    }
+    levels.set(level, { id: level, label: level, rank: THINKING_LEVEL_RANKS[level] });
+  }
+  // Provider-native labels that already match canonical effort names.
+  for (const raw of supportedEfforts) {
     const effort = normalizeThinkLevel(raw);
-    if (effort && effort !== "off" && !levels.has(effort)) {
-      levels.set(effort, { id: effort, label: effort, rank: THINKING_LEVEL_RANKS[effort] });
+    if (effort) {
+      addCanonicalLevel(effort);
+    }
+  }
+  // Provider-native labels reached only through a reasoning-effort map.
+  const effortMap = params.compat?.reasoningEffortMap;
+  if (effortMap && typeof effortMap === "object") {
+    for (const raw of Object.keys(effortMap)) {
+      const level = normalizeThinkLevel(raw);
+      const mapped = effortMap[raw];
+      if (level && typeof mapped === "string" && supportedEfforts.has(mapped)) {
+        addCanonicalLevel(level);
+      }
     }
   }
   if (levels.size <= 1) {

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -116,21 +116,20 @@ function buildOpenAICompatThinkingProfile(params: {
   compat: ThinkingCatalogEntry["compat"];
   defaultLevel?: ThinkLevel | null;
 }): ResolvedThinkingProfile | undefined {
-  const efforts = params.compat?.supportedReasoningEfforts;
-  if (!Array.isArray(efforts)) {
-    return undefined;
-  }
+  // Explicit reasoning-effort disable takes precedence even when no supported
+  // efforts array is supplied.
   if (params.compat?.supportsReasoningEffort === false) {
     return buildOffOnlyThinkingProfile();
   }
-  const supportedEfforts = new Set(
-    efforts.filter((value): value is string => typeof value === "string"),
-  );
-  if (supportedEfforts.size === 0) {
+  const efforts = params.compat?.supportedReasoningEfforts;
+  if (!Array.isArray(efforts) || efforts.length === 0) {
     // Empty array is treated as "not provided" by the canonical request resolver,
     // which then falls back to model-id defaults. Match that parity here.
     return undefined;
   }
+  const supportedEfforts = new Set(
+    efforts.filter((value): value is string => typeof value === "string"),
+  );
   const levels = new Map<ThinkLevel, RankedThinkingLevelOption>([
     ["off", { id: "off", label: "off", rank: THINKING_LEVEL_RANKS.off }],
   ]);

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -814,6 +814,45 @@ describe("gateway sessions patch", () => {
     expect(entry.thinkingLevel).toBe("medium");
   });
 
+  test("accepts thinking patches mapped through reasoningEffortMap", async () => {
+    const entry = expectPatchOk(
+      await runPatch({
+        cfg: {
+          agents: {
+            defaults: {
+              model: { primary: "groq/qwen/qwen3-32b" },
+            },
+          },
+        } as OpenClawConfig,
+        patch: {
+          key: MAIN_SESSION_KEY,
+          thinkingLevel: "medium",
+        },
+        loadGatewayModelCatalog: async () => [
+          {
+            provider: "groq",
+            id: "qwen/qwen3-32b",
+            name: "Groq Qwen3 32B",
+            api: "openai-completions",
+            reasoning: true,
+            compat: {
+              supportedReasoningEfforts: ["none", "default"],
+              reasoningEffortMap: {
+                off: "none",
+                low: "default",
+                medium: "default",
+                high: "default",
+                xhigh: "default",
+              },
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(entry.thinkingLevel).toBe("medium");
+  });
+
   test("validates global patches against the selected agent", async () => {
     const entry = expectPatchOk(
       await runPatch({

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -784,6 +784,36 @@ describe("gateway sessions patch", () => {
     expect(entry.thinkingLevel).toBe("xhigh");
   });
 
+  test("accepts medium thinking patches for custom openai-completions models", async () => {
+    const entry = expectPatchOk(
+      await runPatch({
+        cfg: {
+          agents: {
+            defaults: {
+              model: { primary: "free/gpt-5.5" },
+            },
+          },
+        } as OpenClawConfig,
+        patch: {
+          key: MAIN_SESSION_KEY,
+          thinkingLevel: "medium",
+        },
+        loadGatewayModelCatalog: async () => [
+          {
+            provider: "free",
+            id: "gpt-5.5",
+            name: "free gpt-5.5",
+            api: "openai-completions",
+            reasoning: true,
+            compat: { supportedReasoningEfforts: ["low", "medium", "high", "xhigh"] },
+          },
+        ],
+      }),
+    );
+
+    expect(entry.thinkingLevel).toBe("medium");
+  });
+
   test("validates global patches against the selected agent", async () => {
     const entry = expectPatchOk(
       await runPatch({


### PR DESCRIPTION
## What Problem This Solves

Fixes #102779. Custom models using the `openai-completions` API (for example `free/gpt-5.5`) accept request-level `--thinking` values, but session-level controls such as `/think medium` or the WebUI thinking level selector reject the same values with "use off". The session profile resolver was falling back to generic base levels and did not consult the per-model `compat.supportedReasoningEfforts` contract that the request-time reasoning-effort path already uses.

## Why This Change Was Made

### Session profile from `compat.supportedReasoningEfforts`

`resolveThinkingProfile` now builds the thinking-level list from `compat.supportedReasoningEfforts` for catalog rows whose `api` is `openai-completions`, matching the provider normalization in `packages/ai/src/providers/openai-reasoning-effort.ts`. This keeps session-level thinking controls consistent with per-request reasoning controls for OpenAI-compatible custom providers.

### `reasoningEffortMap` parity

Some OpenAI-compatible backends advertise provider-native effort labels (for example `["none", "default"]`) and expose a map from canonical OpenClaw levels to those native labels. The session profile now includes the canonical levels whose mapped value appears in `supportedReasoningEfforts`, so `/think low|medium|high|xhigh` works for those models too.

### Subset-effort fallback parity

When a requested level is not directly supported, session-level clamping delegates to the canonical request resolver (`resolveOpenAIReasoningEffortForModel`) for `openai-completions` models and maps the resulting provider-native effort back to a canonical level. This makes `/think` fallback behavior identical to the reasoning effort that would be sent at request time.

### Empty `supportedReasoningEfforts` parity

An empty `supportedReasoningEfforts` array is treated as "not provided" by the session profile builder, matching the canonical request resolver (`readCompatReasoningEfforts` returns `undefined` for an empty list and falls back to model-id defaults). Fallback clamping still uses the request resolver, so unsupported requests are resolved to the same effort the provider request path would use.

### Flag-only explicit-disable precedence

`supportsReasoningEffort: false` now takes precedence even when `supportedReasoningEfforts` is omitted, producing an off-only profile. Previously a flag-only disable was ignored and the code fell back to the generic base profile.

## User Impact

Users can now set `/think low|medium|high|xhigh` (or the values advertised by the model's `compat.supportedReasoningEfforts` / `compat.reasoningEffortMap`) for custom `openai-completions` models in session state and the WebUI, instead of being forced to `off`. Requests for unsupported subset levels are clamped to the same fallback effort the provider request path uses. A model can also explicitly opt out of reasoning effort with `compat.supportsReasoningEffort: false` alone.

## Evidence

### Automated checks

- `node scripts/run-vitest.mjs src/auto-reply/thinking.test.ts --run` — 74 passed
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` — passed
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo` — passed
- `node_modules/.bin/oxlint -c .oxlintrc.json src/auto-reply/thinking.ts src/auto-reply/thinking.test.ts` — 0 warnings/errors
- `node_modules/.bin/oxfmt --check src/auto-reply/thinking.ts src/auto-reply/thinking.test.ts` — clean

### Regression tests

`src/auto-reply/thinking.test.ts` covers:
- `free/gpt-5.5` with `supportedReasoningEfforts: ["low", "medium", "high", "xhigh"]` exposes all five levels.
- Explicit `supportsReasoningEffort: false` yields off-only.
- **Flag-only** `supportsReasoningEffort: false` (no `supportedReasoningEfforts`) also yields off-only.
- `groq/qwen/qwen3-32b` with provider-native `reasoningEffortMap` exposes canonical `off/low/medium/high/xhigh`.
- Subset-effort fallback for `supportedReasoningEfforts: ["medium", "high"]` matches the canonical request resolver (`low -> medium`, `minimal -> medium`, `xhigh -> high`).
- `reasoningEffortMap` subset fallback returns the closest canonical key.
- Empty `supportedReasoningEfforts: []` is treated as omitted; fallback clamping still delegates to the canonical request resolver.

`src/gateway/sessions-patch.test.ts` covers patching `thinkingLevel: "medium"` for the direct `supportedReasoningEfforts` shape and the `reasoningEffortMap` shape.

### Real Gateway session patch transcript

Ran a standalone script that calls the production `applySessionsPatchToStore` path with the reported model configuration (no mocks for the patch logic):

```
[proof-102779] custom openai-completions model with xhigh supportedReasoningEfforts
[proof-102779]   modelRef: free/gpt-5.5
[proof-102779]   patch:    { key: "main", thinkingLevel: "xhigh" }
[proof-102779]   response: {
[proof-102779]     "ok": true,
[proof-102779]     "entry": {
[proof-102779]       "sessionId": "50803bf1-2448-4e22-880d-fa895389f4a2",
[proof-102779]       "updatedAt": 1783711210428,
[proof-102779]       "thinkingLevel": "xhigh"
[proof-102779]     }
[proof-102779]   }
[proof-102779]   => ACCEPTED

[proof-102779] flag-only supportsReasoningEffort:false rejects non-off levels
[proof-102779]   modelRef: free/gpt-5.5
[proof-102779]   patch:    { key: "main", thinkingLevel: "medium" }
[proof-102779]   response: {
[proof-102779]     "ok": false,
[proof-102779]     "error": {
[proof-102779]       "code": "INVALID_REQUEST",
[proof-102779]       "message": "thinkingLevel \"medium\" is not supported for free/gpt-5.5 (use off)"
[proof-102779]     }
[proof-102779]   }
[proof-102779]   => REJECTED
```

This demonstrates that after the fix the production session-patch path accepts `xhigh` for a custom `openai-completions` model and that a flag-only `supportsReasoningEffort: false` correctly rejects non-off levels.

### Note on TUI/WebUI visual proof

A live TUI/WebUI recording would require a configured Gateway plus a browser or PTY capture environment. The local `gh` CLI is too old to drive GitHub operations, and manually starting the Gateway/TUI here would touch the operator's local `~/.openclaw` configuration. The evidence above exercises the exact backend path (`applySessionsPatchToStore`) that the TUI and WebUI call after a level selection.

### Pre-existing test note

Two `src/gateway/sessions-patch.test.ts` tests for `openai/gpt-5.6-luna` ("persists OpenClaw Luna Ultra..." and "honors an explicit OpenClaw session runtime override for Luna Ultra") fail on the current `upstream/main` independently of this change. I verified this by stashing my changes and running the same tests; they still fail with `thinkingLevel "ultra" is not supported for openai/gpt-5.6-luna (use off|minimal|low|medium|high|xhigh|max)`.