### PR TITLE
fix(google): bound Gemini batch output file download to prevent OOM

### DIFF
--- a/extensions/google/embedding-batch.test.ts
+++ b/extensions/google/embedding-batch.test.ts
@@ -70,13 +70,13 @@ function singleRequest(): GeminiBatchRequest[] {
   ];
 }
 
-function makeOversizedResponse(): {
+function makeOversizedResponse(mib = 20): {
   response: Response;
   getReadCount: () => number;
   wasCanceled: () => boolean;
 } {
   const chunkSize = 1024 * 1024;
-  const chunkCount = 20; // 20 MiB — over 16 MiB cap
+  const chunkCount = mib;
   let readCount = 0;
   let canceled = false;
   return {
@@ -197,6 +197,53 @@ describe("Google embedding-batch bounded JSON reads", () => {
 
     expect(streamed.wasCanceled()).toBe(true);
     expect(streamed.getReadCount()).toBeLessThan(20);
+  });
+
+  it("bounds oversized file download JSONL response and cancels the stream", async () => {
+    // 257 MiB exceeds the 256 MiB GEMINI_BATCH_OUTPUT_MAX_BYTES cap.
+    const streamed = makeOversizedResponse(257);
+    let statusCalled = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = fetchInputUrl(input);
+        if (url.includes("/upload/")) {
+          return jsonResponse({ name: "files/f-ok" });
+        }
+        if (url.includes(":asyncBatchEmbedContent")) {
+          return jsonResponse({ name: "batches/b-0", state: "PENDING" });
+        }
+        if (url.includes("/batches/") && !statusCalled) {
+          statusCalled = true;
+          return jsonResponse({
+            name: "batches/b-0",
+            state: "SUCCEEDED",
+            outputConfig: { file: "files/out-0" },
+          });
+        }
+        if (url.includes(":download")) {
+          return streamed.response;
+        }
+        return new Response("unexpected", { status: 500 });
+      }),
+    );
+
+    await expect(
+      runGeminiEmbeddingBatches({
+        gemini: makeGeminiClient(),
+        agentId: "main",
+        requests: singleRequest(),
+        wait: true,
+        concurrency: 1,
+        pollIntervalMs: 50,
+        timeoutMs: 30_000,
+      }),
+    ).rejects.toThrow(/Gemini batch output file too large/);
+
+    // The overflow was detected at the 257th chunk (256 MiB cap reached).
+    // readResponseWithLimit cancelled the reader; the cap prevented unbounded
+    // reading past the limit.
+    expect(streamed.getReadCount()).toBe(257);
   });
 
   it("parses small responses on all three JSON paths correctly", async () => {

--- a/extensions/google/embedding-batch.ts
+++ b/extensions/google/embedding-batch.ts
@@ -13,6 +13,7 @@ import {
   createProviderHttpError,
   readProviderJsonResponse,
 } from "openclaw/plugin-sdk/provider-http";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { GeminiEmbeddingClient, GeminiTextEmbeddingRequest } from "./embedding-provider.js";
 
@@ -54,6 +55,7 @@ type GeminiBatchOutputLine = {
 };
 
 const GEMINI_BATCH_MAX_REQUESTS = 50000;
+const GEMINI_BATCH_OUTPUT_MAX_BYTES = 256 * 1024 * 1024;
 function hashText(text: string): string {
   return crypto.createHash("sha256").update(text).digest("hex");
 }
@@ -205,6 +207,7 @@ async function fetchGeminiBatchStatus(params: {
 async function fetchGeminiFileContent(params: {
   gemini: GeminiEmbeddingClient;
   fileId: string;
+  maxBytes?: number;
 }): Promise<string> {
   const baseUrl = normalizeBatchBaseUrl(params.gemini);
   const file = params.fileId.startsWith("files/") ? params.fileId : `files/${params.fileId}`;
@@ -220,7 +223,14 @@ async function fetchGeminiFileContent(params: {
       if (!res.ok) {
         throw await createProviderHttpError(res, "gemini batch file content failed");
       }
-      return await res.text();
+      const maxBytes = params.maxBytes ?? GEMINI_BATCH_OUTPUT_MAX_BYTES;
+      const buffer = await readResponseWithLimit(res, maxBytes, {
+        onOverflow: ({ size, maxBytes: limit }) =>
+          new Error(
+            `Gemini batch output file too large: ${size} bytes (limit: ${limit} bytes). Reduce batch size or increase the limit.`,
+          ),
+      });
+      return buffer.toString("utf8");
     },
   });
 }


### PR DESCRIPTION
## What Problem This Solves

Gemini batch embedding output file downloads could read an unbounded response body into memory, causing Node.js out-of-memory crashes when the batch is large. With `GEMINI_BATCH_MAX_REQUESTS=50000` and 3072-dim embeddings, the output file can reach ~600MB.

## Why This Change Was Made

The same file already uses `readProviderJsonResponse` (which wraps `readResponseWithLimit`) for the upload, batch-create, and batch-status HTTP responses — all three have bounded reads. `fetchGeminiFileContent` (the download path) was the only one using bare `res.text()` without any size limit. This change aligns the download path with the existing pattern by replacing `res.text()` with `readResponseWithLimit` and a 256MB cap.

## User Impact

Gemini batch embedding no longer risks OOM on large output file downloads. If a batch output file exceeds 256MB, the user gets a clear error: "Gemini batch output file too large" with instructions to reduce batch size. Normal-sized batches (up to ~42K items with 768-dim embeddings) continue to work without change.

## Evidence

- **Real environment tested**: local Linux Node.js v22.19.0, `fix/gemini-batch-download-oom-bound` branch
- **Exact commands**:

```bash
node --import tsx -e '...real loopback server that streams 300MB...'
```

- **Evidence after fix**:

```console
=== NEGATIVE CONTROL: bare res.text() (old behavior) ===
Requesting 300 MB from local server...
Read 314572800 chars in 1429 ms
RSS memory: before=111 MB, after=1028 MB, delta=917 MB
→ 300MB loaded into memory (OOM risk with larger files)

=== WITH CAP (new behavior) ===
Server on port 45057 | Response: 300 MB | Cap: 256 MB
BOUNDED: Cap triggered at 268435456 bytes
Stream was cancelled, memory spike prevented
```

- **Observed result after fix**: The 300MB test response is capped at 256MB with an appropriate error, instead of loading 917MB RSS. The stream is cancelled at the cap boundary.
- **What was not tested**: real Gemini API traffic (the fix only affects the download body read path, which is exercised by any batch completion)

### Real behavior proof

A local `node:http` loopback server serves a 300MB response on the batch download URL path. Before fix, `res.text()` loads the entire 300MB (+917MB RSS). After fix, `readResponseWithLimit` cancels the stream at 256MB, preventing unbounded memory growth.

### Regression test plan

```bash
pnpm test extensions/google/embedding-batch.test.ts
```

Regression: 4 existing tests continue to pass (upload, batch-create, batch-status oversized + happy path). New test verifies the download path bounded read.

---

AI-assisted.
