### PR TITLE
fix(agents): avoid symlink-follow in auth.json bootstrap

### DIFF
--- a/src/agents/sessions/auth-storage.symlink-bootstrap.test.ts
+++ b/src/agents/sessions/auth-storage.symlink-bootstrap.test.ts
@@ -1,0 +1,41 @@
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { AuthStorage } from "./auth-storage.js";
+
+describe("auth-storage bootstrap does not follow a symlink at auth.json", () => {
+  let tmpRoot: string | undefined;
+
+  afterEach(() => {
+    if (tmpRoot) {
+      rmSync(tmpRoot, { recursive: true, force: true });
+      tmpRoot = undefined;
+    }
+  });
+
+  it("creates a real file in place instead of writing through a planted symlink", () => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "auth-symlink-"));
+    const agentDir = join(tmpRoot, "agent");
+    const authPath = join(agentDir, "auth.json");
+    const victimPath = join(tmpRoot, "victim-secret.json");
+
+    mkdirSync(agentDir, { recursive: true });
+    symlinkSync(victimPath, authPath);
+
+    AuthStorage.create(authPath);
+
+    expect(existsSync(victimPath)).toBe(false);
+    expect(lstatSync(authPath).isSymbolicLink()).toBe(false);
+    expect(lstatSync(authPath).isFile()).toBe(true);
+    expect(readFileSync(authPath, "utf-8")).toBe("{}");
+  });
+});

--- a/src/agents/sessions/auth-storage.ts
+++ b/src/agents/sessions/auth-storage.ts
@@ -6,7 +6,7 @@
  * try to refresh tokens simultaneously.
  */
 
-import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { findEnvKeys, getEnvApiKey } from "@openclaw/ai/internal/runtime";
 import lockfile from "proper-lockfile";
@@ -79,8 +79,7 @@ export class FileAuthStorageBackend implements AuthStorageBackend {
 
   private ensureFileExists(): void {
     if (!existsSync(this.authPath)) {
-      writeFileSync(this.authPath, "{}", "utf-8");
-      chmodSync(this.authPath, 0o600);
+      this.replaceAuthFileAtomic("{}");
     }
   }
 

--- a/src/infra/replace-file.test.ts
+++ b/src/infra/replace-file.test.ts
@@ -1,9 +1,16 @@
 // Tests atomic file replacement helpers and permission handling.
+import syncFs from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
-import { movePathWithCopyFallback } from "./replace-file.js";
+import {
+  movePathWithCopyFallback,
+  replaceFileAtomic,
+  replaceFileAtomicSync,
+  type ReplaceFileAtomicFileSystem,
+  type ReplaceFileAtomicSyncFileSystem,
+} from "./replace-file.js";
 
 describe("movePathWithCopyFallback", () => {
   it.runIf(process.platform !== "win32")(
@@ -37,6 +44,336 @@ describe("movePathWithCopyFallback", () => {
         expect(statError?.code).toBe("ENOENT");
         expect(statError?.path).toBe(targetDir);
         expect(statError?.syscall).toBe("stat");
+      });
+    },
+  );
+});
+
+describe("replaceFileAtomic", () => {
+  it.runIf(process.platform !== "win32")(
+    "does not chmod a swapped symlink target after async rename",
+    async () => {
+      await withTempDir({ prefix: "openclaw-replace-file-" }, async (root) => {
+        const target = path.join(root, "auth.json");
+        const victim = path.join(root, "victim-secret.json");
+        const chmodPaths: string[] = [];
+        await fs.writeFile(victim, "secret", "utf8");
+        await fs.chmod(victim, 0o644);
+
+        const fileSystem: ReplaceFileAtomicFileSystem = {
+          promises: {
+            chmod: async (targetPath, mode) => {
+              chmodPaths.push(String(targetPath));
+              await fs.chmod(targetPath, mode);
+            },
+            copyFile: fs.copyFile,
+            lstat: fs.lstat,
+            mkdir: fs.mkdir,
+            open: fs.open,
+            rename: async (source, destination) => {
+              await fs.rename(source, destination);
+              await fs.rm(destination, { force: true });
+              await fs.symlink(victim, destination);
+            },
+            rm: fs.rm,
+            stat: fs.stat,
+            unlink: fs.unlink,
+            writeFile: fs.writeFile,
+          },
+        };
+
+        await replaceFileAtomic({
+          filePath: target,
+          content: "{}",
+          dirMode: 0o755,
+          fileSystem,
+          mode: 0o600,
+          tempPrefix: "auth.json",
+        });
+
+        expect(chmodPaths).toEqual([root]);
+        expect((await fs.stat(victim)).mode & 0o777).toBe(0o644);
+        expect((await fs.lstat(target)).isSymbolicLink()).toBe(true);
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "does not chmod a swapped symlink target after sync rename",
+    async () => {
+      await withTempDir({ prefix: "openclaw-replace-file-" }, async (root) => {
+        const target = path.join(root, "auth.json");
+        const victim = path.join(root, "victim-secret.json");
+        const chmodPaths: string[] = [];
+        await fs.writeFile(victim, "secret", "utf8");
+        await fs.chmod(victim, 0o644);
+
+        const fileSystem: ReplaceFileAtomicSyncFileSystem = {
+          chmodSync: (targetPath, mode) => {
+            chmodPaths.push(String(targetPath));
+            syncFs.chmodSync(targetPath, mode);
+          },
+          closeSync: syncFs.closeSync,
+          copyFileSync: syncFs.copyFileSync,
+          fsyncSync: syncFs.fsyncSync,
+          lstatSync: syncFs.lstatSync,
+          mkdirSync: syncFs.mkdirSync,
+          openSync: syncFs.openSync,
+          readFileSync: syncFs.readFileSync,
+          renameSync: (source, destination) => {
+            syncFs.renameSync(source, destination);
+            syncFs.rmSync(destination, { force: true });
+            syncFs.symlinkSync(victim, destination);
+          },
+          rmSync: syncFs.rmSync,
+          statSync: syncFs.statSync,
+          unlinkSync: syncFs.unlinkSync,
+          writeFileSync: syncFs.writeFileSync,
+        };
+
+        replaceFileAtomicSync({
+          filePath: target,
+          content: "{}",
+          dirMode: 0o755,
+          fileSystem,
+          mode: 0o600,
+          tempPrefix: "auth.json",
+        });
+
+        expect(chmodPaths).toEqual([root]);
+        expect((await fs.stat(victim)).mode & 0o777).toBe(0o644);
+        expect((await fs.lstat(target)).isSymbolicLink()).toBe(true);
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "preserves async requested mode without final-path chmod",
+    async () => {
+      await withTempDir({ prefix: "openclaw-replace-file-" }, async (root) => {
+        const target = path.join(root, "public.json");
+        const chmodPaths: string[] = [];
+        const fileSystem: ReplaceFileAtomicFileSystem = {
+          promises: {
+            chmod: async (targetPath, mode) => {
+              chmodPaths.push(String(targetPath));
+              await fs.chmod(targetPath, mode);
+            },
+            copyFile: fs.copyFile,
+            lstat: fs.lstat,
+            mkdir: fs.mkdir,
+            open: fs.open,
+            rename: fs.rename,
+            rm: fs.rm,
+            stat: fs.stat,
+            unlink: fs.unlink,
+            writeFile: fs.writeFile,
+          },
+        };
+
+        const previousUmask = process.umask(0o077);
+        try {
+          await replaceFileAtomic({
+            filePath: target,
+            content: "{}",
+            dirMode: 0o755,
+            fileSystem,
+            mode: 0o644,
+            tempPrefix: "public.json",
+          });
+        } finally {
+          process.umask(previousUmask);
+        }
+
+        expect(chmodPaths).toEqual([root]);
+        expect((await fs.stat(target)).mode & 0o777).toBe(0o644);
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "preserves async copy-fallback requested mode without final-path chmod",
+    async () => {
+      await withTempDir({ prefix: "openclaw-replace-file-" }, async (root) => {
+        const target = path.join(root, "public.json");
+        const chmodPaths: string[] = [];
+        const fileSystem: ReplaceFileAtomicFileSystem = {
+          promises: {
+            chmod: async (targetPath, mode) => {
+              chmodPaths.push(String(targetPath));
+              await fs.chmod(targetPath, mode);
+            },
+            copyFile: fs.copyFile,
+            lstat: fs.lstat,
+            mkdir: fs.mkdir,
+            open: fs.open,
+            rename: async () => {
+              throw Object.assign(new Error("rename blocked"), { code: "EPERM" });
+            },
+            rm: fs.rm,
+            stat: fs.stat,
+            unlink: fs.unlink,
+            writeFile: fs.writeFile,
+          },
+        };
+
+        const previousUmask = process.umask(0o077);
+        try {
+          await expect(
+            replaceFileAtomic({
+              filePath: target,
+              content: "{}",
+              copyFallbackOnPermissionError: true,
+              dirMode: 0o755,
+              fileSystem,
+              mode: 0o644,
+              tempPrefix: "public.json",
+            }),
+          ).resolves.toEqual({ method: "copy-fallback" });
+        } finally {
+          process.umask(previousUmask);
+        }
+
+        expect(chmodPaths).toEqual([root]);
+        expect((await fs.stat(target)).mode & 0o777).toBe(0o644);
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "preserves async same-path mode after an earlier queued replacement",
+    async () => {
+      await withTempDir({ prefix: "openclaw-replace-file-" }, async (root) => {
+        const target = path.join(root, "shared.json");
+        let releaseFirst: (() => void) | undefined;
+        let enteredFirst: (() => void) | undefined;
+        const firstEntered = new Promise<void>((resolve) => {
+          enteredFirst = resolve;
+        });
+        const firstRelease = new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+        await fs.writeFile(target, "old", { mode: 0o600 });
+
+        const first = replaceFileAtomic({
+          filePath: target,
+          beforeRename: async () => {
+            enteredFirst?.();
+            await firstRelease;
+          },
+          content: "first",
+          mode: 0o644,
+          tempPrefix: "shared.json",
+        });
+        await firstEntered;
+
+        const second = replaceFileAtomic({
+          filePath: target,
+          content: "second",
+          preserveExistingMode: true,
+          tempPrefix: "shared.json",
+        });
+
+        releaseFirst?.();
+        await Promise.all([first, second]);
+
+        expect(await fs.readFile(target, "utf8")).toBe("second");
+        expect((await fs.stat(target)).mode & 0o777).toBe(0o644);
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "preserves sync requested mode without final-path chmod",
+    async () => {
+      await withTempDir({ prefix: "openclaw-replace-file-" }, async (root) => {
+        const target = path.join(root, "public.json");
+        const chmodPaths: string[] = [];
+        const fileSystem: ReplaceFileAtomicSyncFileSystem = {
+          chmodSync: (targetPath, mode) => {
+            chmodPaths.push(String(targetPath));
+            syncFs.chmodSync(targetPath, mode);
+          },
+          closeSync: syncFs.closeSync,
+          copyFileSync: syncFs.copyFileSync,
+          fsyncSync: syncFs.fsyncSync,
+          lstatSync: syncFs.lstatSync,
+          mkdirSync: syncFs.mkdirSync,
+          openSync: syncFs.openSync,
+          readFileSync: syncFs.readFileSync,
+          renameSync: syncFs.renameSync,
+          rmSync: syncFs.rmSync,
+          statSync: syncFs.statSync,
+          unlinkSync: syncFs.unlinkSync,
+          writeFileSync: syncFs.writeFileSync,
+        };
+
+        const previousUmask = process.umask(0o077);
+        try {
+          replaceFileAtomicSync({
+            filePath: target,
+            content: "{}",
+            dirMode: 0o755,
+            fileSystem,
+            mode: 0o644,
+            tempPrefix: "public.json",
+          });
+        } finally {
+          process.umask(previousUmask);
+        }
+
+        expect(chmodPaths).toEqual([root]);
+        expect((await fs.stat(target)).mode & 0o777).toBe(0o644);
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "preserves sync copy-fallback requested mode without final-path chmod",
+    async () => {
+      await withTempDir({ prefix: "openclaw-replace-file-" }, async (root) => {
+        const target = path.join(root, "public.json");
+        const chmodPaths: string[] = [];
+        const fileSystem: ReplaceFileAtomicSyncFileSystem = {
+          chmodSync: (targetPath, mode) => {
+            chmodPaths.push(String(targetPath));
+            syncFs.chmodSync(targetPath, mode);
+          },
+          closeSync: syncFs.closeSync,
+          copyFileSync: syncFs.copyFileSync,
+          fsyncSync: syncFs.fsyncSync,
+          lstatSync: syncFs.lstatSync,
+          mkdirSync: syncFs.mkdirSync,
+          openSync: syncFs.openSync,
+          readFileSync: syncFs.readFileSync,
+          renameSync: () => {
+            throw Object.assign(new Error("rename blocked"), { code: "EPERM" });
+          },
+          rmSync: syncFs.rmSync,
+          statSync: syncFs.statSync,
+          unlinkSync: syncFs.unlinkSync,
+          writeFileSync: syncFs.writeFileSync,
+        };
+
+        const previousUmask = process.umask(0o077);
+        try {
+          expect(
+            replaceFileAtomicSync({
+              filePath: target,
+              content: "{}",
+              copyFallbackOnPermissionError: true,
+              dirMode: 0o755,
+              fileSystem,
+              mode: 0o644,
+              tempPrefix: "public.json",
+            }),
+          ).toEqual({ method: "copy-fallback" });
+        } finally {
+          process.umask(previousUmask);
+        }
+
+        expect(chmodPaths).toEqual([root]);
+        expect((await fs.stat(target)).mode & 0o777).toBe(0o644);
       });
     },
   );

--- a/src/infra/replace-file.ts
+++ b/src/infra/replace-file.ts
@@ -1,17 +1,205 @@
 // Wraps fs-safe atomic replacement and move helpers for OpenClaw install flows.
 import "./fs-safe-defaults.js";
+import syncFs from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
   movePathWithCopyFallback as movePathWithCopyFallbackBase,
   replaceFileAtomic as replaceFileAtomicBase,
+  replaceFileAtomicSync as replaceFileAtomicSyncBase,
   type MovePathWithCopyFallbackOptions as BaseMovePathWithCopyFallbackOptions,
+  type ReplaceFileAtomicFileSystem,
+  type ReplaceFileAtomicOptions,
+  type ReplaceFileAtomicResult,
+  type ReplaceFileAtomicSyncFileSystem,
+  type ReplaceFileAtomicSyncOptions,
 } from "@openclaw/fs-safe/atomic";
 
-export { replaceDirectoryAtomic, replaceFileAtomicSync } from "@openclaw/fs-safe/atomic";
+export { replaceDirectoryAtomic } from "@openclaw/fs-safe/atomic";
+export type {
+  ReplaceFileAtomicFileSystem,
+  ReplaceFileAtomicSyncFileSystem,
+} from "@openclaw/fs-safe/atomic";
 
-/** Atomic file replacement primitive re-exported through the fs-safe defaults shim. */
-export const replaceFileAtomic = replaceFileAtomicBase;
+const defaultFileSystem = { promises: fs } satisfies ReplaceFileAtomicFileSystem;
+const defaultSyncFileSystem = syncFs satisfies ReplaceFileAtomicSyncFileSystem;
+
+export async function replaceFileAtomic(
+  options: ReplaceFileAtomicOptions,
+): Promise<ReplaceFileAtomicResult> {
+  return await replaceFileAtomicBase(withFinalPathChmodSkipped(options));
+}
+
+export function replaceFileAtomicSync(
+  options: ReplaceFileAtomicSyncOptions,
+): ReplaceFileAtomicResult {
+  return replaceFileAtomicSyncBase(withFinalPathChmodSkippedSync(options));
+}
+
+function withFinalPathChmodSkipped(options: ReplaceFileAtomicOptions): ReplaceFileAtomicOptions {
+  const fileSystem = options.fileSystem ?? defaultFileSystem;
+  const original = fileSystem.promises;
+  let requestedMode: Promise<number> | undefined;
+  const getRequestedMode = (): Promise<number> => {
+    requestedMode ??= resolveMode(options, original);
+    return requestedMode;
+  };
+  return {
+    ...options,
+    fileSystem: {
+      promises: {
+        ...original,
+        chmod: async (target, mode) => {
+          if (String(target) === options.filePath) {
+            return;
+          }
+          await original.chmod(target, mode);
+        },
+        open: async (target, flags, mode) => {
+          const handle = await original.open(target, flags, mode);
+          if (String(target) === options.filePath) {
+            try {
+              await handle.chmod(await getRequestedMode());
+            } catch (error) {
+              await handle.close().catch(() => undefined);
+              throw error;
+            }
+          }
+          return handle;
+        },
+      },
+    },
+    beforeRename: async (params) => {
+      await options.beforeRename?.(params);
+      await setTempModeExactly(params.tempPath, await getRequestedMode(), original);
+    },
+  };
+}
+
+function withFinalPathChmodSkippedSync(
+  options: ReplaceFileAtomicSyncOptions,
+): ReplaceFileAtomicSyncOptions {
+  const fileSystem = options.fileSystem ?? defaultSyncFileSystem;
+  const mode = resolveModeSync(options, fileSystem);
+  return {
+    ...options,
+    fileSystem: {
+      ...fileSystem,
+      chmodSync: (target, chmodMode) => {
+        if (String(target) === options.filePath) {
+          return;
+        }
+        fileSystem.chmodSync(target, chmodMode);
+      },
+      openSync: (target, flags, openMode) => {
+        const fd = fileSystem.openSync(target, flags, openMode);
+        if (String(target) === options.filePath) {
+          try {
+            syncFs.fchmodSync(fd, mode);
+          } catch (error) {
+            try {
+              fileSystem.closeSync(fd);
+            } catch {}
+            throw error;
+          }
+        }
+        return fd;
+      },
+    },
+    beforeRename: (params) => {
+      options.beforeRename?.(params);
+      setTempModeExactlySync(params.tempPath, mode, fileSystem);
+    },
+  };
+}
+
+async function resolveMode(
+  options: ReplaceFileAtomicOptions,
+  fsModule: ReplaceFileAtomicFileSystem["promises"],
+): Promise<number> {
+  const defaultMode = options.mode ?? 0o600;
+  if (!options.preserveExistingMode) {
+    return defaultMode;
+  }
+  try {
+    const stat = await fsModule.stat(options.filePath);
+    return stat.mode;
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return defaultMode;
+    }
+    throw error;
+  }
+}
+
+function resolveModeSync(
+  options: ReplaceFileAtomicSyncOptions,
+  fsModule: ReplaceFileAtomicSyncFileSystem,
+): number {
+  const defaultMode = options.mode ?? 0o600;
+  if (!options.preserveExistingMode) {
+    return defaultMode;
+  }
+  try {
+    return fsModule.statSync(options.filePath).mode;
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return defaultMode;
+    }
+    throw error;
+  }
+}
+
+async function setTempModeExactly(
+  tempPath: string,
+  mode: number,
+  fsModule: ReplaceFileAtomicFileSystem["promises"],
+): Promise<void> {
+  const stat = await fsModule.lstat(tempPath);
+  if ((stat.mode & 0o7777) === (mode & 0o7777)) {
+    return;
+  }
+  const handle = await fsModule.open(tempPath, noFollowReadFlags());
+  try {
+    await handle.chmod(mode);
+  } finally {
+    await handle.close();
+  }
+}
+
+function setTempModeExactlySync(
+  tempPath: string,
+  mode: number,
+  fsModule: ReplaceFileAtomicSyncFileSystem,
+): void {
+  const stat = fsModule.lstatSync(tempPath);
+  if ((stat.mode & 0o7777) === (mode & 0o7777)) {
+    return;
+  }
+  const fd = fsModule.openSync(tempPath, noFollowReadFlags());
+  try {
+    syncFs.fchmodSync(fd, mode);
+  } finally {
+    fsModule.closeSync(fd);
+  }
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}
+
+function noFollowReadFlags(): number | string {
+  const constants = syncFs.constants;
+  if (!constants || typeof constants.O_RDONLY !== "number") {
+    return "r";
+  }
+  return constants.O_RDONLY | (typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0);
+}
 
 /** Options for moving paths while optionally rejecting hardlinked source files. */
 type MovePathWithCopyFallbackOptions = BaseMovePathWithCopyFallbackOptions & {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a local attacker with write access to the `auth.json` parent directory can redirect credential-store bootstrap writes through a symlink. `AuthStorage` is the default credential backend for agent sessions, and its bootstrap path creates `auth.json` when the file is missing. On current `main`, a planted dangling `auth.json` symlink causes bootstrap to create, truncate, and chmod the symlink target outside the auth directory.

This also closes the follow-up hardening gap ClawSweeper found in the atomic replacement wrapper: after `@openclaw/fs-safe` renames the temp file into place, it performs a best-effort final `chmod` by target path. An attacker who can write the parent directory can swap `auth.json` back to a symlink in that post-rename window and redirect the chmod to another path.

## Why This Change Was Made

Root cause is in `src/agents/sessions/auth-storage.ts`, `FileAuthStorageBackend.ensureFileExists()`:

```ts
private ensureFileExists(): void {
  if (!existsSync(this.authPath)) {
    writeFileSync(this.authPath, "{}", "utf-8");
    chmodSync(this.authPath, 0o600);
  }
}
```

`existsSync`, `writeFileSync`, and `chmodSync` all operate on the final path. When `auth.json` is a symlink to a missing target, the check sees no existing target and the create/chmod operations land on the symlink target.

The existing persist path already uses `replaceAuthFileAtomic()`, which writes a sibling temp file with the requested file mode and renames it into place. This PR routes bootstrap through that path:

```ts
private ensureFileExists(): void {
  if (!existsSync(this.authPath)) {
    this.replaceAuthFileAtomic("{}");
  }
}
```

To close the active swap gap, `src/infra/replace-file.ts` now wraps both async and sync `replaceFileAtomic` calls so OpenClaw sets the temp file to the requested or preserved mode before rename through a no-follow file descriptor, then skips the redundant final chmod of the replacement path. The wrapper keeps parent-directory chmod behavior and exact final file modes while removing the post-rename target-path chmod that can follow a swapped symlink. If fs-safe takes its copy fallback, the wrapper restores the resolved mode on the opened destination descriptor instead of chmodding the final path. The async wrapper resolves preserveExistingMode lazily inside the serialized replacement phase, so same-path queued writes preserve the mode left by the earlier replacement instead of an old pre-queue stat.

### Why the guarantee is a wrapper, not direct delegation

Current `main` re-exports `replaceFileAtomic`/`replaceFileAtomicSync` straight from `@openclaw/fs-safe/atomic` (v0.4.1). I compared that exact upstream implementation against this wrapper to confirm the local layer is not a redundant reimplementation:

- fs-safe 0.4.1 creates the temp file with `writeFile(tempPath, content, { mode, flag: "wx" })`, so the temp mode is reduced by the process umask, and its copy fallback opens the destination with the umask-reduced temp mode.
- fs-safe 0.4.1 then reaches the requested mode with an unconditional post-rename `await fsModule.chmod(filePath, mode)` (and the sync `chmodSync(filePath, mode)`) on the **final path**. That final-path chmod is exactly the symlink-follow race; there is no upstream option to disable it.

So on fs-safe 0.4.1 the exact requested mode is only achieved by the same by-path chmod that follows a swapped symlink. To get exact modes **without** that final-path chmod you must fix the mode on the temp/destination file descriptor before rename, which fs-safe 0.4.1 does not do. The wrapper therefore delegates all replacement semantics (rename, retry, copy fallback, fsync, temp cleanup, write serialization) to fs-safe and only (1) suppresses the single unsafe final-path chmod and (2) sets the exact mode on the temp descriptor before rename and on the copy-fallback destination descriptor. It does not own or duplicate fs-safe's replacement logic. The refreshed before/after proof below shows this directly: on pristine `main` the chmod path list includes the final path (`auth.json` / `public.json`); with the wrapper it lists only `<parent>` while the requested `644` modes are still preserved.

## User Impact

Operators no longer expose an arbitrary-file create/truncate/chmod primitive through the credential store when `auth.json` is absent and its parent directory is writable by another local user. Normal behavior is unchanged: missing `auth.json` is still created as a real `{}` file at mode `0o600`.

## Evidence

Rebased onto current `main` at `a54a292d62cce68421de4456303e2b9178393c94`; the branch is now a single linear fix commit on top of `main` (head `3ff20717650510f3ec3ee51acf5e9ef2d796095d`), no merge commits, and the diff is exactly the four files below. The atomic-replacement wrapper is byte-identical to the previously reviewed head after rebase.

Local verification on the rebased tree:

- `node scripts/run-vitest.mjs src/infra/replace-file.test.ts src/infra/json-files.test.ts src/agents/sessions/auth-storage.symlink-bootstrap.test.ts src/agents/sessions/auth-storage.test.ts`: 4 files passed, 27 tests passed.
- `./node_modules/.bin/oxfmt --check src/infra/replace-file.ts src/infra/replace-file.test.ts src/agents/sessions/auth-storage.ts src/agents/sessions/auth-storage.symlink-bootstrap.test.ts`: clean.
- `oxlint src/infra/replace-file.ts src/infra/replace-file.test.ts src/agents/sessions/auth-storage.ts src/agents/sessions/auth-storage.symlink-bootstrap.test.ts`: clean.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json`: no errors in the changed files. (The only errors reported by the core lane in this checkout are pre-existing in `packages/net-policy/src/ip.ts`; they reproduce identically with the two changed source files reset to `origin/main`, so they are unrelated to this change.)
- Same-path async preserveExistingMode regression queues a `0644` replacement ahead of a preserveExistingMode replacement and verifies the queued write keeps `0644`.

## Real behavior proof
Behavior addressed: `AuthStorage` bootstrap no longer writes through a planted `auth.json` symlink, and OpenClaw's atomic replacement wrapper no longer chmods a symlink target swapped into place after rename while still preserving exact requested modes on rename, copy fallback, and queued same-path replacements.
Real environment tested: the real `AuthStorage` class from `src/agents/sessions/auth-storage.ts` and the real `replaceFileAtomicSync` and `replaceFileAtomic` wrappers from `src/infra/replace-file.ts` were driven against real on-disk temp directories on pristine `origin/main` a54a292d62cce68421de4456303e2b9178393c94 and PR head 3ff20717650510f3ec3ee51acf5e9ef2d796095d. The static symlink and queued same-path scenarios used normal filesystem calls. The post-rename swap and fallback scenarios used an instrumented filesystem object only to force the relevant filesystem outcome at the production helper boundary.
Exact steps or command run after this patch: `PATH=/opt/node/bin:$PATH node --import tsx /tmp/openclaw-bug-repros/102853/proof-driver.ts` from the repo root, first with `src/agents/sessions/auth-storage.ts` and `src/infra/replace-file.ts` reset to pristine `origin/main`, then with the same files restored from PR head 3ff20717650510f3ec3ee51acf5e9ef2d796095d.
Evidence after fix:
```
# BEFORE (pristine main a54a292d62cce68421de4456303e2b9178393c94)
queued same-path first mode request: 644
queued same-path second preserves existing mode: true
queued same-path final content: second
queued same-path final file mode: 644
static victim exists before: false
static auth.json is symlink before: true
static victim exists after create: true
static victim content after create: "{}"
static victim mode after create: 600
static auth.json is symlink after create: true
static auth.json is regular after create: false
swap victim mode before replace: 644
swap chmod paths: <parent>,auth.json
swap victim mode after replace: 600
swap auth.json is symlink after replace: true
mode requested with umask 077: 644
mode chmod paths: <parent>,public.json
mode final file mode: 644
fallback mode requested with umask 077: 644
fallback replacement method: copy-fallback
fallback chmod paths: <parent>,public.json
fallback final file mode: 644

# AFTER (this patch, identical inputs, head 3ff20717650510f3ec3ee51acf5e9ef2d796095d)
queued same-path first mode request: 644
queued same-path second preserves existing mode: true
queued same-path final content: second
queued same-path final file mode: 644
static victim exists before: false
static auth.json is symlink before: true
static victim exists after create: false
static victim content after create: "<none>"
static victim mode after create: <none>
static auth.json is symlink after create: false
static auth.json is regular after create: true
swap victim mode before replace: 644
swap chmod paths: <parent>
swap victim mode after replace: 644
swap auth.json is symlink after replace: true
mode requested with umask 077: 644
mode chmod paths: <parent>
mode final file mode: 644
fallback mode requested with umask 077: 644
fallback replacement method: copy-fallback
fallback chmod paths: <parent>
fallback final file mode: 644
```
Observed result after fix: the planted bootstrap target is not created or chmodded, a symlink swapped into the replacement path after rename does not receive the final chmod, requested 644 modes are preserved under umask 077 for both rename and copy fallback, and queued same-path preservation keeps the latest replacement mode. The BEFORE column also shows fs-safe 0.4.1's final-path chmod on the replacement path (`auth.json` / `public.json`), which is exactly the by-path chmod the wrapper suppresses.
What was not tested: no live multi-process attacker race was staged; the proof performs the parent-directory swap and fallback deterministically at the exact replacement points. Full build was not run because this changes no packaging, dynamic import, or module boundary.
