### PR TITLE
fix(tlon): add timeouts to file upload HTTP requests

### DIFF
--- a/extensions/tlon/src/tlon-api.test.ts
+++ b/extensions/tlon/src/tlon-api.test.ts
@@ -139,6 +139,7 @@ describe("uploadFile memex upload hardening", () => {
     expect(firstCall?.auditContext).toBe("tlon-memex-upload-url");
     expect(firstCall?.capture).toBe(false);
     expect(firstCall?.maxRedirects).toBe(0);
+    expect(firstCall?.timeoutMs).toBe(30_000);
     const firstBodyRaw = firstCall?.init?.body;
     expect(typeof firstBodyRaw).toBe("string");
     const firstBody = JSON.parse(firstBodyRaw as string) as Record<string, unknown>;
@@ -156,6 +157,7 @@ describe("uploadFile memex upload hardening", () => {
     expect(secondCall?.auditContext).toBe("tlon-memex-upload");
     expect(secondCall?.capture).toBe(false);
     expect(secondCall?.maxRedirects).toBe(0);
+    expect(secondCall?.timeoutMs).toBe(120_000);
     expect(secondCall?.init?.body).toBeInstanceOf(Blob);
     expect(mockRelease).toHaveBeenCalledTimes(2);
   });
@@ -504,6 +506,7 @@ describe("uploadFile custom S3 upload hardening", () => {
     expect(uploadCall?.auditContext).toBe("tlon-custom-s3-upload");
     expect(uploadCall?.capture).toBe(false);
     expect(uploadCall?.maxRedirects).toBe(0);
+    expect(uploadCall?.timeoutMs).toBe(120_000);
     expect(uploadCall?.policy).toBeUndefined();
     expect(mockRelease).toHaveBeenCalledTimes(1);
     expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();

--- a/extensions/tlon/src/tlon-api.test.ts
+++ b/extensions/tlon/src/tlon-api.test.ts
@@ -157,7 +157,7 @@ describe("uploadFile memex upload hardening", () => {
     expect(secondCall?.auditContext).toBe("tlon-memex-upload");
     expect(secondCall?.capture).toBe(false);
     expect(secondCall?.maxRedirects).toBe(0);
-    expect(secondCall?.timeoutMs).toBe(120_000);
+    expect(secondCall?.timeoutMs).toBe(300_000);
     expect(secondCall?.init?.body).toBeInstanceOf(Blob);
     expect(mockRelease).toHaveBeenCalledTimes(2);
   });
@@ -506,7 +506,7 @@ describe("uploadFile custom S3 upload hardening", () => {
     expect(uploadCall?.auditContext).toBe("tlon-custom-s3-upload");
     expect(uploadCall?.capture).toBe(false);
     expect(uploadCall?.maxRedirects).toBe(0);
-    expect(uploadCall?.timeoutMs).toBe(120_000);
+    expect(uploadCall?.timeoutMs).toBe(300_000);
     expect(uploadCall?.policy).toBeUndefined();
     expect(mockRelease).toHaveBeenCalledTimes(1);
     expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();

--- a/extensions/tlon/src/tlon-api.ts
+++ b/extensions/tlon/src/tlon-api.ts
@@ -49,6 +49,12 @@ const MEMEX_BASE_URL = "https://memex.tlon.network";
 /** Max bytes to read from the Memex upload JSON response. */
 const MEMEX_UPLOAD_RESPONSE_MAX_BYTES = 64 * 1024;
 
+/** Timeout for the Memex upload URL lookup request. */
+const TLON_MEMEX_UPLOAD_URL_TIMEOUT_MS = 30_000;
+
+/** Timeout for the actual file upload to Memex or a custom S3 target. */
+const TLON_UPLOAD_TIMEOUT_MS = 120_000;
+
 let currentClientConfig: ClientConfig | null = null;
 
 export function configureClient(params: ClientConfig): void {
@@ -250,6 +256,7 @@ async function getMemexUploadUrl(params: {
       auditContext: "tlon-memex-upload-url",
       capture: false,
       maxRedirects: 0,
+      timeoutMs: TLON_MEMEX_UPLOAD_URL_TIMEOUT_MS,
     });
     release = guarded.release;
     if (!guarded.response.ok) {
@@ -317,6 +324,7 @@ export async function uploadFile(params: UploadFileParams): Promise<UploadResult
         auditContext: "tlon-memex-upload",
         capture: false,
         maxRedirects: 0,
+        timeoutMs: TLON_UPLOAD_TIMEOUT_MS,
       });
       release = guarded.release;
       assertTrustedMemexUploadUrl(guarded.finalUrl, "Memex final upload URL");
@@ -381,6 +389,7 @@ export async function uploadFile(params: UploadFileParams): Promise<UploadResult
       capture: false,
       maxRedirects: 0,
       policy: privateNetworkPolicy,
+      timeoutMs: TLON_UPLOAD_TIMEOUT_MS,
     });
     release = guarded.release;
     if (!guarded.response.ok) {

--- a/extensions/tlon/src/tlon-api.ts
+++ b/extensions/tlon/src/tlon-api.ts
@@ -49,11 +49,11 @@ const MEMEX_BASE_URL = "https://memex.tlon.network";
 /** Max bytes to read from the Memex upload JSON response. */
 const MEMEX_UPLOAD_RESPONSE_MAX_BYTES = 64 * 1024;
 
-/** Timeout for the Memex upload URL lookup request. */
+/** Total deadline for the Memex upload URL lookup, including DNS and response reading. */
 const TLON_MEMEX_UPLOAD_URL_TIMEOUT_MS = 30_000;
 
-/** Timeout for the actual file upload to Memex or a custom S3 target. */
-const TLON_UPLOAD_TIMEOUT_MS = 120_000;
+/** Total deadline for Memex and custom S3 PUTs, including DNS and the full upload. */
+const TLON_UPLOAD_TIMEOUT_MS = 300_000;
 
 let currentClientConfig: ClientConfig | null = null;
 


### PR DESCRIPTION
## What Problem This Solves

Tlon file delivery made three outbound requests without an owner-level total deadline: Memex upload-URL lookup, Memex upload, and custom-S3 upload. The shared SSRF guard bounds the complete operation only when its caller supplies `timeoutMs`, so stalled DNS or response work could otherwise outlive delivery indefinitely.

## Why This Change Was Made

Pass explicit deadlines through the existing SSRF-safe fetch path at the Tlon owner boundary: 30 seconds for the small upload-URL lookup and 300 seconds for uploads. The five-minute upload limit keeps the operation bounded while allowing realistic headroom for the existing 6 MiB source-media cap.

Direct Undici 8.5.0 source inspection confirmed its defaults are not an equivalent contract: connect timeout is 10 seconds, while header/body timeouts are 300-second idle limits rather than one total DNS-to-body deadline.

## User Impact

Tlon uploads now fail predictably when network work stalls, while slow valid uploads retain five minutes to complete.

## Evidence

- Blacksmith Testbox `tbx_01kxjvmc4cn3xmqyhkyq2mvmnt`: `CI=1 pnpm test extensions/tlon/src/tlon-api.test.ts` — 15/15 passed.
- Blacksmith Testbox changed gate: `CI=1 ... pnpm check:changed` — extension production/tests typechecks, lint, database-first guard, media helper guard, sidecar guard, and import-cycle check passed.
- Fresh autoreview, local and full branch modes: no findings.
- Tests assert the exact timeout option on all three request branches: 30 seconds for lookup, 300 seconds for both upload backends.
- No live Tlon/Memex/custom-S3 credentials were used; HTTP option forwarding and owner-boundary behavior are covered with request mocks.

AI-assisted: This PR was prepared with AI assistance.
