### PR TITLE
feat(durable): record sqlite schema lifecycle

### DIFF
--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -547,6 +547,20 @@ terminal summary, and sanitized error text. `agentId` identifies the agent
 executing the task; `sessionKey` and `ownerKey` preserve requester and control
 context.
 
+### Durable coordination RPCs
+
+Operator clients may inspect native Durable Core coordination state through a
+bounded projection instead of reading the shared OpenClaw state database
+directly. These methods are disabled unless `OPENCLAW_DURABLE_WORKFLOWS` is
+explicitly enabled.
+
+- `durable.coordination.get` requires `operator.read`.
+  - Params: `{ "workflowRunId": string }`.
+  - Result: `{ "projection": DurableCoordinationProjection }`.
+  - The projection includes workflow identity, status, recovery state, current
+    step, waiting reason, external task/session/run bindings, child counts, ref
+    summaries, and supported controls.
+
 ### Operator helper methods
 
 - Operators may call `commands.list` (`operator.read`) to fetch the runtime

--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -52,7 +52,10 @@ const rawSqliteAllowPathGroups = {
     "src/infra/state-migrations.ts",
     "src/infra/state-migrations.debug-proxy.ts",
   ],
-  "shared database stores with direct DatabaseSync access": ["src/proxy-capture/store.sqlite.ts"],
+  "shared database stores with direct DatabaseSync access": [
+    "src/durable/sqlite-store.ts",
+    "src/proxy-capture/store.sqlite.ts",
+  ],
   "Kysely-backed stores that own a DatabaseSync boundary": [
     "src/acp/event-ledger.ts",
     "src/agents/subagent-registry.store.ts",

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -519,6 +519,7 @@ export function createOpenClawTools(
           createSessionsSpawnTool({
             agentSessionKey: options?.agentSessionKey,
             completionOwnerKey: options?.runSessionKey,
+            requesterRunId: options?.runId,
             agentChannel: options?.agentChannel,
             agentAccountId: options?.agentAccountId,
             agentTo: options?.agentTo,

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -5,6 +5,10 @@
  */
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  recordDurableSubagentRegistered,
+  recordDurableSubagentTerminal,
+} from "../durable/subagent.js";
 import { callGateway } from "../gateway/call.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
@@ -149,6 +153,7 @@ export type RegisterSubagentRunParams = {
   taskName?: string;
   agentId?: string;
   requesterAgentId?: string;
+  requesterRunId?: string;
   cleanup: "delete" | "keep";
   label?: string;
   model?: string;
@@ -313,6 +318,11 @@ export function createSubagentRunManager(params: {
           timeoutCompletion.startedAt = startedAt;
         }
         completionForRetry = timeoutCompletion;
+        recordDurableSubagentTerminal({
+          runId,
+          childSessionKey: entry.childSessionKey,
+          status: "timeout",
+        });
         await params.completeSubagentRun(completionForRetry);
       };
       if (waitStatus === "timeout") {
@@ -441,6 +451,12 @@ export function createSubagentRunManager(params: {
         triggerCleanup: true,
         startedAt: observedStartedAt,
       };
+      recordDurableSubagentTerminal({
+        runId,
+        childSessionKey: entry.childSessionKey,
+        status: outcome.status,
+        error: outcome.status === "error" ? outcome.error : undefined,
+      });
       await params.completeSubagentRun(completionForRetry);
     } catch (error) {
       const current = params.runs.get(runId);
@@ -681,8 +697,9 @@ export function createSubagentRunManager(params: {
       params.runs.delete(runId);
       throw error;
     }
+    let backgroundTask: ReturnType<typeof createRunningTaskRun> | null | undefined;
     try {
-      const task = createRunningTaskRun({
+      backgroundTask = createRunningTaskRun({
         runtime: "subagent",
         sourceId: runId,
         ownerKey: requesterSessionKey,
@@ -699,7 +716,7 @@ export function createSubagentRunManager(params: {
         startedAt: now,
         lastEventAt: now,
       });
-      if (!task) {
+      if (!backgroundTask) {
         log.warn("Failed to persist background task for subagent run", {
           runId: registerParams.runId,
         });
@@ -710,6 +727,19 @@ export function createSubagentRunManager(params: {
         error,
       });
     }
+    recordDurableSubagentRegistered({
+      runId,
+      childSessionKey,
+      requesterSessionKey,
+      taskId: backgroundTask?.taskId,
+      taskFlowId: backgroundTask?.parentFlowId,
+      task: registerParams.task,
+      taskName: registerParams.taskName,
+      label: registerParams.label,
+      agentId: registerParams.agentId,
+      requesterAgentId: registerParams.requesterAgentId,
+      requesterRunId: registerParams.requesterRunId,
+    });
     params.ensureListener();
     params.persist();
     // Always start sweeper — session-mode runs (no archiveAtMs) also need TTL cleanup.
@@ -787,6 +817,12 @@ export function createSubagentRunManager(params: {
       entry.cleanupHandled = true;
       entry.cleanupCompletedAt = now;
       entry.suppressAnnounceReason = "killed";
+      recordDurableSubagentTerminal({
+        runId,
+        childSessionKey: entry.childSessionKey,
+        status: "killed",
+        error: reason,
+      });
       if (!entriesByChildSessionKey.has(entry.childSessionKey)) {
         entriesByChildSessionKey.set(entry.childSessionKey, entry);
       }

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -187,6 +187,8 @@ export type SpawnSubagentContext = {
   agentSessionKey?: string;
   /** Separate key used only for completion routing, not sandbox policy. */
   completionOwnerKey?: string;
+  /** Current requester agent run id, used only for internal durable lineage. */
+  requesterRunId?: string;
   agentChannel?: string;
   agentAccountId?: string;
   agentTo?: string;
@@ -1659,6 +1661,7 @@ export async function spawnSubagentDirect(
       taskName,
       agentId: targetAgentId,
       requesterAgentId,
+      requesterRunId: ctx.requesterRunId,
       cleanup,
       label: label || undefined,
       model: resolvedModel,

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -255,6 +255,8 @@ export function createSessionsSpawnTool(
     agentSessionKey?: string;
     /** Separate key used only for completion routing (registerSubagentRun requesterSessionKey). */
     completionOwnerKey?: string;
+    /** Current requester agent run id, used only for internal durable lineage. */
+    requesterRunId?: string;
     agentChannel?: GatewayMessageChannel;
     agentAccountId?: string;
     agentTo?: string;
@@ -449,6 +451,7 @@ export function createSessionsSpawnTool(
               task,
               taskName,
               requesterAgentId: opts?.requesterAgentIdOverride,
+              requesterRunId: opts?.requesterRunId,
               cleanup: trackedCleanup,
               label: label || undefined,
               runTimeoutSeconds: result.runTimeoutSeconds,
@@ -496,6 +499,7 @@ export function createSessionsSpawnTool(
         {
           agentSessionKey: opts?.agentSessionKey,
           completionOwnerKey: opts?.completionOwnerKey,
+          requesterRunId: opts?.requesterRunId,
           agentChannel: opts?.agentChannel,
           agentAccountId: opts?.agentAccountId,
           agentTo: opts?.agentTo,

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -2,6 +2,8 @@
 import { randomUUID } from "node:crypto";
 import net from "node:net";
 import { clearRuntimeConfigSnapshot } from "../../config/runtime-snapshot.js";
+import { startDurableRecoveryWorker } from "../../durable/recovery.js";
+import { maybeRecordDurableGatewayStartup } from "../../durable/startup.js";
 import {
   captureGatewayRestartTraceHandoff,
   createGatewayRestartTraceHandoffEnv,
@@ -124,6 +126,7 @@ export async function runGatewayLoop(params: {
   const eagerLifecycleRuntime = await loadGatewayLifecycleRuntimeModule();
   let lock = await acquireGatewayLock({ port: params.lockPort });
   let server: Awaited<ReturnType<typeof startGatewayServer>> | null = null;
+  let stopDurableRecoveryWorker: (() => void) | null = null;
   let shuttingDown = false;
   let restartResolver: (() => void) | null = null;
   // The HTTP server can report ready before params.start returns its close handle.
@@ -618,6 +621,8 @@ export async function runGatewayLoop(params: {
 
         armCloseForceExitTimerForIndefiniteRestart();
         const closeDrainTimeoutMs = resolveRestartCloseDrainTimeoutMs();
+        stopDurableRecoveryWorker?.();
+        stopDurableRecoveryWorker = null;
         await server?.close({
           reason: isRestart ? "gateway restarting" : "gateway stopping",
           restartExpectedMs: isRestart ? 1500 : null,
@@ -840,6 +845,15 @@ export async function runGatewayLoop(params: {
       let startupFailedBeforeServerHandle = false;
       try {
         server = await params.start({ startupStartedAt });
+        await maybeRecordDurableGatewayStartup({
+          processInstanceId,
+          startupStartedAt,
+          port: params.lockPort,
+        });
+        stopDurableRecoveryWorker?.();
+        stopDurableRecoveryWorker = startDurableRecoveryWorker({
+          processInstanceId,
+        });
         startupFailedWithoutServerHandle = false;
         isFirstStart = false;
       } catch (err) {
@@ -877,6 +891,8 @@ export async function runGatewayLoop(params: {
       });
     }
   } finally {
+    stopDurableRecoveryWorker?.();
+    stopDurableRecoveryWorker = null;
     await releaseLockIfHeld();
     cleanupSignals();
   }

--- a/src/cli/program/command-registry-core.ts
+++ b/src/cli/program/command-registry-core.ts
@@ -131,6 +131,13 @@ const coreEntrySpecs: readonly CommandGroupDescriptorSpec<
       mod.registerAgentsCommands(program);
     },
   ),
+  defineImportedCommandGroupSpec(
+    ["durable"],
+    () => import("./register.durable.js"),
+    (mod, { program }) => {
+      mod.registerDurableCommand(program);
+    },
+  ),
   ...withProgramOnlySpecs(
     defineImportedProgramCommandGroupSpecs([
       {

--- a/src/cli/program/core-command-descriptors.ts
+++ b/src/cli/program/core-command-descriptors.ts
@@ -113,6 +113,12 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
     description: "Inspect durable background tasks and flows",
     hasSubcommands: true,
   },
+  {
+    name: "durable",
+    description: "Inspect native durable workflow runs, timelines, and coordination state",
+    hasSubcommands: true,
+    parentDefaultHelp: true,
+  },
 ] as const satisfies ReadonlyArray<CoreCliCommandDescriptor>);
 
 /** Static root-command descriptors for the core CLI surface. */

--- a/src/cli/program/register.durable.ts
+++ b/src/cli/program/register.durable.ts
@@ -1,0 +1,84 @@
+import type { Command } from "commander";
+import { durableCommand, type DurableCliAction } from "../../commands/durable.js";
+import { defaultRuntime } from "../../runtime.js";
+
+type DurableCliCommanderOptions = {
+  json?: boolean;
+  limit?: string;
+};
+
+function parseLimit(value: string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    defaultRuntime.error("--limit must be a positive integer.");
+    defaultRuntime.exit(1);
+    return undefined;
+  }
+  return parsed;
+}
+
+function addCommonOptions(command: Command): Command {
+  return command.option("--json", "Output JSON instead of text", false);
+}
+
+async function runDurableAction(
+  action: DurableCliAction,
+  workflowRunId: string | undefined,
+  opts: DurableCliCommanderOptions,
+): Promise<void> {
+  await durableCommand(
+    {
+      action,
+      workflowRunId,
+      json: Boolean(opts.json),
+      limit: parseLimit(opts.limit),
+    },
+    defaultRuntime,
+  );
+}
+
+export function registerDurableCommand(program: Command) {
+  const durable = program
+    .command("durable")
+    .description("Inspect native durable workflow runs, timelines, and coordination state");
+
+  addCommonOptions(
+    durable.command("stats").description("Show durable workflow store stats"),
+  ).action(async (opts) => {
+    await runDurableAction("stats", undefined, opts);
+  });
+
+  addCommonOptions(
+    durable
+      .command("runs")
+      .description("List recent durable workflow runs")
+      .option("--limit <count>", "Maximum runs to show", "50"),
+  ).action(async (opts) => {
+    await runDurableAction("runs", undefined, opts);
+  });
+
+  for (const [name, action, description] of [
+    ["show", "show", "Show a durable workflow run with steps, links, signals, and timeline"],
+    ["timeline", "timeline", "Show durable workflow events for one run"],
+    ["steps", "steps", "Show durable workflow steps for one run"],
+    ["children", "children", "Show child workflow links for one run"],
+    ["parents", "parents", "Show parent workflow links for one run"],
+    [
+      "coordination",
+      "coordination",
+      "Show durable coordination projection for task, TaskFlow, and Workboard",
+    ],
+    ["signals", "signals", "Show durable workflow signals for one run"],
+    ["refs", "refs", "Show durable workflow state refs for one run"],
+    ["timers", "timers", "Show durable workflow timers for one run"],
+  ] as const) {
+    addCommonOptions(durable.command(`${name} <workflowRunId>`).description(description)).action(
+      async (workflowRunId: string, opts) => {
+        await runDurableAction(action, workflowRunId, opts);
+      },
+    );
+  }
+}

--- a/src/commands/durable.ts
+++ b/src/commands/durable.ts
@@ -1,0 +1,344 @@
+import { buildDurableCoordinationProjection } from "../durable/coordination-projection.js";
+import { openDurableWorkflowSqliteStore } from "../durable/sqlite-store.js";
+import type {
+  DurableWorkflowEvent,
+  DurableWorkflowLink,
+  DurableWorkflowRef,
+  DurableWorkflowRun,
+  DurableWorkflowSignal,
+  DurableWorkflowStep,
+  DurableWorkflowStore,
+  DurableWorkflowTimer,
+} from "../durable/types.js";
+import type { RuntimeEnv } from "../runtime.js";
+
+export type DurableCliAction =
+  | "runs"
+  | "show"
+  | "timeline"
+  | "steps"
+  | "children"
+  | "parents"
+  | "signals"
+  | "refs"
+  | "timers"
+  | "coordination"
+  | "stats";
+
+export type DurableCliOptions = {
+  action: DurableCliAction;
+  workflowRunId?: string;
+  json?: boolean;
+  limit?: number;
+  env?: NodeJS.ProcessEnv;
+};
+
+type DurableRunDetails = {
+  run: DurableWorkflowRun;
+  steps: DurableWorkflowStep[];
+  children: DurableWorkflowLink[];
+  parents: DurableWorkflowLink[];
+  signals: DurableWorkflowSignal[];
+  refs: DurableWorkflowRef[];
+  timers: DurableWorkflowTimer[];
+  timeline: DurableWorkflowEvent[];
+};
+
+function write(runtime: RuntimeEnv, value: string): void {
+  runtime.log(value);
+}
+
+function writeJson(runtime: RuntimeEnv, value: unknown): void {
+  runtime.log(JSON.stringify(value, null, 2));
+}
+
+function formatTime(value?: number): string {
+  return value ? new Date(value).toISOString() : "-";
+}
+
+function parseLimit(value: number | undefined): number {
+  return Math.max(1, Math.min(500, Math.trunc(value ?? 50)));
+}
+
+function requireRunId(opts: DurableCliOptions, runtime: RuntimeEnv): string | undefined {
+  const workflowRunId = opts.workflowRunId?.trim();
+  if (workflowRunId) {
+    return workflowRunId;
+  }
+  runtime.error("A workflow run id is required.");
+  runtime.exit(1);
+  return undefined;
+}
+
+function loadRunDetails(
+  store: DurableWorkflowStore,
+  workflowRunId: string,
+): DurableRunDetails | undefined {
+  const run = store.getRun(workflowRunId);
+  if (!run) {
+    return undefined;
+  }
+  return {
+    run,
+    steps: store.listSteps(workflowRunId),
+    children: store.listChildLinks(workflowRunId),
+    parents: store.listParentLinks(workflowRunId),
+    signals: store.listSignals(workflowRunId),
+    refs: store.listRefs(workflowRunId),
+    timers: store.listTimers(workflowRunId),
+    timeline: store.getTimeline(workflowRunId),
+  };
+}
+
+function summarizeRun(run: DurableWorkflowRun): string {
+  const heartbeat = run.heartbeatAt ? ` heartbeat=${formatTime(run.heartbeatAt)}` : "";
+  const source = run.sourceRef ? ` source=${run.sourceRef}` : "";
+  const parent = run.parentWorkflowRunId ? ` parent=${run.parentWorkflowRunId}` : "";
+  return [
+    run.workflowRunId,
+    run.workflowId,
+    `${run.status}/${run.recoveryState}`,
+    `updated=${formatTime(run.updatedAt)}`,
+    `${source}${parent}${heartbeat}`.trim(),
+  ]
+    .filter(Boolean)
+    .join("  ");
+}
+
+function renderRuns(runs: DurableWorkflowRun[]): string {
+  if (runs.length === 0) {
+    return "No durable workflow runs found.";
+  }
+  return runs.map(summarizeRun).join("\n");
+}
+
+function renderTimeline(events: DurableWorkflowEvent[]): string {
+  if (events.length === 0) {
+    return "No durable workflow events found.";
+  }
+  return events
+    .map((event) =>
+      [
+        `#${event.eventSeq}`,
+        formatTime(event.eventTime),
+        event.eventType,
+        event.stepId ? `step=${event.stepId}` : "",
+        event.correlationId ? `corr=${event.correlationId}` : "",
+      ]
+        .filter(Boolean)
+        .join("  "),
+    )
+    .join("\n");
+}
+
+function renderSteps(steps: DurableWorkflowStep[]): string {
+  if (steps.length === 0) {
+    return "No durable workflow steps found.";
+  }
+  return steps
+    .map((step) =>
+      [
+        step.stepId,
+        step.stepType,
+        `${step.status}/${step.recoveryState}`,
+        `attempt=${step.attempt}`,
+        step.heartbeatAt ? `heartbeat=${formatTime(step.heartbeatAt)}` : "",
+        step.outputRef ? `output=${step.outputRef}` : "",
+        step.errorRef ? `error=${step.errorRef}` : "",
+      ]
+        .filter(Boolean)
+        .join("  "),
+    )
+    .join("\n");
+}
+
+function renderLinks(links: DurableWorkflowLink[], direction: "children" | "parents"): string {
+  if (links.length === 0) {
+    return `No durable workflow ${direction} found.`;
+  }
+  return links
+    .map((link) =>
+      [
+        direction === "children"
+          ? `child=${link.childWorkflowRunId}`
+          : `parent=${link.parentWorkflowRunId}`,
+        `step=${link.parentStepId}`,
+        link.linkType,
+        link.status,
+        `updated=${formatTime(link.updatedAt)}`,
+      ].join("  "),
+    )
+    .join("\n");
+}
+
+function renderSignals(signals: DurableWorkflowSignal[]): string {
+  if (signals.length === 0) {
+    return "No durable workflow signals found.";
+  }
+  return signals
+    .map((signal) =>
+      [
+        signal.signalId,
+        signal.signalType,
+        signal.consumedAt ? "consumed" : "pending",
+        `received=${formatTime(signal.receivedAt)}`,
+        signal.correlationId ? `corr=${signal.correlationId}` : "",
+      ]
+        .filter(Boolean)
+        .join("  "),
+    )
+    .join("\n");
+}
+
+function renderRefs(refs: DurableWorkflowRef[]): string {
+  if (refs.length === 0) {
+    return "No durable workflow refs found.";
+  }
+  return refs
+    .map((ref) =>
+      [
+        ref.refId,
+        ref.refKind,
+        ref.storageKind,
+        ref.stepId ? `step=${ref.stepId}` : "",
+        ref.hash ? `hash=${ref.hash}` : "",
+        ref.storageUri ? `uri=${ref.storageUri}` : "",
+      ]
+        .filter(Boolean)
+        .join("  "),
+    )
+    .join("\n");
+}
+
+function renderTimers(timers: DurableWorkflowTimer[]): string {
+  if (timers.length === 0) {
+    return "No durable workflow timers found.";
+  }
+  return timers
+    .map((timer) =>
+      [
+        timer.timerId,
+        timer.timerType,
+        timer.status,
+        `due=${formatTime(timer.dueAt)}`,
+        timer.stepId ? `step=${timer.stepId}` : "",
+      ]
+        .filter(Boolean)
+        .join("  "),
+    )
+    .join("\n");
+}
+
+function renderDetails(details: DurableRunDetails): string {
+  return [
+    summarizeRun(details.run),
+    "",
+    "Steps:",
+    renderSteps(details.steps),
+    "",
+    "Children:",
+    renderLinks(details.children, "children"),
+    "",
+    "Signals:",
+    renderSignals(details.signals),
+    "",
+    "Timeline:",
+    renderTimeline(details.timeline),
+  ].join("\n");
+}
+
+export async function durableCommand(opts: DurableCliOptions, runtime: RuntimeEnv): Promise<void> {
+  const store = openDurableWorkflowSqliteStore({ env: opts.env });
+  try {
+    if (opts.action === "stats") {
+      const stats = store.getStats();
+      if (opts.json) {
+        writeJson(runtime, stats);
+      } else {
+        write(
+          runtime,
+          `Durable workflow store: ${stats.path}\nruns=${stats.runs} open=${stats.openRuns} steps=${stats.steps} events=${stats.events}`,
+        );
+      }
+      return;
+    }
+
+    if (opts.action === "runs") {
+      const runs = store.listRuns({ limit: parseLimit(opts.limit) });
+      opts.json ? writeJson(runtime, runs) : write(runtime, renderRuns(runs));
+      return;
+    }
+
+    const workflowRunId = requireRunId(opts, runtime);
+    if (!workflowRunId) {
+      return;
+    }
+
+    const details = loadRunDetails(store, workflowRunId);
+    if (!details) {
+      runtime.error(`Durable workflow run not found: ${workflowRunId}`);
+      runtime.exit(1);
+      return;
+    }
+
+    const payload =
+      opts.action === "show"
+        ? details
+        : opts.action === "coordination"
+          ? buildDurableCoordinationProjection({
+              run: details.run,
+              steps: details.steps,
+              childLinks: details.children,
+              refs: details.refs,
+            })
+          : opts.action === "timeline"
+            ? details.timeline
+            : opts.action === "steps"
+              ? details.steps
+              : opts.action === "children"
+                ? details.children
+                : opts.action === "parents"
+                  ? details.parents
+                  : opts.action === "signals"
+                    ? details.signals
+                    : opts.action === "refs"
+                      ? details.refs
+                      : details.timers;
+
+    if (opts.json) {
+      writeJson(runtime, payload);
+      return;
+    }
+
+    const text =
+      opts.action === "show"
+        ? renderDetails(details)
+        : opts.action === "coordination"
+          ? JSON.stringify(
+              buildDurableCoordinationProjection({
+                run: details.run,
+                steps: details.steps,
+                childLinks: details.children,
+                refs: details.refs,
+              }),
+              null,
+              2,
+            )
+          : opts.action === "timeline"
+            ? renderTimeline(details.timeline)
+            : opts.action === "steps"
+              ? renderSteps(details.steps)
+              : opts.action === "children"
+                ? renderLinks(details.children, "children")
+                : opts.action === "parents"
+                  ? renderLinks(details.parents, "parents")
+                  : opts.action === "signals"
+                    ? renderSignals(details.signals)
+                    : opts.action === "refs"
+                      ? renderRefs(details.refs)
+                      : renderTimers(details.timers);
+    write(runtime, text);
+  } finally {
+    store.close();
+  }
+}

--- a/src/durable/agent-turn.ts
+++ b/src/durable/agent-turn.ts
@@ -1,0 +1,312 @@
+// Durable workflow lifecycle helpers for one agent turn.
+import { createHash } from "node:crypto";
+import { isDurableWorkflowsEnabled } from "./config.js";
+import { openDurableWorkflowSqliteStore } from "./sqlite-store.js";
+import type {
+  DurableRecoveryState,
+  DurableWorkflowRun,
+  DurableWorkflowRunStatus,
+  DurableWorkflowStore,
+} from "./types.js";
+import { DURABLE_AGENT_TURN_WORKFLOW_ID } from "./workflow-ids.js";
+
+export type DurableAgentTurnLifecycle = {
+  workflowRunId: string;
+  markRunning(payload?: Record<string, unknown>): void;
+  recordHeartbeat(payload?: Record<string, unknown>): void;
+  markTerminal(params: {
+    status: DurableWorkflowRunStatus;
+    recoveryState?: DurableRecoveryState;
+    eventType: string;
+    payload?: Record<string, unknown>;
+  }): void;
+  close(): void;
+};
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function compactErrorPayload(error: unknown): Record<string, unknown> {
+  return {
+    name: error instanceof Error ? error.name : undefined,
+    message: error instanceof Error ? error.message : String(error),
+  };
+}
+
+function safeCall(action: () => void): void {
+  try {
+    action();
+  } catch {
+    // Durable recording must never make the user-facing turn fail.
+  }
+}
+
+function createNoopLifecycle(): DurableAgentTurnLifecycle {
+  return {
+    workflowRunId: "",
+    markRunning: () => {},
+    recordHeartbeat: () => {},
+    markTerminal: () => {},
+    close: () => {},
+  };
+}
+
+function resolveHeartbeatIntervalMs(env: NodeJS.ProcessEnv): number {
+  const raw = env.OPENCLAW_DURABLE_AGENT_TURN_HEARTBEAT_MS;
+  if (raw === undefined || raw.trim() === "") {
+    return 30_000;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return 30_000;
+  }
+  return Math.trunc(parsed);
+}
+
+export function startDurableAgentTurnLifecycle(params: {
+  runId: string;
+  message: string;
+  agentId?: string;
+  sessionKey?: string;
+  channel?: string;
+  transport: "gateway" | "local";
+  deliver?: boolean;
+  env?: NodeJS.ProcessEnv;
+}): DurableAgentTurnLifecycle {
+  const env = params.env ?? process.env;
+  if (!isDurableWorkflowsEnabled(env)) {
+    return createNoopLifecycle();
+  }
+
+  let store: DurableWorkflowStore | null = null;
+  let run: DurableWorkflowRun | undefined;
+  let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+  const stepId = "agent_invocation";
+  const messageHash = sha256(params.message);
+  const inputRefId = `agent-turn:${params.runId}:input`;
+  const metadata = {
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+    channel: params.channel,
+    transport: params.transport,
+    deliver: params.deliver === true,
+    messageLength: params.message.length,
+    messageHash,
+  };
+
+  try {
+    store = openDurableWorkflowSqliteStore({ env });
+    run = store.createRun({
+      workflowId: DURABLE_AGENT_TURN_WORKFLOW_ID,
+      workflowVersion: "1",
+      status: "received",
+      recoveryState: "runnable",
+      idempotencyKey: params.runId,
+      requestHash: messageHash,
+      sourceType: "agent",
+      sourceRef: params.sessionKey ?? params.agentId ?? "unknown",
+      inputRef: inputRefId,
+      metadata,
+    });
+    const inputRef = store.createRef({
+      refId: inputRefId,
+      workflowRunId: run.workflowRunId,
+      stepId,
+      refKind: "input",
+      mediaType: "application/vnd.openclaw.agent-turn+json",
+      hash: messageHash,
+      storageKind: "external",
+      storageUri: inputRefId,
+      metadata,
+    });
+    store.createStep({
+      workflowRunId: run.workflowRunId,
+      stepId,
+      stepType: "agent",
+      status: "queued",
+      recoveryState: "runnable",
+      inputRef: inputRef.refId,
+      idempotencyKey: params.runId,
+      metadata,
+    });
+    store.appendEvent({
+      workflowRunId: run.workflowRunId,
+      eventType: "agent.turn.received",
+      stepId: "intake",
+      agentInvocationId: params.runId,
+      idempotencyKey: params.runId,
+      correlationId: params.sessionKey,
+      payload: metadata,
+      payloadHash: messageHash,
+    });
+  } catch {
+    store?.close();
+    return createNoopLifecycle();
+  }
+
+  function stopHeartbeat(): void {
+    if (heartbeatTimer) {
+      clearInterval(heartbeatTimer);
+      heartbeatTimer = undefined;
+    }
+  }
+
+  function recordHeartbeat(payload?: Record<string, unknown>): void {
+    safeCall(() => {
+      if (!store || !run) {
+        return;
+      }
+      const now = Date.now();
+      store.updateRun({
+        workflowRunId: run.workflowRunId,
+        heartbeatAt: now,
+        metadata,
+        now,
+      });
+      store.updateStep({
+        workflowRunId: run.workflowRunId,
+        stepId,
+        heartbeatAt: now,
+        metadata,
+        now,
+      });
+      store.appendEvent({
+        workflowRunId: run.workflowRunId,
+        eventType: "agent.turn.heartbeat",
+        eventTime: now,
+        stepId,
+        agentInvocationId: params.runId,
+        idempotencyKey: `${params.runId}:heartbeat:${now}`,
+        correlationId: params.sessionKey,
+        payload: payload ?? { heartbeatAt: now },
+      });
+    });
+  }
+
+  function startHeartbeat(): void {
+    const intervalMs = resolveHeartbeatIntervalMs(env);
+    if (intervalMs <= 0 || heartbeatTimer) {
+      return;
+    }
+    heartbeatTimer = setInterval(() => {
+      recordHeartbeat();
+    }, intervalMs);
+    heartbeatTimer.unref?.();
+  }
+
+  return {
+    workflowRunId: run.workflowRunId,
+    markRunning(payload?: Record<string, unknown>): void {
+      safeCall(() => {
+        if (!store || !run) {
+          return;
+        }
+        store.updateRun({
+          workflowRunId: run.workflowRunId,
+          status: "running",
+          recoveryState: "running",
+          heartbeatAt: Date.now(),
+          metadata,
+        });
+        store.updateStep({
+          workflowRunId: run.workflowRunId,
+          stepId,
+          status: "running",
+          recoveryState: "running",
+          startedAt: Date.now(),
+          heartbeatAt: Date.now(),
+          metadata,
+        });
+        store.appendEvent({
+          workflowRunId: run.workflowRunId,
+          eventType: "agent.turn.running",
+          stepId: "agent_invocation",
+          agentInvocationId: params.runId,
+          idempotencyKey: params.runId,
+          correlationId: params.sessionKey,
+          payload,
+        });
+        startHeartbeat();
+      });
+    },
+    recordHeartbeat,
+    markTerminal(paramsTerminal): void {
+      safeCall(() => {
+        if (!store || !run) {
+          return;
+        }
+        stopHeartbeat();
+        const completedAt = Date.now();
+        store.updateRun({
+          workflowRunId: run.workflowRunId,
+          status: paramsTerminal.status,
+          recoveryState: paramsTerminal.recoveryState ?? "terminal",
+          completedAt,
+          metadata,
+          now: completedAt,
+        });
+        const ref =
+          paramsTerminal.status === "succeeded"
+            ? store.createRef({
+                workflowRunId: run.workflowRunId,
+                stepId,
+                refKind: "output",
+                mediaType: "application/vnd.openclaw.agent-turn-result+json",
+                storageKind: "external",
+                storageUri: `agent-turn:${params.runId}:output`,
+                metadata: paramsTerminal.payload,
+                now: completedAt,
+              })
+            : store.createRef({
+                workflowRunId: run.workflowRunId,
+                stepId,
+                refKind: "error",
+                mediaType: "application/vnd.openclaw.agent-turn-error+json",
+                storageKind: "external",
+                storageUri: `agent-turn:${params.runId}:error`,
+                metadata: paramsTerminal.payload,
+                now: completedAt,
+              });
+        store.updateStep({
+          workflowRunId: run.workflowRunId,
+          stepId,
+          status:
+            paramsTerminal.status === "succeeded"
+              ? "succeeded"
+              : paramsTerminal.status === "cancelled"
+                ? "cancelled"
+                : paramsTerminal.status === "lost"
+                  ? "lost"
+                  : "failed",
+          recoveryState: paramsTerminal.recoveryState ?? "terminal",
+          ...(paramsTerminal.status === "succeeded"
+            ? { outputRef: ref.refId }
+            : { errorRef: ref.refId }),
+          completedAt,
+          metadata,
+          now: completedAt,
+        });
+        store.appendEvent({
+          workflowRunId: run.workflowRunId,
+          eventType: paramsTerminal.eventType,
+          eventTime: completedAt,
+          stepId: "terminal",
+          agentInvocationId: params.runId,
+          idempotencyKey: params.runId,
+          correlationId: params.sessionKey,
+          payload: paramsTerminal.payload,
+        });
+      });
+    },
+    close(): void {
+      stopHeartbeat();
+      store?.close();
+      store = null;
+    },
+  };
+}
+
+export function durableAgentTurnErrorPayload(error: unknown): Record<string, unknown> {
+  return compactErrorPayload(error);
+}

--- a/src/durable/config.ts
+++ b/src/durable/config.ts
@@ -1,0 +1,12 @@
+// Durable workflow feature flag and path resolution.
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+
+const ENABLED_VALUES = new Set(["1", "true", "yes", "on"]);
+
+export function isDurableWorkflowsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return ENABLED_VALUES.has((env.OPENCLAW_DURABLE_WORKFLOWS ?? "").trim().toLowerCase());
+}
+
+export function resolveDurableWorkflowSqlitePath(env: NodeJS.ProcessEnv = process.env): string {
+  return resolveOpenClawStateSqlitePath(env);
+}

--- a/src/durable/coordination-projection.test.ts
+++ b/src/durable/coordination-projection.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDurableCoordinationProjection,
+  buildDurableTaskFlowStateProjection,
+  buildDurableWorkboardMetadataProjection,
+  mergeDurableProjectionIntoJsonObject,
+} from "./coordination-projection.js";
+import type { DurableWorkflowLink, DurableWorkflowRun, DurableWorkflowStep } from "./types.js";
+
+describe("durable coordination projection", () => {
+  it("summarizes waiting child runs for taskflow and workboard consumers", () => {
+    const run: DurableWorkflowRun = {
+      workflowRunId: "wfr_parent",
+      workflowId: "openclaw.agent.turn",
+      workflowVersion: "1",
+      status: "waiting_child",
+      recoveryState: "waiting_child",
+      sourceType: "agent_turn",
+      sourceRef: "agent:bo:discord:channel:bo-main",
+      heartbeatAt: 120,
+      metadata: {
+        taskId: "task_parent",
+        taskFlowId: "flow_parent",
+        agentId: "bo",
+      },
+      createdAt: 100,
+      updatedAt: 150,
+    };
+    const steps: DurableWorkflowStep[] = [
+      {
+        workflowRunId: run.workflowRunId,
+        stepId: "subagents",
+        stepType: "fan_in",
+        status: "waiting",
+        recoveryState: "waiting_child",
+        attempt: 1,
+        createdAt: 110,
+        updatedAt: 140,
+      },
+    ];
+    const childLinks: DurableWorkflowLink[] = [
+      {
+        parentWorkflowRunId: run.workflowRunId,
+        parentStepId: "subagents",
+        childWorkflowRunId: "wfr_child_1",
+        linkType: "subagent",
+        status: "succeeded",
+        createdAt: 120,
+        updatedAt: 130,
+      },
+      {
+        parentWorkflowRunId: run.workflowRunId,
+        parentStepId: "subagents",
+        childWorkflowRunId: "wfr_child_2",
+        linkType: "subagent",
+        status: "failed",
+        createdAt: 121,
+        updatedAt: 131,
+      },
+      {
+        parentWorkflowRunId: run.workflowRunId,
+        parentStepId: "subagents",
+        childWorkflowRunId: "wfr_child_3",
+        linkType: "subagent",
+        status: "running",
+        createdAt: 122,
+        updatedAt: 132,
+      },
+    ];
+
+    const projection = buildDurableCoordinationProjection({ run, steps, childLinks });
+
+    expect(projection).toMatchObject({
+      workflowRunId: "wfr_parent",
+      status: "waiting_child",
+      recoveryState: "waiting_child",
+      currentStepId: "subagents",
+      waitingReason: "child",
+      external: {
+        taskId: "task_parent",
+        taskFlowId: "flow_parent",
+        sessionKey: "agent:bo:discord:channel:bo-main",
+        agentId: "bo",
+      },
+      children: {
+        total: 3,
+        succeeded: 1,
+        failed: 1,
+        running: 1,
+        terminal: 2,
+        open: 1,
+      },
+      controls: {
+        canCancel: true,
+        canResume: true,
+        canOpenTimeline: true,
+      },
+    });
+
+    expect(buildDurableTaskFlowStateProjection(projection)).toMatchObject({
+      workflowRunId: "wfr_parent",
+      waitingReason: "child",
+      children: { open: 1, failed: 1 },
+    });
+    expect(buildDurableWorkboardMetadataProjection(projection)).toMatchObject({
+      workflowRunId: "wfr_parent",
+      taskId: "task_parent",
+      taskFlowId: "flow_parent",
+      timelineCommand: "openclaw durable timeline wfr_parent",
+    });
+    expect(
+      mergeDurableProjectionIntoJsonObject(
+        { existing: true },
+        buildDurableTaskFlowStateProjection(projection),
+      ),
+    ).toMatchObject({
+      existing: true,
+      durable: {
+        workflowRunId: "wfr_parent",
+      },
+    });
+  });
+});

--- a/src/durable/coordination-projection.ts
+++ b/src/durable/coordination-projection.ts
@@ -1,0 +1,332 @@
+// Builds stable coordination projections for task, TaskFlow, and Workboard surfaces.
+import type {
+  DurableRecoveryState,
+  DurableWorkflowLink,
+  DurableWorkflowRef,
+  DurableWorkflowRun,
+  DurableWorkflowRunStatus,
+  DurableWorkflowStep,
+} from "./types.js";
+
+export const DURABLE_COORDINATION_METADATA_KEY = "durable";
+
+export type DurableCoordinationWaitingReason =
+  | "signal"
+  | "timer"
+  | "child"
+  | "retry"
+  | "worker"
+  | "unknown";
+
+export type DurableCoordinationExternalRefs = {
+  taskId?: string;
+  taskFlowId?: string;
+  workboardCardId?: string;
+  sessionKey?: string;
+  childSessionKey?: string;
+  runId?: string;
+  agentId?: string;
+  requesterAgentId?: string;
+};
+
+export type DurableCoordinationChildCounts = {
+  total: number;
+  pending: number;
+  running: number;
+  succeeded: number;
+  failed: number;
+  cancelled: number;
+  lost: number;
+  terminal: number;
+  open: number;
+};
+
+export type DurableCoordinationRefs = {
+  inputRef?: string;
+  checkpointRef?: string;
+  outputRefs: string[];
+  errorRefs: string[];
+  artifactRefs: string[];
+};
+
+export type DurableCoordinationControls = {
+  canCancel: boolean;
+  canRetry: boolean;
+  canResume: boolean;
+  canSignal: boolean;
+  canOpenTimeline: boolean;
+};
+
+export type DurableCoordinationProjection = {
+  workflowRunId: string;
+  workflowId: string;
+  workflowVersion: string;
+  status: DurableWorkflowRunStatus;
+  recoveryState: DurableRecoveryState;
+  sourceType?: string;
+  sourceRef?: string;
+  parentWorkflowRunId?: string;
+  parentStepId?: string;
+  currentStepId?: string;
+  waitingReason?: DurableCoordinationWaitingReason;
+  heartbeatAt?: number;
+  updatedAt: number;
+  completedAt?: number;
+  refs: DurableCoordinationRefs;
+  external: DurableCoordinationExternalRefs;
+  children: DurableCoordinationChildCounts;
+  controls: DurableCoordinationControls;
+};
+
+export type BuildDurableCoordinationProjectionInput = {
+  run: DurableWorkflowRun;
+  steps?: readonly DurableWorkflowStep[];
+  childLinks?: readonly DurableWorkflowLink[];
+  refs?: readonly DurableWorkflowRef[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function latestStep(steps: readonly DurableWorkflowStep[]): DurableWorkflowStep | undefined {
+  return [...steps].sort((left, right) => right.updatedAt - left.updatedAt)[0];
+}
+
+function latestOpenStep(steps: readonly DurableWorkflowStep[]): DurableWorkflowStep | undefined {
+  return [...steps]
+    .filter(
+      (step) =>
+        step.status !== "succeeded" &&
+        step.status !== "failed" &&
+        step.status !== "cancelled" &&
+        step.status !== "lost" &&
+        step.status !== "skipped",
+    )
+    .sort((left, right) => right.updatedAt - left.updatedAt)[0];
+}
+
+function inferWaitingReason(params: {
+  run: DurableWorkflowRun;
+  currentStep?: DurableWorkflowStep;
+}): DurableCoordinationWaitingReason | undefined {
+  if (params.run.recoveryState === "waiting_signal" || params.run.status === "waiting_signal") {
+    return "signal";
+  }
+  if (params.run.recoveryState === "waiting_timer" || params.run.status === "waiting_timer") {
+    return "timer";
+  }
+  if (params.run.recoveryState === "waiting_child" || params.run.status === "waiting_child") {
+    return "child";
+  }
+  if (params.run.recoveryState === "retry_scheduled" || params.run.status === "retry_scheduled") {
+    return "retry";
+  }
+  if (params.run.recoveryState === "claimed" || params.run.recoveryState === "running") {
+    return "worker";
+  }
+  if (params.run.recoveryState === "unknown_after_side_effect") {
+    return "unknown";
+  }
+  if (params.currentStep?.stepType === "fan_in" && params.currentStep.status === "waiting") {
+    return "child";
+  }
+  if (params.currentStep?.stepType === "signal" && params.currentStep.status === "waiting") {
+    return "signal";
+  }
+  if (params.currentStep?.stepType === "timer" && params.currentStep.status === "waiting") {
+    return "timer";
+  }
+  return undefined;
+}
+
+function childCounts(links: readonly DurableWorkflowLink[]): DurableCoordinationChildCounts {
+  const counts: DurableCoordinationChildCounts = {
+    total: links.length,
+    pending: 0,
+    running: 0,
+    succeeded: 0,
+    failed: 0,
+    cancelled: 0,
+    lost: 0,
+    terminal: 0,
+    open: 0,
+  };
+  for (const link of links) {
+    counts[link.status] += 1;
+  }
+  counts.terminal = counts.succeeded + counts.failed + counts.cancelled + counts.lost;
+  counts.open = counts.pending + counts.running;
+  return counts;
+}
+
+function refSummary(params: {
+  run: DurableWorkflowRun;
+  steps: readonly DurableWorkflowStep[];
+  refs: readonly DurableWorkflowRef[];
+}): DurableCoordinationRefs {
+  const outputRefs = new Set<string>();
+  const errorRefs = new Set<string>();
+  const artifactRefs = new Set<string>();
+  for (const step of params.steps) {
+    if (step.outputRef) {
+      outputRefs.add(step.outputRef);
+    }
+    if (step.errorRef) {
+      errorRefs.add(step.errorRef);
+    }
+  }
+  for (const ref of params.refs) {
+    if (ref.refKind === "output") {
+      outputRefs.add(ref.refId);
+    } else if (ref.refKind === "error") {
+      errorRefs.add(ref.refId);
+    } else if (ref.refKind === "artifact") {
+      artifactRefs.add(ref.refId);
+    }
+  }
+  return {
+    ...(params.run.inputRef ? { inputRef: params.run.inputRef } : {}),
+    ...(params.run.checkpointRef ? { checkpointRef: params.run.checkpointRef } : {}),
+    outputRefs: [...outputRefs],
+    errorRefs: [...errorRefs],
+    artifactRefs: [...artifactRefs],
+  };
+}
+
+export function extractDurableCoordinationExternalRefs(
+  run: DurableWorkflowRun,
+): DurableCoordinationExternalRefs {
+  const metadata = isRecord(run.metadata) ? run.metadata : {};
+  const taskId = firstString(metadata.taskId, metadata.task_id);
+  const taskFlowId = firstString(metadata.taskFlowId, metadata.flowId, metadata.parentFlowId);
+  const workboardCardId = firstString(metadata.workboardCardId, metadata.cardId);
+  const sessionKey = firstString(
+    metadata.sessionKey,
+    run.sourceType === "agent_turn" ? run.sourceRef : undefined,
+  );
+  const childSessionKey = firstString(
+    metadata.childSessionKey,
+    run.sourceType === "subagent" ? run.sourceRef : undefined,
+  );
+  const runId = firstString(metadata.runId, run.idempotencyKey);
+  const agentId = firstString(metadata.agentId);
+  const requesterAgentId = firstString(metadata.requesterAgentId);
+  return {
+    ...(taskId ? { taskId } : {}),
+    ...(taskFlowId ? { taskFlowId } : {}),
+    ...(workboardCardId ? { workboardCardId } : {}),
+    ...(sessionKey ? { sessionKey } : {}),
+    ...(childSessionKey ? { childSessionKey } : {}),
+    ...(runId ? { runId } : {}),
+    ...(agentId ? { agentId } : {}),
+    ...(requesterAgentId ? { requesterAgentId } : {}),
+  };
+}
+
+function isTerminalRun(status: DurableWorkflowRunStatus): boolean {
+  return (
+    status === "succeeded" || status === "failed" || status === "cancelled" || status === "lost"
+  );
+}
+
+export function buildDurableCoordinationProjection(
+  input: BuildDurableCoordinationProjectionInput,
+): DurableCoordinationProjection {
+  const steps = input.steps ?? [];
+  const childLinks = input.childLinks ?? [];
+  const currentStep = latestOpenStep(steps) ?? latestStep(steps);
+  const waitingReason = inferWaitingReason({ run: input.run, currentStep });
+  const terminal = isTerminalRun(input.run.status);
+  return {
+    workflowRunId: input.run.workflowRunId,
+    workflowId: input.run.workflowId,
+    workflowVersion: input.run.workflowVersion,
+    status: input.run.status,
+    recoveryState: input.run.recoveryState,
+    ...(input.run.sourceType ? { sourceType: input.run.sourceType } : {}),
+    ...(input.run.sourceRef ? { sourceRef: input.run.sourceRef } : {}),
+    ...(input.run.parentWorkflowRunId
+      ? { parentWorkflowRunId: input.run.parentWorkflowRunId }
+      : {}),
+    ...(input.run.parentStepId ? { parentStepId: input.run.parentStepId } : {}),
+    ...(currentStep ? { currentStepId: currentStep.stepId } : {}),
+    ...(waitingReason ? { waitingReason } : {}),
+    ...(input.run.heartbeatAt ? { heartbeatAt: input.run.heartbeatAt } : {}),
+    updatedAt: input.run.updatedAt,
+    ...(input.run.completedAt ? { completedAt: input.run.completedAt } : {}),
+    refs: refSummary({ run: input.run, steps, refs: input.refs ?? [] }),
+    external: extractDurableCoordinationExternalRefs(input.run),
+    children: childCounts(childLinks),
+    controls: {
+      canCancel: !terminal,
+      canRetry: terminal || input.run.recoveryState === "unknown_after_side_effect",
+      canResume:
+        !terminal &&
+        (input.run.status === "waiting" ||
+          input.run.status === "waiting_signal" ||
+          input.run.status === "waiting_timer" ||
+          input.run.status === "waiting_child" ||
+          input.run.status === "retry_scheduled"),
+      canSignal:
+        !terminal &&
+        (input.run.status === "waiting" ||
+          input.run.status === "waiting_signal" ||
+          input.run.recoveryState === "waiting_signal"),
+      canOpenTimeline: true,
+    },
+  };
+}
+
+export function buildDurableTaskFlowStateProjection(
+  projection: DurableCoordinationProjection,
+): Record<string, unknown> {
+  return {
+    workflowRunId: projection.workflowRunId,
+    workflowId: projection.workflowId,
+    status: projection.status,
+    recoveryState: projection.recoveryState,
+    ...(projection.currentStepId ? { currentStepId: projection.currentStepId } : {}),
+    ...(projection.waitingReason ? { waitingReason: projection.waitingReason } : {}),
+    children: projection.children,
+    external: projection.external,
+    updatedAt: projection.updatedAt,
+  };
+}
+
+export function buildDurableWorkboardMetadataProjection(
+  projection: DurableCoordinationProjection,
+): Record<string, unknown> {
+  return {
+    workflowRunId: projection.workflowRunId,
+    workflowId: projection.workflowId,
+    workflowVersion: projection.workflowVersion,
+    status: projection.status,
+    recoveryState: projection.recoveryState,
+    ...(projection.waitingReason ? { waitingReason: projection.waitingReason } : {}),
+    ...(projection.currentStepId ? { currentStepId: projection.currentStepId } : {}),
+    ...projection.external,
+    children: projection.children,
+    timelineCommand: `openclaw durable timeline ${projection.workflowRunId}`,
+    updatedAt: projection.updatedAt,
+  };
+}
+
+export function mergeDurableProjectionIntoJsonObject(
+  current: unknown,
+  durable: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    ...(isRecord(current) ? current : {}),
+    [DURABLE_COORDINATION_METADATA_KEY]: durable,
+  };
+}

--- a/src/durable/executor.test.ts
+++ b/src/durable/executor.test.ts
@@ -1,0 +1,196 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { runDurableExecutorOnce } from "./executor.js";
+import { createDurableWorkflowRegistry } from "./registry.js";
+import { openDurableWorkflowSqliteStore } from "./sqlite-store.js";
+
+function tempStore() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-executor-"));
+  const store = openDurableWorkflowSqliteStore({
+    path: path.join(dir, "openclaw.sqlite"),
+  });
+  return {
+    store,
+    cleanup: () => {
+      store.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe("durable workflow executor", () => {
+  it("claims a runnable step, runs a handler, records heartbeat, and completes the run", async () => {
+    const { store, cleanup } = tempStore();
+    try {
+      const registry = createDurableWorkflowRegistry();
+      registry.registerStepHandler("tool", (context) => {
+        context.heartbeat({ phase: "testing" });
+        return {
+          kind: "succeeded",
+          output: { ok: true },
+          completeRun: true,
+        };
+      });
+      const run = store.createRun({
+        workflowId: "test.workflow",
+        status: "queued",
+        recoveryState: "runnable",
+        now: 100,
+      });
+      const step = store.createStep({
+        workflowRunId: run.workflowRunId,
+        stepType: "tool",
+        status: "queued",
+        recoveryState: "runnable",
+        now: 110,
+      });
+      let clock = 120;
+
+      const result = await runDurableExecutorOnce({
+        store,
+        registry,
+        workerId: "worker-1",
+        workflowId: "test.workflow",
+        now: () => {
+          clock += 10;
+          return clock;
+        },
+      });
+
+      expect(result).toEqual({
+        claimed: true,
+        workflowRunId: run.workflowRunId,
+        stepId: step.stepId,
+        outcome: "succeeded",
+      });
+      expect(store.getRun(run.workflowRunId)).toMatchObject({
+        status: "succeeded",
+        recoveryState: "terminal",
+      });
+      expect(store.listSteps(run.workflowRunId)).toMatchObject([
+        {
+          stepId: step.stepId,
+          status: "succeeded",
+          recoveryState: "terminal",
+          outputRef: expect.any(String),
+        },
+      ]);
+      expect(store.getTimeline(run.workflowRunId).map((event) => event.eventType)).toEqual([
+        "workflow.step.running",
+        "workflow.step.heartbeat",
+        "workflow.step.succeeded",
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("schedules retry timers for retryable handler failures", async () => {
+    const { store, cleanup } = tempStore();
+    try {
+      const registry = createDurableWorkflowRegistry();
+      registry.registerStepHandler("tool", () => ({
+        kind: "failed",
+        error: { code: "temporary" },
+        retryAfterMs: 500,
+      }));
+      const run = store.createRun({
+        workflowId: "test.workflow",
+        status: "queued",
+        recoveryState: "runnable",
+        now: 100,
+      });
+      const step = store.createStep({
+        workflowRunId: run.workflowRunId,
+        stepType: "tool",
+        status: "queued",
+        recoveryState: "runnable",
+        maxAttempts: 3,
+        now: 110,
+      });
+
+      const result = await runDurableExecutorOnce({
+        store,
+        registry,
+        workerId: "worker-1",
+        workflowId: "test.workflow",
+        now: () => 200,
+      });
+
+      expect(result).toMatchObject({ claimed: true, outcome: "failed" });
+      expect(store.getRun(run.workflowRunId)).toMatchObject({
+        status: "retry_scheduled",
+        recoveryState: "retry_scheduled",
+      });
+      expect(store.listSteps(run.workflowRunId)).toMatchObject([
+        {
+          stepId: step.stepId,
+          status: "retry_scheduled",
+          recoveryState: "retry_scheduled",
+          attempt: 2,
+          errorRef: expect.any(String),
+        },
+      ]);
+      expect(store.listTimers(run.workflowRunId)).toMatchObject([
+        {
+          timerType: "retry",
+          dueAt: 700,
+          status: "pending",
+          stepId: step.stepId,
+        },
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("marks unhandled step types as unknown instead of replaying blindly", async () => {
+    const { store, cleanup } = tempStore();
+    try {
+      const registry = createDurableWorkflowRegistry();
+      const run = store.createRun({
+        workflowId: "test.workflow",
+        status: "queued",
+        recoveryState: "runnable",
+        now: 100,
+      });
+      const step = store.createStep({
+        workflowRunId: run.workflowRunId,
+        stepType: "agent",
+        status: "queued",
+        recoveryState: "runnable",
+        now: 110,
+      });
+
+      const result = await runDurableExecutorOnce({
+        store,
+        registry,
+        workerId: "worker-1",
+        workflowId: "test.workflow",
+        now: () => 200,
+      });
+
+      expect(result).toEqual({
+        claimed: true,
+        workflowRunId: run.workflowRunId,
+        stepId: step.stepId,
+        outcome: "no_handler",
+      });
+      expect(store.getRun(run.workflowRunId)).toMatchObject({
+        status: "waiting",
+        recoveryState: "unknown_after_side_effect",
+      });
+      expect(store.listSteps(run.workflowRunId)).toMatchObject([
+        {
+          stepId: step.stepId,
+          status: "waiting",
+          recoveryState: "unknown_after_side_effect",
+        },
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/durable/executor.ts
+++ b/src/durable/executor.ts
@@ -1,0 +1,548 @@
+import type { DurableWorkflowRegistry, DurableWorkflowStepHandlerResult } from "./registry.js";
+import type {
+  DurableWorkflowRef,
+  DurableWorkflowRun,
+  DurableWorkflowStep,
+  DurableWorkflowStepType,
+  DurableWorkflowStore,
+} from "./types.js";
+
+export type DurableExecutorRunOnceOptions = {
+  store: DurableWorkflowStore;
+  registry: DurableWorkflowRegistry;
+  workerId: string;
+  claimTtlMs?: number;
+  workflowId?: string;
+  stepType?: DurableWorkflowStepType;
+  now?: () => number;
+};
+
+export type DurableExecutorRunOnceResult =
+  | {
+      claimed: false;
+      reason: "no_runnable_step";
+    }
+  | {
+      claimed: true;
+      workflowRunId: string;
+      stepId: string;
+      outcome: DurableWorkflowStepHandlerResult["kind"] | "no_handler" | "handler_exception";
+    };
+
+const DEFAULT_CLAIM_TTL_MS = 5 * 60 * 1000;
+
+function terminalRunStatus(run: DurableWorkflowRun): boolean {
+  return (
+    run.status === "succeeded" ||
+    run.status === "failed" ||
+    run.status === "cancelled" ||
+    run.status === "lost"
+  );
+}
+
+function createJsonRef(params: {
+  store: DurableWorkflowStore;
+  run: DurableWorkflowRun;
+  step: DurableWorkflowStep;
+  refKind: DurableWorkflowRef["refKind"];
+  metadata: Record<string, unknown>;
+  label: string;
+  now: number;
+}): DurableWorkflowRef {
+  return params.store.createRef({
+    workflowRunId: params.run.workflowRunId,
+    stepId: params.step.stepId,
+    refKind: params.refKind,
+    mediaType: "application/json",
+    storageKind: "inline",
+    storageUri: `inline:durable-step:${params.step.stepId}:${params.label}`,
+    metadata: params.metadata,
+    now: params.now,
+  });
+}
+
+function clearStepClaimFields(workerId: string): {
+  claimedBy: null;
+  claimExpiresAt: null;
+  heartbeatAt: null;
+} {
+  void workerId;
+  return {
+    claimedBy: null,
+    claimExpiresAt: null,
+    heartbeatAt: null,
+  };
+}
+
+function markNoHandler(params: {
+  store: DurableWorkflowStore;
+  run: DurableWorkflowRun;
+  step: DurableWorkflowStep;
+  workerId: string;
+  now: number;
+}): DurableExecutorRunOnceResult {
+  params.store.updateStep({
+    workflowRunId: params.step.workflowRunId,
+    stepId: params.step.stepId,
+    status: "waiting",
+    recoveryState: "unknown_after_side_effect",
+    ...clearStepClaimFields(params.workerId),
+    now: params.now,
+  });
+  params.store.updateRun({
+    workflowRunId: params.run.workflowRunId,
+    status: "waiting",
+    recoveryState: "unknown_after_side_effect",
+    heartbeatAt: null,
+    now: params.now,
+  });
+  params.store.appendEvent({
+    workflowRunId: params.run.workflowRunId,
+    eventType: "workflow.step.no_handler",
+    eventTime: params.now,
+    stepId: params.step.stepId,
+    payload: {
+      stepType: params.step.stepType,
+      workerId: params.workerId,
+    },
+  });
+  return {
+    claimed: true,
+    workflowRunId: params.run.workflowRunId,
+    stepId: params.step.stepId,
+    outcome: "no_handler",
+  };
+}
+
+function markHandlerException(params: {
+  store: DurableWorkflowStore;
+  run: DurableWorkflowRun;
+  step: DurableWorkflowStep;
+  workerId: string;
+  now: number;
+  err: unknown;
+}): DurableExecutorRunOnceResult {
+  const errorRef = createJsonRef({
+    store: params.store,
+    run: params.run,
+    step: params.step,
+    refKind: "error",
+    label: "handler-exception",
+    metadata: { message: String(params.err) },
+    now: params.now,
+  });
+  params.store.updateStep({
+    workflowRunId: params.step.workflowRunId,
+    stepId: params.step.stepId,
+    status: "failed",
+    recoveryState: "terminal",
+    errorRef: errorRef.refId,
+    completedAt: params.now,
+    ...clearStepClaimFields(params.workerId),
+    now: params.now,
+  });
+  params.store.updateRun({
+    workflowRunId: params.run.workflowRunId,
+    status: "failed",
+    recoveryState: "terminal",
+    completedAt: params.now,
+    heartbeatAt: null,
+    now: params.now,
+  });
+  params.store.appendEvent({
+    workflowRunId: params.run.workflowRunId,
+    eventType: "workflow.step.handler_exception",
+    eventTime: params.now,
+    stepId: params.step.stepId,
+    payload: {
+      errorRef: errorRef.refId,
+      workerId: params.workerId,
+    },
+  });
+  return {
+    claimed: true,
+    workflowRunId: params.run.workflowRunId,
+    stepId: params.step.stepId,
+    outcome: "handler_exception",
+  };
+}
+
+function applyStepResult(params: {
+  store: DurableWorkflowStore;
+  run: DurableWorkflowRun;
+  step: DurableWorkflowStep;
+  workerId: string;
+  now: number;
+  result: DurableWorkflowStepHandlerResult;
+}): DurableExecutorRunOnceResult {
+  const { store, run, step, workerId, now, result } = params;
+
+  if (result.kind === "succeeded") {
+    const outputRef =
+      result.outputRef ??
+      (result.output
+        ? createJsonRef({
+            store,
+            run,
+            step,
+            refKind: "output",
+            label: "output",
+            metadata: result.output,
+            now,
+          }).refId
+        : undefined);
+    store.updateStep({
+      workflowRunId: step.workflowRunId,
+      stepId: step.stepId,
+      status: "succeeded",
+      recoveryState: "terminal",
+      outputRef,
+      checkpointRef: result.checkpointRef ?? null,
+      completedAt: now,
+      ...clearStepClaimFields(workerId),
+      now,
+    });
+    store.appendEvent({
+      workflowRunId: run.workflowRunId,
+      eventType: "workflow.step.succeeded",
+      eventTime: now,
+      stepId: step.stepId,
+      payload: { outputRef, workerId },
+    });
+    store.updateRun(
+      result.completeRun
+        ? {
+            workflowRunId: run.workflowRunId,
+            status: "succeeded",
+            recoveryState: "terminal",
+            checkpointRef: result.checkpointRef ?? null,
+            completedAt: now,
+            heartbeatAt: null,
+            now,
+          }
+        : {
+            workflowRunId: run.workflowRunId,
+            status: "queued",
+            recoveryState: "runnable",
+            checkpointRef: result.checkpointRef ?? undefined,
+            heartbeatAt: null,
+            now,
+          },
+    );
+    return {
+      claimed: true,
+      workflowRunId: run.workflowRunId,
+      stepId: step.stepId,
+      outcome: result.kind,
+    };
+  }
+
+  if (result.kind === "failed") {
+    const errorRef = createJsonRef({
+      store,
+      run,
+      step,
+      refKind: "error",
+      label: "error",
+      metadata: result.error ?? { message: "durable step failed" },
+      now,
+    });
+    const retryAllowed = Boolean(
+      result.retryAfterMs && (!step.maxAttempts || step.attempt < step.maxAttempts),
+    );
+    if (retryAllowed) {
+      const timer = store.createTimer({
+        workflowRunId: run.workflowRunId,
+        stepId: step.stepId,
+        timerType: "retry",
+        dueAt: now + Math.max(0, Math.trunc(result.retryAfterMs ?? 0)),
+        metadata: { errorRef: errorRef.refId },
+        now,
+      });
+      store.updateStep({
+        workflowRunId: step.workflowRunId,
+        stepId: step.stepId,
+        status: "retry_scheduled",
+        recoveryState: "retry_scheduled",
+        attempt: step.attempt + 1,
+        errorRef: errorRef.refId,
+        checkpointRef: result.checkpointRef ?? null,
+        ...clearStepClaimFields(workerId),
+        now,
+      });
+      store.updateRun({
+        workflowRunId: run.workflowRunId,
+        status: "retry_scheduled",
+        recoveryState: "retry_scheduled",
+        checkpointRef: result.checkpointRef ?? undefined,
+        heartbeatAt: null,
+        now,
+      });
+      store.appendEvent({
+        workflowRunId: run.workflowRunId,
+        eventType: "workflow.step.retry_scheduled",
+        eventTime: now,
+        stepId: step.stepId,
+        payload: { errorRef: errorRef.refId, timerId: timer.timerId, workerId },
+      });
+      return {
+        claimed: true,
+        workflowRunId: run.workflowRunId,
+        stepId: step.stepId,
+        outcome: result.kind,
+      };
+    }
+    store.updateStep({
+      workflowRunId: step.workflowRunId,
+      stepId: step.stepId,
+      status: "failed",
+      recoveryState: "terminal",
+      errorRef: errorRef.refId,
+      checkpointRef: result.checkpointRef ?? null,
+      completedAt: now,
+      ...clearStepClaimFields(workerId),
+      now,
+    });
+    if (result.completeRun !== false) {
+      store.updateRun({
+        workflowRunId: run.workflowRunId,
+        status: "failed",
+        recoveryState: "terminal",
+        checkpointRef: result.checkpointRef ?? null,
+        completedAt: now,
+        heartbeatAt: null,
+        now,
+      });
+    }
+    store.appendEvent({
+      workflowRunId: run.workflowRunId,
+      eventType: "workflow.step.failed",
+      eventTime: now,
+      stepId: step.stepId,
+      payload: { errorRef: errorRef.refId, workerId },
+    });
+    return {
+      claimed: true,
+      workflowRunId: run.workflowRunId,
+      stepId: step.stepId,
+      outcome: result.kind,
+    };
+  }
+
+  if (result.kind === "waiting_signal") {
+    store.updateStep({
+      workflowRunId: step.workflowRunId,
+      stepId: step.stepId,
+      status: "waiting",
+      recoveryState: "waiting_signal",
+      checkpointRef: result.checkpointRef ?? null,
+      ...clearStepClaimFields(workerId),
+      now,
+    });
+    store.updateRun({
+      workflowRunId: run.workflowRunId,
+      status: "waiting_signal",
+      recoveryState: "waiting_signal",
+      checkpointRef: result.checkpointRef ?? undefined,
+      heartbeatAt: null,
+      now,
+    });
+    store.appendEvent({
+      workflowRunId: run.workflowRunId,
+      eventType: "workflow.step.waiting_signal",
+      eventTime: now,
+      stepId: step.stepId,
+      payload: { reason: result.reason, workerId },
+    });
+    return {
+      claimed: true,
+      workflowRunId: run.workflowRunId,
+      stepId: step.stepId,
+      outcome: result.kind,
+    };
+  }
+
+  if (result.kind === "waiting_timer") {
+    const timer = store.createTimer({
+      workflowRunId: run.workflowRunId,
+      stepId: step.stepId,
+      timerType: result.timerType ?? "sleep",
+      dueAt: result.dueAt,
+      metadata: { reason: result.reason },
+      now,
+    });
+    store.updateStep({
+      workflowRunId: step.workflowRunId,
+      stepId: step.stepId,
+      status: "waiting",
+      recoveryState: "waiting_timer",
+      checkpointRef: result.checkpointRef ?? null,
+      ...clearStepClaimFields(workerId),
+      now,
+    });
+    store.updateRun({
+      workflowRunId: run.workflowRunId,
+      status: "waiting_timer",
+      recoveryState: "waiting_timer",
+      checkpointRef: result.checkpointRef ?? undefined,
+      heartbeatAt: null,
+      now,
+    });
+    store.appendEvent({
+      workflowRunId: run.workflowRunId,
+      eventType: "workflow.step.waiting_timer",
+      eventTime: now,
+      stepId: step.stepId,
+      payload: { timerId: timer.timerId, reason: result.reason, workerId },
+    });
+    return {
+      claimed: true,
+      workflowRunId: run.workflowRunId,
+      stepId: step.stepId,
+      outcome: result.kind,
+    };
+  }
+
+  store.updateStep({
+    workflowRunId: step.workflowRunId,
+    stepId: step.stepId,
+    status: "waiting",
+    recoveryState: "unknown_after_side_effect",
+    checkpointRef: result.checkpointRef ?? null,
+    ...clearStepClaimFields(workerId),
+    now,
+  });
+  store.updateRun({
+    workflowRunId: run.workflowRunId,
+    status: "waiting",
+    recoveryState: "unknown_after_side_effect",
+    checkpointRef: result.checkpointRef ?? undefined,
+    heartbeatAt: null,
+    now,
+  });
+  store.appendEvent({
+    workflowRunId: run.workflowRunId,
+    eventType: "workflow.step.side_effect_uncertain",
+    eventTime: now,
+    stepId: step.stepId,
+    payload: { reason: result.reason, workerId },
+  });
+  return {
+    claimed: true,
+    workflowRunId: run.workflowRunId,
+    stepId: step.stepId,
+    outcome: result.kind,
+  };
+}
+
+export async function runDurableExecutorOnce(
+  options: DurableExecutorRunOnceOptions,
+): Promise<DurableExecutorRunOnceResult> {
+  const now = options.now ?? (() => Date.now());
+  const claimTime = now();
+  const step = options.store.claimNextRunnableStep({
+    workflowId: options.workflowId,
+    stepType: options.stepType,
+    workerId: options.workerId,
+    claimTtlMs: options.claimTtlMs ?? DEFAULT_CLAIM_TTL_MS,
+    now: claimTime,
+  });
+  if (!step) {
+    return { claimed: false, reason: "no_runnable_step" };
+  }
+  const run = options.store.getRun(step.workflowRunId);
+  if (!run || terminalRunStatus(run)) {
+    options.store.releaseStepClaim({
+      workflowRunId: step.workflowRunId,
+      stepId: step.stepId,
+      workerId: options.workerId,
+      now: now(),
+    });
+    return { claimed: false, reason: "no_runnable_step" };
+  }
+  const handler = options.registry.getStepHandler(step.stepType);
+  const startTime = now();
+  options.store.updateStep({
+    workflowRunId: step.workflowRunId,
+    stepId: step.stepId,
+    status: "running",
+    recoveryState: "running",
+    startedAt: step.startedAt ?? startTime,
+    heartbeatAt: startTime,
+    now: startTime,
+  });
+  options.store.updateRun({
+    workflowRunId: run.workflowRunId,
+    status: "running",
+    recoveryState: "running",
+    heartbeatAt: startTime,
+    now: startTime,
+  });
+  options.store.appendEvent({
+    workflowRunId: run.workflowRunId,
+    eventType: "workflow.step.running",
+    eventTime: startTime,
+    stepId: step.stepId,
+    payload: {
+      stepType: step.stepType,
+      workerId: options.workerId,
+    },
+  });
+  if (!handler) {
+    return markNoHandler({
+      store: options.store,
+      run,
+      step,
+      workerId: options.workerId,
+      now: now(),
+    });
+  }
+
+  try {
+    const result = await handler({
+      store: options.store,
+      run,
+      step,
+      workerId: options.workerId,
+      now,
+      heartbeat: (payload?: Record<string, unknown>) => {
+        const heartbeatAt = now();
+        options.store.updateStep({
+          workflowRunId: step.workflowRunId,
+          stepId: step.stepId,
+          heartbeatAt,
+          now: heartbeatAt,
+        });
+        options.store.updateRun({
+          workflowRunId: run.workflowRunId,
+          heartbeatAt,
+          now: heartbeatAt,
+        });
+        options.store.appendEvent({
+          workflowRunId: run.workflowRunId,
+          eventType: "workflow.step.heartbeat",
+          eventTime: heartbeatAt,
+          stepId: step.stepId,
+          payload: { ...payload, workerId: options.workerId },
+        });
+      },
+    });
+    return applyStepResult({
+      store: options.store,
+      run,
+      step,
+      workerId: options.workerId,
+      now: now(),
+      result,
+    });
+  } catch (err) {
+    return markHandlerException({
+      store: options.store,
+      run,
+      step,
+      workerId: options.workerId,
+      now: now(),
+      err,
+    });
+  }
+}

--- a/src/durable/fan-in.test.ts
+++ b/src/durable/fan-in.test.ts
@@ -1,0 +1,263 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { reconcileDurableFanIn } from "./fan-in.js";
+import { openDurableWorkflowSqliteStore } from "./sqlite-store.js";
+
+describe("durable workflow fan-in", () => {
+  it("unblocks the parent when all children are terminal under continue policy", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-fanin-"));
+    const store = openDurableWorkflowSqliteStore({
+      path: path.join(dir, "openclaw.sqlite"),
+    });
+    try {
+      const parent = store.createRun({
+        workflowId: "test.parent",
+        status: "waiting_child",
+        recoveryState: "waiting_child",
+        now: 100,
+      });
+      const fanInStep = store.createStep({
+        workflowRunId: parent.workflowRunId,
+        stepId: "fan_in_children",
+        stepType: "fan_in",
+        status: "waiting",
+        recoveryState: "waiting_child",
+        now: 100,
+      });
+      const childA = store.createRun({
+        workflowId: "test.child",
+        parentWorkflowRunId: parent.workflowRunId,
+        parentStepId: fanInStep.stepId,
+        status: "succeeded",
+        recoveryState: "terminal",
+        completedAt: 120,
+        now: 120,
+      });
+      const childB = store.createRun({
+        workflowId: "test.child",
+        parentWorkflowRunId: parent.workflowRunId,
+        parentStepId: fanInStep.stepId,
+        status: "failed",
+        recoveryState: "terminal",
+        completedAt: 130,
+        now: 130,
+      });
+      store.createLink({
+        parentWorkflowRunId: parent.workflowRunId,
+        parentStepId: fanInStep.stepId,
+        childWorkflowRunId: childA.workflowRunId,
+        linkType: "child_workflow",
+        status: "succeeded",
+        now: 121,
+      });
+      store.createLink({
+        parentWorkflowRunId: parent.workflowRunId,
+        parentStepId: fanInStep.stepId,
+        childWorkflowRunId: childB.workflowRunId,
+        linkType: "child_workflow",
+        status: "failed",
+        now: 131,
+      });
+
+      const result = reconcileDurableFanIn({
+        store,
+        parentWorkflowRunId: parent.workflowRunId,
+        parentStepId: fanInStep.stepId,
+        policy: "continue_on_child_failure",
+        now: 140,
+      });
+
+      expect(result).toEqual({
+        status: "succeeded",
+        total: 2,
+        succeeded: 1,
+        failed: 1,
+        terminal: 2,
+        ready: true,
+      });
+      expect(store.listSteps(parent.workflowRunId)).toMatchObject([
+        {
+          stepId: fanInStep.stepId,
+          status: "succeeded",
+          recoveryState: "terminal",
+          completedAt: 140,
+        },
+      ]);
+      expect(store.listOpenRuns({ workflowId: "test.parent" })).toMatchObject([
+        {
+          workflowRunId: parent.workflowRunId,
+          status: "queued",
+          recoveryState: "runnable",
+        },
+      ]);
+      expect(store.getTimeline(parent.workflowRunId).at(-1)).toMatchObject({
+        eventType: "fan_in.ready",
+      });
+    } finally {
+      store.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails the parent when fail-parent policy sees a failed child", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-fanin-"));
+    const store = openDurableWorkflowSqliteStore({
+      path: path.join(dir, "openclaw.sqlite"),
+    });
+    try {
+      const parent = store.createRun({
+        workflowId: "test.parent",
+        status: "waiting_child",
+        recoveryState: "waiting_child",
+        now: 100,
+      });
+      const fanInStep = store.createStep({
+        workflowRunId: parent.workflowRunId,
+        stepId: "fan_in_children",
+        stepType: "fan_in",
+        status: "waiting",
+        recoveryState: "waiting_child",
+        now: 100,
+      });
+      const child = store.createRun({
+        workflowId: "test.child",
+        status: "failed",
+        recoveryState: "terminal",
+        completedAt: 120,
+        now: 120,
+      });
+      store.createLink({
+        parentWorkflowRunId: parent.workflowRunId,
+        parentStepId: fanInStep.stepId,
+        childWorkflowRunId: child.workflowRunId,
+        linkType: "child_workflow",
+        status: "failed",
+        now: 121,
+      });
+
+      const result = reconcileDurableFanIn({
+        store,
+        parentWorkflowRunId: parent.workflowRunId,
+        parentStepId: fanInStep.stepId,
+        policy: "fail_parent_on_child_failure",
+        now: 130,
+      });
+
+      expect(result.status).toBe("failed");
+      expect(store.listRuns({ limit: 10 })).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            workflowRunId: parent.workflowRunId,
+            status: "failed",
+            recoveryState: "terminal",
+            completedAt: 130,
+          }),
+        ]),
+      );
+      expect(store.getTimeline(parent.workflowRunId).at(-1)).toMatchObject({
+        eventType: "fan_in.failed",
+      });
+    } finally {
+      store.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reopens a completed fan-in step when a new child is linked later", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-fanin-"));
+    const store = openDurableWorkflowSqliteStore({
+      path: path.join(dir, "openclaw.sqlite"),
+    });
+    try {
+      const parent = store.createRun({
+        workflowId: "test.parent",
+        status: "waiting_child",
+        recoveryState: "waiting_child",
+        now: 100,
+      });
+      const fanInStep = store.createStep({
+        workflowRunId: parent.workflowRunId,
+        stepId: "fan_in_children",
+        stepType: "fan_in",
+        status: "waiting",
+        recoveryState: "waiting_child",
+        now: 100,
+      });
+      const firstChild = store.createRun({
+        workflowId: "test.child",
+        status: "succeeded",
+        recoveryState: "terminal",
+        completedAt: 120,
+        now: 120,
+      });
+      store.createLink({
+        parentWorkflowRunId: parent.workflowRunId,
+        parentStepId: fanInStep.stepId,
+        childWorkflowRunId: firstChild.workflowRunId,
+        linkType: "child_workflow",
+        status: "succeeded",
+        now: 121,
+      });
+
+      expect(
+        reconcileDurableFanIn({
+          store,
+          parentWorkflowRunId: parent.workflowRunId,
+          parentStepId: fanInStep.stepId,
+          policy: "continue_on_child_failure",
+          now: 130,
+        }).status,
+      ).toBe("succeeded");
+      const laterChild = store.createRun({
+        workflowId: "test.child",
+        status: "running",
+        recoveryState: "running",
+        now: 140,
+      });
+      store.createLink({
+        parentWorkflowRunId: parent.workflowRunId,
+        parentStepId: fanInStep.stepId,
+        childWorkflowRunId: laterChild.workflowRunId,
+        linkType: "child_workflow",
+        status: "running",
+        now: 141,
+      });
+
+      const result = reconcileDurableFanIn({
+        store,
+        parentWorkflowRunId: parent.workflowRunId,
+        parentStepId: fanInStep.stepId,
+        policy: "continue_on_child_failure",
+        now: 150,
+      });
+
+      expect(result).toEqual({
+        status: "waiting",
+        total: 2,
+        succeeded: 1,
+        failed: 0,
+        terminal: 1,
+        ready: false,
+      });
+      const reopenedStep = store.listSteps(parent.workflowRunId)[0];
+      expect(reopenedStep).toMatchObject({
+        stepId: fanInStep.stepId,
+        status: "waiting",
+        recoveryState: "waiting_child",
+      });
+      expect(reopenedStep?.completedAt).toBeUndefined();
+      const reopenedParent = store.listOpenRuns({ workflowId: "test.parent" })[0];
+      expect(reopenedParent).toMatchObject({
+        workflowRunId: parent.workflowRunId,
+        status: "waiting_child",
+        recoveryState: "waiting_child",
+      });
+      expect(reopenedParent?.completedAt).toBeUndefined();
+    } finally {
+      store.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/durable/fan-in.ts
+++ b/src/durable/fan-in.ts
@@ -1,0 +1,171 @@
+// Durable parent/child fan-in policy helpers.
+import type {
+  DurableWorkflowLinkStatus,
+  DurableWorkflowStepStatus,
+  DurableWorkflowStore,
+} from "./types.js";
+
+export type DurableFanInPolicy =
+  | "all_succeeded"
+  | "all_terminal"
+  | "first_success"
+  | "continue_on_child_failure"
+  | "fail_parent_on_child_failure";
+
+export type DurableFanInResult = {
+  status: DurableWorkflowStepStatus;
+  total: number;
+  succeeded: number;
+  failed: number;
+  terminal: number;
+  ready: boolean;
+};
+
+function isTerminalLinkStatus(status: DurableWorkflowLinkStatus): boolean {
+  return (
+    status === "succeeded" || status === "failed" || status === "cancelled" || status === "lost"
+  );
+}
+
+function computeFanInResult(params: {
+  statuses: DurableWorkflowLinkStatus[];
+  policy: DurableFanInPolicy;
+}): DurableFanInResult {
+  const total = params.statuses.length;
+  const succeeded = params.statuses.filter((status) => status === "succeeded").length;
+  const failed = params.statuses.filter(
+    (status) => status === "failed" || status === "cancelled" || status === "lost",
+  ).length;
+  const terminal = params.statuses.filter(isTerminalLinkStatus).length;
+
+  if (total === 0) {
+    return { status: "waiting", total, succeeded, failed, terminal, ready: false };
+  }
+
+  switch (params.policy) {
+    case "all_succeeded":
+      if (failed > 0) {
+        return { status: "failed", total, succeeded, failed, terminal, ready: true };
+      }
+      return {
+        status: succeeded === total ? "succeeded" : "waiting",
+        total,
+        succeeded,
+        failed,
+        terminal,
+        ready: succeeded === total,
+      };
+    case "all_terminal":
+    case "continue_on_child_failure":
+      return {
+        status: terminal === total ? "succeeded" : "waiting",
+        total,
+        succeeded,
+        failed,
+        terminal,
+        ready: terminal === total,
+      };
+    case "first_success":
+      if (succeeded > 0) {
+        return { status: "succeeded", total, succeeded, failed, terminal, ready: true };
+      }
+      return {
+        status: terminal === total ? "failed" : "waiting",
+        total,
+        succeeded,
+        failed,
+        terminal,
+        ready: terminal === total,
+      };
+    case "fail_parent_on_child_failure":
+      if (failed > 0) {
+        return { status: "failed", total, succeeded, failed, terminal, ready: true };
+      }
+      return {
+        status: succeeded === total ? "succeeded" : "waiting",
+        total,
+        succeeded,
+        failed,
+        terminal,
+        ready: succeeded === total,
+      };
+  }
+}
+
+export function reconcileDurableFanIn(params: {
+  store: DurableWorkflowStore;
+  parentWorkflowRunId: string;
+  parentStepId: string;
+  policy: DurableFanInPolicy;
+  now?: number;
+}): DurableFanInResult {
+  const now = params.now ?? Date.now();
+  const childLinks = params.store
+    .listChildLinks(params.parentWorkflowRunId)
+    .filter((link) => link.parentStepId === params.parentStepId);
+  const result = computeFanInResult({
+    statuses: childLinks.map((link) => link.status),
+    policy: params.policy,
+  });
+
+  params.store.updateStep({
+    workflowRunId: params.parentWorkflowRunId,
+    stepId: params.parentStepId,
+    status: result.status,
+    recoveryState: result.status === "waiting" ? "waiting_child" : "terminal",
+    completedAt: result.ready ? now : null,
+    metadata: {
+      policy: params.policy,
+      total: result.total,
+      succeeded: result.succeeded,
+      failed: result.failed,
+      terminal: result.terminal,
+    },
+    now,
+  });
+
+  params.store.appendEvent({
+    workflowRunId: params.parentWorkflowRunId,
+    eventType: result.ready
+      ? result.status === "succeeded"
+        ? "fan_in.ready"
+        : "fan_in.failed"
+      : "fan_in.partial",
+    eventTime: now,
+    stepId: params.parentStepId,
+    payload: {
+      policy: params.policy,
+      total: result.total,
+      succeeded: result.succeeded,
+      failed: result.failed,
+      terminal: result.terminal,
+    },
+  });
+
+  if (result.status === "waiting") {
+    params.store.updateRun({
+      workflowRunId: params.parentWorkflowRunId,
+      status: "waiting_child",
+      recoveryState: "waiting_child",
+      completedAt: null,
+      now,
+    });
+  } else if (result.status === "succeeded") {
+    params.store.updateRun({
+      workflowRunId: params.parentWorkflowRunId,
+      status: "queued",
+      recoveryState: "runnable",
+      now,
+    });
+  } else if (result.status === "failed" && params.policy === "fail_parent_on_child_failure") {
+    params.store.updateRun({
+      workflowRunId: params.parentWorkflowRunId,
+      status: "failed",
+      recoveryState: "terminal",
+      completedAt: now,
+      now,
+    });
+  }
+
+  return result;
+}

--- a/src/durable/recovery.test.ts
+++ b/src/durable/recovery.test.ts
@@ -1,0 +1,265 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  reconcileDueDurableTimers,
+  reconcileDurableAgentTurnsOnGatewayStartup,
+  reconcilePendingDurableSignals,
+  reconcileStaleDurableAgentTurns,
+} from "./recovery.js";
+import { openDurableWorkflowSqliteStore } from "./sqlite-store.js";
+import { DURABLE_AGENT_TURN_WORKFLOW_ID } from "./workflow-ids.js";
+
+describe("durable workflow recovery", () => {
+  it("marks running agent turns lost on gateway startup without touching waiting turns", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-recovery-"));
+    const store = openDurableWorkflowSqliteStore({
+      path: path.join(dir, "openclaw.sqlite"),
+    });
+    try {
+      const running = store.createRun({
+        workflowId: DURABLE_AGENT_TURN_WORKFLOW_ID,
+        idempotencyKey: "run-running",
+        status: "running",
+        recoveryState: "running",
+        metadata: { sessionKey: "agent:test:running" },
+        now: 100,
+      });
+      const runningStep = store.createStep({
+        workflowRunId: running.workflowRunId,
+        stepId: "agent_invocation",
+        stepType: "agent",
+        status: "running",
+        recoveryState: "running",
+        now: 100,
+      });
+      const waiting = store.createRun({
+        workflowId: DURABLE_AGENT_TURN_WORKFLOW_ID,
+        idempotencyKey: "run-waiting",
+        status: "waiting",
+        recoveryState: "waiting_signal",
+        metadata: { sessionKey: "agent:test:waiting" },
+        now: 100,
+      });
+
+      const result = reconcileDurableAgentTurnsOnGatewayStartup({
+        store,
+        processInstanceId: "process-1",
+        now: 200,
+      });
+
+      expect(result).toEqual({ scanned: 2, markedLost: 1 });
+      expect(store.listRuns({ limit: 10 })).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            workflowRunId: running.workflowRunId,
+            status: "lost",
+            recoveryState: "lost",
+            completedAt: 200,
+          }),
+          expect.objectContaining({
+            workflowRunId: waiting.workflowRunId,
+            status: "waiting",
+            recoveryState: "waiting_signal",
+          }),
+        ]),
+      );
+      expect(store.getTimeline(running.workflowRunId).map((event) => event.eventType)).toEqual([
+        "agent.turn.lost",
+      ]);
+      expect(store.listSteps(running.workflowRunId)).toMatchObject([
+        {
+          stepId: runningStep.stepId,
+          status: "lost",
+          recoveryState: "lost",
+          completedAt: 200,
+        },
+      ]);
+    } finally {
+      store.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("marks only stale running agent turns lost during periodic recovery", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-recovery-"));
+    const store = openDurableWorkflowSqliteStore({
+      path: path.join(dir, "openclaw.sqlite"),
+    });
+    try {
+      const stale = store.createRun({
+        workflowId: DURABLE_AGENT_TURN_WORKFLOW_ID,
+        idempotencyKey: "run-stale",
+        status: "running",
+        recoveryState: "running",
+        metadata: { sessionKey: "agent:test:stale" },
+        now: 100,
+      });
+      const fresh = store.createRun({
+        workflowId: DURABLE_AGENT_TURN_WORKFLOW_ID,
+        idempotencyKey: "run-fresh",
+        status: "running",
+        recoveryState: "running",
+        metadata: { sessionKey: "agent:test:fresh" },
+        now: 1_900,
+      });
+
+      const result = reconcileStaleDurableAgentTurns({
+        store,
+        processInstanceId: "process-1",
+        now: 2_000,
+        staleAfterMs: 1_000,
+      });
+
+      expect(result).toEqual({ scanned: 2, markedLost: 1 });
+      expect(store.listRuns({ limit: 10 })).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            workflowRunId: stale.workflowRunId,
+            status: "lost",
+            recoveryState: "lost",
+            completedAt: 2_000,
+          }),
+          expect.objectContaining({
+            workflowRunId: fresh.workflowRunId,
+            status: "running",
+            recoveryState: "running",
+          }),
+        ]),
+      );
+      expect(store.getTimeline(stale.workflowRunId).at(-1)).toMatchObject({
+        eventType: "agent.turn.lost",
+        payload: expect.objectContaining({
+          reason: "stale_agent_turn_reconciliation",
+        }),
+      });
+    } finally {
+      store.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("queues retry-scheduled run and step only when retry timer is due", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-recovery-"));
+    const store = openDurableWorkflowSqliteStore({
+      path: path.join(dir, "openclaw.sqlite"),
+    });
+    try {
+      const run = store.createRun({
+        workflowId: "test.workflow",
+        idempotencyKey: "run-retry",
+        status: "retry_scheduled",
+        recoveryState: "retry_scheduled",
+        now: 100,
+      });
+      const step = store.createStep({
+        workflowRunId: run.workflowRunId,
+        stepId: "tool_step",
+        stepType: "tool",
+        status: "retry_scheduled",
+        recoveryState: "retry_scheduled",
+        now: 100,
+      });
+      store.createTimer({
+        workflowRunId: run.workflowRunId,
+        stepId: step.stepId,
+        timerType: "retry",
+        dueAt: 1_000,
+        now: 100,
+      });
+
+      expect(
+        reconcileDueDurableTimers({
+          store,
+          processInstanceId: "process-1",
+          now: 999,
+        }),
+      ).toEqual({ scanned: 0, markedLost: 0, firedTimers: 0, queuedRuns: 0 });
+      expect(store.getRun(run.workflowRunId)).toMatchObject({
+        status: "retry_scheduled",
+        recoveryState: "retry_scheduled",
+      });
+
+      expect(
+        reconcileDueDurableTimers({
+          store,
+          processInstanceId: "process-1",
+          now: 1_000,
+        }),
+      ).toEqual({ scanned: 1, markedLost: 0, firedTimers: 1, queuedRuns: 1 });
+      expect(store.getRun(run.workflowRunId)).toMatchObject({
+        status: "queued",
+        recoveryState: "runnable",
+      });
+      expect(store.listSteps(run.workflowRunId)).toMatchObject([
+        {
+          stepId: step.stepId,
+          status: "queued",
+          recoveryState: "runnable",
+        },
+      ]);
+      expect(store.getTimeline(run.workflowRunId).map((event) => event.eventType)).toEqual([
+        "workflow.timer.fired",
+        "workflow.retry_due",
+      ]);
+    } finally {
+      store.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("queues waiting signal step when a resume signal is consumed", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-recovery-"));
+    const store = openDurableWorkflowSqliteStore({
+      path: path.join(dir, "openclaw.sqlite"),
+    });
+    try {
+      const run = store.createRun({
+        workflowId: "test.workflow",
+        idempotencyKey: "run-signal",
+        status: "waiting_signal",
+        recoveryState: "waiting_signal",
+        now: 100,
+      });
+      const step = store.createStep({
+        workflowRunId: run.workflowRunId,
+        stepId: "approval",
+        stepType: "signal",
+        status: "waiting",
+        recoveryState: "waiting_signal",
+        now: 100,
+      });
+      store.createSignal({
+        workflowRunId: run.workflowRunId,
+        stepId: step.stepId,
+        signalType: "resume",
+        idempotencyKey: "resume-1",
+        now: 200,
+      });
+
+      expect(
+        reconcilePendingDurableSignals({
+          store,
+          processInstanceId: "process-1",
+          now: 300,
+        }),
+      ).toEqual({ scanned: 1, markedLost: 0, consumedSignals: 1, queuedRuns: 1 });
+      expect(store.getRun(run.workflowRunId)).toMatchObject({
+        status: "queued",
+        recoveryState: "runnable",
+      });
+      expect(store.listSteps(run.workflowRunId)).toMatchObject([
+        {
+          stepId: step.stepId,
+          status: "queued",
+          recoveryState: "runnable",
+        },
+      ]);
+      expect(store.listPendingSignals()).toEqual([]);
+    } finally {
+      store.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/durable/recovery.test.ts
+++ b/src/durable/recovery.test.ts
@@ -82,6 +82,89 @@ describe("durable workflow recovery", () => {
     }
   });
 
+  it("marks persisted running agent turns lost after the store is reopened", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-recovery-"));
+    const dbPath = path.join(dir, "openclaw.sqlite");
+    let runningWorkflowRunId = "";
+    let runningStepId = "";
+    let waitingWorkflowRunId = "";
+
+    const setupStore = openDurableWorkflowSqliteStore({ path: dbPath });
+    try {
+      const running = setupStore.createRun({
+        workflowId: DURABLE_AGENT_TURN_WORKFLOW_ID,
+        idempotencyKey: "run-running-after-restart",
+        status: "running",
+        recoveryState: "running",
+        metadata: { sessionKey: "agent:test:running-after-restart" },
+        now: 100,
+      });
+      const runningStep = setupStore.createStep({
+        workflowRunId: running.workflowRunId,
+        stepId: "agent_invocation",
+        stepType: "agent",
+        status: "running",
+        recoveryState: "running",
+        now: 100,
+      });
+      const waiting = setupStore.createRun({
+        workflowId: DURABLE_AGENT_TURN_WORKFLOW_ID,
+        idempotencyKey: "run-waiting-after-restart",
+        status: "waiting",
+        recoveryState: "waiting_signal",
+        metadata: { sessionKey: "agent:test:waiting-after-restart" },
+        now: 100,
+      });
+      runningWorkflowRunId = running.workflowRunId;
+      runningStepId = runningStep.stepId;
+      waitingWorkflowRunId = waiting.workflowRunId;
+    } finally {
+      setupStore.close();
+    }
+
+    const restartedStore = openDurableWorkflowSqliteStore({ path: dbPath });
+    try {
+      const result = reconcileDurableAgentTurnsOnGatewayStartup({
+        store: restartedStore,
+        processInstanceId: "process-after-restart",
+        now: 200,
+      });
+
+      expect(result).toEqual({ scanned: 2, markedLost: 1 });
+      expect(restartedStore.getRun(runningWorkflowRunId)).toMatchObject({
+        workflowRunId: runningWorkflowRunId,
+        status: "lost",
+        recoveryState: "lost",
+        completedAt: 200,
+      });
+      expect(restartedStore.getRun(waitingWorkflowRunId)).toMatchObject({
+        workflowRunId: waitingWorkflowRunId,
+        status: "waiting",
+        recoveryState: "waiting_signal",
+      });
+      expect(restartedStore.listSteps(runningWorkflowRunId)).toMatchObject([
+        {
+          stepId: runningStepId,
+          status: "lost",
+          recoveryState: "lost",
+          completedAt: 200,
+        },
+      ]);
+      expect(restartedStore.getTimeline(runningWorkflowRunId)).toMatchObject([
+        {
+          eventType: "agent.turn.lost",
+          payload: expect.objectContaining({
+            processInstanceId: "process-after-restart",
+            reason: "gateway_startup_reconciliation",
+          }),
+        },
+      ]);
+    } finally {
+      restartedStore.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("marks only stale running agent turns lost during periodic recovery", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-recovery-"));
     const store = openDurableWorkflowSqliteStore({

--- a/src/durable/recovery.ts
+++ b/src/durable/recovery.ts
@@ -1,0 +1,480 @@
+import { createSubsystemLogger } from "../logging/subsystem.js";
+// Recovery reconciliation for durable workflow runs.
+import { isDurableWorkflowsEnabled } from "./config.js";
+import { openDurableWorkflowSqliteStore } from "./sqlite-store.js";
+import type { DurableWorkflowRun, DurableWorkflowStep, DurableWorkflowStore } from "./types.js";
+import { DURABLE_AGENT_TURN_WORKFLOW_ID } from "./workflow-ids.js";
+
+const log = createSubsystemLogger("durable/recovery");
+
+const DEFAULT_RECOVERY_INTERVAL_MS = 60_000;
+const DEFAULT_STALE_AGENT_TURN_AFTER_MS = 6 * 60 * 60 * 1000;
+
+export type DurableRecoveryResult = {
+  scanned: number;
+  markedLost: number;
+  firedTimers?: number;
+  consumedSignals?: number;
+  queuedRuns?: number;
+};
+
+function parsePositiveInteger(value: string | undefined): number | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+export function resolveDurableRecoveryIntervalMs(env: NodeJS.ProcessEnv = process.env): number {
+  return (
+    parsePositiveInteger(env.OPENCLAW_DURABLE_RECOVERY_INTERVAL_MS) ?? DEFAULT_RECOVERY_INTERVAL_MS
+  );
+}
+
+export function resolveDurableStaleAgentTurnAfterMs(env: NodeJS.ProcessEnv = process.env): number {
+  return (
+    parsePositiveInteger(env.OPENCLAW_DURABLE_STALE_AGENT_TURN_AFTER_MS) ??
+    DEFAULT_STALE_AGENT_TURN_AFTER_MS
+  );
+}
+
+function shouldMarkAgentTurnLost(run: DurableWorkflowRun): boolean {
+  if (run.workflowId !== DURABLE_AGENT_TURN_WORKFLOW_ID) {
+    return false;
+  }
+  return run.status === "received" || run.status === "running";
+}
+
+function correlationIdForRun(run: DurableWorkflowRun): string | undefined {
+  return run.metadata?.sessionKey ? String(run.metadata.sessionKey) : run.sourceRef;
+}
+
+function markAgentTurnLost(params: {
+  store: DurableWorkflowStore;
+  run: DurableWorkflowRun;
+  now: number;
+  reason: string;
+  processInstanceId: string;
+}): boolean {
+  if (!shouldMarkAgentTurnLost(params.run)) {
+    return false;
+  }
+  params.store.updateRun({
+    workflowRunId: params.run.workflowRunId,
+    status: "lost",
+    recoveryState: "lost",
+    completedAt: params.now,
+    now: params.now,
+  });
+  for (const step of params.store.listSteps(params.run.workflowRunId)) {
+    if (
+      step.status === "succeeded" ||
+      step.status === "failed" ||
+      step.status === "cancelled" ||
+      step.status === "lost" ||
+      step.status === "skipped"
+    ) {
+      continue;
+    }
+    params.store.updateStep({
+      workflowRunId: params.run.workflowRunId,
+      stepId: step.stepId,
+      status: "lost",
+      recoveryState: "lost",
+      completedAt: params.now,
+      now: params.now,
+    });
+  }
+  params.store.appendEvent({
+    workflowRunId: params.run.workflowRunId,
+    eventType: "agent.turn.lost",
+    eventTime: params.now,
+    stepId: "recovery",
+    agentInvocationId: params.run.idempotencyKey,
+    idempotencyKey: params.run.idempotencyKey,
+    correlationId: correlationIdForRun(params.run),
+    payload: {
+      reason: params.reason,
+      processInstanceId: params.processInstanceId,
+      previousStatus: params.run.status,
+      previousRecoveryState: params.run.recoveryState,
+    },
+  });
+  return true;
+}
+
+export function reconcileDurableAgentTurnsOnGatewayStartup(params: {
+  store: DurableWorkflowStore;
+  processInstanceId: string;
+  now: number;
+  limit?: number;
+}): DurableRecoveryResult {
+  const openRuns = params.store.listOpenRuns({
+    workflowId: DURABLE_AGENT_TURN_WORKFLOW_ID,
+    limit: params.limit ?? 5000,
+  });
+  let markedLost = 0;
+  for (const run of openRuns) {
+    if (
+      markAgentTurnLost({
+        store: params.store,
+        run,
+        now: params.now,
+        reason: "gateway_startup_reconciliation",
+        processInstanceId: params.processInstanceId,
+      })
+    ) {
+      markedLost += 1;
+    }
+  }
+  return { scanned: openRuns.length, markedLost };
+}
+
+export function reconcileStaleDurableAgentTurns(params: {
+  store: DurableWorkflowStore;
+  processInstanceId: string;
+  now: number;
+  staleAfterMs: number;
+  limit?: number;
+}): DurableRecoveryResult {
+  const cutoff = params.now - params.staleAfterMs;
+  const openRuns = params.store.listOpenRuns({
+    workflowId: DURABLE_AGENT_TURN_WORKFLOW_ID,
+    limit: params.limit ?? 5000,
+  });
+  let markedLost = 0;
+  for (const run of openRuns) {
+    if (run.updatedAt > cutoff) {
+      continue;
+    }
+    if (
+      markAgentTurnLost({
+        store: params.store,
+        run,
+        now: params.now,
+        reason: "stale_agent_turn_reconciliation",
+        processInstanceId: params.processInstanceId,
+      })
+    ) {
+      markedLost += 1;
+    }
+  }
+  return { scanned: openRuns.length, markedLost };
+}
+
+function isTerminalRun(run: DurableWorkflowRun): boolean {
+  return (
+    run.status === "succeeded" ||
+    run.status === "failed" ||
+    run.status === "cancelled" ||
+    run.status === "lost"
+  );
+}
+
+function isTerminalStep(step: DurableWorkflowStep): boolean {
+  return (
+    step.status === "succeeded" ||
+    step.status === "failed" ||
+    step.status === "cancelled" ||
+    step.status === "lost" ||
+    step.status === "skipped"
+  );
+}
+
+function markOpenStepsTerminal(params: {
+  store: DurableWorkflowStore;
+  workflowRunId: string;
+  status: "cancelled" | "lost";
+  now: number;
+}): void {
+  for (const step of params.store.listSteps(params.workflowRunId)) {
+    if (isTerminalStep(step)) {
+      continue;
+    }
+    params.store.updateStep({
+      workflowRunId: params.workflowRunId,
+      stepId: step.stepId,
+      status: params.status,
+      recoveryState: params.status === "lost" ? "lost" : "terminal",
+      claimedBy: null,
+      claimExpiresAt: null,
+      heartbeatAt: null,
+      completedAt: params.now,
+      now: params.now,
+    });
+  }
+}
+
+function queueStepForRecovery(params: {
+  store: DurableWorkflowStore;
+  workflowRunId: string;
+  stepId?: string;
+  recoveryState?: "waiting_signal" | "waiting_timer" | "retry_scheduled";
+  now: number;
+}): number {
+  let queued = 0;
+  for (const step of params.store.listSteps(params.workflowRunId)) {
+    if (isTerminalStep(step)) {
+      continue;
+    }
+    if (params.stepId && step.stepId !== params.stepId) {
+      continue;
+    }
+    if (!params.stepId && params.recoveryState && step.recoveryState !== params.recoveryState) {
+      continue;
+    }
+    params.store.updateStep({
+      workflowRunId: params.workflowRunId,
+      stepId: step.stepId,
+      status: "queued",
+      recoveryState: "runnable",
+      claimedBy: null,
+      claimExpiresAt: null,
+      heartbeatAt: null,
+      now: params.now,
+    });
+    queued += 1;
+  }
+  return queued;
+}
+
+export function reconcileDueDurableTimers(params: {
+  store: DurableWorkflowStore;
+  processInstanceId: string;
+  now: number;
+  limit?: number;
+}): DurableRecoveryResult {
+  const timers = params.store.listDueTimers(params.now, { limit: params.limit ?? 500 });
+  let firedTimers = 0;
+  let queuedRuns = 0;
+  for (const timer of timers) {
+    const run = params.store.getRun(timer.workflowRunId);
+    params.store.updateTimer({ timerId: timer.timerId, status: "fired", now: params.now });
+    firedTimers += 1;
+    params.store.appendEvent({
+      workflowRunId: timer.workflowRunId,
+      eventType: "workflow.timer.fired",
+      eventTime: params.now,
+      stepId: timer.stepId,
+      payload: {
+        timerId: timer.timerId,
+        timerType: timer.timerType,
+        processInstanceId: params.processInstanceId,
+      },
+    });
+    if (!run || isTerminalRun(run)) {
+      continue;
+    }
+    if (timer.timerType === "retry") {
+      queueStepForRecovery({
+        store: params.store,
+        workflowRunId: timer.workflowRunId,
+        stepId: timer.stepId,
+        recoveryState: "retry_scheduled",
+        now: params.now,
+      });
+      params.store.updateRun({
+        workflowRunId: timer.workflowRunId,
+        status: "queued",
+        recoveryState: "runnable",
+        now: params.now,
+      });
+      queuedRuns += 1;
+      params.store.appendEvent({
+        workflowRunId: timer.workflowRunId,
+        eventType: "workflow.retry_due",
+        eventTime: params.now,
+        stepId: timer.stepId,
+        payload: {
+          timerId: timer.timerId,
+          processInstanceId: params.processInstanceId,
+        },
+      });
+      continue;
+    }
+    if (run.status === "waiting_timer" || run.recoveryState === "waiting_timer") {
+      queueStepForRecovery({
+        store: params.store,
+        workflowRunId: timer.workflowRunId,
+        stepId: timer.stepId,
+        recoveryState: "waiting_timer",
+        now: params.now,
+      });
+      params.store.updateRun({
+        workflowRunId: timer.workflowRunId,
+        status: "queued",
+        recoveryState: "runnable",
+        now: params.now,
+      });
+      queuedRuns += 1;
+      params.store.appendEvent({
+        workflowRunId: timer.workflowRunId,
+        eventType: "workflow.timer.resume_queued",
+        eventTime: params.now,
+        stepId: timer.stepId,
+        payload: {
+          timerId: timer.timerId,
+          timerType: timer.timerType,
+          processInstanceId: params.processInstanceId,
+        },
+      });
+    }
+  }
+  return { scanned: timers.length, markedLost: 0, firedTimers, queuedRuns };
+}
+
+export function reconcilePendingDurableSignals(params: {
+  store: DurableWorkflowStore;
+  processInstanceId: string;
+  now: number;
+  limit?: number;
+}): DurableRecoveryResult {
+  const signals = params.store.listPendingSignals({ limit: params.limit ?? 5000 });
+  let consumedSignals = 0;
+  let queuedRuns = 0;
+  for (const signal of signals) {
+    const run = params.store.getRun(signal.workflowRunId);
+    if (!run || isTerminalRun(run)) {
+      params.store.consumeSignal({ signalId: signal.signalId, now: params.now });
+      consumedSignals += 1;
+      continue;
+    }
+    if (signal.signalType === "cancel") {
+      params.store.consumeSignal({ signalId: signal.signalId, now: params.now });
+      markOpenStepsTerminal({
+        store: params.store,
+        workflowRunId: run.workflowRunId,
+        status: "cancelled",
+        now: params.now,
+      });
+      params.store.updateRun({
+        workflowRunId: run.workflowRunId,
+        status: "cancelled",
+        recoveryState: "terminal",
+        completedAt: params.now,
+        now: params.now,
+      });
+      params.store.appendEvent({
+        workflowRunId: run.workflowRunId,
+        eventType: "workflow.signal.cancelled",
+        eventTime: params.now,
+        correlationId: signal.correlationId,
+        payload: {
+          signalId: signal.signalId,
+          processInstanceId: params.processInstanceId,
+        },
+      });
+      consumedSignals += 1;
+      continue;
+    }
+    if (
+      signal.signalType === "resume" ||
+      run.recoveryState === "waiting_signal" ||
+      run.status === "waiting_signal"
+    ) {
+      params.store.consumeSignal({ signalId: signal.signalId, now: params.now });
+      queueStepForRecovery({
+        store: params.store,
+        workflowRunId: run.workflowRunId,
+        stepId: signal.stepId,
+        recoveryState: "waiting_signal",
+        now: params.now,
+      });
+      params.store.updateRun({
+        workflowRunId: run.workflowRunId,
+        status: "queued",
+        recoveryState: "runnable",
+        now: params.now,
+      });
+      params.store.appendEvent({
+        workflowRunId: run.workflowRunId,
+        eventType: "workflow.signal.resume_queued",
+        eventTime: params.now,
+        correlationId: signal.correlationId,
+        payload: {
+          signalId: signal.signalId,
+          signalType: signal.signalType,
+          processInstanceId: params.processInstanceId,
+        },
+      });
+      consumedSignals += 1;
+      queuedRuns += 1;
+    }
+  }
+  return { scanned: signals.length, markedLost: 0, consumedSignals, queuedRuns };
+}
+
+export function startDurableRecoveryWorker(params: {
+  processInstanceId: string;
+  env?: NodeJS.ProcessEnv;
+}): () => void {
+  const env = params.env ?? process.env;
+  if (!isDurableWorkflowsEnabled(env)) {
+    return () => {};
+  }
+  const intervalMs = resolveDurableRecoveryIntervalMs(env);
+  const staleAfterMs = resolveDurableStaleAgentTurnAfterMs(env);
+  let running = false;
+  let stopped = false;
+
+  const reconcileOnce = () => {
+    if (running || stopped) {
+      return;
+    }
+    running = true;
+    let store: DurableWorkflowStore | null = null;
+    try {
+      store = openDurableWorkflowSqliteStore({ env });
+      const result = reconcileStaleDurableAgentTurns({
+        store,
+        processInstanceId: params.processInstanceId,
+        now: Date.now(),
+        staleAfterMs,
+      });
+      const timerResult = reconcileDueDurableTimers({
+        store,
+        processInstanceId: params.processInstanceId,
+        now: Date.now(),
+      });
+      const signalResult = reconcilePendingDurableSignals({
+        store,
+        processInstanceId: params.processInstanceId,
+        now: Date.now(),
+      });
+      if (
+        result.markedLost > 0 ||
+        (timerResult.firedTimers ?? 0) > 0 ||
+        (signalResult.consumedSignals ?? 0) > 0
+      ) {
+        log.warn("reconciled durable workflow state", {
+          staleScanned: result.scanned,
+          markedLost: result.markedLost,
+          firedTimers: timerResult.firedTimers ?? 0,
+          consumedSignals: signalResult.consumedSignals ?? 0,
+          queuedRuns: (timerResult.queuedRuns ?? 0) + (signalResult.queuedRuns ?? 0),
+          staleAfterMs,
+        });
+      }
+    } catch (err) {
+      log.warn(`durable recovery worker failed: ${String(err)}`);
+    } finally {
+      store?.close();
+      running = false;
+    }
+  };
+
+  const timer = setInterval(reconcileOnce, intervalMs);
+  timer.unref?.();
+  log.info("started durable recovery worker", {
+    intervalMs,
+    staleAfterMs,
+    processInstanceId: params.processInstanceId,
+  });
+
+  return () => {
+    stopped = true;
+    clearInterval(timer);
+  };
+}

--- a/src/durable/registry.ts
+++ b/src/durable/registry.ts
@@ -1,0 +1,103 @@
+import type {
+  DurableWorkflowRun,
+  DurableWorkflowStep,
+  DurableWorkflowStepType,
+  DurableWorkflowStore,
+  DurableWorkflowTimer,
+} from "./types.js";
+
+export type DurableWorkflowDefinition = {
+  workflowId: string;
+  version: string;
+  description?: string;
+  stepTypes?: DurableWorkflowStepType[];
+  metadata?: Record<string, unknown>;
+};
+
+export type DurableWorkflowStepHandlerContext = {
+  store: DurableWorkflowStore;
+  run: DurableWorkflowRun;
+  step: DurableWorkflowStep;
+  workerId: string;
+  now(): number;
+  heartbeat(payload?: Record<string, unknown>): void;
+};
+
+export type DurableWorkflowStepHandlerResult =
+  | {
+      kind: "succeeded";
+      output?: Record<string, unknown>;
+      outputRef?: string;
+      checkpointRef?: string;
+      completeRun?: boolean;
+    }
+  | {
+      kind: "failed";
+      error?: Record<string, unknown>;
+      retryAfterMs?: number;
+      checkpointRef?: string;
+      completeRun?: boolean;
+    }
+  | {
+      kind: "waiting_signal";
+      reason?: string;
+      checkpointRef?: string;
+    }
+  | {
+      kind: "waiting_timer";
+      dueAt: number;
+      timerType?: DurableWorkflowTimer["timerType"];
+      reason?: string;
+      checkpointRef?: string;
+    }
+  | {
+      kind: "unknown_after_side_effect";
+      reason?: string;
+      checkpointRef?: string;
+    };
+
+export type DurableWorkflowStepHandler = (
+  context: DurableWorkflowStepHandlerContext,
+) => DurableWorkflowStepHandlerResult | Promise<DurableWorkflowStepHandlerResult>;
+
+export type DurableWorkflowRegistry = {
+  registerWorkflow(definition: DurableWorkflowDefinition): void;
+  getWorkflow(workflowId: string, version?: string): DurableWorkflowDefinition | undefined;
+  listWorkflows(): DurableWorkflowDefinition[];
+  registerStepHandler(stepType: DurableWorkflowStepType, handler: DurableWorkflowStepHandler): void;
+  getStepHandler(stepType: DurableWorkflowStepType): DurableWorkflowStepHandler | undefined;
+};
+
+function workflowKey(workflowId: string, version: string): string {
+  return `${workflowId}@${version}`;
+}
+
+export function createDurableWorkflowRegistry(): DurableWorkflowRegistry {
+  const workflows = new Map<string, DurableWorkflowDefinition>();
+  const handlers = new Map<DurableWorkflowStepType, DurableWorkflowStepHandler>();
+
+  return {
+    registerWorkflow(definition: DurableWorkflowDefinition): void {
+      workflows.set(workflowKey(definition.workflowId, definition.version), { ...definition });
+    },
+
+    getWorkflow(workflowId: string, version = "1"): DurableWorkflowDefinition | undefined {
+      return workflows.get(workflowKey(workflowId, version));
+    },
+
+    listWorkflows(): DurableWorkflowDefinition[] {
+      return [...workflows.values()].map((definition) => ({ ...definition }));
+    },
+
+    registerStepHandler(
+      stepType: DurableWorkflowStepType,
+      handler: DurableWorkflowStepHandler,
+    ): void {
+      handlers.set(stepType, handler);
+    },
+
+    getStepHandler(stepType: DurableWorkflowStepType): DurableWorkflowStepHandler | undefined {
+      return handlers.get(stepType);
+    },
+  };
+}

--- a/src/durable/sqlite-store.test.ts
+++ b/src/durable/sqlite-store.test.ts
@@ -3,7 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
-import { openDurableWorkflowSqliteStore } from "./sqlite-store.js";
+import {
+  DURABLE_WORKFLOW_SQLITE_SCHEMA_VERSION,
+  openDurableWorkflowSqliteStore,
+} from "./sqlite-store.js";
 
 const DURABLE_TABLES = [
   "durable_workflow_events",
@@ -16,6 +19,52 @@ const DURABLE_TABLES = [
 ] as const;
 
 describe("durable workflow sqlite store", () => {
+  it("records the supported durable schema version", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-store-"));
+    const store = openDurableWorkflowSqliteStore({
+      path: path.join(dir, "openclaw.sqlite"),
+    });
+    try {
+      expect(store.getStats()).toMatchObject({
+        schemaVersion: DURABLE_WORKFLOW_SQLITE_SCHEMA_VERSION,
+      });
+    } finally {
+      store.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects durable stores from a newer schema version", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-store-"));
+    const dbPath = path.join(dir, "openclaw.sqlite");
+    const { DatabaseSync } = requireNodeSqlite();
+    const db = new DatabaseSync(dbPath);
+    try {
+      db.exec(`
+        CREATE TABLE durable_schema_migrations (
+          schema_name TEXT NOT NULL PRIMARY KEY,
+          version INTEGER NOT NULL,
+          applied_at INTEGER NOT NULL,
+          metadata_json TEXT
+        );
+      `);
+      db.prepare(
+        `INSERT INTO durable_schema_migrations (schema_name, version, applied_at, metadata_json)
+         VALUES (?, ?, ?, ?)`,
+      ).run("durable_workflows", DURABLE_WORKFLOW_SQLITE_SCHEMA_VERSION + 1, 100, null);
+    } finally {
+      db.close();
+    }
+
+    try {
+      expect(() => openDurableWorkflowSqliteStore({ path: dbPath })).toThrow(
+        /newer than supported version/,
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("creates runs, dedupes idempotency keys, and appends ordered events", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-store-"));
     const store = openDurableWorkflowSqliteStore({

--- a/src/durable/sqlite-store.test.ts
+++ b/src/durable/sqlite-store.test.ts
@@ -2,7 +2,18 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { openDurableWorkflowSqliteStore } from "./sqlite-store.js";
+
+const DURABLE_TABLES = [
+  "durable_workflow_events",
+  "durable_workflow_links",
+  "durable_workflow_refs",
+  "durable_workflow_runs",
+  "durable_workflow_signals",
+  "durable_workflow_steps",
+  "durable_workflow_timers",
+] as const;
 
 describe("durable workflow sqlite store", () => {
   it("creates runs, dedupes idempotency keys, and appends ordered events", () => {
@@ -300,6 +311,80 @@ describe("durable workflow sqlite store", () => {
       ).toBeUndefined();
     } finally {
       store.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("adds durable tables to an existing shared state database without rewriting existing rows", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-store-"));
+    const dbPath = path.join(dir, "openclaw.sqlite");
+    const { DatabaseSync } = requireNodeSqlite();
+    const existingDb = new DatabaseSync(dbPath);
+    try {
+      existingDb.exec(`
+        CREATE TABLE diagnostic_events (
+          scope TEXT NOT NULL,
+          event_key TEXT NOT NULL,
+          payload_json TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          PRIMARY KEY (scope, event_key)
+        );
+      `);
+      existingDb
+        .prepare(
+          `INSERT INTO diagnostic_events (scope, event_key, payload_json, created_at)
+           VALUES (?, ?, ?, ?)`,
+        )
+        .run("state", "startup", '{"ok":true}', 123);
+      const durableTablesBefore = existingDb
+        .prepare(
+          `SELECT name
+             FROM sqlite_master
+            WHERE type = 'table'
+              AND name LIKE 'durable_workflow_%'
+            ORDER BY name`,
+        )
+        .all() as Array<{ name: string }>;
+      expect(durableTablesBefore).toEqual([]);
+    } finally {
+      existingDb.close();
+    }
+
+    const store = openDurableWorkflowSqliteStore({ path: dbPath });
+    store.close();
+
+    const upgradedDb = new DatabaseSync(dbPath);
+    try {
+      const durableTablesAfter = upgradedDb
+        .prepare(
+          `SELECT name
+             FROM sqlite_master
+            WHERE type = 'table'
+              AND name LIKE 'durable_workflow_%'
+            ORDER BY name`,
+        )
+        .all() as Array<{ name: string }>;
+      expect(durableTablesAfter.map((row) => row.name)).toEqual([...DURABLE_TABLES].sort());
+      expect(
+        upgradedDb
+          .prepare(
+            `SELECT scope, event_key, payload_json, created_at
+               FROM diagnostic_events
+              WHERE scope = ?
+                AND event_key = ?`,
+          )
+          .get("state", "startup"),
+      ).toEqual({
+        scope: "state",
+        event_key: "startup",
+        payload_json: '{"ok":true}',
+        created_at: 123,
+      });
+      expect(upgradedDb.prepare("PRAGMA integrity_check").get()).toEqual({
+        integrity_check: "ok",
+      });
+    } finally {
+      upgradedDb.close();
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });

--- a/src/durable/sqlite-store.test.ts
+++ b/src/durable/sqlite-store.test.ts
@@ -1,0 +1,306 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { openDurableWorkflowSqliteStore } from "./sqlite-store.js";
+
+describe("durable workflow sqlite store", () => {
+  it("creates runs, dedupes idempotency keys, and appends ordered events", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-store-"));
+    const store = openDurableWorkflowSqliteStore({
+      path: path.join(dir, "openclaw.sqlite"),
+    });
+    try {
+      const first = store.createRun({
+        workflowId: "test.workflow",
+        idempotencyKey: "request-1",
+        requestHash: "hash-1",
+        metadata: { surface: "test" },
+        now: 100,
+      });
+      const duplicate = store.createRun({
+        workflowId: "test.workflow",
+        idempotencyKey: "request-1",
+        requestHash: "hash-1",
+        now: 200,
+      });
+      expect(duplicate.workflowRunId).toBe(first.workflowRunId);
+
+      const started = store.appendEvent({
+        workflowRunId: first.workflowRunId,
+        eventType: "workflow.started",
+        payload: { ok: true },
+      });
+      const completed = store.appendEvent({
+        workflowRunId: first.workflowRunId,
+        eventType: "workflow.completed",
+      });
+      expect(store.listOpenRuns({ workflowId: "test.workflow" })).toMatchObject([
+        {
+          workflowRunId: first.workflowRunId,
+          workflowId: "test.workflow",
+          status: "received",
+        },
+      ]);
+      const terminal = store.updateRun({
+        workflowRunId: first.workflowRunId,
+        status: "succeeded",
+        recoveryState: "terminal",
+        completedAt: 300,
+        now: 300,
+      });
+
+      expect(started.eventSeq).toBe(1);
+      expect(completed.eventSeq).toBe(2);
+      expect(terminal).toMatchObject({
+        workflowRunId: first.workflowRunId,
+        status: "succeeded",
+        recoveryState: "terminal",
+        completedAt: 300,
+      });
+      expect(store.getTimeline(first.workflowRunId).map((event) => event.eventType)).toEqual([
+        "workflow.started",
+        "workflow.completed",
+      ]);
+      expect(store.listOpenRuns({ workflowId: "test.workflow" })).toEqual([]);
+      expect(store.getStats()).toMatchObject({ runs: 1, events: 2, steps: 0, openRuns: 0 });
+    } finally {
+      store.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("stores core workflow primitives for steps, refs, links, timers, signals, and claims", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-store-"));
+    const store = openDurableWorkflowSqliteStore({
+      path: path.join(dir, "openclaw.sqlite"),
+    });
+    try {
+      const parent = store.createRun({
+        workflowId: "test.workflow",
+        status: "queued",
+        recoveryState: "runnable",
+        idempotencyKey: "parent",
+        now: 100,
+      });
+      const child = store.createRun({
+        workflowId: "test.workflow",
+        status: "queued",
+        recoveryState: "runnable",
+        idempotencyKey: "child",
+        parentWorkflowRunId: parent.workflowRunId,
+        now: 110,
+      });
+      const claimed = store.claimNextRunnableRun({
+        workflowId: "test.workflow",
+        workerId: "worker-1",
+        claimTtlMs: 1_000,
+        now: 120,
+      });
+      expect(claimed).toMatchObject({
+        workflowRunId: parent.workflowRunId,
+        claimedBy: "worker-1",
+        recoveryState: "claimed",
+        claimExpiresAt: 1_120,
+      });
+      const released = store.releaseRunClaim({
+        workflowRunId: parent.workflowRunId,
+        workerId: "worker-1",
+        now: 130,
+      });
+      expect(released).toMatchObject({
+        workflowRunId: parent.workflowRunId,
+        recoveryState: "runnable",
+      });
+
+      const inputRef = store.createRef({
+        workflowRunId: parent.workflowRunId,
+        refKind: "input",
+        mediaType: "application/json",
+        hash: "input-hash",
+        storageKind: "inline",
+        storageUri: "inline:test",
+        now: 140,
+      });
+      expect(store.getRef(inputRef.refId)).toMatchObject({
+        refKind: "input",
+        storageKind: "inline",
+        hash: "input-hash",
+      });
+
+      const step = store.createStep({
+        workflowRunId: parent.workflowRunId,
+        stepType: "fan_in",
+        status: "waiting",
+        recoveryState: "waiting_child",
+        inputRef: inputRef.refId,
+        idempotencyKey: "fan-in-1",
+        metadata: { policy: "all_terminal" },
+        now: 150,
+      });
+      const duplicateStep = store.createStep({
+        workflowRunId: parent.workflowRunId,
+        stepType: "fan_in",
+        idempotencyKey: "fan-in-1",
+        now: 160,
+      });
+      expect(duplicateStep.stepId).toBe(step.stepId);
+
+      const updatedStep = store.updateStep({
+        workflowRunId: parent.workflowRunId,
+        stepId: step.stepId,
+        status: "succeeded",
+        recoveryState: "terminal",
+        outputRef: "output-ref",
+        completedAt: 170,
+        now: 170,
+      });
+      expect(updatedStep).toMatchObject({
+        stepId: step.stepId,
+        status: "succeeded",
+        outputRef: "output-ref",
+        completedAt: 170,
+      });
+      expect(store.listSteps(parent.workflowRunId)).toHaveLength(1);
+
+      const executableStep = store.createStep({
+        workflowRunId: parent.workflowRunId,
+        stepType: "tool",
+        status: "queued",
+        recoveryState: "runnable",
+        idempotencyKey: "tool-1",
+        now: 175,
+      });
+      const claimedStep = store.claimNextRunnableStep({
+        workflowId: "test.workflow",
+        stepType: "tool",
+        workerId: "worker-1",
+        claimTtlMs: 1_000,
+        now: 176,
+      });
+      expect(claimedStep).toMatchObject({
+        workflowRunId: parent.workflowRunId,
+        stepId: executableStep.stepId,
+        status: "queued",
+        recoveryState: "claimed",
+        claimedBy: "worker-1",
+        claimExpiresAt: 1_176,
+      });
+      expect(
+        store.releaseStepClaim({
+          workflowRunId: parent.workflowRunId,
+          stepId: executableStep.stepId,
+          workerId: "worker-1",
+          now: 177,
+        }),
+      ).toMatchObject({
+        stepId: executableStep.stepId,
+        recoveryState: "runnable",
+      });
+
+      const link = store.createLink({
+        parentWorkflowRunId: parent.workflowRunId,
+        parentStepId: step.stepId,
+        childWorkflowRunId: child.workflowRunId,
+        linkType: "child_workflow",
+        status: "running",
+        now: 180,
+      });
+      expect(link.status).toBe("running");
+      expect(
+        store.updateLink({
+          parentWorkflowRunId: parent.workflowRunId,
+          parentStepId: step.stepId,
+          childWorkflowRunId: child.workflowRunId,
+          status: "succeeded",
+          now: 190,
+        }),
+      ).toMatchObject({ status: "succeeded" });
+      expect(store.listChildLinks(parent.workflowRunId)).toHaveLength(1);
+
+      const timer = store.createTimer({
+        workflowRunId: parent.workflowRunId,
+        stepId: step.stepId,
+        timerType: "retry",
+        dueAt: 200,
+        now: 195,
+      });
+      expect(store.listDueTimers(199)).toEqual([]);
+      expect(store.listDueTimers(200)).toMatchObject([{ timerId: timer.timerId }]);
+      expect(
+        store.updateTimer({ timerId: timer.timerId, status: "fired", now: 201 }),
+      ).toMatchObject({
+        status: "fired",
+        firedAt: 201,
+      });
+
+      const signal = store.createSignal({
+        workflowRunId: parent.workflowRunId,
+        stepId: step.stepId,
+        signalType: "human_input",
+        idempotencyKey: "signal-1",
+        payloadRef: inputRef.refId,
+        now: 210,
+      });
+      const duplicateSignal = store.createSignal({
+        workflowRunId: parent.workflowRunId,
+        signalType: "human_input",
+        idempotencyKey: "signal-1",
+        now: 211,
+      });
+      expect(duplicateSignal.signalId).toBe(signal.signalId);
+      expect(store.consumeSignal({ signalId: signal.signalId, now: 220 })).toMatchObject({
+        signalId: signal.signalId,
+        consumedAt: 220,
+      });
+      expect(store.listSignals(parent.workflowRunId)).toHaveLength(1);
+      expect(store.listPendingSignals()).toEqual([]);
+      expect(store.getStats()).toMatchObject({ runs: 2, steps: 2 });
+    } finally {
+      store.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not claim retry-scheduled runs or steps before recovery queues them", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-store-"));
+    const store = openDurableWorkflowSqliteStore({
+      path: path.join(dir, "openclaw.sqlite"),
+    });
+    try {
+      const run = store.createRun({
+        workflowId: "test.workflow",
+        status: "retry_scheduled",
+        recoveryState: "retry_scheduled",
+        now: 100,
+      });
+      store.createStep({
+        workflowRunId: run.workflowRunId,
+        stepType: "tool",
+        status: "retry_scheduled",
+        recoveryState: "retry_scheduled",
+        now: 110,
+      });
+
+      expect(
+        store.claimNextRunnableRun({
+          workflowId: "test.workflow",
+          workerId: "worker-1",
+          claimTtlMs: 1_000,
+          now: 120,
+        }),
+      ).toBeUndefined();
+      expect(
+        store.claimNextRunnableStep({
+          workflowId: "test.workflow",
+          workerId: "worker-1",
+          claimTtlMs: 1_000,
+          now: 120,
+        }),
+      ).toBeUndefined();
+    } finally {
+      store.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/durable/sqlite-store.ts
+++ b/src/durable/sqlite-store.ts
@@ -1,0 +1,1406 @@
+// SQLite-backed durable workflow store for the native control-plane prototype.
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync, SQLInputValue } from "node:sqlite";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import { runSqliteImmediateTransactionSync } from "../infra/sqlite-transaction.js";
+import { configureSqliteConnectionPragmas } from "../infra/sqlite-wal.js";
+import { resolveDurableWorkflowSqlitePath } from "./config.js";
+import type {
+  AppendDurableWorkflowEventInput,
+  ClaimDurableWorkflowRunInput,
+  ClaimDurableWorkflowStepInput,
+  CreateDurableWorkflowLinkInput,
+  CreateDurableWorkflowRefInput,
+  CreateDurableWorkflowRunInput,
+  CreateDurableWorkflowSignalInput,
+  CreateDurableWorkflowStepInput,
+  CreateDurableWorkflowTimerInput,
+  DurableWorkflowLink,
+  DurableWorkflowLinkStatus,
+  DurableWorkflowLinkType,
+  DurableRecoveryState,
+  DurableWorkflowEvent,
+  DurableWorkflowRef,
+  DurableWorkflowRefKind,
+  DurableWorkflowRun,
+  DurableWorkflowRunStatus,
+  DurableWorkflowSignal,
+  DurableWorkflowStep,
+  DurableWorkflowStepStatus,
+  DurableWorkflowStepType,
+  DurableWorkflowStore,
+  DurableWorkflowStoreStats,
+  DurableWorkflowTimer,
+  DurableWorkflowTimerStatus,
+  UpdateDurableWorkflowRunInput,
+  UpdateDurableWorkflowLinkInput,
+  UpdateDurableWorkflowStepInput,
+  UpdateDurableWorkflowTimerInput,
+} from "./types.js";
+
+type DurableWorkflowRunRow = {
+  workflow_run_id: string;
+  workflow_id: string;
+  workflow_version: string;
+  idempotency_key: string | null;
+  request_hash: string | null;
+  status: DurableWorkflowRunStatus;
+  source_type: string | null;
+  source_ref: string | null;
+  input_ref: string | null;
+  created_at: number;
+  updated_at: number;
+  completed_at: number | null;
+  recovery_state: DurableRecoveryState;
+  checkpoint_ref: string | null;
+  parent_workflow_run_id: string | null;
+  parent_step_id: string | null;
+  message_id: string | null;
+  turn_id: string | null;
+  claimed_by: string | null;
+  claim_expires_at: number | null;
+  heartbeat_at: number | null;
+  metadata_json: string | null;
+};
+
+type DurableWorkflowEventRow = {
+  event_id: string;
+  workflow_run_id: string;
+  event_seq: number;
+  event_type: string;
+  event_time: number;
+  step_id: string | null;
+  agent_invocation_id: string | null;
+  tool_invocation_id: string | null;
+  idempotency_key: string | null;
+  payload_json: string | null;
+  payload_hash: string | null;
+  checkpoint_ref: string | null;
+  causation_event_id: string | null;
+  correlation_id: string | null;
+  recorded_at: number;
+};
+
+type DurableWorkflowStepRow = {
+  workflow_run_id: string;
+  step_id: string;
+  parent_step_id: string | null;
+  step_type: DurableWorkflowStepType;
+  status: DurableWorkflowStepStatus;
+  recovery_state: DurableRecoveryState;
+  attempt: number;
+  max_attempts: number | null;
+  idempotency_key: string | null;
+  input_ref: string | null;
+  output_ref: string | null;
+  error_ref: string | null;
+  checkpoint_ref: string | null;
+  claimed_by: string | null;
+  claim_expires_at: number | null;
+  heartbeat_at: number | null;
+  created_at: number;
+  started_at: number | null;
+  updated_at: number;
+  completed_at: number | null;
+  metadata_json: string | null;
+};
+
+type DurableWorkflowRefRow = {
+  ref_id: string;
+  workflow_run_id: string;
+  step_id: string | null;
+  ref_kind: DurableWorkflowRefKind;
+  media_type: string | null;
+  hash: string | null;
+  storage_kind: "inline" | "file" | "external";
+  storage_uri: string | null;
+  created_at: number;
+  metadata_json: string | null;
+};
+
+type DurableWorkflowLinkRow = {
+  parent_workflow_run_id: string;
+  parent_step_id: string;
+  child_workflow_run_id: string;
+  link_type: DurableWorkflowLinkType;
+  status: DurableWorkflowLinkStatus;
+  created_at: number;
+  updated_at: number;
+  metadata_json: string | null;
+};
+
+type DurableWorkflowTimerRow = {
+  timer_id: string;
+  workflow_run_id: string;
+  step_id: string | null;
+  timer_type: DurableWorkflowTimer["timerType"];
+  due_at: number;
+  status: DurableWorkflowTimerStatus;
+  created_at: number;
+  fired_at: number | null;
+  cancelled_at: number | null;
+  metadata_json: string | null;
+};
+
+type DurableWorkflowSignalRow = {
+  signal_id: string;
+  workflow_run_id: string;
+  step_id: string | null;
+  signal_type: DurableWorkflowSignal["signalType"];
+  idempotency_key: string | null;
+  payload_ref: string | null;
+  correlation_id: string | null;
+  received_at: number;
+  consumed_at: number | null;
+  metadata_json: string | null;
+};
+
+type CountRow = { count: number | bigint };
+
+const DURABLE_WORKFLOW_SQLITE_BUSY_TIMEOUT_MS = 30_000;
+
+function optionalText(value: string | undefined): string | null {
+  return value && value.trim() ? value : null;
+}
+
+function serializeJson(value: Record<string, unknown> | undefined): string | null {
+  return value === undefined ? null : JSON.stringify(value);
+}
+
+function parseJsonRecord(value: string | null): Record<string, unknown> | undefined {
+  if (!value) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function rowToRun(row: DurableWorkflowRunRow): DurableWorkflowRun {
+  return {
+    workflowRunId: row.workflow_run_id,
+    workflowId: row.workflow_id,
+    workflowVersion: row.workflow_version,
+    status: row.status,
+    recoveryState: row.recovery_state,
+    ...(row.idempotency_key ? { idempotencyKey: row.idempotency_key } : {}),
+    ...(row.request_hash ? { requestHash: row.request_hash } : {}),
+    ...(row.source_type ? { sourceType: row.source_type } : {}),
+    ...(row.source_ref ? { sourceRef: row.source_ref } : {}),
+    ...(row.input_ref ? { inputRef: row.input_ref } : {}),
+    ...(row.checkpoint_ref ? { checkpointRef: row.checkpoint_ref } : {}),
+    ...(row.parent_workflow_run_id ? { parentWorkflowRunId: row.parent_workflow_run_id } : {}),
+    ...(row.parent_step_id ? { parentStepId: row.parent_step_id } : {}),
+    ...(row.message_id ? { messageId: row.message_id } : {}),
+    ...(row.turn_id ? { turnId: row.turn_id } : {}),
+    ...(row.claimed_by ? { claimedBy: row.claimed_by } : {}),
+    ...(row.claim_expires_at == null ? {} : { claimExpiresAt: Number(row.claim_expires_at) }),
+    ...(row.heartbeat_at == null ? {} : { heartbeatAt: Number(row.heartbeat_at) }),
+    ...(row.metadata_json ? { metadata: parseJsonRecord(row.metadata_json) } : {}),
+    createdAt: Number(row.created_at),
+    updatedAt: Number(row.updated_at),
+    ...(row.completed_at == null ? {} : { completedAt: Number(row.completed_at) }),
+  };
+}
+
+function rowToEvent(row: DurableWorkflowEventRow): DurableWorkflowEvent {
+  return {
+    eventId: row.event_id,
+    workflowRunId: row.workflow_run_id,
+    eventSeq: Number(row.event_seq),
+    eventType: row.event_type,
+    eventTime: Number(row.event_time),
+    ...(row.step_id ? { stepId: row.step_id } : {}),
+    ...(row.agent_invocation_id ? { agentInvocationId: row.agent_invocation_id } : {}),
+    ...(row.tool_invocation_id ? { toolInvocationId: row.tool_invocation_id } : {}),
+    ...(row.idempotency_key ? { idempotencyKey: row.idempotency_key } : {}),
+    ...(row.payload_json ? { payload: parseJsonRecord(row.payload_json) } : {}),
+    ...(row.payload_hash ? { payloadHash: row.payload_hash } : {}),
+    ...(row.checkpoint_ref ? { checkpointRef: row.checkpoint_ref } : {}),
+    ...(row.causation_event_id ? { causationEventId: row.causation_event_id } : {}),
+    ...(row.correlation_id ? { correlationId: row.correlation_id } : {}),
+    recordedAt: Number(row.recorded_at),
+  };
+}
+
+function rowToStep(row: DurableWorkflowStepRow): DurableWorkflowStep {
+  return {
+    workflowRunId: row.workflow_run_id,
+    stepId: row.step_id,
+    ...(row.parent_step_id ? { parentStepId: row.parent_step_id } : {}),
+    stepType: row.step_type,
+    status: row.status,
+    recoveryState: row.recovery_state,
+    attempt: Number(row.attempt),
+    ...(row.max_attempts == null ? {} : { maxAttempts: Number(row.max_attempts) }),
+    ...(row.idempotency_key ? { idempotencyKey: row.idempotency_key } : {}),
+    ...(row.input_ref ? { inputRef: row.input_ref } : {}),
+    ...(row.output_ref ? { outputRef: row.output_ref } : {}),
+    ...(row.error_ref ? { errorRef: row.error_ref } : {}),
+    ...(row.checkpoint_ref ? { checkpointRef: row.checkpoint_ref } : {}),
+    ...(row.claimed_by ? { claimedBy: row.claimed_by } : {}),
+    ...(row.claim_expires_at == null ? {} : { claimExpiresAt: Number(row.claim_expires_at) }),
+    ...(row.heartbeat_at == null ? {} : { heartbeatAt: Number(row.heartbeat_at) }),
+    ...(row.metadata_json ? { metadata: parseJsonRecord(row.metadata_json) } : {}),
+    createdAt: Number(row.created_at),
+    ...(row.started_at == null ? {} : { startedAt: Number(row.started_at) }),
+    updatedAt: Number(row.updated_at),
+    ...(row.completed_at == null ? {} : { completedAt: Number(row.completed_at) }),
+  };
+}
+
+function rowToRef(row: DurableWorkflowRefRow): DurableWorkflowRef {
+  return {
+    refId: row.ref_id,
+    workflowRunId: row.workflow_run_id,
+    ...(row.step_id ? { stepId: row.step_id } : {}),
+    refKind: row.ref_kind,
+    ...(row.media_type ? { mediaType: row.media_type } : {}),
+    ...(row.hash ? { hash: row.hash } : {}),
+    storageKind: row.storage_kind,
+    ...(row.storage_uri ? { storageUri: row.storage_uri } : {}),
+    ...(row.metadata_json ? { metadata: parseJsonRecord(row.metadata_json) } : {}),
+    createdAt: Number(row.created_at),
+  };
+}
+
+function rowToLink(row: DurableWorkflowLinkRow): DurableWorkflowLink {
+  return {
+    parentWorkflowRunId: row.parent_workflow_run_id,
+    parentStepId: row.parent_step_id,
+    childWorkflowRunId: row.child_workflow_run_id,
+    linkType: row.link_type,
+    status: row.status,
+    ...(row.metadata_json ? { metadata: parseJsonRecord(row.metadata_json) } : {}),
+    createdAt: Number(row.created_at),
+    updatedAt: Number(row.updated_at),
+  };
+}
+
+function rowToTimer(row: DurableWorkflowTimerRow): DurableWorkflowTimer {
+  return {
+    timerId: row.timer_id,
+    workflowRunId: row.workflow_run_id,
+    ...(row.step_id ? { stepId: row.step_id } : {}),
+    timerType: row.timer_type,
+    dueAt: Number(row.due_at),
+    status: row.status,
+    ...(row.metadata_json ? { metadata: parseJsonRecord(row.metadata_json) } : {}),
+    createdAt: Number(row.created_at),
+    ...(row.fired_at == null ? {} : { firedAt: Number(row.fired_at) }),
+    ...(row.cancelled_at == null ? {} : { cancelledAt: Number(row.cancelled_at) }),
+  };
+}
+
+function rowToSignal(row: DurableWorkflowSignalRow): DurableWorkflowSignal {
+  return {
+    signalId: row.signal_id,
+    workflowRunId: row.workflow_run_id,
+    ...(row.step_id ? { stepId: row.step_id } : {}),
+    signalType: row.signal_type,
+    ...(row.idempotency_key ? { idempotencyKey: row.idempotency_key } : {}),
+    ...(row.payload_ref ? { payloadRef: row.payload_ref } : {}),
+    ...(row.correlation_id ? { correlationId: row.correlation_id } : {}),
+    ...(row.metadata_json ? { metadata: parseJsonRecord(row.metadata_json) } : {}),
+    receivedAt: Number(row.received_at),
+    ...(row.consumed_at == null ? {} : { consumedAt: Number(row.consumed_at) }),
+  };
+}
+
+function ensureColumn(db: DatabaseSync, tableName: string, columnDefinition: string): void {
+  try {
+    db.exec(`ALTER TABLE ${tableName} ADD COLUMN ${columnDefinition}`);
+  } catch (err) {
+    if (!String(err).includes("duplicate column name")) {
+      throw err;
+    }
+  }
+}
+
+function ensureDurableWorkflowSchema(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS durable_workflow_runs (
+      workflow_run_id TEXT NOT NULL PRIMARY KEY,
+      workflow_id TEXT NOT NULL,
+      workflow_version TEXT NOT NULL DEFAULT '1',
+      idempotency_key TEXT,
+      request_hash TEXT,
+      status TEXT NOT NULL,
+      source_type TEXT,
+      source_ref TEXT,
+      input_ref TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      completed_at INTEGER,
+      recovery_state TEXT NOT NULL DEFAULT 'runnable',
+      checkpoint_ref TEXT,
+      parent_workflow_run_id TEXT,
+      parent_step_id TEXT,
+      message_id TEXT,
+      turn_id TEXT,
+      claimed_by TEXT,
+      claim_expires_at INTEGER,
+      heartbeat_at INTEGER,
+      metadata_json TEXT
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_durable_workflow_runs_idempotency
+      ON durable_workflow_runs(workflow_id, idempotency_key)
+      WHERE idempotency_key IS NOT NULL;
+
+    CREATE INDEX IF NOT EXISTS idx_durable_workflow_runs_status
+      ON durable_workflow_runs(status, updated_at, workflow_run_id);
+
+    CREATE TABLE IF NOT EXISTS durable_workflow_events (
+      event_id TEXT NOT NULL UNIQUE,
+      workflow_run_id TEXT NOT NULL,
+      event_seq INTEGER NOT NULL,
+      event_type TEXT NOT NULL,
+      event_time INTEGER NOT NULL,
+      step_id TEXT,
+      agent_invocation_id TEXT,
+      tool_invocation_id TEXT,
+      idempotency_key TEXT,
+      payload_json TEXT,
+      payload_hash TEXT,
+      checkpoint_ref TEXT,
+      causation_event_id TEXT,
+      correlation_id TEXT,
+      recorded_at INTEGER NOT NULL,
+      PRIMARY KEY (workflow_run_id, event_seq),
+      FOREIGN KEY (workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+        ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_durable_workflow_events_type
+      ON durable_workflow_events(event_type, event_time, workflow_run_id);
+
+    CREATE TABLE IF NOT EXISTS durable_workflow_steps (
+      workflow_run_id TEXT NOT NULL,
+      step_id TEXT NOT NULL,
+      parent_step_id TEXT,
+      step_type TEXT NOT NULL,
+      status TEXT NOT NULL,
+      recovery_state TEXT NOT NULL,
+      attempt INTEGER NOT NULL DEFAULT 1,
+      max_attempts INTEGER,
+      idempotency_key TEXT,
+      input_ref TEXT,
+      output_ref TEXT,
+      error_ref TEXT,
+      checkpoint_ref TEXT,
+      claimed_by TEXT,
+      claim_expires_at INTEGER,
+      heartbeat_at INTEGER,
+      created_at INTEGER NOT NULL,
+      started_at INTEGER,
+      updated_at INTEGER NOT NULL,
+      completed_at INTEGER,
+      metadata_json TEXT,
+      PRIMARY KEY (workflow_run_id, step_id),
+      FOREIGN KEY (workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+        ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_durable_workflow_steps_status
+      ON durable_workflow_steps(status, updated_at, workflow_run_id, step_id);
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_durable_workflow_steps_idempotency
+      ON durable_workflow_steps(workflow_run_id, idempotency_key)
+      WHERE idempotency_key IS NOT NULL;
+
+    CREATE TABLE IF NOT EXISTS durable_workflow_refs (
+      ref_id TEXT NOT NULL PRIMARY KEY,
+      workflow_run_id TEXT NOT NULL,
+      step_id TEXT,
+      ref_kind TEXT NOT NULL,
+      media_type TEXT,
+      hash TEXT,
+      storage_kind TEXT NOT NULL,
+      storage_uri TEXT,
+      created_at INTEGER NOT NULL,
+      metadata_json TEXT,
+      FOREIGN KEY (workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+        ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_durable_workflow_refs_run
+      ON durable_workflow_refs(workflow_run_id, ref_kind, created_at);
+
+    CREATE TABLE IF NOT EXISTS durable_workflow_links (
+      parent_workflow_run_id TEXT NOT NULL,
+      parent_step_id TEXT NOT NULL,
+      child_workflow_run_id TEXT NOT NULL,
+      link_type TEXT NOT NULL,
+      status TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      metadata_json TEXT,
+      PRIMARY KEY (parent_workflow_run_id, parent_step_id, child_workflow_run_id),
+      FOREIGN KEY (parent_workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+        ON DELETE CASCADE,
+      FOREIGN KEY (child_workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+        ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_durable_workflow_links_child
+      ON durable_workflow_links(child_workflow_run_id, status);
+
+    CREATE TABLE IF NOT EXISTS durable_workflow_timers (
+      timer_id TEXT NOT NULL PRIMARY KEY,
+      workflow_run_id TEXT NOT NULL,
+      step_id TEXT,
+      timer_type TEXT NOT NULL,
+      due_at INTEGER NOT NULL,
+      status TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      fired_at INTEGER,
+      cancelled_at INTEGER,
+      metadata_json TEXT,
+      FOREIGN KEY (workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+        ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_durable_workflow_timers_due
+      ON durable_workflow_timers(status, due_at, timer_id);
+
+    CREATE TABLE IF NOT EXISTS durable_workflow_signals (
+      signal_id TEXT NOT NULL PRIMARY KEY,
+      workflow_run_id TEXT NOT NULL,
+      step_id TEXT,
+      signal_type TEXT NOT NULL,
+      idempotency_key TEXT,
+      payload_ref TEXT,
+      correlation_id TEXT,
+      received_at INTEGER NOT NULL,
+      consumed_at INTEGER,
+      metadata_json TEXT,
+      FOREIGN KEY (workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+        ON DELETE CASCADE
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_durable_workflow_signals_idempotency
+      ON durable_workflow_signals(workflow_run_id, idempotency_key)
+      WHERE idempotency_key IS NOT NULL;
+
+    CREATE INDEX IF NOT EXISTS idx_durable_workflow_signals_pending
+      ON durable_workflow_signals(consumed_at, received_at, signal_id);
+  `);
+  for (const column of [
+    "parent_workflow_run_id TEXT",
+    "parent_step_id TEXT",
+    "message_id TEXT",
+    "turn_id TEXT",
+    "claimed_by TEXT",
+    "claim_expires_at INTEGER",
+    "heartbeat_at INTEGER",
+  ]) {
+    ensureColumn(db, "durable_workflow_runs", column);
+  }
+  for (const column of ["claimed_by TEXT", "claim_expires_at INTEGER", "heartbeat_at INTEGER"]) {
+    ensureColumn(db, "durable_workflow_steps", column);
+  }
+}
+
+function count(db: DatabaseSync, sql: string, values: SQLInputValue[] = []): number {
+  const row = db.prepare(sql).get(...values) as CountRow | undefined;
+  return Number(row?.count ?? 0);
+}
+
+export function openDurableWorkflowSqliteStore(options?: {
+  path?: string;
+  env?: NodeJS.ProcessEnv;
+}): DurableWorkflowStore {
+  const pathname = path.resolve(options?.path ?? resolveDurableWorkflowSqlitePath(options?.env));
+  fs.mkdirSync(path.dirname(pathname), { recursive: true, mode: 0o700 });
+  const sqlite = requireNodeSqlite();
+  const db = new sqlite.DatabaseSync(pathname);
+  const walMaintenance = configureSqliteConnectionPragmas(db, {
+    busyTimeoutMs: DURABLE_WORKFLOW_SQLITE_BUSY_TIMEOUT_MS,
+    databaseLabel: "openclaw-durable-workflows",
+    databasePath: pathname,
+    foreignKeys: true,
+    synchronous: "NORMAL",
+  });
+  ensureDurableWorkflowSchema(db);
+
+  return {
+    createRun(input: CreateDurableWorkflowRunInput): DurableWorkflowRun {
+      const now = input.now ?? Date.now();
+      const workflowRunId = input.workflowRunId ?? `wfr_${randomUUID()}`;
+      const workflowVersion = input.workflowVersion ?? "1";
+      const status = input.status ?? "received";
+      const recoveryState = input.recoveryState ?? "runnable";
+      return runSqliteImmediateTransactionSync(db, () => {
+        const existing =
+          input.idempotencyKey &&
+          (db
+            .prepare(
+              `SELECT *
+                 FROM durable_workflow_runs
+                WHERE workflow_id = ?
+                  AND idempotency_key = ?`,
+            )
+            .get(input.workflowId, input.idempotencyKey) as DurableWorkflowRunRow | undefined);
+        if (existing) {
+          if (
+            input.requestHash &&
+            existing.request_hash &&
+            existing.request_hash !== input.requestHash
+          ) {
+            throw new Error(
+              `Durable workflow idempotency key conflict for ${input.workflowId}:${input.idempotencyKey}`,
+            );
+          }
+          return rowToRun(existing);
+        }
+        db.prepare(
+          `INSERT INTO durable_workflow_runs (
+             workflow_run_id, workflow_id, workflow_version, idempotency_key, request_hash,
+             status, source_type, source_ref, input_ref, created_at, updated_at, completed_at,
+             recovery_state, checkpoint_ref, parent_workflow_run_id, parent_step_id, message_id,
+             turn_id, claimed_by, claim_expires_at, heartbeat_at, metadata_json
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ).run(
+          workflowRunId,
+          input.workflowId,
+          workflowVersion,
+          optionalText(input.idempotencyKey),
+          optionalText(input.requestHash),
+          status,
+          optionalText(input.sourceType),
+          optionalText(input.sourceRef),
+          optionalText(input.inputRef),
+          now,
+          now,
+          null,
+          recoveryState,
+          optionalText(input.checkpointRef),
+          optionalText(input.parentWorkflowRunId),
+          optionalText(input.parentStepId),
+          optionalText(input.messageId),
+          optionalText(input.turnId),
+          null,
+          null,
+          null,
+          serializeJson(input.metadata),
+        );
+        const row = db
+          .prepare("SELECT * FROM durable_workflow_runs WHERE workflow_run_id = ?")
+          .get(workflowRunId) as DurableWorkflowRunRow;
+        return rowToRun(row);
+      });
+    },
+
+    getRun(workflowRunId: string): DurableWorkflowRun | undefined {
+      const row = db
+        .prepare("SELECT * FROM durable_workflow_runs WHERE workflow_run_id = ?")
+        .get(workflowRunId) as DurableWorkflowRunRow | undefined;
+      return row ? rowToRun(row) : undefined;
+    },
+
+    updateRun(input: UpdateDurableWorkflowRunInput): DurableWorkflowRun | undefined {
+      const now = input.now ?? Date.now();
+      return runSqliteImmediateTransactionSync(db, () => {
+        const current = db
+          .prepare("SELECT * FROM durable_workflow_runs WHERE workflow_run_id = ?")
+          .get(input.workflowRunId) as DurableWorkflowRunRow | undefined;
+        if (!current) {
+          return undefined;
+        }
+        const completedAt =
+          input.completedAt === undefined
+            ? current.completed_at
+            : input.completedAt === null
+              ? null
+              : input.completedAt;
+        db.prepare(
+          `UPDATE durable_workflow_runs
+              SET status = ?,
+                  recovery_state = ?,
+                  updated_at = ?,
+                  completed_at = ?,
+                  checkpoint_ref = ?,
+                  claimed_by = ?,
+                  claim_expires_at = ?,
+                  heartbeat_at = ?,
+                  metadata_json = ?
+            WHERE workflow_run_id = ?`,
+        ).run(
+          input.status ?? current.status,
+          input.recoveryState ?? current.recovery_state,
+          now,
+          completedAt,
+          input.checkpointRef === undefined
+            ? current.checkpoint_ref
+            : optionalText(input.checkpointRef ?? undefined),
+          input.claimedBy === undefined
+            ? current.claimed_by
+            : optionalText(input.claimedBy ?? undefined),
+          input.claimExpiresAt === undefined ? current.claim_expires_at : input.claimExpiresAt,
+          input.heartbeatAt === undefined ? current.heartbeat_at : input.heartbeatAt,
+          input.metadata === undefined ? current.metadata_json : serializeJson(input.metadata),
+          input.workflowRunId,
+        );
+        const row = db
+          .prepare("SELECT * FROM durable_workflow_runs WHERE workflow_run_id = ?")
+          .get(input.workflowRunId) as DurableWorkflowRunRow;
+        return rowToRun(row);
+      });
+    },
+
+    appendEvent(input: AppendDurableWorkflowEventInput): DurableWorkflowEvent {
+      const now = input.eventTime ?? Date.now();
+      const recordedAt = Date.now();
+      const eventId = input.eventId ?? `wfe_${randomUUID()}`;
+      return runSqliteImmediateTransactionSync(db, () => {
+        const nextSeq = count(
+          db,
+          "SELECT COALESCE(MAX(event_seq), 0) + 1 AS count FROM durable_workflow_events WHERE workflow_run_id = ?",
+          [input.workflowRunId],
+        );
+        db.prepare(
+          `INSERT INTO durable_workflow_events (
+             event_id, workflow_run_id, event_seq, event_type, event_time, step_id,
+             agent_invocation_id, tool_invocation_id, idempotency_key, payload_json,
+             payload_hash, checkpoint_ref, causation_event_id, correlation_id, recorded_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ).run(
+          eventId,
+          input.workflowRunId,
+          nextSeq,
+          input.eventType,
+          now,
+          optionalText(input.stepId),
+          optionalText(input.agentInvocationId),
+          optionalText(input.toolInvocationId),
+          optionalText(input.idempotencyKey),
+          serializeJson(input.payload),
+          optionalText(input.payloadHash),
+          optionalText(input.checkpointRef),
+          optionalText(input.causationEventId),
+          optionalText(input.correlationId),
+          recordedAt,
+        );
+        db.prepare(
+          `UPDATE durable_workflow_runs
+              SET updated_at = ?
+            WHERE workflow_run_id = ?`,
+        ).run(recordedAt, input.workflowRunId);
+        const row = db
+          .prepare(
+            `SELECT *
+               FROM durable_workflow_events
+              WHERE workflow_run_id = ?
+                AND event_seq = ?`,
+          )
+          .get(input.workflowRunId, nextSeq) as DurableWorkflowEventRow;
+        return rowToEvent(row);
+      });
+    },
+
+    listRuns(options?: { limit?: number }): DurableWorkflowRun[] {
+      const limit = Math.max(1, Math.min(500, Math.trunc(options?.limit ?? 50)));
+      const rows = db
+        .prepare(
+          `SELECT *
+             FROM durable_workflow_runs
+            ORDER BY updated_at DESC, workflow_run_id DESC
+            LIMIT ?`,
+        )
+        .all(limit) as DurableWorkflowRunRow[];
+      return rows.map(rowToRun);
+    },
+
+    listOpenRuns(options?: { workflowId?: string; limit?: number }): DurableWorkflowRun[] {
+      const limit = Math.max(1, Math.min(5000, Math.trunc(options?.limit ?? 500)));
+      const workflowId = optionalText(options?.workflowId);
+      const rows = workflowId
+        ? (db
+            .prepare(
+              `SELECT *
+                 FROM durable_workflow_runs
+                WHERE workflow_id = ?
+                  AND status NOT IN ('succeeded', 'failed', 'cancelled', 'lost')
+                ORDER BY updated_at ASC, workflow_run_id ASC
+                LIMIT ?`,
+            )
+            .all(workflowId, limit) as DurableWorkflowRunRow[])
+        : (db
+            .prepare(
+              `SELECT *
+                 FROM durable_workflow_runs
+                WHERE status NOT IN ('succeeded', 'failed', 'cancelled', 'lost')
+                ORDER BY updated_at ASC, workflow_run_id ASC
+                LIMIT ?`,
+            )
+            .all(limit) as DurableWorkflowRunRow[]);
+      return rows.map(rowToRun);
+    },
+
+    claimNextRunnableRun(input: ClaimDurableWorkflowRunInput): DurableWorkflowRun | undefined {
+      const now = input.now ?? Date.now();
+      const claimExpiresAt = now + input.claimTtlMs;
+      return runSqliteImmediateTransactionSync(db, () => {
+        const workflowId = optionalText(input.workflowId);
+        const row = workflowId
+          ? (db
+              .prepare(
+                `SELECT *
+                   FROM durable_workflow_runs
+                  WHERE workflow_id = ?
+                    AND status IN ('received', 'queued')
+                    AND recovery_state = 'runnable'
+                    AND (claimed_by IS NULL OR claim_expires_at IS NULL OR claim_expires_at <= ?)
+                  ORDER BY updated_at ASC, workflow_run_id ASC
+                  LIMIT 1`,
+              )
+              .get(workflowId, now) as DurableWorkflowRunRow | undefined)
+          : (db
+              .prepare(
+                `SELECT *
+                   FROM durable_workflow_runs
+                  WHERE status IN ('received', 'queued')
+                    AND recovery_state = 'runnable'
+                    AND (claimed_by IS NULL OR claim_expires_at IS NULL OR claim_expires_at <= ?)
+                  ORDER BY updated_at ASC, workflow_run_id ASC
+                  LIMIT 1`,
+              )
+              .get(now) as DurableWorkflowRunRow | undefined);
+        if (!row) {
+          return undefined;
+        }
+        db.prepare(
+          `UPDATE durable_workflow_runs
+              SET status = 'queued',
+                  recovery_state = 'claimed',
+                  claimed_by = ?,
+                  claim_expires_at = ?,
+                  heartbeat_at = ?,
+                  updated_at = ?
+            WHERE workflow_run_id = ?`,
+        ).run(input.workerId, claimExpiresAt, now, now, row.workflow_run_id);
+        const claimed = db
+          .prepare("SELECT * FROM durable_workflow_runs WHERE workflow_run_id = ?")
+          .get(row.workflow_run_id) as DurableWorkflowRunRow;
+        return rowToRun(claimed);
+      });
+    },
+
+    releaseRunClaim(input: {
+      workflowRunId: string;
+      workerId: string;
+      now?: number;
+    }): DurableWorkflowRun | undefined {
+      const now = input.now ?? Date.now();
+      return runSqliteImmediateTransactionSync(db, () => {
+        db.prepare(
+          `UPDATE durable_workflow_runs
+              SET recovery_state = 'runnable',
+                  claimed_by = NULL,
+                  claim_expires_at = NULL,
+                  heartbeat_at = NULL,
+                  updated_at = ?
+            WHERE workflow_run_id = ?
+              AND claimed_by = ?`,
+        ).run(now, input.workflowRunId, input.workerId);
+        const row = db
+          .prepare("SELECT * FROM durable_workflow_runs WHERE workflow_run_id = ?")
+          .get(input.workflowRunId) as DurableWorkflowRunRow | undefined;
+        return row ? rowToRun(row) : undefined;
+      });
+    },
+
+    createStep(input: CreateDurableWorkflowStepInput): DurableWorkflowStep {
+      const now = input.now ?? Date.now();
+      const stepId = input.stepId ?? `step_${randomUUID()}`;
+      const status = input.status ?? "pending";
+      const recoveryState = input.recoveryState ?? "runnable";
+      const attempt = input.attempt ?? 1;
+      return runSqliteImmediateTransactionSync(db, () => {
+        const existing =
+          input.idempotencyKey &&
+          (db
+            .prepare(
+              `SELECT *
+                 FROM durable_workflow_steps
+                WHERE workflow_run_id = ?
+                  AND idempotency_key = ?`,
+            )
+            .get(input.workflowRunId, input.idempotencyKey) as DurableWorkflowStepRow | undefined);
+        if (existing) {
+          return rowToStep(existing);
+        }
+        db.prepare(
+          `INSERT INTO durable_workflow_steps (
+             workflow_run_id, step_id, parent_step_id, step_type, status, recovery_state,
+             attempt, max_attempts, idempotency_key, input_ref, output_ref, error_ref,
+             checkpoint_ref, claimed_by, claim_expires_at, heartbeat_at, created_at,
+             started_at, updated_at, completed_at, metadata_json
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ).run(
+          input.workflowRunId,
+          stepId,
+          optionalText(input.parentStepId),
+          input.stepType,
+          status,
+          recoveryState,
+          attempt,
+          input.maxAttempts ?? null,
+          optionalText(input.idempotencyKey),
+          optionalText(input.inputRef),
+          optionalText(input.outputRef),
+          optionalText(input.errorRef),
+          optionalText(input.checkpointRef),
+          null,
+          null,
+          null,
+          now,
+          status === "running" ? now : null,
+          now,
+          null,
+          serializeJson(input.metadata),
+        );
+        const row = db
+          .prepare("SELECT * FROM durable_workflow_steps WHERE workflow_run_id = ? AND step_id = ?")
+          .get(input.workflowRunId, stepId) as DurableWorkflowStepRow;
+        return rowToStep(row);
+      });
+    },
+
+    updateStep(input: UpdateDurableWorkflowStepInput): DurableWorkflowStep | undefined {
+      const now = input.now ?? Date.now();
+      return runSqliteImmediateTransactionSync(db, () => {
+        const current = db
+          .prepare("SELECT * FROM durable_workflow_steps WHERE workflow_run_id = ? AND step_id = ?")
+          .get(input.workflowRunId, input.stepId) as DurableWorkflowStepRow | undefined;
+        if (!current) {
+          return undefined;
+        }
+        db.prepare(
+          `UPDATE durable_workflow_steps
+              SET status = ?,
+                  recovery_state = ?,
+                  attempt = ?,
+                  max_attempts = ?,
+                  input_ref = ?,
+                  output_ref = ?,
+                  error_ref = ?,
+                  checkpoint_ref = ?,
+                  claimed_by = ?,
+                  claim_expires_at = ?,
+                  heartbeat_at = ?,
+                  started_at = ?,
+                  completed_at = ?,
+                  updated_at = ?,
+                  metadata_json = ?
+            WHERE workflow_run_id = ?
+              AND step_id = ?`,
+        ).run(
+          input.status ?? current.status,
+          input.recoveryState ?? current.recovery_state,
+          input.attempt ?? current.attempt,
+          input.maxAttempts === undefined ? current.max_attempts : input.maxAttempts,
+          input.inputRef === undefined
+            ? current.input_ref
+            : optionalText(input.inputRef ?? undefined),
+          input.outputRef === undefined
+            ? current.output_ref
+            : optionalText(input.outputRef ?? undefined),
+          input.errorRef === undefined
+            ? current.error_ref
+            : optionalText(input.errorRef ?? undefined),
+          input.checkpointRef === undefined
+            ? current.checkpoint_ref
+            : optionalText(input.checkpointRef ?? undefined),
+          input.claimedBy === undefined
+            ? current.claimed_by
+            : optionalText(input.claimedBy ?? undefined),
+          input.claimExpiresAt === undefined ? current.claim_expires_at : input.claimExpiresAt,
+          input.heartbeatAt === undefined ? current.heartbeat_at : input.heartbeatAt,
+          input.startedAt === undefined
+            ? current.started_at
+            : input.startedAt === null
+              ? null
+              : input.startedAt,
+          input.completedAt === undefined
+            ? current.completed_at
+            : input.completedAt === null
+              ? null
+              : input.completedAt,
+          now,
+          input.metadata === undefined ? current.metadata_json : serializeJson(input.metadata),
+          input.workflowRunId,
+          input.stepId,
+        );
+        const row = db
+          .prepare("SELECT * FROM durable_workflow_steps WHERE workflow_run_id = ? AND step_id = ?")
+          .get(input.workflowRunId, input.stepId) as DurableWorkflowStepRow;
+        return rowToStep(row);
+      });
+    },
+
+    claimNextRunnableStep(input: ClaimDurableWorkflowStepInput): DurableWorkflowStep | undefined {
+      const now = input.now ?? Date.now();
+      const claimExpiresAt = now + input.claimTtlMs;
+      return runSqliteImmediateTransactionSync(db, () => {
+        const filters: string[] = [
+          "s.status IN ('pending', 'queued')",
+          "s.recovery_state = 'runnable'",
+          "(s.claimed_by IS NULL OR s.claim_expires_at IS NULL OR s.claim_expires_at <= ?)",
+          "r.status NOT IN ('succeeded', 'failed', 'cancelled', 'lost')",
+        ];
+        const values: SQLInputValue[] = [now];
+        const workflowId = optionalText(input.workflowId);
+        if (workflowId) {
+          filters.push("r.workflow_id = ?");
+          values.push(workflowId);
+        }
+        if (input.stepType) {
+          filters.push("s.step_type = ?");
+          values.push(input.stepType);
+        }
+        const row = db
+          .prepare(
+            `SELECT s.*
+               FROM durable_workflow_steps s
+               JOIN durable_workflow_runs r
+                 ON r.workflow_run_id = s.workflow_run_id
+              WHERE ${filters.join(" AND ")}
+              ORDER BY s.updated_at ASC, s.workflow_run_id ASC, s.step_id ASC
+              LIMIT 1`,
+          )
+          .get(...values) as DurableWorkflowStepRow | undefined;
+        if (!row) {
+          return undefined;
+        }
+        db.prepare(
+          `UPDATE durable_workflow_steps
+              SET status = 'queued',
+                  recovery_state = 'claimed',
+                  claimed_by = ?,
+                  claim_expires_at = ?,
+                  heartbeat_at = ?,
+                  updated_at = ?
+            WHERE workflow_run_id = ?
+              AND step_id = ?`,
+        ).run(input.workerId, claimExpiresAt, now, now, row.workflow_run_id, row.step_id);
+        const claimed = db
+          .prepare("SELECT * FROM durable_workflow_steps WHERE workflow_run_id = ? AND step_id = ?")
+          .get(row.workflow_run_id, row.step_id) as DurableWorkflowStepRow;
+        return rowToStep(claimed);
+      });
+    },
+
+    releaseStepClaim(input: {
+      workflowRunId: string;
+      stepId: string;
+      workerId: string;
+      now?: number;
+    }): DurableWorkflowStep | undefined {
+      const now = input.now ?? Date.now();
+      return runSqliteImmediateTransactionSync(db, () => {
+        db.prepare(
+          `UPDATE durable_workflow_steps
+              SET status = CASE WHEN status = 'running' THEN 'queued' ELSE status END,
+                  recovery_state = 'runnable',
+                  claimed_by = NULL,
+                  claim_expires_at = NULL,
+                  heartbeat_at = NULL,
+                  updated_at = ?
+            WHERE workflow_run_id = ?
+              AND step_id = ?
+              AND claimed_by = ?`,
+        ).run(now, input.workflowRunId, input.stepId, input.workerId);
+        const row = db
+          .prepare("SELECT * FROM durable_workflow_steps WHERE workflow_run_id = ? AND step_id = ?")
+          .get(input.workflowRunId, input.stepId) as DurableWorkflowStepRow | undefined;
+        return row ? rowToStep(row) : undefined;
+      });
+    },
+
+    listSteps(workflowRunId: string): DurableWorkflowStep[] {
+      const rows = db
+        .prepare(
+          `SELECT *
+             FROM durable_workflow_steps
+            WHERE workflow_run_id = ?
+            ORDER BY created_at ASC, step_id ASC`,
+        )
+        .all(workflowRunId) as DurableWorkflowStepRow[];
+      return rows.map(rowToStep);
+    },
+
+    createRef(input: CreateDurableWorkflowRefInput): DurableWorkflowRef {
+      const now = input.now ?? Date.now();
+      const refId = input.refId ?? `ref_${randomUUID()}`;
+      db.prepare(
+        `INSERT INTO durable_workflow_refs (
+           ref_id, workflow_run_id, step_id, ref_kind, media_type, hash, storage_kind,
+           storage_uri, created_at, metadata_json
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        refId,
+        input.workflowRunId,
+        optionalText(input.stepId),
+        input.refKind,
+        optionalText(input.mediaType),
+        optionalText(input.hash),
+        input.storageKind ?? "external",
+        optionalText(input.storageUri),
+        now,
+        serializeJson(input.metadata),
+      );
+      const row = db
+        .prepare("SELECT * FROM durable_workflow_refs WHERE ref_id = ?")
+        .get(refId) as DurableWorkflowRefRow;
+      return rowToRef(row);
+    },
+
+    getRef(refId: string): DurableWorkflowRef | undefined {
+      const row = db.prepare("SELECT * FROM durable_workflow_refs WHERE ref_id = ?").get(refId) as
+        | DurableWorkflowRefRow
+        | undefined;
+      return row ? rowToRef(row) : undefined;
+    },
+
+    listRefs(workflowRunId: string): DurableWorkflowRef[] {
+      const rows = db
+        .prepare(
+          `SELECT *
+             FROM durable_workflow_refs
+            WHERE workflow_run_id = ?
+            ORDER BY created_at ASC, ref_id ASC`,
+        )
+        .all(workflowRunId) as DurableWorkflowRefRow[];
+      return rows.map(rowToRef);
+    },
+
+    createLink(input: CreateDurableWorkflowLinkInput): DurableWorkflowLink {
+      const now = input.now ?? Date.now();
+      db.prepare(
+        `INSERT INTO durable_workflow_links (
+           parent_workflow_run_id, parent_step_id, child_workflow_run_id, link_type,
+           status, created_at, updated_at, metadata_json
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        input.parentWorkflowRunId,
+        input.parentStepId,
+        input.childWorkflowRunId,
+        input.linkType,
+        input.status ?? "pending",
+        now,
+        now,
+        serializeJson(input.metadata),
+      );
+      const row = db
+        .prepare(
+          `SELECT *
+             FROM durable_workflow_links
+            WHERE parent_workflow_run_id = ?
+              AND parent_step_id = ?
+              AND child_workflow_run_id = ?`,
+        )
+        .get(
+          input.parentWorkflowRunId,
+          input.parentStepId,
+          input.childWorkflowRunId,
+        ) as DurableWorkflowLinkRow;
+      return rowToLink(row);
+    },
+
+    updateLink(input: UpdateDurableWorkflowLinkInput): DurableWorkflowLink | undefined {
+      const now = input.now ?? Date.now();
+      return runSqliteImmediateTransactionSync(db, () => {
+        const current = db
+          .prepare(
+            `SELECT *
+               FROM durable_workflow_links
+              WHERE parent_workflow_run_id = ?
+                AND parent_step_id = ?
+                AND child_workflow_run_id = ?`,
+          )
+          .get(input.parentWorkflowRunId, input.parentStepId, input.childWorkflowRunId) as
+          | DurableWorkflowLinkRow
+          | undefined;
+        if (!current) {
+          return undefined;
+        }
+        db.prepare(
+          `UPDATE durable_workflow_links
+              SET status = ?,
+                  updated_at = ?,
+                  metadata_json = ?
+            WHERE parent_workflow_run_id = ?
+              AND parent_step_id = ?
+              AND child_workflow_run_id = ?`,
+        ).run(
+          input.status ?? current.status,
+          now,
+          input.metadata === undefined ? current.metadata_json : serializeJson(input.metadata),
+          input.parentWorkflowRunId,
+          input.parentStepId,
+          input.childWorkflowRunId,
+        );
+        const row = db
+          .prepare(
+            `SELECT *
+               FROM durable_workflow_links
+              WHERE parent_workflow_run_id = ?
+                AND parent_step_id = ?
+                AND child_workflow_run_id = ?`,
+          )
+          .get(
+            input.parentWorkflowRunId,
+            input.parentStepId,
+            input.childWorkflowRunId,
+          ) as DurableWorkflowLinkRow;
+        return rowToLink(row);
+      });
+    },
+
+    listChildLinks(parentWorkflowRunId: string): DurableWorkflowLink[] {
+      const rows = db
+        .prepare(
+          `SELECT *
+             FROM durable_workflow_links
+            WHERE parent_workflow_run_id = ?
+            ORDER BY created_at ASC, child_workflow_run_id ASC`,
+        )
+        .all(parentWorkflowRunId) as DurableWorkflowLinkRow[];
+      return rows.map(rowToLink);
+    },
+
+    listParentLinks(childWorkflowRunId: string): DurableWorkflowLink[] {
+      const rows = db
+        .prepare(
+          `SELECT *
+             FROM durable_workflow_links
+            WHERE child_workflow_run_id = ?
+            ORDER BY created_at ASC, parent_workflow_run_id ASC, parent_step_id ASC`,
+        )
+        .all(childWorkflowRunId) as DurableWorkflowLinkRow[];
+      return rows.map(rowToLink);
+    },
+
+    createTimer(input: CreateDurableWorkflowTimerInput): DurableWorkflowTimer {
+      const now = input.now ?? Date.now();
+      const timerId = input.timerId ?? `timer_${randomUUID()}`;
+      db.prepare(
+        `INSERT INTO durable_workflow_timers (
+           timer_id, workflow_run_id, step_id, timer_type, due_at, status, created_at,
+           fired_at, cancelled_at, metadata_json
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        timerId,
+        input.workflowRunId,
+        optionalText(input.stepId),
+        input.timerType,
+        input.dueAt,
+        "pending",
+        now,
+        null,
+        null,
+        serializeJson(input.metadata),
+      );
+      const row = db
+        .prepare("SELECT * FROM durable_workflow_timers WHERE timer_id = ?")
+        .get(timerId) as DurableWorkflowTimerRow;
+      return rowToTimer(row);
+    },
+
+    updateTimer(input: UpdateDurableWorkflowTimerInput): DurableWorkflowTimer | undefined {
+      const now = input.now ?? Date.now();
+      return runSqliteImmediateTransactionSync(db, () => {
+        const current = db
+          .prepare("SELECT * FROM durable_workflow_timers WHERE timer_id = ?")
+          .get(input.timerId) as DurableWorkflowTimerRow | undefined;
+        if (!current) {
+          return undefined;
+        }
+        db.prepare(
+          `UPDATE durable_workflow_timers
+              SET status = ?,
+                  fired_at = ?,
+                  cancelled_at = ?
+            WHERE timer_id = ?`,
+        ).run(
+          input.status,
+          input.firedAt === undefined
+            ? input.status === "fired"
+              ? now
+              : current.fired_at
+            : input.firedAt,
+          input.cancelledAt === undefined
+            ? input.status === "cancelled"
+              ? now
+              : current.cancelled_at
+            : input.cancelledAt,
+          input.timerId,
+        );
+        const row = db
+          .prepare("SELECT * FROM durable_workflow_timers WHERE timer_id = ?")
+          .get(input.timerId) as DurableWorkflowTimerRow;
+        return rowToTimer(row);
+      });
+    },
+
+    listTimers(workflowRunId?: string): DurableWorkflowTimer[] {
+      const rows = workflowRunId
+        ? (db
+            .prepare(
+              `SELECT *
+                 FROM durable_workflow_timers
+                WHERE workflow_run_id = ?
+                ORDER BY due_at ASC, timer_id ASC`,
+            )
+            .all(workflowRunId) as DurableWorkflowTimerRow[])
+        : (db
+            .prepare(
+              `SELECT *
+                 FROM durable_workflow_timers
+                ORDER BY due_at ASC, timer_id ASC`,
+            )
+            .all() as DurableWorkflowTimerRow[]);
+      return rows.map(rowToTimer);
+    },
+
+    listDueTimers(now: number, options?: { limit?: number }): DurableWorkflowTimer[] {
+      const limit = Math.max(1, Math.min(5000, Math.trunc(options?.limit ?? 500)));
+      const rows = db
+        .prepare(
+          `SELECT *
+             FROM durable_workflow_timers
+            WHERE status = 'pending'
+              AND due_at <= ?
+            ORDER BY due_at ASC, timer_id ASC
+            LIMIT ?`,
+        )
+        .all(now, limit) as DurableWorkflowTimerRow[];
+      return rows.map(rowToTimer);
+    },
+
+    createSignal(input: CreateDurableWorkflowSignalInput): DurableWorkflowSignal {
+      const now = input.now ?? Date.now();
+      return runSqliteImmediateTransactionSync(db, () => {
+        const existing =
+          input.idempotencyKey &&
+          (db
+            .prepare(
+              `SELECT *
+                 FROM durable_workflow_signals
+                WHERE workflow_run_id = ?
+                  AND idempotency_key = ?`,
+            )
+            .get(input.workflowRunId, input.idempotencyKey) as
+            | DurableWorkflowSignalRow
+            | undefined);
+        if (existing) {
+          return rowToSignal(existing);
+        }
+        const signalId = input.signalId ?? `sig_${randomUUID()}`;
+        db.prepare(
+          `INSERT INTO durable_workflow_signals (
+             signal_id, workflow_run_id, step_id, signal_type, idempotency_key, payload_ref,
+             correlation_id, received_at, consumed_at, metadata_json
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ).run(
+          signalId,
+          input.workflowRunId,
+          optionalText(input.stepId),
+          input.signalType,
+          optionalText(input.idempotencyKey),
+          optionalText(input.payloadRef),
+          optionalText(input.correlationId),
+          now,
+          null,
+          serializeJson(input.metadata),
+        );
+        const row = db
+          .prepare("SELECT * FROM durable_workflow_signals WHERE signal_id = ?")
+          .get(signalId) as DurableWorkflowSignalRow;
+        return rowToSignal(row);
+      });
+    },
+
+    consumeSignal(input: { signalId: string; now?: number }): DurableWorkflowSignal | undefined {
+      const now = input.now ?? Date.now();
+      return runSqliteImmediateTransactionSync(db, () => {
+        db.prepare(
+          `UPDATE durable_workflow_signals
+              SET consumed_at = COALESCE(consumed_at, ?)
+            WHERE signal_id = ?`,
+        ).run(now, input.signalId);
+        const row = db
+          .prepare("SELECT * FROM durable_workflow_signals WHERE signal_id = ?")
+          .get(input.signalId) as DurableWorkflowSignalRow | undefined;
+        return row ? rowToSignal(row) : undefined;
+      });
+    },
+
+    listPendingSignals(options?: { limit?: number }): DurableWorkflowSignal[] {
+      const limit = Math.max(1, Math.min(5000, Math.trunc(options?.limit ?? 500)));
+      const rows = db
+        .prepare(
+          `SELECT *
+             FROM durable_workflow_signals
+            WHERE consumed_at IS NULL
+            ORDER BY received_at ASC, signal_id ASC
+            LIMIT ?`,
+        )
+        .all(limit) as DurableWorkflowSignalRow[];
+      return rows.map(rowToSignal);
+    },
+
+    listSignals(workflowRunId: string): DurableWorkflowSignal[] {
+      const rows = db
+        .prepare(
+          `SELECT *
+             FROM durable_workflow_signals
+            WHERE workflow_run_id = ?
+            ORDER BY received_at ASC, signal_id ASC`,
+        )
+        .all(workflowRunId) as DurableWorkflowSignalRow[];
+      return rows.map(rowToSignal);
+    },
+
+    getTimeline(workflowRunId: string): DurableWorkflowEvent[] {
+      const rows = db
+        .prepare(
+          `SELECT *
+             FROM durable_workflow_events
+            WHERE workflow_run_id = ?
+            ORDER BY event_seq ASC`,
+        )
+        .all(workflowRunId) as DurableWorkflowEventRow[];
+      return rows.map(rowToEvent);
+    },
+
+    getStats(): DurableWorkflowStoreStats {
+      return {
+        path: pathname,
+        runs: count(db, "SELECT COUNT(*) AS count FROM durable_workflow_runs"),
+        events: count(db, "SELECT COUNT(*) AS count FROM durable_workflow_events"),
+        steps: count(db, "SELECT COUNT(*) AS count FROM durable_workflow_steps"),
+        openRuns: count(
+          db,
+          "SELECT COUNT(*) AS count FROM durable_workflow_runs WHERE status NOT IN ('succeeded', 'failed', 'cancelled', 'lost')",
+        ),
+      };
+    },
+
+    close(): void {
+      walMaintenance.close();
+      if (db.isOpen) {
+        db.close();
+      }
+    },
+  };
+}

--- a/src/durable/sqlite-store.ts
+++ b/src/durable/sqlite-store.ts
@@ -158,8 +158,16 @@ type DurableWorkflowSignalRow = {
 };
 
 type CountRow = { count: number | bigint };
+type DurableSchemaMigrationRow = {
+  schema_name: string;
+  version: number | bigint;
+  applied_at: number | bigint;
+  metadata_json: string | null;
+};
 
 const DURABLE_WORKFLOW_SQLITE_BUSY_TIMEOUT_MS = 30_000;
+export const DURABLE_WORKFLOW_SQLITE_SCHEMA_VERSION = 1;
+const DURABLE_WORKFLOW_SQLITE_SCHEMA_NAME = "durable_workflows";
 
 function optionalText(value: string | undefined): string | null {
   return value && value.trim() ? value : null;
@@ -326,6 +334,13 @@ function ensureColumn(db: DatabaseSync, tableName: string, columnDefinition: str
 
 function ensureDurableWorkflowSchema(db: DatabaseSync): void {
   db.exec(`
+    CREATE TABLE IF NOT EXISTS durable_schema_migrations (
+      schema_name TEXT NOT NULL PRIMARY KEY,
+      version INTEGER NOT NULL,
+      applied_at INTEGER NOT NULL,
+      metadata_json TEXT
+    );
+
     CREATE TABLE IF NOT EXISTS durable_workflow_runs (
       workflow_run_id TEXT NOT NULL PRIMARY KEY,
       workflow_id TEXT NOT NULL,
@@ -507,6 +522,55 @@ function ensureDurableWorkflowSchema(db: DatabaseSync): void {
   for (const column of ["claimed_by TEXT", "claim_expires_at INTEGER", "heartbeat_at INTEGER"]) {
     ensureColumn(db, "durable_workflow_steps", column);
   }
+  ensureDurableWorkflowSchemaVersion(db);
+}
+
+function ensureDurableWorkflowSchemaVersion(db: DatabaseSync): void {
+  const now = Date.now();
+  const row = db
+    .prepare("SELECT * FROM durable_schema_migrations WHERE schema_name = ?")
+    .get(DURABLE_WORKFLOW_SQLITE_SCHEMA_NAME) as DurableSchemaMigrationRow | undefined;
+  const currentVersion = Number(row?.version ?? 0);
+  if (currentVersion > DURABLE_WORKFLOW_SQLITE_SCHEMA_VERSION) {
+    throw new Error(
+      `Durable workflow schema version ${currentVersion} is newer than supported version ${DURABLE_WORKFLOW_SQLITE_SCHEMA_VERSION}`,
+    );
+  }
+  if (currentVersion === DURABLE_WORKFLOW_SQLITE_SCHEMA_VERSION) {
+    return;
+  }
+
+  const metadata = JSON.stringify({
+    kind: currentVersion === 0 ? "fresh-install" : "schema-upgrade",
+    previousVersion: currentVersion,
+  });
+  if (row) {
+    db.prepare(
+      `UPDATE durable_schema_migrations
+          SET version = ?,
+              applied_at = ?,
+              metadata_json = ?
+        WHERE schema_name = ?`,
+    ).run(
+      DURABLE_WORKFLOW_SQLITE_SCHEMA_VERSION,
+      now,
+      metadata,
+      DURABLE_WORKFLOW_SQLITE_SCHEMA_NAME,
+    );
+    return;
+  }
+
+  db.prepare(
+    `INSERT INTO durable_schema_migrations (schema_name, version, applied_at, metadata_json)
+     VALUES (?, ?, ?, ?)`,
+  ).run(DURABLE_WORKFLOW_SQLITE_SCHEMA_NAME, DURABLE_WORKFLOW_SQLITE_SCHEMA_VERSION, now, metadata);
+}
+
+function getDurableWorkflowSchemaVersion(db: DatabaseSync): number {
+  const row = db
+    .prepare("SELECT * FROM durable_schema_migrations WHERE schema_name = ?")
+    .get(DURABLE_WORKFLOW_SQLITE_SCHEMA_NAME) as DurableSchemaMigrationRow | undefined;
+  return Number(row?.version ?? 0);
 }
 
 function count(db: DatabaseSync, sql: string, values: SQLInputValue[] = []): number {
@@ -1386,6 +1450,7 @@ export function openDurableWorkflowSqliteStore(options?: {
     getStats(): DurableWorkflowStoreStats {
       return {
         path: pathname,
+        schemaVersion: getDurableWorkflowSchemaVersion(db),
         runs: count(db, "SELECT COUNT(*) AS count FROM durable_workflow_runs"),
         events: count(db, "SELECT COUNT(*) AS count FROM durable_workflow_events"),
         steps: count(db, "SELECT COUNT(*) AS count FROM durable_workflow_steps"),

--- a/src/durable/startup.ts
+++ b/src/durable/startup.ts
@@ -1,0 +1,62 @@
+import { createSubsystemLogger } from "../logging/subsystem.js";
+// Gateway startup integration for the durable workflow control plane.
+import { isDurableWorkflowsEnabled } from "./config.js";
+import { reconcileDurableAgentTurnsOnGatewayStartup } from "./recovery.js";
+import { openDurableWorkflowSqliteStore } from "./sqlite-store.js";
+
+const log = createSubsystemLogger("durable/workflows");
+
+export async function maybeRecordDurableGatewayStartup(params: {
+  processInstanceId: string;
+  startupStartedAt: number;
+  port?: number;
+  env?: NodeJS.ProcessEnv;
+}): Promise<void> {
+  const env = params.env ?? process.env;
+  if (!isDurableWorkflowsEnabled(env)) {
+    return;
+  }
+  let store: ReturnType<typeof openDurableWorkflowSqliteStore> | null = null;
+  try {
+    store = openDurableWorkflowSqliteStore({ env });
+    const recovery = reconcileDurableAgentTurnsOnGatewayStartup({
+      store,
+      processInstanceId: params.processInstanceId,
+      now: params.startupStartedAt,
+    });
+    const run = store.createRun({
+      workflowId: "openclaw.gateway.startup",
+      workflowVersion: "1",
+      status: "succeeded",
+      recoveryState: "terminal",
+      sourceType: "gateway",
+      sourceRef: params.processInstanceId,
+      metadata: {
+        processInstanceId: params.processInstanceId,
+        startupStartedAt: params.startupStartedAt,
+        port: params.port,
+      },
+    });
+    store.appendEvent({
+      workflowRunId: run.workflowRunId,
+      eventType: "gateway.startup.succeeded",
+      payload: {
+        processInstanceId: params.processInstanceId,
+        startupStartedAt: params.startupStartedAt,
+        port: params.port,
+      },
+    });
+    const stats = store.getStats();
+    log.info("recorded durable gateway startup", {
+      workflowRunId: run.workflowRunId,
+      path: stats.path,
+      runs: stats.runs,
+      events: stats.events,
+      reconciledLostAgentTurns: recovery.markedLost,
+    });
+  } catch (err) {
+    log.warn(`durable workflow startup record failed: ${String(err)}`);
+  } finally {
+    store?.close();
+  }
+}

--- a/src/durable/subagent.test.ts
+++ b/src/durable/subagent.test.ts
@@ -1,0 +1,310 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { openDurableWorkflowSqliteStore } from "./sqlite-store.js";
+import { recordDurableSubagentRegistered, recordDurableSubagentTerminal } from "./subagent.js";
+import {
+  DURABLE_AGENT_TURN_WORKFLOW_ID,
+  DURABLE_SUBAGENT_RUN_WORKFLOW_ID,
+} from "./workflow-ids.js";
+
+describe("durable subagent bridge", () => {
+  it("links children to the active requester run when same-session parents overlap", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-subagent-"));
+    const dbPath = path.join(dir, "state", "openclaw.sqlite");
+    const env = {
+      ...process.env,
+      OPENCLAW_DURABLE_WORKFLOWS: "1",
+      OPENCLAW_STATE_DIR: dir,
+    };
+    const parentSessionKey = "agent:bo:discord:channel:bo-main";
+
+    let olderParentId = "";
+    let activeParentId = "";
+    const setupStore = openDurableWorkflowSqliteStore({ path: dbPath });
+    try {
+      olderParentId = setupStore.createRun({
+        workflowId: DURABLE_AGENT_TURN_WORKFLOW_ID,
+        status: "running",
+        recoveryState: "running",
+        idempotencyKey: "run_parent_old",
+        sourceType: "agent_turn",
+        sourceRef: parentSessionKey,
+        metadata: { sessionKey: parentSessionKey },
+        now: 100,
+      }).workflowRunId;
+      activeParentId = setupStore.createRun({
+        workflowId: DURABLE_AGENT_TURN_WORKFLOW_ID,
+        status: "running",
+        recoveryState: "running",
+        idempotencyKey: "run_parent_active",
+        sourceType: "agent_turn",
+        sourceRef: parentSessionKey,
+        metadata: { sessionKey: parentSessionKey },
+        now: 200,
+      }).workflowRunId;
+    } finally {
+      setupStore.close();
+    }
+
+    recordDurableSubagentRegistered({
+      runId: "run_child",
+      childSessionKey: "agent:bo:subagent:active-child",
+      requesterSessionKey: parentSessionKey,
+      requesterRunId: "run_parent_active",
+      task: "Check active parent binding",
+      label: "active parent",
+      agentId: "bo",
+      requesterAgentId: "bo",
+      env,
+    });
+
+    const assertStore = openDurableWorkflowSqliteStore({ path: dbPath });
+    try {
+      const child = assertStore
+        .listRuns({ limit: 20 })
+        .find((run) => run.workflowId === DURABLE_SUBAGENT_RUN_WORKFLOW_ID);
+      expect(child).toBeDefined();
+      expect(child?.parentWorkflowRunId).toBe(activeParentId);
+      expect(child?.parentWorkflowRunId).not.toBe(olderParentId);
+      expect(assertStore.listChildLinks(activeParentId)).toMatchObject([
+        {
+          childWorkflowRunId: child?.workflowRunId,
+          status: "running",
+        },
+      ]);
+      expect(assertStore.listChildLinks(olderParentId)).toEqual([]);
+    } finally {
+      assertStore.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to the newest same-session parent when requester run id is unavailable", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-subagent-"));
+    const dbPath = path.join(dir, "state", "openclaw.sqlite");
+    const env = {
+      ...process.env,
+      OPENCLAW_DURABLE_WORKFLOWS: "1",
+      OPENCLAW_STATE_DIR: dir,
+    };
+    const parentSessionKey = "agent:bo:discord:channel:bo-main";
+
+    let newerParentId = "";
+    const setupStore = openDurableWorkflowSqliteStore({ path: dbPath });
+    try {
+      setupStore.createRun({
+        workflowId: DURABLE_AGENT_TURN_WORKFLOW_ID,
+        status: "running",
+        recoveryState: "running",
+        idempotencyKey: "run_parent_old",
+        sourceType: "agent_turn",
+        sourceRef: parentSessionKey,
+        metadata: { sessionKey: parentSessionKey },
+        now: 100,
+      });
+      newerParentId = setupStore.createRun({
+        workflowId: DURABLE_AGENT_TURN_WORKFLOW_ID,
+        status: "running",
+        recoveryState: "running",
+        idempotencyKey: "run_parent_new",
+        sourceType: "agent_turn",
+        sourceRef: parentSessionKey,
+        metadata: { sessionKey: parentSessionKey },
+        now: 200,
+      }).workflowRunId;
+    } finally {
+      setupStore.close();
+    }
+
+    recordDurableSubagentRegistered({
+      runId: "run_child",
+      childSessionKey: "agent:bo:subagent:newest-child",
+      requesterSessionKey: parentSessionKey,
+      task: "Check newest parent binding",
+      label: "newest parent",
+      agentId: "bo",
+      requesterAgentId: "bo",
+      env,
+    });
+
+    const assertStore = openDurableWorkflowSqliteStore({ path: dbPath });
+    try {
+      const child = assertStore
+        .listRuns({ limit: 20 })
+        .find((run) => run.workflowId === DURABLE_SUBAGENT_RUN_WORKFLOW_ID);
+      expect(child).toBeDefined();
+      expect(child?.parentWorkflowRunId).toBe(newerParentId);
+    } finally {
+      assertStore.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves background task and taskflow bindings on child runs and parent links", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-subagent-"));
+    const dbPath = path.join(dir, "state", "openclaw.sqlite");
+    const env = {
+      ...process.env,
+      OPENCLAW_DURABLE_WORKFLOWS: "1",
+      OPENCLAW_STATE_DIR: dir,
+    };
+    const parentSessionKey = "agent:bo:discord:channel:bo-main";
+    const childSessionKey = "agent:bo:subagent:workboard-default-card";
+
+    const setupStore = openDurableWorkflowSqliteStore({ path: dbPath });
+    try {
+      setupStore.createRun({
+        workflowId: DURABLE_AGENT_TURN_WORKFLOW_ID,
+        status: "running",
+        recoveryState: "running",
+        sourceType: "agent_turn",
+        sourceRef: parentSessionKey,
+        metadata: { sessionKey: parentSessionKey },
+        now: 100,
+      });
+    } finally {
+      setupStore.close();
+    }
+
+    recordDurableSubagentRegistered({
+      runId: "run_child",
+      childSessionKey,
+      requesterSessionKey: parentSessionKey,
+      taskId: "task_child",
+      taskFlowId: "flow_child",
+      task: "Summarize durable bridge",
+      label: "durable bridge",
+      agentId: "bo",
+      requesterAgentId: "bo",
+      env,
+    });
+
+    recordDurableSubagentTerminal({
+      runId: "run_child",
+      childSessionKey,
+      status: "success",
+      summary: "done",
+      env,
+    });
+
+    const assertStore = openDurableWorkflowSqliteStore({ path: dbPath });
+    try {
+      const child = assertStore
+        .listRuns({ limit: 20 })
+        .find((run) => run.workflowId === DURABLE_SUBAGENT_RUN_WORKFLOW_ID);
+      expect(child).toMatchObject({
+        status: "succeeded",
+        metadata: {
+          runId: "run_child",
+          taskId: "task_child",
+          taskFlowId: "flow_child",
+          taskHash: expect.any(String),
+          childSessionKey,
+          agentId: "bo",
+          requesterAgentId: "bo",
+          summary: "done",
+        },
+      });
+      expect(child).toBeDefined();
+      const parentLink = assertStore.listParentLinks(child!.workflowRunId)[0];
+      expect(parentLink).toMatchObject({
+        status: "succeeded",
+        metadata: {
+          runId: "run_child",
+          taskId: "task_child",
+          taskFlowId: "flow_child",
+          taskHash: expect.any(String),
+          childSessionKey,
+          summary: "done",
+        },
+      });
+      expect(child?.metadata?.task).toBeUndefined();
+      expect(parentLink?.metadata?.task).toBeUndefined();
+    } finally {
+      assertStore.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reopens parent fan-in when a later child starts after an earlier child completed", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-subagent-"));
+    const dbPath = path.join(dir, "state", "openclaw.sqlite");
+    const env = {
+      ...process.env,
+      OPENCLAW_DURABLE_WORKFLOWS: "1",
+      OPENCLAW_STATE_DIR: dir,
+    };
+    const parentSessionKey = "agent:bo:discord:channel:bo-main";
+    const setupStore = openDurableWorkflowSqliteStore({ path: dbPath });
+    try {
+      setupStore.createRun({
+        workflowId: DURABLE_AGENT_TURN_WORKFLOW_ID,
+        status: "running",
+        recoveryState: "running",
+        idempotencyKey: "run_parent",
+        sourceType: "agent_turn",
+        sourceRef: parentSessionKey,
+        metadata: { sessionKey: parentSessionKey },
+        now: 100,
+      });
+    } finally {
+      setupStore.close();
+    }
+
+    recordDurableSubagentRegistered({
+      runId: "run_child_a",
+      childSessionKey: "agent:bo:subagent:child-a",
+      requesterSessionKey: parentSessionKey,
+      requesterRunId: "run_parent",
+      task: "First child",
+      env,
+    });
+    recordDurableSubagentTerminal({
+      runId: "run_child_a",
+      childSessionKey: "agent:bo:subagent:child-a",
+      status: "success",
+      summary: "child a done",
+      env,
+    });
+    recordDurableSubagentRegistered({
+      runId: "run_child_b",
+      childSessionKey: "agent:bo:subagent:child-b",
+      requesterSessionKey: parentSessionKey,
+      requesterRunId: "run_parent",
+      task: "Second child",
+      env,
+    });
+
+    const assertStore = openDurableWorkflowSqliteStore({ path: dbPath });
+    try {
+      const parent = assertStore
+        .listRuns({ limit: 20 })
+        .find((run) => run.workflowId === DURABLE_AGENT_TURN_WORKFLOW_ID);
+      expect(parent).toMatchObject({
+        status: "waiting_child",
+        recoveryState: "waiting_child",
+      });
+      expect(parent?.completedAt).toBeUndefined();
+      const fanInStep = assertStore
+        .listSteps(parent!.workflowRunId)
+        .find((step) => step.stepId === "subagents");
+      expect(fanInStep).toMatchObject({
+        stepId: "subagents",
+        status: "waiting",
+        recoveryState: "waiting_child",
+      });
+      expect(fanInStep?.completedAt).toBeUndefined();
+      expect(assertStore.listChildLinks(parent!.workflowRunId)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ status: "succeeded" }),
+          expect.objectContaining({ status: "running" }),
+        ]),
+      );
+    } finally {
+      assertStore.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/durable/subagent.ts
+++ b/src/durable/subagent.ts
@@ -1,0 +1,354 @@
+import { createHash } from "node:crypto";
+import { isDurableWorkflowsEnabled } from "./config.js";
+import { reconcileDurableFanIn, type DurableFanInPolicy } from "./fan-in.js";
+import { openDurableWorkflowSqliteStore } from "./sqlite-store.js";
+import type {
+  DurableWorkflowLinkStatus,
+  DurableWorkflowRun,
+  DurableWorkflowStore,
+} from "./types.js";
+import {
+  DURABLE_AGENT_TURN_WORKFLOW_ID,
+  DURABLE_SUBAGENT_RUN_WORKFLOW_ID,
+} from "./workflow-ids.js";
+const SUBAGENT_PARENT_STEP_ID = "subagents";
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function hashOptional(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? sha256(normalized) : undefined;
+}
+
+function boundedText(value: string | undefined, maxLength: number): string | undefined {
+  const normalized = value?.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, Math.max(0, maxLength - 3))}...`;
+}
+
+function safeCall(action: () => void): void {
+  try {
+    action();
+  } catch {
+    // Durable mirroring must never break the live subagent runtime.
+  }
+}
+
+function findLatestOpenParentRun(params: {
+  store: DurableWorkflowStore;
+  requesterSessionKey: string;
+  requesterRunId?: string;
+}): DurableWorkflowRun | undefined {
+  const requesterRunId = params.requesterRunId?.trim();
+  const candidates = params.store
+    .listOpenRuns({ workflowId: DURABLE_AGENT_TURN_WORKFLOW_ID, limit: 5000 })
+    .filter(
+      (run) =>
+        run.sourceRef === params.requesterSessionKey ||
+        run.metadata?.sessionKey === params.requesterSessionKey,
+    );
+  if (requesterRunId) {
+    const exactRun = candidates.find((run) => run.idempotencyKey === requesterRunId);
+    if (exactRun) {
+      return exactRun;
+    }
+  }
+  return candidates.toSorted((a, b) => {
+    const createdDelta = b.createdAt - a.createdAt;
+    if (createdDelta !== 0) {
+      return createdDelta;
+    }
+    const updatedDelta = b.updatedAt - a.updatedAt;
+    if (updatedDelta !== 0) {
+      return updatedDelta;
+    }
+    return b.workflowRunId.localeCompare(a.workflowRunId);
+  })[0];
+}
+
+function mapOutcomeToLinkStatus(status: string | undefined): DurableWorkflowLinkStatus {
+  switch (status) {
+    case "success":
+    case "succeeded":
+      return "succeeded";
+    case "cancelled":
+    case "killed":
+      return "cancelled";
+    case "lost":
+    case "timed_out":
+    case "timeout":
+      return "lost";
+    default:
+      return "failed";
+  }
+}
+
+export function recordDurableSubagentRegistered(params: {
+  runId: string;
+  childSessionKey: string;
+  requesterSessionKey: string;
+  taskId?: string;
+  taskFlowId?: string;
+  task?: string;
+  taskName?: string;
+  label?: string;
+  agentId?: string;
+  requesterAgentId?: string;
+  requesterRunId?: string;
+  env?: NodeJS.ProcessEnv;
+}): void {
+  const env = params.env ?? process.env;
+  if (!isDurableWorkflowsEnabled(env)) {
+    return;
+  }
+  safeCall(() => {
+    const now = Date.now();
+    const store = openDurableWorkflowSqliteStore({ env });
+    try {
+      const parent = findLatestOpenParentRun({
+        store,
+        requesterSessionKey: params.requesterSessionKey,
+        requesterRunId: params.requesterRunId,
+      });
+      const metadata = {
+        childSessionKey: params.childSessionKey,
+        requesterSessionKey: params.requesterSessionKey,
+        runId: params.runId,
+        taskId: params.taskId,
+        taskFlowId: params.taskFlowId,
+        taskHash: hashOptional(params.task),
+        taskName: boundedText(params.taskName, 120),
+        label: boundedText(params.label, 120),
+        agentId: params.agentId,
+        requesterAgentId: params.requesterAgentId,
+        requesterRunId: params.requesterRunId,
+      };
+      const child = store.createRun({
+        workflowId: DURABLE_SUBAGENT_RUN_WORKFLOW_ID,
+        workflowVersion: "1",
+        status: "running",
+        recoveryState: "running",
+        idempotencyKey: params.runId,
+        requestHash: sha256(`${params.runId}:${params.childSessionKey}`),
+        sourceType: "subagent",
+        sourceRef: params.childSessionKey,
+        parentWorkflowRunId: parent?.workflowRunId,
+        parentStepId: parent ? SUBAGENT_PARENT_STEP_ID : undefined,
+        metadata,
+        now,
+      });
+      store.createStep({
+        workflowRunId: child.workflowRunId,
+        stepId: "subagent_run",
+        stepType: "agent",
+        status: "running",
+        recoveryState: "running",
+        idempotencyKey: params.runId,
+        metadata,
+        now,
+      });
+      store.appendEvent({
+        workflowRunId: child.workflowRunId,
+        eventType: "subagent.run.started",
+        eventTime: now,
+        stepId: "subagent_run",
+        agentInvocationId: params.runId,
+        idempotencyKey: params.runId,
+        correlationId: params.requesterSessionKey,
+        payload: metadata,
+      });
+      if (!parent) {
+        return;
+      }
+      store.createStep({
+        workflowRunId: parent.workflowRunId,
+        stepId: SUBAGENT_PARENT_STEP_ID,
+        stepType: "fan_in",
+        status: "waiting",
+        recoveryState: "waiting_child",
+        idempotencyKey: `${parent.workflowRunId}:${SUBAGENT_PARENT_STEP_ID}`,
+        metadata: { policy: "continue_on_child_failure" satisfies DurableFanInPolicy },
+        now,
+      });
+      store.createLink({
+        parentWorkflowRunId: parent.workflowRunId,
+        parentStepId: SUBAGENT_PARENT_STEP_ID,
+        childWorkflowRunId: child.workflowRunId,
+        linkType: "subagent",
+        status: "running",
+        metadata,
+        now,
+      });
+      store.appendEvent({
+        workflowRunId: parent.workflowRunId,
+        eventType: "subagent.child.linked",
+        eventTime: now,
+        stepId: SUBAGENT_PARENT_STEP_ID,
+        agentInvocationId: params.runId,
+        correlationId: params.childSessionKey,
+        payload: {
+          childWorkflowRunId: child.workflowRunId,
+          ...metadata,
+        },
+      });
+      reconcileDurableFanIn({
+        store,
+        parentWorkflowRunId: parent.workflowRunId,
+        parentStepId: SUBAGENT_PARENT_STEP_ID,
+        policy: "continue_on_child_failure",
+        now,
+      });
+    } finally {
+      store.close();
+    }
+  });
+}
+
+export function recordDurableSubagentTerminal(params: {
+  runId: string;
+  childSessionKey?: string;
+  status?: string;
+  error?: string;
+  summary?: string;
+  env?: NodeJS.ProcessEnv;
+}): void {
+  const env = params.env ?? process.env;
+  if (!isDurableWorkflowsEnabled(env)) {
+    return;
+  }
+  safeCall(() => {
+    const now = Date.now();
+    const store = openDurableWorkflowSqliteStore({ env });
+    try {
+      const child = store.createRun({
+        workflowId: DURABLE_SUBAGENT_RUN_WORKFLOW_ID,
+        workflowVersion: "1",
+        status: "running",
+        recoveryState: "running",
+        idempotencyKey: params.runId,
+        requestHash: params.childSessionKey
+          ? sha256(`${params.runId}:${params.childSessionKey}`)
+          : undefined,
+        sourceType: "subagent",
+        sourceRef: params.childSessionKey,
+        metadata: {
+          childSessionKey: params.childSessionKey,
+        },
+        now,
+      });
+      const linkStatus = mapOutcomeToLinkStatus(params.status);
+      const existingMetadata =
+        child.metadata && typeof child.metadata === "object" && !Array.isArray(child.metadata)
+          ? child.metadata
+          : {};
+      const runStatus =
+        linkStatus === "succeeded"
+          ? "succeeded"
+          : linkStatus === "cancelled"
+            ? "cancelled"
+            : linkStatus === "lost"
+              ? "lost"
+              : "failed";
+      store.updateRun({
+        workflowRunId: child.workflowRunId,
+        status: runStatus,
+        recoveryState: runStatus === "lost" ? "lost" : "terminal",
+        completedAt: now,
+        metadata: {
+          ...existingMetadata,
+          childSessionKey: params.childSessionKey,
+          status: params.status,
+          error: params.error,
+          summary: params.summary,
+        },
+        now,
+      });
+      store.updateStep({
+        workflowRunId: child.workflowRunId,
+        stepId: "subagent_run",
+        status:
+          runStatus === "succeeded"
+            ? "succeeded"
+            : runStatus === "cancelled"
+              ? "cancelled"
+              : runStatus === "lost"
+                ? "lost"
+                : "failed",
+        recoveryState: runStatus === "lost" ? "lost" : "terminal",
+        completedAt: now,
+        metadata: {
+          ...existingMetadata,
+          childSessionKey: params.childSessionKey,
+          status: params.status,
+          error: params.error,
+          summary: params.summary,
+        },
+        now,
+      });
+      store.appendEvent({
+        workflowRunId: child.workflowRunId,
+        eventType: "subagent.run.terminal",
+        eventTime: now,
+        stepId: "subagent_run",
+        agentInvocationId: params.runId,
+        idempotencyKey: `${params.runId}:terminal`,
+        correlationId: params.childSessionKey,
+        payload: {
+          status: params.status,
+          error: params.error,
+          summary: params.summary,
+        },
+      });
+      for (const link of store.listParentLinks(child.workflowRunId)) {
+        const linkMetadata =
+          link.metadata && typeof link.metadata === "object" && !Array.isArray(link.metadata)
+            ? link.metadata
+            : {};
+        store.updateLink({
+          parentWorkflowRunId: link.parentWorkflowRunId,
+          parentStepId: link.parentStepId,
+          childWorkflowRunId: link.childWorkflowRunId,
+          status: linkStatus,
+          metadata: {
+            ...linkMetadata,
+            childSessionKey: params.childSessionKey,
+            status: params.status,
+            error: params.error,
+            summary: params.summary,
+          },
+          now,
+        });
+        store.appendEvent({
+          workflowRunId: link.parentWorkflowRunId,
+          eventType: "subagent.child.terminal",
+          eventTime: now,
+          stepId: link.parentStepId,
+          agentInvocationId: params.runId,
+          correlationId: params.childSessionKey,
+          payload: {
+            childWorkflowRunId: child.workflowRunId,
+            status: linkStatus,
+            error: params.error,
+            summary: params.summary,
+          },
+        });
+        reconcileDurableFanIn({
+          store,
+          parentWorkflowRunId: link.parentWorkflowRunId,
+          parentStepId: link.parentStepId,
+          policy: "continue_on_child_failure",
+          now,
+        });
+      }
+    } finally {
+      store.close();
+    }
+  });
+}

--- a/src/durable/types.ts
+++ b/src/durable/types.ts
@@ -358,6 +358,7 @@ export type ClaimDurableWorkflowStepInput = {
 
 export type DurableWorkflowStoreStats = {
   path: string;
+  schemaVersion: number;
   runs: number;
   events: number;
   steps: number;

--- a/src/durable/types.ts
+++ b/src/durable/types.ts
@@ -1,0 +1,408 @@
+// Shared durable workflow control-plane types.
+export type DurableWorkflowRunStatus =
+  | "received"
+  | "queued"
+  | "running"
+  | "waiting"
+  | "waiting_signal"
+  | "waiting_timer"
+  | "waiting_child"
+  | "retry_scheduled"
+  | "succeeded"
+  | "failed"
+  | "cancelled"
+  | "lost";
+
+export type DurableRecoveryState =
+  | "runnable"
+  | "claimed"
+  | "running"
+  | "waiting_signal"
+  | "waiting_timer"
+  | "waiting_child"
+  | "retry_scheduled"
+  | "reconciling"
+  | "unknown_after_side_effect"
+  | "lost"
+  | "terminal";
+
+export type DurableWorkflowStepType =
+  | "agent"
+  | "tool"
+  | "timer"
+  | "signal"
+  | "child_workflow"
+  | "checkpoint"
+  | "fan_in";
+
+export type DurableWorkflowStepStatus =
+  | "pending"
+  | "queued"
+  | "running"
+  | "waiting"
+  | "retry_scheduled"
+  | "succeeded"
+  | "failed"
+  | "cancelled"
+  | "lost"
+  | "skipped";
+
+export type DurableWorkflowRefKind = "input" | "output" | "error" | "artifact";
+
+export type DurableWorkflowLinkType =
+  | "child_workflow"
+  | "handoff"
+  | "subagent"
+  | "evidence"
+  | "artifact";
+
+export type DurableWorkflowLinkStatus =
+  | "pending"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "cancelled"
+  | "lost";
+
+export type DurableWorkflowTimerStatus = "pending" | "fired" | "cancelled";
+export type DurableWorkflowSignalStatus = "pending" | "consumed";
+
+export type DurableWorkflowRun = {
+  workflowRunId: string;
+  workflowId: string;
+  workflowVersion: string;
+  status: DurableWorkflowRunStatus;
+  recoveryState: DurableRecoveryState;
+  idempotencyKey?: string;
+  requestHash?: string;
+  sourceType?: string;
+  sourceRef?: string;
+  inputRef?: string;
+  checkpointRef?: string;
+  parentWorkflowRunId?: string;
+  parentStepId?: string;
+  messageId?: string;
+  turnId?: string;
+  claimedBy?: string;
+  claimExpiresAt?: number;
+  heartbeatAt?: number;
+  metadata?: Record<string, unknown>;
+  createdAt: number;
+  updatedAt: number;
+  completedAt?: number;
+};
+
+export type DurableWorkflowStep = {
+  workflowRunId: string;
+  stepId: string;
+  parentStepId?: string;
+  stepType: DurableWorkflowStepType;
+  status: DurableWorkflowStepStatus;
+  recoveryState: DurableRecoveryState;
+  attempt: number;
+  maxAttempts?: number;
+  idempotencyKey?: string;
+  inputRef?: string;
+  outputRef?: string;
+  errorRef?: string;
+  checkpointRef?: string;
+  claimedBy?: string;
+  claimExpiresAt?: number;
+  heartbeatAt?: number;
+  metadata?: Record<string, unknown>;
+  createdAt: number;
+  startedAt?: number;
+  updatedAt: number;
+  completedAt?: number;
+};
+
+export type DurableWorkflowRef = {
+  refId: string;
+  workflowRunId: string;
+  stepId?: string;
+  refKind: DurableWorkflowRefKind;
+  mediaType?: string;
+  hash?: string;
+  storageKind: "inline" | "file" | "external";
+  storageUri?: string;
+  metadata?: Record<string, unknown>;
+  createdAt: number;
+};
+
+export type DurableWorkflowLink = {
+  parentWorkflowRunId: string;
+  parentStepId: string;
+  childWorkflowRunId: string;
+  linkType: DurableWorkflowLinkType;
+  status: DurableWorkflowLinkStatus;
+  metadata?: Record<string, unknown>;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type DurableWorkflowTimer = {
+  timerId: string;
+  workflowRunId: string;
+  stepId?: string;
+  timerType: "retry" | "deadline" | "sleep" | "human_timeout" | "child_timeout" | "scheduled_start";
+  dueAt: number;
+  status: DurableWorkflowTimerStatus;
+  metadata?: Record<string, unknown>;
+  createdAt: number;
+  firedAt?: number;
+  cancelledAt?: number;
+};
+
+export type DurableWorkflowSignal = {
+  signalId: string;
+  workflowRunId: string;
+  stepId?: string;
+  signalType:
+    | "human_input"
+    | "approval"
+    | "rejection"
+    | "external_callback"
+    | "child_completed"
+    | "child_failed"
+    | "cancel"
+    | "resume";
+  idempotencyKey?: string;
+  payloadRef?: string;
+  correlationId?: string;
+  metadata?: Record<string, unknown>;
+  receivedAt: number;
+  consumedAt?: number;
+};
+
+export type DurableWorkflowEvent = {
+  eventId: string;
+  workflowRunId: string;
+  eventSeq: number;
+  eventType: string;
+  eventTime: number;
+  stepId?: string;
+  agentInvocationId?: string;
+  toolInvocationId?: string;
+  idempotencyKey?: string;
+  payload?: Record<string, unknown>;
+  payloadHash?: string;
+  checkpointRef?: string;
+  causationEventId?: string;
+  correlationId?: string;
+  recordedAt: number;
+};
+
+export type CreateDurableWorkflowRunInput = {
+  workflowRunId?: string;
+  workflowId: string;
+  workflowVersion?: string;
+  status?: DurableWorkflowRunStatus;
+  recoveryState?: DurableRecoveryState;
+  idempotencyKey?: string;
+  requestHash?: string;
+  sourceType?: string;
+  sourceRef?: string;
+  inputRef?: string;
+  checkpointRef?: string;
+  parentWorkflowRunId?: string;
+  parentStepId?: string;
+  messageId?: string;
+  turnId?: string;
+  metadata?: Record<string, unknown>;
+  now?: number;
+};
+
+export type AppendDurableWorkflowEventInput = {
+  workflowRunId: string;
+  eventId?: string;
+  eventType: string;
+  eventTime?: number;
+  stepId?: string;
+  agentInvocationId?: string;
+  toolInvocationId?: string;
+  idempotencyKey?: string;
+  payload?: Record<string, unknown>;
+  payloadHash?: string;
+  checkpointRef?: string;
+  causationEventId?: string;
+  correlationId?: string;
+};
+
+export type UpdateDurableWorkflowRunInput = {
+  workflowRunId: string;
+  status?: DurableWorkflowRunStatus;
+  recoveryState?: DurableRecoveryState;
+  completedAt?: number | null;
+  checkpointRef?: string | null;
+  claimedBy?: string | null;
+  claimExpiresAt?: number | null;
+  heartbeatAt?: number | null;
+  metadata?: Record<string, unknown>;
+  now?: number;
+};
+
+export type CreateDurableWorkflowStepInput = {
+  workflowRunId: string;
+  stepId?: string;
+  parentStepId?: string;
+  stepType: DurableWorkflowStepType;
+  status?: DurableWorkflowStepStatus;
+  recoveryState?: DurableRecoveryState;
+  attempt?: number;
+  maxAttempts?: number;
+  idempotencyKey?: string;
+  inputRef?: string;
+  outputRef?: string;
+  errorRef?: string;
+  checkpointRef?: string;
+  metadata?: Record<string, unknown>;
+  now?: number;
+};
+
+export type UpdateDurableWorkflowStepInput = {
+  workflowRunId: string;
+  stepId: string;
+  status?: DurableWorkflowStepStatus;
+  recoveryState?: DurableRecoveryState;
+  attempt?: number;
+  maxAttempts?: number | null;
+  inputRef?: string | null;
+  outputRef?: string | null;
+  errorRef?: string | null;
+  checkpointRef?: string | null;
+  claimedBy?: string | null;
+  claimExpiresAt?: number | null;
+  heartbeatAt?: number | null;
+  startedAt?: number | null;
+  completedAt?: number | null;
+  metadata?: Record<string, unknown>;
+  now?: number;
+};
+
+export type CreateDurableWorkflowRefInput = {
+  refId?: string;
+  workflowRunId: string;
+  stepId?: string;
+  refKind: DurableWorkflowRefKind;
+  mediaType?: string;
+  hash?: string;
+  storageKind?: "inline" | "file" | "external";
+  storageUri?: string;
+  metadata?: Record<string, unknown>;
+  now?: number;
+};
+
+export type CreateDurableWorkflowLinkInput = {
+  parentWorkflowRunId: string;
+  parentStepId: string;
+  childWorkflowRunId: string;
+  linkType: DurableWorkflowLinkType;
+  status?: DurableWorkflowLinkStatus;
+  metadata?: Record<string, unknown>;
+  now?: number;
+};
+
+export type UpdateDurableWorkflowLinkInput = {
+  parentWorkflowRunId: string;
+  parentStepId: string;
+  childWorkflowRunId: string;
+  status?: DurableWorkflowLinkStatus;
+  metadata?: Record<string, unknown>;
+  now?: number;
+};
+
+export type CreateDurableWorkflowTimerInput = {
+  timerId?: string;
+  workflowRunId: string;
+  stepId?: string;
+  timerType: DurableWorkflowTimer["timerType"];
+  dueAt: number;
+  metadata?: Record<string, unknown>;
+  now?: number;
+};
+
+export type UpdateDurableWorkflowTimerInput = {
+  timerId: string;
+  status: DurableWorkflowTimerStatus;
+  firedAt?: number | null;
+  cancelledAt?: number | null;
+  now?: number;
+};
+
+export type CreateDurableWorkflowSignalInput = {
+  signalId?: string;
+  workflowRunId: string;
+  stepId?: string;
+  signalType: DurableWorkflowSignal["signalType"];
+  idempotencyKey?: string;
+  payloadRef?: string;
+  correlationId?: string;
+  metadata?: Record<string, unknown>;
+  now?: number;
+};
+
+export type ClaimDurableWorkflowRunInput = {
+  workflowId?: string;
+  workerId: string;
+  claimTtlMs: number;
+  now?: number;
+};
+
+export type ClaimDurableWorkflowStepInput = {
+  workflowId?: string;
+  stepType?: DurableWorkflowStepType;
+  workerId: string;
+  claimTtlMs: number;
+  now?: number;
+};
+
+export type DurableWorkflowStoreStats = {
+  path: string;
+  runs: number;
+  events: number;
+  steps: number;
+  openRuns: number;
+};
+
+export type DurableWorkflowStore = {
+  createRun(input: CreateDurableWorkflowRunInput): DurableWorkflowRun;
+  getRun(workflowRunId: string): DurableWorkflowRun | undefined;
+  updateRun(input: UpdateDurableWorkflowRunInput): DurableWorkflowRun | undefined;
+  appendEvent(input: AppendDurableWorkflowEventInput): DurableWorkflowEvent;
+  listRuns(options?: { limit?: number }): DurableWorkflowRun[];
+  listOpenRuns(options?: { workflowId?: string; limit?: number }): DurableWorkflowRun[];
+  claimNextRunnableRun(input: ClaimDurableWorkflowRunInput): DurableWorkflowRun | undefined;
+  releaseRunClaim(input: {
+    workflowRunId: string;
+    workerId: string;
+    now?: number;
+  }): DurableWorkflowRun | undefined;
+  createStep(input: CreateDurableWorkflowStepInput): DurableWorkflowStep;
+  updateStep(input: UpdateDurableWorkflowStepInput): DurableWorkflowStep | undefined;
+  claimNextRunnableStep(input: ClaimDurableWorkflowStepInput): DurableWorkflowStep | undefined;
+  releaseStepClaim(input: {
+    workflowRunId: string;
+    stepId: string;
+    workerId: string;
+    now?: number;
+  }): DurableWorkflowStep | undefined;
+  listSteps(workflowRunId: string): DurableWorkflowStep[];
+  createRef(input: CreateDurableWorkflowRefInput): DurableWorkflowRef;
+  getRef(refId: string): DurableWorkflowRef | undefined;
+  listRefs(workflowRunId: string): DurableWorkflowRef[];
+  createLink(input: CreateDurableWorkflowLinkInput): DurableWorkflowLink;
+  updateLink(input: UpdateDurableWorkflowLinkInput): DurableWorkflowLink | undefined;
+  listChildLinks(parentWorkflowRunId: string): DurableWorkflowLink[];
+  listParentLinks(childWorkflowRunId: string): DurableWorkflowLink[];
+  createTimer(input: CreateDurableWorkflowTimerInput): DurableWorkflowTimer;
+  updateTimer(input: UpdateDurableWorkflowTimerInput): DurableWorkflowTimer | undefined;
+  listTimers(workflowRunId?: string): DurableWorkflowTimer[];
+  listDueTimers(now: number, options?: { limit?: number }): DurableWorkflowTimer[];
+  createSignal(input: CreateDurableWorkflowSignalInput): DurableWorkflowSignal;
+  consumeSignal(input: { signalId: string; now?: number }): DurableWorkflowSignal | undefined;
+  listPendingSignals(options?: { limit?: number }): DurableWorkflowSignal[];
+  listSignals(workflowRunId: string): DurableWorkflowSignal[];
+  getTimeline(workflowRunId: string): DurableWorkflowEvent[];
+  getStats(): DurableWorkflowStoreStats;
+  close(): void;
+};

--- a/src/durable/workflow-ids.ts
+++ b/src/durable/workflow-ids.ts
@@ -1,0 +1,2 @@
+export const DURABLE_AGENT_TURN_WORKFLOW_ID = "openclaw.agent.turn";
+export const DURABLE_SUBAGENT_RUN_WORKFLOW_ID = "openclaw.subagent.run";

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -97,6 +97,7 @@ export const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
   { name: "tasks.list", scope: "operator.read" },
   { name: "tasks.get", scope: "operator.read" },
   { name: "tasks.cancel", scope: "operator.write" },
+  { name: "durable.coordination.get", scope: "operator.read" },
   { name: "environments.list", scope: "operator.read" },
   { name: "environments.status", scope: "operator.read" },
   { name: "agents.list", scope: "operator.read" },

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -110,6 +110,10 @@ const loadDoctorHandlers = lazyHandlerModule(
   () => import("./server-methods/doctor.js"),
   (module) => module.doctorHandlers,
 );
+const loadDurableHandlers = lazyHandlerModule(
+  () => import("./server-methods/durable.js"),
+  (module) => module.durableHandlers,
+);
 const loadEnvironmentsHandlers = lazyHandlerModule(
   () => import("./server-methods/environments.js"),
   (module) => module.environmentsHandlers,
@@ -423,6 +427,10 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...createLazyCoreHandlers({
     methods: ["tasks.list", "tasks.get", "tasks.cancel"],
     loadHandlers: loadTasksHandlers,
+  }),
+  ...createLazyCoreHandlers({
+    methods: ["durable.coordination.get"],
+    loadHandlers: loadDurableHandlers,
   }),
   ...createLazyCoreHandlers({
     methods: ["tools.catalog"],

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -75,6 +75,11 @@ import {
 import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-maintenance.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
+  durableAgentTurnErrorPayload,
+  startDurableAgentTurnLifecycle,
+  type DurableAgentTurnLifecycle,
+} from "../../durable/agent-turn.js";
+import {
   assertAgentRunLifecycleGenerationCurrent,
   claimAgentRunContext,
   clearAgentRunContext,
@@ -845,6 +850,7 @@ function dispatchAgentRunFromGateway(params: {
   respond: GatewayRequestHandlerOptions["respond"];
   context: GatewayRequestHandlerOptions["context"];
   taskTrackingMode: Exclude<GatewayAgentTaskTrackingMode, "plugin_subagent">;
+  durableLifecycle?: DurableAgentTurnLifecycle;
 }) {
   const shouldTrackTask = params.taskTrackingMode === "cli";
   let taskTracked = false;
@@ -911,6 +917,20 @@ function dispatchAgentRunFromGateway(params: {
           payload,
         },
       });
+      params.durableLifecycle?.markTerminal({
+        status: aborted ? "cancelled" : "succeeded",
+        eventType: aborted ? "agent.turn.cancelled" : "agent.turn.succeeded",
+        payload: {
+          summary: payload.summary,
+          ...(aborted ? { stopReason: payload.stopReason ?? "rpc" } : {}),
+          ...(timeoutAttribution.timeoutPhase
+            ? { timeoutPhase: timeoutAttribution.timeoutPhase }
+            : {}),
+          ...(timeoutAttribution.providerStarted !== undefined
+            ? { providerStarted: timeoutAttribution.providerStarted }
+            : {}),
+        },
+      });
       // Send a second res frame (same id) so TS clients with expectFinal can wait.
       // Swift clients will typically treat the first res as the result and ignore this.
       params.respond(true, payload, undefined, { runId: params.runId });
@@ -945,12 +965,20 @@ function dispatchAgentRunFromGateway(params: {
           ...(aborted ? {} : { error }),
         },
       });
+      params.durableLifecycle?.markTerminal({
+        status: aborted ? "cancelled" : "failed",
+        eventType: aborted ? "agent.turn.cancelled" : "agent.turn.failed",
+        payload: aborted
+          ? { summary: payload.summary, stopReason, timeoutPhase: "gateway_draining" }
+          : durableAgentTurnErrorPayload(err),
+      });
       params.respond(aborted, payload, aborted ? undefined : error, {
         runId: params.runId,
         ...(aborted ? {} : { error: formatForLog(err) }),
       });
     })
     .finally(() => {
+      params.durableLifecycle?.close();
       clearAgentRunContext(params.runId, params.ingressOpts.lifecycleGeneration);
       params.cleanupAbortController();
     });
@@ -2540,6 +2568,15 @@ export const agentHandlers: GatewayRequestHandlers = {
         }
       }
 
+      const durableLifecycle = startDurableAgentTurnLifecycle({
+        runId,
+        message,
+        agentId: resolvedSessionKey === "global" ? activeSessionAgentId : agentId,
+        sessionKey: resolvedSessionKey,
+        channel: resolvedChannel,
+        transport: "gateway",
+        deliver,
+      });
       const accepted = {
         runId,
         sessionKey: resolvedSessionKey,
@@ -2547,6 +2584,11 @@ export const agentHandlers: GatewayRequestHandlers = {
         status: "accepted" as const,
         acceptedAt: Date.now(),
       };
+      durableLifecycle.markRunning({
+        acceptedAt: accepted.acceptedAt,
+        taskTrackingMode,
+        controlUiVisible: !suppressVisibleSessionEffects,
+      });
       const acceptedDedupePayload = {
         ...accepted,
         controlUiVisible: !suppressVisibleSessionEffects,
@@ -2597,6 +2639,16 @@ export const agentHandlers: GatewayRequestHandlers = {
               undefined,
               { runId },
             );
+            durableLifecycle.markTerminal({
+              status: "cancelled",
+              eventType: "agent.turn.cancelled",
+              payload: {
+                summary: "aborted",
+                stopReason,
+                timeoutPhase: "queue",
+                providerStarted: false,
+              },
+            });
             return;
           }
 
@@ -2752,6 +2804,7 @@ export const agentHandlers: GatewayRequestHandlers = {
             respond,
             context,
             taskTrackingMode: dispatchTaskTrackingMode,
+            durableLifecycle,
           });
           dispatched = true;
         } catch (err) {
@@ -2775,8 +2828,14 @@ export const agentHandlers: GatewayRequestHandlers = {
             runId,
             error: formatForLog(err),
           });
+          durableLifecycle.markTerminal({
+            status: "failed",
+            eventType: "agent.turn.failed",
+            payload: durableAgentTurnErrorPayload(err),
+          });
         } finally {
           if (!dispatched) {
+            durableLifecycle.close();
             activeRunAbort.cleanup({ force: true });
           }
         }

--- a/src/gateway/server-methods/durable.test.ts
+++ b/src/gateway/server-methods/durable.test.ts
@@ -1,0 +1,129 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { openDurableWorkflowSqliteStore } from "../../durable/sqlite-store.js";
+import { durableHandlers } from "./durable.js";
+
+describe("durable gateway methods", () => {
+  it("returns coordination projection for a durable workflow run", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-gateway-"));
+    const dbPath = path.join(dir, "state", "openclaw.sqlite");
+    const previousEnabled = process.env.OPENCLAW_DURABLE_WORKFLOWS;
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_DURABLE_WORKFLOWS = "1";
+    process.env.OPENCLAW_STATE_DIR = dir;
+    const store = openDurableWorkflowSqliteStore({ path: dbPath });
+    let storeClosed = false;
+    try {
+      const parent = store.createRun({
+        workflowId: "test.parent",
+        status: "waiting_child",
+        recoveryState: "waiting_child",
+        metadata: {
+          taskId: "task-parent",
+          taskFlowId: "flow-parent",
+          sessionKey: "agent:bo:main",
+        },
+        now: 100,
+      });
+      store.createStep({
+        workflowRunId: parent.workflowRunId,
+        stepId: "subagents",
+        stepType: "fan_in",
+        status: "waiting",
+        recoveryState: "waiting_child",
+        now: 110,
+      });
+      const child = store.createRun({
+        workflowId: "test.child",
+        status: "succeeded",
+        recoveryState: "terminal",
+        now: 120,
+      });
+      store.createLink({
+        parentWorkflowRunId: parent.workflowRunId,
+        parentStepId: "subagents",
+        childWorkflowRunId: child.workflowRunId,
+        linkType: "subagent",
+        status: "succeeded",
+        now: 130,
+      });
+      store.close();
+      storeClosed = true;
+
+      const calls: unknown[][] = [];
+      durableHandlers["durable.coordination.get"]?.({
+        params: { workflowRunId: parent.workflowRunId },
+        respond: (...args: unknown[]) => calls.push(args),
+      } as never);
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.[0]).toBe(true);
+      expect(calls[0]?.[1]).toMatchObject({
+        projection: {
+          workflowRunId: parent.workflowRunId,
+          waitingReason: "child",
+          currentStepId: "subagents",
+          external: {
+            taskId: "task-parent",
+            taskFlowId: "flow-parent",
+            sessionKey: "agent:bo:main",
+          },
+          children: {
+            total: 1,
+            succeeded: 1,
+            terminal: 1,
+            open: 0,
+          },
+        },
+      });
+    } finally {
+      if (!storeClosed) {
+        store.close();
+      }
+      if (previousEnabled === undefined) {
+        delete process.env.OPENCLAW_DURABLE_WORKFLOWS;
+      } else {
+        process.env.OPENCLAW_DURABLE_WORKFLOWS = previousEnabled;
+      }
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not create durable state when the feature is disabled", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-disabled-"));
+    const previousEnabled = process.env.OPENCLAW_DURABLE_WORKFLOWS;
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    delete process.env.OPENCLAW_DURABLE_WORKFLOWS;
+    process.env.OPENCLAW_STATE_DIR = dir;
+    try {
+      const calls: unknown[][] = [];
+      durableHandlers["durable.coordination.get"]?.({
+        params: { workflowRunId: "wfr_disabled" },
+        respond: (...args: unknown[]) => calls.push(args),
+      } as never);
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.[0]).toBe(false);
+      expect(fs.existsSync(path.join(dir, "state", "openclaw.sqlite"))).toBe(false);
+    } finally {
+      if (previousEnabled === undefined) {
+        delete process.env.OPENCLAW_DURABLE_WORKFLOWS;
+      } else {
+        process.env.OPENCLAW_DURABLE_WORKFLOWS = previousEnabled;
+      }
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/gateway/server-methods/durable.ts
+++ b/src/gateway/server-methods/durable.ts
@@ -1,0 +1,61 @@
+// Durable workflow gateway methods expose coordination projections to operator surfaces.
+import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import { isDurableWorkflowsEnabled } from "../../durable/config.js";
+import { buildDurableCoordinationProjection } from "../../durable/coordination-projection.js";
+import { openDurableWorkflowSqliteStore } from "../../durable/sqlite-store.js";
+import type { GatewayRequestHandlers } from "./types.js";
+
+function readWorkflowRunId(params: unknown): string | undefined {
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    return undefined;
+  }
+  const value = (params as Record<string, unknown>).workflowRunId;
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export const durableHandlers: GatewayRequestHandlers = {
+  "durable.coordination.get": ({ params, respond }) => {
+    if (!isDurableWorkflowsEnabled()) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "Durable workflows are disabled."),
+      );
+      return;
+    }
+    const workflowRunId = readWorkflowRunId(params);
+    if (!workflowRunId) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "workflowRunId is required."),
+      );
+      return;
+    }
+    const store = openDurableWorkflowSqliteStore();
+    try {
+      const run = store.getRun(workflowRunId);
+      if (!run) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            `durable workflow run not found: ${workflowRunId}`,
+          ),
+        );
+        return;
+      }
+      respond(true, {
+        projection: buildDurableCoordinationProjection({
+          run,
+          steps: store.listSteps(workflowRunId),
+          childLinks: store.listChildLinks(workflowRunId),
+          refs: store.listRefs(workflowRunId),
+        }),
+      });
+    } finally {
+      store.close();
+    }
+  },
+};

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -455,6 +455,123 @@ export interface DiagnosticStabilityBundles {
   reason: string;
 }
 
+export interface DurableWorkflowEvents {
+  agent_invocation_id: string | null;
+  causation_event_id: string | null;
+  checkpoint_ref: string | null;
+  correlation_id: string | null;
+  event_id: string;
+  event_seq: number;
+  event_time: number;
+  event_type: string;
+  idempotency_key: string | null;
+  payload_hash: string | null;
+  payload_json: string | null;
+  recorded_at: number;
+  step_id: string | null;
+  tool_invocation_id: string | null;
+  workflow_run_id: string;
+}
+
+export interface DurableWorkflowLinks {
+  child_workflow_run_id: string;
+  created_at: number;
+  link_type: string;
+  metadata_json: string | null;
+  parent_step_id: string;
+  parent_workflow_run_id: string;
+  status: string;
+  updated_at: number;
+}
+
+export interface DurableWorkflowRefs {
+  created_at: number;
+  hash: string | null;
+  media_type: string | null;
+  metadata_json: string | null;
+  ref_id: string;
+  ref_kind: string;
+  step_id: string | null;
+  storage_kind: string;
+  storage_uri: string | null;
+  workflow_run_id: string;
+}
+
+export interface DurableWorkflowRuns {
+  checkpoint_ref: string | null;
+  claim_expires_at: number | null;
+  claimed_by: string | null;
+  completed_at: number | null;
+  created_at: number;
+  heartbeat_at: number | null;
+  idempotency_key: string | null;
+  input_ref: string | null;
+  message_id: string | null;
+  metadata_json: string | null;
+  parent_step_id: string | null;
+  parent_workflow_run_id: string | null;
+  recovery_state: Generated<string>;
+  request_hash: string | null;
+  source_ref: string | null;
+  source_type: string | null;
+  status: string;
+  turn_id: string | null;
+  updated_at: number;
+  workflow_id: string;
+  workflow_run_id: string;
+  workflow_version: Generated<string>;
+}
+
+export interface DurableWorkflowSignals {
+  consumed_at: number | null;
+  correlation_id: string | null;
+  idempotency_key: string | null;
+  metadata_json: string | null;
+  payload_ref: string | null;
+  received_at: number;
+  signal_id: string;
+  signal_type: string;
+  step_id: string | null;
+  workflow_run_id: string;
+}
+
+export interface DurableWorkflowSteps {
+  attempt: Generated<number>;
+  checkpoint_ref: string | null;
+  claim_expires_at: number | null;
+  claimed_by: string | null;
+  completed_at: number | null;
+  created_at: number;
+  error_ref: string | null;
+  heartbeat_at: number | null;
+  idempotency_key: string | null;
+  input_ref: string | null;
+  max_attempts: number | null;
+  metadata_json: string | null;
+  output_ref: string | null;
+  parent_step_id: string | null;
+  recovery_state: string;
+  started_at: number | null;
+  status: string;
+  step_id: string;
+  step_type: string;
+  updated_at: number;
+  workflow_run_id: string;
+}
+
+export interface DurableWorkflowTimers {
+  cancelled_at: number | null;
+  created_at: number;
+  due_at: number;
+  fired_at: number | null;
+  metadata_json: string | null;
+  status: string;
+  step_id: string | null;
+  timer_id: string;
+  timer_type: string;
+  workflow_run_id: string;
+}
+
 export interface ExecApprovalsConfig {
   agent_count: number;
   allowlist_count: number;
@@ -984,6 +1101,13 @@ export interface DB {
   device_pairing_pending: DevicePairingPending;
   diagnostic_events: DiagnosticEvents;
   diagnostic_stability_bundles: DiagnosticStabilityBundles;
+  durable_workflow_events: DurableWorkflowEvents;
+  durable_workflow_links: DurableWorkflowLinks;
+  durable_workflow_refs: DurableWorkflowRefs;
+  durable_workflow_runs: DurableWorkflowRuns;
+  durable_workflow_signals: DurableWorkflowSignals;
+  durable_workflow_steps: DurableWorkflowSteps;
+  durable_workflow_timers: DurableWorkflowTimers;
   exec_approvals_config: ExecApprovalsConfig;
   flow_runs: FlowRuns;
   gateway_restart_handoff: GatewayRestartHandoff;

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -455,6 +455,13 @@ export interface DiagnosticStabilityBundles {
   reason: string;
 }
 
+export interface DurableSchemaMigrations {
+  applied_at: number;
+  metadata_json: string | null;
+  schema_name: string;
+  version: number;
+}
+
 export interface DurableWorkflowEvents {
   agent_invocation_id: string | null;
   causation_event_id: string | null;
@@ -1101,6 +1108,7 @@ export interface DB {
   device_pairing_pending: DevicePairingPending;
   diagnostic_events: DiagnosticEvents;
   diagnostic_stability_bundles: DiagnosticStabilityBundles;
+  durable_schema_migrations: DurableSchemaMigrations;
   durable_workflow_events: DurableWorkflowEvents;
   durable_workflow_links: DurableWorkflowLinks;
   durable_workflow_refs: DurableWorkflowRefs;

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -1186,6 +1186,173 @@ CREATE INDEX IF NOT EXISTS idx_flow_runs_status ON flow_runs(status);
 CREATE INDEX IF NOT EXISTS idx_flow_runs_owner_key ON flow_runs(owner_key);
 CREATE INDEX IF NOT EXISTS idx_flow_runs_updated_at ON flow_runs(updated_at);
 
+CREATE TABLE IF NOT EXISTS durable_workflow_runs (
+  workflow_run_id TEXT NOT NULL PRIMARY KEY,
+  workflow_id TEXT NOT NULL,
+  workflow_version TEXT NOT NULL DEFAULT '1',
+  idempotency_key TEXT,
+  request_hash TEXT,
+  status TEXT NOT NULL,
+  source_type TEXT,
+  source_ref TEXT,
+  input_ref TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  completed_at INTEGER,
+  recovery_state TEXT NOT NULL DEFAULT 'runnable',
+  checkpoint_ref TEXT,
+  parent_workflow_run_id TEXT,
+  parent_step_id TEXT,
+  message_id TEXT,
+  turn_id TEXT,
+  claimed_by TEXT,
+  claim_expires_at INTEGER,
+  heartbeat_at INTEGER,
+  metadata_json TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_durable_workflow_runs_idempotency
+  ON durable_workflow_runs(workflow_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_durable_workflow_runs_status
+  ON durable_workflow_runs(status, updated_at, workflow_run_id);
+
+CREATE TABLE IF NOT EXISTS durable_workflow_events (
+  event_id TEXT NOT NULL UNIQUE,
+  workflow_run_id TEXT NOT NULL,
+  event_seq INTEGER NOT NULL,
+  event_type TEXT NOT NULL,
+  event_time INTEGER NOT NULL,
+  step_id TEXT,
+  agent_invocation_id TEXT,
+  tool_invocation_id TEXT,
+  idempotency_key TEXT,
+  payload_json TEXT,
+  payload_hash TEXT,
+  checkpoint_ref TEXT,
+  causation_event_id TEXT,
+  correlation_id TEXT,
+  recorded_at INTEGER NOT NULL,
+  PRIMARY KEY (workflow_run_id, event_seq),
+  FOREIGN KEY (workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_durable_workflow_events_type
+  ON durable_workflow_events(event_type, event_time, workflow_run_id);
+
+CREATE TABLE IF NOT EXISTS durable_workflow_steps (
+  workflow_run_id TEXT NOT NULL,
+  step_id TEXT NOT NULL,
+  parent_step_id TEXT,
+  step_type TEXT NOT NULL,
+  status TEXT NOT NULL,
+  recovery_state TEXT NOT NULL,
+  attempt INTEGER NOT NULL DEFAULT 1,
+  max_attempts INTEGER,
+  idempotency_key TEXT,
+  input_ref TEXT,
+  output_ref TEXT,
+  error_ref TEXT,
+  checkpoint_ref TEXT,
+  claimed_by TEXT,
+  claim_expires_at INTEGER,
+  heartbeat_at INTEGER,
+  created_at INTEGER NOT NULL,
+  started_at INTEGER,
+  updated_at INTEGER NOT NULL,
+  completed_at INTEGER,
+  metadata_json TEXT,
+  PRIMARY KEY (workflow_run_id, step_id),
+  FOREIGN KEY (workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_durable_workflow_steps_status
+  ON durable_workflow_steps(status, updated_at, workflow_run_id, step_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_durable_workflow_steps_idempotency
+  ON durable_workflow_steps(workflow_run_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS durable_workflow_refs (
+  ref_id TEXT NOT NULL PRIMARY KEY,
+  workflow_run_id TEXT NOT NULL,
+  step_id TEXT,
+  ref_kind TEXT NOT NULL,
+  media_type TEXT,
+  hash TEXT,
+  storage_kind TEXT NOT NULL,
+  storage_uri TEXT,
+  created_at INTEGER NOT NULL,
+  metadata_json TEXT,
+  FOREIGN KEY (workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_durable_workflow_refs_run
+  ON durable_workflow_refs(workflow_run_id, ref_kind, created_at);
+
+CREATE TABLE IF NOT EXISTS durable_workflow_links (
+  parent_workflow_run_id TEXT NOT NULL,
+  parent_step_id TEXT NOT NULL,
+  child_workflow_run_id TEXT NOT NULL,
+  link_type TEXT NOT NULL,
+  status TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  metadata_json TEXT,
+  PRIMARY KEY (parent_workflow_run_id, parent_step_id, child_workflow_run_id),
+  FOREIGN KEY (parent_workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+    ON DELETE CASCADE,
+  FOREIGN KEY (child_workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_durable_workflow_links_child
+  ON durable_workflow_links(child_workflow_run_id, status);
+
+CREATE TABLE IF NOT EXISTS durable_workflow_timers (
+  timer_id TEXT NOT NULL PRIMARY KEY,
+  workflow_run_id TEXT NOT NULL,
+  step_id TEXT,
+  timer_type TEXT NOT NULL,
+  due_at INTEGER NOT NULL,
+  status TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  fired_at INTEGER,
+  cancelled_at INTEGER,
+  metadata_json TEXT,
+  FOREIGN KEY (workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_durable_workflow_timers_due
+  ON durable_workflow_timers(status, due_at, timer_id);
+
+CREATE TABLE IF NOT EXISTS durable_workflow_signals (
+  signal_id TEXT NOT NULL PRIMARY KEY,
+  workflow_run_id TEXT NOT NULL,
+  step_id TEXT,
+  signal_type TEXT NOT NULL,
+  idempotency_key TEXT,
+  payload_ref TEXT,
+  correlation_id TEXT,
+  received_at INTEGER NOT NULL,
+  consumed_at INTEGER,
+  metadata_json TEXT,
+  FOREIGN KEY (workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+    ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_durable_workflow_signals_idempotency
+  ON durable_workflow_signals(workflow_run_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_durable_workflow_signals_pending
+  ON durable_workflow_signals(consumed_at, received_at, signal_id);
+
 CREATE TABLE IF NOT EXISTS migration_runs (
   id TEXT NOT NULL PRIMARY KEY,
   started_at INTEGER NOT NULL,

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -1186,6 +1186,13 @@ CREATE INDEX IF NOT EXISTS idx_flow_runs_status ON flow_runs(status);
 CREATE INDEX IF NOT EXISTS idx_flow_runs_owner_key ON flow_runs(owner_key);
 CREATE INDEX IF NOT EXISTS idx_flow_runs_updated_at ON flow_runs(updated_at);
 
+CREATE TABLE IF NOT EXISTS durable_schema_migrations (
+  schema_name TEXT NOT NULL PRIMARY KEY,
+  version INTEGER NOT NULL,
+  applied_at INTEGER NOT NULL,
+  metadata_json TEXT
+);
+
 CREATE TABLE IF NOT EXISTS durable_workflow_runs (
   workflow_run_id TEXT NOT NULL PRIMARY KEY,
   workflow_id TEXT NOT NULL,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -1181,6 +1181,13 @@ CREATE INDEX IF NOT EXISTS idx_flow_runs_status ON flow_runs(status);
 CREATE INDEX IF NOT EXISTS idx_flow_runs_owner_key ON flow_runs(owner_key);
 CREATE INDEX IF NOT EXISTS idx_flow_runs_updated_at ON flow_runs(updated_at);
 
+CREATE TABLE IF NOT EXISTS durable_schema_migrations (
+  schema_name TEXT NOT NULL PRIMARY KEY,
+  version INTEGER NOT NULL,
+  applied_at INTEGER NOT NULL,
+  metadata_json TEXT
+);
+
 CREATE TABLE IF NOT EXISTS durable_workflow_runs (
   workflow_run_id TEXT NOT NULL PRIMARY KEY,
   workflow_id TEXT NOT NULL,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -1181,6 +1181,173 @@ CREATE INDEX IF NOT EXISTS idx_flow_runs_status ON flow_runs(status);
 CREATE INDEX IF NOT EXISTS idx_flow_runs_owner_key ON flow_runs(owner_key);
 CREATE INDEX IF NOT EXISTS idx_flow_runs_updated_at ON flow_runs(updated_at);
 
+CREATE TABLE IF NOT EXISTS durable_workflow_runs (
+  workflow_run_id TEXT NOT NULL PRIMARY KEY,
+  workflow_id TEXT NOT NULL,
+  workflow_version TEXT NOT NULL DEFAULT '1',
+  idempotency_key TEXT,
+  request_hash TEXT,
+  status TEXT NOT NULL,
+  source_type TEXT,
+  source_ref TEXT,
+  input_ref TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  completed_at INTEGER,
+  recovery_state TEXT NOT NULL DEFAULT 'runnable',
+  checkpoint_ref TEXT,
+  parent_workflow_run_id TEXT,
+  parent_step_id TEXT,
+  message_id TEXT,
+  turn_id TEXT,
+  claimed_by TEXT,
+  claim_expires_at INTEGER,
+  heartbeat_at INTEGER,
+  metadata_json TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_durable_workflow_runs_idempotency
+  ON durable_workflow_runs(workflow_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_durable_workflow_runs_status
+  ON durable_workflow_runs(status, updated_at, workflow_run_id);
+
+CREATE TABLE IF NOT EXISTS durable_workflow_events (
+  event_id TEXT NOT NULL UNIQUE,
+  workflow_run_id TEXT NOT NULL,
+  event_seq INTEGER NOT NULL,
+  event_type TEXT NOT NULL,
+  event_time INTEGER NOT NULL,
+  step_id TEXT,
+  agent_invocation_id TEXT,
+  tool_invocation_id TEXT,
+  idempotency_key TEXT,
+  payload_json TEXT,
+  payload_hash TEXT,
+  checkpoint_ref TEXT,
+  causation_event_id TEXT,
+  correlation_id TEXT,
+  recorded_at INTEGER NOT NULL,
+  PRIMARY KEY (workflow_run_id, event_seq),
+  FOREIGN KEY (workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_durable_workflow_events_type
+  ON durable_workflow_events(event_type, event_time, workflow_run_id);
+
+CREATE TABLE IF NOT EXISTS durable_workflow_steps (
+  workflow_run_id TEXT NOT NULL,
+  step_id TEXT NOT NULL,
+  parent_step_id TEXT,
+  step_type TEXT NOT NULL,
+  status TEXT NOT NULL,
+  recovery_state TEXT NOT NULL,
+  attempt INTEGER NOT NULL DEFAULT 1,
+  max_attempts INTEGER,
+  idempotency_key TEXT,
+  input_ref TEXT,
+  output_ref TEXT,
+  error_ref TEXT,
+  checkpoint_ref TEXT,
+  claimed_by TEXT,
+  claim_expires_at INTEGER,
+  heartbeat_at INTEGER,
+  created_at INTEGER NOT NULL,
+  started_at INTEGER,
+  updated_at INTEGER NOT NULL,
+  completed_at INTEGER,
+  metadata_json TEXT,
+  PRIMARY KEY (workflow_run_id, step_id),
+  FOREIGN KEY (workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_durable_workflow_steps_status
+  ON durable_workflow_steps(status, updated_at, workflow_run_id, step_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_durable_workflow_steps_idempotency
+  ON durable_workflow_steps(workflow_run_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS durable_workflow_refs (
+  ref_id TEXT NOT NULL PRIMARY KEY,
+  workflow_run_id TEXT NOT NULL,
+  step_id TEXT,
+  ref_kind TEXT NOT NULL,
+  media_type TEXT,
+  hash TEXT,
+  storage_kind TEXT NOT NULL,
+  storage_uri TEXT,
+  created_at INTEGER NOT NULL,
+  metadata_json TEXT,
+  FOREIGN KEY (workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_durable_workflow_refs_run
+  ON durable_workflow_refs(workflow_run_id, ref_kind, created_at);
+
+CREATE TABLE IF NOT EXISTS durable_workflow_links (
+  parent_workflow_run_id TEXT NOT NULL,
+  parent_step_id TEXT NOT NULL,
+  child_workflow_run_id TEXT NOT NULL,
+  link_type TEXT NOT NULL,
+  status TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  metadata_json TEXT,
+  PRIMARY KEY (parent_workflow_run_id, parent_step_id, child_workflow_run_id),
+  FOREIGN KEY (parent_workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+    ON DELETE CASCADE,
+  FOREIGN KEY (child_workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_durable_workflow_links_child
+  ON durable_workflow_links(child_workflow_run_id, status);
+
+CREATE TABLE IF NOT EXISTS durable_workflow_timers (
+  timer_id TEXT NOT NULL PRIMARY KEY,
+  workflow_run_id TEXT NOT NULL,
+  step_id TEXT,
+  timer_type TEXT NOT NULL,
+  due_at INTEGER NOT NULL,
+  status TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  fired_at INTEGER,
+  cancelled_at INTEGER,
+  metadata_json TEXT,
+  FOREIGN KEY (workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_durable_workflow_timers_due
+  ON durable_workflow_timers(status, due_at, timer_id);
+
+CREATE TABLE IF NOT EXISTS durable_workflow_signals (
+  signal_id TEXT NOT NULL PRIMARY KEY,
+  workflow_run_id TEXT NOT NULL,
+  step_id TEXT,
+  signal_type TEXT NOT NULL,
+  idempotency_key TEXT,
+  payload_ref TEXT,
+  correlation_id TEXT,
+  received_at INTEGER NOT NULL,
+  consumed_at INTEGER,
+  metadata_json TEXT,
+  FOREIGN KEY (workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+    ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_durable_workflow_signals_idempotency
+  ON durable_workflow_signals(workflow_run_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_durable_workflow_signals_pending
+  ON durable_workflow_signals(consumed_at, received_at, signal_id);
+
 CREATE TABLE IF NOT EXISTS migration_runs (
   id TEXT NOT NULL PRIMARY KEY,
   started_at INTEGER NOT NULL,


### PR DESCRIPTION
## Context capsule

This is PR4/5 in the durable runtime stack. It follows PR3 and adds durable recovery/schema lifecycle coverage so the persisted runtime model can be reviewed for upgrade safety before the opt-in workflow worker loop is submitted.


## Durable core stack overview

Durable core means the shared, opt-in runtime substrate that records run identity, step/event ordering, parent/child links, bounded refs, recovery states, signals/timers, and read-only inspection for long-running OpenClaw agent/session/task/subagent work. It is needed because local incidents and related public PRs show repeated coordinator-silence, stale-running-session, non-durable parent handoff, restart recovery, and bespoke durable-delivery fixes that cannot be solved cleanly by one product surface alone. The core is intentionally below Task Flow, Workboard, plugins, sessions, and channel UI: those can project from it, but they should not own the persistence boundary.

The full stack is: PR1 #101828 docs-only RFC/root-cause/canonical boundary; PR2 #102495 durable runtime core with SQLite state, lifecycle primitives, gateway/operator surfaces, QR repair, and tests; PR3 agent/session/subagent restart and upgrade-safety proof; PR4 schema lifecycle/recovery hardening; PR5 opt-in workflow worker loop. Promotion remains sequential: PR3 waits for PR1+PR2 threshold, PR4 waits for PR3, and PR5 waits for PR4.

This PR is PR4/5: it hardens schema lifecycle and recovery proof after PR3.

## Stack position

- Stack item: PR4/5
- Canonical upstream gates: PR1 #101828 threshold-met; PR2 #102495 pending; PR3 must be submitted and threshold-met first.
- This PR head: `codex/openclaw-durable-runtime-recovery-pr4-v2-submit` at `5faa048369` (`feat(durable): record sqlite schema lifecycle`)
- Intended base: final threshold-met PR3 head.

## Dependency / promotion gate

- Submit gate: PR3 must be threshold_met.
- Current gate state: waiting on PR2, then PR3 submission/review.
- Next dependent PR: PR5 waits for PR4 threshold_met.

## What Problem This Solves

The durable runtime introduces persistent SQLite state, so reviewers need explicit schema lifecycle and recovery proof before worker automation depends on that state. This PR records and tests the schema/recovery lifecycle separately from the worker-loop PR to keep upgrade review focused.

## Scope

- Durable SQLite schema lifecycle/recovery behavior.
- Focused durable runtime and gateway durable method tests.
- Upgrade/schema proof notes for persisted durable runtime tables.

## Non-scope

- Does not add the PR5 opt-in workflow worker loop.
- Does not change promotion ordering or submit before PR3 reaches threshold.
- Does not repair PR2 QR/chat behavior; that belongs to PR2 engineering lane.

## Base / diff hygiene

- Base comparison: expected final PR3 head once PR3 is threshold-met.
- Branch/head verified with `git rev-parse --short=10 codex/openclaw-durable-runtime-recovery-pr4-v2-submit && git log -1 --oneline`.
- Non-cumulative check must be rerun before submit against final PR3 base.

## Proof matrix

| Gate | Command / artifact | Result |
|---|---|---|
| Head verification | `git rev-parse --short=10 codex/openclaw-durable-runtime-recovery-pr4-v2-submit && git log -1 --oneline` | passed; `5faa048369 feat(durable): record sqlite schema lifecycle` |
| Focused durable/gateway tests | `CI=true ./node_modules/.bin/vitest run src/durable/*.test.ts src/gateway/server-methods/durable.test.ts --config test/vitest/vitest.unit.config.ts` | passed 2026-07-09T14:10+07; 6 files / 22 tests |
| Artifact | `/tmp/pr4-proof-linked-goodnm-20260709.log` | available locally |
| Dependency caveat | used known-good `node_modules` from canonical PR2 worktree; avoided `pnpm exec` because it attempted a 1207-package reinstall after disk pressure | recorded in state |
| Diff hygiene | rerun `git log --oneline --reverse <final-pr3-base>..HEAD` and `git diff --name-status <final-pr3-base>..HEAD` before submit | pending final base |
| Live proof | `openclaw e` durable proof exists for equivalent recovery worktree | passed in stack state; rerun if final PR4 diff changes materially |

## Live proof

Stack state records `openclaw e` proof on the durable recovery worktree: gateway health passed on local-e, durable SQLite table counts/recent runs were observable, and durable runtime vitest passed (15 files / 55 tests). Before PR4 submission, rerun or explicitly link this proof if the final PR4 head differs materially from the applied worktree.

## ClawSweeper requirements

- Includes authored `What Problem This Solves`: yes.
- Includes authored `Evidence`: yes.
- Names stored data model / migration impact: yes; this PR is schema lifecycle/recovery focused.
- Names upgrade risk: yes.
- Keeps proof artifacts accessible: yes.

## Risk / upgrade notes

- Primary risk is SQLite schema compatibility/lifecycle handling for existing installs.
- Proof currently depends on a known-good linked dependency install because a killed pnpm reinstall left another worktree incomplete; avoid `pnpm exec` in the recovery worktree until dependencies are intentionally restored.
- Feature rollout should remain gated by the durable runtime defaults/env posture established in PR2.

## Evidence

- PR4 submit branch exists at `5faa048369`.
- Focused durable/gateway vitest gate passed: 6 files / 22 tests.
- Artifact: `/tmp/pr4-proof-linked-goodnm-20260709.log`.
- Stack-level `openclaw e` proof shows durable runtime health and SQLite observability.

## Next gate

Wait for PR3 to reach gold_shrimp_schrimp threshold, then rebase/recompare PR4 against final PR3, rerun focused schema/recovery proof if needed, and submit PR4.
