### PR TITLE
refactor(ui): localize internal declarations in thinking module

### DIFF
--- a/ui/src/lib/chat/thinking.ts
+++ b/ui/src/lib/chat/thinking.ts
@@ -9,7 +9,7 @@ import { pushUniqueTrimmedSelectOption } from "../select-options.ts";
 import { sessionModelMatchesDefaults } from "../session-model-defaults.ts";
 import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
 
-export type ThinkingCatalogEntry = {
+type ThinkingCatalogEntry = {
   provider: string;
   id: string;
   reasoning?: boolean;
@@ -68,7 +68,7 @@ export function listThinkingLevelLabels(
   return BASE_THINKING_LEVELS;
 }
 
-export function resolveThinkingDefaultForModel(params: {
+function resolveThinkingDefaultForModel(params: {
   provider: string;
   model: string;
   catalog?: readonly ThinkingCatalogEntry[];


### PR DESCRIPTION
## What Problem This Solves

Two declarations in `ui/src/lib/chat/thinking.ts` carry `export` but have no importers outside their own module within the `ui/` package. The unused `export` widens the module's public API surface unnecessarily.

## Why This Change Was Made

Removed `export` from `ThinkingCatalogEntry` (type) and `resolveThinkingDefaultForModel` (function). Both are referenced only within `thinking.ts` itself — zero external imports within `ui/`.

Zero runtime behavior change. Matches the pattern established by #102793 (`refactor(ui): localize internal declarations`).

## User Impact

No user impact. Purely internal visibility change.

## Evidence

**Real environment tested:** Node v24, local OpenClaw checkout, PR head commit.

**Proof — zero external consumers within ui/:**

```
$ git grep "\bThinkingCatalogEntry\b" -- 'ui/**/*.ts' 'ui/**/*.tsx'
ui/src/lib/chat/thinking.ts:12:type ThinkingCatalogEntry = {
ui/src/lib/chat/thinking.ts:71:  catalog?: readonly ThinkingCatalogEntry[];
ui/src/lib/chat/thinking.ts:207:  catalog: readonly ThinkingCatalogEntry[];
ui/src/lib/chat/thinking.ts:258:  catalog: readonly ThinkingCatalogEntry[];
# ← 全部在 thinking.ts 自身内

$ git grep "\bresolveThinkingDefaultForModel\b" -- 'ui/**/*.ts' 'ui/**/*.tsx'
ui/src/lib/chat/thinking.ts:68:function resolveThinkingDefaultForModel(params: {
ui/src/lib/chat/thinking.ts:159:  return resolveThinkingDefaultForModel({
ui/src/lib/chat/thinking.ts:286:      ? resolveThinkingDefaultForModel({
# ← 全部在 thinking.ts 自身内
```

```
npx oxlint ui/src/lib/chat/thinking.ts
# exit 0

git diff upstream/main --stat
# 1 file changed, 2 insertions(+), 2 deletions(-)
```

**Full UI build proof:**

```
$ cd ui && pnpm run build
✓ built in 1.35s

$ git diff --check
# exit 0
```

**Observed result after fix:** Two symbols that had no external importers are now correctly scoped as module-private. Full UI production build succeeds with zero errors.

**What was not tested:** None — the change has zero runtime surface to verify beyond build, lint, and related tests.

## Regression Test Plan

- `npx oxlint ui/src/lib/chat/thinking.ts` — **exit 0**
- `cd ui && pnpm run build` — **✓ built in 1.35s**
- `node scripts/run-vitest.mjs ui/src/lib/chat/model-ref.test.ts --run` — **24 passed**
- `node scripts/run-vitest.mjs ui/src/pages/chat/models.test.ts --run` — **3 passed**
- `git diff upstream/main --stat` — **1 file, +2/-2**

## Root Cause

`ThinkingCatalogEntry` and `resolveThinkingDefaultForModel` were exported but never imported by any other module within the `ui/` package. Per AGENTS.md: "Keep APIs narrow: export only current caller needs; keep types/helpers local by default."

AI-assisted: Claude Opus 4.8