### PR TITLE
fix(secrets): reject prototype-polluting mutation paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Secrets path safety:** reject prototype-polluting path segments before shared config mutation, including plugin wizard `uiHints`, preventing global prototype writes, inherited deletes, and partial config creation. (#102840) Thanks @yetval.
 - **CLI plugin listing:** skip state-migration runtime loading when no legacy inputs exist, reducing packaged cold-start memory while preserving migrations for legacy plugin indexes and configured session stores.
 - **Unicode-safe bounded text:** preserve complete UTF-16 surrogate pairs when shortening previews, prompts, diagnostics, labels, session keys, link metadata, and identity values across Control UI, CLI, Gateway, plugins, QA, memory, and Android surfaces. (#102625, #102626, #102627, #102656, #102816, #102823, #102833, #102877, #102949, #102963, #102969, #102988, #103010, #103034) Thanks @zhangguiping-xydt, @wings1029, @wangyan2026, @Pandah97, @MoerAI, @SunnyShu0925, @zhangqueping, @zw-xysk, @cxbAsDev, @lzyyzznl, @coder-master-0915, @LeonidasLux, @mushuiyu886, @ly85206559, and @Simon-XYDT.
 - **CLI model tables:** sanitize, truncate, and pad model-list cells by rendered terminal width so emoji, CJK, and other wide graphemes keep columns aligned. (#102819) Thanks @Kevin23-design and @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Secrets path safety:** reject prototype-polluting path segments before shared config mutation, including plugin wizard `uiHints`, preventing global prototype writes, inherited deletes, and partial config creation. (#102840) Thanks @yetval.
 - **CLI plugin listing:** skip state-migration runtime loading when no legacy inputs exist, reducing packaged cold-start memory while preserving migrations for legacy plugin indexes and configured session stores.
 - **Unicode-safe bounded text:** preserve complete UTF-16 surrogate pairs when shortening previews, prompts, diagnostics, labels, session keys, link metadata, and identity values across Control UI, CLI, Gateway, plugins, QA, memory, and Android surfaces. (#102625, #102626, #102627, #102656, #102816, #102823, #102833, #102877, #102949, #102963, #102969, #102988, #103010, #103034) Thanks @zhangguiping-xydt, @wings1029, @wangyan2026, @Pandah97, @MoerAI, @SunnyShu0925, @zhangqueping, @zw-xysk, @cxbAsDev, @lzyyzznl, @coder-master-0915, @LeonidasLux, @mushuiyu886, @ly85206559, and @Simon-XYDT.
 - **CLI model tables:** sanitize, truncate, and pad model-list cells by rendered terminal width so emoji, CJK, and other wide graphemes keep columns aligned. (#102819) Thanks @Kevin23-design and @vincentkoc.

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -511,7 +511,7 @@ Supported evidence entries:
 
 ## uiHints reference
 
-`uiHints` is a map from config field names to small rendering hints.
+`uiHints` is a map from config field names to small rendering hints. Keys can use dots for nested config fields, but no path segment may be `__proto__`, `constructor`, or `prototype`; setup rejects those names.
 
 ```json
 {

--- a/src/secrets/path-utils.test.ts
+++ b/src/secrets/path-utils.test.ts
@@ -20,6 +20,9 @@ function createAgentListConfig(): OpenClawConfig {
   });
 }
 
+const BLOCKED_PATH_SEGMENTS = ["__proto__", "constructor", "prototype"];
+const POLLUTION_PROBE = "openclawPathPollutionProbe";
+
 describe("secrets path utils", () => {
   it("deletePathStrict compacts arrays via splice", () => {
     const config = asConfig({});
@@ -54,6 +57,37 @@ describe("secrets path utils", () => {
     expect(() => setPathCreateStrict(config, ["agents", "list", "+0", "id"], "b")).toThrow(
       /Invalid path shape/,
     );
+  });
+
+  it.each(BLOCKED_PATH_SEGMENTS)(
+    "setPathCreateStrict rejects %s before creating partial containers",
+    (blockedSegment) => {
+      const config = asConfig({});
+
+      expect(() =>
+        setPathCreateStrict(config, ["safe", blockedSegment, POLLUTION_PROBE], "yes"),
+      ).toThrow(/prototype-polluting/);
+      expect(config).toEqual({});
+      expect(Object.hasOwn(Object.prototype, POLLUTION_PROBE)).toBe(false);
+    },
+  );
+
+  it.each([
+    ["leading", (blockedSegment: string) => [blockedSegment, POLLUTION_PROBE]],
+    ["middle", (blockedSegment: string) => ["safe", blockedSegment, POLLUTION_PROBE]],
+    ["leaf", (blockedSegment: string) => ["safe", "value", blockedSegment]],
+  ] as const)("all mutation helpers reject blocked segments at the %s", (_position, pathFor) => {
+    for (const blockedSegment of BLOCKED_PATH_SEGMENTS) {
+      const segments = pathFor(blockedSegment);
+      const config = asConfig({ safe: { value: "kept" } });
+
+      expect(() => setPathCreateStrict(config, segments, "changed")).toThrow(/prototype-polluting/);
+      expect(() => setPathExistingStrict(config, segments, "changed")).toThrow(
+        /prototype-polluting/,
+      );
+      expect(() => deletePathStrict(config, segments)).toThrow(/prototype-polluting/);
+      expect(config).toEqual({ safe: { value: "kept" } });
+    }
   });
 
   it("setPathExistingStrict throws when path does not already exist", () => {

--- a/src/secrets/path-utils.ts
+++ b/src/secrets/path-utils.ts
@@ -1,5 +1,6 @@
 /** Strict dotted-path get/set/delete helpers for secrets migration targets. */
 import { isDeepStrictEqual } from "node:util";
+import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import { parseConfigPathArrayIndex } from "../shared/path-array-index.js";
 import { isRecord } from "./shared.js";
 
@@ -23,6 +24,16 @@ function expectedContainer(nextSegment: string): "array" | "object" {
   return looksLikeArrayIndexSegment(nextSegment) ? "array" : "object";
 }
 
+function assertSafeMutationPath(segments: string[]): void {
+  if (segments.length === 0) {
+    throw new Error("Target path is empty.");
+  }
+  const blockedSegment = segments.find(isBlockedObjectKey);
+  if (blockedSegment) {
+    throw new Error(`Refusing to mutate prototype-polluting path segment "${blockedSegment}".`);
+  }
+}
+
 function parseArrayLeafTarget(
   cursor: unknown,
   leaf: string,
@@ -39,9 +50,7 @@ function traverseToLeafParent(params: {
   segments: string[];
   requireExistingSegment: boolean;
 }): unknown {
-  if (params.segments.length === 0) {
-    throw new Error("Target path is empty.");
-  }
+  assertSafeMutationPath(params.segments);
 
   let cursor: unknown = params.root;
   for (let index = 0; index < params.segments.length - 1; index += 1) {
@@ -108,9 +117,7 @@ export function setPathCreateStrict(
   segments: string[],
   value: unknown,
 ): boolean {
-  if (segments.length === 0) {
-    throw new Error("Target path is empty.");
-  }
+  assertSafeMutationPath(segments);
   let cursor: unknown = root;
   let changed = false;
 

--- a/src/secrets/plan.ts
+++ b/src/secrets/plan.ts
@@ -3,6 +3,7 @@ import { isRecord as isObjectRecord } from "@openclaw/normalization-core/record-
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import type { SecretProviderConfig, SecretRef } from "../config/types.secrets.js";
 import { SecretProviderSchema } from "../config/zod-schema.core.js";
+import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import { isValidSecretProviderAlias, isValidSecretRef } from "./ref-contract.js";
 import { parseDotPath, toDotPath } from "./shared.js";
 import { resolvePlanTargetAgainstRegistry, type ResolvedPlanTarget } from "./target-registry.js";
@@ -60,14 +61,8 @@ export type SecretsApplyPlan = {
   };
 };
 
-const FORBIDDEN_PATH_SEGMENTS = new Set(["__proto__", "prototype", "constructor"]);
-
 function isSecretProviderConfigShape(value: unknown): value is SecretProviderConfig {
   return SecretProviderSchema.safeParse(value).success;
-}
-
-function hasForbiddenPathSegment(segments: string[]): boolean {
-  return segments.some((segment) => FORBIDDEN_PATH_SEGMENTS.has(segment));
 }
 
 /** Resolves a user-supplied plan target through the registry after path safety checks. */
@@ -91,7 +86,7 @@ export function resolveValidatedPlanTarget(candidate: {
     Array.isArray(candidate.pathSegments) && candidate.pathSegments.length > 0
       ? normalizeStringEntries(candidate.pathSegments)
       : parseDotPath(path);
-  if (segments.length === 0 || hasForbiddenPathSegment(segments) || path !== toDotPath(segments)) {
+  if (segments.length === 0 || segments.some(isBlockedObjectKey) || path !== toDotPath(segments)) {
     return null;
   }
   // Registry resolution is the ownership gate; caller-provided paths must map to a known

--- a/src/wizard/setup.plugin-config.test.ts
+++ b/src/wizard/setup.plugin-config.test.ts
@@ -357,6 +357,43 @@ describe("setupPluginConfig", () => {
     expect(result.plugins?.entries?.brave?.config?.["webSearch.mode"]).toBeUndefined();
   });
 
+  it("rejects prototype-polluting dotted uiHint paths without mutating config", async () => {
+    const pollutionProbe = "openclawPluginPollutionProbe";
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          ...makeManifestPlugin("unsafe-plugin", {
+            [`safe.__proto__.${pollutionProbe}`]: { label: "Unsafe field" },
+          }),
+          enabledByDefault: true,
+        },
+      ],
+    });
+    const config: OpenClawConfig = {
+      plugins: { entries: { "unsafe-plugin": { enabled: true } } },
+    };
+
+    await expect(
+      setupPluginConfig({
+        config,
+        prompter: {
+          intro: vi.fn(async () => {}),
+          outro: vi.fn(async () => {}),
+          note: vi.fn(async () => {}),
+          select: vi.fn(async () => "") as unknown as WizardPrompter["select"],
+          multiselect: vi.fn(async () => [
+            "unsafe-plugin",
+          ]) as unknown as WizardPrompter["multiselect"],
+          text: vi.fn(async () => "owned") as unknown as WizardPrompter["text"],
+          confirm: vi.fn(async () => true),
+          progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+        },
+      }),
+    ).rejects.toThrow(/prototype-polluting/);
+    expect(config.plugins?.entries?.["unsafe-plugin"]?.config).toBeUndefined();
+    expect(({} as Record<string, unknown>)[pollutionProbe]).toBeUndefined();
+  });
+
   it("coerces integer schema fields from text input", async () => {
     loadPluginManifestRegistry.mockReturnValue({
       plugins: [


### PR DESCRIPTION
## What Problem This Solves

`openclaw onboard` and `openclaw configure` turn plugin `uiHints` keys into dotted config paths. The shared secrets path mutators accepted `__proto__`, `constructor`, and `prototype`; create writes could therefore mutate `Object.prototype`, and delete traversal could reach inherited prototype state.

## Why This Change Was Made

This rewrite moves the invariant to the shared mutation boundary instead of protecting only one caller:

- one `assertSafeMutationPath` guard runs before traversal or partial container creation;
- all three mutation helpers (`setPathCreateStrict`, `setPathExistingStrict`, and `deletePathStrict`) reject blocked segments at every position;
- plan validation reuses the canonical `isBlockedObjectKey` policy instead of keeping a second blocked-key table;
- regression coverage drives the real plugin-wizard ingress as well as each exported mutation primitive.
- the plugin manifest reference documents the blocked dotted-path segments.

Read-only `getPath` remains unchanged.

## User Impact

Malicious or malformed plugin metadata can no longer redirect wizard answers or secrets mutations into shared JavaScript prototype state. Valid nested object and array paths retain their existing behavior.

## Evidence

### Live before/after runtime proof

Run on Blacksmith Testbox lease `tbx_01kx4g6var40jc2kqm9ej96mxt` against the real exported TypeScript implementation, with identical input on current `main` and this exact rewrite:

```json
{"revision":"main-before","error":null,"polluted":"owned","config":{}}
{"revision":"rewritten-after","error":"Error: Refusing to mutate prototype-polluting path segment \"__proto__\".","polluted":null,"config":{}}
```

The baseline left the intended config empty while a fresh object inherited the injected value. The rewritten path throws before mutation; both the config and `Object.prototype` remain clean.

### Automated proof

- Blacksmith Testbox focused run: `38` tests passed across `src/secrets/path-utils.test.ts`, `src/secrets/plan.test.ts`, and `src/wizard/setup.plugin-config.test.ts`.
- `pnpm format:check` passed for the four code/test files and the manifest documentation; `pnpm docs:list` also passed.
- remote `pnpm check:changed` passed: core and core-test typechecks, changed-file lint, import cycles, database/storage guards, dependency/patch guards, and repository policy checks.
- fresh structured autoreview: clean, no accepted or actionable findings (`overall_correctness: patch is correct`, confidence `0.98`).
- `git diff --check`: clean.

No screenshot is applicable: this is a non-visual security boundary. The focused wizard test drives the production onboarding/configuration path with malicious dotted `uiHints`; the separate live probe proves the runtime mutation and its elimination without mocks.
