### PR TITLE
improve(webchat): model picker applies changes immediately, no Save/Discard row

### DIFF
--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -626,9 +626,9 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
       await expect
         .poll(() => composer.locator('[data-chat-model-provider-group="codex"]').count())
         .toBe(0);
-      const defaultOption = composer.locator('[data-chat-model-option=""]');
-      await expect.poll(() => defaultOption.count()).toBe(1);
-      await expect.poll(() => defaultOption.textContent()).toContain("Default");
+      // The default model is advertised as unavailable, so the pinned default
+      // option must not be offered.
+      await expect.poll(() => composer.locator('[data-chat-model-option=""]').count()).toBe(0);
     } finally {
       await context.close();
       await browser.close();

--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -185,22 +185,10 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
       await expect
         .poll(() => composer.locator(".chat-controls__provider-icon").count())
         .toBeGreaterThan(0);
-      const patchCountBeforeDraft = (await gateway.getRequests("sessions.patch")).length;
+      // Reasoning and speed commit immediately; the picker stays open so all
+      // three controls can be adjusted together.
       await thinkingSlider.press("Home");
       await thinkingSlider.press("ArrowRight");
-      await expect
-        .poll(() => gateway.getRequests("sessions.patch"))
-        .toHaveLength(patchCountBeforeDraft);
-      await expect.poll(() => model.getAttribute("data-chat-thinking-value")).toBe("low");
-      await expect.poll(() => thinkingSlider.inputValue()).toBe("1");
-      await composer.locator('[data-chat-speed-option="on"]').click();
-      await expect
-        .poll(() => gateway.getRequests("sessions.patch"))
-        .toHaveLength(patchCountBeforeDraft);
-      await expect
-        .poll(() => composer.locator('[data-chat-speed-option="on"]').getAttribute("aria-pressed"))
-        .toBe("true");
-      await composer.getByRole("button", { name: "Save", exact: true }).click();
       await expect
         .poll(async () =>
           (await gateway.getRequests("sessions.patch")).some(
@@ -212,6 +200,9 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
           ),
         )
         .toBe(true);
+      await expect.poll(() => model.getAttribute("data-chat-thinking-value")).toBe("low");
+      await expect.poll(() => thinkingSlider.inputValue()).toBe("1");
+      await composer.locator('[data-chat-speed-option="on"]').click();
       await expect
         .poll(async () =>
           (await gateway.getRequests("sessions.patch")).some(
@@ -223,6 +214,10 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
           ),
         )
         .toBe(true);
+      await expect
+        .poll(() => composer.locator('[data-chat-speed-option="on"]').getAttribute("aria-pressed"))
+        .toBe("true");
+      await page.keyboard.press("Escape");
       await expect
         .poll(() => composer.locator(".chat-controls__inline-select-menu").isVisible())
         .toBe(false);
@@ -631,7 +626,9 @@ describeControlUiE2e("Control UI chat composer redesign", () => {
       await expect
         .poll(() => composer.locator('[data-chat-model-provider-group="codex"]').count())
         .toBe(0);
-      await expect.poll(() => composer.locator('[data-chat-model-option=""]').count()).toBe(0);
+      const defaultOption = composer.locator('[data-chat-model-option=""]');
+      await expect.poll(() => defaultOption.count()).toBe(1);
+      await expect.poll(() => defaultOption.textContent()).toContain("Default");
     } finally {
       await context.close();
       await browser.close();

--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -1937,7 +1937,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
         const option = main.locator(`[data-chat-model-option="${value}"]`);
         await option.waitFor({ state: "visible", timeout: 10_000 });
         await option.click();
-        await main.getByRole("button", { name: "Save", exact: true }).click();
+        await page.keyboard.press("Escape");
       };
 
       let modelSelect = await openModelSelect();
@@ -2060,7 +2060,6 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       await modelSelect.click();
       await main.locator('[data-chat-model-provider="openai"]').click();
       await main.locator('[data-chat-model-option="openai/gpt-5.5"]').click();
-      await main.getByRole("button", { name: "Save", exact: true }).click();
       const firstPatch = await gateway.waitForRequest("sessions.patch");
       expect(requireRecord(firstPatch.params)).toMatchObject({
         key: "agent:ops:session-a",
@@ -2068,9 +2067,9 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       });
       expect(await modelSelect.textContent()).toContain("GPT-5.5");
 
-      await modelSelect.click();
-      await main.getByRole("button", { name: "Use default model", exact: true }).click();
-      await main.getByRole("button", { name: "Save", exact: true }).click();
+      // The picker stays open after an immediate apply; the pinned default
+      // option clears the override without a save step.
+      await main.locator('[data-chat-model-option=""]').click();
       const patches = await waitForRequests(gateway, "sessions.patch", 2);
       expect(requireRecord(patches[1]?.params)).toMatchObject({
         key: "agent:ops:session-a",
@@ -2257,7 +2256,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       await main.locator('[data-chat-model-select="true"]').click();
       await main.locator('[data-chat-model-provider="bedrock"]').click();
       await main.locator('[data-chat-model-option="bedrock/claude-opus-4.5"]').click();
-      await main.getByRole("button", { name: "Save", exact: true }).click();
+      await page.keyboard.press("Escape");
       await gateway.waitForRequest("sessions.patch");
 
       const prompt = "send while the model save is pending";

--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T12:43:59.175Z",
+  "generatedAt": "2026-07-09T14:10:34.634Z",
   "locale": "ar",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c61a2780692a19d53b400e76891ffe3013927bff53da3689a80e404b06d97303",
-  "totalKeys": 1757,
-  "translatedKeys": 1757,
+  "sourceHash": "3399b824b867a344d87b038202dd0203eba98be72bebb5dd65b504e054c74925",
+  "totalKeys": 1755,
+  "translatedKeys": 1755,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T12:43:57.792Z",
+  "generatedAt": "2026-07-09T14:10:23.475Z",
   "locale": "de",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c61a2780692a19d53b400e76891ffe3013927bff53da3689a80e404b06d97303",
-  "totalKeys": 1757,
-  "translatedKeys": 1757,
+  "sourceHash": "3399b824b867a344d87b038202dd0203eba98be72bebb5dd65b504e054c74925",
+  "totalKeys": 1755,
+  "translatedKeys": 1755,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T12:43:58.022Z",
+  "generatedAt": "2026-07-09T14:10:25.405Z",
   "locale": "es",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c61a2780692a19d53b400e76891ffe3013927bff53da3689a80e404b06d97303",
-  "totalKeys": 1757,
-  "translatedKeys": 1757,
+  "sourceHash": "3399b824b867a344d87b038202dd0203eba98be72bebb5dd65b504e054c74925",
+  "totalKeys": 1755,
+  "translatedKeys": 1755,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T12:44:00.894Z",
+  "generatedAt": "2026-07-09T14:10:46.793Z",
   "locale": "fa",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c61a2780692a19d53b400e76891ffe3013927bff53da3689a80e404b06d97303",
-  "totalKeys": 1757,
-  "translatedKeys": 1757,
+  "sourceHash": "3399b824b867a344d87b038202dd0203eba98be72bebb5dd65b504e054c74925",
+  "totalKeys": 1755,
+  "translatedKeys": 1755,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T12:43:58.720Z",
+  "generatedAt": "2026-07-09T14:10:31.315Z",
   "locale": "fr",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c61a2780692a19d53b400e76891ffe3013927bff53da3689a80e404b06d97303",
-  "totalKeys": 1757,
-  "translatedKeys": 1757,
+  "sourceHash": "3399b824b867a344d87b038202dd0203eba98be72bebb5dd65b504e054c74925",
+  "totalKeys": 1755,
+  "translatedKeys": 1755,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/hi.meta.json
+++ b/ui/src/i18n/.i18n/hi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T12:43:58.973Z",
+  "generatedAt": "2026-07-09T14:10:32.997Z",
   "locale": "hi",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c61a2780692a19d53b400e76891ffe3013927bff53da3689a80e404b06d97303",
-  "totalKeys": 1757,
-  "translatedKeys": 1757,
+  "sourceHash": "3399b824b867a344d87b038202dd0203eba98be72bebb5dd65b504e054c74925",
+  "totalKeys": 1755,
+  "translatedKeys": 1755,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T12:43:59.924Z",
+  "generatedAt": "2026-07-09T14:10:40.074Z",
   "locale": "id",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c61a2780692a19d53b400e76891ffe3013927bff53da3689a80e404b06d97303",
-  "totalKeys": 1757,
-  "translatedKeys": 1757,
+  "sourceHash": "3399b824b867a344d87b038202dd0203eba98be72bebb5dd65b504e054c74925",
+  "totalKeys": 1755,
+  "translatedKeys": 1755,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T12:43:59.371Z",
+  "generatedAt": "2026-07-09T14:10:35.669Z",
   "locale": "it",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c61a2780692a19d53b400e76891ffe3013927bff53da3689a80e404b06d97303",
-  "totalKeys": 1757,
-  "translatedKeys": 1757,
+  "sourceHash": "3399b824b867a344d87b038202dd0203eba98be72bebb5dd65b504e054c74925",
+  "totalKeys": 1755,
+  "translatedKeys": 1755,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T12:43:58.260Z",
+  "generatedAt": "2026-07-09T14:10:26.721Z",
   "locale": "ja-JP",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c61a2780692a19d53b400e76891ffe3013927bff53da3689a80e404b06d97303",
-  "totalKeys": 1757,
-  "translatedKeys": 1757,
+  "sourceHash": "3399b824b867a344d87b038202dd0203eba98be72bebb5dd65b504e054c74925",
+  "totalKeys": 1755,
+  "translatedKeys": 1755,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T12:43:58.495Z",
+  "generatedAt": "2026-07-09T14:10:28.446Z",
   "locale": "ko",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c61a2780692a19d53b400e76891ffe3013927bff53da3689a80e404b06d97303",
-  "totalKeys": 1757,
-  "translatedKeys": 1757,
+  "sourceHash": "3399b824b867a344d87b038202dd0203eba98be72bebb5dd65b504e054c74925",
+  "totalKeys": 1755,
+  "translatedKeys": 1755,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T12:44:00.693Z",
+  "generatedAt": "2026-07-09T14:10:45.348Z",
   "locale": "nl",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c61a2780692a19d53b400e76891ffe3013927bff53da3689a80e404b06d97303",
-  "totalKeys": 1757,
-  "translatedKeys": 1757,
+  "sourceHash": "3399b824b867a344d87b038202dd0203eba98be72bebb5dd65b504e054c74925",
+  "totalKeys": 1755,
+  "translatedKeys": 1755,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T12:44:00.105Z",
+  "generatedAt": "2026-07-09T14:10:41.317Z",
   "locale": "pl",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c61a2780692a19d53b400e76891ffe3013927bff53da3689a80e404b06d97303",
-  "totalKeys": 1757,
-  "translatedKeys": 1757,
+  "sourceHash": "3399b824b867a344d87b038202dd0203eba98be72bebb5dd65b504e054c74925",
+  "totalKeys": 1755,
+  "translatedKeys": 1755,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T12:43:57.588Z",
+  "generatedAt": "2026-07-09T14:10:21.814Z",
   "locale": "pt-BR",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c61a2780692a19d53b400e76891ffe3013927bff53da3689a80e404b06d97303",
-  "totalKeys": 1757,
-  "translatedKeys": 1757,
+  "sourceHash": "3399b824b867a344d87b038202dd0203eba98be72bebb5dd65b504e054c74925",
+  "totalKeys": 1755,
+  "translatedKeys": 1755,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ru.meta.json
+++ b/ui/src/i18n/.i18n/ru.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T12:44:01.101Z",
+  "generatedAt": "2026-07-09T14:10:48.339Z",
   "locale": "ru",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c61a2780692a19d53b400e76891ffe3013927bff53da3689a80e404b06d97303",
-  "totalKeys": 1757,
-  "translatedKeys": 1757,
+  "sourceHash": "3399b824b867a344d87b038202dd0203eba98be72bebb5dd65b504e054c74925",
+  "totalKeys": 1755,
+  "translatedKeys": 1755,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T12:44:00.284Z",
+  "generatedAt": "2026-07-09T14:10:42.588Z",
   "locale": "th",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c61a2780692a19d53b400e76891ffe3013927bff53da3689a80e404b06d97303",
-  "totalKeys": 1757,
-  "translatedKeys": 1757,
+  "sourceHash": "3399b824b867a344d87b038202dd0203eba98be72bebb5dd65b504e054c74925",
+  "totalKeys": 1755,
+  "translatedKeys": 1755,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T12:43:59.571Z",
+  "generatedAt": "2026-07-09T14:10:37.545Z",
   "locale": "tr",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c61a2780692a19d53b400e76891ffe3013927bff53da3689a80e404b06d97303",
-  "totalKeys": 1757,
-  "translatedKeys": 1757,
+  "sourceHash": "3399b824b867a344d87b038202dd0203eba98be72bebb5dd65b504e054c74925",
+  "totalKeys": 1755,
+  "translatedKeys": 1755,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T12:43:59.753Z",
+  "generatedAt": "2026-07-09T14:10:38.987Z",
   "locale": "uk",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c61a2780692a19d53b400e76891ffe3013927bff53da3689a80e404b06d97303",
-  "totalKeys": 1757,
-  "translatedKeys": 1757,
+  "sourceHash": "3399b824b867a344d87b038202dd0203eba98be72bebb5dd65b504e054c74925",
+  "totalKeys": 1755,
+  "translatedKeys": 1755,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T12:44:00.504Z",
+  "generatedAt": "2026-07-09T14:10:44.024Z",
   "locale": "vi",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c61a2780692a19d53b400e76891ffe3013927bff53da3689a80e404b06d97303",
-  "totalKeys": 1757,
-  "translatedKeys": 1757,
+  "sourceHash": "3399b824b867a344d87b038202dd0203eba98be72bebb5dd65b504e054c74925",
+  "totalKeys": 1755,
+  "translatedKeys": 1755,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T12:43:57.082Z",
+  "generatedAt": "2026-07-09T14:10:19.310Z",
   "locale": "zh-CN",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c61a2780692a19d53b400e76891ffe3013927bff53da3689a80e404b06d97303",
-  "totalKeys": 1757,
-  "translatedKeys": 1757,
+  "sourceHash": "3399b824b867a344d87b038202dd0203eba98be72bebb5dd65b504e054c74925",
+  "totalKeys": 1755,
+  "translatedKeys": 1755,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-07-09T12:43:57.321Z",
+  "generatedAt": "2026-07-09T14:10:20.289Z",
   "locale": "zh-TW",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "c61a2780692a19d53b400e76891ffe3013927bff53da3689a80e404b06d97303",
-  "totalKeys": 1757,
-  "translatedKeys": 1757,
+  "sourceHash": "3399b824b867a344d87b038202dd0203eba98be72bebb5dd65b504e054c74925",
+  "totalKeys": 1755,
+  "translatedKeys": 1755,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -1721,10 +1721,8 @@ export const ar: TranslationMap = {
       retryQueuedMessage: "إعادة محاولة الرسالة في قائمة الانتظار",
     },
     modelPicker: {
-      discard: "تجاهل",
       faster: "أسرع",
       smarter: "أذكى",
-      useDefaultModel: "استخدام النموذج الافتراضي",
     },
     pairingQrExpired: {
       title: "انتهت صلاحية رمز الاقتران QR",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -1755,10 +1755,8 @@ export const de: TranslationMap = {
       retryQueuedMessage: "Nachricht in der Warteschlange erneut senden",
     },
     modelPicker: {
-      discard: "Verwerfen",
       faster: "Schneller",
       smarter: "Intelligenter",
-      useDefaultModel: "Standardmodell verwenden",
     },
     pairingQrExpired: {
       title: "Kopplungs-QR-Code abgelaufen",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1729,10 +1729,8 @@ export const en: TranslationMap = {
       retryQueuedMessage: "Retry queued message",
     },
     modelPicker: {
-      discard: "Discard",
       faster: "Faster",
       smarter: "Smarter",
-      useDefaultModel: "Use default model",
     },
     pairingQrExpired: {
       title: "Pairing QR expired",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -1752,10 +1752,8 @@ export const es: TranslationMap = {
       retryQueuedMessage: "Reintentar mensaje en cola",
     },
     modelPicker: {
-      discard: "Descartar",
       faster: "Más rápido",
       smarter: "Más inteligente",
-      useDefaultModel: "Usar modelo predeterminado",
     },
     pairingQrExpired: {
       title: "Código QR de emparejamiento caducado",

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -1742,10 +1742,8 @@ export const fa: TranslationMap = {
       retryQueuedMessage: "تلاش دوباره برای پیام در صف",
     },
     modelPicker: {
-      discard: "رد کردن",
       faster: "سریع‌تر",
       smarter: "هوشمندتر",
-      useDefaultModel: "استفاده از مدل پیش‌فرض",
     },
     pairingQrExpired: {
       title: "کد QR جفت‌سازی منقضی شد",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -1764,10 +1764,8 @@ export const fr: TranslationMap = {
       retryQueuedMessage: "Réessayer le message en file d’attente",
     },
     modelPicker: {
-      discard: "Abandonner",
       faster: "Plus rapide",
       smarter: "Plus intelligent",
-      useDefaultModel: "Utiliser le modèle par défaut",
     },
     pairingQrExpired: {
       title: "QR d'appairage expiré",

--- a/ui/src/i18n/locales/hi.ts
+++ b/ui/src/i18n/locales/hi.ts
@@ -1724,10 +1724,8 @@ export const hi: TranslationMap = {
       retryQueuedMessage: "कतारबद्ध संदेश का पुनः प्रयास करें",
     },
     modelPicker: {
-      discard: "त्यागें",
       faster: "तेज़",
       smarter: "अधिक बुद्धिमान",
-      useDefaultModel: "डिफ़ॉल्ट मॉडल का उपयोग करें",
     },
     pairingQrExpired: {
       title: "पेयरिंग QR की समय-सीमा समाप्त हो गई",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -1742,10 +1742,8 @@ export const id: TranslationMap = {
       retryQueuedMessage: "Coba lagi pesan dalam antrean",
     },
     modelPicker: {
-      discard: "Buang",
       faster: "Lebih cepat",
       smarter: "Lebih cerdas",
-      useDefaultModel: "Gunakan model default",
     },
     pairingQrExpired: {
       title: "QR pemasangan kedaluwarsa",

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -1755,10 +1755,8 @@ export const it: TranslationMap = {
       retryQueuedMessage: "Riprova messaggio in coda",
     },
     modelPicker: {
-      discard: "Scarta",
       faster: "Più veloce",
       smarter: "Più intelligente",
-      useDefaultModel: "Usa modello predefinito",
     },
     pairingQrExpired: {
       title: "QR di pairing scaduto",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -1749,10 +1749,8 @@ export const ja_JP: TranslationMap = {
       retryQueuedMessage: "キュー内のメッセージを再試行",
     },
     modelPicker: {
-      discard: "破棄",
       faster: "より速く",
       smarter: "より賢く",
-      useDefaultModel: "デフォルトモデルを使用",
     },
     pairingQrExpired: {
       title: "ペアリングQRの有効期限が切れました",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -1731,10 +1731,8 @@ export const ko: TranslationMap = {
       retryQueuedMessage: "대기 중인 메시지 다시 시도",
     },
     modelPicker: {
-      discard: "버리기",
       faster: "더 빠르게",
       smarter: "더 똑똑하게",
-      useDefaultModel: "기본 모델 사용",
     },
     pairingQrExpired: {
       title: "페어링 QR 만료됨",

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -1748,10 +1748,8 @@ export const nl: TranslationMap = {
       retryQueuedMessage: "Bericht in wachtrij opnieuw proberen",
     },
     modelPicker: {
-      discard: "Verwerpen",
       faster: "Sneller",
       smarter: "Slimmer",
-      useDefaultModel: "Standaardmodel gebruiken",
     },
     pairingQrExpired: {
       title: "Koppelings-QR verlopen",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -1748,10 +1748,8 @@ export const pl: TranslationMap = {
       retryQueuedMessage: "Ponów wiadomość w kolejce",
     },
     modelPicker: {
-      discard: "Odrzuć",
       faster: "Szybciej",
       smarter: "Inteligentniej",
-      useDefaultModel: "Użyj modelu domyślnego",
     },
     pairingQrExpired: {
       title: "Kod QR parowania wygasł",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -1744,10 +1744,8 @@ export const pt_BR: TranslationMap = {
       retryQueuedMessage: "Tentar novamente mensagem na fila",
     },
     modelPicker: {
-      discard: "Descartar",
       faster: "Mais rápido",
       smarter: "Mais inteligente",
-      useDefaultModel: "Usar modelo padrão",
     },
     pairingQrExpired: {
       title: "QR de pareamento expirado",

--- a/ui/src/i18n/locales/ru.ts
+++ b/ui/src/i18n/locales/ru.ts
@@ -1757,10 +1757,8 @@ export const ru: TranslationMap = {
       retryQueuedMessage: "Повторить сообщение в очереди",
     },
     modelPicker: {
-      discard: "Сбросить",
       faster: "Быстрее",
       smarter: "Умнее",
-      useDefaultModel: "Использовать модель по умолчанию",
     },
     pairingQrExpired: {
       title: "QR-код сопряжения истек",

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -1705,10 +1705,8 @@ export const th: TranslationMap = {
       retryQueuedMessage: "ลองส่งข้อความในคิวอีกครั้ง",
     },
     modelPicker: {
-      discard: "ละทิ้ง",
       faster: "เร็วขึ้น",
       smarter: "ฉลาดขึ้น",
-      useDefaultModel: "ใช้โมเดลเริ่มต้น",
     },
     pairingQrExpired: {
       title: "QR การจับคู่หมดอายุ",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -1750,10 +1750,8 @@ export const tr: TranslationMap = {
       retryQueuedMessage: "Kuyruğa alınan iletiyi yeniden dene",
     },
     modelPicker: {
-      discard: "Vazgeç",
       faster: "Daha hızlı",
       smarter: "Daha akıllı",
-      useDefaultModel: "Varsayılan modeli kullan",
     },
     pairingQrExpired: {
       title: "Eşleştirme QR kodunun süresi doldu",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -1745,10 +1745,8 @@ export const uk: TranslationMap = {
       retryQueuedMessage: "Повторити повідомлення в черзі",
     },
     modelPicker: {
-      discard: "Відкинути",
       faster: "Швидше",
       smarter: "Розумніше",
-      useDefaultModel: "Використати модель за замовчуванням",
     },
     pairingQrExpired: {
       title: "QR-код для пар'ювання застарів",

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -1733,10 +1733,8 @@ export const vi: TranslationMap = {
       retryQueuedMessage: "Thử lại tin nhắn trong hàng đợi",
     },
     modelPicker: {
-      discard: "Bỏ",
       faster: "Nhanh hơn",
       smarter: "Thông minh hơn",
-      useDefaultModel: "Dùng mô hình mặc định",
     },
     pairingQrExpired: {
       title: "Mã QR ghép nối đã hết hạn",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -1700,10 +1700,8 @@ export const zh_CN: TranslationMap = {
       retryQueuedMessage: "重试排队消息",
     },
     modelPicker: {
-      discard: "放弃",
       faster: "更快",
       smarter: "更智能",
-      useDefaultModel: "使用默认模型",
     },
     pairingQrExpired: {
       title: "配对二维码已过期",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -1702,10 +1702,8 @@ export const zh_TW: TranslationMap = {
       retryQueuedMessage: "重試佇列中的訊息",
     },
     modelPicker: {
-      discard: "捨棄",
       faster: "更快",
       smarter: "更智慧",
-      useDefaultModel: "使用預設模型",
     },
     pairingQrExpired: {
       title: "配對 QR 碼已過期",

--- a/ui/src/i18n/test/translate.test.ts
+++ b/ui/src/i18n/test/translate.test.ts
@@ -217,11 +217,7 @@ describe("i18n", () => {
   });
 
   it("keeps new chat composer commands localized in shipped locale bundles", () => {
-    const checkedKeys = [
-      "chat.modelPicker.useDefaultModel",
-      "chat.composer.addAttachment",
-      "chat.composer.attachFileOption",
-    ];
+    const checkedKeys = ["chat.composer.addAttachment", "chat.composer.attachFileOption"];
 
     for (const [locale, value] of Object.entries(shippedLocales)) {
       for (const key of checkedKeys) {

--- a/ui/src/pages/chat/chat-controls.test.ts
+++ b/ui/src/pages/chat/chat-controls.test.ts
@@ -43,7 +43,6 @@ function createProps(overrides: Record<string, unknown> = {}): ChatControlsProps
     model: {
       activeRunId: null,
       connected: true,
-      draftScope: {},
       gatewayAvailable: true,
       loading: false,
       modelCatalog: [],

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -1027,7 +1027,6 @@ class ChatPane extends OpenClawLightDomElement {
           activeRunId: state.chatRunId,
           agentDefaultModel,
           connected: state.connected,
-          draftScope: state,
           gatewayAvailable: Boolean(state.client),
           loading: state.chatLoading,
           modelCatalog: state.chatModelCatalog,

--- a/ui/src/pages/chat/chat-session.ts
+++ b/ui/src/pages/chat/chat-session.ts
@@ -227,6 +227,37 @@ function setChatError(host: ChatModelSettingsHost, error: string | null, request
   }
 }
 
+// Immediate-apply pickers can overlap patches for the same session. Mirror the
+// pendingModelPatches token guard in sessions/index.ts: only the latest patch
+// may re-assert or roll back the optimistic row, so a slow earlier request
+// cannot clobber a newer selection.
+const chatFastModePatchTokens = new WeakMap<object, Map<string, symbol>>();
+const chatThinkingPatchTokens = new WeakMap<object, Map<string, symbol>>();
+
+function claimChatSettingsPatch(
+  store: WeakMap<object, Map<string, symbol>>,
+  host: object,
+  sessionKey: string,
+): symbol {
+  let tokens = store.get(host);
+  if (!tokens) {
+    tokens = new Map();
+    store.set(host, tokens);
+  }
+  const token = Symbol(sessionKey);
+  tokens.set(sessionKey, token);
+  return token;
+}
+
+function isCurrentChatSettingsPatch(
+  store: WeakMap<object, Map<string, symbol>>,
+  host: object,
+  sessionKey: string,
+  token: symbol,
+): boolean {
+  return store.get(host)?.get(sessionKey) === token;
+}
+
 function patchSessionRow(
   host: ChatModelSettingsHost,
   sessionKey: string,
@@ -259,6 +290,7 @@ export async function switchChatFastMode(
   if (previousFastMode === next) {
     return true;
   }
+  const token = claimChatSettingsPatch(chatFastModePatchTokens, host, targetSessionKey);
   setChatError(host, null, true);
   patchSessionRow(host, targetSessionKey, { fastMode: next });
   try {
@@ -270,10 +302,14 @@ export async function switchChatFastMode(
       scopedAgentParamsForSession(host, targetSessionKey),
     );
     await refreshCurrentChatSessionList(host);
-    patchSessionRow(host, targetSessionKey, { fastMode: next });
+    if (isCurrentChatSettingsPatch(chatFastModePatchTokens, host, targetSessionKey, token)) {
+      patchSessionRow(host, targetSessionKey, { fastMode: next });
+    }
     return true;
   } catch (err) {
-    patchSessionRow(host, targetSessionKey, { fastMode: previousFastMode });
+    if (isCurrentChatSettingsPatch(chatFastModePatchTokens, host, targetSessionKey, token)) {
+      patchSessionRow(host, targetSessionKey, { fastMode: previousFastMode });
+    }
     setChatError(host, `Failed to set speed: ${String(err)}`, true);
     return false;
   }
@@ -355,6 +391,7 @@ export async function switchChatThinkingLevel(
   if ((normalizedPrev ?? "") === (normalizedNext ?? "")) {
     return true;
   }
+  const token = claimChatSettingsPatch(chatThinkingPatchTokens, host, targetSessionKey);
   setChatError(host, null, true);
   patchSessionRow(host, targetSessionKey, { thinkingLevel: normalizedNext });
   if (host.sessionKey === targetSessionKey) {
@@ -369,15 +406,19 @@ export async function switchChatThinkingLevel(
       scopedAgentParamsForSession(host, targetSessionKey),
     );
     await refreshCurrentChatSessionList(host);
-    patchSessionRow(host, targetSessionKey, { thinkingLevel: normalizedNext });
-    if (host.sessionKey === targetSessionKey) {
-      host.chatThinkingLevel = normalizedNext ?? null;
+    if (isCurrentChatSettingsPatch(chatThinkingPatchTokens, host, targetSessionKey, token)) {
+      patchSessionRow(host, targetSessionKey, { thinkingLevel: normalizedNext });
+      if (host.sessionKey === targetSessionKey) {
+        host.chatThinkingLevel = normalizedNext ?? null;
+      }
     }
     return true;
   } catch (err) {
-    patchSessionRow(host, targetSessionKey, { thinkingLevel: previousThinkingLevel });
-    if (host.sessionKey === targetSessionKey) {
-      host.chatThinkingLevel = normalizedPrev ?? null;
+    if (isCurrentChatSettingsPatch(chatThinkingPatchTokens, host, targetSessionKey, token)) {
+      patchSessionRow(host, targetSessionKey, { thinkingLevel: previousThinkingLevel });
+      if (host.sessionKey === targetSessionKey) {
+        host.chatThinkingLevel = normalizedPrev ?? null;
+      }
     }
     setChatError(host, `Failed to set thinking level: ${String(err)}`, true);
     return false;

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -463,7 +463,6 @@ function createChatModelControlsProps(state: ChatHeaderTestState): ChatModelCont
   return {
     activeRunId: state.chatRunId,
     connected: state.connected,
-    draftScope: state,
     gatewayAvailable: Boolean(state.client),
     loading: state.chatLoading,
     modelCatalog: state.chatModelCatalog,
@@ -3242,7 +3241,7 @@ describe("chat model controls", () => {
     expect(modelSelect.getAttribute("aria-disabled")).toBe("true");
   });
 
-  it("disables staged model settings when a run starts before save", () => {
+  it("applies a model selection immediately", () => {
     const { state } = createChatHeaderState({
       model: "gpt-5.5",
       modelProvider: "openai",
@@ -3251,23 +3250,45 @@ describe("chat model controls", () => {
         { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
       ],
     });
+    const onModelSelect = vi.fn(async () => true);
     const container = document.createElement("div");
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
+    render(
+      renderChatModelControls({ ...createChatModelControlsProps(state), onModelSelect }),
+      container,
+    );
     const modelOption = Array.from(
       container.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]"),
     ).find((button) => button.getAttribute("aria-selected") === "false");
     expect(modelOption).toBeInstanceOf(HTMLButtonElement);
     modelOption?.click();
 
+    expect(onModelSelect).toHaveBeenCalledWith(modelOption?.dataset.chatModelOption, "main");
+  });
+
+  it("ignores model clicks while a run is active", () => {
+    const { state } = createChatHeaderState({
+      model: "gpt-5.5",
+      modelProvider: "openai",
+      models: [
+        { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
+        { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
+      ],
+    });
     state.chatRunId = "run-123";
     state.chatStream = "Working";
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
+    const onModelSelect = vi.fn(async () => true);
+    const container = document.createElement("div");
+    render(
+      renderChatModelControls({ ...createChatModelControlsProps(state), onModelSelect }),
+      container,
+    );
+    const modelOption = Array.from(
+      container.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]"),
+    ).find((button) => button.getAttribute("aria-selected") === "false");
+    expect(modelOption?.disabled).toBe(true);
+    modelOption?.click();
 
-    expect(
-      container.querySelector<HTMLButtonElement>(".chat-controls__picker-actions .primary")
-        ?.disabled,
-    ).toBe(true);
-    container.querySelector<HTMLButtonElement>(".chat-controls__discard")?.click();
+    expect(onModelSelect).not.toHaveBeenCalled();
   });
 
   it("groups models by provider and switches the visible provider section", () => {
@@ -3438,13 +3459,15 @@ describe("chat model controls", () => {
     expect(
       container.querySelector(".chat-controls__inline-select-label")?.textContent?.trim(),
     ).toBe("GPT-5.5 · High");
-    expect(container.querySelector('[data-chat-model-option=""]')).toBeNull();
+    const defaultOption = container.querySelector<HTMLButtonElement>('[data-chat-model-option=""]');
+    expect(defaultOption?.getAttribute("aria-selected")).toBe("true");
+    expect(defaultOption?.textContent).toContain("Default (GPT-5.5)");
     expect(
       container.querySelector('[data-chat-model-option="openai/gpt-5.5"]')?.textContent,
     ).toContain("GPT-5.5");
   });
 
-  it("stages clearing a model override until save", async () => {
+  it("clears the model override from the pinned default option", async () => {
     const { state } = createChatHeaderState({
       model: "gpt-5.4",
       modelProvider: "openai",
@@ -3472,56 +3495,14 @@ describe("chat model controls", () => {
       container,
     );
 
-    const useDefault = container.querySelector<HTMLButtonElement>(
-      ".chat-controls__use-default-model",
-    );
-    expect(useDefault).toBeInstanceOf(HTMLButtonElement);
-    expect(useDefault?.disabled).toBe(false);
-    useDefault?.click();
-    expect(onModelSelect).not.toHaveBeenCalled();
+    const defaultOption = container.querySelector<HTMLButtonElement>('[data-chat-model-option=""]');
+    expect(defaultOption).toBeInstanceOf(HTMLButtonElement);
+    expect(defaultOption?.getAttribute("aria-selected")).toBe("false");
+    defaultOption?.click();
 
-    container.querySelector<HTMLButtonElement>(".chat-controls__picker-actions .primary")?.click();
     await vi.waitFor(() => {
       expect(onModelSelect).toHaveBeenCalledWith("", sessionKey);
     });
-  });
-
-  it("stages the active agent default instead of the global model default", () => {
-    const { state } = createChatHeaderState({
-      model: "gpt-5.4",
-      modelProvider: "openai",
-      models: [
-        { id: "gpt-5.4", name: "GPT-5.4", provider: "openai", reasoning: true },
-        { id: "gpt-5.5", name: "GPT-5.5", provider: "openai", reasoning: true },
-        {
-          id: "claude-opus-4-5",
-          name: "Claude Opus 4.5",
-          provider: "anthropic",
-          reasoning: true,
-        },
-      ],
-    });
-    state.sessionsResult = createSessionsListResult({
-      defaultsModel: "gpt-5.5",
-      defaultsProvider: "openai",
-      model: "gpt-5.4",
-      modelProvider: "openai",
-    });
-    const container = document.createElement("div");
-    const props = {
-      ...createChatModelControlsProps(state),
-      agentDefaultModel: "anthropic/claude-opus-4-5",
-      modelOverrides: { main: "openai/gpt-5.4" },
-    };
-    render(renderChatModelControls(props), container);
-
-    container.querySelector<HTMLButtonElement>(".chat-controls__use-default-model")?.click();
-    render(renderChatModelControls(props), container);
-
-    const speedLabels = Array.from(
-      container.querySelectorAll<HTMLButtonElement>("[data-chat-speed-option]"),
-    ).map((button) => button.textContent?.trim());
-    expect(speedLabels).toEqual(["Default", "Fast", "Standard", "Auto"]);
   });
 
   it("shows canonical OpenAI names for legacy Codex model references", () => {
@@ -3664,7 +3645,7 @@ describe("chat model controls", () => {
     ).not.toBeNull();
   });
 
-  it("stages model, reasoning, and speed for the session that opened the picker", async () => {
+  it("applies model, reasoning, and speed immediately for the session that opened the picker", () => {
     const { state } = createChatHeaderState({
       model: "gpt-5.5",
       modelProvider: "openai",
@@ -3683,13 +3664,9 @@ describe("chat model controls", () => {
         { id: "high", label: "high" },
       ],
     });
-    let resolveModelSwitch: (value: boolean) => void = () => undefined;
-    const modelSwitch = new Promise<boolean>((resolve) => {
-      resolveModelSwitch = resolve;
-    });
-    const onModelSelect = vi.fn(() => modelSwitch);
-    const onThinkingSelect = vi.fn();
-    const onFastModeSelect = vi.fn();
+    const onModelSelect = vi.fn(async () => true);
+    const onThinkingSelect = vi.fn(async () => true);
+    const onFastModeSelect = vi.fn(async () => true);
     const container = document.createElement("div");
     render(
       renderChatModelControls({
@@ -3703,154 +3680,35 @@ describe("chat model controls", () => {
 
     const modelOption = Array.from(
       container.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]"),
-    ).find((button) => button.getAttribute("aria-selected") === "false");
+    ).find(
+      (button) =>
+        button.getAttribute("aria-selected") === "false" && button.dataset.chatModelOption !== "",
+    );
     expect(modelOption).toBeInstanceOf(HTMLButtonElement);
     modelOption?.click();
-    expect(onModelSelect).not.toHaveBeenCalled();
+    expect(onModelSelect).toHaveBeenCalledWith(modelOption?.dataset.chatModelOption, "main");
 
     const slider = getThinkingSlider(container);
     expect(slider).toBeInstanceOf(HTMLInputElement);
     if (slider) {
       slider.value = "0";
       slider.dispatchEvent(new Event("input", { bubbles: true }));
+      // Drag preview updates the value label before the change commit.
+      expect(getThinkingReasoningValueLabel(container)).toBe("Low");
       slider.dispatchEvent(new Event("change", { bubbles: true }));
     }
-    render(
-      renderChatModelControls({
-        ...createChatModelControlsProps(state),
-        onFastModeSelect,
-        onModelSelect,
-        onThinkingSelect,
-      }),
-      container,
-    );
-    expect(getThinkingReasoningValueLabel(container)).toBe("Low");
+    expect(onThinkingSelect).toHaveBeenCalledWith("low", "main");
+
     const fastButton = Array.from(
       container.querySelectorAll<HTMLButtonElement>("[data-chat-speed-option]"),
     ).find((button) => button.textContent?.trim() === "Fast");
     expect(fastButton).toBeInstanceOf(HTMLButtonElement);
     fastButton?.click();
-    expect(onModelSelect).not.toHaveBeenCalled();
-
-    container.querySelector<HTMLButtonElement>(".chat-controls__picker-actions .primary")?.click();
-    await vi.waitFor(() => {
-      expect(onModelSelect).toHaveBeenCalledWith(modelOption?.dataset.chatModelOption, "main");
-    });
-
-    state.sessionKey = "other";
-    resolveModelSwitch(true);
-
-    await vi.waitFor(() => {
-      expect(onThinkingSelect).toHaveBeenCalledWith("low", "main");
-      expect(onFastModeSelect).toHaveBeenCalledWith("on", "main");
-    });
+    expect(onFastModeSelect).toHaveBeenCalledWith("on", "main");
+    expect(fastButton?.getAttribute("aria-pressed")).toBe("true");
   });
 
-  it("preserves staged settings when a save step fails", async () => {
-    const { state } = createChatHeaderState({
-      model: "gpt-5.5",
-      modelProvider: "openai",
-      models: [{ id: "gpt-5.5", name: "GPT-5.5", provider: "openai" }],
-      thinkingDefault: "high",
-    });
-    state.sessionsResult = createSessionsListResult({
-      defaultsModel: "gpt-5.5",
-      defaultsProvider: "openai",
-      defaultsThinkingDefault: "high",
-      defaultsThinkingLevels: [
-        { id: "low", label: "low" },
-        { id: "high", label: "high" },
-      ],
-    });
-    const onThinkingSelect = vi.fn().mockResolvedValue(false);
-    const onFastModeSelect = vi.fn();
-    const props = {
-      ...createChatModelControlsProps(state),
-      onFastModeSelect,
-      onThinkingSelect,
-    };
-    const container = document.createElement("div");
-    render(renderChatModelControls(props), container);
-
-    const slider = getThinkingSlider(container);
-    expect(slider).toBeInstanceOf(HTMLInputElement);
-    if (slider) {
-      slider.value = "0";
-      slider.dispatchEvent(new Event("input", { bubbles: true }));
-      slider.dispatchEvent(new Event("change", { bubbles: true }));
-    }
-    render(renderChatModelControls(props), container);
-    const fastButton = Array.from(
-      container.querySelectorAll<HTMLButtonElement>("[data-chat-speed-option]"),
-    ).find((button) => button.textContent?.trim() === "Fast");
-    fastButton?.click();
-
-    container.querySelector<HTMLButtonElement>(".chat-controls__picker-actions .primary")?.click();
-    await vi.waitFor(() => {
-      expect(onThinkingSelect).toHaveBeenCalledWith("low", "main");
-    });
-    expect(onFastModeSelect).not.toHaveBeenCalled();
-
-    render(renderChatModelControls(props), container);
-    expect(getThinkingReasoningValueLabel(container)).toBe("Low");
-    expect(
-      Array.from(container.querySelectorAll<HTMLButtonElement>("[data-chat-speed-option]"))
-        .find((button) => button.textContent?.trim() === "Fast")
-        ?.getAttribute("aria-pressed"),
-    ).toBe("true");
-  });
-
-  it("clears staged model settings when the active session changes", () => {
-    const { state } = createChatHeaderState({
-      model: "gpt-5.5",
-      modelProvider: "openai",
-      models: [
-        { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
-        { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
-      ],
-    });
-    const container = document.createElement("div");
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
-
-    container
-      .querySelector<HTMLButtonElement>('[data-chat-model-option="openai/gpt-5.4"]')
-      ?.click();
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
-    expect(
-      container
-        .querySelector<HTMLButtonElement>('[data-chat-model-option="openai/gpt-5.4"]')
-        ?.getAttribute("aria-selected"),
-    ).toBe("true");
-
-    state.sessionKey = "other";
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
-    state.sessionKey = "main";
-    render(renderChatModelControls(createChatModelControlsProps(state)), container);
-
-    expect(
-      container
-        .querySelector<HTMLButtonElement>('[data-chat-model-option="openai/gpt-5.5"]')
-        ?.getAttribute("aria-selected"),
-    ).toBe("true");
-
-    container
-      .querySelector<HTMLButtonElement>('[data-chat-model-option="openai/gpt-5.4"]')
-      ?.click();
-    render(
-      renderChatModelControls({
-        ...createChatModelControlsProps(state),
-        draftScope: {},
-      }),
-      container,
-    );
-    expect(
-      container
-        .querySelector<HTMLButtonElement>('[data-chat-model-option="openai/gpt-5.5"]')
-        ?.getAttribute("aria-selected"),
-    ).toBe("true");
-  });
-
-  it("preserves staged model settings when the model save fails", async () => {
+  it("renders the committed model selection when a model switch fails", async () => {
     const { state } = createChatHeaderState({
       model: "gpt-5.5",
       modelProvider: "openai",
@@ -3867,24 +3725,19 @@ describe("chat model controls", () => {
     };
     render(renderChatModelControls(props), container);
 
-    const modelOption = Array.from(
-      container.querySelectorAll<HTMLButtonElement>("[data-chat-model-option]"),
-    ).find((button) => button.dataset.chatModelOption === "openai/gpt-5.4");
-    expect(modelOption).toBeInstanceOf(HTMLButtonElement);
-    modelOption?.click();
-    container.querySelector<HTMLButtonElement>(".chat-controls__picker-actions .primary")?.click();
+    container
+      .querySelector<HTMLButtonElement>('[data-chat-model-option="openai/gpt-5.4"]')
+      ?.click();
 
     await vi.waitFor(() => {
       expect(onModelSelect).toHaveBeenCalledWith("openai/gpt-5.4", "main");
     });
-    await vi.waitFor(() => {
-      render(renderChatModelControls(props), container);
-      expect(
-        container
-          .querySelector<HTMLButtonElement>('[data-chat-model-option="openai/gpt-5.4"]')
-          ?.getAttribute("aria-selected"),
-      ).toBe("true");
-    });
+    render(renderChatModelControls(props), container);
+    expect(
+      container
+        .querySelector<HTMLButtonElement>('[data-chat-model-option="openai/gpt-5.5"]')
+        ?.getAttribute("aria-selected"),
+    ).toBe("true");
   });
 
   it("keeps speed choices visible and disabled for unsupported providers", () => {
@@ -3946,7 +3799,6 @@ describe("chat model controls", () => {
     const slider = getThinkingSlider(container);
     expect(slider?.classList.contains("chat-controls__reasoning-range--unanchored")).toBe(true);
     slider?.click();
-    container.querySelector<HTMLButtonElement>(".chat-controls__picker-actions .primary")?.click();
 
     await vi.waitFor(() => {
       expect(request).toHaveBeenCalledWith("sessions.patch", {
@@ -3992,7 +3844,6 @@ describe("chat model controls", () => {
     expect(only).toBeInstanceOf(HTMLButtonElement);
     expect(only?.getAttribute("aria-pressed")).toBe("false");
     only?.click();
-    container.querySelector<HTMLButtonElement>(".chat-controls__picker-actions .primary")?.click();
 
     await vi.waitFor(() => {
       expect(request).toHaveBeenCalledWith("sessions.patch", {

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -3708,6 +3708,44 @@ describe("chat model controls", () => {
     expect(fastButton?.getAttribute("aria-pressed")).toBe("true");
   });
 
+  it("locks reasoning and speed while a model switch is pending", () => {
+    const { state } = createChatHeaderState({
+      model: "gpt-5.5",
+      modelProvider: "openai",
+      models: [
+        { id: "gpt-5.4", name: "GPT-5.4", provider: "openai" },
+        { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
+      ],
+      thinkingDefault: "high",
+    });
+    state.sessionsResult = createSessionsListResult({
+      defaultsModel: "gpt-5.5",
+      defaultsProvider: "openai",
+      defaultsThinkingDefault: "high",
+      defaultsThinkingLevels: [
+        { id: "low", label: "low" },
+        { id: "high", label: "high" },
+      ],
+    });
+    const container = document.createElement("div");
+    render(
+      renderChatModelControls({
+        ...createChatModelControlsProps(state),
+        modelSwitching: true,
+      }),
+      container,
+    );
+
+    // The session row still describes the previous model while the switch is
+    // pending, so committing reasoning/speed then would target stale levels.
+    expect(getThinkingSlider(container)?.disabled).toBe(true);
+    const speedButtons = Array.from(
+      container.querySelectorAll<HTMLButtonElement>("[data-chat-speed-option]"),
+    );
+    expect(speedButtons.length).toBeGreaterThan(0);
+    expect(speedButtons.every((button) => button.disabled)).toBe(true);
+  });
+
   it("renders the committed model selection when a model switch fails", async () => {
     const { state } = createChatHeaderState({
       model: "gpt-5.5",

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -3746,6 +3746,42 @@ describe("chat model controls", () => {
     expect(speedButtons.every((button) => button.disabled)).toBe(true);
   });
 
+  it("keeps the newest speed selection when an older patch fails late", async () => {
+    const pendingPatches: Array<{ resolve: () => void; reject: (error: Error) => void }> = [];
+    // Minimal host: the factory's mock gateway rebuilds session rows on every
+    // refresh, which would mask the optimistic fastMode value under test.
+    const host = {
+      client: {},
+      connected: true,
+      sessionKey: "main",
+      chatModelCatalog: [],
+      chatThinkingLevel: null,
+      sessionsResult: createSessionsResultFromRows([{ key: "main", kind: "direct", updatedAt: 1 }]),
+      sessions: {
+        patch: () =>
+          new Promise((resolve, reject) => {
+            pendingPatches.push({ resolve: () => resolve(null), reject });
+          }),
+        refresh: async () => {},
+      },
+    } as unknown as Parameters<typeof switchChatFastMode>[0];
+
+    const first = switchChatFastMode(host, "on");
+    await vi.waitFor(() => expect(pendingPatches).toHaveLength(1));
+    const second = switchChatFastMode(host, "off");
+    await vi.waitFor(() => expect(pendingPatches).toHaveLength(2));
+
+    pendingPatches[1]?.resolve();
+    await expect(second).resolves.toBe(true);
+    pendingPatches[0]?.reject(new Error("boom"));
+    await expect(first).resolves.toBe(false);
+
+    // Without the per-session patch token, the older failure would roll the
+    // row back to its pre-"on" value and clobber the newer selection.
+    const row = host.sessionsResult?.sessions.find((entry) => entry.key === "main");
+    expect(row?.fastMode).toBe(false);
+  });
+
   it("renders the committed model selection when a model switch fails", async () => {
     const { state } = createChatHeaderState({
       model: "gpt-5.5",

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -1,11 +1,7 @@
 // Chat-owned model, reasoning, and speed picker.
 import { html } from "lit";
 import { repeat } from "lit/directives/repeat.js";
-import type {
-  GatewaySessionRow,
-  ModelCatalogEntry,
-  SessionsListResult,
-} from "../../../api/types.ts";
+import type { ModelCatalogEntry, SessionsListResult } from "../../../api/types.ts";
 import { inferControlUiPublicAssetPath } from "../../../app/public-assets.ts";
 import { icons } from "../../../components/icons.ts";
 import "../../../components/tooltip.ts";
@@ -27,7 +23,6 @@ export type ChatModelControlsProps = {
   activeRunId: string | null;
   agentDefaultModel?: string;
   connected: boolean;
-  draftScope: object;
   gatewayAvailable: boolean;
   loading: boolean;
   modelCatalog: ModelCatalogEntry[];
@@ -47,50 +42,6 @@ export type ChatModelControlsProps = {
 type ChatModelProviderOption = ChatModelSelectOption & {
   provider: string;
 };
-
-type ChatModelPickerDraft = {
-  fastModeValue: ChatFastModeSelectValue;
-  initialFastModeValue: ChatFastModeSelectValue;
-  initialModelValue: string;
-  initialThinkingValue: string;
-  modelValue: string;
-  saving: boolean;
-  thinkingValue: string;
-};
-
-type ChatModelPickerDraftStore = {
-  delete: () => void;
-  get: () => ChatModelPickerDraft | undefined;
-  set: (draft: ChatModelPickerDraft) => void;
-};
-
-type ChatModelPickerDraftContext = {
-  draft?: ChatModelPickerDraft;
-  sessionKey: string;
-};
-
-const chatModelPickerDraftContexts = new WeakMap<object, ChatModelPickerDraftContext>();
-
-function resolveChatModelPickerDraftStore(
-  scope: object,
-  sessionKey: string,
-): ChatModelPickerDraftStore {
-  let context = chatModelPickerDraftContexts.get(scope);
-  if (!context || context.sessionKey !== sessionKey) {
-    context = { sessionKey };
-    chatModelPickerDraftContexts.set(scope, context);
-  }
-  const activeContext = context;
-  return {
-    delete: () => {
-      activeContext.draft = undefined;
-    },
-    get: () => activeContext.draft,
-    set: (draft) => {
-      activeContext.draft = draft;
-    },
-  };
-}
 
 const CHAT_MODEL_PROVIDER_LABELS: Readonly<Record<string, string>> = {
   anthropic: "Anthropic",
@@ -261,122 +212,6 @@ function resolveChatModelProvider(
   return "other";
 }
 
-function resolveChatModelTarget(params: {
-  catalog: ModelCatalogEntry[];
-  defaultModel: string;
-  modelOptions: ChatModelProviderOption[];
-  value: string;
-}): { model: string | undefined; provider: string | undefined } {
-  const targetValue = params.value || params.defaultModel;
-  if (!targetValue) {
-    return { model: undefined, provider: undefined };
-  }
-  const option = params.modelOptions.find((entry) => entry.value === params.value);
-  const provider = option?.provider ?? resolveChatModelProvider(targetValue, params.catalog);
-  const normalizedProvider = normalizeChatModelProviderGroupId(provider);
-  const normalizedValue = targetValue.trim().toLowerCase();
-  const catalogEntry = params.catalog.find((entry) => {
-    const entryProvider = normalizeChatModelProviderId(entry.provider);
-    const entryProviderGroup = normalizeChatModelProviderGroupId(entry.provider);
-    const entryId = entry.id.trim().toLowerCase();
-    return (
-      entryProviderGroup === normalizedProvider &&
-      (entryId === normalizedValue || `${entryProvider}/${entryId}` === normalizedValue)
-    );
-  });
-  if (catalogEntry) {
-    return {
-      model: catalogEntry.id,
-      provider: catalogEntry.provider,
-    };
-  }
-  const separator = normalizedValue.indexOf("/");
-  const qualifiedProvider =
-    separator > 0 ? normalizeChatModelProviderGroupId(normalizedValue.slice(0, separator)) : "";
-  return {
-    model:
-      separator > 0 && qualifiedProvider === normalizedProvider
-        ? targetValue.slice(separator + 1)
-        : targetValue,
-    provider,
-  };
-}
-
-function resolveDraftFastMode(value: ChatFastModeSelectValue): GatewaySessionRow["fastMode"] {
-  if (value === "auto") {
-    return "auto";
-  }
-  if (value === "on") {
-    return true;
-  }
-  if (value === "off") {
-    return false;
-  }
-  return undefined;
-}
-
-function applyChatModelPickerDraft(params: {
-  catalog: ModelCatalogEntry[];
-  defaultModel: string;
-  draft: ChatModelPickerDraft | undefined;
-  modelOptions: ChatModelProviderOption[];
-  sessionKey: string;
-  sessionsResult: SessionsListResult | null;
-}): SessionsListResult | null {
-  if (!params.draft || !params.sessionsResult) {
-    return params.sessionsResult;
-  }
-  const draft = params.draft;
-  const sessionsResult = params.sessionsResult;
-  const target = resolveChatModelTarget({
-    catalog: params.catalog,
-    defaultModel: params.defaultModel,
-    modelOptions: params.modelOptions,
-    value: draft.modelValue,
-  });
-  const fastMode = resolveDraftFastMode(draft.fastModeValue);
-  return {
-    ...sessionsResult,
-    sessions: sessionsResult.sessions.map((row) =>
-      row.key === params.sessionKey
-        ? Object.assign({}, row, {
-            model: target.model,
-            modelProvider: target.provider,
-            thinkingLevel: draft.thinkingValue || undefined,
-            fastMode,
-            effectiveFastMode: fastMode,
-          })
-        : row,
-    ),
-  };
-}
-
-function ensureChatModelPickerDraft(
-  draftStore: ChatModelPickerDraftStore,
-  params: {
-    fastModeValue: ChatFastModeSelectValue;
-    modelValue: string;
-    sessionKey: string;
-    thinkingValue: string;
-  },
-): ChatModelPickerDraft {
-  const existing = draftStore.get();
-  if (existing) {
-    return existing;
-  }
-  const draft: ChatModelPickerDraft = {
-    fastModeValue: params.fastModeValue,
-    initialFastModeValue: params.fastModeValue,
-    initialModelValue: params.modelValue,
-    initialThinkingValue: params.thinkingValue,
-    modelValue: params.modelValue,
-    saving: false,
-    thinkingValue: params.thinkingValue,
-  };
-  draftStore.set(draft);
-  return draft;
-}
-
 function resolveChatModelPickerLabel(
   value: string,
   fallbackLabel: string,
@@ -426,7 +261,6 @@ function selectChatModelProvider(event: MouseEvent, provider: string): void {
 }
 
 export function renderChatModelControls(props: ChatModelControlsProps) {
-  const draftStore = resolveChatModelPickerDraftStore(props.draftScope, props.sessionKey);
   const {
     currentOverride,
     defaultSelectable,
@@ -440,12 +274,12 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
     sessionKey: props.sessionKey,
     sessionsResult: props.sessionsResult,
   });
-  const committedThinking = resolveChatThinkingSelectState({
+  const thinking = resolveChatThinkingSelectState({
     catalog: props.modelCatalog,
     sessionKey: props.sessionKey,
     sessionsResult: props.sessionsResult,
   });
-  const committedFastMode = resolveChatFastModeSelectState({
+  const fastMode = resolveChatFastModeSelectState({
     activeRunId: props.activeRunId,
     catalog: props.modelCatalog,
     connected: props.connected,
@@ -503,45 +337,10 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
       props.modelCatalog,
     );
   const committedThinkingLabel =
-    committedThinking.currentOverride === ""
-      ? committedThinking.defaultLabel
-      : (committedThinking.options.find(
-          (entry) => entry.value === committedThinking.currentOverride,
-        )?.label ?? committedThinking.currentOverride);
-  const draft = draftStore.get();
-  const selectedModelValue = draft?.modelValue ?? currentOverride;
-  const draftSessionsResult = applyChatModelPickerDraft({
-    catalog: props.modelCatalog,
-    defaultModel,
-    draft,
-    modelOptions,
-    sessionKey: props.sessionKey,
-    sessionsResult: props.sessionsResult,
-  });
-  const thinking = draft
-    ? resolveChatThinkingSelectState({
-        catalog: props.modelCatalog,
-        sessionKey: props.sessionKey,
-        sessionsResult: draftSessionsResult,
-      })
-    : committedThinking;
-  const fastMode = draft
-    ? {
-        ...resolveChatFastModeSelectState({
-          activeRunId: props.activeRunId,
-          catalog: props.modelCatalog,
-          connected: props.connected,
-          currentModelOverride: selectedModelValue,
-          gatewayAvailable: props.gatewayAvailable,
-          loading: props.loading,
-          sending: props.sending,
-          sessionKey: props.sessionKey,
-          sessionsResult: draftSessionsResult,
-          stream: props.stream,
-        }),
-        currentOverride: draft.fastModeValue,
-      }
-    : committedFastMode;
+    thinking.currentOverride === ""
+      ? thinking.defaultLabel
+      : (thinking.options.find((entry) => entry.value === thinking.currentOverride)?.label ??
+        thinking.currentOverride);
   const busy =
     props.loading || props.sending || Boolean(props.activeRunId) || props.stream !== null;
   const disabled =
@@ -557,14 +356,10 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
     (thinking.options.length === 0 && thinking.currentOverride === "");
   return renderChatModelReasoningSelect({
     disabled,
-    draftStore,
     fastMode,
     modelOptions,
-    initialFastModeValue: committedFastMode.currentOverride,
-    initialModelValue: currentOverride,
-    initialThinkingValue: committedThinking.currentOverride,
     onRequestUpdate: props.onRequestUpdate,
-    selectedModelValue,
+    selectedModelValue: currentOverride,
     selectedThinkingValue: thinking.currentOverride,
     sessionKey: props.sessionKey,
     thinkingDefaultValue: thinking.defaultValue,
@@ -608,12 +403,8 @@ function formatCombinedPickerThinkingLabel(label: string): string {
 }
 
 function renderChatModelReasoningSelect(params: {
-  draftStore: ChatModelPickerDraftStore;
   fastMode: ChatFastModeSelectState;
   disabled: boolean;
-  initialFastModeValue: ChatFastModeSelectValue;
-  initialModelValue: string;
-  initialThinkingValue: string;
   modelOptions: ChatModelProviderOption[];
   selectedModelValue: string;
   selectedThinkingValue: string;
@@ -630,11 +421,7 @@ function renderChatModelReasoningSelect(params: {
 }) {
   const {
     disabled,
-    draftStore,
     fastMode,
-    initialFastModeValue,
-    initialModelValue,
-    initialThinkingValue,
     modelOptions,
     selectedModelValue,
     selectedThinkingValue,
@@ -672,21 +459,31 @@ function renderChatModelReasoningSelect(params: {
         selectedThinkingOption?.label ?? formatThinkingOverrideLabel(selectedThinkingValue),
       )
     : `Default (${defaultLevelLabel})`;
+  // Selections commit immediately; the picker stays open so model, reasoning,
+  // and speed can be adjusted together. The extra onRequestUpdate re-renders
+  // the optimistic state patched synchronously by the switch helpers.
+  const commitModel = (value: string) => {
+    void onModelSelect(value, sessionKey).finally(() => onRequestUpdate?.());
+    onRequestUpdate?.();
+  };
+  const commitThinking = (value: string) => {
+    void onThinkingSelect(value, sessionKey).finally(() => onRequestUpdate?.());
+    onRequestUpdate?.();
+  };
   const onSliderDrag = (event: Event) => {
     const input = event.currentTarget as HTMLInputElement;
     const stop = sliderStops[Number(input.value)];
     if (!stop) {
       return;
     }
-    const draft = ensureChatModelPickerDraft(draftStore, {
-      fastModeValue: initialFastModeValue,
-      modelValue: initialModelValue,
-      sessionKey,
-      thinkingValue: initialThinkingValue,
-    });
-    draft.thinkingValue = stop.value;
     input.style.setProperty("--reasoning-fill", `${sliderFillPercent(Number(input.value))}%`);
-    onRequestUpdate?.();
+    // Live drag preview without committing; change commits on release.
+    const valueLabel = input
+      .closest(".chat-controls__reasoning-panel")
+      ?.querySelector(".chat-controls__reasoning-value");
+    if (valueLabel) {
+      valueLabel.textContent = formatCombinedPickerThinkingLabel(stop.label);
+    }
   };
   const onSliderCommit = (event: Event) => {
     if (thinkingDisabled) {
@@ -697,14 +494,7 @@ function renderChatModelReasoningSelect(params: {
     if (!stop || stop.value === selectedThinkingValue) {
       return;
     }
-    const draft = ensureChatModelPickerDraft(draftStore, {
-      fastModeValue: initialFastModeValue,
-      modelValue: initialModelValue,
-      sessionKey,
-      thinkingValue: initialThinkingValue,
-    });
-    draft.thinkingValue = stop.value;
-    onRequestUpdate?.();
+    commitThinking(stop.value);
   };
   const onUnanchoredSliderClick = (event: MouseEvent) => {
     const input = event.currentTarget as HTMLInputElement;
@@ -724,15 +514,6 @@ function renderChatModelReasoningSelect(params: {
   const effectiveThinkingValue = selectedThinkingValue || thinkingDefaultValue;
   const onlyStopSelected = onlyStop?.value === effectiveThinkingValue;
   const showReasoningPanel = showReasoning || fastMode.options.length > 0;
-  const shouldDisableSave = () => {
-    const draft = draftStore.get();
-    return Boolean(
-      disabled ||
-      draft?.saving ||
-      (draft && draft.thinkingValue !== draft.initialThinkingValue && thinkingDisabled) ||
-      (draft && draft.fastModeValue !== draft.initialFastModeValue && fastMode.disabled),
-    );
-  };
   const providerGroups = new Map<string, ChatModelProviderOption[]>();
   for (const option of modelOptions) {
     if (option.value === "") {
@@ -766,10 +547,15 @@ function renderChatModelReasoningSelect(params: {
       : selectedModelProvider;
   const renderModelOption = (entry: ChatModelProviderOption) => {
     const selected = entry.value === selectedModelValue;
+    const isDefaultOption = entry.value === "";
     const modelLabel = formatCombinedPickerModelOptionLabel(entry, selected);
     return html`
-      <div class="chat-controls__combined-model">
-        <openclaw-tooltip .content=${modelLabel}>
+      <div
+        class="chat-controls__combined-model ${isDefaultOption
+          ? "chat-controls__combined-model--default"
+          : ""}"
+      >
+        <openclaw-tooltip .content=${entry.label}>
           <button
             class="chat-controls__inline-select-option chat-controls__combined-model-option ${selected
               ? "chat-controls__inline-select-option--selected"
@@ -785,18 +571,13 @@ function renderChatModelReasoningSelect(params: {
                 event.preventDefault();
                 return;
               }
-              const draft = ensureChatModelPickerDraft(draftStore, {
-                fastModeValue: initialFastModeValue,
-                modelValue: initialModelValue,
-                sessionKey,
-                thinkingValue: initialThinkingValue,
-              });
-              draft.modelValue = entry.value;
-              onRequestUpdate?.();
+              commitModel(entry.value);
             }}
           >
             <span class="chat-controls__model-option-copy">
-              <span class="chat-controls__model-option-title">${modelLabel}</span>
+              <span class="chat-controls__model-option-title">
+                ${isDefaultOption ? entry.label : modelLabel}
+              </span>
               <span class="chat-controls__model-option-provider">
                 ${formatChatModelProviderLabel(entry.provider)}
               </span>
@@ -814,26 +595,7 @@ function renderChatModelReasoningSelect(params: {
     `;
   };
   return html`
-    <details
-      class="chat-controls__session chat-controls__inline-select chat-controls__model"
-      @toggle=${(event: Event) => {
-        const details = event.currentTarget as HTMLDetailsElement;
-        if (details.open) {
-          ensureChatModelPickerDraft(draftStore, {
-            fastModeValue: initialFastModeValue,
-            modelValue: initialModelValue,
-            sessionKey,
-            thinkingValue: initialThinkingValue,
-          });
-          return;
-        }
-        const draft = draftStore.get();
-        if (!draft?.saving) {
-          draftStore.delete();
-          onRequestUpdate?.();
-        }
-      }}
-    >
+    <details class="chat-controls__session chat-controls__inline-select chat-controls__model">
       <summary
         class="chat-controls__inline-select-trigger ${disabled
           ? "chat-controls__inline-select-trigger--disabled"
@@ -886,6 +648,7 @@ function renderChatModelReasoningSelect(params: {
             )}
           </div>
           <div class="chat-controls__provider-models">
+            ${defaultModelOption ? renderModelOption(defaultModelOption) : ""}
             ${repeat(
               orderedProviderGroups,
               ([provider]) => provider,
@@ -926,14 +689,7 @@ function renderChatModelReasoningSelect(params: {
                                 event.preventDefault();
                                 return;
                               }
-                              const draft = ensureChatModelPickerDraft(draftStore, {
-                                fastModeValue: initialFastModeValue,
-                                modelValue: initialModelValue,
-                                sessionKey,
-                                thinkingValue: initialThinkingValue,
-                              });
-                              draft.thinkingValue = "";
-                              onRequestUpdate?.();
+                              commitThinking("");
                             }}
                           >
                             (Default is ${defaultLevelLabel})
@@ -1002,14 +758,7 @@ function renderChatModelReasoningSelect(params: {
                                     event.preventDefault();
                                     return;
                                   }
-                                  const draft = ensureChatModelPickerDraft(draftStore, {
-                                    fastModeValue: initialFastModeValue,
-                                    modelValue: initialModelValue,
-                                    sessionKey,
-                                    thinkingValue: initialThinkingValue,
-                                  });
-                                  draft.thinkingValue = onlyStop.value;
-                                  onRequestUpdate?.();
+                                  commitThinking(onlyStop.value);
                                 }}
                               >
                                 <span>${onlyStop.label}</span>
@@ -1051,31 +800,27 @@ function renderChatModelReasoningSelect(params: {
                           ?disabled=${fastMode.disabled}
                           @click=${(event: MouseEvent) => {
                             event.stopPropagation();
-                            if (fastMode.disabled) {
+                            if (fastMode.disabled || speedSelected) {
                               event.preventDefault();
                               return;
                             }
-                            const draft = ensureChatModelPickerDraft(draftStore, {
-                              fastModeValue: initialFastModeValue,
-                              modelValue: initialModelValue,
-                              sessionKey,
-                              thinkingValue: initialThinkingValue,
-                            });
-                            draft.fastModeValue = speedValue;
+                            void onFastModeSelect(speedValue, sessionKey).finally(() =>
+                              onRequestUpdate?.(),
+                            );
+                            // Instant toggle feedback: effectiveFastMode masks the
+                            // optimistic fastMode patch until the session list refreshes.
                             const currentButton = event.currentTarget as HTMLButtonElement;
                             currentButton
                               .closest(".chat-controls__reasoning-options--speed")
                               ?.querySelectorAll<HTMLButtonElement>("[data-chat-speed-option]")
                               .forEach((button) => {
-                                const selected =
-                                  button.dataset.chatSpeedOption === draft.fastModeValue;
+                                const selected = button.dataset.chatSpeedOption === speed.value;
                                 button.setAttribute("aria-pressed", selected ? "true" : "false");
                                 button.classList.toggle(
                                   "chat-controls__reasoning-option--selected",
                                   selected,
                                 );
                               });
-                            onRequestUpdate?.();
                           }}
                         >
                           <span>${speed.label}</span>
@@ -1087,102 +832,6 @@ function renderChatModelReasoningSelect(params: {
               </div>
             `
           : ""}
-        <div class="chat-controls__picker-actions">
-          ${defaultModelOption
-            ? html`
-                <button
-                  class="btn btn--sm chat-controls__use-default-model"
-                  type="button"
-                  ?disabled=${disabled || draftStore.get()?.saving || selectedModelValue === ""}
-                  @click=${(event: MouseEvent) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    if (disabled || draftStore.get()?.saving || selectedModelValue === "") {
-                      return;
-                    }
-                    const draft = ensureChatModelPickerDraft(draftStore, {
-                      fastModeValue: initialFastModeValue,
-                      modelValue: initialModelValue,
-                      sessionKey,
-                      thinkingValue: initialThinkingValue,
-                    });
-                    draft.modelValue = "";
-                    onRequestUpdate?.();
-                  }}
-                >
-                  ${t("chat.modelPicker.useDefaultModel")}
-                </button>
-              `
-            : ""}
-          <button
-            class="btn btn--sm chat-controls__discard"
-            type="button"
-            ?disabled=${draftStore.get()?.saving}
-            @click=${(event: MouseEvent) => {
-              event.preventDefault();
-              event.stopPropagation();
-              draftStore.delete();
-              (event.currentTarget as HTMLElement).closest("details")?.removeAttribute("open");
-              onRequestUpdate?.();
-            }}
-          >
-            ${t("chat.modelPicker.discard")}
-          </button>
-          <button
-            class="btn btn--sm primary"
-            type="button"
-            ?disabled=${shouldDisableSave()}
-            @click=${async (event: MouseEvent) => {
-              event.preventDefault();
-              event.stopPropagation();
-              if (shouldDisableSave()) {
-                return;
-              }
-              const details = (event.currentTarget as HTMLElement).closest("details");
-              const draft = ensureChatModelPickerDraft(draftStore, {
-                fastModeValue: initialFastModeValue,
-                modelValue: initialModelValue,
-                sessionKey,
-                thinkingValue: initialThinkingValue,
-              });
-              if (draft.saving) {
-                return;
-              }
-              draft.saving = true;
-              details?.removeAttribute("open");
-              onRequestUpdate?.();
-              try {
-                if (draft.modelValue !== draft.initialModelValue) {
-                  const switched = await onModelSelect(draft.modelValue, sessionKey);
-                  if (switched === false) {
-                    return;
-                  }
-                }
-                if (draft.thinkingValue !== draft.initialThinkingValue) {
-                  const switched = await onThinkingSelect(draft.thinkingValue, sessionKey);
-                  if (switched === false) {
-                    return;
-                  }
-                }
-                if (draft.fastModeValue !== draft.initialFastModeValue) {
-                  const switched = await onFastModeSelect(draft.fastModeValue, sessionKey);
-                  if (switched === false) {
-                    return;
-                  }
-                }
-                draftStore.delete();
-              } finally {
-                const current = draftStore.get();
-                if (current === draft) {
-                  current.saving = false;
-                }
-                onRequestUpdate?.();
-              }
-            }}
-          >
-            ${t("common.save")}
-          </button>
-        </div>
       </div>
     </details>
   `;

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -279,7 +279,7 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
     sessionKey: props.sessionKey,
     sessionsResult: props.sessionsResult,
   });
-  const fastMode = resolveChatFastModeSelectState({
+  const fastModeSelect = resolveChatFastModeSelectState({
     activeRunId: props.activeRunId,
     catalog: props.modelCatalog,
     connected: props.connected,
@@ -291,6 +291,10 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
     sessionsResult: props.sessionsResult,
     stream: props.stream,
   });
+  // Reasoning/speed state derives from the session row, which still describes
+  // the previous model while a switch is pending; keep both locked until the
+  // refreshed session list lands so stale levels cannot be committed.
+  const fastMode = props.modelSwitching ? { ...fastModeSelect, disabled: true } : fastModeSelect;
   const activeSession = props.sessionsResult?.sessions.find((row) => row.key === props.sessionKey);
   const currentProviderHint = activeSession?.modelProvider ?? "";
   const defaultProviderHint = props.sessionsResult?.defaults?.modelProvider ?? "";
@@ -352,6 +356,7 @@ export function renderChatModelControls(props: ChatModelControlsProps) {
   const thinkingDisabled =
     !props.connected ||
     busy ||
+    props.modelSwitching ||
     !props.gatewayAvailable ||
     (thinking.options.length === 0 && thinking.currentOverride === "");
   return renderChatModelReasoningSelect({

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -582,13 +582,13 @@ function renderChatModelReasoningSelect(params: {
                 ${formatChatModelProviderLabel(entry.provider)}
               </span>
             </span>
-            <span
-              class="chat-controls__inline-select-check"
-              aria-hidden="true"
-              ?hidden=${!selected}
-            >
-              ${icons.check}
-            </span>
+            ${selected
+              ? html`
+                  <span class="chat-controls__inline-select-check" aria-hidden="true">
+                    ${icons.check}
+                  </span>
+                `
+              : ""}
           </button>
         </openclaw-tooltip>
       </div>

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -467,6 +467,8 @@ function renderChatModelReasoningSelect(params: {
   // Selections commit immediately; the picker stays open so model, reasoning,
   // and speed can be adjusted together. The extra onRequestUpdate re-renders
   // the optimistic state patched synchronously by the switch helpers.
+  // Sends gate only on pending model switches (chatModelSwitchPromises), same
+  // as the old Save flow; reasoning/speed patches are not send-blocking.
   const commitModel = (value: string) => {
     void onModelSelect(value, sessionKey).finally(() => onRequestUpdate?.());
     onRequestUpdate?.();

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -3224,6 +3224,14 @@ openclaw-chat-page {
   display: block;
 }
 
+/* Pinned "Default (...)" row stays above the per-provider groups so clearing
+   the session override is one click; selections apply immediately. */
+.chat-controls__combined-model--default {
+  margin-bottom: 6px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+}
+
 .chat-controls__combined-model-option {
   justify-content: flex-start;
   gap: 8px;
@@ -3483,23 +3491,6 @@ openclaw-chat-page {
 .chat-controls__reasoning-option:disabled {
   cursor: not-allowed;
   opacity: 0.55;
-}
-
-.chat-controls__picker-actions {
-  position: sticky;
-  bottom: 0;
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 8px;
-  flex: 0 0 auto;
-  padding: 7px 10px;
-  border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-  background: color-mix(in srgb, var(--bg-elevated) 96%, var(--card));
-}
-
-.chat-controls__use-default-model {
-  margin-right: auto;
 }
 
 .chat-controls__inline-select-check {


### PR DESCRIPTION
## What Problem This Solves

The webchat model picker staged every change behind a `Use default model` / `Discard` / `Save` footer row. A picker should not need a save/cancel confirmation: every selection it makes (model, reasoning, speed) is an independently reversible session override, so the footer only added an extra click, a stale-draft failure mode, and a draft-store mechanism to keep three controls in sync.

## Why This Change Was Made

Selections now commit immediately through the existing optimistic `sessions.patch` helpers (which already no-op on unchanged values and roll back on failure), so the entire picker draft store and its footer row are deleted. Clearing a session override moved from the footer button into a pinned `Default (<model>)` row at the top of the model list; it stays hidden when the default model is advertised as unavailable, preserving the previous `defaultSelectable` behavior. The picker stays open after a selection so model, reasoning, and speed can be adjusted together, and closes on outside click or Escape as before.

Immediate apply needed two pieces of hardening that the staged flow hid: reasoning/speed lock while a model switch is pending (the session row still describes the previous model until the refreshed list lands, so committing then would target stale levels), and the fastMode/thinking rollback paths are now token-guarded per session (mirroring the existing `pendingModelPatches` guard) so a slow earlier patch cannot clobber a newer selection. Also fixed in passing: check marks rendered on every picker row in Chromium because the `hidden` attribute lost to the check's `display: inline-flex` rule; checks are now rendered only on the selected row.

## User Impact

Model, reasoning, and speed changes in the chat picker take effect the moment you click them; there is no Save/Discard step anymore. Resetting a session to its default model is one click on the pinned Default row.

## Evidence

Before / after (mock-gateway harness, dark scheme):

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/model-picker-immediate-apply/before-picker-menu.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/model-picker-immediate-apply/after-picker-menu.png) |

(The stray check marks on every row in the before shot are the pre-existing Chromium `hidden`-attribute bug fixed here.)

- Testbox (Blacksmith): `pnpm test ui/src/pages/chat/chat-view.test.ts ui/src/pages/chat/chat-controls.test.ts ui/src/i18n/test/translate.test.ts ui/src/e2e/chat-flow.e2e.test.ts ui/src/e2e/chat-composer-redesign.e2e.test.ts` - all green (unit 150+, e2e 42), including new regression tests for immediate apply, the pending-switch lock, and the late-failing overlapping patch.
- Testbox: `pnpm check:changed` - exit 0 (lint, tsgo, import cycles, guards).
- Net diff: ~-500 non-test LOC; locale bundles regenerated via `pnpm ui:i18n:sync` (drops the now-unused `chat.modelPicker.discard` / `useDefaultModel` keys).
- Codex review (gpt-5.5, 3 rounds): accepted and fixed two findings (reasoning/speed lock during a pending model switch; token-guarded rollbacks for overlapping immediate patches). One remaining P2 (sends do not wait for in-flight reasoning/speed patches) is pre-existing on `main` - the old Save flow fired the same patches without send gating (`waitForPendingChatModelSwitch` only covers model switches) - and is tracked as a follow-up rather than expanded into this PR.
