### PR TITLE
feat(memory-lancedb): scope memory_recall and memory_forget + configurable thresholds

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -5915,7 +5915,9 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H3: Dimensions
   - H2: Ollama embeddings
   - H2: Recall and capture limits
+  - H3: Recall selectivity (auto-recall)
   - H2: Commands
+  - H2: Scope (partitioning a shared store)
   - H2: Storage
   - H2: Runtime dependencies and platform support
   - H2: Troubleshooting

--- a/docs/plugins/memory-lancedb.md
+++ b/docs/plugins/memory-lancedb.md
@@ -206,6 +206,20 @@ Auto-capture also rejects text that looks like envelope/transport metadata,
 prompt-injection payloads, or already-injected `<relevant-memories>` context,
 and caps at 3 captured memories per agent turn.
 
+### Recall selectivity (auto-recall)
+
+These tune the automatic `before_prompt_build` recall — how many candidates it
+fetches, how strict the similarity cutoff is, and how many memories it injects.
+Defaults equal the previously hardcoded values, so leaving them unset preserves
+current behavior. They take effect at the before-prompt hook (not only at
+startup).
+
+| Setting               | Default | Range | Applies to                                                           |
+| --------------------- | ------- | ----- | -------------------------------------------------------------------- |
+| `recallMinScore`      | `0.3`   | 0-1   | Minimum similarity score for a memory to be injected by auto-recall. |
+| `autoRecallOverfetch` | `10`    | 1-200 | Candidate pool size fetched before scoring/capping in auto-recall.   |
+| `recallResultCap`     | `3`     | 1-50  | Maximum memories injected per turn by auto-recall.                   |
+
 ## Commands
 
 `memory-lancedb` registers the `ltm` CLI namespace whenever it is installed
@@ -213,7 +227,7 @@ and caps at 3 captured memories per agent turn.
 
 ```bash
 openclaw ltm list [--limit <n>] [--order-by-created-at]
-openclaw ltm search <query> [--limit <n>]
+openclaw ltm search <query> [--limit <n>] [--scope <slug>]
 openclaw ltm stats
 ```
 
@@ -233,11 +247,53 @@ openclaw ltm query --filter "category = 'preference'" --order-by createdAt:desc
 
 Agents get three tools from the active memory plugin:
 
-- `memory_recall`: vector search over stored memories.
+- `memory_recall`: vector search over stored memories. Takes an optional `scope`
+  to read one partition (see [Scope](#scope-partitioning-a-shared-store));
+  unscoped, it reads global memories only.
 - `memory_store`: save a fact, preference, decision, or entity (rejects text
   that looks like a prompt-injection payload; skips near-duplicate stores).
+  Prefix the text with `[SCOPE:<slug>]` to partition the memory.
 - `memory_forget`: delete by `memoryId`, or by `query` (auto-deletes a single
-  match above 90% score, otherwise lists candidate IDs to disambiguate).
+  match above 90% score, otherwise lists candidate IDs to disambiguate). Takes an
+  optional `scope`; unscoped, it only deletes global memories, and a `memoryId`
+  delete is fenced to the target row's scope.
+
+## Scope (partitioning a shared store)
+
+By default every memory is **global**: visible to recall, auto-recall, and forget
+across the whole store. A memory can instead be tagged with an opaque **scope** —
+a partition key such as a project, person, channel, or tenant — so it is only
+visible to operations that ask for that scope. This partitions one shared store
+without splitting it into a separate store per context.
+
+- **Tagging.** Prefix the stored text with `[SCOPE:<slug>]` (via the
+  `memory_store` tool or a tagged user message). The tag is parsed into a `scope`
+  column and stripped before embedding, so the vector reflects the fact, not the
+  prefix, and the tag is never echoed back on recall. A scope key must be a slug
+  matching `[A-Za-z0-9_-]+`; a tag whose key is not a valid slug (for example a
+  raw channel/room id with punctuation) is **rejected**, not silently stored
+  global — map it to a slug first. A tag with no text after it (`[SCOPE:<slug>]`
+  alone) is likewise rejected on store and skipped on auto-capture, so the control
+  tag is never embedded or persisted as a memory on its own.
+- **Scoped vs unscoped recall.** `memory_recall` takes an optional `scope`. A
+  scoped call returns that scope's matches first, with global rows filling the
+  rest (scope and global are retrieved in separate vector passes so strong global
+  neighbors cannot crowd the scope out). An unscoped call returns global rows
+  only, so a scoped memory never surfaces in a plain recall.
+- **Scoped vs unscoped forget.** `memory_forget` takes the same `scope`. A scoped
+  forget only deletes within that scope; an unscoped forget only deletes global
+  rows. This holds for both delete paths: a `query` forget filters by scope, and a
+  `memoryId` forget is fenced by first checking the target row's scope — so a
+  known id from another partition cannot bypass it.
+- **Automatic recall is global-only.** The `before_prompt_build` auto-recall has
+  no active-scope signal, so it injects only global/untagged memories; a scoped
+  memory is never auto-recalled into an unrelated turn.
+- **CLI search mirrors the tool.** `ltm search` is global-only by default; pass
+  `--scope <slug>` to vector-search within one partition. Unscoped, it never scans
+  across partitions, so scoped rows do not leak into a plain `ltm search`.
+
+Scope is behavior-preserving until you use it: pre-existing rows migrate to an
+empty (global) scope, and installs that never tag a memory see no change.
 
 ## Storage
 

--- a/extensions/memory-lancedb/config.ts
+++ b/extensions/memory-lancedb/config.ts
@@ -20,6 +20,9 @@ export type MemoryConfig = {
   customTriggers?: string[];
   recallMaxChars?: number;
   storageOptions?: Record<string, string>;
+  recallMinScore?: number;
+  recallResultCap?: number;
+  autoRecallOverfetch?: number;
 };
 
 export const MEMORY_CATEGORIES = ["preference", "fact", "decision", "entity", "other"] as const;
@@ -152,6 +155,9 @@ export const memoryConfigSchema = {
         "customTriggers",
         "recallMaxChars",
         "storageOptions",
+        "recallMinScore",
+        "recallResultCap",
+        "autoRecallOverfetch",
       ],
       "memory config",
     );
@@ -185,6 +191,31 @@ export const memoryConfigSchema = {
       min: 100,
       max: 10_000,
       label: "recallMaxChars",
+    });
+    const recallMinScore = ((): number => {
+      if (cfg.recallMinScore === undefined) {
+        return 0.3;
+      }
+      const parsed =
+        typeof cfg.recallMinScore === "number" ? parseFiniteNumber(cfg.recallMinScore) : undefined;
+      if (parsed === undefined || parsed < 0 || parsed > 1) {
+        throw new Error("recallMinScore must be a number between 0 and 1");
+      }
+      return parsed;
+    })();
+    const recallResultCap = resolveBoundedIntegerConfig({
+      value: cfg.recallResultCap,
+      fallback: 3,
+      min: 1,
+      max: 50,
+      label: "recallResultCap",
+    });
+    const autoRecallOverfetch = resolveBoundedIntegerConfig({
+      value: cfg.autoRecallOverfetch,
+      fallback: 10,
+      min: 1,
+      max: 200,
+      label: "autoRecallOverfetch",
     });
     let customTriggers: string[] | undefined;
     if (cfg.customTriggers !== undefined) {
@@ -251,6 +282,9 @@ export const memoryConfigSchema = {
       captureMaxChars,
       ...(customTriggers ? { customTriggers } : {}),
       recallMaxChars,
+      recallMinScore,
+      recallResultCap,
+      autoRecallOverfetch,
       ...(storageOptions ? { storageOptions } : {}),
     };
   },
@@ -313,6 +347,24 @@ export const memoryConfigSchema = {
       help: "Maximum prompt/query length embedded for memory recall. Lower for small local embedding models.",
       advanced: true,
       placeholder: String(DEFAULT_RECALL_MAX_CHARS),
+    },
+    recallMinScore: {
+      label: "Recall Min Score",
+      help: "Minimum similarity (0-1) for a memory to be eligible for auto-recall injection. Higher = stricter.",
+      advanced: true,
+      placeholder: "0.3",
+    },
+    recallResultCap: {
+      label: "Recall Result Cap",
+      help: "Maximum number of memories auto-recall injects into context.",
+      advanced: true,
+      placeholder: "3",
+    },
+    autoRecallOverfetch: {
+      label: "Auto-Recall Overfetch",
+      help: "Candidates fetched before sludge-filtering and capping. Keep a few multiples above the result cap.",
+      advanced: true,
+      placeholder: "10",
     },
     storageOptions: {
       label: "Storage Options",

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -540,7 +540,7 @@ describe("memory plugin e2e", () => {
     }));
     const toArray = vi.fn(async () => []);
     const limit = vi.fn(() => ({ toArray }));
-    const vectorSearch = vi.fn(() => ({ limit }));
+    const vectorSearch = vi.fn(() => ({ where: () => ({ limit }), limit }));
     const loadLanceDbModule = vi.fn(async () => ({
       connect: vi.fn(async () => ({
         tableNames: vi.fn(async () => ["memories"]),
@@ -651,7 +651,7 @@ describe("memory plugin e2e", () => {
     const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
     const toArray = vi.fn(async () => []);
     const limit = vi.fn(() => ({ toArray }));
-    const vectorSearch = vi.fn(() => ({ limit }));
+    const vectorSearch = vi.fn(() => ({ where: () => ({ limit }), limit }));
     const loadLanceDbModule = vi.fn(async () => ({
       connect: vi.fn(async () => ({
         tableNames: vi.fn(async () => ["memories"]),
@@ -748,7 +748,7 @@ describe("memory plugin e2e", () => {
       },
     ]);
     const limit = vi.fn(() => ({ toArray }));
-    const vectorSearch = vi.fn(() => ({ limit }));
+    const vectorSearch = vi.fn(() => ({ where: () => ({ limit }), limit }));
     const loadLanceDbModule = vi.fn(async () => ({
       connect: vi.fn(async () => ({
         tableNames: vi.fn(async () => ["memories"]),
@@ -1097,7 +1097,7 @@ describe("memory plugin e2e", () => {
       },
     ]);
     const limit = vi.fn(() => ({ toArray }));
-    const vectorSearch = vi.fn(() => ({ limit }));
+    const vectorSearch = vi.fn(() => ({ where: () => ({ limit }), limit }));
     const openTable = vi.fn(async () => ({
       vectorSearch,
       countRows: vi.fn(async () => 0),
@@ -1336,7 +1336,7 @@ describe("memory plugin e2e", () => {
       },
     ]);
     const limit = vi.fn(() => ({ toArray }));
-    const vectorSearch = vi.fn(() => ({ limit }));
+    const vectorSearch = vi.fn(() => ({ where: () => ({ limit }), limit }));
     const openTable = vi.fn(async () => ({
       vectorSearch,
       countRows: vi.fn(async () => 0),
@@ -1455,6 +1455,171 @@ describe("memory plugin e2e", () => {
       });
       expect(result?.prependContext).toContain("I prefer Helix for editing code.");
       expect(logger.info).toHaveBeenCalledWith("memory-lancedb: injecting 1 memories into context");
+    } finally {
+      vi.doUnmock("openclaw/plugin-sdk/runtime-env");
+      vi.doUnmock("openai");
+      vi.doUnmock("./lancedb-runtime.js");
+      vi.resetModules();
+    }
+  });
+
+  test("threads operator recall thresholds through live config into auto-recall", async () => {
+    // Regression (codex P2): resolveCurrentHookConfig() must carry the new
+    // recallMinScore / recallResultCap / autoRecallOverfetch fields from the
+    // registration config before spreading the live runtime config. Before the
+    // fix it only threaded the older knobs, so once a live runtime config object
+    // was present (the normal case) these three were dropped and reparsed as
+    // defaults, and operator-configured values never took effect in
+    // before_prompt_build. Here the knobs live only in the registration
+    // pluginConfig; the live config omits them, so they survive only via that
+    // baseline. autoRecallOverfetch=4 (not the default 10) and recallMinScore=
+    // 0.85 (not the default 0.3, which would keep the weak 0.5-score row).
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.1, 0.2, 0.3] }],
+    }));
+    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
+    const toArray = vi.fn(async () => [
+      {
+        id: "memory-strong",
+        text: "I prefer Helix for editing code.",
+        vector: [0.1, 0.2, 0.3],
+        importance: 0.8,
+        category: "preference",
+        createdAt: 1,
+        _distance: 0.1, // score = 1/1.1 ≈ 0.91 -> passes 0.85
+      },
+      {
+        id: "memory-weak",
+        text: "A weakly related note.",
+        vector: [0.1, 0.2, 0.3],
+        importance: 0.8,
+        category: "other",
+        createdAt: 1,
+        _distance: 1, // score = 1/2 = 0.50 -> passes default 0.3, fails 0.85
+      },
+    ]);
+    const limit = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({ where: () => ({ limit }), limit }));
+    const openTable = vi.fn(async () => ({
+      vectorSearch,
+      countRows: vi.fn(async () => 0),
+      add: vi.fn(async () => undefined),
+      delete: vi.fn(async () => undefined),
+    }));
+    const loadLanceDbModule = vi.fn(async () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable,
+      })),
+    }));
+    let configFile: Record<string, unknown> = {
+      plugins: {
+        entries: {
+          "memory-lancedb": {
+            config: {
+              embedding: {
+                apiKey: OPENAI_API_KEY,
+                model: "text-embedding-3-small",
+              },
+              dbPath: getDbPath(),
+              autoCapture: false,
+              autoRecall: false,
+            },
+          },
+        },
+      },
+    };
+
+    vi.resetModules();
+    vi.doMock("openclaw/plugin-sdk/runtime-env", () => ({
+      ensureGlobalUndiciEnvProxyDispatcher,
+    }));
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
+      },
+    }));
+    vi.doMock("./lancedb-runtime.js", () => ({
+      loadLanceDbModule,
+    }));
+
+    try {
+      const { default: dynamicMemoryPlugin } = await import("./index.js");
+      const on = vi.fn();
+      const logger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      };
+      const mockApi = {
+        id: "memory-lancedb",
+        name: "Memory (LanceDB)",
+        source: "test",
+        config: {},
+        // Thresholds live ONLY in the registration config (-> cfg baseline).
+        pluginConfig: {
+          embedding: {
+            apiKey: OPENAI_API_KEY,
+            model: "text-embedding-3-small",
+          },
+          dbPath: getDbPath(),
+          autoCapture: false,
+          autoRecall: false,
+          recallMinScore: 0.85,
+          autoRecallOverfetch: 4,
+        },
+        runtime: {
+          config: {
+            current: () => configFile,
+          },
+        },
+        logger,
+        registerTool: vi.fn(),
+        registerCli: vi.fn(),
+        registerService: vi.fn(),
+        on,
+        resolvePath: (p: string) => p,
+      };
+
+      registerTestPlugin(dynamicMemoryPlugin, mockApi);
+
+      // Live config enables auto-recall but omits the threshold knobs.
+      configFile = {
+        plugins: {
+          entries: {
+            "memory-lancedb": {
+              config: {
+                embedding: {
+                  apiKey: OPENAI_API_KEY,
+                  model: "text-embedding-3-small",
+                },
+                dbPath: getDbPath(),
+                autoCapture: false,
+                autoRecall: true,
+              },
+            },
+          },
+        },
+      };
+
+      const beforePromptBuild = on.mock.calls.find(
+        ([hookName]) => hookName === "before_prompt_build",
+      )?.[1];
+      expect(beforePromptBuild).toBeTypeOf("function");
+
+      const result = await beforePromptBuild?.(
+        { prompt: "what editor should i use?", messages: [] },
+        {},
+      );
+
+      // autoRecallOverfetch reached the search (not the default 10).
+      expect(limit).toHaveBeenCalledWith(4);
+      // recallMinScore=0.85 filtered the weak row; the default 0.3 would keep it.
+      expect(result?.prependContext).toContain("I prefer Helix for editing code.");
+      expect(result?.prependContext).not.toContain("A weakly related note.");
     } finally {
       vi.doUnmock("openclaw/plugin-sdk/runtime-env");
       vi.doUnmock("openai");
@@ -1709,7 +1874,7 @@ describe("memory plugin e2e", () => {
     const add = vi.fn(async () => undefined);
     const toArray = vi.fn(async () => []);
     const limit = vi.fn(() => ({ toArray }));
-    const vectorSearch = vi.fn(() => ({ limit }));
+    const vectorSearch = vi.fn(() => ({ where: () => ({ limit }), limit }));
     const openTable = vi.fn(async () => ({
       vectorSearch,
       countRows: vi.fn(async () => 0),
@@ -1816,7 +1981,7 @@ describe("memory plugin e2e", () => {
     const add = vi.fn(async () => undefined);
     const toArray = vi.fn(async () => []);
     const limit = vi.fn(() => ({ toArray }));
-    const vectorSearch = vi.fn(() => ({ limit }));
+    const vectorSearch = vi.fn(() => ({ where: () => ({ limit }), limit }));
     const openTable = vi.fn(async () => ({
       vectorSearch,
       countRows: vi.fn(async () => 0),
@@ -2201,7 +2366,7 @@ describe("memory plugin e2e", () => {
     const add = vi.fn(async () => undefined);
     const toArray = vi.fn(async () => overrides?.searchResults ?? []);
     const limit = vi.fn(() => ({ toArray }));
-    const vectorSearch = vi.fn(() => ({ limit }));
+    const vectorSearch = vi.fn(() => ({ where: () => ({ limit }), limit }));
     const openTable = vi.fn(async () => ({
       vectorSearch,
       countRows: vi.fn(async () => 0),
@@ -2452,7 +2617,7 @@ describe("memory plugin e2e", () => {
     const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
     const toArray = vi.fn(async () => []);
     const limit = vi.fn(() => ({ toArray }));
-    const vectorSearch = vi.fn(() => ({ limit }));
+    const vectorSearch = vi.fn(() => ({ where: () => ({ limit }), limit }));
     const loadLanceDbModule = vi.fn(async () => ({
       connect: vi.fn(async () => ({
         tableNames: vi.fn(async () => ["memories"]),
@@ -2551,7 +2716,7 @@ describe("memory plugin e2e", () => {
     const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
     const toArray = vi.fn(async () => []);
     const limit = vi.fn(() => ({ toArray }));
-    const vectorSearch = vi.fn(() => ({ limit }));
+    const vectorSearch = vi.fn(() => ({ where: () => ({ limit }), limit }));
     const loadLanceDbModule = vi
       .fn()
       .mockRejectedValueOnce(new Error("temporary LanceDB install failure"))
@@ -2847,7 +3012,7 @@ describe("memory plugin e2e", () => {
     const add = vi.fn(async () => undefined);
     const toArray = vi.fn(async () => []);
     const limit = vi.fn(() => ({ toArray }));
-    const vectorSearch = vi.fn(() => ({ limit }));
+    const vectorSearch = vi.fn(() => ({ where: () => ({ limit }), limit }));
     const openTable = vi.fn(async () => ({
       vectorSearch,
       add,
@@ -2947,6 +3112,1187 @@ describe("memory plugin e2e", () => {
     });
   });
 
+  test("memory_store captures the [SCOPE:<slug>] tag and strips it from the stored text", async () => {
+    // Regression: the scope-tag slug regex must accept hyphens. A pre-fix
+    // pattern of [a-zA-Z0-9_]+ truncated a hyphenated, underscored scope value
+    // ("demo-shop_eu") at the hyphen to "demo", silently
+    // mis-scoping the row. Underscores must survive too; an untagged store
+    // must leave scope = "" (global). See also the autoCapture path, which
+    // uses the same pattern. The [SCOPE:...] tag must also be stripped from the
+    // embedded input and the persisted text, so the vector reflects the fact
+    // (not the synthetic prefix) and the tag is never echoed back on recall.
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.1, 0.2, 0.3] }],
+    }));
+    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
+    const add = vi.fn(async () => undefined);
+    const toArray = vi.fn(async () => []);
+    const limit = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({ where: () => ({ limit }), limit }));
+    const openTable = vi.fn(async () => ({
+      vectorSearch,
+      add,
+      countRows: vi.fn(async () => 0),
+      delete: vi.fn(async () => undefined),
+    }));
+    const loadLanceDbModule = vi.fn(async () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable,
+      })),
+    }));
+
+    await withMockedOpenAiMemoryPlugin({
+      ensureGlobalUndiciEnvProxyDispatcher,
+      embeddingsCreate,
+      loadLanceDbModule,
+      run: async (dynamicMemoryPlugin) => {
+        const registeredTools: any[] = [];
+        const mockApi = {
+          id: "memory-lancedb",
+          name: "Memory (LanceDB)",
+          source: "test",
+          config: {},
+          pluginConfig: {
+            embedding: {
+              apiKey: OPENAI_API_KEY,
+              model: "text-embedding-3-small",
+            },
+            dbPath: getDbPath(),
+            autoCapture: false,
+            autoRecall: false,
+          },
+          runtime: {},
+          logger: {
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+            debug: vi.fn(),
+          },
+          registerTool: (tool: any, opts: any) => {
+            registeredTools.push({ tool, opts });
+          },
+          registerCli: vi.fn(),
+          registerService: vi.fn(),
+          on: vi.fn(),
+          resolvePath: (filePath: string) => filePath,
+        };
+
+        registerTestPlugin(dynamicMemoryPlugin, mockApi);
+        const storeTool = registeredTools.find((t) => t.opts?.name === "memory_store")?.tool;
+        if (!storeTool) {
+          throw new Error("memory_store tool was not registered");
+        }
+
+        // Hyphen + underscore slug must be captured verbatim (the regression).
+        const tagged = await storeTool.execute("test-call-scope-hyphen", {
+          text: "[SCOPE:demo-shop_eu] go-live is late December",
+          importance: "0.8",
+          category: "fact",
+        });
+        expect(tagged.details?.action).toBe("created");
+        expect(add).toHaveBeenCalledTimes(1);
+        expect(firstAddedMemory(add).scope).toBe("demo-shop_eu");
+        // The routing tag is stripped from the persisted text and the embedded
+        // input; the vector reflects the fact, not the synthetic prefix.
+        expect(firstAddedMemory(add).text).toBe("go-live is late December");
+        expect(embeddingsCreate).toHaveBeenNthCalledWith(1, {
+          model: "text-embedding-3-small",
+          input: "go-live is late December",
+        });
+
+        // An untagged store stays global (scope = "").
+        add.mockClear();
+        const untagged = await storeTool.execute("test-call-scope-none", {
+          text: "The user prefers concise replies",
+          importance: "0.7",
+          category: "preference",
+        });
+        expect(untagged.details?.action).toBe("created");
+        expect(add).toHaveBeenCalledTimes(1);
+        expect(firstAddedMemory(add).scope).toBe("");
+        // Untagged text is stored unchanged.
+        expect(firstAddedMemory(add).text).toBe("The user prefers concise replies");
+      },
+    });
+  });
+
+  test("dedup is scope-aware: the same fact survives under different scopes", async () => {
+    // Regression (P2): findCleanDuplicateMemory must scope duplicate detection to
+    // the row's scope. Before the fix it deduped globally, so storing the same
+    // fact under [SCOPE:beta] after [SCOPE:alpha] was wrongly rejected as a
+    // duplicate and could never be recalled scoped to beta. Same-scope and
+    // global-vs-global writes must still dedup.
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.1, 0.2, 0.3] }],
+    }));
+    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
+    const rows: Array<Record<string, unknown>> = [];
+    const add = vi.fn(async (batch: Array<Record<string, unknown>>) => {
+      rows.push(expectDefined(batch[0], "dedup add batch row"));
+    });
+    // Stateful search: every row added so far comes back as an exact match
+    // (_distance 0 -> score 1.0, above the 0.95 dedup threshold).
+    const toArray = vi.fn(async () => rows.map((r) => Object.assign({}, r, { _distance: 0 })));
+    const limit = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({ where: () => ({ limit }), limit }));
+    const openTable = vi.fn(async () => ({
+      vectorSearch,
+      add,
+      countRows: vi.fn(async () => rows.length),
+      delete: vi.fn(async () => undefined),
+    }));
+    const loadLanceDbModule = vi.fn(async () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable,
+      })),
+    }));
+
+    await withMockedOpenAiMemoryPlugin({
+      ensureGlobalUndiciEnvProxyDispatcher,
+      embeddingsCreate,
+      loadLanceDbModule,
+      run: async (dynamicMemoryPlugin) => {
+        const registeredTools: any[] = [];
+        const mockApi = {
+          id: "memory-lancedb",
+          name: "Memory (LanceDB)",
+          source: "test",
+          config: {},
+          pluginConfig: {
+            embedding: { apiKey: OPENAI_API_KEY, model: "text-embedding-3-small" },
+            dbPath: getDbPath(),
+            autoCapture: false,
+            autoRecall: false,
+          },
+          runtime: {},
+          logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+          registerTool: (tool: any, opts: any) => {
+            registeredTools.push({ tool, opts });
+          },
+          registerCli: vi.fn(),
+          registerService: vi.fn(),
+          on: vi.fn(),
+          resolvePath: (filePath: string) => filePath,
+        };
+
+        registerTestPlugin(dynamicMemoryPlugin, mockApi);
+        const storeTool = registeredTools.find((t) => t.opts?.name === "memory_store")?.tool;
+        if (!storeTool) {
+          throw new Error("memory_store tool was not registered");
+        }
+
+        const fact = "the release deadline is Friday";
+
+        // 1. First scope: nothing to match yet -> stored.
+        const alpha = await storeTool.execute("call-alpha", {
+          text: `[SCOPE:alpha] ${fact}`,
+          category: "fact",
+        });
+        expect(alpha.details?.action).toBe("created");
+
+        // 2. Same fact, DIFFERENT scope: the alpha row is an exact vector match
+        //    but a different scope -> NOT a duplicate -> stored.
+        const beta = await storeTool.execute("call-beta", {
+          text: `[SCOPE:beta] ${fact}`,
+          category: "fact",
+        });
+        expect(beta.details?.action).toBe("created");
+        expect(rows.map((r) => r.scope)).toEqual(["alpha", "beta"]);
+
+        // 3. Same fact, SAME scope -> still deduped (must not break legit dedup).
+        const alphaAgain = await storeTool.execute("call-alpha-2", {
+          text: `[SCOPE:alpha] ${fact}`,
+          category: "fact",
+        });
+        expect(alphaAgain.details?.action).toBe("duplicate");
+        expect(rows).toHaveLength(2);
+
+        // 4. Untagged/global writes still dedup against other global rows.
+        const global1 = await storeTool.execute("call-global-1", { text: fact, category: "fact" });
+        expect(global1.details?.action).toBe("created");
+        expect(rows.at(-1)?.scope).toBe("");
+        const global2 = await storeTool.execute("call-global-2", { text: fact, category: "fact" });
+        expect(global2.details?.action).toBe("duplicate");
+        expect(rows).toHaveLength(3);
+      },
+    });
+  });
+
+  test("dedup prefilters by scope so a same-scope duplicate is not pushed out by other scopes", async () => {
+    // Regression (codex P2): findCleanDuplicateMemory prefilters by scope via
+    // .where() BEFORE the top-K limit. Otherwise, when many other-scope rows share
+    // a near-identical vector, the same-scope duplicate can fall outside the top
+    // DUPLICATE_SEARCH_LIMIT neighbors and a duplicate write is wrongly accepted.
+    // Here the alpha duplicate is seeded LAST, behind 6 global rows (> the limit of
+    // 5) with the same vector: only a scope prefilter surfaces it.
+    const embeddingsCreate = vi.fn(async () => ({ data: [{ embedding: [0.1, 0.2, 0.3] }] }));
+    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
+    const fact = "the deadline is Friday";
+    const rows: Array<Record<string, unknown>> = [
+      ...Array.from({ length: 6 }, (_unused, i) => ({
+        id: `global-${i}`,
+        text: fact,
+        category: "fact",
+        vector: [0.1],
+        importance: 0.8,
+        createdAt: 0,
+        scope: "",
+      })),
+      {
+        id: "alpha-dup",
+        text: fact,
+        category: "fact",
+        vector: [0.1],
+        importance: 0.8,
+        createdAt: 0,
+        scope: "alpha",
+      },
+    ];
+    const add = vi.fn(async () => undefined);
+    const matchesFilter = (r: Record<string, unknown>, filter?: string): boolean => {
+      if (!filter) {
+        return true;
+      }
+      const rowScope = typeof r.scope === "string" ? r.scope : "";
+      if (filter === `scope = '${rowScope}'`) {
+        return true;
+      }
+      return filter === "scope = '' OR scope IS NULL" && rowScope === "";
+    };
+    // .where()-aware query: filters by the prefilter BEFORE applying the limit.
+    const buildQuery = (filter?: string) => ({
+      where: (f: string) => buildQuery(f),
+      limit: (n: number) => ({
+        toArray: async () =>
+          rows
+            .filter((r) => matchesFilter(r, filter))
+            .slice(0, n)
+            .map((r) => Object.assign({}, r, { _distance: 0 })),
+      }),
+    });
+    const vectorSearch = vi.fn(() => buildQuery(undefined));
+    const openTable = vi.fn(async () => ({
+      vectorSearch,
+      add,
+      countRows: vi.fn(async () => rows.length),
+      delete: vi.fn(async () => undefined),
+    }));
+    const loadLanceDbModule = vi.fn(async () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable,
+      })),
+    }));
+
+    await withMockedOpenAiMemoryPlugin({
+      ensureGlobalUndiciEnvProxyDispatcher,
+      embeddingsCreate,
+      loadLanceDbModule,
+      run: async (dynamicMemoryPlugin) => {
+        const registeredTools: any[] = [];
+        const mockApi = {
+          id: "memory-lancedb",
+          name: "Memory (LanceDB)",
+          source: "test",
+          config: {},
+          pluginConfig: {
+            embedding: { apiKey: OPENAI_API_KEY, model: "text-embedding-3-small" },
+            dbPath: getDbPath(),
+            autoCapture: false,
+            autoRecall: false,
+          },
+          runtime: {},
+          logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+          registerTool: (tool: any, opts: any) => {
+            registeredTools.push({ tool, opts });
+          },
+          registerCli: vi.fn(),
+          registerService: vi.fn(),
+          on: vi.fn(),
+          resolvePath: (filePath: string) => filePath,
+        };
+
+        registerTestPlugin(dynamicMemoryPlugin, mockApi);
+        const storeTool = registeredTools.find((t) => t.opts?.name === "memory_store")?.tool;
+        if (!storeTool) {
+          throw new Error("memory_store tool was not registered");
+        }
+
+        const result = await storeTool.execute("call-alpha-dup", {
+          text: `[SCOPE:alpha] ${fact}`,
+          category: "fact",
+        });
+        expect(result.details?.action).toBe("duplicate");
+        expect(add).not.toHaveBeenCalled();
+      },
+    });
+  });
+
+  test("scoped memory_recall prioritizes the requested scope over many strong global matches", async () => {
+    // Regression (codex P2): a scoped memory_recall must give the requested
+    // scope its own retrieval budget and return its matches first. Before the
+    // fix a single ANN query over (scope OR global) with a shared top-K let the
+    // scope's one row fall outside the candidate window once enough strong
+    // global neighbors existed, so a scoped recall silently missed rows from the
+    // very scope the caller asked for. Here 20 global rows (> the overfetch of
+    // limit + 10 = 15) share the query vector and the sole alpha row is seeded
+    // LAST: only a separate scoped pass surfaces it.
+    const embeddingsCreate = vi.fn(async () => ({ data: [{ embedding: [0.1, 0.2, 0.3] }] }));
+    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
+    const rows: Array<Record<string, unknown>> = [
+      ...Array.from({ length: 20 }, (_unused, i) => ({
+        id: `global-${i}`,
+        text: "a global memory",
+        category: "fact",
+        vector: [0.1],
+        importance: 0.8,
+        createdAt: 0,
+        scope: "",
+      })),
+      {
+        id: "alpha-1",
+        text: "an alpha-only memory",
+        category: "fact",
+        vector: [0.1],
+        importance: 0.8,
+        createdAt: 0,
+        scope: "alpha",
+      },
+    ];
+    const matchesFilter = (r: Record<string, unknown>, filter?: string): boolean => {
+      if (!filter) {
+        return true;
+      }
+      const rowScope = typeof r.scope === "string" ? r.scope : "";
+      if (filter === `scope = '${rowScope}'`) {
+        return true;
+      }
+      return filter === "scope = '' OR scope IS NULL" && rowScope === "";
+    };
+    // .where()-aware query: filters by the prefilter BEFORE applying the limit.
+    const buildQuery = (filter?: string) => ({
+      where: (f: string) => buildQuery(f),
+      limit: (n: number) => ({
+        toArray: async () =>
+          rows
+            .filter((r) => matchesFilter(r, filter))
+            .slice(0, n)
+            .map((r) => Object.assign({}, r, { _distance: 0 })),
+      }),
+    });
+    const vectorSearch = vi.fn(() => buildQuery(undefined));
+    const loadLanceDbModule = vi.fn(async () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          countRows: vi.fn(async () => rows.length),
+          add: vi.fn(async () => undefined),
+          delete: vi.fn(async () => undefined),
+        })),
+      })),
+    }));
+
+    await withMockedOpenAiMemoryPlugin({
+      ensureGlobalUndiciEnvProxyDispatcher,
+      embeddingsCreate,
+      loadLanceDbModule,
+      run: async (dynamicMemoryPlugin) => {
+        const registeredTools: any[] = [];
+        const mockApi = {
+          id: "memory-lancedb",
+          name: "Memory (LanceDB)",
+          source: "test",
+          config: {},
+          pluginConfig: {
+            embedding: { apiKey: OPENAI_API_KEY, model: "text-embedding-3-small" },
+            dbPath: getDbPath(),
+            autoCapture: false,
+            autoRecall: false,
+          },
+          runtime: {},
+          logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+          registerTool: (tool: any, opts: any) => {
+            registeredTools.push({ tool, opts });
+          },
+          registerCli: vi.fn(),
+          registerService: vi.fn(),
+          on: vi.fn(),
+          resolvePath: (filePath: string) => filePath,
+        };
+
+        registerTestPlugin(dynamicMemoryPlugin, mockApi);
+        const recallTool = registeredTools.find((t) => t.opts?.name === "memory_recall")?.tool;
+        if (!recallTool) {
+          throw new Error("memory_recall tool was not registered");
+        }
+
+        const result = await recallTool.execute("call-scoped-recall", {
+          query: "a memory",
+          scope: "alpha",
+        });
+
+        const text = result.content?.[0]?.text ?? "";
+        // The alpha row is returned despite 20 stronger-or-equal global rows...
+        expect(text).toContain("an alpha-only memory");
+        // ...and it comes first (scoped matches precede global fill).
+        expect(text.indexOf("an alpha-only memory")).toBeLessThan(text.indexOf("a global memory"));
+        expect(result.details?.count).toBe(5);
+      },
+    });
+  });
+
+  test("unscoped memory_recall returns only global memories, hiding scoped rows", async () => {
+    // Partition semantics (codex P2): an unscoped recall is a global-only view.
+    // A row stored under [SCOPE:alpha] must not bleed into a plain memory_recall
+    // with no scope; only unscoped/global rows are eligible. Before the fix the
+    // no-scope branch searched the whole table and surfaced the scoped row.
+    const embeddingsCreate = vi.fn(async () => ({ data: [{ embedding: [0.1, 0.2, 0.3] }] }));
+    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
+    const rows: Array<Record<string, unknown>> = [
+      {
+        id: "global-1",
+        text: "a global memory",
+        category: "fact",
+        vector: [0.1],
+        importance: 0.8,
+        createdAt: 0,
+        scope: "",
+      },
+      {
+        id: "alpha-1",
+        text: "an alpha-scoped memory",
+        category: "fact",
+        vector: [0.1],
+        importance: 0.8,
+        createdAt: 0,
+        scope: "alpha",
+      },
+    ];
+    const matchesFilter = (r: Record<string, unknown>, filter?: string): boolean => {
+      if (!filter) {
+        return true;
+      }
+      const rowScope = typeof r.scope === "string" ? r.scope : "";
+      if (filter === `scope = '${rowScope}'`) {
+        return true;
+      }
+      return filter === "scope = '' OR scope IS NULL" && rowScope === "";
+    };
+    const buildQuery = (filter?: string) => ({
+      where: (f: string) => buildQuery(f),
+      limit: (n: number) => ({
+        toArray: async () =>
+          rows
+            .filter((r) => matchesFilter(r, filter))
+            .slice(0, n)
+            .map((r) => Object.assign({}, r, { _distance: 0 })),
+      }),
+    });
+    const vectorSearch = vi.fn(() => buildQuery(undefined));
+    const loadLanceDbModule = vi.fn(async () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          countRows: vi.fn(async () => rows.length),
+          add: vi.fn(async () => undefined),
+          delete: vi.fn(async () => undefined),
+        })),
+      })),
+    }));
+
+    await withMockedOpenAiMemoryPlugin({
+      ensureGlobalUndiciEnvProxyDispatcher,
+      embeddingsCreate,
+      loadLanceDbModule,
+      run: async (dynamicMemoryPlugin) => {
+        const registeredTools: any[] = [];
+        const mockApi = {
+          id: "memory-lancedb",
+          name: "Memory (LanceDB)",
+          source: "test",
+          config: {},
+          pluginConfig: {
+            embedding: { apiKey: OPENAI_API_KEY, model: "text-embedding-3-small" },
+            dbPath: getDbPath(),
+            autoCapture: false,
+            autoRecall: false,
+          },
+          runtime: {},
+          logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+          registerTool: (tool: any, opts: any) => {
+            registeredTools.push({ tool, opts });
+          },
+          registerCli: vi.fn(),
+          registerService: vi.fn(),
+          on: vi.fn(),
+          resolvePath: (filePath: string) => filePath,
+        };
+
+        registerTestPlugin(dynamicMemoryPlugin, mockApi);
+        const recallTool = registeredTools.find((t) => t.opts?.name === "memory_recall")?.tool;
+        if (!recallTool) {
+          throw new Error("memory_recall tool was not registered");
+        }
+
+        const result = await recallTool.execute("call-unscoped-recall", { query: "a memory" });
+        const text = result.content?.[0]?.text ?? "";
+        expect(text).toContain("a global memory");
+        expect(text).not.toContain("an alpha-scoped memory");
+        expect(result.details?.count).toBe(1);
+      },
+    });
+  });
+
+  test("unscoped memory_forget cannot nominate or delete a scoped row", async () => {
+    // Partition semantics (codex P2): a query-based memory_forget with no scope
+    // must be global-only, so it can never auto-delete or nominate a partitioned
+    // row from another scope. Before the fix the no-scope search spanned every
+    // scoped row and could delete the wrong context's memory.
+    const embeddingsCreate = vi.fn(async () => ({ data: [{ embedding: [0.1, 0.2, 0.3] }] }));
+    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
+    const rows: Array<Record<string, unknown>> = [
+      {
+        id: "alpha-1",
+        text: "an alpha-scoped memory",
+        category: "fact",
+        vector: [0.1],
+        importance: 0.8,
+        createdAt: 0,
+        scope: "alpha",
+      },
+    ];
+    const matchesFilter = (r: Record<string, unknown>, filter?: string): boolean => {
+      if (!filter) {
+        return true;
+      }
+      const rowScope = typeof r.scope === "string" ? r.scope : "";
+      if (filter === `scope = '${rowScope}'`) {
+        return true;
+      }
+      return filter === "scope = '' OR scope IS NULL" && rowScope === "";
+    };
+    const buildQuery = (filter?: string) => ({
+      where: (f: string) => buildQuery(f),
+      limit: (n: number) => ({
+        toArray: async () =>
+          rows
+            .filter((r) => matchesFilter(r, filter))
+            .slice(0, n)
+            // High score so it WOULD be an auto-delete candidate if surfaced.
+            .map((r) => Object.assign({}, r, { _distance: 0 })),
+      }),
+    });
+    const vectorSearch = vi.fn(() => buildQuery(undefined));
+    const del = vi.fn(async () => undefined);
+    const loadLanceDbModule = vi.fn(async () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          countRows: vi.fn(async () => rows.length),
+          add: vi.fn(async () => undefined),
+          delete: del,
+        })),
+      })),
+    }));
+
+    await withMockedOpenAiMemoryPlugin({
+      ensureGlobalUndiciEnvProxyDispatcher,
+      embeddingsCreate,
+      loadLanceDbModule,
+      run: async (dynamicMemoryPlugin) => {
+        const registeredTools: any[] = [];
+        const mockApi = {
+          id: "memory-lancedb",
+          name: "Memory (LanceDB)",
+          source: "test",
+          config: {},
+          pluginConfig: {
+            embedding: { apiKey: OPENAI_API_KEY, model: "text-embedding-3-small" },
+            dbPath: getDbPath(),
+            autoCapture: false,
+            autoRecall: false,
+          },
+          runtime: {},
+          logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+          registerTool: (tool: any, opts: any) => {
+            registeredTools.push({ tool, opts });
+          },
+          registerCli: vi.fn(),
+          registerService: vi.fn(),
+          on: vi.fn(),
+          resolvePath: (filePath: string) => filePath,
+        };
+
+        registerTestPlugin(dynamicMemoryPlugin, mockApi);
+        const forgetTool = registeredTools.find((t) => t.opts?.name === "memory_forget")?.tool;
+        if (!forgetTool) {
+          throw new Error("memory_forget tool was not registered");
+        }
+
+        const result = await forgetTool.execute("call-unscoped-forget", { query: "a memory" });
+        expect(result.details?.found).toBe(0);
+        expect(del).not.toHaveBeenCalled();
+      },
+    });
+  });
+
+  test("auto-recall injects only global memories, never scoped rows", async () => {
+    // Partition semantics (codex P2): the before_prompt_build hook has no
+    // active-scope signal, so it must inject only global/untagged memories. A row
+    // stored under [SCOPE:alpha] must never be auto-recalled into an unrelated
+    // session. Before the fix the hook ran a global ANN search with no filter and
+    // could surface scoped rows.
+    const embeddingsCreate = vi.fn(async () => ({ data: [{ embedding: [0.1, 0.2, 0.3] }] }));
+    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
+    const rows: Array<Record<string, unknown>> = [
+      {
+        id: "global-1",
+        text: "I prefer Helix for editing code.",
+        category: "preference",
+        vector: [0.1],
+        importance: 0.8,
+        createdAt: 1,
+        scope: "",
+      },
+      {
+        id: "alpha-1",
+        text: "an alpha-scoped secret",
+        category: "fact",
+        vector: [0.1],
+        importance: 0.8,
+        createdAt: 1,
+        scope: "alpha",
+      },
+    ];
+    const matchesFilter = (r: Record<string, unknown>, filter?: string): boolean => {
+      if (!filter) {
+        return true;
+      }
+      const rowScope = typeof r.scope === "string" ? r.scope : "";
+      if (filter === `scope = '${rowScope}'`) {
+        return true;
+      }
+      return filter === "scope = '' OR scope IS NULL" && rowScope === "";
+    };
+    const buildQuery = (filter?: string) => ({
+      where: (f: string) => buildQuery(f),
+      limit: (n: number) => ({
+        toArray: async () =>
+          rows
+            .filter((r) => matchesFilter(r, filter))
+            .slice(0, n)
+            .map((r) => Object.assign({}, r, { _distance: 0.1 })),
+      }),
+    });
+    const vectorSearch = vi.fn(() => buildQuery(undefined));
+    const loadLanceDbModule = vi.fn(async () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          countRows: vi.fn(async () => rows.length),
+          add: vi.fn(async () => undefined),
+          delete: vi.fn(async () => undefined),
+        })),
+      })),
+    }));
+
+    await withMockedOpenAiMemoryPlugin({
+      ensureGlobalUndiciEnvProxyDispatcher,
+      embeddingsCreate,
+      loadLanceDbModule,
+      run: async (dynamicMemoryPlugin) => {
+        const on = vi.fn();
+        const mockApi = {
+          id: "memory-lancedb",
+          name: "Memory (LanceDB)",
+          source: "test",
+          config: {},
+          pluginConfig: {
+            embedding: { apiKey: OPENAI_API_KEY, model: "text-embedding-3-small" },
+            dbPath: getDbPath(),
+            autoCapture: false,
+            autoRecall: true,
+          },
+          runtime: {},
+          logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+          registerTool: vi.fn(),
+          registerCli: vi.fn(),
+          registerService: vi.fn(),
+          on,
+          resolvePath: (filePath: string) => filePath,
+        };
+
+        registerTestPlugin(dynamicMemoryPlugin, mockApi);
+        const beforePromptBuild = on.mock.calls.find(
+          ([hookName]) => hookName === "before_prompt_build",
+        )?.[1];
+        expect(beforePromptBuild).toBeTypeOf("function");
+
+        const result = await beforePromptBuild?.(
+          {
+            prompt: "what editor should i use?",
+            messages: [{ role: "user", content: "what editor should i use?" }],
+          },
+          {},
+        );
+
+        expect(result?.prependContext).toContain("I prefer Helix for editing code.");
+        expect(result?.prependContext).not.toContain("an alpha-scoped secret");
+      },
+    });
+  });
+
+  test("memory_store rejects a [SCOPE:...] tag whose key is not a slug", async () => {
+    // Regression (codex P2): a punctuated scope key (e.g. a Matrix room id like
+    // "!ops:example.org") must NOT silently fall back to the global partition.
+    // The store is rejected so an intended-scoped memory never leaks into global
+    // recall; a valid slug tag still stores scoped (covered by another test).
+    const embeddingsCreate = vi.fn(async () => ({ data: [{ embedding: [0.1, 0.2, 0.3] }] }));
+    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
+    const add = vi.fn(async () => undefined);
+    const toArray = vi.fn(async () => []);
+    const limit = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({ where: () => ({ limit }), limit }));
+    const loadLanceDbModule = vi.fn(async () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          add,
+          countRows: vi.fn(async () => 0),
+          delete: vi.fn(async () => undefined),
+        })),
+      })),
+    }));
+
+    await withMockedOpenAiMemoryPlugin({
+      ensureGlobalUndiciEnvProxyDispatcher,
+      embeddingsCreate,
+      loadLanceDbModule,
+      run: async (dynamicMemoryPlugin) => {
+        const registeredTools: any[] = [];
+        const mockApi = {
+          id: "memory-lancedb",
+          name: "Memory (LanceDB)",
+          source: "test",
+          config: {},
+          pluginConfig: {
+            embedding: { apiKey: OPENAI_API_KEY, model: "text-embedding-3-small" },
+            dbPath: getDbPath(),
+            autoCapture: false,
+            autoRecall: false,
+          },
+          runtime: {},
+          logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+          registerTool: (tool: any, opts: any) => {
+            registeredTools.push({ tool, opts });
+          },
+          registerCli: vi.fn(),
+          registerService: vi.fn(),
+          on: vi.fn(),
+          resolvePath: (filePath: string) => filePath,
+        };
+
+        registerTestPlugin(dynamicMemoryPlugin, mockApi);
+        const storeTool = registeredTools.find((t) => t.opts?.name === "memory_store")?.tool;
+        if (!storeTool) {
+          throw new Error("memory_store tool was not registered");
+        }
+
+        const result = await storeTool.execute("call-bad-scope", {
+          text: "[SCOPE:!ops:example.org] remember X",
+          category: "fact",
+        });
+        expect(result.details?.action).toBe("rejected");
+        expect(result.details?.reason).toBe("invalid_scope_key");
+        expect(add).not.toHaveBeenCalled();
+        // The embedding must not run for a rejected store.
+        expect(embeddingsCreate).not.toHaveBeenCalled();
+      },
+    });
+  });
+
+  test("memory_store rejects a [SCOPE:...] tag with no memory text after it", async () => {
+    // Regression (codex P3): a tag-only payload ([SCOPE:alpha] with nothing after
+    // it) must NOT fall back to storing the raw text. That would embed and persist
+    // the control tag itself, breaking the invariant that [SCOPE:...] is stripped
+    // before storage and leaving a synthetic tag-only memory that can be recalled.
+    const embeddingsCreate = vi.fn(async () => ({ data: [{ embedding: [0.1, 0.2, 0.3] }] }));
+    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
+    const add = vi.fn(async () => undefined);
+    const toArray = vi.fn(async () => []);
+    const limit = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({ where: () => ({ limit }), limit }));
+    const loadLanceDbModule = vi.fn(async () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          add,
+          countRows: vi.fn(async () => 0),
+          delete: vi.fn(async () => undefined),
+        })),
+      })),
+    }));
+
+    await withMockedOpenAiMemoryPlugin({
+      ensureGlobalUndiciEnvProxyDispatcher,
+      embeddingsCreate,
+      loadLanceDbModule,
+      run: async (dynamicMemoryPlugin) => {
+        const registeredTools: any[] = [];
+        const mockApi = {
+          id: "memory-lancedb",
+          name: "Memory (LanceDB)",
+          source: "test",
+          config: {},
+          pluginConfig: {
+            embedding: { apiKey: OPENAI_API_KEY, model: "text-embedding-3-small" },
+            dbPath: getDbPath(),
+            autoCapture: false,
+            autoRecall: false,
+          },
+          runtime: {},
+          logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+          registerTool: (tool: any, opts: any) => {
+            registeredTools.push({ tool, opts });
+          },
+          registerCli: vi.fn(),
+          registerService: vi.fn(),
+          on: vi.fn(),
+          resolvePath: (filePath: string) => filePath,
+        };
+
+        registerTestPlugin(dynamicMemoryPlugin, mockApi);
+        const storeTool = registeredTools.find((t) => t.opts?.name === "memory_store")?.tool;
+        if (!storeTool) {
+          throw new Error("memory_store tool was not registered");
+        }
+
+        const result = await storeTool.execute("call-empty-scope", {
+          text: "[SCOPE:alpha]   ",
+          category: "fact",
+        });
+        expect(result.details?.action).toBe("rejected");
+        expect(result.details?.reason).toBe("empty_scoped_text");
+        expect(add).not.toHaveBeenCalled();
+        // The embedding must not run for a rejected store.
+        expect(embeddingsCreate).not.toHaveBeenCalled();
+      },
+    });
+  });
+
+  test("auto-capture eligibility ignores the [SCOPE:...] tag length (heuristic runs on stripped text)", async () => {
+    // Regression (codex P3): the routing tag must not change capture eligibility.
+    // A long tag prepended to otherwise-valid content used to push the raw string
+    // past captureMaxChars, so the message was wrongly rejected before the tag was
+    // ever stripped. Eligibility must be evaluated on the stripped fact, not the
+    // tagged string — and the stripped fact is what gets embedded and stored.
+    const embeddingsCreate = vi.fn(async () => ({ data: [{ embedding: [0.1, 0.2, 0.3] }] }));
+    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
+    const add = vi.fn(async () => undefined);
+    const toArray = vi.fn(async () => []);
+    const limit = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({ where: () => ({ limit }), limit }));
+    const openTable = vi.fn(async () => ({
+      vectorSearch,
+      countRows: vi.fn(async () => 0),
+      add,
+      delete: vi.fn(async () => undefined),
+    }));
+    const loadLanceDbModule = vi.fn(async () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable,
+      })),
+    }));
+
+    vi.resetModules();
+    vi.doMock("openclaw/plugin-sdk/runtime-env", () => ({
+      ensureGlobalUndiciEnvProxyDispatcher,
+    }));
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
+      },
+    }));
+    vi.doMock("./lancedb-runtime.js", () => ({
+      loadLanceDbModule,
+    }));
+
+    try {
+      const { default: dynamicMemoryPlugin } = await import("./index.js");
+      const on = vi.fn();
+      // Stripped fact fits under captureMaxChars (100); the tagged form exceeds it.
+      // Under the old order (heuristic on the tagged string) this was rejected.
+      const fact = `I prefer Helix. ${"x".repeat(79)}`;
+      const tagged = `[SCOPE:project] ${fact}`;
+      const mockApi = {
+        id: "memory-lancedb",
+        name: "Memory (LanceDB)",
+        source: "test",
+        config: {},
+        pluginConfig: {
+          embedding: { apiKey: OPENAI_API_KEY, model: "text-embedding-3-small" },
+          dbPath: getDbPath(),
+          autoCapture: true,
+          autoRecall: false,
+          captureMaxChars: 100,
+        },
+        runtime: {},
+        logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+        registerTool: vi.fn(),
+        registerCli: vi.fn(),
+        registerService: vi.fn(),
+        on,
+        resolvePath: (p: string) => p,
+      };
+
+      registerTestPlugin(dynamicMemoryPlugin, mockApi);
+      // Guard the arithmetic the regression hinges on: stripped <= max < tagged.
+      expect(fact.length).toBeLessThanOrEqual(100);
+      expect(tagged.length).toBeGreaterThan(100);
+
+      const agentEnd = on.mock.calls.find(([hookName]) => hookName === "agent_end")?.[1];
+      expect(agentEnd).toBeTypeOf("function");
+
+      await agentEnd?.(
+        {
+          success: true,
+          messages: [{ role: "user", content: tagged }],
+        },
+        {},
+      );
+
+      // Captured on the stripped fact, under its scope; the tag is never embedded.
+      expect(embeddingsCreate).toHaveBeenCalledTimes(1);
+      expect(embeddingsCreate).toHaveBeenCalledWith({
+        model: "text-embedding-3-small",
+        input: fact,
+      });
+      expect(add).toHaveBeenCalledTimes(1);
+      const memory = firstAddedMemory(add);
+      expect(memory.text).toBe(fact);
+      expect(memory.scope).toBe("project");
+    } finally {
+      vi.doUnmock("openclaw/plugin-sdk/runtime-env");
+      vi.doUnmock("openai");
+      vi.doUnmock("./lancedb-runtime.js");
+      vi.resetModules();
+    }
+  });
+
+  test("ltm search is global-only by default and honors --scope", async () => {
+    // Regression (codex P2): the CLI search path passed no filter, so a table-wide
+    // ANN scan leaked scoped rows across partitions once any [SCOPE:...] memory
+    // existed. It must mirror the memory_recall tool: unscoped is global-only,
+    // --scope <slug> restricts to that partition, and a non-slug key is rejected.
+    const embeddingsCreate = vi.fn(async () => ({ data: [{ embedding: [0.1, 0.2, 0.3] }] }));
+    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
+    const whereFilters: string[] = [];
+    const toArray = vi.fn(async () => []);
+    const limit = vi.fn(() => ({ toArray }));
+    const where = vi.fn((filter: string) => {
+      whereFilters.push(filter);
+      return { limit };
+    });
+    const vectorSearch = vi.fn(() => ({ where, limit }));
+    const loadLanceDbModule = vi.fn(async () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          add: vi.fn(async () => undefined),
+          countRows: vi.fn(async () => 0),
+          delete: vi.fn(async () => undefined),
+        })),
+      })),
+    }));
+
+    await withMockedOpenAiMemoryPlugin({
+      ensureGlobalUndiciEnvProxyDispatcher,
+      embeddingsCreate,
+      loadLanceDbModule,
+      run: async (dynamicMemoryPlugin) => {
+        const registerCli = vi.fn();
+        const mockApi = {
+          id: "memory-lancedb",
+          name: "Memory (LanceDB)",
+          source: "test",
+          config: {},
+          pluginConfig: {
+            embedding: { apiKey: OPENAI_API_KEY, model: "text-embedding-3-small" },
+            dbPath: getDbPath(),
+            autoCapture: false,
+            autoRecall: false,
+          },
+          runtime: {},
+          logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+          registerTool: vi.fn(),
+          registerCli,
+          registerService: vi.fn(),
+          on: vi.fn(),
+          resolvePath: (filePath: string) => filePath,
+        };
+        const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+        try {
+          registerTestPlugin(dynamicMemoryPlugin, mockApi);
+          const registrar = firstMockArg(registerCli as unknown as MockCallSource, "cli registrar");
+          const runSearch = async (args: string[]) => {
+            const program = new Command();
+            program.exitOverride();
+            (registrar as (params: { program: Command }) => void)({ program });
+            await program.parseAsync(["node", "openclaw", "ltm", "search", ...args]);
+          };
+
+          // Unscoped: global-only prefilter, never a table-wide scan.
+          await runSearch(["deploy notes"]);
+          expect(whereFilters).toEqual(["scope = '' OR scope IS NULL"]);
+
+          // Scoped: restricted to the requested partition.
+          await runSearch(["deploy notes", "--scope", "demo-shop_eu"]);
+          expect(whereFilters).toEqual(["scope = '' OR scope IS NULL", "scope = 'demo-shop_eu'"]);
+
+          // A non-slug scope key is rejected before any search runs.
+          await expect(runSearch(["deploy notes", "--scope", "!ops:example.org"])).rejects.toThrow(
+            /slug/,
+          );
+          expect(whereFilters).toHaveLength(2);
+        } finally {
+          log.mockRestore();
+        }
+      },
+    });
+  });
+
+  test("memory_forget by memoryId is fenced to the row's scope", async () => {
+    // Regression (codex P2): deleting by memoryId must respect the partition. A
+    // scoped row can only be forgotten from within its scope; an unscoped forget
+    // may only remove global rows. Otherwise a known id from another partition
+    // could bypass the isolation this feature adds.
+    const scopedId = "11111111-1111-1111-1111-111111111111";
+    const globalId = "22222222-2222-2222-2222-222222222222";
+    const missingId = "33333333-3333-3333-3333-333333333333";
+    const rowsById: Record<string, { id: string; scope: string }> = {
+      [scopedId]: { id: scopedId, scope: "alpha" },
+      [globalId]: { id: globalId, scope: "" },
+    };
+    const embeddingsCreate = vi.fn(async () => ({ data: [{ embedding: [0.1, 0.2, 0.3] }] }));
+    const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
+    const del = vi.fn(async () => undefined);
+    // .where()-aware query() mock: getScopeById filters by `id = '<id>'`.
+    const query = vi.fn(() => {
+      let filter = "";
+      const q: {
+        where: (f: string) => typeof q;
+        limit: (n: number) => { toArray: () => Promise<unknown[]> };
+      } = {
+        where: (f: string) => {
+          filter = f;
+          return q;
+        },
+        limit: (_n: number) => ({
+          toArray: async () => {
+            const m = /id = '([^']+)'/.exec(filter);
+            const id = m?.[1];
+            const row = id ? rowsById[id] : undefined;
+            return row ? [row] : [];
+          },
+        }),
+      };
+      return q;
+    });
+    const emptyVectorQuery = {
+      where: () => ({ limit: () => ({ toArray: async () => [] }) }),
+      limit: () => ({ toArray: async () => [] }),
+    };
+    const loadLanceDbModule = vi.fn(async () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch: vi.fn(() => emptyVectorQuery),
+          query,
+          add: vi.fn(async () => undefined),
+          countRows: vi.fn(async () => 2),
+          delete: del,
+        })),
+      })),
+    }));
+
+    await withMockedOpenAiMemoryPlugin({
+      ensureGlobalUndiciEnvProxyDispatcher,
+      embeddingsCreate,
+      loadLanceDbModule,
+      run: async (dynamicMemoryPlugin) => {
+        const registeredTools: any[] = [];
+        const mockApi = {
+          id: "memory-lancedb",
+          name: "Memory (LanceDB)",
+          source: "test",
+          config: {},
+          pluginConfig: {
+            embedding: { apiKey: OPENAI_API_KEY, model: "text-embedding-3-small" },
+            dbPath: getDbPath(),
+            autoCapture: false,
+            autoRecall: false,
+          },
+          runtime: {},
+          logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+          registerTool: (tool: any, opts: any) => {
+            registeredTools.push({ tool, opts });
+          },
+          registerCli: vi.fn(),
+          registerService: vi.fn(),
+          on: vi.fn(),
+          resolvePath: (filePath: string) => filePath,
+        };
+
+        registerTestPlugin(dynamicMemoryPlugin, mockApi);
+        const forgetTool = registeredTools.find((t) => t.opts?.name === "memory_forget")?.tool;
+        if (!forgetTool) {
+          throw new Error("memory_forget tool was not registered");
+        }
+
+        // 1. Unscoped forget of a SCOPED row -> blocked, not deleted.
+        const blocked = await forgetTool.execute("c1", { memoryId: scopedId });
+        expect(blocked.details?.action).toBe("blocked");
+        expect(del).not.toHaveBeenCalled();
+
+        // 2. Forget with the MATCHING scope -> deleted.
+        const okScoped = await forgetTool.execute("c2", { memoryId: scopedId, scope: "alpha" });
+        expect(okScoped.details?.action).toBe("deleted");
+        // MemoryDB.delete issues `id = '<id>'` to the table.
+        expect(del).toHaveBeenCalledWith(`id = '${scopedId}'`);
+
+        // 3. Forget with a DIFFERENT scope -> blocked.
+        del.mockClear();
+        const wrongScope = await forgetTool.execute("c3", { memoryId: scopedId, scope: "beta" });
+        expect(wrongScope.details?.action).toBe("blocked");
+        expect(del).not.toHaveBeenCalled();
+
+        // 4. Unscoped forget of a GLOBAL row -> deleted.
+        del.mockClear();
+        const okGlobal = await forgetTool.execute("c4", { memoryId: globalId });
+        expect(okGlobal.details?.action).toBe("deleted");
+        expect(del).toHaveBeenCalledWith(`id = '${globalId}'`);
+
+        // 5. Unknown id -> not found, nothing deleted.
+        del.mockClear();
+        const missing = await forgetTool.execute("c5", { memoryId: missingId });
+        expect(missing.details?.action).toBe("not_found");
+        expect(del).not.toHaveBeenCalled();
+      },
+    });
+  });
+
   test("detectCategory classifies using production logic", () => {
     expect(detectCategory("I prefer dark mode")).toBe("preference");
     expect(detectCategory("We decided to use React")).toBe("decision");
@@ -2985,7 +4331,7 @@ describe("memory plugin e2e", () => {
 
     const toArray = vi.fn(async () => fakeRows);
     const limitFn = vi.fn(() => ({ toArray }));
-    const vectorSearch = vi.fn(() => ({ limit: limitFn }));
+    const vectorSearch = vi.fn(() => ({ where: () => ({ limit: limitFn }), limit: limitFn }));
 
     vi.resetModules();
     vi.doMock("openai", () => ({
@@ -3050,6 +4396,132 @@ describe("memory plugin e2e", () => {
       // Ensure truncated 8-char prefix alone is NOT the format used
       expect(text).not.toMatch(/\[890e1fae\]/);
       expect(text).not.toMatch(/\[a1b2c3d4\]/);
+    } finally {
+      vi.doUnmock("openai");
+      vi.doUnmock("./lancedb-runtime.js");
+      vi.resetModules();
+    }
+  });
+
+  test("memory_forget scopes the query search: forgetting in one scope spares another", async () => {
+    // Regression (P2): the query-based forget must not delete a same-fact row from
+    // a different scope. With a `scope`, the search is restricted to that exact
+    // scope via a native .where() prefilter, so a scoped forget can only ever
+    // delete within its own scope — never a global or other-scope copy.
+    const alphaId = "11111111-1111-4111-8111-111111111111";
+    const betaId = "22222222-2222-4222-8222-222222222222";
+    // The same fact stored under two different scopes.
+    const rows: Array<Record<string, unknown>> = [
+      {
+        id: alphaId,
+        text: "[SCOPE:alpha] the deadline is Friday",
+        category: "fact",
+        vector: [0.1],
+        importance: 0.8,
+        createdAt: Date.now(),
+        scope: "alpha",
+      },
+      {
+        id: betaId,
+        text: "[SCOPE:beta] the deadline is Friday",
+        category: "fact",
+        vector: [0.1],
+        importance: 0.8,
+        createdAt: Date.now(),
+        scope: "beta",
+      },
+    ];
+
+    // Query builder that honors the `scope = '<x>'` prefilter; every surviving row
+    // comes back as an exact match (_distance 0 -> score 1.0, above the 0.9 auto-
+    // delete threshold).
+    const buildQuery = (filter?: string) => ({
+      where: (f: string) => buildQuery(f),
+      limit: () => ({
+        toArray: async () =>
+          rows
+            .filter((r) => {
+              if (!filter) {
+                return true;
+              }
+              const rowScope = typeof r.scope === "string" ? r.scope : "";
+              return filter === `scope = '${rowScope}'`;
+            })
+            .map((r) => Object.assign({}, r, { _distance: 0 })),
+      }),
+    });
+    const vectorSearch = vi.fn(() => buildQuery(undefined));
+    const deleteFn = vi.fn(async (predicate: string) => {
+      const match = /id = '([^']+)'/.exec(predicate);
+      if (match) {
+        const idx = rows.findIndex((r) => r.id === match[1]);
+        if (idx >= 0) {
+          rows.splice(idx, 1);
+        }
+      }
+    });
+
+    vi.resetModules();
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        post = vi.fn(async () => ({ data: [{ embedding: [0.1, 0.2, 0.3] }] }));
+      },
+    }));
+    vi.doMock("./lancedb-runtime.js", () => ({
+      loadLanceDbModule: vi.fn(async () => ({
+        connect: vi.fn(async () => ({
+          tableNames: vi.fn(async () => ["memories"]),
+          openTable: vi.fn(async () => ({
+            vectorSearch,
+            countRows: vi.fn(async () => rows.length),
+            add: vi.fn(async () => undefined),
+            delete: deleteFn,
+          })),
+        })),
+      })),
+    }));
+
+    try {
+      const { default: memoryPluginLocal } = await import("./index.js");
+      const registeredTools: any[] = [];
+      const mockApi = {
+        id: "memory-lancedb",
+        name: "Memory (LanceDB)",
+        source: "test",
+        config: {},
+        pluginConfig: {
+          embedding: { apiKey: OPENAI_API_KEY, model: "text-embedding-3-small" },
+          dbPath: getDbPath(),
+          autoCapture: false,
+          autoRecall: false,
+        },
+        runtime: {},
+        logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+        registerTool: (tool: any, opts: any) => {
+          registeredTools.push({ tool, opts });
+        },
+        registerCli: vi.fn(),
+        registerService: vi.fn(),
+        on: vi.fn(),
+        resolvePath: (p: string) => p,
+      };
+
+      registerTestPlugin(memoryPluginLocal, mockApi);
+      const forgetTool = registeredTools.find((t) => t.opts?.name === "memory_forget")?.tool;
+      if (!forgetTool) {
+        throw new Error("expected memory_forget tool registration");
+      }
+      expectToolExecute(forgetTool);
+
+      // Forget the fact in beta only: it deletes beta's row, and the alpha copy
+      // (an exact vector match in a different scope) must survive.
+      const result = await forgetTool.execute("call-forget-beta", {
+        query: "the deadline is Friday",
+        scope: "beta",
+      });
+      expect(result.details?.action).toBe("deleted");
+      expect(result.details?.id).toBe(betaId);
+      expect(rows.map((r) => r.id)).toEqual([alphaId]);
     } finally {
       vi.doUnmock("openai");
       vi.doUnmock("./lancedb-runtime.js");

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -56,6 +56,8 @@ type MemoryEntry = {
   importance: number;
   category: MemoryCategory;
   createdAt: number;
+  scope?: string;
+  agent?: string;
 };
 
 type MemoryListEntry = Omit<MemoryEntry, "vector">;
@@ -195,6 +197,35 @@ const DEFAULT_AUTO_RECALL_OVERFETCH_LIMIT = 10;
 const DEFAULT_AUTO_RECALL_RESULT_CAP = 3;
 const DUPLICATE_SEARCH_LIMIT = 5;
 
+// A scope key is an opaque partition slug matching [a-zA-Z0-9_-]+.
+const SCOPE_KEY_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+// Parse an optional scope tool argument. An empty/absent value means "unscoped"
+// (global). A non-empty value that is not a valid slug is reported as invalid
+// rather than silently stripped/transformed — otherwise a punctuated key could
+// be canonicalized into (and mixed with) a different partition.
+function parseScopeArg(raw: unknown): { scope: string } | { invalidKey: string } {
+  if (typeof raw !== "string" || raw === "") {
+    return { scope: "" };
+  }
+  return SCOPE_KEY_PATTERN.test(raw) ? { scope: raw } : { invalidKey: raw };
+}
+
+function deriveAgentFromSessionKey(sessionKey: string | undefined): string {
+  // Provenance only (never used to filter recall). Gateway sessionKey scheme is
+  // "agent:<agentId>:<transport>:..." (e.g. "agent:<id>:slack:channel:...");
+  // agentId is the 2nd segment.
+  if (!sessionKey) {
+    return "";
+  }
+  const parts = sessionKey.split(":");
+  if (parts[0] !== "agent" || parts.length < 2) {
+    return "";
+  }
+  const seg = (parts[1] ?? "").trim();
+  return /^[a-zA-Z0-9_-]+$/.test(seg) ? seg : "";
+}
+
 function parsePositiveIntegerOption(value: string | undefined, flag: string): number | undefined {
   if (value === undefined) {
     return undefined;
@@ -242,6 +273,20 @@ class MemoryDB {
 
     if (tables.includes(TABLE_NAME)) {
       this.table = await this.db.openTable(TABLE_NAME);
+      // Migration (2026.6.x): self-heal scope columns on pre-existing tables.
+      // Guarded on schema()/addColumns presence so partial Table test doubles
+      // are a no-op; real LanceDB implements both. addColumns preserves existing
+      // rows + vectors. Default '' = unscoped/global; idempotent
+      // (skips when the columns already exist).
+      const tbl = this.table as Partial<LanceDB.Table>;
+      if (typeof tbl.schema === "function" && typeof tbl.addColumns === "function") {
+        const existingSchema = await this.table.schema();
+        const existingNames = new Set(existingSchema.fields.map((f) => f.name));
+        const missing = (["scope", "agent"] as const).filter((c) => !existingNames.has(c));
+        if (missing.length > 0) {
+          await this.table.addColumns(missing.map((name) => ({ name, valueSql: "''" })));
+        }
+      }
     } else {
       this.table = await this.db.createTable(TABLE_NAME, [
         {
@@ -251,6 +296,8 @@ class MemoryDB {
           importance: 0,
           category: "other",
           createdAt: 0,
+          scope: "",
+          agent: "",
         },
       ]);
       await this.table.delete('id = "__schema__"');
@@ -261,6 +308,8 @@ class MemoryDB {
     await this.ensureInitialized();
 
     const fullEntry: MemoryEntry = {
+      scope: "",
+      agent: "",
       ...entry,
       id: randomUUID(),
       createdAt: Date.now(),
@@ -270,10 +319,20 @@ class MemoryDB {
     return fullEntry;
   }
 
-  async search(vector: number[], limit = 5, minScore = 0.5): Promise<MemorySearchResult[]> {
+  async search(
+    vector: number[],
+    limit = 5,
+    minScore = 0.5,
+    filter?: string,
+  ): Promise<MemorySearchResult[]> {
     await this.ensureInitialized();
 
-    const results = await this.table!.vectorSearch(vector).limit(limit).toArray();
+    let pending = this.table!.vectorSearch(vector);
+    if (filter) {
+      // Native LanceDB prefilter: only rows matching `filter` enter the ANN scan.
+      pending = pending.where(filter);
+    }
+    const results = await pending.limit(limit).toArray();
 
     // LanceDB uses L2 distance by default; convert to similarity score
     const mapped = results.map((row) => {
@@ -288,6 +347,8 @@ class MemoryDB {
           importance: row.importance as number,
           category: row.category as MemoryEntry["category"],
           createdAt: row.createdAt as number,
+          scope: (row.scope as string | undefined) ?? undefined,
+          agent: (row.agent as string | undefined) ?? undefined,
         },
         score,
       };
@@ -330,6 +391,22 @@ class MemoryDB {
     }
     await this.table!.delete(`id = '${id}'`);
     return true;
+  }
+
+  // Returns the scope of a row by id ("" = global), or null when no such row
+  // exists. Used to fence memoryId-based deletes to the caller's partition.
+  async getScopeById(id: string): Promise<string | null> {
+    await this.ensureInitialized();
+    // Validate UUID format to prevent injection (mirrors delete()).
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!uuidRegex.test(id)) {
+      throw new Error(`Invalid memory ID format: ${id}`);
+    }
+    const rows = await this.table!.query().where(`id = '${id}'`).limit(1).toArray();
+    if (rows.length === 0) {
+      return null;
+    }
+    return (rows[0].scope as string | undefined) ?? "";
   }
 
   async count(): Promise<number> {
@@ -649,12 +726,29 @@ function sanitizeRecallMemoryText(text: string): string | null {
 
 async function findCleanDuplicateMemory(
   db: {
-    search(vector: number[], limit?: number, minScore?: number): Promise<MemorySearchResult[]>;
+    search(
+      vector: number[],
+      limit?: number,
+      minScore?: number,
+      filter?: string,
+    ): Promise<MemorySearchResult[]>;
   },
   vector: number[],
+  scope: string,
 ): Promise<MemorySearchResult | undefined> {
-  const existing = await db.search(vector, DUPLICATE_SEARCH_LIMIT, 0.95);
-  return existing.find((result) => sanitizeRecallMemoryText(result.entry.text) !== null);
+  // Prefilter by scope so the near-exact (>=0.95) neighbors are all within the
+  // requested scope. A global top-K could otherwise push the same-scope duplicate
+  // out of the returned rows once many scopes share a near-identical vector,
+  // silently accepting a duplicate that already exists in that scope. Scoped
+  // writes match that exact scope; global writes (scope === "") match other global
+  // rows (stored "" or legacy NULL). The scope post-filter is a defensive ''/NULL
+  // normalization; the sanitize post-filter mirrors this helper's prior behavior.
+  const scopeFilter = scope ? `scope = '${scope}'` : `scope = '' OR scope IS NULL`;
+  const existing = await db.search(vector, DUPLICATE_SEARCH_LIMIT, 0.95, scopeFilter);
+  return existing.find(
+    (result) =>
+      sanitizeRecallMemoryText(result.entry.text) !== null && (result.entry.scope ?? "") === scope,
+  );
 }
 
 function cleanMemorySearchResults(results: MemorySearchResult[]): Array<{
@@ -1457,6 +1551,9 @@ export default definePluginEntry({
         autoRecall: cfg.autoRecall,
         captureMaxChars: cfg.captureMaxChars,
         recallMaxChars: cfg.recallMaxChars,
+        recallMinScore: cfg.recallMinScore,
+        recallResultCap: cfg.recallResultCap,
+        autoRecallOverfetch: cfg.autoRecallOverfetch,
         ...(cfg.storageOptions ? { storageOptions: cfg.storageOptions } : {}),
         ...asRecord(runtimePluginConfig),
       });
@@ -1501,11 +1598,30 @@ export default definePluginEntry({
         parameters: Type.Object({
           query: Type.String({ description: "Search query" }),
           limit: optionalPositiveIntegerSchema({ description: "Max results (default: 5)" }),
+          scope: Type.Optional(
+            Type.String({
+              description:
+                "Restrict recall to this scope — an opaque partition key (a slug matching [A-Za-z0-9_-]+) such as a project, person, or channel. This scope's memories are returned first; unscoped/global memories fill any remaining slots. When omitted, only unscoped/global memories are searched — scoped memories stay hidden.",
+            }),
+          ),
         }),
         async execute(_toolCallId, params) {
           const rawParams = params as Record<string, unknown>;
           const query = rawParams.query as string;
           const limit = readPositiveIntegerParam(rawParams, "limit") ?? 5;
+          const scopeArg = parseScopeArg(rawParams.scope);
+          if ("invalidKey" in scopeArg) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: "Invalid scope: a scope key must be a slug matching [A-Za-z0-9_-]+ (map channel/room ids to a slug first).",
+                },
+              ],
+              details: { count: 0 },
+            };
+          }
+          const scope = scopeArg.scope;
 
           const currentCfg = resolveCurrentHookConfig();
           const cooldown = readMemoryRecallCooldown();
@@ -1526,7 +1642,26 @@ export default definePluginEntry({
                 } catch (error) {
                   throw new MemoryRecallEmbeddingError(error);
                 }
-                return await db.search(vector, limit + DEFAULT_TOOL_RECALL_OVERFETCH_EXTRA, 0.1);
+                const overfetch = limit + DEFAULT_TOOL_RECALL_OVERFETCH_EXTRA;
+                if (!scope) {
+                  // Unscoped recall is a global-only view: partitioned rows stay
+                  // hidden unless the caller asks for their scope, so scoped
+                  // memories never bleed into an unrelated plain recall.
+                  return await db.search(vector, overfetch, 0.1, `scope = '' OR scope IS NULL`);
+                }
+                // Explicit scoped recall prioritizes the requested scope. The
+                // scope's own matches and the global rows are retrieved in
+                // separate ANN passes, each with its own candidate budget, so
+                // many strong global neighbors can never crowd the requested
+                // scope out of a single shared top-K window (which would make a
+                // scoped recall silently miss rows from the very scope the
+                // caller asked for). Scoped matches come first; global matches
+                // fill any remaining slots.
+                const [scoped, globals] = await Promise.all([
+                  db.search(vector, overfetch, 0.1, `scope = '${scope}'`),
+                  db.search(vector, overfetch, 0.1, `scope = '' OR scope IS NULL`),
+                ]);
+                return [...scoped, ...globals];
               },
             });
           } catch (error) {
@@ -1592,7 +1727,7 @@ export default definePluginEntry({
         name: "memory_store",
         label: "Memory Store",
         description:
-          "Save important information in long-term memory. Use for preferences, facts, decisions.",
+          "Save important information in long-term memory. Use for preferences, facts, decisions. Prefix the text with [SCOPE:<slug>] to partition a memory to a scope (slug = [A-Za-z0-9_-]+); an invalid scope tag is rejected.",
         parameters: Type.Object({
           text: Type.String({ description: "Information to remember" }),
           importance: optionalFiniteNumberSchema({
@@ -1628,9 +1763,52 @@ export default definePluginEntry({
             };
           }
 
-          const vector = await embeddings.embed(text);
+          // The [SCOPE:...] tag is a routing prefix, not part of the fact. Detect
+          // it broadly (any content up to ']') so a punctuated key is not silently
+          // treated as untagged — which would store an intended-scoped memory in
+          // the global partition. A tag must carry a valid slug key; otherwise
+          // reject rather than mis-scope. Strip a valid tag before embedding and
+          // storing so the vector reflects the content, not the synthetic prefix.
+          const scopeTagMatch = /^\s*\[SCOPE:([^\]]*)\]\s*/.exec(text);
+          let scope = "";
+          let memoryText = text;
+          if (scopeTagMatch) {
+            const scopeKey = expectDefined(scopeTagMatch[1], "store scope tag key");
+            if (!SCOPE_KEY_PATTERN.test(scopeKey)) {
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: "Memory was not stored: the [SCOPE:...] key must be a slug matching [A-Za-z0-9_-]+ (map channel/room ids to a slug first).",
+                  },
+                ],
+                details: { action: "rejected", reason: "invalid_scope_key" },
+              };
+            }
+            scope = scopeKey;
+            // A tag-only payload ([SCOPE:x] with nothing — or only whitespace —
+            // after it) carries no fact to store. Reject it rather than fall back to
+            // the raw text: that would embed and persist the control tag itself,
+            // breaking the invariant that [SCOPE:...] is stripped before storage and
+            // leaving a synthetic tag-only memory that could later be recalled. The
+            // trim() also guards embedding backends that error on blank input.
+            memoryText = text.slice(scopeTagMatch[0].length);
+            if (memoryText.trim().length === 0) {
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: "Memory was not stored: the [SCOPE:...] tag has no memory text after it.",
+                  },
+                ],
+                details: { action: "rejected", reason: "empty_scoped_text" },
+              };
+            }
+          }
 
-          const existing = await findCleanDuplicateMemory(db, vector);
+          const vector = await embeddings.embed(memoryText);
+
+          const existing = await findCleanDuplicateMemory(db, vector, scope);
           if (existing) {
             return {
               content: [
@@ -1648,14 +1826,15 @@ export default definePluginEntry({
           }
 
           const entry = await db.store({
-            text,
+            text: memoryText,
             vector,
             importance,
             category,
+            scope,
           });
 
           return {
-            content: [{ type: "text", text: `Stored: "${truncateUtf16Safe(text, 100)}..."` }],
+            content: [{ type: "text", text: `Stored: "${truncateUtf16Safe(memoryText, 100)}..."` }],
             details: { action: "created", id: entry.id },
           };
         },
@@ -1671,11 +1850,62 @@ export default definePluginEntry({
         parameters: Type.Object({
           query: Type.Optional(Type.String({ description: "Search to find memory" })),
           memoryId: Type.Optional(Type.String({ description: "Specific memory ID" })),
+          scope: Type.Optional(
+            Type.String({
+              description:
+                "Restrict the query search to this scope — an opaque partition key (a slug matching [A-Za-z0-9_-]+) such as a project, person, or channel. Only matches within this scope can be forgotten. When omitted, only unscoped/global memories can be forgotten. With memoryId, the delete is fenced to this scope (or to global when omitted).",
+            }),
+          ),
         }),
         async execute(_toolCallId, params) {
-          const { query, memoryId } = params as { query?: string; memoryId?: string };
+          const {
+            query,
+            memoryId,
+            scope: scopeParam,
+          } = params as {
+            query?: string;
+            memoryId?: string;
+            scope?: string;
+          };
+
+          const scopeArg = parseScopeArg(scopeParam);
+          if ("invalidKey" in scopeArg) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: "Invalid scope: a scope key must be a slug matching [A-Za-z0-9_-]+ (map channel/room ids to a slug first).",
+                },
+              ],
+              details: { action: "rejected", reason: "invalid_scope_key" },
+            };
+          }
+          const scope = scopeArg.scope;
+          const scopeProvided = typeof scopeParam === "string" && scopeParam !== "";
 
           if (memoryId) {
+            const rowScope = await db.getScopeById(memoryId);
+            if (rowScope === null) {
+              return {
+                content: [{ type: "text", text: `Memory ${memoryId} not found.` }],
+                details: { action: "not_found", id: memoryId },
+              };
+            }
+            // Scope fence: a scoped row can only be forgotten from within its
+            // scope; an unscoped forget (no scope arg) may only remove global
+            // rows. Prevents deleting another partition's row via a known id.
+            const allowed = scopeProvided ? rowScope === scope : rowScope === "";
+            if (!allowed) {
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: `Memory ${memoryId} belongs to a different scope and was not deleted.`,
+                  },
+                ],
+                details: { action: "blocked", id: memoryId, reason: "scope_mismatch" },
+              };
+            }
             await db.delete(memoryId);
             return {
               content: [{ type: "text", text: `Memory ${memoryId} forgotten.` }],
@@ -1685,10 +1915,15 @@ export default definePluginEntry({
 
           if (query) {
             const currentCfg = resolveCurrentHookConfig();
+            // A scoped forget is restricted to that exact scope: a delete must
+            // never reach global or other scopes. An unscoped forget is
+            // global-only for the same reason — it must never nominate or delete
+            // a partitioned row that belongs to another scope.
+            const scopeFilter = scope ? `scope = '${scope}'` : `scope = '' OR scope IS NULL`;
             const vector = await embeddings.embed(
               normalizeRecallQuery(query, currentCfg.recallMaxChars),
             );
-            const results = await db.search(vector, 5, 0.7);
+            const results = await db.search(vector, 5, 0.7, scopeFilter);
 
             if (results.length === 0) {
               return {
@@ -1764,10 +1999,27 @@ export default definePluginEntry({
           .description("Search memories")
           .argument("<query>", "Search query")
           .option("--limit <n>", "Max results", "5")
+          .option(
+            "--scope <slug>",
+            "Restrict the search to a scope partition (default: global/untagged rows only)",
+          )
           .action(async (query, opts) => {
+            // Mirror the memory_recall tool contract: no --scope means global-only
+            // (a table-wide scan would leak scoped rows across partitions), a slug
+            // restricts to that partition, and a non-slug key is rejected rather
+            // than silently canonicalized into another partition.
+            const scopeArg = parseScopeArg(opts.scope);
+            if ("invalidKey" in scopeArg) {
+              throw new Error(
+                `--scope must be a slug matching [A-Za-z0-9_-]+ (got "${scopeArg.invalidKey}")`,
+              );
+            }
+            const scopeFilter = scopeArg.scope
+              ? `scope = '${scopeArg.scope}'`
+              : `scope = '' OR scope IS NULL`;
             const vector = await embeddings.embed(normalizeRecallQuery(query, cfg.recallMaxChars));
             const limit = parsePositiveIntegerOption(opts.limit, "--limit");
-            const results = await db.search(vector, limit, 0.3);
+            const results = await db.search(vector, limit, 0.3, scopeFilter);
             // Strip vectors for output
             const output = results.map((r) => ({
               id: r.entry.id,
@@ -1883,7 +2135,16 @@ export default definePluginEntry({
             });
             // Overfetch to compensate for sludge filtering: if contaminated
             // entries occupy the top slots we still surface enough clean ones.
-            return await db.search(vector, DEFAULT_AUTO_RECALL_OVERFETCH_LIMIT, 0.3);
+            // The before-prompt hook has no active-scope signal, so it injects
+            // only global/untagged memories. Partitioned rows are never
+            // auto-recalled into an unrelated session; scope-aware auto-injection
+            // is left for a later change that can derive the active scope here.
+            return await db.search(
+              vector,
+              currentCfg.autoRecallOverfetch ?? DEFAULT_AUTO_RECALL_OVERFETCH_LIMIT,
+              currentCfg.recallMinScore ?? 0.3,
+              `scope = '' OR scope IS NULL`,
+            );
           },
         });
         if (recall.status === "timeout") {
@@ -1896,7 +2157,7 @@ export default definePluginEntry({
         // Filter contaminated memories, then cap at the prompt-budget bound.
         const cleanResults = cleanMemorySearchResults(recall.value)
           .map(({ result, text }) => ({ category: result.entry.category, text }))
-          .slice(0, DEFAULT_AUTO_RECALL_RESULT_CAP);
+          .slice(0, currentCfg.recallResultCap ?? DEFAULT_AUTO_RECALL_RESULT_CAP);
 
         if (cleanResults.length === 0) {
           return undefined;
@@ -1930,6 +2191,7 @@ export default definePluginEntry({
 
       try {
         const cursorKey = ctx.sessionKey ?? ctx.sessionId;
+        const writerAgent = deriveAgentFromSessionKey(ctx.sessionKey ?? ctx.sessionId);
         const startIndex = resolveAutoCaptureStartIndex(
           event.messages,
           cursorKey ? autoCaptureCursors.get(cursorKey) : undefined,
@@ -1944,9 +2206,34 @@ export default definePluginEntry({
             for (const text of extractUserTextContent(message)) {
               // Sanitize envelope metadata before checking and storing
               const sanitized = sanitizeForMemoryCapture(text);
+              if (!sanitized) {
+                continue;
+              }
+
+              // Detect and strip the [SCOPE:...] tag BEFORE the capture heuristics,
+              // so the routing prefix never changes capture eligibility: its length
+              // must not push short content over the minimum, nor a long tag push
+              // otherwise-valid content past captureMaxChars. A punctuated/invalid
+              // key is skipped rather than stored globally (which would leak an
+              // intended-scoped memory into the global partition). The stripped text
+              // is what both the heuristic and the embedding see.
+              const scopeTagMatch = /^\s*\[SCOPE:([^\]]*)\]\s*/.exec(sanitized);
+              let scope = "";
+              let memoryText = sanitized;
+              if (scopeTagMatch) {
+                const scopeKey = expectDefined(scopeTagMatch[1], "capture scope tag key");
+                if (!SCOPE_KEY_PATTERN.test(scopeKey)) {
+                  continue;
+                }
+                scope = scopeKey;
+                memoryText = sanitized.slice(scopeTagMatch[0].length);
+              }
+
+              // Tag-only or whitespace-only payloads carry no fact; run the capture
+              // heuristics on the stripped text so eligibility is tag-independent.
               if (
-                !sanitized ||
-                !shouldCapture(sanitized, {
+                memoryText.trim().length === 0 ||
+                !shouldCapture(memoryText, {
                   customTriggers: currentCfg.customTriggers,
                   maxChars: currentCfg.captureMaxChars,
                 })
@@ -1958,19 +2245,21 @@ export default definePluginEntry({
                 continue;
               }
 
-              const category = detectCategory(sanitized);
-              const vector = await embeddings.embed(sanitized);
+              const category = detectCategory(memoryText);
+              const vector = await embeddings.embed(memoryText);
 
-              const existing = await findCleanDuplicateMemory(db, vector);
+              const existing = await findCleanDuplicateMemory(db, vector, scope);
               if (existing) {
                 continue;
               }
 
               await db.store({
-                text: sanitized,
+                text: memoryText,
                 vector,
                 importance: 0.7,
                 category,
+                scope,
+                agent: writerAgent,
               });
               stored++;
             }

--- a/extensions/memory-lancedb/openclaw.plugin.json
+++ b/extensions/memory-lancedb/openclaw.plugin.json
@@ -79,6 +79,24 @@
       "label": "Storage Options",
       "advanced": true,
       "help": "Storage configuration options (access_key, secret_key, endpoint, etc.); supports ${ENV_VAR} values"
+    },
+    "recallMinScore": {
+      "label": "Recall Min Score",
+      "advanced": true,
+      "placeholder": "0.3",
+      "help": "Minimum similarity score (0-1) required for an auto-recall match. Higher is stricter."
+    },
+    "recallResultCap": {
+      "label": "Recall Result Cap",
+      "advanced": true,
+      "placeholder": "3",
+      "help": "Maximum number of memories injected per auto-recall."
+    },
+    "autoRecallOverfetch": {
+      "label": "Auto-Recall Overfetch",
+      "advanced": true,
+      "placeholder": "10",
+      "help": "Candidates fetched before sludge-filtering and capping during auto-recall."
     }
   },
   "configSchema": {
@@ -139,6 +157,21 @@
         "type": "number",
         "minimum": 100,
         "maximum": 10000
+      },
+      "recallMinScore": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1
+      },
+      "recallResultCap": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 50
+      },
+      "autoRecallOverfetch": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 200
       },
       "storageOptions": {
         "type": "object",


### PR DESCRIPTION
<!--
DRAFT — for Joël's zero-leak review before opening.
Target: openclaw/openclaw (base: main). Follows .github/pull_request_template.md.
Sanitized: no client names, no server paths, no internal metrics.
PR title:
  feat(memory-lancedb): scope memory_recall and memory_forget + configurable thresholds
-->

## What Problem This Solves

When several contexts share a single LanceDB memory store, the explicit memory
tools operate across the **entire** store with no way to constrain them to a
subset:

- `memory_recall` selects the top-K nearest vectors globally, so a memory written
  in one context can surface as a recall result in an unrelated one.
- `memory_forget` (query mode) runs an unfiltered vector search and auto-deletes a
  lone high-confidence match — so once the same fact exists in more than one
  context, it can delete the wrong context's copy.
- The **automatic before-prompt recall** injects from the whole store on every
  turn, with no way to keep one context's memories out of an unrelated
  conversation.

Splitting into a separate store per context is the only current workaround, which
defeats the point of a shared store. Two smaller gaps compound this:

- **Duplicate detection is global.** The same fact stored under two different
  contexts is rejected as a duplicate on the second write, so it can never be
  recalled within the second context.
- **Recall selectivity is hardcoded** (minimum similarity score, result cap, and
  auto-recall over-fetch), so operators cannot tune precision/recall for their
  own data without editing the plugin source.

## Why This Change Was Made

Add an optional per-row **scope** column and apply a native LanceDB `.where()`
**prefilter** in the explicit memory tools, so results are constrained to the
requested scope *before* the vector search returns — no separate store per context
needed. `.where()` is a native LanceDB primitive the plugin already uses on the
`--filter` CLI path but not on these tools.

**Scope is an opaque partition key, not a fixed concept.** It is whatever the
caller wants to partition by — a project, a person, a channel, a tenant. The
plugin never interprets it: a memory is tagged by prefixing its text with
`[SCOPE:<value>]`, and both tools take a `scope` parameter. The tag is a routing
prefix, not part of the fact: it is parsed into the `scope` column and **stripped
from the text before embedding and storing** (in both the explicit store tool and
the auto-capture path), so the vector reflects the content rather than the
synthetic prefix and the tag is never echoed back to the model on recall. A scope
key is a slug (`[A-Za-z0-9_-]+`); a tag or `scope` argument whose key is not a valid
slug is **rejected** rather than silently transformed, so a punctuated key (e.g. a
raw channel/room id) can never be canonicalized into — and mixed with — another
partition, nor silently stored global. OpenClaw builds the `.where()` clause
internally from the validated slug — no raw filter expression is ever accepted from
the caller.

**Scope is enforced as a partition, not an optional label.** A tagged memory is
hidden from any operation that does not ask for its scope — it never surfaces in an
unscoped recall, is never auto-recalled into an unrelated session, and can never be
deleted by an unscoped forget. The three read/delete paths:

- **`memory_recall`** — a *scoped* call returns that scope's matches first, with
  untagged/global rows filling any remaining slots; the scope and the global rows
  are retrieved in **separate ANN passes** (each with its own candidate budget) so
  many strong global neighbors cannot crowd the requested scope out of a shared
  top-K and make the call miss rows from the very scope it asked for. An *unscoped*
  call is **global-only** (`scope = '' OR scope IS NULL`) — scoped rows stay
  hidden.
- **`memory_forget`** — a *scoped* call is restricted to the **exact** scope
  (`scope = '…'`); an *unscoped* call is **global-only**. This holds for **both**
  delete paths: a **query** forget filters by scope, and a **memoryId** forget is
  fenced by first checking the target row's scope — a scoped row can only be deleted
  from within its scope, and an unscoped `memoryId` delete only removes global rows
  — so a known id from another partition cannot bypass the fence.
- **Automatic before-prompt recall** — **global-only**. The hook has no
  active-scope signal, so it injects only untagged/global memories; a scoped memory
  is never auto-recalled into an unrelated session.

Scope is threaded consistently so it cannot silently mis-behave:

- Duplicate detection is made **scope-aware**: the scope is applied as a
  `.where()` prefilter before the near-exact top-K, so a duplicate only counts
  within the same scope and a same-scope duplicate is never pushed out of the
  candidate window by other scopes. The same fact can coexist under different
  scopes; same-scope and global-vs-global writes still dedup.
- A self-healing migration adds the `scope` column to pre-existing tables
  (guarded on the driver's `schema()`/`addColumns`; a no-op for partial test
  doubles), preserving existing rows and vectors.

The recall thresholds are surfaced as configuration (with matching manifest
`uiHints`, so they appear in setup/config flows) with defaults equal to the
previously hardcoded values. They are threaded through the live-config merge so
operator values take effect in the before-prompt hook, not only at startup.

**What is deferred (explicit non-goal).** This PR does not *target* the automatic
before-prompt injection at a specific scope — the hook has no active-scope signal,
so it cannot know which partition the current turn belongs to. Rather than leak, it
**fails safe**: the automatic path is restricted to global/untagged memories, so a
scoped memory is never auto-injected anywhere. Scope-*targeted* auto-injection
(surfacing `scope=alpha` memories inside an alpha turn) is future work; the scope
column and `.where()` prefilter added here are the foundation a later change can
build on once such a signal is available at that hook.

**Security model — scope is a partition primitive, not a trust boundary.** The
`scope` value is caller-supplied (a `scope` argument, or a `[SCOPE:<value>]` tag in
the text), and OpenClaw deliberately does **not** bind it to a session/channel
identity: the partition key is caller-defined (a project, a person, a tenant), and
only the caller knows which partition a given turn belongs to. This does not weaken
the current model — today every memory is global, so any turn can already recall,
forget, or write any memory. Scope only **adds** isolation: a tagged row is hidden
from unscoped operations, so a caller that supplies a consistent scope gains
partitioning it did not have before, and no caller gains a capability it lacked.
Treating a scope as an *enforced* boundary between mutually-distrusting callers
(checking the requested scope against a trusted active-session signal before every
read/write/delete) is a deployment policy layered on top of this primitive, and is
deferred to the same future work as scope-targeted auto-injection — the `scope`
column and `.where()` prefilter added here are exactly the mechanism such a policy
would build on.

The change is **behavior-preserving until you tag a memory**: every pre-existing
row has an empty scope, so it stays global and is returned by unscoped recall and
the automatic injection exactly as before, and thresholds default to today's
values. A memory becomes partitioned only when it is explicitly tagged
`[SCOPE:<value>]` (via the store tool or a tagged user message) — at which point it
is hidden from unscoped and other-scope operations by design. Installs that never
use scope tags see no change at all.

## User Impact

- A tagged memory is **partitioned in a shared store**: it is hidden from unscoped
  recall, never auto-recalled into an unrelated session, and cannot be deleted by
  an unscoped forget — real isolation without splitting into multiple stores.
- Callers can pass `scope` to `memory_recall` to **read one partition** (project,
  person, channel, …): that scope's memories are returned first and untagged/global
  ones fill any remaining slots, and a scope with many strong global neighbors is
  no longer crowded out of the results.
- Callers can pass `scope` to `memory_forget` to **delete safely within one
  partition**: a scoped forget can never remove a global or other-scope copy of
  the same fact, and this fence applies to **both** the `query` and the `memoryId`
  delete paths (a known id from another partition cannot bypass it).
- An invalid scope key (not a `[A-Za-z0-9_-]+` slug) is **rejected**, not silently
  stored global — a punctuated key such as a raw channel/room id cannot leak an
  intended-scoped memory into the global partition.
- The same fact can be stored under **different scopes** without the second write
  being swallowed as a duplicate.
- Recall precision/recall is **tunable via config** (`recallMinScore`,
  `recallResultCap`, `autoRecallOverfetch`) instead of requiring a source edit.
- **No change until you use scope**: with no scope tags, every row stays global —
  unscoped recall, forget, and the automatic before-prompt injection behave exactly
  as before.

## Evidence

### Real-behavior proof (real `@lancedb/lancedb` driver, on-disk table)

The unit tests mock the LanceDB driver, so the two things they cannot show are the
schema **migration** and the native **prefilter** running against the real engine.
The script below drives the real pinned `@lancedb/lancedb` (no mock) on a real
on-disk table, replaying `MemoryDB`'s exact persistence operations — the self-heal
migration (`schema()` → `addColumns`), the scoped/unscoped `.where()` recall, and
the scoped delete. Deterministic vectors, no embeddings/network; the only scope
slug is the fictional `demo-shop_eu` and all memory text is generic.

```text
temp store: /tmp/mldb-scope-proof-XXXXXX

PART 1 — migration on a pre-existing (legacy) table
  legacy columns: id, text, vector, importance, category, createdAt
  [PASS] legacy table has no 'scope' column
  [PASS] legacy table has no 'agent' column
  missing columns detected: ["scope","agent"]
  columns after migration: id, text, vector, importance, category, createdAt, scope, agent
  [PASS] 'scope' column added
  [PASS] 'agent' column added
  [PASS] both legacy rows preserved
  [PASS] row 'a' text preserved
  [PASS] row 'a' vector preserved (len + values)
  [PASS] migrated rows default to global scope ''

PART 2 — native .where() prefilter isolation
  scoped recall  where scope='demo-shop_eu' -> ids: [c]
  [PASS] scoped recall returns ONLY the scoped row (c)
  unscoped recall where scope=''/NULL   -> ids: [a,b]
  [PASS] unscoped recall returns ONLY global rows (a,b)
  [PASS] scoped row hidden from unscoped recall despite identical nearest vector

PART 3 — scoped delete is fenced to its scope
  rows after delete where scope='demo-shop_eu' -> ids: [a,b]
  [PASS] scoped delete removed the scoped row (c gone)
  [PASS] scoped delete preserved global rows (a,b remain)

=== RESULT: ALL CHECKS PASSED ===
```

The scoped row (`c`) is deliberately given the **same nearest vector** as a global
row (`a`), so only a real prefilter — not distance ranking — can keep it out of the
unscoped recall. The migrated `scope` column is non-nullable and defaults to `''`,
so pre-existing rows become global while their vectors are preserved (the
`OR scope IS NULL` branch is a defensive belt-and-suspenders for any externally
NULL rows).

<details>
<summary>Reproducible standalone script (drop at repo root, <code>node _scope-proof.mjs</code>)</summary>

```js
import { mkdtemp, rm } from "node:fs/promises";
import { tmpdir } from "node:os";
import { join } from "node:path";
import * as lancedb from "@lancedb/lancedb";

const DIM = 8;
const near = Array.from({ length: DIM }, (_, i) => (i === 0 ? 1 : 0));
const far = Array.from({ length: DIM }, (_, i) => (i === DIM - 1 ? 1 : 0));
const query = near;

let failures = 0;
function check(label, cond) {
  console.log(`  [${cond ? "PASS" : "FAIL"}] ${label}`);
  if (!cond) failures++;
}
const ids = (rows) => rows.map((r) => r.id).sort().join(",");

const dir = await mkdtemp(join(tmpdir(), "mldb-scope-proof-"));
const TABLE = "memories";
console.log(`temp store: ${dir}\n`);

try {
  const db = await lancedb.connect(dir);

  console.log("PART 1 — migration on a pre-existing (legacy) table");
  await db.createTable(TABLE, [
    { id: "a", text: "prefers dark roast coffee", vector: near, importance: 1, category: "preference", createdAt: 1 },
    { id: "b", text: "team ships on fridays", vector: far, importance: 1, category: "fact", createdAt: 2 },
  ]);
  let tbl = await db.openTable(TABLE);

  const legacyCols = (await tbl.schema()).fields.map((f) => f.name);
  console.log(`  legacy columns: ${legacyCols.join(", ")}`);
  check("legacy table has no 'scope' column", !legacyCols.includes("scope"));
  check("legacy table has no 'agent' column", !legacyCols.includes("agent"));

  const existingNames = new Set((await tbl.schema()).fields.map((f) => f.name));
  const missing = ["scope", "agent"].filter((c) => !existingNames.has(c));
  console.log(`  missing columns detected: ${JSON.stringify(missing)}`);
  if (missing.length > 0) {
    await tbl.addColumns(missing.map((name) => ({ name, valueSql: "''" })));
  }

  const migratedCols = (await tbl.schema()).fields.map((f) => f.name);
  console.log(`  columns after migration: ${migratedCols.join(", ")}`);
  check("'scope' column added", migratedCols.includes("scope"));
  check("'agent' column added", migratedCols.includes("agent"));

  const migratedRows = await tbl.query().toArray();
  const rowA = migratedRows.find((r) => r.id === "a");
  const rowB = migratedRows.find((r) => r.id === "b");
  check("both legacy rows preserved", migratedRows.length === 2 && !!rowA && !!rowB);
  check("row 'a' text preserved", rowA?.text === "prefers dark roast coffee");
  check("row 'a' vector preserved (len + values)", Array.from(rowA?.vector ?? []).join(",") === near.join(","));
  check("migrated rows default to global scope ''", (rowA?.scope ?? "") === "" && (rowB?.scope ?? "") === "");

  console.log("\nPART 2 — native .where() prefilter isolation");
  // 'c' is scoped and shares the SAME (nearest) vector as global 'a', so only the
  // prefilter — not distance ranking — can keep it out of an unscoped recall.
  await tbl.add([
    { id: "c", text: "demo-shop_eu catalog prices are in EUR", vector: near, importance: 1, category: "fact", createdAt: 3, scope: "demo-shop_eu", agent: "" },
  ]);

  const scoped = await tbl.vectorSearch(query).where("scope = 'demo-shop_eu'").limit(5).toArray();
  console.log(`  scoped recall  where scope='demo-shop_eu' -> ids: [${ids(scoped)}]`);
  check("scoped recall returns ONLY the scoped row (c)", ids(scoped) === "c");

  const globalOnly = await tbl.vectorSearch(query).where("scope = '' OR scope IS NULL").limit(5).toArray();
  console.log(`  unscoped recall where scope=''/NULL   -> ids: [${ids(globalOnly)}]`);
  check("unscoped recall returns ONLY global rows (a,b)", ids(globalOnly) === "a,b");
  check("scoped row hidden from unscoped recall despite identical nearest vector", !ids(globalOnly).includes("c"));

  console.log("\nPART 3 — scoped delete is fenced to its scope");
  await tbl.delete("scope = 'demo-shop_eu'");
  const afterDelete = await tbl.query().toArray();
  console.log(`  rows after delete where scope='demo-shop_eu' -> ids: [${ids(afterDelete)}]`);
  check("scoped delete removed the scoped row (c gone)", !ids(afterDelete).includes("c"));
  check("scoped delete preserved global rows (a,b remain)", ids(afterDelete) === "a,b");

  console.log(`\n=== RESULT: ${failures === 0 ? "ALL CHECKS PASSED" : failures + " CHECK(S) FAILED"} ===`);
} finally {
  await rm(dir, { recursive: true, force: true });
}
process.exit(failures === 0 ? 0 : 1);
```

</details>

### Automated checks

- Type-check clean: `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` both
  exit 0 with no errors.
- `pnpm test:extension memory-lancedb` — **149 tests passing**, including fourteen
  regression tests:
  1. the `[SCOPE:<value>]` tag is captured verbatim (a value with hyphens **and**
     underscores is not truncated and mis-scoped) and is stripped from the
     embedded input and the stored text, so the vector reflects the fact and the
     tag is not echoed back on recall;
  2. dedup is scope-aware — the same fact survives under different scopes, while
     same-scope and global-vs-global writes still dedup;
  3. dedup prefilters by scope before the top-K limit, so a same-scope duplicate
     is still detected even when many other scopes share a near-identical vector;
  4. scoped `memory_recall` prioritizes its scope — the requested scope's row is
     returned (and ranked first) even behind many strong global matches that
     would otherwise fill the candidate window;
  5. an **unscoped** `memory_recall` is global-only — a scoped row never surfaces
     in a plain recall;
  6. a scoped `memory_forget` deletes only within its scope — the same fact under
     a different scope survives;
  7. an **unscoped** `memory_forget` is global-only — it cannot nominate or delete
     a scoped row from another partition;
  8. **auto-recall** injects only global memories — a scoped row is never
     auto-recalled into an unrelated session;
  9. operator recall thresholds survive the live-config merge — a configured
     `autoRecallOverfetch`/`recallMinScore` reaches the before-prompt auto-recall
     instead of silently falling back to the defaults;
  10. a `memory_store` tag whose key is not a slug (e.g. a punctuated channel id)
      is **rejected** — an intended-scoped memory never silently falls back to the
      global partition;
  11. a `memory_forget` by `memoryId` is fenced to the row's scope — a scoped row
      is not deleted by an unscoped or mismatched-scope call, while a matching
      scope (or a global row) deletes as expected;
  12. a tag-only `[SCOPE:<value>]` store (no text after the tag) is **rejected**,
      and auto-capture skips it — the bare control tag is never embedded or
      persisted as a memory on its own;
  13. `ltm search` is global-only by default and honors `--scope <slug>` — the CLI
      never scans across partitions unless a scope is explicitly requested, and a
      non-slug `--scope` key is rejected.
  14. **auto-capture eligibility is evaluated on the scope-stripped text** — a
      `[SCOPE:<slug>]` message whose fact fits under `captureMaxChars` is captured
      even when the routing tag makes the raw string exceed the limit, so a long tag
      can no longer flip a message's memory-worthiness; the tag is stripped before
      the capture heuristics run, then the fact is embedded and stored under its
      scope.
- Rebased onto current `main`. The `memory_store` success string applies `main`'s
  UTF-16-safe `truncateUtf16Safe(...)` helper to the scope-stripped text
  (`truncateUtf16Safe(memoryText, 100)`), so both `main`'s UTF-16 fix and this PR's
  tag-strip hold; `pnpm check:no-conflict-markers` passes and no raw `.slice(0, N)`
  truncation remains on memory text.
- Adapted to `main`'s tightened quality gates in the extensions lane: the
  newly-enforced `noUncheckedIndexedAccess` (the `[SCOPE:<value>]` capture-group
  reads and one test batch access are guarded with the SDK's `expectDefined`,
  matching `main`'s idiom), the oxlint rules (`no-map-spread`, `curly`, and the
  **type-aware** `restrict-template-expressions` / `no-unnecessary-type-conversion`,
  reproduced locally with the `--tsconfig` shard config CI runs), and the
  zero-`any`-cast type-suppression inventory (the added test mocks were reworked to
  drop every `as any`). `pnpm tsgo:extensions`, `pnpm tsgo:extensions:test`, the
  extensions lint shard, and the type-suppression-inventory test are all green for
  this plugin's files.
- Closed two partition gaps found in review: (1) the `ltm search` CLI was the only
  `db.search` caller left without a scope filter, so a table-wide scan could expose
  scoped rows — it is now global-only by default with an opt-in `--scope <slug>`,
  mirroring `memory_recall`; (2) a tag-only `[SCOPE:<value>]` payload used to fall
  back to storing the raw text (embedding the control tag itself) — it is now
  rejected on store and skipped on auto-capture. Both are covered by the new
  regression tests (12–13 above).
- A follow-up review pass hardened the scoped-capture path: a scoped store or
  auto-capture payload that is empty **or whitespace-only** after the tag is stripped
  is rejected (never embedded as a blank memory), and auto-capture now runs its
  capture heuristics on the **stripped** text, so the routing tag's length cannot
  change a message's eligibility. Covered by regression test 14 (and the existing
  tag-only test 12).
- Docs updated (`docs/plugins/memory-lancedb.md`): a new **Scope** section (tag /
  slug shape, global-vs-scoped recall and forget, `memoryId` fence, global-only
  auto-recall, and the `ltm search --scope` behavior) plus a **Recall selectivity**
  table for the three new settings, with `docs/docs_map.md` regenerated for the new
  headings; `pnpm format:docs:check`, `docs:map:check`, the MDX check, and the
  internal-link check all pass.

---
<sub>Prepared with AI assistance.</sub>
