### PR TITLE
fix(gateway): use regex instead of per-character loop in chat input sanitizer

### DIFF
--- a/src/gateway/chat-input-sanitize.ts
+++ b/src/gateway/chat-input-sanitize.ts
@@ -1,15 +1,13 @@
 // Chat send input sanitizer for Gateway message payloads.
 
+/** Regex matching ASCII control characters that must be stripped from user messages.
+ *  Preserves: \t (\x09), \n (\x0A), \r (\x0D). */
+// eslint-disable-next-line no-control-regex
+const DISALLOWED_CHAT_CONTROL_RE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g;
+
 /** Drop disallowed control characters while preserving tab and line breaks. */
 function stripDisallowedChatControlChars(message: string): string {
-  let output = "";
-  for (const char of message) {
-    const code = char.charCodeAt(0);
-    if (code === 9 || code === 10 || code === 13 || (code >= 32 && code !== 127)) {
-      output += char;
-    }
-  }
-  return output;
+  return message.replace(DISALLOWED_CHAT_CONTROL_RE, "");
 }
 
 /** Normalize chat text and reject null bytes before routing to channels. */

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -2614,6 +2614,18 @@ describe("sanitizeChatSendMessageInput", () => {
   ])("$name", ({ input, expected }) => {
     expect(sanitizeChatSendMessageInput(input)).toEqual(expected);
   });
+
+  it("completes within 50ms for a 1MB message without control characters", () => {
+    // Performance regression guard: the common case (clean text) must use
+    // the regex fast path, not a per-character loop that blocks the event
+    // loop for hundreds of milliseconds on large messages.
+    const text = "a".repeat(1_000_000);
+    const start = performance.now();
+    const result = sanitizeChatSendMessageInput(text);
+    const elapsed = performance.now() - start;
+    expect(result).toEqual({ ok: true as const, message: text });
+    expect(elapsed).toBeLessThan(50);
+  });
 });
 
 describe("gateway chat transcript writes (guardrail)", () => {

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -203,6 +203,7 @@ describe("production lint suppressions", () => {
         "src/cli/command-options.ts|typescript/no-unnecessary-type-parameters|1",
         "src/cli/plugins-cli-test-helpers.ts|typescript/no-unnecessary-type-parameters|1",
         "src/cli/test-runtime-capture.ts|typescript/no-unnecessary-type-parameters|1",
+        "src/gateway/chat-input-sanitize.ts|no-control-regex|1",
         "src/gateway/test-helpers.server.ts|typescript/no-unnecessary-type-parameters|1",
         "src/hooks/module-loader.ts|typescript/no-unnecessary-type-parameters|1",
         "src/infra/exec-approvals-effective.ts|typescript/no-unnecessary-type-parameters|1",


### PR DESCRIPTION
## What Problem This Solves

Fixes #102915 — `stripDisallowedChatControlChars` uses a per-character `for...of` loop with `output += char` string concatenation. For large messages (1MB+), this blocks the gateway event loop for ~120ms on every `chat.send` request. At 10MB, the block exceeds 750ms — a gateway availability concern.

## Why This Change Was Made

Replace the per-character loop with `String.prototype.replace` using a precompiled regex. The character class `[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]` matches exactly the same disallowed bytes as the original `if` condition.

## Evidence

### Production-path proof

```
$ node --import tsx -e "import { sanitizeChatSendMessageInput } from './src/gateway/chat-input-sanitize.js';
const text = 'a'.repeat(1_000_000);
const t0 = performance.now();
const result = sanitizeChatSendMessageInput(text);
console.log('elapsed=' + (performance.now() - t0).toFixed(1) + 'ms  ok=' + result.ok + '  len=' + result.message.length);"

elapsed=7.7ms  ok=true  len=1000000
```

### Tests

```
$ node scripts/run-vitest.mjs src/gateway/server-methods/server-methods.test.ts -t "sanitizeChatSendMessageInput"
 Test Files  1 passed (1)
      Tests  4 passed (4)

$ node scripts/run-vitest.mjs src/gateway/server-methods/server-methods.test.ts -t "sanitizeChatSendMessageInput" --reporter=verbose
 ✓ sanitizeChatSendMessageInput > rejects null bytes
 ✓ sanitizeChatSendMessageInput > strips unsafe control characters while preserving tab/newline/carriage return
 ✓ sanitizeChatSendMessageInput > normalizes unicode to NFC
 ✓ sanitizeChatSendMessageInput > completes within 50ms for a 1MB message without control characters
```

### Correctness: all 256 code points match

```
$ node -e "
const oldStrip = (m) => { let o=''; for(const c of m){ const code=c.charCodeAt(0); if(code===9||code===10||code===13||(code>=32&&code!==127)) o+=c; } return o; };
const newStrip = (m) => m.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '');
for(let i=0;i<256;i++){ const input=String.fromCharCode(i); if(oldStrip(input)!==newStrip(input)){ console.log('FAIL at',i); process.exit(1); } }
console.log('All 256 code points match');
"
All 256 code points match
```

### Files Changed (3 files, +19/-8)

```
 src/gateway/chat-input-sanitize.ts                   | 10 +++++-----
 src/gateway/server-methods/server-methods.test.ts    | 10 ++++++++++
 test/scripts/lint-suppressions.test.ts               |  1 +
```
