### PR TITLE
fix(qqbot): add 30s request timeout to token endpoint fetch

### DIFF
--- a/extensions/qqbot/src/engine/api/token.test.ts
+++ b/extensions/qqbot/src/engine/api/token.test.ts
@@ -54,6 +54,7 @@ describe("QQBot token manager", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.useRealTimers();
   });
 
@@ -74,6 +75,7 @@ describe("QQBot token manager", () => {
         hostnameAllowlist: ["bots.qq.com"],
         allowRfc2544BenchmarkRange: true,
       },
+      timeoutMs: 30_000,
       init: {
         method: "POST",
         headers: {
@@ -176,5 +178,73 @@ describe("QQBot token manager", () => {
     expect(logger.debug).toHaveBeenCalledWith(
       "[qqbot:token:app-id] Not cached: invalid process clock",
     );
+  });
+
+  it("times out one stalled token fetch for every singleflight waiter and allows retry", async () => {
+    vi.useFakeTimers();
+    const { fetchWithSsrFGuard } = await vi.importActual<
+      typeof import("openclaw/plugin-sdk/ssrf-runtime")
+    >("openclaw/plugin-sdk/ssrf-runtime");
+    fetchWithSsrFGuardMock.mockImplementation(fetchWithSsrFGuard);
+
+    let fetchSignal: AbortSignal | undefined;
+    const stalledFetch = vi.fn(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          fetchSignal = init?.signal ?? undefined;
+          if (!fetchSignal) {
+            reject(new Error("missing guarded fetch signal"));
+            return;
+          }
+          fetchSignal.addEventListener(
+            "abort",
+            () => {
+              const reason = fetchSignal?.reason;
+              const error =
+                reason instanceof Error ? reason : new Error("request aborted", { cause: reason });
+              reject(error);
+            },
+            { once: true },
+          );
+        }),
+    );
+    vi.stubGlobal("fetch", stalledFetch);
+
+    const manager = new TokenManager();
+    const first = manager.getAccessToken("app-id", "secret");
+    const second = manager.getAccessToken(" app-id ", "secret");
+    const outcomes = Promise.allSettled([first, second]);
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(stalledFetch).toHaveBeenCalledTimes(1);
+    expect(manager.getStatus("app-id").status).toBe("refreshing");
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    const [firstOutcome, secondOutcome] = await outcomes;
+    expect(fetchSignal?.aborted).toBe(true);
+    expect(firstOutcome.status).toBe("rejected");
+    expect(secondOutcome.status).toBe("rejected");
+    if (firstOutcome.status !== "rejected" || secondOutcome.status !== "rejected") {
+      throw new Error("expected every singleflight waiter to reject");
+    }
+    const timeoutError = firstOutcome.reason as Error;
+    expect(timeoutError).toBe(secondOutcome.reason);
+    expect(timeoutError.message).toBe("Network error getting access_token: request timed out");
+    expect(timeoutError.cause).toMatchObject({
+      name: "TimeoutError",
+      message: "request timed out",
+    });
+    expect(manager.getStatus("app-id")).toEqual({ status: "none", expiresAt: null });
+
+    stalledFetch.mockResolvedValueOnce(
+      new Response('{"access_token":"token-2","expires_in":7200}', {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await expect(manager.getAccessToken("app-id", "secret")).resolves.toBe("token-2");
+    expect(stalledFetch).toHaveBeenCalledTimes(2);
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/extensions/qqbot/src/engine/api/token.ts
+++ b/extensions/qqbot/src/engine/api/token.ts
@@ -20,6 +20,7 @@ import { formatErrorMessage } from "../utils/format.js";
 const TOKEN_URL = "https://bots.qq.com/app/getAppAccessToken";
 const DEFAULT_TOKEN_EXPIRES_IN_SECONDS = 7200;
 const QQBOT_TOKEN_RESPONSE_LIMIT_BYTES = 8 * 1024;
+const QQBOT_TOKEN_REQUEST_TIMEOUT_MS = 30_000;
 
 /**
  * Host-scoped SSRF policy for the QQ Bot token endpoint.
@@ -247,6 +248,7 @@ export class TokenManager {
         auditContext: "qqbot-token",
         capture: false,
         policy: QQBOT_TOKEN_SSRF_POLICY,
+        timeoutMs: QQBOT_TOKEN_REQUEST_TIMEOUT_MS,
         init: {
           method: "POST",
           headers: {


### PR DESCRIPTION
## What Problem This Solves

`TokenManager.doFetchToken()` called `fetchWithSsrFGuard` without a deadline. If the QQBot token endpoint accepted a connection but never returned response headers, the singleflight token request could hang indefinitely and block every caller waiting for the same app token.

## Why This Change Was Made

The token endpoint now uses the existing guarded-fetch timeout contract with a 30-second deadline. The change stays in the QQBot token owner and reuses the same bounded-fetch mechanism already used elsewhere rather than adding another timer path.

## User Impact

A stalled QQBot token request now aborts after 30 seconds. Every caller sharing that in-flight request receives the same timeout failure, the singleflight state is cleared, and a later request can retry normally.

## Evidence

- The owner-boundary regression drives the real `TokenManager` through the real guarded fetch with two same-app callers.
- A stalled request aborts at the configured deadline; both callers reject; the in-flight status is cleared; the next request succeeds.
- Sanitized AWS Crabbox run `run_3e6b0bdb1f9e`: `extensions/qqbot/src/engine/api/token.test.ts`, 7/7 passed.
- Patch-identical hosted CI run `29132587977`: 62 green rollup checks, no failures; native prepare accepted it after the clean rebase.
- Fresh Codex autoreview: no accepted or actionable findings.

Live QQ platform traffic was not required for this failure class: the regression controls the stalled response at the guarded-fetch boundary while exercising production `TokenManager` singleflight behavior.

## Root Cause

The token acquisition path was the remaining QQBot fetch path without a bounded deadline. Because `TokenManager` deduplicates requests per app, one stalled request also stalled every waiter.

AI-assisted.
