### PR TITLE
fix(feishu): add 30 s request timeout to streaming-card API calls

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -3,6 +3,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 type StreamingSessionStub = {
   active: boolean;
+  credentials: unknown;
   start: ReturnType<typeof vi.fn>;
   update: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
@@ -92,7 +93,8 @@ vi.mock("./streaming-card.js", () => {
       });
       isActive = vi.fn(() => this.active);
 
-      constructor() {
+      constructor(_client: unknown, credentials: unknown) {
+        this.credentials = credentials;
         streamingInstances.push(this);
       }
     },
@@ -148,6 +150,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       config: {
         renderMode: "auto",
         streaming: true,
+        httpTimeoutMs: 45_000,
       },
     });
 
@@ -462,6 +465,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     await options.onIdle?.();
 
     expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].credentials).toMatchObject({ httpTimeoutMs: 45_000 });
     expect(streamingInstances[0].close).toHaveBeenCalledWith("plain text", {
       note: "Agent: agent",
     });

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -80,6 +80,7 @@ vi.mock("./streaming-card.js", () => {
     mergeStreamingText,
     FeishuStreamingSession: class {
       active = false;
+      credentials: unknown;
       start = vi.fn(async () => {
         this.active = true;
       });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -13,6 +13,7 @@ import {
 } from "openclaw/plugin-sdk/reply-payload";
 import { stripReasoningTagsFromText } from "openclaw/plugin-sdk/text-chunking";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
+import { resolveConfiguredHttpTimeoutMs } from "./client-timeout.js";
 import { createFeishuClient } from "./client.js";
 import { resolveFeishuIdentityEmoji } from "./identity-header.js";
 import { sendMediaFeishu, shouldSuppressFeishuTextForVoiceMedia } from "./media.js";
@@ -383,7 +384,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     streamingStartPromise = (async () => {
       const creds =
         account.appId && account.appSecret
-          ? { appId: account.appId, appSecret: account.appSecret, domain: account.domain }
+          ? {
+              appId: account.appId,
+              appSecret: account.appSecret,
+              domain: account.domain,
+              httpTimeoutMs: resolveConfiguredHttpTimeoutMs(account),
+            }
           : null;
       if (!creds) {
         return;

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -320,7 +320,7 @@ describe("FeishuStreamingSession", () => {
     );
   });
 
-  it("aborts a stalled Feishu tenant-token request after 30 seconds", async () => {
+  it("aborts a stalled Feishu tenant-token request after the configured timeout", async () => {
     vi.useFakeTimers();
     let authRequestReceived = false;
     const deps: StreamingFetchDeps = {
@@ -360,6 +360,7 @@ describe("FeishuStreamingSession", () => {
       {
         appId: "app_stalled_token",
         appSecret: "secret",
+        httpTimeoutMs: 25,
       },
       undefined,
       deps,
@@ -373,11 +374,11 @@ describe("FeishuStreamingSession", () => {
         return true;
       },
     );
-    await vi.advanceTimersByTimeAsync(30_001);
+    await vi.advanceTimersByTimeAsync(26);
     await result;
     expect(authRequestReceived).toBe(true);
     console.log(
-      "[feishu streaming-card stall proof] stalled tenant-token fetch aborted after 30000ms",
+      "[feishu streaming-card stall proof] stalled tenant-token fetch honored configured timeout",
     );
   });
 

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -320,6 +320,67 @@ describe("FeishuStreamingSession", () => {
     );
   });
 
+  it("aborts a stalled Feishu tenant-token request after 30 seconds", async () => {
+    vi.useFakeTimers();
+    let authRequestReceived = false;
+    const deps: StreamingFetchDeps = {
+      fetchImpl: withFetchPreconnect(
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = new URL(input instanceof Request ? input.url : input.toString());
+          if (!url.pathname.includes("/auth/")) {
+            return jsonResponse({ code: 0, msg: "ok", data: { card_id: "card_should_not_reach" } });
+          }
+          authRequestReceived = true;
+          return await new Promise<Response>((_resolve, reject) => {
+            const signal = init?.signal;
+            if (!signal) {
+              reject(new Error("missing guarded fetch signal"));
+              return;
+            }
+            signal.addEventListener(
+              "abort",
+              () => {
+                const reason = signal.reason;
+                reject(
+                  reason instanceof Error
+                    ? reason
+                    : new Error("request aborted", { cause: reason }),
+                );
+              },
+              { once: true },
+            );
+          });
+        }),
+      ) as FeishuStreamingFetch,
+      lookupFn: hermeticPublicLookup,
+    };
+
+    const session = new FeishuStreamingSession(
+      {} as never,
+      {
+        appId: "app_stalled_token",
+        appSecret: "secret",
+      },
+      undefined,
+      deps,
+    );
+
+    const result = expect(session.start("chat_id", "open_id")).rejects.toSatisfy(
+      (error: unknown) => {
+        expect(error).toBeInstanceOf(Error);
+        const message = (error as Error).message;
+        expect(message).toMatch(/timed out/i);
+        return true;
+      },
+    );
+    await vi.advanceTimersByTimeAsync(30_001);
+    await result;
+    expect(authRequestReceived).toBe(true);
+    console.log(
+      "[feishu streaming-card stall proof] stalled tenant-token fetch aborted after 30000ms",
+    );
+  });
+
   it("rejects oversized streaming card-create JSON before buffering the full body", async () => {
     let streamState:
       | {

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -10,18 +10,19 @@ import {
 } from "openclaw/plugin-sdk/number-runtime";
 import { fetchWithSsrFGuard, type LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { FEISHU_HTTP_TIMEOUT_MS } from "./client-timeout.js";
 import { getFeishuUserAgent } from "./client.js";
 import { requestFeishuApi } from "./comment-shared.js";
 import { readFeishuJsonResponse } from "./json-response.js";
 import { resolveFeishuCardTemplate, type CardHeaderConfig } from "./send.js";
 import type { FeishuDomain } from "./types.js";
 
-// All CardKit and token requests share a single deadline. Without this, a
-// server that accepts the TCP connection but stalls blocks the streaming-card
-// reply lane and pins a gateway request open indefinitely.
-const FEISHU_STREAMING_CARD_REQUEST_TIMEOUT_MS = 30_000;
-
-type Credentials = { appId: string; appSecret: string; domain?: FeishuDomain };
+type Credentials = {
+  appId: string;
+  appSecret: string;
+  domain?: FeishuDomain;
+  httpTimeoutMs?: number;
+};
 type CardState = {
   cardId: string;
   messageId: string;
@@ -145,7 +146,7 @@ async function getToken(creds: Credentials, deps?: FeishuStreamingDeps): Promise
     lookupFn: deps?.lookupFn,
     policy: { allowedHostnames: resolveAllowedHostnames(creds.domain) },
     auditContext: "feishu.streaming-card.token",
-    timeoutMs: FEISHU_STREAMING_CARD_REQUEST_TIMEOUT_MS,
+    timeoutMs: creds.httpTimeoutMs ?? FEISHU_HTTP_TIMEOUT_MS,
   });
   let data: {
     code: number;
@@ -326,7 +327,7 @@ export class FeishuStreamingSession {
       lookupFn: this.lookupFn,
       policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
       auditContext: "feishu.streaming-card.create",
-      timeoutMs: FEISHU_STREAMING_CARD_REQUEST_TIMEOUT_MS,
+      timeoutMs: this.creds.httpTimeoutMs ?? FEISHU_HTTP_TIMEOUT_MS,
     });
     let createData: {
       code: number;
@@ -441,7 +442,7 @@ export class FeishuStreamingSession {
         lookupFn: this.lookupFn,
         policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
         auditContext: "feishu.streaming-card.update",
-        timeoutMs: FEISHU_STREAMING_CARD_REQUEST_TIMEOUT_MS,
+        timeoutMs: this.creds.httpTimeoutMs ?? FEISHU_HTTP_TIMEOUT_MS,
       });
       try {
         await assertSuccessfulCardKitResponse(
@@ -491,7 +492,7 @@ export class FeishuStreamingSession {
         lookupFn: this.lookupFn,
         policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
         auditContext: "feishu.streaming-card.replace",
-        timeoutMs: FEISHU_STREAMING_CARD_REQUEST_TIMEOUT_MS,
+        timeoutMs: this.creds.httpTimeoutMs ?? FEISHU_HTTP_TIMEOUT_MS,
       });
       try {
         await assertSuccessfulCardKitResponse(
@@ -604,7 +605,7 @@ export class FeishuStreamingSession {
       lookupFn: this.lookupFn,
       policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
       auditContext: "feishu.streaming-card.note-update",
-      timeoutMs: FEISHU_STREAMING_CARD_REQUEST_TIMEOUT_MS,
+      timeoutMs: this.creds.httpTimeoutMs ?? FEISHU_HTTP_TIMEOUT_MS,
     })
       .then(async ({ response, release }) => {
         try {
@@ -682,7 +683,7 @@ export class FeishuStreamingSession {
       lookupFn: this.lookupFn,
       policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
       auditContext: "feishu.streaming-card.close",
-      timeoutMs: FEISHU_STREAMING_CARD_REQUEST_TIMEOUT_MS,
+      timeoutMs: this.creds.httpTimeoutMs ?? FEISHU_HTTP_TIMEOUT_MS,
     })
       .then(async ({ response, release }) => {
         try {

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -16,6 +16,11 @@ import { readFeishuJsonResponse } from "./json-response.js";
 import { resolveFeishuCardTemplate, type CardHeaderConfig } from "./send.js";
 import type { FeishuDomain } from "./types.js";
 
+// All CardKit and token requests share a single deadline. Without this, a
+// server that accepts the TCP connection but stalls blocks the streaming-card
+// reply lane and pins a gateway request open indefinitely.
+const FEISHU_STREAMING_CARD_REQUEST_TIMEOUT_MS = 30_000;
+
 type Credentials = { appId: string; appSecret: string; domain?: FeishuDomain };
 type CardState = {
   cardId: string;
@@ -140,6 +145,7 @@ async function getToken(creds: Credentials, deps?: FeishuStreamingDeps): Promise
     lookupFn: deps?.lookupFn,
     policy: { allowedHostnames: resolveAllowedHostnames(creds.domain) },
     auditContext: "feishu.streaming-card.token",
+    timeoutMs: FEISHU_STREAMING_CARD_REQUEST_TIMEOUT_MS,
   });
   let data: {
     code: number;
@@ -320,6 +326,7 @@ export class FeishuStreamingSession {
       lookupFn: this.lookupFn,
       policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
       auditContext: "feishu.streaming-card.create",
+      timeoutMs: FEISHU_STREAMING_CARD_REQUEST_TIMEOUT_MS,
     });
     let createData: {
       code: number;
@@ -434,6 +441,7 @@ export class FeishuStreamingSession {
         lookupFn: this.lookupFn,
         policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
         auditContext: "feishu.streaming-card.update",
+        timeoutMs: FEISHU_STREAMING_CARD_REQUEST_TIMEOUT_MS,
       });
       try {
         await assertSuccessfulCardKitResponse(
@@ -483,6 +491,7 @@ export class FeishuStreamingSession {
         lookupFn: this.lookupFn,
         policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
         auditContext: "feishu.streaming-card.replace",
+        timeoutMs: FEISHU_STREAMING_CARD_REQUEST_TIMEOUT_MS,
       });
       try {
         await assertSuccessfulCardKitResponse(
@@ -595,6 +604,7 @@ export class FeishuStreamingSession {
       lookupFn: this.lookupFn,
       policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
       auditContext: "feishu.streaming-card.note-update",
+      timeoutMs: FEISHU_STREAMING_CARD_REQUEST_TIMEOUT_MS,
     })
       .then(async ({ response, release }) => {
         try {
@@ -672,6 +682,7 @@ export class FeishuStreamingSession {
       lookupFn: this.lookupFn,
       policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
       auditContext: "feishu.streaming-card.close",
+      timeoutMs: FEISHU_STREAMING_CARD_REQUEST_TIMEOUT_MS,
     })
       .then(async ({ response, release }) => {
         try {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where all six outbound CardKit and tenant-token requests in
`extensions/feishu/src/streaming-card.ts` called `fetchWithSsrFGuard` without
a `timeoutMs` deadline. If the Feishu API endpoint accepts a TCP connection but
never completes the HTTP response (stalled server, network middlebox, proxy delay),
the affected call blocks indefinitely and pins a gateway request lane open.

The critical path is `getToken()`: tenant-token refresh is called before every
CardKit request, so a single stalled token endpoint blocks the entire streaming-card
reply pipeline for a running agent turn.

## Why This Change Was Made

`fetchWithSsrFGuard` exposes a top-level `timeoutMs` parameter that applies a hard
abort deadline to the underlying request. Adding `FEISHU_STREAMING_CARD_REQUEST_TIMEOUT_MS = 30_000`
and wiring it to all six call sites in one constant covers every streaming-card path
without touching callers.

The 30-second value matches the sibling pattern already used across the codebase
(e.g. `extensions/googlechat/src/api.ts`, `extensions/google-meet/src/meet.ts`,
`extensions/mattermost/src/api.ts`).

`extensions/feishu/src/app-registration.ts` was checked and is not affected: its
`fetchFeishuJson` helper receives `signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)`
through the caller's `init`, providing equivalent protection via a different mechanism.

## User Impact

**Before:** A stalled Feishu API endpoint leaves tenant-token refresh or any CardKit
request pending indefinitely. No timeout error is surfaced; the streaming-card reply
lane is blocked until the process is restarted.

**After:** Every streaming-card API request fails with an abort/timeout error after
30 seconds. The caller receives a concrete error, the lane is released, and the gateway
can continue processing other messages.

## Evidence

Branch: `fix/feishu-streaming-card-timeouts`  
Base: `upstream/main`  
Node: v22.22.0 — macOS Darwin 24.3.0 arm64

### Existing tests — all passing after change

```
$ node scripts/run-vitest.mjs extensions/feishu/src/streaming-card.test.ts --reporter=verbose

 ✓ FeishuStreamingSession > rejects oversized streaming tenant-token JSON before buffering the full body
 ✓ FeishuStreamingSession > rejects oversized streaming card-create JSON before buffering the full body
 ✓ FeishuStreamingSession > flushes throttled pending text after the throttle window
 ✓ FeishuStreamingSession > handles a rejected scheduled flush update
 ✓ FeishuStreamingSession > pushes natural-boundary updates immediately inside the throttle window
 ✓ FeishuStreamingSession > retries cumulative content after a failed streaming update
 ✓ FeishuStreamingSession > retries cumulative content after a non-OK streaming update
 ✓ FeishuStreamingSession > replaces content when final text removes transient streamed status
 ✓ FeishuStreamingSession > drops a surrogate pair whole when truncating the closeout summary
 ✓ FeishuStreamingSession > logs a final replacement failure when CardKit returns non-OK
 ✓ FeishuStreamingSession > reports no visible content when final close update fails before any accepted text
 ✓ FeishuStreamingSession > bounds streaming token cache lifetime when token expiry overflows
 ✓ FeishuStreamingSession > bounds streaming token fallback lifetime when the process clock is invalid
 ✓ FeishuStreamingSession > treats an invalid process clock as a streaming token cache miss
 ... (7 more)

 Test Files  1 passed (1)
      Tests  21 passed (21)
   Duration  10.74s
```

### Format and lint

```
$ git diff --check   →  (no output, clean)
$ node scripts/run-oxlint.mjs extensions/feishu/src/streaming-card.ts
→ exit 0, no warnings
```

### Diff summary

```
extensions/feishu/src/streaming-card.ts | 11 +++++ (constant + 6 × timeoutMs)
```

Call sites covered:
- `feishu.streaming-card.token` (tenant token refresh)
- `feishu.streaming-card.create` (card entity creation)
- `feishu.streaming-card.update` (content stream update)
- `feishu.streaming-card.replace` (content replace)
- `feishu.streaming-card.note-update` (note footer update)
- `feishu.streaming-card.close` (streaming mode close)

What was not tested: a live Feishu API stall scenario. Crabbox/Testbox remote CI
was not run at submission time.

- [x] AI-assisted (Cursor / Claude Sonnet 4.6)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
