### PR TITLE
test(ui): scope default agent selector

### DIFF
--- a/ui/src/e2e/agents-set-default-persistence.e2e.test.ts
+++ b/ui/src/e2e/agents-set-default-persistence.e2e.test.ts
@@ -90,7 +90,10 @@ describeControlUiE2e("Control UI agents Set Default mocked Gateway E2E", () => {
       // these implicitly assert the dropdown loaded and Set Default is clickable for a
       // non-default agent.
       await page.locator(".agent-select__trigger").click();
-      await page.getByRole("option", { name: "Kimi agent" }).click();
+      await page
+        .getByRole("listbox", { name: "Select an agent" })
+        .getByRole("option", { name: "Kimi agent", exact: true })
+        .click();
       await page.getByRole("button", { name: "Set Default", exact: true }).click();
 
       // The fix routes Set Default through the canonical save path; without it the click


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation failed in [Release Checks job 86139783937](https://github.com/openclaw/openclaw/actions/runs/29024071902/job/86139783937) because the Set Default E2E test used a page-global `role=option` locator. The Agents picker and the persistent session-filter `<select>` both expose a `Kimi agent` option, so Playwright strict mode correctly rejected the ambiguous click.

## Why This Change Was Made

The test now scopes the exact `Kimi agent` option through the accessible `Select an agent` listbox before clicking. This follows the component's public accessibility structure and preserves strict locator behavior.

## User Impact

No product behavior changes. The release UI E2E lane becomes deterministic while continuing to prove that Set Default sends the canonical `config.set` request.

## Evidence

- Blacksmith Testbox `tbx_01kx3kpfkbsxac7akmdhw4zmgk`: the focused mocked-Gateway Playwright E2E passed twice consecutively.
- Targeted `oxfmt --check` and `git diff --check`: passed.
- Fresh autoreview: clean at 0.99 confidence.
- Failure provenance: 92/93 UI E2E tests passed; the sole failure was the strict selector collision before the persistence action.
