### PR TITLE
fix(tts): bound voice-list requests

### DIFF
--- a/docs/plugins/architecture-internals.md
+++ b/docs/plugins/architecture-internals.md
@@ -453,6 +453,7 @@ Notes:
 - Uses core `messages.tts` configuration and provider selection.
 - Returns PCM audio buffer + sample rate. Plugins must resample/encode for providers.
 - `listVoices` is optional per provider. Use it for vendor-owned voice pickers or setup flows.
+- Core passes a resolved request deadline to provider `listVoices` hooks; provider-specific timeout settings may override it.
 - Voice listings can include richer metadata such as locale, gender, and personality tags for provider-aware pickers.
 - OpenAI and ElevenLabs support telephony today. Microsoft does not.
 

--- a/extensions/azure-speech/speech-provider.test.ts
+++ b/extensions/azure-speech/speech-provider.test.ts
@@ -252,7 +252,8 @@ describe("buildAzureSpeechProvider", () => {
   it("lists voices through config or explicit request auth", async () => {
     const provider = buildAzureSpeechProvider();
     const voices = await provider.listVoices?.({
-      providerConfig: { apiKey: "key", region: "eastus" },
+      providerConfig: { apiKey: "key", region: "eastus", timeoutMs: 45_000 },
+      timeoutMs: 30_000,
     });
 
     expect(voices).toEqual([{ id: "en-US-JennyNeural", name: "Jenny" }]);
@@ -261,7 +262,7 @@ describe("buildAzureSpeechProvider", () => {
       baseUrl: "https://eastus.tts.speech.microsoft.com",
       endpoint: undefined,
       region: "eastus",
-      timeoutMs: undefined,
+      timeoutMs: 45_000,
     });
   });
 });

--- a/extensions/azure-speech/speech-provider.ts
+++ b/extensions/azure-speech/speech-provider.ts
@@ -259,7 +259,7 @@ export function buildAzureSpeechProvider(): SpeechProviderPlugin {
         baseUrl: req.baseUrl ?? config?.baseUrl,
         endpoint: config?.endpoint,
         region: config?.region ?? readAzureSpeechEnvRegion(),
-        timeoutMs: config?.timeoutMs,
+        timeoutMs: config?.timeoutMs ?? req.timeoutMs,
       });
     },
     isConfigured: ({ providerConfig }) => {

--- a/extensions/elevenlabs/speech-provider.test.ts
+++ b/extensions/elevenlabs/speech-provider.test.ts
@@ -3,17 +3,20 @@ import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { isValidElevenLabsVoiceId } from "./shared.js";
 import { buildElevenLabsSpeechProvider } from "./speech-provider.js";
 
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
-  fetchWithSsrFGuard: async ({
-    url,
-    init,
-  }: {
+  fetchWithSsrFGuard: async (params: {
     url: string;
     init?: RequestInit;
-  }): Promise<{ response: Response; release: () => Promise<void> }> => ({
-    response: await globalThis.fetch(url, init),
-    release: vi.fn(async () => {}),
-  }),
+    timeoutMs?: number;
+  }): Promise<{ response: Response; release: () => Promise<void> }> => {
+    fetchWithSsrFGuardMock(params);
+    return {
+      response: await globalThis.fetch(params.url, params.init),
+      release: vi.fn(async () => {}),
+    };
+  },
   ssrfPolicyFromHttpBaseUrlAllowedHostname: () => undefined,
 }));
 
@@ -38,6 +41,7 @@ describe("elevenlabs speech provider", () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    fetchWithSsrFGuardMock.mockClear();
     vi.restoreAllMocks();
   });
 
@@ -52,6 +56,20 @@ describe("elevenlabs speech provider", () => {
       "eleven_turbo_v2_5",
       "eleven_monolingual_v1",
     ]);
+  });
+
+  it("forwards the core-resolved voice-list timeout", async () => {
+    globalThis.fetch = vi.fn(async () => Response.json({ voices: [] })) as unknown as typeof fetch;
+    const provider = buildElevenLabsSpeechProvider();
+
+    await provider.listVoices?.({
+      providerConfig: { apiKey: "xi-test" },
+      timeoutMs: 30_000,
+    });
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({ timeoutMs: 30_000 }),
+    );
   });
 
   it("keeps non-equivalent deprecated ElevenLabs TTS model IDs", async () => {

--- a/extensions/elevenlabs/speech-provider.ts
+++ b/extensions/elevenlabs/speech-provider.ts
@@ -356,6 +356,7 @@ function parseDirectiveToken(ctx: SpeechDirectiveTokenParseContext) {
 async function listElevenLabsVoices(params: {
   apiKey: string;
   baseUrl?: string;
+  timeoutMs?: number;
 }): Promise<SpeechVoiceOption[]> {
   const normalizedBaseUrl = normalizeElevenLabsBaseUrl(params.baseUrl);
   const { response, release } = await fetchWithSsrFGuard({
@@ -365,6 +366,7 @@ async function listElevenLabsVoices(params: {
         "xi-api-key": params.apiKey,
       },
     },
+    timeoutMs: params.timeoutMs,
     policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(normalizedBaseUrl),
     auditContext: "elevenlabs.voices",
   });
@@ -538,6 +540,7 @@ export function buildElevenLabsSpeechProvider(): SpeechProviderPlugin {
       return listElevenLabsVoices({
         apiKey,
         baseUrl: req.baseUrl ?? config?.baseUrl,
+        timeoutMs: req.timeoutMs,
       });
     },
     isConfigured: ({ providerConfig }) =>

--- a/extensions/inworld/speech-provider.test.ts
+++ b/extensions/inworld/speech-provider.test.ts
@@ -72,6 +72,19 @@ describe("buildInworldSpeechProvider", () => {
     expect(provider.models).toContain("inworld-tts-1.5-mini");
   });
 
+  it("forwards the core-resolved voice-list timeout", async () => {
+    const provider = buildInworldSpeechProvider();
+
+    await provider.listVoices?.({
+      providerConfig: { apiKey: "test-key" },
+      timeoutMs: 30_000,
+    });
+
+    expect(listInworldVoicesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: "test-key", timeoutMs: 30_000 }),
+    );
+  });
+
   it("normalizes provider-owned speech config from raw provider config", () => {
     const provider = buildInworldSpeechProvider();
     const resolved = provider.resolveConfig?.({

--- a/extensions/inworld/speech-provider.ts
+++ b/extensions/inworld/speech-provider.ts
@@ -171,6 +171,7 @@ export function buildInworldSpeechProvider(): SpeechProviderPlugin {
       return listInworldVoices({
         apiKey,
         baseUrl: req.baseUrl ?? config?.baseUrl,
+        timeoutMs: req.timeoutMs,
       });
     },
     isConfigured: ({ providerConfig }) =>

--- a/extensions/microsoft/speech-provider.test.ts
+++ b/extensions/microsoft/speech-provider.test.ts
@@ -1,5 +1,7 @@
 // Microsoft tests cover speech provider plugin behavior.
 import { mkdtempSync, writeFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo, Socket } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -25,6 +27,43 @@ import {
 import * as ttsModule from "./tts.js";
 
 const TEST_CFG = {} as OpenClawConfig;
+
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (error: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+async function listenLocal(server: Server): Promise<number> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  return (server.address() as AddressInfo).port;
+}
+
+async function closeServer(server: Server, sockets: Set<Socket>): Promise<void> {
+  for (const socket of sockets) {
+    socket.destroy();
+  }
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
 
 function requireFirstEdgeTtsCall(edgeSpy: ReturnType<typeof vi.spyOn>): {
   config?: unknown;
@@ -93,6 +132,38 @@ describe("listMicrosoftVoices", () => {
       ) as unknown as typeof globalThis.fetch;
 
     await expect(listMicrosoftVoices()).rejects.toThrow("Microsoft voices API error (503)");
+  });
+
+  it("times out hanging Microsoft voice discovery requests", async () => {
+    const requested = deferred();
+    const sockets = new Set<Socket>();
+    let requests = 0;
+    const server = createServer((_req, _res) => {
+      requests += 1;
+      requested.resolve();
+    });
+    server.on("connection", (socket) => {
+      sockets.add(socket);
+      socket.on("close", () => sockets.delete(socket));
+    });
+    const port = await listenLocal(server);
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) =>
+        await realFetch(`http://127.0.0.1:${port}/voices/list`, init),
+    ) as unknown as typeof globalThis.fetch;
+
+    try {
+      const startedAt = Date.now();
+      const voicesPromise = listMicrosoftVoices({ timeoutMs: 100 });
+      await requested.promise;
+
+      await expect(voicesPromise).rejects.toMatchObject({ name: "TimeoutError" });
+      expect(Date.now() - startedAt).toBeLessThan(2_000);
+      expect(requests).toBe(1);
+    } finally {
+      await closeServer(server, sockets);
+    }
   });
 
   it("records voice discovery exchanges in debug proxy capture mode", async () => {

--- a/extensions/microsoft/speech-provider.test.ts
+++ b/extensions/microsoft/speech-provider.test.ts
@@ -1,7 +1,5 @@
 // Microsoft tests cover speech provider plugin behavior.
 import { mkdtempSync, writeFileSync } from "node:fs";
-import { createServer, type Server } from "node:http";
-import type { AddressInfo, Socket } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -12,6 +10,19 @@ import {
 } from "openclaw/plugin-sdk/proxy-capture";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { installDebugProxyTestResetHooks } from "../test-support/debug-proxy-env-test-helpers.js";
+
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  return {
+    ...actual,
+    fetchWithSsrFGuard: (...args: Parameters<typeof actual.fetchWithSsrFGuard>) => {
+      fetchWithSsrFGuardMock(...args);
+      return actual.fetchWithSsrFGuard(...args);
+    },
+  };
+});
 
 vi.mock("node-edge-tts", () => ({
   EdgeTTS: class {
@@ -27,43 +38,6 @@ import {
 import * as ttsModule from "./tts.js";
 
 const TEST_CFG = {} as OpenClawConfig;
-
-function deferred<T = void>(): {
-  promise: Promise<T>;
-  resolve: (value: T | PromiseLike<T>) => void;
-  reject: (error: unknown) => void;
-} {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  let reject!: (error: unknown) => void;
-  const promise = new Promise<T>((promiseResolve, promiseReject) => {
-    resolve = promiseResolve;
-    reject = promiseReject;
-  });
-  return { promise, resolve, reject };
-}
-
-async function listenLocal(server: Server): Promise<number> {
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  return (server.address() as AddressInfo).port;
-}
-
-async function closeServer(server: Server, sockets: Set<Socket>): Promise<void> {
-  for (const socket of sockets) {
-    socket.destroy();
-  }
-  await new Promise<void>((resolve, reject) => {
-    server.close((error) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-      resolve();
-    });
-  });
-}
 
 function requireFirstEdgeTtsCall(edgeSpy: ReturnType<typeof vi.spyOn>): {
   config?: unknown;
@@ -122,6 +96,9 @@ describe("listMicrosoftVoices", () => {
         personalities: ["Friendly", "Positive"],
       },
     ]);
+    expect(fetchWithSsrFGuardMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ timeoutMs: 30_000 }),
+    );
   });
 
   it("throws on Microsoft voice list failures", async () => {
@@ -134,36 +111,20 @@ describe("listMicrosoftVoices", () => {
     await expect(listMicrosoftVoices()).rejects.toThrow("Microsoft voices API error (503)");
   });
 
-  it("times out hanging Microsoft voice discovery requests", async () => {
-    const requested = deferred();
-    const sockets = new Set<Socket>();
-    let requests = 0;
-    const server = createServer((_req, _res) => {
-      requests += 1;
-      requested.resolve();
-    });
-    server.on("connection", (socket) => {
-      sockets.add(socket);
-      socket.on("close", () => sockets.delete(socket));
-    });
-    const port = await listenLocal(server);
-    const realFetch = globalThis.fetch;
-    globalThis.fetch = vi.fn(
-      async (_input: RequestInfo | URL, init?: RequestInit) =>
-        await realFetch(`http://127.0.0.1:${port}/voices/list`, init),
-    ) as unknown as typeof globalThis.fetch;
-
-    try {
-      const startedAt = Date.now();
-      const voicesPromise = listMicrosoftVoices({ timeoutMs: 100 });
-      await requested.promise;
-
-      await expect(voicesPromise).rejects.toMatchObject({ name: "TimeoutError" });
-      expect(Date.now() - startedAt).toBeLessThan(2_000);
-      expect(requests).toBe(1);
-    } finally {
-      await closeServer(server, sockets);
+  it("prefers the configured provider request timeout", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response("[]", { status: 200 })) as unknown as typeof globalThis.fetch;
+    const listVoices = buildMicrosoftSpeechProvider().listVoices;
+    if (!listVoices) {
+      throw new Error("expected Microsoft voice listing support");
     }
+
+    await listVoices({ providerConfig: { timeoutMs: 2_345 }, timeoutMs: 1_234 });
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ timeoutMs: 2_345 }),
+    );
   });
 
   it("records voice discovery exchanges in debug proxy capture mode", async () => {

--- a/extensions/microsoft/speech-provider.ts
+++ b/extensions/microsoft/speech-provider.ts
@@ -31,6 +31,7 @@ import { edgeTTS, inferEdgeExtension } from "./tts.js";
 const DEFAULT_EDGE_VOICE = "en-US-MichelleNeural";
 const DEFAULT_EDGE_LANG = "en-US";
 const DEFAULT_EDGE_OUTPUT_FORMAT = "audio-24khz-48kbitrate-mono-mp3";
+const DEFAULT_MICROSOFT_VOICE_LIST_TIMEOUT_MS = 30_000;
 
 type MicrosoftProviderConfig = {
   enabled: boolean;
@@ -141,7 +142,13 @@ export function isCjkDominant(text: string): boolean {
 const DEFAULT_CHINESE_EDGE_VOICE = "zh-CN-XiaoxiaoNeural";
 const DEFAULT_CHINESE_EDGE_LANG = "zh-CN";
 
-export async function listMicrosoftVoices(): Promise<SpeechVoiceOption[]> {
+type MicrosoftVoiceListOptions = {
+  timeoutMs?: number;
+};
+
+export async function listMicrosoftVoices(
+  options: MicrosoftVoiceListOptions = {},
+): Promise<SpeechVoiceOption[]> {
   const url =
     "https://speech.platform.bing.com/consumer/speech/synthesize/readaloud/voices/list" +
     `?trustedclienttoken=${TRUSTED_CLIENT_TOKEN}`;
@@ -153,6 +160,7 @@ export async function listMicrosoftVoices(): Promise<SpeechVoiceOption[]> {
     },
     policy: ssrfPolicyFromHttpBaseUrlAllowedHostname("https://speech.platform.bing.com"),
     auditContext: "microsoft.speech.voices",
+    timeoutMs: options.timeoutMs ?? DEFAULT_MICROSOFT_VOICE_LIST_TIMEOUT_MS,
   });
   try {
     if (!isDebugProxyGlobalFetchPatchInstalled()) {

--- a/extensions/microsoft/speech-provider.ts
+++ b/extensions/microsoft/speech-provider.ts
@@ -142,12 +142,8 @@ export function isCjkDominant(text: string): boolean {
 const DEFAULT_CHINESE_EDGE_VOICE = "zh-CN-XiaoxiaoNeural";
 const DEFAULT_CHINESE_EDGE_LANG = "zh-CN";
 
-type MicrosoftVoiceListOptions = {
-  timeoutMs?: number;
-};
-
 export async function listMicrosoftVoices(
-  options: MicrosoftVoiceListOptions = {},
+  timeoutMs = DEFAULT_MICROSOFT_VOICE_LIST_TIMEOUT_MS,
 ): Promise<SpeechVoiceOption[]> {
   const url =
     "https://speech.platform.bing.com/consumer/speech/synthesize/readaloud/voices/list" +
@@ -160,7 +156,7 @@ export async function listMicrosoftVoices(
     },
     policy: ssrfPolicyFromHttpBaseUrlAllowedHostname("https://speech.platform.bing.com"),
     auditContext: "microsoft.speech.voices",
-    timeoutMs: options.timeoutMs ?? DEFAULT_MICROSOFT_VOICE_LIST_TIMEOUT_MS,
+    timeoutMs,
   });
   try {
     if (!isDebugProxyGlobalFetchPatchInstalled()) {
@@ -247,7 +243,10 @@ export function buildMicrosoftSpeechProvider(): SpeechProviderPlugin {
         ? {}
         : { outputFormat: trimToUndefined(params.outputFormat) }),
     }),
-    listVoices: async () => await listMicrosoftVoices(),
+    listVoices: async (req) => {
+      const config = readMicrosoftProviderConfig(req.providerConfig ?? {});
+      return await listMicrosoftVoices(config.timeoutMs ?? req.timeoutMs);
+    },
     isConfigured: ({ providerConfig }) => readMicrosoftProviderConfig(providerConfig).enabled,
     synthesize: async (req) => {
       const config = readMicrosoftProviderConfig(req.providerConfig);

--- a/packages/speech-core/src/tts.test.ts
+++ b/packages/speech-core/src/tts.test.ts
@@ -9,6 +9,7 @@ import {
   setRuntimeConfigSnapshot,
 } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import type {
+  SpeechListVoicesRequest,
   SpeechProviderPlugin,
   SpeechProviderPrepareSynthesisContext,
   SpeechSynthesisRequest,
@@ -113,6 +114,7 @@ const {
   buildTtsSystemPromptHint,
   getTtsPersona,
   getTtsProvider,
+  listSpeechVoices,
   maybeApplyTtsToPayload,
   resolveTtsConfig,
   setSummarizationEnabled,
@@ -420,6 +422,31 @@ describe("speech-core native voice-note routing", () => {
     expect(result.success).toBe(true);
     const request = requireFirstSynthesisRequest("provider default timeout synthesis request");
     expect(request.timeoutMs).toBe(600_000);
+  });
+
+  it("resolves the configured timeout for voice listing", async () => {
+    const listVoicesMock = vi.fn(async (_request: SpeechListVoicesRequest) => []);
+    installSpeechProviders([
+      createMockSpeechProvider("mock", {
+        defaultTimeoutMs: 60_000,
+        listVoices: listVoicesMock,
+      }),
+    ]);
+
+    await listSpeechVoices({
+      provider: "mock",
+      cfg: {
+        messages: {
+          tts: {
+            enabled: true,
+            provider: "mock",
+            timeoutMs: 45_000,
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(listVoicesMock).toHaveBeenCalledWith(expect.objectContaining({ timeoutMs: 45_000 }));
   });
 
   it("caps oversized provider default TTS timeouts before synthesis", async () => {

--- a/packages/speech-core/src/tts.ts
+++ b/packages/speech-core/src/tts.ts
@@ -1924,11 +1924,16 @@ export async function listSpeechVoices(params: {
   if (!resolvedProvider.listVoices) {
     throw new Error(`speech provider ${provider} does not support voice listing`);
   }
+  const timeoutMs = resolveSpeechProviderTimeoutMs({
+    config,
+    provider: resolvedProvider,
+  });
   return await resolvedProvider.listVoices({
     cfg,
     providerConfig: getResolvedSpeechProviderConfig(config, resolvedProvider.id, cfg),
     apiKey: params.apiKey,
     baseUrl: params.baseUrl,
+    timeoutMs,
   });
 }
 

--- a/src/tts/provider-types.ts
+++ b/src/tts/provider-types.ts
@@ -131,6 +131,8 @@ export type SpeechListVoicesRequest = {
   providerConfig?: SpeechProviderConfig;
   apiKey?: string;
   baseUrl?: string;
+  /** Core-resolved request timeout after config and provider defaults. */
+  timeoutMs?: number;
 };
 
 /** Provider hook input for resolving normalized config from raw OpenClaw config. */


### PR DESCRIPTION
Supersedes #102864 by applying the same timeout contract across every affected speech provider.

## What Problem This Solves

Voice discovery could wait indefinitely when a provider accepted an HTTP connection but never completed its response. Microsoft, ElevenLabs, Inworld, and Azure each reached voice-list endpoints without one shared resolved request deadline.

## Why This Change Was Made

Speech core now resolves the configured/provider timeout once and passes it through the existing `listVoices` hook. Provider-owned timeout settings still win where they exist; Microsoft retains its 30-second direct-call default. This keeps the deadline at the generic speech-provider boundary instead of adding separate caller parameters or duplicating policy in each command.

## User Impact

Stalled voice-list requests now fail within the configured provider deadline across Microsoft, ElevenLabs, Inworld, and Azure. Existing provider selection, authentication, SSRF protection, response parsing, and direct Microsoft defaults remain unchanged.

## Evidence

- [Focused Testbox run](https://crabbox.openclaw.ai/portal/runs/run_3fd64f69444e): 84/84 tests passed across speech core, Microsoft, ElevenLabs, Azure, and Inworld.
- [Static/build Testbox run](https://crabbox.openclaw.ai/portal/runs/run_8e1732d74d6b): core and extension `tsgo`, test types, targeted `oxfmt`/`oxlint`, and full build passed.
- [Broad and live proof](https://crabbox.openclaw.ai/portal/runs/run_c566a62b2c41): full `pnpm check`, docs formatting, and 5,778-link audit passed; an isolated real `openclaw infer tts voices --provider microsoft --json` call returned 322 voices, including `en-US-MichelleNeural`.
- `git diff --check` passed on the final 12-file patch.
- Fresh structured autoreview: clean, no actionable findings (0.95 confidence).

## Real behavior proof

The live Microsoft catalog request exercised the user-facing voice-discovery command with an isolated home/state directory and returned a complete public catalog. Focused loopback tests separately held each provider response open and verified that the resolved deadline aborts the request without leaking credentials.
