### PR TITLE
fix(slack): keep mpDM human and bot messages on one group session

### DIFF
--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -170,6 +170,17 @@ export type SlackMonitorContext = {
     topic?: string;
     purpose?: string;
   }>;
+  /**
+   * Cache an authoritative Slack conversation type (event `channel_type` or
+   * conversations.info `is_mpim` / `is_im` / …). Bot-authored events often omit
+   * `channel_type`; without this cache they fall back to C-prefix → `channel`
+   * and split mpDM sessions from the human `mpim` path.
+   */
+  rememberAuthoritativeChannelType: (
+    channelId: string,
+    channelType?: string | null,
+    eventScope?: SlackEventScope,
+  ) => void;
   resolveUserName: (userId: string, eventScope?: SlackEventScope) => Promise<{ name?: string }>;
   setSlackThreadStatus: (params: {
     channelId: string;
@@ -252,6 +263,9 @@ export function createSlackMonitorContext(params: {
       purpose?: string;
     }
   >();
+  // Separate from channelCache so remembering event channel_type does not
+  // short-circuit conversations.info name/topic fetches on later messages.
+  const authoritativeChannelTypeCache = new Map<string, SlackMessageEvent["channel_type"]>();
   const userCache = new Map<string, { name?: string }>();
   const seenMessages = createDedupeCache({ ttlMs: 60_000, maxSize: 500 });
   const assistantThreadContexts = new Map<string, SlackAssistantThreadContext>();
@@ -429,6 +443,33 @@ export function createSlackMonitorContext(params: {
     }).sessionKey;
   };
 
+  const rememberAuthoritativeChannelType = (
+    channelId: string,
+    channelType?: string | null,
+    eventScope?: SlackEventScope,
+  ) => {
+    const id = channelId.trim();
+    if (!id) {
+      return;
+    }
+    const normalized = normalizeOptionalString(channelType)?.toLowerCase();
+    if (
+      normalized !== "im" &&
+      normalized !== "mpim" &&
+      normalized !== "channel" &&
+      normalized !== "group"
+    ) {
+      return;
+    }
+    // Keep D-prefix DM override and other normalize rules consistent with ingress.
+    const type = normalizeSlackChannelType(normalized, id);
+    const cacheKey = scopedKey(id, eventScope);
+    if (authoritativeChannelTypeCache.get(cacheKey) === type) {
+      return;
+    }
+    authoritativeChannelTypeCache.set(cacheKey, type);
+  };
+
   const resolveChannelName = async (channelId: string, eventScope?: SlackEventScope) => {
     const cacheKey = scopedKey(channelId, eventScope);
     const cached = channelCache.get(cacheKey);
@@ -456,9 +497,16 @@ export function createSlackMonitorContext(params: {
         channel && "purpose" in channel ? (channel.purpose?.value ?? undefined) : undefined;
       const entry = { name, type, topic, purpose };
       channelCache.set(cacheKey, entry);
+      if (type) {
+        rememberAuthoritativeChannelType(channelId, type, eventScope);
+      }
       return entry;
     } catch {
-      return {};
+      // When conversations.info fails, still surface a previously remembered
+      // authoritative type so bot-authored mpDM events do not fall back to
+      // C-prefix "channel" session keys.
+      const rememberedType = authoritativeChannelTypeCache.get(cacheKey);
+      return rememberedType ? { type: rememberedType } : {};
     }
   };
 
@@ -691,6 +739,7 @@ export function createSlackMonitorContext(params: {
     resolveSlackSystemEventSessionKey,
     isChannelAllowed,
     resolveChannelName,
+    rememberAuthoritativeChannelType,
     resolveUserName,
     setSlackThreadStatus,
     getSlackAssistantThreadContext,

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -1866,6 +1866,123 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     expect(prepared.ctxPayload.From).toBe("slack:group:G123");
   });
 
+  it("keeps C-prefixed mpDM human and bot-authored ingress on one group session when channel info fails (#102676)", async () => {
+    // Modern Slack MPIMs use C-prefixed IDs. Humans carry channel_type: "mpim";
+    // bot-authored events often omit it. When conversations.info is unavailable,
+    // missing-type bot events previously C-prefix-inferred "channel" and split
+    // a second slack:channel:<id> session beside slack:group:<id>.
+    const conversationsInfo = vi.fn().mockRejectedValue(new Error("missing_scope"));
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        channels: {
+          slack: { enabled: true, replyToMode: "all", allowBots: true },
+        },
+      } as OpenClawConfig,
+      appClient: { conversations: { info: conversationsInfo } } as unknown as App["client"],
+      replyToMode: "all",
+      defaultRequireMention: false,
+    });
+    slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
+    const account = createSlackAccount({ replyToMode: "all", allowBots: true });
+    const channelId = "C0MPIMSPLIT1";
+
+    const human = await prepareMessageWith(
+      slackCtx,
+      account,
+      createSlackMessage({
+        channel: channelId,
+        channel_type: "mpim",
+        user: "U1",
+        text: "human in mpdm",
+        ts: "10.000",
+      }),
+    );
+    assertPrepared(human);
+    expect(human.ctxPayload.ChatType).toBe("group");
+    expect(human.ctxPayload.From).toBe(`slack:group:${channelId}`);
+
+    const bot = await prepareMessageWith(
+      slackCtx,
+      account,
+      createSlackMessage({
+        channel: channelId,
+        channel_type: undefined,
+        user: undefined,
+        bot_id: "BOTHER1",
+        subtype: "bot_message",
+        username: "other-agent",
+        text: "bot reply in mpdm",
+        ts: "11.000",
+      }),
+    );
+    assertPrepared(bot);
+    expect(bot.ctxPayload.ChatType).toBe("group");
+    expect(bot.ctxPayload.From).toBe(`slack:group:${channelId}`);
+    expect(bot.ctxPayload.From).toBe(human.ctxPayload.From);
+    expect(conversationsInfo).toHaveBeenCalled();
+  });
+
+  it("does not reclassify unresolved G-prefix private channels as mpDM group sessions (#102676)", async () => {
+    // Negative control: G-prefix private channels use channel_type "group" and
+    // must keep slack:channel:<id> session keys — not slack:group:<id>.
+    // Room bot admission also needs an allowFrom owner present in members.
+    const conversationsInfo = vi.fn().mockRejectedValue(new Error("missing_scope"));
+    const members = vi.fn().mockResolvedValue({
+      members: ["UOWNER"],
+      response_metadata: { next_cursor: "" },
+    });
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        channels: {
+          slack: { enabled: true, replyToMode: "all", allowBots: true },
+        },
+      } as OpenClawConfig,
+      appClient: {
+        conversations: { info: conversationsInfo, members },
+      } as unknown as App["client"],
+      replyToMode: "all",
+      defaultRequireMention: false,
+    });
+    slackCtx.allowFrom = ["UOWNER"];
+    slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
+    const account = createSlackAccount({ replyToMode: "all", allowBots: true });
+    const channelId = "G0PRIVATE1";
+
+    const human = await prepareMessageWith(
+      slackCtx,
+      account,
+      createSlackMessage({
+        channel: channelId,
+        channel_type: "group",
+        user: "U1",
+        text: "human in private channel",
+        ts: "20.000",
+      }),
+    );
+    assertPrepared(human);
+    expect(human.ctxPayload.ChatType).toBe("channel");
+    expect(human.ctxPayload.From).toBe(`slack:channel:${channelId}`);
+
+    const bot = await prepareMessageWith(
+      slackCtx,
+      account,
+      createSlackMessage({
+        channel: channelId,
+        channel_type: undefined,
+        user: undefined,
+        bot_id: "BOTHER2",
+        subtype: "bot_message",
+        username: "other-agent",
+        text: "bot reply in private channel",
+        ts: "21.000",
+      }),
+    );
+    assertPrepared(bot);
+    expect(bot.ctxPayload.ChatType).toBe("channel");
+    expect(bot.ctxPayload.From).toBe(`slack:channel:${channelId}`);
+    expect(bot.ctxPayload.From).not.toBe(`slack:group:${channelId}`);
+  });
+
   it.each([
     {
       peer: { kind: "group", id: "channel:C0AJUGWG5L6" },
@@ -3927,6 +4044,7 @@ describe("prepareSlackMessage sender prefix", () => {
       resolveSlackSystemEventSessionKey: () => "agent:main:slack:channel:c1",
       isChannelAllowed: () => true,
       resolveChannelName: async () => ({ name: "general", type: "channel" }),
+      rememberAuthoritativeChannelType: () => {},
       resolveUserName: async () => ({ name: "Alice" }),
       setSlackThreadStatus: async () => undefined,
     } as unknown as SlackMonitorContext;

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -495,10 +495,20 @@ async function resolveSlackConversationContext(params: {
   // that common path to avoid an unnecessary API round-trip.
   if (resolvedChannelType !== "im" && (!message.channel_type || message.channel_type !== "im")) {
     channelInfo = await ctx.resolveChannelName(message.channel, params.eventScope);
+    // Prefer event channel_type, then conversations.info / remembered type.
+    // resolveChannelName surfaces remembered types when the API fails so bot
+    // events missing channel_type stay on the same mpDM session as humans.
     resolvedChannelType = normalizeSlackChannelType(
       message.channel_type ?? channelInfo.type,
       message.channel,
     );
+  }
+  // Carry authoritative types across events. Human messages usually include
+  // channel_type: "mpim"; bot-authored events often omit it and would otherwise
+  // C-prefix-infer "channel" when conversations.info is unavailable.
+  ctx.rememberAuthoritativeChannelType(message.channel, message.channel_type, params.eventScope);
+  if (channelInfo.type) {
+    ctx.rememberAuthoritativeChannelType(message.channel, channelInfo.type, params.eventScope);
   }
   const channelName = channelInfo?.name;
   const isDirectMessage = resolvedChannelType === "im";


### PR DESCRIPTION
Fixes #102676

## What Problem This Solves

Fixes an issue where users running multiple Slack agents in one multi-party DM (mpDM) would get **two parallel sessions per agent** for the same room: human messages keyed as `slack:group:<id>`, while bot-authored messages (often missing `channel_type`) fell back to C-prefix inference and keyed as `slack:channel:<id>` when channel info could not be resolved. That split context breaks `/reset` and produces stale twin-session replies.

## Why This Change Was Made

ClawSweeper and maintainer feedback asked for carrying/caching **authoritative** Slack conversation type (`channel_type: "mpim"` / `conversations.info` `is_mpim`) through the unresolved bot-event path—not G-prefix heuristics alone (closed #102702 / #102752).

This change keeps a process-local authoritative type cache separate from the name/topic channel cache so remembering type does not skip later name fetches. On `conversations.info` failure, `resolveChannelName` still surfaces a previously remembered type so ingress classification stays consistent.

Non-goals: historical twin-session doctor migration; live multi-bot bot-authored path was validated at source level; live proof below is human-authored C-prefix Group DM session keying on a real Slack workspace.

## User Impact

mpDM rooms keep **one session key family** (`slack:group:<id>`) for turns in that room. Private/public channels remain `slack:channel:<id>`.

## Evidence

### 1. Live Slack (real workspace) — redacted

Environment: local macOS gateway on PR head `59908fbec`, Socket Mode Slack app in workspace `macmini-claw`, bot `openclaw`.

**Control (public/private channel, not mpDM):**
```
Inbound app_mention ... channel:C0AL6DKA70U ... (channel, ...)
session: agent:main:slack:channel:c0al6dka70u
```

**Target (Group DM / C-prefix modern mpDM, two human accounts + bot):**
```
watch-mpdm result:
  GROUP agent:main:slack:group:c0bge2wsml4
  CHANNEL agent:main:slack:channel:c0al6dka70u [IGNORED old]
---- RESULT: got_group_session ----
```

Gateway runtime (redacted):
```
lane=session:agent:main:slack:group:c0bge2wsml4
[slack] delivered reply to channel:C0BGE2WSML4
```

Channel probe: Slack `connected=true`, `healthState=healthy`, bot `openclaw` present.

Note: model reply returned Deepseek 401 (invalid API key) — unrelated to session keying; the **session key** is the proof target and is correctly `slack:group:` for the Group DM.

### 2. Focused source regression

```
node scripts/run-vitest.mjs extensions/slack/src/monitor/message-handler/prepare.test.ts -t "102676"
✓ keeps C-prefixed mpDM human and bot-authored ingress on one group session when channel info fails (#102676)
✓ does not reclassify unresolved G-prefix private channels as mpDM group sessions (#102676)
```

Full prepare suite: 116 passed. oxlint/oxfmt clean on touched files.

## Real behavior proof

- Behavior addressed: Live C-prefix Slack Group DM (mpDM-class room id `C0BGE2WSML4`) keys as `agent:main:slack:group:c0bge2wsml4`, distinct from a real channel room which keys as `slack:channel:c0al6dka70u`.
- Environment: macOS local OpenClaw gateway (PR `59908fbec`), Slack Socket Mode, workspace macmini-claw, bot openclaw; Group DM with two human accounts + bot.
- Current-main contrast: Without correct type resolution/cache, C-prefix rooms without explicit `mpim` fall to `channel` session keys; the live channel control still shows `slack:channel:`, while the Group DM on this patch shows `slack:group:`.
- Exact steps or command run after this patch:
  1. Configure Slack socket mode; run gateway on this branch.
  2. Open Slack Group DM (two humans + openclaw bot; no #channel).
  3. Send a human message in that Group DM.
  4. `pnpm openclaw sessions --active 60` / watch script → observe `slack:group:c0bge2wsml4`.
- Evidence after fix: Session list shows `GROUP agent:main:slack:group:c0bge2wsml4`; gateway lane `session:agent:main:slack:group:c0bge2wsml4`; delivery to `C0BGE2WSML4`.
- Control check: Earlier #channel @mention created only `slack:channel:c0al6dka70u` and remains separate; Group DM did not land on `slack:channel:` for `C0BGE2WSML4`.
- Observed result after fix: Live Group DM uses **group** session family as required for mpDM; channel control remains channel-keyed.
- What was not tested: Live multi-bot bot-authored twin-session race under failed `conversations.info` (covered by focused unit tests); historical twin migration; Discord noise unrelated.

## AI disclosure

This fix was authored with AI assistance (Grok). Code and tests should be reviewed as contributor-owned.
