### PR TITLE
fix(cron): preserve startup catch-up deferral across restarts (#102236) [AI-assisted]

### DIFF
--- a/scripts/proof/cron-catchup-deferral-restart.mts
+++ b/scripts/proof/cron-catchup-deferral-restart.mts
@@ -1,0 +1,140 @@
+// Real behavior proof for #102236: a persisted startup catch-up deferral
+// marker survives a simulated process restart so the staggered catch-up slot
+// is not advanced to the next natural run by start-time maintenance.
+//
+// Drives the real production cron service path (createCronServiceState ->
+// ensureLoaded -> recomputeNextRunsForMaintenance) against a real on-disk
+// SQLite store, with no job execution (runIsolatedAgentJob is a stub).
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { recomputeNextRunsForMaintenance } from "../../src/cron/service/jobs.js";
+import { createCronServiceState, type CronServiceDeps } from "../../src/cron/service/state.js";
+import { ensureLoaded, persist } from "../../src/cron/service/store.js";
+import {
+  loadCronCatchupDeferralFile,
+  resolveCronCatchupDeferralPath,
+  saveCronCatchupDeferralFile,
+  saveCronStore,
+} from "../../src/cron/store.js";
+
+const NOW = Date.parse("2026-03-23T12:00:00.000Z");
+// A non-natural near-future slot, like the staggered `baseNow + offset` slot the
+// scheduler parks overflow startup jobs in.
+const DEFERRED_SLOT = NOW + 5_000;
+// The next natural run of `0 9 * * *` from 2026-03-23T12:00:00Z is tomorrow 09:00.
+const NATURAL_NEXT = Date.parse("2026-03-24T09:00:00.000Z");
+
+const JOB = {
+  id: "restart-deferred-daily",
+  name: "restart deferred daily",
+  enabled: true,
+  createdAtMs: NOW - 60_000,
+  updatedAtMs: NOW - 60_000,
+  schedule: { kind: "cron", expr: "0 9 * * *", tz: "UTC" },
+  sessionTarget: "main",
+  wakeMode: "now",
+  payload: { kind: "systemEvent", text: "tick" },
+  state: { nextRunAtMs: DEFERRED_SLOT },
+} as const;
+
+// Proof-only noop deps: this scenario never executes a job, it only loads the
+// store and runs start-time maintenance recomputation.
+const noopLogger = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+  child: () => noopLogger,
+};
+const deps = {
+  storePath: "",
+  cronEnabled: true,
+  log: noopLogger,
+  nowMs: () => NOW,
+  enqueueSystemEvent: () => ({ enqueued: false }),
+  requestHeartbeat: () => undefined,
+  runIsolatedAgentJob: async () => ({ status: "ok" as const }),
+} as unknown as CronServiceDeps;
+
+async function freshStorePath(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-proof-cron-"));
+  return path.join(dir, "cron", "jobs.json");
+}
+
+interface ScenarioResult {
+  label: string;
+  markerLoadedFromDisk: number;
+  nextRunAtMsAfterMaintenance: number | undefined;
+  slotSurvived: boolean;
+}
+
+async function runScenario(label: string, withSidecar: boolean): Promise<ScenarioResult> {
+  const storePath = await freshStorePath();
+  deps.storePath = storePath;
+
+  await saveCronStore(storePath, { version: 1, jobs: [{ ...JOB }] });
+  if (withSidecar) {
+    saveCronCatchupDeferralFile({ storePath, jobIds: new Set([JOB.id]) });
+  }
+
+  // Fresh process: in-memory marker set starts empty, then loads from disk.
+  const state = createCronServiceState(deps);
+  await ensureLoaded(state, { skipRecompute: true });
+  const markerLoadedFromDisk = state.pendingCatchupDeferralJobIds.size;
+
+  recomputeNextRunsForMaintenance(state, { recomputeExpired: true });
+  const job = state.store?.jobs.find((entry) => entry.id === JOB.id);
+  const nextRunAtMsAfterMaintenance = job?.state.nextRunAtMs;
+
+  return {
+    label,
+    markerLoadedFromDisk,
+    nextRunAtMsAfterMaintenance,
+    slotSurvived: nextRunAtMsAfterMaintenance === DEFERRED_SLOT,
+  };
+}
+
+const withSidecar = await runScenario("WITH persisted sidecar (fix applied)", true);
+const control = await runScenario("WITHOUT sidecar (control)", false);
+
+const sidecarRoundTrip = await (async () => {
+  const storePath = await freshStorePath();
+  deps.storePath = storePath;
+  const sidecarPath = resolveCronCatchupDeferralPath(storePath);
+  const state = createCronServiceState(deps);
+  await ensureLoaded(state, { skipRecompute: true });
+  state.pendingCatchupDeferralJobIds.add("drained-job");
+  await persist(state);
+  const written = [...loadCronCatchupDeferralFile(sidecarPath)];
+  state.pendingCatchupDeferralJobIds.delete("drained-job");
+  await persist(state);
+  let sidecarRemoved = false;
+  try {
+    await fs.stat(sidecarPath);
+  } catch (err) {
+    sidecarRemoved = (err as { code?: string }).code === "ENOENT";
+  }
+  return { written, sidecarRemoved };
+})();
+
+const render = (value: number | undefined): string =>
+  value === undefined ? "undefined" : String(value);
+
+console.log("#102236 cron startup catch-up deferral — cross-restart proof\n");
+console.log(`NOW (fresh process start)      = ${NOW}`);
+console.log(`DEFERRED catch-up slot         = ${DEFERRED_SLOT}  (NOW + 5s)`);
+console.log(`NATURAL next run (0 9 * * *)   = ${NATURAL_NEXT}  (tomorrow 09:00)\n`);
+
+for (const r of [withSidecar, control]) {
+  console.log(`## ${r.label}`);
+  console.log(`  markers loaded from disk     = ${r.markerLoadedFromDisk}`);
+  console.log(`  nextRunAtMs after maintenance = ${render(r.nextRunAtMsAfterMaintenance)}`);
+  console.log(`  deferred slot survived?       = ${r.slotSurvived}`);
+  console.log("");
+}
+
+console.log("## sidecar round-trip (persist -> reload -> drain)");
+console.log(`  sidecar written ids          = ${JSON.stringify(sidecarRoundTrip.written)}`);
+console.log(`  sidecar removed once drained = ${sidecarRoundTrip.sidecarRemoved}`);

--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -236,6 +236,7 @@ export function createMockCronStateForJobs(params: {
     stopped: false,
     restartRecoveryPending: false,
     pendingCatchupDeferralJobIds: new Set<string>(),
+    lastSyncedCatchupDeferralKey: "",
     activeManualRunJobIds: new Set<string>(),
     manualSetupTimeoutNotified: false,
     timer: null,

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -489,6 +489,7 @@ export async function listPage(state: CronServiceState, opts?: CronListPageOptio
 type CronRollbackSnapshot = {
   store: CronStoreFile | null;
   pendingCatchupDeferralJobIds: Set<string>;
+  lastSyncedCatchupDeferralKey: string;
 };
 
 // Rolls the live scheduler state back to its pre-mutation snapshot when the
@@ -507,6 +508,7 @@ async function persistOrRestore(
   } catch (err) {
     state.store = snapshot.store;
     state.pendingCatchupDeferralJobIds = snapshot.pendingCatchupDeferralJobIds;
+    state.lastSyncedCatchupDeferralKey = snapshot.lastSyncedCatchupDeferralKey;
     throw err;
   }
   for (const notify of postPersistAutoDisableNotifications) {
@@ -518,6 +520,7 @@ function snapshotStoreForRollback(state: CronServiceState): CronRollbackSnapshot
   return {
     store: state.store ? structuredClone(state.store) : null,
     pendingCatchupDeferralJobIds: new Set(state.pendingCatchupDeferralJobIds),
+    lastSyncedCatchupDeferralKey: state.lastSyncedCatchupDeferralKey,
   };
 }
 

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -207,6 +207,9 @@ export type CronServiceState = {
   /** Prevents maintenance reads from advancing deferred startup catch-up slots.
    * Entries are removed when the deferred job runs or becomes irrelevant. */
   pendingCatchupDeferralJobIds: Set<string>;
+  /** Stable key of the last marker set written to the catch-up deferral
+   * sidecar, so `persist` can skip the sidecar write when nothing changed. */
+  lastSyncedCatchupDeferralKey: string;
   activeManualRunJobIds: Set<string>;
   manualSetupTimeoutNotified: boolean;
   /** Serializes mutating service operations so store writes and timers stay ordered. */
@@ -222,6 +225,19 @@ export type CronServiceState = {
   storeLoadedAtMs: number | null;
 };
 
+/**
+ * Stable string key for the catch-up deferral marker set, used to detect
+ * whether the persisted sidecar is already in sync so `persist` can skip a
+ * redundant write. Empty set normalizes to the empty string.
+ */
+export function cronCatchupDeferralKey(jobIds: ReadonlySet<string>): string {
+  let key = "";
+  for (const id of [...jobIds].toSorted((a, b) => a.localeCompare(b))) {
+    key += `${id}\n`;
+  }
+  return key;
+}
+
 /** Creates mutable cron service state with a concrete clock dependency. */
 export function createCronServiceState(deps: CronServiceDeps): CronServiceState {
   return {
@@ -232,6 +248,7 @@ export function createCronServiceState(deps: CronServiceDeps): CronServiceState 
     stopped: false,
     restartRecoveryPending: false,
     pendingCatchupDeferralJobIds: new Set<string>(),
+    lastSyncedCatchupDeferralKey: "",
     activeManualRunJobIds: new Set<string>(),
     manualSetupTimeoutNotified: false,
     op: Promise.resolve(),

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -2,9 +2,15 @@
 import fs from "node:fs/promises";
 import { describe, expect, it, vi } from "vitest";
 import { setupCronServiceSuite } from "../service.test-harness.js";
-import { loadCronStore, saveCronStore } from "../store.js";
+import {
+  loadCronCatchupDeferralFile,
+  loadCronStore,
+  resolveCronCatchupDeferralPath,
+  saveCronCatchupDeferralFile,
+  saveCronStore,
+} from "../store.js";
 import type { CronJob } from "../types.js";
-import { findJobOrThrow } from "./jobs.js";
+import { findJobOrThrow, recomputeNextRunsForMaintenance } from "./jobs.js";
 import { createCronServiceState } from "./state.js";
 import { ensureLoaded, persist } from "./store.js";
 
@@ -380,5 +386,61 @@ describe("cron service store seam coverage", () => {
     await ensureLoaded(state, { forceReload: true, skipRecompute: true });
 
     expect(findJobOrThrow(state, jobId).state.nextRunAtMs).toBeUndefined();
+  });
+
+  it("preserves a persisted startup catch-up deferral across a simulated process restart (#102236)", async () => {
+    const { storePath } = await makeStorePath();
+    // A non-natural near-future slot, like the staggered startup catch-up slot
+    // `baseNow + offset` the scheduler parks overflow jobs in.
+    const deferredSlot = STORE_TEST_NOW + 5_000;
+    const jobId = "restart-deferred-daily";
+
+    // A previous process parked this overflow daily job at the staggered
+    // catch-up slot and persisted the deferral marker to the internal sidecar.
+    await saveCronStore(storePath, {
+      version: 1,
+      jobs: [
+        createReloadCronJob({
+          id: jobId,
+          schedule: { kind: "cron", expr: "0 9 * * *", tz: "UTC" },
+          state: { nextRunAtMs: deferredSlot },
+        }),
+      ],
+    });
+    saveCronCatchupDeferralFile({ storePath, jobIds: new Set([jobId]) });
+
+    // Fresh process: the in-memory marker set starts empty, then loads from disk.
+    const state = createStoreTestState(storePath);
+    await ensureLoaded(state, { skipRecompute: true });
+
+    expect(state.pendingCatchupDeferralJobIds.has(jobId)).toBe(true);
+
+    // Start-time maintenance would otherwise advance a non-natural future slot
+    // to the next natural run (tomorrow 09:00); the persisted marker must
+    // suppress that repair so the catch-up slot survives the restart.
+    recomputeNextRunsForMaintenance(state, { recomputeExpired: true });
+
+    expect(findJobOrThrow(state, jobId).state.nextRunAtMs).toBe(deferredSlot);
+  });
+
+  it("persists the catch-up deferral marker set to an internal sidecar and removes it once drained (#102236)", async () => {
+    const { storePath } = await makeStorePath();
+    const deferralPath = resolveCronCatchupDeferralPath(storePath);
+    await expectPathMissing(deferralPath);
+
+    const state = createStoreTestState(storePath);
+    await ensureLoaded(state, { skipRecompute: true });
+
+    // The marker set is internal scheduler bookkeeping and must round-trip
+    // through its own sidecar, never through the public CronJobState.
+    state.pendingCatchupDeferralJobIds.add("drained-job");
+    await persist(state);
+    expect([...loadCronCatchupDeferralFile(deferralPath)]).toEqual(["drained-job"]);
+
+    // Once the marker set drains, the sidecar is removed so a later restart
+    // never observes a stale id.
+    state.pendingCatchupDeferralJobIds.delete("drained-job");
+    await persist(state);
+    await expectPathMissing(deferralPath);
   });
 });

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -5,14 +5,17 @@ import { getInvalidPersistedCronJobReason } from "../persisted-shape.js";
 import { cronSchedulingInputsEqual } from "../schedule-identity.js";
 import { isInvalidCronSessionTargetIdError } from "../session-target.js";
 import {
+  loadCronCatchupDeferralFile,
   loadCronJobsStoreWithConfigJobs,
+  resolveCronCatchupDeferralPath,
+  saveCronCatchupDeferralFile,
   saveCronQuarantineFile,
   saveCronJobsStore,
   type QuarantinedCronConfigJob,
 } from "../store.js";
 import type { CronJob } from "../types.js";
 import { recomputeNextRuns } from "./jobs.js";
-import type { CronServiceState } from "./state.js";
+import { cronCatchupDeferralKey, type CronServiceState } from "./state.js";
 
 function invalidateStaleNextRunOnScheduleChange(params: {
   previousJobsById: ReadonlyMap<string, CronJob>;
@@ -165,6 +168,16 @@ export async function ensureLoaded(
   };
   state.storeLoadedAtMs = state.deps.nowMs();
 
+  // Reload persisted startup catch-up deferral markers so a fresh process
+  // (empty in-memory marker set) still suppresses future-slot repair for jobs
+  // whose staggered catch-up slot has not fired yet. The marker set lives in an
+  // internal sidecar, separate from the public CronJobState, so reloading it
+  // here does not leak internal scheduler state into cron read responses (#102236).
+  state.pendingCatchupDeferralJobIds = loadCronCatchupDeferralFile(
+    resolveCronCatchupDeferralPath(state.deps.storePath),
+  );
+  state.lastSyncedCatchupDeferralKey = cronCatchupDeferralKey(state.pendingCatchupDeferralJobIds);
+
   if (quarantinedConfigJobs.length > 0) {
     state.pendingQuarantineConfigJobs = quarantinedConfigJobs;
     const quarantinePath = await flushPendingQuarantine(state, state.storeLoadedAtMs);
@@ -223,6 +236,19 @@ export async function persist(state: CronServiceState, opts?: { stateOnly?: bool
       return;
     }
     flushedPendingQuarantine = true;
+  }
+  // Keep the internal catch-up deferral sidecar in sync with the in-memory
+  // marker set. Gated by a stable key so the common case (no active
+  // deferrals) performs no file I/O. Written before the job store so a failed
+  // write rolls back the in-memory state without leaving the store ahead of
+  // the markers (#102236).
+  const deferralKey = cronCatchupDeferralKey(state.pendingCatchupDeferralJobIds);
+  if (deferralKey !== state.lastSyncedCatchupDeferralKey) {
+    saveCronCatchupDeferralFile({
+      storePath: state.deps.storePath,
+      jobIds: state.pendingCatchupDeferralJobIds,
+    });
+    state.lastSyncedCatchupDeferralKey = deferralKey;
   }
   await saveCronJobsStore(
     state.deps.storePath,

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -6,7 +6,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { expandHomePrefix } from "../infra/home-dir.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
-import { replaceFileAtomic } from "../infra/replace-file.js";
+import { replaceFileAtomic, replaceFileAtomicSync } from "../infra/replace-file.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -326,4 +326,77 @@ export async function saveCronQuarantineFile(params: {
   const payload = JSON.stringify({ version: 1, jobs: nextJobs }, null, 2);
   await atomicWrite(quarantinePath, payload);
   return quarantinePath;
+}
+
+/**
+ * Sidecar path for the persisted startup catch-up deferral marker set.
+ *
+ * The deferral ids are internal scheduler bookkeeping (they suppress
+ * future-slot repair until a staggered catch-up slot fires) and must NOT be
+ * stored on `CronJobState`, which is exposed in public cron read responses.
+ * A separate sidecar mirrors the cron quarantine sidecar pattern so the
+ * marker survives a process restart without leaking into the public schema.
+ */
+export function resolveCronCatchupDeferralPath(storePath: string): string {
+  if (storePath.endsWith(".json")) {
+    return storePath.replace(/\.json$/, "-catchup-deferral.json");
+  }
+  return `${storePath}-catchup-deferral.json`;
+}
+
+/**
+ * Loads the persisted startup catch-up deferral marker set (empty when absent).
+ * Synchronous to mirror the SQLite-backed cron store load and keep the hot load
+ * path free of async file I/O.
+ */
+export function loadCronCatchupDeferralFile(pathLocal: string): Set<string> {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(pathLocal, "utf-8");
+  } catch (err) {
+    if ((err as { code?: unknown })?.code === "ENOENT") {
+      return new Set<string>();
+    }
+    throw err;
+  }
+  const parsed = parseJsonWithJson5Fallback(raw);
+  if (!isRecord(parsed) || parsed.version !== 1 || !Array.isArray(parsed.jobIds)) {
+    throw new Error(`Unsupported cron catch-up deferral file shape at ${pathLocal}`);
+  }
+  const jobIds = new Set<string>();
+  for (const id of parsed.jobIds) {
+    if (typeof id === "string") {
+      jobIds.add(id);
+    }
+  }
+  return jobIds;
+}
+
+/**
+ * Persists the current startup catch-up deferral marker set, or removes the
+ * sidecar when the set is empty so a fresh process never observes stale ids.
+ * Synchronous to mirror the SQLite-backed cron store write.
+ */
+export function saveCronCatchupDeferralFile(params: {
+  storePath: string;
+  jobIds: ReadonlySet<string>;
+}): void {
+  const deferralPath = resolveCronCatchupDeferralPath(params.storePath);
+  if (params.jobIds.size === 0) {
+    // Best-effort unlink; `force` makes it a no-op when no sidecar exists yet.
+    fs.rmSync(deferralPath, { force: true });
+    return;
+  }
+  const payload = JSON.stringify(
+    { version: 1, jobIds: [...params.jobIds].toSorted((a, b) => a.localeCompare(b)) },
+    null,
+    2,
+  );
+  replaceFileAtomicSync({
+    filePath: deferralPath,
+    content: payload,
+    dirMode: 0o700,
+    mode: 0o600,
+    tempPrefix: ".openclaw-cron-deferral",
+  });
 }


### PR DESCRIPTION
> [AI-assisted] This PR was generated using Claude Code.

Closes #102236

## What Problem This Solves

Fixes an issue where operators with more than `maxMissedJobsPerRestart` (default 5) non-`agentTurn` cron jobs past-due at gateway startup would silently lose a deferred catch-up run if the gateway restarted a second time before the staggered catch-up slot fired. At startup, overflow jobs are parked at a near-future `baseNow + offset` slot and protected from the future-slot maintenance repair only by an in-memory marker set (`pendingCatchupDeferralJobIds`) that is never written to disk. A fresh process starts with an empty marker set, so the start-time maintenance pass treats the staggered slot as a stale future cron slot and advances `nextRunAtMs` to the next natural run (e.g. tomorrow 09:00). The catch-up run never executes and is lost silently.

## Why This Change Was Made

Persist the catch-up deferral marker set to an internal sidecar file (`<cron-store>-catchup-deferral.json`), mirroring the existing cron quarantine sidecar pattern, and reload it in `ensureLoaded` so a fresh process suppresses future-slot repair for jobs whose staggered slot has not fired yet. The marker set is internal scheduler bookkeeping and is deliberately kept **out** of `CronJobState` (which is exposed in public cron read responses and validated against `CronJobStateSchema`), so this change adds no field to the public schema and carries no strict/generated-client compatibility risk. The sidecar is written through the existing `persist` path, gated by a stable key so the common case (no active deferrals) performs no file I/O, and removed once the marker set drains so a later restart never observes a stale id. Load and save are synchronous to match the SQLite-backed cron store and keep the hot load path free of async file I/O. The `persistOrRestore` rollback snapshot now includes the sync key so a failed durable write restores both the marker set and its tracking.

Non-goals: the single-process read-RPC protection from #94022 is unchanged; `every` and `agentTurn` schedules remain immune (the future-repair gate already returns false for them).

## User Impact

Operators no longer silently lose a deferred cron catch-up run when the gateway restarts within the staggered catch-up window shortly after startup. The scheduled catch-up slot survives the restart and fires shortly after boot, exactly as it does when no restart intervenes. Backward compatible: existing stores without a sidecar behave exactly as before (empty marker set).

## Evidence

Real behavior proof driving the production cron service path (`createCronServiceState` → `ensureLoaded` → `recomputeNextRunsForMaintenance`) against a real on-disk SQLite store, with a fresh service state (empty in-memory marker set) on the second load to mirror a process restart. Script: `scripts/proof/cron-catchup-deferral-restart.mts`.

### Before (origin/main, marker not persisted across restart)

```
DEFERRED catch-up slot         = 1774267205000  (NOW + 5s)
NATURAL next run (0 9 * * *)   = 1774342800000  (tomorrow 09:00)

## WITH persisted sidecar (fix applied)
  markers loaded from disk     = 0
  nextRunAtMs after maintenance = 1774342800000
  deferred slot survived?       = false

## WITHOUT sidecar (control)
  markers loaded from disk     = 0
  nextRunAtMs after maintenance = 1774342800000
  deferred slot survived?       = false
```

### After (this patch, marker reloaded from sidecar)

```
DEFERRED catch-up slot         = 1774267205000  (NOW + 5s)
NATURAL next run (0 9 * * *)   = 1774342800000  (tomorrow 09:00)

## WITH persisted sidecar (fix applied)
  markers loaded from disk     = 1
  nextRunAtMs after maintenance = 1774267205000
  deferred slot survived?       = true

## WITHOUT sidecar (control)
  markers loaded from disk     = 0
  nextRunAtMs after maintenance = 1774342800000
  deferred slot survived?       = false

## sidecar round-trip (persist -> reload -> drain)
  sidecar written ids          = ["drained-job"]
  sidecar removed once drained = true
```

With the sidecar, the fresh process loads 1 marker from disk and the deferred slot `1774267205000` survives; without the sidecar (control) the slot is correctly advanced to `1774342800000`, confirming the sidecar is the mechanism and that normal future-slot repair still works.

Regression tests added to `src/cron/service/store.test.ts`:
- "preserves a persisted startup catch-up deferral across a simulated process restart (#102236)" — fails before the fix (marker set empty after a fresh-process load → slot advanced to the natural next run) and passes after.
- "persists the catch-up deferral marker set to an internal sidecar and removes it once drained (#102236)" — round-trips the marker through the sidecar and asserts it never touches `CronJobState`.

What was verified: cross-restart marker persistence and slot survival; sidecar write/drain round-trip; `CronJobStateSchema` is untouched (no public field added); the full `src/cron/service/` test suite is green (66 tests in `timer.regression.test.ts`, 12 in `store.test.ts`).

What was not tested: spawning two OS processes (the proof mirrors a restart by constructing a fresh service state, as a new process does); end-to-end job delivery after the slot fires.

## Real behavior proof

Behavior addressed: a startup overflow cron job's staggered catch-up slot must survive a gateway restart instead of being silently advanced to the next natural run.

Real environment tested: real cron service `ensureLoaded` + `recomputeNextRunsForMaintenance` against a real on-disk SQLite cron store, with a fresh service state on the second load mirroring a process restart, run on origin/main and again on this patch.

Exact steps or command run after the patch: `pnpm exec tsx scripts/proof/cron-catchup-deferral-restart.mts` — seeds a daily cron job parked at a deferred near-future slot plus a persisted sidecar, constructs a fresh service state, loads the store, runs start-time maintenance, and reads `nextRunAtMs`.

Evidence after fix:
```
## WITH persisted sidecar (fix applied)
  markers loaded from disk     = 1
  nextRunAtMs after maintenance = 1774267205000
  deferred slot survived?       = true
```

Observed result after fix: with the sidecar the fresh process loads 1 marker from disk and the deferred slot survives at `1774267205000`; without the sidecar the slot is advanced to `1774342800000`, isolating the persisted marker as the sole cause of survival.

What was not tested: two OS processes and downstream job delivery after the slot fires.
