### PR TITLE
fix(ui): prevent heredoc body content from being parsed as commands (#102875)

### DIFF
--- a/src/agents/tool-display-exec-shell.ts
+++ b/src/agents/tool-display-exec-shell.ts
@@ -252,8 +252,8 @@ export function scanTopLevelChars(
 
     if (heredocDelimiter !== undefined && heredocBodyStartIndex !== undefined && i >= heredocBodyStartIndex) {
       const newlineAfterHeredoc = command.indexOf("\n", i);
-      let lineEnd = newlineAfterHeredoc !== -1 ? newlineAfterHeredoc : command.length;
-      let lineContent = command.slice(i, lineEnd).trimEnd();
+      const lineEnd = newlineAfterHeredoc !== -1 ? newlineAfterHeredoc : command.length;
+      const lineContent = command.slice(i, lineEnd).trimEnd();
 
       if (lineContent === heredocDelimiter) {
         heredocDelimiter = undefined;

--- a/src/agents/tool-display-exec-shell.ts
+++ b/src/agents/tool-display-exec-shell.ts
@@ -243,9 +243,34 @@ export function scanTopLevelChars(
 ): void {
   let quote: '"' | "'" | undefined;
   let escaped = false;
+  let heredocDelimiter: string | undefined;
+  let heredocBodyStartIndex: number | undefined;
+  let heredocEndIndex: number | undefined;
 
   for (let i = 0; i < command.length; i += 1) {
     const char = command[i];
+
+    if (heredocDelimiter !== undefined && heredocBodyStartIndex !== undefined && i >= heredocBodyStartIndex) {
+      const newlineAfterHeredoc = command.indexOf("\n", i);
+      let lineEnd = newlineAfterHeredoc !== -1 ? newlineAfterHeredoc : command.length;
+      let lineContent = command.slice(i, lineEnd).trimEnd();
+
+      if (lineContent === heredocDelimiter) {
+        heredocDelimiter = undefined;
+        heredocBodyStartIndex = undefined;
+        heredocEndIndex = undefined;
+        i = lineEnd;
+        continue;
+      }
+      i = lineEnd;
+      continue;
+    }
+
+    if (i < (heredocEndIndex ?? -1)) {
+      i = (heredocEndIndex ?? i) - 1;
+      heredocEndIndex = undefined;
+      continue;
+    }
 
     if (escaped) {
       escaped = false;
@@ -268,10 +293,118 @@ export function scanTopLevelChars(
       continue;
     }
 
+    if (heredocDelimiter === undefined && char === "<" && command[i + 1] === "<" && command[i + 2] !== "<") {
+      const stripTabs = command[i + 2] === "-";
+      const delimiterStart = i + (stripTabs ? 3 : 2);
+      const delimiter = parseHeredocDelimiter(command, delimiterStart);
+      if (delimiter) {
+        heredocDelimiter = delimiter;
+        const newlineIndex = command.indexOf("\n", delimiterStart);
+        if (newlineIndex !== -1) {
+          heredocBodyStartIndex = newlineIndex + 1;
+        }
+        const heredocEnd = findHeredocDelimiterEnd(command, delimiterStart);
+        heredocEndIndex = heredocEnd !== undefined ? heredocEnd + 1 : delimiterStart + delimiter.length;
+        i = heredocEndIndex - 1;
+        continue;
+      }
+    }
+
     if (visit(char, i) === false) {
       return;
     }
   }
+}
+
+function findHeredocDelimiterEnd(command: string, start: number): number | undefined {
+  let index = start;
+  while (index < command.length && /\s/u.test(command[index] ?? "")) {
+    index += 1;
+  }
+
+  let quote: '"' | "'" | undefined;
+
+  while (index < command.length) {
+    const char = command[index] ?? "";
+
+    if (quote) {
+      if (char === quote) {
+        return index;
+      }
+      if (quote === '"' && char === "\\" && index + 1 < command.length) {
+        index += 2;
+        continue;
+      }
+      index += 1;
+      continue;
+    }
+
+    if (/[\s;&|<>]/u.test(char)) {
+      return index - 1;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      index += 1;
+      continue;
+    }
+    if (char === "\\" && index + 1 < command.length) {
+      index += 2;
+      continue;
+    }
+    index += 1;
+  }
+
+  return undefined;
+}
+
+function parseHeredocDelimiter(command: string, start: number): string | undefined {
+  let index = start;
+  while (index < command.length && /\s/u.test(command[index] ?? "")) {
+    index += 1;
+  }
+
+  let value = "";
+  let quote: '"' | "'" | undefined;
+
+  while (index < command.length) {
+    const char = command[index] ?? "";
+
+    if (quote) {
+      if (char === quote) {
+        quote = undefined;
+        index += 1;
+        continue;
+      }
+      if (quote === '"' && char === "\\" && index + 1 < command.length) {
+        index += 1;
+        value += command[index] ?? "";
+        index += 1;
+        continue;
+      }
+      value += char;
+      index += 1;
+      continue;
+    }
+
+    if (/[\s;&|<>]/u.test(char)) {
+      break;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      index += 1;
+      continue;
+    }
+    if (char === "\\" && index + 1 < command.length) {
+      index += 1;
+      value += command[index] ?? "";
+      index += 1;
+      continue;
+    }
+    value += char;
+    index += 1;
+  }
+
+  return value || undefined;
 }
 
 /** Splits a command on top-level stage separators such as `;`, `&&`, and `||`. */

--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -12,7 +12,6 @@ import {
   firstPositional,
   optionValue,
   positionalArgs,
-  scanTopLevelChars,
   splitShellWords,
   splitTopLevelPipes,
   splitTopLevelStages,

--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -307,18 +307,18 @@ type HeredocTerminator = {
 
 function collectHeredocTerminators(commandLine: string): HeredocTerminator[] {
   const terminators: HeredocTerminator[] = [];
-  scanTopLevelChars(commandLine, (char, index) => {
-    if (char !== "<" || commandLine[index + 1] !== "<" || commandLine[index + 2] === "<") {
-      return true;
+  for (let i = 0; i < commandLine.length; i += 1) {
+    const char = commandLine[i];
+    if (char !== "<" || commandLine[i + 1] !== "<" || commandLine[i + 2] === "<") {
+      continue;
     }
 
-    const stripLeadingTabs = commandLine[index + 2] === "-";
-    const parsed = parseHeredocTerminator(commandLine, index + (stripLeadingTabs ? 3 : 2));
+    const stripTabs = commandLine[i + 2] === "-";
+    const parsed = parseHeredocTerminator(commandLine, i + (stripTabs ? 3 : 2));
     if (parsed) {
-      terminators.push({ value: parsed, stripLeadingTabs });
+      terminators.push({ value: parsed, stripLeadingTabs: stripTabs });
     }
-    return true;
-  });
+  }
   return terminators;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes #102875: The tool-status footer was rendering heredoc body content (e.g., email body text) as failed commands, confusing operators and causing false incident reports.

**Example:** When an agent ran:
```bash
cat > file.txt <<EOF
Buenos dias equipo;
se ajusta la orden A1251718: sc-carwhi(100)
Gracias.
EOF
./scripts/send
```

The Telegram footer showed:
```
⚠️ 🛠 create folder → show > → run sc-carwhi(100) → Gracias. failed
```

Operators interpreted this as a broken/hallucinating agent, when the turn actually succeeded.

## Why This Change Was Made

The `scanTopLevelChars` function in `src/agents/tool-display-exec-shell.ts:240` tracked quotes but not heredocs, so semicolons and other shell metacharacters inside heredoc bodies were incorrectly treated as command separators.

## User Impact

- ✅ Heredoc body content no longer appears as phantom failed commands
- ✅ Operators see accurate command summaries
- ✅ No information leak of heredoc payload content in collapsed tool results

## Evidence

### Unit Tests
```
✓ All 48 tests in src/agents/tool-display*.test.ts pass
```

### Manual Verification
```bash
# Test case from issue #102875
resolveExecDetail({ command: `mkdir -p .openclaw/tmp/farm-notices
cat > .openclaw/tmp/farm-notices/ventura.txt <<EOF
Buenos dias equipo;
sc-carwhi(100)
Gracias.
EOF
./scripts/email_preview_new && ./scripts/email_preview_new` })

# Result: "create folder .openclaw/tmp/farm-notices → show > → run email_preview_new → run email_preview_new"
# ✓ No "sc-carwhi(100)" or "Gracias." as separate commands
```

### Files Changed
- `src/agents/tool-display-exec-shell.ts`: +133 lines (heredoc detection and skipping logic)
- `src/agents/tool-display-exec.ts`: +8 lines (collectHeredocTerminators direct scanning)

### Testing Commands
```bash
pnpm test src/agents/tool-display*.test.ts
# Result: Test Files 2 passed (2), Tests 48 passed (48)
```