### PR TITLE
fix: let Codex start with computer control enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Codex computer control:** publish fixed-length coordinate pairs as homogeneous array schemas so Codex app-server can start threads with the `computer` tool instead of rejecting tuple-valued `items`.
 - **Google Chat request deadlines:** bound control calls to 30 seconds while giving media transfers size-aware total budgets and a separate 30-second stalled-body guard, preventing hung Chat API requests without breaking large attachment uploads. (#102227) Thanks @hugenshen.
 - **Google Gemini prefixed model IDs:** recognize `google/gemini-*` and `models/gemini-*` when selecting multimodal function-response behavior, preserving the Gemini 2 image fallback without regressing Gemini 3 inline image responses. (#102382) Thanks @LiLan0125.
 - **Generated provider model catalogs:** keep MiniMax and NVIDIA catalog rows when they advertise audio or video metadata while projecting runtime model inputs to text/image, preventing configured multimodal primaries from being dropped and falling back. (#97858, #97048) Thanks @ly-wang19 and @zackchiutw.

--- a/src/agents/tools/computer-tool.test.ts
+++ b/src/agents/tools/computer-tool.test.ts
@@ -125,6 +125,31 @@ describe("buildComputerActParams", () => {
   });
 });
 
+describe("createComputerTool schema", () => {
+  it("publishes Codex-compatible fixed-size coordinate arrays", () => {
+    const properties = (
+      createComputerTool().parameters as {
+        properties?: Record<string, Record<string, unknown>>;
+      }
+    ).properties;
+
+    for (const key of ["coordinate", "startCoordinate"] as const) {
+      const schema = properties?.[key];
+      if (!schema) {
+        throw new Error(`missing ${key} schema`);
+      }
+      expect(schema).toMatchObject({
+        type: "array",
+        items: { type: "number" },
+        minItems: 2,
+        maxItems: 2,
+      });
+      expect(Array.isArray(schema.items)).toBe(false);
+      expect(schema).not.toHaveProperty("additionalItems");
+    }
+  });
+});
+
 describe("createComputerTool node resolution", () => {
   beforeEach(() => {
     listNodesMock.mockReset();

--- a/src/agents/tools/computer-tool.ts
+++ b/src/agents/tools/computer-tool.ts
@@ -123,13 +123,19 @@ const ComputerToolSchema = Type.Object({
         "Paired node id or display name. Omit when exactly one connected computer-capable node exists.",
     }),
   ),
+  // Codex accepts a single schema in array `items`, not tuple item arrays.
+  // Fixed bounds preserve the coordinate-pair contract across runtimes.
   coordinate: Type.Optional(
-    Type.Tuple([Type.Number(), Type.Number()], {
+    Type.Array(Type.Number(), {
+      minItems: 2,
+      maxItems: 2,
       description: "[x, y] target in pixels of the most recent screenshot.",
     }),
   ),
   startCoordinate: Type.Optional(
-    Type.Tuple([Type.Number(), Type.Number()], {
+    Type.Array(Type.Number(), {
+      minItems: 2,
+      maxItems: 2,
       description: "left_click_drag: [x, y] drag origin in screenshot pixels.",
     }),
   ),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Codex-backed agent runs with computer control enabled failed at thread startup because Codex rejected the `computer` dynamic tool input schema.

## Why This Change Was Made

Computer coordinates remain exactly two finite numbers, but their JSON Schema now uses one homogeneous numeric `items` schema with `minItems` and `maxItems` set to two. This is the smallest shared tool-schema fix: it preserves OpenClaw validation and executor checks while matching Codex's supported array contract, without adding a provider-specific projection path.

## User Impact

Codex app-server threads can start normally when the OpenClaw `computer` tool is present, restoring computer-control and other Codex harness flows that were blocked before the first turn.

## Evidence

- Release Checks run [29026539097](https://github.com/openclaw/openclaw/actions/runs/29026539097) reproduced the same startup failure independently in `gateway-core` and `gateway-backends` at exact SHA `3e492e01460d8ec18787201845fafa3cc929c853`.
- Codex CLI `0.143.0` app-server probe: tuple `items` returned `dynamic tool input schema is not supported for computer: invalid type: map, expected a string`; the homogeneous fixed-size array started the thread successfully.
- Blacksmith Testbox `tbx_01kx3nttr2dtyna66x1csd431b`: `pnpm test src/agents/tools/computer-tool.test.ts` — 16/16 passed; scoped `oxfmt` check passed.
- Regression coverage asserts both `coordinate` and `startCoordinate` serialize with object-valued numeric `items`, exact length bounds, and no tuple-only `additionalItems`.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`: clean, no actionable findings, confidence 0.98.
