### PR TITLE
test(ui): isolate chat pane custom-element registration

### DIFF
--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -1,9 +1,10 @@
 /* @vitest-environment jsdom */
+/* @vitest-environment-options {"url":"http://chat-page.test/"} */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// The non-isolated UI shard shares custom elements across files. Leave the
-// production tag free so chat-pane tests can install its real class.
+// The dedicated jsdom context keeps this host-only mock from sharing the
+// production tag registry with component tests.
 vi.mock("./chat-pane.ts", () => ({}));
 
 import { loadSettings } from "../../app/settings.ts";

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -2,12 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("./chat-pane.ts", () => {
-  if (!customElements.get("openclaw-chat-pane")) {
-    customElements.define("openclaw-chat-pane", class extends HTMLElement {});
-  }
-  return {};
-});
+vi.mock("./chat-pane.ts", () => ({}));
 
 import { loadSettings } from "../../app/settings.ts";
 import type { ResizableDivider } from "../../components/resizable-divider.ts";

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -2,6 +2,8 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// The non-isolated UI shard shares custom elements across files. Leave the
+// production tag free so chat-pane tests can install its real class.
 vi.mock("./chat-pane.ts", () => ({}));
 
 import { loadSettings } from "../../app/settings.ts";


### PR DESCRIPTION
## What Problem This Solves

The non-isolated Control UI Vitest shard can place `chat-page.test.ts` and `chat-pane.test.ts` in the same worker. The page test registered a dummy `openclaw-chat-pane` class in that worker-global `CustomElementRegistry`, so the real module's guarded registration could not replace it and all six pane lifecycle tests then ran against an empty `HTMLElement`.

This failed `checks-node-compact-large-whole-1` in exact-head CI: https://github.com/openclaw/openclaw/actions/runs/29020837846/job/86127826149

## Why This Change Was Made

Keep the host-only `chat-pane.ts` module mock, remove its dummy production-tag registration, and give `chat-page.test.ts` a dedicated jsdom environment option. Vitest 4 groups non-isolated single-worker specs by environment name and serialized options, so the page and pane suites now receive separate jsdom contexts and separate custom-element registries in either execution order.

This is narrower than enabling isolation for the full UI project and avoids exposing production component internals solely for tests.

## User Impact

No runtime behavior changes. Control UI CI no longer depends on which worker collects the two chat test files first.

## Evidence

- Exact prepared head: `871e6bafd7e968caad938fb81c345c3dd598d0d9`.
- Blacksmith Testbox through Crabbox: `tbx_01kx3j7kwad8rt20fznq208x4a`.
- Deterministic pane-first proof: 2 files / 18 tests passed; the mock-only patch failed this order with 19 unhandled lifecycle errors.
- Final-head focused pair: 2 files / 18 tests passed.
- Final-head full Control UI shard: 183 files / 2,603 tests passed.
- Targeted oxfmt and `git diff --check`: clean.
- Fresh autoreview: no accepted or actionable findings, confidence 0.99.
