### PR TITLE
fix(active-memory): keep timeout partial replies valid at emoji caps

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -3197,6 +3197,26 @@ describe("active-memory plugin", () => {
     expect(readFileSpy).not.toHaveBeenCalled();
   });
 
+  it("keeps partial assistant transcript caps UTF-16 safe", async () => {
+    const sessionFile = path.join(stateDir, "surrogate-timeout-transcript.jsonl");
+    await writeTranscriptJsonl(sessionFile, [
+      {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: `${"a".repeat(38)}🎉TAILWORD`,
+        },
+      },
+    ]);
+
+    const result = await testing.readPartialAssistantText(sessionFile, {
+      maxChars: 39,
+      maxLines: 10,
+    });
+
+    expect(result).toBe("a".repeat(38));
+  });
+
   it("skips malformed JSONL lines when reading partial assistant transcripts", async () => {
     const sessionFile = path.join(stateDir, "malformed-timeout-transcript.jsonl");
     await fs.mkdir(path.dirname(sessionFile), { recursive: true });

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -2251,7 +2251,7 @@ async function readPartialAssistantText(
         if (remaining <= 0) {
           return true;
         }
-        const nextText = text.slice(0, remaining);
+        const nextText = truncateUtf16Safe(text, remaining);
         texts.push(nextText);
         collectedChars += separatorChars + nextText.length;
         return collectedChars >= resolvedLimits.maxChars;
@@ -2259,12 +2259,13 @@ async function readPartialAssistantText(
       return false;
     },
   });
-  const joined = texts
-    .map((text) => text.trim())
-    .filter(Boolean)
-    .join("\n")
-    .slice(0, resolvedLimits.maxChars)
-    .trim();
+  const joined = truncateUtf16Safe(
+    texts
+      .map((text) => text.trim())
+      .filter(Boolean)
+      .join("\n"),
+    resolvedLimits.maxChars,
+  ).trim();
   return joined || null;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where active-memory timeout recovery could attach a partial assistant transcript containing a broken UTF-16 surrogate when the transcript cap lands inside an emoji or other surrogate-pair character.

## Why This Change Was Made

The partial transcript reader now applies the same UTF-16-safe truncation used by other active-memory text caps before storing or returning bounded assistant text. The fix stays limited to partial assistant transcript collection and does not change transcript parsing, memory search behavior, or summary generation.

## User Impact

Users who hit active-memory timeout recovery can expect partial assistant replies to remain valid text instead of exposing replacement characters or malformed emoji boundaries in the recovered timeout context.

## Evidence

- Confirmed `origin/main` still used raw `slice(0, remaining)` and final joined `slice(0, resolvedLimits.maxChars)` in `readPartialAssistantText`; #102877 only covered the recent-turn recall query path.
- Searched open PRs for `readPartialAssistantText`, `activeMemoryPartialReply`, `partial assistant`, `surrogate`, and `UTF-16`; no open PR was covering this same problem.
- Focused validation:

  ```text
  $ node scripts/test-projects.mjs extensions/active-memory/index.test.ts -- --maxWorkers=1
  [test] starting test/vitest/vitest.extension-active-memory.config.ts
  The `envFile` option is deprecated, please use `envDir: false` instead.

   RUN  v4.1.9 [local path redacted]

  [vitest] still running with no output for 30000ms (test/vitest/vitest.extension-active-memory.config.ts).
  [vitest] still running with no output for 60000ms (test/vitest/vitest.extension-active-memory.config.ts).

   Test Files  1 passed (1)
        Tests  159 passed (159)
     Start at  22:32:25
     Duration  84.80s (transform 32.74s, setup 1.14s, import 39.72s, tests 43.52s, environment 0ms)

  [test] passed 1 Vitest shard in 96.46s
  ```
