### PR TITLE
fix(gateway): reject disallowed browser Origin before accepting auth.mode=none on HTTP (#102834)

### DIFF
--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -370,6 +370,27 @@ describe("gateway auth", () => {
     expect(res.method).toBe("none");
   });
 
+  it("does not apply the none-mode Origin policy to authenticated HTTP clients", async () => {
+    const res = await authorizeHttpGatewayConnect({
+      auth: { mode: "token", token: "secret", allowTailscale: false },
+      connectAuth: { token: "secret" },
+      req: {
+        socket: { remoteAddress: "10.0.0.1" },
+        headers: {
+          host: "gateway.example.com",
+          origin: "https://app.example",
+        },
+      } as never,
+      browserOriginPolicy: {
+        requestHost: "gateway.example.com",
+        origin: "https://app.example",
+        allowedOrigins: ["https://control.example.com"],
+      },
+    });
+    expect(res.ok).toBe(true);
+    expect(res.method).toBe("token");
+  });
+
   it("keeps none mode authoritative even when token is present", async () => {
     const auth = resolveGatewayAuth({
       authConfig: { mode: "none", token: "configured-token" },

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -288,6 +288,88 @@ describe("gateway auth", () => {
     expect(res.method).toBe("none");
   });
 
+  it("rejects HTTP requests with disallowed Origin under auth mode none", async () => {
+    await expect(
+      authorizeHttpGatewayConnect({
+        auth: { mode: "none", allowTailscale: false },
+        connectAuth: null,
+        req: {
+          socket: { remoteAddress: "10.0.0.1" },
+          headers: {
+            host: "gateway.example.com",
+            origin: "https://evil.example",
+          },
+        } as never,
+        browserOriginPolicy: {
+          requestHost: "gateway.example.com",
+          origin: "https://evil.example",
+          allowedOrigins: ["https://control.example.com"],
+        },
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      reason: "origin_not_allowed",
+    });
+  });
+
+  it("accepts HTTP requests with allowed Origin under auth mode none", async () => {
+    const res = await authorizeHttpGatewayConnect({
+      auth: { mode: "none", allowTailscale: false },
+      connectAuth: null,
+      req: {
+        socket: { remoteAddress: "10.0.0.1" },
+        headers: {
+          host: "gateway.example.com",
+          origin: "https://control.example.com",
+        },
+      } as never,
+      browserOriginPolicy: {
+        requestHost: "gateway.example.com",
+        origin: "https://control.example.com",
+        allowedOrigins: ["https://control.example.com"],
+      },
+    });
+    expect(res.ok).toBe(true);
+    expect(res.method).toBe("none");
+  });
+
+  it("keeps origin-less HTTP requests working under auth mode none", async () => {
+    const res = await authorizeHttpGatewayConnect({
+      auth: { mode: "none", allowTailscale: false },
+      connectAuth: null,
+      req: {
+        socket: { remoteAddress: "127.0.0.1" },
+        headers: { host: "localhost" },
+      } as never,
+      browserOriginPolicy: {
+        requestHost: "localhost",
+        allowedOrigins: ["https://control.example.com"],
+      },
+    });
+    expect(res.ok).toBe(true);
+    expect(res.method).toBe("none");
+  });
+
+  it("accepts HTTP requests with local loopback Origin under localDirect auth mode none", async () => {
+    const res = await authorizeHttpGatewayConnect({
+      auth: { mode: "none", allowTailscale: false },
+      connectAuth: null,
+      req: {
+        socket: { remoteAddress: "127.0.0.1" },
+        headers: {
+          host: "127.0.0.1",
+          origin: "http://localhost:5173",
+        },
+      } as never,
+      browserOriginPolicy: {
+        requestHost: "127.0.0.1",
+        origin: "http://localhost:5173",
+      },
+    });
+    expect(res.ok).toBe(true);
+    expect(res.method).toBe("none");
+  });
+
   it("keeps none mode authoritative even when token is present", async () => {
     const auth = resolveGatewayAuth({
       authConfig: { mode: "none", token: "configured-token" },

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -81,7 +81,7 @@ export type AuthorizeGatewayConnectParams = {
   rateLimitScope?: string;
   /** Trust X-Real-IP only when explicitly enabled. */
   allowRealIpFallback?: boolean;
-  /** Optional browser-origin policy for trusted-proxy HTTP requests. */
+  /** Optional browser-origin policy for HTTP requests that require Origin checks. */
   browserOriginPolicy?: {
     requestHost?: string;
     origin?: string;
@@ -360,9 +360,11 @@ function shouldAllowTailscaleHeaderAuth(authSurface: GatewayAuthSurface): boolea
   return authSurface === "ws-control-ui";
 }
 
-function authorizeTrustedProxyBrowserOrigin(params: {
+function authorizeHttpBrowserOrigin(params: {
   authSurface: GatewayAuthSurface;
   browserOriginPolicy?: AuthorizeGatewayConnectParams["browserOriginPolicy"];
+  isLocalClient: boolean;
+  reason: string;
 }): { ok: false; reason: string } | null {
   if (params.authSurface !== "http") {
     return null;
@@ -378,12 +380,12 @@ function authorizeTrustedProxyBrowserOrigin(params: {
     origin,
     allowedOrigins: params.browserOriginPolicy?.allowedOrigins,
     allowHostHeaderOriginFallback: params.browserOriginPolicy?.allowHostHeaderOriginFallback,
-    isLocalClient: false,
+    isLocalClient: params.isLocalClient,
   });
   if (originCheck.ok) {
     return null;
   }
-  return { ok: false, reason: "trusted_proxy_origin_not_allowed" };
+  return { ok: false, reason: params.reason };
 }
 
 function authorizeTokenAuth(params: {
@@ -505,9 +507,11 @@ async function authorizeGatewayConnectCore(
     });
 
     if ("user" in result) {
-      const originResult = authorizeTrustedProxyBrowserOrigin({
+      const originResult = authorizeHttpBrowserOrigin({
         authSurface,
         browserOriginPolicy: params.browserOriginPolicy,
+        isLocalClient: false,
+        reason: "trusted_proxy_origin_not_allowed",
       });
       if (originResult) {
         return originResult;
@@ -530,25 +534,16 @@ async function authorizeGatewayConnectCore(
     return { ok: false, reason: result.reason };
   }
 
-  // Reject browser requests with a disallowed Origin under any auth mode before
-  // the none-mode success return, matching the WebSocket ingress invariant that
-  // checks any present Origin header independent of auth mode. Only applies to
-  // the HTTP surface (WS has its own origin check in message-handler.ts:881).
-  // Origin-less requests (headless proxy clients, curl, scripts) are unaffected.
-  if (authSurface === "http" && params.browserOriginPolicy?.origin) {
-    const originCheck = checkBrowserOrigin({
-      requestHost: params.browserOriginPolicy.requestHost,
-      origin: params.browserOriginPolicy.origin,
-      allowedOrigins: params.browserOriginPolicy.allowedOrigins,
-      allowHostHeaderOriginFallback: params.browserOriginPolicy.allowHostHeaderOriginFallback,
-      isLocalClient: localDirect,
-    });
-    if (!originCheck.ok) {
-      return { ok: false, reason: "origin_not_allowed" };
-    }
-  }
-
   if (auth.mode === "none") {
+    const originResult = authorizeHttpBrowserOrigin({
+      authSurface,
+      browserOriginPolicy: params.browserOriginPolicy,
+      isLocalClient: localDirect,
+      reason: "origin_not_allowed",
+    });
+    if (originResult) {
+      return originResult;
+    }
     return { ok: true, method: "none" };
   }
 

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -388,6 +388,17 @@ function authorizeHttpBrowserOrigin(params: {
   return { ok: false, reason: params.reason };
 }
 
+function authorizeTrustedProxyBrowserOrigin(params: {
+  authSurface: GatewayAuthSurface;
+  browserOriginPolicy?: AuthorizeGatewayConnectParams["browserOriginPolicy"];
+}): { ok: false; reason: string } | null {
+  return authorizeHttpBrowserOrigin({
+    ...params,
+    isLocalClient: false,
+    reason: "trusted_proxy_origin_not_allowed",
+  });
+}
+
 function authorizeTokenAuth(params: {
   authToken?: string;
   connectToken?: string;
@@ -507,11 +518,9 @@ async function authorizeGatewayConnectCore(
     });
 
     if ("user" in result) {
-      const originResult = authorizeHttpBrowserOrigin({
+      const originResult = authorizeTrustedProxyBrowserOrigin({
         authSurface,
         browserOriginPolicy: params.browserOriginPolicy,
-        isLocalClient: false,
-        reason: "trusted_proxy_origin_not_allowed",
       });
       if (originResult) {
         return originResult;

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -530,6 +530,24 @@ async function authorizeGatewayConnectCore(
     return { ok: false, reason: result.reason };
   }
 
+  // Reject browser requests with a disallowed Origin under any auth mode before
+  // the none-mode success return, matching the WebSocket ingress invariant that
+  // checks any present Origin header independent of auth mode. Only applies to
+  // the HTTP surface (WS has its own origin check in message-handler.ts:881).
+  // Origin-less requests (headless proxy clients, curl, scripts) are unaffected.
+  if (authSurface === "http" && params.browserOriginPolicy?.origin) {
+    const originCheck = checkBrowserOrigin({
+      requestHost: params.browserOriginPolicy.requestHost,
+      origin: params.browserOriginPolicy.origin,
+      allowedOrigins: params.browserOriginPolicy.allowedOrigins,
+      allowHostHeaderOriginFallback: params.browserOriginPolicy.allowHostHeaderOriginFallback,
+      isLocalClient: localDirect,
+    });
+    if (!originCheck.ok) {
+      return { ok: false, reason: "origin_not_allowed" };
+    }
+  }
+
   if (auth.mode === "none") {
     return { ok: true, method: "none" };
   }


### PR DESCRIPTION
Closes #102834

## What Problem This Solves

With explicit `gateway.auth.mode: "none"`, a hostile web page can submit a simple cross-origin HTTP request without credentials. The Gateway accepted that request before checking its browser `Origin`, allowing state-changing routes to reach operator business logic. The WebSocket ingress already rejects the same hostile Origin.

## Why This Change Was Made

The HTTP auth path now applies the existing browser-Origin policy immediately before accepting `auth.mode: "none"`. It reuses the trusted-proxy Origin helper rather than adding a second policy implementation.

The maintainer refactor deliberately does not apply the new gate to token/password clients: explicit credentials remain their trust boundary. Existing trusted-proxy Origin handling, WebSocket checks, origin-less clients, and local-loopback browser development remain unchanged.

## User Impact

- No-auth HTTP plus a disallowed browser Origin returns `origin_not_allowed`.
- Allowed Origins, origin-less scripts/proxies, and local-loopback development continue to work in no-auth mode.
- Valid token/password HTTP clients are not newly rejected because they send an Origin.
- No config, migration, or fallback surface is added.

## Evidence

- Focused regression coverage: hostile, allowed, origin-less, and local-loopback no-auth requests plus authenticated-token compatibility.
- Fresh full-stack autoreview: clean, 0.96 confidence.
- Exact-head fork CI: https://github.com/openclaw/openclaw/actions/runs/29185506827
- `git diff --check` and canonical formatting passed.

Live Gateway HTTP proof remains required before merge. Local test execution was intentionally skipped because this is an external contributor branch; exact-head fork CI or sanitized fresh-PR Crabbox is the execution boundary.

This PR is AI-assisted. The original fix was contributed by @wangyan2026 and then narrowed and rebased by the maintainer.
