### PR TITLE
refactor(ui): localize internal TaskRuntime type in tasks data

### DIFF
--- a/ui/src/lib/tasks/data.ts
+++ b/ui/src/lib/tasks/data.ts
@@ -2,7 +2,7 @@ import { t } from "../../i18n/index.ts";
 
 export type TaskStatus = "queued" | "running" | "completed" | "failed" | "cancelled" | "timed_out";
 
-export type TaskRuntime = "subagent" | "cron" | "acp" | "cli";
+type TaskRuntime = "subagent" | "cron" | "acp" | "cli";
 type TaskTimestamp = number | string;
 
 export type TaskSummary = {


### PR DESCRIPTION
## What Problem This Solves

`TaskRuntime` in `ui/src/pages/tasks/data.ts` is exported but only referenced inside that module. The unnecessary `export` widens the module's internal surface and leaves a false-positive unused-export candidate.

## Why This Change Was Made

Remove the unused `export` modifier so the type stays local to its module. This is a purely internal TypeScript surface cleanup.

## User Impact

None. `TaskRuntime` is a compile-time-only type with no external importers, so runtime behavior and all other modules are unchanged.

## Evidence

- Repository-wide search confirms no module outside `ui/src/pages/tasks/data.ts` imports `TaskRuntime` from this file (a same-named type in `src/tasks/` is a separate declaration and is untouched).
- `pnpm tsgo:core` — exit 0 (core + Control UI typecheck clean).
- `cd ui && pnpm run build` — **✓ built in 1.32s** (full UI production bundle).
- `node scripts/run-vitest.mjs ui/src/pages/tasks/data.test.ts` — 6/6 passed.
- `oxlint` — exit 0; `oxfmt --check` — clean.
- `git diff --check` — clean.

AI-assisted.