### PR TITLE
fix(ai): direct require('node:fs') in getProcEnv breaks browser bundlers

### DIFF
--- a/packages/ai/src/env-api-keys.ts
+++ b/packages/ai/src/env-api-keys.ts
@@ -89,12 +89,14 @@ function getProcEnv(key: string): string | undefined {
   if (procEnvCache === null) {
     procEnvCache = new Map();
     try {
-      const { readFileSync } = require("node:fs") as typeof import("node:fs");
-      const data = readFileSync("/proc/self/environ", "utf-8");
-      for (const entry of data.split("\0")) {
-        const idx = entry.indexOf("=");
-        if (idx > 0) {
-          procEnvCache.set(entry.slice(0, idx), entry.slice(idx + 1));
+      const fsModule = loadNodeBuiltinModule(NODE_FS_SPECIFIER) as typeof import("node:fs") | null;
+      if (fsModule) {
+        const data = fsModule.readFileSync("/proc/self/environ", "utf-8");
+        for (const entry of data.split("\0")) {
+          const idx = entry.indexOf("=");
+          if (idx > 0) {
+            procEnvCache.set(entry.slice(0, idx), entry.slice(idx + 1));
+          }
         }
       }
     } catch {


### PR DESCRIPTION
### Description

In `packages/ai/src/env-api-keys.ts`, the file carefully avoids top-level imports of Node.js modules to ensure browser and Vite builds do not fail.
However, inside the `getProcEnv` helper, it performs a direct, un-guarded `require("node:fs")`:

```typescript
function getProcEnv(key: string): string | undefined {
  // ...
  if (procEnvCache === null) {
    procEnvCache = new Map();
    try {
      const { readFileSync } = require("node:fs") as typeof import("node:fs");
      const data = readFileSync("/proc/self/environ", "utf-8");
```

### Impact

Vite and other static bundlers scan source code for occurrences of `require("node:fs")`. Even if wrapped in a `try...catch` block and guarded by runtime checks, this direct literal string import will trigger static dependency resolution warnings or compile/bundle failures in non-Node browser environments.

### Suggested Fix

Use the existing `loadNodeBuiltinModule` wrapper function which handles dynamic require safely without exposing raw string literals to static bundlers:
```typescript
      const fsModule = loadNodeBuiltinModule("node:fs") as typeof import("node:fs") | null;
      if (!fsModule) {
        return undefined;
      }
      const data = fsModule.readFileSync("/proc/self/environ", "utf-8");
```
