### PR TITLE
fix(utils): fetchWithTimeout ignores caller-provided AbortSignal in RequestInit

### DIFF
--- a/extensions/mattermost/src/mattermost/client.fetch-timeout.test.ts
+++ b/extensions/mattermost/src/mattermost/client.fetch-timeout.test.ts
@@ -101,6 +101,44 @@ describe("Mattermost REST client fetch timeout", () => {
     });
   });
 
+  it("preserves caller cancellation through a custom fetch response body", async () => {
+    let notifyFetchResolved: () => void = () => {};
+    const fetchResolved = new Promise<void>((resolve) => {
+      notifyFetchResolved = resolve;
+    });
+    await withServer(
+      (_request, response) => {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.write('{"id":"partial');
+      },
+      async (baseUrl) => {
+        const fetchImpl: typeof fetch = async (input, init) => {
+          const response = await fetch(input, init);
+          notifyFetchResolved();
+          return response;
+        };
+        const client = createMattermostClient({
+          baseUrl,
+          botToken: "bot-token",
+          fetchImpl,
+          timeoutMs: 30_000,
+        });
+        const controller = new AbortController();
+        const reason = new Error("caller stopped after headers");
+        const request = client.request("/users/me", { signal: controller.signal });
+
+        await fetchResolved;
+        // Let the client's post-fetch cleanup run before cancellation so this
+        // specifically covers the response-body phase.
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        controller.abort(reason);
+
+        const outcome = await settleWithin(request, 750);
+        expect(outcome).toEqual({ status: "rejected", error: reason });
+      },
+    );
+  });
+
   it("preserves configured DM retry timeouts longer than the client default", async () => {
     await withHangingMattermostServer(async (server) => {
       const client = createMattermostClient({

--- a/extensions/mattermost/src/mattermost/client.fetch-timeout.test.ts
+++ b/extensions/mattermost/src/mattermost/client.fetch-timeout.test.ts
@@ -130,7 +130,9 @@ describe("Mattermost REST client fetch timeout", () => {
         await fetchResolved;
         // Let the client's post-fetch cleanup run before cancellation so this
         // specifically covers the response-body phase.
-        await new Promise<void>((resolve) => setImmediate(resolve));
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
         controller.abort(reason);
 
         const outcome = await settleWithin(request, 750);

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -223,16 +223,24 @@ export function createMattermostClient(params: {
           typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
         const { timeoutMs: initTimeoutMs, ...requestInit } = init ?? {};
         const timeoutMs = resolveTimerTimeoutMs(initTimeoutMs, requestTimeoutMs);
-        const { signal, cleanup } = buildTimeoutAbortSignal({
+        const { signal: timeoutSignal, cleanup } = buildTimeoutAbortSignal({
           timeoutMs,
-          signal: requestInit.signal ?? undefined,
           operation: "mattermost-api",
           url,
         });
+        const callerSignal = requestInit.signal ?? undefined;
+        const signal =
+          callerSignal && timeoutSignal
+            ? AbortSignal.any([callerSignal, timeoutSignal])
+            : (callerSignal ?? timeoutSignal);
         try {
-          return await externalFetchImpl(input, { ...requestInit, signal });
-        } finally {
+          const response = await externalFetchImpl(input, { ...requestInit, signal });
+          // Match guarded production fetches: retain cancellation and the
+          // request deadline until the custom response body is consumed.
+          return responseWithRelease(response, async () => cleanup());
+        } catch (error) {
           cleanup();
+          throw error;
         }
       }
     : undefined;

--- a/src/utils/fetch-timeout.test.ts
+++ b/src/utils/fetch-timeout.test.ts
@@ -239,7 +239,11 @@ describe("buildTimeoutAbortSignal", () => {
             reject(new Error("missing signal"));
             return;
           }
-          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+          signal.addEventListener(
+            "abort",
+            () => reject(toLintErrorObject(signal.reason, "Non-Error rejection")),
+            { once: true },
+          );
         }),
     );
 

--- a/src/utils/fetch-timeout.test.ts
+++ b/src/utils/fetch-timeout.test.ts
@@ -228,6 +228,80 @@ describe("buildTimeoutAbortSignal", () => {
     await assertion;
   });
 
+  it("preserves caller abort reasons before response headers", async () => {
+    const parent = new AbortController();
+    const reason = new Error("caller stopped before headers");
+    const fetchFn = vi.fn<typeof fetch>(
+      async (_input, init) =>
+        await new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          if (!signal) {
+            reject(new Error("missing signal"));
+            return;
+          }
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        }),
+    );
+
+    const result = fetchWithTimeout(
+      "https://example.com/v1/audio",
+      { signal: parent.signal },
+      25,
+      fetchFn,
+    );
+    parent.abort(reason);
+
+    await expect(result).rejects.toBe(reason);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("keeps following caller aborts while the returned body is consumed", async () => {
+    const parent = new AbortController();
+    const reason = new Error("caller stopped after headers");
+    let fetchSignal: AbortSignal | null | undefined;
+    const fetchFn = vi.fn<typeof fetch>(async (_input, init) => {
+      fetchSignal = init?.signal;
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            fetchSignal?.addEventListener("abort", () => controller.error(fetchSignal?.reason), {
+              once: true,
+            });
+          },
+        }),
+      );
+    });
+
+    const response = await fetchWithTimeout(
+      "https://example.com/v1/audio",
+      { signal: parent.signal },
+      25,
+      fetchFn,
+    );
+    const body = response.text();
+
+    await vi.advanceTimersByTimeAsync(25);
+    expect(fetchSignal?.aborted).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+
+    parent.abort(reason);
+
+    await expect(body).rejects.toBe(reason);
+    expect(fetchSignal?.reason).toBe(reason);
+  });
+
+  it("accepts a null RequestInit signal", async () => {
+    const response = new Response("ok");
+    const fetchFn = vi.fn<typeof fetch>(async (_input, init) => {
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+      return response;
+    });
+
+    await expect(
+      fetchWithTimeout("https://example.com/v1/audio", { signal: null }, 25, fetchFn),
+    ).resolves.toBe(response);
+  });
+
   it("clamps oversized fetchWithTimeout delays before fetch starts", async () => {
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const response = new Response("ok");

--- a/src/utils/fetch-timeout.ts
+++ b/src/utils/fetch-timeout.ts
@@ -182,12 +182,18 @@ export async function fetchWithTimeout(
   timeoutMs: number,
   fetchFn: typeof fetch = fetch,
 ): Promise<Response> {
-  const { signal, cleanup } = buildTimeoutAbortSignal({
+  const { signal: timeoutSignal, cleanup } = buildTimeoutAbortSignal({
     timeoutMs: Math.max(1, timeoutMs),
     operation: "fetchWithTimeout",
     url,
-    signal: init.signal,
   });
+  const callerSignal = init.signal ?? undefined;
+  // The wrapper timeout ends once fetch returns headers, but the response body
+  // must keep following caller cancellation (and its reason) after that point.
+  const signal =
+    callerSignal && timeoutSignal
+      ? AbortSignal.any([callerSignal, timeoutSignal])
+      : (callerSignal ?? timeoutSignal);
   try {
     return await fetchFn(url, { ...init, signal });
   } finally {

--- a/src/utils/fetch-timeout.ts
+++ b/src/utils/fetch-timeout.ts
@@ -186,6 +186,7 @@ export async function fetchWithTimeout(
     timeoutMs: Math.max(1, timeoutMs),
     operation: "fetchWithTimeout",
     url,
+    signal: init.signal,
   });
   try {
     return await fetchFn(url, { ...init, signal });


### PR DESCRIPTION
### Description

In `src/utils/fetch-timeout.ts`, the `fetchWithTimeout` wrapper is implemented as follows:
```typescript
export async function fetchWithTimeout(
  url: string,
  init: RequestInit,
  timeoutMs: number,
  fetchFn: typeof fetch = fetch,
): Promise<Response> {
  const { signal, cleanup } = buildTimeoutAbortSignal({
    timeoutMs: Math.max(1, timeoutMs),
    operation: "fetchWithTimeout",
    url,
  });
  try {
    return await fetchFn(url, { ...init, signal });
  } finally {
    cleanup();
  }
}
```

However, if the caller specifies a custom `AbortSignal` in `init.signal` (for instance, to cancel the request if a parent operation is aborted or the client disconnects), this signal is completely overridden by the new signal created in `buildTimeoutAbortSignal`.

### Impact

The caller-provided `AbortSignal` is silently dropped and ignored, meaning that cancellations from the caller side will not abort the request during `fetchWithTimeout`.

### Suggested Fix

Pass `init.signal` to `buildTimeoutAbortSignal` so that the timeout controller is chained to the parent signal:
```typescript
  const { signal, cleanup } = buildTimeoutAbortSignal({
    timeoutMs: Math.max(1, timeoutMs),
    operation: "fetchWithTimeout",
    url,
    signal: init.signal,
  });
```
