### PR TITLE
fix(elevenlabs): add timeout to voices list request

### DIFF
--- a/extensions/elevenlabs/speech-provider.test.ts
+++ b/extensions/elevenlabs/speech-provider.test.ts
@@ -1,4 +1,7 @@
 // Elevenlabs tests cover speech provider plugin behavior.
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { Socket } from "node:net";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { isValidElevenLabsVoiceId } from "./shared.js";
 import { buildElevenLabsSpeechProvider } from "./speech-provider.js";
@@ -7,11 +10,20 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   fetchWithSsrFGuard: async ({
     url,
     init,
+    timeoutMs,
   }: {
     url: string;
     init?: RequestInit;
+    timeoutMs?: number;
   }): Promise<{ response: Response; release: () => Promise<void> }> => ({
-    response: await globalThis.fetch(url, init),
+    response: await globalThis.fetch(url, {
+      ...init,
+      signal:
+        init?.signal ??
+        (typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0
+          ? AbortSignal.timeout(timeoutMs)
+          : undefined),
+    }),
     release: vi.fn(async () => {}),
   }),
   ssrfPolicyFromHttpBaseUrlAllowedHostname: () => undefined,
@@ -26,6 +38,26 @@ function parseRequestBody(init: RequestInit | undefined): Record<string, unknown
     throw new Error("expected ElevenLabs request body");
   }
   return body as Record<string, unknown>;
+}
+
+async function listen(server: Server): Promise<string> {
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected local HTTP server address");
+  }
+  return `http://127.0.0.1:${(address as AddressInfo).port}`;
+}
+
+async function closeServer(server: Server, sockets: Set<Socket>): Promise<void> {
+  for (const socket of sockets) {
+    socket.destroy();
+  }
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
 }
 
 describe("elevenlabs speech provider", () => {
@@ -258,5 +290,42 @@ describe("elevenlabs speech provider", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("times out a hanging ElevenLabs voices list request", async () => {
+    const provider = buildElevenLabsSpeechProvider();
+    if (!provider.listVoices) {
+      throw new Error("expected ElevenLabs provider to support voice listing");
+    }
+    const sockets = new Set<Socket>();
+    let requestCount = 0;
+    const server = createServer((_req, _res) => {
+      requestCount += 1;
+    });
+    server.on("connection", (socket) => {
+      sockets.add(socket);
+      socket.on("close", () => sockets.delete(socket));
+    });
+    const baseUrl = await listen(server);
+    const startedAt = Date.now();
+
+    try {
+      await expect(
+        Promise.race([
+          provider.listVoices({
+            apiKey: "xi-test",
+            baseUrl,
+            timeoutMs: 250,
+          }),
+          new Promise<never>((_, reject) => {
+            setTimeout(() => reject(new Error("voices list did not time out")), 2_000);
+          }),
+        ]),
+      ).rejects.toThrow(/aborted|timeout|timed out/i);
+      expect(Date.now() - startedAt).toBeLessThan(2_000);
+      expect(requestCount).toBe(1);
+    } finally {
+      await closeServer(server, sockets);
+    }
   });
 });

--- a/extensions/elevenlabs/speech-provider.ts
+++ b/extensions/elevenlabs/speech-provider.ts
@@ -356,6 +356,7 @@ function parseDirectiveToken(ctx: SpeechDirectiveTokenParseContext) {
 async function listElevenLabsVoices(params: {
   apiKey: string;
   baseUrl?: string;
+  timeoutMs: number;
 }): Promise<SpeechVoiceOption[]> {
   const normalizedBaseUrl = normalizeElevenLabsBaseUrl(params.baseUrl);
   const { response, release } = await fetchWithSsrFGuard({
@@ -365,6 +366,7 @@ async function listElevenLabsVoices(params: {
         "xi-api-key": params.apiKey,
       },
     },
+    timeoutMs: params.timeoutMs,
     policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(normalizedBaseUrl),
     auditContext: "elevenlabs.voices",
   });
@@ -538,6 +540,7 @@ export function buildElevenLabsSpeechProvider(): SpeechProviderPlugin {
       return listElevenLabsVoices({
         apiKey,
         baseUrl: req.baseUrl ?? config?.baseUrl,
+        timeoutMs: req.timeoutMs,
       });
     },
     isConfigured: ({ providerConfig }) =>

--- a/extensions/elevenlabs/speech-provider.ts
+++ b/extensions/elevenlabs/speech-provider.ts
@@ -34,6 +34,7 @@ import { isValidElevenLabsVoiceId, normalizeElevenLabsBaseUrl } from "./shared.j
 import { elevenLabsTTS, elevenLabsTTSStream } from "./tts.js";
 const DEFAULT_ELEVENLABS_VOICE_ID = "pMsXgVXv3BLzUgSXRplE";
 const DEFAULT_ELEVENLABS_MODEL_ID = "eleven_multilingual_v2";
+const DEFAULT_ELEVENLABS_VOICE_LIST_TIMEOUT_MS = 30_000;
 const DEFAULT_ELEVENLABS_VOICE_SETTINGS = {
   stability: 0.5,
   similarityBoost: 0.75,
@@ -540,7 +541,7 @@ export function buildElevenLabsSpeechProvider(): SpeechProviderPlugin {
       return listElevenLabsVoices({
         apiKey,
         baseUrl: req.baseUrl ?? config?.baseUrl,
-        timeoutMs: req.timeoutMs,
+        timeoutMs: req.timeoutMs ?? DEFAULT_ELEVENLABS_VOICE_LIST_TIMEOUT_MS,
       });
     },
     isConfigured: ({ providerConfig }) =>

--- a/packages/speech-core/src/tts.ts
+++ b/packages/speech-core/src/tts.ts
@@ -1907,6 +1907,7 @@ export async function listSpeechVoices(params: {
   config?: ResolvedTtsConfig;
   apiKey?: string;
   baseUrl?: string;
+  timeoutMs?: number;
 }): Promise<SpeechVoiceOption[]> {
   const cfg = params.cfg ? resolveTtsRuntimeConfig(params.cfg) : undefined;
   const provider = canonicalizeSpeechProviderId(params.provider, cfg);
@@ -1929,6 +1930,11 @@ export async function listSpeechVoices(params: {
     providerConfig: getResolvedSpeechProviderConfig(config, resolvedProvider.id, cfg),
     apiKey: params.apiKey,
     baseUrl: params.baseUrl,
+    timeoutMs: resolveSpeechProviderTimeoutMs({
+      timeoutMs: params.timeoutMs,
+      config,
+      provider: resolvedProvider,
+    }),
   });
 }
 

--- a/src/tts/provider-types.ts
+++ b/src/tts/provider-types.ts
@@ -131,7 +131,7 @@ export type SpeechListVoicesRequest = {
   providerConfig?: SpeechProviderConfig;
   apiKey?: string;
   baseUrl?: string;
-  timeoutMs: number;
+  timeoutMs?: number;
 };
 
 /** Provider hook input for resolving normalized config from raw OpenClaw config. */

--- a/src/tts/provider-types.ts
+++ b/src/tts/provider-types.ts
@@ -131,6 +131,7 @@ export type SpeechListVoicesRequest = {
   providerConfig?: SpeechProviderConfig;
   apiKey?: string;
   baseUrl?: string;
+  timeoutMs: number;
 };
 
 /** Provider hook input for resolving normalized config from raw OpenClaw config. */


### PR DESCRIPTION
## What Problem This Solves

ElevenLabs voice discovery could wait indefinitely when the voices API accepted the HTTP connection but never returned a response.

## Why This Change Was Made

Synthesis paths already receive bounded provider timeouts, but the generic voice-listing path did not pass a timeout into provider `listVoices` hooks. This change threads the resolved speech provider timeout through `listSpeechVoices` and uses it for the ElevenLabs voices request while preserving existing auth, base-url normalization, SSRF policy, and response parsing.

The provider hook field remains optional so direct provider callers and existing tests stay source-compatible; direct ElevenLabs voice-list calls use a 30-second default timeout.

## User Impact

A stalled ElevenLabs voices endpoint no longer blocks voice discovery forever. Callers using configured provider timeouts now get a bounded failure for the discovery request as well as synthesis requests.

## Evidence

- `node scripts/run-vitest.mjs run extensions/elevenlabs/speech-provider.test.ts` - passed; `Test Files  1 passed (1)`, `Tests  9 passed (9)`.
- `pnpm exec oxfmt --check --threads=1 extensions/elevenlabs/speech-provider.ts extensions/elevenlabs/speech-provider.test.ts packages/speech-core/src/tts.ts src/tts/provider-types.ts` - passed.
- `./node_modules/.bin/oxlint --config .oxlintrc.json --tsconfig config/tsconfig/oxlint.json extensions/elevenlabs/speech-provider.ts extensions/elevenlabs/speech-provider.test.ts packages/speech-core/src/tts.ts src/tts/provider-types.ts` - passed; exit 0.
- `pnpm check:test-types` - passed; exit 0.
- `git diff --check upstream/main..HEAD` - passed; exit 0 before the compatibility commit, and `git diff --check` - passed before pushing the follow-up commit.
- Open PR collision check: searched open PR topics and scanned the latest 500 open PR changed-file lists; no open PR touched `extensions/elevenlabs/speech-provider.ts`, `packages/speech-core/src/tts.ts`, or `src/tts/provider-types.ts`.

## Real behavior proof

Behavior addressed: ElevenLabs voices-list GETs now have a deadline when the remote endpoint accepts the request but never sends a response.

Real environment tested: local Linux Node source checkout; real `node:http` loopback server that receives the provider `listVoices` request and deliberately never responds.

Exact command run after this patch: `node scripts/run-vitest.mjs run extensions/elevenlabs/speech-provider.test.ts`

Evidence after fix: the focused regression drives the provider `listVoices` hook with a local base URL and `timeoutMs: 250`, asserts the hanging server receives exactly one request, and observes an abort/timeout-class rejection within the bounded window.

What was not tested: live ElevenLabs traffic; the hang is reproduced with a real local HTTP server, not the real third-party service.
