### PR TITLE
fix(ci): stop asserting deleted Android copy

### DIFF
--- a/test/scripts/native-app-i18n.test.ts
+++ b/test/scripts/native-app-i18n.test.ts
@@ -50,7 +50,6 @@ describe("native app i18n inventory", () => {
     expect(entries.some((entry) => entry.source === "QR Scanner Unavailable")).toBe(true);
     expect(entries.some((entry) => entry.source === "Request ID: \\(value)")).toBe(true);
     expect(entries.some((entry) => entry.source === "Open ${row.title}")).toBe(true);
-    expect(entries.some((entry) => entry.source === "$deviceModel · $appVersion")).toBe(true);
     expect(entries.some((entry) => entry.source === "Approval command copied")).toBe(true);
     expect(entries.some((entry) => entry.source === "Save Profile")).toBe(true);
     expect(entries.some((entry) => entry.source === "Mute")).toBe(true);


### PR DESCRIPTION
Related: #102809

## What Problem This Solves

Fixes an issue where every full CI run fails in the native-app i18n inventory after the Android orphan-screen cleanup removed the last `$deviceModel · $appVersion` source string.

## Why This Change Was Made

The inventory test still contains many active Android and Apple source assertions, including Kotlin interpolation coverage. This removes only the assertion for the deleted settings-screen copy; it does not weaken inventory generation or production behavior.

This test-only `main` repair is required to validate the active Google Chat, Gemini, model-catalog, and CLI-audio fixes currently in the landing queue.

## User Impact

No product behavior changes. Full CI can validate new changes again instead of failing on copy deleted by #102809.

## Evidence

- Before: `node scripts/run-vitest.mjs test/scripts/native-app-i18n.test.ts` failed exactly one assertion at line 53.
- The test file, generated native-source inventory, and entire `apps/android` tree had identical Git object IDs on the failing PR head and current `origin/main`, proving baseline ownership.
- After: the same focused command passes all 5 tests.
- `git diff --check` passes; diff is one deleted stale assertion.
