### PR TITLE
fix(agents): clamp zero bash job TTLs

### DIFF
--- a/src/agents/bash-process-registry.test.ts
+++ b/src/agents/bash-process-registry.test.ts
@@ -14,6 +14,7 @@ import {
   markBackgrounded,
   markExited,
   resetProcessRegistryForTests,
+  setJobTtlMs,
   tail,
 } from "./bash-process-registry.js";
 import { createProcessSessionFixture } from "./bash-process-registry.test-helpers.js";
@@ -170,6 +171,34 @@ describe("bash process registry", () => {
         totalOutputChars: 0,
       },
     ]);
+  });
+
+  it("clamps a zero retention TTL to one minute", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-07-09T00:00:00Z"));
+      setJobTtlMs(0);
+
+      const session = createRegistrySession({
+        id: "zero-ttl",
+        maxOutputChars: 100,
+        pendingMaxOutputChars: 30_000,
+        backgrounded: true,
+      });
+      addSession(session);
+      markExited(session, 0, null, "completed");
+
+      vi.advanceTimersByTime(30_000);
+      expect(listFinishedSessions()).toHaveLength(1);
+
+      vi.advanceTimersByTime(60_000);
+      expect(listFinishedSessions()).toHaveLength(0);
+    } finally {
+      resetProcessRegistryForTests();
+      setJobTtlMs(30 * 60 * 1000);
+      resetProcessRegistryForTests();
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -17,7 +17,7 @@ const MAX_JOB_TTL_MS = 3 * 60 * 60 * 1000; // 3 hours
 const DEFAULT_PENDING_OUTPUT_CHARS = 30_000;
 
 function clampTtl(value: number | undefined) {
-  if (!value || Number.isNaN(value)) {
+  if (value === undefined || Number.isNaN(value)) {
     return DEFAULT_JOB_TTL_MS;
   }
   return Math.min(Math.max(value, MIN_JOB_TTL_MS), MAX_JOB_TTL_MS);


### PR DESCRIPTION
## What Problem This Solves

An explicit zero bash-job TTL was treated like a missing value by `clampTtl`, so it selected the 30-minute default before clamping instead of the documented one-minute minimum.

This is a clean maintainer replacement for #102520 after GitHub's signed fork refresh expanded stale ancestry into hundreds of unrelated files and the original PR was closed automatically.

## Why This Change Was Made

Default only when the TTL is `undefined`; let numeric zero continue through the existing finite-number clamp. The regression drives the real registry setter under fake timers, distinguishes the one-minute minimum from the old 30-minute default, and proves the job survives before—but is swept after—the minimum boundary.

The replacement is one current-main commit with `0668000787` preserved as co-author.

## User Impact

`OPENCLAW_BASH_JOB_TTL_MS=0` and equivalent explicit zero configuration now resolve to the documented minimum instead of unexpectedly retaining completed jobs for 30 minutes. Missing and invalid values still use the default.

## Evidence

- Fresh branch autoreview: clean, confidence 0.98.
- Exact predecessor-tree isolated AWS proof: `run_ac5687282487`, 11/11 focused tests passed; final replacement SHA will be re-proved before merge.
- Formatting and `git diff --check origin/main...HEAD` passed.
- Full exact-head hosted CI will be attached before merge.

Supersedes #102520 while preserving contributor credit.
