### PR TITLE
chore: stabilize WhatsApp reconnect boundary test

### DIFF
--- a/extensions/whatsapp/src/monitor-inbox.append-upsert.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.append-upsert.test-support.ts
@@ -144,32 +144,45 @@ describe("append upsert handling (#20952)", () => {
   });
 
   it("processes a distinct catch-up message from the boundary second", async () => {
-    const onMessage = vi.fn(async () => {});
-    const boundarySeconds = Math.floor(Date.now() / 1000) - 20 * 60 + 1;
-    const { listener, sock } = await startInboxMonitor(onMessage, {
-      appendReplyWindow: {
-        afterMs: boundarySeconds * 1000,
-        untilMs: Date.now() + 30 * 60_000,
-        maxAgeMs: 20 * 60_000,
-      },
-    });
-
-    sock.ev.emit("messages.upsert", {
-      type: "append",
-      messages: [
-        {
-          key: { id: "catch-up-same-second", fromMe: false, remoteJid: "999@s.whatsapp.net" },
-          message: { conversation: "same second, different message" },
-          messageTimestamp: boundarySeconds,
-          pushName: "Reconnect Tester",
+    // Baileys timestamps use whole seconds. Freeze this inclusive boundary so
+    // async monitor startup cannot age the fixture beyond maxAgeMs.
+    const nowMs = 1_700_000_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(nowMs);
+    try {
+      const onMessage = vi.fn(async () => {});
+      const boundarySeconds = nowMs / 1000 - 20 * 60;
+      const { listener, sock } = await startInboxMonitor(onMessage, {
+        appendReplyWindow: {
+          afterMs: boundarySeconds * 1000,
+          untilMs: nowMs + 30 * 60_000,
+          maxAgeMs: 20 * 60_000,
         },
-      ],
-    });
-    await waitForMessageCalls(onMessage, 1);
+      });
+      try {
+        sock.ev.emit("messages.upsert", {
+          type: "append",
+          messages: [
+            {
+              key: {
+                id: "catch-up-same-second",
+                fromMe: false,
+                remoteJid: "999@s.whatsapp.net",
+              },
+              message: { conversation: "same second, different message" },
+              messageTimestamp: boundarySeconds,
+              pushName: "Reconnect Tester",
+            },
+          ],
+        });
+        await waitForMessageCalls(onMessage, 1);
 
-    expect(onMessage).toHaveBeenCalledTimes(1);
-
-    await listener.close();
+        expect(onMessage).toHaveBeenCalledTimes(1);
+      } finally {
+        await listener.close();
+      }
+    } finally {
+      dateNow.mockRestore();
+    }
   });
 
   it("skips append messages with NaN/non-finite timestamps", async () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves an intermittent Plugin CI failure where the WhatsApp reconnect catch-up boundary test could age its whole-second fixture past the moving 20-minute cutoff during asynchronous monitor startup.

## Why This Change Was Made

The production rolling max-age behavior is correct. The test now freezes `Date.now()` for the exact inclusive boundary, closes the listener in a nested `finally`, and restores the clock spy so the assertion is deterministic without changing runtime behavior.

## User Impact

No user-visible behavior changes. Release and plugin validation no longer fails nondeterministically at this WhatsApp reconnect boundary.

## Evidence

- Blacksmith Testbox `tbx_01kx3nttr2dtyna66x1csd431b`: focused boundary test passed 10 consecutive runs.
- Same Testbox after merging current `main`: `pnpm test extensions/whatsapp/src/monitor-inbox.behavior.test.ts` — 93/93 passed.
- Independent Blacksmith Testbox run [29027186035](https://github.com/openclaw/openclaw/actions/runs/29027186035), job `86149933646`: 93/93 passed and scoped format check passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`: clean, no actionable findings, confidence 0.97.
