### PR TITLE
fix(gateway): add abort listener to clean up queued chat turn on client disconnect

### DIFF
--- a/src/gateway/chat-queued-turns.test.ts
+++ b/src/gateway/chat-queued-turns.test.ts
@@ -219,4 +219,35 @@ describe("chat-queued-turns", () => {
     expect(b.signal.aborted).toBe(true);
     expect(map.size).toBe(0);
   });
+
+  it("cleans up the map entry when the abort signal fires (client disconnect)", () => {
+    const map = emptyMap();
+    const controller = new AbortController();
+    registerQueuedChatTurn({
+      chatQueuedTurns: map,
+      runId: "run-dc",
+      controller,
+      sessionId: "sess-dc",
+      sessionKey: "main",
+    });
+    expect(map.has("run-dc")).toBe(true);
+    controller.abort();
+    expect(map.has("run-dc")).toBe(false);
+  });
+
+  it("keeps a retired collect identity after abort (idempotency guard)", () => {
+    const map = emptyMap();
+    const controller = new AbortController();
+    registerQueuedChatTurn({
+      chatQueuedTurns: map,
+      runId: "run-retired",
+      controller,
+      sessionId: "sess-retired",
+      sessionKey: "main",
+    });
+    retireQueuedChatTurnCancellation(map, "run-retired");
+    expect(getQueuedChatTurn(map, "run-retired")?.abortable).toBe(false);
+    controller.abort();
+    expect(map.has("run-retired")).toBe(true);
+  });
 });

--- a/src/gateway/chat-queued-turns.ts
+++ b/src/gateway/chat-queued-turns.ts
@@ -63,6 +63,20 @@ export function registerQueuedChatTurn(params: RegisterQueuedChatTurnParams): bo
     ownerDeviceId: normalizeOptionalString(params.ownerDeviceId),
   };
   params.chatQueuedTurns.set(runId, entry);
+  // Defensive cleanup: the drain path normally calls completeQueuedChatTurn
+  // via the lifecycle callback, but a direct client-disconnect abort can
+  // fire before the followup ever reaches the drainer.  Retired collect
+  // identities (abortable: false) stay as idempotency guards.
+  params.controller.signal.addEventListener(
+    "abort",
+    () => {
+      const current = params.chatQueuedTurns.get(runId);
+      if (current?.controller === params.controller && current.abortable !== false) {
+        params.chatQueuedTurns.delete(runId);
+      }
+    },
+    { once: true },
+  );
   return true;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes #102914 — `registerQueuedChatTurn` did not register an abort listener on the AbortSignal. If a client disconnected and the followup never reached the queue drainer, the entry would leak in `chatQueuedTurns` until gateway restart.

## Why This Change Was Made

The drain path (`drain.ts`) normally calls `completeQueuedChatTurn` via the lifecycle callback when it detects an aborted signal. However, there is a window between registration and drain admission where a direct client-disconnect abort can fire without anyone checking the map. Registering a `{ once: true }` abort listener on the controller ensures the entry is cleaned up regardless of the drain state. The listener guards against removing retired collect identities (`abortable: false`) so idempotency protection is preserved.

The pattern matches existing defensive abort-listener usage elsewhere in the codebase (`command-queue.ts:350`, `process/exec.ts:614`, `channel-lifecycle.core.ts:116`).

## User Impact

Prevents a slow memory leak in the gateway when clients disconnect while queued chat turns are pending, without breaking idempotency for retired collect-mode entries.

## Evidence

### Real Gateway queue behavior proof

Run against the production `src/gateway/chat-queued-turns.ts` module:

```text
REAL_GATEWAY_QUEUE_PROOF commit=... surface=src/gateway/chat-queued-turns.ts
PASS queued_turn_registered {"runId":"proof-owner-abort","mapSize":1,"signalAborted":false}
PASS owner_abort_fired_and_entry_removed {"runId":"proof-owner-abort","mapSize":0,"signalAborted":true}
PASS stale_abort_did_not_remove_reused_run_id {"runId":"proof-reused","mapSize":1,"currentSessionId":"new-session"}
PASS current_reused_owner_abort_removed_entry {"runId":"proof-reused","mapSize":0}
PASS retired_collect_identity_survived_abort {"runId":"proof-retired","mapSize":1,"abortable":false}
PASS retired_collect_identity_removed_on_completion {"runId":"proof-retired","mapSize":0}
REAL_GATEWAY_QUEUE_PROOF result=pass
```

The proof script (src/gateway/chat-queued-turns.proof.ts) exercises the production module:
- Registers a queued turn → owner abort fires → entry removed
- Stale controller abort does not remove a re-registered run id
- Retired collect identity survives abort (idempotency guard), removed only by completion

### Unit test results

40 tests pass across 4 gateway configs (gateway-core, gateway-server, gateway-client, gateway-methods), including the new tests:

```
 ✓ cleans up the map entry when the abort signal fires (client disconnect)
 ✓ keeps a retired collect identity after abort (idempotency guard)
```