### PR TITLE
fix(inworld): add timeout to voices list request

### DIFF
--- a/extensions/inworld/tts.test.ts
+++ b/extensions/inworld/tts.test.ts
@@ -192,6 +192,22 @@ describe("listInworldVoices", () => {
 
     expect(lastGuardRequest().url).toBe("https://api.inworld.ai/voices/v1/voices?languages=EN_US");
   });
+
+  it("defaults to a bounded timeout for voice list requests", async () => {
+    queueGuardedResponse(new Response(JSON.stringify({ voices: [] }), { status: 200 }));
+
+    await listInworldVoices({ apiKey: "test-key" });
+
+    expect(lastGuardRequest().timeoutMs).toBe(30_000);
+  });
+
+  it("preserves an explicit timeout for voice list requests", async () => {
+    queueGuardedResponse(new Response(JSON.stringify({ voices: [] }), { status: 200 }));
+
+    await listInworldVoices({ apiKey: "test-key", timeoutMs: 5_000 });
+
+    expect(lastGuardRequest().timeoutMs).toBe(5_000);
+  });
 });
 
 describe("inworldTTS", () => {

--- a/extensions/inworld/tts.ts
+++ b/extensions/inworld/tts.ts
@@ -8,9 +8,6 @@ import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 const DEFAULT_INWORLD_BASE_URL = "https://api.inworld.ai";
 export const DEFAULT_INWORLD_VOICE_ID = "Sarah";
 export const DEFAULT_INWORLD_MODEL_ID = "inworld-tts-1.5-max";
-// Voice discovery should fail boundedly instead of waiting forever when the
-// Inworld voices endpoint accepts the connection but never responds.
-const DEFAULT_INWORLD_VOICE_LIST_TIMEOUT_MS = 30_000;
 
 // The streaming TTS endpoint returns newline-delimited JSON whose audio is
 // base64-encoded, so the wire body is ~4/3 larger than the decoded audio plus a
@@ -25,7 +22,7 @@ const INWORLD_TTS_BODY_MAX_BYTES = MAX_AUDIO_BYTES * 2;
 const INWORLD_VOICES_BODY_MAX_BYTES = MAX_AUDIO_BYTES;
 // Abort the read if the upstream stalls mid-body so a hung stream cannot pin the
 // socket and buffers open indefinitely.
-const INWORLD_BODY_READ_IDLE_TIMEOUT_MS = 30_000;
+const INWORLD_UPSTREAM_IDLE_TIMEOUT_MS = 30_000;
 // Error responses only need a short diagnostic snippet, never the whole body.
 const INWORLD_ERROR_BODY_MAX_BYTES = 8 * 1024;
 const INWORLD_ERROR_BODY_MAX_CHARS = 400;
@@ -156,7 +153,7 @@ export async function inworldTTS(params: {
 
     const body = (
       await readResponseWithLimit(response, INWORLD_TTS_BODY_MAX_BYTES, {
-        chunkTimeoutMs: INWORLD_BODY_READ_IDLE_TIMEOUT_MS,
+        chunkTimeoutMs: INWORLD_UPSTREAM_IDLE_TIMEOUT_MS,
         onOverflow: ({ size, maxBytes }) =>
           new Error(`Inworld TTS audio stream too large: ${size} bytes (limit: ${maxBytes} bytes)`),
         onIdleTimeout: ({ chunkTimeoutMs }) =>
@@ -229,7 +226,9 @@ export async function listInworldVoices(params: {
         Authorization: `Basic ${params.apiKey}`,
       },
     },
-    timeoutMs: params.timeoutMs ?? DEFAULT_INWORLD_VOICE_LIST_TIMEOUT_MS,
+    // Cover the phase before response headers; the bounded body reader below
+    // only starts after fetch resolves.
+    timeoutMs: params.timeoutMs ?? INWORLD_UPSTREAM_IDLE_TIMEOUT_MS,
     policy: ssrfPolicyFromInworldBaseUrl(baseUrl),
     auditContext: "inworld-voices",
   });
@@ -242,7 +241,7 @@ export async function listInworldVoices(params: {
 
     const voicesBody = (
       await readResponseWithLimit(response, INWORLD_VOICES_BODY_MAX_BYTES, {
-        chunkTimeoutMs: INWORLD_BODY_READ_IDLE_TIMEOUT_MS,
+        chunkTimeoutMs: INWORLD_UPSTREAM_IDLE_TIMEOUT_MS,
         onOverflow: ({ size, maxBytes }) =>
           new Error(`Inworld voices response too large: ${size} bytes (limit: ${maxBytes} bytes)`),
         onIdleTimeout: ({ chunkTimeoutMs }) =>

--- a/extensions/inworld/tts.ts
+++ b/extensions/inworld/tts.ts
@@ -8,6 +8,9 @@ import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 const DEFAULT_INWORLD_BASE_URL = "https://api.inworld.ai";
 export const DEFAULT_INWORLD_VOICE_ID = "Sarah";
 export const DEFAULT_INWORLD_MODEL_ID = "inworld-tts-1.5-max";
+// Voice discovery should fail boundedly instead of waiting forever when the
+// Inworld voices endpoint accepts the connection but never responds.
+const DEFAULT_INWORLD_VOICE_LIST_TIMEOUT_MS = 30_000;
 
 // The streaming TTS endpoint returns newline-delimited JSON whose audio is
 // base64-encoded, so the wire body is ~4/3 larger than the decoded audio plus a
@@ -226,7 +229,7 @@ export async function listInworldVoices(params: {
         Authorization: `Basic ${params.apiKey}`,
       },
     },
-    timeoutMs: params.timeoutMs,
+    timeoutMs: params.timeoutMs ?? DEFAULT_INWORLD_VOICE_LIST_TIMEOUT_MS,
     policy: ssrfPolicyFromInworldBaseUrl(baseUrl),
     auditContext: "inworld-voices",
   });

--- a/extensions/inworld/voices-timeout.test.ts
+++ b/extensions/inworld/voices-timeout.test.ts
@@ -1,33 +1,6 @@
-// Inworld voice list live timeout proof.
-// Uses a local node:http server that accepts the connection but never responds,
-// proving that listInworldVoices aborts within the configured timeout.
-import { createServer, type Server } from "node:http";
-import type { AddressInfo, Socket } from "node:net";
+import { withServer } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { listInworldVoices } from "./tts.js";
-
-async function listenLocal(server: Server): Promise<number> {
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  return (server.address() as AddressInfo).port;
-}
-
-async function closeServer(server: Server, sockets: Set<Socket>): Promise<void> {
-  for (const socket of sockets) {
-    socket.destroy();
-  }
-  await new Promise<void>((resolve, reject) => {
-    server.close((error) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-      resolve();
-    });
-  });
-}
 
 describe("listInworldVoices live timeout", () => {
   const originalFetch = globalThis.fetch;
@@ -37,44 +10,36 @@ describe("listInworldVoices live timeout", () => {
   });
 
   it("aborts a hanging voice list request within the configured timeout", async () => {
-    const sockets = new Set<Socket>();
     let requestCount = 0;
-    const server = createServer((_req, _res) => {
-      requestCount += 1;
-    });
-    server.on("connection", (socket) => {
-      sockets.add(socket);
-      socket.on("close", () => sockets.delete(socket));
-    });
+    await withServer(
+      (request) => {
+        requestCount += 1;
+        request.resume();
+      },
+      async (baseUrl) => {
+        vi.stubGlobal(
+          "fetch",
+          vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+            return await originalFetch(`${baseUrl}/voices/v1/voices`, init);
+          }) as unknown as typeof globalThis.fetch,
+        );
 
-    const port = await listenLocal(server);
-
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-        return await originalFetch(`http://127.0.0.1:${port}/voices/v1/voices`, init);
-      }) as unknown as typeof globalThis.fetch,
+        const startedAt = Date.now();
+        await expect(
+          Promise.race([
+            listInworldVoices({
+              apiKey: "test-key",
+              baseUrl: "https://custom.inworld.example.com",
+              timeoutMs: 250,
+            }),
+            new Promise<never>((_, reject) => {
+              setTimeout(() => reject(new Error("voices list did not time out")), 2_000);
+            }),
+          ]),
+        ).rejects.toThrow(/aborted|timeout|timed out/i);
+        expect(Date.now() - startedAt).toBeLessThan(2_000);
+        expect(requestCount).toBe(1);
+      },
     );
-
-    const startedAt = Date.now();
-
-    try {
-      await expect(
-        Promise.race([
-          listInworldVoices({
-            apiKey: "test-key",
-            baseUrl: "https://custom.inworld.example.com",
-            timeoutMs: 250,
-          }),
-          new Promise<never>((_, reject) => {
-            setTimeout(() => reject(new Error("voices list did not time out")), 2_000);
-          }),
-        ]),
-      ).rejects.toThrow(/aborted|timeout|timed out/i);
-      expect(Date.now() - startedAt).toBeLessThan(2_000);
-      expect(requestCount).toBe(1);
-    } finally {
-      await closeServer(server, sockets);
-    }
   });
 });

--- a/extensions/inworld/voices-timeout.test.ts
+++ b/extensions/inworld/voices-timeout.test.ts
@@ -1,0 +1,80 @@
+// Inworld voice list live timeout proof.
+// Uses a local node:http server that accepts the connection but never responds,
+// proving that listInworldVoices aborts within the configured timeout.
+import { createServer, type Server } from "node:http";
+import type { AddressInfo, Socket } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { listInworldVoices } from "./tts.js";
+
+async function listenLocal(server: Server): Promise<number> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  return (server.address() as AddressInfo).port;
+}
+
+async function closeServer(server: Server, sockets: Set<Socket>): Promise<void> {
+  for (const socket of sockets) {
+    socket.destroy();
+  }
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+describe("listInworldVoices live timeout", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("aborts a hanging voice list request within the configured timeout", async () => {
+    const sockets = new Set<Socket>();
+    let requestCount = 0;
+    const server = createServer((_req, _res) => {
+      requestCount += 1;
+    });
+    server.on("connection", (socket) => {
+      sockets.add(socket);
+      socket.on("close", () => sockets.delete(socket));
+    });
+
+    const port = await listenLocal(server);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        return await originalFetch(`http://127.0.0.1:${port}/voices/v1/voices`, init);
+      }) as unknown as typeof globalThis.fetch,
+    );
+
+    const startedAt = Date.now();
+
+    try {
+      await expect(
+        Promise.race([
+          listInworldVoices({
+            apiKey: "test-key",
+            baseUrl: "https://custom.inworld.example.com",
+            timeoutMs: 250,
+          }),
+          new Promise<never>((_, reject) => {
+            setTimeout(() => reject(new Error("voices list did not time out")), 2_000);
+          }),
+        ]),
+      ).rejects.toThrow(/aborted|timeout|timed out/i);
+      expect(Date.now() - startedAt).toBeLessThan(2_000);
+      expect(requestCount).toBe(1);
+    } finally {
+      await closeServer(server, sockets);
+    }
+  });
+});

--- a/extensions/inworld/voices-timeout.test.ts
+++ b/extensions/inworld/voices-timeout.test.ts
@@ -9,37 +9,34 @@ describe("listInworldVoices live timeout", () => {
     vi.unstubAllGlobals();
   });
 
-  it("aborts a hanging voice list request within the configured timeout", async () => {
-    let requestCount = 0;
-    await withServer(
-      (request) => {
-        requestCount += 1;
-        request.resume();
-      },
-      async (baseUrl) => {
-        vi.stubGlobal(
-          "fetch",
-          vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-            return await originalFetch(`${baseUrl}/voices/v1/voices`, init);
-          }) as unknown as typeof globalThis.fetch,
-        );
+  it(
+    "aborts a hanging voice list request within the configured timeout",
+    { timeout: 2_000 },
+    async () => {
+      let requestCount = 0;
+      await withServer(
+        (request) => {
+          requestCount += 1;
+          request.resume();
+        },
+        async (baseUrl) => {
+          vi.stubGlobal(
+            "fetch",
+            vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+              return await originalFetch(`${baseUrl}/voices/v1/voices`, init);
+            }) as unknown as typeof globalThis.fetch,
+          );
 
-        const startedAt = Date.now();
-        await expect(
-          Promise.race([
+          await expect(
             listInworldVoices({
               apiKey: "test-key",
               baseUrl: "https://custom.inworld.example.com",
               timeoutMs: 250,
             }),
-            new Promise<never>((_, reject) => {
-              setTimeout(() => reject(new Error("voices list did not time out")), 2_000);
-            }),
-          ]),
-        ).rejects.toThrow(/aborted|timeout|timed out/i);
-        expect(Date.now() - startedAt).toBeLessThan(2_000);
-        expect(requestCount).toBe(1);
-      },
-    );
-  });
+          ).rejects.toThrow(/aborted|timeout|timed out/i);
+          expect(requestCount).toBe(1);
+        },
+      );
+    },
+  );
 });


### PR DESCRIPTION
## What Problem This Solves

Inworld voice discovery could wait indefinitely when the voices endpoint accepted the HTTP connection but never returned a response.

## Why This Change Was Made

The Inworld TTS paths already receive bounded provider timeouts, but `listInworldVoices` did not apply a deadline to its guarded voices-list request. The provider hook calls `listInworldVoices` without passing `timeoutMs`, so the request was falling through to the underlying unbounded fetch.

This change adds a bounded default timeout for voice discovery while preserving existing request headers, SSRF policy, and response parsing. Callers that pass an explicit `timeoutMs` continue to have it honored.

## User Impact

A stalled Inworld voices endpoint no longer blocks voice discovery forever. The discovery request now fails boundedly instead of leaving callers pending.

## Evidence

- Added mock-based regression tests in `extensions/inworld/tts.test.ts` verifying default `timeoutMs: 30_000` and explicit timeout preservation.
- Added live timeout proof in `extensions/inworld/voices-timeout.test.ts` using a local `node:http` loopback server that accepts the connection but never responds; the test stubs `globalThis.fetch` to redirect the guarded request to `127.0.0.1` and asserts `listInworldVoices({ ..., timeoutMs: 250 })` rejects with an abort/timeout error within 2 seconds.
- Ran `./node_modules/.bin/vitest run extensions/inworld/` — `Test Files  3 passed (3)`, `Tests  42 passed (42)`.
- Ran `./node_modules/.bin/oxfmt --write extensions/inworld/voices-timeout.test.ts` and `./node_modules/.bin/oxlint extensions/inworld/voices-timeout.test.ts` — passed.
- `git diff --check` — passed.

## Real behavior proof

A local `node:http` server on `127.0.0.1:0` accepts the request and leaves the socket open. The live test (`extensions/inworld/voices-timeout.test.ts`) routes the guarded `fetchWithSsrFGuard` call through `globalThis.fetch` to that server, then calls `listInworldVoices({ apiKey: "test-key", baseUrl: "https://custom.inworld.example.com", timeoutMs: 250 })`. The call rejects within ~270 ms with an `aborted`/`timeout` error, well under the 2 second harness limit.

Command after this patch:
```
./node_modules/.bin/vitest run extensions/inworld/voices-timeout.test.ts
```
Result:
```
✓ |extensions| .../voices-timeout.test.ts > listInworldVoices live timeout > aborts a hanging voice list request within the configured timeout 302ms
Test Files  1 passed (1)
Tests  1 passed (1)
```

What was not tested: live production Inworld traffic; the loopback harness proves the abort path behaves correctly without relying on a real third-party stall.