### PR TITLE
fix(ai): replace raw require(node:fs) with loadNodeBuiltinModule in getProcEnv

### DIFF
--- a/packages/ai/src/env-api-keys.browser-bundle.test.ts
+++ b/packages/ai/src/env-api-keys.browser-bundle.test.ts
@@ -1,0 +1,19 @@
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+import { describe, expect, it } from "vitest";
+
+describe("env API key browser bundle", () => {
+  it("does not emit a static node:fs require", async () => {
+    const result = await build({
+      entryPoints: [fileURLToPath(new URL("./env-api-keys.ts", import.meta.url))],
+      bundle: true,
+      format: "esm",
+      logLevel: "silent",
+      platform: "browser",
+      write: false,
+    });
+
+    const output = result.outputFiles[0]?.text ?? "";
+    expect(output).not.toMatch(/(?:__)?require\(\s*["']node:fs["']\s*\)/u);
+  });
+});

--- a/packages/ai/src/env-api-keys.ts
+++ b/packages/ai/src/env-api-keys.ts
@@ -89,8 +89,11 @@ function getProcEnv(key: string): string | undefined {
   if (procEnvCache === null) {
     procEnvCache = new Map();
     try {
-      const { readFileSync } = require("node:fs") as typeof import("node:fs");
-      const data = readFileSync("/proc/self/environ", "utf-8");
+      const fsModule = loadNodeBuiltinModule(NODE_FS_SPECIFIER) as typeof import("node:fs") | null;
+      if (!fsModule) {
+        return undefined;
+      }
+      const data = fsModule.readFileSync("/proc/self/environ", "utf-8");
       for (const entry of data.split("\0")) {
         const idx = entry.indexOf("=");
         if (idx > 0) {


### PR DESCRIPTION
## What Problem This Solves

Fixes #102934 — `getProcEnv` used a raw `require("node:fs")` string literal on line 92, which static bundlers such as Vite scan and attempt to resolve even when guarded by `try/catch`. The same file already has a safe `loadNodeBuiltinModule` wrapper (line 17) used by `loadNodeHelpersSync` (line 32) for the same purpose — `getProcEnv` was the only remaining raw require.

## Why This Change Was Made

The file header explicitly states: `// NEVER convert to top-level imports - breaks browser/Vite builds`. Using `loadNodeBuiltinModule` and `NODE_FS_SPECIFIER` (both already defined in the file) eliminates the static `require("node:fs")` literal without changing runtime behavior.

## User Impact

No user-visible impact. Fixes a static analysis / bundler compatibility gap for packages consuming `@openclaw/ai` in browser contexts.

## Evidence

**Before** — `packages/ai/src/env-api-keys.ts:92` (raw static `require` literal):
```ts
const { readFileSync } = require("node:fs") as typeof import("node:fs");
const data = readFileSync("/proc/self/environ", "utf-8");
```

**After** — same behavior via `loadNodeBuiltinModule`:
```ts
const fsModule = loadNodeBuiltinModule(NODE_FS_SPECIFIER) as typeof import("node:fs") | null;
if (!fsModule) {
  return undefined;
}
const data = fsModule.readFileSync("/proc/self/environ", "utf-8");
```

**`loadNodeBuiltinModule` is runtime-equivalent** — `packages/ai/src/env-api-keys.ts:17-28`:
```ts
function loadNodeBuiltinModule(specifier: string): NodeBuiltinModule | null {
  const getBuiltinModule = (typeof process !== "undefined" ? process : undefined) as
    | (NodeJS.Process & { getBuiltinModule?: (id: string) => unknown })
    | undefined;
  if (typeof getBuiltinModule?.getBuiltinModule === "function") {
    return getBuiltinModule.getBuiltinModule(specifier) as NodeBuiltinModule;
  }
  if (typeof require === "function") {
    return require(specifier) as NodeBuiltinModule;  // ← same require call, but indirect
  }
  return null;
}
```

The wrapper first tries `process.getBuiltinModule` (Node 22+), then falls back to `require(specifier)`. The key difference for bundlers: `require` is called with a **variable** (`specifier`) rather than a **string literal** (`"node:fs"`), so static analyzers cannot trace the dependency. The added `null` guard is also stricter — `getProcEnv` now returns `undefined` when `fs` is unavailable, where previously it would have thrown.