### PR TITLE
fix(slack): preserve standalone reply anchors

### DIFF
--- a/extensions/slack/src/action-runtime.test.ts
+++ b/extensions/slack/src/action-runtime.test.ts
@@ -1,6 +1,7 @@
 // Slack tests cover action runtime plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SlackActionContext } from "./action-runtime.js";
 import { handleSlackAction, slackActionRuntime } from "./action-runtime.js";
 import { parseSlackBlocksInput } from "./blocks-input.js";
 import { buildSlackThreadingToolContext } from "./threading-tool-context.js";
@@ -153,7 +154,7 @@ describe("handleSlackAction", () => {
 
   async function sendSecondMessageAndExpectNoThread(params: {
     cfg: OpenClawConfig;
-    context: ReturnType<typeof createReplyToFirstContext>;
+    context: SlackActionContext;
   }) {
     await handleSlackAction(
       { action: "sendMessage", to: "channel:C123", content: "Second" },
@@ -784,6 +785,59 @@ describe("handleSlackAction", () => {
 
     expectLastSlackSend("First", cfg, "1111111111.111111");
     await sendSecondMessageAndExpectNoThread({ cfg, context });
+  });
+
+  it("replyToMode=first threads standalone message-tool sends without ReplyToId", async () => {
+    const cfg = slackConfig({ replyToMode: "first" });
+    const hasRepliedRef = { value: false };
+    const context = buildSlackThreadingToolContext({
+      cfg,
+      accountId: null,
+      hasRepliedRef,
+      context: {
+        ChatType: "channel",
+        To: "channel:C123",
+        CurrentMessageId: "1111111111.111111",
+      },
+    });
+
+    await handleSlackAction(
+      { action: "sendMessage", to: "channel:C123", content: "First" },
+      cfg,
+      context,
+    );
+
+    expectLastSlackSend("First", cfg, "1111111111.111111");
+    await sendSecondMessageAndExpectNoThread({ cfg, context });
+  });
+
+  it("does not use standalone current-message anchors for different channels", async () => {
+    const cfg = slackConfig({ replyToMode: "first" });
+    const hasRepliedRef = { value: false };
+    const context = buildSlackThreadingToolContext({
+      cfg,
+      accountId: null,
+      hasRepliedRef,
+      context: {
+        ChatType: "channel",
+        To: "channel:C123",
+        CurrentMessageId: "1111111111.111111",
+      },
+    });
+
+    await handleSlackAction(
+      { action: "sendMessage", to: "channel:C999", content: "Other channel" },
+      cfg,
+      context,
+    );
+
+    expectSlackSendCall(0, "channel:C999", "Other channel", {
+      cfg,
+      mediaUrl: undefined,
+      threadTs: undefined,
+      blocks: undefined,
+    });
+    expect(hasRepliedRef.value).toBe(false);
   });
 
   it("replyToMode=first normalizes channel target when accounting explicit threadTs", async () => {

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -817,7 +817,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(prepared.ctxPayload.GroupSpace).toBe("T1");
   });
 
-  it("does not enable Slack status reactions when the message timestamp is missing", async () => {
+  it("uses event_ts as the standalone message id without enabling reactions", async () => {
     const slackCtx = createInboundSlackCtx({
       cfg: {
         messages: {
@@ -839,6 +839,8 @@ describe("slack prepareSlackMessage inbound contract", () => {
     } as SlackMessageEvent);
 
     assertPrepared(prepared);
+    expect(prepared.ctxPayload.MessageSid).toBe("1.000");
+    expect(prepared.ctxPayload.ReplyToId).toBeUndefined();
     expect(prepared?.ackReactionMessageTs).toBeUndefined();
     expect(prepared?.ackReactionPromise).toBeNull();
   });
@@ -1835,7 +1837,7 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
 
       expectMainScopedDmClassification(prepared, { includeFromCheck: testCase.name !== "raw im" });
       expect(prepared!.ctxPayload.MessageThreadId).toBe("1.000");
-      expect(prepared!.ctxPayload.ReplyToId).toBe("1.000");
+      expect(prepared!.ctxPayload.ReplyToId).toBeUndefined();
     }
   });
 
@@ -1848,6 +1850,7 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
 
     assertPrepared(prepared);
     expect(prepared.ctxPayload.MessageThreadId).toBe("1.000");
+    expect(prepared.ctxPayload.ReplyToId).toBeUndefined();
   });
 
   it("classifies MPIM group DMs as group chat context", async () => {
@@ -3831,7 +3834,7 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     expect(prepared.ctxPayload.WasMentioned).toBe(true);
   });
 
-  it("preserves single-use reply mode metadata on seeded top-level roots", async () => {
+  it("preserves seeded top-level roots without reply_to_id self-references", async () => {
     const { storePath } = storeFixture.makeTmpStorePath();
     const rootTs = "1777244692.409919";
 
@@ -3866,7 +3869,7 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
         "agent:main:slack:channel:c0ahzfcas1k:thread:1777244692.409919",
       );
       expect(prepared.ctxPayload.MessageThreadId).toBeUndefined();
-      expect(prepared.ctxPayload.ReplyToId).toBe(rootTs);
+      expect(prepared.ctxPayload.ReplyToId).toBeUndefined();
     }
   });
 });

--- a/extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts
@@ -361,6 +361,7 @@ describe("thread-level session keys", () => {
 
     expect(routing.sessionKey).toBe("agent:main:slack:channel:c123");
     expect(routing.threadContext.messageThreadId).toBeUndefined();
+    expect(routing.threadContext.replyToId).toBeUndefined();
   });
 
   it("does not seed top-level group DM mentions into thread sessions", () => {

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -1362,7 +1362,7 @@ export async function prepareSlackMessage(params: {
   const ctxPayload = buildChannelInboundEventContext({
     channel: "slack",
     accountId: route.accountId,
-    messageId: message.ts,
+    messageId: threadContext.messageTs,
     timestamp: resolveSlackTimestampMs(message.ts),
     from: slackFrom,
     sender: {

--- a/extensions/slack/src/threading-tool-context.test.ts
+++ b/extensions/slack/src/threading-tool-context.test.ts
@@ -213,6 +213,28 @@ describe("buildSlackThreadingToolContext", () => {
     expect(result.replyToMode).toBe("first");
   });
 
+  it("uses CurrentMessageId as a non-explicit anchor when ReplyToId is omitted", () => {
+    const result = buildSlackThreadingToolContext({
+      cfg: {
+        channels: {
+          slack: {
+            replyToMode: "first",
+          },
+        },
+      } as OpenClawConfig,
+      accountId: null,
+      context: {
+        ChatType: "channel",
+        To: "channel:C123",
+        CurrentMessageId: "1771999998.834199",
+      },
+    });
+
+    expect(result.currentThreadTs).toBe("1771999998.834199");
+    expect(result.replyToMode).toBe("first");
+    expect(result.sameChannelThreadRequired).toBe(false);
+  });
+
   it("keeps configured channel behavior when not in a thread", () => {
     const cfg = {
       channels: {

--- a/extensions/slack/src/threading-tool-context.ts
+++ b/extensions/slack/src/threading-tool-context.ts
@@ -25,7 +25,8 @@ export function buildSlackThreadingToolContext(params: {
   const transportThreadTs = normalizeSlackThreadTsCandidate(params.context.TransportThreadId);
   const replyToThreadTs = normalizeSlackThreadTsCandidate(params.context.ReplyToId);
   const currentMessageTs = normalizeSlackThreadTsCandidate(params.context.CurrentMessageId);
-  const currentThreadTs = messageThreadTs ?? transportThreadTs ?? replyToThreadTs;
+  const currentThreadTs =
+    messageThreadTs ?? transportThreadTs ?? replyToThreadTs ?? currentMessageTs;
   const hasExplicitThreadTarget =
     messageThreadTs != null ||
     transportThreadTs != null ||

--- a/extensions/slack/src/threading.test.ts
+++ b/extensions/slack/src/threading.test.ts
@@ -86,7 +86,7 @@ describe("resolveSlackThreadTargets", () => {
 
     expect(context.isThreadReply).toBe(false);
     expect(context.messageThreadId).toBe("123");
-    expect(context.replyToId).toBe("123");
+    expect(context.replyToId).toBeUndefined();
   });
 
   it("sets messageThreadId for DM assistant thread-root messages regardless of replyToMode", () => {
@@ -107,7 +107,7 @@ describe("resolveSlackThreadTargets", () => {
       // thread_ts == ts in a DM: Agents & Assistants root — preserve thread
       // context so tool calls (subagent results) thread correctly.
       expect(context.messageThreadId).toBe("123");
-      expect(context.replyToId).toBe("123");
+      expect(context.replyToId).toBeUndefined();
     }
   });
 
@@ -129,7 +129,7 @@ describe("resolveSlackThreadTargets", () => {
 
       expect(context.isThreadReply).toBe(false);
       expect(context.messageThreadId).toBe("123");
-      expect(context.replyToId).toBe("123");
+      expect(context.replyToId).toBeUndefined();
     }
   });
 
@@ -151,7 +151,7 @@ describe("resolveSlackThreadTargets", () => {
       // thread_ts == ts in a channel: auto-created top-level thread_ts should
       // NOT force threaded mode — only DM assistant threads get the override.
       expect(context.messageThreadId).toBeUndefined();
-      expect(context.replyToId).toBe("123");
+      expect(context.replyToId).toBeUndefined();
     }
   });
 

--- a/extensions/slack/src/threading.ts
+++ b/extensions/slack/src/threading.ts
@@ -21,7 +21,9 @@ export function resolveSlackThreadContext(params: {
   const hasThreadTs = typeof incomingThreadTs === "string" && incomingThreadTs.length > 0;
   const isThreadReply =
     hasThreadTs && (incomingThreadTs !== messageTs || Boolean(params.message.parent_user_id));
-  const replyToId = incomingThreadTs ?? messageTs;
+  // ReplyToId names a genuine parent only. Standalone tool anchoring uses
+  // CurrentMessageId; restart-safe roots persist through the routed thread id.
+  const replyToId = isThreadReply ? incomingThreadTs : undefined;
   // Preserve thread context for Slack Agents & Assistants DM root messages
   // where thread_ts == ts. Non-DM self-thread roots must stay unset because
   // downstream tool threading treats MessageThreadId as an explicit thread

--- a/src/auto-reply/reply/queue.collect.test.ts
+++ b/src/auto-reply/reply/queue.collect.test.ts
@@ -212,6 +212,94 @@ describe("followup queue collect routing", () => {
     expect(calls.map((call) => call.messageId)).toEqual(["101.001", "101.002"]);
   });
 
+  it.each([
+    ["first", " Slack "],
+    ["batched", "SLACK"],
+  ] as const)(
+    "splits standalone Slack collect batches by message id in %s reply mode",
+    async (replyToMode, originatingChannel) => {
+      const key = `test-collect-slack-standalone-${replyToMode}-${Date.now()}`;
+      const calls: FollowupRun[] = [];
+      const done = createDeferred<void>();
+      const settings: QueueSettings = {
+        mode: "collect",
+        debounceMs: 0,
+        cap: 50,
+        dropPolicy: "summarize",
+      };
+
+      for (const [prompt, messageId] of [
+        ["one", "101.001"],
+        ["two", "101.002"],
+      ] as const) {
+        enqueueFollowupRun(
+          key,
+          createRun({
+            prompt,
+            messageId,
+            originatingChannel,
+            originatingTo: "channel:A",
+            originatingReplyToMode: replyToMode,
+            originatingChatType: "channel",
+          }),
+          settings,
+        );
+      }
+
+      scheduleFollowupDrain(key, async (run) => {
+        calls.push(run);
+        if (calls.length === 2) {
+          done.resolve();
+        }
+      });
+      await done.promise;
+
+      expect(calls.map((call) => call.prompt)).toEqual(["one", "two"]);
+      expect(calls.map((call) => call.messageId)).toEqual(["101.001", "101.002"]);
+    },
+  );
+
+  it("collects distinct messages inside the same routed thread", async () => {
+    const key = `test-collect-shared-thread-${Date.now()}`;
+    const calls: FollowupRun[] = [];
+    const done = createDeferred<void>();
+    const settings: QueueSettings = {
+      mode: "collect",
+      debounceMs: 0,
+      cap: 50,
+      dropPolicy: "summarize",
+    };
+
+    for (const [prompt, messageId] of [
+      ["one", "message-1"],
+      ["two", "message-2"],
+    ] as const) {
+      enqueueFollowupRun(
+        key,
+        createRun({
+          prompt,
+          messageId,
+          originatingChannel: "telegram",
+          originatingTo: "chat:1",
+          originatingThreadId: "topic-1",
+          originatingReplyToMode: "all",
+          originatingChatType: "group",
+        }),
+        settings,
+      );
+    }
+
+    scheduleFollowupDrain(key, async (run) => {
+      calls.push(run);
+      done.resolve();
+    });
+    await done.promise;
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.prompt).toContain("Queued #1\none");
+    expect(calls[0]?.prompt).toContain("Queued #2\ntwo");
+  });
+
   it("does not collect when captured reply modes differ on the same anchor", async () => {
     const key = `test-collect-slack-reply-mode-${Date.now()}`;
     const calls: FollowupRun[] = [];
@@ -2377,14 +2465,32 @@ describe("followup queue collect routing", () => {
     expect(calls[0]?.prompt).toContain("two");
   });
 
-  it("collects matching local webchat routes without an external destination", async () => {
+  it("collects matching local webchat routes with distinct message ids", async () => {
     const key = `test-collect-local-webchat-${Date.now()}`;
     const calls: FollowupRun[] = [];
     const done = createDeferred<void>();
     const settings: QueueSettings = { mode: "collect", debounceMs: 0 };
 
-    enqueueFollowupRun(key, createRun({ prompt: "one", originatingChannel: "webchat" }), settings);
-    enqueueFollowupRun(key, createRun({ prompt: "two", originatingChannel: "webchat" }), settings);
+    enqueueFollowupRun(
+      key,
+      createRun({
+        prompt: "one",
+        messageId: "webchat-message-1",
+        originatingChannel: "webchat",
+        originatingReplyToMode: "all",
+      }),
+      settings,
+    );
+    enqueueFollowupRun(
+      key,
+      createRun({
+        prompt: "two",
+        messageId: "webchat-message-2",
+        originatingChannel: "webchat",
+        originatingReplyToMode: "all",
+      }),
+      settings,
+    );
     scheduleFollowupDrain(key, async (run) => {
       calls.push(run);
       done.resolve();

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -15,6 +15,7 @@ import {
   createUserTurnTranscriptRecorder,
 } from "../../../sessions/user-turn-transcript.js";
 import { resolveGlobalMap } from "../../../shared/global-singleton.js";
+import { normalizeMessageChannel } from "../../../utils/message-channel.js";
 import {
   buildCollectPrompt,
   beginQueueDrain,
@@ -174,9 +175,22 @@ export function resolveFollowupDeliveryContextKey(run: FollowupRun): string {
 }
 
 export function resolveFollowupReplyAnchor(run: FollowupRun): string | undefined {
-  return run.originatingReplyToMode === "off"
-    ? undefined
-    : normalizeOptionalString(run.originatingReplyToId);
+  if (run.originatingReplyToMode === "off") {
+    return undefined;
+  }
+  const replyToId = normalizeOptionalString(run.originatingReplyToId);
+  if (replyToId || normalizeMessageChannel(run.originatingChannel) !== "slack") {
+    return replyToId;
+  }
+  const threadId = run.originatingThreadId;
+  const hasRoutedThread =
+    typeof threadId === "number"
+      ? Number.isFinite(threadId)
+      : normalizeOptionalString(threadId) !== undefined;
+  // Slack standalone turns have no parent reply id, but enabled reply policies
+  // still need the message id so collect groups cannot cross independent roots.
+  // A routed thread already owns that boundary and remains collectable across turns.
+  return hasRoutedThread ? undefined : normalizeOptionalString(run.messageId);
 }
 
 function splitCollectItemsByDeliveryContext(items: FollowupRun[]): FollowupRun[][] {


### PR DESCRIPTION
Closes #102457.

## What Problem This Solves

Standalone Slack messages and self-thread roots could expose `reply_to_id` equal to their own `message_id`, making non-replies look like replies to themselves. Genuine thread replies should carry the parent timestamp; standalone messages should not.

This is a maintainer-owned replacement for #102462 after GitHub's signed fork-update path repeatedly failed while recreating its stale ancestry.

## Why This Change Was Made

Slack now sets `ReplyToId` only for genuine replies. Message-tool threading falls back to `CurrentMessageId` as the non-explicit current-turn anchor, preserving configured `first`, `batched`, and `all` behavior without reintroducing misleading prompt metadata.

The queued follow-up path applies the standalone-message fallback only to normalized Slack origins and only when no routed thread exists. Explicit parents still win, routed Telegram-style threads still collect, reply mode `off` remains off, and webchat's per-turn client IDs do not accidentally split collect batches.

Independent restart-path adjudication confirmed that `ReplyToId` was never persisted. Restart-safe roots continue through `MessageThreadId`, `TransportThreadId`, or the thread-scoped session key; live and ordinary queued turns retain `MessageSid` as `CurrentMessageId`. The replacement is one current-main commit with `ZengWen-DT` preserved as co-author.

## User Impact

Agents receive accurate Slack reply metadata for standalone messages, self-thread roots, and true replies. Existing same-channel message-tool threading remains intact, sends to another channel cannot inherit the inbound message's thread anchor, and non-Slack queue semantics are unchanged.

## Evidence

- Fresh full-path autoreview: clean after two independent queue-path findings were repaired, confidence 0.95.
- Coverage spans resolver, prepare/routing, thread-session key, tool context, action runtime, true replies, standalone sends, cross-channel guards, routed-thread collection, and realistic webchat client IDs.
- Formatting and `git diff --check origin/main...HEAD` passed.
- Exact-head isolated proof and hosted CI will be attached before merge.

Supersedes #102462 while preserving contributor credit.
