### PR TITLE
fix(copilot): redact OAuth error response body in fetchJson error messages

### DIFF
--- a/src/llm/utils/oauth/github-copilot.test.ts
+++ b/src/llm/utils/oauth/github-copilot.test.ts
@@ -309,4 +309,43 @@ describe("GitHub Copilot OAuth error body redaction", () => {
     // Structured code is preserved but raw JSON keys are not leaked
     await expect(refreshGitHubCopilotToken("refresh-token")).rejects.toThrow(/code=rate_limited/);
   });
+
+  it("redacts error body via the device code flow", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({ error: "invalid_request", error_description: "missing client_id" }),
+            { status: 400, headers: { "Content-Type": "application/json" } },
+          ),
+      ),
+    );
+
+    await expect(testing.startDeviceFlow("github.com")).rejects.toThrow(
+      "GitHub Copilot device code request failed with status 400",
+    );
+    await expect(testing.startDeviceFlow("github.com")).rejects.not.toThrow(/error_description/);
+  });
+
+  it("handles non-JSON error bodies with bounded detail", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response("Internal Server Error", {
+            status: 500,
+            headers: { "Content-Type": "text/plain" },
+          }),
+      ),
+    );
+
+    // For non-JSON bodies the detail is the body text itself (bounded by readResponseTextLimited).
+    // The error message should include the status code and the bounded body as detail.
+    await expect(refreshGitHubCopilotToken("refresh-token")).rejects.toThrow(
+      /GitHub Copilot token refresh request failed with status 500/,
+    );
+    // Raw JSON syntax like {"error": must never appear for non-JSON responses
+    await expect(refreshGitHubCopilotToken("refresh-token")).rejects.not.toThrow(/\{"error"/);
+  });
 });

--- a/src/llm/utils/oauth/github-copilot.test.ts
+++ b/src/llm/utils/oauth/github-copilot.test.ts
@@ -42,6 +42,7 @@ function stubHangingFetch(timeoutMs: number): void {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
@@ -264,88 +265,120 @@ describe("GitHub Copilot OAuth bounded reads", () => {
   });
 });
 
-describe("GitHub Copilot OAuth error body redaction", () => {
-  it("redacts raw JSON response body from non-2xx error messages", async () => {
+describe("GitHub Copilot OAuth error responses", () => {
+  const githubToken = `ghr_${"s".repeat(40)}`;
+
+  function createOversizedOAuthErrorResponse(): {
+    response: Response;
+    cancel: ReturnType<typeof vi.fn>;
+  } {
+    const cancel = vi.fn();
+    const payload =
+      JSON.stringify({
+        error: "invalid_grant",
+        error_description: `refresh_token=${githubToken} was rejected`,
+        refresh_token: githubToken,
+      }) + " ".repeat(32 * 1024);
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(payload));
+      },
+      cancel,
+    });
+    return {
+      response: new Response(body, {
+        status: 400,
+        headers: {
+          "Content-Type": "application/json",
+          "x-request-id": "copilot-request-id",
+        },
+      }),
+      cancel,
+    };
+  }
+
+  async function captureError(promise: Promise<unknown>): Promise<Error> {
+    try {
+      await promise;
+    } catch (error) {
+      if (error instanceof Error) {
+        return error;
+      }
+      throw error;
+    }
+    throw new Error("Expected request to fail");
+  }
+
+  function expectBoundedRedactedError(error: Error, label: string): void {
+    expect(error).toMatchObject({
+      name: "ProviderHttpError",
+      status: 400,
+      code: "invalid_grant",
+      requestId: "copilot-request-id",
+    });
+    expect(error.message).toContain(`${label} (400):`);
+    expect(error.message).toContain("[code=invalid_grant]");
+    expect(error.message).toContain("[request_id=copilot-request-id]");
+    expect(error.message).not.toContain("error_description");
+    expect(error.message).not.toContain(githubToken);
+    const errorBody = (error as Error & { errorBody?: string }).errorBody;
+    expect(errorBody).toBeDefined();
+    expect(errorBody).not.toContain(githubToken);
+    expect(errorBody?.length).toBeLessThanOrEqual(500);
+  }
+
+  it("bounds and redacts device-code HTTP failures", async () => {
+    const { response, cancel } = createOversizedOAuthErrorResponse();
     vi.stubGlobal(
       "fetch",
-      vi.fn(
-        async () =>
-          new Response(
-            JSON.stringify({
-              error: "invalid_grant",
-              error_description: "The authorization code is invalid or expired.",
-            }),
-            { status: 400, headers: { "Content-Type": "application/json" } },
-          ),
-      ),
+      vi.fn(async () => response),
     );
 
-    await expect(refreshGitHubCopilotToken("refresh-token")).rejects.toThrow(
-      "GitHub Copilot token refresh request failed with status 400",
-    );
-    // Raw JSON body keys must not appear in the error message
-    await expect(refreshGitHubCopilotToken("refresh-token")).rejects.not.toThrow(
-      /error_description/,
-    );
+    const error = await captureError(testing.startDeviceFlow("github.com"));
+
+    expectBoundedRedactedError(error, "GitHub Copilot device code request");
+    expect(cancel).toHaveBeenCalledOnce();
   });
 
-  it("includes redacted structured error detail when the body is valid JSON", async () => {
+  it("bounds and redacts device-token HTTP failures", async () => {
+    vi.useFakeTimers();
+    const { response, cancel } = createOversizedOAuthErrorResponse();
     vi.stubGlobal(
       "fetch",
-      vi.fn(
-        async () =>
-          new Response(
-            JSON.stringify({
-              error: { code: "rate_limited", message: "Too many requests" },
-            }),
-            { status: 429, headers: { "Content-Type": "application/json" } },
-          ),
-      ),
+      vi.fn(async () => response),
     );
 
-    await expect(refreshGitHubCopilotToken("refresh-token")).rejects.toThrow(
-      /GitHub Copilot token refresh request failed with status 429/,
+    const pending = captureError(
+      testing.pollForGitHubAccessToken("github.com", "device-code", 0, Date.now() + 5_000),
     );
-    // Structured code is preserved but raw JSON keys are not leaked
-    await expect(refreshGitHubCopilotToken("refresh-token")).rejects.toThrow(/code=rate_limited/);
+    await vi.advanceTimersByTimeAsync(1_200);
+    const error = await pending;
+
+    expectBoundedRedactedError(error, "GitHub Copilot device token request");
+    expect(cancel).toHaveBeenCalledOnce();
   });
 
-  it("redacts error body via the device code flow", async () => {
+  it("bounds and redacts Copilot-token HTTP failures", async () => {
+    const { response, cancel } = createOversizedOAuthErrorResponse();
     vi.stubGlobal(
       "fetch",
-      vi.fn(
-        async () =>
-          new Response(
-            JSON.stringify({ error: "invalid_request", error_description: "missing client_id" }),
-            { status: 400, headers: { "Content-Type": "application/json" } },
-          ),
-      ),
+      vi.fn(async () => response),
     );
 
-    await expect(testing.startDeviceFlow("github.com")).rejects.toThrow(
-      "GitHub Copilot device code request failed with status 400",
-    );
-    await expect(testing.startDeviceFlow("github.com")).rejects.not.toThrow(/error_description/);
+    const error = await captureError(refreshGitHubCopilotToken("refresh-token"));
+
+    expectBoundedRedactedError(error, "GitHub Copilot token refresh request");
+    expect(cancel).toHaveBeenCalledOnce();
   });
 
-  it("handles non-JSON error bodies with bounded detail", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(
-        async () =>
-          new Response("Internal Server Error", {
-            status: 500,
-            headers: { "Content-Type": "text/plain" },
-          }),
-      ),
-    );
+  it("bounds model-list HTTP failures before treating discovery as optional", async () => {
+    const { response, cancel } = createOversizedOAuthErrorResponse();
+    const fetchMock = vi.fn(async () => response);
+    vi.stubGlobal("fetch", fetchMock);
 
-    // For non-JSON bodies the detail is the body text itself (bounded by readResponseTextLimited).
-    // The error message should include the status code and the bounded body as detail.
-    await expect(refreshGitHubCopilotToken("refresh-token")).rejects.toThrow(
-      /GitHub Copilot token refresh request failed with status 500/,
-    );
-    // Raw JSON syntax like {"error": must never appear for non-JSON responses
-    await expect(refreshGitHubCopilotToken("refresh-token")).rejects.not.toThrow(/\{"error"/);
+    await expect(testing.listGitHubCopilotModelIds("copilot-token")).resolves.toEqual([]);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(cancel).toHaveBeenCalledOnce();
   });
 });

--- a/src/llm/utils/oauth/github-copilot.test.ts
+++ b/src/llm/utils/oauth/github-copilot.test.ts
@@ -263,3 +263,50 @@ describe("GitHub Copilot OAuth bounded reads", () => {
     expect(cancel).toHaveBeenCalled();
   });
 });
+
+describe("GitHub Copilot OAuth error body redaction", () => {
+  it("redacts raw JSON response body from non-2xx error messages", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              error: "invalid_grant",
+              error_description: "The authorization code is invalid or expired.",
+            }),
+            { status: 400, headers: { "Content-Type": "application/json" } },
+          ),
+      ),
+    );
+
+    await expect(refreshGitHubCopilotToken("refresh-token")).rejects.toThrow(
+      "GitHub Copilot token refresh request failed with status 400",
+    );
+    // Raw JSON body keys must not appear in the error message
+    await expect(refreshGitHubCopilotToken("refresh-token")).rejects.not.toThrow(
+      /error_description/,
+    );
+  });
+
+  it("includes redacted structured error detail when the body is valid JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              error: { code: "rate_limited", message: "Too many requests" },
+            }),
+            { status: 429, headers: { "Content-Type": "application/json" } },
+          ),
+      ),
+    );
+
+    await expect(refreshGitHubCopilotToken("refresh-token")).rejects.toThrow(
+      /GitHub Copilot token refresh request failed with status 429/,
+    );
+    // Structured code is preserved but raw JSON keys are not leaked
+    await expect(refreshGitHubCopilotToken("refresh-token")).rejects.toThrow(/code=rate_limited/);
+  });
+});

--- a/src/llm/utils/oauth/github-copilot.ts
+++ b/src/llm/utils/oauth/github-copilot.ts
@@ -4,8 +4,8 @@
 
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import {
+  extractProviderErrorDetail,
   readProviderJsonResponse,
-  readProviderTextResponse,
 } from "../../../agents/provider-http-errors.js";
 import {
   nonNegativeSecondsToSafeMilliseconds,
@@ -190,8 +190,10 @@ async function fetchJson(
   const response = await fetchResponse(url, init, operation, options);
   const label = `GitHub Copilot ${operation}`;
   if (!response.ok) {
-    const text = await readProviderTextResponse(response, label);
-    throw new Error(`${response.status} ${response.statusText}: ${text}`);
+    const detail = await extractProviderErrorDetail(response);
+    throw new Error(
+      `${label} failed with status ${response.status}` + (detail ? `: ${detail}` : ""),
+    );
   }
   return readProviderJsonResponse(response, label);
 }

--- a/src/llm/utils/oauth/github-copilot.ts
+++ b/src/llm/utils/oauth/github-copilot.ts
@@ -4,7 +4,7 @@
 
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import {
-  extractProviderErrorDetail,
+  assertOkOrThrowProviderError,
   readProviderJsonResponse,
 } from "../../../agents/provider-http-errors.js";
 import {
@@ -20,8 +20,7 @@ type CopilotCredentials = OAuthCredentials & {
   enterpriseUrl?: string;
 };
 
-const decode = (s: string) => atob(s);
-const CLIENT_ID = decode("SXYxLmI1MDdhMDhjODdlY2ZlOTg=");
+const CLIENT_ID = "Iv1.b507a08c87ecfe98";
 
 const COPILOT_HEADERS = {
   "User-Agent": "GitHubCopilotChat/0.35.0",
@@ -189,12 +188,7 @@ async function fetchJson(
 ): Promise<unknown> {
   const response = await fetchResponse(url, init, operation, options);
   const label = `GitHub Copilot ${operation}`;
-  if (!response.ok) {
-    const detail = await extractProviderErrorDetail(response);
-    throw new Error(
-      `${label} failed with status ${response.status}` + (detail ? `: ${detail}` : ""),
-    );
-  }
+  await assertOkOrThrowProviderError(response, label);
   return readProviderJsonResponse(response, label);
 }
 
@@ -596,5 +590,6 @@ export const githubCopilotOAuthProvider: OAuthProviderInterface = {
 export const testing = {
   enableGitHubCopilotModel,
   listGitHubCopilotModelIds,
+  pollForGitHubAccessToken,
   startDeviceFlow,
 };


### PR DESCRIPTION
## What Problem This Solves

GitHub Copilot's shared OAuth JSON request helper embedded the complete non-2xx response body in an `Error`. A hostile or unexpectedly verbose OAuth endpoint could therefore retain up to 16 MiB in an error/log path and expose credentials returned in JSON fields.

The affected helper owns four operations: device-code creation, device-token polling, Copilot-token exchange, and optional model-list discovery.

## Why This Change Was Made

The final implementation routes the shared `fetchJson` non-OK branch through the existing `assertOkOrThrowProviderError` boundary. That canonical helper already owns bounded error-prefix reads, overflow cancellation, secret redaction, structured code/type/request-id extraction, and the `ProviderHttpError` shape.

Successful response parsing is unchanged. Optional model-list failures still return the static fallback, and the separate model-policy request remains unchanged because it never formats the response body and already cancels it.

Thanks @ZOOWH for identifying the leak and supplying the initial patch.

## User Impact

Copilot login and token-refresh failures retain actionable HTTP status, provider code, and request-id metadata without embedding the full raw response or credential values. Oversized error bodies are cancelled after a small diagnostic prefix instead of being buffered to the successful-response limit.

## Evidence

Exact reviewed head: `66fa0e5209b16f1749a368d28bea6aea0dded652`

- Blacksmith Testbox through Crabbox `tbx_01kx4vws97n2fs1esghbxmxg29`: `src/llm/utils/oauth/github-copilot.test.ts`, 17/17 passed.
- Real Node loopback proof on the same Testbox exercised all four operations. Each endpoint streamed a 128 KiB secret-bearing JSON failure; the client cancelled every response after 17,590 bytes, emitted `ProviderHttpError`, preserved status/code/request-id, and omitted the full synthetic credential from both `message` and `errorBody`.
- `check:changed` passed the `core` and `coreTests` lanes on the same Testbox, including production/test tsgo and oxlint.
- [GitHub Actions CI run 29063528289](https://github.com/openclaw/openclaw/actions/runs/29063528289): 65 successful, 31 skipped, 1 neutral, zero failed or pending checks on the exact head.
- Fresh autoreview against current `origin/main`: clean, correctness 0.88.
- Official contract check: [GitHub's device-flow documentation](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps) documents the JSON device-code/token responses and polling error codes used by these callers.

No production GitHub credential was needed for the failure proof; the loopback server deterministically exercised oversized and secret-bearing responses without exposing a real account token.

- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
