### PR TITLE
fix: keep heredoc bodies out of shell stage splits

### DIFF
--- a/src/agents/tool-display-exec-shell.ts
+++ b/src/agents/tool-display-exec-shell.ts
@@ -246,6 +246,7 @@ type HeredocMarker = {
 function parseHeredocMarker(command: string, operatorIndex: number): HeredocMarker | undefined {
   if (
     command[operatorIndex] !== "<" ||
+    command[operatorIndex - 1] === "<" ||
     command[operatorIndex + 1] !== "<" ||
     command[operatorIndex + 2] === "<"
   ) {

--- a/src/agents/tool-display-exec-shell.ts
+++ b/src/agents/tool-display-exec-shell.ts
@@ -237,6 +237,90 @@ export function unwrapShellWrapper(command: string): string {
   return inner ? (stripOuterQuotes(inner) ?? command) : command;
 }
 
+type HeredocMarker = {
+  value: string;
+  stripLeadingTabs: boolean;
+};
+
+function parseHeredocMarker(command: string, operatorIndex: number): HeredocMarker | undefined {
+  if (
+    command[operatorIndex] !== "<" ||
+    command[operatorIndex + 1] !== "<" ||
+    command[operatorIndex + 2] === "<"
+  ) {
+    return undefined;
+  }
+
+  const stripLeadingTabs = command[operatorIndex + 2] === "-";
+  let index = operatorIndex + (stripLeadingTabs ? 3 : 2);
+  while (/[ \t]/u.test(command[index] ?? "")) {
+    index += 1;
+  }
+
+  let value = "";
+  let quote: '"' | "'" | undefined;
+  for (; index < command.length; index += 1) {
+    const char = command[index] ?? "";
+    if (quote) {
+      if (char === quote) {
+        quote = undefined;
+        continue;
+      }
+      if (quote === '"' && char === "\\" && index + 1 < command.length) {
+        index += 1;
+        value += command[index] ?? "";
+        continue;
+      }
+      value += char;
+      continue;
+    }
+
+    if (/[\r\n;&|<>]/u.test(char) || /[ \t]/u.test(char)) {
+      break;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (char === "\\" && index + 1 < command.length) {
+      index += 1;
+      value += command[index] ?? "";
+      continue;
+    }
+    value += char;
+  }
+
+  return value ? { value, stripLeadingTabs } : undefined;
+}
+
+function findHeredocBodyEnd(
+  command: string,
+  marker: HeredocMarker,
+  operatorIndex: number,
+): number | undefined {
+  const bodyStart = command.indexOf("\n", operatorIndex);
+  if (bodyStart === -1) {
+    return undefined;
+  }
+
+  let lineStart = bodyStart + 1;
+  while (lineStart <= command.length) {
+    const lineEnd = command.indexOf("\n", lineStart);
+    const end = lineEnd === -1 ? command.length : lineEnd;
+    const rawLine = command.slice(lineStart, end).replace(/\r$/u, "");
+    const candidate = marker.stripLeadingTabs ? rawLine.replace(/^\t+/u, "") : rawLine;
+    if (candidate === marker.value) {
+      return end;
+    }
+    if (lineEnd === -1) {
+      return undefined;
+    }
+    lineStart = lineEnd + 1;
+  }
+
+  return undefined;
+}
+
 export function scanTopLevelChars(
   command: string,
   visit: (char: string, index: number) => boolean | void,
@@ -266,6 +350,15 @@ export function scanTopLevelChars(
     if (char === '"' || char === "'") {
       quote = char;
       continue;
+    }
+
+    const heredoc = parseHeredocMarker(command, i);
+    if (heredoc) {
+      const bodyEnd = findHeredocBodyEnd(command, heredoc, i);
+      if (bodyEnd !== undefined) {
+        i = bodyEnd - 1;
+        continue;
+      }
     }
 
     if (visit(char, i) === false) {

--- a/src/agents/tool-display-exec-shell.ts
+++ b/src/agents/tool-display-exec-shell.ts
@@ -325,6 +325,9 @@ export function scanTopLevelChars(
 ): void {
   let quote: '"' | "'" | undefined;
   let escaped = false;
+  let atWordStart = true;
+  let arithmeticDepth = 0;
+  let plainSubshellDepth = 0;
   let pendingHeredocs: HeredocMarker[] = [];
 
   for (let i = 0; i < command.length; i += 1) {
@@ -332,6 +335,9 @@ export function scanTopLevelChars(
 
     if (escaped) {
       escaped = false;
+      if (char !== "\n") {
+        atWordStart = false;
+      }
       continue;
     }
     if (char === "\\") {
@@ -348,12 +354,31 @@ export function scanTopLevelChars(
 
     if (char === '"' || char === "'") {
       quote = char;
+      atWordStart = false;
       continue;
     }
 
-    const heredoc = parseHeredocMarker(command, i);
-    if (heredoc) {
-      pendingHeredocs.push(heredoc);
+    if (char === "#" && atWordStart && arithmeticDepth === 0) {
+      const newline = command.indexOf("\n", i + 1);
+      if (newline === -1) {
+        return;
+      }
+      i = newline - 1;
+      continue;
+    }
+
+    const startsArithmetic =
+      arithmeticDepth === 0 &&
+      char === "(" &&
+      command[i + 1] === "(" &&
+      (command[i - 1] === "$" || atWordStart);
+    const inArithmetic = arithmeticDepth > 0 || startsArithmetic;
+
+    if (!inArithmetic) {
+      const heredoc = parseHeredocMarker(command, i);
+      if (heredoc) {
+        pendingHeredocs.push(heredoc);
+      }
     }
 
     if (char === "\n" && pendingHeredocs.length > 0) {
@@ -378,8 +403,46 @@ export function scanTopLevelChars(
       }
     }
 
-    if (visit(char, i) === false) {
+    if (!inArithmetic && visit(char, i) === false) {
       return;
+    }
+
+    if (char === "(" && (arithmeticDepth > 0 || startsArithmetic)) {
+      arithmeticDepth += 1;
+      continue;
+    }
+    if (char === ")" && arithmeticDepth > 0) {
+      arithmeticDepth -= 1;
+      continue;
+    }
+    if (inArithmetic) {
+      continue;
+    }
+
+    if (/\s/u.test(char)) {
+      atWordStart = true;
+    } else if (char === "(") {
+      const previous = command[i - 1];
+      const isWordExpansion = previous === "$" || previous === "<" || previous === ">";
+      if (isWordExpansion) {
+        // The expansion is part of the surrounding word, but its body starts a fresh command.
+        atWordStart = true;
+      } else if (atWordStart) {
+        plainSubshellDepth += 1;
+        atWordStart = true;
+      }
+    } else if (char === ")") {
+      if (plainSubshellDepth > 0) {
+        plainSubshellDepth -= 1;
+        atWordStart = true;
+      } else {
+        // Command and process substitutions remain part of the word that opened them.
+        atWordStart = false;
+      }
+    } else if (/[;&|<>]/u.test(char)) {
+      atWordStart = true;
+    } else {
+      atWordStart = false;
     }
   }
 }

--- a/src/agents/tool-display-exec-shell.ts
+++ b/src/agents/tool-display-exec-shell.ts
@@ -296,14 +296,9 @@ function parseHeredocMarker(command: string, operatorIndex: number): HeredocMark
 function findHeredocBodyEnd(
   command: string,
   marker: HeredocMarker,
-  operatorIndex: number,
+  bodyStart: number,
 ): number | undefined {
-  const bodyStart = command.indexOf("\n", operatorIndex);
-  if (bodyStart === -1) {
-    return undefined;
-  }
-
-  let lineStart = bodyStart + 1;
+  let lineStart = bodyStart;
   while (lineStart <= command.length) {
     const lineEnd = command.indexOf("\n", lineStart);
     const end = lineEnd === -1 ? command.length : lineEnd;
@@ -327,6 +322,7 @@ export function scanTopLevelChars(
 ): void {
   let quote: '"' | "'" | undefined;
   let escaped = false;
+  let pendingHeredocs: HeredocMarker[] = [];
 
   for (let i = 0; i < command.length; i += 1) {
     const char = command[i];
@@ -354,7 +350,20 @@ export function scanTopLevelChars(
 
     const heredoc = parseHeredocMarker(command, i);
     if (heredoc) {
-      const bodyEnd = findHeredocBodyEnd(command, heredoc, i);
+      pendingHeredocs.push(heredoc);
+    }
+
+    if (char === "\n" && pendingHeredocs.length > 0) {
+      let bodyStart = i + 1;
+      let bodyEnd: number | undefined;
+      for (const marker of pendingHeredocs) {
+        bodyEnd = findHeredocBodyEnd(command, marker, bodyStart);
+        if (bodyEnd === undefined) {
+          break;
+        }
+        bodyStart = bodyEnd + 1;
+      }
+      pendingHeredocs = [];
       if (bodyEnd !== undefined) {
         i = bodyEnd - 1;
         continue;

--- a/src/agents/tool-display-exec-shell.ts
+++ b/src/agents/tool-display-exec-shell.ts
@@ -240,6 +240,7 @@ export function unwrapShellWrapper(command: string): string {
 type HeredocMarker = {
   value: string;
   stripLeadingTabs: boolean;
+  operatorIndex: number;
 };
 
 function parseHeredocMarker(command: string, operatorIndex: number): HeredocMarker | undefined {
@@ -290,7 +291,7 @@ function parseHeredocMarker(command: string, operatorIndex: number): HeredocMark
     value += char;
   }
 
-  return value ? { value, stripLeadingTabs } : undefined;
+  return value ? { value, stripLeadingTabs, operatorIndex } : undefined;
 }
 
 function findHeredocBodyEnd(
@@ -319,6 +320,7 @@ function findHeredocBodyEnd(
 export function scanTopLevelChars(
   command: string,
   visit: (char: string, index: number) => boolean | void,
+  visitHeredocBody?: (operatorIndex: number, start: number, end: number) => void,
 ): void {
   let quote: '"' | "'" | undefined;
   let escaped = false;
@@ -356,15 +358,20 @@ export function scanTopLevelChars(
     if (char === "\n" && pendingHeredocs.length > 0) {
       let bodyStart = i + 1;
       let bodyEnd: number | undefined;
+      const bodies: Array<{ marker: HeredocMarker; start: number; end: number }> = [];
       for (const marker of pendingHeredocs) {
         bodyEnd = findHeredocBodyEnd(command, marker, bodyStart);
         if (bodyEnd === undefined) {
           break;
         }
+        bodies.push({ marker, start: bodyStart, end: bodyEnd });
         bodyStart = bodyEnd + 1;
       }
       pendingHeredocs = [];
       if (bodyEnd !== undefined) {
+        for (const body of bodies) {
+          visitHeredocBody?.(body.marker.operatorIndex, body.start, body.end);
+        }
         i = bodyEnd - 1;
         continue;
       }
@@ -376,44 +383,61 @@ export function scanTopLevelChars(
   }
 }
 
+function splitTopLevel(
+  command: string,
+  separatorLength: (char: string, index: number) => number,
+): string[] {
+  const parts: string[] = [];
+  let segmentStart = 0;
+  let sliceStart = 0;
+  let chunks: string[] = [];
+
+  scanTopLevelChars(
+    command,
+    (char, index) => {
+      const length = separatorLength(char, index);
+      if (length === 0) {
+        return true;
+      }
+      parts.push(chunks.join("") + command.slice(sliceStart, index));
+      segmentStart = index + length;
+      sliceStart = segmentStart;
+      chunks = [];
+      return true;
+    },
+    (operatorIndex, bodyStart, bodyEnd) => {
+      if (operatorIndex < segmentStart) {
+        chunks.push(command.slice(sliceStart, bodyStart));
+        sliceStart = bodyEnd;
+      }
+    },
+  );
+
+  parts.push(chunks.join("") + command.slice(sliceStart));
+  return parts.map((part) => part.trim()).filter((part) => part.length > 0);
+}
+
 /** Splits a command on top-level stage separators such as `;`, `&&`, and `||`. */
 export function splitTopLevelStages(command: string): string[] {
-  const parts: string[] = [];
-  let start = 0;
-
-  scanTopLevelChars(command, (char, index) => {
+  return splitTopLevel(command, (char, index) => {
     if (char === ";") {
-      parts.push(command.slice(start, index));
-      start = index + 1;
-      return true;
+      return 1;
     }
     if ((char === "&" || char === "|") && command[index + 1] === char) {
-      parts.push(command.slice(start, index));
-      start = index + 2;
-      return true;
+      return 2;
     }
-    return true;
+    return 0;
   });
-
-  parts.push(command.slice(start));
-  return parts.map((part) => part.trim()).filter((part) => part.length > 0);
 }
 
 /** Splits a command on top-level single pipes without splitting `||`. */
 export function splitTopLevelPipes(command: string): string[] {
-  const parts: string[] = [];
-  let start = 0;
-
-  scanTopLevelChars(command, (char, index) => {
+  return splitTopLevel(command, (char, index) => {
     if (char === "|" && command[index - 1] !== "|" && command[index + 1] !== "|") {
-      parts.push(command.slice(start, index));
-      start = index + 1;
+      return 1;
     }
-    return true;
+    return 0;
   });
-
-  parts.push(command.slice(start));
-  return parts.map((part) => part.trim()).filter((part) => part.length > 0);
 }
 
 function parseChdirTarget(head: string): string | undefined {

--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -308,7 +308,12 @@ type HeredocTerminator = {
 function collectHeredocTerminators(commandLine: string): HeredocTerminator[] {
   const terminators: HeredocTerminator[] = [];
   scanTopLevelChars(commandLine, (char, index) => {
-    if (char !== "<" || commandLine[index + 1] !== "<" || commandLine[index + 2] === "<") {
+    if (
+      char !== "<" ||
+      commandLine[index - 1] === "<" ||
+      commandLine[index + 1] !== "<" ||
+      commandLine[index + 2] === "<"
+    ) {
       return true;
     }
 

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -9,6 +9,18 @@ import { resolveExecDetail } from "./tool-display-exec.js";
 import { formatToolDetail, formatToolSummary, resolveToolDisplay } from "./tool-display.js";
 
 describe("tool display details", () => {
+  it("keeps same-line heredoc operators from attaching the body to later stages", () => {
+    const command = "cat <<EOF && printf ok\nbody | secret\nEOF\nprintf done";
+    const stages = splitTopLevelStages(command);
+
+    expect(stages).toHaveLength(2);
+    expect(stages[0]).toBe("cat <<EOF");
+    expect(stages[1]).toContain("printf ok");
+    expect(stages[1]).toContain("printf done");
+    expect(stages[1]).not.toContain("body | secret");
+    expect(splitTopLevelPipes(stages[1] ?? "")).toHaveLength(1);
+  });
+
   it("summarizes tool-search code targets from described tool ids", () => {
     expect(
       resolveToolSearchCodeDisplayTarget({

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -4,7 +4,11 @@
  */
 import { describe, expect, it } from "vitest";
 import { resolveToolSearchCodeDisplayTarget } from "./tool-display-common.js";
-import { splitTopLevelPipes, splitTopLevelStages } from "./tool-display-exec-shell.js";
+import {
+  scanTopLevelChars,
+  splitTopLevelPipes,
+  splitTopLevelStages,
+} from "./tool-display-exec-shell.js";
 import { resolveExecDetail } from "./tool-display-exec.js";
 import { formatToolDetail, formatToolSummary, resolveToolDisplay } from "./tool-display.js";
 
@@ -587,6 +591,68 @@ describe("tool display details", () => {
       resolveToolDisplay({ name: "exec", args: { command }, detailMode: "explain" }),
     );
     expect(detail).toContain("run build");
+  });
+
+  it("ignores heredoc-looking tokens inside shell comments", () => {
+    const command = [
+      "export MODE=test # next block uses <<EOF && this is still a comment",
+      "cat <<EOF",
+      "body && data",
+      "EOF",
+      "npm test && npm build",
+    ].join("\n");
+
+    const detail = formatToolDetail(
+      resolveToolDisplay({ name: "exec", args: { command }, detailMode: "explain" }),
+    );
+    expect(detail).toBe("show <<EOF → run tests → run build");
+
+    expect(splitTopLevelStages("echo foo\\ #bar && npm test")).toEqual([
+      "echo foo\\ #bar",
+      "npm test",
+    ]);
+    expect(splitTopLevelStages("echo prefix$(printf suffix)#bar && npm test")).toEqual([
+      "echo prefix$(printf suffix)#bar",
+      "npm test",
+    ]);
+
+    const bodies: string[] = [];
+    const scanBodies = (input: string) => {
+      scanTopLevelChars(
+        input,
+        () => true,
+        (_operatorIndex, start, end) => bodies.push(input.slice(start, end)),
+      );
+    };
+    scanBodies(["(printf ok)# comment uses <<STOP", "npm test && npm build", "STOP"].join("\n"));
+    scanBodies(["echo $(# comment uses <<STOP", "printf ok", ") && npm test"].join("\n"));
+    expect(bodies).toEqual([]);
+
+    for (const expansion of [
+      "echo $(printf suffix)#tag",
+      "echo <(printf suffix)#tag",
+      "echo $(case x in x) printf ok;; esac)#tag",
+    ]) {
+      const withHeredoc = [expansion + " <<STOP", "body", "STOP"].join("\n");
+      scanBodies(withHeredoc);
+    }
+    expect(bodies).toEqual(["body\nSTOP", "body\nSTOP", "body\nSTOP"]);
+  });
+
+  it("does not treat arithmetic bitshifts as heredocs", () => {
+    for (const firstLine of ["echo $((flags << true ))", "((flags << true ))"]) {
+      const command = [firstLine, "npm test && npm build", "true", "pnpm test"].join("\n");
+
+      expect(splitTopLevelStages(command)).toEqual([
+        [firstLine, "npm test"].join("\n"),
+        ["npm build", "true", "pnpm test"].join("\n"),
+      ]);
+
+      const detail = formatToolDetail(
+        resolveToolDisplay({ name: "exec", args: { command }, detailMode: "explain" }),
+      );
+      expect(detail).toContain("run build");
+    }
   });
 
   it("keeps heredoc body pipes out of top-level stage summaries", () => {

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -559,6 +559,25 @@ describe("tool display details", () => {
     ]);
   });
 
+  it("matches escaped heredoc delimiters in top-level stage splitting", () => {
+    const command = [
+      "cat <<\\EOF",
+      "body; not a stage && not a stage || not a stage",
+      "EOF",
+      "printf done && npm test",
+    ].join("\n");
+
+    expect(splitTopLevelStages(command)).toEqual([
+      [
+        "cat <<\\EOF",
+        "body; not a stage && not a stage || not a stage",
+        "EOF",
+        "printf done",
+      ].join("\n"),
+      "npm test",
+    ]);
+  });
+
   it("keeps heredoc body pipes out of top-level stage summaries", () => {
     const detail = formatToolDetail(
       resolveToolDisplay({

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -575,6 +575,20 @@ describe("tool display details", () => {
     ]);
   });
 
+  it("does not treat the overlapping end of a here-string as a heredoc", () => {
+    const command = ["cat <<<true", "npm test && npm build", "true", "pnpm test"].join("\n");
+
+    expect(splitTopLevelStages(command)).toEqual([
+      ["cat <<<true", "npm test"].join("\n"),
+      ["npm build", "true", "pnpm test"].join("\n"),
+    ]);
+
+    const detail = formatToolDetail(
+      resolveToolDisplay({ name: "exec", args: { command }, detailMode: "explain" }),
+    );
+    expect(detail).toContain("run build");
+  });
+
   it("keeps heredoc body pipes out of top-level stage summaries", () => {
     const detail = formatToolDetail(
       resolveToolDisplay({

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, expect, it } from "vitest";
 import { resolveToolSearchCodeDisplayTarget } from "./tool-display-common.js";
+import { splitTopLevelStages } from "./tool-display-exec-shell.js";
 import { resolveExecDetail } from "./tool-display-exec.js";
 import { formatToolDetail, formatToolSummary, resolveToolDisplay } from "./tool-display.js";
 
@@ -517,6 +518,54 @@ describe("tool display details", () => {
     );
 
     expect(detail).toBe("run python3 inline script (heredoc) → run tests");
+  });
+
+  it("keeps heredoc body separators out of top-level stage splitting", () => {
+    const stages = splitTopLevelStages(
+      [
+        "mkdir -p .openclaw/tmp/farm-notices",
+        "cat > .openclaw/tmp/farm-notices/ventura.txt <<'EOF'",
+        "Buenos dias equipo; se ajusta la orden A1251718:",
+        "sc-carwhi(100) && sc-cardoc(100) || sc-carwhi(100)",
+        "Gracias.",
+        "EOF",
+        "./scripts/email_preview_new --to farm@example.com && ./scripts/email_preview_new --to farm2@example.com",
+      ].join("\n"),
+    );
+
+    expect(stages).toEqual([
+      [
+        "mkdir -p .openclaw/tmp/farm-notices",
+        "cat > .openclaw/tmp/farm-notices/ventura.txt <<'EOF'",
+        "Buenos dias equipo; se ajusta la orden A1251718:",
+        "sc-carwhi(100) && sc-cardoc(100) || sc-carwhi(100)",
+        "Gracias.",
+        "EOF",
+        "./scripts/email_preview_new --to farm@example.com",
+      ].join("\n"),
+      "./scripts/email_preview_new --to farm2@example.com",
+    ]);
+  });
+
+  it("keeps heredoc body pipes out of top-level stage summaries", () => {
+    const detail = formatToolDetail(
+      resolveToolDisplay({
+        name: "exec",
+        args: {
+          command: [
+            "cat > .openclaw/tmp/farm-notices/ventura.txt <<-'EOF'",
+            "\tBuenos dias equipo; se ajusta la orden A1251718:",
+            "\tsc-carwhi(100) && sc-cardoc(100) || sc-carwhi(100)",
+            "\tGracias.",
+            "\tEOF",
+            "./scripts/email_preview_new --to farm@example.com && ./scripts/email_preview_new --to farm2@example.com",
+          ].join("\n"),
+        },
+        detailMode: "explain",
+      }),
+    );
+
+    expect(detail).toBe("show > → run email_preview_new → run email_preview_new");
   });
 
   it("appends node name to exec detail when node is set", () => {

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, expect, it } from "vitest";
 import { resolveToolSearchCodeDisplayTarget } from "./tool-display-common.js";
-import { splitTopLevelStages } from "./tool-display-exec-shell.js";
+import { splitTopLevelPipes, splitTopLevelStages } from "./tool-display-exec-shell.js";
 import { resolveExecDetail } from "./tool-display-exec.js";
 import { formatToolDetail, formatToolSummary, resolveToolDisplay } from "./tool-display.js";
 
@@ -566,6 +566,49 @@ describe("tool display details", () => {
     );
 
     expect(detail).toBe("show > → run email_preview_new → run email_preview_new");
+  });
+
+  it("consumes same-line heredocs in declaration order before splitting later stages", () => {
+    const stages = splitTopLevelStages(
+      [
+        "cat <<'FIRST' <<-\"SECOND\"",
+        "first; body && body || body | body",
+        "FIRST",
+        "\tsecond; body && body || body | body",
+        "\tSECOND",
+        "printf done && npm test",
+      ].join("\n"),
+    );
+
+    expect(stages).toEqual([
+      [
+        "cat <<'FIRST' <<-\"SECOND\"",
+        "first; body && body || body | body",
+        "FIRST",
+        "\tsecond; body && body || body | body",
+        "\tSECOND",
+        "printf done",
+      ].join("\n"),
+      "npm test",
+    ]);
+  });
+
+  it("splits a real pipe after the final same-line heredoc terminator", () => {
+    const command = [
+      "cat <<ONE <<-'TWO'",
+      "one | body",
+      "ONE",
+      "\ttwo && body",
+      "\tTWO",
+      "cat result | wc -l",
+    ].join("\n");
+
+    expect(splitTopLevelPipes(command)).toEqual([
+      ["cat <<ONE <<-'TWO'", "one | body", "ONE", "\ttwo && body", "\tTWO", "cat result"].join(
+        "\n",
+      ),
+      "wc -l",
+    ]);
   });
 
   it("appends node name to exec detail when node is set", () => {

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -568,12 +568,9 @@ describe("tool display details", () => {
     ].join("\n");
 
     expect(splitTopLevelStages(command)).toEqual([
-      [
-        "cat <<\\EOF",
-        "body; not a stage && not a stage || not a stage",
-        "EOF",
-        "printf done",
-      ].join("\n"),
+      ["cat <<\\EOF", "body; not a stage && not a stage || not a stage", "EOF", "printf done"].join(
+        "\n",
+      ),
       "npm test",
     ]);
   });


### PR DESCRIPTION
Closes #102875

## What Problem This Solves

Fixes an issue where operators reading channel tool-status footers could see heredoc body text rendered as phantom shell commands when an exec command writes multiline content with `<<EOF` and then runs a later command that fails.

In the reported Telegram footer, email body lines such as `sc-carwhi(100)` and `Gracias.` were shown as command stages, which made a normal self-correcting turn look like the agent had hallucinated broken commands.

## Why This Change Was Made

The top-level shell scanner already respected quotes and escapes, but it still visited separator characters inside heredoc bodies. This change teaches the scanner to recognize `<<` / `<<-` heredoc markers, parse quoted or escaped terminators, and skip the body until the matching terminator line before continuing normal stage and pipe splitting.

This keeps the change bounded to display-summary parsing; it does not try to validate full shell syntax or change command execution.

## User Impact

Users and operators now get clearer exec status footers for scripts that write multiline files or inline content before running follow-up commands. Heredoc body text is no longer mislabeled as failed commands, while real commands after the heredoc terminator are still summarized.

## Evidence

- `node scripts/run-vitest.mjs src/agents/tool-display.test.ts --reporter=verbose` — passed, 47 tests.
- `pnpm exec oxfmt --check src/agents/tool-display-exec-shell.ts src/agents/tool-display.test.ts` — passed.
- `pnpm exec oxlint --config .oxlintrc.json --tsconfig config/tsconfig/oxlint.core.json src/agents/tool-display-exec-shell.ts src/agents/tool-display.test.ts` — passed, 0 warnings / 0 errors.
- `git diff --check` — passed.
- Secret scan over the diff — passed, 0 hits.

Note: `pnpm check:changed -- src/agents/tool-display-exec-shell.ts src/agents/tool-display.test.ts` could not run locally because this checkout delegates to Blacksmith Testbox and the local `crabbox` binary failed its basic sanity check before executing the lane.