### PR TITLE
fix(gateway): guard thinkingLevel re-validation against only relevant patch fields

### DIFF
--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -827,6 +827,17 @@ describe("gateway sessions patch", () => {
     expect(entry.thinkingLevel).toBe("xhigh");
   });
 
+  test("does not re-validate thinkingLevel on patches without thinkingLevel or model", async () => {
+    const store = mainStoreEntry({ thinkingLevel: "low" });
+    const entry = expectPatchOk(
+      await runPatch({
+        store,
+        patch: { key: MAIN_SESSION_KEY, label: "new label" },
+      }),
+    );
+    expect(entry.thinkingLevel).toBe("low");
+  });
+
   test("sets spawnedBy for ACP sessions", async () => {
     const entry = expectPatchOk(
       await runPatch({

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -1,6 +1,6 @@
 // Session patch tests cover model/provider edits, subagent patching, provider
 // aliases, model catalog validation, and rejected invalid patch payloads.
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { resetProviderAuthAliasMapCacheForTest } from "../agents/provider-auth-aliases.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
@@ -827,15 +827,23 @@ describe("gateway sessions patch", () => {
     expect(entry.thinkingLevel).toBe("xhigh");
   });
 
-  test("does not re-validate thinkingLevel on patches without thinkingLevel or model", async () => {
-    const store = mainStoreEntry({ thinkingLevel: "low" });
+  test("preserves an incompatible stored thinkingLevel without loading the catalog for unrelated patches", async () => {
+    const loadGatewayModelCatalog = vi.fn(async () => [
+      { provider: "synthetic", id: "plain", name: "plain", reasoning: false },
+    ]);
     const entry = expectPatchOk(
       await runPatch({
-        store,
+        cfg: {
+          agents: { defaults: { model: { primary: "synthetic/plain" } } },
+        } as OpenClawConfig,
+        store: mainStoreEntry({ thinkingLevel: "max" }),
         patch: { key: MAIN_SESSION_KEY, label: "new label" },
+        loadGatewayModelCatalog,
       }),
     );
-    expect(entry.thinkingLevel).toBe("low");
+
+    expect(loadGatewayModelCatalog).not.toHaveBeenCalled();
+    expect(entry).toMatchObject({ label: "new label", thinkingLevel: "max" });
   });
 
   test("sets spawnedBy for ACP sessions", async () => {

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -632,7 +632,7 @@ export async function projectSessionsPatchEntry(params: {
     }
   }
 
-  if (next.thinkingLevel) {
+  if (next.thinkingLevel && ("thinkingLevel" in patch || "model" in patch)) {
     const effectiveProvider = next.providerOverride ?? resolvedDefault.provider;
     const effectiveModel = next.modelOverride ?? resolvedDefault.model;
     const thinkingLevel = normalizeThinkLevel(next.thinkingLevel);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where any session patch (even ones that don't touch `thinkingLevel` or `model`) enters the thinkingLevel re-validation block when the session already has a `thinkingLevel` from a previous update. This triggers unnecessary model catalog loading and can silently delete or modify the existing thinkingLevel.

## Why This Change Was Made

The re-validation block at `sessions-patch.ts:635` used `if (next.thinkingLevel)` — since `next` is cloned from the existing entry, any inherited thinkingLevel value causes spurious entry even for unrelated patches (e.g. `{ label: "new label" }`). The fix narrows the guard to only enter when the patch explicitly touches `thinkingLevel` or changes `model` (which may alter the effective provider/model that thinkingLevel is validated against).

## User Impact

Users no longer have their session's thinking level silently changed or removed when they patch unrelated session fields like `label`, `category`, `pinned`, `sendPolicy`, etc. Also eliminates unnecessary model catalog I/O on those patches.

## Real Behavior Proof

**Behavior addressed**: A session patch like `{ label: "new label" }` on a session with existing `thinkingLevel: "low"` enters the re-validation block at line 635, loading the model catalog and potentially calling `resolveSupportedThinkingLevel()` (silent modification) or `delete next.thinkingLevel` (silent removal).

**Real environment tested**: Linux (4.19.112), Node 22.19, branch `fix/bug-002-thinkingLevel-guard`

**Exact steps or command run after this patch**:

```bash
# Direct logic proof
node --input-type=module <<'NODE'
const patchFields = {
  "no thinkingLevel/model": { label: "new label" },
  "thinkingLevel only":     { thinkingLevel: "high" },
  "model only":             { model: "openai/gpt-5.5" },
  "both":                   { thinkingLevel: "high", model: "openai/gpt-5.5" },
};
console.log("=== Does patch enter the thinkingLevel re-validation block? ===");
for (const [desc, patch] of Object.entries(patchFields)) {
  const existingTL = "low";
  const oldGuard = !!existingTL;
  const newGuard = !!existingTL && ("thinkingLevel" in patch || "model" in patch);
  console.log(`  ${desc.padEnd(30)} old=${String(oldGuard).padEnd(5)} new=${String(newGuard).padEnd(5)} ${oldGuard && !newGuard ? "← BUG: spurious entry" : ""}`);
}
console.log("\n=== Impact ===");
const scenarios = [
  ["patch: { label: 'new' } (existing thinkingLevel)", true, false, false],
  ["patch: { thinkingLevel: 'medium' }", true, true, false],
  ["patch: { model: 'new-model' } (existing thinkingLevel)", true, false, true],
];
for (const [label, hasTL, tlInPatch, modelInPatch] of scenarios) {
  const enters = hasTL && (tlInPatch || modelInPatch);
  console.log(`  ${String(label).padEnd(55)} enters=${String(enters).padEnd(5)} ${enters ? "re-validates" : "skips, preserved"}`);
}
NODE

# Unit test
node scripts/run-vitest.mjs src/gateway/sessions-patch.test.ts -t "does not re-validate thinkingLevel"

# Production function call (real applySessionsPatchToStore)
node --import tsx --input-type=module <<'NODE'
import { applySessionsPatchToStore } from "./src/gateway/sessions-patch.ts"
const r1 = await applySessionsPatchToStore({
  cfg: {},
  store: { "agent:main:main": { sessionId: "sess", updatedAt: 1, thinkingLevel: "low" } },
  storeKey: "agent:main:main",
  patch: { key: "agent:main:main", label: "new label" },
})
console.log("label-only patch → thinkingLevel =", r1.ok ? r1.entry.thinkingLevel : "ERROR: " + r1.error.message)
const r2 = await applySessionsPatchToStore({
  cfg: {},
  store: { "agent:main:main": { sessionId: "sess", updatedAt: 1 } },
  storeKey: "agent:main:main",
  patch: { key: "agent:main:main", thinkingLevel: "low" },
})
console.log("thinkingLevel patch → thinkingLevel =", r2.ok ? r2.entry.thinkingLevel : "ERROR: " + r2.error.message)
NODE
```

**Evidence after fix**:

```console
$ node --input-type=module <<'NODE'
=== Does patch enter the thinkingLevel re-validation block? ===
  no thinkingLevel/model         old=true  new=false ← BUG: spurious entry
  thinkingLevel only             old=true  new=true  
  model only                     old=true  new=true  
  both                           old=true  new=true  

=== Impact ===
  patch: { label: 'new' } (existing thinkingLevel)              enters=false skips, preserved ✓
  patch: { thinkingLevel: 'medium' }                            enters=true  re-validates ✓
  patch: { model: 'new-model' } (existing thinkingLevel)         enters=true  re-validates ✓
```

```console
$ node scripts/run-vitest.mjs src/gateway/sessions-patch.test.ts -t "does not re-validate thinkingLevel"
 ✓ |gateway-core|  does not re-validate thinkingLevel on patches without thinkingLevel or model 19ms
 ✓ |gateway-server| does not re-validate thinkingLevel on patches without thinkingLevel or model 15ms
 ✓ |gateway-client| does not re-validate thinkingLevel on patches without thinkingLevel or model 14ms
 Test Files  3 passed (3)
      Tests  3 passed | 183 skipped (186)
```

```console
$ node --import tsx --input-type=module <<'NODE'
label-only patch → thinkingLevel = low
thinkingLevel patch → thinkingLevel = low
```

**Observed result after fix**: Patches that don't touch `thinkingLevel` or `model` no longer enter the re-validation block. `thinkingLevel` patches still validate against the effective provider/model. `model` patches still re-validate the existing thinkingLevel against the new provider/model. Existing tests continue to pass.

**What was not tested**: No E2E test starting a real gateway — the unit test covers the logic at the function level, which is sufficient since the change is purely about branch entry conditions in a pure function.

## Regression Test Plan

```
node scripts/run-vitest.mjs src/gateway/sessions-patch.test.ts
```

