### PR TITLE
fix(synology-chat): strip internal tool-trace banners from outbound text

### DIFF
--- a/extensions/synology-chat/src/channel.test.ts
+++ b/extensions/synology-chat/src/channel.test.ts
@@ -558,7 +558,7 @@ describe("createSynologyChatPlugin", () => {
     it("sanitizeText strips internal tool-trace banners from outbound text", () => {
       const plugin = createSynologyChatPlugin();
       const sanitizeText = plugin.outbound.sanitizeText;
-      if (!sanitizeText) throw new Error("sanitizeText not defined");
+      if (!sanitizeText) { throw new Error("sanitizeText not defined"); }
 
       const text = "Done.\n⚠️ 🛠️ `search repos (agent)` failed";
       const result = sanitizeText({ text, payload: { text } });
@@ -574,7 +574,7 @@ describe("createSynologyChatPlugin", () => {
     it("sanitizeText returns empty string for trace-only replies", () => {
       const plugin = createSynologyChatPlugin();
       const sanitizeText = plugin.outbound.sanitizeText;
-      if (!sanitizeText) throw new Error("sanitizeText not defined");
+      if (!sanitizeText) { throw new Error("sanitizeText not defined"); }
 
       const traceOnly = "⚠️ 🛠️ `search repos (agent)` failed";
       const result = sanitizeText({ text: traceOnly, payload: { text: traceOnly } });

--- a/extensions/synology-chat/src/channel.test.ts
+++ b/extensions/synology-chat/src/channel.test.ts
@@ -554,6 +554,32 @@ describe("createSynologyChatPlugin", () => {
         }),
       ).rejects.toThrow("not configured");
     });
+
+    it("sanitizeText strips internal tool-trace banners from outbound text", () => {
+      const plugin = createSynologyChatPlugin();
+      const sanitizeText = plugin.outbound.sanitizeText;
+      if (!sanitizeText) throw new Error("sanitizeText not defined");
+
+      const text = "Done.\n⚠️ 🛠️ `search repos (agent)` failed";
+      const result = sanitizeText({ text, payload: { text } });
+      expect(result).not.toContain("⚠️");
+      expect(result).not.toContain("`search repos (agent)` failed");
+      expect(result).toContain("Done.");
+
+      const prose = "The pipeline has 3 open deals.";
+      const proseResult = sanitizeText({ text: prose, payload: { text: prose } });
+      expect(proseResult).toBe(prose);
+    });
+
+    it("sanitizeText returns empty string for trace-only replies", () => {
+      const plugin = createSynologyChatPlugin();
+      const sanitizeText = plugin.outbound.sanitizeText;
+      if (!sanitizeText) throw new Error("sanitizeText not defined");
+
+      const traceOnly = "⚠️ 🛠️ `search repos (agent)` failed";
+      const result = sanitizeText({ text: traceOnly, payload: { text: traceOnly } });
+      expect(result?.trim()).toBe("");
+    });
   });
 
   describe("gateway", () => {

--- a/extensions/synology-chat/src/channel.test.ts
+++ b/extensions/synology-chat/src/channel.test.ts
@@ -556,29 +556,22 @@ describe("createSynologyChatPlugin", () => {
     });
 
     it("sanitizeText strips internal tool-trace banners from outbound text", () => {
-      const plugin = createSynologyChatPlugin();
-      const sanitizeText = plugin.outbound.sanitizeText;
-      if (!sanitizeText) { throw new Error("sanitizeText not defined"); }
-
       const text = "Done.\n⚠️ 🛠️ `search repos (agent)` failed";
-      const result = sanitizeText({ text, payload: { text } });
-      expect(result).not.toContain("⚠️");
-      expect(result).not.toContain("`search repos (agent)` failed");
-      expect(result).toContain("Done.");
+      const sanitizeText = createSynologyChatPlugin().outbound.sanitizeText;
+      expect(sanitizeText({ text, payload: { text } })).toBe("Done.");
 
       const prose = "The pipeline has 3 open deals.";
-      const proseResult = sanitizeText({ text: prose, payload: { text: prose } });
-      expect(proseResult).toBe(prose);
+      expect(sanitizeText({ text: prose, payload: { text: prose } })).toBe(prose);
     });
 
     it("sanitizeText returns empty string for trace-only replies", () => {
-      const plugin = createSynologyChatPlugin();
-      const sanitizeText = plugin.outbound.sanitizeText;
-      if (!sanitizeText) { throw new Error("sanitizeText not defined"); }
-
       const traceOnly = "⚠️ 🛠️ `search repos (agent)` failed";
-      const result = sanitizeText({ text: traceOnly, payload: { text: traceOnly } });
-      expect(result?.trim()).toBe("");
+      expect(
+        createSynologyChatPlugin().outbound.sanitizeText({
+          text: traceOnly,
+          payload: { text: traceOnly },
+        }),
+      ).toBe("");
     });
   });
 

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -12,6 +12,7 @@ import {
 } from "openclaw/plugin-sdk/channel-config-helpers";
 import { createChatChannelPlugin, type ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import { waitUntilAbort } from "openclaw/plugin-sdk/channel-outbound";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import {
   createMessageReceiptFromOutboundResults,
   defineChannelMessageAdapter,
@@ -441,7 +442,7 @@ export function createSynologyChatPlugin(): SynologyChatPlugin {
     outbound: {
       deliveryMode: "gateway" as const,
       textChunkLimit: 2000,
-
+      sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
       sendText: sendSynologyChatText,
       sendMedia: async (ctx) => {
         if (!ctx.mediaUrl) {

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -10,9 +10,9 @@ import {
   createHybridChannelConfigAdapter,
   createScopedDmSecurityResolver,
 } from "openclaw/plugin-sdk/channel-config-helpers";
+import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/channel-contract";
 import { createChatChannelPlugin, type ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import { waitUntilAbort } from "openclaw/plugin-sdk/channel-outbound";
-import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import {
   createMessageReceiptFromOutboundResults,
   defineChannelMessageAdapter,
@@ -31,6 +31,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeStringEntriesLower,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { listAccountIds, resolveAccount } from "./accounts.js";
 import { synologyChatApprovalAuth } from "./approval-auth.js";
 import { sendMessage, sendFileUrl } from "./client.js";
@@ -181,7 +182,7 @@ type SynologyChatPlugin = Omit<
   outbound: {
     deliveryMode: "gateway";
     textChunkLimit: number;
-    sanitizeText?: (params: { text: string; payload: { text: string } }) => string;
+    sanitizeText: NonNullable<ChannelOutboundAdapter["sanitizeText"]>;
     sendText: (ctx: SynologyChannelSendTextContext) => Promise<SynologyChatOutboundResult>;
     sendMedia: (ctx: SynologyChannelSendMediaContext) => Promise<SynologyChatOutboundResult>;
   };

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -181,6 +181,7 @@ type SynologyChatPlugin = Omit<
   outbound: {
     deliveryMode: "gateway";
     textChunkLimit: number;
+    sanitizeText?: (params: { text: string; payload: { text: string } }) => string;
     sendText: (ctx: SynologyChannelSendTextContext) => Promise<SynologyChatOutboundResult>;
     sendMedia: (ctx: SynologyChannelSendMediaContext) => Promise<SynologyChatOutboundResult>;
   };


### PR DESCRIPTION
Part of #90684

## What Problem This Solves

Synology Chat outbound delivery omitted the channel sanitizer hook, so internal assistant tool-trace banners such as “⚠️ 🛠️ search repos (agent) failed” could reach end users. A trace-only reply was also sent as a standalone webhook message.

## Why This Change Was Made

The Synology Chat outbound adapter now uses the canonical `sanitizeAssistantVisibleText` hook before transport, matching the existing channel-owned delivery contract. The adapter type reuses `ChannelOutboundAdapter["sanitizeText"]` instead of maintaining a narrower local callback shape that could drift from `ReplyPayload`.

This is the narrowest correct owner boundary: the shared durable-delivery pipeline invokes the explicit channel hook, then drops payloads that become empty before platform I/O. A global default would change channels that intentionally preserve different text, while sanitizing inside the HTTP client would be too late and would duplicate delivery policy.

## User Impact

- Mixed replies keep visible prose and remove internal tool-trace banners.
- Trace-only replies produce no Synology webhook request.
- Normal prose is unchanged.

## Evidence

- Exact rewritten head: `a416d86e0d6caafbec575c6f838b6462ae424bd3`.
- Blacksmith Testbox `tbx_01kx56yss8pk3ze695em4bz009` (`harbor-barnacle`), Linux Node 24.
- Real local Gateway + actual `openclaw message send --channel synology-chat` + real HTTP webhook capture:
  - current `main` posted all three inputs verbatim: mixed prose/banner, trace-only banner, and normal prose;
  - rewritten head posted `Done.` and the unchanged normal prose;
  - rewritten head made no HTTP request for the trace-only payload.
- `pnpm test extensions/synology-chat/src/channel.test.ts extensions/synology-chat/src/client.test.ts` — 62/62 passed.
- Exact rewritten-head remote `check:changed` — passed, including TypeScript, extension/core lint, import cycles, package guards, and repository policy checks.
- Fresh autoreview — clean, no accepted/actionable findings (correctness confidence 0.98).

The environment has no Synology NAS webhook credentials or hardware, so the final dependency hop into a physical NAS was unavailable. The real Gateway, plugin loader, durable-delivery sanitizer/drop path, CLI client, Synology HTTP transport, recipient encoding, and webhook request were exercised end to end against a local endpoint. No screenshot is useful for this non-visual transport fix; the captured request bodies are the behavioral proof.
