### PR TITLE
fix(msteams): pass timeoutMs to attachment submodule fetch calls

### DIFF
--- a/extensions/msteams/src/attachments/graph.test.ts
+++ b/extensions/msteams/src/attachments/graph.test.ts
@@ -287,6 +287,32 @@ describe("downloadMSTeamsGraphMedia hosted content $value fallback", () => {
       expect((headers as Headers).get("User-Agent")).toMatch(
         /^teams\.ts\[apps\]\/.+ OpenClaw\/.+$/,
       );
+      expect(call.timeoutMs).toBe(30_000);
+    }
+  });
+
+  it("passes timeoutMs to all guarded Graph attachment fetches", async () => {
+    mockGraphMediaFetch({
+      messageId: "msg-timeout",
+      hostedContents: [{ id: "hosted-t1", contentType: "image/png" }],
+      valueResponses: {
+        "/hostedContents/hosted-t1/$value": new Response(
+          Buffer.from([0x89, 0x50, 0x4e, 0x47]) as BodyInit,
+          { status: 200 },
+        ),
+      },
+    });
+
+    await downloadMSTeamsGraphMedia({
+      messageUrl: "https://graph.microsoft.com/v1.0/chats/c/messages/msg-timeout",
+      tokenProvider: { getAccessToken: vi.fn(async () => "test-token") },
+      maxBytes: 10 * 1024 * 1024,
+    });
+
+    const guardCalls = vi.mocked(fetchWithSsrFGuard).mock.calls;
+    expect(guardCalls.length).toBeGreaterThanOrEqual(3);
+    for (const [call] of guardCalls) {
+      expect(call).toMatchObject({ timeoutMs: 30_000 });
     }
   });
 

--- a/extensions/msteams/src/attachments/graph.ts
+++ b/extensions/msteams/src/attachments/graph.ts
@@ -10,6 +10,10 @@ import {
   normalizeOptionalString,
   uniqueStrings,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+// Matches the sibling graph.ts top-level GRAPH_REQUEST_TIMEOUT_MS; keeps all
+// Graph API calls in the attachments submodule bounded on accept-but-no-reply.
+const MSTEAMS_GRAPH_ATTACHMENT_TIMEOUT_MS = 30_000;
+
 import { getMSTeamsRuntime } from "../runtime.js";
 import { ensureUserAgentHeader } from "../user-agent.js";
 import { downloadMSTeamsAttachments } from "./download.js";
@@ -138,6 +142,7 @@ async function fetchGraphCollection(params: {
     },
     policy: params.ssrfPolicy,
     auditContext: "msteams.graph.collection",
+    timeoutMs: MSTEAMS_GRAPH_ATTACHMENT_TIMEOUT_MS,
   });
   try {
     const status = response.status;
@@ -218,6 +223,7 @@ async function downloadGraphHostedContent(params: {
         },
         policy: params.ssrfPolicy,
         auditContext: "msteams.graph.hostedContent.value",
+        timeoutMs: MSTEAMS_GRAPH_ATTACHMENT_TIMEOUT_MS,
       });
       try {
         if (!valRes.ok) {
@@ -303,6 +309,7 @@ export async function downloadMSTeamsGraphMedia(params: {
       },
       policy: ssrfPolicy,
       auditContext: "msteams.graph.message",
+      timeoutMs: MSTEAMS_GRAPH_ATTACHMENT_TIMEOUT_MS,
     });
     try {
       messageStatus = msgRes.status;

--- a/extensions/msteams/src/attachments/shared.ts
+++ b/extensions/msteams/src/attachments/shared.ts
@@ -583,6 +583,9 @@ export async function resolveAndValidateIP(
 
 /** Maximum number of redirects to follow in safeFetch. */
 const MAX_SAFE_REDIRECTS = 5;
+// Keeps the SSRF-guarded attachment download path bounded; a stalled CDN/Graph
+// host can otherwise hold the lane open until the process is restarted.
+const MSTEAMS_ATTACHMENT_FETCH_TIMEOUT_MS = 30_000;
 /**
  * Fetch a URL with redirect: "manual", validating each redirect target
  * against the hostname allowlist and optional DNS-resolved IP (anti-SSRF).
@@ -646,6 +649,7 @@ export async function safeFetch(params: {
       retainAuthorizationRedirectHostnameAllowlist:
         resolveRetainedAuthorizationRedirectHostnameAllowlist(params.authorizationAllowHosts),
       auditContext: "msteams.attachment",
+      timeoutMs: MSTEAMS_ATTACHMENT_FETCH_TIMEOUT_MS,
     });
     return responseWithRelease(guarded.response, guarded.release);
   }


### PR DESCRIPTION
## What Problem This Solves

The `attachments/` submodule of the MSTeams plugin contains several `fetchWithSsrFGuard`
calls that have no `timeoutMs` and no `signal`. If a remote endpoint (Graph API, CDN,
Bot Framework service URL) accepts the TCP connection but never sends an HTTP response,
the call blocks indefinitely.

Three call sites are in `attachments/graph.ts`:
- `fetchGraphCollection`: fetches the `/hostedContents` metadata list for a Teams message
- `downloadGraphHostedContent` inner `$value` fetch: downloads the actual binary bytes
  for each hosted content item (images, documents)
- `downloadMSTeamsGraphMedia` message fetch: fetches the message JSON from Graph to
  enumerate attachments

One call site is in `attachments/shared.ts` (`safeFetch`), which is the SSRF-guarded
attachment download entry point used by the Bot Framework path
(`fetchBotFrameworkAttachmentInfo`, `saveBotFrameworkAttachmentView` via
`safeFetchWithPolicy`). This covers the remaining 2 call sites from the "6 call sites"
report.

## Why This Change Was Made

`fetchWithSsrFGuard` accepts a top-level `timeoutMs` parameter
(`src/infra/net/fetch-guard.ts:80`). The sibling top-level `graph.ts` already defines
`GRAPH_REQUEST_TIMEOUT_MS = 30_000` and passes it to both its Graph API calls (lines 69
and 135), with tests asserting `timeoutMs: 30_000`. The attachments submodule had no
equivalent protection.

- `attachments/graph.ts`: `MSTEAMS_GRAPH_ATTACHMENT_TIMEOUT_MS = 30_000` added; forwarded
  to all three `fetchWithSsrFGuard` call sites.
- `attachments/shared.ts`: `MSTEAMS_ATTACHMENT_FETCH_TIMEOUT_MS = 30_000` added; forwarded
  to the single `fetchWithSsrFGuard` call in `safeFetch`, covering both Bot Framework
  `safeFetchWithPolicy` paths.

Both constants use the same 30-second value as the sibling `GRAPH_REQUEST_TIMEOUT_MS`.

## User Impact

**Before:** Any stalled Graph API endpoint, CDN, or Bot Framework service URL during
attachment download hangs the processing of that Teams message indefinitely. Under
concurrent inbound messages with attachments, stalled fetches accumulate. For the Bot
Framework path (personal DMs), a stalled `/v3/attachments/{id}` endpoint also hangs
indefinitely.

**After:** All attachment-related `fetchWithSsrFGuard` calls abort after 30 seconds with
a timeout error. The error is caught and logged; the affected attachment is skipped. Other
messages continue processing normally.

## Evidence

Branch: `fix/msteams-attachment-fetch-timeout`  
Base: `upstream/main` (`baa009e26f`)  
Node: v22.22.0 — macOS Darwin 24.3.0 arm64

### Regression tests

```
$ node scripts/run-vitest.mjs extensions/msteams/src/attachments/graph.test.ts

 RUN  v4.1.9 /Users/shen/Documents/GitHub/openclaw

 Test Files  1 passed (1)
      Tests  14 passed (14)
   Start at  23:18:08
   Duration  1.21s (transform 832ms, setup 246ms, import 662ms, tests 214ms, environment 0ms)
```

14 tests pass. The existing `"adds the OpenClaw User-Agent to guarded Graph attachment
fetches"` test now also asserts `call.timeoutMs === 30_000` for every `fetchWithSsrFGuard`
call. A new dedicated test `"passes timeoutMs to all guarded Graph attachment fetches"`
exercises a message + hostedContents + $value fetch path and verifies all 3 call sites
receive `timeoutMs: 30_000`.

The `safeFetch` `timeoutMs` in `shared.ts` is not directly unit tested in this PR because
the existing `shared.test.ts` fixture feeds `fetchFn` mocks that flow through
`fetchWithSsrFGuard` as `fetchImpl`; isolating the `timeoutMs` parameter would require
restructuring the test harness. The `graph.ts` test coverage confirms the 30-second policy
is consistent; `shared.ts` follows the same pattern.

### Source-level proof

- `attachments/graph.ts`: `MSTEAMS_GRAPH_ATTACHMENT_TIMEOUT_MS = 30_000` forwarded to
  `auditContext: "msteams.graph.collection"`, `"msteams.graph.hostedContent.value"`, and
  `"msteams.graph.message"`.
- `attachments/shared.ts`: `MSTEAMS_ATTACHMENT_FETCH_TIMEOUT_MS = 30_000` forwarded to
  `auditContext: "msteams.attachment"` in `safeFetch`.

### Diff summary

```
extensions/msteams/src/attachments/graph.ts      |  7 +++++++ (constant + 3x timeoutMs field)
extensions/msteams/src/attachments/shared.ts     |  4 ++++ (constant + timeoutMs field)
extensions/msteams/src/attachments/graph.test.ts | 26 ++++++++ (updated assertion + 1 new test)
```

### Reproduction sketch (end-to-end, not run)

1. Stand up a TCP server that accepts connections and sends a valid TLS handshake but
   never emits an HTTP response.
2. Route `graph.microsoft.com` to that server.
3. Send an MSTeams message containing an attachment to an OpenClaw agent.
4. **Before fix:** the Graph collection and hosted content fetches hang indefinitely.
5. **After fix:** both abort after 30 s; warnings are logged; the message is delivered
   without media.

What was not tested: live Graph API or Bot Framework stall scenario with a real Microsoft
365 tenant. Crabbox/Testbox remote CI was not available at submission time.

- [x] AI-assisted (Cursor / Claude Sonnet 4.6)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
