### PR TITLE
fix(discord): add timeouts to voice upload requests

### DIFF
--- a/extensions/discord/src/voice-message.test.ts
+++ b/extensions/discord/src/voice-message.test.ts
@@ -1,14 +1,13 @@
 // Discord tests cover voice message plugin behavior.
 import fs from "node:fs/promises";
-import { createServer, type Server } from "node:http";
-import type { Socket } from "node:net";
 import path from "node:path";
+import { withServer } from "openclaw/plugin-sdk/test-env";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RequestClient } from "./internal/discord.js";
+import { DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS } from "./monitor/timeouts.js";
 import type { VoiceMessageMetadata } from "./voice-message.js";
 
-const DISCORD_VOICE_UPLOAD_REQUEST_TIMEOUT_MS = 120_000;
-const GUARDED_FETCH_TEST_TIMEOUT_CLAMP_MS = 500;
+const GUARDED_FETCH_TEST_TIMEOUT_MS = 250;
 
 const runFfprobeMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<string>>());
 const runFfmpegMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<void>>());
@@ -18,59 +17,22 @@ const fetchWithSsrFGuardMock = vi.hoisted(() =>
       url: string;
       init?: RequestInit;
       timeoutMs?: number;
-      signal?: AbortSignal;
       policy?: { allowRfc2544BenchmarkRange?: boolean; allowIpv6UniqueLocalRange?: boolean };
       auditContext?: string;
-    }) => ({
-      response: await fetchWithGuardedTestTimeout(params),
-      release: async () => {},
-    }),
+    }) => {
+      if (!Number.isFinite(params.timeoutMs) || (params.timeoutMs ?? 0) <= 0) {
+        throw new Error("guarded voice upload fetch requires a finite timeout");
+      }
+      return {
+        response: await globalThis.fetch(params.url, {
+          ...params.init,
+          signal: AbortSignal.timeout(GUARDED_FETCH_TEST_TIMEOUT_MS),
+        }),
+        release: async () => {},
+      };
+    },
   ),
 );
-
-function fetchWithGuardedTestTimeout(params: {
-  url: string;
-  init?: RequestInit;
-  timeoutMs?: number;
-  signal?: AbortSignal;
-}): Promise<Response> {
-  if (!params.timeoutMs && !params.signal && !params.init?.signal) {
-    return globalThis.fetch(params.url, params.init);
-  }
-
-  const controller = new AbortController();
-  const onAbort = () => controller.abort();
-  const signals = [params.signal, params.init?.signal].filter((signal): signal is AbortSignal =>
-    Boolean(signal),
-  );
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  for (const signal of signals) {
-    if (signal.aborted) {
-      controller.abort();
-    } else {
-      signal.addEventListener("abort", onAbort, { once: true });
-    }
-  }
-  if (params.timeoutMs) {
-    timeout = setTimeout(
-      () => {
-        const error = new Error(`request timed out after ${params.timeoutMs}ms`);
-        error.name = "TimeoutError";
-        controller.abort(error);
-      },
-      Math.min(params.timeoutMs, GUARDED_FETCH_TEST_TIMEOUT_CLAMP_MS),
-    );
-  }
-
-  return globalThis.fetch(params.url, { ...params.init, signal: controller.signal }).finally(() => {
-    if (timeout) {
-      clearTimeout(timeout);
-    }
-    for (const signal of signals) {
-      signal.removeEventListener("abort", onAbort);
-    }
-  });
-}
 
 vi.mock("openclaw/plugin-sdk/temp-path", async () => {
   return {
@@ -123,30 +85,6 @@ function cancelTrackedResponse(
     response: new Response(stream, init),
     wasCanceled: () => canceled,
   };
-}
-
-async function listenLoopbackServer(server: Server): Promise<string> {
-  return await new Promise((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => {
-      server.off("error", reject);
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        reject(new Error("expected loopback TCP address"));
-        return;
-      }
-      resolve(`http://127.0.0.1:${address.port}`);
-    });
-  });
-}
-
-async function closeLoopbackServer(server: Server, sockets: Set<Socket>): Promise<void> {
-  for (const socket of sockets) {
-    socket.destroy();
-  }
-  await new Promise<void>((resolve) => {
-    server.close(() => resolve());
-  });
 }
 
 describe("ensureOggOpus", () => {
@@ -309,7 +247,7 @@ describe("sendDiscordVoiceMessage", () => {
 
   function createRest(post = vi.fn(async () => ({ id: "msg-1", channel_id: "channel-1" }))) {
     return {
-      options: { baseUrl: "https://discord.test/api/v10" },
+      options: { baseUrl: "https://discord.test/api/v10", timeout: 17 },
       post,
     } as unknown as RequestClient;
   }
@@ -526,98 +464,59 @@ describe("sendDiscordVoiceMessage", () => {
   });
 
   it.each([
-    {
-      label: "upload URL request",
-      expectedHangingRoute: "POST /api/v10/channels/channel-1/attachments",
-      hangUploadUrl: true,
-    },
-    {
-      label: "PUT upload request",
-      expectedHangingRoute: "PUT /upload",
-      hangUploadUrl: false,
-    },
-  ])("times out a hanging $label", async ({ expectedHangingRoute, hangUploadUrl }) => {
-    const sockets = new Set<Socket>();
-    const requests: string[] = [];
-    const closedResponses: string[] = [];
+    ["upload URL request", "POST /api/v10/channels/channel-1/attachments", 37],
+    ["PUT upload request", "PUT /upload", DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS],
+  ])("times out a hanging %s", async (_label, hangingRoute, expectedTimeoutMs) => {
+    const closedResponses = vi.fn();
     let baseUrl = "";
-    const server = createServer((req, res) => {
-      const route = `${req.method ?? "GET"} ${req.url ?? "/"}`;
-      requests.push(route);
-      res.on("close", () => {
-        closedResponses.push(route);
-      });
-
-      if (route === "POST /api/v10/channels/channel-1/attachments") {
-        if (hangUploadUrl) {
+    await withServer(
+      (req, res) => {
+        req.resume();
+        const route = `${req.method ?? "GET"} ${req.url ?? "/"}`;
+        res.on("close", () => closedResponses(route));
+        if (route === hangingRoute) {
+          return;
+        }
+        if (route !== "POST /api/v10/channels/channel-1/attachments") {
+          res.statusCode = 500;
+          res.end(`unexpected ${route}`);
           return;
         }
         res.setHeader("content-type", "application/json");
         res.end(
           JSON.stringify({
             attachments: [
-              {
-                id: 0,
-                upload_url: `${baseUrl}/upload`,
-                upload_filename: "uploaded.ogg",
-              },
+              { id: 0, upload_url: `${baseUrl}/upload`, upload_filename: "uploaded.ogg" },
             ],
           }),
         );
-        return;
-      }
+      },
+      async (url) => {
+        baseUrl = url;
+        const rest = {
+          options: { baseUrl: `${baseUrl}/api/v10`, timeout: 37 },
+          post: vi.fn(async () => ({ id: "msg-1", channel_id: "channel-1" })),
+        } as unknown as RequestClient;
 
-      if (route === "PUT /upload") {
-        return;
-      }
+        await expect(
+          sendDiscordVoiceMessage(
+            rest,
+            "channel-1",
+            Buffer.from("ogg"),
+            metadata,
+            undefined,
+            async (fn) => await fn(),
+            false,
+            "bot-token",
+          ),
+        ).rejects.toThrow(/timed out|abort/i);
 
-      res.statusCode = 500;
-      res.end(`unexpected ${route}`);
-    });
-    server.on("connection", (socket) => {
-      sockets.add(socket);
-      socket.on("close", () => {
-        sockets.delete(socket);
-      });
-    });
-    baseUrl = await listenLoopbackServer(server);
-
-    try {
-      const rest = {
-        options: { baseUrl: `${baseUrl}/api/v10` },
-        post: vi.fn(async () => ({ id: "msg-1", channel_id: "channel-1" })),
-      } as unknown as RequestClient;
-
-      const startedAt = Date.now();
-      await expect(
-        sendDiscordVoiceMessage(
-          rest,
-          "channel-1",
-          Buffer.from("ogg"),
-          metadata,
-          undefined,
-          async (fn) => await fn(),
-          false,
-          "bot-token",
-        ),
-      ).rejects.toThrow(/timed out|abort/i);
-
-      expect(Date.now() - startedAt).toBeLessThan(5_000);
-      expect(requests).toContain(expectedHangingRoute);
-      await vi.waitFor(() => expect(closedResponses).toContain(expectedHangingRoute));
-      expect(
-        fetchWithSsrFGuardMock.mock.calls.map(([params]) => ({
-          auditContext: params.auditContext,
-          timeoutMs: params.timeoutMs,
-        })),
-      ).toContainEqual({
-        auditContext: hangUploadUrl
-          ? "discord.voice.upload-url"
-          : "discord.voice.attachment-upload",
-        timeoutMs: DISCORD_VOICE_UPLOAD_REQUEST_TIMEOUT_MS,
-      });
-    } finally {
-      await closeLoopbackServer(server, sockets);
-    }
+        await vi.waitFor(() => expect(closedResponses).toHaveBeenCalledWith(hangingRoute));
+        const guardedCall = fetchWithSsrFGuardMock.mock.calls.find(
+          ([params]) => `${params.init?.method} ${new URL(params.url).pathname}` === hangingRoute,
+        );
+        expect(guardedCall?.[0].timeoutMs).toBe(expectedTimeoutMs);
+      },
+    );
   });
 });

--- a/extensions/discord/src/voice-message.test.ts
+++ b/extensions/discord/src/voice-message.test.ts
@@ -1,9 +1,14 @@
 // Discord tests cover voice message plugin behavior.
 import fs from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import type { Socket } from "node:net";
 import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RequestClient } from "./internal/discord.js";
 import type { VoiceMessageMetadata } from "./voice-message.js";
+
+const DISCORD_VOICE_UPLOAD_REQUEST_TIMEOUT_MS = 120_000;
+const GUARDED_FETCH_TEST_TIMEOUT_CLAMP_MS = 500;
 
 const runFfprobeMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<string>>());
 const runFfmpegMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<void>>());
@@ -12,14 +17,60 @@ const fetchWithSsrFGuardMock = vi.hoisted(() =>
     async (params: {
       url: string;
       init?: RequestInit;
+      timeoutMs?: number;
+      signal?: AbortSignal;
       policy?: { allowRfc2544BenchmarkRange?: boolean; allowIpv6UniqueLocalRange?: boolean };
       auditContext?: string;
     }) => ({
-      response: await globalThis.fetch(params.url, params.init),
+      response: await fetchWithGuardedTestTimeout(params),
       release: async () => {},
     }),
   ),
 );
+
+function fetchWithGuardedTestTimeout(params: {
+  url: string;
+  init?: RequestInit;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}): Promise<Response> {
+  if (!params.timeoutMs && !params.signal && !params.init?.signal) {
+    return globalThis.fetch(params.url, params.init);
+  }
+
+  const controller = new AbortController();
+  const onAbort = () => controller.abort();
+  const signals = [params.signal, params.init?.signal].filter((signal): signal is AbortSignal =>
+    Boolean(signal),
+  );
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  for (const signal of signals) {
+    if (signal.aborted) {
+      controller.abort();
+    } else {
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+  }
+  if (params.timeoutMs) {
+    timeout = setTimeout(
+      () => {
+        const error = new Error(`request timed out after ${params.timeoutMs}ms`);
+        error.name = "TimeoutError";
+        controller.abort(error);
+      },
+      Math.min(params.timeoutMs, GUARDED_FETCH_TEST_TIMEOUT_CLAMP_MS),
+    );
+  }
+
+  return globalThis.fetch(params.url, { ...params.init, signal: controller.signal }).finally(() => {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    for (const signal of signals) {
+      signal.removeEventListener("abort", onAbort);
+    }
+  });
+}
 
 vi.mock("openclaw/plugin-sdk/temp-path", async () => {
   return {
@@ -72,6 +123,30 @@ function cancelTrackedResponse(
     response: new Response(stream, init),
     wasCanceled: () => canceled,
   };
+}
+
+async function listenLoopbackServer(server: Server): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("expected loopback TCP address"));
+        return;
+      }
+      resolve(`http://127.0.0.1:${address.port}`);
+    });
+  });
+}
+
+async function closeLoopbackServer(server: Server, sockets: Set<Socket>): Promise<void> {
+  for (const socket of sockets) {
+    socket.destroy();
+  }
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
 }
 
 describe("ensureOggOpus", () => {
@@ -448,5 +523,101 @@ describe("sendDiscordVoiceMessage", () => {
     expect(JSON.stringify((error as { rawBody?: unknown }).rawBody)).not.toContain("tail");
     expect(tracked.wasCanceled()).toBe(true);
     expect(textSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      label: "upload URL request",
+      expectedHangingRoute: "POST /api/v10/channels/channel-1/attachments",
+      hangUploadUrl: true,
+    },
+    {
+      label: "PUT upload request",
+      expectedHangingRoute: "PUT /upload",
+      hangUploadUrl: false,
+    },
+  ])("times out a hanging $label", async ({ expectedHangingRoute, hangUploadUrl }) => {
+    const sockets = new Set<Socket>();
+    const requests: string[] = [];
+    const closedResponses: string[] = [];
+    let baseUrl = "";
+    const server = createServer((req, res) => {
+      const route = `${req.method ?? "GET"} ${req.url ?? "/"}`;
+      requests.push(route);
+      res.on("close", () => {
+        closedResponses.push(route);
+      });
+
+      if (route === "POST /api/v10/channels/channel-1/attachments") {
+        if (hangUploadUrl) {
+          return;
+        }
+        res.setHeader("content-type", "application/json");
+        res.end(
+          JSON.stringify({
+            attachments: [
+              {
+                id: 0,
+                upload_url: `${baseUrl}/upload`,
+                upload_filename: "uploaded.ogg",
+              },
+            ],
+          }),
+        );
+        return;
+      }
+
+      if (route === "PUT /upload") {
+        return;
+      }
+
+      res.statusCode = 500;
+      res.end(`unexpected ${route}`);
+    });
+    server.on("connection", (socket) => {
+      sockets.add(socket);
+      socket.on("close", () => {
+        sockets.delete(socket);
+      });
+    });
+    baseUrl = await listenLoopbackServer(server);
+
+    try {
+      const rest = {
+        options: { baseUrl: `${baseUrl}/api/v10` },
+        post: vi.fn(async () => ({ id: "msg-1", channel_id: "channel-1" })),
+      } as unknown as RequestClient;
+
+      const startedAt = Date.now();
+      await expect(
+        sendDiscordVoiceMessage(
+          rest,
+          "channel-1",
+          Buffer.from("ogg"),
+          metadata,
+          undefined,
+          async (fn) => await fn(),
+          false,
+          "bot-token",
+        ),
+      ).rejects.toThrow(/timed out|abort/i);
+
+      expect(Date.now() - startedAt).toBeLessThan(5_000);
+      expect(requests).toContain(expectedHangingRoute);
+      await vi.waitFor(() => expect(closedResponses).toContain(expectedHangingRoute));
+      expect(
+        fetchWithSsrFGuardMock.mock.calls.map(([params]) => ({
+          auditContext: params.auditContext,
+          timeoutMs: params.timeoutMs,
+        })),
+      ).toContainEqual({
+        auditContext: hangUploadUrl
+          ? "discord.voice.upload-url"
+          : "discord.voice.attachment-upload",
+        timeoutMs: DISCORD_VOICE_UPLOAD_REQUEST_TIMEOUT_MS,
+      });
+    } finally {
+      await closeLoopbackServer(server, sockets);
+    }
   });
 });

--- a/extensions/discord/src/voice-message.ts
+++ b/extensions/discord/src/voice-message.ts
@@ -34,13 +34,13 @@ import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { DiscordError, RateLimitError, type RequestClient } from "./internal/discord.js";
 import { readDiscordMessage, readRetryAfter } from "./internal/rest-errors.js";
+import { DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS } from "./monitor/timeouts.js";
 
 const DISCORD_VOICE_MESSAGE_FLAG = 1 << 13;
 const SUPPRESS_NOTIFICATIONS_FLAG = 1 << 12;
 const WAVEFORM_SAMPLES = 256;
 const DISCORD_OPUS_SAMPLE_RATE_HZ = 48_000;
 const DISCORD_VOICE_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
-const DISCORD_VOICE_UPLOAD_REQUEST_TIMEOUT_MS = 120_000;
 const DISCORD_VOICE_UPLOAD_SSRF_POLICY: SsrFPolicy = {
   allowRfc2544BenchmarkRange: true,
   allowIpv6UniqueLocalRange: true,
@@ -349,7 +349,9 @@ async function requestVoiceUploadUrl(params: {
   const { response: res, release } = await fetchWithSsrFGuard({
     url,
     init: uploadUrlInit,
-    timeoutMs: DISCORD_VOICE_UPLOAD_REQUEST_TIMEOUT_MS,
+    // Keep control-plane negotiation on the REST budget; the binary upload below
+    // needs the longer attachment-transfer budget.
+    timeoutMs: params.rest.options.timeout,
     policy: DISCORD_VOICE_UPLOAD_SSRF_POLICY,
     auditContext: "discord.voice.upload-url",
   });
@@ -376,7 +378,7 @@ async function uploadVoiceAttachment(params: {
       },
       body: new Uint8Array(params.audioBuffer),
     },
-    timeoutMs: DISCORD_VOICE_UPLOAD_REQUEST_TIMEOUT_MS,
+    timeoutMs: DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS,
     policy: DISCORD_VOICE_UPLOAD_SSRF_POLICY,
     auditContext: "discord.voice.attachment-upload",
   });

--- a/extensions/discord/src/voice-message.ts
+++ b/extensions/discord/src/voice-message.ts
@@ -40,6 +40,7 @@ const SUPPRESS_NOTIFICATIONS_FLAG = 1 << 12;
 const WAVEFORM_SAMPLES = 256;
 const DISCORD_OPUS_SAMPLE_RATE_HZ = 48_000;
 const DISCORD_VOICE_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
+const DISCORD_VOICE_UPLOAD_REQUEST_TIMEOUT_MS = 120_000;
 const DISCORD_VOICE_UPLOAD_SSRF_POLICY: SsrFPolicy = {
   allowRfc2544BenchmarkRange: true,
   allowIpv6UniqueLocalRange: true,
@@ -348,6 +349,7 @@ async function requestVoiceUploadUrl(params: {
   const { response: res, release } = await fetchWithSsrFGuard({
     url,
     init: uploadUrlInit,
+    timeoutMs: DISCORD_VOICE_UPLOAD_REQUEST_TIMEOUT_MS,
     policy: DISCORD_VOICE_UPLOAD_SSRF_POLICY,
     auditContext: "discord.voice.upload-url",
   });
@@ -374,6 +376,7 @@ async function uploadVoiceAttachment(params: {
       },
       body: new Uint8Array(params.audioBuffer),
     },
+    timeoutMs: DISCORD_VOICE_UPLOAD_REQUEST_TIMEOUT_MS,
     policy: DISCORD_VOICE_UPLOAD_SSRF_POLICY,
     auditContext: "discord.voice.attachment-upload",
   });


### PR DESCRIPTION
## What Problem This Solves

Discord voice-message delivery uses two guarded HTTP calls outside the ordinary REST request path: one POST negotiates an upload URL and one PUT streams the OGG attachment. Either call could wait forever after the peer accepted the connection but stopped responding.

## Why This Change Was Made

The maintainer revision removes the new one-size-fits-all timeout and reuses the owning policies already present in the Discord plugin:

- Upload-URL negotiation inherits the normalized Discord REST-client timeout, so the control-plane request follows the same budget as other Discord REST calls.
- The signed attachment PUT uses `DISCORD_ATTACHMENT_TOTAL_TIMEOUT_MS`, preserving the longer transfer budget for binary uploads.
- Both calls retain the existing guarded-fetch SSRF policy, Discord error parsing, rate-limit behavior, and response-release lifecycle.

The regression test was reduced from a custom socket/server harness to the shared `withServer` fixture. It hangs each real HTTP route independently, rejects missing/non-finite production timeouts, verifies that abort closes the exact hanging response, and asserts the route-specific timeout source.

## User Impact

A stalled Discord upload negotiation or attachment transfer now fails through the existing delivery error path instead of wedging the voice-message workflow indefinitely. Normal uploads retain the established REST and attachment-transfer budgets.

## Evidence

- Original exact contributor head CI passed: https://github.com/openclaw/openclaw/actions/runs/29022630270
- Final rewrite autoreview found no accepted/actionable findings (confidence 0.85).
- The final diff is five production lines plus a net-reduced regression harness; no config, SDK, or changelog surface was added.
- Native review artifacts, signature, ancestry, and diff hygiene passed.
- Exact prepared-tree live proof posted one silent 0.6-second voice message to the approved maintainer channel. Authenticated readback verified empty text content, voice+silent flags (`12288`), exactly one `audio/ogg` attachment, 0.6065-second duration, and a 256-byte waveform (message `1524880878969294979`).

The focused regression uses real loopback HTTP connections and proves both hanging routes are aborted and closed. Live proof invoked the exact prepared implementation directly with a private temporary config because the long-running gateway held a stale in-memory token; the real config was unchanged and all temporary credential/config/audio files were removed.
