### PR TITLE
fix(tool-call-repair): parseXmlishPlainTextToolCallBlockAt rejects function calls with zero parameters

### DIFF
--- a/packages/tool-call-repair/src/payload.ts
+++ b/packages/tool-call-repair/src/payload.ts
@@ -323,9 +323,6 @@ function parseXmlishPlainTextToolCallBlockEndAt(text: string, start: number): nu
     parameterCount += 1;
     cursor = parameter.end;
   }
-  if (parameterCount === 0) {
-    return null;
-  }
   return opening.allowsOptionalXmlishClose
     ? consumeOptionalXmlishFunctionClose(text, cursor)
     : consumeXmlishFunctionClose(text, cursor);
@@ -369,10 +366,6 @@ function parseXmlishPlainTextToolCallBlockAt(
     parameterCount += 1;
     cursor = parameter.end;
   }
-  if (parameterCount === 0) {
-    return null;
-  }
-
   const end = opening.allowsOptionalXmlishClose
     ? consumeOptionalXmlishFunctionClose(text, cursor)
     : consumeXmlishFunctionClose(text, cursor);


### PR DESCRIPTION
### Description

In `packages/tool-call-repair/src/payload.ts`, the XML-ish parser checks for parameter blocks in a tool call:

```typescript
function parseXmlishPlainTextToolCallBlockEndAt(text: string, start: number): number | null {
  const opening = parseXmlishOpening(text, start);
  if (!opening) {
    return null;
  }

  let cursor = opening.end;
  let parameterCount = 0;
  while (true) {
    const parameter = findXmlishParameterBlock(text, cursor);
    if (!parameter) {
      break;
    }
    parameterCount += 1;
    cursor = parameter.end;
  }
  if (parameterCount === 0) {
    return null;
  }
```

And similarly inside `parseXmlishPlainTextToolCallBlockAt`:
```typescript
  if (parameterCount === 0) {
    return null;
  }
```

### Impact

If an LLM makes a tool call with zero parameters (e.g. `<function=get_system_info></function>`), `parameterCount` is `0`, causing the parser to return `null`. This prevents the tool-call-repair module from recognizing or repairing any XML-ish tool calls that do not take arguments.

### Suggested Fix

Remove the `parameterCount === 0` rejection check so that function calls without arguments are parsed successfully.
