### PR TITLE
fix(qqbot): pass timeoutMs to token fetch in doFetchToken

### DIFF
--- a/extensions/qqbot/src/engine/api/token.test.ts
+++ b/extensions/qqbot/src/engine/api/token.test.ts
@@ -74,6 +74,7 @@ describe("QQBot token manager", () => {
         hostnameAllowlist: ["bots.qq.com"],
         allowRfc2544BenchmarkRange: true,
       },
+      timeoutMs: 30_000,
       init: {
         method: "POST",
         headers: {
@@ -175,6 +176,19 @@ describe("QQBot token manager", () => {
     expect(manager.getStatus("app-id")).toEqual({ status: "none", expiresAt: null });
     expect(logger.debug).toHaveBeenCalledWith(
       "[qqbot:token:app-id] Not cached: invalid process clock",
+    );
+  });
+
+  it("passes timeoutMs to fetchWithSsrFGuard on every token fetch", async () => {
+    mockGuardedTokenResponse('{"access_token":"token-1","expires_in":7200}', {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+
+    await new TokenManager().getAccessToken("app-id", "secret");
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({ timeoutMs: 30_000 }),
     );
   });
 });

--- a/extensions/qqbot/src/engine/api/token.ts
+++ b/extensions/qqbot/src/engine/api/token.ts
@@ -20,6 +20,10 @@ import { formatErrorMessage } from "../utils/format.js";
 const TOKEN_URL = "https://bots.qq.com/app/getAppAccessToken";
 const DEFAULT_TOKEN_EXPIRES_IN_SECONDS = 7200;
 const QQBOT_TOKEN_RESPONSE_LIMIT_BYTES = 8 * 1024;
+// Token endpoint is on the critical path for every authenticated request;
+// an unbounded fetch blocks all QQBot operations if bots.qq.com accepts
+// but never responds (stalled middlebox, proxy delay, etc.).
+const QQBOT_TOKEN_TIMEOUT_MS = 30_000;
 
 /**
  * Host-scoped SSRF policy for the QQ Bot token endpoint.
@@ -247,6 +251,7 @@ export class TokenManager {
         auditContext: "qqbot-token",
         capture: false,
         policy: QQBOT_TOKEN_SSRF_POLICY,
+        timeoutMs: QQBOT_TOKEN_TIMEOUT_MS,
         init: {
           method: "POST",
           headers: {


### PR DESCRIPTION
## What Problem This Solves

`TokenManager.doFetchToken` in `extensions/qqbot/src/engine/api/token.ts` calls
`fetchWithSsrFGuard` to POST credentials to `https://bots.qq.com/app/getAppAccessToken`
without a `timeoutMs` or top-level `signal`. If `bots.qq.com` accepts the TCP connection
but never sends an HTTP response (stalled server, network middlebox, or proxy delay), the
token fetch hangs indefinitely.

This is especially impactful because the token endpoint is on the critical path for every
authenticated QQBot API call. Every message send, API call, and upload eventually calls
`getAccessToken`, which goes through `doFetchToken` when the cache is empty or expired.
A stalled token fetch blocks all QQBot operations with no timeout error surfaced.

The sibling `ApiClient.request` method and `executeChannelApi` both implement 30-second
timeouts via `AbortController` + `signal`. The `stt.ts` transcription helper passes
`timeoutMs` directly. `doFetchToken` was the only call site with no timeout of any kind.

## Why This Change Was Made

`fetchWithSsrFGuard` accepts a top-level `timeoutMs` parameter (defined in
`src/infra/net/fetch-guard.ts:80`). Adding `timeoutMs: QQBOT_TOKEN_TIMEOUT_MS` to the
single `fetchWithSsrFGuard` call site in `doFetchToken` closes the gap. The 30-second
constant matches the `DEFAULT_TIMEOUT_MS` used in `ApiClient` and `channel-api.ts`,
keeping the timeout policy consistent across all QQBot HTTP call sites.

## User Impact

**Before:** If `bots.qq.com` accepts but never answers, every QQBot operation requiring
auth hangs indefinitely — no timeout error, no lane release. Under concurrent usage,
multiple stalled token fetches accumulate and singleflight collapses them into one pending
promise, but that promise also never resolves.

**After:** `doFetchToken` fails with an abort/timeout error after 30 seconds. The caller
receives a concrete network error, the lane is released, and the singleflight map is
cleared. Subsequent calls can retry.

## Evidence

Branch: `fix/qqbot-token-fetch-timeout`  
Base: `upstream/main` (`9775f09194`)  
Node: v22.22.0 — macOS Darwin 24.3.0 arm64

### Regression tests

```
$ node scripts/run-vitest.mjs extensions/qqbot/src/engine/api/token.test.ts

 RUN  v4.1.9 /Users/shen/Documents/GitHub/openclaw

 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  23:11:37
   Duration  799ms (transform 408ms, setup 127ms, import 539ms, tests 63ms, environment 0ms)
```

7 tests pass: the 6 pre-existing cases (including the RFC 2544 SSRF regression for #88984)
plus the new `"passes timeoutMs to fetchWithSsrFGuard on every token fetch"` case.

The existing `"wraps malformed access token JSON"` test uses an exact `toHaveBeenCalledWith`
assertion — it now includes `timeoutMs: 30_000` and still passes, confirming the field is
forwarded on real calls.

### Source-level proof

`QQBOT_TOKEN_TIMEOUT_MS = 30_000` is defined in `token.ts` and forwarded as `timeoutMs`
in the single `fetchWithSsrFGuard` call in `doFetchToken`. No other call sites are
affected; the other QQBot `fetchWithSsrFGuard` callers already implement timeout via
`AbortController` + `signal` (api-client.ts, channel-api.ts, media-chunked.ts, media.ts)
or `timeoutMs` (stt.ts).

### Diff summary

```
extensions/qqbot/src/engine/api/token.ts      |  5 +++++ (constant + timeoutMs field)
extensions/qqbot/src/engine/api/token.test.ts | 14 ++++++++++++++ (updated exact assertion + new regression test)
```

### Reproduction sketch (end-to-end, not run)

1. Stand up a TCP server that accepts connections and sends a valid TLS handshake but
   never emits an HTTP response.
2. Route `bots.qq.com` to that server via `/etc/hosts`.
3. Trigger any QQBot message that requires a token refresh (empty or expired cache).
4. **Before fix:** `doFetchToken` never resolves — all QQBot operations stall indefinitely.
5. **After fix:** fetch aborts after 30 s with a timeout error, error is logged, caller
   receives `"Network error getting access_token: ..."`, gateway can continue.

What was not tested: live `bots.qq.com` stall scenario with a real QQ Bot application.
Crabbox/Testbox remote CI was not available at submission time.

- [x] AI-assisted (Cursor / Claude Sonnet 4.6)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
