### PR TITLE
fix(google): bound SSE stream body reads at 16 MiB

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -1016,7 +1016,9 @@ describe("google transport stream", () => {
       for (const socket of sockets) {
         socket.destroy();
       }
-      await new Promise<void>((resolve) => server.close(resolve));
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
     }
   });
 
@@ -1070,7 +1072,9 @@ describe("google transport stream", () => {
       for (const socket of sockets) {
         socket.destroy();
       }
-      await new Promise<void>((resolve) => server.close(resolve));
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
     }
   });
 

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -948,6 +948,29 @@ describe("google transport stream", () => {
     expect(cancelCalled).toBe(true);
   });
 
+  it("rejects oversized Google SSE bodies", async () => {
+    const bigPayload = "x".repeat(16 * 1024 * 1024 + 1);
+    guardedFetchMock.mockResolvedValueOnce(buildRawSseResponse(`data: ${bigPayload}\n\n`));
+
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGeminiModel(),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as unknown as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "gemini-api-key",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toContain("exceeds 16777216 bytes");
+  });
+
   it("retries Gemini 3 requests with lean thinking when the first attempt has no first response", async () => {
     vi.stubEnv("OPENCLAW_GOOGLE_GEMINI_FIRST_RESPONSE_RETRY_MS", "10");
     guardedFetchMock

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -1,5 +1,7 @@
-// Google tests cover transport stream plugin behavior.
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+// Google tests cover transport stream plugin behavior.
+import { createServer, type Server } from "node:http";
+import type { AddressInfo, Socket } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { gzipSync } from "node:zlib";
@@ -969,6 +971,107 @@ describe("google transport stream", () => {
 
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toContain("exceeds 16777216 bytes");
+  });
+
+  it("rejects oversized Google SSE bodies from a real TCP loopback server", async () => {
+    const sockets = new Set<Socket>();
+    const server: Server = createServer((_req, res) => {
+      const sse = `data: ${"x".repeat(16 * 1024 * 1024 + 1)}\n\n`;
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      res.end(new TextEncoder().encode(sse));
+    });
+    server.on("connection", (socket) => {
+      sockets.add(socket);
+      socket.on("close", () => sockets.delete(socket));
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const port = (server.address() as AddressInfo).port;
+
+    guardedFetchMock.mockImplementation(
+      async (_url: string, init?: RequestInit) =>
+        await globalThis.fetch(`http://127.0.0.1:${port}`, init),
+    );
+
+    try {
+      const streamFn = createGoogleGenerativeAiTransportStreamFn();
+      const stream = await Promise.resolve(
+        streamFn(
+          buildGeminiModel(),
+          {
+            messages: [{ role: "user", content: "hello", timestamp: 0 }],
+          } as unknown as Parameters<typeof streamFn>[1],
+          {
+            apiKey: "gemini-api-key",
+          } as Parameters<typeof streamFn>[2],
+        ),
+      );
+      const result = await stream.result();
+
+      expect(result.stopReason).toBe("error");
+      expect(result.errorMessage).toContain("exceeds 16777216 bytes");
+    } finally {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      await new Promise<void>((resolve) => server.close(resolve));
+    }
+  });
+
+  it("rejects oversized Google Vertex SSE bodies from a real TCP loopback server", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-loopback-"));
+    vi.stubEnv("HOME", path.join(tempDir, "home"));
+    vi.stubEnv("APPDATA", "");
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", "loopback-project");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "global");
+    googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.loopback-token");
+
+    const sockets = new Set<Socket>();
+    const server: Server = createServer((_req, res) => {
+      const sse = `data: ${"x".repeat(16 * 1024 * 1024 + 1)}\n\n`;
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      res.end(new TextEncoder().encode(sse));
+    });
+    server.on("connection", (socket) => {
+      sockets.add(socket);
+      socket.on("close", () => sockets.delete(socket));
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const port = (server.address() as AddressInfo).port;
+
+    guardedFetchMock.mockImplementation(
+      async (_url: string, init?: RequestInit) =>
+        await globalThis.fetch(`http://127.0.0.1:${port}`, init),
+    );
+
+    try {
+      const streamFn = createGoogleVertexTransportStreamFn();
+      const stream = await Promise.resolve(
+        streamFn(
+          buildGoogleVertexModel(),
+          {
+            messages: [{ role: "user", content: "hello", timestamp: 0 }],
+          } as unknown as Parameters<typeof streamFn>[1],
+          {
+            apiKey: "gcp-vertex-credentials",
+          } as Parameters<typeof streamFn>[2],
+        ),
+      );
+      const result = await stream.result();
+
+      expect(result.stopReason).toBe("error");
+      expect(result.errorMessage).toContain("exceeds 16777216 bytes");
+    } finally {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      await new Promise<void>((resolve) => server.close(resolve));
+    }
   });
 
   it("retries Gemini 3 requests with lean thinking when the first attempt has no first response", async () => {

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -93,6 +93,7 @@ type GoogleGenerateContentRequest = {
 
 const GOOGLE_GEMINI3_FIRST_RESPONSE_RETRY_DEFAULT_MS = 45_000;
 const GOOGLE_GEMINI3_FIRST_RESPONSE_RETRY_ENV = "OPENCLAW_GOOGLE_GEMINI_FIRST_RESPONSE_RETRY_MS";
+const GOOGLE_SSE_STREAM_MAX_BYTES = 16 * 1024 * 1024;
 
 type GoogleTransportContentBlock =
   | { type: "text"; text: string; textSignature?: string }
@@ -1175,6 +1176,7 @@ async function* parseGoogleSseChunks(
   const decoder = new TextDecoder();
   let buffer = "";
   let completed = false;
+  let totalBytes = 0;
   const abortHandler = () => {
     void reader.cancel().catch(() => undefined);
   };
@@ -1188,6 +1190,13 @@ async function* parseGoogleSseChunks(
       if (done) {
         completed = true;
         break;
+      }
+      const chunkLen = value.byteLength;
+      totalBytes += chunkLen;
+      if (totalBytes > GOOGLE_SSE_STREAM_MAX_BYTES) {
+        throw new Error(
+          `Google SSE stream exceeds ${GOOGLE_SSE_STREAM_MAX_BYTES} bytes (received ${totalBytes})`,
+        );
       }
       buffer += decoder.decode(value, { stream: true }).replace(/\r/g, "");
       let boundary = buffer.indexOf("\n\n");


### PR DESCRIPTION
## What Problem This Solves

The `parseGoogleSseChunks` function in Google's transport stream reads SSE response bodies without a byte cap. A hanging or malicious Google/Vertex AI endpoint that streams data without `\n\n` boundaries (or that never sends `[DONE]`) could cause unbounded buffer growth and OOM.

## Why This Change Was Made

The OpenClaw codebase already applies 16 MiB byte caps to SSE/NDJSON streams in Ollama (#99585), Mistral, and OpenAI Chat/Responses providers. Google was the last major bundled provider whose raw SSE parser had no such limit. This change applies the same pattern with a matching fail-closed threshold.

## User Impact

A Google Gemini or Vertex AI endpoint that returns an oversized SSE body (or an unbounded event stream) no longer causes unbounded memory growth. The stream errors cleanly with a descriptive message once the 16 MiB limit is exceeded.

## Evidence

- `pnpm test extensions/google/transport-stream.test.ts` — 86 tests passed (3 new: mock oversized body, real TCP loopback for Gemini, real TCP loopback for Vertex)
- `pnpm exec oxfmt --check --threads=1 extensions/google/transport-stream.ts extensions/google/transport-stream.test.ts` — passed
- `./node_modules/.bin/oxlint --config .oxlintrc.json --tsconfig config/tsconfig/oxlint.extensions.json extensions/google/transport-stream.ts extensions/google/transport-stream.test.ts` — exit 0
- `git diff --check origin/main..HEAD` — clean
- Open PR collision check: searched open PRs touching `extensions/google/transport-stream.ts` — none found

## Real behavior proof

Behavior addressed: Google and Vertex AI SSE success-body streams are capped at 16 MiB.

Real environment tested: local Linux Node source checkout; real `node:http` loopback servers.

Exact command run after this patch:
```
pnpm test extensions/google/transport-stream.test.ts
  ✓ 86 tests passed
```

Three layers of proof:

1. **Mock oversized body** — feeds a 16 MiB + 1 byte single-chunk SSE event through a mocked `buildGuardedModelFetch` response; verifies `stopReason: "error"` with the overflow message.

2. **Real Gemini TCP loopback** — starts a real `node:http` server on `127.0.0.1:0` that responds with a 16 MiB + 1 byte SSE body; the transport stream fetches through `globalThis.fetch` from this real server; verifies the byte guard triggers on real network bytes.

3. **Real Vertex TCP loopback** — same real server setup through the Vertex transport stream with `gcp-vertex-credentials` auth marker; verifies the guard also fires on the Vertex routing path.

All three tests assert `stopReason: "error"` and an error message containing `"exceeds 16777216 bytes"`.

Co-Authored-By: Claude <noreply@anthropic.com>
