### PR TITLE
fix(nextcloud-talk): add timeout to room info lookup

### DIFF
--- a/extensions/nextcloud-talk/src/room-info.fetch-timeout.test.ts
+++ b/extensions/nextcloud-talk/src/room-info.fetch-timeout.test.ts
@@ -1,0 +1,49 @@
+// Nextcloud Talk room info lookup tests cover real HTTP timeout behavior.
+import { withServer } from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it, vi } from "vitest";
+import { resolveNextcloudTalkRoomKind, testing } from "./room-info.js";
+
+describe("nextcloud talk room info fetch timeout", () => {
+  it("bounds hanging room info GET requests", async () => {
+    let received = false;
+    const runtimeError = vi.fn();
+
+    try {
+      await withServer(
+        (request) => {
+          received = true;
+          expect(request.method).toBe("GET");
+          expect(request.url).toBe("/ocs/v2.php/apps/spreed/api/v4/room/abc123");
+          request.resume();
+        },
+        async (baseUrl) => {
+          const kind = await resolveNextcloudTalkRoomKind({
+            account: {
+              accountId: "acct-hanging-room-info",
+              baseUrl,
+              config: {
+                apiUser: "bot",
+                apiPassword: "secret",
+                network: { dangerouslyAllowPrivateNetwork: true },
+              },
+            } as never,
+            roomToken: "abc123",
+            runtime: {
+              error: runtimeError,
+              exit: vi.fn(),
+              log: vi.fn(),
+            },
+            timeoutMs: 50,
+          });
+
+          expect(kind).toBeUndefined();
+        },
+      );
+    } finally {
+      testing.resetRoomCache();
+    }
+
+    expect(received).toBe(true);
+    expect(String(runtimeError.mock.calls[0]?.[0] ?? "")).toMatch(/abort|timeout/i);
+  });
+});

--- a/extensions/nextcloud-talk/src/room-info.test.ts
+++ b/extensions/nextcloud-talk/src/room-info.test.ts
@@ -20,11 +20,14 @@ afterEach(() => {
   }
 });
 
-function requireFirstFetchParams(): {
+type RoomInfoFetchParams = {
   auditContext?: string;
   init?: { headers?: { Authorization?: string } };
+  timeoutMs?: number;
   url?: string;
-} {
+};
+
+function requireFirstFetchParams(): RoomInfoFetchParams {
   const [call] = fetchWithSsrFGuard.mock.calls;
   if (!call) {
     throw new Error("expected Nextcloud Talk room info fetch call");
@@ -33,7 +36,7 @@ function requireFirstFetchParams(): {
   if (!fetchParams || typeof fetchParams !== "object" || Array.isArray(fetchParams)) {
     throw new Error("expected Nextcloud Talk room info fetch call");
   }
-  return fetchParams as { auditContext?: string; url?: string };
+  return fetchParams as RoomInfoFetchParams;
 }
 
 function jsonResponse(payload: unknown, init?: ResponseInit): Response {
@@ -76,6 +79,7 @@ describe("nextcloud talk room info", () => {
       "https://nc.example.com/ocs/v2.php/apps/spreed/api/v4/room/room-direct",
     );
     expect(fetchParams.auditContext).toBe("nextcloud-talk.room-info");
+    expect(fetchParams.timeoutMs).toBe(30_000);
     expect(release).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/nextcloud-talk/src/room-info.ts
+++ b/extensions/nextcloud-talk/src/room-info.ts
@@ -11,6 +11,7 @@ import { resolveNextcloudTalkApiCredentials } from "./api-credentials.js";
 const ROOM_CACHE_TTL_MS = 5 * 60 * 1000;
 const ROOM_CACHE_ERROR_TTL_MS = 30 * 1000;
 const ROOM_CACHE_MAX_ENTRIES = 1000;
+const NEXTCLOUD_TALK_ROOM_INFO_TIMEOUT_MS = 30_000;
 
 const roomCache = new Map<
   string,
@@ -56,6 +57,7 @@ export async function resolveNextcloudTalkRoomKind(params: {
   account: ResolvedNextcloudTalkAccount;
   roomToken: string;
   runtime?: RuntimeEnv;
+  timeoutMs?: number;
 }): Promise<"direct" | "group" | undefined> {
   const { account, roomToken, runtime } = params;
   const key = resolveRoomCacheKey({ accountId: account.accountId, roomToken });
@@ -103,6 +105,7 @@ export async function resolveNextcloudTalkRoomKind(params: {
       },
       auditContext: "nextcloud-talk.room-info",
       policy: ssrfPolicyFromPrivateNetworkOptIn(account.config),
+      timeoutMs: params.timeoutMs ?? NEXTCLOUD_TALK_ROOM_INFO_TIMEOUT_MS,
     });
     try {
       if (!response.ok) {


### PR DESCRIPTION
## What Problem This Solves

Nextcloud Talk room-kind lookup could wait indefinitely when the Talk server accepts the room-info HTTP request but never sends a response.

## Why This Change Was Made

The room-info lookup already goes through the existing guarded fetch path and SSRF policy. This change adds a bounded request timeout to that same call while preserving existing auth headers, cache behavior, and error-to-undefined fallback handling.

## User Impact

A stalled self-hosted or remote Nextcloud Talk endpoint no longer leaves room classification pending forever. The lookup fails boundedly, records the existing short error cache entry, and continues with the established undefined-kind fallback.

## Evidence

- `node scripts/run-vitest.mjs run extensions/nextcloud-talk/src/room-info.fetch-timeout.test.ts` - passed; `Test Files  1 passed (1)`, `Tests  1 passed (1)`.
- Current-head base refresh: after merging latest `upstream/main`, reran `node scripts/run-vitest.mjs run extensions/nextcloud-talk/src/room-info.fetch-timeout.test.ts` - passed; `Test Files  1 passed (1)`, `Tests  1 passed (1)`.
- `pnpm exec oxfmt --check --threads=1 extensions/nextcloud-talk/src/room-info.ts extensions/nextcloud-talk/src/room-info.fetch-timeout.test.ts` - passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/nextcloud-talk/src/room-info.ts extensions/nextcloud-talk/src/room-info.fetch-timeout.test.ts` - passed; exit 0.
- `git diff --check upstream/main..HEAD` - passed; exit 0.
- Open PR collision check: searched open PR topics and scanned the latest 500 open PR changed-file lists; no open PR touched `extensions/nextcloud-talk/src/room-info.ts`.

## Real behavior proof

Behavior addressed: Nextcloud Talk room-info GETs now have a deadline when the remote server accepts the connection but never sends a response.

Real environment tested: local Linux Node source checkout; real `node:http` loopback server that receives the exported `resolveNextcloudTalkRoomKind` request and deliberately never responds.

Exact command run after this patch: `node scripts/run-vitest.mjs run extensions/nextcloud-talk/src/room-info.fetch-timeout.test.ts`

Evidence after fix: the focused test asserts the loopback server receives `GET /ocs/v2.php/apps/spreed/api/v4/room/abc123`; with the timeout wiring the lookup returns `undefined` and logs an abort/timeout-class error instead of staying pending.

What was not tested: a live Nextcloud Talk endpoint; the hang is reproduced with a real local HTTP server, not the real third-party service.