### PR TITLE
fix(media): accept repeated content-length when values match

### DIFF
--- a/packages/media-core/src/content-length.test.ts
+++ b/packages/media-core/src/content-length.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { parseMediaContentLength } from "./content-length.js";
+
+describe("parseMediaContentLength", () => {
+  it.each([
+    { raw: null, expected: null },
+    { raw: "0", expected: 0 },
+    { raw: " 42\t", expected: 42 },
+    { raw: "42, 42", expected: 42 },
+    { raw: "42,\t42, 42", expected: 42 },
+    { raw: "042, 042", expected: 42 },
+  ])("parses $raw", ({ raw, expected }) => {
+    expect(parseMediaContentLength(raw)).toBe(expected);
+  });
+
+  it.each([
+    "",
+    " ",
+    "0x2a",
+    "42,",
+    ",42",
+    "42, 43",
+    "042, 42",
+    "42,\u00a042",
+    String(Number.MAX_SAFE_INTEGER + 1),
+  ])("rejects %j", (raw) => {
+    expect(() => parseMediaContentLength(raw)).toThrow(`invalid content-length header: ${raw}`);
+  });
+});

--- a/packages/media-core/src/content-length.ts
+++ b/packages/media-core/src/content-length.ts
@@ -3,11 +3,14 @@ export function parseMediaContentLength(raw: string | null): number | null {
   if (raw === null) {
     return null;
   }
-  const trimmed = raw.trim();
-  if (!/^\d+$/.test(trimmed)) {
+  const values = raw.split(",").map((value) => value.replace(/^[\t ]+|[\t ]+$/g, ""));
+  const value = values[0] ?? "";
+  // Repeated lengths affect framing, so their trimmed decimal bytes must match.
+  // Numeric comparison would wrongly accept ambiguous values such as "05, 5".
+  if (!/^\d+$/.test(value) || values.some((candidate) => candidate !== value)) {
     throw new Error(`invalid content-length header: ${raw}`);
   }
-  const size = Number(trimmed);
+  const size = Number(value);
   if (!Number.isSafeInteger(size)) {
     throw new Error(`invalid content-length header: ${raw}`);
   }

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -310,6 +310,25 @@ describe("readRemoteMediaBuffer", () => {
     expect(body.wasCanceled()).toBe(true);
   });
 
+  it("accepts comma-joined identical content-length values", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response("hello", {
+          status: 200,
+          headers: { "content-length": "5, 5" },
+        }),
+    );
+
+    const result = await readRemoteMediaBuffer({
+      url: "https://example.com/file.bin",
+      fetchImpl,
+      maxBytes: 5,
+      lookupFn: makeLookupFn(),
+    });
+
+    expect(result.buffer.toString()).toBe("hello");
+  });
+
   it("applies a default stream limit when maxBytes is omitted", async () => {
     const fetchImpl = vi.fn(
       async () =>


### PR DESCRIPTION
## What Problem This Solves

OpenClaw rejected media and plugin responses when a server or intermediary emitted the same `Content-Length` twice. Fetch-compatible runtimes expose those physical fields as a comma-joined value such as `5, 5`, so the shared parser rejected a valid recoverable framing case before any bounded body read.

## Why This Change Was Made

The shared media-core parser is the canonical owner for seven production consumers and the plugin SDK export. It now splits comma-joined members, removes only HTTP space/tab whitespace, requires every decimal member to match byte-for-byte, and performs the safe-integer conversion once.

That exact comparison is intentional: matching `5, 5` is accepted, while malformed, unsafe, conflicting, or merely numeric-equivalent values such as `05, 5` remain rejected. This follows the [WHATWG Fetch Content-Length algorithm](https://fetch.spec.whatwg.org/#content-length-header) and the recoverable repeated-value case in [RFC 9110 section 8.6](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6) and [RFC 9112 section 6.3](https://www.rfc-editor.org/rfc/rfc9112.html#section-6.3).

## User Impact

Valid media and attachment downloads no longer fail solely because an upstream server or proxy repeated an identical length. Existing streaming byte caps remain the final bound, and ambiguous framing still fails closed before the body is returned.

## Evidence

Exact rewritten head: `c28ebe73474e737ae7e18537ee8052dd622ffe6a`

- Blacksmith Testbox: `tbx_01kx4mgz40xc73rppjjxq72rbf` (`swift-shrimp`)
- Runtime: Bun 1.3.14, matching the repository CI pin
- Live setup: raw TCP server on `127.0.0.1`, physical duplicate header fields, `Connection: close`, and the real `readRemoteMediaBuffer` path with private-loopback access explicitly enabled
- Before: unmodified main parser blob `98b21a5d34b7ee0e6d08f0657afa798d0a2749ad` saw Bun's `5, 5`, then both the parser and media read rejected it
- After: physical `5` / `5` produced `parserResult: 5` and `mediaRead: hello`
- Bound preserved: physical `6` / `6` with `maxBytes: 5` produced `code: max_bytes`
- Conflict rejected: physical `6` / `5` produced `code: http_error` with `invalid content-length header: 6, 5`
- Numeric-equivalent ambiguity rejected: `05, 5` remained invalid
- Focused tests: 2 Vitest shards, 55 tests passed
- `pnpm check:changed`: `core, coreTests` lanes passed, including production/test typechecks, lint, import-cycle and media-download guards
- `oxfmt --check`: all 3 changed files passed
- Fresh structured Codex autoreview: clean, no accepted/actionable findings, patch correct at 0.88 confidence

No visual proof is applicable to this transport/parser fix.
