### PR TITLE
fix(auto-reply): preserve periodic usage-limit details for mid-turn failures

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -4145,6 +4145,36 @@ describe("runAgentTurnWithFallback", () => {
     },
   );
 
+  it.each(NON_DIRECT_FAILURE_SURFACE_CASES)(
+    "preserves periodic usage-limit reset details from no-text mid-turn failures in $label chats",
+    async (testCase) => {
+      state.runEmbeddedAgentMock.mockResolvedValueOnce({
+        payloads: [{ text: "thinking", isReasoning: true }],
+        meta: {
+          error: {
+            kind: "rate_limit",
+            message: "You've hit your weekly limit · resets 6pm (UTC)",
+          },
+        },
+      });
+
+      const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+      const result = await runAgentTurnWithFallback(
+        createMinimalRunAgentTurnParams({
+          sessionCtx: createNonDirectFailureSessionCtx(testCase),
+        }),
+      );
+
+      expect(result.kind).toBe("success");
+      if (result.kind === "success") {
+        expect(result.runResult.payloads?.[0]?.isError).toBe(true);
+        expect(result.runResult.payloads?.[0]?.text).toContain("weekly limit");
+        expect(result.runResult.payloads?.[0]?.text).toContain("resets 6pm");
+        expect(result.runResult.payloads?.[0]?.text).not.toContain("few minutes");
+      }
+    },
+  );
+
   it("surfaces model capacity errors from pre-reply CLI failures", async () => {
     state.runWithModelFallbackMock.mockRejectedValueOnce(
       new Error("Selected model is at capacity. Please try a different model."),

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -3604,7 +3604,9 @@ async function runAgentTurnWithFallbackInternal(
         )?.text ?? "";
       const errorCandidate = metaErrorMsg || rawErrorPayloadText;
       const formattedErrorCandidate = errorCandidate
-        ? formatRateLimitOrOverloadedErrorCopy(errorCandidate)
+        ? isPeriodicUsageLimitErrorMessage(errorCandidate)
+          ? buildRateLimitCooldownMessage(errorCandidate)
+          : formatRateLimitOrOverloadedErrorCopy(errorCandidate)
         : undefined;
       if (formattedErrorCandidate) {
         runResult.payloads = [


### PR DESCRIPTION
## What Problem This Solves

Periodic usage-limit errors that happen mid-turn after the agent already emitted only reasoning/no visible reply were still being collapsed into the generic rate-limit fallback copy. That lost the provider's concrete reset timing details, even though the newer auto-reply paths already preserve them in other failure branches.

## Why This Change Was Made

The no-text mid-turn fallback branch now recognizes periodic usage-limit messages and reuses the existing `buildRateLimitCooldownMessage()` path instead of always going through the generic rate-limit/overload formatter. This keeps the existing behavior for ordinary rate limits and overloads while preserving the more actionable reset wording for periodic limits.

## User Impact

When a group/channel auto-reply turn fails mid-turn with a periodic usage-limit message like "resets 6pm (UTC)", users now see that reset detail instead of a generic "try again in a few minutes" message.

## Evidence

- Local focused test: `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts`
- Local focused test output:
  - `[test] starting test/vitest/vitest.auto-reply.config.ts`
  - `RUN  v4.1.9 /home/0668000995/10288592/git-hub/codex/openclaw`
  - `Test Files  1 passed (1)`
  - `Tests  248 passed (248)`
  - `Duration  12.77s (transform 3.33s, setup 372ms, import 6.18s, tests 5.91s, environment 0ms)`
  - `[test] passed 1 Vitest shard in 22.63s`
- Regression proof from the same real local run: the newly added no-text mid-turn periodic-limit test fails on the pre-fix path and passes after this change, preserving `weekly limit` and `resets 6pm` instead of falling back to `few minutes` copy.
