### PR TITLE
fix(matrix): treat outbound media content types case-insensitively

### DIFF
--- a/extensions/matrix/src/matrix/send/formatting.test.ts
+++ b/extensions/matrix/src/matrix/send/formatting.test.ts
@@ -1,0 +1,41 @@
+// Matrix tests cover outbound msgtype resolution formatting behavior.
+import { mediaKindFromMime } from "@openclaw/media-core/constants";
+import { afterEach, describe, expect, it } from "vitest";
+import type { PluginRuntime } from "../../runtime-api.js";
+import { setMatrixRuntime } from "../../runtime.js";
+import { resolveMatrixMsgType } from "./formatting.js";
+import { MsgType } from "./types.js";
+
+// Wire the real core classifier so case sensitivity is exercised end-to-end
+// (send.test.ts mocks mediaKindFromMime, so it cannot cover normalization).
+function installRuntimeWithRealMediaKind(): void {
+  setMatrixRuntime({
+    media: { mediaKindFromMime },
+  } as unknown as PluginRuntime);
+}
+
+describe("resolveMatrixMsgType", () => {
+  afterEach(() => {
+    setMatrixRuntime(undefined as unknown as PluginRuntime);
+  });
+
+  it("classifies mixed-case image content types as MsgType.Image", () => {
+    installRuntimeWithRealMediaKind();
+    expect(resolveMatrixMsgType("Image/PNG")).toBe(MsgType.Image);
+  });
+
+  it("classifies mixed-case audio content types as MsgType.Audio", () => {
+    installRuntimeWithRealMediaKind();
+    expect(resolveMatrixMsgType("Audio/Ogg")).toBe(MsgType.Audio);
+  });
+
+  it("classifies mixed-case video content types as MsgType.Video", () => {
+    installRuntimeWithRealMediaKind();
+    expect(resolveMatrixMsgType("Video/MP4")).toBe(MsgType.Video);
+  });
+
+  it("keeps lowercase image content types as MsgType.Image (regression)", () => {
+    installRuntimeWithRealMediaKind();
+    expect(resolveMatrixMsgType("image/png")).toBe(MsgType.Image);
+  });
+});

--- a/extensions/matrix/src/matrix/send/formatting.ts
+++ b/extensions/matrix/src/matrix/send/formatting.ts
@@ -1,4 +1,5 @@
 // Matrix helper module supports formatting behavior.
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { getMatrixRuntime } from "../../runtime.js";
 import {
   markdownToMatrixHtml,
@@ -157,7 +158,10 @@ export function buildThreadRelation(threadId: string, replyToId?: string): Matri
 }
 
 export function resolveMatrixMsgType(contentType?: string, _fileName?: string): MatrixMediaMsgType {
-  const kind = getCore().media.mediaKindFromMime(contentType ?? "");
+  // MIME types are case-insensitive (RFC 2045 §5.1); the outbound contentType can be a raw
+  // HTTP Content-Type header, so lowercase before the case-sensitive mediaKindFromMime prefix
+  // checks or mixed-case image/audio/video would misclassify and degrade to MsgType.File.
+  const kind = getCore().media.mediaKindFromMime(normalizeLowercaseStringOrEmpty(contentType));
   switch (kind) {
     case "image":
       return MsgType.Image;


### PR DESCRIPTION
## What Problem This Solves

Matrix outbound media picks the event `msgtype` from the media `contentType` without normalizing case, so it treats MIME types as case-sensitive. MIME types are case-insensitive (RFC 2045 §5.1), and this `contentType` can be a raw upstream HTTP `Content-Type` header (via `loadOutboundMediaFromUrl` → `loadWebMedia`, which passes the fetched header through for non-image media), so it can arrive in any case.

In `extensions/matrix/src/matrix/send/formatting.ts`, `resolveMatrixMsgType()` classifies every outbound media send via `mediaKindFromMime(contentType)` — the raw (non-normalizing) classifier, whose checks are `startsWith("image/")` / `"audio/"` / `"video/"`. So `Image/PNG`, `Audio/Ogg`, and `Video/MP4` match none of them, fall through to `undefined`, and the send degrades to a plain **file** (`MsgType.File`) instead of `MsgType.Image` / `Audio` / `Video`.

## Why This Change Was Made

This is the Matrix sibling of three fixes applying the same RFC 2045 rule:

- #102431 `fix(msteams): ...` (merged)
- #102753 `fix(qqbot): treat inbound attachment content types case-insensitively` (merged)
- #102820 `fix(feishu): treat outbound media content types case-insensitively` (open)

The fix case-normalizes `contentType` once at the single classification call using the SDK's `normalizeLowercaseStringOrEmpty` (already used across this plugin), which trims and lowercases the value (and yields `""` for nullish input, matching the previous `?? ""`). It does not strip MIME parameters, and it does not change any passthrough value — `resolveMatrixMsgType` returns only the `msgtype` enum, never the content type. `media.contentType` is untouched everywhere else (upload, `info.mimetype`, duration probe).

Normalizing here (rather than swapping in the normalizing `kindFromMime` wrapper) is the minimal correct fix: the runtime media surface injected into plugins exposes only the raw `mediaKindFromMime`, not `kindFromMime`, and this plugin reaches core media helpers only through that injected runtime — so a wrapper swap would require widening the shared plugin runtime contract. A single local normalize keeps the change inside the one affected function.

Scope is limited to this one classification site. It deliberately does not touch the core `mediaKindFromMime` helper (its raw-vs-normalizing split — `kindFromMime` wraps it with `normalizeMimeType` — is intentional), the separate `info.mimetype` header field, or any other channel.

Voice sends are already case-safe and are not changed: `resolveMatrixVoiceDecision` routes through the core `isVoiceCompatibleAudio`, which normalizes MIME case internally, and `send.ts` composes `msgtype = useVoice ? MsgType.Audio : baseMsgType`, so a voice-intent audio message is unaffected. The degrade this fixes is the msgtype classification of **non-voice** image / audio / video.

## User Impact

On Matrix, outbound media whose `contentType` uses non-lowercase casing now sends with the correct msgtype instead of degrading to a generic file: images render as images, audio as audio, video as video. Lowercase content types are unaffected. No config, schema, or API changes.

## Evidence

Real-behavior boundary capture — drives the shipped `resolveMatrixMsgType` and `resolveMatrixVoiceDecision`, composed exactly as `send.ts` composes them (`msgtype = useVoice ? MsgType.Audio : baseMsgType`), under `node --import tsx`. The matrix runtime is wired with the **real** core `mediaKindFromMime` and the **real** core `isVoiceCompatibleAudio` — no classifier is faked. A live Matrix homeserver send is not exercised (infeasible here); the classification below is the shipped code that selects the outgoing event's msgtype.

```
                                 contentType     before (unfixed)          after (fixed)
mixed-case image                 "Image/PNG"     msgtype=m.file            msgtype=m.image
mixed-case audio (non-voice)     "Audio/Ogg"     msgtype=m.file            msgtype=m.audio
mixed-case video                 "Video/MP4"     msgtype=m.file            msgtype=m.video
mixed-case audio (voice intent)  "Audio/Ogg"     msgtype=m.audio          msgtype=m.audio   (unchanged; already correct)
lowercase image (regression)     "image/png"     msgtype=m.image          msgtype=m.image   (unchanged)
```

Unit tests (`extensions/matrix/src/matrix/send/formatting.test.ts`, 4 added) drive `resolveMatrixMsgType` through the real core `mediaKindFromMime`: mixed-case image/audio/video → their proper MsgType, plus a lowercase-image regression. Reverting the production change fails exactly the three mixed-case tests and leaves the lowercase one green.

Local: matrix extension prod + test typecheck clean (`tsgo:extensions`, `tsgo:test:extensions`); `oxfmt` clean; targeted matrix formatting suite green. Full `check:changed` (extension prod + extension test lanes) runs on CI.
