### PR TITLE
fix(voice-call): fail-closed media-stream auth for non-Twilio providers

### DIFF
--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -156,7 +156,7 @@ Voice-call credentials accept SecretRefs. `plugins.entries.voice-call.config.twi
             defaultMode: "notify", // notify | conversation
           },
 
-          streaming: { enabled: true /* see Streaming transcription */ },
+          streaming: { enabled: true /* Twilio only; see Streaming transcription */ },
           realtime: { enabled: false /* see Realtime voice conversations */ },
         },
       },
@@ -399,7 +399,10 @@ options.
 
 ## Streaming transcription
 
-`streaming` selects a realtime transcription provider for live call audio.
+`streaming` connects Twilio Media Streams to a realtime transcription provider.
+The classic streaming path requires `provider: "twilio"`; configuration with
+Telnyx, Plivo, or mock is rejected. Telnyx live audio uses the separately
+authenticated `realtime.enabled` path instead.
 
 Current runtime behavior:
 

--- a/extensions/voice-call/index.ts
+++ b/extensions/voice-call/index.ts
@@ -81,7 +81,11 @@ const voiceCallConfigSchema = {
       label: "Allow ngrok Free Tier (Loopback Bypass)",
       advanced: true,
     },
-    "streaming.enabled": { label: "Enable Streaming", advanced: true },
+    "streaming.enabled": {
+      label: "Enable Streaming",
+      help: "Classic streaming transcription currently requires the Twilio call provider.",
+      advanced: true,
+    },
     "streaming.provider": {
       label: "Streaming Provider",
       help: "Uses the first registered realtime transcription provider when unset.",

--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -118,6 +118,7 @@
     },
     "streaming.enabled": {
       "label": "Enable Streaming",
+      "help": "Classic streaming transcription currently requires the Twilio call provider.",
       "advanced": true
     },
     "streaming.provider": {

--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -313,6 +313,34 @@ describe("validateProviderConfig", () => {
       );
     });
   });
+
+  describe("streaming config", () => {
+    it.each(["telnyx", "plivo", "mock"] as const)(
+      "rejects streaming.enabled with provider=%s",
+      (provider) => {
+        const config = createBaseConfig(provider);
+        config.streaming.enabled = true;
+
+        const result = validateProviderConfig(config);
+
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain(
+          'plugins.entries.voice-call.config.provider must be "twilio" when streaming.enabled is true',
+        );
+      },
+    );
+
+    it("accepts streaming.enabled with provider=twilio", () => {
+      const config = createBaseConfig("twilio");
+      config.streaming.enabled = true;
+      config.twilio = {
+        accountSid: "AC123",
+        authToken: { source: "env", provider: "default", id: "TWILIO_AUTH_TOKEN" },
+      };
+
+      expect(validateProviderConfig(config)).toEqual({ valid: true, errors: [] });
+    });
+  });
 });
 
 describe("resolveVoiceCallConfig session routing", () => {

--- a/extensions/voice-call/src/config.ts
+++ b/extensions/voice-call/src/config.ts
@@ -364,7 +364,7 @@ export type VoiceCallRealtimeConfig = z.infer<typeof VoiceCallRealtimeConfigSche
 
 const VoiceCallStreamingConfigSchema = z
   .object({
-    /** Enable real-time audio streaming (requires WebSocket support) */
+    /** Enable Twilio Media Streams for real-time transcription. */
     enabled: z.boolean().default(false),
     /** Provider id from registered realtime transcription providers. */
     provider: z.string().min(1).optional(),
@@ -921,6 +921,12 @@ export function validateProviderConfig(config: VoiceCallConfig): {
   if (config.realtime.enabled && config.streaming.enabled) {
     errors.push(
       "plugins.entries.voice-call.config.realtime.enabled and plugins.entries.voice-call.config.streaming.enabled cannot both be true",
+    );
+  }
+
+  if (config.streaming.enabled && config.provider && config.provider !== "twilio") {
+    errors.push(
+      'plugins.entries.voice-call.config.provider must be "twilio" when streaming.enabled is true',
     );
   }
 

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -353,6 +353,54 @@ describe("VoiceCallWebhookServer realtime transcription provider selection", () 
   });
 });
 
+describe("VoiceCallWebhookServer media stream authorization", () => {
+  it.each(["telnyx", "plivo", "mock"] as const)(
+    "rejects active provider=%s calls before consulting their call id",
+    async (providerName) => {
+      const call = createCall(Date.now());
+      const getCallByProviderCallId = vi.fn(() => call);
+      const manager = {
+        getActiveCalls: () => [call],
+        getCallByProviderCallId,
+        endCall: vi.fn(async () => ({ success: true })),
+        processEvent: vi.fn(),
+        speakInitialMessage: vi.fn(async () => {}),
+      } as unknown as CallManager;
+      const config = createConfig({
+        provider: providerName,
+        streaming: {
+          ...createConfig().streaming,
+          enabled: true,
+        },
+      });
+      const server = new VoiceCallWebhookServer(config, manager, {
+        ...provider,
+        name: providerName,
+      });
+
+      try {
+        await server.start();
+        const handler = server.getMediaStreamHandler() as unknown as {
+          config: {
+            shouldAcceptStream?: (input: { callId: string; streamSid: string }) => boolean;
+          };
+        };
+        const shouldAcceptStream = handler?.config.shouldAcceptStream;
+        if (!shouldAcceptStream) {
+          throw new Error("expected media stream acceptance validator");
+        }
+
+        expect(
+          shouldAcceptStream({ callId: call.providerCallId ?? "", streamSid: "stream-1" }),
+        ).toBe(false);
+        expect(getCallByProviderCallId).not.toHaveBeenCalled();
+      } finally {
+        await server.stop();
+      }
+    },
+  );
+});
+
 describe("VoiceCallWebhookServer media stream client IP resolution", () => {
   type MediaStreamRequestDouble = {
     headers: Record<string, string>;

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -358,16 +358,22 @@ export class VoiceCallWebhookServer {
       maxConnections: streaming.maxConnections,
       resolveClientIp: (request) => this.resolveMediaStreamClientIp(request),
       shouldAcceptStream: ({ callId, token }) => {
+        // The classic media handler parses Twilio frames and only Twilio issues
+        // its per-call token. Other carriers use their separate realtime path.
+        if (this.provider.name !== "twilio") {
+          this.logger.warn(
+            `Rejecting media stream: provider ${this.provider.name} does not support authenticated classic streaming`,
+          );
+          return false;
+        }
         const call = this.manager.getCallByProviderCallId(callId);
         if (!call) {
           return false;
         }
-        if (this.provider.name === "twilio") {
-          const twilio = this.provider as TwilioProvider;
-          if (!twilio.isValidStreamToken(callId, token)) {
-            this.logger.warn(`Rejecting media stream: invalid token for ${callId}`);
-            return false;
-          }
+        const twilio = this.provider as TwilioProvider;
+        if (!twilio.isValidStreamToken(callId, token)) {
+          this.logger.warn(`Rejecting media stream: invalid token for ${callId}`);
+          return false;
         }
         return true;
       },


### PR DESCRIPTION
Closes #102837

## What Problem This Solves

The classic `/voice/stream` handler accepted an active non-Twilio call ID without credentials. A caller who learned an active ID could inject audio into that call path.

## Why This Change Was Made

Classic streaming is a Twilio Media Streams implementation: it parses Twilio frames, Twilio alone creates the tokenized stream URL, and runtime wiring only connects the handler to `TwilioProvider`. A generic provider authentication hook would create a new compatibility-sensitive contract before a second provider uses this path.

This maintainer rewrite instead:

- rejects non-Twilio classic streaming during config validation;
- keeps a defense-in-depth provider check at the WebSocket authorization boundary before call-ID lookup;
- preserves Twilio's existing per-call token validation;
- documents that Telnyx live audio uses its separately authenticated realtime path; and
- adds provider-matrix regression coverage plus matching config metadata/help.

## User Impact

Twilio classic streaming continues to work with its existing per-call token. Unsupported Telnyx, Plivo, and mock classic-streaming configurations now fail setup clearly instead of exposing an unauthenticated media path. Telnyx `realtime.enabled` behavior is unchanged.

## Evidence

- Blacksmith Testbox `tbx_01kxdpsp2hehaakdq8d3wxzc6m`: 133 focused assertions passed across config, webhook authorization, and plugin configuration suites at final head `451d2a3a915`.
- Source-blind CLI setup proof: mock + `streaming.enabled` reports the Twilio-only provider error; Twilio + `streaming.enabled` reports setup OK.
- `git diff --check` and targeted `oxfmt` passed.
- Fresh structured autoreview found no actionable defects with 0.96 confidence; exact-head hosted CI is recorded in the maintainer proof comment before merge.

This keeps the contributor's security report and credit while replacing the proposed provider API with the narrower owner-boundary fix.
