### PR TITLE
fix(active-memory): recall context breaks when recent turns contain emoji

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -3201,6 +3201,47 @@ describe("active-memory plugin", () => {
     expect(readFileSpy).not.toHaveBeenCalled();
   });
 
+  it("keeps partial assistant transcript caps UTF-16 safe", async () => {
+    const sessionFile = path.join(stateDir, "surrogate-timeout-transcript.jsonl");
+    await writeTranscriptJsonl(sessionFile, [
+      {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: `${"a".repeat(38)}🎉TAILWORD`,
+        },
+      },
+    ]);
+
+    const result = await testing.readPartialAssistantText(sessionFile, {
+      maxChars: 39,
+      maxLines: 10,
+    });
+
+    expect(result).toBe("a".repeat(38));
+  });
+
+  it("keeps joined partial assistant transcript caps UTF-16 safe", async () => {
+    const sessionFile = path.join(stateDir, "joined-surrogate-timeout-transcript.jsonl");
+    await writeTranscriptJsonl(sessionFile, [
+      {
+        type: "message",
+        message: { role: "assistant", content: "a".repeat(37) },
+      },
+      {
+        type: "message",
+        message: { role: "assistant", content: "🎉TAILWORD" },
+      },
+    ]);
+
+    const result = await testing.readPartialAssistantText(sessionFile, {
+      maxChars: 39,
+      maxLines: 10,
+    });
+
+    expect(result).toBe("a".repeat(37));
+  });
+
   it("skips malformed JSONL lines when reading partial assistant transcripts", async () => {
     const sessionFile = path.join(stateDir, "malformed-timeout-transcript.jsonl");
     await fs.mkdir(path.dirname(sessionFile), { recursive: true });

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -71,27 +71,6 @@ describe("active-memory plugin", () => {
     expect(query).not.toContain("\uD83D");
   });
 
-  it("keeps recent recall query turn snippets UTF-16 well-formed", () => {
-    const query = testing.buildQuery({
-      latestUserMessage: "what now?",
-      recentTurns: [
-        { role: "user", text: `${"u".repeat(39)}🚀 user tail` },
-        { role: "assistant", text: `${"a".repeat(39)}🚀 assistant tail` },
-      ],
-      config: testing.normalizePluginConfig({
-        queryMode: "recent",
-        recentUserTurns: 1,
-        recentAssistantTurns: 1,
-        recentUserChars: 40,
-        recentAssistantChars: 40,
-      }),
-    });
-
-    expect(query).toContain(`user: ${"u".repeat(39)}`);
-    expect(query).toContain(`assistant: ${"a".repeat(39)}`);
-    expect(query).not.toContain("\uD83D");
-  });
-
   const hooks: Record<string, Function> = {};
   const hookOptions: Record<string, Record<string, unknown> | undefined> = {};
   const registeredCommands: Record<string, any> = {};
@@ -5116,6 +5095,48 @@ describe("active-memory plugin", () => {
     expect(prompt).toContain("Bounded memory search query:\nwhat should i grab on the way?");
     expect(prompt).toContain("Conversation context:\nwhat should i grab on the way?");
     expect(prompt).not.toContain("Recent conversation tail:");
+  });
+
+  it("keeps recent conversation context UTF-16 well-formed", async () => {
+    api.pluginConfig = {
+      agents: ["main"],
+      queryMode: "recent",
+      recentUserTurns: 1,
+      recentAssistantTurns: 1,
+      recentUserChars: 40,
+      recentAssistantChars: 40,
+    };
+    plugin.register(api as unknown as OpenClawPluginApi);
+
+    await hooks.before_prompt_build(
+      {
+        prompt: "what now?",
+        messages: [
+          { role: "user", content: `${"u".repeat(39)}🚀 user tail` },
+          { role: "assistant", content: `${"a".repeat(39)}🚀 assistant tail` },
+        ],
+      },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:main",
+        messageProvider: "webchat",
+      },
+    );
+
+    const prompt = lastEmbeddedPrompt();
+    expect(prompt).toContain(
+      [
+        "Conversation context:",
+        "Recent conversation tail:",
+        `user: ${"u".repeat(39)}`,
+        `assistant: ${"a".repeat(39)}`,
+        "",
+        "Latest user message:",
+        "what now?",
+      ].join("\n"),
+    );
+    expect(prompt).not.toContain("\uD83D");
   });
 
   it("keeps a whole code point when the bounded search query crosses an emoji", async () => {

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -71,6 +71,27 @@ describe("active-memory plugin", () => {
     expect(query).not.toContain("\uD83D");
   });
 
+  it("keeps recent recall query turn snippets UTF-16 well-formed", () => {
+    const query = testing.buildQuery({
+      latestUserMessage: "what now?",
+      recentTurns: [
+        { role: "user", text: `${"u".repeat(39)}🚀 user tail` },
+        { role: "assistant", text: `${"a".repeat(39)}🚀 assistant tail` },
+      ],
+      config: testing.normalizePluginConfig({
+        queryMode: "recent",
+        recentUserTurns: 1,
+        recentAssistantTurns: 1,
+        recentUserChars: 40,
+        recentAssistantChars: 40,
+      }),
+    });
+
+    expect(query).toContain(`user: ${"u".repeat(39)}`);
+    expect(query).toContain(`assistant: ${"a".repeat(39)}`);
+    expect(query).not.toContain("\uD83D");
+  });
+
   const hooks: Record<string, Function> = {};
   const hookOptions: Record<string, Record<string, unknown> | undefined> = {};
   const registeredCommands: Record<string, any> = {};

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -15,6 +15,10 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+// Match only lone surrogates so valid supplementary-plane characters remain allowed.
+const UNPAIRED_SURROGATE_RE =
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+
 async function expectPathMissing(targetPath: string): Promise<void> {
   try {
     await fs.access(targetPath);
@@ -68,7 +72,7 @@ describe("active-memory plugin", () => {
     });
 
     expect(query).toBe(`${"x".repeat(119)} why?`);
-    expect(query).not.toContain("\uD83D");
+    expect(query).not.toMatch(UNPAIRED_SURROGATE_RE);
   });
 
   const hooks: Record<string, Function> = {};
@@ -5136,7 +5140,7 @@ describe("active-memory plugin", () => {
         "what now?",
       ].join("\n"),
     );
-    expect(prompt).not.toContain("\uD83D");
+    expect(prompt).not.toMatch(UNPAIRED_SURROGATE_RE);
   });
 
   it("keeps a whole code point when the bounded search query crosses an emoji", async () => {

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -2640,7 +2640,10 @@ function buildQuery(params: {
       remainingUser -= 1;
       selected.push({
         role: "user",
-        text: turn.text.trim().replace(/\s+/g, " ").slice(0, params.config.recentUserChars),
+        text: truncateUtf16Safe(
+          turn.text.trim().replace(/\s+/g, " "),
+          params.config.recentUserChars,
+        ),
       });
       continue;
     }
@@ -2650,7 +2653,10 @@ function buildQuery(params: {
     remainingAssistant -= 1;
     selected.push({
       role: "assistant",
-      text: turn.text.trim().replace(/\s+/g, " ").slice(0, params.config.recentAssistantChars),
+      text: truncateUtf16Safe(
+        turn.text.trim().replace(/\s+/g, " "),
+        params.config.recentAssistantChars,
+      ),
     });
   }
   const recentTurns = selected.toReversed().filter((turn) => turn.text.length > 0);
@@ -3754,6 +3760,7 @@ export default definePluginEntry({
 });
 
 const testing = {
+  buildQuery,
   buildSearchQuery,
   buildCacheKey,
   buildCircuitBreakerKey,

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -2251,20 +2251,20 @@ async function readPartialAssistantText(
         if (remaining <= 0) {
           return true;
         }
-        const nextText = text.slice(0, remaining);
+        const nextText = truncateUtf16Safe(text, remaining);
+        if (!nextText) {
+          return true;
+        }
         texts.push(nextText);
         collectedChars += separatorChars + nextText.length;
-        return collectedChars >= resolvedLimits.maxChars;
+        // A surrogate backoff leaves spare code units; stop instead of skipping ahead.
+        return nextText.length < text.length || collectedChars >= resolvedLimits.maxChars;
       }
       return false;
     },
   });
-  const joined = texts
-    .map((text) => text.trim())
-    .filter(Boolean)
-    .join("\n")
-    .slice(0, resolvedLimits.maxChars)
-    .trim();
+  // Accepted chunks and separators are charged before append, so the join is already bounded.
+  const joined = texts.join("\n").trim();
   return joined || null;
 }
 

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -3760,7 +3760,6 @@ export default definePluginEntry({
 });
 
 const testing = {
-  buildQuery,
   buildSearchQuery,
   buildCacheKey,
   buildCircuitBreakerKey,


### PR DESCRIPTION
## What Problem This Solves

Fixes two active-memory paths that could pass malformed text onward when a configured UTF-16 code-unit cap landed inside an emoji or another surrogate-pair character:

- recent user or assistant turns embedded in the model-visible recall context; and
- timeout-recovered partial assistant transcripts.

The timeout path folds the distinct useful work from same-author PR #102920 into this active same-plugin fix after that PR was closed only by the contributor queue limit.

## Why This Change Was Made

Active-memory already bounds both surfaces, but their raw string slices could retain one half of a surrogate pair. The fix reuses the existing `truncateUtf16Safe` contract at each bounded append.

For timeout transcripts, each already-trimmed record and separator is accounted before append. Collection stops at the first truncation or surrogate backoff so later records cannot skip ahead, and the redundant final map/filter/slice path is deleted. The configured limits and recall query shape remain unchanged.

## User Impact

Users can include emoji and other non-BMP characters in recent conversation turns and timeout-recovered partial replies without active-memory corrupting those characters before memory search or partial-result recovery.

## Evidence

Final exact head: `c0d70155b31638f8c4a3a7a359204b904b3e92af` (GitHub-verified signed maintainer follow-up; original author credited).

- Current-main inspection confirmed raw UTF-16 slicing in both recent recall snippets and partial transcript collection. Caller/callee review traced the resulting text through `before_prompt_build`, timeout recovery, and the embedded-agent prompt.
- Focused RED control: [Crabbox `run_c9984877a13a`](https://crabbox.openclaw.ai/portal/runs/run_c9984877a13a). Reversing only the production-file PR diff made all three exact regressions fail with lone-surrogate output.
- Exact-head GREEN proof: [Crabbox `run_2d2505291a1a`](https://crabbox.openclaw.ai/portal/runs/run_2d2505291a1a).
  - `/usr/local/bin/pnpm test extensions/active-memory/index.test.ts -- -t "keeps recent conversation context UTF-16 well-formed|keeps partial assistant transcript caps UTF-16 safe|keeps joined partial assistant transcript caps UTF-16 safe"`: 3/3 passed.
  - `/usr/local/bin/pnpm test extensions/active-memory/index.test.ts`: 161/161 passed.
- Both isolated AWS runs used public networking, no Tailscale, no instance profile, pinned Node 24/pnpm, and exact-SHA verification. The lease was stopped afterward.
- Static proof: `node_modules/.bin/oxfmt --check extensions/active-memory/index.test.ts extensions/active-memory/index.ts` and `git diff --check` passed.
- Fresh autoreview reported no actionable findings (0.98 confidence); an independent same-plugin review also found the fold to be the best fix.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/29028114301): 58 passed, 0 failed, 0 pending.

No known proof gaps.
