### PR TITLE
fix(plugins): enforce own install record lookups

### DIFF
--- a/src/cli/plugins-uninstall-command.ts
+++ b/src/cli/plugins-uninstall-command.ts
@@ -105,7 +105,7 @@ export async function runPluginUninstallCommand(
     runtime.exit(1);
     return;
   }
-  const hasInstall = pluginId in (cfg.plugins?.installs ?? {});
+  const hasInstall = Object.hasOwn(cfg.plugins?.installs ?? {}, pluginId);
 
   const preview: string[] = [];
   if (plan.actions.entry) {

--- a/src/cli/plugins-update-selection.test.ts
+++ b/src/cli/plugins-update-selection.test.ts
@@ -1,7 +1,11 @@
 // Plugin update selection tests cover CLI plugin update target selection.
 import { describe, expect, it } from "vitest";
+import type { HookInstallRecord } from "../config/types.hooks.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
-import { resolvePluginUpdateSelection } from "./plugins-update-selection.js";
+import {
+  resolveHookPackUpdateSelection,
+  resolvePluginUpdateSelection,
+} from "./plugins-update-selection.js";
 
 function createNpmInstall(params: {
   spec: string;
@@ -12,6 +16,19 @@ function createNpmInstall(params: {
     source: "npm",
     spec: params.spec,
     installPath: params.installPath ?? "/tmp/plugin",
+    ...(params.resolvedName ? { resolvedName: params.resolvedName } : {}),
+  };
+}
+
+function createNpmHookInstall(params: {
+  spec: string;
+  installPath?: string;
+  resolvedName?: string;
+}): HookInstallRecord {
+  return {
+    source: "npm",
+    spec: params.spec,
+    installPath: params.installPath ?? "/tmp/hook-pack",
     ...(params.resolvedName ? { resolvedName: params.resolvedName } : {}),
   };
 }
@@ -111,6 +128,54 @@ describe("resolvePluginUpdateSelection", () => {
       specOverrides: {
         "lossless-claw": "@martian-engineering/lossless-claw",
       },
+    });
+  });
+
+  it("maps prototype-named npm packages by own install records", () => {
+    expect(
+      resolvePluginUpdateSelection({
+        installs: {
+          "tracked-constructor": createNpmInstall({
+            spec: "constructor",
+            resolvedName: "constructor",
+          }),
+        },
+        rawId: "constructor",
+      }),
+    ).toEqual({
+      pluginIds: ["tracked-constructor"],
+      specOverrides: {
+        "tracked-constructor": "constructor",
+      },
+    });
+  });
+});
+
+describe("resolveHookPackUpdateSelection", () => {
+  it("does not treat inherited prototype keys as installed hook ids", () => {
+    expect(
+      resolveHookPackUpdateSelection({
+        installs: {},
+        rawId: "constructor",
+      }),
+    ).toEqual({
+      hookIds: [],
+    });
+  });
+
+  it("keeps own prototype-named hook ids selectable", () => {
+    expect(
+      resolveHookPackUpdateSelection({
+        installs: {
+          constructor: createNpmHookInstall({
+            spec: "openclaw-hooks-constructor",
+            resolvedName: "openclaw-hooks-constructor",
+          }),
+        },
+        rawId: "constructor",
+      }),
+    ).toEqual({
+      hookIds: ["constructor"],
     });
   });
 });

--- a/src/cli/plugins-update-selection.ts
+++ b/src/cli/plugins-update-selection.ts
@@ -20,7 +20,7 @@ export function resolvePluginUpdateSelection(params: {
     return { pluginIds: [] };
   }
 
-  if (params.rawId in params.installs) {
+  if (Object.hasOwn(params.installs, params.rawId)) {
     return { pluginIds: [params.rawId] };
   }
 
@@ -67,7 +67,7 @@ export function resolveHookPackUpdateSelection(params: {
   if (!params.rawId) {
     return { hookIds: [] };
   }
-  if (params.rawId in params.installs) {
+  if (Object.hasOwn(params.installs, params.rawId)) {
     return { hookIds: [params.rawId] };
   }
 

--- a/src/plugins/uninstall.test.ts
+++ b/src/plugins/uninstall.test.ts
@@ -743,6 +743,36 @@ describe("uninstallPlugin", () => {
     }
   });
 
+  it("does not treat inherited prototype names as installed plugins", async () => {
+    const result = await uninstallPlugin({
+      config: createPluginConfig({ entries: {}, installs: {} }),
+      pluginId: "constructor",
+      deleteFiles: false,
+    });
+
+    expect(result).toEqual({ ok: false, error: "Plugin not found: constructor" });
+  });
+
+  it("uninstalls own prototype-named plugin records", async () => {
+    const result = await uninstallPlugin({
+      config: createPluginConfig({
+        entries: {
+          constructor: { enabled: true },
+        },
+        installs: {
+          constructor: createNpmInstallRecord("constructor"),
+        },
+      }),
+      pluginId: "constructor",
+      deleteFiles: false,
+    });
+
+    const successfulResult = expectSuccessfulUninstall(result);
+    expect(successfulResult.config.plugins).toBeUndefined();
+    expect(successfulResult.actions.entry).toBe(true);
+    expect(successfulResult.actions.install).toBe(true);
+  });
+
   it("cleans stale policy references even when plugin code and install records are gone", async () => {
     const result = await uninstallPlugin({
       config: createPluginConfig({

--- a/src/plugins/uninstall.ts
+++ b/src/plugins/uninstall.ts
@@ -392,7 +392,7 @@ export function removePluginFromConfig(
 
   // Remove from entries
   let entries = pluginsConfig.entries;
-  if (entries && pluginId in entries) {
+  if (entries && Object.hasOwn(entries, pluginId)) {
     const { [pluginId]: _, ...rest } = entries;
     entries = Object.keys(rest).length > 0 ? rest : undefined;
     actions.entry = true;
@@ -400,8 +400,9 @@ export function removePluginFromConfig(
 
   // Remove from installs
   let installs = pluginsConfig.installs;
-  const installRecord = installs?.[pluginId];
-  if (installs && pluginId in installs) {
+  const hasInstallRecord = Object.hasOwn(installs ?? {}, pluginId);
+  const installRecord = hasInstallRecord ? installs?.[pluginId] : undefined;
+  if (installs && hasInstallRecord) {
     const { [pluginId]: _, ...rest } = installs;
     installs = Object.keys(rest).length > 0 ? rest : undefined;
     actions.install = true;
@@ -498,7 +499,6 @@ export function removePluginFromConfig(
 
   // Remove channel config owned by this installed plugin.
   // Built-in channels have no install record, so keep their config untouched.
-  const hasInstallRecord = Object.hasOwn(cfg.plugins?.installs ?? {}, pluginId);
   let channels = cfg.channels as Record<string, unknown> | undefined;
   if (hasInstallRecord && channels) {
     for (const key of resolveUninstallChannelConfigKeys(pluginId, opts)) {
@@ -539,9 +539,11 @@ export type UninstallPluginParams = {
 export function planPluginUninstall(params: UninstallPluginParams): PluginUninstallPlanResult {
   const { config, pluginId, channelIds, deleteFiles = true, extensionsDir } = params;
 
-  const hasEntry = pluginId in (config.plugins?.entries ?? {});
-  const hasInstall = pluginId in (config.plugins?.installs ?? {});
-  const installRecord = config.plugins?.installs?.[pluginId];
+  const entries = config.plugins?.entries ?? {};
+  const installs = config.plugins?.installs ?? {};
+  const hasEntry = Object.hasOwn(entries, pluginId);
+  const hasInstall = Object.hasOwn(installs, pluginId);
+  const installRecord = hasInstall ? installs[pluginId] : undefined;
   const isLinked = isLinkedPathInstallRecord(installRecord);
 
   // Remove from config

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -5401,6 +5401,7 @@ describe("syncPluginsForUpdateChannel", () => {
     "migrates already-externalized records to prototype-named plugin id %s",
     async (targetPluginId) => {
       const legacyPluginId = `legacy-${targetPluginId}`;
+      const npmPackageName = `openclaw-plugin-${targetPluginId}`;
       resolveBundledPluginSourcesMock.mockReturnValue(new Map());
 
       const result = await syncPluginsForUpdateChannel({
@@ -5409,7 +5410,7 @@ describe("syncPluginsForUpdateChannel", () => {
           {
             bundledPluginId: legacyPluginId,
             pluginId: targetPluginId,
-            npmSpec: targetPluginId,
+            npmSpec: npmPackageName,
             channelIds: [],
           },
         ],
@@ -5421,7 +5422,7 @@ describe("syncPluginsForUpdateChannel", () => {
             installs: {
               [legacyPluginId]: {
                 source: "npm",
-                spec: targetPluginId,
+                spec: npmPackageName,
                 installPath: `/tmp/${targetPluginId}`,
               },
             },
@@ -5438,7 +5439,7 @@ describe("syncPluginsForUpdateChannel", () => {
       expect(Object.getPrototypeOf(result.config.plugins?.installs ?? {})).toBe(Object.prototype);
       expectRecordFields(result.config.plugins?.installs?.[targetPluginId], {
         source: "npm",
-        spec: targetPluginId,
+        spec: npmPackageName,
         installPath: `/tmp/${targetPluginId}`,
       });
       expect(result.config.plugins?.entries?.[legacyPluginId]).toBeUndefined();

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -555,6 +555,26 @@ describe("updateNpmInstalledPlugins", () => {
     }
   });
 
+  it("does not treat inherited prototype names as install records", async () => {
+    const config: OpenClawConfig = { plugins: { installs: {} } };
+
+    const result = await updateNpmInstalledPlugins({
+      config,
+      pluginIds: ["constructor"],
+    });
+
+    expect(installPluginFromNpmSpecMock).not.toHaveBeenCalled();
+    expect(result.changed).toBe(false);
+    expect(result.config).toBe(config);
+    expect(result.outcomes).toEqual([
+      {
+        pluginId: "constructor",
+        status: "skipped",
+        message: 'No install record for "constructor".',
+      },
+    ]);
+  });
+
   it.each([
     {
       name: "skips integrity drift checks for unpinned npm specs during dry-run updates",
@@ -5376,6 +5396,55 @@ describe("syncPluginsForUpdateChannel", () => {
       source: "path",
     });
   });
+
+  it.each(["constructor", "__proto__"])(
+    "migrates already-externalized records to prototype-named plugin id %s",
+    async (targetPluginId) => {
+      const legacyPluginId = `legacy-${targetPluginId}`;
+      resolveBundledPluginSourcesMock.mockReturnValue(new Map());
+
+      const result = await syncPluginsForUpdateChannel({
+        channel: "stable",
+        externalizedBundledPluginBridges: [
+          {
+            bundledPluginId: legacyPluginId,
+            pluginId: targetPluginId,
+            npmSpec: targetPluginId,
+            channelIds: [],
+          },
+        ],
+        config: {
+          plugins: {
+            entries: {
+              [legacyPluginId]: { enabled: true },
+            },
+            installs: {
+              [legacyPluginId]: {
+                source: "npm",
+                spec: targetPluginId,
+                installPath: `/tmp/${targetPluginId}`,
+              },
+            },
+          },
+        },
+      });
+
+      expect(installPluginFromNpmSpecMock).not.toHaveBeenCalled();
+      expect(result.changed).toBe(true);
+      expect(Object.hasOwn(result.config.plugins?.entries ?? {}, targetPluginId)).toBe(true);
+      expect(Object.getPrototypeOf(result.config.plugins?.entries ?? {})).toBe(Object.prototype);
+      expect(result.config.plugins?.entries?.[targetPluginId]).toEqual({ enabled: true });
+      expect(Object.hasOwn(result.config.plugins?.installs ?? {}, targetPluginId)).toBe(true);
+      expect(Object.getPrototypeOf(result.config.plugins?.installs ?? {})).toBe(Object.prototype);
+      expectRecordFields(result.config.plugins?.installs?.[targetPluginId], {
+        source: "npm",
+        spec: targetPluginId,
+        installPath: `/tmp/${targetPluginId}`,
+      });
+      expect(result.config.plugins?.entries?.[legacyPluginId]).toBeUndefined();
+      expect(result.config.plugins?.installs?.[legacyPluginId]).toBeUndefined();
+    },
+  );
 
   it("removes stale bundled load paths for already-externalized npm installs", async () => {
     resolveBundledPluginSourcesMock.mockReturnValue(new Map());

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -733,6 +733,9 @@ function resolveBridgeInstallRecord(params: {
   bridge: ExternalizedBundledPluginBridge;
 }): { pluginId: string; record: PluginInstallRecord } | undefined {
   for (const pluginId of getExternalizedBundledPluginLookupIds(params.bridge)) {
+    if (!Object.hasOwn(params.installs, pluginId)) {
+      continue;
+    }
     const record = params.installs[pluginId];
     if (record) {
       return { pluginId, record };
@@ -1169,10 +1172,16 @@ function migratePluginConfigId(cfg: OpenClawConfig, fromId: string, toId: string
 
   const installs = plugins.installs;
   if (installs && Object.hasOwn(installs, fromId)) {
+    const record = installs[fromId];
     const nextInstalls = { ...installs };
-    const record = nextInstalls[fromId];
-    if (record && !(toId in nextInstalls)) {
-      nextInstalls[toId] = record;
+    if (record && !Object.hasOwn(installs, toId)) {
+      // Plugin ids are record keys; define data properties so "__proto__" cannot invoke its setter.
+      Object.defineProperty(nextInstalls, toId, {
+        configurable: true,
+        enumerable: true,
+        value: record,
+        writable: true,
+      });
     }
     delete nextInstalls[fromId];
     ensureNextPlugins().installs = nextInstalls;
@@ -1180,15 +1189,21 @@ function migratePluginConfigId(cfg: OpenClawConfig, fromId: string, toId: string
 
   const entries = plugins.entries;
   if (entries && Object.hasOwn(entries, fromId)) {
+    const entry = entries[fromId];
+    const existingEntry = Object.hasOwn(entries, toId) ? entries[toId] : undefined;
     const nextEntries = { ...entries };
-    const entry = nextEntries[fromId];
     if (entry) {
-      nextEntries[toId] = nextEntries[toId]
-        ? {
-            ...entry,
-            ...nextEntries[toId],
-          }
-        : entry;
+      Object.defineProperty(nextEntries, toId, {
+        configurable: true,
+        enumerable: true,
+        value: existingEntry
+          ? {
+              ...entry,
+              ...existingEntry,
+            }
+          : entry,
+        writable: true,
+      });
     }
     delete nextEntries[fromId];
     ensureNextPlugins().entries = nextEntries;
@@ -1447,7 +1462,7 @@ export async function updateNpmInstalledPlugins(params: {
       continue;
     }
 
-    const record = installs[pluginId];
+    const record = Object.hasOwn(installs, pluginId) ? installs[pluginId] : undefined;
     if (!record) {
       outcomes.push({
         pluginId,


### PR DESCRIPTION
## What Problem This Solves

Plugin and hook identifiers such as `constructor` can collide with inherited `Object.prototype` properties. Update and uninstall paths used prototype-aware membership checks or unguarded indexed reads, so an inherited key could be mistaken for an installed record while a real own record could be skipped or migrated incorrectly.

This is a clean maintainer replacement for #102201 after GitHub's signed fork refresh expanded stale ancestry into hundreds of unrelated files.

## Why This Change Was Made

Use own-property checks consistently across plugin/hook update selection, npm update record resolution, externalized-plugin migration, uninstall planning, config removal, and the uninstall preview. For destination migrations, define explicit enumerable/writable/configurable own data properties so the exact `__proto__` key cannot invoke the inherited setter or mutate map prototypes.

This preserves the current plain-object config shape and keeps every membership/write decision tied to serialized own data. It does not broaden durable installed-index policy for blocked prototype keys. The replacement is one current-main commit with `Alix-007` preserved as co-author.

## User Impact

Updates and uninstalls no longer act on inherited prototype names. Own prototype-named records remain selectable, migratable, and removable without mutating object prototypes or losing source records.

## Evidence

- Fresh branch autoreview found and drove the `__proto__` destination-write repair; final review is clean, patch correct, confidence 0.94 before the patch-identical final rebase.
- Exact predecessor-tree isolated AWS proof: `run_a87463fa4504`, 202/202 tests passed; final replacement SHA will be re-proved before merge.
- Regressions cover inherited and own plugin/hook selection, update/uninstall, `constructor` and `__proto__` migrations, own descriptors, and unchanged `Object.prototype` map prototypes.
- Formatting and `git diff --check origin/main...HEAD` passed.
- Full exact-head hosted CI will be attached before merge.

Supersedes #102201 while preserving contributor credit.
