### PR TITLE
fix(browser): reject credentialed page URLs safely

### DIFF
--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -1519,6 +1519,24 @@ describe("browser tool url alias support", () => {
     expect(opts.profile).toBeUndefined();
   });
 
+  it("rejects credentialed open URLs before host or node dispatch", async () => {
+    mockSingleBrowserProxyNode();
+    const tool = createBrowserTool();
+    for (const target of ["host", "node"] as const) {
+      for (const url of ["https://user:secret@example.com/path", "https://user:secret@"]) {
+        const error = await tool.execute?.("call-1", { action: "open", target, url }).then(
+          () => new Error("credentialed URL was accepted"),
+          (cause: unknown) => cause,
+        );
+        expect(error).toBeInstanceOf(Error);
+        expect(String(error)).not.toContain("secret");
+      }
+    }
+
+    expect(browserClientMocks.browserOpenTab).not.toHaveBeenCalled();
+    expect(gatewayMocks.callGatewayTool).not.toHaveBeenCalled();
+  });
+
   it("tracks opened tabs when session context is available", async () => {
     browserClientMocks.browserOpenTab.mockResolvedValueOnce({
       targetId: "tab-123",
@@ -1573,6 +1591,26 @@ describe("browser tool url alias support", () => {
     expect(request.url).toBe("https://example.com");
     expect(request.targetId).toBe("tab-1");
     expect(request.profile).toBeUndefined();
+  });
+
+  it("rejects credentialed navigate URLs before host or node dispatch", async () => {
+    mockSingleBrowserProxyNode();
+    const tool = createBrowserTool();
+    for (const target of ["host", "node"] as const) {
+      for (const url of ["https://user:secret@example.com/path", "https://user:secret@"]) {
+        const error = await tool
+          .execute?.("call-1", { action: "navigate", target, url, targetId: "tab-1" })
+          .then(
+            () => new Error("credentialed URL was accepted"),
+            (cause: unknown) => cause,
+          );
+        expect(error).toBeInstanceOf(Error);
+        expect(String(error)).not.toContain("secret");
+      }
+    }
+
+    expect(browserActionsMocks.browserNavigate).not.toHaveBeenCalled();
+    expect(gatewayMocks.callGatewayTool).not.toHaveBeenCalled();
   });
 
   it("keeps targetUrl required error label when both params are missing", async () => {

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -57,6 +57,7 @@ import {
   untrackSessionBrowserTab,
 } from "./browser-tool.runtime.js";
 import { DEFAULT_BROWSER_SCREENSHOT_TIMEOUT_MS } from "./browser/constants.js";
+import { parseBrowserNavigationUrl } from "./browser/navigation-guard.js";
 import { normalizeBrowserScreenshot } from "./browser/screenshot.js";
 import { describeBrowserScreenshot, neutralizeMediaDirectives } from "./browser/vision.js";
 import { wrapExternalContent } from "./sdk-security-runtime.js";
@@ -163,10 +164,11 @@ function readOptionalTargetAndTimeout(params: Record<string, unknown>) {
 }
 
 function readTargetUrlParam(params: Record<string, unknown>) {
-  return (
+  const targetUrl =
     readStringParam(params, "targetUrl") ??
-    readStringParam(params, "url", { required: true, label: "targetUrl" })
-  );
+    readStringParam(params, "url", { required: true, label: "targetUrl" });
+  parseBrowserNavigationUrl(targetUrl);
+  return targetUrl;
 }
 
 function formatScreenshotShareHint(filePath: string): string {

--- a/extensions/browser/src/browser/navigation-guard.test.ts
+++ b/extensions/browser/src/browser/navigation-guard.test.ts
@@ -252,6 +252,26 @@ describe("browser navigation guard", () => {
     ).rejects.toBeInstanceOf(InvalidBrowserNavigationUrlError);
   });
 
+  it("blocks network URLs with embedded credentials before lookup", async () => {
+    const lookupFn = createLookupFn("93.184.216.34");
+    const result = assertBrowserNavigationAllowed({
+      url: "https://user:secret@example.com/private",
+      lookupFn,
+    });
+    await expect(result).rejects.toThrow("URL-embedded credentials are not supported");
+    await expect(result).rejects.toThrow("openclaw browser set credentials");
+    await expect(result).rejects.not.toThrow("secret");
+    expect(lookupFn).not.toHaveBeenCalled();
+  });
+
+  it("redacts malformed credential-bearing URLs from diagnostics", async () => {
+    const result = assertBrowserNavigationAllowed({
+      url: "https://user:secret@",
+    });
+    await expect(result).rejects.toThrow("Invalid URL: [redacted credential-bearing URL]");
+    await expect(result).rejects.not.toThrow("secret");
+  });
+
   it("validates final network URLs after navigation", async () => {
     const lookupFn = createLookupFn("127.0.0.1");
     await expect(

--- a/extensions/browser/src/browser/navigation-guard.ts
+++ b/extensions/browser/src/browser/navigation-guard.ts
@@ -15,14 +15,12 @@ import { matchesHostnameAllowlist, normalizeHostname } from "../sdk-security-run
 
 const NETWORK_NAVIGATION_PROTOCOLS = new Set(["http:", "https:"]);
 const SAFE_NON_NETWORK_URLS = new Set(["about:blank"]);
+const BROWSER_NAVIGATION_CREDENTIALS_BLOCKED_MESSAGE =
+  "Navigation blocked: URL-embedded credentials are not supported for page navigation. Set HTTP Basic auth with `openclaw browser set credentials <username> <password>` or use an authenticated browser profile.";
 
 function isAllowedNonNetworkNavigationUrl(parsed: URL): boolean {
   // Keep non-network navigation explicit; about:blank is the only allowed bootstrap URL.
   return SAFE_NON_NETWORK_URLS.has(parsed.href);
-}
-
-function normalizeNavigationUrl(url: string): string {
-  return url.trim();
 }
 
 /** Raised when a browser navigation URL fails syntax or policy validation. */
@@ -31,6 +29,27 @@ export class InvalidBrowserNavigationUrlError extends Error {
     super(message);
     this.name = "InvalidBrowserNavigationUrlError";
   }
+}
+
+/** Parse a page-navigation URL and reject credentials before any transport dispatch. */
+export function parseBrowserNavigationUrl(url: string): URL {
+  const rawUrl = url.trim();
+  if (!rawUrl) {
+    throw new InvalidBrowserNavigationUrlError("url is required");
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    const diagnostic = rawUrl.includes("@") ? "[redacted credential-bearing URL]" : rawUrl;
+    throw new InvalidBrowserNavigationUrlError(`Invalid URL: ${diagnostic}`);
+  }
+
+  if (parsed.username || parsed.password) {
+    throw new InvalidBrowserNavigationUrlError(BROWSER_NAVIGATION_CREDENTIALS_BLOCKED_MESSAGE);
+  }
+  return parsed;
 }
 
 /** Policy inputs applied to browser page navigation checks. */
@@ -107,17 +126,7 @@ export async function assertBrowserNavigationAllowed(
     lookupFn?: LookupFn;
   } & BrowserNavigationPolicyOptions,
 ): Promise<void> {
-  const rawUrl = normalizeNavigationUrl(opts.url);
-  if (!rawUrl) {
-    throw new InvalidBrowserNavigationUrlError("url is required");
-  }
-
-  let parsed: URL;
-  try {
-    parsed = new URL(rawUrl);
-  } catch {
-    throw new InvalidBrowserNavigationUrlError(`Invalid URL: ${rawUrl}`);
-  }
+  const parsed = parseBrowserNavigationUrl(opts.url);
 
   if (!NETWORK_NAVIGATION_PROTOCOLS.has(parsed.protocol)) {
     if (isAllowedNonNetworkNavigationUrl(parsed)) {
@@ -174,7 +183,7 @@ export async function assertBrowserNavigationResultAllowed(
     lookupFn?: LookupFn;
   } & BrowserNavigationPolicyOptions,
 ): Promise<void> {
-  const rawUrl = normalizeNavigationUrl(opts.url);
+  const rawUrl = opts.url.trim();
   if (!rawUrl) {
     return;
   }


### PR DESCRIPTION
## What Problem This Solves

Browser `open` and `navigate` accepted page URLs containing userinfo. Chromium/Playwright can reject those URLs after the credential-bearing string has crossed tool or node-proxy boundaries, and malformed credential-like URLs could also reach dispatch before validation.

Closes #55365. This carries forward and improves #82490 by @lidge-jun after the nominally maintainer-editable fork branch could not be updated.

## Why This Change Was Made

Use one canonical navigation URL parser at both boundaries that matter:

- the model-facing Browser tool, before host or Browser-node dispatch;
- the server navigation guard, before DNS lookup and SSRF policy evaluation.

Parsed URL userinfo is rejected with guidance to supported authentication flows. Malformed credential-bearing input is fully redacted in diagnostics. The refactor removes the separate one-use helper from #82490 and keeps the steady-state path small.

The supported alternatives remain intact: explicit Browser HTTP credentials, authenticated browser profiles, and credentials on configured CDP endpoint URLs.

## User Impact

Credential-bearing page URLs now fail fast without exposing the credential in the error. Ordinary navigation still works, and users who need authentication retain the dedicated Browser credential/profile/CDP flows.

## Evidence

- Focused regression lane: 4 test files, 152 tests passed (`navigation-guard`, Browser tool host/node dispatch, Playwright navigation guard, authenticated CDP helpers).
- Real Dev Gateway + OpenAI + Chrome: normal agent Browser navigation passed; a second transcript-proven agent Browser call rejected a credential-bearing URL; valid and malformed inputs stayed redacted; explicit HTTP Basic credentials loaded the protected page; an authenticated CDP profile connected successfully.
- `oxfmt --check`, targeted `oxlint`, and `git diff --check` passed.
- Fresh GPT-5.5 autoreview: no accepted/actionable findings; patch judged correct (0.85 confidence).

Contributor credit is preserved in the commit trailer.
