### PR TITLE
refactor(ui): simplify Lit state ownership

### DIFF
--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -35,14 +35,12 @@ type ShellEpochState = {
   navDrawerTrigger: HTMLElement | null;
   lastWorkspaceLocation: { routeId: string; search: string } | null;
   activeSessionKey: string;
-  agentLabel: string;
   commandPaletteTarget: unknown;
   agentsListClient: GatewayBrowserClient | null;
   agentsListSource: ApplicationContext["agents"] | null;
   sessionKeyClient: GatewayBrowserClient | null;
   runtimeConfigClient: GatewayBrowserClient | null;
   runtimeConfigSource: ApplicationContext["runtimeConfig"] | null;
-  terminalClient: GatewayBrowserClient | null;
   settingsPreloadTimers: Map<EventTarget, ReturnType<typeof globalThis.setTimeout>>;
   disconnectedCallback: () => void;
 };
@@ -104,14 +102,12 @@ describe("OpenClaw shell source initialization", () => {
     shell.navDrawerTrigger = trigger;
     shell.lastWorkspaceLocation = { routeId: "overview", search: "?agent=old" };
     shell.activeSessionKey = "agent:old:main";
-    shell.agentLabel = "Old agent";
     shell.commandPaletteTarget = {};
     shell.agentsListClient = client;
     shell.agentsListSource = agents;
     shell.sessionKeyClient = client;
     shell.runtimeConfigClient = client;
     shell.runtimeConfigSource = runtimeConfig;
-    shell.terminalClient = client;
     shell.settingsPreloadTimers.set(
       trigger,
       globalThis.setTimeout(() => undefined, 60_000),
@@ -123,14 +119,12 @@ describe("OpenClaw shell source initialization", () => {
     expect(shell.navDrawerTrigger).toBeNull();
     expect(shell.lastWorkspaceLocation).toBeNull();
     expect(shell.activeSessionKey).toBe("");
-    expect(shell.agentLabel).toBe("");
     expect(shell.commandPaletteTarget).toBeUndefined();
     expect(shell.agentsListClient).toBeNull();
     expect(shell.agentsListSource).toBeNull();
     expect(shell.sessionKeyClient).toBeNull();
     expect(shell.runtimeConfigClient).toBeNull();
     expect(shell.runtimeConfigSource).toBeNull();
-    expect(shell.terminalClient).toBeNull();
     expect(shell.settingsPreloadTimers.size).toBe(0);
   });
 

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -1,4 +1,4 @@
-import { consume, ContextProvider } from "@lit/context";
+import { ContextProvider } from "@lit/context";
 import type { RouteLocation, RouterState } from "@openclaw/uirouter";
 import { html, nothing } from "lit";
 import { property, query, state } from "lit/decorators.js";
@@ -42,10 +42,9 @@ import {
   type ApplicationNavigationOptions,
 } from "./context.ts";
 import { hasOperatorAdminAccess } from "./operator-access.ts";
-import type { ApplicationOverlaySnapshot } from "./overlays.ts";
 import { controlUiPublicAssetPath } from "./public-assets.ts";
 import { selectRenderedRouteMatch } from "./router-outlet.ts";
-import { NAV_WIDTH_DEFAULT, NAV_WIDTH_MAX, NAV_WIDTH_MIN } from "./settings.ts";
+import { NAV_WIDTH_MAX, NAV_WIDTH_MIN } from "./settings.ts";
 
 type ShellRouteState = {
   routeId?: RouteId;
@@ -137,10 +136,6 @@ function isMobileNavLayout(): boolean {
 }
 
 class OpenClawApp extends OpenClawLightDomElement {
-  @state() private gatewayConnected = false;
-  @state() private gatewayReconnecting = false;
-  @state() private gatewayLastError: string | null = null;
-  @state() private gatewayLastErrorCode: string | null = null;
   // Pinned while a connect submitted from the visible login gate is in
   // flight, so a failed manual attempt cannot flash the shell in between.
   @state() private loginGatePinned = false;
@@ -151,8 +146,6 @@ class OpenClawApp extends OpenClawLightDomElement {
   @state() private loginShowGatewayPassword = false;
   @state() private pendingGatewayUrl: string | null = null;
   @state() private onboarding = resolveOnboardingMode();
-  @state() private terminalAvailable = false;
-  @state() private terminalClient: GatewayBrowserClient | null = null;
 
   private readonly terminalOnly = isTerminalOnlyView();
   // Fixed at page load: whether this browser held credentials (token,
@@ -160,13 +153,16 @@ class OpenClawApp extends OpenClawLightDomElement {
   // Later manual gate submissions are covered by loginGatePinned instead.
   private initialAuthPresent = false;
   private runtime: ApplicationRuntime | undefined;
-  private context: ApplicationContext<RouteId> | undefined;
   private readonly contextProvider = new ContextProvider(this, {
     context: applicationContext,
   });
   private readonly subscriptions = new SubscriptionsController(this);
   private loginGatewaySource: ApplicationContext["gateway"] | null = null;
   private loginConnectionClient: GatewayBrowserClient | null = null;
+
+  private get context(): ApplicationContext<RouteId> | undefined {
+    return this.runtime?.context;
+  }
 
   constructor() {
     super();
@@ -179,7 +175,6 @@ class OpenClawApp extends OpenClawLightDomElement {
       .watch(
         () => (this.terminalOnly ? this.context?.config : undefined),
         (config, notify) => config.subscribe(notify),
-        () => this.updateTerminalSurface(),
       );
   }
 
@@ -187,12 +182,12 @@ class OpenClawApp extends OpenClawLightDomElement {
     super.connectedCallback();
     this.resetLoginSensitivePresentation();
     this.runtime = bootstrapApplication();
-    this.context = this.runtime.context;
-    this.initialAuthPresent = hasStoredGatewayAuth(this.context.gateway.connection);
+    const context = this.runtime.context;
+    this.initialAuthPresent = hasStoredGatewayAuth(context.gateway.connection);
     this.pendingGatewayUrl = this.runtime.pendingGatewayConnection?.gatewayUrl ?? null;
     // Context identity changes only across a full app-tree connection epoch;
     // descendants reconnect and rebuild their controller-owned state afterward.
-    this.contextProvider.setValue(this.context);
+    this.contextProvider.setValue(context);
     this.syncLoginConnection();
     // The runtime is created after controller hostConnected hooks run. Ensure
     // their lazy source getters bind on both the initial mount and reconnect.
@@ -207,7 +202,6 @@ class OpenClawApp extends OpenClawLightDomElement {
     this.subscriptions.clear();
     this.runtime?.stop();
     this.runtime = undefined;
-    this.context = undefined;
     this.loginGatewaySource = null;
     this.loginConnectionClient = null;
     this.pendingGatewayUrl = null;
@@ -231,8 +225,9 @@ class OpenClawApp extends OpenClawLightDomElement {
     if (sourceChanged || clientChanged) {
       this.syncLoginConnection(gateway);
     }
-    this.updateGatewayStatus(snapshot);
-    this.updateTerminalSurface();
+    if (snapshot.connected) {
+      this.loginGatePinned = false;
+    }
   }
 
   private syncLoginConnection(gateway = this.context?.gateway) {
@@ -250,39 +245,13 @@ class OpenClawApp extends OpenClawLightDomElement {
     this.loginShowGatewayPassword = false;
   }
 
-  private readonly updateGatewayStatus = (snapshot: {
-    connected: boolean;
-    reconnecting: boolean;
-    lastError: string | null;
-    lastErrorCode: string | null;
-  }) => {
-    this.gatewayConnected = snapshot.connected;
-    this.gatewayReconnecting = snapshot.reconnecting;
-    this.gatewayLastError = snapshot.lastError;
-    this.gatewayLastErrorCode = snapshot.lastErrorCode;
-    if (snapshot.connected) {
-      this.loginGatePinned = false;
-    }
-  };
-
-  private updateTerminalSurface() {
-    if (!this.terminalOnly || !this.context) {
-      return;
-    }
-    const snapshot = this.context.gateway.snapshot;
-    this.terminalClient = snapshot.connected ? snapshot.client : null;
-    this.terminalAvailable = isTerminalAvailable(
-      snapshot,
-      this.context.config.current.terminalEnabled ?? false,
-    );
-  }
-
   override render() {
     const context = this.context;
     const runtime = this.runtime;
     if (!context || !runtime) {
       return html`<main class="app-shell app-shell--booting" aria-busy="true"></main>`;
     }
+    const gatewaySnapshot = context.gateway.snapshot;
     const gatewayUrlConfirmation = this.pendingGatewayUrl
       ? html`
           <openclaw-gateway-url-confirmation
@@ -303,14 +272,18 @@ class OpenClawApp extends OpenClawLightDomElement {
     // Embedded mobile terminals own the whole document. Keep the generic login
     // gate out of this path or a connecting native session exposes Web UI chrome.
     if (this.terminalOnly) {
+      const terminalAvailable = isTerminalAvailable(
+        gatewaySnapshot,
+        context.config.current.terminalEnabled ?? false,
+      );
       return html`
         <openclaw-terminal-panel
-          .client=${this.terminalClient}
-          .available=${this.terminalAvailable}
+          .client=${gatewaySnapshot.connected ? gatewaySnapshot.client : null}
+          .available=${terminalAvailable}
           .themeMode=${resolveTerminalThemeMode()}
           fullscreen
         ></openclaw-terminal-panel>
-        ${!this.terminalAvailable && (this.gatewayConnected || this.gatewayLastError)
+        ${!terminalAvailable && (gatewaySnapshot.connected || gatewaySnapshot.lastError)
           ? html`<div class="terminal-view-unavailable">${t("terminal.unavailable")}</div>`
           : nothing}
       `;
@@ -323,11 +296,11 @@ class OpenClawApp extends OpenClawLightDomElement {
     // the moment the attempt fails (lastError set on every close).
     const initialConnectPending =
       this.initialAuthPresent &&
-      !this.gatewayConnected &&
-      !this.gatewayReconnecting &&
+      !gatewaySnapshot.connected &&
+      !gatewaySnapshot.reconnecting &&
       !this.loginGatePinned &&
-      this.gatewayLastError === null &&
-      context.gateway.snapshot.client !== null;
+      gatewaySnapshot.lastError === null &&
+      gatewaySnapshot.client !== null;
     if (initialConnectPending) {
       return html`
         <openclaw-tooltip-provider>
@@ -336,16 +309,16 @@ class OpenClawApp extends OpenClawLightDomElement {
       `;
     }
     const showLoginGate =
-      !this.gatewayConnected && (this.loginGatePinned || !this.gatewayReconnecting);
+      !gatewaySnapshot.connected && (this.loginGatePinned || !gatewaySnapshot.reconnecting);
     if (showLoginGate) {
       return html`
         <openclaw-tooltip-provider>
           <openclaw-login-gate
             .props=${{
               basePath: context.basePath,
-              connected: this.gatewayConnected,
-              lastError: this.gatewayLastError,
-              lastErrorCode: this.gatewayLastErrorCode,
+              connected: gatewaySnapshot.connected,
+              lastError: gatewaySnapshot.lastError,
+              lastErrorCode: gatewaySnapshot.lastErrorCode,
               hasToken: Boolean(this.loginToken.trim()),
               hasPassword: Boolean(this.loginPassword.trim()),
               gatewayUrl: this.loginGatewayUrl,
@@ -384,7 +357,7 @@ class OpenClawApp extends OpenClawLightDomElement {
     }
     return html`
       <openclaw-tooltip-provider>
-        <openclaw-github-link-hovercard-provider .client=${context.gateway.snapshot.client}>
+        <openclaw-github-link-hovercard-provider .client=${gatewaySnapshot.client}>
           ${gatewayUrlConfirmation}
           <openclaw-app-shell
             .runtime=${runtime}
@@ -399,34 +372,10 @@ class OpenClawApp extends OpenClawLightDomElement {
 class OpenClawShell extends OpenClawLightDomElement {
   @property({ attribute: false }) runtime?: ApplicationRuntime;
   @property({ attribute: false }) onboarding = false;
-  @consume({ context: applicationContext, subscribe: true })
-  private context?: ApplicationContext<RouteId>;
 
-  @state() private navCollapsed = false;
-  @state() private navWidth = NAV_WIDTH_DEFAULT;
-  @state() private sidebarPinnedRoutes: readonly SidebarNavRoute[] = [];
-  @state() private sidebarMoreExpanded = false;
   @state() private navDrawerOpen = false;
-  @state() private gatewayConnected = false;
-  @state() private gatewayLastError: string | null = null;
-  @state() private terminalAvailable = false;
-  @state() private terminalClient: GatewayBrowserClient | null = null;
   @state() private activeSessionKey = "";
-  @state() private agentLabel = "";
   @state() private routeState: ShellRouteState = {};
-  @state() private overlaySnapshot: ApplicationOverlaySnapshot = {
-    updateAvailable: null,
-    updateRunning: false,
-    updateStatusBanner: null,
-    approvalQueue: [],
-    approvalBusy: false,
-    approvalError: null,
-    devicePairSetupOpen: false,
-    devicePairSetupLoading: false,
-    devicePairSetupError: null,
-    devicePairSetup: null,
-    devicePairPendingCount: 0,
-  };
   @query("openclaw-command-palette") private commandPalette?: CommandPalette;
   private commandPaletteTarget?: CommandPaletteTargetDetail;
   private navDrawerTrigger: HTMLElement | null = null;
@@ -444,6 +393,10 @@ class OpenClawShell extends OpenClawLightDomElement {
   >();
   private readonly subscriptions = new SubscriptionsController(this);
 
+  private get context(): ApplicationContext<RouteId> | undefined {
+    return this.runtime?.context;
+  }
+
   constructor() {
     super();
     this.subscriptions
@@ -454,7 +407,6 @@ class OpenClawShell extends OpenClawLightDomElement {
       .watch(
         () => this.context?.navigation,
         (navigation, notify) => navigation.subscribe(notify),
-        (navigation) => this.updateNavigationPreferences(navigation.snapshot),
       )
       .watch(
         () => this.context?.gateway,
@@ -464,12 +416,6 @@ class OpenClawShell extends OpenClawLightDomElement {
       .watch(
         () => this.context?.config,
         (config, notify) => config.subscribe(notify),
-        () => {
-          const snapshot = this.context?.gateway.snapshot;
-          if (snapshot) {
-            this.updateTerminalSurface(snapshot);
-          }
-        },
       )
       .watch(
         () => this.context?.theme,
@@ -479,7 +425,6 @@ class OpenClawShell extends OpenClawLightDomElement {
         () => this.context?.agents,
         (agents, notify) => agents.subscribe(notify),
         (agents) => {
-          this.updateAgentLabel();
           const snapshot = this.context?.gateway.snapshot;
           if (snapshot) {
             this.ensureAgentsList(snapshot, agents);
@@ -500,9 +445,6 @@ class OpenClawShell extends OpenClawLightDomElement {
       .watch(
         () => this.context?.overlays,
         (overlays, notify) => overlays.subscribe(notify),
-        (overlays) => {
-          this.overlaySnapshot = overlays.snapshot;
-        },
       )
       .watch(
         () => this.context?.runtimeConfig,
@@ -536,14 +478,12 @@ class OpenClawShell extends OpenClawLightDomElement {
     this.navDrawerTrigger = null;
     this.lastWorkspaceLocation = null;
     this.activeSessionKey = "";
-    this.agentLabel = "";
     this.commandPaletteTarget = undefined;
     this.agentsListClient = null;
     this.agentsListSource = null;
     this.sessionKeyClient = null;
     this.runtimeConfigClient = null;
     this.runtimeConfigSource = null;
-    this.terminalClient = null;
     for (const timer of this.settingsPreloadTimers.values()) {
       globalThis.clearTimeout(timer);
     }
@@ -611,7 +551,7 @@ class OpenClawShell extends OpenClawLightDomElement {
     }
     // A drawer that survived a breakpoint change is visually expanded even
     // when the persisted desktop preference says collapsed.
-    const nextNavCollapsed = this.navDrawerOpen || !this.navCollapsed;
+    const nextNavCollapsed = this.navDrawerOpen || !context.navigation.snapshot.navCollapsed;
     this.closeNavDrawer();
     context.navigation.update({
       navCollapsed: nextNavCollapsed,
@@ -692,10 +632,11 @@ class OpenClawShell extends OpenClawLightDomElement {
    * palette, menus, and text inputs keep their native dismiss/blur behavior.
    */
   private shouldIgnoreSettingsEscape(event: KeyboardEvent): boolean {
+    const overlaySnapshot = this.context?.overlays.snapshot;
     if (
       this.commandPalette?.isOpen ||
-      this.overlaySnapshot.devicePairSetupOpen ||
-      this.overlaySnapshot.approvalQueue.length > 0 ||
+      overlaySnapshot?.devicePairSetupOpen ||
+      (overlaySnapshot?.approvalQueue.length ?? 0) > 0 ||
       document.querySelector("dialog[open]")
     ) {
       return true;
@@ -742,33 +683,8 @@ class OpenClawShell extends OpenClawLightDomElement {
 
   private synchronizeGateway(snapshot: ApplicationContext["gateway"]["snapshot"]) {
     this.updateGatewaySessionKey(snapshot);
-    this.updateGatewayStatus(snapshot);
-    this.updateTerminalSurface(snapshot);
-    this.updateAgentLabel();
     this.ensureAgentsList(snapshot);
     this.ensureRuntimeConfig(snapshot);
-  }
-
-  private readonly updateGatewayStatus = (snapshot: {
-    connected: boolean;
-    lastError: string | null;
-  }) => {
-    if (
-      snapshot.connected === this.gatewayConnected &&
-      snapshot.lastError === this.gatewayLastError
-    ) {
-      return;
-    }
-    this.gatewayConnected = snapshot.connected;
-    this.gatewayLastError = snapshot.lastError;
-  };
-
-  private updateTerminalSurface(snapshot: ApplicationContext["gateway"]["snapshot"]) {
-    this.terminalClient = snapshot.connected ? snapshot.client : null;
-    this.terminalAvailable = isTerminalAvailable(
-      snapshot,
-      this.context?.config.current.terminalEnabled ?? false,
-    );
   }
 
   private ensureRuntimeConfig(
@@ -832,19 +748,7 @@ class OpenClawShell extends OpenClawLightDomElement {
     this.sessionKeyClient = snapshot.client;
     if (sessionKey) {
       this.activeSessionKey = sessionKey;
-      this.updateAgentLabel();
     }
-  }
-
-  private updateAgentLabel() {
-    const context = this.context;
-    if (!context) {
-      return;
-    }
-    this.agentLabel = resolveAgentLabel(
-      this.activeSessionKey || context.gateway.snapshot.sessionKey,
-      context.agents.state.agentsList,
-    );
   }
 
   private updateRouteState(routeState: ShellRouteState) {
@@ -865,18 +769,8 @@ class OpenClawShell extends OpenClawLightDomElement {
     const sessionKey = new URLSearchParams(routeState.location?.search).get("session")?.trim();
     if (sessionKey) {
       this.activeSessionKey = sessionKey;
-      this.updateAgentLabel();
     }
   }
-
-  private readonly updateNavigationPreferences = (
-    snapshot: ApplicationRuntime["context"]["navigation"]["snapshot"],
-  ) => {
-    this.navCollapsed = snapshot.navCollapsed;
-    this.navWidth = snapshot.navWidth;
-    this.sidebarPinnedRoutes = snapshot.sidebarPinnedRoutes;
-    this.sidebarMoreExpanded = snapshot.sidebarMoreExpanded;
-  };
 
   override render() {
     const context = this.context;
@@ -884,6 +778,17 @@ class OpenClawShell extends OpenClawLightDomElement {
     if (!context || !runtime) {
       return nothing;
     }
+    const gatewaySnapshot = context.gateway.snapshot;
+    const navigationSnapshot = context.navigation.snapshot;
+    const overlaySnapshot = context.overlays.snapshot;
+    const terminalAvailable = isTerminalAvailable(
+      gatewaySnapshot,
+      context.config.current.terminalEnabled ?? false,
+    );
+    const agentLabel = resolveAgentLabel(
+      this.activeSessionKey || gatewaySnapshot.sessionKey,
+      context.agents.state.agentsList,
+    );
     const activeRoute = this.routeState.routeId ?? "chat";
     // Plugin tabs share one route; the search picks the active item.
     const activePluginTabId =
@@ -895,7 +800,7 @@ class OpenClawShell extends OpenClawLightDomElement {
     // Drawer navigation always opens expanded; the desktop collapse preference
     // stays persisted for when the viewport returns to the desktop layout.
     // The settings sidebar has a fixed width, so the collapse state pauses too.
-    const navCollapsed = this.navCollapsed && !navDrawerOpen && !settingsTakeover;
+    const navCollapsed = navigationSnapshot.navCollapsed && !navDrawerOpen && !settingsTakeover;
     const shellWidth = Math.max(globalThis.innerWidth || 0, NAV_WIDTH_MAX);
     return html`
       <openclaw-command-palette
@@ -912,7 +817,7 @@ class OpenClawShell extends OpenClawLightDomElement {
           : ""} ${navDrawerOpen ? "shell--nav-drawer-open" : ""} ${this.onboarding
           ? "shell--onboarding"
           : ""} ${settingsTakeover ? "shell--settings" : ""}"
-        style=${`--shell-nav-expanded-width: ${this.navWidth}px`}
+        style=${`--shell-nav-expanded-width: ${navigationSnapshot.navWidth}px`}
         @keydown=${this.handleShellKeydown}
         @theme-change=${this.handleThemeChange}
       >
@@ -925,7 +830,7 @@ class OpenClawShell extends OpenClawLightDomElement {
         <openclaw-app-topbar
           .routeId=${activeRoute}
           .basePath=${context.basePath}
-          .agentLabel=${this.agentLabel}
+          .agentLabel=${agentLabel}
           .overviewHref=${pathForRoute("overview", context.basePath)}
           .searchDisabled=${false}
           .navDrawerOpen=${navDrawerOpen}
@@ -940,10 +845,10 @@ class OpenClawShell extends OpenClawLightDomElement {
             ? renderSettingsSidebar({
                 basePath: context.basePath,
                 activeRouteId: activeRoute,
-                connected: this.gatewayConnected,
+                connected: gatewaySnapshot.connected,
                 version:
                   context.config.current.serverVersion ??
-                  context.gateway.snapshot.hello?.server?.version ??
+                  gatewaySnapshot.hello?.server?.version ??
                   "",
                 onExit: () => this.exitSettings(),
                 onNavigate: (routeId) => this.navigate(routeId),
@@ -957,11 +862,11 @@ class OpenClawShell extends OpenClawLightDomElement {
                 .enabledRouteIds=${this.enabledRouteIds()}
                 .sessionKey=${this.activeSessionKey}
                 .collapsed=${navCollapsed}
-                .connected=${this.gatewayConnected}
-                .canPairDevice=${this.gatewayConnected &&
-                hasOperatorAdminAccess(context.gateway.snapshot.hello?.auth ?? null)}
-                .sidebarPinnedRoutes=${this.sidebarPinnedRoutes}
-                .sidebarMoreExpanded=${this.sidebarMoreExpanded}
+                .connected=${gatewaySnapshot.connected}
+                .canPairDevice=${gatewaySnapshot.connected &&
+                hasOperatorAdminAccess(gatewaySnapshot.hello?.auth ?? null)}
+                .sidebarPinnedRoutes=${navigationSnapshot.sidebarPinnedRoutes}
+                .sidebarMoreExpanded=${navigationSnapshot.sidebarMoreExpanded}
                 .themeMode=${context.theme.mode}
                 .onOpenPalette=${this.openPalette}
                 .onToggleSidebar=${() => this.toggleNavigationSurface()}
@@ -983,10 +888,10 @@ class OpenClawShell extends OpenClawLightDomElement {
               <resizable-divider
                 class="sidebar-resizer"
                 .label=${t("nav.resize")}
-                .splitRatio=${this.navWidth / shellWidth}
+                .splitRatio=${navigationSnapshot.navWidth / shellWidth}
                 .minRatio=${NAV_WIDTH_MIN / shellWidth}
                 .maxRatio=${NAV_WIDTH_MAX / shellWidth}
-                aria-valuetext=${`${this.navWidth} pixels`}
+                aria-valuetext=${`${navigationSnapshot.navWidth} pixels`}
                 title=${t("nav.resize")}
                 @resize=${(event: CustomEvent<{ splitRatio: number }>) =>
                   this.resizeNavigation(event.detail.splitRatio)}
@@ -999,20 +904,20 @@ class OpenClawShell extends OpenClawLightDomElement {
             ? "content--workboard"
             : ""}"
         >
-          ${this.gatewayConnected
+          ${gatewaySnapshot.connected
             ? nothing
             : html`<openclaw-connection-banner
                 .props=${{
-                  lastError: this.gatewayLastError,
+                  lastError: gatewaySnapshot.lastError,
                   onRetry: () => context.gateway.connect(),
                 }}
               ></openclaw-connection-banner>`}
           <openclaw-update-banner
             .props=${{
-              statusBanner: this.overlaySnapshot.updateStatusBanner,
-              updateAvailable: this.overlaySnapshot.updateAvailable,
-              updateRunning: this.overlaySnapshot.updateRunning,
-              connected: this.gatewayConnected,
+              statusBanner: overlaySnapshot.updateStatusBanner,
+              updateAvailable: overlaySnapshot.updateAvailable,
+              updateRunning: overlaySnapshot.updateRunning,
+              connected: gatewaySnapshot.connected,
               onUpdate: () => context.overlays.runUpdate(),
               onDismiss: () => context.overlays.dismissUpdate(),
             }}
@@ -1024,25 +929,25 @@ class OpenClawShell extends OpenClawLightDomElement {
           ></openclaw-router-outlet>
         </main>
         <openclaw-terminal-panel
-          .client=${this.terminalClient}
-          .available=${this.terminalAvailable}
+          .client=${gatewaySnapshot.connected ? gatewaySnapshot.client : null}
+          .available=${terminalAvailable}
           .themeMode=${resolveTerminalThemeMode()}
         ></openclaw-terminal-panel>
         <openclaw-exec-approval
           .props=${{
-            queue: this.overlaySnapshot.approvalQueue,
-            busy: this.overlaySnapshot.approvalBusy,
-            error: this.overlaySnapshot.approvalError,
+            queue: overlaySnapshot.approvalQueue,
+            busy: overlaySnapshot.approvalBusy,
+            error: overlaySnapshot.approvalError,
             onDecision: (decision: Parameters<typeof context.overlays.decideApproval>[0]) =>
               context.overlays.decideApproval(decision),
           }}
         ></openclaw-exec-approval>
         ${renderDevicePairSetup({
-          open: this.overlaySnapshot.devicePairSetupOpen,
-          loading: this.overlaySnapshot.devicePairSetupLoading,
-          error: this.overlaySnapshot.devicePairSetupError,
-          setup: this.overlaySnapshot.devicePairSetup,
-          pendingCount: this.overlaySnapshot.devicePairPendingCount,
+          open: overlaySnapshot.devicePairSetupOpen,
+          loading: overlaySnapshot.devicePairSetupLoading,
+          error: overlaySnapshot.devicePairSetupError,
+          setup: overlaySnapshot.devicePairSetup,
+          pendingCount: overlaySnapshot.devicePairPendingCount,
           onRefresh: () => void context.overlays.refreshDevicePairSetup(),
           onClose: () => context.overlays.closeDevicePairSetup(),
           onCopy: (setupCode) => void copyToClipboard(setupCode),

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -70,7 +70,7 @@ import {
   resolveSessionAgentFilterOptions,
 } from "../lib/sessions/session-options.ts";
 import { normalizeOptionalString } from "../lib/string-coerce.ts";
-import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
+import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import { getSafeLocalStorage } from "../local-storage.ts";
 import { pluginTabKey, pluginTabSearch } from "../pages/plugin/route.ts";
@@ -165,7 +165,7 @@ function shouldHandleNavigationClick(event: MouseEvent): boolean {
   );
 }
 
-class AppSidebar extends OpenClawLightDomElement {
+class AppSidebar extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) basePath = "";
   @property({ attribute: false }) activeRouteId?: NavigationRouteId;
   @property({ attribute: false }) activePluginTabId = "";
@@ -243,11 +243,6 @@ class AppSidebar extends OpenClawLightDomElement {
         () => this.context?.agentSelection,
         (agentSelection, notify) => agentSelection.subscribe(notify),
       );
-  }
-
-  override connectedCallback() {
-    super.connectedCallback();
-    this.style.display = "contents";
   }
 
   override disconnectedCallback() {

--- a/ui/src/components/app-topbar.ts
+++ b/ui/src/components/app-topbar.ts
@@ -3,12 +3,12 @@ import { property } from "lit/decorators.js";
 import type { NavigationRouteId } from "../app-navigation.ts";
 import { controlUiPublicAssetPath } from "../app/public-assets.ts";
 import { t } from "../i18n/index.ts";
-import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
+import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import { icons } from "./icons.ts";
 import "./dashboard-header.ts";
 import "./tooltip.ts";
 
-class AppTopbar extends OpenClawLightDomElement {
+class AppTopbar extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) routeId?: NavigationRouteId;
   @property({ attribute: false }) navDrawerOpen = false;
   @property({ attribute: false }) onboarding = false;
@@ -19,11 +19,6 @@ class AppTopbar extends OpenClawLightDomElement {
   @property({ attribute: false }) onOpenPalette?: () => void;
   @property({ attribute: false }) onNavigate?: (routeId: NavigationRouteId) => void;
   @property({ attribute: false }) searchDisabled = false;
-
-  override connectedCallback() {
-    super.connectedCallback();
-    this.style.display = "contents";
-  }
 
   private readonly handleNavigate = (event: CustomEvent<NavigationRouteId>) => {
     this.onNavigate?.(event.detail);

--- a/ui/src/components/command-palette.ts
+++ b/ui/src/components/command-palette.ts
@@ -10,7 +10,7 @@ import { formatRelativeTimestamp } from "../lib/format.ts";
 import { resolveSessionDisplayName } from "../lib/session-display.ts";
 import { getVisibleSessionRows } from "../lib/sessions/index.ts";
 import { normalizeLowercaseStringOrEmpty, normalizeOptionalString } from "../lib/string-coerce.ts";
-import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
+import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import { icons, type IconName } from "./icons.ts";
 
@@ -424,7 +424,7 @@ function renderCommandPalette(props: CommandPaletteProps) {
   `;
 }
 
-export class CommandPalette extends OpenClawLightDomElement {
+export class CommandPalette extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) onNavigate?: (routeId: RouteId) => void;
   @property({ attribute: false }) onSelectSession?: (sessionKey: string) => void;
   @property({ attribute: false }) onSlashCommand?: (command: string) => void;
@@ -455,7 +455,6 @@ export class CommandPalette extends OpenClawLightDomElement {
 
   override connectedCallback() {
     super.connectedCallback();
-    this.style.display = "contents";
     document.addEventListener("keydown", this.handleGlobalKeydown);
   }
 

--- a/ui/src/components/connection-banner.ts
+++ b/ui/src/components/connection-banner.ts
@@ -3,7 +3,7 @@
 import { html, nothing } from "lit";
 import { property } from "lit/decorators.js";
 import { t } from "../i18n/index.ts";
-import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
+import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import { redactLoginFailureError } from "./login-gate.ts";
 
 type ConnectionBannerProps = {
@@ -29,13 +29,8 @@ function renderConnectionBanner(props: ConnectionBannerProps) {
   `;
 }
 
-class ConnectionBanner extends OpenClawLightDomElement {
+class ConnectionBanner extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) props?: ConnectionBannerProps;
-
-  override connectedCallback() {
-    super.connectedCallback();
-    this.style.display = "contents";
-  }
 
   override render() {
     return this.props ? renderConnectionBanner(this.props) : nothing;

--- a/ui/src/components/exec-approval.ts
+++ b/ui/src/components/exec-approval.ts
@@ -9,7 +9,7 @@ import type {
 } from "../app/exec-approval.ts";
 import "./modal-dialog.ts";
 import { t } from "../i18n/index.ts";
-import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
+import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 
 const DEFAULT_EXEC_APPROVAL_DECISIONS = [
   "allow-once",
@@ -225,13 +225,8 @@ function renderExecApprovalPrompt(props: ExecApprovalProps) {
   `;
 }
 
-class ExecApproval extends OpenClawLightDomElement {
+class ExecApproval extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) props?: ExecApprovalProps;
-
-  override connectedCallback() {
-    super.connectedCallback();
-    this.style.display = "contents";
-  }
 
   override render() {
     return this.props ? renderExecApprovalPrompt(this.props) : nothing;

--- a/ui/src/components/gateway-url-confirmation.ts
+++ b/ui/src/components/gateway-url-confirmation.ts
@@ -2,7 +2,7 @@
 import { html, nothing } from "lit";
 import { property } from "lit/decorators.js";
 import { t } from "../i18n/index.ts";
-import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
+import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import "./modal-dialog.ts";
 
 type GatewayUrlConfirmationProps = {
@@ -46,13 +46,8 @@ function renderGatewayUrlConfirmation(props: GatewayUrlConfirmationProps) {
   `;
 }
 
-class GatewayUrlConfirmation extends OpenClawLightDomElement {
+class GatewayUrlConfirmation extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) props?: GatewayUrlConfirmationProps;
-
-  override connectedCallback() {
-    super.connectedCallback();
-    this.style.display = "contents";
-  }
 
   override render() {
     return this.props ? renderGatewayUrlConfirmation(this.props) : nothing;

--- a/ui/src/components/login-gate.ts
+++ b/ui/src/components/login-gate.ts
@@ -12,7 +12,7 @@ import {
   shouldShowInsecureContextHint,
 } from "../lib/overview-hints.ts";
 import { normalizeLowercaseStringOrEmpty } from "../lib/string-coerce.ts";
-import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
+import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import { renderConnectCommand } from "./connect-command.ts";
 import { icons } from "./icons.ts";
 
@@ -432,13 +432,8 @@ function renderLoginGate(props: LoginGateProps) {
   `;
 }
 
-class LoginGate extends OpenClawLightDomElement {
+class LoginGate extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) props?: LoginGateProps;
-
-  override connectedCallback() {
-    super.connectedCallback();
-    this.style.display = "contents";
-  }
 
   override render() {
     return this.props ? renderLoginGate(this.props) : nothing;

--- a/ui/src/components/native-link-menu.test.ts
+++ b/ui/src/components/native-link-menu.test.ts
@@ -1,15 +1,21 @@
 /* @vitest-environment jsdom */
 
 import { html, render } from "lit";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { i18n } from "../i18n/index.ts";
 import { NativeLinkMenu, type NativeLinkMenuAction } from "./native-link-menu.ts";
 
 const containers: HTMLElement[] = [];
 
-afterEach(() => {
+beforeEach(async () => {
+  await i18n.setLocale("en");
+});
+
+afterEach(async () => {
   for (const container of containers.splice(0)) {
     container.remove();
   }
+  await i18n.setLocale("en");
 });
 
 async function mountMenu(options: {
@@ -59,6 +65,20 @@ describe("native link menu", () => {
 
     items[0]?.click();
     expect(calls).toEqual(["close", "inline"]);
+  });
+
+  it("rerenders open actions when the locale changes", async () => {
+    const menu = await mountMenu({});
+
+    await i18n.setLocale("de");
+    await menu.updateComplete;
+
+    expect(menu.querySelector('[role="menu"]')?.getAttribute("aria-label")).toBe("Link-Aktionen");
+    expect(menuItems(menu).map((item) => item.textContent?.trim())).toEqual([
+      "In der Seitenleiste öffnen",
+      "Im Standardbrowser öffnen",
+      "Link kopieren",
+    ]);
   });
 
   it("closes on Escape and outside pointerdown while preserving trigger clicks", async () => {

--- a/ui/src/components/native-link-menu.ts
+++ b/ui/src/components/native-link-menu.ts
@@ -1,15 +1,12 @@
-import { LitElement, html } from "lit";
+import { html } from "lit";
 import { property } from "lit/decorators.js";
 import { t } from "../i18n/index.ts";
+import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { icons } from "./icons.ts";
 
 export type NativeLinkMenuAction = "inline" | "external" | "copy";
 
-export class NativeLinkMenu extends LitElement {
-  override createRenderRoot() {
-    return this;
-  }
-
+export class NativeLinkMenu extends OpenClawLightDomElement {
   @property({ attribute: false }) x = 0;
   @property({ attribute: false }) y = 0;
   @property({ attribute: false }) trigger: HTMLAnchorElement | null = null;

--- a/ui/src/components/theme-mode-toggle.ts
+++ b/ui/src/components/theme-mode-toggle.ts
@@ -2,7 +2,7 @@ import { html } from "lit";
 import { property } from "lit/decorators.js";
 import type { ThemeMode } from "../app/theme.ts";
 import { t } from "../i18n/index.ts";
-import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
+import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import { icons } from "./icons.ts";
 import "./tooltip.ts";
 
@@ -11,13 +11,8 @@ export type ThemeModeChangeDetail = {
   element: HTMLElement;
 };
 
-class ThemeModeToggle extends OpenClawLightDomElement {
+class ThemeModeToggle extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) mode: ThemeMode = "system";
-
-  override connectedCallback() {
-    super.connectedCallback();
-    this.style.display = "contents";
-  }
 
   private readonly handleModeChange = (event: Event) => {
     const mode = this.mode === "system" ? "light" : this.mode === "light" ? "dark" : "system";

--- a/ui/src/components/update-banner.ts
+++ b/ui/src/components/update-banner.ts
@@ -3,7 +3,7 @@ import { html, nothing } from "lit";
 import { property } from "lit/decorators.js";
 import type { UpdateAvailable } from "../api/types.ts";
 import { t } from "../i18n/index.ts";
-import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
+import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import { getSafeLocalStorage } from "../local-storage.ts";
 import { icons } from "./icons.ts";
 
@@ -68,13 +68,8 @@ type UpdateBannerProps = {
   onDismiss: () => void;
 };
 
-class UpdateBanner extends OpenClawLightDomElement {
+class UpdateBanner extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) props?: UpdateBannerProps;
-
-  override connectedCallback() {
-    super.connectedCallback();
-    this.style.display = "contents";
-  }
 
   override render() {
     const props = this.props;

--- a/ui/src/lit/openclaw-element.test.ts
+++ b/ui/src/lit/openclaw-element.test.ts
@@ -1,9 +1,14 @@
 import { html } from "lit";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { i18n, t } from "../i18n/index.ts";
-import { OpenClawLightDomElement, OpenClawLitElement } from "./openclaw-element.ts";
+import {
+  OpenClawLightDomContentsElement,
+  OpenClawLightDomElement,
+  OpenClawLitElement,
+} from "./openclaw-element.ts";
 
 const LIGHT_ELEMENT_NAME = "test-openclaw-light-dom-element";
+const LIGHT_CONTENTS_ELEMENT_NAME = "test-openclaw-light-dom-contents-element";
 const SHADOW_ELEMENT_NAME = "test-openclaw-shadow-dom-element";
 
 class TestLightDomElement extends OpenClawLightDomElement {
@@ -21,11 +26,20 @@ class TestShadowDomElement extends OpenClawLitElement {
   }
 }
 
+class TestLightDomContentsElement extends OpenClawLightDomContentsElement {
+  override render() {
+    return html`<span>contents</span>`;
+  }
+}
+
 if (!customElements.get(LIGHT_ELEMENT_NAME)) {
   customElements.define(LIGHT_ELEMENT_NAME, TestLightDomElement);
 }
 if (!customElements.get(SHADOW_ELEMENT_NAME)) {
   customElements.define(SHADOW_ELEMENT_NAME, TestShadowDomElement);
+}
+if (!customElements.get(LIGHT_CONTENTS_ELEMENT_NAME)) {
+  customElements.define(LIGHT_CONTENTS_ELEMENT_NAME, TestLightDomContentsElement);
 }
 
 describe("OpenClaw Lit elements", () => {
@@ -40,13 +54,18 @@ describe("OpenClaw Lit elements", () => {
 
   it("provides explicit light- and shadow-DOM bases", async () => {
     const light = document.createElement(LIGHT_ELEMENT_NAME) as TestLightDomElement;
+    const contents = document.createElement(
+      LIGHT_CONTENTS_ELEMENT_NAME,
+    ) as TestLightDomContentsElement;
     const shadow = document.createElement(SHADOW_ELEMENT_NAME) as TestShadowDomElement;
-    document.body.append(light, shadow);
+    document.body.append(light, contents, shadow);
 
-    await Promise.all([light.updateComplete, shadow.updateComplete]);
+    await Promise.all([light.updateComplete, contents.updateComplete, shadow.updateComplete]);
 
     expect(light.shadowRoot).toBeNull();
     expect(light.textContent).toContain("Refresh");
+    expect(contents.shadowRoot).toBeNull();
+    expect(contents.style.display).toBe("contents");
     expect(shadow.shadowRoot?.textContent).toContain("shadow content");
   });
 

--- a/ui/src/lit/openclaw-element.ts
+++ b/ui/src/lit/openclaw-element.ts
@@ -12,3 +12,11 @@ export abstract class OpenClawLightDomElement extends OpenClawLitElement {
     return this;
   }
 }
+
+/** Light-DOM element whose host should not add a layout box around its render output. */
+export abstract class OpenClawLightDomContentsElement extends OpenClawLightDomElement {
+  override connectedCallback() {
+    super.connectedCallback();
+    this.style.display = "contents";
+  }
+}

--- a/ui/src/pages/plugin/plugin-page.ts
+++ b/ui/src/pages/plugin/plugin-page.ts
@@ -6,7 +6,7 @@ import type { RouteId } from "../../app-route-paths.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { t } from "../../i18n/index.ts";
 import { resolveEmbedSandbox } from "../../lib/chat/tool-display.ts";
-import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
+import { OpenClawLightDomContentsElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import { pluginTabKey } from "./route.ts";
 
@@ -43,7 +43,7 @@ const BUNDLED_TAB_VIEWS: Record<string, () => Promise<BundledPluginTabView>> = {
   },
 };
 
-export class PluginPage extends OpenClawLightDomElement {
+export class PluginPage extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) pluginId = "";
   @property({ attribute: false }) tabId = "";
 
@@ -63,11 +63,6 @@ export class PluginPage extends OpenClawLightDomElement {
     (gateway, notify) => gateway.subscribe(notify),
     (gateway) => this.updateGatewaySource(gateway),
   );
-
-  override connectedCallback() {
-    super.connectedCallback();
-    this.style.display = "contents";
-  }
 
   override disconnectedCallback() {
     this.subscriptions.clear();


### PR DESCRIPTION
Closes #102821

## What Problem This Solves

Resolves a Control UI ownership problem where the app host and shell copied values from already-subscribed gateway, navigation, overlay, config, theme, and agent capabilities into a second set of Lit state fields. Those parallel state paths added duplicate rendering and could drift as reconnect and capability behavior evolved.

Also fixes an issue where an already-open native-link menu kept labels from the previous locale after the active locale changed.

## Why This Change Was Made

The app and shell now render from the canonical capability snapshots while retaining only genuine local interaction state and required eager-load side effects. Repeated light-DOM `display: contents` setup now lives in one Lit base, and the native-link menu uses the locale-aware OpenClaw base.

The patch removes 136 production lines overall and does not change dependencies, configuration, persistence, public APIs, or visual layout.

## User Impact

Native-link actions retranslate immediately when the locale changes. Other Control UI behavior is intentionally unchanged, with fewer synchronization paths that can present stale shell state during future capability changes.

## Evidence

- Focused Control UI Vitest: 6 files, 17/17 tests passed.
- Focused browser E2E: 5 files, 11/11 scenarios passed, covering initial authentication, sidebar persistence and config gating, approvals, embedded terminal mode, and native-link routing.
- `pnpm check:changed`: passed type checks, core/UI lint, extension lint, and architecture/guard checks.
- `pnpm ui:build`: passed; 1,019 modules transformed.
- `git diff --check` and targeted Oxfmt checks: passed.
- Fresh pre-commit and committed-branch Codex autoreviews: no accepted/actionable findings.
- No screenshot attached because the change intentionally has no visual-layout delta; the locale transition is covered directly by the component regression.

AI-assisted: yes. The implementation was maintainer-directed, reviewed against the complete diff, and validated with focused unit/browser coverage plus repository gates.
