### PR TITLE
fix(minimax): add timeouts to OAuth HTTP requests

### DIFF
--- a/extensions/minimax/oauth.test.ts
+++ b/extensions/minimax/oauth.test.ts
@@ -1,4 +1,6 @@
 // Minimax tests cover oauth plugin behavior.
+import { createServer } from "node:http";
+import type { Socket } from "node:net";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { loginMiniMaxPortalOAuth, normalizeOAuthExpires } from "./oauth.js";
@@ -23,6 +25,158 @@ function cancelTrackedResponse(
     response: new Response(stream, init),
     wasCanceled: () => canceled,
   };
+}
+
+function timeoutResult<T>(value: T, timeoutMs: number): Promise<T> {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(value), timeoutMs);
+  });
+}
+
+async function listenOnLoopback(server: ReturnType<typeof createServer>): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const onError = (err: Error) => reject(err);
+    server.once("error", onError);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", onError);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("expected loopback TCP address"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+async function startHangingLoopbackServer(): Promise<{
+  origin: string;
+  requests: string[];
+  waitForRequestCount: (count: number) => Promise<void>;
+  close: () => Promise<void>;
+}> {
+  type RequestWaiter = {
+    count: number;
+    resolve: () => void;
+    reject: (error: Error) => void;
+    timer?: ReturnType<typeof setTimeout>;
+  };
+
+  const sockets = new Set<Socket>();
+  const requests: string[] = [];
+  const waiters: RequestWaiter[] = [];
+
+  const resolveWaiters = () => {
+    for (let index = waiters.length - 1; index >= 0; index -= 1) {
+      const waiter = waiters[index];
+      if (!waiter || requests.length < waiter.count) {
+        continue;
+      }
+      waiters.splice(index, 1);
+      if (waiter.timer) {
+        clearTimeout(waiter.timer);
+      }
+      waiter.resolve();
+    }
+  };
+
+  const server = createServer((req, _res) => {
+    requests.push(req.url ?? "");
+    req.resume();
+    resolveWaiters();
+  });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+  });
+
+  const port = await listenOnLoopback(server);
+  return {
+    origin: `http://127.0.0.1:${port}`,
+    requests,
+    waitForRequestCount: async (count: number) => {
+      if (requests.length >= count) {
+        return;
+      }
+      await new Promise<void>((resolve, reject) => {
+        const waiter: RequestWaiter = {
+          count,
+          resolve,
+          reject,
+        };
+        waiter.timer = setTimeout(() => {
+          const index = waiters.indexOf(waiter);
+          if (index >= 0) {
+            waiters.splice(index, 1);
+          }
+          reject(new Error(`server received ${requests.length} request(s), expected ${count}`));
+        }, 500);
+        waiters.push(waiter);
+      });
+    },
+    close: async () => {
+      for (const waiter of waiters.splice(0)) {
+        if (waiter.timer) {
+          clearTimeout(waiter.timer);
+        }
+        waiter.reject(new Error("server closed"));
+      }
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+async function expectFetchWithoutDeadlineToStayPending(url: string, init?: RequestInit) {
+  const controller = new AbortController();
+  const request = fetch(url, { ...init, signal: controller.signal });
+  request.catch(() => undefined);
+
+  const result = await Promise.race([
+    request.then(
+      () => "settled" as const,
+      () => "settled" as const,
+    ),
+    timeoutResult("pending" as const, 30),
+  ]);
+
+  controller.abort();
+  await request.catch(() => undefined);
+  expect(result).toBe("pending");
+}
+
+async function loginOutcomeWithin(
+  promise: Promise<unknown>,
+  timeoutMs: number,
+): Promise<
+  | { status: "pending" }
+  | { status: "resolved" }
+  | {
+      status: "rejected";
+      error: unknown;
+    }
+> {
+  return await Promise.race([
+    promise.then(
+      () => ({ status: "resolved" as const }),
+      (error: unknown) => ({ status: "rejected" as const, error }),
+    ),
+    timeoutResult({ status: "pending" as const }, timeoutMs),
+  ]);
+}
+
+function expectAbortOrTimeoutError(error: unknown) {
+  expect(error).toHaveProperty("name", expect.stringMatching(/^(AbortError|TimeoutError)$/));
 }
 
 afterEach(() => {
@@ -52,6 +206,102 @@ describe("normalizeOAuthExpires", () => {
 });
 
 describe("loginMiniMaxPortalOAuth", () => {
+  it("times out authorization code HTTP requests against a hanging loopback server", async () => {
+    const realFetch = fetch;
+    const server = await startHangingLoopbackServer();
+    let loginPromise: Promise<unknown> | undefined;
+
+    try {
+      await expectFetchWithoutDeadlineToStayPending(`${server.origin}/control`, {
+        method: "POST",
+        body: "response_type=code",
+      });
+      await server.waitForRequestCount(1);
+
+      const fetchMock = vi.fn(
+        async (_input: RequestInfo | URL, init?: RequestInit) =>
+          await realFetch(`${server.origin}/device-code`, init),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      loginPromise = loginMiniMaxPortalOAuth({
+        openUrl: vi.fn(async () => undefined),
+        note: vi.fn(async () => undefined),
+        progress: { update: vi.fn(), stop: vi.fn() },
+        requestTimeoutMs: 50,
+      });
+      loginPromise.catch(() => undefined);
+
+      await server.waitForRequestCount(2);
+      const result = await loginOutcomeWithin(loginPromise, 500);
+      if (result.status !== "rejected") {
+        throw new Error(`expected authorization code request to reject, got ${result.status}`);
+      }
+      expectAbortOrTimeoutError(result.error);
+      expect(server.requests).toContain("/device-code");
+      expect(fetchMock.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+    } finally {
+      await server.close();
+      await loginPromise?.catch(() => undefined);
+    }
+  });
+
+  it("times out token polling HTTP requests against a hanging loopback server", async () => {
+    const realFetch = fetch;
+    const server = await startHangingLoopbackServer();
+    let loginPromise: Promise<unknown> | undefined;
+
+    try {
+      await expectFetchWithoutDeadlineToStayPending(`${server.origin}/control`, {
+        method: "POST",
+        body: "grant_type=user_code",
+      });
+      await server.waitForRequestCount(1);
+
+      let callCount = 0;
+      const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        callCount += 1;
+        const body =
+          init?.body instanceof URLSearchParams
+            ? init.body
+            : new URLSearchParams(typeof init?.body === "string" ? init.body : "");
+        if (callCount === 1) {
+          return new Response(
+            JSON.stringify({
+              user_code: "CODE",
+              verification_uri: "https://example.com/device",
+              expired_in: Date.now() + 10_000,
+              state: body.get("state"),
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        return await realFetch(`${server.origin}/token`, init);
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      loginPromise = loginMiniMaxPortalOAuth({
+        openUrl: vi.fn(async () => undefined),
+        note: vi.fn(async () => undefined),
+        progress: { update: vi.fn(), stop: vi.fn() },
+        requestTimeoutMs: 50,
+      });
+      loginPromise.catch(() => undefined);
+
+      await server.waitForRequestCount(2);
+      const result = await loginOutcomeWithin(loginPromise, 500);
+      if (result.status !== "rejected") {
+        throw new Error(`expected token polling request to reject, got ${result.status}`);
+      }
+      expectAbortOrTimeoutError(result.error);
+      expect(server.requests).toContain("/token");
+      expect(fetchMock.mock.calls[1]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+    } finally {
+      await server.close();
+      await loginPromise?.catch(() => undefined);
+    }
+  });
+
   it("bounds authorization error bodies without using response.text()", async () => {
     const tracked = cancelTrackedResponse(
       `${"minimax authorization unavailable ".repeat(1024)}tail`,

--- a/extensions/minimax/oauth.test.ts
+++ b/extensions/minimax/oauth.test.ts
@@ -6,7 +6,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { loginMiniMaxPortalOAuth, normalizeOAuthExpires } from "./oauth.js";
 
 const MINIMAX_OAUTH_FETCH_TIMEOUT_MS = 30_000;
-const ACCELERATED_FETCH_TIMEOUT_MS = 50;
 
 function cancelTrackedResponse(
   text: string,
@@ -36,19 +35,31 @@ function timeoutResult<T>(value: T, timeoutMs: number): Promise<T> {
   });
 }
 
-function accelerateMiniMaxOAuthFetchTimeout() {
+function captureMiniMaxOAuthFetchTimeout() {
   const originalSetTimeout = globalThis.setTimeout;
-  return vi
-    .spyOn(globalThis, "setTimeout")
-    .mockImplementation(((
-      callback: (...args: unknown[]) => void,
-      timeout?: number,
-      ...args: unknown[]
-    ) =>
-      originalSetTimeout(
-        () => callback(...args),
-        timeout === MINIMAX_OAUTH_FETCH_TIMEOUT_MS ? ACCELERATED_FETCH_TIMEOUT_MS : timeout,
-      )) as typeof setTimeout);
+  let fireTimeout: (() => void) | undefined;
+  const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+    callback: (...args: unknown[]) => void,
+    timeout?: number,
+    ...args: unknown[]
+  ) => {
+    if (timeout === MINIMAX_OAUTH_FETCH_TIMEOUT_MS) {
+      fireTimeout = () => callback(...args);
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }
+    return originalSetTimeout(() => callback(...args), timeout);
+  }) as typeof setTimeout);
+  return {
+    setTimeoutSpy,
+    fire() {
+      if (!fireTimeout) {
+        throw new Error("expected MiniMax OAuth fetch timeout to be scheduled");
+      }
+      const callback = fireTimeout;
+      fireTimeout = undefined;
+      callback();
+    },
+  };
 }
 
 async function listenOnLoopback(server: ReturnType<typeof createServer>): Promise<number> {
@@ -128,7 +139,7 @@ async function startHangingLoopbackServer(): Promise<{
             waiters.splice(index, 1);
           }
           reject(new Error(`server received ${requests.length} request(s), expected ${count}`));
-        }, 500);
+        }, 2_000);
         waiters.push(waiter);
       });
     },
@@ -155,10 +166,15 @@ async function startHangingLoopbackServer(): Promise<{
   };
 }
 
-async function expectFetchWithoutDeadlineToStayPending(url: string, init?: RequestInit) {
+async function expectFetchWithoutDeadlineToStayPending(params: {
+  url: string;
+  init?: RequestInit;
+  waitForRequest: () => Promise<void>;
+}) {
   const controller = new AbortController();
-  const request = fetch(url, { ...init, signal: controller.signal });
+  const request = fetch(params.url, { ...params.init, signal: controller.signal });
   request.catch(() => undefined);
+  await params.waitForRequest();
 
   const result = await Promise.race([
     request.then(
@@ -227,15 +243,15 @@ describe("loginMiniMaxPortalOAuth", () => {
   it("times out authorization code HTTP requests against a hanging loopback server", async () => {
     const realFetch = fetch;
     const server = await startHangingLoopbackServer();
-    const setTimeoutSpy = accelerateMiniMaxOAuthFetchTimeout();
+    const oauthTimeout = captureMiniMaxOAuthFetchTimeout();
     let loginPromise: Promise<unknown> | undefined;
 
     try {
-      await expectFetchWithoutDeadlineToStayPending(`${server.origin}/control`, {
-        method: "POST",
-        body: "response_type=code",
+      await expectFetchWithoutDeadlineToStayPending({
+        url: `${server.origin}/control`,
+        init: { method: "POST", body: "response_type=code" },
+        waitForRequest: () => server.waitForRequestCount(1),
       });
-      await server.waitForRequestCount(1);
 
       const fetchMock = vi.fn(
         async (_input: RequestInfo | URL, init?: RequestInit) =>
@@ -251,7 +267,8 @@ describe("loginMiniMaxPortalOAuth", () => {
       loginPromise.catch(() => undefined);
 
       await server.waitForRequestCount(2);
-      const result = await loginOutcomeWithin(loginPromise, 500);
+      oauthTimeout.fire();
+      const result = await loginOutcomeWithin(loginPromise, 2_000);
       if (result.status !== "rejected") {
         throw new Error(`expected authorization code request to reject, got ${result.status}`);
       }
@@ -259,7 +276,9 @@ describe("loginMiniMaxPortalOAuth", () => {
       expect(server.requests).toContain("/device-code");
       expect(fetchMock.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
       expect(
-        setTimeoutSpy.mock.calls.some(([, timeout]) => timeout === MINIMAX_OAUTH_FETCH_TIMEOUT_MS),
+        oauthTimeout.setTimeoutSpy.mock.calls.some(
+          ([, timeout]) => timeout === MINIMAX_OAUTH_FETCH_TIMEOUT_MS,
+        ),
       ).toBe(true);
     } finally {
       await server.close();
@@ -270,15 +289,15 @@ describe("loginMiniMaxPortalOAuth", () => {
   it("times out token polling HTTP requests against a hanging loopback server", async () => {
     const realFetch = fetch;
     const server = await startHangingLoopbackServer();
-    const setTimeoutSpy = accelerateMiniMaxOAuthFetchTimeout();
+    const oauthTimeout = captureMiniMaxOAuthFetchTimeout();
     let loginPromise: Promise<unknown> | undefined;
 
     try {
-      await expectFetchWithoutDeadlineToStayPending(`${server.origin}/control`, {
-        method: "POST",
-        body: "grant_type=user_code",
+      await expectFetchWithoutDeadlineToStayPending({
+        url: `${server.origin}/control`,
+        init: { method: "POST", body: "grant_type=user_code" },
+        waitForRequest: () => server.waitForRequestCount(1),
       });
-      await server.waitForRequestCount(1);
 
       let callCount = 0;
       const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
@@ -310,7 +329,8 @@ describe("loginMiniMaxPortalOAuth", () => {
       loginPromise.catch(() => undefined);
 
       await server.waitForRequestCount(2);
-      const result = await loginOutcomeWithin(loginPromise, 500);
+      oauthTimeout.fire();
+      const result = await loginOutcomeWithin(loginPromise, 2_000);
       if (result.status !== "rejected") {
         throw new Error(`expected token polling request to reject, got ${result.status}`);
       }
@@ -318,7 +338,9 @@ describe("loginMiniMaxPortalOAuth", () => {
       expect(server.requests).toContain("/token");
       expect(fetchMock.mock.calls[1]?.[1]?.signal).toBeInstanceOf(AbortSignal);
       expect(
-        setTimeoutSpy.mock.calls.some(([, timeout]) => timeout === MINIMAX_OAUTH_FETCH_TIMEOUT_MS),
+        oauthTimeout.setTimeoutSpy.mock.calls.some(
+          ([, timeout]) => timeout === MINIMAX_OAUTH_FETCH_TIMEOUT_MS,
+        ),
       ).toBe(true);
     } finally {
       await server.close();

--- a/extensions/minimax/oauth.test.ts
+++ b/extensions/minimax/oauth.test.ts
@@ -5,6 +5,9 @@ import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { loginMiniMaxPortalOAuth, normalizeOAuthExpires } from "./oauth.js";
 
+const MINIMAX_OAUTH_FETCH_TIMEOUT_MS = 30_000;
+const ACCELERATED_FETCH_TIMEOUT_MS = 50;
+
 function cancelTrackedResponse(
   text: string,
   init: ResponseInit,
@@ -31,6 +34,21 @@ function timeoutResult<T>(value: T, timeoutMs: number): Promise<T> {
   return new Promise((resolve) => {
     setTimeout(() => resolve(value), timeoutMs);
   });
+}
+
+function accelerateMiniMaxOAuthFetchTimeout() {
+  const originalSetTimeout = globalThis.setTimeout;
+  return vi
+    .spyOn(globalThis, "setTimeout")
+    .mockImplementation(((
+      callback: (...args: unknown[]) => void,
+      timeout?: number,
+      ...args: unknown[]
+    ) =>
+      originalSetTimeout(
+        () => callback(...args),
+        timeout === MINIMAX_OAUTH_FETCH_TIMEOUT_MS ? ACCELERATED_FETCH_TIMEOUT_MS : timeout,
+      )) as typeof setTimeout);
 }
 
 async function listenOnLoopback(server: ReturnType<typeof createServer>): Promise<number> {
@@ -209,6 +227,7 @@ describe("loginMiniMaxPortalOAuth", () => {
   it("times out authorization code HTTP requests against a hanging loopback server", async () => {
     const realFetch = fetch;
     const server = await startHangingLoopbackServer();
+    const setTimeoutSpy = accelerateMiniMaxOAuthFetchTimeout();
     let loginPromise: Promise<unknown> | undefined;
 
     try {
@@ -228,7 +247,6 @@ describe("loginMiniMaxPortalOAuth", () => {
         openUrl: vi.fn(async () => undefined),
         note: vi.fn(async () => undefined),
         progress: { update: vi.fn(), stop: vi.fn() },
-        requestTimeoutMs: 50,
       });
       loginPromise.catch(() => undefined);
 
@@ -240,6 +258,9 @@ describe("loginMiniMaxPortalOAuth", () => {
       expectAbortOrTimeoutError(result.error);
       expect(server.requests).toContain("/device-code");
       expect(fetchMock.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+      expect(
+        setTimeoutSpy.mock.calls.some(([, timeout]) => timeout === MINIMAX_OAUTH_FETCH_TIMEOUT_MS),
+      ).toBe(true);
     } finally {
       await server.close();
       await loginPromise?.catch(() => undefined);
@@ -249,6 +270,7 @@ describe("loginMiniMaxPortalOAuth", () => {
   it("times out token polling HTTP requests against a hanging loopback server", async () => {
     const realFetch = fetch;
     const server = await startHangingLoopbackServer();
+    const setTimeoutSpy = accelerateMiniMaxOAuthFetchTimeout();
     let loginPromise: Promise<unknown> | undefined;
 
     try {
@@ -284,7 +306,6 @@ describe("loginMiniMaxPortalOAuth", () => {
         openUrl: vi.fn(async () => undefined),
         note: vi.fn(async () => undefined),
         progress: { update: vi.fn(), stop: vi.fn() },
-        requestTimeoutMs: 50,
       });
       loginPromise.catch(() => undefined);
 
@@ -296,6 +317,9 @@ describe("loginMiniMaxPortalOAuth", () => {
       expectAbortOrTimeoutError(result.error);
       expect(server.requests).toContain("/token");
       expect(fetchMock.mock.calls[1]?.[1]?.signal).toBeInstanceOf(AbortSignal);
+      expect(
+        setTimeoutSpy.mock.calls.some(([, timeout]) => timeout === MINIMAX_OAUTH_FETCH_TIMEOUT_MS),
+      ).toBe(true);
     } finally {
       await server.close();
       await loginPromise?.catch(() => undefined);

--- a/extensions/minimax/oauth.ts
+++ b/extensions/minimax/oauth.ts
@@ -5,7 +5,6 @@ import {
   asSafeIntegerInRange,
   resolveExpiresAtMsFromDurationOrEpoch,
   resolvePositiveTimerTimeoutMs,
-  resolveTimerTimeoutMs,
 } from "openclaw/plugin-sdk/number-runtime";
 import { generatePkceVerifierChallenge, toFormUrlEncoded } from "openclaw/plugin-sdk/provider-auth";
 import {
@@ -87,10 +86,6 @@ function normalizeOAuthAuthorizationExpires(expiredIn: unknown): number | undefi
   return asSafeIntegerInRange(expiredIn, { min: 1, max: MAX_DATE_TIMESTAMP_MS });
 }
 
-function resolveMiniMaxOAuthFetchTimeoutMs(value: unknown): number {
-  return resolveTimerTimeoutMs(value, MINIMAX_OAUTH_FETCH_TIMEOUT_MS);
-}
-
 function generatePkce(): { verifier: string; challenge: string; state: string } {
   const { verifier, challenge } = generatePkceVerifierChallenge();
   const state = randomBytes(16).toString("base64url");
@@ -101,7 +96,6 @@ async function requestOAuthCode(params: {
   challenge: string;
   state: string;
   region: MiniMaxRegion;
-  requestTimeoutMs: number;
 }): Promise<MiniMaxOAuthAuthorization> {
   const endpoints = getOAuthEndpoints(params.region);
   const { response, release } = await fetchWithSsrFGuard({
@@ -122,7 +116,7 @@ async function requestOAuthCode(params: {
         state: params.state,
       }),
     },
-    timeoutMs: params.requestTimeoutMs,
+    timeoutMs: MINIMAX_OAUTH_FETCH_TIMEOUT_MS,
     policy: { allowedHostnames: [endpoints.hostname] },
     auditContext: "minimax.oauth.code",
   });
@@ -159,7 +153,6 @@ async function pollOAuthToken(params: {
   userCode: string;
   verifier: string;
   region: MiniMaxRegion;
-  requestTimeoutMs: number;
 }): Promise<TokenResult> {
   const endpoints = getOAuthEndpoints(params.region);
   const { response, release } = await fetchWithSsrFGuard({
@@ -177,7 +170,7 @@ async function pollOAuthToken(params: {
         code_verifier: params.verifier,
       }),
     },
-    timeoutMs: params.requestTimeoutMs,
+    timeoutMs: MINIMAX_OAUTH_FETCH_TIMEOUT_MS,
     policy: { allowedHostnames: [endpoints.hostname] },
     auditContext: "minimax.oauth.token",
   });
@@ -259,15 +252,13 @@ export async function loginMiniMaxPortalOAuth(params: {
   note: (message: string, title?: string) => Promise<void>;
   progress: { update: (message: string) => void; stop: (message?: string) => void };
   region?: MiniMaxRegion;
-  requestTimeoutMs?: number;
 }): Promise<MiniMaxOAuthToken> {
   // Ensure env-based proxy dispatcher is active before any outbound fetch calls.
   // Without this, HTTP_PROXY/HTTPS_PROXY env vars are silently ignored (#51619).
   ensureGlobalUndiciEnvProxyDispatcher();
   const region = params.region ?? "global";
-  const requestTimeoutMs = resolveMiniMaxOAuthFetchTimeoutMs(params.requestTimeoutMs);
   const { verifier, challenge, state } = generatePkce();
-  const oauth = await requestOAuthCode({ challenge, state, region, requestTimeoutMs });
+  const oauth = await requestOAuthCode({ challenge, state, region });
   const verificationUrl = oauth.verification_uri;
 
   const noteLines = [
@@ -293,7 +284,6 @@ export async function loginMiniMaxPortalOAuth(params: {
       userCode: oauth.user_code,
       verifier,
       region,
-      requestTimeoutMs,
     });
 
     if (result.status === "success") {

--- a/extensions/minimax/oauth.ts
+++ b/extensions/minimax/oauth.ts
@@ -12,7 +12,6 @@ import {
   readProviderJsonResponse,
   readResponseTextLimited,
 } from "openclaw/plugin-sdk/provider-http";
-import { buildOAuthRequestSignal } from "openclaw/plugin-sdk/provider-oauth-runtime";
 import { ensureGlobalUndiciEnvProxyDispatcher } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 
@@ -122,7 +121,6 @@ async function requestOAuthCode(params: {
         code_challenge_method: "S256",
         state: params.state,
       }),
-      signal: buildOAuthRequestSignal({ timeoutMs: params.requestTimeoutMs }),
     },
     timeoutMs: params.requestTimeoutMs,
     policy: { allowedHostnames: [endpoints.hostname] },
@@ -178,7 +176,6 @@ async function pollOAuthToken(params: {
         user_code: params.userCode,
         code_verifier: params.verifier,
       }),
-      signal: buildOAuthRequestSignal({ timeoutMs: params.requestTimeoutMs }),
     },
     timeoutMs: params.requestTimeoutMs,
     policy: { allowedHostnames: [endpoints.hostname] },

--- a/extensions/minimax/oauth.ts
+++ b/extensions/minimax/oauth.ts
@@ -5,12 +5,14 @@ import {
   asSafeIntegerInRange,
   resolveExpiresAtMsFromDurationOrEpoch,
   resolvePositiveTimerTimeoutMs,
+  resolveTimerTimeoutMs,
 } from "openclaw/plugin-sdk/number-runtime";
 import { generatePkceVerifierChallenge, toFormUrlEncoded } from "openclaw/plugin-sdk/provider-auth";
 import {
   readProviderJsonResponse,
   readResponseTextLimited,
 } from "openclaw/plugin-sdk/provider-http";
+import { buildOAuthRequestSignal } from "openclaw/plugin-sdk/provider-oauth-runtime";
 import { ensureGlobalUndiciEnvProxyDispatcher } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 
@@ -34,6 +36,7 @@ const MINIMAX_OAUTH_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:user_code";
 const MINIMAX_RELATIVE_EXPIRY_SECONDS_THRESHOLD = 1_000_000_000;
 const MINIMAX_ABSOLUTE_EXPIRY_MS_THRESHOLD = 1_000_000_000_000;
 const MINIMAX_OAUTH_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
+const MINIMAX_OAUTH_FETCH_TIMEOUT_MS = 30_000;
 
 function getOAuthEndpoints(region: MiniMaxRegion) {
   const config = MINIMAX_OAUTH_CONFIG[region];
@@ -85,6 +88,10 @@ function normalizeOAuthAuthorizationExpires(expiredIn: unknown): number | undefi
   return asSafeIntegerInRange(expiredIn, { min: 1, max: MAX_DATE_TIMESTAMP_MS });
 }
 
+function resolveMiniMaxOAuthFetchTimeoutMs(value: unknown): number {
+  return resolveTimerTimeoutMs(value, MINIMAX_OAUTH_FETCH_TIMEOUT_MS);
+}
+
 function generatePkce(): { verifier: string; challenge: string; state: string } {
   const { verifier, challenge } = generatePkceVerifierChallenge();
   const state = randomBytes(16).toString("base64url");
@@ -95,6 +102,7 @@ async function requestOAuthCode(params: {
   challenge: string;
   state: string;
   region: MiniMaxRegion;
+  requestTimeoutMs: number;
 }): Promise<MiniMaxOAuthAuthorization> {
   const endpoints = getOAuthEndpoints(params.region);
   const { response, release } = await fetchWithSsrFGuard({
@@ -114,7 +122,9 @@ async function requestOAuthCode(params: {
         code_challenge_method: "S256",
         state: params.state,
       }),
+      signal: buildOAuthRequestSignal({ timeoutMs: params.requestTimeoutMs }),
     },
+    timeoutMs: params.requestTimeoutMs,
     policy: { allowedHostnames: [endpoints.hostname] },
     auditContext: "minimax.oauth.code",
   });
@@ -151,6 +161,7 @@ async function pollOAuthToken(params: {
   userCode: string;
   verifier: string;
   region: MiniMaxRegion;
+  requestTimeoutMs: number;
 }): Promise<TokenResult> {
   const endpoints = getOAuthEndpoints(params.region);
   const { response, release } = await fetchWithSsrFGuard({
@@ -167,7 +178,9 @@ async function pollOAuthToken(params: {
         user_code: params.userCode,
         code_verifier: params.verifier,
       }),
+      signal: buildOAuthRequestSignal({ timeoutMs: params.requestTimeoutMs }),
     },
+    timeoutMs: params.requestTimeoutMs,
     policy: { allowedHostnames: [endpoints.hostname] },
     auditContext: "minimax.oauth.token",
   });
@@ -249,13 +262,15 @@ export async function loginMiniMaxPortalOAuth(params: {
   note: (message: string, title?: string) => Promise<void>;
   progress: { update: (message: string) => void; stop: (message?: string) => void };
   region?: MiniMaxRegion;
+  requestTimeoutMs?: number;
 }): Promise<MiniMaxOAuthToken> {
   // Ensure env-based proxy dispatcher is active before any outbound fetch calls.
   // Without this, HTTP_PROXY/HTTPS_PROXY env vars are silently ignored (#51619).
   ensureGlobalUndiciEnvProxyDispatcher();
   const region = params.region ?? "global";
+  const requestTimeoutMs = resolveMiniMaxOAuthFetchTimeoutMs(params.requestTimeoutMs);
   const { verifier, challenge, state } = generatePkce();
-  const oauth = await requestOAuthCode({ challenge, state, region });
+  const oauth = await requestOAuthCode({ challenge, state, region, requestTimeoutMs });
   const verificationUrl = oauth.verification_uri;
 
   const noteLines = [
@@ -281,6 +296,7 @@ export async function loginMiniMaxPortalOAuth(params: {
       userCode: oauth.user_code,
       verifier,
       region,
+      requestTimeoutMs,
     });
 
     if (result.status === "success") {


### PR DESCRIPTION
## What Problem This Solves

MiniMax OAuth login could wait indefinitely when either the device-code request or token-poll request accepted the HTTP connection but never returned a response.

## Why This Change Was Made

The OAuth flow already bounds polling and authorization expiry, but each outbound HTTP request lacked its own deadline. This change gives both guarded POSTs one provider-owned 30-second deadline while preserving PKCE payloads, SSRF hostname policy, bounded error reads, and polling behavior.

Maintainer preparation kept that timeout internal instead of exposing a test-only override. The regressions capture the production timeout callback and fire it only after a real loopback server confirms request receipt, so they prove stalled-response behavior without short wall-clock races.

## User Impact

A stalled MiniMax OAuth endpoint no longer leaves login wedged. Authorization-code and token-poll hangs reject boundedly instead of waiting forever.

## Evidence

- Exact prepared head: `d9f05ef74426ac87cf236eeaf9e8c069ccaedd41`.
- Sanitized public-network AWS Crabbox `run_f4ac0dda4e25` on the patch-identical pre-rebase head: `pnpm test extensions/minimax/oauth.test.ts` passed, 1 file and 14 tests.
- Blacksmith Testbox `tbx_01kx7n3r5489aa45a154b1hrkd`, Actions run 29138804960: deterministic timeout fix passed the same 14 tests.
- Fresh exact-head autoreview after rebase: no accepted or actionable findings; patch correct at 0.97 confidence.
- [Exact-head hosted CI run 29140223930](https://github.com/openclaw/openclaw/actions/runs/29140223930) passed all 45 jobs with zero failures; `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 102862` verified the same hosted gates.
- `git diff --check origin/main...HEAD` passed.

## Real behavior proof

The focused tests use a real `node:http` loopback server that accepts requests and deliberately never responds. A bare fetch is first confirmed received and still pending without a deadline. The exported `loginMiniMaxPortalOAuth` path is then exercised for both authorization-code and token-poll requests; after the server confirms receipt, the captured production 30-second deadline is fired and each request rejects with abort/timeout semantics.

Live MiniMax account approval was not exercised. The exact network failure mode is reproduced locally without third-party credentials.
