### PR TITLE
fix(workshop): keep approval target names UTF-16 safe

### DIFF
--- a/docs/plugins/plugin-permission-requests.md
+++ b/docs/plugins/plugin-permission-requests.md
@@ -77,7 +77,7 @@ export default definePluginEntry({
 Write prompt text for the person who will approve the action:
 
 - Keep `title` short and action-focused; the Gateway caps it at 80 characters.
-- Keep `description` specific and bounded; the Gateway caps it at 256
+- Keep `description` specific and bounded; the Gateway caps it at 512
   characters.
 - Include the action, target, and risk. Do not include secrets, tokens, or
   private payloads that should not appear in chat approval surfaces.

--- a/src/skills/workshop/policy.test.ts
+++ b/src/skills/workshop/policy.test.ts
@@ -70,46 +70,18 @@ describe("resolveSkillWorkshopToolApproval", () => {
     );
   });
 
-  it("bounds approval metadata without dropping required proposal facts", async () => {
+  it("bounds approval metadata without splitting UTF-16 surrogates", async () => {
     const workspaceDir = await tempDirs.make("openclaw-skill-workshop-policy-long-name-");
     const description = "d".repeat(160);
-    const proposal = await proposeCreateSkill({
-      workspaceDir,
-      name: "n".repeat(240),
-      description,
-      content: "# Long name\n",
-    });
-
-    const result = await resolveSkillWorkshopToolApproval({
-      toolName: "skill_workshop",
-      toolParams: { action: "apply", proposal_id: proposal.record.id },
-      workspaceDir,
-    });
-    const approvalDescription = result?.requireApproval?.description ?? "";
-
-    expect(approvalDescription.length).toBeLessThanOrEqual(512);
-    expect(approvalDescription).toContain(`Proposal ID: ${proposal.record.id}`);
-    expect(approvalDescription).toContain(`Description: ${description}`);
-    expect(approvalDescription).toContain("Support files: 0");
-    expect(approvalDescription).toContain(
-      `Body size: ${(Buffer.byteLength(proposal.content, "utf8") / 1024).toFixed(1)} KB`,
-    );
-    expect(approvalDescription).toContain("Target skill: nnn");
-  });
-
-  it("keeps truncated target skill names UTF-16 safe", async () => {
-    const workspaceDir = await tempDirs.make("openclaw-skill-workshop-policy-utf16-");
-    const description = "d".repeat(160);
-    const content = "# Unicode name\n";
-    const proposalIdLength = 60 + 1 + 8 + 1 + 10;
-    const fixedLines = [
-      `Proposal ID: ${"p".repeat(proposalIdLength)}`,
+    const content = "# Long name\n";
+    // Long proposal ids use a 60-character skill key, 8-character date, and 10-character suffix.
+    const fixedLength = [
+      `Proposal ID: ${"p".repeat(60)}-00000000-0000000000`,
+      "Target skill: ",
       `Description: ${description}`,
       "Support files: 0",
       `Body size: ${(Buffer.byteLength(content, "utf8") / 1024).toFixed(1)} KB`,
-    ];
-    const skillPrefix = "Target skill: ";
-    const fixedLength = fixedLines.join("\n").length + skillPrefix.length + fixedLines.length;
+    ].join("\n").length;
     const availableSkillNameLength = Math.max(
       1,
       PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH - fixedLength,
@@ -127,10 +99,23 @@ describe("resolveSkillWorkshopToolApproval", () => {
       toolParams: { action: "apply", proposal_id: proposal.record.id },
       workspaceDir,
     });
+    const approvalDescription = result?.requireApproval?.description ?? "";
+
+    expect(approvalDescription.length).toBeLessThanOrEqual(
+      PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH,
+    );
+    expect(approvalDescription).toContain(`Proposal ID: ${proposal.record.id}`);
+    expect(approvalDescription).toContain(`Description: ${description}`);
+    expect(approvalDescription).toContain("Support files: 0");
+    expect(approvalDescription).toContain(
+      `Body size: ${(Buffer.byteLength(proposal.content, "utf8") / 1024).toFixed(1)} KB`,
+    );
     const targetLine = result?.requireApproval?.description.split("\n")[1] ?? "";
 
     expect(targetLine).toBe(`Target skill: ${prefix}…`);
-    expect(targetLine).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+    expect(approvalDescription).not.toMatch(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/,
+    );
   });
 
   it("renders proposal-controlled fields without approval-line injection", async () => {

--- a/src/skills/workshop/policy.test.ts
+++ b/src/skills/workshop/policy.test.ts
@@ -74,14 +74,15 @@ describe("resolveSkillWorkshopToolApproval", () => {
     const workspaceDir = await tempDirs.make("openclaw-skill-workshop-policy-long-name-");
     const description = "d".repeat(160);
     const content = "# Long name\n";
-    // Long proposal ids use a 60-character skill key, 8-character date, and 10-character suffix.
-    const fixedLength = [
-      `Proposal ID: ${"p".repeat(60)}-00000000-0000000000`,
-      "Target skill: ",
+    const proposalIdLength = 60 + 1 + 8 + 1 + 10;
+    const fixedLines = [
+      `Proposal ID: ${"p".repeat(proposalIdLength)}`,
       `Description: ${description}`,
       "Support files: 0",
       `Body size: ${(Buffer.byteLength(content, "utf8") / 1024).toFixed(1)} KB`,
-    ].join("\n").length;
+    ];
+    const skillPrefix = "Target skill: ";
+    const fixedLength = fixedLines.join("\n").length + skillPrefix.length + fixedLines.length;
     const availableSkillNameLength = Math.max(
       1,
       PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH - fixedLength,

--- a/src/skills/workshop/policy.test.ts
+++ b/src/skills/workshop/policy.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH } from "../../infra/plugin-approvals.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -94,6 +95,42 @@ describe("resolveSkillWorkshopToolApproval", () => {
       `Body size: ${(Buffer.byteLength(proposal.content, "utf8") / 1024).toFixed(1)} KB`,
     );
     expect(approvalDescription).toContain("Target skill: nnn");
+  });
+
+  it("keeps truncated target skill names UTF-16 safe", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skill-workshop-policy-utf16-");
+    const description = "d".repeat(160);
+    const content = "# Unicode name\n";
+    const proposalIdLength = 60 + 1 + 8 + 1 + 10;
+    const fixedLines = [
+      `Proposal ID: ${"p".repeat(proposalIdLength)}`,
+      `Description: ${description}`,
+      "Support files: 0",
+      `Body size: ${(Buffer.byteLength(content, "utf8") / 1024).toFixed(1)} KB`,
+    ];
+    const skillPrefix = "Target skill: ";
+    const fixedLength = fixedLines.join("\n").length + skillPrefix.length + fixedLines.length;
+    const availableSkillNameLength = Math.max(
+      1,
+      PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH - fixedLength,
+    );
+    const prefix = "n".repeat(availableSkillNameLength - 2);
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      name: `${prefix}\u{1F600}tail`,
+      description,
+      content,
+    });
+
+    const result = await resolveSkillWorkshopToolApproval({
+      toolName: "skill_workshop",
+      toolParams: { action: "apply", proposal_id: proposal.record.id },
+      workspaceDir,
+    });
+    const targetLine = result?.requireApproval?.description.split("\n")[1] ?? "";
+
+    expect(targetLine).toBe(`Target skill: ${prefix}…`);
+    expect(targetLine).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
   });
 
   it("renders proposal-controlled fields without approval-line injection", async () => {

--- a/src/skills/workshop/policy.ts
+++ b/src/skills/workshop/policy.ts
@@ -1,5 +1,6 @@
 // Workshop policy helpers validate generated skill drafts against workspace policy.
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH } from "../../infra/plugin-approvals.js";
 import type { PluginHookBeforeToolCallResult } from "../../plugins/hook-before-tool-call-result.js";
@@ -92,7 +93,7 @@ function buildLifecycleApprovalDescription(params: {
   const skillName =
     requestedSkillName.length <= availableSkillNameLength
       ? requestedSkillName
-      : `${requestedSkillName.slice(0, Math.max(0, availableSkillNameLength - 1))}…`;
+      : `${truncateUtf16Safe(requestedSkillName, Math.max(0, availableSkillNameLength - 1))}…`;
   return [fixedLines[0], `${skillPrefix}${skillName}`, ...fixedLines.slice(1)].join("\n");
 }
 


### PR DESCRIPTION
## What Problem This Solves

Skill Workshop lifecycle approvals bound the `Target skill:` line to the 512-UTF-16-code-unit approval-description limit with raw JavaScript `slice`. If an astral character crossed that exact cut, the prompt contained a lone surrogate and could render `�` instead of a valid target name.

## Why This Change Was Made

`buildLifecycleApprovalDescription` is the source formatter for apply, reject, and quarantine approval payloads. This change replaces only its raw target-name slice with the existing shared `truncateUtf16Safe` helper from `@openclaw/normalization-core/utf16-slice`.

That is the best owner boundary: proposal lookup, lifecycle policy, persistence, gateway limits, and renderers remain unchanged, while every affected approval payload becomes valid before it leaves the formatter. Downstream UI or gateway sanitization would be later, duplicated, and incomplete.

The regression exercises the real `proposeCreateSkill` → persisted proposal → `resolveSkillWorkshopToolApproval` path. It extends the existing metadata-bound test instead of adding a near-duplicate scenario, preserves every required approval fact, checks the shared 512-unit constant, and rejects lone high or low surrogates.

The docs correction changes the generic plugin approval description limit from the stale 256 value to the runtime and gateway-protocol value of 512.

## User Impact

Operators see a clean ellipsis-truncated target name for long Unicode skill names. Short names, approval policy, allowed decisions, timeout behavior, proposal lookup/state, and apply/reject/quarantine behavior do not change.

## Evidence

Frozen reviewed head: `3e7224efcbcfb8f23f16e4ba44ee10c4f78b8c49`.

Untrusted contributor code was exercised only in sanitized AWS Crabbox leases with public networking, no Tailscale, no instance role, isolated `HOME`, pinned Node/pnpm, `--fresh-pr`, and `--no-hydrate`.

- [Exact-final-head non-test Node behavior proof](https://crabbox.openclaw.ai/portal/runs/run_e069f47836f4) on AWS lease `cbx_94657e95da1f`: created persisted boundary and short-control proposals, resolved the exported approval payload, and checked the behavior contract without Vitest. Boundary output was at most 512 UTF-16 code units, kept the complete prefix plus one ellipsis, contained every approval fact, and had no unpaired surrogate; the short control remained unchanged.
- [Focused GREEN](https://crabbox.openclaw.ai/portal/runs/run_c6f44a064850): `pnpm test src/skills/workshop/policy.test.ts` — 1 file, 4/4 tests passed.
- [Old-slice RED](https://crabbox.openclaw.ai/portal/runs/run_6b0823018ad0): in a fresh checkout, restoring only the old raw `slice` made exactly the boundary regression fail; the received target line contained `�` before the ellipsis.
- [Full Workshop GREEN](https://crabbox.openclaw.ai/portal/runs/run_b55a74f632ba): `pnpm test src/skills/workshop` — 2 files, 40/40 tests passed.
- [Exact-final-head CI](https://github.com/openclaw/openclaw/actions/runs/29033553042): success; 44 jobs succeeded and 11 skipped. The complete PR rollup is 65 success, 38 skipped, 1 neutral, 2 cancelled stale automation runs, and 0 pending/failing.
- [OpenGrep attempt 2](https://github.com/openclaw/openclaw/actions/runs/29033553021): success after retrying the first attempt's GitHub-release lookup/SARIF infrastructure failure.
- Source-blind behavior validation: PASS — 11/11 contract clauses, no accepted findings or evidence gaps.
- Fresh full-branch autoreview: clean, no accepted/actionable findings, correctness confidence 0.88. Independent exact-head review also found no blocker.
- `node scripts/check-docs-mdx.mjs docs/plugins/plugin-permission-requests.md`: passed.
- `git diff --check`: clean.

No external service participates in this formatter path. Browser UI automation was not used; the live proof observes the exported approval payload consumed by the approval runtime/UI.

## Root Cause and Provenance

The raw bounded slice was introduced in #100498 (`f53103de72da09185b27a58618ece136a5667c18`). JavaScript string indices are UTF-16 code units, so the cut could land between a valid high/low surrogate pair. This PR follows the same shared-helper fix class as #102816 but covers the distinct Skill Workshop approval formatter. A live related-PR search found no same-point open fix.

## Risk / Compatibility

Risk is low and display-only. At a pair-splitting boundary, the visible prefix can be one code unit shorter so the astral character is omitted whole before the existing ellipsis. There are no config, schema, storage, protocol, dependency, provider, security-boundary, or operator-workflow changes.

Landed through the repository native wrapper as `b451d8b5e59539c21009947c23e203df7d438943` after exact-head Testbox preparation and merge verification.
