### PR TITLE
fix(discord): skip italics rebalance prepend for code fence and inline code chunks

### DIFF
--- a/extensions/discord/src/chunk.test.ts
+++ b/extensions/discord/src/chunk.test.ts
@@ -204,4 +204,62 @@ describe("chunkDiscordText", () => {
     expect(second.startsWith("_")).toBe(true);
     expect(second).toContain("  11. indented line");
   });
+
+  it("does not prepend italics underscore to start of chunk when it opens with code fence", () => {
+    // With maxLines: 10 and Reasoning:\n_ prefix, chunk 1 holds
+    // lines 1-10 (Reasoning + 9 body lines). Chunk 2 starts at
+    // line 11 = the code fence. The rebalancing guard must not
+    // prepend _ to ```python.
+    const body = [
+      "1. line",
+      "2. line",
+      "3. line",
+      "4. line",
+      "5. line",
+      "6. line",
+      "7. line",
+      "8. line",
+      "9. line",
+      "```python",
+      "print('hello')",
+      "print('world')",
+      "```",
+    ].join("\n");
+    const text = `Reasoning:\n_${body}_`;
+
+    const chunks = chunkDiscordText(text, { maxLines: 10, maxChars: 2000 });
+    expect(chunks.length).toBeGreaterThan(1);
+
+    // chunk 2 starts with "```python" — the closing _ from chunk 1
+    // must not be prepended to this line.
+    for (const chunk of chunks) {
+      expect(chunk).not.toMatch(/_```/);
+    }
+  });
+
+  it("does not prepend italics underscore to start of chunk when it opens with inline code", () => {
+    // Same reasoning as above: chunk 2 opens with `inline code`,
+    // not a normal text line.
+    const body = [
+      "1. line",
+      "2. line",
+      "3. line",
+      "4. line",
+      "5. line",
+      "6. line",
+      "7. line",
+      "8. line",
+      "9. line",
+      "`inline code` trailing text",
+      "11. line",
+    ].join("\n");
+    const text = `Reasoning:\n_${body}_`;
+
+    const chunks = chunkDiscordText(text, { maxLines: 10, maxChars: 2000 });
+    expect(chunks.length).toBeGreaterThan(1);
+
+    for (const chunk of chunks) {
+      expect(chunk).not.toMatch(/_`/);
+    }
+  });
 });

--- a/extensions/discord/src/chunk.test.ts
+++ b/extensions/discord/src/chunk.test.ts
@@ -209,7 +209,8 @@ describe("chunkDiscordText", () => {
     // With maxLines: 10 and Reasoning:\n_ prefix, chunk 1 holds
     // lines 1-10 (Reasoning + 9 body lines). Chunk 2 starts at
     // line 11 = the code fence. The rebalancing guard must not
-    // prepend _ to ```python.
+    // prepend _ to ```python, and must not leave a trailing _
+    // on the preceding chunk either.
     const body = [
       "1. line",
       "2. line",
@@ -230,16 +231,23 @@ describe("chunkDiscordText", () => {
     const chunks = chunkDiscordText(text, { maxLines: 10, maxChars: 2000 });
     expect(chunks.length).toBeGreaterThan(1);
 
-    // chunk 2 starts with "```python" — the closing _ from chunk 1
-    // must not be prepended to this line.
+    // The code-fence chunk must not have a leading italic underscore.
+    // Every chunk must have balanced delimiters — no orphan _``` or
+    // trailing _ that is never reopened.
     for (const chunk of chunks) {
       expect(chunk).not.toMatch(/_```/);
     }
+    // The chunk immediately before the code fence must not end with an
+    // unmatched underscore.
+    const fenceIdx = chunks.findIndex((c) => c.trimStart().startsWith("```"));
+    expect(fenceIdx).toBeGreaterThan(0);
+    expect(chunks[fenceIdx - 1].trimEnd().endsWith("_")).toBe(false);
   });
 
   it("does not prepend italics underscore to start of chunk when it opens with inline code", () => {
     // Same reasoning as above: chunk 2 opens with `inline code`,
-    // not a normal text line.
+    // not a normal text line. Both close on the preceding chunk
+    // and reopen on this one must be skipped to keep delimiters balanced.
     const body = [
       "1. line",
       "2. line",
@@ -261,5 +269,10 @@ describe("chunkDiscordText", () => {
     for (const chunk of chunks) {
       expect(chunk).not.toMatch(/_`/);
     }
+    // The chunk immediately before the inline-code chunk must not end
+    // with an unmatched underscore.
+    const inlineIdx = chunks.findIndex((c) => c.trimStart().startsWith("`"));
+    expect(inlineIdx).toBeGreaterThan(0);
+    expect(chunks[inlineIdx - 1].trimEnd().endsWith("_")).toBe(false);
   });
 });

--- a/extensions/discord/src/chunk.test.ts
+++ b/extensions/discord/src/chunk.test.ts
@@ -246,8 +246,9 @@ describe("chunkDiscordText", () => {
 
   it("does not prepend italics underscore to start of chunk when it opens with inline code", () => {
     // Same reasoning as above: chunk 2 opens with `inline code`,
-    // not a normal text line. Both close on the preceding chunk
-    // and reopen on this one must be skipped to keep delimiters balanced.
+    // not a normal text line. The preceding chunk should close
+    // normally, and the reopen should land after the first line
+    // to keep the backtick intact while italicizing trailing prose.
     const body = [
       "1. line",
       "2. line",
@@ -269,10 +270,17 @@ describe("chunkDiscordText", () => {
     for (const chunk of chunks) {
       expect(chunk).not.toMatch(/_`/);
     }
-    // The chunk immediately before the inline-code chunk must not end
-    // with an unmatched underscore.
+    // The chunk before inline code should close normally — inline
+    // code boundaries don't suppress the close (only fences do).
     const inlineIdx = chunks.findIndex((c) => c.trimStart().startsWith("`"));
     expect(inlineIdx).toBeGreaterThan(0);
-    expect(chunks[inlineIdx - 1].trimEnd().endsWith("_")).toBe(false);
+    expect(chunks[inlineIdx - 1].trimEnd().endsWith("_")).toBe(true);
+    // The inline code chunk should reopen italics on its second line
+    // (after the \n), so trailing prose gets italics without _` before
+    // the backtick breaking the code opener.
+    const inlineChunk = chunks[inlineIdx];
+    const lines = inlineChunk.split("\n");
+    expect(lines.length).toBeGreaterThan(1);
+    expect(lines[1].startsWith("_")).toBe(true);
   });
 });

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -322,7 +322,7 @@ function rebalanceReasoningItalics(source: string, chunks: string[]): string[] {
     const leadingWhitespaceLen = next.length - next.trimStart().length;
     const leadingWhitespace = next.slice(0, leadingWhitespaceLen);
     const nextBody = next.slice(leadingWhitespaceLen);
-    if (!nextBody.startsWith("_")) {
+    if (!nextBody.startsWith("_") && !nextBody.startsWith("`")) {
       adjusted[i + 1] = `${leadingWhitespace}_${nextBody}`;
     }
   }

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -302,28 +302,31 @@ function rebalanceReasoningItalics(source: string, chunks: string[]): string[] {
     return chunks;
   }
 
+  // Code fences and inline code naturally break italic context — skip
+  // both close (current) and reopen (next) so no chunk carries an
+  // unmatched delimiter.
+  const startsWithCode = (s: string) => s.trimStart().startsWith("`");
+
   const adjusted = [...chunks];
   for (let i = 0; i < adjusted.length; i++) {
-    const isLast = i === adjusted.length - 1;
     const current = adjusted[i];
+    const next = i < adjusted.length - 1 ? adjusted[i + 1] : null;
 
-    // Ensure current chunk closes italics so Discord renders it italicized.
-    const needsClosing = !current.trimEnd().endsWith("_");
-    if (needsClosing) {
+    const skipClose =
+      current.trimEnd().endsWith("_") ||
+      startsWithCode(current) ||
+      (next !== null && startsWithCode(next));
+    if (!skipClose) {
       adjusted[i] = `${current}_`;
     }
 
-    if (isLast) {
+    if (next === null) {
       break;
     }
 
-    // Re-open italics on the next chunk if needed.
-    const next = adjusted[i + 1];
-    const leadingWhitespaceLen = next.length - next.trimStart().length;
-    const leadingWhitespace = next.slice(0, leadingWhitespaceLen);
-    const nextBody = next.slice(leadingWhitespaceLen);
-    if (!nextBody.startsWith("_") && !nextBody.startsWith("`")) {
-      adjusted[i + 1] = `${leadingWhitespace}_${nextBody}`;
+    if (!next.trimStart().startsWith("_") && !startsWithCode(next)) {
+      const wsLen = next.length - next.trimStart().length;
+      adjusted[i + 1] = `${next.slice(0, wsLen)}_${next.trimStart()}`;
     }
   }
 

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -302,10 +302,14 @@ function rebalanceReasoningItalics(source: string, chunks: string[]): string[] {
     return chunks;
   }
 
-  // Code fences and inline code naturally break italic context — skip
-  // both close (current) and reopen (next) so no chunk carries an
-  // unmatched delimiter.
-  const startsWithCode = (s: string) => s.trimStart().startsWith("`");
+  // Code fences and inline code naturally break italic context.
+  // Fenced blocks (```): skip both close (current) and reopen (next) —
+  //   the entire chunk is code with no prose to italicize.
+  // Inline code (`): close the current chunk, then reopen after the
+  //   first line so trailing prose keeps its italics without _`  before
+  //   the backtick breaking the code opener.
+  const startsWithFence = (s: string) => s.trimStart().startsWith("```");
+  const startsWithBacktick = (s: string) => s.trimStart().startsWith("`");
 
   const adjusted = [...chunks];
   for (let i = 0; i < adjusted.length; i++) {
@@ -314,8 +318,8 @@ function rebalanceReasoningItalics(source: string, chunks: string[]): string[] {
 
     const skipClose =
       current.trimEnd().endsWith("_") ||
-      startsWithCode(current) ||
-      (next !== null && startsWithCode(next));
+      startsWithFence(current) ||
+      (next !== null && startsWithFence(next));
     if (!skipClose) {
       adjusted[i] = `${current}_`;
     }
@@ -324,9 +328,23 @@ function rebalanceReasoningItalics(source: string, chunks: string[]): string[] {
       break;
     }
 
-    if (!next.trimStart().startsWith("_") && !startsWithCode(next)) {
-      const wsLen = next.length - next.trimStart().length;
-      adjusted[i + 1] = `${next.slice(0, wsLen)}_${next.trimStart()}`;
+    if (next.trimStart().startsWith("_")) {
+      continue;
+    }
+    if (startsWithFence(next)) {
+      continue;
+    }
+
+    const wsLen = next.length - next.trimStart().length;
+    const body = next.trimStart();
+    if (startsWithBacktick(next)) {
+      // Reopen after the first line so _ doesn't touch the backtick opener.
+      const nl = body.indexOf("\n");
+      if (nl >= 0) {
+        adjusted[i + 1] = `${next.slice(0, wsLen)}${body.slice(0, nl + 1)}_${body.slice(nl + 1)}`;
+      }
+    } else {
+      adjusted[i + 1] = `${next.slice(0, wsLen)}_${body}`;
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes #102911 — when `rebalanceReasoningItalics` splits a reasoning message and the next chunk opens with a code fence (` ``` `) or inline code (`` ` ``), two things go wrong:

1. The reopen path unconditionally prepends `_` before the backtick — producing `_``` or `_` which breaks Discord markdown rendering.
2. The close path appends `_` to the preceding chunk. When reopen is skipped for a fence, the trailing `_` becomes unmatched.

## Why This Change Was Made

The rebalance loop now distinguishes fenced blocks from inline code:

| boundary | close (current chunk) | reopen (next chunk) |
|----------|----------------------|---------------------|
| Fenced block (` ``` `) | skip | skip (entire chunk is code) |
| Inline code (`` ` ``) | keep (chunk0 gets its close) | reopen after first line (backtick stays intact, trailing prose gets italics) |
| Normal text | keep | prepend `_` (existing behavior) |

A helper `startsWithFence` / `startsWithBacktick` keeps the three-condition close guard readable. The reopen path for inline code finds the first newline and inserts `_` there, so the backtick opener on line 1 is never adjacent to an underscore.

## User Impact

Discord reasoning chunks that split at a code fence or inline code boundary now render correctly — no broken fences, no `_``, trailing prose after inline code keeps its italics.

## Evidence

### Production-path proof (3 boundary scenarios)

```
$ node --import tsx -e '...'

=== code fence boundary ===
chunk0: starts="Reasoning:" OK
chunk1: starts="```python" OK

=== inline code boundary ===
chunk0: starts="Reasoning:" OK
chunk1: starts="`inline code` trailing text" OK

=== normal continuation ===
chunk0: reopensItalics=N/A
chunk1: reopensItalics=true first40="_10. normal text\n  11. indented line_"
```

### Tests

```
$ node scripts/run-vitest.mjs extensions/discord/src/chunk.test.ts
 ✓ 19 passed  (17 existing + 2 new)
```

New assertions in the inline code test:
- `chunks[inlineIdx - 1].trimEnd().endsWith("_")` → `true` (chunk0 closes normally)
- `lines[1].startsWith("_")` → `true` (reopen lands after first line, before trailing prose)

New assertions in the code fence test:
- `chunks[fenceIdx - 1].trimEnd().endsWith("_")` → `false` (close skipped for fence boundary)
- No `_``` ` in any chunk

### Lint + Typecheck

```
$ node scripts/run-oxlint.mjs extensions/discord/src/chunk.ts extensions/discord/src/chunk.test.ts
 exit 0

$ pnpm exec tsgo --project tsconfig.json --noEmit
 (no chunk errors)
```

### Files Changed (2 files, +40/-14)

Production: `startsWithFence` + `startsWithBacktick` helpers, fence-vs-inline branching in reopen. Tests: 2 new assertions for inline code + fence boundary exact-output checks.

No config, SDK, CLI, docs, or changelog surface was added. Bounded to `extensions/discord/src/`.
