### PR TITLE
fix(ai): fold case in OpenAI reasoning-effort matching (#102908)

### DIFF
--- a/packages/ai/src/providers/openai-reasoning-effort.test.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.test.ts
@@ -111,4 +111,26 @@ describe("OpenAI reasoning effort support", () => {
     expect(resolveOpenAIReasoningEffortForModel({ model, effort: "none" })).toBeUndefined();
     expect(resolveOpenAIReasoningEffortForModel({ model, effort: "high" })).toBe("high");
   });
+
+  it("matches mixed-case requested efforts against supported lists (#102908)", () => {
+    const model = { provider: "openai", id: "gpt-5.6" };
+
+    expect(resolveOpenAIReasoningEffortForModel({ model, effort: "High" })).toBe("high");
+    expect(resolveOpenAIReasoningEffortForModel({ model, effort: "XHIGH" })).toBe("xhigh");
+    // Mixed case must also keep the disabled semantics, not fall through the ladder.
+    expect(resolveOpenAIReasoningEffortForModel({ model, effort: "None" })).toBeUndefined();
+  });
+
+  it("folds case in compat-declared supported efforts (#102908)", () => {
+    const model = {
+      provider: "xai",
+      id: "grok-4.3",
+      compat: { supportedReasoningEfforts: ["Low", "MEDIUM", "High"] },
+    };
+
+    expect(resolveOpenAISupportedReasoningEfforts(model)).toEqual(["low", "medium", "high"]);
+    // On main the mixed-case list fails .includes(), so "low" mis-ladders to a
+    // different effort instead of matching the declared "Low".
+    expect(resolveOpenAIReasoningEffortForModel({ model, effort: "low" })).toBe("low");
+  });
 });

--- a/packages/ai/src/providers/openai-reasoning-effort.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.ts
@@ -5,7 +5,7 @@
  */
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import {
-  normalizeStringEntries,
+  normalizeStringEntriesLower,
   uniqueStrings,
 } from "@openclaw/normalization-core/string-normalization";
 
@@ -59,7 +59,10 @@ export function isOpenAIGpt55Model(model: OpenAIReasoningModel): boolean {
 
 /** Normalize user-facing reasoning effort names to API effort names. */
 export function normalizeOpenAIReasoningEffort(effort: string): string {
-  return effort === "minimal" ? "minimal" : effort;
+  // Effort names are matched against lowercase supported lists and sent to the API
+  // lowercase; fold case here so "High"/"XHIGH" from user-authored config or plugin
+  // callers match instead of silently falling through the support ladder (#102908).
+  return normalizeLowercaseStringOrEmpty(effort);
 }
 
 function readCompatReasoningEfforts(compat: unknown): OpenAIApiReasoningEffort[] | undefined {
@@ -73,8 +76,10 @@ function readCompatReasoningEfforts(compat: unknown): OpenAIApiReasoningEffort[]
   if (!Array.isArray(raw)) {
     return undefined;
   }
+  // Compat lists come from user-authored model config; fold case so entries like
+  // "High" match the lowercase effort names used everywhere else (#102908).
   const supported = uniqueStrings(
-    normalizeStringEntries(raw.filter((value) => typeof value === "string")),
+    normalizeStringEntriesLower(raw.filter((value) => typeof value === "string")),
   );
   return supported.length > 0 ? supported : undefined;
 }


### PR DESCRIPTION
## What Problem This Solves

`normalizeOpenAIReasoningEffort` (`packages/ai/src/providers/openai-reasoning-effort.ts`) passes effort names through unchanged, and `readCompatReasoningEfforts` keeps user-authored `compat.supportedReasoningEfforts` entries as written. So a mixed-case requested effort (`"High"`) or a mixed-case compat entry (`"Low"`) fails the lowercase `.includes()` matching in `resolveOpenAIReasoningEffortForModel` / `supportsOpenAIReasoningEffort`. The miss doesn't fail loudly — it silently falls through the support ladder and returns a **different effort than the one the model actually supports** (e.g. requested `low` against a declared `["Low","MEDIUM","High"]` mis-ladders to another tier). Fixes #102908.

## Why This Change Was Made

Fold case on both sides of the boundary, using the normalization helpers this package already imports: `normalizeOpenAIReasoningEffort` now lowercases (efforts are matched against lowercase lists and sent to the API lowercase), and compat lists use the existing `normalizeStringEntriesLower` sibling helper. Disabled semantics (`"None"`/`"OFF"`) also work case-insensitively instead of falling through the ladder into an enabled effort. No new options or API surface; internal lowercase callers are byte-for-byte unaffected.

## User Impact

Operators writing `reasoningEffort`/`supportedReasoningEfforts` values in config with any casing get the effort they asked for, instead of a silently substituted tier (which changes model behavior and cost).

## Evidence

**Live OpenAI-compatible request run (wire capture, full recipe in PR comment):** real agent turn via `pnpm openclaw agent --local --thinking high` against a local OpenAI-compatible endpoint with user-authored mixed-case `compat.supportedReasoningEfforts: ["Low","MEDIUM","High"]`:

```
BEFORE (main):    POST /v1/chat/completions  → "reasoning_effort": "Low"    ← asked high, silently mis-laddered
AFTER  (this PR): POST /v1/chat/completions  → "reasoning_effort": "high"   ← correct tier and case
```

Two new regression tests **fail on current `main`** and pass with this PR:
```
main:    × matches mixed-case requested efforts     — expected 'low' to be 'high'   (mis-laddered)
         × folds case in compat-declared efforts    — ['Low','MEDIUM','High'] ≠ ['low','medium','high']
this PR: 12/12 pass
```
Consumer suites checked: `openai-responses-shared.test.ts` green; `stream-wrappers/openai.test.ts` has 2 pre-existing local failures (Codex attribution/user-agent, fail identically with main's reasoning-effort file — verified unrelated). `oxfmt`/`oxlint` clean.

