### PR TITLE
fix(voice-call): bound shared provider JSON API request deadline

### DIFF
--- a/extensions/voice-call/src/providers/shared/guarded-json-api.test.ts
+++ b/extensions/voice-call/src/providers/shared/guarded-json-api.test.ts
@@ -66,6 +66,7 @@ describe("guardedJsonApiRequest", () => {
       },
       policy: { allowedHostnames: ["api.example.com"] },
       auditContext: "voice-call:test",
+      timeoutMs: 30_000,
     });
     expect(release).toHaveBeenCalledTimes(1);
   });

--- a/extensions/voice-call/src/providers/shared/guarded-json-api.ts
+++ b/extensions/voice-call/src/providers/shared/guarded-json-api.ts
@@ -8,6 +8,12 @@ import {
 
 // Shared guarded JSON API client for voice-call providers.
 
+// Owner-controlled request deadline so a telephony API that accepts the
+// connection but never returns response headers cannot hang voice-call
+// operations (dial, hangup, status polling) forever. Callers cannot override
+// or disable it. Matches the 30s voice-call gateway operation budget.
+const VOICE_CALL_API_REQUEST_TIMEOUT_MS = 30_000;
+
 /** Parameters for an SSRF-guarded provider JSON request. */
 type GuardedJsonApiRequestParams = {
   url: string;
@@ -33,6 +39,7 @@ export async function guardedJsonApiRequest<T = unknown>(
     },
     policy: { allowedHostnames: params.allowedHostnames },
     auditContext: params.auditContext,
+    timeoutMs: VOICE_CALL_API_REQUEST_TIMEOUT_MS,
   });
 
   try {


### PR DESCRIPTION
## What Problem This Solves

Voice-call provider requests (Plivo, Telnyx, Twilio) issued through the shared
`guardedJsonApiRequest` helper could wait indefinitely when a telephony API
accepted the TCP connection but never returned response headers. This blocks
dial, hangup, and call-status-polling flows on both the CLI and the gateway.

## Why This Change Was Made

`guardedJsonApiRequest` is the single request boundary for every voice-call
provider, but it called `fetchWithSsrFGuard` without a `timeoutMs`, so the SSRF
guard produced no request deadline. The helper now supplies an owner-controlled
30-second deadline at that boundary; callers cannot override or disable it.

## User Impact

Stalled telephony API requests now fail with a `TimeoutError` after 30 seconds
instead of hanging voice-call operations forever. Successful requests and caller
APIs are unchanged.

## Evidence

- Focused suite: `node scripts/run-vitest.mjs extensions/voice-call/src/providers/shared/guarded-json-api.test.ts` — 6/6 passed.
- The regression asserts the production call now passes `timeoutMs: 30_000` to `fetchWithSsrFGuard`.
- Negative control: reverting only the source (keeping the assertion) fails with `Received: - "timeoutMs": 30000`, proving the deadline is wired to the production call.
- `oxlint` — exit 0; `oxfmt --check` — clean.

AI-assisted.
